### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-editor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-editor",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Collaborative AI-human document editor with MCP tool integration for Claude",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Bump version to 0.3.1 for post-Wave-4 cleanup release.

## What landed in 0.3.1
- **#237** docs: formalize agent-driven issue pipeline workflow
- **#238** fix: normalize CRLF line endings across the repo (closes #229)
- **#239** fix(e2e): Playwright webServer root-cause fix — run against pre-built server to avoid Windows stdio deadlock (closes #230)
- **#240** fix(scripts): make `capture:screenshots` cross-platform via `cross-env` (closes #231)
- **#241** test(e2e): add data-testids to SidePanel Clear button and held banner (closes #232)
- **#242** refactor(types): tighten PanelLayout with discriminated union (closes part of #233)

Plus Phase G fold-in: `.github/workflows/publish.yml` bumped from node 20 → 22 to match `engines`.

## Test plan
- [ ] CI green
- [ ] Tag `v0.3.1` created after merge
- [ ] GitHub release published

🤖 Generated with [Claude Code](https://claude.com/claude-code)