### PR TITLE
fix(docs): correct stale enums, error codes, and browser URL

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -25,7 +25,9 @@ All tools return responses in a standard envelope:
 | `FILE_LOCKED` | File is open in another program (e.g., Word). Close it first. |
 | `FORMAT_ERROR` | Unsupported format, file too large (>50MB), or invalid regex. |
 | `INVALID_RANGE` | Offset out of bounds, text not found, or range overlaps heading markup. |
-| `RANGE_STALE` | *(Planned)* Document changed between resolveRange and a mutation. |
+| `RANGE_MOVED` | Target text has moved. Response includes `resolvedFrom`/`resolvedTo` with relocated coordinates. |
+| `RANGE_GONE` | Target text was deleted from the document. |
+| `PERMISSION_DENIED` | File path is not accessible (OS-level permission denied, e.g., `EACCES`). |
 
 ## Coordinate System
 
@@ -88,7 +90,7 @@ tandem_open({ filePath: "C:\\Users\\bkolb\\Documents\\progress-report-feb.md" })
 
 **Notes:**
 - Supported formats: `.md`, `.txt`, `.html`, `.docx` (review-only).
-- Browser opens automatically to `http://localhost:5173` on the first call.
+- Browser opens automatically to `http://localhost:3479` on the first call.
 - Opening a file that's already open switches to its tab (returns `alreadyOpen: true`).
 - Pass `force: true` to reload from disk when the file changed externally (git pull, external editor). Clears annotations and session. Returns `forceReloaded: true`.
 - Multiple documents can be open simultaneously -- each gets its own tab.
@@ -261,7 +263,7 @@ Check editor status: running state, open documents, active document.
 ```
 
 **Notes:**
-- `interruptionMode` reflects the user's current interruption preference from the browser StatusBar: `"all"` (show everything), `"urgent"` (only flags, questions, and `priority: 'urgent'`), or `"paused"` (hold all new annotations). Adapt your annotation strategy accordingly — e.g., in `"urgent"` mode, prefer `tandem_flag` with `priority: 'urgent'` over `tandem_comment` for important findings.
+- `interruptionMode` reflects the user's current interruption preference from the browser StatusBar: `"all"` (show everything), `"urgent-only"` (only flags, questions, and `priority: 'urgent'`), or `"paused"` (hold all new annotations). Adapt your annotation strategy accordingly — e.g., in `"urgent-only"` mode, prefer `tandem_flag` with `priority: 'urgent'` over `tandem_comment` for important findings.
 
 ---
 
@@ -430,7 +432,7 @@ Flag a text range for attention (e.g., issues, concerns, or items needing review
 | `note` | string | No | Reason for flagging |
 | `documentId` | string | No | Target document ID (defaults to active document) |
 | `priority` | `'normal'` \| `'urgent'` | No | Annotation priority. Set to 'urgent' for critical issues visible in urgent-only mode. Flags and questions are implicitly urgent. |
-| `textSnapshot` | string | No | Expected text at range — returns RANGE_STALE if moved |
+| `textSnapshot` | string | No | Expected text at range — returns `RANGE_MOVED` with relocated range on mismatch, or `RANGE_GONE` if deleted |
 
 **Returns:** `{ annotationId: string }`
 
@@ -446,8 +448,8 @@ Read all annotations, optionally filtered. For checking new user actions, prefer
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `author` | enum | no | `user` or `claude` |
-| `type` | enum | no | `highlight`, `comment`, `suggestion`, `overlay`, `question` |
+| `author` | enum | no | `user`, `claude`, or `import` |
+| `type` | enum | no | `highlight`, `comment`, `suggestion`, `overlay`, `question`, `flag` |
 | `status` | enum | no | `pending`, `accepted`, `dismissed` |
 | `documentId` | string | no | Target document ID (defaults to active document) |
 
@@ -732,7 +734,7 @@ Check for user actions you haven't seen yet -- new highlights, comments, questio
 - `userActions`: annotations created by the user (highlights, comments, questions).
 - `userResponses`: the user's accept/dismiss decisions on Claude's annotations.
 - `chatMessages`: new chat messages from the user via the ChatPanel sidebar. Each entry has `id`, `author`, `text`, `timestamp`, and optionally `documentId` (the document that was active when the message was sent).
-- `interruptionMode`: the user's current interruption preference (`"all"`, `"urgent"`, or `"paused"`). When `"urgent"`, only use `tandem_flag` with `priority: 'urgent'` for critical findings. When `"paused"`, queue work and wait for the mode to change.
+- `interruptionMode`: the user's current interruption preference (`"all"`, `"urgent-only"`, or `"paused"`). When `"urgent-only"`, only use `tandem_flag` with `priority: 'urgent'` for critical findings. When `"paused"`, queue work and wait for the mode to change.
 
 ---
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -14,10 +14,10 @@ Most AI document tools are writing assistants — they help you produce content.
 
 ### The annotation model
 
-Tandem's core differentiator is that AI suggestions are **first-class data objects**, not ephemeral UI. Each annotation (highlight, comment, suggestion, question) is:
+Tandem's core differentiator is that AI suggestions are **first-class data objects**, not ephemeral UI. Each annotation (highlight, comment, suggestion, question, flag) is:
 
 - **Addressable** — stored in a Y.Map with a unique ID
-- **Typed** — highlight, comment, suggestion, or question, each with distinct visual treatment
+- **Typed** — highlight, comment, suggestion, question, or flag, each with distinct visual treatment
 - **Attributable** — author field tracks who created it (Claude or user)
 - **Resolvable** — user accepts or dismisses each one individually
 - **Queryable** — user can ask Claude about specific annotations via "Ask Claude"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -164,7 +164,7 @@ Remaining:
 - WebSocket reconnection: automatic, no data loss (Yjs handles this)
 
 Remaining:
-- `RANGE_STALE` error: auto-retry with re-resolved range (currently documented but not implemented)
+- `RANGE_MOVED` / `RANGE_GONE` auto-retry: re-resolve range automatically when text has shifted
 - Large file warnings: alert at 50+ pages about potential slowness
 
 ### 8f: Toolbar Enhancements — PARTIALLY DONE

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -251,7 +251,7 @@ Opus: tandem_getAnnotations({ author: "claude", status: "pending" })
 **Setup:** Claude has finished reviewing and left 15+ annotations. Bryan wants to process them efficiently.
 
 The browser's side panel shows all pending annotations with filter controls:
-- Filter by type (highlights, comments, suggestions, questions)
+- Filter by type (highlights, comments, suggestions, questions, flags)
 - Filter by author (Claude, You)
 - Filter by status (pending, accepted, dismissed)
 


### PR DESCRIPTION
## Summary

- Replace phantom `RANGE_STALE` error code with actual `RANGE_MOVED`, `RANGE_GONE`, and `PERMISSION_DENIED`
- Fix browser auto-open URL from `:5173` (Vite dev) to `:3479` (production MCP port)
- Add missing `"import"` author and `"flag"` type to `tandem_getAnnotations` parameter docs
- Fix `interruptionMode` enum value `"urgent"` → `"urgent-only"` in two locations
- Update `textSnapshot` description with correct `RANGE_MOVED`/`RANGE_GONE` behavior
- Fix stale `RANGE_STALE` reference in roadmap.md
- Add `flag` to annotation type lists in workflows.md and positioning.md

All changes verified against source schemas (`AuthorSchema`, `AnnotationTypeSchema`, `ToolErrorCodeSchema`, `InterruptionModeSchema` in `src/shared/types.ts`).

## Test plan

- [ ] Verify error code table in mcp-tools.md matches `ToolErrorCodeSchema`
- [ ] Verify `tandem_getAnnotations` enums match `AuthorSchema` and `AnnotationTypeSchema`
- [ ] Confirm browser opens to `:3479` in production mode (`npm run start:server`)
- [ ] Grep for any remaining `RANGE_STALE` references (should be zero)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)