### PR TITLE
fix(e2e): stabilize flaky layout-switch timing

### DIFF
--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -268,18 +268,17 @@ test("layout switches between tabbed and three-panel", async ({ page }) => {
   await page.goto("/");
   await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
 
+  // Explicit timeouts on the handle-count assertions below allow React to
+  // finish re-rendering panelLayout state before asserting — prevents flake
+  // under CI load (issue #281).
+  const leftHandle = page.locator("[data-testid='left-panel-resize-handle']");
+  const rightHandle = page.locator("[data-testid='right-panel-resize-handle']");
+  const tabbedHandle = page.locator("[data-testid='panel-resize-handle']");
+
   // Three-panel layout (default) mounts separate left and right handles.
-  // Explicit timeouts allow React to finish re-rendering panelLayout state
-  // before asserting — prevents flake under CI load (issue #281).
-  await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(1, {
-    timeout: 10_000,
-  });
-  await expect(page.locator("[data-testid='right-panel-resize-handle']")).toHaveCount(1, {
-    timeout: 10_000,
-  });
-  await expect(page.locator("[data-testid='panel-resize-handle']")).toHaveCount(0, {
-    timeout: 10_000,
-  });
+  await expect(leftHandle).toHaveCount(1, { timeout: 10_000 });
+  await expect(rightHandle).toHaveCount(1, { timeout: 10_000 });
+  await expect(tabbedHandle).toHaveCount(0, { timeout: 10_000 });
 
   // Switch to tabbed.
   await page.locator("[data-testid='settings-btn']").click();
@@ -288,12 +287,8 @@ test("layout switches between tabbed and three-panel", async ({ page }) => {
 
   // Tabbed layout mounts exactly one resize handle and drops the
   // three-panel handles.
-  await expect(page.locator("[data-testid='panel-resize-handle']")).toHaveCount(1, {
-    timeout: 10_000,
-  });
-  await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(0, {
-    timeout: 10_000,
-  });
+  await expect(tabbedHandle).toHaveCount(1, { timeout: 10_000 });
+  await expect(leftHandle).toHaveCount(0, { timeout: 10_000 });
 
   const tabbedSaved = await page.evaluate((key) => {
     const raw = localStorage.getItem(key);
@@ -303,15 +298,9 @@ test("layout switches between tabbed and three-panel", async ({ page }) => {
 
   // Switch back to three-panel.
   await page.locator("[data-testid='layout-three-panel-btn']").click();
-  await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(1, {
-    timeout: 10_000,
-  });
-  await expect(page.locator("[data-testid='right-panel-resize-handle']")).toHaveCount(1, {
-    timeout: 10_000,
-  });
-  await expect(page.locator("[data-testid='panel-resize-handle']")).toHaveCount(0, {
-    timeout: 10_000,
-  });
+  await expect(leftHandle).toHaveCount(1, { timeout: 10_000 });
+  await expect(rightHandle).toHaveCount(1, { timeout: 10_000 });
+  await expect(tabbedHandle).toHaveCount(0, { timeout: 10_000 });
 });
 
 test("three-panel layout resizes left/right widths independently", async ({ page }) => {

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -269,9 +269,17 @@ test("layout switches between tabbed and three-panel", async ({ page }) => {
   await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
 
   // Three-panel layout (default) mounts separate left and right handles.
-  await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(1);
-  await expect(page.locator("[data-testid='right-panel-resize-handle']")).toHaveCount(1);
-  await expect(page.locator("[data-testid='panel-resize-handle']")).toHaveCount(0);
+  // Explicit timeouts allow React to finish re-rendering panelLayout state
+  // before asserting — prevents flake under CI load (issue #281).
+  await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(1, {
+    timeout: 10_000,
+  });
+  await expect(page.locator("[data-testid='right-panel-resize-handle']")).toHaveCount(1, {
+    timeout: 10_000,
+  });
+  await expect(page.locator("[data-testid='panel-resize-handle']")).toHaveCount(0, {
+    timeout: 10_000,
+  });
 
   // Switch to tabbed.
   await page.locator("[data-testid='settings-btn']").click();
@@ -280,8 +288,12 @@ test("layout switches between tabbed and three-panel", async ({ page }) => {
 
   // Tabbed layout mounts exactly one resize handle and drops the
   // three-panel handles.
-  await expect(page.locator("[data-testid='panel-resize-handle']")).toHaveCount(1);
-  await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(0);
+  await expect(page.locator("[data-testid='panel-resize-handle']")).toHaveCount(1, {
+    timeout: 10_000,
+  });
+  await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(0, {
+    timeout: 10_000,
+  });
 
   const tabbedSaved = await page.evaluate((key) => {
     const raw = localStorage.getItem(key);
@@ -291,9 +303,15 @@ test("layout switches between tabbed and three-panel", async ({ page }) => {
 
   // Switch back to three-panel.
   await page.locator("[data-testid='layout-three-panel-btn']").click();
-  await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(1);
-  await expect(page.locator("[data-testid='right-panel-resize-handle']")).toHaveCount(1);
-  await expect(page.locator("[data-testid='panel-resize-handle']")).toHaveCount(0);
+  await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(1, {
+    timeout: 10_000,
+  });
+  await expect(page.locator("[data-testid='right-panel-resize-handle']")).toHaveCount(1, {
+    timeout: 10_000,
+  });
+  await expect(page.locator("[data-testid='panel-resize-handle']")).toHaveCount(0, {
+    timeout: 10_000,
+  });
 });
 
 test("three-panel layout resizes left/right widths independently", async ({ page }) => {

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -289,6 +289,7 @@ test("layout switches between tabbed and three-panel", async ({ page }) => {
   // three-panel handles.
   await expect(tabbedHandle).toHaveCount(1, { timeout: 10_000 });
   await expect(leftHandle).toHaveCount(0, { timeout: 10_000 });
+  await expect(rightHandle).toHaveCount(0, { timeout: 10_000 });
 
   const tabbedSaved = await page.evaluate((key) => {
     const raw = localStorage.getItem(key);


### PR DESCRIPTION
## Summary

- Raises `toHaveCount` assertion timeouts to `10_000ms` in the flaky \"layout switches between tabbed and three-panel\" E2E test, so Playwright waits for React's re-render to settle after each layout-button click rather than relying on the auto-retry window
- Extracts the three resize-handle locators to named constants at the top of the test (sibling tests already use this pattern)
- Also covers the baseline assertions at L272-274 that run immediately after the editor becomes visible — these had no explicit timeout and were a secondary flake candidate

## Root cause

The test clicked `layout-tabbed-btn` or `layout-three-panel-btn` and immediately asserted DOM handle counts. On slow CI machines, React's `useEffect → setPanelLayout → re-render` cycle takes longer than Playwright's poll interval, causing intermittent assertion failures before auto-retry fires. The existing `toHaveCount` calls already did the right thing structurally — they just needed their timeouts raised to survive load.

## What was NOT changed

No production code. `SettingsPopover.tsx` auto-close-on-layout-change was intentionally skipped — that's a UX behavior change, not needed for test stability.

## Test plan

- [ ] `npm run test:e2e` — full suite green
- [ ] `npx playwright test tests/e2e/settings-and-filters.spec.ts -g "layout switches"` × 10 — 10/10 pass, 0 retries

Closes #281