### PR TITLE
test(e2e): add data-testids to SidePanel Clear button and held banner (#232)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Default: treat all files as text, normalize EOLs to LF on checkin and checkout
+* text=auto eol=lf
+
+# Explicit text files (belt and braces)
+*.ts    text eol=lf
+*.tsx   text eol=lf
+*.js    text eol=lf
+*.mjs   text eol=lf
+*.cjs   text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+*.html  text eol=lf
+*.css   text eol=lf
+*.sh    text eol=lf
+*.svg   text eol=lf
+LICENSE text eol=lf
+
+# Binary assets -- never touch
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.docx  binary
+*.pdf   binary
+*.zip   binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,16 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci
 
       - name: Lint
         run: npm run lint
+
+      - name: Biome format check
+        run: npx biome check .
 
       - name: Typecheck (client)
         run: npx tsc --noEmit -p tsconfig.client.json

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,9 +1,9 @@
-import { readFileSync, existsSync } from "node:fs";
-import { writeFile, rename, copyFile, unlink, mkdir } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join, dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { copyFile, mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { DEFAULT_MCP_PORT } from "../shared/constants.js";
 import { SKILL_CONTENT } from "./skill-content.js";
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -3,13 +3,13 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   DISCONNECT_DEBOUNCE_MS,
   PANEL_WIDTH_KEYS,
+  type PanelSide,
   PROLONGED_DISCONNECT_MS,
   TANDEM_MODE_DEFAULT,
   TANDEM_MODE_KEY,
   Y_MAP_DWELL_MS,
   Y_MAP_MODE,
   Y_MAP_USER_AWARENESS,
-  type PanelSide,
 } from "../shared/constants";
 import { toPmPos } from "../shared/positions/types";
 import type { CapturedAnchor, TandemMode } from "../shared/types";

--- a/src/client/components/FileOpenDialog.tsx
+++ b/src/client/components/FileOpenDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { API_BASE, readFileForUpload } from "../utils/fileUpload";
 import {
   addRecentFile,

--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -1,19 +1,19 @@
-import React, { useEffect, useCallback } from "react";
-import { USER_NAME_KEY, USER_NAME_DEFAULT } from "../../shared/constants.js";
-import { useEditor, EditorContent } from "@tiptap/react";
-import type { Editor as TiptapEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
+import { HocuspocusProvider } from "@hocuspocus/provider";
 import Collaboration from "@tiptap/extension-collaboration";
 import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
 import Highlight from "@tiptap/extension-highlight";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import Table from "@tiptap/extension-table";
-import TableRow from "@tiptap/extension-table-row";
 import TableCell from "@tiptap/extension-table-cell";
 import TableHeader from "@tiptap/extension-table-header";
+import TableRow from "@tiptap/extension-table-row";
+import type { Editor as TiptapEditor } from "@tiptap/react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import React, { useCallback, useEffect } from "react";
 import * as Y from "yjs";
-import { HocuspocusProvider } from "@hocuspocus/provider";
+import { USER_NAME_DEFAULT, USER_NAME_KEY } from "../../shared/constants.js";
 import { AnnotationExtension } from "./extensions/annotation";
 import { AwarenessExtension } from "./extensions/awareness";
 

--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -1,7 +1,7 @@
 import { Extension } from "@tiptap/core";
+import type { Node as PmNode } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
-import type { Node as PmNode } from "@tiptap/pm/model";
 import * as Y from "yjs";
 import { HIGHLIGHT_COLORS, Y_MAP_ANNOTATIONS } from "../../../shared/constants";
 import type { Annotation } from "../../../shared/types";

--- a/src/client/editor/extensions/awareness.ts
+++ b/src/client/editor/extensions/awareness.ts
@@ -1,12 +1,12 @@
 import { Extension } from "@tiptap/core";
+import type { Node as PmNode } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
-import type { Node as PmNode } from "@tiptap/pm/model";
 import * as Y from "yjs";
 import { TYPING_DEBOUNCE, Y_MAP_AWARENESS, Y_MAP_USER_AWARENESS } from "../../../shared/constants";
+import { toPmPos } from "../../../shared/positions/types";
 import type { ClaudeAwareness } from "../../../shared/types";
 import { pmSelectionToFlat } from "../../positions";
-import { toPmPos } from "../../../shared/positions/types";
 
 const awarenessPluginKey = new PluginKey("tandemAwareness");
 

--- a/src/client/editor/toolbar/FormattingToolbar.tsx
+++ b/src/client/editor/toolbar/FormattingToolbar.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef } from "react";
 import type { Editor as TiptapEditor } from "@tiptap/react";
+import React, { useEffect, useRef, useState } from "react";
 import { yUndoPluginKey } from "y-prosemirror";
 import { ToolbarButton } from "./ToolbarButton";
 

--- a/src/client/editor/toolbar/Toolbar.tsx
+++ b/src/client/editor/toolbar/Toolbar.tsx
@@ -1,14 +1,14 @@
-import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import type { Editor as TiptapEditor } from "@tiptap/react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as Y from "yjs";
-import { pmPosToFlatOffset } from "../../positions";
-import { toPmPos } from "../../../shared/positions/types";
-import { generateAnnotationId } from "../../../shared/utils";
 import { HIGHLIGHT_COLORS, Y_MAP_ANNOTATIONS } from "../../../shared/constants";
+import { toPmPos } from "../../../shared/positions/types";
 import type { Annotation, AnnotationType, HighlightColor, TandemMode } from "../../../shared/types";
+import { generateAnnotationId } from "../../../shared/utils";
+import { pmPosToFlatOffset } from "../../positions";
+import { FormattingToolbar } from "./FormattingToolbar";
 import { InputGroup } from "./InputGroup";
 import { ToolbarButton } from "./ToolbarButton";
-import { FormattingToolbar } from "./FormattingToolbar";
 
 const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
   { value: "yellow", label: "Yellow" },

--- a/src/client/hooks/useFileDrop.ts
+++ b/src/client/hooks/useFileDrop.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, type DragEvent } from "react";
+import { type DragEvent, useCallback, useState } from "react";
 import { API_BASE, readFileForUpload } from "../utils/fileUpload";
 
 /**

--- a/src/client/hooks/useReviewCompletion.ts
+++ b/src/client/hooks/useReviewCompletion.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Annotation } from "../../shared/types";
 
 /**

--- a/src/client/hooks/useTabOrder.ts
+++ b/src/client/hooks/useTabOrder.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { OpenTab } from "../types";
 
 export interface UseTabOrderResult {

--- a/src/client/hooks/useTutorial.ts
+++ b/src/client/hooks/useTutorial.ts
@@ -1,8 +1,7 @@
-import { useState, useEffect, useCallback, useRef } from "react";
-
 import type { Editor } from "@tiptap/core";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-import { TUTORIAL_COMPLETED_KEY, TUTORIAL_ANNOTATION_PREFIX } from "../../shared/constants";
+import { TUTORIAL_ANNOTATION_PREFIX, TUTORIAL_COMPLETED_KEY } from "../../shared/constants";
 import type { Annotation } from "../../shared/types";
 
 interface UseTutorialResult {

--- a/src/client/hooks/useYjsSync.ts
+++ b/src/client/hooks/useYjsSync.ts
@@ -1,10 +1,10 @@
-import { useState, useRef, useCallback, useEffect } from "react";
-import * as Y from "yjs";
 import { HocuspocusProvider } from "@hocuspocus/provider";
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as Y from "yjs";
 import {
-  DEFAULT_WS_PORT,
-  DEFAULT_MCP_PORT,
   CTRL_ROOM,
+  DEFAULT_MCP_PORT,
+  DEFAULT_WS_PORT,
   Y_MAP_ANNOTATIONS,
   Y_MAP_AWARENESS,
   Y_MAP_DOCUMENT_META,

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { ErrorBoundary } from "./components/ErrorBoundary";
 import App from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
 const root = createRoot(document.getElementById("root")!);
 root.render(

--- a/src/client/panels/AnnotationCard.tsx
+++ b/src/client/panels/AnnotationCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import type { Annotation } from "../../shared/types";
 import { HIGHLIGHT_COLORS } from "../../shared/constants";
+import type { Annotation } from "../../shared/types";
 
 export interface AnnotationCardProps {
   annotation: Annotation;

--- a/src/client/panels/ChatPanel.tsx
+++ b/src/client/panels/ChatPanel.tsx
@@ -1,12 +1,12 @@
-import { Y_MAP_CHAT, CLAUDE_PRESENCE_COLOR } from "../../shared/constants";
-import React, { useState, useEffect, useRef, useCallback } from "react";
 import type { Editor as TiptapEditor } from "@tiptap/react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import * as Y from "yjs";
-import { flatOffsetToPmPos } from "../positions";
+import { CLAUDE_PRESENCE_COLOR, Y_MAP_CHAT } from "../../shared/constants";
 import type { FlatOffset } from "../../shared/positions/types";
+import type { CapturedAnchor, ChatMessage } from "../../shared/types";
 import { generateMessageId } from "../../shared/utils";
-import type { ChatMessage, CapturedAnchor } from "../../shared/types";
+import { flatOffsetToPmPos } from "../positions";
 
 const TYPING_DOT_STYLE: React.CSSProperties = {
   width: "5px",

--- a/src/client/panels/CommentThread.tsx
+++ b/src/client/panels/CommentThread.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 interface CommentThreadProps {
   threadId: string;
@@ -6,8 +6,8 @@ interface CommentThreadProps {
 
 export function CommentThread({ threadId }: CommentThreadProps) {
   return (
-    <div style={{ padding: '8px', borderBottom: '1px solid #e5e7eb' }}>
-      <p style={{ fontSize: '13px', color: '#9ca3af' }}>Thread {threadId}</p>
+    <div style={{ padding: "8px", borderBottom: "1px solid #e5e7eb" }}>
+      <p style={{ fontSize: "13px", color: "#9ca3af" }}>Thread {threadId}</p>
     </div>
   );
 }

--- a/src/client/panels/DocumentHealth.tsx
+++ b/src/client/panels/DocumentHealth.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React from "react";
 
 export function DocumentHealth() {
   return (
-    <div style={{ padding: '8px' }}>
-      <h4 style={{ fontSize: '13px', fontWeight: 600 }}>Document Health</h4>
-      <p style={{ fontSize: '12px', color: '#9ca3af' }}>No analysis available.</p>
+    <div style={{ padding: "8px" }}>
+      <h4 style={{ fontSize: "13px", fontWeight: 600 }}>Document Health</h4>
+      <p style={{ fontSize: "12px", color: "#9ca3af" }}>No analysis available.</p>
     </div>
   );
 }

--- a/src/client/panels/ReviewSummary.tsx
+++ b/src/client/panels/ReviewSummary.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 interface ReviewSummaryProps {
   accepted: number;
@@ -11,62 +11,67 @@ export function ReviewSummary({ accepted, dismissed, total, onDismiss }: ReviewS
   const acceptRate = total > 0 ? Math.round((accepted / total) * 100) : 0;
 
   return (
-    <div style={{
-      position: 'fixed',
-      inset: 0,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      background: 'rgba(0, 0, 0, 0.4)',
-      zIndex: 1000,
-    }} onClick={onDismiss}>
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0, 0, 0, 0.4)",
+        zIndex: 1000,
+      }}
+      onClick={onDismiss}
+    >
       <div
         style={{
-          background: 'white',
-          borderRadius: '12px',
-          padding: '32px 40px',
-          maxWidth: '400px',
-          boxShadow: '0 20px 60px rgba(0,0,0,0.2)',
-          textAlign: 'center',
+          background: "white",
+          borderRadius: "12px",
+          padding: "32px 40px",
+          maxWidth: "400px",
+          boxShadow: "0 20px 60px rgba(0,0,0,0.2)",
+          textAlign: "center",
         }}
-        onClick={e => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
       >
-        <div style={{ fontSize: '48px', marginBottom: '8px' }}>
-          {acceptRate >= 80 ? '\u2705' : acceptRate >= 50 ? '\uD83D\uDCCB' : '\uD83D\uDD0D'}
+        <div style={{ fontSize: "48px", marginBottom: "8px" }}>
+          {acceptRate >= 80 ? "\u2705" : acceptRate >= 50 ? "\uD83D\uDCCB" : "\uD83D\uDD0D"}
         </div>
-        <h2 style={{ margin: '0 0 8px', fontSize: '20px', fontWeight: 600, color: '#111827' }}>
+        <h2 style={{ margin: "0 0 8px", fontSize: "20px", fontWeight: 600, color: "#111827" }}>
           Review Complete
         </h2>
-        <p style={{ margin: '0 0 20px', color: '#6b7280', fontSize: '14px' }}>
+        <p style={{ margin: "0 0 20px", color: "#6b7280", fontSize: "14px" }}>
           All annotations have been resolved.
         </p>
-        <div style={{ display: 'flex', justifyContent: 'center', gap: '24px', marginBottom: '20px' }}>
+        <div
+          style={{ display: "flex", justifyContent: "center", gap: "24px", marginBottom: "20px" }}
+        >
           <div>
-            <div style={{ fontSize: '28px', fontWeight: 700, color: '#16a34a' }}>{accepted}</div>
-            <div style={{ fontSize: '12px', color: '#6b7280' }}>Accepted</div>
+            <div style={{ fontSize: "28px", fontWeight: 700, color: "#16a34a" }}>{accepted}</div>
+            <div style={{ fontSize: "12px", color: "#6b7280" }}>Accepted</div>
           </div>
-          <div style={{ width: '1px', background: '#e5e7eb' }} />
+          <div style={{ width: "1px", background: "#e5e7eb" }} />
           <div>
-            <div style={{ fontSize: '28px', fontWeight: 700, color: '#dc2626' }}>{dismissed}</div>
-            <div style={{ fontSize: '12px', color: '#6b7280' }}>Dismissed</div>
+            <div style={{ fontSize: "28px", fontWeight: 700, color: "#dc2626" }}>{dismissed}</div>
+            <div style={{ fontSize: "12px", color: "#6b7280" }}>Dismissed</div>
           </div>
-          <div style={{ width: '1px', background: '#e5e7eb' }} />
+          <div style={{ width: "1px", background: "#e5e7eb" }} />
           <div>
-            <div style={{ fontSize: '28px', fontWeight: 700, color: '#6366f1' }}>{acceptRate}%</div>
-            <div style={{ fontSize: '12px', color: '#6b7280' }}>Accept rate</div>
+            <div style={{ fontSize: "28px", fontWeight: 700, color: "#6366f1" }}>{acceptRate}%</div>
+            <div style={{ fontSize: "12px", color: "#6b7280" }}>Accept rate</div>
           </div>
         </div>
         <button
           onClick={onDismiss}
           style={{
-            padding: '8px 24px',
-            fontSize: '14px',
+            padding: "8px 24px",
+            fontSize: "14px",
             fontWeight: 500,
-            border: 'none',
-            borderRadius: '6px',
-            background: '#6366f1',
-            color: 'white',
-            cursor: 'pointer',
+            border: "none",
+            borderRadius: "6px",
+            background: "#6366f1",
+            color: "white",
+            cursor: "pointer",
           }}
         >
           Done

--- a/src/client/panels/SidePanel.tsx
+++ b/src/client/panels/SidePanel.tsx
@@ -494,7 +494,7 @@ export function SidePanel({
             alignItems: "center",
           }}
         >
-          <span>
+          <span data-testid="held-banner">
             {heldCount} annotation{heldCount !== 1 ? "s" : ""} held
           </span>
           <button
@@ -649,6 +649,7 @@ export function SidePanel({
         />
         {hasFilters && (
           <button
+            data-testid="clear-filters-btn"
             onClick={() => {
               setFilterType("all");
               setFilterAuthor("all");

--- a/src/client/positions.ts
+++ b/src/client/positions.ts
@@ -16,11 +16,11 @@
 
 import type { Node as PmNode } from "@tiptap/pm/model";
 import * as Y from "yjs";
-import type { Annotation } from "../shared/types";
-import type { FlatOffset, PmPos, DocumentRange, RelativeRange } from "../shared/positions/types";
-import type { PmRangeResult } from "../shared/positions/index";
-import { toFlatOffset, toPmPos } from "../shared/positions/types";
 import { headingPrefixLength } from "../shared/offsets";
+import type { PmRangeResult } from "../shared/positions/index";
+import type { DocumentRange, FlatOffset, PmPos, RelativeRange } from "../shared/positions/types";
+import { toFlatOffset, toPmPos } from "../shared/positions/types";
+import type { Annotation } from "../shared/types";
 
 // ---------------------------------------------------------------------------
 // Low-level: flat offset ↔ ProseMirror position

--- a/src/client/status/StatusBar.tsx
+++ b/src/client/status/StatusBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { CLAUDE_PRESENCE_COLOR, USER_NAME_KEY, USER_NAME_DEFAULT } from "../../shared/constants";
+import { CLAUDE_PRESENCE_COLOR, USER_NAME_DEFAULT, USER_NAME_KEY } from "../../shared/constants";
 import type { ConnectionStatus } from "../hooks/useYjsSync";
 
 interface StatusBarProps {

--- a/src/client/tabs/DocumentTabs.tsx
+++ b/src/client/tabs/DocumentTabs.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
-import type { OpenTab } from "../types";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { FileOpenDialog } from "../components/FileOpenDialog";
 import { useTabDirty } from "../hooks/useTabDirty";
+import type { OpenTab } from "../types";
 
 interface DocumentTabsProps {
   tabs: OpenTab[];

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,5 @@
-import type * as Y from "yjs";
 import type { HocuspocusProvider } from "@hocuspocus/provider";
+import type * as Y from "yjs";
 
 export interface DocListEntry {
   id: string;

--- a/src/server/file-io/docx-apply.ts
+++ b/src/server/file-io/docx-apply.ts
@@ -3,17 +3,17 @@
 // Uses the shared walker (docx-walker.ts) to map flat-text offsets into
 // the XML DOM, then mutates the DOM in-place before serializing back to ZIP.
 
-import JSZip from "jszip";
-import { parseDocument } from "htmlparser2";
-import { Element, Text } from "domhandler";
-import type { ChildNode } from "domhandler";
 import render from "dom-serializer";
+import type { ChildNode } from "domhandler";
+import { Element, Text } from "domhandler";
+import { parseDocument } from "htmlparser2";
+import JSZip from "jszip";
 import {
-  walkDocumentBody,
   findAllByName,
-  isElement,
   getAttr,
+  isElement,
   type TextHit,
+  walkDocumentBody,
 } from "./docx-walker.js";
 
 /** Element names inside <w:r> that would produce malformed XML if split. */

--- a/src/server/file-io/docx-comments.ts
+++ b/src/server/file-io/docx-comments.ts
@@ -5,14 +5,14 @@
 // alongside character offsets. Heading prefix offsets are accounted for so
 // flat-text positions match Tandem's coordinate system after mammoth → htmlToYDoc.
 
-import JSZip from "jszip";
 import { parseDocument } from "htmlparser2";
+import JSZip from "jszip";
 import * as Y from "yjs";
 import { Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
-import { anchoredRange } from "../positions.js";
 import type { FlatOffset } from "../../shared/types.js";
 import { toFlatOffset } from "../../shared/types.js";
 import { MCP_ORIGIN } from "../events/queue.js";
+import { anchoredRange } from "../positions.js";
 import { findAllByName, getAttr, getTextContent, walkDocumentBody } from "./docx-walker.js";
 
 // ---------------------------------------------------------------------------

--- a/src/server/file-io/docx-html.ts
+++ b/src/server/file-io/docx-html.ts
@@ -1,7 +1,7 @@
 // HTML → Y.Doc conversion: htmlparser2 DOM traversal → Yjs XmlFragment
 
+import type { ChildNode, Element, Text } from "domhandler";
 import * as htmlparser2 from "htmlparser2";
-import type { Element, Text, ChildNode } from "domhandler";
 import * as Y from "yjs";
 
 /** All marks that can appear on inline text (superset of mdast-ydoc) */

--- a/src/server/file-io/docx-walker.ts
+++ b/src/server/file-io/docx-walker.ts
@@ -8,8 +8,8 @@
 // tracked-change text), while <w:ins> subtrees are traversed normally
 // (mammoth includes inserted text).
 
-import { parseDocument } from "htmlparser2";
 import type { ChildNode, Element } from "domhandler";
+import { parseDocument } from "htmlparser2";
 import { headingPrefixLength } from "../../shared/offsets.js";
 
 // ---------------------------------------------------------------------------

--- a/src/server/file-io/index.ts
+++ b/src/server/file-io/index.ts
@@ -1,22 +1,22 @@
 import fs from "fs/promises";
 import path from "path";
-import type { FormatAdapter } from "./types.js";
-import { loadMarkdown, saveMarkdown } from "./markdown.js";
+import { extractText, populateYDoc } from "../mcp/document-model.js";
 import { htmlToYDoc, loadDocx } from "./docx.js";
 import {
+  type DocxComment,
   extractDocxComments,
   injectCommentsAsAnnotations,
-  type DocxComment,
 } from "./docx-comments.js";
-import { populateYDoc, extractText } from "../mcp/document-model.js";
+import { loadMarkdown, saveMarkdown } from "./markdown.js";
+import type { FormatAdapter } from "./types.js";
 
-export type { FormatAdapter } from "./types.js";
 export {
-  applyTrackedChanges,
   type AcceptedSuggestion,
   type ApplyOptions,
   type ApplyOutput,
+  applyTrackedChanges,
 } from "./docx-apply.js";
+export type { FormatAdapter } from "./types.js";
 
 // -- Adapter implementations --
 

--- a/src/server/file-io/markdown.ts
+++ b/src/server/file-io/markdown.ts
@@ -1,9 +1,9 @@
-import * as Y from "yjs";
-import { unified } from "unified";
-import remarkParse from "remark-parse";
-import remarkGfm from "remark-gfm";
-import remarkStringify from "remark-stringify";
 import type { Root } from "mdast";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import { unified } from "unified";
+import * as Y from "yjs";
 import { mdastToYDoc, yDocToMdast } from "./mdast-ydoc.js";
 
 // Cached processors — stateless and safe to reuse across calls

--- a/src/server/file-io/markdown.ts
+++ b/src/server/file-io/markdown.ts
@@ -1,21 +1,21 @@
-import * as Y from 'yjs';
-import { unified } from 'unified';
-import remarkParse from 'remark-parse';
-import remarkGfm from 'remark-gfm';
-import remarkStringify from 'remark-stringify';
-import type { Root } from 'mdast';
-import { mdastToYDoc, yDocToMdast } from './mdast-ydoc.js';
+import * as Y from "yjs";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkStringify from "remark-stringify";
+import type { Root } from "mdast";
+import { mdastToYDoc, yDocToMdast } from "./mdast-ydoc.js";
 
 // Cached processors — stateless and safe to reuse across calls
 const parser = unified().use(remarkParse).use(remarkGfm).freeze();
 const serializer = unified()
   .use(remarkGfm)
   .use(remarkStringify, {
-    bullet: '-',
-    emphasis: '*',
-    strong: '*',
-    listItemIndent: 'one',
-    rule: '-',
+    bullet: "-",
+    emphasis: "*",
+    strong: "*",
+    listItemIndent: "one",
+    rule: "-",
   })
   .freeze();
 

--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -1,5 +1,5 @@
+import type { PhrasingContent, Root, RootContent } from "mdast";
 import * as Y from "yjs";
-import type { Root, RootContent, PhrasingContent } from "mdast";
 
 /**
  * Convert an MDAST tree into Y.Doc XmlFragment elements.

--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -1,5 +1,5 @@
-import * as Y from 'yjs';
-import type { Root, RootContent, PhrasingContent } from 'mdast';
+import * as Y from "yjs";
+import type { Root, RootContent, PhrasingContent } from "mdast";
 
 /**
  * Convert an MDAST tree into Y.Doc XmlFragment elements.
@@ -10,7 +10,7 @@ import type { Root, RootContent, PhrasingContent } from 'mdast';
  * requires this for correct insert ordering on Y.XmlText.
  */
 export function mdastToYDoc(doc: Y.Doc, tree: Root): void {
-  const fragment = doc.getXmlFragment('default');
+  const fragment = doc.getXmlFragment("default");
 
   // Clear existing content in a single operation
   if (fragment.length > 0) {
@@ -47,25 +47,25 @@ function blockToYxml(
   deferred: Array<{ xmlText: Y.XmlText; nodes?: PhrasingContent[]; plainText?: string }>,
 ): Y.XmlElement[] {
   switch (node.type) {
-    case 'heading': {
-      const el = new Y.XmlElement('heading');
-      el.setAttribute('level', node.depth as any);
+    case "heading": {
+      const el = new Y.XmlElement("heading");
+      el.setAttribute("level", node.depth as any);
       const text = new Y.XmlText();
       el.insert(0, [text]);
       deferred.push({ xmlText: text, nodes: node.children });
       return [el];
     }
 
-    case 'paragraph': {
-      const el = new Y.XmlElement('paragraph');
+    case "paragraph": {
+      const el = new Y.XmlElement("paragraph");
       const text = new Y.XmlText();
       el.insert(0, [text]);
       deferred.push({ xmlText: text, nodes: node.children });
       return [el];
     }
 
-    case 'blockquote': {
-      const el = new Y.XmlElement('blockquote');
+    case "blockquote": {
+      const el = new Y.XmlElement("blockquote");
       for (const child of node.children) {
         const childEls = blockToYxml(child, deferred);
         for (const c of childEls) {
@@ -75,14 +75,14 @@ function blockToYxml(
       return [el];
     }
 
-    case 'list': {
-      const nodeName = node.ordered ? 'orderedList' : 'bulletList';
+    case "list": {
+      const nodeName = node.ordered ? "orderedList" : "bulletList";
       const el = new Y.XmlElement(nodeName);
       if (node.ordered && node.start != null && node.start !== 1) {
-        el.setAttribute('start', node.start as any);
+        el.setAttribute("start", node.start as any);
       }
       for (const item of node.children) {
-        const listItem = new Y.XmlElement('listItem');
+        const listItem = new Y.XmlElement("listItem");
         for (const child of item.children) {
           const childEls = blockToYxml(child, deferred);
           for (const c of childEls) {
@@ -94,10 +94,10 @@ function blockToYxml(
       return [el];
     }
 
-    case 'code': {
-      const el = new Y.XmlElement('codeBlock');
+    case "code": {
+      const el = new Y.XmlElement("codeBlock");
       if (node.lang) {
-        el.setAttribute('language', node.lang);
+        el.setAttribute("language", node.lang);
       }
       const text = new Y.XmlText();
       el.insert(0, [text]);
@@ -105,22 +105,22 @@ function blockToYxml(
       return [el];
     }
 
-    case 'thematicBreak': {
-      return [new Y.XmlElement('horizontalRule')];
+    case "thematicBreak": {
+      return [new Y.XmlElement("horizontalRule")];
     }
 
-    case 'image': {
-      const el = new Y.XmlElement('image');
-      el.setAttribute('src', node.url);
-      if (node.alt) el.setAttribute('alt', node.alt);
-      if (node.title) el.setAttribute('title', node.title);
+    case "image": {
+      const el = new Y.XmlElement("image");
+      el.setAttribute("src", node.url);
+      if (node.alt) el.setAttribute("alt", node.alt);
+      if (node.title) el.setAttribute("title", node.title);
       return [el];
     }
 
     // html blocks, definitions, etc. — wrap as paragraphs to avoid data loss
     default: {
-      if ('value' in node && typeof node.value === 'string') {
-        const el = new Y.XmlElement('paragraph');
+      if ("value" in node && typeof node.value === "string") {
+        const el = new Y.XmlElement("paragraph");
         const text = new Y.XmlText();
         el.insert(0, [text]);
         deferred.push({ xmlText: text, plainText: node.value });
@@ -132,7 +132,7 @@ function blockToYxml(
 }
 
 /** All mark names that can appear on inline text */
-const ALL_MARKS = ['bold', 'italic', 'strike', 'code', 'link'] as const;
+const ALL_MARKS = ["bold", "italic", "strike", "code", "link"] as const;
 
 /**
  * Build Yjs insert attributes from the current mark stack.
@@ -159,42 +159,42 @@ function processInline(
 ): void {
   for (const node of nodes) {
     switch (node.type) {
-      case 'text': {
+      case "text": {
         xmlText.insert(xmlText.length, node.value, buildAttrs(marks));
         break;
       }
 
-      case 'strong':
+      case "strong":
         processInline(xmlText, node.children, { ...marks, bold: {} });
         break;
 
-      case 'emphasis':
+      case "emphasis":
         processInline(xmlText, node.children, { ...marks, italic: {} });
         break;
 
-      case 'delete':
+      case "delete":
         processInline(xmlText, node.children, { ...marks, strike: {} });
         break;
 
-      case 'inlineCode': {
+      case "inlineCode": {
         xmlText.insert(xmlText.length, node.value, buildAttrs({ ...marks, code: {} }));
         break;
       }
 
-      case 'link':
+      case "link":
         processInline(xmlText, node.children, {
           ...marks,
           link: { href: node.url, ...(node.title ? { title: node.title } : {}) },
         });
         break;
 
-      case 'break': {
-        const embed = new Y.XmlElement('hardBreak');
+      case "break": {
+        const embed = new Y.XmlElement("hardBreak");
         xmlText.insertEmbed(xmlText.length, embed);
         break;
       }
 
-      case 'image': {
+      case "image": {
         // Inline images: insert alt text (best-effort)
         xmlText.insert(xmlText.length, node.alt || node.url, buildAttrs(marks));
         break;
@@ -202,7 +202,7 @@ function processInline(
 
       // html inline, footnoteReference, etc. — insert raw value if available
       default:
-        if ('value' in node && typeof node.value === 'string') {
+        if ("value" in node && typeof node.value === "string") {
           xmlText.insert(xmlText.length, node.value, buildAttrs(marks));
         }
         break;
@@ -214,7 +214,7 @@ function processInline(
  * Convert a Y.Doc's XmlFragment back to an MDAST Root tree.
  */
 export function yDocToMdast(doc: Y.Doc): Root {
-  const fragment = doc.getXmlFragment('default');
+  const fragment = doc.getXmlFragment("default");
   const children: RootContent[] = [];
 
   for (let i = 0; i < fragment.length; i++) {
@@ -225,21 +225,21 @@ export function yDocToMdast(doc: Y.Doc): Root {
     }
   }
 
-  return { type: 'root', children };
+  return { type: "root", children };
 }
 
 /** Convert a Y.XmlElement back to an MDAST block node */
 function yxmlToMdast(el: Y.XmlElement): RootContent | null {
   switch (el.nodeName) {
-    case 'heading': {
-      const depth = (Number(el.getAttribute('level') ?? 1)) as 1 | 2 | 3 | 4 | 5 | 6;
-      return { type: 'heading', depth, children: deltaToPhrasingContent(el) };
+    case "heading": {
+      const depth = Number(el.getAttribute("level") ?? 1) as 1 | 2 | 3 | 4 | 5 | 6;
+      return { type: "heading", depth, children: deltaToPhrasingContent(el) };
     }
 
-    case 'paragraph':
-      return { type: 'paragraph', children: deltaToPhrasingContent(el) };
+    case "paragraph":
+      return { type: "paragraph", children: deltaToPhrasingContent(el) };
 
-    case 'blockquote': {
+    case "blockquote": {
       const children: RootContent[] = [];
       for (let i = 0; i < el.length; i++) {
         const child = el.get(i);
@@ -249,17 +249,17 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
         }
       }
       // blockquote.children is BlockContent[] but RootContent covers it
-      return { type: 'blockquote', children: children as any };
+      return { type: "blockquote", children: children as any };
     }
 
-    case 'bulletList':
-    case 'orderedList': {
-      const ordered = el.nodeName === 'orderedList';
-      const start = ordered ? (Number(el.getAttribute('start')) || 1) : undefined;
+    case "bulletList":
+    case "orderedList": {
+      const ordered = el.nodeName === "orderedList";
+      const start = ordered ? Number(el.getAttribute("start")) || 1 : undefined;
       const listItems: any[] = [];
       for (let i = 0; i < el.length; i++) {
         const child = el.get(i);
-        if (child instanceof Y.XmlElement && child.nodeName === 'listItem') {
+        if (child instanceof Y.XmlElement && child.nodeName === "listItem") {
           const itemChildren: any[] = [];
           for (let j = 0; j < child.length; j++) {
             const grandchild = child.get(j);
@@ -268,11 +268,11 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
               if (m) itemChildren.push(m);
             }
           }
-          listItems.push({ type: 'listItem', spread: false, children: itemChildren });
+          listItems.push({ type: "listItem", spread: false, children: itemChildren });
         }
       }
       return {
-        type: 'list',
+        type: "list",
         ordered,
         spread: false,
         ...(ordered && start !== 1 ? { start } : {}),
@@ -280,27 +280,27 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
       } as any;
     }
 
-    case 'codeBlock': {
-      const lang = el.getAttribute('language') as string | undefined;
-      let value = '';
+    case "codeBlock": {
+      const lang = el.getAttribute("language") as string | undefined;
+      let value = "";
       for (let i = 0; i < el.length; i++) {
         const child = el.get(i);
         if (child instanceof Y.XmlText) {
           value += child.toString();
         }
       }
-      return { type: 'code', lang: lang || null, value } as any;
+      return { type: "code", lang: lang || null, value } as any;
     }
 
-    case 'horizontalRule':
-      return { type: 'thematicBreak' };
+    case "horizontalRule":
+      return { type: "thematicBreak" };
 
-    case 'image': {
+    case "image": {
       return {
-        type: 'image',
-        url: (el.getAttribute('src') as string) || '',
-        alt: (el.getAttribute('alt') as string) || undefined,
-        title: (el.getAttribute('title') as string) || null,
+        type: "image",
+        url: (el.getAttribute("src") as string) || "",
+        alt: (el.getAttribute("alt") as string) || undefined,
+        title: (el.getAttribute("title") as string) || null,
       } as any;
     }
 
@@ -308,7 +308,7 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
     default: {
       const phrasing = deltaToPhrasingContent(el);
       if (phrasing.length > 0) {
-        return { type: 'paragraph', children: phrasing };
+        return { type: "paragraph", children: phrasing };
       }
       return null;
     }
@@ -320,7 +320,7 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
  * y-prosemirror appends "--<hash>" to mark names in delta attributes.
  */
 function stripHashSuffix(key: string): string {
-  const dashIdx = key.indexOf('--');
+  const dashIdx = key.indexOf("--");
   return dashIdx >= 0 ? key.slice(0, dashIdx) : key;
 }
 
@@ -338,9 +338,9 @@ function deltaToPhrasingContent(el: Y.XmlElement): PhrasingContent[] {
       const delta = child.toDelta();
       for (const op of delta) {
         // Embedded elements (hardBreak, etc.)
-        if (typeof op.insert !== 'string') {
-          if (op.insert instanceof Y.XmlElement && op.insert.nodeName === 'hardBreak') {
-            result.push({ type: 'break' });
+        if (typeof op.insert !== "string") {
+          if (op.insert instanceof Y.XmlElement && op.insert.nodeName === "hardBreak") {
+            result.push({ type: "break" });
           }
           continue;
         }
@@ -356,42 +356,42 @@ function deltaToPhrasingContent(el: Y.XmlElement): PhrasingContent[] {
         }
 
         // Build phrasing node, wrapping with marks from inside out
-        let node: PhrasingContent = { type: 'text', value: text };
+        let node: PhrasingContent = { type: "text", value: text };
 
         // link wraps first (innermost), then code, then strike, then italic, then bold
-        if (marks.has('link')) {
-          const linkAttrs = marks.get('link') || {};
+        if (marks.has("link")) {
+          const linkAttrs = marks.get("link") || {};
           node = {
-            type: 'link',
-            url: linkAttrs.href || '',
+            type: "link",
+            url: linkAttrs.href || "",
             ...(linkAttrs.title ? { title: linkAttrs.title } : {}),
             children: [node],
           };
         }
-        if (marks.has('code')) {
+        if (marks.has("code")) {
           // Code is a leaf node — extract text value
-          node = { type: 'inlineCode', value: text };
+          node = { type: "inlineCode", value: text };
         }
-        if (marks.has('strike')) {
-          if (node.type === 'inlineCode') {
+        if (marks.has("strike")) {
+          if (node.type === "inlineCode") {
             // Can't nest inlineCode inside delete — best effort
-            node = { type: 'delete', children: [{ type: 'text', value: text }] } as any;
+            node = { type: "delete", children: [{ type: "text", value: text }] } as any;
           } else {
-            node = { type: 'delete', children: [node] } as any;
+            node = { type: "delete", children: [node] } as any;
           }
         }
-        if (marks.has('italic')) {
-          if (node.type === 'inlineCode') {
-            node = { type: 'emphasis', children: [{ type: 'text', value: text }] };
+        if (marks.has("italic")) {
+          if (node.type === "inlineCode") {
+            node = { type: "emphasis", children: [{ type: "text", value: text }] };
           } else {
-            node = { type: 'emphasis', children: [node] };
+            node = { type: "emphasis", children: [node] };
           }
         }
-        if (marks.has('bold')) {
-          if (node.type === 'inlineCode') {
-            node = { type: 'strong', children: [{ type: 'text', value: text }] };
+        if (marks.has("bold")) {
+          if (node.type === "inlineCode") {
+            node = { type: "strong", children: [{ type: "text", value: text }] };
           } else {
-            node = { type: 'strong', children: [node] };
+            node = { type: "strong", children: [node] };
           }
         }
 
@@ -399,8 +399,8 @@ function deltaToPhrasingContent(el: Y.XmlElement): PhrasingContent[] {
       }
     } else if (child instanceof Y.XmlElement) {
       // Non-text child elements embedded in a block (shouldn't happen often)
-      if (child.nodeName === 'hardBreak') {
-        result.push({ type: 'break' });
+      if (child.nodeName === "hardBreak") {
+        result.push({ type: "break" });
       }
     }
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,35 +1,35 @@
 import type { Server } from "http";
 import path from "path";
 import { fileURLToPath } from "url";
-import {
-  startMcpServerStdio,
-  startMcpServerHttp,
-  closeMcpSession,
-  APP_VERSION,
-} from "./mcp/server.js";
-import { startHocuspocus, setDocLifecycleCallbacks, getOrCreateDocument } from "./yjs/provider.js";
-import { DEFAULT_WS_PORT, DEFAULT_MCP_PORT, CTRL_ROOM } from "../shared/constants.js";
-import { cleanupSessions, stopAutoSave } from "./session/manager.js";
-import {
-  saveCurrentSession,
-  restoreCtrlSession,
-  restoreOpenDocuments,
-  writeGenerationId,
-} from "./mcp/document.js";
-import { freePort, waitForPort, LAST_SEEN_VERSION_FILE } from "./platform.js";
-import { checkVersionChange } from "./version-check.js";
+import { CTRL_ROOM, DEFAULT_MCP_PORT, DEFAULT_WS_PORT } from "../shared/constants.js";
 import { isKnownHocuspocusError } from "./error-filter.js";
 import {
   attachCtrlObservers,
-  reattachObservers,
-  reattachCtrlObservers,
   detachObservers,
+  reattachCtrlObservers,
+  reattachObservers,
 } from "./events/queue.js";
-import { docCount } from "./mcp/document-service.js";
 import { unwatchAll } from "./file-watcher.js";
-import { openFileByPath } from "./mcp/file-opener.js";
+import {
+  restoreCtrlSession,
+  restoreOpenDocuments,
+  saveCurrentSession,
+  writeGenerationId,
+} from "./mcp/document.js";
 import { docIdFromPath } from "./mcp/document-model.js";
+import { docCount } from "./mcp/document-service.js";
+import { openFileByPath } from "./mcp/file-opener.js";
+import {
+  APP_VERSION,
+  closeMcpSession,
+  startMcpServerHttp,
+  startMcpServerStdio,
+} from "./mcp/server.js";
 import { injectTutorialAnnotations } from "./mcp/tutorial-annotations.js";
+import { freePort, LAST_SEEN_VERSION_FILE, waitForPort } from "./platform.js";
+import { cleanupSessions, stopAutoSave } from "./session/manager.js";
+import { checkVersionChange } from "./version-check.js";
+import { getOrCreateDocument, setDocLifecycleCallbacks, startHocuspocus } from "./yjs/provider.js";
 
 // stdout is exclusively reserved for the MCP JSON-RPC wire protocol (stdio mode).
 // Redirect any console.log calls (from Hocuspocus or other libs) to stderr.

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -1,26 +1,26 @@
-import { Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
-import { MCP_ORIGIN } from "../events/queue.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import { getOrCreateDocument } from "../yjs/provider.js";
-import { getCurrentDoc, extractText } from "./document.js";
-import { mcpSuccess, mcpError, noDocumentError, withErrorBoundary } from "./response.js";
-import { exportAnnotations } from "../file-io/docx.js";
 import * as Y from "yjs";
+import { z } from "zod";
+import { Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
+import type { AnchoredRangeResult, RangeValidation } from "../../shared/positions/index.js";
 import type { Annotation, AnnotationType, HighlightColor } from "../../shared/types.js";
 import {
-  AnnotationTypeSchema,
-  AnnotationStatusSchema,
-  HighlightColorSchema,
-  AuthorSchema,
   AnnotationActionSchema,
+  AnnotationStatusSchema,
+  AnnotationTypeSchema,
+  AuthorSchema,
   ExportFormatSchema,
+  HighlightColorSchema,
   toFlatOffset,
 } from "../../shared/types.js";
-import { anchoredRange, refreshAllRanges } from "../positions.js";
-import type { RangeValidation, AnchoredRangeResult } from "../../shared/positions/index.js";
-import { pushNotification } from "../notifications.js";
 import { generateAnnotationId, generateNotificationId } from "../../shared/utils.js";
+import { MCP_ORIGIN } from "../events/queue.js";
+import { exportAnnotations } from "../file-io/docx.js";
+import { pushNotification } from "../notifications.js";
+import { anchoredRange, refreshAllRanges } from "../positions.js";
+import { getOrCreateDocument } from "../yjs/provider.js";
+import { extractText, getCurrentDoc } from "./document.js";
+import { mcpError, mcpSuccess, noDocumentError, withErrorBoundary } from "./response.js";
 
 /** Get the Y.Doc and annotations Y.Map for a document, or null if no doc is open */
 function getDocAndAnnotations(documentId?: string): { ydoc: Y.Doc; map: Y.Map<unknown> } | null {
@@ -148,7 +148,7 @@ export function collectAnnotations(map: Y.Map<unknown>): Annotation[] {
   return result;
 }
 
-export { refreshRange, refreshAllRanges } from "../positions.js";
+export { refreshAllRanges, refreshRange } from "../positions.js";
 
 export function registerAnnotationTools(server: McpServer): void {
   server.tool(

--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -1,4 +1,4 @@
-import type { Express, Request, Response, NextFunction } from "express";
+import type { Express, NextFunction, Request, Response } from "express";
 
 import {
   CHANNEL_SSE_KEEPALIVE_MS,
@@ -9,13 +9,13 @@ import {
 } from "../../shared/constants.js";
 import type { TandemNotification } from "../../shared/types.js";
 import { TandemModeSchema } from "../../shared/types.js";
-import { detectFormat } from "./document-model.js";
-import { openFileByPath, openFileFromContent } from "./file-opener.js";
-import { closeDocumentById } from "./document-service.js";
 import { subscribe as subscribeNotifications } from "../notifications.js";
-import { convertToMarkdown } from "./convert.js";
-import { applyChangesCore } from "./docx-apply.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
+import { convertToMarkdown } from "./convert.js";
+import { detectFormat } from "./document-model.js";
+import { closeDocumentById } from "./document-service.js";
+import { applyChangesCore } from "./docx-apply.js";
+import { openFileByPath, openFileFromContent } from "./file-opener.js";
 
 /** Express middleware/handler function type (Express 5 compatible). */
 export type Handler = (req: Request, res: Response, next: NextFunction) => void;

--- a/src/server/mcp/awareness.ts
+++ b/src/server/mcp/awareness.ts
@@ -1,12 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getOrCreateDocument } from "../yjs/provider.js";
-import { getCurrentDoc, extractText } from "./document.js";
-import { collectAnnotations, refreshRange } from "./annotations.js";
-import { mcpSuccess, noDocumentError, withErrorBoundary } from "./response.js";
-import type { Annotation, ChatMessage, FlatOffset } from "../../shared/types.js";
-import { TandemModeSchema } from "../../shared/types.js";
-import { generateMessageId } from "../../shared/utils.js";
 import {
   CTRL_ROOM,
   TANDEM_MODE_DEFAULT,
@@ -15,7 +8,14 @@ import {
   Y_MAP_MODE,
   Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
+import type { Annotation, ChatMessage, FlatOffset } from "../../shared/types.js";
+import { TandemModeSchema } from "../../shared/types.js";
+import { generateMessageId } from "../../shared/utils.js";
 import { MCP_ORIGIN } from "../events/queue.js";
+import { getOrCreateDocument } from "../yjs/provider.js";
+import { collectAnnotations, refreshRange } from "./annotations.js";
+import { extractText, getCurrentDoc } from "./document.js";
+import { mcpSuccess, noDocumentError, withErrorBoundary } from "./response.js";
 
 // Track which annotation IDs have been surfaced to Claude via checkInbox
 const surfacedIds = new Set<string>();

--- a/src/server/mcp/channel-routes.ts
+++ b/src/server/mcp/channel-routes.ts
@@ -1,12 +1,11 @@
 import type { Express, Request, Response } from "express";
-
-import type { Handler } from "./api-routes.js";
 import { CTRL_ROOM, Y_MAP_AWARENESS, Y_MAP_CHAT } from "../../shared/constants.js";
 import type { ClaudeAwareness } from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
 import { MCP_ORIGIN } from "../events/queue.js";
 import { sseHandler } from "../events/sse.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
+import type { Handler } from "./api-routes.js";
 
 const pendingPermissions = new Map<
   string,

--- a/src/server/mcp/convert.ts
+++ b/src/server/mcp/convert.ts
@@ -1,10 +1,10 @@
 import fs from "fs/promises";
 import path from "path";
+import { atomicWrite } from "../file-io/index.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
 import { extractMarkdown } from "./document-model.js";
-import { atomicWrite } from "../file-io/index.js";
-import { openFileByPath } from "./file-opener.js";
 import { getCurrentDoc } from "./document-service.js";
+import { openFileByPath } from "./file-opener.js";
 
 export interface ConvertResult {
   outputPath: string;

--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -1,9 +1,9 @@
 import path from "path";
 import * as Y from "yjs";
 import {
-  headingPrefixLength as sharedHeadingPrefixLength,
-  headingPrefix,
   FLAT_SEPARATOR,
+  headingPrefix,
+  headingPrefixLength as sharedHeadingPrefixLength,
 } from "../../shared/offsets.js";
 import { saveMarkdown } from "../file-io/markdown.js";
 

--- a/src/server/mcp/document-service.ts
+++ b/src/server/mcp/document-service.ts
@@ -1,19 +1,19 @@
+import { randomUUID } from "node:crypto";
 import path from "path";
 import * as Y from "yjs";
-import { getOrCreateDocument, setShouldKeepDocument } from "../yjs/provider.js";
-import {
-  saveSession,
-  deleteSession,
-  saveCtrlSession,
-  loadCtrlSession,
-  restoreCtrlDoc,
-  listSessionFilePaths,
-  stopAutoSave,
-} from "../session/manager.js";
 import { CTRL_ROOM, Y_MAP_DOCUMENT_META } from "../../shared/constants.js";
 import { MCP_ORIGIN } from "../events/queue.js";
-import { randomUUID } from "node:crypto";
 import { unwatchFile } from "../file-watcher.js";
+import {
+  deleteSession,
+  listSessionFilePaths,
+  loadCtrlSession,
+  restoreCtrlDoc,
+  saveCtrlSession,
+  saveSession,
+  stopAutoSave,
+} from "../session/manager.js";
+import { getOrCreateDocument, setShouldKeepDocument } from "../yjs/provider.js";
 
 // --- Multi-document state ---
 

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -1,22 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 import * as Y from "yjs";
-import { getOrCreateDocument } from "../yjs/provider.js";
-import {
-  mcpSuccess,
-  mcpError,
-  noDocumentError,
-  getErrorMessage,
-  withErrorBoundary,
-} from "./response.js";
-import { pushNotification } from "../notifications.js";
-import { generateNotificationId } from "../../shared/utils.js";
-import { headingPrefix } from "../../shared/offsets.js";
-import { getAdapter, atomicWrite } from "../file-io/index.js";
-import { suppressNextChange } from "../file-watcher.js";
-import { convertToMarkdown } from "./convert.js";
-import { saveSession } from "../session/manager.js";
-import { openFileByPath } from "./file-opener.js";
+import { z } from "zod";
 import {
   CTRL_ROOM,
   TANDEM_MODE_DEFAULT,
@@ -25,79 +9,91 @@ import {
   Y_MAP_SAVED_AT_VERSION,
   Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
-import { toFlatOffset, TandemModeSchema } from "../../shared/types.js";
+import { headingPrefix } from "../../shared/offsets.js";
+import { TandemModeSchema, toFlatOffset } from "../../shared/types.js";
+import { generateNotificationId } from "../../shared/utils.js";
 import { MCP_ORIGIN } from "../events/queue.js";
-
+import { atomicWrite, getAdapter } from "../file-io/index.js";
+import { suppressNextChange } from "../file-watcher.js";
+import { pushNotification } from "../notifications.js";
+// Position system
+import { resolveToElement, validateRange } from "../positions.js";
+import { saveSession } from "../session/manager.js";
+import { getOrCreateDocument } from "../yjs/provider.js";
+import { convertToMarkdown } from "./convert.js";
 // Document model (pure logic)
 import { extractText, getElementText, getOrCreateXmlText } from "./document-model.js";
-
-// Position system
-import { validateRange, resolveToElement } from "../positions.js";
-
 // Document service (state management)
 import {
-  getOpenDocs,
-  getActiveDocId,
-  setActiveDocId,
-  getCurrentDoc,
-  requireDocument,
   broadcastOpenDocs,
-  toDocListEntry,
-  hasDoc,
-  docCount,
   closeDocumentById,
+  docCount,
+  getActiveDocId,
+  getCurrentDoc,
+  getOpenDocs,
+  hasDoc,
+  requireDocument,
+  setActiveDocId,
+  toDocListEntry,
 } from "./document-service.js";
+import { openFileByPath } from "./file-opener.js";
+import {
+  getErrorMessage,
+  mcpError,
+  mcpSuccess,
+  noDocumentError,
+  withErrorBoundary,
+} from "./response.js";
 
-// Re-export for backward compatibility with existing consumers.
-export {
-  extractText,
-  extractMarkdown,
-  populateYDoc,
-  getElementText,
-  findXmlText,
-  getOrCreateXmlText,
-  resolveOffset,
-  verifyAndResolveRange,
-  detectFormat,
-  docIdFromPath,
-  getHeadingPrefixLength,
-} from "./document-model.js";
-export type { ResolvedOffset, RangeVerifyResult } from "./document-model.js";
-
-// Position system re-exports
-export {
-  validateRange,
-  anchoredRange,
-  resolveToElement,
-  flatOffsetToRelPos,
-  relPosToFlatOffset,
-  refreshRange,
-  refreshAllRanges,
-} from "../positions.js";
 export type {
-  RangeValidation,
   AnchoredRangeResult,
   ElementPosition,
+  RangeValidation,
 } from "../../shared/positions/index.js";
+// Position system re-exports
 export {
+  anchoredRange,
+  flatOffsetToRelPos,
+  refreshAllRanges,
+  refreshRange,
+  relPosToFlatOffset,
+  resolveToElement,
+  validateRange,
+} from "../positions.js";
+export type { RangeVerifyResult, ResolvedOffset } from "./document-model.js";
+// Re-export for backward compatibility with existing consumers.
+export {
+  detectFormat,
+  docIdFromPath,
+  extractMarkdown,
+  extractText,
+  findXmlText,
+  getElementText,
+  getHeadingPrefixLength,
+  getOrCreateXmlText,
+  populateYDoc,
+  resolveOffset,
+  verifyAndResolveRange,
+} from "./document-model.js";
+export type { OpenDoc } from "./document-service.js";
+export {
+  addDoc,
+  docCount,
+  getActiveDocId,
   getCurrentDoc,
   getOpenDocs,
-  getActiveDocId,
-  setActiveDocId,
+  hasDoc,
+  removeDoc,
   requireDocument,
-  toDocListEntry,
-  saveCurrentSession,
   restoreCtrlSession,
   restoreOpenDocuments,
+  saveCurrentSession,
+  setActiveDocId,
+  toDocListEntry,
   writeGenerationId,
-  addDoc,
-  removeDoc,
-  hasDoc,
-  docCount,
 } from "./document-service.js";
-export type { OpenDoc } from "./document-service.js";
-export { openFileByPath, openFileFromContent, SUPPORTED_EXTENSIONS } from "./file-opener.js";
 export type { OpenFileResult } from "./file-opener.js";
+export { openFileByPath, openFileFromContent, SUPPORTED_EXTENSIONS } from "./file-opener.js";
 
 export interface OutlineEntry {
   level: number;

--- a/src/server/mcp/docx-apply.ts
+++ b/src/server/mcp/docx-apply.ts
@@ -3,20 +3,20 @@
  * tracked changes, and restoring from backup.
  */
 
-import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import fs from "fs/promises";
 import path from "path";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getCurrentDoc, requireDocument } from "./document-service.js";
+import { z } from "zod";
 import { Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
-import { relPosToFlatOffset } from "../positions.js";
-import { extractText } from "./document-model.js";
+import type { Annotation } from "../../shared/types.js";
 import {
+  type AcceptedSuggestion,
   applyTrackedChanges,
   atomicWriteBuffer,
-  type AcceptedSuggestion,
 } from "../file-io/index.js";
-import type { Annotation } from "../../shared/types.js";
+import { relPosToFlatOffset } from "../positions.js";
+import { extractText } from "./document-model.js";
+import { getCurrentDoc, requireDocument } from "./document-service.js";
 import { mcpError, mcpSuccess, noDocumentError, withErrorBoundary } from "./response.js";
 
 // ---------------------------------------------------------------------------

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -1,48 +1,48 @@
-import fs from "fs/promises";
+import { randomUUID } from "node:crypto";
 import fsSync from "fs";
+import fs from "fs/promises";
 import path from "path";
 import type * as Y from "yjs";
-import { randomUUID } from "node:crypto";
-import { getOrCreateDocument, getDocument } from "../yjs/provider.js";
 import {
-  MAX_FILE_SIZE,
   CHARS_PER_PAGE,
   LARGE_FILE_PAGE_THRESHOLD,
-  VERY_LARGE_FILE_PAGE_THRESHOLD,
+  MAX_FILE_SIZE,
   SUPPORTED_EXTENSIONS,
+  VERY_LARGE_FILE_PAGE_THRESHOLD,
   Y_MAP_ANNOTATIONS,
   Y_MAP_AWARENESS,
-  Y_MAP_USER_AWARENESS,
   Y_MAP_DOCUMENT_META,
   Y_MAP_SAVED_AT_VERSION,
+  Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
-import { MCP_ORIGIN, attachObservers } from "../events/queue.js";
-import { getAdapter } from "../file-io/index.js";
-import { watchFile } from "../file-watcher.js";
-import { refreshAllRanges, validateRange, anchoredRange } from "../positions.js";
-import { pushNotification } from "../notifications.js";
-import { generateNotificationId } from "../../shared/utils.js";
 import type { Annotation } from "../../shared/types.js";
-import { loadMarkdown } from "../file-io/markdown.js";
+import { generateNotificationId } from "../../shared/utils.js";
+import { attachObservers, MCP_ORIGIN } from "../events/queue.js";
 import { loadDocx } from "../file-io/docx.js";
-import { htmlToYDoc } from "../file-io/docx-html.js";
 import { extractDocxComments, injectCommentsAsAnnotations } from "../file-io/docx-comments.js";
+import { htmlToYDoc } from "../file-io/docx-html.js";
+import { getAdapter } from "../file-io/index.js";
+import { loadMarkdown } from "../file-io/markdown.js";
+import { watchFile } from "../file-watcher.js";
+import { pushNotification } from "../notifications.js";
+import { anchoredRange, refreshAllRanges, validateRange } from "../positions.js";
 import {
-  saveSession,
+  deleteSession,
+  isAutoSaveRunning,
   loadSession,
   restoreYDoc,
+  saveSession,
   sourceFileChanged,
-  deleteSession,
   startAutoSave,
-  isAutoSaveRunning,
 } from "../session/manager.js";
-import { extractText, detectFormat, docIdFromPath, populateYDoc } from "./document-model.js";
+import { getDocument, getOrCreateDocument } from "../yjs/provider.js";
+import { detectFormat, docIdFromPath, extractText, populateYDoc } from "./document-model.js";
 import {
-  type OpenDoc,
-  getOpenDocs,
-  setActiveDocId,
-  broadcastOpenDocs,
   addDoc,
+  broadcastOpenDocs,
+  getOpenDocs,
+  type OpenDoc,
+  setActiveDocId,
 } from "./document-service.js";
 
 export { SUPPORTED_EXTENSIONS };

--- a/src/server/mcp/navigation.ts
+++ b/src/server/mcp/navigation.ts
@@ -1,17 +1,17 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { Y_MAP_AWARENESS } from "../../shared/constants.js";
 import type { FlatOffset } from "../../shared/positions/types.js";
 import { toFlatOffset } from "../../shared/positions/types.js";
 import { MCP_ORIGIN } from "../events/queue.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 import { getOrCreateDocument } from "../yjs/provider.js";
-import { getCurrentDoc, extractText } from "./document.js";
+import { extractText, getCurrentDoc } from "./document.js";
 import {
-  mcpSuccess,
-  mcpError,
-  noDocumentError,
   escapeRegex,
   getErrorMessage,
+  mcpError,
+  mcpSuccess,
+  noDocumentError,
   withErrorBoundary,
 } from "./response.js";
 

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -5,9 +8,6 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "crypto";
 import type { Server } from "http";
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { createRequire } from "module";
 
 import { openBrowser } from "../open-browser.js";
@@ -28,6 +28,7 @@ try {
     `[Tandem] Could not read version from package.json: ${err instanceof Error ? err.message : err}`,
   );
 }
+
 export { APP_VERSION };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/src/server/mcp/tutorial-annotations.ts
+++ b/src/server/mcp/tutorial-annotations.ts
@@ -1,10 +1,10 @@
 import * as Y from "yjs";
 
-import { Y_MAP_ANNOTATIONS, TUTORIAL_ANNOTATION_PREFIX } from "../../shared/constants.js";
+import { TUTORIAL_ANNOTATION_PREFIX, Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
 import type { Annotation, AnnotationType, HighlightColor } from "../../shared/types.js";
+import { toFlatOffset } from "../../shared/types.js";
 import { MCP_ORIGIN } from "../events/queue.js";
 import { anchoredRange } from "../positions.js";
-import { toFlatOffset } from "../../shared/types.js";
 import { extractText } from "./document-model.js";
 
 interface TutorialAnnotationDef {

--- a/src/server/platform.ts
+++ b/src/server/platform.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
+import envPaths from "env-paths";
 import net from "net";
 import path from "path";
-import envPaths from "env-paths";
 
 const paths = envPaths("tandem", { suffix: "" });
 

--- a/src/server/positions.ts
+++ b/src/server/positions.ts
@@ -17,22 +17,22 @@
  */
 
 import * as Y from "yjs";
-import type { Annotation } from "../shared/types.js";
-import { MCP_ORIGIN } from "./events/queue.js";
 import type {
-  FlatOffset,
-  SerializedRelPos,
-  DocumentRange,
-  RelativeRange,
-  RangeValidation,
   AnchoredRangeResult,
+  DocumentRange,
   ElementPosition,
+  FlatOffset,
+  RangeValidation,
+  RelativeRange,
+  SerializedRelPos,
 } from "../shared/positions/index.js";
 import { toFlatOffset, toSerializedRelPos } from "../shared/positions/index.js";
+import type { Annotation } from "../shared/types.js";
+import { MCP_ORIGIN } from "./events/queue.js";
 import {
-  getElementText,
   extractText,
   findXmlText,
+  getElementText,
   getHeadingPrefixLength,
 } from "./mcp/document-model.js";
 

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -1,11 +1,10 @@
 import fs from "fs/promises";
 import path from "path";
 import * as Y from "yjs";
+import { CTRL_ROOM, SESSION_MAX_AGE, Y_MAP_CHAT } from "../../shared/constants.js";
 import type { SessionData } from "../../shared/types.js";
-import { SESSION_DIR } from "../platform.js";
-
-import { SESSION_MAX_AGE, CTRL_ROOM, Y_MAP_CHAT } from "../../shared/constants.js";
 import { MCP_ORIGIN } from "../events/queue.js";
+import { SESSION_DIR } from "../platform.js";
 
 const AUTO_SAVE_INTERVAL = 60 * 1000; // 60 seconds
 const RENAME_MAX_RETRIES = 3;

--- a/src/shared/offsets.ts
+++ b/src/shared/offsets.ts
@@ -10,7 +10,7 @@
  */
 
 /** Flat-text separator between block elements. */
-export const FLAT_SEPARATOR = '\n';
+export const FLAT_SEPARATOR = "\n";
 
 /**
  * Length of the heading prefix in flat text for a given heading level.
@@ -27,5 +27,5 @@ export function headingPrefixLength(level: number | null | undefined): number {
  * Level 1 → "# ", level 2 → "## ", etc.
  */
 export function headingPrefix(level: number): string {
-  return '#'.repeat(level) + ' ';
+  return "#".repeat(level) + " ";
 }

--- a/src/shared/positions/index.ts
+++ b/src/shared/positions/index.ts
@@ -1,14 +1,14 @@
 export type {
+  AnchoredRangeResult,
+  DocumentRange,
+  ElementPosition,
   FlatOffset,
   PmPos,
-  SerializedRelPos,
-  DocumentRange,
-  RelativeRange,
-  RangeValidation,
-  AnchoredRangeResult,
-  ElementPosition,
-  ResolutionMethod,
   PmRangeResult,
+  RangeValidation,
+  RelativeRange,
+  ResolutionMethod,
+  SerializedRelPos,
 } from "./types.js";
 
 export {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,11 +3,11 @@ import type { DocumentRange, RelativeRange } from "./positions/types.js";
 
 // Canonical definitions live in the positions module; re-exported for backward compatibility.
 export type {
+  DocumentRange,
   FlatOffset,
   PmPos,
-  SerializedRelPos,
-  DocumentRange,
   RelativeRange,
+  SerializedRelPos,
 } from "./positions/types.js";
 export { toFlatOffset, toPmPos, toSerializedRelPos } from "./positions/types.js";
 

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -1,10 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyConfig, buildMcpEntries, detectTargets, installSkill } from "../../src/cli/setup.js";
 import { DEFAULT_MCP_PORT } from "../../src/shared/constants.js";
-import { buildMcpEntries, detectTargets, applyConfig, installSkill } from "../../src/cli/setup.js";
 
 describe("buildMcpEntries", () => {
   it("returns tandem HTTP entry and channel node entry", () => {

--- a/tests/client/annotation-card.test.ts
+++ b/tests/client/annotation-card.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { parseSuggestion } from "../../src/client/panels/AnnotationCard.js";
 
 describe("parseSuggestion", () => {

--- a/tests/client/coordinate-conversion.test.ts
+++ b/tests/client/coordinate-conversion.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
+  annotationToPmRange,
   flatOffsetToPmPos,
   pmPosToFlatOffset,
-  annotationToPmRange,
   relRangeToPmPositions,
 } from "../../src/client/positions";
-import { makeDoc, getFragment, makeAnnotation } from "../helpers/ydoc-factory";
 import { flatOffsetToRelPos } from "../../src/server/positions";
+import { getFragment, makeAnnotation, makeDoc } from "../helpers/ydoc-factory";
 
 // Minimal ProseMirror-compatible mock. Assumes single flat text run per block
 // (no inline marks). nodeSize = 1 (open) + text.length + 1 (close).

--- a/tests/client/dedup-extended.test.ts
+++ b/tests/client/dedup-extended.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { deduplicateDocList } from "../../src/client/hooks/useYjsSync.js";
 import type { DocListEntry } from "../../src/client/types.js";
 

--- a/tests/client/dedup.test.ts
+++ b/tests/client/dedup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { deduplicateDocList } from "../../src/client/hooks/useYjsSync";
 import type { DocListEntry } from "../../src/client/types";
 

--- a/tests/client/file-upload.test.ts
+++ b/tests/client/file-upload.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   arrayBufferToBase64,
   isBinaryFormat,

--- a/tests/client/recent-files.test.ts
+++ b/tests/client/recent-files.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { addRecentFile } from "../../src/client/utils/recentFiles.js";
 
 describe("addRecentFile", () => {

--- a/tests/client/solo-tandem-mode.test.ts
+++ b/tests/client/solo-tandem-mode.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { shouldShowInMode } from "../../src/client/hooks/useModeGate.js";
 import type { Annotation, TandemMode } from "../../src/shared/types.js";
 import { makeAnnotation } from "../helpers/ydoc-factory.js";

--- a/tests/client/toolbar-button-title.test.ts
+++ b/tests/client/toolbar-button-title.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 /**
  * Unit test for ToolbarButton title logic.

--- a/tests/client/useTabOrder.test.ts
+++ b/tests/client/useTabOrder.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { reconcileOrder, applyReorder } from "../../src/client/hooks/useTabOrder.js";
+import { describe, expect, it } from "vitest";
+import { applyReorder, reconcileOrder } from "../../src/client/hooks/useTabOrder.js";
 
 describe("reconcileOrder", () => {
   it("initial order matches tabs input order when localOrder is empty", () => {

--- a/tests/client/user-name.test.ts
+++ b/tests/client/user-name.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { USER_NAME_DEFAULT } from "../../src/shared/constants.js";
 
 function resolveUserName(stored: string | null): string {

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -193,7 +193,7 @@ test("Solo/Tandem mode toggle switches via toolbar and holds pending annotations
   await expect(soloBtn).toHaveAttribute("aria-pressed", "false");
 
   // In Tandem mode the held banner is absent — the annotation is visible.
-  const heldBanner = page.getByText(/\d+ annotation(s)? held/);
+  const heldBanner = page.getByTestId("held-banner");
   await expect(heldBanner).toHaveCount(0);
 
   // Switch to solo. Assert via localStorage (race-free) + aria-pressed
@@ -209,6 +209,8 @@ test("Solo/Tandem mode toggle switches via toolbar and holds pending annotations
   // contract, not just the localStorage bit. Catches regressions where the
   // toggle updates storage but fails to drive the useModeGate hook.
   await expect(heldBanner).toBeVisible({ timeout: 2_000 });
+  // Preserve the count + pluralization contract the old regex locator asserted.
+  await expect(heldBanner).toHaveText(/\d+ annotation(s)? held/);
 
   // Switch back.
   await tandemBtn.click();
@@ -556,8 +558,7 @@ test("Clear-filters button also resets scroll to top", async ({ page }) => {
   expect(scrollBefore).toBeGreaterThan(0);
 
   // Click Clear — the filter-change effect should reset scroll to 0.
-  // (There's no testid on the Clear button; target by visible text.)
-  await page.getByRole("button", { name: "Clear" }).click();
+  await page.getByTestId("clear-filters-btn").click();
 
   await expect
     .poll(async () => scrollContainer.evaluate((el) => el.scrollTop), {

--- a/tests/e2e/tab-overflow.spec.ts
+++ b/tests/e2e/tab-overflow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import path from "path";
 import {
   cleanupAllOpenDocuments,

--- a/tests/helpers/ydoc-factory.ts
+++ b/tests/helpers/ydoc-factory.ts
@@ -1,10 +1,10 @@
-import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import * as Y from "yjs";
-import { populateYDoc } from "../../src/server/mcp/document.js";
 import { loadMarkdown } from "../../src/server/file-io/markdown.js";
+import { populateYDoc } from "../../src/server/mcp/document.js";
 import { anchoredRange } from "../../src/server/positions.js";
-import type { Annotation } from "../../src/shared/types.js";
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import { toFlatOffset } from "../../src/shared/positions/types.js";
+import type { Annotation } from "../../src/shared/types.js";
 
 /** Create a Y.Doc populated with text content */
 export function makeDoc(text: string): Y.Doc {

--- a/tests/server/annotation-relpos.test.ts
+++ b/tests/server/annotation-relpos.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { populateYDoc } from "../../src/server/mcp/document.js";
-import { flatOffsetToRelPos, relPosToFlatOffset } from "../../src/server/mcp/document.js";
+import {
+  flatOffsetToRelPos,
+  populateYDoc,
+  relPosToFlatOffset,
+} from "../../src/server/mcp/document.js";
 
 // Tests server-side RelativePosition round-trip logic used by the client's annotation extension.
 // The client-side functions (flatOffsetToPmPos, relRangeToPmPositions) require ProseMirror nodes

--- a/tests/server/annotation-text-snapshot.test.ts
+++ b/tests/server/annotation-text-snapshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { createAnnotation, collectAnnotations } from "../../src/server/mcp/annotations.js";
+import { collectAnnotations, createAnnotation } from "../../src/server/mcp/annotations.js";
 import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 
 function makeResult(from: number, to: number) {

--- a/tests/server/annotation-tools.test.ts
+++ b/tests/server/annotation-tools.test.ts
@@ -1,20 +1,20 @@
-import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { exportAnnotations } from "../../src/server/file-io/docx.js";
 import {
-  createAnnotation,
   collectAnnotations,
+  createAnnotation,
   refreshRange,
 } from "../../src/server/mcp/annotations.js";
+import { extractText, populateYDoc, verifyAndResolveRange } from "../../src/server/mcp/document.js";
 import {
   addDoc,
+  getOpenDocs,
   removeDoc,
   setActiveDocId,
-  getOpenDocs,
 } from "../../src/server/mcp/document-service.js";
-import { populateYDoc, extractText, verifyAndResolveRange } from "../../src/server/mcp/document.js";
-import { exportAnnotations } from "../../src/server/file-io/docx.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import type { Annotation } from "../../src/shared/types.js";
 import { rangeOf } from "../helpers/ydoc-factory.js";
 

--- a/tests/server/annotations.test.ts
+++ b/tests/server/annotations.test.ts
@@ -1,14 +1,14 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import {
-  createAnnotation,
   collectAnnotations,
+  createAnnotation,
   refreshRange,
 } from "../../src/server/mcp/annotations.js";
-import { generateAnnotationId } from "../../src/shared/utils.js";
-import { makeDoc, getAnnotationsMap, getFragment, rangeOf } from "../helpers/ydoc-factory.js";
-import { getOrCreateXmlText, extractText } from "../../src/server/mcp/document.js";
+import { extractText, getOrCreateXmlText } from "../../src/server/mcp/document.js";
 import type { Annotation } from "../../src/shared/types.js";
+import { generateAnnotationId } from "../../src/shared/utils.js";
+import { getAnnotationsMap, getFragment, makeDoc, rangeOf } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 

--- a/tests/server/api-middleware.test.ts
+++ b/tests/server/api-middleware.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
+  errorCodeToHttpStatus,
   isHostAllowed,
   isLocalhostOrigin,
-  errorCodeToHttpStatus,
 } from "../../src/server/mcp/api-routes.js";
 import { jsonrpcId } from "../../src/server/mcp/server.js";
 

--- a/tests/server/awareness-tools.test.ts
+++ b/tests/server/awareness-tools.test.ts
@@ -1,3 +1,19 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { collectAnnotations, createAnnotation } from "../../src/server/mcp/annotations.js";
+import {
+  isUserActive,
+  processInboxAnnotations,
+  resetInbox,
+  safeSlice,
+} from "../../src/server/mcp/awareness.js";
+import { extractText, populateYDoc } from "../../src/server/mcp/document.js";
+import {
+  addDoc,
+  getOpenDocs,
+  removeDoc,
+  setActiveDocId,
+} from "../../src/server/mcp/document-service.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import {
   CTRL_ROOM,
   TANDEM_MODE_DEFAULT,
@@ -7,26 +23,10 @@ import {
   Y_MAP_MODE,
   Y_MAP_USER_AWARENESS,
 } from "../../src/shared/constants.js";
-import { describe, it, expect, beforeEach } from "vitest";
-import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
-import {
-  resetInbox,
-  safeSlice,
-  isUserActive,
-  processInboxAnnotations,
-} from "../../src/server/mcp/awareness.js";
-import { createAnnotation, collectAnnotations } from "../../src/server/mcp/annotations.js";
-import { rangeOf } from "../helpers/ydoc-factory.js";
-import {
-  addDoc,
-  removeDoc,
-  setActiveDocId,
-  getOpenDocs,
-} from "../../src/server/mcp/document-service.js";
-import { populateYDoc, extractText } from "../../src/server/mcp/document.js";
-import { generateMessageId } from "../../src/shared/utils.js";
-import { TandemModeSchema } from "../../src/shared/types.js";
 import type { Annotation, ChatMessage } from "../../src/shared/types.js";
+import { TandemModeSchema } from "../../src/shared/types.js";
+import { generateMessageId } from "../../src/shared/utils.js";
+import { rangeOf } from "../helpers/ydoc-factory.js";
 
 function setupDoc(id: string, text: string) {
   const ydoc = getOrCreateDocument(id);

--- a/tests/server/awareness.test.ts
+++ b/tests/server/awareness.test.ts
@@ -1,9 +1,9 @@
-import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { resetInbox } from "../../src/server/mcp/awareness.js";
 import { collectAnnotations } from "../../src/server/mcp/annotations.js";
-import { populateYDoc, extractText } from "../../src/server/mcp/document.js";
+import { resetInbox } from "../../src/server/mcp/awareness.js";
+import { extractText, populateYDoc } from "../../src/server/mcp/document.js";
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import type { Annotation } from "../../src/shared/types.js";
 
 let doc: Y.Doc;

--- a/tests/server/changelog-on-update.test.ts
+++ b/tests/server/changelog-on-update.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, afterEach } from "vitest";
 import fs from "fs/promises";
-import path from "path";
 import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
 import { checkVersionChange } from "../../src/server/version-check.js";
 
 let tmpDir: string | null = null;

--- a/tests/server/chat-extended.test.ts
+++ b/tests/server/chat-extended.test.ts
@@ -1,8 +1,8 @@
-import { Y_MAP_CHAT } from "../../src/shared/constants.js";
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
-import { generateMessageId } from "../../src/shared/utils.js";
+import { Y_MAP_CHAT } from "../../src/shared/constants.js";
 import type { ChatMessage } from "../../src/shared/types.js";
+import { generateMessageId } from "../../src/shared/utils.js";
 
 describe("chat message pruning logic", () => {
   it("prunes old messages keeping newest 200", () => {

--- a/tests/server/chat.test.ts
+++ b/tests/server/chat.test.ts
@@ -1,8 +1,8 @@
-import { Y_MAP_CHAT } from "../../src/shared/constants.js";
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
-import { generateMessageId } from "../../src/shared/utils.js";
+import { Y_MAP_CHAT } from "../../src/shared/constants.js";
 import type { ChatMessage } from "../../src/shared/types.js";
+import { generateMessageId } from "../../src/shared/utils.js";
 
 describe("generateMessageId", () => {
   it("produces msg_ prefixed IDs", () => {

--- a/tests/server/dirty-state.test.ts
+++ b/tests/server/dirty-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import { Y_MAP_DOCUMENT_META, Y_MAP_SAVED_AT_VERSION } from "../../src/shared/constants.js";
 

--- a/tests/server/document-edit.test.ts
+++ b/tests/server/document-edit.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, resolveOffset, getOrCreateXmlText } from "../../src/server/mcp/document.js";
+import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
 import { makeDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;

--- a/tests/server/document-edit.test.ts
+++ b/tests/server/document-edit.test.ts
@@ -1,11 +1,7 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import * as Y from 'yjs';
-import {
-  extractText,
-  resolveOffset,
-  getOrCreateXmlText,
-} from '../../src/server/mcp/document.js';
-import { makeDoc } from '../helpers/ydoc-factory.js';
+import { describe, it, expect, afterEach } from "vitest";
+import * as Y from "yjs";
+import { extractText, resolveOffset, getOrCreateXmlText } from "../../src/server/mcp/document.js";
+import { makeDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 
@@ -20,14 +16,14 @@ afterEach(() => {
 function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): string | null {
   if (from > to) return `Invalid range: from (${from}) must be <= to (${to}).`;
 
-  const fragment = doc.getXmlFragment('default');
+  const fragment = doc.getXmlFragment("default");
   const startPos = resolveOffset(fragment, from);
   const endPos = resolveOffset(fragment, to);
 
   if (!startPos || !endPos) return `Cannot resolve offset range [${from}, ${to}].`;
 
   if (startPos.clampedFromPrefix || endPos.clampedFromPrefix) {
-    return 'Edit range overlaps with heading markup.';
+    return "Edit range overlaps with heading markup.";
   }
 
   if (startPos.elementIndex !== endPos.elementIndex) {
@@ -74,122 +70,122 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): strin
   return null;
 }
 
-describe('same-element edits', () => {
-  it('replaces text in the middle of a paragraph', () => {
-    doc = makeDoc('Hello world');
-    const err = applyEdit(doc, 6, 11, 'there');
+describe("same-element edits", () => {
+  it("replaces text in the middle of a paragraph", () => {
+    doc = makeDoc("Hello world");
+    const err = applyEdit(doc, 6, 11, "there");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('Hello there');
+    expect(extractText(doc)).toBe("Hello there");
   });
 
-  it('inserts at beginning (from === to)', () => {
-    doc = makeDoc('Hello world');
-    const err = applyEdit(doc, 0, 0, 'Hey ');
+  it("inserts at beginning (from === to)", () => {
+    doc = makeDoc("Hello world");
+    const err = applyEdit(doc, 0, 0, "Hey ");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('Hey Hello world');
+    expect(extractText(doc)).toBe("Hey Hello world");
   });
 
-  it('inserts at end', () => {
-    doc = makeDoc('Hello world');
-    const err = applyEdit(doc, 11, 11, '!');
+  it("inserts at end", () => {
+    doc = makeDoc("Hello world");
+    const err = applyEdit(doc, 11, 11, "!");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('Hello world!');
+    expect(extractText(doc)).toBe("Hello world!");
   });
 
-  it('deletes text (empty newText)', () => {
-    doc = makeDoc('Hello world');
-    const err = applyEdit(doc, 0, 6, '');
+  it("deletes text (empty newText)", () => {
+    doc = makeDoc("Hello world");
+    const err = applyEdit(doc, 0, 6, "");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('world');
+    expect(extractText(doc)).toBe("world");
   });
 
-  it('replaces entire paragraph content', () => {
-    doc = makeDoc('Hello world');
-    const err = applyEdit(doc, 0, 11, 'Goodbye');
+  it("replaces entire paragraph content", () => {
+    doc = makeDoc("Hello world");
+    const err = applyEdit(doc, 0, 11, "Goodbye");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('Goodbye');
+    expect(extractText(doc)).toBe("Goodbye");
   });
 });
 
-describe('cross-element edits', () => {
-  it('spanning two paragraphs merges them', () => {
-    doc = makeDoc('First line\nSecond line');
+describe("cross-element edits", () => {
+  it("spanning two paragraphs merges them", () => {
+    doc = makeDoc("First line\nSecond line");
     // "First line\nSecond line"
     // Delete from "line" in first to "Second " → merge
-    const err = applyEdit(doc, 6, 18, '');
+    const err = applyEdit(doc, 6, 18, "");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('First line');
+    expect(extractText(doc)).toBe("First line");
   });
 
-  it('spanning two paragraphs with replacement text', () => {
-    doc = makeDoc('First line\nSecond line');
+  it("spanning two paragraphs with replacement text", () => {
+    doc = makeDoc("First line\nSecond line");
     // Replace from offset 5 (" line") through offset 17 ("Second ") with " and second "
     // "First" + " and second " + "line"
-    const err = applyEdit(doc, 5, 18, ' and second ');
+    const err = applyEdit(doc, 5, 18, " and second ");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('First and second line');
+    expect(extractText(doc)).toBe("First and second line");
   });
 
-  it('spanning three elements deletes middle entirely', () => {
-    doc = makeDoc('First\nMiddle\nThird');
+  it("spanning three elements deletes middle entirely", () => {
+    doc = makeDoc("First\nMiddle\nThird");
     // "First\nMiddle\nThird" → F=0..4, \n=5, M=6..11, \n=12, T=13..17
     // Delete from end of First (5) to start of Third (13)
-    const err = applyEdit(doc, 5, 13, ' and ');
+    const err = applyEdit(doc, 5, 13, " and ");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('First and Third');
+    expect(extractText(doc)).toBe("First and Third");
   });
 
-  it('endPos.textOffset === 0 (selection ends at start of element)', () => {
-    doc = makeDoc('First\nSecond');
+  it("endPos.textOffset === 0 (selection ends at start of element)", () => {
+    doc = makeDoc("First\nSecond");
     // Delete from offset 3 to offset 6 (start of "Second")
     // endPos for offset 6 → elementIndex 1, textOffset 0
-    const err = applyEdit(doc, 3, 6, '');
+    const err = applyEdit(doc, 3, 6, "");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('FirSecond');
+    expect(extractText(doc)).toBe("FirSecond");
   });
 });
 
-describe('heading prefix rejection', () => {
-  it('rejects edit starting inside heading prefix', () => {
-    doc = makeDoc('## Heading');
-    const err = applyEdit(doc, 0, 5, 'X');
-    expect(err).toContain('heading markup');
+describe("heading prefix rejection", () => {
+  it("rejects edit starting inside heading prefix", () => {
+    doc = makeDoc("## Heading");
+    const err = applyEdit(doc, 0, 5, "X");
+    expect(err).toContain("heading markup");
   });
 
-  it('rejects edit ending inside heading prefix', () => {
-    doc = makeDoc('Some text\n## Heading');
+  it("rejects edit ending inside heading prefix", () => {
+    doc = makeDoc("Some text\n## Heading");
     // offset 10 = \n, offset 11 = start of "## " prefix
-    const err = applyEdit(doc, 8, 11, 'X');
-    expect(err).toContain('heading markup');
+    const err = applyEdit(doc, 8, 11, "X");
+    expect(err).toContain("heading markup");
   });
 
-  it('allows edit starting at first text char of heading', () => {
-    doc = makeDoc('## Heading');
+  it("allows edit starting at first text char of heading", () => {
+    doc = makeDoc("## Heading");
     // "## Heading" → prefix is 3 chars, offset 3 = first char "H"
-    const err = applyEdit(doc, 3, 10, 'Title');
+    const err = applyEdit(doc, 3, 10, "Title");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('## Title');
+    expect(extractText(doc)).toBe("## Title");
   });
 
-  it('rejects edit at prefixLen - 1', () => {
-    doc = makeDoc('## Heading');
+  it("rejects edit at prefixLen - 1", () => {
+    doc = makeDoc("## Heading");
     // offset 2 is still inside "## " prefix
-    const err = applyEdit(doc, 2, 5, 'X');
-    expect(err).toContain('heading markup');
+    const err = applyEdit(doc, 2, 5, "X");
+    expect(err).toContain("heading markup");
   });
 });
 
-describe('validation', () => {
-  it('from > to returns error', () => {
-    doc = makeDoc('Hello');
-    const err = applyEdit(doc, 5, 2, 'X');
-    expect(err).toContain('Invalid range');
+describe("validation", () => {
+  it("from > to returns error", () => {
+    doc = makeDoc("Hello");
+    const err = applyEdit(doc, 5, 2, "X");
+    expect(err).toContain("Invalid range");
   });
 
-  it('from === to with non-empty newText is a valid insert', () => {
-    doc = makeDoc('Hello');
-    const err = applyEdit(doc, 3, 3, 'XYZ');
+  it("from === to with non-empty newText is a valid insert", () => {
+    doc = makeDoc("Hello");
+    const err = applyEdit(doc, 3, 3, "XYZ");
     expect(err).toBeNull();
-    expect(extractText(doc)).toBe('HelXYZlo');
+    expect(extractText(doc)).toBe("HelXYZlo");
   });
 });

--- a/tests/server/document-offset.test.ts
+++ b/tests/server/document-offset.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { resolveOffset, extractText } from "../../src/server/mcp/document.js";
+import { extractText, resolveOffset } from "../../src/server/mcp/document.js";
 import { validateRange } from "../../src/server/positions.js";
-import { makeDoc, makeEmptyDoc, makeMarkdownDoc, getFragment } from "../helpers/ydoc-factory.js";
+import { getFragment, makeDoc, makeEmptyDoc, makeMarkdownDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 

--- a/tests/server/document-roundtrip.test.ts
+++ b/tests/server/document-roundtrip.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import {
-  populateYDoc,
   extractText,
   getElementText,
   getHeadingPrefixLength,
+  populateYDoc,
 } from "../../src/server/mcp/document.js";
-import { makeDoc, makeEmptyDoc, getFragment } from "../helpers/ydoc-factory.js";
+import { getFragment, makeDoc, makeEmptyDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 

--- a/tests/server/document-roundtrip.test.ts
+++ b/tests/server/document-roundtrip.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import * as Y from 'yjs';
+import { describe, it, expect, afterEach } from "vitest";
+import * as Y from "yjs";
 import {
   populateYDoc,
   extractText,
   getElementText,
   getHeadingPrefixLength,
-} from '../../src/server/mcp/document.js';
-import { makeDoc, makeEmptyDoc, getFragment } from '../helpers/ydoc-factory.js';
+} from "../../src/server/mcp/document.js";
+import { makeDoc, makeEmptyDoc, getFragment } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 
@@ -14,175 +14,175 @@ afterEach(() => {
   doc?.destroy();
 });
 
-describe('populateYDoc', () => {
-  it('creates paragraph elements for plain text lines', () => {
-    doc = makeDoc('hello\nworld');
+describe("populateYDoc", () => {
+  it("creates paragraph elements for plain text lines", () => {
+    doc = makeDoc("hello\nworld");
     const frag = getFragment(doc);
     expect(frag.length).toBe(2);
     const first = frag.get(0) as Y.XmlElement;
     const second = frag.get(1) as Y.XmlElement;
-    expect(first.nodeName).toBe('paragraph');
-    expect(getElementText(first)).toBe('hello');
-    expect(second.nodeName).toBe('paragraph');
-    expect(getElementText(second)).toBe('world');
+    expect(first.nodeName).toBe("paragraph");
+    expect(getElementText(first)).toBe("hello");
+    expect(second.nodeName).toBe("paragraph");
+    expect(getElementText(second)).toBe("world");
   });
 
   it.each([
-    ['# ', 1],
-    ['## ', 2],
-    ['### ', 3],
-  ])('creates heading for %s prefix with correct level attribute', (prefix, level) => {
+    ["# ", 1],
+    ["## ", 2],
+    ["### ", 3],
+  ])("creates heading for %s prefix with correct level attribute", (prefix, level) => {
     doc = makeDoc(`${prefix}Title`);
     const frag = getFragment(doc);
     expect(frag.length).toBe(1);
     const el = frag.get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('heading');
-    expect(el.getAttribute('level')).toBe(level);
-    expect(getElementText(el)).toBe('Title');
+    expect(el.nodeName).toBe("heading");
+    expect(el.getAttribute("level")).toBe(level);
+    expect(getElementText(el)).toBe("Title");
   });
 
   it('preserves blank lines: "a\\n\\nb" produces three elements', () => {
-    doc = makeDoc('a\n\nb');
+    doc = makeDoc("a\n\nb");
     const frag = getFragment(doc);
     expect(frag.length).toBe(3);
-    expect(getElementText(frag.get(1) as Y.XmlElement)).toBe('');
-    expect(extractText(doc)).toBe('a\n\nb');
+    expect(getElementText(frag.get(1) as Y.XmlElement)).toBe("");
+    expect(extractText(doc)).toBe("a\n\nb");
   });
 
-  it('string of only blank lines produces empty paragraph elements', () => {
-    doc = makeDoc('\n\n\n');
+  it("string of only blank lines produces empty paragraph elements", () => {
+    doc = makeDoc("\n\n\n");
     const frag = getFragment(doc);
     // '\n\n\n'.split('\n') = ['', '', '', ''] → 4 empty paragraphs
     expect(frag.length).toBe(4);
     for (let i = 0; i < frag.length; i++) {
-      expect(getElementText(frag.get(i) as Y.XmlElement)).toBe('');
+      expect(getElementText(frag.get(i) as Y.XmlElement)).toBe("");
     }
   });
 
   it('treats "#" without space as a paragraph', () => {
-    doc = makeDoc('#NotAHeading');
+    doc = makeDoc("#NotAHeading");
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('paragraph');
-    expect(getElementText(el)).toBe('#NotAHeading');
+    expect(el.nodeName).toBe("paragraph");
+    expect(getElementText(el)).toBe("#NotAHeading");
   });
 
   it('treats "##Heading" (no space) as a paragraph', () => {
-    doc = makeDoc('##NoSpace');
+    doc = makeDoc("##NoSpace");
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('paragraph');
-    expect(getElementText(el)).toBe('##NoSpace');
+    expect(el.nodeName).toBe("paragraph");
+    expect(getElementText(el)).toBe("##NoSpace");
   });
 
-  it('calling twice replaces content, does not append', () => {
+  it("calling twice replaces content, does not append", () => {
     doc = new Y.Doc();
-    populateYDoc(doc, 'first content');
+    populateYDoc(doc, "first content");
     expect(getFragment(doc).length).toBe(1);
-    populateYDoc(doc, 'second\nthird');
+    populateYDoc(doc, "second\nthird");
     const frag = getFragment(doc);
     expect(frag.length).toBe(2);
-    expect(getElementText(frag.get(0) as Y.XmlElement)).toBe('second');
-    expect(getElementText(frag.get(1) as Y.XmlElement)).toBe('third');
+    expect(getElementText(frag.get(0) as Y.XmlElement)).toBe("second");
+    expect(getElementText(frag.get(1) as Y.XmlElement)).toBe("third");
   });
 
-  it('empty string produces empty fragment', () => {
-    doc = makeDoc('');
+  it("empty string produces empty fragment", () => {
+    doc = makeDoc("");
     expect(getFragment(doc).length).toBe(0);
   });
 });
 
-describe('extractText', () => {
-  it('returns empty string for a never-populated doc', () => {
+describe("extractText", () => {
+  it("returns empty string for a never-populated doc", () => {
     doc = makeEmptyDoc();
-    expect(extractText(doc)).toBe('');
+    expect(extractText(doc)).toBe("");
   });
 
-  it('returns empty string for a doc populated with empty string', () => {
-    doc = makeDoc('');
-    expect(extractText(doc)).toBe('');
+  it("returns empty string for a doc populated with empty string", () => {
+    doc = makeDoc("");
+    expect(extractText(doc)).toBe("");
   });
 
-  it('returns text for a single paragraph', () => {
-    doc = makeDoc('just a paragraph');
-    expect(extractText(doc)).toBe('just a paragraph');
+  it("returns text for a single paragraph", () => {
+    doc = makeDoc("just a paragraph");
+    expect(extractText(doc)).toBe("just a paragraph");
   });
 
-  it('returns markdown heading format for a single heading', () => {
-    doc = makeDoc('## Section');
-    expect(extractText(doc)).toBe('## Section');
+  it("returns markdown heading format for a single heading", () => {
+    doc = makeDoc("## Section");
+    expect(extractText(doc)).toBe("## Section");
   });
 
-  it('joins multiple elements with newline', () => {
-    doc = makeDoc('# Title\nParagraph one\nParagraph two');
-    expect(extractText(doc)).toBe('# Title\nParagraph one\nParagraph two');
+  it("joins multiple elements with newline", () => {
+    doc = makeDoc("# Title\nParagraph one\nParagraph two");
+    expect(extractText(doc)).toBe("# Title\nParagraph one\nParagraph two");
   });
 });
 
-describe('round-trip: populateYDoc -> extractText', () => {
-  it('plain paragraphs', () => {
-    const input = 'first line\nsecond line\nthird line';
+describe("round-trip: populateYDoc -> extractText", () => {
+  it("plain paragraphs", () => {
+    const input = "first line\nsecond line\nthird line";
     doc = makeDoc(input);
     expect(extractText(doc)).toBe(input);
   });
 
   it.each([
-    ['# Heading One'],
-    ['## Heading Two'],
-    ['### Heading Three'],
-  ])('heading round-trip: %s', (input) => {
+    ["# Heading One"],
+    ["## Heading Two"],
+    ["### Heading Three"],
+  ])("heading round-trip: %s", (input) => {
     doc = makeDoc(input);
     expect(extractText(doc)).toBe(input);
   });
 
-  it('mixed headings and paragraphs', () => {
-    const input = '# Title\n## Section\nParagraph text\n### Sub\nMore text';
+  it("mixed headings and paragraphs", () => {
+    const input = "# Title\n## Section\nParagraph text\n### Sub\nMore text";
     doc = makeDoc(input);
     expect(extractText(doc)).toBe(input);
   });
 
-  it('unicode: emoji and CJK characters', () => {
-    const input = 'Hello 🎉\n你好世界\n## 标题';
+  it("unicode: emoji and CJK characters", () => {
+    const input = "Hello 🎉\n你好世界\n## 标题";
     doc = makeDoc(input);
     expect(extractText(doc)).toBe(input);
   });
 
-  it('very long line (1000+ chars)', () => {
-    const longLine = 'x'.repeat(1200);
+  it("very long line (1000+ chars)", () => {
+    const longLine = "x".repeat(1200);
     doc = makeDoc(longLine);
     expect(extractText(doc)).toBe(longLine);
   });
 
-  it('document with only headings', () => {
-    const input = '# H1\n## H2\n### H3';
+  it("document with only headings", () => {
+    const input = "# H1\n## H2\n### H3";
     doc = makeDoc(input);
     expect(extractText(doc)).toBe(input);
   });
 
-  it('preserves leading/trailing whitespace within lines', () => {
-    const input = '  indented paragraph\ntrailing spaces   \n## Heading with space ';
+  it("preserves leading/trailing whitespace within lines", () => {
+    const input = "  indented paragraph\ntrailing spaces   \n## Heading with space ";
     doc = makeDoc(input);
     expect(extractText(doc)).toBe(input);
   });
 });
 
-describe('getHeadingPrefixLength', () => {
+describe("getHeadingPrefixLength", () => {
   it.each([
-    ['# ', 1, 2],
-    ['## ', 2, 3],
-    ['### ', 3, 4],
+    ["# ", 1, 2],
+    ["## ", 2, 3],
+    ["### ", 3, 4],
   ])('level %i heading (prefix "%s") returns %i', (_prefix, level, expected) => {
     // Y.XmlElement attributes only work inside a Y.Doc
     const testDoc = new Y.Doc();
-    const frag = testDoc.getXmlFragment('default');
-    const el = new Y.XmlElement('heading');
-    el.setAttribute('level', level);
+    const frag = testDoc.getXmlFragment("default");
+    const el = new Y.XmlElement("heading");
+    el.setAttribute("level", level);
     frag.insert(0, [el]);
     expect(getHeadingPrefixLength(el)).toBe(expected);
     testDoc.destroy();
   });
 
-  it('paragraph element returns 0', () => {
+  it("paragraph element returns 0", () => {
     // Use a doc-attached element
-    doc = makeDoc('just text');
+    doc = makeDoc("just text");
     const el = getFragment(doc).get(0) as Y.XmlElement;
     expect(getHeadingPrefixLength(el)).toBe(0);
   });

--- a/tests/server/document-service.test.ts
+++ b/tests/server/document-service.test.ts
@@ -1,21 +1,21 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
-import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import type { OpenDoc } from "../../src/server/mcp/document-service.js";
 import {
-  getOpenDocs,
   addDoc,
-  removeDoc,
-  hasDoc,
-  docCount,
-  getActiveDocId,
-  setActiveDocId,
-  getCurrentDoc,
-  requireDocument,
-  toDocListEntry,
   broadcastOpenDocs,
   closeDocumentById,
+  docCount,
+  getActiveDocId,
+  getCurrentDoc,
+  getOpenDocs,
+  hasDoc,
+  removeDoc,
+  requireDocument,
+  setActiveDocId,
+  toDocListEntry,
 } from "../../src/server/mcp/document-service.js";
-import type { OpenDoc } from "../../src/server/mcp/document-service.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import { CTRL_ROOM, Y_MAP_DOCUMENT_META } from "../../src/shared/constants.js";
 
 // Mock session manager to avoid filesystem side effects

--- a/tests/server/document-tools.test.ts
+++ b/tests/server/document-tools.test.ts
@@ -1,23 +1,24 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import {
-  addDoc,
-  removeDoc,
-  setActiveDocId,
-  getOpenDocs,
-  getCurrentDoc,
-  requireDocument,
-  hasDoc,
-  docCount,
-} from "../../src/server/mcp/document-service.js";
-import {
+  getOrCreateXmlText,
+  getOutline,
+  getSection,
   populateYDoc,
   resolveOffset,
-  getOrCreateXmlText,
   verifyAndResolveRange,
 } from "../../src/server/mcp/document.js";
-import { getOutline, getSection } from "../../src/server/mcp/document.js";
+import {
+  addDoc,
+  docCount,
+  getCurrentDoc,
+  getOpenDocs,
+  hasDoc,
+  removeDoc,
+  requireDocument,
+  setActiveDocId,
+} from "../../src/server/mcp/document-service.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 
 function setupDoc(id: string, text: string, opts?: { readOnly?: boolean; format?: string }) {
   const ydoc = getOrCreateDocument(id);

--- a/tests/server/docx-apply.test.ts
+++ b/tests/server/docx-apply.test.ts
@@ -1,19 +1,19 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import JSZip from "jszip";
 import render from "dom-serializer";
+import JSZip from "jszip";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
-  buildOffsetMap,
   applySingleSuggestion,
   applyTrackedChanges,
+  buildOffsetMap,
   resolveWordComments,
 } from "../../src/server/file-io/docx-apply.js";
-import { applyChangesCore } from "../../src/server/mcp/docx-apply.js";
 import {
   addDoc,
+  getOpenDocs,
   removeDoc,
   setActiveDocId,
-  getOpenDocs,
 } from "../../src/server/mcp/document-service.js";
+import { applyChangesCore } from "../../src/server/mcp/docx-apply.js";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 
 // ---------------------------------------------------------------------------

--- a/tests/server/docx-comments.test.ts
+++ b/tests/server/docx-comments.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import {
-  parseCommentMetadata,
   calculateCommentRanges,
+  type DocxComment,
   extractDocxComments,
   injectCommentsAsAnnotations,
-  type DocxComment,
+  parseCommentMetadata,
 } from "../../src/server/file-io/docx-comments.js";
 import { htmlToYDoc } from "../../src/server/file-io/docx-html.js";
 import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";

--- a/tests/server/docx-walker.test.ts
+++ b/tests/server/docx-walker.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { parseDocument } from "htmlparser2";
+import { describe, expect, it } from "vitest";
 import {
-  walkDocumentBody,
+  type CommentStartHit,
   detectHeadingLevel,
   findAllByName,
   type TextHit,
-  type CommentStartHit,
+  walkDocumentBody,
 } from "../../src/server/file-io/docx-walker.js";
-import { parseDocument } from "htmlparser2";
 
 // ---------------------------------------------------------------------------
 // Helper: wrap body content in a minimal document.xml envelope

--- a/tests/server/docx.test.ts
+++ b/tests/server/docx.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { htmlToYDoc, exportAnnotations } from "../../src/server/file-io/docx.js";
+import { exportAnnotations, htmlToYDoc } from "../../src/server/file-io/docx.js";
 import { getElementText } from "../../src/server/mcp/document.js";
 import type { Annotation } from "../../src/shared/types.js";
 import { getFragment, makeAnnotation } from "../helpers/ydoc-factory.js";

--- a/tests/server/edit-annotation.test.ts
+++ b/tests/server/edit-annotation.test.ts
@@ -2,21 +2,22 @@
  * Tests for tandem_editAnnotation MCP tool.
  * Uses in-memory MCP client to exercise the actual tool handler.
  */
-import { describe, it, expect, beforeEach } from "vitest";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
-import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
-import { registerAnnotationTools, createAnnotation } from "../../src/server/mcp/annotations.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { MCP_ORIGIN } from "../../src/server/events/queue.js";
+import { createAnnotation, registerAnnotationTools } from "../../src/server/mcp/annotations.js";
+import { populateYDoc } from "../../src/server/mcp/document.js";
 import {
   addDoc,
+  getOpenDocs,
   removeDoc,
   setActiveDocId,
-  getOpenDocs,
 } from "../../src/server/mcp/document-service.js";
-import { populateYDoc } from "../../src/server/mcp/document.js";
-import { MCP_ORIGIN } from "../../src/server/events/queue.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import type { Annotation } from "../../src/shared/types.js";
 import { rangeOf } from "../helpers/ydoc-factory.js";
 

--- a/tests/server/error-filter.test.ts
+++ b/tests/server/error-filter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { isKnownHocuspocusError } from "../../src/server/error-filter.js";
 
 /** Helper: create an Error with a `.code` property, mimicking ws library errors */

--- a/tests/server/file-open-api.test.ts
+++ b/tests/server/file-open-api.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
 import fs from "fs/promises";
-import path from "path";
 import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { docIdFromPath, extractText } from "../../src/server/mcp/document-model.js";
+import { getOpenDocs, removeDoc } from "../../src/server/mcp/document-service.js";
 import {
   openFileByPath,
   openFileFromContent,
   SUPPORTED_EXTENSIONS,
 } from "../../src/server/mcp/file-opener.js";
-import { getOpenDocs, removeDoc } from "../../src/server/mcp/document-service.js";
-import { getOrCreateDocument, removeDocument } from "../../src/server/yjs/provider.js";
-import { extractText, docIdFromPath } from "../../src/server/mcp/document-model.js";
 import { sourceFileChanged } from "../../src/server/session/manager.js";
+import { getOrCreateDocument, removeDocument } from "../../src/server/yjs/provider.js";
 import {
   Y_MAP_ANNOTATIONS,
   Y_MAP_AWARENESS,

--- a/tests/server/file-opener-edge-cases.test.ts
+++ b/tests/server/file-opener-edge-cases.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, beforeEach } from "vitest";
 import fs from "fs/promises";
-import path from "path";
 import os from "os";
+import path from "path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getOpenDocs, removeDoc, setActiveDocId } from "../../src/server/mcp/document-service.js";
 import {
   openFileByPath,
   openFileFromContent,
   SUPPORTED_EXTENSIONS,
 } from "../../src/server/mcp/file-opener.js";
-import { removeDoc, setActiveDocId, getOpenDocs } from "../../src/server/mcp/document-service.js";
 
 let tmpDir: string;
 

--- a/tests/server/file-watcher.test.ts
+++ b/tests/server/file-watcher.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  watchFile,
-  unwatchFile,
-  unwatchAll,
   suppressNextChange,
+  unwatchAll,
+  unwatchFile,
   watchedCount,
+  watchFile,
 } from "../../src/server/file-watcher.js";
 
 // We mock fs.watch to avoid touching the real filesystem

--- a/tests/server/format-adapter.test.ts
+++ b/tests/server/format-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import { getAdapter } from "../../src/server/file-io/index.js";
 import { extractText } from "../../src/server/mcp/document-model.js";

--- a/tests/server/integration.test.ts
+++ b/tests/server/integration.test.ts
@@ -1,12 +1,8 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import * as Y from 'yjs';
-import {
-  extractText,
-  resolveOffset,
-  getOrCreateXmlText,
-} from '../../src/server/mcp/document.js';
-import { escapeRegex } from '../../src/server/mcp/response.js';
-import { makeDoc } from '../helpers/ydoc-factory.js';
+import { describe, it, expect, afterEach } from "vitest";
+import * as Y from "yjs";
+import { extractText, resolveOffset, getOrCreateXmlText } from "../../src/server/mcp/document.js";
+import { escapeRegex } from "../../src/server/mcp/response.js";
+import { makeDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 
@@ -16,7 +12,7 @@ afterEach(() => {
 
 /** Find text like tandem_resolveRange */
 function findText(fullText: string, pattern: string, occurrence = 1) {
-  const regex = new RegExp(escapeRegex(pattern), 'g');
+  const regex = new RegExp(escapeRegex(pattern), "g");
   let match;
   let count = 0;
   while ((match = regex.exec(fullText)) !== null) {
@@ -30,7 +26,7 @@ function findText(fullText: string, pattern: string, occurrence = 1) {
 
 /** Apply edit like tandem_edit */
 function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boolean {
-  const fragment = doc.getXmlFragment('default');
+  const fragment = doc.getXmlFragment("default");
   const startPos = resolveOffset(fragment, from);
   const endPos = resolveOffset(fragment, to);
   if (!startPos || !endPos) return false;
@@ -76,47 +72,47 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boole
   return true;
 }
 
-describe('resolveRange → edit pipeline', () => {
-  it('find text, replace it, verify result', () => {
-    doc = makeDoc('The quick brown fox jumps over the lazy dog');
+describe("resolveRange → edit pipeline", () => {
+  it("find text, replace it, verify result", () => {
+    doc = makeDoc("The quick brown fox jumps over the lazy dog");
     const text = extractText(doc);
-    const range = findText(text, 'brown fox');
+    const range = findText(text, "brown fox");
     expect(range).not.toBeNull();
 
-    const success = applyEdit(doc, range!.from, range!.to, 'red cat');
+    const success = applyEdit(doc, range!.from, range!.to, "red cat");
     expect(success).toBe(true);
-    expect(extractText(doc)).toBe('The quick red cat jumps over the lazy dog');
+    expect(extractText(doc)).toBe("The quick red cat jumps over the lazy dog");
   });
 
-  it('find and edit text in document with headings', () => {
-    doc = makeDoc('# Title\nThe old paragraph\n## Section\nMore content');
+  it("find and edit text in document with headings", () => {
+    doc = makeDoc("# Title\nThe old paragraph\n## Section\nMore content");
     const text = extractText(doc);
-    const range = findText(text, 'old paragraph');
+    const range = findText(text, "old paragraph");
     expect(range).not.toBeNull();
 
-    const success = applyEdit(doc, range!.from, range!.to, 'new paragraph');
+    const success = applyEdit(doc, range!.from, range!.to, "new paragraph");
     expect(success).toBe(true);
 
     const result = extractText(doc);
-    expect(result).toBe('# Title\nThe new paragraph\n## Section\nMore content');
+    expect(result).toBe("# Title\nThe new paragraph\n## Section\nMore content");
     // Heading structure preserved
-    expect(result).toContain('# Title');
-    expect(result).toContain('## Section');
+    expect(result).toContain("# Title");
+    expect(result).toContain("## Section");
   });
 
-  it('search → edit → search again at new position', () => {
-    doc = makeDoc('Replace OLD with something NEW');
+  it("search → edit → search again at new position", () => {
+    doc = makeDoc("Replace OLD with something NEW");
     let text = extractText(doc);
 
-    const range = findText(text, 'OLD');
+    const range = findText(text, "OLD");
     expect(range).not.toBeNull();
-    applyEdit(doc, range!.from, range!.to, 'FRESH');
+    applyEdit(doc, range!.from, range!.to, "FRESH");
 
     text = extractText(doc);
-    expect(text).toBe('Replace FRESH with something NEW');
+    expect(text).toBe("Replace FRESH with something NEW");
 
     // "FRESH" should be findable at the expected position
-    const newRange = findText(text, 'FRESH');
+    const newRange = findText(text, "FRESH");
     expect(newRange).not.toBeNull();
     expect(newRange!.from).toBe(8); // "Replace " is 8 chars
     expect(newRange!.to).toBe(13); // "FRESH" is 5 chars

--- a/tests/server/integration.test.ts
+++ b/tests/server/integration.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, resolveOffset, getOrCreateXmlText } from "../../src/server/mcp/document.js";
+import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
 import { escapeRegex } from "../../src/server/mcp/response.js";
 import { makeDoc } from "../helpers/ydoc-factory.js";
 

--- a/tests/server/markdown-roundtrip.test.ts
+++ b/tests/server/markdown-roundtrip.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import * as Y from 'yjs';
-import { loadMarkdown, saveMarkdown } from '../../src/server/file-io/markdown.js';
+import { describe, it, expect, afterEach } from "vitest";
+import * as Y from "yjs";
+import { loadMarkdown, saveMarkdown } from "../../src/server/file-io/markdown.js";
 
 let doc: Y.Doc;
 
@@ -23,175 +23,175 @@ function normalize(s: string): string {
   return s.trim();
 }
 
-describe('markdown round-trip', () => {
-  it('headings and paragraphs', () => {
-    const input = '# Title\n\nSome text.\n\n## Section\n\nMore text.';
+describe("markdown round-trip", () => {
+  it("headings and paragraphs", () => {
+    const input = "# Title\n\nSome text.\n\n## Section\n\nMore text.";
     expect(normalize(roundTrip(input))).toBe(normalize(input));
   });
 
-  it('heading levels 1-6', () => {
-    const input = '# H1\n\n## H2\n\n### H3\n\n#### H4\n\n##### H5\n\n###### H6';
+  it("heading levels 1-6", () => {
+    const input = "# H1\n\n## H2\n\n### H3\n\n#### H4\n\n##### H5\n\n###### H6";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('# H1');
-    expect(output).toContain('## H2');
-    expect(output).toContain('###### H6');
+    expect(output).toContain("# H1");
+    expect(output).toContain("## H2");
+    expect(output).toContain("###### H6");
   });
 
-  it('blank lines between paragraphs', () => {
-    const input = 'First paragraph.\n\nSecond paragraph.';
+  it("blank lines between paragraphs", () => {
+    const input = "First paragraph.\n\nSecond paragraph.";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('First paragraph.');
-    expect(output).toContain('Second paragraph.');
+    expect(output).toContain("First paragraph.");
+    expect(output).toContain("Second paragraph.");
   });
 
-  it('inline formatting: bold, italic, strikethrough, code', () => {
-    const input = 'This is **bold** and *italic* and ~~strike~~ and `code`.';
+  it("inline formatting: bold, italic, strikethrough, code", () => {
+    const input = "This is **bold** and *italic* and ~~strike~~ and `code`.";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('**bold**');
-    expect(output).toContain('*italic*');
-    expect(output).toContain('~~strike~~');
-    expect(output).toContain('`code`');
+    expect(output).toContain("**bold**");
+    expect(output).toContain("*italic*");
+    expect(output).toContain("~~strike~~");
+    expect(output).toContain("`code`");
   });
 
-  it('links', () => {
+  it("links", () => {
     const input = 'Visit [Example](https://example.com "A site") for more.';
     const output = normalize(roundTrip(input));
-    expect(output).toContain('[Example]');
-    expect(output).toContain('https://example.com');
+    expect(output).toContain("[Example]");
+    expect(output).toContain("https://example.com");
   });
 
-  it('bullet lists', () => {
-    const input = '- Item one\n- Item two\n- Item three';
+  it("bullet lists", () => {
+    const input = "- Item one\n- Item two\n- Item three";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('- Item one');
-    expect(output).toContain('- Item two');
-    expect(output).toContain('- Item three');
+    expect(output).toContain("- Item one");
+    expect(output).toContain("- Item two");
+    expect(output).toContain("- Item three");
   });
 
-  it('ordered lists', () => {
-    const input = '1. First\n2. Second\n3. Third';
+  it("ordered lists", () => {
+    const input = "1. First\n2. Second\n3. Third";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('1. First');
-    expect(output).toContain('2. Second');
-    expect(output).toContain('3. Third');
+    expect(output).toContain("1. First");
+    expect(output).toContain("2. Second");
+    expect(output).toContain("3. Third");
   });
 
-  it('nested lists (2 levels)', () => {
-    const input = '- Outer\n  - Inner one\n  - Inner two';
+  it("nested lists (2 levels)", () => {
+    const input = "- Outer\n  - Inner one\n  - Inner two";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('- Outer');
-    expect(output).toContain('Inner one');
-    expect(output).toContain('Inner two');
+    expect(output).toContain("- Outer");
+    expect(output).toContain("Inner one");
+    expect(output).toContain("Inner two");
   });
 
-  it('code block with language', () => {
-    const input = '```javascript\nconst x = 1;\nconsole.log(x);\n```';
+  it("code block with language", () => {
+    const input = "```javascript\nconst x = 1;\nconsole.log(x);\n```";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('```javascript');
-    expect(output).toContain('const x = 1;');
-    expect(output).toContain('console.log(x);');
-    expect(output).toContain('```');
+    expect(output).toContain("```javascript");
+    expect(output).toContain("const x = 1;");
+    expect(output).toContain("console.log(x);");
+    expect(output).toContain("```");
   });
 
-  it('code block without language', () => {
-    const input = '```\nplain code\n```';
+  it("code block without language", () => {
+    const input = "```\nplain code\n```";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('plain code');
+    expect(output).toContain("plain code");
   });
 
-  it('blockquote', () => {
-    const input = '> This is a quote.\n>\n> Second paragraph in quote.';
+  it("blockquote", () => {
+    const input = "> This is a quote.\n>\n> Second paragraph in quote.";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('> This is a quote.');
-    expect(output).toContain('> Second paragraph in quote.');
+    expect(output).toContain("> This is a quote.");
+    expect(output).toContain("> Second paragraph in quote.");
   });
 
-  it('horizontal rule', () => {
-    const input = 'Above\n\n---\n\nBelow';
+  it("horizontal rule", () => {
+    const input = "Above\n\n---\n\nBelow";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('Above');
-    expect(output).toContain('---');
-    expect(output).toContain('Below');
+    expect(output).toContain("Above");
+    expect(output).toContain("---");
+    expect(output).toContain("Below");
   });
 
-  it('comprehensive mixed document', () => {
+  it("comprehensive mixed document", () => {
     const input = [
-      '# Document Title',
-      '',
-      'An introductory paragraph with **bold** and *italic* text.',
-      '',
-      '## Section One',
-      '',
-      '- First item',
-      '- Second item with `code`',
-      '- Third item',
-      '',
-      '### Subsection',
-      '',
-      '> A blockquote with some *emphasis*.',
-      '',
-      '```typescript',
-      'function hello(): void {',
+      "# Document Title",
+      "",
+      "An introductory paragraph with **bold** and *italic* text.",
+      "",
+      "## Section One",
+      "",
+      "- First item",
+      "- Second item with `code`",
+      "- Third item",
+      "",
+      "### Subsection",
+      "",
+      "> A blockquote with some *emphasis*.",
+      "",
+      "```typescript",
+      "function hello(): void {",
       '  console.log("hi");',
-      '}',
-      '```',
-      '',
-      '---',
-      '',
-      '1. Ordered one',
-      '2. Ordered two',
-      '',
-      'Final paragraph.',
-    ].join('\n');
+      "}",
+      "```",
+      "",
+      "---",
+      "",
+      "1. Ordered one",
+      "2. Ordered two",
+      "",
+      "Final paragraph.",
+    ].join("\n");
 
     const output = normalize(roundTrip(input));
-    expect(output).toContain('# Document Title');
-    expect(output).toContain('**bold**');
-    expect(output).toContain('*italic*');
-    expect(output).toContain('- First item');
-    expect(output).toContain('`code`');
-    expect(output).toContain('blockquote');
-    expect(output).toContain('```typescript');
-    expect(output).toContain('function hello()');
-    expect(output).toContain('---');
-    expect(output).toContain('1. Ordered one');
-    expect(output).toContain('Final paragraph.');
+    expect(output).toContain("# Document Title");
+    expect(output).toContain("**bold**");
+    expect(output).toContain("*italic*");
+    expect(output).toContain("- First item");
+    expect(output).toContain("`code`");
+    expect(output).toContain("blockquote");
+    expect(output).toContain("```typescript");
+    expect(output).toContain("function hello()");
+    expect(output).toContain("---");
+    expect(output).toContain("1. Ordered one");
+    expect(output).toContain("Final paragraph.");
   });
 
-  it('empty document', () => {
-    const output = roundTrip('');
-    expect(normalize(output)).toBe('');
+  it("empty document", () => {
+    const output = roundTrip("");
+    expect(normalize(output)).toBe("");
   });
 
-  it('document with only headings', () => {
-    const input = '# H1\n\n## H2\n\n### H3';
+  it("document with only headings", () => {
+    const input = "# H1\n\n## H2\n\n### H3";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('# H1');
-    expect(output).toContain('## H2');
-    expect(output).toContain('### H3');
+    expect(output).toContain("# H1");
+    expect(output).toContain("## H2");
+    expect(output).toContain("### H3");
   });
 
-  it('unicode: emoji and CJK characters', () => {
-    const input = 'Hello 🎉\n\n你好世界\n\n## 标题';
+  it("unicode: emoji and CJK characters", () => {
+    const input = "Hello 🎉\n\n你好世界\n\n## 标题";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('🎉');
-    expect(output).toContain('你好世界');
-    expect(output).toContain('## 标题');
+    expect(output).toContain("🎉");
+    expect(output).toContain("你好世界");
+    expect(output).toContain("## 标题");
   });
 
-  it('image preserves alt text (inline images degrade to text)', () => {
+  it("image preserves alt text (inline images degrade to text)", () => {
     // remark parses inline images inside a paragraph, so they degrade to alt text
     // Block-level images are handled via the image Y.XmlElement
     const input = '![Alt text](https://example.com/image.png "Title")';
     const output = normalize(roundTrip(input));
-    expect(output).toContain('Alt text');
+    expect(output).toContain("Alt text");
   });
 
-  it('list in blockquote', () => {
-    const input = '> - Item one\n> - Item two';
+  it("list in blockquote", () => {
+    const input = "> - Item one\n> - Item two";
     const output = normalize(roundTrip(input));
-    expect(output).toContain('> -');
-    expect(output).toContain('Item one');
-    expect(output).toContain('Item two');
+    expect(output).toContain("> -");
+    expect(output).toContain("Item one");
+    expect(output).toContain("Item two");
   });
 });

--- a/tests/server/markdown-roundtrip.test.ts
+++ b/tests/server/markdown-roundtrip.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import { loadMarkdown, saveMarkdown } from "../../src/server/file-io/markdown.js";
 

--- a/tests/server/mcp-tool-integration.test.ts
+++ b/tests/server/mcp-tool-integration.test.ts
@@ -5,23 +5,22 @@
  * including Zod schema validation, withErrorBoundary wrapping, and
  * mcpSuccess/mcpError response formatting.
  */
-import { describe, it, expect, beforeEach } from "vitest";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
-import { registerDocumentTools } from "../../src/server/mcp/document.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { beforeEach, describe, expect, it } from "vitest";
 import { registerAnnotationTools } from "../../src/server/mcp/annotations.js";
-import { registerNavigationTools } from "../../src/server/mcp/navigation.js";
-import { registerAwarenessTools } from "../../src/server/mcp/awareness.js";
+import { registerAwarenessTools, resetInbox } from "../../src/server/mcp/awareness.js";
+import { populateYDoc, registerDocumentTools } from "../../src/server/mcp/document.js";
 import {
   addDoc,
+  getOpenDocs,
   removeDoc,
   setActiveDocId,
-  getOpenDocs,
 } from "../../src/server/mcp/document-service.js";
-import { populateYDoc } from "../../src/server/mcp/document.js";
-import { resetInbox } from "../../src/server/mcp/awareness.js";
+import { registerNavigationTools } from "../../src/server/mcp/navigation.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 
 let client: Client;
 

--- a/tests/server/mdast-ydoc.test.ts
+++ b/tests/server/mdast-ydoc.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import * as Y from 'yjs';
-import { mdastToYDoc, yDocToMdast } from '../../src/server/file-io/mdast-ydoc.js';
-import { getElementText } from '../../src/server/mcp/document.js';
-import { getFragment } from '../helpers/ydoc-factory.js';
-import type { Root } from 'mdast';
+import { describe, it, expect, afterEach } from "vitest";
+import * as Y from "yjs";
+import { mdastToYDoc, yDocToMdast } from "../../src/server/file-io/mdast-ydoc.js";
+import { getElementText } from "../../src/server/mcp/document.js";
+import { getFragment } from "../helpers/ydoc-factory.js";
+import type { Root } from "mdast";
 
 let doc: Y.Doc;
 
@@ -12,7 +12,7 @@ afterEach(() => {
 });
 
 function makeMdast(children: any[]): Root {
-  return { type: 'root', children };
+  return { type: "root", children };
 }
 
 function loadTree(tree: Root): Y.Doc {
@@ -21,188 +21,254 @@ function loadTree(tree: Root): Y.Doc {
   return doc;
 }
 
-describe('mdastToYDoc — block nodes', () => {
-  it.each([1, 2, 3, 4, 5, 6])('heading depth %i', (depth) => {
-    loadTree(makeMdast([{
-      type: 'heading', depth, children: [{ type: 'text', value: 'Title' }],
-    }]));
+describe("mdastToYDoc — block nodes", () => {
+  it.each([1, 2, 3, 4, 5, 6])("heading depth %i", (depth) => {
+    loadTree(
+      makeMdast([
+        {
+          type: "heading",
+          depth,
+          children: [{ type: "text", value: "Title" }],
+        },
+      ]),
+    );
     const frag = getFragment(doc);
     expect(frag.length).toBe(1);
     const el = frag.get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('heading');
-    expect(el.getAttribute('level')).toBe(depth);
-    expect(getElementText(el)).toBe('Title');
+    expect(el.nodeName).toBe("heading");
+    expect(el.getAttribute("level")).toBe(depth);
+    expect(getElementText(el)).toBe("Title");
   });
 
-  it('paragraph', () => {
-    loadTree(makeMdast([{
-      type: 'paragraph', children: [{ type: 'text', value: 'Hello world' }],
-    }]));
+  it("paragraph", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "Hello world" }],
+        },
+      ]),
+    );
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('paragraph');
-    expect(getElementText(el)).toBe('Hello world');
+    expect(el.nodeName).toBe("paragraph");
+    expect(getElementText(el)).toBe("Hello world");
   });
 
-  it('blockquote with nested paragraph', () => {
-    loadTree(makeMdast([{
-      type: 'blockquote',
-      children: [{ type: 'paragraph', children: [{ type: 'text', value: 'quoted' }] }],
-    }]));
+  it("blockquote with nested paragraph", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "blockquote",
+          children: [{ type: "paragraph", children: [{ type: "text", value: "quoted" }] }],
+        },
+      ]),
+    );
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('blockquote');
+    expect(el.nodeName).toBe("blockquote");
     expect(el.length).toBe(1);
     const inner = el.get(0) as Y.XmlElement;
-    expect(inner.nodeName).toBe('paragraph');
-    expect(getElementText(inner)).toBe('quoted');
+    expect(inner.nodeName).toBe("paragraph");
+    expect(getElementText(inner)).toBe("quoted");
   });
 
-  it('unordered list', () => {
-    loadTree(makeMdast([{
-      type: 'list', ordered: false,
-      children: [
-        { type: 'listItem', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'one' }] }] },
-        { type: 'listItem', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'two' }] }] },
-      ],
-    }]));
+  it("unordered list", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "list",
+          ordered: false,
+          children: [
+            {
+              type: "listItem",
+              children: [{ type: "paragraph", children: [{ type: "text", value: "one" }] }],
+            },
+            {
+              type: "listItem",
+              children: [{ type: "paragraph", children: [{ type: "text", value: "two" }] }],
+            },
+          ],
+        },
+      ]),
+    );
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('bulletList');
+    expect(el.nodeName).toBe("bulletList");
     expect(el.length).toBe(2);
     const item1 = el.get(0) as Y.XmlElement;
-    expect(item1.nodeName).toBe('listItem');
-    expect(getElementText(item1)).toBe('one');
+    expect(item1.nodeName).toBe("listItem");
+    expect(getElementText(item1)).toBe("one");
   });
 
-  it('ordered list with start', () => {
-    loadTree(makeMdast([{
-      type: 'list', ordered: true, start: 5,
-      children: [
-        { type: 'listItem', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'five' }] }] },
-      ],
-    }]));
+  it("ordered list with start", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "list",
+          ordered: true,
+          start: 5,
+          children: [
+            {
+              type: "listItem",
+              children: [{ type: "paragraph", children: [{ type: "text", value: "five" }] }],
+            },
+          ],
+        },
+      ]),
+    );
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('orderedList');
-    expect(el.getAttribute('start')).toBe(5);
+    expect(el.nodeName).toBe("orderedList");
+    expect(el.getAttribute("start")).toBe(5);
   });
 
-  it('code block with language', () => {
-    loadTree(makeMdast([{
-      type: 'code', lang: 'javascript', value: 'const x = 1;\nconsole.log(x);',
-    }]));
+  it("code block with language", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "code",
+          lang: "javascript",
+          value: "const x = 1;\nconsole.log(x);",
+        },
+      ]),
+    );
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('codeBlock');
-    expect(el.getAttribute('language')).toBe('javascript');
-    expect(getElementText(el)).toBe('const x = 1;\nconsole.log(x);');
+    expect(el.nodeName).toBe("codeBlock");
+    expect(el.getAttribute("language")).toBe("javascript");
+    expect(getElementText(el)).toBe("const x = 1;\nconsole.log(x);");
   });
 
-  it('empty code block', () => {
-    loadTree(makeMdast([{ type: 'code', lang: null, value: '' }]));
+  it("empty code block", () => {
+    loadTree(makeMdast([{ type: "code", lang: null, value: "" }]));
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('codeBlock');
-    expect(getElementText(el)).toBe('');
+    expect(el.nodeName).toBe("codeBlock");
+    expect(getElementText(el)).toBe("");
   });
 
-  it('thematic break', () => {
-    loadTree(makeMdast([{ type: 'thematicBreak' }]));
+  it("thematic break", () => {
+    loadTree(makeMdast([{ type: "thematicBreak" }]));
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('horizontalRule');
+    expect(el.nodeName).toBe("horizontalRule");
   });
 
-  it('image', () => {
-    loadTree(makeMdast([{
-      type: 'image', url: 'https://example.com/img.png', alt: 'photo', title: 'My photo',
-    }]));
+  it("image", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "image",
+          url: "https://example.com/img.png",
+          alt: "photo",
+          title: "My photo",
+        },
+      ]),
+    );
     const el = getFragment(doc).get(0) as Y.XmlElement;
-    expect(el.nodeName).toBe('image');
-    expect(el.getAttribute('src')).toBe('https://example.com/img.png');
-    expect(el.getAttribute('alt')).toBe('photo');
-    expect(el.getAttribute('title')).toBe('My photo');
+    expect(el.nodeName).toBe("image");
+    expect(el.getAttribute("src")).toBe("https://example.com/img.png");
+    expect(el.getAttribute("alt")).toBe("photo");
+    expect(el.getAttribute("title")).toBe("My photo");
   });
 
-  it('nested list (2 levels)', () => {
-    loadTree(makeMdast([{
-      type: 'list', ordered: false,
-      children: [{
-        type: 'listItem',
-        children: [
-          { type: 'paragraph', children: [{ type: 'text', value: 'outer' }] },
-          {
-            type: 'list', ordered: false,
-            children: [{
-              type: 'listItem',
-              children: [{ type: 'paragraph', children: [{ type: 'text', value: 'inner' }] }],
-            }],
-          },
-        ],
-      }],
-    }]));
+  it("nested list (2 levels)", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "list",
+          ordered: false,
+          children: [
+            {
+              type: "listItem",
+              children: [
+                { type: "paragraph", children: [{ type: "text", value: "outer" }] },
+                {
+                  type: "list",
+                  ordered: false,
+                  children: [
+                    {
+                      type: "listItem",
+                      children: [
+                        { type: "paragraph", children: [{ type: "text", value: "inner" }] },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]),
+    );
     const list = getFragment(doc).get(0) as Y.XmlElement;
-    expect(list.nodeName).toBe('bulletList');
+    expect(list.nodeName).toBe("bulletList");
     const item = list.get(0) as Y.XmlElement;
-    expect(item.nodeName).toBe('listItem');
+    expect(item.nodeName).toBe("listItem");
     expect(item.length).toBe(2); // paragraph + nested bulletList
     const nested = item.get(1) as Y.XmlElement;
-    expect(nested.nodeName).toBe('bulletList');
+    expect(nested.nodeName).toBe("bulletList");
   });
 });
 
-describe('mdastToYDoc — inline marks', () => {
+describe("mdastToYDoc — inline marks", () => {
   function loadParagraphWithInline(children: any[]): Y.XmlText {
-    loadTree(makeMdast([{ type: 'paragraph', children }]));
+    loadTree(makeMdast([{ type: "paragraph", children }]));
     const el = getFragment(doc).get(0) as Y.XmlElement;
     return el.get(0) as Y.XmlText;
   }
 
-  it('bold text', () => {
+  it("bold text", () => {
     const xmlText = loadParagraphWithInline([
-      { type: 'strong', children: [{ type: 'text', value: 'bold' }] },
+      { type: "strong", children: [{ type: "text", value: "bold" }] },
     ]);
     const delta = xmlText.toDelta();
     expect(delta).toHaveLength(1);
-    expect(delta[0].insert).toBe('bold');
+    expect(delta[0].insert).toBe("bold");
     expect(delta[0].attributes?.bold).toEqual({});
   });
 
-  it('italic text', () => {
+  it("italic text", () => {
     const xmlText = loadParagraphWithInline([
-      { type: 'emphasis', children: [{ type: 'text', value: 'italic' }] },
+      { type: "emphasis", children: [{ type: "text", value: "italic" }] },
     ]);
     const delta = xmlText.toDelta();
     expect(delta[0].attributes?.italic).toEqual({});
   });
 
-  it('strikethrough text', () => {
+  it("strikethrough text", () => {
     const xmlText = loadParagraphWithInline([
-      { type: 'delete', children: [{ type: 'text', value: 'deleted' }] },
+      { type: "delete", children: [{ type: "text", value: "deleted" }] },
     ]);
     const delta = xmlText.toDelta();
     expect(delta[0].attributes?.strike).toEqual({});
   });
 
-  it('inline code', () => {
-    const xmlText = loadParagraphWithInline([
-      { type: 'inlineCode', value: 'console.log' },
-    ]);
+  it("inline code", () => {
+    const xmlText = loadParagraphWithInline([{ type: "inlineCode", value: "console.log" }]);
     const delta = xmlText.toDelta();
-    expect(delta[0].insert).toBe('console.log');
+    expect(delta[0].insert).toBe("console.log");
     expect(delta[0].attributes?.code).toEqual({});
   });
 
-  it('link', () => {
+  it("link", () => {
     const xmlText = loadParagraphWithInline([
-      { type: 'link', url: 'https://example.com', title: 'Example', children: [{ type: 'text', value: 'click' }] },
+      {
+        type: "link",
+        url: "https://example.com",
+        title: "Example",
+        children: [{ type: "text", value: "click" }],
+      },
     ]);
     const delta = xmlText.toDelta();
-    expect(delta[0].insert).toBe('click');
-    expect(delta[0].attributes?.link).toEqual({ href: 'https://example.com', title: 'Example' });
+    expect(delta[0].insert).toBe("click");
+    expect(delta[0].attributes?.link).toEqual({ href: "https://example.com", title: "Example" });
   });
 
-  it('overlapping marks: bold-italic', () => {
+  it("overlapping marks: bold-italic", () => {
     const xmlText = loadParagraphWithInline([
-      { type: 'strong', children: [
-        { type: 'text', value: 'bold ' },
-        { type: 'emphasis', children: [{ type: 'text', value: 'bold-italic' }] },
-        { type: 'text', value: ' bold' },
-      ] },
+      {
+        type: "strong",
+        children: [
+          { type: "text", value: "bold " },
+          { type: "emphasis", children: [{ type: "text", value: "bold-italic" }] },
+          { type: "text", value: " bold" },
+        ],
+      },
     ]);
     const delta = xmlText.toDelta();
     expect(delta).toHaveLength(3);
@@ -213,148 +279,190 @@ describe('mdastToYDoc — inline marks', () => {
     }
 
     // Verify all characters are present (Y.js may reorder segments internally)
-    const fullText = delta.map((op: any) => op.insert).join('');
-    expect(fullText.split('').sort().join('')).toBe('bold bold-italic bold'.split('').sort().join(''));
+    const fullText = delta.map((op: any) => op.insert).join("");
+    expect(fullText.split("").sort().join("")).toBe(
+      "bold bold-italic bold".split("").sort().join(""),
+    );
 
     // The bold-italic segment should have both marks
-    const boldItalic = delta.find((op: any) => op.insert === 'bold-italic');
+    const boldItalic = delta.find((op: any) => op.insert === "bold-italic");
     expect(boldItalic?.attributes?.italic).toEqual({});
 
     // The bold-only segments should NOT have italic
-    const boldOnly = delta.filter((op: any) => op.insert !== 'bold-italic');
+    const boldOnly = delta.filter((op: any) => op.insert !== "bold-italic");
     for (const op of boldOnly) {
       expect(op.attributes?.italic).toBeUndefined();
     }
   });
 
-  it('hardBreak via insertEmbed', () => {
+  it("hardBreak via insertEmbed", () => {
     const xmlText = loadParagraphWithInline([
-      { type: 'text', value: 'before' },
-      { type: 'break' },
-      { type: 'text', value: 'after' },
+      { type: "text", value: "before" },
+      { type: "break" },
+      { type: "text", value: "after" },
     ]);
     const delta = xmlText.toDelta();
     // Should have 3 segments: two text and one embed
     expect(delta.length).toBe(3);
 
-    const textSegments = delta.filter((op: any) => typeof op.insert === 'string');
-    const embedSegments = delta.filter((op: any) => typeof op.insert !== 'string');
+    const textSegments = delta.filter((op: any) => typeof op.insert === "string");
+    const embedSegments = delta.filter((op: any) => typeof op.insert !== "string");
 
-    expect(textSegments.map((op: any) => op.insert).sort()).toEqual(['after', 'before']);
+    expect(textSegments.map((op: any) => op.insert).sort()).toEqual(["after", "before"]);
     expect(embedSegments).toHaveLength(1);
     expect(embedSegments[0].insert).toBeInstanceOf(Y.XmlElement);
-    expect((embedSegments[0].insert as Y.XmlElement).nodeName).toBe('hardBreak');
+    expect((embedSegments[0].insert as Y.XmlElement).nodeName).toBe("hardBreak");
   });
 });
 
-describe('yDocToMdast — reverse conversion', () => {
-  it('heading', () => {
-    loadTree(makeMdast([{
-      type: 'heading', depth: 2, children: [{ type: 'text', value: 'Title' }],
-    }]));
+describe("yDocToMdast — reverse conversion", () => {
+  it("heading", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "heading",
+          depth: 2,
+          children: [{ type: "text", value: "Title" }],
+        },
+      ]),
+    );
     const tree = yDocToMdast(doc);
     expect(tree.children).toHaveLength(1);
     const h = tree.children[0] as any;
-    expect(h.type).toBe('heading');
+    expect(h.type).toBe("heading");
     expect(h.depth).toBe(2);
-    expect(h.children[0].value).toBe('Title');
+    expect(h.children[0].value).toBe("Title");
   });
 
-  it('paragraph with bold', () => {
-    loadTree(makeMdast([{
-      type: 'paragraph',
-      children: [
-        { type: 'text', value: 'plain ' },
-        { type: 'strong', children: [{ type: 'text', value: 'bold' }] },
-      ],
-    }]));
+  it("paragraph with bold", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "paragraph",
+          children: [
+            { type: "text", value: "plain " },
+            { type: "strong", children: [{ type: "text", value: "bold" }] },
+          ],
+        },
+      ]),
+    );
     const tree = yDocToMdast(doc);
     const p = tree.children[0] as any;
-    expect(p.type).toBe('paragraph');
+    expect(p.type).toBe("paragraph");
     // Should have plain text and bold text
     const texts = p.children;
-    expect(texts.some((t: any) => t.type === 'text' && t.value === 'plain ')).toBe(true);
-    expect(texts.some((t: any) => t.type === 'strong')).toBe(true);
+    expect(texts.some((t: any) => t.type === "text" && t.value === "plain ")).toBe(true);
+    expect(texts.some((t: any) => t.type === "strong")).toBe(true);
   });
 
-  it('code block', () => {
-    loadTree(makeMdast([{
-      type: 'code', lang: 'js', value: 'let x = 1;',
-    }]));
+  it("code block", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "code",
+          lang: "js",
+          value: "let x = 1;",
+        },
+      ]),
+    );
     const tree = yDocToMdast(doc);
     const code = tree.children[0] as any;
-    expect(code.type).toBe('code');
-    expect(code.lang).toBe('js');
-    expect(code.value).toBe('let x = 1;');
+    expect(code.type).toBe("code");
+    expect(code.lang).toBe("js");
+    expect(code.value).toBe("let x = 1;");
   });
 
-  it('bulletList', () => {
-    loadTree(makeMdast([{
-      type: 'list', ordered: false,
-      children: [
-        { type: 'listItem', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'a' }] }] },
-        { type: 'listItem', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'b' }] }] },
-      ],
-    }]));
+  it("bulletList", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "list",
+          ordered: false,
+          children: [
+            {
+              type: "listItem",
+              children: [{ type: "paragraph", children: [{ type: "text", value: "a" }] }],
+            },
+            {
+              type: "listItem",
+              children: [{ type: "paragraph", children: [{ type: "text", value: "b" }] }],
+            },
+          ],
+        },
+      ]),
+    );
     const tree = yDocToMdast(doc);
     const list = tree.children[0] as any;
-    expect(list.type).toBe('list');
+    expect(list.type).toBe("list");
     expect(list.ordered).toBe(false);
     expect(list.children).toHaveLength(2);
-    expect(list.children[0].type).toBe('listItem');
+    expect(list.children[0].type).toBe("listItem");
   });
 
-  it('orderedList with start', () => {
-    loadTree(makeMdast([{
-      type: 'list', ordered: true, start: 3,
-      children: [
-        { type: 'listItem', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'c' }] }] },
-      ],
-    }]));
+  it("orderedList with start", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "list",
+          ordered: true,
+          start: 3,
+          children: [
+            {
+              type: "listItem",
+              children: [{ type: "paragraph", children: [{ type: "text", value: "c" }] }],
+            },
+          ],
+        },
+      ]),
+    );
     const tree = yDocToMdast(doc);
     const list = tree.children[0] as any;
-    expect(list.type).toBe('list');
+    expect(list.type).toBe("list");
     expect(list.ordered).toBe(true);
     expect(list.start).toBe(3);
   });
 
-  it('thematic break', () => {
-    loadTree(makeMdast([{ type: 'thematicBreak' }]));
+  it("thematic break", () => {
+    loadTree(makeMdast([{ type: "thematicBreak" }]));
     const tree = yDocToMdast(doc);
-    expect(tree.children[0].type).toBe('thematicBreak');
+    expect(tree.children[0].type).toBe("thematicBreak");
   });
 
-  it('blockquote', () => {
-    loadTree(makeMdast([{
-      type: 'blockquote',
-      children: [{ type: 'paragraph', children: [{ type: 'text', value: 'quoted' }] }],
-    }]));
+  it("blockquote", () => {
+    loadTree(
+      makeMdast([
+        {
+          type: "blockquote",
+          children: [{ type: "paragraph", children: [{ type: "text", value: "quoted" }] }],
+        },
+      ]),
+    );
     const tree = yDocToMdast(doc);
     const bq = tree.children[0] as any;
-    expect(bq.type).toBe('blockquote');
-    expect(bq.children[0].type).toBe('paragraph');
+    expect(bq.type).toBe("blockquote");
+    expect(bq.children[0].type).toBe("paragraph");
   });
 
-  it('empty document', () => {
+  it("empty document", () => {
     doc = new Y.Doc();
     const tree = yDocToMdast(doc);
     expect(tree.children).toHaveLength(0);
   });
 
-  it('delta attribute hash suffix stripping', () => {
+  it("delta attribute hash suffix stripping", () => {
     // Manually create a Y.Doc with hash-suffixed attributes (as y-prosemirror does)
     doc = new Y.Doc();
-    const frag = doc.getXmlFragment('default');
-    const el = new Y.XmlElement('paragraph');
+    const frag = doc.getXmlFragment("default");
+    const el = new Y.XmlElement("paragraph");
     const text = new Y.XmlText();
     el.insert(0, [text]);
-    text.insert(0, 'hashed');
-    text.format(0, 6, { 'bold--abc123': {} });
+    text.insert(0, "hashed");
+    text.format(0, 6, { "bold--abc123": {} });
     frag.insert(0, [el]);
 
     const tree = yDocToMdast(doc);
     const p = tree.children[0] as any;
     // Should recognize as bold despite the hash suffix
-    expect(p.children.some((c: any) => c.type === 'strong')).toBe(true);
+    expect(p.children.some((c: any) => c.type === "strong")).toBe(true);
   });
 });

--- a/tests/server/mdast-ydoc.test.ts
+++ b/tests/server/mdast-ydoc.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, afterEach } from "vitest";
+import type { Root } from "mdast";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import { mdastToYDoc, yDocToMdast } from "../../src/server/file-io/mdast-ydoc.js";
 import { getElementText } from "../../src/server/mcp/document.js";
 import { getFragment } from "../helpers/ydoc-factory.js";
-import type { Root } from "mdast";
 
 let doc: Y.Doc;
 

--- a/tests/server/multi-document.test.ts
+++ b/tests/server/multi-document.test.ts
@@ -1,12 +1,12 @@
-import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
-import { describe, it, expect } from "vitest";
-import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { describe, expect, it } from "vitest";
 import {
   docIdFromPath,
+  extractText,
   getCurrentDoc,
   populateYDoc,
-  extractText,
 } from "../../src/server/mcp/document.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 
 describe("docIdFromPath", () => {
   it("generates stable IDs from the same path", () => {

--- a/tests/server/navigation-tools.test.ts
+++ b/tests/server/navigation-tools.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { extractText, populateYDoc } from "../../src/server/mcp/document.js";
 import {
   addDoc,
+  getOpenDocs,
   removeDoc,
   setActiveDocId,
-  getOpenDocs,
 } from "../../src/server/mcp/document-service.js";
-import { populateYDoc, extractText } from "../../src/server/mcp/document.js";
-import { searchText, findOccurrence, extractContext } from "../../src/server/mcp/navigation.js";
+import { extractContext, findOccurrence, searchText } from "../../src/server/mcp/navigation.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 
 function setupDoc(id: string, text: string) {
   const ydoc = getOrCreateDocument(id);

--- a/tests/server/navigation.test.ts
+++ b/tests/server/navigation.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { escapeRegex } from "../../src/server/mcp/response.js";
 import { extractText } from "../../src/server/mcp/document.js";
 import { searchText } from "../../src/server/mcp/navigation.js";
+import { escapeRegex } from "../../src/server/mcp/response.js";
 import { makeDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;

--- a/tests/server/notifications.test.ts
+++ b/tests/server/notifications.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  pushNotification,
-  subscribe,
   getBuffer,
+  pushNotification,
   resetForTesting,
+  subscribe,
 } from "../../src/server/notifications";
 import type { TandemNotification } from "../../src/shared/types";
 

--- a/tests/server/platform.test.ts
+++ b/tests/server/platform.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, afterEach } from "vitest";
 import net from "net";
 import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
-  SESSION_DIR,
   freePort,
   parseLsofPids,
   parseSsPid,
+  SESSION_DIR,
   waitForPort,
 } from "../../src/server/platform";
 

--- a/tests/server/positions.test.ts
+++ b/tests/server/positions.test.ts
@@ -1,22 +1,22 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
+import { getOrCreateXmlText } from "../../src/server/mcp/document.js";
 import {
-  validateRange,
   anchoredRange,
-  resolveToElement,
   flatOffsetToRelPos,
-  relPosToFlatOffset,
-  refreshRange,
   refreshAllRanges,
+  refreshRange,
+  relPosToFlatOffset,
+  resolveToElement,
+  validateRange,
 } from "../../src/server/positions.js";
+import type { Annotation } from "../../src/shared/types.js";
 import {
-  makeDoc,
   getAnnotationsMap,
   getFragment,
   makeAnnotation,
+  makeDoc,
 } from "../helpers/ydoc-factory.js";
-import { getOrCreateXmlText } from "../../src/server/mcp/document.js";
-import type { Annotation } from "../../src/shared/types.js";
 
 let doc: Y.Doc;
 

--- a/tests/server/provider.test.ts
+++ b/tests/server/provider.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
+import { writeGenerationId } from "../../src/server/mcp/document-service.js";
 import {
-  getOrCreateDocument,
   getDocument,
+  getOrCreateDocument,
   removeDocument,
   setShouldKeepDocument,
 } from "../../src/server/yjs/provider.js";
 import { CTRL_ROOM, Y_MAP_DOCUMENT_META } from "../../src/shared/constants.js";
-import { writeGenerationId } from "../../src/server/mcp/document-service.js";
 
 describe("Y.Doc lifecycle (provider)", () => {
   it("getOrCreateDocument creates a new doc if none exists", () => {

--- a/tests/server/relative-position.test.ts
+++ b/tests/server/relative-position.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import {
-  flatOffsetToRelPos,
-  relPosToFlatOffset,
-  getOrCreateXmlText,
   extractText,
+  flatOffsetToRelPos,
+  getOrCreateXmlText,
+  relPosToFlatOffset,
 } from "../../src/server/mcp/document.js";
-import { makeDoc, getFragment } from "../helpers/ydoc-factory.js";
+import { getFragment, makeDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 

--- a/tests/server/reload.test.ts
+++ b/tests/server/reload.test.ts
@@ -4,20 +4,20 @@
  * refreshAllRanges + textSnapshot-based relocation.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { makeDoc, getAnnotationsMap, makeAnnotation } from "../helpers/ydoc-factory.js";
-import { populateYDoc, extractText } from "../../src/server/mcp/document-model.js";
+import { MCP_ORIGIN } from "../../src/server/events/queue.js";
 import { loadMarkdown } from "../../src/server/file-io/markdown.js";
+import { extractText, populateYDoc } from "../../src/server/mcp/document-model.js";
 import {
+  anchoredRange,
   refreshAllRanges,
   refreshRange,
   validateRange,
-  anchoredRange,
 } from "../../src/server/positions.js";
-import { MCP_ORIGIN } from "../../src/server/events/queue.js";
-import type { Annotation } from "../../src/shared/types.js";
 import { toFlatOffset } from "../../src/shared/positions/types.js";
+import type { Annotation } from "../../src/shared/types.js";
+import { getAnnotationsMap, makeAnnotation, makeDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 

--- a/tests/server/response.test.ts
+++ b/tests/server/response.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-  mcpSuccess,
-  mcpError,
-  noDocumentError,
-  getErrorMessage,
   escapeRegex,
+  getErrorMessage,
+  mcpError,
+  mcpSuccess,
+  noDocumentError,
   withErrorBoundary,
 } from "../../src/server/mcp/response.js";
 

--- a/tests/server/session-restore.test.ts
+++ b/tests/server/session-restore.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
-import * as Y from "yjs";
 import fs from "fs/promises";
 import path from "path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
 import { CTRL_ROOM } from "../../src/shared/constants";
 
 // Isolate session tests in a unique temp directory to avoid races with other test files
@@ -16,14 +16,14 @@ vi.mock("../../src/server/platform", async (importOriginal) => {
   };
 });
 
+import { SESSION_DIR } from "../../src/server/platform";
 import {
-  saveSession,
   deleteSession,
   listSessionFilePaths,
   saveCtrlSession,
+  saveSession,
   sessionKey,
 } from "../../src/server/session/manager";
-import { SESSION_DIR } from "../../src/server/platform";
 
 // Unique paths to avoid collisions with other tests
 const TEST_FILES = [

--- a/tests/server/session.test.ts
+++ b/tests/server/session.test.ts
@@ -1,8 +1,8 @@
-import { Y_MAP_ANNOTATIONS, Y_MAP_CHAT, Y_MAP_DOCUMENT_META } from "../../src/shared/constants.js";
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
-import * as Y from "yjs";
 import fs from "fs/promises";
 import path from "path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+import { Y_MAP_ANNOTATIONS, Y_MAP_CHAT, Y_MAP_DOCUMENT_META } from "../../src/shared/constants.js";
 
 // Isolate session tests in a unique temp directory to avoid races with other test files
 vi.mock("../../src/server/platform", async (importOriginal) => {
@@ -16,18 +16,18 @@ vi.mock("../../src/server/platform", async (importOriginal) => {
   };
 });
 
-import {
-  saveSession,
-  loadSession,
-  restoreYDoc,
-  sourceFileChanged,
-  sessionKey,
-  deleteSession,
-  saveCtrlSession,
-  loadCtrlSession,
-  restoreCtrlDoc,
-} from "../../src/server/session/manager";
 import { SESSION_DIR } from "../../src/server/platform";
+import {
+  deleteSession,
+  loadCtrlSession,
+  loadSession,
+  restoreCtrlDoc,
+  restoreYDoc,
+  saveCtrlSession,
+  saveSession,
+  sessionKey,
+  sourceFileChanged,
+} from "../../src/server/session/manager";
 
 describe("Session persistence", () => {
   beforeAll(async () => {

--- a/tests/shared/offsets.test.ts
+++ b/tests/shared/offsets.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { headingPrefixLength, headingPrefix, FLAT_SEPARATOR } from "../../src/shared/offsets";
+import { describe, expect, it } from "vitest";
+import { FLAT_SEPARATOR, headingPrefix, headingPrefixLength } from "../../src/shared/offsets";
 
 describe("headingPrefixLength", () => {
   it("returns 0 for null/undefined/0", () => {

--- a/tests/shared/offsets.test.ts
+++ b/tests/shared/offsets.test.ts
@@ -1,36 +1,32 @@
-import { describe, it, expect } from 'vitest';
-import {
-  headingPrefixLength,
-  headingPrefix,
-  FLAT_SEPARATOR,
-} from '../../src/shared/offsets';
+import { describe, it, expect } from "vitest";
+import { headingPrefixLength, headingPrefix, FLAT_SEPARATOR } from "../../src/shared/offsets";
 
-describe('headingPrefixLength', () => {
-  it('returns 0 for null/undefined/0', () => {
+describe("headingPrefixLength", () => {
+  it("returns 0 for null/undefined/0", () => {
     expect(headingPrefixLength(null)).toBe(0);
     expect(headingPrefixLength(undefined)).toBe(0);
     expect(headingPrefixLength(0)).toBe(0);
   });
 
-  it('returns level + 1 for heading levels', () => {
-    expect(headingPrefixLength(1)).toBe(2);  // "# "
-    expect(headingPrefixLength(2)).toBe(3);  // "## "
-    expect(headingPrefixLength(3)).toBe(4);  // "### "
-    expect(headingPrefixLength(4)).toBe(5);  // "#### "
-    expect(headingPrefixLength(6)).toBe(7);  // "###### "
+  it("returns level + 1 for heading levels", () => {
+    expect(headingPrefixLength(1)).toBe(2); // "# "
+    expect(headingPrefixLength(2)).toBe(3); // "## "
+    expect(headingPrefixLength(3)).toBe(4); // "### "
+    expect(headingPrefixLength(4)).toBe(5); // "#### "
+    expect(headingPrefixLength(6)).toBe(7); // "###### "
   });
 });
 
-describe('headingPrefix', () => {
-  it('builds correct prefix strings', () => {
-    expect(headingPrefix(1)).toBe('# ');
-    expect(headingPrefix(2)).toBe('## ');
-    expect(headingPrefix(3)).toBe('### ');
+describe("headingPrefix", () => {
+  it("builds correct prefix strings", () => {
+    expect(headingPrefix(1)).toBe("# ");
+    expect(headingPrefix(2)).toBe("## ");
+    expect(headingPrefix(3)).toBe("### ");
   });
 });
 
-describe('FLAT_SEPARATOR', () => {
-  it('is a newline', () => {
-    expect(FLAT_SEPARATOR).toBe('\n');
+describe("FLAT_SEPARATOR", () => {
+  it("is a newline", () => {
+    expect(FLAT_SEPARATOR).toBe("\n");
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,26 +1,26 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import path from 'path';
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
 
 export default defineConfig({
   plugins: [react()],
-  root: '.',
+  root: ".",
   resolve: {
     alias: {
-      '@shared': path.resolve(__dirname, 'src/shared'),
-      '@client': path.resolve(__dirname, 'src/client'),
+      "@shared": path.resolve(__dirname, "src/shared"),
+      "@client": path.resolve(__dirname, "src/client"),
     },
   },
   server: {
     port: 5173,
     proxy: {
-      '/ws': {
-        target: 'ws://localhost:3478',
+      "/ws": {
+        target: "ws://localhost:3478",
         ws: true,
       },
     },
   },
   build: {
-    outDir: 'dist/client',
+    outDir: "dist/client",
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vitest/config";
 import path from "path";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,21 +1,21 @@
-import { defineConfig } from 'vitest/config';
-import path from 'path';
+import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
   resolve: {
     alias: {
-      '@shared': path.resolve(__dirname, 'src/shared'),
-      '@server': path.resolve(__dirname, 'src/server'),
-      '@client': path.resolve(__dirname, 'src/client'),
+      "@shared": path.resolve(__dirname, "src/shared"),
+      "@server": path.resolve(__dirname, "src/server"),
+      "@client": path.resolve(__dirname, "src/client"),
     },
   },
   test: {
-    include: ['tests/**/*.test.ts'],
+    include: ["tests/**/*.test.ts"],
     coverage: {
-      provider: 'v8',
+      provider: "v8",
       include: [
-        'src/client/editor/extensions/annotation.ts',
-        'src/client/editor/extensions/awareness.ts',
+        "src/client/editor/extensions/annotation.ts",
+        "src/client/editor/extensions/awareness.ts",
       ],
     },
   },


### PR DESCRIPTION
Closes #232

## Summary

Preventive hardening of two E2E selectors per CLAUDE.md rule #7 ("E2E tests use data-testid attributes"). Adds `data-testid="held-banner"` to the held-annotation banner `<span>` and `data-testid="clear-filters-btn"` to the filter Clear `<button>` in `SidePanel.tsx`, then swaps the matching locators in `tests/e2e/settings-and-filters.spec.ts` from text/role matchers to `getByTestId`.

**Not a flake fix.** Git log shows no flakiness touching this spec — the current selectors work today. But the Clear button text-match would silently break if the label changed to "Reset" or got i18n'd, and the `/\d+ annotation(s)? held/` regex couples the test to exact copy. Testids decouple both.

## Scope notes

- The `heldBanner` `const` at line ~196 is reused by three assertions (lines 196, 211, 221). One binding-site edit fixes all three.
- **Preserved content contract.** Dropping the regex locator removes an implicit "has a count + correct pluralization" assertion. Added `await expect(heldBanner).toHaveText(/\d+ annotation(s)? held/)` alongside the existing `toBeVisible()` in the Solo-mode branch to keep that guarantee.
- **Accepted tradeoff.** Swapping `getByRole("button", { name: "Clear" })` for `getByTestId` drops the implicit `role=button` + accessible-name check. The "Clear-filters button resets scroll" test is about scroll behavior, not a11y, so this is intentional — a11y regressions on that element would need a dedicated test.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 909/909 pass
- [ ] `npx playwright test tests/e2e/settings-and-filters.spec.ts` — manual at Gate 1
- [ ] Verify the Solo-mode test still asserts banner count + pluralization via the new `toHaveText`