### PR TITLE
refactor: extract token file helpers to shared layer

### DIFF
--- a/src/cli/rotate-token.ts
+++ b/src/cli/rotate-token.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { promises as fsPromises } from "node:fs";
 import path from "node:path";
-import { getTokenFilePath, readTokenFromFile } from "../server/auth/token-store.js";
+import { getTokenFilePath, readTokenFromFile } from "../shared/auth/token-file.js";
 import { DEFAULT_MCP_PORT } from "../shared/constants.js";
 import { applyConfigWithToken } from "./setup.js";
 

--- a/src/server/auth/token-store.ts
+++ b/src/server/auth/token-store.ts
@@ -1,36 +1,9 @@
 import crypto from "crypto";
-import envPaths from "env-paths";
 import fs from "fs";
 import path from "path";
-import { TOKEN_FILE_NAME } from "../../shared/constants.js";
+import { getTokenFilePath, readTokenFromFile } from "../../shared/auth/token-file.js";
 
-export function getTokenFilePath(): string {
-  return path.join(envPaths("tandem", { suffix: "" }).data, TOKEN_FILE_NAME);
-}
-
-export async function readTokenFromFile(): Promise<string | null> {
-  const filePath = getTokenFilePath();
-  try {
-    const content = await fs.promises.readFile(filePath, "utf8");
-    // Remediate insecure permissions if a previous chmod failed (e.g., process crashed).
-    if (process.platform !== "win32") {
-      try {
-        const stat = await fs.promises.stat(filePath);
-        if ((stat.mode & 0o077) !== 0) {
-          console.error("[tandem] auth token file has insecure permissions; attempting chmod 0600");
-          await fs.promises.chmod(filePath, 0o600);
-        }
-      } catch {
-        // Non-fatal: stat/chmod failure doesn't invalidate the token we already read
-      }
-    }
-    const trimmed = content.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw err;
-  }
-}
+export { getTokenFilePath, readTokenFromFile } from "../../shared/auth/token-file.js";
 
 export async function writeTokenToFile(token: string): Promise<string> {
   const filePath = getTokenFilePath();

--- a/src/shared/auth/token-file.ts
+++ b/src/shared/auth/token-file.ts
@@ -1,0 +1,32 @@
+import fs from "fs";
+import path from "path";
+import envPaths from "env-paths";
+import { TOKEN_FILE_NAME } from "../constants.js";
+
+export function getTokenFilePath(): string {
+  return path.join(envPaths("tandem", { suffix: "" }).data, TOKEN_FILE_NAME);
+}
+
+export async function readTokenFromFile(): Promise<string | null> {
+  const filePath = getTokenFilePath();
+  try {
+    const content = await fs.promises.readFile(filePath, "utf8");
+    // Remediate insecure permissions if a previous chmod failed (e.g., process crashed).
+    if (process.platform !== "win32") {
+      try {
+        const stat = await fs.promises.stat(filePath);
+        if ((stat.mode & 0o077) !== 0) {
+          console.error("[tandem] auth token file has insecure permissions; attempting chmod 0600");
+          await fs.promises.chmod(filePath, 0o600);
+        }
+      } catch {
+        // Non-fatal: stat/chmod failure doesn't invalidate the token we already read
+      }
+    }
+    const trimmed = content.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}

--- a/tests/cli/rotate-token.test.ts
+++ b/tests/cli/rotate-token.test.ts
@@ -36,9 +36,8 @@ vi.mock("node:fs", async (importOriginal) => {
   };
 });
 
-vi.mock("../../src/server/auth/token-store.js", () => ({
+vi.mock("../../src/shared/auth/token-file.js", () => ({
   readTokenFromFile: _readTokenSpy,
-  writeTokenToFile: vi.fn(),
   getTokenFilePath: _getTokenPathSpy,
 }));
 


### PR DESCRIPTION
## Summary
- Moves `getTokenFilePath()` and `readTokenFromFile()` from `src/server/auth/token-store.ts` to `src/shared/auth/token-file.ts`
- Server re-exports both for backward compat; CLI imports from shared
- Test mock path updated in `tests/cli/rotate-token.test.ts`

Fixes layer violation: `src/cli/rotate-token.ts` no longer imports from `src/server/`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run build`
- [x] 33/33 tests pass (token-store, rotate-token, rotate-token-route)

Part of Phase 1 codebase audit remediation ([docs/phase-1-plan.md](docs/phase-1-plan.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
