### PR TITLE
refactor(server/events): split queue.ts into focused observer modules (Phase 3)

### DIFF
--- a/docs/phase-3-plan.md
+++ b/docs/phase-3-plan.md
@@ -1,0 +1,445 @@
+# Phase 3: Event Queue Observer Split
+
+## Context
+
+Tandem is at v0.7.1 heading toward v1.0. The pre-v1.0 codebase audit (`docs/audit-v1.md`, finding #5) identified `src/server/events/queue.ts` (602 LOC) as the most entangled server module: it owns five distinct Y.Map observer bodies, a circular event buffer, a per-document selection buffer shared across observer types, a file-sync context registry, and SSE subscriber management. Phase 1 (foundation cleanup, PRs #384–#389, merged 2026-04-22) and Phase 2 (server splits, PRs #391, #392, merged 2026-04-23) prepared the ground. Phase 3 is the audit's highest-risk refactor because it touches the two hardest CRDT correctness concerns in the server — Y.js transaction origin filtering and observer lifecycle across Hocuspocus doc swap.
+
+This refactor is **mechanical**: no behavioral change, no new event types, no Y.js origin-string changes, no `TandemEvent` shape changes. The safety net is the existing test suite:
+
+- `tests/server/event-queue.test.ts` — 1,124 LOC, ~44 test cases across 11 feature groups
+- `tests/server/event-queue-dwell.test.ts` — 207 LOC, ~12 cases
+- `tests/server/annotations/sync.test.ts` — 1,136 LOC, integrates `reattachObservers`
+- `tests/server/file-opener-lifecycle.test.ts` — spies `setFileSyncContext` (added in PR #392)
+
+**Effort:** ~1.5 days. **Single sequential PR**, one worktree agent.
+
+**Why single PR:** Not because the modules are inseparable — `origins.ts` + `file-sync-registry.ts` (Steps 1–2) and the five observer factories (Steps 3–7) are cleanly separable. A 2-PR split would add branch-cut, CI wait, review, merge, and branch-update overhead (~1–2 hours) for a ~1.5-day mechanical reshuffle where each of the 8 steps is individually checkpoint-verified. For a refactor where velocity matters and the test suite is the safety net, single-PR is the lower-overhead path. A 2-PR split would not reduce risk.
+
+**Branch:** `refactor/event-queue-observer-split`
+
+---
+
+## Target Structure
+
+```
+src/server/events/
+  origins.ts               (~12 LOC)   MCP_ORIGIN, FILE_SYNC_ORIGIN only
+  types.ts                 (existing)  + BufferedSelection type (new)
+  queue.ts                 (~170 LOC)  buffer, pushEvent, subscribe, replaySince,
+                                       selectionBuffer (owned), emittedPayloadIds,
+                                       attachObservers / detachObservers / reattachObservers,
+                                       attachCtrlObservers / reattachCtrlObservers,
+                                       resetForTesting, barrel re-exports
+  file-sync-registry.ts    (~110 LOC)  fileSyncContexts Map, safeCleanup,
+                                       setFileSyncContext, clearFileSyncContext,
+                                       reattachFileSyncObserver, resetForTesting (registry-scoped)
+  observers/
+    annotations.ts         (~85 LOC)   makeAnnotationsObserver
+    replies.ts             (~55 LOC)   makeRepliesObserver
+    awareness.ts           (~75 LOC)   makeAwarenessObserver, getDwellMs (private)
+    ctrl-chat.ts           (~85 LOC)   makeCtrlChatObserver
+    ctrl-meta.ts           (~80 LOC)   makeCtrlMetaObserver
+```
+
+LOC targets include imports, JSDoc, and `import type` lines. **Not a pass/fail gate.**
+
+**Naming note — `make*` not `create*`:** Phase 2 (PRs #391, #392) established `makeXxxHandler` for dep-injected factories returning closures (`makeOpenHandler`, `makeSetupHandler`, `makeNotifyStreamHandler`, etc.). Observers are the same pattern. Use `make*` consistently.
+
+**Naming note — `ctrl-chat.ts`, `ctrl-meta.ts`:** The `CTRL_ROOM` abbreviation is established (`shared/constants.ts`, `queue.ts`, `index.ts`). Add a one-line top-of-file JSDoc to both: `/** Observer for CTRL_ROOM's Y.Map('chat'). */` and `/** Observer for CTRL_ROOM's Y.Map('documentMeta'). */` — disambiguates from the keyboard modifier.
+
+---
+
+## Step 0 Architectural Note — Why `origins.ts` Exists
+
+There is a **latent import cycle today**:
+
+```
+queue.ts           ──imports──> registerAnnotationObserver, SyncContext, ObserverCleanupPhase
+                                   from annotations/sync.ts
+annotations/sync.ts ──imports──> FILE_SYNC_ORIGIN
+                                   from queue.ts
+```
+
+Verified: `src/server/annotations/sync.ts:61` reads `import { FILE_SYNC_ORIGIN } from "../events/queue.js";`. It works at runtime because both sides resolve at call time, but it is fragile. After this PR, `file-sync-registry.ts` owns the `registerAnnotationObserver` call site, so the cycle would become a 3-module chain (`queue → file-sync-registry → annotations/sync → queue`).
+
+**Fix in Step 1**, before any other extraction: create `src/server/events/origins.ts` holding only the two origin string constants. `annotations/sync.ts` imports directly from `origins.ts`. `queue.ts` re-exports both for backward compat. Cost: a ~12 LOC file. Benefit: a true DAG for the rest of Phase 3.
+
+---
+
+## New Shared Type: `BufferedSelection`
+
+Add to `src/server/events/types.ts`:
+
+```ts
+export type BufferedSelection = {
+  from: number;   // FlatOffset
+  to: number;     // FlatOffset
+  selectedText: string;
+};
+```
+
+The shape is currently duplicated inline at three sites in `queue.ts` (awareness observer writes, ctrl-chat observer reads, `getBufferedSelection` return type). After extraction it would be duplicated across three files. Extract the type so the three factory signatures and the `getBufferedSelection` return reference one canonical definition.
+
+This is in-scope because it touches only files this PR already modifies.
+
+---
+
+## Factory Signatures
+
+All five observer factories live in `src/server/events/observers/*.ts`, take a **struct**, and return a **plain `() => void` cleanup**. None uses the `(phase?: ObserverCleanupPhase) => void` shape — that belongs to `registerAnnotationObserver` in `annotations/sync.ts` (disk-persistence observer), called from `file-sync-registry.ts`. The channel-event observer for annotations (in `observers/annotations.ts`) is a distinct observer with no phase concern.
+
+```ts
+import type { BufferedSelection } from "../types.js";
+
+// observers/annotations.ts
+export function makeAnnotationsObserver(deps: {
+  docName: string;
+  doc: Y.Doc;
+  pushEvent: (e: TandemEvent) => void;
+}): () => void;
+
+// observers/replies.ts
+export function makeRepliesObserver(deps: {
+  docName: string;
+  doc: Y.Doc;
+  pushEvent: (e: TandemEvent) => void;
+}): () => void;
+
+// observers/awareness.ts
+export function makeAwarenessObserver(deps: {
+  docName: string;
+  doc: Y.Doc;
+  selectionBuffer: Map<string, BufferedSelection>;
+}): () => void;
+
+// observers/ctrl-chat.ts
+export function makeCtrlChatObserver(deps: {
+  ctrlDoc: Y.Doc;
+  pushEvent: (e: TandemEvent) => void;
+  selectionBuffer: Map<string, BufferedSelection>;
+}): () => void;
+
+// observers/ctrl-meta.ts
+export function makeCtrlMetaObserver(deps: {
+  ctrlDoc: Y.Doc;
+  pushEvent: (e: TandemEvent) => void;
+}): () => void;
+```
+
+**Why structs, not positional args:** Dependency sets are inhomogeneous. A shared positional shape would over-supply (`pushEvent` to observers that never call it) or require optional handling everywhere.
+
+**Why `pushEvent` is injected:** `queue.ts` remains sole owner of `buffer`, `subscribers`, and `emittedPayloadIds`. Observers emit via the injected function, which handles ref-counted dedup.
+
+**Why `selectionBuffer` is passed by reference:** Shared between awareness (producer) and chat (consumer). Keeping one Map in `queue.ts` passed by reference preserves single ownership and makes coupling explicit.
+
+**Where `ctrlDoc` comes from:** `attachCtrlObservers()` calls `getOrCreateDocument(CTRL_ROOM)` once at the top (current `queue.ts:442`), then passes the resulting `ctrlDoc` into both `makeCtrlChatObserver` and `makeCtrlMetaObserver`. Factories do NOT call `getOrCreateDocument` themselves.
+
+---
+
+## State Ownership Map
+
+| State | Owner file | Exposed via |
+|-------|------------|-------------|
+| `buffer`, `subscribers` | `queue.ts` | Internal. `pushEvent`, `subscribe`, `unsubscribe`, `replaySince` are the public surface. |
+| `emittedPayloadIds` (ref-counted dedup) | `queue.ts` | Mutated by `pushEvent` only (via `trackPayloadId` / `untrackPayloadId` on eviction). Read via `wasEmittedViaChannel`. |
+| `selectionBuffer: Map<string, BufferedSelection>` | `queue.ts` | Passed by reference to `makeAwarenessObserver` (writes) and `makeCtrlChatObserver` (reads + deletes). `getBufferedSelection` exported for tests. |
+| `docObservers` (per-doc cleanup registry) | `queue.ts` | Internal to `attachObservers` / `detachObservers` / `reattachObservers`. |
+| `ctrlCleanups` | `queue.ts` | Internal to `attachCtrlObservers` / `reattachCtrlObservers`. Plain `let` array (matches current pattern). |
+| `fileSyncContexts` Map, `safeCleanup` helper | `file-sync-registry.ts` | Public: `setFileSyncContext`, `clearFileSyncContext`, `reattachFileSyncObserver`. |
+| `ObserverCleanupPhase` type | Stays in `annotations/sync.ts`. | Imported by `file-sync-registry.ts` only. |
+| `getDwellMs()` | Private helper inside `observers/awareness.ts`. | Not exported. Only awareness calls it. |
+| `MCP_ORIGIN`, `FILE_SYNC_ORIGIN` | `origins.ts` | `queue.ts` re-exports both for backward compat. |
+| `EventCallback` type, `getTrackableId()` private fn | `queue.ts` | Internal; unchanged. |
+| `BufferedSelection` type | `src/server/events/types.ts` (new addition) | Imported by `queue.ts` and by `observers/awareness.ts` + `observers/ctrl-chat.ts`. |
+
+`queue.ts:reattachObservers(docName, newDoc)` calls `attachObservers(docName, newDoc)` then delegates the file-sync rebind via `reattachFileSyncObserver(docName, newDoc)` imported from `file-sync-registry.ts`.
+
+**`queue.ts:resetForTesting()` delegation contract** — match current behavior (`queue.ts:583-601`) exactly, plus delegate:
+
+```ts
+// queue.ts:resetForTesting — target shape
+export function resetForTesting(): void {
+  // 1. Clear data-only collections (observer cleanups don't touch these)
+  buffer.length = 0;
+  subscribers.clear();
+  emittedPayloadIds.clear();
+  selectionBuffer.clear();
+
+  // 2. Run per-doc observer cleanups, then clear the map that holds them
+  for (const cleanups of docObservers.values()) {
+    for (const cleanup of cleanups) cleanup();
+  }
+  docObservers.clear();
+
+  // 3. Run CTRL cleanups, then reset the array that holds them
+  for (const cleanup of ctrlCleanups) cleanup();
+  ctrlCleanups = [];
+
+  // 4. Delegate registry reset (CRITICAL — do not forget)
+  fileSyncRegistry.resetForTesting();
+}
+```
+
+**Why this order:** The four data-only collections (buffer, subscribers, emittedPayloadIds, selectionBuffer) are safe to clear first because observer cleanups never read or write them — cleanups only do `map.unobserve(handler)`. The critical ordering constraint is per-collection: cleanup iteration over a collection must precede `.clear()` on that same collection. That's what this target shape preserves.
+
+And `file-sync-registry.ts:resetForTesting()` **must include the try/catch cleanup loop** — not just `fileSyncContexts.clear()`:
+
+```ts
+// file-sync-registry.ts:resetForTesting — target shape
+export function resetForTesting(): void {
+  for (const entry of fileSyncContexts.values()) {
+    try { entry.cleanup("close"); } catch { /* swallow, matches queue.ts:596-599 defensive pattern */ }
+  }
+  fileSyncContexts.clear();
+}
+```
+
+Forgetting the try/catch loop leaks any in-flight tombstone debounces across tests; the failure would be silent (tests stay green) because `safeCleanup` inside the cleanup function already swallows errors. This is the most seductive trap in the migration.
+
+---
+
+## Import Graph (strict DAG)
+
+```
+origins.ts  ── (leaf; imports nothing from our modules)
+    ▲
+    │
+    ├── queue.ts ─────► observers/{annotations,replies,awareness,ctrl-chat,ctrl-meta}.ts
+    │       │           │
+    │       │           └── (yjs, shared/constants, shared/types, shared/sanitize,
+    │       │                types.ts for BufferedSelection)
+    │       │
+    │       └─────► file-sync-registry.ts ─────► annotations/sync.ts
+    │                                                  │
+    └── (annotations/sync.ts also imports origins.ts) ─┘
+```
+
+Checks:
+- `origins.ts` is a leaf.
+- `observers/*.ts` import only from `yjs` (npm package), `../../yjs/provider.js` (for `getOrCreateDocument` in `observers/awareness.ts`), `../../shared/*`, `../types.js`, and `../origins.js`. No observer imports from `queue.ts` or from other observers.
+- `file-sync-registry.ts` imports from `annotations/sync.ts`. It does **not** import from `queue.ts`.
+- `queue.ts` imports from `observers/*.ts` and `file-sync-registry.ts`. It does **not** import from `annotations/sync.ts` at all after this PR.
+- `annotations/sync.ts` imports from `origins.ts` only.
+
+**Result:** strict DAG.
+
+---
+
+## Re-export Barrel Contract
+
+External consumers import **15 symbols** from `src/server/events/queue.js`. Every one must resolve unchanged through the barrel.
+
+| Symbol | After split, physically lives in | Re-exported from `queue.ts`? |
+|--------|----------------------------------|------------------------------|
+| `MCP_ORIGIN` | `origins.ts` | Yes |
+| `FILE_SYNC_ORIGIN` | `origins.ts` | Yes |
+| `attachObservers` | `queue.ts` | (native) |
+| `detachObservers` | `queue.ts` | (native) |
+| `reattachObservers` | `queue.ts` | (native) |
+| `attachCtrlObservers` | `queue.ts` | (native) |
+| `reattachCtrlObservers` | `queue.ts` | (native) |
+| `setFileSyncContext` | `file-sync-registry.ts` | Yes |
+| `clearFileSyncContext` | `file-sync-registry.ts` | Yes |
+| `subscribe` | `queue.ts` | (native) |
+| `unsubscribe` | `queue.ts` | (native) |
+| `replaySince` | `queue.ts` | (native) |
+| `wasEmittedViaChannel` | `queue.ts` | (native) |
+| `getBufferedSelection` | `queue.ts` | (native) |
+| `resetForTesting` | `queue.ts` | (native — internally delegates to the registry) |
+
+External importers (barrel-only access confirmed sufficient):
+
+| Consumer | Imports |
+|----------|---------|
+| `src/server/index.ts` | `attachCtrlObservers`, `detachObservers`, `reattachCtrlObservers`, `reattachObservers` |
+| `src/server/events/sse.ts` | `replaySince`, `subscribe`, `unsubscribe` |
+| `src/server/mcp/file-opener.ts` | `attachObservers`, `clearFileSyncContext`, `MCP_ORIGIN`, `setFileSyncContext` |
+| `src/server/mcp/document-service.ts` | `clearFileSyncContext`, `MCP_ORIGIN` |
+| `src/server/mcp/{document,channel-routes,navigation,awareness,tutorial-annotations,annotations}.ts` | `MCP_ORIGIN` |
+| `src/server/positions.ts`, `session/manager.ts`, `file-io/docx-comments.ts` | `MCP_ORIGIN` |
+| `src/server/annotations/sync.ts` | `FILE_SYNC_ORIGIN` — **change this one import** to `../events/origins.js` as part of Step 1 (eliminates the cycle) |
+
+**14 source consumers + 5 test consumers = 19 import sites total.** Only `annotations/sync.ts:61` changes its specifier.
+
+---
+
+## Test Mock Paths
+
+Goal: **zero test logic changes** where possible; **one pre-decided spy-target switch** for `file-opener-lifecycle.test.ts`.
+
+| Test file | Imports from queue.js | Status after split |
+|-----------|----------------------|---------------------|
+| `tests/server/event-queue.test.ts` | Static: `attachCtrlObservers`, `attachObservers`, `detachObservers`, `FILE_SYNC_ORIGIN`, `getBufferedSelection`, `MCP_ORIGIN`, `reattachObservers`, `replaySince`, `resetForTesting`, `subscribe`, `unsubscribe`, `wasEmittedViaChannel`. Dynamic (lines 696, 699, 774): `setFileSyncContext`, `clearFileSyncContext`, `MCP_ORIGIN`. | All symbols re-exported from barrel. **No path change.** |
+| `tests/server/event-queue-dwell.test.ts` | `attachObservers`, `detachObservers`, `getBufferedSelection`, `resetForTesting`, `subscribe`, `unsubscribe` | **No path change.** |
+| `tests/server/annotations/sync.test.ts` | `FILE_SYNC_ORIGIN`, `MCP_ORIGIN` | **No path change.** |
+| `tests/server/annotation-replies.test.ts`, `edit-annotation.test.ts`, `reload.test.ts` | `MCP_ORIGIN` | **No path change.** |
+| `tests/server/file-opener-lifecycle.test.ts:142` | `vi.spyOn(queueModule, "setFileSyncContext")` where `queueModule = import * as from queue.js` | **Will fail after Step 2 (pre-decided).** In Vitest ESM mode, re-exports are live bindings; `vi.spyOn` on the re-exporting namespace does NOT intercept the originating module's live binding used at `file-opener.ts`'s import site. Pre-decided fix as part of Step 2 — make BOTH edits: (a) **add** a new import statement at the top of the test file: `import * as fileSyncRegistryModule from "../../src/server/events/file-sync-registry.js";` (do NOT remove the existing `queueModule` import — leave it unless other references to `queueModule` are also gone). (b) **change** the `vi.spyOn(queueModule, "setFileSyncContext")` call at line 142 to `vi.spyOn(fileSyncRegistryModule, "setFileSyncContext")`. The assertion at line 149 (`expect(spy).toHaveBeenCalled()`) stays the same. |
+
+After each extraction step, run `npm test -- event-queue` and `npm test -- file-opener-lifecycle` to catch any spy-target regression immediately.
+
+---
+
+## Migration Order — Single Sequential PR
+
+### Step-by-step with mandatory checkpoints
+
+Every checkpoint: `npm run typecheck && npm test`. Do not batch two extractions before a checkpoint.
+
+1. **Extract `origins.ts`.** Create `src/server/events/origins.ts` exporting `MCP_ORIGIN = "mcp"` and `FILE_SYNC_ORIGIN = "file-sync"`. In `queue.ts`, replace the two `export const` declarations with `export { MCP_ORIGIN, FILE_SYNC_ORIGIN } from "./origins.js";`. In `src/server/annotations/sync.ts:61`, change `from "../events/queue.js"` → `from "../events/origins.js"`. **Checkpoint.**
+
+2. **Extract `file-sync-registry.ts`.** Move: `fileSyncContexts` Map, `safeCleanup` helper (including its try/catch + structured log), `setFileSyncContext`, `clearFileSyncContext`. Add new `reattachFileSyncObserver(docName, newDoc)` helper containing the logic from `queue.ts:342–353`, **including the `safeCleanup` wrapper — do not call `cleanup()` directly**. Add `resetForTesting()` that iterates `fileSyncContexts.values()`, calls each `entry.cleanup("close")` inside try/catch (matches `queue.ts:596–599` defensive pattern), then `fileSyncContexts.clear()`. In `queue.ts`: re-export `setFileSyncContext` and `clearFileSyncContext`; call `reattachFileSyncObserver` inside `reattachObservers`; call `fileSyncRegistry.resetForTesting()` from `queue.ts:resetForTesting`. Also in Step 2: **apply the pre-decided spy fix** in `tests/server/file-opener-lifecycle.test.ts` — add `import * as fileSyncRegistryModule from "../../src/server/events/file-sync-registry.js";` near the existing imports, then change `vi.spyOn(queueModule, "setFileSyncContext")` at line 142 to `vi.spyOn(fileSyncRegistryModule, "setFileSyncContext")`. Do NOT remove the `queueModule` import unless a grep confirms no other references remain. **Checkpoint.** `npm test -- file-opener-lifecycle` must pass — if it doesn't, the spy fix wasn't applied correctly.
+
+3. **Extract `observers/annotations.ts`.** Move the body from `queue.ts:181–240` into `makeAnnotationsObserver({ docName, doc, pushEvent })`. `queue.ts:attachObservers` calls it and pushes the returned cleanup into its local `cleanups` array (preserve push order). **Checkpoint.**
+
+4. **Extract `observers/replies.ts`.** Same pattern for `queue.ts:243–272`. The observer needs both the replies map (for `get` on the reply) and the annotations map (for parent-annotation `textSnapshot` lookup). Both are accessed from `doc` inside the factory. **Checkpoint.**
+
+5. **Extract `observers/ctrl-meta.ts`.** Move `queue.ts:505–572` into `makeCtrlMetaObserver({ ctrlDoc, pushEvent })`. The local `lastActiveDocId` / `lastOpenDocIds` become closure state inside the factory — each call returns a fresh observer with its own history (matches current module behavior). Add file-top JSDoc: `/** Observer for CTRL_ROOM's Y.Map('documentMeta'). */`. **Checkpoint.**
+
+6. **Extract `observers/awareness.ts`.** Move `queue.ts:277–316` into `makeAwarenessObserver({ docName, doc, selectionBuffer })`. Move `getDwellMs()` too, as a private helper inside the file. Preserve the `console.warn` at current `queue.ts:71` — it's correct (stderr-redirected in `index.ts`).
+
+   Concrete imports `observers/awareness.ts` needs:
+   ```ts
+   import * as Y from "yjs";
+   import { getOrCreateDocument } from "../../yjs/provider.js";
+   import {
+     CTRL_ROOM,
+     SELECTION_DWELL_DEFAULT_MS,
+     SELECTION_DWELL_MIN_MS,
+     SELECTION_DWELL_MAX_MS,
+     Y_MAP_DWELL_MS,
+     Y_MAP_USER_AWARENESS,
+   } from "../../shared/constants.js";
+   import { MCP_ORIGIN } from "../origins.js";
+   import type { BufferedSelection } from "../types.js";
+   ```
+
+   **Invariant:** the `setTimeout` callback reads `getDwellMs()` at schedule time, not fire time — preserve by keeping the exact call-site pattern `setTimeout(callback, getDwellMs())`. Cleanup must `clearTimeout(selectionDwellTimer)` AND `selectionBuffer.delete(docName)`. **Checkpoint.**
+
+7. **Extract `observers/ctrl-chat.ts`.** Move `queue.ts:444–502` into `makeCtrlChatObserver({ ctrlDoc, pushEvent, selectionBuffer })`. `validateRange` stays inside the factory (imports from `../../positions.js`). `attachCtrlObservers` still does `const ctrlDoc = getOrCreateDocument(CTRL_ROOM)` once at the top and passes the same `ctrlDoc` to both meta and chat factories. Add file-top JSDoc: `/** Observer for CTRL_ROOM's Y.Map('chat'). */`. **Checkpoint.** `npm test -- event-queue` exercises the awareness→chat selection-attachment path.
+
+8. **Final `queue.ts` sanity pass.** At this point `queue.ts` should be ~170 LOC. **Verify (do not re-remove)** that the following imports are already gone: `sanitizeAnnotation`, `generateEventId`, `getOpenDocs`, `validateRange`, `SyncContext`, `ObserverCleanupPhase`, `registerAnnotationObserver`. They should have traveled with the observers / registry in prior steps. Confirm `attachObservers` still calls `detachObservers(docName)` as its first line (unlisted invariant — see below). **Checkpoint.** `npm run typecheck && npm test && npm run test:e2e && npm run build`.
+
+**Ordering rationale** (real data dependencies, not post-hoc):
+- **Awareness (6) before chat (7):** chat consumes `selectionBuffer` produced by awareness; awareness first settles the "selectionBuffer passed by reference" convention.
+- **Annotations (3) before replies (4):** annotations is the clean origin-filter pattern. Establishing the factory shape there de-risks replies (same filter + cross-map parent lookup).
+- **Ctrl-meta (5) before awareness (6) / ctrl-chat (7):** meta has neither `selectionBuffer` nor complex state. It validates the `(ctrlDoc, pushEvent)` CTRL_ROOM factory pattern before the harder chat observer.
+
+---
+
+## Invariants and Mitigations
+
+| # | Invariant | How preserved | Test evidence |
+|---|-----------|---------------|---------------|
+| 1 | `selectionBuffer` is shared between awareness (producer) and chat (consumer) — must be injected, not hidden | `queue.ts` owns the Map; passes the same reference to both observers. Never duplicated. | `event-queue.test.ts` selection-buffer-lifecycle group (chat event receives buffered selection; cleared after consumption). |
+| 2 | `reattachObservers` is idempotent | `reattachObservers` still calls `detachObservers → attachObservers` first, then `reattachFileSyncObserver`. Registry rebind disposes the prior cleanup via `safeCleanup` before registering the new one. | `event-queue.test.ts:651-675` and `:761-765` (no-op on unbound doc). |
+| 3 | File-sync cleanup phase `"swap"` vs `"close"` distinction (#333) | `file-sync-registry.ts:reattachFileSyncObserver` passes `"swap"`; `setFileSyncContext` (replace path) and `clearFileSyncContext` pass `"close"`. Identical to current behavior, only relocated. | `event-queue.test.ts:774+`; `annotations/sync.test.ts`. |
+| 4 | Origin checks happen PER-observer, independently | Each factory contains its own `if (txn.origin === …) return;` guard. No shared guard, no delegation. | `event-queue.test.ts` origin-filter cases per observer type. |
+| 5 | Dwell timer uses `getDwellMs()` at schedule time, not fire time | `observers/awareness.ts` preserves `setTimeout(callback, getDwellMs())`. Copy verbatim. | `event-queue-dwell.test.ts` — mid-dwell slider change case. |
+| 6 | `wasEmittedViaChannel(payloadId)` survives buffer eviction | `emittedPayloadIds` stays in `queue.ts`. `pushEvent` (owned by `queue.ts`) handles track/untrack. Observers emit via injected `pushEvent`. | `event-queue.test.ts:358-400` ref-counted dedup test (pushes `CHANNEL_EVENT_BUFFER_SIZE + 10` filler events; confirms original evicted, new still tracked). |
+| 7 | `setDocLifecycleCallbacks` fires before `startHocuspocus` | **Not touched by this PR.** `src/server/index.ts:21,227` remain byte-identical. | Manual smoke (doc open triggers attach — no warning from `yjs/provider.ts:114`). |
+| 8 (new) | `attachObservers` always calls `detachObservers(docName)` as its first line | Preserve this line verbatim when refactoring `attachObservers`. Without it, a direct caller of `attachObservers` could double-attach. | `event-queue.test.ts:651-675` (implicitly — idempotency tests). |
+| 9 (new) | In `resetForTesting`, each cleanup-holding collection must be iterated before it is `.clear()`ed | `queue.ts:resetForTesting` iterates `docObservers.values()` then calls `docObservers.clear()`; iterates `ctrlCleanups` then reassigns `ctrlCleanups = []`; registry iterates `fileSyncContexts.values()` then calls `.clear()`. Data-only collections (buffer/subs/dedup/selectionBuffer) can clear in any order — observer cleanups don't touch them. | Implicit — no test asserts order directly. |
+
+---
+
+## Verification
+
+Run from project root after the final commit:
+
+1. `npm run typecheck` — zero errors.
+2. `npm test` — all existing tests pass unchanged (except the one pre-decided spy-target switch in `file-opener-lifecycle.test.ts:142`).
+3. `npm run test:e2e` — end-to-end smoke passes.
+4. `npm run build` — production bundles (server, channel, monitor) build clean.
+5. **Import diff check in `src/server/index.ts`:** the file diff must be import-only (or zero). The `setDocLifecycleCallbacks(...)` call at line 227 and its argument expressions must be byte-identical.
+6. **Module cycle audit:** manually trace (or `npx madge --circular src/server/events/` if available). Expected: zero cycles.
+
+### Manual smoke test
+
+Open .md → MCP-mutate → user-edit → save → external file edit reload → force-reload → close. Specifically verify:
+
+- Channel events fire for user-originated edits only (no echo on MCP or file-sync origin writes).
+- After a Hocuspocus reconnect (close browser tab, reopen), annotations persist — the reattach path. If tombstones silently drop, invariant #3 regressed.
+- Selection dwell-gated buffering still attaches the selection to the next chat message.
+- Document open/close/switch events fire correctly.
+- Force-reload clears annotations without leaking observers (the `setFileSyncContext` replace path with phase `"close"`).
+
+---
+
+## Deliberately NOT in Scope
+
+- **Not changing Y.js transaction origin string values.** `"mcp"` and `"file-sync"` stay verbatim.
+- **Not introducing new `TandemEvent` types.** Emitted payloads are byte-identical.
+- **Not refactoring `src/server/annotations/sync.ts`.** Only one line changes: the import specifier for `FILE_SYNC_ORIGIN`.
+- **Not touching `src/server/index.ts` beyond import statements.**
+- **Not changing the dedup algorithm for `emittedPayloadIds`.**
+- **Not changing observer attach/detach ordering** inside `attachObservers` / `attachCtrlObservers`. Push order stays identical.
+
+**Reversed exclusions** (now IN scope because the plan decided to):
+- `BufferedSelection` type added to `src/server/events/types.ts` (see "New Shared Type" section above).
+- `makeXxxObserver` naming (not `createXxxObserver`) to match Phase 2's `makeXxxHandler` convention.
+- One pre-decided spy-target switch in `file-opener-lifecycle.test.ts:142`.
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Cycle re-introduction via `file-sync-registry` → `sync.ts` → `queue.ts` | Fragile resolution, possible TDZ errors | Step 1 (`origins.ts` extraction) dissolves the cycle before the registry is carved out. |
+| `selectionBuffer` reference diverges between awareness and chat | Selection silently never attaches to chat messages | Single Map instance in `queue.ts`, passed by reference to both factories. Covered by `event-queue.test.ts` selection-attachment case. |
+| Dwell timer reads `getDwellMs()` at fire time instead of schedule time | Mid-dwell slider changes affect in-flight timers (#188 class bug) | Preserve exact call site: `setTimeout(callback, getDwellMs())`. Covered by `event-queue-dwell.test.ts`. |
+| `fileSyncRegistry.resetForTesting()` omits the try/catch cleanup loop | **Silent state leak** across tests; no test failure because `safeCleanup` swallows errors | Plan specifies the exact function body (see State Ownership Map). Reviewer must diff against the specified shape. |
+| `reattachFileSyncObserver` calls `cleanup()` directly instead of through `safeCleanup` | Cleanup error crashes reattach instead of logging + continuing | Plan's Step 2 mandates `safeCleanup` wrapper. |
+| `vi.spyOn(queueModule, "setFileSyncContext")` becomes a silent no-op after re-export | Test would fail (good — loud failure) | Pre-decided switch to `vi.spyOn(fileSyncRegistryModule, ...)` as part of Step 2. |
+| Observer cleanup stash order changes, altering detach order | Ordering-dependent test flakes | Preserve exact push order in `attachObservers` / `attachCtrlObservers`. |
+| `attachObservers` accidentally loses its leading `detachObservers(docName)` call | Double-attachment on direct callers | New invariant #8 codifies this. Verified in Step 8 sanity pass. |
+| Hidden import in observer body not carried across | Build failure or runtime `undefined` call | Typecheck catches the first; tests catch the second. |
+
+---
+
+## Tests Worth Adding as a Follow-up PR (not blocking)
+
+These address genuine coverage gaps the review surfaced. They are not prerequisites for this PR — the existing 56+ cases are sufficient to catch a mechanical slip — but they would lock down edges that a future refactor could regress:
+
+1. **Mid-dwell detach:** Set selection → `detachObservers` before dwell fires → advance fake timers past dwell → assert `getBufferedSelection` is `undefined`. Validates the `clearTimeout` in the awareness cleanup — the exact scenario Step 6 is most likely to regress.
+2. **Rapid distinct-doc swaps:** `attachObservers("doc", doc1)` → `reattachObservers("doc", doc2)` → `reattachObservers("doc", doc3)` — write to doc1 and doc2, assert no events; write to doc3, assert one event. Validates clean disposal across a 3-doc sequence (current idempotency test only covers same-doc).
+3. **`resetForTesting` registry delegation:** Call `setFileSyncContext` with a spy cleanup → call `resetForTesting` → assert the spy was called with phase `"close"`. Turns "implicitly covered" into an explicit assertion.
+4. **Confirm the spy-target switch locks down correctly:** After the switch lands, add a regression test that asserts `setFileSyncContext` is called once per `openFileByPath` invocation, via the new spy target.
+
+Track these in a roadmap issue alongside this PR's merge.
+
+---
+
+## Execution
+
+Single worktree agent. ~1.5 days. Sequential checkpoints per Step are **mandatory** — do not batch two extraction steps before `npm run typecheck && npm test`. If any step fails its checkpoint, revert only that step (not the cumulative diff) and diagnose before continuing.
+
+Set up worktree:
+
+```
+git worktree add .claude/worktrees/refactor-event-queue-split -b refactor/event-queue-observer-split master
+```
+
+Symlink `node_modules` from the main repo (Windows junctions per user preference) so typecheck and tests run without a full re-install.
+
+### Critical files touched
+
+- `src/server/events/queue.ts` (extraction source)
+- `src/server/events/origins.ts` (new)
+- `src/server/events/types.ts` (existing; add `BufferedSelection`)
+- `src/server/events/file-sync-registry.ts` (new)
+- `src/server/events/observers/{annotations,replies,awareness,ctrl-chat,ctrl-meta}.ts` (new)
+- `src/server/annotations/sync.ts` (one import line)
+- `tests/server/file-opener-lifecycle.test.ts` (one spy-target switch)
+
+### Critical files NOT touched (guard via diff check)
+
+- `src/server/index.ts` — import-only changes acceptable; call-site invariant
+- `src/server/yjs/provider.ts` — zero changes expected
+- `src/server/events/sse.ts` — zero changes (imports 3 symbols, all natively in queue.ts post-split)
+- All `tests/server/**` except the one spy-target switch above
+- `CLAUDE.md` — Rule #2 wording remains accurate
+
+### Commit structure
+
+One branch, one PR. Commits may follow migration steps (one commit per checkpoint) for reviewer clarity, but this is reviewer ergonomics, not a functional requirement. PR description should cite this plan doc.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -396,8 +396,8 @@ Full quality sweep documented in [`docs/audit-v1.md`](audit-v1.md). Three indepe
 | Phase | Scope | Effort | Status |
 |-------|-------|--------|--------|
 | 1 | Foundation: wire-protocol types to shared, token-store extraction, awareness.ts #355, Editor CSS extraction, tsconfig tightening, dead Tauri deps | ~2 days | **DONE** (PRs #384–#389, merged 2026-04-22) |
-| 2 | Server splits: api-routes.ts → per-route modules, file-opener.ts → phased helpers + lifecycle tests | ~2 days | Next |
-| 3 | Event queue observer split (highest-risk, sequential) | ~1.5 days | — |
+| 2 | Server splits: api-routes.ts → per-route modules, file-opener.ts → phased helpers + lifecycle tests | ~2 days | **DONE** (PRs #391, #392, merged 2026-04-23) |
+| 3 | Event queue observer split (highest-risk, sequential) | ~1.5 days | **In review** (PR #398, plan: `docs/phase-3-plan.md`, follow-up tests: #399) |
 | 4 | Client splits: App.tsx hooks, SidePanel decomposition, Toolbar/Settings/AnnotationCard sub-components | ~3 days | — |
 | 5 | Prop-drilling evaluation (conditional, post-Phase 4) | ~0.5 day | — |
 | 6 | Polish: accessibility, E2E error recovery, Tauri integration tests (post-v1.0) | incremental | — |

--- a/src/server/annotations/sync.ts
+++ b/src/server/annotations/sync.ts
@@ -58,7 +58,7 @@ import * as Y from "yjs";
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
 import { type RawAnnotation, sanitizeAnnotation } from "../../shared/sanitize.js";
 import { AnnotationTypeSchema } from "../../shared/types.js";
-import { FILE_SYNC_ORIGIN } from "../events/queue.js";
+import { FILE_SYNC_ORIGIN } from "../events/origins.js";
 import {
   type AnnotationDocV1,
   type AnnotationRecordV1,

--- a/src/server/events/file-sync-registry.ts
+++ b/src/server/events/file-sync-registry.ts
@@ -1,0 +1,122 @@
+/**
+ * File-sync observer registry for durable annotation persistence.
+ *
+ * Tracks per-doc SyncContext so reattachObservers (in queue.ts) can
+ * re-register the annotation file-writer observer against the new Y.Doc
+ * after a Hocuspocus doc swap. Stored alongside the cleanup handle from
+ * the prior registerAnnotationObserver call so we can dispose it
+ * deterministically.
+ */
+
+import * as Y from "yjs";
+import type { DocStore } from "../annotations/store.js";
+import {
+  type ObserverCleanupPhase,
+  registerAnnotationObserver,
+  type SyncContext,
+} from "../annotations/sync.js";
+
+/**
+ * Track per-doc SyncContext so `reattachObservers` can re-register the
+ * annotation file-writer observer against the new Y.Doc after a Hocuspocus
+ * doc swap. Stored alongside the cleanup handle from the prior
+ * `registerAnnotationObserver` call so we can dispose it deterministically.
+ */
+const fileSyncContexts = new Map<
+  string,
+  { ctx: SyncContext; cleanup: (phase?: ObserverCleanupPhase) => void }
+>();
+
+/**
+ * Run a file-sync observer cleanup in a try/catch with a uniform log line.
+ * Cleanups can throw if the underlying Y.Doc was already destroyed (e.g. a
+ * Hocuspocus reload beat us to it) — that's harmless, but we want the logs
+ * to be consistent enough to grep.
+ */
+function safeCleanup(
+  docName: string,
+  cleanup: (phase?: ObserverCleanupPhase) => void,
+  phase: ObserverCleanupPhase,
+  logTag: string,
+): void {
+  try {
+    cleanup(phase);
+  } catch (err) {
+    console.warn("[EventQueue] file-sync cleanup threw during %s for %s:", logTag, docName, err);
+  }
+}
+
+/**
+ * Register the durable-annotation sync context for a document. Called by the
+ * file-opener after `loadAndMerge` returns its observer cleanup. The cleanup
+ * passed here is what gets invoked on `clearFileSyncContext` or the next
+ * `reattachObservers` call.
+ *
+ * Callers don't need to think about the swap-vs-close distinction: the queue
+ * picks the phase at teardown time based on which entrypoint ran.
+ */
+export function setFileSyncContext(
+  docName: string,
+  ctx: SyncContext,
+  cleanup: (phase?: ObserverCleanupPhase) => void,
+): void {
+  // Dispose any prior entry first so we never leak observers on duplicate
+  // registration (e.g., forceReload paths that re-run loadAndMerge). Normal
+  // flow pre-clears via `clearFileSyncContext`, so this branch is defensive;
+  // `"close"` is correct because we're replacing — not rebinding — the
+  // context, so the prior docHash's tombstones belong to a superseded state.
+  const existing = fileSyncContexts.get(docName);
+  if (existing) {
+    safeCleanup(docName, existing.cleanup, "close", "replace");
+  }
+  fileSyncContexts.set(docName, { ctx, cleanup });
+}
+
+/**
+ * Drop the file-sync context for a document (on close or force-reload prep).
+ * Returns the dropped `{ store, docHash }` so callers can flush/clear the
+ * durable store without recomputing the hash or minting a transient handle.
+ * Returns `undefined` if no context was registered (e.g. feature flag off,
+ * or `wireAnnotationStore` failed during open).
+ */
+export function clearFileSyncContext(
+  docName: string,
+): { store: DocStore; docHash: string } | undefined {
+  const entry = fileSyncContexts.get(docName);
+  if (!entry) return undefined;
+  safeCleanup(docName, entry.cleanup, "close", "clear");
+  fileSyncContexts.delete(docName);
+  return { store: entry.ctx.store, docHash: entry.ctx.docHash };
+}
+
+/**
+ * Reattach the file-sync annotation observer to a new Y.Doc after a Hocuspocus
+ * doc swap. Disposes the prior cleanup via safeCleanup (swap phase), then
+ * re-registers against the new doc. Called from queue.ts:reattachObservers.
+ */
+export function reattachFileSyncObserver(docName: string, newDoc: Y.Doc): void {
+  const oldCtx = fileSyncContexts.get(docName);
+  if (oldCtx) {
+    safeCleanup(docName, oldCtx.cleanup, "swap", "reattach");
+    const newCtx: SyncContext = {
+      ydoc: newDoc,
+      store: oldCtx.ctx.store,
+      docHash: oldCtx.ctx.docHash,
+      meta: oldCtx.ctx.meta,
+    };
+    const cleanup = registerAnnotationObserver(newCtx);
+    fileSyncContexts.set(docName, { ctx: newCtx, cleanup });
+  }
+}
+
+/** Reset all registry state. For tests only — do not call in production. */
+export function resetForTesting(): void {
+  for (const entry of fileSyncContexts.values()) {
+    try {
+      entry.cleanup("close");
+    } catch {
+      /* swallow, matches queue.ts:596-599 defensive pattern */
+    }
+  }
+  fileSyncContexts.clear();
+}

--- a/src/server/events/file-sync-registry.ts
+++ b/src/server/events/file-sync-registry.ts
@@ -16,12 +16,6 @@ import {
   type SyncContext,
 } from "../annotations/sync.js";
 
-/**
- * Track per-doc SyncContext so `reattachObservers` can re-register the
- * annotation file-writer observer against the new Y.Doc after a Hocuspocus
- * doc swap. Stored alongside the cleanup handle from the prior
- * `registerAnnotationObserver` call so we can dispose it deterministically.
- */
 const fileSyncContexts = new Map<
   string,
   { ctx: SyncContext; cleanup: (phase?: ObserverCleanupPhase) => void }
@@ -111,12 +105,8 @@ export function reattachFileSyncObserver(docName: string, newDoc: Y.Doc): void {
 
 /** Reset all registry state. For tests only — do not call in production. */
 export function resetForTesting(): void {
-  for (const entry of fileSyncContexts.values()) {
-    try {
-      entry.cleanup("close");
-    } catch {
-      /* swallow, matches queue.ts:596-599 defensive pattern */
-    }
+  for (const [docName, entry] of fileSyncContexts) {
+    safeCleanup(docName, entry.cleanup, "close", "resetForTesting");
   }
   fileSyncContexts.clear();
 }

--- a/src/server/events/observers/annotations.ts
+++ b/src/server/events/observers/annotations.ts
@@ -1,7 +1,7 @@
 import * as Y from "yjs";
 import { Y_MAP_ANNOTATIONS } from "../../../shared/constants.js";
+import { sanitizeAnnotation } from "../../../shared/sanitize.js";
 import type { Annotation } from "../../../shared/types.js";
-import { sanitizeAnnotation } from "../../mcp/annotations.js";
 import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "../origins.js";
 import type { TandemEvent } from "../types.js";
 import { generateEventId } from "../types.js";

--- a/src/server/events/observers/annotations.ts
+++ b/src/server/events/observers/annotations.ts
@@ -1,0 +1,77 @@
+import * as Y from "yjs";
+import { Y_MAP_ANNOTATIONS } from "../../../shared/constants.js";
+import type { Annotation } from "../../../shared/types.js";
+import { sanitizeAnnotation } from "../../mcp/annotations.js";
+import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "../origins.js";
+import type { TandemEvent } from "../types.js";
+import { generateEventId } from "../types.js";
+
+export function makeAnnotationsObserver(deps: {
+  docName: string;
+  doc: Y.Doc;
+  pushEvent: (e: TandemEvent) => void;
+}): () => void {
+  const { docName, doc, pushEvent } = deps;
+  const annotationsMap = doc.getMap(Y_MAP_ANNOTATIONS);
+
+  const annotationsObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
+    if (txn.origin === MCP_ORIGIN || txn.origin === FILE_SYNC_ORIGIN) return;
+
+    for (const [key, change] of event.changes.keys) {
+      const raw = annotationsMap.get(key) as Annotation | undefined;
+      if (!raw) continue;
+
+      let ann: Annotation;
+      try {
+        ann = sanitizeAnnotation(raw);
+      } catch (err) {
+        console.warn(`[EventQueue] sanitizeAnnotation failed for key=${key}:`, err);
+        continue;
+      }
+
+      if (change.action === "add" && ann.author === "user") {
+        pushEvent({
+          id: generateEventId(),
+          type: "annotation:created",
+          timestamp: Date.now(),
+          documentId: docName,
+          payload: {
+            annotationId: ann.id,
+            annotationType: ann.type,
+            content: ann.content,
+            textSnippet: ann.textSnapshot ?? "",
+            ...(ann.suggestedText !== undefined ? { hasSuggestedText: true } : {}),
+            ...(ann.directedAt ? { directedAt: ann.directedAt } : {}),
+          },
+        });
+      } else if (change.action === "update" && ann.author === "claude") {
+        if (ann.status === "accepted") {
+          pushEvent({
+            id: generateEventId(),
+            type: "annotation:accepted",
+            timestamp: Date.now(),
+            documentId: docName,
+            payload: {
+              annotationId: ann.id,
+              textSnippet: ann.textSnapshot ?? "",
+            },
+          });
+        } else if (ann.status === "dismissed") {
+          pushEvent({
+            id: generateEventId(),
+            type: "annotation:dismissed",
+            timestamp: Date.now(),
+            documentId: docName,
+            payload: {
+              annotationId: ann.id,
+              textSnippet: ann.textSnapshot ?? "",
+            },
+          });
+        }
+      }
+    }
+  };
+
+  annotationsMap.observe(annotationsObs);
+  return () => annotationsMap.unobserve(annotationsObs);
+}

--- a/src/server/events/observers/awareness.ts
+++ b/src/server/events/observers/awareness.ts
@@ -1,0 +1,90 @@
+import * as Y from "yjs";
+import {
+  CTRL_ROOM,
+  SELECTION_DWELL_DEFAULT_MS,
+  SELECTION_DWELL_MAX_MS,
+  SELECTION_DWELL_MIN_MS,
+  Y_MAP_DWELL_MS,
+  Y_MAP_USER_AWARENESS,
+} from "../../../shared/constants.js";
+import type { FlatOffset } from "../../../shared/types.js";
+import { getOrCreateDocument } from "../../yjs/provider.js";
+import { MCP_ORIGIN } from "../origins.js";
+import type { BufferedSelection } from "../types.js";
+
+/**
+ * Read the user's configured selection dwell time from CTRL_ROOM.
+ *
+ * Called at timer-schedule time (not fire time), so mid-dwell slider changes
+ * don't affect an in-flight timer — the updated value takes effect on the
+ * next selection change.
+ *
+ * Falls back to `SELECTION_DWELL_DEFAULT_MS` when:
+ *   - CTRL_ROOM has no dwell key set (normal on cold startup, before the
+ *     client's broadcast effect runs)
+ *   - The stored value is the wrong type or outside [MIN, MAX] — the client
+ *     clamps on write, so this branch indicates a bug or client/server
+ *     constant drift. Logged as a warning so it can be diagnosed.
+ */
+function getDwellMs(): number {
+  const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
+  const awareness = ctrlDoc.getMap(Y_MAP_USER_AWARENESS);
+  const val = awareness.get(Y_MAP_DWELL_MS);
+  if (val === undefined) return SELECTION_DWELL_DEFAULT_MS;
+  if (typeof val === "number" && val >= SELECTION_DWELL_MIN_MS && val <= SELECTION_DWELL_MAX_MS) {
+    return val;
+  }
+  console.warn(
+    `[EventQueue] Invalid dwell time in CTRL_ROOM awareness (type=${typeof val}, value=${String(val)}); using default ${SELECTION_DWELL_DEFAULT_MS}ms`,
+  );
+  return SELECTION_DWELL_DEFAULT_MS;
+}
+
+export function makeAwarenessObserver(deps: {
+  docName: string;
+  doc: Y.Doc;
+  selectionBuffer: Map<string, BufferedSelection>;
+}): () => void {
+  const { docName, doc, selectionBuffer } = deps;
+  const userAwareness = doc.getMap(Y_MAP_USER_AWARENESS);
+  let selectionDwellTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const awarenessObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
+    if (txn.origin === MCP_ORIGIN) return;
+
+    if (event.keysChanged.has("selection")) {
+      const selection = userAwareness.get("selection") as
+        | { from: FlatOffset; to: FlatOffset; selectedText?: string }
+        | undefined;
+
+      // Cancel any pending dwell timer
+      if (selectionDwellTimer) {
+        clearTimeout(selectionDwellTimer);
+        selectionDwellTimer = null;
+      }
+
+      // Skip cleared selections — also clear the buffer
+      if (!selection || selection.from === selection.to) {
+        selectionBuffer.delete(docName);
+        return;
+      }
+
+      // Buffer after dwell to filter transient drag selections
+      selectionDwellTimer = setTimeout(() => {
+        selectionDwellTimer = null;
+        selectionBuffer.set(docName, {
+          from: selection.from,
+          to: selection.to,
+          selectedText: selection.selectedText ?? "",
+        });
+      }, getDwellMs());
+    }
+  };
+
+  userAwareness.observe(awarenessObs);
+  return () => {
+    userAwareness.unobserve(awarenessObs);
+    if (selectionDwellTimer) clearTimeout(selectionDwellTimer);
+    selectionBuffer.delete(docName);
+  };
+}

--- a/src/server/events/observers/ctrl-chat.ts
+++ b/src/server/events/observers/ctrl-chat.ts
@@ -1,0 +1,79 @@
+/** Observer for CTRL_ROOM's Y.Map('chat'). */
+
+import * as Y from "yjs";
+import { Y_MAP_CHAT } from "../../../shared/constants.js";
+import type { ChatMessage, FlatOffset } from "../../../shared/types.js";
+import { validateRange } from "../../positions.js";
+import { getOrCreateDocument } from "../../yjs/provider.js";
+import { MCP_ORIGIN } from "../origins.js";
+import type { BufferedSelection, TandemEvent } from "../types.js";
+import { generateEventId } from "../types.js";
+
+export function makeCtrlChatObserver(deps: {
+  ctrlDoc: Y.Doc;
+  pushEvent: (e: TandemEvent) => void;
+  selectionBuffer: Map<string, BufferedSelection>;
+}): () => void {
+  const { ctrlDoc, pushEvent, selectionBuffer } = deps;
+  const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
+
+  const chatObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
+    if (txn.origin === MCP_ORIGIN) return;
+
+    for (const [key, change] of event.changes.keys) {
+      if (change.action !== "add") continue;
+      const msg = chatMap.get(key) as ChatMessage | undefined;
+      if (!msg || msg.author !== "user") continue;
+
+      // Attach buffered selection context if available for this document
+      let selection:
+        | { from: number; to: number; selectedText: string }
+        | { selectedText: string }
+        | undefined;
+      if (msg.documentId) {
+        const buffered = selectionBuffer.get(msg.documentId);
+        if (buffered) {
+          selectionBuffer.delete(msg.documentId);
+          // Validate range is still valid before attaching offsets
+          try {
+            const doc = getOrCreateDocument(msg.documentId);
+            const validation = validateRange(
+              doc,
+              buffered.from as FlatOffset,
+              buffered.to as FlatOffset,
+            );
+            if (validation.ok) {
+              selection = buffered;
+            } else {
+              // Range went stale — attach text only (no offsets)
+              selection = { selectedText: buffered.selectedText };
+            }
+          } catch (err) {
+            console.warn(
+              `[EventQueue] Failed to validate buffered selection for doc=${msg.documentId}:`,
+              err,
+            );
+            selection = { selectedText: buffered.selectedText };
+          }
+        }
+      }
+
+      pushEvent({
+        id: generateEventId(),
+        type: "chat:message",
+        timestamp: Date.now(),
+        documentId: msg.documentId,
+        payload: {
+          messageId: msg.id,
+          text: msg.text,
+          replyTo: msg.replyTo ?? null,
+          anchor: msg.anchor ?? null,
+          ...(selection ? { selection } : {}),
+        },
+      });
+    }
+  };
+
+  chatMap.observe(chatObs);
+  return () => chatMap.unobserve(chatObs);
+}

--- a/src/server/events/observers/ctrl-meta.ts
+++ b/src/server/events/observers/ctrl-meta.ts
@@ -1,0 +1,84 @@
+/** Observer for CTRL_ROOM's Y.Map('documentMeta'). */
+
+import * as Y from "yjs";
+import { Y_MAP_DOCUMENT_META } from "../../../shared/constants.js";
+import { getOpenDocs } from "../../mcp/document-service.js";
+import { MCP_ORIGIN } from "../origins.js";
+import type { TandemEvent } from "../types.js";
+import { generateEventId } from "../types.js";
+
+export function makeCtrlMetaObserver(deps: {
+  ctrlDoc: Y.Doc;
+  pushEvent: (e: TandemEvent) => void;
+}): () => void {
+  const { ctrlDoc, pushEvent } = deps;
+  const metaMap = ctrlDoc.getMap(Y_MAP_DOCUMENT_META);
+  let lastActiveDocId: string | null = null;
+  let lastOpenDocIds = new Set<string>();
+
+  const metaObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
+    if (txn.origin === MCP_ORIGIN) return;
+
+    // Check for activeDocumentId change (tab switch)
+    if (event.keysChanged.has("activeDocumentId")) {
+      const activeId = metaMap.get("activeDocumentId") as string | undefined;
+      if (activeId && activeId !== lastActiveDocId) {
+        const openDoc = getOpenDocs().get(activeId);
+        pushEvent({
+          id: generateEventId(),
+          type: "document:switched",
+          timestamp: Date.now(),
+          documentId: activeId,
+          payload: {
+            fileName: openDoc?.filePath?.split(/[/\\]/).pop() ?? activeId,
+          },
+        });
+        lastActiveDocId = activeId;
+      }
+    }
+
+    // Check for openDocuments change (doc open/close)
+    if (event.keysChanged.has("openDocuments")) {
+      const docList =
+        (metaMap.get("openDocuments") as Array<{ id: string; fileName?: string }>) ?? [];
+      const currentIds = new Set(docList.map((d) => d.id));
+
+      // Newly opened
+      for (const doc of docList) {
+        if (!lastOpenDocIds.has(doc.id)) {
+          const openDoc = getOpenDocs().get(doc.id);
+          pushEvent({
+            id: generateEventId(),
+            type: "document:opened",
+            timestamp: Date.now(),
+            documentId: doc.id,
+            payload: {
+              fileName: doc.fileName ?? openDoc?.filePath?.split(/[/\\]/).pop() ?? doc.id,
+              format: openDoc?.format ?? "unknown",
+            },
+          });
+        }
+      }
+
+      // Closed
+      for (const oldId of lastOpenDocIds) {
+        if (!currentIds.has(oldId)) {
+          pushEvent({
+            id: generateEventId(),
+            type: "document:closed",
+            timestamp: Date.now(),
+            documentId: oldId,
+            payload: {
+              fileName: oldId,
+            },
+          });
+        }
+      }
+
+      lastOpenDocIds = currentIds;
+    }
+  };
+
+  metaMap.observe(metaObs);
+  return () => metaMap.unobserve(metaObs);
+}

--- a/src/server/events/observers/replies.ts
+++ b/src/server/events/observers/replies.ts
@@ -1,0 +1,47 @@
+import * as Y from "yjs";
+import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../../shared/constants.js";
+import type { Annotation, AnnotationReply } from "../../../shared/types.js";
+import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "../origins.js";
+import type { TandemEvent } from "../types.js";
+import { generateEventId } from "../types.js";
+
+export function makeRepliesObserver(deps: {
+  docName: string;
+  doc: Y.Doc;
+  pushEvent: (e: TandemEvent) => void;
+}): () => void {
+  const { docName, doc, pushEvent } = deps;
+  const annotationsMap = doc.getMap(Y_MAP_ANNOTATIONS);
+  const repliesMap = doc.getMap(Y_MAP_ANNOTATION_REPLIES);
+
+  const repliesObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
+    if (txn.origin === MCP_ORIGIN || txn.origin === FILE_SYNC_ORIGIN) return;
+
+    for (const [key, change] of event.changes.keys) {
+      if (change.action !== "add") continue;
+      const reply = repliesMap.get(key) as AnnotationReply | undefined;
+      if (!reply || reply.author !== "user") continue;
+
+      // Look up the parent annotation for the text snippet
+      const parentAnn = annotationsMap.get(reply.annotationId) as Annotation | undefined;
+      const textSnippet = parentAnn?.textSnapshot ?? "";
+
+      pushEvent({
+        id: generateEventId(),
+        type: "annotation:reply",
+        timestamp: Date.now(),
+        documentId: docName,
+        payload: {
+          annotationId: reply.annotationId,
+          replyId: reply.id,
+          replyText: reply.text,
+          replyAuthor: reply.author,
+          textSnippet,
+        },
+      });
+    }
+  };
+
+  repliesMap.observe(repliesObs);
+  return () => repliesMap.unobserve(repliesObs);
+}

--- a/src/server/events/origins.ts
+++ b/src/server/events/origins.ts
@@ -6,7 +6,7 @@
  * `queue.ts`.
  */
 
-/** Origin tag for all MCP-initiated Y.Map writes. Import and use this — never use raw "mcp" strings. */
+/** Origin tag for all MCP-initiated Y.Map writes. */
 export const MCP_ORIGIN = "mcp";
 
 /**

--- a/src/server/events/origins.ts
+++ b/src/server/events/origins.ts
@@ -1,0 +1,18 @@
+/**
+ * Y.Map transaction origin constants for the Tandem event queue.
+ *
+ * Kept in a standalone file so that `src/server/annotations/sync.ts` can
+ * import `FILE_SYNC_ORIGIN` without creating a circular dependency through
+ * `queue.ts`.
+ */
+
+/** Origin tag for all MCP-initiated Y.Map writes. Import and use this — never use raw "mcp" strings. */
+export const MCP_ORIGIN = "mcp";
+
+/**
+ * Origin tag for Y.Map writes that originated from the annotation file-writer
+ * (app-data JSON → Y.Map sync). Observers that emit channel events to external
+ * consumers MUST skip transactions with this origin so a file-reload doesn't
+ * fire spurious `annotation:*` SSE events.
+ */
+export const FILE_SYNC_ORIGIN = "file-sync";

--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -22,7 +22,6 @@ import {
   Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
 import type { Annotation, AnnotationReply, ChatMessage, FlatOffset } from "../../shared/types.js";
-import { sanitizeAnnotation } from "../mcp/annotations.js";
 import { getOpenDocs } from "../mcp/document-service.js";
 import { validateRange } from "../positions.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
@@ -32,6 +31,7 @@ import {
   reattachFileSyncObserver,
   setFileSyncContext,
 } from "./file-sync-registry.js";
+import { makeAnnotationsObserver } from "./observers/annotations.js";
 import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "./origins.js";
 import type { TandemEvent } from "./types.js";
 import { generateEventId } from "./types.js";
@@ -170,68 +170,10 @@ export function attachObservers(docName: string, doc: Y.Doc): void {
   const cleanups: Array<() => void> = [];
 
   // 1. Annotations observer
-  const annotationsMap = doc.getMap(Y_MAP_ANNOTATIONS);
-  const annotationsObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
-    if (txn.origin === MCP_ORIGIN || txn.origin === FILE_SYNC_ORIGIN) return;
-
-    for (const [key, change] of event.changes.keys) {
-      const raw = annotationsMap.get(key) as Annotation | undefined;
-      if (!raw) continue;
-
-      let ann: Annotation;
-      try {
-        ann = sanitizeAnnotation(raw);
-      } catch (err) {
-        console.warn(`[EventQueue] sanitizeAnnotation failed for key=${key}:`, err);
-        continue;
-      }
-
-      if (change.action === "add" && ann.author === "user") {
-        pushEvent({
-          id: generateEventId(),
-          type: "annotation:created",
-          timestamp: Date.now(),
-          documentId: docName,
-          payload: {
-            annotationId: ann.id,
-            annotationType: ann.type,
-            content: ann.content,
-            textSnippet: ann.textSnapshot ?? "",
-            ...(ann.suggestedText !== undefined ? { hasSuggestedText: true } : {}),
-            ...(ann.directedAt ? { directedAt: ann.directedAt } : {}),
-          },
-        });
-      } else if (change.action === "update" && ann.author === "claude") {
-        if (ann.status === "accepted") {
-          pushEvent({
-            id: generateEventId(),
-            type: "annotation:accepted",
-            timestamp: Date.now(),
-            documentId: docName,
-            payload: {
-              annotationId: ann.id,
-              textSnippet: ann.textSnapshot ?? "",
-            },
-          });
-        } else if (ann.status === "dismissed") {
-          pushEvent({
-            id: generateEventId(),
-            type: "annotation:dismissed",
-            timestamp: Date.now(),
-            documentId: docName,
-            payload: {
-              annotationId: ann.id,
-              textSnippet: ann.textSnapshot ?? "",
-            },
-          });
-        }
-      }
-    }
-  };
-  annotationsMap.observe(annotationsObs);
-  cleanups.push(() => annotationsMap.unobserve(annotationsObs));
+  cleanups.push(makeAnnotationsObserver({ docName, doc, pushEvent }));
 
   // 2. Annotation replies observer
+  const annotationsMap = doc.getMap(Y_MAP_ANNOTATIONS);
   const repliesMap = doc.getMap(Y_MAP_ANNOTATION_REPLIES);
   const repliesObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
     if (txn.origin === MCP_ORIGIN || txn.origin === FILE_SYNC_ORIGIN) return;

--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -14,14 +14,12 @@ import {
   SELECTION_DWELL_DEFAULT_MS,
   SELECTION_DWELL_MAX_MS,
   SELECTION_DWELL_MIN_MS,
-  Y_MAP_ANNOTATION_REPLIES,
-  Y_MAP_ANNOTATIONS,
   Y_MAP_CHAT,
   Y_MAP_DOCUMENT_META,
   Y_MAP_DWELL_MS,
   Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
-import type { Annotation, AnnotationReply, ChatMessage, FlatOffset } from "../../shared/types.js";
+import type { ChatMessage, FlatOffset } from "../../shared/types.js";
 import { getOpenDocs } from "../mcp/document-service.js";
 import { validateRange } from "../positions.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
@@ -32,6 +30,7 @@ import {
   setFileSyncContext,
 } from "./file-sync-registry.js";
 import { makeAnnotationsObserver } from "./observers/annotations.js";
+import { makeRepliesObserver } from "./observers/replies.js";
 import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "./origins.js";
 import type { TandemEvent } from "./types.js";
 import { generateEventId } from "./types.js";
@@ -173,37 +172,7 @@ export function attachObservers(docName: string, doc: Y.Doc): void {
   cleanups.push(makeAnnotationsObserver({ docName, doc, pushEvent }));
 
   // 2. Annotation replies observer
-  const annotationsMap = doc.getMap(Y_MAP_ANNOTATIONS);
-  const repliesMap = doc.getMap(Y_MAP_ANNOTATION_REPLIES);
-  const repliesObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
-    if (txn.origin === MCP_ORIGIN || txn.origin === FILE_SYNC_ORIGIN) return;
-
-    for (const [key, change] of event.changes.keys) {
-      if (change.action !== "add") continue;
-      const reply = repliesMap.get(key) as AnnotationReply | undefined;
-      if (!reply || reply.author !== "user") continue;
-
-      // Look up the parent annotation for the text snippet
-      const parentAnn = annotationsMap.get(reply.annotationId) as Annotation | undefined;
-      const textSnippet = parentAnn?.textSnapshot ?? "";
-
-      pushEvent({
-        id: generateEventId(),
-        type: "annotation:reply",
-        timestamp: Date.now(),
-        documentId: docName,
-        payload: {
-          annotationId: reply.annotationId,
-          replyId: reply.id,
-          replyText: reply.text,
-          replyAuthor: reply.author,
-          textSnippet,
-        },
-      });
-    }
-  };
-  repliesMap.observe(repliesObs);
-  cleanups.push(() => repliesMap.unobserve(repliesObs));
+  cleanups.push(makeRepliesObserver({ docName, doc, pushEvent }));
 
   // 3. User awareness observer (selection buffering)
   // Selections are buffered per-document and attached to the next chat:message,

--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -15,12 +15,10 @@ import {
   SELECTION_DWELL_MAX_MS,
   SELECTION_DWELL_MIN_MS,
   Y_MAP_CHAT,
-  Y_MAP_DOCUMENT_META,
   Y_MAP_DWELL_MS,
   Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
 import type { ChatMessage, FlatOffset } from "../../shared/types.js";
-import { getOpenDocs } from "../mcp/document-service.js";
 import { validateRange } from "../positions.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
 import {
@@ -30,6 +28,7 @@ import {
   setFileSyncContext,
 } from "./file-sync-registry.js";
 import { makeAnnotationsObserver } from "./observers/annotations.js";
+import { makeCtrlMetaObserver } from "./observers/ctrl-meta.js";
 import { makeRepliesObserver } from "./observers/replies.js";
 import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "./origins.js";
 import type { TandemEvent } from "./types.js";
@@ -319,74 +318,7 @@ export function attachCtrlObservers(): void {
   ctrlCleanups.push(() => chatMap.unobserve(chatObs));
 
   // Document meta observer (open/close/switch)
-  const metaMap = ctrlDoc.getMap(Y_MAP_DOCUMENT_META);
-  let lastActiveDocId: string | null = null;
-  let lastOpenDocIds = new Set<string>();
-
-  const metaObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
-    if (txn.origin === MCP_ORIGIN) return;
-
-    // Check for activeDocumentId change (tab switch)
-    if (event.keysChanged.has("activeDocumentId")) {
-      const activeId = metaMap.get("activeDocumentId") as string | undefined;
-      if (activeId && activeId !== lastActiveDocId) {
-        const openDoc = getOpenDocs().get(activeId);
-        pushEvent({
-          id: generateEventId(),
-          type: "document:switched",
-          timestamp: Date.now(),
-          documentId: activeId,
-          payload: {
-            fileName: openDoc?.filePath?.split(/[/\\]/).pop() ?? activeId,
-          },
-        });
-        lastActiveDocId = activeId;
-      }
-    }
-
-    // Check for openDocuments change (doc open/close)
-    if (event.keysChanged.has("openDocuments")) {
-      const docList =
-        (metaMap.get("openDocuments") as Array<{ id: string; fileName?: string }>) ?? [];
-      const currentIds = new Set(docList.map((d) => d.id));
-
-      // Newly opened
-      for (const doc of docList) {
-        if (!lastOpenDocIds.has(doc.id)) {
-          const openDoc = getOpenDocs().get(doc.id);
-          pushEvent({
-            id: generateEventId(),
-            type: "document:opened",
-            timestamp: Date.now(),
-            documentId: doc.id,
-            payload: {
-              fileName: doc.fileName ?? openDoc?.filePath?.split(/[/\\]/).pop() ?? doc.id,
-              format: openDoc?.format ?? "unknown",
-            },
-          });
-        }
-      }
-
-      // Closed
-      for (const oldId of lastOpenDocIds) {
-        if (!currentIds.has(oldId)) {
-          pushEvent({
-            id: generateEventId(),
-            type: "document:closed",
-            timestamp: Date.now(),
-            documentId: oldId,
-            payload: {
-              fileName: oldId,
-            },
-          });
-        }
-      }
-
-      lastOpenDocIds = currentIds;
-    }
-  };
-  metaMap.observe(metaObs);
-  ctrlCleanups.push(() => metaMap.unobserve(metaObs));
+  ctrlCleanups.push(makeCtrlMetaObserver({ ctrlDoc, pushEvent }));
 
   console.error("[EventQueue] Attached CTRL_ROOM observers (chat + documentMeta)");
 }

--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -125,21 +125,15 @@ export function getBufferedSelection(docName: string): BufferedSelection | undef
 
 /** Attach observers to a document's Y.Maps. Call after doc swap in onLoadDocument. */
 export function attachObservers(docName: string, doc: Y.Doc): void {
-  // Detach existing observers first (idempotent)
   detachObservers(docName);
 
-  const cleanups: Array<() => void> = [];
-
-  // 1. Annotations observer
-  cleanups.push(makeAnnotationsObserver({ docName, doc, pushEvent }));
-
-  // 2. Annotation replies observer
-  cleanups.push(makeRepliesObserver({ docName, doc, pushEvent }));
-
-  // 3. User awareness observer (selection buffering)
   // Selections are buffered per-document and attached to the next chat:message,
   // rather than firing as standalone events (#188).
-  cleanups.push(makeAwarenessObserver({ docName, doc, selectionBuffer }));
+  const cleanups: Array<() => void> = [
+    makeAnnotationsObserver({ docName, doc, pushEvent }),
+    makeRepliesObserver({ docName, doc, pushEvent }),
+    makeAwarenessObserver({ docName, doc, selectionBuffer }),
+  ];
 
   docObservers.set(docName, cleanups);
   console.error(`[EventQueue] Attached observers for document: ${docName}`);
@@ -158,13 +152,6 @@ export function detachObservers(docName: string): void {
 /** Reattach observers after Hocuspocus replaces a Y.Doc instance. */
 export function reattachObservers(docName: string, newDoc: Y.Doc): void {
   attachObservers(docName, newDoc);
-
-  // Annotation file-writer observer: if this doc has an active file-sync
-  // context (registered by the file-opener after loadAndMerge), re-register
-  // it against the NEW Y.Doc so disk persistence keeps flowing after the
-  // Hocuspocus doc swap. The previous observer was attached to the old
-  // Y.Doc and is no longer reachable (Hocuspocus destroyed the old doc
-  // in onLoadDocument); the cleanup we stashed would be a no-op anyway.
   reattachFileSyncObserver(docName, newDoc);
 }
 
@@ -174,17 +161,13 @@ let ctrlCleanups: Array<() => void> = [];
 
 /** Attach observers to the CTRL_ROOM Y.Doc for chat messages and document meta changes. */
 export function attachCtrlObservers(): void {
-  // Detach existing first
   for (const cleanup of ctrlCleanups) cleanup();
-  ctrlCleanups = [];
 
   const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
-
-  // Chat message observer
-  ctrlCleanups.push(makeCtrlChatObserver({ ctrlDoc, pushEvent, selectionBuffer }));
-
-  // Document meta observer (open/close/switch)
-  ctrlCleanups.push(makeCtrlMetaObserver({ ctrlDoc, pushEvent }));
+  ctrlCleanups = [
+    makeCtrlChatObserver({ ctrlDoc, pushEvent, selectionBuffer }),
+    makeCtrlMetaObserver({ ctrlDoc, pushEvent }),
+  ];
 
   console.error("[EventQueue] Attached CTRL_ROOM observers (chat + documentMeta)");
 }

--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -22,21 +22,21 @@ import {
   Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
 import type { Annotation, AnnotationReply, ChatMessage, FlatOffset } from "../../shared/types.js";
-import type { DocStore } from "../annotations/store.js";
-import {
-  type ObserverCleanupPhase,
-  registerAnnotationObserver,
-  type SyncContext,
-} from "../annotations/sync.js";
 import { sanitizeAnnotation } from "../mcp/annotations.js";
 import { getOpenDocs } from "../mcp/document-service.js";
 import { validateRange } from "../positions.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
+import {
+  clearFileSyncContext,
+  resetForTesting as fileSyncResetForTesting,
+  reattachFileSyncObserver,
+  setFileSyncContext,
+} from "./file-sync-registry.js";
 import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "./origins.js";
 import type { TandemEvent } from "./types.js";
 import { generateEventId } from "./types.js";
 
-export { FILE_SYNC_ORIGIN, MCP_ORIGIN };
+export { clearFileSyncContext, FILE_SYNC_ORIGIN, MCP_ORIGIN, setFileSyncContext };
 
 /**
  * Read the user's configured selection dwell time from CTRL_ROOM.
@@ -331,93 +331,7 @@ export function reattachObservers(docName: string, newDoc: Y.Doc): void {
   // Hocuspocus doc swap. The previous observer was attached to the old
   // Y.Doc and is no longer reachable (Hocuspocus destroyed the old doc
   // in onLoadDocument); the cleanup we stashed would be a no-op anyway.
-  const oldCtx = fileSyncContexts.get(docName);
-  if (oldCtx) {
-    safeCleanup(docName, oldCtx.cleanup, "swap", "reattach");
-    const newCtx: SyncContext = {
-      ydoc: newDoc,
-      store: oldCtx.ctx.store,
-      docHash: oldCtx.ctx.docHash,
-      meta: oldCtx.ctx.meta,
-    };
-    const cleanup = registerAnnotationObserver(newCtx);
-    fileSyncContexts.set(docName, { ctx: newCtx, cleanup });
-  }
-}
-
-// --- File-sync observer registry (durable annotations) ---
-
-/**
- * Track per-doc SyncContext so `reattachObservers` can re-register the
- * annotation file-writer observer against the new Y.Doc after a Hocuspocus
- * doc swap. Stored alongside the cleanup handle from the prior
- * `registerAnnotationObserver` call so we can dispose it deterministically.
- */
-const fileSyncContexts = new Map<
-  string,
-  { ctx: SyncContext; cleanup: (phase?: ObserverCleanupPhase) => void }
->();
-
-/**
- * Run a file-sync observer cleanup in a try/catch with a uniform log line.
- * Cleanups can throw if the underlying Y.Doc was already destroyed (e.g. a
- * Hocuspocus reload beat us to it) — that's harmless, but we want the logs
- * to be consistent enough to grep.
- */
-function safeCleanup(
-  docName: string,
-  cleanup: (phase?: ObserverCleanupPhase) => void,
-  phase: ObserverCleanupPhase,
-  logTag: string,
-): void {
-  try {
-    cleanup(phase);
-  } catch (err) {
-    console.warn("[EventQueue] file-sync cleanup threw during %s for %s:", logTag, docName, err);
-  }
-}
-
-/**
- * Register the durable-annotation sync context for a document. Called by the
- * file-opener after `loadAndMerge` returns its observer cleanup. The cleanup
- * passed here is what gets invoked on `clearFileSyncContext` or the next
- * `reattachObservers` call.
- *
- * Callers don't need to think about the swap-vs-close distinction: the queue
- * picks the phase at teardown time based on which entrypoint ran.
- */
-export function setFileSyncContext(
-  docName: string,
-  ctx: SyncContext,
-  cleanup: (phase?: ObserverCleanupPhase) => void,
-): void {
-  // Dispose any prior entry first so we never leak observers on duplicate
-  // registration (e.g., forceReload paths that re-run loadAndMerge). Normal
-  // flow pre-clears via `clearFileSyncContext`, so this branch is defensive;
-  // `"close"` is correct because we're replacing — not rebinding — the
-  // context, so the prior docHash's tombstones belong to a superseded state.
-  const existing = fileSyncContexts.get(docName);
-  if (existing) {
-    safeCleanup(docName, existing.cleanup, "close", "replace");
-  }
-  fileSyncContexts.set(docName, { ctx, cleanup });
-}
-
-/**
- * Drop the file-sync context for a document (on close or force-reload prep).
- * Returns the dropped `{ store, docHash }` so callers can flush/clear the
- * durable store without recomputing the hash or minting a transient handle.
- * Returns `undefined` if no context was registered (e.g. feature flag off,
- * or `wireAnnotationStore` failed during open).
- */
-export function clearFileSyncContext(
-  docName: string,
-): { store: DocStore; docHash: string } | undefined {
-  const entry = fileSyncContexts.get(docName);
-  if (!entry) return undefined;
-  safeCleanup(docName, entry.cleanup, "close", "clear");
-  fileSyncContexts.delete(docName);
-  return { store: entry.ctx.store, docHash: entry.ctx.docHash };
+  reattachFileSyncObserver(docName, newDoc);
 }
 
 // --- CTRL_ROOM observers (chat + document meta) ---
@@ -573,22 +487,22 @@ export function reattachCtrlObservers(): void {
 
 /** Reset all module state. For tests only — do not call in production. */
 export function resetForTesting(): void {
+  // 1. Clear data-only collections (observer cleanups don't touch these)
   buffer.length = 0;
   subscribers.clear();
   emittedPayloadIds.clear();
   selectionBuffer.clear();
+
+  // 2. Run per-doc observer cleanups, then clear the map that holds them
   for (const cleanups of docObservers.values()) {
     for (const cleanup of cleanups) cleanup();
   }
   docObservers.clear();
+
+  // 3. Run CTRL cleanups, then reset the array that holds them
   for (const cleanup of ctrlCleanups) cleanup();
   ctrlCleanups = [];
-  for (const entry of fileSyncContexts.values()) {
-    try {
-      entry.cleanup("close");
-    } catch {
-      /* ignore — test cleanup should not throw on pre-torn-down docs */
-    }
-  }
-  fileSyncContexts.clear();
+
+  // 4. Delegate registry reset (CRITICAL — do not forget)
+  fileSyncResetForTesting();
 }

--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -11,10 +11,7 @@ import {
   CHANNEL_EVENT_BUFFER_AGE_MS,
   CHANNEL_EVENT_BUFFER_SIZE,
   CTRL_ROOM,
-  Y_MAP_CHAT,
 } from "../../shared/constants.js";
-import type { ChatMessage, FlatOffset } from "../../shared/types.js";
-import { validateRange } from "../positions.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
 import {
   clearFileSyncContext,
@@ -24,11 +21,11 @@ import {
 } from "./file-sync-registry.js";
 import { makeAnnotationsObserver } from "./observers/annotations.js";
 import { makeAwarenessObserver } from "./observers/awareness.js";
+import { makeCtrlChatObserver } from "./observers/ctrl-chat.js";
 import { makeCtrlMetaObserver } from "./observers/ctrl-meta.js";
 import { makeRepliesObserver } from "./observers/replies.js";
 import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "./origins.js";
 import type { BufferedSelection, TandemEvent } from "./types.js";
-import { generateEventId } from "./types.js";
 
 export { clearFileSyncContext, FILE_SYNC_ORIGIN, MCP_ORIGIN, setFileSyncContext };
 
@@ -184,65 +181,7 @@ export function attachCtrlObservers(): void {
   const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
 
   // Chat message observer
-  const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
-  const chatObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
-    if (txn.origin === MCP_ORIGIN) return;
-
-    for (const [key, change] of event.changes.keys) {
-      if (change.action !== "add") continue;
-      const msg = chatMap.get(key) as ChatMessage | undefined;
-      if (!msg || msg.author !== "user") continue;
-
-      // Attach buffered selection context if available for this document
-      let selection:
-        | { from: number; to: number; selectedText: string }
-        | { selectedText: string }
-        | undefined;
-      if (msg.documentId) {
-        const buffered = selectionBuffer.get(msg.documentId);
-        if (buffered) {
-          selectionBuffer.delete(msg.documentId);
-          // Validate range is still valid before attaching offsets
-          try {
-            const doc = getOrCreateDocument(msg.documentId);
-            const validation = validateRange(
-              doc,
-              buffered.from as FlatOffset,
-              buffered.to as FlatOffset,
-            );
-            if (validation.ok) {
-              selection = buffered;
-            } else {
-              // Range went stale — attach text only (no offsets)
-              selection = { selectedText: buffered.selectedText };
-            }
-          } catch (err) {
-            console.warn(
-              `[EventQueue] Failed to validate buffered selection for doc=${msg.documentId}:`,
-              err,
-            );
-            selection = { selectedText: buffered.selectedText };
-          }
-        }
-      }
-
-      pushEvent({
-        id: generateEventId(),
-        type: "chat:message",
-        timestamp: Date.now(),
-        documentId: msg.documentId,
-        payload: {
-          messageId: msg.id,
-          text: msg.text,
-          replyTo: msg.replyTo ?? null,
-          anchor: msg.anchor ?? null,
-          ...(selection ? { selection } : {}),
-        },
-      });
-    }
-  };
-  chatMap.observe(chatObs);
-  ctrlCleanups.push(() => chatMap.unobserve(chatObs));
+  ctrlCleanups.push(makeCtrlChatObserver({ ctrlDoc, pushEvent, selectionBuffer }));
 
   // Document meta observer (open/close/switch)
   ctrlCleanups.push(makeCtrlMetaObserver({ ctrlDoc, pushEvent }));

--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -1,9 +1,10 @@
 /**
  * Event queue that observes Y.Map changes and emits TandemEvents.
  *
- * Observers filter by transaction origin — only browser-originated changes
- * (origin !== 'mcp') generate events. This prevents Claude from seeing its
- * own actions echoed back via the channel.
+ * Observers filter by transaction origin — MCP-origin writes are skipped so
+ * Claude doesn't see its own actions echoed back, and file-sync-origin writes
+ * are skipped so disk reloads don't fire spurious SSE events. Only
+ * browser-originated changes generate channel events.
  */
 
 import * as Y from "yjs";
@@ -111,7 +112,7 @@ export function replaySince(lastEventId: string): TandemEvent[] {
   return buffer.slice(idx + 1);
 }
 
-/** O(1) check if an annotation/message was already pushed via channel. Intended for checkInbox dedup (not yet wired). */
+/** O(1) check if an annotation/message was already pushed via channel. Used for checkInbox dedup. */
 export function wasEmittedViaChannel(payloadId: string): boolean {
   return emittedPayloadIds.has(payloadId);
 }
@@ -179,22 +180,20 @@ export function reattachCtrlObservers(): void {
 
 /** Reset all module state. For tests only — do not call in production. */
 export function resetForTesting(): void {
-  // 1. Clear data-only collections (observer cleanups don't touch these)
   buffer.length = 0;
   subscribers.clear();
   emittedPayloadIds.clear();
   selectionBuffer.clear();
 
-  // 2. Run per-doc observer cleanups, then clear the map that holds them
   for (const cleanups of docObservers.values()) {
     for (const cleanup of cleanups) cleanup();
   }
   docObservers.clear();
 
-  // 3. Run CTRL cleanups, then reset the array that holds them
   for (const cleanup of ctrlCleanups) cleanup();
   ctrlCleanups = [];
 
-  // 4. Delegate registry reset (CRITICAL — do not forget)
+  // Delegate to registry — its cleanup loop is the only way to dispose
+  // in-flight tombstone debounces across tests.
   fileSyncResetForTesting();
 }

--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -11,12 +11,7 @@ import {
   CHANNEL_EVENT_BUFFER_AGE_MS,
   CHANNEL_EVENT_BUFFER_SIZE,
   CTRL_ROOM,
-  SELECTION_DWELL_DEFAULT_MS,
-  SELECTION_DWELL_MAX_MS,
-  SELECTION_DWELL_MIN_MS,
   Y_MAP_CHAT,
-  Y_MAP_DWELL_MS,
-  Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
 import type { ChatMessage, FlatOffset } from "../../shared/types.js";
 import { validateRange } from "../positions.js";
@@ -28,48 +23,21 @@ import {
   setFileSyncContext,
 } from "./file-sync-registry.js";
 import { makeAnnotationsObserver } from "./observers/annotations.js";
+import { makeAwarenessObserver } from "./observers/awareness.js";
 import { makeCtrlMetaObserver } from "./observers/ctrl-meta.js";
 import { makeRepliesObserver } from "./observers/replies.js";
 import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "./origins.js";
-import type { TandemEvent } from "./types.js";
+import type { BufferedSelection, TandemEvent } from "./types.js";
 import { generateEventId } from "./types.js";
 
 export { clearFileSyncContext, FILE_SYNC_ORIGIN, MCP_ORIGIN, setFileSyncContext };
-
-/**
- * Read the user's configured selection dwell time from CTRL_ROOM.
- *
- * Called at timer-schedule time (not fire time), so mid-dwell slider changes
- * don't affect an in-flight timer — the updated value takes effect on the
- * next selection change.
- *
- * Falls back to `SELECTION_DWELL_DEFAULT_MS` when:
- *   - CTRL_ROOM has no dwell key set (normal on cold startup, before the
- *     client's broadcast effect runs)
- *   - The stored value is the wrong type or outside [MIN, MAX] — the client
- *     clamps on write, so this branch indicates a bug or client/server
- *     constant drift. Logged as a warning so it can be diagnosed.
- */
-function getDwellMs(): number {
-  const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
-  const awareness = ctrlDoc.getMap(Y_MAP_USER_AWARENESS);
-  const val = awareness.get(Y_MAP_DWELL_MS);
-  if (val === undefined) return SELECTION_DWELL_DEFAULT_MS;
-  if (typeof val === "number" && val >= SELECTION_DWELL_MIN_MS && val <= SELECTION_DWELL_MAX_MS) {
-    return val;
-  }
-  console.warn(
-    `[EventQueue] Invalid dwell time in CTRL_ROOM awareness (type=${typeof val}, value=${String(val)}); using default ${SELECTION_DWELL_DEFAULT_MS}ms`,
-  );
-  return SELECTION_DWELL_DEFAULT_MS;
-}
 
 type EventCallback = (event: TandemEvent) => void;
 
 const docObservers = new Map<string, Array<() => void>>();
 
 /** Per-document selection buffer. Selections are stored here instead of being pushed as events. They get attached to the next chat:message for the same document. */
-const selectionBuffer = new Map<string, { from: number; to: number; selectedText: string }>();
+const selectionBuffer = new Map<string, BufferedSelection>();
 
 /** O(1) dedup: ref-counted annotation/message IDs that have been pushed via channel. */
 const emittedPayloadIds = new Map<string, number>();
@@ -152,9 +120,7 @@ export function wasEmittedViaChannel(payloadId: string): boolean {
 }
 
 /** Read the buffered selection for a document. For tests and checkInbox. */
-export function getBufferedSelection(
-  docName: string,
-): { from: number; to: number; selectedText: string } | undefined {
+export function getBufferedSelection(docName: string): BufferedSelection | undefined {
   return selectionBuffer.get(docName);
 }
 
@@ -176,46 +142,7 @@ export function attachObservers(docName: string, doc: Y.Doc): void {
   // 3. User awareness observer (selection buffering)
   // Selections are buffered per-document and attached to the next chat:message,
   // rather than firing as standalone events (#188).
-  const userAwareness = doc.getMap(Y_MAP_USER_AWARENESS);
-  let selectionDwellTimer: ReturnType<typeof setTimeout> | null = null;
-
-  const awarenessObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
-    if (txn.origin === MCP_ORIGIN) return;
-
-    if (event.keysChanged.has("selection")) {
-      const selection = userAwareness.get("selection") as
-        | { from: FlatOffset; to: FlatOffset; selectedText?: string }
-        | undefined;
-
-      // Cancel any pending dwell timer
-      if (selectionDwellTimer) {
-        clearTimeout(selectionDwellTimer);
-        selectionDwellTimer = null;
-      }
-
-      // Skip cleared selections — also clear the buffer
-      if (!selection || selection.from === selection.to) {
-        selectionBuffer.delete(docName);
-        return;
-      }
-
-      // Buffer after dwell to filter transient drag selections
-      selectionDwellTimer = setTimeout(() => {
-        selectionDwellTimer = null;
-        selectionBuffer.set(docName, {
-          from: selection.from,
-          to: selection.to,
-          selectedText: selection.selectedText ?? "",
-        });
-      }, getDwellMs());
-    }
-  };
-  userAwareness.observe(awarenessObs);
-  cleanups.push(() => {
-    userAwareness.unobserve(awarenessObs);
-    if (selectionDwellTimer) clearTimeout(selectionDwellTimer);
-    selectionBuffer.delete(docName);
-  });
+  cleanups.push(makeAwarenessObserver({ docName, doc, selectionBuffer }));
 
   docObservers.set(docName, cleanups);
   console.error(`[EventQueue] Attached observers for document: ${docName}`);

--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -32,19 +32,11 @@ import { sanitizeAnnotation } from "../mcp/annotations.js";
 import { getOpenDocs } from "../mcp/document-service.js";
 import { validateRange } from "../positions.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
+import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "./origins.js";
 import type { TandemEvent } from "./types.js";
 import { generateEventId } from "./types.js";
 
-/** Origin tag for all MCP-initiated Y.Map writes. Import and use this — never use raw "mcp" strings. */
-export const MCP_ORIGIN = "mcp";
-
-/**
- * Origin tag for Y.Map writes that originated from the annotation file-writer
- * (app-data JSON → Y.Map sync). Observers that emit channel events to external
- * consumers MUST skip transactions with this origin so a file-reload doesn't
- * fire spurious `annotation:*` SSE events.
- */
-export const FILE_SYNC_ORIGIN = "file-sync";
+export { FILE_SYNC_ORIGIN, MCP_ORIGIN };
 
 /**
  * Read the user's configured selection dwell time from CTRL_ROOM.

--- a/src/server/events/types.ts
+++ b/src/server/events/types.ts
@@ -9,3 +9,14 @@
  */
 
 export * from "../../shared/events/types.js";
+
+/**
+ * Per-document selection buffer entry. Produced by the awareness observer
+ * after a dwell timeout and consumed by the ctrl-chat observer when attaching
+ * selection context to a chat message.
+ */
+export type BufferedSelection = {
+  from: number; // FlatOffset
+  to: number; // FlatOffset
+  selectedText: string;
+};

--- a/tests/server/file-opener-lifecycle.test.ts
+++ b/tests/server/file-opener-lifecycle.test.ts
@@ -34,7 +34,7 @@ vi.mock("../../src/server/file-watcher", async (importOriginal) => ({
   watchFile: vi.fn(),
 }));
 
-import * as queueModule from "../../src/server/events/queue.js";
+import * as fileSyncRegistryModule from "../../src/server/events/file-sync-registry.js";
 import { watchFile } from "../../src/server/file-watcher.js";
 import { getOpenDocs, removeDoc, setActiveDocId } from "../../src/server/mcp/document-service.js";
 import { openFileByPath } from "../../src/server/mcp/file-opener.js";
@@ -139,7 +139,7 @@ describe("session restore — empty fragment", () => {
 // ---------------------------------------------------------------------------
 describe("annotation wiring", () => {
   it("calls setFileSyncContext with the document id on open", async () => {
-    const spy = vi.spyOn(queueModule, "setFileSyncContext");
+    const spy = vi.spyOn(fileSyncRegistryModule, "setFileSyncContext");
 
     const filePath = path.join(tmpDir, "annotation-wire.md");
     await fs.writeFile(filePath, "# Annotation wiring test");


### PR DESCRIPTION
## Summary

Phase 3 of the pre-v1.0 codebase audit: mechanically decomposes the 602-LOC `src/server/events/queue.ts` god-module into a strict DAG of focused files. Zero behavioral change, zero new event types, zero Y.js origin-string changes.

Plan: [docs/phase-3-plan.md](docs/phase-3-plan.md) (committed on this branch)

### What changed

- `src/server/events/origins.ts` — new leaf module with `MCP_ORIGIN` / `FILE_SYNC_ORIGIN` (dissolves the pre-existing `queue.ts ↔ annotations/sync.ts` import cycle)
- `src/server/events/file-sync-registry.ts` — new: `fileSyncContexts` Map + `setFileSyncContext` / `clearFileSyncContext` / `reattachFileSyncObserver` / `resetForTesting`
- `src/server/events/observers/{annotations,replies,awareness,ctrl-chat,ctrl-meta}.ts` — five `makeXxxObserver(deps)` factory modules
- `src/server/events/types.ts` — adds canonical `BufferedSelection` type (previously duplicated at 3 sites)
- `src/server/events/queue.ts` — now ~217 LOC: owns buffer / subscribers / `emittedPayloadIds` / `selectionBuffer` / attach-detach orchestration. Barrel re-exports 15 public symbols so no consumer import specifier changes (except `annotations/sync.ts:61` which switches to `origins.js`).
- `tests/server/file-opener-lifecycle.test.ts` — pre-decided spy-target switch from `queueModule` to `fileSyncRegistryModule` (Vitest ESM re-exports aren't interceptable from the barrel).

### Structure
```
src/server/events/
  origins.ts                18 LOC
  types.ts                  22 LOC   (+ BufferedSelection)
  queue.ts                 217 LOC
  file-sync-registry.ts    122 LOC
  sse.ts                    68 LOC   (unchanged)
  observers/
    annotations.ts          77 LOC
    replies.ts              47 LOC
    awareness.ts            90 LOC
    ctrl-chat.ts            79 LOC
    ctrl-meta.ts            84 LOC
```

### Invariants preserved

- `attachObservers` still starts with `detachObservers(docName)` (idempotency)
- `setTimeout(callback, getDwellMs())` inline evaluation at schedule time (dwell-slider bug class)
- Per-observer origin guards (no shared delegation)
- `selectionBuffer` is a single `Map` in `queue.ts` passed by reference to awareness (producer) and ctrl-chat (consumer)
- `reattachObservers` → `reattachFileSyncObserver` passes phase `"swap"`; close paths pass `"close"` (#333)
- `ref-counted` `emittedPayloadIds` dedup survives buffer eviction
- `resetForTesting` in the registry includes the try/catch cleanup loop (silent-leak trap)
- `src/server/index.ts` — byte-identical (import-only concern; not touched)

### Commits (reviewer ergonomics)

One commit per migration step, each verified by `npm run typecheck && npm test` before proceeding.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1,428 passed, 3 skipped. One pre-existing flake in `tests/cli/mcp-stdio.test.ts` under parallel load (passes in isolation; confirmed unrelated to this PR via baseline stash-and-retest)
- [x] `npm run build` — all four bundles (server / channel / cli / monitor) build clean
- [ ] `npm run test:e2e` — skipped locally because user's dev server is running on :3478/:3479 and Playwright's `webServer` would `freePort()` it. CI will run it.
- [x] Import-diff check on `src/server/index.ts` — unchanged (confirmed via `git diff master..HEAD --stat`)
- [x] Module cycle audit — strict DAG (origins.ts is a leaf; observers don't import from queue.ts or each other)

## Follow-up (tracked separately, not blocking)

Four regression tests named in the plan:
1. Mid-dwell detach clears the selection buffer timer
2. Rapid distinct-doc swaps (3-doc sequence) — cleaner coverage than current same-doc idempotency test
3. Explicit assertion that `resetForTesting` delegates to `fileSyncRegistry.resetForTesting()` with phase `"close"`
4. Regression lock on the new spy target after the switch

Will file a roadmap issue once this PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)