### PR TITLE
fix(ui): use absolute URL for /api/close in handleTabClose

### DIFF
--- a/src/client/hooks/useYjsSync.ts
+++ b/src/client/hooks/useYjsSync.ts
@@ -3,6 +3,7 @@ import * as Y from "yjs";
 import { HocuspocusProvider } from "@hocuspocus/provider";
 import {
   DEFAULT_WS_PORT,
+  DEFAULT_MCP_PORT,
   CTRL_ROOM,
   Y_MAP_ANNOTATIONS,
   Y_MAP_AWARENESS,
@@ -302,7 +303,7 @@ export function useYjsSync(): YjsSyncResult {
     });
 
     // Tell the server to close the document — the broadcast will reconcile tabs
-    fetch("/api/close", {
+    fetch(`http://localhost:${DEFAULT_MCP_PORT}/api/close`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ documentId: tabId }),


### PR DESCRIPTION
## Summary

- `handleTabClose` was calling `fetch("/api/close", ...)` with a relative URL
- Vite's dev server (port 5173) has no `/api` proxy configured, so the request silently 404'd
- The API server on port 3479 never received the close signal, so the tab never disappeared
- Fixed by using `http://localhost:${DEFAULT_MCP_PORT}/api/close` — the same absolute URL pattern used by all other API calls in the client (e.g. `FileOpenDialog`, `useNotifications`, `ReviewOnlyBanner`)

## Test plan

- [ ] Open multiple documents in Tandem
- [ ] Click the × button on a tab — verify the tab closes and the document is removed
- [ ] Close the last remaining tab — verify it closes cleanly and the empty state is shown
- [ ] Verify existing file open / upload flows still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)