### PR TITLE
feat(authorship): track user vs Claude text (#190)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -20,6 +20,7 @@ import { ReviewOnlyBanner } from "./components/ReviewOnlyBanner";
 import { SettingsPopover } from "./components/SettingsPopover";
 import { ToastContainer } from "./components/ToastContainer";
 import { Editor } from "./editor/Editor";
+import { authorshipPluginKey } from "./editor/extensions/authorship";
 import { Toolbar } from "./editor/toolbar/Toolbar";
 import { useFileDrop } from "./hooks/useFileDrop";
 import { useModeGate } from "./hooks/useModeGate";
@@ -232,6 +233,17 @@ export default function App() {
     const awareness = bootstrapYdoc.getMap(Y_MAP_USER_AWARENESS);
     awareness.set(Y_MAP_DWELL_MS, settings.selectionDwellMs);
   }, [settings.selectionDwellMs, bootstrapYdoc]);
+
+  // Dispatch authorship toggle to the ProseMirror plugin when the setting changes
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const tr = editor.state.tr.setMeta(authorshipPluginKey, {
+      type: "toggle",
+      visible: settings.showAuthorship,
+    });
+    editor.view.dispatch(tr);
+  }, [settings.showAuthorship]);
 
   const [reviewMode, setReviewMode] = useState(false);
   const [showChat, setShowChat] = useState(() => settings.primaryTab === "chat");

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -259,6 +259,34 @@ export function SettingsPopover({
         </div>
       </div>
 
+      {/* Authorship tracking toggle */}
+      <div>
+        <div style={sectionLabelStyle}>Authorship</div>
+        <label
+          data-testid="authorship-toggle"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            cursor: "pointer",
+            fontSize: "12px",
+            color: "#374151",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={settings.showAuthorship}
+            onChange={(e) => onUpdate({ showAuthorship: e.target.checked })}
+            style={{ accentColor: "#6366f1" }}
+          />
+          <span>Show who wrote what</span>
+        </label>
+        <div style={{ fontSize: "10px", color: "#9ca3af", marginTop: "4px" }}>
+          Highlights text by author: <span style={{ color: "#3b82f6" }}>you</span> /{" "}
+          <span style={{ color: "#22c55e" }}>Claude</span>
+        </div>
+      </div>
+
       {/* Selection sensitivity (dwell time) */}
       <div>
         <div style={sectionLabelStyle}>

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -283,7 +283,7 @@ export function SettingsPopover({
         </label>
         <div style={{ fontSize: "10px", color: "#9ca3af", marginTop: "4px" }}>
           Highlights text by author: <span style={{ color: "#3b82f6" }}>you</span> /{" "}
-          <span style={{ color: "#22c55e" }}>Claude</span>
+          <span style={{ color: "#ea8a1e" }}>Claude</span>
         </div>
       </div>
 

--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -15,6 +15,7 @@ import React, { useCallback, useEffect } from "react";
 import * as Y from "yjs";
 import { USER_NAME_DEFAULT, USER_NAME_KEY } from "../../shared/constants.js";
 import { AnnotationExtension } from "./extensions/annotation";
+import { AuthorshipExtension } from "./extensions/authorship";
 import { AwarenessExtension } from "./extensions/awareness";
 
 interface EditorProps {
@@ -71,6 +72,7 @@ export function Editor({
           },
         }),
         AnnotationExtension.configure({ ydoc }),
+        AuthorshipExtension.configure({ ydoc }),
         AwarenessExtension.configure({ ydoc }),
       ],
       editorProps: {
@@ -192,6 +194,11 @@ export function Editor({
           outline-offset: 1px;
           border-radius: 2px;
         }
+
+        /* Authorship decorations — user=blue, claude=green */
+        .tandem-authorship { border-radius: 2px; transition: background 0.2s; }
+        .tandem-authorship--user { background: rgba(59, 130, 246, 0.08); }
+        .tandem-authorship--claude { background: rgba(34, 197, 94, 0.08); }
 
         /* Claude focus paragraph */
         .tandem-claude-focus {

--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -195,10 +195,10 @@ export function Editor({
           border-radius: 2px;
         }
 
-        /* Authorship decorations — user=blue, claude=green */
-        .tandem-authorship { border-radius: 2px; transition: background 0.2s; }
-        .tandem-authorship--user { background: rgba(59, 130, 246, 0.08); }
-        .tandem-authorship--claude { background: rgba(34, 197, 94, 0.08); }
+        /* Authorship decorations — user=blue, claude=orange */
+        .tandem-authorship { transition: color 0.2s; }
+        .tandem-authorship--user { color: rgb(59, 130, 246); }
+        .tandem-authorship--claude { color: rgb(234, 138, 30); }
 
         /* Claude focus paragraph */
         .tandem-claude-focus {

--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -25,6 +25,7 @@ function resolveAuthorshipRange(
     if (resolved && resolved.from < resolved.to) return resolved;
   }
   if (entry.range) {
+    console.warn("[authorship] Falling back to flat offsets for range", entry.id);
     const from = flatOffsetToPmPos(pmDoc, entry.range.from);
     const to = flatOffsetToPmPos(pmDoc, entry.range.to);
     if (from < to) return { from, to };
@@ -64,6 +65,7 @@ function buildAuthorshipDecorations(
       decorations.push(Decoration.inline(from, to, attrs));
     } catch (err) {
       if (!(err instanceof RangeError)) throw err;
+      console.warn("[authorship] Decoration RangeError for entry", entry.id, err);
     }
   });
 
@@ -103,8 +105,8 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions>({
     let visible = false;
     try {
       visible = localStorage.getItem(AUTHORSHIP_TOGGLE_KEY) === "true";
-    } catch {
-      // localStorage unavailable
+    } catch (err) {
+      console.warn("[authorship] localStorage unavailable", err);
     }
 
     return [
@@ -214,7 +216,7 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions>({
         if (insertedLen > 0) {
           try {
             const flatFrom = pmPosToFlatOffset(pmDoc, toPmPos(newStart));
-            const flatTo = pmPosToFlatOffset(pmDoc, toPmPos(newStart + insertedLen));
+            const flatTo = pmPosToFlatOffset(pmDoc, toPmPos(newEnd));
             if (flatTo <= flatFrom) return;
 
             const rangeId = generateAuthorshipId("user");
@@ -225,8 +227,8 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions>({
               timestamp: Date.now(),
             };
             authorshipMap.set(rangeId, entry);
-          } catch {
-            // Position conversion can fail during complex edits; skip silently
+          } catch (err) {
+            console.warn("[authorship] Position conversion failed during user attribution", err);
           }
         }
       });

--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -6,6 +6,7 @@ import * as Y from "yjs";
 import { AUTHORSHIP_TOGGLE_KEY, Y_MAP_AUTHORSHIP } from "../../../shared/constants";
 import { toPmPos } from "../../../shared/positions/types";
 import type { AuthorshipRange } from "../../../shared/types";
+import { generateAuthorshipId } from "../../../shared/utils";
 import { flatOffsetToPmPos, pmPosToFlatOffset, relRangeToPmPositions } from "../../positions";
 
 export const authorshipPluginKey = new PluginKey("tandemAuthorship");
@@ -55,12 +56,8 @@ function buildAuthorshipDecorations(
     const { from, to } = resolved;
     if (from >= to || from < 0 || to > maxPos) return;
 
-    const isUser = entry.author === "user";
     const attrs: Record<string, string> = {
       class: `tandem-authorship tandem-authorship--${entry.author}`,
-      style: isUser
-        ? "background: rgba(59, 130, 246, 0.08);"
-        : "background: rgba(34, 197, 94, 0.08);",
     };
 
     try {
@@ -220,7 +217,7 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions>({
             const flatTo = pmPosToFlatOffset(pmDoc, toPmPos(newStart + insertedLen));
             if (flatTo <= flatFrom) return;
 
-            const rangeId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+            const rangeId = generateAuthorshipId("user");
             const entry: AuthorshipRange = {
               id: rangeId,
               author: "user",

--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -1,0 +1,238 @@
+import { Extension } from "@tiptap/core";
+import type { Node as PmNode } from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import * as Y from "yjs";
+import { AUTHORSHIP_TOGGLE_KEY, Y_MAP_AUTHORSHIP } from "../../../shared/constants";
+import { toPmPos } from "../../../shared/positions/types";
+import type { AuthorshipRange } from "../../../shared/types";
+import { flatOffsetToPmPos, pmPosToFlatOffset, relRangeToPmPositions } from "../../positions";
+
+export const authorshipPluginKey = new PluginKey("tandemAuthorship");
+
+/**
+ * Resolve an AuthorshipRange to ProseMirror positions.
+ * Prefers relRange (CRDT-anchored) with flat-offset fallback.
+ */
+function resolveAuthorshipRange(
+  entry: AuthorshipRange,
+  pmDoc: PmNode,
+  ydoc: Y.Doc,
+): { from: number; to: number } | null {
+  if (entry.relRange) {
+    const resolved = relRangeToPmPositions(ydoc, pmDoc, entry.relRange);
+    if (resolved && resolved.from < resolved.to) return resolved;
+  }
+  if (entry.range) {
+    const from = flatOffsetToPmPos(pmDoc, entry.range.from);
+    const to = flatOffsetToPmPos(pmDoc, entry.range.to);
+    if (from < to) return { from, to };
+  }
+  return null;
+}
+
+/**
+ * Build decorations from authorship Y.Map entries.
+ */
+function buildAuthorshipDecorations(
+  doc: PmNode,
+  authorshipMap: Y.Map<unknown>,
+  ydoc: Y.Doc,
+  visible: boolean,
+): DecorationSet {
+  if (!visible) return DecorationSet.empty;
+
+  const decorations: Decoration[] = [];
+  const maxPos = doc.content.size;
+
+  authorshipMap.forEach((value) => {
+    const entry = value as AuthorshipRange;
+    if (!entry.author || !entry.range) return;
+
+    const resolved = resolveAuthorshipRange(entry, doc, ydoc);
+    if (!resolved) return;
+
+    const { from, to } = resolved;
+    if (from >= to || from < 0 || to > maxPos) return;
+
+    const isUser = entry.author === "user";
+    const attrs: Record<string, string> = {
+      class: `tandem-authorship tandem-authorship--${entry.author}`,
+      style: isUser
+        ? "background: rgba(59, 130, 246, 0.08);"
+        : "background: rgba(34, 197, 94, 0.08);",
+    };
+
+    try {
+      decorations.push(Decoration.inline(from, to, attrs));
+    } catch (err) {
+      if (!(err instanceof RangeError)) throw err;
+    }
+  });
+
+  return DecorationSet.create(doc, decorations);
+}
+
+interface AuthorshipPluginState {
+  visible: boolean;
+  decorations: DecorationSet;
+}
+
+interface AuthorshipOptions {
+  ydoc: Y.Doc | null;
+}
+
+/**
+ * Tiptap extension that renders authorship tracking stored in Y.Map('authorship')
+ * as ProseMirror inline decorations. Uses the Y.Map overlay strategy (not inline
+ * marks) to avoid CRDT size overhead -- see tests/crdt/authorship-marks-size.test.ts.
+ *
+ * User attribution: onTransaction detects local (non-y-sync) text insertions
+ * and records them as author="user" in the authorship Y.Map.
+ */
+export const AuthorshipExtension = Extension.create<AuthorshipOptions>({
+  name: "tandemAuthorship",
+
+  addOptions() {
+    return { ydoc: null };
+  },
+
+  addProseMirrorPlugins() {
+    const ydoc = this.options.ydoc;
+    if (!ydoc) return [];
+
+    const authorshipMap = ydoc.getMap(Y_MAP_AUTHORSHIP);
+
+    let visible = false;
+    try {
+      visible = localStorage.getItem(AUTHORSHIP_TOGGLE_KEY) === "true";
+    } catch {
+      // localStorage unavailable
+    }
+
+    return [
+      new Plugin({
+        key: authorshipPluginKey,
+
+        state: {
+          init(_, state): AuthorshipPluginState {
+            return {
+              visible,
+              decorations: buildAuthorshipDecorations(state.doc, authorshipMap, ydoc, visible),
+            };
+          },
+          apply(
+            tr,
+            pluginState: AuthorshipPluginState,
+            _oldState,
+            newState,
+          ): AuthorshipPluginState {
+            const meta = tr.getMeta(authorshipPluginKey);
+
+            if (meta?.type === "toggle") {
+              const newVisible = meta.visible as boolean;
+              return {
+                visible: newVisible,
+                decorations: buildAuthorshipDecorations(
+                  newState.doc,
+                  authorshipMap,
+                  ydoc,
+                  newVisible,
+                ),
+              };
+            }
+
+            if (meta?.type === "rebuild") {
+              return {
+                visible: pluginState.visible,
+                decorations: buildAuthorshipDecorations(
+                  newState.doc,
+                  authorshipMap,
+                  ydoc,
+                  pluginState.visible,
+                ),
+              };
+            }
+
+            if (tr.docChanged && pluginState.visible) {
+              return {
+                visible: pluginState.visible,
+                decorations: pluginState.decorations.map(tr.mapping, tr.doc),
+              };
+            }
+
+            return pluginState;
+          },
+        },
+
+        props: {
+          decorations(state) {
+            return (
+              (authorshipPluginKey.getState(state) as AuthorshipPluginState | undefined)
+                ?.decorations ?? DecorationSet.empty
+            );
+          },
+        },
+
+        view(editorView) {
+          // Observe Y.Map changes and trigger decoration rebuild
+          const observer = () => {
+            const tr = editorView.state.tr.setMeta(authorshipPluginKey, { type: "rebuild" });
+            editorView.dispatch(tr);
+          };
+          authorshipMap.observe(observer);
+
+          return {
+            destroy() {
+              authorshipMap.unobserve(observer);
+            },
+          };
+        },
+      }),
+    ];
+  },
+
+  /**
+   * User attribution via onTransaction: detect local text insertions
+   * (not y-sync remotes) and record them as author="user".
+   */
+  onTransaction({ transaction }) {
+    const ydoc = this.options.ydoc;
+    if (!ydoc) return;
+
+    // Skip remote syncs -- y-sync$ meta is set by the collaboration extension
+    if (transaction.getMeta("y-sync$")) return;
+    // Skip our own rebuild/toggle transactions
+    if (transaction.getMeta(authorshipPluginKey)) return;
+    // Skip if doc didn't change
+    if (!transaction.docChanged) return;
+
+    const authorshipMap = ydoc.getMap(Y_MAP_AUTHORSHIP);
+    const pmDoc = transaction.doc;
+
+    transaction.steps.forEach((step) => {
+      const stepMap = step.getMap();
+      stepMap.forEach((oldStart, oldEnd, newStart, newEnd) => {
+        const insertedLen = newEnd - newStart - (oldEnd - oldStart);
+        if (insertedLen > 0) {
+          try {
+            const flatFrom = pmPosToFlatOffset(pmDoc, toPmPos(newStart));
+            const flatTo = pmPosToFlatOffset(pmDoc, toPmPos(newStart + insertedLen));
+            if (flatTo <= flatFrom) return;
+
+            const rangeId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+            const entry: AuthorshipRange = {
+              id: rangeId,
+              author: "user",
+              range: { from: flatFrom, to: flatTo },
+              timestamp: Date.now(),
+            };
+            authorshipMap.set(rangeId, entry);
+          } catch {
+            // Position conversion can fail during complex edits; skip silently
+          }
+        }
+      });
+    });
+  },
+});

--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -181,8 +181,14 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions>({
           };
           authorshipMap.observe(observer);
 
+          // Rebuild after initial sync — data may arrive before the observer is attached
+          const syncRebuild = setTimeout(() => {
+            if (authorshipMap.size > 0) observer();
+          }, 500);
+
           return {
             destroy() {
+              clearTimeout(syncRebuild);
               authorshipMap.unobserve(observer);
             },
           };

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import {
+  AUTHORSHIP_TOGGLE_KEY,
   SELECTION_DWELL_DEFAULT_MS,
   SELECTION_DWELL_MAX_MS,
   SELECTION_DWELL_MIN_MS,
@@ -16,6 +17,7 @@ export interface TandemSettings {
   panelOrder: PanelOrder;
   editorWidthPercent: number;
   selectionDwellMs: number;
+  showAuthorship: boolean;
 }
 
 const DEFAULTS: TandemSettings = {
@@ -24,6 +26,7 @@ const DEFAULTS: TandemSettings = {
   panelOrder: "chat-editor-annotations",
   editorWidthPercent: 50,
   selectionDwellMs: SELECTION_DWELL_DEFAULT_MS,
+  showAuthorship: false,
 };
 
 /**
@@ -61,6 +64,7 @@ export function loadSettings(): TandemSettings {
             Number(parsed.selectionDwellMs) || SELECTION_DWELL_DEFAULT_MS,
           ),
         ),
+        showAuthorship: parsed.showAuthorship === true,
       };
     }
   } catch {
@@ -86,6 +90,8 @@ export function useTandemSettings() {
       };
       try {
         localStorage.setItem(TANDEM_SETTINGS_KEY, JSON.stringify(next));
+        // Mirror authorship toggle to dedicated key for ProseMirror plugin init
+        localStorage.setItem(AUTHORSHIP_TOGGLE_KEY, String(next.showAuthorship));
       } catch {
         // localStorage unavailable (incognito/storage-disabled)
       }

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -384,7 +384,12 @@ export function registerDocumentTools(server: McpServer): void {
           }, MCP_ORIGIN);
         }
 
-        // Record authorship for the inserted text (Y.Map overlay strategy)
+        // Record authorship for the inserted text (Y.Map overlay strategy).
+        // This runs in a separate transaction because anchoredRange() reads the
+        // Y.Doc state *after* the edit to compute RelativePositions for the new
+        // text. Combining it into the edit transaction would anchor against
+        // pre-edit state. The race window is acceptable for v1 — authorship is
+        // decorative (highlight overlay), not semantic.
         if (newText.length > 0) {
           const newFrom = from;
           const newTo = toFlatOffset(newFrom + newText.length);

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -4,14 +4,16 @@ import { z } from "zod";
 import {
   CTRL_ROOM,
   TANDEM_MODE_DEFAULT,
+  Y_MAP_AUTHORSHIP,
   Y_MAP_MODE,
   Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
 import { headingPrefix } from "../../shared/offsets.js";
+import type { AuthorshipRange } from "../../shared/types.js";
 import { TandemModeSchema, toFlatOffset } from "../../shared/types.js";
 import { MCP_ORIGIN } from "../events/queue.js";
 // Position system
-import { resolveToElement, validateRange } from "../positions.js";
+import { anchoredRange, resolveToElement, validateRange } from "../positions.js";
 import { saveSession } from "../session/manager.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
 import { convertToMarkdown } from "./convert.js";
@@ -379,6 +381,27 @@ export function registerDocumentTools(server: McpServer): void {
               textNode.insert(startPos.textOffset, newText);
             }
           }, MCP_ORIGIN);
+        }
+
+        // Record authorship for the inserted text (Y.Map overlay strategy)
+        if (newText.length > 0) {
+          const newFrom = from;
+          const newTo = toFlatOffset(newFrom + newText.length);
+          const anchored = anchoredRange(r.doc, newFrom, newTo);
+          if (anchored.ok) {
+            const authorshipMap = r.doc.getMap(Y_MAP_AUTHORSHIP);
+            const rangeId = `claude-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+            const entry: AuthorshipRange = {
+              id: rangeId,
+              author: "claude",
+              range: anchored.range,
+              relRange: anchored.fullyAnchored ? anchored.relRange : undefined,
+              timestamp: Date.now(),
+            };
+            r.doc.transact(() => {
+              authorshipMap.set(rangeId, entry);
+            }, MCP_ORIGIN);
+          }
         }
 
         return mcpSuccess({ edited: true, from, to, newTextLength: newText.length });

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -11,6 +11,7 @@ import {
 import { headingPrefix } from "../../shared/offsets.js";
 import type { AuthorshipRange } from "../../shared/types.js";
 import { TandemModeSchema, toFlatOffset } from "../../shared/types.js";
+import { generateAuthorshipId } from "../../shared/utils.js";
 import { MCP_ORIGIN } from "../events/queue.js";
 // Position system
 import { anchoredRange, resolveToElement, validateRange } from "../positions.js";
@@ -390,7 +391,7 @@ export function registerDocumentTools(server: McpServer): void {
           const anchored = anchoredRange(r.doc, newFrom, newTo);
           if (anchored.ok) {
             const authorshipMap = r.doc.getMap(Y_MAP_AUTHORSHIP);
-            const rangeId = `claude-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+            const rangeId = generateAuthorshipId("claude");
             const entry: AuthorshipRange = {
               id: rangeId,
               author: "claude",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -77,6 +77,9 @@ export const Y_MAP_CHAT = "chat";
 export const Y_MAP_DOCUMENT_META = "documentMeta";
 export const Y_MAP_ANNOTATION_REPLIES = "annotationReplies";
 export const Y_MAP_SAVED_AT_VERSION = "savedAtVersion";
+export const Y_MAP_AUTHORSHIP = "authorship";
+
+export const AUTHORSHIP_TOGGLE_KEY = "tandem:showAuthorship";
 
 export const SERVER_INFO_DIR = ".tandem";
 export const SERVER_INFO_FILE = ".tandem/.server-info";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -98,6 +98,21 @@ export type Annotation =
       directedAt?: undefined;
     });
 
+/**
+ * Authorship tracking range stored in Y.Map('authorship').
+ * Uses the same flat-offset coordinate system as annotations.
+ * RelativePositions anchor the range to survive concurrent edits.
+ */
+export interface AuthorshipRange {
+  id: string;
+  author: "user" | "claude";
+  range: DocumentRange;
+  /** CRDT-anchored range for edit survival. */
+  relRange?: RelativeRange;
+  /** Timestamp of when this range was created. */
+  timestamp: number;
+}
+
 export interface AnchoredRange {
   start: { nodeId: string; offset: number };
   end: { nodeId: string; offset: number };

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -21,3 +21,7 @@ export function generateReplyId(): string {
 export function generateNotificationId(): string {
   return generateId("ntf");
 }
+
+export function generateAuthorshipId(author: "user" | "claude"): string {
+  return generateId(author);
+}

--- a/tests/crdt/authorship-marks-size.test.ts
+++ b/tests/crdt/authorship-marks-size.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+
+/**
+ * Phase A: CRDT Size Impact Assessment for Authorship Marks
+ *
+ * Measures Y.Doc byte overhead of per-character author attributes on
+ * Y.XmlText nodes to determine if inline marks are viable.
+ *
+ * Thresholds:
+ *   GREEN  (<5% overhead)  -- proceed with inline marks
+ *   YELLOW (5-15% overhead) -- proceed with optimization notes
+ *   RED    (>15% overhead) -- pivot to Y.Map overlay strategy
+ *
+ * RESULT: RED -- continuous marks add ~31% overhead on 100KB docs.
+ * Fragmented marks (realistic editing) add 400%+. Interleaved char-by-char
+ * editing adds 4000%+. Decision: use Y.Map overlay strategy.
+ *
+ * This test documents the measurement and asserts the RED threshold was
+ * correctly identified, serving as a regression test if Y.js ever
+ * optimizes attribute storage.
+ */
+
+/** Generate deterministic text of approximately `targetBytes` in size. */
+function generateText(targetBytes: number): string {
+  const sentence = "The quick brown fox jumps over the lazy dog. ";
+  const repeats = Math.ceil(targetBytes / sentence.length);
+  return sentence.repeat(repeats).slice(0, targetBytes);
+}
+
+/** Populate a Y.Doc with paragraphs of ~100 chars each. */
+function populateDoc(doc: Y.Doc, text: string): void {
+  const fragment = doc.getXmlFragment("default");
+  const chunkSize = 100;
+  for (let i = 0; i < text.length; i += chunkSize) {
+    const chunk = text.slice(i, i + chunkSize);
+    const el = new Y.XmlElement("paragraph");
+    fragment.insert(fragment.length, [el]);
+    const textNode = new Y.XmlText();
+    el.insert(0, [textNode]);
+    textNode.insert(0, chunk);
+  }
+}
+
+/** Apply continuous author marks -- 50% user, 50% claude in large runs. */
+function applyContinuousMarks(doc: Y.Doc): void {
+  const fragment = doc.getXmlFragment("default");
+  doc.transact(() => {
+    for (let i = 0; i < fragment.length; i++) {
+      const el = fragment.get(i) as Y.XmlElement;
+      const textNode = el.get(0) as Y.XmlText;
+      const len = textNode.toString().length;
+      const author = i % 2 === 0 ? "user" : "claude";
+      textNode.format(0, len, { author });
+    }
+  });
+}
+
+/** Apply fragmented author marks -- alternating user/claude every 10 chars. */
+function applyFragmentedMarks(doc: Y.Doc): void {
+  const fragment = doc.getXmlFragment("default");
+  doc.transact(() => {
+    for (let i = 0; i < fragment.length; i++) {
+      const el = fragment.get(i) as Y.XmlElement;
+      const textNode = el.get(0) as Y.XmlText;
+      const len = textNode.toString().length;
+      for (let offset = 0; offset < len; offset += 10) {
+        const end = Math.min(offset + 10, len);
+        const author = Math.floor(offset / 10) % 2 === 0 ? "user" : "claude";
+        textNode.format(offset, end - offset, { author });
+      }
+    }
+  });
+}
+
+/** Simulate interleaved editing: alternating user/claude inserts char-by-char. */
+function simulateInterleavedEditing(doc: Y.Doc, totalChars: number): void {
+  const fragment = doc.getXmlFragment("default");
+  const el = new Y.XmlElement("paragraph");
+  fragment.insert(fragment.length, [el]);
+  const textNode = new Y.XmlText();
+  el.insert(0, [textNode]);
+
+  for (let i = 0; i < totalChars; i++) {
+    const author = i % 2 === 0 ? "user" : "claude";
+    textNode.insert(i, "x", { author });
+  }
+}
+
+function getDocSize(doc: Y.Doc): number {
+  return Y.encodeStateAsUpdate(doc).byteLength;
+}
+
+function overhead(baseline: number, withMarks: number): number {
+  return ((withMarks - baseline) / baseline) * 100;
+}
+
+describe("Authorship Marks -- CRDT Size Impact (Phase A)", () => {
+  describe("continuous marks (100-char runs)", () => {
+    const sizes = [
+      { label: "1KB", bytes: 1_000 },
+      { label: "10KB", bytes: 10_000 },
+      { label: "100KB", bytes: 100_000 },
+    ];
+
+    for (const { label, bytes } of sizes) {
+      it(`${label} document -- overhead exceeds GREEN threshold`, () => {
+        const text = generateText(bytes);
+
+        const baseline = new Y.Doc();
+        populateDoc(baseline, text);
+        const baselineSize = getDocSize(baseline);
+
+        const marked = new Y.Doc();
+        populateDoc(marked, text);
+        applyContinuousMarks(marked);
+        const markedSize = getDocSize(marked);
+
+        const pct = overhead(baselineSize, markedSize);
+        console.log(
+          `[continuous] ${label}: baseline=${baselineSize}B, marked=${markedSize}B, overhead=${pct.toFixed(2)}%`,
+        );
+
+        // Document the RED result: even best-case continuous marks exceed 15%
+        expect(pct).toBeGreaterThan(15);
+      });
+    }
+  });
+
+  describe("fragmented marks (alternating every 10 chars)", () => {
+    const sizes = [
+      { label: "1KB", bytes: 1_000 },
+      { label: "10KB", bytes: 10_000 },
+      { label: "100KB", bytes: 100_000 },
+    ];
+
+    for (const { label, bytes } of sizes) {
+      it(`${label} document -- overhead is extreme`, () => {
+        const text = generateText(bytes);
+
+        const baseline = new Y.Doc();
+        populateDoc(baseline, text);
+        const baselineSize = getDocSize(baseline);
+
+        const marked = new Y.Doc();
+        populateDoc(marked, text);
+        applyFragmentedMarks(marked);
+        const markedSize = getDocSize(marked);
+
+        const pct = overhead(baselineSize, markedSize);
+        console.log(
+          `[fragmented] ${label}: baseline=${baselineSize}B, marked=${markedSize}B, overhead=${pct.toFixed(2)}%`,
+        );
+
+        // Fragmented marks are far worse than continuous
+        expect(pct).toBeGreaterThan(100);
+      });
+    }
+  });
+
+  describe("interleaved editing simulation", () => {
+    // Only test 1KB -- char-by-char insertion is O(n^2) and 10KB+ times out
+    it("1KB document -- char-by-char interleaved is catastrophic", () => {
+      const baseline = new Y.Doc();
+      const baseFragment = baseline.getXmlFragment("default");
+      const baseEl = new Y.XmlElement("paragraph");
+      baseFragment.insert(0, [baseEl]);
+      const baseText = new Y.XmlText();
+      baseEl.insert(0, [baseText]);
+      baseText.insert(0, "x".repeat(1_000));
+      const baselineSize = getDocSize(baseline);
+
+      const interleaved = new Y.Doc();
+      simulateInterleavedEditing(interleaved, 1_000);
+      const interleavedSize = getDocSize(interleaved);
+
+      const pct = overhead(baselineSize, interleavedSize);
+      console.log(
+        `[interleaved] 1KB: baseline=${baselineSize}B, interleaved=${interleavedSize}B, overhead=${pct.toFixed(2)}%`,
+      );
+
+      // Worst-case: each char is its own segment with an author attribute
+      expect(pct).toBeGreaterThan(1000);
+    });
+  });
+
+  describe("incremental sync size", () => {
+    it("measures sync delta when adding marks to existing content", () => {
+      const text = generateText(100_000);
+      const doc = new Y.Doc();
+      populateDoc(doc, text);
+
+      const stateBeforeMarks = Y.encodeStateVector(doc);
+
+      applyContinuousMarks(doc);
+
+      const incrementalUpdate = Y.encodeStateAsUpdate(doc, stateBeforeMarks);
+      const fullSize = getDocSize(doc);
+
+      console.log(
+        `[incremental sync] 100KB doc: full=${fullSize}B, markDelta=${incrementalUpdate.byteLength}B, deltaRatio=${((incrementalUpdate.byteLength / fullSize) * 100).toFixed(2)}%`,
+      );
+
+      expect(incrementalUpdate.byteLength).toBeGreaterThan(0);
+      expect(incrementalUpdate.byteLength).toBeLessThan(fullSize);
+    });
+  });
+});

--- a/tests/server/authorship-edit-integration.test.ts
+++ b/tests/server/authorship-edit-integration.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
+import { anchoredRange } from "../../src/server/positions.js";
+import { Y_MAP_AUTHORSHIP } from "../../src/shared/constants.js";
+import { toFlatOffset } from "../../src/shared/positions/types.js";
+import type { AuthorshipRange } from "../../src/shared/types.js";
+import { generateAuthorshipId } from "../../src/shared/utils.js";
+import { makeDoc } from "../helpers/ydoc-factory.js";
+
+const MCP_ORIGIN = "mcp";
+
+let doc: Y.Doc;
+
+afterEach(() => {
+  doc?.destroy();
+});
+
+/**
+ * Replicate the full tandem_edit + authorship recording flow.
+ * Returns null on success or an error string.
+ */
+function applyEditWithAuthorship(
+  doc: Y.Doc,
+  from: number,
+  to: number,
+  newText: string,
+): string | null {
+  const fragment = doc.getXmlFragment("default");
+  const startPos = resolveOffset(fragment, from);
+  const endPos = resolveOffset(fragment, to);
+
+  if (!startPos || !endPos) return `Cannot resolve offset range [${from}, ${to}].`;
+  if (startPos.clampedFromPrefix || endPos.clampedFromPrefix) {
+    return "Edit range overlaps with heading markup.";
+  }
+
+  // Apply the edit (same-element only for simplicity — cross-element tested elsewhere)
+  if (startPos.elementIndex !== endPos.elementIndex) {
+    doc.transact(() => {
+      const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
+      const startText = getOrCreateXmlText(startNode);
+      const startLen = startText.toString().length;
+      if (startPos.textOffset < startLen) {
+        startText.delete(startPos.textOffset, startLen - startPos.textOffset);
+      }
+      const deleteCount = endPos.elementIndex - startPos.elementIndex - 1;
+      for (let i = 0; i < deleteCount; i++) {
+        fragment.delete(startPos.elementIndex + 1, 1);
+      }
+      const endNode = fragment.get(startPos.elementIndex + 1) as Y.XmlElement;
+      const endText = getOrCreateXmlText(endNode);
+      if (endPos.textOffset > 0) {
+        endText.delete(0, endPos.textOffset);
+      }
+      const remainingText = endText.toString();
+      if (remainingText.length > 0) {
+        startText.insert(startPos.textOffset, remainingText);
+      }
+      fragment.delete(startPos.elementIndex + 1, 1);
+      startText.insert(startPos.textOffset, newText);
+    }, MCP_ORIGIN);
+  } else {
+    doc.transact(() => {
+      const node = fragment.get(startPos.elementIndex) as Y.XmlElement;
+      const textNode = getOrCreateXmlText(node);
+      const deleteLen = endPos.textOffset - startPos.textOffset;
+      if (deleteLen > 0) {
+        textNode.delete(startPos.textOffset, deleteLen);
+      }
+      if (newText.length > 0) {
+        textNode.insert(startPos.textOffset, newText);
+      }
+    }, MCP_ORIGIN);
+  }
+
+  // Record authorship — mirrors document.ts logic
+  if (newText.length > 0) {
+    const newFrom = toFlatOffset(from);
+    const newTo = toFlatOffset(from + newText.length);
+    const anchored = anchoredRange(doc, newFrom, newTo);
+    if (anchored.ok) {
+      const authorshipMap = doc.getMap(Y_MAP_AUTHORSHIP);
+      const rangeId = generateAuthorshipId("claude");
+      const entry: AuthorshipRange = {
+        id: rangeId,
+        author: "claude",
+        range: anchored.range,
+        relRange: anchored.fullyAnchored ? anchored.relRange : undefined,
+        timestamp: Date.now(),
+      };
+      doc.transact(() => {
+        authorshipMap.set(rangeId, entry);
+      }, MCP_ORIGIN);
+    }
+  }
+
+  return null;
+}
+
+describe("tandem_edit authorship recording (integration)", () => {
+  it("records authorship entry after a replacement edit", () => {
+    doc = makeDoc("Hello world");
+    const err = applyEditWithAuthorship(doc, 6, 11, "there");
+    expect(err).toBeNull();
+    expect(extractText(doc)).toBe("Hello there");
+
+    const authorshipMap = doc.getMap(Y_MAP_AUTHORSHIP);
+    expect(authorshipMap.size).toBe(1);
+
+    const entries: AuthorshipRange[] = [];
+    authorshipMap.forEach((v) => entries.push(v as AuthorshipRange));
+
+    const entry = entries[0];
+    expect(entry.author).toBe("claude");
+    expect(entry.range.from).toBe(6);
+    expect(entry.range.to).toBe(11);
+    expect(entry.id).toMatch(/^claude_/);
+    expect(entry.timestamp).toBeGreaterThan(0);
+  });
+
+  it("records authorship with CRDT-anchored relRange", () => {
+    doc = makeDoc("Hello world");
+    const err = applyEditWithAuthorship(doc, 0, 5, "Greetings");
+    expect(err).toBeNull();
+    expect(extractText(doc)).toBe("Greetings world");
+
+    const authorshipMap = doc.getMap(Y_MAP_AUTHORSHIP);
+    const entries: AuthorshipRange[] = [];
+    authorshipMap.forEach((v) => entries.push(v as AuthorshipRange));
+
+    const entry = entries[0];
+    expect(entry.relRange).toBeDefined();
+    expect(entry.relRange!.fromRel).toBeDefined();
+    expect(entry.relRange!.toRel).toBeDefined();
+  });
+
+  it("does not record authorship for pure deletions", () => {
+    doc = makeDoc("Hello world");
+    const err = applyEditWithAuthorship(doc, 5, 11, "");
+    expect(err).toBeNull();
+    expect(extractText(doc)).toBe("Hello");
+
+    const authorshipMap = doc.getMap(Y_MAP_AUTHORSHIP);
+    expect(authorshipMap.size).toBe(0);
+  });
+
+  it("records authorship for insertion at a point (from === to)", () => {
+    doc = makeDoc("Hello world");
+    const err = applyEditWithAuthorship(doc, 5, 5, " beautiful");
+    expect(err).toBeNull();
+    expect(extractText(doc)).toBe("Hello beautiful world");
+
+    const authorshipMap = doc.getMap(Y_MAP_AUTHORSHIP);
+    expect(authorshipMap.size).toBe(1);
+
+    const entries: AuthorshipRange[] = [];
+    authorshipMap.forEach((v) => entries.push(v as AuthorshipRange));
+
+    const entry = entries[0];
+    expect(entry.author).toBe("claude");
+    expect(entry.range.from).toBe(5);
+    expect(entry.range.to).toBe(15);
+  });
+
+  it("records separate entries for multiple edits", () => {
+    doc = makeDoc("Hello world");
+    applyEditWithAuthorship(doc, 0, 5, "Hi");
+    // After first edit: "Hi world"
+    applyEditWithAuthorship(doc, 3, 8, "there");
+    // After second edit: "Hi there"
+
+    expect(extractText(doc)).toBe("Hi there");
+
+    const authorshipMap = doc.getMap(Y_MAP_AUTHORSHIP);
+    expect(authorshipMap.size).toBe(2);
+  });
+});

--- a/tests/server/authorship-tracking.test.ts
+++ b/tests/server/authorship-tracking.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { Y_MAP_AUTHORSHIP } from "../../src/shared/constants.js";
+import type { AuthorshipRange } from "../../src/shared/types.js";
+
+/**
+ * Verifies authorship tracking via Y.Map overlay:
+ * - Claude edits produce entries in Y.Map('authorship')
+ * - Entries have correct author, range, and structure
+ * - Multiple edits produce multiple entries
+ */
+
+/** Minimal Y.Doc with a paragraph containing the given text. */
+function createDocWithText(text: string): Y.Doc {
+  const doc = new Y.Doc();
+  const fragment = doc.getXmlFragment("default");
+  const para = new Y.XmlElement("paragraph");
+  fragment.insert(0, [para]);
+  const textNode = new Y.XmlText();
+  para.insert(0, [textNode]);
+  textNode.insert(0, text);
+  return doc;
+}
+
+describe("Authorship tracking — Y.Map overlay", () => {
+  it("records an authorship entry in the Y.Map", () => {
+    const doc = createDocWithText("Hello world");
+    const authorshipMap = doc.getMap(Y_MAP_AUTHORSHIP);
+
+    // Simulate what tandem_edit does after a successful edit
+    const rangeId = "claude-test-1";
+    const entry: AuthorshipRange = {
+      id: rangeId,
+      author: "claude",
+      range: { from: 0 as any, to: 5 as any },
+      timestamp: Date.now(),
+    };
+    doc.transact(() => {
+      authorshipMap.set(rangeId, entry);
+    }, "mcp");
+
+    expect(authorshipMap.size).toBe(1);
+    const stored = authorshipMap.get(rangeId) as AuthorshipRange;
+    expect(stored.author).toBe("claude");
+    expect(stored.range.from).toBe(0);
+    expect(stored.range.to).toBe(5);
+  });
+
+  it("records user authorship entries", () => {
+    const doc = createDocWithText("Hello world");
+    const authorshipMap = doc.getMap(Y_MAP_AUTHORSHIP);
+
+    const rangeId = "user-test-1";
+    const entry: AuthorshipRange = {
+      id: rangeId,
+      author: "user",
+      range: { from: 6 as any, to: 11 as any },
+      timestamp: Date.now(),
+    };
+    authorshipMap.set(rangeId, entry);
+
+    const stored = authorshipMap.get(rangeId) as AuthorshipRange;
+    expect(stored.author).toBe("user");
+  });
+
+  it("supports multiple authorship entries", () => {
+    const doc = createDocWithText("Hello world test");
+    const authorshipMap = doc.getMap(Y_MAP_AUTHORSHIP);
+
+    const entries: AuthorshipRange[] = [
+      { id: "claude-1", author: "claude", range: { from: 0 as any, to: 5 as any }, timestamp: 1 },
+      { id: "user-1", author: "user", range: { from: 6 as any, to: 11 as any }, timestamp: 2 },
+      {
+        id: "claude-2",
+        author: "claude",
+        range: { from: 12 as any, to: 16 as any },
+        timestamp: 3,
+      },
+    ];
+
+    for (const entry of entries) {
+      authorshipMap.set(entry.id, entry);
+    }
+
+    expect(authorshipMap.size).toBe(3);
+
+    const claudeEntries: AuthorshipRange[] = [];
+    const userEntries: AuthorshipRange[] = [];
+    authorshipMap.forEach((value) => {
+      const e = value as AuthorshipRange;
+      if (e.author === "claude") claudeEntries.push(e);
+      else userEntries.push(e);
+    });
+
+    expect(claudeEntries).toHaveLength(2);
+    expect(userEntries).toHaveLength(1);
+  });
+
+  it("survives Y.Doc state sync (entries persist)", () => {
+    const doc1 = new Y.Doc();
+    const fragment = doc1.getXmlFragment("default");
+    const para = new Y.XmlElement("paragraph");
+    fragment.insert(0, [para]);
+    const textNode = new Y.XmlText();
+    para.insert(0, [textNode]);
+    textNode.insert(0, "Hello world");
+
+    const authorshipMap = doc1.getMap(Y_MAP_AUTHORSHIP);
+    authorshipMap.set("claude-1", {
+      id: "claude-1",
+      author: "claude",
+      range: { from: 0, to: 5 },
+      timestamp: Date.now(),
+    });
+
+    // Sync to a second doc
+    const doc2 = new Y.Doc();
+    const update = Y.encodeStateAsUpdate(doc1);
+    Y.applyUpdate(doc2, update);
+
+    const map2 = doc2.getMap(Y_MAP_AUTHORSHIP);
+    expect(map2.size).toBe(1);
+    const entry = map2.get("claude-1") as AuthorshipRange;
+    expect(entry.author).toBe("claude");
+    expect(entry.range.from).toBe(0);
+    expect(entry.range.to).toBe(5);
+  });
+
+  it("overlay overhead scales with entry count, not document size", () => {
+    // With a 100KB doc and 20 edits (realistic session), overhead is small
+    const baseline = new Y.Doc();
+    const frag1 = baseline.getXmlFragment("default");
+    const p1 = new Y.XmlElement("paragraph");
+    frag1.insert(0, [p1]);
+    const t1 = new Y.XmlText();
+    p1.insert(0, [t1]);
+    t1.insert(0, "x".repeat(100_000));
+    const baselineSize = Y.encodeStateAsUpdate(baseline).byteLength;
+
+    const withAuthorship = new Y.Doc();
+    const frag2 = withAuthorship.getXmlFragment("default");
+    const p2 = new Y.XmlElement("paragraph");
+    frag2.insert(0, [p2]);
+    const t2 = new Y.XmlText();
+    p2.insert(0, [t2]);
+    t2.insert(0, "x".repeat(100_000));
+
+    // 20 authorship entries — a typical editing session
+    const map = withAuthorship.getMap(Y_MAP_AUTHORSHIP);
+    for (let i = 0; i < 20; i++) {
+      map.set(`entry-${i}`, {
+        id: `entry-${i}`,
+        author: i % 2 === 0 ? "claude" : "user",
+        range: { from: i * 500, to: i * 500 + 200 },
+        timestamp: Date.now(),
+      });
+    }
+
+    const withSize = Y.encodeStateAsUpdate(withAuthorship).byteLength;
+    const overhead = ((withSize - baselineSize) / baselineSize) * 100;
+
+    console.log(
+      `[overlay overhead] 100KB + 20 entries: baseline=${baselineSize}B, withAuthorship=${withSize}B, overhead=${overhead.toFixed(2)}%`,
+    );
+
+    // 20 range entries on a 100KB doc should be under 10% overhead
+    // (each entry is ~80 bytes, so ~1.6KB total vs 100KB baseline)
+    expect(overhead).toBeLessThan(10);
+  });
+});


### PR DESCRIPTION
## Summary

- **Phase A CRDT measurement** found inline marks add 31%+ overhead on 100KB docs (RED threshold). Fragmented marks: 400%+. Interleaved: 4000%+. Pivoted to Y.Map overlay strategy.
- **Server**: `tandem_edit` records Claude authorship ranges in `Y.Map('authorship')` after each insert, with CRDT-anchored RelativePositions.
- **Client**: `AuthorshipExtension` renders authorship decorations as ProseMirror inline decorations (user=blue, claude=green). User attribution via `onTransaction` detecting local (non-y-sync) text insertions.
- **UI**: "Show who wrote what" toggle in Settings popover, persisted to localStorage.
- **13 new tests**: 8 Phase A size measurements documenting the RED decision, 5 overlay unit tests.

## Phase A Results

| Pattern | 1KB | 10KB | 100KB |
|---------|-----|------|-------|
| Continuous marks | 30.6% | 30.9% | 31.6% |
| Fragmented (10-char) | 402% | 406% | 434% |
| Interleaved (char) | 4185% | N/A | N/A |
| **Overlay (20 entries)** | - | - | **<10%** |

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test -- --run` passes (978 tests, 0 failures)
- [ ] Manual: open a file, make user edits, use `tandem_edit` for Claude text
- [ ] Manual: toggle "Show who wrote what" in Settings -- user text blue, Claude text green
- [ ] Manual: close/reopen document -- authorship colors persist
- [ ] Manual: large document (100KB+) with toggle on -- no lag

Closes #190

:robot: Generated with [Claude Code](https://claude.com/claude-code)