### PR TITLE
feat(tauri): add text zoom with keyboard shortcuts

### DIFF
--- a/src-tauri/capabilities/desktop.json
+++ b/src-tauri/capabilities/desktop.json
@@ -10,6 +10,7 @@
   ],
   "permissions": [
     "window-state:default",
-    "updater:default"
+    "updater:default",
+    "webview:allow-set-webview-zoom"
   ]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
         "minWidth": 800,
         "minHeight": 600,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "zoomHotkeysEnabled": true
       }
     ],
     "security": {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -28,6 +28,7 @@ import { useReviewCompletion } from "./hooks/useReviewCompletion";
 import { useTabOrder } from "./hooks/useTabOrder";
 import { useTandemSettings } from "./hooks/useTandemSettings";
 import { useTutorial } from "./hooks/useTutorial";
+import { useWebViewZoom } from "./hooks/useWebViewZoom";
 import { useYjsSync } from "./hooks/useYjsSync";
 import type { PanelLayout } from "./panel-layout";
 import { ChatPanel } from "./panels/ChatPanel";
@@ -142,6 +143,8 @@ function loadPanelWidth(side: PanelSide): number {
 }
 
 export default function App() {
+  useWebViewZoom();
+
   const {
     tabs,
     activeTabId,

--- a/src/client/hooks/useWebViewZoom.ts
+++ b/src/client/hooks/useWebViewZoom.ts
@@ -15,11 +15,14 @@ import { ZOOM_DEFAULT, ZOOM_MAX, ZOOM_MIN, ZOOM_STORAGE_KEY } from "../../shared
  */
 export function useWebViewZoom(): void {
   useEffect(() => {
+    let tornDown = false;
     let cleanup: (() => void) | undefined;
 
     // Dynamic import — silently fails outside Tauri, making the hook a no-op
     import("@tauri-apps/api/webview")
       .then(({ getCurrentWebview }) => {
+        if (tornDown) return; // Component already unmounted
+
         const webview = getCurrentWebview();
 
         // Restore persisted zoom level
@@ -30,6 +33,8 @@ export function useWebViewZoom(): void {
             const parsed = Number(raw);
             if (Number.isFinite(parsed)) {
               currentZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, parsed));
+            } else {
+              console.warn(`[tandem] ignoring invalid stored zoom: ${raw}`);
             }
           }
         } catch {
@@ -37,7 +42,9 @@ export function useWebViewZoom(): void {
         }
 
         if (currentZoom !== ZOOM_DEFAULT) {
-          webview.setZoom(currentZoom).catch(() => {});
+          webview.setZoom(currentZoom).catch((err: unknown) => {
+            console.warn("[tandem] failed to restore zoom level:", err);
+          });
         }
 
         function persist(zoom: number): void {
@@ -57,7 +64,9 @@ export function useWebViewZoom(): void {
           e.stopPropagation();
 
           currentZoom = ZOOM_DEFAULT;
-          webview.setZoom(ZOOM_DEFAULT).catch(() => {});
+          webview.setZoom(ZOOM_DEFAULT).catch((err: unknown) => {
+            console.warn("[tandem] failed to reset zoom:", err);
+          });
           persist(ZOOM_DEFAULT);
         };
 
@@ -91,6 +100,9 @@ export function useWebViewZoom(): void {
         // Not running in Tauri — hook is a no-op
       });
 
-    return () => cleanup?.();
+    return () => {
+      tornDown = true;
+      cleanup?.();
+    };
   }, []);
 }

--- a/src/client/hooks/useWebViewZoom.ts
+++ b/src/client/hooks/useWebViewZoom.ts
@@ -1,0 +1,96 @@
+import { useEffect } from "react";
+import { ZOOM_DEFAULT, ZOOM_MAX, ZOOM_MIN, ZOOM_STORAGE_KEY } from "../../shared/constants";
+
+/**
+ * Persists and restores WebView zoom level in Tauri desktop builds.
+ *
+ * - On mount: reads zoom from localStorage, clamps it, and applies via Tauri's
+ *   `webview.setZoom()`.
+ * - Ctrl+0 / Cmd+0: resets zoom to 1.0 and persists.
+ * - Native Ctrl+Plus/Minus zoom is handled by `zoomHotkeysEnabled` in
+ *   tauri.conf.json — this hook does NOT duplicate those handlers. It does
+ *   intercept those keys (after they fire natively) to track the current zoom
+ *   level for persistence, since Tauri has no `getZoom()` API.
+ * - Complete no-op in non-Tauri environments (dynamic import fails gracefully).
+ */
+export function useWebViewZoom(): void {
+  useEffect(() => {
+    let cleanup: (() => void) | undefined;
+
+    // Dynamic import — silently fails outside Tauri, making the hook a no-op
+    import("@tauri-apps/api/webview")
+      .then(({ getCurrentWebview }) => {
+        const webview = getCurrentWebview();
+
+        // Restore persisted zoom level
+        let currentZoom = ZOOM_DEFAULT;
+        try {
+          const raw = localStorage.getItem(ZOOM_STORAGE_KEY);
+          if (raw !== null) {
+            const parsed = Number(raw);
+            if (Number.isFinite(parsed)) {
+              currentZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, parsed));
+            }
+          }
+        } catch {
+          // localStorage unavailable (incognito, storage-disabled)
+        }
+
+        if (currentZoom !== ZOOM_DEFAULT) {
+          webview.setZoom(currentZoom).catch(() => {});
+        }
+
+        function persist(zoom: number): void {
+          try {
+            localStorage.setItem(ZOOM_STORAGE_KEY, String(zoom));
+          } catch {
+            // localStorage unavailable
+          }
+        }
+
+        // Ctrl+0 / Cmd+0 reset — capture phase fires before Tiptap swallows it
+        const handleReset = (e: KeyboardEvent) => {
+          const mod = e.metaKey || e.ctrlKey;
+          if (!mod || e.key !== "0") return;
+
+          e.preventDefault();
+          e.stopPropagation();
+
+          currentZoom = ZOOM_DEFAULT;
+          webview.setZoom(ZOOM_DEFAULT).catch(() => {});
+          persist(ZOOM_DEFAULT);
+        };
+
+        // Track zoom changes from native Ctrl+Plus/Minus for persistence.
+        // Tauri's zoomHotkeysEnabled handles the actual zoom; we just update
+        // our tracked level. The native zoom step is ~10% per keypress.
+        const ZOOM_STEP = 0.1;
+        const handleZoomTrack = (e: KeyboardEvent) => {
+          const mod = e.metaKey || e.ctrlKey;
+          if (!mod) return;
+
+          // "=" is the unshifted key for "+" on US/intl keyboards
+          const isZoomIn = e.key === "+" || e.key === "=";
+          const isZoomOut = e.key === "-" || e.key === "_";
+          if (!isZoomIn && !isZoomOut) return;
+
+          const next = isZoomIn ? currentZoom + ZOOM_STEP : currentZoom - ZOOM_STEP;
+          currentZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round(next * 100) / 100));
+          persist(currentZoom);
+        };
+
+        window.addEventListener("keydown", handleReset, { capture: true });
+        window.addEventListener("keydown", handleZoomTrack, { capture: true });
+
+        cleanup = () => {
+          window.removeEventListener("keydown", handleReset, { capture: true });
+          window.removeEventListener("keydown", handleZoomTrack, { capture: true });
+        };
+      })
+      .catch(() => {
+        // Not running in Tauri — hook is a no-op
+      });
+
+    return () => cleanup?.();
+  }, []);
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -107,3 +107,9 @@ export const CHANNEL_RETRY_DELAY_MS = 2_000;
 
 /** Tauri WebView origin hostname — must be accepted alongside localhost. */
 export const TAURI_HOSTNAME = "tauri.localhost";
+
+// Zoom persistence (Tauri desktop)
+export const ZOOM_STORAGE_KEY = "tandem:zoomLevel";
+export const ZOOM_MIN = 0.5;
+export const ZOOM_MAX = 2.0;
+export const ZOOM_DEFAULT = 1.0;


### PR DESCRIPTION
## Summary
- Enables native Ctrl+Plus/Minus zoom via tauri.conf.json `zoomHotkeysEnabled`
- Persists zoom level to localStorage, restores on app load
- Ctrl+0 resets zoom to 100%
- No-op in non-Tauri (web) environments
- Zoom clamped to 50%-200% range

## Test plan
- [x] typecheck clean
- [x] tests pass (951/951)
- [ ] Tauri: Ctrl+Plus zooms in, Ctrl+Minus zooms out
- [ ] Tauri: Ctrl+0 resets to 100%
- [ ] Tauri: close/reopen — zoom persists
- [ ] Web: no zoom behavior added (browser handles it)

Closes #258