### PR TITLE
feat(auth): token-store primitive (v0.7.0 PR a/4)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,10 @@ tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 tokio = { version = "1", features = ["time"] }
+keyring = "3"
+base64 = "0.22"
+dirs = "6"
+rand = "0.8"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+mod token_store;
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -305,6 +307,17 @@ async fn start_sidecar(handle: &tauri::AppHandle, client: &reqwest::Client) -> R
         .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
     let app_data_dir_str = strip_win_prefix(&app_data_dir);
 
+    // Obtain or create the auth token before spawning — the Node sidecar
+    // reads TANDEM_AUTH_TOKEN and skips its own generation when it's present.
+    // Token-less is acceptable for now; PR b will enforce it.
+    let auth_token: Option<String> = match token_store::get_or_create_token() {
+        Ok(token) => Some(token),
+        Err(e) => {
+            log::error!("Failed to obtain auth token (sidecar will start token-less): {e}");
+            None
+        }
+    };
+
     for attempt in 0..=MAX_RESTARTS {
         if attempt > 0 {
             let backoff = Duration::from_secs(2u64.pow(attempt - 1));
@@ -314,13 +327,19 @@ async fn start_sidecar(handle: &tauri::AppHandle, client: &reqwest::Client) -> R
             tokio::time::sleep(backoff).await;
         }
 
-        let (rx, child) = handle
+        let mut cmd = handle
             .shell()
             .sidecar("node-sidecar")
             .map_err(|e| format!("Failed to create sidecar command: {e}"))?
             .args([server_js_str.as_str()])
             .env("TANDEM_OPEN_BROWSER", "0")
-            .env("TANDEM_DATA_DIR", app_data_dir_str.as_str())
+            .env("TANDEM_DATA_DIR", app_data_dir_str.as_str());
+
+        if let Some(ref token) = auth_token {
+            cmd = cmd.env("TANDEM_AUTH_TOKEN", token.as_str());
+        }
+
+        let (rx, child) = cmd
             .spawn()
             .map_err(|e| format!("Failed to spawn sidecar: {e}"))?;
 

--- a/src-tauri/src/token_store.rs
+++ b/src-tauri/src/token_store.rs
@@ -76,7 +76,12 @@ pub fn get_or_create_token() -> Result<String, String> {
     match entry.get_password() {
         Ok(token) if !token.trim().is_empty() => return Ok(token),
         Ok(_) => {} // empty keyring entry — treat as missing
-        Err(_) => {} // keyring unavailable (headless Linux CI, etc.) — fall through
+        Err(keyring::Error::NoEntry) => {
+            // token not yet stored — fall through to file or generate
+        }
+        Err(e) => {
+            eprintln!("[tandem] keyring read failed (falling through to file): {e}");
+        }
     }
 
     // 2. Try env-paths file.

--- a/src-tauri/src/token_store.rs
+++ b/src-tauri/src/token_store.rs
@@ -1,0 +1,96 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use keyring::Entry;
+use std::path::PathBuf;
+
+const SERVICE: &str = "tandem";
+const ENTRY_NAME: &str = "auth-token";
+const TOKEN_FILE_NAME: &str = "auth-token";
+
+/// Resolve the env-paths-equivalent data directory for the token file.
+/// Mirrors the Node.js `envPaths("tandem", { suffix: "" }).data` path:
+///   Windows: %LOCALAPPDATA%\tandem\Data
+///   macOS:   ~/Library/Application Support/tandem
+///   Linux:   ~/.local/share/tandem
+fn data_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        dirs::data_local_dir().map(|d| d.join("tandem").join("Data"))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        dirs::data_dir().map(|d| d.join("tandem"))
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        dirs::data_local_dir().map(|d| d.join("tandem"))
+    }
+}
+
+fn token_file_path() -> Option<PathBuf> {
+    data_dir().map(|d| d.join(TOKEN_FILE_NAME))
+}
+
+fn read_from_file() -> Option<String> {
+    let path = token_file_path()?;
+    let content = std::fs::read_to_string(&path).ok()?;
+    let trimmed = content.trim().to_string();
+    if trimmed.is_empty() { None } else { Some(trimmed) }
+}
+
+fn write_to_file(token: &str) -> Result<(), String> {
+    let path = token_file_path().ok_or("Cannot resolve data dir")?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir failed: {e}"))?;
+    }
+    std::fs::write(&path, token).map_err(|e| format!("write failed: {e}"))?;
+
+    // Restrict to owner on POSIX; on Windows, directory ACL inheritance applies.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("chmod failed: {e}"))?;
+    }
+
+    Ok(())
+}
+
+fn generate_token() -> String {
+    // 32 bytes of OS randomness encoded as base64url without padding = 43 chars.
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Return the auth token, creating one if none exists.
+///
+/// Priority:
+///   1. Keyring (native secure storage — Windows Credential Manager / macOS Keychain)
+///   2. Env-paths file (fallback for Linux CI or locked-down environments)
+///   3. Generate, persist to keyring or file, return.
+pub fn get_or_create_token() -> Result<String, String> {
+    let entry = Entry::new(SERVICE, ENTRY_NAME).map_err(|e| format!("keyring init: {e}"))?;
+
+    // 1. Try keyring.
+    match entry.get_password() {
+        Ok(token) if !token.trim().is_empty() => return Ok(token),
+        Ok(_) => {} // empty keyring entry — treat as missing
+        Err(_) => {} // keyring unavailable (headless Linux CI, etc.) — fall through
+    }
+
+    // 2. Try env-paths file.
+    if let Some(token) = read_from_file() {
+        return Ok(token);
+    }
+
+    // 3. Generate a fresh token and persist it.
+    let token = generate_token();
+
+    // Try keyring first; fall back to file if unavailable.
+    if entry.set_password(&token).is_err() {
+        write_to_file(&token)?;
+    }
+
+    Ok(token)
+}

--- a/src/server/auth/token-store.ts
+++ b/src/server/auth/token-store.ts
@@ -72,17 +72,9 @@ export async function writeTokenToFile(token: string): Promise<string> {
   return token;
 }
 
-/**
- * Returns the active auth token:
- *  - Env var (injected by Tauri before sidecar spawn) takes priority — no file I/O.
- *  - Existing valid file is adopted on all subsequent boots.
- *  - Otherwise a fresh token is generated, persisted, and returned.
- *
- * Exits with code 1 on crypto failure or unwritable dir; those are
- * non-recoverable in Tauri/Cowork mode. Returns null only when the caller
- * is in CLI loopback mode and no token exists yet — PR b will gate on this.
- * NOTE: PR a never produces null; the union is reserved for PR b's gating logic.
- */
+// Priority: env var (Tauri injects before sidecar spawn) → existing file → generate+persist.
+// Exits with code 1 on crypto failure or unwritable dir — non-recoverable in Tauri/Cowork mode.
+// Returns string | null: PR a never produces null; null is reserved for PR b's CLI loopback gating.
 export async function loadOrCreateToken(): Promise<string | null> {
   // Tauri passes the token via env before spawning the sidecar.
   const envToken = process.env.TANDEM_AUTH_TOKEN;

--- a/src/server/auth/token-store.ts
+++ b/src/server/auth/token-store.ts
@@ -1,0 +1,119 @@
+import crypto from "crypto";
+import envPaths from "env-paths";
+import fs from "fs";
+import path from "path";
+import { TOKEN_FILE_NAME } from "../../shared/constants.js";
+
+export function getTokenFilePath(): string {
+  return path.join(envPaths("tandem", { suffix: "" }).data, TOKEN_FILE_NAME);
+}
+
+export async function readTokenFromFile(): Promise<string | null> {
+  const filePath = getTokenFilePath();
+  try {
+    const content = await fs.promises.readFile(filePath, "utf8");
+    const trimmed = content.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export async function writeTokenToFile(token: string): Promise<string> {
+  const filePath = getTokenFilePath();
+  const dir = path.dirname(filePath);
+
+  await fs.promises.mkdir(dir, { recursive: true });
+
+  // Warn on Windows when data dir is not under %LOCALAPPDATA% — NTFS ACL
+  // inheritance may not restrict access to the current user the way 0600 does.
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA;
+    if (localAppData) {
+      const normalizedDir = path.resolve(dir).toLowerCase();
+      const normalizedLocal = path.resolve(localAppData).toLowerCase();
+      if (!normalizedDir.startsWith(normalizedLocal)) {
+        console.warn(
+          `[Tandem] auth token dir is outside %LOCALAPPDATA% (${dir}); NTFS ACL inheritance may not restrict access to current user`,
+        );
+      }
+    }
+  }
+
+  // O_EXCL first-write: on EEXIST, adopt the winner's token instead of overwriting.
+  let fh: fs.promises.FileHandle;
+  try {
+    fh = await fs.promises.open(filePath, "wx");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      // Concurrent start won the race — read and adopt their token.
+      const existing = await readTokenFromFile();
+      if (existing) return existing;
+      // File exists but is empty (degenerate race) — fall through to overwrite below.
+      fh = await fs.promises.open(filePath, "w");
+    } else {
+      throw err;
+    }
+  }
+
+  try {
+    await fh.writeFile(token, "utf8");
+  } finally {
+    await fh.close();
+  }
+
+  // Restrict read/write to owner on POSIX. On Windows, the mkdir + NTFS warning
+  // above is the extent of our access control — chmod is a no-op there.
+  if (process.platform !== "win32") {
+    await fs.promises.chmod(filePath, 0o600);
+  }
+
+  return token;
+}
+
+/**
+ * Returns the active auth token:
+ *  - Env var (injected by Tauri before sidecar spawn) takes priority — no file I/O.
+ *  - Existing valid file is adopted on all subsequent boots.
+ *  - Otherwise a fresh token is generated, persisted, and returned.
+ *
+ * Exits with code 1 on crypto failure or unwritable dir; those are
+ * non-recoverable in Tauri/Cowork mode. Returns null only when the caller
+ * is in CLI loopback mode and no token exists yet — PR b will gate on this.
+ * NOTE: PR a never produces null; the union is reserved for PR b's gating logic.
+ */
+export async function loadOrCreateToken(): Promise<string | null> {
+  // Tauri passes the token via env before spawning the sidecar.
+  const envToken = process.env.TANDEM_AUTH_TOKEN;
+  if (envToken && envToken.trim().length > 0) {
+    console.error("[Tandem] auth token loaded from env");
+    return envToken.trim();
+  }
+
+  const existing = await readTokenFromFile();
+  if (existing) {
+    console.error("[Tandem] auth token loaded from file");
+    return existing;
+  }
+
+  // Generate exactly 32 bytes of CSPRNG — no fallback to pseudorandom.
+  let raw: Buffer;
+  try {
+    raw = crypto.randomBytes(32);
+  } catch (err) {
+    console.error("[Tandem] FATAL: crypto.randomBytes failed:", err);
+    process.exit(1);
+  }
+
+  const token = raw.toString("base64url");
+
+  try {
+    const written = await writeTokenToFile(token);
+    console.error("[Tandem] auth token written to file");
+    return written;
+  } catch (err) {
+    console.error("[Tandem] FATAL: cannot write auth token:", err);
+    process.exit(1);
+  }
+}

--- a/src/server/auth/token-store.ts
+++ b/src/server/auth/token-store.ts
@@ -12,6 +12,18 @@ export async function readTokenFromFile(): Promise<string | null> {
   const filePath = getTokenFilePath();
   try {
     const content = await fs.promises.readFile(filePath, "utf8");
+    // Remediate insecure permissions if a previous chmod failed (e.g., process crashed).
+    if (process.platform !== "win32") {
+      try {
+        const stat = await fs.promises.stat(filePath);
+        if ((stat.mode & 0o077) !== 0) {
+          console.error("[tandem] auth token file has insecure permissions; attempting chmod 0600");
+          await fs.promises.chmod(filePath, 0o600);
+        }
+      } catch {
+        // Non-fatal: stat/chmod failure doesn't invalidate the token we already read
+      }
+    }
     const trimmed = content.trim();
     return trimmed.length > 0 ? trimmed : null;
   } catch (err) {
@@ -44,7 +56,7 @@ export async function writeTokenToFile(token: string): Promise<string> {
   // O_EXCL first-write: on EEXIST, adopt the winner's token instead of overwriting.
   let fh: fs.promises.FileHandle;
   try {
-    fh = await fs.promises.open(filePath, "wx");
+    fh = await fs.promises.open(filePath, "wx", 0o600);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "EEXIST") {
       // Concurrent start won the race — read and adopt their token.
@@ -73,9 +85,9 @@ export async function writeTokenToFile(token: string): Promise<string> {
 }
 
 // Priority: env var (Tauri injects before sidecar spawn) → existing file → generate+persist.
-// Exits with code 1 on crypto failure or unwritable dir — non-recoverable in Tauri/Cowork mode.
-// Returns string | null: PR a never produces null; null is reserved for PR b's CLI loopback gating.
-export async function loadOrCreateToken(): Promise<string | null> {
+// Returns the token string. Exits with code 1 on unrecoverable failure. Return type will be
+// widened to string|null in PR b when CLI loopback-only mode may proceed token-less.
+export async function loadOrCreateToken(): Promise<string> {
   // Tauri passes the token via env before spawning the sidecar.
   const envToken = process.env.TANDEM_AUTH_TOKEN;
   if (envToken && envToken.trim().length > 0) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { CTRL_ROOM, DEFAULT_MCP_PORT, DEFAULT_WS_PORT } from "../shared/constants.js";
 import { acquireStoreLock, releaseStoreLock } from "./annotations/store.js";
+import { loadOrCreateToken } from "./auth/token-store.js";
 import { isKnownHocuspocusError } from "./error-filter.js";
 import {
   attachCtrlObservers,
@@ -227,6 +228,11 @@ async function main() {
       detachObservers(docName);
     },
   );
+
+  // token loaded here; PR b will wire it into the auth middleware
+  // TANDEM_AUTH_TOKEN env (set by Tauri before sidecar spawn) takes priority
+  // so this is effectively a no-op disk-wise in Tauri mode.
+  const _authToken = await loadOrCreateToken();
 
   if (transportMode === "http") {
     // HTTP mode: no startup-order constraint — start both concurrently

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -111,6 +111,9 @@ export const CHANNEL_SSE_KEEPALIVE_MS = 15_000; // 15 seconds
 export const CHANNEL_MAX_RETRIES = 5;
 export const CHANNEL_RETRY_DELAY_MS = 2_000;
 
+/** Auth token filename inside the app-data directory. */
+export const TOKEN_FILE_NAME = "auth-token";
+
 /** Tauri WebView origin hostname — must be accepted alongside localhost. */
 export const TAURI_HOSTNAME = "tauri.localhost";
 

--- a/tests/server/token-store.test.ts
+++ b/tests/server/token-store.test.ts
@@ -1,0 +1,170 @@
+import crypto from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// We need the module to use a temp dir for data. Override env-paths by patching
+// TANDEM_APP_DATA_DIR — platform.ts uses it, but token-store.ts uses env-paths
+// directly. We mock the env-paths module instead.
+let tempDir: string;
+
+vi.mock("env-paths", () => ({
+  default: () => ({ data: tempDir }),
+}));
+
+// Import after mocks are registered.
+const { loadOrCreateToken, readTokenFromFile, writeTokenToFile, getTokenFilePath } = await import(
+  "../../src/server/auth/token-store"
+);
+
+const BASE64URL_RE = /^[A-Za-z0-9_-]{43}$/;
+
+describe("token-store", () => {
+  let mockExit: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tandem-token-test-"));
+    // Clear env token between tests
+    delete process.env.TANDEM_AUTH_TOKEN;
+    // Mock process.exit per the pattern used in retry.test.ts — must be in
+    // beforeEach, not module scope, to avoid vitest's built-in interceptor.
+    mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+    delete process.env.TANDEM_AUTH_TOKEN;
+    vi.restoreAllMocks();
+  });
+
+  describe("readTokenFromFile()", () => {
+    it("returns null when file does not exist", async () => {
+      const result = await readTokenFromFile();
+      expect(result).toBeNull();
+    });
+
+    it("returns null when file is empty", async () => {
+      await fs.promises.mkdir(path.dirname(getTokenFilePath()), { recursive: true });
+      await fs.promises.writeFile(getTokenFilePath(), "", "utf8");
+      const result = await readTokenFromFile();
+      expect(result).toBeNull();
+    });
+
+    it("returns null when file contains only whitespace", async () => {
+      await fs.promises.mkdir(path.dirname(getTokenFilePath()), { recursive: true });
+      await fs.promises.writeFile(getTokenFilePath(), "   \n  ", "utf8");
+      const result = await readTokenFromFile();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("writeTokenToFile() + readTokenFromFile() roundtrip", () => {
+    it("persists a token and reads it back", async () => {
+      const token = crypto.randomBytes(32).toString("base64url");
+      await writeTokenToFile(token);
+      const read = await readTokenFromFile();
+      expect(read).toBe(token);
+    });
+
+    it("creates parent directory if missing", async () => {
+      const token = crypto.randomBytes(32).toString("base64url");
+      // tempDir exists but no sub-dir for the token file yet
+      const nestedDir = path.join(tempDir, "nested", "sub");
+      vi.spyOn(path, "dirname").mockReturnValueOnce(nestedDir);
+      // Re-implement: just verify writeTokenToFile handles recursive mkdir
+      await writeTokenToFile(token);
+      const read = await readTokenFromFile();
+      expect(read).toBe(token);
+    });
+  });
+
+  describe("loadOrCreateToken()", () => {
+    it("creates token file on first call", async () => {
+      const token = await loadOrCreateToken();
+      expect(token).not.toBeNull();
+      expect(token).toMatch(BASE64URL_RE);
+      // File now exists
+      const fromFile = await readTokenFromFile();
+      expect(fromFile).toBe(token);
+    });
+
+    it("reuses existing token on second call", async () => {
+      const first = await loadOrCreateToken();
+      const second = await loadOrCreateToken();
+      expect(second).toBe(first);
+    });
+
+    it("regenerates token when file is empty", async () => {
+      await fs.promises.mkdir(path.dirname(getTokenFilePath()), { recursive: true });
+      await fs.promises.writeFile(getTokenFilePath(), "", "utf8");
+      const token = await loadOrCreateToken();
+      expect(token).not.toBeNull();
+      expect(token).toMatch(BASE64URL_RE);
+    });
+
+    it("returns env var without touching the file when TANDEM_AUTH_TOKEN is set", async () => {
+      const envToken = "env-token-for-testing-abc";
+      process.env.TANDEM_AUTH_TOKEN = envToken;
+      const result = await loadOrCreateToken();
+      expect(result).toBe(envToken);
+      // File must not be created
+      const fromFile = await readTokenFromFile();
+      expect(fromFile).toBeNull();
+    });
+
+    it("generated token matches base64url-of-32-bytes format", async () => {
+      const token = await loadOrCreateToken();
+      expect(token).toMatch(BASE64URL_RE);
+    });
+
+    describe("O_EXCL race simulation", () => {
+      it("adopts existing token when open(wx) throws EEXIST", async () => {
+        // Write a known token to disk first (simulates the racing process winning)
+        const existingToken = crypto.randomBytes(32).toString("base64url");
+        await writeTokenToFile(existingToken);
+
+        // Mock fs.promises.open to throw EEXIST on the first call, then succeed.
+        const originalOpen = fs.promises.open;
+        let firstCall = true;
+        vi.spyOn(fs.promises, "open").mockImplementation(
+          async (filePath: fs.PathLike | fs.promises.FileHandle, flags: fs.OpenMode, ...rest) => {
+            if (firstCall && flags === "wx") {
+              firstCall = false;
+              const err = Object.assign(new Error("EEXIST: file already exists"), {
+                code: "EEXIST",
+              });
+              throw err;
+            }
+            // @ts-ignore — spread rest args for arity compat
+            return originalOpen(filePath, flags, ...rest);
+          },
+        );
+
+        // Delete the file so loadOrCreateToken tries to generate a new one,
+        // then restore it before the mock throws to simulate the race.
+        const filePath = getTokenFilePath();
+        // Actually: the mock already wrote the file via writeTokenToFile above.
+        // Just call loadOrCreateToken — it will try open(wx), get EEXIST, and
+        // fall back to readTokenFromFile which returns existingToken.
+        const result = await loadOrCreateToken();
+        expect(result).toBe(existingToken);
+      });
+    });
+
+    describe("process.exit on crypto failure", () => {
+      it("calls process.exit(1) when randomBytes throws", async () => {
+        vi.spyOn(crypto, "randomBytes").mockImplementationOnce(() => {
+          throw new Error("Entropy source failed");
+        });
+
+        // vitest intercepts process.exit and throws its own error — we just
+        // verify it was called with the right code rather than matching message.
+        await expect(loadOrCreateToken()).rejects.toThrow();
+        expect(mockExit).toHaveBeenCalledWith(1);
+      });
+    });
+  });
+});

--- a/tests/server/token-store.test.ts
+++ b/tests/server/token-store.test.ts
@@ -120,51 +120,46 @@ describe("token-store", () => {
       expect(token).toMatch(BASE64URL_RE);
     });
 
-    describe("O_EXCL race simulation", () => {
-      it("adopts existing token when open(wx) throws EEXIST", async () => {
-        // No file on disk yet — loadOrCreateToken will generate a token and try
-        // open(wx). The spy intercepts, writes the "winner's" token inline
-        // (simulating the racing process winning), then throws EEXIST. Our code
-        // must fall back to readTokenFromFile and return the winner's token.
-        const winnerToken = crypto.randomBytes(32).toString("base64url");
-        const filePath = getTokenFilePath();
-        const originalOpen = fs.promises.open;
-        let exclAttempted = false;
+    it("adopts existing token when open(wx) throws EEXIST (O_EXCL race)", async () => {
+      // No file on disk yet — loadOrCreateToken will generate a token and try
+      // open(wx). The spy writes the "winner's" token to disk before throwing
+      // EEXIST — this is the critical invariant: readTokenFromFile must find a
+      // real token there so our code adopts the winner's value, not its own.
+      const winnerToken = crypto.randomBytes(32).toString("base64url");
+      const filePath = getTokenFilePath();
+      const originalOpen = fs.promises.open;
+      let exclAttempted = false;
 
-        vi.spyOn(fs.promises, "open").mockImplementation(
-          async (fp: fs.PathLike | fs.promises.FileHandle, flags: fs.OpenMode, ...rest) => {
-            if (!exclAttempted && flags === "wx") {
-              exclAttempted = true;
-              // Write the winner's token to disk before throwing — simulates the
-              // other process winning the O_EXCL race and persisting its token.
-              await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
-              await fs.promises.writeFile(filePath, winnerToken, "utf8");
-              throw Object.assign(new Error("EEXIST: file already exists"), { code: "EEXIST" });
-            }
-            // @ts-ignore — spread rest args for arity compat
-            return originalOpen(fp, flags, ...rest);
-          },
-        );
+      vi.spyOn(fs.promises, "open").mockImplementation(
+        async (fp: fs.PathLike | fs.promises.FileHandle, flags: fs.OpenMode, ...rest) => {
+          if (!exclAttempted && flags === "wx") {
+            exclAttempted = true;
+            // Simulate the racing process: persist its token, then surface EEXIST.
+            await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+            await fs.promises.writeFile(filePath, winnerToken, "utf8");
+            throw Object.assign(new Error("EEXIST: file already exists"), { code: "EEXIST" });
+          }
+          // @ts-expect-error — spread rest args for arity compat
+          return originalOpen(fp, flags, ...rest);
+        },
+      );
 
-        const result = await loadOrCreateToken();
-        // Must adopt the winner's token, not the one we generated.
-        expect(result).toBe(winnerToken);
-        // Verify the EEXIST branch actually fired (not just the file-read path).
-        expect(exclAttempted).toBe(true);
-      });
+      const result = await loadOrCreateToken();
+      // Must adopt the winner's token, not the one we generated.
+      expect(result).toBe(winnerToken);
+      // Verify the EEXIST branch actually fired (not just the file-read path).
+      expect(exclAttempted).toBe(true);
     });
 
-    describe("process.exit on crypto failure", () => {
-      it("calls process.exit(1) when randomBytes throws", async () => {
-        vi.spyOn(crypto, "randomBytes").mockImplementationOnce(() => {
-          throw new Error("Entropy source failed");
-        });
-
-        // vitest intercepts process.exit and throws its own error — we just
-        // verify it was called with the right code rather than matching message.
-        await expect(loadOrCreateToken()).rejects.toThrow();
-        expect(mockExit).toHaveBeenCalledWith(1);
+    it("calls process.exit(1) when randomBytes throws", async () => {
+      vi.spyOn(crypto, "randomBytes").mockImplementationOnce(() => {
+        throw new Error("Entropy source failed");
       });
+
+      // vitest intercepts process.exit and throws its own error — we just
+      // verify it was called with the right code rather than matching message.
+      await expect(loadOrCreateToken()).rejects.toThrow();
+      expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/tests/server/token-store.test.ts
+++ b/tests/server/token-store.test.ts
@@ -122,35 +122,35 @@ describe("token-store", () => {
 
     describe("O_EXCL race simulation", () => {
       it("adopts existing token when open(wx) throws EEXIST", async () => {
-        // Write a known token to disk first (simulates the racing process winning)
-        const existingToken = crypto.randomBytes(32).toString("base64url");
-        await writeTokenToFile(existingToken);
-
-        // Mock fs.promises.open to throw EEXIST on the first call, then succeed.
+        // No file on disk yet — loadOrCreateToken will generate a token and try
+        // open(wx). The spy intercepts, writes the "winner's" token inline
+        // (simulating the racing process winning), then throws EEXIST. Our code
+        // must fall back to readTokenFromFile and return the winner's token.
+        const winnerToken = crypto.randomBytes(32).toString("base64url");
+        const filePath = getTokenFilePath();
         const originalOpen = fs.promises.open;
-        let firstCall = true;
+        let exclAttempted = false;
+
         vi.spyOn(fs.promises, "open").mockImplementation(
-          async (filePath: fs.PathLike | fs.promises.FileHandle, flags: fs.OpenMode, ...rest) => {
-            if (firstCall && flags === "wx") {
-              firstCall = false;
-              const err = Object.assign(new Error("EEXIST: file already exists"), {
-                code: "EEXIST",
-              });
-              throw err;
+          async (fp: fs.PathLike | fs.promises.FileHandle, flags: fs.OpenMode, ...rest) => {
+            if (!exclAttempted && flags === "wx") {
+              exclAttempted = true;
+              // Write the winner's token to disk before throwing — simulates the
+              // other process winning the O_EXCL race and persisting its token.
+              await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+              await fs.promises.writeFile(filePath, winnerToken, "utf8");
+              throw Object.assign(new Error("EEXIST: file already exists"), { code: "EEXIST" });
             }
             // @ts-ignore — spread rest args for arity compat
-            return originalOpen(filePath, flags, ...rest);
+            return originalOpen(fp, flags, ...rest);
           },
         );
 
-        // Delete the file so loadOrCreateToken tries to generate a new one,
-        // then restore it before the mock throws to simulate the race.
-        const filePath = getTokenFilePath();
-        // Actually: the mock already wrote the file via writeTokenToFile above.
-        // Just call loadOrCreateToken — it will try open(wx), get EEXIST, and
-        // fall back to readTokenFromFile which returns existingToken.
         const result = await loadOrCreateToken();
-        expect(result).toBe(existingToken);
+        // Must adopt the winner's token, not the one we generated.
+        expect(result).toBe(winnerToken);
+        // Verify the EEXIST branch actually fired (not just the file-read path).
+        expect(exclAttempted).toBe(true);
       });
     });
 

--- a/tests/server/token-store.test.ts
+++ b/tests/server/token-store.test.ts
@@ -69,15 +69,20 @@ describe("token-store", () => {
       expect(read).toBe(token);
     });
 
-    it("creates parent directory if missing", async () => {
-      const token = crypto.randomBytes(32).toString("base64url");
-      // tempDir exists but no sub-dir for the token file yet
-      const nestedDir = path.join(tempDir, "nested", "sub");
-      vi.spyOn(path, "dirname").mockReturnValueOnce(nestedDir);
-      // Re-implement: just verify writeTokenToFile handles recursive mkdir
-      await writeTokenToFile(token);
-      const read = await readTokenFromFile();
-      expect(read).toBe(token);
+    it("creates parent directories if missing", async () => {
+      const originalTempDir = tempDir;
+      // Re-route getTokenFilePath() to a deeply nested path that doesn't exist yet.
+      // The env-paths mock uses a closure over `tempDir`, so changing it here redirects
+      // writeTokenToFile/readTokenFromFile to the new path.
+      tempDir = path.join(originalTempDir, "nested", "sub");
+      try {
+        const token = crypto.randomBytes(32).toString("base64url");
+        await writeTokenToFile(token);
+        expect(await readTokenFromFile()).toBe(token);
+      } finally {
+        // Restore so afterEach rm covers the whole subtree
+        tempDir = originalTempDir;
+      }
     });
   });
 
@@ -158,6 +163,15 @@ describe("token-store", () => {
 
       // vitest intercepts process.exit and throws its own error — we just
       // verify it was called with the right code rather than matching message.
+      await expect(loadOrCreateToken()).rejects.toThrow();
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("calls process.exit(1) when writeTokenToFile throws (EPERM)", async () => {
+      // Simulate unwritable directory: open("wx") throws EPERM
+      vi.spyOn(fs.promises, "open").mockRejectedValue(
+        Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" }),
+      );
       await expect(loadOrCreateToken()).rejects.toThrow();
       expect(mockExit).toHaveBeenCalledWith(1);
     });


### PR DESCRIPTION
## Summary

- Adds `src/server/auth/token-store.ts` — Node-side auth-token primitive: generate (`crypto.randomBytes(32)` base64url), persist with O_EXCL first-boot race protection, read with empty-token rejection, chmod 0600 on POSIX, NTFS ACL warning on Windows
- Adds `src-tauri/src/token_store.rs` — Rust keyring wrapper (DPAPI/Keychain/Secret Service) with env-paths file fallback; generates if neither source has a token; called before sidecar spawn
- `src/server/index.ts` — calls `loadOrCreateToken()` on CLI-mode boot (no-op until PR b wires it into auth middleware)
- `src/shared/constants.ts` — adds `TOKEN_FILE_NAME = "auth-token"`
- `src-tauri/Cargo.toml` — adds `keyring = "3"` and supporting crates

Zero user-visible behavior change. This is foundation for PR b (auth middleware) in the v0.7.0 Cowork auth series.

## Security invariants

- `crypto.randomBytes(32)` failure → `process.exit(1)` (never pseudorandom fallback)
- O_EXCL write (`fs.open(path, "wx")`) — on EEXIST, adopts the winner's token rather than overwriting
- Tauri mode: Rust generates BEFORE sidecar spawn; Node skips generation when `TANDEM_AUTH_TOKEN` env is present
- Token value never appears in any log line

## Test plan

- [ ] 12/12 unit tests in `tests/server/token-store.test.ts` pass
- [ ] `npm run typecheck` clean
- [ ] Manual: fresh boot on clean profile — `auth-token` file appears; restart — token reused; delete file — regenerates
- [ ] Manual: Tauri launch — keyring entry created; sidecar env includes `TANDEM_AUTH_TOKEN`

Part of: [v0.7.0 Cowork Foundation](docs/superpowers/plans/2026-04-16-durable-annotations-cowork.md)
Milestone: v0.7.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)