### PR TITLE
fix(tauri): stop writing tandem-channel MCP entry + fix updater file lock

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -453,22 +453,43 @@ async fn wait_for_port_release(client: &reqwest::Client, deadline_secs: u64) -> 
 }
 
 /// Resolve the sidecar executable path (alongside the main binary).
-fn sidecar_exe_path() -> Option<std::path::PathBuf> {
-    let exe_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
+fn sidecar_exe_path() -> Result<std::path::PathBuf, String> {
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("current_exe failed: {e}"))?;
+    let exe_dir = exe
+        .parent()
+        .ok_or_else(|| "exe path has no parent dir".to_string())?
+        .to_path_buf();
     let name = if cfg!(target_os = "windows") {
         format!("node-sidecar-{}.exe", env!("TARGET_TRIPLE"))
     } else {
         format!("node-sidecar-{}", env!("TARGET_TRIPLE"))
     };
-    Some(exe_dir.join(name))
+    Ok(exe_dir.join(name))
 }
 
 /// Poll until the sidecar exe file is writable (OS released the handle).
 #[cfg(target_os = "windows")]
 async fn wait_for_sidecar_unlock(deadline_secs: u64) -> bool {
     let sidecar_path = match sidecar_exe_path() {
-        Some(p) if p.exists() => p,
-        _ => return true,
+        Ok(p) if p.exists() => p,
+        Ok(p) => {
+            // Missing in release = packaging bug; in dev = normal (no bundled sidecar).
+            if cfg!(debug_assertions) {
+                log::debug!("Sidecar exe not on disk at {} — skipping unlock wait (dev mode)", p.display());
+            } else {
+                log::warn!("Sidecar exe not on disk at {} — skipping unlock wait (packaging bug?)", p.display());
+            }
+            return true;
+        }
+        Err(e) => {
+            if cfg!(debug_assertions) {
+                log::debug!("Could not resolve sidecar exe path: {e} — skipping unlock wait");
+            } else {
+                log::warn!("Could not resolve sidecar exe path: {e} — skipping unlock wait");
+            }
+            return true;
+        }
     };
     let deadline = tokio::time::Instant::now() + Duration::from_secs(deadline_secs);
     while tokio::time::Instant::now() < deadline {
@@ -575,7 +596,7 @@ fn resolve_setup_paths(handle: &tauri::AppHandle) -> Result<(String, String), St
         let channel_path = resource_dir.join("dist/channel/index.js");
 
         let node_binary = sidecar_exe_path()
-            .ok_or("Failed to resolve sidecar exe path")?;
+            .map_err(|e| format!("Failed to resolve sidecar exe path: {e}"))?;
 
         Ok((
             strip_win_prefix(&node_binary),
@@ -759,6 +780,12 @@ async fn check_for_update(app: &tauri::AppHandle, manual: bool) {
     // Wait for port release and (on Windows) file-lock release concurrently.
     // Port-down alone isn't sufficient on Windows: TerminateProcess returns
     // before the OS releases the exe file handle.
+    //
+    // Collect human-readable warnings so we can thread them into the failure
+    // dialog if download_and_install later fails. Declared outside the cfg
+    // block so the non-Windows branch contributes too.
+    let mut pre_install_warnings: Vec<String> = Vec::new();
+
     #[cfg(target_os = "windows")]
     {
         let (port_ok, file_ok) = tokio::join!(
@@ -766,15 +793,21 @@ async fn check_for_update(app: &tauri::AppHandle, manual: bool) {
             wait_for_sidecar_unlock(5),
         );
         if !port_ok {
-            log::warn!("Sidecar still responding after 5s kill deadline -- proceeding with install anyway");
+            let msg = "Sidecar still responding after 5s kill deadline -- proceeding with install anyway";
+            log::warn!("{msg}");
+            pre_install_warnings.push(msg.to_string());
         }
         if !file_ok {
-            log::warn!("Sidecar exe still locked after 5s -- installer may prompt for retry");
+            let msg = "Sidecar exe still locked after 5s -- installer may prompt for retry";
+            log::warn!("{msg}");
+            pre_install_warnings.push(msg.to_string());
         }
     }
     #[cfg(not(target_os = "windows"))]
     if !wait_for_port_release(&client, 5).await {
-        log::warn!("Sidecar still responding after 5s kill deadline -- proceeding with install anyway");
+        let msg = "Sidecar still responding after 5s kill deadline -- proceeding with install anyway";
+        log::warn!("{msg}");
+        pre_install_warnings.push(msg.to_string());
     }
 
     match update.download_and_install(
@@ -791,7 +824,15 @@ async fn check_for_update(app: &tauri::AppHandle, manual: bool) {
         }
         Err(e) => {
             log::error!("Update install failed: {e}");
-            show_update_error_dialog(app, &e.to_string());
+            let dialog_msg = if pre_install_warnings.is_empty() {
+                e.to_string()
+            } else {
+                format!(
+                    "{e}\n\nPre-install warnings:\n  - {}",
+                    pre_install_warnings.join("\n  - ")
+                )
+            };
+            show_update_error_dialog(app, &dialog_msg);
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -452,6 +452,35 @@ async fn wait_for_port_release(client: &reqwest::Client, deadline_secs: u64) -> 
     false
 }
 
+/// Resolve the sidecar executable path (alongside the main binary).
+fn sidecar_exe_path() -> Option<std::path::PathBuf> {
+    let exe_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
+    let name = if cfg!(target_os = "windows") {
+        format!("node-sidecar-{}.exe", env!("TARGET_TRIPLE"))
+    } else {
+        format!("node-sidecar-{}", env!("TARGET_TRIPLE"))
+    };
+    Some(exe_dir.join(name))
+}
+
+/// Poll until the sidecar exe file is writable (OS released the handle).
+#[cfg(target_os = "windows")]
+async fn wait_for_sidecar_unlock(deadline_secs: u64) -> bool {
+    let sidecar_path = match sidecar_exe_path() {
+        Some(p) if p.exists() => p,
+        _ => return true,
+    };
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(deadline_secs);
+    while tokio::time::Instant::now() < deadline {
+        if std::fs::OpenOptions::new().write(true).open(&sidecar_path).is_ok() {
+            log::info!("Sidecar exe file lock released");
+            return true;
+        }
+        tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
+    }
+    false
+}
+
 const CLAUDE_DOWNLOAD_URL: &str = "https://claude.ai/download";
 
 /// POST to /api/setup with resolved paths. Best-effort — failures are logged, not fatal.
@@ -545,19 +574,8 @@ fn resolve_setup_paths(handle: &tauri::AppHandle) -> Result<(String, String), St
             .map_err(|e| format!("Failed to resolve resource dir: {e}"))?;
         let channel_path = resource_dir.join("dist/channel/index.js");
 
-        // Sidecar binary lives alongside the main executable with target triple suffix
-        let exe_dir = std::env::current_exe()
-            .map_err(|e| format!("Failed to get current exe: {e}"))?
-            .parent()
-            .ok_or("Failed to get exe parent dir")?
-            .to_path_buf();
-
-        let sidecar_name = if cfg!(target_os = "windows") {
-            format!("node-sidecar-{}.exe", env!("TARGET_TRIPLE"))
-        } else {
-            format!("node-sidecar-{}", env!("TARGET_TRIPLE"))
-        };
-        let node_binary = exe_dir.join(sidecar_name);
+        let node_binary = sidecar_exe_path()
+            .ok_or("Failed to resolve sidecar exe path")?;
 
         Ok((
             strip_win_prefix(&node_binary),
@@ -737,6 +755,24 @@ async fn check_for_update(app: &tauri::AppHandle, manual: bool) {
     // If the process is still running, the file is locked and install fails.
     kill_sidecar(app);
     let client = app.state::<reqwest::Client>().inner().clone();
+
+    // Wait for port release and (on Windows) file-lock release concurrently.
+    // Port-down alone isn't sufficient on Windows: TerminateProcess returns
+    // before the OS releases the exe file handle.
+    #[cfg(target_os = "windows")]
+    {
+        let (port_ok, file_ok) = tokio::join!(
+            wait_for_port_release(&client, 5),
+            wait_for_sidecar_unlock(5),
+        );
+        if !port_ok {
+            log::warn!("Sidecar still responding after 5s kill deadline -- proceeding with install anyway");
+        }
+        if !file_ok {
+            log::warn!("Sidecar exe still locked after 5s -- installer may prompt for retry");
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
     if !wait_for_port_release(&client, 5).await {
         log::warn!("Sidecar still responding after 5s kill deadline -- proceeding with install anyway");
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,7 +46,8 @@
       "../dist/channel/": "dist/channel/",
       "../dist/client/": "dist/client/",
       "../sample/": "sample/",
-      "../skills/": "skills/"
+      "../skills/": "skills/",
+      "../CHANGELOG.md": "CHANGELOG.md"
     }
   },
   "plugins": {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -234,13 +234,16 @@ export async function applyConfig(configPath: string, entries: McpEntries): Prom
     }
   }
 
-  const updated = {
-    ...existing,
-    mcpServers: {
-      ...(existing.mcpServers ?? {}),
-      ...entries,
-    },
+  const merged = {
+    ...(existing.mcpServers ?? {}),
+    ...entries,
   };
+  // Remove stale tandem-channel entry left by older Tauri installers.
+  // The channel shim is Claude Code-only; Cowork can't use it.
+  if (!entries["tandem-channel"]) {
+    delete merged["tandem-channel"];
+  }
+  const updated = { ...existing, mcpServers: merged };
 
   await mkdir(dirname(configPath), { recursive: true });
   await atomicWrite(JSON.stringify(updated, null, 2) + "\n", configPath);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -241,6 +241,11 @@ export async function applyConfig(configPath: string, entries: McpEntries): Prom
   // Remove stale tandem-channel entry left by older Tauri installers.
   // The channel shim is Claude Code-only; Cowork can't use it.
   if (!entries["tandem-channel"]) {
+    if (merged["tandem-channel"]) {
+      console.error(
+        `  Warning: removed stale tandem-channel entry from ${configPath} (legacy Tauri install artifact)`,
+      );
+    }
     delete merged["tandem-channel"];
   }
   const updated = { ...existing, mcpServers: merged };

--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -141,7 +141,6 @@ export async function runSetupHandler(
 
   for (const target of targets) {
     const entries = buildMcpEntries(channelPath, {
-      withChannelShim: true,
       nodeBinary,
       token,
       targetKind: target.kind,

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -196,6 +196,34 @@ describe("applyConfig", () => {
     expect(written.mcpServers.tandem.url).toBe(`http://localhost:${DEFAULT_MCP_PORT}/mcp`);
   });
 
+  it("removes stale tandem-channel entry left by older installers", async () => {
+    const configPath = join(tmpDir, ".claude.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          tandem: { type: "http", url: "http://old:9999/mcp" },
+          "tandem-channel": { command: "/app/MacOS/node-sidecar", args: ["/old/channel.js"] },
+          "my-other-server": { command: "foo" },
+        },
+      }),
+    );
+    const entries = buildMcpEntries("/fake/channel/index.js");
+    await applyConfig(configPath, entries);
+    const written = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(written.mcpServers["tandem-channel"]).toBeUndefined();
+    expect(written.mcpServers["my-other-server"]).toEqual({ command: "foo" });
+    expect(written.mcpServers.tandem).toBeDefined();
+  });
+
+  it("preserves tandem-channel when explicitly included in entries", async () => {
+    const configPath = join(tmpDir, ".claude.json");
+    const entries = buildMcpEntries("/fake/channel/index.js", { withChannelShim: true });
+    await applyConfig(configPath, entries);
+    const written = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(written.mcpServers["tandem-channel"]).toBeDefined();
+  });
+
   it("overwrites malformed JSON with fresh config", async () => {
     const configPath = join(tmpDir, ".claude.json");
     writeFileSync(configPath, "{ this is not json }}}");

--- a/tests/server/setup-api.test.ts
+++ b/tests/server/setup-api.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -212,5 +212,41 @@ describe("runSetupHandler", () => {
     expect(result.status).toBe(200);
     const config = JSON.parse(readFileSync(join(tmpDir, ".claude.json"), "utf-8"));
     expect(config.mcpServers["tandem-channel"]).toBeUndefined();
+  });
+
+  it("removes pre-existing stale tandem-channel entry from .claude.json", async () => {
+    const configPath = join(tmpDir, ".claude.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          "tandem-channel": {
+            command: "node",
+            args: ["/legacy/path/channel.js"],
+          },
+          "some-other-server": {
+            url: "http://localhost:9999",
+          },
+        },
+      }),
+    );
+
+    const result = await runSetupHandler(
+      {
+        nodeBinary: "/app/MacOS/node-sidecar",
+        channelPath: "/app/Resources/dist/channel/index.js",
+      },
+      tmpDir,
+    );
+    expect(result.status).toBe(200);
+
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(config.mcpServers["tandem-channel"]).toBeUndefined();
+    expect(config.mcpServers["some-other-server"]).toBeDefined();
+    expect(config.mcpServers["some-other-server"].url).toBe("http://localhost:9999");
+    // Load-bearing: proves runSetupHandler's merge actually ran, not a silent no-op.
+    // Claude Code targets use HTTP format (url), not stdio (command).
+    expect(config.mcpServers.tandem).toBeDefined();
+    expect(config.mcpServers.tandem.url).toContain("/mcp");
   });
 });

--- a/tests/server/setup-api.test.ts
+++ b/tests/server/setup-api.test.ts
@@ -152,8 +152,7 @@ describe("runSetupHandler", () => {
     // Verify the config file was actually written
     const config = JSON.parse(readFileSync(join(tmpDir, ".claude.json"), "utf-8"));
     expect(config.mcpServers.tandem.url).toContain("/mcp");
-    expect(config.mcpServers["tandem-channel"].command).toBe("node");
-    expect(config.mcpServers["tandem-channel"].args).toEqual(["/fake/dist/channel/index.js"]);
+    expect(config.mcpServers["tandem-channel"]).toBeUndefined();
   });
 
   it("does not detect Claude Code when .claude dir is absent", async () => {
@@ -202,7 +201,7 @@ describe("runSetupHandler", () => {
     expect(result.status).toBe(207);
   });
 
-  it("uses custom nodeBinary in MCP config", async () => {
+  it("does not write tandem-channel entry (channel shim is Claude Code-only)", async () => {
     const result = await runSetupHandler(
       {
         nodeBinary: "/app/MacOS/node-sidecar",
@@ -212,6 +211,6 @@ describe("runSetupHandler", () => {
     );
     expect(result.status).toBe(200);
     const config = JSON.parse(readFileSync(join(tmpDir, ".claude.json"), "utf-8"));
-    expect(config.mcpServers["tandem-channel"].command).toBe("/app/MacOS/node-sidecar");
+    expect(config.mcpServers["tandem-channel"]).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- **Stop writing `tandem-channel` to Claude Desktop MCP config.** The Tauri app's `/api/setup` handler was hardcoding `withChannelShim: true`, producing an entry that always fails in Cowork (Channels are Claude Code-only). Removed the flag and added cleanup logic in `applyConfig()` to strip stale entries from older installs.
- **Fix Windows updater file-lock bug.** `kill_sidecar()` sends `TerminateProcess` but the OS doesn't release the exe file handle until the process fully exits. The NSIS installer would hit "Error opening file for writing" trying to overwrite the locked binary. Now polls both port release and file writability concurrently via `tokio::join!` with a dedicated `wait_for_sidecar_unlock()` helper.
- **Bundle `CHANGELOG.md` in Tauri resources** so the post-update changelog auto-open actually finds the file in the desktop app.
- **Extract `sidecar_exe_path()` helper** in lib.rs to deduplicate sidecar path resolution between `resolve_setup_paths` and the updater.

## Test plan

- [x] `npm test` — 65 setup tests pass (including 2 new tests for stale entry cleanup)
- [x] `npm run typecheck` — clean
- [ ] Verify on Windows: in-app update no longer shows "Error opening file for writing" dialog
- [ ] Verify Claude Desktop config no longer contains `tandem-channel` after setup

Closes the updater file-lock issue reported during v0.7.1 update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)