### PR TITLE
refactor(server): simplify zero-arg handler factories (#393)

### DIFF
--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -2,17 +2,17 @@ import type { Express, NextFunction, Request, Response } from "express";
 
 import { TAURI_HOSTNAME } from "../../shared/constants.js";
 import type { Handler } from "./routes/_shared.js";
-import { makeAnnotationReplyHandler } from "./routes/annotation-reply.js";
-import { makeApplyChangesHandler } from "./routes/apply-changes.js";
-import { makeCloseHandler } from "./routes/close.js";
-import { makeConvertHandler } from "./routes/convert.js";
-import { makeModeHandler } from "./routes/mode.js";
-import { makeNotifyStreamHandler } from "./routes/notify-stream.js";
-import { makeOpenHandler } from "./routes/open.js";
+import { handleAnnotationReply } from "./routes/annotation-reply.js";
+import { handleApplyChanges } from "./routes/apply-changes.js";
+import { handleClose } from "./routes/close.js";
+import { handleConvert } from "./routes/convert.js";
+import { handleMode } from "./routes/mode.js";
+import { handleNotifyStream } from "./routes/notify-stream.js";
+import { handleOpen } from "./routes/open.js";
 import { makeRotateTokenHandler } from "./routes/rotate-token.js";
-import { makeSaveHandler } from "./routes/save.js";
+import { handleSave } from "./routes/save.js";
 import { makeSetupHandler } from "./routes/setup.js";
-import { makeUploadHandler } from "./routes/upload.js";
+import { handleUpload } from "./routes/upload.js";
 
 export type { Handler } from "./routes/_shared.js";
 // Re-export shared utilities that tests and other modules import from here
@@ -97,35 +97,35 @@ export function registerApiRoutes(
   getCurrentToken: () => string | null = () => null,
 ): void {
   // SSE notification stream for browser toasts
-  app.get("/api/notify-stream", mw, makeNotifyStreamHandler());
+  app.get("/api/notify-stream", mw, handleNotifyStream);
 
   // NOTE: /api/mode is GET-only — no OPTIONS registration
-  app.get("/api/mode", mw, makeModeHandler());
+  app.get("/api/mode", mw, handleMode);
 
   app.options("/api/open", mw);
-  app.post("/api/open", mw, largeBody, makeOpenHandler());
+  app.post("/api/open", mw, largeBody, handleOpen);
 
   app.options("/api/close", mw);
-  app.post("/api/close", mw, largeBody, makeCloseHandler());
+  app.post("/api/close", mw, largeBody, handleClose);
 
   app.options("/api/save", mw);
-  app.post("/api/save", mw, largeBody, makeSaveHandler());
+  app.post("/api/save", mw, largeBody, handleSave);
 
   app.options("/api/upload", mw);
-  app.post("/api/upload", mw, largeBody, makeUploadHandler());
+  app.post("/api/upload", mw, largeBody, handleUpload);
 
   app.options("/api/convert", mw);
-  app.post("/api/convert", mw, largeBody, makeConvertHandler());
+  app.post("/api/convert", mw, largeBody, handleConvert);
 
   app.options("/api/apply-changes", mw);
-  app.post("/api/apply-changes", mw, largeBody, makeApplyChangesHandler());
+  app.post("/api/apply-changes", mw, largeBody, handleApplyChanges);
 
   app.options("/api/setup", mw);
   app.post("/api/setup", mw, largeBody, makeSetupHandler({ token }));
 
   // Annotation reply: browser user posts a reply to an annotation thread
   app.options("/api/annotation-reply", mw);
-  app.post("/api/annotation-reply", mw, largeBody, makeAnnotationReplyHandler());
+  app.post("/api/annotation-reply", mw, largeBody, handleAnnotationReply);
 
   // Token rotation: CLI calls this to activate the 60-second grace window and swap the
   // in-memory current token to the NEW token that was already written to disk.

--- a/src/server/mcp/routes/annotation-reply.ts
+++ b/src/server/mcp/routes/annotation-reply.ts
@@ -5,43 +5,40 @@ import { pushNotification } from "../../notifications.js";
 import { getOrCreateDocument } from "../../yjs/provider.js";
 import { addReplyToAnnotation } from "../annotations.js";
 import { getCurrentDoc } from "../document.js";
-import type { Handler } from "./_shared.js";
 
-export function makeAnnotationReplyHandler(): Handler {
-  return (req: Request, res: Response) => {
-    const { annotationId, text, documentId } = (req.body ?? {}) as Record<string, unknown>;
-    if (!annotationId || typeof annotationId !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "annotationId is required" });
-      return;
-    }
-    if (!text || typeof text !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "text is required" });
-      return;
-    }
+export function handleAnnotationReply(req: Request, res: Response): void {
+  const { annotationId, text, documentId } = (req.body ?? {}) as Record<string, unknown>;
+  if (!annotationId || typeof annotationId !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "annotationId is required" });
+    return;
+  }
+  if (!text || typeof text !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "text is required" });
+    return;
+  }
 
-    const doc = getCurrentDoc(typeof documentId === "string" ? documentId : undefined);
-    if (!doc) {
-      res.status(404).json({ error: "NOT_FOUND", message: "No document open" });
-      return;
-    }
-    const ydoc = getOrCreateDocument(doc.docName);
-    const annotationsMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+  const doc = getCurrentDoc(typeof documentId === "string" ? documentId : undefined);
+  if (!doc) {
+    res.status(404).json({ error: "NOT_FOUND", message: "No document open" });
+    return;
+  }
+  const ydoc = getOrCreateDocument(doc.docName);
+  const annotationsMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
 
-    // No origin tag — allows event emission so Claude sees user replies
-    const result = addReplyToAnnotation(ydoc, annotationsMap, annotationId, text, "user");
-    if (!result.ok) {
-      const status = result.code === "ANNOTATION_RESOLVED" ? 409 : 404;
-      pushNotification({
-        id: generateNotificationId(),
-        type: "annotation-error",
-        severity: "error",
-        message: `Reply failed: ${result.error}`,
-        dedupKey: `reply-error:${annotationId}`,
-        timestamp: Date.now(),
-      });
-      res.status(status).json({ error: result.code, message: result.error });
-      return;
-    }
-    res.json({ data: { replyId: result.replyId, annotationId } });
-  };
+  // No origin tag — allows event emission so Claude sees user replies
+  const result = addReplyToAnnotation(ydoc, annotationsMap, annotationId, text, "user");
+  if (!result.ok) {
+    const status = result.code === "ANNOTATION_RESOLVED" ? 409 : 404;
+    pushNotification({
+      id: generateNotificationId(),
+      type: "annotation-error",
+      severity: "error",
+      message: `Reply failed: ${result.error}`,
+      dedupKey: `reply-error:${annotationId}`,
+      timestamp: Date.now(),
+    });
+    res.status(status).json({ error: result.code, message: result.error });
+    return;
+  }
+  res.json({ data: { replyId: result.replyId, annotationId } });
 }

--- a/src/server/mcp/routes/apply-changes.ts
+++ b/src/server/mcp/routes/apply-changes.ts
@@ -1,33 +1,30 @@
 import type { Request, Response } from "express";
 import { applyChangesCore } from "../docx-apply.js";
-import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
-export function makeApplyChangesHandler(): Handler {
-  return async (req: Request, res: Response) => {
-    const { documentId, author, backupPath } = (req.body ?? {}) as Record<string, unknown>;
-    if (documentId !== undefined && typeof documentId !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
-      return;
-    }
-    if (author !== undefined && typeof author !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "author must be a string" });
-      return;
-    }
-    if (backupPath !== undefined && typeof backupPath !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "backupPath must be a string" });
-      return;
-    }
+export async function handleApplyChanges(req: Request, res: Response): Promise<void> {
+  const { documentId, author, backupPath } = (req.body ?? {}) as Record<string, unknown>;
+  if (documentId !== undefined && typeof documentId !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
+    return;
+  }
+  if (author !== undefined && typeof author !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "author must be a string" });
+    return;
+  }
+  if (backupPath !== undefined && typeof backupPath !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "backupPath must be a string" });
+    return;
+  }
 
-    try {
-      const result = await applyChangesCore(
-        documentId as string | undefined,
-        author as string | undefined,
-        backupPath as string | undefined,
-      );
-      res.json({ data: result });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  };
+  try {
+    const result = await applyChangesCore(
+      documentId as string | undefined,
+      author as string | undefined,
+      backupPath as string | undefined,
+    );
+    res.json({ data: result });
+  } catch (err: unknown) {
+    sendApiError(res, err);
+  }
 }

--- a/src/server/mcp/routes/close.ts
+++ b/src/server/mcp/routes/close.ts
@@ -1,26 +1,23 @@
 import type { Request, Response } from "express";
 import { closeDocumentById } from "../document-service.js";
-import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
-export function makeCloseHandler(): Handler {
-  return async (req: Request, res: Response) => {
-    const { documentId } = (req.body ?? {}) as Record<string, unknown>;
-    if (!documentId || typeof documentId !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "documentId is required" });
+export async function handleClose(req: Request, res: Response): Promise<void> {
+  const { documentId } = (req.body ?? {}) as Record<string, unknown>;
+  if (!documentId || typeof documentId !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "documentId is required" });
+    return;
+  }
+  try {
+    const result = await closeDocumentById(documentId);
+    if (!result.success) {
+      res.status(404).json({ error: "NOT_FOUND", message: result.error });
       return;
     }
-    try {
-      const result = await closeDocumentById(documentId);
-      if (!result.success) {
-        res.status(404).json({ error: "NOT_FOUND", message: result.error });
-        return;
-      }
-      res.json({
-        data: { closedPath: result.closedPath, activeDocumentId: result.activeDocumentId },
-      });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  };
+    res.json({
+      data: { closedPath: result.closedPath, activeDocumentId: result.activeDocumentId },
+    });
+  } catch (err: unknown) {
+    sendApiError(res, err);
+  }
 }

--- a/src/server/mcp/routes/convert.ts
+++ b/src/server/mcp/routes/convert.ts
@@ -1,28 +1,25 @@
 import type { Request, Response } from "express";
 import { convertToMarkdown } from "../convert.js";
-import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
-export function makeConvertHandler(): Handler {
-  return async (req: Request, res: Response) => {
-    const { documentId, outputPath } = (req.body ?? {}) as Record<string, unknown>;
-    if (documentId !== undefined && typeof documentId !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
-      return;
-    }
-    if (outputPath !== undefined && typeof outputPath !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "outputPath must be a string" });
-      return;
-    }
+export async function handleConvert(req: Request, res: Response): Promise<void> {
+  const { documentId, outputPath } = (req.body ?? {}) as Record<string, unknown>;
+  if (documentId !== undefined && typeof documentId !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
+    return;
+  }
+  if (outputPath !== undefined && typeof outputPath !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "outputPath must be a string" });
+    return;
+  }
 
-    try {
-      const result = await convertToMarkdown(
-        documentId as string | undefined,
-        outputPath as string | undefined,
-      );
-      res.json({ data: result });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  };
+  try {
+    const result = await convertToMarkdown(
+      documentId as string | undefined,
+      outputPath as string | undefined,
+    );
+    res.json({ data: result });
+  } catch (err: unknown) {
+    sendApiError(res, err);
+  }
 }

--- a/src/server/mcp/routes/mode.ts
+++ b/src/server/mcp/routes/mode.ts
@@ -7,13 +7,10 @@ import {
 } from "../../../shared/constants.js";
 import { TandemModeSchema } from "../../../shared/types.js";
 import { getOrCreateDocument } from "../../yjs/provider.js";
-import type { Handler } from "./_shared.js";
 
-export function makeModeHandler(): Handler {
-  return (_req: Request, res: Response) => {
-    const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
-    const awareness = ctrlDoc.getMap(Y_MAP_USER_AWARENESS);
-    const mode = TandemModeSchema.catch(TANDEM_MODE_DEFAULT).parse(awareness.get(Y_MAP_MODE));
-    res.json({ mode });
-  };
+export function handleMode(_req: Request, res: Response): void {
+  const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
+  const awareness = ctrlDoc.getMap(Y_MAP_USER_AWARENESS);
+  const mode = TandemModeSchema.catch(TANDEM_MODE_DEFAULT).parse(awareness.get(Y_MAP_MODE));
+  res.json({ mode });
 }

--- a/src/server/mcp/routes/notify-stream.ts
+++ b/src/server/mcp/routes/notify-stream.ts
@@ -2,52 +2,49 @@ import type { Request, Response } from "express";
 import { CHANNEL_SSE_KEEPALIVE_MS } from "../../../shared/constants.js";
 import type { TandemNotification } from "../../../shared/types.js";
 import { subscribe as subscribeNotifications } from "../../notifications.js";
-import type { Handler } from "./_shared.js";
 
-export function makeNotifyStreamHandler(): Handler {
-  return (req: Request, res: Response) => {
-    res.writeHead(200, {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
-    });
+export function handleNotifyStream(req: Request, res: Response): void {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
 
-    res.write(": connected\n\n");
+  res.write(": connected\n\n");
 
-    function cleanup(): void {
-      clearInterval(keepalive);
-      unsubscribe();
-    }
+  function cleanup(): void {
+    clearInterval(keepalive);
+    unsubscribe();
+  }
 
-    const unsubscribe = subscribeNotifications((notification: TandemNotification) => {
-      try {
-        res.write(`data: ${JSON.stringify(notification)}\n\n`);
-      } catch (err) {
-        console.error(
-          "[NotifyStream] Write failed, cleaning up:",
-          err instanceof Error ? err.message : err,
-        );
-        cleanup();
-      }
-    });
-
-    const keepalive = setInterval(() => {
-      try {
-        if (!res.writableEnded) res.write(": keepalive\n\n");
-      } catch (err) {
-        console.error(
-          "[NotifyStream] Keepalive write failed, cleaning up:",
-          err instanceof Error ? err.message : err,
-        );
-        cleanup();
-      }
-    }, CHANNEL_SSE_KEEPALIVE_MS);
-
-    req.on("close", () => {
+  const unsubscribe = subscribeNotifications((notification: TandemNotification) => {
+    try {
+      res.write(`data: ${JSON.stringify(notification)}\n\n`);
+    } catch (err) {
+      console.error(
+        "[NotifyStream] Write failed, cleaning up:",
+        err instanceof Error ? err.message : err,
+      );
       cleanup();
-      console.error("[NotifyStream] Client disconnected from /api/notify-stream");
-    });
+    }
+  });
 
-    console.error("[NotifyStream] Client connected to /api/notify-stream");
-  };
+  const keepalive = setInterval(() => {
+    try {
+      if (!res.writableEnded) res.write(": keepalive\n\n");
+    } catch (err) {
+      console.error(
+        "[NotifyStream] Keepalive write failed, cleaning up:",
+        err instanceof Error ? err.message : err,
+      );
+      cleanup();
+    }
+  }, CHANNEL_SSE_KEEPALIVE_MS);
+
+  req.on("close", () => {
+    cleanup();
+    console.error("[NotifyStream] Client disconnected from /api/notify-stream");
+  });
+
+  console.error("[NotifyStream] Client connected to /api/notify-stream");
 }

--- a/src/server/mcp/routes/open.ts
+++ b/src/server/mcp/routes/open.ts
@@ -1,20 +1,17 @@
 import type { Request, Response } from "express";
 import { openFileByPath } from "../file-opener.js";
-import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
-export function makeOpenHandler(): Handler {
-  return async (req: Request, res: Response) => {
-    const { filePath, force } = (req.body ?? {}) as Record<string, unknown>;
-    if (!filePath || typeof filePath !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "filePath is required" });
-      return;
-    }
-    try {
-      const result = await openFileByPath(filePath, { force: force === true });
-      res.json({ data: result });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  };
+export async function handleOpen(req: Request, res: Response): Promise<void> {
+  const { filePath, force } = (req.body ?? {}) as Record<string, unknown>;
+  if (!filePath || typeof filePath !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "filePath is required" });
+    return;
+  }
+  try {
+    const result = await openFileByPath(filePath, { force: force === true });
+    res.json({ data: result });
+  } catch (err: unknown) {
+    sendApiError(res, err);
+  }
 }

--- a/src/server/mcp/routes/save.ts
+++ b/src/server/mcp/routes/save.ts
@@ -1,25 +1,22 @@
 import type { Request, Response } from "express";
 import { getActiveDocId, saveDocumentToDisk } from "../document-service.js";
-import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
-export function makeSaveHandler(): Handler {
-  return async (req: Request, res: Response) => {
-    const { documentId } = (req.body ?? {}) as Record<string, unknown>;
-    if (documentId !== undefined && typeof documentId !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
-      return;
-    }
-    const targetId = (documentId as string | undefined) ?? getActiveDocId();
-    if (!targetId) {
-      res.status(404).json({ error: "NOT_FOUND", message: "No document to save." });
-      return;
-    }
-    try {
-      const result = await saveDocumentToDisk(targetId, "manual");
-      res.json({ data: result });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  };
+export async function handleSave(req: Request, res: Response): Promise<void> {
+  const { documentId } = (req.body ?? {}) as Record<string, unknown>;
+  if (documentId !== undefined && typeof documentId !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "documentId must be a string" });
+    return;
+  }
+  const targetId = (documentId as string | undefined) ?? getActiveDocId();
+  if (!targetId) {
+    res.status(404).json({ error: "NOT_FOUND", message: "No document to save." });
+    return;
+  }
+  try {
+    const result = await saveDocumentToDisk(targetId, "manual");
+    res.json({ data: result });
+  } catch (err: unknown) {
+    sendApiError(res, err);
+  }
 }

--- a/src/server/mcp/routes/upload.ts
+++ b/src/server/mcp/routes/upload.ts
@@ -1,31 +1,28 @@
 import type { Request, Response } from "express";
 import { detectFormat } from "../document-model.js";
 import { openFileFromContent } from "../file-opener.js";
-import type { Handler } from "./_shared.js";
 import { sendApiError } from "./_shared.js";
 
-export function makeUploadHandler(): Handler {
-  return async (req: Request, res: Response) => {
-    const { fileName, content } = (req.body ?? {}) as Record<string, unknown>;
-    if (!fileName || typeof fileName !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "fileName is required" });
-      return;
-    }
-    if (content === undefined || content === null) {
-      res.status(400).json({ error: "BAD_REQUEST", message: "content is required" });
-      return;
-    }
-    if (typeof content !== "string") {
-      res.status(400).json({ error: "BAD_REQUEST", message: "content must be a base64 string" });
-      return;
-    }
-    try {
-      const format = detectFormat(fileName);
-      const decoded = format === "docx" ? Buffer.from(content, "base64") : String(content);
-      const result = await openFileFromContent(fileName, decoded);
-      res.json({ data: result });
-    } catch (err: unknown) {
-      sendApiError(res, err);
-    }
-  };
+export async function handleUpload(req: Request, res: Response): Promise<void> {
+  const { fileName, content } = (req.body ?? {}) as Record<string, unknown>;
+  if (!fileName || typeof fileName !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "fileName is required" });
+    return;
+  }
+  if (content === undefined || content === null) {
+    res.status(400).json({ error: "BAD_REQUEST", message: "content is required" });
+    return;
+  }
+  if (typeof content !== "string") {
+    res.status(400).json({ error: "BAD_REQUEST", message: "content must be a base64 string" });
+    return;
+  }
+  try {
+    const format = detectFormat(fileName);
+    const decoded = format === "docx" ? Buffer.from(content, "base64") : String(content);
+    const result = await openFileFromContent(fileName, decoded);
+    res.json({ data: result });
+  } catch (err: unknown) {
+    sendApiError(res, err);
+  }
 }


### PR DESCRIPTION
## Summary
- Unwrap 9 zero-arg handler factories (`makeXxxHandler()`) to direct function exports (`handleXxx`)
- Update imports and callsites in `api-routes.ts`
- No behavioral change — pure rename/inline refactor

Closes #393

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] All 9 API endpoints respond correctly
- [ ] `setup.ts` and `rotate-token.ts` unaffected (still use factories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)