### PR TITLE
test(e2e): add functional dwell-time selection pipeline test (#234)

### DIFF
--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "@playwright/test";
 import path from "path";
 import {
+  DEFAULT_MCP_PORT,
   LEFT_PANEL_WIDTH_KEY,
   PANEL_WIDTH_KEY,
+  SELECTION_DWELL_DEFAULT_MS,
   TANDEM_MODE_KEY,
   TANDEM_SETTINGS_KEY,
 } from "../../src/shared/constants";
@@ -23,7 +25,26 @@ test.beforeEach(async () => {
   tmpDir = createFixtureDir("sample.md");
 });
 
-test.afterEach(async () => {
+test.afterEach(async ({ page }) => {
+  // Explicitly close any test-scoped EventSource before tearing down the
+  // page. Playwright creates fresh pages per test by default, so in
+  // practice this guards against fixture-sharing regressions and leaves
+  // a clean slate if anyone ever converts this file to a shared-page
+  // fixture layout. Wrapped in try/catch because the page may already
+  // be closed on failure paths.
+  try {
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __tandemEventSource?: EventSource;
+        __tandemEvents?: unknown[];
+      };
+      w.__tandemEventSource?.close();
+      w.__tandemEventSource = undefined;
+      w.__tandemEvents = undefined;
+    });
+  } catch {
+    // Page already closed — nothing to tear down.
+  }
   await cleanupAllOpenDocuments(mcp);
   await mcp.close();
   cleanupFixtureDir(tmpDir);
@@ -750,3 +771,206 @@ test("dwell-time slider value persists across reload", async ({ page }) => {
   const reloadedSlider = page.locator("[data-testid='dwell-time-slider']");
   await expect(reloadedSlider).toHaveValue("2000");
 });
+
+// Bridge-layer coverage that cannot be exercised by
+// `tests/server/event-queue-dwell.test.ts:122` ("respects custom dwell time
+// from CTRL_ROOM awareness"). The unit test writes directly to the server-side
+// CTRL_ROOM awareness map and drives `vi.advanceTimersByTime`, bypassing:
+//   1. SettingsPopover → useTandemSettings → localStorage persistence
+//   2. App.tsx useEffect → awareness.set(Y_MAP_DWELL_MS, value) broadcast
+//   3. Hocuspocus client → server sync of CTRL_ROOM awareness
+//   4. awareness.ts editor extension writing real DOM selection into
+//      per-document user awareness
+//   5. SSE channel delivery through /api/events
+// This E2E proves all five links are wired correctly; do not delete it as
+// "already covered by unit tests."
+test("dwell-time slider value is honored by the selection event pipeline", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+
+  await page.goto("/");
+  await expect(page.locator(".ProseMirror")).toBeVisible({ timeout: 10_000 });
+
+  // --- Step 0: Reset CTRL_ROOM dwell to default before doing anything.
+  // CTRL_ROOM's Y_MAP_DWELL_MS is server-side state shared across every
+  // E2E test within the same webServer lifetime. Playwright's per-context
+  // isolation does NOT reset it, so a preceding test that set dwell=2000
+  // (the persistence test above) would leave stale CTRL_ROOM state. Without
+  // this reset, the negative-window assertion below can pass for the wrong
+  // reason (stale 2000ms value happens to exceed the 1500ms negative wait).
+  //
+  // Route through the slider UI so App.tsx's broadcast useEffect fires, which
+  // is the only non-invasive way to rewrite CTRL_ROOM's awareness map.
+  // We bounce through a non-default value first to guarantee React's onChange
+  // fires (React skips no-op value writes on controlled inputs, and a fresh
+  // page's in-memory state is already SELECTION_DWELL_DEFAULT_MS so a
+  // direct single write of that value would be a no-op that neither persists
+  // to localStorage nor triggers App.tsx's broadcast effect).
+  const bounceValue = SELECTION_DWELL_DEFAULT_MS + 100;
+  await setDwellSliderValue(page, bounceValue);
+  await setDwellSliderValue(page, SELECTION_DWELL_DEFAULT_MS);
+  await expect
+    .poll(
+      async () =>
+        page.evaluate((key) => {
+          const raw = localStorage.getItem(key);
+          return raw ? (JSON.parse(raw) as { selectionDwellMs?: number }).selectionDwellMs : null;
+        }, TANDEM_SETTINGS_KEY),
+      { timeout: 2_000 },
+    )
+    .toBe(SELECTION_DWELL_DEFAULT_MS);
+  // Give the Hocuspocus client a beat to push the awareness write to the
+  // server before we start relying on it.
+  await page.waitForTimeout(250);
+  // Close the popover so future clicks in the editor dispatch selection.
+  await page.keyboard.press("Escape");
+
+  // --- Step 3: Subscribe to SSE with an absolute URL.
+  // `page.evaluate(() => new EventSource("/api/events"))` would resolve
+  // against the page origin (Vite :5173), which does NOT proxy /api/events.
+  // Must be absolute to the MCP HTTP server (:3479).
+  const eventsUrl = `http://localhost:${DEFAULT_MCP_PORT}/api/events`;
+  await page.evaluate((url) => {
+    (window as unknown as { __tandemEvents: unknown[] }).__tandemEvents = [];
+    const es = new EventSource(url);
+    (window as unknown as { __tandemEventSource: EventSource }).__tandemEventSource = es;
+    es.onmessage = (e: MessageEvent) => {
+      try {
+        (window as unknown as { __tandemEvents: unknown[] }).__tandemEvents.push(
+          JSON.parse(e.data),
+        );
+      } catch {
+        // Ignore keepalives or non-JSON comment lines.
+      }
+    };
+  }, eventsUrl);
+
+  // --- Step 4: Open settings popover and set slider to 2500ms.
+  await setDwellSliderValue(page, 2500);
+
+  // --- Step 5: Pre-assertion — localStorage reflects the broadcast.
+  // Catches broadcast-key regressions without requiring timing. If this
+  // fails, the pipeline is broken upstream of the server and there's no
+  // point proceeding to the timing checks.
+  const savedDwell = await page.evaluate((key) => {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as { selectionDwellMs?: number }).selectionDwellMs : null;
+  }, TANDEM_SETTINGS_KEY);
+  expect(savedDwell).toBe(2500);
+
+  // --- Step 6: Close settings popover so selection clicks reach the editor.
+  await page.keyboard.press("Escape");
+  await expect(page.locator("[data-testid='settings-popover']")).toBeHidden({ timeout: 2_000 });
+
+  // --- Step 7: Wait for SSE subscription to be OPEN before making the
+  // selection. Without this, the test can silently false-pass because the
+  // selection event fires before the subscription was established.
+  await page.waitForFunction(
+    () =>
+      (window as unknown as { __tandemEventSource?: EventSource }).__tandemEventSource
+        ?.readyState === 1, // EventSource.OPEN
+    null,
+    { timeout: 5_000 },
+  );
+
+  // Give the awareness write from setDwellSliderValue a beat to propagate to
+  // the server — otherwise the selection dwell timer we're about to trigger
+  // would schedule with the stale value.
+  await page.waitForTimeout(250);
+
+  // --- Step 8: Make a real selection in the editor. Mirror how the
+  // persistence test dispatches events: use the ProseMirror DOM API via
+  // Playwright so the editor's awareness plugin picks it up exactly as a
+  // human-driven selection would.
+  const prose = page.locator(".ProseMirror");
+  await prose.click(); // focus the editor
+  // Select the phrase "Test Document" in the H1. `selectText()` selects
+  // the entire element; for a steady, non-trivial selection that's fine
+  // since the awareness plugin writes the range with truncated text.
+  await prose.locator("h1").first().selectText();
+
+  // Mark start time so we can assert the negative window wasn't cut short
+  // by CI runner scheduling. Not a strict guard, but a diagnostic hook.
+  const negativeStart = Date.now();
+
+  // --- Step 9: Negative window (fixed wait).
+  // The default dwell is 1000ms. A regression to default would fire at
+  // ~1000ms — this 1500ms wait catches that with 500ms of headroom. Any
+  // faster-than-2500ms regression (500ms, 0ms, etc.) is also caught.
+  await page.waitForTimeout(1500);
+  const negativeElapsed = Date.now() - negativeStart;
+  // Diagnostic: a runner preempted for >1500ms would extend the wait,
+  // so < 1500 is only possible via clock skew. Log it as a warning rather
+  // than failing so CI artifacts show the shape of the flake if it happens.
+  if (negativeElapsed < 1500) {
+    console.warn(
+      `[test] negative-window wait returned early: ${negativeElapsed}ms; this should not happen`,
+    );
+  }
+
+  const afterNegative = await page.evaluate(
+    () => (window as unknown as { __tandemEvents: unknown[] }).__tandemEvents?.length ?? 0,
+  );
+  expect(
+    afterNegative,
+    "selection:changed fired before the configured dwell elapsed — slider is not controlling the server pipeline",
+  ).toBe(0);
+
+  // --- Step 10: Positive window (bounded poll).
+  // Total time-of-selection budget: up to 1500 (neg) + 4000 (poll) = 5500ms,
+  // well over the 2500ms dwell even on a slow CI. The poll cadence is
+  // [100, 200, 400] so we settle quickly once the event lands.
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(
+          () => (window as unknown as { __tandemEvents: unknown[] }).__tandemEvents?.length ?? 0,
+        ),
+      { timeout: 4_000, intervals: [100, 200, 400] },
+    )
+    .toBeGreaterThanOrEqual(1);
+
+  // Verify the received event shape — at least one must be a
+  // selection:changed for a real document (not CTRL_ROOM), with a
+  // non-empty selectedText payload matching what we selected.
+  const events = (await page.evaluate(
+    () => (window as unknown as { __tandemEvents: unknown[] }).__tandemEvents ?? [],
+  )) as Array<{
+    type?: string;
+    documentId?: string;
+    payload?: { selectedText?: string };
+  }>;
+  const selectionEvents = events.filter((e) => e?.type === "selection:changed");
+  expect(selectionEvents.length).toBeGreaterThanOrEqual(1);
+  const first = selectionEvents[0];
+  expect(first.documentId).toBeTruthy();
+  expect(first.documentId).not.toBe("tandem:ctrl"); // CTRL_ROOM is reserved
+  expect(first.payload?.selectedText ?? "").toContain("Test Document");
+});
+
+/**
+ * Open the settings popover (if not already open), set the dwell-time slider
+ * to the given value, and verify the input reflects it. Uses the React
+ * native-setter trick so React's onChange actually fires — a plain `.fill()`
+ * doesn't round-trip through React's controlled-input tracking. Leaves the
+ * popover open. Safe to call repeatedly.
+ */
+async function setDwellSliderValue(
+  page: import("@playwright/test").Page,
+  value: number,
+): Promise<void> {
+  const popover = page.locator("[data-testid='settings-popover']");
+  const isOpen = await popover.isVisible().catch(() => false);
+  if (!isOpen) {
+    await page.locator("[data-testid='settings-btn']").click();
+    await expect(popover).toBeVisible({ timeout: 2_000 });
+  }
+  const slider = page.locator("[data-testid='dwell-time-slider']");
+  await expect(slider).toBeVisible({ timeout: 2_000 });
+  await slider.evaluate((el, v) => {
+    const input = el as HTMLInputElement;
+    const nativeSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    nativeSetter?.call(input, String(v));
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  }, value);
+  await expect(slider).toHaveValue(String(value));
+}

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import path from "path";
 import {
+  CTRL_ROOM,
   DEFAULT_MCP_PORT,
   LEFT_PANEL_WIDTH_KEY,
   PANEL_WIDTH_KEY,
@@ -38,6 +39,9 @@ test.afterEach(async ({ page }) => {
         __tandemEventSource?: EventSource;
         __tandemEvents?: unknown[];
       };
+      // Most tests in this file never open an EventSource — short-circuit
+      // the teardown so we don't pay a round-trip on every test.
+      if (!w.__tandemEventSource && !w.__tandemEvents) return;
       w.__tandemEventSource?.close();
       w.__tandemEventSource = undefined;
       w.__tandemEvents = undefined;
@@ -785,7 +789,18 @@ test("dwell-time slider value persists across reload", async ({ page }) => {
 // This E2E proves all five links are wired correctly; do not delete it as
 // "already covered by unit tests."
 test("dwell-time slider value is honored by the selection event pipeline", async ({ page }) => {
-  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  // Capture the fixture's documentId so the positive assertion below can
+  // match against the actual document, not just `toBeTruthy()`. This closes
+  // a silent-failure hole: without the strict match, a selection event from
+  // an unrelated document (or a future regression that leaks CTRL_ROOM
+  // events) would pass the check trivially.
+  const openResult = (await mcp.callTool("tandem_open", {
+    filePath: path.join(tmpDir, "sample.md"),
+  })) as { error: false; data: { documentId: string } } | { error: true };
+  if (openResult.error !== false) {
+    throw new Error("tandem_open failed in dwell-time test setup");
+  }
+  const fixtureDocId = openResult.data.documentId;
 
   await page.goto("/");
   await expect(page.locator(".ProseMirror")).toBeVisible({ timeout: 10_000 });
@@ -822,7 +837,11 @@ test("dwell-time slider value is honored by the selection event pipeline", async
   // server before we start relying on it.
   await page.waitForTimeout(250);
   // Close the popover so future clicks in the editor dispatch selection.
+  // Wait for the hidden state explicitly — otherwise the next
+  // `setDwellSliderValue(2500)` call races the close animation and its
+  // `isVisible()` branch would skip the re-open click.
   await page.keyboard.press("Escape");
+  await expect(page.locator("[data-testid='settings-popover']")).toBeHidden({ timeout: 2_000 });
 
   // --- Step 3: Subscribe to SSE with an absolute URL.
   // `page.evaluate(() => new EventSource("/api/events"))` would resolve
@@ -942,8 +961,13 @@ test("dwell-time slider value is honored by the selection event pipeline", async
   const selectionEvents = events.filter((e) => e?.type === "selection:changed");
   expect(selectionEvents.length).toBeGreaterThanOrEqual(1);
   const first = selectionEvents[0];
-  expect(first.documentId).toBeTruthy();
-  expect(first.documentId).not.toBe("tandem:ctrl"); // CTRL_ROOM is reserved
+  // Strict positive match against the fixture's actual documentId. This
+  // implicitly excludes CTRL_ROOM (which is `CTRL_ROOM` from shared
+  // constants, not the previously-hardcoded "tandem:ctrl" literal that
+  // could never match anything), and also catches any regression that
+  // leaks an event from an unrelated document into this test's context.
+  expect(first.documentId).toBe(fixtureDocId);
+  expect(first.documentId).not.toBe(CTRL_ROOM);
   expect(first.payload?.selectedText ?? "").toContain("Test Document");
 });
 


### PR DESCRIPTION
Closes #234

## Summary

Adds a functional end-to-end test that proves the dwell-time slider actually controls the selection event pipeline, not just persists to localStorage. The existing persistence test (`dwell-time slider value persists across reload`) only round-trips through localStorage — this new test subscribes to the `/api/events` SSE stream, sets the slider to 2500ms, holds a real DOM selection in the editor, then asserts:

- **Negative window (1500ms fixed wait):** zero `selection:changed` events have fired. This catches regressions to the default dwell (1000ms) or any faster-than-configured pipeline.
- **Positive window (`expect.poll` bounded at 4000ms):** at least one `selection:changed` event has landed with a `documentId` for a real document (not `tandem:ctrl`) and a payload `selectedText` matching what we selected.

The asymmetry is deliberate: strict negative window catches regressions, lenient positive window absorbs CI jitter.

This closes the bridge-layer gap between `tests/server/event-queue-dwell.test.ts:122` (unit test that writes directly to server-side CTRL_ROOM) and the user-visible setting. The five links the E2E covers that the unit test cannot: SettingsPopover persistence, App.tsx broadcast effect, Hocuspocus client→server awareness sync, the `awareness.ts` editor extension writing real ProseMirror selections, and SSE delivery through `/api/events`.

## Phase B amendments applied

- **SSE URL absolute** — uses `http://localhost:${DEFAULT_MCP_PORT}/api/events` instead of a relative URL, which would resolve against Vite `:5173` (no proxy) and silently produce zero events.
- **CTRL_ROOM reset in step 0** — routes through the slider UI with a bounce through `DEFAULT + 100` then back to `DEFAULT`, forcing React's onChange to fire even though the fresh page already has the default value in memory. Prevents a stale `Y_MAP_DWELL_MS` from a preceding test from making the negative-window assertion pass for the wrong reason.
- **`afterEach` EventSource teardown** — explicit `close()` + `undefined` on the window hooks, wrapped in try/catch so it survives failure-path page closures.
- **`waitForFunction readyState === 1 (OPEN)`** — SSE subscription readiness check before making the selection, preventing silent false-pass where events fire before the subscription is active.
- **`expect.poll` positive window** — bounded at 4000ms with `[100, 200, 400]` intervals, rather than a fixed `waitForTimeout`.

## Test plan

- [x] `npx playwright test tests/e2e/settings-and-filters.spec.ts -g "honored by the selection event pipeline"` passes locally
- [x] `--repeat-each=3` stability check (3/3 passes)
- [x] `npm run test:e2e` full suite passes (27 passed + 1 pre-existing skipped)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no new warnings)
- [ ] Manual regression check: temporarily change `App.tsx:228` to broadcast a hardcoded `1000` and confirm the test FAILS on the negative-window assertion
- [ ] Manual regression check: temporarily change `getDwellMs()` in `queue.ts` to always return `SELECTION_DWELL_DEFAULT_MS` and confirm the test FAILS on the negative-window assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
