### PR TITLE
fix(server): use extractText for tandem_getTextContent offsets

### DIFF
--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -24,12 +24,7 @@ import {
 import { MCP_ORIGIN } from "../events/queue.js";
 
 // Document model (pure logic)
-import {
-  extractText,
-  extractMarkdown,
-  getElementText,
-  getOrCreateXmlText,
-} from "./document-model.js";
+import { extractText, getElementText, getOrCreateXmlText } from "./document-model.js";
 
 // Position system
 import { validateRange, resolveToElement } from "../positions.js";
@@ -251,9 +246,10 @@ export function registerDocumentTools(server: McpServer): void {
         return mcpSuccess({ text: result.text, filePath: r.filePath, section });
       }
 
-      const docState = getCurrentDoc(documentId);
-      const format = docState?.format;
-      const text = format === "md" ? extractMarkdown(r.doc) : extractText(r.doc);
+      // Always use extractText — its offsets match validateRange/anchoredRange.
+      // extractMarkdown adds markdown syntax (e.g. `> ` for blockquotes) that
+      // shifts offsets, causing RANGE_MOVED errors in annotation tools.
+      const text = extractText(r.doc);
       return mcpSuccess({ text, filePath: r.filePath, documentId: r.docId });
     }),
   );

--- a/tests/server/document-offset.test.ts
+++ b/tests/server/document-offset.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, afterEach, beforeEach } from 'vitest';
-import * as Y from 'yjs';
-import { resolveOffset } from '../../src/server/mcp/document.js';
-import { makeDoc, makeEmptyDoc, getFragment } from '../helpers/ydoc-factory.js';
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import * as Y from "yjs";
+import { resolveOffset, extractText } from "../../src/server/mcp/document.js";
+import { validateRange } from "../../src/server/positions.js";
+import { makeDoc, makeEmptyDoc, makeMarkdownDoc, getFragment } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 
@@ -9,23 +10,23 @@ afterEach(() => {
   doc?.destroy();
 });
 
-describe('resolveOffset', () => {
+describe("resolveOffset", () => {
   describe('single paragraph doc ("Hello world")', () => {
     beforeEach(() => {
-      doc = makeDoc('Hello world');
+      doc = makeDoc("Hello world");
     });
 
-    it('offset 0 → start of element', () => {
+    it("offset 0 → start of element", () => {
       const result = resolveOffset(getFragment(doc), 0);
       expect(result).toEqual({ elementIndex: 0, textOffset: 0, clampedFromPrefix: false });
     });
 
-    it('offset 5 → middle of text', () => {
+    it("offset 5 → middle of text", () => {
       const result = resolveOffset(getFragment(doc), 5);
       expect(result).toEqual({ elementIndex: 0, textOffset: 5, clampedFromPrefix: false });
     });
 
-    it('offset 11 → end of text', () => {
+    it("offset 11 → end of text", () => {
       // "Hello world" has 11 chars, offset 11 is past end of element content
       // but within the element's full length, so it clamps to end
       const result = resolveOffset(getFragment(doc), 11);
@@ -35,145 +36,215 @@ describe('resolveOffset', () => {
 
   describe('multi-paragraph doc ("Hello\\nWorld")', () => {
     beforeEach(() => {
-      doc = makeDoc('Hello\nWorld');
+      doc = makeDoc("Hello\nWorld");
       // extractText: "Hello\nWorld" → H=0 e=1 l=2 l=3 o=4 \n=5 W=6 o=7 r=8 l=9 d=10
     });
 
-    it('offset 0 → first element, start', () => {
+    it("offset 0 → first element, start", () => {
       expect(resolveOffset(getFragment(doc), 0)).toEqual({
-        elementIndex: 0, textOffset: 0, clampedFromPrefix: false,
+        elementIndex: 0,
+        textOffset: 0,
+        clampedFromPrefix: false,
       });
     });
 
     it('offset 4 → first element, "o"', () => {
       expect(resolveOffset(getFragment(doc), 4)).toEqual({
-        elementIndex: 0, textOffset: 4, clampedFromPrefix: false,
+        elementIndex: 0,
+        textOffset: 4,
+        clampedFromPrefix: false,
       });
     });
 
-    it('offset 5 (\\n separator) → end of first element', () => {
+    it("offset 5 (\\n separator) → end of first element", () => {
       // This hits the distinct separator code path (document.ts:163-167)
       expect(resolveOffset(getFragment(doc), 5)).toEqual({
-        elementIndex: 0, textOffset: 5, clampedFromPrefix: false,
+        elementIndex: 0,
+        textOffset: 5,
+        clampedFromPrefix: false,
       });
     });
 
-    it('offset 6 → start of second element', () => {
+    it("offset 6 → start of second element", () => {
       expect(resolveOffset(getFragment(doc), 6)).toEqual({
-        elementIndex: 1, textOffset: 0, clampedFromPrefix: false,
+        elementIndex: 1,
+        textOffset: 0,
+        clampedFromPrefix: false,
       });
     });
 
-    it('offset 10 → end of second element', () => {
+    it("offset 10 → end of second element", () => {
       expect(resolveOffset(getFragment(doc), 10)).toEqual({
-        elementIndex: 1, textOffset: 4, clampedFromPrefix: false,
+        elementIndex: 1,
+        textOffset: 4,
+        clampedFromPrefix: false,
       });
     });
   });
 
   describe('three paragraph doc ("A\\nB\\nC")', () => {
     beforeEach(() => {
-      doc = makeDoc('A\nB\nC');
+      doc = makeDoc("A\nB\nC");
       // A=0 \n=1 B=2 \n=3 C=4
     });
 
-    it('offset 0 → element 0', () => {
+    it("offset 0 → element 0", () => {
       expect(resolveOffset(getFragment(doc), 0)).toEqual({
-        elementIndex: 0, textOffset: 0, clampedFromPrefix: false,
+        elementIndex: 0,
+        textOffset: 0,
+        clampedFromPrefix: false,
       });
     });
 
-    it('offset 1 (\\n) → end of element 0', () => {
+    it("offset 1 (\\n) → end of element 0", () => {
       expect(resolveOffset(getFragment(doc), 1)).toEqual({
-        elementIndex: 0, textOffset: 1, clampedFromPrefix: false,
+        elementIndex: 0,
+        textOffset: 1,
+        clampedFromPrefix: false,
       });
     });
 
-    it('offset 2 → start of element 1', () => {
+    it("offset 2 → start of element 1", () => {
       expect(resolveOffset(getFragment(doc), 2)).toEqual({
-        elementIndex: 1, textOffset: 0, clampedFromPrefix: false,
+        elementIndex: 1,
+        textOffset: 0,
+        clampedFromPrefix: false,
       });
     });
 
-    it('offset 3 (\\n) → end of element 1', () => {
+    it("offset 3 (\\n) → end of element 1", () => {
       expect(resolveOffset(getFragment(doc), 3)).toEqual({
-        elementIndex: 1, textOffset: 1, clampedFromPrefix: false,
+        elementIndex: 1,
+        textOffset: 1,
+        clampedFromPrefix: false,
       });
     });
 
-    it('offset 4 → start of element 2', () => {
+    it("offset 4 → start of element 2", () => {
       expect(resolveOffset(getFragment(doc), 4)).toEqual({
-        elementIndex: 2, textOffset: 0, clampedFromPrefix: false,
+        elementIndex: 2,
+        textOffset: 0,
+        clampedFromPrefix: false,
       });
     });
   });
 
   describe('heading prefix handling ("## Title\\nBody")', () => {
     beforeEach(() => {
-      doc = makeDoc('## Title\nBody');
+      doc = makeDoc("## Title\nBody");
       // extractText: "## Title\nBody"
       // ##_=0,1,2 T=3 i=4 t=5 l=6 e=7 \n=8 B=9 o=10 d=11 y=12
     });
 
     it('offset 0 (inside "## ") → clampedFromPrefix', () => {
       expect(resolveOffset(getFragment(doc), 0)).toEqual({
-        elementIndex: 0, textOffset: 0, clampedFromPrefix: true,
+        elementIndex: 0,
+        textOffset: 0,
+        clampedFromPrefix: true,
       });
     });
 
     it('offset 1 (inside "## ") → clampedFromPrefix', () => {
       expect(resolveOffset(getFragment(doc), 1)).toEqual({
-        elementIndex: 0, textOffset: 0, clampedFromPrefix: true,
+        elementIndex: 0,
+        textOffset: 0,
+        clampedFromPrefix: true,
       });
     });
 
     it('offset 2 (last char of "## ") → clampedFromPrefix', () => {
       expect(resolveOffset(getFragment(doc), 2)).toEqual({
-        elementIndex: 0, textOffset: 0, clampedFromPrefix: true,
+        elementIndex: 0,
+        textOffset: 0,
+        clampedFromPrefix: true,
       });
     });
 
     it('offset 3 (first char "T") → NOT clamped', () => {
       expect(resolveOffset(getFragment(doc), 3)).toEqual({
-        elementIndex: 0, textOffset: 0, clampedFromPrefix: false,
+        elementIndex: 0,
+        textOffset: 0,
+        clampedFromPrefix: false,
       });
     });
 
     it('offset 7 ("e" in Title) → textOffset 4', () => {
       expect(resolveOffset(getFragment(doc), 7)).toEqual({
-        elementIndex: 0, textOffset: 4, clampedFromPrefix: false,
+        elementIndex: 0,
+        textOffset: 4,
+        clampedFromPrefix: false,
       });
     });
 
-    it('offset 8 (\\n separator) → end of heading text', () => {
+    it("offset 8 (\\n separator) → end of heading text", () => {
       expect(resolveOffset(getFragment(doc), 8)).toEqual({
-        elementIndex: 0, textOffset: 5, clampedFromPrefix: false,
+        elementIndex: 0,
+        textOffset: 5,
+        clampedFromPrefix: false,
       });
     });
 
     it('offset 9 ("B" of Body) → start of second element', () => {
       expect(resolveOffset(getFragment(doc), 9)).toEqual({
-        elementIndex: 1, textOffset: 0, clampedFromPrefix: false,
+        elementIndex: 1,
+        textOffset: 0,
+        clampedFromPrefix: false,
       });
     });
   });
 
-  describe('edge cases', () => {
-    it('empty document returns null', () => {
+  describe("edge cases", () => {
+    it("empty document returns null", () => {
       doc = makeEmptyDoc();
       expect(resolveOffset(getFragment(doc), 0)).toBeNull();
     });
 
-    it('offset past document end clamps to last element', () => {
-      doc = makeDoc('Hello');
+    it("offset past document end clamps to last element", () => {
+      doc = makeDoc("Hello");
       const result = resolveOffset(getFragment(doc), 100);
       expect(result).toEqual({ elementIndex: 0, textOffset: 5, clampedFromPrefix: false });
     });
 
-    it('offset past end of multi-element doc clamps to last element', () => {
-      doc = makeDoc('A\nB');
+    it("offset past end of multi-element doc clamps to last element", () => {
+      doc = makeDoc("A\nB");
       const result = resolveOffset(getFragment(doc), 100);
       expect(result).toEqual({ elementIndex: 1, textOffset: 1, clampedFromPrefix: false });
     });
+  });
+});
+
+describe("blockquote offset consistency (Issue #148)", () => {
+  afterEach(() => {
+    doc?.destroy();
+  });
+
+  it("extractText offsets match validateRange for text after a blockquote", () => {
+    doc = makeMarkdownDoc("# Title\n\n> A blockquote line\n\nText after blockquote");
+    const text = extractText(doc);
+
+    const target = "Text after blockquote";
+    const from = text.indexOf(target);
+    expect(from).toBeGreaterThan(-1);
+    const to = from + target.length;
+
+    const result = validateRange(doc, from, to, { textSnapshot: target });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.range.from).toBe(from);
+      expect(result.range.to).toBe(to);
+    }
+  });
+
+  it("extractText offsets match validateRange for text after multiple blockquotes", () => {
+    doc = makeMarkdownDoc("Intro\n\n> Quote one\n\n> Quote two\n\nAfter quotes");
+    const text = extractText(doc);
+
+    const target = "After quotes";
+    const from = text.indexOf(target);
+    expect(from).toBeGreaterThan(-1);
+    const to = from + target.length;
+
+    const result = validateRange(doc, from, to, { textSnapshot: target });
+    expect(result.ok).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- `tandem_getTextContent` used `extractMarkdown()` for .md files, which adds markdown syntax (`> ` blockquote prefixes, blank lines) that shifts offsets relative to `extractText()` used by `validateRange`/`anchoredRange`
- This caused `RANGE_MOVED` errors when callers derived offsets from `getTextContent` and passed them to annotation tools on documents with blockquotes
- Fix: always use `extractText()`, whose offsets match the annotation coordinate system

Closes #148

## Test plan
- [x] 2 new unit tests: blockquote offset consistency between `extractText` and `validateRange`
- [x] All 765 tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)