### PR TITLE
fix(cli): detect MSIX Claude Desktop + generate stdio MCP entries

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { copyFile, mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
@@ -39,15 +39,34 @@ export interface BuildMcpEntriesOptions {
    *  When omitted (first-run before token provisioned), headers/env are omitted
    *  and backward compatibility is preserved. */
   token?: string;
+  /** Target kind controls entry shape. Claude Code uses HTTP (direct);
+   *  Claude Desktop uses stdio (npx bridge) because Cowork sessions can
+   *  only surface stdio MCP servers. */
+  targetKind?: TargetKind;
 }
 
 export function buildMcpEntries(
   channelPath: string,
   opts: BuildMcpEntriesOptions = {},
 ): McpEntries {
-  const tandemEntry: McpEntry = { type: "http", url: `${MCP_URL}/mcp` };
-  if (opts.token) {
-    tandemEntry.headers = { Authorization: `Bearer ${opts.token}` };
+  const isDesktop = opts.targetKind === "claude-desktop";
+
+  let tandemEntry: McpEntry;
+  if (isDesktop) {
+    const env: Record<string, string> = { TANDEM_URL: MCP_URL };
+    if (opts.token) {
+      env.TANDEM_AUTH_TOKEN = opts.token;
+    }
+    tandemEntry = {
+      command: "npx",
+      args: ["-y", "tandem-editor", "mcp-stdio"],
+      env,
+    };
+  } else {
+    tandemEntry = { type: "http", url: `${MCP_URL}/mcp` };
+    if (opts.token) {
+      tandemEntry.headers = { Authorization: `Bearer ${opts.token}` };
+    }
   }
   const entries: McpEntries = { tandem: tandemEntry };
 
@@ -65,13 +84,17 @@ export function buildMcpEntries(
   return entries;
 }
 
+export type TargetKind = "claude-code" | "claude-desktop";
+
 export interface DetectedTarget {
   label: string;
   configPath: string;
+  kind: TargetKind;
 }
 
-interface DetectOptions {
+export interface DetectOptions {
   homeOverride?: string;
+  localAppDataOverride?: string;
   force?: boolean;
 }
 
@@ -86,7 +109,7 @@ export function detectTargets(opts: DetectOptions = {}): DetectedTarget[] {
   const claudeCodeConfig = join(home, ".claude.json");
   const claudeCodeDir = join(home, ".claude");
   if (opts.force || existsSync(claudeCodeConfig) || existsSync(claudeCodeDir)) {
-    targets.push({ label: "Claude Code", configPath: claudeCodeConfig });
+    targets.push({ label: "Claude Code", configPath: claudeCodeConfig, kind: "claude-code" });
   }
 
   // Claude Desktop — platform-specific.
@@ -109,7 +132,43 @@ export function detectTargets(opts: DetectOptions = {}): DetectedTarget[] {
   }
 
   if (desktopConfig && (opts.force || existsSync(desktopConfig))) {
-    targets.push({ label: "Claude Desktop", configPath: desktopConfig });
+    targets.push({ label: "Claude Desktop", configPath: desktopConfig, kind: "claude-desktop" });
+  }
+
+  // Claude Desktop (MSIX) — Windows only.
+  // MSIX-packaged installs (Microsoft Store) redirect %APPDATA% to a per-package
+  // LocalCache dir. The config lives under %LOCALAPPDATA%\Packages\Claude_*\
+  // LocalCache\Roaming\Claude\. Multiple package families may exist.
+  if (process.platform === "win32") {
+    const localAppData =
+      opts.localAppDataOverride ?? process.env.LOCALAPPDATA ?? join(home, "AppData", "Local");
+    const packagesDir = join(localAppData, "Packages");
+    try {
+      const entries = readdirSync(packagesDir);
+      for (const pkg of entries.filter((n) => n.startsWith("Claude_"))) {
+        const msixConfig = join(
+          packagesDir,
+          pkg,
+          "LocalCache",
+          "Roaming",
+          "Claude",
+          "claude_desktop_config.json",
+        );
+        if (opts.force || existsSync(msixConfig)) {
+          const suffix =
+            entries.filter((n) => n.startsWith("Claude_")).length > 1
+              ? ` (${pkg.slice(0, 12)}…)`
+              : "";
+          targets.push({
+            label: `Claude Desktop MSIX${suffix}`,
+            configPath: msixConfig,
+            kind: "claude-desktop",
+          });
+        }
+      }
+    } catch {
+      // %LOCALAPPDATA%\Packages doesn't exist or isn't readable — not an MSIX install
+    }
   }
 
   return targets;
@@ -216,14 +275,15 @@ export async function applyConfigWithToken(
   opts: { force?: boolean; withChannelShim?: boolean } = {},
 ): Promise<{ updated: number; errors: string[] }> {
   const targets = detectTargets({ force: opts.force });
-  const entries = buildMcpEntries(CHANNEL_DIST, {
-    withChannelShim: opts.withChannelShim,
-    token: token ?? undefined,
-  });
 
   let updated = 0;
   const errors: string[] = [];
   for (const t of targets) {
+    const entries = buildMcpEntries(CHANNEL_DIST, {
+      withChannelShim: opts.withChannelShim,
+      token: token ?? undefined,
+      targetKind: t.kind,
+    });
     try {
       await applyConfig(t.configPath, entries);
       updated++;
@@ -266,10 +326,13 @@ export async function runSetup(
   }
 
   console.error("\nWriting MCP configuration...");
-  const entries = buildMcpEntries(CHANNEL_DIST, { withChannelShim: opts.withChannelShim });
 
   let failures = 0;
   for (const t of targets) {
+    const entries = buildMcpEntries(CHANNEL_DIST, {
+      withChannelShim: opts.withChannelShim,
+      targetKind: t.kind,
+    });
     try {
       await applyConfig(t.configPath, entries);
       console.error(`  \x1b[32m✓\x1b[0m ${t.label}`);

--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -135,13 +135,17 @@ export async function runSetupHandler(
   }
 
   const targets = detectTargets({ homeOverride });
-  // Tauri setup always registers the channel shim — the sidecar IS the channel.
-  const entries = buildMcpEntries(channelPath, { withChannelShim: true, nodeBinary, token });
 
   const configured: string[] = [];
   const errors: string[] = [];
 
   for (const target of targets) {
+    const entries = buildMcpEntries(channelPath, {
+      withChannelShim: true,
+      nodeBinary,
+      token,
+      targetKind: target.kind,
+    });
     try {
       await applyConfig(target.configPath, entries);
       configured.push(target.label);

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -75,6 +75,36 @@ describe("buildMcpEntries", () => {
     expect(entries["tandem-channel"]?.env?.TANDEM_AUTH_TOKEN).toBeUndefined();
     expect(entries["tandem-channel"]?.env?.TANDEM_URL).toBe(`http://localhost:${DEFAULT_MCP_PORT}`);
   });
+
+  it("generates stdio entry for claude-desktop targets", () => {
+    const entries = buildMcpEntries("/abs/path/to/dist/channel/index.js", {
+      targetKind: "claude-desktop",
+    });
+    expect(entries.tandem.command).toBe("npx");
+    expect(entries.tandem.args).toEqual(["-y", "tandem-editor", "mcp-stdio"]);
+    expect(entries.tandem.env?.TANDEM_URL).toBe(`http://localhost:${DEFAULT_MCP_PORT}`);
+    expect(entries.tandem.type).toBeUndefined();
+    expect(entries.tandem.url).toBeUndefined();
+  });
+
+  it("includes token in stdio entry env for claude-desktop targets", () => {
+    const token = "abcdefghijklmnopqrstuvwxyz012345";
+    const entries = buildMcpEntries("/abs/path/to/dist/channel/index.js", {
+      targetKind: "claude-desktop",
+      token,
+    });
+    expect(entries.tandem.env?.TANDEM_AUTH_TOKEN).toBe(token);
+    expect(entries.tandem.headers).toBeUndefined();
+  });
+
+  it("generates HTTP entry for claude-code targets (default)", () => {
+    const entries = buildMcpEntries("/abs/path/to/dist/channel/index.js", {
+      targetKind: "claude-code",
+    });
+    expect(entries.tandem.type).toBe("http");
+    expect(entries.tandem.url).toBe(`http://localhost:${DEFAULT_MCP_PORT}/mcp`);
+    expect(entries.tandem.command).toBeUndefined();
+  });
 });
 
 describe("validateChannelShimPrereq", () => {
@@ -229,6 +259,103 @@ describe("detectTargets", () => {
   it("detects Claude Code with --force even when ~/.claude is absent", async () => {
     const targets = detectTargets({ homeOverride: tmpDir, force: true });
     expect(targets.some((t) => t.label === "Claude Code")).toBe(true);
+  });
+
+  it("sets kind to claude-code for Claude Code targets", () => {
+    writeFileSync(join(tmpDir, ".claude.json"), "{}");
+    const targets = detectTargets({ homeOverride: tmpDir });
+    const cc = targets.find((t) => t.label === "Claude Code");
+    expect(cc?.kind).toBe("claude-code");
+  });
+});
+
+describe.skipIf(process.platform !== "win32")("detectTargets — MSIX", () => {
+  let tmpDir: string;
+  let localAppData: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "tandem-msix-test-"));
+    localAppData = join(tmpDir, "LocalAppData");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects MSIX config when Claude_* package dir has config file", () => {
+    const msixConfigDir = join(
+      localAppData,
+      "Packages",
+      "Claude_abc123",
+      "LocalCache",
+      "Roaming",
+      "Claude",
+    );
+    mkdirSync(msixConfigDir, { recursive: true });
+    writeFileSync(join(msixConfigDir, "claude_desktop_config.json"), "{}");
+
+    const targets = detectTargets({
+      homeOverride: tmpDir,
+      localAppDataOverride: localAppData,
+    });
+    const msix = targets.find((t) => t.label.includes("MSIX"));
+    expect(msix).toBeDefined();
+    expect(msix!.kind).toBe("claude-desktop");
+    expect(msix!.configPath).toContain("Claude_abc123");
+  });
+
+  it("skips MSIX when no Claude_* package dirs exist", () => {
+    mkdirSync(join(localAppData, "Packages", "SomeOtherApp_xyz"), { recursive: true });
+
+    const targets = detectTargets({
+      homeOverride: tmpDir,
+      localAppDataOverride: localAppData,
+    });
+    expect(targets.some((t) => t.label.includes("MSIX"))).toBe(false);
+  });
+
+  it("skips MSIX when Packages dir does not exist", () => {
+    const targets = detectTargets({
+      homeOverride: tmpDir,
+      localAppDataOverride: localAppData,
+    });
+    expect(targets.some((t) => t.label.includes("MSIX"))).toBe(false);
+  });
+
+  it("detects multiple MSIX installs and adds suffix", () => {
+    for (const pkg of ["Claude_aaa111", "Claude_bbb222"]) {
+      const dir = join(localAppData, "Packages", pkg, "LocalCache", "Roaming", "Claude");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "claude_desktop_config.json"), "{}");
+    }
+
+    const targets = detectTargets({
+      homeOverride: tmpDir,
+      localAppDataOverride: localAppData,
+    });
+    const msixTargets = targets.filter((t) => t.label.includes("MSIX"));
+    expect(msixTargets.length).toBe(2);
+    expect(msixTargets.every((t) => t.label.includes("…"))).toBe(true);
+  });
+
+  it("detects MSIX with --force even when config file is absent", () => {
+    const msixDir = join(
+      localAppData,
+      "Packages",
+      "Claude_abc123",
+      "LocalCache",
+      "Roaming",
+      "Claude",
+    );
+    mkdirSync(msixDir, { recursive: true });
+
+    const targets = detectTargets({
+      homeOverride: tmpDir,
+      localAppDataOverride: localAppData,
+      force: true,
+    });
+    const msix = targets.find((t) => t.label.includes("MSIX"));
+    expect(msix).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- **MSIX detection**: `tandem setup` now scans `%LOCALAPPDATA%\Packages\Claude_*\` for MSIX-packaged Claude Desktop installs (Microsoft Store). Previously only detected the classic `%APPDATA%\Claude\` path.
- **Stdio entries for Desktop**: All Claude Desktop targets (classic, MSIX, macOS, Linux) now get stdio MCP entries (`npx tandem-editor mcp-stdio`) instead of HTTP entries. Claude Desktop — especially Cowork sessions — can only bridge stdio MCP servers into sandboxed environments; HTTP entries were silently ignored.
- **Per-target entry generation**: `buildMcpEntries()` accepts a `targetKind` parameter. Claude Code still gets HTTP entries (direct connection). The Tauri setup endpoint, `runSetup()`, and `applyConfigWithToken()` all generate entries per-target.

### Why

Claude Desktop's Cowork feature runs in a Hyper-V VM. Only stdio MCP servers declared in the config are spawned on the host and proxied into the VM. HTTP MCP entries are routed through Anthropic's cloud infrastructure, which can't reach `localhost`. This was the root cause of tandem_* tools not appearing in Cowork sessions.

The MSIX path issue compounded this — even if entries were correct, `tandem setup` was writing to a config file that the MSIX-packaged Claude Desktop doesn't read.

## Test plan

- [x] All 64 setup-related tests pass (7 new)
- [x] MSIX detection tests gated with `describe.skipIf(process.platform !== "win32")`
- [x] Zero type errors
- [x] Pre-commit hooks pass (eslint + biome)
- [ ] Manual: run `tandem setup` on Windows with MSIX Claude Desktop installed, verify config written to MSIX path with stdio entry
- [ ] Manual: run `tandem setup` on macOS, verify Claude Desktop config gets stdio entry
- [ ] Manual: verify Cowork session can access tandem_* tools after setup + publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)