### PR TITLE
feat: suppress selection channel events until first chat message (#188)

### DIFF
--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -35,6 +35,13 @@ const emittedPayloadIds = new Map<string, number>();
 const buffer: TandemEvent[] = [];
 const subscribers = new Set<EventCallback>();
 
+/**
+ * Selection gate: suppress selection:changed channel events until the user
+ * sends their first chat message. Once the gate opens it stays open for the
+ * lifetime of the server process (reset only via resetForTesting).
+ */
+let selectionGateOpen = false;
+
 function getTrackableId(event: TandemEvent): string | undefined {
   switch (event.type) {
     case "annotation:created":
@@ -179,6 +186,7 @@ export function attachObservers(docName: string, doc: Y.Doc): void {
         | undefined;
       // Skip cleared selections (cursor moves without selecting text) — they flood the channel
       if (!selection || selection.from === selection.to) return;
+      if (!selectionGateOpen) return;
       pushEvent({
         id: generateEventId(),
         type: "selection:changed",
@@ -235,6 +243,9 @@ export function attachCtrlObservers(): void {
       if (change.action !== "add") continue;
       const msg = chatMap.get(key) as ChatMessage | undefined;
       if (!msg || msg.author !== "user") continue;
+
+      // Open the selection gate on first user chat message (#188)
+      selectionGateOpen = true;
 
       pushEvent({
         id: generateEventId(),
@@ -331,11 +342,17 @@ export function reattachCtrlObservers(): void {
   attachCtrlObservers();
 }
 
+/** Open the selection gate manually. For tests only — production code opens it via chat messages. */
+export function openSelectionGateForTesting(): void {
+  selectionGateOpen = true;
+}
+
 /** Reset all module state. For tests only — do not call in production. */
 export function resetForTesting(): void {
   buffer.length = 0;
   subscribers.clear();
   emittedPayloadIds.clear();
+  selectionGateOpen = false;
   for (const cleanups of docObservers.values()) {
     for (const cleanup of cleanups) cleanup();
   }

--- a/tests/server/event-queue.test.ts
+++ b/tests/server/event-queue.test.ts
@@ -5,6 +5,7 @@ import {
   attachObservers,
   detachObservers,
   MCP_ORIGIN,
+  openSelectionGateForTesting,
   reattachObservers,
   replaySince,
   resetForTesting,
@@ -373,6 +374,8 @@ describe("selection event filtering", () => {
   beforeEach(() => {
     doc = new Y.Doc();
     attachObservers("sel-doc", doc);
+    // Open the selection gate so these tests focus on from/to filtering, not the gate
+    openSelectionGateForTesting();
   });
 
   afterEach(() => {
@@ -613,6 +616,110 @@ vi.mock("../../src/server/yjs/provider.js", () => ({
 vi.mock("../../src/server/mcp/document-service.js", () => ({
   getOpenDocs: () => new Map(),
 }));
+
+// --- Selection gate (#188): suppress selection events until first chat message ---
+
+describe("selection gate (#188)", () => {
+  let doc: Y.Doc;
+
+  beforeEach(() => {
+    doc = new Y.Doc();
+    attachObservers("gate-doc", doc);
+  });
+
+  afterEach(() => {
+    detachObservers("gate-doc");
+    doc.destroy();
+  });
+
+  it("suppresses selection:changed events before any chat message", () => {
+    const { events, cleanup } = collectEvents();
+    const awareness = doc.getMap(Y_MAP_USER_AWARENESS);
+
+    awareness.set("selection", {
+      from: 10,
+      to: 50,
+      selectedText: "selected text",
+      timestamp: Date.now(),
+    });
+
+    expect(events.filter((e) => e.type === "selection:changed")).toHaveLength(0);
+    cleanup();
+  });
+
+  it("emits selection:changed events after first chat message opens the gate", () => {
+    const { events, cleanup } = collectEvents();
+
+    // Attach CTRL_ROOM observers so chat messages are processed
+    _ctrlTestDoc = new Y.Doc();
+    attachCtrlObservers();
+
+    // Send a chat message to open the gate
+    const chatMap = _ctrlTestDoc.getMap(Y_MAP_CHAT);
+    chatMap.set("msg_gate", {
+      id: "msg_gate",
+      author: "user",
+      text: "Hello",
+      timestamp: Date.now(),
+      documentId: "gate-doc",
+      read: false,
+    });
+
+    // Now selection events should flow
+    const awareness = doc.getMap(Y_MAP_USER_AWARENESS);
+    awareness.set("selection", {
+      from: 10,
+      to: 50,
+      selectedText: "now visible",
+      timestamp: Date.now(),
+    });
+
+    const selEvents = events.filter((e) => e.type === "selection:changed");
+    expect(selEvents).toHaveLength(1);
+    expect(selEvents[0].payload.selectedText).toBe("now visible");
+
+    _ctrlTestDoc.destroy();
+    cleanup();
+  });
+
+  it("resetForTesting closes the selection gate", () => {
+    const { cleanup } = collectEvents();
+
+    // Manually open the gate via a chat message
+    _ctrlTestDoc = new Y.Doc();
+    attachCtrlObservers();
+    const chatMap = _ctrlTestDoc.getMap(Y_MAP_CHAT);
+    chatMap.set("msg_reset", {
+      id: "msg_reset",
+      author: "user",
+      text: "open gate",
+      timestamp: Date.now(),
+      documentId: "gate-doc",
+      read: false,
+    });
+
+    _ctrlTestDoc.destroy();
+    cleanup();
+
+    // Reset should close the gate
+    resetForTesting();
+
+    // Reattach after reset
+    doc = new Y.Doc();
+    attachObservers("gate-doc", doc);
+    const { events: events2, cleanup: cleanup2 } = collectEvents();
+    const awareness = doc.getMap(Y_MAP_USER_AWARENESS);
+    awareness.set("selection", {
+      from: 10,
+      to: 50,
+      selectedText: "should be suppressed",
+      timestamp: Date.now(),
+    });
+
+    expect(events2.filter((e) => e.type === "selection:changed")).toHaveLength(0);
+    cleanup2();
+  });
+});
 
 describe("attachCtrlObservers (CTRL_ROOM)", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Closed

Closing this PR after reviewing issue #206, which establishes that #188 should land **after** the panel layout rework (chat left, editor center, annotations right) and skill update. Implementing selection suppression standalone would break the side-by-side terminal workflow described in #206.

---

## Original Summary
- Adds a module-level `selectionGateOpen` flag in the event queue that prevents `selection:changed` events from being pushed to the channel until the user sends their first chat message
- Reduces noise for Claude when a user is just reading/scrolling before initiating conversation
- Selections are still written to Y.Map for polling tools (`tandem_getSelections`) -- only channel push is gated

https://claude.ai/code/session_01AhJpHFxXLHK1RRKPKc27qC