### PR TITLE
feat: cross-platform MCP setup + doctor diagnostic

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,8 +5,8 @@
       "url": "http://localhost:3479/mcp"
     },
     "tandem-channel": {
-      "command": "cmd",
-      "args": ["/c", "npx", "tsx", "src/channel/index.ts"],
+      "command": "npx",
+      "args": ["tsx", "src/channel/index.ts"],
       "env": {
         "TANDEM_URL": "http://localhost:3479"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 - `npm run build:server` -- Bundle server via tsup → `dist/server/index.js`
 - `npm run start:server` -- Run bundled server (`node dist/server/index.js`)
 - `npm run typecheck` -- Type-check server + client without emitting
+- `npm run doctor` -- Diagnose setup issues (Node version, .mcp.json, server health, ports)
 - `npm test` -- Run vitest (unit tests)
 - `npm run test:e2e` -- Run Playwright E2E tests (requires server running or auto-starts via webServer)
 - `npm run test:e2e:ui` -- Playwright UI mode for interactive E2E debugging

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ graph LR
 git clone https://github.com/bloknayrb/tandem.git
 cd tandem
 npm install
-npm run build     # builds server + channel shim into dist/
 ```
 
 ### Run
@@ -52,6 +51,12 @@ Claude calls `tandem_open`, the document appears in the browser, and annotations
 ### Verify (if something seems wrong)
 
 ```bash
+npm run doctor
+```
+
+This checks Node.js version, `.mcp.json` configuration, server health, and port status with actionable fix suggestions. You can also check the raw health endpoint:
+
+```bash
 curl http://localhost:3479/health
 # → {"status":"ok","version":"0.1.0","transport":"http","hasSession":false}
 ```
@@ -70,23 +75,15 @@ Tandem uses two MCP connections: **HTTP** for document tools (27 tools including
       "url": "http://localhost:3479/mcp"
     },
     "tandem-channel": {
-      "command": "cmd",
-      "args": ["/c", "npx", "tsx", "src/channel/index.ts"],
+      "command": "npx",
+      "args": ["tsx", "src/channel/index.ts"],
       "env": { "TANDEM_URL": "http://localhost:3479" }
     }
   }
 }
 ```
 
-The `tandem` entry (HTTP) is platform-independent. The `tandem-channel` entry varies by platform:
-
-| Platform | `command` | `args` |
-|----------|-----------|--------|
-| **Windows** | `"cmd"` | `["/c", "npx", "tsx", "src/channel/index.ts"]` |
-| **macOS / Linux** | `"npx"` | `["tsx", "src/channel/index.ts"]` |
-| **Production** (any, requires `npm run build`) | `"node"` | `["dist/channel/index.js"]` |
-
-All channel entries need `"env": { "TANDEM_URL": "http://localhost:3479" }`.
+Both entries are cross-platform -- no platform-specific configuration needed. For production deployments (after `npm run build`), you can use `"command": "node", "args": ["dist/channel/index.js"]` instead for faster startup.
 
 The channel shim is optional -- without it, Claude relies on polling via `tandem_checkInbox` instead of receiving real-time push events.
 
@@ -108,6 +105,8 @@ See `.env.example` for a copy-paste template.
 
 ## Troubleshooting
 
+Run `npm run doctor` for a quick diagnostic of your setup. It checks Node.js version, `.mcp.json` config, server health, and port status.
+
 **Claude Code says "MCP failed to connect"**
 Start the server first (`npm run dev:standalone`), then open Claude Code. The server must be running before Claude Code probes the MCP URL. If you restart the server, run `/mcp` in Claude Code to reconnect.
 
@@ -115,7 +114,7 @@ Start the server first (`npm run dev:standalone`), then open Claude Code. The se
 Tandem kills stale processes on :3478/:3479 at startup. If another app uses those ports, set `TANDEM_PORT` / `TANDEM_MCP_PORT` to different values and update `TANDEM_URL` to match.
 
 **Channel shim fails to start**
-The `tandem-channel` entry spawns a subprocess. If you see `MODULE_NOT_FOUND`, run `npm run build` -- the production channel entry needs `dist/channel/index.js`. If on macOS/Linux, check the platform-specific `.mcp.json` examples above.
+The `tandem-channel` entry spawns a subprocess. If you see `MODULE_NOT_FOUND` with a production config (`node dist/channel/index.js`), run `npm run build`. The default dev config uses `npx tsx` and doesn't require a build step.
 
 **Browser shows "Cannot reach the Tandem server"**
 The Vite client connects to the server via WebSocket. Make sure `npm run dev:standalone` (or `npm run dev:server`) is running. The message appears after 3 seconds of failed connection.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
     "preview": "vite preview",
     "lint": "eslint .",
     "format": "biome format --write .",
+    "doctor": "node scripts/doctor.mjs",
     "prepare": "husky"
+  },
+  "engines": {
+    "node": ">=22"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+
+/**
+ * Tandem Doctor — diagnose common setup issues.
+ * Usage: npm run doctor
+ *
+ * Pure Node.js built-ins only (no external dependencies).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { createConnection } from "node:net";
+import { join } from "node:path";
+import { request } from "node:http";
+
+// Keep in sync with src/shared/constants.ts (can't import TS from standalone .mjs)
+const WS_PORT = 3478;
+const MCP_PORT = 3479;
+
+// ── Formatting helpers ──────────────────────────────────────────────
+
+let failures = 0;
+let warnings = 0;
+
+function pass(msg) {
+  console.log(`  \x1b[32m[PASS]\x1b[0m ${msg}`);
+}
+
+function warn(msg, fix) {
+  warnings++;
+  console.log(`  \x1b[33m[WARN]\x1b[0m ${msg}`);
+  if (fix) console.log(`         Fix: ${fix}`);
+}
+
+function fail(msg, fix) {
+  failures++;
+  console.log(`  \x1b[31m[FAIL]\x1b[0m ${msg}`);
+  if (fix) console.log(`         Fix: ${fix}`);
+}
+
+// ── Check: Node.js version ──────────────────────────────────────────
+
+function checkNodeVersion() {
+  const version = process.version;
+  const major = parseInt(version.slice(1), 10);
+  if (major >= 22) {
+    pass(`Node.js ${version} (>= 22 required)`);
+  } else {
+    fail(
+      `Node.js ${version} — version 22+ required`,
+      "Install Node.js 22+ from https://nodejs.org",
+    );
+  }
+}
+
+// ── Check: node_modules exists ──────────────────────────────────────
+
+function checkNodeModules() {
+  if (existsSync(join(process.cwd(), "node_modules"))) {
+    pass("node_modules/ exists");
+  } else {
+    fail("node_modules/ not found", "npm install");
+  }
+}
+
+// ── Check: .mcp.json ────────────────────────────────────────────────
+
+function checkMcpJson() {
+  const mcpPath = join(process.cwd(), ".mcp.json");
+  if (!existsSync(mcpPath)) {
+    fail(".mcp.json not found", "Restore it from git: git checkout .mcp.json");
+    return;
+  }
+
+  let config;
+  try {
+    config = JSON.parse(readFileSync(mcpPath, "utf-8"));
+  } catch {
+    fail(".mcp.json is not valid JSON", "Check for syntax errors");
+    return;
+  }
+
+  const servers = config.mcpServers;
+  if (!servers) {
+    fail('.mcp.json missing "mcpServers" key');
+    return;
+  }
+
+  // Check tandem (HTTP MCP) entry
+  const tandem = servers.tandem;
+  if (!tandem) {
+    fail('.mcp.json missing "tandem" server entry');
+  } else if (tandem.type !== "http" || !tandem.url?.includes("/mcp")) {
+    warn(`.mcp.json tandem: unexpected config — type=${tandem.type}, url=${tandem.url}`);
+  } else {
+    pass(`.mcp.json tandem \u2192 ${tandem.url}`);
+  }
+
+  // Check tandem-channel entry
+  const channel = servers["tandem-channel"];
+  if (!channel) {
+    warn(".mcp.json missing tandem-channel — Claude will use polling instead of push notifications");
+  } else {
+    const cmd = channel.command;
+    const args = (channel.args || []).join(" ");
+
+    if (cmd === "cmd" && args.includes("/c")) {
+      warn(
+        `.mcp.json tandem-channel uses Windows-only "cmd /c" — won't work on macOS/Linux`,
+        'Change to: "command": "npx", "args": ["tsx", "src/channel/index.ts"]',
+      );
+    } else {
+      pass(`.mcp.json tandem-channel \u2192 ${cmd} ${args}`);
+    }
+
+    if (!channel.env?.TANDEM_URL) {
+      warn("tandem-channel missing TANDEM_URL env var", 'Add "env": {"TANDEM_URL": "http://localhost:3479"}');
+    }
+  }
+}
+
+// ── Check: port status ──────────────────────────────────────────────
+
+function probePort(port, timeoutMs = 2000) {
+  return new Promise((resolve) => {
+    const socket = createConnection({ port, host: "127.0.0.1" }, () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.setTimeout(timeoutMs);
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.on("error", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function checkPorts() {
+  const [ws, mcp] = await Promise.all([probePort(WS_PORT), probePort(MCP_PORT)]);
+
+  if (ws && mcp) {
+    pass(`Ports ${WS_PORT} (WebSocket) + ${MCP_PORT} (MCP HTTP) in use`);
+  } else if (!ws && !mcp) {
+    fail(
+      `Ports ${WS_PORT} + ${MCP_PORT} not listening — server not running`,
+      "npm run dev:standalone",
+    );
+  } else {
+    warn(
+      `Partial: port ${WS_PORT} ${ws ? "up" : "down"}, port ${MCP_PORT} ${mcp ? "up" : "down"}`,
+      "Server may be starting up or partially crashed",
+    );
+  }
+
+  return { ws, mcp };
+}
+
+// ── Check: /health endpoint ─────────────────────────────────────────
+
+function httpGet(url, timeoutMs = 3000) {
+  return new Promise((resolve) => {
+    const req = request(url, { timeout: timeoutMs }, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => {
+        try {
+          resolve({ status: res.statusCode, data: JSON.parse(body) });
+        } catch {
+          resolve({ status: res.statusCode, data: null });
+        }
+      });
+    });
+    req.on("error", () => resolve(null));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(null);
+    });
+    req.end();
+  });
+}
+
+async function checkHealth() {
+  const result = await httpGet(`http://127.0.0.1:${MCP_PORT}/health`);
+
+  if (!result) {
+    fail(`Server not responding on localhost:${MCP_PORT}`, "npm run dev:standalone");
+    return false;
+  }
+
+  if (result.status !== 200) {
+    fail(`/health returned status ${result.status}`);
+    return false;
+  }
+
+  const d = result.data;
+  if (d) {
+    const session = d.hasSession ? "session active" : "no MCP session";
+    pass(`Server healthy (v${d.version}, ${d.transport}, ${session})`);
+    if (!d.hasSession) {
+      warn("No active MCP session — Claude Code hasn't connected yet");
+    }
+  } else {
+    pass("Server responded on /health (could not parse body)");
+  }
+  return true;
+}
+
+// ── Check: SSE event stream ─────────────────────────────────────────
+
+function checkSseEndpoint() {
+  return new Promise((resolve) => {
+    const req = request(
+      `http://127.0.0.1:${MCP_PORT}/api/events`,
+      { timeout: 2000 },
+      (res) => {
+        // SSE endpoint responds with 200 and text/event-stream
+        req.destroy(); // don't hold the connection open
+        const ct = res.headers["content-type"] || "";
+        if (res.statusCode === 200 && ct.includes("text/event-stream")) {
+          pass("SSE event stream reachable (/api/events)");
+        } else {
+          warn(`/api/events responded with status ${res.statusCode}, content-type: ${ct}`);
+        }
+        resolve();
+      },
+    );
+    req.on("error", () => {
+      // Server not running — already caught by health check
+      resolve();
+    });
+    req.on("timeout", () => {
+      req.destroy();
+      warn("/api/events timed out");
+      resolve();
+    });
+    req.end();
+  });
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log();
+  console.log("  Tandem Doctor");
+  console.log("  =============");
+  console.log();
+
+  checkNodeVersion();
+  checkNodeModules();
+  checkMcpJson();
+
+  console.log();
+  const { mcp } = await checkPorts();
+
+  if (mcp) {
+    const healthy = await checkHealth();
+    if (healthy) {
+      await checkSseEndpoint();
+    }
+  }
+
+  console.log();
+  if (failures > 0) {
+    console.log(`  ${failures} issue(s) found. Fix the items above and re-run: npm run doctor`);
+    process.exit(1);
+  } else if (warnings > 0) {
+    console.log(`  ${warnings} warning(s) — Tandem should work, but check the items above.`);
+  } else {
+    console.log("  All checks passed. Tandem is ready.");
+  }
+  console.log();
+}
+
+main();

--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -9,10 +9,12 @@
  * the Channels API spec.
  */
 
+import { createConnection } from "node:net";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { DEFAULT_MCP_PORT } from "../shared/constants.js";
 import { startEventBridge } from "./event-bridge.js";
 
 // stdout is the MCP wire — redirect console.log to stderr
@@ -21,6 +23,28 @@ console.warn = console.error;
 console.info = console.error;
 
 const TANDEM_URL = process.env.TANDEM_URL || "http://localhost:3479";
+
+// --- Pre-flight: verify Tandem server is reachable before MCP handshake ---
+
+async function checkServerReachable(url: string, timeoutMs = 2000): Promise<boolean> {
+  const parsed = new URL(url);
+  const port = parseInt(parsed.port || String(DEFAULT_MCP_PORT), 10);
+  return new Promise((resolve) => {
+    const socket = createConnection({ port, host: parsed.hostname }, () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.setTimeout(timeoutMs);
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.on("error", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
 
 // --- MCP Server setup ---
 
@@ -153,6 +177,13 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }) => {
 
 async function main() {
   console.error(`[Channel] Tandem channel shim starting (server: ${TANDEM_URL})`);
+
+  const reachable = await checkServerReachable(TANDEM_URL);
+  if (!reachable) {
+    console.error(`[Channel] Cannot reach Tandem server at ${TANDEM_URL}`);
+    console.error("[Channel] Start it with: npm run dev:standalone");
+    // Continue anyway — the event bridge will retry, and the server may start later
+  }
 
   // Connect to Claude Code over stdio
   const transport = new StdioServerTransport();


### PR DESCRIPTION
## Summary

- **Fix .mcp.json cross-platform:** Replace Windows-only `cmd /c npx tsx` with direct `npx tsx` — works on Windows, macOS, and Linux without platform-specific config
- **Add `npm run doctor`:** Health check script that diagnoses Node version, `.mcp.json` validity, server health, port status, and SSE endpoint — with actionable fix suggestions on failure
- **Channel shim pre-flight check:** TCP reachability probe before MCP handshake; logs clear error message (`Cannot reach Tandem server... Start it with: npm run dev:standalone`) visible in Claude Code's MCP error display
- **Add `engines` field:** `"node": ">=22"` in package.json for early version mismatch warnings
- **Simplify README:** Remove platform variant table, drop `npm run build` from getting-started flow, add `npm run doctor` to verify + troubleshooting sections

## Test plan

- [x] `npx tsx src/channel/index.ts` starts successfully on Windows without `cmd /c`
- [x] `npm run doctor` passes all checks with server running
- [x] `npm run doctor` reports failures with actionable fixes when server is stopped
- [x] Typecheck passes (`npx tsc -p tsconfig.server.json --noEmit`)
- [x] All 756 unit tests pass (`npm test`)
- [ ] Verify on macOS/Linux (or WSL) that `.mcp.json` works without edits

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)