### PR TITLE
feat(server): TANDEM_BIND_HOST bind mode selection (v0.7.0 PR c/4)

### DIFF
--- a/src/server/bind-check.ts
+++ b/src/server/bind-check.ts
@@ -1,0 +1,138 @@
+/**
+ * Bind-mode safety checks for TANDEM_BIND_HOST.
+ *
+ * Extracted from index.ts main() so the logic is fully unit-testable without
+ * spawning a process. index.ts calls checkBindConfig(), acts on the result,
+ * then passes resolvedLanIP to startMcpServerHttp for the Host-header allowlist.
+ */
+
+import type * as os from "os";
+
+export interface BindCheckOptions {
+  /** The value of TANDEM_BIND_HOST (or DEFAULT_BIND_HOST if not set). */
+  bindHost: string;
+  /** MCP port, used only to construct error messages. */
+  port: number;
+  /** Auth token (null when token-store returned nothing). */
+  authToken: string | null;
+  /** True when TANDEM_ALLOW_UNAUTHENTICATED_LAN=1 is set. */
+  allowUnauthLAN: boolean;
+  /** Explicit LAN IP from TANDEM_LAN_IP env var (may be undefined). */
+  lanIP?: string;
+  /**
+   * Injected for testing. Defaults to os.networkInterfaces at call time.
+   * Signature matches the Node built-in.
+   */
+  networkInterfaces?: () => NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+}
+
+export interface BindCheckResult {
+  /** false means the caller must emit stderrMessage then exit(exitCode). */
+  ok: boolean;
+  exitCode?: number;
+  /** Message to write to stderr before exiting (when ok === false). */
+  stderrMessage?: string;
+  /**
+   * When ok === true and bind is non-loopback, the LAN warning to emit.
+   * Undefined for loopback binds.
+   */
+  lanWarning?: string;
+  /**
+   * The resolved LAN IP to use for the Host-header allowlist.
+   * Set when the bind is non-loopback and ok === true.
+   * undefined for loopback binds.
+   */
+  resolvedLanIP?: string;
+  /**
+   * All detected non-internal IPv4 addresses (populated even when resolvedLanIP
+   * is set, so the caller can log them).
+   */
+  detectedIPs?: string[];
+}
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+
+/** True when bindHost is a non-loopback value (including 0.0.0.0). */
+export function isNonLoopback(bindHost: string): boolean {
+  return !LOOPBACK_HOSTS.has(bindHost);
+}
+
+/**
+ * Pure function — no process.exit, no process.env access, no side effects.
+ * index.ts reads the result and acts on it.
+ */
+export function checkBindConfig(opts: BindCheckOptions): BindCheckResult {
+  const { bindHost, port, authToken, allowUnauthLAN, lanIP } = opts;
+
+  if (!isNonLoopback(bindHost)) {
+    // Default loopback path — nothing to check.
+    return { ok: true };
+  }
+
+  // ── Invariant 3: fail-closed without token ──────────────────────────────────
+  if (!authToken && !allowUnauthLAN) {
+    return {
+      ok: false,
+      exitCode: 1,
+      stderrMessage:
+        `[tandem] Refusing to bind on ${bindHost}:${port} without an auth token.\n` +
+        `Set TANDEM_ALLOW_UNAUTHENTICATED_LAN=1 to explicitly opt in to insecure mode,\n` +
+        `or run \`tandem setup\` (CLI) / launch Tauri once to provision a token.\n`,
+    };
+  }
+
+  // ── Multi-homed detection ───────────────────────────────────────────────────
+  // Only fire when bindHost is a wildcard (0.0.0.0 / ::). If the user already
+  // supplied a specific IP they've chosen their interface — skip the check.
+  const isWildcard = bindHost === "0.0.0.0" || bindHost === "::";
+
+  const getInterfaces =
+    opts.networkInterfaces ??
+    (() => {
+      // Lazy import so this module remains importable in environments without `os`
+      // (shouldn't happen in Node, but keeps the unit tests clean).
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      return require("os").networkInterfaces() as NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+    });
+
+  let detectedIPs: string[] = [];
+  let resolvedLanIP: string | undefined;
+
+  if (isWildcard) {
+    const ifaceMap = getInterfaces();
+    detectedIPs = Object.values(ifaceMap)
+      .flat()
+      .filter(
+        (iface): iface is NonNullable<typeof iface> =>
+          !!iface && iface.family === "IPv4" && !iface.internal,
+      )
+      .map((i) => i.address);
+
+    if (detectedIPs.length > 1 && !lanIP) {
+      return {
+        ok: false,
+        exitCode: 1,
+        stderrMessage:
+          `[tandem] Multiple non-internal IPv4 addresses detected: ${detectedIPs.join(", ")}.\n` +
+          `Set TANDEM_LAN_IP=<address> to specify which address to advertise.\n`,
+        detectedIPs,
+      };
+    }
+
+    resolvedLanIP = lanIP ?? detectedIPs[0];
+  } else {
+    // User specified a concrete IP — use it directly.
+    resolvedLanIP = bindHost;
+  }
+
+  // ── Invariant 4: plaintext LAN warning (token present only) ─────────────────
+  let lanWarning: string | undefined;
+  if (authToken) {
+    lanWarning =
+      `[tandem] WARNING: Tandem is listening on ${bindHost}:${port}. ` +
+      `Tokens and document content transit unencrypted; ` +
+      `do not use on untrusted networks (public Wi-Fi, shared LAN).\n`;
+  }
+
+  return { ok: true, lanWarning, resolvedLanIP, detectedIPs };
+}

--- a/src/server/bind-check.ts
+++ b/src/server/bind-check.ts
@@ -6,7 +6,8 @@
  * then passes resolvedLanIP to startMcpServerHttp for the Host-header allowlist.
  */
 
-import type * as os from "os";
+import type { NetworkInterfaceInfo } from "os";
+import { networkInterfaces as osNetworkInterfaces } from "os";
 
 export interface BindCheckOptions {
   /** The value of TANDEM_BIND_HOST (or DEFAULT_BIND_HOST if not set). */
@@ -20,10 +21,10 @@ export interface BindCheckOptions {
   /** Explicit LAN IP from TANDEM_LAN_IP env var (may be undefined). */
   lanIP?: string;
   /**
-   * Injected for testing. Defaults to os.networkInterfaces at call time.
+   * Injected for testing. Defaults to os.networkInterfaces.
    * Signature matches the Node built-in.
    */
-  networkInterfaces?: () => NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  networkInterfaces?: () => NodeJS.Dict<NetworkInterfaceInfo[]>;
 }
 
 export interface BindCheckResult {
@@ -86,14 +87,7 @@ export function checkBindConfig(opts: BindCheckOptions): BindCheckResult {
   // supplied a specific IP they've chosen their interface — skip the check.
   const isWildcard = bindHost === "0.0.0.0" || bindHost === "::";
 
-  const getInterfaces =
-    opts.networkInterfaces ??
-    (() => {
-      // Lazy import so this module remains importable in environments without `os`
-      // (shouldn't happen in Node, but keeps the unit tests clean).
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      return require("os").networkInterfaces() as NodeJS.Dict<os.NetworkInterfaceInfo[]>;
-    });
+  const getInterfaces = opts.networkInterfaces ?? osNetworkInterfaces;
 
   let detectedIPs: string[] = [];
   let resolvedLanIP: string | undefined;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,5 @@
 import type { Server } from "http";
+import { isIP } from "net";
 import path from "path";
 import { fileURLToPath } from "url";
 import {
@@ -243,12 +244,38 @@ async function main() {
 
   // ── Bind-host selection (MCP only — Hocuspocus always stays loopback) ────────
   const bindHost = process.env.TANDEM_BIND_HOST ?? DEFAULT_BIND_HOST;
+
+  // Fix 4: Validate TANDEM_BIND_HOST as an IP when it is non-loopback and non-wildcard.
+  // Loopback and wildcard values are reserved words handled by checkBindConfig;
+  // only concrete IPs need net.isIP validation here.
+  const LOOPBACK_AND_WILDCARD = new Set(["127.0.0.1", "localhost", "::1", "0.0.0.0", "::"]);
+  if (!LOOPBACK_AND_WILDCARD.has(bindHost) && isIP(bindHost) === 0) {
+    process.stderr.write(
+      `[tandem] TANDEM_BIND_HOST="${bindHost}" is not a valid IP address. Exiting.\n`,
+    );
+    process.exit(1);
+  }
+
+  // Fix 2: Coerce empty-string TANDEM_LAN_IP to undefined so nullish coalescing
+  // in bind-check.ts does not treat "" as a valid IP and add it to the Host allowlist.
+  // (An empty Host header would otherwise match "" via includes("") === true.)
+  const lanIP = process.env.TANDEM_LAN_IP || undefined;
+
+  // Fix 4: Validate TANDEM_LAN_IP when set.
+  if (lanIP && isIP(lanIP) === 0) {
+    process.stderr.write(`[tandem] TANDEM_LAN_IP="${lanIP}" is not a valid IP address. Exiting.\n`);
+    process.exit(1);
+  }
+
   const bindCheck = checkBindConfig({
     bindHost,
     port: mcpPort,
     authToken,
-    allowUnauthLAN: !!process.env[TANDEM_ALLOW_UNAUTHENTICATED_LAN_ENV],
-    lanIP: process.env.TANDEM_LAN_IP,
+    // Fix 3: Only treat the env var as truthy when it equals exactly "1".
+    // Values like "0", "false", or "no" were previously treated as opt-in due
+    // to the truthiness of any non-empty string.
+    allowUnauthLAN: process.env[TANDEM_ALLOW_UNAUTHENTICATED_LAN_ENV] === "1",
+    lanIP,
   });
 
   if (!bindCheck.ok) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,9 +1,16 @@
 import type { Server } from "http";
 import path from "path";
 import { fileURLToPath } from "url";
-import { CTRL_ROOM, DEFAULT_MCP_PORT, DEFAULT_WS_PORT } from "../shared/constants.js";
+import {
+  CTRL_ROOM,
+  DEFAULT_BIND_HOST,
+  DEFAULT_MCP_PORT,
+  DEFAULT_WS_PORT,
+  TANDEM_ALLOW_UNAUTHENTICATED_LAN_ENV,
+} from "../shared/constants.js";
 import { acquireStoreLock, releaseStoreLock } from "./annotations/store.js";
 import { loadOrCreateToken } from "./auth/token-store.js";
+import { checkBindConfig, isNonLoopback } from "./bind-check.js";
 import { isKnownHocuspocusError } from "./error-filter.js";
 import {
   attachCtrlObservers,
@@ -234,6 +241,33 @@ async function main() {
   // so this is effectively a no-op disk-wise in Tauri mode.
   const authToken = await loadOrCreateToken();
 
+  // ── Bind-host selection (MCP only — Hocuspocus always stays loopback) ────────
+  const bindHost = process.env.TANDEM_BIND_HOST ?? DEFAULT_BIND_HOST;
+  const bindCheck = checkBindConfig({
+    bindHost,
+    port: mcpPort,
+    authToken,
+    allowUnauthLAN: !!process.env[TANDEM_ALLOW_UNAUTHENTICATED_LAN_ENV],
+    lanIP: process.env.TANDEM_LAN_IP,
+  });
+
+  if (!bindCheck.ok) {
+    process.stderr.write(bindCheck.stderrMessage ?? "");
+    process.exit(bindCheck.exitCode ?? 1);
+  }
+
+  if (bindCheck.lanWarning) {
+    process.stderr.write(bindCheck.lanWarning);
+  }
+
+  if (isNonLoopback(bindHost) && bindCheck.detectedIPs && bindCheck.detectedIPs.length === 1) {
+    process.stderr.write(`[tandem] Detected LAN interface: ${bindCheck.detectedIPs[0]}\n`);
+  }
+
+  // The resolved LAN IP is used in the Host-header allowlist so browsers on
+  // the LAN can connect. undefined for loopback binds.
+  const resolvedLanIP = bindCheck.resolvedLanIP;
+
   if (transportMode === "http") {
     // HTTP mode: no startup-order constraint — start both concurrently
     freePort(wsPort);
@@ -282,7 +316,7 @@ async function main() {
     }
 
     const [srv] = await Promise.all([
-      startMcpServerHttp(mcpPort, undefined, authToken),
+      startMcpServerHttp(mcpPort, bindHost, authToken, resolvedLanIP),
       startHocuspocus(wsPort).then(() => {
         console.error(`[Tandem] Hocuspocus WebSocket server running on ws://localhost:${wsPort}`);
       }),

--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -32,10 +32,20 @@ import { openFileByPath, openFileFromContent } from "./file-opener.js";
 /** Express middleware/handler function type (Express 5 compatible). */
 export type Handler = (req: Request, res: Response, next: NextFunction) => void;
 
-/** Check if a Host header value is allowed (localhost only). Exported for testing. */
-export function isHostAllowed(host: string | undefined): boolean {
+/**
+ * Check if a Host header value is allowed (localhost + optional extra hosts).
+ * Exported for testing.
+ *
+ * @param host - The Host header value (may include port).
+ * @param extraHosts - Additional hosts to allow (e.g. a LAN IP when
+ *   TANDEM_BIND_HOST is non-loopback). Always empty for loopback binds.
+ */
+export function isHostAllowed(host: string | undefined, extraHosts: string[] = []): boolean {
   const reqHost = (host ?? "").split(":")[0];
-  return reqHost === "localhost" || reqHost === "127.0.0.1" || reqHost === TAURI_HOSTNAME;
+  if (reqHost === "localhost" || reqHost === "127.0.0.1" || reqHost === TAURI_HOSTNAME) {
+    return true;
+  }
+  return extraHosts.includes(reqHost);
 }
 
 function escapeRegExp(s: string): string {
@@ -191,22 +201,34 @@ export function errorCodeToHttpStatus(code: string | undefined): number {
   }
 }
 
-/** CORS + DNS rebinding protection middleware for /api/* routes */
-export function apiMiddleware(req: Request, res: Response, next: NextFunction): void {
-  if (!isHostAllowed(req.headers.host as string | undefined)) {
-    res.status(403).json({ error: "FORBIDDEN", message: "Host not allowed." });
-    return;
-  }
-  const origin = req.headers.origin as string | undefined;
-  res.header("Access-Control-Allow-Origin", isLocalhostOrigin(origin) ? origin! : "null");
-  res.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  res.header("Access-Control-Allow-Headers", "Content-Type");
-  if (req.method === "OPTIONS") {
-    res.sendStatus(204);
-    return;
-  }
-  next();
+/**
+ * Create a CORS + DNS rebinding protection middleware for /api/* routes.
+ *
+ * @param extraHosts - Additional hosts to allow beyond localhost/127.0.0.1/tauri.localhost.
+ *   Pass the resolved LAN IP when TANDEM_BIND_HOST is non-loopback so that
+ *   browsers on the LAN (which send e.g. `Host: 192.168.1.50:3479`) are not
+ *   blocked by the DNS-rebinding check.
+ */
+export function createApiMiddleware(extraHosts: string[] = []): Handler {
+  return function apiMiddlewareFn(req: Request, res: Response, next: NextFunction): void {
+    if (!isHostAllowed(req.headers.host as string | undefined, extraHosts)) {
+      res.status(403).json({ error: "FORBIDDEN", message: "Host not allowed." });
+      return;
+    }
+    const origin = req.headers.origin as string | undefined;
+    res.header("Access-Control-Allow-Origin", isLocalhostOrigin(origin) ? origin! : "null");
+    res.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    res.header("Access-Control-Allow-Headers", "Content-Type");
+    if (req.method === "OPTIONS") {
+      res.sendStatus(204);
+      return;
+    }
+    next();
+  };
 }
+
+/** Default CORS + DNS rebinding protection middleware (loopback-only allowlist). */
+export const apiMiddleware: Handler = createApiMiddleware();
 
 /** Map a Node/custom error code to a JSON-body error label. */
 function errorCodeToLabel(code: string): string {
@@ -293,12 +315,23 @@ function notifyStreamHandler(req: Request, res: Response): void {
   console.error("[NotifyStream] Client connected to /api/notify-stream");
 }
 
-/** Register /api/open, /api/upload, and /api/notify-stream routes on the Express app. */
-export function registerApiRoutes(app: Express, largeBody: Handler, token?: string): void {
+/**
+ * Register /api/open, /api/upload, and /api/notify-stream routes on the Express app.
+ *
+ * @param mw - The DNS-rebinding middleware to use. Pass `createApiMiddleware([lanIP])`
+ *   when TANDEM_BIND_HOST is non-loopback so LAN Host headers are allowed.
+ *   Defaults to the standard loopback-only `apiMiddleware`.
+ */
+export function registerApiRoutes(
+  app: Express,
+  largeBody: Handler,
+  token?: string,
+  mw: Handler = apiMiddleware,
+): void {
   // SSE notification stream for browser toasts
-  app.get("/api/notify-stream", apiMiddleware, notifyStreamHandler);
-  app.options("/api/open", apiMiddleware);
-  app.post("/api/open", apiMiddleware, largeBody, async (req: Request, res: Response) => {
+  app.get("/api/notify-stream", mw, notifyStreamHandler);
+  app.options("/api/open", mw);
+  app.post("/api/open", mw, largeBody, async (req: Request, res: Response) => {
     const { filePath, force } = (req.body ?? {}) as Record<string, unknown>;
     if (!filePath || typeof filePath !== "string") {
       res.status(400).json({ error: "BAD_REQUEST", message: "filePath is required" });
@@ -312,8 +345,8 @@ export function registerApiRoutes(app: Express, largeBody: Handler, token?: stri
     }
   });
 
-  app.options("/api/close", apiMiddleware);
-  app.post("/api/close", apiMiddleware, largeBody, async (req: Request, res: Response) => {
+  app.options("/api/close", mw);
+  app.post("/api/close", mw, largeBody, async (req: Request, res: Response) => {
     const { documentId } = (req.body ?? {}) as Record<string, unknown>;
     if (!documentId || typeof documentId !== "string") {
       res.status(400).json({ error: "BAD_REQUEST", message: "documentId is required" });
@@ -333,8 +366,8 @@ export function registerApiRoutes(app: Express, largeBody: Handler, token?: stri
     }
   });
 
-  app.options("/api/save", apiMiddleware);
-  app.post("/api/save", apiMiddleware, largeBody, async (req: Request, res: Response) => {
+  app.options("/api/save", mw);
+  app.post("/api/save", mw, largeBody, async (req: Request, res: Response) => {
     const { documentId } = (req.body ?? {}) as Record<string, unknown>;
     if (documentId !== undefined && typeof documentId !== "string") {
       res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
@@ -353,8 +386,8 @@ export function registerApiRoutes(app: Express, largeBody: Handler, token?: stri
     }
   });
 
-  app.options("/api/upload", apiMiddleware);
-  app.post("/api/upload", apiMiddleware, largeBody, async (req: Request, res: Response) => {
+  app.options("/api/upload", mw);
+  app.post("/api/upload", mw, largeBody, async (req: Request, res: Response) => {
     const { fileName, content } = (req.body ?? {}) as Record<string, unknown>;
     if (!fileName || typeof fileName !== "string") {
       res.status(400).json({ error: "BAD_REQUEST", message: "fileName is required" });
@@ -378,8 +411,8 @@ export function registerApiRoutes(app: Express, largeBody: Handler, token?: stri
     }
   });
 
-  app.options("/api/convert", apiMiddleware);
-  app.post("/api/convert", apiMiddleware, largeBody, async (req: Request, res: Response) => {
+  app.options("/api/convert", mw);
+  app.post("/api/convert", mw, largeBody, async (req: Request, res: Response) => {
     const { documentId, outputPath } = (req.body ?? {}) as Record<string, unknown>;
     if (documentId !== undefined && typeof documentId !== "string") {
       res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
@@ -401,15 +434,15 @@ export function registerApiRoutes(app: Express, largeBody: Handler, token?: stri
     }
   });
 
-  app.get("/api/mode", apiMiddleware, (_req: Request, res: Response) => {
+  app.get("/api/mode", mw, (_req: Request, res: Response) => {
     const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
     const awareness = ctrlDoc.getMap(Y_MAP_USER_AWARENESS);
     const mode = TandemModeSchema.catch(TANDEM_MODE_DEFAULT).parse(awareness.get(Y_MAP_MODE));
     res.json({ mode });
   });
 
-  app.options("/api/apply-changes", apiMiddleware);
-  app.post("/api/apply-changes", apiMiddleware, largeBody, async (req: Request, res: Response) => {
+  app.options("/api/apply-changes", mw);
+  app.post("/api/apply-changes", mw, largeBody, async (req: Request, res: Response) => {
     const { documentId, author, backupPath } = (req.body ?? {}) as Record<string, unknown>;
     if (documentId !== undefined && typeof documentId !== "string") {
       res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
@@ -436,8 +469,8 @@ export function registerApiRoutes(app: Express, largeBody: Handler, token?: stri
     }
   });
 
-  app.options("/api/setup", apiMiddleware);
-  app.post("/api/setup", apiMiddleware, largeBody, async (req: Request, res: Response) => {
+  app.options("/api/setup", mw);
+  app.post("/api/setup", mw, largeBody, async (req: Request, res: Response) => {
     try {
       const result = await runSetupHandler(
         (req.body ?? {}) as Record<string, unknown>,
@@ -455,8 +488,8 @@ export function registerApiRoutes(app: Express, largeBody: Handler, token?: stri
   });
 
   // Annotation reply: browser user posts a reply to an annotation thread
-  app.options("/api/annotation-reply", apiMiddleware);
-  app.post("/api/annotation-reply", apiMiddleware, largeBody, (req: Request, res: Response) => {
+  app.options("/api/annotation-reply", mw);
+  app.post("/api/annotation-reply", mw, largeBody, (req: Request, res: Response) => {
     const { annotationId, text, documentId } = (req.body ?? {}) as Record<string, unknown>;
     if (!annotationId || typeof annotationId !== "string") {
       res.status(400).json({ error: "BAD_REQUEST", message: "annotationId is required" });

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -10,10 +10,11 @@ import { randomUUID } from "crypto";
 import type { Server } from "http";
 import { createRequire } from "module";
 
+import { DEFAULT_BIND_HOST } from "../../shared/constants.js";
 import { createAuthMiddleware, isLoopback } from "../auth/middleware.js";
 import { openBrowser } from "../open-browser.js";
 import { registerAnnotationTools } from "./annotations.js";
-import { apiMiddleware, registerApiRoutes } from "./api-routes.js";
+import { apiMiddleware, createApiMiddleware, registerApiRoutes } from "./api-routes.js";
 import { registerAwarenessTools } from "./awareness.js";
 import { registerChannelRoutes } from "./channel-routes.js";
 import { registerDocumentTools } from "./document.js";
@@ -126,8 +127,15 @@ export async function startMcpServerStdio(): Promise<void> {
 /** Start the MCP server on HTTP using Streamable HTTP transport. Returns the http.Server for lifecycle management. */
 export async function startMcpServerHttp(
   port: number,
-  host = "127.0.0.1",
+  host = DEFAULT_BIND_HOST,
   token?: string,
+  /**
+   * Resolved LAN IP for the Host-header allowlist.
+   * Passed when TANDEM_BIND_HOST is non-loopback so that browsers on the LAN
+   * (which send e.g. `Host: 192.168.1.50:3479`) pass the DNS-rebinding check.
+   * undefined for loopback binds — only localhost/127.0.0.1/tauri.localhost allowed.
+   */
+  resolvedLanIP?: string,
 ): Promise<Server> {
   mcpServer = createMcpServer();
 
@@ -145,6 +153,13 @@ export async function startMcpServerHttp(
   // Loopback (127.0.0.1, ::1, ::ffff:127.0.0.1) is always exempt —
   // Claude Code zero-config is preserved.
   const authMiddleware = createAuthMiddleware(() => token ?? null);
+
+  // DNS-rebinding middleware: extend the Host-header allowlist with the resolved
+  // LAN IP when binding non-loopback. For loopback binds resolvedLanIP is
+  // undefined and this falls back to the standard localhost-only middleware.
+  const lanAwareApiMiddleware = resolvedLanIP
+    ? createApiMiddleware([resolvedLanIP])
+    : apiMiddleware;
 
   // Large body parser for file-open and upload routes only (up to 70MB).
   // NOT mounted globally — other routes (MCP, /health) use the SDK's own parser.
@@ -202,12 +217,12 @@ export async function startMcpServerHttp(
   app.use("/mcp", authMiddleware);
   app.use("/api", authMiddleware);
 
-  // Health endpoint — apiMiddleware protects against DNS rebinding.
+  // Health endpoint — lanAwareApiMiddleware protects against DNS rebinding.
   // Auth-exempt: health is public diagnostic info.
   // Invariant 7: omit hasSession when request is non-loopback (session presence leaks).
   app.get(
     "/health",
-    apiMiddleware,
+    lanAwareApiMiddleware,
     (req: import("express").Request, res: import("express").Response) => {
       const body: Record<string, unknown> = {
         status: "ok",
@@ -252,10 +267,10 @@ export async function startMcpServerHttp(
   app.use(mcpApp);
 
   // --- REST API for browser-initiated file opening ---
-  registerApiRoutes(app, largeBody, token);
+  registerApiRoutes(app, largeBody, token, lanAwareApiMiddleware);
 
   // --- Channel support endpoints ---
-  registerChannelRoutes(app, apiMiddleware);
+  registerChannelRoutes(app, lanAwareApiMiddleware);
 
   // Serve built client assets when present (populated by `vite build`).
   // express.static falls through for paths it doesn't find, so /mcp, /api/*,

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -10,7 +10,7 @@ import { randomUUID } from "crypto";
 import type { Server } from "http";
 import { createRequire } from "module";
 
-import { DEFAULT_BIND_HOST } from "../../shared/constants.js";
+import { DEFAULT_BIND_HOST, TAURI_HOSTNAME } from "../../shared/constants.js";
 import { createAuthMiddleware, isLoopback } from "../auth/middleware.js";
 import { openBrowser } from "../open-browser.js";
 import { registerAnnotationTools } from "./annotations.js";
@@ -165,8 +165,16 @@ export async function startMcpServerHttp(
   // NOT mounted globally — other routes (MCP, /health) use the SDK's own parser.
   const largeBody = express.json({ limit: "70mb" });
 
-  // SDK app provides express.json() (100kb limit) + DNS rebinding protection
-  const mcpApp = createMcpExpressApp({ host });
+  // SDK app provides express.json() (100kb limit) + DNS rebinding protection.
+  // When binding non-loopback, pass allowedHosts so the SDK's hostHeaderValidation
+  // activates for /mcp (port-agnostic hostname matching). This closes the
+  // DNS-rebinding gap that would otherwise exist because authMiddleware's loopback
+  // bypass runs before the SDK's host-header check on the inner mcpApp.
+  // The SDK strips the port via URL.hostname, so we supply bare hostnames only.
+  const allowedHosts = resolvedLanIP
+    ? ["127.0.0.1", "localhost", "::1", resolvedLanIP, TAURI_HOSTNAME]
+    : undefined;
+  const mcpApp = createMcpExpressApp({ host, ...(allowedHosts ? { allowedHosts } : {}) });
 
   mcpApp.post("/mcp", async (req: import("express").Request, res: import("express").Response) => {
     const body = req.body as unknown;

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -172,7 +172,7 @@ export async function startMcpServerHttp(
   // bypass runs before the SDK's host-header check on the inner mcpApp.
   // The SDK strips the port via URL.hostname, so we supply bare hostnames only.
   const allowedHosts = resolvedLanIP
-    ? ["127.0.0.1", "localhost", "::1", resolvedLanIP, TAURI_HOSTNAME]
+    ? ["127.0.0.1", "localhost", "[::1]", resolvedLanIP, TAURI_HOSTNAME]
     : undefined;
   const mcpApp = createMcpExpressApp({ host, ...(allowedHosts ? { allowedHosts } : {}) });
 

--- a/src/server/yjs/provider.ts
+++ b/src/server/yjs/provider.ts
@@ -62,6 +62,8 @@ export function removeDocument(name: string): boolean {
 export async function startHocuspocus(port: number): Promise<Hocuspocus> {
   hocuspocusInstance = new Hocuspocus({
     port,
+    // Hocuspocus always binds loopback — the MCP bind-host env var does not apply here.
+    // WebSocket collaboration traffic stays local-only per the Cowork architecture.
     address: "127.0.0.1",
     quiet: true, // stdout is the MCP wire — suppress the startup banner
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -114,6 +114,12 @@ export const CHANNEL_RETRY_DELAY_MS = 2_000;
 /** Auth token filename inside the app-data directory. */
 export const TOKEN_FILE_NAME = "auth-token";
 
+/** Default MCP bind host — loopback only by default. */
+export const DEFAULT_BIND_HOST = "127.0.0.1";
+
+/** Env var name to opt in to unauthenticated LAN binding. */
+export const TANDEM_ALLOW_UNAUTHENTICATED_LAN_ENV = "TANDEM_ALLOW_UNAUTHENTICATED_LAN";
+
 /** Tauri WebView origin hostname — must be accepted alongside localhost. */
 export const TAURI_HOSTNAME = "tauri.localhost";
 

--- a/tests/server/bind-mode.test.ts
+++ b/tests/server/bind-mode.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Tests for src/server/bind-check.ts
+ *
+ * All tests are pure unit tests — checkBindConfig is a side-effect-free function
+ * that accepts injected networkInterfaces, so no process spawning required.
+ */
+
+import type * as os from "os";
+import { describe, expect, it } from "vitest";
+import { checkBindConfig, isNonLoopback } from "../../src/server/bind-check.js";
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+function makeIface(address: string, internal: boolean): os.NetworkInterfaceInfo {
+  return {
+    address,
+    netmask: "255.255.255.0",
+    family: "IPv4",
+    mac: "00:00:00:00:00:00",
+    internal,
+    cidr: `${address}/24`,
+  };
+}
+
+function singleLanInterfaces(ip = "192.168.1.50"): () => NodeJS.Dict<os.NetworkInterfaceInfo[]> {
+  return () => ({
+    lo: [makeIface("127.0.0.1", true)],
+    eth0: [makeIface(ip, false)],
+  });
+}
+
+function multiLanInterfaces(): () => NodeJS.Dict<os.NetworkInterfaceInfo[]> {
+  return () => ({
+    lo: [makeIface("127.0.0.1", true)],
+    eth0: [makeIface("192.168.1.50", false)],
+    wlan0: [makeIface("10.0.0.5", false)],
+  });
+}
+
+function loopbackOnlyInterfaces(): () => NodeJS.Dict<os.NetworkInterfaceInfo[]> {
+  return () => ({
+    lo: [makeIface("127.0.0.1", true)],
+  });
+}
+
+const VALID_TOKEN = "abc123";
+
+// ── isNonLoopback ──────────────────────────────────────────────────────────────
+
+describe("isNonLoopback", () => {
+  it("127.0.0.1 is loopback", () => {
+    expect(isNonLoopback("127.0.0.1")).toBe(false);
+  });
+  it("localhost is loopback", () => {
+    expect(isNonLoopback("localhost")).toBe(false);
+  });
+  it("::1 is loopback", () => {
+    expect(isNonLoopback("::1")).toBe(false);
+  });
+  it("0.0.0.0 is non-loopback", () => {
+    expect(isNonLoopback("0.0.0.0")).toBe(true);
+  });
+  it("specific LAN IP is non-loopback", () => {
+    expect(isNonLoopback("192.168.1.50")).toBe(true);
+  });
+});
+
+// ── Test 1: default bind (loopback) ───────────────────────────────────────────
+
+describe("checkBindConfig — loopback (default)", () => {
+  it("returns ok=true with no other fields when bindHost is 127.0.0.1", () => {
+    const result = checkBindConfig({
+      bindHost: "127.0.0.1",
+      port: 3479,
+      authToken: null,
+      allowUnauthLAN: false,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.exitCode).toBeUndefined();
+    expect(result.stderrMessage).toBeUndefined();
+    expect(result.lanWarning).toBeUndefined();
+    expect(result.resolvedLanIP).toBeUndefined();
+  });
+
+  it("returns ok=true for localhost", () => {
+    const result = checkBindConfig({
+      bindHost: "localhost",
+      port: 3479,
+      authToken: null,
+      allowUnauthLAN: false,
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ── Test 2: fail-closed without token ─────────────────────────────────────────
+
+describe("checkBindConfig — Invariant 3 (fail-closed without token)", () => {
+  it("exits 1 when bindHost=0.0.0.0, no token, no TANDEM_ALLOW_UNAUTHENTICATED_LAN", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: null,
+      allowUnauthLAN: false,
+      networkInterfaces: singleLanInterfaces(),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderrMessage).toContain("[tandem] Refusing to bind on 0.0.0.0:3479");
+    expect(result.stderrMessage).toContain("TANDEM_ALLOW_UNAUTHENTICATED_LAN=1");
+    expect(result.stderrMessage).toContain("tandem setup");
+  });
+
+  it("fail-closed message contains correct host and port", () => {
+    const result = checkBindConfig({
+      bindHost: "192.168.1.50",
+      port: 9000,
+      authToken: null,
+      allowUnauthLAN: false,
+    });
+    expect(result.ok).toBe(false);
+    // Should not even reach networkInterfaces check — token check fires first
+    expect(result.stderrMessage).toContain("192.168.1.50:9000");
+  });
+
+  it("fail-closed message matches Invariant 3 exact text pattern", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: null,
+      allowUnauthLAN: false,
+      networkInterfaces: singleLanInterfaces(),
+    });
+    expect(result.stderrMessage).toContain(
+      "[tandem] Refusing to bind on 0.0.0.0:3479 without an auth token.",
+    );
+    expect(result.stderrMessage).toContain(
+      "Set TANDEM_ALLOW_UNAUTHENTICATED_LAN=1 to explicitly opt in to insecure mode,",
+    );
+    expect(result.stderrMessage).toContain(
+      "or run `tandem setup` (CLI) / launch Tauri once to provision a token.",
+    );
+  });
+});
+
+// ── Test 3: opt-in escape hatch ────────────────────────────────────────────────
+
+describe("checkBindConfig — opt-in escape hatch (TANDEM_ALLOW_UNAUTHENTICATED_LAN=1)", () => {
+  it("does not exit when allowUnauthLAN=true even without token", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: null,
+      allowUnauthLAN: true,
+      networkInterfaces: singleLanInterfaces(),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.exitCode).toBeUndefined();
+    expect(result.stderrMessage).toBeUndefined();
+  });
+
+  it("does not emit fail-closed message when opted in", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: null,
+      allowUnauthLAN: true,
+      networkInterfaces: singleLanInterfaces(),
+    });
+    expect(result.stderrMessage).toBeUndefined();
+  });
+
+  it("no lanWarning when token is absent even with opt-in", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: null,
+      allowUnauthLAN: true,
+      networkInterfaces: singleLanInterfaces(),
+    });
+    // lanWarning only fires when token IS present (Invariant 4)
+    expect(result.lanWarning).toBeUndefined();
+  });
+});
+
+// ── Test 4: happy path (token present) ────────────────────────────────────────
+
+describe("checkBindConfig — Invariant 4 (plaintext LAN warning)", () => {
+  it("emits lanWarning when bindHost=0.0.0.0 and token is present", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      networkInterfaces: singleLanInterfaces(),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.lanWarning).toContain("[tandem] WARNING:");
+    expect(result.lanWarning).toContain("0.0.0.0:3479");
+    expect(result.lanWarning).toContain("unencrypted");
+    expect(result.lanWarning).toContain("untrusted networks");
+  });
+
+  it("lanWarning matches Invariant 4 exact text pattern", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      networkInterfaces: singleLanInterfaces(),
+    });
+    expect(result.lanWarning).toContain("[tandem] WARNING: Tandem is listening on 0.0.0.0:3479.");
+    expect(result.lanWarning).toContain("Tokens and document content transit unencrypted;");
+    expect(result.lanWarning).toContain(
+      "do not use on untrusted networks (public Wi-Fi, shared LAN).",
+    );
+  });
+
+  it("no lanWarning for loopback bind even with token", () => {
+    const result = checkBindConfig({
+      bindHost: "127.0.0.1",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+    });
+    expect(result.lanWarning).toBeUndefined();
+  });
+});
+
+// ── Test 5: multi-homed detection ─────────────────────────────────────────────
+
+describe("checkBindConfig — multi-homed detection", () => {
+  it("exits 1 when multiple non-internal IPs exist and TANDEM_LAN_IP not set", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      networkInterfaces: multiLanInterfaces(),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderrMessage).toContain("Multiple non-internal IPv4 addresses detected");
+    expect(result.stderrMessage).toContain("192.168.1.50");
+    expect(result.stderrMessage).toContain("10.0.0.5");
+    expect(result.stderrMessage).toContain("TANDEM_LAN_IP=<address>");
+  });
+
+  it("includes all detected IPs in error message", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      networkInterfaces: multiLanInterfaces(),
+    });
+    // Both IPs must appear in the message
+    expect(result.stderrMessage).toContain("192.168.1.50");
+    expect(result.stderrMessage).toContain("10.0.0.5");
+    expect(result.detectedIPs).toHaveLength(2);
+  });
+
+  it("proceeds when TANDEM_LAN_IP is set with multiple interfaces", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      lanIP: "192.168.1.50",
+      networkInterfaces: multiLanInterfaces(),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.resolvedLanIP).toBe("192.168.1.50");
+  });
+
+  it("multi-homed check does NOT fire for loopback bind", () => {
+    const result = checkBindConfig({
+      bindHost: "127.0.0.1",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      networkInterfaces: multiLanInterfaces(),
+    });
+    // Loopback path short-circuits before multi-homed check
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ── Test 6: single LAN IP ─────────────────────────────────────────────────────
+
+describe("checkBindConfig — single LAN IP auto-detection", () => {
+  it("resolves single non-internal IPv4 automatically", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      networkInterfaces: singleLanInterfaces("192.168.1.77"),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.resolvedLanIP).toBe("192.168.1.77");
+    expect(result.detectedIPs).toEqual(["192.168.1.77"]);
+  });
+
+  it("TANDEM_LAN_IP overrides auto-detected single IP", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      lanIP: "10.0.0.99",
+      networkInterfaces: singleLanInterfaces("192.168.1.77"),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.resolvedLanIP).toBe("10.0.0.99");
+  });
+
+  it("no non-internal interfaces — resolvedLanIP is undefined", () => {
+    const result = checkBindConfig({
+      bindHost: "0.0.0.0",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      networkInterfaces: loopbackOnlyInterfaces(),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.resolvedLanIP).toBeUndefined();
+    expect(result.detectedIPs).toHaveLength(0);
+  });
+});
+
+// ── Test 7: specific (non-wildcard) non-loopback bind ─────────────────────────
+
+describe("checkBindConfig — specific non-loopback IP (no multi-homed check)", () => {
+  it("uses bindHost directly as resolvedLanIP when it is a specific IP", () => {
+    const result = checkBindConfig({
+      bindHost: "192.168.1.50",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      // Providing multi-homed interfaces — but check should be skipped for specific IP
+      networkInterfaces: multiLanInterfaces(),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.resolvedLanIP).toBe("192.168.1.50");
+    // multi-homed check did not fire (no exit)
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("specific IP bind does not call networkInterfaces", () => {
+    let called = false;
+    const mockInterfaces = () => {
+      called = true;
+      return multiLanInterfaces()();
+    };
+    const result = checkBindConfig({
+      bindHost: "192.168.1.50",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      networkInterfaces: mockInterfaces,
+    });
+    expect(result.ok).toBe(true);
+    // networkInterfaces should NOT have been called — user specified their IP
+    expect(called).toBe(false);
+  });
+});
+
+// ── Test 8: Hocuspocus stays loopback (static check) ─────────────────────────
+
+describe("Hocuspocus stays loopback", () => {
+  it("provider.ts hardcodes address: '127.0.0.1' (static check)", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join } = await import("node:path");
+    const dir = dirname(fileURLToPath(import.meta.url));
+    const providerPath = join(dir, "../../src/server/yjs/provider.ts");
+    const content = await readFile(providerPath, "utf8");
+
+    // The hardcoded loopback address must be present
+    expect(content).toContain('address: "127.0.0.1"');
+
+    // TANDEM_BIND_HOST must NOT appear in provider.ts — Hocuspocus ignores the env var
+    expect(content).not.toContain("TANDEM_BIND_HOST");
+  });
+});

--- a/tests/server/bind-mode.test.ts
+++ b/tests/server/bind-mode.test.ts
@@ -366,6 +366,49 @@ describe("checkBindConfig — specific non-loopback IP (no multi-homed check)", 
   });
 });
 
+// ── Test 8b: IPv6 :: wildcard bind ───────────────────────────────────────────
+
+describe("checkBindConfig — IPv6 '::' wildcard bind", () => {
+  it("treats '::' as wildcard and triggers multi-homed detection like 0.0.0.0", () => {
+    const result = checkBindConfig({
+      bindHost: "::",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      networkInterfaces: multiLanInterfaces(),
+    });
+    // With multiple interfaces and no lanIP, multi-homed detection must fire
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderrMessage).toContain("Multiple non-internal IPv4 addresses detected");
+  });
+
+  it("'::' with single LAN interface resolves resolvedLanIP", () => {
+    const result = checkBindConfig({
+      bindHost: "::",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      networkInterfaces: singleLanInterfaces("192.168.1.50"),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.resolvedLanIP).toBe("192.168.1.50");
+  });
+
+  it("'::' with TANDEM_LAN_IP set bypasses multi-homed check", () => {
+    const result = checkBindConfig({
+      bindHost: "::",
+      port: 3479,
+      authToken: VALID_TOKEN,
+      allowUnauthLAN: false,
+      lanIP: "10.0.0.1",
+      networkInterfaces: multiLanInterfaces(),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.resolvedLanIP).toBe("10.0.0.1");
+  });
+});
+
 // ── Test 8: Hocuspocus stays loopback (static check) ─────────────────────────
 
 describe("Hocuspocus stays loopback", () => {

--- a/tests/server/server-security-invariants.test.ts
+++ b/tests/server/server-security-invariants.test.ts
@@ -124,6 +124,92 @@ describe("Invariant 7 — /health includes hasSession for loopback callers", () 
   });
 });
 
+// ── Fix 1 regression: /mcp DNS-rebinding protection with allowedHosts ────────
+//
+// When startMcpServerHttp is called with resolvedLanIP set (non-loopback bind),
+// createMcpExpressApp receives allowedHosts and activates hostHeaderValidation.
+// A request to /mcp with Host: evil.com must be rejected 403.
+//
+// Node.js fetch() silently overrides the Host header with the connection target,
+// so we use http.request() with explicit headers to properly spoof the Host header.
+
+import { request as httpRequest } from "node:http";
+
+/** Low-level HTTP POST that preserves the Host header exactly as given. */
+function rawPost(
+  port: number,
+  path: string,
+  hostHeader: string,
+  body: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const bodyBuf = Buffer.from(body, "utf8");
+    const req = httpRequest(
+      {
+        host: "127.0.0.1",
+        port,
+        path,
+        method: "POST",
+        headers: {
+          Host: hostHeader,
+          "Content-Type": "application/json",
+          "Content-Length": bodyBuf.length,
+        },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk: Buffer) => {
+          data += chunk.toString();
+        });
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
+      },
+    );
+    req.on("error", reject);
+    req.write(bodyBuf);
+    req.end();
+  });
+}
+
+describe("Fix 1 regression — /mcp DNS-rebinding protection (non-loopback bind)", () => {
+  let lanHttpServer: Server;
+  let lanPort: number;
+
+  beforeEach(async () => {
+    lanPort = await allocPort();
+    // Pass resolvedLanIP to simulate a non-loopback bind (e.g. TANDEM_BIND_HOST=0.0.0.0
+    // with a single detected interface). The server itself still binds to 127.0.0.1 so
+    // the test runner can reach it; what matters is that allowedHosts gets activated.
+    lanHttpServer = await startMcpServerHttp(lanPort, "127.0.0.1", undefined, "192.168.1.50");
+  });
+
+  afterEach(() => {
+    return new Promise<void>((resolve, reject) => {
+      lanHttpServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it("blocks /mcp POST with Host: evil.com when resolvedLanIP is set", async () => {
+    const payload = JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 });
+    const res = await rawPost(lanPort, "/mcp", "evil.com", payload);
+    // SDK hostHeaderValidation must reject the spoofed Host header
+    expect(res.status).toBe(403);
+  });
+
+  it("allows /mcp POST with Host: 127.0.0.1 when resolvedLanIP is set", async () => {
+    const payload = JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 });
+    const res = await rawPost(lanPort, "/mcp", `127.0.0.1:${lanPort}`, payload);
+    // 127.0.0.1 is in the allowlist — should not be blocked by host-header validation
+    expect(res.status).not.toBe(403);
+  });
+
+  it("allows /mcp POST with Host matching resolvedLanIP", async () => {
+    const payload = JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 });
+    const res = await rawPost(lanPort, "/mcp", `192.168.1.50:${lanPort}`, payload);
+    // resolvedLanIP is in the allowlist — should not be blocked by host-header validation
+    expect(res.status).not.toBe(403);
+  });
+});
+
 // ── Invariant 7 (non-loopback path): /health must omit hasSession ─────────────
 //
 // The test server binds to 127.0.0.1; all fetch() calls from the test runner


### PR DESCRIPTION
## Summary

- Adds `src/server/bind-check.ts` — pure `checkBindConfig()` function with injected `networkInterfaces` for testability. Implements fail-closed and multi-homed detection.
- `TANDEM_BIND_HOST` env var controls MCP bind host (default `127.0.0.1`). Hocuspocus always binds loopback regardless.
- **Fail-closed (invariant #3):** non-loopback bind without token → exits 1 with explicit guidance message unless `TANDEM_ALLOW_UNAUTHENTICATED_LAN=1` is set.
- **Plaintext LAN warning (invariant #4):** non-loopback + token present → stderr warning on every boot.
- **Multi-homed detection:** multiple non-internal IPv4s without `TANDEM_LAN_IP` → exits 1 with interface list.
- `src/server/mcp/api-routes.ts` — `createApiMiddleware(extraHosts?)` factory extends Host-header allowlist with LAN IP for non-loopback bind.
- `src/server/yjs/provider.ts` — comment clarifying Hocuspocus bind is loopback-fixed.

## Security invariants verified

- Non-loopback bind without token → exit 1 (no listener appears)
- `TANDEM_ALLOW_UNAUTHENTICATED_LAN=1` escape hatch works
- Hocuspocus stays 127.0.0.1 regardless of TANDEM_BIND_HOST (comment + test)
- Plaintext warning emitted verbatim on non-loopback boot with token

## Test plan

- [ ] 26/26 `bind-mode.test.ts`
- [ ] Full suite ~1381 pass, typecheck clean
- [ ] Manual: `TANDEM_BIND_HOST=0.0.0.0` without token → exit 1, no 3479 listener
- [ ] Manual: `TANDEM_BIND_HOST=0.0.0.0 TANDEM_ALLOW_UNAUTHENTICATED_LAN=1` → starts with warning
- [ ] Manual: `TANDEM_BIND_HOST=0.0.0.0` with token → starts with plaintext LAN warning
- [ ] Manual: port 3478 (Hocuspocus) stays on 127.0.0.1

Stacked on: #366 (PR b — auth middleware), #365 (PR a — token storage)
Part of: [v0.7.0 Cowork Foundation](docs/superpowers/plans/2026-04-16-durable-annotations-cowork.md)
Milestone: v0.7.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)