### PR TITLE
fix(save): discriminate error types in tandem_save catch block

### DIFF
--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -413,7 +413,11 @@ export function registerDocumentTools(server: McpServer): void {
         await saveSession(r.filePath, format, r.doc);
         return mcpSuccess({ saved: true, filePath: r.filePath });
       } catch (err: unknown) {
-        return mcpError("FILE_LOCKED", getErrorMessage(err));
+        const errCode = (err as NodeJS.ErrnoException).code;
+        if (errCode === "EACCES" || errCode === "EPERM") {
+          return mcpError("FILE_LOCKED", getErrorMessage(err));
+        }
+        return mcpError("FORMAT_ERROR", `Save failed: ${getErrorMessage(err)}`);
       }
     }),
   );


### PR DESCRIPTION
## Summary
- Only `EACCES`/`EPERM` errno codes map to `FILE_LOCKED` — these are actual OS-level permission/lock errors
- All other errors return `FORMAT_ERROR` with a descriptive `Save failed: <message>` instead of the misleading `FILE_LOCKED`

Closes #70

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 617 tests pass
- [ ] Manual: trigger a save on a corrupt/missing format adapter and verify the error message is descriptive, not `FILE_LOCKED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)