### PR TITLE
feat(ui): default to three-panel layout

### DIFF
--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -19,10 +19,10 @@ export interface TandemSettings {
 }
 
 const DEFAULTS: TandemSettings = {
-  layout: "tabbed",
+  layout: "three-panel",
   primaryTab: "chat",
   panelOrder: "chat-editor-annotations",
-  editorWidthPercent: 100,
+  editorWidthPercent: 50,
   selectionDwellMs: SELECTION_DWELL_DEFAULT_MS,
 };
 
@@ -41,13 +41,19 @@ export function loadSettings(): TandemSettings {
     if (saved) {
       const parsed = JSON.parse(saved);
       return {
-        layout: parsed.layout === "three-panel" ? "three-panel" : "tabbed",
+        layout:
+          parsed.layout === "three-panel" || parsed.layout === "tabbed"
+            ? parsed.layout
+            : DEFAULTS.layout,
         primaryTab: parsed.primaryTab === "annotations" ? "annotations" : "chat",
         panelOrder:
           parsed.panelOrder === "annotations-editor-chat"
             ? "annotations-editor-chat"
             : "chat-editor-annotations",
-        editorWidthPercent: Math.max(50, Math.min(100, Number(parsed.editorWidthPercent) || 100)),
+        editorWidthPercent: Math.max(
+          50,
+          Math.min(100, Number(parsed.editorWidthPercent) || DEFAULTS.editorWidthPercent),
+        ),
         selectionDwellMs: Math.max(
           SELECTION_DWELL_MIN_MS,
           Math.min(

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -48,6 +48,8 @@ describe("loadSettings — selectionDwellMs clamping", () => {
 
   it("returns default when no settings are stored", () => {
     const settings = loadSettings();
+    expect(settings.layout).toBe("three-panel");
+    expect(settings.editorWidthPercent).toBe(50);
     expect(settings.selectionDwellMs).toBe(SELECTION_DWELL_DEFAULT_MS);
   });
 


### PR DESCRIPTION
## Summary
- Changes default layout from `"tabbed"` to `"three-panel"` in `useTandemSettings.ts`
- Changes default `editorWidthPercent` from `100` to `50` (appropriate for three-panel)
- Fixes `loadSettings()` to fall back to `DEFAULTS` instead of hardcoded values, so partial localStorage entries inherit the correct default
- Existing users are unaffected — localStorage overrides persist their chosen layout

## Test plan
- [x] `npm run typecheck` clean
- [x] `vitest run tests/client/useTandemSettings.test.ts` — 11/11 pass
- [ ] Fresh browser (clear localStorage): loads three-panel layout
- [ ] Existing user with `layout: "tabbed"` in localStorage: stays tabbed
- [ ] Manual verify: chat left, editor center, annotations right

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)