### PR TITLE
refactor(types): move DocumentRange/RelativeRange to shared/positions

### DIFF
--- a/src/client/positions.ts
+++ b/src/client/positions.ts
@@ -16,7 +16,8 @@
 
 import type { Node as PmNode } from "@tiptap/pm/model";
 import * as Y from "yjs";
-import type { Annotation, RelativeRange, DocumentRange } from "../shared/types";
+import type { Annotation } from "../shared/types";
+import type { DocumentRange, RelativeRange } from "../shared/positions/types";
 import type { PmRangeResult } from "../shared/positions/index";
 import { headingPrefixLength } from "../shared/offsets";
 

--- a/src/server/positions.ts
+++ b/src/server/positions.ts
@@ -17,8 +17,10 @@
  */
 
 import * as Y from "yjs";
-import type { Annotation, DocumentRange, RelativeRange } from "../shared/types.js";
+import type { Annotation } from "../shared/types.js";
 import type {
+  DocumentRange,
+  RelativeRange,
   RangeValidation,
   AnchoredRangeResult,
   ElementPosition,

--- a/src/shared/positions/index.ts
+++ b/src/shared/positions/index.ts
@@ -1,4 +1,6 @@
 export type {
+  DocumentRange,
+  RelativeRange,
   RangeValidation,
   AnchoredRangeResult,
   ElementPosition,

--- a/src/shared/positions/types.ts
+++ b/src/shared/positions/types.ts
@@ -11,7 +11,17 @@
  *   - src/client/positions.ts (ProseMirror operations)
  */
 
-import type { DocumentRange, RelativeRange } from "../types.js";
+/** Flat-offset range used by MCP tools and annotations. */
+export interface DocumentRange {
+  from: number;
+  to: number;
+}
+
+/** CRDT-anchored range that survives concurrent edits. Serialized via Y.relativePositionToJSON(). */
+export interface RelativeRange {
+  fromRel: unknown;
+  toRel: unknown;
+}
 
 /** Result of validating a flat-offset range against a document. */
 export type RangeValidation =

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import type { DocumentRange, RelativeRange } from "./positions/types.js";
+
+// Canonical definitions live in the positions module; re-exported for backward compatibility.
+export type { DocumentRange, RelativeRange } from "./positions/types.js";
 
 // --- Zod schemas (source of truth) ---
 
@@ -52,17 +56,6 @@ export interface Annotation {
   timestamp: number;
   color?: HighlightColor;
   priority?: AnnotationPriority;
-}
-
-export interface DocumentRange {
-  from: number;
-  to: number;
-}
-
-/** CRDT-anchored range that survives concurrent edits. Serialized via Y.relativePositionToJSON(). */
-export interface RelativeRange {
-  fromRel: unknown;
-  toRel: unknown;
 }
 
 export interface AnchoredRange {


### PR DESCRIPTION
## Summary
- Move `DocumentRange` and `RelativeRange` definitions from `src/shared/types.ts` to `src/shared/positions/types.ts` where they belong
- Re-export from `src/shared/types.ts` for backward compatibility
- Update direct importers (`server/positions.ts`, `client/positions.ts`) to use canonical path
- Add to `positions/index.ts` barrel export

Closes #71

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 617 tests pass
- [x] No circular imports introduced (verified: positions/types.ts no longer imports from shared/types.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)