### PR TITLE
refactor(monitor): round 3 hardening from PR #285 split

### DIFF
--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -531,10 +531,15 @@ function refreshMode(): void {
   // every hot-path event.
   if (now - cachedModeFailedAt < MODE_CACHE_TTL_MS) return;
 
-  // Fire-and-forget. The inner try/finally catches fetch errors, but we
-  // attach an outer .catch as a belt-and-suspenders guard against any future
-  // synchronous throw before the try escaping to the hot-path caller that
-  // cannot handle it.
+  // Fire-and-forget. fetchMode() converts network/parse errors into
+  // { ok: false }, and the inner try/finally clears `_modeRefreshInFlight` on
+  // both success and thrown rejection — so today, the outer .catch is
+  // unreachable. It exists as a belt-and-suspenders guard: a future refactor
+  // that introduces a throw above the try (or a caller-visible rejection path)
+  // would otherwise surface as a process-level `unhandledRejection`, because
+  // the hot-path caller does not await this promise. The outer handler also
+  // mirrors the inner {ok:false} rate-limit so a reachable-throw regression
+  // can't flood stderr on every hot-path event.
   _modeRefreshInFlight = (async () => {
     try {
       const result = await fetchMode();
@@ -553,7 +558,10 @@ function refreshMode(): void {
     }
   })().catch((err) => {
     console.error("[Monitor] refreshMode unexpected error:", err);
-    _modeRefreshInFlight = null;
+    cachedModeFailedAt = Date.now();
+    // Note: not re-setting `_modeRefreshInFlight = null` here — the inner
+    // `finally` already did, and re-nulling from this microtask can race
+    // with a new refreshMode() call that reclaimed the slot in between.
   });
 }
 

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -7,6 +7,15 @@
  *
  * Replaces the channel shim for event delivery without requiring
  * --dangerously-load-development-channels.
+ *
+ * **STDOUT IS RESERVED** (CLAUDE.md rule #3). The only writes to stdout are
+ * the formatted event notification inside `connectAndStream` and the
+ * exhaustion notice inside `main`. Everything else — including anything that
+ * would otherwise call `console.log/warn/info` — is redirected to stderr by
+ * the guard immediately below this comment. When adding a new dependency,
+ * grep its source for `process.stdout.write` and `console.log` before
+ * accepting; a stdout-writing dep bundled into this file would corrupt the
+ * plugin-host line protocol silently.
  */
 
 import { resolve as resolvePath } from "node:path";

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -140,6 +140,11 @@ export async function main(): Promise<void> {
       await new Promise((r) => setTimeout(r, delay));
     }
   }
+  // Defensive: if connectAndStream ever returns normally (it always throws today),
+  // the retry loop exits without an explicit exit code. Claude Code would see the
+  // plugin just stop. Fail loudly instead so the invariant is enforced.
+  console.error("[Monitor] Retry loop exited unexpectedly without exhaustion");
+  process.exit(1);
 }
 
 export async function connectAndStream(

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -517,6 +517,10 @@ function refreshMode(): void {
   // every hot-path event.
   if (now - cachedModeFailedAt < MODE_CACHE_TTL_MS) return;
 
+  // Fire-and-forget. The inner try/finally catches fetch errors, but we
+  // attach an outer .catch as a belt-and-suspenders guard against any future
+  // synchronous throw before the try escaping to the hot-path caller that
+  // cannot handle it.
   _modeRefreshInFlight = (async () => {
     try {
       const result = await fetchMode();
@@ -533,7 +537,10 @@ function refreshMode(): void {
     } finally {
       _modeRefreshInFlight = null;
     }
-  })();
+  })().catch((err) => {
+    console.error("[Monitor] refreshMode unexpected error:", err);
+    _modeRefreshInFlight = null;
+  });
 }
 
 /**

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -149,10 +149,18 @@ export async function main(): Promise<void> {
       await new Promise((r) => setTimeout(r, delay));
     }
   }
-  // Defensive: if connectAndStream ever returns normally (it always throws today),
-  // the retry loop exits without an explicit exit code. Claude Code would see the
-  // plugin just stop. Fail loudly instead so the invariant is enforced.
-  console.error("[Monitor] Retry loop exited unexpectedly without exhaustion");
+  // Defensive: under normal exhaustion, the catch block above calls
+  // process.exit(1) before control returns to the while-loop condition, so
+  // this branch is unreachable today. It exists as an invariant guard — if a
+  // future refactor removes that exit, makes it non-terminating (e.g. wraps
+  // it in a test shim), or lets retries increment past MAX without entering
+  // the exhaustion branch, the loop would fall through here. Fail loudly so
+  // "monitor exits 1 on exhaustion" survives refactoring. Include the
+  // retries counter because if this ever fires, that number is the single
+  // most useful debugging breadcrumb.
+  console.error(
+    `[Monitor] Retry loop exited unexpectedly (retries=${retries}/${CHANNEL_MAX_RETRIES})`,
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

Round 3 review fixes, part 4 of 5: **defensive hardening refactors** split out of PR #285.

3 commits — no behavior change for healthy paths, just belt-and-suspenders for unexpected states:

- `refactor(monitor)`: outer `.catch` on `refreshMode` fire-and-forget — async error from the periodic mode refresh no longer surfaces as an unhandled rejection on certain Node versions
- `refactor(monitor)`: defensive exit after retry loop exits without exhaustion — paranoia branch for the case where the retry loop somehow returns without either succeeding or hitting `CHANNEL_MAX_RETRIES`
- `docs(monitor)`: top-of-file warning that stdout is reserved for the Channels JSON wire — prevents future contributors from adding `console.log` and corrupting the MCP stdio fallback (CLAUDE.md gotcha #3)

## Split context

Part of the 5-PR split of PR #285 round 3. Last code-bearing PR — PR E will be the CHANGELOG roll-up. CHANGELOG omitted here per the split-strategy plan.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1108 passed + 2 skipped on Windows (no test changes; baseline holds)
- [ ] CI green
