### PR TITLE
fix(monitor): round 3 bug fixes from PR #285 split

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -336,7 +336,7 @@ On exhaustion (`CHANNEL_MAX_RETRIES`), the monitor:
 
 Each incoming event schedules a debounced (500ms) POST to `/api/channel-awareness` (`active: true, status: "processing: <type>"`), followed by an auto-clear POST 3s later (`active: false, status: "idle"`). The browser's `StatusBar` component observes these changes and shows "Claude is active."
 
-On SIGINT/SIGTERM, `finalClearAwareness()` POSTs a final clear with the last known `documentId` before `process.exit(0)`. VITEST guards (`process.env.VITEST !== "true"`) prevent signal-listener accumulation across test files.
+On SIGINT/SIGTERM, `finalClearAwareness()` drains any in-flight awareness POSTs and then sends a final `active: false` clear for the last-known `documentId`. If no awareness was ever scheduled (no event carried a `documentId`), the shutdown POST is skipped — sending `{documentId: null}` is ambiguous and the server may reject it. `shutdownMonitor` exits 0 on a clean clear and 1 if the clear returned non-OK or threw. VITEST guards (`process.env.VITEST !== "true"`) prevent signal-listener accumulation across test files.
 
 ### Fetch Timeouts
 

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -393,12 +393,15 @@ async function finalClearAwareness(): Promise<void> {
   }
 }
 
-/** Exposed for testing. Callers should NOT invoke this outside tests. */
-export async function shutdownForTests(signal: string): Promise<void> {
+/** Called on SIGINT/SIGTERM and from tests. Flushes awareness then exits. */
+export async function shutdownMonitor(signal: string): Promise<void> {
   console.error(`[Monitor] Received ${signal}, clearing awareness and exiting`);
   await finalClearAwareness();
   process.exit(0);
 }
+
+/** @deprecated Use shutdownMonitor. Kept for backwards compatibility during the rename. */
+export const shutdownForTests = shutdownMonitor;
 
 /** Exposed for testing only — seeds the lastDocumentId that shutdown reads. */
 export function _setLastDocumentIdForTests(id: string | null): void {
@@ -413,11 +416,11 @@ export function _addOutstandingAwarenessForTests(p: Promise<unknown>): void {
 
 function installShutdownHandlers(): void {
   // Never install real signal handlers under vitest — tests drive
-  // shutdownForTests() directly. Prevents listener accumulation and
+  // shutdownMonitor() directly. Prevents listener accumulation and
   // stray real-SIGINT mid-test process.exit.
   if (IS_VITEST) return;
   const handler = (signal: string) => {
-    shutdownForTests(signal).catch((err) => {
+    shutdownMonitor(signal).catch((err) => {
       console.error("[Monitor] Shutdown handler failed:", err);
       process.exit(1);
     });

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -221,7 +221,10 @@ export async function connectAndStream(
     if (!pendingAwareness) return;
     const event = pendingAwareness;
     pendingAwareness = null;
-    shutdownTimers.lastDocumentId = event.documentId ?? null;
+    // Only update when the event has a real documentId. A doc-less event
+    // (e.g. chat:message) must NOT wipe the last-known docId — finalClearAwareness
+    // needs a non-null id to send the shutdown clear.
+    if (event.documentId) shutdownTimers.lastDocumentId = event.documentId;
     const p = fetchWithTimeout(
       `${TANDEM_URL}/api/channel-awareness`,
       {
@@ -406,6 +409,11 @@ export const shutdownForTests = shutdownMonitor;
 /** Exposed for testing only — seeds the lastDocumentId that shutdown reads. */
 export function _setLastDocumentIdForTests(id: string | null): void {
   shutdownTimers.lastDocumentId = id;
+}
+
+/** Exposed for testing only — reads the last document id that shutdown would send. */
+export function _getLastDocumentIdForTests(): string | null {
+  return shutdownTimers.lastDocumentId;
 }
 
 /** Exposed for testing only — seeds an outstanding awareness POST so the

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -363,7 +363,7 @@ function trackAwareness(p: Promise<unknown>): void {
   p.finally(() => outstandingAwareness.delete(p));
 }
 
-async function finalClearAwareness(): Promise<void> {
+async function finalClearAwareness(): Promise<boolean> {
   if (shutdownTimers.awarenessTimer) clearTimeout(shutdownTimers.awarenessTimer);
   if (shutdownTimers.clearAwarenessTimer) clearTimeout(shutdownTimers.clearAwarenessTimer);
   // Drain any in-flight awareness POSTs first so the shutdown "active:false"
@@ -373,9 +373,9 @@ async function finalClearAwareness(): Promise<void> {
   }
   // If no awareness was ever scheduled for a document, skip the POST —
   // sending {documentId: null} is ambiguous and the server may reject it.
-  if (shutdownTimers.lastDocumentId === null) return;
+  if (shutdownTimers.lastDocumentId === null) return true;
   try {
-    await fetchWithTimeout(
+    const res = await fetchWithTimeout(
       `${TANDEM_URL}/api/channel-awareness`,
       {
         method: "POST",
@@ -388,19 +388,25 @@ async function finalClearAwareness(): Promise<void> {
       },
       AWARENESS_FETCH_TIMEOUT_MS,
     );
+    if (!res.ok) {
+      console.error(`[Monitor] Shutdown awareness clear returned ${res.status}`);
+      return false;
+    }
+    return true;
   } catch (err) {
     console.error(
       "[Monitor] Shutdown awareness clear failed:",
       describeFetchError(err, "/api/channel-awareness shutdown", AWARENESS_FETCH_TIMEOUT_MS),
     );
+    return false;
   }
 }
 
 /** Called on SIGINT/SIGTERM and from tests. Flushes awareness then exits. */
 export async function shutdownMonitor(signal: string): Promise<void> {
   console.error(`[Monitor] Received ${signal}, clearing awareness and exiting`);
-  await finalClearAwareness();
-  process.exit(0);
+  const ok = await finalClearAwareness();
+  process.exit(ok ? 0 : 1);
 }
 
 /** @deprecated Use shutdownMonitor. Kept for backwards compatibility during the rename. */

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -323,13 +323,19 @@ export async function connectAndStream(
           }
         }
 
-        if (eventId) onEventId(eventId);
-
         // Collapse newlines so multi-line content stays as a single
         // notification (each stdout line is delivered separately).
         const content = formatEventContent(event).replace(/\n/g, " ");
-        process.stdout.write(content + "\n");
+        try {
+          process.stdout.write(content + "\n");
+        } catch (err) {
+          // EPIPE on a closed plugin-host pipe — re-throw so main's retry loop
+          // can decide to exhaust and exit. Do NOT checkpoint lastEventId
+          // because the event wasn't delivered.
+          throw err;
+        }
 
+        if (eventId) onEventId(eventId);
         scheduleAwareness(event);
       }
     }

--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -133,7 +133,9 @@ export async function runSetupHandler(
       await applyConfig(target.configPath, entries);
       configured.push(target.label);
     } catch (err) {
-      errors.push(`${target.label}: ${err instanceof Error ? err.message : String(err)}`);
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`${target.label}: ${msg}`);
+      console.error(`[Setup] target=${target.label} failed: ${msg}`);
     }
   }
 
@@ -142,7 +144,9 @@ export async function runSetupHandler(
     await installSkill({ homeOverride });
     skillInstalled = true;
   } catch (err) {
-    errors.push(`Skill install: ${err instanceof Error ? err.message : String(err)}`);
+    const msg = err instanceof Error ? err.message : String(err);
+    errors.push(`Skill install: ${msg}`);
+    console.error(`[Setup] skill install failed: ${msg}`);
   }
 
   // HTTP status reflects outcome:

--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -145,8 +145,18 @@ export async function runSetupHandler(
     errors.push(`Skill install: ${err instanceof Error ? err.message : String(err)}`);
   }
 
+  // HTTP status reflects outcome:
+  //   200 — every attempt succeeded (at least one configured target + skill installed)
+  //   207 — partial failure (some targets configured or skill installed, but not all)
+  //   500 — total failure (no targets configured AND skill install failed)
+  const totalFailed = configured.length === 0 && !skillInstalled;
+  const anyFailed = errors.length > 0;
+  let status: number = 200;
+  if (totalFailed) status = 500;
+  else if (anyFailed) status = 207;
+
   return {
-    status: 200,
+    status,
     body: { data: { targets, configured, errors, skillInstalled } },
   };
 }

--- a/tests/monitor/shutdown.test.ts
+++ b/tests/monitor/shutdown.test.ts
@@ -128,4 +128,34 @@ describe("graceful shutdown", () => {
 
     expect(mod._getLastDocumentIdForTests()).toBe("doc-x");
   });
+
+  it("exits 1 when the final awareness clear POST fails", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as never);
+
+    stub.on("/api/channel-awareness", () => new Response("boom", { status: 500 }));
+
+    const mod = await import("../../src/monitor/index.js");
+    mod._resetMonitorStateForTests();
+    mod._setLastDocumentIdForTests("doc-a");
+
+    await expect(mod.shutdownMonitor("SIGINT")).rejects.toThrow("exit:1");
+    exitSpy.mockRestore();
+  });
+
+  it("exits 0 when the final awareness clear POST succeeds", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as never);
+
+    stub.on("/api/channel-awareness", () => new Response("", { status: 200 }));
+
+    const mod = await import("../../src/monitor/index.js");
+    mod._resetMonitorStateForTests();
+    mod._setLastDocumentIdForTests("doc-a");
+
+    await expect(mod.shutdownMonitor("SIGINT")).rejects.toThrow("exit:0");
+    exitSpy.mockRestore();
+  });
 });

--- a/tests/monitor/shutdown.test.ts
+++ b/tests/monitor/shutdown.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createFetchStub, installMonitorFakeTimers } from "./fetch-harness.js";
+import {
+  ControllableStream,
+  createFetchStub,
+  installMonitorFakeTimers,
+  sseFrame,
+  sseResponse,
+} from "./fetch-harness.js";
 
 describe("graceful shutdown", () => {
   let stub: ReturnType<typeof createFetchStub>;
@@ -91,5 +97,35 @@ describe("graceful shutdown", () => {
     await shutdown;
     expect(exitSpy).toHaveBeenCalled();
     exitSpy.mockRestore();
+  });
+
+  it("regression: chat:message with no documentId does not wipe lastDocumentId from a prior doc event", async () => {
+    const stream = new ControllableStream();
+    stub.on("/api/events", () => sseResponse(stream));
+    stub.on("/api/channel-awareness", () => new Response("", { status: 200 }));
+
+    const mod = await import("../../src/monitor/index.js");
+    mod._resetMonitorStateForTests();
+    const p = mod.connectAndStream(undefined, () => {});
+
+    // First event carries a documentId.
+    stream.push(
+      sseFrame(
+        { id: "e1", type: "annotation:created", timestamp: 1, documentId: "doc-x", payload: {} },
+        "e1",
+      ),
+    );
+    await vi.advanceTimersByTimeAsync(600); // past AWARENESS_DEBOUNCE_MS
+
+    // Second event: chat:message without documentId.
+    stream.push(
+      sseFrame({ id: "e2", type: "chat:message", timestamp: 2, payload: { text: "hi" } }, "e2"),
+    );
+    await vi.advanceTimersByTimeAsync(600);
+
+    stream.end();
+    await p.catch(() => {});
+
+    expect(mod._getLastDocumentIdForTests()).toBe("doc-x");
   });
 });

--- a/tests/server/setup-api.test.ts
+++ b/tests/server/setup-api.test.ts
@@ -184,16 +184,23 @@ describe("runSetupHandler", () => {
     expect(readFileSync(skillPath, "utf-8")).toContain("name: tandem");
   });
 
-  it("reports partial failures without failing the whole request", async () => {
-    // Create a directory at the config path to make applyConfig fail for it
+  it("returns 207 on partial failure (some target configs fail, others succeed, skill installs)", async () => {
+    // Create a directory at the config path to make applyConfig fail for it.
+    // Skill install still succeeds against ~/.claude, and detectTargets may produce
+    // additional targets on this platform — which is fine, the handler reports the mix.
     const configPath = join(tmpDir, ".claude.json");
     mkdirSync(configPath, { recursive: true });
     const result = await runSetupHandler(
       { nodeBinary: "node", channelPath: "/fake/channel.js" },
       tmpDir,
     );
-    expect(result.status).toBe(200);
-    expect(result.body.data.errors.length).toBeGreaterThan(0);
+    const data = result.body.data!;
+    expect(data.errors.length).toBeGreaterThan(0);
+    // If skill installed (always true when ~/.claude exists and isn't read-only),
+    // the outcome is partial, not total — 207.
+    if (data.skillInstalled) {
+      expect(result.status).toBe(207);
+    }
   });
 
   it("uses custom nodeBinary in MCP config", async () => {

--- a/tests/server/setup-api.test.ts
+++ b/tests/server/setup-api.test.ts
@@ -186,8 +186,9 @@ describe("runSetupHandler", () => {
 
   it("returns 207 on partial failure (some target configs fail, others succeed, skill installs)", async () => {
     // Create a directory at the config path to make applyConfig fail for it.
-    // Skill install still succeeds against ~/.claude, and detectTargets may produce
-    // additional targets on this platform — which is fine, the handler reports the mix.
+    // Skill install still succeeds against ~/.claude (writable in beforeEach),
+    // and detectTargets may produce additional targets on this platform — which
+    // is fine, the handler reports the mix.
     const configPath = join(tmpDir, ".claude.json");
     mkdirSync(configPath, { recursive: true });
     const result = await runSetupHandler(
@@ -195,12 +196,10 @@ describe("runSetupHandler", () => {
       tmpDir,
     );
     const data = result.body.data!;
+    expect(data.skillInstalled).toBe(true);
     expect(data.errors.length).toBeGreaterThan(0);
-    // If skill installed (always true when ~/.claude exists and isn't read-only),
-    // the outcome is partial, not total — 207.
-    if (data.skillInstalled) {
-      expect(result.status).toBe(207);
-    }
+    expect(data.errors.some((e) => e.includes("Claude Code"))).toBe(true);
+    expect(result.status).toBe(207);
   });
 
   it("uses custom nodeBinary in MCP config", async () => {

--- a/tests/server/setup-route.test.ts
+++ b/tests/server/setup-route.test.ts
@@ -1,0 +1,74 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runSetupHandler } from "../../src/server/mcp/api-routes.js";
+
+describe("runSetupHandler — HTTP status reflects outcome", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "tandem-setup-status-"));
+  });
+  afterEach(() => {
+    // Windows: re-enable write so rmSync can remove readonly files.
+    try {
+      chmodSync(home, 0o700);
+    } catch {
+      /* best effort */
+    }
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("returns 200 when everything succeeds (at least one target + skill install)", async () => {
+    // Create ~/.claude so Claude Code target is detected and skill install has a target.
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    const result = await runSetupHandler(
+      { nodeBinary: process.execPath, channelPath: join(home, "channel.js") },
+      home,
+    );
+    const data = result.body.data!;
+    if (data.configured.length > 0 && data.skillInstalled) {
+      expect(result.status).toBe(200);
+    }
+  });
+
+  it("returns 500 when every target fails AND skill install fails", async () => {
+    // Block both target-config writes AND skill install by making ~/.claude a
+    // directory whose child .claude.json slot is occupied by a non-writable
+    // directory (forces applyConfig ENOTDIR/EEXIST) and ~/.claude itself is
+    // read-only (forces installSkill to fail creating the skills subtree).
+    const claudeDir = join(home, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    // Place a directory where the .claude.json file should go.
+    mkdirSync(join(home, ".claude.json"), { recursive: true });
+    chmodSync(claudeDir, 0o500); // read+execute, no write
+
+    const result = await runSetupHandler(
+      { nodeBinary: process.execPath, channelPath: join(home, "channel.js") },
+      home,
+    );
+    const data = result.body.data!;
+    if (data.configured.length === 0 && !data.skillInstalled) {
+      expect(result.status).toBe(500);
+      expect(data.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns 207 when at least one attempt succeeds but another failed", async () => {
+    // Make ~/.claude readonly to block skill install while leaving target
+    // config writes possible (claude.json at a writable tmp location).
+    const claudeDir = join(home, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    chmodSync(claudeDir, 0o500);
+
+    const result = await runSetupHandler(
+      { nodeBinary: process.execPath, channelPath: join(home, "channel.js") },
+      home,
+    );
+    const data = result.body.data!;
+    if (data.configured.length > 0 && !data.skillInstalled) {
+      expect(result.status).toBe(207);
+    }
+  });
+});

--- a/tests/server/setup-route.test.ts
+++ b/tests/server/setup-route.test.ts
@@ -28,47 +28,59 @@ describe("runSetupHandler — HTTP status reflects outcome", () => {
       home,
     );
     const data = result.body.data!;
-    if (data.configured.length > 0 && data.skillInstalled) {
-      expect(result.status).toBe(200);
-    }
+    expect(data.configured.length).toBeGreaterThan(0);
+    expect(data.skillInstalled).toBe(true);
+    expect(result.status).toBe(200);
   });
 
-  it("returns 500 when every target fails AND skill install fails", async () => {
-    // Block both target-config writes AND skill install by making ~/.claude a
-    // directory whose child .claude.json slot is occupied by a non-writable
-    // directory (forces applyConfig ENOTDIR/EEXIST) and ~/.claude itself is
-    // read-only (forces installSkill to fail creating the skills subtree).
-    const claudeDir = join(home, ".claude");
-    mkdirSync(claudeDir, { recursive: true });
-    // Place a directory where the .claude.json file should go.
-    mkdirSync(join(home, ".claude.json"), { recursive: true });
-    chmodSync(claudeDir, 0o500); // read+execute, no write
+  // chmod 0o500 is a no-op on Windows, so the read-only precondition required
+  // to force applyConfig/installSkill failures cannot be established. Skip on
+  // win32 rather than assert conditionally — a guard would let the test pass
+  // without exercising the 500/207 branches at all.
+  it.skipIf(process.platform === "win32")(
+    "returns 500 when every target fails AND skill install fails",
+    async () => {
+      // Block both target-config writes AND skill install by making ~/.claude a
+      // directory whose child .claude.json slot is occupied by a non-writable
+      // directory (forces applyConfig ENOTDIR/EEXIST) and ~/.claude itself is
+      // read-only (forces installSkill to fail creating the skills subtree).
+      const claudeDir = join(home, ".claude");
+      mkdirSync(claudeDir, { recursive: true });
+      // Place a directory where the .claude.json file should go.
+      mkdirSync(join(home, ".claude.json"), { recursive: true });
+      chmodSync(claudeDir, 0o500); // read+execute, no write
 
-    const result = await runSetupHandler(
-      { nodeBinary: process.execPath, channelPath: join(home, "channel.js") },
-      home,
-    );
-    const data = result.body.data!;
-    if (data.configured.length === 0 && !data.skillInstalled) {
+      const result = await runSetupHandler(
+        { nodeBinary: process.execPath, channelPath: join(home, "channel.js") },
+        home,
+      );
+      const data = result.body.data!;
+      expect(data.configured.length).toBe(0);
+      expect(data.skillInstalled).toBe(false);
       expect(result.status).toBe(500);
       expect(data.errors.length).toBeGreaterThan(0);
-    }
-  });
+      expect(data.errors.some((e) => e.startsWith("Skill install:"))).toBe(true);
+    },
+  );
 
-  it("returns 207 when at least one attempt succeeds but another failed", async () => {
-    // Make ~/.claude readonly to block skill install while leaving target
-    // config writes possible (claude.json at a writable tmp location).
-    const claudeDir = join(home, ".claude");
-    mkdirSync(claudeDir, { recursive: true });
-    chmodSync(claudeDir, 0o500);
+  it.skipIf(process.platform === "win32")(
+    "returns 207 when at least one attempt succeeds but another failed",
+    async () => {
+      // Make ~/.claude readonly to block skill install while leaving target
+      // config writes possible (claude.json at a writable tmp location).
+      const claudeDir = join(home, ".claude");
+      mkdirSync(claudeDir, { recursive: true });
+      chmodSync(claudeDir, 0o500);
 
-    const result = await runSetupHandler(
-      { nodeBinary: process.execPath, channelPath: join(home, "channel.js") },
-      home,
-    );
-    const data = result.body.data!;
-    if (data.configured.length > 0 && !data.skillInstalled) {
+      const result = await runSetupHandler(
+        { nodeBinary: process.execPath, channelPath: join(home, "channel.js") },
+        home,
+      );
+      const data = result.body.data!;
+      expect(data.configured.length).toBeGreaterThan(0);
+      expect(data.skillInstalled).toBe(false);
       expect(result.status).toBe(207);
-    }
-  });
+      expect(data.errors.length).toBeGreaterThan(0);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Round 3 review fixes, part 1 of 5: **production bug fixes** split out of PR #285 for easier review.

Five commits, all landed in round 3 of #285 and now re-grouped here on a clean base:

- `refactor(monitor)`: rename `shutdownForTests` to `shutdownMonitor`, keep alias
- `fix(monitor)`: keep last-known `documentId` across doc-less events
- `fix(monitor)`: exit 1 when shutdown awareness clear fails
- `fix(api)`: return 207/500 from `/api/setup` on partial/total failure
- `fix(monitor)`: checkpoint event id only after successful stdout write (EPIPE data-loss fix)

The last commit — originally grouped as "hardening" — is a real correctness fix for an EPIPE edge case where the checkpoint file could advance past an unwritten event. Moved here at plan-review time.

## Split context

PR #285 reached 61 commits across three review rounds. Rounds 1+2 (38 commits) merged via rebase as #285. Round 3 (23 commits) is splitting into:

- **PR A (this) — bugs** (5 commits)
- **PR B — docs** (4 commits, parallel)
- **PR C — regression tests** (10 commits, after A merges)
- **PR D — hardening refactors** (3 commits)
- **PR E — CHANGELOG roll-up** (1 commit, last)

CHANGELOG is omitted from A/B/C/D and lands as a single roll-up in E to avoid 4-way conflicts on the same subheading.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1110 passed (78 files)
- [ ] CI green on the PR
- [ ] Reviewer spot-check on the EPIPE checkpoint fix (`src/monitor/index.ts`)
