### PR TITLE
fix(cli): surface -32000 for pending requests on stdio bridge failure (#336)

### DIFF
--- a/docs/plans/2026-04-17-pr346-review-fixes.md
+++ b/docs/plans/2026-04-17-pr346-review-fixes.md
@@ -1,0 +1,505 @@
+# PR #346 Review Fix Plan — Revision 2
+
+Status: final, ready for implementation
+Target branch: `fix/336-stdio-bridge-silent-failures` (PR #346)
+Base: master
+Author: Bryan (via Claude)
+Date: 2026-04-17
+
+## Revision notes (vs. R1)
+
+- Line numbers refreshed against `pr-346` HEAD (commit `d0fab3f`).
+- **A1 reframed.** `StdioServerTransport.send` never rejects on the current SDK — the catch arm is defensive. Per silent-failure-hunter, the cleanest fix is to call `shutdown(1, synth)` directly from the catch so there's no id-leak path if a future SDK *does* reject.
+- **B2 dropped.** `StreamableHTTPClientTransport.start()` doesn't perform HTTP I/O — it only creates an `AbortController`. The only way for it to throw is double-start, which our code never does. No test possible without mocking; the catch branch is defense-in-depth and gets a comment instead.
+- **A3 scope expanded.** `channel.ts` also needs updating — small change, same PR.
+- **B1 renamed + rescoped.** It's a "pendingIds cleared on success" test, not an A1 regression guard.
+- **New A10** — note drain parallelism in a source comment (C#2 from R1).
+- **A6 comment softened.** Don't claim "dead code"; say we haven't observed the SDK firing `onclose` independently.
+
+## Context
+
+PR #346 fixes silent-failure paths in `src/cli/mcp-stdio.ts` so plugin hosts (Cowork, Claude Code plugin-loader mode) receive JSON-RPC `-32000` errors instead of silent stdio close when the Tandem HTTP upstream is unavailable. Five specialized review agents found one HIGH silent-failure, two MEDIUM issues, multiple test gaps, comment hygiene items, and a latent race. Two plan-reviewers then critiqued this fix plan and surfaced SDK-level constraints that reshape A1 and B2.
+
+This plan addresses every actionable finding in the same PR. Section D explicitly lists items deliberately dropped.
+
+## Items (ordered by dependency)
+
+### A. Source fixes
+
+#### A1 [HIGH → HARDENED-DEFENSIVE] `http.onmessage` stdio-send failure must not leak pending ids
+
+**Source:** silent-failure-hunter H1 + plan-review discovery that `StdioServerTransport.send` never rejects today.
+
+**Current (`src/cli/mcp-stdio.ts:159-166`):**
+```ts
+http.onmessage = (msg: JSONRPCMessage) => {
+  const responseId = getResponseId(msg);
+  if (responseId !== undefined) pendingIds.delete(responseId);
+  stdio.send(msg).catch((err: unknown) => {
+    const detail = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[tandem mcp-stdio] stdio write failed: ${detail}\n`);
+  });
+};
+```
+
+**Why we're hardening:** if `stdio.send` ever rejects (future SDK change, EPIPE-on-drain, etc.), the current code deletes `pendingIds[responseId]` *before* the send, so `synthesizePending` cannot recover. And because `stdio.onclose` only fires from our own `stdio.close()` call, there is no trigger to even start shutdown. A leaking-then-silent scenario identical to the one the whole PR exists to prevent.
+
+**Fix:** delete only on successful send; on failure, trigger shutdown via `shutdown(1, {synth})` which drains `pendingIds` including this id. Include the id in the stderr diagnostic.
+
+```ts
+http.onmessage = (msg: JSONRPCMessage) => {
+  const responseId = getResponseId(msg);
+  stdio.send(msg).then(
+    () => {
+      if (responseId !== undefined) pendingIds.delete(responseId);
+    },
+    (err: unknown) => {
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[tandem mcp-stdio] stdio write failed for id ${responseId ?? "<notification>"}: ${detail}\n`,
+      );
+      // Leave responseId in pendingIds — shutdown's synthesizePending will
+      // retry via sendErrorResponse. If stdio is truly gone, that send also
+      // fails and we log twice. Safe delete-after-send narrows the pending
+      // window; it never widens for well-ordered responses.
+      void shutdown(1, {
+        message: "Tandem stdio write failed",
+        detail,
+      });
+    },
+  );
+};
+```
+
+**Test coverage:** see B1 (pendingIds cleared on success) which also exercises the rewritten delete-after-send ordering. The rejection-specific path is guarded by a comment + code structure; not separately tested because the SDK's `send` cannot reject today, and mocking-based tests here add more fragility than they remove.
+
+---
+
+#### A2 [IMPORTANT] Guard `forwardToUpstream` catch against double-synthesize (future-proofing)
+
+**Source:** code-reviewer latent-race finding; both plan-reviewers confirmed orderings sound.
+
+**Current (`src/cli/mcp-stdio.ts:108-115`):**
+```ts
+http.send(msg).catch((err: unknown) => {
+  const detail = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[tandem mcp-stdio] upstream send failed: ${detail}\n`);
+  if (requestId !== undefined) {
+    pendingIds.delete(requestId);
+    void sendErrorResponse(requestId, "Tandem HTTP upstream unreachable", detail);
+  }
+});
+```
+
+**Fix:** `Set.prototype.delete` returns `true` iff the element was present — atomic check-and-remove.
+
+```ts
+http.send(msg).catch((err: unknown) => {
+  const detail = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[tandem mcp-stdio] upstream send failed: ${detail}\n`);
+  // `delete` returns true iff the id was still pending — prevents double-
+  // synth if a future change ever allows synthesizePending to fire while
+  // http.send is still in flight. (Not a current bug; belt-and-suspenders.)
+  if (requestId !== undefined && pendingIds.delete(requestId)) {
+    void sendErrorResponse(requestId, "Tandem HTTP upstream unreachable", detail);
+  }
+});
+```
+
+No new test — future-proofing guard, not a bug fix.
+
+---
+
+#### A3 [MEDIUM] Distinguish "unreachable" from "unhealthy" in preflight probe — update both callers
+
+**Source:** silent-failure-hunter M1 + plan-reviewer C3 (update `channel.ts` too).
+
+**Change `src/cli/preflight.ts`:**
+
+```ts
+// Note: "unreachable" is a catch-all for any non-HTTP-status failure —
+// DNS, TLS, timeout, ECONNREFUSED, RST all land here. "unhealthy" is
+// strictly non-2xx responses from /health.
+export type PreflightProbe =
+  | { ok: true }
+  | { ok: false; url: string; reason: string; kind: "unreachable" | "unhealthy" };
+
+export async function probeTandemServer(opts: PreflightOptions = {}): Promise<PreflightProbe> {
+  const url = resolveTandemUrl(opts.url);
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(`${url}/health`, { signal: controller.signal });
+    if (!res.ok) {
+      return {
+        ok: false,
+        url,
+        reason: `health endpoint returned HTTP ${res.status}`,
+        kind: "unhealthy",
+      };
+    }
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      url,
+      reason: err instanceof Error ? err.message : String(err),
+      kind: "unreachable",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function ensureTandemServer(opts: PreflightOptions = {}): Promise<void> {
+  const probe = await probeTandemServer(opts);
+  if (!probe.ok) {
+    const guidance =
+      probe.kind === "unreachable"
+        ? "Start the Tauri app or run `tandem start` on the host, then retry."
+        : "The Tandem server is running but unhealthy — check the host logs.";
+    process.stderr.write(
+      `[tandem] Tandem server preflight failed at ${probe.url} (${probe.reason}).\n` +
+        `[tandem] ${guidance}\n`,
+    );
+    process.exit(1);
+  }
+}
+```
+
+**Change `src/cli/mcp-stdio.ts` caller (lines 194-211):** branch user-facing strings on `probe.kind`, route through `deferredShutdown` (introduced in A5).
+
+```ts
+const probe = await probeTandemServer({ url: baseUrl });
+if (!probe.ok) {
+  const guidance =
+    probe.kind === "unreachable"
+      ? "Start the Tauri app or run `tandem start` on the host, then retry."
+      : "The Tandem server is running but unhealthy — check the host logs.";
+  process.stderr.write(
+    `[tandem mcp-stdio] Tandem server preflight failed at ${probe.url} (${probe.reason}).\n` +
+      `[tandem mcp-stdio] ${guidance}\n`,
+  );
+  const synthMessage =
+    probe.kind === "unreachable"
+      ? "Tandem server not running. Start the Tauri app or run `tandem start`."
+      : "Tandem server unhealthy (check host logs).";
+  deferredShutdown({ message: synthMessage, detail: probe.reason });
+  return;
+}
+```
+
+`channel.ts` doesn't need a direct change — it uses `ensureTandemServer`, which now handles both cases internally.
+
+---
+
+#### A4 [MEDIUM] `shutdown` close-failures must not be silent
+
+**Source:** silent-failure-hunter M2.
+
+**Current (`src/cli/mcp-stdio.ts:145-146`):**
+```ts
+await http.close().catch(() => {});
+await stdio.close().catch(() => {});
+```
+
+**Fix:**
+```ts
+await http.close().catch((err: unknown) => {
+  const detail = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[tandem mcp-stdio] http.close failed: ${detail}\n`);
+});
+await stdio.close().catch((err: unknown) => {
+  const detail = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[tandem mcp-stdio] stdio.close failed: ${detail}\n`);
+});
+```
+
+---
+
+#### A5 [REFACTOR] Extract `deferredShutdown` helper
+
+**Source:** code-simplifier #3; prerequisite for A3's readable caller.
+
+Inside `runMcpStdio`, above `stdio.onmessage`:
+
+```ts
+function deferredShutdown(synth: { message: string; detail?: string }): void {
+  setTimeout(() => void shutdown(1, synth), PREFLIGHT_GRACE_MS);
+}
+```
+
+Replace both `setTimeout(() => void shutdown(1, {...}), PREFLIGHT_GRACE_MS)` blocks (preflight-fail + http.start-fail) with `deferredShutdown({...})`.
+
+---
+
+#### A6 [COMMENT] Soften `http.onclose` guard rationale
+
+**Source:** comment-analyzer #6 + plan-reviewer C1.
+
+**Current (`src/cli/mcp-stdio.ts:181-187`):**
+```ts
+http.onclose = () => {
+  if (shuttingDown) return;
+  void shutdown(1, {
+    message: "Tandem HTTP upstream closed unexpectedly",
+    detail: "upstream connection dropped mid-session",
+  });
+};
+```
+
+**Fix:** add a comment explaining both the `shuttingDown` guard (defends against synth-during-shutdown) AND the observed behavior (the current SDK only fires onclose from our own close()).
+
+```ts
+http.onclose = () => {
+  // We've observed the current @modelcontextprotocol/sdk (0.20.x) only
+  // firing onclose from inside its own close() method — i.e., as a
+  // consequence of *our* shutdown. The synth branch below is defensive
+  // for future SDK versions that may propagate socket-death as onclose.
+  // The `shuttingDown` guard prevents double-synth when shutdown() calls
+  // http.close() itself.
+  if (shuttingDown) return;
+  void shutdown(1, {
+    message: "Tandem HTTP upstream closed unexpectedly",
+    detail: "upstream connection dropped mid-session",
+  });
+};
+```
+
+---
+
+#### A7 [COMMENT] Soften hardcoded "2s" in `PREFLIGHT_GRACE_MS` docblock
+
+**Source:** comment-analyzer #2.
+
+**Current (`src/cli/mcp-stdio.ts:35-39`):** mentions "preflight's own 2s fetch timeout" (cross-file magic number coupling).
+
+**Fix:**
+```ts
+// After preflight or http.start() fails we wait ~1.5s for any already-in-
+// flight `initialize` from the plugin loader to land on stdin and receive
+// a -32000 reply before tear-down. Sizing covers stdin-read lag between
+// preflight resolution and first message arrival — independent of
+// preflight's own fetch timeout.
+const PREFLIGHT_GRACE_MS = 1500;
+```
+
+---
+
+#### A8 [COMMENT] Soften "typically writes `initialize`" claim
+
+**Source:** comment-analyzer #4.
+
+**Current (`src/cli/mcp-stdio.ts:200-203`)** — inside the preflight-fail branch, will be moved/rewritten by A3. After A3 lands, edit the remaining rationale on `deferredShutdown` OR add a module-level comment once (since both preflight-fail and http.start-fail paths benefit).
+
+**Fix** — add one comment next to `deferredShutdown`'s definition:
+
+```ts
+// Plugin hosts typically send `initialize` immediately after spawn (MCP
+// lifecycle §initialization). Deferring shutdown by PREFLIGHT_GRACE_MS
+// lets that request land during the preflight/start window and receive
+// a -32000 reply rather than a silent stdio close. stdio.onclose
+// short-circuits this if the loader closes stdin first.
+function deferredShutdown(synth: { message: string; detail?: string }): void {
+  setTimeout(() => void shutdown(1, synth), PREFLIGHT_GRACE_MS);
+}
+```
+
+---
+
+#### A9 [COMMENT] Trim WHAT-sentence at drain block
+
+**Source:** comment-analyzer #9.
+
+**Current (`src/cli/mcp-stdio.ts:228-230`):**
+```ts
+// Drain any requests that arrived while preflight + http.start() were
+// running. They were held to preserve forwarding semantics — now that
+// upstream is ready, push them through the normal path.
+const buffered = preReadyBuffer.splice(0);
+for (const msg of buffered) forwardToUpstream(msg);
+```
+
+**Fix:**
+```ts
+// Held to preserve forwarding semantics — push through the normal path
+// now that upstream is ready. Note: forwardToUpstream does not await the
+// http.send, so buffered requests POST in parallel. Plugin hosts wait
+// for `initialize` to resolve before sending follow-ups per MCP spec, so
+// the buffer is usually ≤1 entry; we don't enforce serial ordering here.
+const buffered = preReadyBuffer.splice(0);
+for (const msg of buffered) forwardToUpstream(msg);
+```
+
+---
+
+#### A10 [COMMENT] Document drain parallelism in source
+
+**Source:** plan-reviewer 2, item C#2.
+
+Covered by A9's expanded comment. No separate code change needed.
+
+---
+
+### B. Test fixes — `tests/cli/mcp-stdio.test.ts`
+
+#### B1 [NEW TEST] `pendingIds` is cleared on successful response
+
+**Source:** pr-test-analyzer gap #4 + plan-reviewer I1 (corrected framing).
+
+**Scope:** integration test proving that a successful round-trip does NOT leave its id in `pendingIds`. This exercises both the pre-existing `delete` logic AND the A1-reordered `.then(delete)` path.
+
+**Test:**
+1. Spawn mcp-stdio pointed at a fake server that answers `initialize` with `result`.
+2. Send request id=1, read success response, assert `error` is undefined.
+3. Send a SECOND request id=2; this time fake server holds the response.
+4. Destroy the held response (`held.destroy()`) so `forwardToUpstream.catch` fires for id=2.
+5. Read next stdout line: expect exactly ONE `-32000` with id=2. No second line for id=1.
+
+Success = id=1 was cleared from `pendingIds` after its response, so it was NOT eligible for synth.
+
+---
+
+#### B2 [DROPPED] `http.start()` failure path
+
+**Source:** pr-test-analyzer gap #1 + plan-reviewer C2.
+
+**Rationale for drop:** `StreamableHTTPClientTransport.start()` in the current SDK only creates an `AbortController` — no HTTP I/O. The only way for it to throw is double-start, which our code never triggers. Integration test is impossible; mock-based unit test would test the SDK's error propagation rather than our logic.
+
+**Mitigation:** leave A6-style defensive comment at the `try { await http.start() }` block (`mcp-stdio.ts:213-225`):
+
+```ts
+// The current @modelcontextprotocol/sdk's StreamableHTTPClientTransport.start()
+// only creates an AbortController and returns synchronously — this catch is
+// defensive for future SDK versions that may perform real I/O during start().
+try {
+  await http.start();
+} catch (err) {
+  // ...
+}
+```
+
+---
+
+#### B3 [NEW TEST] Notifications do not receive synth
+
+**Source:** pr-test-analyzer gap #5.
+
+**Test:**
+1. Spawn mcp-stdio with env pointing at a dead port (preflight fails fast).
+2. Immediately write a notification (`{jsonrpc: "2.0", method: "notifications/initialized"}` — no id) to stdin.
+3. Wait for child to exit with code 1.
+4. Assert: stdout is empty OR contains no JSON-RPC line with `error.code === -32000`.
+
+A regression that added notifications to `pendingIds` would produce a reply with `id: null`, breaking protocol.
+
+---
+
+#### B4 [NEW TEST] Multiple concurrent pending requests all receive synth
+
+**Source:** pr-test-analyzer gap #3.
+
+**Test:**
+1. Spawn mcp-stdio against a fake server that answers `/health` 200 and holds all `/mcp` POSTs.
+2. Poll for http-ready (first `/mcp` GET received OR `receivedPosts.length > 0` on an initial throwaway).
+3. Send three requests (ids 100, 101, 102).
+4. Destroy the server.
+5. Collect stdout lines until three `-32000` replies arrive, each with a distinct id in {100,101,102}.
+
+Proves `synthesizePending`'s `Promise.all` delivers for all entries.
+
+---
+
+#### B5 [FLAKINESS FIX] Poll for handshake in existing mid-session test
+
+**Source:** pr-test-analyzer #8.
+
+Existing `await new Promise(r => setTimeout(r, 600))` (`tests/cli/mcp-stdio.test.ts:372` area) replaced with polling on the fake server's `/mcp` GET counter or received-POST count. Cleaner and more cold-CI-robust.
+
+---
+
+#### B6 [HYGIENE] Tighten regex in mid-session test
+
+**Source:** code-reviewer Important-1 + plan-reviewer (test hygiene, not bug closure).
+
+The existing `/closed|unreachable/i` regex accepts either path. Per SDK investigation, the test currently hits `forwardToUpstream.catch` → message `"Tandem HTTP upstream unreachable"`. Tighten to `/unreachable/i`. If we want to add `onclose`-path coverage, that requires forcing the SDK to fire onclose from external socket death — which doesn't happen on the current SDK. Leave that path covered by the comment in A6.
+
+---
+
+#### B7 [HYGIENE] Trim third `#336` citation
+
+**Source:** comment-analyzer #10.
+
+Delete the `describe`-block preamble at the top of the error-synthesis suite in `tests/cli/mcp-stdio.test.ts` (lines 168-172 area). The test names already describe the behavior; the file-level source docblock is the canonical explanation.
+
+---
+
+### C. Additional comment cleanup
+
+#### C1 [COMMENT] Trim `preReadyBuffer` / `pendingIds` inline descriptions
+
+**Source:** comment-analyzer #7 (borderline).
+
+**Current (`src/cli/mcp-stdio.ts:64-70`):** redundant WHAT halves.
+
+**Fix (tighten to WHY-only):**
+```ts
+// On upstream failure we synthesize -32000 for every entry before exit.
+const pendingIds = new Set<string | number>();
+// Messages arriving before httpReady flips; either drained and forwarded
+// on success, or each request answered with -32000 on preflight/http-start
+// failure.
+const preReadyBuffer: JSONRPCMessage[] = [];
+```
+
+Small win; bundled here rather than as a separate item.
+
+---
+
+### D. Items explicitly NOT addressed (with rationale)
+
+1. **Shared preflight-failure-message formatter across mcp-stdio + channel (code-simplifier #6):** A3 already unifies the logic inside `ensureTandemServer` + branches in the mcp-stdio caller. Further extraction buys <5 LOC and adds an export.
+2. **Drain `await` ordering (code-reviewer suggestion):** parallel POSTs match the non-buffered hot path; changing only the drain path creates behavioral asymmetry. Documented via A9's expanded comment instead.
+3. **`readOneLine` listener-attach ergonomics (code-reviewer + pr-test-analyzer #7):** test-only, not currently hit. Defer.
+4. **`readOneLine` interval-vs-event refactor (code-simplifier #7):** equivalent complexity.
+5. **`getRequestId`/`getResponseId` merge (code-simplifier #4):** names carry their weight.
+6. **Port-1 portability (pr-test-analyzer #9):** currently reliable across platforms.
+7. **`stdio.onclose` abandoned-pendingIds logging:** deferred; stdio-close implies client no longer listens.
+
+---
+
+## Build order
+
+1. **A5** — extract `deferredShutdown` helper (prerequisite for A3's caller).
+2. **A3** — preflight discriminator + update both callers (`mcp-stdio.ts`, `ensureTandemServer`).
+3. **A1** — stdio-send failure hardening (delete-after-send + `shutdown` trigger).
+4. **A2** — double-synth guard (one-line).
+5. **A4** — close-failure logs.
+6. **A6–A9, C1** — comment updates (batch).
+7. **B1, B3, B4** — new tests.
+8. **B5, B6, B7** — flakiness fix + regex tighten + preamble trim.
+9. **typecheck + test** — expect +3 new integration tests, +1 unit cluster (getResponseId already added).
+10. **Commit** on top of `fix/336-stdio-bridge-silent-failures`.
+
+## Verification checklist
+
+- `npm run typecheck` — clean.
+- `npm test` — all pass; new test count matches; no new skips.
+- Expected test delta: existing 1219 + 3 new integration (B1, B3, B4) = **1222 passing, 3 skipped** post-change. (B5/B6 modify existing tests; B7 trims a comment.)
+- Manual smoke (not blocking): `node dist/cli/index.js mcp-stdio` against a down server; observe `-32000` on stdout.
+
+## Out of scope for this PR
+
+Per PR #346's own charter (deferred to v0.7.0):
+- Channel-shim tests (issue #336 item).
+- Windows `npx` smoke test.
+- The 5 nits in #336.
+
+## Estimated diff size
+
+Source: ~50 lines added, ~35 lines modified.
+Tests: ~180 lines added.
+PR growth: +~230 lines on top of the current +445/-72.

--- a/src/cli/mcp-stdio.ts
+++ b/src/cli/mcp-stdio.ts
@@ -35,8 +35,8 @@ redirectConsoleToStderr();
 // After preflight or http.start() fails we wait ~1.5s for any already-in-
 // flight `initialize` from the plugin loader to land on stdin and receive
 // a -32000 reply before tear-down. Sizing covers stdin-read lag between
-// preflight resolution and the first message arrival; unrelated to
-// preflight's own 2s fetch timeout.
+// preflight resolution and first message arrival — independent of
+// preflight's own fetch timeout.
 const PREFLIGHT_GRACE_MS = 1500;
 
 // Last-gasp handlers for truly unexpected crashes: write one diagnostic to
@@ -61,12 +61,11 @@ export async function runMcpStdio(): Promise<void> {
   const http = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`));
   const stdio = new StdioServerTransport();
 
-  // Requests forwarded to upstream but not yet responded to. On upstream
-  // failure we synthesize -32000 for every entry before exit.
+  // On upstream failure we synthesize -32000 for every entry before exit.
   const pendingIds = new Set<string | number>();
-  // Messages received from stdin before `httpReady` flips. On success they
-  // are drained and forwarded; on preflight/http-start failure each request
-  // in the buffer gets a -32000 reply.
+  // Messages arriving before httpReady flips; either drained and forwarded
+  // on success, or each request answered with -32000 on preflight/http-start
+  // failure.
   const preReadyBuffer: JSONRPCMessage[] = [];
   let shuttingDown = false;
   let httpReady = false;
@@ -108,8 +107,10 @@ export async function runMcpStdio(): Promise<void> {
     http.send(msg).catch((err: unknown) => {
       const detail = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[tandem mcp-stdio] upstream send failed: ${detail}\n`);
-      if (requestId !== undefined) {
-        pendingIds.delete(requestId);
+      // `delete` returns true iff the id was still pending — prevents double-
+      // synth if a future change ever allows synthesizePending to fire while
+      // http.send is still in flight. (Not a current bug; belt-and-suspenders.)
+      if (requestId !== undefined && pendingIds.delete(requestId)) {
         void sendErrorResponse(requestId, "Tandem HTTP upstream unreachable", detail);
       }
     });
@@ -142,11 +143,26 @@ export async function runMcpStdio(): Promise<void> {
         await synthesizeBuffered(synth.message, synth.detail);
         await synthesizePending(synth.message, synth.detail);
       }
-      await http.close().catch(() => {});
-      await stdio.close().catch(() => {});
+      await http.close().catch((err: unknown) => {
+        const detail = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[tandem mcp-stdio] http.close failed: ${detail}\n`);
+      });
+      await stdio.close().catch((err: unknown) => {
+        const detail = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[tandem mcp-stdio] stdio.close failed: ${detail}\n`);
+      });
     }
     process.exit(code);
   };
+
+  // Plugin hosts typically send `initialize` immediately after spawn (MCP
+  // lifecycle §initialization). Deferring shutdown by PREFLIGHT_GRACE_MS
+  // lets that request land during the preflight/start window and receive
+  // a -32000 reply rather than a silent stdio close. stdio.onclose
+  // short-circuits this if the loader closes stdin first.
+  function deferredShutdown(synth: { message: string; detail?: string }): void {
+    setTimeout(() => void shutdown(1, synth), PREFLIGHT_GRACE_MS);
+  }
 
   stdio.onmessage = (msg: JSONRPCMessage) => {
     if (!httpReady) {
@@ -158,11 +174,25 @@ export async function runMcpStdio(): Promise<void> {
 
   http.onmessage = (msg: JSONRPCMessage) => {
     const responseId = getResponseId(msg);
-    if (responseId !== undefined) pendingIds.delete(responseId);
-    stdio.send(msg).catch((err: unknown) => {
-      const detail = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[tandem mcp-stdio] stdio write failed: ${detail}\n`);
-    });
+    stdio.send(msg).then(
+      () => {
+        if (responseId !== undefined) pendingIds.delete(responseId);
+      },
+      (err: unknown) => {
+        const detail = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[tandem mcp-stdio] stdio write failed for id ${responseId ?? "<notification>"}: ${detail}\n`,
+        );
+        // Leave responseId in pendingIds — shutdown's synthesizePending will
+        // retry via sendErrorResponse. If stdio is truly gone, that send also
+        // fails and we log twice. Safe delete-after-send narrows the pending
+        // window; it never widens for well-ordered responses.
+        void shutdown(1, {
+          message: "Tandem stdio write failed",
+          detail,
+        });
+      },
+    );
   };
 
   stdio.onerror = (err) => {
@@ -179,6 +209,12 @@ export async function runMcpStdio(): Promise<void> {
     void shutdown(0);
   };
   http.onclose = () => {
+    // We've observed the current @modelcontextprotocol/sdk (0.20.x) only
+    // firing onclose from inside its own close() method — i.e., as a
+    // consequence of *our* shutdown. The synth branch below is defensive
+    // for future SDK versions that may propagate socket-death as onclose.
+    // The `shuttingDown` guard prevents double-synth when shutdown() calls
+    // http.close() itself.
     if (shuttingDown) return;
     void shutdown(1, {
       message: "Tandem HTTP upstream closed unexpectedly",
@@ -193,41 +229,40 @@ export async function runMcpStdio(): Promise<void> {
 
   const probe = await probeTandemServer({ url: baseUrl });
   if (!probe.ok) {
+    const guidance =
+      probe.kind === "unreachable"
+        ? "Start the Tauri app or run `tandem start` on the host, then retry."
+        : "The Tandem server is running but unhealthy — check the host logs.";
     process.stderr.write(
-      `[tandem mcp-stdio] Tandem server not reachable at ${probe.url} (${probe.reason}).\n` +
-        `[tandem mcp-stdio] Start the Tauri app or run \`tandem start\` on the host, then retry.\n`,
+      `[tandem mcp-stdio] Tandem server preflight failed at ${probe.url} (${probe.reason}).\n` +
+        `[tandem mcp-stdio] ${guidance}\n`,
     );
-    // Stay listen-only briefly so any already-buffered request (the plugin
-    // loader typically writes `initialize` the moment after spawn) gets a
-    // -32000 reply before we tear down. stdio.onclose short-circuits if
-    // the loader closes stdin first.
-    setTimeout(() => {
-      void shutdown(1, {
-        message: "Tandem server not running. Start the Tauri app or run `tandem start`.",
-        detail: probe.reason,
-      });
-    }, PREFLIGHT_GRACE_MS);
+    const synthMessage =
+      probe.kind === "unreachable"
+        ? "Tandem server not running. Start the Tauri app or run `tandem start`."
+        : "Tandem server unhealthy (check host logs).";
+    deferredShutdown({ message: synthMessage, detail: probe.reason });
     return;
   }
 
+  // The current @modelcontextprotocol/sdk's StreamableHTTPClientTransport.start()
+  // only creates an AbortController and returns synchronously — this catch is
+  // defensive for future SDK versions that may perform real I/O during start().
   try {
     await http.start();
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     process.stderr.write(`[tandem mcp-stdio] upstream http start failed: ${detail}\n`);
-    setTimeout(() => {
-      void shutdown(1, {
-        message: "Tandem HTTP upstream failed to start",
-        detail,
-      });
-    }, PREFLIGHT_GRACE_MS);
+    deferredShutdown({ message: "Tandem HTTP upstream failed to start", detail });
     return;
   }
   httpReady = true;
 
-  // Drain any requests that arrived while preflight + http.start() were
-  // running. They were held to preserve forwarding semantics — now that
-  // upstream is ready, push them through the normal path.
+  // Held to preserve forwarding semantics — push through the normal path
+  // now that upstream is ready. Note: forwardToUpstream does not await the
+  // http.send, so buffered requests POST in parallel. Plugin hosts wait
+  // for `initialize` to resolve before sending follow-ups per MCP spec, so
+  // the buffer is usually ≤1 entry; we don't enforce serial ordering here.
   const buffered = preReadyBuffer.splice(0);
   for (const msg of buffered) forwardToUpstream(msg);
 }

--- a/src/cli/mcp-stdio.ts
+++ b/src/cli/mcp-stdio.ts
@@ -32,22 +32,17 @@ import { probeTandemServer } from "./preflight.js";
 
 redirectConsoleToStderr();
 
-// Grace window after preflight or http.start() failure before the process
-// exits. Covers the case where the plugin loader has already written its
-// `initialize` to our stdin before we've had a chance to run preflight —
-// stdio.onmessage buffers the message and synthesizes a -32000 reply, then
-// we tear down. Derived from `probeTandemServer`'s DEFAULT_TIMEOUT_MS
-// (2000ms) so that lowering the preflight timeout doesn't strand buffered
-// requests; a stdin read lag of ~500ms suffices on top.
+// After preflight or http.start() fails we wait ~1.5s for any already-in-
+// flight `initialize` from the plugin loader to land on stdin and receive
+// a -32000 reply before tear-down. Sizing covers stdin-read lag between
+// preflight resolution and the first message arrival; unrelated to
+// preflight's own 2s fetch timeout.
 const PREFLIGHT_GRACE_MS = 1500;
 
-// Last-gasp handlers for a crash anywhere in the bridge: even if we can't
-// reach the message-level catch, write one diagnostic to stderr before
-// process death. Installed at module load so a repeat invocation never
-// stacks duplicates. No in-flight request synthesis here — the handlers
-// run outside runMcpStdio()'s closure and don't know about pendingIds.
-// (In practice, runMcpStdio()'s own error paths cover every expected
-// failure mode; these guard against truly unexpected crashes.)
+// Last-gasp handlers for truly unexpected crashes: write one diagnostic to
+// stderr before exit. Installed at module load; process.once bounds each
+// handler to a single fire. No -32000 synthesis here because pendingIds
+// lives inside runMcpStdio()'s closure.
 process.once("uncaughtException", (err: Error) => {
   process.stderr.write(
     `[tandem mcp-stdio] uncaughtException: ${err.message}\n${err.stack ?? ""}\n`,
@@ -95,8 +90,15 @@ export async function runMcpStdio(): Promise<void> {
     };
     try {
       await stdio.send(errorResponse);
-    } catch {
-      // stdio already torn down; nothing more we can do.
+    } catch (err) {
+      // stdio already torn down; log so synth failures during shutdown
+      // (e.g., http.onclose racing stdio.onclose) aren't silently dropped —
+      // a silent drop here would recreate exactly the failure mode this
+      // module exists to prevent.
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[tandem mcp-stdio] failed to send synthesized error for id ${id}: ${detail}\n`,
+      );
     }
   }
 
@@ -164,10 +166,13 @@ export async function runMcpStdio(): Promise<void> {
   };
 
   stdio.onerror = (err) => {
-    process.stderr.write(`[tandem mcp-stdio] stdio error: ${err.message}\n`);
+    process.stderr.write(`[tandem mcp-stdio] stdio error: ${err.message}\n${err.stack ?? ""}\n`);
   };
   http.onerror = (err) => {
-    process.stderr.write(`[tandem mcp-stdio] http error: ${err.message}\n`);
+    const cause = (err as { cause?: unknown }).cause;
+    process.stderr.write(
+      `[tandem mcp-stdio] http error: ${err.message}\n${err.stack ?? ""}${cause !== undefined ? `\ncause: ${cause}` : ""}\n`,
+    );
   };
 
   stdio.onclose = () => {

--- a/src/cli/mcp-stdio.ts
+++ b/src/cli/mcp-stdio.ts
@@ -10,32 +10,136 @@
  * Any message the upstream emits (tool results, notifications, future
  * methods we haven't heard of) reaches the stdio client unchanged.
  *
+ * Error surfacing (issue #336): the stdio transport is started before
+ * preflight and http.start(), and early messages are buffered until the
+ * upstream is ready. If the upstream never becomes ready — or dies mid-
+ * session — every in-flight request ID is answered with a synthesized
+ * `-32000` JSON-RPC error instead of a silent stdio close. Plugin hosts
+ * surface `-32000` as actionable; a silent close is what produces "tools
+ * never appear in Cowork" with nothing diagnosable in the logs.
+ *
  * Intentional: no reconnection logic. If the upstream HTTP server dies
- * mid-session, `http.onclose` fires and we exit(0). The plugin loader will
- * respawn us on the next tool call and the preflight will re-run with a
- * fresh, accurate error if the server is still down. A reconnect loop here
- * would hide server death from the user.
+ * mid-session, we synthesize errors for pending requests and exit 1.
+ * The plugin loader will respawn us on the next tool call and preflight
+ * will re-run with a fresh, accurate error if the server is still down.
  */
 
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { redirectConsoleToStderr, resolveTandemUrl } from "../shared/cli-runtime.js";
-import { ensureTandemServer } from "./preflight.js";
+import { probeTandemServer } from "./preflight.js";
 
 redirectConsoleToStderr();
 
+// Grace window after preflight or http.start() failure before the process
+// exits. Covers the case where the plugin loader has already written its
+// `initialize` to our stdin before we've had a chance to run preflight —
+// stdio.onmessage buffers the message and synthesizes a -32000 reply, then
+// we tear down. Derived from `probeTandemServer`'s DEFAULT_TIMEOUT_MS
+// (2000ms) so that lowering the preflight timeout doesn't strand buffered
+// requests; a stdin read lag of ~500ms suffices on top.
+const PREFLIGHT_GRACE_MS = 1500;
+
+// Last-gasp handlers for a crash anywhere in the bridge: even if we can't
+// reach the message-level catch, write one diagnostic to stderr before
+// process death. Installed at module load so a repeat invocation never
+// stacks duplicates. No in-flight request synthesis here — the handlers
+// run outside runMcpStdio()'s closure and don't know about pendingIds.
+// (In practice, runMcpStdio()'s own error paths cover every expected
+// failure mode; these guard against truly unexpected crashes.)
+process.once("uncaughtException", (err: Error) => {
+  process.stderr.write(
+    `[tandem mcp-stdio] uncaughtException: ${err.message}\n${err.stack ?? ""}\n`,
+  );
+  process.exit(1);
+});
+process.once("unhandledRejection", (reason: unknown) => {
+  const detail = reason instanceof Error ? reason.message : String(reason);
+  process.stderr.write(`[tandem mcp-stdio] unhandledRejection: ${detail}\n`);
+  process.exit(1);
+});
+
 export async function runMcpStdio(): Promise<void> {
   const baseUrl = resolveTandemUrl();
-  await ensureTandemServer({ url: baseUrl });
 
   const http = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`));
   const stdio = new StdioServerTransport();
 
+  // Requests forwarded to upstream but not yet responded to. On upstream
+  // failure we synthesize -32000 for every entry before exit.
+  const pendingIds = new Set<string | number>();
+  // Messages received from stdin before `httpReady` flips. On success they
+  // are drained and forwarded; on preflight/http-start failure each request
+  // in the buffer gets a -32000 reply.
+  const preReadyBuffer: JSONRPCMessage[] = [];
   let shuttingDown = false;
-  const shutdown = async (code = 0): Promise<never> => {
+  let httpReady = false;
+
+  async function sendErrorResponse(
+    id: string | number,
+    message: string,
+    detail?: string,
+  ): Promise<void> {
+    const errorResponse: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      id,
+      error: {
+        // -32000 is the implementation-defined server error range per
+        // JSON-RPC 2.0 §5.1 — upstream unavailability is an application-
+        // level condition, not a generic Internal Error.
+        code: -32000,
+        message,
+        ...(detail !== undefined ? { data: { detail } } : {}),
+      },
+    };
+    try {
+      await stdio.send(errorResponse);
+    } catch {
+      // stdio already torn down; nothing more we can do.
+    }
+  }
+
+  function forwardToUpstream(msg: JSONRPCMessage): void {
+    const requestId = getRequestId(msg);
+    if (requestId !== undefined) pendingIds.add(requestId);
+    http.send(msg).catch((err: unknown) => {
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[tandem mcp-stdio] upstream send failed: ${detail}\n`);
+      if (requestId !== undefined) {
+        pendingIds.delete(requestId);
+        void sendErrorResponse(requestId, "Tandem HTTP upstream unreachable", detail);
+      }
+    });
+  }
+
+  async function synthesizeBuffered(message: string, detail?: string): Promise<void> {
+    const buffered = preReadyBuffer.splice(0);
+    const ids = buffered
+      .map((msg) => getRequestId(msg))
+      .filter((id): id is string | number => id !== undefined);
+    for (const id of ids) {
+      await sendErrorResponse(id, message, detail);
+    }
+  }
+
+  async function synthesizePending(message: string, detail?: string): Promise<void> {
+    if (pendingIds.size === 0) return;
+    const ids = [...pendingIds];
+    pendingIds.clear();
+    await Promise.all(ids.map((id) => sendErrorResponse(id, message, detail)));
+  }
+
+  const shutdown = async (
+    code = 0,
+    synth?: { message: string; detail?: string },
+  ): Promise<never> => {
     if (!shuttingDown) {
       shuttingDown = true;
+      if (synth) {
+        await synthesizeBuffered(synth.message, synth.detail);
+        await synthesizePending(synth.message, synth.detail);
+      }
       await http.close().catch(() => {});
       await stdio.close().catch(() => {});
     }
@@ -43,29 +147,16 @@ export async function runMcpStdio(): Promise<void> {
   };
 
   stdio.onmessage = (msg: JSONRPCMessage) => {
-    http.send(msg).catch((err: unknown) => {
-      const detail = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[tandem mcp-stdio] upstream send failed: ${detail}\n`);
-      const requestId = getRequestId(msg);
-      if (requestId !== undefined) {
-        const errorResponse: JSONRPCMessage = {
-          jsonrpc: "2.0",
-          id: requestId,
-          error: {
-            // -32000 is the implementation-defined server error range per
-            // JSON-RPC 2.0 §5.1 — the upstream being unreachable is an
-            // application-level condition, not a generic Internal Error.
-            code: -32000,
-            message: "Tandem HTTP upstream unreachable",
-            data: { detail },
-          },
-        };
-        stdio.send(errorResponse).catch(() => {});
-      }
-    });
+    if (!httpReady) {
+      preReadyBuffer.push(msg);
+      return;
+    }
+    forwardToUpstream(msg);
   };
 
   http.onmessage = (msg: JSONRPCMessage) => {
+    const responseId = getResponseId(msg);
+    if (responseId !== undefined) pendingIds.delete(responseId);
     stdio.send(msg).catch((err: unknown) => {
       const detail = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[tandem mcp-stdio] stdio write failed: ${detail}\n`);
@@ -83,24 +174,69 @@ export async function runMcpStdio(): Promise<void> {
     void shutdown(0);
   };
   http.onclose = () => {
-    void shutdown(0);
+    if (shuttingDown) return;
+    void shutdown(1, {
+      message: "Tandem HTTP upstream closed unexpectedly",
+      detail: "upstream connection dropped mid-session",
+    });
   };
 
-  // stdio first: if http.start() throws in the window between preflight and
-  // here, the stderr log still reaches the upstream instead of dying silent.
+  // Start stdio BEFORE preflight so any `initialize` that arrives during
+  // the preflight window is captured and either forwarded once upstream is
+  // ready, or answered with -32000 if upstream never comes up.
   await stdio.start();
+
+  const probe = await probeTandemServer({ url: baseUrl });
+  if (!probe.ok) {
+    process.stderr.write(
+      `[tandem mcp-stdio] Tandem server not reachable at ${probe.url} (${probe.reason}).\n` +
+        `[tandem mcp-stdio] Start the Tauri app or run \`tandem start\` on the host, then retry.\n`,
+    );
+    // Stay listen-only briefly so any already-buffered request (the plugin
+    // loader typically writes `initialize` the moment after spawn) gets a
+    // -32000 reply before we tear down. stdio.onclose short-circuits if
+    // the loader closes stdin first.
+    setTimeout(() => {
+      void shutdown(1, {
+        message: "Tandem server not running. Start the Tauri app or run `tandem start`.",
+        detail: probe.reason,
+      });
+    }, PREFLIGHT_GRACE_MS);
+    return;
+  }
+
   try {
     await http.start();
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     process.stderr.write(`[tandem mcp-stdio] upstream http start failed: ${detail}\n`);
-    await shutdown(1);
+    setTimeout(() => {
+      void shutdown(1, {
+        message: "Tandem HTTP upstream failed to start",
+        detail,
+      });
+    }, PREFLIGHT_GRACE_MS);
+    return;
   }
+  httpReady = true;
+
+  // Drain any requests that arrived while preflight + http.start() were
+  // running. They were held to preserve forwarding semantics — now that
+  // upstream is ready, push them through the normal path.
+  const buffered = preReadyBuffer.splice(0);
+  for (const msg of buffered) forwardToUpstream(msg);
 }
 
 export function getRequestId(msg: JSONRPCMessage): string | number | undefined {
   const m = msg as { id?: unknown; method?: unknown };
   if (typeof m.method !== "string") return undefined;
+  if (typeof m.id === "string" || typeof m.id === "number") return m.id;
+  return undefined;
+}
+
+export function getResponseId(msg: JSONRPCMessage): string | number | undefined {
+  const m = msg as { id?: unknown; method?: unknown };
+  if (typeof m.method === "string") return undefined;
   if (typeof m.id === "string" || typeof m.id === "number") return m.id;
   return undefined;
 }

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -22,7 +22,12 @@ export interface PreflightOptions {
   timeoutMs?: number;
 }
 
-export type PreflightProbe = { ok: true } | { ok: false; url: string; reason: string };
+// Note: "unreachable" is a catch-all for any non-HTTP-status failure —
+// DNS, TLS, timeout, ECONNREFUSED, RST all land here. "unhealthy" is
+// strictly non-2xx responses from /health.
+export type PreflightProbe =
+  | { ok: true }
+  | { ok: false; url: string; reason: string; kind: "unreachable" | "unhealthy" };
 
 export async function probeTandemServer(opts: PreflightOptions = {}): Promise<PreflightProbe> {
   const url = resolveTandemUrl(opts.url);
@@ -34,11 +39,21 @@ export async function probeTandemServer(opts: PreflightOptions = {}): Promise<Pr
   try {
     const res = await fetch(`${url}/health`, { signal: controller.signal });
     if (!res.ok) {
-      return { ok: false, url, reason: `health endpoint returned HTTP ${res.status}` };
+      return {
+        ok: false,
+        url,
+        reason: `health endpoint returned HTTP ${res.status}`,
+        kind: "unhealthy",
+      };
     }
     return { ok: true };
   } catch (err) {
-    return { ok: false, url, reason: err instanceof Error ? err.message : String(err) };
+    return {
+      ok: false,
+      url,
+      reason: err instanceof Error ? err.message : String(err),
+      kind: "unreachable",
+    };
   } finally {
     clearTimeout(timer);
   }
@@ -47,9 +62,13 @@ export async function probeTandemServer(opts: PreflightOptions = {}): Promise<Pr
 export async function ensureTandemServer(opts: PreflightOptions = {}): Promise<void> {
   const probe = await probeTandemServer(opts);
   if (!probe.ok) {
+    const guidance =
+      probe.kind === "unreachable"
+        ? "Start the Tauri app or run `tandem start` on the host, then retry."
+        : "The Tandem server is running but unhealthy — check the host logs.";
     process.stderr.write(
-      `[tandem] Tandem server not reachable at ${probe.url} (${probe.reason}).\n` +
-        `[tandem] Start the Tauri app or run \`tandem start\` on the host, then retry.\n`,
+      `[tandem] Tandem server preflight failed at ${probe.url} (${probe.reason}).\n` +
+        `[tandem] ${guidance}\n`,
     );
     process.exit(1);
   }

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -2,9 +2,15 @@
  * Shared preflight check for stdio MCP subcommands.
  *
  * Both `tandem mcp-stdio` and `tandem channel` need a live Tandem server on
- * localhost before they can do anything useful. If the server isn't running,
- * fail fast with a single clear error on stderr and exit 1 — otherwise
- * repeated handshake failures surface as reconnect-loop noise.
+ * localhost before they can do anything useful. Two flavors:
+ *
+ * - `ensureTandemServer` — fail fast via stderr + exit(1) when the server
+ *   isn't reachable. Used by `tandem channel`, whose stdio transport can't
+ *   meaningfully respond on its own.
+ * - `probeTandemServer` — returns a result without side effects. Used by
+ *   `tandem mcp-stdio`, which starts its stdio transport before preflight
+ *   so it can synthesize -32000 JSON-RPC errors for any in-flight request
+ *   before exiting (issue #336).
  */
 
 import { resolveTandemUrl } from "../shared/cli-runtime.js";
@@ -16,7 +22,9 @@ export interface PreflightOptions {
   timeoutMs?: number;
 }
 
-export async function ensureTandemServer(opts: PreflightOptions = {}): Promise<void> {
+export type PreflightProbe = { ok: true } | { ok: false; url: string; reason: string };
+
+export async function probeTandemServer(opts: PreflightOptions = {}): Promise<PreflightProbe> {
   const url = resolveTandemUrl(opts.url);
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
@@ -26,20 +34,23 @@ export async function ensureTandemServer(opts: PreflightOptions = {}): Promise<v
   try {
     const res = await fetch(`${url}/health`, { signal: controller.signal });
     if (!res.ok) {
-      fail(url, `health endpoint returned HTTP ${res.status}`);
+      return { ok: false, url, reason: `health endpoint returned HTTP ${res.status}` };
     }
+    return { ok: true };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    fail(url, msg);
+    return { ok: false, url, reason: err instanceof Error ? err.message : String(err) };
   } finally {
     clearTimeout(timer);
   }
 }
 
-function fail(url: string, detail: string): never {
-  process.stderr.write(
-    `[tandem] Tandem server not reachable at ${url} (${detail}).\n` +
-      `[tandem] Start the Tauri app or run \`tandem start\` on the host, then retry.\n`,
-  );
-  process.exit(1);
+export async function ensureTandemServer(opts: PreflightOptions = {}): Promise<void> {
+  const probe = await probeTandemServer(opts);
+  if (!probe.ok) {
+    process.stderr.write(
+      `[tandem] Tandem server not reachable at ${probe.url} (${probe.reason}).\n` +
+        `[tandem] Start the Tauri app or run \`tandem start\` on the host, then retry.\n`,
+    );
+    process.exit(1);
+  }
 }

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -2,7 +2,38 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getRequestId } from "../../src/cli/mcp-stdio.js";
+import { getRequestId, getResponseId } from "../../src/cli/mcp-stdio.js";
+
+/** Read one newline-delimited line from the child's stdout with a timeout,
+ *  capturing stderr for diagnostic context on failure. */
+async function readOneLine(
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs = 10_000,
+): Promise<string> {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c.toString("utf8")));
+  child.stderr.on("data", (c: Buffer) => stderrChunks.push(c.toString("utf8")));
+  return new Promise<string>((resolveResp, rejectResp) => {
+    const checker = setInterval(() => {
+      const joined = stdoutChunks.join("");
+      const nl = joined.indexOf("\n");
+      if (nl >= 0) {
+        clearTimeout(timer);
+        clearInterval(checker);
+        resolveResp(joined.slice(0, nl));
+      }
+    }, 50);
+    const timer = setTimeout(() => {
+      clearInterval(checker);
+      rejectResp(
+        new Error(
+          `no stdout within ${timeoutMs}ms. stderr=${stderrChunks.join("")} stdout=${stdoutChunks.join("")}`,
+        ),
+      );
+    }, timeoutMs);
+  });
+}
 
 describe("getRequestId", () => {
   it("returns the id for JSON-RPC requests (has method + id)", () => {
@@ -19,6 +50,23 @@ describe("getRequestId", () => {
     expect(
       getRequestId({ jsonrpc: "2.0", id: 1, error: { code: 0, message: "" } } as never),
     ).toBeUndefined();
+  });
+});
+
+describe("getResponseId", () => {
+  it("returns the id for JSON-RPC responses (id, no method)", () => {
+    expect(getResponseId({ jsonrpc: "2.0", id: 1, result: {} } as never)).toBe(1);
+    expect(
+      getResponseId({ jsonrpc: "2.0", id: "abc", error: { code: 0, message: "" } } as never),
+    ).toBe("abc");
+  });
+
+  it("returns undefined for JSON-RPC requests (has method)", () => {
+    expect(getResponseId({ jsonrpc: "2.0", id: 1, method: "tools/list" } as never)).toBeUndefined();
+  });
+
+  it("returns undefined for JSON-RPC notifications (has method, no id)", () => {
+    expect(getResponseId({ jsonrpc: "2.0", method: "notifications/foo" } as never)).toBeUndefined();
   });
 });
 
@@ -93,11 +141,6 @@ describe("mcp-stdio proxy integration", () => {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
-    const stdoutChunks: string[] = [];
-    child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c.toString("utf8")));
-    const stderrChunks: string[] = [];
-    child.stderr.on("data", (c: Buffer) => stderrChunks.push(c.toString("utf8")));
-
     const initialize = {
       jsonrpc: "2.0",
       id: 42,
@@ -112,26 +155,7 @@ describe("mcp-stdio proxy integration", () => {
     await new Promise((r) => setTimeout(r, 500));
     child.stdin.write(`${JSON.stringify(initialize)}\n`);
 
-    // Wait for a response on stdout (or fail the test).
-    const response = await new Promise<string>((resolveResp, rejectResp) => {
-      const timer = setTimeout(() => {
-        rejectResp(
-          new Error(
-            `no stdout within 10s. stderr=${stderrChunks.join("")} stdout=${stdoutChunks.join("")}`,
-          ),
-        );
-      }, 10_000);
-      const checker = setInterval(() => {
-        const joined = stdoutChunks.join("");
-        const nl = joined.indexOf("\n");
-        if (nl >= 0) {
-          clearTimeout(timer);
-          clearInterval(checker);
-          resolveResp(joined.slice(0, nl));
-        }
-      }, 50);
-    });
-
+    const response = await readOneLine(child);
     const parsed = JSON.parse(response) as {
       id: number;
       result?: { serverInfo?: { name?: string } };
@@ -140,5 +164,126 @@ describe("mcp-stdio proxy integration", () => {
     expect(parsed.result?.serverInfo?.name).toBe("fake-tandem");
     expect(receivedPosts).toHaveLength(1);
     expect((receivedPosts[0]?.body as { method?: string })?.method).toBe("initialize");
+  }, 30_000);
+});
+
+describe("mcp-stdio error synthesis on upstream unavailability", () => {
+  // Covers issue #336: the stdio bridge must reply with a JSON-RPC -32000
+  // error for any in-flight request when the upstream is unavailable, rather
+  // than closing stdio silently (which surfaces as "tools never appear" with
+  // no diagnostic in the plugin host).
+
+  let child: ChildProcessWithoutNullStreams | undefined;
+
+  afterEach(() => {
+    child?.kill();
+    child = undefined;
+  });
+
+  it("synthesizes -32000 for an initialize request when the upstream server is not running", async () => {
+    const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
+    // Point at a port nothing's listening on. Preflight probe fails, the
+    // already-started stdio transport replies -32000 to any incoming request.
+    child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
+      env: { ...process.env, TANDEM_URL: "http://127.0.0.1:1" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const initialize = {
+      jsonrpc: "2.0",
+      id: 99,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        clientInfo: { name: "test-harness", version: "0.0.0" },
+        capabilities: {},
+      },
+    };
+    // Send the request immediately; the child will either buffer it (not
+    // ready yet) or receive it after preflight fails but before exit. Either
+    // way, the reply must be a -32000.
+    child.stdin.write(`${JSON.stringify(initialize)}\n`);
+
+    const line = await readOneLine(child);
+    const parsed = JSON.parse(line) as {
+      id: number;
+      error?: { code: number; message: string };
+    };
+    expect(parsed.id).toBe(99);
+    expect(parsed.error?.code).toBe(-32000);
+    expect(parsed.error?.message).toMatch(/not (running|ready)/i);
+  }, 30_000);
+
+  it("synthesizes -32000 for pending requests when the upstream dies mid-session", async () => {
+    // Fake server that accepts the initialize POST but never responds —
+    // then close the socket mid-request to simulate an upstream crash.
+    let held: ServerResponse | undefined;
+    const server = createServer((req, res) => {
+      if (req.method === "GET" && req.url === "/health") {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("ok");
+        return;
+      }
+      if (req.method === "POST" && req.url === "/mcp") {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+          // Hold the response — we'll close the server under the client
+          // instead of replying.
+          held = res;
+        });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("server.address() unexpected");
+    const port = addr.port;
+
+    try {
+      const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
+      child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
+        env: { ...process.env, TANDEM_URL: `http://127.0.0.1:${port}` },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      // Let the bridge finish its preflight + http.start() handshake.
+      await new Promise((r) => setTimeout(r, 600));
+
+      const initialize = {
+        jsonrpc: "2.0",
+        id: 77,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          clientInfo: { name: "test-harness", version: "0.0.0" },
+          capabilities: {},
+        },
+      };
+      child.stdin.write(`${JSON.stringify(initialize)}\n`);
+
+      // Wait until the fake upstream has received the POST, then slam the
+      // socket shut so the client's connection closes mid-session.
+      for (let i = 0; i < 50; i++) {
+        if (held) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      // Destroy the held response — the mcp-stdio bridge sees this as
+      // upstream-closed-unexpectedly. Server close happens in finally.
+      held?.destroy();
+
+      const line = await readOneLine(child);
+      const parsed = JSON.parse(line) as {
+        id: number;
+        error?: { code: number; message: string };
+      };
+      expect(parsed.id).toBe(77);
+      expect(parsed.error?.code).toBe(-32000);
+      expect(parsed.error?.message).toMatch(/closed|unreachable/i);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
   }, 30_000);
 });

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -33,6 +33,42 @@ async function readOneLine(
   });
 }
 
+/**
+ * Read up to `n` newline-delimited JSON-RPC lines from child stdout.
+ * Returns as soon as n lines arrive or timeoutMs elapses (in which case
+ * it resolves with whatever arrived — callers assert on the count).
+ */
+async function readLines(
+  child: ChildProcessWithoutNullStreams,
+  n: number,
+  timeoutMs = 10_000,
+): Promise<string[]> {
+  const stdoutChunks: string[] = [];
+  child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c.toString("utf8")));
+  return new Promise<string[]>((resolveResp) => {
+    const lines: string[] = [];
+    let remainder = "";
+    const checker = setInterval(() => {
+      const joined = remainder + stdoutChunks.join("");
+      stdoutChunks.length = 0;
+      const parts = joined.split("\n");
+      remainder = parts.pop() ?? "";
+      for (const part of parts) {
+        if (part.trim()) lines.push(part);
+      }
+      if (lines.length >= n) {
+        clearTimeout(timer);
+        clearInterval(checker);
+        resolveResp(lines);
+      }
+    }, 50);
+    const timer = setTimeout(() => {
+      clearInterval(checker);
+      resolveResp(lines);
+    }, timeoutMs);
+  });
+}
+
 describe("getRequestId", () => {
   it("returns the id for JSON-RPC requests (has method + id)", () => {
     expect(getRequestId({ jsonrpc: "2.0", id: 1, method: "tools/list" } as never)).toBe(1);
@@ -166,11 +202,6 @@ describe("mcp-stdio proxy integration", () => {
 });
 
 describe("mcp-stdio error synthesis on upstream unavailability", () => {
-  // Covers issue #336: the stdio bridge must reply with a JSON-RPC -32000
-  // error for any in-flight request when the upstream is unavailable, rather
-  // than closing stdio silently (which surfaces as "tools never appear" with
-  // no diagnostic in the plugin host).
-
   let child: ChildProcessWithoutNullStreams | undefined;
 
   afterEach(() => {
@@ -325,9 +356,9 @@ describe("mcp-stdio error synthesis on upstream unavailability", () => {
         stdio: ["pipe", "pipe", "pipe"],
       });
 
-      // Let the bridge finish its preflight + http.start() handshake.
-      await new Promise((r) => setTimeout(r, 600));
-
+      // Send immediately and let the preReadyBuffer→drain path deliver the
+      // request once preflight completes. No fixed sleep needed — we poll
+      // `held` below and proceed only once the server has the POST in hand.
       const initialize = {
         jsonrpc: "2.0",
         id: 77,
@@ -346,8 +377,8 @@ describe("mcp-stdio error synthesis on upstream unavailability", () => {
         if (held) break;
         await new Promise((r) => setTimeout(r, 50));
       }
-      // Destroy the held response — the mcp-stdio bridge sees this as
-      // upstream-closed-unexpectedly. Server close happens in finally.
+      // Destroy the held response — exercises forwardToUpstream.catch (not
+      // http.onclose, which the current SDK only fires from its own close()).
       held?.destroy();
 
       const line = await readOneLine(child);
@@ -357,7 +388,209 @@ describe("mcp-stdio error synthesis on upstream unavailability", () => {
       };
       expect(parsed.id).toBe(77);
       expect(parsed.error?.code).toBe(-32000);
-      expect(parsed.error?.message).toMatch(/closed|unreachable/i);
+      // forwardToUpstream.catch fires with "Tandem HTTP upstream unreachable"
+      expect(parsed.error?.message).toMatch(/unreachable/i);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  }, 30_000);
+
+  it("does not synthesize for notifications (no id) on preflight failure", async () => {
+    const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
+    // Point at a dead port so preflight fails immediately.
+    child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
+      env: { ...process.env, TANDEM_URL: "http://127.0.0.1:1" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    // Write a notification (no id) — must never produce a -32000 reply.
+    const notification = { jsonrpc: "2.0", method: "notifications/initialized" };
+    child.stdin.write(`${JSON.stringify(notification)}\n`);
+
+    // Wait for child to exit (it exits 1 after PREFLIGHT_GRACE_MS).
+    await new Promise<void>((r) => child!.once("exit", () => r()));
+
+    // Collect any stdout lines that arrived.
+    const stdoutChunks: string[] = [];
+    child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c.toString("utf8")));
+    const allOutput = stdoutChunks.join("");
+    const lines = allOutput.split("\n").filter((l) => l.trim());
+
+    // No line should be a -32000 error reply.
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line) as { error?: { code?: number } };
+        expect(parsed.error?.code).not.toBe(-32000);
+      } catch {
+        // Non-JSON line — fine, ignore.
+      }
+    }
+  }, 15_000);
+
+  it("synthesizes -32000 for multiple concurrent pending requests on mid-session upstream death", async () => {
+    // Fake server: /health → 200, /mcp → holds all POSTs without replying.
+    const heldResponses: ServerResponse[] = [];
+    const server = createServer((req, res) => {
+      if (req.method === "GET" && req.url === "/health") {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("ok");
+        return;
+      }
+      if (req.method === "POST" && req.url === "/mcp") {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+          heldResponses.push(res);
+        });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("server.address() unexpected");
+    const port = addr.port;
+
+    try {
+      const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
+      child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
+        env: { ...process.env, TANDEM_URL: `http://127.0.0.1:${port}` },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      // Send three concurrent requests with distinct ids.
+      const makeRequest = (id: number) => ({
+        jsonrpc: "2.0",
+        id,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          clientInfo: { name: "test-harness", version: "0.0.0" },
+          capabilities: {},
+        },
+      });
+      child.stdin.write(`${JSON.stringify(makeRequest(100))}\n`);
+      child.stdin.write(`${JSON.stringify(makeRequest(101))}\n`);
+      child.stdin.write(`${JSON.stringify(makeRequest(102))}\n`);
+
+      // Poll until all three POSTs reach the server (preflight + drain must complete first).
+      for (let i = 0; i < 100; i++) {
+        if (heldResponses.length >= 3) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(heldResponses.length).toBeGreaterThanOrEqual(3);
+
+      // Destroy all held responses to trigger forwardToUpstream.catch for each.
+      for (const r of heldResponses) r.destroy();
+
+      // Collect three -32000 lines.
+      const lines = await readLines(child, 3, 10_000);
+      expect(lines).toHaveLength(3);
+
+      const receivedIds = new Set<number>();
+      for (const line of lines) {
+        const parsed = JSON.parse(line) as {
+          id: number;
+          error?: { code: number };
+        };
+        expect(parsed.error?.code).toBe(-32000);
+        receivedIds.add(parsed.id);
+      }
+      expect(receivedIds).toEqual(new Set([100, 101, 102]));
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  }, 30_000);
+
+  it("clears pendingIds after a successful response", async () => {
+    // Fake server: first POST (id=1) → success reply; second POST (id=2) → held.
+    let postCount = 0;
+    let held: ServerResponse | undefined;
+    const server = createServer((req, res) => {
+      if (req.method === "GET" && req.url === "/health") {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("ok");
+        return;
+      }
+      if (req.method === "POST" && req.url === "/mcp") {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+          const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+            id?: number | string;
+          };
+          postCount++;
+          if (postCount === 1) {
+            // Reply immediately for id=1.
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: body.id,
+                result: { protocolVersion: "2024-11-05", capabilities: {} },
+              }),
+            );
+          } else {
+            // Hold id=2 — will be destroyed to trigger forwardToUpstream.catch.
+            held = res;
+          }
+        });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("server.address() unexpected");
+    const port = addr.port;
+
+    try {
+      const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
+      child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
+        env: { ...process.env, TANDEM_URL: `http://127.0.0.1:${port}` },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      const makeRequest = (id: number) => ({
+        jsonrpc: "2.0",
+        id,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          clientInfo: { name: "test-harness", version: "0.0.0" },
+          capabilities: {},
+        },
+      });
+
+      // Send id=1, read success response — proves delete-after-send path.
+      child.stdin.write(`${JSON.stringify(makeRequest(1))}\n`);
+      const line1 = await readOneLine(child, 10_000);
+      const parsed1 = JSON.parse(line1) as { id: number; error?: { code: number } };
+      expect(parsed1.id).toBe(1);
+      expect(parsed1.error).toBeUndefined();
+
+      // Send id=2 and wait until the server holds it.
+      child.stdin.write(`${JSON.stringify(makeRequest(2))}\n`);
+      for (let i = 0; i < 100; i++) {
+        if (held) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(held).toBeDefined();
+
+      // Destroy the held response → forwardToUpstream.catch fires for id=2 only.
+      held!.destroy();
+
+      const line2 = await readOneLine(child, 10_000);
+      const parsed2 = JSON.parse(line2) as { id: number; error?: { code: number } };
+      expect(parsed2.id).toBe(2);
+      expect(parsed2.error?.code).toBe(-32000);
+
+      // Verify no additional line arrives — id=1 must have been removed from
+      // pendingIds on success and must NOT be re-synthesized.
+      const extra = await readLines(child, 1, 500);
+      expect(extra).toHaveLength(0);
     } finally {
       await new Promise<void>((r) => server.close(() => r()));
     }

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -4,8 +4,6 @@ import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getRequestId, getResponseId } from "../../src/cli/mcp-stdio.js";
 
-/** Read one newline-delimited line from the child's stdout with a timeout,
- *  capturing stderr for diagnostic context on failure. */
 async function readOneLine(
   child: ChildProcessWithoutNullStreams,
   timeoutMs = 10_000,
@@ -179,6 +177,84 @@ describe("mcp-stdio error synthesis on upstream unavailability", () => {
     child?.kill();
     child = undefined;
   });
+
+  it("forwards a buffered request once upstream becomes ready", async () => {
+    // Regression guard for the drain path: a request arriving BEFORE
+    // http.start() completes must still be forwarded (not dropped, not
+    // synthesized) once httpReady flips. The fake server artificially
+    // delays /health so preflight takes ~400ms — long enough that a
+    // stdin write immediately after spawn lands in preReadyBuffer.
+    const receivedPosts: Array<{ method?: string; id?: unknown }> = [];
+    const server = createServer((req, res) => {
+      if (req.method === "GET" && req.url === "/health") {
+        setTimeout(() => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("ok");
+        }, 400);
+        return;
+      }
+      if (req.method === "POST" && req.url === "/mcp") {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+          const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+          receivedPosts.push(body);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: body.id,
+              result: { protocolVersion: "2024-11-05", capabilities: { tools: {} } },
+            }),
+          );
+        });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("server.address() unexpected");
+    const port = addr.port;
+
+    try {
+      const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
+      child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
+        env: { ...process.env, TANDEM_URL: `http://127.0.0.1:${port}` },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      // Write IMMEDIATELY — no 500ms grace. The request must land in
+      // preReadyBuffer and survive the drain once httpReady flips.
+      const initialize = {
+        jsonrpc: "2.0",
+        id: 55,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          clientInfo: { name: "test-harness", version: "0.0.0" },
+          capabilities: {},
+        },
+      };
+      child.stdin.write(`${JSON.stringify(initialize)}\n`);
+
+      const line = await readOneLine(child);
+      const parsed = JSON.parse(line) as {
+        id: number;
+        result?: { capabilities?: Record<string, unknown> };
+        error?: { code: number };
+      };
+      expect(parsed.id).toBe(55);
+      // Must be a successful forward, NOT a synthesized -32000.
+      expect(parsed.error).toBeUndefined();
+      expect(parsed.result?.capabilities).toBeDefined();
+      expect(receivedPosts).toHaveLength(1);
+      expect(receivedPosts[0]?.method).toBe("initialize");
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  }, 30_000);
 
   it("synthesizes -32000 for an initialize request when the upstream server is not running", async () => {
     const cliEntry = resolve(__dirname, "../../src/cli/index.ts");

--- a/tests/cli/preflight.test.ts
+++ b/tests/cli/preflight.test.ts
@@ -42,7 +42,7 @@ describe("ensureTandemServer", () => {
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
     const writes = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
-    expect(writes).toContain("Tandem server not reachable at http://localhost:55999");
+    expect(writes).toContain("Tandem server preflight failed at http://localhost:55999");
     expect(writes).toContain("ECONNREFUSED");
     expect(writes).toContain("tandem start");
   });


### PR DESCRIPTION
## Summary

Closes 3 of the 10 items in issue #336 — the silent-failure paths in `src/cli/mcp-stdio.ts` that produce "tools never appear in Cowork" with no diagnostic for plugin-loader users. The `http.send()` synthesis path (already shipped) is untouched.

## What changed

- **stdio starts before preflight.** The plugin loader typically writes `initialize` the instant it spawns us; the old flow ran preflight first and exited before we could read. Now `stdio.start()` happens first, incoming messages are buffered until `httpReady` flips, and each failure path keeps stdio open for a 1500ms grace window so buffered requests get a `-32000` reply before exit.
- **`http.onclose` now exits 1 with synthesis.** Previously returned `shutdown(0)` silently — any in-flight request IDs are now answered with `-32000 "upstream closed unexpectedly"`.
- **`http.start()` failure path** mirrors the preflight failure path.
- **Process-level last-gasp handlers** installed at module scope with `process.once()` so repeat invocations don't stack duplicates.
- **`probeTandemServer`** added to `src/cli/preflight.ts` — non-throwing variant alongside the existing `ensureTandemServer` (still used by `tandem channel`).

## Round-2 review fixes (commit 8da93c8)

Dispatched 5 specialized review agents and 2 plan-reviewers; findings consolidated in `docs/plans/2026-04-17-pr346-review-fixes.md` and applied as a single commit on top:

- **[HIGH]** `http.onmessage` now deletes `pendingIds[id]` only on successful `stdio.send`, and on rejection triggers `shutdown(1, synth)` so the id is drained via `synthesizePending` rather than leaked. Defensive today — current SDK never rejects — but closes the one remaining silent-failure path if a future SDK propagates EPIPE.
- **[MEDIUM]** `PreflightProbe` now carries a `kind: "unreachable" | "unhealthy"` discriminator; user-facing messages on both `mcp-stdio` and `channel` branches distinguish server-down from server-up-but-unhealthy.
- **[MEDIUM]** `shutdown()` close-failures log to stderr instead of swallowing silently — consistent with the rest of the module.
- **[LATENT-RACE]** `forwardToUpstream.catch` uses `Set.delete(id)`'s boolean return as atomic check-and-remove to prevent double-synth under future shutdown-mid-send races.
- **Refactor:** `deferredShutdown()` helper consolidates two `setTimeout(shutdown(1, {...}), PREFLIGHT_GRACE_MS)` blocks.
- **Comments:** softened SDK-behavior claims (onclose, http.start), dropped cross-file "2s" magic-number reference, added drain-parallelism note.
- **Tests added (3):** pendingIds-cleared-on-success, notifications-no-synth, concurrent-pending-synth.
- **Tests hardened:** replaced 600ms fixed-sleep handshake wait with immediate-send + drain-path; tightened `/closed|unreachable/i` regex to `/unreachable/i` to pin the assertion to the actual code path.

## Out of scope (deferred to v0.7.0)

Issue #336 listed 10 items; this PR handles the 3 critical silent-failure fixes plus the review-round hardening above. Deferred: channel-shim tests, Windows `npx` smoke test, the 5 nits.

## Depends on

None. Branches from master. The v0.6.3 release plan (docs/plans/2026-04-17-v0.6.3-release.md) is in PR #345 (Bundle A) — reviewers can read the plan there for context.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **1223 pass / 3 skipped** (full suite, post-review-round)
- [x] `tests/cli/mcp-stdio.test.ts`:
  - `getResponseId` handles requests / notifications / responses correctly
  - `"synthesizes -32000 when upstream not running"` — spawn pointing at dead port, expect -32000 on stdout
  - `"synthesizes -32000 when upstream dies mid-session"` — fake server holds request then destroys socket, expect -32000 on stdout
  - `"forwards a buffered request once upstream becomes ready"` — regression guard for drain path
  - **NEW:** `"clears pendingIds after a successful response"` — id=1 succeeds, id=2 fails, only id=2 gets -32000
  - **NEW:** `"does not synthesize for notifications (no id) on preflight failure"` — protocol-guarantee guard
  - **NEW:** `"synthesizes -32000 for multiple concurrent pending requests on mid-session upstream death"` — covers synthesizePending's Promise.all
- [x] `tests/cli/preflight.test.ts` assertion updated for new "preflight failed" wording
- [ ] Manual smoke: install `tandem-editor` in a Cowork plugin session, stop the host server, send a request, confirm plugin host surfaces `-32000` (not silent close)

## Notes

- `http.send()` synthesis path (the existing pre-PR code) was already correct per issue #336's claims — verified before starting this PR. No re-implementation.
- Grace window derived from the preflight default timeout + stdin read lag. Commented rationale in-line.
- `StreamableHTTPClientTransport.start()` on the current SDK (0.20.x) creates an AbortController and returns synchronously — no HTTP I/O. The `http.start()` catch branch is defensive for future SDK versions; a dedicated test would only exercise SDK error propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
