### PR TITLE
refactor: replace hardcoded rgba with semantic tokens in awareness.ts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,17 +65,18 @@ Full file-level detail: [docs/architecture.md](docs/architecture.md#file-map)
 - File open/close converge in `file-opener.ts` / `document-service.ts`; tab close goes through `POST /api/close`
 
 ## Semantic Tokens
-- Token families defined in `index.html` `:root` (light) and `[data-theme="dark"]` blocks. Never use raw hex or non-neutral `rgba()` for semantic colors in `src/client/**/*.{ts,tsx}` — use `var(--tandem-*)` or import from `src/client/utils/colors.ts`. (`rgba(0,0,0,...)` / `rgba(255,255,255,...)` alpha values for shadows and overlays are fine.) Known exemption until #355 lands: `src/client/editor/extensions/awareness.ts` inlines `rgba(99, 102, 241, …)` for Claude focus/cursor decorations.
+- Token families defined in `index.html` `:root` (light) and `[data-theme="dark"]` blocks. Never use raw hex or non-neutral `rgba()` for semantic colors in `src/client/**/*.{ts,tsx}` — use `var(--tandem-*)` or import from `src/client/utils/colors.ts`. (`rgba(0,0,0,...)` / `rgba(255,255,255,...)` alpha values for shadows and overlays are fine.)
 - **`--tandem-success-*`** — green. Success toasts, completion states. `--tandem-success`, `-fg`, `-fg-strong`, `-bg`, `-border`.
 - **`--tandem-warning-*`** — amber. Warnings, held-annotation banners, unsaved indicators. `--tandem-warning`, `-fg`, `-fg-strong`, `-bg`, `-border`.
 - **`--tandem-error-*`** — red. Error banners, destructive actions, flag annotations. `--tandem-error`, `-fg`, `-fg-strong`, `-bg`, `-border`.
 - **`--tandem-info-*`** — blue. Informational banners, review-only mode. `--tandem-info`, `-fg`, `-fg-strong`, `-bg`, `-border`.
 - **`--tandem-accent-border`** — single token for accent-family bordered elements.
 - **`--tandem-author-user`** / **`--tandem-author-claude`** — authorship colors. Blue/orange in light, adjusted in dark.
+- **`--tandem-claude-focus-bg`** / **`--tandem-claude-focus-border`** — Claude focus paragraph indicator. Derived from `--tandem-author-claude` via `color-mix` (10% / 40% opacity against transparent). Used in `awareness.ts` for the paragraph gutter decoration.
 - **Light mode:** `--tandem-success-bg`, `--tandem-warning-bg`, and `--tandem-error-bg` are derived via `color-mix(in srgb, var(--tandem-{color}) 10%, var(--tandem-surface))`. `--tandem-accent-bg` (`#eef2ff`) and `--tandem-info-bg` (`#eff6ff`) use hand-picked hex.
 - **Dark mode:** all `*-bg` tokens use hand-coded saturated hex (e.g. `#052e16`, `#451a03`, `#450a0a`). `color-mix` produces washed-out surfaces against the dark neutral; hand-picked values read as intentionally colored.
 - **`src/client/utils/colors.ts`** exports `errorStateColors`, `successStateColors`, `warningStateColors` — import these instead of inlining all three CSS vars when you need the full set (e.g. `SidePanel.tsx` held-banner).
-- Raw hex in client code is a regression; lint rule tracked in #356 (awareness.ts migration tracked in #355).
+- Raw hex in client code is a regression; lint rule tracked in #356.
 
 ## Desktop App (Tauri)
 - `cargo tauri dev` -- Tauri dev mode (Vite hot-reload + Rust rebuild)

--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
         --tandem-accent-fg-strong: #4338ca;
         --tandem-author-user: #3b82f6;
         --tandem-author-claude: #ea8a1e;
+        --tandem-claude-focus-bg: color-mix(in srgb, var(--tandem-author-claude) 10%, transparent);
+        --tandem-claude-focus-border: color-mix(in srgb, var(--tandem-author-claude) 40%, transparent);
         --tandem-success: #16a34a;
         --tandem-success-fg: #ffffff;
         --tandem-success-fg-strong: #166534;
@@ -69,6 +71,8 @@
         --tandem-accent-fg-strong: #c7d2fe;
         --tandem-author-user: #60a5fa;
         --tandem-author-claude: #fbbf24;
+        --tandem-claude-focus-bg: color-mix(in srgb, var(--tandem-author-claude) 10%, transparent);
+        --tandem-claude-focus-border: color-mix(in srgb, var(--tandem-author-claude) 40%, transparent);
         --tandem-success: #22c55e;
         --tandem-success-fg: #0f172a;
         --tandem-success-fg-strong: #bbf7d0;
@@ -109,6 +113,8 @@
           --tandem-accent-fg-strong: HighlightText;
           --tandem-author-user: CanvasText;
           --tandem-author-claude: CanvasText;
+          --tandem-claude-focus-bg: Canvas;
+          --tandem-claude-focus-border: Highlight;
         }
 
         /* Held-count badge uses warning-bg only (no border) — add one so it stays visible. */

--- a/src/client/editor/extensions/awareness.ts
+++ b/src/client/editor/extensions/awareness.ts
@@ -35,7 +35,7 @@ export function buildAwarenessDecorations(
           Decoration.node(offset, offset + node.nodeSize, {
             class: "tandem-claude-focus",
             style:
-              "background: rgba(99, 102, 241, 0.1); border-left: 3px solid rgba(99, 102, 241, 0.4); padding-left: 8px; transition: background 0.3s ease, border-color 0.3s ease;",
+              "background: var(--tandem-claude-focus-bg); border-left: 3px solid var(--tandem-claude-focus-border); padding-left: 8px; transition: background 0.3s ease, border-color 0.3s ease;",
           }),
         );
       }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -62,9 +62,6 @@ export const CHARS_PER_PAGE = 3_000;
 export const LARGE_FILE_PAGE_THRESHOLD = 50;
 export const VERY_LARGE_FILE_PAGE_THRESHOLD = 100;
 
-export const CLAUDE_PRESENCE_COLOR = "#6366f1";
-export const CLAUDE_FOCUS_OPACITY = 0.1;
-
 export const CTRL_ROOM = "__tandem_ctrl__";
 
 /** Y.Map key constants — centralized to prevent silent bugs from string typos. */


### PR DESCRIPTION
## Summary
- Adds `--tandem-claude-focus-bg` and `--tandem-claude-focus-border` CSS tokens to `index.html` (light, dark, forced-colors)
- Replaces `rgba(99, 102, 241, 0.1/0.4)` in `awareness.ts` with `var()` references
- Removes dead `CLAUDE_PRESENCE_COLOR` and `CLAUDE_FOCUS_OPACITY` constants from `shared/constants.ts`
- Updates CLAUDE.md: removes #355 exemption, documents new tokens

**Visual change:** Focus indicator shifts from indigo to orange (derived from `--tandem-author-claude`). Intentional — Claude's authorship color is orange.

Closes #355

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run build`
- [ ] Visual check in light/dark/high-contrast modes

Part of Phase 1 codebase audit remediation ([docs/phase-1-plan.md](docs/phase-1-plan.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
