### PR TITLE
chore(deps): pin Hocuspocus and Y.js versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "tandem-editor",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-editor",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@hocuspocus/provider": "^3.4.4",
-        "@hocuspocus/server": "^2.13.0",
+        "@hocuspocus/provider": "3.4.4",
+        "@hocuspocus/server": "2.15.3",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.7.0",
@@ -49,9 +49,9 @@
         "remark-stringify": "^11.0.0",
         "unified": "^11.0.0",
         "update-notifier": "^7.3.1",
-        "y-prosemirror": "^1.2.12",
-        "y-protocols": "^1.0.6",
-        "yjs": "^13.6.0",
+        "y-prosemirror": "1.3.7",
+        "y-protocols": "1.0.7",
+        "yjs": "13.6.30",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     ]
   },
   "dependencies": {
-    "@hocuspocus/provider": "^3.4.4",
-    "@hocuspocus/server": "^2.13.0",
+    "@hocuspocus/provider": "3.4.4",
+    "@hocuspocus/server": "2.15.3",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.7.0",
@@ -114,9 +114,9 @@
     "remark-stringify": "^11.0.0",
     "unified": "^11.0.0",
     "update-notifier": "^7.3.1",
-    "y-prosemirror": "^1.2.12",
-    "y-protocols": "^1.0.6",
-    "yjs": "^13.6.0",
+    "y-prosemirror": "1.3.7",
+    "y-protocols": "1.0.7",
+    "yjs": "13.6.30",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Pins @hocuspocus/server, @hocuspocus/provider, yjs, y-prosemirror, and y-protocols to exact versions
- Prevents surprise breaking changes from minor/patch semver updates
- Pinned to currently-installed versions (not floor versions) to avoid peer dependency conflicts

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 951/951 pass
- [ ] `npm run dev:standalone` starts both frontend and backend
- [ ] WebSocket connection to :3478 works

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)