### PR TITLE
docs(monitor): round 3 doc fixes from PR #285 split

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -340,14 +340,18 @@ On SIGINT/SIGTERM, `finalClearAwareness()` drains any in-flight awareness POSTs 
 
 ### Fetch Timeouts
 
-All outbound HTTP calls use an `AbortSignal.timeout`-wrapped helper with per-route budgets:
+Outbound HTTP calls use two mechanisms:
 
-| Route | Budget |
-|-------|--------|
-| SSE connect (`/api/events`) | 10s |
-| Mode check (`/api/mode`) | 2s |
-| Awareness POST (`/api/channel-awareness`) | 5s |
-| Error report (`/api/channel-error`) | 3s |
+1. **`fetchWithTimeout(url, init, ms)`** — wraps `AbortSignal.timeout(ms)` around `fetch`. Used for all request-response routes.
+2. **Split handshake + inactivity watchdog** — used for the streaming `/api/events` route. A local `AbortController` bounds the handshake; once the response headers arrive the controller's timer is cleared, and a separate inactivity watchdog cancels the body stream if no bytes arrive for `SSE_INACTIVITY_TIMEOUT_MS`. See [lesson #42](./lessons-learned.md#42-abortsignal-passed-to-fetch-governs-the-response-body-too).
+
+| Route | Mechanism | Budget |
+|-------|-----------|--------|
+| SSE handshake (`/api/events`) | Local `AbortController` | 10s (handshake only) |
+| SSE body (`/api/events`) | Inactivity watchdog | 60s per-read |
+| Mode check (`/api/mode`) | `AbortSignal.timeout` | 2s |
+| Awareness POST (`/api/channel-awareness`) | `AbortSignal.timeout` | 5s |
+| Error report (`/api/channel-error`) | `AbortSignal.timeout` | 3s |
 
 ### Why `tandem-channel` Is Now Opt-In
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -392,7 +392,10 @@ Initial attempts to filter at the bridge and server levels had no effect because
 
 ```ts
 const connectCtrl = new AbortController();
-const connectTimer = setTimeout(() => connectCtrl.abort(), CONNECT_FETCH_TIMEOUT_MS);
+const connectTimer = setTimeout(
+  () => connectCtrl.abort(new Error("handshake timeout")),
+  CONNECT_FETCH_TIMEOUT_MS,
+);
 let res: Response;
 try {
   res = await fetch(url, { headers, signal: connectCtrl.signal });
@@ -401,6 +404,8 @@ try {
 }
 ```
 
+Pass an `Error` argument to `abort()` so the reason flows through to `fetch`'s rejection — a bare `abort()` loses the handshake-vs-body distinction when you later surface the error to logs.
+
 **Follow-on gotcha:** `reader.cancel(reason)` resolves the pending `read()` with `{done: true}` — it does NOT reject, and the `reason` argument is not surfaced to the caller. To propagate the cause (e.g., "was this a natural end-of-stream or a watchdog cancel?"), set a local flag before cancelling and branch on it after `done: true`:
 
 ```ts
@@ -408,7 +413,7 @@ let inactivityTimedOut = false;
 const watchdog = setInterval(() => {
   if (Date.now() - lastActivityAt > SSE_INACTIVITY_TIMEOUT_MS) {
     inactivityTimedOut = true;
-    reader.cancel().catch(() => {});
+    reader.cancel(new Error("SSE inactivity timeout")).catch(() => {});
   }
 }, SSE_INACTIVITY_TIMEOUT_MS / 4);
 // ...

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -352,8 +352,9 @@ export async function connectAndStream(
   }
 }
 
-// Placeholder bindings — populated by later tasks (shutdown and mode-refresh).
-// Declared here so _resetMonitorStateForTests can reference them safely.
+// Module-level shutdown timers + mode-refresh lock. Declared at module scope
+// so _resetMonitorStateForTests can clear them in a single call and
+// finalClearAwareness can flush them from the signal handler.
 const shutdownTimers: {
   awarenessTimer: ReturnType<typeof setTimeout> | null;
   clearAwarenessTimer: ReturnType<typeof setTimeout> | null;


### PR DESCRIPTION
## Summary

Round 3 review fixes, part 2 of 5: **documentation fixes** split out of PR #285.

Four commits, pure docs (plus one 5-line stale-comment removal in `src/monitor/index.ts`):

- `docs(architecture)`: split handshake and body timeouts in fetch table
- `docs(architecture)`: document `finalClearAwareness` early-return and exit code
- `docs(monitor)`: remove stale "placeholder bindings" comment
- `docs(lessons)`: align lesson #42 snippets with monitor source

## Split context

Part of the 5-PR split of PR #285 round 3. See #288 (PR A — bugs) for the full split rationale. Parallel-reviewable with #288.

CHANGELOG intentionally omitted here; it lands as a single roll-up (PR E) after A/B/C/D merge, to avoid conflicts on the shared round-3 subheading.

## Test plan

- [x] `npm run typecheck` clean
- [ ] CI green
- [ ] Reviewer spot-check on updated lesson #42 snippets matching current `src/monitor/index.ts`
