### PR TITLE
feat(annotations): migrate ranges to Yjs RelativePosition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Three layers: Browser (Tiptap) <-> Tandem Server (Hocuspocus + MCP) <-> Claude C
 - Server logs use console.error (stdout reserved for MCP protocol in stdio mode; defense-in-depth in HTTP mode)
 - Ranges use `resolveRange()` for safe targeting (not raw offsets)
 - Two coordinate systems: "flat text offsets" (server side, includes heading prefixes) and "ProseMirror positions" (client side, structural). Extensions convert between them.
+- Annotation ranges use Yjs RelativePosition (`relRange` field) for CRDT-anchored positions that survive concurrent edits. Flat offsets in `range` are the fallback. `refreshRange()` resolves relRange → flat offsets on read; lazily attaches relRange to annotations that lack it.
 - tandem_edit rejects ranges that overlap heading markup (e.g., "## ") — target text content only
 - User→Claude communication via `tandem_checkInbox` (annotation actions, responses, and chat messages) and `tandem_reply` (Claude's chat responses). Chat sidebar provides freeform conversation alongside annotation-based review. Call `tandem_checkInbox` between tasks.
 - Multi-document: each open file gets a unique documentId (hash of path), used as both Map key and Hocuspocus room name. All MCP tools accept optional `documentId` param, defaulting to the active document.
@@ -73,6 +74,7 @@ Three layers: Browser (Tiptap) <-> Tandem Server (Hocuspocus + MCP) <-> Claude C
 - [x] fix(ci): add `@types/node` and split client/server tsconfigs to resolve typecheck failures
 - [x] fix(ci): update OIDC permissions in claude-review workflow
 - [x] fix(server): per-session MCP transport rotation so `/mcp` restart works without server restart (Issue #18)
+- [x] feat(annotations): migrate ranges to Yjs RelativePosition for CRDT-anchored positions (Issue #37)
 
 **Remaining — see [docs/roadmap.md](docs/roadmap.md):**
 - [ ] Phase 2: Cowork integration — configurable port/URL, cross-platform sessions, MCP registration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -228,6 +228,29 @@ Some text here
 
 The `flatOffsetToPmPos` function (in `annotation.ts`) and `pmPosToFlatOffset` function (in `awareness.ts`) handle this conversion. MCP tool users never need to think about PM positions.
 
+### Yjs RelativePosition (CRDT-anchored ranges)
+
+Flat offsets go stale when the document is edited — an annotation at offset 10 stays at offset 10 even if text was inserted before it. **Yjs RelativePosition** solves this by encoding positions as references to CRDT Item IDs, which automatically track through concurrent edits.
+
+Annotations store an optional `relRange` field alongside the flat `range`:
+
+```typescript
+interface Annotation {
+  range: { from: number; to: number };      // flat offsets (fallback)
+  relRange?: { fromRel: unknown; toRel: unknown }; // CRDT-anchored (preferred)
+}
+```
+
+**Creation:** Server computes `relRange` via `flatOffsetToRelPos()` when creating annotations. The `assoc` parameter controls boundary behavior: `0` for range start (stick right — annotation grows on insert at boundary), `-1` for range end (stick left — annotation doesn't grow).
+
+**Reading:** `refreshRange()` resolves `relRange` back to flat offsets, correcting any drift. It also lazily attaches `relRange` to annotations that lack it (user-created or legacy). All server-side read paths (`tandem_getAnnotations`, `tandem_exportAnnotations`, `tandem_checkInbox`) call `refreshRange` before returning data.
+
+**Client rendering:** `buildDecorations()` prefers `relRange` resolution via `relRangeToPmPositions()`, bypassing the flat-offset-to-PM conversion and its heading-prefix math. Falls back to `flatOffsetToPmPos()` when `relRange` is absent or can't resolve.
+
+**Conversion utilities** (in `document-model.ts`):
+- `flatOffsetToRelPos(doc, offset, assoc)` — flat offset → serialized RelativePosition JSON
+- `relPosToFlatOffset(doc, relPosJson)` — serialized RelativePosition → flat offset (or null if deleted)
+
 ## Security
 
 - Server binds to `127.0.0.1` only -- not accessible from network

--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -1,13 +1,13 @@
-import { Extension } from '@tiptap/core';
-import { Plugin, PluginKey } from '@tiptap/pm/state';
-import { Decoration, DecorationSet } from '@tiptap/pm/view';
-import type { Node as PmNode } from '@tiptap/pm/model';
-import * as Y from 'yjs';
-import { HIGHLIGHT_COLORS } from '../../../shared/constants';
-import type { Annotation } from '../../../shared/types';
-import { headingPrefixLength } from '../../../shared/offsets';
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import type { Node as PmNode } from "@tiptap/pm/model";
+import * as Y from "yjs";
+import { HIGHLIGHT_COLORS } from "../../../shared/constants";
+import type { Annotation, RelativeRange } from "../../../shared/types";
+import { headingPrefixLength } from "../../../shared/offsets";
 
-const annotationPluginKey = new PluginKey('tandemAnnotations');
+const annotationPluginKey = new PluginKey("tandemAnnotations");
 
 /**
  * Convert a flat character offset (from the server's extractText format) to a
@@ -28,9 +28,8 @@ export function flatOffsetToPmPos(doc: PmNode, flatOffset: number): number {
     const childStart = pmOffset + 1;
 
     // Heading prefix chars exist in flat text but not in PM
-    const prefixLen = child.type.name === 'heading'
-      ? headingPrefixLength((child.attrs.level as number) || 1)
-      : 0;
+    const prefixLen =
+      child.type.name === "heading" ? headingPrefixLength((child.attrs.level as number) || 1) : 0;
 
     const textLen = child.textContent.length;
     const fullFlatLen = prefixLen + textLen;
@@ -61,19 +60,106 @@ export function flatOffsetToPmPos(doc: PmNode, flatOffset: number): number {
 }
 
 /**
+ * Resolve a Y.AbsolutePosition (from a RelativePosition) to a ProseMirror position.
+ * Walks the Y.XmlFragment and PM doc in parallel, matching by XmlText identity.
+ */
+function xmlTextIndexToPmPos(
+  pmDoc: PmNode,
+  fragment: Y.XmlFragment,
+  absPos: { type: Y.AbstractType<unknown>; index: number },
+): number | null {
+  let pmOffset = 0;
+
+  const nodeCount = Math.min(pmDoc.childCount, fragment.length);
+  for (let i = 0; i < nodeCount; i++) {
+    const yNode = fragment.get(i);
+    const pmChild = pmDoc.child(i);
+    const childStart = pmOffset + 1; // +1 for PM block open tag
+
+    if (yNode instanceof Y.XmlElement) {
+      // Walk XmlText siblings, accumulating char offsets for multi-span (formatted) text
+      let charAccum = 0;
+      for (let j = 0; j < yNode.length; j++) {
+        const child = yNode.get(j);
+        if (child instanceof Y.XmlText) {
+          if (child === absPos.type) {
+            return childStart + Math.min(charAccum + absPos.index, pmChild.textContent.length);
+          }
+          charAccum += child.length;
+        }
+      }
+    }
+
+    pmOffset += pmChild.nodeSize;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a RelativeRange to ProseMirror positions.
+ * Returns null if either position can't be resolved (e.g., deleted content).
+ */
+export function relRangeToPmPositions(
+  ydoc: Y.Doc,
+  pmDoc: PmNode,
+  relRange: RelativeRange,
+): { from: number; to: number } | null {
+  const fromRpos = Y.createRelativePositionFromJSON(relRange.fromRel);
+  const toRpos = Y.createRelativePositionFromJSON(relRange.toRel);
+
+  const fromAbs = Y.createAbsolutePositionFromRelativePosition(fromRpos, ydoc);
+  const toAbs = Y.createAbsolutePositionFromRelativePosition(toRpos, ydoc);
+  if (!fromAbs || !toAbs) return null;
+
+  const fragment = ydoc.getXmlFragment("default");
+  const fromPm = xmlTextIndexToPmPos(pmDoc, fragment, fromAbs);
+  const toPm = xmlTextIndexToPmPos(pmDoc, fragment, toAbs);
+  if (fromPm === null || toPm === null) return null;
+
+  return { from: fromPm, to: toPm };
+}
+
+/**
+ * Resolve an annotation's range to PM positions, preferring relRange.
+ */
+export function resolveAnnotationPmRange(
+  ann: Annotation,
+  pmDoc: PmNode,
+  ydoc: Y.Doc | null,
+): { from: number; to: number } | null {
+  // Try relRange first
+  if (ann.relRange && ydoc) {
+    const resolved = relRangeToPmPositions(ydoc, pmDoc, ann.relRange);
+    if (resolved) return resolved;
+  }
+  // Fall back to flat offsets
+  if (!ann.range) return null;
+  return {
+    from: flatOffsetToPmPos(pmDoc, ann.range.from),
+    to: flatOffsetToPmPos(pmDoc, ann.range.to),
+  };
+}
+
+/**
  * Build a DecorationSet from all pending annotations in the Y.Map.
  */
-function buildDecorations(doc: PmNode, annotationsMap: Y.Map<unknown>): DecorationSet {
+function buildDecorations(
+  doc: PmNode,
+  annotationsMap: Y.Map<unknown>,
+  ydoc: Y.Doc | null,
+): DecorationSet {
   const decorations: Decoration[] = [];
   const maxPos = doc.content.size;
 
   annotationsMap.forEach((value) => {
     const ann = value as Annotation;
-    if (ann.status !== 'pending') return;
-    if (!ann.range) return;
+    if (ann.status !== "pending") return;
+    if (!ann.range && !ann.relRange) return;
 
-    const from = flatOffsetToPmPos(doc, ann.range.from);
-    const to = flatOffsetToPmPos(doc, ann.range.to);
+    const resolved = resolveAnnotationPmRange(ann, doc, ydoc);
+    if (!resolved) return;
+    const { from, to } = resolved;
 
     // Skip invalid ranges
     if (from >= to || from < 0 || to > maxPos) return;
@@ -81,42 +167,45 @@ function buildDecorations(doc: PmNode, annotationsMap: Y.Map<unknown>): Decorati
     let attrs: Record<string, string> = {};
 
     switch (ann.type) {
-      case 'highlight': {
-        const color = ann.color || 'yellow';
+      case "highlight": {
+        const color = ann.color || "yellow";
         const bg = HIGHLIGHT_COLORS[color] || HIGHLIGHT_COLORS.yellow;
         attrs = {
           class: `tandem-highlight tandem-highlight--${color}`,
           style: `background: ${bg}; border-radius: 2px; padding: 1px 0;`,
-          'data-annotation-id': ann.id,
+          "data-annotation-id": ann.id,
         };
         break;
       }
-      case 'comment':
+      case "comment":
         attrs = {
-          class: 'tandem-comment',
-          style: 'border-bottom: 2px dashed #3b82f6; padding-bottom: 1px;',
-          'data-annotation-id': ann.id,
+          class: "tandem-comment",
+          style: "border-bottom: 2px dashed #3b82f6; padding-bottom: 1px;",
+          "data-annotation-id": ann.id,
         };
         break;
-      case 'suggestion':
+      case "suggestion":
         attrs = {
-          class: 'tandem-suggestion',
-          style: 'background: rgba(139, 92, 246, 0.15); text-decoration: underline wavy #8b5cf6; text-underline-offset: 3px;',
-          'data-annotation-id': ann.id,
+          class: "tandem-suggestion",
+          style:
+            "background: rgba(139, 92, 246, 0.15); text-decoration: underline wavy #8b5cf6; text-underline-offset: 3px;",
+          "data-annotation-id": ann.id,
         };
         break;
-      case 'question':
+      case "question":
         attrs = {
-          class: 'tandem-question',
-          style: 'background: rgba(99, 102, 241, 0.12); border-bottom: 2px solid #6366f1; padding-bottom: 1px;',
-          'data-annotation-id': ann.id,
+          class: "tandem-question",
+          style:
+            "background: rgba(99, 102, 241, 0.12); border-bottom: 2px solid #6366f1; padding-bottom: 1px;",
+          "data-annotation-id": ann.id,
         };
         break;
-      case 'flag':
+      case "flag":
         attrs = {
-          class: 'tandem-flag',
-          style: 'background: rgba(239, 68, 68, 0.12); border-bottom: 2px solid #ef4444; padding-bottom: 1px;',
-          'data-annotation-id': ann.id,
+          class: "tandem-flag",
+          style:
+            "background: rgba(239, 68, 68, 0.12); border-bottom: 2px solid #ef4444; padding-bottom: 1px;",
+          "data-annotation-id": ann.id,
         };
         break;
       default:
@@ -138,7 +227,7 @@ function buildDecorations(doc: PmNode, annotationsMap: Y.Map<unknown>): Decorati
  * as ProseMirror inline decorations in the editor.
  */
 export const AnnotationExtension = Extension.create<{ ydoc: Y.Doc | null }>({
-  name: 'tandemAnnotations',
+  name: "tandemAnnotations",
 
   addOptions() {
     return { ydoc: null };
@@ -148,7 +237,7 @@ export const AnnotationExtension = Extension.create<{ ydoc: Y.Doc | null }>({
     const ydoc = this.options.ydoc;
     if (!ydoc) return [];
 
-    const annotationsMap = ydoc.getMap('annotations');
+    const annotationsMap = ydoc.getMap("annotations");
 
     return [
       new Plugin({
@@ -156,12 +245,12 @@ export const AnnotationExtension = Extension.create<{ ydoc: Y.Doc | null }>({
 
         state: {
           init(_, state) {
-            return buildDecorations(state.doc, annotationsMap);
+            return buildDecorations(state.doc, annotationsMap, ydoc);
           },
           apply(tr, decorationSet, _oldState, newState) {
             // If annotations were explicitly updated, full rebuild
             if (tr.getMeta(annotationPluginKey)) {
-              return buildDecorations(newState.doc, annotationsMap);
+              return buildDecorations(newState.doc, annotationsMap, ydoc);
             }
             // If doc changed, map existing decorations forward
             if (tr.docChanged) {

--- a/src/client/panels/SidePanel.tsx
+++ b/src/client/panels/SidePanel.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import type { Editor as TiptapEditor } from '@tiptap/react';
-import * as Y from 'yjs';
-import type { Annotation, AnnotationType, InterruptionMode } from '../../shared/types';
-import { HIGHLIGHT_COLORS } from '../../shared/constants';
-import { flatOffsetToPmPos } from '../editor/extensions/annotation';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import type { Editor as TiptapEditor } from "@tiptap/react";
+import * as Y from "yjs";
+import type { Annotation, AnnotationType, InterruptionMode } from "../../shared/types";
+import { HIGHLIGHT_COLORS } from "../../shared/constants";
+import { resolveAnnotationPmRange } from "../editor/extensions/annotation";
 
 interface SidePanelProps {
   annotations: Annotation[];
@@ -19,29 +19,46 @@ interface SidePanelProps {
   onActiveAnnotationChange: (id: string | null) => void;
 }
 
-type FilterType = AnnotationType | 'all';
-type FilterAuthor = 'all' | 'claude' | 'user';
-type FilterStatus = 'all' | 'pending' | 'accepted' | 'dismissed';
+type FilterType = AnnotationType | "all";
+type FilterAuthor = "all" | "claude" | "user";
+type FilterStatus = "all" | "pending" | "accepted" | "dismissed";
 
 /** Apply a suggestion annotation's text replacement in the editor */
-function applySuggestion(ann: Annotation, editor: TiptapEditor) {
-  if (ann.type !== 'suggestion') return;
+function applySuggestion(ann: Annotation, editor: TiptapEditor, ydoc: Y.Doc | null) {
+  if (ann.type !== "suggestion") return;
   try {
     const { newText } = JSON.parse(ann.content);
-    if (typeof newText === 'string') {
-      const pmFrom = flatOffsetToPmPos(editor.state.doc, ann.range.from);
-      const pmTo = flatOffsetToPmPos(editor.state.doc, ann.range.to);
-      editor.chain().focus().deleteRange({ from: pmFrom, to: pmTo }).insertContentAt(pmFrom, newText).run();
+    if (typeof newText === "string") {
+      const resolved = resolveAnnotationPmRange(ann, editor.state.doc, ydoc);
+      if (!resolved) return;
+      editor
+        .chain()
+        .focus()
+        .deleteRange({ from: resolved.from, to: resolved.to })
+        .insertContentAt(resolved.from, newText)
+        .run();
     }
   } catch {
     // Malformed suggestion content
   }
 }
 
-export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interruptionMode: _interruptionMode, onModeChange, reviewMode, onToggleReviewMode, onExitReviewMode, activeAnnotationId: _activeAnnotationId, onActiveAnnotationChange }: SidePanelProps) {
-  const [filterType, setFilterType] = useState<FilterType>('all');
-  const [filterAuthor, setFilterAuthor] = useState<FilterAuthor>('all');
-  const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
+export function SidePanel({
+  annotations,
+  editor,
+  ydoc,
+  heldCount = 0,
+  interruptionMode: _interruptionMode,
+  onModeChange,
+  reviewMode,
+  onToggleReviewMode,
+  onExitReviewMode,
+  activeAnnotationId: _activeAnnotationId,
+  onActiveAnnotationChange,
+}: SidePanelProps) {
+  const [filterType, setFilterType] = useState<FilterType>("all");
+  const [filterAuthor, setFilterAuthor] = useState<FilterAuthor>("all");
+  const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
   const [reviewIndex, setReviewIndex] = useState(0);
   const reviewIndexRef = useRef(0);
 
@@ -57,15 +74,15 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
     const allPending: Annotation[] = [];
 
     for (const a of annotations) {
-      if (a.status === 'pending') allPending.push(a);
-      const matchType = filterType === 'all' || a.type === filterType;
-      const matchAuthor = filterAuthor === 'all' || a.author === filterAuthor;
-      const matchStatus = filterStatus === 'all' || a.status === filterStatus;
+      if (a.status === "pending") allPending.push(a);
+      const matchType = filterType === "all" || a.type === filterType;
+      const matchAuthor = filterAuthor === "all" || a.author === filterAuthor;
+      const matchStatus = filterStatus === "all" || a.status === filterStatus;
       if (matchType && matchAuthor && matchStatus) filtered.push(a);
     }
 
-    const pending = filtered.filter(a => a.status === 'pending');
-    const resolved = filtered.filter(a => a.status !== 'pending');
+    const pending = filtered.filter((a) => a.status === "pending");
+    const resolved = filtered.filter((a) => a.status !== "pending");
 
     return { filtered, pending, resolved, allPending };
   }, [annotations, filterType, filterAuthor, filterStatus]);
@@ -75,71 +92,75 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
   const reviewTargetsRef = useRef(reviewTargets);
   reviewTargetsRef.current = reviewTargets;
 
-  function resolveAnnotation(id: string, status: 'accepted' | 'dismissed') {
+  function resolveAnnotation(id: string, status: "accepted" | "dismissed") {
     const y = ydocRef.current;
     if (!y) return;
-    const map = y.getMap('annotations');
+    const map = y.getMap("annotations");
     const ann = map.get(id) as Annotation | undefined;
     if (!ann) return;
     map.set(id, { ...ann, status });
-    if (status === 'accepted' && editorRef.current) {
-      applySuggestion(ann, editorRef.current);
+    if (status === "accepted" && editorRef.current) {
+      applySuggestion(ann, editorRef.current, ydocRef.current);
     }
   }
 
   function handleAccept(id: string) {
-    resolveAnnotation(id, 'accepted');
+    resolveAnnotation(id, "accepted");
   }
 
   function handleDismiss(id: string) {
-    resolveAnnotation(id, 'dismissed');
+    resolveAnnotation(id, "dismissed");
   }
 
   function handleBulkAccept() {
-    for (const ann of allPending) resolveAnnotation(ann.id, 'accepted');
+    for (const ann of allPending) resolveAnnotation(ann.id, "accepted");
   }
 
   function handleBulkDismiss() {
-    for (const ann of allPending) resolveAnnotation(ann.id, 'dismissed');
+    for (const ann of allPending) resolveAnnotation(ann.id, "dismissed");
   }
 
   // Scroll editor to an annotation's range
   const scrollToAnnotation = useCallback((ann: Annotation) => {
     const ed = editorRef.current;
     if (!ed) return;
-    const pmFrom = flatOffsetToPmPos(ed.state.doc, ann.range.from);
-    const pmTo = flatOffsetToPmPos(ed.state.doc, ann.range.to);
-    ed.chain().focus().setTextSelection({ from: pmFrom, to: pmTo }).run();
-    const domAtPos = ed.view.domAtPos(pmFrom);
+    const resolved = resolveAnnotationPmRange(ann, ed.state.doc, ydocRef.current);
+    if (!resolved) return;
+    ed.chain().focus().setTextSelection({ from: resolved.from, to: resolved.to }).run();
+    const domAtPos = ed.view.domAtPos(resolved.from);
     const el = domAtPos.node instanceof HTMLElement ? domAtPos.node : domAtPos.node.parentElement;
-    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el?.scrollIntoView({ behavior: "smooth", block: "center" });
   }, []);
 
   // Stable keyboard review callbacks (use refs to avoid dep cascade)
-  const navigateReview = useCallback((direction: 'next' | 'prev') => {
-    const targets = reviewTargetsRef.current;
-    if (targets.length === 0) return;
-    let idx = reviewIndexRef.current;
-    idx = direction === 'next'
-      ? (idx + 1) % targets.length
-      : (idx - 1 + targets.length) % targets.length;
-    reviewIndexRef.current = idx;
-    setReviewIndex(idx);
-    scrollToAnnotation(targets[idx]);
-  }, [scrollToAnnotation]);
+  const navigateReview = useCallback(
+    (direction: "next" | "prev") => {
+      const targets = reviewTargetsRef.current;
+      if (targets.length === 0) return;
+      let idx = reviewIndexRef.current;
+      idx =
+        direction === "next"
+          ? (idx + 1) % targets.length
+          : (idx - 1 + targets.length) % targets.length;
+      reviewIndexRef.current = idx;
+      setReviewIndex(idx);
+      scrollToAnnotation(targets[idx]);
+    },
+    [scrollToAnnotation],
+  );
 
   const acceptCurrent = useCallback(() => {
     const targets = reviewTargetsRef.current;
     if (targets.length === 0) return;
     const ann = targets[reviewIndexRef.current];
-    if (ann) resolveAnnotation(ann.id, 'accepted');
+    if (ann) resolveAnnotation(ann.id, "accepted");
   }, []);
 
   const dismissCurrent = useCallback(() => {
     const targets = reviewTargetsRef.current;
     if (targets.length === 0) return;
     const ann = targets[reviewIndexRef.current];
-    if (ann) resolveAnnotation(ann.id, 'dismissed');
+    if (ann) resolveAnnotation(ann.id, "dismissed");
   }, []);
 
   // Reset review index and scroll to first annotation when entering review mode
@@ -165,7 +186,7 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
   // Keyboard shortcuts — stable deps via refs
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.ctrlKey && e.shiftKey && e.key === 'R') {
+      if (e.ctrlKey && e.shiftKey && e.key === "R") {
         e.preventDefault();
         onToggleReviewMode();
         return;
@@ -173,18 +194,18 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
 
       if (!reviewMode) return;
 
-      if (e.key === 'Tab' && !e.ctrlKey && !e.altKey) {
+      if (e.key === "Tab" && !e.ctrlKey && !e.altKey) {
         e.preventDefault();
-        navigateReview(e.shiftKey ? 'prev' : 'next');
-      } else if (e.key === 'y' || e.key === 'Y') {
+        navigateReview(e.shiftKey ? "prev" : "next");
+      } else if (e.key === "y" || e.key === "Y") {
         if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
         e.preventDefault();
         acceptCurrent();
-      } else if (e.key === 'n' || e.key === 'N') {
+      } else if (e.key === "n" || e.key === "N") {
         if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
         e.preventDefault();
         dismissCurrent();
-      } else if (e.key === 'e' || e.key === 'E') {
+      } else if (e.key === "e" || e.key === "E") {
         if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
         e.preventDefault();
         // Scroll to current annotation and exit review mode without resolving
@@ -192,14 +213,22 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
         const ann = targets[reviewIndexRef.current];
         if (ann) scrollToAnnotation(ann);
         onExitReviewMode();
-      } else if (e.key === 'Escape') {
+      } else if (e.key === "Escape") {
         onExitReviewMode();
       }
     }
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [reviewMode, navigateReview, acceptCurrent, dismissCurrent, scrollToAnnotation, onToggleReviewMode, onExitReviewMode]);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [
+    reviewMode,
+    navigateReview,
+    acceptCurrent,
+    dismissCurrent,
+    scrollToAnnotation,
+    onToggleReviewMode,
+    onExitReviewMode,
+  ]);
 
   // Keep review index in bounds when annotations change
   useEffect(() => {
@@ -217,36 +246,48 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
     }
   }, [reviewMode, reviewTargets.length, onExitReviewMode]);
 
-  const hasFilters = filterType !== 'all' || filterAuthor !== 'all' || filterStatus !== 'all';
-  const activeReviewAnn = reviewMode && reviewTargets.length > 0 ? reviewTargets[reviewIndex] : null;
+  const hasFilters = filterType !== "all" || filterAuthor !== "all" || filterStatus !== "all";
+  const activeReviewAnn =
+    reviewMode && reviewTargets.length > 0 ? reviewTargets[reviewIndex] : null;
 
   return (
-    <div style={{
-      width: '100%',
-      background: '#fafafa',
-      display: 'flex',
-      flexDirection: 'column',
-      overflowY: 'auto',
-    }}>
+    <div
+      style={{
+        width: "100%",
+        background: "#fafafa",
+        display: "flex",
+        flexDirection: "column",
+        overflowY: "auto",
+      }}
+    >
       {/* Held-annotation banner */}
       {heldCount > 0 && (
-        <div style={{
-          padding: '6px 16px',
-          background: '#fef3c7',
-          borderBottom: '1px solid #fde68a',
-          fontSize: '12px',
-          color: '#92400e',
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}>
-          <span>{heldCount} annotation{heldCount !== 1 ? 's' : ''} held</span>
+        <div
+          style={{
+            padding: "6px 16px",
+            background: "#fef3c7",
+            borderBottom: "1px solid #fde68a",
+            fontSize: "12px",
+            color: "#92400e",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <span>
+            {heldCount} annotation{heldCount !== 1 ? "s" : ""} held
+          </span>
           <button
-            onClick={() => onModeChange?.('all')}
+            onClick={() => onModeChange?.("all")}
             style={{
-              fontSize: '11px', padding: '1px 8px', border: '1px solid #fbbf24',
-              borderRadius: '4px', background: '#fff', color: '#92400e',
-              cursor: 'pointer', fontWeight: 500,
+              fontSize: "11px",
+              padding: "1px 8px",
+              border: "1px solid #fbbf24",
+              borderRadius: "4px",
+              background: "#fff",
+              color: "#92400e",
+              cursor: "pointer",
+              fontWeight: 500,
             }}
           >
             Show all
@@ -254,19 +295,21 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
         </div>
       )}
       {/* Header */}
-      <div style={{ padding: '12px 16px', borderBottom: '1px solid #e5e7eb' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <h3 style={{ fontSize: '14px', fontWeight: 600, margin: 0 }}>
+      <div style={{ padding: "12px 16px", borderBottom: "1px solid #e5e7eb" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <h3 style={{ fontSize: "14px", fontWeight: 600, margin: 0 }}>
             Annotations
             {allPending.length > 0 && (
-              <span style={{
-                marginLeft: '8px',
-                padding: '1px 6px',
-                fontSize: '11px',
-                background: '#6366f1',
-                color: 'white',
-                borderRadius: '10px',
-              }}>
+              <span
+                style={{
+                  marginLeft: "8px",
+                  padding: "1px 6px",
+                  fontSize: "11px",
+                  background: "#6366f1",
+                  color: "white",
+                  borderRadius: "10px",
+                }}
+              >
                 {allPending.length}
               </span>
             )}
@@ -276,17 +319,17 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
               onClick={onToggleReviewMode}
               title="Keyboard review mode (Ctrl+Shift+R)"
               style={{
-                padding: '2px 8px',
-                fontSize: '11px',
-                border: `1px solid ${reviewMode ? '#6366f1' : '#d1d5db'}`,
-                borderRadius: '3px',
-                background: reviewMode ? '#eef2ff' : '#fff',
-                color: reviewMode ? '#6366f1' : '#6b7280',
-                cursor: 'pointer',
+                padding: "2px 8px",
+                fontSize: "11px",
+                border: `1px solid ${reviewMode ? "#6366f1" : "#d1d5db"}`,
+                borderRadius: "3px",
+                background: reviewMode ? "#eef2ff" : "#fff",
+                color: reviewMode ? "#6366f1" : "#6b7280",
+                cursor: "pointer",
                 fontWeight: reviewMode ? 600 : 400,
               }}
             >
-              {reviewMode ? 'Exit Review' : 'Review'}
+              {reviewMode ? "Exit Review" : "Review"}
             </button>
           )}
         </div>
@@ -294,68 +337,80 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
 
       {/* Review mode indicator */}
       {reviewMode && reviewTargets.length > 0 && (
-        <div style={{
-          padding: '8px 16px',
-          background: '#eef2ff',
-          borderBottom: '1px solid #e5e7eb',
-          fontSize: '12px',
-          color: '#4338ca',
-        }}>
-          <div style={{ fontWeight: 600, marginBottom: '2px' }}>
+        <div
+          style={{
+            padding: "8px 16px",
+            background: "#eef2ff",
+            borderBottom: "1px solid #e5e7eb",
+            fontSize: "12px",
+            color: "#4338ca",
+          }}
+        >
+          <div style={{ fontWeight: 600, marginBottom: "2px" }}>
             Reviewing {reviewIndex + 1} / {reviewTargets.length}
           </div>
-          <div style={{ color: '#6366f1' }}>
+          <div style={{ color: "#6366f1" }}>
             Tab: next · Shift+Tab: prev · Y: accept · N: dismiss · E: examine · Esc: exit
           </div>
         </div>
       )}
 
       {/* Filters */}
-      <div style={{
-        padding: '8px 16px',
-        borderBottom: '1px solid #e5e7eb',
-        display: 'flex',
-        gap: '4px',
-        flexWrap: 'wrap',
-        alignItems: 'center',
-      }}>
+      <div
+        style={{
+          padding: "8px 16px",
+          borderBottom: "1px solid #e5e7eb",
+          display: "flex",
+          gap: "4px",
+          flexWrap: "wrap",
+          alignItems: "center",
+        }}
+      >
         <FilterSelect
           value={filterType}
-          onChange={v => setFilterType(v as FilterType)}
+          onChange={(v) => setFilterType(v as FilterType)}
           options={[
-            { value: 'all', label: 'All types' },
-            { value: 'highlight', label: 'Highlights' },
-            { value: 'comment', label: 'Comments' },
-            { value: 'suggestion', label: 'Suggestions' },
-            { value: 'question', label: 'Questions' },
-            { value: 'flag', label: 'Flags' },
+            { value: "all", label: "All types" },
+            { value: "highlight", label: "Highlights" },
+            { value: "comment", label: "Comments" },
+            { value: "suggestion", label: "Suggestions" },
+            { value: "question", label: "Questions" },
+            { value: "flag", label: "Flags" },
           ]}
         />
         <FilterSelect
           value={filterAuthor}
-          onChange={v => setFilterAuthor(v as FilterAuthor)}
+          onChange={(v) => setFilterAuthor(v as FilterAuthor)}
           options={[
-            { value: 'all', label: 'Anyone' },
-            { value: 'claude', label: 'Claude' },
-            { value: 'user', label: 'You' },
+            { value: "all", label: "Anyone" },
+            { value: "claude", label: "Claude" },
+            { value: "user", label: "You" },
           ]}
         />
         <FilterSelect
           value={filterStatus}
-          onChange={v => setFilterStatus(v as FilterStatus)}
+          onChange={(v) => setFilterStatus(v as FilterStatus)}
           options={[
-            { value: 'all', label: 'Any status' },
-            { value: 'pending', label: 'Pending' },
-            { value: 'accepted', label: 'Accepted' },
-            { value: 'dismissed', label: 'Dismissed' },
+            { value: "all", label: "Any status" },
+            { value: "pending", label: "Pending" },
+            { value: "accepted", label: "Accepted" },
+            { value: "dismissed", label: "Dismissed" },
           ]}
         />
         {hasFilters && (
           <button
-            onClick={() => { setFilterType('all'); setFilterAuthor('all'); setFilterStatus('all'); }}
+            onClick={() => {
+              setFilterType("all");
+              setFilterAuthor("all");
+              setFilterStatus("all");
+            }}
             style={{
-              background: 'none', border: 'none', color: '#6366f1',
-              fontSize: '11px', cursor: 'pointer', padding: '2px 4px',
+              background: "none",
+              border: "none",
+              color: "#6366f1",
+              fontSize: "11px",
+              cursor: "pointer",
+              padding: "2px 4px",
             }}
           >
             Clear
@@ -365,17 +420,24 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
 
       {/* Bulk actions */}
       {allPending.length > 1 && (
-        <div style={{
-          padding: '6px 16px',
-          borderBottom: '1px solid #e5e7eb',
-          display: 'flex',
-          gap: '6px',
-        }}>
+        <div
+          style={{
+            padding: "6px 16px",
+            borderBottom: "1px solid #e5e7eb",
+            display: "flex",
+            gap: "6px",
+          }}
+        >
           <button
             onClick={handleBulkAccept}
             style={{
-              padding: '2px 8px', fontSize: '11px', border: '1px solid #d1d5db',
-              borderRadius: '3px', background: '#f0fdf4', color: '#166534', cursor: 'pointer',
+              padding: "2px 8px",
+              fontSize: "11px",
+              border: "1px solid #d1d5db",
+              borderRadius: "3px",
+              background: "#f0fdf4",
+              color: "#166534",
+              cursor: "pointer",
             }}
           >
             Accept All ({allPending.length})
@@ -383,8 +445,13 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
           <button
             onClick={handleBulkDismiss}
             style={{
-              padding: '2px 8px', fontSize: '11px', border: '1px solid #d1d5db',
-              borderRadius: '3px', background: '#fef2f2', color: '#991b1b', cursor: 'pointer',
+              padding: "2px 8px",
+              fontSize: "11px",
+              border: "1px solid #d1d5db",
+              borderRadius: "3px",
+              background: "#fef2f2",
+              color: "#991b1b",
+              cursor: "pointer",
             }}
           >
             Dismiss All
@@ -393,14 +460,16 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
       )}
 
       {/* Annotation list */}
-      <div style={{ padding: '8px 16px', flex: 1 }}>
+      <div style={{ padding: "8px 16px", flex: 1 }}>
         {filtered.length === 0 ? (
-          <p style={{ fontSize: '13px', color: '#9ca3af', marginTop: '8px' }}>
-            {hasFilters ? 'No annotations match filters.' : 'No annotations yet. Open a document to get started.'}
+          <p style={{ fontSize: "13px", color: "#9ca3af", marginTop: "8px" }}>
+            {hasFilters
+              ? "No annotations match filters."
+              : "No annotations yet. Open a document to get started."}
           </p>
         ) : (
           <>
-            {pending.map(ann => (
+            {pending.map((ann) => (
               <AnnotationCard
                 key={ann.id}
                 annotation={ann}
@@ -411,11 +480,11 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
               />
             ))}
             {resolved.length > 0 && (
-              <details style={{ marginTop: '12px' }}>
-                <summary style={{ fontSize: '12px', color: '#9ca3af', cursor: 'pointer' }}>
+              <details style={{ marginTop: "12px" }}>
+                <summary style={{ fontSize: "12px", color: "#9ca3af", cursor: "pointer" }}>
                   {resolved.length} resolved
                 </summary>
-                {resolved.map(ann => (
+                {resolved.map((ann) => (
                   <AnnotationCard
                     key={ann.id}
                     annotation={ann}
@@ -431,7 +500,11 @@ export function SidePanel({ annotations, editor, ydoc, heldCount = 0, interrupti
   );
 }
 
-function FilterSelect({ value, onChange, options }: {
+function FilterSelect({
+  value,
+  onChange,
+  options,
+}: {
   value: string;
   onChange: (v: string) => void;
   options: Array<{ value: string; label: string }>;
@@ -439,19 +512,21 @@ function FilterSelect({ value, onChange, options }: {
   return (
     <select
       value={value}
-      onChange={e => onChange(e.target.value)}
+      onChange={(e) => onChange(e.target.value)}
       style={{
-        padding: '2px 4px',
-        fontSize: '11px',
-        border: '1px solid #e5e7eb',
-        borderRadius: '3px',
-        background: '#fff',
-        color: '#374151',
-        cursor: 'pointer',
+        padding: "2px 4px",
+        fontSize: "11px",
+        border: "1px solid #e5e7eb",
+        borderRadius: "3px",
+        background: "#fff",
+        color: "#374151",
+        cursor: "pointer",
       }}
     >
-      {options.map(o => (
-        <option key={o.value} value={o.value}>{o.label}</option>
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
       ))}
     </select>
   );
@@ -466,60 +541,68 @@ interface AnnotationCardProps {
 }
 
 const ANNOTATION_BORDER_COLORS: Record<string, string> = {
-  comment: '#3b82f6',
-  suggestion: '#8b5cf6',
-  question: '#6366f1',
-  flag: '#ef4444',
+  comment: "#3b82f6",
+  suggestion: "#8b5cf6",
+  question: "#6366f1",
+  flag: "#ef4444",
 };
 
 function getBorderColor(annotation: Annotation): string {
   if (annotation.color) {
-    return HIGHLIGHT_COLORS[annotation.color] || '#e5e7eb';
+    return HIGHLIGHT_COLORS[annotation.color] || "#e5e7eb";
   }
-  return ANNOTATION_BORDER_COLORS[annotation.type] || '#e5e7eb';
+  return ANNOTATION_BORDER_COLORS[annotation.type] || "#e5e7eb";
 }
 
-function AnnotationCard({ annotation, isReviewTarget, onAccept, onDismiss, onClick }: AnnotationCardProps) {
+function AnnotationCard({
+  annotation,
+  isReviewTarget,
+  onAccept,
+  onDismiss,
+  onClick,
+}: AnnotationCardProps) {
   const borderColor = getBorderColor(annotation);
 
-  const isPending = annotation.status === 'pending';
+  const isPending = annotation.status === "pending";
 
   return (
     <div
       onClick={onClick}
       style={{
-        padding: '8px 10px',
-        marginBottom: '6px',
+        padding: "8px 10px",
+        marginBottom: "6px",
         borderLeft: `3px solid ${borderColor}`,
-        background: isReviewTarget ? '#eef2ff' : 'white',
-        borderRadius: '0 4px 4px 0',
-        fontSize: '13px',
+        background: isReviewTarget ? "#eef2ff" : "white",
+        borderRadius: "0 4px 4px 0",
+        fontSize: "13px",
         opacity: isPending ? 1 : 0.6,
-        cursor: onClick ? 'pointer' : 'default',
-        outline: isReviewTarget ? '2px solid #6366f1' : 'none',
-        transition: 'background 0.15s, outline 0.15s',
+        cursor: onClick ? "pointer" : "default",
+        outline: isReviewTarget ? "2px solid #6366f1" : "none",
+        transition: "background 0.15s, outline 0.15s",
       }}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
-        <span style={{ fontWeight: 500, textTransform: 'capitalize' }}>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "4px" }}>
+        <span style={{ fontWeight: 500, textTransform: "capitalize" }}>
           {annotation.type}
           {!isPending && (
-            <span style={{
-              marginLeft: '6px',
-              fontSize: '10px',
-              color: annotation.status === 'accepted' ? '#16a34a' : '#dc2626',
-              fontWeight: 600,
-            }}>
+            <span
+              style={{
+                marginLeft: "6px",
+                fontSize: "10px",
+                color: annotation.status === "accepted" ? "#16a34a" : "#dc2626",
+                fontWeight: 600,
+              }}
+            >
               {annotation.status}
             </span>
           )}
         </span>
-        <span style={{ fontSize: '11px', color: '#9ca3af' }}>
-          {annotation.author === 'claude' ? 'Claude' : 'You'}
+        <span style={{ fontSize: "11px", color: "#9ca3af" }}>
+          {annotation.author === "claude" ? "Claude" : "You"}
         </span>
       </div>
-      <p style={{ margin: 0, color: '#4b5563', lineHeight: '1.4' }}>
-        {annotation.type === 'suggestion'
+      <p style={{ margin: 0, color: "#4b5563", lineHeight: "1.4" }}>
+        {annotation.type === "suggestion"
           ? (() => {
               try {
                 const parsed = JSON.parse(annotation.content);
@@ -528,16 +611,24 @@ function AnnotationCard({ annotation, isReviewTarget, onAccept, onDismiss, onCli
                 return annotation.content;
               }
             })()
-          : annotation.content || '(no note)'}
+          : annotation.content || "(no note)"}
       </p>
       {isPending && (onAccept || onDismiss) && (
-        <div style={{ display: 'flex', gap: '6px', marginTop: '6px' }}>
+        <div style={{ display: "flex", gap: "6px", marginTop: "6px" }}>
           {onAccept && (
             <button
-              onClick={(e) => { e.stopPropagation(); onAccept(annotation.id); }}
+              onClick={(e) => {
+                e.stopPropagation();
+                onAccept(annotation.id);
+              }}
               style={{
-                padding: '2px 8px', fontSize: '11px', border: '1px solid #d1d5db',
-                borderRadius: '3px', background: '#f0fdf4', color: '#166534', cursor: 'pointer',
+                padding: "2px 8px",
+                fontSize: "11px",
+                border: "1px solid #d1d5db",
+                borderRadius: "3px",
+                background: "#f0fdf4",
+                color: "#166534",
+                cursor: "pointer",
               }}
             >
               Accept
@@ -545,10 +636,18 @@ function AnnotationCard({ annotation, isReviewTarget, onAccept, onDismiss, onCli
           )}
           {onDismiss && (
             <button
-              onClick={(e) => { e.stopPropagation(); onDismiss(annotation.id); }}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDismiss(annotation.id);
+              }}
               style={{
-                padding: '2px 8px', fontSize: '11px', border: '1px solid #d1d5db',
-                borderRadius: '3px', background: '#fef2f2', color: '#991b1b', cursor: 'pointer',
+                padding: "2px 8px",
+                fontSize: "11px",
+                border: "1px solid #d1d5db",
+                borderRadius: "3px",
+                background: "#fef2f2",
+                color: "#991b1b",
+                cursor: "pointer",
               }}
             >
               Dismiss

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -1,22 +1,33 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
-import { getOrCreateDocument } from '../yjs/provider.js';
-import { getCurrentDoc, extractText, verifyAndResolveRange } from './document.js';
-import { mcpSuccess, mcpError, noDocumentError } from './response.js';
-import { exportAnnotations } from '../file-io/docx.js';
-import * as Y from 'yjs';
-import type { Annotation, AnnotationType, HighlightColor } from '../../shared/types.js';
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getOrCreateDocument } from "../yjs/provider.js";
 import {
-  AnnotationTypeSchema, AnnotationStatusSchema, AnnotationPrioritySchema,
-  HighlightColorSchema, AuthorSchema, AnnotationActionSchema, ExportFormatSchema,
-} from '../../shared/types.js';
+  getCurrentDoc,
+  extractText,
+  verifyAndResolveRange,
+  flatOffsetToRelPos,
+  relPosToFlatOffset,
+} from "./document.js";
+import { mcpSuccess, mcpError, noDocumentError } from "./response.js";
+import { exportAnnotations } from "../file-io/docx.js";
+import * as Y from "yjs";
+import type { Annotation, AnnotationType, HighlightColor } from "../../shared/types.js";
+import {
+  AnnotationTypeSchema,
+  AnnotationStatusSchema,
+  AnnotationPrioritySchema,
+  HighlightColorSchema,
+  AuthorSchema,
+  AnnotationActionSchema,
+  ExportFormatSchema,
+} from "../../shared/types.js";
 
 /** Get the Y.Doc and annotations Y.Map for a document, or null if no doc is open */
 function getDocAndAnnotations(documentId?: string): { ydoc: Y.Doc; map: Y.Map<unknown> } | null {
   const doc = getCurrentDoc(documentId);
   if (!doc) return null;
   const ydoc = getOrCreateDocument(doc.docName);
-  return { ydoc, map: ydoc.getMap('annotations') };
+  return { ydoc, map: ydoc.getMap("annotations") };
 }
 
 /** Check textSnapshot against the document range. Returns an error response if stale, or null if valid. */
@@ -25,15 +36,15 @@ function checkRangeStale(ydoc: Y.Doc, from: number, to: number, textSnapshot: st
   const result = verifyAndResolveRange(ydoc, from, to, textSnapshot);
   if (result.valid) return null;
   if (result.gone) {
-    return mcpError('RANGE_STALE', 'Target text no longer exists in the document.');
+    return mcpError("RANGE_STALE", "Target text no longer exists in the document.");
   }
-  return mcpError('RANGE_STALE', 'Target text has moved. Use resolvedFrom/resolvedTo to retry.', {
+  return mcpError("RANGE_STALE", "Target text has moved. Use resolvedFrom/resolvedTo to retry.", {
     resolvedFrom: result.resolvedFrom,
     resolvedTo: result.resolvedTo,
   });
 }
 
-import { generateAnnotationId as generateId } from '../../shared/utils.js';
+import { generateAnnotationId as generateId } from "../../shared/utils.js";
 export { generateId };
 
 /** Create an annotation and store it in the Y.Map. Returns the annotation ID. */
@@ -44,15 +55,28 @@ export function createAnnotation(
   to: number,
   content: string,
   extras?: Partial<Annotation>,
+  ydoc?: Y.Doc,
 ): string {
   const id = generateId();
+
+  // Compute CRDT-anchored positions when Y.Doc is available
+  let relRange: Annotation["relRange"];
+  if (ydoc) {
+    const fromRel = flatOffsetToRelPos(ydoc, from, 0); // assoc 0: stick right
+    const toRel = flatOffsetToRelPos(ydoc, to, -1); // assoc -1: stick left
+    if (fromRel && toRel) {
+      relRange = { fromRel, toRel };
+    }
+  }
+
   const annotation: Annotation = {
     id,
-    author: 'claude',
+    author: "claude",
     type,
     range: { from, to },
+    ...(relRange ? { relRange } : {}),
     content,
-    status: 'pending',
+    status: "pending",
     timestamp: Date.now(),
     ...extras,
   };
@@ -67,167 +91,296 @@ export function collectAnnotations(map: Y.Map<unknown>): Annotation[] {
   return result;
 }
 
+/**
+ * Refresh an annotation's flat offsets from its relRange, or lazily attach
+ * relRange if missing. Returns the (possibly updated) annotation.
+ * If `map` is provided, persists changes back to the Y.Map.
+ */
+export function refreshRange(ann: Annotation, ydoc: Y.Doc, map?: Y.Map<unknown>): Annotation {
+  if (!ann.relRange) {
+    // Lazy attachment: compute relRange from current flat offsets
+    const fromRel = flatOffsetToRelPos(ydoc, ann.range.from, 0);
+    const toRel = flatOffsetToRelPos(ydoc, ann.range.to, -1);
+    if (!fromRel || !toRel) return ann;
+    const updated = { ...ann, relRange: { fromRel, toRel } };
+    if (map) map.set(ann.id, updated);
+    return updated;
+  }
+
+  // Resolve relRange to current flat offsets
+  const newFrom = relPosToFlatOffset(ydoc, ann.relRange.fromRel);
+  const newTo = relPosToFlatOffset(ydoc, ann.relRange.toRel);
+  if (newFrom === null || newTo === null) return ann; // deleted content, keep old range
+  if (newFrom === ann.range.from && newTo === ann.range.to) return ann; // unchanged
+
+  const updated = { ...ann, range: { from: newFrom, to: newTo } };
+  if (map) map.set(ann.id, updated);
+  return updated;
+}
+
+/** Refresh all annotations in a batch, wrapping Y.Map writes in a transaction. */
+function refreshAllRanges(
+  annotations: Annotation[],
+  ydoc: Y.Doc,
+  map: Y.Map<unknown>,
+): Annotation[] {
+  const results: Annotation[] = [];
+  ydoc.transact(() => {
+    for (const ann of annotations) {
+      results.push(refreshRange(ann, ydoc, map));
+    }
+  });
+  return results;
+}
+
 export function registerAnnotationTools(server: McpServer): void {
   server.tool(
-    'tandem_highlight',
-    'Highlight text with a color and optional note',
+    "tandem_highlight",
+    "Highlight text with a color and optional note",
     {
-      from: z.number().describe('Start position'),
-      to: z.number().describe('End position'),
-      color: HighlightColorSchema.describe('Highlight color'),
-      note: z.string().optional().describe('Optional note for the highlight'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
-      priority: AnnotationPrioritySchema.optional().describe('Annotation priority — urgent bypasses the Hold interruption mode'),
-      textSnapshot: z.string().optional().describe('Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch'),
+      from: z.number().describe("Start position"),
+      to: z.number().describe("End position"),
+      color: HighlightColorSchema.describe("Highlight color"),
+      note: z.string().optional().describe("Optional note for the highlight"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
+      priority: AnnotationPrioritySchema.optional().describe(
+        "Annotation priority — urgent bypasses the Hold interruption mode",
+      ),
+      textSnapshot: z
+        .string()
+        .optional()
+        .describe(
+          "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
+        ),
     },
     async ({ from, to, color, note, documentId, priority, textSnapshot }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
       const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
       if (staleError) return staleError;
-      const id = createAnnotation(da.map, 'highlight', from, to, note || '', { color: color as HighlightColor, ...(priority ? { priority } : {}) });
+      const id = createAnnotation(
+        da.map,
+        "highlight",
+        from,
+        to,
+        note || "",
+        { color: color as HighlightColor, ...(priority ? { priority } : {}) },
+        da.ydoc,
+      );
       return mcpSuccess({ annotationId: id });
-    }
+    },
   );
 
   server.tool(
-    'tandem_comment',
-    'Add a comment to a text range',
+    "tandem_comment",
+    "Add a comment to a text range",
     {
-      from: z.number().describe('Start position'),
-      to: z.number().describe('End position'),
-      text: z.string().describe('Comment text'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
-      priority: AnnotationPrioritySchema.optional().describe('Annotation priority — urgent bypasses the Hold interruption mode'),
-      textSnapshot: z.string().optional().describe('Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch'),
+      from: z.number().describe("Start position"),
+      to: z.number().describe("End position"),
+      text: z.string().describe("Comment text"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
+      priority: AnnotationPrioritySchema.optional().describe(
+        "Annotation priority — urgent bypasses the Hold interruption mode",
+      ),
+      textSnapshot: z
+        .string()
+        .optional()
+        .describe(
+          "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
+        ),
     },
     async ({ from, to, text, documentId, priority, textSnapshot }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
       const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
       if (staleError) return staleError;
-      const id = createAnnotation(da.map, 'comment', from, to, text, priority ? { priority } : {});
+      const id = createAnnotation(
+        da.map,
+        "comment",
+        from,
+        to,
+        text,
+        priority ? { priority } : {},
+        da.ydoc,
+      );
       return mcpSuccess({ annotationId: id });
-    }
+    },
   );
 
   server.tool(
-    'tandem_suggest',
-    'Propose a text replacement (tracked change style)',
+    "tandem_suggest",
+    "Propose a text replacement (tracked change style)",
     {
-      from: z.number().describe('Start position'),
-      to: z.number().describe('End position'),
-      newText: z.string().describe('Suggested replacement text'),
-      reason: z.string().optional().describe('Reason for the suggestion'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
-      priority: AnnotationPrioritySchema.optional().describe('Annotation priority — urgent bypasses the Hold interruption mode'),
-      textSnapshot: z.string().optional().describe('Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch'),
+      from: z.number().describe("Start position"),
+      to: z.number().describe("End position"),
+      newText: z.string().describe("Suggested replacement text"),
+      reason: z.string().optional().describe("Reason for the suggestion"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
+      priority: AnnotationPrioritySchema.optional().describe(
+        "Annotation priority — urgent bypasses the Hold interruption mode",
+      ),
+      textSnapshot: z
+        .string()
+        .optional()
+        .describe(
+          "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
+        ),
     },
     async ({ from, to, newText, reason, documentId, priority, textSnapshot }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
       const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
       if (staleError) return staleError;
-      const id = createAnnotation(da.map, 'suggestion', from, to, JSON.stringify({ newText, reason: reason || '' }), priority ? { priority } : {});
+      const id = createAnnotation(
+        da.map,
+        "suggestion",
+        from,
+        to,
+        JSON.stringify({ newText, reason: reason || "" }),
+        priority ? { priority } : {},
+        da.ydoc,
+      );
       return mcpSuccess({ annotationId: id });
-    }
+    },
   );
 
   server.tool(
-    'tandem_flag',
-    'Flag a text range for attention (e.g., issues, concerns, or items needing review)',
+    "tandem_flag",
+    "Flag a text range for attention (e.g., issues, concerns, or items needing review)",
     {
-      from: z.number().describe('Start position'),
-      to: z.number().describe('End position'),
-      note: z.string().optional().describe('Reason for flagging'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
-      priority: AnnotationPrioritySchema.optional().describe('Annotation priority — urgent bypasses the Hold interruption mode'),
-      textSnapshot: z.string().optional().describe('Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch'),
+      from: z.number().describe("Start position"),
+      to: z.number().describe("End position"),
+      note: z.string().optional().describe("Reason for flagging"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
+      priority: AnnotationPrioritySchema.optional().describe(
+        "Annotation priority — urgent bypasses the Hold interruption mode",
+      ),
+      textSnapshot: z
+        .string()
+        .optional()
+        .describe(
+          "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
+        ),
     },
     async ({ from, to, note, documentId, priority, textSnapshot }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
       const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
       if (staleError) return staleError;
-      const id = createAnnotation(da.map, 'flag', from, to, note || '', priority ? { priority } : {});
+      const id = createAnnotation(
+        da.map,
+        "flag",
+        from,
+        to,
+        note || "",
+        priority ? { priority } : {},
+        da.ydoc,
+      );
       return mcpSuccess({ annotationId: id });
-    }
+    },
   );
 
   server.tool(
-    'tandem_getAnnotations',
-    'Read all annotations, optionally filtered by author/type/status. For checking new user actions, prefer tandem_checkInbox.',
+    "tandem_getAnnotations",
+    "Read all annotations, optionally filtered by author/type/status. For checking new user actions, prefer tandem_checkInbox.",
     {
-      author: AuthorSchema.optional().describe('Filter by author'),
-      type: AnnotationTypeSchema.optional().describe('Filter by type'),
-      status: AnnotationStatusSchema.optional().describe('Filter by status'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      author: AuthorSchema.optional().describe("Filter by author"),
+      type: AnnotationTypeSchema.optional().describe("Filter by type"),
+      status: AnnotationStatusSchema.optional().describe("Filter by status"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ author, type, status, documentId }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
 
-      let results = collectAnnotations(da.map);
-      if (author) results = results.filter(a => a.author === author);
-      if (type) results = results.filter(a => a.type === type);
-      if (status) results = results.filter(a => a.status === status);
+      let results = refreshAllRanges(collectAnnotations(da.map), da.ydoc, da.map);
+      if (author) results = results.filter((a) => a.author === author);
+      if (type) results = results.filter((a) => a.type === type);
+      if (status) results = results.filter((a) => a.status === status);
 
       return mcpSuccess({ annotations: results, count: results.length });
-    }
+    },
   );
 
   server.tool(
-    'tandem_resolveAnnotation',
-    'Accept or dismiss an annotation',
+    "tandem_resolveAnnotation",
+    "Accept or dismiss an annotation",
     {
-      id: z.string().describe('Annotation ID'),
-      action: AnnotationActionSchema.describe('Action to take'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      id: z.string().describe("Annotation ID"),
+      action: AnnotationActionSchema.describe("Action to take"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ id, action, documentId }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
 
       const ann = da.map.get(id) as Annotation | undefined;
-      if (!ann) return mcpError('INVALID_RANGE', `Annotation ${id} not found`);
+      if (!ann) return mcpError("INVALID_RANGE", `Annotation ${id} not found`);
 
-      const updated = { ...ann, status: action === 'accept' ? 'accepted' as const : 'dismissed' as const };
+      const updated = {
+        ...ann,
+        status: action === "accept" ? ("accepted" as const) : ("dismissed" as const),
+      };
       da.map.set(id, updated);
       return mcpSuccess({ id, status: updated.status });
-    }
+    },
   );
 
   server.tool(
-    'tandem_removeAnnotation',
-    'Remove an annotation entirely',
+    "tandem_removeAnnotation",
+    "Remove an annotation entirely",
     {
-      id: z.string().describe('Annotation ID'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      id: z.string().describe("Annotation ID"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ id, documentId }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
-      if (!da.map.has(id)) return mcpError('INVALID_RANGE', `Annotation ${id} not found`);
+      if (!da.map.has(id)) return mcpError("INVALID_RANGE", `Annotation ${id} not found`);
       da.map.delete(id);
       return mcpSuccess({ removed: true, id });
-    }
+    },
   );
 
   server.tool(
-    'tandem_exportAnnotations',
-    'Export all annotations as a formatted summary. Useful for review reports, especially on read-only .docx files.',
+    "tandem_exportAnnotations",
+    "Export all annotations as a formatted summary. Useful for review reports, especially on read-only .docx files.",
     {
-      format: ExportFormatSchema.optional().describe('Output format (default: markdown)'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      format: ExportFormatSchema.optional().describe("Output format (default: markdown)"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ format, documentId }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
 
-      const annotations = collectAnnotations(da.map);
+      const annotations = refreshAllRanges(collectAnnotations(da.map), da.ydoc, da.map);
       const { ydoc } = da;
 
-      if (format === 'json') {
+      if (format === "json") {
         const fullText = extractText(ydoc);
         const enriched = annotations.map((ann) => ({
           ...ann,
@@ -241,6 +394,6 @@ export function registerAnnotationTools(server: McpServer): void {
 
       const markdown = exportAnnotations(ydoc, annotations);
       return mcpSuccess({ markdown, count: annotations.length });
-    }
+    },
   );
 }

--- a/src/server/mcp/awareness.ts
+++ b/src/server/mcp/awareness.ts
@@ -1,11 +1,11 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
-import { getOrCreateDocument } from '../yjs/provider.js';
-import { getCurrentDoc, extractText } from './document.js';
-import { collectAnnotations } from './annotations.js';
-import { mcpSuccess, noDocumentError } from './response.js';
-import type { Annotation, ChatMessage } from '../../shared/types.js';
-import { generateMessageId } from '../../shared/utils.js';
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getOrCreateDocument } from "../yjs/provider.js";
+import { getCurrentDoc, extractText } from "./document.js";
+import { collectAnnotations, refreshRange } from "./annotations.js";
+import { mcpSuccess, noDocumentError } from "./response.js";
+import type { Annotation, ChatMessage } from "../../shared/types.js";
+import { generateMessageId } from "../../shared/utils.js";
 
 // Track which annotation IDs have been surfaced to Claude via checkInbox
 const surfacedIds = new Set<string>();
@@ -17,54 +17,69 @@ export function resetInbox(): void {
 
 export function registerAwarenessTools(server: McpServer): void {
   server.tool(
-    'tandem_getSelections',
-    'Get text currently selected by the user in the editor',
+    "tandem_getSelections",
+    "Get text currently selected by the user in the editor",
     {
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ documentId }) => {
       const current = getCurrentDoc(documentId);
       if (!current) return noDocumentError();
 
       const doc = getOrCreateDocument(current.docName);
-      const userAwareness = doc.getMap('userAwareness');
-      const selection = userAwareness.get('selection') as { from: number; to: number; timestamp: number } | undefined;
+      const userAwareness = doc.getMap("userAwareness");
+      const selection = userAwareness.get("selection") as
+        | { from: number; to: number; timestamp: number }
+        | undefined;
 
       if (!selection || selection.from === selection.to) {
-        return mcpSuccess({ selections: [], message: 'No text selected' });
+        return mcpSuccess({ selections: [], message: "No text selected" });
       }
 
       return mcpSuccess({
         selections: [{ from: selection.from, to: selection.to }],
         timestamp: selection.timestamp,
       });
-    }
+    },
   );
 
   server.tool(
-    'tandem_getActivity',
-    'Check if the user is actively editing and where their cursor is',
+    "tandem_getActivity",
+    "Check if the user is actively editing and where their cursor is",
     {
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ documentId }) => {
       const current = getCurrentDoc(documentId);
       if (!current) return noDocumentError();
 
       const doc = getOrCreateDocument(current.docName);
-      const userAwareness = doc.getMap('userAwareness');
-      const activity = userAwareness.get('activity') as {
-        isTyping: boolean;
-        cursor: number;
-        lastEdit: number;
-      } | undefined;
+      const userAwareness = doc.getMap("userAwareness");
+      const activity = userAwareness.get("activity") as
+        | {
+            isTyping: boolean;
+            cursor: number;
+            lastEdit: number;
+          }
+        | undefined;
 
       if (!activity) {
-        return mcpSuccess({ active: false, cursor: null, lastEdit: null, message: 'No activity detected' });
+        return mcpSuccess({
+          active: false,
+          cursor: null,
+          lastEdit: null,
+          message: "No activity detected",
+        });
       }
 
       // Consider user active if last edit was within 10 seconds
-      const isActive = activity.isTyping || (Date.now() - activity.lastEdit < 10000);
+      const isActive = activity.isTyping || Date.now() - activity.lastEdit < 10000;
 
       return mcpSuccess({
         active: isActive,
@@ -72,21 +87,24 @@ export function registerAwarenessTools(server: McpServer): void {
         cursor: activity.cursor,
         lastEdit: activity.lastEdit,
       });
-    }
+    },
   );
 
   server.tool(
-    'tandem_checkInbox',
-    'Check for user actions you haven\'t seen yet — new highlights, comments, questions, flags, and responses to your annotations. Call this after completing any task, between steps, and whenever you pause. Low token cost.',
+    "tandem_checkInbox",
+    "Check for user actions you haven't seen yet — new highlights, comments, questions, flags, and responses to your annotations. Call this after completing any task, between steps, and whenever you pause. Low token cost.",
     {
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ documentId }) => {
       const current = getCurrentDoc(documentId);
       if (!current) return noDocumentError();
 
       const doc = getOrCreateDocument(current.docName);
-      const annotationsMap = doc.getMap('annotations');
+      const annotationsMap = doc.getMap("annotations");
       const allAnnotations = collectAnnotations(annotationsMap);
       const fullText = extractText(doc);
 
@@ -95,28 +113,35 @@ export function registerAwarenessTools(server: McpServer): void {
       // Bucket 2: user responses to Claude's annotations (accepted/dismissed)
       const userResponses: Array<Annotation & { textSnippet: string }> = [];
 
-      for (const ann of allAnnotations) {
-        if (surfacedIds.has(ann.id)) continue;
+      // Refresh only unsurfaced annotations; batch Y.Map writes
+      const unsurfaced: Annotation[] = [];
+      doc.transact(() => {
+        for (const raw of allAnnotations) {
+          if (surfacedIds.has(raw.id)) continue;
+          unsurfaced.push(refreshRange(raw, doc, annotationsMap));
+        }
+      });
 
+      for (const ann of unsurfaced) {
         const snippet = safeSlice(fullText, ann.range.from, ann.range.to);
 
-        if (ann.author === 'user') {
+        if (ann.author === "user") {
           userActions.push({ ...ann, textSnippet: snippet });
           surfacedIds.add(ann.id);
-        } else if (ann.author === 'claude' && ann.status !== 'pending') {
+        } else if (ann.author === "claude" && ann.status !== "pending") {
           userResponses.push({ ...ann, textSnippet: snippet });
           surfacedIds.add(ann.id);
         }
       }
 
       // Bucket 3: unread chat messages from __tandem_ctrl__
-      const ctrlDoc = getOrCreateDocument('__tandem_ctrl__');
-      const chatMap = ctrlDoc.getMap('chat');
-      const chatMessages: Array<Omit<ChatMessage, 'read' | 'author'>> = [];
+      const ctrlDoc = getOrCreateDocument("__tandem_ctrl__");
+      const chatMap = ctrlDoc.getMap("chat");
+      const chatMessages: Array<Omit<ChatMessage, "read" | "author">> = [];
 
       chatMap.forEach((value) => {
         const msg = value as ChatMessage;
-        if (msg.author === 'user' && !msg.read) {
+        if (msg.author === "user" && !msg.read) {
           chatMessages.push({
             id: msg.id,
             text: msg.text,
@@ -131,13 +156,17 @@ export function registerAwarenessTools(server: McpServer): void {
       });
 
       // Current user activity
-      const userAwareness = doc.getMap('userAwareness');
-      const selection = userAwareness.get('selection') as { from: number; to: number; timestamp: number } | undefined;
-      const activity = userAwareness.get('activity') as {
-        isTyping: boolean;
-        cursor: number;
-        lastEdit: number;
-      } | undefined;
+      const userAwareness = doc.getMap("userAwareness");
+      const selection = userAwareness.get("selection") as
+        | { from: number; to: number; timestamp: number }
+        | undefined;
+      const activity = userAwareness.get("activity") as
+        | {
+            isTyping: boolean;
+            cursor: number;
+            lastEdit: number;
+          }
+        | undefined;
 
       const hasSelection = selection && selection.from !== selection.to;
       const selectedText = hasSelection
@@ -152,8 +181,8 @@ export function registerAwarenessTools(server: McpServer): void {
           typeCounts[a.type] = (typeCounts[a.type] || 0) + 1;
         }
         const typeList = Object.entries(typeCounts)
-          .map(([t, n]) => `${n} ${t}${n > 1 ? 's' : ''}`)
-          .join(', ');
+          .map(([t, n]) => `${n} ${t}${n > 1 ? "s" : ""}`)
+          .join(", ");
         parts.push(`${userActions.length} new: ${typeList}`);
       }
       if (userResponses.length > 0) {
@@ -163,13 +192,13 @@ export function registerAwarenessTools(server: McpServer): void {
         }
         const statusList = Object.entries(statusCounts)
           .map(([s, n]) => `${n} ${s}`)
-          .join(', ');
+          .join(", ");
         parts.push(statusList);
       }
       if (chatMessages.length > 0) {
-        parts.push(`${chatMessages.length} new chat message${chatMessages.length > 1 ? 's' : ''}`);
+        parts.push(`${chatMessages.length} new chat message${chatMessages.length > 1 ? "s" : ""}`);
       }
-      const summary = parts.length > 0 ? parts.join('. ') + '.' : 'No new actions.';
+      const summary = parts.length > 0 ? parts.join(". ") + "." : "No new actions.";
 
       const hasNew = userActions.length > 0 || userResponses.length > 0 || chatMessages.length > 0;
 
@@ -186,19 +215,22 @@ export function registerAwarenessTools(server: McpServer): void {
           selectedText,
         },
       });
-    }
+    },
   );
   server.tool(
-    'tandem_reply',
-    'Send a chat message to the user in the Tandem sidebar. Use this to respond to chat messages from tandem_checkInbox.',
+    "tandem_reply",
+    "Send a chat message to the user in the Tandem sidebar. Use this to respond to chat messages from tandem_checkInbox.",
     {
-      text: z.string().describe('Your message to the user'),
-      replyTo: z.string().optional().describe('ID of the user message you are replying to'),
-      documentId: z.string().optional().describe('Document context for this reply (defaults to active document)'),
+      text: z.string().describe("Your message to the user"),
+      replyTo: z.string().optional().describe("ID of the user message you are replying to"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Document context for this reply (defaults to active document)"),
     },
     async ({ text, replyTo, documentId }) => {
-      const ctrlDoc = getOrCreateDocument('__tandem_ctrl__');
-      const chatMap = ctrlDoc.getMap('chat');
+      const ctrlDoc = getOrCreateDocument("__tandem_ctrl__");
+      const chatMap = ctrlDoc.getMap("chat");
 
       const id = generateMessageId();
       const current = getCurrentDoc(documentId);
@@ -206,7 +238,7 @@ export function registerAwarenessTools(server: McpServer): void {
 
       const msg: ChatMessage = {
         id,
-        author: 'claude',
+        author: "claude",
         text,
         timestamp: Date.now(),
         ...(docId ? { documentId: docId } : {}),
@@ -217,7 +249,7 @@ export function registerAwarenessTools(server: McpServer): void {
       chatMap.set(id, msg);
 
       return mcpSuccess({ sent: true, messageId: id });
-    }
+    },
   );
 }
 
@@ -225,5 +257,5 @@ function safeSlice(text: string, from: number, to: number): string {
   const start = Math.max(0, Math.min(from, text.length));
   const end = Math.max(start, Math.min(to, text.length));
   const snippet = text.slice(start, end);
-  return snippet.length > 100 ? snippet.slice(0, 97) + '...' : snippet;
+  return snippet.length > 100 ? snippet.slice(0, 97) + "..." : snippet;
 }

--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -230,17 +230,83 @@ export function resolveOffset(fragment: Y.XmlFragment, charOffset: number): Reso
 }
 
 /**
- * Find the first Y.XmlText child of a Y.XmlElement.
- * Creates one if the element is empty.
+ * Find the first Y.XmlText child of a Y.XmlElement (read-only).
+ * Returns null if no XmlText child exists.
  */
-export function getOrCreateXmlText(element: Y.XmlElement): Y.XmlText {
+export function findXmlText(element: Y.XmlElement): Y.XmlText | null {
   for (let i = 0; i < element.length; i++) {
     const child = element.get(i);
     if (child instanceof Y.XmlText) {
       return child;
     }
   }
-  const textNode = new Y.XmlText("");
-  element.insert(0, [textNode]);
-  return textNode;
+  return null;
+}
+
+/**
+ * Find the first Y.XmlText child of a Y.XmlElement.
+ * Creates one if the element is empty.
+ */
+export function getOrCreateXmlText(element: Y.XmlElement): Y.XmlText {
+  return (
+    findXmlText(element) ??
+    (() => {
+      const textNode = new Y.XmlText("");
+      element.insert(0, [textNode]);
+      return textNode;
+    })()
+  );
+}
+
+/**
+ * Convert a flat text offset to a JSON-serialized Yjs RelativePosition.
+ * Returns null if the offset falls in a heading prefix or can't be resolved.
+ */
+export function flatOffsetToRelPos(doc: Y.Doc, offset: number, assoc: 0 | -1): unknown | null {
+  const fragment = doc.getXmlFragment("default");
+  const resolved = resolveOffset(fragment, offset);
+  if (!resolved || resolved.clampedFromPrefix) return null;
+
+  const node = fragment.get(resolved.elementIndex);
+  if (!(node instanceof Y.XmlElement)) return null;
+
+  const xmlText = getOrCreateXmlText(node);
+  const rpos = Y.createRelativePositionFromTypeIndex(xmlText, resolved.textOffset, assoc);
+  return Y.relativePositionToJSON(rpos);
+}
+
+/**
+ * Resolve a JSON-serialized Yjs RelativePosition back to a flat text offset.
+ * Returns null if the referenced content was deleted.
+ */
+export function relPosToFlatOffset(doc: Y.Doc, relPosJson: unknown): number | null {
+  const rpos = Y.createRelativePositionFromJSON(relPosJson);
+  const absPos = Y.createAbsolutePositionFromRelativePosition(rpos, doc);
+  if (!absPos) return null;
+
+  const fragment = doc.getXmlFragment("default");
+  let accumulated = 0;
+
+  for (let i = 0; i < fragment.length; i++) {
+    const node = fragment.get(i);
+    if (!(node instanceof Y.XmlElement)) continue;
+
+    const prefixLen = getHeadingPrefixLength(node);
+    const text = getElementText(node);
+
+    // Check if this element contains the resolved XmlText (read-only)
+    const xmlText = findXmlText(node);
+    if (xmlText && xmlText === absPos.type) {
+      return accumulated + prefixLen + absPos.index;
+    }
+
+    accumulated += prefixLen + text.length;
+
+    // Separator between elements (not after last)
+    if (i < fragment.length - 1) {
+      accumulated += 1;
+    }
+  }
+
+  return null;
 }

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -1,60 +1,98 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
-import fs from 'fs/promises';
-import fsSync from 'fs';
-import path from 'path';
-import * as Y from 'yjs';
-import { getOrCreateDocument } from '../yjs/provider.js';
-import { mcpSuccess, mcpError, noDocumentError, getErrorMessage } from './response.js';
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import fs from "fs/promises";
+import fsSync from "fs";
+import path from "path";
+import * as Y from "yjs";
+import { getOrCreateDocument } from "../yjs/provider.js";
+import { mcpSuccess, mcpError, noDocumentError, getErrorMessage } from "./response.js";
 import {
   MAX_FILE_SIZE,
   CHARS_PER_PAGE,
   LARGE_FILE_PAGE_THRESHOLD,
   VERY_LARGE_FILE_PAGE_THRESHOLD,
-} from '../../shared/constants.js';
-import { headingPrefix } from '../../shared/offsets.js';
-import { loadMarkdown, saveMarkdown } from '../file-io/markdown.js';
-import { loadDocx, htmlToYDoc } from '../file-io/docx.js';
+} from "../../shared/constants.js";
+import { headingPrefix } from "../../shared/offsets.js";
+import { loadMarkdown, saveMarkdown } from "../file-io/markdown.js";
+import { loadDocx, htmlToYDoc } from "../file-io/docx.js";
 import {
-  saveSession, loadSession, restoreYDoc, sourceFileChanged,
-  startAutoSave, stopAutoSave, isAutoSaveRunning,
-} from '../session/manager.js';
+  saveSession,
+  loadSession,
+  restoreYDoc,
+  sourceFileChanged,
+  startAutoSave,
+  stopAutoSave,
+  isAutoSaveRunning,
+} from "../session/manager.js";
 
 // Document model (pure logic)
 import {
-  extractText, extractMarkdown, populateYDoc, getElementText,
-  resolveOffset, getOrCreateXmlText, verifyAndResolveRange,
-  detectFormat, docIdFromPath,
-} from './document-model.js';
+  extractText,
+  extractMarkdown,
+  populateYDoc,
+  getElementText,
+  resolveOffset,
+  getOrCreateXmlText,
+  verifyAndResolveRange,
+  detectFormat,
+  docIdFromPath,
+} from "./document-model.js";
 
 // Document service (state management)
 import {
-  getOpenDocs, getActiveDocId, setActiveDocId,
-  getCurrentDoc, requireDocument, broadcastOpenDocs, toDocListEntry,
-  addDoc, removeDoc, hasDoc, docCount,
-} from './document-service.js';
+  getOpenDocs,
+  getActiveDocId,
+  setActiveDocId,
+  getCurrentDoc,
+  requireDocument,
+  broadcastOpenDocs,
+  toDocListEntry,
+  addDoc,
+  removeDoc,
+  hasDoc,
+  docCount,
+} from "./document-service.js";
 
 // Re-export for backward compatibility with existing consumers.
 export {
-  extractText, extractMarkdown, populateYDoc, getElementText,
-  getOrCreateXmlText, resolveOffset, verifyAndResolveRange,
-  detectFormat, docIdFromPath, getHeadingPrefixLength,
-} from './document-model.js';
-export type { ResolvedOffset, RangeVerifyResult } from './document-model.js';
+  extractText,
+  extractMarkdown,
+  populateYDoc,
+  getElementText,
+  findXmlText,
+  getOrCreateXmlText,
+  resolveOffset,
+  verifyAndResolveRange,
+  detectFormat,
+  docIdFromPath,
+  getHeadingPrefixLength,
+  flatOffsetToRelPos,
+  relPosToFlatOffset,
+} from "./document-model.js";
+export type { ResolvedOffset, RangeVerifyResult } from "./document-model.js";
 export {
-  getCurrentDoc, getOpenDocs, getActiveDocId, setActiveDocId,
-  requireDocument, toDocListEntry, saveCurrentSession, restoreCtrlSession,
-  addDoc, removeDoc, hasDoc, docCount,
-} from './document-service.js';
-export type { OpenDoc } from './document-service.js';
+  getCurrentDoc,
+  getOpenDocs,
+  getActiveDocId,
+  setActiveDocId,
+  requireDocument,
+  toDocListEntry,
+  saveCurrentSession,
+  restoreCtrlSession,
+  addDoc,
+  removeDoc,
+  hasDoc,
+  docCount,
+} from "./document-service.js";
+export type { OpenDoc } from "./document-service.js";
 
 export function registerDocumentTools(server: McpServer): void {
   const openDocs = getOpenDocs();
 
   server.tool(
-    'tandem_open',
-    'Open a file in the Tandem editor. Returns a documentId for multi-document workflows. Auto-opens browser.',
-    { filePath: z.string().describe('Absolute path to the file to open') },
+    "tandem_open",
+    "Open a file in the Tandem editor. Returns a documentId for multi-document workflows. Auto-opens browser.",
+    { filePath: z.string().describe("Absolute path to the file to open") },
     async ({ filePath }) => {
       let resolved = path.resolve(filePath);
       try {
@@ -64,17 +102,17 @@ export function registerDocumentTools(server: McpServer): void {
           resolved = path.resolve(filePath);
         }
 
-        if (resolved.startsWith('\\\\') || resolved.startsWith('//')) {
-          return mcpError('FILE_NOT_FOUND', 'UNC paths are not supported for security reasons.');
+        if (resolved.startsWith("\\\\") || resolved.startsWith("//")) {
+          return mcpError("FILE_NOT_FOUND", "UNC paths are not supported for security reasons.");
         }
 
         const stat = await fs.stat(resolved);
         if (stat.size > MAX_FILE_SIZE) {
-          return mcpError('FORMAT_ERROR', 'File exceeds 50MB limit.');
+          return mcpError("FORMAT_ERROR", "File exceeds 50MB limit.");
         }
 
         const format = detectFormat(resolved);
-        const isDocx = format === 'docx';
+        const isDocx = format === "docx";
         const readOnly = isDocx;
 
         const id = docIdFromPath(resolved);
@@ -116,8 +154,8 @@ export function registerDocumentTools(server: McpServer): void {
             const html = await loadDocx(resolved);
             htmlToYDoc(doc, html);
           } else {
-            const fileContent = await fs.readFile(resolved, 'utf-8');
-            if (format === 'md') {
+            const fileContent = await fs.readFile(resolved, "utf-8");
+            if (format === "md") {
               loadMarkdown(doc, fileContent);
             } else {
               populateYDoc(doc, fileContent);
@@ -128,11 +166,11 @@ export function registerDocumentTools(server: McpServer): void {
         addDoc(id, { id, filePath: resolved, format, readOnly });
         setActiveDocId(id);
 
-        const meta = doc.getMap('documentMeta');
-        meta.set('readOnly', readOnly);
-        meta.set('format', format);
-        meta.set('documentId', id);
-        meta.set('fileName', fileName);
+        const meta = doc.getMap("documentMeta");
+        meta.set("readOnly", readOnly);
+        meta.set("format", format);
+        meta.set("documentId", id);
+        meta.set("fileName", fileName);
 
         broadcastOpenDocs();
 
@@ -151,9 +189,13 @@ export function registerDocumentTools(server: McpServer): void {
 
         const warnings: string[] = [];
         if (pageEstimate >= VERY_LARGE_FILE_PAGE_THRESHOLD) {
-          warnings.push(`Very large document (~${pageEstimate} pages). Consider splitting into smaller files.`);
+          warnings.push(
+            `Very large document (~${pageEstimate} pages). Consider splitting into smaller files.`,
+          );
         } else if (pageEstimate >= LARGE_FILE_PAGE_THRESHOLD) {
-          warnings.push(`Large document (~${pageEstimate} pages). Operations may be slower than usual.`);
+          warnings.push(
+            `Large document (~${pageEstimate} pages). Operations may be slower than usual.`,
+          );
         }
 
         return mcpSuccess({
@@ -174,47 +216,59 @@ export function registerDocumentTools(server: McpServer): void {
         });
       } catch (err: unknown) {
         const e = err as NodeJS.ErrnoException;
-        if (e.code === 'ENOENT') {
-          return mcpError('FILE_NOT_FOUND', `File not found: ${resolved}`);
+        if (e.code === "ENOENT") {
+          return mcpError("FILE_NOT_FOUND", `File not found: ${resolved}`);
         }
-        if (e.code === 'EBUSY' || e.code === 'EPERM') {
-          return mcpError('FILE_LOCKED', `File is locked — another program (likely Microsoft Word) has it open. Close it and try again.`);
+        if (e.code === "EBUSY" || e.code === "EPERM") {
+          return mcpError(
+            "FILE_LOCKED",
+            `File is locked — another program (likely Microsoft Word) has it open. Close it and try again.`,
+          );
         }
-        if (e.code === 'EACCES') {
-          return mcpError('PERMISSION_DENIED', `Permission denied — check file permissions for: ${resolved}`);
+        if (e.code === "EACCES") {
+          return mcpError(
+            "PERMISSION_DENIED",
+            `Permission denied — check file permissions for: ${resolved}`,
+          );
         }
-        return mcpError('FORMAT_ERROR', getErrorMessage(err));
+        return mcpError("FORMAT_ERROR", getErrorMessage(err));
       }
-    }
+    },
   );
 
   server.tool(
-    'tandem_getContent',
-    'Read full document content. Warning: token-heavy for large docs. Use getOutline() or getTextContent() instead.',
+    "tandem_getContent",
+    "Read full document content. Warning: token-heavy for large docs. Use getOutline() or getTextContent() instead.",
     {
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ documentId }) => {
       const r = requireDocument(documentId);
       if (!r) return noDocumentError();
-      const fragment = r.doc.getXmlFragment('default');
+      const fragment = r.doc.getXmlFragment("default");
       return mcpSuccess({ content: fragment.toJSON(), filePath: r.filePath, documentId: r.docId });
-    }
+    },
   );
 
   server.tool(
-    'tandem_getTextContent',
-    'Read document as plain text. ~60% fewer tokens than getContent().',
+    "tandem_getTextContent",
+    "Read document as plain text. ~60% fewer tokens than getContent().",
     {
-      section: z.string().optional().describe('Optional heading text to read only that section'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      section: z.string().optional().describe("Optional heading text to read only that section"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ section, documentId }) => {
       const r = requireDocument(documentId);
       if (!r) return noDocumentError();
 
       if (section) {
-        const fragment = r.doc.getXmlFragment('default');
+        const fragment = r.doc.getXmlFragment("default");
         const lines: string[] = [];
         let inSection = false;
         let sectionLevel = 0;
@@ -225,8 +279,8 @@ export function registerDocumentTools(server: McpServer): void {
 
           const text = getElementText(node);
 
-          if (node.nodeName === 'heading') {
-            const level = Number(node.getAttribute('level') ?? 1);
+          if (node.nodeName === "heading") {
+            const level = Number(node.getAttribute("level") ?? 1);
             if (inSection && level <= sectionLevel) break;
             if (text.trim().toLowerCase() === section.trim().toLowerCase()) {
               inSection = true;
@@ -237,8 +291,8 @@ export function registerDocumentTools(server: McpServer): void {
           }
 
           if (inSection) {
-            if (node.nodeName === 'heading') {
-              const level = Number(node.getAttribute('level') ?? 1);
+            if (node.nodeName === "heading") {
+              const level = Number(node.getAttribute("level") ?? 1);
               lines.push(headingPrefix(level) + text);
             } else {
               lines.push(text);
@@ -247,51 +301,62 @@ export function registerDocumentTools(server: McpServer): void {
         }
 
         if (!inSection) {
-          return mcpError('INVALID_RANGE', `Section "${section}" not found in document.`);
+          return mcpError("INVALID_RANGE", `Section "${section}" not found in document.`);
         }
-        return mcpSuccess({ text: lines.join('\n'), filePath: r.filePath, section });
+        return mcpSuccess({ text: lines.join("\n"), filePath: r.filePath, section });
       }
 
       const docState = getCurrentDoc(documentId);
       const format = docState?.format;
-      const text = format === 'md' ? extractMarkdown(r.doc) : extractText(r.doc);
+      const text = format === "md" ? extractMarkdown(r.doc) : extractText(r.doc);
       return mcpSuccess({ text, filePath: r.filePath, documentId: r.docId });
-    }
+    },
   );
 
   server.tool(
-    'tandem_getOutline',
-    'Get document structure (headings, sections) without full content. Low token cost.',
+    "tandem_getOutline",
+    "Get document structure (headings, sections) without full content. Low token cost.",
     {
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ documentId }) => {
       const r = requireDocument(documentId);
       if (!r) return noDocumentError();
-      const fragment = r.doc.getXmlFragment('default');
+      const fragment = r.doc.getXmlFragment("default");
       const outline: Array<{ level: number; text: string; index: number }> = [];
 
       for (let i = 0; i < fragment.length; i++) {
         const node = fragment.get(i);
-        if (node instanceof Y.XmlElement && node.nodeName === 'heading') {
-          const level = Number(node.getAttribute('level') ?? 1);
+        if (node instanceof Y.XmlElement && node.nodeName === "heading") {
+          const level = Number(node.getAttribute("level") ?? 1);
           outline.push({ level, text: getElementText(node), index: i });
         }
       }
 
       return mcpSuccess({ outline, totalNodes: fragment.length });
-    }
+    },
   );
 
   server.tool(
-    'tandem_edit',
-    'Edit text in the document at a specific range. For single-paragraph replacements only — newlines in newText are inserted as literal text.',
+    "tandem_edit",
+    "Edit text in the document at a specific range. For single-paragraph replacements only — newlines in newText are inserted as literal text.",
     {
-      from: z.number().describe('Start position (character offset)'),
-      to: z.number().describe('End position (character offset)'),
-      newText: z.string().describe('Replacement text (single paragraph — no newlines)'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
-      textSnapshot: z.string().optional().describe('Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch'),
+      from: z.number().describe("Start position (character offset)"),
+      to: z.number().describe("End position (character offset)"),
+      newText: z.string().describe("Replacement text (single paragraph — no newlines)"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
+      textSnapshot: z
+        .string()
+        .optional()
+        .describe(
+          "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
+        ),
     },
     async ({ from, to, newText, documentId, textSnapshot }) => {
       const r = requireDocument(documentId);
@@ -301,36 +366,45 @@ export function registerDocumentTools(server: McpServer): void {
         const result = verifyAndResolveRange(r.doc, from, to, textSnapshot);
         if (!result.valid) {
           if (result.gone) {
-            return mcpError('RANGE_STALE', 'Target text no longer exists in the document.');
+            return mcpError("RANGE_STALE", "Target text no longer exists in the document.");
           }
-          return mcpError('RANGE_STALE', 'Target text has moved. Use resolvedFrom/resolvedTo to retry.', {
-            resolvedFrom: result.resolvedFrom,
-            resolvedTo: result.resolvedTo,
-          });
+          return mcpError(
+            "RANGE_STALE",
+            "Target text has moved. Use resolvedFrom/resolvedTo to retry.",
+            {
+              resolvedFrom: result.resolvedFrom,
+              resolvedTo: result.resolvedTo,
+            },
+          );
         }
       }
 
       const docState = getCurrentDoc(documentId);
       if (docState?.readOnly) {
-        return mcpError('FORMAT_ERROR', 'Document is read-only (.docx). Use annotations instead.');
+        return mcpError("FORMAT_ERROR", "Document is read-only (.docx). Use annotations instead.");
       }
 
       if (from > to) {
-        return mcpError('INVALID_RANGE', `Invalid range: from (${from}) must be <= to (${to}).`);
+        return mcpError("INVALID_RANGE", `Invalid range: from (${from}) must be <= to (${to}).`);
       }
 
-      const fragment = r.doc.getXmlFragment('default');
+      const fragment = r.doc.getXmlFragment("default");
       const startPos = resolveOffset(fragment, from);
       const endPos = resolveOffset(fragment, to);
 
       if (!startPos || !endPos) {
-        return mcpError('INVALID_RANGE', `Cannot resolve offset range [${from}, ${to}] in document.`);
+        return mcpError(
+          "INVALID_RANGE",
+          `Cannot resolve offset range [${from}, ${to}] in document.`,
+        );
       }
 
       if (startPos.clampedFromPrefix || endPos.clampedFromPrefix) {
-        return mcpError('INVALID_RANGE',
+        return mcpError(
+          "INVALID_RANGE",
           'Edit range overlaps with heading markup (e.g., "## "). Target the text content only. ' +
-          'Use tandem_resolveRange to find the text position.');
+            "Use tandem_resolveRange to find the text position.",
+        );
       }
 
       if (startPos.elementIndex !== endPos.elementIndex) {
@@ -375,21 +449,24 @@ export function registerDocumentTools(server: McpServer): void {
       }
 
       return mcpSuccess({ edited: true, from, to, newTextLength: newText.length });
-    }
+    },
   );
 
   server.tool(
-    'tandem_save',
-    'Save the current document back to disk',
+    "tandem_save",
+    "Save the current document back to disk",
     {
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
     async ({ documentId }) => {
       const r = requireDocument(documentId);
       if (!r) return noDocumentError();
       try {
         const docState = getCurrentDoc(documentId);
-        const format = docState?.format ?? 'txt';
+        const format = docState?.format ?? "txt";
         const readOnly = docState?.readOnly ?? false;
 
         if (readOnly) {
@@ -398,33 +475,36 @@ export function registerDocumentTools(server: McpServer): void {
             saved: true,
             sessionOnly: true,
             filePath: r.filePath,
-            message: 'Session saved (annotations preserved). Source file unchanged — document is read-only.',
+            message:
+              "Session saved (annotations preserved). Source file unchanged — document is read-only.",
           });
         }
 
-        const output = format === 'md' ? saveMarkdown(r.doc) : extractText(r.doc);
+        const output = format === "md" ? saveMarkdown(r.doc) : extractText(r.doc);
         const tempPath = path.join(path.dirname(r.filePath), `.tandem-tmp-${Date.now()}`);
-        await fs.writeFile(tempPath, output, 'utf-8');
+        await fs.writeFile(tempPath, output, "utf-8");
         await fs.rename(tempPath, r.filePath);
         await saveSession(r.filePath, format, r.doc);
         return mcpSuccess({ saved: true, filePath: r.filePath });
       } catch (err: unknown) {
-        return mcpError('FILE_LOCKED', getErrorMessage(err));
+        return mcpError("FILE_LOCKED", getErrorMessage(err));
       }
-    }
+    },
   );
 
   server.tool(
-    'tandem_status',
-    'Check editor status: running, open documents, active document',
+    "tandem_status",
+    "Check editor status: running, open documents, active document",
     {},
     async () => {
       const activeId = getActiveDocId();
       const active = activeId ? openDocs.get(activeId) : null;
       return mcpSuccess({
         running: true,
-        activeDocument: active ? { documentId: active.id, filePath: active.filePath, format: active.format } : null,
-        openDocuments: Array.from(openDocs.values()).map(d => ({
+        activeDocument: active
+          ? { documentId: active.id, filePath: active.filePath, format: active.format }
+          : null,
+        openDocuments: Array.from(openDocs.values()).map((d) => ({
           documentId: d.id,
           filePath: d.filePath,
           format: d.format,
@@ -432,21 +512,24 @@ export function registerDocumentTools(server: McpServer): void {
         })),
         documentCount: docCount(),
       });
-    }
+    },
   );
 
   server.tool(
-    'tandem_close',
-    'Close a document. Closes the active document if no documentId specified.',
+    "tandem_close",
+    "Close a document. Closes the active document if no documentId specified.",
     {
-      documentId: z.string().optional().describe('Document ID to close (defaults to active document)'),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Document ID to close (defaults to active document)"),
     },
     async ({ documentId }) => {
       const id = documentId ?? getActiveDocId();
-      if (!id) return mcpError('NO_DOCUMENT', 'No document to close.');
+      if (!id) return mcpError("NO_DOCUMENT", "No document to close.");
 
       const docState = openDocs.get(id);
-      if (!docState) return mcpError('NO_DOCUMENT', `Document ${id} not found.`);
+      if (!docState) return mcpError("NO_DOCUMENT", `Document ${id} not found.`);
 
       const doc = getOrCreateDocument(id);
       await saveSession(docState.filePath, docState.format, doc);
@@ -469,34 +552,34 @@ export function registerDocumentTools(server: McpServer): void {
         was: docState.filePath,
         activeDocumentId: getActiveDocId(),
       });
-    }
+    },
   );
 
   server.tool(
-    'tandem_listDocuments',
-    'List all open documents with their IDs, file paths, and formats.',
+    "tandem_listDocuments",
+    "List all open documents with their IDs, file paths, and formats.",
     {},
     async () => {
       return mcpSuccess({
-        documents: Array.from(openDocs.values()).map(d => ({
+        documents: Array.from(openDocs.values()).map((d) => ({
           ...toDocListEntry(d),
           isActive: d.id === getActiveDocId(),
         })),
         activeDocumentId: getActiveDocId(),
         count: docCount(),
       });
-    }
+    },
   );
 
   server.tool(
-    'tandem_switchDocument',
-    'Switch the active document. Tools will operate on this document by default.',
+    "tandem_switchDocument",
+    "Switch the active document. Tools will operate on this document by default.",
     {
-      documentId: z.string().describe('Document ID to switch to'),
+      documentId: z.string().describe("Document ID to switch to"),
     },
     async ({ documentId }) => {
       if (!hasDoc(documentId)) {
-        return mcpError('NO_DOCUMENT', `Document ${documentId} is not open.`);
+        return mcpError("NO_DOCUMENT", `Document ${documentId} is not open.`);
       }
       setActiveDocId(documentId);
       broadcastOpenDocs();
@@ -504,6 +587,6 @@ export function registerDocumentTools(server: McpServer): void {
         activeDocumentId: documentId,
         ...toDocListEntry(openDocs.get(documentId)!),
       });
-    }
+    },
   );
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,20 +1,32 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 // --- Zod schemas (source of truth) ---
 
-export const AnnotationTypeSchema = z.enum(['highlight', 'comment', 'suggestion', 'overlay', 'question', 'flag']);
-export const AnnotationStatusSchema = z.enum(['pending', 'accepted', 'dismissed']);
-export const AnnotationPrioritySchema = z.enum(['normal', 'urgent']);
-export const InterruptionModeSchema = z.enum(['all', 'urgent-only', 'paused']);
-export const HighlightColorSchema = z.enum(['yellow', 'red', 'green', 'blue', 'purple']);
-export const SeveritySchema = z.enum(['info', 'warning', 'error', 'success']);
-export const AuthorSchema = z.enum(['user', 'claude']);
-export const AnnotationActionSchema = z.enum(['accept', 'dismiss']);
-export const ExportFormatSchema = z.enum(['markdown', 'json']);
-export const DocumentFormatSchema = z.enum(['md', 'txt', 'html', 'docx']);
+export const AnnotationTypeSchema = z.enum([
+  "highlight",
+  "comment",
+  "suggestion",
+  "overlay",
+  "question",
+  "flag",
+]);
+export const AnnotationStatusSchema = z.enum(["pending", "accepted", "dismissed"]);
+export const AnnotationPrioritySchema = z.enum(["normal", "urgent"]);
+export const InterruptionModeSchema = z.enum(["all", "urgent-only", "paused"]);
+export const HighlightColorSchema = z.enum(["yellow", "red", "green", "blue", "purple"]);
+export const SeveritySchema = z.enum(["info", "warning", "error", "success"]);
+export const AuthorSchema = z.enum(["user", "claude"]);
+export const AnnotationActionSchema = z.enum(["accept", "dismiss"]);
+export const ExportFormatSchema = z.enum(["markdown", "json"]);
+export const DocumentFormatSchema = z.enum(["md", "txt", "html", "docx"]);
 export const ToolErrorCodeSchema = z.enum([
-  'RANGE_STALE', 'FILE_LOCKED', 'FILE_NOT_FOUND', 'NO_DOCUMENT',
-  'INVALID_RANGE', 'FORMAT_ERROR', 'PERMISSION_DENIED',
+  "RANGE_STALE",
+  "FILE_LOCKED",
+  "FILE_NOT_FOUND",
+  "NO_DOCUMENT",
+  "INVALID_RANGE",
+  "FORMAT_ERROR",
+  "PERMISSION_DENIED",
 ]);
 
 // --- Derived TypeScript types ---
@@ -30,9 +42,11 @@ export type Severity = z.infer<typeof SeveritySchema>;
 
 export interface Annotation {
   id: string;
-  author: 'user' | 'claude';
+  author: "user" | "claude";
   type: AnnotationType;
   range: DocumentRange;
+  /** CRDT-anchored range that survives edits. Falls back to `range` if absent. */
+  relRange?: RelativeRange;
   content: string;
   status: AnnotationStatus;
   timestamp: number;
@@ -43,6 +57,12 @@ export interface Annotation {
 export interface DocumentRange {
   from: number;
   to: number;
+}
+
+/** CRDT-anchored range that survives concurrent edits. Serialized via Y.relativePositionToJSON(). */
+export interface RelativeRange {
+  fromRel: unknown;
+  toRel: unknown;
 }
 
 export interface AnchoredRange {
@@ -75,7 +95,7 @@ export interface OverlayDefinition {
   label: string;
   type: string;
   visible: boolean;
-  mode: 'snapshot' | 'live';
+  mode: "snapshot" | "live";
   entries: OverlayEntry[];
   createdAt: number;
   updatedAt: number;
@@ -148,7 +168,7 @@ export interface SessionData {
 /** Chat message between user and Claude, stored in Y.Map('chat') on __tandem_ctrl__ */
 export interface ChatMessage {
   id: string;
-  author: 'user' | 'claude';
+  author: "user" | "claude";
   text: string;
   timestamp: number;
   documentId?: string;

--- a/tests/server/annotations.test.ts
+++ b/tests/server/annotations.test.ts
@@ -1,8 +1,14 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import * as Y from 'yjs';
-import { generateId, createAnnotation, collectAnnotations } from '../../src/server/mcp/annotations.js';
-import { makeDoc, getAnnotationsMap } from '../helpers/ydoc-factory.js';
-import type { Annotation } from '../../src/shared/types.js';
+import { describe, it, expect, afterEach } from "vitest";
+import * as Y from "yjs";
+import {
+  generateId,
+  createAnnotation,
+  collectAnnotations,
+  refreshRange,
+} from "../../src/server/mcp/annotations.js";
+import { makeDoc, getAnnotationsMap, getFragment } from "../helpers/ydoc-factory.js";
+import { getOrCreateXmlText, extractText } from "../../src/server/mcp/document.js";
+import type { Annotation } from "../../src/shared/types.js";
 
 let doc: Y.Doc;
 
@@ -10,179 +16,302 @@ afterEach(() => {
   doc?.destroy();
 });
 
-describe('generateId', () => {
-  it('matches expected format', () => {
+describe("generateId", () => {
+  it("matches expected format", () => {
     const id = generateId();
     expect(id).toMatch(/^ann_\d+_[a-z0-9]+$/);
   });
 
-  it('successive calls produce different IDs', () => {
+  it("successive calls produce different IDs", () => {
     const id1 = generateId();
     const id2 = generateId();
     expect(id1).not.toBe(id2);
   });
 });
 
-describe('createAnnotation', () => {
-  it('stores annotation with correct default fields', () => {
-    doc = makeDoc('test');
+describe("createAnnotation", () => {
+  it("stores annotation with correct default fields", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    const id = createAnnotation(map, 'comment', 0, 4, 'nice text');
+    const id = createAnnotation(map, "comment", 0, 4, "nice text");
 
     const stored = map.get(id) as Annotation;
     expect(stored.id).toBe(id);
-    expect(stored.author).toBe('claude');
-    expect(stored.type).toBe('comment');
+    expect(stored.author).toBe("claude");
+    expect(stored.type).toBe("comment");
     expect(stored.range).toEqual({ from: 0, to: 4 });
-    expect(stored.content).toBe('nice text');
-    expect(stored.status).toBe('pending');
-    expect(stored.timestamp).toBeTypeOf('number');
+    expect(stored.content).toBe("nice text");
+    expect(stored.status).toBe("pending");
+    expect(stored.timestamp).toBeTypeOf("number");
   });
 
-  it('extras override defaults', () => {
-    doc = makeDoc('test');
+  it("extras override defaults", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    const id = createAnnotation(map, 'highlight', 0, 4, '', { color: 'red' });
+    const id = createAnnotation(map, "highlight", 0, 4, "", { color: "red" });
 
     const stored = map.get(id) as Annotation;
-    expect(stored.color).toBe('red');
+    expect(stored.color).toBe("red");
   });
 });
 
-describe('collectAnnotations', () => {
-  it('returns empty array for empty map', () => {
-    doc = makeDoc('test');
+describe("collectAnnotations", () => {
+  it("returns empty array for empty map", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
     expect(collectAnnotations(map)).toEqual([]);
   });
 
-  it('returns all stored annotations', () => {
-    doc = makeDoc('test');
+  it("returns all stored annotations", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    createAnnotation(map, 'comment', 0, 2, 'first');
-    createAnnotation(map, 'highlight', 2, 4, 'second');
+    createAnnotation(map, "comment", 0, 2, "first");
+    createAnnotation(map, "highlight", 2, 4, "second");
 
     const all = collectAnnotations(map);
     expect(all).toHaveLength(2);
   });
 
-  it('returns annotations of different types', () => {
-    doc = makeDoc('test');
+  it("returns annotations of different types", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    createAnnotation(map, 'comment', 0, 2, 'c');
-    createAnnotation(map, 'highlight', 0, 2, 'h');
-    createAnnotation(map, 'suggestion', 0, 2, '{}');
+    createAnnotation(map, "comment", 0, 2, "c");
+    createAnnotation(map, "highlight", 0, 2, "h");
+    createAnnotation(map, "suggestion", 0, 2, "{}");
 
-    const types = collectAnnotations(map).map(a => a.type);
-    expect(types).toContain('comment');
-    expect(types).toContain('highlight');
-    expect(types).toContain('suggestion');
+    const types = collectAnnotations(map).map((a) => a.type);
+    expect(types).toContain("comment");
+    expect(types).toContain("highlight");
+    expect(types).toContain("suggestion");
   });
 });
 
-describe('filter logic', () => {
+describe("filter logic", () => {
   function setupAnnotations() {
-    doc = makeDoc('test content here');
+    doc = makeDoc("test content here");
     const map = getAnnotationsMap(doc);
-    createAnnotation(map, 'comment', 0, 4, 'a comment');
-    createAnnotation(map, 'highlight', 0, 4, '', { color: 'yellow' });
-    createAnnotation(map, 'suggestion', 5, 12, JSON.stringify({ newText: 'stuff', reason: 'clarity' }));
+    createAnnotation(map, "comment", 0, 4, "a comment");
+    createAnnotation(map, "highlight", 0, 4, "", { color: "yellow" });
+    createAnnotation(
+      map,
+      "suggestion",
+      5,
+      12,
+      JSON.stringify({ newText: "stuff", reason: "clarity" }),
+    );
     return map;
   }
 
-  it('filters by type', () => {
+  it("filters by type", () => {
     const map = setupAnnotations();
-    const comments = collectAnnotations(map).filter(a => a.type === 'comment');
+    const comments = collectAnnotations(map).filter((a) => a.type === "comment");
     expect(comments).toHaveLength(1);
-    expect(comments[0].content).toBe('a comment');
+    expect(comments[0].content).toBe("a comment");
   });
 
-  it('filters by status', () => {
+  it("filters by status", () => {
     const map = setupAnnotations();
-    const pending = collectAnnotations(map).filter(a => a.status === 'pending');
+    const pending = collectAnnotations(map).filter((a) => a.status === "pending");
     expect(pending).toHaveLength(3);
   });
 
-  it('filters by author', () => {
+  it("filters by author", () => {
     const map = setupAnnotations();
-    const claude = collectAnnotations(map).filter(a => a.author === 'claude');
+    const claude = collectAnnotations(map).filter((a) => a.author === "claude");
     expect(claude).toHaveLength(3);
-    const user = collectAnnotations(map).filter(a => a.author === 'user');
+    const user = collectAnnotations(map).filter((a) => a.author === "user");
     expect(user).toHaveLength(0);
   });
 
-  it('compound filter: author + type', () => {
+  it("compound filter: author + type", () => {
     const map = setupAnnotations();
     const result = collectAnnotations(map)
-      .filter(a => a.author === 'claude')
-      .filter(a => a.type === 'suggestion');
+      .filter((a) => a.author === "claude")
+      .filter((a) => a.type === "suggestion");
     expect(result).toHaveLength(1);
   });
 });
 
-describe('suggestion JSON contract', () => {
-  it('suggestion content is parseable JSON with newText and reason', () => {
-    doc = makeDoc('test');
+describe("suggestion JSON contract", () => {
+  it("suggestion content is parseable JSON with newText and reason", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    const id = createAnnotation(map, 'suggestion', 0, 4,
-      JSON.stringify({ newText: 'replacement', reason: 'better wording' }));
+    const id = createAnnotation(
+      map,
+      "suggestion",
+      0,
+      4,
+      JSON.stringify({ newText: "replacement", reason: "better wording" }),
+    );
 
     const stored = map.get(id) as Annotation;
     const parsed = JSON.parse(stored.content);
-    expect(parsed.newText).toBe('replacement');
-    expect(parsed.reason).toBe('better wording');
+    expect(parsed.newText).toBe("replacement");
+    expect(parsed.reason).toBe("better wording");
   });
 
-  it('suggestion with empty reason', () => {
-    doc = makeDoc('test');
+  it("suggestion with empty reason", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    const id = createAnnotation(map, 'suggestion', 0, 4,
-      JSON.stringify({ newText: 'x', reason: '' }));
+    const id = createAnnotation(
+      map,
+      "suggestion",
+      0,
+      4,
+      JSON.stringify({ newText: "x", reason: "" }),
+    );
 
     const stored = map.get(id) as Annotation;
     const parsed = JSON.parse(stored.content);
-    expect(parsed.reason).toBe('');
+    expect(parsed.reason).toBe("");
   });
 });
 
-describe('resolve and remove', () => {
-  it('resolve changes status to accepted', () => {
-    doc = makeDoc('test');
+describe("resolve and remove", () => {
+  it("resolve changes status to accepted", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    const id = createAnnotation(map, 'comment', 0, 4, 'text');
+    const id = createAnnotation(map, "comment", 0, 4, "text");
 
     const ann = map.get(id) as Annotation;
-    map.set(id, { ...ann, status: 'accepted' as const });
+    map.set(id, { ...ann, status: "accepted" as const });
 
     const updated = map.get(id) as Annotation;
-    expect(updated.status).toBe('accepted');
+    expect(updated.status).toBe("accepted");
   });
 
-  it('resolve changes status to dismissed', () => {
-    doc = makeDoc('test');
+  it("resolve changes status to dismissed", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    const id = createAnnotation(map, 'comment', 0, 4, 'text');
+    const id = createAnnotation(map, "comment", 0, 4, "text");
 
     const ann = map.get(id) as Annotation;
-    map.set(id, { ...ann, status: 'dismissed' as const });
+    map.set(id, { ...ann, status: "dismissed" as const });
 
     const updated = map.get(id) as Annotation;
-    expect(updated.status).toBe('dismissed');
+    expect(updated.status).toBe("dismissed");
   });
 
-  it('remove deletes from map', () => {
-    doc = makeDoc('test');
+  it("remove deletes from map", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    const id = createAnnotation(map, 'comment', 0, 4, 'text');
+    const id = createAnnotation(map, "comment", 0, 4, "text");
     expect(map.has(id)).toBe(true);
 
     map.delete(id);
     expect(map.has(id)).toBe(false);
   });
 
-  it('get nonexistent ID returns undefined', () => {
-    doc = makeDoc('test');
+  it("get nonexistent ID returns undefined", () => {
+    doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    expect(map.get('ann_fake_id')).toBeUndefined();
+    expect(map.get("ann_fake_id")).toBeUndefined();
+  });
+});
+
+describe("createAnnotation with ydoc (relRange)", () => {
+  it("stores relRange when ydoc is provided", () => {
+    doc = makeDoc("hello world");
+    const map = getAnnotationsMap(doc);
+    const id = createAnnotation(map, "comment", 0, 5, "note", {}, doc);
+
+    const stored = map.get(id) as Annotation;
+    expect(stored.relRange).toBeDefined();
+    expect(stored.relRange!.fromRel).not.toBeNull();
+    expect(stored.relRange!.toRel).not.toBeNull();
+  });
+
+  it("omits relRange when ydoc is not provided", () => {
+    doc = makeDoc("hello world");
+    const map = getAnnotationsMap(doc);
+    const id = createAnnotation(map, "comment", 0, 5, "note");
+
+    const stored = map.get(id) as Annotation;
+    expect(stored.relRange).toBeUndefined();
+  });
+
+  it("omits relRange when offset is in heading prefix", () => {
+    doc = makeDoc("## Title");
+    const map = getAnnotationsMap(doc);
+    // from=0 is inside "## " prefix → flatOffsetToRelPos returns null
+    const id = createAnnotation(map, "highlight", 0, 3, "", {}, doc);
+
+    const stored = map.get(id) as Annotation;
+    expect(stored.relRange).toBeUndefined();
+  });
+});
+
+describe("refreshRange", () => {
+  it("lazily attaches relRange to annotations missing it", () => {
+    doc = makeDoc("hello world");
+    const map = getAnnotationsMap(doc);
+    const id = createAnnotation(map, "comment", 0, 5, "note"); // no ydoc → no relRange
+
+    const ann = map.get(id) as Annotation;
+    expect(ann.relRange).toBeUndefined();
+
+    const refreshed = refreshRange(ann, doc, map);
+    expect(refreshed.relRange).toBeDefined();
+    expect(refreshed.relRange!.fromRel).not.toBeNull();
+    expect(refreshed.relRange!.toRel).not.toBeNull();
+
+    // Verify persisted to map
+    const stored = map.get(id) as Annotation;
+    expect(stored.relRange).toBeDefined();
+  });
+
+  it("updates stale flat offsets from relRange", () => {
+    doc = makeDoc("hello world");
+    const map = getAnnotationsMap(doc);
+    const id = createAnnotation(map, "comment", 6, 11, "note", {}, doc);
+
+    // Verify initial range
+    const ann = map.get(id) as Annotation;
+    expect(ann.range).toEqual({ from: 6, to: 11 });
+    expect(ann.relRange).toBeDefined();
+
+    // Insert text before the annotation → flat offsets go stale
+    const fragment = getFragment(doc);
+    const el = fragment.get(0) as Y.XmlElement;
+    const xmlText = getOrCreateXmlText(el);
+    xmlText.insert(0, "XXX");
+
+    expect(extractText(doc)).toBe("XXXhello world");
+
+    // refreshRange should correct the flat offsets
+    const refreshed = refreshRange(ann, doc, map);
+    expect(refreshed.range).toEqual({ from: 9, to: 14 }); // shifted by 3
+
+    // Verify persisted
+    const stored = map.get(id) as Annotation;
+    expect(stored.range).toEqual({ from: 9, to: 14 });
+  });
+
+  it("returns original annotation when offsets are unchanged", () => {
+    doc = makeDoc("hello world");
+    const map = getAnnotationsMap(doc);
+    const id = createAnnotation(map, "comment", 0, 5, "note", {}, doc);
+
+    const ann = map.get(id) as Annotation;
+    const refreshed = refreshRange(ann, doc);
+    // Same object since no update needed (no map write)
+    expect(refreshed.range).toEqual(ann.range);
+  });
+
+  it("returns original when relRange resolves to null (deleted content)", () => {
+    doc = makeDoc("first\nsecond");
+    const map = getAnnotationsMap(doc);
+    const id = createAnnotation(map, "comment", 6, 12, "note", {}, doc);
+
+    const ann = map.get(id) as Annotation;
+    expect(ann.relRange).toBeDefined();
+
+    // Delete the second element
+    const fragment = getFragment(doc);
+    fragment.delete(1, 1);
+
+    const refreshed = refreshRange(ann, doc);
+    // Falls back to original range since relRange can't resolve
+    expect(refreshed.range).toEqual({ from: 6, to: 12 });
   });
 });

--- a/tests/server/relative-position.test.ts
+++ b/tests/server/relative-position.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as Y from "yjs";
+import {
+  flatOffsetToRelPos,
+  relPosToFlatOffset,
+  getOrCreateXmlText,
+  extractText,
+} from "../../src/server/mcp/document.js";
+import { makeDoc, getFragment } from "../helpers/ydoc-factory.js";
+
+let doc: Y.Doc;
+
+afterEach(() => {
+  doc?.destroy();
+});
+
+describe("flatOffsetToRelPos", () => {
+  it("returns JSON-serializable RelativePosition for paragraph text", () => {
+    doc = makeDoc("hello world");
+    const relPos = flatOffsetToRelPos(doc, 6, 0);
+    expect(relPos).not.toBeNull();
+    expect(typeof relPos).toBe("object");
+  });
+
+  it("returns null for offset inside heading prefix", () => {
+    doc = makeDoc("## Title");
+    // Offset 0-2 are inside "## " prefix
+    expect(flatOffsetToRelPos(doc, 0, 0)).toBeNull();
+    expect(flatOffsetToRelPos(doc, 1, 0)).toBeNull();
+    expect(flatOffsetToRelPos(doc, 2, 0)).toBeNull();
+  });
+
+  it("works for text after heading prefix", () => {
+    doc = makeDoc("## Title");
+    // "## " is 3 chars, so offset 3 = start of "Title"
+    const relPos = flatOffsetToRelPos(doc, 3, 0);
+    expect(relPos).not.toBeNull();
+  });
+});
+
+describe("relPosToFlatOffset", () => {
+  it("returns null for invalid relPos JSON", () => {
+    doc = makeDoc("hello");
+    // Create a relPos from a different doc — should resolve to null
+    const otherDoc = new Y.Doc();
+    Y.applyUpdate(otherDoc, Y.encodeStateAsUpdate(new Y.Doc()));
+    const fragment = otherDoc.getXmlFragment("default");
+    const el = new Y.XmlElement("paragraph");
+    el.insert(0, [new Y.XmlText("other")]);
+    fragment.insert(0, [el]);
+    const xmlText = getOrCreateXmlText(el);
+    const rpos = Y.createRelativePositionFromTypeIndex(xmlText, 2, 0);
+    const json = Y.relativePositionToJSON(rpos);
+    otherDoc.destroy();
+
+    // Resolving against a different doc returns null
+    expect(relPosToFlatOffset(doc, json)).toBeNull();
+  });
+});
+
+describe("round-trip: flatOffset → relPos → flatOffset", () => {
+  it("is identity for single paragraph", () => {
+    doc = makeDoc("hello world");
+    for (const offset of [0, 5, 11]) {
+      const relPos = flatOffsetToRelPos(doc, offset, 0);
+      expect(relPos).not.toBeNull();
+      const back = relPosToFlatOffset(doc, relPos!);
+      expect(back).toBe(offset);
+    }
+  });
+
+  it("is identity for multi-paragraph text", () => {
+    doc = makeDoc("first\nsecond\nthird");
+    // "first" is offsets 0-4, "\n" is 5, "second" is 6-11, "\n" is 12, "third" is 13-17
+    for (const offset of [0, 4, 6, 11, 13, 17]) {
+      const relPos = flatOffsetToRelPos(doc, offset, 0);
+      expect(relPos).not.toBeNull();
+      const back = relPosToFlatOffset(doc, relPos!);
+      expect(back).toBe(offset);
+    }
+  });
+
+  it("is identity for heading text (after prefix)", () => {
+    doc = makeDoc("## Title\nBody text");
+    // "## " = 3 chars, "Title" starts at 3, "\n" at 8, "Body text" starts at 9
+    for (const offset of [3, 7, 9, 17]) {
+      const relPos = flatOffsetToRelPos(doc, offset, 0);
+      expect(relPos).not.toBeNull();
+      const back = relPosToFlatOffset(doc, relPos!);
+      expect(back).toBe(offset);
+    }
+  });
+
+  it("preserves assoc parameter", () => {
+    doc = makeDoc("hello world");
+    const relStart = flatOffsetToRelPos(doc, 5, 0);
+    const relEnd = flatOffsetToRelPos(doc, 5, -1);
+    expect(relStart).not.toBeNull();
+    expect(relEnd).not.toBeNull();
+    // Both should resolve to the same flat offset
+    expect(relPosToFlatOffset(doc, relStart!)).toBe(5);
+    expect(relPosToFlatOffset(doc, relEnd!)).toBe(5);
+  });
+});
+
+describe("edit survival", () => {
+  it("relPos tracks forward when text is inserted before it", () => {
+    doc = makeDoc("hello world");
+    // Create relPos at offset 6 (start of "world")
+    const relPos = flatOffsetToRelPos(doc, 6, 0);
+    expect(relPos).not.toBeNull();
+
+    // Insert "big " before "world" → "hello big world"
+    const fragment = getFragment(doc);
+    const firstElement = fragment.get(0) as Y.XmlElement;
+    const xmlText = getOrCreateXmlText(firstElement);
+    xmlText.insert(6, "big ");
+
+    // Verify document changed
+    expect(extractText(doc)).toBe("hello big world");
+
+    // relPos should now resolve to offset 10 (start of "world" in new text)
+    const newOffset = relPosToFlatOffset(doc, relPos!);
+    expect(newOffset).toBe(10);
+  });
+
+  it("relPos tracks backward when text is deleted before it", () => {
+    doc = makeDoc("hello world");
+    // Create relPos at offset 6 (start of "world")
+    const relPos = flatOffsetToRelPos(doc, 6, 0);
+    expect(relPos).not.toBeNull();
+
+    // Delete "hel" (0-3) → "lo world"
+    const fragment = getFragment(doc);
+    const firstElement = fragment.get(0) as Y.XmlElement;
+    const xmlText = getOrCreateXmlText(firstElement);
+    xmlText.delete(0, 3);
+
+    expect(extractText(doc)).toBe("lo world");
+
+    const newOffset = relPosToFlatOffset(doc, relPos!);
+    expect(newOffset).toBe(3); // "world" now starts at 3
+  });
+
+  it("returns null when the containing element is deleted", () => {
+    doc = makeDoc("first\nsecond");
+    // Create relPos in "second" (offset 6)
+    const relPos = flatOffsetToRelPos(doc, 6, 0);
+    expect(relPos).not.toBeNull();
+
+    // Delete the second element entirely
+    const fragment = getFragment(doc);
+    fragment.delete(1, 1);
+
+    expect(extractText(doc)).toBe("first");
+
+    const newOffset = relPosToFlatOffset(doc, relPos!);
+    expect(newOffset).toBeNull();
+  });
+
+  it("annotation range survives insert between from and to", () => {
+    doc = makeDoc("abcdefghij");
+    const fromRel = flatOffsetToRelPos(doc, 2, 0); // after "ab"
+    const toRel = flatOffsetToRelPos(doc, 8, -1); // before "ij"
+    expect(fromRel).not.toBeNull();
+    expect(toRel).not.toBeNull();
+
+    // Insert "XYZ" at position 5 → "abcdeXYZfghij"
+    const fragment = getFragment(doc);
+    const el = fragment.get(0) as Y.XmlElement;
+    const xmlText = getOrCreateXmlText(el);
+    xmlText.insert(5, "XYZ");
+
+    expect(extractText(doc)).toBe("abcdeXYZfghij");
+
+    const newFrom = relPosToFlatOffset(doc, fromRel!);
+    const newTo = relPosToFlatOffset(doc, toRel!);
+    expect(newFrom).toBe(2); // "ab" boundary unchanged
+    expect(newTo).toBe(11); // shifted by 3 ("XYZ".length)
+  });
+});
+
+describe("separator boundary", () => {
+  it("offset at separator position between elements resolves correctly", () => {
+    doc = makeDoc("abc\ndef");
+    // Offset 3 = end of "abc" (last char index)
+    const relAtEnd = flatOffsetToRelPos(doc, 3, 0);
+    expect(relAtEnd).not.toBeNull();
+    expect(relPosToFlatOffset(doc, relAtEnd!)).toBe(3);
+
+    // Offset 4 = start of "def"
+    const relAtStart = flatOffsetToRelPos(doc, 4, 0);
+    expect(relAtStart).not.toBeNull();
+    expect(relPosToFlatOffset(doc, relAtStart!)).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary

- Annotation ranges now store CRDT-anchored positions (`relRange` field) alongside flat text offsets, so highlights/comments/suggestions survive concurrent document edits without going stale
- `refreshRange()` auto-corrects stale flat offsets on read and lazily attaches `relRange` to user-created and legacy annotations
- Client-side rendering prefers `relRange` resolution (bypasses heading-prefix math), with flat offset fallback
- Added `findXmlText()` read-only helper to avoid mutating Y.Doc during position resolution
- 24 new tests covering round-trip conversion, edit survival, lazy attachment, and refresh

## Test plan

- [x] `npm test` — all 274 tests pass (24 new)
- [x] Both `tsconfig.json` and `tsconfig.server.json` typecheck clean
- [x] Manual: created annotation via MCP, edited text before highlight — highlight tracked correctly
- [x] Manual: `tandem_getAnnotations` confirmed flat offsets auto-corrected from `{12, 31}` to `{39, 58}` after edit
- [ ] Manual: session restore (pre-existing bug filed as #44 — unrelated to this change)
- [ ] Manual: user-created annotation via toolbar + lazy `relRange` attachment

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)