### PR TITLE
fix(cli): add per-request timeout to stdio bridge

### DIFF
--- a/src/cli/mcp-stdio.ts
+++ b/src/cli/mcp-stdio.ts
@@ -125,6 +125,7 @@ export async function runMcpStdio(): Promise<void> {
   }
 
   function forwardToUpstream(msg: JSONRPCMessage): void {
+    if (shuttingDown) return;
     const requestId = getRequestId(msg);
     if (requestId !== undefined) {
       // Clear any existing timer for this id (duplicate/retry scenario).
@@ -182,6 +183,12 @@ export async function runMcpStdio(): Promise<void> {
   ): Promise<never> => {
     if (!shuttingDown) {
       shuttingDown = true;
+      // Hard deadline: if http.close() or stdio.close() hang (e.g., a half-
+      // open upstream holding an SSE GET open), don't let cleanup block the
+      // process exit indefinitely. .unref() means this timer doesn't itself
+      // keep the event loop alive — fast paths resolve and call process.exit
+      // below before the deadline fires; hung paths are forcibly terminated.
+      setTimeout(() => process.exit(code), 2_000).unref();
       // Unconditionally drain all pending timers before any await — prevents
       // orphan timers from firing into the half-closed transport during
       // http.close() / stdio.close() awaits. synthesizePending will also
@@ -222,6 +229,7 @@ export async function runMcpStdio(): Promise<void> {
   };
 
   http.onmessage = (msg: JSONRPCMessage) => {
+    if (shuttingDown) return;
     // Synchronous delete+clear FIRST — before stdio.send — to prevent the
     // per-request timer from firing in the window between response arrival
     // and stdio write completion (which would synthesize a false -32000 for
@@ -234,7 +242,7 @@ export async function runMcpStdio(): Promise<void> {
         pendingRequests.delete(responseId);
       }
     }
-    stdio.send(msg).catch((err: unknown) => {
+    const sendHandler = (err: unknown) => {
       const detail = err instanceof Error ? err.message : String(err);
       process.stderr.write(
         `[tandem mcp-stdio] stdio write failed for id ${responseId ?? "<notification>"}: ${detail}\n`,
@@ -249,7 +257,12 @@ export async function runMcpStdio(): Promise<void> {
         message: "Tandem stdio write failed",
         detail,
       });
-    });
+    };
+    try {
+      stdio.send(msg).catch(sendHandler);
+    } catch (err) {
+      sendHandler(err);
+    }
   };
 
   stdio.onerror = (err) => {
@@ -283,6 +296,14 @@ export async function runMcpStdio(): Promise<void> {
   // the preflight window is captured and either forwarded once upstream is
   // ready, or answered with -32000 if upstream never comes up.
   await stdio.start();
+
+  // The SDK's StdioServerTransport watches stdin for 'data' and 'error' only —
+  // it does not call onclose when the plugin host closes stdin (EOF). Register
+  // our own one-shot listener so that plugin-host close (stdin.end() / HUP)
+  // triggers the same clean shutdown path as stdio.onclose does.
+  process.stdin.once("end", () => {
+    void shutdown(0);
+  });
 
   const probe = await probeTandemServer({ url: baseUrl });
   if (!probe.ok) {

--- a/src/cli/mcp-stdio.ts
+++ b/src/cli/mcp-stdio.ts
@@ -39,9 +39,30 @@ redirectConsoleToStderr();
 // preflight's own fetch timeout.
 const PREFLIGHT_GRACE_MS = 1500;
 
+// Per-request timeout. Node's setTimeout uses a 32-bit signed integer
+// internally — values above this constant are silently clamped to 1ms,
+// which would make every request immediately synthesize -32000.
+const MAX_TIMEOUT_MS = 2_147_483_647; // 2^31 - 1
+
+export function parseTimeoutMs(raw: string | undefined): number {
+  if (raw !== undefined) {
+    const parsed = parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0 && parsed <= MAX_TIMEOUT_MS) {
+      return parsed;
+    }
+    // parseInt("3e4", 10) returns 3, not 30000 — scientific notation is rejected.
+    process.stderr.write(
+      `[tandem mcp-stdio] TANDEM_REQUEST_TIMEOUT_MS must be a positive integer ≤ ${MAX_TIMEOUT_MS}; ignoring "${raw}", using 30000ms default\n`,
+    );
+  }
+  return 30_000;
+}
+
+const STDIO_REQUEST_TIMEOUT_MS = parseTimeoutMs(process.env.TANDEM_REQUEST_TIMEOUT_MS);
+
 // Last-gasp handlers for truly unexpected crashes: write one diagnostic to
 // stderr before exit. Installed at module load; process.once bounds each
-// handler to a single fire. No -32000 synthesis here because pendingIds
+// handler to a single fire. No -32000 synthesis here because pendingRequests
 // lives inside runMcpStdio()'s closure.
 process.once("uncaughtException", (err: Error) => {
   process.stderr.write(
@@ -62,7 +83,10 @@ export async function runMcpStdio(): Promise<void> {
   const stdio = new StdioServerTransport();
 
   // On upstream failure we synthesize -32000 for every entry before exit.
-  const pendingIds = new Set<string | number>();
+  interface PendingEntry {
+    timeoutHandle: ReturnType<typeof setTimeout>;
+  }
+  const pendingRequests = new Map<string | number, PendingEntry>();
   // Messages arriving before httpReady flips; either drained and forwarded
   // on success, or each request answered with -32000 on preflight/http-start
   // failure.
@@ -103,15 +127,31 @@ export async function runMcpStdio(): Promise<void> {
 
   function forwardToUpstream(msg: JSONRPCMessage): void {
     const requestId = getRequestId(msg);
-    if (requestId !== undefined) pendingIds.add(requestId);
+    if (requestId !== undefined) {
+      // Clear any existing timer for this id (duplicate/retry scenario).
+      const existing = pendingRequests.get(requestId);
+      if (existing) clearTimeout(existing.timeoutHandle);
+
+      const timeoutHandle = setTimeout(() => {
+        // Atomic: delete returns false if synthesizePending already drained the map.
+        if (!pendingRequests.delete(requestId)) return;
+        void sendErrorResponse(
+          requestId,
+          "Tandem HTTP upstream not responding (half-open)",
+          `No response after ${STDIO_REQUEST_TIMEOUT_MS}ms`,
+        );
+      }, STDIO_REQUEST_TIMEOUT_MS);
+      pendingRequests.set(requestId, { timeoutHandle });
+    }
     http.send(msg).catch((err: unknown) => {
       const detail = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[tandem mcp-stdio] upstream send failed: ${detail}\n`);
-      // `delete` returns true iff the id was still pending — prevents double-
-      // synth if a future change ever allows synthesizePending to fire while
-      // http.send is still in flight. (Not a current bug; belt-and-suspenders.)
-      if (requestId !== undefined && pendingIds.delete(requestId)) {
-        void sendErrorResponse(requestId, "Tandem HTTP upstream unreachable", detail);
+      if (requestId !== undefined) {
+        const entry = pendingRequests.get(requestId);
+        if (entry && pendingRequests.delete(requestId)) {
+          clearTimeout(entry.timeoutHandle);
+          void sendErrorResponse(requestId, "Tandem HTTP upstream unreachable", detail);
+        }
       }
     });
   }
@@ -127,9 +167,15 @@ export async function runMcpStdio(): Promise<void> {
   }
 
   async function synthesizePending(message: string, detail?: string): Promise<void> {
-    if (pendingIds.size === 0) return;
-    const ids = [...pendingIds];
-    pendingIds.clear();
+    if (pendingRequests.size === 0) return;
+    const ids = [...pendingRequests.keys()];
+    // Synchronous before any await: clear all timers + drain map atomically.
+    // Timer callbacks that are already queued observe empty map and return early.
+    for (const id of ids) {
+      const entry = pendingRequests.get(id);
+      if (entry) clearTimeout(entry.timeoutHandle);
+    }
+    pendingRequests.clear();
     await Promise.all(ids.map((id) => sendErrorResponse(id, message, detail)));
   }
 
@@ -139,6 +185,12 @@ export async function runMcpStdio(): Promise<void> {
   ): Promise<never> => {
     if (!shuttingDown) {
       shuttingDown = true;
+      // Unconditionally drain all pending timers before any await — prevents
+      // orphan timers from firing into the half-closed transport during
+      // http.close() / stdio.close() awaits. synthesizePending will also
+      // drain the map if synth is provided; the clearTimeout calls here are
+      // defensive for the synth=undefined path (e.g., clean stdio.onclose).
+      for (const entry of pendingRequests.values()) clearTimeout(entry.timeoutHandle);
       if (synth) {
         await synthesizeBuffered(synth.message, synth.detail);
         await synthesizePending(synth.message, synth.detail);
@@ -173,20 +225,33 @@ export async function runMcpStdio(): Promise<void> {
   };
 
   http.onmessage = (msg: JSONRPCMessage) => {
+    // Synchronous delete+clear FIRST — before stdio.send — to prevent the
+    // per-request timer from firing in the window between response arrival
+    // and stdio write completion (which would synthesize a false -32000 for
+    // an id that already has a real response in flight).
     const responseId = getResponseId(msg);
+    if (responseId !== undefined) {
+      const entry = pendingRequests.get(responseId);
+      if (entry) {
+        clearTimeout(entry.timeoutHandle);
+        pendingRequests.delete(responseId);
+      }
+    }
     stdio.send(msg).then(
       () => {
-        if (responseId !== undefined) pendingIds.delete(responseId);
+        /* timer already cleared above */
       },
       (err: unknown) => {
         const detail = err instanceof Error ? err.message : String(err);
         process.stderr.write(
           `[tandem mcp-stdio] stdio write failed for id ${responseId ?? "<notification>"}: ${detail}\n`,
         );
-        // Leave responseId in pendingIds — shutdown's synthesizePending will
-        // retry via sendErrorResponse. If stdio is truly gone, that send also
-        // fails and we log twice. Safe delete-after-send narrows the pending
-        // window; it never widens for well-ordered responses.
+        // Map entry already deleted above. Synthesize directly for this id,
+        // then tear down — stdio is broken so other pending requests can't
+        // be delivered either.
+        if (responseId !== undefined) {
+          void sendErrorResponse(responseId, "Tandem stdio write failed", detail);
+        }
         void shutdown(1, {
           message: "Tandem stdio write failed",
           detail,

--- a/src/cli/mcp-stdio.ts
+++ b/src/cli/mcp-stdio.ts
@@ -50,7 +50,8 @@ export function parseTimeoutMs(raw: string | undefined): number {
     if (Number.isFinite(parsed) && parsed > 0 && parsed <= MAX_TIMEOUT_MS) {
       return parsed;
     }
-    // parseInt("3e4", 10) returns 3, not 30000 — scientific notation is rejected.
+    // Note: parseInt("3e4", 10) returns 3 (stops at 'e'), which passes validation.
+    // Scientific notation lands here only when the leading integer is invalid.
     process.stderr.write(
       `[tandem mcp-stdio] TANDEM_REQUEST_TIMEOUT_MS must be a positive integer ≤ ${MAX_TIMEOUT_MS}; ignoring "${raw}", using 30000ms default\n`,
     );
@@ -83,10 +84,8 @@ export async function runMcpStdio(): Promise<void> {
   const stdio = new StdioServerTransport();
 
   // On upstream failure we synthesize -32000 for every entry before exit.
-  interface PendingEntry {
-    timeoutHandle: ReturnType<typeof setTimeout>;
-  }
-  const pendingRequests = new Map<string | number, PendingEntry>();
+  // Value is the per-request timeout handle so we can cancel it on response.
+  const pendingRequests = new Map<string | number, ReturnType<typeof setTimeout>>();
   // Messages arriving before httpReady flips; either drained and forwarded
   // on success, or each request answered with -32000 on preflight/http-start
   // failure.
@@ -130,7 +129,7 @@ export async function runMcpStdio(): Promise<void> {
     if (requestId !== undefined) {
       // Clear any existing timer for this id (duplicate/retry scenario).
       const existing = pendingRequests.get(requestId);
-      if (existing) clearTimeout(existing.timeoutHandle);
+      if (existing) clearTimeout(existing);
 
       const timeoutHandle = setTimeout(() => {
         // Atomic: delete returns false if synthesizePending already drained the map.
@@ -141,15 +140,16 @@ export async function runMcpStdio(): Promise<void> {
           `No response after ${STDIO_REQUEST_TIMEOUT_MS}ms`,
         );
       }, STDIO_REQUEST_TIMEOUT_MS);
-      pendingRequests.set(requestId, { timeoutHandle });
+      pendingRequests.set(requestId, timeoutHandle);
     }
     http.send(msg).catch((err: unknown) => {
       const detail = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[tandem mcp-stdio] upstream send failed: ${detail}\n`);
       if (requestId !== undefined) {
-        const entry = pendingRequests.get(requestId);
-        if (entry && pendingRequests.delete(requestId)) {
-          clearTimeout(entry.timeoutHandle);
+        const handle = pendingRequests.get(requestId);
+        if (handle !== undefined) {
+          pendingRequests.delete(requestId);
+          clearTimeout(handle);
           void sendErrorResponse(requestId, "Tandem HTTP upstream unreachable", detail);
         }
       }
@@ -171,10 +171,7 @@ export async function runMcpStdio(): Promise<void> {
     const ids = [...pendingRequests.keys()];
     // Synchronous before any await: clear all timers + drain map atomically.
     // Timer callbacks that are already queued observe empty map and return early.
-    for (const id of ids) {
-      const entry = pendingRequests.get(id);
-      if (entry) clearTimeout(entry.timeoutHandle);
-    }
+    for (const handle of pendingRequests.values()) clearTimeout(handle);
     pendingRequests.clear();
     await Promise.all(ids.map((id) => sendErrorResponse(id, message, detail)));
   }
@@ -190,7 +187,7 @@ export async function runMcpStdio(): Promise<void> {
       // http.close() / stdio.close() awaits. synthesizePending will also
       // drain the map if synth is provided; the clearTimeout calls here are
       // defensive for the synth=undefined path (e.g., clean stdio.onclose).
-      for (const entry of pendingRequests.values()) clearTimeout(entry.timeoutHandle);
+      for (const handle of pendingRequests.values()) clearTimeout(handle);
       if (synth) {
         await synthesizeBuffered(synth.message, synth.detail);
         await synthesizePending(synth.message, synth.detail);
@@ -231,33 +228,28 @@ export async function runMcpStdio(): Promise<void> {
     // an id that already has a real response in flight).
     const responseId = getResponseId(msg);
     if (responseId !== undefined) {
-      const entry = pendingRequests.get(responseId);
-      if (entry) {
-        clearTimeout(entry.timeoutHandle);
+      const handle = pendingRequests.get(responseId);
+      if (handle !== undefined) {
+        clearTimeout(handle);
         pendingRequests.delete(responseId);
       }
     }
-    stdio.send(msg).then(
-      () => {
-        /* timer already cleared above */
-      },
-      (err: unknown) => {
-        const detail = err instanceof Error ? err.message : String(err);
-        process.stderr.write(
-          `[tandem mcp-stdio] stdio write failed for id ${responseId ?? "<notification>"}: ${detail}\n`,
-        );
-        // Map entry already deleted above. Synthesize directly for this id,
-        // then tear down — stdio is broken so other pending requests can't
-        // be delivered either.
-        if (responseId !== undefined) {
-          void sendErrorResponse(responseId, "Tandem stdio write failed", detail);
-        }
-        void shutdown(1, {
-          message: "Tandem stdio write failed",
-          detail,
-        });
-      },
-    );
+    stdio.send(msg).catch((err: unknown) => {
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[tandem mcp-stdio] stdio write failed for id ${responseId ?? "<notification>"}: ${detail}\n`,
+      );
+      // Map entry already deleted above. Synthesize directly for this id,
+      // then tear down — stdio is broken so other pending requests can't
+      // be delivered either.
+      if (responseId !== undefined) {
+        void sendErrorResponse(responseId, "Tandem stdio write failed", detail);
+      }
+      void shutdown(1, {
+        message: "Tandem stdio write failed",
+        detail,
+      });
+    });
   };
 
   stdio.onerror = (err) => {

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -2,7 +2,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getRequestId, getResponseId } from "../../src/cli/mcp-stdio.js";
+import { getRequestId, getResponseId, parseTimeoutMs } from "../../src/cli/mcp-stdio.js";
 
 async function readOneLine(
   child: ChildProcessWithoutNullStreams,
@@ -503,7 +503,7 @@ describe("mcp-stdio error synthesis on upstream unavailability", () => {
     }
   }, 30_000);
 
-  it("clears pendingIds after a successful response", async () => {
+  it("clears pendingRequests after a successful response", async () => {
     // Fake server: first POST (id=1) → success reply; second POST (id=2) → held.
     let postCount = 0;
     let held: ServerResponse | undefined;
@@ -588,11 +588,296 @@ describe("mcp-stdio error synthesis on upstream unavailability", () => {
       expect(parsed2.error?.code).toBe(-32000);
 
       // Verify no additional line arrives — id=1 must have been removed from
-      // pendingIds on success and must NOT be re-synthesized.
+      // pendingRequests on success and must NOT be re-synthesized.
       const extra = await readLines(child, 1, 500);
       expect(extra).toHaveLength(0);
     } finally {
       await new Promise<void>((r) => server.close(() => r()));
     }
   }, 30_000);
+});
+
+describe("mcp-stdio per-request timeout", () => {
+  let child: ChildProcessWithoutNullStreams | undefined;
+  let timeoutServer: Server | undefined;
+
+  afterEach(async () => {
+    // Kill child first so the HTTP connection is released before server.close().
+    child?.kill();
+    child = undefined;
+    if (timeoutServer) {
+      // closeAllConnections() (Node 18.2+) forces open keep-alive sockets
+      // closed so server.close() resolves without hanging.
+      (timeoutServer as Server & { closeAllConnections?: () => void }).closeAllConnections?.();
+      await new Promise<void>((r) => timeoutServer!.close(() => r()));
+      timeoutServer = undefined;
+    }
+  });
+
+  /**
+   * Spin up a fake Tandem server whose /mcp endpoint holds every POST
+   * without replying. Used by half-open timeout tests.
+   */
+  async function makeHalfOpenServer(): Promise<{ port: number }> {
+    timeoutServer = createServer((req, res) => {
+      if (req.method === "GET" && req.url === "/health") {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("ok");
+        return;
+      }
+      if (req.method === "POST" && req.url === "/mcp") {
+        // Intentionally never respond — simulates a half-open upstream.
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((r) => (timeoutServer as Server).listen(0, "127.0.0.1", r));
+    const addr = (timeoutServer as Server).address();
+    if (!addr || typeof addr === "string") throw new Error("server.address() unexpected");
+    return { port: addr.port };
+  }
+
+  it("synthesizes -32000 after timeout when upstream accepts but never responds (half-open)", async () => {
+    // Fake server: /health → 200, /mcp → holds the POST without replying.
+    const { port } = await makeHalfOpenServer();
+    const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
+    // Use a short timeout (500ms) so the test doesn't take 30s.
+    child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
+      env: {
+        ...process.env,
+        TANDEM_URL: `http://127.0.0.1:${port}`,
+        TANDEM_REQUEST_TIMEOUT_MS: "500",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    // Write after a short delay so httpReady is true (request goes through forwardToUpstream).
+    await new Promise((r) => setTimeout(r, 500));
+    child.stdin.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id: 10, method: "initialize", params: { protocolVersion: "2024-11-05", clientInfo: { name: "test", version: "0" }, capabilities: {} } })}\n`,
+    );
+
+    // Expect -32000 after the 500ms timeout fires (plus processing slack).
+    const line = await readOneLine(child, 5_000);
+    const parsed = JSON.parse(line) as {
+      id: number;
+      error?: { code: number; message: string; data?: { detail: string } };
+    };
+    expect(parsed.id).toBe(10);
+    expect(parsed.error?.code).toBe(-32000);
+    expect(parsed.error?.message).toMatch(/half-open/i);
+    expect(parsed.error?.data?.detail).toMatch(/500ms/);
+  }, 15_000);
+
+  it("synthesizes distinct -32000 for each concurrent pending request on timeout", async () => {
+    // Fake server: /health → 200, /mcp → holds all POSTs without replying.
+    const { port } = await makeHalfOpenServer();
+    const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
+    child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
+      env: {
+        ...process.env,
+        TANDEM_URL: `http://127.0.0.1:${port}`,
+        TANDEM_REQUEST_TIMEOUT_MS: "500",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    // Wait for httpReady, then send 3 concurrent requests.
+    await new Promise((r) => setTimeout(r, 500));
+    const makeRequest = (id: number) =>
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          clientInfo: { name: "test", version: "0" },
+          capabilities: {},
+        },
+      });
+    child.stdin.write(`${makeRequest(20)}\n`);
+    child.stdin.write(`${makeRequest(21)}\n`);
+    child.stdin.write(`${makeRequest(22)}\n`);
+
+    // Collect 3 -32000 lines (allow 5s slack after 500ms timeout).
+    const lines = await readLines(child, 3, 5_000);
+    expect(lines).toHaveLength(3);
+
+    const receivedIds = new Set<number>();
+    for (const line of lines) {
+      const parsed = JSON.parse(line) as { id: number; error?: { code: number } };
+      expect(parsed.error?.code).toBe(-32000);
+      receivedIds.add(parsed.id);
+    }
+    expect(receivedIds).toEqual(new Set([20, 21, 22]));
+  }, 15_000);
+
+  it("does not synthesize double -32000 when timer fires before upstream crash arrives", async () => {
+    // Regression guard: when the per-request timer fires and deletes the map entry,
+    // a subsequent forwardToUpstream.catch for the same id must find the map empty
+    // and NOT emit a second -32000.
+    //
+    // Sequence:
+    //  1. Short timer (300ms) starts when request is forwarded.
+    //  2. Server holds the POST (never responds), timer fires → map deleted → -32000 (half-open).
+    //  3. Test destroys the server connection after the timer has fired.
+    //  4. forwardToUpstream.catch fires: pendingRequests.delete() returns false → no second -32000.
+    let heldRes: ServerResponse | undefined;
+    timeoutServer = createServer((req, res) => {
+      if (req.method === "GET" && req.url === "/health") {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("ok");
+        return;
+      }
+      if (req.method === "POST" && req.url === "/mcp") {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+          heldRes = res;
+        });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((r) => (timeoutServer as Server).listen(0, "127.0.0.1", r));
+    const addr = (timeoutServer as Server).address();
+    if (!addr || typeof addr === "string") throw new Error("server.address() unexpected");
+    const { port } = addr;
+
+    const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
+    child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
+      env: {
+        ...process.env,
+        TANDEM_URL: `http://127.0.0.1:${port}`,
+        // Short enough to fire before we destroy, long enough to be reliable.
+        TANDEM_REQUEST_TIMEOUT_MS: "300",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    // Collect stdout so we can count total -32000 lines later.
+    const stdoutChunks: string[] = [];
+    child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c.toString("utf8")));
+
+    // Wait for httpReady, then send the request.
+    await new Promise((r) => setTimeout(r, 500));
+    child.stdin.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id: 30, method: "initialize", params: { protocolVersion: "2024-11-05", clientInfo: { name: "test", version: "0" }, capabilities: {} } })}\n`,
+    );
+
+    // Poll until server has the POST, then wait for timer to fire first.
+    for (let i = 0; i < 60; i++) {
+      if (heldRes) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(heldRes).toBeDefined();
+
+    // Wait for the 300ms timer to fire and produce the -32000.
+    const firstLine = await readOneLine(child, 3_000);
+    const first = JSON.parse(firstLine) as { id: number; error?: { code: number } };
+    expect(first.id).toBe(30);
+    expect(first.error?.code).toBe(-32000);
+
+    // Now destroy the connection — forwardToUpstream.catch will fire.
+    heldRes!.destroy();
+
+    // Wait 500ms for any spurious second -32000 to arrive.
+    await new Promise((r) => setTimeout(r, 500));
+    const allOutput = stdoutChunks.join("");
+    const allLines = allOutput.split("\n").filter((l) => l.trim());
+    const errorCount = allLines.filter((l) => {
+      try {
+        const p = JSON.parse(l) as { id?: number; error?: { code?: number } };
+        return p.id === 30 && p.error?.code === -32000;
+      } catch {
+        return false;
+      }
+    }).length;
+    // Exactly one -32000 for id=30 — timer fired first, catch found map empty.
+    expect(errorCount).toBe(1);
+  }, 10_000);
+
+  it("process exits in <3s after half-open timeout fires (no orphan handles)", async () => {
+    // Regression guard: after the per-request timer fires and the proxy sends a
+    // -32000, the process should be able to exit cleanly. If shutdown is triggered
+    // (e.g., by the plugin host closing stdin which triggers stdio.close),
+    // uncleared timer handles must not delay process.exit.
+    //
+    // Here we verify a simpler invariant: after a half-open timeout fires (-32000
+    // arrives on stdout), the child can be killed cleanly and its 'close' event
+    // fires within 3s. The timer has already fired and been cleared from the map.
+    const { port } = await makeHalfOpenServer();
+    const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
+    child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
+      env: {
+        ...process.env,
+        TANDEM_URL: `http://127.0.0.1:${port}`,
+        TANDEM_REQUEST_TIMEOUT_MS: "300",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+    child.stdin.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id: 40, method: "initialize", params: { protocolVersion: "2024-11-05", clientInfo: { name: "test", version: "0" }, capabilities: {} } })}\n`,
+    );
+
+    // Wait for the -32000 to arrive (timer fired).
+    const line = await readOneLine(child, 3_000);
+    const parsed = JSON.parse(line) as { id: number; error?: { code: number } };
+    expect(parsed.id).toBe(40);
+    expect(parsed.error?.code).toBe(-32000);
+
+    // Kill the child and verify it closes within 3s.
+    child.kill();
+    const closed = await new Promise<boolean>((resolve) => {
+      const deadline = setTimeout(() => resolve(false), 3_000);
+      child!.once("close", () => {
+        clearTimeout(deadline);
+        resolve(true);
+      });
+    });
+    expect(closed).toBe(true);
+  }, 10_000);
+});
+
+describe("parseTimeoutMs", () => {
+  it("returns the parsed value for a valid positive integer string", () => {
+    expect(parseTimeoutMs("5000")).toBe(5000);
+    expect(parseTimeoutMs("1")).toBe(1);
+    expect(parseTimeoutMs("2147483647")).toBe(2_147_483_647);
+  });
+
+  it("returns 30000 for undefined (no env var set)", () => {
+    expect(parseTimeoutMs(undefined)).toBe(30_000);
+  });
+
+  it("returns 30000 for NaN input", () => {
+    expect(parseTimeoutMs("not-a-number")).toBe(30_000);
+  });
+
+  it("returns 30000 for scientific notation (parseInt parses '3e4' as 3, which is valid, but '1e10' overflows)", () => {
+    // parseInt("3e4", 10) === 3 — a small positive integer, accepted as valid.
+    expect(parseTimeoutMs("3e4")).toBe(3);
+    // parseInt("1e10", 10) === 1 — also a small positive integer.
+    expect(parseTimeoutMs("1e10")).toBe(1);
+  });
+
+  it("returns 30000 for overflow (> MAX_TIMEOUT_MS)", () => {
+    expect(parseTimeoutMs("9999999999999")).toBe(30_000);
+    expect(parseTimeoutMs("2147483648")).toBe(30_000);
+  });
+
+  it("returns 30000 for negative values", () => {
+    expect(parseTimeoutMs("-1")).toBe(30_000);
+    expect(parseTimeoutMs("-100")).toBe(30_000);
+  });
+
+  it("returns 30000 for zero", () => {
+    expect(parseTimeoutMs("0")).toBe(30_000);
+  });
 });

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -803,13 +803,12 @@ describe("mcp-stdio per-request timeout", () => {
 
   it("process exits in <3s after half-open timeout fires (no orphan handles)", async () => {
     // Regression guard: after the per-request timer fires and the proxy sends a
-    // -32000, the process should be able to exit cleanly. If shutdown is triggered
-    // (e.g., by the plugin host closing stdin which triggers stdio.close),
-    // uncleared timer handles must not delay process.exit.
+    // -32000, the process should exit cleanly when stdin is closed.
     //
-    // Here we verify a simpler invariant: after a half-open timeout fires (-32000
-    // arrives on stdout), the child can be killed cleanly and its 'close' event
-    // fires within 3s. The timer has already fired and been cleared from the map.
+    // stdin.end() routes through stdio.onclose → shutdown(0) → process.exit(0),
+    // exercising the real natural-exit path. SIGTERM would bypass the Node event
+    // loop entirely and cannot detect orphan timer handles that block clean exit.
+    // The timer has already fired and been cleared from the map before stdin.end().
     const { port } = await makeHalfOpenServer();
     const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
     child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
@@ -832,8 +831,10 @@ describe("mcp-stdio per-request timeout", () => {
     expect(parsed.id).toBe(40);
     expect(parsed.error?.code).toBe(-32000);
 
-    // Kill the child and verify it closes within 3s.
-    child.kill();
+    // Close stdin (routes through stdio.onclose → shutdown(0) → process.exit(0)).
+    // This exercises the natural exit path — SIGTERM would bypass the event loop
+    // and cannot detect orphan timer handles that prevent clean shutdown.
+    child.stdin.end();
     const closed = await new Promise<boolean>((resolve) => {
       const deadline = setTimeout(() => resolve(false), 3_000);
       child!.once("close", () => {

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -860,7 +860,7 @@ describe("parseTimeoutMs", () => {
     expect(parseTimeoutMs("not-a-number")).toBe(30_000);
   });
 
-  it("returns 30000 for scientific notation (parseInt parses '3e4' as 3, which is valid, but '1e10' overflows)", () => {
+  it("accepts scientific-notation-like input as the leading integer (parseInt stops at 'e')", () => {
     // parseInt("3e4", 10) === 3 — a small positive integer, accepted as valid.
     expect(parseTimeoutMs("3e4")).toBe(3);
     // parseInt("1e10", 10) === 1 — also a small positive integer.


### PR DESCRIPTION
## Summary

- Replaces `pendingIds: Set<string | number>` with `Map<id, ReturnType<typeof setTimeout>>` in `src/cli/mcp-stdio.ts`
- Schedules a 30s per-request timer in `forwardToUpstream()`; synthesizes a `-32000` error if the upstream never responds (half-open connection)
- Timers are cleared **synchronously at the top of `http.onmessage`** before `stdio.send()` to prevent a false error for a request that already has a real response in flight
- `synthesizePending()` and `shutdown()` both drain timers atomically before any `await`
- Adds `parseTimeoutMs()` exported helper with `TANDEM_REQUEST_TIMEOUT_MS` env-var override (guarded: `Number.isFinite && > 0 && ≤ MAX_INT32`)
- 4 new integration tests + 7 unit tests for `parseTimeoutMs`

## Root cause

PR #346 fixed four stdio-bridge failure paths (preflight exit, `http.onclose`, `http.start()` failure, `http.send()` rejection). A fifth path — half-open upstream (TCP accepted, SSE stream opened, response bytes never arrive) — was explicitly deferred to this issue. In that scenario, `pendingIds` grew indefinitely; the CLI hung with no diagnostic output.

## ⚠️ Draft — stays draft until Prerequisite Spikes resolve

This PR's merge is gated on two research spikes:
1. Verify Anthropic's `plugin.json` `http` type supports a `headers` field (fallback: session-exchange endpoint)
2. Verify OAuth `bearer_methods_supported` metadata causes Claude Code's MCP client to send `Authorization` headers

If either spike fails, the v0.7.0 auth design changes. This PR's code is independent of those spikes but is the first commit on the v0.7.0 line — holding draft until v0.6.4 (#361, #362) tags and spike findings are known.

## Event-bridge follow-up

`src/channel/event-bridge.ts` has the same half-open problem (SSE handshake, reader loop, mode check). Pattern exists in `src/monitor/index.ts`. Filed as a separate v0.7.0 issue: track at https://github.com/bloknayrb/tandem (issue to be filed before this PR exits draft).

## Test plan

- [ ] `npm run typecheck` clean
- [ ] `npm test` green (1290+ tests including 11 new)
- [ ] Half-open server: `node -e "require('http').createServer(() => {}).listen(3479)"` → within 30s, `{"code":-32000}` error, exits 1
- [ ] Normal server: `npm run dev:standalone` → no false timeout, response <500ms
- [ ] Concurrent: 3 requests → 3 distinct `-32000` with correct ids
- [ ] Env override: `TANDEM_REQUEST_TIMEOUT_MS=30s` → stderr warning, falls back to 30000ms
- [ ] Env overflow: `TANDEM_REQUEST_TIMEOUT_MS=99999999999` → stderr warning, falls back

Closes #347