### PR TITLE
Update README to lead with text iteration use case and MCP advantage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
   <img src="docs/assets/banner.png" alt="Tandem — Collaborative AI-Human Document Editor" width="800">
 </p>
 
-Have you ever been working on a document (or any multi-paragraph piece of text) with Claude and wondered aloud, "Why isn't there an easier way to do this?" Well look no further, because now there is! My goal with this was to try to create an experience kind of similar to editing a Google doc with another person except that that other person is Claude Code. 
+Have you ever been working on a piece of writing with an LLM and caught yourself copy-pasting the same paragraph into the chat for the fifth time just so the model knows what you're talking about? That's the friction Tandem eliminates. Open a file directly, or just tell Claude "let's work on my draft in tandem" — the document appears in the editor, and from that point on you highlight text and Claude sees it directly. No pasting, no "here's the paragraph I mean," no losing your place.
+
+And because Tandem hooks into Claude as an MCP server, you're not stuck in some stripped-down document-editing silo. It's the full Claude — with all its knowledge, your conversation context, and every tool it has access to — just now it can also see and edit your document.
 
 ![Tandem editor showing a document with annotations, side panel, and Claude's presence](docs/screenshots/01-editor-overview.png)
+
+## Why Tandem?
+
+- **No more copy-paste ping-pong.** Select text in the editor, and Claude reads your selection directly. Ask "what do you think of this?" or "make this more concise" — Claude knows exactly which text you mean.
+- **Your full LLM, not a toy editor.** Tandem connects via MCP, so Claude keeps all its knowledge, all its tools, and your full conversation context. Need it to cross-reference your document against a codebase, a URL, or another file? It can — it's still Claude.
+- **Iterate in place.** Claude can suggest rewrites, leave comments, flag issues, and edit text — all appearing as annotations you accept, dismiss, or tweak right in the document.
 
 ## Quick Start
 
@@ -105,27 +113,29 @@ Open http://localhost:5173 — you'll see `sample/welcome.md` loaded automatical
 
 ## Using Tandem
 
-A one-minute mental model of the daily loop:
+You point at text, Claude sees it. Here's how that plays out day-to-day:
 
-- **Open a document.** Ask Claude (`"open notes.md"`), drag a file onto the browser, or click the **+** in the tab bar. `.md`, `.txt`, `.html`, and `.docx` (review-only) are supported.
-- **Talk about specific text.** Select it in the browser editor, then ask Claude about "this paragraph" in the terminal. Claude reads your selection from `tandem_checkInbox` — no copy/paste. Hold the selection still for about a second so it registers (dwell-time gating filters out incidental clicks).
-- **Review what Claude suggests.** Annotations appear in the side panel. Press **Ctrl+Shift+R** to enter keyboard review mode: **Tab** to navigate, **Y** accept, **N** dismiss, **E** edit, **Z** undo within a 10-second window.
+- **Open a document.** Ask Claude (`"let's work on notes.md in tandem"`), drag a file onto the browser, or click the **+** in the tab bar. `.md`, `.txt`, `.html`, and `.docx` (review-only) are supported.
+- **Point at what you mean.** Select text in the editor and ask Claude about "this paragraph" in the terminal — or just wait for Claude to react if you have channels on. Claude reads your selection directly, no copy-paste needed. Hold the selection for about a second so it registers (dwell-time gating filters out incidental clicks).
+- **Iterate on Claude's response.** Claude's suggestions appear as annotations in the side panel — accept, dismiss, edit, or ask follow-up questions. Each round refines the text without you ever leaving the document. Press **Ctrl+Shift+R** for keyboard review mode: **Tab** to navigate, **Y** accept, **N** dismiss, **E** edit, **Z** undo within a 10-second window.
 - **Heads-down vs collaborative.** Toggle **Solo** mode when you want to write without interruptions — Tandem queues non-urgent annotations until you flip back to **Tandem** mode. Both `tandem_status` and `tandem_checkInbox` return the current mode so Claude adapts its behavior automatically.
 - **Save.** Ask Claude ("save the file"), press the save button, or let session auto-persistence take over — your documents and annotations survive server restarts either way.
 
 ## Features
 
-### Annotations
-
-![Side panel showing annotation cards with filtering, bulk actions, and text previews](docs/screenshots/03-side-panel.png)
-
-Claude adds highlights, comments, suggestions, and flags directly in the document. Suggestion cards show a visual diff — original text in red strikethrough, replacement in green. The side panel lists all annotations with filtering by type, author, and status. Accept, dismiss, or edit each one individually — or use bulk actions to process them in batches.
+Everything in Tandem is built around one idea: you work in the document, Claude works alongside you, and neither of you has to leave your surface to stay in sync.
 
 ### Chat
 
 ![Chat sidebar showing messages, typing indicator, and panel toggle](docs/screenshots/02-chat-sidebar.png)
 
-Send freeform messages to Claude alongside annotation review. Select text before sending to attach it as a clickable anchor — clicking it later scrolls back to that passage.
+Send messages to Claude alongside your document. Select text before sending to attach it as context — Claude sees exactly what you mean. Clicking an anchored selection later scrolls back to that passage.
+
+### Annotations
+
+![Side panel showing annotation cards with filtering, bulk actions, and text previews](docs/screenshots/03-side-panel.png)
+
+This is how Claude's feedback shows up in the document. Claude adds highlights, comments, suggestions, and flags directly on the text. Suggestion cards show a visual diff — original text in red strikethrough, replacement in green. The side panel lists all annotations with filtering by type, author, and status. Accept, dismiss, or edit each one individually — or use bulk actions to process them in batches.
 
 ### Review Mode
 
@@ -135,11 +145,11 @@ Press **Ctrl+Shift+R** to enter keyboard review mode. Navigate with **Tab**, acc
 
 ### More
 
+- **Full LLM via MCP** — Claude connects through MCP tools, so it retains all its knowledge, conversation context, and tool access while working on your document
 - **Multi-document tabs** — open `.md`, `.txt`, `.html`, `.docx` files side by side; drag to reorder
 - **.docx review-only mode** — open Word documents for annotation; imported Word comments appear alongside Claude's
 - **Session persistence** — documents and annotations survive server restarts
 - **Solo / Tandem mode** — flip to Solo when you want to write heads-down; Tandem queues non-urgent annotations until you're ready
-- **Selection-aware chat** — highlight text in the browser, ask Claude about "this" in the terminal; Claude reads your selection directly, no copy/paste
 - **Real-time channel push** *(recommended)* — with the `--dangerously-load-development-channels` Claude Code flag, selections, annotations, and chat push to Claude instantly, making Tandem feel like a live collaborator watching over your shoulder
 - **Keyboard shortcuts** — press `?` for the full reference
 - **Unsaved-changes indicator** — dot on tab title when a document has pending edits

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ See the full [Roadmap](docs/roadmap.md) and [Known Limitations](docs/roadmap.md#
 - **[User Guide](docs/user-guide.md)** — How to use Tandem: browser UI, annotations, chat, review mode, keyboard shortcuts
 - [MCP Tool Reference](docs/mcp-tools.md) — 30 MCP tools + channel API endpoints
 - [Architecture](docs/architecture.md) — System design, data flows, coordinate systems, channel push
-- [Workflows](docs/workflows.md) — Claude Code usage patterns: document review, cross-referencing, multi-model
+- [Workflows](docs/workflows.md) — Claude Code usage patterns: text iteration, cross-referencing, multi-model
 - [Roadmap](docs/roadmap.md) — Phase 2+ roadmap, known issues, future extensions
 - [Design Decisions](docs/decisions.md) — ADR-001 through ADR-022
 - [Lessons Learned](docs/lessons-learned.md) — 37 implementation lessons

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -4,13 +4,13 @@ _Last updated: 2026-03-21_
 
 ## What Tandem Is
 
-Tandem is an AI-powered document review tool. You open a document — a progress report, an RFP response, a compliance filing — and Claude reviews it alongside you in real time. Claude highlights issues, leaves comments, suggests rewrites. You accept, dismiss, or ask follow-up questions. The original file is never modified unless you say so.
+Tandem lets you work on documents with an LLM without the constant copy-paste. You open a document — a progress report, an RFP response, a compliance filing — highlight the text you want to discuss, and Claude sees it directly. Claude can suggest rewrites, leave comments, flag issues, and edit text alongside you. Because Claude connects through MCP, it brings all its knowledge, tools, and conversation context to the document — it's not working in isolation. The original file is never modified unless you say so.
 
-The closest analogy: **what GitHub Copilot code review is for pull requests, Tandem is for documents.**
+The core value: **you point at text, the LLM sees it, and you iterate together without leaving the document.**
 
 ## What Makes It Different
 
-Most AI document tools are writing assistants — they help you produce content. Tandem is a **review assistant** — it helps you evaluate content someone else wrote. That's a different workflow, a different user, and a different product.
+Most AI document tools are either writing assistants (generate content for you) or chat interfaces (you paste text in, get text back). Tandem is an **iteration surface** — you and the LLM both see the document, and you work on it together without copy-paste. The LLM can review what's there, help you rewrite it, or draft new content, all without either of you leaving your surface.
 
 ### The annotation model
 
@@ -93,8 +93,8 @@ The compliance and commercial use cases that would pay for this tool require eit
 **Don't say:** "Collaborative AI editor" (invites comparison with Google Docs)
 **Don't say:** "AI writing assistant" (crowded, undifferentiated)
 
-**Do say:** "AI document reviewer" — like having a junior analyst review your reports
-**Do say:** "What GitHub Copilot code review is for pull requests, Tandem is for documents"
-**Do say:** "Open a Word doc, get AI annotations without touching the original"
+**Do say:** "Work on documents with your LLM — no more copy-paste"
+**Do say:** "Your full Claude, just now it can see and edit your document too"
+**Do say:** "Point at text, Claude sees it, iterate together"
 
-The narrower and more specific the positioning, the stronger it is. The broadest defensible claim: **Tandem is the first tool that treats AI document suggestions as first-class, addressable, persistent objects that users can accept, dismiss, and converse about.**
+The narrower and more specific the positioning, the stronger it is. The broadest defensible claim: **Tandem is the first tool that connects your full LLM to your document via MCP, so you iterate on text together without copy-paste — and Claude's suggestions are first-class, addressable, persistent objects you can accept, dismiss, and converse about.**

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -6,7 +6,7 @@ A complete guide to using Tandem — from first launch to advanced workflows.
 
 ## Overview
 
-Tandem is an AI document reviewer. You open a document — a progress report, RFP response, compliance filing, or any prose — and Claude reviews it alongside you in real time. Claude highlights issues, leaves comments, suggests rewrites, and flags items for attention. Each annotation is a first-class object you can accept, dismiss, edit, or discuss. The original file is never modified unless you save.
+Tandem lets you work on documents with an LLM without the constant copy-paste. You open a document — a progress report, RFP response, compliance filing, or any prose — highlight the text you want to discuss, and Claude sees it directly. Claude can suggest rewrites, leave comments, flag issues, and edit text alongside you in real time. Because Claude connects through MCP, it brings all its knowledge, tools, and conversation context to the document — it's not working in isolation. Each annotation is a first-class object you can accept, dismiss, edit, or discuss. The original file is never modified unless you save.
 
 Tandem runs as a local server with two surfaces: a **browser editor** where you read and edit documents, and **Claude Code** where Claude connects via MCP tools. Changes sync instantly between them through Yjs CRDT collaboration.
 
@@ -78,7 +78,7 @@ The bottom bar shows:
 - **Document count** — How many documents are currently open.
 - **Display name** — Your name as it appears to Claude. Click to change it (stored in localStorage).
 - **Review Only badge** — Appears when the active document is read-only (e.g. an imported `.docx`).
-- **Claude's activity** — What Claude is doing ("Reviewing Cost Summary...", idle, etc.).
+- **Claude's activity** — What Claude is doing ("Working on Cost Summary...", idle, etc.).
 
 Claude collaboration mode (**Solo** / **Tandem**) lives in the toolbar at the top of the window, not the status bar. See [Solo / Tandem Mode](#solo--tandem-mode).
 
@@ -121,7 +121,7 @@ Press `Ctrl+S` to save the active document to disk. Claude can also save via `ta
 
 ## Annotations
 
-Annotations are Tandem's core feature. There are three types, each with distinct visual styling in the document:
+Annotations are how Claude's feedback shows up in the document. There are three types, each with distinct visual styling:
 
 ### Highlight
 
@@ -194,7 +194,7 @@ The toolbar includes a **Solo / Tandem** toggle that controls whether Claude's a
 - **Tandem** (default) — Claude's annotations appear immediately as they arrive.
 - **Solo** — Claude's pending annotations are held back. Resolved annotations (accepted/dismissed) are always visible regardless of mode.
 
-Use **Solo** during focused writing to avoid interruption. Switch to **Tandem** when you're ready to review Claude's work — all held annotations appear at once.
+Use **Solo** during focused writing to avoid interruption. Switch to **Tandem** when you're ready to see Claude's suggestions — all held annotations appear at once.
 
 ## Chat
 
@@ -311,7 +311,7 @@ With channel push active, Claude receives events automatically without needing t
 1. Call `tandem_status()` to see open documents
 2. Call `tandem_listDocuments()` for details
 3. Call `tandem_getOutline()` on the active document to orient
-4. Call `tandem_getAnnotations()` to see existing review state
+4. Call `tandem_getAnnotations()` to see existing annotation state
 5. Continue where the previous session left off
 
 Previously-open documents are auto-restored when the server starts — no manual `tandem_open` needed.
@@ -319,7 +319,7 @@ Previously-open documents are auto-restored when the server starts — no manual
 ### Further Reading
 
 - [MCP Tool Reference](mcp-tools.md) — Full documentation for all 30 tools
-- [Workflows](workflows.md) — Advanced Claude Code patterns: cross-referencing documents, multi-model review, RFP drafting, session handoff details
+- [Workflows](workflows.md) — Advanced Claude Code patterns: cross-referencing documents, multi-model collaboration, RFP drafting, session handoff details
 - [Architecture](architecture.md) — System design, coordinate systems, data flows
 
 ## Troubleshooting

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -48,10 +48,10 @@ claude --dangerously-load-development-channels server:tandem-channel
 
 Then try:
 ```
-"Review the welcome document with me"
+"Let's work on the welcome document together"
 ```
 
-Claude connects to the running Tandem server, opens the document, and begins reviewing. With the channel active, chat messages and annotation actions push to Claude instantly. Without it, Claude falls back to polling via `tandem_checkInbox`.
+Claude connects to the running Tandem server, opens the document, and starts reading. With the channel active, chat messages and annotation actions push to Claude instantly. Without it, Claude falls back to polling via `tandem_checkInbox`.
 
 **After upgrading** (re-run setup to update the skill and MCP paths):
 ```bash
@@ -59,7 +59,7 @@ npm update -g tandem-editor
 tandem setup    # re-writes MCP config with new paths
 ```
 
-## Reviewing a DRPA Progress Report
+## Editing a DRPA Progress Report
 
 **Setup:** Bryan has a monthly progress report draft that needs review before submitting to DRPA.
 
@@ -82,10 +82,10 @@ Claude: tandem_getOutline()
   ]}
 ```
 
-Claude reviews section by section without loading the full doc:
+Claude reads section by section without loading the full doc:
 
 ```
-Claude: tandem_setStatus("Reviewing Cost Summary...", { focusParagraph: 8 })
+Claude: tandem_setStatus("Working on Cost Summary...", { focusParagraph: 8 })
 Claude: tandem_getTextContent({ section: "Cost Summary" })
 ```
 
@@ -117,7 +117,7 @@ Bryan sees the suggestion in the side panel -- accepts or rejects with one click
 When done:
 ```
 Claude: tandem_save()
-Claude: tandem_setStatus("Review complete")
+Claude: tandem_setStatus("Done")
 ```
 
 ## Cross-Referencing an Invoice (Multi-Document)
@@ -221,7 +221,7 @@ Claude: tandem_getTextContent({ section: "Technical Approach" })
 
 ## Multi-Model Workflow
 
-**Setup:** Large document that benefits from parallel review. Opus orchestrates, Sonnet agents handle sections.
+**Setup:** Large document that benefits from parallel processing. Opus orchestrates, Sonnet agents handle sections.
 
 Opus reads the outline:
 ```
@@ -250,7 +250,7 @@ Opus: tandem_getAnnotations({ author: "claude", status: "pending" })
 
 ## Keyboard Review Mode
 
-**Setup:** Claude has finished reviewing and left 15+ annotations. Bryan wants to process them efficiently.
+**Setup:** Claude has finished and left 15+ annotations. Bryan wants to process them efficiently.
 
 The browser's side panel shows all pending annotations with filter controls:
 - Filter by type (highlights, comments, flags) — comments with replacement text show as "With replacement", comments with `directedAt` show as "For Claude"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem-editor",
   "version": "0.4.0",
-  "description": "Collaborative AI-human document editor with MCP tool integration for Claude",
+  "description": "Edit and iterate on documents with Claude — no copy-paste, full LLM access via MCP",
   "repository": {
     "type": "git",
     "url": "https://github.com/bloknayrb/tandem"

--- a/sample/welcome.md
+++ b/sample/welcome.md
@@ -1,6 +1,6 @@
 # Welcome to Tandem
 
-Tandem is a collaborative document editor where you and Claude can review your documents together in real-time.
+Tandem lets you work on documents with Claude — highlight text and Claude sees it directly, no copy-paste needed. Because Claude connects via MCP, it brings all its knowledge and tools to the document.
 
 ## Getting Started
 
@@ -10,7 +10,7 @@ Open Claude Code from any directory -- your Tandem tools are already configured.
 
 ## Try These
 
-1. **Review an annotation** -- Look at the highlighted text in this document. Open the side panel to accept or dismiss annotations, or press Ctrl+Shift+R for Review Mode.
+1. **Respond to a suggestion** -- Look at the highlighted text in this document. Open the side panel to accept or dismiss annotations, or press Ctrl+Shift+R for Review Mode.
 2. **Ask Claude a question** -- Select some text and press Ctrl+Shift+A, or type in the Chat panel.
 3. **Make an edit** -- Click anywhere in the document and start typing. You can simplify sentences, fix typos, or add new content.
 
@@ -18,4 +18,4 @@ Open Claude Code from any directory -- your Tandem tools are already configured.
 
 The project launched in early 2025 with three core goals: simplify onboarding, reduce support tickets by 40%, and ship a self-service dashboard by Q3. The team completed the first two milestones ahead of schedule, but the dashboard timeline slipped due to an unexpected API redesign in May.
 
-> Once Claude connects, ask it to review this document -- you'll see highlights and suggestions appear in the side panel.
+> Once Claude connects, try asking it to help you improve this text -- you'll see highlights and suggestions appear in the side panel.

--- a/src/cli/skill-content.ts
+++ b/src/cli/skill-content.ts
@@ -6,7 +6,7 @@ export const SKILL_CONTENT = `---
 name: tandem
 description: >
   Use when tandem_* MCP tools are available, the user asks about Tandem
-  document editing, or collaborative document review. Provides workflow
+  document editing, or iterating on text collaboratively. Provides workflow
   guidance, annotation strategy, and tool usage patterns for the Tandem
   collaborative editor.
 ---
@@ -27,13 +27,13 @@ These prevent the most common failures. Follow them always.
 
 ## Workflow
 
-Standard review sequence:
+Standard workflow:
 
 1. \`tandem_status\` — check for already-open documents (sessions restore automatically)
 2. \`tandem_getOutline\` — understand document structure
-3. \`tandem_setStatus("Reviewing [section]...", { focusParagraph: N })\` — show progress (use \`index\` from outline)
+3. \`tandem_setStatus("Working on [section]...", { focusParagraph: N })\` — show progress (use \`index\` from outline)
 4. \`tandem_getTextContent({ section: "..." })\` — read one section at a time
-5. Annotate findings (see annotation guide below)
+5. Annotate or edit as needed (see annotation guide below)
 6. \`tandem_checkInbox\` — check for user messages and actions
 7. Repeat steps 3-6 for each section
 8. \`tandem_save\` — persist edits to disk when done


### PR DESCRIPTION
Reframe the README positioning away from "collaborative document review"
toward the primary use case: eliminating copy-paste friction when iterating
on text with an LLM. Key changes:

- Rewrite opening pitch around the copy-paste problem and seamless entry
  ("just tell Claude 'let's work on X in tandem'")
- Add "Why Tandem?" section highlighting no copy-paste, full LLM via MCP,
  and in-place iteration
- Reframe "Using Tandem" bullets: "Point at what you mean" and "Iterate on
  Claude's response" instead of review-centric language
- Reorder Features: Chat (iteration surface) before Annotations; add MCP
  bullet; remove redundant "Selection-aware chat" bullet

https://claude.ai/code/session_01Sw2C8A8baxXBTpoPoiD9p1