### PR TITLE
refactor(shared): extract Y.Map key strings to shared constants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Three layers: Browser (Tiptap) <-> Tandem Server (Hocuspocus + MCP) <-> Claude C
 ## Key Patterns
 - All document mutations go through the server's Y.Doc
 - Claude's MCP tools mutate Y.Doc directly -> changes sync to browser via Hocuspocus
-- Annotations stored in Y.Map('annotations'), not in the document content
+- Annotations stored in Y.Map('annotations'), not in the document content. Y.Map key strings are centralized in `shared/constants.ts` (`Y_MAP_ANNOTATIONS`, `Y_MAP_AWARENESS`, etc.) — never use raw string literals for Y.Map keys.
 - Claude's status stored in Y.Map('awareness') key 'claude'; user's selection in Y.Map('userAwareness')
 - Server logs use console.error (stdout reserved for MCP protocol in stdio mode; defense-in-depth in HTTP mode)
 - Ranges use `validateRange()` and `anchoredRange()` for safe targeting (not raw offsets)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,8 @@ graph LR
     StatusBar -.->|observes| YDoc
 ```
 
+**Note:** Y.Map key strings (`'annotations'`, `'awareness'`, `'userAwareness'`, `'chat'`, `'documentMeta'`) are defined as named constants in `src/shared/constants.ts` (e.g., `Y_MAP_ANNOTATIONS`). All source code uses these constants — never raw strings.
+
 ## Data Flows
 
 ### Claude Edits the Document

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -156,3 +156,9 @@ A secondary issue: `saveCtrlSession` persists the entire `__tandem_ctrl__` Y.Doc
 3. **Temp fixture dirs** per test via `fs.mkdtemp()` — each test gets unique file paths, preventing session restore interference from previous runs.
 
 **Also:** `workers: 1` is essential — the MCP server supports one session at a time. Parallel tests would fight over the transport. And flat-text offsets in test fixtures must account for heading prefixes (`# ` = 2 chars) — offset 0 is the `#`, not the text content.
+
+## 19. Centralize Y.Map Key Strings as Constants
+
+**Problem:** Y.Map key strings like `"annotations"`, `"awareness"`, `"chat"` appeared as raw string literals across 20+ files. A typo in any one of them creates a silently disconnected map — the writer pushes to one key while the reader observes another, with no runtime error or type error.
+
+**Solution:** Define all Y.Map keys as named exports in `shared/constants.ts` (`Y_MAP_ANNOTATIONS`, `Y_MAP_AWARENESS`, `Y_MAP_USER_AWARENESS`, `Y_MAP_CHAT`, `Y_MAP_DOCUMENT_META`). Import the constant everywhere. TypeScript catches misspelled import names at compile time.

--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -3,7 +3,7 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import type { Node as PmNode } from "@tiptap/pm/model";
 import * as Y from "yjs";
-import { HIGHLIGHT_COLORS } from "../../../shared/constants";
+import { HIGHLIGHT_COLORS, Y_MAP_ANNOTATIONS } from "../../../shared/constants";
 import type { Annotation } from "../../../shared/types";
 import { annotationToPmRange } from "../../positions";
 
@@ -106,7 +106,7 @@ export const AnnotationExtension = Extension.create<{ ydoc: Y.Doc | null }>({
     const ydoc = this.options.ydoc;
     if (!ydoc) return [];
 
-    const annotationsMap = ydoc.getMap("annotations");
+    const annotationsMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
 
     return [
       new Plugin({

--- a/src/client/editor/extensions/awareness.ts
+++ b/src/client/editor/extensions/awareness.ts
@@ -3,7 +3,7 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import type { Node as PmNode } from "@tiptap/pm/model";
 import * as Y from "yjs";
-import { TYPING_DEBOUNCE } from "../../../shared/constants";
+import { TYPING_DEBOUNCE, Y_MAP_AWARENESS, Y_MAP_USER_AWARENESS } from "../../../shared/constants";
 import type { ClaudeAwareness } from "../../../shared/types";
 import { pmSelectionToFlat } from "../../positions";
 
@@ -53,8 +53,8 @@ export const AwarenessExtension = Extension.create<{ ydoc: Y.Doc | null }>({
     const ydoc = this.options.ydoc;
     if (!ydoc) return [];
 
-    const awarenessMap = ydoc.getMap("awareness");
-    const userAwareness = ydoc.getMap("userAwareness");
+    const awarenessMap = ydoc.getMap(Y_MAP_AWARENESS);
+    const userAwareness = ydoc.getMap(Y_MAP_USER_AWARENESS);
 
     return [
       // Plugin 1: Claude presence rendering
@@ -170,7 +170,7 @@ export const AwarenessExtension = Extension.create<{ ydoc: Y.Doc | null }>({
  * Used by StatusBar component.
  */
 export function getClaudeStatus(ydoc: Y.Doc): ClaudeAwareness | null {
-  const awarenessMap = ydoc.getMap("awareness");
+  const awarenessMap = ydoc.getMap(Y_MAP_AWARENESS);
   const claude = awarenessMap.get("claude") as ClaudeAwareness | undefined;
   return claude ?? null;
 }

--- a/src/client/editor/toolbar/Toolbar.tsx
+++ b/src/client/editor/toolbar/Toolbar.tsx
@@ -3,7 +3,7 @@ import type { Editor as TiptapEditor } from "@tiptap/react";
 import * as Y from "yjs";
 import { pmPosToFlatOffset } from "../../positions";
 import { generateAnnotationId } from "../../../shared/utils";
-import { HIGHLIGHT_COLORS } from "../../../shared/constants";
+import { HIGHLIGHT_COLORS, Y_MAP_ANNOTATIONS } from "../../../shared/constants";
 import type { Annotation, AnnotationType, HighlightColor } from "../../../shared/types";
 
 const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
@@ -107,7 +107,7 @@ export function Toolbar({ editor, ydoc }: ToolbarProps) {
       ...(color ? { color } : {}),
     };
 
-    ydoc.getMap("annotations").set(id, annotation);
+    ydoc.getMap(Y_MAP_ANNOTATIONS).set(id, annotation);
     capturedRangeRef.current = null;
   }
 

--- a/src/client/hooks/useYjsSync.ts
+++ b/src/client/hooks/useYjsSync.ts
@@ -1,7 +1,13 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import * as Y from "yjs";
 import { HocuspocusProvider } from "@hocuspocus/provider";
-import { DEFAULT_WS_PORT, CTRL_ROOM } from "../../shared/constants";
+import {
+  DEFAULT_WS_PORT,
+  CTRL_ROOM,
+  Y_MAP_ANNOTATIONS,
+  Y_MAP_AWARENESS,
+  Y_MAP_DOCUMENT_META,
+} from "../../shared/constants";
 import type { Annotation } from "../../shared/types";
 import type { DocListEntry, OpenTab } from "../types";
 
@@ -68,7 +74,7 @@ export function useYjsSync(): YjsSyncResult {
   const setupTabObservers = useCallback((tab: OpenTab) => {
     const { ydoc } = tab;
 
-    const annotationsMap = ydoc.getMap("annotations");
+    const annotationsMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const annotationObserver = () => {
       const anns: Annotation[] = [];
       annotationsMap.forEach((value) => {
@@ -79,7 +85,7 @@ export function useYjsSync(): YjsSyncResult {
     annotationsMap.observe(annotationObserver);
     annotationObserver();
 
-    const awarenessMap = ydoc.getMap("awareness");
+    const awarenessMap = ydoc.getMap(Y_MAP_AWARENESS);
     let prevStatus: string | null = null;
     let prevActive = false;
     const awarenessObserver = () => {
@@ -100,7 +106,7 @@ export function useYjsSync(): YjsSyncResult {
     awarenessMap.observe(awarenessObserver);
     awarenessObserver();
 
-    const documentMetaMap = ydoc.getMap("documentMeta");
+    const documentMetaMap = ydoc.getMap(Y_MAP_DOCUMENT_META);
     let prevReadOnly = false;
     const documentMetaObserver = () => {
       const ro = (documentMetaMap.get("readOnly") as boolean | undefined) === true;
@@ -151,7 +157,7 @@ export function useYjsSync(): YjsSyncResult {
       });
       pendingProvidersRef.current.set(doc.id, { ydoc, provider });
 
-      const meta = ydoc.getMap("documentMeta");
+      const meta = ydoc.getMap(Y_MAP_DOCUMENT_META);
       const metaObserver = () => {
         const docs = meta.get("openDocuments") as DocListEntry[] | undefined;
         const active = meta.get("activeDocumentId") as string | null | undefined;
@@ -217,7 +223,7 @@ export function useYjsSync(): YjsSyncResult {
   // (effects run in declaration order within a component/hook).
   useEffect(() => {
     if (!bootstrapRef.current) return;
-    const meta = bootstrapRef.current.ydoc.getMap("documentMeta");
+    const meta = bootstrapRef.current.ydoc.getMap(Y_MAP_DOCUMENT_META);
     const observer = () => {
       // Detect server restart via generationId change
       const newGenId = meta.get("generationId") as string | undefined;

--- a/src/client/panels/ChatPanel.tsx
+++ b/src/client/panels/ChatPanel.tsx
@@ -1,3 +1,4 @@
+import { Y_MAP_CHAT } from "../../shared/constants";
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import type { Editor as TiptapEditor } from "@tiptap/react";
 import ReactMarkdown from "react-markdown";
@@ -27,7 +28,7 @@ export function ChatPanel({ ctrlYdoc, editor, activeDocId, openDocs }: ChatPanel
   // Observe Y.Map('chat') for changes
   useEffect(() => {
     if (!ctrlYdoc) return;
-    const chatMap = ctrlYdoc.getMap("chat");
+    const chatMap = ctrlYdoc.getMap(Y_MAP_CHAT);
 
     const observer = () => {
       const msgs: ChatMessage[] = [];
@@ -68,7 +69,7 @@ export function ChatPanel({ ctrlYdoc, editor, activeDocId, openDocs }: ChatPanel
 
   const sendMessage = useCallback(() => {
     if (!ctrlYdoc || !inputText.trim()) return;
-    const chatMap = ctrlYdoc.getMap("chat");
+    const chatMap = ctrlYdoc.getMap(Y_MAP_CHAT);
 
     const msg: ChatMessage = {
       id: generateMessageId(),

--- a/src/client/panels/SidePanel.tsx
+++ b/src/client/panels/SidePanel.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from "react"
 import type { Editor as TiptapEditor } from "@tiptap/react";
 import * as Y from "yjs";
 import type { Annotation, AnnotationType, InterruptionMode } from "../../shared/types";
-import { HIGHLIGHT_COLORS } from "../../shared/constants";
+import { HIGHLIGHT_COLORS, Y_MAP_ANNOTATIONS } from "../../shared/constants";
 import { annotationToPmRange } from "../positions";
 
 interface SidePanelProps {
@@ -95,7 +95,7 @@ export function SidePanel({
   function resolveAnnotation(id: string, status: "accepted" | "dismissed") {
     const y = ydocRef.current;
     if (!y) return;
-    const map = y.getMap("annotations");
+    const map = y.getMap(Y_MAP_ANNOTATIONS);
     const ann = map.get(id) as Annotation | undefined;
     if (!ann) return;
     map.set(id, { ...ann, status });

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -1,3 +1,4 @@
+import { Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getOrCreateDocument } from "../yjs/provider.js";
@@ -23,7 +24,7 @@ function getDocAndAnnotations(documentId?: string): { ydoc: Y.Doc; map: Y.Map<un
   const doc = getCurrentDoc(documentId);
   if (!doc) return null;
   const ydoc = getOrCreateDocument(doc.docName);
-  return { ydoc, map: ydoc.getMap("annotations") };
+  return { ydoc, map: ydoc.getMap(Y_MAP_ANNOTATIONS) };
 }
 
 /** Convert an anchoredRange validation failure to an MCP error response. */

--- a/src/server/mcp/awareness.ts
+++ b/src/server/mcp/awareness.ts
@@ -6,7 +6,12 @@ import { collectAnnotations, refreshRange } from "./annotations.js";
 import { mcpSuccess, noDocumentError, withErrorBoundary } from "./response.js";
 import type { Annotation, ChatMessage } from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
-import { CTRL_ROOM } from "../../shared/constants.js";
+import {
+  CTRL_ROOM,
+  Y_MAP_ANNOTATIONS,
+  Y_MAP_CHAT,
+  Y_MAP_USER_AWARENESS,
+} from "../../shared/constants.js";
 
 // Track which annotation IDs have been surfaced to Claude via checkInbox
 const surfacedIds = new Set<string>();
@@ -31,7 +36,7 @@ export function registerAwarenessTools(server: McpServer): void {
       if (!current) return noDocumentError();
 
       const doc = getOrCreateDocument(current.docName);
-      const userAwareness = doc.getMap("userAwareness");
+      const userAwareness = doc.getMap(Y_MAP_USER_AWARENESS);
       const selection = userAwareness.get("selection") as
         | { from: number; to: number; timestamp: number }
         | undefined;
@@ -61,7 +66,7 @@ export function registerAwarenessTools(server: McpServer): void {
       if (!current) return noDocumentError();
 
       const doc = getOrCreateDocument(current.docName);
-      const userAwareness = doc.getMap("userAwareness");
+      const userAwareness = doc.getMap(Y_MAP_USER_AWARENESS);
       const activity = userAwareness.get("activity") as
         | {
             isTyping: boolean;
@@ -105,7 +110,7 @@ export function registerAwarenessTools(server: McpServer): void {
       if (!current) return noDocumentError();
 
       const doc = getOrCreateDocument(current.docName);
-      const annotationsMap = doc.getMap("annotations");
+      const annotationsMap = doc.getMap(Y_MAP_ANNOTATIONS);
       const allAnnotations = collectAnnotations(annotationsMap);
       const fullText = extractText(doc);
 
@@ -137,7 +142,7 @@ export function registerAwarenessTools(server: McpServer): void {
 
       // Bucket 3: unread chat messages from CTRL_ROOM
       const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
-      const chatMap = ctrlDoc.getMap("chat");
+      const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
       const chatMessages: Array<Omit<ChatMessage, "read" | "author">> = [];
 
       chatMap.forEach((value) => {
@@ -157,7 +162,7 @@ export function registerAwarenessTools(server: McpServer): void {
       });
 
       // Current user activity
-      const userAwareness = doc.getMap("userAwareness");
+      const userAwareness = doc.getMap(Y_MAP_USER_AWARENESS);
       const selection = userAwareness.get("selection") as
         | { from: number; to: number; timestamp: number }
         | undefined;
@@ -231,7 +236,7 @@ export function registerAwarenessTools(server: McpServer): void {
     },
     withErrorBoundary("tandem_reply", async ({ text, replyTo, documentId }) => {
       const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
-      const chatMap = ctrlDoc.getMap("chat");
+      const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
       const id = generateMessageId();
       const current = getCurrentDoc(documentId);

--- a/src/server/mcp/document-service.ts
+++ b/src/server/mcp/document-service.ts
@@ -7,7 +7,7 @@ import {
   loadCtrlSession,
   restoreCtrlDoc,
 } from "../session/manager.js";
-import { CTRL_ROOM } from "../../shared/constants.js";
+import { CTRL_ROOM, Y_MAP_DOCUMENT_META } from "../../shared/constants.js";
 import { randomUUID } from "node:crypto";
 
 // --- Multi-document state ---
@@ -103,7 +103,7 @@ export function broadcastOpenDocs(): void {
     const id = activeDocId;
 
     const ctrl = getOrCreateDocument(CTRL_ROOM);
-    const ctrlMeta = ctrl.getMap("documentMeta");
+    const ctrlMeta = ctrl.getMap(Y_MAP_DOCUMENT_META);
     ctrlMeta.set("openDocuments", docList);
     ctrlMeta.set("activeDocumentId", id);
 
@@ -112,7 +112,7 @@ export function broadcastOpenDocs(): void {
     // could fire the client's metaObserver and incorrectly remove tabs.
     for (const [docId] of openDocs) {
       const ydoc = getOrCreateDocument(docId);
-      const meta = ydoc.getMap("documentMeta");
+      const meta = ydoc.getMap(Y_MAP_DOCUMENT_META);
       meta.set("openDocuments", docList);
       meta.set("activeDocumentId", id);
     }
@@ -140,7 +140,7 @@ export async function restoreCtrlSession(): Promise<void> {
 
     // Clear stale document tracking — no docs are actually open after a restart.
     // Chat history is preserved; only the document list is wiped.
-    const meta = ctrlDoc.getMap("documentMeta");
+    const meta = ctrlDoc.getMap(Y_MAP_DOCUMENT_META);
     meta.delete("openDocuments");
     meta.delete("activeDocumentId");
 
@@ -151,7 +151,7 @@ export async function restoreCtrlSession(): Promise<void> {
 /** Write a unique generationId to the ctrl doc so clients can detect server restarts. */
 export function writeGenerationId(): void {
   const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
-  const meta = ctrlDoc.getMap("documentMeta");
+  const meta = ctrlDoc.getMap(Y_MAP_DOCUMENT_META);
   const generationId = randomUUID();
   meta.set("generationId", generationId);
   console.error(`[Tandem] Server generationId: ${generationId}`);

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -10,6 +10,7 @@ import {
   LARGE_FILE_PAGE_THRESHOLD,
   VERY_LARGE_FILE_PAGE_THRESHOLD,
   SUPPORTED_EXTENSIONS,
+  Y_MAP_DOCUMENT_META,
 } from "../../shared/constants.js";
 import { getAdapter } from "../file-io/index.js";
 import {
@@ -200,7 +201,7 @@ function writeDocMeta(
   format: string,
   readOnly: boolean,
 ): void {
-  const meta = doc.getMap("documentMeta");
+  const meta = doc.getMap(Y_MAP_DOCUMENT_META);
   meta.set("readOnly", readOnly);
   meta.set("format", format);
   meta.set("documentId", id);

--- a/src/server/mcp/navigation.ts
+++ b/src/server/mcp/navigation.ts
@@ -1,3 +1,4 @@
+import { Y_MAP_AWARENESS } from "../../shared/constants.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getOrCreateDocument } from "../yjs/provider.js";
@@ -145,7 +146,7 @@ export function registerNavigationTools(server: McpServer): void {
         });
       }
       const doc = getOrCreateDocument(current.docName);
-      const awarenessMap = doc.getMap("awareness");
+      const awarenessMap = doc.getMap(Y_MAP_AWARENESS);
       awarenessMap.set("claude", {
         status: text,
         timestamp: Date.now(),

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -4,7 +4,7 @@ import * as Y from "yjs";
 import type { SessionData } from "../../shared/types.js";
 import { SESSION_DIR } from "../platform.js";
 
-import { SESSION_MAX_AGE, CTRL_ROOM } from "../../shared/constants.js";
+import { SESSION_MAX_AGE, CTRL_ROOM, Y_MAP_CHAT } from "../../shared/constants.js";
 
 const AUTO_SAVE_INTERVAL = 60 * 1000; // 60 seconds
 let sessionDirReady = false;
@@ -107,7 +107,7 @@ export async function saveCtrlSession(doc: Y.Doc): Promise<void> {
   }
 
   // Prune chat to newest 200 messages before saving
-  const chatMap = doc.getMap("chat");
+  const chatMap = doc.getMap(Y_MAP_CHAT);
   const entries: Array<{ id: string; timestamp: number }> = [];
   chatMap.forEach((value, key) => {
     const msg = value as { timestamp: number };

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -33,5 +33,12 @@ export const CLAUDE_FOCUS_OPACITY = 0.1;
 
 export const CTRL_ROOM = "__tandem_ctrl__";
 
+/** Y.Map key constants — centralized to prevent silent bugs from string typos. */
+export const Y_MAP_ANNOTATIONS = "annotations";
+export const Y_MAP_AWARENESS = "awareness";
+export const Y_MAP_USER_AWARENESS = "userAwareness";
+export const Y_MAP_CHAT = "chat";
+export const Y_MAP_DOCUMENT_META = "documentMeta";
+
 export const SERVER_INFO_DIR = ".tandem";
 export const SERVER_INFO_FILE = ".tandem/.server-info";

--- a/tests/helpers/ydoc-factory.ts
+++ b/tests/helpers/ydoc-factory.ts
@@ -1,3 +1,4 @@
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import * as Y from "yjs";
 import { populateYDoc } from "../../src/server/mcp/document.js";
 import { loadMarkdown } from "../../src/server/file-io/markdown.js";
@@ -29,7 +30,7 @@ export function makeMarkdownDoc(md: string): Y.Doc {
 
 /** Shortcut to get the 'annotations' Y.Map */
 export function getAnnotationsMap(doc: Y.Doc): Y.Map<unknown> {
-  return doc.getMap("annotations");
+  return doc.getMap(Y_MAP_ANNOTATIONS);
 }
 
 /** Create an anchored range (flat + CRDT) for annotation creation in tests. */

--- a/tests/server/annotation-tools.test.ts
+++ b/tests/server/annotation-tools.test.ts
@@ -1,3 +1,4 @@
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import { describe, it, expect, beforeEach } from "vitest";
 import * as Y from "yjs";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
@@ -33,7 +34,7 @@ beforeEach(() => {
 describe("tandem_highlight tool logic", () => {
   it("creates highlight annotation with color", () => {
     const ydoc = setupDoc("hl-1", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "highlight", rangeOf(0, 5, ydoc), "", { color: "yellow" });
 
     const stored = map.get(id) as Annotation;
@@ -45,7 +46,7 @@ describe("tandem_highlight tool logic", () => {
 
   it("supports all highlight colors", () => {
     const ydoc = setupDoc("hl-2", "Hello world test content here");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
 
     for (const color of ["yellow", "red", "green", "blue", "purple"] as const) {
       const id = createAnnotation(map, "highlight", rangeOf(0, 5, ydoc), "", { color });
@@ -56,7 +57,7 @@ describe("tandem_highlight tool logic", () => {
 
   it("supports priority field", () => {
     const ydoc = setupDoc("hl-3", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "highlight", rangeOf(0, 5, ydoc), "", { priority: "urgent" });
 
     const stored = map.get(id) as Annotation;
@@ -67,7 +68,7 @@ describe("tandem_highlight tool logic", () => {
 describe("tandem_comment tool logic", () => {
   it("creates comment with text content", () => {
     const ydoc = setupDoc("cm-1", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "comment", rangeOf(0, 5, ydoc), "This needs revision");
 
     const stored = map.get(id) as Annotation;
@@ -79,7 +80,7 @@ describe("tandem_comment tool logic", () => {
 describe("tandem_suggest tool logic", () => {
   it("creates suggestion with JSON content", () => {
     const ydoc = setupDoc("sg-1", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const content = JSON.stringify({ newText: "Hi", reason: "more concise" });
     const id = createAnnotation(map, "suggestion", rangeOf(0, 5, ydoc), content);
 
@@ -92,7 +93,7 @@ describe("tandem_suggest tool logic", () => {
 
   it("handles empty reason", () => {
     const ydoc = setupDoc("sg-2", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const content = JSON.stringify({ newText: "Hi", reason: "" });
     const id = createAnnotation(map, "suggestion", rangeOf(0, 5, ydoc), content);
 
@@ -105,7 +106,7 @@ describe("tandem_suggest tool logic", () => {
 describe("tandem_flag tool logic", () => {
   it("creates flag annotation", () => {
     const ydoc = setupDoc("fl-1", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "flag", rangeOf(0, 5, ydoc), "Needs review");
 
     const stored = map.get(id) as Annotation;
@@ -115,7 +116,7 @@ describe("tandem_flag tool logic", () => {
 
   it("flag with no note has empty content", () => {
     const ydoc = setupDoc("fl-2", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "flag", rangeOf(0, 5, ydoc), "");
 
     const stored = map.get(id) as Annotation;
@@ -125,7 +126,7 @@ describe("tandem_flag tool logic", () => {
 
 describe("tandem_getAnnotations tool logic", () => {
   function populateAnnotations(ydoc: Y.Doc) {
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     createAnnotation(map, "comment", rangeOf(0, 5, ydoc), "comment 1", { author: "claude" });
     createAnnotation(map, "highlight", rangeOf(0, 5), "", { author: "user", color: "yellow" });
     createAnnotation(
@@ -191,7 +192,7 @@ describe("tandem_getAnnotations tool logic", () => {
 describe("tandem_resolveAnnotation tool logic", () => {
   it("accepts an annotation", () => {
     const ydoc = setupDoc("ra-1", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "comment", rangeOf(0, 5), "review me");
 
     const ann = map.get(id) as Annotation;
@@ -203,7 +204,7 @@ describe("tandem_resolveAnnotation tool logic", () => {
 
   it("dismisses an annotation", () => {
     const ydoc = setupDoc("ra-2", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "comment", rangeOf(0, 5), "review me");
 
     const ann = map.get(id) as Annotation;
@@ -215,7 +216,7 @@ describe("tandem_resolveAnnotation tool logic", () => {
 
   it("returns error for non-existent annotation ID", () => {
     const ydoc = setupDoc("ra-3", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const ann = map.get("fake_id") as Annotation | undefined;
     expect(ann).toBeUndefined();
   });
@@ -224,7 +225,7 @@ describe("tandem_resolveAnnotation tool logic", () => {
 describe("tandem_removeAnnotation tool logic", () => {
   it("removes annotation from map", () => {
     const ydoc = setupDoc("rm-1", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "comment", rangeOf(0, 5), "to remove");
 
     expect(map.has(id)).toBe(true);
@@ -234,7 +235,7 @@ describe("tandem_removeAnnotation tool logic", () => {
 
   it("returns false for non-existent annotation", () => {
     const ydoc = setupDoc("rm-2", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     expect(map.has("nonexistent")).toBe(false);
   });
 });
@@ -242,7 +243,7 @@ describe("tandem_removeAnnotation tool logic", () => {
 describe("tandem_exportAnnotations tool logic", () => {
   it("exports markdown summary", () => {
     const ydoc = setupDoc("ex-1", "Hello world test content");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     createAnnotation(map, "comment", rangeOf(0, 5, ydoc), "Nice intro");
     createAnnotation(map, "highlight", rangeOf(6, 11, ydoc), "", { color: "yellow" });
     createAnnotation(
@@ -269,7 +270,7 @@ describe("tandem_exportAnnotations tool logic", () => {
 
   it("exports JSON format with text snippets", () => {
     const ydoc = setupDoc("ex-3", "Hello world test content");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     createAnnotation(map, "comment", rangeOf(0, 5, ydoc), "Note");
 
     const annotations = collectAnnotations(map);
@@ -322,7 +323,7 @@ describe("annotation stale range detection", () => {
 describe("annotation CRDT-anchored positions", () => {
   it("annotations with relRange survive edits", () => {
     const ydoc = setupDoc("crdt-1", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "comment", rangeOf(6, 11, ydoc), "note on world");
 
     const ann = map.get(id) as Annotation;
@@ -342,7 +343,7 @@ describe("annotation CRDT-anchored positions", () => {
 
   it("annotations without relRange get it lazily attached", () => {
     const ydoc = setupDoc("crdt-2", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "comment", rangeOf(0, 5), "note"); // no ydoc
 
     const ann = map.get(id) as Annotation;
@@ -358,8 +359,8 @@ describe("annotation on multi-document", () => {
     const ydoc1 = setupDoc("md-1", "Doc one");
     const ydoc2 = setupDoc("md-2", "Doc two");
 
-    const map1 = ydoc1.getMap("annotations");
-    const map2 = ydoc2.getMap("annotations");
+    const map1 = ydoc1.getMap(Y_MAP_ANNOTATIONS);
+    const map2 = ydoc2.getMap(Y_MAP_ANNOTATIONS);
 
     createAnnotation(map1, "comment", rangeOf(0, 3), "on doc 1");
     createAnnotation(map2, "highlight", rangeOf(0, 3), "", { color: "red" });

--- a/tests/server/awareness-tools.test.ts
+++ b/tests/server/awareness-tools.test.ts
@@ -1,3 +1,9 @@
+import {
+  Y_MAP_ANNOTATIONS,
+  Y_MAP_AWARENESS,
+  Y_MAP_CHAT,
+  Y_MAP_USER_AWARENESS,
+} from "../../src/shared/constants.js";
 import { describe, it, expect, beforeEach } from "vitest";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import {
@@ -78,7 +84,7 @@ describe("isUserActive", () => {
 describe("processInboxAnnotations", () => {
   it("buckets user annotations into userActions", () => {
     const ydoc = setupDoc("inbox-1", "Hello world test");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     createAnnotation(map, "highlight", rangeOf(0, 5), "", { author: "user", color: "yellow" });
     createAnnotation(map, "comment", rangeOf(6, 11), "Nice", { author: "user" });
 
@@ -94,7 +100,7 @@ describe("processInboxAnnotations", () => {
 
   it("buckets resolved Claude annotations into userResponses", () => {
     const ydoc = setupDoc("inbox-2", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, "suggestion", rangeOf(0, 5), '{"newText":"Hi","reason":""}');
     const ann = map.get(id) as Annotation;
     map.set(id, { ...ann, status: "accepted" as const });
@@ -110,7 +116,7 @@ describe("processInboxAnnotations", () => {
 
   it("ignores pending Claude annotations", () => {
     const ydoc = setupDoc("inbox-3", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     createAnnotation(map, "comment", rangeOf(0, 5), "A comment"); // author=claude, status=pending
 
     const allAnns = collectAnnotations(map);
@@ -124,7 +130,7 @@ describe("processInboxAnnotations", () => {
 
   it("deduplicates via surfacedIds — second call returns empty", () => {
     const ydoc = setupDoc("inbox-4", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     createAnnotation(map, "highlight", rangeOf(0, 5), "", { author: "user" });
 
     const allAnns = collectAnnotations(map);
@@ -140,7 +146,7 @@ describe("processInboxAnnotations", () => {
 
   it("calls refreshFn on each unsurfaced annotation", () => {
     const ydoc = setupDoc("inbox-5", "Hello world");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     createAnnotation(map, "highlight", rangeOf(0, 5), "", { author: "user" });
 
     const allAnns = collectAnnotations(map);
@@ -157,7 +163,7 @@ describe("processInboxAnnotations", () => {
 
   it("includes text snippets from annotation ranges", () => {
     const ydoc = setupDoc("inbox-6", "The quick brown fox");
-    const map = ydoc.getMap("annotations");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     createAnnotation(map, "comment", rangeOf(4, 9), "Note", { author: "user" });
 
     const allAnns = collectAnnotations(map);
@@ -172,7 +178,7 @@ describe("processInboxAnnotations", () => {
 describe("checkInbox — chat messages (real Y.Map operations)", () => {
   it("reads unread chat messages from CTRL_ROOM", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_inbox_chat_1__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     const msg: ChatMessage = {
       id: generateMessageId(),
@@ -203,7 +209,7 @@ describe("checkInbox — chat messages (real Y.Map operations)", () => {
 
   it("ignores Claude messages in inbox", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_inbox_chat_2__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     chatMap.set("msg_claude_only", {
       id: "msg_claude_only",
@@ -225,7 +231,7 @@ describe("checkInbox — chat messages (real Y.Map operations)", () => {
 describe("tandem_reply — real Y.Map operations", () => {
   it("stores a Claude reply in CTRL_ROOM", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_reply_1__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     const id = generateMessageId();
     const msg: ChatMessage = {
@@ -244,7 +250,7 @@ describe("tandem_reply — real Y.Map operations", () => {
 
   it("supports replyTo for threading", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_reply_2__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     const replyId = generateMessageId();
     const reply: ChatMessage = {
@@ -265,7 +271,7 @@ describe("tandem_reply — real Y.Map operations", () => {
 describe("tandem_setStatus — real Y.Map operations", () => {
   it("writes Claude status to awareness map", () => {
     const ydoc = setupDoc("status-1", "Hello world");
-    const awarenessMap = ydoc.getMap("awareness");
+    const awarenessMap = ydoc.getMap(Y_MAP_AWARENESS);
 
     awarenessMap.set("claude", {
       status: "Reviewing section 3...",
@@ -288,13 +294,13 @@ describe("tandem_setStatus — real Y.Map operations", () => {
 describe("tandem_getSelections — real Y.Map operations", () => {
   it("returns empty when no selection exists", () => {
     const ydoc = setupDoc("sel-1", "Hello world");
-    const userAwareness = ydoc.getMap("userAwareness");
+    const userAwareness = ydoc.getMap(Y_MAP_USER_AWARENESS);
     expect(userAwareness.get("selection")).toBeUndefined();
   });
 
   it("detects no selection when from === to", () => {
     const ydoc = setupDoc("sel-2", "Hello world");
-    const userAwareness = ydoc.getMap("userAwareness");
+    const userAwareness = ydoc.getMap(Y_MAP_USER_AWARENESS);
     userAwareness.set("selection", { from: 3, to: 3, timestamp: Date.now() });
 
     const selection = userAwareness.get("selection") as { from: number; to: number };

--- a/tests/server/awareness.test.ts
+++ b/tests/server/awareness.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as Y from 'yjs';
-import { resetInbox } from '../../src/server/mcp/awareness.js';
-import { collectAnnotations } from '../../src/server/mcp/annotations.js';
-import { populateYDoc, extractText } from '../../src/server/mcp/document.js';
-import type { Annotation } from '../../src/shared/types.js';
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as Y from "yjs";
+import { resetInbox } from "../../src/server/mcp/awareness.js";
+import { collectAnnotations } from "../../src/server/mcp/annotations.js";
+import { populateYDoc, extractText } from "../../src/server/mcp/document.js";
+import type { Annotation } from "../../src/shared/types.js";
 
 let doc: Y.Doc;
 
@@ -13,17 +14,14 @@ function makeDoc(text: string): Y.Doc {
   return doc;
 }
 
-function addAnnotation(
-  map: Y.Map<unknown>,
-  overrides: Partial<Annotation>,
-): Annotation {
+function addAnnotation(map: Y.Map<unknown>, overrides: Partial<Annotation>): Annotation {
   const ann: Annotation = {
     id: `ann_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
-    author: 'user',
-    type: 'highlight',
+    author: "user",
+    type: "highlight",
     range: { from: 0, to: 5 },
-    content: '',
-    status: 'pending',
+    content: "",
+    status: "pending",
     timestamp: Date.now(),
     ...overrides,
   };
@@ -39,60 +37,69 @@ afterEach(() => {
   doc?.destroy();
 });
 
-describe('tandem_checkInbox logic', () => {
+describe("tandem_checkInbox logic", () => {
   // These tests verify the inbox logic directly since we can't easily call MCP tools in unit tests.
   // The logic is: collect annotations, split by author/status, dedup via surfacedIds.
 
-  it('surfaces new user annotations', () => {
-    makeDoc('Hello world test');
-    const map = doc.getMap('annotations');
+  it("surfaces new user annotations", () => {
+    makeDoc("Hello world test");
+    const map = doc.getMap(Y_MAP_ANNOTATIONS);
 
-    const _highlight = addAnnotation(map, { author: 'user', type: 'highlight', range: { from: 0, to: 5 } });
-    const _comment = addAnnotation(map, { author: 'user', type: 'comment', range: { from: 6, to: 11 }, content: 'Nice' });
+    const _highlight = addAnnotation(map, {
+      author: "user",
+      type: "highlight",
+      range: { from: 0, to: 5 },
+    });
+    const _comment = addAnnotation(map, {
+      author: "user",
+      type: "comment",
+      range: { from: 6, to: 11 },
+      content: "Nice",
+    });
 
     const allAnns = collectAnnotations(map);
-    const userActions = allAnns.filter(a => a.author === 'user');
+    const userActions = allAnns.filter((a) => a.author === "user");
 
     expect(userActions.length).toBe(2);
-    expect(userActions.find(a => a.type === 'highlight')).toBeTruthy();
-    expect(userActions.find(a => a.type === 'comment')).toBeTruthy();
+    expect(userActions.find((a) => a.type === "highlight")).toBeTruthy();
+    expect(userActions.find((a) => a.type === "comment")).toBeTruthy();
   });
 
-  it('surfaces user responses to Claude annotations', () => {
-    makeDoc('Hello world');
-    const map = doc.getMap('annotations');
+  it("surfaces user responses to Claude annotations", () => {
+    makeDoc("Hello world");
+    const map = doc.getMap(Y_MAP_ANNOTATIONS);
 
-    addAnnotation(map, { author: 'claude', type: 'suggestion', status: 'accepted' });
-    addAnnotation(map, { author: 'claude', type: 'comment', status: 'dismissed' });
-    addAnnotation(map, { author: 'claude', type: 'highlight', status: 'pending' }); // Still pending, not a response
+    addAnnotation(map, { author: "claude", type: "suggestion", status: "accepted" });
+    addAnnotation(map, { author: "claude", type: "comment", status: "dismissed" });
+    addAnnotation(map, { author: "claude", type: "highlight", status: "pending" }); // Still pending, not a response
 
     const allAnns = collectAnnotations(map);
-    const responses = allAnns.filter(a => a.author === 'claude' && a.status !== 'pending');
+    const responses = allAnns.filter((a) => a.author === "claude" && a.status !== "pending");
 
     expect(responses.length).toBe(2);
   });
 
-  it('question annotation type works', () => {
-    makeDoc('Hello world');
-    const map = doc.getMap('annotations');
+  it("question annotation type works", () => {
+    makeDoc("Hello world");
+    const map = doc.getMap(Y_MAP_ANNOTATIONS);
 
     const _question = addAnnotation(map, {
-      author: 'user',
-      type: 'question',
+      author: "user",
+      type: "question",
       range: { from: 0, to: 5 },
-      content: 'What does this mean?',
+      content: "What does this mean?",
     });
 
     const allAnns = collectAnnotations(map);
-    const questions = allAnns.filter(a => a.type === 'question');
+    const questions = allAnns.filter((a) => a.type === "question");
 
     expect(questions.length).toBe(1);
-    expect(questions[0].content).toBe('What does this mean?');
-    expect(questions[0].author).toBe('user');
+    expect(questions[0].content).toBe("What does this mean?");
+    expect(questions[0].author).toBe("user");
   });
 
-  it('text snippets can be extracted for annotation ranges', () => {
-    makeDoc('The quick brown fox jumps over the lazy dog');
+  it("text snippets can be extracted for annotation ranges", () => {
+    makeDoc("The quick brown fox jumps over the lazy dog");
     const fullText = extractText(doc);
 
     // Simulate snippet extraction (same logic as tandem_checkInbox)
@@ -101,15 +108,15 @@ describe('tandem_checkInbox logic', () => {
       Math.max(4, Math.min(9, fullText.length)),
     );
 
-    expect(snippet).toBe('quick');
+    expect(snippet).toBe("quick");
   });
 });
 
-describe('surfacedIds deduplication', () => {
+describe("surfacedIds deduplication", () => {
   // The inbox uses a Set<string> to track which IDs have been returned.
   // resetInbox() clears it between tests.
 
-  it('resetInbox clears the set', () => {
+  it("resetInbox clears the set", () => {
     // This is a basic sanity check that the exported function works.
     // The actual dedup behavior is tested via the MCP tool integration.
     resetInbox();

--- a/tests/server/chat-extended.test.ts
+++ b/tests/server/chat-extended.test.ts
@@ -1,3 +1,4 @@
+import { Y_MAP_CHAT } from "../../src/shared/constants.js";
 import { describe, it, expect } from "vitest";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import { generateMessageId } from "../../src/shared/utils.js";
@@ -6,7 +7,7 @@ import type { ChatMessage } from "../../src/shared/types.js";
 describe("chat message pruning logic", () => {
   it("prunes old messages keeping newest 200", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_prune_1__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     // Add 250 messages
     for (let i = 0; i < 250; i++) {
@@ -49,7 +50,7 @@ describe("chat message pruning logic", () => {
 
   it("does not prune when under 200 messages", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_prune_2__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     for (let i = 0; i < 50; i++) {
       const id = `msg_small_${i}`;
@@ -74,7 +75,7 @@ describe("chat message pruning logic", () => {
 describe("chat message ordering", () => {
   it("messages can be sorted by timestamp", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_order_1__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     // Add messages out of order
     chatMap.set("msg_3", {
@@ -112,7 +113,7 @@ describe("chat message ordering", () => {
 describe("chat message document context", () => {
   it("messages can reference a specific document", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_docctx_1__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     const msg: ChatMessage = {
       id: generateMessageId(),
@@ -130,7 +131,7 @@ describe("chat message document context", () => {
 
   it("messages can include text anchors", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_anchor_1__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     const msg: ChatMessage = {
       id: generateMessageId(),
@@ -153,7 +154,7 @@ describe("chat message document context", () => {
 describe("chat message reply threading", () => {
   it("builds a conversation thread via replyTo", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_thread_1__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     const msg1: ChatMessage = {
       id: "msg_thread_1",
@@ -195,7 +196,7 @@ describe("chat message reply threading", () => {
 describe("chat mixed author messages", () => {
   it("separates user and claude messages in inbox", () => {
     const ctrlDoc = getOrCreateDocument("__tandem_ctrl_mixed_1__");
-    const chatMap = ctrlDoc.getMap("chat");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     chatMap.set("u1", {
       id: "u1",

--- a/tests/server/chat.test.ts
+++ b/tests/server/chat.test.ts
@@ -1,31 +1,32 @@
-import { describe, it, expect } from 'vitest';
-import { getOrCreateDocument } from '../../src/server/yjs/provider.js';
-import { generateMessageId } from '../../src/shared/utils.js';
-import type { ChatMessage } from '../../src/shared/types.js';
+import { Y_MAP_CHAT } from "../../src/shared/constants.js";
+import { describe, it, expect } from "vitest";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { generateMessageId } from "../../src/shared/utils.js";
+import type { ChatMessage } from "../../src/shared/types.js";
 
-describe('generateMessageId', () => {
-  it('produces msg_ prefixed IDs', () => {
+describe("generateMessageId", () => {
+  it("produces msg_ prefixed IDs", () => {
     const id = generateMessageId();
     expect(id).toMatch(/^msg_\d+_[a-z0-9]+$/);
   });
 
-  it('produces unique IDs', () => {
+  it("produces unique IDs", () => {
     const ids = new Set(Array.from({ length: 100 }, () => generateMessageId()));
     expect(ids.size).toBe(100);
   });
 });
 
-describe('Y.Map chat message operations', () => {
-  it('reads unread user messages from __tandem_ctrl__ chat map', () => {
-    const ctrlDoc = getOrCreateDocument('__tandem_ctrl_chat_test_1__');
-    const chatMap = ctrlDoc.getMap('chat');
+describe("Y.Map chat message operations", () => {
+  it("reads unread user messages from __tandem_ctrl__ chat map", () => {
+    const ctrlDoc = getOrCreateDocument("__tandem_ctrl_chat_test_1__");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     const msg: ChatMessage = {
-      id: 'msg_test_001',
-      author: 'user',
-      text: 'Look at this paragraph',
+      id: "msg_test_001",
+      author: "user",
+      text: "Look at this paragraph",
       timestamp: Date.now(),
-      documentId: 'test-doc',
+      documentId: "test-doc",
       read: false,
     };
     chatMap.set(msg.id, msg);
@@ -33,23 +34,23 @@ describe('Y.Map chat message operations', () => {
     const unread: ChatMessage[] = [];
     chatMap.forEach((value) => {
       const m = value as ChatMessage;
-      if (m.author === 'user' && !m.read) {
+      if (m.author === "user" && !m.read) {
         unread.push(m);
       }
     });
 
     expect(unread).toHaveLength(1);
-    expect(unread[0].text).toBe('Look at this paragraph');
+    expect(unread[0].text).toBe("Look at this paragraph");
   });
 
-  it('marks messages as read after processing', () => {
-    const ctrlDoc = getOrCreateDocument('__tandem_ctrl_chat_test_2__');
-    const chatMap = ctrlDoc.getMap('chat');
+  it("marks messages as read after processing", () => {
+    const ctrlDoc = getOrCreateDocument("__tandem_ctrl_chat_test_2__");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     const msg: ChatMessage = {
-      id: 'msg_test_002',
-      author: 'user',
-      text: 'Check this section',
+      id: "msg_test_002",
+      author: "user",
+      text: "Check this section",
       timestamp: Date.now(),
       read: false,
     };
@@ -62,36 +63,36 @@ describe('Y.Map chat message operations', () => {
     expect(afterRead.read).toBe(true);
   });
 
-  it('writes a claude reply to chat map', () => {
-    const ctrlDoc = getOrCreateDocument('__tandem_ctrl_chat_test_3__');
-    const chatMap = ctrlDoc.getMap('chat');
+  it("writes a claude reply to chat map", () => {
+    const ctrlDoc = getOrCreateDocument("__tandem_ctrl_chat_test_3__");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
     const id = generateMessageId();
     const reply: ChatMessage = {
       id,
-      author: 'claude',
-      text: 'I see the issue. Here is a suggestion...',
+      author: "claude",
+      text: "I see the issue. Here is a suggestion...",
       timestamp: Date.now(),
       read: true,
     };
     chatMap.set(id, reply);
 
     const stored = chatMap.get(id) as ChatMessage;
-    expect(stored.author).toBe('claude');
-    expect(stored.text).toContain('I see the issue');
+    expect(stored.author).toBe("claude");
+    expect(stored.text).toContain("I see the issue");
     expect(stored.read).toBe(true);
   });
 
-  it('links reply to original message via replyTo', () => {
-    const ctrlDoc = getOrCreateDocument('__tandem_ctrl_chat_test_4__');
-    const chatMap = ctrlDoc.getMap('chat');
+  it("links reply to original message via replyTo", () => {
+    const ctrlDoc = getOrCreateDocument("__tandem_ctrl_chat_test_4__");
+    const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
 
-    const originalId = 'msg_original_123';
+    const originalId = "msg_original_123";
     const replyId = generateMessageId();
     const reply: ChatMessage = {
       id: replyId,
-      author: 'claude',
-      text: 'Response to your question',
+      author: "claude",
+      text: "Response to your question",
       timestamp: Date.now(),
       replyTo: originalId,
       read: true,

--- a/tests/server/document-service.test.ts
+++ b/tests/server/document-service.test.ts
@@ -15,7 +15,7 @@ import {
   broadcastOpenDocs,
 } from "../../src/server/mcp/document-service.js";
 import type { OpenDoc } from "../../src/server/mcp/document-service.js";
-import { CTRL_ROOM } from "../../src/shared/constants.js";
+import { CTRL_ROOM, Y_MAP_DOCUMENT_META } from "../../src/shared/constants.js";
 
 function makeOpenDoc(id: string, filePath = `/tmp/${id}.md`): OpenDoc {
   return { id, filePath, format: "md", readOnly: false, source: "file" };
@@ -184,7 +184,7 @@ describe("broadcastOpenDocs", () => {
     broadcastOpenDocs();
 
     const ctrl = getOrCreateDocument(CTRL_ROOM);
-    const meta = ctrl.getMap("documentMeta");
+    const meta = ctrl.getMap(Y_MAP_DOCUMENT_META);
     const docs = meta.get("openDocuments") as any[];
     const activeId = meta.get("activeDocumentId");
 
@@ -202,12 +202,12 @@ describe("broadcastOpenDocs", () => {
     broadcastOpenDocs();
 
     const docA = getOrCreateDocument("room-a");
-    const metaA = docA.getMap("documentMeta");
+    const metaA = docA.getMap(Y_MAP_DOCUMENT_META);
     const docsA = metaA.get("openDocuments") as any[];
     expect(docsA).toHaveLength(2);
 
     const docB = getOrCreateDocument("room-b");
-    const metaB = docB.getMap("documentMeta");
+    const metaB = docB.getMap(Y_MAP_DOCUMENT_META);
     const docsB = metaB.get("openDocuments") as any[];
     expect(docsB).toHaveLength(2);
   });
@@ -216,7 +216,7 @@ describe("broadcastOpenDocs", () => {
     broadcastOpenDocs();
 
     const ctrl = getOrCreateDocument(CTRL_ROOM);
-    const meta = ctrl.getMap("documentMeta");
+    const meta = ctrl.getMap(Y_MAP_DOCUMENT_META);
     const docs = meta.get("openDocuments") as any[];
     expect(docs).toEqual([]);
     expect(meta.get("activeDocumentId")).toBeNull();

--- a/tests/server/multi-document.test.ts
+++ b/tests/server/multi-document.test.ts
@@ -1,80 +1,85 @@
-import { describe, it, expect } from 'vitest';
-import { getOrCreateDocument } from '../../src/server/yjs/provider.js';
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
+import { describe, it, expect } from "vitest";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import {
-  docIdFromPath, getCurrentDoc,
-  populateYDoc, extractText,
-} from '../../src/server/mcp/document.js';
+  docIdFromPath,
+  getCurrentDoc,
+  populateYDoc,
+  extractText,
+} from "../../src/server/mcp/document.js";
 
-describe('docIdFromPath', () => {
-  it('generates stable IDs from the same path', () => {
-    const id1 = docIdFromPath('C:\\Users\\test\\report.md');
-    const id2 = docIdFromPath('C:\\Users\\test\\report.md');
+describe("docIdFromPath", () => {
+  it("generates stable IDs from the same path", () => {
+    const id1 = docIdFromPath("C:\\Users\\test\\report.md");
+    const id2 = docIdFromPath("C:\\Users\\test\\report.md");
     expect(id1).toBe(id2);
   });
 
-  it('generates different IDs for different paths', () => {
-    const id1 = docIdFromPath('C:\\Users\\test\\report.md');
-    const id2 = docIdFromPath('C:\\Users\\test\\invoice.md');
+  it("generates different IDs for different paths", () => {
+    const id1 = docIdFromPath("C:\\Users\\test\\report.md");
+    const id2 = docIdFromPath("C:\\Users\\test\\invoice.md");
     expect(id1).not.toBe(id2);
   });
 
-  it('normalizes path separators', () => {
-    const id1 = docIdFromPath('C:\\Users\\test\\report.md');
-    const id2 = docIdFromPath('C:/Users/test/report.md');
+  it("normalizes path separators", () => {
+    const id1 = docIdFromPath("C:\\Users\\test\\report.md");
+    const id2 = docIdFromPath("C:/Users/test/report.md");
     expect(id1).toBe(id2);
   });
 
-  it('produces readable IDs with filename prefix', () => {
-    const id = docIdFromPath('C:\\Users\\test\\my-report.md');
+  it("produces readable IDs with filename prefix", () => {
+    const id = docIdFromPath("C:\\Users\\test\\my-report.md");
     expect(id).toMatch(/^my-report-[a-z0-9]+$/);
   });
 
-  it('truncates long filenames', () => {
-    const id = docIdFromPath('C:\\Users\\test\\this-is-a-very-long-filename-that-should-be-truncated.md');
+  it("truncates long filenames", () => {
+    const id = docIdFromPath(
+      "C:\\Users\\test\\this-is-a-very-long-filename-that-should-be-truncated.md",
+    );
     // The name part should be at most 16 chars
-    const namePart = id.split('-').slice(0, -1).join('-');
+    const namePart = id.split("-").slice(0, -1).join("-");
     expect(namePart.length).toBeLessThanOrEqual(16);
   });
 });
 
-describe('getCurrentDoc with documentId', () => {
-  it('returns null when no docs are open', () => {
+describe("getCurrentDoc with documentId", () => {
+  it("returns null when no docs are open", () => {
     expect(getCurrentDoc()).toBeNull();
-    expect(getCurrentDoc('nonexistent')).toBeNull();
+    expect(getCurrentDoc("nonexistent")).toBeNull();
   });
 });
 
-describe('multi-document Y.Doc isolation', () => {
-  it('maintains separate Y.Docs for different room names', () => {
-    const doc1 = getOrCreateDocument('room-a');
-    const doc2 = getOrCreateDocument('room-b');
+describe("multi-document Y.Doc isolation", () => {
+  it("maintains separate Y.Docs for different room names", () => {
+    const doc1 = getOrCreateDocument("room-a");
+    const doc2 = getOrCreateDocument("room-b");
 
-    populateYDoc(doc1, 'Content A');
-    populateYDoc(doc2, 'Content B');
+    populateYDoc(doc1, "Content A");
+    populateYDoc(doc2, "Content B");
 
-    expect(extractText(doc1)).toBe('Content A');
-    expect(extractText(doc2)).toBe('Content B');
+    expect(extractText(doc1)).toBe("Content A");
+    expect(extractText(doc2)).toBe("Content B");
   });
 
-  it('returns the same Y.Doc for the same room name', () => {
-    const doc1 = getOrCreateDocument('room-same');
-    const doc2 = getOrCreateDocument('room-same');
+  it("returns the same Y.Doc for the same room name", () => {
+    const doc1 = getOrCreateDocument("room-same");
+    const doc2 = getOrCreateDocument("room-same");
     expect(doc1).toBe(doc2);
   });
 
-  it('maintains separate annotation maps per document', () => {
-    const doc1 = getOrCreateDocument('ann-room-1');
-    const doc2 = getOrCreateDocument('ann-room-2');
+  it("maintains separate annotation maps per document", () => {
+    const doc1 = getOrCreateDocument("ann-room-1");
+    const doc2 = getOrCreateDocument("ann-room-2");
 
-    const map1 = doc1.getMap('annotations');
-    const map2 = doc2.getMap('annotations');
+    const map1 = doc1.getMap(Y_MAP_ANNOTATIONS);
+    const map2 = doc2.getMap(Y_MAP_ANNOTATIONS);
 
-    map1.set('ann1', { id: 'ann1', type: 'comment', content: 'Note on doc 1' });
-    map2.set('ann2', { id: 'ann2', type: 'highlight', content: 'Note on doc 2' });
+    map1.set("ann1", { id: "ann1", type: "comment", content: "Note on doc 1" });
+    map2.set("ann2", { id: "ann2", type: "highlight", content: "Note on doc 2" });
 
-    expect(map1.has('ann1')).toBe(true);
-    expect(map1.has('ann2')).toBe(false);
-    expect(map2.has('ann2')).toBe(true);
-    expect(map2.has('ann1')).toBe(false);
+    expect(map1.has("ann1")).toBe(true);
+    expect(map1.has("ann2")).toBe(false);
+    expect(map2.has("ann2")).toBe(true);
+    expect(map2.has("ann1")).toBe(false);
   });
 });

--- a/tests/server/provider.test.ts
+++ b/tests/server/provider.test.ts
@@ -6,7 +6,7 @@ import {
   removeDocument,
   setShouldKeepDocument,
 } from "../../src/server/yjs/provider.js";
-import { CTRL_ROOM } from "../../src/shared/constants.js";
+import { CTRL_ROOM, Y_MAP_DOCUMENT_META } from "../../src/shared/constants.js";
 import { writeGenerationId } from "../../src/server/mcp/document-service.js";
 
 describe("Y.Doc lifecycle (provider)", () => {
@@ -87,7 +87,7 @@ describe("writeGenerationId", () => {
   it("writes a generationId to the CTRL_ROOM documentMeta", () => {
     writeGenerationId();
     const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
-    const meta = ctrlDoc.getMap("documentMeta");
+    const meta = ctrlDoc.getMap(Y_MAP_DOCUMENT_META);
     const genId = meta.get("generationId") as string;
     expect(genId).toBeDefined();
     expect(typeof genId).toBe("string");
@@ -97,7 +97,7 @@ describe("writeGenerationId", () => {
   it("produces a different generationId on each call", () => {
     writeGenerationId();
     const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
-    const meta = ctrlDoc.getMap("documentMeta");
+    const meta = ctrlDoc.getMap(Y_MAP_DOCUMENT_META);
     const first = meta.get("generationId") as string;
 
     writeGenerationId();

--- a/tests/server/session.test.ts
+++ b/tests/server/session.test.ts
@@ -1,3 +1,4 @@
+import { Y_MAP_ANNOTATIONS, Y_MAP_CHAT, Y_MAP_DOCUMENT_META } from "../../src/shared/constants.js";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as Y from "yjs";
 import fs from "fs/promises";
@@ -27,7 +28,7 @@ describe("Session persistence", () => {
     fragment.insert(0, [p]);
 
     // Add an annotation
-    const annotations = doc.getMap("annotations");
+    const annotations = doc.getMap(Y_MAP_ANNOTATIONS);
     annotations.set("ann_test_1", {
       id: "ann_test_1",
       author: "claude",
@@ -108,7 +109,7 @@ describe("Session persistence", () => {
       restoreYDoc(restored, session!);
 
       // Check annotations survived
-      const annotations = restored.getMap("annotations");
+      const annotations = restored.getMap(Y_MAP_ANNOTATIONS);
       const ann = annotations.get("ann_test_1") as any;
       expect(ann).toBeTruthy();
       expect(ann.id).toBe("ann_test_1");
@@ -148,11 +149,11 @@ describe("Session persistence", () => {
     it("preserves chat but clears openDocuments and activeDocumentId", async () => {
       // Build a ctrl doc with both chat history and stale document metadata
       const ctrlDoc = new Y.Doc();
-      const chat = ctrlDoc.getMap("chat");
+      const chat = ctrlDoc.getMap(Y_MAP_CHAT);
       chat.set("msg1", { id: "msg1", author: "user", text: "hello", timestamp: Date.now() });
       chat.set("msg2", { id: "msg2", author: "claude", text: "hi back", timestamp: Date.now() });
 
-      const meta = ctrlDoc.getMap("documentMeta");
+      const meta = ctrlDoc.getMap(Y_MAP_DOCUMENT_META);
       meta.set("openDocuments", [
         {
           id: "stale-doc-1",
@@ -174,12 +175,12 @@ describe("Session persistence", () => {
       restoreCtrlDoc(restored, savedState!);
 
       // Simulate the clear that restoreCtrlSession() now does
-      const restoredMeta = restored.getMap("documentMeta");
+      const restoredMeta = restored.getMap(Y_MAP_DOCUMENT_META);
       restoredMeta.delete("openDocuments");
       restoredMeta.delete("activeDocumentId");
 
       // Chat should survive
-      const restoredChat = restored.getMap("chat");
+      const restoredChat = restored.getMap(Y_MAP_CHAT);
       expect(restoredChat.get("msg1")).toBeTruthy();
       expect(restoredChat.get("msg2")).toBeTruthy();
       expect((restoredChat.get("msg1") as any).text).toBe("hello");
@@ -191,7 +192,7 @@ describe("Session persistence", () => {
 
     it("round-trips ctrl doc with only chat (no stale metadata)", async () => {
       const ctrlDoc = new Y.Doc();
-      const chat = ctrlDoc.getMap("chat");
+      const chat = ctrlDoc.getMap(Y_MAP_CHAT);
       chat.set("msg1", { id: "msg1", author: "user", text: "test", timestamp: 12345 });
 
       await saveCtrlSession(ctrlDoc);
@@ -201,7 +202,7 @@ describe("Session persistence", () => {
       expect(savedState).not.toBeNull();
       restoreCtrlDoc(restored, savedState!);
 
-      const restoredChat = restored.getMap("chat");
+      const restoredChat = restored.getMap(Y_MAP_CHAT);
       expect((restoredChat.get("msg1") as any).text).toBe("test");
     });
   });


### PR DESCRIPTION
## Summary
- Adds 5 named constants to `shared/constants.ts`: `Y_MAP_ANNOTATIONS`, `Y_MAP_AWARENESS`, `Y_MAP_USER_AWARENESS`, `Y_MAP_CHAT`, `Y_MAP_DOCUMENT_META`
- Replaces all raw string literals across 26 files (13 source + 13 test files)
- TypeScript now catches misspelled map key names at compile time
- Updated CLAUDE.md (Key Patterns), docs/architecture.md, docs/lessons-learned.md (Lesson 19)

## Files changed
26 files — `src/shared/constants.ts` (new constants), 12 source files (import + usage), 10 test files (import + usage), 3 doc files

## Test plan
- [x] `npm run typecheck` — zero errors
- [x] `npm test -- --run` — 617 tests pass
- [x] No remaining raw `getMap("annotations")` etc. in `src/` or `tests/`
- [ ] Manual: open doc, create annotations, use chat, verify everything works identically

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)