### PR TITLE
fix(client): improve annotation card UX (#195, #196, #201)

### DIFF
--- a/src/client/panels/AnnotationCard.tsx
+++ b/src/client/panels/AnnotationCard.tsx
@@ -29,7 +29,7 @@ function getBorderColor(annotation: Annotation): string {
 }
 
 /** Parse suggestion content JSON, returning { newText, reason } or null on failure */
-function parseSuggestion(content: string): { newText: string; reason: string } | null {
+export function parseSuggestion(content: string): { newText: string; reason: string } | null {
   try {
     const parsed = JSON.parse(content);
     if (typeof parsed.newText === "string") {
@@ -176,9 +176,9 @@ export const AnnotationCard = React.memo(function AnnotationCard({
                 enterEditMode();
               }}
               style={editBtnStyle}
-              title="Edit annotation"
+              title="Edit this annotation's content"
             >
-              ✎
+              ✎ Edit
             </button>
           )}
         </span>
@@ -313,14 +313,59 @@ export const AnnotationCard = React.memo(function AnnotationCard({
           </div>
         </div>
       ) : (
-        <p style={{ margin: 0, color: "#4b5563", lineHeight: "1.4" }}>
-          {annotation.type === "suggestion"
-            ? (() => {
-                const parsed = parseSuggestion(annotation.content);
-                return parsed ? parsed.reason || parsed.newText : annotation.content;
-              })()
-            : annotation.content || "(no note)"}
-        </p>
+        <div style={{ margin: 0, color: "#4b5563", lineHeight: "1.4" }}>
+          {annotation.type === "suggestion" ? (
+            (() => {
+              const parsed = parseSuggestion(annotation.content);
+              if (!parsed) return <p style={{ margin: 0 }}>{annotation.content}</p>;
+              return (
+                <>
+                  <div
+                    data-testid={`suggestion-diff-${annotation.id}`}
+                    style={{
+                      padding: "4px 8px",
+                      marginBottom: parsed.reason ? "4px" : 0,
+                      backgroundColor: "#f9fafb",
+                      borderRadius: "3px",
+                      fontSize: "12px",
+                      lineHeight: "1.5",
+                    }}
+                  >
+                    {annotation.textSnapshot && (
+                      <span
+                        style={{
+                          textDecoration: "line-through",
+                          color: "#dc2626",
+                          backgroundColor: "#fef2f2",
+                          padding: "0 2px",
+                          borderRadius: "2px",
+                        }}
+                      >
+                        {annotation.textSnapshot}
+                      </span>
+                    )}
+                    {annotation.textSnapshot && " → "}
+                    <span
+                      style={{
+                        color: "#166534",
+                        backgroundColor: "#f0fdf4",
+                        padding: "0 2px",
+                        borderRadius: "2px",
+                      }}
+                    >
+                      {parsed.newText}
+                    </span>
+                  </div>
+                  {parsed.reason && (
+                    <p style={{ margin: 0, fontSize: "12px", color: "#6b7280" }}>{parsed.reason}</p>
+                  )}
+                </>
+              );
+            })()
+          ) : (
+            <p style={{ margin: 0 }}>{annotation.content || "(no note)"}</p>
+          )}
+        </div>
       )}
       {isPending && !isEditing && (onAccept || onDismiss) && (
         <div style={{ display: "flex", gap: "6px", marginTop: "6px" }}>
@@ -367,7 +412,7 @@ export const AnnotationCard = React.memo(function AnnotationCard({
         </div>
       )}
       {!isPending && undoable && onUndo && (
-        <div style={{ marginTop: "4px" }}>
+        <div style={{ marginTop: "4px", position: "relative" }}>
           <button
             data-testid="undo-btn"
             onClick={(e) => {
@@ -386,6 +431,22 @@ export const AnnotationCard = React.memo(function AnnotationCard({
           >
             Undo
           </button>
+          <div
+            data-testid="undo-countdown"
+            style={{
+              height: "2px",
+              marginTop: "2px",
+              borderRadius: "1px",
+              backgroundColor: "#6366f1",
+              animation: "undo-countdown-shrink 10s linear forwards",
+            }}
+          />
+          <style>
+            {`@keyframes undo-countdown-shrink {
+              from { width: 100%; }
+              to { width: 0%; }
+            }`}
+          </style>
         </div>
       )}
     </div>

--- a/tests/client/annotation-card.test.ts
+++ b/tests/client/annotation-card.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { parseSuggestion } from "../../src/client/panels/AnnotationCard.js";
+
+describe("parseSuggestion", () => {
+  it("parses valid suggestion with newText and reason", () => {
+    const content = JSON.stringify({ newText: "fixed text", reason: "typo correction" });
+    const result = parseSuggestion(content);
+    expect(result).toEqual({ newText: "fixed text", reason: "typo correction" });
+  });
+
+  it("parses valid suggestion with newText only (no reason)", () => {
+    const content = JSON.stringify({ newText: "replacement" });
+    const result = parseSuggestion(content);
+    expect(result).toEqual({ newText: "replacement", reason: "" });
+  });
+
+  it("returns null for non-JSON content", () => {
+    expect(parseSuggestion("just plain text")).toBeNull();
+  });
+
+  it("returns null for JSON without newText field", () => {
+    const content = JSON.stringify({ reason: "some reason" });
+    expect(parseSuggestion(content)).toBeNull();
+  });
+
+  it("returns null for JSON with non-string newText", () => {
+    const content = JSON.stringify({ newText: 42 });
+    expect(parseSuggestion(content)).toBeNull();
+  });
+
+  it("handles empty string newText", () => {
+    const content = JSON.stringify({ newText: "", reason: "delete this text" });
+    const result = parseSuggestion(content);
+    expect(result).toEqual({ newText: "", reason: "delete this text" });
+  });
+
+  it("defaults reason to empty string when reason is falsy", () => {
+    const content = JSON.stringify({ newText: "abc", reason: "" });
+    const result = parseSuggestion(content);
+    expect(result).toEqual({ newText: "abc", reason: "" });
+  });
+});


### PR DESCRIPTION
## Summary
- **#195**: Suggestion cards now show a diff view (strikethrough original → green replacement text) instead of hiding `newText` when `reason` exists
- **#196**: Pure CSS 10-second countdown bar below the Undo button — no new state, just a `@keyframes` animation matching the existing timer
- **#201**: Edit button shows "✎ Edit" with descriptive tooltip instead of icon-only

## Test plan
- [x] 7 new unit tests for `parseSuggestion` (valid JSON, edge cases, non-JSON fallback)
- [x] All 891 tests pass
- [ ] Manual: create suggestion with reason + newText, verify both display
- [ ] Manual: resolve annotation, verify countdown bar shrinks over 10s
- [ ] Manual: verify edit button label visible and tooltip reads "Edit this annotation's content"

Closes #195, closes #196, closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)