### PR TITLE
fix(ui): session persistence, tab bar scrollbar, tab cycling shortcuts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Full file-level detail: [docs/architecture.md](docs/architecture.md#file-map)
 
 ## Status
 
-Core complete: 30 MCP tools, multi-doc tabs, CRDT-anchored annotations, chat sidebar, channel push, .md/.docx/.txt/.html support, npm global install (`tandem-editor`), Tauri desktop app (v0.4.0), 951 tests. See [docs/roadmap.md](docs/roadmap.md) for remaining work.
+Core complete: 30 MCP tools, multi-doc tabs, CRDT-anchored annotations, chat sidebar, channel push, .md/.docx/.txt/.html support, npm global install (`tandem-editor`), Tauri desktop app (v0.4.0), 1012 tests. See [docs/roadmap.md](docs/roadmap.md) for remaining work.
 
 <!-- autoskills:start -->
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,7 +73,7 @@ Close the browser, restart the server, reopen — document and annotations are s
   - Browser-open tracking
 - **Save triggers:**
   - On `tandem_save()` — save session alongside file save
-  - On `tandem_close()` — save session before clearing state
+  - On `tandem_close()` — delete session file (so closed docs don't reopen on restart)
   - Auto-save every 60 seconds while a document is open
   - On server shutdown (SIGTERM/SIGINT handler)
 - **Resume flow:**
@@ -184,6 +184,7 @@ Remaining:
 - ~~Review Mode toggle~~ — implemented (Ctrl+Shift+R)
 - ~~"+" File Open button~~ — implemented in DocumentTabs (opens FileOpenDialog)
 - ~~Tab overflow + reorder~~ — implemented: horizontal scroll with arrow buttons, HTML5 drag-and-drop reorder, Alt+Left/Right keyboard reorder, filename ellipsis with tooltip (Issue #99)
+- ~~Tab cycling~~ — implemented: Ctrl+Tab / Ctrl+Shift+Tab to cycle through tabs (Issue #266)
 - Highlight color picker (5 colors available server-side, UI picker not yet built)
 
 ### Verification

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -174,15 +174,19 @@ export default function App() {
   // Dep is tabs.length (not tabs) to avoid spurious fires from array identity changes.
   useEffect(() => {
     if (tabs.length === 0) return;
-    const before = loadRecentFiles();
-    let recent = before;
-    for (const tab of tabs) {
-      if (!tab.filePath.startsWith("upload://")) {
-        recent = addRecentFile(recent, tab.filePath);
+    try {
+      const before = loadRecentFiles();
+      let recent = before;
+      for (const tab of tabs) {
+        if (!tab.filePath.startsWith("upload://")) {
+          recent = addRecentFile(recent, tab.filePath);
+        }
       }
-    }
-    if (recent.length !== before.length || recent.some((p, i) => p !== before[i])) {
-      saveRecentFiles(recent);
+      if (recent.length !== before.length || recent.some((p, i) => p !== before[i])) {
+        saveRecentFiles(recent);
+      }
+    } catch (err) {
+      console.warn("[tandem] failed to sync recent files:", err);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabs.length]);

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -27,6 +27,7 @@ import { useModeGate } from "./hooks/useModeGate";
 import { useNotifications } from "./hooks/useNotifications";
 import { useReviewCompletion } from "./hooks/useReviewCompletion";
 import { useSaveShortcut } from "./hooks/useSaveShortcut";
+import { useTabCycleKeyboard } from "./hooks/useTabCycleKeyboard";
 import { useTabOrder } from "./hooks/useTabOrder";
 import { useTandemSettings } from "./hooks/useTandemSettings";
 import { useTutorial } from "./hooks/useTutorial";
@@ -40,6 +41,7 @@ import { pmSelectionToFlat } from "./positions";
 import { StatusBar } from "./status/StatusBar";
 import { DocumentTabs } from "./tabs/DocumentTabs";
 import type { DocListEntry, OpenTab } from "./types";
+import { addRecentFile, loadRecentFiles, saveRecentFiles } from "./utils/recentFiles";
 
 export type { DocListEntry, OpenTab };
 
@@ -166,6 +168,24 @@ export default function App() {
   } = useYjsSync();
 
   const { orderedTabs, reorder } = useTabOrder(tabs);
+  useTabCycleKeyboard(orderedTabs, activeTabId, setActiveTabId);
+
+  // Sync open tabs into the recent files list so files opened by Claude also appear.
+  // Dep is tabs.length (not tabs) to avoid spurious fires from array identity changes.
+  useEffect(() => {
+    if (tabs.length === 0) return;
+    const before = loadRecentFiles();
+    let recent = before;
+    for (const tab of tabs) {
+      if (!tab.filePath.startsWith("upload://")) {
+        recent = addRecentFile(recent, tab.filePath);
+      }
+    }
+    if (recent.length !== before.length || recent.some((p, i) => p !== before[i])) {
+      saveRecentFiles(recent);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabs.length]);
 
   // Tandem mode — persisted to localStorage
   const [tandemMode, setTandemMode] = useState<TandemMode>(() => {

--- a/src/client/components/HelpModal.tsx
+++ b/src/client/components/HelpModal.tsx
@@ -38,6 +38,15 @@ const SECTIONS: ShortcutSection[] = [
     rows: [{ keys: ["Enter"], description: "Send message" }],
   },
   {
+    title: "Tabs",
+    rows: [
+      { keys: ["Ctrl", "Tab"], description: "Next tab" },
+      { keys: ["Ctrl", "Shift", "Tab"], description: "Previous tab" },
+      { keys: ["Alt", "←"], description: "Move tab left" },
+      { keys: ["Alt", "→"], description: "Move tab right" },
+    ],
+  },
+  {
     title: "General",
     rows: [{ keys: ["?"], description: "Show / hide this help" }],
   },

--- a/src/client/hooks/useTabCycleKeyboard.ts
+++ b/src/client/hooks/useTabCycleKeyboard.ts
@@ -1,5 +1,18 @@
 import { useEffect, useRef } from "react";
 
+/** Pure cycling logic — exported for direct testing. */
+export function cycleTab(
+  tabs: Array<{ id: string }>,
+  activeTabId: string | null,
+  shiftKey: boolean,
+): string | null {
+  if (tabs.length < 2) return null;
+  const currentIdx = tabs.findIndex((t) => t.id === activeTabId);
+  const direction = shiftKey ? -1 : 1;
+  const nextIdx = (currentIdx + direction + tabs.length) % tabs.length;
+  return tabs[nextIdx].id;
+}
+
 /**
  * Ctrl+Tab / Ctrl+Shift+Tab to cycle through document tabs.
  * Registers a single listener on mount; refs avoid churn on every tab switch.
@@ -18,15 +31,12 @@ export function useTabCycleKeyboard(
     const handler = (e: KeyboardEvent) => {
       if (!e.ctrlKey && !e.metaKey) return;
       if (e.key !== "Tab") return;
-      const tabs = tabsRef.current;
-      if (tabs.length < 2) return;
+
+      const nextId = cycleTab(tabsRef.current, activeRef.current, e.shiftKey);
+      if (!nextId) return;
 
       e.preventDefault();
-
-      const currentIdx = tabs.findIndex((t) => t.id === activeRef.current);
-      const direction = e.shiftKey ? -1 : 1;
-      const nextIdx = (currentIdx + direction + tabs.length) % tabs.length;
-      setActiveTabId(tabs[nextIdx].id);
+      setActiveTabId(nextId);
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);

--- a/src/client/hooks/useTabCycleKeyboard.ts
+++ b/src/client/hooks/useTabCycleKeyboard.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Ctrl+Tab / Ctrl+Shift+Tab to cycle through document tabs.
+ * Registers a single listener on mount; refs avoid churn on every tab switch.
+ */
+export function useTabCycleKeyboard(
+  orderedTabs: Array<{ id: string }>,
+  activeTabId: string | null,
+  setActiveTabId: (id: string) => void,
+): void {
+  const tabsRef = useRef(orderedTabs);
+  tabsRef.current = orderedTabs;
+  const activeRef = useRef(activeTabId);
+  activeRef.current = activeTabId;
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return;
+      if (e.key !== "Tab") return;
+      const tabs = tabsRef.current;
+      if (tabs.length < 2) return;
+
+      e.preventDefault();
+
+      const currentIdx = tabs.findIndex((t) => t.id === activeRef.current);
+      const direction = e.shiftKey ? -1 : 1;
+      const nextIdx = (currentIdx + direction + tabs.length) % tabs.length;
+      setActiveTabId(tabs[nextIdx].id);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [setActiveTabId]);
+}

--- a/src/client/tabs/DocumentTabs.tsx
+++ b/src/client/tabs/DocumentTabs.tsx
@@ -389,6 +389,7 @@ export function DocumentTabs({
           gap: "1px",
           flex: 1,
           overflowX: "auto",
+          overflowY: "hidden",
           padding: "0 4px",
         }}
       >

--- a/src/client/utils/recentFiles.ts
+++ b/src/client/utils/recentFiles.ts
@@ -13,7 +13,8 @@ export function loadRecentFiles(): string[] {
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
     return parsed.filter((x): x is string => typeof x === "string");
-  } catch {
+  } catch (err) {
+    console.warn("[tandem] failed to load recent files:", err);
     return [];
   }
 }
@@ -21,15 +22,15 @@ export function loadRecentFiles(): string[] {
 export function saveRecentFiles(list: string[]): void {
   try {
     localStorage.setItem(RECENT_FILES_KEY, JSON.stringify(list));
-  } catch {
-    // localStorage unavailable (incognito, storage-disabled)
+  } catch (err) {
+    console.warn("[tandem] failed to save recent files:", err);
   }
 }
 
 export function clearRecentFiles(): void {
   try {
     localStorage.removeItem(RECENT_FILES_KEY);
-  } catch {
-    // localStorage unavailable (incognito, storage-disabled)
+  } catch (err) {
+    console.warn("[tandem] failed to clear recent files:", err);
   }
 }

--- a/src/server/mcp/document-service.ts
+++ b/src/server/mcp/document-service.ts
@@ -288,15 +288,14 @@ export async function closeDocumentById(
   // Clear save lock to prevent a close-reopen race where the old lock blocks new saves
   savingDocs.delete(id);
 
-  // Best-effort persist before removing — save failure should not prevent close
-  try {
-    const doc = getOrCreateDocument(id);
-    await saveSession(docState.filePath, docState.format, doc);
-  } catch (err) {
-    console.error(`[Tandem] Failed to save session before closing ${id}:`, err);
-  }
-
   removeDoc(id);
+
+  // Delete the session file so this document doesn't reopen on restart
+  try {
+    await deleteSession(docState.filePath);
+  } catch (err) {
+    console.error(`[Tandem] Failed to delete session for ${id}:`, err);
+  }
 
   if (getActiveDocId() === id) {
     const remaining = Array.from(openDocs.keys());

--- a/tests/client/useTabCycleKeyboard.test.ts
+++ b/tests/client/useTabCycleKeyboard.test.ts
@@ -1,25 +1,9 @@
 import { describe, expect, it } from "vitest";
-
-/**
- * Tests for the tab-cycling logic used by useTabCycleKeyboard.
- * Extracted to avoid needing a full React/DOM environment.
- */
-
-function cycleTab(
-  tabs: { id: string }[],
-  activeTabId: string | null,
-  shiftKey: boolean,
-): string | null {
-  if (tabs.length < 2) return null;
-  const currentIdx = tabs.findIndex((t) => t.id === activeTabId);
-  const direction = shiftKey ? -1 : 1;
-  const nextIdx = (currentIdx + direction + tabs.length) % tabs.length;
-  return tabs[nextIdx].id;
-}
+import { cycleTab } from "../../src/client/hooks/useTabCycleKeyboard.js";
 
 const tabs = [{ id: "a" }, { id: "b" }, { id: "c" }];
 
-describe("tab cycle logic", () => {
+describe("cycleTab", () => {
   it("cycles forward from first tab", () => {
     expect(cycleTab(tabs, "a", false)).toBe("b");
   });
@@ -38,6 +22,10 @@ describe("tab cycle logic", () => {
 
   it("returns null with fewer than 2 tabs", () => {
     expect(cycleTab([{ id: "only" }], "only", false)).toBeNull();
+  });
+
+  it("returns null with zero tabs", () => {
+    expect(cycleTab([], null, false)).toBeNull();
   });
 
   it("handles unknown activeTabId by cycling from index -1", () => {

--- a/tests/client/useTabCycleKeyboard.test.ts
+++ b/tests/client/useTabCycleKeyboard.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Tests for the tab-cycling logic used by useTabCycleKeyboard.
+ * Extracted to avoid needing a full React/DOM environment.
+ */
+
+function cycleTab(
+  tabs: { id: string }[],
+  activeTabId: string | null,
+  shiftKey: boolean,
+): string | null {
+  if (tabs.length < 2) return null;
+  const currentIdx = tabs.findIndex((t) => t.id === activeTabId);
+  const direction = shiftKey ? -1 : 1;
+  const nextIdx = (currentIdx + direction + tabs.length) % tabs.length;
+  return tabs[nextIdx].id;
+}
+
+const tabs = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+describe("tab cycle logic", () => {
+  it("cycles forward from first tab", () => {
+    expect(cycleTab(tabs, "a", false)).toBe("b");
+  });
+
+  it("cycles forward from last tab wraps to first", () => {
+    expect(cycleTab(tabs, "c", false)).toBe("a");
+  });
+
+  it("cycles backward from first tab wraps to last", () => {
+    expect(cycleTab(tabs, "a", true)).toBe("c");
+  });
+
+  it("cycles backward from middle tab", () => {
+    expect(cycleTab(tabs, "b", true)).toBe("a");
+  });
+
+  it("returns null with fewer than 2 tabs", () => {
+    expect(cycleTab([{ id: "only" }], "only", false)).toBeNull();
+  });
+
+  it("handles unknown activeTabId by cycling from index -1", () => {
+    // findIndex returns -1, so (-1 + 1 + 3) % 3 = 0 → first tab
+    expect(cycleTab(tabs, "unknown", false)).toBe("a");
+  });
+});

--- a/tests/server/document-service.test.ts
+++ b/tests/server/document-service.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../src/server/session/manager.js", async (importOriginal) => {
   return {
     ...actual,
     saveSession: vi.fn().mockResolvedValue(undefined),
+    deleteSession: vi.fn().mockResolvedValue(undefined),
     stopAutoSave: vi.fn(),
   };
 });
@@ -353,6 +354,15 @@ describe("closeDocumentById", () => {
 
     await closeDocumentById("final-doc");
     expect(stopAutoSave).toHaveBeenCalled();
+  });
+
+  it("deletes the session file on close", async () => {
+    const { deleteSession } = await import("../../src/server/session/manager.js");
+    addDoc("del-session", makeOpenDoc("del-session", "/tmp/del.md"));
+    setActiveDocId("del-session");
+
+    await closeDocumentById("del-session");
+    expect(deleteSession).toHaveBeenCalledWith("/tmp/del.md");
   });
 
   it("broadcasts updated doc list after close", async () => {

--- a/tests/server/document-service.test.ts
+++ b/tests/server/document-service.test.ts
@@ -357,12 +357,32 @@ describe("closeDocumentById", () => {
   });
 
   it("deletes the session file on close", async () => {
-    const { deleteSession } = await import("../../src/server/session/manager.js");
+    const { deleteSession, saveSession } = await import("../../src/server/session/manager.js");
+    vi.mocked(saveSession).mockClear();
     addDoc("del-session", makeOpenDoc("del-session", "/tmp/del.md"));
     setActiveDocId("del-session");
 
     await closeDocumentById("del-session");
     expect(deleteSession).toHaveBeenCalledWith("/tmp/del.md");
+    expect(saveSession).not.toHaveBeenCalled();
+  });
+
+  it("succeeds even when deleteSession rejects", async () => {
+    const { deleteSession } = await import("../../src/server/session/manager.js");
+    vi.mocked(deleteSession).mockClear();
+    vi.mocked(deleteSession).mockRejectedValueOnce(new Error("EPERM"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    addDoc("fail-del", makeOpenDoc("fail-del", "/tmp/fail.md"));
+    setActiveDocId("fail-del");
+
+    const result = await closeDocumentById("fail-del");
+    expect(result.success).toBe(true);
+    expect(hasDoc("fail-del")).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to delete session"),
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
   });
 
   it("broadcasts updated doc list after close", async () => {


### PR DESCRIPTION
## Summary

- **#268 Session persistence bug**: `closeDocumentById()` now deletes the session file instead of saving it, so closed tabs don't reopen on restart. Also syncs all open tabs (including Claude-opened files) to the recent files list via a new `useEffect` in App.tsx.
- **#267 Tab bar scrollbar**: Added `overflowY: "hidden"` to the tab scroll container — eliminates the unwanted vertical scrollbar.
- **#266 Ctrl+Tab tab cycling**: New `useTabCycleKeyboard` hook with ref-based listener (registers once, no churn on tab switches). Added "Tabs" section to HelpModal documenting all tab shortcuts.

Closes #266, Closes #267, Closes #268

## Test plan

- [ ] Open multiple files, close some tabs, restart server — closed tabs should NOT reopen
- [ ] Open a file via Claude (`tandem_open`), then open FileOpenDialog — file should appear in Recent list
- [ ] Verify tab bar has no vertical scrollbar with 1-5 tabs open
- [ ] Ctrl+Tab cycles forward through tabs, Ctrl+Shift+Tab cycles backward, wraps around
- [ ] Press `?` to open help modal — verify new "Tabs" section appears with all 4 shortcuts
- [ ] `npm test` passes (1012 tests including 2 new test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)