### PR TITLE
feat(ui): add help modal with keyboard shortcuts reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Three layers: Browser (Tiptap) <-> Tandem Server (Hocuspocus + MCP) <-> Claude C
 - `DocListEntry` and `OpenTab` types live in `src/client/types.ts`
 - DocumentTabs shows tab bar + "+" button (FileOpenDialog); tab switching passes different ydoc/provider to Editor (key-based remount)
 - FileOpenDialog (src/client/components/) provides path input and drag-and-drop upload for opening files without Claude
+- HelpModal (src/client/components/) shows keyboard shortcuts reference, toggled by `?` (suppressed in text inputs)
 - Annotations observed from Y.Map('annotations') on the active tab's Y.Doc
 - AnnotationExtension renders highlights/comments/suggestions as ProseMirror Decorations
 - AwarenessExtension renders Claude's focus paragraph + broadcasts user selection to Y.Map('userAwareness')

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -7,6 +7,7 @@ import { StatusBar } from "./status/StatusBar";
 import { Toolbar } from "./editor/toolbar/Toolbar";
 import { DocumentTabs } from "./tabs/DocumentTabs";
 import { ReviewSummary } from "./panels/ReviewSummary";
+import { HelpModal } from "./components/HelpModal";
 import {
   INTERRUPTION_MODE_DEFAULT,
   INTERRUPTION_MODE_KEY,
@@ -61,6 +62,7 @@ export default function App() {
   const [showChat, setShowChat] = useState(false);
   const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null);
   const [fileDragOver, setFileDragOver] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
   const editorRef = useRef<TiptapEditor | null>(null);
   const prevPendingRef = useRef<number>(0);
 
@@ -143,6 +145,18 @@ export default function App() {
   const exitReviewMode = useCallback(() => {
     setReviewMode(false);
     setShowBanner(false);
+  }, []);
+
+  // Toggle help modal with '?' — skip when focus is in a text input
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "?") return;
+      const el = e.target as HTMLElement;
+      if (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable) return;
+      setShowHelp((prev) => !prev);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
   }, []);
 
   const activeTab = tabs.find((t) => t.id === activeTabId);
@@ -365,6 +379,7 @@ export default function App() {
           onDismiss={() => setShowReviewSummary(false)}
         />
       )}
+      <HelpModal open={showHelp} onClose={() => setShowHelp(false)} />
     </div>
   );
 }

--- a/src/client/components/HelpModal.tsx
+++ b/src/client/components/HelpModal.tsx
@@ -1,0 +1,239 @@
+import { useEffect } from "react";
+
+interface ShortcutRow {
+  keys: string[];
+  description: string;
+}
+
+interface ShortcutSection {
+  title: string;
+  rows: ShortcutRow[];
+}
+
+const SECTIONS: ShortcutSection[] = [
+  {
+    title: "Editor",
+    rows: [
+      { keys: ["Ctrl", "B"], description: "Bold" },
+      { keys: ["Ctrl", "I"], description: "Italic" },
+      { keys: ["Ctrl", "Z"], description: "Undo" },
+      { keys: ["Ctrl", "Y"], description: "Redo" },
+      { keys: ["Ctrl", "S"], description: "Save document" },
+    ],
+  },
+  {
+    title: "Review Mode",
+    rows: [
+      { keys: ["Tab"], description: "Next annotation" },
+      { keys: ["Shift", "Tab"], description: "Previous annotation" },
+      { keys: ["Y"], description: "Accept annotation" },
+      { keys: ["N"], description: "Dismiss annotation" },
+      { keys: ["Escape"], description: "Exit review mode" },
+    ],
+  },
+  {
+    title: "Chat",
+    rows: [{ keys: ["Enter"], description: "Send message" }],
+  },
+  {
+    title: "General",
+    rows: [{ keys: ["?"], description: "Show / hide this help" }],
+  },
+];
+
+interface HelpModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function HelpModal({ open, onClose }: HelpModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.45)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+      }}
+      onClick={onClose}
+      data-testid="help-modal"
+    >
+      <div
+        style={{
+          backgroundColor: "#fff",
+          border: "1px solid #e0e0e0",
+          borderRadius: "8px",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+          padding: "24px 28px 20px",
+          width: "480px",
+          maxWidth: "90vw",
+          maxHeight: "80vh",
+          overflowY: "auto",
+          position: "relative",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: "16px",
+          }}
+        >
+          <h2
+            style={{
+              margin: 0,
+              fontSize: "16px",
+              fontWeight: 600,
+              color: "#1a1a1a",
+            }}
+          >
+            Keyboard Shortcuts
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close help"
+            data-testid="help-modal-close"
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              fontSize: "18px",
+              color: "#666",
+              lineHeight: 1,
+              padding: "2px 6px",
+              borderRadius: "4px",
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {SECTIONS.map((section) => (
+          <div key={section.title} style={{ marginBottom: "18px" }}>
+            <div
+              style={{
+                fontSize: "11px",
+                fontWeight: 600,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "#888",
+                marginBottom: "6px",
+              }}
+            >
+              {section.title}
+            </div>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <tbody>
+                {section.rows.map((row) => (
+                  <tr key={row.description}>
+                    <td
+                      style={{
+                        paddingBottom: "5px",
+                        paddingRight: "16px",
+                        whiteSpace: "nowrap",
+                        verticalAlign: "middle",
+                        width: "1%",
+                      }}
+                    >
+                      <span style={{ display: "flex", gap: "4px", alignItems: "center" }}>
+                        {row.keys.map((key, i) => (
+                          <span key={key}>
+                            <kbd
+                              style={{
+                                display: "inline-block",
+                                padding: "1px 6px",
+                                fontSize: "12px",
+                                fontFamily: "ui-monospace, SFMono-Regular, monospace",
+                                background: "#f5f5f5",
+                                border: "1px solid #d4d4d4",
+                                borderBottom: "2px solid #bbb",
+                                borderRadius: "4px",
+                                color: "#333",
+                                lineHeight: "1.5",
+                              }}
+                            >
+                              {key}
+                            </kbd>
+                            {i < row.keys.length - 1 && (
+                              <span style={{ color: "#aaa", fontSize: "11px", margin: "0 2px" }}>
+                                +
+                              </span>
+                            )}
+                          </span>
+                        ))}
+                      </span>
+                    </td>
+                    <td
+                      style={{
+                        paddingBottom: "5px",
+                        fontSize: "13px",
+                        color: "#444",
+                        verticalAlign: "middle",
+                      }}
+                    >
+                      {row.description}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))}
+
+        <div
+          style={{
+            marginTop: "12px",
+            paddingTop: "10px",
+            borderTop: "1px solid #f0f0f0",
+            fontSize: "11px",
+            color: "#aaa",
+            textAlign: "center",
+          }}
+        >
+          Press{" "}
+          <kbd
+            style={{
+              fontSize: "11px",
+              padding: "1px 4px",
+              background: "#f5f5f5",
+              border: "1px solid #ddd",
+              borderRadius: "3px",
+            }}
+          >
+            ?
+          </kbd>{" "}
+          or{" "}
+          <kbd
+            style={{
+              fontSize: "11px",
+              padding: "1px 4px",
+              background: "#f5f5f5",
+              border: "1px solid #ddd",
+              borderRadius: "3px",
+            }}
+          >
+            Esc
+          </kbd>{" "}
+          to close
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `HelpModal` component showing all keyboard shortcuts grouped by section
- Triggered by pressing `?` anywhere (suppressed in text inputs and contenteditable)
- Closes on Escape, `?` again, or clicking backdrop
- `data-testid="help-modal"` and `data-testid="help-modal-close"` for E2E

## Shortcuts documented
| Section | Shortcuts |
|---------|-----------|
| Editor | Ctrl+B/I/Z/Y/S |
| Review Mode | Tab, Shift+Tab, Y, N, Escape |
| Chat | Enter |
| General | ? |

## Test plan
- [x] `npm run typecheck` — zero errors
- [x] `npm test -- --run` — 617 tests pass
- [ ] Manual: press `?` → modal opens, shows all shortcuts
- [ ] Manual: press `?` again or Escape → modal closes
- [ ] Manual: click backdrop → modal closes
- [ ] Manual: type `?` in chat input → modal does NOT open

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)