### PR TITLE
refactor(positions): split RANGE_STALE and type AnchoredRangeResult

### DIFF
--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -16,7 +16,7 @@ import {
   ExportFormatSchema,
 } from "../../shared/types.js";
 import { anchoredRange, refreshAllRanges } from "../positions.js";
-import type { RangeValidation } from "../../shared/positions/index.js";
+import type { RangeValidation, AnchoredRangeResult } from "../../shared/positions/index.js";
 
 /** Get the Y.Doc and annotations Y.Map for a document, or null if no doc is open */
 function getDocAndAnnotations(documentId?: string): { ydoc: Y.Doc; map: Y.Map<unknown> } | null {
@@ -28,11 +28,11 @@ function getDocAndAnnotations(documentId?: string): { ydoc: Y.Doc; map: Y.Map<un
 
 /** Convert an anchoredRange validation failure to an MCP error response. */
 function rangeFailureToError(result: Extract<RangeValidation, { ok: false }>) {
-  if (result.code === "RANGE_STALE") {
-    if (result.gone) {
-      return mcpError("RANGE_STALE", "Target text no longer exists in the document.");
-    }
-    return mcpError("RANGE_STALE", "Target text has moved. Use resolvedFrom/resolvedTo to retry.", {
+  if (result.code === "RANGE_GONE") {
+    return mcpError("RANGE_GONE", "Target text no longer exists in the document.");
+  }
+  if (result.code === "RANGE_MOVED") {
+    return mcpError("RANGE_MOVED", "Target text has moved. Use resolvedFrom/resolvedTo to retry.", {
       resolvedFrom: result.resolvedFrom,
       resolvedTo: result.resolvedTo,
     });
@@ -54,10 +54,7 @@ export { generateId };
 export function createAnnotation(
   map: Y.Map<unknown>,
   type: AnnotationType,
-  anchored: {
-    range: { from: number; to: number };
-    relRange?: { fromRel: unknown; toRel: unknown };
-  },
+  anchored: AnchoredRangeResult,
   content: string,
   extras?: Partial<Annotation>,
 ): string {
@@ -107,7 +104,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
+          "Expected text at [from, to] — returns RANGE_MOVED with relocated range on mismatch, or RANGE_GONE if text was deleted",
         ),
     },
     withErrorBoundary(
@@ -144,7 +141,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
+          "Expected text at [from, to] — returns RANGE_MOVED with relocated range on mismatch, or RANGE_GONE if text was deleted",
         ),
     },
     withErrorBoundary(
@@ -179,7 +176,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
+          "Expected text at [from, to] — returns RANGE_MOVED with relocated range on mismatch, or RANGE_GONE if text was deleted",
         ),
     },
     withErrorBoundary(
@@ -219,7 +216,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
+          "Expected text at [from, to] — returns RANGE_MOVED with relocated range on mismatch, or RANGE_GONE if text was deleted",
         ),
     },
     withErrorBoundary(

--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -144,7 +144,7 @@ export function getHeadingPrefixLength(node: Y.XmlElement): number {
   return 0;
 }
 
-// -- RANGE_STALE detection ---------------------------------------------------
+// -- Range staleness detection ------------------------------------------------
 
 export type RangeVerifyResult =
   | { valid: true }

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -273,7 +273,7 @@ export function registerDocumentTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          "Expected text at [from, to] — returns RANGE_STALE with relocated range on mismatch",
+          "Expected text at [from, to] — returns RANGE_MOVED with relocated range on mismatch, or RANGE_GONE if text was deleted",
         ),
     },
     withErrorBoundary("tandem_edit", async ({ from, to, newText, documentId, textSnapshot }) => {
@@ -290,12 +290,12 @@ export function registerDocumentTools(server: McpServer): void {
         rejectHeadingOverlap: true,
       });
       if (!v.ok) {
-        if (v.code === "RANGE_STALE") {
-          if (v.gone) {
-            return mcpError("RANGE_STALE", "Target text no longer exists in the document.");
-          }
+        if (v.code === "RANGE_GONE") {
+          return mcpError("RANGE_GONE", "Target text no longer exists in the document.");
+        }
+        if (v.code === "RANGE_MOVED") {
           return mcpError(
-            "RANGE_STALE",
+            "RANGE_MOVED",
             "Target text has moved. Use resolvedFrom/resolvedTo to retry.",
             { resolvedFrom: v.resolvedFrom, resolvedTo: v.resolvedTo },
           );

--- a/src/server/positions.ts
+++ b/src/server/positions.ts
@@ -191,13 +191,12 @@ export function validateRange(
         searchFrom = idx + 1;
       }
       if (candidates.length === 0) {
-        return { ok: false, code: "RANGE_STALE", gone: true };
+        return { ok: false, code: "RANGE_GONE" };
       }
       const best = candidates.reduce((a, b) => (Math.abs(a - from) <= Math.abs(b - from) ? a : b));
       return {
         ok: false,
-        code: "RANGE_STALE",
-        gone: false,
+        code: "RANGE_MOVED",
         resolvedFrom: best,
         resolvedTo: best + opts.textSnapshot.length,
       };
@@ -257,7 +256,10 @@ export function anchoredRange(
     }
   }
 
-  return { ok: true, range, relRange };
+  if (relRange) {
+    return { ok: true, fullyAnchored: true, range, relRange };
+  }
+  return { ok: true, fullyAnchored: false, range };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/positions/types.ts
+++ b/src/shared/positions/types.ts
@@ -26,17 +26,15 @@ export interface RelativeRange {
 /** Result of validating a flat-offset range against a document. */
 export type RangeValidation =
   | { ok: true; range: DocumentRange }
-  | { ok: false; code: "RANGE_STALE"; gone: true }
-  | { ok: false; code: "RANGE_STALE"; gone: false; resolvedFrom: number; resolvedTo: number }
+  | { ok: false; code: "RANGE_GONE" }
+  | { ok: false; code: "RANGE_MOVED"; resolvedFrom: number; resolvedTo: number }
   | { ok: false; code: "INVALID_RANGE"; message: string }
   | { ok: false; code: "HEADING_OVERLAP" };
 
 /** Result of anchoredRange: validated flat + CRDT-anchored range ready to store on an Annotation. */
-export interface AnchoredRangeResult {
-  ok: true;
-  range: DocumentRange;
-  relRange?: RelativeRange;
-}
+export type AnchoredRangeResult =
+  | { ok: true; fullyAnchored: true; range: DocumentRange; relRange: RelativeRange }
+  | { ok: true; fullyAnchored: false; range: DocumentRange; relRange?: undefined };
 
 /** A resolved element position inside a Y.Doc XmlFragment. */
 export interface ElementPosition {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -24,7 +24,8 @@ export const AnnotationActionSchema = z.enum(["accept", "dismiss"]);
 export const ExportFormatSchema = z.enum(["markdown", "json"]);
 export const DocumentFormatSchema = z.enum(["md", "txt", "html", "docx"]);
 export const ToolErrorCodeSchema = z.enum([
-  "RANGE_STALE",
+  "RANGE_GONE",
+  "RANGE_MOVED",
   "FILE_LOCKED",
   "FILE_NOT_FOUND",
   "NO_DOCUMENT",

--- a/tests/server/positions.test.ts
+++ b/tests/server/positions.test.ts
@@ -45,8 +45,8 @@ describe("validateRange", () => {
     const result = validateRange(doc, 0, 5, { textSnapshot: "hello" });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.code).toBe("RANGE_STALE");
-      if (!result.gone) {
+      expect(result.code).toBe("RANGE_MOVED");
+      if (result.code === "RANGE_MOVED") {
         expect(result.resolvedFrom).toBe(3);
         expect(result.resolvedTo).toBe(8);
       }
@@ -65,8 +65,7 @@ describe("validateRange", () => {
     const result = validateRange(doc, 0, 5, { textSnapshot: "hello" });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.code).toBe("RANGE_STALE");
-      expect(result.gone).toBe(true);
+      expect(result.code).toBe("RANGE_GONE");
     }
   });
 
@@ -122,7 +121,7 @@ describe("anchoredRange", () => {
 
     const result = anchoredRange(doc, 0, 5, "hello");
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.code).toBe("RANGE_STALE");
+    if (!result.ok) expect(result.code).toBe("RANGE_MOVED");
   });
 
   it("omits relRange when offset is in heading prefix", () => {


### PR DESCRIPTION
## Summary
- **RANGE_STALE → RANGE_GONE + RANGE_MOVED**: The overloaded `RANGE_STALE` error code is split into two distinct codes. `RANGE_GONE` means the target text was deleted (no recovery). `RANGE_MOVED` means it relocated (provides `resolvedFrom`/`resolvedTo` for retry). Callers no longer need a secondary `gone` flag.
- **AnchoredRangeResult discriminated union**: Changed from an interface with optional `relRange` to a discriminated union on `fullyAnchored: true/false`. Makes the "degraded without CRDT anchors" case explicit.
- **createAnnotation typed**: Uses `AnchoredRangeResult` by name instead of a structural type.
- **ToolErrorCodeSchema updated**: `RANGE_STALE` removed, `RANGE_GONE` and `RANGE_MOVED` added.
- **Tool descriptions updated**: All 5 tools that mention stale ranges now document both error codes.

Note: `resolveOffset`/`verifyAndResolveRange` re-exports from `document.ts` kept — tests still import them. Not dead after all.

Issue #76 (branded types) deferred to a separate PR — scope is significantly larger than the cleanup work here.

Closes #77

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 617 tests pass
- [x] Grep confirms zero `RANGE_STALE` references in `src/`
- [ ] Manual: trigger a stale range via `tandem_edit` and verify `RANGE_MOVED`/`RANGE_GONE` codes appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)