### PR TITLE
feat: review mode polish — E key, threshold banner, document dimming

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -8,7 +8,7 @@ import { StatusBar } from './status/StatusBar';
 import { Toolbar } from './editor/toolbar/Toolbar';
 import { DocumentTabs } from './tabs/DocumentTabs';
 import { ReviewSummary } from './panels/ReviewSummary';
-import { DEFAULT_WS_PORT } from '../shared/constants';
+import { DEFAULT_WS_PORT, REVIEW_BANNER_THRESHOLD } from '../shared/constants';
 import type { Annotation } from '../shared/types';
 
 export interface DocListEntry {
@@ -35,6 +35,9 @@ export default function App() {
   const [ready, setReady] = useState(false);
   const [showReviewSummary, setShowReviewSummary] = useState(false);
   const [reviewSummaryData, setReviewSummaryData] = useState<{ accepted: number; dismissed: number; total: number } | null>(null);
+  const [reviewMode, setReviewMode] = useState(false);
+  const [showBanner, setShowBanner] = useState(false);
+  const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null);
   const [, setEditorVersion] = useState(0);
 
   const editorRef = useRef<TiptapEditor | null>(null);
@@ -210,7 +213,7 @@ export default function App() {
     }
   }, [activeTabId, setupTabObservers]);
 
-  // Detect review completion: all pending → 0 while resolved > 0 (single pass)
+  // Detect review completion: all pending -> 0 while resolved > 0 (single pass)
   useEffect(() => {
     let pending = 0, accepted = 0, dismissed = 0;
     for (const a of annotations) {
@@ -226,6 +229,22 @@ export default function App() {
     }
     prevPendingRef.current = pending;
   }, [annotations]);
+
+  // Show banner when pending annotations exceed threshold
+  useEffect(() => {
+    const pendingCount = annotations.filter(a => a.status === 'pending').length;
+    if (pendingCount >= REVIEW_BANNER_THRESHOLD && !reviewMode) {
+      setShowBanner(true);
+    }
+    if (pendingCount === 0) {
+      setShowBanner(false);
+    }
+  }, [annotations, reviewMode]);
+
+  const toggleReviewMode = useCallback(() => {
+    setReviewMode(prev => !prev);
+    setShowBanner(false);
+  }, []);
 
   const handleTabSwitch = useCallback((tabId: string) => {
     setActiveTabId(tabId);
@@ -260,6 +279,53 @@ export default function App() {
           onTabClose={handleTabClose}
         />
       )}
+      {showBanner && !reviewMode && (
+        <div style={{
+          padding: '8px 16px',
+          background: '#eef2ff',
+          borderBottom: '1px solid #c7d2fe',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          fontSize: '13px',
+          color: '#4338ca',
+        }}>
+          <span>
+            {annotations.filter(a => a.status === 'pending').length} annotations pending review.
+          </span>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <button
+              onClick={toggleReviewMode}
+              style={{
+                padding: '3px 10px',
+                fontSize: '12px',
+                border: '1px solid #6366f1',
+                borderRadius: '4px',
+                background: '#6366f1',
+                color: 'white',
+                cursor: 'pointer',
+                fontWeight: 500,
+              }}
+            >
+              Review in sequence
+            </button>
+            <button
+              onClick={() => setShowBanner(false)}
+              style={{
+                padding: '3px 10px',
+                fontSize: '12px',
+                border: '1px solid #d1d5db',
+                borderRadius: '4px',
+                background: 'white',
+                color: '#6b7280',
+                cursor: 'pointer',
+              }}
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
       <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
         <div style={{ flex: 1, overflow: 'auto', padding: '24px 48px' }}>
           {activeTab ? (
@@ -268,6 +334,8 @@ export default function App() {
               ydoc={activeTab.ydoc}
               provider={activeTab.provider}
               readOnly={readOnly}
+              reviewMode={reviewMode}
+              activeAnnotationId={activeAnnotationId}
               onConnectionChange={setConnected}
               onEditorReady={handleEditorReady}
             />
@@ -281,6 +349,10 @@ export default function App() {
           annotations={annotations}
           editor={editorRef.current}
           ydoc={activeTab?.ydoc ?? null}
+          reviewMode={reviewMode}
+          onToggleReviewMode={toggleReviewMode}
+          activeAnnotationId={activeAnnotationId}
+          onActiveAnnotationChange={setActiveAnnotationId}
         />
       </div>
       <StatusBar

--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -20,11 +20,13 @@ interface EditorProps {
   ydoc: Y.Doc;
   provider: HocuspocusProvider;
   readOnly: boolean;
+  reviewMode?: boolean;
+  activeAnnotationId?: string | null;
   onConnectionChange: (connected: boolean) => void;
   onEditorReady?: (editor: TiptapEditor | null) => void;
 }
 
-export function Editor({ ydoc, provider, readOnly, onConnectionChange, onEditorReady }: EditorProps) {
+export function Editor({ ydoc, provider, readOnly, reviewMode, activeAnnotationId, onConnectionChange, onEditorReady }: EditorProps) {
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -72,8 +74,26 @@ export function Editor({ ydoc, provider, readOnly, onConnectionChange, onEditorR
     return () => onEditorReady?.(null);
   }, [editor, onEditorReady]);
 
+  // Apply active annotation highlight class based on activeAnnotationId
+  useEffect(() => {
+    if (!editor) return;
+    const container = editor.view.dom;
+
+    container.querySelectorAll('.tandem-annotation-active').forEach(el => {
+      el.classList.remove('tandem-annotation-active');
+    });
+
+    if (activeAnnotationId && reviewMode) {
+      container.querySelectorAll(`[data-annotation-id="${activeAnnotationId}"]`).forEach(el => {
+        el.classList.add('tandem-annotation-active');
+      });
+    }
+  }, [editor, activeAnnotationId, reviewMode]);
+
+  const containerClass = reviewMode ? 'tandem-review-dimmed' : '';
+
   return (
-    <div>
+    <div className={containerClass}>
       <EditorContent editor={editor} />
       <style>{`
         .tandem-editor h1 { font-size: 2em; font-weight: 700; margin: 0.67em 0; }
@@ -121,6 +141,22 @@ export function Editor({ ydoc, provider, readOnly, onConnectionChange, onEditorR
         .tandem-comment { cursor: pointer; }
         .tandem-comment:hover { border-bottom-style: solid; }
         .tandem-suggestion { cursor: pointer; }
+
+        /* Review mode dimming — grays out text, keeps annotated spans readable */
+        .tandem-review-dimmed .ProseMirror {
+          color: #9ca3af;
+          transition: color 0.2s;
+        }
+        .tandem-review-dimmed .tandem-highlight,
+        .tandem-review-dimmed .tandem-comment,
+        .tandem-review-dimmed .tandem-suggestion {
+          color: #1f2937;
+        }
+        .tandem-review-dimmed .tandem-annotation-active {
+          outline: 2px solid #6366f1;
+          outline-offset: 1px;
+          border-radius: 2px;
+        }
 
         /* Claude focus paragraph */
         .tandem-claude-focus {

--- a/src/client/panels/SidePanel.tsx
+++ b/src/client/panels/SidePanel.tsx
@@ -9,6 +9,10 @@ interface SidePanelProps {
   annotations: Annotation[];
   editor: TiptapEditor | null;
   ydoc: Y.Doc | null;
+  reviewMode: boolean;
+  onToggleReviewMode: () => void;
+  activeAnnotationId: string | null;
+  onActiveAnnotationChange: (id: string | null) => void;
 }
 
 type FilterType = AnnotationType | 'all';
@@ -30,11 +34,10 @@ function applySuggestion(ann: Annotation, editor: TiptapEditor) {
   }
 }
 
-export function SidePanel({ annotations, editor, ydoc }: SidePanelProps) {
+export function SidePanel({ annotations, editor, ydoc, reviewMode, onToggleReviewMode, activeAnnotationId, onActiveAnnotationChange }: SidePanelProps) {
   const [filterType, setFilterType] = useState<FilterType>('all');
   const [filterAuthor, setFilterAuthor] = useState<FilterAuthor>('all');
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
-  const [reviewMode, setReviewMode] = useState(false);
   const [reviewIndex, setReviewIndex] = useState(0);
   const reviewIndexRef = useRef(0);
 
@@ -135,19 +138,32 @@ export function SidePanel({ annotations, editor, ydoc }: SidePanelProps) {
     if (ann) resolveAnnotation(ann.id, 'dismissed');
   }, []);
 
+  // Reset review index and scroll to first annotation when entering review mode
+  const prevReviewModeRef = useRef(false);
+  useEffect(() => {
+    if (reviewMode && !prevReviewModeRef.current && reviewTargets.length > 0) {
+      reviewIndexRef.current = 0;
+      setReviewIndex(0);
+      scrollToAnnotation(reviewTargets[0]);
+    }
+    prevReviewModeRef.current = reviewMode;
+  }, [reviewMode, reviewTargets, scrollToAnnotation]);
+
+  // Sync activeAnnotationId when review index changes
+  useEffect(() => {
+    if (reviewMode && reviewTargets.length > 0) {
+      onActiveAnnotationChange(reviewTargets[reviewIndex]?.id ?? null);
+    } else {
+      onActiveAnnotationChange(null);
+    }
+  }, [reviewMode, reviewIndex, reviewTargets, onActiveAnnotationChange]);
+
   // Keyboard shortcuts — stable deps via refs
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.ctrlKey && e.shiftKey && e.key === 'R') {
         e.preventDefault();
-        setReviewMode(prev => {
-          if (!prev && reviewTargetsRef.current.length > 0) {
-            reviewIndexRef.current = 0;
-            setReviewIndex(0);
-            scrollToAnnotation(reviewTargetsRef.current[0]);
-          }
-          return !prev;
-        });
+        onToggleReviewMode();
         return;
       }
 
@@ -164,14 +180,22 @@ export function SidePanel({ annotations, editor, ydoc }: SidePanelProps) {
         if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
         e.preventDefault();
         dismissCurrent();
+      } else if (e.key === 'e' || e.key === 'E') {
+        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+        e.preventDefault();
+        // Scroll to current annotation and exit review mode without resolving
+        const targets = reviewTargetsRef.current;
+        const ann = targets[reviewIndexRef.current];
+        if (ann) scrollToAnnotation(ann);
+        onToggleReviewMode();
       } else if (e.key === 'Escape') {
-        setReviewMode(false);
+        onToggleReviewMode();
       }
     }
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [reviewMode, navigateReview, acceptCurrent, dismissCurrent, scrollToAnnotation]);
+  }, [reviewMode, navigateReview, acceptCurrent, dismissCurrent, scrollToAnnotation, onToggleReviewMode]);
 
   // Keep review index in bounds when annotations change
   useEffect(() => {
@@ -185,23 +209,12 @@ export function SidePanel({ annotations, editor, ydoc }: SidePanelProps) {
   // Auto-exit review mode when no pending left
   useEffect(() => {
     if (reviewMode && reviewTargets.length === 0) {
-      setReviewMode(false);
+      onToggleReviewMode();
     }
-  }, [reviewMode, reviewTargets.length]);
+  }, [reviewMode, reviewTargets.length, onToggleReviewMode]);
 
   const hasFilters = filterType !== 'all' || filterAuthor !== 'all' || filterStatus !== 'all';
   const activeReviewAnn = reviewMode && reviewTargets.length > 0 ? reviewTargets[reviewIndex] : null;
-
-  const toggleReviewMode = useCallback(() => {
-    setReviewMode(prev => {
-      if (!prev && reviewTargetsRef.current.length > 0) {
-        reviewIndexRef.current = 0;
-        setReviewIndex(0);
-        scrollToAnnotation(reviewTargetsRef.current[0]);
-      }
-      return !prev;
-    });
-  }, [scrollToAnnotation]);
 
   return (
     <div style={{
@@ -232,7 +245,7 @@ export function SidePanel({ annotations, editor, ydoc }: SidePanelProps) {
           </h3>
           {allPending.length > 0 && (
             <button
-              onClick={toggleReviewMode}
+              onClick={onToggleReviewMode}
               title="Keyboard review mode (Ctrl+Shift+R)"
               style={{
                 padding: '2px 8px',
@@ -264,7 +277,7 @@ export function SidePanel({ annotations, editor, ydoc }: SidePanelProps) {
             Reviewing {reviewIndex + 1} / {reviewTargets.length}
           </div>
           <div style={{ color: '#6366f1' }}>
-            Tab: next · Shift+Tab: prev · Y: accept · N: dismiss · Esc: exit
+            Tab: next · Shift+Tab: prev · Y: accept · N: dismiss · E: examine · Esc: exit
           </div>
         </div>
       )}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -7,6 +7,7 @@ export const IDLE_TIMEOUT = 30 * 60 * 1000; // 30 minutes
 export const SESSION_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
 export const TYPING_DEBOUNCE = 3000; // 3 seconds
 export const OVERLAY_STALE_DEBOUNCE = 200; // 200ms
+export const REVIEW_BANNER_THRESHOLD = 5;
 
 export const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: 'rgba(255, 235, 59, 0.3)',


### PR DESCRIPTION
## Summary
- Add E keyboard shortcut in review mode: scrolls to annotation and exits without accepting/dismissing
- Add configurable threshold banner (REVIEW_BANNER_THRESHOLD = 5) with "Review in sequence" action
- Lift reviewMode state from SidePanel to App for banner integration
- Add document dimming in review mode via dynamic CSS: grays out text, keeps annotated spans readable, outlines active annotation

## Test plan
- [ ] Enter review mode with 5+ pending annotations, verify banner appears
- [ ] Click "Review in sequence", verify banner dismisses and review mode activates
- [ ] Press E on an annotation, verify it scrolls and exits review mode without accepting
- [ ] Verify document dims in review mode with active annotation highlighted

Closes #N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)