### PR TITLE
refactor(server): decompose api-routes into route handler files

### DIFF
--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -1,6 +1,7 @@
 import type { Express, NextFunction, Request, Response } from "express";
 
 import { TAURI_HOSTNAME } from "../../shared/constants.js";
+import type { Handler } from "./routes/_shared.js";
 import { makeAnnotationReplyHandler } from "./routes/annotation-reply.js";
 import { makeApplyChangesHandler } from "./routes/apply-changes.js";
 import { makeCloseHandler } from "./routes/close.js";
@@ -13,12 +14,10 @@ import { makeSaveHandler } from "./routes/save.js";
 import { makeSetupHandler } from "./routes/setup.js";
 import { makeUploadHandler } from "./routes/upload.js";
 
+export type { Handler } from "./routes/_shared.js";
 // Re-export shared utilities that tests and other modules import from here
 export { errorCodeToHttpStatus, isValidChannelPath, isValidNodeBinary } from "./routes/_shared.js";
 export { runSetupHandler } from "./routes/setup.js";
-
-/** Express middleware/handler function type (Express 5 compatible). */
-export type Handler = (req: Request, res: Response, next: NextFunction) => void;
 
 /**
  * Check if a Host header value is allowed (localhost + optional extra hosts).

--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -1,35 +1,21 @@
 import type { Express, NextFunction, Request, Response } from "express";
 
-import {
-  applyConfig,
-  buildMcpEntries,
-  type DetectedTarget,
-  detectTargets,
-  installSkill,
-} from "../../cli/setup.js";
-import {
-  CHANNEL_SSE_KEEPALIVE_MS,
-  CTRL_ROOM,
-  TANDEM_MODE_DEFAULT,
-  TAURI_HOSTNAME,
-  Y_MAP_ANNOTATIONS,
-  Y_MAP_MODE,
-  Y_MAP_USER_AWARENESS,
-} from "../../shared/constants.js";
-import type { TandemNotification } from "../../shared/types.js";
-import { TandemModeSchema } from "../../shared/types.js";
-import { generateNotificationId } from "../../shared/utils.js";
-import { setPreviousToken } from "../auth/middleware.js";
-import { readTokenFromFile } from "../auth/token-store.js";
-import { pushNotification, subscribe as subscribeNotifications } from "../notifications.js";
-import { getOrCreateDocument } from "../yjs/provider.js";
-import { addReplyToAnnotation } from "./annotations.js";
-import { convertToMarkdown } from "./convert.js";
-import { getCurrentDoc } from "./document.js";
-import { detectFormat } from "./document-model.js";
-import { closeDocumentById, getActiveDocId, saveDocumentToDisk } from "./document-service.js";
-import { applyChangesCore } from "./docx-apply.js";
-import { openFileByPath, openFileFromContent } from "./file-opener.js";
+import { TAURI_HOSTNAME } from "../../shared/constants.js";
+import { makeAnnotationReplyHandler } from "./routes/annotation-reply.js";
+import { makeApplyChangesHandler } from "./routes/apply-changes.js";
+import { makeCloseHandler } from "./routes/close.js";
+import { makeConvertHandler } from "./routes/convert.js";
+import { makeModeHandler } from "./routes/mode.js";
+import { makeNotifyStreamHandler } from "./routes/notify-stream.js";
+import { makeOpenHandler } from "./routes/open.js";
+import { makeRotateTokenHandler } from "./routes/rotate-token.js";
+import { makeSaveHandler } from "./routes/save.js";
+import { makeSetupHandler } from "./routes/setup.js";
+import { makeUploadHandler } from "./routes/upload.js";
+
+// Re-export shared utilities that tests and other modules import from here
+export { errorCodeToHttpStatus, isValidChannelPath, isValidNodeBinary } from "./routes/_shared.js";
+export { runSetupHandler } from "./routes/setup.js";
 
 /** Express middleware/handler function type (Express 5 compatible). */
 export type Handler = (req: Request, res: Response, next: NextFunction) => void;
@@ -62,150 +48,6 @@ export function isLocalhostOrigin(origin: string | undefined): boolean {
   return LOCALHOST_ORIGIN_RE.test(origin ?? "");
 }
 
-/** Reject UNC paths (both backslash and forward-slash variants) to prevent NTLM hash leaks. */
-function hasUncPrefix(p: string): boolean {
-  return p.startsWith("\\\\") || p.startsWith("//");
-}
-
-/** basename() on Linux doesn't treat `\` as a separator, so Windows-style paths
- *  like `C:\Program Files\node.exe` return the whole string. Split on both. */
-function crossBasename(p: string): string {
-  return p.split(/[/\\]/).pop() || "";
-}
-
-/** Validate that a nodeBinary path points to a Node.js binary, not an arbitrary executable. */
-const VALID_NODE_BASENAME_RE = /^node(-sidecar(-[a-z0-9_-]+)?)?(\.exe)?$/;
-export function isValidNodeBinary(nodeBinary: string): boolean {
-  if (!nodeBinary) return false;
-  if (nodeBinary.includes("..")) return false;
-  if (hasUncPrefix(nodeBinary)) return false;
-  return VALID_NODE_BASENAME_RE.test(crossBasename(nodeBinary));
-}
-
-/** Validate that a channelPath points to a JS file without traversal or UNC paths. */
-export function isValidChannelPath(channelPath: string): boolean {
-  if (!channelPath) return false;
-  if (!crossBasename(channelPath).endsWith(".js")) return false;
-  if (channelPath.includes("..")) return false;
-  if (hasUncPrefix(channelPath)) return false;
-  return true;
-}
-
-interface SetupResult {
-  status: number;
-  body: {
-    error?: string;
-    message?: string;
-    data?: {
-      targets: DetectedTarget[];
-      configured: string[];
-      errors: string[];
-      skillInstalled: boolean;
-    };
-  };
-}
-
-export async function runSetupHandler(
-  input: Record<string, unknown>,
-  homeOverride?: string,
-  token?: string,
-): Promise<SetupResult> {
-  const { nodeBinary, channelPath } = input;
-
-  if (!nodeBinary || typeof nodeBinary !== "string") {
-    return { status: 400, body: { error: "BAD_REQUEST", message: "nodeBinary is required" } };
-  }
-  if (!channelPath || typeof channelPath !== "string") {
-    return { status: 400, body: { error: "BAD_REQUEST", message: "channelPath is required" } };
-  }
-  if (!isValidNodeBinary(nodeBinary)) {
-    return {
-      status: 400,
-      body: { error: "BAD_REQUEST", message: "nodeBinary must be a node binary" },
-    };
-  }
-  if (!isValidChannelPath(channelPath)) {
-    return {
-      status: 400,
-      body: {
-        error: "BAD_REQUEST",
-        message: "channelPath must be a .js file without path traversal",
-      },
-    };
-  }
-
-  const targets = detectTargets({ homeOverride });
-
-  const configured: string[] = [];
-  const errors: string[] = [];
-
-  for (const target of targets) {
-    const entries = buildMcpEntries(channelPath, {
-      nodeBinary,
-      token,
-      targetKind: target.kind,
-    });
-    try {
-      await applyConfig(target.configPath, entries);
-      configured.push(target.label);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      errors.push(`${target.label}: ${msg}`);
-      console.error(`[Setup] target=${target.label} failed: ${msg}`);
-    }
-  }
-
-  let skillInstalled = false;
-  try {
-    await installSkill({ homeOverride });
-    skillInstalled = true;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    errors.push(`Skill install: ${msg}`);
-    console.error(`[Setup] skill install failed: ${msg}`);
-  }
-
-  // HTTP status reflects outcome:
-  //   200 — every attempt succeeded (at least one configured target + skill installed)
-  //   207 — partial failure (some targets configured or skill installed, but not all)
-  //   500 — total failure (no targets configured AND skill install failed)
-  const totalFailed = configured.length === 0 && !skillInstalled;
-  const anyFailed = errors.length > 0;
-  let status: number = 200;
-  if (totalFailed) status = 500;
-  else if (anyFailed) status = 207;
-
-  return {
-    status,
-    body: { data: { targets, configured, errors, skillInstalled } },
-  };
-}
-
-/** Map error code to HTTP status. Exported for testing. */
-export function errorCodeToHttpStatus(code: string | undefined): number {
-  switch (code) {
-    case "ENOENT":
-    case "FILE_NOT_FOUND":
-    case "NO_DOCUMENT":
-      return 404;
-    case "INVALID_PATH":
-    case "UNSUPPORTED_FORMAT":
-    case "NO_SUGGESTIONS":
-      return 400;
-    case "FILE_TOO_LARGE":
-      return 413;
-    case "EBUSY":
-    case "EPERM":
-      return 423;
-    case "EACCES":
-      return 403;
-    case "BACKUP_FAILED":
-      return 500;
-    default:
-      return 500;
-  }
-}
-
 /**
  * Create a CORS + DNS rebinding protection middleware for /api/* routes.
  *
@@ -235,93 +77,8 @@ export function createApiMiddleware(extraHosts: string[] = []): Handler {
 /** Default CORS + DNS rebinding protection middleware (loopback-only allowlist). */
 export const apiMiddleware: Handler = createApiMiddleware();
 
-/** Map a Node/custom error code to a JSON-body error label. */
-function errorCodeToLabel(code: string): string {
-  switch (code) {
-    case "ENOENT":
-    case "FILE_NOT_FOUND":
-    case "NO_DOCUMENT":
-      return "NOT_FOUND";
-    case "INVALID_PATH":
-      return "INVALID_PATH";
-    case "UNSUPPORTED_FORMAT":
-    case "NO_SUGGESTIONS":
-      return "BAD_REQUEST";
-    case "FILE_TOO_LARGE":
-      return "FILE_TOO_LARGE";
-    case "EBUSY":
-    case "EPERM":
-      return "FILE_LOCKED";
-    case "EACCES":
-      return "PERMISSION_DENIED";
-    case "BACKUP_FAILED":
-      return "INTERNAL";
-    default:
-      return "INTERNAL";
-  }
-}
-
-/** Map error codes from file-opener to HTTP responses */
-function sendApiError(res: Response, err: unknown): void {
-  const e = err as NodeJS.ErrnoException;
-  const code = e.code ?? "";
-  const status = errorCodeToHttpStatus(code);
-  const label = errorCodeToLabel(code);
-  const msg =
-    label === "FILE_LOCKED" ? "File is locked by another program." : (e.message ?? String(err));
-  if (status === 500) console.error("[Tandem] Unhandled API error:", err);
-  res.status(status).json({ error: label, message: msg });
-}
-
-/** SSE endpoint for streaming notifications to the browser. */
-function notifyStreamHandler(req: Request, res: Response): void {
-  res.writeHead(200, {
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-  });
-
-  res.write(": connected\n\n");
-
-  function cleanup(): void {
-    clearInterval(keepalive);
-    unsubscribe();
-  }
-
-  const unsubscribe = subscribeNotifications((notification: TandemNotification) => {
-    try {
-      res.write(`data: ${JSON.stringify(notification)}\n\n`);
-    } catch (err) {
-      console.error(
-        "[NotifyStream] Write failed, cleaning up:",
-        err instanceof Error ? err.message : err,
-      );
-      cleanup();
-    }
-  });
-
-  const keepalive = setInterval(() => {
-    try {
-      if (!res.writableEnded) res.write(": keepalive\n\n");
-    } catch (err) {
-      console.error(
-        "[NotifyStream] Keepalive write failed, cleaning up:",
-        err instanceof Error ? err.message : err,
-      );
-      cleanup();
-    }
-  }, CHANNEL_SSE_KEEPALIVE_MS);
-
-  req.on("close", () => {
-    cleanup();
-    console.error("[NotifyStream] Client disconnected from /api/notify-stream");
-  });
-
-  console.error("[NotifyStream] Client connected to /api/notify-stream");
-}
-
 /**
- * Register /api/open, /api/upload, and /api/notify-stream routes on the Express app.
+ * Register /api/* routes on the Express app.
  *
  * @param mw - The DNS-rebinding middleware to use. Pass `createApiMiddleware([lanIP])`
  *   when TANDEM_BIND_HOST is non-loopback so LAN Host headers are allowed.
@@ -341,202 +98,35 @@ export function registerApiRoutes(
   getCurrentToken: () => string | null = () => null,
 ): void {
   // SSE notification stream for browser toasts
-  app.get("/api/notify-stream", mw, notifyStreamHandler);
+  app.get("/api/notify-stream", mw, makeNotifyStreamHandler());
+
+  // NOTE: /api/mode is GET-only — no OPTIONS registration
+  app.get("/api/mode", mw, makeModeHandler());
+
   app.options("/api/open", mw);
-  app.post("/api/open", mw, largeBody, async (req: Request, res: Response) => {
-    const { filePath, force } = (req.body ?? {}) as Record<string, unknown>;
-    if (!filePath || typeof filePath !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "filePath is required" });
-      return;
-    }
-    try {
-      const result = await openFileByPath(filePath, { force: force === true });
-      res.json({ data: result });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  });
+  app.post("/api/open", mw, largeBody, makeOpenHandler());
 
   app.options("/api/close", mw);
-  app.post("/api/close", mw, largeBody, async (req: Request, res: Response) => {
-    const { documentId } = (req.body ?? {}) as Record<string, unknown>;
-    if (!documentId || typeof documentId !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "documentId is required" });
-      return;
-    }
-    try {
-      const result = await closeDocumentById(documentId);
-      if (!result.success) {
-        res.status(404).json({ error: "NOT_FOUND", message: result.error });
-        return;
-      }
-      res.json({
-        data: { closedPath: result.closedPath, activeDocumentId: result.activeDocumentId },
-      });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  });
+  app.post("/api/close", mw, largeBody, makeCloseHandler());
 
   app.options("/api/save", mw);
-  app.post("/api/save", mw, largeBody, async (req: Request, res: Response) => {
-    const { documentId } = (req.body ?? {}) as Record<string, unknown>;
-    if (documentId !== undefined && typeof documentId !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
-      return;
-    }
-    const targetId = (documentId as string | undefined) ?? getActiveDocId();
-    if (!targetId) {
-      res.status(404).json({ error: "NOT_FOUND", message: "No document to save." });
-      return;
-    }
-    try {
-      const result = await saveDocumentToDisk(targetId, "manual");
-      res.json({ data: result });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  });
+  app.post("/api/save", mw, largeBody, makeSaveHandler());
 
   app.options("/api/upload", mw);
-  app.post("/api/upload", mw, largeBody, async (req: Request, res: Response) => {
-    const { fileName, content } = (req.body ?? {}) as Record<string, unknown>;
-    if (!fileName || typeof fileName !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "fileName is required" });
-      return;
-    }
-    if (content === undefined || content === null) {
-      res.status(400).json({ error: "BAD_REQUEST", message: "content is required" });
-      return;
-    }
-    if (typeof content !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "content must be a base64 string" });
-      return;
-    }
-    try {
-      const format = detectFormat(fileName);
-      const decoded = format === "docx" ? Buffer.from(content, "base64") : String(content);
-      const result = await openFileFromContent(fileName, decoded);
-      res.json({ data: result });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  });
+  app.post("/api/upload", mw, largeBody, makeUploadHandler());
 
   app.options("/api/convert", mw);
-  app.post("/api/convert", mw, largeBody, async (req: Request, res: Response) => {
-    const { documentId, outputPath } = (req.body ?? {}) as Record<string, unknown>;
-    if (documentId !== undefined && typeof documentId !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
-      return;
-    }
-    if (outputPath !== undefined && typeof outputPath !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "outputPath must be a string" });
-      return;
-    }
-
-    try {
-      const result = await convertToMarkdown(
-        documentId as string | undefined,
-        outputPath as string | undefined,
-      );
-      res.json({ data: result });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  });
-
-  app.get("/api/mode", mw, (_req: Request, res: Response) => {
-    const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
-    const awareness = ctrlDoc.getMap(Y_MAP_USER_AWARENESS);
-    const mode = TandemModeSchema.catch(TANDEM_MODE_DEFAULT).parse(awareness.get(Y_MAP_MODE));
-    res.json({ mode });
-  });
+  app.post("/api/convert", mw, largeBody, makeConvertHandler());
 
   app.options("/api/apply-changes", mw);
-  app.post("/api/apply-changes", mw, largeBody, async (req: Request, res: Response) => {
-    const { documentId, author, backupPath } = (req.body ?? {}) as Record<string, unknown>;
-    if (documentId !== undefined && typeof documentId !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
-      return;
-    }
-    if (author !== undefined && typeof author !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "author must be a string" });
-      return;
-    }
-    if (backupPath !== undefined && typeof backupPath !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "backupPath must be a string" });
-      return;
-    }
-
-    try {
-      const result = await applyChangesCore(
-        documentId as string | undefined,
-        author as string | undefined,
-        backupPath as string | undefined,
-      );
-      res.json({ data: result });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  });
+  app.post("/api/apply-changes", mw, largeBody, makeApplyChangesHandler());
 
   app.options("/api/setup", mw);
-  app.post("/api/setup", mw, largeBody, async (req: Request, res: Response) => {
-    try {
-      const result = await runSetupHandler(
-        (req.body ?? {}) as Record<string, unknown>,
-        undefined,
-        token,
-      );
-      res.status(result.status).json(result.body);
-    } catch (err: unknown) {
-      console.error("[Tandem] Setup handler threw:", err);
-      res.status(500).json({
-        error: "INTERNAL",
-        message: err instanceof Error ? err.message : String(err),
-      });
-    }
-  });
+  app.post("/api/setup", mw, largeBody, makeSetupHandler({ token }));
 
   // Annotation reply: browser user posts a reply to an annotation thread
   app.options("/api/annotation-reply", mw);
-  app.post("/api/annotation-reply", mw, largeBody, (req: Request, res: Response) => {
-    const { annotationId, text, documentId } = (req.body ?? {}) as Record<string, unknown>;
-    if (!annotationId || typeof annotationId !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "annotationId is required" });
-      return;
-    }
-    if (!text || typeof text !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "text is required" });
-      return;
-    }
-
-    const doc = getCurrentDoc(typeof documentId === "string" ? documentId : undefined);
-    if (!doc) {
-      res.status(404).json({ error: "NOT_FOUND", message: "No document open" });
-      return;
-    }
-    const ydoc = getOrCreateDocument(doc.docName);
-    const annotationsMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
-
-    // No origin tag — allows event emission so Claude sees user replies
-    const result = addReplyToAnnotation(ydoc, annotationsMap, annotationId, text, "user");
-    if (!result.ok) {
-      const status = result.code === "ANNOTATION_RESOLVED" ? 409 : 404;
-      pushNotification({
-        id: generateNotificationId(),
-        type: "annotation-error",
-        severity: "error",
-        message: `Reply failed: ${result.error}`,
-        dedupKey: `reply-error:${annotationId}`,
-        timestamp: Date.now(),
-      });
-      res.status(status).json({ error: result.code, message: result.error });
-      return;
-    }
-    res.json({ data: { replyId: result.replyId, annotationId } });
-  });
+  app.post("/api/annotation-reply", mw, largeBody, makeAnnotationReplyHandler());
 
   // Token rotation: CLI calls this to activate the 60-second grace window and swap the
   // in-memory current token to the NEW token that was already written to disk.
@@ -544,41 +134,10 @@ export function registerApiRoutes(
   // previousToken is NOT accepted from the request body — the handler captures it from
   // getCurrentToken() to prevent callers from injecting arbitrary strings into the grace slot.
   app.options("/api/rotate-token", mw);
-  app.post("/api/rotate-token", mw, largeBody, async (_req: Request, res: Response) => {
-    // Fix 4: Tauri-launched servers use env-injected tokens; rotation would diverge
-    // the disk token from what Tauri passes on next launch, breaking auth.
-    if (process.env.TANDEM_AUTH_TOKEN) {
-      res.status(409).json({ error: "Token is managed by Tauri; rotate via the app." });
-      return;
-    }
-
-    // Capture the current token BEFORE swapping — this is the grace-window credential.
-    // If null (server started without a token), there's nothing to preserve.
-    const oldToken = getCurrentToken();
-
-    let newToken: string | null;
-    try {
-      newToken = await readTokenFromFile();
-    } catch (err) {
-      console.error("[tandem] rotate-token: failed to read new token from disk:", err);
-      res.status(500).json({ error: "INTERNAL", message: "Could not read new token from disk." });
-      return;
-    }
-
-    if (!newToken) {
-      res
-        .status(500)
-        .json({ error: "INTERNAL", message: "No token found on disk after rotation." });
-      return;
-    }
-
-    if (oldToken) {
-      setPreviousToken(oldToken, 60_000);
-    }
-
-    setCurrentToken(newToken);
-
-    console.error("[tandem] auth token rotated; 60-second grace window active for old token");
-    res.json({ ok: true });
-  });
+  app.post(
+    "/api/rotate-token",
+    mw,
+    largeBody,
+    makeRotateTokenHandler({ setCurrentToken, getCurrentToken }),
+  );
 }

--- a/src/server/mcp/routes/_shared.ts
+++ b/src/server/mcp/routes/_shared.ts
@@ -1,0 +1,93 @@
+import type { Response } from "express";
+
+/** Reject UNC paths (both backslash and forward-slash variants) to prevent NTLM hash leaks. */
+function hasUncPrefix(p: string): boolean {
+  return p.startsWith("\\\\") || p.startsWith("//");
+}
+
+/** basename() on Linux doesn't treat `\` as a separator, so Windows-style paths
+ *  like `C:\Program Files\node.exe` return the whole string. Split on both. */
+function crossBasename(p: string): string {
+  return p.split(/[/\\]/).pop() || "";
+}
+
+/** Validate that a nodeBinary path points to a Node.js binary, not an arbitrary executable. */
+const VALID_NODE_BASENAME_RE = /^node(-sidecar(-[a-z0-9_-]+)?)?(\.exe)?$/;
+export function isValidNodeBinary(nodeBinary: string): boolean {
+  if (!nodeBinary) return false;
+  if (nodeBinary.includes("..")) return false;
+  if (hasUncPrefix(nodeBinary)) return false;
+  return VALID_NODE_BASENAME_RE.test(crossBasename(nodeBinary));
+}
+
+/** Validate that a channelPath points to a JS file without traversal or UNC paths. */
+export function isValidChannelPath(channelPath: string): boolean {
+  if (!channelPath) return false;
+  if (!crossBasename(channelPath).endsWith(".js")) return false;
+  if (channelPath.includes("..")) return false;
+  if (hasUncPrefix(channelPath)) return false;
+  return true;
+}
+
+/** Map error code to HTTP status. Exported for testing. */
+export function errorCodeToHttpStatus(code: string | undefined): number {
+  switch (code) {
+    case "ENOENT":
+    case "FILE_NOT_FOUND":
+    case "NO_DOCUMENT":
+      return 404;
+    case "INVALID_PATH":
+    case "UNSUPPORTED_FORMAT":
+    case "NO_SUGGESTIONS":
+      return 400;
+    case "FILE_TOO_LARGE":
+      return 413;
+    case "EBUSY":
+    case "EPERM":
+      return 423;
+    case "EACCES":
+      return 403;
+    case "BACKUP_FAILED":
+      return 500;
+    default:
+      return 500;
+  }
+}
+
+/** Map a Node/custom error code to a JSON-body error label. */
+function errorCodeToLabel(code: string): string {
+  switch (code) {
+    case "ENOENT":
+    case "FILE_NOT_FOUND":
+    case "NO_DOCUMENT":
+      return "NOT_FOUND";
+    case "INVALID_PATH":
+      return "INVALID_PATH";
+    case "UNSUPPORTED_FORMAT":
+    case "NO_SUGGESTIONS":
+      return "BAD_REQUEST";
+    case "FILE_TOO_LARGE":
+      return "FILE_TOO_LARGE";
+    case "EBUSY":
+    case "EPERM":
+      return "FILE_LOCKED";
+    case "EACCES":
+      return "PERMISSION_DENIED";
+    case "BACKUP_FAILED":
+      return "INTERNAL";
+    default:
+      return "INTERNAL";
+  }
+}
+
+/** Map error codes from file-opener to HTTP responses */
+export function sendApiError(res: Response, err: unknown): void {
+  const e = err as NodeJS.ErrnoException;
+  const code = e.code ?? "";
+  const status = errorCodeToHttpStatus(code);
+  const label = errorCodeToLabel(code);
+  const msg =
+    label === "FILE_LOCKED" ? "File is locked by another program." : (e.message ?? String(err));
+  if (status === 500) console.error("[Tandem] Unhandled API error:", err);
+  res.status(status).json({ error: label, message: msg });
+}

--- a/src/server/mcp/routes/_shared.ts
+++ b/src/server/mcp/routes/_shared.ts
@@ -1,4 +1,7 @@
-import type { Response } from "express";
+import type { NextFunction, Request, Response } from "express";
+
+/** Express middleware/handler function type (Express 5 compatible). */
+export type Handler = (req: Request, res: Response, next: NextFunction) => void;
 
 /** Reject UNC paths (both backslash and forward-slash variants) to prevent NTLM hash leaks. */
 function hasUncPrefix(p: string): boolean {

--- a/src/server/mcp/routes/annotation-reply.ts
+++ b/src/server/mcp/routes/annotation-reply.ts
@@ -4,8 +4,8 @@ import { generateNotificationId } from "../../../shared/utils.js";
 import { pushNotification } from "../../notifications.js";
 import { getOrCreateDocument } from "../../yjs/provider.js";
 import { addReplyToAnnotation } from "../annotations.js";
-import type { Handler } from "../api-routes.js";
 import { getCurrentDoc } from "../document.js";
+import type { Handler } from "./_shared.js";
 
 export function makeAnnotationReplyHandler(): Handler {
   return (req: Request, res: Response) => {

--- a/src/server/mcp/routes/annotation-reply.ts
+++ b/src/server/mcp/routes/annotation-reply.ts
@@ -1,0 +1,47 @@
+import type { Request, Response } from "express";
+import { Y_MAP_ANNOTATIONS } from "../../../shared/constants.js";
+import { generateNotificationId } from "../../../shared/utils.js";
+import { pushNotification } from "../../notifications.js";
+import { getOrCreateDocument } from "../../yjs/provider.js";
+import { addReplyToAnnotation } from "../annotations.js";
+import type { Handler } from "../api-routes.js";
+import { getCurrentDoc } from "../document.js";
+
+export function makeAnnotationReplyHandler(): Handler {
+  return (req: Request, res: Response) => {
+    const { annotationId, text, documentId } = (req.body ?? {}) as Record<string, unknown>;
+    if (!annotationId || typeof annotationId !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "annotationId is required" });
+      return;
+    }
+    if (!text || typeof text !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "text is required" });
+      return;
+    }
+
+    const doc = getCurrentDoc(typeof documentId === "string" ? documentId : undefined);
+    if (!doc) {
+      res.status(404).json({ error: "NOT_FOUND", message: "No document open" });
+      return;
+    }
+    const ydoc = getOrCreateDocument(doc.docName);
+    const annotationsMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+
+    // No origin tag — allows event emission so Claude sees user replies
+    const result = addReplyToAnnotation(ydoc, annotationsMap, annotationId, text, "user");
+    if (!result.ok) {
+      const status = result.code === "ANNOTATION_RESOLVED" ? 409 : 404;
+      pushNotification({
+        id: generateNotificationId(),
+        type: "annotation-error",
+        severity: "error",
+        message: `Reply failed: ${result.error}`,
+        dedupKey: `reply-error:${annotationId}`,
+        timestamp: Date.now(),
+      });
+      res.status(status).json({ error: result.code, message: result.error });
+      return;
+    }
+    res.json({ data: { replyId: result.replyId, annotationId } });
+  };
+}

--- a/src/server/mcp/routes/apply-changes.ts
+++ b/src/server/mcp/routes/apply-changes.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
-import type { Handler } from "../api-routes.js";
 import { applyChangesCore } from "../docx-apply.js";
+import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
 export function makeApplyChangesHandler(): Handler {

--- a/src/server/mcp/routes/apply-changes.ts
+++ b/src/server/mcp/routes/apply-changes.ts
@@ -1,0 +1,33 @@
+import type { Request, Response } from "express";
+import type { Handler } from "../api-routes.js";
+import { applyChangesCore } from "../docx-apply.js";
+import { sendApiError } from "./_shared.js";
+
+export function makeApplyChangesHandler(): Handler {
+  return async (req: Request, res: Response) => {
+    const { documentId, author, backupPath } = (req.body ?? {}) as Record<string, unknown>;
+    if (documentId !== undefined && typeof documentId !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
+      return;
+    }
+    if (author !== undefined && typeof author !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "author must be a string" });
+      return;
+    }
+    if (backupPath !== undefined && typeof backupPath !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "backupPath must be a string" });
+      return;
+    }
+
+    try {
+      const result = await applyChangesCore(
+        documentId as string | undefined,
+        author as string | undefined,
+        backupPath as string | undefined,
+      );
+      res.json({ data: result });
+    } catch (err: unknown) {
+      sendApiError(res, err);
+    }
+  };
+}

--- a/src/server/mcp/routes/close.ts
+++ b/src/server/mcp/routes/close.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
-import type { Handler } from "../api-routes.js";
 import { closeDocumentById } from "../document-service.js";
+import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
 export function makeCloseHandler(): Handler {

--- a/src/server/mcp/routes/close.ts
+++ b/src/server/mcp/routes/close.ts
@@ -1,0 +1,26 @@
+import type { Request, Response } from "express";
+import type { Handler } from "../api-routes.js";
+import { closeDocumentById } from "../document-service.js";
+import { sendApiError } from "./_shared.js";
+
+export function makeCloseHandler(): Handler {
+  return async (req: Request, res: Response) => {
+    const { documentId } = (req.body ?? {}) as Record<string, unknown>;
+    if (!documentId || typeof documentId !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "documentId is required" });
+      return;
+    }
+    try {
+      const result = await closeDocumentById(documentId);
+      if (!result.success) {
+        res.status(404).json({ error: "NOT_FOUND", message: result.error });
+        return;
+      }
+      res.json({
+        data: { closedPath: result.closedPath, activeDocumentId: result.activeDocumentId },
+      });
+    } catch (err: unknown) {
+      sendApiError(res, err);
+    }
+  };
+}

--- a/src/server/mcp/routes/convert.ts
+++ b/src/server/mcp/routes/convert.ts
@@ -1,0 +1,28 @@
+import type { Request, Response } from "express";
+import type { Handler } from "../api-routes.js";
+import { convertToMarkdown } from "../convert.js";
+import { sendApiError } from "./_shared.js";
+
+export function makeConvertHandler(): Handler {
+  return async (req: Request, res: Response) => {
+    const { documentId, outputPath } = (req.body ?? {}) as Record<string, unknown>;
+    if (documentId !== undefined && typeof documentId !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
+      return;
+    }
+    if (outputPath !== undefined && typeof outputPath !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "outputPath must be a string" });
+      return;
+    }
+
+    try {
+      const result = await convertToMarkdown(
+        documentId as string | undefined,
+        outputPath as string | undefined,
+      );
+      res.json({ data: result });
+    } catch (err: unknown) {
+      sendApiError(res, err);
+    }
+  };
+}

--- a/src/server/mcp/routes/convert.ts
+++ b/src/server/mcp/routes/convert.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
-import type { Handler } from "../api-routes.js";
 import { convertToMarkdown } from "../convert.js";
+import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
 export function makeConvertHandler(): Handler {

--- a/src/server/mcp/routes/mode.ts
+++ b/src/server/mcp/routes/mode.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../shared/constants.js";
 import { TandemModeSchema } from "../../../shared/types.js";
 import { getOrCreateDocument } from "../../yjs/provider.js";
-import type { Handler } from "../api-routes.js";
+import type { Handler } from "./_shared.js";
 
 export function makeModeHandler(): Handler {
   return (_req: Request, res: Response) => {

--- a/src/server/mcp/routes/mode.ts
+++ b/src/server/mcp/routes/mode.ts
@@ -1,0 +1,19 @@
+import type { Request, Response } from "express";
+import {
+  CTRL_ROOM,
+  TANDEM_MODE_DEFAULT,
+  Y_MAP_MODE,
+  Y_MAP_USER_AWARENESS,
+} from "../../../shared/constants.js";
+import { TandemModeSchema } from "../../../shared/types.js";
+import { getOrCreateDocument } from "../../yjs/provider.js";
+import type { Handler } from "../api-routes.js";
+
+export function makeModeHandler(): Handler {
+  return (_req: Request, res: Response) => {
+    const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
+    const awareness = ctrlDoc.getMap(Y_MAP_USER_AWARENESS);
+    const mode = TandemModeSchema.catch(TANDEM_MODE_DEFAULT).parse(awareness.get(Y_MAP_MODE));
+    res.json({ mode });
+  };
+}

--- a/src/server/mcp/routes/notify-stream.ts
+++ b/src/server/mcp/routes/notify-stream.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { CHANNEL_SSE_KEEPALIVE_MS } from "../../../shared/constants.js";
 import type { TandemNotification } from "../../../shared/types.js";
 import { subscribe as subscribeNotifications } from "../../notifications.js";
-import type { Handler } from "../api-routes.js";
+import type { Handler } from "./_shared.js";
 
 export function makeNotifyStreamHandler(): Handler {
   return (req: Request, res: Response) => {

--- a/src/server/mcp/routes/notify-stream.ts
+++ b/src/server/mcp/routes/notify-stream.ts
@@ -1,0 +1,53 @@
+import type { Request, Response } from "express";
+import { CHANNEL_SSE_KEEPALIVE_MS } from "../../../shared/constants.js";
+import type { TandemNotification } from "../../../shared/types.js";
+import { subscribe as subscribeNotifications } from "../../notifications.js";
+import type { Handler } from "../api-routes.js";
+
+export function makeNotifyStreamHandler(): Handler {
+  return (req: Request, res: Response) => {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+
+    res.write(": connected\n\n");
+
+    function cleanup(): void {
+      clearInterval(keepalive);
+      unsubscribe();
+    }
+
+    const unsubscribe = subscribeNotifications((notification: TandemNotification) => {
+      try {
+        res.write(`data: ${JSON.stringify(notification)}\n\n`);
+      } catch (err) {
+        console.error(
+          "[NotifyStream] Write failed, cleaning up:",
+          err instanceof Error ? err.message : err,
+        );
+        cleanup();
+      }
+    });
+
+    const keepalive = setInterval(() => {
+      try {
+        if (!res.writableEnded) res.write(": keepalive\n\n");
+      } catch (err) {
+        console.error(
+          "[NotifyStream] Keepalive write failed, cleaning up:",
+          err instanceof Error ? err.message : err,
+        );
+        cleanup();
+      }
+    }, CHANNEL_SSE_KEEPALIVE_MS);
+
+    req.on("close", () => {
+      cleanup();
+      console.error("[NotifyStream] Client disconnected from /api/notify-stream");
+    });
+
+    console.error("[NotifyStream] Client connected to /api/notify-stream");
+  };
+}

--- a/src/server/mcp/routes/open.ts
+++ b/src/server/mcp/routes/open.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
-import type { Handler } from "../api-routes.js";
 import { openFileByPath } from "../file-opener.js";
+import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
 export function makeOpenHandler(): Handler {

--- a/src/server/mcp/routes/open.ts
+++ b/src/server/mcp/routes/open.ts
@@ -1,0 +1,20 @@
+import type { Request, Response } from "express";
+import type { Handler } from "../api-routes.js";
+import { openFileByPath } from "../file-opener.js";
+import { sendApiError } from "./_shared.js";
+
+export function makeOpenHandler(): Handler {
+  return async (req: Request, res: Response) => {
+    const { filePath, force } = (req.body ?? {}) as Record<string, unknown>;
+    if (!filePath || typeof filePath !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "filePath is required" });
+      return;
+    }
+    try {
+      const result = await openFileByPath(filePath, { force: force === true });
+      res.json({ data: result });
+    } catch (err: unknown) {
+      sendApiError(res, err);
+    }
+  };
+}

--- a/src/server/mcp/routes/rotate-token.ts
+++ b/src/server/mcp/routes/rotate-token.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 import { setPreviousToken } from "../../auth/middleware.js";
 import { readTokenFromFile } from "../../auth/token-store.js";
-import type { Handler } from "../api-routes.js";
+import type { Handler } from "./_shared.js";
 
 export function makeRotateTokenHandler(deps: {
   setCurrentToken: (t: string) => void;

--- a/src/server/mcp/routes/rotate-token.ts
+++ b/src/server/mcp/routes/rotate-token.ts
@@ -1,0 +1,47 @@
+import type { Request, Response } from "express";
+import { setPreviousToken } from "../../auth/middleware.js";
+import { readTokenFromFile } from "../../auth/token-store.js";
+import type { Handler } from "../api-routes.js";
+
+export function makeRotateTokenHandler(deps: {
+  setCurrentToken: (t: string) => void;
+  getCurrentToken: () => string | null;
+}): Handler {
+  return async (_req: Request, res: Response) => {
+    // Fix 4: Tauri-launched servers use env-injected tokens; rotation would diverge
+    // the disk token from what Tauri passes on next launch, breaking auth.
+    if (process.env.TANDEM_AUTH_TOKEN) {
+      res.status(409).json({ error: "Token is managed by Tauri; rotate via the app." });
+      return;
+    }
+
+    // Capture the current token BEFORE swapping — this is the grace-window credential.
+    // If null (server started without a token), there's nothing to preserve.
+    const oldToken = deps.getCurrentToken();
+
+    let newToken: string | null;
+    try {
+      newToken = await readTokenFromFile();
+    } catch (err) {
+      console.error("[tandem] rotate-token: failed to read new token from disk:", err);
+      res.status(500).json({ error: "INTERNAL", message: "Could not read new token from disk." });
+      return;
+    }
+
+    if (!newToken) {
+      res
+        .status(500)
+        .json({ error: "INTERNAL", message: "No token found on disk after rotation." });
+      return;
+    }
+
+    if (oldToken) {
+      setPreviousToken(oldToken, 60_000);
+    }
+
+    deps.setCurrentToken(newToken);
+
+    console.error("[tandem] auth token rotated; 60-second grace window active for old token");
+    res.json({ ok: true });
+  };
+}

--- a/src/server/mcp/routes/save.ts
+++ b/src/server/mcp/routes/save.ts
@@ -1,0 +1,25 @@
+import type { Request, Response } from "express";
+import type { Handler } from "../api-routes.js";
+import { getActiveDocId, saveDocumentToDisk } from "../document-service.js";
+import { sendApiError } from "./_shared.js";
+
+export function makeSaveHandler(): Handler {
+  return async (req: Request, res: Response) => {
+    const { documentId } = (req.body ?? {}) as Record<string, unknown>;
+    if (documentId !== undefined && typeof documentId !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
+      return;
+    }
+    const targetId = (documentId as string | undefined) ?? getActiveDocId();
+    if (!targetId) {
+      res.status(404).json({ error: "NOT_FOUND", message: "No document to save." });
+      return;
+    }
+    try {
+      const result = await saveDocumentToDisk(targetId, "manual");
+      res.json({ data: result });
+    } catch (err: unknown) {
+      sendApiError(res, err);
+    }
+  };
+}

--- a/src/server/mcp/routes/save.ts
+++ b/src/server/mcp/routes/save.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
-import type { Handler } from "../api-routes.js";
 import { getActiveDocId, saveDocumentToDisk } from "../document-service.js";
+import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
 export function makeSaveHandler(): Handler {

--- a/src/server/mcp/routes/setup.ts
+++ b/src/server/mcp/routes/setup.ts
@@ -1,0 +1,119 @@
+import type { Request, Response } from "express";
+import {
+  applyConfig,
+  buildMcpEntries,
+  type DetectedTarget,
+  detectTargets,
+  installSkill,
+} from "../../../cli/setup.js";
+import type { Handler } from "../api-routes.js";
+import { isValidChannelPath, isValidNodeBinary } from "./_shared.js";
+
+interface SetupResult {
+  status: number;
+  body: {
+    error?: string;
+    message?: string;
+    data?: {
+      targets: DetectedTarget[];
+      configured: string[];
+      errors: string[];
+      skillInstalled: boolean;
+    };
+  };
+}
+
+export async function runSetupHandler(
+  input: Record<string, unknown>,
+  homeOverride?: string,
+  token?: string,
+): Promise<SetupResult> {
+  const { nodeBinary, channelPath } = input;
+
+  if (!nodeBinary || typeof nodeBinary !== "string") {
+    return { status: 400, body: { error: "BAD_REQUEST", message: "nodeBinary is required" } };
+  }
+  if (!channelPath || typeof channelPath !== "string") {
+    return { status: 400, body: { error: "BAD_REQUEST", message: "channelPath is required" } };
+  }
+  if (!isValidNodeBinary(nodeBinary)) {
+    return {
+      status: 400,
+      body: { error: "BAD_REQUEST", message: "nodeBinary must be a node binary" },
+    };
+  }
+  if (!isValidChannelPath(channelPath)) {
+    return {
+      status: 400,
+      body: {
+        error: "BAD_REQUEST",
+        message: "channelPath must be a .js file without path traversal",
+      },
+    };
+  }
+
+  const targets = detectTargets({ homeOverride });
+
+  const configured: string[] = [];
+  const errors: string[] = [];
+
+  for (const target of targets) {
+    const entries = buildMcpEntries(channelPath, {
+      nodeBinary,
+      token,
+      targetKind: target.kind,
+    });
+    try {
+      await applyConfig(target.configPath, entries);
+      configured.push(target.label);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`${target.label}: ${msg}`);
+      console.error(`[Setup] target=${target.label} failed: ${msg}`);
+    }
+  }
+
+  let skillInstalled = false;
+  try {
+    await installSkill({ homeOverride });
+    skillInstalled = true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    errors.push(`Skill install: ${msg}`);
+    console.error(`[Setup] skill install failed: ${msg}`);
+  }
+
+  // HTTP status reflects outcome:
+  //   200 — every attempt succeeded (at least one configured target + skill installed)
+  //   207 — partial failure (some targets configured or skill installed, but not all)
+  //   500 — total failure (no targets configured AND skill install failed)
+  const totalFailed = configured.length === 0 && !skillInstalled;
+  const anyFailed = errors.length > 0;
+  let status: number = 200;
+  if (totalFailed) status = 500;
+  else if (anyFailed) status = 207;
+
+  return {
+    status,
+    body: { data: { targets, configured, errors, skillInstalled } },
+  };
+}
+
+export function makeSetupHandler(opts: { token?: string }): Handler {
+  return async (_req: Request, res: Response) => {
+    try {
+      const result = await runSetupHandler(
+        (_req.body ?? {}) as Record<string, unknown>,
+        undefined,
+        opts.token,
+      );
+      res.status(result.status).json(result.body);
+    } catch (err: unknown) {
+      console.error("[Tandem] Setup handler threw:", err);
+      res.status(500).json({
+        error: "INTERNAL",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+}

--- a/src/server/mcp/routes/setup.ts
+++ b/src/server/mcp/routes/setup.ts
@@ -100,10 +100,10 @@ export async function runSetupHandler(
 }
 
 export function makeSetupHandler(opts: { token?: string }): Handler {
-  return async (_req: Request, res: Response) => {
+  return async (req: Request, res: Response) => {
     try {
       const result = await runSetupHandler(
-        (_req.body ?? {}) as Record<string, unknown>,
+        (req.body ?? {}) as Record<string, unknown>,
         undefined,
         opts.token,
       );

--- a/src/server/mcp/routes/setup.ts
+++ b/src/server/mcp/routes/setup.ts
@@ -6,7 +6,7 @@ import {
   detectTargets,
   installSkill,
 } from "../../../cli/setup.js";
-import type { Handler } from "../api-routes.js";
+import type { Handler } from "./_shared.js";
 import { isValidChannelPath, isValidNodeBinary } from "./_shared.js";
 
 interface SetupResult {

--- a/src/server/mcp/routes/upload.ts
+++ b/src/server/mcp/routes/upload.ts
@@ -1,0 +1,31 @@
+import type { Request, Response } from "express";
+import type { Handler } from "../api-routes.js";
+import { detectFormat } from "../document-model.js";
+import { openFileFromContent } from "../file-opener.js";
+import { sendApiError } from "./_shared.js";
+
+export function makeUploadHandler(): Handler {
+  return async (req: Request, res: Response) => {
+    const { fileName, content } = (req.body ?? {}) as Record<string, unknown>;
+    if (!fileName || typeof fileName !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "fileName is required" });
+      return;
+    }
+    if (content === undefined || content === null) {
+      res.status(400).json({ error: "BAD_REQUEST", message: "content is required" });
+      return;
+    }
+    if (typeof content !== "string") {
+      res.status(400).json({ error: "BAD_REQUEST", message: "content must be a base64 string" });
+      return;
+    }
+    try {
+      const format = detectFormat(fileName);
+      const decoded = format === "docx" ? Buffer.from(content, "base64") : String(content);
+      const result = await openFileFromContent(fileName, decoded);
+      res.json({ data: result });
+    } catch (err: unknown) {
+      sendApiError(res, err);
+    }
+  };
+}

--- a/src/server/mcp/routes/upload.ts
+++ b/src/server/mcp/routes/upload.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
-import type { Handler } from "../api-routes.js";
 import { detectFormat } from "../document-model.js";
 import { openFileFromContent } from "../file-opener.js";
+import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
 export function makeUploadHandler(): Handler {


### PR DESCRIPTION
## Summary

- Extracts 11 route handlers from `api-routes.ts` (584 LOC -> 143 LOC) into focused files under `src/server/mcp/routes/`
- Each handler is a factory function in its own file — stateless handlers export `makeXxxHandler()` (no params); stateful handlers (`makeSetupHandler`, `makeRotateTokenHandler`) take an options object with required dependencies
- Error utilities and validation functions moved to `routes/_shared.ts`, eliminating potential circular imports
- All existing test imports preserved via re-exports -- zero test file changes
- Audit finding #4

## Details

**New files:** 12 under `src/server/mcp/routes/`:
- `_shared.ts` -- `sendApiError`, `errorCodeToHttpStatus`, `isValidNodeBinary`, `isValidChannelPath`, `Handler` type
- `open.ts`, `close.ts`, `save.ts`, `upload.ts`, `convert.ts`, `mode.ts`, `apply-changes.ts`, `setup.ts`, `annotation-reply.ts`, `rotate-token.ts`, `notify-stream.ts`

**`api-routes.ts` retains:** `isHostAllowed`, `isLocalhostOrigin`, `LOCALHOST_ORIGIN_RE`, `createApiMiddleware`, `apiMiddleware`, and the `registerApiRoutes` orchestrator (plus re-exports for test compatibility).

**Import graph is a clean DAG** -- no circular dependencies. Validators live in `_shared.ts` (not `api-routes.ts`) so `routes/setup.ts` imports them without creating a cycle.

## Factory pattern

Two shapes:
- **Stateless:** `export function makeXxxHandler(): Handler` — used by handlers that don't need runtime-injected state. Example: `makeOpenHandler`, `makeSaveHandler`.
- **Stateful:** `export function makeXxxHandler(opts: {...}): Handler` — used by `makeSetupHandler({ token })` and `makeRotateTokenHandler({ setCurrentToken, getCurrentToken })`, which need token state passed from the server bootstrap.

## Test plan

- [x] `npm run typecheck` -- zero errors
- [x] `npm test` -- all existing tests pass unchanged (api-middleware, setup-api, setup-route)
- [x] `npm run build:server` -- production bundles build successfully
- [ ] `npm run test:e2e` -- end-to-end smoke test

Generated with [Claude Code](https://claude.com/claude-code)

Closes audit finding #4
