### PR TITLE
feat(ui): better connection error messages with attempt count and banner

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -14,6 +14,7 @@ import {
   DISCONNECT_DEBOUNCE_MS,
   INTERRUPTION_MODE_DEFAULT,
   INTERRUPTION_MODE_KEY,
+  PROLONGED_DISCONNECT_MS,
   REVIEW_BANNER_THRESHOLD,
   Y_MAP_USER_AWARENESS,
 } from "../shared/constants";
@@ -70,6 +71,43 @@ function EmptyState({ connected, claudeActive }: { connected: boolean; claudeAct
   );
 }
 
+/** Red banner shown after prolonged disconnect (>30s). Dismissible. */
+function ConnectionBanner({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <div
+      style={{
+        padding: "8px 16px",
+        background: "#fef2f2",
+        borderBottom: "1px solid #fca5a5",
+        fontSize: "13px",
+        color: "#991b1b",
+        textAlign: "center",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        gap: "12px",
+      }}
+    >
+      <span>Connection to the Tandem server has been lost. Ensure the server is running.</span>
+      <button
+        onClick={onDismiss}
+        style={{
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          color: "#991b1b",
+          fontSize: "16px",
+          lineHeight: 1,
+          padding: "0 4px",
+        }}
+        aria-label="Dismiss connection banner"
+      >
+        \u00d7
+      </button>
+    </div>
+  );
+}
+
 export default function App() {
   const {
     tabs,
@@ -77,6 +115,9 @@ export default function App() {
     setActiveTabId,
     handleTabClose,
     connected,
+    connectionStatus,
+    reconnectAttempts,
+    disconnectedSince,
     annotations,
     claudeStatus,
     claudeActive,
@@ -106,6 +147,25 @@ export default function App() {
     const awareness = activeYdoc.getMap(Y_MAP_USER_AWARENESS);
     awareness.set("interruptionMode", interruptionMode);
   }, [interruptionMode, activeYdoc]);
+
+  // Prolonged disconnect banner — shown after PROLONGED_DISCONNECT_MS of being disconnected
+  const [showDisconnectBanner, setShowDisconnectBanner] = useState(false);
+  const [disconnectBannerDismissed, setDisconnectBannerDismissed] = useState(false);
+  useEffect(() => {
+    if (disconnectedSince == null) {
+      setShowDisconnectBanner(false);
+      setDisconnectBannerDismissed(false);
+      return;
+    }
+    const elapsed = Date.now() - disconnectedSince;
+    const remaining = PROLONGED_DISCONNECT_MS - elapsed;
+    if (remaining <= 0) {
+      setShowDisconnectBanner(true);
+      return;
+    }
+    const timer = setTimeout(() => setShowDisconnectBanner(true), remaining);
+    return () => clearTimeout(timer);
+  }, [disconnectedSince]);
 
   const { visibleAnnotations, heldCount } = useAnnotationGate(annotations, interruptionMode);
   const openDocs = useMemo(() => tabs.map((t) => ({ id: t.id, fileName: t.fileName })), [tabs]);
@@ -192,6 +252,9 @@ export default function App() {
         >
           Server restarted — refreshing documents
         </div>
+      )}
+      {showDisconnectBanner && !disconnectBannerDismissed && (
+        <ConnectionBanner onDismiss={() => setDisconnectBannerDismissed(true)} />
       )}
       <Toolbar editor={editorRef.current} ydoc={activeTab?.ydoc ?? null} />
       <DocumentTabs
@@ -373,6 +436,9 @@ export default function App() {
       </div>
       <StatusBar
         connected={connected}
+        connectionStatus={connectionStatus}
+        reconnectAttempts={reconnectAttempts}
+        disconnectedSince={disconnectedSince}
         claudeStatus={claudeStatus}
         claudeActive={claudeActive}
         readOnly={readOnly}

--- a/src/client/hooks/useYjsSync.ts
+++ b/src/client/hooks/useYjsSync.ts
@@ -20,12 +20,17 @@ export function deduplicateDocList(
   return docList.filter((d) => !existingIds.has(d.id) && !pendingIds.has(d.id));
 }
 
+export type ConnectionStatus = "connected" | "connecting" | "disconnected";
+
 export interface YjsSyncResult {
   tabs: OpenTab[];
   activeTabId: string | null;
   setActiveTabId: (id: string) => void;
   handleTabClose: (id: string) => void;
   connected: boolean;
+  connectionStatus: ConnectionStatus;
+  reconnectAttempts: number;
+  disconnectedSince: number | null;
   annotations: Annotation[];
   claudeStatus: string | null;
   claudeActive: boolean;
@@ -40,6 +45,9 @@ export function useYjsSync(): YjsSyncResult {
   const [tabs, setTabs] = useState<OpenTab[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("connecting");
+  const [reconnectAttempts, setReconnectAttempts] = useState(0);
+  const [disconnectedSince, setDisconnectedSince] = useState<number | null>(null);
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
   const [claudeStatus, setClaudeStatus] = useState<string | null>(null);
   const [claudeActive, setClaudeActive] = useState(false);
@@ -47,6 +55,8 @@ export function useYjsSync(): YjsSyncResult {
   const [ready, setReady] = useState(false);
   const [serverRestarted, setServerRestarted] = useState(false);
   const restartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Track whether we've ever connected — don't count initial connection attempt as a reconnect. */
+  const hadConnectionRef = useRef(false);
 
   const bootstrapRef = useRef<{ ydoc: Y.Doc; provider: HocuspocusProvider } | null>(null);
   const generationIdRef = useRef<string | null>(null);
@@ -207,6 +217,21 @@ export function useYjsSync(): YjsSyncResult {
 
     provider.on("status", ({ status }: { status: string }) => {
       setConnected(status === "connected");
+      setConnectionStatus(status as ConnectionStatus);
+
+      if (status === "connected") {
+        hadConnectionRef.current = true;
+        setReconnectAttempts(0);
+        setDisconnectedSince(null);
+      } else if (status === "disconnected") {
+        setDisconnectedSince((prev) => prev ?? Date.now());
+      } else if (status === "connecting") {
+        // Only count reconnection attempts after the first successful connection
+        if (hadConnectionRef.current) {
+          setReconnectAttempts((prev) => prev + 1);
+        }
+        setDisconnectedSince((prev) => prev ?? Date.now());
+      }
     });
 
     setReady(true);
@@ -278,6 +303,9 @@ export function useYjsSync(): YjsSyncResult {
     setActiveTabId,
     handleTabClose,
     connected,
+    connectionStatus,
+    reconnectAttempts,
+    disconnectedSince,
     annotations,
     claudeStatus,
     claudeActive,

--- a/src/client/status/StatusBar.tsx
+++ b/src/client/status/StatusBar.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect, useRef, useState } from "react";
 import { CLAUDE_PRESENCE_COLOR, USER_NAME_KEY, USER_NAME_DEFAULT } from "../../shared/constants";
 import type { InterruptionMode } from "../../shared/types";
+import type { ConnectionStatus } from "../hooks/useYjsSync";
 
 interface StatusBarProps {
   connected: boolean;
+  connectionStatus: ConnectionStatus;
+  reconnectAttempts: number;
+  disconnectedSince: number | null;
   claudeStatus: string | null;
   claudeActive: boolean;
   readOnly?: boolean;
@@ -24,10 +28,12 @@ const MODES: { value: InterruptionMode; label: string; title: string }[] = [
 ];
 
 const RECONNECTED_FLASH_MS = 2_000;
-const SERVER_CHECK_MS = 30_000;
 
 export function StatusBar({
   connected,
+  connectionStatus,
+  reconnectAttempts,
+  disconnectedSince,
   claudeStatus,
   claudeActive,
   readOnly,
@@ -47,36 +53,53 @@ export function StatusBar({
     localStorage.setItem(USER_NAME_KEY, trimmed);
   };
   const [showReconnectedFlash, setShowReconnectedFlash] = useState(false);
-  const [showServerBanner, setShowServerBanner] = useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const prevConnected = useRef(connected);
-  const disconnectedAt = useRef<number | null>(null);
 
   useEffect(() => {
     const was = prevConnected.current;
     prevConnected.current = connected;
-    if (!connected) {
-      if (disconnectedAt.current === null) disconnectedAt.current = Date.now();
-      const timer = setTimeout(() => setShowServerBanner(true), SERVER_CHECK_MS);
-      return () => clearTimeout(timer);
-    }
-    disconnectedAt.current = null;
-    setShowServerBanner(false);
-    if (!was) {
+    if (connected && !was) {
       setShowReconnectedFlash(true);
       const timer = setTimeout(() => setShowReconnectedFlash(false), RECONNECTED_FLASH_MS);
       return () => clearTimeout(timer);
     }
   }, [connected]);
 
-  const isReconnecting = !connected && disconnectedAt.current !== null;
+  // Tick elapsed time while disconnected
+  useEffect(() => {
+    if (disconnectedSince == null) {
+      setElapsedSeconds(0);
+      return;
+    }
+    // Set initial value immediately
+    setElapsedSeconds(Math.floor((Date.now() - disconnectedSince) / 1000));
+    const interval = setInterval(() => {
+      setElapsedSeconds(Math.floor((Date.now() - disconnectedSince) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [disconnectedSince]);
+
+  const isReconnecting = connectionStatus === "connecting";
   const dotColor = connected ? "#22c55e" : isReconnecting ? "#eab308" : "#ef4444";
-  const connLabel = showReconnectedFlash
-    ? "Reconnected"
-    : connected
-      ? "Connected"
-      : isReconnecting
-        ? "Reconnecting\u2026"
-        : "Disconnected";
+
+  let connLabel: string;
+  if (showReconnectedFlash) {
+    connLabel = "Reconnected";
+  } else if (connectionStatus === "connected") {
+    connLabel = "Connected";
+  } else if (connectionStatus === "connecting") {
+    const parts = ["Reconnecting\u2026"];
+    if (reconnectAttempts > 0 || elapsedSeconds > 0) {
+      const details: string[] = [];
+      if (reconnectAttempts > 0) details.push(`attempt ${reconnectAttempts}`);
+      if (elapsedSeconds > 0) details.push(`${elapsedSeconds}s`);
+      parts.push(`(${details.join(", ")})`);
+    }
+    connLabel = parts.join(" ");
+  } else {
+    connLabel = "Disconnected \u2014 check that the server is running";
+  }
 
   return (
     <div
@@ -105,9 +128,6 @@ export function StatusBar({
           }}
         />
         <span>{connLabel}</span>
-        {showServerBanner && !connected && (
-          <span style={{ color: "#eab308", fontWeight: 500 }}>— check server</span>
-        )}
         {documentCount > 0 && (
           <span style={{ color: "#9ca3af" }}>
             {documentCount} doc{documentCount !== 1 ? "s" : ""} open

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -10,6 +10,7 @@ export const IDLE_TIMEOUT = 30 * 60 * 1000; // 30 minutes
 export const SESSION_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
 export const TYPING_DEBOUNCE = 3000; // 3 seconds
 export const DISCONNECT_DEBOUNCE_MS = 3000; // 3 seconds before showing "server not reachable"
+export const PROLONGED_DISCONNECT_MS = 30_000; // 30 seconds before showing App-level disconnect banner
 export const OVERLAY_STALE_DEBOUNCE = 200; // 200ms
 export const REVIEW_BANNER_THRESHOLD = 5;
 


### PR DESCRIPTION
## Summary
- StatusBar shows reconnect attempt count + elapsed time during reconnection
- Actionable message when fully disconnected ("check that the server is running")
- Prominent red banner after 30s of continuous disconnect, auto-clears on reconnect
- Three-state connection tracking (`connected | connecting | disconnected`) in `useYjsSync`

## Files Changed
| File | Change |
|------|--------|
| `src/client/hooks/useYjsSync.ts` | Track `reconnectAttempts`, `disconnectedSince`, `connectionStatus` |
| `src/client/status/StatusBar.tsx` | Show attempt count + elapsed time, actionable disconnect message |
| `src/client/App.tsx` | Dismissible `ConnectionBanner` after 30s disconnect |
| `src/shared/constants.ts` | `PROLONGED_DISCONNECT_MS` constant |

## Test plan
- [ ] Stop the server while connected — verify StatusBar shows "Reconnecting... (attempt N, Xs)"
- [ ] Wait 30+ seconds — verify red banner appears
- [ ] Dismiss the banner — verify it disappears
- [ ] Restart the server — verify banner clears and StatusBar returns to normal
- [ ] `npm test` — 747 tests passing

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)