### PR TITLE
refactor: consolidate test helpers, remove unused deps, delete stubs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "express": "^5.2.1",
         "htmlparser2": "^12.0.0",
         "mammoth": "^1.8.0",
-        "open": "^10.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
@@ -3159,21 +3158,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -3697,46 +3681,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -4965,21 +4909,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5023,24 +4952,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -5066,21 +4977,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6786,24 +6682,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/option": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
@@ -7707,18 +7585,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/run-applescript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rxjs": {
@@ -9445,21 +9311,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "express": "^5.2.1",
     "htmlparser2": "^12.0.0",
     "mammoth": "^1.8.0",
-    "open": "^10.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",

--- a/src/client/editor/extensions/overlay.ts
+++ b/src/client/editor/extensions/overlay.ts
@@ -1,4 +1,0 @@
-// Custom Tiptap extension for analysis overlays
-// Background tint on text ranges with hover tooltips
-// TODO: Implement using ProseMirror DecorationSet
-export {};

--- a/src/client/editor/extensions/suggestion.ts
+++ b/src/client/editor/extensions/suggestion.ts
@@ -1,4 +1,0 @@
-// Custom Tiptap extension for tracked-change suggestions
-// Red strikethrough for deletions, blue underline for insertions
-// TODO: Implement as Tiptap decoration plugin
-export {};

--- a/tests/client/annotation-gate.test.ts
+++ b/tests/client/annotation-gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { shouldShow } from "../../src/client/hooks/useAnnotationGate.js";
 import type { Annotation, InterruptionMode } from "../../src/shared/types.js";
+import { makeAnnotation } from "../helpers/ydoc-factory.js";
 
 /**
  * Inline implementation of the useAnnotationGate hook logic (without React useMemo).
@@ -17,19 +18,6 @@ function gateAnnotations(annotations: Annotation[], mode: InterruptionMode) {
     }
   }
   return { visibleAnnotations, heldCount };
-}
-
-function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
-  return {
-    id: "ann_test_001",
-    author: "claude",
-    type: "comment",
-    range: { from: 0, to: 5 },
-    content: "test",
-    status: "pending",
-    timestamp: Date.now(),
-    ...overrides,
-  };
 }
 
 describe("shouldShow", () => {

--- a/tests/client/coordinate-conversion.test.ts
+++ b/tests/client/coordinate-conversion.test.ts
@@ -5,9 +5,8 @@ import {
   annotationToPmRange,
   relRangeToPmPositions,
 } from "../../src/client/positions";
-import { makeDoc, getFragment } from "../helpers/ydoc-factory";
+import { makeDoc, getFragment, makeAnnotation } from "../helpers/ydoc-factory";
 import { flatOffsetToRelPos } from "../../src/server/positions";
-import type { Annotation } from "../../src/shared/types";
 
 // Minimal ProseMirror-compatible mock. Assumes single flat text run per block
 // (no inline marks). nodeSize = 1 (open) + text.length + 1 (close).
@@ -148,25 +147,6 @@ describe("round-trip: pmPosToFlatOffset(flatOffsetToPmPos(offset)) === offset", 
     }
   });
 });
-
-// ---------------------------------------------------------------------------
-// Helper: create a test annotation with optional relRange from a Y.Doc
-// ---------------------------------------------------------------------------
-
-function makeAnnotation(
-  overrides: Partial<Annotation> & { range?: { from: number; to: number } },
-): Annotation {
-  return {
-    id: "test-1",
-    author: "claude",
-    type: "comment",
-    range: { from: 0, to: 5 },
-    content: "test",
-    status: "pending",
-    timestamp: Date.now(),
-    ...overrides,
-  };
-}
 
 // ---------------------------------------------------------------------------
 // annotationToPmRange

--- a/tests/helpers/ydoc-factory.ts
+++ b/tests/helpers/ydoc-factory.ts
@@ -3,6 +3,7 @@ import * as Y from "yjs";
 import { populateYDoc } from "../../src/server/mcp/document.js";
 import { loadMarkdown } from "../../src/server/file-io/markdown.js";
 import { anchoredRange } from "../../src/server/positions.js";
+import type { Annotation } from "../../src/shared/types.js";
 
 /** Create a Y.Doc populated with text content */
 export function makeDoc(text: string): Y.Doc {
@@ -31,6 +32,20 @@ export function makeMarkdownDoc(md: string): Y.Doc {
 /** Shortcut to get the 'annotations' Y.Map */
 export function getAnnotationsMap(doc: Y.Doc): Y.Map<unknown> {
   return doc.getMap(Y_MAP_ANNOTATIONS);
+}
+
+/** Create a test annotation with sensible defaults and optional overrides. */
+export function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: "ann_test_001",
+    author: "claude",
+    type: "comment",
+    range: { from: 0, to: 5 },
+    content: "test",
+    status: "pending",
+    timestamp: Date.now(),
+    ...overrides,
+  };
 }
 
 /** Create an anchored range (flat + CRDT) for annotation creation in tests. */

--- a/tests/server/docx.test.ts
+++ b/tests/server/docx.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import * as Y from 'yjs';
-import { htmlToYDoc, exportAnnotations } from '../../src/server/file-io/docx.js';
-import { getElementText } from '../../src/server/mcp/document.js';
-import { getFragment } from '../helpers/ydoc-factory.js';
-import type { Annotation } from '../../src/shared/types.js';
+import { describe, it, expect, afterEach } from "vitest";
+import * as Y from "yjs";
+import { htmlToYDoc, exportAnnotations } from "../../src/server/file-io/docx.js";
+import { getElementText } from "../../src/server/mcp/document.js";
+import type { Annotation } from "../../src/shared/types.js";
+import { getFragment, makeAnnotation } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 
@@ -19,86 +19,86 @@ function loadHtml(html: string): Y.Doc {
 
 // -- Block elements --
 
-describe('htmlToYDoc — block elements', () => {
-  it.each([1, 2, 3, 4, 5, 6])('h%i → heading with correct level', (level) => {
+describe("htmlToYDoc — block elements", () => {
+  it.each([1, 2, 3, 4, 5, 6])("h%i → heading with correct level", (level) => {
     loadHtml(`<h${level}>Title</h${level}>`);
     const frag = getFragment(doc);
     expect(frag.length).toBe(1);
     const el = frag.get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('heading');
-    expect(el.getAttribute('level')).toBe(level);
-    expect(getElementText(el)).toBe('Title');
+    expect(el.nodeName).toBe("heading");
+    expect(el.getAttribute("level")).toBe(level);
+    expect(getElementText(el)).toBe("Title");
   });
 
-  it('paragraph', () => {
-    loadHtml('<p>Hello world</p>');
+  it("paragraph", () => {
+    loadHtml("<p>Hello world</p>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('paragraph');
-    expect(getElementText(el)).toBe('Hello world');
+    expect(el.nodeName).toBe("paragraph");
+    expect(getElementText(el)).toBe("Hello world");
   });
 
-  it('multiple paragraphs', () => {
-    loadHtml('<p>First</p><p>Second</p>');
+  it("multiple paragraphs", () => {
+    loadHtml("<p>First</p><p>Second</p>");
     const frag = getFragment(doc);
     expect(frag.length).toBe(2);
-    expect(getElementText(frag.get(0) as Y.XmlElement)).toBe('First');
-    expect(getElementText(frag.get(1) as Y.XmlElement)).toBe('Second');
+    expect(getElementText(frag.get(0) as Y.XmlElement)).toBe("First");
+    expect(getElementText(frag.get(1) as Y.XmlElement)).toBe("Second");
   });
 
-  it('blockquote with nested paragraph', () => {
-    loadHtml('<blockquote><p>quoted text</p></blockquote>');
+  it("blockquote with nested paragraph", () => {
+    loadHtml("<blockquote><p>quoted text</p></blockquote>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('blockquote');
+    expect(el.nodeName).toBe("blockquote");
     expect(el.length).toBe(1);
     const inner = el.get(0) as Y.XmlElement;
-    expect(inner.nodeName).toBe('paragraph');
-    expect(getElementText(inner)).toBe('quoted text');
+    expect(inner.nodeName).toBe("paragraph");
+    expect(getElementText(inner)).toBe("quoted text");
   });
 
-  it('unordered list', () => {
-    loadHtml('<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>');
+  it("unordered list", () => {
+    loadHtml("<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('bulletList');
+    expect(el.nodeName).toBe("bulletList");
     expect(el.length).toBe(2);
     const item1 = el.get(0) as Y.XmlElement;
-    expect(item1.nodeName).toBe('listItem');
-    expect(getElementText(item1)).toBe('Item 1');
+    expect(item1.nodeName).toBe("listItem");
+    expect(getElementText(item1)).toBe("Item 1");
   });
 
-  it('ordered list with start', () => {
+  it("ordered list with start", () => {
     loadHtml('<ol start="5"><li><p>Fifth</p></li></ol>');
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('orderedList');
-    expect(el.getAttribute('start')).toBe(5);
+    expect(el.nodeName).toBe("orderedList");
+    expect(el.getAttribute("start")).toBe(5);
   });
 
-  it('code block', () => {
-    loadHtml('<pre><code>const x = 1;</code></pre>');
+  it("code block", () => {
+    loadHtml("<pre><code>const x = 1;</code></pre>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('codeBlock');
-    expect(getElementText(el)).toBe('const x = 1;');
+    expect(el.nodeName).toBe("codeBlock");
+    expect(getElementText(el)).toBe("const x = 1;");
   });
 
-  it('horizontal rule', () => {
-    loadHtml('<hr>');
+  it("horizontal rule", () => {
+    loadHtml("<hr>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('horizontalRule');
+    expect(el.nodeName).toBe("horizontalRule");
   });
 
-  it('image', () => {
+  it("image", () => {
     loadHtml('<img src="test.png" alt="A test" title="Test Image">');
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('image');
-    expect(el.getAttribute('src')).toBe('test.png');
-    expect(el.getAttribute('alt')).toBe('A test');
-    expect(el.getAttribute('title')).toBe('Test Image');
+    expect(el.nodeName).toBe("image");
+    expect(el.getAttribute("src")).toBe("test.png");
+    expect(el.getAttribute("alt")).toBe("A test");
+    expect(el.getAttribute("title")).toBe("Test Image");
   });
 });
 
 // -- Table elements --
 
-describe('htmlToYDoc — tables', () => {
-  it('basic table with header and data cells', () => {
+describe("htmlToYDoc — tables", () => {
+  it("basic table with header and data cells", () => {
     loadHtml(`
       <table>
         <tr><th>Name</th><th>Value</th></tr>
@@ -106,33 +106,33 @@ describe('htmlToYDoc — tables', () => {
       </table>
     `);
     const table = getFragment(doc).get(0) as Y.XmlElement;
-    expect(table.nodeName).toBe('table');
+    expect(table.nodeName).toBe("table");
     expect(table.length).toBe(2); // 2 rows
 
     const headerRow = table.get(0) as Y.XmlElement;
-    expect(headerRow.nodeName).toBe('tableRow');
+    expect(headerRow.nodeName).toBe("tableRow");
     const th = headerRow.get(0) as Y.XmlElement;
-    expect(th.nodeName).toBe('tableHeader');
+    expect(th.nodeName).toBe("tableHeader");
     // Cell must contain a paragraph (Tiptap content: 'block+')
     const cellPara = th.get(0) as Y.XmlElement;
-    expect(cellPara.nodeName).toBe('paragraph');
-    expect(getElementText(cellPara)).toBe('Name');
+    expect(cellPara.nodeName).toBe("paragraph");
+    expect(getElementText(cellPara)).toBe("Name");
 
     const dataRow = table.get(1) as Y.XmlElement;
     const td = dataRow.get(0) as Y.XmlElement;
-    expect(td.nodeName).toBe('tableCell');
+    expect(td.nodeName).toBe("tableCell");
   });
 
-  it('table with colspan and rowspan', () => {
+  it("table with colspan and rowspan", () => {
     loadHtml('<table><tr><td colspan="2" rowspan="3">Merged</td></tr></table>');
     const table = getFragment(doc).get(0) as Y.XmlElement;
     const row = table.get(0) as Y.XmlElement;
     const cell = row.get(0) as Y.XmlElement;
-    expect(cell.getAttribute('colspan')).toBe(2);
-    expect(cell.getAttribute('rowspan')).toBe(3);
+    expect(cell.getAttribute("colspan")).toBe(2);
+    expect(cell.getAttribute("rowspan")).toBe(3);
   });
 
-  it('table with tbody wrapper', () => {
+  it("table with tbody wrapper", () => {
     loadHtml(`
       <table>
         <thead><tr><th>H</th></tr></thead>
@@ -146,51 +146,51 @@ describe('htmlToYDoc — tables', () => {
 
 // -- Inline marks --
 
-describe('htmlToYDoc — inline marks', () => {
-  it('bold text', () => {
-    loadHtml('<p><strong>bold</strong></p>');
+describe("htmlToYDoc — inline marks", () => {
+  it("bold text", () => {
+    loadHtml("<p><strong>bold</strong></p>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
     const textNode = el.get(0) as Y.XmlText;
     const delta = textNode.toDelta();
     expect(delta.length).toBe(1);
-    expect(delta[0].insert).toBe('bold');
+    expect(delta[0].insert).toBe("bold");
     expect(delta[0].attributes?.bold).toEqual({});
   });
 
-  it('italic text', () => {
-    loadHtml('<p><em>italic</em></p>');
+  it("italic text", () => {
+    loadHtml("<p><em>italic</em></p>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
     const textNode = el.get(0) as Y.XmlText;
     const delta = textNode.toDelta();
     expect(delta[0].attributes?.italic).toEqual({});
   });
 
-  it('underline text', () => {
-    loadHtml('<p><u>underlined</u></p>');
+  it("underline text", () => {
+    loadHtml("<p><u>underlined</u></p>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
     const textNode = el.get(0) as Y.XmlText;
     const delta = textNode.toDelta();
     expect(delta[0].attributes?.underline).toEqual({});
   });
 
-  it('strikethrough text', () => {
-    loadHtml('<p><s>deleted</s></p>');
+  it("strikethrough text", () => {
+    loadHtml("<p><s>deleted</s></p>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
     const textNode = el.get(0) as Y.XmlText;
     const delta = textNode.toDelta();
     expect(delta[0].attributes?.strike).toEqual({});
   });
 
-  it('link', () => {
+  it("link", () => {
     loadHtml('<p><a href="https://example.com">click</a></p>');
     const el = getFragment(doc).get(0) as Y.XmlElement;
     const textNode = el.get(0) as Y.XmlText;
     const delta = textNode.toDelta();
-    expect(delta[0].attributes?.link).toEqual({ href: 'https://example.com' });
+    expect(delta[0].attributes?.link).toEqual({ href: "https://example.com" });
   });
 
-  it('superscript and subscript', () => {
-    loadHtml('<p><sup>up</sup><sub>down</sub></p>');
+  it("superscript and subscript", () => {
+    loadHtml("<p><sup>up</sup><sub>down</sub></p>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
     const textNode = el.get(0) as Y.XmlText;
     const delta = textNode.toDelta();
@@ -198,36 +198,36 @@ describe('htmlToYDoc — inline marks', () => {
     expect(delta[1].attributes?.subscript).toEqual({});
   });
 
-  it('nested marks: bold + italic', () => {
-    loadHtml('<p><strong><em>bold italic</em></strong></p>');
+  it("nested marks: bold + italic", () => {
+    loadHtml("<p><strong><em>bold italic</em></strong></p>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
     const textNode = el.get(0) as Y.XmlText;
     const delta = textNode.toDelta();
-    expect(delta[0].insert).toBe('bold italic');
+    expect(delta[0].insert).toBe("bold italic");
     expect(delta[0].attributes?.bold).toEqual({});
     expect(delta[0].attributes?.italic).toEqual({});
   });
 
-  it('mixed plain and formatted text', () => {
-    loadHtml('<p>plain <strong>bold</strong> plain</p>');
+  it("mixed plain and formatted text", () => {
+    loadHtml("<p>plain <strong>bold</strong> plain</p>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
     const textNode = el.get(0) as Y.XmlText;
     const delta = textNode.toDelta();
     expect(delta.length).toBe(3);
-    expect(delta[0].insert).toBe('plain ');
+    expect(delta[0].insert).toBe("plain ");
     // Null marks are set via buildAttrs but Yjs delta omits null-valued attrs
     expect(delta[0].attributes?.bold).toBeFalsy();
-    expect(delta[1].insert).toBe('bold');
+    expect(delta[1].insert).toBe("bold");
     expect(delta[1].attributes?.bold).toEqual({});
-    expect(delta[2].insert).toBe(' plain');
+    expect(delta[2].insert).toBe(" plain");
     expect(delta[2].attributes?.bold).toBeFalsy();
   });
 });
 
 // -- Nested structures --
 
-describe('htmlToYDoc — nested structures', () => {
-  it('list item with paragraph and nested list', () => {
+describe("htmlToYDoc — nested structures", () => {
+  it("list item with paragraph and nested list", () => {
     loadHtml(`
       <ul>
         <li>
@@ -237,128 +237,126 @@ describe('htmlToYDoc — nested structures', () => {
       </ul>
     `);
     const list = getFragment(doc).get(0) as Y.XmlElement;
-    expect(list.nodeName).toBe('bulletList');
+    expect(list.nodeName).toBe("bulletList");
     const item = list.get(0) as Y.XmlElement;
-    expect(item.nodeName).toBe('listItem');
+    expect(item.nodeName).toBe("listItem");
     expect(item.length).toBe(2); // paragraph + nested bulletList
-    expect((item.get(0) as Y.XmlElement).nodeName).toBe('paragraph');
-    expect((item.get(1) as Y.XmlElement).nodeName).toBe('bulletList');
+    expect((item.get(0) as Y.XmlElement).nodeName).toBe("paragraph");
+    expect((item.get(1) as Y.XmlElement).nodeName).toBe("bulletList");
   });
 
-  it('blockquote with multiple paragraphs', () => {
-    loadHtml('<blockquote><p>First</p><p>Second</p></blockquote>');
+  it("blockquote with multiple paragraphs", () => {
+    loadHtml("<blockquote><p>First</p><p>Second</p></blockquote>");
     const bq = getFragment(doc).get(0) as Y.XmlElement;
-    expect(bq.nodeName).toBe('blockquote');
+    expect(bq.nodeName).toBe("blockquote");
     expect(bq.length).toBe(2);
   });
 });
 
 // -- Edge cases --
 
-describe('htmlToYDoc — edge cases', () => {
-  it('empty HTML produces empty fragment', () => {
-    loadHtml('');
+describe("htmlToYDoc — edge cases", () => {
+  it("empty HTML produces empty fragment", () => {
+    loadHtml("");
     expect(getFragment(doc).length).toBe(0);
   });
 
-  it('whitespace-only HTML produces empty fragment', () => {
-    loadHtml('   \n  ');
+  it("whitespace-only HTML produces empty fragment", () => {
+    loadHtml("   \n  ");
     expect(getFragment(doc).length).toBe(0);
   });
 
-  it('clears existing content before populating', () => {
+  it("clears existing content before populating", () => {
     doc = new Y.Doc();
-    const fragment = doc.getXmlFragment('default');
-    const existing = new Y.XmlElement('paragraph');
-    existing.insert(0, [new Y.XmlText('old')]);
+    const fragment = doc.getXmlFragment("default");
+    const existing = new Y.XmlElement("paragraph");
+    existing.insert(0, [new Y.XmlText("old")]);
     fragment.insert(0, [existing]);
     expect(fragment.length).toBe(1);
 
-    htmlToYDoc(doc, '<p>new</p>');
+    htmlToYDoc(doc, "<p>new</p>");
     expect(fragment.length).toBe(1);
-    expect(getElementText(fragment.get(0) as Y.XmlElement)).toBe('new');
+    expect(getElementText(fragment.get(0) as Y.XmlElement)).toBe("new");
   });
 });
 
 // -- Two-pass verification --
 
-describe('htmlToYDoc — two-pass text population', () => {
-  it('marks render in correct order after two-pass', () => {
+describe("htmlToYDoc — two-pass text population", () => {
+  it("marks render in correct order after two-pass", () => {
     // This test verifies ADR-009: text populated on detached nodes reverses insert order
-    loadHtml('<p>a <strong>b</strong> c</p>');
+    loadHtml("<p>a <strong>b</strong> c</p>");
     const el = getFragment(doc).get(0) as Y.XmlElement;
     const textNode = el.get(0) as Y.XmlText;
     const delta = textNode.toDelta();
 
     // Verify order is preserved: "a " then "b" then " c"
-    expect(delta[0].insert).toBe('a ');
-    expect(delta[1].insert).toBe('b');
+    expect(delta[0].insert).toBe("a ");
+    expect(delta[1].insert).toBe("b");
     expect(delta[1].attributes?.bold).toEqual({});
-    expect(delta[2].insert).toBe(' c');
+    expect(delta[2].insert).toBe(" c");
   });
 });
 
 // -- exportAnnotations --
 
-describe('exportAnnotations', () => {
-  function makeAnnotation(overrides: Partial<Annotation>): Annotation {
-    return {
-      id: 'ann_1',
-      author: 'claude',
-      type: 'comment',
-      range: { from: 0, to: 5 },
-      content: 'Test comment',
-      status: 'pending',
-      timestamp: Date.now(),
-      ...overrides,
-    };
-  }
-
+describe("exportAnnotations", () => {
   it('returns "no annotations" for empty list', () => {
     doc = new Y.Doc();
     const result = exportAnnotations(doc, []);
-    expect(result).toContain('No annotations found');
+    expect(result).toContain("No annotations found");
   });
 
-  it('generates markdown grouped by type', () => {
-    loadHtml('<p>Hello world test content</p>');
+  it("generates markdown grouped by type", () => {
+    loadHtml("<p>Hello world test content</p>");
 
     const annotations: Annotation[] = [
-      makeAnnotation({ id: 'h1', type: 'highlight', range: { from: 0, to: 5 }, content: '', color: 'yellow' }),
-      makeAnnotation({ id: 'c1', type: 'comment', range: { from: 6, to: 11 }, content: 'Nice word' }),
       makeAnnotation({
-        id: 's1', type: 'suggestion', range: { from: 0, to: 5 },
-        content: JSON.stringify({ newText: 'Hi', reason: 'More casual' }),
+        id: "h1",
+        type: "highlight",
+        range: { from: 0, to: 5 },
+        content: "",
+        color: "yellow",
+      }),
+      makeAnnotation({
+        id: "c1",
+        type: "comment",
+        range: { from: 6, to: 11 },
+        content: "Nice word",
+      }),
+      makeAnnotation({
+        id: "s1",
+        type: "suggestion",
+        range: { from: 0, to: 5 },
+        content: JSON.stringify({ newText: "Hi", reason: "More casual" }),
       }),
     ];
 
     const result = exportAnnotations(doc, annotations);
-    expect(result).toContain('## Highlights');
-    expect(result).toContain('## Comments');
-    expect(result).toContain('## Suggestions');
-    expect(result).toContain('Nice word');
+    expect(result).toContain("## Highlights");
+    expect(result).toContain("## Comments");
+    expect(result).toContain("## Suggestions");
+    expect(result).toContain("Nice word");
     expect(result).toContain('Replace with: "Hi"');
-    expect(result).toContain('More casual');
-    expect(result).toContain('Color: yellow');
+    expect(result).toContain("More casual");
+    expect(result).toContain("Color: yellow");
   });
 
-  it('includes text snippet from document', () => {
-    loadHtml('<p>The quick brown fox</p>');
-    const annotations = [
-      makeAnnotation({ range: { from: 4, to: 9 }, content: 'fast animal' }),
-    ];
+  it("includes text snippet from document", () => {
+    loadHtml("<p>The quick brown fox</p>");
+    const annotations = [makeAnnotation({ range: { from: 4, to: 9 }, content: "fast animal" })];
     const result = exportAnnotations(doc, annotations);
-    expect(result).toContain('quick');
+    expect(result).toContain("quick");
   });
 });
 
 // -- Read-only guard pattern --
 
-describe('read-only guard', () => {
-  it('currentDoc.readOnly blocks tandem_edit pattern', () => {
+describe("read-only guard", () => {
+  it("currentDoc.readOnly blocks tandem_edit pattern", () => {
     // This is a unit-level check that the pattern works;
     // the actual MCP integration is tested in the integration suite
-    const docState = { filePath: 'test.docx', format: 'docx', readOnly: true };
+    const docState = { filePath: "test.docx", format: "docx", readOnly: true };
     expect(docState.readOnly).toBe(true);
   });
 });

--- a/tests/server/positions.test.ts
+++ b/tests/server/positions.test.ts
@@ -9,7 +9,12 @@ import {
   refreshRange,
   refreshAllRanges,
 } from "../../src/server/positions.js";
-import { makeDoc, getAnnotationsMap, getFragment } from "../helpers/ydoc-factory.js";
+import {
+  makeDoc,
+  getAnnotationsMap,
+  getFragment,
+  makeAnnotation,
+} from "../helpers/ydoc-factory.js";
 import { getOrCreateXmlText } from "../../src/server/mcp/document.js";
 import type { Annotation } from "../../src/shared/types.js";
 
@@ -235,22 +240,22 @@ describe("flatOffsetToRelPos / relPosToFlatOffset round-trip", () => {
 });
 
 describe("refreshRange (via positions module)", () => {
-  function makeAnnotation(map: Y.Map<unknown>, from: number, to: number, ydoc?: Y.Doc): Annotation {
+  function makeAnchoredAnnotation(
+    map: Y.Map<unknown>,
+    from: number,
+    to: number,
+    ydoc?: Y.Doc,
+  ): Annotation {
     const result = ydoc
       ? anchoredRange(ydoc, from, to)
       : { ok: true as const, range: { from, to } };
     if (!result.ok) throw new Error("Failed");
     const id = `ann_test_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
-    const ann: Annotation = {
+    const ann = makeAnnotation({
       id,
-      author: "claude",
-      type: "comment",
       range: result.range,
       ...("relRange" in result && result.relRange ? { relRange: result.relRange } : {}),
-      content: "test",
-      status: "pending",
-      timestamp: Date.now(),
-    };
+    });
     map.set(id, ann);
     return ann;
   }
@@ -258,7 +263,7 @@ describe("refreshRange (via positions module)", () => {
   it("lazily attaches relRange", () => {
     doc = makeDoc("hello world");
     const map = getAnnotationsMap(doc);
-    const ann = makeAnnotation(map, 0, 5); // no ydoc → no relRange
+    const ann = makeAnchoredAnnotation(map, 0, 5); // no ydoc → no relRange
 
     expect(ann.relRange).toBeUndefined();
     const refreshed = refreshRange(ann, doc, map);
@@ -268,7 +273,7 @@ describe("refreshRange (via positions module)", () => {
   it("updates stale flat offsets after edit", () => {
     doc = makeDoc("hello world");
     const map = getAnnotationsMap(doc);
-    const ann = makeAnnotation(map, 6, 11, doc);
+    const ann = makeAnchoredAnnotation(map, 6, 11, doc);
 
     // Insert before annotation
     const fragment = getFragment(doc);
@@ -282,7 +287,7 @@ describe("refreshRange (via positions module)", () => {
   it("returns original annotation when CRDT resolves to inverted range", () => {
     doc = makeDoc("hello world");
     const map = getAnnotationsMap(doc);
-    const ann = makeAnnotation(map, 0, 5, doc); // "hello"
+    const ann = makeAnchoredAnnotation(map, 0, 5, doc); // "hello"
 
     // Manually craft an inverted relRange by swapping fromRel and toRel
     const invertedAnn: Annotation = {


### PR DESCRIPTION
## Summary
- Extract shared `makeAnnotation()` into `tests/helpers/ydoc-factory.ts`, replacing 4 inline duplicates
- Remove unused `open` package from dependencies (zero imports in codebase)
- Delete empty stub files `overlay.ts` and `suggestion.ts` (TODO-only, no imports)

## Test plan
- [x] `npm test` — all 684 tests pass
- [x] `npm run typecheck` — clean
- [x] No file conflicts with other refactor branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)