### PR TITLE
refactor(client): decompose AnnotationCard.tsx (#403)

### DIFF
--- a/src/client/panels/AnnotationCard.tsx
+++ b/src/client/panels/AnnotationCard.tsx
@@ -5,6 +5,30 @@ import { AnnotationCardActions } from "./AnnotationCardActions";
 import { AnnotationEditForm } from "./AnnotationEditForm";
 import { ReplyThread } from "./ReplyThread";
 
+export const TEXTAREA_STYLE: React.CSSProperties = {
+  width: "100%",
+  padding: "4px 6px",
+  fontSize: "12px",
+  border: "1px solid var(--tandem-border-strong)",
+  borderRadius: "3px",
+  resize: "vertical",
+  fontFamily: "inherit",
+  minHeight: "40px",
+  boxSizing: "border-box",
+  background: "var(--tandem-surface)",
+  color: "var(--tandem-fg)",
+};
+
+const EDIT_BTN_STYLE: React.CSSProperties = {
+  padding: "1px 4px",
+  fontSize: "11px",
+  border: "none",
+  background: "none",
+  color: "var(--tandem-fg-subtle)",
+  cursor: "pointer",
+  lineHeight: 1,
+};
+
 export interface AnnotationCardProps {
   annotation: Annotation;
   replies?: AnnotationReply[];
@@ -17,6 +41,18 @@ export interface AnnotationCardProps {
   /** Whether this annotation was recently resolved and can be undone */
   undoable?: boolean;
   onClick?: () => void;
+}
+
+function getDisplayType(annotation: Annotation): string {
+  if (annotation.suggestedText !== undefined) return "replacement";
+  if (annotation.directedAt === "claude") return "question";
+  return annotation.type;
+}
+
+function getAuthorLabel(author: Annotation["author"]): string {
+  if (author === "claude") return "Claude";
+  if (author === "import") return "Imported";
+  return "You";
 }
 
 function getBorderColor(annotation: Annotation): string {
@@ -50,6 +86,7 @@ export const AnnotationCard = React.memo(function AnnotationCard({
   const [editReason, setEditReason] = useState("");
 
   const hasSuggestedText = annotation.suggestedText !== undefined;
+  const displayType = getDisplayType(annotation);
 
   function enterEditMode() {
     if (hasSuggestedText) {
@@ -84,40 +121,11 @@ export const AnnotationCard = React.memo(function AnnotationCard({
     }
   }
 
-  const textareaStyle: React.CSSProperties = {
-    width: "100%",
-    padding: "4px 6px",
-    fontSize: "12px",
-    border: "1px solid var(--tandem-border-strong)",
-    borderRadius: "3px",
-    resize: "vertical",
-    fontFamily: "inherit",
-    minHeight: "40px",
-    boxSizing: "border-box",
-    background: "var(--tandem-surface)",
-    color: "var(--tandem-fg)",
-  };
-
-  const editBtnStyle: React.CSSProperties = {
-    padding: "1px 4px",
-    fontSize: "11px",
-    border: "none",
-    background: "none",
-    color: "var(--tandem-fg-subtle)",
-    cursor: "pointer",
-    lineHeight: 1,
-  };
-
   const truncatedContent = annotation.content
     ? annotation.content.length > 60
       ? annotation.content.slice(0, 57) + "..."
       : annotation.content
     : "";
-  const displayType = hasSuggestedText
-    ? "replacement"
-    : annotation.directedAt === "claude"
-      ? "question"
-      : annotation.type;
   const cardLabel = `${displayType} annotation${truncatedContent ? ": " + truncatedContent : ""}, ${annotation.status}`;
 
   return (
@@ -173,7 +181,7 @@ export const AnnotationCard = React.memo(function AnnotationCard({
                 e.stopPropagation();
                 enterEditMode();
               }}
-              style={editBtnStyle}
+              style={EDIT_BTN_STYLE}
               title="Edit this annotation's content"
             >
               ✎ Edit
@@ -196,11 +204,7 @@ export const AnnotationCard = React.memo(function AnnotationCard({
               (edited)
             </span>
           )}
-          {annotation.author === "claude"
-            ? "Claude"
-            : annotation.author === "import"
-              ? "Imported"
-              : "You"}
+          {getAuthorLabel(annotation.author)}
         </span>
       </div>
       {annotation.textSnapshot && (
@@ -229,7 +233,6 @@ export const AnnotationCard = React.memo(function AnnotationCard({
           editText={editText}
           editNewText={editNewText}
           editReason={editReason}
-          textareaStyle={textareaStyle}
           onChangeEditText={setEditText}
           onChangeEditNewText={setEditNewText}
           onChangeEditReason={setEditReason}
@@ -302,7 +305,6 @@ export const AnnotationCard = React.memo(function AnnotationCard({
         replies={replies}
         isPending={isPending}
         isEditing={isEditing}
-        textareaStyle={textareaStyle}
         onReply={onReply}
       />
     </div>

--- a/src/client/panels/AnnotationCard.tsx
+++ b/src/client/panels/AnnotationCard.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import { HIGHLIGHT_COLORS } from "../../shared/constants";
 import type { Annotation, AnnotationReply } from "../../shared/types";
-import { CommentThread } from "./CommentThread";
+import { AnnotationCardActions } from "./AnnotationCardActions";
+import { AnnotationEditForm } from "./AnnotationEditForm";
+import { ReplyThread } from "./ReplyThread";
 
 export interface AnnotationCardProps {
   annotation: Annotation;
@@ -46,9 +48,6 @@ export const AnnotationCard = React.memo(function AnnotationCard({
   const [editText, setEditText] = useState("");
   const [editNewText, setEditNewText] = useState("");
   const [editReason, setEditReason] = useState("");
-  const [isReplying, setIsReplying] = useState(false);
-  const [replyText, setReplyText] = useState("");
-  const [isSendingReply, setIsSendingReply] = useState(false);
 
   const hasSuggestedText = annotation.suggestedText !== undefined;
 
@@ -82,29 +81,6 @@ export const AnnotationCard = React.memo(function AnnotationCard({
     if (e.key === "Escape") {
       e.stopPropagation();
       handleCancel();
-    }
-  }
-
-  function handleReplyKeyDown(e: React.KeyboardEvent) {
-    if (e.key === "Escape") {
-      e.stopPropagation();
-      setIsReplying(false);
-      setReplyText("");
-    }
-  }
-
-  async function handleSendReply() {
-    const trimmed = replyText.trim();
-    if (!trimmed || isSendingReply) return;
-    setIsSendingReply(true);
-    try {
-      const ok = await onReply?.(annotation.id, trimmed);
-      if (ok !== false) {
-        setReplyText("");
-        setIsReplying(false);
-      }
-    } finally {
-      setIsSendingReply(false);
     }
   }
 
@@ -247,95 +223,20 @@ export const AnnotationCard = React.memo(function AnnotationCard({
         </div>
       )}
       {isEditing ? (
-        <div style={{ marginTop: "4px" }} onClick={(e) => e.stopPropagation()}>
-          {hasSuggestedText ? (
-            <>
-              <label
-                style={{
-                  fontSize: "11px",
-                  color: "var(--tandem-fg-muted)",
-                  display: "block",
-                  marginBottom: "2px",
-                }}
-              >
-                Replacement text
-              </label>
-              <textarea
-                data-testid={`edit-newtext-${annotation.id}`}
-                value={editNewText}
-                onChange={(e) => setEditNewText(e.target.value)}
-                onKeyDown={handleKeyDown}
-                style={textareaStyle}
-                autoFocus
-              />
-              <label
-                style={{
-                  fontSize: "11px",
-                  color: "var(--tandem-fg-muted)",
-                  display: "block",
-                  marginTop: "4px",
-                  marginBottom: "2px",
-                }}
-              >
-                Reason
-              </label>
-              <textarea
-                data-testid={`edit-reason-${annotation.id}`}
-                value={editReason}
-                onChange={(e) => setEditReason(e.target.value)}
-                onKeyDown={handleKeyDown}
-                style={textareaStyle}
-              />
-            </>
-          ) : (
-            <textarea
-              data-testid={`edit-text-${annotation.id}`}
-              value={editText}
-              onChange={(e) => setEditText(e.target.value)}
-              onKeyDown={handleKeyDown}
-              style={textareaStyle}
-              autoFocus
-            />
-          )}
-          <div style={{ display: "flex", gap: "6px", marginTop: "4px" }}>
-            <button
-              data-testid={`edit-save-btn-${annotation.id}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                handleSave();
-              }}
-              style={{
-                padding: "2px 8px",
-                fontSize: "11px",
-                border: "1px solid var(--tandem-border-strong)",
-                borderRadius: "3px",
-                background: "var(--tandem-success-bg)",
-                color: "var(--tandem-success-fg-strong)",
-                cursor: "pointer",
-              }}
-            >
-              Save
-            </button>
-            <button
-              data-testid={`edit-cancel-btn-${annotation.id}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                handleCancel();
-              }}
-              style={{
-                padding: "2px 8px",
-                fontSize: "11px",
-                border: "1px solid var(--tandem-border-strong)",
-                borderRadius: "3px",
-                background: "var(--tandem-surface)",
-                color: "var(--tandem-fg-muted)",
-                cursor: "pointer",
-              }}
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+        <AnnotationEditForm
+          annotationId={annotation.id}
+          hasSuggestedText={hasSuggestedText}
+          editText={editText}
+          editNewText={editNewText}
+          editReason={editReason}
+          textareaStyle={textareaStyle}
+          onChangeEditText={setEditText}
+          onChangeEditNewText={setEditNewText}
+          onChangeEditReason={setEditReason}
+          onKeyDown={handleKeyDown}
+          onSave={handleSave}
+          onCancel={handleCancel}
+        />
       ) : (
         <div style={{ margin: 0, color: "var(--tandem-fg)", lineHeight: "1.4" }}>
           {hasSuggestedText ? (
@@ -387,169 +288,23 @@ export const AnnotationCard = React.memo(function AnnotationCard({
           )}
         </div>
       )}
-      {isPending && !isEditing && (onAccept || onDismiss) && (
-        <div style={{ display: "flex", gap: "6px", marginTop: "6px" }}>
-          {onAccept && (
-            <button
-              data-testid={`accept-btn-${annotation.id}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onAccept(annotation.id);
-              }}
-              style={{
-                padding: "2px 8px",
-                fontSize: "11px",
-                border: "1px solid var(--tandem-border-strong)",
-                borderRadius: "3px",
-                background: "var(--tandem-success-bg)",
-                color: "var(--tandem-success-fg-strong)",
-                cursor: "pointer",
-              }}
-            >
-              Accept
-            </button>
-          )}
-          {onDismiss && (
-            <button
-              data-testid={`dismiss-btn-${annotation.id}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onDismiss(annotation.id);
-              }}
-              style={{
-                padding: "2px 8px",
-                fontSize: "11px",
-                border: "1px solid var(--tandem-border-strong)",
-                borderRadius: "3px",
-                background: "var(--tandem-error-bg)",
-                color: "var(--tandem-error-fg-strong)",
-                cursor: "pointer",
-              }}
-            >
-              Reject
-            </button>
-          )}
-        </div>
-      )}
-      {!isPending && undoable && onUndo && (
-        <div style={{ marginTop: "4px", position: "relative" }}>
-          <button
-            data-testid="undo-btn"
-            onClick={(e) => {
-              e.stopPropagation();
-              onUndo(annotation.id);
-            }}
-            style={{
-              padding: "1px 6px",
-              fontSize: "11px",
-              border: "none",
-              background: "none",
-              color: "var(--tandem-accent)",
-              cursor: "pointer",
-              textDecoration: "underline",
-            }}
-          >
-            Undo
-          </button>
-          <div
-            data-testid="undo-countdown"
-            style={{
-              height: "2px",
-              marginTop: "2px",
-              borderRadius: "1px",
-              backgroundColor: "var(--tandem-accent)",
-              animation: "undo-countdown-shrink 10s linear forwards",
-            }}
-          />
-          <style>
-            {`@keyframes undo-countdown-shrink {
-              from { width: 100%; }
-              to { width: 0%; }
-            }`}
-          </style>
-        </div>
-      )}
-      {/* Reply thread */}
-      <CommentThread replies={replies} />
-      {/* Reply input — only on pending annotations with a reply handler */}
-      {isPending && onReply && !isEditing && (
-        <div style={{ marginTop: "6px" }} onClick={(e) => e.stopPropagation()}>
-          {isReplying ? (
-            <div>
-              <textarea
-                data-testid={`reply-input-${annotation.id}`}
-                value={replyText}
-                onChange={(e) => setReplyText(e.target.value)}
-                onKeyDown={handleReplyKeyDown}
-                placeholder="Write a reply..."
-                style={textareaStyle}
-                autoFocus
-              />
-              <div style={{ display: "flex", gap: "6px", marginTop: "4px" }}>
-                <button
-                  data-testid={`reply-send-btn-${annotation.id}`}
-                  onClick={handleSendReply}
-                  disabled={!replyText.trim() || isSendingReply}
-                  style={{
-                    padding: "2px 8px",
-                    fontSize: "11px",
-                    border: "1px solid var(--tandem-border-strong)",
-                    borderRadius: "3px",
-                    background: replyText.trim()
-                      ? "var(--tandem-accent-bg)"
-                      : "var(--tandem-surface-muted)",
-                    color: replyText.trim()
-                      ? "var(--tandem-accent-fg-strong)"
-                      : "var(--tandem-fg-subtle)",
-                    cursor: replyText.trim() ? "pointer" : "default",
-                  }}
-                >
-                  Send
-                </button>
-                <button
-                  data-testid={`reply-cancel-btn-${annotation.id}`}
-                  onClick={() => {
-                    setIsReplying(false);
-                    setReplyText("");
-                  }}
-                  style={{
-                    padding: "2px 8px",
-                    fontSize: "11px",
-                    border: "1px solid var(--tandem-border-strong)",
-                    borderRadius: "3px",
-                    background: "var(--tandem-surface)",
-                    color: "var(--tandem-fg-muted)",
-                    cursor: "pointer",
-                  }}
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          ) : (
-            <button
-              data-testid={`reply-btn-${annotation.id}`}
-              onClick={() => setIsReplying(true)}
-              style={{
-                padding: "1px 4px",
-                fontSize: "11px",
-                border: "none",
-                background: "none",
-                color: "var(--tandem-fg-subtle)",
-                cursor: "pointer",
-              }}
-            >
-              Reply{replies.length > 0 ? ` (${replies.length})` : ""}
-            </button>
-          )}
-        </div>
-      )}
-      {/* Read-only reply count for resolved annotations */}
-      {!isPending && replies.length > 0 && !onReply && (
-        <div style={{ marginTop: "4px", fontSize: "11px", color: "var(--tandem-fg-subtle)" }}>
-          {replies.length} {replies.length === 1 ? "reply" : "replies"}
-        </div>
-      )}
+      <AnnotationCardActions
+        annotationId={annotation.id}
+        isPending={isPending}
+        isEditing={isEditing}
+        undoable={undoable}
+        onAccept={onAccept}
+        onDismiss={onDismiss}
+        onUndo={onUndo}
+      />
+      <ReplyThread
+        annotationId={annotation.id}
+        replies={replies}
+        isPending={isPending}
+        isEditing={isEditing}
+        textareaStyle={textareaStyle}
+        onReply={onReply}
+      />
     </div>
   );
 });

--- a/src/client/panels/AnnotationCardActions.tsx
+++ b/src/client/panels/AnnotationCardActions.tsx
@@ -1,0 +1,109 @@
+export interface AnnotationCardActionsProps {
+  annotationId: string;
+  isPending: boolean;
+  isEditing: boolean;
+  undoable?: boolean;
+  onAccept?: (id: string) => void;
+  onDismiss?: (id: string) => void;
+  onUndo?: (id: string) => void;
+}
+
+export function AnnotationCardActions({
+  annotationId,
+  isPending,
+  isEditing,
+  undoable,
+  onAccept,
+  onDismiss,
+  onUndo,
+}: AnnotationCardActionsProps) {
+  if (isPending && !isEditing && (onAccept || onDismiss)) {
+    return (
+      <div style={{ display: "flex", gap: "6px", marginTop: "6px" }}>
+        {onAccept && (
+          <button
+            data-testid={`accept-btn-${annotationId}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onAccept(annotationId);
+            }}
+            style={{
+              padding: "2px 8px",
+              fontSize: "11px",
+              border: "1px solid var(--tandem-border-strong)",
+              borderRadius: "3px",
+              background: "var(--tandem-success-bg)",
+              color: "var(--tandem-success-fg-strong)",
+              cursor: "pointer",
+            }}
+          >
+            Accept
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            data-testid={`dismiss-btn-${annotationId}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDismiss(annotationId);
+            }}
+            style={{
+              padding: "2px 8px",
+              fontSize: "11px",
+              border: "1px solid var(--tandem-border-strong)",
+              borderRadius: "3px",
+              background: "var(--tandem-error-bg)",
+              color: "var(--tandem-error-fg-strong)",
+              cursor: "pointer",
+            }}
+          >
+            Reject
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  if (!isPending && undoable && onUndo) {
+    return (
+      <div style={{ marginTop: "4px", position: "relative" }}>
+        <button
+          data-testid="undo-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            onUndo(annotationId);
+          }}
+          style={{
+            padding: "1px 6px",
+            fontSize: "11px",
+            border: "none",
+            background: "none",
+            color: "var(--tandem-accent)",
+            cursor: "pointer",
+            textDecoration: "underline",
+          }}
+        >
+          Undo
+        </button>
+        <div
+          data-testid="undo-countdown"
+          style={{
+            height: "2px",
+            marginTop: "2px",
+            borderRadius: "1px",
+            backgroundColor: "var(--tandem-accent)",
+            animation: "undo-countdown-shrink 10s linear forwards",
+          }}
+        />
+        <style>
+          {`@keyframes undo-countdown-shrink {
+              from { width: 100%; }
+              to { width: 0%; }
+            }`}
+        </style>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/client/panels/AnnotationEditForm.tsx
+++ b/src/client/panels/AnnotationEditForm.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { TEXTAREA_STYLE } from "./AnnotationCard";
 
 export interface AnnotationEditFormProps {
   annotationId: string;
@@ -6,7 +7,6 @@ export interface AnnotationEditFormProps {
   editText: string;
   editNewText: string;
   editReason: string;
-  textareaStyle: React.CSSProperties;
   onChangeEditText: (value: string) => void;
   onChangeEditNewText: (value: string) => void;
   onChangeEditReason: (value: string) => void;
@@ -21,7 +21,6 @@ export function AnnotationEditForm({
   editText,
   editNewText,
   editReason,
-  textareaStyle,
   onChangeEditText,
   onChangeEditNewText,
   onChangeEditReason,
@@ -48,7 +47,7 @@ export function AnnotationEditForm({
             value={editNewText}
             onChange={(e) => onChangeEditNewText(e.target.value)}
             onKeyDown={onKeyDown}
-            style={textareaStyle}
+            style={TEXTAREA_STYLE}
             autoFocus
           />
           <label
@@ -67,7 +66,7 @@ export function AnnotationEditForm({
             value={editReason}
             onChange={(e) => onChangeEditReason(e.target.value)}
             onKeyDown={onKeyDown}
-            style={textareaStyle}
+            style={TEXTAREA_STYLE}
           />
         </>
       ) : (
@@ -76,7 +75,7 @@ export function AnnotationEditForm({
           value={editText}
           onChange={(e) => onChangeEditText(e.target.value)}
           onKeyDown={onKeyDown}
-          style={textareaStyle}
+          style={TEXTAREA_STYLE}
           autoFocus
         />
       )}

--- a/src/client/panels/AnnotationEditForm.tsx
+++ b/src/client/panels/AnnotationEditForm.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+
+export interface AnnotationEditFormProps {
+  annotationId: string;
+  hasSuggestedText: boolean;
+  editText: string;
+  editNewText: string;
+  editReason: string;
+  textareaStyle: React.CSSProperties;
+  onChangeEditText: (value: string) => void;
+  onChangeEditNewText: (value: string) => void;
+  onChangeEditReason: (value: string) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+export function AnnotationEditForm({
+  annotationId,
+  hasSuggestedText,
+  editText,
+  editNewText,
+  editReason,
+  textareaStyle,
+  onChangeEditText,
+  onChangeEditNewText,
+  onChangeEditReason,
+  onKeyDown,
+  onSave,
+  onCancel,
+}: AnnotationEditFormProps) {
+  return (
+    <div style={{ marginTop: "4px" }} onClick={(e) => e.stopPropagation()}>
+      {hasSuggestedText ? (
+        <>
+          <label
+            style={{
+              fontSize: "11px",
+              color: "var(--tandem-fg-muted)",
+              display: "block",
+              marginBottom: "2px",
+            }}
+          >
+            Replacement text
+          </label>
+          <textarea
+            data-testid={`edit-newtext-${annotationId}`}
+            value={editNewText}
+            onChange={(e) => onChangeEditNewText(e.target.value)}
+            onKeyDown={onKeyDown}
+            style={textareaStyle}
+            autoFocus
+          />
+          <label
+            style={{
+              fontSize: "11px",
+              color: "var(--tandem-fg-muted)",
+              display: "block",
+              marginTop: "4px",
+              marginBottom: "2px",
+            }}
+          >
+            Reason
+          </label>
+          <textarea
+            data-testid={`edit-reason-${annotationId}`}
+            value={editReason}
+            onChange={(e) => onChangeEditReason(e.target.value)}
+            onKeyDown={onKeyDown}
+            style={textareaStyle}
+          />
+        </>
+      ) : (
+        <textarea
+          data-testid={`edit-text-${annotationId}`}
+          value={editText}
+          onChange={(e) => onChangeEditText(e.target.value)}
+          onKeyDown={onKeyDown}
+          style={textareaStyle}
+          autoFocus
+        />
+      )}
+      <div style={{ display: "flex", gap: "6px", marginTop: "4px" }}>
+        <button
+          data-testid={`edit-save-btn-${annotationId}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSave();
+          }}
+          style={{
+            padding: "2px 8px",
+            fontSize: "11px",
+            border: "1px solid var(--tandem-border-strong)",
+            borderRadius: "3px",
+            background: "var(--tandem-success-bg)",
+            color: "var(--tandem-success-fg-strong)",
+            cursor: "pointer",
+          }}
+        >
+          Save
+        </button>
+        <button
+          data-testid={`edit-cancel-btn-${annotationId}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onCancel();
+          }}
+          style={{
+            padding: "2px 8px",
+            fontSize: "11px",
+            border: "1px solid var(--tandem-border-strong)",
+            borderRadius: "3px",
+            background: "var(--tandem-surface)",
+            color: "var(--tandem-fg-muted)",
+            cursor: "pointer",
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/client/panels/ReplyThread.tsx
+++ b/src/client/panels/ReplyThread.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from "react";
+import type { AnnotationReply } from "../../shared/types";
+import { CommentThread } from "./CommentThread";
+
+export interface ReplyThreadProps {
+  annotationId: string;
+  replies: AnnotationReply[];
+  isPending: boolean;
+  isEditing: boolean;
+  textareaStyle: React.CSSProperties;
+  onReply?: (id: string, text: string) => Promise<boolean>;
+}
+
+export function ReplyThread({
+  annotationId,
+  replies,
+  isPending,
+  isEditing,
+  textareaStyle,
+  onReply,
+}: ReplyThreadProps) {
+  const [isReplying, setIsReplying] = useState(false);
+  const [replyText, setReplyText] = useState("");
+  const [isSendingReply, setIsSendingReply] = useState(false);
+
+  function handleReplyKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      setIsReplying(false);
+      setReplyText("");
+    }
+  }
+
+  async function handleSendReply() {
+    const trimmed = replyText.trim();
+    if (!trimmed || isSendingReply) return;
+    setIsSendingReply(true);
+    try {
+      const ok = await onReply?.(annotationId, trimmed);
+      if (ok !== false) {
+        setReplyText("");
+        setIsReplying(false);
+      }
+    } finally {
+      setIsSendingReply(false);
+    }
+  }
+
+  return (
+    <>
+      {/* Reply thread */}
+      <CommentThread replies={replies} />
+      {/* Reply input — only on pending annotations with a reply handler */}
+      {isPending && onReply && !isEditing && (
+        <div style={{ marginTop: "6px" }} onClick={(e) => e.stopPropagation()}>
+          {isReplying ? (
+            <div>
+              <textarea
+                data-testid={`reply-input-${annotationId}`}
+                value={replyText}
+                onChange={(e) => setReplyText(e.target.value)}
+                onKeyDown={handleReplyKeyDown}
+                placeholder="Write a reply..."
+                style={textareaStyle}
+                autoFocus
+              />
+              <div style={{ display: "flex", gap: "6px", marginTop: "4px" }}>
+                <button
+                  data-testid={`reply-send-btn-${annotationId}`}
+                  onClick={handleSendReply}
+                  disabled={!replyText.trim() || isSendingReply}
+                  style={{
+                    padding: "2px 8px",
+                    fontSize: "11px",
+                    border: "1px solid var(--tandem-border-strong)",
+                    borderRadius: "3px",
+                    background: replyText.trim()
+                      ? "var(--tandem-accent-bg)"
+                      : "var(--tandem-surface-muted)",
+                    color: replyText.trim()
+                      ? "var(--tandem-accent-fg-strong)"
+                      : "var(--tandem-fg-subtle)",
+                    cursor: replyText.trim() ? "pointer" : "default",
+                  }}
+                >
+                  Send
+                </button>
+                <button
+                  data-testid={`reply-cancel-btn-${annotationId}`}
+                  onClick={() => {
+                    setIsReplying(false);
+                    setReplyText("");
+                  }}
+                  style={{
+                    padding: "2px 8px",
+                    fontSize: "11px",
+                    border: "1px solid var(--tandem-border-strong)",
+                    borderRadius: "3px",
+                    background: "var(--tandem-surface)",
+                    color: "var(--tandem-fg-muted)",
+                    cursor: "pointer",
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              data-testid={`reply-btn-${annotationId}`}
+              onClick={() => setIsReplying(true)}
+              style={{
+                padding: "1px 4px",
+                fontSize: "11px",
+                border: "none",
+                background: "none",
+                color: "var(--tandem-fg-subtle)",
+                cursor: "pointer",
+              }}
+            >
+              Reply{replies.length > 0 ? ` (${replies.length})` : ""}
+            </button>
+          )}
+        </div>
+      )}
+      {/* Read-only reply count for resolved annotations */}
+      {!isPending && replies.length > 0 && !onReply && (
+        <div style={{ marginTop: "4px", fontSize: "11px", color: "var(--tandem-fg-subtle)" }}>
+          {replies.length} {replies.length === 1 ? "reply" : "replies"}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/client/panels/ReplyThread.tsx
+++ b/src/client/panels/ReplyThread.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import type { AnnotationReply } from "../../shared/types";
+import { TEXTAREA_STYLE } from "./AnnotationCard";
 import { CommentThread } from "./CommentThread";
 
 export interface ReplyThreadProps {
@@ -7,7 +8,6 @@ export interface ReplyThreadProps {
   replies: AnnotationReply[];
   isPending: boolean;
   isEditing: boolean;
-  textareaStyle: React.CSSProperties;
   onReply?: (id: string, text: string) => Promise<boolean>;
 }
 
@@ -16,12 +16,13 @@ export function ReplyThread({
   replies,
   isPending,
   isEditing,
-  textareaStyle,
   onReply,
 }: ReplyThreadProps) {
   const [isReplying, setIsReplying] = useState(false);
   const [replyText, setReplyText] = useState("");
   const [isSendingReply, setIsSendingReply] = useState(false);
+
+  const hasText = Boolean(replyText.trim());
 
   function handleReplyKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Escape") {
@@ -61,26 +62,22 @@ export function ReplyThread({
                 onChange={(e) => setReplyText(e.target.value)}
                 onKeyDown={handleReplyKeyDown}
                 placeholder="Write a reply..."
-                style={textareaStyle}
+                style={TEXTAREA_STYLE}
                 autoFocus
               />
               <div style={{ display: "flex", gap: "6px", marginTop: "4px" }}>
                 <button
                   data-testid={`reply-send-btn-${annotationId}`}
                   onClick={handleSendReply}
-                  disabled={!replyText.trim() || isSendingReply}
+                  disabled={!hasText || isSendingReply}
                   style={{
                     padding: "2px 8px",
                     fontSize: "11px",
                     border: "1px solid var(--tandem-border-strong)",
                     borderRadius: "3px",
-                    background: replyText.trim()
-                      ? "var(--tandem-accent-bg)"
-                      : "var(--tandem-surface-muted)",
-                    color: replyText.trim()
-                      ? "var(--tandem-accent-fg-strong)"
-                      : "var(--tandem-fg-subtle)",
-                    cursor: replyText.trim() ? "pointer" : "default",
+                    background: hasText ? "var(--tandem-accent-bg)" : "var(--tandem-surface-muted)",
+                    color: hasText ? "var(--tandem-accent-fg-strong)" : "var(--tandem-fg-subtle)",
+                    cursor: hasText ? "pointer" : "default",
                   }}
                 >
                   Send


### PR DESCRIPTION
## Summary

- Extracts `AnnotationEditForm` (presentational, receives edit state + callbacks as props) from the inline edit UI (~L249-338)
- Extracts `AnnotationCardActions` (stateless, renders pending accept/dismiss OR undo branch based on props) from the action buttons (~L390-471) including the `@keyframes undo-countdown-shrink` style tag
- Extracts `ReplyThread` (owns reply state: `isReplying`, `replyText`, `isSendingReply`, and handlers) from the reply input + CommentThread wrapper (~L472-552); takes over the `CommentThread` import
- `AnnotationCard.tsx` reduced from 555 LOC to ~310 LOC; edit state stays in parent since `enterEditMode` lives in the header span
- `textareaStyle` defined once in parent and passed as prop to both `AnnotationEditForm` and `ReplyThread`
- All `data-testid` attributes preserved exactly, including `undo-btn`/`undo-countdown` (no id suffix) vs all others which carry `${annotation.id}`
- SidePanel's `{ AnnotationCard }` import is unchanged

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 1428 passed, 1 pre-existing timeout failure in `mcp-stdio.test.ts` (network test unrelated to this change)
- [x] All 18 `data-testid` attributes verified across the 4 files

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)