### PR TITLE
fix(settings): center popover and cap height (#306)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -254,7 +254,7 @@ export default function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const settingsBtnRef = useRef<HTMLButtonElement | null>(null);
 
-  const openAtButton = useCallback(() => {
+  const openSettings = useCallback(() => {
     setSettingsOpen(true);
   }, []);
   const settingsOpenRef = useRef(settingsOpen);
@@ -264,8 +264,8 @@ export default function App() {
       setSettingsOpen(false);
       return;
     }
-    openAtButton();
-  }, [openAtButton]);
+    openSettings();
+  }, [openSettings]);
   useSettingsShortcut(toggleSettings);
 
   // Broadcast selection dwell time to CTRL_ROOM so the server uses the user's setting

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -252,11 +252,9 @@ export default function App() {
 
   const { settings, updateSettings } = useTandemSettings();
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [settingsAnchor, setSettingsAnchor] = useState<DOMRect | null>(null);
   const settingsBtnRef = useRef<HTMLButtonElement | null>(null);
 
   const openAtButton = useCallback(() => {
-    setSettingsAnchor(settingsBtnRef.current?.getBoundingClientRect() ?? null);
     setSettingsOpen(true);
   }, []);
   const settingsOpenRef = useRef(settingsOpen);
@@ -939,7 +937,6 @@ export default function App() {
       <SettingsPopover
         open={settingsOpen}
         onClose={() => setSettingsOpen(false)}
-        anchorRect={settingsAnchor}
         settings={settings}
         onUpdate={updateSettings}
         returnFocusRef={settingsBtnRef}

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -18,7 +18,6 @@ import { useUserName } from "../hooks/useUserName";
 interface SettingsPopoverProps {
   open: boolean;
   onClose: () => void;
-  anchorRect: DOMRect | null;
   settings: TandemSettings;
   onUpdate: (partial: Partial<TandemSettings>) => void;
   /** Element to return focus to on close (typically the settings gear button). */
@@ -40,7 +39,6 @@ const FOCUSABLE_SELECTOR =
 export function SettingsPopover({
   open,
   onClose,
-  anchorRect,
   settings,
   onUpdate,
   returnFocusRef,
@@ -161,17 +159,7 @@ export function SettingsPopover({
     return () => window.removeEventListener("keydown", handler);
   }, [open, onClose]);
 
-  if (!open || !anchorRect) return null;
-
-  // Position below the anchor, centered horizontally
-  const left = Math.max(
-    8,
-    Math.min(
-      anchorRect.left + anchorRect.width / 2 - POPOVER_WIDTH / 2,
-      window.innerWidth - POPOVER_WIDTH - 8,
-    ),
-  );
-  const top = anchorRect.bottom + 6;
+  if (!open) return null;
 
   const sectionLabelStyle: React.CSSProperties = {
     fontSize: "11px",
@@ -216,8 +204,11 @@ export function SettingsPopover({
       tabIndex={-1}
       style={{
         position: "fixed",
-        left: `${left}px`,
-        top: `${top}px`,
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        maxHeight: "calc(100vh - 32px)",
+        overflowY: "auto",
         width: `${POPOVER_WIDTH}px`,
         background: "var(--tandem-surface)",
         color: "var(--tandem-fg)",

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -791,6 +791,30 @@ test("dwell-time slider value persists across reload", async ({ page }) => {
   await expect(reloadedSlider).toHaveValue("2000");
 });
 
+test("settings popover stays within viewport on short screens (#306)", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+
+  await page.setViewportSize({ width: 1024, height: 600 });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("[data-testid='settings-btn']").click();
+
+  const popover = page.locator("[data-testid='settings-popover']");
+  await expect(popover).toBeVisible();
+
+  const box = await popover.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box).not.toBeNull();
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
+
+  const scrollable = await popover.evaluate(
+    (el) => el.scrollHeight > el.clientHeight,
+  );
+  expect(scrollable).toBe(true);
+});
+
 // Verifies that selections are buffered server-side and no longer emitted
 // as standalone SSE events (#188). This E2E proves the full pipeline from
 // browser selection → server awareness → SSE endpoint produces no

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -794,7 +794,7 @@ test("dwell-time slider value persists across reload", async ({ page }) => {
 test("settings popover stays within viewport on short screens (#306)", async ({ page }) => {
   await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
 
-  await page.setViewportSize({ width: 1024, height: 600 });
+  await page.setViewportSize({ width: 1024, height: 400 }); // 400px guarantees maxHeight overflow
   await page.goto("/");
   await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
 

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -806,13 +806,16 @@ test("settings popover stays within viewport on short screens (#306)", async ({ 
   const box = await popover.boundingBox();
   const viewport = page.viewportSize();
   expect(box).not.toBeNull();
+  expect(viewport).not.toBeNull();
   expect(box!.y).toBeGreaterThanOrEqual(0);
   expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
 
-  const scrollable = await popover.evaluate(
-    (el) => el.scrollHeight > el.clientHeight,
-  );
-  expect(scrollable).toBe(true);
+  const { overflowed, overflowY } = await popover.evaluate((el) => ({
+    overflowed: el.scrollHeight > el.clientHeight,
+    overflowY: window.getComputedStyle(el).overflowY,
+  }));
+  expect(overflowed).toBe(true);
+  expect(overflowY).toBe("auto");
 });
 
 // Verifies that selections are buffered server-side and no longer emitted


### PR DESCRIPTION
## Summary

- Replaces anchor-relative positioning (`anchorRect.bottom + 6`) with `position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%)` — the popover now opens centered in the viewport
- Adds `maxHeight: calc(100vh - 32px)` + `overflowY: auto` so tall content scrolls rather than clipping off screen at any viewport size
- Removes now-dead `settingsAnchor` state and `getBoundingClientRect()` plumbing from `App.tsx` (~5 lines deleted)
- Adds E2E regression at 1024×400 viewport asserting popover stays fully within viewport bounds and is scrollable

**Design note:** Pivoted from anchor-clamp to centered modal. Centering is simpler, works at all viewport sizes, and matches the existing `role="dialog" aria-modal="true"` semantics.

## Test plan

- [x] `npm run typecheck` — clean
- [x] Popover centers on click (verified in browser at 1568px wide)
- [x] Scrollbar appears and content scrolls at 500px viewport height
- [x] Popover bottom stays within viewport: `top=16px`, `bottom=627px < viewportH=643px`
- [x] Escape key closes popover
- [x] New E2E regression: asserting bounds + scrollable at 1024×400

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)