### PR TITLE
fix(cli): add uncaughtException/unhandledRejection handlers to CLI entries

### DIFF
--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -10,20 +10,12 @@
 import { runChannel } from "./run.js";
 
 process.once("uncaughtException", (err: Error) => {
-  try {
-    process.stderr.write(`[tandem channel] uncaught exception: ${err.message}\n`);
-  } catch {
-    /* EPIPE during teardown — swallow */
-  }
+  process.stderr.write(`[tandem channel] uncaughtException: ${err.message}\n${err.stack ?? ""}\n`);
   process.exit(1);
 });
 process.once("unhandledRejection", (reason: unknown) => {
-  try {
-    const msg = reason instanceof Error ? reason.message : String(reason);
-    process.stderr.write(`[tandem channel] unhandled rejection: ${msg}\n`);
-  } catch {
-    /* EPIPE during teardown — swallow */
-  }
+  const detail = reason instanceof Error ? reason.message : String(reason);
+  process.stderr.write(`[tandem channel] unhandledRejection: ${detail}\n`);
   process.exit(1);
 });
 

--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -9,8 +9,13 @@
 
 import { runChannel } from "./run.js";
 
-process.once("uncaughtException", (err: Error) => {
-  process.stderr.write(`[tandem channel] uncaughtException: ${err.message}\n${err.stack ?? ""}\n`);
+process.once("uncaughtException", (err: unknown) => {
+  const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  try {
+    process.stderr.write(`[tandem channel] uncaughtException: ${msg}\n`);
+  } catch {
+    /* EPIPE */
+  }
   process.exit(1);
 });
 process.once("unhandledRejection", (reason: unknown) => {

--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -9,6 +9,24 @@
 
 import { runChannel } from "./run.js";
 
+process.once("uncaughtException", (err: Error) => {
+  try {
+    process.stderr.write(`[tandem channel] uncaught exception: ${err.message}\n`);
+  } catch {
+    /* EPIPE during teardown — swallow */
+  }
+  process.exit(1);
+});
+process.once("unhandledRejection", (reason: unknown) => {
+  try {
+    const msg = reason instanceof Error ? reason.message : String(reason);
+    process.stderr.write(`[tandem channel] unhandled rejection: ${msg}\n`);
+  } catch {
+    /* EPIPE during teardown — swallow */
+  }
+  process.exit(1);
+});
+
 runChannel().catch((err) => {
   console.error("[Channel] Fatal error:", err);
   process.exit(1);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,20 +13,12 @@
 import updateNotifier from "update-notifier";
 
 process.once("uncaughtException", (err: Error) => {
-  try {
-    process.stderr.write(`[tandem cli] uncaught exception: ${err.message}\n`);
-  } catch {
-    /* EPIPE during teardown — swallow */
-  }
+  process.stderr.write(`[tandem cli] uncaughtException: ${err.message}\n${err.stack ?? ""}\n`);
   process.exit(1);
 });
 process.once("unhandledRejection", (reason: unknown) => {
-  try {
-    const msg = reason instanceof Error ? reason.message : String(reason);
-    process.stderr.write(`[tandem cli] unhandled rejection: ${msg}\n`);
-  } catch {
-    /* EPIPE during teardown — swallow */
-  }
+  const detail = reason instanceof Error ? reason.message : String(reason);
+  process.stderr.write(`[tandem cli] unhandledRejection: ${detail}\n`);
   process.exit(1);
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,8 +12,13 @@
 
 import updateNotifier from "update-notifier";
 
-process.once("uncaughtException", (err: Error) => {
-  process.stderr.write(`[tandem cli] uncaughtException: ${err.message}\n${err.stack ?? ""}\n`);
+process.once("uncaughtException", (err: unknown) => {
+  const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  try {
+    process.stderr.write(`[tandem cli] uncaughtException: ${msg}\n`);
+  } catch {
+    /* EPIPE */
+  }
   process.exit(1);
 });
 process.once("unhandledRejection", (reason: unknown) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,24 @@
 
 import updateNotifier from "update-notifier";
 
+process.once("uncaughtException", (err: Error) => {
+  try {
+    process.stderr.write(`[tandem cli] uncaught exception: ${err.message}\n`);
+  } catch {
+    /* EPIPE during teardown — swallow */
+  }
+  process.exit(1);
+});
+process.once("unhandledRejection", (reason: unknown) => {
+  try {
+    const msg = reason instanceof Error ? reason.message : String(reason);
+    process.stderr.write(`[tandem cli] unhandled rejection: ${msg}\n`);
+  } catch {
+    /* EPIPE during teardown — swallow */
+  }
+  process.exit(1);
+});
+
 // Injected at build time by tsup define; declared here for TypeScript
 declare const __TANDEM_VERSION__: string;
 const version = typeof __TANDEM_VERSION__ !== "undefined" ? __TANDEM_VERSION__ : "0.0.0-dev";


### PR DESCRIPTION
## Summary

- Adds `process.once("uncaughtException", ...)` and `process.once("unhandledRejection", ...)` to `src/channel/index.ts` (the Tauri sidecar) and `src/cli/index.ts` (the `tandem` CLI binary)
- These were the only two process entry points lacking handlers; silent crashes in either path produced no diagnostic output, surfacing to users as "tools never appear"
- `uncaughtException` handler now uses `unknown` type with `instanceof Error` guard — fixes silent `undefined` output when non-Error values are thrown

## Scope clarification (from Phase A classification)

Three of four "critical" items from the original PR #304 review were already fixed in current main:
- `stdio.start()` before preflight — fixed in PR #346 (mcp-stdio.ts:225-246)
- `http.onclose` silent exit 0 — fixed (synthesizes -32000 + exits 1)
- `http.start()` TOCTOU — fixed (try/catch + deferredShutdown grace)

Only the missing process-level handlers remained. Remaining PR #304 nits (Windows npx smoke test, explicit synthesis tests, URL validation, JSDoc cleanup) deferred to v0.7.0.

## Design notes

- Handlers use `err.stack` (not `err.message`) for better crash diagnostics
- Handler format aligned with the existing pattern in `src/cli/mcp-stdio.ts:46-56`
- Handler registration order for `tandem mcp-stdio`: `[tandem cli]` registers in `cli/index.ts` at module top (before the dynamic import), then `[tandem mcp-stdio]` registers in `mcp-stdio.ts:46-56` when that module is dynamically imported. Node.js fires `uncaughtException` listeners in registration order — the `[tandem cli]` handler fires first and calls `process.exit(1)`, terminating the process before `[tandem mcp-stdio]` runs. **For `tandem mcp-stdio` crashes, look for the `[tandem cli]` prefix in stderr, not `[tandem mcp-stdio]`.** The `mcp-stdio.ts:46-56` handlers are retained as specialized context but are shadowed on crash. Longer-term: add conditional registration in v0.7.0.
- No `isKnownHocuspocusError` narrowing: CLI bridges have no Hocuspocus context (CLAUDE.md §Gotchas specifies narrowing only on server paths)

## Test plan

- [ ] `npm run typecheck` clean
- [ ] `npm test` green (1279+ tests)
- [ ] Manual: inject `throw new Error("test sidecar crash")` in `src/channel/index.ts` startup → stderr shows `[tandem channel] uncaughtException: ...`, exits 1
- [ ] Manual: inject crash in `src/cli/index.ts` start dispatch → `[tandem cli] uncaughtException: ...`, exits 1
- [ ] Manual: inject `throw "not-an-error"` (string, not Error) → stderr shows the string value, not `undefined`
- [ ] Revert patches, verify normal `tandem start` startup

Closes #336 (v0.6.4 scope)
