### PR TITLE
feat(annotations): show text snippet on annotation cards

### DIFF
--- a/src/client/panels/SidePanel.tsx
+++ b/src/client/panels/SidePanel.tsx
@@ -603,6 +603,25 @@ function AnnotationCard({
           {annotation.author === "claude" ? "Claude" : "You"}
         </span>
       </div>
+      {annotation.textSnapshot && (
+        <div
+          data-testid={`annotation-snippet-${annotation.id}`}
+          style={{
+            padding: "4px 8px",
+            marginBottom: "6px",
+            borderLeft: "3px solid #d1d5db",
+            color: "#6b7280",
+            fontSize: "12px",
+            fontStyle: "italic",
+            backgroundColor: "#f9fafb",
+            borderRadius: "2px",
+          }}
+        >
+          {annotation.textSnapshot.length > 80
+            ? annotation.textSnapshot.slice(0, 77) + "..."
+            : annotation.textSnapshot}
+        </div>
+      )}
       <p style={{ margin: 0, color: "#4b5563", lineHeight: "1.4" }}>
         {annotation.type === "suggestion"
           ? (() => {

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -49,6 +49,13 @@ function rangeFailureToError(result: Extract<RangeValidation, { ok: false }>) {
 }
 
 import { generateAnnotationId as generateId } from "../../shared/utils.js";
+
+const SNAPSHOT_CAP = 200;
+/** Capture a text snapshot from the document at the given range, truncated to SNAPSHOT_CAP chars. */
+function captureSnapshot(ydoc: Y.Doc, from: number, to: number): string {
+  const text = extractText(ydoc).slice(from, to);
+  return text.length > SNAPSHOT_CAP ? text.slice(0, SNAPSHOT_CAP - 3) + "..." : text;
+}
 export { generateId };
 
 /** Create an annotation from an anchored range result and store it in the Y.Map. Returns the annotation ID. */
@@ -115,9 +122,11 @@ export function registerAnnotationTools(server: McpServer): void {
         if (!da) return noDocumentError();
         const result = anchoredRange(da.ydoc, from, to, textSnapshot);
         if (!result.ok) return rangeFailureToError(result);
+        const snap = captureSnapshot(da.ydoc, result.range.from, result.range.to);
         const id = createAnnotation(da.map, "highlight", result, note || "", {
           color: color as HighlightColor,
           ...(priority ? { priority } : {}),
+          textSnapshot: snap,
         });
         return mcpSuccess({ annotationId: id });
       },
@@ -152,7 +161,11 @@ export function registerAnnotationTools(server: McpServer): void {
         if (!da) return noDocumentError();
         const result = anchoredRange(da.ydoc, from, to, textSnapshot);
         if (!result.ok) return rangeFailureToError(result);
-        const id = createAnnotation(da.map, "comment", result, text, priority ? { priority } : {});
+        const snap = captureSnapshot(da.ydoc, result.range.from, result.range.to);
+        const id = createAnnotation(da.map, "comment", result, text, {
+          ...(priority ? { priority } : {}),
+          textSnapshot: snap,
+        });
         return mcpSuccess({ annotationId: id });
       },
     ),
@@ -187,12 +200,13 @@ export function registerAnnotationTools(server: McpServer): void {
         if (!da) return noDocumentError();
         const result = anchoredRange(da.ydoc, from, to, textSnapshot);
         if (!result.ok) return rangeFailureToError(result);
+        const snap = captureSnapshot(da.ydoc, result.range.from, result.range.to);
         const id = createAnnotation(
           da.map,
           "suggestion",
           result,
           JSON.stringify({ newText, reason: reason || "" }),
-          priority ? { priority } : {},
+          { ...(priority ? { priority } : {}), textSnapshot: snap },
         );
         return mcpSuccess({ annotationId: id });
       },
@@ -227,13 +241,11 @@ export function registerAnnotationTools(server: McpServer): void {
         if (!da) return noDocumentError();
         const result = anchoredRange(da.ydoc, from, to, textSnapshot);
         if (!result.ok) return rangeFailureToError(result);
-        const id = createAnnotation(
-          da.map,
-          "flag",
-          result,
-          note || "",
-          priority ? { priority } : {},
-        );
+        const snap = captureSnapshot(da.ydoc, result.range.from, result.range.to);
+        const id = createAnnotation(da.map, "flag", result, note || "", {
+          ...(priority ? { priority } : {}),
+          textSnapshot: snap,
+        });
         return mcpSuccess({ annotationId: id });
       },
     ),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -57,6 +57,8 @@ export interface Annotation {
   timestamp: number;
   color?: HighlightColor;
   priority?: AnnotationPriority;
+  /** Snapshot of the annotated document text at creation time. Truncated to 200 chars. */
+  textSnapshot?: string;
 }
 
 export interface AnchoredRange {

--- a/tests/server/annotation-text-snapshot.test.ts
+++ b/tests/server/annotation-text-snapshot.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { createAnnotation, collectAnnotations } from "../../src/server/mcp/annotations.js";
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
+
+function makeResult(from: number, to: number) {
+  return { ok: true as const, fullyAnchored: false as const, range: { from, to } };
+}
+
+describe("annotation textSnapshot", () => {
+  it("stores textSnapshot when provided via extras", () => {
+    const ydoc = new Y.Doc();
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const id = createAnnotation(map, "comment", makeResult(0, 10), "Nice paragraph", {
+      textSnapshot: "hello worl",
+    });
+    const annotations = collectAnnotations(map);
+    const stored = annotations.find((a) => a.id === id);
+    expect(stored).toBeDefined();
+    expect(stored?.textSnapshot).toBe("hello worl");
+  });
+
+  it("works without textSnapshot (legacy compatibility)", () => {
+    const ydoc = new Y.Doc();
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const id = createAnnotation(map, "highlight", makeResult(0, 5), "Looks good");
+    const annotations = collectAnnotations(map);
+    const stored = annotations.find((a) => a.id === id);
+    expect(stored).toBeDefined();
+    expect(stored?.textSnapshot).toBeUndefined();
+  });
+
+  it("stores textSnapshot alongside priority", () => {
+    const ydoc = new Y.Doc();
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const id = createAnnotation(map, "flag", makeResult(5, 20), "Needs review", {
+      priority: "urgent",
+      textSnapshot: "flagged text",
+    });
+    const annotations = collectAnnotations(map);
+    const stored = annotations.find((a) => a.id === id);
+    expect(stored?.textSnapshot).toBe("flagged text");
+    expect(stored?.priority).toBe("urgent");
+  });
+});
+
+describe("snapshot truncation (inline logic)", () => {
+  const cap = 200;
+  function truncate(text: string): string {
+    return text.length > cap ? text.slice(0, cap - 3) + "..." : text;
+  }
+
+  it("truncates text longer than 200 chars", () => {
+    const long = "a".repeat(250);
+    expect(truncate(long)).toHaveLength(200);
+    expect(truncate(long).endsWith("...")).toBe(true);
+  });
+
+  it("keeps text at exactly 200 chars unchanged", () => {
+    const exact = "b".repeat(200);
+    expect(truncate(exact)).toBe(exact);
+  });
+
+  it("keeps short text unchanged", () => {
+    expect(truncate("short")).toBe("short");
+  });
+});


### PR DESCRIPTION
## Summary
- Capture annotated document text at annotation creation time, truncate to 200 chars
- Display as a muted italic quote block on annotation cards in the SidePanel (80-char display limit)
- Guards for `undefined` on legacy annotations created before this change

## Test plan
- [x] Unit tests: textSnapshot storage, truncation, legacy compat (6 tests)
- [x] Typecheck passes
- [ ] Manual: open file, create comment via MCP, verify snippet on card
- [ ] Manual: create comment on >80 char text, verify truncation with ellipsis

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)