### PR TITLE
feat(tutorial): rename Skip button to Next, show Done on last step

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Annotation failures and save errors surface as dismissible toast notifications. 
 
 ### Onboarding Tutorial
 
-![Onboarding tutorial card showing step 1 of 3 with progress dots and skip button](docs/screenshots/08-onboarding-tutorial.png)
+![Onboarding tutorial card showing step 1 of 3 with progress dots and next button](docs/screenshots/08-onboarding-tutorial.png)
 
 On first launch, a 3-step guided walkthrough appears over the welcome document. Pre-placed annotations let you practice reviewing, asking Claude a question, and editing -- then the tutorial dismisses itself. Progress persists in localStorage so it only shows once.
 

--- a/scripts/take-screenshots.mjs
+++ b/scripts/take-screenshots.mjs
@@ -145,7 +145,7 @@ async function main() {
     });
 
     // Dismiss any existing tutorial card
-    const tutorialDismiss = page.locator('[data-testid="tutorial-skip-btn"]');
+    const tutorialDismiss = page.locator('[data-testid="tutorial-next-btn"]');
     if (await tutorialDismiss.isVisible({ timeout: 1000 }).catch(() => false)) {
       await tutorialDismiss.click();
       await sleep(300);

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -223,7 +223,7 @@ export default function App() {
 
   const activeTab = tabs.find((t) => t.id === activeTabId);
 
-  const { tutorialActive, currentStep, dismissTutorial, skipStep } = useTutorial(
+  const { tutorialActive, currentStep, dismissTutorial, nextStep } = useTutorial(
     annotations,
     editorRef,
     activeTab?.fileName,
@@ -468,7 +468,7 @@ export default function App() {
       {tutorialActive && (
         <OnboardingTutorial
           currentStep={currentStep}
-          onSkip={skipStep}
+          onNext={nextStep}
           onDismiss={dismissTutorial}
         />
       )}

--- a/src/client/components/OnboardingTutorial.tsx
+++ b/src/client/components/OnboardingTutorial.tsx
@@ -1,6 +1,6 @@
 interface OnboardingTutorialProps {
   currentStep: number;
-  onSkip: () => void;
+  onNext: () => void;
   onDismiss: () => void;
 }
 
@@ -26,7 +26,7 @@ const STEPS = [
 /** Steps 0-2 are actionable; step 3 is the completion message */
 const TOTAL_STEPS = 3;
 
-export function OnboardingTutorial({ currentStep, onSkip, onDismiss }: OnboardingTutorialProps) {
+export function OnboardingTutorial({ currentStep, onNext, onDismiss }: OnboardingTutorialProps) {
   const step = STEPS[currentStep];
   if (!step) return null;
 
@@ -116,8 +116,8 @@ export function OnboardingTutorial({ currentStep, onSkip, onDismiss }: Onboardin
               Dismiss tutorial
             </button>
             <button
-              data-testid="tutorial-skip-btn"
-              onClick={onSkip}
+              data-testid="tutorial-next-btn"
+              onClick={onNext}
               style={{
                 padding: "4px 12px",
                 fontSize: 12,
@@ -129,7 +129,7 @@ export function OnboardingTutorial({ currentStep, onSkip, onDismiss }: Onboardin
                 fontWeight: 500,
               }}
             >
-              Skip
+              {currentStep === TOTAL_STEPS - 1 ? "Done" : "Next"}
             </button>
           </div>
         </div>

--- a/src/client/hooks/useTutorial.ts
+++ b/src/client/hooks/useTutorial.ts
@@ -9,7 +9,7 @@ interface UseTutorialResult {
   tutorialActive: boolean;
   currentStep: number;
   dismissTutorial: () => void;
-  skipStep: () => void;
+  nextStep: () => void;
 }
 
 function readCompleted(): boolean {
@@ -109,7 +109,7 @@ export function useTutorial(
     setCompleted(true);
   }, []);
 
-  const skipStep = useCallback(() => {
+  const nextStep = useCallback(() => {
     stepAdvancedAt.current = Date.now();
     setCurrentStep((prev) => Math.min(prev + 1, 3));
   }, []);
@@ -118,6 +118,6 @@ export function useTutorial(
     tutorialActive,
     currentStep,
     dismissTutorial,
-    skipStep,
+    nextStep,
   };
 }


### PR DESCRIPTION
## Summary
- Renames the onboarding tutorial "Skip" button to "Next" for clearer UX
- Shows "Done" on the final actionable step instead of "Next"
- Renames `onSkip`→`onNext` prop, `skipStep`→`nextStep` hook function throughout

Closes #154

## Test plan
- [x] `npm run typecheck` passes
- [x] All 765 unit tests pass
- [ ] Manual: open app, verify tutorial shows "Next" on steps 1-2 and "Done" on step 3
- [ ] Manual: verify "Dismiss tutorial" still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>