### PR TITLE
fix(tauri): ship skills/ in bundle resources so sidecar server boots

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Edit and iterate on documents with Claude — no copy-paste, real-time push via plugin monitor",
   "author": {
     "name": "Tandem"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-15
+
+### Fixed
+
+- **Tauri desktop app fails to start** — `src/cli/skill-content.ts` reads `skills/tandem/SKILL.md` at module-init via `readFileSync`, and `src/server/mcp/api-routes.ts` transitively imports it, so the bundled sidecar server crashed on startup with `ENOENT: skills/tandem/SKILL.md`. The `skills/` directory was never declared in `src-tauri/tauri.conf.json` bundle resources (latent since the v0.5.1 refactor to read SKILL.md at runtime). Add `"../skills/": "skills/"` so the sidecar's relative path resolution matches the npm-install layout. npm-published 0.6.0 was unaffected because `skills/` ships in the npm tarball via `package.json` `files`.
+
 ## [0.6.0] - 2026-04-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Edit and iterate on documents with Claude — no copy-paste, real-time push via plugin monitor",
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-desktop"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "log",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-desktop"
-version = "0.6.0"
+version = "0.6.1"
 description = "Collaborative AI-human document editor"
 authors = ["Bryan Kolb"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.tandem.editor",
   "build": {
     "frontendDist": "../dist/client",
@@ -45,7 +45,8 @@
       "../dist/server/": "dist/server/",
       "../dist/channel/": "dist/channel/",
       "../dist/client/": "dist/client/",
-      "../sample/": "sample/"
+      "../sample/": "sample/",
+      "../skills/": "skills/"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary
- Bundles `skills/` into the Tauri installer so the sidecar server can find `skills/tandem/SKILL.md` at startup
- Bumps to **v0.6.1** across `package.json`, `.claude-plugin/plugin.json`, `src-tauri/Cargo.{toml,lock}`, and `src-tauri/tauri.conf.json`

## Root cause
Since v0.5.1 (`8587be7 refactor(setup): read SKILL.md at runtime, drop parity test`), `src/cli/skill-content.ts` reads `skills/tandem/SKILL.md` at module-init via `readFileSync`. `src/server/mcp/api-routes.ts` transitively imports `installSkill` → module-init fires on every server boot.

`tauri.conf.json` bundle resources never included `../skills/`, so the installed sidecar failed with:

```
Error: ENOENT: no such file or directory, open 'C:\Users\blokn\AppData\Local\tandem\skills\tandem\SKILL.md'
```

v0.5.1's Tauri bundle had the same latent bug, but v0.6.0 is the first time it bit a user because `8587be7` landed after v0.5.0 and no one booted the v0.5.1 Tauri installer end-to-end.

## Scope
- npm `tandem-editor@0.6.0` is **unaffected** — `skills/` ships in the tarball via `package.json` `files`, so the CLI / `mcp-stdio` proxy path works.
- This PR fixes Tauri only.

## Test plan
- [ ] CI green (`check` + CodeQL + Socket)
- [ ] Tauri build workflow produces installers on tag push
- [ ] Install v0.6.1 on Windows → app launches → server reachable at `http://localhost:3479/health`
- [ ] Cowork plugin stdio bridge probe still works (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)