### PR TITLE
chore(gitignore): ignore non-tracked .claude/skills/ junction links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,14 @@ gha-creds-*.json
 skills-lock.json
 test-results/
 .pipeline-state/
+
+# Skill symlinks/junctions managed by Claude Code tooling point into .agents/
+# and break git-bash dir walks on Windows (MSYS2 opendir returns ENOSYS for
+# NTFS junctions, triggering "Function not implemented" warnings that then
+# corrupt lint-staged via tinyexec's merged stderr). Ignore the whole dir,
+# then allow-list the real tracked skills. New tracked skills need a new
+# allow-list line here.
+.claude/skills/*
+!.claude/skills/dev-server/
+!.claude/skills/e2e/
+!.claude/skills/screenshots/


### PR DESCRIPTION
## Summary

Fixes a Windows-only `husky pre-commit` failure mode where every commit errors out with `error: pathspec 'ning: could not open directory...did not match any file(s) known to git`.

## Root cause

Claude Code tooling populates `.claude/skills/` with **NTFS directory junctions** (not symlinks) pointing into `.agents/skills/`. On Windows:

1. MSYS2's `opendir()` returns `ENOSYS` when it traverses a junction's reparse tag, so git emits `warning: could not open directory '.claude/skills/<name>/': Function not implemented` for each of the 13 junctions on every `git status`.
2. `tinyexec` (used by lint-staged) merges stderr into its async iterator. The warnings get parsed as `git diff --raw -z` records, split on spaces, and the garbage tokens end up as the `filename` field. That filename is then passed as a pathspec to a follow-up git invocation, producing the `"ning: could not open..."` error and failing the commit.

## Fix

Ignore `.claude/skills/*` wholesale and allow-list the three real tracked skill dirs (`dev-server`, `e2e`, `screenshots` — each has a `SKILL.md`). Gitignored paths are pruned *before* `opendir` runs, so git never walks the junctions and the whole warning class disappears.

## Verification

- `git ls-files .claude/skills/` unchanged: `dev-server/SKILL.md`, `e2e/SKILL.md`, `screenshots/SKILL.md` still tracked.
- With just this `.gitignore` rule (and my local `.git/info/exclude` workaround removed), `git status` emits zero warnings.
- `lint-staged` runs clean — this commit went through the normal hook pipeline.

## Maintenance note

New tracked skills need a new allow-list line in `.gitignore`. Low-frequency (3 additions over months), acceptable friction. Flagged in an inline comment.

## Test plan

- [x] `git status` clean on Windows
- [x] `git commit` through husky/lint-staged without errors
- [x] Tracked `SKILL.md` files still show up in `git ls-files`
- [ ] Linux/macOS CI unaffected (the glob just matches nothing where the junctions don't exist)
