### PR TITLE
chore(lint-staged): add EOL normalizer for .yml and .md files

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
     ],
     "*.json !package-lock.json": [
       "biome check --write"
+    ],
+    "*.{yml,yaml,md}": [
+      "node scripts/normalize-eol.mjs"
     ]
   },
   "dependencies": {

--- a/scripts/normalize-eol.mjs
+++ b/scripts/normalize-eol.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+// Normalizes CRLF → LF and ensures a trailing newline for file types
+// that Biome 2.x doesn't format (YAML, Markdown). Used by lint-staged.
+import { readFileSync, writeFileSync } from "fs";
+
+for (const file of process.argv.slice(2)) {
+  const original = readFileSync(file, "utf8");
+  const normalized = original.replace(/\r\n/g, "\n").trimEnd() + "\n";
+  if (normalized !== original) {
+    writeFileSync(file, normalized, "utf8");
+  }
+}

--- a/scripts/normalize-eol.mjs
+++ b/scripts/normalize-eol.mjs
@@ -4,9 +4,13 @@
 import { readFileSync, writeFileSync } from "fs";
 
 for (const file of process.argv.slice(2)) {
-  const original = readFileSync(file, "utf8");
-  const normalized = original.replace(/\r\n/g, "\n").trimEnd() + "\n";
-  if (normalized !== original) {
-    writeFileSync(file, normalized, "utf8");
+  try {
+    const original = readFileSync(file, "utf8");
+    const normalized = original.replace(/\r\n?/g, "\n").trimEnd() + "\n";
+    if (normalized !== original) {
+      writeFileSync(file, normalized, "utf8");
+    }
+  } catch (err) {
+    console.error(`normalize-eol: skipping ${file}: ${err.message}`);
   }
 }


### PR DESCRIPTION
## Summary
- Adds `scripts/normalize-eol.mjs` — a lightweight Node script that normalizes CRLF→LF and ensures trailing newlines
- Wires it into lint-staged for `*.{yml,yaml,md}` files
- No new dependencies — Biome 2.x doesn't support YAML/Markdown formatting, so this fills the gap for EOL enforcement

## Test plan
- [x] Smoke-tested: `printf "line1\r\nline2\r\n" > /tmp/test.md && node scripts/normalize-eol.mjs /tmp/test.md` → LF output with trailing newline
- [x] Pre-commit hook runs clean (lint-staged recognizes the new entry)
- [ ] Stage a `.md` with CRLF, verify commit rewrites to LF
- [ ] `npx biome check .` still passes (no routing conflict)

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)