### PR TITLE
refactor(annotations): mergeMap<T> helper, ReplyAuthorSchema, header trims (#324, #332)

### DIFF
--- a/src/server/annotations/schema.ts
+++ b/src/server/annotations/schema.ts
@@ -1,42 +1,16 @@
 /**
  * On-disk schema for Tandem's durable annotation envelope.
  *
- * The envelope is written to app-data JSON (per Phase 1 of the durable-annotations
- * plan). It wraps the existing in-memory annotation / reply shapes with:
- *   - `schemaVersion` for forward-compat migrations
- *   - `docHash` so a stale file can be detected when the underlying document has
- *     changed on disk
- *   - `meta` for bookkeeping (filePath, lastUpdated)
- *   - `tombstones` so deleted annotations don't resurrect on merge
- *   - `rev: number` on each annotation/reply for last-writer-wins semantics
- *
  * ## Unknown-field policy
  *
- * All object schemas in this module use `.passthrough()` (Zod default is to strip
- * unknowns; we intentionally override that). Forward-compatibility is the goal:
- * a future version might add fields (e.g. `pinnedBy`, `severity`) that a pre-
- * upgrade Tandem install should *preserve* when rewriting the file, not silently
- * drop. Strict rejection would turn a harmless additive change into a "corrupt"
- * error and trip the `.json.future` fallback path unnecessarily.
- *
- * Forward version jumps (`schemaVersion > 1`) are still handled explicitly via
- * `parseAnnotationDoc` returning `{ ok: false, error: "future" }` — passthrough
- * only covers *additive* changes inside the v1 shape.
- *
- * ## Why this schema doesn't fully mirror the Annotation TS discriminated union
- *
- * `src/shared/types.ts` defines `Annotation` as a three-variant discriminated
- * union (`highlight` / `comment` / `flag`) with mutually-exclusive `undefined`
- * markers on the non-applicable variant fields. Mirroring that shape in Zod
- * via `z.discriminatedUnion` would duplicate a lot of field surface area and
- * drift from the TS type as it evolves. Instead, we validate the *shared*
- * structural shape (AnnotationBase + optional `type`-tagged fields) and let
- * consumers cast to `Annotation` downstream. The Zod schema is a gatekeeper
- * against malformed files on disk, not the source of truth for the app's
- * annotation type system.
- *
- * Full migration framework for v1 → v2+ is deferred to issue #320. This module
- * ships only `migrateToV1` (legacy session-blob → v1).
+ * All object schemas use `.passthrough()` (overriding Zod's default strip).
+ * Forward-compatibility is the goal: a future version might add fields
+ * (e.g. `pinnedBy`, `severity`) that a pre-upgrade Tandem install should
+ * *preserve* when rewriting the file, not silently drop. Strict rejection
+ * would turn a harmless additive change into a "corrupt" error and trip the
+ * `.json.future` fallback path unnecessarily. Breaking version jumps
+ * (`schemaVersion > 1`) are still handled explicitly via
+ * `parseAnnotationDoc` returning `{ ok: false, error: "future" }`.
  */
 
 import { z } from "zod";
@@ -45,6 +19,7 @@ import {
   AnnotationTypeSchema,
   AuthorSchema,
   HighlightColorSchema,
+  ReplyAuthorSchema,
 } from "../../shared/types.js";
 
 /** On-disk envelope version. Bump when making breaking changes to the file shape. */
@@ -137,7 +112,7 @@ export const AnnotationReplyRecordSchemaV1 = z
   .object({
     id: z.string().min(1),
     annotationId: z.string().min(1),
-    author: z.enum(["user", "claude"]),
+    author: ReplyAuthorSchema,
     text: z.string(),
     timestamp: z.number(),
     editedAt: z.number().optional(),

--- a/src/server/annotations/store.ts
+++ b/src/server/annotations/store.ts
@@ -1,29 +1,17 @@
 /**
- * Durable per-document annotation store.
+ * Durable per-document annotation store. One JSON file per document at
+ * `<annotationsDir>/<docHash>.json`; the Y.Map remains the live collab
+ * state, this module is the crash-safe source of record behind it.
  *
- * One JSON file per document at `<annotationsDir>/<docHash>.json`. The Y.Map
- * (`Y_MAP_ANNOTATIONS`) remains the live collab state; this module is the
- * crash-safe source of record behind it.
- *
- * Behaviour summary (see the Phase 1 durable-annotations plan for rationale):
- *   - Location: `env-paths("tandem").data/annotations/` by default, override
- *     via `TANDEM_APP_DATA_DIR`.
- *   - Writes are atomic (reuses `file-io/atomicWrite` with Windows retries).
- *   - Writes are debounced per docHash (100ms) — bursty rapid writes for the
- *     same doc coalesce, but parallel writes to different docs do NOT share a
- *     debounce timer.
- *   - `queueWrite` takes a THUNK, not a pre-computed doc. The snapshot runs at
- *     debounce-fire time, not at mutation time, so a 50-mutation burst only
- *     pays for one serialization.
- *   - Corrupt files are quarantined to `<hash>.json.corrupt.<epoch-ms>`.
- *   - Files from a newer schema are parked at `<hash>.json.future` (no ts so
- *     future migration tooling has a predictable name).
- *   - Cross-process concurrent-writer guard via a `store.lock` PID lockfile
- *     (belt-and-braces on top of the port 3479 bind, which is the primary
- *     lock).
- *   - Disk-full / permission-denied errors: 60s throttled toast per doc,
- *     disable writes for that doc after 3 consecutive failures (in-memory —
- *     restart clears the flag, matching the "restart to retry" UX).
+ * Non-obvious invariants:
+ *   - `queueWrite` takes a THUNK. The snapshot runs at debounce-fire time,
+ *     not at mutation time, so a 50-mutation burst only pays for one
+ *     serialization. The last-queued thunk wins (last-writer-wins coalescing).
+ *   - `store.lock` PID lockfile is a belt-and-braces fallback on top of the
+ *     port 3479 bind, which is the primary concurrent-writer lock.
+ *   - After `DISABLE_AFTER_FAILURES` consecutive write failures for a doc,
+ *     that doc's writes are disabled in-memory until process restart — one
+ *     persistent-notice toast fires, not a flood.
  *   - `TANDEM_ANNOTATION_STORE=off` short-circuits the entire module.
  */
 

--- a/src/server/annotations/store.ts
+++ b/src/server/annotations/store.ts
@@ -10,8 +10,9 @@
  *   - `store.lock` PID lockfile is a belt-and-braces fallback on top of the
  *     port 3479 bind, which is the primary concurrent-writer lock.
  *   - After `DISABLE_AFTER_FAILURES` consecutive write failures for a doc,
- *     that doc's writes are disabled in-memory until process restart — one
- *     persistent-notice toast fires, not a flood.
+ *     that doc's writes are disabled in-memory until process restart. Toasts
+ *     are throttled per-doc (`NOTIFY_THROTTLE_MS`) so a failing-disk burst
+ *     doesn't flood the UI.
  *   - `TANDEM_ANNOTATION_STORE=off` short-circuits the entire module.
  */
 

--- a/src/server/annotations/sync.ts
+++ b/src/server/annotations/sync.ts
@@ -289,12 +289,12 @@ function pickWinner(
 }
 
 /**
- * Merge a Map of file records into a Y.Map under last-writer-wins rules.
- * For each file record: insert if absent (unless `shouldSkipInsert` vetoes),
- * otherwise run `pickWinner` against the normalized Y.Map copy. After the
- * pass, `needsWrite` is true if the Y.Map carries ids the file doesn't
- * (minus `ymapOnlyIgnoreIds`) — the caller queues a post-merge write so
- * those Y.Map-only entries land on disk.
+ * Merge a Map of file records into a Y.Map under `pickWinner`'s rules
+ * (higher `rev` wins; tied `rev` falls back to `editedAt`). For each file
+ * record: insert if absent (unless `shouldSkipInsert` vetoes), otherwise
+ * compare normalized copies and let the winner replace. After the pass,
+ * `needsWrite` is true if the Y.Map carries ids the file doesn't (minus
+ * `ymapOnlyIgnoreIds`) — caller queues a post-merge write so those land.
  */
 function mergeMap<T extends { rev: number; editedAt?: number }>(
   ymap: Y.Map<unknown>,
@@ -423,18 +423,20 @@ export async function loadAndMerge(
       // else: resurrection — leave the Y.Map entry alone.
     }
 
-    // Set of ids where the tombstone rev beats the file's alive record. The
-    // file shouldn't carry both, but if it does (bug, manual edit) the
-    // tombstone is authoritative — skip the insert.
+    // Set of ids where a tombstone beats the file's alive record. The file
+    // shouldn't carry both (contradiction — bug or manual edit), but if it
+    // does the tombstone is authoritative. This guards only the
+    // Y.Map-absent insert path; the preceding loop already handled the
+    // Y.Map-present case.
+    const fileAnns = new Map(file.annotations.map((a) => [a.id, a]));
     const winningTombstoneIds = new Set<string>();
     const tombstoneIds = new Set<string>();
     for (const stone of file.tombstones) {
       tombstoneIds.add(stone.id);
-      const fileAnn = file.annotations.find((a) => a.id === stone.id);
+      const fileAnn = fileAnns.get(stone.id);
       if (fileAnn && stone.rev > fileAnn.rev) winningTombstoneIds.add(stone.id);
     }
 
-    const fileAnns = new Map(file.annotations.map((a) => [a.id, a]));
     const annResult = mergeMap(annMap, fileAnns, normalizeAnnotation, {
       shouldSkipInsert: (id) => winningTombstoneIds.has(id),
       ymapOnlyIgnoreIds: tombstoneIds,

--- a/src/server/annotations/sync.ts
+++ b/src/server/annotations/sync.ts
@@ -52,9 +52,6 @@
  *     (already-updated) tombstone list via its lazy thunk. If the caller
  *     needs a standalone write without a Y.Map.delete, they call
  *     `store.flush()` explicitly.
- *   - A per-docHash context registry (`docContexts`) is populated by
- *     observer registration and cleaned up on unregister. It's retained
- *     primarily for future diagnostic/admin paths.
  */
 
 import * as Y from "yjs";
@@ -86,22 +83,12 @@ export interface SyncContext {
   meta: SyncMeta;
 }
 
-/** Per-docHash live state, populated by `registerAnnotationObserver`. */
-interface DocContext {
-  ydoc: Y.Doc;
-  store: DocStore;
-  meta: SyncMeta;
-}
-
 // ---------------------------------------------------------------------------
 // Module-scoped state
 // ---------------------------------------------------------------------------
 
 /** Tombstones live in memory, keyed by docHash. Seeded from disk on load. */
 const tombstonesByDoc = new Map<string, TombstoneRecordV1[]>();
-
-/** Live ydoc+store handles so diagnostic paths can locate them by docHash. */
-const docContexts = new Map<string, DocContext>();
 
 // ---------------------------------------------------------------------------
 // Serialization
@@ -194,7 +181,6 @@ export function registerAnnotationObserver(
   ctx: SyncContext,
 ): (phase?: ObserverCleanupPhase) => void {
   const { ydoc, store, docHash, meta } = ctx;
-  docContexts.set(docHash, { ydoc, store, meta });
 
   const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
   const repMap = ydoc.getMap(Y_MAP_ANNOTATION_REPLIES);
@@ -217,7 +203,6 @@ export function registerAnnotationObserver(
   return (phase: ObserverCleanupPhase = "close") => {
     annMap.unobserve(onMutation);
     repMap.unobserve(onMutation);
-    docContexts.delete(docHash);
     if (phase === "close") {
       tombstonesByDoc.delete(docHash);
     }
@@ -303,6 +288,55 @@ function pickWinner(
   return "ymap";
 }
 
+/**
+ * Merge a Map of file records into a Y.Map under last-writer-wins rules.
+ * For each file record: insert if absent (unless `shouldSkipInsert` vetoes),
+ * otherwise run `pickWinner` against the normalized Y.Map copy. After the
+ * pass, `needsWrite` is true if the Y.Map carries ids the file doesn't
+ * (minus `ymapOnlyIgnoreIds`) — the caller queues a post-merge write so
+ * those Y.Map-only entries land on disk.
+ */
+function mergeMap<T extends { rev: number; editedAt?: number }>(
+  ymap: Y.Map<unknown>,
+  fileRecs: Map<string, T>,
+  normalize: (raw: unknown) => T | null,
+  opts: {
+    shouldSkipInsert?: (id: string, fileRec: T) => boolean;
+    ymapOnlyIgnoreIds?: Set<string>;
+  } = {},
+): { needsWrite: boolean } {
+  let needsWrite = false;
+
+  for (const [id, fileRec] of fileRecs) {
+    const ymapRaw = ymap.get(id);
+    if (ymapRaw === undefined) {
+      if (opts.shouldSkipInsert?.(id, fileRec)) continue;
+      ymap.set(id, fileRec);
+      continue;
+    }
+    const ymapRec = normalize(ymapRaw);
+    if (!ymapRec) {
+      ymap.set(id, fileRec);
+      continue;
+    }
+    const winner = pickWinner(fileRec, ymapRec);
+    if (winner === "file") {
+      ymap.set(id, fileRec);
+    } else {
+      needsWrite = true;
+    }
+  }
+
+  for (const id of ymap.keys()) {
+    if (fileRecs.has(id)) continue;
+    if (opts.ymapOnlyIgnoreIds?.has(id)) continue;
+    needsWrite = true;
+    break;
+  }
+
+  return { needsWrite };
+}
+
 // ---------------------------------------------------------------------------
 // loadAndMerge
 // ---------------------------------------------------------------------------
@@ -378,11 +412,8 @@ export async function loadAndMerge(
   let needsWrite = false;
 
   ydoc.transact(() => {
-    // --- Annotations ---
-    const fileAnns = new Map(file.annotations.map((a) => [a.id, a]));
-
-    // 1. Tombstones rule (process first so we don't overwrite a delete with
-    //    a concurrent file-side alive record that shouldn't have been there).
+    // Apply tombstones first so a later merge step can't overwrite a winning
+    // delete.
     for (const stone of file.tombstones) {
       const ymapAnn = normalizeAnnotation(annMap.get(stone.id));
       if (!ymapAnn) continue;
@@ -392,68 +423,27 @@ export async function loadAndMerge(
       // else: resurrection — leave the Y.Map entry alone.
     }
 
-    // 2. File annotations vs Y.Map.
-    for (const [id, fileAnn] of fileAnns) {
-      const ymapRaw = annMap.get(id);
-      if (ymapRaw === undefined) {
-        // Not in Y.Map and not blocked by a tombstone → file wins.
-        // (If it WAS in Y.Map + got tombstone-deleted above, it'll still be
-        // absent here, but that's a contradiction — a file can't carry both
-        // an alive record and a winning tombstone for the same id. We treat
-        // "tombstone won the deletion" as authoritative and drop the file's
-        // alive record in that case.)
-        const deletedByTombstone = file.tombstones.some((t) => t.id === id && t.rev > fileAnn.rev);
-        if (!deletedByTombstone) {
-          annMap.set(id, fileAnn);
-        }
-        continue;
-      }
-      const ymapAnn = normalizeAnnotation(ymapRaw);
-      if (!ymapAnn) {
-        annMap.set(id, fileAnn);
-        continue;
-      }
-      const winner = pickWinner(fileAnn, ymapAnn);
-      if (winner === "file") {
-        annMap.set(id, fileAnn);
-      } else {
-        // Y.Map is authoritative — its state needs to land on disk.
-        needsWrite = true;
-      }
+    // Set of ids where the tombstone rev beats the file's alive record. The
+    // file shouldn't carry both, but if it does (bug, manual edit) the
+    // tombstone is authoritative — skip the insert.
+    const winningTombstoneIds = new Set<string>();
+    const tombstoneIds = new Set<string>();
+    for (const stone of file.tombstones) {
+      tombstoneIds.add(stone.id);
+      const fileAnn = file.annotations.find((a) => a.id === stone.id);
+      if (fileAnn && stone.rev > fileAnn.rev) winningTombstoneIds.add(stone.id);
     }
 
-    // 3. Y.Map annotations absent from file, not tombstoned → keep + write.
-    const tombstoneIds = new Set(file.tombstones.map((t) => t.id));
-    for (const id of annMap.keys()) {
-      if (fileAnns.has(id)) continue;
-      if (tombstoneIds.has(id)) continue;
-      needsWrite = true;
-    }
+    const fileAnns = new Map(file.annotations.map((a) => [a.id, a]));
+    const annResult = mergeMap(annMap, fileAnns, normalizeAnnotation, {
+      shouldSkipInsert: (id) => winningTombstoneIds.has(id),
+      ymapOnlyIgnoreIds: tombstoneIds,
+    });
+    if (annResult.needsWrite) needsWrite = true;
 
-    // --- Replies (same shape, no tombstones) ---
     const fileReplies = new Map(file.replies.map((r) => [r.id, r]));
-    for (const [id, fileRep] of fileReplies) {
-      const ymapRaw = repMap.get(id);
-      if (ymapRaw === undefined) {
-        repMap.set(id, fileRep);
-        continue;
-      }
-      const ymapRep = normalizeReply(ymapRaw);
-      if (!ymapRep) {
-        repMap.set(id, fileRep);
-        continue;
-      }
-      const winner = pickWinner(fileRep, ymapRep);
-      if (winner === "file") {
-        repMap.set(id, fileRep);
-      } else {
-        needsWrite = true;
-      }
-    }
-
-    for (const id of repMap.keys()) {
-      if (!fileReplies.has(id)) needsWrite = true;
-    }
+    const repResult = mergeMap(repMap, fileReplies, normalizeReply);
+    if (repResult.needsWrite) needsWrite = true;
   }, FILE_SYNC_ORIGIN);
 
   if (needsWrite) {
@@ -470,5 +460,4 @@ export async function loadAndMerge(
 /** Reset all module state. Tests only — never call in production. */
 export function resetForTesting(): void {
   tombstonesByDoc.clear();
-  docContexts.clear();
 }

--- a/src/server/events/types.ts
+++ b/src/server/events/types.ts
@@ -6,6 +6,8 @@
  * `notifications/claude/channel` messages.
  */
 
+import type { ReplyAuthor } from "../../shared/types.js";
+
 // --- Per-event payload interfaces ---
 
 export interface AnnotationCreatedPayload {
@@ -49,7 +51,7 @@ export interface AnnotationReplyPayload {
   annotationId: string;
   replyId: string;
   replyText: string;
-  replyAuthor: "user" | "claude";
+  replyAuthor: ReplyAuthor;
   textSnippet: string;
 }
 

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -9,6 +9,7 @@ import type {
   AnnotationReply,
   AnnotationType,
   HighlightColor,
+  ReplyAuthor,
 } from "../../shared/types.js";
 import {
   AnnotationActionSchema,
@@ -76,7 +77,7 @@ export function addReplyToAnnotation(
   annotationsMap: Y.Map<unknown>,
   annotationId: string,
   text: string,
-  author: "user" | "claude",
+  author: ReplyAuthor,
   origin?: string,
 ): { ok: true; replyId: string } | { ok: false; error: string; code?: string } {
   const raw = annotationsMap.get(annotationId) as Annotation | undefined;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -20,6 +20,8 @@ export const HighlightColorSchema = z.enum(["yellow", "red", "green", "blue", "p
 export const SeveritySchema = z.enum(["info", "warning", "error", "success"]);
 export const TandemModeSchema = z.enum(["solo", "tandem"]);
 export const AuthorSchema = z.enum(["user", "claude", "import"]);
+/** Subset of {@link AuthorSchema} allowed on replies — `import` is annotations-only. */
+export const ReplyAuthorSchema = z.enum(["user", "claude"]);
 export const AnnotationActionSchema = z.enum(["accept", "dismiss"]);
 export const ExportFormatSchema = z.enum(["markdown", "json"]);
 export const DocumentFormatSchema = z.enum(["md", "txt", "html", "docx"]);
@@ -42,13 +44,14 @@ export type TandemMode = z.infer<typeof TandemModeSchema>;
 export type WidthMode = "reading" | "full";
 export type HighlightColor = z.infer<typeof HighlightColorSchema>;
 export type Severity = z.infer<typeof SeveritySchema>;
+export type ReplyAuthor = z.infer<typeof ReplyAuthorSchema>;
 
 // --- Reply types ---
 
 export interface AnnotationReply {
   id: string;
   annotationId: string;
-  author: "user" | "claude";
+  author: ReplyAuthor;
   text: string;
   timestamp: number;
   editedAt?: number;

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -521,6 +521,88 @@ describe("loadAndMerge", () => {
 
     cleanup();
   });
+
+  it("#18 merge: file has alive ann AND winning tombstone for same id, Y.Map empty → insert suppressed", async () => {
+    // Contradiction: file carries an alive record for "ann_1" (rev 2) and a
+    // tombstone for "ann_1" (rev 5). Tombstone wins (5 > 2) so the alive
+    // record must NOT be inserted. Exercises shouldSkipInsert /
+    // winningTombstoneIds — the only mergeMap path never hit by the existing
+    // suite (prior tombstone tests all use annotations: []).
+    const store0 = createStore(HASH_A, { filePath: FILE_A });
+    store0.queueWrite(() =>
+      makeFile(HASH_A, FILE_A, {
+        annotations: [annRecord({ id: "ann_1", rev: 2 })],
+        tombstones: [{ id: "ann_1", rev: 5, deletedAt: 9999 }],
+      }),
+    );
+    await store0.flush();
+    resetStoreForTesting();
+
+    const ydoc = new Y.Doc();
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const cleanup = await loadAndMerge(syncCtx(ydoc, store));
+
+    expect(annMap.get("ann_1")).toBeUndefined();
+    expect(getTombstones(HASH_A)).toEqual([{ id: "ann_1", rev: 5, deletedAt: 9999 }]);
+    cleanup();
+  });
+
+  it("#18b merge: file has alive ann AND tombstone at equal rev → insert proceeds (strict-> contract)", async () => {
+    // Boundary: stone.rev === fileAnn.rev (both 5). The veto is strict
+    // greater-than, so equal rev must NOT suppress the insert. Guards against
+    // someone changing > to >=.
+    const store0 = createStore(HASH_A, { filePath: FILE_A });
+    store0.queueWrite(() =>
+      makeFile(HASH_A, FILE_A, {
+        annotations: [annRecord({ id: "ann_1", rev: 5 })],
+        tombstones: [{ id: "ann_1", rev: 5, deletedAt: 9999 }],
+      }),
+    );
+    await store0.flush();
+    resetStoreForTesting();
+
+    const ydoc = new Y.Doc();
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const cleanup = await loadAndMerge(syncCtx(ydoc, store));
+
+    const inserted = annMap.get("ann_1") as AnnotationRecordV1 | undefined;
+    expect(inserted).toBeDefined();
+    expect(inserted?.rev).toBe(5);
+    cleanup();
+  });
+
+  it("#19 merge: tombstone loses to Y.Map (resurrection) — no spurious queueWrite", async () => {
+    // Tombstone rev=2 loses to Y.Map rev=7. "ann_1" is in Y.Map but NOT in
+    // the file's alive list. Without ymapOnlyIgnoreIds, the "Y.Map keys
+    // absent from file" pass would see it and set needsWrite → spurious write.
+    const store0 = createStore(HASH_A, { filePath: FILE_A });
+    store0.queueWrite(() =>
+      makeFile(HASH_A, FILE_A, {
+        annotations: [],
+        tombstones: [{ id: "ann_1", rev: 2, deletedAt: 1 }],
+      }),
+    );
+    await store0.flush();
+    resetStoreForTesting();
+
+    const ydoc = new Y.Doc();
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    annMap.set("ann_1", annRecord({ id: "ann_1", rev: 7, content: "reborn" }));
+
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const queueSpy = vi.spyOn(store, "queueWrite");
+    const cleanup = await loadAndMerge(syncCtx(ydoc, store));
+
+    const survivor = annMap.get("ann_1") as AnnotationRecordV1 | undefined;
+    expect(survivor).toBeDefined();
+    expect(survivor?.rev).toBe(7);
+    expect(queueSpy).not.toHaveBeenCalled();
+    cleanup();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -633,6 +715,79 @@ describe("replies merge", () => {
     const onDisk = JSON.parse(raw);
     expect(onDisk.replies).toHaveLength(1);
     expect(onDisk.replies[0].id).toBe("rep_1");
+    cleanup();
+  });
+
+  it("#20 reply: file has reply, Y.Map empty → reply inserted", async () => {
+    const store0 = createStore(HASH_A, { filePath: FILE_A });
+    store0.queueWrite(() =>
+      makeFile(HASH_A, FILE_A, {
+        replies: [replyRecord({ id: "rep_2", rev: 3, text: "from-disk" })],
+      }),
+    );
+    await store0.flush();
+    resetStoreForTesting();
+
+    const ydoc = new Y.Doc();
+    const repMap = ydoc.getMap(Y_MAP_ANNOTATION_REPLIES);
+
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const cleanup = await loadAndMerge(syncCtx(ydoc, store));
+
+    const inserted = repMap.get("rep_2") as AnnotationReplyRecordV1 | undefined;
+    expect(inserted).toBeDefined();
+    expect(inserted?.rev).toBe(3);
+    expect(inserted?.text).toBe("from-disk");
+    cleanup();
+  });
+
+  it("#21 reply: Y.Map has reply, file has no replies → queueWrite fires", async () => {
+    // The file must have an annotation so fileEmpty is false — otherwise
+    // loadAndMerge takes the first-upgrade fast path and queueWrite fires for
+    // a different reason without ever reaching the reply merge loop.
+    const store0 = createStore(HASH_A, { filePath: FILE_A });
+    store0.queueWrite(() =>
+      makeFile(HASH_A, FILE_A, {
+        annotations: [annRecord({ id: "ann_other", rev: 1 })],
+        replies: [],
+      }),
+    );
+    await store0.flush();
+    resetStoreForTesting();
+
+    const ydoc = new Y.Doc();
+    const repMap = ydoc.getMap(Y_MAP_ANNOTATION_REPLIES);
+    repMap.set("rep_3", replyRecord({ id: "rep_3", rev: 1, text: "in-memory" }));
+
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const queueSpy = vi.spyOn(store, "queueWrite");
+    const cleanup = await loadAndMerge(syncCtx(ydoc, store));
+
+    expect(repMap.get("rep_3")).toBeDefined();
+    expect(queueSpy).toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("#22 reply: Y.Map rev > file rev → Y.Map wins (unchanged)", async () => {
+    const store0 = createStore(HASH_A, { filePath: FILE_A });
+    store0.queueWrite(() =>
+      makeFile(HASH_A, FILE_A, {
+        replies: [replyRecord({ id: "rep_1", rev: 1, text: "from-disk" })],
+      }),
+    );
+    await store0.flush();
+    resetStoreForTesting();
+
+    const ydoc = new Y.Doc();
+    const repMap = ydoc.getMap(Y_MAP_ANNOTATION_REPLIES);
+    repMap.set("rep_1", replyRecord({ id: "rep_1", rev: 4, text: "from-ymap" }));
+
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const cleanup = await loadAndMerge(syncCtx(ydoc, store));
+
+    const winner = repMap.get("rep_1") as AnnotationReplyRecordV1;
+    expect(winner.rev).toBe(4);
+    expect(winner.text).toBe("from-ymap");
     cleanup();
   });
 });


### PR DESCRIPTION
## Summary

Four /simplify follow-ups from PR #323 durable-annotations Phase 1, bundled because they all touch the same three files (`sync.ts`, `schema.ts`, `store.ts`) and share the same shape (dedupe / promote-to-shared / trim headers).

- **#324** — Extract `mergeMap<T>(ymap, fileRecs, normalize, opts)` helper in `src/server/annotations/sync.ts`. Two near-duplicate merge loops in `loadAndMerge` (annotations + replies) collapse to helper invocations. The `shouldSkipInsert` closure for tombstone-veto is now a precomputed `Set` lookup instead of `O(A×T)` linear scan per file annotation. Added a small optimization: the "Y.Map keys absent from file" pass now `break`s on first hit instead of walking the whole map.
- **#332.1** — Add `ReplyAuthorSchema = z.enum(["user", "claude"])` + `ReplyAuthor` type to `src/shared/types.ts`. `annotations/schema.ts` uses the schema in `AnnotationReplyRecordSchemaV1`. `events/types.ts` (`AnnotationReplyPayload.replyAuthor`) and `mcp/annotations.ts` (`addReplyToAnnotation` param) adopt the type alias. Kept `AuthorshipRange.author` / `ChatMessage.author` / `generateAuthorshipId` as raw literals — those aren't replies, different semantics.
- **#332.2** — Trim over-documented module headers: `schema.ts` 40→13 lines, `store.ts` 28→15 lines. Kept non-obvious WHYs (passthrough rationale, thunk lazy-eval, lockfile belt-and-braces, feature flag kill switch). Dropped self-evident narration (debounce timing, corrupt-file quarantine, atomic-write wrapper).
- **#332.3** — Drop unused `docContexts` Map in `sync.ts`. It was populated by observer registration and cleared on teardown but never read by anyone.

All behavior-preserving. No new public API surface. 1234/1237 tests pass, typecheck clean.

Closes #324, #332.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1234 / 1237 (3 skipped pre-existing)
- [x] Simplify review (reuse + quality + efficiency agents, parallel): quality agent flagged O(A×T) tombstone scan — hoisted to precomputed Set. Reuse agent flagged additional \`ReplyAuthor\` adoption sites — adopted the two genuinely reply-semantic ones (events payload + addReply param), skipped the three semantically-distinct sites (AuthorshipRange, ChatMessage, generateAuthorshipId).

🤖 Generated with [Claude Code](https://claude.com/claude-code)