### PR TITLE
fix(ci): sort imports to fix biome check failures on all open PRs

### DIFF
--- a/src/channel/event-bridge.ts
+++ b/src/channel/event-bridge.ts
@@ -4,10 +4,10 @@
  */
 
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import type { TandemEvent } from "../shared/events/types.js";
-import { formatEventContent, formatEventMeta, parseTandemEvent } from "../shared/events/types.js";
 import { authFetch } from "../shared/cli-runtime.js";
 import { CHANNEL_MAX_RETRIES, CHANNEL_RETRY_DELAY_MS } from "../shared/constants.js";
+import type { TandemEvent } from "../shared/events/types.js";
+import { formatEventContent, formatEventMeta, parseTandemEvent } from "../shared/events/types.js";
 
 const AWARENESS_DEBOUNCE_MS = 500;
 const MODE_CACHE_TTL_MS = 2000;

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -20,8 +20,6 @@
 
 import { resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { TandemEvent } from "../shared/events/types.js";
-import { formatEventContent, parseTandemEvent } from "../shared/events/types.js";
 import { authFetch } from "../shared/cli-runtime.js";
 import {
   CHANNEL_MAX_RETRIES,
@@ -29,6 +27,8 @@ import {
   DEFAULT_MCP_PORT,
   TANDEM_MODE_DEFAULT,
 } from "../shared/constants.js";
+import type { TandemEvent } from "../shared/events/types.js";
+import { formatEventContent, parseTandemEvent } from "../shared/events/types.js";
 import { type TandemMode, TandemModeSchema } from "../shared/types.js";
 
 const IS_VITEST = process.env.VITEST === "true";

--- a/src/shared/auth/token-file.ts
+++ b/src/shared/auth/token-file.ts
@@ -1,6 +1,6 @@
+import envPaths from "env-paths";
 import fs from "fs";
 import path from "path";
-import envPaths from "env-paths";
 import { TOKEN_FILE_NAME } from "../constants.js";
 
 export function getTokenFilePath(): string {


### PR DESCRIPTION
## Summary

- Fixes the failing `check` CI job that was blocking PRs #391 and #392 (and any future PRs based on current master)
- Reorders imports in 3 files to satisfy `npx biome check .`'s `organizeImports` rule

## Root cause analysis

Two recently merged PRs introduced unsorted import statements:

| File | Introduced by |
|---|---|
| `src/channel/event-bridge.ts` | PR #384 (wire-protocol types to shared layer) |
| `src/monitor/index.ts` | PR #384 (wire-protocol types to shared layer) |
| `src/shared/auth/token-file.ts` | PR #385 (token store shared extraction) |

In each file, the newly added `../shared/events/types.js` or `env-paths` imports were inserted out of alphabetical order relative to adjacent imports, causing `npx biome check .` to fail with 3 `assist/source/organizeImports` errors. Since this was in master, every subsequent PR inherited the broken CI.

## Fix

`npx biome check --write` on the 3 files — pure import reordering, zero behavioral change.

## About the separate `CodeQL` check failure

Both PRs #391 and #392 also show a `CodeQL` check failing with `conclusion: failure` (completing in ~2 seconds). This check:
- Is posted by GitHub's Code Scanning GitHub App, not a workflow file
- Was `neutral` (non-blocking) on PR #388 but `failure` on PRs #391/#392
- Is separate from the `Analyze (javascript-typescript/rust/actions)` jobs which all succeed

This appears to be a GitHub Code Scanning enforcement change that started failing after the Phase 1 PRs (#384–#389) merged. Resolving it likely requires investigating open Code Scanning alerts in the repository's Security tab, or adjusting the "Alert severity causing PR check failure" setting under Settings → Code Security → Code scanning.

## Test plan

- [x] `npx biome check .` — 0 errors (235 files checked)
- [x] `npx tsc --noEmit -p tsconfig.client.json` — clean
- [x] `npx tsc --noEmit -p tsconfig.server.json` — clean
- [x] `npm test -- --run` — 1417 passing (2 chmod-based failures are root-only false positives, not CI regressions)

https://claude.ai/code/session_01X7gccCMMV3auKcMYwUo2Vw

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7gccCMMV3auKcMYwUo2Vw)_