### PR TITLE
release(0.6.0): Settings expansion + monitor EPIPE hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,14 @@ gha-creds-*.json
 skills-lock.json
 test-results/
 .pipeline-state/
+
+# Skill symlinks/junctions managed by Claude Code tooling point into .agents/
+# and break git-bash dir walks on Windows (MSYS2 opendir returns ENOSYS for
+# NTFS junctions, triggering "Function not implemented" warnings that then
+# corrupt lint-staged via tinyexec's merged stderr). Ignore the whole dir,
+# then allow-list the real tracked skills. New tracked skills need a new
+# allow-list line here.
+.claude/skills/*
+!.claude/skills/dev-server/
+!.claude/skills/e2e/
+!.claude/skills/screenshots/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-14
+
 ### Added
 
 - **Settings expansion** — Settings popover grows from layout/dwell/authorship into a fuller preferences surface:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Monitor exits 1 on shutdown awareness failure** — if the final `clearAwareness` POST fails during SIGINT/SIGTERM, the monitor exits with a non-zero status rather than silently succeeding.
 - **`/api/setup` returns accurate status codes** — 207 on partial failure (some targets configured, some failed) and 500 on total failure, instead of always returning 200.
 - **Checkpoint after stdout write** — `lastEventId` is only advanced after `process.stdout.write` returns, so EPIPE on a closed pipe no longer silently skips an event on reconnect.
+- **Async EPIPE surfaces as exit(1)** — `process.stdout.on('error')` listener now catches asynchronous EPIPE (plugin host closes pipe mid-stream); monitor exits 1 instead of silently advancing `lastEventId` past lost events.
 - **Defensive exit on monitor fallthrough** — the retry loop exits 1 if it ever terminates without hitting the explicit exhaustion path.
 
 ## [0.5.1] - 2026-04-13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Edit and iterate on documents with Claude — no copy-paste, real-time push via plugin monitor",
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-desktop"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "log",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-desktop"
-version = "0.5.1"
+version = "0.6.0"
 description = "Collaborative AI-human document editor"
 authors = ["Bryan Kolb"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "identifier": "com.tandem.editor",
   "build": {
     "frontendDist": "../dist/client",

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -350,12 +350,13 @@ export async function connectAndStream(
         // notification (each stdout line is delivered separately).
         const content = formatEventContent(event).replace(/\n/g, " ");
         // False-checkpoint guard: `onEventId(eventId)` MUST stay below the
-        // write. A synchronous EPIPE throw propagates out of the loop and the
-        // retry layer handles it; the ordering ensures lastEventId never
-        // advances past an event that didn't make it to stdout. Asynchronous
-        // EPIPE (plugin host closes mid-stream, write buffered but not
-        // flushed) is caught by the one-shot stdout 'error' listener
-        // installed in main() → process.exit(1).
+        // write so lastEventId never advances past an event that didn't
+        // make it to stdout. EPIPE on process.stdout is almost always
+        // async — Node emits 'error' after the close; see installStdoutErrorHandler,
+        // which calls process.exit(1) so the plugin host respawns us. A
+        // synchronous throw (rare) would propagate out of the loop and the
+        // retry layer would handle it; either way, the order below is what
+        // closes the silent-advance hole.
         process.stdout.write(content + "\n");
 
         if (eventId) onEventId(eventId);
@@ -474,20 +475,23 @@ function installShutdownHandlers(): void {
 }
 
 /**
- * `process.stdout.write` does NOT synchronously throw on EPIPE. Node emits
- * an 'error' event asynchronously when the downstream pipe (plugin host)
- * closes its read end mid-stream. Without this handler, writes after the
- * close are silently dropped and the retry loop keeps advancing
- * lastEventId past events that never arrived — the next reconnect's
- * Last-Event-ID header then skips the lost range. Exit 1 so the plugin
- * host can respawn us with a fresh stdout instead.
+ * Async EPIPE handler. `process.stdout.write` does NOT synchronously throw
+ * on EPIPE — Node emits an 'error' event asynchronously when the downstream
+ * pipe (plugin host) closes its read end mid-stream. Without this handler,
+ * writes after the close are silently dropped and the retry loop keeps
+ * advancing lastEventId past events that never arrived; the next reconnect's
+ * Last-Event-ID header then skips the lost range. Logging to stderr keeps a
+ * trail for support; exit 1 so the plugin host respawns us with a fresh
+ * stdout instead of wedging on a dead pipe.
  */
+function onStdoutError(err: Error): void {
+  console.error("[Monitor] stdout error (plugin-host pipe likely closed):", err);
+  process.exit(1);
+}
+
 function installStdoutErrorHandler(): void {
   if (IS_VITEST) return;
-  process.stdout.on("error", (err) => {
-    console.error("[Monitor] stdout error (plugin-host pipe likely closed):", err);
-    process.exit(1);
-  });
+  process.stdout.on("error", onStdoutError);
 }
 
 let cachedMode: TandemMode = TANDEM_MODE_DEFAULT;
@@ -612,6 +616,15 @@ export function _resetMonitorStateForTests(): void {
   process.removeAllListeners("SIGINT");
   process.removeAllListeners("SIGTERM");
 }
+
+/**
+ * Test-only exports. DO NOT import from production code.
+ * Grouped in a single namespace so production imports never accidentally
+ * pull handler internals.
+ */
+export const _monitorTestExports = {
+  onStdoutError,
+};
 
 // Auto-run when invoked directly (e.g. `node dist/monitor/index.js` or
 // `tsx src/monitor/index.ts`). Skipped under vitest so tests can import

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -78,6 +78,7 @@ function describeFetchError(err: unknown, endpoint: string, timeoutMs: number): 
 
 export async function main(): Promise<void> {
   installShutdownHandlers();
+  installStdoutErrorHandler();
   console.error(`[Monitor] Tandem monitor starting (server: ${TANDEM_URL})`);
 
   // Warm the mode cache before the first event so we don't default-suppress
@@ -348,14 +349,14 @@ export async function connectAndStream(
         // Collapse newlines so multi-line content stays as a single
         // notification (each stdout line is delivered separately).
         const content = formatEventContent(event).replace(/\n/g, " ");
-        try {
-          process.stdout.write(content + "\n");
-        } catch (err) {
-          // EPIPE on a closed plugin-host pipe — re-throw so main's retry loop
-          // can decide to exhaust and exit. Do NOT checkpoint lastEventId
-          // because the event wasn't delivered.
-          throw err;
-        }
+        // False-checkpoint guard: `onEventId(eventId)` MUST stay below the
+        // write. A synchronous EPIPE throw propagates out of the loop and the
+        // retry layer handles it; the ordering ensures lastEventId never
+        // advances past an event that didn't make it to stdout. Asynchronous
+        // EPIPE (plugin host closes mid-stream, write buffered but not
+        // flushed) is caught by the one-shot stdout 'error' listener
+        // installed in main() → process.exit(1).
+        process.stdout.write(content + "\n");
 
         if (eventId) onEventId(eventId);
         scheduleAwareness(event);
@@ -470,6 +471,23 @@ function installShutdownHandlers(): void {
   };
   process.on("SIGINT", () => handler("SIGINT"));
   process.on("SIGTERM", () => handler("SIGTERM"));
+}
+
+/**
+ * `process.stdout.write` does NOT synchronously throw on EPIPE. Node emits
+ * an 'error' event asynchronously when the downstream pipe (plugin host)
+ * closes its read end mid-stream. Without this handler, writes after the
+ * close are silently dropped and the retry loop keeps advancing
+ * lastEventId past events that never arrived — the next reconnect's
+ * Last-Event-ID header then skips the lost range. Exit 1 so the plugin
+ * host can respawn us with a fresh stdout instead.
+ */
+function installStdoutErrorHandler(): void {
+  if (IS_VITEST) return;
+  process.stdout.on("error", (err) => {
+    console.error("[Monitor] stdout error (plugin-host pipe likely closed):", err);
+    process.exit(1);
+  });
 }
 
 let cachedMode: TandemMode = TANDEM_MODE_DEFAULT;

--- a/tests/monitor/shutdown.test.ts
+++ b/tests/monitor/shutdown.test.ts
@@ -133,6 +133,7 @@ describe("graceful shutdown", () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`exit:${code ?? 0}`);
     }) as never);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     stub.on("/api/channel-awareness", () => new Response("boom", { status: 500 }));
 
@@ -141,6 +142,12 @@ describe("graceful shutdown", () => {
     mod._setLastDocumentIdForTests("doc-a");
 
     await expect(mod.shutdownMonitor("SIGINT")).rejects.toThrow("exit:1");
+    // A silent exit(1) is nearly as bad as exit(0) for support debugging —
+    // the reason must land on stderr before the process dies.
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Shutdown awareness clear returned 500"),
+    );
+    errorSpy.mockRestore();
     exitSpy.mockRestore();
   });
 

--- a/tests/monitor/sse-parsing.test.ts
+++ b/tests/monitor/sse-parsing.test.ts
@@ -194,6 +194,29 @@ describe("EPIPE on stdout.write", () => {
   });
 });
 
+describe("installStdoutErrorHandler (async EPIPE)", () => {
+  it("logs stderr and exits 1 when stdout emits 'error' (async EPIPE)", async () => {
+    // The PR's headline fix: process.stdout.write does NOT synchronously throw
+    // on EPIPE. Node emits an 'error' event asynchronously when the plugin-host
+    // read end closes mid-stream. Without a listener, writes keep advancing
+    // lastEventId past events that never arrived. This test fences that the
+    // handler (a) logs to stderr so support has a trail, and (b) exits 1 so
+    // the plugin host respawns us with a fresh stdout.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    const mod = await import("../../src/monitor/index.js");
+    const err = new Error("EPIPE");
+
+    mod._monitorTestExports.onStdoutError(err);
+
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("stdout error"), err);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+
 describe("SSE resume behavior", () => {
   let stub: ReturnType<typeof createFetchStub>;
   let stdoutSpy: ReturnType<typeof vi.spyOn>;

--- a/tests/monitor/sse-parsing.test.ts
+++ b/tests/monitor/sse-parsing.test.ts
@@ -143,6 +143,57 @@ describe("SSE buffer overflow", () => {
   });
 });
 
+describe("EPIPE on stdout.write", () => {
+  let stub: ReturnType<typeof createFetchStub>;
+  let stream: ControllableStream;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    installMonitorFakeTimers();
+    stub = createFetchStub();
+    stub.install();
+    stream = new ControllableStream();
+    stub.on("/api/events", () => sseResponse(stream));
+    stub.on("/api/mode", () => new Response(JSON.stringify({ mode: "tandem" }), { status: 200 }));
+    stub.on("/api/channel-awareness", () => new Response("", { status: 200 }));
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const mod = await import("../../src/monitor/index.js");
+    mod._resetMonitorStateForTests();
+  });
+  afterEach(() => {
+    stub.restore();
+    vi.useRealTimers();
+    stdoutSpy.mockRestore();
+  });
+
+  it("does NOT call onEventId when stdout.write throws (regression fence for #288)", async () => {
+    // Regression fence: if a future refactor moves `onEventId(eventId)` above
+    // the write or drops the order guarantee, lastEventId would advance past
+    // an event that never reached the plugin host — the server would have no
+    // way to replay it on reconnect.
+    stdoutSpy.mockImplementationOnce(() => {
+      throw new Error("EPIPE");
+    });
+    const onEventId = vi.fn();
+    const promise = connectAndStream(undefined, onEventId);
+
+    stream.push(
+      sseFrame(
+        {
+          id: "e1",
+          type: "chat:message",
+          timestamp: 1,
+          payload: { messageId: "m", text: "hi", replyTo: null, anchor: null },
+        },
+        "e1",
+      ),
+    );
+
+    await expect(promise).rejects.toThrow("EPIPE");
+    expect(onEventId).not.toHaveBeenCalledWith("e1");
+  });
+});
+
 describe("SSE resume behavior", () => {
   let stub: ReturnType<typeof createFetchStub>;
   let stdoutSpy: ReturnType<typeof vi.spyOn>;


### PR DESCRIPTION
## Summary

Cuts **v0.6.0**. Bundles the async-EPIPE hardening follow-ups from PR #288 review with the release version bump.

Minor bump because this release ships the full **Settings expansion** surface (Ctrl+, hotkey, Display Name, Reduce Motion, Text Size, Light/Dark/System theme) alongside accumulated monitor fixes.

### Changes in this PR

- **#290 (fix)** — `process.stdout.write` does NOT synchronously throw on EPIPE. When the plugin-host closes its read end mid-stream, Node emits `'error'` asynchronously; the previous try/catch never fired and writes silently advanced `lastEventId` past events that never arrived. Install a one-shot `process.stdout.on('error')` listener in `main()` that logs and exits 1. Drops the no-op `try { write } catch (err) { throw err }` (identical propagation to no try at all) and replaces its comment with one explaining that the real guarantee is the `onEventId`-after-write order.
- **#295 (test)** — Regression fence for the synchronous EPIPE case: a future refactor that moves `onEventId(eventId)` above the write would land silently today. Mocks `stdout.write` to throw once, asserts `onEventId` was NOT called and the stream promise rejected.
- **#291 (test)** — Spies `console.error` in the "exits 1 when final awareness clear POST fails" test and asserts it logs "Shutdown awareness clear returned 500" before the exit (silent `exit(1)` is nearly as bad as `exit(0)` for support debugging).
- **Release cut** — `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock` bumped 0.5.1 → 0.6.0; CHANGELOG `[Unreleased]` moved under `[0.6.0] - 2026-04-14`.

### Full release notes — see `CHANGELOG.md [0.6.0]`

Settings expansion, monitor awareness-preservation fixes, `/api/setup` status codes, checkpoint-after-write fix, defensive retry-loop exit, async EPIPE handler, plus test fences.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1120 pass, 2 skipped
- [x] `npx vitest run tests/monitor/` — 45 pass
- [x] CI green (including tauri-release-check matrix)
- [ ] After merge: tag `v0.6.0` on master, release workflow auto-builds installers

Closes #290
Closes #291
Closes #295
