### PR TITLE
test(server): extract shared annotation test fixtures (#344)

### DIFF
--- a/tests/helpers/annotation-fixtures.ts
+++ b/tests/helpers/annotation-fixtures.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared annotation fixture constants and factory functions for durable store
+ * and sync tests.
+ *
+ * NOTE: This file exports `makeAnnotationDoc` (not `makeDoc`) to avoid
+ * collision with `tests/helpers/ydoc-factory.ts::makeDoc` which returns a
+ * Y.Doc. `makeAnnotationDoc` returns an `AnnotationDocV1` envelope.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  type AnnotationDocV1,
+  type AnnotationRecordV1,
+  type AnnotationReplyRecordV1,
+  migrateToV1,
+} from "../../src/server/annotations/schema.js";
+
+// ---------------------------------------------------------------------------
+// Shared hash + path constants
+// ---------------------------------------------------------------------------
+
+export const HASH_A = "a".repeat(64);
+export const HASH_B = "b".repeat(64);
+export const FILE_A = "/virtual/doc-a.md";
+export const FILE_B = "/virtual/doc-b.md";
+
+// ---------------------------------------------------------------------------
+// Single-record factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns an `AnnotationRecordV1` with sensible defaults.
+ *
+ * Shape matches the `annRecord` helper in sync.test.ts (rev defaults to 0,
+ * all required fields present).
+ */
+export function annRecord(overrides: Partial<AnnotationRecordV1> = {}): AnnotationRecordV1 {
+  return {
+    id: "ann_1",
+    author: "claude",
+    type: "comment",
+    range: { from: 0, to: 5 },
+    content: "hello",
+    status: "pending",
+    timestamp: 1_700_000_000_000,
+    rev: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * Returns an `AnnotationReplyRecordV1` with sensible defaults.
+ *
+ * Shape matches the `replyRecord` helper in sync.test.ts.
+ */
+export function replyRecord(
+  overrides: Partial<AnnotationReplyRecordV1> = {},
+): AnnotationReplyRecordV1 {
+  return {
+    id: "rep_1",
+    annotationId: "ann_1",
+    author: "user",
+    text: "ack",
+    timestamp: 1_700_000_000_000,
+    rev: 0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Envelope factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns an `AnnotationDocV1` envelope using `migrateToV1({})` as the base.
+ *
+ * Shape matches the local `makeDoc` / `makeFile` helpers in store.test.ts and
+ * sync.test.ts:
+ *   - `docHash` set from the first argument
+ *   - `meta.filePath` set from the second argument
+ *   - `meta.lastUpdated` set to `Date.now()`
+ *   - Optional `overrides` merged on top
+ *
+ * Named `makeAnnotationDoc` (not `makeDoc`) to avoid collision with
+ * `tests/helpers/ydoc-factory.ts::makeDoc` which returns a `Y.Doc`.
+ */
+export function makeAnnotationDoc(
+  docHash: string,
+  filePath: string,
+  overrides: Partial<AnnotationDocV1> = {},
+): AnnotationDocV1 {
+  const { doc } = migrateToV1({});
+  doc.docHash = docHash;
+  doc.meta = { filePath, lastUpdated: Date.now() };
+  return { ...doc, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Disk write helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Writes an `AnnotationDocV1` envelope to the annotations directory under
+ * `process.env.TANDEM_APP_DATA_DIR`.
+ *
+ * Creates the directory if it does not exist. Resolves the dir from the env
+ * var rather than accepting a path parameter so it stays in sync with whatever
+ * `getAnnotationsDir()` returns in production.
+ */
+export async function writeEnvelopeToDisk(envelope: AnnotationDocV1): Promise<void> {
+  const appDataDir = process.env.TANDEM_APP_DATA_DIR;
+  if (!appDataDir) throw new Error("TANDEM_APP_DATA_DIR is not set");
+  const annotationsDir = path.join(appDataDir, "annotations");
+  await fs.mkdir(annotationsDir, { recursive: true });
+  await fs.writeFile(
+    path.join(annotationsDir, `${envelope.docHash}.json`),
+    JSON.stringify(envelope),
+    "utf-8",
+  );
+}

--- a/tests/helpers/annotation-store-env.ts
+++ b/tests/helpers/annotation-store-env.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared tmpdir + env setup for durable annotation store tests.
+ *
+ * Two helpers: one that saves/restores only TANDEM_APP_DATA_DIR (for tests
+ * that do not touch TANDEM_ANNOTATION_STORE), and one that also saves/restores
+ * the feature flag and deletes it in beforeEach so the store defaults to "on".
+ *
+ * Neither helper runs resetForTesting() — each test file is responsible for
+ * its own module-level state resets, as the required reset functions vary per
+ * file (store only, sync only, or both).
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach } from "vitest";
+
+/**
+ * Registers beforeEach/afterEach hooks that create a fresh tmpdir, point
+ * TANDEM_APP_DATA_DIR at it, and clean up afterwards.
+ *
+ * For tests that do NOT need TANDEM_ANNOTATION_STORE save/restore
+ * (cleanup-orphans.test.ts, perf.test.ts).
+ *
+ * Returns a ref whose `tmpRoot` property is updated in beforeEach so callers
+ * can access the current temp directory.
+ */
+export function useTmpAnnotationsEnv(prefix = "tandem-test-"): { tmpRoot: string } {
+  const ref = { tmpRoot: "" };
+  let prevAppDataDir: string | undefined;
+
+  beforeEach(async () => {
+    ref.tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+    prevAppDataDir = process.env.TANDEM_APP_DATA_DIR;
+    process.env.TANDEM_APP_DATA_DIR = ref.tmpRoot;
+  });
+
+  afterEach(async () => {
+    if (prevAppDataDir === undefined) delete process.env.TANDEM_APP_DATA_DIR;
+    else process.env.TANDEM_APP_DATA_DIR = prevAppDataDir;
+    if (ref.tmpRoot) await fs.rm(ref.tmpRoot, { recursive: true, force: true });
+    ref.tmpRoot = "";
+  });
+
+  return ref;
+}
+
+/**
+ * Like `useTmpAnnotationsEnv` but also saves/restores TANDEM_ANNOTATION_STORE
+ * and deletes it in beforeEach so the store defaults to "on".
+ *
+ * For tests that set TANDEM_ANNOTATION_STORE within individual test bodies
+ * (store.test.ts, sync.test.ts).
+ */
+export function useTmpAnnotationsEnvWithFlag(prefix = "tandem-test-"): { tmpRoot: string } {
+  const ref = { tmpRoot: "" };
+  let prevAppDataDir: string | undefined;
+  let prevFeatureFlag: string | undefined;
+
+  beforeEach(async () => {
+    ref.tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+    prevAppDataDir = process.env.TANDEM_APP_DATA_DIR;
+    prevFeatureFlag = process.env.TANDEM_ANNOTATION_STORE;
+    process.env.TANDEM_APP_DATA_DIR = ref.tmpRoot;
+    delete process.env.TANDEM_ANNOTATION_STORE; // default = on
+  });
+
+  afterEach(async () => {
+    if (prevAppDataDir === undefined) delete process.env.TANDEM_APP_DATA_DIR;
+    else process.env.TANDEM_APP_DATA_DIR = prevAppDataDir;
+    if (prevFeatureFlag === undefined) delete process.env.TANDEM_ANNOTATION_STORE;
+    else process.env.TANDEM_ANNOTATION_STORE = prevFeatureFlag;
+    if (ref.tmpRoot) await fs.rm(ref.tmpRoot, { recursive: true, force: true });
+    ref.tmpRoot = "";
+  });
+
+  return ref;
+}

--- a/tests/helpers/doc-service.ts
+++ b/tests/helpers/doc-service.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared document-service setup helpers for Cluster B test files:
+ * annotation-replies.test.ts and annotation-tools.test.ts.
+ *
+ * Both files duplicate `setupDoc()` and a `beforeEach` that clears open docs.
+ * Centralising here ensures changes propagate everywhere and avoids drift.
+ */
+
+import { populateYDoc } from "../../src/server/mcp/document.js";
+import {
+  addDoc,
+  getOpenDocs,
+  removeDoc,
+  setActiveDocId,
+} from "../../src/server/mcp/document-service.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+
+/**
+ * Creates (or reuses) a Y.Doc for `id`, populates it with `text`, registers
+ * it in the document-service, and marks it as the active document.
+ *
+ * Returns the Y.Doc.
+ */
+export function setupDoc(id: string, text: string) {
+  const ydoc = getOrCreateDocument(id);
+  populateYDoc(ydoc, text);
+  addDoc(id, { id, filePath: `/tmp/${id}.md`, format: "md", readOnly: false, source: "file" });
+  setActiveDocId(id);
+  return ydoc;
+}
+
+/**
+ * Removes every document from the open-docs registry and clears the active
+ * document ID.
+ *
+ * Call in `beforeEach` to prevent cross-test contamination from the shared
+ * document-service singleton.
+ */
+export function clearOpenDocs(): void {
+  for (const id of [...getOpenDocs().keys()]) removeDoc(id);
+  setActiveDocId(null);
+}

--- a/tests/server/annotation-replies.test.ts
+++ b/tests/server/annotation-replies.test.ts
@@ -5,29 +5,13 @@ import {
   collectRepliesForAnnotation,
   createAnnotation,
 } from "../../src/server/mcp/annotations.js";
-import { populateYDoc } from "../../src/server/mcp/document.js";
-import {
-  addDoc,
-  getOpenDocs,
-  removeDoc,
-  setActiveDocId,
-} from "../../src/server/mcp/document-service.js";
-import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import type { Annotation, AnnotationReply } from "../../src/shared/types.js";
+import { clearOpenDocs, setupDoc } from "../helpers/doc-service.js";
 import { rangeOf } from "../helpers/ydoc-factory.js";
 
-function setupDoc(id: string, text: string) {
-  const ydoc = getOrCreateDocument(id);
-  populateYDoc(ydoc, text);
-  addDoc(id, { id, filePath: `/tmp/${id}.md`, format: "md", readOnly: false, source: "file" });
-  setActiveDocId(id);
-  return ydoc;
-}
-
 beforeEach(() => {
-  for (const id of [...getOpenDocs().keys()]) removeDoc(id);
-  setActiveDocId(null);
+  clearOpenDocs();
 });
 
 describe("addReplyToAnnotation", () => {

--- a/tests/server/annotation-tools.test.ts
+++ b/tests/server/annotation-tools.test.ts
@@ -6,29 +6,14 @@ import {
   createAnnotation,
   refreshRange,
 } from "../../src/server/mcp/annotations.js";
-import { extractText, populateYDoc, verifyAndResolveRange } from "../../src/server/mcp/document.js";
-import {
-  addDoc,
-  getOpenDocs,
-  removeDoc,
-  setActiveDocId,
-} from "../../src/server/mcp/document-service.js";
-import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { extractText, verifyAndResolveRange } from "../../src/server/mcp/document.js";
 import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import type { Annotation } from "../../src/shared/types.js";
+import { clearOpenDocs, setupDoc } from "../helpers/doc-service.js";
 import { rangeOf } from "../helpers/ydoc-factory.js";
 
-function setupDoc(id: string, text: string) {
-  const ydoc = getOrCreateDocument(id);
-  populateYDoc(ydoc, text);
-  addDoc(id, { id, filePath: `/tmp/${id}.md`, format: "md", readOnly: false, source: "file" });
-  setActiveDocId(id);
-  return ydoc;
-}
-
 beforeEach(() => {
-  for (const id of [...getOpenDocs().keys()]) removeDoc(id);
-  setActiveDocId(null);
+  clearOpenDocs();
 });
 
 describe("tandem_highlight tool logic", () => {

--- a/tests/server/annotations/cleanup-orphans.test.ts
+++ b/tests/server/annotations/cleanup-orphans.test.ts
@@ -9,11 +9,12 @@
  */
 
 import * as fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanupOrphanedAnnotationFiles } from "../../../src/server/session/manager.js";
 import { SESSION_MAX_AGE } from "../../../src/shared/constants.js";
+import { HASH_A, HASH_B } from "../../helpers/annotation-fixtures.js";
+import { useTmpAnnotationsEnv } from "../../helpers/annotation-store-env.js";
 
 // Hoist the mock so Vitest can intercept the module before any import resolves.
 // The factory spreads the real implementation so non-spy tests use real fs.
@@ -24,25 +25,12 @@ vi.mock("node:fs/promises", async (importActual) => {
   return { ...mod, default: mod };
 });
 
-const HASH_A = "a".repeat(64);
-const HASH_B = "b".repeat(64);
-
-let tmpRoot: string;
+const env = useTmpAnnotationsEnv("tandem-cleanup-test-");
 let annotationsDir: string;
-let prevAppDataDir: string | undefined;
 
 beforeEach(async () => {
-  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "tandem-cleanup-test-"));
-  prevAppDataDir = process.env.TANDEM_APP_DATA_DIR;
-  process.env.TANDEM_APP_DATA_DIR = tmpRoot;
-  annotationsDir = path.join(tmpRoot, "annotations");
+  annotationsDir = path.join(env.tmpRoot, "annotations");
   await fs.mkdir(annotationsDir, { recursive: true });
-});
-
-afterEach(async () => {
-  if (prevAppDataDir === undefined) delete process.env.TANDEM_APP_DATA_DIR;
-  else process.env.TANDEM_APP_DATA_DIR = prevAppDataDir;
-  await fs.rm(tmpRoot, { recursive: true, force: true });
 });
 
 async function writeWithMtime(file: string, ageMs: number): Promise<void> {

--- a/tests/server/annotations/perf.test.ts
+++ b/tests/server/annotations/perf.test.ts
@@ -16,9 +16,6 @@
  * gated behind `vitest bench`.
  */
 
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
@@ -36,6 +33,8 @@ import {
   resetForTesting as resetSyncForTesting,
 } from "../../../src/server/annotations/sync.js";
 import { Y_MAP_ANNOTATIONS } from "../../../src/shared/constants.js";
+import { writeEnvelopeToDisk } from "../../helpers/annotation-fixtures.js";
+import { useTmpAnnotationsEnv } from "../../helpers/annotation-store-env.js";
 
 const HASH = "b".repeat(64);
 const FILE_PATH = "/virtual/perf-doc.md";
@@ -67,39 +66,21 @@ function makeEnvelope(count: number): AnnotationDocV1 {
   };
 }
 
-let tmpRoot = "";
-let prevAppDataDir: string | undefined;
+useTmpAnnotationsEnv("tandem-perf-test-");
 
-beforeEach(async () => {
-  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "tandem-perf-test-"));
-  prevAppDataDir = process.env.TANDEM_APP_DATA_DIR;
-  process.env.TANDEM_APP_DATA_DIR = tmpRoot;
+beforeEach(() => {
   resetStoreForTesting();
   resetSyncForTesting();
 });
 
-afterEach(async () => {
+afterEach(() => {
   resetStoreForTesting();
   resetSyncForTesting();
-  if (prevAppDataDir === undefined) delete process.env.TANDEM_APP_DATA_DIR;
-  else process.env.TANDEM_APP_DATA_DIR = prevAppDataDir;
-  if (tmpRoot) await fs.rm(tmpRoot, { recursive: true, force: true });
-  tmpRoot = "";
 });
-
-async function writeEnvelope(envelope: AnnotationDocV1): Promise<void> {
-  const annotationsDir = path.join(tmpRoot, "annotations");
-  await fs.mkdir(annotationsDir, { recursive: true });
-  await fs.writeFile(
-    path.join(annotationsDir, `${envelope.docHash}.json`),
-    JSON.stringify(envelope),
-    "utf-8",
-  );
-}
 
 async function measureLoadAndMerge(count: number): Promise<number> {
   const envelope = makeEnvelope(count);
-  await writeEnvelope(envelope);
+  await writeEnvelopeToDisk(envelope);
 
   const ydoc = new Y.Doc();
   const store = createStore(HASH, { filePath: FILE_PATH });
@@ -120,7 +101,7 @@ async function measureLoadAndMerge(count: number): Promise<number> {
 
 async function measureLoadAndMergeWithConflicts(count: number): Promise<number> {
   const envelope = makeEnvelope(count);
-  await writeEnvelope(envelope);
+  await writeEnvelopeToDisk(envelope);
 
   const ydoc = new Y.Doc();
   const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);

--- a/tests/server/annotations/store.test.ts
+++ b/tests/server/annotations/store.test.ts
@@ -22,11 +22,7 @@ vi.mock("../../../src/server/notifications.js", async (importOriginal) => {
   };
 });
 
-import {
-  type AnnotationDocV1,
-  migrateToV1,
-  SCHEMA_VERSION,
-} from "../../../src/server/annotations/schema.js";
+import { SCHEMA_VERSION } from "../../../src/server/annotations/schema.js";
 import {
   acquireStoreLock,
   closeStore,
@@ -36,44 +32,24 @@ import {
   resetForTesting,
 } from "../../../src/server/annotations/store.js";
 import { pushNotification } from "../../../src/server/notifications.js";
+import {
+  FILE_A,
+  FILE_B,
+  HASH_A,
+  HASH_B,
+  makeAnnotationDoc,
+} from "../../helpers/annotation-fixtures.js";
+import { useTmpAnnotationsEnvWithFlag } from "../../helpers/annotation-store-env.js";
 
-const HASH_A = "a".repeat(64);
-const HASH_B = "b".repeat(64);
-const FILE_A = "/virtual/doc-a.md";
-const FILE_B = "/virtual/doc-b.md";
+const env = useTmpAnnotationsEnvWithFlag("tandem-store-test-");
 
-function makeDoc(
-  docHash: string,
-  filePath: string,
-  overrides: Partial<AnnotationDocV1> = {},
-): AnnotationDocV1 {
-  const { doc } = migrateToV1({});
-  doc.docHash = docHash;
-  doc.meta = { filePath, lastUpdated: Date.now() };
-  return { ...doc, ...overrides };
-}
-
-let tmpRoot: string;
-let prevAppDataDir: string | undefined;
-let prevFeatureFlag: string | undefined;
-
-beforeEach(async () => {
-  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "tandem-store-test-"));
-  prevAppDataDir = process.env.TANDEM_APP_DATA_DIR;
-  prevFeatureFlag = process.env.TANDEM_ANNOTATION_STORE;
-  process.env.TANDEM_APP_DATA_DIR = tmpRoot;
-  delete process.env.TANDEM_ANNOTATION_STORE; // default = on
+beforeEach(() => {
   resetForTesting();
   vi.mocked(pushNotification).mockClear();
 });
 
-afterEach(async () => {
+afterEach(() => {
   resetForTesting();
-  if (prevAppDataDir === undefined) delete process.env.TANDEM_APP_DATA_DIR;
-  else process.env.TANDEM_APP_DATA_DIR = prevAppDataDir;
-  if (prevFeatureFlag === undefined) delete process.env.TANDEM_ANNOTATION_STORE;
-  else process.env.TANDEM_ANNOTATION_STORE = prevFeatureFlag;
-  await fs.rm(tmpRoot, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------
@@ -100,7 +76,7 @@ describe("createStore + load", () => {
 describe("queueWrite + flush round-trip", () => {
   it("persists a written doc and round-trips through load", async () => {
     const store = createStore(HASH_A, { filePath: FILE_A });
-    const doc = makeDoc(HASH_A, FILE_A, {
+    const doc = makeAnnotationDoc(HASH_A, FILE_A, {
       annotations: [
         {
           id: "ann_1",
@@ -118,7 +94,10 @@ describe("queueWrite + flush round-trip", () => {
     store.queueWrite(() => doc);
     await store.flush();
 
-    const onDisk = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const onDisk = await fs.readFile(
+      path.join(env.tmpRoot, "annotations", `${HASH_A}.json`),
+      "utf-8",
+    );
     expect(JSON.parse(onDisk)).toMatchObject({
       schemaVersion: 1,
       docHash: HASH_A,
@@ -140,9 +119,9 @@ describe("debounce coalescing", () => {
     const store = createStore(HASH_A, { filePath: FILE_A });
     const writeSpy = vi.spyOn(fs, "writeFile");
 
-    store.queueWrite(() => makeDoc(HASH_A, FILE_A, { annotations: [] }));
+    store.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A, { annotations: [] }));
     store.queueWrite(() =>
-      makeDoc(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [
           {
             id: "ann_mid",
@@ -158,7 +137,7 @@ describe("debounce coalescing", () => {
       }),
     );
     store.queueWrite(() =>
-      makeDoc(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [
           {
             id: "ann_last",
@@ -197,12 +176,12 @@ describe("per-doc debounce", () => {
     const storeA = createStore(HASH_A, { filePath: FILE_A });
     const storeB = createStore(HASH_B, { filePath: FILE_B });
 
-    storeA.queueWrite(() => makeDoc(HASH_A, FILE_A));
-    storeB.queueWrite(() => makeDoc(HASH_B, FILE_B));
+    storeA.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A));
+    storeB.queueWrite(() => makeAnnotationDoc(HASH_B, FILE_B));
 
     await Promise.all([storeA.flush(), storeB.flush()]);
 
-    const files = await fs.readdir(path.join(tmpRoot, "annotations"));
+    const files = await fs.readdir(path.join(env.tmpRoot, "annotations"));
     expect(files).toContain(`${HASH_A}.json`);
     expect(files).toContain(`${HASH_B}.json`);
   });
@@ -271,7 +250,7 @@ describe("lock held by live PID", () => {
     const store = createStore(HASH_A, { filePath: FILE_A });
     expect(store.isReadOnly()).toBe(true);
 
-    store.queueWrite(() => makeDoc(HASH_A, FILE_A));
+    store.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A));
     await store.flush();
 
     // File should not have been created.
@@ -318,19 +297,19 @@ describe("write failure → throttled notify → disable after 3", () => {
     const notify = vi.mocked(pushNotification);
 
     // Attempt 1 — transient failure, 1 notification.
-    store.queueWrite(() => makeDoc(HASH_A, FILE_A));
+    store.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A));
     await expect(store.flush()).rejects.toThrow();
     expect(store.isDisabled(HASH_A)).toBe(false);
     expect(notify).toHaveBeenCalledTimes(1);
 
     // Attempt 2 — within the 60s window, throttled (no new notification).
-    store.queueWrite(() => makeDoc(HASH_A, FILE_A));
+    store.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A));
     await expect(store.flush()).rejects.toThrow();
     expect(store.isDisabled(HASH_A)).toBe(false);
     expect(notify).toHaveBeenCalledTimes(1); // throttled
 
     // Attempt 3 — third consecutive failure flips to "persistent" and disables.
-    store.queueWrite(() => makeDoc(HASH_A, FILE_A));
+    store.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A));
     await expect(store.flush()).rejects.toThrow();
     expect(store.isDisabled(HASH_A)).toBe(true);
     // Persistent notification bypasses the throttle.
@@ -338,7 +317,7 @@ describe("write failure → throttled notify → disable after 3", () => {
 
     // Attempt 4 — disabled: queueWrite is a no-op; writeFile not called again.
     const prevWriteCount = writeSpy.mock.calls.length;
-    store.queueWrite(() => makeDoc(HASH_A, FILE_A));
+    store.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A));
     await store.flush();
     expect(writeSpy.mock.calls.length).toBe(prevWriteCount);
     // Still exactly 2 notifications total (no extras once disabled).
@@ -362,12 +341,12 @@ describe("TANDEM_ANNOTATION_STORE=off", () => {
     expect(loaded.annotations).toEqual([]);
     expect(loaded.schemaVersion).toBe(SCHEMA_VERSION);
 
-    store.queueWrite(() => makeDoc(HASH_A, FILE_A));
+    store.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A));
     await store.flush();
     await store.clear();
 
     // No annotations dir should have been created.
-    const annotationsDir = path.join(tmpRoot, "annotations");
+    const annotationsDir = path.join(env.tmpRoot, "annotations");
     await expect(fs.readdir(annotationsDir)).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
@@ -379,10 +358,10 @@ describe("TANDEM_ANNOTATION_STORE=off", () => {
 describe("clear()", () => {
   it("deletes the file and is idempotent", async () => {
     const store = createStore(HASH_A, { filePath: FILE_A });
-    store.queueWrite(() => makeDoc(HASH_A, FILE_A));
+    store.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A));
     await store.flush();
 
-    const target = path.join(tmpRoot, "annotations", `${HASH_A}.json`);
+    const target = path.join(env.tmpRoot, "annotations", `${HASH_A}.json`);
     await fs.access(target); // exists
 
     await store.clear();
@@ -414,10 +393,10 @@ describe("closeStore", () => {
     // First: a healthy doc that had a pending write. closeStore should flush it
     // and evict the (absent) failure state entry entirely.
     const storeA = createStore(HASH_A, { filePath: FILE_A });
-    storeA.queueWrite(() => makeDoc(HASH_A, FILE_A));
+    storeA.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A));
     await closeStore(HASH_A);
     // The pending write flushed as part of close.
-    const aFiles = await fs.readdir(path.join(tmpRoot, "annotations"));
+    const aFiles = await fs.readdir(path.join(env.tmpRoot, "annotations"));
     expect(aFiles).toContain(`${HASH_A}.json`);
 
     // Second: drive storeB into the disabled state via 3 consecutive failures,
@@ -428,7 +407,7 @@ describe("closeStore", () => {
       .mockRejectedValue(Object.assign(new Error("ENOSPC"), { code: "ENOSPC" }));
     const storeB = createStore(HASH_B, { filePath: FILE_B });
     for (let i = 0; i < 3; i++) {
-      storeB.queueWrite(() => makeDoc(HASH_B, FILE_B));
+      storeB.queueWrite(() => makeAnnotationDoc(HASH_B, FILE_B));
       await expect(storeB.flush()).rejects.toThrow();
     }
     expect(storeB.isDisabled(HASH_B)).toBe(true);
@@ -470,7 +449,7 @@ describe("queueWrite thunk that throws", () => {
     expect(pushNotification).toHaveBeenCalled();
     // And no file should have landed on disk.
     await expect(
-      fs.access(path.join(tmpRoot, "annotations", `${HASH_A}.json`)),
+      fs.access(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`)),
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -7,7 +7,6 @@
  */
 
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
@@ -22,10 +21,7 @@ vi.mock("../../../src/server/notifications.js", async (importOriginal) => {
 });
 
 import {
-  type AnnotationDocV1,
   type AnnotationRecordV1,
-  type AnnotationReplyRecordV1,
-  migrateToV1,
   parseAnnotationDoc,
   SCHEMA_VERSION,
 } from "../../../src/server/annotations/schema.js";
@@ -45,48 +41,16 @@ import {
 } from "../../../src/server/annotations/sync.js";
 import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "../../../src/server/events/queue.js";
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../../src/shared/constants.js";
-
-const HASH_A = "a".repeat(64);
-const FILE_A = "/virtual/doc-a.md";
-const HASH_B = "b".repeat(64);
-const FILE_B = "/virtual/doc-b.md";
-
-function annRecord(overrides: Partial<AnnotationRecordV1> = {}): AnnotationRecordV1 {
-  return {
-    id: "ann_1",
-    author: "claude",
-    type: "comment",
-    range: { from: 0, to: 5 },
-    content: "hello",
-    status: "pending",
-    timestamp: 1_700_000_000_000,
-    rev: 0,
-    ...overrides,
-  };
-}
-
-function replyRecord(overrides: Partial<AnnotationReplyRecordV1> = {}): AnnotationReplyRecordV1 {
-  return {
-    id: "rep_1",
-    annotationId: "ann_1",
-    author: "user",
-    text: "ack",
-    timestamp: 1_700_000_000_000,
-    rev: 0,
-    ...overrides,
-  };
-}
-
-function makeFile(
-  docHash: string,
-  filePath: string,
-  overrides: Partial<AnnotationDocV1> = {},
-): AnnotationDocV1 {
-  const { doc } = migrateToV1({});
-  doc.docHash = docHash;
-  doc.meta = { filePath, lastUpdated: Date.now() };
-  return { ...doc, ...overrides };
-}
+import {
+  annRecord,
+  FILE_A,
+  FILE_B,
+  HASH_A,
+  HASH_B,
+  makeAnnotationDoc,
+  replyRecord,
+} from "../../helpers/annotation-fixtures.js";
+import { useTmpAnnotationsEnvWithFlag } from "../../helpers/annotation-store-env.js";
 
 function syncCtx(ydoc: Y.Doc, store: DocStore, overrides: Partial<SyncContext> = {}): SyncContext {
   return {
@@ -98,28 +62,16 @@ function syncCtx(ydoc: Y.Doc, store: DocStore, overrides: Partial<SyncContext> =
   };
 }
 
-let tmpRoot: string;
-let prevAppDataDir: string | undefined;
-let prevFeatureFlag: string | undefined;
+const env = useTmpAnnotationsEnvWithFlag("tandem-sync-test-");
 
-beforeEach(async () => {
-  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "tandem-sync-test-"));
-  prevAppDataDir = process.env.TANDEM_APP_DATA_DIR;
-  prevFeatureFlag = process.env.TANDEM_ANNOTATION_STORE;
-  process.env.TANDEM_APP_DATA_DIR = tmpRoot;
-  delete process.env.TANDEM_ANNOTATION_STORE;
+beforeEach(() => {
   resetForTesting();
   resetStoreForTesting();
 });
 
-afterEach(async () => {
+afterEach(() => {
   resetForTesting();
   resetStoreForTesting();
-  if (prevAppDataDir === undefined) delete process.env.TANDEM_APP_DATA_DIR;
-  else process.env.TANDEM_APP_DATA_DIR = prevAppDataDir;
-  if (prevFeatureFlag === undefined) delete process.env.TANDEM_ANNOTATION_STORE;
-  else process.env.TANDEM_ANNOTATION_STORE = prevFeatureFlag;
-  await fs.rm(tmpRoot, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------
@@ -137,7 +89,7 @@ describe("registerAnnotationObserver", () => {
 
     await store.flush();
 
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.schemaVersion).toBe(SCHEMA_VERSION);
     expect(onDisk.annotations).toHaveLength(1);
@@ -157,7 +109,7 @@ describe("registerAnnotationObserver", () => {
 
     await store.flush();
 
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.annotations).toHaveLength(1);
     cleanup();
@@ -177,7 +129,7 @@ describe("registerAnnotationObserver", () => {
     expect(queueSpy).not.toHaveBeenCalled();
     // No file created.
     await expect(
-      fs.access(path.join(tmpRoot, "annotations", `${HASH_A}.json`)),
+      fs.access(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`)),
     ).rejects.toMatchObject({ code: "ENOENT" });
     cleanup();
   });
@@ -192,7 +144,7 @@ describe("registerAnnotationObserver", () => {
 
     await store.flush();
 
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.annotations[0].rev).toBe(3);
     cleanup();
@@ -212,7 +164,7 @@ describe("registerAnnotationObserver", () => {
 
     await store.flush();
 
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.annotations).toHaveLength(1);
     expect(onDisk.annotations[0].rev).toBe(0);
@@ -306,7 +258,7 @@ describe("legacy-type sanitize on write", () => {
 
     await store.flush();
 
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.annotations).toHaveLength(1);
     expect(onDisk.annotations[0].type).toBe("comment");
@@ -340,7 +292,7 @@ describe("legacy-type sanitize on write", () => {
 
     await store.flush();
 
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.annotations[0].type).toBe("comment");
     expect(onDisk.annotations[0].directedAt).toBe("claude");
@@ -449,7 +401,7 @@ describe("legacy-type sanitize on write", () => {
 
     await store.flush();
 
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.annotations[0].rev).toBe(7);
 
@@ -513,7 +465,7 @@ describe("legacy-type sanitize on write", () => {
     // is the input to normalizeAnnotation at line ~438.
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [annRecord({ id: "ann_legacy_merge", rev: 1 })],
       }),
     );
@@ -575,7 +527,7 @@ describe("loadAndMerge", () => {
     expect(queueSpy).toHaveBeenCalledTimes(1);
     await store.flush();
 
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.annotations).toHaveLength(1);
     expect(onDisk.annotations[0].id).toBe("ann_legacy");
@@ -588,7 +540,7 @@ describe("loadAndMerge", () => {
     // Pre-write a file with one annotation.
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, { annotations: [annRecord({ id: "ann_disk", rev: 5 })] }),
+      makeAnnotationDoc(HASH_A, FILE_A, { annotations: [annRecord({ id: "ann_disk", rev: 5 })] }),
     );
     await store0.flush();
     resetStoreForTesting();
@@ -608,7 +560,7 @@ describe("loadAndMerge", () => {
     // File has rev 5.
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [annRecord({ id: "ann_1", rev: 5, content: "from-disk" })],
       }),
     );
@@ -633,7 +585,7 @@ describe("loadAndMerge", () => {
     // File has rev 1.
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [annRecord({ id: "ann_1", rev: 1, content: "from-disk" })],
       }),
     );
@@ -657,7 +609,7 @@ describe("loadAndMerge", () => {
   it("#11 merge: rev tie, file has editedAt, Y.Map doesn't → file wins", async () => {
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [annRecord({ id: "ann_1", rev: 2, content: "from-disk", editedAt: 111 })],
       }),
     );
@@ -682,7 +634,7 @@ describe("loadAndMerge", () => {
   it("#12 merge: rev tie, both have editedAt, higher editedAt wins", async () => {
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [annRecord({ id: "ann_1", rev: 2, content: "from-disk", editedAt: 100 })],
       }),
     );
@@ -705,7 +657,7 @@ describe("loadAndMerge", () => {
   it("#13 merge: tombstone rev > Y.Map rev → annotation deleted from Y.Map", async () => {
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [],
         tombstones: [{ id: "ann_1", rev: 5, deletedAt: 9999 }],
       }),
@@ -730,7 +682,7 @@ describe("loadAndMerge", () => {
   it("#14 merge: tombstone rev < Y.Map rev → Y.Map annotation preserved (resurrection)", async () => {
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [],
         tombstones: [{ id: "ann_1", rev: 2, deletedAt: 1 }],
       }),
@@ -755,7 +707,7 @@ describe("loadAndMerge", () => {
   it("#15 merge: alive in Y.Map, absent from file, not tombstoned → kept + queueWrite fires", async () => {
     // File exists but empty.
     const store0 = createStore(HASH_A, { filePath: FILE_A });
-    store0.queueWrite(() => makeFile(HASH_A, FILE_A, { annotations: [], replies: [] }));
+    store0.queueWrite(() => makeAnnotationDoc(HASH_A, FILE_A, { annotations: [], replies: [] }));
     await store0.flush();
     resetStoreForTesting();
 
@@ -773,7 +725,7 @@ describe("loadAndMerge", () => {
     expect(queueSpy).toHaveBeenCalled();
 
     await store.flush();
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.annotations).toHaveLength(1);
     expect(onDisk.annotations[0].id).toBe("ann_new");
@@ -789,7 +741,7 @@ describe("loadAndMerge", () => {
     // suite (prior tombstone tests all use annotations: []).
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [annRecord({ id: "ann_1", rev: 2 })],
         tombstones: [{ id: "ann_1", rev: 5, deletedAt: 9999 }],
       }),
@@ -814,7 +766,7 @@ describe("loadAndMerge", () => {
     // someone changing > to >=.
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [annRecord({ id: "ann_1", rev: 5 })],
         tombstones: [{ id: "ann_1", rev: 5, deletedAt: 9999 }],
       }),
@@ -840,7 +792,7 @@ describe("loadAndMerge", () => {
     // absent from file" pass would see it and set needsWrite → spurious write.
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [],
         tombstones: [{ id: "ann_1", rev: 2, deletedAt: 1 }],
       }),
@@ -910,7 +862,7 @@ describe("recordTombstone + getTombstones", () => {
 
     await store.flush();
 
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.tombstones).toHaveLength(1);
     expect(onDisk.tombstones[0].id).toBe("ann_dead");
@@ -941,7 +893,7 @@ describe("replies merge", () => {
   it("#17 file reply rev > Y.Map reply rev → file wins", async () => {
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         replies: [replyRecord({ id: "rep_1", rev: 5, text: "disk" })],
       }),
     );
@@ -970,7 +922,7 @@ describe("replies merge", () => {
     repMap.set("rep_1", replyRecord({ id: "rep_1" }));
 
     await store.flush();
-    const raw = await fs.readFile(path.join(tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
+    const raw = await fs.readFile(path.join(env.tmpRoot, "annotations", `${HASH_A}.json`), "utf-8");
     const onDisk = JSON.parse(raw);
     expect(onDisk.replies).toHaveLength(1);
     expect(onDisk.replies[0].id).toBe("rep_1");
@@ -980,7 +932,7 @@ describe("replies merge", () => {
   it("#20 reply: file has reply, Y.Map empty → reply inserted", async () => {
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         replies: [replyRecord({ id: "rep_2", rev: 3, text: "from-disk" })],
       }),
     );
@@ -1006,7 +958,7 @@ describe("replies merge", () => {
     // a different reason without ever reaching the reply merge loop.
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         annotations: [annRecord({ id: "ann_other", rev: 1 })],
         replies: [],
       }),
@@ -1030,7 +982,7 @@ describe("replies merge", () => {
   it("#22 reply: Y.Map rev > file rev → Y.Map wins (unchanged)", async () => {
     const store0 = createStore(HASH_A, { filePath: FILE_A });
     store0.queueWrite(() =>
-      makeFile(HASH_A, FILE_A, {
+      makeAnnotationDoc(HASH_A, FILE_A, {
         replies: [replyRecord({ id: "rep_1", rev: 1, text: "from-disk" })],
       }),
     );


### PR DESCRIPTION
## Summary

- Adds three helper files under `tests/helpers/` to eliminate duplicated boilerplate across 6 annotation test files
- `annotation-store-env.ts` — `useTmpAnnotationsEnv()` and `useTmpAnnotationsEnvWithFlag()` for tmpdir + `TANDEM_APP_DATA_DIR` lifecycle (flag variant also saves/restores `TANDEM_ANNOTATION_STORE`)
- `annotation-fixtures.ts` — shared `HASH_A/B`, `FILE_A/B`, `annRecord()`, `replyRecord()`, `makeAnnotationDoc()`, `writeEnvelopeToDisk()`
- `doc-service.ts` — `setupDoc()` and `clearOpenDocs()` used by both MCP annotation test files

Cluster A (4 files): cleanup-orphans, store, sync, perf — replace tmpdir boilerplate and local constants
Cluster B (2 files): annotation-replies, annotation-tools — replace duplicate `setupDoc` + `beforeEach` clear

Zero logic changes — only import replacements and removal of locally-defined duplicates. `vi.mock` declarations remain at module scope in every file.

Closes #344

## Test plan

- [ ] `npm test` — 96 test files pass, 1429+ tests pass, 3 skipped (same as pre-PR baseline)
- [ ] `npm run typecheck` — zero errors
- [ ] `TANDEM_ANNOTATION_STORE` is NOT saved/restored in cleanup-orphans.test.ts or perf.test.ts (only env-only helper used)
- [ ] `vi.mock` calls remain at module scope in store.test.ts and sync.test.ts
- [ ] No semantic diff — `git diff master...HEAD` shows only import replacements and deleted local defs

🤖 Generated with [Claude Code](https://claude.com/claude-code)