### PR TITLE
fix(a11y): forced-colors held-badge border + #309 sweep (#309, #311)

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,11 @@
           --tandem-author-user: CanvasText;
           --tandem-author-claude: CanvasText;
         }
+
+        /* Held-count badge uses warning-bg only (no border) — add one so it stays visible. */
+        [data-testid="held-badge"] {
+          border: 1px solid ButtonText;
+        }
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary

Bundle G1 — closes #309 and #311.

**#309 — Stale hex color refs in tests:**
Sweep found no issues. No test files contain `toHaveCSS` color assertions, `rgb()`/`rgba()` color literals, or hardcoded hex values against UI colors. Issue closes as verified-clean post-PR #303.

**#311 — Forced-colors fallback audit:**
Audited all annotation surfaces listed in #311 against the existing `@media (forced-colors: active)` block in `index.html`.

| Surface | Assessment | Action |
|---------|-----------|--------|
| `tandem-suggestion`/`question`/`flag` decorations | border-bottom survives | none |
| Held-annotation banner (SidePanel) | `borderBottom` maps to `CanvasText` | none |
| "Show all" button in held banner | `border` via `--tandem-border-strong` → `CanvasText` | none |
| Toast severity badges | 4px colored `border-left` survives | none |
| Mode toggle (Solo/Tandem) | Active state uses `--tandem-accent` → `Highlight` (system color) | none |
| Bulk-action buttons | `border` via `SMALL_BTN` → `--tandem-border-strong` → `CanvasText` | none |
| **Held-count badge** (`[data-testid="held-badge"]`) | **bg-only pill, no border — loses visual identity** | **fixed** |

Fix: added `[data-testid="held-badge"] { border: 1px solid ButtonText; }` inside the existing `@media (forced-colors: active)` block in `index.html`.

## Test plan

- [ ] Enable Windows High Contrast (or Chromium DevTools → Rendering → Emulate CSS `forced-colors: active`)
- [ ] Open Tandem in Solo mode with held annotations — confirm held-badge pill is visually distinct (has visible border)
- [ ] Confirm mode toggle, bulk-action buttons, and held-announcement banner all remain usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)