### PR TITLE
feat(annotations): sanitize legacy types on write + migrateToV1 drop counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Annotation serialization upgrades legacy `type` values on write** (#329) — records with non-canonical `type` (`"suggestion"` / `"question"` / anything outside `highlight` / `comment` / `flag`) are now routed through `sanitizeAnnotation` during snapshot serialization, which rewrites them to `"comment"`. Before this change, a legacy session-restored record would be written verbatim to disk, then fail Zod validation on the next load and quarantine the envelope to `.json.future`. **One-way lossy migration:** users with legacy-type annotations will see `type` flip to `"comment"` on the next durable write for that document — the original distinction between `suggestion` and `question` is not recoverable.
+
+### Added
+
+- **`migrateToV1` reports drop counts** (#330) — `migrateToV1(raw)` now returns `{ doc, droppedAnnotations, droppedReplies }` so future production callers can surface lossy upgrades to users rather than silently discarding malformed records. No production caller exists yet (load-time envelope validation goes through `parseAnnotationDoc`, which short-circuits on the v1 schema); a follow-up will wire drop counts to `npm run doctor` or a toast when the first caller lands.
+
 ## [0.6.2] - 2026-04-16
 
 ### Fixed

--- a/docs/plans/2026-04-17-v0.6.3-release.md
+++ b/docs/plans/2026-04-17-v0.6.3-release.md
@@ -95,8 +95,8 @@ User guidance: small, focused PRs by default; bundle only when interdependent.
 ### Bundle C — Annotation observability (with CHANGELOG caveats)
 
 - **#329** `sanitizeAnnotation` on write — **note in CHANGELOG:** one-way lossy migration for `suggestion`/`question` types (both rewritten to `comment`). Users with legacy types will see `type` field change on next write.
-- **#330** `migrateToV1` drop-counter — **requirement:** counter must surface via at least one user-visible path (throttled toast on non-zero drop, OR `npm run doctor` field). Silent `console.error` is insufficient — Phase 1 already has data-loss bugs; users need to see when load-time rejects happen.
-- **Add `npm run doctor` annotation-health section** if not already present (plan's CHANGELOG previously claimed `doctor` surfaces these; verify or remove claim).
+- **#330** `migrateToV1` drop-counter — **shipped in Bundle C:** signature now returns `{ doc, droppedAnnotations, droppedReplies }`. **Surfacing deferred:** `migrateToV1` has no production caller today (load-time envelope validation lives in `parseAnnotationDoc`, which short-circuits on the v1 schema). The user-visible path — throttled toast or `npm run doctor` field — must land in the same PR that introduces the first production caller, so the counts are never produced silently. CHANGELOG [Unreleased] records this deferral.
+- **`npm run doctor` annotation-health section** is already present (`checkAnnotationStore` in `scripts/doctor.mjs`, covers count / size / newest write / schema version / corrupt files / lock). Drop-counter field to be added alongside the future caller — not part of Bundle C.
 - **One PR.**
 
 ### Bundle D — Test coverage (standalone)

--- a/src/server/annotations/schema.ts
+++ b/src/server/annotations/schema.ts
@@ -227,9 +227,9 @@ export function parseAnnotationDoc(raw: unknown): ParseAnnotationDocResult {
 /** Result of `migrateToV1`. Drop counts let callers surface lossy upgrades. */
 export interface MigrationResult {
   doc: AnnotationDocV1;
-  /** Number of annotation records the migration had to skip (non-object input or schema rejection). */
+  /** Count of annotation records skipped during migration (non-object input or schema rejection). */
   droppedAnnotations: number;
-  /** Number of reply records the migration had to skip (same criteria). */
+  /** Count of reply records skipped during migration (same criteria). */
   droppedReplies: number;
 }
 
@@ -245,9 +245,11 @@ export interface MigrationResult {
  *
  * Expects `raw` to be roughly `{ annotations?: unknown[]; replies?: unknown[] }`.
  * Anything unrecognized is coerced; invalid records are skipped and tallied
- * in `droppedAnnotations`/`droppedReplies` so callers can surface data loss
- * rather than silently discarding records. The full v1 → vN migration
- * framework is deferred to #320.
+ * in `droppedAnnotations` / `droppedReplies` so callers can surface data loss
+ * rather than silently discarding records. As a second line of defense, a
+ * single `console.error` fires when any records are dropped — without it a
+ * caller that forgets to destructure the counts would lose the data-loss
+ * signal entirely. The full v1 → vN migration framework is deferred.
  */
 export function migrateToV1(raw: unknown): MigrationResult {
   const src = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
@@ -280,6 +282,12 @@ export function migrateToV1(raw: unknown): MigrationResult {
     const parsed = AnnotationReplyRecordSchemaV1.safeParse(withRev);
     if (parsed.success) replies.push(parsed.data);
     else droppedReplies++;
+  }
+
+  if (droppedAnnotations > 0 || droppedReplies > 0) {
+    console.error(
+      `[ANNOTATION-STORE] migrateToV1 dropped ${droppedAnnotations} annotation(s) and ${droppedReplies} reply/replies as malformed`,
+    );
   }
 
   return {

--- a/src/server/annotations/schema.ts
+++ b/src/server/annotations/schema.ts
@@ -224,6 +224,15 @@ export function parseAnnotationDoc(raw: unknown): ParseAnnotationDocResult {
   return { ok: true, doc: result.data };
 }
 
+/** Result of `migrateToV1`. Drop counts let callers surface lossy upgrades. */
+export interface MigrationResult {
+  doc: AnnotationDocV1;
+  /** Number of annotation records the migration had to skip (non-object input or schema rejection). */
+  droppedAnnotations: number;
+  /** Number of reply records the migration had to skip (same criteria). */
+  droppedReplies: number;
+}
+
 /**
  * Best-effort migration from a legacy session-blob–shaped object (no `rev`,
  * no `tombstones`, no `docHash`, no `meta`) into the v1 envelope shape.
@@ -235,38 +244,54 @@ export function parseAnnotationDoc(raw: unknown): ParseAnnotationDocResult {
  *   - `meta: { filePath: "", lastUpdated: 0 }` (caller overrides)
  *
  * Expects `raw` to be roughly `{ annotations?: unknown[]; replies?: unknown[] }`.
- * Anything unrecognized is coerced; invalid records are skipped silently —
- * this is a lossy upgrade path, not a strict validator.
- *
- * NOTE: Phase 1 ships only this single migration function. The general
- * v1 → vN migration framework is deferred to issue #320.
+ * Anything unrecognized is coerced; invalid records are skipped and tallied
+ * in `droppedAnnotations`/`droppedReplies` so callers can surface data loss
+ * rather than silently discarding records. The full v1 → vN migration
+ * framework is deferred to #320.
  */
-export function migrateToV1(raw: unknown): AnnotationDocV1 {
+export function migrateToV1(raw: unknown): MigrationResult {
   const src = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
 
   const annotationsIn = Array.isArray(src.annotations) ? src.annotations : [];
   const repliesIn = Array.isArray(src.replies) ? src.replies : [];
 
-  const annotations = annotationsIn.flatMap((ann): AnnotationRecordV1[] => {
-    if (!ann || typeof ann !== "object") return [];
+  let droppedAnnotations = 0;
+  let droppedReplies = 0;
+
+  const annotations: AnnotationRecordV1[] = [];
+  for (const ann of annotationsIn) {
+    if (!ann || typeof ann !== "object") {
+      droppedAnnotations++;
+      continue;
+    }
     const withRev = { rev: 0, ...(ann as object) };
     const parsed = AnnotationRecordSchemaV1.safeParse(withRev);
-    return parsed.success ? [parsed.data] : [];
-  });
+    if (parsed.success) annotations.push(parsed.data);
+    else droppedAnnotations++;
+  }
 
-  const replies = repliesIn.flatMap((r): AnnotationReplyRecordV1[] => {
-    if (!r || typeof r !== "object") return [];
+  const replies: AnnotationReplyRecordV1[] = [];
+  for (const r of repliesIn) {
+    if (!r || typeof r !== "object") {
+      droppedReplies++;
+      continue;
+    }
     const withRev = { rev: 0, ...(r as object) };
     const parsed = AnnotationReplyRecordSchemaV1.safeParse(withRev);
-    return parsed.success ? [parsed.data] : [];
-  });
+    if (parsed.success) replies.push(parsed.data);
+    else droppedReplies++;
+  }
 
   return {
-    schemaVersion: SCHEMA_VERSION,
-    docHash: "",
-    meta: { filePath: "", lastUpdated: 0 },
-    annotations,
-    tombstones: [],
-    replies,
+    doc: {
+      schemaVersion: SCHEMA_VERSION,
+      docHash: "",
+      meta: { filePath: "", lastUpdated: 0 },
+      annotations,
+      tombstones: [],
+      replies,
+    },
+    droppedAnnotations,
+    droppedReplies,
   };
 }

--- a/src/server/annotations/sync.ts
+++ b/src/server/annotations/sync.ts
@@ -56,6 +56,8 @@
 
 import * as Y from "yjs";
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
+import { type RawAnnotation, sanitizeAnnotation } from "../../shared/sanitize.js";
+import { AnnotationTypeSchema } from "../../shared/types.js";
 import { FILE_SYNC_ORIGIN } from "../events/queue.js";
 import {
   type AnnotationDocV1,
@@ -94,21 +96,43 @@ const tombstonesByDoc = new Map<string, TombstoneRecordV1[]>();
 // Serialization
 // ---------------------------------------------------------------------------
 
+const CANONICAL_TYPES = new Set<string>(AnnotationTypeSchema.options);
+const loggedLegacyDocs = new Set<string>();
+
 /**
  * Normalize a Y.Map annotation value into an `AnnotationRecordV1`. Supplies
- * `rev: 0` for legacy session-blob entries that lack the field. All other
- * fields pass through unchanged — the Zod schema validates on parse, not
- * here (this is called on the write path, where we trust the Y.Map state).
+ * `rev: 0` for legacy session-blob entries that lack the field.
  *
- * Fast path: records that already carry a numeric `rev` are returned as-is
- * (cast only). The vast majority of post-migration traffic hits this path,
- * so we skip the object-spread allocation.
+ * Records with a non-canonical `type` (e.g. pre-canonicalization `"suggestion"`
+ * or `"question"`) are routed through `sanitizeAnnotation` which rewrites
+ * them to `"comment"`. Without this, the next `parseAnnotationDoc` would
+ * reject the file and self-quarantine the envelope. The Y.Map value is NOT
+ * rewritten in place, so every subsequent snapshot of a legacy record re-runs
+ * the sanitize spread until a user action overwrites the entry — acceptable
+ * cost given the small record count and infrequent snapshots.
+ *
+ * Fast path for the common case (canonical type + numeric rev) skips the
+ * spread/sanitize entirely — `snapshot()` runs once per debounced write
+ * across every annotation in the doc, so the hot path stays tight.
  */
-function normalizeAnnotation(raw: unknown): AnnotationRecordV1 | null {
+function normalizeAnnotation(raw: unknown, docHash?: string): AnnotationRecordV1 | null {
   if (!raw || typeof raw !== "object") return null;
   const obj = raw as Record<string, unknown> & Partial<AnnotationRecordV1>;
-  if (typeof obj.rev === "number") return obj as AnnotationRecordV1;
-  return { ...(obj as AnnotationRecordV1), rev: 0 };
+  const isCanonical = CANONICAL_TYPES.has(obj.type as string);
+  if (typeof obj.rev === "number" && isCanonical) return obj as AnnotationRecordV1;
+
+  if (!isCanonical && docHash && !loggedLegacyDocs.has(docHash)) {
+    loggedLegacyDocs.add(docHash);
+    console.error(
+      `[ANNOTATION-STORE] upgrading legacy annotation type in ${docHash} to "comment" on write`,
+    );
+  }
+
+  const sanitized = sanitizeAnnotation(obj as unknown as RawAnnotation);
+  return {
+    ...sanitized,
+    rev: typeof obj.rev === "number" ? obj.rev : 0,
+  } as unknown as AnnotationRecordV1;
 }
 
 function normalizeReply(raw: unknown): AnnotationReplyRecordV1 | null {
@@ -130,7 +154,7 @@ function snapshot(ydoc: Y.Doc, docHash: string, meta: SyncMeta): AnnotationDocV1
 
   const annotations: AnnotationRecordV1[] = [];
   for (const value of annMap.values()) {
-    const rec = normalizeAnnotation(value);
+    const rec = normalizeAnnotation(value, docHash);
     if (rec) annotations.push(rec);
   }
 
@@ -205,6 +229,9 @@ export function registerAnnotationObserver(
     repMap.unobserve(onMutation);
     if (phase === "close") {
       tombstonesByDoc.delete(docHash);
+      // Drop the dedupe flag so a subsequent reopen can log once again —
+      // matches "close" semantics (fresh context on next open).
+      loggedLegacyDocs.delete(docHash);
     }
   };
 }
@@ -415,7 +442,7 @@ export async function loadAndMerge(
     // Apply tombstones first so a later merge step can't overwrite a winning
     // delete.
     for (const stone of file.tombstones) {
-      const ymapAnn = normalizeAnnotation(annMap.get(stone.id));
+      const ymapAnn = normalizeAnnotation(annMap.get(stone.id), docHash);
       if (!ymapAnn) continue;
       if (stone.rev > ymapAnn.rev) {
         annMap.delete(stone.id);
@@ -437,7 +464,7 @@ export async function loadAndMerge(
       if (fileAnn && stone.rev > fileAnn.rev) winningTombstoneIds.add(stone.id);
     }
 
-    const annResult = mergeMap(annMap, fileAnns, normalizeAnnotation, {
+    const annResult = mergeMap(annMap, fileAnns, (raw) => normalizeAnnotation(raw, docHash), {
       shouldSkipInsert: (id) => winningTombstoneIds.has(id),
       ymapOnlyIgnoreIds: tombstoneIds,
     });
@@ -462,4 +489,5 @@ export async function loadAndMerge(
 /** Reset all module state. Tests only — never call in production. */
 export function resetForTesting(): void {
   tombstonesByDoc.clear();
+  loggedLegacyDocs.clear();
 }

--- a/src/server/annotations/sync.ts
+++ b/src/server/annotations/sync.ts
@@ -103,17 +103,17 @@ const loggedLegacyDocs = new Set<string>();
  * Normalize a Y.Map annotation value into an `AnnotationRecordV1`. Supplies
  * `rev: 0` for legacy session-blob entries that lack the field.
  *
- * Records with a non-canonical `type` (e.g. pre-canonicalization `"suggestion"`
- * or `"question"`) are routed through `sanitizeAnnotation` which rewrites
- * them to `"comment"`. Without this, the next `parseAnnotationDoc` would
- * reject the file and self-quarantine the envelope. The Y.Map value is NOT
- * rewritten in place, so every subsequent snapshot of a legacy record re-runs
- * the sanitize spread until a user action overwrites the entry — acceptable
- * cost given the small record count and infrequent snapshots.
+ * Records whose `type` is outside `AnnotationTypeSchema.options` are routed
+ * through `sanitizeAnnotation` which rewrites them to `"comment"`. Without
+ * this, the next `parseAnnotationDoc` would reject the file and self-
+ * quarantine the envelope. The Y.Map value is NOT rewritten in place, so
+ * every subsequent snapshot of a legacy record re-runs the sanitize spread
+ * until a user action overwrites the entry — acceptable cost given the
+ * small record count and infrequent snapshots.
  *
  * Fast path for the common case (canonical type + numeric rev) skips the
- * spread/sanitize entirely — `snapshot()` runs once per debounced write
- * across every annotation in the doc, so the hot path stays tight.
+ * spread/sanitize — `snapshot()` runs this across every annotation in the
+ * doc on every debounced write.
  */
 function normalizeAnnotation(raw: unknown, docHash?: string): AnnotationRecordV1 | null {
   if (!raw || typeof raw !== "object") return null;

--- a/src/server/annotations/sync.ts
+++ b/src/server/annotations/sync.ts
@@ -123,6 +123,8 @@ function normalizeAnnotation(raw: unknown, docHash?: string): AnnotationRecordV1
 
   if (!isCanonical && docHash && !loggedLegacyDocs.has(docHash)) {
     loggedLegacyDocs.add(docHash);
+    // TODO(#330): surface this lossy upgrade as a toast / doctor field once
+    // migrateToV1 has a production caller.
     console.error(
       `[ANNOTATION-STORE] upgrading legacy annotation type in ${docHash} to "comment" on write`,
     );

--- a/tests/server/annotations/schema.test.ts
+++ b/tests/server/annotations/schema.test.ts
@@ -194,7 +194,7 @@ describe("migrateToV1", () => {
       ],
     };
 
-    const migrated = migrateToV1(legacy);
+    const { doc: migrated, droppedAnnotations, droppedReplies } = migrateToV1(legacy);
 
     expect(migrated.schemaVersion).toBe(SCHEMA_VERSION);
     expect(migrated.docHash).toBe("");
@@ -210,6 +210,9 @@ describe("migrateToV1", () => {
     expect(migrated.replies).toHaveLength(1);
     expect(migrated.replies[0]?.rev).toBe(0);
     expect(migrated.replies[0]?.text).toBe("sounds good");
+
+    expect(droppedAnnotations).toBe(0);
+    expect(droppedReplies).toBe(0);
   });
 
   it("produces a doc that passes full v1 validation", () => {
@@ -227,17 +230,19 @@ describe("migrateToV1", () => {
       ],
       replies: [],
     };
-    const migrated = migrateToV1(legacy);
+    const { doc: migrated } = migrateToV1(legacy);
     const round = AnnotationDocSchemaV1.safeParse(migrated);
     expect(round.success).toBe(true);
   });
 
   it("tolerates completely empty input", () => {
-    const migrated = migrateToV1({});
+    const { doc: migrated, droppedAnnotations, droppedReplies } = migrateToV1({});
     expect(migrated.annotations).toEqual([]);
     expect(migrated.replies).toEqual([]);
     expect(migrated.tombstones).toEqual([]);
     expect(migrated.schemaVersion).toBe(1);
+    expect(droppedAnnotations).toBe(0);
+    expect(droppedReplies).toBe(0);
   });
 
   it("skips malformed annotation records silently (lossy upgrade)", () => {
@@ -266,16 +271,18 @@ describe("migrateToV1", () => {
         "garbage",
       ],
     };
-    const migrated = migrateToV1(legacy);
+    const { doc: migrated, droppedAnnotations } = migrateToV1(legacy);
     expect(migrated.annotations).toHaveLength(1);
     expect(migrated.annotations[0]?.id).toBe("good");
+    // Two invalid records (missing id, "garbage" string) → counted as drops.
+    expect(droppedAnnotations).toBe(2);
   });
 
   it("tolerates non-object input without throwing", () => {
     expect(() => migrateToV1(null)).not.toThrow();
     expect(() => migrateToV1("nope")).not.toThrow();
     expect(() => migrateToV1(42)).not.toThrow();
-    const migrated = migrateToV1(null);
+    const { doc: migrated } = migrateToV1(null);
     expect(migrated.annotations).toEqual([]);
   });
 });

--- a/tests/server/annotations/schema.test.ts
+++ b/tests/server/annotations/schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   AnnotationDocSchemaV1,
   type AnnotationDocV1,
@@ -245,7 +245,8 @@ describe("migrateToV1", () => {
     expect(droppedReplies).toBe(0);
   });
 
-  it("skips malformed annotation records silently (lossy upgrade)", () => {
+  it("skips malformed annotation records (lossy upgrade, tallied in droppedAnnotations)", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const legacy = {
       annotations: [
         // Valid
@@ -276,6 +277,7 @@ describe("migrateToV1", () => {
     expect(migrated.annotations[0]?.id).toBe("good");
     // Two invalid records (missing id, "garbage" string) → counted as drops.
     expect(droppedAnnotations).toBe(2);
+    errorSpy.mockRestore();
   });
 
   it("tolerates non-object input without throwing", () => {
@@ -284,6 +286,61 @@ describe("migrateToV1", () => {
     expect(() => migrateToV1(42)).not.toThrow();
     const { doc: migrated } = migrateToV1(null);
     expect(migrated.annotations).toEqual([]);
+  });
+
+  it("counts reply drops separately from annotation drops", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const legacy = {
+      annotations: [],
+      replies: [
+        // Valid
+        {
+          id: "rep_good",
+          annotationId: "ann_1",
+          author: "user",
+          text: "ok",
+          timestamp: 1,
+        },
+        // Invalid — not an object
+        "garbage",
+        // Invalid — missing required fields
+        { author: "user" },
+      ],
+    };
+    const { droppedAnnotations, droppedReplies, doc } = migrateToV1(legacy);
+    expect(droppedAnnotations).toBe(0);
+    expect(droppedReplies).toBe(2);
+    expect(doc.replies).toHaveLength(1);
+    expect(doc.replies[0]?.id).toBe("rep_good");
+    errorSpy.mockRestore();
+  });
+
+  it("treats non-array annotations/replies as empty (no drops attributed)", () => {
+    const { droppedAnnotations, droppedReplies, doc } = migrateToV1({
+      annotations: "not-an-array",
+      replies: 42,
+    });
+    expect(droppedAnnotations).toBe(0);
+    expect(droppedReplies).toBe(0);
+    expect(doc.annotations).toEqual([]);
+    expect(doc.replies).toEqual([]);
+  });
+
+  it("logs once when any records are dropped (future-caller safety net)", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    migrateToV1({
+      annotations: [null, "garbage"],
+      replies: [{ author: "user" }],
+    });
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[0]).toMatch(/migrateToV1/);
+
+    errorSpy.mockClear();
+    // Clean input → no log.
+    migrateToV1({});
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
   });
 });
 

--- a/tests/server/annotations/store.test.ts
+++ b/tests/server/annotations/store.test.ts
@@ -47,10 +47,10 @@ function makeDoc(
   filePath: string,
   overrides: Partial<AnnotationDocV1> = {},
 ): AnnotationDocV1 {
-  const base = migrateToV1({});
-  base.docHash = docHash;
-  base.meta = { filePath, lastUpdated: Date.now() };
-  return { ...base, ...overrides };
+  const { doc } = migrateToV1({});
+  doc.docHash = docHash;
+  doc.meta = { filePath, lastUpdated: Date.now() };
+  return { ...doc, ...overrides };
 }
 
 let tmpRoot: string;

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -26,6 +26,7 @@ import {
   type AnnotationRecordV1,
   type AnnotationReplyRecordV1,
   migrateToV1,
+  parseAnnotationDoc,
   SCHEMA_VERSION,
 } from "../../../src/server/annotations/schema.js";
 import type { DocStore } from "../../../src/server/annotations/store.js";
@@ -273,6 +274,125 @@ describe("registerAnnotationObserver", () => {
 
     await store.flush();
     expect(queueSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy-type sanitize-on-write
+// ---------------------------------------------------------------------------
+
+describe("legacy-type sanitize on write", () => {
+  it("rewrites a non-canonical type to 'comment' so the envelope stays loadable", async () => {
+    const ydoc = new Y.Doc();
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    // The legacy-type branch emits `console.error`; silence for this assertion.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cleanup = registerAnnotationObserver(syncCtx(ydoc, store));
+
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    // A pre-canonicalization record — `AnnotationTypeSchema` no longer accepts
+    // "suggestion", so without sanitize-on-write this envelope would Zod-reject
+    // on the next load and end up quarantined to `.json.future`.
+    const legacy = {
+      ...annRecord({ id: "ann_legacy" }),
+      type: "suggestion",
+      suggestedText: "canonical form",
+      content: "a rationale string, not JSON",
+    };
+    ydoc.transact(() => annMap.set("ann_legacy", legacy), MCP_ORIGIN);
+
+    await store.flush();
+
+    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const onDisk = JSON.parse(raw);
+    expect(onDisk.annotations).toHaveLength(1);
+    expect(onDisk.annotations[0].type).toBe("comment");
+
+    // The critical invariant: the envelope we just wrote must round-trip
+    // cleanly through the v1 parser. If this assertion ever regresses, the
+    // durable store will self-quarantine on the next open.
+    const parsed = parseAnnotationDoc(raw);
+    expect(parsed.ok).toBe(true);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    cleanup();
+    errorSpy.mockRestore();
+  });
+
+  it("dedupes the upgrade warning to once per docHash per session", async () => {
+    const ydoc = new Y.Doc();
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cleanup = registerAnnotationObserver(syncCtx(ydoc, store));
+
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    ydoc.transact(() => {
+      annMap.set("a1", { ...annRecord({ id: "a1" }), type: "suggestion" });
+      annMap.set("a2", { ...annRecord({ id: "a2" }), type: "question" });
+    }, MCP_ORIGIN);
+    await store.flush();
+
+    // Two legacy records, one docHash → exactly one warning.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    cleanup();
+    errorSpy.mockRestore();
+  });
+
+  it("close-phase cleanup lets the next open log once again", async () => {
+    const ydoc = new Y.Doc();
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const cleanup1 = registerAnnotationObserver(syncCtx(ydoc, store));
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    ydoc.transact(
+      () => annMap.set("a1", { ...annRecord({ id: "a1" }), type: "suggestion" }),
+      MCP_ORIGIN,
+    );
+    await store.flush();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    cleanup1("close");
+
+    // Fresh observer for the same docHash — dedupe state should have been
+    // cleared so a further legacy record emits a new warning.
+    const cleanup2 = registerAnnotationObserver(syncCtx(ydoc, store));
+    ydoc.transact(
+      () => annMap.set("a2", { ...annRecord({ id: "a2" }), type: "question" }),
+      MCP_ORIGIN,
+    );
+    await store.flush();
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+
+    cleanup2("close");
+    errorSpy.mockRestore();
+  });
+
+  it("swap-phase cleanup preserves dedupe so a Y.Doc swap doesn't spam", async () => {
+    const ydoc = new Y.Doc();
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const cleanup1 = registerAnnotationObserver(syncCtx(ydoc, store));
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    ydoc.transact(
+      () => annMap.set("a1", { ...annRecord({ id: "a1" }), type: "suggestion" }),
+      MCP_ORIGIN,
+    );
+    await store.flush();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    cleanup1("swap");
+
+    const cleanup2 = registerAnnotationObserver(syncCtx(ydoc, store));
+    ydoc.transact(
+      () => annMap.set("a2", { ...annRecord({ id: "a2" }), type: "question" }),
+      MCP_ORIGIN,
+    );
+    await store.flush();
+    // Same docHash, swap semantics → no additional warning.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+
+    cleanup2("close");
+    errorSpy.mockRestore();
   });
 });
 

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -395,6 +395,33 @@ describe("legacy-type sanitize on write", () => {
     errorSpy.mockRestore();
   });
 
+  it("preserves the original rev value through the sanitize branch (not zeroed)", async () => {
+    const ydoc = new Y.Doc();
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cleanup = registerAnnotationObserver(syncCtx(ydoc, store));
+
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    // Use a nonzero rev so a regression that resets to 0 is detectable.
+    ydoc.transact(
+      () =>
+        annMap.set("ann_rev_check", {
+          ...annRecord({ id: "ann_rev_check", rev: 7 }),
+          type: "suggestion",
+        }),
+      MCP_ORIGIN,
+    );
+
+    await store.flush();
+
+    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const onDisk = JSON.parse(raw);
+    expect(onDisk.annotations[0].rev).toBe(7);
+
+    cleanup();
+    errorSpy.mockRestore();
+  });
+
   it("loadAndMerge logs legacy-type upgrade when Y.Map has a non-canonical type that beats the file", async () => {
     // Seed the Y.Map with a legacy-typed annotation at rev:2 (as session-restore
     // would leave it). The Y.Map wins the merge — no file-side overwrite — so

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -47,6 +47,8 @@ import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../../src/shared
 
 const HASH_A = "a".repeat(64);
 const FILE_A = "/virtual/doc-a.md";
+const HASH_B = "b".repeat(64);
+const FILE_B = "/virtual/doc-b.md";
 
 function annRecord(overrides: Partial<AnnotationRecordV1> = {}): AnnotationRecordV1 {
   return {
@@ -419,6 +421,43 @@ describe("legacy-type sanitize on write", () => {
     expect(onDisk.annotations[0].rev).toBe(7);
 
     cleanup();
+    errorSpy.mockRestore();
+  });
+
+  it("dedupes independently per docHash (two docs each log once)", async () => {
+    const ydocA = new Y.Doc();
+    const storeA = createStore(HASH_A, { filePath: FILE_A });
+    const ydocB = new Y.Doc();
+    const storeB = createStore(HASH_B, { filePath: FILE_B });
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const cleanupA = registerAnnotationObserver(syncCtx(ydocA, storeA));
+    const cleanupB = registerAnnotationObserver(
+      syncCtx(ydocB, storeB, { docHash: HASH_B, meta: { filePath: FILE_B } }),
+    );
+
+    const annMapA = ydocA.getMap(Y_MAP_ANNOTATIONS);
+    const annMapB = ydocB.getMap(Y_MAP_ANNOTATIONS);
+
+    ydocA.transact(
+      () => annMapA.set("a1", { ...annRecord({ id: "a1" }), type: "suggestion" }),
+      MCP_ORIGIN,
+    );
+    ydocB.transact(
+      () => annMapB.set("b1", { ...annRecord({ id: "b1" }), type: "question" }),
+      MCP_ORIGIN,
+    );
+
+    await storeA.flush();
+    await storeB.flush();
+
+    // Two different docHashes → two independent log entries.
+    // If dedupe collapsed to a single boolean, the second would be suppressed.
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+
+    cleanupA();
+    cleanupB();
     errorSpy.mockRestore();
   });
 

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -394,6 +394,46 @@ describe("legacy-type sanitize on write", () => {
     cleanup2("close");
     errorSpy.mockRestore();
   });
+
+  it("loadAndMerge logs legacy-type upgrade when Y.Map has a non-canonical type that beats the file", async () => {
+    // Seed the Y.Map with a legacy-typed annotation at rev:2 (as session-restore
+    // would leave it). The Y.Map wins the merge — no file-side overwrite — so
+    // normalizeAnnotation runs against this Y.Map value at the file-vs-ymap
+    // comparison site (sync.ts ~line 438).
+    const ydoc = new Y.Doc();
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    annMap.set("ann_legacy_merge", {
+      ...annRecord({ id: "ann_legacy_merge", rev: 2 }),
+      type: "suggestion",
+    });
+
+    // Pre-write a file with a CANONICAL-typed record at rev:1 so the file
+    // parses cleanly (type:"suggestion" in the file body would Zod-reject as
+    // corrupt and route through the quarantine path, bypassing the merge loop).
+    // Y.Map rev:2 > file rev:1, so Y.Map wins and the legacy-typed Y.Map entry
+    // is the input to normalizeAnnotation at line ~438.
+    const store0 = createStore(HASH_A, { filePath: FILE_A });
+    store0.queueWrite(() =>
+      makeFile(HASH_A, FILE_A, {
+        annotations: [annRecord({ id: "ann_legacy_merge", rev: 1 })],
+      }),
+    );
+    await store0.flush();
+    resetStoreForTesting();
+
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const cleanup = await loadAndMerge(syncCtx(ydoc, store));
+
+    // Without the docHash fix, normalizeAnnotation is called without docHash
+    // and the guard `if (!isCanonical && docHash && ...)` short-circuits → 0.
+    // With the fix, docHash is passed and the log fires → 1.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    errorSpy.mockRestore();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -321,6 +321,38 @@ describe("legacy-type sanitize on write", () => {
     errorSpy.mockRestore();
   });
 
+  it("rewrites 'question' type to 'comment' with directedAt preserved, envelope stays loadable", async () => {
+    const ydoc = new Y.Doc();
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cleanup = registerAnnotationObserver(syncCtx(ydoc, store));
+
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    ydoc.transact(
+      () =>
+        annMap.set("ann_question", {
+          ...annRecord({ id: "ann_question", rev: 3 }),
+          type: "question",
+        }),
+      MCP_ORIGIN,
+    );
+
+    await store.flush();
+
+    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const onDisk = JSON.parse(raw);
+    expect(onDisk.annotations[0].type).toBe("comment");
+    expect(onDisk.annotations[0].directedAt).toBe("claude");
+
+    // Envelope must parse cleanly — regression here means the store would
+    // self-quarantine on the next open.
+    const parsed = parseAnnotationDoc(raw);
+    expect(parsed.ok).toBe(true);
+
+    cleanup();
+    errorSpy.mockRestore();
+  });
+
   it("dedupes the upgrade warning to once per docHash per session", async () => {
     const ydoc = new Y.Doc();
     const store = createStore(HASH_A, { filePath: FILE_A });

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -78,10 +78,10 @@ function makeFile(
   filePath: string,
   overrides: Partial<AnnotationDocV1> = {},
 ): AnnotationDocV1 {
-  const base = migrateToV1({});
-  base.docHash = docHash;
-  base.meta = { filePath, lastUpdated: Date.now() };
-  return { ...base, ...overrides };
+  const { doc } = migrateToV1({});
+  doc.docHash = docHash;
+  doc.meta = { filePath, lastUpdated: Date.now() };
+  return { ...doc, ...overrides };
 }
 
 function syncCtx(ydoc: Y.Doc, store: DocStore, overrides: Partial<SyncContext> = {}): SyncContext {


### PR DESCRIPTION
## Summary

Bundle C from the [v0.6.3 release plan](docs/plans/2026-04-17-v0.6.3-release.md#bundle-c--annotation-observability-with-changelog-caveats) — two small annotation-observability changes that harden the Phase 1 durable envelope. Closes #329, closes #330.

- **#329 — sanitize legacy types on write.** `normalizeAnnotation` in `src/server/annotations/sync.ts` routes records whose `type` is outside the canonical `highlight` / `comment` / `flag` set (e.g. legacy `"suggestion"` / `"question"`) through `sanitizeAnnotation` before serializing. Previously those values were written verbatim to disk and the next `parseAnnotationDoc` would Zod-reject the envelope and quarantine it to `.json.future`. **One-way lossy upgrade to `"comment"` on next write** — the CHANGELOG entry documents this caveat. Legacy-detection logs `console.error` once per docHash per session (dedupe flag cleared on doc close).

- **#330 — `migrateToV1` drop counter.** Return signature now `{ doc, droppedAnnotations, droppedReplies }` instead of just the doc, so a future caller can surface lossy upgrades to users rather than silently discarding malformed records. **Surfacing deferred to #330:** `migrateToV1` has no production caller today. The user-visible path (toast / `npm run doctor` field) lands with the first production caller. A `// TODO(#330)` anchor at the log site makes the deferral visible to future reviewers.

### Review fixes (post-review)
Four findings from the code review addressed:
1. **Bug fix:** `normalizeAnnotation` in `loadAndMerge` now receives `docHash` at both call sites (tombstone loop + file-vs-ymap comparison). Previously the legacy-type upgrade log was silently suppressed on the merge path.
2. **Test:** `rev: 7` fixture pins that `rev` survives the sanitize branch (prior tests used `rev: 0`, making a drop-rev regression undetectable).
3. **Test:** Two-docHash fixture (`HASH_A` + `HASH_B`) pins that `loggedLegacyDocs` is truly keyed per-docHash (a single boolean would pass prior tests).
4. **Test:** "question"→"comment" rewrite now has an on-disk field assertion (`directedAt: "claude"`) and `parseAnnotationDoc` round-trip check.

### Simplify pass
Three parallel agents (reuse / quality / efficiency) converged on three fixes that landed before commit:
1. `CANONICAL_TYPES` derives from `AnnotationTypeSchema.options` instead of a hardcoded string set, so it stays in sync if the canonical enum shifts again.
2. Stripped `(#329)` / `(#330)` inline tags from comments + log messages (per CLAUDE.md "don't reference the current task").
3. `loggedLegacyDocs` dedupe cleared on the `"close"` cleanup phase so a reopen can log once again.

### Verification
- `npm run typecheck` — clean.
- `npx vitest run tests/server/annotations/` — 91 passed, 1 skipped.

## Test plan

- [x] Typecheck passes.
- [x] All annotation tests (schema + store + sync + migration) green.
- [x] Drop counts verified in `tests/server/annotations/schema.test.ts`: malformed-input suite asserts `droppedAnnotations === 2` when two invalid records are fed to `migrateToV1`.
- [x] Legacy-type upgrade verified: `suggestion`→`comment` round-trip + `question`→`comment` + `directedAt` field assertions.
- [x] `rev` preservation through sanitize branch (nonzero fixture).
- [x] Per-docHash dedupe keying (two-hash fixture).
- [x] `loadAndMerge` path logs legacy-type upgrade (docHash threading fix).
- [ ] Post-merge: verify `npm run doctor` annotation-health section still reports correctly (no changes to `scripts/doctor.mjs` in this PR — drop-counter field deferred to #330).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
