### PR TITLE
refactor(server): extract file-opener helpers, add lifecycle tests

### DIFF
--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -80,7 +80,6 @@ export interface OpenFileResult {
 interface ResolvedPath {
   resolved: string;
   format: string;
-  isDocx: boolean;
   readOnly: boolean;
   id: string;
 }
@@ -248,7 +247,7 @@ async function resolveAndValidatePath(filePath: string): Promise<ResolvedPath> {
   const readOnly = isDocx;
   const id = docIdFromPath(resolved);
 
-  return { resolved, format, isDocx, readOnly, id };
+  return { resolved, format, readOnly, id };
 }
 
 /**

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -76,6 +76,15 @@ export interface OpenFileResult {
   warnings?: string[];
 }
 
+/** Resolved + validated path metadata for openFileByPath. stat is NOT included — only used for the size check. */
+interface ResolvedPath {
+  resolved: string;
+  format: string;
+  isDocx: boolean;
+  readOnly: boolean;
+  id: string;
+}
+
 /**
  * Open a file by its absolute path on disk.
  * Throws on errors (ENOENT, EACCES, EBUSY, etc.) — caller maps to MCP or HTTP responses.
@@ -85,130 +94,46 @@ export async function openFileByPath(
   filePath: string,
   options?: { force?: boolean },
 ): Promise<OpenFileResult> {
-  let resolved = path.resolve(filePath);
-  try {
-    resolved = fsSync.realpathSync(resolved);
-  } catch (err: unknown) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code !== "ENOENT") {
-      console.error(
-        `[Tandem] realpathSync failed for ${filePath} (${code}), using path.resolve fallback`,
-      );
-    }
-    resolved = path.resolve(filePath);
-  }
-
-  if (process.platform === "win32" && (resolved.startsWith("\\\\") || resolved.startsWith("//"))) {
-    throw Object.assign(new Error("UNC paths are not supported for security reasons."), {
-      code: "INVALID_PATH",
-    });
-  }
-
-  const ext = path.extname(resolved).toLowerCase();
-  if (!SUPPORTED_EXTENSIONS.has(ext)) {
-    throw Object.assign(
-      new Error(
-        `Unsupported file format: ${ext}. Supported: ${[...SUPPORTED_EXTENSIONS].join(", ")}`,
-      ),
-      { code: "UNSUPPORTED_FORMAT" },
-    );
-  }
-
-  const stat = await fs.stat(resolved);
-  if (stat.size > MAX_FILE_SIZE) {
-    throw Object.assign(new Error("File exceeds 50MB limit."), { code: "FILE_TOO_LARGE" });
-  }
-
-  const format = detectFormat(resolved);
-  const isDocx = format === "docx";
-  const readOnly = isDocx;
-  const id = docIdFromPath(resolved);
-  const openDocs = getOpenDocs();
-
-  // Already open — force-reload from disk or switch to it
-  const existing = openDocs.get(id);
-  const forceReload = existing && options?.force === true;
-  if (existing && !forceReload) {
-    setActiveDocId(id);
-    broadcastOpenDocs();
-    const doc = getOrCreateDocument(id);
-    return {
-      ...buildResult(doc, {
-        documentId: id,
-        filePath: resolved,
-        fileName: path.basename(resolved),
-        format,
-        readOnly,
-        source: "file",
-        restoredFromSession: false,
-      }),
-      alreadyOpen: true,
-    };
-  }
-
-  if (forceReload) {
-    const doc = getDocument(id) ?? getOrCreateDocument(id);
-    const fileName = path.basename(resolved);
-    await clearAndReload(id, doc, resolved, format, existing);
-
-    addDoc(id, { id, filePath: resolved, format, readOnly, source: "file" });
-    setActiveDocId(id);
-    await wireAnnotationStore(id, doc, resolved);
-    broadcastOpenDocs();
-    ensureAutoSave();
-
-    return {
-      ...buildResult(doc, {
-        documentId: id,
-        filePath: resolved,
-        fileName,
-        format,
-        readOnly,
-        source: "file",
-        restoredFromSession: false,
-      }),
-      forceReloaded: true,
-    };
-  }
-
-  const doc = getOrCreateDocument(id);
+  const { resolved, format, readOnly, id } = await resolveAndValidatePath(filePath);
   const fileName = path.basename(resolved);
-  let restoredFromSession = false;
+  const openDocs = getOpenDocs();
+  const existing = openDocs.get(id);
 
-  const session = await loadSession(resolved);
-  if (session) {
-    const changed = await sourceFileChanged(session);
-    if (!changed) {
-      restoreYDoc(doc, session);
-      const fragment = doc.getXmlFragment("default");
-      if (fragment.length > 0) {
-        restoredFromSession = true;
-      } else {
-        console.error(
-          `[Tandem] Session restore yielded empty doc for ${fileName}, falling back to source file`,
-        );
-      }
+  // Already open — force-reload or switch to existing
+  if (existing) {
+    const forceReload = options?.force === true;
+    if (forceReload) {
+      // Force-reload stays inline — distinct lifecycle from normal open
+      const doc = getDocument(id) ?? getOrCreateDocument(id);
+      await clearAndReload(id, doc, resolved, format, existing);
+      addDoc(id, { id, filePath: resolved, format, readOnly, source: "file" });
+      setActiveDocId(id);
+      await wireAnnotationStore(id, doc, resolved);
+      broadcastOpenDocs();
+      ensureAutoSave();
+      return {
+        ...buildResult(doc, {
+          documentId: id,
+          filePath: resolved,
+          fileName,
+          format,
+          readOnly,
+          source: "file",
+          restoredFromSession: false,
+        }),
+        forceReloaded: true,
+      };
     }
+    return handleAlreadyOpen(id, getOrCreateDocument(id), format, resolved, readOnly);
   }
 
+  // Normal open
+  const doc = getOrCreateDocument(id);
+  const restoredFromSession = await maybeRestoreSession(resolved, doc, fileName);
   if (!restoredFromSession) {
-    const adapter = getAdapter(format);
-    const fileContent = isDocx ? await fs.readFile(resolved) : await fs.readFile(resolved, "utf-8");
-    await adapter.load(doc, fileContent);
+    await loadContentIntoDoc(doc, format, resolved);
   }
-
-  addDoc(id, { id, filePath: resolved, format, readOnly, source: "file" });
-  setActiveDocId(id);
-  writeDocMeta(doc, id, fileName, format, readOnly);
-  await initSavedBaseline(doc, resolved);
-  await wireAnnotationStore(id, doc, resolved);
-  broadcastOpenDocs();
-  ensureAutoSave();
-
-  // Watch for external file changes (skip .docx — binary format, no live reload)
-  if (format !== "docx") {
-    wireFileWatcher(id, resolved, format);
-  }
+  await finalizeDocOpen(id, doc, resolved, fileName, format, readOnly);
 
   return {
     ...buildResult(doc, {
@@ -274,6 +199,151 @@ export async function openFileFromContent(
     source: "upload",
     restoredFromSession: false,
   });
+}
+
+// --- Extracted helpers for openFileByPath ---
+
+/**
+ * Resolve a raw file path to its canonical form, validate it (UNC check,
+ * extension check, size limit), derive format / readOnly / doc ID.
+ * stat is used only for the size check and is not returned.
+ */
+async function resolveAndValidatePath(filePath: string): Promise<ResolvedPath> {
+  let resolved = path.resolve(filePath);
+  try {
+    resolved = fsSync.realpathSync(resolved);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      console.error(
+        `[Tandem] realpathSync failed for ${filePath} (${code}), using path.resolve fallback`,
+      );
+    }
+    resolved = path.resolve(filePath);
+  }
+
+  if (process.platform === "win32" && (resolved.startsWith("\\\\") || resolved.startsWith("//"))) {
+    throw Object.assign(new Error("UNC paths are not supported for security reasons."), {
+      code: "INVALID_PATH",
+    });
+  }
+
+  const ext = path.extname(resolved).toLowerCase();
+  if (!SUPPORTED_EXTENSIONS.has(ext)) {
+    throw Object.assign(
+      new Error(
+        `Unsupported file format: ${ext}. Supported: ${[...SUPPORTED_EXTENSIONS].join(", ")}`,
+      ),
+      { code: "UNSUPPORTED_FORMAT" },
+    );
+  }
+
+  const stat = await fs.stat(resolved);
+  if (stat.size > MAX_FILE_SIZE) {
+    throw Object.assign(new Error("File exceeds 50MB limit."), { code: "FILE_TOO_LARGE" });
+  }
+
+  const format = detectFormat(resolved);
+  const isDocx = format === "docx";
+  const readOnly = isDocx;
+  const id = docIdFromPath(resolved);
+
+  return { resolved, format, isDocx, readOnly, id };
+}
+
+/**
+ * Handle the non-force already-open branch: activate the doc and broadcast.
+ * This is the only place that sets alreadyOpen: true in the return value.
+ */
+function handleAlreadyOpen(
+  id: string,
+  doc: Y.Doc,
+  format: string,
+  resolved: string,
+  readOnly: boolean,
+): OpenFileResult {
+  setActiveDocId(id);
+  broadcastOpenDocs();
+  return {
+    ...buildResult(doc, {
+      documentId: id,
+      filePath: resolved,
+      fileName: path.basename(resolved),
+      format,
+      readOnly,
+      source: "file",
+      restoredFromSession: false,
+    }),
+    alreadyOpen: true,
+  };
+}
+
+/**
+ * Attempt to restore a Y.Doc from a saved session.
+ * Returns true ONLY if the session was restored AND the fragment is non-empty.
+ * Returns false if no session exists, the source file has changed, or the
+ * restored fragment is empty (falls back to loading from source file).
+ */
+async function maybeRestoreSession(
+  resolved: string,
+  doc: Y.Doc,
+  fileName: string,
+): Promise<boolean> {
+  const session = await loadSession(resolved);
+  if (session) {
+    const changed = await sourceFileChanged(session);
+    if (!changed) {
+      restoreYDoc(doc, session);
+      const fragment = doc.getXmlFragment("default");
+      if (fragment.length > 0) {
+        return true;
+      }
+      console.error(
+        `[Tandem] Session restore yielded empty doc for ${fileName}, falling back to source file`,
+      );
+    }
+  }
+  return false;
+}
+
+/**
+ * Load file content from disk into the Y.Doc using the appropriate adapter.
+ * Reads as Buffer for docx, utf-8 string for all other formats.
+ */
+async function loadContentIntoDoc(doc: Y.Doc, format: string, resolved: string): Promise<void> {
+  const adapter = getAdapter(format);
+  const isDocx = format === "docx";
+  const fileContent = isDocx ? await fs.readFile(resolved) : await fs.readFile(resolved, "utf-8");
+  await adapter.load(doc, fileContent);
+}
+
+/**
+ * Finalize a normal (non-force) document open: register in open-docs map,
+ * set active, write metadata, init saved baseline, wire annotation store,
+ * broadcast, start auto-save, and (for non-docx) set up the file watcher.
+ *
+ * NOTE: openFileFromContent has a similar finalization sequence — keep them in sync.
+ */
+async function finalizeDocOpen(
+  id: string,
+  doc: Y.Doc,
+  resolved: string,
+  fileName: string,
+  format: string,
+  readOnly: boolean,
+): Promise<void> {
+  addDoc(id, { id, filePath: resolved, format, readOnly, source: "file" });
+  setActiveDocId(id);
+  writeDocMeta(doc, id, fileName, format, readOnly);
+  await initSavedBaseline(doc, resolved);
+  await wireAnnotationStore(id, doc, resolved);
+  broadcastOpenDocs();
+  ensureAutoSave();
+
+  // Watch for external file changes (skip .docx — binary format, no live reload)
+  if (format !== "docx") {
+    wireFileWatcher(id, resolved, format);
+  }
 }
 
 // --- Private helpers ---

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -321,7 +321,9 @@ async function loadContentIntoDoc(doc: Y.Doc, format: string, resolved: string):
  * set active, write metadata, init saved baseline, wire annotation store,
  * broadcast, start auto-save, and (for non-docx) set up the file watcher.
  *
- * NOTE: openFileFromContent has a similar finalization sequence — keep them in sync.
+ * NOTE: openFileFromContent follows a similar sequence but intentionally omits
+ * wireFileWatcher and calls initSavedBaseline without a path argument (upload
+ * path — no mtime tracking). These divergences are intentional, not drift.
  */
 async function finalizeDocOpen(
   id: string,

--- a/tests/server/file-opener-lifecycle.test.ts
+++ b/tests/server/file-opener-lifecycle.test.ts
@@ -1,0 +1,180 @@
+import fsSync from "fs";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+
+// vi.mock factories are hoisted before module-level code, so outer `const`s
+// are not accessible inside them. All paths must be computed inline using
+// dynamic import() inside the factory.
+
+vi.mock("../../src/server/platform", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/server/platform")>();
+  const osMod = await import("os");
+  const pathMod = await import("path");
+  const cryptoMod = await import("crypto");
+  // Use a unique subdir under the system temp dir for both sessions and
+  // app-data (annotations). Set the env var here so resolveAppDataDir()
+  // returns the isolated dir for the lifetime of this test file.
+  const appDataDir = pathMod.join(
+    osMod.tmpdir(),
+    `tandem-test-lifecycle-${cryptoMod.randomUUID()}`,
+  );
+  process.env.TANDEM_APP_DATA_DIR = appDataDir;
+  return {
+    ...original,
+    SESSION_DIR: pathMod.join(appDataDir, "sessions"),
+  };
+});
+
+// Mock file-watcher so tests can assert watchFile calls without starting real fs.watch.
+vi.mock("../../src/server/file-watcher", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/server/file-watcher")>()),
+  watchFile: vi.fn(),
+}));
+
+import * as queueModule from "../../src/server/events/queue.js";
+import { watchFile } from "../../src/server/file-watcher.js";
+import { getOpenDocs, removeDoc, setActiveDocId } from "../../src/server/mcp/document-service.js";
+import { openFileByPath } from "../../src/server/mcp/file-opener.js";
+import { saveSession } from "../../src/server/session/manager.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  // Clear open docs state from prior tests
+  for (const id of [...getOpenDocs().keys()]) {
+    removeDoc(id);
+  }
+  setActiveDocId(null);
+  vi.clearAllMocks();
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tandem-lifecycle-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+});
+
+// ---------------------------------------------------------------------------
+// Test 1: Session restore hit
+// ---------------------------------------------------------------------------
+describe("session restore — hit", () => {
+  it("restores from session when source file is unchanged", async () => {
+    const filePath = path.join(tmpDir, "restore-hit.md");
+    await fs.writeFile(filePath, "# Original content");
+
+    // First open — populates Y.Doc and registers in open-docs
+    const first = await openFileByPath(filePath);
+    expect(first.restoredFromSession).toBe(false);
+
+    // Save session state so it's available on next open
+    const doc = getOrCreateDocument(first.documentId);
+    await saveSession(filePath, "md", doc);
+
+    // Close the doc
+    removeDoc(first.documentId);
+    setActiveDocId(null);
+
+    // Reopen — should restore from session (file unchanged)
+    const second = await openFileByPath(filePath);
+    expect(second.restoredFromSession).toBe(true);
+    expect(second.documentId).toBe(first.documentId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Session stale mtime
+// ---------------------------------------------------------------------------
+describe("session restore — stale mtime", () => {
+  it("falls back to source file when file has been modified after session save", async () => {
+    const filePath = path.join(tmpDir, "restore-stale.md");
+    await fs.writeFile(filePath, "# Original content");
+
+    const first = await openFileByPath(filePath);
+    const doc = getOrCreateDocument(first.documentId);
+    await saveSession(filePath, "md", doc);
+
+    removeDoc(first.documentId);
+    setActiveDocId(null);
+
+    // Rewrite the file after saving session — this bumps mtime past the session timestamp
+    await new Promise((r) => setTimeout(r, 20));
+    await fs.writeFile(filePath, "# New content after save");
+
+    const second = await openFileByPath(filePath);
+    expect(second.restoredFromSession).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: Session empty fragment
+// ---------------------------------------------------------------------------
+describe("session restore — empty fragment", () => {
+  it("falls back to source file when saved session has an empty fragment", async () => {
+    const filePath = path.join(tmpDir, "restore-empty.md");
+    await fs.writeFile(filePath, "# Has real content");
+
+    // Save a session from an empty Y.Doc — no content in the XmlFragment
+    const emptyDoc = new Y.Doc();
+    await saveSession(filePath, "md", emptyDoc);
+
+    // Open — should detect fragment.length === 0 and fall back to source file
+    const result = await openFileByPath(filePath);
+    expect(result.restoredFromSession).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: Annotation wiring (setFileSyncContext called)
+// ---------------------------------------------------------------------------
+describe("annotation wiring", () => {
+  it("calls setFileSyncContext with the document id on open", async () => {
+    const spy = vi.spyOn(queueModule, "setFileSyncContext");
+
+    const filePath = path.join(tmpDir, "annotation-wire.md");
+    await fs.writeFile(filePath, "# Annotation wiring test");
+
+    const result = await openFileByPath(filePath);
+
+    expect(spy).toHaveBeenCalled();
+    const firstCallArgs = spy.mock.calls[0];
+    expect(firstCallArgs[0]).toBe(result.documentId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: File-watcher wired for .md
+// ---------------------------------------------------------------------------
+describe("file-watcher — .md", () => {
+  it("calls watchFile with the resolved path for a markdown file", async () => {
+    const filePath = path.join(tmpDir, "watch-md.md");
+    await fs.writeFile(filePath, "# Watch test");
+
+    await openFileByPath(filePath);
+
+    const mockWatchFile = vi.mocked(watchFile);
+    expect(mockWatchFile).toHaveBeenCalled();
+    // First argument should be the canonically resolved file path
+    const calledPath = mockWatchFile.mock.calls[0][0];
+    expect(calledPath).toBe(fsSync.realpathSync(filePath));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: File-watcher NOT wired for .docx
+// ---------------------------------------------------------------------------
+describe("file-watcher — .docx skip", () => {
+  it("does not call watchFile for a .docx file", async () => {
+    // Copy a real minimal docx from mammoth's test fixtures (ships with node_modules)
+    const sourceDocx = path.resolve("node_modules/mammoth/test/test-data/single-paragraph.docx");
+    const filePath = path.join(tmpDir, "watch-docx.docx");
+    await fs.copyFile(sourceDocx, filePath);
+
+    await openFileByPath(filePath);
+
+    const mockWatchFile = vi.mocked(watchFile);
+    expect(mockWatchFile).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server/file-opener-lifecycle.test.ts
+++ b/tests/server/file-opener-lifecycle.test.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as Y from "yjs";
+import { makeEmptyDoc } from "../helpers/ydoc-factory.js";
 
 // vi.mock factories are hoisted before module-level code, so outer `const`s
 // are not accessible inside them. All paths must be computed inline using
@@ -117,7 +117,7 @@ describe("session restore — empty fragment", () => {
     await fs.writeFile(filePath, "# Has real content");
 
     // Save a session from an empty Y.Doc — no content in the XmlFragment
-    const emptyDoc = new Y.Doc();
+    const emptyDoc = makeEmptyDoc();
     await saveSession(filePath, "md", emptyDoc);
 
     // Open — should detect fragment.length === 0 and fall back to source file

--- a/tests/server/file-opener-lifecycle.test.ts
+++ b/tests/server/file-opener-lifecycle.test.ts
@@ -105,9 +105,11 @@ describe("session restore — stale mtime", () => {
     removeDoc(first.documentId);
     setActiveDocId(null);
 
-    // Rewrite the file after saving session — this bumps mtime past the session timestamp
-    await new Promise((r) => setTimeout(r, 20));
+    // Rewrite the file and explicitly bump mtime so the change is detected regardless
+    // of filesystem mtime resolution (Windows coarse-grained on older disks, etc).
     await fs.writeFile(filePath, "# New content after save");
+    const futureMtime = new Date(Date.now() + 10_000);
+    await fs.utimes(filePath, new Date(), futureMtime);
 
     const second = await openFileByPath(filePath);
     expect(second.restoredFromSession).toBe(false);
@@ -172,15 +174,109 @@ describe("file-watcher — .md", () => {
 // Test 6: File-watcher NOT wired for .docx
 // ---------------------------------------------------------------------------
 describe("file-watcher — .docx skip", () => {
-  it("does not call watchFile for a .docx file", async () => {
+  it("does not call watchFile for a .docx file and loads its content", async () => {
     // Copy a real minimal docx from mammoth's test fixtures (ships with node_modules)
     const sourceDocx = path.resolve("node_modules/mammoth/test/test-data/single-paragraph.docx");
     const filePath = path.join(tmpDir, "watch-docx.docx");
     await fs.copyFile(sourceDocx, filePath);
 
-    await openFileByPath(filePath);
+    const result = await openFileByPath(filePath);
 
     const mockWatchFile = vi.mocked(watchFile);
     expect(mockWatchFile).not.toHaveBeenCalled();
+
+    // Content assertion — docx goes through the Buffer adapter branch; a
+    // non-empty fragment proves that path works end-to-end. If the branch
+    // ever accidentally fell through to utf-8 readFile, the docx parser
+    // would choke and the fragment would be empty.
+    const doc = getOrCreateDocument(result.documentId);
+    expect(doc.getXmlFragment("default").length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 7: Already-open branch
+// ---------------------------------------------------------------------------
+describe("already-open branch", () => {
+  it("returns alreadyOpen:true on second open without force and does not re-wire watcher", async () => {
+    const filePath = path.join(tmpDir, "already-open.md");
+    await fs.writeFile(filePath, "# Already open test");
+
+    const first = await openFileByPath(filePath);
+    expect(first.alreadyOpen).toBe(false);
+
+    const mockWatchFile = vi.mocked(watchFile);
+    expect(mockWatchFile.mock.calls.length).toBe(1);
+
+    // Reopen without force — must hit the handleAlreadyOpen branch
+    const second = await openFileByPath(filePath);
+    expect(second.alreadyOpen).toBe(true);
+    expect(second.documentId).toBe(first.documentId);
+    expect(second.forceReloaded).toBe(false);
+    expect(second.restoredFromSession).toBe(false);
+
+    // Key invariant: the already-open branch must NOT re-wire the watcher.
+    // If it did, every reopen would leak a watcher handle.
+    expect(mockWatchFile.mock.calls.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 8: Force-reload branch
+// ---------------------------------------------------------------------------
+describe("force-reload branch", () => {
+  it("returns forceReloaded:true and does not re-wire the file watcher", async () => {
+    const filePath = path.join(tmpDir, "force-reload.md");
+    await fs.writeFile(filePath, "# First content");
+
+    const first = await openFileByPath(filePath);
+    expect(first.forceReloaded).toBe(false);
+
+    const mockWatchFile = vi.mocked(watchFile);
+    expect(mockWatchFile.mock.calls.length).toBe(1);
+
+    // Modify the file on disk so the reload has observable content
+    await fs.writeFile(filePath, "# Second content");
+
+    const second = await openFileByPath(filePath, { force: true });
+    expect(second.forceReloaded).toBe(true);
+    expect(second.alreadyOpen).toBe(false);
+    expect(second.documentId).toBe(first.documentId);
+
+    // Force-reload intentionally skips wireFileWatcher (comment at file-opener.ts
+    // force-reload branch). The original watcher from the first open stays live.
+    expect(mockWatchFile.mock.calls.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 9: Unsupported extension
+// ---------------------------------------------------------------------------
+describe("resolveAndValidatePath — unsupported extension", () => {
+  it("throws UNSUPPORTED_FORMAT for a file with an unsupported extension", async () => {
+    const filePath = path.join(tmpDir, "bad.xyz");
+    await fs.writeFile(filePath, "some content");
+
+    await expect(openFileByPath(filePath)).rejects.toMatchObject({
+      code: "UNSUPPORTED_FORMAT",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 10: Oversized file
+// ---------------------------------------------------------------------------
+describe("resolveAndValidatePath — oversized file", () => {
+  it("throws FILE_TOO_LARGE for a file exceeding the 50MB limit", async () => {
+    const MAX_FILE_SIZE = 50 * 1024 * 1024;
+    const filePath = path.join(tmpDir, "too-big.md");
+    // Sparse-file trick: create empty, then truncate to 51MB. NTFS/ext4 both
+    // allocate as sparse, so this is O(1) regardless of reported size.
+    await fs.writeFile(filePath, "");
+    await fs.truncate(filePath, MAX_FILE_SIZE + 1);
+
+    await expect(openFileByPath(filePath)).rejects.toMatchObject({
+      code: "FILE_TOO_LARGE",
+    });
   });
 });

--- a/tests/server/file-opener-lifecycle.test.ts
+++ b/tests/server/file-opener-lifecycle.test.ts
@@ -57,6 +57,11 @@ afterEach(async () => {
   await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
 });
 
+afterAll(async () => {
+  const appDataDir = process.env.TANDEM_APP_DATA_DIR;
+  if (appDataDir) await fs.rm(appDataDir, { recursive: true, force: true }).catch(() => {});
+});
+
 // ---------------------------------------------------------------------------
 // Test 1: Session restore hit
 // ---------------------------------------------------------------------------

--- a/tests/server/file-opener-lifecycle.test.ts
+++ b/tests/server/file-opener-lifecycle.test.ts
@@ -2,7 +2,7 @@ import fsSync from "fs";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeEmptyDoc } from "../helpers/ydoc-factory.js";
 
 // vi.mock factories are hoisted before module-level code, so outer `const`s
@@ -60,6 +60,7 @@ afterEach(async () => {
 afterAll(async () => {
   const appDataDir = process.env.TANDEM_APP_DATA_DIR;
   if (appDataDir) await fs.rm(appDataDir, { recursive: true, force: true }).catch(() => {});
+  delete process.env.TANDEM_APP_DATA_DIR;
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extracts 5 private helpers from `openFileByPath()` (141 LOC -> ~55 LOC orchestrator), all staying in `file-opener.ts`
- Adds `tests/server/file-opener-lifecycle.test.ts` with 6 test cases covering previously untested lifecycle paths
- Zero export or behavioral changes
- Audit findings #3 and #11

## Details

**Extracted helpers** (private, same file):
- `resolveAndValidatePath` -- path resolution, UNC rejection, extension/size validation, format detection
- `handleAlreadyOpen` -- non-force already-open branch (owns `alreadyOpen: true`)
- `maybeRestoreSession` -- session load, mtime check, restore with empty-fragment fallback
- `loadContentIntoDoc` -- adapter-based file loading
- `finalizeDocOpen` -- doc registration, metadata, annotation wiring, file-watcher setup

**New lifecycle tests** (finding #11 -- previously untested):
1. Session restore hit (matching mtime)
2. Session stale mtime (falls back to source file)
3. Session empty fragment (falls back to source file)
4. Annotation wiring (`setFileSyncContext` called via `vi.spyOn`)
5. File-watcher wired for `.md`
6. File-watcher skipped for `.docx`

**Not changed:** `openFileFromContent`, `clearAndReload`, `reloadFromDisk`, all existing private helpers. A cross-reference comment in `finalizeDocOpen` notes that `openFileFromContent` has a similar finalization sequence.

## Test plan

- [x] `npm run typecheck` -- zero errors
- [x] `npm test` -- all existing tests pass + 6 new lifecycle tests pass
- [x] `npm run build:server` -- production bundles build successfully
- [ ] `npm run test:e2e` -- end-to-end smoke test

Generated with [Claude Code](https://claude.com/claude-code)

Closes audit findings #3, #11
