### PR TITLE
docs: add v1.0 release plan to roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - **Start the server before connecting Claude Code.** `npm run dev:standalone` runs both. Vite hot-reloads client code; restart `dev:server` then `/mcp` in Claude Code for server changes.
 
 ## Documentation
-- [MCP Tool Reference](docs/mcp-tools.md) -- All 30 MCP tools + channel API endpoints
+- [MCP Tool Reference](docs/mcp-tools.md) -- All 31 MCP tools + channel API endpoints
 - [Architecture](docs/architecture.md) -- Diagrams, data flows, coordinate systems, file map
 - [Workflows](docs/workflows.md) -- Real-world usage patterns
 - [Agent Workflow](docs/agent-workflow.md) -- 10-step agent-driven issue pipeline (`/issue-pipeline`)
@@ -117,7 +117,7 @@ Full file-level detail: [docs/architecture.md](docs/architecture.md#file-map)
 
 ## Status
 
-Core complete: 30 MCP tools, multi-doc tabs, CRDT-anchored annotations, chat sidebar, channel push, .md/.docx/.txt/.html support, npm global install (`tandem-editor`), Tauri desktop app (v0.4.0), 1012 tests. See [docs/roadmap.md](docs/roadmap.md) for remaining work.
+Core complete: 31 MCP tools, multi-doc tabs, CRDT-anchored annotations, chat sidebar, channel push, .md/.docx/.txt/.html support, npm global install (`tandem-editor`), Tauri desktop app (v0.4.0), 1014 tests. See [docs/roadmap.md](docs/roadmap.md) for remaining work.
 
 <!-- autoskills:start -->
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ See the full [Roadmap](docs/roadmap.md) and [Known Limitations](docs/roadmap.md#
 ## Documentation
 
 - **[User Guide](docs/user-guide.md)** — How to use Tandem: browser UI, annotations, chat, review mode, keyboard shortcuts
-- [MCP Tool Reference](docs/mcp-tools.md) — 30 MCP tools + channel API endpoints
+- [MCP Tool Reference](docs/mcp-tools.md) — 31 MCP tools + channel API endpoints
 - [Architecture](docs/architecture.md) — System design, data flows, coordinate systems, channel push
 - [Workflows](docs/workflows.md) — Claude Code usage patterns: text iteration, cross-referencing, multi-model
 - [Roadmap](docs/roadmap.md) — Phase 2+ roadmap, known issues, future extensions

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tool Reference
 
-Tandem exposes 30 tools via MCP HTTP (Model Context Protocol). The channel shim also exposes `tandem_reply` for real-time push contexts; Claude Code discovers both transports automatically. All tools use flat text character offsets for positions -- use `tandem_resolveRange` to get safe offsets from text patterns.
+Tandem exposes 31 tools via MCP HTTP (Model Context Protocol). The channel shim also exposes `tandem_reply` for real-time push contexts; Claude Code discovers both transports automatically. All tools use flat text character offsets for positions -- use `tandem_resolveRange` to get safe offsets from text patterns.
 
 ## Response Format
 
@@ -566,6 +566,38 @@ tandem_editAnnotation({
 - Only pending annotations can be edited — accepted or dismissed annotations return an error.
 - Sets `editedAt` timestamp on the annotation. The browser shows an "(edited)" indicator.
 - `newText` sets the `suggestedText` field directly on the annotation, turning a plain comment into a replacement suggestion (or updating an existing one).
+
+---
+
+### tandem_annotationReply
+
+Reply to an annotation thread. Only works on pending annotations.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `annotationId` | string | yes | The annotation ID to reply to |
+| `text` | string | yes | Reply text |
+| `documentId` | string | no | Target document ID (defaults to active document) |
+
+**Returns:**
+```json
+{ "replyId": "reply_1710936500000_x1y2z3", "annotationId": "ann_1710936000000_a1b2c3" }
+```
+
+**Errors:** `NO_DOCUMENT` (document not found), `NOT_FOUND` (annotation not found), `ANNOTATION_RESOLVED` (annotation already resolved).
+
+**Example:**
+```
+tandem_annotationReply({
+  annotationId: "ann_1710936000000_a1b2c3",
+  text: "Good point — I'll revise the wording in the next edit."
+})
+```
+
+**Notes:**
+- Replies are threaded under the parent annotation. The browser renders them as a conversation.
+- Only pending annotations accept replies — resolved annotations return `ANNOTATION_RESOLVED`.
+- The reply author is set to `"claude"` when called via MCP.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -353,6 +353,71 @@ Future hardening (not blocking release):
 
 ---
 
+## v1.0 Release Plan
+
+Six-phase plan to ship Tandem v1.0. Core features are complete (31 MCP tools, multi-doc tabs, CRDT annotations, chat, channel push, npm global install, Tauri desktop). Remaining work focuses on stability, UI polish, and API cleanup.
+
+### Phase 1: Bug Fixes
+
+- **#268 — Session persistence bug:** `closeDocumentById()` saves the session on close instead of marking it closed, causing closed tabs to reopen on restart. Fix: add `open: boolean` flag to `SessionData`. On tab close, save with `open: false`. On restore, filter to `open !== false`. Preserves session data for future recovery UI (#103).
+  - Files: `src/shared/types.ts`, `src/server/mcp/document-service.ts`, `src/server/session/manager.ts`
+- **#267 — Tab bar height:** Fix unnecessary vertical scrollbar in tab container.
+  - Files: `src/client/components/DocumentTabs.tsx`
+
+### Phase 2: Tailwind CSS 4 Migration (#24)
+
+Estimated 10–12 dev days. Replaces ~294 inline `style={{}}` objects across 23 files. Foundation for dark mode, design consistency, and faster UI iteration.
+
+1. **Infrastructure:** Install Tailwind CSS 4 + Vite plugin. Configure theme (primary indigo, gray scale, status colors, highlight colors). Create `editor.css` for Tiptap/ProseMirror content. Configure `dark:` via `class` strategy on `<html>`.
+2. **Extract reusable components first:** `Button` (variants: primary/secondary/ghost/danger), `PanelHeader`, `Badge`/`Pill`.
+3. **Migrate small files first:** StatusBar, DocumentTabs, OnboardingTutorial, ToastContainer, FileOpenDialog, ToolbarButton.
+4. **Migrate large files:** Toolbar (547 LOC), SettingsPopover (326 LOC), ChatPanel (426 LOC), SidePanel (881 LOC), App (889 LOC).
+5. **Verify:** Typecheck, E2E tests (use `data-testid`, unaffected by style changes), visual inspection.
+
+### Phase 3: MCP Tool Consolidation (#259)
+
+Clean up API surface before v1.0 locks it. Breaking changes are acceptable pre-1.0 but not after.
+
+| Tool | Action |
+|------|--------|
+| `tandem_suggest` | Deprecate (keep shim with warning, hard-remove in v1.1) |
+| `tandem_getContent` | Hard-remove (superseded by `tandem_getTextContent`, 0 test deps) |
+| `tandem_getSelections` | Hard-remove (redundant with `tandem_checkInbox.activity.selectedText`) |
+| `tandem_setStatus` | Merge into `tandem_status` (make read/write with optional params) |
+| `tandem_getActivity` | Keep (distinct semantic: user activity vs. editor state) |
+| `tandem_getContext` | Keep (low cost, distinct purpose from text reads) |
+| `tandem_removeAnnotation` | Keep (orphan-reply cleanup logic must stay explicit) |
+
+Net result: ~28 tools (down from 31). Files: `document.ts`, `awareness.ts`, `navigation.ts`, `annotations.ts`, `docs/mcp-tools.md`.
+
+### Phase 4: Dark Theme (#59)
+
+Depends on Phase 2. Tailwind `dark:` classes on `<html>`, toggle in settings, `prefers-color-scheme` default, localStorage persistence, `editor.css` dark overrides, annotation highlight legibility verification.
+
+### Phase 5: First-Run & Session UX
+
+- **#265 — Welcome tutorial update:** Update `sample/welcome.md`, tutorial annotations, and onboarding steps for current UI (Solo/Tandem mode, unified comment button, etc.).
+- **#103 — Session management UI:** Session browser in FileOpenDialog. List sessions with metadata (path, date, annotation count, open/closed). Actions: reopen, delete, clear all. Depends on Phase 1 (`open` flag) and Phase 2 (Tailwind).
+
+### Phase 6: Version Bump to 1.0.0
+
+Bump version, update CHANGELOG, update roadmap, final E2E pass + full build verification.
+
+### Deferred to Post-v1.0
+
+| Item | Reason |
+|------|--------|
+| #260 — Coordinate system refactoring | Risky refactor; tests solid; historical bugs fixed |
+| #153 — Inline images | Nice-to-have, not core |
+| #244 — Windows Playwright deadlock | Investigation-only, CI workaround exists |
+| Three-way merge / conflict UI (5c partial) | Complex; reload behavior acceptable for v1.0 |
+| RANGE_MOVED auto-retry | Edge case |
+| Flag markers / highlight color picker | Minor toolbar gaps |
+| #269 — Desktop UI exploration | Needs scoping |
+| #266 — Keyboard shortcuts (Ctrl+Tab etc.) | Nice-to-have |
+
+---
+
 ## Future Extensions (v2+)
 
 - **Progressive Web App (PWA)** — Lower priority now that the desktop app ships. Would still be useful as a lighter-weight alternative for users who prefer not to install a native app.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -292,21 +292,6 @@ Closing a tab in the browser now actually closes the document on the server. Pre
 
 ---
 
-## Known Limitations (v1)
-
-These are intentional scope boundaries, not bugs:
-
-- .docx is review-only — use Word for final formatting/production
-- No formula support in tables
-- No .xlsx/.csv support (deferred to v2)
-- No drawing/freeform annotation (deferred to v2)
-- Single user + Claude only (no multi-human collaboration)
-- Documents over ~50 pages may be slow to render
-- No plugin/extension architecture — custom extensions require code changes
-- No synchronized scrolling between split panes
-
----
-
 ## Tauri Desktop — DONE (v0.4.0, PR #257)
 
 Native desktop distribution via Tauri v2. The Node.js server runs as a bundled sidecar; the WebView loads the existing web client unchanged.
@@ -355,23 +340,18 @@ Future hardening (not blocking release):
 
 ## v1.0 Release Plan
 
-Six-phase plan to ship Tandem v1.0. Core features are complete (31 MCP tools, multi-doc tabs, CRDT annotations, chat, channel push, npm global install, Tauri desktop). Remaining work focuses on stability, UI polish, and API cleanup.
+Five-phase plan to ship Tandem v1.0. Core features are complete (31 MCP tools, multi-doc tabs, CRDT annotations, chat, channel push, npm global install, Tauri desktop). Remaining work focuses on UI polish and API cleanup.
 
-### Phase 1: Bug Fixes
-
-- **#268 — Session persistence bug:** `closeDocumentById()` saves the session on close instead of marking it closed, causing closed tabs to reopen on restart. Fix: add `open: boolean` flag to `SessionData`. On tab close, save with `open: false`. On restore, filter to `open !== false`. Preserves session data for future recovery UI (#103).
-  - Files: `src/shared/types.ts`, `src/server/mcp/document-service.ts`, `src/server/session/manager.ts`
-- **#267 — Tab bar height:** Fix unnecessary vertical scrollbar in tab container.
-  - Files: `src/client/components/DocumentTabs.tsx`
+> **Phase 1 (Bug Fixes) is done.** #268 (session persistence), #267 (tab bar height), and #266 (keyboard shortcuts) were all fixed in PR #278.
 
 ### Phase 2: Tailwind CSS 4 Migration (#24)
 
-Estimated 10–12 dev days. Replaces ~294 inline `style={{}}` objects across 23 files. Foundation for dark mode, design consistency, and faster UI iteration.
+Estimated 10–12 dev days. Replaces ~290 inline `style={{}}` objects across ~22 files. Foundation for dark mode, design consistency, and faster UI iteration.
 
 1. **Infrastructure:** Install Tailwind CSS 4 + Vite plugin. Configure theme (primary indigo, gray scale, status colors, highlight colors). Create `editor.css` for Tiptap/ProseMirror content. Configure `dark:` via `class` strategy on `<html>`.
 2. **Extract reusable components first:** `Button` (variants: primary/secondary/ghost/danger), `PanelHeader`, `Badge`/`Pill`.
 3. **Migrate small files first:** StatusBar, DocumentTabs, OnboardingTutorial, ToastContainer, FileOpenDialog, ToolbarButton.
-4. **Migrate large files:** Toolbar (547 LOC), SettingsPopover (326 LOC), ChatPanel (426 LOC), SidePanel (881 LOC), App (889 LOC).
+4. **Migrate large files:** Toolbar (547 LOC), SettingsPopover (326 LOC), ChatPanel (426 LOC), SidePanel (881 LOC), App (913 LOC).
 5. **Verify:** Typecheck, E2E tests (use `data-testid`, unaffected by style changes), visual inspection.
 
 ### Phase 3: MCP Tool Consolidation (#259)
@@ -381,7 +361,7 @@ Clean up API surface before v1.0 locks it. Breaking changes are acceptable pre-1
 | Tool | Action |
 |------|--------|
 | `tandem_suggest` | Deprecate (keep shim with warning, hard-remove in v1.1) |
-| `tandem_getContent` | Hard-remove (superseded by `tandem_getTextContent`, 0 test deps) |
+| `tandem_getContent` | Hard-remove (superseded by `tandem_getTextContent`, 1 test dep in `document-tools.test.ts`) |
 | `tandem_getSelections` | Hard-remove (redundant with `tandem_checkInbox.activity.selectedText`) |
 | `tandem_setStatus` | Merge into `tandem_status` (make read/write with optional params) |
 | `tandem_getActivity` | Keep (distinct semantic: user activity vs. editor state) |
@@ -397,11 +377,11 @@ Depends on Phase 2. Tailwind `dark:` classes on `<html>`, toggle in settings, `p
 ### Phase 5: First-Run & Session UX
 
 - **#265 — Welcome tutorial update:** Update `sample/welcome.md`, tutorial annotations, and onboarding steps for current UI (Solo/Tandem mode, unified comment button, etc.).
-- **#103 — Session management UI:** Session browser in FileOpenDialog. List sessions with metadata (path, date, annotation count, open/closed). Actions: reopen, delete, clear all. Depends on Phase 1 (`open` flag) and Phase 2 (Tailwind).
+- **#103 — Session management UI:** Session browser in FileOpenDialog. List sessions with metadata (path, date, annotation count, open/closed). Actions: reopen, delete, clear all. Depends on Phase 2 (Tailwind).
 
 ### Phase 6: Version Bump to 1.0.0
 
-Bump version, update CHANGELOG, update roadmap, final E2E pass + full build verification.
+Bump version, update CHANGELOG, update roadmap, update `CLAUDE.md` and `docs/mcp-tools.md` to reflect any tool removals from Phase 3, final E2E pass + full build verification.
 
 ### Deferred to Post-v1.0
 
@@ -414,7 +394,21 @@ Bump version, update CHANGELOG, update roadmap, final E2E pass + full build veri
 | RANGE_MOVED auto-retry | Edge case |
 | Flag markers / highlight color picker | Minor toolbar gaps |
 | #269 — Desktop UI exploration | Needs scoping |
-| #266 — Keyboard shortcuts (Ctrl+Tab etc.) | Nice-to-have |
+
+---
+
+## Known Limitations (v1)
+
+These are intentional scope boundaries, not bugs:
+
+- .docx is review-only — use Word for final formatting/production
+- No formula support in tables
+- No .xlsx/.csv support (deferred to v2)
+- No drawing/freeform annotation (deferred to v2)
+- Single user + Claude only (no multi-human collaboration)
+- Documents over ~50 pages may be slow to render
+- No plugin/extension architecture — custom extensions require code changes
+- No synchronized scrolling between split panes
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -257,7 +257,7 @@ Press `?` to open the in-app shortcuts reference at any time.
 
 ## Working with Claude Code
 
-Tandem connects to Claude Code through MCP (Model Context Protocol). Claude gets 30 tools for reading documents, creating annotations, searching text, managing files, and communicating with you.
+Tandem connects to Claude Code through MCP (Model Context Protocol). Claude gets 31 tools for reading documents, creating annotations, searching text, managing files, and communicating with you.
 
 ### Connection
 
@@ -318,7 +318,7 @@ Previously-open documents are auto-restored when the server starts — no manual
 
 ### Further Reading
 
-- [MCP Tool Reference](mcp-tools.md) — Full documentation for all 30 tools
+- [MCP Tool Reference](mcp-tools.md) — Full documentation for all 31 tools
 - [Workflows](workflows.md) — Advanced Claude Code patterns: cross-referencing documents, multi-model collaboration, RFP drafting, session handoff details
 - [Architecture](architecture.md) — System design, coordinate systems, data flows
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -32,7 +32,7 @@ Setup complete! Start Tandem with: tandem
 Then in Claude, your tandem_* tools will be available.
 ```
 
-The skill teaches Claude how to use Tandem's 30 MCP tools effectively — workflow patterns, annotation strategy, Solo/Tandem mode respect, and error recovery. It auto-activates when Claude detects `tandem_*` tools.
+The skill teaches Claude how to use Tandem's 31 MCP tools effectively — workflow patterns, annotation strategy, Solo/Tandem mode respect, and error recovery. It auto-activates when Claude detects `tandem_*` tools.
 
 Start Tandem from any directory:
 ```bash


### PR DESCRIPTION
Six-phase plan covering bug fixes (#268, #267), Tailwind CSS 4 migration (#24), MCP tool consolidation (#259), dark theme (#59), tutorial/session UX (#265, #103), and version bump. Includes deferred items list.

https://claude.ai/code/session_01Ls5YS6P4aRvNLrSzZHAm7N