### PR TITLE
docs(changelog): roll up PR #285 round 3 fixes into [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Settings heading renamed "Layout Settings" → "Settings"
 - Settings popover hardcoded hex values swapped to CSS tokens (remaining components will migrate in a follow-up)
+- `shutdownForTests` renamed to `shutdownMonitor` (test-only alias kept for backward compatibility)
+- `refreshMode` IIFE now wrapped in an outer `.catch` to keep future synchronous throws off the hot path
+
+### Fixed
+
+- **Monitor preserves last-known `documentId`** — doc-less events (e.g. `chat:message`) no longer blank out the tracked document, so the shutdown awareness clear always targets a valid document.
+- **Monitor exits 1 on shutdown awareness failure** — if the final `clearAwareness` POST fails during SIGINT/SIGTERM, the monitor exits with a non-zero status rather than silently succeeding.
+- **`/api/setup` returns accurate status codes** — 207 on partial failure (some targets configured, some failed) and 500 on total failure, instead of always returning 200.
+- **Checkpoint after stdout write** — `lastEventId` is only advanced after `process.stdout.write` returns, so EPIPE on a closed pipe no longer silently skips an event on reconnect.
+- **Defensive exit on monitor fallthrough** — the retry loop exits 1 if it ever terminates without hitting the explicit exhaustion path.
 
 ## [0.5.1] - 2026-04-13
 


### PR DESCRIPTION
## Summary

- Gathers the monitor + `/api/setup` fixes and refactors that landed across PRs #288, #289, #293, and #294 (PR #285's round-3 split) into user-facing bullets under `[Unreleased]`.
- Skips rewriting the released `[0.5.1] - 2026-04-13` section — the round-3 fixes post-date that release and will ship in the next version bump alongside the Settings expansion work already queued under `[Unreleased]`.
- Filters the source bullets from the original backup commit down to the user-visible set: drops internal test/regression fences and internal doc touch-ups.

## Test plan

- [x] `git diff master..HEAD` shows only CHANGELOG.md (+10 lines, -0)
- [x] Lint-staged (`normalize-eol.mjs`) ran clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)