### PR TITLE
Fix MCP transport: per-session lifecycle management

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,20 +1,20 @@
-import type { Server } from 'http';
-import { execSync } from 'child_process';
-import { startMcpServerStdio, startMcpServerHttp } from './mcp/server.js';
-import { startHocuspocus } from './yjs/provider.js';
-import { DEFAULT_WS_PORT, DEFAULT_MCP_PORT } from '../shared/constants.js';
-import { cleanupSessions, stopAutoSave } from './session/manager.js';
-import { saveCurrentSession, restoreCtrlSession } from './mcp/document.js';
+import type { Server } from "http";
+import { execSync } from "child_process";
+import { startMcpServerStdio, startMcpServerHttp, closeMcpSession } from "./mcp/server.js";
+import { startHocuspocus } from "./yjs/provider.js";
+import { DEFAULT_WS_PORT, DEFAULT_MCP_PORT } from "../shared/constants.js";
+import { cleanupSessions, stopAutoSave } from "./session/manager.js";
+import { saveCurrentSession, restoreCtrlSession } from "./mcp/document.js";
 
 // stdout is exclusively reserved for the MCP JSON-RPC wire protocol (stdio mode).
 // Redirect any console.log calls (from Hocuspocus or other libs) to stderr.
 // In HTTP mode this is defense-in-depth; in stdio mode it's critical.
-// eslint-disable-next-line no-console
+
 console.log = console.error;
 console.warn = console.error;
 console.info = console.error;
 
-const transportMode = (process.env.TANDEM_TRANSPORT || 'http').toLowerCase();
+const transportMode = (process.env.TANDEM_TRANSPORT || "http").toLowerCase();
 const wsPort = parseInt(process.env.TANDEM_PORT || String(DEFAULT_WS_PORT), 10);
 const mcpPort = parseInt(process.env.TANDEM_MCP_PORT || String(DEFAULT_MCP_PORT), 10);
 
@@ -23,13 +23,13 @@ let httpServer: Server | null = null;
 /** Kill any process currently listening on the given TCP port (Windows). */
 function freePort(p: number): void {
   try {
-    const out = execSync(
-      `netstat -ano | findstr ":${p}.*LISTENING"`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] },
-    );
+    const out = execSync(`netstat -ano | findstr ":${p}.*LISTENING"`, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+    });
     const pid = out.trim().split(/\s+/).at(-1);
     if (pid && /^\d+$/.test(pid)) {
-      execSync(`taskkill /PID ${pid} /F`, { stdio: 'ignore' });
+      execSync(`taskkill /PID ${pid} /F`, { stdio: "ignore" });
       console.error(`[Tandem] Killed stale PID ${pid} holding port ${p}`);
     }
   } catch {
@@ -39,19 +39,19 @@ function freePort(p: number): void {
 
 // Swallow all uncaught exceptions to keep the server alive during stale browser reconnects.
 // Hocuspocus throws on malformed WebSocket frames; we log but never exit.
-process.on('uncaughtException', (err: Error) => {
-  console.error('[Tandem] uncaughtException (swallowed):', err.name, err.message, err.stack);
+process.on("uncaughtException", (err: Error) => {
+  console.error("[Tandem] uncaughtException (swallowed):", err.name, err.message, err.stack);
 });
-process.on('unhandledRejection', (reason) => {
-  console.error('[Tandem] unhandledRejection (swallowed):', reason);
+process.on("unhandledRejection", (reason) => {
+  console.error("[Tandem] unhandledRejection (swallowed):", reason);
 });
-process.on('exit', (code) => {
+process.on("exit", (code) => {
   console.error(`[Tandem] Process exiting with code ${code}`);
 });
 
-if (transportMode === 'stdio') {
-  process.stdin.on('end', () => {
-    console.error('[Tandem] stdin ended (MCP transport closed)');
+if (transportMode === "stdio") {
+  process.stdin.on("end", () => {
+    console.error("[Tandem] stdin ended (MCP transport closed)");
   });
 }
 
@@ -62,33 +62,36 @@ async function shutdown(signal: string) {
     await saveCurrentSession();
     stopAutoSave();
   } catch (err) {
-    console.error('[Tandem] Session save on shutdown failed:', err);
+    console.error("[Tandem] Session save on shutdown failed:", err);
   }
+  await closeMcpSession();
   if (httpServer) {
     httpServer.close();
   }
   process.exit(0);
 }
-process.on('SIGTERM', () => shutdown('SIGTERM'));
-process.on('SIGINT', () => shutdown('SIGINT'));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
 
 async function main() {
   console.error(`[Tandem] Starting server (transport: ${transportMode})...`);
 
   // Clean up sessions older than 30 days
-  cleanupSessions().then(n => {
-    if (n > 0) console.error(`[Tandem] Cleaned up ${n} stale session(s)`);
-  }).catch(() => {});
+  cleanupSessions()
+    .then((n) => {
+      if (n > 0) console.error(`[Tandem] Cleaned up ${n} stale session(s)`);
+    })
+    .catch(() => {});
 
   // Restore chat history from previous session
   restoreCtrlSession().catch(() => {});
 
-  if (transportMode === 'http') {
+  if (transportMode === "http") {
     // HTTP mode: no startup-order constraint — start both concurrently
     freePort(wsPort);
     freePort(mcpPort);
     // Give the OS a moment to release the ports after killing stale processes
-    await new Promise(r => setTimeout(r, 300));
+    await new Promise((r) => setTimeout(r, 300));
 
     const [srv] = await Promise.all([
       startMcpServerHttp(mcpPort),
@@ -101,19 +104,19 @@ async function main() {
     // Stdio mode: MCP must start before Hocuspocus to beat Claude Code's init timeout
     (async () => {
       freePort(wsPort);
-      await new Promise(r => setTimeout(r, 300));
+      await new Promise((r) => setTimeout(r, 300));
       await startHocuspocus(wsPort);
       console.error(`[Tandem] Hocuspocus WebSocket server running on ws://localhost:${wsPort}`);
     })().catch((err) => {
-      console.error('[Tandem] Hocuspocus startup error:', err);
+      console.error("[Tandem] Hocuspocus startup error:", err);
     });
 
     await startMcpServerStdio();
-    console.error('[Tandem] MCP server running on stdio');
+    console.error("[Tandem] MCP server running on stdio");
   }
 }
 
 main().catch((err) => {
-  console.error('[Tandem] Fatal error:', err);
+  console.error("[Tandem] Fatal error:", err);
   process.exit(1);
 });

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -4,10 +4,17 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { registerDocumentTools } from "./document.js";
 import { registerAnnotationTools } from "./annotations.js";
 import { registerNavigationTools } from "./navigation.js";
 import { registerAwarenessTools } from "./awareness.js";
+
+// McpServer is long-lived (tool registrations survive close/reconnect).
+// Transport is ephemeral — rotated on each new initialize request.
+let mcpServer: McpServer | null = null;
+let currentTransport: StreamableHTTPServerTransport | null = null;
+let connectingPromise: Promise<void> | null = null;
 
 /** Create an McpServer with all tool groups registered (no transport). */
 function createMcpServer(): McpServer {
@@ -24,6 +31,64 @@ function createMcpServer(): McpServer {
   return server;
 }
 
+/** Extract the JSON-RPC `id` from a request body (single message only, not batches). */
+function jsonrpcId(body: unknown): unknown {
+  return body && typeof body === "object" && !Array.isArray(body) && "id" in body
+    ? (body as any).id
+    : null;
+}
+
+/** Send a JSON-RPC error response. */
+function sendJsonRpcError(
+  res: any,
+  status: number,
+  code: number,
+  message: string,
+  id: unknown = null,
+): void {
+  res.status(status).json({ jsonrpc: "2.0", error: { code, message }, id });
+}
+
+/**
+ * Tear down the current transport (if any) and connect a fresh one.
+ * Serialized via connectingPromise so concurrent initialize requests
+ * don't double-rotate.
+ */
+async function connectFreshTransport(): Promise<void> {
+  if (!mcpServer) throw new Error("mcpServer not initialized");
+
+  const doConnect = async () => {
+    if (currentTransport) {
+      console.error("[Tandem] Closing previous MCP transport session");
+      await mcpServer!.close();
+      currentTransport = null;
+    }
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+    });
+
+    await mcpServer!.connect(transport);
+    currentTransport = transport;
+    console.error("[Tandem] New MCP session established");
+  };
+
+  // Chain behind any in-flight rotation to prevent races
+  const promise = (connectingPromise ?? Promise.resolve()).then(doConnect);
+  connectingPromise = promise;
+  await promise;
+  // Release the lock once settled so the resolved promise can be GC'd
+  if (connectingPromise === promise) connectingPromise = null;
+}
+
+/** Close the active MCP session (for graceful shutdown). */
+export async function closeMcpSession(): Promise<void> {
+  if (currentTransport && mcpServer) {
+    await mcpServer.close();
+    currentTransport = null;
+  }
+}
+
 /** Start the MCP server on stdio (legacy, used as fallback via TANDEM_TRANSPORT=stdio). */
 export async function startMcpServerStdio(): Promise<void> {
   const server = createMcpServer();
@@ -33,25 +98,55 @@ export async function startMcpServerStdio(): Promise<void> {
 
 /** Start the MCP server on HTTP using Streamable HTTP transport. Returns the http.Server for lifecycle management. */
 export async function startMcpServerHttp(port: number, host = "127.0.0.1"): Promise<Server> {
-  const server = createMcpServer();
+  mcpServer = createMcpServer();
   const app = createMcpExpressApp({ host });
 
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
+  app.post("/mcp", async (req: any, res: any) => {
+    const body = req.body as unknown;
+    const isInit =
+      isInitializeRequest(body) || (Array.isArray(body) && body.some(isInitializeRequest));
+
+    if (isInit) {
+      console.error("[Tandem] Received initialize request, rotating transport");
+      try {
+        await connectFreshTransport();
+      } catch (err) {
+        console.error("[Tandem] Failed to create new transport:", err);
+        sendJsonRpcError(res, 500, -32603, "Internal error", jsonrpcId(body));
+        return;
+      }
+    }
+
+    if (!currentTransport) {
+      sendJsonRpcError(res, 503, -32000, "No active session", jsonrpcId(body));
+      return;
+    }
+
+    await currentTransport.handleRequest(req, res, body);
   });
 
-  const mcpHandler = async (req: any, res: any) => {
-    await transport.handleRequest(req, res, req.body);
-  };
-  app.post("/mcp", mcpHandler);
-  app.get("/mcp", mcpHandler);
-  app.delete("/mcp", mcpHandler);
+  app.get("/mcp", async (req: any, res: any) => {
+    if (!currentTransport) {
+      sendJsonRpcError(res, 503, -32000, "No active session");
+      return;
+    }
+    await currentTransport.handleRequest(req, res, req.body);
+  });
+
+  // DELETE — SDK handles session teardown internally via handleDeleteRequest,
+  // which closes the transport and triggers Protocol._onclose().
+  app.delete("/mcp", async (req: any, res: any) => {
+    if (!currentTransport) {
+      sendJsonRpcError(res, 404, -32001, "Session not found");
+      return;
+    }
+    await currentTransport.handleRequest(req, res, req.body);
+    currentTransport = null;
+  });
 
   app.get("/health", (_req: unknown, res: { json: (body: unknown) => void }) => {
-    res.json({ status: "ok", transport: "http" });
+    res.json({ status: "ok", transport: "http", hasSession: currentTransport !== null });
   });
-
-  await server.connect(transport);
 
   return new Promise<Server>((resolve, reject) => {
     const httpServer = app.listen(port, host, () => {


### PR DESCRIPTION
## Summary

- Rotates the `StreamableHTTPServerTransport` on each new `initialize` request so Claude Code's `/mcp` restart works without restarting the Tandem server
- Reuses the long-lived `McpServer` (tool registrations survive close/reconnect) — only the transport is ephemeral
- Adds `closeMcpSession()` export called during graceful shutdown to clean up SSE streams

## What changed

**`src/server/mcp/server.ts`** — the only file with substantive changes:
- POST handler detects `initialize` via the SDK's `isInitializeRequest()` and calls `connectFreshTransport()` to tear down the old transport and create a fresh one
- GET/DELETE handlers return proper JSON-RPC errors when no session exists
- Promise-chain lock (`connectingPromise`) serializes concurrent rotations
- `jsonrpcId()` and `sendJsonRpcError()` helpers reduce duplication across route handlers
- `/health` endpoint now includes `hasSession` for debugging

**`src/server/index.ts`** — one-line addition: calls `closeMcpSession()` in the shutdown handler

## Test plan

- [x] `npm test` — 254 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Manual HTTP test: first initialize → 200
- [x] Manual HTTP test: tool call on session → 200
- [x] Manual HTTP test: re-initialize (the core fix) → 200 with new session ID
- [x] Manual HTTP test: tool call after re-init → 200
- [x] Manual HTTP test: 5 consecutive re-initializes → all 200
- [x] Manual HTTP test: stale session ID → 404 rejected
- [x] Manual HTTP test: DELETE → `hasSession: false`
- [x] Manual HTTP test: initialize after DELETE → 200

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)