### PR TITLE
feat(ui): configurable user display name

### DIFF
--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { USER_NAME_KEY, USER_NAME_DEFAULT } from "../../shared/constants.js";
 import { useEditor, EditorContent } from "@tiptap/react";
 import type { Editor as TiptapEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
@@ -56,7 +57,10 @@ export function Editor({
         }),
         CollaborationCursor.configure({
           provider: provider,
-          user: { name: "Bryan", color: "#f59e0b" },
+          user: {
+            name: localStorage.getItem(USER_NAME_KEY)?.trim() || USER_NAME_DEFAULT,
+            color: "#f59e0b",
+          },
         }),
         AnnotationExtension.configure({ ydoc }),
         AwarenessExtension.configure({ ydoc }),

--- a/src/client/status/StatusBar.tsx
+++ b/src/client/status/StatusBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { CLAUDE_PRESENCE_COLOR } from "../../shared/constants";
+import { CLAUDE_PRESENCE_COLOR, USER_NAME_KEY, USER_NAME_DEFAULT } from "../../shared/constants";
 import type { InterruptionMode } from "../../shared/types";
 
 interface StatusBarProps {
@@ -36,6 +36,16 @@ export function StatusBar({
   onModeChange,
   heldCount,
 }: StatusBarProps) {
+  const [userName, setUserName] = useState(
+    () => localStorage.getItem(USER_NAME_KEY)?.trim() || USER_NAME_DEFAULT,
+  );
+  const [nameInput, setNameInput] = useState(userName);
+  const commitName = () => {
+    const trimmed = nameInput.trim() || USER_NAME_DEFAULT;
+    setUserName(trimmed);
+    setNameInput(trimmed);
+    localStorage.setItem(USER_NAME_KEY, trimmed);
+  };
   const [showReconnectedFlash, setShowReconnectedFlash] = useState(false);
   const [showServerBanner, setShowServerBanner] = useState(false);
   const prevConnected = useRef(connected);
@@ -151,6 +161,44 @@ export function StatusBar({
         </div>
       </div>
 
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "4px",
+          fontSize: "11px",
+          color: "#9ca3af",
+        }}
+      >
+        <span>You:</span>
+        <input
+          data-testid="user-name-input"
+          type="text"
+          value={nameInput}
+          onChange={(e) => setNameInput(e.target.value)}
+          onBlur={commitName}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+            if (e.key === "Escape") {
+              setNameInput(userName);
+              e.currentTarget.blur();
+            }
+          }}
+          aria-label="Display name"
+          title="Your display name (updates on next tab switch or refresh)"
+          maxLength={40}
+          style={{
+            background: "transparent",
+            border: "none",
+            borderBottom: "1px solid #e5e7eb",
+            color: "#6b7280",
+            fontSize: "11px",
+            width: "80px",
+            outline: "none",
+            padding: "0 2px",
+          }}
+        />
+      </div>
       {readOnly && (
         <span
           style={{

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -46,3 +46,6 @@ export const SERVER_INFO_FILE = ".tandem/.server-info";
 
 export const RECENT_FILES_KEY = "tandem:recentFiles";
 export const RECENT_FILES_CAP = 20;
+
+export const USER_NAME_KEY = "tandem:userName";
+export const USER_NAME_DEFAULT = "You";

--- a/tests/client/user-name.test.ts
+++ b/tests/client/user-name.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { USER_NAME_DEFAULT } from "../../src/shared/constants.js";
+
+function resolveUserName(stored: string | null): string {
+  return stored?.trim() || USER_NAME_DEFAULT;
+}
+
+describe("resolveUserName", () => {
+  it("returns stored name when valid", () => {
+    expect(resolveUserName("Alice")).toBe("Alice");
+  });
+
+  it("returns default for null", () => {
+    expect(resolveUserName(null)).toBe(USER_NAME_DEFAULT);
+  });
+
+  it("returns default for empty string", () => {
+    expect(resolveUserName("")).toBe(USER_NAME_DEFAULT);
+  });
+
+  it("returns default for whitespace-only", () => {
+    expect(resolveUserName("   ")).toBe(USER_NAME_DEFAULT);
+  });
+
+  it("trims whitespace from valid name", () => {
+    expect(resolveUserName("  Bob  ")).toBe("Bob");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace hardcoded "Bryan" cursor name with localStorage-backed configurable name
- Editable inline input in StatusBar, defaults to "You"
- Name updates on next editor mount (tab switch or refresh)
- Trim + fallback logic handles empty/whitespace input

## Test plan
- [x] Unit tests: resolve logic (null, empty, whitespace, trim) — 5 tests
- [x] Typecheck passes
- [ ] Manual: change name in StatusBar, switch tabs, verify cursor label
- [ ] Manual: refresh page, verify name persisted

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)