### PR TITLE
chore(lint): extend biome and lint-staged to cover .mjs files (#246 partial)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -3,7 +3,8 @@
     "enabled": true,
     "indentStyle": "space",
     "indentWidth": 2,
-    "lineWidth": 100
+    "lineWidth": 100,
+    "lineEnding": "lf"
   },
   "javascript": {
     "formatter": {
@@ -19,7 +20,8 @@
     "includes": [
       "src/**/*.{ts,tsx,json}",
       "tests/**/*.{ts,tsx}",
-      "scripts/**/*.{ts,tsx}",
+      "scripts/**/*.{ts,tsx,mjs}",
+      "packages/**/*.{ts,tsx,mjs}",
       "*.{ts,json}",
       "!dist/**",
       "!node_modules/**",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
       "eslint --fix",
       "biome format --write"
     ],
+    "*.mjs": [
+      "eslint --fix",
+      "biome format --write"
+    ],
     "*.json !package-lock.json": [
       "biome format --write"
     ]

--- a/package.json
+++ b/package.json
@@ -61,14 +61,14 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",
-      "biome format --write"
+      "biome check --write"
     ],
     "*.mjs": [
       "eslint --fix",
-      "biome format --write"
+      "biome check --write"
     ],
     "*.json !package-lock.json": [
-      "biome format --write"
+      "biome check --write"
     ]
   },
   "dependencies": {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -8,9 +8,9 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import { request } from "node:http";
 import { createConnection } from "node:net";
 import { join } from "node:path";
-import { request } from "node:http";
 
 // Keep in sync with src/shared/constants.ts (can't import TS from standalone .mjs)
 const WS_PORT = 3478;
@@ -106,7 +106,9 @@ function checkMcpJson() {
   // Check tandem-channel entry
   const channel = servers["tandem-channel"];
   if (!channel) {
-    warn(".mcp.json missing tandem-channel — Claude will use polling instead of push notifications");
+    warn(
+      ".mcp.json missing tandem-channel — Claude will use polling instead of push notifications",
+    );
   } else {
     const cmd = channel.command;
     const args = (channel.args || []).join(" ");
@@ -121,7 +123,10 @@ function checkMcpJson() {
     }
 
     if (!channel.env?.TANDEM_URL) {
-      warn("tandem-channel missing TANDEM_URL env var", 'Add "env": {"TANDEM_URL": "http://localhost:3479"}');
+      warn(
+        "tandem-channel missing TANDEM_URL env var",
+        'Add "env": {"TANDEM_URL": "http://localhost:3479"}',
+      );
     }
   }
 }
@@ -144,7 +149,10 @@ function checkUserMcpConfig() {
   try {
     config = JSON.parse(readFileSync(claudeCodePath, "utf-8"));
   } catch (err) {
-    warn(`~/.claude/mcp_settings.json is malformed JSON: ${err.message}`, "Run: tandem setup to rewrite it");
+    warn(
+      `~/.claude/mcp_settings.json is malformed JSON: ${err.message}`,
+      "Run: tandem setup to rewrite it",
+    );
     return;
   }
 
@@ -234,7 +242,10 @@ async function checkHealth() {
   }
 
   if (result.error) {
-    fail(`Server not responding on localhost:${MCP_PORT} (${result.error})`, "npm run dev:standalone");
+    fail(
+      `Server not responding on localhost:${MCP_PORT} (${result.error})`,
+      "npm run dev:standalone",
+    );
     return false;
   }
 
@@ -260,21 +271,17 @@ async function checkHealth() {
 
 function checkSseEndpoint() {
   return new Promise((resolve) => {
-    const req = request(
-      `http://127.0.0.1:${MCP_PORT}/api/events`,
-      { timeout: 2000 },
-      (res) => {
-        // SSE endpoint responds with 200 and text/event-stream
-        req.destroy(); // don't hold the connection open
-        const ct = res.headers["content-type"] || "";
-        if (res.statusCode === 200 && ct.includes("text/event-stream")) {
-          pass("SSE event stream reachable (/api/events)");
-        } else {
-          warn(`/api/events responded with status ${res.statusCode}, content-type: ${ct}`);
-        }
-        resolve();
-      },
-    );
+    const req = request(`http://127.0.0.1:${MCP_PORT}/api/events`, { timeout: 2000 }, (res) => {
+      // SSE endpoint responds with 200 and text/event-stream
+      req.destroy(); // don't hold the connection open
+      const ct = res.headers["content-type"] || "";
+      if (res.statusCode === 200 && ct.includes("text/event-stream")) {
+        pass("SSE event stream reachable (/api/events)");
+      } else {
+        warn(`/api/events responded with status ${res.statusCode}, content-type: ${ct}`);
+      }
+      resolve();
+    });
     req.on("error", (err) => {
       warn(`/api/events not reachable: ${err.message}`);
       resolve();

--- a/scripts/take-screenshots.mjs
+++ b/scripts/take-screenshots.mjs
@@ -6,12 +6,12 @@
  * Run with: node scripts/take-screenshots.mjs
  */
 
-import { chromium } from "@playwright/test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { chromium } from "@playwright/test";
 import fs from "fs";
-import path from "path";
 import os from "os";
+import path from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -155,7 +155,10 @@ async function main() {
     const toastDismissBtns = page.locator('[data-testid^="toast-dismiss-"]');
     const toastCount = await toastDismissBtns.count();
     for (let i = 0; i < toastCount; i++) {
-      try { await toastDismissBtns.nth(0).click(); await sleep(200); } catch {}
+      try {
+        await toastDismissBtns.nth(0).click();
+        await sleep(200);
+      } catch {}
     }
     await sleep(500);
 
@@ -165,7 +168,11 @@ async function main() {
     for (const ann of annList) {
       if (ann.status === "pending" && ann.id?.startsWith("tutorial-")) {
         try {
-          await mcp.call("tandem_resolveAnnotation", { annotationId: ann.id, action: "dismiss", documentId: docId });
+          await mcp.call("tandem_resolveAnnotation", {
+            annotationId: ann.id,
+            action: "dismiss",
+            documentId: docId,
+          });
         } catch {}
       }
     }
@@ -258,7 +265,10 @@ async function main() {
     const toastDismissBtns2 = page.locator('[data-testid^="toast-dismiss-"]');
     const toastCount2 = await toastDismissBtns2.count();
     for (let i = 0; i < toastCount2; i++) {
-      try { await toastDismissBtns2.nth(0).click(); await sleep(200); } catch {}
+      try {
+        await toastDismissBtns2.nth(0).click();
+        await sleep(200);
+      } catch {}
     }
     await sleep(500);
 
@@ -368,7 +378,9 @@ async function main() {
     const chatInput = page.locator('[data-testid="chat-input"]').first();
     if (await chatInput.isVisible({ timeout: 2000 }).catch(() => false)) {
       await chatInput.click();
-      await chatInput.fill("Can you look at the sample content section? The timeline details feel vague.");
+      await chatInput.fill(
+        "Can you look at the sample content section? The timeline details feel vague.",
+      );
       await page.keyboard.press("Enter");
       await sleep(800);
     }


### PR DESCRIPTION
Partial fix for #246.

## Summary

Closes the `.mjs` CI coverage gap identified in PR #238's Phase B review: `scripts/doctor.mjs`, `scripts/take-screenshots.mjs`, and `packages/tandem-doc/bin/tandem.mjs` are now checked by `npx biome check .` (CI) and normalized by pre-commit lint-staged.

Also **swaps lint-staged from `biome format --write` to `biome check --write`** across all three entries (`*.{ts,tsx}`, `*.mjs`, `*.json`). Phase F silent-failure review empirically verified that `biome format --write` exits 0 on files with organize-imports drift — it runs only the formatter pass, not Biome 2.x's `assist/source/organizeImports`. CI runs `npx biome check .`, so staged files with import drift slid through pre-commit and then broke CI. The scope expansion to `*.{ts,tsx}` / `*.json` is intentional: the same silent failure existed for those rules, and narrow-scoping would have left the bug in place for every other file type.

Pins `"lineEnding": "lf"` in `biome.json` defensively (Biome 2.x already defaults to `"lf"`, but making it explicit protects against a future default change silently re-introducing CRLF).

Includes a one-time biome normalization pass (format + `organizeImports`) for the two `scripts/*.mjs` files the new scope surfaced — required for `biome check .` to exit 0 on CI. `packages/tandem-doc/bin/tandem.mjs` was already clean.

## What's NOT included

The original issue asked for `.yml`, `.md`, and `.sh` coverage. Phase B review (two independent agents) empirically verified that **Biome 2.4.8 does NOT support YAML or Markdown formatters** — `biome format --write` silently ignores those extensions, and adding them to `files.includes` would break `biome check .`. Shipping `.yml`/`.md` coverage requires a different tool (Prettier or a small custom normalizer) and is tracked as a follow-up issue.

Shell scripts (`.sh`) remain covered by `.gitattributes:16` (`*.sh text eol=lf`), which is sufficient for EOL normalization without any Biome involvement.

## Files changed

- `biome.json` — add `formatter.lineEnding: "lf"`, extend `scripts/**` glob, add `packages/**` glob
- `package.json` — add `*.mjs` lint-staged rule, swap all three entries from `biome format --write` to `biome check --write`
- `scripts/doctor.mjs`, `scripts/take-screenshots.mjs` — mechanical biome format + organize-imports pass (no behavior change)

## Test plan

- [x] `npx biome check .` exits 0 with new scope (170+ files) on CI
- [x] `npm run format` produces no uncommitted diffs after the normalization commit
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors; pre-existing `no-explicit-any` warnings unchanged)
- [x] `npm test -- --run` passes (909 tests)
- [x] `npm run build` succeeds (tsup + vite)
- [x] **SF1 verified empirically:** throwaway `.mjs` with drifted imports → `biome check --write` rewrites them; `biome format --write` leaves them untouched (exit 0)
- [x] **SF1 end-to-end:** staged drifted `.mjs` → `git commit` → husky → lint-staged → `biome check --write` → committed file is sorted
- [x] **SF3 footgun verified:** `git commit -a` on a dirty drifted `.mjs` correctly triggers lint-staged, which rewrites the drift before the commit lands (no drifted commit possible via `-a`)

Full Phase G verification details in `.pipeline-state/issue-246/phase-g-report.md`.

## Follow-up

- `chore(lint-staged): add prettier-based .yml and .md EOL normalization` — to be filed, references this PR and the Phase B findings on the Biome 2.4.8 formatter limitation.
- `chore(dev): normalize Windows working-tree line endings` — to be filed. `core.autocrlf=true` on Windows leaves `.mjs`/`.ts`/etc. with CRLF in the working tree even though `.gitattributes eol=lf` marks them LF. `biome check .` fails locally as a result. Pre-existing on master — this PR does not introduce it, but it's worth fixing so contributors can run the formatter locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
