### PR TITLE
feat(session): persist sessions across server restarts

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,8 @@ import { execSync } from 'child_process';
 import { startMcpServer } from './mcp/server.js';
 import { startHocuspocus } from './yjs/provider.js';
 import { DEFAULT_WS_PORT } from '../shared/constants.js';
+import { cleanupSessions, stopAutoSave } from './session/manager.js';
+import { saveCurrentSession } from './mcp/document.js';
 
 // stdout is exclusively reserved for the MCP JSON-RPC wire protocol.
 // Redirect any console.log calls (from Hocuspocus or other libs) to stderr.
@@ -36,8 +38,27 @@ process.on('unhandledRejection', (reason) => {
   console.error('[Tandem] unhandledRejection (swallowed):', reason);
 });
 
+// Graceful shutdown: save session + stop auto-save before exit
+async function shutdown(signal: string) {
+  console.error(`[Tandem] ${signal} received, saving session...`);
+  try {
+    await saveCurrentSession();
+    stopAutoSave();
+  } catch (err) {
+    console.error('[Tandem] Session save on shutdown failed:', err);
+  }
+  process.exit(0);
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
 async function main() {
   console.error('[Tandem] Starting server...');
+
+  // Clean up sessions older than 30 days
+  cleanupSessions().then(n => {
+    if (n > 0) console.error(`[Tandem] Cleaned up ${n} stale session(s)`);
+  }).catch(() => {});
 
   // Start Hocuspocus in the background so MCP can respond to initialize immediately.
   // Claude Code sends MCP initialize right after spawn — if we delay, the client times out.

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -7,6 +7,10 @@ import { getOrCreateDocument } from '../yjs/provider.js';
 import { mcpSuccess, mcpError, noDocumentError, getErrorMessage } from './response.js';
 import { MAX_FILE_SIZE } from '../../shared/constants.js';
 import { loadMarkdown, saveMarkdown } from '../file-io/markdown.js';
+import {
+  saveSession, loadSession, restoreYDoc, sourceFileChanged,
+  startAutoSave, stopAutoSave,
+} from '../session/manager.js';
 import * as Y from 'yjs';
 
 // Fixed room name — both MCP tools and browser client use this
@@ -19,6 +23,13 @@ let currentDoc: { filePath: string; format: string } | null = null;
 
 export function getCurrentDoc() {
   return currentDoc ? { ...currentDoc, docName: ROOM_NAME } : null;
+}
+
+/** Save current session (for shutdown handler). No-op if no doc is open. */
+export async function saveCurrentSession(): Promise<void> {
+  if (!currentDoc) return;
+  const doc = getOrCreateDocument(ROOM_NAME);
+  await saveSession(currentDoc.filePath, currentDoc.format, doc);
 }
 
 /** Returns the shared Y.Doc or a noDocumentError if no doc is open */
@@ -242,23 +253,50 @@ export function registerDocumentTools(server: McpServer): void {
           return mcpError('FORMAT_ERROR', 'DOCX support not yet implemented. Use .md or .txt files for now.');
         }
 
-        const content = await fs.readFile(resolved, 'utf-8');
         const doc = getOrCreateDocument(ROOM_NAME);
-        if (format === 'md') {
-          loadMarkdown(doc, content);
-        } else {
-          populateYDoc(doc, content);
+        const fileName = path.basename(resolved);
+        const fileContent = await fs.readFile(resolved, 'utf-8');
+        let restoredFromSession = false;
+
+        // Check for existing session
+        const session = await loadSession(resolved);
+        if (session) {
+          const changed = await sourceFileChanged(session);
+          if (!changed) {
+            // Source file unchanged — restore Y.Doc from session (preserves annotations)
+            restoreYDoc(doc, session);
+            restoredFromSession = true;
+          }
+          // If source changed, fall through to fresh load (annotations may be stale)
         }
+
+        if (!restoredFromSession) {
+          if (format === 'md') {
+            loadMarkdown(doc, fileContent);
+          } else {
+            populateYDoc(doc, fileContent);
+          }
+        }
+
         currentDoc = { filePath: resolved, format };
 
-        const fileName = path.basename(resolved);
+        // Start auto-save timer
+        startAutoSave(async () => {
+          if (currentDoc) {
+            await saveSession(currentDoc.filePath, currentDoc.format, doc);
+          }
+        });
+
         return mcpSuccess({
           filePath: resolved,
           fileName,
           format,
-          tokenEstimate: Math.ceil(content.length / 4),
-          pageEstimate: Math.ceil(content.length / 3000),
-          message: `Document opened: ${fileName}`,
+          tokenEstimate: Math.ceil(fileContent.length / 4),
+          pageEstimate: Math.ceil(fileContent.length / 3000),
+          restoredFromSession,
+          message: restoredFromSession
+            ? `Session restored: ${fileName} (annotations preserved)`
+            : `Document opened: ${fileName}`,
         });
       } catch (err: unknown) {
         const message = getErrorMessage(err);
@@ -458,6 +496,8 @@ export function registerDocumentTools(server: McpServer): void {
         const tempPath = path.join(path.dirname(r.filePath), `.tandem-tmp-${Date.now()}`);
         await fs.writeFile(tempPath, output, 'utf-8');
         await fs.rename(tempPath, r.filePath);
+        // Save session alongside file save (captures annotations + doc state)
+        await saveSession(r.filePath, format ?? 'txt', r.doc);
         return mcpSuccess({ saved: true, filePath: r.filePath });
       } catch (err: unknown) {
         return mcpError('FILE_LOCKED', getErrorMessage(err));
@@ -483,6 +523,8 @@ export function registerDocumentTools(server: McpServer): void {
     'Close the current document',
     {},
     async () => {
+      stopAutoSave(); // Prevent auto-save firing during close
+      await saveCurrentSession(); // Save session before clearing state
       const was = currentDoc?.filePath ?? null;
       currentDoc = null;
       return mcpSuccess({ closed: true, was });

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import * as Y from 'yjs';
 import type { SessionData } from '../../shared/types.js';
 
 // Session storage in %LOCALAPPDATA%\tandem\sessions\ (not project dir, avoids OneDrive sync)
@@ -7,25 +8,92 @@ const SESSION_DIR = process.env.LOCALAPPDATA
   ? path.join(process.env.LOCALAPPDATA, 'tandem', 'sessions')
   : path.join('.tandem', 'sessions');
 
-const SESSION_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
+import { SESSION_MAX_AGE } from '../../shared/constants.js';
 
-export async function saveSession(key: string, data: SessionData): Promise<void> {
-  await fs.mkdir(SESSION_DIR, { recursive: true });
-  const filePath = path.join(SESSION_DIR, `${encodeURIComponent(key)}.json`);
-  await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+const AUTO_SAVE_INTERVAL = 60 * 1000; // 60 seconds
+let sessionDirReady = false;
+
+/** Generate a session key from a file path */
+export function sessionKey(filePath: string): string {
+  return encodeURIComponent(filePath.replace(/\\/g, '/'));
 }
 
-export async function loadSession(key: string): Promise<SessionData | null> {
-  const filePath = path.join(SESSION_DIR, `${encodeURIComponent(key)}.json`);
+/** Save Y.Doc state + metadata as a session file */
+export async function saveSession(
+  filePath: string,
+  format: string,
+  doc: Y.Doc,
+): Promise<void> {
+  const key = sessionKey(filePath);
+  let sourceFileMtime = 0;
   try {
-    const content = await fs.readFile(filePath, 'utf-8');
+    const stat = await fs.stat(filePath);
+    sourceFileMtime = stat.mtimeMs;
+  } catch {
+    // File may not exist yet (new doc)
+  }
+
+  const state = Y.encodeStateAsUpdate(doc);
+  const ydocState = Buffer.from(state).toString('base64');
+
+  const data: SessionData = {
+    filePath,
+    format,
+    ydocState,
+    sourceFileMtime,
+    lastAccessed: Date.now(),
+  };
+
+  if (!sessionDirReady) {
+    await fs.mkdir(SESSION_DIR, { recursive: true });
+    sessionDirReady = true;
+  }
+  const sessionPath = path.join(SESSION_DIR, `${key}.json`);
+  await fs.writeFile(sessionPath, JSON.stringify(data), 'utf-8');
+}
+
+/** Load a session file if it exists */
+export async function loadSession(filePath: string): Promise<SessionData | null> {
+  const key = sessionKey(filePath);
+  const sessionPath = path.join(SESSION_DIR, `${key}.json`);
+  try {
+    const content = await fs.readFile(sessionPath, 'utf-8');
     return JSON.parse(content) as SessionData;
   } catch {
     return null;
   }
 }
 
-export async function cleanupSessions(): Promise<void> {
+/** Restore a Y.Doc from a session's base64-encoded state */
+export function restoreYDoc(doc: Y.Doc, session: SessionData): void {
+  const state = Buffer.from(session.ydocState, 'base64');
+  Y.applyUpdate(doc, new Uint8Array(state));
+}
+
+/** Check if the source file has changed since the session was saved */
+export async function sourceFileChanged(session: SessionData): Promise<boolean> {
+  try {
+    const stat = await fs.stat(session.filePath);
+    return stat.mtimeMs !== session.sourceFileMtime;
+  } catch {
+    return true; // File doesn't exist — treat as changed
+  }
+}
+
+/** Delete a session file */
+export async function deleteSession(filePath: string): Promise<void> {
+  const key = sessionKey(filePath);
+  const sessionPath = path.join(SESSION_DIR, `${key}.json`);
+  try {
+    await fs.unlink(sessionPath);
+  } catch {
+    // Already gone
+  }
+}
+
+/** Delete sessions older than 30 days */
+export async function cleanupSessions(): Promise<number> {
+  let cleaned = 0;
   try {
     const files = await fs.readdir(SESSION_DIR);
     const now = Date.now();
@@ -35,9 +103,38 @@ export async function cleanupSessions(): Promise<void> {
       const stat = await fs.stat(filePath);
       if (now - stat.mtimeMs > SESSION_MAX_AGE) {
         await fs.unlink(filePath);
+        cleaned++;
       }
     }
   } catch {
-    // Session dir doesn't exist yet, nothing to clean
+    // Session dir doesn't exist yet
   }
+  return cleaned;
+}
+
+// --- Auto-save ---
+
+let autoSaveTimer: ReturnType<typeof setInterval> | null = null;
+let autoSaveCallback: (() => Promise<void>) | null = null;
+
+/** Start auto-saving every 60 seconds. Pass a callback that saves the current session. */
+export function startAutoSave(callback: () => Promise<void>): void {
+  stopAutoSave();
+  autoSaveCallback = callback;
+  autoSaveTimer = setInterval(async () => {
+    try {
+      await autoSaveCallback?.();
+    } catch (err) {
+      console.error('[Tandem] Auto-save failed:', err);
+    }
+  }, AUTO_SAVE_INTERVAL);
+}
+
+/** Stop auto-save timer */
+export function stopAutoSave(): void {
+  if (autoSaveTimer) {
+    clearInterval(autoSaveTimer);
+    autoSaveTimer = null;
+  }
+  autoSaveCallback = null;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -114,8 +114,8 @@ export interface ClaudeAwareness {
 
 export interface SessionData {
   filePath: string;
-  annotations: Annotation[];
-  overlays: OverlayDefinition[];
-  groupId?: string;
+  format: string;
+  ydocState: string; // Base64-encoded Y.encodeStateAsUpdate()
+  sourceFileMtime: number; // Source file mtime at save — detect external changes on resume
   lastAccessed: number;
 }

--- a/tests/server/session.test.ts
+++ b/tests/server/session.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as Y from 'yjs';
+import fs from 'fs/promises';
+import path from 'path';
+import {
+  saveSession, loadSession, restoreYDoc, sourceFileChanged,
+  sessionKey, deleteSession, cleanupSessions,
+} from '../../src/server/session/manager';
+
+// Use a temp directory for test sessions
+const TEST_SESSION_DIR = path.join('.tandem', 'test-sessions');
+
+describe('Session persistence', () => {
+  // Create a Y.Doc with some content and annotations
+  function createTestDoc(): Y.Doc {
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment('default');
+    const p = new Y.XmlElement('paragraph');
+    p.insert(0, [new Y.XmlText('Hello world')]);
+    fragment.insert(0, [p]);
+
+    // Add an annotation
+    const annotations = doc.getMap('annotations');
+    annotations.set('ann_test_1', {
+      id: 'ann_test_1',
+      author: 'claude',
+      type: 'highlight',
+      range: { from: 0, to: 5 },
+      content: 'test note',
+      status: 'pending',
+      timestamp: Date.now(),
+      color: 'yellow',
+    });
+
+    return doc;
+  }
+
+  describe('sessionKey', () => {
+    it('encodes file paths consistently', () => {
+      const key = sessionKey('C:\\Users\\test\\doc.md');
+      expect(key).toBe(encodeURIComponent('C:/Users/test/doc.md'));
+    });
+
+    it('normalizes backslashes to forward slashes', () => {
+      const key1 = sessionKey('C:\\Users\\test\\doc.md');
+      const key2 = sessionKey('C:/Users/test/doc.md');
+      expect(key1).toBe(key2);
+    });
+  });
+
+  describe('save and restore round-trip', () => {
+    const testFilePath = path.resolve('tests/fixtures/session-test.md');
+
+    beforeEach(async () => {
+      // Create a temp fixture file
+      await fs.mkdir(path.dirname(testFilePath), { recursive: true });
+      await fs.writeFile(testFilePath, '# Test\nHello world\n', 'utf-8');
+    });
+
+    afterEach(async () => {
+      await deleteSession(testFilePath);
+      try { await fs.unlink(testFilePath); } catch {}
+    });
+
+    it('saves and loads session data', async () => {
+      const doc = createTestDoc();
+      await saveSession(testFilePath, 'md', doc);
+
+      const session = await loadSession(testFilePath);
+      expect(session).not.toBeNull();
+      expect(session!.filePath).toBe(testFilePath);
+      expect(session!.format).toBe('md');
+      expect(session!.ydocState).toBeTruthy();
+      expect(session!.lastAccessed).toBeGreaterThan(0);
+    });
+
+    it('restores Y.Doc content from session', async () => {
+      const doc = createTestDoc();
+      await saveSession(testFilePath, 'md', doc);
+
+      const session = await loadSession(testFilePath);
+      expect(session).not.toBeNull();
+
+      // Restore into a fresh Y.Doc
+      const restored = new Y.Doc();
+      restoreYDoc(restored, session!);
+
+      // Check document content
+      const fragment = restored.getXmlFragment('default');
+      expect(fragment.length).toBeGreaterThan(0);
+    });
+
+    it('restores annotations from session', async () => {
+      const doc = createTestDoc();
+      await saveSession(testFilePath, 'md', doc);
+
+      const session = await loadSession(testFilePath);
+      const restored = new Y.Doc();
+      restoreYDoc(restored, session!);
+
+      // Check annotations survived
+      const annotations = restored.getMap('annotations');
+      const ann = annotations.get('ann_test_1') as any;
+      expect(ann).toBeTruthy();
+      expect(ann.id).toBe('ann_test_1');
+      expect(ann.content).toBe('test note');
+      expect(ann.color).toBe('yellow');
+    });
+
+    it('detects unchanged source file', async () => {
+      const doc = createTestDoc();
+      await saveSession(testFilePath, 'md', doc);
+
+      const session = await loadSession(testFilePath);
+      const changed = await sourceFileChanged(session!);
+      expect(changed).toBe(false);
+    });
+
+    it('detects changed source file', async () => {
+      const doc = createTestDoc();
+      await saveSession(testFilePath, 'md', doc);
+
+      // Modify the source file
+      await new Promise(r => setTimeout(r, 50)); // Ensure mtime differs
+      await fs.writeFile(testFilePath, '# Modified\nDifferent content\n', 'utf-8');
+
+      const session = await loadSession(testFilePath);
+      const changed = await sourceFileChanged(session!);
+      expect(changed).toBe(true);
+    });
+
+    it('returns null for non-existent session', async () => {
+      const session = await loadSession('/nonexistent/path.md');
+      expect(session).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Session restore on reopen**: `tandem_open` checks for an existing session before loading from disk. If the source file hasn't changed, Y.Doc state (content + annotations) is restored from the session file, preserving all annotations from the previous session.
- **Session save on save/close**: `tandem_save` and `tandem_close` both persist session state alongside their normal operations.
- **Auto-save every 60s**: While a document is open, session state is saved automatically every 60 seconds.
- **Graceful shutdown**: SIGTERM/SIGINT handlers save the current session before exit.
- **Startup cleanup**: Sessions older than 30 days are removed on server start.
- **SessionData type updated**: Now stores base64-encoded Y.Doc state vector + source file mtime for change detection, instead of the previous annotation/overlay arrays.

## Test plan
- [x] 8 new unit tests: save/restore round-trip, annotation preservation, source file change detection, session key encoding
- [x] `npm run build` passes
- [x] `npm test` — 181 tests pass (173 existing + 8 new)
- [ ] Manual: open file, add annotations, restart server, reopen — annotations preserved
- [ ] Manual: open file, edit source externally, restart, reopen — fresh load (no stale session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)