### PR TITLE
feat(client): interactive annotations — highlight, comment, accept/dismiss

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
+import type { Editor as TiptapEditor } from '@tiptap/react';
 import * as Y from 'yjs';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Editor } from './editor/Editor';
@@ -14,10 +15,17 @@ export default function App() {
   const [claudeStatus, setClaudeStatus] = useState<string | null>(null);
   const [claudeActive, setClaudeActive] = useState(false);
   const [ready, setReady] = useState(false);
+  const [, setEditorVersion] = useState(0); // Triggers re-render when editor arrives
 
   // Stable refs for Y.Doc and provider — survive StrictMode double-mount
   const ydocRef = useRef<Y.Doc | null>(null);
   const providerRef = useRef<HocuspocusProvider | null>(null);
+  const editorRef = useRef<TiptapEditor | null>(null);
+
+  const handleEditorReady = useCallback((editor: TiptapEditor | null) => {
+    editorRef.current = editor;
+    if (editor) setEditorVersion(v => v + 1); // Force re-render when editor arrives (skip null cleanup)
+  }, []);
 
   useEffect(() => {
     const ydoc = new Y.Doc();
@@ -98,16 +106,17 @@ export default function App() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-      <Toolbar />
+      <Toolbar editor={editorRef.current} ydoc={ydocRef.current} />
       <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
         <div style={{ flex: 1, overflow: 'auto', padding: '24px 48px' }}>
           <Editor
             ydoc={ydocRef.current}
             provider={providerRef.current}
             onConnectionChange={handleConnectionChange}
+            onEditorReady={handleEditorReady}
           />
         </div>
-        <SidePanel annotations={annotations} />
+        <SidePanel annotations={annotations} editor={editorRef.current} ydoc={ydocRef.current} />
       </div>
       <StatusBar
         connected={connected}

--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
+import type { Editor as TiptapEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Collaboration from '@tiptap/extension-collaboration';
 import CollaborationCursor from '@tiptap/extension-collaboration-cursor';
@@ -19,9 +20,10 @@ interface EditorProps {
   ydoc: Y.Doc;
   provider: HocuspocusProvider;
   onConnectionChange: (connected: boolean) => void;
+  onEditorReady?: (editor: TiptapEditor | null) => void;
 }
 
-export function Editor({ ydoc, provider, onConnectionChange }: EditorProps) {
+export function Editor({ ydoc, provider, onConnectionChange, onEditorReady }: EditorProps) {
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -56,6 +58,11 @@ export function Editor({ ydoc, provider, onConnectionChange }: EditorProps) {
       },
     },
   }, [ydoc, provider]); // Re-create editor if ydoc or provider change
+
+  useEffect(() => {
+    onEditorReady?.(editor);
+    return () => onEditorReady?.(null);
+  }, [editor, onEditorReady]);
 
   return (
     <div>

--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -16,7 +16,7 @@ const annotationPluginKey = new PluginKey('tandemAnnotations');
  * like "# ", "## ". ProseMirror doesn't have those prefixes in its content,
  * so we need to account for them when mapping.
  */
-function flatOffsetToPmPos(doc: PmNode, flatOffset: number): number {
+export function flatOffsetToPmPos(doc: PmNode, flatOffset: number): number {
   let accumulated = 0;
   let pmOffset = 0; // Running ProseMirror position
 

--- a/src/client/editor/extensions/awareness.ts
+++ b/src/client/editor/extensions/awareness.ts
@@ -13,7 +13,7 @@ const awarenessPluginKey = new PluginKey('tandemAwareness');
  * This is the inverse of flatOffsetToPmPos in annotation.ts.
  * Flat text includes heading prefixes ("## ") and "\n" between elements.
  */
-function pmPosToFlatOffset(doc: PmNode, pmPos: number): number {
+export function pmPosToFlatOffset(doc: PmNode, pmPos: number): number {
   let flatOffset = 0;
   let pmOffset = 0;
 

--- a/src/client/editor/toolbar/Toolbar.tsx
+++ b/src/client/editor/toolbar/Toolbar.tsx
@@ -1,6 +1,115 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import type { Editor as TiptapEditor } from '@tiptap/react';
+import * as Y from 'yjs';
+import { pmPosToFlatOffset } from '../extensions/awareness';
+import type { Annotation, HighlightColor } from '../../../shared/types';
 
-export function Toolbar() {
+interface ToolbarProps {
+  editor: TiptapEditor | null;
+  ydoc: Y.Doc | null;
+}
+
+function generateAnnotationId(): string {
+  return `ann_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function Toolbar({ editor, ydoc }: ToolbarProps) {
+  const [hasSelection, setHasSelection] = useState(false);
+  const [commentMode, setCommentMode] = useState(false);
+  const [commentText, setCommentText] = useState('');
+  const capturedRangeRef = useRef<{ from: number; to: number } | null>(null);
+  const commentInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!editor) return;
+
+    const onSelectionUpdate = () => {
+      const { from, to } = editor.state.selection;
+      const next = from !== to;
+      setHasSelection(prev => prev === next ? prev : next);
+    };
+
+    editor.on('selectionUpdate', onSelectionUpdate);
+    return () => { editor.off('selectionUpdate', onSelectionUpdate); };
+  }, [editor]);
+
+  // Focus the comment input when entering comment mode
+  useEffect(() => {
+    if (commentMode && commentInputRef.current) {
+      commentInputRef.current.focus();
+    }
+  }, [commentMode]);
+
+  function createAnnotation(type: 'highlight' | 'comment', content: string, color?: HighlightColor) {
+    if (!editor || !ydoc) return;
+
+    const range = capturedRangeRef.current ?? editor.state.selection;
+    const { from, to } = range;
+    if (from === to) return;
+
+    const flatFrom = pmPosToFlatOffset(editor.state.doc, from);
+    const flatTo = pmPosToFlatOffset(editor.state.doc, to);
+
+    const id = generateAnnotationId();
+    const annotation: Annotation = {
+      id,
+      author: 'user',
+      type,
+      range: { from: flatFrom, to: flatTo },
+      content,
+      status: 'pending',
+      timestamp: Date.now(),
+      ...(color ? { color } : {}),
+    };
+
+    ydoc.getMap('annotations').set(id, annotation);
+    capturedRangeRef.current = null;
+  }
+
+  function handleHighlight(e: React.MouseEvent) {
+    e.preventDefault(); // Prevent editor blur
+    createAnnotation('highlight', '', 'yellow');
+  }
+
+  function handleCommentStart(e: React.MouseEvent) {
+    e.preventDefault(); // Prevent editor blur
+    if (!editor) return;
+    // Capture current selection before it might change
+    const { from, to } = editor.state.selection;
+    capturedRangeRef.current = { from, to };
+    setCommentMode(true);
+    setCommentText('');
+  }
+
+  function handleCommentSubmit() {
+    if (!commentText.trim()) {
+      handleCommentCancel();
+      return;
+    }
+    createAnnotation('comment', commentText.trim());
+    setCommentMode(false);
+    setCommentText('');
+    editor?.chain().focus().run();
+  }
+
+  function handleCommentCancel() {
+    setCommentMode(false);
+    setCommentText('');
+    capturedRangeRef.current = null;
+    editor?.chain().focus().run();
+  }
+
+  function handleCommentKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleCommentSubmit();
+    } else if (e.key === 'Escape') {
+      handleCommentCancel();
+    }
+  }
+
+  const canAnnotate = editor && ydoc && hasSelection;
+
   return (
     <div style={{
       display: 'flex',
@@ -15,8 +124,38 @@ export function Toolbar() {
         Tandem
       </span>
       <div style={{ width: '1px', height: '20px', background: '#e5e7eb', margin: '0 8px' }} />
-      <ToolbarButton label="Highlight" shortcut="" disabled />
-      <ToolbarButton label="Comment" shortcut="" disabled />
+      <ToolbarButton
+        label="Highlight"
+        disabled={!canAnnotate || commentMode}
+        onMouseDown={handleHighlight}
+      />
+      <ToolbarButton
+        label="Comment"
+        disabled={!canAnnotate || commentMode}
+        onMouseDown={handleCommentStart}
+      />
+      {commentMode && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+          <input
+            ref={commentInputRef}
+            type="text"
+            value={commentText}
+            onChange={e => setCommentText(e.target.value)}
+            onKeyDown={handleCommentKeyDown}
+            placeholder="Add a comment..."
+            style={{
+              padding: '3px 8px',
+              fontSize: '13px',
+              border: '1px solid #3b82f6',
+              borderRadius: '4px',
+              outline: 'none',
+              width: '200px',
+            }}
+          />
+          <ToolbarButton label="Add" disabled={!commentText.trim()} onClick={handleCommentSubmit} />
+          <ToolbarButton label="Cancel" disabled={false} onClick={handleCommentCancel} />
+        </div>
+      )}
       <ToolbarButton label="Ask Claude" shortcut="Ctrl+Shift+A" disabled />
       <div style={{ flex: 1 }} />
       <span style={{ fontSize: '12px', color: '#9ca3af' }}>Review Mode</span>
@@ -24,11 +163,19 @@ export function Toolbar() {
   );
 }
 
-function ToolbarButton({ label, shortcut, disabled }: { label: string; shortcut: string; disabled?: boolean }) {
+function ToolbarButton({ label, shortcut, disabled, onMouseDown, onClick }: {
+  label: string;
+  shortcut?: string;
+  disabled?: boolean;
+  onMouseDown?: (e: React.MouseEvent) => void;
+  onClick?: () => void;
+}) {
   return (
     <button
       disabled={disabled}
       title={shortcut ? `${label} (${shortcut})` : label}
+      onMouseDown={onMouseDown}
+      onClick={onClick}
       style={{
         padding: '4px 10px',
         fontSize: '13px',

--- a/src/client/panels/SidePanel.tsx
+++ b/src/client/panels/SidePanel.tsx
@@ -1,14 +1,51 @@
 import React from 'react';
+import type { Editor as TiptapEditor } from '@tiptap/react';
+import * as Y from 'yjs';
 import type { Annotation } from '../../shared/types';
 import { HIGHLIGHT_COLORS } from '../../shared/constants';
+import { flatOffsetToPmPos } from '../editor/extensions/annotation';
 
 interface SidePanelProps {
   annotations: Annotation[];
+  editor: TiptapEditor | null;
+  ydoc: Y.Doc | null;
 }
 
-export function SidePanel({ annotations }: SidePanelProps) {
+export function SidePanel({ annotations, editor, ydoc }: SidePanelProps) {
   const pending = annotations.filter(a => a.status === 'pending');
   const resolved = annotations.filter(a => a.status !== 'pending');
+
+  function handleDismiss(id: string) {
+    if (!ydoc) return;
+    const map = ydoc.getMap('annotations');
+    const ann = map.get(id) as Annotation | undefined;
+    if (!ann) return;
+    map.set(id, { ...ann, status: 'dismissed' as const });
+  }
+
+  function handleAccept(id: string) {
+    if (!ydoc) return;
+    const map = ydoc.getMap('annotations');
+    const ann = map.get(id) as Annotation | undefined;
+    if (!ann) return;
+
+    // Update status first
+    map.set(id, { ...ann, status: 'accepted' as const });
+
+    // For suggestions, apply the text replacement
+    if (ann.type === 'suggestion' && editor) {
+      try {
+        const { newText } = JSON.parse(ann.content);
+        if (typeof newText === 'string') {
+          const pmFrom = flatOffsetToPmPos(editor.state.doc, ann.range.from);
+          const pmTo = flatOffsetToPmPos(editor.state.doc, ann.range.to);
+          editor.chain().focus().deleteRange({ from: pmFrom, to: pmTo }).insertContentAt(pmFrom, newText).run();
+        }
+      } catch {
+        // Malformed suggestion content — status already updated, skip text change
+      }
+    }
+  }
 
   return (
     <div style={{
@@ -45,7 +82,12 @@ export function SidePanel({ annotations }: SidePanelProps) {
         ) : (
           <>
             {pending.map(ann => (
-              <AnnotationCard key={ann.id} annotation={ann} />
+              <AnnotationCard
+                key={ann.id}
+                annotation={ann}
+                onAccept={handleAccept}
+                onDismiss={handleDismiss}
+              />
             ))}
             {resolved.length > 0 && (
               <details style={{ marginTop: '12px' }}>
@@ -64,12 +106,20 @@ export function SidePanel({ annotations }: SidePanelProps) {
   );
 }
 
-function AnnotationCard({ annotation }: { annotation: Annotation }) {
+interface AnnotationCardProps {
+  annotation: Annotation;
+  onAccept?: (id: string) => void;
+  onDismiss?: (id: string) => void;
+}
+
+function AnnotationCard({ annotation, onAccept, onDismiss }: AnnotationCardProps) {
   const borderColor = annotation.color
     ? HIGHLIGHT_COLORS[annotation.color] || '#e5e7eb'
     : annotation.type === 'comment' ? '#3b82f6'
     : annotation.type === 'suggestion' ? '#8b5cf6'
     : '#e5e7eb';
+
+  const isPending = annotation.status === 'pending';
 
   return (
     <div style={{
@@ -79,7 +129,7 @@ function AnnotationCard({ annotation }: { annotation: Annotation }) {
       background: 'white',
       borderRadius: '0 4px 4px 0',
       fontSize: '13px',
-      opacity: annotation.status === 'pending' ? 1 : 0.6,
+      opacity: isPending ? 1 : 0.6,
     }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
         <span style={{ fontWeight: 500, textTransform: 'capitalize' }}>{annotation.type}</span>
@@ -99,6 +149,42 @@ function AnnotationCard({ annotation }: { annotation: Annotation }) {
             })()
           : annotation.content || '(no note)'}
       </p>
+      {isPending && (onAccept || onDismiss) && (
+        <div style={{ display: 'flex', gap: '6px', marginTop: '6px' }}>
+          {onAccept && (
+            <button
+              onClick={() => onAccept(annotation.id)}
+              style={{
+                padding: '2px 8px',
+                fontSize: '11px',
+                border: '1px solid #d1d5db',
+                borderRadius: '3px',
+                background: '#f0fdf4',
+                color: '#166534',
+                cursor: 'pointer',
+              }}
+            >
+              Accept
+            </button>
+          )}
+          {onDismiss && (
+            <button
+              onClick={() => onDismiss(annotation.id)}
+              style={{
+                padding: '2px 8px',
+                fontSize: '11px',
+                border: '1px solid #d1d5db',
+                borderRadius: '3px',
+                background: '#fef2f2',
+                color: '#991b1b',
+                cursor: 'pointer',
+              }}
+            >
+              Dismiss
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Highlight button**: select text in the editor, click Highlight → yellow highlight annotation created in Y.Map, renders as background decoration
- **Comment button**: select text, click Comment → inline text input appears in toolbar → submit creates comment annotation with dashed blue underline
- **Accept/Dismiss buttons**: every pending annotation card in the side panel now has Accept and Dismiss buttons. Accepting a suggestion applies the text replacement (`deleteRange` + `insertContentAt`) to the document.
- Coordinate conversion helpers (`pmPosToFlatOffset`, `flatOffsetToPmPos`) exported for cross-extension use
- Editor instance exposed from `Editor.tsx` via `onEditorReady` callback, wired through `App.tsx` to Toolbar and SidePanel

## Known Limitations
- Coordinate conversion only handles top-level paragraphs and headings (lists, blockquotes, code blocks use opaque text content). Pre-existing limitation — affects server-created annotations equally.
- Annotation flat offsets become stale after document edits. Accepted annotations are filtered from rendering so they don't misrender; other pending annotations may shift.

## Test plan
- [x] Select text, click Highlight → yellow highlight appears in editor + side panel card
- [x] Select text, click Comment, type note, Enter → dashed underline + card with comment text
- [x] Click Dismiss on annotation → card moves to resolved, decoration removed
- [x] Click Accept on suggestion → text replaced in editor, card moves to resolved
- [x] Annotations from both user and Claude render correctly
- [x] No console errors
- [x] `npm run build` passes
- [x] `npm test` — 173 tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)