### PR TITLE
fix(ci): use correct prompt param for claude-code-action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -23,3 +24,5 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this PR. Focus on correctness, potential bugs, and whether the changes match the PR description. Be concise — only comment on things that matter.


### PR DESCRIPTION
## Summary

- Rename `direct_prompt` to `prompt` — the correct parameter name for `anthropics/claude-code-action@v1`. The old param was silently ignored, causing "NO PROMPT" / "Trigger result: false" on every PR.
- Add `timeout-minutes: 10` as a safety net.

## Test plan

- [ ] Merge this PR, then open another PR — the review action should trigger and post a review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)