### PR TITLE
fix(server): serve RFC 9728 metadata for MCP OAuth discovery

### DIFF
--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -195,6 +195,29 @@ export async function startMcpServerHttp(port: number, host = "127.0.0.1"): Prom
     res.json({ status: "ok", transport: "http", hasSession: currentTransport !== null });
   });
 
+  // RFC 9728 Protected Resource Metadata — declares no auth required.
+  // Newer Claude Code versions probe this before connecting to MCP.
+  app.get(
+    "/.well-known/oauth-protected-resource/mcp",
+    (_req: import("express").Request, res: import("express").Response) => {
+      res.header("Access-Control-Allow-Origin", "*");
+      res.json({
+        resource: `http://localhost:${port}/mcp`,
+        bearer_methods_supported: [],
+      });
+    },
+  );
+  app.get(
+    "/.well-known/oauth-protected-resource",
+    (_req: import("express").Request, res: import("express").Response) => {
+      res.header("Access-Control-Allow-Origin", "*");
+      res.json({
+        resource: `http://localhost:${port}/mcp`,
+        bearer_methods_supported: [],
+      });
+    },
+  );
+
   // Mount SDK app (handles /mcp, /health with 100kb body parser)
   app.use(mcpApp);
 


### PR DESCRIPTION
## Summary
- Newer Claude Code versions probe `/.well-known/oauth-protected-resource` (RFC 9728) before connecting to MCP HTTP servers. Without this endpoint, the client can't determine the server's auth posture and only offers "authenticate" instead of listing tools.
- Adds two GET routes on the outer Express app serving minimal Protected Resource Metadata with empty `bearer_methods_supported`, declaring no auth is required.
- Both the path-aware (`/.well-known/oauth-protected-resource/mcp`) and root fallback (`/.well-known/oauth-protected-resource`) endpoints are handled.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (617 tests)
- [ ] `curl http://localhost:3479/.well-known/oauth-protected-resource/mcp` returns `{"resource":"http://localhost:3479/mcp","bearer_methods_supported":[]}`
- [ ] `/mcp` in Claude Code shows tools (not just "authenticate")
- [ ] Verify on second machine where the issue was observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)