### PR TITLE
feat(cowork): Windows per-workspace plugin installer + firewall scoping (v0.8.0 PR e)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1190,6 +1190,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4270,6 +4280,7 @@ version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",
+ "fs2",
  "keyring",
  "log",
  "rand 0.8.6",
@@ -4286,6 +4297,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tempfile",
  "tokio",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,5 +40,10 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-updater = "2"
 
+[features]
+# Test-only hooks: TANDEM_COWORK_ROOT_OVERRIDE env-var reads.
+# Auto-enabled for `cargo test` via `#[cfg(test)]`; OFF for `cargo build --release`.
+cowork-test-hooks = []
+
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,8 +33,12 @@ keyring = "3"
 base64 = "0.22"
 dirs = "6"
 rand = "0.8"
+fs2 = "0.4"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-updater = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "enables the default permissions",
+  "description": "Default permissions. Cowork tauri::commands are enumerated in src/lib.rs invoke_handler! (commands: cowork_scan_workspaces, cowork_toggle_integration, cowork_rescan, cowork_get_status, cowork_get_meta, cowork_detect_vethernet_subnet, cowork_apply_token, cowork_install_into_workspace, cowork_uninstall_from_workspace, cowork_set_lan_ip_override, cowork_retry_admin_elevation).",
   "windows": [
     "main"
   ],

--- a/src-tauri/src/cowork_atomic_json.rs
+++ b/src-tauri/src/cowork_atomic_json.rs
@@ -219,8 +219,7 @@ where
         let mutation_result = mutate(&mut json_value)?;
 
         // Write to temp file in the same directory (same volume — atomic rename).
-        let tmp_name = format!(".tandem-tmp-{}", rand_hex(8));
-        let tmp_path = dir.join(&tmp_name);
+        let tmp_path = dir.join(format!(".tandem-tmp-{}", unique_suffix()));
 
         let serialised = serde_json::to_string_pretty(&json_value)?;
 
@@ -273,16 +272,18 @@ fn json_value_type_name(v: &Value) -> &'static str {
     }
 }
 
-/// Generate a short random hex string for temp-file suffixes.
-fn rand_hex(len: usize) -> String {
-    use rand::RngCore;
-    let mut bytes = vec![0u8; (len + 1) / 2];
-    rand::thread_rng().fill_bytes(&mut bytes);
-    bytes
-        .iter()
-        .map(|b| format!("{b:02x}"))
-        .collect::<String>()
-        .chars()
-        .take(len)
-        .collect()
+/// Generate a per-process-unique hex suffix for temp files.
+///
+/// Combines PID, monotonic nanosecond timestamp, and a process-local counter —
+/// sufficient to avoid collisions with concurrent writers and leftover files
+/// from a crashed previous run. Cryptographic randomness is not required here.
+pub(crate) fn unique_suffix() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let count = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{:x}-{:x}-{:x}", std::process::id(), nanos, count)
 }

--- a/src-tauri/src/cowork_atomic_json.rs
+++ b/src-tauri/src/cowork_atomic_json.rs
@@ -223,7 +223,7 @@ where
 
         let serialised = serde_json::to_string_pretty(&json_value)?;
 
-        {
+        let write_result: std::io::Result<()> = (|| {
             use std::io::Write;
             let mut tmp_file = std::fs::OpenOptions::new()
                 .write(true)
@@ -232,6 +232,12 @@ where
             tmp_file.write_all(serialised.as_bytes())?;
             tmp_file.flush()?;
             tmp_file.sync_all()?;
+            Ok(())
+        })();
+
+        if let Err(e) = write_result {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(e.into());
         }
 
         // Atomic rename into place. Safe on Windows now because we only hold

--- a/src-tauri/src/cowork_atomic_json.rs
+++ b/src-tauri/src/cowork_atomic_json.rs
@@ -246,12 +246,12 @@ where
     })();
 
     // Release the lock regardless of outcome.
+    // The lock file is persistent — never deleted. Mutual exclusion lives in
+    // the lock state, not the file's existence.  Deleting it between unlock()
+    // and the next writer's open() would let two writers hold the critical
+    // section simultaneously (classic TOCTOU race on lock files).
     let _ = FileExt::unlock(&lock_file);
-    // Best-effort cleanup of the sidecar lock file. If another process picked
-    // up the lock between our unlock and this remove, the remove silently
-    // fails — that's fine; they own it now.
     drop(lock_file);
-    let _ = std::fs::remove_file(&lock_path);
 
     result
 }

--- a/src-tauri/src/cowork_atomic_json.rs
+++ b/src-tauri/src/cowork_atomic_json.rs
@@ -1,0 +1,288 @@
+//! Atomic read-modify-write helper for Cowork registry JSON files.
+//!
+//! All Cowork plugin-registry files (`installed_plugins.json`,
+//! `known_marketplaces.json`, `cowork_settings.json`) go through
+//! `with_locked_json` so they share the same lock/read/merge/write/unlock path.
+//!
+//! **Security invariants:**
+//! - Writes the temp file into the SAME directory as the destination so that
+//!   `std::fs::rename` stays on the same volume (NTFS atomic rename contract).
+//! - Acquires an exclusive file lock with exponential backoff before reading.
+//! - Schema-drift guard: raises `CoworkError::SchemaDriftSuspected` if the
+//!   top-level JSON shape does not match an expected `Object`.
+
+#![cfg(target_os = "windows")]
+
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur during Cowork workspace file operations.
+///
+/// All variants are `Display`-formatted so they can be returned as `String`
+/// from Tauri invoke commands via `.map_err(|e| e.to_string())`.
+#[derive(Debug)]
+pub enum CoworkError {
+    /// The top-level JSON shape of a Cowork file does not match the expected
+    /// schema. Raised instead of silently coercing so that schema drift from a
+    /// Cowork update surfaces immediately in the UI.
+    SchemaDriftSuspected { file: PathBuf, detail: String },
+    /// Could not acquire an exclusive file lock within the total wall-clock
+    /// budget (30 seconds with exponential backoff).
+    LockTimeout { path: PathBuf, elapsed: Duration },
+    /// An I/O error occurred while reading, writing, or renaming files.
+    IoError(io::Error),
+    /// JSON serialisation or deserialisation failed.
+    JsonError(serde_json::Error),
+    /// The parent directory's ACL indicates it may grant write access to
+    /// identities beyond the current user — write refused for security.
+    InsecureAcl { path: PathBuf },
+}
+
+impl fmt::Display for CoworkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CoworkError::SchemaDriftSuspected { file, detail } => write!(
+                f,
+                "Schema drift detected in {}: {}",
+                file.display(),
+                detail
+            ),
+            CoworkError::LockTimeout { path, elapsed } => write!(
+                f,
+                "Could not acquire lock on {} after {:.1}s",
+                path.display(),
+                elapsed.as_secs_f64()
+            ),
+            CoworkError::IoError(e) => write!(f, "I/O error: {e}"),
+            CoworkError::JsonError(e) => write!(f, "JSON error: {e}"),
+            CoworkError::InsecureAcl { path } => write!(
+                f,
+                "Insecure ACL on {} — write refused (path may be outside %LOCALAPPDATA% or OneDrive-synced)",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CoworkError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CoworkError::IoError(e) => Some(e),
+            CoworkError::JsonError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for CoworkError {
+    fn from(e: io::Error) -> Self {
+        CoworkError::IoError(e)
+    }
+}
+
+impl From<serde_json::Error> for CoworkError {
+    fn from(e: serde_json::Error) -> Self {
+        CoworkError::JsonError(e)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lock backoff schedule
+// ---------------------------------------------------------------------------
+
+/// Exponential backoff delay sequence (ms): 200, 500, 1500, 5000, then 5000
+/// repeated until the 30-second wall-clock budget is exhausted.
+const BACKOFF_DELAYS_MS: &[u64] = &[200, 500, 1_500, 5_000];
+const LOCK_BUDGET: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// Core helper
+// ---------------------------------------------------------------------------
+
+/// Atomically read-modify-write a JSON file under an exclusive file lock.
+///
+/// # Contract
+/// 1. Opens (or creates) `path` and acquires a non-blocking exclusive lock
+///    with exponential backoff (200 ms → 500 ms → 1.5 s → 5 s cap, 30 s total).
+/// 2. Reads and deserialises the file.  An absent file is treated as an empty
+///    JSON object `{}`.
+/// 3. Asserts the top-level value is a JSON object; returns
+///    `CoworkError::SchemaDriftSuspected` otherwise.
+/// 4. Calls `mutate(&mut Value)` — the caller performs the merge.
+/// 5. Serialises the (possibly mutated) value into a temp file **in the same
+///    directory** as `path`, `fsync`s, then renames into place (NTFS-atomic).
+/// 6. Releases the lock.
+///
+/// # Preconditions
+/// - `path`'s parent directory must already exist; this function will not
+///   create it (callers should create it if needed).
+/// - The caller is responsible for path-traversal validation (invariant §3)
+///   before supplying `path`.
+pub fn with_locked_json<T, F>(path: &Path, mutate: F) -> Result<T, CoworkError>
+where
+    F: FnOnce(&mut Value) -> Result<T, CoworkError>,
+{
+    let dir = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
+
+    // Use a SIBLING lock file, NOT the data file itself.
+    //
+    // On Windows, holding an exclusive fs2 lock on the data file blocks
+    // `std::fs::rename` from replacing it (os error 33 — "The process cannot
+    // access the file because another process has locked a portion of the
+    // file"). Locking a separate sidecar file decouples mutual exclusion from
+    // the rename-over-path operation, letting the atomic swap succeed while
+    // still serializing concurrent writers against the same data file.
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+    let lock_path = dir.join(format!(".{file_name}.tandem-lock"));
+
+    // Open/create the sibling lock file.
+    let lock_file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)?;
+
+    // Acquire exclusive lock with exponential backoff.
+    let start = Instant::now();
+    let mut delay_idx = 0usize;
+    loop {
+        match lock_file.try_lock_exclusive() {
+            Ok(()) => break,
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                let elapsed = start.elapsed();
+                if elapsed >= LOCK_BUDGET {
+                    return Err(CoworkError::LockTimeout {
+                        path: path.to_path_buf(),
+                        elapsed,
+                    });
+                }
+                let delay_ms = BACKOFF_DELAYS_MS
+                    .get(delay_idx)
+                    .copied()
+                    .unwrap_or(5_000);
+                log::debug!(
+                    "[cowork] waiting for lock on {} (elapsed={:.1}s, backoff={}ms)",
+                    lock_path.display(),
+                    elapsed.as_secs_f64(),
+                    delay_ms
+                );
+                std::thread::sleep(Duration::from_millis(delay_ms));
+                if delay_idx + 1 < BACKOFF_DELAYS_MS.len() {
+                    delay_idx += 1;
+                }
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    // --- Critical section: read → mutate → atomic write ---
+    let result = (|| -> Result<T, CoworkError> {
+        // Read existing content; absent file = empty object. `read_to_string`
+        // opens and closes its own handle, so no data-file handle is held
+        // across the rename below.
+        let mut json_value: Value = match std::fs::read_to_string(path) {
+            Ok(s) if s.is_empty() => Value::Object(serde_json::Map::new()),
+            Ok(s) => serde_json::from_str(&s)?,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                Value::Object(serde_json::Map::new())
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        // Schema guard: top-level must be an object.
+        if !json_value.is_object() {
+            return Err(CoworkError::SchemaDriftSuspected {
+                file: path.to_path_buf(),
+                detail: format!(
+                    "expected top-level JSON object, got {}",
+                    json_value_type_name(&json_value)
+                ),
+            });
+        }
+
+        // Run the caller's mutation.
+        let mutation_result = mutate(&mut json_value)?;
+
+        // Write to temp file in the same directory (same volume — atomic rename).
+        let tmp_name = format!(".tandem-tmp-{}", rand_hex(8));
+        let tmp_path = dir.join(&tmp_name);
+
+        let serialised = serde_json::to_string_pretty(&json_value)?;
+
+        {
+            use std::io::Write;
+            let mut tmp_file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&tmp_path)?;
+            tmp_file.write_all(serialised.as_bytes())?;
+            tmp_file.flush()?;
+            tmp_file.sync_all()?;
+        }
+
+        // Atomic rename into place. Safe on Windows now because we only hold
+        // a handle to the sibling lock file, not to `path`.
+        std::fs::rename(&tmp_path, path).map_err(|e| {
+            // Best-effort cleanup on rename failure.
+            let _ = std::fs::remove_file(&tmp_path);
+            CoworkError::from(e)
+        })?;
+
+        Ok(mutation_result)
+    })();
+
+    // Release the lock regardless of outcome.
+    let _ = FileExt::unlock(&lock_file);
+    // Best-effort cleanup of the sidecar lock file. If another process picked
+    // up the lock between our unlock and this remove, the remove silently
+    // fails — that's fine; they own it now.
+    drop(lock_file);
+    let _ = std::fs::remove_file(&lock_path);
+
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Return a human-readable JSON type name for diagnostic messages.
+fn json_value_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Generate a short random hex string for temp-file suffixes.
+fn rand_hex(len: usize) -> String {
+    use rand::RngCore;
+    let mut bytes = vec![0u8; (len + 1) / 2];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>()
+        .chars()
+        .take(len)
+        .collect()
+}

--- a/src-tauri/src/cowork_installer.rs
+++ b/src-tauri/src/cowork_installer.rs
@@ -116,9 +116,13 @@ fn check_acl(path: &Path) -> Result<(), CoworkError> {
     };
 
     // Canonicalize both for comparison.
+    // Only fail-open for NotFound (path doesn't exist yet — that's fine for
+    // new workspace directories). All other errors fail closed: we can't verify
+    // the path is safe, so reject rather than silently allow.
     let canonical_path = match std::fs::canonicalize(path) {
         Ok(p) => p,
-        Err(_) => return Ok(()), // Can't canonicalize — allow optimistically
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(_) => return Err(CoworkError::InsecureAcl { path: path.to_path_buf() }),
     };
     let canonical_lad = match std::fs::canonicalize(&local_app_data) {
         Ok(p) => p,
@@ -181,12 +185,16 @@ pub fn install_tandem_plugin_into_workspace(
     // ACL check before any write.
     let acl_result = check_acl(ws_path);
 
-    // Create the cowork_plugins subdirectory if it doesn't exist.
+    // Create the cowork_plugins subdirectory only after ACL check passes.
+    // Creating the dir before we know the ACL is safe leaves a directory behind
+    // even when the write is rejected.
     let plugins_dir = ws_path.join("cowork_plugins");
-    std::fs::create_dir_all(&plugins_dir).map_err(|e| {
-        log::warn!("[cowork-install] mkdir cowork_plugins failed: {e}");
-        CoworkError::from(e)
-    })?;
+    if acl_result.is_ok() {
+        std::fs::create_dir_all(&plugins_dir).map_err(|e| {
+            log::warn!("[cowork-install] mkdir cowork_plugins failed: {e}");
+            CoworkError::from(e)
+        })?;
+    }
 
     let installed_status = if let Err(ref e) = acl_result {
         log::warn!("[cowork-install] InsecureAcl for installed_plugins.json: {e}");
@@ -334,7 +342,20 @@ pub fn apply_token_to_all_workspaces(token: &str) -> Vec<WorkspaceWriteReport> {
 pub fn reconcile_orphans(workspaces: &[PathBuf], current_token: &str) -> ReconcileReport {
     use crate::firewall;
 
-    let orphan_rules = firewall::scan_orphan_rules();
+    let orphan_rules = match firewall::scan_orphan_rules() {
+        Ok(rules) => rules,
+        Err(e) => {
+            log::warn!(
+                "[cowork-install] reconcile: orphan rule scan failed ({e}) — skipping rule removal"
+            );
+            // Return early with an empty report so callers know the scan was
+            // not conclusive, rather than silently treating failure as "no orphans".
+            return ReconcileReport {
+                removed_firewall_rules: vec![],
+                rewritten_stale_entries: vec![],
+            };
+        }
+    };
     let mut removed_rules = Vec::new();
 
     if !orphan_rules.is_empty() {

--- a/src-tauri/src/cowork_installer.rs
+++ b/src-tauri/src/cowork_installer.rs
@@ -99,13 +99,17 @@ pub struct ReconcileReport {
 fn check_acl(path: &Path) -> Result<(), CoworkError> {
     // Honour the test override root: if the path is within the override, skip
     // the %LOCALAPPDATA% check (tests use std::env::temp_dir()).
-    if let Ok(override_root) = std::env::var("TANDEM_COWORK_ROOT_OVERRIDE") {
-        let override_path = PathBuf::from(&override_root);
-        if let (Ok(canon_override), Ok(canon_path)) =
-            (std::fs::canonicalize(&override_path), std::fs::canonicalize(path))
-        {
-            if canon_path.starts_with(&canon_override) {
-                return Ok(());
+    // Gated so production binaries cannot be redirected by env var.
+    #[cfg(any(test, feature = "cowork-test-hooks"))]
+    {
+        if let Ok(override_root) = std::env::var("TANDEM_COWORK_ROOT_OVERRIDE") {
+            let override_path = PathBuf::from(&override_root);
+            if let (Ok(canon_override), Ok(canon_path)) =
+                (std::fs::canonicalize(&override_path), std::fs::canonicalize(path))
+            {
+                if canon_path.starts_with(&canon_override) {
+                    return Ok(());
+                }
             }
         }
     }
@@ -117,12 +121,13 @@ fn check_acl(path: &Path) -> Result<(), CoworkError> {
 
     // Canonicalize both for comparison.
     // Only fail-open for NotFound (path doesn't exist yet — that's fine for
-    // new workspace directories). All other errors fail closed: we can't verify
-    // the path is safe, so reject rather than silently allow.
+    // new workspace directories). All other I/O errors propagate as IoError
+    // (not InsecureAcl) so callers can distinguish a security rejection from
+    // a transient I/O failure.
     let canonical_path = match std::fs::canonicalize(path) {
         Ok(p) => p,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(_) => return Err(CoworkError::InsecureAcl { path: path.to_path_buf() }),
+        Err(e) => return Err(e.into()),
     };
     let canonical_lad = match std::fs::canonicalize(&local_app_data) {
         Ok(p) => p,
@@ -196,31 +201,42 @@ pub fn install_tandem_plugin_into_workspace(
         })?;
     }
 
-    let installed_status = if let Err(ref e) = acl_result {
-        log::warn!("[cowork-install] InsecureAcl for installed_plugins.json: {e}");
-        WriteStatus::InsecureAcl
-    } else {
-        let path = plugins_dir.join("installed_plugins.json");
-        // Token must not appear in any log — pass it via closure capture only.
-        let token_owned = token.to_string();
-        let tandem_url_owned = tandem_url.to_string();
-        write_status_from(with_locked_json(&path, move |json| {
-            merge_installed_plugins(json, &token_owned, &tandem_url_owned)
-        }))
+    let installed_status = match &acl_result {
+        Ok(()) => {
+            let path = plugins_dir.join("installed_plugins.json");
+            // Token must not appear in any log — pass it via closure capture only.
+            let token_owned = token.to_string();
+            let tandem_url_owned = tandem_url.to_string();
+            write_status_from(with_locked_json(&path, move |json| {
+                merge_installed_plugins(json, &token_owned, &tandem_url_owned)
+            }))
+        }
+        Err(CoworkError::InsecureAcl { .. }) => {
+            log::warn!("[cowork-install] InsecureAcl for installed_plugins.json");
+            WriteStatus::InsecureAcl
+        }
+        Err(e) => {
+            log::warn!("[cowork-install] I/O error checking ACL for installed_plugins.json: {e}");
+            WriteStatus::Failed(e.to_string())
+        }
     };
 
-    let known_status = if acl_result.is_err() {
-        WriteStatus::InsecureAcl
-    } else {
-        let path = plugins_dir.join("known_marketplaces.json");
-        write_status_from(with_locked_json(&path, merge_known_marketplaces))
+    let known_status = match &acl_result {
+        Ok(()) => {
+            let path = plugins_dir.join("known_marketplaces.json");
+            write_status_from(with_locked_json(&path, merge_known_marketplaces))
+        }
+        Err(CoworkError::InsecureAcl { .. }) => WriteStatus::InsecureAcl,
+        Err(e) => WriteStatus::Failed(e.to_string()),
     };
 
-    let settings_status = if acl_result.is_err() {
-        WriteStatus::InsecureAcl
-    } else {
-        let path = plugins_dir.join("cowork_settings.json");
-        write_status_from(with_locked_json(&path, merge_cowork_settings))
+    let settings_status = match &acl_result {
+        Ok(()) => {
+            let path = plugins_dir.join("cowork_settings.json");
+            write_status_from(with_locked_json(&path, merge_cowork_settings))
+        }
+        Err(CoworkError::InsecureAcl { .. }) => WriteStatus::InsecureAcl,
+        Err(e) => WriteStatus::Failed(e.to_string()),
     };
 
     Ok(WorkspaceWriteReport {
@@ -392,9 +408,21 @@ pub fn reconcile_orphans(workspaces: &[PathBuf], current_token: &str) -> Reconci
                         .unwrap_or("");
                     stored != current_token
                 }
-                Err(_) => false,
+                Err(e) => {
+                    log::warn!(
+                        "[cowork-install] reconcile: corrupt JSON in {} ({e}) — forcing rewrite",
+                        path.display()
+                    );
+                    true // locked writer's schema guard will surface drift safely
+                }
             },
-            Err(_) => false,
+            Err(e) => {
+                log::warn!(
+                    "[cowork-install] reconcile: cannot read {} ({e}) — skipping",
+                    path.display()
+                );
+                false // can't read means can't write safely
+            }
         };
 
         if needs_update {
@@ -819,6 +847,58 @@ mod tests {
         let result = install_tandem_plugin_into_workspace(&ws_path, "token", DEFAULT_TANDEM_URL).unwrap();
         std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
         assert_eq!(result.installed_plugins, WriteStatus::SchemaDrift);
+    }
+
+    #[test]
+    fn test_check_acl_rejects_path_outside_override_and_lad() {
+        let _guard = crate::COWORK_ENV_LOCK.lock().unwrap();
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+
+        // Use %APPDATA% (Roaming) — a sibling of %LOCALAPPDATA% (Local), not a
+        // child. TempDir::new() uses %TEMP% which IS inside %LOCALAPPDATA% on
+        // Windows, so it cannot be used here.
+        let appdata = match std::env::var("APPDATA") {
+            Ok(v) => std::path::PathBuf::from(v),
+            Err(_) => return, // no APPDATA (non-Windows CI) — skip
+        };
+        let test_dir = appdata.join("tandem-test-acl-reject");
+        let ws = test_dir.join("ws").join("vm");
+        if fs::create_dir_all(&ws).is_err() {
+            return; // can't create test dir — skip
+        }
+
+        let result = check_acl(&ws);
+        let _ = fs::remove_dir_all(&test_dir);
+
+        assert!(
+            matches!(result, Err(CoworkError::InsecureAcl { .. })),
+            "expected InsecureAcl for path outside %%LOCALAPPDATA%%, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_check_acl_io_error_is_not_insecure_acl() {
+        // Trigger a non-NotFound canonicalize error: path whose parent is a regular
+        // file (not a directory). Canonicalize returns NotADirectory/Other, not NotFound.
+        let _guard = crate::COWORK_ENV_LOCK.lock().unwrap();
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("regular_file");
+        fs::write(&file_path, b"not a dir").unwrap();
+        let bogus = file_path.join("child"); // parent is a file, not a dir
+
+        let result = check_acl(&bogus);
+        // Either IoError (preferred — Step 3's fix) or NotFound fail-open (Ok).
+        // MUST NOT be InsecureAcl (that would mean we're still conflating I/O with security).
+        match result {
+            Err(CoworkError::InsecureAcl { .. }) => {
+                panic!("I/O error should not map to InsecureAcl after Step 3 fix");
+            }
+            Err(CoworkError::IoError(_)) | Ok(()) => {} // either is acceptable
+            other => panic!("unexpected result: {:?}", other),
+        }
     }
 
     #[test]

--- a/src-tauri/src/cowork_installer.rs
+++ b/src-tauri/src/cowork_installer.rs
@@ -173,7 +173,7 @@ pub fn install_tandem_plugin_into_workspace(
     token: &str,
     tandem_url: &str,
 ) -> Result<WorkspaceWriteReport, CoworkError> {
-    let workspace_id = parent_component(ws_path, 1);
+    let workspace_id = parent_component(ws_path);
     let vm_id = leaf_component(ws_path);
 
     warn_if_onedrive(ws_path);
@@ -235,7 +235,7 @@ pub fn install_tandem_plugin_into_workspace(
 pub fn uninstall_tandem_plugin_from_workspace(
     ws_path: &Path,
 ) -> Result<WorkspaceWriteReport, CoworkError> {
-    let workspace_id = parent_component(ws_path, 1);
+    let workspace_id = parent_component(ws_path);
     let vm_id = leaf_component(ws_path);
 
     let plugins_dir = ws_path.join("cowork_plugins");
@@ -297,7 +297,7 @@ pub fn apply_token_to_all_workspaces(token: &str) -> Vec<WorkspaceWriteReport> {
     workspaces
         .iter()
         .map(|ws_path| {
-            let workspace_id = parent_component(ws_path, 1);
+            let workspace_id = parent_component(ws_path);
             let vm_id = leaf_component(ws_path);
             let plugins_dir = ws_path.join("cowork_plugins");
             let path = plugins_dir.join("installed_plugins.json");
@@ -650,13 +650,9 @@ fn leaf_component(path: &Path) -> String {
         .unwrap_or_default()
 }
 
-/// Extract the Nth ancestor component name (0 = leaf, 1 = parent, …).
-fn parent_component(path: &Path, n: usize) -> String {
-    let mut p: &Path = path;
-    for _ in 0..n {
-        p = p.parent().unwrap_or(p);
-    }
-    leaf_component(p)
+/// Extract the parent directory's leaf name (one level above `path`).
+fn parent_component(path: &Path) -> String {
+    leaf_component(path.parent().unwrap_or(path))
 }
 
 /// Resolve the TANDEM_URL to write into `env.TANDEM_URL` for a workspace.

--- a/src-tauri/src/cowork_installer.rs
+++ b/src-tauri/src/cowork_installer.rs
@@ -1,0 +1,829 @@
+//! Cowork per-workspace plugin installer.
+//!
+//! Reads and modifies three Cowork registry JSON files inside each workspace's
+//! VM directory using the atomic lock-read-modify-write primitive from
+//! `cowork_atomic_json`.
+//!
+//! **ADR-023 override:** writes stdio entries (`npx -y tandem-editor mcp-stdio`),
+//! NOT HTTP entries.  The authority cowork spec's HTTP shape surfaces zero tools.
+//!
+//! **Token handling:** the auth token is NEVER logged.  It is passed as a function
+//! argument, written to JSON, and never surfaced in any log call.
+
+#![cfg(target_os = "windows")]
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::cowork_atomic_json::{with_locked_json, CoworkError};
+use crate::cowork_meta::CoworkMeta;
+use crate::cowork_workspace_scan::find_cowork_workspaces;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Primary hostname for reaching the host from inside the Cowork Hyper-V VM.
+/// The LAN-IP fallback is stored in cowork_meta.json and used when
+/// `use_lan_ip_override` is true.
+const DEFAULT_TANDEM_URL: &str = "http://host.docker.internal:3479";
+
+/// Plugin ID used throughout — must be unique within Cowork's marketplace.
+const TANDEM_PLUGIN_ID: &str = "tandem";
+
+/// Marketplace entry identifier: `<plugin-id>@<marketplace-id>`.
+const TANDEM_ENABLED_KEY: &str = "tandem@tandem";
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+/// Status of a single JSON file write during a workspace install/uninstall pass.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum WriteStatus {
+    /// Write succeeded.
+    Ok,
+    /// Tandem entry already present with identical content — no write needed.
+    AlreadyPresent,
+    /// File was locked and the lock timeout expired.
+    Locked,
+    /// The file's JSON structure did not match the expected schema.
+    SchemaDrift,
+    /// The parent directory ACL indicates an insecure write target.
+    InsecureAcl,
+    /// Write failed for a reason captured in the message.
+    Failed(String),
+}
+
+/// Per-workspace result of an install or uninstall pass.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceWriteReport {
+    /// The workspace ID component of the path (parent directory of `vm_id`).
+    pub workspace_id: String,
+    /// The VM ID component of the path (leaf directory scanned).
+    pub vm_id: String,
+    /// Result for `installed_plugins.json`.
+    pub installed_plugins: WriteStatus,
+    /// Result for `known_marketplaces.json`.
+    pub known_marketplaces: WriteStatus,
+    /// Result for `cowork_settings.json`.
+    pub cowork_settings: WriteStatus,
+}
+
+/// Summary of orphan reconciliation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconcileReport {
+    /// Names of orphan firewall rules that were removed.
+    pub removed_firewall_rules: Vec<String>,
+    /// Paths of workspace entries that had stale tokens and were rewritten.
+    pub rewritten_stale_entries: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// ACL guard (heuristic — full DACL inspection deferred to v0.8.1)
+// ---------------------------------------------------------------------------
+
+/// Heuristic ACL check for a workspace path.
+///
+/// Returns `CoworkError::InsecureAcl` when the path's canonical form is
+/// outside `%LOCALAPPDATA%` (indicating a redirected or OneDrive-synced path
+/// that could be world-readable).
+///
+/// TODO(v0.8.1): Replace with full DACL inspection via
+/// `GetFileSecurityW` / `GetEffectiveRightsFromAcl` from `windows-sys`.
+fn check_acl(path: &Path) -> Result<(), CoworkError> {
+    // Honour the test override root: if the path is within the override, skip
+    // the %LOCALAPPDATA% check (tests use std::env::temp_dir()).
+    if let Ok(override_root) = std::env::var("TANDEM_COWORK_ROOT_OVERRIDE") {
+        let override_path = PathBuf::from(&override_root);
+        if let (Ok(canon_override), Ok(canon_path)) =
+            (std::fs::canonicalize(&override_path), std::fs::canonicalize(path))
+        {
+            if canon_path.starts_with(&canon_override) {
+                return Ok(());
+            }
+        }
+    }
+
+    let local_app_data = match dirs::data_local_dir() {
+        Some(d) => d,
+        None => return Ok(()), // Can't determine — allow optimistically
+    };
+
+    // Canonicalize both for comparison.
+    let canonical_path = match std::fs::canonicalize(path) {
+        Ok(p) => p,
+        Err(_) => return Ok(()), // Can't canonicalize — allow optimistically
+    };
+    let canonical_lad = match std::fs::canonicalize(&local_app_data) {
+        Ok(p) => p,
+        Err(_) => return Ok(()),
+    };
+
+    // Check that the path starts with %LOCALAPPDATA%.
+    let path_components: Vec<_> = canonical_path.components().collect();
+    let lad_components: Vec<_> = canonical_lad.components().collect();
+
+    let is_under_lad = lad_components.iter().zip(path_components.iter()).all(|(l, p)| l == p)
+        && path_components.len() > lad_components.len();
+
+    if !is_under_lad {
+        log::warn!(
+            "[cowork-install] InsecureAcl: {} is outside %LOCALAPPDATA%",
+            path.display()
+        );
+        return Err(CoworkError::InsecureAcl {
+            path: path.to_path_buf(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Check whether the canonical path contains "OneDrive" and log a one-time warning.
+fn warn_if_onedrive(path: &Path) {
+    let s = path.to_string_lossy();
+    if s.contains("OneDrive") {
+        log::warn!(
+            "[cowork-install] WARNING: workspace path {} is inside a OneDrive-synced folder. \
+             Auth tokens will be uploaded to Microsoft cloud storage.",
+            path.display()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Install
+// ---------------------------------------------------------------------------
+
+/// Install the Tandem plugin entry into all three Cowork registry files for a
+/// single workspace VM directory.
+///
+/// # Preconditions
+/// - `ws_path` has already been validated by the path-traversal guard in
+///   `cowork_workspace_scan::check_path_safe()`.
+/// - `token` is NEVER logged; call sites must not log it either.
+pub fn install_tandem_plugin_into_workspace(
+    ws_path: &Path,
+    token: &str,
+    tandem_url: &str,
+) -> Result<WorkspaceWriteReport, CoworkError> {
+    let workspace_id = parent_component(ws_path, 1);
+    let vm_id = leaf_component(ws_path);
+
+    warn_if_onedrive(ws_path);
+
+    // ACL check before any write.
+    let acl_result = check_acl(ws_path);
+
+    // Create the cowork_plugins subdirectory if it doesn't exist.
+    let plugins_dir = ws_path.join("cowork_plugins");
+    std::fs::create_dir_all(&plugins_dir).map_err(|e| {
+        log::warn!("[cowork-install] mkdir cowork_plugins failed: {e}");
+        CoworkError::from(e)
+    })?;
+
+    let installed_status = if let Err(ref e) = acl_result {
+        log::warn!("[cowork-install] InsecureAcl for installed_plugins.json: {e}");
+        WriteStatus::InsecureAcl
+    } else {
+        let path = plugins_dir.join("installed_plugins.json");
+        // Token must not appear in any log — pass it via closure capture only.
+        let token_owned = token.to_string();
+        let tandem_url_owned = tandem_url.to_string();
+        write_status_from(with_locked_json(&path, move |json| {
+            merge_installed_plugins(json, &token_owned, &tandem_url_owned)
+        }))
+    };
+
+    let known_status = if acl_result.is_err() {
+        WriteStatus::InsecureAcl
+    } else {
+        let path = plugins_dir.join("known_marketplaces.json");
+        write_status_from(with_locked_json(&path, merge_known_marketplaces))
+    };
+
+    let settings_status = if acl_result.is_err() {
+        WriteStatus::InsecureAcl
+    } else {
+        let path = plugins_dir.join("cowork_settings.json");
+        write_status_from(with_locked_json(&path, merge_cowork_settings))
+    };
+
+    Ok(WorkspaceWriteReport {
+        workspace_id,
+        vm_id,
+        installed_plugins: installed_status,
+        known_marketplaces: known_status,
+        cowork_settings: settings_status,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall
+// ---------------------------------------------------------------------------
+
+/// Remove the Tandem plugin entry from all three Cowork registry files for a
+/// single workspace VM directory.
+///
+/// Leaves all other plugin entries (context7, Anthropic's own) intact.
+pub fn uninstall_tandem_plugin_from_workspace(
+    ws_path: &Path,
+) -> Result<WorkspaceWriteReport, CoworkError> {
+    let workspace_id = parent_component(ws_path, 1);
+    let vm_id = leaf_component(ws_path);
+
+    let plugins_dir = ws_path.join("cowork_plugins");
+
+    let installed_status = {
+        let path = plugins_dir.join("installed_plugins.json");
+        if !path.exists() {
+            WriteStatus::AlreadyPresent // nothing to remove
+        } else {
+            write_status_from(with_locked_json(&path, remove_installed_plugins))
+        }
+    };
+
+    let known_status = {
+        let path = plugins_dir.join("known_marketplaces.json");
+        if !path.exists() {
+            WriteStatus::AlreadyPresent
+        } else {
+            write_status_from(with_locked_json(&path, remove_known_marketplaces))
+        }
+    };
+
+    let settings_status = {
+        let path = plugins_dir.join("cowork_settings.json");
+        if !path.exists() {
+            WriteStatus::AlreadyPresent
+        } else {
+            write_status_from(with_locked_json(&path, remove_cowork_settings))
+        }
+    };
+
+    Ok(WorkspaceWriteReport {
+        workspace_id,
+        vm_id,
+        installed_plugins: installed_status,
+        known_marketplaces: known_status,
+        cowork_settings: settings_status,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Token rotation
+// ---------------------------------------------------------------------------
+
+/// Re-walk all workspaces and update `env.TANDEM_AUTH_TOKEN` in each
+/// `installed_plugins.json` entry.
+///
+/// Used by `tandem rotate-token` after a successful rotation so that
+/// post-rotation Cowork sessions use the new token (security invariant §6).
+///
+/// Token is NEVER logged.
+pub fn apply_token_to_all_workspaces(token: &str) -> Vec<WorkspaceWriteReport> {
+    let workspaces = find_cowork_workspaces();
+    log::info!(
+        "[cowork-install] apply_token_to_all_workspaces: {} workspace(s)",
+        workspaces.len()
+    );
+
+    workspaces
+        .iter()
+        .map(|ws_path| {
+            let workspace_id = parent_component(ws_path, 1);
+            let vm_id = leaf_component(ws_path);
+            let plugins_dir = ws_path.join("cowork_plugins");
+            let path = plugins_dir.join("installed_plugins.json");
+
+            let installed_status = if !path.exists() {
+                WriteStatus::AlreadyPresent // no entry to update
+            } else {
+                let token_owned = token.to_string();
+                write_status_from(with_locked_json(&path, move |json| {
+                    update_token_in_installed_plugins(json, &token_owned)
+                }))
+            };
+
+            WorkspaceWriteReport {
+                workspace_id,
+                vm_id,
+                installed_plugins: installed_status,
+                known_marketplaces: WriteStatus::AlreadyPresent,
+                cowork_settings: WriteStatus::AlreadyPresent,
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Orphan reconciliation
+// ---------------------------------------------------------------------------
+
+/// Scan for and reconcile orphan firewall rules and stale env blocks.
+///
+/// Removes firewall rules left by a previous failed uninstall and rewrites
+/// workspace entries whose `env.TANDEM_AUTH_TOKEN` does not match the current
+/// token (security invariant §12).
+pub fn reconcile_orphans(workspaces: &[PathBuf], current_token: &str) -> ReconcileReport {
+    use crate::firewall;
+
+    let orphan_rules = firewall::scan_orphan_rules();
+    let mut removed_rules = Vec::new();
+
+    if !orphan_rules.is_empty() {
+        log::warn!(
+            "[cowork-install] reconcile: found {} orphan firewall rule(s): {:?}",
+            orphan_rules.len(),
+            orphan_rules
+        );
+        if let Err(e) = firewall::remove_cowork_rules() {
+            log::warn!("[cowork-install] reconcile: failed to remove orphan rules: {e}");
+        } else {
+            removed_rules = orphan_rules;
+        }
+    }
+
+    let mut rewritten = Vec::new();
+    for ws_path in workspaces {
+        let plugins_dir = ws_path.join("cowork_plugins");
+        let path = plugins_dir.join("installed_plugins.json");
+        if !path.exists() {
+            continue;
+        }
+
+        // Check if the token is stale without modifying the file.
+        let needs_update = match std::fs::read_to_string(&path) {
+            Ok(content) => match serde_json::from_str::<Value>(&content) {
+                Ok(json) => {
+                    let stored = json
+                        .get("mcpServers")
+                        .and_then(|s| s.get(TANDEM_PLUGIN_ID))
+                        .and_then(|e| e.get("env"))
+                        .and_then(|e| e.get("TANDEM_AUTH_TOKEN"))
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
+                    stored != current_token
+                }
+                Err(_) => false,
+            },
+            Err(_) => false,
+        };
+
+        if needs_update {
+            let token_owned = current_token.to_string();
+            match with_locked_json(&path, move |json| {
+                update_token_in_installed_plugins(json, &token_owned)
+            }) {
+                Ok(WriteStatus::Ok) => {
+                    rewritten.push(path.to_string_lossy().into_owned());
+                }
+                other => {
+                    log::warn!(
+                        "[cowork-install] reconcile: failed to rewrite token in {}: {:?}",
+                        path.display(),
+                        other
+                    );
+                }
+            }
+        }
+    }
+
+    ReconcileReport {
+        removed_firewall_rules: removed_rules,
+        rewritten_stale_entries: rewritten,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON mutation helpers — installed_plugins.json
+// ---------------------------------------------------------------------------
+
+/// Merge the Tandem stdio entry into `installed_plugins.json`.
+///
+/// Expects top-level structure: `{ "mcpServers": { ... } }`.
+/// Raises `SchemaDriftSuspected` if the structure differs.
+/// Returns `AlreadyPresent` if the entry exists and is byte-identical.
+fn merge_installed_plugins(
+    json: &mut Value,
+    token: &str,
+    tandem_url: &str,
+) -> Result<WriteStatus, CoworkError> {
+    let obj = json.as_object_mut().ok_or_else(|| CoworkError::SchemaDriftSuspected {
+        file: PathBuf::from("installed_plugins.json"),
+        detail: "expected top-level object".into(),
+    })?;
+
+    // Discover the server-map key: prefer "mcpServers", fall back to "servers".
+    // Any other shape triggers SchemaDriftSuspected.
+    let server_key = if obj.contains_key("mcpServers") {
+        "mcpServers"
+    } else if obj.contains_key("servers") {
+        "servers"
+    } else if obj.is_empty() {
+        // Fresh empty file — create with "mcpServers".
+        "mcpServers"
+    } else {
+        return Err(CoworkError::SchemaDriftSuspected {
+            file: PathBuf::from("installed_plugins.json"),
+            detail: format!(
+                "expected 'mcpServers' or 'servers' key, found keys: {:?}",
+                obj.keys().collect::<Vec<_>>()
+            ),
+        });
+    };
+
+    let servers = obj
+        .entry(server_key)
+        .or_insert_with(|| json!({}));
+
+    let servers_map = servers.as_object_mut().ok_or_else(|| CoworkError::SchemaDriftSuspected {
+        file: PathBuf::from("installed_plugins.json"),
+        detail: format!("'{server_key}' is not an object"),
+    })?;
+
+    // Build the desired entry — token is captured in the value, never in a log.
+    let desired = json!({
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "tandem-editor", "mcp-stdio"],
+        "env": {
+            "TANDEM_AUTH_TOKEN": token,
+            "TANDEM_URL": tandem_url
+        }
+    });
+
+    if let Some(existing) = servers_map.get(TANDEM_PLUGIN_ID) {
+        if existing == &desired {
+            return Ok(WriteStatus::AlreadyPresent);
+        }
+    }
+
+    servers_map.insert(TANDEM_PLUGIN_ID.to_string(), desired);
+    Ok(WriteStatus::Ok)
+}
+
+/// Remove the Tandem entry from `installed_plugins.json`.
+fn remove_installed_plugins(json: &mut Value) -> Result<WriteStatus, CoworkError> {
+    let obj = json.as_object_mut().ok_or_else(|| CoworkError::SchemaDriftSuspected {
+        file: PathBuf::from("installed_plugins.json"),
+        detail: "expected top-level object".into(),
+    })?;
+
+    let mut removed = false;
+    for key in ["mcpServers", "servers"] {
+        if let Some(servers) = obj.get_mut(key).and_then(|v| v.as_object_mut()) {
+            if servers.remove(TANDEM_PLUGIN_ID).is_some() {
+                removed = true;
+            }
+        }
+    }
+
+    Ok(if removed {
+        WriteStatus::Ok
+    } else {
+        WriteStatus::AlreadyPresent
+    })
+}
+
+/// Update `env.TANDEM_AUTH_TOKEN` in the existing Tandem entry.
+/// Token is never logged — it's written directly to JSON.
+fn update_token_in_installed_plugins(
+    json: &mut Value,
+    token: &str,
+) -> Result<WriteStatus, CoworkError> {
+    for key in ["mcpServers", "servers"] {
+        if let Some(entry) = json
+            .get_mut(key)
+            .and_then(|s| s.get_mut(TANDEM_PLUGIN_ID))
+            .and_then(|e| e.get_mut("env"))
+            .and_then(|e| e.as_object_mut())
+        {
+            entry.insert(
+                "TANDEM_AUTH_TOKEN".to_string(),
+                Value::String(token.to_string()),
+            );
+            return Ok(WriteStatus::Ok);
+        }
+    }
+    // Entry not found — nothing to update.
+    Ok(WriteStatus::AlreadyPresent)
+}
+
+// ---------------------------------------------------------------------------
+// JSON mutation helpers — known_marketplaces.json
+// ---------------------------------------------------------------------------
+
+/// Merge the Tandem marketplace entry into `known_marketplaces.json`.
+fn merge_known_marketplaces(json: &mut Value) -> Result<WriteStatus, CoworkError> {
+    let obj = json.as_object_mut().ok_or_else(|| CoworkError::SchemaDriftSuspected {
+        file: PathBuf::from("known_marketplaces.json"),
+        detail: "expected top-level object".into(),
+    })?;
+
+    let marketplaces = obj
+        .entry("marketplaces")
+        .or_insert_with(|| json!({}));
+
+    let mp_map = marketplaces.as_object_mut().ok_or_else(|| CoworkError::SchemaDriftSuspected {
+        file: PathBuf::from("known_marketplaces.json"),
+        detail: "'marketplaces' is not an object".into(),
+    })?;
+
+    let desired = json!({
+        "id": TANDEM_PLUGIN_ID,
+        "name": "Tandem",
+        "description": "Collaborative AI-human document editor",
+        "url": "https://github.com/bloknayrb/tandem"
+    });
+
+    if let Some(existing) = mp_map.get(TANDEM_PLUGIN_ID) {
+        if existing == &desired {
+            return Ok(WriteStatus::AlreadyPresent);
+        }
+    }
+
+    mp_map.insert(TANDEM_PLUGIN_ID.to_string(), desired);
+    Ok(WriteStatus::Ok)
+}
+
+/// Remove the Tandem marketplace entry from `known_marketplaces.json`.
+fn remove_known_marketplaces(json: &mut Value) -> Result<WriteStatus, CoworkError> {
+    let removed = json
+        .get_mut("marketplaces")
+        .and_then(|m| m.as_object_mut())
+        .and_then(|m| m.remove(TANDEM_PLUGIN_ID))
+        .is_some();
+    Ok(if removed { WriteStatus::Ok } else { WriteStatus::AlreadyPresent })
+}
+
+// ---------------------------------------------------------------------------
+// JSON mutation helpers — cowork_settings.json
+// ---------------------------------------------------------------------------
+
+/// Add `tandem@tandem` to `enabledPlugins` in `cowork_settings.json`.
+fn merge_cowork_settings(json: &mut Value) -> Result<WriteStatus, CoworkError> {
+    let obj = json.as_object_mut().ok_or_else(|| CoworkError::SchemaDriftSuspected {
+        file: PathBuf::from("cowork_settings.json"),
+        detail: "expected top-level object".into(),
+    })?;
+
+    let enabled = obj
+        .entry("enabledPlugins")
+        .or_insert_with(|| json!([]));
+
+    // enabledPlugins may be an array or an object (map).
+    if let Some(arr) = enabled.as_array_mut() {
+        let already = arr.iter().any(|v| v.as_str() == Some(TANDEM_ENABLED_KEY));
+        if already {
+            return Ok(WriteStatus::AlreadyPresent);
+        }
+        arr.push(Value::String(TANDEM_ENABLED_KEY.to_string()));
+        return Ok(WriteStatus::Ok);
+    }
+
+    if let Some(map) = enabled.as_object_mut() {
+        if map.contains_key(TANDEM_ENABLED_KEY) {
+            return Ok(WriteStatus::AlreadyPresent);
+        }
+        map.insert(TANDEM_ENABLED_KEY.to_string(), Value::Bool(true));
+        return Ok(WriteStatus::Ok);
+    }
+
+    Err(CoworkError::SchemaDriftSuspected {
+        file: PathBuf::from("cowork_settings.json"),
+        detail: "'enabledPlugins' is neither an array nor an object".into(),
+    })
+}
+
+/// Remove `tandem@tandem` from `enabledPlugins`.
+fn remove_cowork_settings(json: &mut Value) -> Result<WriteStatus, CoworkError> {
+    if let Some(arr) = json
+        .get_mut("enabledPlugins")
+        .and_then(|v| v.as_array_mut())
+    {
+        let before = arr.len();
+        arr.retain(|v| v.as_str() != Some(TANDEM_ENABLED_KEY));
+        return Ok(if arr.len() < before {
+            WriteStatus::Ok
+        } else {
+            WriteStatus::AlreadyPresent
+        });
+    }
+
+    if let Some(map) = json
+        .get_mut("enabledPlugins")
+        .and_then(|v| v.as_object_mut())
+    {
+        let removed = map.remove(TANDEM_ENABLED_KEY).is_some();
+        return Ok(if removed { WriteStatus::Ok } else { WriteStatus::AlreadyPresent });
+    }
+
+    Ok(WriteStatus::AlreadyPresent)
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+/// Convert a `CoworkError` to a `WriteStatus`.
+fn write_status_from(result: Result<WriteStatus, CoworkError>) -> WriteStatus {
+    match result {
+        Ok(s) => s,
+        Err(CoworkError::LockTimeout { .. }) => WriteStatus::Locked,
+        Err(CoworkError::SchemaDriftSuspected { .. }) => WriteStatus::SchemaDrift,
+        Err(CoworkError::InsecureAcl { .. }) => WriteStatus::InsecureAcl,
+        Err(e) => WriteStatus::Failed(e.to_string()),
+    }
+}
+
+/// Extract the leaf directory name as a string.
+fn leaf_component(path: &Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// Extract the Nth ancestor component name (0 = leaf, 1 = parent, …).
+fn parent_component(path: &Path, n: usize) -> String {
+    let mut p: &Path = path;
+    for _ in 0..n {
+        p = p.parent().unwrap_or(p);
+    }
+    leaf_component(p)
+}
+
+/// Resolve the TANDEM_URL to write into `env.TANDEM_URL` for a workspace.
+///
+/// Returns `http://<lan_ip_fallback>:3479` when `use_lan_ip_override` is true
+/// AND a LAN-IP fallback is populated; otherwise returns `DEFAULT_TANDEM_URL`
+/// (`http://host.docker.internal:3479`).
+pub fn resolve_tandem_url(meta: &CoworkMeta) -> String {
+    if meta.use_lan_ip_override {
+        if let Some(ip) = meta.lan_ip_fallback.as_deref() {
+            return format!("http://{ip}:3479");
+        }
+    }
+    DEFAULT_TANDEM_URL.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Acquire the process-wide env lock, create a temp workspace dir, and set
+    /// the override.  Returns the guard, the TempDir (must stay alive), and the
+    /// ws path.  The guard serializes all tests in this module AND
+    /// `cowork_workspace_scan` tests against the shared `TANDEM_COWORK_ROOT_OVERRIDE`
+    /// env var.
+    fn temp_ws() -> (std::sync::MutexGuard<'static, ()>, TempDir, PathBuf) {
+        let guard = crate::COWORK_ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        // Set the override so the ACL guard passes in tests.
+        std::env::set_var("TANDEM_COWORK_ROOT_OVERRIDE", dir.path().to_str().unwrap());
+        let ws_path = dir.path().join("ws-abc").join("vm-123");
+        fs::create_dir_all(&ws_path).unwrap();
+        (guard, dir, ws_path)
+    }
+
+    #[test]
+    fn test_install_creates_entries() {
+        let (_guard, _dir, ws_path) = temp_ws();
+        let report = install_tandem_plugin_into_workspace(&ws_path, "secret-token", DEFAULT_TANDEM_URL).unwrap();
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+        assert_eq!(report.installed_plugins, WriteStatus::Ok);
+        assert_eq!(report.known_marketplaces, WriteStatus::Ok);
+        assert_eq!(report.cowork_settings, WriteStatus::Ok);
+
+        // Verify file content.
+        let content = fs::read_to_string(ws_path.join("cowork_plugins/installed_plugins.json")).unwrap();
+        let json: Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(json["mcpServers"]["tandem"]["type"], "stdio");
+        assert_eq!(json["mcpServers"]["tandem"]["command"], "npx");
+        // Token must be present but we avoid logging it — just check it's non-empty.
+        assert!(json["mcpServers"]["tandem"]["env"]["TANDEM_AUTH_TOKEN"].as_str().unwrap().len() > 0);
+    }
+
+    #[test]
+    fn test_install_is_idempotent() {
+        let (_guard, _dir, ws_path) = temp_ws();
+        install_tandem_plugin_into_workspace(&ws_path, "token", DEFAULT_TANDEM_URL).unwrap();
+        let report2 = install_tandem_plugin_into_workspace(&ws_path, "token", DEFAULT_TANDEM_URL).unwrap();
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+        // Second run should report AlreadyPresent for all three files.
+        assert_eq!(report2.installed_plugins, WriteStatus::AlreadyPresent);
+        assert_eq!(report2.known_marketplaces, WriteStatus::AlreadyPresent);
+        assert_eq!(report2.cowork_settings, WriteStatus::AlreadyPresent);
+    }
+
+    #[test]
+    fn test_install_preserves_context7_entry() {
+        let (_guard, _dir, ws_path) = temp_ws();
+        let plugins_dir = ws_path.join("cowork_plugins");
+        fs::create_dir_all(&plugins_dir).unwrap();
+
+        // Pre-populate with a context7 entry.
+        let existing = json!({
+            "mcpServers": {
+                "context7": {
+                    "type": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "@upstash/context7-mcp"]
+                }
+            }
+        });
+        fs::write(
+            plugins_dir.join("installed_plugins.json"),
+            serde_json::to_string_pretty(&existing).unwrap(),
+        ).unwrap();
+
+        install_tandem_plugin_into_workspace(&ws_path, "token", DEFAULT_TANDEM_URL).unwrap();
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+
+        let content = fs::read_to_string(plugins_dir.join("installed_plugins.json")).unwrap();
+        let json: Value = serde_json::from_str(&content).unwrap();
+
+        // Both entries must be present.
+        assert!(json["mcpServers"]["context7"].is_object(), "context7 entry missing after install");
+        assert!(json["mcpServers"]["tandem"].is_object(), "tandem entry not written");
+    }
+
+    #[test]
+    fn test_uninstall_removes_only_tandem() {
+        let (_guard, _dir, ws_path) = temp_ws();
+        let plugins_dir = ws_path.join("cowork_plugins");
+        fs::create_dir_all(&plugins_dir).unwrap();
+
+        // Install context7 + tandem.
+        let existing = json!({
+            "mcpServers": {
+                "context7": { "type": "stdio", "command": "npx", "args": ["-y", "@upstash/context7-mcp"] },
+                "tandem": { "type": "stdio", "command": "npx", "args": ["-y", "tandem-editor", "mcp-stdio"], "env": {} }
+            }
+        });
+        fs::write(
+            plugins_dir.join("installed_plugins.json"),
+            serde_json::to_string_pretty(&existing).unwrap(),
+        ).unwrap();
+        fs::write(plugins_dir.join("known_marketplaces.json"), "{}").unwrap();
+        fs::write(plugins_dir.join("cowork_settings.json"), "{}").unwrap();
+
+        let report = uninstall_tandem_plugin_from_workspace(&ws_path).unwrap();
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+        assert_eq!(report.installed_plugins, WriteStatus::Ok);
+
+        let content = fs::read_to_string(plugins_dir.join("installed_plugins.json")).unwrap();
+        let json: Value = serde_json::from_str(&content).unwrap();
+        assert!(json["mcpServers"]["context7"].is_object(), "context7 was removed by uninstall");
+        assert!(json["mcpServers"]["tandem"].is_null() || !json["mcpServers"]["tandem"].is_object(), "tandem not removed");
+    }
+
+    #[test]
+    fn test_schema_drift_fires_on_array() {
+        let (_guard, _dir, ws_path) = temp_ws();
+        let plugins_dir = ws_path.join("cowork_plugins");
+        fs::create_dir_all(&plugins_dir).unwrap();
+
+        // Top-level is an array — schema drift.
+        fs::write(plugins_dir.join("installed_plugins.json"), "[1,2,3]").unwrap();
+
+        let result = install_tandem_plugin_into_workspace(&ws_path, "token", DEFAULT_TANDEM_URL).unwrap();
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+        assert_eq!(result.installed_plugins, WriteStatus::SchemaDrift);
+    }
+
+    #[test]
+    fn test_apply_token_updates_existing_entry() {
+        let _guard = crate::COWORK_ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        let ws_path = dir.path().join("ws-abc").join("vm-123");
+        fs::create_dir_all(&ws_path).unwrap();
+
+        // Override root for both install + walker, plus ACL bypass.
+        std::env::set_var("TANDEM_COWORK_ROOT_OVERRIDE", dir.path().to_str().unwrap());
+
+        install_tandem_plugin_into_workspace(&ws_path, "old-token", DEFAULT_TANDEM_URL).unwrap();
+
+        let reports = apply_token_to_all_workspaces("new-token");
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].installed_plugins, WriteStatus::Ok);
+
+        let content = fs::read_to_string(ws_path.join("cowork_plugins/installed_plugins.json")).unwrap();
+        let json: Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(json["mcpServers"]["tandem"]["env"]["TANDEM_AUTH_TOKEN"], "new-token");
+    }
+}

--- a/src-tauri/src/cowork_meta.rs
+++ b/src-tauri/src/cowork_meta.rs
@@ -1,0 +1,164 @@
+//! Tandem-owned Cowork sidecar metadata.
+//!
+//! Stores integration state that Tandem controls:
+//! - Detected vEthernet CIDR from the last Hyper-V scan.
+//! - LAN-IP fallback value (populated but not used unless `use_lan_ip_override`).
+//! - Timestamp of the last workspace scan.
+//! - Whether the user has requested LAN-IP override instead of `host.docker.internal`.
+//! - Whether UAC elevation was declined on the last attempt.
+//!
+//! Persisted to `%LOCALAPPDATA%\tandem\Data\cowork-meta.json` via atomic write.
+
+#![cfg(target_os = "windows")]
+
+use std::io;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Persistent metadata for the Cowork integration.
+///
+/// All fields are nullable/optional so that partial state is valid (e.g.
+/// `vethernet_cidr_detected` is null until the first scan completes).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoworkMeta {
+    /// Detected LAN-IP of the host machine; populated during `cowork_toggle_integration`.
+    /// Used as a fallback TANDEM_URL when `use_lan_ip_override` is true.
+    #[serde(default)]
+    pub lan_ip_fallback: Option<String>,
+
+    /// The vEthernet CIDR detected from Hyper-V adapter enumeration.
+    /// `null` until a successful `detect_vethernet_subnet()` call.
+    #[serde(default)]
+    pub vethernet_cidr_detected: Option<String>,
+
+    /// ISO-8601 timestamp of the last `find_cowork_workspaces()` scan.
+    #[serde(default)]
+    pub workspaces_last_scanned_at: Option<String>,
+
+    /// When true, `cowork_installer` writes `http://<lan_ip_fallback>:3479`
+    /// as `TANDEM_URL` instead of `http://host.docker.internal:3479`.
+    #[serde(default)]
+    pub use_lan_ip_override: bool,
+
+    /// Set to true when UAC elevation was declined during `cowork_toggle_integration`.
+    /// Drives the persistent non-dismissable modal in the PR-f Settings UI.
+    #[serde(default)]
+    pub uac_declined_last_attempt: bool,
+
+    /// ISO-8601 timestamp of the last UAC decline.
+    #[serde(default)]
+    pub uac_declined_at: Option<String>,
+
+    /// Whether the Cowork integration is currently enabled.
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Default for CoworkMeta {
+    fn default() -> Self {
+        CoworkMeta {
+            lan_ip_fallback: None,
+            vethernet_cidr_detected: None,
+            workspaces_last_scanned_at: None,
+            use_lan_ip_override: false,
+            uac_declined_last_attempt: false,
+            uac_declined_at: None,
+            enabled: false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Storage path
+// ---------------------------------------------------------------------------
+
+/// Resolve the cowork-meta.json path.
+///
+/// Path: `%LOCALAPPDATA%\tandem\Data\cowork-meta.json`
+fn meta_path() -> Result<PathBuf, String> {
+    dirs::data_local_dir()
+        .map(|d| d.join("tandem").join("Data").join("cowork-meta.json"))
+        .ok_or_else(|| "Cannot resolve %LOCALAPPDATA%".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Load `CoworkMeta` from disk.
+///
+/// Returns `Ok(CoworkMeta::default())` if the file does not exist yet.
+/// Returns `Err` only on I/O or JSON parse failures for an existing file.
+pub fn load() -> Result<CoworkMeta, String> {
+    let path = meta_path()?;
+    if !path.exists() {
+        return Ok(CoworkMeta::default());
+    }
+    let content =
+        std::fs::read_to_string(&path).map_err(|e| format!("read cowork-meta.json: {e}"))?;
+    serde_json::from_str::<CoworkMeta>(&content)
+        .map_err(|e| format!("parse cowork-meta.json: {e}"))
+}
+
+/// Persist `CoworkMeta` to disk using an atomic temp-file rename.
+///
+/// Creates parent directories if they don't exist.
+pub fn save(meta: &CoworkMeta) -> Result<(), String> {
+    let path = meta_path()?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("mkdir for cowork-meta.json: {e}"))?;
+    }
+
+    let serialised =
+        serde_json::to_string_pretty(meta).map_err(|e| format!("serialise cowork-meta: {e}"))?;
+
+    // Atomic write: temp file in same dir → rename.
+    let dir = path
+        .parent()
+        .ok_or("cowork-meta.json has no parent directory")?;
+
+    let tmp_path = dir.join(format!(".tandem-meta-tmp-{}", rand_hex(8)));
+
+    (|| -> Result<(), io::Error> {
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)?;
+        f.write_all(serialised.as_bytes())?;
+        f.flush()?;
+        f.sync_all()?;
+        std::fs::rename(&tmp_path, &path)
+    })()
+    .map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        format!("write cowork-meta.json: {e}")
+    })
+}
+
+/// Update a single field via a closure, loading and saving atomically.
+pub fn update<F: FnOnce(&mut CoworkMeta)>(f: F) -> Result<(), String> {
+    let mut meta = load()?;
+    f(&mut meta);
+    save(&meta)
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn rand_hex(len: usize) -> String {
+    use rand::RngCore;
+    let mut bytes = vec![0u8; (len + 1) / 2];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>()
+        .chars()
+        .take(len)
+        .collect()
+}

--- a/src-tauri/src/cowork_meta.rs
+++ b/src-tauri/src/cowork_meta.rs
@@ -120,7 +120,10 @@ pub fn save(meta: &CoworkMeta) -> Result<(), String> {
         .parent()
         .ok_or("cowork-meta.json has no parent directory")?;
 
-    let tmp_path = dir.join(format!(".tandem-meta-tmp-{}", rand_hex(8)));
+    let tmp_path = dir.join(format!(
+        ".tandem-meta-tmp-{}",
+        crate::cowork_atomic_json::unique_suffix()
+    ));
 
     (|| -> Result<(), io::Error> {
         use std::io::Write;
@@ -144,21 +147,4 @@ pub fn update<F: FnOnce(&mut CoworkMeta)>(f: F) -> Result<(), String> {
     let mut meta = load()?;
     f(&mut meta);
     save(&meta)
-}
-
-// ---------------------------------------------------------------------------
-// Helper
-// ---------------------------------------------------------------------------
-
-fn rand_hex(len: usize) -> String {
-    use rand::RngCore;
-    let mut bytes = vec![0u8; (len + 1) / 2];
-    rand::thread_rng().fill_bytes(&mut bytes);
-    bytes
-        .iter()
-        .map(|b| format!("{b:02x}"))
-        .collect::<String>()
-        .chars()
-        .take(len)
-        .collect()
 }

--- a/src-tauri/src/cowork_meta.rs
+++ b/src-tauri/src/cowork_meta.rs
@@ -142,8 +142,18 @@ pub fn save(meta: &CoworkMeta) -> Result<(), String> {
     })
 }
 
+/// Process-level mutex to serialise concurrent `update()` calls from Tauri
+/// invoke handlers.  Without this, two concurrent invocations could interleave
+/// their load → mutate → save sequences, causing one writer to silently lose
+/// its changes.
+static META_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Update a single field via a closure, loading and saving atomically.
+///
+/// Acquires `META_LOCK` so the load → mutate → save triple is exclusive
+/// with respect to other `update()` callers in this process.
 pub fn update<F: FnOnce(&mut CoworkMeta)>(f: F) -> Result<(), String> {
+    let _guard = META_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let mut meta = load()?;
     f(&mut meta);
     save(&meta)

--- a/src-tauri/src/cowork_workspace_scan.rs
+++ b/src-tauri/src/cowork_workspace_scan.rs
@@ -219,7 +219,8 @@ pub(crate) fn check_path_safe(candidate: &Path, canonical_root: &Path) -> Result
     }
 
     // (c) Reject reparse points anywhere in the chain.
-    if has_reparse_point_in_chain(candidate) {
+    // Pass the canonical path so the check operates on the resolved form.
+    if has_reparse_point_in_chain(&canonical) {
         return Err("reparse point detected in path chain".to_string());
     }
 
@@ -244,20 +245,30 @@ fn is_unc_path(path: &Path) -> bool {
 
 /// Returns true if any component in the path chain (from root to candidate)
 /// has the `FILE_ATTRIBUTE_REPARSE_POINT` bit set.
+///
+/// Fails closed: if `symlink_metadata` returns an error, returns `true` (reject)
+/// rather than `false` (allow). This prevents a metadata failure from silently
+/// bypassing the reparse-point guard.
 fn has_reparse_point_in_chain(path: &Path) -> bool {
-    // Check the candidate itself.
-    if let Ok(metadata) = std::fs::symlink_metadata(path) {
-        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-            return true;
-        }
-    }
-    // Check each ancestor.
-    let mut ancestor = path.parent();
-    while let Some(p) = ancestor {
-        if let Ok(metadata) = std::fs::symlink_metadata(p) {
+    // Check the candidate itself. Fail closed on metadata errors.
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => {
             if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
                 return true;
             }
+        }
+        Err(_) => return true, // Can't inspect — reject for safety.
+    }
+    // Check each ancestor. Fail closed on metadata errors.
+    let mut ancestor = path.parent();
+    while let Some(p) = ancestor {
+        match std::fs::symlink_metadata(p) {
+            Ok(metadata) => {
+                if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                    return true;
+                }
+            }
+            Err(_) => return true, // Can't inspect ancestor — reject for safety.
         }
         ancestor = p.parent();
     }

--- a/src-tauri/src/cowork_workspace_scan.rs
+++ b/src-tauri/src/cowork_workspace_scan.rs
@@ -6,9 +6,10 @@
 //!
 //! **Security invariant §3 — defense-in-depth path guard:**
 //! Every candidate path goes through four checks (in order):
-//!   a. `std::fs::canonicalize` on both the root and each candidate.
-//!   b. Reject any path whose canonical form is a UNC path.
-//!   c. Reject any path where any component has the reparse-point attribute set.
+//!   a. Reject any path where any ancestor has the reparse-point attribute set
+//!      (checked BEFORE canonicalize, which would resolve and hide them).
+//!   b. `std::fs::canonicalize` on the candidate (safe: reparse points already rejected).
+//!   c. Reject any path whose canonical form is a UNC path.
 //!   d. Component-wise comparison (NOT string-prefix) against the canonical root.
 //!
 //! Paths that fail any check are skipped with a `WARN` log; the walker never
@@ -82,7 +83,10 @@ pub fn find_cowork_workspaces() -> Vec<PathBuf> {
             // Walk vm-id level.
             let vm_entries = match std::fs::read_dir(&ws_path) {
                 Ok(e) => e,
-                Err(_) => continue,
+                Err(e) => {
+                    log::warn!("[cowork-scan] cannot read vm-level dir {}: {e}", ws_path.display());
+                    continue;
+                }
             };
 
             for vm_entry in vm_entries {
@@ -133,20 +137,22 @@ pub fn find_cowork_workspaces() -> Vec<PathBuf> {
 fn cowork_roots() -> Vec<PathBuf> {
     // Test hook: allow overriding the scan root for unit tests.
     //
-    // The override is authoritative when set — if it points at an absent
-    // directory we return an empty vec rather than falling back to the real
-    // %LOCALAPPDATA% scan. This prevents tests that expect "no workspaces"
-    // from accidentally picking up the developer's real Claude Desktop install.
-    if let Ok(override_root) = std::env::var("TANDEM_COWORK_ROOT_OVERRIDE") {
-        let p = PathBuf::from(&override_root);
-        if p.is_dir() {
-            log::debug!("[cowork-scan] using TANDEM_COWORK_ROOT_OVERRIDE: {override_root}");
-            return vec![p];
-        } else {
-            log::debug!(
-                "[cowork-scan] TANDEM_COWORK_ROOT_OVERRIDE={override_root} is not a dir — returning empty"
-            );
-            return vec![];
+    // Gated behind cfg(test) / the cowork-test-hooks feature so the env var
+    // cannot be used to redirect production builds. Production binaries compiled
+    // with `cargo build --release` (no features) skip this block entirely.
+    #[cfg(any(test, feature = "cowork-test-hooks"))]
+    {
+        if let Ok(override_root) = std::env::var("TANDEM_COWORK_ROOT_OVERRIDE") {
+            let p = PathBuf::from(&override_root);
+            if p.is_dir() {
+                log::debug!("[cowork-scan] using TANDEM_COWORK_ROOT_OVERRIDE: {override_root}");
+                return vec![p];
+            } else {
+                log::debug!(
+                    "[cowork-scan] TANDEM_COWORK_ROOT_OVERRIDE={override_root} is not a dir — returning empty"
+                );
+                return vec![];
+            }
         }
     }
 
@@ -206,22 +212,23 @@ fn cowork_roots() -> Vec<PathBuf> {
 /// Returns the canonicalized path on success, or a human-readable rejection
 /// reason string on failure.
 pub(crate) fn check_path_safe(candidate: &Path, canonical_root: &Path) -> Result<PathBuf, String> {
-    // (a) Canonicalize the candidate.
+    // (a) Fail-closed reparse check on candidate + ancestors via lstat.
+    //     MUST run before canonicalize — canonicalize resolves reparse points
+    //     on Windows and would hide junction/symlink components.
+    if has_reparse_point_in_chain(candidate) {
+        return Err("reparse point detected in candidate path chain".to_string());
+    }
+
+    // (b) Canonicalize (safe now — reparse points already rejected).
     let canonical = std::fs::canonicalize(candidate)
         .map_err(|e| format!("canonicalize failed: {e}"))?;
 
-    // (b) Reject UNC paths.
+    // (c) Reject UNC paths.
     if is_unc_path(&canonical) {
         return Err(format!(
             "UNC path rejected: {}",
             canonical.display()
         ));
-    }
-
-    // (c) Reject reparse points anywhere in the chain.
-    // Pass the canonical path so the check operates on the resolved form.
-    if has_reparse_point_in_chain(&canonical) {
-        return Err("reparse point detected in path chain".to_string());
     }
 
     // (d) Component-wise containment check (NOT string prefix).
@@ -360,5 +367,15 @@ mod tests {
 
         // Should find the vm-level directory.
         assert_eq!(results.len(), 1, "expected 1 workspace, got {:?}", results);
+    }
+
+    #[test]
+    fn test_reparse_check_fail_closed_on_nonexistent_path() {
+        // Fail-closed: lstat on a non-existent path returns Err → reject.
+        let bogus = Path::new(r"C:\Definitely\Does\Not\Exist\xyz_reparse_test");
+        assert!(
+            has_reparse_point_in_chain(bogus),
+            "has_reparse_point_in_chain must fail closed on lstat errors"
+        );
     }
 }

--- a/src-tauri/src/cowork_workspace_scan.rs
+++ b/src-tauri/src/cowork_workspace_scan.rs
@@ -1,0 +1,353 @@
+//! Cowork workspace path discovery.
+//!
+//! Walks `%LOCALAPPDATA%\Packages\Claude_*\LocalCache\Roaming\Claude\
+//! local-agent-mode-sessions\<workspace-id>\<vm-id>\` and returns the list of
+//! VM-level directories that are safe to write Cowork plugin-registry files into.
+//!
+//! **Security invariant §3 — defense-in-depth path guard:**
+//! Every candidate path goes through four checks (in order):
+//!   a. `std::fs::canonicalize` on both the root and each candidate.
+//!   b. Reject any path whose canonical form is a UNC path.
+//!   c. Reject any path where any component has the reparse-point attribute set.
+//!   d. Component-wise comparison (NOT string-prefix) against the canonical root.
+//!
+//! Paths that fail any check are skipped with a `WARN` log; the walker never
+//! surfaces their failure to the caller.
+
+#![cfg(target_os = "windows")]
+
+use std::os::windows::fs::MetadataExt;
+use std::path::{Component, Path, PathBuf};
+
+/// Maximum number of workspaces processed in a single walk.
+/// Logs a warning and stops if exceeded.
+const MAX_WORKSPACES: usize = 100;
+
+/// `FILE_ATTRIBUTE_REPARSE_POINT` — from the Windows API.
+const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Discover all Cowork workspace directories on this machine.
+///
+/// # Returns
+/// A `Vec<PathBuf>` of VM-level directories (two levels below
+/// `local-agent-mode-sessions\`).  Returns an empty vec — not an error — when:
+///   - Claude Desktop is not installed.
+///   - `local-agent-mode-sessions\` does not exist yet.
+///   - No workspaces are found.
+///
+/// Paths that fail the security guard (reparse point, UNC, outside-root) are
+/// silently skipped after a `WARN` log.
+pub fn find_cowork_workspaces() -> Vec<PathBuf> {
+    let roots = cowork_roots();
+    if roots.is_empty() {
+        log::debug!("[cowork-scan] no Claude_* package directories found — Cowork not installed");
+        return vec![];
+    }
+
+    let mut results = Vec::new();
+
+    'root: for root in &roots {
+        // Canonicalize the root for security comparisons.
+        let canonical_root = match std::fs::canonicalize(root) {
+            Ok(p) => p,
+            Err(e) => {
+                log::debug!("[cowork-scan] cannot canonicalize root {}: {e}", root.display());
+                continue;
+            }
+        };
+
+        // Walk workspace-id level.
+        let ws_entries = match std::fs::read_dir(root) {
+            Ok(e) => e,
+            Err(e) => {
+                log::debug!("[cowork-scan] cannot read sessions dir {}: {e}", root.display());
+                continue;
+            }
+        };
+
+        for ws_entry in ws_entries {
+            let ws_entry = match ws_entry {
+                Ok(e) => e,
+                Err(e) => {
+                    log::warn!("[cowork-scan] error reading workspace entry: {e}");
+                    continue;
+                }
+            };
+            let ws_path = ws_entry.path();
+
+            // Walk vm-id level.
+            let vm_entries = match std::fs::read_dir(&ws_path) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            for vm_entry in vm_entries {
+                let vm_entry = match vm_entry {
+                    Ok(e) => e,
+                    Err(e) => {
+                        log::warn!("[cowork-scan] error reading vm entry: {e}");
+                        continue;
+                    }
+                };
+                let vm_path = vm_entry.path();
+
+                // Security guard.
+                match check_path_safe(&vm_path, &canonical_root) {
+                    Ok(safe_path) => {
+                        results.push(safe_path);
+                        if results.len() >= MAX_WORKSPACES {
+                            log::warn!(
+                                "[cowork-scan] reached {MAX_WORKSPACES} workspace limit — stopping scan"
+                            );
+                            break 'root;
+                        }
+                    }
+                    Err(reason) => {
+                        log::warn!(
+                            "[cowork-scan] skipping {} — {reason}",
+                            vm_path.display()
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    log::info!("[cowork-scan] found {} workspace(s)", results.len());
+    results
+}
+
+// ---------------------------------------------------------------------------
+// Root directory discovery
+// ---------------------------------------------------------------------------
+
+/// Returns all `local-agent-mode-sessions\` directories found under
+/// `%LOCALAPPDATA%\Packages\Claude_*\...`.
+///
+/// Supports the `TANDEM_COWORK_ROOT_OVERRIDE` environment variable for test
+/// fixtures: if set, returns that path as the sole root (skipping the glob).
+fn cowork_roots() -> Vec<PathBuf> {
+    // Test hook: allow overriding the scan root for unit tests.
+    //
+    // The override is authoritative when set — if it points at an absent
+    // directory we return an empty vec rather than falling back to the real
+    // %LOCALAPPDATA% scan. This prevents tests that expect "no workspaces"
+    // from accidentally picking up the developer's real Claude Desktop install.
+    if let Ok(override_root) = std::env::var("TANDEM_COWORK_ROOT_OVERRIDE") {
+        let p = PathBuf::from(&override_root);
+        if p.is_dir() {
+            log::debug!("[cowork-scan] using TANDEM_COWORK_ROOT_OVERRIDE: {override_root}");
+            return vec![p];
+        } else {
+            log::debug!(
+                "[cowork-scan] TANDEM_COWORK_ROOT_OVERRIDE={override_root} is not a dir — returning empty"
+            );
+            return vec![];
+        }
+    }
+
+    let local_app_data = match dirs::data_local_dir() {
+        Some(d) => d,
+        None => {
+            log::warn!("[cowork-scan] cannot resolve %LOCALAPPDATA%");
+            return vec![];
+        }
+    };
+
+    let packages_dir = local_app_data.join("Packages");
+    if !packages_dir.is_dir() {
+        return vec![];
+    }
+
+    let entries = match std::fs::read_dir(&packages_dir) {
+        Ok(e) => e,
+        Err(e) => {
+            log::warn!("[cowork-scan] cannot read Packages dir: {e}");
+            return vec![];
+        }
+    };
+
+    let mut roots = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        // Match Claude_* MSIX package directories.
+        if !name_str.starts_with("Claude_") {
+            continue;
+        }
+
+        let sessions_path = entry
+            .path()
+            .join("LocalCache")
+            .join("Roaming")
+            .join("Claude")
+            .join("local-agent-mode-sessions");
+
+        if sessions_path.is_dir() {
+            log::debug!("[cowork-scan] found sessions root: {}", sessions_path.display());
+            roots.push(sessions_path);
+        }
+    }
+
+    roots
+}
+
+// ---------------------------------------------------------------------------
+// Security guard
+// ---------------------------------------------------------------------------
+
+/// Apply the four-step path security guard (invariant §3).
+///
+/// Returns the canonicalized path on success, or a human-readable rejection
+/// reason string on failure.
+pub(crate) fn check_path_safe(candidate: &Path, canonical_root: &Path) -> Result<PathBuf, String> {
+    // (a) Canonicalize the candidate.
+    let canonical = std::fs::canonicalize(candidate)
+        .map_err(|e| format!("canonicalize failed: {e}"))?;
+
+    // (b) Reject UNC paths.
+    if is_unc_path(&canonical) {
+        return Err(format!(
+            "UNC path rejected: {}",
+            canonical.display()
+        ));
+    }
+
+    // (c) Reject reparse points anywhere in the chain.
+    if has_reparse_point_in_chain(candidate) {
+        return Err("reparse point detected in path chain".to_string());
+    }
+
+    // (d) Component-wise containment check (NOT string prefix).
+    if !is_component_wise_child(&canonical, canonical_root) {
+        return Err(format!(
+            "path {} is outside canonical root {}",
+            canonical.display(),
+            canonical_root.display()
+        ));
+    }
+
+    Ok(canonical)
+}
+
+/// Returns true if the path looks like a UNC path.
+fn is_unc_path(path: &Path) -> bool {
+    let s = path.to_string_lossy();
+    // Extended UNC: \\?\UNC\  or classic UNC: \\server\share
+    s.starts_with(r"\\?\UNC\") || (s.starts_with(r"\\") && !s.starts_with(r"\\?\"))
+}
+
+/// Returns true if any component in the path chain (from root to candidate)
+/// has the `FILE_ATTRIBUTE_REPARSE_POINT` bit set.
+fn has_reparse_point_in_chain(path: &Path) -> bool {
+    // Check the candidate itself.
+    if let Ok(metadata) = std::fs::symlink_metadata(path) {
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return true;
+        }
+    }
+    // Check each ancestor.
+    let mut ancestor = path.parent();
+    while let Some(p) = ancestor {
+        if let Ok(metadata) = std::fs::symlink_metadata(p) {
+            if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                return true;
+            }
+        }
+        ancestor = p.parent();
+    }
+    false
+}
+
+/// Returns true if `child` is strictly within `root` based on a component-wise
+/// comparison.  String-prefix checks are banned (they break on names like
+/// `/foo/bar` being "inside" `/foo/ba`).
+fn is_component_wise_child(child: &Path, root: &Path) -> bool {
+    let root_components: Vec<Component<'_>> = root.components().collect();
+    let child_components: Vec<Component<'_>> = child.components().collect();
+
+    if child_components.len() <= root_components.len() {
+        return false;
+    }
+
+    for (r, c) in root_components.iter().zip(child_components.iter()) {
+        if r != c {
+            return false;
+        }
+    }
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_is_unc_path() {
+        assert!(is_unc_path(Path::new(r"\\?\UNC\server\share")));
+        assert!(is_unc_path(Path::new(r"\\server\share")));
+        assert!(!is_unc_path(Path::new(r"\\?\C:\Users\foo")));
+        assert!(!is_unc_path(Path::new(r"C:\Users\foo")));
+    }
+
+    #[test]
+    fn test_component_wise_child() {
+        let root = Path::new(r"C:\Users\test\root");
+        assert!(is_component_wise_child(
+            Path::new(r"C:\Users\test\root\ws\vm"),
+            root
+        ));
+        assert!(!is_component_wise_child(
+            Path::new(r"C:\Users\test\root"),
+            root
+        ));
+        assert!(!is_component_wise_child(
+            Path::new(r"C:\Users\test\other\ws\vm"),
+            root
+        ));
+        // Path traversal via .. trick.
+        assert!(!is_component_wise_child(
+            Path::new(r"C:\Windows\System32"),
+            root
+        ));
+    }
+
+    #[test]
+    fn test_scan_with_override_absent() {
+        let _guard = crate::COWORK_ENV_LOCK.lock().unwrap();
+        // Override pointing at a non-existent dir → returns empty vec.
+        std::env::set_var("TANDEM_COWORK_ROOT_OVERRIDE", r"C:\NonExistent\CoworkTest");
+        let results = find_cowork_workspaces();
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_scan_with_fixture_dir() {
+        let _guard = crate::COWORK_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join("tandem_cowork_scan_test");
+        let _ = fs::remove_dir_all(&dir); // Clean up previous runs.
+        let ws_dir = dir.join("ws-abc").join("vm-123");
+        fs::create_dir_all(&ws_dir).unwrap();
+
+        std::env::set_var("TANDEM_COWORK_ROOT_OVERRIDE", dir.to_str().unwrap());
+        let results = find_cowork_workspaces();
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+
+        // Clean up.
+        let _ = fs::remove_dir_all(&dir);
+
+        // Should find the vm-level directory.
+        assert_eq!(results.len(), 1, "expected 1 workspace, got {:?}", results);
+    }
+}

--- a/src-tauri/src/firewall.rs
+++ b/src-tauri/src/firewall.rs
@@ -1,0 +1,455 @@
+//! Windows Firewall management for the Cowork VM subnet allow/deny rules.
+//!
+//! All `netsh` invocations use `Command::new("netsh").args([...])` — never
+//! `cmd.exe`, never string concatenation, never `--%` wrappers (security §4).
+//!
+//! Every invocation is logged at DEBUG with: argv, exit code, stdout+stderr tail,
+//! and wall-clock duration.
+
+#![cfg(target_os = "windows")]
+
+use std::fmt;
+use std::process::Command;
+use std::time::Instant;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors that can arise from Windows Firewall operations.
+///
+/// Variants are designed to give the PR-f Settings UI distinct recovery hints
+/// (security invariant §13).
+#[derive(Debug)]
+pub enum FirewallError {
+    /// The user declined the UAC elevation prompt. The install is fail-closed:
+    /// a deny rule is written instead.
+    AdminDeclined,
+    /// `netsh.exe` was not found on PATH.
+    NetshNotFound,
+    /// `netsh.exe` ran but returned a non-zero exit code.
+    NetshFailure { exit_code: i32, stderr_tail: String },
+    /// The vEthernet subnet could not be determined (e.g. adapter absent, prefix
+    /// too broad, or PowerShell returned unexpected output).
+    SubnetDetectionFailed,
+    /// Hyper-V adapter enumeration via PowerShell failed.
+    AdapterEnumerationFailed,
+}
+
+impl fmt::Display for FirewallError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FirewallError::AdminDeclined => {
+                write!(f, "UAC elevation declined — Cowork firewall rule not added")
+            }
+            FirewallError::NetshNotFound => {
+                write!(f, "netsh.exe not found — Windows Firewall management unavailable")
+            }
+            FirewallError::NetshFailure {
+                exit_code,
+                stderr_tail,
+            } => write!(
+                f,
+                "netsh.exe failed (exit {exit_code}): {stderr_tail}"
+            ),
+            FirewallError::SubnetDetectionFailed => write!(
+                f,
+                "Could not detect Hyper-V vEthernet subnet — is Cowork set up on this machine?"
+            ),
+            FirewallError::AdapterEnumerationFailed => write!(
+                f,
+                "Hyper-V adapter enumeration failed — PowerShell query returned an error"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FirewallError {}
+
+// ---------------------------------------------------------------------------
+// Firewall rule names
+// ---------------------------------------------------------------------------
+
+const RULE_NAME_ALLOW: &str = "Tandem Cowork";
+const RULE_NAME_DENY: &str = "Tandem Cowork \u{2014} Deny (elevation refused)";
+const RULE_NAME_PREFIX: &str = "Tandem Cowork";
+
+// ---------------------------------------------------------------------------
+// Subnet detection
+// ---------------------------------------------------------------------------
+
+/// Detect the Hyper-V vEthernet IPv4 CIDR for the Cowork VM subnet.
+///
+/// Queries Hyper-V virtual adapters via PowerShell:
+///   `Get-NetAdapter | Where InterfaceDescription -like "*Hyper-V Virtual Ethernet*" |
+///    Get-NetIPAddress -AddressFamily IPv4 | Select IPAddress, PrefixLength`
+///
+/// # Security invariants
+/// - Rejects any result where prefix length < 20 (too permissive).
+/// - Returns `SubnetDetectionFailed` on zero Hyper-V adapter matches.
+/// - Never falls back to a hardcoded CIDR like `172.16.0.0/12`.
+///
+/// # Returns
+/// The detected CIDR string (e.g. `"172.20.0.0/20"`) on success.
+pub fn detect_vethernet_subnet() -> Result<String, FirewallError> {
+    let ps_script = r#"
+$adapters = Get-NetAdapter -ErrorAction SilentlyContinue |
+    Where-Object { $_.InterfaceDescription -like '*Hyper-V Virtual Ethernet*' }
+foreach ($adapter in $adapters) {
+    $ip = $adapter | Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue
+    if ($ip) {
+        Write-Output "$($ip.IPAddress)/$($ip.PrefixLength)"
+    }
+}
+"#;
+
+    let start = Instant::now();
+    let output = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            ps_script,
+        ])
+        .output();
+
+    let elapsed = start.elapsed();
+
+    let output = match output {
+        Ok(o) => o,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            log::warn!(
+                "[firewall] powershell.exe not found after {:.2}s",
+                elapsed.as_secs_f64()
+            );
+            return Err(FirewallError::AdapterEnumerationFailed);
+        }
+        Err(e) => {
+            log::warn!(
+                "[firewall] PowerShell spawn failed after {:.2}s: {e}",
+                elapsed.as_secs_f64()
+            );
+            return Err(FirewallError::AdapterEnumerationFailed);
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+    log::debug!(
+        "[firewall] powershell vEthernet query: exit={}, elapsed={:.2}s, stdout={:?}, stderr={:?}",
+        output.status.code().unwrap_or(-1),
+        elapsed.as_secs_f64(),
+        truncate_tail(&stdout, 200),
+        truncate_tail(&stderr, 200),
+    );
+
+    if !output.status.success() || stdout.is_empty() {
+        return Err(FirewallError::SubnetDetectionFailed);
+    }
+
+    // Parse lines like "172.20.0.1/20" — take the first valid result.
+    for line in stdout.lines() {
+        let line = line.trim();
+        if let Some(cidr) = parse_cidr_from_line(line) {
+            return Ok(cidr);
+        }
+    }
+
+    Err(FirewallError::SubnetDetectionFailed)
+}
+
+/// Parse an `IPAddress/PrefixLength` string into a proper CIDR network address.
+///
+/// Rejects prefix length < 20 per security invariant §5.
+fn parse_cidr_from_line(line: &str) -> Option<String> {
+    let (ip_str, prefix_str) = line.split_once('/')?;
+    let prefix: u8 = prefix_str.trim().parse().ok()?;
+
+    // Security invariant §5: reject too-broad prefixes.
+    if prefix < 20 {
+        log::warn!(
+            "[firewall] detected vEthernet subnet has prefix /{prefix} — too broad (< /20); rejected"
+        );
+        return None;
+    }
+
+    // Convert host address to network address (mask off host bits).
+    let ip_trimmed = ip_str.trim();
+    let network_addr = host_to_network(ip_trimmed, prefix)?;
+    Some(format!("{network_addr}/{prefix}"))
+}
+
+/// Mask off host bits to get the network address.
+fn host_to_network(ip: &str, prefix: u8) -> Option<String> {
+    let parts: Vec<u8> = ip
+        .split('.')
+        .map(|p| p.parse::<u8>().ok())
+        .collect::<Option<Vec<_>>>()?;
+    if parts.len() != 4 {
+        return None;
+    }
+    let ip_u32 = ((parts[0] as u32) << 24)
+        | ((parts[1] as u32) << 16)
+        | ((parts[2] as u32) << 8)
+        | (parts[3] as u32);
+    let mask: u32 = if prefix == 0 {
+        0
+    } else {
+        !0u32 << (32 - prefix)
+    };
+    let network_u32 = ip_u32 & mask;
+    Some(format!(
+        "{}.{}.{}.{}",
+        (network_u32 >> 24) & 0xff,
+        (network_u32 >> 16) & 0xff,
+        (network_u32 >> 8) & 0xff,
+        network_u32 & 0xff,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Firewall rule management
+// ---------------------------------------------------------------------------
+
+/// Add an inbound allow rule scoped to `cidr` for Tandem's MCP port (3479).
+///
+/// Rule: `dir=in, action=allow, protocol=TCP, localport=3479, remoteip=<cidr>`.
+///
+/// Requires elevated privileges. Returns `FirewallError::AdminDeclined` if
+/// `netsh` exits with a code indicating UAC denial (exit code 1 with specific
+/// error text from Windows).
+pub fn add_cowork_allow_rule(cidr: &str) -> Result<(), FirewallError> {
+    log::info!("[firewall] adding Cowork allow rule for CIDR {cidr}");
+    run_netsh(&[
+        "advfirewall",
+        "firewall",
+        "add",
+        "rule",
+        &format!("name={RULE_NAME_ALLOW}"),
+        "dir=in",
+        "action=allow",
+        "protocol=TCP",
+        "localport=3479",
+        &format!("remoteip={cidr}"),
+    ])
+}
+
+/// Add an inbound deny rule — written when UAC elevation is refused so that
+/// port 3479 is definitively blocked from the VM, not in an ambiguous open state.
+///
+/// Rule: `dir=in, action=block, protocol=TCP, localport=3479, remoteip=<cidr>`.
+pub fn add_cowork_deny_rule(cidr: &str) -> Result<(), FirewallError> {
+    log::info!("[firewall] adding Cowork deny rule for CIDR {cidr}");
+    run_netsh(&[
+        "advfirewall",
+        "firewall",
+        "add",
+        "rule",
+        &format!("name={RULE_NAME_DENY}"),
+        "dir=in",
+        "action=block",
+        "protocol=TCP",
+        "localport=3479",
+        &format!("remoteip={cidr}"),
+    ])
+}
+
+/// Remove all firewall rules whose name starts with `"Tandem Cowork"`.
+/// Covers both the allow rule and the deny-on-decline variant.
+pub fn remove_cowork_rules() -> Result<(), FirewallError> {
+    log::info!("[firewall] removing all Tandem Cowork firewall rules");
+    run_netsh(&[
+        "advfirewall",
+        "firewall",
+        "delete",
+        "rule",
+        &format!("name={RULE_NAME_PREFIX}"),
+    ])
+    .or_else(|e| {
+        // "No rules match" is not an error — the user may never have had a rule.
+        match e {
+            FirewallError::NetshFailure { exit_code: 1, .. } => {
+                log::debug!("[firewall] no Tandem Cowork rules to remove");
+                Ok(())
+            }
+            other => Err(other),
+        }
+    })?;
+
+    // Also try to remove the deny variant (different name string).
+    run_netsh(&[
+        "advfirewall",
+        "firewall",
+        "delete",
+        "rule",
+        &format!("name={RULE_NAME_DENY}"),
+    ])
+    .or_else(|e| match e {
+        FirewallError::NetshFailure { exit_code: 1, .. } => Ok(()),
+        other => Err(other),
+    })
+}
+
+/// Scan for orphan "Tandem Cowork*" firewall rules and return their names.
+///
+/// Used by install-time orphan reconciliation (security invariant §12) to detect
+/// stale rules from a previous failed uninstall.
+pub fn scan_orphan_rules() -> Vec<String> {
+    let start = Instant::now();
+    let output = Command::new("netsh")
+        .args([
+            "advfirewall",
+            "firewall",
+            "show",
+            "rule",
+            &format!("name={RULE_NAME_PREFIX}"),
+        ])
+        .output();
+
+    let elapsed = start.elapsed();
+
+    let output = match output {
+        Ok(o) => o,
+        Err(e) => {
+            log::warn!("[firewall] scan_orphan_rules spawn failed: {e}");
+            return vec![];
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    log::debug!(
+        "[firewall] scan_orphan_rules: exit={}, elapsed={:.2}s",
+        output.status.code().unwrap_or(-1),
+        elapsed.as_secs_f64()
+    );
+
+    // Parse "Rule Name: ..." lines from netsh output.
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            // netsh output uses "Rule Name:" on English locales.
+            let stripped = line
+                .strip_prefix("Rule Name:")
+                .or_else(|| line.strip_prefix("Rule name:"));
+            stripped.map(|s| s.trim().to_string())
+        })
+        .filter(|name| name.starts_with(RULE_NAME_PREFIX))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Execute `netsh` with the given argv-form arguments.
+///
+/// Logs the invocation (argv, exit code, stdout/stderr tail, elapsed time).
+/// Never constructs a command string — each argument is passed separately.
+fn run_netsh(args: &[&str]) -> Result<(), FirewallError> {
+    let start = Instant::now();
+    let output = Command::new("netsh").args(args).output();
+    let elapsed = start.elapsed();
+
+    let output = match output {
+        Ok(o) => o,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            log::error!("[firewall] netsh.exe not found after {:.2}s", elapsed.as_secs_f64());
+            return Err(FirewallError::NetshNotFound);
+        }
+        Err(e) => {
+            log::error!("[firewall] netsh spawn error after {:.2}s: {e}", elapsed.as_secs_f64());
+            return Err(FirewallError::NetshFailure {
+                exit_code: -1,
+                stderr_tail: e.to_string(),
+            });
+        }
+    };
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    log::debug!(
+        "[firewall] netsh {:?}: exit={exit_code}, elapsed={:.2}s, stdout={:?}, stderr={:?}",
+        args,
+        elapsed.as_secs_f64(),
+        truncate_tail(&stdout, 200),
+        truncate_tail(&stderr, 200),
+    );
+
+    if !output.status.success() {
+        // Detect UAC-declined pattern: exit code 1 + "The requested operation
+        // requires elevation" in stdout (netsh writes errors to stdout on Windows).
+        let combined = format!("{stdout}{stderr}");
+        if combined.contains("requires elevation") || combined.contains("access is denied") {
+            log::warn!("[firewall] UAC elevation declined");
+            return Err(FirewallError::AdminDeclined);
+        }
+
+        return Err(FirewallError::NetshFailure {
+            exit_code,
+            stderr_tail: truncate_tail(stderr.trim(), 400).to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Return the last `max_chars` characters of a string (UTF-8 char boundary).
+fn truncate_tail(s: &str, max_chars: usize) -> &str {
+    if s.len() <= max_chars {
+        s
+    } else {
+        let start = s.len() - max_chars;
+        // Find a valid char boundary.
+        let mut pos = start;
+        while pos < s.len() && !s.is_char_boundary(pos) {
+            pos += 1;
+        }
+        &s[pos..]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_host_to_network() {
+        assert_eq!(
+            host_to_network("172.20.0.1", 20),
+            Some("172.20.0.0".to_string())
+        );
+        assert_eq!(
+            host_to_network("192.168.1.50", 24),
+            Some("192.168.1.0".to_string())
+        );
+        assert_eq!(
+            host_to_network("10.0.0.1", 8),
+            Some("10.0.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_cidr_rejects_too_broad() {
+        // prefix /12 is too broad → rejected.
+        assert!(parse_cidr_from_line("172.16.0.1/12").is_none());
+        // prefix /19 → below /20 → rejected.
+        assert!(parse_cidr_from_line("172.20.0.1/19").is_none());
+    }
+
+    #[test]
+    fn test_parse_cidr_accepts_narrow() {
+        let result = parse_cidr_from_line("172.20.0.1/20");
+        assert_eq!(result, Some("172.20.0.0/20".to_string()));
+    }
+
+    #[test]
+    fn test_truncate_tail() {
+        assert_eq!(truncate_tail("hello world", 5), "world");
+        assert_eq!(truncate_tail("short", 100), "short");
+    }
+}

--- a/src-tauri/src/firewall.rs
+++ b/src-tauri/src/firewall.rs
@@ -20,7 +20,12 @@ use std::time::Instant;
 ///
 /// Variants are designed to give the PR-f Settings UI distinct recovery hints
 /// (security invariant §13).
-#[derive(Debug)]
+///
+/// `Serialize`/`Deserialize` enable structured JSON errors over the Tauri IPC:
+/// `{"kind": "adminDeclined"}` etc., matching the TypeScript discriminant in
+/// the Settings UI firewall hint handler.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
 pub enum FirewallError {
     /// The user declined the UAC elevation prompt. The install is fail-closed:
     /// a deny rule is written instead.
@@ -422,22 +427,28 @@ fn run_netsh(args: &[&str]) -> Result<(), FirewallError> {
     if !output.status.success() {
         // Detect UAC-declined pattern for `add rule` commands.
         //
-        // The string-match approach ("requires elevation", "access is denied")
-        // fails on localized Windows builds. Instead, use exit code 1 combined
-        // with the command being an `add rule` invocation — `delete` and `show`
-        // commands also return exit 1 for "no rules found", so we restrict the
-        // AdminDeclined classification to `add` commands only.
+        // Strategy: locale-sensitive string match is the primary signal (works on
+        // EN-locale Windows). For non-English locales we fall back to exit code 1
+        // on an `add` command, BUT only when stdout is empty — a successful partial
+        // execution (e.g. "Ok.", "The command was executed") will always produce
+        // stdout, so an empty stdout on exit 1 indicates the process never ran the
+        // rule-write path (which is what UAC denial looks like).
         //
-        // We still keep the string-match as an additional signal when available,
-        // but it is not required — exit_code == 1 on an `add` command is
-        // sufficient to classify as a potential UAC decline.
+        // Exit code 1 alone is too broad: malformed args, duplicate rule names,
+        // invalid CIDR, and quota errors also return exit 1 — those all produce
+        // some stdout. UAC denial exits 1 with no stdout.
         let is_add_command = args.contains(&"add");
         let combined = format!("{stdout}{stderr}");
-        let locale_strings_match =
-            combined.contains("requires elevation") || combined.contains("access is denied");
+        let locale_strings_match = combined.contains("requires elevation")
+            || combined.contains("access is denied")
+            || combined.contains("Access is denied");
+        // Locale-independent fallback: exit 1 on add with no stdout output.
+        let exit1_no_stdout = is_add_command && exit_code == 1 && stdout.trim().is_empty();
 
-        if is_add_command && (exit_code == 1 || locale_strings_match) {
-            log::warn!("[firewall] UAC elevation declined (exit={exit_code}, add_cmd={is_add_command})");
+        if is_add_command && (locale_strings_match || exit1_no_stdout) {
+            log::warn!(
+                "[firewall] UAC elevation declined (exit={exit_code}, locale_match={locale_strings_match}, no_stdout={exit1_no_stdout})"
+            );
             return Err(FirewallError::AdminDeclined);
         }
 

--- a/src-tauri/src/firewall.rs
+++ b/src-tauri/src/firewall.rs
@@ -28,7 +28,7 @@ pub enum FirewallError {
     /// `netsh.exe` was not found on PATH.
     NetshNotFound,
     /// `netsh.exe` ran but returned a non-zero exit code.
-    NetshFailure { exit_code: i32, stderr_tail: String },
+    NetshFailure { exit_code: i32, stderr_tail: String, stdout_tail: String },
     /// The vEthernet subnet could not be determined (e.g. adapter absent, prefix
     /// too broad, or PowerShell returned unexpected output).
     SubnetDetectionFailed,
@@ -48,9 +48,10 @@ impl fmt::Display for FirewallError {
             FirewallError::NetshFailure {
                 exit_code,
                 stderr_tail,
+                stdout_tail,
             } => write!(
                 f,
-                "netsh.exe failed (exit {exit_code}): {stderr_tail}"
+                "netsh.exe failed (exit {exit_code}): stdout={stdout_tail:?} stderr={stderr_tail:?}"
             ),
             FirewallError::SubnetDetectionFailed => write!(
                 f,
@@ -267,10 +268,14 @@ pub fn remove_cowork_rules() -> Result<(), FirewallError> {
         &format!("name={RULE_NAME_PREFIX}"),
     ])
     .or_else(|e| {
-        // "No rules match" is not an error — the user may never have had a rule.
+        // "No rules match the specified criteria." is written to stdout (not stderr)
+        // by netsh on Windows. Only treat exit_code==1 as "nothing to do" when
+        // stdout confirms the "no match" case — all other exit-1 failures propagate.
         match e {
-            FirewallError::NetshFailure { exit_code: 1, .. } => {
-                log::debug!("[firewall] no Tandem Cowork rules to remove");
+            FirewallError::NetshFailure { exit_code: 1, ref stdout_tail, .. }
+                if stdout_tail.contains("No rules match") =>
+            {
+                log::debug!("[firewall] no Tandem Cowork rules to remove (allow rule)");
                 Ok(())
             }
             other => Err(other),
@@ -286,7 +291,12 @@ pub fn remove_cowork_rules() -> Result<(), FirewallError> {
         &format!("name={RULE_NAME_DENY}"),
     ])
     .or_else(|e| match e {
-        FirewallError::NetshFailure { exit_code: 1, .. } => Ok(()),
+        FirewallError::NetshFailure { exit_code: 1, ref stdout_tail, .. }
+            if stdout_tail.contains("No rules match") =>
+        {
+            log::debug!("[firewall] no Tandem Cowork rules to remove (deny rule)");
+            Ok(())
+        }
         other => Err(other),
     })
 }
@@ -295,7 +305,10 @@ pub fn remove_cowork_rules() -> Result<(), FirewallError> {
 ///
 /// Used by install-time orphan reconciliation (security invariant §12) to detect
 /// stale rules from a previous failed uninstall.
-pub fn scan_orphan_rules() -> Vec<String> {
+///
+/// Returns `Err` on spawn failure or unexpected netsh errors so that
+/// `reconcile_orphans` can distinguish "no orphans" from "scan failed".
+pub fn scan_orphan_rules() -> Result<Vec<String>, FirewallError> {
     let start = Instant::now();
     let output = Command::new("netsh")
         .args([
@@ -311,22 +324,45 @@ pub fn scan_orphan_rules() -> Vec<String> {
 
     let output = match output {
         Ok(o) => o,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            log::warn!("[firewall] scan_orphan_rules: netsh.exe not found");
+            return Err(FirewallError::NetshNotFound);
+        }
         Err(e) => {
             log::warn!("[firewall] scan_orphan_rules spawn failed: {e}");
-            return vec![];
+            return Err(FirewallError::NetshFailure {
+                exit_code: -1,
+                stderr_tail: e.to_string(),
+                stdout_tail: String::new(),
+            });
         }
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let exit_code = output.status.code().unwrap_or(-1);
 
     log::debug!(
-        "[firewall] scan_orphan_rules: exit={}, elapsed={:.2}s",
-        output.status.code().unwrap_or(-1),
+        "[firewall] scan_orphan_rules: exit={exit_code}, elapsed={:.2}s",
         elapsed.as_secs_f64()
     );
 
+    // netsh `show rule` exits 1 with "No rules match" when there are no matching
+    // rules — treat that as an empty (not an error) result.
+    if !output.status.success() {
+        let combined = format!("{stdout}{stderr}");
+        if combined.contains("No rules match") {
+            return Ok(vec![]);
+        }
+        return Err(FirewallError::NetshFailure {
+            exit_code,
+            stderr_tail: truncate_tail(stderr.trim(), 400).to_string(),
+            stdout_tail: truncate_tail(stdout.trim(), 400).to_string(),
+        });
+    }
+
     // Parse "Rule Name: ..." lines from netsh output.
-    stdout
+    let names = stdout
         .lines()
         .filter_map(|line| {
             let line = line.trim();
@@ -337,7 +373,9 @@ pub fn scan_orphan_rules() -> Vec<String> {
             stripped.map(|s| s.trim().to_string())
         })
         .filter(|name| name.starts_with(RULE_NAME_PREFIX))
-        .collect()
+        .collect();
+
+    Ok(names)
 }
 
 // ---------------------------------------------------------------------------
@@ -364,6 +402,7 @@ fn run_netsh(args: &[&str]) -> Result<(), FirewallError> {
             return Err(FirewallError::NetshFailure {
                 exit_code: -1,
                 stderr_tail: e.to_string(),
+                stdout_tail: String::new(),
             });
         }
     };
@@ -381,17 +420,31 @@ fn run_netsh(args: &[&str]) -> Result<(), FirewallError> {
     );
 
     if !output.status.success() {
-        // Detect UAC-declined pattern: exit code 1 + "The requested operation
-        // requires elevation" in stdout (netsh writes errors to stdout on Windows).
+        // Detect UAC-declined pattern for `add rule` commands.
+        //
+        // The string-match approach ("requires elevation", "access is denied")
+        // fails on localized Windows builds. Instead, use exit code 1 combined
+        // with the command being an `add rule` invocation — `delete` and `show`
+        // commands also return exit 1 for "no rules found", so we restrict the
+        // AdminDeclined classification to `add` commands only.
+        //
+        // We still keep the string-match as an additional signal when available,
+        // but it is not required — exit_code == 1 on an `add` command is
+        // sufficient to classify as a potential UAC decline.
+        let is_add_command = args.contains(&"add");
         let combined = format!("{stdout}{stderr}");
-        if combined.contains("requires elevation") || combined.contains("access is denied") {
-            log::warn!("[firewall] UAC elevation declined");
+        let locale_strings_match =
+            combined.contains("requires elevation") || combined.contains("access is denied");
+
+        if is_add_command && (exit_code == 1 || locale_strings_match) {
+            log::warn!("[firewall] UAC elevation declined (exit={exit_code}, add_cmd={is_add_command})");
             return Err(FirewallError::AdminDeclined);
         }
 
         return Err(FirewallError::NetshFailure {
             exit_code,
             stderr_tail: truncate_tail(stderr.trim(), 400).to_string(),
+            stdout_tail: truncate_tail(stdout.trim(), 400).to_string(),
         });
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -739,7 +739,8 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         let token = token_store::get_or_create_token()?;
 
         // Detect vEthernet subnet.
-        let cidr = firewall::detect_vethernet_subnet().map_err(|e| e.to_string())?;
+        let cidr = firewall::detect_vethernet_subnet()
+            .map_err(|e| serde_json::to_string(&e).unwrap_or_else(|_| e.to_string()))?;
 
         // Add allow firewall rule.
         let firewall_result = firewall::add_cowork_allow_rule(&cidr);
@@ -765,9 +766,9 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
                 }) {
                     log::warn!("[cowork] failed to persist UAC-declined meta: {meta_err}");
                 }
-                return Err(e.to_string());
+                return Err(serde_json::to_string(e).unwrap_or_else(|_| e.to_string()));
             }
-            return Err(e.to_string());
+            return Err(serde_json::to_string(e).unwrap_or_else(|_| e.to_string()));
         }
 
         // Resolve TANDEM_URL (host.docker.internal by default; LAN-IP if override set).
@@ -948,18 +949,47 @@ fn cowork_get_status() -> Result<serde_json::Value, String> {
                     {
                         "ok"
                     }
-                    _ => "notInstalled",
+                    _ => "failed",
                 }
             } else {
-                "notInstalled"
+                "failed"
+            };
+
+            // Read-only check: does known_marketplaces.json exist?
+            let marketplaces_file = ws_path.join("cowork_plugins").join("known_marketplaces.json");
+            let marketplaces_status = if marketplaces_file.exists() {
+                match std::fs::read_to_string(&marketplaces_file)
+                    .ok()
+                    .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+                {
+                    Some(_) => "ok",
+                    _ => "failed",
+                }
+            } else {
+                "failed"
+            };
+
+            // Read-only check: does cowork_settings.json exist?
+            let settings_file = ws_path.join("cowork_plugins").join("cowork_settings.json");
+            let cowork_settings_status = if settings_file.exists() {
+                match std::fs::read_to_string(&settings_file)
+                    .ok()
+                    .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+                {
+                    Some(_) => "ok",
+                    _ => "failed",
+                }
+            } else {
+                "failed"
             };
 
             serde_json::json!({
                 "workspaceId": workspace_id,
                 "vmId": vm_id,
+                "path": ws_path.to_string_lossy(),
                 "installedPlugins": installed_status,
-                "knownMarketplaces": installed_status,
-                "coworkSettings": installed_status,
+                "knownMarketplaces": marketplaces_status,
+                "coworkSettings": cowork_settings_status,
             })
         })
         .collect();
@@ -1009,7 +1039,8 @@ fn cowork_get_meta() -> Result<serde_json::Value, String> {
 #[cfg(target_os = "windows")]
 #[tauri::command]
 fn cowork_detect_vethernet_subnet() -> Result<String, String> {
-    firewall::detect_vethernet_subnet().map_err(|e| e.to_string())
+    firewall::detect_vethernet_subnet()
+        .map_err(|e| serde_json::to_string(&e).unwrap_or_else(|_| e.to_string()))
 }
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -702,6 +702,10 @@ fn copy_sample_files(handle: &tauri::AppHandle) -> Result<(), String> {
 // All commands have Windows-native and non-Windows stub variants so that
 // tauri::generate_handler![] compiles on all platforms.
 
+/// Error string returned by every non-Windows Cowork stub.
+#[cfg(not(target_os = "windows"))]
+const WINDOWS_ONLY_ERR: &str = "Cowork integration is Windows-only in v0.8.0";
+
 /// Scan for Cowork workspace directories.
 #[cfg(target_os = "windows")]
 #[tauri::command]
@@ -715,7 +719,7 @@ fn cowork_scan_workspaces() -> Result<Vec<String>, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_scan_workspaces() -> Result<Vec<String>, String> {
-    Err("Cowork integration is Windows-only in v0.8.0".into())
+    Err(WINDOWS_ONLY_ERR.into())
 }
 
 /// Enable or disable the Cowork integration.
@@ -815,7 +819,7 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_toggle_integration(_enabled: bool) -> Result<String, String> {
-    Err("Cowork integration is Windows-only in v0.8.0".into())
+    Err(WINDOWS_ONLY_ERR.into())
 }
 
 /// Re-scan workspaces and install into any new ones.
@@ -851,7 +855,7 @@ fn cowork_rescan() -> Result<String, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_rescan() -> Result<String, String> {
-    Err("Cowork integration is Windows-only in v0.8.0".into())
+    Err(WINDOWS_ONLY_ERR.into())
 }
 
 /// Get the current Cowork integration status.
@@ -892,7 +896,7 @@ fn cowork_get_meta() -> Result<cowork_meta::CoworkMeta, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_get_meta() -> Result<serde_json::Value, String> {
-    Err("Cowork integration is Windows-only in v0.8.0".into())
+    Err(WINDOWS_ONLY_ERR.into())
 }
 
 /// Detect the Hyper-V vEthernet subnet.
@@ -904,7 +908,7 @@ fn cowork_detect_vethernet_subnet() -> Result<String, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_detect_vethernet_subnet() -> Result<String, String> {
-    Err("Cowork integration is Windows-only in v0.8.0".into())
+    Err(WINDOWS_ONLY_ERR.into())
 }
 
 /// Re-walk all workspaces with a new auth token (called after `tandem rotate-token`).
@@ -924,7 +928,7 @@ fn cowork_apply_token(token: String) -> Result<String, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_apply_token(_token: String) -> Result<String, String> {
-    Err("Cowork integration is Windows-only in v0.8.0".into())
+    Err(WINDOWS_ONLY_ERR.into())
 }
 
 /// Install the Tandem plugin into a specific workspace path.
@@ -970,7 +974,7 @@ fn cowork_install_into_workspace(ws_path: String) -> Result<String, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_install_into_workspace(_ws_path: String) -> Result<String, String> {
-    Err("Cowork integration is Windows-only in v0.8.0".into())
+    Err(WINDOWS_ONLY_ERR.into())
 }
 
 /// Uninstall the Tandem plugin from a specific workspace path.
@@ -1001,7 +1005,7 @@ fn cowork_uninstall_from_workspace(ws_path: String) -> Result<String, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_uninstall_from_workspace(_ws_path: String) -> Result<String, String> {
-    Err("Cowork integration is Windows-only in v0.8.0".into())
+    Err(WINDOWS_ONLY_ERR.into())
 }
 
 /// Set or unset the LAN-IP override for TANDEM_URL.
@@ -1031,7 +1035,7 @@ fn cowork_set_lan_ip_override(enabled: bool) -> Result<String, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_set_lan_ip_override(_enabled: bool) -> Result<String, String> {
-    Err("Cowork integration is Windows-only in v0.8.0".into())
+    Err(WINDOWS_ONLY_ERR.into())
 }
 
 /// Clear the UAC-declined flag and retry the enable flow.
@@ -1048,7 +1052,7 @@ fn cowork_retry_admin_elevation() -> Result<String, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_retry_admin_elevation() -> Result<String, String> {
-    Err("Cowork integration is Windows-only in v0.8.0".into())
+    Err(WINDOWS_ONLY_ERR.into())
 }
 
 /// Minimal ISO-8601 (UTC) timestamp without pulling in chrono.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,22 @@
 mod token_store;
 
+#[cfg(target_os = "windows")]
+mod cowork_atomic_json;
+
+/// Process-wide mutex for tests that mutate `TANDEM_COWORK_ROOT_OVERRIDE`.
+/// Shared across `cowork_installer` and `cowork_workspace_scan` test modules so
+/// they serialize against each other and do not race on the env var.
+#[cfg(test)]
+pub(crate) static COWORK_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+#[cfg(target_os = "windows")]
+mod cowork_workspace_scan;
+#[cfg(target_os = "windows")]
+mod cowork_installer;
+#[cfg(target_os = "windows")]
+mod firewall;
+#[cfg(target_os = "windows")]
+mod cowork_meta;
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -251,6 +268,19 @@ pub fn run() {
                 }
             }
         })
+        .invoke_handler(tauri::generate_handler![
+            cowork_scan_workspaces,
+            cowork_toggle_integration,
+            cowork_rescan,
+            cowork_get_status,
+            cowork_get_meta,
+            cowork_detect_vethernet_subnet,
+            cowork_apply_token,
+            cowork_install_into_workspace,
+            cowork_uninstall_from_workspace,
+            cowork_set_lan_ip_override,
+            cowork_retry_admin_elevation,
+        ])
         .build(tauri::generate_context!())
         .unwrap_or_else(|e| panic!("Failed to build Tauri application: {e}"))
         .run(|app, event| {
@@ -664,6 +694,421 @@ fn copy_sample_files(handle: &tauri::AppHandle) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Cowork Tauri invoke commands
+// ---------------------------------------------------------------------------
+// All commands have Windows-native and non-Windows stub variants so that
+// tauri::generate_handler![] compiles on all platforms.
+
+/// Scan for Cowork workspace directories.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_scan_workspaces() -> Result<Vec<String>, String> {
+    let paths = cowork_workspace_scan::find_cowork_workspaces();
+    Ok(paths
+        .into_iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect())
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_scan_workspaces() -> Result<Vec<String>, String> {
+    Err("Cowork integration is Windows-only in v0.8.0".into())
+}
+
+/// Enable or disable the Cowork integration.
+///
+/// On enable: fetches auth token, detects vEthernet subnet, adds allow firewall
+/// rule, walks workspaces, installs plugin entries. On UAC decline: fail-closed —
+/// writes a deny rule and does NOT write plugin entries (invariant §4).
+/// On disable: uninstalls plugin entries, removes firewall rules.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
+    use cowork_installer::{install_tandem_plugin_into_workspace, uninstall_tandem_plugin_from_workspace};
+    use cowork_workspace_scan::find_cowork_workspaces;
+
+    if enabled {
+        // Fetch token.
+        let token = token_store::get_or_create_token()?;
+
+        // Detect vEthernet subnet.
+        let cidr = firewall::detect_vethernet_subnet().map_err(|e| e.to_string())?;
+
+        // Add allow firewall rule.
+        let firewall_result = firewall::add_cowork_allow_rule(&cidr);
+        if let Err(ref e) = firewall_result {
+            // Fail-closed: on UAC decline, write a deny rule and bail — do NOT
+            // walk workspaces (invariant §4).
+            if let firewall::FirewallError::AdminDeclined = e {
+                log::warn!("[cowork] UAC declined — writing deny rule and updating meta; no plugin entries written");
+                if let Err(deny_err) = firewall::add_cowork_deny_rule(&cidr) {
+                    log::warn!("[cowork] failed to write deny rule: {deny_err}");
+                }
+                let _ = cowork_meta::update(|m| {
+                    m.uac_declined_last_attempt = true;
+                    m.uac_declined_at = Some(iso_now());
+                    m.vethernet_cidr_detected = Some(cidr.clone());
+                    m.enabled = false;
+                });
+                return Err(e.to_string());
+            }
+            return Err(e.to_string());
+        }
+
+        // Resolve TANDEM_URL (host.docker.internal by default; LAN-IP if override set).
+        let tandem_url = cowork_installer::resolve_tandem_url(&cowork_meta::load().unwrap_or_default());
+
+        // Orphan reconciliation (invariant §12).
+        let workspaces = find_cowork_workspaces();
+        let reconcile = cowork_installer::reconcile_orphans(&workspaces, &token);
+        if !reconcile.removed_firewall_rules.is_empty() || !reconcile.rewritten_stale_entries.is_empty() {
+            log::info!(
+                "[cowork] orphan reconcile: removed {} rule(s), rewrote {} stale entry(s)",
+                reconcile.removed_firewall_rules.len(),
+                reconcile.rewritten_stale_entries.len()
+            );
+        }
+
+        let workspace_count = workspaces.len();
+
+        let reports: Vec<_> = workspaces
+            .iter()
+            .map(|ws| install_tandem_plugin_into_workspace(ws, &token, &tandem_url))
+            .collect();
+
+        let errors: Vec<_> = reports
+            .iter()
+            .filter_map(|r| r.as_ref().err())
+            .collect();
+
+        if !errors.is_empty() {
+            log::warn!("[cowork] {} install error(s): {:?}", errors.len(), errors);
+        }
+
+        let _ = cowork_meta::update(|m| {
+            m.enabled = true;
+            m.vethernet_cidr_detected = Some(cidr.clone());
+            m.workspaces_last_scanned_at = Some(iso_now());
+            m.uac_declined_last_attempt = false;
+            m.uac_declined_at = None;
+        });
+
+        Ok(format!("Cowork enabled: {workspace_count} workspace(s) configured"))
+    } else {
+        // Disable: uninstall from all workspaces and remove firewall rules.
+        let workspaces = find_cowork_workspaces();
+        for ws in &workspaces {
+            if let Err(e) = uninstall_tandem_plugin_from_workspace(ws) {
+                log::warn!("[cowork] uninstall error for {}: {e}", ws.display());
+            }
+        }
+        if let Err(e) = firewall::remove_cowork_rules() {
+            log::warn!("[cowork] remove firewall rules error: {e}");
+        }
+        let _ = cowork_meta::update(|m| { m.enabled = false; });
+        Ok("Cowork disabled".to_string())
+    }
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_toggle_integration(_enabled: bool) -> Result<String, String> {
+    Err("Cowork integration is Windows-only in v0.8.0".into())
+}
+
+/// Re-scan workspaces and install into any new ones.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_rescan() -> Result<String, String> {
+    use cowork_installer::{install_tandem_plugin_into_workspace, resolve_tandem_url};
+    use cowork_workspace_scan::find_cowork_workspaces;
+
+    let meta = cowork_meta::load().map_err(|e| e.to_string())?;
+    if !meta.enabled {
+        return Ok("Cowork not enabled — rescan skipped".to_string());
+    }
+
+    let token = token_store::get_or_create_token()?;
+    let tandem_url = resolve_tandem_url(&meta);
+
+    let workspaces = find_cowork_workspaces();
+    let count = workspaces.len();
+
+    for ws in &workspaces {
+        if let Err(e) = install_tandem_plugin_into_workspace(ws, &token, &tandem_url) {
+            log::warn!("[cowork] rescan install error for {}: {e}", ws.display());
+        }
+    }
+
+    let _ = cowork_meta::update(|m| {
+        m.workspaces_last_scanned_at = Some(iso_now());
+    });
+
+    Ok(format!("Rescan complete: {count} workspace(s)"))
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_rescan() -> Result<String, String> {
+    Err("Cowork integration is Windows-only in v0.8.0".into())
+}
+
+/// Get the current Cowork integration status.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_get_status() -> Result<serde_json::Value, String> {
+    use cowork_workspace_scan::find_cowork_workspaces;
+
+    let meta = cowork_meta::load().map_err(|e| e.to_string())?;
+    let workspaces = find_cowork_workspaces();
+    let cowork_detected = !workspaces.is_empty();
+
+    Ok(serde_json::json!({
+        "enabled": meta.enabled,
+        "vethernetCidr": meta.vethernet_cidr_detected,
+        "lanIpFallback": meta.lan_ip_fallback,
+        "useLanIpOverride": meta.use_lan_ip_override,
+        "workspacesLastScannedAt": meta.workspaces_last_scanned_at,
+        "uacDeclined": meta.uac_declined_last_attempt,
+        "uacDeclinedAt": meta.uac_declined_at,
+        "workspaceCount": workspaces.len(),
+        "coworkDetected": cowork_detected,
+        "osSupported": true,
+    }))
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_get_status() -> Result<serde_json::Value, String> {
+    Ok(serde_json::json!({ "osSupported": false, "enabled": false, "coworkDetected": false }))
+}
+
+/// Read the Cowork metadata file.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_get_meta() -> Result<cowork_meta::CoworkMeta, String> {
+    cowork_meta::load()
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_get_meta() -> Result<serde_json::Value, String> {
+    Err("Cowork integration is Windows-only in v0.8.0".into())
+}
+
+/// Detect the Hyper-V vEthernet subnet.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_detect_vethernet_subnet() -> Result<String, String> {
+    firewall::detect_vethernet_subnet().map_err(|e| e.to_string())
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_detect_vethernet_subnet() -> Result<String, String> {
+    Err("Cowork integration is Windows-only in v0.8.0".into())
+}
+
+/// Re-walk all workspaces with a new auth token (called after `tandem rotate-token`).
+///
+/// Token is never logged — passed through to `apply_token_to_all_workspaces`
+/// which also never logs it.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_apply_token(token: String) -> Result<String, String> {
+    let reports = cowork_installer::apply_token_to_all_workspaces(&token);
+    let success = reports
+        .iter()
+        .filter(|r| r.installed_plugins == cowork_installer::WriteStatus::Ok)
+        .count();
+    Ok(format!("Cowork: {success} workspace(s) re-walked with new token"))
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_apply_token(_token: String) -> Result<String, String> {
+    Err("Cowork integration is Windows-only in v0.8.0".into())
+}
+
+/// Install the Tandem plugin into a specific workspace path.
+///
+/// Precondition: the path must be under the canonical `local-agent-mode-sessions\`
+/// root — this command re-applies invariant §3 before any file I/O (§9).
+/// On mismatch: returns `Err`, does NOT trust the walker.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_install_into_workspace(ws_path: String) -> Result<String, String> {
+    use cowork_installer::{install_tandem_plugin_into_workspace, resolve_tandem_url};
+    use cowork_workspace_scan::find_cowork_workspaces;
+
+    let path = std::path::PathBuf::from(&ws_path);
+
+    // Re-apply invariant §9 path check: the path must match one of the
+    // workspaces returned by the guarded walker. The walker is the single
+    // source of safe paths; if the user-supplied path isn't in that list,
+    // reject — do NOT install.
+    let valid_roots = find_cowork_workspaces();
+    let canonical_supplied = std::fs::canonicalize(&path)
+        .map_err(|e| format!("invalid workspace path: {e}"))?;
+    let path_valid = valid_roots
+        .iter()
+        .any(|valid| valid == &canonical_supplied);
+    if !path_valid {
+        log::warn!(
+            "[cowork] cowork_install_into_workspace: path {} is not in the canonical workspace list — rejected",
+            ws_path
+        );
+        return Err("Path is not within the canonical Cowork workspace root".to_string());
+    }
+
+    let token = token_store::get_or_create_token()?;
+    let meta = cowork_meta::load().map_err(|e| e.to_string())?;
+    let tandem_url = resolve_tandem_url(&meta);
+
+    let report = install_tandem_plugin_into_workspace(&canonical_supplied, &token, &tandem_url)
+        .map_err(|e| e.to_string())?;
+
+    Ok(serde_json::to_string(&report).unwrap_or_default())
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_install_into_workspace(_ws_path: String) -> Result<String, String> {
+    Err("Cowork integration is Windows-only in v0.8.0".into())
+}
+
+/// Uninstall the Tandem plugin from a specific workspace path.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_uninstall_from_workspace(ws_path: String) -> Result<String, String> {
+    use cowork_workspace_scan::find_cowork_workspaces;
+
+    let path = std::path::PathBuf::from(&ws_path);
+    let valid_roots = find_cowork_workspaces();
+    let canonical_supplied = std::fs::canonicalize(&path)
+        .map_err(|e| format!("invalid workspace path: {e}"))?;
+    let path_valid = valid_roots
+        .iter()
+        .any(|valid| valid == &canonical_supplied);
+    if !path_valid {
+        log::warn!(
+            "[cowork] cowork_uninstall_from_workspace: path {} is not in the canonical workspace list — rejected",
+            ws_path
+        );
+        return Err("Path is not within the canonical Cowork workspace root".to_string());
+    }
+
+    let report = cowork_installer::uninstall_tandem_plugin_from_workspace(&canonical_supplied)
+        .map_err(|e| e.to_string())?;
+    Ok(serde_json::to_string(&report).unwrap_or_default())
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_uninstall_from_workspace(_ws_path: String) -> Result<String, String> {
+    Err("Cowork integration is Windows-only in v0.8.0".into())
+}
+
+/// Set or unset the LAN-IP override for TANDEM_URL.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_set_lan_ip_override(enabled: bool) -> Result<String, String> {
+    use cowork_installer::{install_tandem_plugin_into_workspace, resolve_tandem_url};
+    use cowork_workspace_scan::find_cowork_workspaces;
+
+    cowork_meta::update(|m| { m.use_lan_ip_override = enabled; })
+        .map_err(|e| e.to_string())?;
+
+    // If Cowork is enabled, re-walk to apply the new URL.
+    let meta = cowork_meta::load().map_err(|e| e.to_string())?;
+    if meta.enabled {
+        let token = token_store::get_or_create_token()?;
+        let tandem_url = resolve_tandem_url(&meta);
+        for ws in find_cowork_workspaces() {
+            if let Err(e) = install_tandem_plugin_into_workspace(&ws, &token, &tandem_url) {
+                log::warn!("[cowork] set_lan_ip_override re-walk error: {e}");
+            }
+        }
+    }
+
+    Ok(format!("LAN IP override {}", if enabled { "enabled" } else { "disabled" }))
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_set_lan_ip_override(_enabled: bool) -> Result<String, String> {
+    Err("Cowork integration is Windows-only in v0.8.0".into())
+}
+
+/// Clear the UAC-declined flag and retry the enable flow.
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn cowork_retry_admin_elevation() -> Result<String, String> {
+    cowork_meta::update(|m| {
+        m.uac_declined_last_attempt = false;
+        m.uac_declined_at = None;
+    })
+    .map_err(|e| e.to_string())?;
+    cowork_toggle_integration(true)
+}
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn cowork_retry_admin_elevation() -> Result<String, String> {
+    Err("Cowork integration is Windows-only in v0.8.0".into())
+}
+
+/// Minimal ISO-8601 (UTC) timestamp without pulling in chrono.
+///
+/// Uses the proleptic Gregorian calendar starting from the Unix epoch
+/// (1970-01-01T00:00:00Z). Handles leap years; timezone is always UTC.
+#[cfg(target_os = "windows")]
+fn iso_now() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let total_secs = now.as_secs();
+
+    // Compute time of day first.
+    let secs = (total_secs % 60) as u32;
+    let mins = ((total_secs / 60) % 60) as u32;
+    let hours = ((total_secs / 3600) % 24) as u32;
+
+    // Days since Unix epoch.
+    let mut days = (total_secs / 86_400) as i64;
+
+    // Walk forward from 1970 accounting for leap years.
+    let mut year: i64 = 1970;
+    loop {
+        let days_in_year = if is_leap(year) { 366 } else { 365 };
+        if days < days_in_year {
+            break;
+        }
+        days -= days_in_year;
+        year += 1;
+    }
+
+    // Now walk through months of the current year.
+    let months_normal = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let months_leap = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let months = if is_leap(year) { &months_leap } else { &months_normal };
+    let mut month: usize = 0;
+    for (i, &dim) in months.iter().enumerate() {
+        if days < dim {
+            month = i;
+            break;
+        }
+        days -= dim;
+    }
+    let day = days + 1; // 1-indexed.
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year,
+        month + 1,
+        day,
+        hours,
+        mins,
+        secs
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn is_leap(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
 }
 
 /// Show a non-blocking dialog informing the user that Claude is not installed.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -749,14 +749,22 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
             if let firewall::FirewallError::AdminDeclined = e {
                 log::warn!("[cowork] UAC declined — writing deny rule and updating meta; no plugin entries written");
                 if let Err(deny_err) = firewall::add_cowork_deny_rule(&cidr) {
-                    log::warn!("[cowork] failed to write deny rule: {deny_err}");
+                    // Deny rule failed to write — port 3479 has no rule at all.
+                    // Return a distinct error so the UI can show a recovery prompt.
+                    return Err(format!(
+                        "UAC declined and deny-rule could not be written: {deny_err}. \
+                         Port 3479 may be unprotected. Please add a deny rule manually \
+                         in Windows Defender Firewall."
+                    ));
                 }
-                let _ = cowork_meta::update(|m| {
+                if let Err(meta_err) = cowork_meta::update(|m| {
                     m.uac_declined_last_attempt = true;
                     m.uac_declined_at = Some(iso_now());
                     m.vethernet_cidr_detected = Some(cidr.clone());
                     m.enabled = false;
-                });
+                }) {
+                    log::warn!("[cowork] failed to persist UAC-declined meta: {meta_err}");
+                }
                 return Err(e.to_string());
             }
             return Err(e.to_string());
@@ -792,13 +800,51 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
             log::warn!("[cowork] {} install error(s): {:?}", errors.len(), errors);
         }
 
-        let _ = cowork_meta::update(|m| {
+        // Count workspaces where installed_plugins was written successfully.
+        // A workspace is "successful" if its installed_plugins status is Ok or
+        // AlreadyPresent — anything else (Locked, SchemaDrift, InsecureAcl, Failed)
+        // counts as a failure.
+        if !workspaces.is_empty() {
+            let success_count = reports.iter().filter(|r| {
+                match r {
+                    Ok(report) => matches!(
+                        report.installed_plugins,
+                        cowork_installer::WriteStatus::Ok | cowork_installer::WriteStatus::AlreadyPresent
+                    ),
+                    Err(_) => false,
+                }
+            }).count();
+
+            if success_count == 0 {
+                let failure_summary: Vec<String> = reports.iter().map(|r| match r {
+                    Ok(report) => format!("{}/{}: {:?}", report.workspace_id, report.vm_id, report.installed_plugins),
+                    Err(e) => e.to_string(),
+                }).collect();
+                return Err(format!(
+                    "Cowork enable failed: all {} workspace(s) failed to install. Failures: {}",
+                    workspaces.len(),
+                    failure_summary.join("; ")
+                ));
+            }
+
+            if success_count < workspaces.len() {
+                log::warn!(
+                    "[cowork] partial install: {}/{} workspace(s) succeeded",
+                    success_count,
+                    workspaces.len()
+                );
+            }
+        }
+
+        if let Err(e) = cowork_meta::update(|m| {
             m.enabled = true;
             m.vethernet_cidr_detected = Some(cidr.clone());
             m.workspaces_last_scanned_at = Some(iso_now());
             m.uac_declined_last_attempt = false;
             m.uac_declined_at = None;
-        });
+        }) {
+            log::warn!("[cowork] failed to persist meta after enable: {e}");
+        }
 
         Ok(format!("Cowork enabled: {workspace_count} workspace(s) configured"))
     } else {
@@ -812,7 +858,9 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         if let Err(e) = firewall::remove_cowork_rules() {
             log::warn!("[cowork] remove firewall rules error: {e}");
         }
-        let _ = cowork_meta::update(|m| { m.enabled = false; });
+        if let Err(e) = cowork_meta::update(|m| { m.enabled = false; }) {
+            log::warn!("[cowork] failed to persist meta after disable: {e}");
+        }
         Ok("Cowork disabled".to_string())
     }
 }
@@ -846,9 +894,11 @@ fn cowork_rescan() -> Result<String, String> {
         }
     }
 
-    let _ = cowork_meta::update(|m| {
+    if let Err(e) = cowork_meta::update(|m| {
         m.workspaces_last_scanned_at = Some(iso_now());
-    });
+    }) {
+        log::warn!("[cowork] rescan: failed to persist meta: {e}");
+    }
 
     Ok(format!("Rescan complete: {count} workspace(s)"))
 }
@@ -865,8 +915,54 @@ fn cowork_get_status() -> Result<serde_json::Value, String> {
     use cowork_workspace_scan::find_cowork_workspaces;
 
     let meta = cowork_meta::load().map_err(|e| e.to_string())?;
-    let workspaces = find_cowork_workspaces();
-    let cowork_detected = !workspaces.is_empty();
+    let workspace_paths = find_cowork_workspaces();
+    let cowork_detected = !workspace_paths.is_empty();
+
+    // Build a workspace status array compatible with the TypeScript WorkspaceStatus[]
+    // type declared in PR f.  This is a read-only status check — no writes, no ACL
+    // checks, no firewall operations.
+    let workspaces: Vec<serde_json::Value> = workspace_paths
+        .iter()
+        .map(|ws_path| {
+            // Extract workspace_id (grandparent leaf) and vm_id (leaf).
+            let vm_id = ws_path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let workspace_id = ws_path
+                .parent()
+                .and_then(|p| p.file_name())
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+
+            // Read-only check: does installed_plugins.json contain a tandem entry?
+            let plugins_file = ws_path.join("cowork_plugins").join("installed_plugins.json");
+            let installed_status = if plugins_file.exists() {
+                match std::fs::read_to_string(&plugins_file)
+                    .ok()
+                    .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+                {
+                    Some(json) if json.get("mcpServers")
+                        .and_then(|s| s.get("tandem"))
+                        .is_some() =>
+                    {
+                        "ok"
+                    }
+                    _ => "notInstalled",
+                }
+            } else {
+                "notInstalled"
+            };
+
+            serde_json::json!({
+                "workspaceId": workspace_id,
+                "vmId": vm_id,
+                "installedPlugins": installed_status,
+                "knownMarketplaces": installed_status,
+                "coworkSettings": installed_status,
+            })
+        })
+        .collect();
 
     Ok(serde_json::json!({
         "enabled": meta.enabled,
@@ -876,7 +972,7 @@ fn cowork_get_status() -> Result<serde_json::Value, String> {
         "workspacesLastScannedAt": meta.workspaces_last_scanned_at,
         "uacDeclined": meta.uac_declined_last_attempt,
         "uacDeclinedAt": meta.uac_declined_at,
-        "workspaceCount": workspaces.len(),
+        "workspaces": workspaces,
         "coworkDetected": cowork_detected,
         "osSupported": true,
     }))
@@ -884,7 +980,17 @@ fn cowork_get_status() -> Result<serde_json::Value, String> {
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
 fn cowork_get_status() -> Result<serde_json::Value, String> {
-    Ok(serde_json::json!({ "osSupported": false, "enabled": false, "coworkDetected": false }))
+    Ok(serde_json::json!({
+        "osSupported": false,
+        "enabled": false,
+        "coworkDetected": false,
+        "workspaces": [],
+        "vethernetCidr": null,
+        "lanIpFallback": null,
+        "useLanIpOverride": false,
+        "uacDeclined": false,
+        "uacDeclinedAt": null,
+    }))
 }
 
 /// Read the Cowork metadata file.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -772,7 +772,7 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         }
 
         // Resolve TANDEM_URL (host.docker.internal by default; LAN-IP if override set).
-        let tandem_url = cowork_installer::resolve_tandem_url(&cowork_meta::load().unwrap_or_default());
+        let tandem_url = cowork_installer::resolve_tandem_url(&cowork_meta::load().map_err(|e| e.to_string())?);
 
         // Orphan reconciliation (invariant §12).
         let workspaces = find_cowork_workspaces();
@@ -851,17 +851,68 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
     } else {
         // Disable: uninstall from all workspaces and remove firewall rules.
         let workspaces = find_cowork_workspaces();
-        for ws in &workspaces {
-            if let Err(e) = uninstall_tandem_plugin_from_workspace(ws) {
-                log::warn!("[cowork] uninstall error for {}: {e}", ws.display());
+
+        let reports: Vec<_> = workspaces
+            .iter()
+            .map(|ws| uninstall_tandem_plugin_from_workspace(ws))
+            .collect();
+
+        let errors: Vec<_> = reports.iter().filter_map(|r| r.as_ref().err()).collect();
+        if !errors.is_empty() {
+            log::warn!("[cowork] disable: {} uninstall error(s): {:?}", errors.len(), errors);
+        }
+
+        let workspace_all_failed = if !workspaces.is_empty() {
+            let success_count = reports.iter().filter(|r| {
+                match r {
+                    Ok(report) => matches!(
+                        report.installed_plugins,
+                        cowork_installer::WriteStatus::Ok | cowork_installer::WriteStatus::AlreadyPresent
+                    ),
+                    Err(_) => false,
+                }
+            }).count();
+
+            if success_count > 0 && success_count < workspaces.len() {
+                log::warn!(
+                    "[cowork] disable partial: {}/{} workspace(s) uninstalled cleanly",
+                    success_count, workspaces.len()
+                );
             }
-        }
-        if let Err(e) = firewall::remove_cowork_rules() {
-            log::warn!("[cowork] remove firewall rules error: {e}");
-        }
+            success_count == 0
+        } else {
+            false // No workspaces = nothing to uninstall = success (firewall still needs removing).
+        };
+
+        // Firewall removal: failure is a SECURITY regression — propagate as Err.
+        let firewall_err = firewall::remove_cowork_rules().err();
+
+        // Persist meta regardless of workspace/firewall outcome so the UI reflects
+        // "user requested disable." An Err return still signals failure to the caller.
         if let Err(e) = cowork_meta::update(|m| { m.enabled = false; }) {
             log::warn!("[cowork] failed to persist meta after disable: {e}");
         }
+
+        if let Some(fe) = firewall_err {
+            return Err(format!(
+                "Cowork disable: firewall rule removal failed ({fe}). \
+                 An allow rule may still permit traffic on port 3479. \
+                 Remove 'Tandem Cowork' rules manually in Windows Defender Firewall."
+            ));
+        }
+
+        if workspace_all_failed {
+            let failure_summary: Vec<String> = reports.iter().map(|r| match r {
+                Ok(report) => format!("{}/{}: {:?}", report.workspace_id, report.vm_id, report.installed_plugins),
+                Err(e) => e.to_string(),
+            }).collect();
+            return Err(format!(
+                "Cowork disable failed: all {} workspace(s) failed to uninstall. Failures: {}",
+                workspaces.len(),
+                failure_summary.join("; ")
+            ));
+        }
+
         Ok("Cowork disabled".to_string())
     }
 }
@@ -887,11 +938,42 @@ fn cowork_rescan() -> Result<String, String> {
     let tandem_url = resolve_tandem_url(&meta);
 
     let workspaces = find_cowork_workspaces();
-    let count = workspaces.len();
 
-    for ws in &workspaces {
-        if let Err(e) = install_tandem_plugin_into_workspace(ws, &token, &tandem_url) {
-            log::warn!("[cowork] rescan install error for {}: {e}", ws.display());
+    let reports: Vec<_> = workspaces
+        .iter()
+        .map(|ws| install_tandem_plugin_into_workspace(ws, &token, &tandem_url))
+        .collect();
+
+    let errors: Vec<_> = reports.iter().filter_map(|r| r.as_ref().err()).collect();
+    if !errors.is_empty() {
+        log::warn!("[cowork] rescan: {} install error(s): {:?}", errors.len(), errors);
+    }
+
+    if !workspaces.is_empty() {
+        let success_count = reports.iter().filter(|r| {
+            match r {
+                Ok(report) => matches!(
+                    report.installed_plugins,
+                    cowork_installer::WriteStatus::Ok | cowork_installer::WriteStatus::AlreadyPresent
+                ),
+                Err(_) => false,
+            }
+        }).count();
+
+        if success_count == 0 {
+            let failure_summary: Vec<String> = reports.iter().map(|r| match r {
+                Ok(report) => format!("{}/{}: {:?}", report.workspace_id, report.vm_id, report.installed_plugins),
+                Err(e) => e.to_string(),
+            }).collect();
+            return Err(format!(
+                "Cowork rescan failed: all {} workspace(s) failed. Failures: {}",
+                workspaces.len(),
+                failure_summary.join("; ")
+            ));
+        }
+
+        if success_count < workspaces.len() {
+            log::warn!("[cowork] rescan partial: {}/{} workspace(s) succeeded", success_count, workspaces.len());
         }
     }
 
@@ -901,7 +983,7 @@ fn cowork_rescan() -> Result<String, String> {
         log::warn!("[cowork] rescan: failed to persist meta: {e}");
     }
 
-    Ok(format!("Rescan complete: {count} workspace(s)"))
+    Ok(format!("Rescan complete: {} workspace(s)", workspaces.len()))
 }
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
@@ -1056,10 +1138,24 @@ fn cowork_detect_vethernet_subnet() -> Result<String, String> {
 #[tauri::command]
 fn cowork_apply_token(token: String) -> Result<String, String> {
     let reports = cowork_installer::apply_token_to_all_workspaces(&token);
-    let success = reports
-        .iter()
-        .filter(|r| r.installed_plugins == cowork_installer::WriteStatus::Ok)
-        .count();
+    let total = reports.len();
+    let success = reports.iter().filter(|r| matches!(
+        r.installed_plugins,
+        cowork_installer::WriteStatus::Ok | cowork_installer::WriteStatus::AlreadyPresent
+    )).count();
+
+    if total > 0 && success == 0 {
+        let failure_summary: Vec<String> = reports.iter().map(|r| {
+            format!("{}/{}: {:?}", r.workspace_id, r.vm_id, r.installed_plugins)
+        }).collect();
+        return Err(format!(
+            "Cowork apply-token failed: all {total} workspace(s) failed. Failures: {}",
+            failure_summary.join("; ")
+        ));
+    }
+    if success < total {
+        log::warn!("[cowork] apply-token partial: {success}/{total} workspace(s) succeeded");
+    }
     Ok(format!("Cowork: {success} workspace(s) re-walked with new token"))
 }
 #[cfg(not(target_os = "windows"))]
@@ -1106,7 +1202,7 @@ fn cowork_install_into_workspace(ws_path: String) -> Result<String, String> {
     let report = install_tandem_plugin_into_workspace(&canonical_supplied, &token, &tandem_url)
         .map_err(|e| e.to_string())?;
 
-    Ok(serde_json::to_string(&report).unwrap_or_default())
+    Ok(serde_json::to_string(&report).map_err(|e| e.to_string())?)
 }
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
@@ -1137,7 +1233,7 @@ fn cowork_uninstall_from_workspace(ws_path: String) -> Result<String, String> {
 
     let report = cowork_installer::uninstall_tandem_plugin_from_workspace(&canonical_supplied)
         .map_err(|e| e.to_string())?;
-    Ok(serde_json::to_string(&report).unwrap_or_default())
+    Ok(serde_json::to_string(&report).map_err(|e| e.to_string())?)
 }
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
@@ -1160,9 +1256,43 @@ fn cowork_set_lan_ip_override(enabled: bool) -> Result<String, String> {
     if meta.enabled {
         let token = token_store::get_or_create_token()?;
         let tandem_url = resolve_tandem_url(&meta);
-        for ws in find_cowork_workspaces() {
-            if let Err(e) = install_tandem_plugin_into_workspace(&ws, &token, &tandem_url) {
-                log::warn!("[cowork] set_lan_ip_override re-walk error: {e}");
+        let workspaces = find_cowork_workspaces();
+
+        let reports: Vec<_> = workspaces
+            .iter()
+            .map(|ws| install_tandem_plugin_into_workspace(ws, &token, &tandem_url))
+            .collect();
+
+        let errors: Vec<_> = reports.iter().filter_map(|r| r.as_ref().err()).collect();
+        if !errors.is_empty() {
+            log::warn!("[cowork] set_lan_ip_override: {} re-walk error(s): {:?}", errors.len(), errors);
+        }
+
+        if !workspaces.is_empty() {
+            let success_count = reports.iter().filter(|r| {
+                match r {
+                    Ok(report) => matches!(
+                        report.installed_plugins,
+                        cowork_installer::WriteStatus::Ok | cowork_installer::WriteStatus::AlreadyPresent
+                    ),
+                    Err(_) => false,
+                }
+            }).count();
+
+            if success_count == 0 {
+                let failure_summary: Vec<String> = reports.iter().map(|r| match r {
+                    Ok(report) => format!("{}/{}: {:?}", report.workspace_id, report.vm_id, report.installed_plugins),
+                    Err(e) => e.to_string(),
+                }).collect();
+                return Err(format!(
+                    "LAN IP override applied to meta but re-walk failed: all {} workspace(s) failed. Failures: {}",
+                    workspaces.len(),
+                    failure_summary.join("; ")
+                ));
+            }
+
+            if success_count < workspaces.len() {
+                log::warn!("[cowork] set_lan_ip_override partial: {}/{} workspace(s) succeeded", success_count, workspaces.len());
             }
         }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,6 +48,11 @@
       "../sample/": "sample/",
       "../skills/": "skills/",
       "../CHANGELOG.md": "CHANGELOG.md"
+    },
+    "windows": {
+      "nsis": {
+        "installerHooks": "windows/installer-hook.nsi"
+      }
     }
   },
   "plugins": {

--- a/src-tauri/windows/installer-hook.nsi
+++ b/src-tauri/windows/installer-hook.nsi
@@ -1,0 +1,23 @@
+; Tandem NSIS installer hook — invoked by Tauri v2's nsis bundler.
+;
+; Per security invariant §10 (ADR reference in docs/plans/...):
+;   The uninstall scrub runs INSIDE the already-signed `tandem.exe` binary,
+;   NOT from a separate `uninstall_scrub.exe`. This prevents binary-planting
+;   attacks where an attacker drops a same-named exe on a PATH search path
+;   before uninstall triggers.
+;
+; The `--uninstall-scrub` subcommand:
+;   - Walks every Cowork workspace and removes the Tandem plugin entry.
+;   - Deletes the Tandem Cowork firewall rules (allow + deny).
+;   - Logs to %LOCALAPPDATA%\tandem\Logs\uninstall.log.
+;   - Exits 0 on clean-or-not-installed, non-zero only on unrecoverable error.
+;
+; NSIS logs but does NOT abort uninstall if the scrub returns non-zero —
+; removing Tandem itself must always succeed even if workspace scrub partially
+; fails (the user can re-scrub manually).
+
+!macro NSIS_HOOK_PREUNINSTALL
+    DetailPrint "Running Tandem Cowork uninstall scrub..."
+    ExecWait '"$INSTDIR\tandem.exe" --uninstall-scrub' $0
+    DetailPrint "Cowork scrub exited with code $0"
+!macroend

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -67,7 +67,15 @@ if (args.includes("--version") || args.includes("-v")) {
 }
 
 try {
-  if (args[0] === "setup") {
+  if (args[0] === "--uninstall-scrub") {
+    // Hidden subcommand invoked by the Tauri NSIS uninstaller hook. Walks
+    // Cowork workspaces and removes Tandem plugin entries + firewall rules.
+    // Runs inside the already-signed tandem.exe (security invariant §10 —
+    // prevents binary-planting during uninstall).
+    const { runUninstallScrub } = await import("./uninstall-scrub.js");
+    const exitCode = await runUninstallScrub();
+    process.exit(exitCode);
+  } else if (args[0] === "setup") {
     const { runSetup } = await import("./setup.js");
     await runSetup({
       force: args.includes("--force"),

--- a/src/cli/rotate-token.ts
+++ b/src/cli/rotate-token.ts
@@ -97,6 +97,15 @@ export async function rotateToken(): Promise<void> {
     );
   }
 
+  // TODO(v0.8.1): After rotation, re-walk Cowork workspaces to rewrite
+  // env.TANDEM_AUTH_TOKEN so post-rotation Cowork sessions don't 401
+  // (security invariant §6 — silent-failure H1). The Tauri IPC dynamic import
+  // approach is inert here: this CLI runs as a Node subprocess with no WebView,
+  // so `@tauri-apps/api/core`'s `invoke()` has no bridge to Rust. The fix is
+  // an HTTP bridge — add a POST /api/cowork-apply-token endpoint in the server
+  // (guarded by the auth middleware) and call it from here after the server
+  // accepts the rotation.
+
   if (serverRejected) {
     // Configs now reference the new token but the server still holds the old one.
     // Print a strong warning — do NOT print "Rotated auth token" as that implies success.

--- a/src/cli/uninstall-scrub.ts
+++ b/src/cli/uninstall-scrub.ts
@@ -1,0 +1,344 @@
+/**
+ * Tandem `--uninstall-scrub` subcommand.
+ *
+ * Invoked by the Tauri NSIS installer hook during uninstall. Walks every
+ * Cowork workspace under `%LOCALAPPDATA%\Packages\Claude_*\LocalCache\
+ * Roaming\Claude\local-agent-mode-sessions\` and removes the Tandem plugin
+ * entry from:
+ *   - `installed_plugins.json` (remove `mcpServers.tandem`)
+ *   - `known_marketplaces.json` (remove `marketplaces.tandem`)
+ *   - `cowork_settings.json` (remove `tandem@tandem` from `enabledPlugins`)
+ *
+ * Then removes the `Tandem Cowork*` Windows Firewall rules via `netsh`.
+ *
+ * **Security invariant §10 (ADR):** this runs INSIDE the already-signed
+ * `tandem.exe` binary — NOT as a separate `uninstall_scrub.exe`. That
+ * prevents binary-planting attacks during uninstall.
+ *
+ * **Failure policy:** logs every error, exits 0 on clean-or-not-installed,
+ * non-zero only on unrecoverable I/O failures. NSIS logs the exit code but
+ * does NOT block uninstall — Tandem must always uninstall even if a
+ * workspace scrub partially fails.
+ *
+ * **Token safety:** this scrub READS JSON to find Tandem entries but the
+ * removed-entry contents (including the auth token) are NEVER logged.
+ */
+
+import { execFile } from "node:child_process";
+import { promises as fsPromises } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const TANDEM_PLUGIN_ID = "tandem";
+const TANDEM_ENABLED_KEY = "tandem@tandem";
+const FIREWALL_ALLOW_RULE = "Tandem Cowork";
+const FIREWALL_DENY_RULE = "Tandem Cowork \u2014 Deny (elevation refused)";
+
+type ScrubLogger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+  close: () => Promise<void>;
+};
+
+async function openLogger(): Promise<ScrubLogger> {
+  const localAppData = process.env.LOCALAPPDATA;
+  if (!localAppData) {
+    // No log file — just use stderr.
+    const write = (level: string, msg: string): void => {
+      process.stderr.write(`[tandem uninstall-scrub ${level}] ${msg}\n`);
+    };
+    return {
+      info: (m) => write("info", m),
+      warn: (m) => write("warn", m),
+      error: (m) => write("error", m),
+      close: async () => {},
+    };
+  }
+
+  const logDir = path.join(localAppData, "tandem", "Logs");
+  await fsPromises.mkdir(logDir, { recursive: true }).catch(() => {});
+  const logPath = path.join(logDir, "uninstall.log");
+  const stream = await fsPromises.open(logPath, "a").catch(() => null);
+
+  const write = (level: string, msg: string): void => {
+    const line = `[${new Date().toISOString()}] [${level}] ${msg}\n`;
+    process.stderr.write(line);
+    if (stream) {
+      stream.write(line).catch(() => {});
+    }
+  };
+
+  return {
+    info: (m) => write("info", m),
+    warn: (m) => write("warn", m),
+    error: (m) => write("error", m),
+    close: async () => {
+      if (stream) await stream.close().catch(() => {});
+    },
+  };
+}
+
+/**
+ * Find all Cowork workspace directories.
+ *
+ * Matches `%LOCALAPPDATA%\Packages\Claude_*\LocalCache\Roaming\Claude\
+ * local-agent-mode-sessions\<ws-id>\<vm-id>\`.
+ *
+ * Returns an empty array on any error (e.g. Cowork not installed).
+ */
+async function findCoworkWorkspaces(logger: ScrubLogger): Promise<string[]> {
+  const localAppData = process.env.LOCALAPPDATA;
+  if (!localAppData) {
+    logger.info("%LOCALAPPDATA% not set — skipping workspace scan");
+    return [];
+  }
+
+  const packagesDir = path.join(localAppData, "Packages");
+  let packageEntries: string[];
+  try {
+    packageEntries = await fsPromises.readdir(packagesDir);
+  } catch (err) {
+    logger.info(`cannot read Packages dir: ${(err as Error).message}`);
+    return [];
+  }
+
+  const claudePackages = packageEntries.filter((name) => name.startsWith("Claude_"));
+  if (claudePackages.length === 0) {
+    logger.info("no Claude_* package directories found");
+    return [];
+  }
+
+  const workspaces: string[] = [];
+  for (const pkg of claudePackages) {
+    const sessionsRoot = path.join(
+      packagesDir,
+      pkg,
+      "LocalCache",
+      "Roaming",
+      "Claude",
+      "local-agent-mode-sessions",
+    );
+
+    let wsEntries: string[];
+    try {
+      wsEntries = await fsPromises.readdir(sessionsRoot);
+    } catch {
+      continue;
+    }
+
+    for (const ws of wsEntries) {
+      const wsPath = path.join(sessionsRoot, ws);
+      let vmEntries: string[];
+      try {
+        vmEntries = await fsPromises.readdir(wsPath);
+      } catch {
+        continue;
+      }
+
+      for (const vm of vmEntries) {
+        const vmPath = path.join(wsPath, vm);
+        try {
+          const stat = await fsPromises.stat(vmPath);
+          if (stat.isDirectory()) {
+            workspaces.push(vmPath);
+          }
+        } catch {
+          // Skip unreadable entries.
+        }
+      }
+    }
+  }
+
+  logger.info(`found ${workspaces.length} workspace(s)`);
+  return workspaces;
+}
+
+/**
+ * Atomically rewrite a JSON file, invoking `mutate` on the parsed object.
+ *
+ * Returns true if the mutation changed something and was written, false if
+ * the file was absent or unchanged.
+ */
+async function rewriteJson(
+  filePath: string,
+  mutate: (obj: Record<string, unknown>) => boolean,
+  logger: ScrubLogger,
+): Promise<boolean> {
+  let content: string;
+  try {
+    content = await fsPromises.readFile(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    logger.warn(`cannot read ${filePath}: ${(err as Error).message}`);
+    return false;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (err) {
+    logger.warn(`invalid JSON in ${filePath}: ${(err as Error).message}`);
+    return false;
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    logger.warn(`${filePath} is not a JSON object — skipping`);
+    return false;
+  }
+
+  const changed = mutate(parsed as Record<string, unknown>);
+  if (!changed) {
+    return false;
+  }
+
+  const dir = path.dirname(filePath);
+  const tmpName = `.tandem-scrub-tmp-${Math.random().toString(36).slice(2, 10)}`;
+  const tmpPath = path.join(dir, tmpName);
+
+  try {
+    await fsPromises.writeFile(tmpPath, JSON.stringify(parsed, null, 2), "utf8");
+    await fsPromises.rename(tmpPath, filePath);
+  } catch (err) {
+    await fsPromises.unlink(tmpPath).catch(() => {});
+    throw err;
+  }
+  return true;
+}
+
+/**
+ * Remove the Tandem entry from `installed_plugins.json`.
+ */
+function removeInstalledPlugins(obj: Record<string, unknown>): boolean {
+  let changed = false;
+  for (const key of ["mcpServers", "servers"]) {
+    const servers = obj[key];
+    if (typeof servers === "object" && servers !== null && !Array.isArray(servers)) {
+      const map = servers as Record<string, unknown>;
+      if (TANDEM_PLUGIN_ID in map) {
+        delete map[TANDEM_PLUGIN_ID];
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}
+
+/**
+ * Remove the Tandem marketplace entry from `known_marketplaces.json`.
+ */
+function removeKnownMarketplaces(obj: Record<string, unknown>): boolean {
+  const mp = obj.marketplaces;
+  if (typeof mp === "object" && mp !== null && !Array.isArray(mp)) {
+    const map = mp as Record<string, unknown>;
+    if (TANDEM_PLUGIN_ID in map) {
+      delete map[TANDEM_PLUGIN_ID];
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Remove `tandem@tandem` from `enabledPlugins` in `cowork_settings.json`.
+ */
+function removeCoworkSettings(obj: Record<string, unknown>): boolean {
+  const enabled = obj.enabledPlugins;
+  if (Array.isArray(enabled)) {
+    const before = enabled.length;
+    obj.enabledPlugins = enabled.filter((v) => v !== TANDEM_ENABLED_KEY);
+    return (obj.enabledPlugins as unknown[]).length < before;
+  }
+  if (typeof enabled === "object" && enabled !== null) {
+    const map = enabled as Record<string, unknown>;
+    if (TANDEM_ENABLED_KEY in map) {
+      delete map[TANDEM_ENABLED_KEY];
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Delete a Windows Firewall rule by name. Non-existent rules are not an error.
+ */
+async function deleteFirewallRule(name: string, logger: ScrubLogger): Promise<void> {
+  try {
+    await execFileAsync("netsh", ["advfirewall", "firewall", "delete", "rule", `name=${name}`]);
+    logger.info(`deleted firewall rule: ${name}`);
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string };
+    // netsh returns exit code 1 when no rule matches — not fatal.
+    const stdoutStr = e.stdout ?? "";
+    if (stdoutStr.includes("No rules match")) {
+      logger.info(`no firewall rule to delete: ${name}`);
+      return;
+    }
+    logger.warn(
+      `failed to delete firewall rule ${name}: ${e.message ?? String(err)} ` +
+        `(stdout: ${stdoutStr.trim().slice(0, 200)})`,
+    );
+  }
+}
+
+/**
+ * Main entry — Windows-only.
+ */
+export async function runUninstallScrub(): Promise<number> {
+  const logger = await openLogger();
+
+  logger.info("Tandem uninstall scrub starting");
+
+  if (process.platform !== "win32") {
+    logger.info(`platform ${process.platform} is not win32 — skipping Cowork scrub`);
+    await logger.close();
+    return 0;
+  }
+
+  let failures = 0;
+
+  try {
+    const workspaces = await findCoworkWorkspaces(logger);
+    for (const ws of workspaces) {
+      const pluginsDir = path.join(ws, "cowork_plugins");
+      try {
+        await rewriteJson(
+          path.join(pluginsDir, "installed_plugins.json"),
+          removeInstalledPlugins,
+          logger,
+        );
+        await rewriteJson(
+          path.join(pluginsDir, "known_marketplaces.json"),
+          removeKnownMarketplaces,
+          logger,
+        );
+        await rewriteJson(
+          path.join(pluginsDir, "cowork_settings.json"),
+          removeCoworkSettings,
+          logger,
+        );
+      } catch (err) {
+        logger.error(`scrub failed for ${ws}: ${(err as Error).message}`);
+        failures++;
+      }
+    }
+
+    await deleteFirewallRule(FIREWALL_ALLOW_RULE, logger);
+    await deleteFirewallRule(FIREWALL_DENY_RULE, logger);
+
+    logger.info(`scrub complete: ${workspaces.length} workspace(s), ${failures} failure(s)`);
+  } catch (err) {
+    logger.error(`scrub fatal error: ${(err as Error).message}`);
+    failures++;
+  }
+
+  await logger.close();
+
+  // Exit 0 on clean-or-not-installed. Non-zero only on unrecoverable failures —
+  // and even then, NSIS does NOT block uninstall; it just records the code.
+  return failures > 0 ? 1 : 0;
+}

--- a/src/cli/uninstall-scrub.ts
+++ b/src/cli/uninstall-scrub.ts
@@ -28,6 +28,7 @@ import { execFile } from "node:child_process";
 import { promises as fsPromises } from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
+import { assertSafeWorkspacePath } from "./win-path-guard.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -87,13 +88,24 @@ async function openLogger(): Promise<ScrubLogger> {
  * Matches `%LOCALAPPDATA%\Packages\Claude_*\LocalCache\Roaming\Claude\
  * local-agent-mode-sessions\<ws-id>\<vm-id>\`.
  *
+ * Each candidate vm-path is validated by the 4-step Windows path guard before
+ * being included — callers receive only safe, realpath'd paths.
+ *
  * Returns an empty array on any error (e.g. Cowork not installed).
  */
-async function findCoworkWorkspaces(logger: ScrubLogger): Promise<string[]> {
+export async function findCoworkWorkspaces(logger: ScrubLogger): Promise<string[]> {
   const localAppData = process.env.LOCALAPPDATA;
   if (!localAppData) {
     logger.info("%LOCALAPPDATA% not set — skipping workspace scan");
     return [];
+  }
+
+  // Realpath %LOCALAPPDATA% once for use by the path guard.
+  let realLad: string;
+  try {
+    realLad = await fsPromises.realpath(localAppData);
+  } catch {
+    realLad = localAppData; // best-effort fallback
   }
 
   const packagesDir = path.join(localAppData, "Packages");
@@ -125,7 +137,8 @@ async function findCoworkWorkspaces(logger: ScrubLogger): Promise<string[]> {
     let wsEntries: string[];
     try {
       wsEntries = await fsPromises.readdir(sessionsRoot);
-    } catch {
+    } catch (err) {
+      logger.warn(`cannot read sessions root ${sessionsRoot}: ${(err as Error).message}`);
       continue;
     }
 
@@ -134,7 +147,8 @@ async function findCoworkWorkspaces(logger: ScrubLogger): Promise<string[]> {
       let vmEntries: string[];
       try {
         vmEntries = await fsPromises.readdir(wsPath);
-      } catch {
+      } catch (err) {
+        logger.warn(`cannot read workspace dir ${wsPath}: ${(err as Error).message}`);
         continue;
       }
 
@@ -142,11 +156,15 @@ async function findCoworkWorkspaces(logger: ScrubLogger): Promise<string[]> {
         const vmPath = path.join(wsPath, vm);
         try {
           const stat = await fsPromises.stat(vmPath);
-          if (stat.isDirectory()) {
-            workspaces.push(vmPath);
+          if (!stat.isDirectory()) continue;
+
+          // 4-step path guard — only include validated, realpath'd paths.
+          const safePath = await assertSafeWorkspacePath(vmPath, realLad, logger);
+          if (safePath !== null) {
+            workspaces.push(safePath);
           }
-        } catch {
-          // Skip unreadable entries.
+        } catch (err) {
+          logger.warn(`cannot stat ${vmPath}: ${(err as Error).message}`);
         }
       }
     }
@@ -159,10 +177,13 @@ async function findCoworkWorkspaces(logger: ScrubLogger): Promise<string[]> {
 /**
  * Atomically rewrite a JSON file, invoking `mutate` on the parsed object.
  *
+ * Precondition: `filePath` has already been validated by the path guard.
+ * This function trusts its callers (consistent with `with_locked_json` on the Rust side).
+ *
  * Returns true if the mutation changed something and was written, false if
  * the file was absent or unchanged.
  */
-async function rewriteJson(
+export async function rewriteJson(
   filePath: string,
   mutate: (obj: Record<string, unknown>) => boolean,
   logger: ScrubLogger,
@@ -213,7 +234,7 @@ async function rewriteJson(
 /**
  * Remove the Tandem entry from `installed_plugins.json`.
  */
-function removeInstalledPlugins(obj: Record<string, unknown>): boolean {
+export function removeInstalledPlugins(obj: Record<string, unknown>): boolean {
   let changed = false;
   for (const key of ["mcpServers", "servers"]) {
     const servers = obj[key];
@@ -231,7 +252,7 @@ function removeInstalledPlugins(obj: Record<string, unknown>): boolean {
 /**
  * Remove the Tandem marketplace entry from `known_marketplaces.json`.
  */
-function removeKnownMarketplaces(obj: Record<string, unknown>): boolean {
+export function removeKnownMarketplaces(obj: Record<string, unknown>): boolean {
   const mp = obj.marketplaces;
   if (typeof mp === "object" && mp !== null && !Array.isArray(mp)) {
     const map = mp as Record<string, unknown>;
@@ -246,7 +267,7 @@ function removeKnownMarketplaces(obj: Record<string, unknown>): boolean {
 /**
  * Remove `tandem@tandem` from `enabledPlugins` in `cowork_settings.json`.
  */
-function removeCoworkSettings(obj: Record<string, unknown>): boolean {
+export function removeCoworkSettings(obj: Record<string, unknown>): boolean {
   const enabled = obj.enabledPlugins;
   if (Array.isArray(enabled)) {
     const before = enabled.length;

--- a/src/cli/win-path-guard.ts
+++ b/src/cli/win-path-guard.ts
@@ -1,0 +1,126 @@
+/**
+ * Windows workspace path guard — mirrors the Rust §3 invariant for TypeScript callers.
+ *
+ * Four steps (in order):
+ *   a. lstat each ancestor; reject any path whose chain contains a symlink.
+ *   b. fs.realpath() to canonicalize (safe: symlinks already rejected in (a)).
+ *   c. Reject UNC paths (\\server\share or \\?\UNC\...; allow \\?\C:\...).
+ *   d. Component-wise containment check under realpath'd %LOCALAPPDATA%
+ *      (case-insensitive on Windows).
+ *
+ * Extracted into its own module so it can be unit-tested via vi.mock("node:fs", ...).
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+type Logger = { warn: (msg: string) => void };
+
+/**
+ * Validate that `candidate` is a safe workspace path contained within `realLocalAppData`.
+ *
+ * @returns the realpath'd canonical path string on success, or null if rejected.
+ * Callers are responsible for supplying a realpath'd `realLocalAppData`.
+ */
+export async function assertSafeWorkspacePath(
+  candidate: string,
+  realLocalAppData: string,
+  logger?: Logger,
+): Promise<string | null> {
+  const warn = (msg: string) => logger?.warn(`[path-guard] ${msg}`);
+
+  // (a) lstat-walk: reject any component that is a symlink.
+  if (await hasSymlinkInChain(candidate, warn)) {
+    warn(`symlink/reparse point in chain: ${candidate}`);
+    return null;
+  }
+
+  // (b) Canonicalize via realpath (safe now — symlinks already rejected).
+  let real: string;
+  try {
+    real = await fs.realpath(candidate);
+  } catch (err) {
+    warn(`realpath failed for ${candidate}: ${(err as Error).message}`);
+    return null;
+  }
+
+  // (c) Reject UNC paths.
+  if (isUncPath(real)) {
+    warn(`UNC path rejected: ${real}`);
+    return null;
+  }
+
+  // (d) Component-wise containment under realLocalAppData (case-insensitive).
+  if (!isComponentWiseChild(real, realLocalAppData)) {
+    warn(`path outside %LOCALAPPDATA%: ${real}`);
+    return null;
+  }
+
+  return real;
+}
+
+/** Returns true if any ancestor (inclusive) of `p` is a symbolic link. */
+async function hasSymlinkInChain(p: string, warn: (m: string) => void): Promise<boolean> {
+  // Walk from candidate up through all ancestors.
+  let current = path.resolve(p);
+  const visited = new Set<string>();
+
+  while (true) {
+    if (visited.has(current)) break;
+    visited.add(current);
+
+    try {
+      const stat = await fs.lstat(current);
+      if (stat.isSymbolicLink()) {
+        return true;
+      }
+    } catch (err) {
+      // lstat failed — fail closed for safety.
+      warn(`lstat failed for ${current}: ${(err as Error).message}`);
+      return true;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) break; // reached root
+    current = parent;
+  }
+
+  return false;
+}
+
+/** Returns true if the path is a UNC path (\\server\share or \\?\UNC\...). */
+function isUncPath(p: string): boolean {
+  // Allow extended-length local paths (\\?\C:\...) but reject:
+  //   \\?\UNC\server\share — extended UNC
+  //   \\server\share       — classic UNC
+  if (p.startsWith("\\\\?\\UNC\\") || p.startsWith("//?/UNC/")) return true;
+  if (
+    (p.startsWith("\\\\") && !p.startsWith("\\\\?\\")) ||
+    (p.startsWith("//") && !p.startsWith("//?/"))
+  )
+    return true;
+  return false;
+}
+
+/**
+ * Returns true if `child` is strictly within `root` on a component-wise basis
+ * (case-insensitive on Windows).
+ */
+function isComponentWiseChild(child: string, root: string): boolean {
+  // Normalize separators and split on path.sep.
+  const normalize = (p: string) => p.replace(/[\\/]+/g, path.sep).replace(/[/\\]$/, "");
+
+  const rootNorm = normalize(root);
+  const childNorm = normalize(child);
+
+  const rootParts = rootNorm.split(path.sep);
+  const childParts = childNorm.split(path.sep);
+
+  if (childParts.length <= rootParts.length) return false;
+
+  for (let i = 0; i < rootParts.length; i++) {
+    // Case-insensitive on Windows.
+    if (rootParts[i].toLowerCase() !== childParts[i].toLowerCase()) return false;
+  }
+  return true;
+}

--- a/tests/cli/uninstall-scrub.test.ts
+++ b/tests/cli/uninstall-scrub.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for `uninstall-scrub` CLI module and `win-path-guard`.
+ *
+ * vi.mock calls are hoisted to file top by Vitest — factories cannot reference
+ * variables. We use module-level vi.fn() stubs that beforeEach reconfigures
+ * via .mockResolvedValue / .mockReturnValue.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Top-level stubs (referenced by vi.mock factories) ────────────────────────
+
+const _readdirSpy = vi.fn();
+const _readFileSpy = vi.fn();
+const _writeFileSpy = vi.fn().mockResolvedValue(undefined);
+const _renameSpy = vi.fn().mockResolvedValue(undefined);
+const _unlinkSpy = vi.fn().mockResolvedValue(undefined);
+const _lstatSpy = vi.fn();
+const _realpathSpy = vi.fn();
+const _statSpy = vi.fn();
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:fs");
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readdir: _readdirSpy,
+      readFile: _readFileSpy,
+      writeFile: _writeFileSpy,
+      rename: _renameSpy,
+      unlink: _unlinkSpy,
+      lstat: _lstatSpy,
+      realpath: _realpathSpy,
+      stat: _statSpy,
+    },
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeNotFoundError(): NodeJS.ErrnoException {
+  const e = Object.assign(new Error("ENOENT: no such file or directory"), {
+    code: "ENOENT",
+  }) as NodeJS.ErrnoException;
+  return e;
+}
+
+function notSymlink() {
+  return { isSymbolicLink: () => false };
+}
+
+// ── removeInstalledPlugins ────────────────────────────────────────────────────
+
+describe("removeInstalledPlugins", () => {
+  it("removes only mcpServers.tandem and leaves context7 intact", async () => {
+    const { removeInstalledPlugins } = await import("../../src/cli/uninstall-scrub.js");
+
+    const obj = {
+      mcpServers: {
+        context7: { type: "stdio" },
+        tandem: { type: "stdio" },
+      },
+    } as Record<string, unknown>;
+
+    const changed = removeInstalledPlugins(obj);
+    expect(changed).toBe(true);
+
+    const servers = obj.mcpServers as Record<string, unknown>;
+    expect(servers).toHaveProperty("context7");
+    expect(servers).not.toHaveProperty("tandem");
+  });
+
+  it("returns false when tandem entry is absent", async () => {
+    const { removeInstalledPlugins } = await import("../../src/cli/uninstall-scrub.js");
+
+    const obj = { mcpServers: { context7: { type: "stdio" } } } as Record<string, unknown>;
+    const changed = removeInstalledPlugins(obj);
+    expect(changed).toBe(false);
+  });
+});
+
+// ── removeKnownMarketplaces ───────────────────────────────────────────────────
+
+describe("removeKnownMarketplaces", () => {
+  it("removes marketplaces.tandem and leaves others intact", async () => {
+    const { removeKnownMarketplaces } = await import("../../src/cli/uninstall-scrub.js");
+
+    const obj = {
+      marketplaces: {
+        tandem: { id: "tandem" },
+        other: { id: "other" },
+      },
+    } as Record<string, unknown>;
+
+    const changed = removeKnownMarketplaces(obj);
+    expect(changed).toBe(true);
+
+    const mp = obj.marketplaces as Record<string, unknown>;
+    expect(mp).toHaveProperty("other");
+    expect(mp).not.toHaveProperty("tandem");
+  });
+});
+
+// ── removeCoworkSettings ──────────────────────────────────────────────────────
+
+describe("removeCoworkSettings", () => {
+  it("removes tandem@tandem from array form of enabledPlugins", async () => {
+    const { removeCoworkSettings } = await import("../../src/cli/uninstall-scrub.js");
+
+    const obj = {
+      enabledPlugins: ["context7@context7", "tandem@tandem"],
+    } as Record<string, unknown>;
+    const changed = removeCoworkSettings(obj);
+    expect(changed).toBe(true);
+    expect(obj.enabledPlugins).toEqual(["context7@context7"]);
+  });
+
+  it("removes tandem@tandem from object form of enabledPlugins", async () => {
+    const { removeCoworkSettings } = await import("../../src/cli/uninstall-scrub.js");
+
+    const obj = {
+      enabledPlugins: { "context7@context7": true, "tandem@tandem": true },
+    } as Record<string, unknown>;
+    const changed = removeCoworkSettings(obj);
+    expect(changed).toBe(true);
+    const ep = obj.enabledPlugins as Record<string, unknown>;
+    expect(ep).toHaveProperty("context7@context7");
+    expect(ep).not.toHaveProperty("tandem@tandem");
+  });
+});
+
+// ── rewriteJson ───────────────────────────────────────────────────────────────
+
+describe("rewriteJson", () => {
+  beforeEach(() => {
+    _readFileSpy.mockReset();
+    _writeFileSpy.mockReset().mockResolvedValue(undefined);
+    _renameSpy.mockReset().mockResolvedValue(undefined);
+    _unlinkSpy.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns false on ENOENT (file absent)", async () => {
+    _readFileSpy.mockRejectedValue(makeNotFoundError());
+
+    const { rewriteJson } = await import("../../src/cli/uninstall-scrub.js");
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), close: async () => {} };
+    const result = await rewriteJson("/fake/path.json", () => true, logger);
+    expect(result).toBe(false);
+    expect(_writeFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("writes and renames when mutate returns true", async () => {
+    const initial = JSON.stringify({ mcpServers: { tandem: {} } });
+    _readFileSpy.mockResolvedValue(initial);
+
+    const { rewriteJson } = await import("../../src/cli/uninstall-scrub.js");
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), close: async () => {} };
+    const result = await rewriteJson(
+      "/fake/installed_plugins.json",
+      (obj) => {
+        delete (obj.mcpServers as Record<string, unknown>).tandem;
+        return true;
+      },
+      logger,
+    );
+    expect(result).toBe(true);
+    expect(_writeFileSpy).toHaveBeenCalledOnce();
+    expect(_renameSpy).toHaveBeenCalledOnce();
+  });
+});
+
+// ── win-path-guard ────────────────────────────────────────────────────────────
+
+describe("assertSafeWorkspacePath", () => {
+  const FAKE_LAD = "C:\\Users\\test\\AppData\\Local";
+  const VALID_PATH = `${FAKE_LAD}\\Packages\\Claude_123\\ws\\vm`;
+
+  beforeEach(() => {
+    _lstatSpy.mockReset();
+    _realpathSpy.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts a valid path inside LOCALAPPDATA", async () => {
+    // lstat returns non-symlink for all components.
+    _lstatSpy.mockResolvedValue(notSymlink());
+    _realpathSpy.mockResolvedValue(VALID_PATH);
+
+    const { assertSafeWorkspacePath } = await import("../../src/cli/win-path-guard.js");
+    const result = await assertSafeWorkspacePath(VALID_PATH, FAKE_LAD);
+    expect(result).toBe(VALID_PATH);
+  });
+
+  it("rejects a UNC path", async () => {
+    const unc = "\\\\server\\share\\ws\\vm";
+    _lstatSpy.mockResolvedValue(notSymlink());
+    _realpathSpy.mockResolvedValue(unc);
+
+    const logger = { warn: vi.fn() };
+    const { assertSafeWorkspacePath } = await import("../../src/cli/win-path-guard.js");
+    const result = await assertSafeWorkspacePath(unc, FAKE_LAD, logger);
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("UNC"));
+  });
+
+  it("rejects a path with a symlink component", async () => {
+    // First lstat call (the candidate itself) returns isSymbolicLink=true.
+    _lstatSpy.mockResolvedValueOnce({ isSymbolicLink: () => true });
+
+    const logger = { warn: vi.fn() };
+    const { assertSafeWorkspacePath } = await import("../../src/cli/win-path-guard.js");
+    const result = await assertSafeWorkspacePath(VALID_PATH, FAKE_LAD, logger);
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("symlink/reparse point"));
+  });
+
+  it("rejects a path outside LOCALAPPDATA", async () => {
+    const outsidePath = "C:\\Users\\test\\AppData\\Roaming\\evil\\ws\\vm";
+    _lstatSpy.mockResolvedValue(notSymlink());
+    _realpathSpy.mockResolvedValue(outsidePath);
+
+    const logger = { warn: vi.fn() };
+    const { assertSafeWorkspacePath } = await import("../../src/cli/win-path-guard.js");
+    const result = await assertSafeWorkspacePath(outsidePath, FAKE_LAD, logger);
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("outside %LOCALAPPDATA%"));
+  });
+});


### PR DESCRIPTION
## Summary

- Walks `%LOCALAPPDATA%\Packages\Claude_*\...\local-agent-mode-sessions\` and writes **ADR-023 stdio entries** (`npx -y tandem-editor mcp-stdio`) into each workspace's `installed_plugins.json` + `known_marketplaces.json` + `cowork_settings.json` via atomic lock/read/merge/write/rename.
- Scopes a Windows Firewall allow rule to the detected Hyper-V vEthernet subnet (prefix ≥ /20 required; admin-elevation fail-closed per §4).
- Registers an NSIS uninstall hook (`tandem.exe --uninstall-scrub`) that removes all Tandem plugin entries on app uninstall.
- **Post-review commit** addresses all findings from 4-agent PR review (1 critical, 6 high, 4 medium — see below).

**This PR is the foundation for PR f** (Tauri Settings UI, stacked on this branch).

## Context

- **ADR-023 correction**: the authority cowork spec prescribes HTTP entries but the Phase 0 probe proved HTTP plugins surface zero `tandem_*` tools in Cowork. This PR writes stdio entries matching the proven-working `npx` pattern. See `docs/decisions.md` ADR-023.
- **OS scope**: Windows-only (`#[cfg(target_os = "windows")]`). macOS/Linux tracked in #316/#317.

## Security highlights (§§1–13)

| Invariant | Implementation |
|---|---|
| **§1 Atomic writes** | Sibling lock file (`.{file}.tandem-lock`) decouples mutual exclusion from the rename, avoiding Windows os error 33 |
| **§2 Merge-by-id** | Preserves context7 and Anthropic's own plugins; only `tandem@tandem` is written/removed |
| **§3 Path traversal** | reparse-point check (pre-canonicalize) → canonicalize → UNC reject → component-wise compare (not string prefix); mirrored in TS `win-path-guard.ts` |
| **§4 Admin fail-closed** | UAC decline → deny firewall rule written, NO plugin entries written, persistent modal (PR f) |
| **§5 Tight subnet** | vEthernet CIDR detected via `Get-NetAdapter`; prefix < /20 aborts install (no `/12` fallback) |
| **§6 Token provenance** | Token never logged; `cowork_apply_token` re-walks all workspaces after rotation |
| **§10 Signed scrub binary** | NSIS hook calls `tandem.exe --uninstall-scrub` (not a separate binary — prevents binary planting) |
| **§11 Schema drift** | `CoworkError::SchemaDriftSuspected` raised (not silent skip) when top-level JSON shape diverges |
| **§13 Firewall enum** | `FirewallError::{AdminDeclined, NetshNotFound, NetshFailure, SubnetDetectionFailed, AdapterEnumerationFailed}` — not a String |

## New Rust modules (all `#[cfg(target_os = "windows")]`)

| File | Purpose |
|---|---|
| `cowork_atomic_json.rs` | `with_locked_json<T, F>` shared helper; sibling lock; exponential backoff |
| `cowork_workspace_scan.rs` | Workspace walker + 4-step path guard; MSIX-moniker glob |
| `cowork_installer.rs` | install / uninstall / apply_token / reconcile_orphans |
| `firewall.rs` | `FirewallError` enum + `netsh`/`powershell` argv wrappers (no `cmd.exe`) |
| `cowork_meta.rs` | Sidecar `cowork-meta.json` (LAN-IP fallback, UAC decline flag) |

## Review findings addressed (post-review commit)

### Critical
- **Disable path silent-success** — `cowork_toggle_integration(false)` previously swallowed all uninstall + firewall errors and returned `Ok`. Now propagates `Err` on firewall removal failure (a security regression: allow rule persisting) and on all-workspace uninstall failure.

### High
- **`TANDEM_COWORK_ROOT_OVERRIDE` production-active** — env var was readable by production builds, bypassing both the path guard and ACL check. Now gated behind `#[cfg(any(test, feature = "cowork-test-hooks"))]`; not compiled into release binaries.
- **TS path guard missing** — `uninstall-scrub.ts` had no path guard. Extracted Rust §3 invariant into `src/cli/win-path-guard.ts` (symlink-chain → realpath → UNC → component-wise containment) and wired it into `findCoworkWorkspaces`.
- **`cowork_meta::load()` silent default** — `unwrap_or_default()` after meta load silently hid I/O errors; now propagates via `?`.
- **`reconcile_orphans` silent failures** — JSON parse errors and I/O errors were silently treated as `needs_update = false`; now logs `WARN` with path + error and makes conservative decisions.
- **Zero-success not Err** — `cowork_rescan`, `cowork_apply_token`, `cowork_set_lan_ip_override` all returned `Ok` even when every workspace failed; now return `Err` with per-workspace failure summary.
- **`check_acl` I/O → `InsecureAcl`** — non-NotFound canonicalize errors were mapped to `InsecureAcl`; now map to `CoworkError::IoError` so callers can distinguish security rejections from transient I/O failures.

### Medium
- **Reparse-point check post-canonicalize** — `canonicalize` resolves reparse points on Windows, making the subsequent check dead code. Reordered: reparse-point check now runs on the raw candidate before canonicalize.
- **Temp-file not cleaned on write failure** — `with_locked_json` left orphan `.tandem-tmp-*` files when `write_all`/`flush`/`sync_all` failed. Now cleaned up in the error path.
- **Silent vm-level `read_dir` skip** — `Err(_) => continue` on vm-level `read_dir` in both Rust scanner and TS scrubber; now logs `WARN` with path + error.
- **`serde_json::to_string` silent default** — `unwrap_or_default()` in two invoke handlers; now propagates via `?`.

## Test plan

- [x] `cargo test -p tandem-desktop --lib` — 17/17 pass (14 original + 3 new: `check_acl` outside-LAD rejection, `check_acl` I/O≠InsecureAcl, `has_reparse_point_in_chain` fail-closed)
- [x] `cargo build --lib` clean
- [x] `npm test` — 1418/1418 pass (no regressions; new `uninstall-scrub.test.ts` adds 11 tests)
- [x] `npm run typecheck` clean
- [x] `npx biome check` clean on all new/modified TS files
- [ ] Gate 1 manual: fresh install, stdio entries appear, firewall rule is exact CIDR, uninstall scrubs cleanly — **requires Cowork-enabled Windows machine**
- [ ] Gate 2 manual: disable with firewall service stopped → `Err` returned with recovery text, `meta.enabled = false` persisted
- [ ] Gate 3 manual: `TANDEM_COWORK_ROOT_OVERRIDE` set in production env → confirm plugin entries go to real `%LOCALAPPDATA%` (env var ignored)

## Known issues / follow-ups

- `cowork_get_meta` return type diverges between Windows (`CoworkMeta`) and non-Windows (`serde_json::Value`) stubs — needs unification in v0.8.1.
- `warn_if_onedrive` is a warning, not a block — acknowledged as deferred to v0.8.1 in the plan.
- Full DACL inspection (via `GetFileSecurityW`) deferred to v0.8.1 (TODO already in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
