### PR TITLE
refactor(client): extract useFileDrop and useReviewCompletion from App.tsx

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useEffect, useMemo, type DragEvent } from "react";
+import React, { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import type { Editor as TiptapEditor } from "@tiptap/react";
 import { Editor } from "./editor/Editor";
 import { SidePanel } from "./panels/SidePanel";
@@ -18,9 +18,10 @@ import {
 import type { InterruptionMode } from "../shared/types";
 import { InterruptionModeSchema } from "../shared/types";
 import { useAnnotationGate } from "./hooks/useAnnotationGate";
+import { useFileDrop } from "./hooks/useFileDrop";
+import { useReviewCompletion } from "./hooks/useReviewCompletion";
 import { useYjsSync } from "./hooks/useYjsSync";
 import type { DocListEntry, OpenTab } from "./types";
-import { API_BASE, readFileForUpload } from "./utils/fileUpload";
 
 export type { DocListEntry, OpenTab };
 
@@ -95,81 +96,21 @@ export default function App() {
   const { visibleAnnotations, heldCount } = useAnnotationGate(annotations, interruptionMode);
   const openDocs = useMemo(() => tabs.map((t) => ({ id: t.id, fileName: t.fileName })), [tabs]);
 
-  const [showReviewSummary, setShowReviewSummary] = useState(false);
-  const [reviewSummaryData, setReviewSummaryData] = useState<{
-    accepted: number;
-    dismissed: number;
-    total: number;
-  } | null>(null);
+  const { fileDragOver, handleEditorDragOver, handleEditorDragLeave, handleEditorDrop } =
+    useFileDrop();
+  const { pendingCount, showReviewSummary, reviewSummaryData, dismissReviewSummary } =
+    useReviewCompletion(annotations);
+
   const [reviewMode, setReviewMode] = useState(false);
   const [showBanner, setShowBanner] = useState(false);
   const [showChat, setShowChat] = useState(false);
   const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null);
-  const [fileDragOver, setFileDragOver] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const editorRef = useRef<TiptapEditor | null>(null);
-  const prevPendingRef = useRef<number>(0);
 
   const handleEditorReady = useCallback((editor: TiptapEditor | null) => {
     editorRef.current = editor;
   }, []);
-
-  // File drag-and-drop on editor area
-  const handleEditorDragOver = useCallback((e: DragEvent) => {
-    // Only show drop indicator for file drops, not editor content drags
-    if (e.dataTransfer.types.includes("Files")) {
-      e.preventDefault();
-      setFileDragOver(true);
-    }
-  }, []);
-
-  const handleEditorDragLeave = useCallback((e: DragEvent) => {
-    // Only reset if leaving the wrapper (not entering a child)
-    if (e.currentTarget === e.target || !e.currentTarget.contains(e.relatedTarget as Node)) {
-      setFileDragOver(false);
-    }
-  }, []);
-
-  const handleEditorDrop = useCallback(async (e: DragEvent) => {
-    setFileDragOver(false);
-    if (!e.dataTransfer.files.length) return;
-    e.preventDefault();
-    const file = e.dataTransfer.files[0];
-    const content = await readFileForUpload(file);
-    try {
-      await fetch(`${API_BASE}/upload`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ fileName: file.name, content }),
-      });
-    } catch {
-      // Server unreachable — silently fail (user can use the dialog instead)
-    }
-  }, []);
-
-  // Detect review completion: all pending -> 0 while resolved > 0 (single pass)
-  useEffect(() => {
-    let pending = 0,
-      accepted = 0,
-      dismissed = 0;
-    for (const a of annotations) {
-      if (a.status === "pending") pending++;
-      else if (a.status === "accepted") accepted++;
-      else dismissed++;
-    }
-    const total = accepted + dismissed;
-
-    if (prevPendingRef.current > 0 && pending === 0 && total > 0) {
-      setReviewSummaryData({ accepted, dismissed, total });
-      setShowReviewSummary(true);
-    }
-    prevPendingRef.current = pending;
-  }, [annotations]);
-
-  const pendingCount = useMemo(
-    () => annotations.filter((a) => a.status === "pending").length,
-    [annotations],
-  );
 
   // Show banner when pending annotations exceed threshold
   useEffect(() => {
@@ -429,7 +370,7 @@ export default function App() {
           accepted={reviewSummaryData.accepted}
           dismissed={reviewSummaryData.dismissed}
           total={reviewSummaryData.total}
-          onDismiss={() => setShowReviewSummary(false)}
+          onDismiss={dismissReviewSummary}
         />
       )}
       <HelpModal open={showHelp} onClose={() => setShowHelp(false)} />

--- a/src/client/hooks/useFileDrop.ts
+++ b/src/client/hooks/useFileDrop.ts
@@ -1,0 +1,49 @@
+import { useState, useCallback, type DragEvent } from "react";
+import { API_BASE, readFileForUpload } from "../utils/fileUpload";
+
+/**
+ * Manages file drag-and-drop on the editor area.
+ * Uploads dropped files to the Tandem server via POST /api/upload.
+ */
+export function useFileDrop() {
+  const [fileDragOver, setFileDragOver] = useState(false);
+
+  const handleEditorDragOver = useCallback((e: DragEvent) => {
+    // Only show drop indicator for file drops, not editor content drags
+    if (e.dataTransfer.types.includes("Files")) {
+      e.preventDefault();
+      setFileDragOver(true);
+    }
+  }, []);
+
+  const handleEditorDragLeave = useCallback((e: DragEvent) => {
+    // Only reset if leaving the wrapper (not entering a child)
+    if (e.currentTarget === e.target || !e.currentTarget.contains(e.relatedTarget as Node)) {
+      setFileDragOver(false);
+    }
+  }, []);
+
+  const handleEditorDrop = useCallback(async (e: DragEvent) => {
+    setFileDragOver(false);
+    if (!e.dataTransfer.files.length) return;
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    const content = await readFileForUpload(file);
+    try {
+      await fetch(`${API_BASE}/upload`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fileName: file.name, content }),
+      });
+    } catch {
+      // Server unreachable — silently fail (user can use the dialog instead)
+    }
+  }, []);
+
+  return {
+    fileDragOver,
+    handleEditorDragOver,
+    handleEditorDragLeave,
+    handleEditorDrop,
+  };
+}

--- a/src/client/hooks/useReviewCompletion.ts
+++ b/src/client/hooks/useReviewCompletion.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import type { Annotation } from "../../shared/types";
+
+/**
+ * Detects when all pending annotations become resolved (accepted/dismissed)
+ * and surfaces the review summary overlay.
+ */
+export function useReviewCompletion(annotations: Annotation[]) {
+  const [showReviewSummary, setShowReviewSummary] = useState(false);
+  const [reviewSummaryData, setReviewSummaryData] = useState<{
+    accepted: number;
+    dismissed: number;
+    total: number;
+  } | null>(null);
+  const prevPendingRef = useRef<number>(0);
+
+  const { pendingCount, acceptedCount, dismissedCount } = useMemo(() => {
+    let pendingCount = 0,
+      acceptedCount = 0,
+      dismissedCount = 0;
+    for (const a of annotations) {
+      if (a.status === "pending") pendingCount++;
+      else if (a.status === "accepted") acceptedCount++;
+      else if (a.status === "dismissed") dismissedCount++;
+    }
+    return { pendingCount, acceptedCount, dismissedCount };
+  }, [annotations]);
+
+  useEffect(() => {
+    const total = acceptedCount + dismissedCount;
+
+    if (prevPendingRef.current > 0 && pendingCount === 0 && total > 0) {
+      setReviewSummaryData({ accepted: acceptedCount, dismissed: dismissedCount, total });
+      setShowReviewSummary(true);
+    }
+    prevPendingRef.current = pendingCount;
+  }, [pendingCount, acceptedCount, dismissedCount]);
+
+  const dismissReviewSummary = useCallback(() => {
+    setShowReviewSummary(false);
+  }, []);
+
+  return {
+    pendingCount,
+    showReviewSummary,
+    reviewSummaryData,
+    dismissReviewSummary,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract `useFileDrop` hook — file drag-and-drop state + handlers (zero deps on App state)
- Extract `useReviewCompletion` hook — review summary detection with scalar `useEffect` deps (fixes spurious fires from array reference changes per project convention)
- App.tsx drops from 438 → 384 lines

## Test plan
- [x] `npm test` — all 684 tests pass
- [x] `npm run typecheck` — clean
- [x] No file conflicts with other refactor branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)