### PR TITLE
feat(settings): expand Settings popover (Tier 0 + Tier 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Tandem will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Settings expansion** — Settings popover grows from layout/dwell/authorship into a fuller preferences surface:
+  - Ctrl+, / Cmd+, hotkey (AZERTY/QWERTZ/IME-safe, survives non-QWERTY layouts)
+  - Display Name field, synced live with the StatusBar via a shared `useUserName` hook
+  - Reduce Motion toggle (JS-gates all autoscroll paths; defaults to `prefers-reduced-motion`)
+  - Text Size S/M/L for editor reading density (browser zoom remains the WCAG 1.4.4 path)
+  - Theme Light/Dark/System (CSS custom-property token system on `<html data-theme>` with `forced-colors` support for Windows High Contrast)
+- Tier 0 accessibility prerequisites on SettingsPopover: `role="dialog"` + `aria-modal`, focus trap, Escape-to-close, pointerdown outside-dismiss, radiogroup semantics, 24×24 hit targets, focus-return on close
+
+### Changed
+
+- Settings heading renamed "Layout Settings" → "Settings"
+- Settings popover hardcoded hex values swapped to CSS tokens (remaining components will migrate in a follow-up)
+
 ## [0.5.1] - 2026-04-13
 
 ### Fixed

--- a/index.html
+++ b/index.html
@@ -7,7 +7,62 @@
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       html, body, #root { height: 100%; }
-      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        background: var(--tandem-bg, #fff);
+        color: var(--tandem-fg, #111827);
+      }
+
+      /* Tandem theme tokens.
+         Light is the default; dark overrides via [data-theme="dark"] on <html>.
+         Pairs meet WCAG AA (4.5:1 for small text, 3:1 for large/non-text). */
+      :root {
+        --tandem-bg: #ffffff;
+        --tandem-fg: #111827;
+        --tandem-surface: #ffffff;
+        --tandem-surface-muted: #f9fafb;
+        --tandem-border: #e5e7eb;
+        --tandem-border-strong: #d1d5db;
+        --tandem-fg-muted: #6b7280;
+        --tandem-fg-subtle: #9ca3af;
+        --tandem-accent: #6366f1;
+        --tandem-accent-fg: #ffffff;
+        --tandem-accent-bg: #eef2ff;
+        --tandem-accent-fg-strong: #4338ca;
+      }
+
+      [data-theme="dark"] {
+        --tandem-bg: #0f172a;
+        --tandem-fg: #f3f4f6;
+        --tandem-surface: #1e293b;
+        --tandem-surface-muted: #111827;
+        --tandem-border: #334155;
+        --tandem-border-strong: #475569;
+        --tandem-fg-muted: #cbd5e1;
+        --tandem-fg-subtle: #94a3b8;
+        --tandem-accent: #818cf8;
+        --tandem-accent-fg: #0f172a;
+        --tandem-accent-bg: #312e81;
+        --tandem-accent-fg-strong: #c7d2fe;
+      }
+
+      /* Windows High Contrast — let the OS drive everything. */
+      @media (forced-colors: active) {
+        :root, [data-theme="dark"] {
+          --tandem-bg: Canvas;
+          --tandem-fg: CanvasText;
+          --tandem-surface: Canvas;
+          --tandem-surface-muted: Canvas;
+          --tandem-border: CanvasText;
+          --tandem-border-strong: CanvasText;
+          --tandem-fg-muted: CanvasText;
+          --tandem-fg-subtle: GrayText;
+          --tandem-accent: Highlight;
+          --tandem-accent-fg: HighlightText;
+          --tandem-accent-bg: Canvas;
+          --tandem-accent-fg-strong: HighlightText;
+        }
+      }
     </style>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@
         --tandem-accent-fg: #ffffff;
         --tandem-accent-bg: #eef2ff;
         --tandem-accent-fg-strong: #4338ca;
+        --tandem-author-user: #3b82f6;
+        --tandem-author-claude: #ea8a1e;
       }
 
       [data-theme="dark"] {
@@ -44,6 +46,8 @@
         --tandem-accent-fg: #0f172a;
         --tandem-accent-bg: #312e81;
         --tandem-accent-fg-strong: #c7d2fe;
+        --tandem-author-user: #60a5fa;
+        --tandem-author-claude: #fbbf24;
       }
 
       /* Windows High Contrast — let the OS drive everything. */
@@ -61,6 +65,8 @@
           --tandem-accent-fg: HighlightText;
           --tandem-accent-bg: Canvas;
           --tandem-accent-fg-strong: HighlightText;
+          --tandem-author-user: CanvasText;
+          --tandem-author-claude: CanvasText;
         }
       }
     </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-editor",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-editor",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -254,9 +254,8 @@ export default function App() {
   const [settingsAnchor, setSettingsAnchor] = useState<DOMRect | null>(null);
   const settingsBtnRef = useRef<HTMLButtonElement | null>(null);
 
-  const openSettings = useCallback(() => {
-    const rect = settingsBtnRef.current?.getBoundingClientRect() ?? null;
-    setSettingsAnchor(rect);
+  const openAtButton = useCallback(() => {
+    setSettingsAnchor(settingsBtnRef.current?.getBoundingClientRect() ?? null);
     setSettingsOpen(true);
   }, []);
   const settingsOpenRef = useRef(settingsOpen);
@@ -266,10 +265,8 @@ export default function App() {
       setSettingsOpen(false);
       return;
     }
-    const rect = settingsBtnRef.current?.getBoundingClientRect() ?? null;
-    setSettingsAnchor(rect);
-    setSettingsOpen(true);
-  }, []);
+    openAtButton();
+  }, [openAtButton]);
   useSettingsShortcut(toggleSettings);
 
   // Broadcast selection dwell time to CTRL_ROOM so the server uses the user's setting
@@ -511,7 +508,7 @@ export default function App() {
       <Toolbar
         editor={editorRef.current}
         ydoc={activeTab?.ydoc ?? null}
-        onSettingsOpen={openSettings}
+        onSettingsOpen={openAtButton}
         settingsBtnRef={settingsBtnRef}
         tandemMode={tandemMode}
         onModeChange={setTandemMode}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -278,6 +278,14 @@ export default function App() {
     editor.view.dispatch(tr);
   }, [settings.showAuthorship]);
 
+  // Body class mirrors the reduce-motion setting so CSS rules (animations,
+  // transitions) can be scoped without a media query alone. JS-level gating
+  // of scrollIntoView `behavior` still happens in the panels.
+  useEffect(() => {
+    document.body.classList.toggle("tandem-reduce-motion", settings.reduceMotion);
+    return () => document.body.classList.remove("tandem-reduce-motion");
+  }, [settings.reduceMotion]);
+
   const [reviewMode, setReviewMode] = useState(false);
   const [showChat, setShowChat] = useState(() => settings.primaryTab === "chat");
 
@@ -531,6 +539,7 @@ export default function App() {
                   capturedAnchor={capturedAnchor}
                   onCapturedAnchorChange={setCapturedAnchor}
                   inputRef={chatInputRef}
+                  reduceMotion={settings.reduceMotion}
                 />
               ) : (
                 <SidePanel
@@ -547,6 +556,7 @@ export default function App() {
                   onExitReviewMode={exitReviewMode}
                   activeAnnotationId={activeAnnotationId}
                   onActiveAnnotationChange={setActiveAnnotationId}
+                  reduceMotion={settings.reduceMotion}
                 />
               )}
             </div>
@@ -674,6 +684,7 @@ export default function App() {
                   onExitReviewMode={exitReviewMode}
                   activeAnnotationId={activeAnnotationId}
                   onActiveAnnotationChange={setActiveAnnotationId}
+                  reduceMotion={settings.reduceMotion}
                 />
               ) : (
                 <ChatPanel
@@ -687,6 +698,7 @@ export default function App() {
                   capturedAnchor={capturedAnchor}
                   onCapturedAnchorChange={setCapturedAnchor}
                   inputRef={chatInputRef}
+                  reduceMotion={settings.reduceMotion}
                 />
               )}
             </div>
@@ -851,6 +863,7 @@ export default function App() {
                 capturedAnchor={capturedAnchor}
                 onCapturedAnchorChange={setCapturedAnchor}
                 inputRef={chatInputRef}
+                reduceMotion={settings.reduceMotion}
               />
             </div>
             <div
@@ -875,6 +888,7 @@ export default function App() {
                 onExitReviewMode={exitReviewMode}
                 activeAnnotationId={activeAnnotationId}
                 onActiveAnnotationChange={setActiveAnnotationId}
+                reduceMotion={settings.reduceMotion}
               />
             </div>
           </div>

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -27,6 +27,7 @@ import { useModeGate } from "./hooks/useModeGate";
 import { useNotifications } from "./hooks/useNotifications";
 import { useReviewCompletion } from "./hooks/useReviewCompletion";
 import { useSaveShortcut } from "./hooks/useSaveShortcut";
+import { useSettingsShortcut } from "./hooks/useSettingsShortcut";
 import { useTabCycleKeyboard } from "./hooks/useTabCycleKeyboard";
 import { useTabOrder } from "./hooks/useTabOrder";
 import { useTandemSettings } from "./hooks/useTandemSettings";
@@ -251,6 +252,13 @@ export default function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsAnchor, setSettingsAnchor] = useState<DOMRect | null>(null);
   const settingsBtnRef = useRef<HTMLButtonElement | null>(null);
+
+  const openSettings = useCallback(() => {
+    const rect = settingsBtnRef.current?.getBoundingClientRect() ?? null;
+    setSettingsAnchor(rect);
+    setSettingsOpen(true);
+  }, []);
+  useSettingsShortcut(openSettings);
 
   // Broadcast selection dwell time to CTRL_ROOM so the server uses the user's setting
   useEffect(() => {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -499,6 +499,7 @@ export default function App() {
         onTabSwitch={setActiveTabId}
         onTabClose={handleTabClose}
         reorder={reorder}
+        reduceMotion={settings.reduceMotion}
       />
       {panelLayout.kind === "three-panel" ? (
         /* ── Three-panel layout: Left | Editor | Right ── */

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -479,10 +479,7 @@ export default function App() {
       <Toolbar
         editor={editorRef.current}
         ydoc={activeTab?.ydoc ?? null}
-        onSettingsClick={(rect) => {
-          setSettingsAnchor(rect);
-          setSettingsOpen(true);
-        }}
+        onSettingsOpen={openSettings}
         settingsBtnRef={settingsBtnRef}
         tandemMode={tandemMode}
         onModeChange={setTandemMode}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -508,7 +508,7 @@ export default function App() {
       <Toolbar
         editor={editorRef.current}
         ydoc={activeTab?.ydoc ?? null}
-        onSettingsOpen={openAtButton}
+        onSettingsOpen={toggleSettings}
         settingsBtnRef={settingsBtnRef}
         tandemMode={tandemMode}
         onModeChange={setTandemMode}
@@ -942,6 +942,7 @@ export default function App() {
         settings={settings}
         onUpdate={updateSettings}
         returnFocusRef={settingsBtnRef}
+        anchorRef={settingsBtnRef}
       />
       <HelpModal open={showHelp} onClose={() => setShowHelp(false)} />
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -259,7 +259,18 @@ export default function App() {
     setSettingsAnchor(rect);
     setSettingsOpen(true);
   }, []);
-  useSettingsShortcut(openSettings);
+  const settingsOpenRef = useRef(settingsOpen);
+  settingsOpenRef.current = settingsOpen;
+  const toggleSettings = useCallback(() => {
+    if (settingsOpenRef.current) {
+      setSettingsOpen(false);
+      return;
+    }
+    const rect = settingsBtnRef.current?.getBoundingClientRect() ?? null;
+    setSettingsAnchor(rect);
+    setSettingsOpen(true);
+  }, []);
+  useSettingsShortcut(toggleSettings);
 
   // Broadcast selection dwell time to CTRL_ROOM so the server uses the user's setting
   useEffect(() => {
@@ -290,8 +301,7 @@ export default function App() {
   useTheme(settings.theme);
 
   // Expose editor font-size as a CSS custom property so the editor style
-  // picks it up without recreating the Tiptap instance. Reading-density
-  // convenience only — browser zoom (Ctrl+=/-) remains the WCAG 1.4.4 path.
+  // picks it up without recreating the Tiptap instance.
   useEffect(() => {
     const px = TEXT_SIZE_PX[settings.textSize];
     document.documentElement.style.setProperty("--tandem-editor-font-size", `${px}px`);

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -31,6 +31,7 @@ import { useSettingsShortcut } from "./hooks/useSettingsShortcut";
 import { useTabCycleKeyboard } from "./hooks/useTabCycleKeyboard";
 import { useTabOrder } from "./hooks/useTabOrder";
 import { TEXT_SIZE_PX, useTandemSettings } from "./hooks/useTandemSettings";
+import { useTheme } from "./hooks/useTheme";
 import { useTutorial } from "./hooks/useTutorial";
 import { useWebViewZoom } from "./hooks/useWebViewZoom";
 import { useYjsSync } from "./hooks/useYjsSync";
@@ -285,6 +286,8 @@ export default function App() {
     document.body.classList.toggle("tandem-reduce-motion", settings.reduceMotion);
     return () => document.body.classList.remove("tandem-reduce-motion");
   }, [settings.reduceMotion]);
+
+  useTheme(settings.theme);
 
   // Expose editor font-size as a CSS custom property so the editor style
   // picks it up without recreating the Tiptap instance. Reading-density

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -30,7 +30,7 @@ import { useSaveShortcut } from "./hooks/useSaveShortcut";
 import { useSettingsShortcut } from "./hooks/useSettingsShortcut";
 import { useTabCycleKeyboard } from "./hooks/useTabCycleKeyboard";
 import { useTabOrder } from "./hooks/useTabOrder";
-import { useTandemSettings } from "./hooks/useTandemSettings";
+import { TEXT_SIZE_PX, useTandemSettings } from "./hooks/useTandemSettings";
 import { useTutorial } from "./hooks/useTutorial";
 import { useWebViewZoom } from "./hooks/useWebViewZoom";
 import { useYjsSync } from "./hooks/useYjsSync";
@@ -285,6 +285,17 @@ export default function App() {
     document.body.classList.toggle("tandem-reduce-motion", settings.reduceMotion);
     return () => document.body.classList.remove("tandem-reduce-motion");
   }, [settings.reduceMotion]);
+
+  // Expose editor font-size as a CSS custom property so the editor style
+  // picks it up without recreating the Tiptap instance. Reading-density
+  // convenience only — browser zoom (Ctrl+=/-) remains the WCAG 1.4.4 path.
+  useEffect(() => {
+    const px = TEXT_SIZE_PX[settings.textSize];
+    document.documentElement.style.setProperty("--tandem-editor-font-size", `${px}px`);
+    return () => {
+      document.documentElement.style.removeProperty("--tandem-editor-font-size");
+    };
+  }, [settings.textSize]);
 
   const [reviewMode, setReviewMode] = useState(false);
   const [showChat, setShowChat] = useState(() => settings.primaryTab === "chat");

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -250,6 +250,7 @@ export default function App() {
   const { settings, updateSettings } = useTandemSettings();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsAnchor, setSettingsAnchor] = useState<DOMRect | null>(null);
+  const settingsBtnRef = useRef<HTMLButtonElement | null>(null);
 
   // Broadcast selection dwell time to CTRL_ROOM so the server uses the user's setting
   useEffect(() => {
@@ -474,6 +475,7 @@ export default function App() {
           setSettingsAnchor(rect);
           setSettingsOpen(true);
         }}
+        settingsBtnRef={settingsBtnRef}
         tandemMode={tandemMode}
         onModeChange={setTandemMode}
         heldCount={heldCount}
@@ -898,6 +900,7 @@ export default function App() {
         anchorRect={settingsAnchor}
         settings={settings}
         onUpdate={updateSettings}
+        returnFocusRef={settingsBtnRef}
       />
       <HelpModal open={showHelp} onClose={() => setShowHelp(false)} />
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -399,6 +399,33 @@ export function SettingsPopover({
         </div>
       </div>
 
+      {/* Reduce motion */}
+      <div>
+        <label
+          data-testid="reduce-motion-toggle"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            cursor: "pointer",
+            fontSize: "12px",
+            color: "#374151",
+            minHeight: "24px",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={settings.reduceMotion}
+            onChange={(e) => onUpdate({ reduceMotion: e.target.checked })}
+            style={{ accentColor: "#6366f1" }}
+          />
+          <span>Reduce motion</span>
+        </label>
+        <div style={{ fontSize: "10px", color: "#9ca3af", marginTop: "4px" }}>
+          Disables smooth autoscroll and the annotation flash animation.
+        </div>
+      </div>
+
       {/* Selection sensitivity (dwell time) */}
       <div>
         <div style={sectionLabelStyle}>

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useRef, useState } from "react";
-import { SELECTION_DWELL_MAX_MS, SELECTION_DWELL_MIN_MS } from "../../shared/constants";
+import {
+  SELECTION_DWELL_MAX_MS,
+  SELECTION_DWELL_MIN_MS,
+  USER_NAME_MAX_LEN,
+} from "../../shared/constants";
 import { useRadioGroup } from "../hooks/useRadioGroup";
 import type {
   LayoutMode,
@@ -280,7 +284,7 @@ export function SettingsPopover({
               e.currentTarget.blur();
             }
           }}
-          maxLength={40}
+          maxLength={USER_NAME_MAX_LEN}
           style={{
             width: "100%",
             padding: "6px 8px",

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useRef, useState } from "react";
 import { SELECTION_DWELL_MAX_MS, SELECTION_DWELL_MIN_MS } from "../../shared/constants";
-import type { TandemSettings } from "../hooks/useTandemSettings";
+import { useRadioGroup } from "../hooks/useRadioGroup";
+import type {
+  LayoutMode,
+  PanelOrder,
+  PrimaryTab,
+  TandemSettings,
+  TextSize,
+  ThemePreference,
+} from "../hooks/useTandemSettings";
 import { useUserName } from "../hooks/useUserName";
 
 interface SettingsPopoverProps {
@@ -31,6 +39,30 @@ export function SettingsPopover({
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
   const { userName, setUserName } = useUserName();
   const [nameInput, setNameInput] = useState(userName);
+
+  const themeRg = useRadioGroup<ThemePreference>(
+    settings.theme,
+    ["light", "dark", "system"] as const,
+    (t) => onUpdate({ theme: t }),
+  );
+  const layoutRg = useRadioGroup<LayoutMode>(
+    settings.layout,
+    ["tabbed", "three-panel"] as const,
+    (l) => onUpdate({ layout: l }),
+  );
+  const primaryTabRg = useRadioGroup<PrimaryTab>(
+    settings.primaryTab,
+    ["chat", "annotations"] as const,
+    (p) => onUpdate({ primaryTab: p }),
+  );
+  const panelOrderRg = useRadioGroup<PanelOrder>(
+    settings.panelOrder,
+    ["chat-editor-annotations", "annotations-editor-chat"] as const,
+    (p) => onUpdate({ panelOrder: p }),
+  );
+  const textSizeRg = useRadioGroup<TextSize>(settings.textSize, ["s", "m", "l"] as const, (t) =>
+    onUpdate({ textSize: t }),
+  );
 
   // Track viewport width for three-panel availability (only while open)
   useEffect(() => {
@@ -206,7 +238,6 @@ export function SettingsPopover({
         </button>
       </div>
 
-      {/* Display name */}
       <div>
         <label htmlFor="settings-display-name" style={sectionLabelStyle}>
           Display Name
@@ -239,7 +270,6 @@ export function SettingsPopover({
         />
       </div>
 
-      {/* Theme */}
       <div>
         <div id="settings-theme-label" style={sectionLabelStyle}>
           Theme
@@ -247,14 +277,17 @@ export function SettingsPopover({
         <div
           role="radiogroup"
           aria-labelledby="settings-theme-label"
+          onKeyDown={themeRg.handleKeyDown}
           style={{ display: "flex", gap: "8px" }}
         >
           {(["light", "dark", "system"] as const).map((t) => (
             <button
               key={t}
               data-testid={`theme-${t}-btn`}
+              data-radio-value={t}
               role="radio"
               aria-checked={settings.theme === t}
+              tabIndex={themeRg.tabIndexFor(t)}
               onClick={() => onUpdate({ theme: t })}
               style={cardStyle(settings.theme === t)}
             >
@@ -272,12 +305,15 @@ export function SettingsPopover({
         <div
           role="radiogroup"
           aria-labelledby="settings-layout-label"
+          onKeyDown={layoutRg.handleKeyDown}
           style={{ display: "flex", gap: "8px" }}
         >
           <button
             data-testid="layout-tabbed-btn"
+            data-radio-value="tabbed"
             role="radio"
             aria-checked={settings.layout === "tabbed"}
+            tabIndex={layoutRg.tabIndexFor("tabbed")}
             onClick={() => onUpdate({ layout: "tabbed" })}
             style={cardStyle(settings.layout === "tabbed")}
           >
@@ -286,9 +322,11 @@ export function SettingsPopover({
           </button>
           <button
             data-testid="layout-three-panel-btn"
+            data-radio-value="three-panel"
             role="radio"
             aria-checked={settings.layout === "three-panel"}
             aria-disabled={threePanelDisabled || undefined}
+            tabIndex={layoutRg.tabIndexFor("three-panel")}
             onClick={() => {
               if (!threePanelDisabled) onUpdate({ layout: "three-panel" });
             }}
@@ -315,12 +353,15 @@ export function SettingsPopover({
           <div
             role="radiogroup"
             aria-labelledby="settings-default-tab-label"
+            onKeyDown={primaryTabRg.handleKeyDown}
             style={{ display: "flex", gap: "8px" }}
           >
             <button
               data-testid="default-tab-chat-btn"
+              data-radio-value="chat"
               role="radio"
               aria-checked={settings.primaryTab === "chat"}
+              tabIndex={primaryTabRg.tabIndexFor("chat")}
               onClick={() => onUpdate({ primaryTab: "chat" })}
               style={cardStyle(settings.primaryTab === "chat")}
             >
@@ -328,8 +369,10 @@ export function SettingsPopover({
             </button>
             <button
               data-testid="default-tab-annotations-btn"
+              data-radio-value="annotations"
               role="radio"
               aria-checked={settings.primaryTab === "annotations"}
+              tabIndex={primaryTabRg.tabIndexFor("annotations")}
               onClick={() => onUpdate({ primaryTab: "annotations" })}
               style={cardStyle(settings.primaryTab === "annotations")}
             >
@@ -348,12 +391,15 @@ export function SettingsPopover({
           <div
             role="radiogroup"
             aria-labelledby="settings-panel-order-label"
+            onKeyDown={panelOrderRg.handleKeyDown}
             style={{ display: "flex", gap: "8px" }}
           >
             <button
               data-testid="panel-order-cea-btn"
+              data-radio-value="chat-editor-annotations"
               role="radio"
               aria-checked={settings.panelOrder === "chat-editor-annotations"}
+              tabIndex={panelOrderRg.tabIndexFor("chat-editor-annotations")}
               onClick={() => onUpdate({ panelOrder: "chat-editor-annotations" })}
               style={cardStyle(settings.panelOrder === "chat-editor-annotations")}
             >
@@ -361,8 +407,10 @@ export function SettingsPopover({
             </button>
             <button
               data-testid="panel-order-aec-btn"
+              data-radio-value="annotations-editor-chat"
               role="radio"
               aria-checked={settings.panelOrder === "annotations-editor-chat"}
+              tabIndex={panelOrderRg.tabIndexFor("annotations-editor-chat")}
               onClick={() => onUpdate({ panelOrder: "annotations-editor-chat" })}
               style={cardStyle(settings.panelOrder === "annotations-editor-chat")}
             >
@@ -436,7 +484,6 @@ export function SettingsPopover({
         </div>
       </div>
 
-      {/* Text size */}
       <div>
         <div id="settings-text-size-label" style={sectionLabelStyle}>
           Text Size
@@ -444,14 +491,17 @@ export function SettingsPopover({
         <div
           role="radiogroup"
           aria-labelledby="settings-text-size-label"
+          onKeyDown={textSizeRg.handleKeyDown}
           style={{ display: "flex", gap: "8px" }}
         >
           {(["s", "m", "l"] as const).map((size) => (
             <button
               key={size}
               data-testid={`text-size-${size}-btn`}
+              data-radio-value={size}
               role="radio"
               aria-checked={settings.textSize === size}
+              tabIndex={textSizeRg.tabIndexFor(size)}
               onClick={() => onUpdate({ textSize: size })}
               style={cardStyle(settings.textSize === size)}
             >
@@ -464,7 +514,6 @@ export function SettingsPopover({
         </div>
       </div>
 
-      {/* Reduce motion */}
       <div>
         <label
           data-testid="reduce-motion-toggle"

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -31,9 +31,6 @@ export function SettingsPopover({
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
   const { userName, setUserName } = useUserName();
   const [nameInput, setNameInput] = useState(userName);
-  useEffect(() => {
-    setNameInput(userName);
-  }, [userName]);
 
   // Track viewport width for three-panel availability (only while open)
   useEffect(() => {

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -37,6 +37,7 @@ export function SettingsPopover({
 }: SettingsPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
+  const threePanelDisabled = viewportWidth < 768;
   const { userName, setUserName } = useUserName();
   const [nameInput, setNameInput] = useState(userName);
 
@@ -49,6 +50,7 @@ export function SettingsPopover({
     settings.layout,
     ["tabbed", "three-panel"] as const,
     (l) => onUpdate({ layout: l }),
+    (l) => l === "three-panel" && threePanelDisabled,
   );
   const primaryTabRg = useRadioGroup<PrimaryTab>(
     settings.primaryTab,
@@ -133,8 +135,6 @@ export function SettingsPopover({
   }, [open, onClose]);
 
   if (!open || !anchorRect) return null;
-
-  const threePanelDisabled = viewportWidth < 768;
 
   // Position below the anchor, centered horizontally
   const left = Math.max(
@@ -284,7 +284,6 @@ export function SettingsPopover({
             <button
               key={t}
               data-testid={`theme-${t}-btn`}
-              data-radio-value={t}
               role="radio"
               aria-checked={settings.theme === t}
               tabIndex={themeRg.tabIndexFor(t)}
@@ -310,7 +309,6 @@ export function SettingsPopover({
         >
           <button
             data-testid="layout-tabbed-btn"
-            data-radio-value="tabbed"
             role="radio"
             aria-checked={settings.layout === "tabbed"}
             tabIndex={layoutRg.tabIndexFor("tabbed")}
@@ -322,7 +320,6 @@ export function SettingsPopover({
           </button>
           <button
             data-testid="layout-three-panel-btn"
-            data-radio-value="three-panel"
             role="radio"
             aria-checked={settings.layout === "three-panel"}
             aria-disabled={threePanelDisabled || undefined}
@@ -358,7 +355,6 @@ export function SettingsPopover({
           >
             <button
               data-testid="default-tab-chat-btn"
-              data-radio-value="chat"
               role="radio"
               aria-checked={settings.primaryTab === "chat"}
               tabIndex={primaryTabRg.tabIndexFor("chat")}
@@ -369,7 +365,6 @@ export function SettingsPopover({
             </button>
             <button
               data-testid="default-tab-annotations-btn"
-              data-radio-value="annotations"
               role="radio"
               aria-checked={settings.primaryTab === "annotations"}
               tabIndex={primaryTabRg.tabIndexFor("annotations")}
@@ -396,7 +391,6 @@ export function SettingsPopover({
           >
             <button
               data-testid="panel-order-cea-btn"
-              data-radio-value="chat-editor-annotations"
               role="radio"
               aria-checked={settings.panelOrder === "chat-editor-annotations"}
               tabIndex={panelOrderRg.tabIndexFor("chat-editor-annotations")}
@@ -407,7 +401,6 @@ export function SettingsPopover({
             </button>
             <button
               data-testid="panel-order-aec-btn"
-              data-radio-value="annotations-editor-chat"
               role="radio"
               aria-checked={settings.panelOrder === "annotations-editor-chat"}
               tabIndex={panelOrderRg.tabIndexFor("annotations-editor-chat")}
@@ -498,7 +491,6 @@ export function SettingsPopover({
             <button
               key={size}
               data-testid={`text-size-${size}-btn`}
-              data-radio-value={size}
               role="radio"
               aria-checked={settings.textSize === size}
               tabIndex={textSizeRg.tabIndexFor(size)}

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -484,8 +484,8 @@ export function SettingsPopover({
           <span>Show who wrote what</span>
         </label>
         <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
-          Highlights text by author: <span style={{ color: "#3b82f6" }}>you</span> /{" "}
-          <span style={{ color: "#ea8a1e" }}>Claude</span>
+          Highlights text by author: <span style={{ color: "var(--tandem-author-user)" }}>you</span>{" "}
+          / <span style={{ color: "var(--tandem-author-claude)" }}>Claude</span>
         </div>
       </div>
 

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -43,10 +43,21 @@ export function SettingsPopover({
   anchorRef,
 }: SettingsPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
   const threePanelDisabled = viewportWidth < 768;
   const { userName, setUserName } = useUserName();
   const [nameInput, setNameInput] = useState(userName);
+
+  // Idle-sync: commit c9a63de dropped the always-sync effect because it
+  // clobbered in-progress edits. This version syncs only when the input
+  // is NOT focused and the value actually differs — so cross-surface
+  // changes propagate, but typing is never interrupted.
+  useEffect(() => {
+    if (nameInput !== userName && document.activeElement !== inputRef.current) {
+      setNameInput(userName);
+    }
+  }, [userName, nameInput]);
 
   const themeRg = useRadioGroup<ThemePreference>(
     settings.theme,
@@ -255,6 +266,7 @@ export function SettingsPopover({
           Display Name
         </label>
         <input
+          ref={inputRef}
           id="settings-display-name"
           data-testid="settings-display-name"
           type="text"

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -19,6 +19,12 @@ interface SettingsPopoverProps {
   onUpdate: (partial: Partial<TandemSettings>) => void;
   /** Element to return focus to on close (typically the settings gear button). */
   returnFocusRef?: React.RefObject<HTMLElement | null>;
+  /**
+   * Element that toggles the popover. Excluded from outside-click detection
+   * so the anchor's own click handler (not the dismiss logic) controls
+   * close-while-open.
+   */
+  anchorRef?: React.RefObject<HTMLElement | null>;
 }
 
 const POPOVER_WIDTH = 320;
@@ -34,6 +40,7 @@ export function SettingsPopover({
   settings,
   onUpdate,
   returnFocusRef,
+  anchorRef,
 }: SettingsPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
@@ -91,7 +98,12 @@ export function SettingsPopover({
   useEffect(() => {
     if (!open) return;
     const handler = (e: PointerEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      // Let the anchor's own click handler toggle the popover — otherwise the
+      // pointerdown-outside close races with the click-reopen and the popover
+      // re-opens immediately.
+      if (anchorRef?.current?.contains(target)) return;
+      if (popoverRef.current && !popoverRef.current.contains(target)) {
         onClose();
       }
     };
@@ -100,7 +112,7 @@ export function SettingsPopover({
       clearTimeout(timer);
       document.removeEventListener("pointerdown", handler);
     };
-  }, [open, onClose]);
+  }, [open, onClose, anchorRef]);
 
   // Escape to close + focus trap on Tab
   useEffect(() => {

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { SELECTION_DWELL_MAX_MS, SELECTION_DWELL_MIN_MS } from "../../shared/constants";
 import type { TandemSettings } from "../hooks/useTandemSettings";
+import { useUserName } from "../hooks/useUserName";
 
 interface SettingsPopoverProps {
   open: boolean;
@@ -28,6 +29,11 @@ export function SettingsPopover({
 }: SettingsPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
+  const { userName, setUserName } = useUserName();
+  const [nameInput, setNameInput] = useState(userName);
+  useEffect(() => {
+    setNameInput(userName);
+  }, [userName]);
 
   // Track viewport width for three-panel availability (only while open)
   useEffect(() => {
@@ -189,6 +195,39 @@ export function SettingsPopover({
         >
           {"\u00d7"}
         </button>
+      </div>
+
+      {/* Display name */}
+      <div>
+        <label htmlFor="settings-display-name" style={sectionLabelStyle}>
+          Display Name
+        </label>
+        <input
+          id="settings-display-name"
+          data-testid="settings-display-name"
+          type="text"
+          value={nameInput}
+          onChange={(e) => setNameInput(e.target.value)}
+          onBlur={() => setUserName(nameInput)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+            if (e.key === "Escape") {
+              setNameInput(userName);
+              e.currentTarget.blur();
+            }
+          }}
+          maxLength={40}
+          style={{
+            width: "100%",
+            padding: "6px 8px",
+            fontSize: "12px",
+            color: "#111827",
+            background: "#fff",
+            border: "1px solid #d1d5db",
+            borderRadius: "4px",
+            outline: "none",
+          }}
+        />
       </div>
 
       {/* Layout mode */}

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -117,7 +117,7 @@ export function SettingsPopover({
   const sectionLabelStyle: React.CSSProperties = {
     fontSize: "11px",
     fontWeight: 600,
-    color: "#374151",
+    color: "var(--tandem-fg)",
     marginBottom: "6px",
     textTransform: "uppercase",
     letterSpacing: "0.5px",
@@ -127,13 +127,21 @@ export function SettingsPopover({
     flex: 1,
     padding: "8px",
     minHeight: "24px",
-    border: selected ? "2px solid #6366f1" : "2px solid #e5e7eb",
+    border: `2px solid ${selected ? "var(--tandem-accent)" : "var(--tandem-border)"}`,
     borderRadius: "6px",
-    background: disabled ? "#f3f4f6" : selected ? "#eef2ff" : "#fff",
+    background: disabled
+      ? "var(--tandem-surface-muted)"
+      : selected
+        ? "var(--tandem-accent-bg)"
+        : "var(--tandem-surface)",
     cursor: disabled ? "not-allowed" : "pointer",
     textAlign: "center",
     fontSize: "11px",
-    color: disabled ? "#9ca3af" : selected ? "#4338ca" : "#6b7280",
+    color: disabled
+      ? "var(--tandem-fg-subtle)"
+      : selected
+        ? "var(--tandem-accent-fg-strong)"
+        : "var(--tandem-fg-muted)",
     fontWeight: selected ? 600 : 400,
     opacity: disabled ? 0.6 : 1,
     transition: "border-color 0.15s, background 0.15s",
@@ -152,8 +160,9 @@ export function SettingsPopover({
         left: `${left}px`,
         top: `${top}px`,
         width: `${POPOVER_WIDTH}px`,
-        background: "#fff",
-        border: "1px solid #e5e7eb",
+        background: "var(--tandem-surface)",
+        color: "var(--tandem-fg)",
+        border: "1px solid var(--tandem-border)",
         borderRadius: "8px",
         boxShadow: "0 4px 24px rgba(0,0,0,0.12)",
         padding: "16px",
@@ -172,7 +181,10 @@ export function SettingsPopover({
           alignItems: "center",
         }}
       >
-        <span id={HEADING_ID} style={{ fontSize: "13px", fontWeight: 600, color: "#111827" }}>
+        <span
+          id={HEADING_ID}
+          style={{ fontSize: "13px", fontWeight: 600, color: "var(--tandem-fg)" }}
+        >
           Settings
         </span>
         <button
@@ -181,7 +193,7 @@ export function SettingsPopover({
             background: "none",
             border: "none",
             cursor: "pointer",
-            color: "#9ca3af",
+            color: "var(--tandem-fg-subtle)",
             fontSize: "16px",
             lineHeight: 1,
             padding: "4px 6px",
@@ -218,13 +230,38 @@ export function SettingsPopover({
             width: "100%",
             padding: "6px 8px",
             fontSize: "12px",
-            color: "#111827",
-            background: "#fff",
-            border: "1px solid #d1d5db",
+            color: "var(--tandem-fg)",
+            background: "var(--tandem-surface)",
+            border: "1px solid var(--tandem-border-strong)",
             borderRadius: "4px",
             outline: "none",
           }}
         />
+      </div>
+
+      {/* Theme */}
+      <div>
+        <div id="settings-theme-label" style={sectionLabelStyle}>
+          Theme
+        </div>
+        <div
+          role="radiogroup"
+          aria-labelledby="settings-theme-label"
+          style={{ display: "flex", gap: "8px" }}
+        >
+          {(["light", "dark", "system"] as const).map((t) => (
+            <button
+              key={t}
+              data-testid={`theme-${t}-btn`}
+              role="radio"
+              aria-checked={settings.theme === t}
+              onClick={() => onUpdate({ theme: t })}
+              style={cardStyle(settings.theme === t)}
+            >
+              {t === "light" ? "Light" : t === "dark" ? "Dark" : "System"}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Layout mode */}
@@ -263,7 +300,7 @@ export function SettingsPopover({
           </button>
         </div>
         {threePanelDisabled && (
-          <div style={{ fontSize: "10px", color: "#9ca3af", marginTop: "4px" }}>
+          <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
             Three-panel requires a wider viewport
           </div>
         )}
@@ -343,7 +380,7 @@ export function SettingsPopover({
             {settings.editorWidthPercent}%
           </span>
         </div>
-        <div style={{ fontSize: "10px", color: "#9ca3af", marginBottom: "6px" }}>
+        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginBottom: "6px" }}>
           How much of the available space the editor text fills
         </div>
         <input
@@ -354,7 +391,7 @@ export function SettingsPopover({
           step={5}
           value={settings.editorWidthPercent}
           onChange={(e) => onUpdate({ editorWidthPercent: Number(e.target.value) })}
-          style={{ width: "100%", accentColor: "#6366f1" }}
+          style={{ width: "100%", accentColor: "var(--tandem-accent)" }}
           aria-label="Editor width"
         />
         <div
@@ -362,7 +399,7 @@ export function SettingsPopover({
             display: "flex",
             justifyContent: "space-between",
             fontSize: "10px",
-            color: "#9ca3af",
+            color: "var(--tandem-fg-subtle)",
           }}
         >
           <span>50%</span>
@@ -381,7 +418,7 @@ export function SettingsPopover({
             gap: "8px",
             cursor: "pointer",
             fontSize: "12px",
-            color: "#374151",
+            color: "var(--tandem-fg)",
             minHeight: "24px",
           }}
         >
@@ -389,11 +426,11 @@ export function SettingsPopover({
             type="checkbox"
             checked={settings.showAuthorship}
             onChange={(e) => onUpdate({ showAuthorship: e.target.checked })}
-            style={{ accentColor: "#6366f1" }}
+            style={{ accentColor: "var(--tandem-accent)" }}
           />
           <span>Show who wrote what</span>
         </label>
-        <div style={{ fontSize: "10px", color: "#9ca3af", marginTop: "4px" }}>
+        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
           Highlights text by author: <span style={{ color: "#3b82f6" }}>you</span> /{" "}
           <span style={{ color: "#ea8a1e" }}>Claude</span>
         </div>
@@ -422,7 +459,7 @@ export function SettingsPopover({
             </button>
           ))}
         </div>
-        <div style={{ fontSize: "10px", color: "#9ca3af", marginTop: "4px" }}>
+        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
           Reading density only — use browser zoom (Ctrl + =/−) to scale the whole UI.
         </div>
       </div>
@@ -437,7 +474,7 @@ export function SettingsPopover({
             gap: "8px",
             cursor: "pointer",
             fontSize: "12px",
-            color: "#374151",
+            color: "var(--tandem-fg)",
             minHeight: "24px",
           }}
         >
@@ -445,11 +482,11 @@ export function SettingsPopover({
             type="checkbox"
             checked={settings.reduceMotion}
             onChange={(e) => onUpdate({ reduceMotion: e.target.checked })}
-            style={{ accentColor: "#6366f1" }}
+            style={{ accentColor: "var(--tandem-accent)" }}
           />
           <span>Reduce motion</span>
         </label>
-        <div style={{ fontSize: "10px", color: "#9ca3af", marginTop: "4px" }}>
+        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
           Disables smooth autoscroll and the annotation flash animation.
         </div>
       </div>
@@ -462,7 +499,7 @@ export function SettingsPopover({
             {(settings.selectionDwellMs / 1000).toFixed(1)}s
           </span>
         </div>
-        <div style={{ fontSize: "10px", color: "#9ca3af", marginBottom: "6px" }}>
+        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginBottom: "6px" }}>
           How long you must hold a selection before Claude notices it
         </div>
         <input
@@ -473,7 +510,7 @@ export function SettingsPopover({
           step={100}
           value={settings.selectionDwellMs}
           onChange={(e) => onUpdate({ selectionDwellMs: Number(e.target.value) })}
-          style={{ width: "100%", accentColor: "#6366f1" }}
+          style={{ width: "100%", accentColor: "var(--tandem-accent)" }}
           aria-label="Selection dwell time"
         />
         <div
@@ -481,7 +518,7 @@ export function SettingsPopover({
             display: "flex",
             justifyContent: "space-between",
             fontSize: "10px",
-            color: "#9ca3af",
+            color: "var(--tandem-fg-subtle)",
           }}
         >
           <span>{(SELECTION_DWELL_MIN_MS / 1000).toFixed(1)}s</span>

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -8,9 +8,15 @@ interface SettingsPopoverProps {
   anchorRect: DOMRect | null;
   settings: TandemSettings;
   onUpdate: (partial: Partial<TandemSettings>) => void;
+  /** Element to return focus to on close (typically the settings gear button). */
+  returnFocusRef?: React.RefObject<HTMLElement | null>;
 }
 
 const POPOVER_WIDTH = 320;
+const HEADING_ID = "tandem-settings-heading";
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 export function SettingsPopover({
   open,
@@ -18,6 +24,7 @@ export function SettingsPopover({
   anchorRect,
   settings,
   onUpdate,
+  returnFocusRef,
 }: SettingsPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
@@ -31,27 +38,60 @@ export function SettingsPopover({
     return () => window.removeEventListener("resize", handler);
   }, [open]);
 
-  // Dismiss on outside click
+  // Initial focus + focus return on close
   useEffect(() => {
     if (!open) return;
-    const handler = (e: MouseEvent) => {
+    // Focus the dialog container so screen readers announce the heading;
+    // Tab then moves into the content.
+    const node = popoverRef.current;
+    node?.focus();
+    return () => {
+      returnFocusRef?.current?.focus();
+    };
+  }, [open, returnFocusRef]);
+
+  // Outside-dismiss on pointerdown (covers mouse + touch + pen)
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: PointerEvent) => {
       if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
         onClose();
       }
     };
-    // Delay listener attachment so the opening click doesn't immediately close
-    const timer = setTimeout(() => document.addEventListener("mousedown", handler), 0);
+    const timer = setTimeout(() => document.addEventListener("pointerdown", handler), 0);
     return () => {
       clearTimeout(timer);
-      document.removeEventListener("mousedown", handler);
+      document.removeEventListener("pointerdown", handler);
     };
   }, [open, onClose]);
 
-  // Dismiss on Escape
+  // Escape to close + focus trap on Tab
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab" || !popoverRef.current) return;
+      const focusables = popoverRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      // If focus has escaped the dialog entirely, pull it back in.
+      if (!popoverRef.current.contains(active)) {
+        e.preventDefault();
+        first.focus();
+        return;
+      }
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
@@ -83,6 +123,7 @@ export function SettingsPopover({
   const cardStyle = (selected: boolean, disabled?: boolean): React.CSSProperties => ({
     flex: 1,
     padding: "8px",
+    minHeight: "24px",
     border: selected ? "2px solid #6366f1" : "2px solid #e5e7eb",
     borderRadius: "6px",
     background: disabled ? "#f3f4f6" : selected ? "#eef2ff" : "#fff",
@@ -99,6 +140,10 @@ export function SettingsPopover({
     <div
       ref={popoverRef}
       data-testid="settings-popover"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={HEADING_ID}
+      tabIndex={-1}
       style={{
         position: "fixed",
         left: `${left}px`,
@@ -113,6 +158,7 @@ export function SettingsPopover({
         display: "flex",
         flexDirection: "column",
         gap: "14px",
+        outline: "none",
       }}
     >
       {/* Header */}
@@ -123,7 +169,9 @@ export function SettingsPopover({
           alignItems: "center",
         }}
       >
-        <span style={{ fontSize: "13px", fontWeight: 600, color: "#111827" }}>Layout Settings</span>
+        <span id={HEADING_ID} style={{ fontSize: "13px", fontWeight: 600, color: "#111827" }}>
+          Settings
+        </span>
         <button
           onClick={onClose}
           style={{
@@ -133,7 +181,9 @@ export function SettingsPopover({
             color: "#9ca3af",
             fontSize: "16px",
             lineHeight: 1,
-            padding: "0 2px",
+            padding: "4px 6px",
+            minWidth: "24px",
+            minHeight: "24px",
           }}
           aria-label="Close settings"
         >
@@ -143,24 +193,33 @@ export function SettingsPopover({
 
       {/* Layout mode */}
       <div>
-        <div style={sectionLabelStyle}>Layout</div>
-        <div style={{ display: "flex", gap: "8px" }}>
+        <div id="settings-layout-label" style={sectionLabelStyle}>
+          Layout
+        </div>
+        <div
+          role="radiogroup"
+          aria-labelledby="settings-layout-label"
+          style={{ display: "flex", gap: "8px" }}
+        >
           <button
             data-testid="layout-tabbed-btn"
+            role="radio"
+            aria-checked={settings.layout === "tabbed"}
             onClick={() => onUpdate({ layout: "tabbed" })}
             style={cardStyle(settings.layout === "tabbed")}
-            aria-pressed={settings.layout === "tabbed"}
           >
             <div style={{ fontSize: "18px", marginBottom: "2px" }}>{"[=|]"}</div>
             Tabbed
           </button>
           <button
             data-testid="layout-three-panel-btn"
+            role="radio"
+            aria-checked={settings.layout === "three-panel"}
+            aria-disabled={threePanelDisabled || undefined}
             onClick={() => {
               if (!threePanelDisabled) onUpdate({ layout: "three-panel" });
             }}
             style={cardStyle(settings.layout === "three-panel", threePanelDisabled)}
-            aria-pressed={settings.layout === "three-panel"}
             title={threePanelDisabled ? "Requires viewport wider than 768px" : undefined}
           >
             <div style={{ fontSize: "18px", marginBottom: "2px" }}>{"[|||]"}</div>
@@ -177,21 +236,29 @@ export function SettingsPopover({
       {/* Primary tab (tabbed mode only) */}
       {settings.layout === "tabbed" && (
         <div>
-          <div style={sectionLabelStyle}>Default Tab</div>
-          <div style={{ display: "flex", gap: "8px" }}>
+          <div id="settings-default-tab-label" style={sectionLabelStyle}>
+            Default Tab
+          </div>
+          <div
+            role="radiogroup"
+            aria-labelledby="settings-default-tab-label"
+            style={{ display: "flex", gap: "8px" }}
+          >
             <button
               data-testid="default-tab-chat-btn"
+              role="radio"
+              aria-checked={settings.primaryTab === "chat"}
               onClick={() => onUpdate({ primaryTab: "chat" })}
               style={cardStyle(settings.primaryTab === "chat")}
-              aria-pressed={settings.primaryTab === "chat"}
             >
               Chat
             </button>
             <button
               data-testid="default-tab-annotations-btn"
+              role="radio"
+              aria-checked={settings.primaryTab === "annotations"}
               onClick={() => onUpdate({ primaryTab: "annotations" })}
               style={cardStyle(settings.primaryTab === "annotations")}
-              aria-pressed={settings.primaryTab === "annotations"}
             >
               Annotations
             </button>
@@ -202,21 +269,29 @@ export function SettingsPopover({
       {/* Panel order (three-panel mode only) */}
       {settings.layout === "three-panel" && (
         <div>
-          <div style={sectionLabelStyle}>Panel Order</div>
-          <div style={{ display: "flex", gap: "8px" }}>
+          <div id="settings-panel-order-label" style={sectionLabelStyle}>
+            Panel Order
+          </div>
+          <div
+            role="radiogroup"
+            aria-labelledby="settings-panel-order-label"
+            style={{ display: "flex", gap: "8px" }}
+          >
             <button
               data-testid="panel-order-cea-btn"
+              role="radio"
+              aria-checked={settings.panelOrder === "chat-editor-annotations"}
               onClick={() => onUpdate({ panelOrder: "chat-editor-annotations" })}
               style={cardStyle(settings.panelOrder === "chat-editor-annotations")}
-              aria-pressed={settings.panelOrder === "chat-editor-annotations"}
             >
               Chat | Editor | Ann.
             </button>
             <button
               data-testid="panel-order-aec-btn"
+              role="radio"
+              aria-checked={settings.panelOrder === "annotations-editor-chat"}
               onClick={() => onUpdate({ panelOrder: "annotations-editor-chat" })}
               style={cardStyle(settings.panelOrder === "annotations-editor-chat")}
-              aria-pressed={settings.panelOrder === "annotations-editor-chat"}
             >
               Ann. | Editor | Chat
             </button>
@@ -271,6 +346,7 @@ export function SettingsPopover({
             cursor: "pointer",
             fontSize: "12px",
             color: "#374151",
+            minHeight: "24px",
           }}
         >
           <input

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -399,6 +399,34 @@ export function SettingsPopover({
         </div>
       </div>
 
+      {/* Text size */}
+      <div>
+        <div id="settings-text-size-label" style={sectionLabelStyle}>
+          Text Size
+        </div>
+        <div
+          role="radiogroup"
+          aria-labelledby="settings-text-size-label"
+          style={{ display: "flex", gap: "8px" }}
+        >
+          {(["s", "m", "l"] as const).map((size) => (
+            <button
+              key={size}
+              data-testid={`text-size-${size}-btn`}
+              role="radio"
+              aria-checked={settings.textSize === size}
+              onClick={() => onUpdate({ textSize: size })}
+              style={cardStyle(settings.textSize === size)}
+            >
+              {size === "s" ? "Small" : size === "m" ? "Medium" : "Large"}
+            </button>
+          ))}
+        </div>
+        <div style={{ fontSize: "10px", color: "#9ca3af", marginTop: "4px" }}>
+          Reading density only — use browser zoom (Ctrl + =/−) to scale the whole UI.
+        </div>
+      </div>
+
       {/* Reduce motion */}
       <div>
         <label

--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -72,7 +72,8 @@ export function Editor({
       editorProps: {
         attributes: {
           class: "tandem-editor",
-          style: "outline: none; min-height: 500px; font-size: 16px; line-height: 1.6;",
+          style:
+            "outline: none; min-height: 500px; font-size: var(--tandem-editor-font-size, 16px); line-height: 1.6;",
         },
       },
     },

--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -200,8 +200,8 @@ export function Editor({
 
         /* Authorship decorations — user=blue, claude=orange */
         .tandem-authorship { transition: color 0.2s; }
-        .tandem-authorship--user { color: rgb(59, 130, 246); }
-        .tandem-authorship--claude { color: rgb(234, 138, 30); }
+        .tandem-authorship--user { color: var(--tandem-author-user); }
+        .tandem-authorship--claude { color: var(--tandem-author-claude); }
 
         /* Claude focus paragraph */
         .tandem-claude-focus {

--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -13,7 +13,8 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import React, { useCallback, useEffect } from "react";
 import * as Y from "yjs";
-import { readStoredName } from "../hooks/useUserName";
+import { USER_NAME_EVENT, USER_NAME_KEY } from "../../shared/constants.js";
+import { readStoredName, resolveUserName } from "../hooks/useUserName";
 import { AnnotationExtension } from "./extensions/annotation";
 import { AuthorshipExtension } from "./extensions/authorship";
 import { AwarenessExtension } from "./extensions/awareness";
@@ -86,6 +87,24 @@ export function Editor({
       editor.setEditable(!readOnly);
     }
   }, [editor, readOnly]);
+
+  // Keep the CollaborationCursor label in sync with the display name. The
+  // cursor user is captured at editor creation, so a later name edit from
+  // StatusBar or Settings won't propagate without this subscription.
+  useEffect(() => {
+    if (!editor) return;
+    const sync = () => editor.commands.updateUser({ name: readStoredName() });
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === USER_NAME_KEY)
+        editor.commands.updateUser({ name: resolveUserName(e.newValue) });
+    };
+    window.addEventListener(USER_NAME_EVENT, sync);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(USER_NAME_EVENT, sync);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [editor]);
 
   useEffect(() => {
     onEditorReady?.(editor);

--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -13,7 +13,7 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import React, { useCallback, useEffect } from "react";
 import * as Y from "yjs";
-import { USER_NAME_DEFAULT, USER_NAME_KEY } from "../../shared/constants.js";
+import { readStoredName } from "../hooks/useUserName";
 import { AnnotationExtension } from "./extensions/annotation";
 import { AuthorshipExtension } from "./extensions/authorship";
 import { AwarenessExtension } from "./extensions/awareness";
@@ -61,13 +61,7 @@ export function Editor({
         CollaborationCursor.configure({
           provider: provider,
           user: {
-            name: (() => {
-              try {
-                return localStorage.getItem(USER_NAME_KEY)?.trim() || USER_NAME_DEFAULT;
-              } catch {
-                return USER_NAME_DEFAULT;
-              }
-            })(),
+            name: readStoredName(),
             color: "#f59e0b",
           },
         }),

--- a/src/client/editor/Editor.tsx
+++ b/src/client/editor/Editor.tsx
@@ -13,8 +13,7 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import React, { useCallback, useEffect } from "react";
 import * as Y from "yjs";
-import { USER_NAME_EVENT, USER_NAME_KEY } from "../../shared/constants.js";
-import { readStoredName, resolveUserName } from "../hooks/useUserName";
+import { readStoredName, subscribeToUserName } from "../hooks/useUserName";
 import { AnnotationExtension } from "./extensions/annotation";
 import { AuthorshipExtension } from "./extensions/authorship";
 import { AwarenessExtension } from "./extensions/awareness";
@@ -93,17 +92,7 @@ export function Editor({
   // StatusBar or Settings won't propagate without this subscription.
   useEffect(() => {
     if (!editor) return;
-    const sync = () => editor.commands.updateUser({ name: readStoredName() });
-    const onStorage = (e: StorageEvent) => {
-      if (e.key === USER_NAME_KEY)
-        editor.commands.updateUser({ name: resolveUserName(e.newValue) });
-    };
-    window.addEventListener(USER_NAME_EVENT, sync);
-    window.addEventListener("storage", onStorage);
-    return () => {
-      window.removeEventListener(USER_NAME_EVENT, sync);
-      window.removeEventListener("storage", onStorage);
-    };
+    return subscribeToUserName((name) => editor.commands.updateUser({ name }));
   }, [editor]);
 
   useEffect(() => {

--- a/src/client/editor/toolbar/Toolbar.tsx
+++ b/src/client/editor/toolbar/Toolbar.tsx
@@ -24,6 +24,9 @@ interface ToolbarProps {
   editor: TiptapEditor | null;
   ydoc: Y.Doc | null;
   onSettingsClick?: (rect: DOMRect) => void;
+  /** Forwarded ref for the settings gear button — needed so a keyboard shortcut
+   * can anchor the popover and so focus can return here when it closes. */
+  settingsBtnRef?: React.RefObject<HTMLButtonElement | null>;
   tandemMode?: TandemMode;
   onModeChange?: (mode: TandemMode) => void;
   heldCount?: number;
@@ -33,6 +36,7 @@ export function Toolbar({
   editor,
   ydoc,
   onSettingsClick,
+  settingsBtnRef,
   tandemMode,
   onModeChange,
   heldCount,
@@ -524,10 +528,12 @@ export function Toolbar({
         )}
         {onSettingsClick && (
           <button
+            ref={settingsBtnRef}
             data-testid="settings-btn"
             onClick={(e) => onSettingsClick(e.currentTarget.getBoundingClientRect())}
-            title="Layout settings"
-            aria-label="Layout settings"
+            title="Settings (Ctrl+,)"
+            aria-label="Settings"
+            aria-keyshortcuts="Control+Comma"
             style={{
               background: "none",
               border: "1px solid #d1d5db",
@@ -536,6 +542,7 @@ export function Toolbar({
               color: "#6b7280",
               fontSize: "13px",
               padding: "4px 12px",
+              minHeight: "24px",
             }}
           >
             Settings

--- a/src/client/editor/toolbar/Toolbar.tsx
+++ b/src/client/editor/toolbar/Toolbar.tsx
@@ -23,7 +23,7 @@ type ToolbarMode = "idle" | "comment";
 interface ToolbarProps {
   editor: TiptapEditor | null;
   ydoc: Y.Doc | null;
-  onSettingsClick?: (rect: DOMRect) => void;
+  onSettingsOpen?: () => void;
   /** Forwarded ref for the settings gear button — needed so a keyboard shortcut
    * can anchor the popover and so focus can return here when it closes. */
   settingsBtnRef?: React.RefObject<HTMLButtonElement | null>;
@@ -35,7 +35,7 @@ interface ToolbarProps {
 export function Toolbar({
   editor,
   ydoc,
-  onSettingsClick,
+  onSettingsOpen,
   settingsBtnRef,
   tandemMode,
   onModeChange,
@@ -526,11 +526,11 @@ export function Toolbar({
             </button>
           </div>
         )}
-        {onSettingsClick && (
+        {onSettingsOpen && (
           <button
             ref={settingsBtnRef}
             data-testid="settings-btn"
-            onClick={(e) => onSettingsClick(e.currentTarget.getBoundingClientRect())}
+            onClick={onSettingsOpen}
             title="Settings (Ctrl+,)"
             aria-label="Settings"
             aria-keyshortcuts="Control+Comma"

--- a/src/client/hooks/useRadioGroup.ts
+++ b/src/client/hooks/useRadioGroup.ts
@@ -1,0 +1,51 @@
+import type React from "react";
+
+/**
+ * Roving tabindex + arrow-key navigation for a `role="radiogroup"` per
+ * WAI-ARIA Authoring Practices. Only the checked radio is in the tab order;
+ * Left/Up/Right/Down/Home/End cycle through values and move focus.
+ *
+ * Each radio button must have `data-radio-value="<value>"` so the keyboard
+ * handler can find the newly-selected DOM node to focus.
+ */
+export function useRadioGroup<T extends string>(
+  value: T,
+  values: readonly T[],
+  setValue: (next: T) => void,
+): {
+  handleKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  tabIndexFor: (v: T) => 0 | -1;
+} {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const { key } = e;
+    if (
+      key !== "ArrowLeft" &&
+      key !== "ArrowRight" &&
+      key !== "ArrowUp" &&
+      key !== "ArrowDown" &&
+      key !== "Home" &&
+      key !== "End"
+    ) {
+      return;
+    }
+    e.preventDefault();
+    const idx = values.indexOf(value);
+    const last = values.length - 1;
+    let next: number;
+    if (key === "Home") next = 0;
+    else if (key === "End") next = last;
+    else if (key === "ArrowLeft" || key === "ArrowUp") next = idx <= 0 ? last : idx - 1;
+    else next = idx >= last ? 0 : idx + 1;
+
+    const nextValue = values[next];
+    setValue(nextValue);
+    const btn = e.currentTarget.querySelector<HTMLButtonElement>(
+      `[data-radio-value="${nextValue}"]`,
+    );
+    btn?.focus();
+  };
+
+  const tabIndexFor = (v: T): 0 | -1 => (v === value ? 0 : -1);
+
+  return { handleKeyDown, tabIndexFor };
+}

--- a/src/client/hooks/useRadioGroup.ts
+++ b/src/client/hooks/useRadioGroup.ts
@@ -5,17 +5,24 @@ import type React from "react";
  * WAI-ARIA Authoring Practices. Only the checked radio is in the tab order;
  * Left/Up/Right/Down/Home/End cycle through values and move focus.
  *
- * Each radio button must have `data-radio-value="<value>"` so the keyboard
- * handler can find the newly-selected DOM node to focus.
+ * `isDisabled` lets the hook skip values that are conditionally unavailable
+ * (e.g., three-panel below the viewport threshold) — without this, arrow
+ * keys would bypass the onClick guard and write a disabled value into state.
+ *
+ * Focus is moved by indexing the matched children, so radio buttons don't
+ * need any extra data attributes — just `role="radio"` on each child.
  */
 export function useRadioGroup<T extends string>(
   value: T,
   values: readonly T[],
   setValue: (next: T) => void,
+  isDisabled?: (v: T) => boolean,
 ): {
   handleKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   tabIndexFor: (v: T) => 0 | -1;
 } {
+  const enabled = isDisabled ? values.filter((v) => !isDisabled(v)) : values;
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     const { key } = e;
     if (
@@ -28,24 +35,34 @@ export function useRadioGroup<T extends string>(
     ) {
       return;
     }
+    if (enabled.length === 0) return;
     e.preventDefault();
-    const idx = values.indexOf(value);
-    const last = values.length - 1;
+
+    const idx = enabled.indexOf(value);
+    const last = enabled.length - 1;
     let next: number;
     if (key === "Home") next = 0;
     else if (key === "End") next = last;
     else if (key === "ArrowLeft" || key === "ArrowUp") next = idx <= 0 ? last : idx - 1;
     else next = idx >= last ? 0 : idx + 1;
 
-    const nextValue = values[next];
+    const nextValue = enabled[next];
     setValue(nextValue);
-    const btn = e.currentTarget.querySelector<HTMLButtonElement>(
-      `[data-radio-value="${nextValue}"]`,
-    );
-    btn?.focus();
+
+    // Index-based focus — no data attributes needed, no selector injection.
+    const radios = e.currentTarget.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+    const domIdx = values.indexOf(nextValue);
+    radios[domIdx]?.focus();
   };
 
-  const tabIndexFor = (v: T): 0 | -1 => (v === value ? 0 : -1);
+  // If the current value happens to be disabled (e.g., user saved
+  // "three-panel" then narrowed the viewport), fall back to the first enabled
+  // value so Tab can still reach the group.
+  const tabStop = isDisabled?.(value) ? enabled[0] : value;
+  const tabIndexFor = (v: T): 0 | -1 => {
+    if (isDisabled?.(v)) return -1;
+    return v === tabStop ? 0 : -1;
+  };
 
   return { handleKeyDown, tabIndexFor };
 }

--- a/src/client/hooks/useSettingsShortcut.ts
+++ b/src/client/hooks/useSettingsShortcut.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+
+/**
+ * Pure matcher so the hotkey logic can be unit-tested without a DOM.
+ * `e.code === "Comma"` survives AZERTY/QWERTZ/IME layouts where `,` lives on
+ * a different physical key; QWERTZ users must Shift to type it, so the shifted
+ * form is accepted. Bail during IME composition.
+ */
+export function isSettingsShortcut(
+  e: Pick<KeyboardEvent, "code" | "ctrlKey" | "metaKey" | "isComposing">,
+): boolean {
+  if (e.isComposing) return false;
+  if (e.code !== "Comma") return false;
+  return e.ctrlKey || e.metaKey;
+}
+
+/** Ctrl+, / Cmd+, opens the Settings popover. */
+export function useSettingsShortcut(onOpen: () => void): void {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!isSettingsShortcut(e)) return;
+      e.preventDefault();
+      onOpen();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onOpen]);
+}

--- a/src/client/hooks/useSettingsShortcut.ts
+++ b/src/client/hooks/useSettingsShortcut.ts
@@ -1,11 +1,6 @@
 import { useEffect } from "react";
 
-/**
- * Pure matcher so the hotkey logic can be unit-tested without a DOM.
- * `e.code === "Comma"` survives AZERTY/QWERTZ/IME layouts where `,` lives on
- * a different physical key; QWERTZ users must Shift to type it, so the shifted
- * form is accepted. Bail during IME composition.
- */
+// `e.code` (not `e.key`) so non-QWERTY layouts still hit; bail during IME.
 export function isSettingsShortcut(
   e: Pick<KeyboardEvent, "code" | "ctrlKey" | "metaKey" | "isComposing">,
 ): boolean {
@@ -14,7 +9,6 @@ export function isSettingsShortcut(
   return e.ctrlKey || e.metaKey;
 }
 
-/** Ctrl+, / Cmd+, opens the Settings popover. */
 export function useSettingsShortcut(onOpen: () => void): void {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -11,6 +11,7 @@ export type LayoutMode = "tabbed" | "three-panel";
 export type PrimaryTab = "chat" | "annotations";
 export type PanelOrder = "chat-editor-annotations" | "annotations-editor-chat";
 export type TextSize = "s" | "m" | "l";
+export type ThemePreference = "light" | "dark" | "system";
 
 export interface TandemSettings {
   layout: LayoutMode;
@@ -21,6 +22,7 @@ export interface TandemSettings {
   showAuthorship: boolean;
   reduceMotion: boolean;
   textSize: TextSize;
+  theme: ThemePreference;
 }
 
 export const TEXT_SIZE_PX: Record<TextSize, number> = { s: 14, m: 16, l: 18 };
@@ -45,6 +47,7 @@ const DEFAULTS: TandemSettings = {
   showAuthorship: false,
   reduceMotion: false,
   textSize: "m",
+  theme: "system",
 };
 
 /**
@@ -89,6 +92,10 @@ export function loadSettings(): TandemSettings {
           parsed.textSize === "s" || parsed.textSize === "m" || parsed.textSize === "l"
             ? parsed.textSize
             : DEFAULTS.textSize,
+        theme:
+          parsed.theme === "light" || parsed.theme === "dark" || parsed.theme === "system"
+            ? parsed.theme
+            : DEFAULTS.theme,
       };
     }
   } catch {

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -10,6 +10,7 @@ import {
 export type LayoutMode = "tabbed" | "three-panel";
 export type PrimaryTab = "chat" | "annotations";
 export type PanelOrder = "chat-editor-annotations" | "annotations-editor-chat";
+export type TextSize = "s" | "m" | "l";
 
 export interface TandemSettings {
   layout: LayoutMode;
@@ -19,7 +20,10 @@ export interface TandemSettings {
   selectionDwellMs: number;
   showAuthorship: boolean;
   reduceMotion: boolean;
+  textSize: TextSize;
 }
+
+export const TEXT_SIZE_PX: Record<TextSize, number> = { s: 14, m: 16, l: 18 };
 
 // OS-level reduced-motion preference — used as the default so users who have
 // already opted in at the system level don't see any animations on first run.
@@ -40,7 +44,12 @@ const DEFAULTS: TandemSettings = {
   selectionDwellMs: SELECTION_DWELL_DEFAULT_MS,
   showAuthorship: false,
   reduceMotion: false,
+  textSize: "m",
 };
+
+function toTextSize(raw: unknown): TextSize {
+  return raw === "s" || raw === "m" || raw === "l" ? raw : DEFAULTS.textSize;
+}
 
 /**
  * Read and normalize settings from localStorage.
@@ -80,6 +89,7 @@ export function loadSettings(): TandemSettings {
         showAuthorship: parsed.showAuthorship === true,
         reduceMotion:
           typeof parsed.reduceMotion === "boolean" ? parsed.reduceMotion : prefersReducedMotion(),
+        textSize: toTextSize(parsed.textSize),
       };
     }
   } catch {

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -47,10 +47,6 @@ const DEFAULTS: TandemSettings = {
   textSize: "m",
 };
 
-function toTextSize(raw: unknown): TextSize {
-  return raw === "s" || raw === "m" || raw === "l" ? raw : DEFAULTS.textSize;
-}
-
 /**
  * Read and normalize settings from localStorage.
  *
@@ -89,7 +85,10 @@ export function loadSettings(): TandemSettings {
         showAuthorship: parsed.showAuthorship === true,
         reduceMotion:
           typeof parsed.reduceMotion === "boolean" ? parsed.reduceMotion : prefersReducedMotion(),
-        textSize: toTextSize(parsed.textSize),
+        textSize:
+          parsed.textSize === "s" || parsed.textSize === "m" || parsed.textSize === "l"
+            ? parsed.textSize
+            : DEFAULTS.textSize,
       };
     }
   } catch {

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -25,8 +25,8 @@ export interface TandemSettings {
 // already opted in at the system level don't see any animations on first run.
 function prefersReducedMotion(): boolean {
   try {
-    if (typeof matchMedia === "undefined") return false;
-    return matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (typeof window === "undefined") return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   } catch {
     return false;
   }

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -60,9 +60,15 @@ const DEFAULTS: TandemSettings = {
  * intentional — `0` is not a valid dwell or width anyway).
  */
 export function loadSettings(): TandemSettings {
+  let saved: string | null;
   try {
-    const saved = localStorage.getItem(TANDEM_SETTINGS_KEY);
-    if (saved) {
+    saved = localStorage.getItem(TANDEM_SETTINGS_KEY);
+  } catch {
+    // localStorage unavailable (incognito/storage-disabled) — fall through.
+    saved = null;
+  }
+  if (saved) {
+    try {
       const parsed = JSON.parse(saved);
       return {
         layout:
@@ -97,9 +103,11 @@ export function loadSettings(): TandemSettings {
             ? parsed.theme
             : DEFAULTS.theme,
       };
+    } catch (err) {
+      // Corrupt blob — log so "my prefs reset" reports are diagnosable instead
+      // of silently clobbered on the next write.
+      console.warn("[tandem] settings JSON is corrupt, resetting to defaults:", err);
     }
-  } catch {
-    // localStorage unavailable (incognito/storage-disabled)
   }
   return { ...DEFAULTS, reduceMotion: prefersReducedMotion() };
 }

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -112,21 +112,32 @@ export function loadSettings(): TandemSettings {
   return { ...DEFAULTS, reduceMotion: prefersReducedMotion() };
 }
 
+/**
+ * Merge a partial update into the current settings and clamp numeric fields
+ * to their valid ranges. Pure — no React, no storage — so the clamp-on-write
+ * contract is directly testable.
+ */
+export function mergeAndClampSettings(
+  prev: TandemSettings,
+  partial: Partial<TandemSettings>,
+): TandemSettings {
+  const merged = { ...prev, ...partial };
+  return {
+    ...merged,
+    editorWidthPercent: Math.max(50, Math.min(100, merged.editorWidthPercent)),
+    selectionDwellMs: Math.max(
+      SELECTION_DWELL_MIN_MS,
+      Math.min(SELECTION_DWELL_MAX_MS, merged.selectionDwellMs),
+    ),
+  };
+}
+
 export function useTandemSettings() {
   const [settings, setSettingsState] = useState<TandemSettings>(loadSettings);
 
   const updateSettings = useCallback((partial: Partial<TandemSettings>) => {
     setSettingsState((prev) => {
-      const merged = { ...prev, ...partial };
-      // Clamp numeric values on write (same rules as loadSettings)
-      const next: TandemSettings = {
-        ...merged,
-        editorWidthPercent: Math.max(50, Math.min(100, merged.editorWidthPercent)),
-        selectionDwellMs: Math.max(
-          SELECTION_DWELL_MIN_MS,
-          Math.min(SELECTION_DWELL_MAX_MS, merged.selectionDwellMs),
-        ),
-      };
+      const next = mergeAndClampSettings(prev, partial);
       try {
         localStorage.setItem(TANDEM_SETTINGS_KEY, JSON.stringify(next));
         // Mirror authorship toggle to dedicated key for ProseMirror plugin init

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -18,6 +18,18 @@ export interface TandemSettings {
   editorWidthPercent: number;
   selectionDwellMs: number;
   showAuthorship: boolean;
+  reduceMotion: boolean;
+}
+
+// OS-level reduced-motion preference — used as the default so users who have
+// already opted in at the system level don't see any animations on first run.
+function prefersReducedMotion(): boolean {
+  try {
+    if (typeof matchMedia === "undefined") return false;
+    return matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
 }
 
 const DEFAULTS: TandemSettings = {
@@ -27,6 +39,7 @@ const DEFAULTS: TandemSettings = {
   editorWidthPercent: 50,
   selectionDwellMs: SELECTION_DWELL_DEFAULT_MS,
   showAuthorship: false,
+  reduceMotion: false,
 };
 
 /**
@@ -65,12 +78,14 @@ export function loadSettings(): TandemSettings {
           ),
         ),
         showAuthorship: parsed.showAuthorship === true,
+        reduceMotion:
+          typeof parsed.reduceMotion === "boolean" ? parsed.reduceMotion : prefersReducedMotion(),
       };
     }
   } catch {
     // localStorage unavailable (incognito/storage-disabled)
   }
-  return DEFAULTS;
+  return { ...DEFAULTS, reduceMotion: prefersReducedMotion() };
 }
 
 export function useTandemSettings() {

--- a/src/client/hooks/useTheme.ts
+++ b/src/client/hooks/useTheme.ts
@@ -18,25 +18,35 @@ export function resolveTheme(pref: ThemePreference): ResolvedTheme {
 
 /**
  * Apply the resolved theme to <html data-theme="…"> and, when the user's
+ * preference is "system", subscribe to OS-level changes. Returns a cleanup
+ * that removes the attribute and (for "system") the matchMedia listener.
+ *
+ * Exported so the DOM side-effect contract is directly testable without
+ * spinning up a React render environment.
+ */
+export function applyTheme(pref: ThemePreference): () => void {
+  const root = document.documentElement;
+  root.setAttribute("data-theme", resolveTheme(pref));
+
+  if (pref !== "system") {
+    return () => root.removeAttribute("data-theme");
+  }
+
+  const mq = window.matchMedia("(prefers-color-scheme: dark)");
+  const onChange = () => root.setAttribute("data-theme", systemTheme());
+  mq.addEventListener("change", onChange);
+  return () => {
+    mq.removeEventListener("change", onChange);
+    root.removeAttribute("data-theme");
+  };
+}
+
+/**
+ * Apply the resolved theme to <html data-theme="…"> and, when the user's
  * preference is "system", re-apply on OS-level changes. Scoped to <html>
  * (not <body>) so CSS-custom-property overrides cascade into portals and
  * popovers rendered outside the React root.
  */
 export function useTheme(pref: ThemePreference): void {
-  useEffect(() => {
-    const root = document.documentElement;
-    root.setAttribute("data-theme", resolveTheme(pref));
-
-    if (pref !== "system") {
-      return () => root.removeAttribute("data-theme");
-    }
-
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const onChange = () => root.setAttribute("data-theme", systemTheme());
-    mq.addEventListener("change", onChange);
-    return () => {
-      mq.removeEventListener("change", onChange);
-      root.removeAttribute("data-theme");
-    };
-  }, [pref]);
+  useEffect(() => applyTheme(pref), [pref]);
 }

--- a/src/client/hooks/useTheme.ts
+++ b/src/client/hooks/useTheme.ts
@@ -3,7 +3,7 @@ import type { ThemePreference } from "./useTandemSettings";
 
 export type ResolvedTheme = "light" | "dark";
 
-function systemTheme(): ResolvedTheme {
+export function systemTheme(): ResolvedTheme {
   try {
     if (typeof window === "undefined") return "light";
     return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
@@ -12,7 +12,7 @@ function systemTheme(): ResolvedTheme {
   }
 }
 
-function resolve(pref: ThemePreference): ResolvedTheme {
+export function resolveTheme(pref: ThemePreference): ResolvedTheme {
   return pref === "system" ? systemTheme() : pref;
 }
 
@@ -25,7 +25,7 @@ function resolve(pref: ThemePreference): ResolvedTheme {
 export function useTheme(pref: ThemePreference): void {
   useEffect(() => {
     const root = document.documentElement;
-    root.setAttribute("data-theme", resolve(pref));
+    root.setAttribute("data-theme", resolveTheme(pref));
 
     if (pref !== "system") {
       return () => root.removeAttribute("data-theme");

--- a/src/client/hooks/useTheme.ts
+++ b/src/client/hooks/useTheme.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import type { ThemePreference } from "./useTandemSettings";
+
+export type ResolvedTheme = "light" | "dark";
+
+function systemTheme(): ResolvedTheme {
+  try {
+    if (typeof window === "undefined") return "light";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  } catch {
+    return "light";
+  }
+}
+
+function resolve(pref: ThemePreference): ResolvedTheme {
+  return pref === "system" ? systemTheme() : pref;
+}
+
+/**
+ * Apply the resolved theme to <html data-theme="…"> and, when the user's
+ * preference is "system", re-apply on OS-level changes. Scoped to <html>
+ * (not <body>) so CSS-custom-property overrides cascade into portals and
+ * popovers rendered outside the React root.
+ */
+export function useTheme(pref: ThemePreference): void {
+  useEffect(() => {
+    const root = document.documentElement;
+    root.setAttribute("data-theme", resolve(pref));
+
+    if (pref !== "system") {
+      return () => root.removeAttribute("data-theme");
+    }
+
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => root.setAttribute("data-theme", systemTheme());
+    mq.addEventListener("change", onChange);
+    return () => {
+      mq.removeEventListener("change", onChange);
+      root.removeAttribute("data-theme");
+    };
+  }, [pref]);
+}

--- a/src/client/hooks/useUserName.ts
+++ b/src/client/hooks/useUserName.ts
@@ -1,13 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
-import { USER_NAME_DEFAULT, USER_NAME_KEY } from "../../shared/constants";
-
-const USER_NAME_EVENT = "tandem:user-name-changed";
+import { USER_NAME_DEFAULT, USER_NAME_EVENT, USER_NAME_KEY } from "../../shared/constants";
 
 export function resolveUserName(stored: string | null | undefined): string {
   return stored?.trim() || USER_NAME_DEFAULT;
 }
 
-function readStoredName(): string {
+export function readStoredName(): string {
   try {
     return resolveUserName(localStorage.getItem(USER_NAME_KEY));
   } catch {

--- a/src/client/hooks/useUserName.ts
+++ b/src/client/hooks/useUserName.ts
@@ -13,12 +13,23 @@ export function readStoredName(): string {
   }
 }
 
-function writeStoredName(name: string): void {
+/**
+ * Persist a display name to localStorage and broadcast the change so other
+ * hook instances (StatusBar, Settings popover, Editor cursor) pick it up
+ * in-tab. Pure — no React — so the write+notify contract is testable.
+ * Returns the trimmed value actually written.
+ */
+export function persistUserName(name: string): string {
+  const trimmed = resolveUserName(name);
   try {
-    localStorage.setItem(USER_NAME_KEY, name);
+    localStorage.setItem(USER_NAME_KEY, trimmed);
   } catch {
     // localStorage unavailable (incognito/storage-disabled) — in-memory only.
   }
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(USER_NAME_EVENT));
+  }
+  return trimmed;
 }
 
 /**
@@ -47,10 +58,8 @@ export function useUserName(): {
   }, []);
 
   const setUserName = useCallback((next: string) => {
-    const trimmed = resolveUserName(next);
-    writeStoredName(trimmed);
+    const trimmed = persistUserName(next);
     setUserNameState(trimmed);
-    window.dispatchEvent(new Event(USER_NAME_EVENT));
   }, []);
 
   return { userName, setUserName };

--- a/src/client/hooks/useUserName.ts
+++ b/src/client/hooks/useUserName.ts
@@ -33,6 +33,23 @@ export function persistUserName(name: string): string {
 }
 
 /**
+ * Subscribe to display-name changes from any source (in-tab via the custom
+ * event, cross-tab via storage). Returns an unsubscribe function.
+ */
+export function subscribeToUserName(onChange: (name: string) => void): () => void {
+  const onCustom = () => onChange(readStoredName());
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === USER_NAME_KEY) onChange(resolveUserName(e.newValue));
+  };
+  window.addEventListener(USER_NAME_EVENT, onCustom);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(USER_NAME_EVENT, onCustom);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+/**
  * Shared display-name state. Persists to localStorage and broadcasts via a
  * custom event so every in-tab subscriber updates together; the `storage`
  * event covers cross-tab.
@@ -43,19 +60,7 @@ export function useUserName(): {
 } {
   const [userName, setUserNameState] = useState(readStoredName);
 
-  useEffect(() => {
-    const onStorage = (e: StorageEvent) => {
-      if (e.key !== USER_NAME_KEY) return;
-      setUserNameState(resolveUserName(e.newValue));
-    };
-    const onCustom = () => setUserNameState(readStoredName());
-    window.addEventListener("storage", onStorage);
-    window.addEventListener(USER_NAME_EVENT, onCustom);
-    return () => {
-      window.removeEventListener("storage", onStorage);
-      window.removeEventListener(USER_NAME_EVENT, onCustom);
-    };
-  }, []);
+  useEffect(() => subscribeToUserName(setUserNameState), []);
 
   const setUserName = useCallback((next: string) => {
     const trimmed = persistUserName(next);

--- a/src/client/hooks/useUserName.ts
+++ b/src/client/hooks/useUserName.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+import { USER_NAME_DEFAULT, USER_NAME_KEY } from "../../shared/constants";
+
+const USER_NAME_EVENT = "tandem:user-name-changed";
+
+export function resolveUserName(stored: string | null | undefined): string {
+  return stored?.trim() || USER_NAME_DEFAULT;
+}
+
+function readStoredName(): string {
+  try {
+    return resolveUserName(localStorage.getItem(USER_NAME_KEY));
+  } catch {
+    return USER_NAME_DEFAULT;
+  }
+}
+
+function writeStoredName(name: string): void {
+  try {
+    localStorage.setItem(USER_NAME_KEY, name);
+  } catch {
+    // localStorage unavailable (incognito/storage-disabled) — in-memory only.
+  }
+}
+
+/**
+ * Shared display-name state. Persists to localStorage and broadcasts via a
+ * custom event so every in-tab subscriber updates together; the `storage`
+ * event covers cross-tab.
+ */
+export function useUserName(): {
+  userName: string;
+  setUserName: (next: string) => void;
+} {
+  const [userName, setUserNameState] = useState(readStoredName);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== USER_NAME_KEY) return;
+      setUserNameState(resolveUserName(e.newValue));
+    };
+    const onCustom = () => setUserNameState(readStoredName());
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(USER_NAME_EVENT, onCustom);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(USER_NAME_EVENT, onCustom);
+    };
+  }, []);
+
+  const setUserName = useCallback((next: string) => {
+    const trimmed = resolveUserName(next);
+    writeStoredName(trimmed);
+    setUserNameState(trimmed);
+    window.dispatchEvent(new Event(USER_NAME_EVENT));
+  }, []);
+
+  return { userName, setUserName };
+}

--- a/src/client/panels/ChatPanel.tsx
+++ b/src/client/panels/ChatPanel.tsx
@@ -28,6 +28,7 @@ interface ChatPanelProps {
   capturedAnchor: CapturedAnchor | null;
   onCapturedAnchorChange: (anchor: CapturedAnchor | null) => void;
   inputRef?: React.RefObject<HTMLTextAreaElement | null>;
+  reduceMotion?: boolean;
 }
 
 export function ChatPanel({
@@ -41,7 +42,9 @@ export function ChatPanel({
   capturedAnchor,
   onCapturedAnchorChange,
   inputRef: externalInputRef,
+  reduceMotion,
 }: ChatPanelProps) {
+  const scrollBehavior: ScrollBehavior = reduceMotion ? "auto" : "smooth";
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputText, setInputText] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -82,15 +85,15 @@ export function ChatPanel({
       return;
     }
     prevClaudeActive.current = !!claudeActive;
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, claudeActive]);
+    messagesEndRef.current?.scrollIntoView({ behavior: scrollBehavior });
+  }, [messages, claudeActive, scrollBehavior]);
 
   // Scroll to bottom when panel becomes visible (display toggle means scrollIntoView no-ops while hidden)
   useEffect(() => {
     if (visible) {
-      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+      messagesEndRef.current?.scrollIntoView({ behavior: scrollBehavior });
     }
-  }, [visible]);
+  }, [visible, scrollBehavior]);
 
   const sendMessage = useCallback(() => {
     if (!ctrlYdoc || !inputText.trim()) return;

--- a/src/client/panels/SidePanel.tsx
+++ b/src/client/panels/SidePanel.tsx
@@ -28,6 +28,7 @@ interface SidePanelProps {
   onExitReviewMode: () => void;
   activeAnnotationId: string | null;
   onActiveAnnotationChange: (id: string | null) => void;
+  reduceMotion?: boolean;
 }
 
 const SMALL_BTN: React.CSSProperties = {
@@ -82,7 +83,9 @@ export function SidePanel({
   onExitReviewMode,
   activeAnnotationId,
   onActiveAnnotationChange,
+  reduceMotion,
 }: SidePanelProps) {
+  const scrollBehavior: ScrollBehavior = reduceMotion ? "auto" : "smooth";
   const [filterType, setFilterType] = useState<FilterType>("all");
   const [filterAuthor, setFilterAuthor] = useState<FilterAuthor>("all");
   const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
@@ -341,16 +344,19 @@ export function SidePanel({
   }
 
   // Scroll editor to an annotation's range
-  const scrollToAnnotation = useCallback((ann: Annotation) => {
-    const ed = editorRef.current;
-    if (!ed) return;
-    const resolved = annotationToPmRange(ann, ed.state.doc, ydocRef.current);
-    if (!resolved) return;
-    ed.chain().focus().setTextSelection({ from: resolved.from, to: resolved.to }).run();
-    const domAtPos = ed.view.domAtPos(resolved.from);
-    const el = domAtPos.node instanceof HTMLElement ? domAtPos.node : domAtPos.node.parentElement;
-    el?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }, []);
+  const scrollToAnnotation = useCallback(
+    (ann: Annotation) => {
+      const ed = editorRef.current;
+      if (!ed) return;
+      const resolved = annotationToPmRange(ann, ed.state.doc, ydocRef.current);
+      if (!resolved) return;
+      ed.chain().focus().setTextSelection({ from: resolved.from, to: resolved.to }).run();
+      const domAtPos = ed.view.domAtPos(resolved.from);
+      const el = domAtPos.node instanceof HTMLElement ? domAtPos.node : domAtPos.node.parentElement;
+      el?.scrollIntoView({ behavior: scrollBehavior, block: "center" });
+    },
+    [scrollBehavior],
+  );
 
   // Stable keyboard review callbacks (use refs to avoid dep cascade)
   const navigateReview = useCallback(
@@ -519,7 +525,7 @@ export function SidePanel({
     const timer = setTimeout(() => {
       const card = document.querySelector(`[data-testid="annotation-card-${activeAnnotationId}"]`);
       if (card) {
-        card.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        card.scrollIntoView({ behavior: scrollBehavior, block: "nearest" });
         card.classList.add("tandem-annotation-flash");
         const onEnd = () => card.classList.remove("tandem-annotation-flash");
         card.addEventListener("animationend", onEnd, { once: true });
@@ -534,7 +540,7 @@ export function SidePanel({
       }
     }, 50);
     return () => clearTimeout(timer);
-  }, [activeAnnotationId]);
+  }, [activeAnnotationId, scrollBehavior]);
 
   const hasFilters = filterType !== "all" || filterAuthor !== "all" || filterStatus !== "all";
   const activeReviewAnn =
@@ -875,6 +881,10 @@ export function SidePanel({
         .tandem-annotation-flash {
           animation: tandem-annotation-flash 0.8s ease-out;
         }
+        @media (prefers-reduced-motion: reduce) {
+          .tandem-annotation-flash { animation: none; }
+        }
+        body.tandem-reduce-motion .tandem-annotation-flash { animation: none; }
       `}</style>
     </div>
   );

--- a/src/client/status/StatusBar.tsx
+++ b/src/client/status/StatusBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { CLAUDE_PRESENCE_COLOR } from "../../shared/constants";
+import { CLAUDE_PRESENCE_COLOR, USER_NAME_MAX_LEN } from "../../shared/constants";
 import { useUserName } from "../hooks/useUserName";
 import type { ConnectionStatus } from "../hooks/useYjsSync";
 
@@ -157,7 +157,7 @@ export function StatusBar({
           }}
           aria-label="Display name"
           title="Your display name"
-          maxLength={40}
+          maxLength={USER_NAME_MAX_LEN}
           style={{
             background: "transparent",
             border: "none",

--- a/src/client/status/StatusBar.tsx
+++ b/src/client/status/StatusBar.tsx
@@ -30,9 +30,6 @@ export function StatusBar({
 }: StatusBarProps) {
   const { userName, setUserName } = useUserName();
   const [nameInput, setNameInput] = useState(userName);
-  useEffect(() => {
-    setNameInput(userName);
-  }, [userName]);
   const commitName = () => {
     setUserName(nameInput);
   };

--- a/src/client/status/StatusBar.tsx
+++ b/src/client/status/StatusBar.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import { CLAUDE_PRESENCE_COLOR, USER_NAME_DEFAULT, USER_NAME_KEY } from "../../shared/constants";
+import { CLAUDE_PRESENCE_COLOR } from "../../shared/constants";
+import { useUserName } from "../hooks/useUserName";
 import type { ConnectionStatus } from "../hooks/useYjsSync";
 
 interface StatusBarProps {
@@ -27,23 +28,13 @@ export function StatusBar({
   documentCount = 0,
   saving = false,
 }: StatusBarProps) {
-  const [userName, setUserName] = useState(() => {
-    try {
-      return localStorage.getItem(USER_NAME_KEY)?.trim() || USER_NAME_DEFAULT;
-    } catch {
-      return USER_NAME_DEFAULT;
-    }
-  });
+  const { userName, setUserName } = useUserName();
   const [nameInput, setNameInput] = useState(userName);
+  useEffect(() => {
+    setNameInput(userName);
+  }, [userName]);
   const commitName = () => {
-    const trimmed = nameInput.trim() || USER_NAME_DEFAULT;
-    setUserName(trimmed);
-    setNameInput(trimmed);
-    try {
-      localStorage.setItem(USER_NAME_KEY, trimmed);
-    } catch {
-      // localStorage unavailable (incognito/storage-disabled)
-    }
+    setUserName(nameInput);
   };
   const [showReconnectedFlash, setShowReconnectedFlash] = useState(false);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);

--- a/src/client/status/StatusBar.tsx
+++ b/src/client/status/StatusBar.tsx
@@ -30,9 +30,19 @@ export function StatusBar({
 }: StatusBarProps) {
   const { userName, setUserName } = useUserName();
   const [nameInput, setNameInput] = useState(userName);
+  const inputRef = useRef<HTMLInputElement>(null);
   const commitName = () => {
     setUserName(nameInput);
   };
+  // Idle-sync: commit c9a63de dropped the always-sync effect because it
+  // clobbered in-progress edits. This version syncs only when the input
+  // is NOT focused and the value actually differs — so cross-surface
+  // changes propagate, but typing is never interrupted.
+  useEffect(() => {
+    if (nameInput !== userName && document.activeElement !== inputRef.current) {
+      setNameInput(userName);
+    }
+  }, [userName, nameInput]);
   const [showReconnectedFlash, setShowReconnectedFlash] = useState(false);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const prevConnected = useRef(connected);
@@ -132,6 +142,7 @@ export function StatusBar({
       >
         <span>You:</span>
         <input
+          ref={inputRef}
           data-testid="user-name-input"
           type="text"
           value={nameInput}
@@ -145,7 +156,7 @@ export function StatusBar({
             }
           }}
           aria-label="Display name"
-          title="Your display name (updates on next tab switch or refresh)"
+          title="Your display name"
           maxLength={40}
           style={{
             background: "transparent",

--- a/src/client/tabs/DocumentTabs.tsx
+++ b/src/client/tabs/DocumentTabs.tsx
@@ -9,6 +9,7 @@ interface DocumentTabsProps {
   onTabSwitch: (tabId: string) => void;
   onTabClose: (tabId: string) => void;
   reorder?: (fromId: string, toId: string, side?: "left" | "right") => void;
+  reduceMotion?: boolean;
 }
 
 const FORMAT_ICONS: Record<string, string> = {
@@ -203,7 +204,9 @@ export function DocumentTabs({
   onTabSwitch,
   onTabClose,
   reorder,
+  reduceMotion,
 }: DocumentTabsProps) {
+  const scrollBehavior: ScrollBehavior = reduceMotion ? "auto" : "smooth";
   const [showDialog, setShowDialog] = useState(false);
   /** Prevent double-click on close button from firing multiple close requests. */
   const closingIdsRef = useRef<Set<string>>(new Set());
@@ -270,10 +273,10 @@ export function DocumentTabs({
       (el as HTMLElement).scrollIntoView({
         inline: "nearest",
         block: "nearest",
-        behavior: "smooth",
+        behavior: scrollBehavior,
       });
     }
-  }, [activeTabId]);
+  }, [activeTabId, scrollBehavior]);
 
   // Clear drag state when tab list changes mid-drag
   useEffect(() => {
@@ -348,12 +351,12 @@ export function DocumentTabs({
   );
 
   const scrollLeft = useCallback(() => {
-    scrollRef.current?.scrollBy({ left: -150, behavior: "smooth" });
-  }, []);
+    scrollRef.current?.scrollBy({ left: -150, behavior: scrollBehavior });
+  }, [scrollBehavior]);
 
   const scrollRight = useCallback(() => {
-    scrollRef.current?.scrollBy({ left: 150, behavior: "smooth" });
-  }, []);
+    scrollRef.current?.scrollBy({ left: 150, behavior: scrollBehavior });
+  }, [scrollBehavior]);
 
   const singleTab = tabs.length <= 1;
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -89,6 +89,7 @@ export const RECENT_FILES_CAP = 20;
 
 export const USER_NAME_KEY = "tandem:userName";
 export const USER_NAME_DEFAULT = "You";
+export const USER_NAME_EVENT = "tandem:user-name-changed";
 
 // Toast notifications
 export const TOAST_DISMISS_MS = { error: 8000, warning: 6000, info: 4000 } as const;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -90,6 +90,7 @@ export const RECENT_FILES_CAP = 20;
 export const USER_NAME_KEY = "tandem:userName";
 export const USER_NAME_DEFAULT = "You";
 export const USER_NAME_EVENT = "tandem:user-name-changed";
+export const USER_NAME_MAX_LEN = 40;
 
 // Toast notifications
 export const TOAST_DISMISS_MS = { error: 8000, warning: 6000, info: 4000 } as const;

--- a/tests/client/useRadioGroup.test.ts
+++ b/tests/client/useRadioGroup.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { useRadioGroup } from "../../src/client/hooks/useRadioGroup.js";
+
+// The hook body runs synchronously when called — we don't need renderHook,
+// we just invoke it as a function and exercise the returned handlers.
+function callHook<T extends string>(
+  value: T,
+  values: readonly T[],
+  isDisabled?: (v: T) => boolean,
+) {
+  const setValue = vi.fn();
+  const { handleKeyDown, tabIndexFor } = useRadioGroup(value, values, setValue, isDisabled);
+  return { setValue, handleKeyDown, tabIndexFor };
+}
+
+describe("useRadioGroup — tabIndexFor", () => {
+  it("puts the checked value in the tab order, others out", () => {
+    const { tabIndexFor } = callHook("m", ["s", "m", "l"] as const);
+    expect(tabIndexFor("s")).toBe(-1);
+    expect(tabIndexFor("m")).toBe(0);
+    expect(tabIndexFor("l")).toBe(-1);
+  });
+
+  it("keeps disabled values out of the tab order", () => {
+    const { tabIndexFor } = callHook(
+      "tabbed",
+      ["tabbed", "three-panel"] as const,
+      (v) => v === "three-panel",
+    );
+    expect(tabIndexFor("three-panel")).toBe(-1);
+  });
+
+  it("falls back to first enabled when the checked value itself is disabled", () => {
+    // User saved "three-panel" then narrowed the viewport — current value
+    // becomes unavailable. The group still needs a Tab stop.
+    const { tabIndexFor } = callHook(
+      "three-panel",
+      ["tabbed", "three-panel"] as const,
+      (v) => v === "three-panel",
+    );
+    expect(tabIndexFor("tabbed")).toBe(0);
+    expect(tabIndexFor("three-panel")).toBe(-1);
+  });
+});
+
+describe("useRadioGroup — handleKeyDown", () => {
+  // Minimal KeyboardEvent stub — we only need the fields the handler reads
+  // plus a querySelectorAll on currentTarget that returns an empty list so
+  // focus() is skipped (no DOM in the vitest node env).
+  function keyEvt(key: string) {
+    let prevented = false;
+    const evt = {
+      key,
+      preventDefault: () => {
+        prevented = true;
+      },
+      currentTarget: {
+        querySelectorAll: () => [] as unknown as NodeListOf<HTMLButtonElement>,
+      },
+    } as unknown as React.KeyboardEvent<HTMLDivElement>;
+    return { evt, prevented: () => prevented };
+  }
+
+  it("ArrowRight moves to the next value and calls setValue", () => {
+    const { setValue, handleKeyDown } = callHook("s", ["s", "m", "l"] as const);
+    const { evt, prevented } = keyEvt("ArrowRight");
+    handleKeyDown(evt);
+    expect(setValue).toHaveBeenCalledWith("m");
+    expect(prevented()).toBe(true);
+  });
+
+  it("ArrowLeft from first wraps to last", () => {
+    const { setValue, handleKeyDown } = callHook("s", ["s", "m", "l"] as const);
+    const { evt } = keyEvt("ArrowLeft");
+    handleKeyDown(evt);
+    expect(setValue).toHaveBeenCalledWith("l");
+  });
+
+  it("Home jumps to first enabled, End to last enabled", () => {
+    const { setValue, handleKeyDown } = callHook("m", ["s", "m", "l"] as const);
+    handleKeyDown(keyEvt("Home").evt);
+    expect(setValue).toHaveBeenLastCalledWith("s");
+    handleKeyDown(keyEvt("End").evt);
+    expect(setValue).toHaveBeenLastCalledWith("l");
+  });
+
+  it("skips disabled values — ArrowRight from tabbed cycles to tabbed, not three-panel", () => {
+    // With only one enabled value, ArrowRight wraps back to itself. This is
+    // the regression guard for the pre-fix bug where arrow keys could write
+    // a disabled value (three-panel on narrow viewports) into settings.
+    const { setValue, handleKeyDown } = callHook(
+      "tabbed",
+      ["tabbed", "three-panel"] as const,
+      (v) => v === "three-panel",
+    );
+    handleKeyDown(keyEvt("ArrowRight").evt);
+    expect(setValue).toHaveBeenCalledWith("tabbed");
+    expect(setValue).not.toHaveBeenCalledWith("three-panel");
+  });
+
+  it("ignores non-navigation keys", () => {
+    const { setValue, handleKeyDown } = callHook("m", ["s", "m", "l"] as const);
+    const { evt, prevented } = keyEvt("a");
+    handleKeyDown(evt);
+    expect(setValue).not.toHaveBeenCalled();
+    expect(prevented()).toBe(false);
+  });
+});

--- a/tests/client/useSettingsShortcut.test.ts
+++ b/tests/client/useSettingsShortcut.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { isSettingsShortcut } from "../../src/client/hooks/useSettingsShortcut.js";
+
+type E = Parameters<typeof isSettingsShortcut>[0];
+const evt = (overrides: Partial<E> = {}): E => ({
+  code: "Comma",
+  ctrlKey: false,
+  metaKey: false,
+  isComposing: false,
+  ...overrides,
+});
+
+describe("isSettingsShortcut", () => {
+  it("matches Ctrl+,", () => {
+    expect(isSettingsShortcut(evt({ ctrlKey: true }))).toBe(true);
+  });
+
+  it("matches Cmd+,", () => {
+    expect(isSettingsShortcut(evt({ metaKey: true }))).toBe(true);
+  });
+
+  it("rejects plain comma (no modifier)", () => {
+    expect(isSettingsShortcut(evt())).toBe(false);
+  });
+
+  it("rejects non-Comma code (AZERTY key that produces ',' without Comma code)", () => {
+    expect(isSettingsShortcut(evt({ code: "KeyM", ctrlKey: true }))).toBe(false);
+  });
+
+  it("bails during IME composition", () => {
+    expect(isSettingsShortcut(evt({ ctrlKey: true, isComposing: true }))).toBe(false);
+  });
+
+  it("accepts shifted form (QWERTZ users must Shift to reach comma)", () => {
+    // Shift handling is implicit — we don't gate on shiftKey, so a Shift+Ctrl+,
+    // on QWERTZ still matches as long as code === "Comma".
+    expect(
+      isSettingsShortcut({
+        code: "Comma",
+        ctrlKey: true,
+        metaKey: false,
+        isComposing: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/client/useSettingsShortcut.test.ts
+++ b/tests/client/useSettingsShortcut.test.ts
@@ -32,13 +32,9 @@ describe("isSettingsShortcut", () => {
   });
 
   it("accepts shifted form (QWERTZ users must Shift to reach comma)", () => {
-    expect(
-      isSettingsShortcut({
-        code: "Comma",
-        ctrlKey: true,
-        metaKey: false,
-        isComposing: false,
-      }),
-    ).toBe(true);
+    // The matcher doesn't gate on shiftKey, so Ctrl+Shift+Comma still matches.
+    // Pick<> doesn't include shiftKey, so this test documents intent: the
+    // matcher is Shift-agnostic by design.
+    expect(isSettingsShortcut(evt({ ctrlKey: true }))).toBe(true);
   });
 });

--- a/tests/client/useSettingsShortcut.test.ts
+++ b/tests/client/useSettingsShortcut.test.ts
@@ -32,8 +32,6 @@ describe("isSettingsShortcut", () => {
   });
 
   it("accepts shifted form (QWERTZ users must Shift to reach comma)", () => {
-    // Shift handling is implicit — we don't gate on shiftKey, so a Shift+Ctrl+,
-    // on QWERTZ still matches as long as code === "Comma".
     expect(
       isSettingsShortcut({
         code: "Comma",

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -166,6 +166,37 @@ describe("loadSettings — textSize", () => {
   });
 });
 
+describe("loadSettings — theme", () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = installLocalStorageStub();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to 'system' when no stored value", () => {
+    expect(loadSettings().theme).toBe("system");
+  });
+
+  it.each(["light", "dark", "system"] as const)("accepts '%s'", (value) => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ theme: value }));
+    expect(loadSettings().theme).toBe(value);
+  });
+
+  it("falls back to 'system' for unknown values", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ theme: "sepia" }));
+    expect(loadSettings().theme).toBe("system");
+  });
+
+  it("falls back to 'system' for non-string values", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ theme: true }));
+    expect(loadSettings().theme).toBe("system");
+  });
+});
+
 describe("loadSettings — reduceMotion", () => {
   let store: Map<string, string>;
 

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -130,6 +130,42 @@ describe("loadSettings — editorWidthPercent clamping (regression guard)", () =
   });
 });
 
+describe("loadSettings — textSize", () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = installLocalStorageStub();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to 'm' when no stored value", () => {
+    expect(loadSettings().textSize).toBe("m");
+  });
+
+  it("accepts 's'", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ textSize: "s" }));
+    expect(loadSettings().textSize).toBe("s");
+  });
+
+  it("accepts 'l'", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ textSize: "l" }));
+    expect(loadSettings().textSize).toBe("l");
+  });
+
+  it("falls back to 'm' for unknown values", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ textSize: "xl" }));
+    expect(loadSettings().textSize).toBe("m");
+  });
+
+  it("falls back to 'm' for non-string values", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ textSize: 42 }));
+    expect(loadSettings().textSize).toBe("m");
+  });
+});
+
 describe("loadSettings — reduceMotion", () => {
   let store: Map<string, string>;
 

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadSettings } from "../../src/client/hooks/useTandemSettings.js";
+import {
+  loadSettings,
+  mergeAndClampSettings,
+  type TandemSettings,
+} from "../../src/client/hooks/useTandemSettings.js";
 import {
   SELECTION_DWELL_DEFAULT_MS,
   SELECTION_DWELL_MAX_MS,
@@ -235,5 +239,65 @@ describe("loadSettings — reduceMotion", () => {
     vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
     store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ reduceMotion: "garbage" }));
     expect(loadSettings().reduceMotion).toBe(true);
+  });
+});
+
+describe("useTandemSettings — updateSettings write path", () => {
+  // mergeAndClampSettings is the pure core of updateSettings — exercising it
+  // directly covers the clamp-on-write contract without spinning up a React
+  // render environment (no @testing-library/react in this project).
+
+  const BASE: TandemSettings = {
+    layout: "three-panel",
+    primaryTab: "chat",
+    panelOrder: "chat-editor-annotations",
+    editorWidthPercent: 75,
+    selectionDwellMs: SELECTION_DWELL_DEFAULT_MS,
+    showAuthorship: false,
+    reduceMotion: false,
+    textSize: "m",
+    theme: "system",
+  };
+
+  it("clamps editorWidthPercent above 100 down to 100", () => {
+    const next = mergeAndClampSettings(BASE, { editorWidthPercent: 120 });
+    expect(next.editorWidthPercent).toBe(100);
+  });
+
+  it("clamps editorWidthPercent below 50 up to 50", () => {
+    const next = mergeAndClampSettings(BASE, { editorWidthPercent: 10 });
+    expect(next.editorWidthPercent).toBe(50);
+  });
+
+  it("clamps selectionDwellMs above max down to SELECTION_DWELL_MAX_MS", () => {
+    const next = mergeAndClampSettings(BASE, { selectionDwellMs: 99_999 });
+    expect(next.selectionDwellMs).toBe(SELECTION_DWELL_MAX_MS);
+  });
+
+  it("clamps selectionDwellMs below min up to SELECTION_DWELL_MIN_MS", () => {
+    const next = mergeAndClampSettings(BASE, { selectionDwellMs: 100 });
+    expect(next.selectionDwellMs).toBe(SELECTION_DWELL_MIN_MS);
+  });
+
+  it("preserves unchanged fields when a single field is updated", () => {
+    const next = mergeAndClampSettings(BASE, { theme: "dark" });
+    expect(next.theme).toBe("dark");
+    expect(next.layout).toBe(BASE.layout);
+    expect(next.primaryTab).toBe(BASE.primaryTab);
+    expect(next.panelOrder).toBe(BASE.panelOrder);
+    expect(next.editorWidthPercent).toBe(BASE.editorWidthPercent);
+    expect(next.selectionDwellMs).toBe(BASE.selectionDwellMs);
+    expect(next.showAuthorship).toBe(BASE.showAuthorship);
+    expect(next.reduceMotion).toBe(BASE.reduceMotion);
+    expect(next.textSize).toBe(BASE.textSize);
+  });
+
+  it("passes in-range numeric values through unchanged", () => {
+    const next = mergeAndClampSettings(BASE, {
+      editorWidthPercent: 80,
+      selectionDwellMs: 1500,
+    });
+    expect(next.editorWidthPercent).toBe(80);
+    expect(next.selectionDwellMs).toBe(1500);
   });
 });

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -137,7 +137,7 @@ describe("loadSettings — reduceMotion", () => {
     store = installLocalStorageStub();
     // Stub matchMedia to a predictable default so tests that don't set
     // reduceMotion explicitly get a deterministic fallback.
-    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+    vi.stubGlobal("window", { matchMedia: () => ({ matches: false }) });
   });
 
   afterEach(() => {
@@ -149,7 +149,7 @@ describe("loadSettings — reduceMotion", () => {
   });
 
   it("honors OS preference when no stored value", () => {
-    vi.stubGlobal("matchMedia", () => ({ matches: true }));
+    vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
     expect(loadSettings().reduceMotion).toBe(true);
   });
 
@@ -159,13 +159,13 @@ describe("loadSettings — reduceMotion", () => {
   });
 
   it("stored false overrides OS preference true", () => {
-    vi.stubGlobal("matchMedia", () => ({ matches: true }));
+    vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
     store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ reduceMotion: false }));
     expect(loadSettings().reduceMotion).toBe(false);
   });
 
   it("non-boolean stored value falls back to OS preference", () => {
-    vi.stubGlobal("matchMedia", () => ({ matches: true }));
+    vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
     store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ reduceMotion: "garbage" }));
     expect(loadSettings().reduceMotion).toBe(true);
   });

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -129,3 +129,44 @@ describe("loadSettings — editorWidthPercent clamping (regression guard)", () =
     expect(loadSettings().editorWidthPercent).toBe(50);
   });
 });
+
+describe("loadSettings — reduceMotion", () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = installLocalStorageStub();
+    // Stub matchMedia to a predictable default so tests that don't set
+    // reduceMotion explicitly get a deterministic fallback.
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to false when no OS preference and no stored value", () => {
+    expect(loadSettings().reduceMotion).toBe(false);
+  });
+
+  it("honors OS preference when no stored value", () => {
+    vi.stubGlobal("matchMedia", () => ({ matches: true }));
+    expect(loadSettings().reduceMotion).toBe(true);
+  });
+
+  it("stored true overrides OS preference false", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ reduceMotion: true }));
+    expect(loadSettings().reduceMotion).toBe(true);
+  });
+
+  it("stored false overrides OS preference true", () => {
+    vi.stubGlobal("matchMedia", () => ({ matches: true }));
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ reduceMotion: false }));
+    expect(loadSettings().reduceMotion).toBe(false);
+  });
+
+  it("non-boolean stored value falls back to OS preference", () => {
+    vi.stubGlobal("matchMedia", () => ({ matches: true }));
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ reduceMotion: "garbage" }));
+    expect(loadSettings().reduceMotion).toBe(true);
+  });
+});

--- a/tests/client/useTheme.test.ts
+++ b/tests/client/useTheme.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveTheme, systemTheme } from "../../src/client/hooks/useTheme.js";
+import { applyTheme, resolveTheme, systemTheme } from "../../src/client/hooks/useTheme.js";
 
 describe("systemTheme", () => {
   afterEach(() => {
@@ -52,5 +52,102 @@ describe("resolveTheme", () => {
     expect(resolveTheme("system")).toBe("light");
     vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
     expect(resolveTheme("system")).toBe("dark");
+  });
+});
+
+/**
+ * Exercise applyTheme — the side-effect core of useTheme — against stubbed
+ * document/window globals. This covers the useEffect body directly without
+ * pulling in a DOM environment (jsdom/happy-dom aren't installed here; the
+ * hook body is a one-liner over applyTheme).
+ */
+describe("useTheme — DOM side effects (via applyTheme)", () => {
+  type Listener = (evt: { matches: boolean }) => void;
+
+  /** Minimal stubs for document.documentElement and window.matchMedia. */
+  function installDomStubs(matchesDark = false) {
+    const attrs = new Map<string, string>();
+    const root = {
+      setAttribute: (name: string, value: string) => {
+        attrs.set(name, value);
+      },
+      removeAttribute: (name: string) => {
+        attrs.delete(name);
+      },
+      getAttribute: (name: string) => attrs.get(name) ?? null,
+    };
+    const listeners = new Set<Listener>();
+    const mq = {
+      matches: matchesDark,
+      addEventListener: (_: string, fn: Listener) => {
+        listeners.add(fn);
+      },
+      removeEventListener: (_: string, fn: Listener) => {
+        listeners.delete(fn);
+      },
+    };
+    vi.stubGlobal("document", { documentElement: root });
+    vi.stubGlobal("window", { matchMedia: () => mq });
+    return {
+      attrs,
+      listeners,
+      // Simulate the OS flipping prefers-color-scheme
+      fireChange: (matches: boolean) => {
+        mq.matches = matches;
+        for (const fn of listeners) fn({ matches });
+      },
+    };
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sets data-theme='light' when pref is 'light'", () => {
+    const { attrs } = installDomStubs();
+    applyTheme("light");
+    expect(attrs.get("data-theme")).toBe("light");
+  });
+
+  it("sets data-theme='dark' when pref is 'dark'", () => {
+    const { attrs } = installDomStubs();
+    applyTheme("dark");
+    expect(attrs.get("data-theme")).toBe("dark");
+  });
+
+  it("cleanup removes data-theme (non-system pref)", () => {
+    const { attrs } = installDomStubs();
+    const cleanup = applyTheme("dark");
+    expect(attrs.get("data-theme")).toBe("dark");
+    cleanup();
+    expect(attrs.get("data-theme")).toBeUndefined();
+  });
+
+  it("with pref='system' and matchMedia dark, sets 'dark'", () => {
+    const { attrs } = installDomStubs(true);
+    applyTheme("system");
+    expect(attrs.get("data-theme")).toBe("dark");
+  });
+
+  it("with pref='system', matchMedia change listener re-applies theme", () => {
+    const { attrs, fireChange } = installDomStubs(false);
+    applyTheme("system");
+    expect(attrs.get("data-theme")).toBe("light");
+    fireChange(true);
+    expect(attrs.get("data-theme")).toBe("dark");
+    fireChange(false);
+    expect(attrs.get("data-theme")).toBe("light");
+  });
+
+  it("with pref='system', cleanup removes the matchMedia listener", () => {
+    const { attrs, listeners, fireChange } = installDomStubs(false);
+    const cleanup = applyTheme("system");
+    expect(listeners.size).toBe(1);
+    cleanup();
+    expect(listeners.size).toBe(0);
+    expect(attrs.get("data-theme")).toBeUndefined();
+    // After unmount, a media-query change must NOT touch the attribute.
+    fireChange(true);
+    expect(attrs.get("data-theme")).toBeUndefined();
   });
 });

--- a/tests/client/useTheme.test.ts
+++ b/tests/client/useTheme.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveTheme, systemTheme } from "../../src/client/hooks/useTheme.js";
+
+describe("systemTheme", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 'light' when window is undefined (SSR/Node)", () => {
+    // No window stub — globalThis.window is absent in the vitest node env.
+    expect(systemTheme()).toBe("light");
+  });
+
+  it("returns 'dark' when matchMedia matches the dark-scheme query", () => {
+    vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
+    expect(systemTheme()).toBe("dark");
+  });
+
+  it("returns 'light' when matchMedia does not match", () => {
+    vi.stubGlobal("window", { matchMedia: () => ({ matches: false }) });
+    expect(systemTheme()).toBe("light");
+  });
+
+  it("returns 'light' when matchMedia throws (old WebViews/jsdom quirks)", () => {
+    vi.stubGlobal("window", {
+      matchMedia: () => {
+        throw new Error("no matchMedia");
+      },
+    });
+    expect(systemTheme()).toBe("light");
+  });
+});
+
+describe("resolveTheme", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", { matchMedia: () => ({ matches: false }) });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("passes 'light' through", () => {
+    expect(resolveTheme("light")).toBe("light");
+  });
+
+  it("passes 'dark' through", () => {
+    expect(resolveTheme("dark")).toBe("dark");
+  });
+
+  it("delegates 'system' to the current systemTheme() result", () => {
+    expect(resolveTheme("system")).toBe("light");
+    vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
+    expect(resolveTheme("system")).toBe("dark");
+  });
+});

--- a/tests/client/user-name.test.ts
+++ b/tests/client/user-name.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { resolveUserName } from "../../src/client/hooks/useUserName.js";
-import { USER_NAME_DEFAULT } from "../../src/shared/constants.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { persistUserName, resolveUserName } from "../../src/client/hooks/useUserName.js";
+import { USER_NAME_DEFAULT, USER_NAME_EVENT, USER_NAME_KEY } from "../../src/shared/constants.js";
 
 describe("resolveUserName", () => {
   it("returns stored name when valid", () => {
@@ -25,5 +25,74 @@ describe("resolveUserName", () => {
 
   it("trims whitespace from valid name", () => {
     expect(resolveUserName("  Bob  ")).toBe("Bob");
+  });
+});
+
+describe("persistUserName — write + broadcast contract", () => {
+  let store: Map<string, string>;
+  let dispatched: string[];
+
+  beforeEach(() => {
+    store = new Map();
+    dispatched = [];
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    } satisfies Storage);
+    vi.stubGlobal("window", {
+      dispatchEvent: (e: Event) => {
+        dispatched.push(e.type);
+        return true;
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("trims and writes to localStorage under USER_NAME_KEY", () => {
+    persistUserName("  Alice  ");
+    expect(store.get(USER_NAME_KEY)).toBe("Alice");
+  });
+
+  it("falls back to default for empty input and still writes", () => {
+    persistUserName("");
+    expect(store.get(USER_NAME_KEY)).toBe(USER_NAME_DEFAULT);
+  });
+
+  it("dispatches USER_NAME_EVENT so in-tab subscribers re-read", () => {
+    persistUserName("Bob");
+    // This assertion is the one that catches the refactor-regression the
+    // review flagged: if dispatchEvent is ever dropped from persistUserName,
+    // every cross-component subscription silently goes stale until reload.
+    expect(dispatched).toContain(USER_NAME_EVENT);
+  });
+
+  it("returns the trimmed value that was persisted", () => {
+    expect(persistUserName("  Carol  ")).toBe("Carol");
+  });
+
+  it("swallows localStorage.setItem errors (incognito/quota) but still dispatches", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota");
+      },
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } satisfies Storage);
+    expect(() => persistUserName("Dave")).not.toThrow();
+    expect(dispatched).toContain(USER_NAME_EVENT);
   });
 });

--- a/tests/client/user-name.test.ts
+++ b/tests/client/user-name.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { resolveUserName } from "../../src/client/hooks/useUserName.js";
 import { USER_NAME_DEFAULT } from "../../src/shared/constants.js";
-
-function resolveUserName(stored: string | null): string {
-  return stored?.trim() || USER_NAME_DEFAULT;
-}
 
 describe("resolveUserName", () => {
   it("returns stored name when valid", () => {
@@ -12,6 +9,10 @@ describe("resolveUserName", () => {
 
   it("returns default for null", () => {
     expect(resolveUserName(null)).toBe(USER_NAME_DEFAULT);
+  });
+
+  it("returns default for undefined", () => {
+    expect(resolveUserName(undefined)).toBe(USER_NAME_DEFAULT);
   });
 
   it("returns default for empty string", () => {

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -80,6 +80,22 @@ test("settings popover opens via settings-btn and exposes dwell slider", async (
   await expect(popover.locator("[data-testid='editor-width-slider']")).toBeVisible();
 });
 
+test("Ctrl+, opens Settings popover", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+
+  const popover = page.locator("[data-testid='settings-popover']");
+  await expect(popover).not.toBeVisible();
+
+  // Playwright maps "Control+," to the Comma key with Ctrl held — matches
+  // the hook's `e.code === "Comma" && e.ctrlKey` gate.
+  await page.keyboard.press("Control+Comma");
+
+  await expect(popover).toBeVisible({ timeout: 2_000 });
+});
+
 test("bulk-confirm resets when a filter changes (issue #199 regression)", async ({ page }) => {
   // Need 2+ pending annotations to show the "Acknowledge All" button
   await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });


### PR DESCRIPTION
## Summary

Expand the Settings popover from its layout/dwell/authorship v1 into a broader preferences surface. Tier 0 locks in a11y prerequisites; Tier 1 adds five user-facing preferences. Future passes will add pause-Claude, Claude tone, replay tutorial, and notification preferences.

## What's in

**Tier 0 — a11y prerequisites** (`766e9df`)
- `role="dialog"` + `aria-modal`, focus trap, Escape to close
- Pointerdown outside-dismiss
- Radiogroup + `aria-checked` on layout cards
- 24×24 min hit targets
- Focus-return to the gear button on close
- Heading rename: "Layout Settings" → "Settings"

**Tier 1**

| Commit | Feature |
|--------|---------|
| `de9a1d9` / `be7e364` | **Ctrl+, / Cmd+, hotkey.** Matches on `e.code === "Comma"` so AZERTY/QWERTZ/IME layouts still trigger; bails during IME composition. Unified click + hotkey path through a single `openSettings` helper. |
| `5e741b6` / `c9a63de` | **Display Name field + shared `useUserName` hook.** StatusBar and the popover now share state via a custom `tandem:user-name-changed` event; `storage` event covers cross-tab. Dropped a sync-from-prop effect that would have clobbered in-progress edits on cross-tab updates. |
| `8aa579f` / `30f4297` | **Reduce Motion toggle.** JS-gates `scrollIntoView({ behavior })` across ChatPanel, SidePanel, and DocumentTabs (the CSS media-query alone can't touch `scrollTo`). Defaults to `(prefers-reduced-motion: reduce)`. Adds a `body.tandem-reduce-motion` class and a `@media` rule so the annotation-flash animation respects the pref too. |
| `9934f93` / `dd38f19` | **Text Size S/M/L.** 14/16/18 px, exposed via `--tandem-editor-font-size` custom property so the Tiptap editor picks it up without being recreated. Labeled explicitly as a reading-density convenience; browser zoom remains the WCAG 1.4.4 path. |
| `7b9ecc6` | **Theme Light/Dark/System.** CSS custom-property token system on `<html data-theme>`, dark tokens via `[data-theme="dark"]`, `forced-colors: active` swaps to system keywords (Canvas/CanvasText/Highlight) for Windows High Contrast. SettingsPopover is the reference conversion — remaining components migrate in a follow-up. |

## Verification

- `npm run typecheck` — clean
- `npx vitest run tests/client/` — 152/152 pass, +12 new tests across `useTandemSettings` and `useSettingsShortcut`
- Each feature landed as its own commit plus a simplify follow-up — 3 agents reviewed each diff for reuse/quality/efficiency; findings were applied or explicitly skipped
- AA contrast verified on all dark-theme token pairs (spot-check in the theme agent review)

## Test plan

- [ ] Open Settings via gear click — popover anchors to the gear, traps focus, closes on Escape and outside click
- [ ] Open Settings via Ctrl+, (and on a non-QWERTY keyboard if available) — same anchor + same focus-return
- [ ] Change display name in popover, verify StatusBar updates without reload; open a second tab and verify cross-tab sync
- [ ] Toggle Reduce Motion — chat autoscroll jumps instead of smooth-scrolls; annotation flash animation stops
- [ ] Change Text Size — editor body text scales; heading proportions stay correct
- [ ] Switch Theme to Dark — popover recolors; flip to System on a machine with `prefers-color-scheme: dark`
- [ ] Windows High Contrast mode — popover uses system colors

## Scoped out (deferred to future passes)

- Pause Claude kill switch
- Claude tone / custom-instructions box
- Replay tutorial
- Notification preferences
- Full app-wide token conversion (beyond SettingsPopover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
