### PR TITLE
ci: run checks on all PRs and drop unused tsconfig baseUrl (#310)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 jobs:
   check:

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -10,8 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "noEmit": true,
-    "rootDir": "src",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "include": ["src/server", "src/shared", "src/channel", "src/monitor"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary

- Removes `branches: [master]` from the `pull_request` CI trigger — CI now runs on every PR regardless of its base branch, closing the gap where PR #303 merged with only Socket Security checks running
- Removes `baseUrl: "."` from `tsconfig.server.json` (no path aliases use it) to silence the TS5101 deprecation warning that was blocking `npm run typecheck` on a clean tree

## Root cause

`pull_request: branches: [master]` means "only run CI if the PR *targets* master." PR #303 had a non-master base branch so the entire `check` job was skipped.

## Test plan

- [ ] Open any PR targeting a non-master branch — `check` job now appears in CI
- [ ] `npm run typecheck` passes without TS5101 noise on a clean tree
- [ ] All existing CI jobs (lint, biome, typecheck, unit, build, E2E) still pass on PRs targeting master

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)