### PR TITLE
feat(ui): add review-only banner for .docx files

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -8,6 +8,7 @@ import { Toolbar } from "./editor/toolbar/Toolbar";
 import { DocumentTabs } from "./tabs/DocumentTabs";
 import { ReviewSummary } from "./panels/ReviewSummary";
 import { HelpModal } from "./components/HelpModal";
+import { ReviewOnlyBanner } from "./components/ReviewOnlyBanner";
 import {
   INTERRUPTION_MODE_DEFAULT,
   INTERRUPTION_MODE_KEY,
@@ -263,6 +264,9 @@ export default function App() {
           onDragLeave={handleEditorDragLeave}
           onDrop={handleEditorDrop}
         >
+          <ReviewOnlyBanner
+            visible={activeTab?.readOnly === true && activeTab?.format === "docx"}
+          />
           {activeTab ? (
             <Editor
               key={activeTab.id}

--- a/src/client/components/ReviewOnlyBanner.tsx
+++ b/src/client/components/ReviewOnlyBanner.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+const DISMISS_KEY = "tandem:reviewOnlyBannerDismissed";
+
+interface ReviewOnlyBannerProps {
+  visible: boolean;
+}
+
+export function ReviewOnlyBanner({ visible }: ReviewOnlyBannerProps) {
+  const [dismissed, setDismissed] = useState(() => localStorage.getItem(DISMISS_KEY) === "true");
+
+  if (!visible || dismissed) return null;
+
+  return (
+    <div
+      data-testid="review-only-banner"
+      style={{
+        padding: "8px 16px",
+        backgroundColor: "#eff6ff",
+        borderBottom: "1px solid #bfdbfe",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        fontSize: "13px",
+        color: "#1e40af",
+      }}
+    >
+      <span>
+        This document is open in review-only mode. You can add annotations and review, but cannot
+        edit directly.
+      </span>
+      <button
+        type="button"
+        data-testid="review-only-dismiss"
+        onClick={() => {
+          localStorage.setItem(DISMISS_KEY, "true");
+          setDismissed(true);
+        }}
+        style={{
+          background: "none",
+          border: "none",
+          color: "#1e40af",
+          cursor: "pointer",
+          fontWeight: 500,
+          fontSize: "13px",
+          padding: "2px 8px",
+          whiteSpace: "nowrap",
+        }}
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Dismissible info banner explaining review-only mode when a .docx is open
- Global dismiss via localStorage — educational banner, not per-file
- Renders between DocumentTabs and editor area, only for readOnly + docx tabs

## Test plan
- [x] Typecheck passes
- [ ] Manual: open .docx, verify banner appears with explanation
- [ ] Manual: dismiss, refresh, reopen .docx — verify stays dismissed
- [ ] Manual: open .md — verify NO banner

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)