### PR TITLE
chore(release): bump version to 0.6.3 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-04-19
+
+### Fixed
+
+- **Annotation GC race on startup (#334)** — `cleanupOrphanedAnnotationFiles` previously ran as a `.then()` chain during boot, racing the boot-path doc opens. On upgrade paths where `sample/welcome.md` or `CHANGELOG.md` hadn't been opened in 30+ days, the GC could unlink the annotation file between read intent and the actual read, silently returning an empty doc. Now `await`-ed before all boot-path opens.
+- **Settings Popover extends out of view (#306)** — centered the popover in the viewport with `transform: translate(-50%, -50%)` and added `maxHeight: calc(100vh - 32px)` + `overflowY: auto` so it is always fully visible and internally scrollable on short screens.
+- **Dark-mode `*-bg` tokens inconsistent (#307)** — `--tandem-success-bg` and `--tandem-warning-bg` in dark mode were hand-coded hex while `--tandem-error-bg` used `color-mix`. All three now use `color-mix(in srgb, var(--tandem-<semantic>) 15%, var(--tandem-surface))` for consistency with light-mode behavior.
+- **stdio bridge silent-failure paths (#336 partial)** — three paths in `src/cli/mcp-stdio.ts` (preflight exit, `http.onclose`, `http.start()` TOCTOU) previously closed stdio without writing a JSON-RPC error, producing "tools never appear in Cowork" with no diagnostics. All three now synthesize `-32000` for any in-flight request ID before exit. Remaining #336 items (channel-shim tests, Windows npx smoke, nits) carry to v0.7.0.
+
 ### Changed
 
-- **Annotation serialization upgrades legacy `type` values on write** (#329) — records with non-canonical `type` (`"suggestion"` / `"question"` / anything outside `highlight` / `comment` / `flag`) are now routed through `sanitizeAnnotation` during snapshot serialization, which rewrites them to `"comment"`. Before this change, a legacy session-restored record would be written verbatim to disk, then fail Zod validation on the next load and quarantine the envelope to `.json.future`. **One-way lossy migration:** users with legacy-type annotations will see `type` flip to `"comment"` on the next durable write for that document — the original distinction between `suggestion` and `question` is not recoverable.
+- **Annotation module internals** — extracted `mergeMap<T>` helper (#324), promoted `UPLOAD_PREFIX` to shared constants (#327), centralized app-data dir resolution in `platform.ts` (#328), extracted `ReplyAuthorSchema`, trimmed module headers, and dropped unused `docContexts` map (#332). No user-facing behavior changes.
+- **Annotation serialization upgrades legacy `type` values on write** (#329) — records with non-canonical `type` (`"suggestion"` / `"question"` / anything outside `highlight` / `comment` / `flag`) are now routed through `sanitizeAnnotation` during snapshot serialization, which rewrites them to `"comment"`. **One-way lossy migration:** users with legacy-type annotations will see `type` flip to `"comment"` on the next durable write for that document — the original distinction between `suggestion` and `question` is not recoverable.
+- **`migrateToV1` reports drop counts** (#330) — `migrateToV1(raw)` now returns `{ doc, droppedAnnotations, droppedReplies }` so future production callers can surface lossy upgrades to users rather than silently discarding malformed records. No production caller exists yet; a follow-up will wire drop counts to `npm run doctor` or a toast when the first caller lands.
 
-### Added
+### Internal
 
-- **`migrateToV1` reports drop counts** (#330) — `migrateToV1(raw)` now returns `{ doc, droppedAnnotations, droppedReplies }` so future production callers can surface lossy upgrades to users rather than silently discarding malformed records. No production caller exists yet (load-time envelope validation goes through `parseAnnotationDoc`, which short-circuits on the v1 schema); a follow-up will wire drop counts to `npm run doctor` or a toast when the first caller lands.
+- Test coverage: `pickWinner`, `SerializedRelPos` edges, UNC paths, upload-path edges (#331); `wireAnnotationStore` perf baseline at 500/1000/5000 annotations (#335).
+- Test sweep: stale hex color refs cleaned up post-PR #303 (#309).
+- Accessibility: forced-colors fallback audit on PR #303 annotation surfaces (#311).
+- CI: typecheck / lint / tests now gate on all PRs regardless of base branch; dropped unused `baseUrl` from `tsconfig.server.json` (#310).
 
 ## [0.6.2] - 2026-04-16
 

--- a/docs/plans/2026-04-17-v0.6.3-release.md
+++ b/docs/plans/2026-04-17-v0.6.3-release.md
@@ -255,6 +255,6 @@ Each PR:
 - [x] Bundle F1 (#306) — PR #357 — MERGED 2026-04-19
 - [x] Bundle F2 (#307) — PR #353 — MERGED 2026-04-19 (#333 triaged, provenance resolved)
 - [x] Bundle G1 (#309, #311) — PR #358 — MERGED 2026-04-19
-- [ ] Bundle G2 (#310) — PR #359 — OPEN
+- [x] Bundle G2 (#310) — PR #359 — MERGED 2026-04-19
 - [ ] Bundle H (version + release) — PR #____
 - [ ] v0.6.3 tagged, GitHub Release published, Tauri updater verified

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -342,12 +342,13 @@ Future hardening (not blocking release):
 
 Plan doc: [`docs/superpowers/plans/2026-04-16-durable-annotations-cowork.md`](superpowers/plans/2026-04-16-durable-annotations-cowork.md). Roadmap issues #313–#322.
 
-### Phase 1 — Durable Annotations in App Data (T1–T8)
+### Phase 1 — Durable Annotations in App Data (T1–T8) — DONE
 
 Moves annotation storage from in-memory Y.Doc + session snapshots to explicit per-document durable JSON under `env-paths` app data. Survives browser/tab loss, tandem-editor reinstalls, OS restarts.
 
 - **T1–T6 (PR #323, merged):** Per-doc on-disk store, migration from session snapshots, load/save wiring, in-memory cache, tests.
-- **T7 + T8 (PR #337):** Content-hashed import annotation IDs for idempotent .docx re-import with dedup, plus `npm run doctor` annotation-health checks and CLAUDE.md Rule #2 rewrite.
+- **T7 + T8 (PR #337, merged):** Content-hashed import annotation IDs for idempotent .docx re-import with dedup, plus `npm run doctor` annotation-health checks and CLAUDE.md Rule #2 rewrite.
+- **Retrospective follow-ups (v0.6.3, merged):** GC race fix (#334), annotation module internals (#324, #327, #328, #332), legacy-type sanitization (#329), drop-counter (#330), test coverage (#331, #335), CI gate (#310), settings popover (#306), dark-mode tokens (#307), a11y sweep (#309, #311), stdio bridge silent-failure paths (#336 partial).
 
 ### Phase 2 — Tauri Multi-Surface Auto-Setup (PRs a–f)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Edit and iterate on documents with Claude — no copy-paste, real-time push via plugin monitor",
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-desktop"
-version = "0.6.2"
+version = "0.6.3"
 description = "Collaborative AI-human document editor"
 authors = ["Bryan Kolb"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "com.tandem.editor",
   "build": {
     "frontendDist": "../dist/client",


### PR DESCRIPTION
## Summary

- Bumps `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml` from `0.6.2` → `0.6.3`
- Promotes `[Unreleased]` to `[0.6.3] - 2026-04-19` in `CHANGELOG.md` with the full release entry (all bundles A, B1, B2, C, D, E1, F1, F2, G1, G2)
- Marks Durable Annotations Phase 1 complete in `docs/roadmap.md`
- Ticks G2 done and H open in the release plan

## What's in 0.6.3

All scope items from the v0.6.3 release plan:

- **Fixed:** GC race on startup (#334), settings popover out-of-view (#306), dark-mode bg token inconsistency (#307), stdio bridge silent-failure paths (#336 partial)
- **Changed:** annotation module internals (#324, #327, #328, #332), legacy-type sanitization (#329), migrateToV1 drop-counter (#330)
- **Internal:** test coverage (#331, #335), test sweep (#309), a11y audit (#311), CI gate (#310)

## After merge

1. `git tag v0.6.3 && git push origin v0.6.3`
2. `gh release create v0.6.3 --notes-from-tag` (or paste CHANGELOG excerpt)
3. Verify Tauri updater `latest.json` publishes

Closes #306, #307, #309, #310, #311, #324, #327, #328, #329, #330, #331, #332, #334, #335, #336

## Test Plan

- [x] Version fields consistent across package.json / tauri.conf.json / Cargo.toml
- [x] CHANGELOG [0.6.3] entry complete and accurate
- [x] CI passes on this PR (all bundles already verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)