### PR TITLE
fix(server): surface HTTP API silent failures (#396)

### DIFF
--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -91,10 +91,10 @@ export const apiMiddleware: Handler = createApiMiddleware();
 export function registerApiRoutes(
   app: Express,
   largeBody: Handler,
-  token?: string,
-  mw: Handler = apiMiddleware,
-  setCurrentToken: (t: string) => void = () => {},
-  getCurrentToken: () => string | null = () => null,
+  token: string | undefined,
+  mw: Handler,
+  setCurrentToken: (t: string) => void,
+  getCurrentToken: () => string | null,
 ): void {
   // SSE notification stream for browser toasts
   app.get("/api/notify-stream", mw, handleNotifyStream);

--- a/src/server/mcp/routes/_shared.ts
+++ b/src/server/mcp/routes/_shared.ts
@@ -91,6 +91,7 @@ export function sendApiError(res: Response, err: unknown): void {
   const label = errorCodeToLabel(code);
   const msg =
     label === "FILE_LOCKED" ? "File is locked by another program." : (e.message ?? String(err));
-  if (status === 500) console.error("[Tandem] Unhandled API error:", err);
+  if (status >= 500) console.error("[Tandem] Unhandled API error:", err);
+  else if (status >= 400) console.warn(`[Tandem] API error (${status}): ${msg}`);
   res.status(status).json({ error: label, message: msg });
 }

--- a/src/server/mcp/routes/annotation-reply.ts
+++ b/src/server/mcp/routes/annotation-reply.ts
@@ -29,6 +29,7 @@ export function handleAnnotationReply(req: Request, res: Response): void {
   const result = addReplyToAnnotation(ydoc, annotationsMap, annotationId, text, "user");
   if (!result.ok) {
     const status = result.code === "ANNOTATION_RESOLVED" ? 409 : 404;
+    console.warn(`[Tandem] API error (${status}): annotation reply failed: ${result.error}`);
     pushNotification({
       id: generateNotificationId(),
       type: "annotation-error",

--- a/src/server/mcp/routes/close.ts
+++ b/src/server/mcp/routes/close.ts
@@ -11,6 +11,9 @@ export async function handleClose(req: Request, res: Response): Promise<void> {
   try {
     const result = await closeDocumentById(documentId);
     if (!result.success) {
+      console.warn(
+        `[Tandem] API error (404): close failed for documentId=${documentId}: ${result.error}`,
+      );
       res.status(404).json({ error: "NOT_FOUND", message: result.error });
       return;
     }

--- a/src/server/mcp/routes/mode.ts
+++ b/src/server/mcp/routes/mode.ts
@@ -11,6 +11,13 @@ import { getOrCreateDocument } from "../../yjs/provider.js";
 export function handleMode(_req: Request, res: Response): void {
   const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
   const awareness = ctrlDoc.getMap(Y_MAP_USER_AWARENESS);
-  const mode = TandemModeSchema.catch(TANDEM_MODE_DEFAULT).parse(awareness.get(Y_MAP_MODE));
+  const raw = awareness.get(Y_MAP_MODE);
+  const parsed = TandemModeSchema.safeParse(raw);
+  if (raw !== undefined && !parsed.success) {
+    console.warn(
+      `[Tandem] Invalid mode value in awareness, falling back to default. raw=${JSON.stringify(raw)}`,
+    );
+  }
+  const mode = parsed.success ? parsed.data : TANDEM_MODE_DEFAULT;
   res.json({ mode });
 }

--- a/src/server/mcp/routes/notify-stream.ts
+++ b/src/server/mcp/routes/notify-stream.ts
@@ -21,10 +21,7 @@ export function handleNotifyStream(req: Request, res: Response): void {
     try {
       res.write(`data: ${JSON.stringify(notification)}\n\n`);
     } catch (err) {
-      console.error(
-        "[NotifyStream] Write failed, cleaning up:",
-        err instanceof Error ? err.message : err,
-      );
+      console.error("[NotifyStream] Write failed, cleaning up:", err);
       cleanup();
     }
   });
@@ -33,10 +30,7 @@ export function handleNotifyStream(req: Request, res: Response): void {
     try {
       if (!res.writableEnded) res.write(": keepalive\n\n");
     } catch (err) {
-      console.error(
-        "[NotifyStream] Keepalive write failed, cleaning up:",
-        err instanceof Error ? err.message : err,
-      );
+      console.error("[NotifyStream] Keepalive write failed, cleaning up:", err);
       cleanup();
     }
   }, CHANNEL_SSE_KEEPALIVE_MS);

--- a/src/server/mcp/routes/rotate-token.ts
+++ b/src/server/mcp/routes/rotate-token.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import { setPreviousToken } from "../../auth/middleware.js";
-import { readTokenFromFile } from "../../auth/token-store.js";
+import { getTokenFilePath, readTokenFromFile } from "../../auth/token-store.js";
 import type { Handler } from "./_shared.js";
 
 export function makeRotateTokenHandler(deps: {
@@ -29,6 +29,10 @@ export function makeRotateTokenHandler(deps: {
     }
 
     if (!newToken) {
+      console.error(
+        "[Tandem] rotate-token: no token found on disk after rotation at:",
+        getTokenFilePath(),
+      );
       res
         .status(500)
         .json({ error: "INTERNAL", message: "No token found on disk after rotation." });

--- a/src/server/mcp/routes/rotate-token.ts
+++ b/src/server/mcp/routes/rotate-token.ts
@@ -23,7 +23,7 @@ export function makeRotateTokenHandler(deps: {
     try {
       newToken = await readTokenFromFile();
     } catch (err) {
-      console.error("[tandem] rotate-token: failed to read new token from disk:", err);
+      console.error("[Tandem] rotate-token: failed to read new token from disk:", err);
       res.status(500).json({ error: "INTERNAL", message: "Could not read new token from disk." });
       return;
     }
@@ -45,7 +45,7 @@ export function makeRotateTokenHandler(deps: {
 
     deps.setCurrentToken(newToken);
 
-    console.error("[tandem] auth token rotated; 60-second grace window active for old token");
+    console.error("[Tandem] auth token rotated; 60-second grace window active for old token");
     res.json({ ok: true });
   };
 }

--- a/src/server/mcp/routes/setup.ts
+++ b/src/server/mcp/routes/setup.ts
@@ -69,7 +69,7 @@ export async function runSetupHandler(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       errors.push(`${target.label}: ${msg}`);
-      console.error(`[Setup] target=${target.label} failed: ${msg}`);
+      console.error(`[Setup] target=${target.label} failed:`, err);
     }
   }
 
@@ -80,7 +80,7 @@ export async function runSetupHandler(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     errors.push(`Skill install: ${msg}`);
-    console.error(`[Setup] skill install failed: ${msg}`);
+    console.error("[Setup] skill install failed:", err);
   }
 
   // HTTP status reflects outcome:


### PR DESCRIPTION
## Summary

Adds server-side logging to 8 previously silent failure paths across HTTP API route handlers. No behavioral change for callers — response status codes and bodies are unchanged. All new log statements use `[Tandem]` prefix and go to stderr (consistent with the project's stdout-reserved rule).

- **Fix 1 — `_shared.ts`**: `sendApiError` now logs `console.warn` for 4xx responses (was 500-only). Format: `[Tandem] API error (${status}): ${message}`
- **Fix 2 — `annotation-reply.ts`**: Failure branch (annotation resolved/not found) now logs `console.warn` before pushing the toast notification
- **Fix 3 — `rotate-token.ts`**: Null token case now logs `console.error` with the token file path via `getTokenFilePath()`
- **Fix 4 — `notify-stream.ts`**: SSE write failures now pass the full `err` object to `console.error` (stack trace was previously discarded with `err.message`-only logging)
- **Fix 5 — `api-routes.ts`**: Removed no-op `= () => {}` and `= () => null` defaults from `registerApiRoutes` — params are now required. Single call site in `server.ts` already passes both explicitly; no test callers exist
- **Fix 6 — `mode.ts`**: Replaced silent `.catch(TANDEM_MODE_DEFAULT).parse()` with `.safeParse()` + manual fallback + `console.warn` on unexpected non-undefined invalid values (undefined = cold server, silently defaults)
- **Fix 7 — `close.ts`**: `closeDocumentById` returning `success === false` now logs `console.warn` with the documentId before sending 404
- **Fix 8 — `setup.ts`**: Both inner `catch` blocks now pass full `err` to `console.error` instead of `err.message` only (stack traces preserved)

## Test plan

- [x] `npm run typecheck` — passes clean
- [x] `npm test` — 1438 tests pass across 96 test files; 1 pre-existing timeout failure in `mcp-stdio.test.ts` (unrelated, reproducible on master)
- [ ] Manual: trigger a failed `POST /api/close` with an unknown documentId and confirm `[Tandem] API error (404):` appears in server stderr
- [ ] Manual: set an invalid mode value in CTRL_ROOM awareness and confirm the warn fires once on `/api/mode` call

Closes #396