### PR TITLE
refactor: tighten tsconfig — extend root, enforce unused checks

### DIFF
--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -95,6 +95,7 @@ function buildDecorations(
         break;
       default: {
         const _exhaustive: never = ann;
+        void _exhaustive;
         console.warn("[annotation] Unhandled annotation type in buildDecorations, skipping");
         return;
       }

--- a/src/client/panels/CommentThread.tsx
+++ b/src/client/panels/CommentThread.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { AnnotationReply } from "../../shared/types";
 
 interface CommentThreadProps {

--- a/src/client/panels/DocumentHealth.tsx
+++ b/src/client/panels/DocumentHealth.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export function DocumentHealth() {
   return (
     <div style={{ padding: "8px", color: "var(--tandem-fg)" }}>

--- a/src/client/panels/ReviewSummary.tsx
+++ b/src/client/panels/ReviewSummary.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 interface ReviewSummaryProps {
   accepted: number;
   dismissed: number;

--- a/src/client/status/StatusBar.tsx
+++ b/src/client/status/StatusBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { USER_NAME_MAX_LEN } from "../../shared/constants";
 import { useUserName } from "../hooks/useUserName";
 import type { ConnectionStatus } from "../hooks/useYjsSync";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "baseUrl": ".",
     "paths": {
       "@shared/*": ["src/shared/*"],

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,15 +1,7 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ES2022",
     "lib": ["ES2022"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "noEmit": true,
     "rootDir": "src"
   },
   "include": ["src/server", "src/shared", "src/channel", "src/monitor"],


### PR DESCRIPTION
## Summary
- Makes `tsconfig.server.json` extend root config (removes 9 duplicated options)
- Adds `noUnusedLocals: true` and `noUnusedParameters: true` to root `tsconfig.json`
- Fixes 7 resulting errors: `void _exhaustive;` in annotation.ts + types.ts, removes unused React imports in 4 files

**Merge order:** Merge PR #1a (wire-protocol types) first — it replaces `src/server/events/types.ts` entirely, resolving the overlap.

## Test plan
- [x] `npm run typecheck` clean (both server and client passes)
- [x] `npx vitest run` (1414+ tests pass)

Part of Phase 1 codebase audit remediation ([docs/phase-1-plan.md](docs/phase-1-plan.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
