### PR TITLE
refactor(types): remove unused overlay annotation kind (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,6 @@ All notable changes to Tandem will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-04-07
-
-### Wave 4: Notification & Interruption Redesign
-
-- **Solo/Tandem mode** replaces All/Urgent/Paused interruption controls (#207, #226)
-- **Dwell-time selection events** — selections fire after 1s hold (#188)
-- **Configurable layout** — tabbed or three-panel, with settings popover (#206)
-- **Click-to-navigate** — click annotated text to jump to annotation card
-- **Tab badges** — notification counts on inactive panel tabs
-- **Skill-directed response routing** — Claude responds in chat panel, not terminal
-- Review banner replaced with per-annotation toasts (#208, landed earlier)
-- `Y_MAP_MODE` constant, Zod validation for mode reads, error logging in channel event bridge
-- 894 tests passing
-
-## [0.3.2] - 2026-04-12
-
-### Removed
-
-- **MCP wire change:** Removed unused `"overlay"` annotation kind from `AnnotationTypeSchema`. No internal code path produced or consumed it, but external clients sending `type: "overlay"` to annotation filtering or creation tools will now receive a Zod validation error. Use `comment`, `suggestion`, `question`, or `flag` instead. Node-anchored analytical overlays (ADR-005, `OverlayEntry` / `OverlayDefinition`) are unrelated and unchanged.
-
 ## [Unreleased]
 
 ### Added
@@ -41,6 +21,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Toolbar wraps to a second row on narrow windows instead of overflowing; inline inputs shrink responsively (#192)
 - Edit button on annotation cards now shows a visible "✎ Edit" label instead of icon-only (#201)
+
+## [0.3.2] - 2026-04-12
+
+### Removed
+
+- **MCP wire change:** Removed unused `"overlay"` annotation kind from `AnnotationTypeSchema`. No internal code path produced or consumed it, but external clients sending `type: "overlay"` to annotation filtering or creation tools will now receive a Zod validation error. Use `comment`, `suggestion`, `question`, or `flag` instead. Node-anchored analytical overlays (ADR-005, `OverlayEntry` / `OverlayDefinition`) are unrelated and unchanged.
+
+## [0.3.0] - 2026-04-07
+
+### Wave 4: Notification & Interruption Redesign
+
+- **Solo/Tandem mode** replaces All/Urgent/Paused interruption controls (#207, #226)
+- **Dwell-time selection events** — selections fire after 1s hold (#188)
+- **Configurable layout** — tabbed or three-panel, with settings popover (#206)
+- **Click-to-navigate** — click annotated text to jump to annotation card
+- **Tab badges** — notification counts on inactive panel tabs
+- **Skill-directed response routing** — Claude responds in chat panel, not terminal
+- Review banner replaced with per-annotation toasts (#208, landed earlier)
+- `Y_MAP_MODE` constant, Zod validation for mode reads, error logging in channel event bridge
+- 894 tests passing
 
 ## [0.2.12] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Y_MAP_MODE` constant, Zod validation for mode reads, error logging in channel event bridge
 - 894 tests passing
 
+## [0.3.2] - 2026-04-12
+
+### Removed
+
+- **MCP wire change:** Removed unused `"overlay"` annotation kind from `AnnotationTypeSchema`. No internal code path produced or consumed it, but external clients sending `type: "overlay"` to annotation filtering or creation tools will now receive a Zod validation error. Use `comment`, `suggestion`, `question`, or `flag` instead. Node-anchored analytical overlays (ADR-005, `OverlayEntry` / `OverlayDefinition`) are unrelated and unchanged.
+
 ## [Unreleased]
 
 ### Added

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -452,7 +452,7 @@ Read all annotations, optionally filtered. For checking new user actions, prefer
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `author` | enum | no | `user`, `claude`, or `import` |
-| `type` | enum | no | `highlight`, `comment`, `suggestion`, `overlay`, `question`, `flag` |
+| `type` | enum | no | `highlight`, `comment`, `suggestion`, `question`, `flag` |
 | `status` | enum | no | `pending`, `accepted`, `dismissed` |
 | `documentId` | string | no | Target document ID (defaults to active document) |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-editor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-editor",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Collaborative AI-human document editor with MCP tool integration for Claude",
   "repository": {
     "type": "git",

--- a/src/cli/skill-content.ts
+++ b/src/cli/skill-content.ts
@@ -47,7 +47,7 @@ Choose the right type for each finding:
 - **\`tandem_suggest\`** — Specific text replacement. **Prefer over comment when you can provide replacement text** — the user gets one-click accept/reject. Cannot create new paragraphs.
 - **\`tandem_flag\`** — Factual errors, compliance risks, missing required content. Signals a blocking issue the user must address before the document ships.
 
-**User-created types:** \`question\` and \`overlay\` annotations are created by users, not Claude. When you see a \`question\` in \`tandem_checkInbox\` or \`tandem_getAnnotations\`, respond with a \`tandem_comment\` on the same range or \`tandem_reply\` for conversational answers.
+**User-created types:** \`question\` annotation is created by users, not Claude. When you see a \`question\` in \`tandem_checkInbox\` or \`tandem_getAnnotations\`, respond with a \`tandem_comment\` on the same range or \`tandem_reply\` for conversational answers.
 
 ## Collaboration Mode
 

--- a/src/server/file-io/docx.ts
+++ b/src/server/file-io/docx.ts
@@ -55,7 +55,7 @@ export function exportAnnotations(doc: Y.Doc, annotations: Annotation[]): string
   } satisfies Record<AnnotationType, string>;
 
   for (const [type, anns] of Object.entries(groups) as [AnnotationType, Annotation[]][]) {
-    lines.push(`## ${typeLabels[type] || type}`, "");
+    lines.push(`## ${typeLabels[type]}`, "");
 
     for (const ann of anns) {
       const snippet = safeSlice(fullText, ann.range.from, ann.range.to);

--- a/src/server/file-io/docx.ts
+++ b/src/server/file-io/docx.ts
@@ -3,7 +3,7 @@
 
 import mammoth from "mammoth";
 import * as Y from "yjs";
-import type { Annotation } from "../../shared/types.js";
+import type { Annotation, AnnotationType } from "../../shared/types.js";
 import { getElementText } from "../mcp/document-model.js";
 
 // Re-export for backward compatibility — consumers can import from either module
@@ -37,25 +37,24 @@ export function exportAnnotations(doc: Y.Doc, annotations: Annotation[]): string
   const fragment = doc.getXmlFragment("default");
   const fullText = extractFullText(fragment);
 
-  const groups: Record<string, Annotation[]> = {};
+  const groups: Partial<Record<AnnotationType, Annotation[]>> = {};
   for (const ann of annotations) {
     const key = ann.type;
     if (!groups[key]) groups[key] = [];
-    groups[key].push(ann);
+    groups[key]?.push(ann);
   }
 
   const lines: string[] = ["# Document Review", ""];
 
-  const typeLabels: Record<string, string> = {
+  const typeLabels = {
     highlight: "Highlights",
     comment: "Comments",
     suggestion: "Suggestions",
-    overlay: "Overlays",
     question: "Questions",
     flag: "Flags",
-  };
+  } satisfies Record<AnnotationType, string>;
 
-  for (const [type, anns] of Object.entries(groups)) {
+  for (const [type, anns] of Object.entries(groups) as [AnnotationType, Annotation[]][]) {
     lines.push(`## ${typeLabels[type] || type}`, "");
 
     for (const ann of anns) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,7 +17,6 @@ export const AnnotationTypeSchema = z.enum([
   "highlight",
   "comment",
   "suggestion",
-  "overlay",
   "question",
   "flag",
 ]);


### PR DESCRIPTION
Closes #247

## Summary

Removes the `"overlay"` value from `AnnotationTypeSchema` — no code path produces or consumes it. Bumps to 0.3.2 (MCP wire change, flagged in CHANGELOG). Also adds `satisfies Record<AnnotationType, string>` to the docx export label map as a compile-time consistency guard (caught no drift this time, but closes a silent-failure path identified in Phase B review).

## Files changed

- `src/shared/types.ts` — drop `overlay` from the `AnnotationTypeSchema` enum
- `src/server/file-io/docx.ts` — drop `overlay:` label + add `satisfies Record<AnnotationType, string>` guard; tighten `groups` to `Partial<Record<AnnotationType, Annotation[]>>` so the iteration stays type-safe
- `src/cli/skill-content.ts` — update skill text (`question` is the only user-created type now)
- `docs/mcp-tools.md` — update `tandem_getAnnotations` type filter enum
- `CHANGELOG.md` — new `[0.3.2] - 2026-04-12` section above `[Unreleased]`
- `package.json` / `package-lock.json` — version bump to 0.3.2

## Notes

- Did **not** rename `[Unreleased]` → `[0.3.1]`. Phase B silent-failure review verified that the polish items currently in `[Unreleased]` don't match the 0.3.0→0.3.1 commit range, so renaming would be historical revisionism. Filing a follow-up to reconcile.
- `OverlayEntry` / `OverlayDefinition` (ADR-005 node-anchored analytical overlays) are unrelated and unchanged.
- The `satisfies` guard surfaced a real type-safety issue: `Object.entries(groups)` widens keys to `string`, which no longer indexes the tightened `typeLabels`. Fixed by typing `groups` as `Partial<Record<AnnotationType, Annotation[]>>` and casting the `Object.entries` result. This is the kind of drift the guard was added to catch — net positive.

## Test plan

### Build & static checks

- [x] `npm run typecheck` — passes cleanly
- [x] `npm run lint` — 0 errors (109 pre-existing warnings, unchanged)
- [x] `npm test -- --run` — full suite passes (909/909)
- [x] `npm run build` — full production build succeeds

### Grep verification

- [x] `grep -rn '"overlay"' src/ tests/` — zero matches
- [x] `grep -n '\boverlay\b' docs/mcp-tools.md` — zero matches
- [x] Spot-checked `docs/architecture.md`, `docs/decisions.md` — still reference `overlay` for the unrelated analytical-overlay system (unchanged)

### Version bump

- [x] `package.json` reads `"version": "0.3.2"`
- [x] `package-lock.json` root and `""` packages entry both read `"version": "0.3.2"`
- [x] `CHANGELOG.md` has `## [0.3.2] - 2026-04-12` section above `## [Unreleased]` with the Removed entry
- [x] `CHANGELOG.md` `[Unreleased]` section is unchanged

### Runtime verification (Gate 2 — manual)

- [ ] Start Tandem (`npm run dev:standalone`)
- [ ] From Claude Code, call `tandem_getAnnotations({ type: "comment" })` — returns normally
- [ ] From Claude Code, call `tandem_getAnnotations({ type: "highlight" })` — returns normally
- [ ] From Claude Code, call `tandem_getAnnotations({ type: "question" })` — returns normally
- [ ] From Claude Code, call `tandem_getAnnotations({ type: "flag" })` — returns normally
- [ ] From Claude Code, call `tandem_getAnnotations({ type: "suggestion" })` — returns normally
- [ ] From Claude Code, call `tandem_getAnnotations({ type: "overlay" })` — **must** return a Zod validation error. Capture the verbatim error message; acceptable form: `Invalid enum value. Expected 'highlight' | 'comment' | 'suggestion' | 'question' | 'flag', received 'overlay'`. If the error is generic (`Invalid arguments`), file a follow-up to add `.describe()` on the filter param.

### Skill-content verification

- [ ] Re-run `tandem setup` against a test Claude Code install (or inspect the generated skill file) — confirm the skill content no longer mentions `overlay` as a user-created type

### Follow-up

- [ ] File `docs: reconcile CHANGELOG [Unreleased] with 0.3.1 release` referencing Phase B silent-failure finding B1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
