### PR TITLE
test(monitor): round 3 regression tests from PR #285 split

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -323,7 +323,7 @@ Two distinct failure modes require two distinct fallbacks:
 
 **Rationale:** Flipping to "solo" mid-session would randomly suppress events the user has not asked to suppress. Honoring the last known good value on transient failure is better UX without weakening the initial privacy signal — solo is still the default on a cold or erroring server.
 
-**Default asymmetry:** `/api/mode` server-side defaults missing or malformed values to `"tandem"` (user's settings fall back to the global default). The monitor defaults to `"solo"` on a failed/unparseable response. This is intentional — the server has durable user state; the monitor does not, and failing closed preserves the stricter privacy signal under transient error. Tests in `tests/monitor/integration.test.ts` fence the monitor side.
+**Default asymmetry:** `/api/mode` server-side defaults missing or malformed values to `"tandem"` (user's settings fall back to the global default). The monitor defaults to `"solo"` on a failed/unparseable response. This is intentional — the server has durable user state; the monitor does not, and failing closed preserves the stricter privacy signal under transient error. Tests in `tests/monitor/integration.test.ts` fence both sides of the asymmetry; `tests/monitor/mode-cache.test.ts` exhaustively covers the monitor-side fail-closed paths (non-JSON, unrecognized value, missing field, non-string).
 
 ### Retry Semantics
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -323,6 +323,8 @@ Two distinct failure modes require two distinct fallbacks:
 
 **Rationale:** Flipping to "solo" mid-session would randomly suppress events the user has not asked to suppress. Honoring the last known good value on transient failure is better UX without weakening the initial privacy signal — solo is still the default on a cold or erroring server.
 
+**Default asymmetry:** `/api/mode` server-side defaults missing or malformed values to `"tandem"` (user's settings fall back to the global default). The monitor defaults to `"solo"` on a failed/unparseable response. This is intentional — the server has durable user state; the monitor does not, and failing closed preserves the stricter privacy signal under transient error. Tests in `tests/monitor/integration.test.ts` fence the monitor side.
+
 ### Retry Semantics
 
 Reconnect uses exponential backoff: 2s / 4s / 8s / 16s / 30s (cap). The retry counter resets **only after `STABLE_CONNECTION_MS` (60s) of continuous uptime** — resetting per event would let a server that crashes after each event reconnect forever, never exhausting the cap.

--- a/tests/monitor/integration.test.ts
+++ b/tests/monitor/integration.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TANDEM_MODE_DEFAULT } from "../../src/shared/constants.js";
+import { TandemModeSchema } from "../../src/shared/types.js";
 import { createFetchStub, installMonitorFakeTimers } from "./fetch-harness.js";
 
-describe("mode default — monitor side of the documented asymmetry", () => {
+// Fences the asymmetry documented in docs/architecture.md "Contract Asymmetry:
+// Mode Check": the server-side /api/mode handler defaults missing/malformed
+// values to "tandem" (fails open); the monitor-side getCachedMode() defaults
+// to "solo" (fails closed). Having both sides in one file makes the asymmetry
+// visible at a glance — if either side drifts, this test file fails.
+describe("mode default asymmetry", () => {
   let stub: ReturnType<typeof createFetchStub>;
 
   beforeEach(async () => {
@@ -16,7 +23,24 @@ describe("mode default — monitor side of the documented asymmetry", () => {
     vi.useRealTimers();
   });
 
-  it("monitor treats a missing mode field as solo (privacy-preserving default)", async () => {
+  // The server-side default is applied at src/server/mcp/api-routes.ts via
+  // TandemModeSchema.catch(TANDEM_MODE_DEFAULT).parse(awareness.get(Y_MAP_MODE)).
+  // Re-exercise that exact expression here so a regression to a different
+  // default (e.g. "solo", removing the catch() clause) trips this test.
+  it("server side fails open to 'tandem' for missing/malformed values", () => {
+    const parseWithServerDefault = (input: unknown) =>
+      TandemModeSchema.catch(TANDEM_MODE_DEFAULT).parse(input);
+
+    expect(parseWithServerDefault(undefined)).toBe("tandem");
+    expect(parseWithServerDefault(null)).toBe("tandem");
+    expect(parseWithServerDefault("")).toBe("tandem");
+    expect(parseWithServerDefault("enterprise")).toBe("tandem");
+    expect(parseWithServerDefault(42)).toBe("tandem");
+    // TANDEM_MODE_DEFAULT itself must remain "tandem" for the asymmetry to hold.
+    expect(TANDEM_MODE_DEFAULT).toBe("tandem");
+  });
+
+  it("monitor side fails closed to 'solo' when /api/mode omits the mode field", async () => {
     stub.on("/api/mode", () => new Response(JSON.stringify({}), { status: 200 }));
     const { getCachedMode } = await import("../../src/monitor/index.js");
     expect(await getCachedMode()).toBe("solo");

--- a/tests/monitor/integration.test.ts
+++ b/tests/monitor/integration.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFetchStub, installMonitorFakeTimers } from "./fetch-harness.js";
+
+describe("mode default — monitor side of the documented asymmetry", () => {
+  let stub: ReturnType<typeof createFetchStub>;
+
+  beforeEach(async () => {
+    installMonitorFakeTimers();
+    stub = createFetchStub();
+    stub.install();
+    const mod = await import("../../src/monitor/index.js");
+    mod._resetMonitorStateForTests();
+  });
+  afterEach(() => {
+    stub.restore();
+    vi.useRealTimers();
+  });
+
+  it("monitor treats a missing mode field as solo (privacy-preserving default)", async () => {
+    stub.on("/api/mode", () => new Response(JSON.stringify({}), { status: 200 }));
+    const { getCachedMode } = await import("../../src/monitor/index.js");
+    expect(await getCachedMode()).toBe("solo");
+  });
+});

--- a/tests/monitor/mode-cache.test.ts
+++ b/tests/monitor/mode-cache.test.ts
@@ -191,8 +191,11 @@ describe("background mode refresh", () => {
 
     // Advance time but DO NOT resolve /api/mode
     await vi.advanceTimersByTimeAsync(100);
-    // stdout should already have the event (cached default is "tandem", non-blocking)
-    expect(stdoutSpy).toHaveBeenCalled();
+    // stdout should already have the event (cached default is "tandem", non-blocking).
+    // Verify the actual event payload reached stdout, not just any stdout write.
+    const stdoutWrites = stdoutSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(stdoutWrites).toMatch(/document|opened/);
+    expect(stdoutWrites).toMatch(/a\.md/);
 
     // Now resolve mode and end the stream
     modeResolve?.(new Response(JSON.stringify({ mode: "tandem" }), { status: 200 }));

--- a/tests/monitor/mode-cache.test.ts
+++ b/tests/monitor/mode-cache.test.ts
@@ -191,11 +191,12 @@ describe("background mode refresh", () => {
 
     // Advance time but DO NOT resolve /api/mode
     await vi.advanceTimersByTimeAsync(100);
-    // stdout should already have the event (cached default is "tandem", non-blocking).
-    // Verify the actual event payload reached stdout, not just any stdout write.
+    // stdout should already have the formatted event (cached default is
+    // "tandem", non-blocking). Match the full formatter prefix from
+    // formatEventContent so a regression that drops the "User opened
+    // document:" prefix or the filename cannot sneak past.
     const stdoutWrites = stdoutSpy.mock.calls.map((c) => String(c[0])).join("");
-    expect(stdoutWrites).toMatch(/document|opened/);
-    expect(stdoutWrites).toMatch(/a\.md/);
+    expect(stdoutWrites).toMatch(/User opened document: a\.md/);
 
     // Now resolve mode and end the stream
     modeResolve?.(new Response(JSON.stringify({ mode: "tandem" }), { status: 200 }));

--- a/tests/monitor/mode-cache.test.ts
+++ b/tests/monitor/mode-cache.test.ts
@@ -244,4 +244,42 @@ describe("background mode refresh", () => {
     const failureCalls = modeCallCount - successCalls;
     expect(failureCalls).toBeLessThanOrEqual(12);
   });
+
+  it("intermittent /api/mode during startup does not spam refreshes", async () => {
+    let modeCallCount = 0;
+    stub.on("/api/mode", () => {
+      modeCallCount++;
+      if (modeCallCount <= 5) return new Response("fail", { status: 503 });
+      return new Response(JSON.stringify({ mode: "tandem" }), { status: 200 });
+    });
+
+    const mod = await import("../../src/monitor/index.js");
+    await mod.getCachedMode();
+    expect(mod.getModeSync()).toBe("solo");
+    expect(modeCallCount).toBe(1);
+
+    const stream = new ControllableStream();
+    stub.on("/api/events", () => sseResponse(stream));
+    const p = mod.connectAndStream(undefined, () => {});
+
+    for (let i = 0; i < 10; i++) {
+      stream.push(
+        sseFrame(
+          {
+            id: `e${i}`,
+            type: "document:opened",
+            timestamp: i,
+            payload: { fileName: "x.md", format: "md" },
+          },
+          `e${i}`,
+        ),
+      );
+      await vi.advanceTimersByTimeAsync(500);
+    }
+    stream.end();
+    await p.catch(() => {});
+
+    // Rate-limiter holds refreshes to <= 6 (1 startup + at most one per 2s window over 5s).
+    expect(modeCallCount).toBeLessThanOrEqual(6);
+  });
 });

--- a/tests/monitor/mode-cache.test.ts
+++ b/tests/monitor/mode-cache.test.ts
@@ -61,6 +61,40 @@ describe("getCachedMode fail-closed", () => {
     await mod.getCachedMode();
     expect(mod.getModeSync()).toBe("solo");
   });
+
+  it("fails closed to 'solo' when /api/mode returns non-JSON (HTML)", async () => {
+    stub.on(
+      "/api/mode",
+      () =>
+        new Response("<html><body>proxy error</body></html>", {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        }),
+    );
+    const { getCachedMode } = await import("../../src/monitor/index.js");
+    expect(await getCachedMode()).toBe("solo");
+  });
+
+  it("fails closed to 'solo' when /api/mode returns an unrecognized mode value", async () => {
+    stub.on(
+      "/api/mode",
+      () => new Response(JSON.stringify({ mode: "enterprise" }), { status: 200 }),
+    );
+    const { getCachedMode } = await import("../../src/monitor/index.js");
+    expect(await getCachedMode()).toBe("solo");
+  });
+
+  it("fails closed to 'solo' when /api/mode omits the mode field", async () => {
+    stub.on("/api/mode", () => new Response(JSON.stringify({}), { status: 200 }));
+    const { getCachedMode } = await import("../../src/monitor/index.js");
+    expect(await getCachedMode()).toBe("solo");
+  });
+
+  it("fails closed to 'solo' when /api/mode returns mode as a non-string", async () => {
+    stub.on("/api/mode", () => new Response(JSON.stringify({ mode: 42 }), { status: 200 }));
+    const { getCachedMode } = await import("../../src/monitor/index.js");
+    expect(await getCachedMode()).toBe("solo");
+  });
 });
 
 describe("startup cache warm", () => {

--- a/tests/monitor/retry.test.ts
+++ b/tests/monitor/retry.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { main } from "../../src/monitor/index.js";
+import { connectAndStream, main } from "../../src/monitor/index.js";
 import {
   ControllableStream,
   createFetchStub,
@@ -138,6 +138,16 @@ describe("retry counter semantics", () => {
     // Drain remaining retries so main() exits via the MAX branch.
     await vi.advanceTimersByTimeAsync(200_000);
     await p;
+  });
+
+  it("503 response does not leak handshake/stable/watchdog timers", async () => {
+    const beforeTimerCount = vi.getTimerCount();
+    stub.on("/api/events", () => new Response("", { status: 503 }));
+
+    await connectAndStream(undefined, () => {}).catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(beforeTimerCount);
   });
 });
 

--- a/tests/monitor/retry.test.ts
+++ b/tests/monitor/retry.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { connectAndStream, main } from "../../src/monitor/index.js";
+import { CHANNEL_MAX_RETRIES } from "../../src/shared/constants.js";
 import {
   ControllableStream,
   createFetchStub,
@@ -62,8 +63,8 @@ describe("retry counter semantics", () => {
     await vi.advanceTimersByTimeAsync(200_000);
     await mainPromise;
 
-    // With the old bug, this would loop forever. With the fix, max 5 attempts.
-    expect(connectAttempts).toBeLessThanOrEqual(6); // CHANNEL_MAX_RETRIES is 5
+    // With the old bug, this would loop forever. With the fix, max attempts is CHANNEL_MAX_RETRIES.
+    expect(connectAttempts).toBeLessThanOrEqual(CHANNEL_MAX_RETRIES);
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
@@ -94,8 +95,8 @@ describe("retry counter semantics", () => {
     await vi.advanceTimersByTimeAsync(200_000);
     await mainPromise;
 
-    // CHANNEL_MAX_RETRIES = 5; expect at least that many connect attempts.
-    expect(connectAttempts).toBeGreaterThanOrEqual(5);
+    // Expect at least CHANNEL_MAX_RETRIES connect attempts before exhaustion.
+    expect(connectAttempts).toBeGreaterThanOrEqual(CHANNEL_MAX_RETRIES);
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 

--- a/tests/monitor/retry.test.ts
+++ b/tests/monitor/retry.test.ts
@@ -59,12 +59,15 @@ describe("retry counter semantics", () => {
     });
 
     const mainPromise = main().catch(() => {});
-    // Advance through 5 retry cycles (each with 2s+ delay, growing with backoff in B7)
+    // Advance past the full backoff budget (2+4+8+16+30 = 60s) so main()
+    // exhausts CHANNEL_MAX_RETRIES and exits via the MAX branch.
     await vi.advanceTimersByTimeAsync(200_000);
     await mainPromise;
 
-    // With the old bug, this would loop forever. With the fix, max attempts is CHANNEL_MAX_RETRIES.
-    expect(connectAttempts).toBeLessThanOrEqual(CHANNEL_MAX_RETRIES);
+    // process.exit(1) only fires from the MAX branch, so connectAttempts must
+    // be exactly CHANNEL_MAX_RETRIES — an upper bound alone would pass for an
+    // early-exit regression (e.g. inverted loop condition) that still exits 1.
+    expect(connectAttempts).toBe(CHANNEL_MAX_RETRIES);
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
@@ -101,41 +104,49 @@ describe("retry counter semantics", () => {
   });
 
   it("retry counter resets after STABLE_CONNECTION_MS of continuous uptime", async () => {
+    // Accumulate retries BEFORE the stable-uptime period so the reset has
+    // something to reset. Attempts 1+2 fail (retries climbs to 2), attempt 3
+    // succeeds and stays up past STABLE_CONNECTION_MS (60s) so onStable fires
+    // and main() resets retries to 0. When attempt 3 ends, main's catch runs:
+    //   - With the reset: retries goes 0→1, backoff = 2000ms.
+    //   - Without the reset: retries would go 2→3, backoff = 8000ms.
+    // Asserting that attempt 4 fires within ~2s proves the reset happened.
+    const attemptTimes: number[] = [];
     let attempt = 0;
-    const stream1 = new ControllableStream();
-    const stream2 = new ControllableStream();
+    const stream3 = new ControllableStream();
+    const stream4 = new ControllableStream();
     stub.on("/api/events", () => {
       attempt++;
-      if (attempt === 1) return sseResponse(stream1);
-      if (attempt === 2) return sseResponse(stream2);
+      attemptTimes.push(Date.now());
+      if (attempt <= 2) throw new Error("refused");
+      if (attempt === 3) return sseResponse(stream3);
+      if (attempt === 4) return sseResponse(stream4);
       throw new Error("unexpected attempt");
     });
 
     const p = main().catch(() => {});
 
-    await vi.advanceTimersByTimeAsync(10);
-    stream1.push(
-      sseFrame(
-        {
-          id: "e1",
-          type: "document:opened",
-          timestamp: 1,
-          payload: { fileName: "a.md", format: "md" },
-        },
-        "e1",
-      ),
-    );
+    // Drive past attempts 1+2 (backoffs 2s+4s) so attempt 3 is active.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(attempt).toBe(3);
 
-    // Past STABLE_CONNECTION_MS (60s) — onStable resets retries to 0.
+    // Hold attempt 3 up past STABLE_CONNECTION_MS so onStable fires.
     await vi.advanceTimersByTimeAsync(60_500);
 
-    stream1.end();
-    // Second attempt should fire after the initial 2s delay, not 30s (cap).
+    stream3.end();
+    const t3End = Date.now();
+
+    // Advance slightly past the base backoff (2s). If reset worked, attempt 4
+    // has fired. If reset failed silently, retries would still be 2→3, delay
+    // would be 8s, and attempt 4 would not have fired yet.
     await vi.advanceTimersByTimeAsync(2_100);
 
-    expect(attempt).toBe(2);
+    expect(attempt).toBe(4);
+    const delayToAttempt4 = attemptTimes[3]! - t3End;
+    expect(delayToAttempt4).toBeGreaterThanOrEqual(1900);
+    expect(delayToAttempt4).toBeLessThan(3000);
 
-    stream2.end();
+    stream4.end();
     // Drain remaining retries so main() exits via the MAX branch.
     await vi.advanceTimersByTimeAsync(200_000);
     await p;

--- a/tests/monitor/retry.test.ts
+++ b/tests/monitor/retry.test.ts
@@ -98,6 +98,47 @@ describe("retry counter semantics", () => {
     expect(connectAttempts).toBeGreaterThanOrEqual(5);
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  it("retry counter resets after STABLE_CONNECTION_MS of continuous uptime", async () => {
+    let attempt = 0;
+    const stream1 = new ControllableStream();
+    const stream2 = new ControllableStream();
+    stub.on("/api/events", () => {
+      attempt++;
+      if (attempt === 1) return sseResponse(stream1);
+      if (attempt === 2) return sseResponse(stream2);
+      throw new Error("unexpected attempt");
+    });
+
+    const p = main().catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(10);
+    stream1.push(
+      sseFrame(
+        {
+          id: "e1",
+          type: "document:opened",
+          timestamp: 1,
+          payload: { fileName: "a.md", format: "md" },
+        },
+        "e1",
+      ),
+    );
+
+    // Past STABLE_CONNECTION_MS (60s) — onStable resets retries to 0.
+    await vi.advanceTimersByTimeAsync(60_500);
+
+    stream1.end();
+    // Second attempt should fire after the initial 2s delay, not 30s (cap).
+    await vi.advanceTimersByTimeAsync(2_100);
+
+    expect(attempt).toBe(2);
+
+    stream2.end();
+    // Drain remaining retries so main() exits via the MAX branch.
+    await vi.advanceTimersByTimeAsync(200_000);
+    await p;
+  });
 });
 
 describe("exponential backoff", () => {

--- a/tests/monitor/shutdown.test.ts
+++ b/tests/monitor/shutdown.test.ts
@@ -47,22 +47,22 @@ describe("graceful shutdown", () => {
     exitSpy.mockRestore();
   });
 
-  it("skips the awareness POST when no document is active (lastDocumentId === null)", async () => {
+  it("skips the shutdown awareness POST when no event with a documentId ever arrived", async () => {
+    const writes: unknown[] = [];
+    stub.on("/api/channel-awareness", async (_url, init) => {
+      if (typeof init?.body === "string") writes.push(JSON.parse(init.body));
+      return new Response("", { status: 200 });
+    });
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as never);
+
     const mod = await import("../../src/monitor/index.js");
     mod._resetMonitorStateForTests();
-    stub.on("/api/channel-awareness", () => new Response("", { status: 200 }));
 
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
-      throw new Error("exit");
-    }) as never);
-    try {
-      await mod.shutdownForTests("SIGINT");
-    } catch {
-      // exit thrown is expected
-    }
-
-    const clears = stub.calls.filter((c) => c.url.includes("/api/channel-awareness"));
-    expect(clears.length).toBe(0);
+    await expect(mod.shutdownMonitor("SIGINT")).rejects.toThrow("exit:0");
+    expect(writes).toEqual([]);
     exitSpy.mockRestore();
   });
 

--- a/tests/monitor/sse-parsing.test.ts
+++ b/tests/monitor/sse-parsing.test.ts
@@ -142,3 +142,80 @@ describe("SSE buffer overflow", () => {
     expect(onEventId).toHaveBeenCalledWith("big");
   });
 });
+
+describe("SSE resume behavior", () => {
+  let stub: ReturnType<typeof createFetchStub>;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    installMonitorFakeTimers();
+    stub = createFetchStub();
+    stub.install();
+    stub.on("/api/mode", () => new Response(JSON.stringify({ mode: "tandem" }), { status: 200 }));
+    stub.on("/api/channel-awareness", () => new Response("", { status: 200 }));
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const mod = await import("../../src/monitor/index.js");
+    mod._resetMonitorStateForTests();
+  });
+  afterEach(() => {
+    stub.restore();
+    vi.useRealTimers();
+    stdoutSpy.mockRestore();
+  });
+
+  it("resume: Last-Event-ID header on reconnect matches the last delivered id", async () => {
+    const stream1 = new ControllableStream();
+    const stream2 = new ControllableStream();
+    let attempts = 0;
+    const headersSeen: Array<Record<string, string>> = [];
+
+    stub.on("/api/events", (_url, init) => {
+      attempts++;
+      const hdrs: Record<string, string> = {};
+      const raw = init?.headers;
+      if (raw && typeof raw === "object") {
+        if (raw instanceof Headers) {
+          raw.forEach((v, k) => {
+            hdrs[k.toLowerCase()] = v;
+          });
+        } else {
+          for (const [k, v] of Object.entries(raw as Record<string, string>)) {
+            hdrs[k.toLowerCase()] = String(v);
+          }
+        }
+      }
+      headersSeen.push(hdrs);
+      if (attempts === 1) return sseResponse(stream1);
+      return sseResponse(stream2);
+    });
+
+    let lastId: string | undefined;
+    const p1 = connectAndStream(undefined, (id) => {
+      lastId = id;
+    });
+    stream1.push(
+      sseFrame(
+        {
+          id: "e7",
+          type: "document:opened",
+          timestamp: 1,
+          payload: { fileName: "a.md", format: "md" },
+        },
+        "e7",
+      ),
+    );
+    await vi.advanceTimersByTimeAsync(10);
+    stream1.end();
+    await p1.catch(() => {});
+
+    expect(lastId).toBe("e7");
+
+    const p2 = connectAndStream(lastId, () => {});
+    stream2.end();
+    await p2.catch(() => {});
+
+    expect(headersSeen).toHaveLength(2);
+    expect(headersSeen[0]["last-event-id"]).toBeUndefined();
+    expect(headersSeen[1]["last-event-id"]).toBe("e7");
+  });
+});

--- a/tests/monitor/timeouts.test.ts
+++ b/tests/monitor/timeouts.test.ts
@@ -36,3 +36,36 @@ describe("fetch timeout", () => {
     expect(mode).toBe("solo");
   });
 });
+
+describe("mode cache under clock skew", () => {
+  let stub: ReturnType<typeof createFetchStub>;
+
+  beforeEach(async () => {
+    installMonitorFakeTimers();
+    stub = createFetchStub();
+    stub.install();
+    stub.on("/api/mode", () => new Response(JSON.stringify({ mode: "tandem" }), { status: 200 }));
+    const mod = await import("../../src/monitor/index.js");
+    mod._resetMonitorStateForTests();
+  });
+  afterEach(() => {
+    stub.restore();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("backward Date.now() jump does not wedge the mode cache permanently", async () => {
+    const mod = await import("../../src/monitor/index.js");
+    expect(await mod.getCachedMode()).toBe("tandem");
+
+    const realNow = Date.now;
+    vi.spyOn(Date, "now").mockImplementation(() => realNow() - 60 * 60 * 1000);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(await mod.getCachedMode()).toBe("tandem"); // stuck-but-safe
+
+    vi.restoreAllMocks();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(await mod.getCachedMode()).toBe("tandem"); // recovers
+  });
+});

--- a/tests/monitor/timeouts.test.ts
+++ b/tests/monitor/timeouts.test.ts
@@ -27,7 +27,6 @@ describe("fetch timeout", () => {
       });
     });
 
-    // Force a cache miss by not setting cachedModeAt recently
     const { getCachedMode } = await import("../../src/monitor/index.js");
     const modePromise = getCachedMode();
     // Advance past the 2000ms mode-check timeout
@@ -44,7 +43,6 @@ describe("mode cache under clock skew", () => {
     installMonitorFakeTimers();
     stub = createFetchStub();
     stub.install();
-    stub.on("/api/mode", () => new Response(JSON.stringify({ mode: "tandem" }), { status: 200 }));
     const mod = await import("../../src/monitor/index.js");
     mod._resetMonitorStateForTests();
   });
@@ -55,17 +53,36 @@ describe("mode cache under clock skew", () => {
   });
 
   it("backward Date.now() jump does not wedge the mode cache permanently", async () => {
+    // The /api/mode handler lives in the test body (not beforeEach) so we can
+    // flip its response mid-test and distinguish "cache wedged, no refetch"
+    // from "cache recovered via refetch" by the returned value.
+    let currentMode: "tandem" | "solo" = "tandem";
+    let modeCallCount = 0;
+    stub.on("/api/mode", () => {
+      modeCallCount++;
+      return new Response(JSON.stringify({ mode: currentMode }), { status: 200 });
+    });
+
     const mod = await import("../../src/monitor/index.js");
     expect(await mod.getCachedMode()).toBe("tandem");
+    expect(modeCallCount).toBe(1);
 
     const realNow = Date.now;
     vi.spyOn(Date, "now").mockImplementation(() => realNow() - 60 * 60 * 1000);
 
+    // Under backward skew, (now - cachedModeAt) is negative, so the TTL check
+    // treats the cache as still fresh and no refetch fires. Stuck but safe.
     await vi.advanceTimersByTimeAsync(5000);
-    expect(await mod.getCachedMode()).toBe("tandem"); // stuck-but-safe
+    expect(await mod.getCachedMode()).toBe("tandem");
+    expect(modeCallCount).toBe(1);
 
+    // Restore the clock and flip the server response. A working recovery path
+    // must re-fetch and observe the new value; a wedged cache returns stale
+    // "tandem" and fails the assertion.
     vi.restoreAllMocks();
+    currentMode = "solo";
     await vi.advanceTimersByTimeAsync(3000);
-    expect(await mod.getCachedMode()).toBe("tandem"); // recovers
+    expect(await mod.getCachedMode()).toBe("solo");
+    expect(modeCallCount).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Round 3 review fixes, part 3 of 5: **regression fences and behavioral tests** split out of PR #285.

10 commits — pure test additions plus one architecture.md note documenting a mode-default asymmetry the tests fence:

- `test(monitor)`: assert `Last-Event-ID` header on reconnect
- `test(monitor)`: regression fences for malformed `/api/mode` payloads
- `docs(architecture)`: document mode-default asymmetry + regression fence
- `test(monitor)`: stable-uptime resets retry delay to initial
- `test(monitor)`: fence timer cleanup on 503 handshake
- `test(monitor)`: replace retry count magic numbers with `CHANNEL_MAX_RETRIES`
- `test(monitor)`: intermittent `/api/mode` doesn't spam refreshes
- `test(monitor)`: fence clock-skew behavior of mode cache
- `test(monitor)`: assert stdout payload, not just that write occurred
- `test(monitor)`: behavioral shutdown skip instead of mock plumbing

## Split context

Part of the 5-PR split of PR #285 round 3. PR A (#288, merged) provided the bug fixes; this PR fences them with regression tests so future refactors trip on the seams.

`d4667e0` (behavioral shutdown skip) depends on `shutdownMonitor` (PR A's `3d9b794`) and exit-code semantics (PR A's `ab4ca3c`). Those are now on master, so this PR was branched off post-merge rather than stacked.

CHANGELOG omitted; lands as roll-up in PR E after A/B/C/D merge.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1118 passed + 2 skipped on Windows (78 → 79 test files)
- [ ] CI green
