### PR TITLE
feat: replace review banner with per-annotation toast notifications (#208)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -17,7 +17,6 @@ import {
   INTERRUPTION_MODE_DEFAULT,
   INTERRUPTION_MODE_KEY,
   PROLONGED_DISCONNECT_MS,
-  REVIEW_BANNER_THRESHOLD,
   Y_MAP_USER_AWARENESS,
 } from "../shared/constants";
 import type { InterruptionMode, WidthMode, CapturedAnchor } from "../shared/types";
@@ -193,11 +192,10 @@ export default function App() {
   const { toasts, dismiss: dismissToast } = useNotifications();
   const { fileDragOver, handleEditorDragOver, handleEditorDragLeave, handleEditorDrop } =
     useFileDrop();
-  const { pendingCount, showReviewSummary, reviewSummaryData, dismissReviewSummary } =
+  const { showReviewSummary, reviewSummaryData, dismissReviewSummary } =
     useReviewCompletion(annotations);
 
   const [reviewMode, setReviewMode] = useState(false);
-  const [showBanner, setShowBanner] = useState(false);
   const [showChat, setShowChat] = useState(false);
   const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null);
   const [showHelp, setShowHelp] = useState(false);
@@ -297,24 +295,12 @@ export default function App() {
     document.addEventListener("mouseup", onMouseUp);
   }, []);
 
-  // Show banner when pending annotations exceed threshold
-  useEffect(() => {
-    if (pendingCount >= REVIEW_BANNER_THRESHOLD && !reviewMode) {
-      setShowBanner(true);
-    }
-    if (pendingCount === 0) {
-      setShowBanner(false);
-    }
-  }, [pendingCount, reviewMode]);
-
   const toggleReviewMode = useCallback(() => {
     setReviewMode((prev) => !prev);
-    setShowBanner(false);
   }, []);
 
   const exitReviewMode = useCallback(() => {
     setReviewMode(false);
-    setShowBanner(false);
   }, []);
 
   // Snapshot editor selection for chat anchor (mousedown fires before click moves focus from editor)
@@ -395,53 +381,6 @@ export default function App() {
         onTabClose={handleTabClose}
         reorder={reorder}
       />
-      {showBanner && !reviewMode && (
-        <div
-          style={{
-            padding: "8px 16px",
-            background: "#eef2ff",
-            borderBottom: "1px solid #c7d2fe",
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            fontSize: "13px",
-            color: "#4338ca",
-          }}
-        >
-          <span>{pendingCount} annotations pending review.</span>
-          <div style={{ display: "flex", gap: "8px" }}>
-            <button
-              onClick={toggleReviewMode}
-              style={{
-                padding: "3px 10px",
-                fontSize: "12px",
-                border: "1px solid #6366f1",
-                borderRadius: "4px",
-                background: "#6366f1",
-                color: "white",
-                cursor: "pointer",
-                fontWeight: 500,
-              }}
-            >
-              Review in sequence
-            </button>
-            <button
-              onClick={() => setShowBanner(false)}
-              style={{
-                padding: "3px 10px",
-                fontSize: "12px",
-                border: "1px solid #d1d5db",
-                borderRadius: "4px",
-                background: "white",
-                color: "#6b7280",
-                cursor: "pointer",
-              }}
-            >
-              Dismiss
-            </button>
-          </div>
-        </div>
-      )}
       <div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
         <div
           style={{

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -110,6 +110,19 @@ export function createAnnotation(
     ...extras,
   };
   ydoc.transact(() => map.set(id, annotation), MCP_ORIGIN);
+
+  const snippet = annotation.textSnapshot
+    ? `: "${annotation.textSnapshot.slice(0, 60)}${annotation.textSnapshot.length > 60 ? "…" : ""}"`
+    : "";
+  pushNotification({
+    id: generateNotificationId(),
+    type: "review-pending",
+    severity: "info",
+    message: `New ${type[0].toUpperCase() + type.slice(1)}${snippet}`,
+    dedupKey: `review-pending:${type}`,
+    timestamp: Date.now(),
+  });
+
   return id;
 }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -12,7 +12,6 @@ export const TYPING_DEBOUNCE = 3000; // 3 seconds
 export const DISCONNECT_DEBOUNCE_MS = 3000; // 3 seconds before showing "server not reachable"
 export const PROLONGED_DISCONNECT_MS = 30_000; // 30 seconds before showing App-level disconnect banner
 export const OVERLAY_STALE_DEBOUNCE = 200; // 200ms
-export const REVIEW_BANNER_THRESHOLD = 5;
 
 export const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: "rgba(255, 235, 59, 0.3)",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -191,7 +191,13 @@ export interface ChatMessage {
 /** Server-to-client ephemeral notification (toast). Not persisted via CRDT. */
 export interface TandemNotification {
   id: string;
-  type: "annotation-error" | "save-error" | "session-restored" | "general-error" | "file-reloaded";
+  type:
+    | "annotation-error"
+    | "save-error"
+    | "session-restored"
+    | "general-error"
+    | "file-reloaded"
+    | "review-pending";
   severity: "info" | "warning" | "error";
   message: string;
   documentId?: string;


### PR DESCRIPTION
## Summary
- Removes the persistent review banner that appeared when >= 5 annotations were pending
- Emits toast notifications via the existing notification system when Claude creates annotations
- Uses per-type dedup keys (`review-pending:highlight`, `review-pending:comment`, etc.) so different annotation types show as separate toasts with count badges
- Removes `REVIEW_BANNER_THRESHOLD` constant and `showBanner` state from App.tsx (~50 lines deleted)
- Review mode remains accessible via the review-mode button and keyboard shortcuts

## Test plan
- [x] Typecheck passes
- [x] Full test suite passes (895 tests)
- [x] E2E regression: 5/7 pass, 2 failures are pre-existing on origin/master (Playwright browser version mismatch)

Closes #208

https://claude.ai/code/session_01AhJpHFxXLHK1RRKPKc27qC