### PR TITLE
feat: add adjustable editor content width toggle

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -13,13 +13,14 @@ import { ToastContainer } from "./components/ToastContainer";
 import { OnboardingTutorial } from "./components/OnboardingTutorial";
 import {
   DISCONNECT_DEBOUNCE_MS,
+  EDITOR_WIDTH_MODE_KEY,
   INTERRUPTION_MODE_DEFAULT,
   INTERRUPTION_MODE_KEY,
   PROLONGED_DISCONNECT_MS,
   REVIEW_BANNER_THRESHOLD,
   Y_MAP_USER_AWARENESS,
 } from "../shared/constants";
-import type { InterruptionMode, CapturedAnchor } from "../shared/types";
+import type { InterruptionMode, WidthMode, CapturedAnchor } from "../shared/types";
 import { InterruptionModeSchema } from "../shared/types";
 import { pmSelectionToFlat } from "./positions";
 import { toPmPos } from "../shared/positions/types";
@@ -117,6 +118,8 @@ const PANEL_MAX_WIDTH = 600;
 const PANEL_DEFAULT_WIDTH = 300;
 const PANEL_WIDTH_KEY = "tandem-panel-width";
 
+const EDITOR_READING_WIDTH_PX = 740;
+
 export default function App() {
   const {
     tabs,
@@ -211,6 +214,26 @@ export default function App() {
     }
     return PANEL_DEFAULT_WIDTH;
   });
+
+  const [widthMode, setWidthMode] = useState<WidthMode>(() => {
+    try {
+      return localStorage.getItem(EDITOR_WIDTH_MODE_KEY) === "reading" ? "reading" : "full";
+    } catch {
+      return "full";
+    }
+  });
+
+  const toggleWidthMode = useCallback(() => {
+    setWidthMode((prev) => {
+      const next = prev === "reading" ? "full" : "reading";
+      try {
+        localStorage.setItem(EDITOR_WIDTH_MODE_KEY, next);
+      } catch {
+        // localStorage unavailable
+      }
+      return next;
+    });
+  }, []);
 
   const panelWidthRef = useRef(panelWidth);
   panelWidthRef.current = panelWidth;
@@ -429,19 +452,26 @@ export default function App() {
             visible={activeTab?.readOnly === true && activeTab?.format === "docx"}
             documentId={activeTab?.id}
           />
-          {activeTab ? (
-            <Editor
-              key={activeTab.id}
-              ydoc={activeTab.ydoc}
-              provider={activeTab.provider}
-              readOnly={readOnly}
-              reviewMode={reviewMode}
-              activeAnnotationId={activeAnnotationId}
-              onEditorReady={handleEditorReady}
-            />
-          ) : (
-            <EmptyState connected={connected} claudeActive={claudeActive} />
-          )}
+          <div
+            style={{
+              maxWidth: widthMode === "reading" ? `${EDITOR_READING_WIDTH_PX}px` : undefined,
+              margin: widthMode === "reading" ? "0 auto" : undefined,
+            }}
+          >
+            {activeTab ? (
+              <Editor
+                key={activeTab.id}
+                ydoc={activeTab.ydoc}
+                provider={activeTab.provider}
+                readOnly={readOnly}
+                reviewMode={reviewMode}
+                activeAnnotationId={activeAnnotationId}
+                onEditorReady={handleEditorReady}
+              />
+            ) : (
+              <EmptyState connected={connected} claudeActive={claudeActive} />
+            )}
+          </div>
         </div>
         {/* Resize handle */}
         <div
@@ -574,6 +604,8 @@ export default function App() {
         interruptionMode={interruptionMode}
         onModeChange={setInterruptionMode}
         heldCount={heldCount}
+        widthMode={widthMode}
+        onToggleWidthMode={toggleWidthMode}
       />
       {showReviewSummary && reviewSummaryData && (
         <ReviewSummary

--- a/src/client/status/StatusBar.tsx
+++ b/src/client/status/StatusBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { CLAUDE_PRESENCE_COLOR, USER_NAME_KEY, USER_NAME_DEFAULT } from "../../shared/constants";
-import type { InterruptionMode } from "../../shared/types";
+import type { InterruptionMode, WidthMode } from "../../shared/types";
 import type { ConnectionStatus } from "../hooks/useYjsSync";
 
 interface StatusBarProps {
@@ -15,6 +15,8 @@ interface StatusBarProps {
   interruptionMode: InterruptionMode;
   onModeChange: (mode: InterruptionMode) => void;
   heldCount: number;
+  widthMode: WidthMode;
+  onToggleWidthMode: () => void;
 }
 
 const MODES: { value: InterruptionMode; label: string; title: string }[] = [
@@ -41,6 +43,8 @@ export function StatusBar({
   interruptionMode,
   onModeChange,
   heldCount,
+  widthMode,
+  onToggleWidthMode,
 }: StatusBarProps) {
   const [userName, setUserName] = useState(
     () => localStorage.getItem(USER_NAME_KEY)?.trim() || USER_NAME_DEFAULT,
@@ -179,6 +183,28 @@ export function StatusBar({
             </button>
           ))}
         </div>
+        <button
+          title={
+            widthMode === "reading"
+              ? "Switch to full width layout"
+              : "Switch to narrow reading width layout"
+          }
+          aria-label="Toggle reading width"
+          aria-pressed={widthMode === "reading"}
+          onClick={onToggleWidthMode}
+          style={{
+            padding: "1px 8px",
+            fontSize: "11px",
+            border: "1px solid #d1d5db",
+            borderRadius: "4px",
+            cursor: "pointer",
+            background: widthMode === "reading" ? "#6366f1" : "transparent",
+            color: widthMode === "reading" ? "#fff" : "#6b7280",
+            fontWeight: widthMode === "reading" ? 600 : 400,
+          }}
+        >
+          Reading Width
+        </button>
       </div>
 
       <div

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -61,6 +61,9 @@ export const NOTIFICATION_BUFFER_SIZE = 50;
 export const TUTORIAL_COMPLETED_KEY = "tandem:tutorialCompleted";
 export const TUTORIAL_ANNOTATION_PREFIX = "tutorial-";
 
+// Editor layout
+export const EDITOR_WIDTH_MODE_KEY = "tandem:editorWidthMode";
+
 // Channel / event queue
 export const CHANNEL_EVENT_BUFFER_SIZE = 200;
 export const CHANNEL_EVENT_BUFFER_AGE_MS = 60_000; // 60 seconds

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -47,6 +47,7 @@ export type AnnotationType = z.infer<typeof AnnotationTypeSchema>;
 export type AnnotationStatus = z.infer<typeof AnnotationStatusSchema>;
 export type AnnotationPriority = z.infer<typeof AnnotationPrioritySchema>;
 export type InterruptionMode = z.infer<typeof InterruptionModeSchema>;
+export type WidthMode = "reading" | "full";
 export type HighlightColor = z.infer<typeof HighlightColorSchema>;
 export type Severity = z.infer<typeof SeveritySchema>;
 


### PR DESCRIPTION
## Summary

Closes #185.

- Adds a "Reading Width" toggle button in the status bar (next to interruption mode)
- When active, constrains editor content to 740px max-width, centered
- Default is full-width (no regression)
- Setting persists via localStorage (`tandem:editorWidthMode`)
- `WidthMode` type exported from `shared/types.ts` for type safety across components

## Files changed
- `src/shared/constants.ts` — `EDITOR_WIDTH_MODE_KEY` constant
- `src/shared/types.ts` — `WidthMode` type export
- `src/client/App.tsx` — width mode state, centering wrapper div
- `src/client/status/StatusBar.tsx` — toggle button with active/inactive visual state

## Test plan

- [ ] Default state is full-width (no visual change for existing users)
- [ ] Click "Reading Width" in status bar — editor content narrows to ~740px, centered
- [ ] Click again — returns to full width
- [ ] Reload page — setting persists
- [ ] Annotation sidebar still works independently
- [ ] File drag-and-drop still works in both modes
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (884 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)