### PR TITLE
fix(ui): infer urgency for flag/question annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Three layers: Browser (Tiptap) <-> Tandem Server (Hocuspocus + MCP) <-> Claude C
 - AnnotationExtension renders highlights/comments/suggestions as ProseMirror Decorations
 - AwarenessExtension renders Claude's focus paragraph + broadcasts user selection to Y.Map('userAwareness')
 - SidePanel: annotation filtering (type/author/status), bulk accept/dismiss, keyboard review mode (Tab/Y/N)
+- StatusBar: connection status, Claude activity, interruption mode selector (All/Urgent/Paused). Urgent-only mode shows flags, questions, and explicitly `priority: 'urgent'` annotations; hides comments, highlights, and suggestions.
 - ReviewSummary overlay shown when all pending annotations are resolved
 
 ### Shared (src/shared/)

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -392,7 +392,7 @@ Flag a text range for attention (e.g., issues, concerns, or items needing review
 | `to` | number | Yes | End position (character offset) |
 | `note` | string | No | Reason for flagging |
 | `documentId` | string | No | Target document ID (defaults to active document) |
-| `priority` | `'normal'` \| `'urgent'` | No | Annotation priority — urgent bypasses Hold mode |
+| `priority` | `'normal'` \| `'urgent'` | No | Annotation priority. Set to 'urgent' for critical issues visible in urgent-only mode. Flags and questions are implicitly urgent. |
 | `textSnapshot` | string | No | Expected text at range — returns RANGE_STALE if moved |
 
 **Returns:** `{ annotationId: string }`

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -217,6 +217,16 @@ When all annotations are resolved, a **Review Summary** overlay appears showing:
 
 For bulk operations, use **Accept All** or **Dismiss All** buttons in the side panel header.
 
+### Interruption Modes
+
+The status bar includes an interruption mode selector with three settings:
+
+- **All** — Show all annotations immediately (default)
+- **Urgent** — Only show flags, questions, and annotations with `priority: 'urgent'`. Comments, highlights, and suggestions are held until the mode changes. The held count appears in the status bar.
+- **Paused** — Hold all new pending annotations. Resolved annotations (accepted/dismissed) are always visible regardless of mode.
+
+This lets Bryan control how aggressively Claude's annotations interrupt the editing flow. During focused writing, switch to Paused; when ready to review, switch back to All.
+
 ## Session Handoff
 
 **What persists** across server restarts (via session persistence):

--- a/src/client/hooks/useAnnotationGate.ts
+++ b/src/client/hooks/useAnnotationGate.ts
@@ -1,14 +1,16 @@
-import { useMemo } from 'react';
-import type { Annotation, InterruptionMode } from '../../shared/types';
+import { useMemo } from "react";
+import type { Annotation, InterruptionMode } from "../../shared/types";
 
 /**
  * Pure function: should an annotation be shown given the current mode?
  * Resolved annotations are always visible.
  */
 export function shouldShow(ann: Annotation, mode: InterruptionMode): boolean {
-  if (ann.status !== 'pending') return true;
-  if (mode === 'all') return true;
-  if (mode === 'urgent-only') return ann.priority === 'urgent';
+  if (ann.status !== "pending") return true;
+  if (mode === "all") return true;
+  if (mode === "urgent-only") {
+    return ann.priority === "urgent" || ann.type === "flag" || ann.type === "question";
+  }
   return false; // paused
 }
 
@@ -19,7 +21,7 @@ export function useAnnotationGate(annotations: Annotation[], mode: InterruptionM
     for (const a of annotations) {
       if (shouldShow(a, mode)) {
         visibleAnnotations.push(a);
-      } else if (a.status === 'pending') {
+      } else if (a.status === "pending") {
         heldCount++;
       }
     }

--- a/src/client/status/StatusBar.tsx
+++ b/src/client/status/StatusBar.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { CLAUDE_PRESENCE_COLOR } from '../../shared/constants';
-import type { InterruptionMode } from '../../shared/types';
+import React, { useEffect, useRef, useState } from "react";
+import { CLAUDE_PRESENCE_COLOR } from "../../shared/constants";
+import type { InterruptionMode } from "../../shared/types";
 
 interface StatusBarProps {
   connected: boolean;
@@ -14,9 +14,13 @@ interface StatusBarProps {
 }
 
 const MODES: { value: InterruptionMode; label: string; title: string }[] = [
-  { value: 'all', label: 'All', title: 'Show all annotations immediately' },
-  { value: 'urgent-only', label: 'Urgent', title: 'Only show urgent annotations' },
-  { value: 'paused', label: 'Paused', title: 'Hold all new annotations' },
+  { value: "all", label: "All", title: "Show all annotations immediately" },
+  {
+    value: "urgent-only",
+    label: "Urgent",
+    title: "Show flags, questions, and explicitly urgent annotations",
+  },
+  { value: "paused", label: "Paused", title: "Hold all new annotations" },
 ];
 
 const RECONNECTED_FLASH_MS = 2_000;
@@ -55,61 +59,90 @@ export function StatusBar({
   }, [connected]);
 
   const isReconnecting = !connected && disconnectedAt.current !== null;
-  const dotColor = connected ? '#22c55e' : isReconnecting ? '#eab308' : '#ef4444';
-  const connLabel = showReconnectedFlash ? 'Reconnected' : connected ? 'Connected' : isReconnecting ? 'Reconnecting\u2026' : 'Disconnected';
+  const dotColor = connected ? "#22c55e" : isReconnecting ? "#eab308" : "#ef4444";
+  const connLabel = showReconnectedFlash
+    ? "Reconnected"
+    : connected
+      ? "Connected"
+      : isReconnecting
+        ? "Reconnecting\u2026"
+        : "Disconnected";
 
   return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      padding: '4px 16px',
-      height: '28px',
-      borderTop: '1px solid #e5e7eb',
-      background: '#fafafa',
-      fontSize: '12px',
-      color: '#6b7280',
-      userSelect: 'none',
-    }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-        <span style={{
-          width: '8px', height: '8px', borderRadius: '50%',
-          background: dotColor, display: 'inline-block',
-          animation: isReconnecting ? 'tandem-reconnect-pulse 1.2s ease-in-out infinite' : 'none',
-        }} />
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "4px 16px",
+        height: "28px",
+        borderTop: "1px solid #e5e7eb",
+        background: "#fafafa",
+        fontSize: "12px",
+        color: "#6b7280",
+        userSelect: "none",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        <span
+          style={{
+            width: "8px",
+            height: "8px",
+            borderRadius: "50%",
+            background: dotColor,
+            display: "inline-block",
+            animation: isReconnecting ? "tandem-reconnect-pulse 1.2s ease-in-out infinite" : "none",
+          }}
+        />
         <span>{connLabel}</span>
         {showServerBanner && !connected && (
-          <span style={{ color: '#eab308', fontWeight: 500 }}>— check server</span>
+          <span style={{ color: "#eab308", fontWeight: 500 }}>— check server</span>
         )}
         {documentCount > 0 && (
-          <span style={{ color: '#9ca3af' }}>
-            {documentCount} doc{documentCount !== 1 ? 's' : ''} open
+          <span style={{ color: "#9ca3af" }}>
+            {documentCount} doc{documentCount !== 1 ? "s" : ""} open
           </span>
         )}
       </div>
 
       {/* Mode switcher */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
         {heldCount > 0 && (
-          <span style={{
-            padding: '1px 6px', fontSize: '10px', fontWeight: 600,
-            color: '#92400e', background: '#fef3c7', borderRadius: '9999px',
-          }}>
+          <span
+            style={{
+              padding: "1px 6px",
+              fontSize: "10px",
+              fontWeight: 600,
+              color: "#92400e",
+              background: "#fef3c7",
+              borderRadius: "9999px",
+            }}
+          >
             {heldCount} held
           </span>
         )}
-        <div style={{ display: 'flex', border: '1px solid #d1d5db', borderRadius: '4px', overflow: 'hidden' }}>
+        <div
+          style={{
+            display: "flex",
+            border: "1px solid #d1d5db",
+            borderRadius: "4px",
+            overflow: "hidden",
+          }}
+        >
           {MODES.map(({ value, label, title }) => (
             <button
               key={value}
               title={title}
               onClick={() => onModeChange(value)}
               style={{
-                padding: '1px 8px', fontSize: '11px', border: 'none', cursor: 'pointer',
-                background: interruptionMode === value ? '#6366f1' : 'transparent',
-                color: interruptionMode === value ? '#fff' : '#6b7280',
+                padding: "1px 8px",
+                fontSize: "11px",
+                border: "none",
+                cursor: "pointer",
+                background: interruptionMode === value ? "#6366f1" : "transparent",
+                color: interruptionMode === value ? "#fff" : "#6b7280",
                 fontWeight: interruptionMode === value ? 600 : 400,
-                borderRight: value !== 'paused' ? '1px solid #d1d5db' : 'none',
+                borderRight: value !== "paused" ? "1px solid #d1d5db" : "none",
               }}
             >
               {label}
@@ -119,22 +152,37 @@ export function StatusBar({
       </div>
 
       {readOnly && (
-        <span style={{
-          padding: '1px 8px', fontSize: '11px', fontWeight: 600,
-          color: '#92400e', background: '#fef3c7', borderRadius: '9999px', border: '1px solid #fde68a',
-        }}>
+        <span
+          style={{
+            padding: "1px 8px",
+            fontSize: "11px",
+            fontWeight: 600,
+            color: "#92400e",
+            background: "#fef3c7",
+            borderRadius: "9999px",
+            border: "1px solid #fde68a",
+          }}
+        >
           Review Only
         </span>
       )}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-        <span style={{
-          width: '8px', height: '8px', borderRadius: '50%',
-          background: CLAUDE_PRESENCE_COLOR, opacity: claudeActive ? 1 : 0.4,
-          display: 'inline-block', transition: 'opacity 0.3s ease',
-          animation: claudeActive ? 'tandem-status-pulse 1.5s ease-in-out infinite' : 'none',
-        }} />
-        <span style={{ transition: 'color 0.3s ease', color: claudeActive ? '#4b5563' : '#9ca3af' }}>
-          {claudeStatus ? `Claude -- ${claudeStatus}` : 'Claude -- idle'}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        <span
+          style={{
+            width: "8px",
+            height: "8px",
+            borderRadius: "50%",
+            background: CLAUDE_PRESENCE_COLOR,
+            opacity: claudeActive ? 1 : 0.4,
+            display: "inline-block",
+            transition: "opacity 0.3s ease",
+            animation: claudeActive ? "tandem-status-pulse 1.5s ease-in-out infinite" : "none",
+          }}
+        />
+        <span
+          style={{ transition: "color 0.3s ease", color: claudeActive ? "#4b5563" : "#9ca3af" }}
+        >
+          {claudeStatus ? `Claude -- ${claudeStatus}` : "Claude -- idle"}
         </span>
       </div>
       <style>{`

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -98,7 +98,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
       priority: AnnotationPrioritySchema.optional().describe(
-        "Annotation priority — urgent bypasses the Hold interruption mode",
+        "Annotation priority. Set to 'urgent' for critical issues that should be visible even when the user has interruption mode set to urgent-only. Flags and questions are implicitly urgent.",
       ),
       textSnapshot: z
         .string()
@@ -135,7 +135,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
       priority: AnnotationPrioritySchema.optional().describe(
-        "Annotation priority — urgent bypasses the Hold interruption mode",
+        "Annotation priority. Set to 'urgent' for critical issues that should be visible even when the user has interruption mode set to urgent-only. Flags and questions are implicitly urgent.",
       ),
       textSnapshot: z
         .string()
@@ -170,7 +170,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
       priority: AnnotationPrioritySchema.optional().describe(
-        "Annotation priority — urgent bypasses the Hold interruption mode",
+        "Annotation priority. Set to 'urgent' for critical issues that should be visible even when the user has interruption mode set to urgent-only. Flags and questions are implicitly urgent.",
       ),
       textSnapshot: z
         .string()
@@ -210,7 +210,7 @@ export function registerAnnotationTools(server: McpServer): void {
         .optional()
         .describe("Target document ID (defaults to active document)"),
       priority: AnnotationPrioritySchema.optional().describe(
-        "Annotation priority — urgent bypasses the Hold interruption mode",
+        "Annotation priority. Set to 'urgent' for critical issues that should be visible even when the user has interruption mode set to urgent-only. Flags and questions are implicitly urgent.",
       ),
       textSnapshot: z
         .string()

--- a/tests/client/annotation-gate.test.ts
+++ b/tests/client/annotation-gate.test.ts
@@ -54,13 +54,39 @@ describe("shouldShow", () => {
   });
 
   describe('mode = "urgent-only"', () => {
-    it("hides pending normal-priority annotations", () => {
-      expect(shouldShow(makeAnnotation({ status: "pending" }), "urgent-only")).toBe(false);
+    it("hides pending comment annotations without priority", () => {
+      expect(
+        shouldShow(makeAnnotation({ status: "pending", type: "comment" }), "urgent-only"),
+      ).toBe(false);
+    });
+
+    it("hides pending highlight annotations without priority", () => {
+      expect(
+        shouldShow(makeAnnotation({ status: "pending", type: "highlight" }), "urgent-only"),
+      ).toBe(false);
+    });
+
+    it("hides pending suggestion annotations without priority", () => {
+      expect(
+        shouldShow(makeAnnotation({ status: "pending", type: "suggestion" }), "urgent-only"),
+      ).toBe(false);
     });
 
     it("shows pending urgent-priority annotations", () => {
       expect(
         shouldShow(makeAnnotation({ status: "pending", priority: "urgent" }), "urgent-only"),
+      ).toBe(true);
+    });
+
+    it("shows pending flag annotations (implicitly urgent)", () => {
+      expect(shouldShow(makeAnnotation({ status: "pending", type: "flag" }), "urgent-only")).toBe(
+        true,
+      );
+    });
+
+    it("shows pending question annotations (implicitly urgent)", () => {
+      expect(
+        shouldShow(makeAnnotation({ status: "pending", type: "question" }), "urgent-only"),
       ).toBe(true);
     });
 
@@ -104,9 +130,8 @@ describe("shouldShow", () => {
   });
 
   describe("edge cases", () => {
-    it("annotations without explicit priority are treated as normal", () => {
-      const ann = makeAnnotation({ status: "pending" });
-      // No priority field set → should be hidden in urgent-only
+    it("comment annotations without explicit priority are hidden in urgent-only", () => {
+      const ann = makeAnnotation({ status: "pending", type: "comment" });
       expect(shouldShow(ann, "urgent-only")).toBe(false);
     });
 
@@ -133,13 +158,25 @@ describe("gateAnnotations (useAnnotationGate hook logic)", () => {
 
   it("holds non-urgent pending in 'urgent-only' mode", () => {
     const anns = [
-      makeAnnotation({ id: "a1", status: "pending" }), // normal → held
-      makeAnnotation({ id: "a2", status: "pending", priority: "urgent" }), // urgent → visible
+      makeAnnotation({ id: "a1", status: "pending", type: "comment" }), // comment → held
+      makeAnnotation({ id: "a2", status: "pending", priority: "urgent" }), // explicit urgent → visible
       makeAnnotation({ id: "a3", status: "accepted" }), // resolved → visible
     ];
     const result = gateAnnotations(anns, "urgent-only");
     expect(result.visibleAnnotations).toHaveLength(2);
     expect(result.heldCount).toBe(1);
+  });
+
+  it("shows flags and questions in 'urgent-only' mode (implicitly urgent)", () => {
+    const anns = [
+      makeAnnotation({ id: "a1", status: "pending", type: "flag" }), // flag → visible
+      makeAnnotation({ id: "a2", status: "pending", type: "question" }), // question → visible
+      makeAnnotation({ id: "a3", status: "pending", type: "comment" }), // comment → held
+      makeAnnotation({ id: "a4", status: "pending", type: "highlight" }), // highlight → held
+    ];
+    const result = gateAnnotations(anns, "urgent-only");
+    expect(result.visibleAnnotations).toHaveLength(2);
+    expect(result.heldCount).toBe(2);
   });
 
   it("holds all pending in 'paused' mode", () => {


### PR DESCRIPTION
## Summary
- Urgent-only interruption mode now shows flags, questions, and `priority: 'urgent'` annotations
- Comments, highlights, and suggestions are hidden unless explicitly marked urgent
- Updated MCP tool descriptions to guide Claude on when to set `priority: 'urgent'`
- StatusBar tooltip updated to reflect new behavior

## Changes
- `useAnnotationGate.ts`: `shouldShow()` treats `type === 'flag'` and `type === 'question'` as implicitly urgent
- `StatusBar.tsx`: tooltip for Urgent mode explains what qualifies
- `annotations.ts` (server): priority field description updated for all 4 annotation tools
- `docs/workflows.md`: new Interruption Modes section
- `docs/mcp-tools.md`: priority field description updated
- `CLAUDE.md`: StatusBar behavior documented
- 5 new tests, 29 total in annotation-gate suite

## Test plan
- [x] `npm run typecheck` — zero errors
- [x] 622 tests pass (5 new)
- [ ] Manual: toggle to Urgent mode, verify flags/questions visible, comments hidden
- [ ] Manual: toggle back to All, verify everything visible

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)