### PR TITLE
fix: quote @hocuspocus/provider edge label in architecture diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,7 @@ graph LR
         Channel["Channel Notifications"]
     end
 
-    Tiptap <-->|@hocuspocus/provider| HP
+    Tiptap <-->|"@hocuspocus/provider"| HP
     HP <--> YDoc
     MCP -->|tandem_open| FO
     API -->|/api/open, /api/upload, /api/close| FO


### PR DESCRIPTION
## Summary
- Fixes the Container Diagram in `docs/architecture.md` failing to render on GitHub
- The `@` character in `@hocuspocus/provider` was being parsed as a Mermaid `LINK_ID` token when unquoted in an edge label
- Wrapped the label in double quotes (`|"@hocuspocus/provider"|`) to fix the parse error

## Test plan
- [ ] View the PR diff on GitHub and confirm the Container Diagram renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)