### PR TITLE
feat: add highlight color picker, suggest button, and flag markers

### DIFF
--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -113,6 +113,13 @@ function buildDecorations(doc: PmNode, annotationsMap: Y.Map<unknown>): Decorati
           'data-annotation-id': ann.id,
         };
         break;
+      case 'flag':
+        attrs = {
+          class: 'tandem-flag',
+          style: 'background: rgba(239, 68, 68, 0.12); border-bottom: 2px solid #ef4444; padding-bottom: 1px;',
+          'data-annotation-id': ann.id,
+        };
+        break;
       default:
         return; // Unknown type, skip
     }

--- a/src/client/editor/toolbar/Toolbar.tsx
+++ b/src/client/editor/toolbar/Toolbar.tsx
@@ -3,7 +3,16 @@ import type { Editor as TiptapEditor } from '@tiptap/react';
 import * as Y from 'yjs';
 import { pmPosToFlatOffset } from '../extensions/awareness';
 import { generateAnnotationId } from '../../../shared/utils';
+import { HIGHLIGHT_COLORS } from '../../../shared/constants';
 import type { Annotation, AnnotationType, HighlightColor } from '../../../shared/types';
+
+const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
+  { value: 'yellow', label: 'Yellow' },
+  { value: 'red', label: 'Red' },
+  { value: 'green', label: 'Green' },
+  { value: 'blue', label: 'Blue' },
+  { value: 'purple', label: 'Purple' },
+];
 
 interface ToolbarProps {
   editor: TiptapEditor | null;
@@ -12,22 +21,29 @@ interface ToolbarProps {
 
 export function Toolbar({ editor, ydoc }: ToolbarProps) {
   const [hasSelection, setHasSelection] = useState(false);
+  const [highlightColor, setHighlightColor] = useState<HighlightColor>('yellow');
+  const [showColorPicker, setShowColorPicker] = useState(false);
   const [commentMode, setCommentMode] = useState(false);
   const [commentText, setCommentText] = useState('');
+  const [suggestMode, setSuggestMode] = useState(false);
+  const [suggestText, setSuggestText] = useState('');
+  const [suggestReason, setSuggestReason] = useState('');
   const [askClaudeMode, setAskClaudeMode] = useState(false);
   const [askClaudeText, setAskClaudeText] = useState('');
   const capturedRangeRef = useRef<{ from: number; to: number } | null>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
+  const suggestInputRef = useRef<HTMLInputElement>(null);
   const askClaudeInputRef = useRef<HTMLInputElement>(null);
+  const colorPickerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!editor) return;
 
-    const onSelectionUpdate = () => {
-      const { from, to } = editor.state.selection;
+    function onSelectionUpdate() {
+      const { from, to } = editor!.state.selection;
       const next = from !== to;
       setHasSelection(prev => prev === next ? prev : next);
-    };
+    }
 
     editor.on('selectionUpdate', onSelectionUpdate);
     return () => { editor.off('selectionUpdate', onSelectionUpdate); };
@@ -41,10 +57,30 @@ export function Toolbar({ editor, ydoc }: ToolbarProps) {
   }, [commentMode]);
 
   useEffect(() => {
+    if (suggestMode && suggestInputRef.current) {
+      suggestInputRef.current.focus();
+    }
+  }, [suggestMode]);
+
+  useEffect(() => {
     if (askClaudeMode && askClaudeInputRef.current) {
       askClaudeInputRef.current.focus();
     }
   }, [askClaudeMode]);
+
+  // Close color picker when clicking outside
+  useEffect(() => {
+    if (!showColorPicker) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      if (colorPickerRef.current && !colorPickerRef.current.contains(e.target as Node)) {
+        setShowColorPicker(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showColorPicker]);
 
   function createAnnotation(type: AnnotationType, content: string, color?: HighlightColor) {
     if (!editor || !ydoc) return;
@@ -72,20 +108,41 @@ export function Toolbar({ editor, ydoc }: ToolbarProps) {
     capturedRangeRef.current = null;
   }
 
-  const inInputMode = commentMode || askClaudeMode;
+  function captureSelectionRange() {
+    if (!editor) return;
+    const { from, to } = editor.state.selection;
+    capturedRangeRef.current = { from, to };
+  }
+
+  function resetAndFocusEditor() {
+    capturedRangeRef.current = null;
+    editor?.chain().focus().run();
+  }
+
+  const inInputMode = commentMode || askClaudeMode || suggestMode;
+
+  // -- Highlight --
 
   function handleHighlight(e: React.MouseEvent) {
     e.preventDefault();
-    createAnnotation('highlight', '', 'yellow');
+    createAnnotation('highlight', '', highlightColor);
+  }
+
+  function handleColorPickerToggle(e: React.MouseEvent) {
+    e.preventDefault();
+    setShowColorPicker(prev => !prev);
+  }
+
+  function handleColorSelect(color: HighlightColor) {
+    setHighlightColor(color);
+    setShowColorPicker(false);
   }
 
   // -- Comment mode --
 
   function handleCommentStart(e: React.MouseEvent) {
     e.preventDefault();
-    if (!editor) return;
-    const { from, to } = editor.state.selection;
-    capturedRangeRef.current = { from, to };
+    captureSelectionRange();
     setCommentMode(true);
     setCommentText('');
   }
@@ -104,8 +161,7 @@ export function Toolbar({ editor, ydoc }: ToolbarProps) {
   function handleCommentCancel() {
     setCommentMode(false);
     setCommentText('');
-    capturedRangeRef.current = null;
-    editor?.chain().focus().run();
+    resetAndFocusEditor();
   }
 
   function handleCommentKeyDown(e: React.KeyboardEvent) {
@@ -117,13 +173,56 @@ export function Toolbar({ editor, ydoc }: ToolbarProps) {
     }
   }
 
+  // -- Suggest mode --
+
+  function handleSuggestStart(e: React.MouseEvent) {
+    e.preventDefault();
+    captureSelectionRange();
+    setSuggestMode(true);
+    setSuggestText('');
+    setSuggestReason('');
+  }
+
+  function handleSuggestSubmit() {
+    if (!suggestText.trim()) {
+      handleSuggestCancel();
+      return;
+    }
+    createAnnotation('suggestion', JSON.stringify({ newText: suggestText.trim(), reason: suggestReason.trim() }));
+    setSuggestMode(false);
+    setSuggestText('');
+    setSuggestReason('');
+    editor?.chain().focus().run();
+  }
+
+  function handleSuggestCancel() {
+    setSuggestMode(false);
+    setSuggestText('');
+    setSuggestReason('');
+    resetAndFocusEditor();
+  }
+
+  function handleSuggestKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSuggestSubmit();
+    } else if (e.key === 'Escape') {
+      handleSuggestCancel();
+    }
+  }
+
+  // -- Flag --
+
+  function handleFlag(e: React.MouseEvent) {
+    e.preventDefault();
+    createAnnotation('flag', '');
+  }
+
   // -- Ask Claude mode --
 
   function handleAskClaudeStart(e: React.MouseEvent) {
     e.preventDefault();
-    if (!editor) return;
-    const { from, to } = editor.state.selection;
-    capturedRangeRef.current = { from, to };
+    captureSelectionRange();
     setAskClaudeMode(true);
     setAskClaudeText('');
   }
@@ -142,8 +241,7 @@ export function Toolbar({ editor, ydoc }: ToolbarProps) {
   function handleAskClaudeCancel() {
     setAskClaudeMode(false);
     setAskClaudeText('');
-    capturedRangeRef.current = null;
-    editor?.chain().focus().run();
+    resetAndFocusEditor();
   }
 
   function handleAskClaudeKeyDown(e: React.KeyboardEvent) {
@@ -171,38 +269,146 @@ export function Toolbar({ editor, ydoc }: ToolbarProps) {
         Tandem
       </span>
       <div style={{ width: '1px', height: '20px', background: '#e5e7eb', margin: '0 8px' }} />
-      <ToolbarButton
-        label="Highlight"
-        disabled={!canAnnotate || inInputMode}
-        onMouseDown={handleHighlight}
-      />
+
+      {/* Highlight with color picker */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '2px', position: 'relative' }}>
+        <ToolbarButton
+          label="Highlight"
+          disabled={!canAnnotate || inInputMode}
+          onMouseDown={handleHighlight}
+          style={{ borderRadius: '4px 0 0 4px', borderRight: 'none' }}
+        />
+        <button
+          disabled={!canAnnotate || inInputMode}
+          onMouseDown={handleColorPickerToggle}
+          title="Choose highlight color"
+          style={{
+            padding: '4px 6px',
+            fontSize: '13px',
+            border: '1px solid #e5e7eb',
+            borderRadius: '0 4px 4px 0',
+            background: (!canAnnotate || inInputMode) ? '#f9fafb' : '#fff',
+            cursor: (!canAnnotate || inInputMode) ? 'not-allowed' : 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <span style={{
+            display: 'inline-block',
+            width: '12px',
+            height: '12px',
+            borderRadius: '2px',
+            background: HIGHLIGHT_COLORS[highlightColor],
+            border: '1px solid rgba(0,0,0,0.15)',
+          }} />
+        </button>
+        {showColorPicker && (
+          <div
+            ref={colorPickerRef}
+            style={{
+              position: 'absolute',
+              top: '100%',
+              left: 0,
+              marginTop: '4px',
+              background: '#fff',
+              border: '1px solid #e5e7eb',
+              borderRadius: '6px',
+              padding: '6px',
+              display: 'flex',
+              gap: '4px',
+              zIndex: 10,
+              boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            }}
+          >
+            {HIGHLIGHT_COLOR_OPTIONS.map(({ value, label }) => (
+              <button
+                key={value}
+                title={label}
+                onClick={() => handleColorSelect(value)}
+                style={{
+                  width: '24px',
+                  height: '24px',
+                  borderRadius: '4px',
+                  border: value === highlightColor ? '2px solid #374151' : '1px solid rgba(0,0,0,0.15)',
+                  background: HIGHLIGHT_COLORS[value],
+                  cursor: 'pointer',
+                  padding: 0,
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
       <ToolbarButton
         label="Comment"
         disabled={!canAnnotate || inInputMode}
         onMouseDown={handleCommentStart}
       />
       {commentMode && (
+        <InputGroup
+          inputRef={commentInputRef}
+          value={commentText}
+          onChange={setCommentText}
+          onKeyDown={handleCommentKeyDown}
+          onSubmit={handleCommentSubmit}
+          onCancel={handleCommentCancel}
+          placeholder="Add a comment..."
+          submitLabel="Add"
+          borderColor="#3b82f6"
+          canSubmit={!!commentText.trim()}
+        />
+      )}
+
+      <ToolbarButton
+        label="Suggest"
+        disabled={!canAnnotate || inInputMode}
+        onMouseDown={handleSuggestStart}
+      />
+      {suggestMode && (
         <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           <input
-            ref={commentInputRef}
+            ref={suggestInputRef}
             type="text"
-            value={commentText}
-            onChange={e => setCommentText(e.target.value)}
-            onKeyDown={handleCommentKeyDown}
-            placeholder="Add a comment..."
+            value={suggestText}
+            onChange={e => setSuggestText(e.target.value)}
+            onKeyDown={handleSuggestKeyDown}
+            placeholder="Replacement text..."
             style={{
               padding: '3px 8px',
               fontSize: '13px',
-              border: '1px solid #3b82f6',
+              border: '1px solid #8b5cf6',
               borderRadius: '4px',
               outline: 'none',
-              width: '200px',
+              width: '160px',
             }}
           />
-          <ToolbarButton label="Add" disabled={!commentText.trim()} onClick={handleCommentSubmit} />
-          <ToolbarButton label="Cancel" disabled={false} onClick={handleCommentCancel} />
+          <input
+            type="text"
+            value={suggestReason}
+            onChange={e => setSuggestReason(e.target.value)}
+            onKeyDown={handleSuggestKeyDown}
+            placeholder="Reason (optional)"
+            style={{
+              padding: '3px 8px',
+              fontSize: '13px',
+              border: '1px solid #d1d5db',
+              borderRadius: '4px',
+              outline: 'none',
+              width: '140px',
+            }}
+          />
+          <ToolbarButton label="Suggest" disabled={!suggestText.trim()} onClick={handleSuggestSubmit} />
+          <ToolbarButton label="Cancel" disabled={false} onClick={handleSuggestCancel} />
         </div>
       )}
+
+      <ToolbarButton
+        label="Flag"
+        disabled={!canAnnotate || inInputMode}
+        onMouseDown={handleFlag}
+      />
+
       <ToolbarButton
         label="Ask Claude"
         shortcut="Ctrl+Shift+A"
@@ -210,39 +416,70 @@ export function Toolbar({ editor, ydoc }: ToolbarProps) {
         onMouseDown={handleAskClaudeStart}
       />
       {askClaudeMode && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-          <input
-            ref={askClaudeInputRef}
-            type="text"
-            value={askClaudeText}
-            onChange={e => setAskClaudeText(e.target.value)}
-            onKeyDown={handleAskClaudeKeyDown}
-            placeholder="Ask about this text..."
-            style={{
-              padding: '3px 8px',
-              fontSize: '13px',
-              border: '1px solid #6366f1',
-              borderRadius: '4px',
-              outline: 'none',
-              width: '200px',
-            }}
-          />
-          <ToolbarButton label="Ask" disabled={!askClaudeText.trim()} onClick={handleAskClaudeSubmit} />
-          <ToolbarButton label="Cancel" disabled={false} onClick={handleAskClaudeCancel} />
-        </div>
+        <InputGroup
+          inputRef={askClaudeInputRef}
+          value={askClaudeText}
+          onChange={setAskClaudeText}
+          onKeyDown={handleAskClaudeKeyDown}
+          onSubmit={handleAskClaudeSubmit}
+          onCancel={handleAskClaudeCancel}
+          placeholder="Ask about this text..."
+          submitLabel="Ask"
+          borderColor="#6366f1"
+          canSubmit={!!askClaudeText.trim()}
+        />
       )}
+
       <div style={{ flex: 1 }} />
       <span style={{ fontSize: '12px', color: '#9ca3af' }}>Review Mode</span>
     </div>
   );
 }
 
-function ToolbarButton({ label, shortcut, disabled, onMouseDown, onClick }: {
+/** Reusable inline input group for comment/question modes */
+function InputGroup({ inputRef, value, onChange, onKeyDown, onSubmit, onCancel, placeholder, submitLabel, borderColor, canSubmit }: {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  value: string;
+  onChange: (v: string) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  placeholder: string;
+  submitLabel: string;
+  borderColor: string;
+  canSubmit: boolean;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        style={{
+          padding: '3px 8px',
+          fontSize: '13px',
+          border: `1px solid ${borderColor}`,
+          borderRadius: '4px',
+          outline: 'none',
+          width: '200px',
+        }}
+      />
+      <ToolbarButton label={submitLabel} disabled={!canSubmit} onClick={onSubmit} />
+      <ToolbarButton label="Cancel" disabled={false} onClick={onCancel} />
+    </div>
+  );
+}
+
+function ToolbarButton({ label, shortcut, disabled, onMouseDown, onClick, style }: {
   label: string;
   shortcut?: string;
   disabled?: boolean;
   onMouseDown?: (e: React.MouseEvent) => void;
   onClick?: () => void;
+  style?: React.CSSProperties;
 }) {
   return (
     <button
@@ -258,6 +495,7 @@ function ToolbarButton({ label, shortcut, disabled, onMouseDown, onClick }: {
         background: disabled ? '#f9fafb' : '#fff',
         color: disabled ? '#9ca3af' : '#374151',
         cursor: disabled ? 'not-allowed' : 'pointer',
+        ...style,
       }}
     >
       {label}

--- a/src/client/panels/SidePanel.tsx
+++ b/src/client/panels/SidePanel.tsx
@@ -287,6 +287,7 @@ export function SidePanel({ annotations, editor, ydoc }: SidePanelProps) {
             { value: 'comment', label: 'Comments' },
             { value: 'suggestion', label: 'Suggestions' },
             { value: 'question', label: 'Questions' },
+            { value: 'flag', label: 'Flags' },
           ]}
         />
         <FilterSelect
@@ -423,13 +424,22 @@ interface AnnotationCardProps {
   onClick?: () => void;
 }
 
+const ANNOTATION_BORDER_COLORS: Record<string, string> = {
+  comment: '#3b82f6',
+  suggestion: '#8b5cf6',
+  question: '#6366f1',
+  flag: '#ef4444',
+};
+
+function getBorderColor(annotation: Annotation): string {
+  if (annotation.color) {
+    return HIGHLIGHT_COLORS[annotation.color] || '#e5e7eb';
+  }
+  return ANNOTATION_BORDER_COLORS[annotation.type] || '#e5e7eb';
+}
+
 function AnnotationCard({ annotation, isReviewTarget, onAccept, onDismiss, onClick }: AnnotationCardProps) {
-  const borderColor = annotation.color
-    ? HIGHLIGHT_COLORS[annotation.color] || '#e5e7eb'
-    : annotation.type === 'comment' ? '#3b82f6'
-    : annotation.type === 'suggestion' ? '#8b5cf6'
-    : annotation.type === 'question' ? '#6366f1'
-    : '#e5e7eb';
+  const borderColor = getBorderColor(annotation);
 
   const isPending = annotation.status === 'pending';
 

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -104,11 +104,28 @@ export function registerAnnotationTools(server: McpServer): void {
   );
 
   server.tool(
+    'tandem_flag',
+    'Flag a text range for attention (e.g., issues, concerns, or items needing review)',
+    {
+      from: z.number().describe('Start position'),
+      to: z.number().describe('End position'),
+      note: z.string().optional().describe('Reason for flagging'),
+      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+    },
+    async ({ from, to, note, documentId }) => {
+      const map = getAnnotationsMap(documentId);
+      if (!map) return noDocumentError();
+      const id = createAnnotation(map, 'flag', from, to, note || '');
+      return mcpSuccess({ annotationId: id });
+    }
+  );
+
+  server.tool(
     'tandem_getAnnotations',
     'Read all annotations, optionally filtered by author/type/status. For checking new user actions, prefer tandem_checkInbox.',
     {
       author: z.enum(['user', 'claude']).optional().describe('Filter by author'),
-      type: z.enum(['highlight', 'comment', 'suggestion', 'overlay', 'question']).optional().describe('Filter by type'),
+      type: z.enum(['highlight', 'comment', 'suggestion', 'overlay', 'question', 'flag']).optional().describe('Filter by type'),
       status: z.enum(['pending', 'accepted', 'dismissed']).optional().describe('Filter by status'),
       documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
     },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,5 @@
 // Annotation types
-export type AnnotationType = 'highlight' | 'comment' | 'suggestion' | 'overlay' | 'question';
+export type AnnotationType = 'highlight' | 'comment' | 'suggestion' | 'overlay' | 'question' | 'flag';
 export type AnnotationStatus = 'pending' | 'accepted' | 'dismissed';
 export type HighlightColor = 'yellow' | 'red' | 'green' | 'blue' | 'purple';
 export type Severity = 'info' | 'warning' | 'error' | 'success';


### PR DESCRIPTION
## Summary

- **Highlight color picker**: Toolbar now shows a split button with a color swatch dropdown. Users can choose yellow, red, green, blue, or purple before highlighting. Default remains yellow.
- **Suggest button**: Users can propose text replacements directly from the toolbar (replacement text + optional reason), creating suggestion annotations that Claude can review.
- **Flag markers**: New `flag` annotation type for marking text that needs attention. One-click Flag button in toolbar, `tandem_flag` MCP tool on the server, red underline decoration in the editor, and filter/border support in the SidePanel.
- **Code quality**: Extracted reusable `InputGroup` component to eliminate duplication across comment/question input modes. Replaced nested ternary border-color logic in `AnnotationCard` with a `getBorderColor` helper backed by a lookup table. Extracted `captureSelectionRange` and `resetAndFocusEditor` helpers to reduce repetition across toolbar modes.

## Files changed

- `src/shared/types.ts` — added `'flag'` to `AnnotationType`
- `src/shared/constants.ts` — no change needed (`'red'` already present in `HIGHLIGHT_COLORS`)
- `src/client/editor/toolbar/Toolbar.tsx` — color picker, suggest mode, flag button, InputGroup extraction
- `src/client/editor/extensions/annotation.ts` — flag decoration case (red underline)
- `src/client/panels/SidePanel.tsx` — flag filter option, `getBorderColor` helper
- `src/server/mcp/annotations.ts` — `tandem_flag` tool, updated `tandem_getAnnotations` type enum

## Test plan

- [x] `npm test` — 230 tests pass
- [x] `npm run build` — Vite client build succeeds (server TS errors are pre-existing)
- [ ] Manual: open a document, select text, verify highlight color picker works
- [ ] Manual: select text, click Suggest, enter replacement text, verify suggestion annotation appears
- [ ] Manual: select text, click Flag, verify red underline decoration appears
- [ ] Manual: verify SidePanel flag filter and flag card border color
- [ ] Manual: verify `tandem_flag` MCP tool via Claude Code

Closes no issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)