### PR TITLE
fix(mcp): structured error boundaries for all 26 tool handlers (#20)

### DIFF
--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -8,7 +8,7 @@ import {
   flatOffsetToRelPos,
   relPosToFlatOffset,
 } from "./document.js";
-import { mcpSuccess, mcpError, noDocumentError } from "./response.js";
+import { mcpSuccess, mcpError, noDocumentError, withErrorBoundary } from "./response.js";
 import { exportAnnotations } from "../file-io/docx.js";
 import * as Y from "yjs";
 import type { Annotation, AnnotationType, HighlightColor } from "../../shared/types.js";
@@ -156,22 +156,25 @@ export function registerAnnotationTools(server: McpServer): void {
           "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
         ),
     },
-    async ({ from, to, color, note, documentId, priority, textSnapshot }) => {
-      const da = getDocAndAnnotations(documentId);
-      if (!da) return noDocumentError();
-      const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
-      if (staleError) return staleError;
-      const id = createAnnotation(
-        da.map,
-        "highlight",
-        from,
-        to,
-        note || "",
-        { color: color as HighlightColor, ...(priority ? { priority } : {}) },
-        da.ydoc,
-      );
-      return mcpSuccess({ annotationId: id });
-    },
+    withErrorBoundary(
+      "tandem_highlight",
+      async ({ from, to, color, note, documentId, priority, textSnapshot }) => {
+        const da = getDocAndAnnotations(documentId);
+        if (!da) return noDocumentError();
+        const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
+        if (staleError) return staleError;
+        const id = createAnnotation(
+          da.map,
+          "highlight",
+          from,
+          to,
+          note || "",
+          { color: color as HighlightColor, ...(priority ? { priority } : {}) },
+          da.ydoc,
+        );
+        return mcpSuccess({ annotationId: id });
+      },
+    ),
   );
 
   server.tool(
@@ -195,22 +198,25 @@ export function registerAnnotationTools(server: McpServer): void {
           "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
         ),
     },
-    async ({ from, to, text, documentId, priority, textSnapshot }) => {
-      const da = getDocAndAnnotations(documentId);
-      if (!da) return noDocumentError();
-      const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
-      if (staleError) return staleError;
-      const id = createAnnotation(
-        da.map,
-        "comment",
-        from,
-        to,
-        text,
-        priority ? { priority } : {},
-        da.ydoc,
-      );
-      return mcpSuccess({ annotationId: id });
-    },
+    withErrorBoundary(
+      "tandem_comment",
+      async ({ from, to, text, documentId, priority, textSnapshot }) => {
+        const da = getDocAndAnnotations(documentId);
+        if (!da) return noDocumentError();
+        const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
+        if (staleError) return staleError;
+        const id = createAnnotation(
+          da.map,
+          "comment",
+          from,
+          to,
+          text,
+          priority ? { priority } : {},
+          da.ydoc,
+        );
+        return mcpSuccess({ annotationId: id });
+      },
+    ),
   );
 
   server.tool(
@@ -235,22 +241,25 @@ export function registerAnnotationTools(server: McpServer): void {
           "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
         ),
     },
-    async ({ from, to, newText, reason, documentId, priority, textSnapshot }) => {
-      const da = getDocAndAnnotations(documentId);
-      if (!da) return noDocumentError();
-      const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
-      if (staleError) return staleError;
-      const id = createAnnotation(
-        da.map,
-        "suggestion",
-        from,
-        to,
-        JSON.stringify({ newText, reason: reason || "" }),
-        priority ? { priority } : {},
-        da.ydoc,
-      );
-      return mcpSuccess({ annotationId: id });
-    },
+    withErrorBoundary(
+      "tandem_suggest",
+      async ({ from, to, newText, reason, documentId, priority, textSnapshot }) => {
+        const da = getDocAndAnnotations(documentId);
+        if (!da) return noDocumentError();
+        const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
+        if (staleError) return staleError;
+        const id = createAnnotation(
+          da.map,
+          "suggestion",
+          from,
+          to,
+          JSON.stringify({ newText, reason: reason || "" }),
+          priority ? { priority } : {},
+          da.ydoc,
+        );
+        return mcpSuccess({ annotationId: id });
+      },
+    ),
   );
 
   server.tool(
@@ -274,22 +283,25 @@ export function registerAnnotationTools(server: McpServer): void {
           "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
         ),
     },
-    async ({ from, to, note, documentId, priority, textSnapshot }) => {
-      const da = getDocAndAnnotations(documentId);
-      if (!da) return noDocumentError();
-      const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
-      if (staleError) return staleError;
-      const id = createAnnotation(
-        da.map,
-        "flag",
-        from,
-        to,
-        note || "",
-        priority ? { priority } : {},
-        da.ydoc,
-      );
-      return mcpSuccess({ annotationId: id });
-    },
+    withErrorBoundary(
+      "tandem_flag",
+      async ({ from, to, note, documentId, priority, textSnapshot }) => {
+        const da = getDocAndAnnotations(documentId);
+        if (!da) return noDocumentError();
+        const staleError = checkRangeStale(da.ydoc, from, to, textSnapshot);
+        if (staleError) return staleError;
+        const id = createAnnotation(
+          da.map,
+          "flag",
+          from,
+          to,
+          note || "",
+          priority ? { priority } : {},
+          da.ydoc,
+        );
+        return mcpSuccess({ annotationId: id });
+      },
+    ),
   );
 
   server.tool(
@@ -304,7 +316,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ author, type, status, documentId }) => {
+    withErrorBoundary("tandem_getAnnotations", async ({ author, type, status, documentId }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
 
@@ -314,7 +326,7 @@ export function registerAnnotationTools(server: McpServer): void {
       if (status) results = results.filter((a) => a.status === status);
 
       return mcpSuccess({ annotations: results, count: results.length });
-    },
+    }),
   );
 
   server.tool(
@@ -328,7 +340,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ id, action, documentId }) => {
+    withErrorBoundary("tandem_resolveAnnotation", async ({ id, action, documentId }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
 
@@ -341,7 +353,7 @@ export function registerAnnotationTools(server: McpServer): void {
       };
       da.map.set(id, updated);
       return mcpSuccess({ id, status: updated.status });
-    },
+    }),
   );
 
   server.tool(
@@ -354,13 +366,13 @@ export function registerAnnotationTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ id, documentId }) => {
+    withErrorBoundary("tandem_removeAnnotation", async ({ id, documentId }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
       if (!da.map.has(id)) return mcpError("INVALID_RANGE", `Annotation ${id} not found`);
       da.map.delete(id);
       return mcpSuccess({ removed: true, id });
-    },
+    }),
   );
 
   server.tool(
@@ -373,7 +385,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ format, documentId }) => {
+    withErrorBoundary("tandem_exportAnnotations", async ({ format, documentId }) => {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
 
@@ -394,6 +406,6 @@ export function registerAnnotationTools(server: McpServer): void {
 
       const markdown = exportAnnotations(ydoc, annotations);
       return mcpSuccess({ markdown, count: annotations.length });
-    },
+    }),
   );
 }

--- a/src/server/mcp/awareness.ts
+++ b/src/server/mcp/awareness.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { getOrCreateDocument } from "../yjs/provider.js";
 import { getCurrentDoc, extractText } from "./document.js";
 import { collectAnnotations, refreshRange } from "./annotations.js";
-import { mcpSuccess, noDocumentError } from "./response.js";
+import { mcpSuccess, noDocumentError, withErrorBoundary } from "./response.js";
 import type { Annotation, ChatMessage } from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
 import { CTRL_ROOM } from "../../shared/constants.js";
@@ -26,7 +26,7 @@ export function registerAwarenessTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ documentId }) => {
+    withErrorBoundary("tandem_getSelections", async ({ documentId }) => {
       const current = getCurrentDoc(documentId);
       if (!current) return noDocumentError();
 
@@ -44,7 +44,7 @@ export function registerAwarenessTools(server: McpServer): void {
         selections: [{ from: selection.from, to: selection.to }],
         timestamp: selection.timestamp,
       });
-    },
+    }),
   );
 
   server.tool(
@@ -56,7 +56,7 @@ export function registerAwarenessTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ documentId }) => {
+    withErrorBoundary("tandem_getActivity", async ({ documentId }) => {
       const current = getCurrentDoc(documentId);
       if (!current) return noDocumentError();
 
@@ -88,7 +88,7 @@ export function registerAwarenessTools(server: McpServer): void {
         cursor: activity.cursor,
         lastEdit: activity.lastEdit,
       });
-    },
+    }),
   );
 
   server.tool(
@@ -100,7 +100,7 @@ export function registerAwarenessTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ documentId }) => {
+    withErrorBoundary("tandem_checkInbox", async ({ documentId }) => {
       const current = getCurrentDoc(documentId);
       if (!current) return noDocumentError();
 
@@ -216,7 +216,7 @@ export function registerAwarenessTools(server: McpServer): void {
           selectedText,
         },
       });
-    },
+    }),
   );
   server.tool(
     "tandem_reply",
@@ -229,7 +229,7 @@ export function registerAwarenessTools(server: McpServer): void {
         .optional()
         .describe("Document context for this reply (defaults to active document)"),
     },
-    async ({ text, replyTo, documentId }) => {
+    withErrorBoundary("tandem_reply", async ({ text, replyTo, documentId }) => {
       const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
       const chatMap = ctrlDoc.getMap("chat");
 
@@ -250,7 +250,7 @@ export function registerAwarenessTools(server: McpServer): void {
       chatMap.set(id, msg);
 
       return mcpSuccess({ sent: true, messageId: id });
-    },
+    }),
   );
 }
 

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -5,7 +5,13 @@ import fsSync from "fs";
 import path from "path";
 import * as Y from "yjs";
 import { getOrCreateDocument } from "../yjs/provider.js";
-import { mcpSuccess, mcpError, noDocumentError, getErrorMessage } from "./response.js";
+import {
+  mcpSuccess,
+  mcpError,
+  noDocumentError,
+  getErrorMessage,
+  withErrorBoundary,
+} from "./response.js";
 import {
   MAX_FILE_SIZE,
   CHARS_PER_PAGE,
@@ -93,7 +99,7 @@ export function registerDocumentTools(server: McpServer): void {
     "tandem_open",
     "Open a file in the Tandem editor. Returns a documentId for multi-document workflows. Auto-opens browser.",
     { filePath: z.string().describe("Absolute path to the file to open") },
-    async ({ filePath }) => {
+    withErrorBoundary("tandem_open", async ({ filePath }) => {
       let resolved = path.resolve(filePath);
       try {
         try {
@@ -243,7 +249,7 @@ export function registerDocumentTools(server: McpServer): void {
         }
         return mcpError("FORMAT_ERROR", getErrorMessage(err));
       }
-    },
+    }),
   );
 
   server.tool(
@@ -255,12 +261,12 @@ export function registerDocumentTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ documentId }) => {
+    withErrorBoundary("tandem_getContent", async ({ documentId }) => {
       const r = requireDocument(documentId);
       if (!r) return noDocumentError();
       const fragment = r.doc.getXmlFragment("default");
       return mcpSuccess({ content: fragment.toJSON(), filePath: r.filePath, documentId: r.docId });
-    },
+    }),
   );
 
   server.tool(
@@ -273,7 +279,7 @@ export function registerDocumentTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ section, documentId }) => {
+    withErrorBoundary("tandem_getTextContent", async ({ section, documentId }) => {
       const r = requireDocument(documentId);
       if (!r) return noDocumentError();
 
@@ -320,7 +326,7 @@ export function registerDocumentTools(server: McpServer): void {
       const format = docState?.format;
       const text = format === "md" ? extractMarkdown(r.doc) : extractText(r.doc);
       return mcpSuccess({ text, filePath: r.filePath, documentId: r.docId });
-    },
+    }),
   );
 
   server.tool(
@@ -332,7 +338,7 @@ export function registerDocumentTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ documentId }) => {
+    withErrorBoundary("tandem_getOutline", async ({ documentId }) => {
       const r = requireDocument(documentId);
       if (!r) return noDocumentError();
       const fragment = r.doc.getXmlFragment("default");
@@ -347,7 +353,7 @@ export function registerDocumentTools(server: McpServer): void {
       }
 
       return mcpSuccess({ outline, totalNodes: fragment.length });
-    },
+    }),
   );
 
   server.tool(
@@ -368,7 +374,7 @@ export function registerDocumentTools(server: McpServer): void {
           "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
         ),
     },
-    async ({ from, to, newText, documentId, textSnapshot }) => {
+    withErrorBoundary("tandem_edit", async ({ from, to, newText, documentId, textSnapshot }) => {
       const r = requireDocument(documentId);
       if (!r) return noDocumentError();
 
@@ -459,7 +465,7 @@ export function registerDocumentTools(server: McpServer): void {
       }
 
       return mcpSuccess({ edited: true, from, to, newTextLength: newText.length });
-    },
+    }),
   );
 
   server.tool(
@@ -471,7 +477,7 @@ export function registerDocumentTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
     },
-    async ({ documentId }) => {
+    withErrorBoundary("tandem_save", async ({ documentId }) => {
       const r = requireDocument(documentId);
       if (!r) return noDocumentError();
       try {
@@ -499,14 +505,14 @@ export function registerDocumentTools(server: McpServer): void {
       } catch (err: unknown) {
         return mcpError("FILE_LOCKED", getErrorMessage(err));
       }
-    },
+    }),
   );
 
   server.tool(
     "tandem_status",
     "Check editor status: running, open documents, active document",
     {},
-    async () => {
+    withErrorBoundary("tandem_status", async () => {
       const activeId = getActiveDocId();
       const active = activeId ? openDocs.get(activeId) : null;
       return mcpSuccess({
@@ -522,7 +528,7 @@ export function registerDocumentTools(server: McpServer): void {
         })),
         documentCount: docCount(),
       });
-    },
+    }),
   );
 
   server.tool(
@@ -534,7 +540,7 @@ export function registerDocumentTools(server: McpServer): void {
         .optional()
         .describe("Document ID to close (defaults to active document)"),
     },
-    async ({ documentId }) => {
+    withErrorBoundary("tandem_close", async ({ documentId }) => {
       const id = documentId ?? getActiveDocId();
       if (!id) return mcpError("NO_DOCUMENT", "No document to close.");
 
@@ -562,14 +568,14 @@ export function registerDocumentTools(server: McpServer): void {
         was: docState.filePath,
         activeDocumentId: getActiveDocId(),
       });
-    },
+    }),
   );
 
   server.tool(
     "tandem_listDocuments",
     "List all open documents with their IDs, file paths, and formats.",
     {},
-    async () => {
+    withErrorBoundary("tandem_listDocuments", async () => {
       return mcpSuccess({
         documents: Array.from(openDocs.values()).map((d) => ({
           ...toDocListEntry(d),
@@ -578,7 +584,7 @@ export function registerDocumentTools(server: McpServer): void {
         activeDocumentId: getActiveDocId(),
         count: docCount(),
       });
-    },
+    }),
   );
 
   server.tool(
@@ -587,7 +593,7 @@ export function registerDocumentTools(server: McpServer): void {
     {
       documentId: z.string().describe("Document ID to switch to"),
     },
-    async ({ documentId }) => {
+    withErrorBoundary("tandem_switchDocument", async ({ documentId }) => {
       if (!hasDoc(documentId)) {
         return mcpError("NO_DOCUMENT", `Document ${documentId} is not open.`);
       }
@@ -597,6 +603,6 @@ export function registerDocumentTools(server: McpServer): void {
         activeDocumentId: documentId,
         ...toDocListEntry(openDocs.get(documentId)!),
       });
-    },
+    }),
   );
 }

--- a/src/server/mcp/navigation.ts
+++ b/src/server/mcp/navigation.ts
@@ -1,8 +1,15 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
-import { getOrCreateDocument } from '../yjs/provider.js';
-import { getCurrentDoc, extractText } from './document.js';
-import { mcpSuccess, mcpError, noDocumentError, escapeRegex, getErrorMessage } from './response.js';
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getOrCreateDocument } from "../yjs/provider.js";
+import { getCurrentDoc, extractText } from "./document.js";
+import {
+  mcpSuccess,
+  mcpError,
+  noDocumentError,
+  escapeRegex,
+  getErrorMessage,
+  withErrorBoundary,
+} from "./response.js";
 
 /** Get full text from the current document's Y.Doc */
 function getFullText(docName: string): string {
@@ -12,14 +19,17 @@ function getFullText(docName: string): string {
 
 export function registerNavigationTools(server: McpServer): void {
   server.tool(
-    'tandem_search',
-    'Search for text in the document. Returns matching positions.',
+    "tandem_search",
+    "Search for text in the document. Returns matching positions.",
     {
-      query: z.string().describe('Search query (supports regex)'),
-      regex: z.boolean().optional().describe('Treat query as regex'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      query: z.string().describe("Search query (supports regex)"),
+      regex: z.boolean().optional().describe("Treat query as regex"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
-    async ({ query, regex, documentId }) => {
+    withErrorBoundary("tandem_search", async ({ query, regex, documentId }) => {
       const current = getCurrentDoc(documentId);
       if (!current) return noDocumentError();
 
@@ -27,82 +37,104 @@ export function registerNavigationTools(server: McpServer): void {
       const matches: Array<{ from: number; to: number; text: string }> = [];
 
       try {
-        const pattern = regex ? new RegExp(query, 'gi') : new RegExp(escapeRegex(query), 'gi');
+        const pattern = regex ? new RegExp(query, "gi") : new RegExp(escapeRegex(query), "gi");
         let match;
         while ((match = pattern.exec(fullText)) !== null) {
           matches.push({ from: match.index, to: match.index + match[0].length, text: match[0] });
         }
       } catch (err) {
-        return mcpError('FORMAT_ERROR', `Invalid regex: ${getErrorMessage(err)}`);
+        return mcpError("FORMAT_ERROR", `Invalid regex: ${getErrorMessage(err)}`);
       }
 
       return mcpSuccess({ matches, count: matches.length });
-    }
+    }),
   );
 
   server.tool(
-    'tandem_resolveRange',
-    'Find text and return a valid range. Safer than raw character offsets under concurrent editing.',
+    "tandem_resolveRange",
+    "Find text and return a valid range. Safer than raw character offsets under concurrent editing.",
     {
-      pattern: z.string().describe('Text to find'),
-      occurrence: z.number().optional().describe('Which occurrence (1-based, default 1)'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      pattern: z.string().describe("Text to find"),
+      occurrence: z.number().optional().describe("Which occurrence (1-based, default 1)"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
-    async ({ pattern, occurrence = 1, documentId }) => {
+    withErrorBoundary("tandem_resolveRange", async ({ pattern, occurrence = 1, documentId }) => {
       const current = getCurrentDoc(documentId);
       if (!current) return noDocumentError();
 
       const fullText = getFullText(current.docName);
-      const regex = new RegExp(escapeRegex(pattern), 'g');
+      const regex = new RegExp(escapeRegex(pattern), "g");
 
       let match;
       let count = 0;
       while ((match = regex.exec(fullText)) !== null) {
         count++;
         if (count === occurrence) {
-          return mcpSuccess({ from: match.index, to: match.index + match[0].length, text: match[0] });
+          return mcpSuccess({
+            from: match.index,
+            to: match.index + match[0].length,
+            text: match[0],
+          });
         }
       }
 
-      return mcpError('INVALID_RANGE', `Text "${pattern}" not found (occurrence ${occurrence}, found ${count} total)`);
-    }
+      return mcpError(
+        "INVALID_RANGE",
+        `Text "${pattern}" not found (occurrence ${occurrence}, found ${count} total)`,
+      );
+    }),
   );
 
   server.tool(
-    'tandem_setStatus',
+    "tandem_setStatus",
     'Update Claude status text shown to user (e.g., "Reviewing cost figures..."). Tip: call tandem_checkInbox after completing work to see if the user has responded.',
     {
-      text: z.string().describe('Status text'),
-      focusParagraph: z.number().optional().describe('Index of paragraph Claude is focusing on'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      text: z.string().describe("Status text"),
+      focusParagraph: z.number().optional().describe("Index of paragraph Claude is focusing on"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
-    async ({ text, focusParagraph, documentId }) => {
+    withErrorBoundary("tandem_setStatus", async ({ text, focusParagraph, documentId }) => {
       const current = getCurrentDoc(documentId);
       if (!current) {
-        return mcpSuccess({ status: text, warning: 'No document open — status not broadcast to editor.' });
+        return mcpSuccess({
+          status: text,
+          warning: "No document open — status not broadcast to editor.",
+        });
       }
       const doc = getOrCreateDocument(current.docName);
-      const awarenessMap = doc.getMap('awareness');
-      awarenessMap.set('claude', {
+      const awarenessMap = doc.getMap("awareness");
+      awarenessMap.set("claude", {
         status: text,
         timestamp: Date.now(),
         active: true,
         focusParagraph: focusParagraph ?? null,
       });
       return mcpSuccess({ status: text });
-    }
+    }),
   );
 
   server.tool(
-    'tandem_getContext',
-    'Read content around a range without pulling the full document. Reduces token usage.',
+    "tandem_getContext",
+    "Read content around a range without pulling the full document. Reduces token usage.",
     {
-      from: z.number().describe('Start position'),
-      to: z.number().describe('End position'),
-      windowSize: z.number().optional().describe('Characters of context before/after (default 500)'),
-      documentId: z.string().optional().describe('Target document ID (defaults to active document)'),
+      from: z.number().describe("Start position"),
+      to: z.number().describe("End position"),
+      windowSize: z
+        .number()
+        .optional()
+        .describe("Characters of context before/after (default 500)"),
+      documentId: z
+        .string()
+        .optional()
+        .describe("Target document ID (defaults to active document)"),
     },
-    async ({ from, to, windowSize = 500, documentId }) => {
+    withErrorBoundary("tandem_getContext", async ({ from, to, windowSize = 500, documentId }) => {
       const current = getCurrentDoc(documentId);
       if (!current) return noDocumentError();
 
@@ -116,6 +148,6 @@ export function registerNavigationTools(server: McpServer): void {
         contextRange: { from: contextStart, to: contextEnd },
         selectionRange: { from, to },
       });
-    }
+    }),
   );
 }

--- a/src/server/mcp/response.ts
+++ b/src/server/mcp/response.ts
@@ -4,13 +4,13 @@
  */
 
 type McpToolResult = {
-  content: Array<{ type: 'text'; text: string }>;
+  content: Array<{ type: "text"; text: string }>;
 };
 
 /** Wrap a successful response in the MCP content envelope */
 export function mcpSuccess<T>(data: T): McpToolResult {
   return {
-    content: [{ type: 'text' as const, text: JSON.stringify({ error: false, data }) }],
+    content: [{ type: "text" as const, text: JSON.stringify({ error: false, data }) }],
   };
 }
 
@@ -18,16 +18,21 @@ export function mcpSuccess<T>(data: T): McpToolResult {
 export function mcpError(
   code: string,
   message: string,
-  details?: Record<string, unknown>
+  details?: Record<string, unknown>,
 ): McpToolResult {
   return {
-    content: [{ type: 'text' as const, text: JSON.stringify({ error: true, code, message, ...(details && { details }) }) }],
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ error: true, code, message, ...(details && { details }) }),
+      },
+    ],
   };
 }
 
 /** Standard NO_DOCUMENT error — returned when a tool requires an open document */
 export function noDocumentError(): McpToolResult {
-  return mcpError('NO_DOCUMENT', 'No document is open. Call tandem_open first.');
+  return mcpError("NO_DOCUMENT", "No document is open. Call tandem_open first.");
 }
 
 /** Extract a human-readable message from an unknown error */
@@ -35,7 +40,24 @@ export function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+/** Wrap an MCP tool handler with a try/catch that returns a structured error.
+ *  Catches unexpected throws so Claude gets a useful error message instead of
+ *  a generic SDK-level JSON-RPC error. */
+export function withErrorBoundary<TArgs extends Record<string, unknown>>(
+  toolName: string,
+  handler: (args: TArgs) => Promise<McpToolResult>,
+): (args: TArgs) => Promise<McpToolResult> {
+  return async (args: TArgs) => {
+    try {
+      return await handler(args);
+    } catch (err) {
+      console.error(`[Tandem] Tool ${toolName} threw:`, err);
+      return mcpError("INTERNAL_ERROR", `${toolName} failed: ${getErrorMessage(err)}`);
+    }
+  };
+}
+
 /** Escape a string for use as a literal in a RegExp */
 export function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/tests/server/response.test.ts
+++ b/tests/server/response.test.ts
@@ -1,122 +1,171 @@
-import { describe, it, expect } from 'vitest';
-import { mcpSuccess, mcpError, noDocumentError, getErrorMessage, escapeRegex } from '../../src/server/mcp/response.js';
+import { describe, it, expect } from "vitest";
+import {
+  mcpSuccess,
+  mcpError,
+  noDocumentError,
+  getErrorMessage,
+  escapeRegex,
+  withErrorBoundary,
+} from "../../src/server/mcp/response.js";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const parse = (r: any) => JSON.parse(r.content[0].text);
 
-describe('mcpSuccess', () => {
-  it('wraps data in expected content structure', () => {
-    const result = mcpSuccess({ foo: 'bar' });
+describe("mcpSuccess", () => {
+  it("wraps data in expected content structure", () => {
+    const result = mcpSuccess({ foo: "bar" });
     expect(result.content).toHaveLength(1);
-    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].type).toBe("text");
     const parsed = parse(result);
-    expect(parsed).toEqual({ error: false, data: { foo: 'bar' } });
+    expect(parsed).toEqual({ error: false, data: { foo: "bar" } });
   });
 
-  it('handles complex nested objects', () => {
+  it("handles complex nested objects", () => {
     const data = { a: { b: { c: [1, 2, 3] } }, d: true };
     const parsed = parse(mcpSuccess(data));
     expect(parsed.error).toBe(false);
     expect(parsed.data).toEqual(data);
   });
 
-  it('handles null data', () => {
+  it("handles null data", () => {
     const parsed = parse(mcpSuccess(null));
     expect(parsed).toEqual({ error: false, data: null });
   });
 
-  it('handles undefined data', () => {
+  it("handles undefined data", () => {
     const parsed = parse(mcpSuccess(undefined));
     expect(parsed.error).toBe(false);
   });
 });
 
-describe('mcpError', () => {
-  it('includes code and message with error: true', () => {
-    const parsed = parse(mcpError('SOME_CODE', 'something went wrong'));
-    expect(parsed).toEqual({ error: true, code: 'SOME_CODE', message: 'something went wrong' });
+describe("mcpError", () => {
+  it("includes code and message with error: true", () => {
+    const parsed = parse(mcpError("SOME_CODE", "something went wrong"));
+    expect(parsed).toEqual({ error: true, code: "SOME_CODE", message: "something went wrong" });
   });
 
-  it('includes details when provided', () => {
-    const parsed = parse(mcpError('ERR', 'msg', { offset: 42, context: 'test' }));
+  it("includes details when provided", () => {
+    const parsed = parse(mcpError("ERR", "msg", { offset: 42, context: "test" }));
     expect(parsed.error).toBe(true);
-    expect(parsed.details).toEqual({ offset: 42, context: 'test' });
+    expect(parsed.details).toEqual({ offset: 42, context: "test" });
   });
 
-  it('omits details key when not provided', () => {
-    const parsed = parse(mcpError('ERR', 'msg'));
-    expect('details' in parsed).toBe(false);
+  it("omits details key when not provided", () => {
+    const parsed = parse(mcpError("ERR", "msg"));
+    expect("details" in parsed).toBe(false);
   });
 });
 
-describe('noDocumentError', () => {
-  it('uses NO_DOCUMENT code', () => {
+describe("noDocumentError", () => {
+  it("uses NO_DOCUMENT code", () => {
     const parsed = parse(noDocumentError());
-    expect(parsed.code).toBe('NO_DOCUMENT');
+    expect(parsed.code).toBe("NO_DOCUMENT");
   });
 
-  it('message mentions tandem_open', () => {
+  it("message mentions tandem_open", () => {
     const parsed = parse(noDocumentError());
-    expect(parsed.message).toContain('tandem_open');
+    expect(parsed.message).toContain("tandem_open");
   });
 
-  it('has error: true', () => {
+  it("has error: true", () => {
     const parsed = parse(noDocumentError());
     expect(parsed.error).toBe(true);
   });
 });
 
-describe('getErrorMessage', () => {
-  it('extracts message from Error instances', () => {
-    expect(getErrorMessage(new Error('boom'))).toBe('boom');
+describe("getErrorMessage", () => {
+  it("extracts message from Error instances", () => {
+    expect(getErrorMessage(new Error("boom"))).toBe("boom");
   });
 
-  it('stringifies plain strings', () => {
-    expect(getErrorMessage('raw string')).toBe('raw string');
+  it("stringifies plain strings", () => {
+    expect(getErrorMessage("raw string")).toBe("raw string");
   });
 
-  it('stringifies numbers', () => {
-    expect(getErrorMessage(404)).toBe('404');
+  it("stringifies numbers", () => {
+    expect(getErrorMessage(404)).toBe("404");
   });
 
-  it('stringifies objects', () => {
-    expect(getErrorMessage({ code: 1 })).toBe('[object Object]');
+  it("stringifies objects", () => {
+    expect(getErrorMessage({ code: 1 })).toBe("[object Object]");
   });
 
-  it('stringifies null', () => {
-    expect(getErrorMessage(null)).toBe('null');
+  it("stringifies null", () => {
+    expect(getErrorMessage(null)).toBe("null");
   });
 });
 
-describe('escapeRegex', () => {
-  it('escapes all regex metacharacters', () => {
-    const meta = '.*+?^${}()|[]\\';
+describe("escapeRegex", () => {
+  it("escapes all regex metacharacters", () => {
+    const meta = ".*+?^${}()|[]\\";
     const escaped = escapeRegex(meta);
     expect(() => new RegExp(escaped)).not.toThrow();
-    expect(escaped).toContain('\\.');
-    expect(escaped).toContain('\\*');
-    expect(escaped).toContain('\\+');
-    expect(escaped).toContain('\\?');
-    expect(escaped).toContain('\\^');
-    expect(escaped).toContain('\\$');
-    expect(escaped).toContain('\\(');
-    expect(escaped).toContain('\\)');
-    expect(escaped).toContain('\\|');
-    expect(escaped).toContain('\\[');
-    expect(escaped).toContain('\\\\');
+    expect(escaped).toContain("\\.");
+    expect(escaped).toContain("\\*");
+    expect(escaped).toContain("\\+");
+    expect(escaped).toContain("\\?");
+    expect(escaped).toContain("\\^");
+    expect(escaped).toContain("\\$");
+    expect(escaped).toContain("\\(");
+    expect(escaped).toContain("\\)");
+    expect(escaped).toContain("\\|");
+    expect(escaped).toContain("\\[");
+    expect(escaped).toContain("\\\\");
   });
 
-  it('leaves alphanumeric and whitespace untouched', () => {
-    expect(escapeRegex('Hello World 123')).toBe('Hello World 123');
+  it("leaves alphanumeric and whitespace untouched", () => {
+    expect(escapeRegex("Hello World 123")).toBe("Hello World 123");
   });
 
-  it('handles empty string', () => {
-    expect(escapeRegex('')).toBe('');
+  it("handles empty string", () => {
+    expect(escapeRegex("")).toBe("");
   });
 
-  it('handles string that is entirely metacharacters', () => {
-    const all = '.*+?^${}()|[]\\';
+  it("handles string that is entirely metacharacters", () => {
+    const all = ".*+?^${}()|[]\\";
     const escaped = escapeRegex(all);
     expect(() => new RegExp(escaped)).not.toThrow();
     expect(escaped.length).toBeGreaterThan(all.length);
+  });
+});
+
+describe("withErrorBoundary", () => {
+  it("passes through successful results unchanged", async () => {
+    const handler = withErrorBoundary("test_tool", async () => mcpSuccess({ ok: true }));
+    const result = await handler({});
+    const parsed = parse(result);
+    expect(parsed.error).toBe(false);
+    expect(parsed.data).toEqual({ ok: true });
+  });
+
+  it("catches thrown errors and returns INTERNAL_ERROR", async () => {
+    const handler = withErrorBoundary("test_tool", async () => {
+      throw new Error("kaboom");
+    });
+    const result = await handler({});
+    const parsed = parse(result);
+    expect(parsed.error).toBe(true);
+    expect(parsed.code).toBe("INTERNAL_ERROR");
+    expect(parsed.message).toContain("test_tool");
+    expect(parsed.message).toContain("kaboom");
+  });
+
+  it("catches non-Error throws", async () => {
+    const handler = withErrorBoundary("test_tool", async () => {
+      throw "string error";
+    });
+    const result = await handler({});
+    const parsed = parse(result);
+    expect(parsed.error).toBe(true);
+    expect(parsed.message).toContain("string error");
+  });
+
+  it("forwards arguments to the wrapped handler", async () => {
+    const handler = withErrorBoundary("test_tool", async (args: { x: number }) => {
+      return mcpSuccess({ doubled: args.x * 2 });
+    });
+    const result = await handler({ x: 21 });
+    const parsed = parse(result);
+    expect(parsed.data.doubled).toBe(42);
   });
 });


### PR DESCRIPTION
## Summary
- Added `withErrorBoundary()` wrapper in `response.ts` that catches unexpected throws and returns a structured `INTERNAL_ERROR` mcpError response
- Wrapped all 26 MCP tool handlers across `annotations.ts`, `awareness.ts`, `navigation.ts`, and `document.ts`
- Previously, unhandled exceptions in most handlers propagated as generic SDK-level JSON-RPC errors invisible to Claude — now Claude gets a useful error message with the tool name and error details

## Details
- `tandem_open` and `tandem_save` already had inner try/catch for known errors (ENOENT, EPERM, etc.); the outer boundary catches anything they miss
- `tandem_checkInbox`'s `Y.Doc.transact()` is safely inside the boundary — a throw won't leave the doc inconsistent since the catch is outside the transact
- Global `uncaughtException`/`unhandledRejection` handlers in `index.ts` remain unchanged — they're a last resort for Hocuspocus WS errors, not a substitute for tool-level boundaries

## Test plan
- [x] 4 new tests for `withErrorBoundary` (success passthrough, Error catch, non-Error catch, argument forwarding)
- [x] All 291 tests pass (287 existing + 4 new)
- [x] Pre-commit hooks pass

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)