### PR TITLE
refactor(client): split Toolbar.tsx and SettingsPopover.tsx (#402)

### DIFF
--- a/src/client/components/AccessibilitySettings.tsx
+++ b/src/client/components/AccessibilitySettings.tsx
@@ -1,0 +1,39 @@
+import type { TandemSettings } from "../hooks/useTandemSettings";
+import { sectionLabelStyle } from "./settingsStyles";
+
+interface AccessibilitySettingsProps {
+  settings: TandemSettings;
+  onUpdate: (partial: Partial<TandemSettings>) => void;
+}
+
+export function AccessibilitySettings({ settings, onUpdate }: AccessibilitySettingsProps) {
+  return (
+    <div>
+      <div style={sectionLabelStyle}>Authorship</div>
+      <label
+        data-testid="authorship-toggle"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          cursor: "pointer",
+          fontSize: "12px",
+          color: "var(--tandem-fg)",
+          minHeight: "24px",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={settings.showAuthorship}
+          onChange={(e) => onUpdate({ showAuthorship: e.target.checked })}
+          style={{ accentColor: "var(--tandem-accent)" }}
+        />
+        <span>Show who wrote what</span>
+      </label>
+      <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
+        Highlights text by author: <span style={{ color: "var(--tandem-author-user)" }}>you</span> /{" "}
+        <span style={{ color: "var(--tandem-author-claude)" }}>Claude</span>
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/AppearanceSettings.tsx
+++ b/src/client/components/AppearanceSettings.tsx
@@ -1,0 +1,285 @@
+import React, { useEffect, useState } from "react";
+import { useRadioGroup } from "../hooks/useRadioGroup";
+import type {
+  LayoutMode,
+  PanelOrder,
+  PrimaryTab,
+  TandemSettings,
+  TextSize,
+  ThemePreference,
+} from "../hooks/useTandemSettings";
+import { sectionLabelStyle } from "./settingsStyles";
+
+interface AppearanceSettingsProps {
+  open: boolean;
+  settings: TandemSettings;
+  onUpdate: (partial: Partial<TandemSettings>) => void;
+}
+
+const cardStyle = (selected: boolean, disabled?: boolean): React.CSSProperties => ({
+  flex: 1,
+  padding: "8px",
+  minHeight: "24px",
+  border: `2px solid ${selected ? "var(--tandem-accent)" : "var(--tandem-border)"}`,
+  borderRadius: "6px",
+  background: disabled
+    ? "var(--tandem-surface-muted)"
+    : selected
+      ? "var(--tandem-accent-bg)"
+      : "var(--tandem-surface)",
+  cursor: disabled ? "not-allowed" : "pointer",
+  textAlign: "center",
+  fontSize: "11px",
+  color: disabled
+    ? "var(--tandem-fg-subtle)"
+    : selected
+      ? "var(--tandem-accent-fg-strong)"
+      : "var(--tandem-fg-muted)",
+  fontWeight: selected ? 600 : 400,
+  opacity: disabled ? 0.6 : 1,
+  transition: "border-color 0.15s, background 0.15s",
+});
+
+export function AppearanceSettings({ open, settings, onUpdate }: AppearanceSettingsProps) {
+  const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
+  const threePanelDisabled = viewportWidth < 768;
+
+  const themeRg = useRadioGroup<ThemePreference>(
+    settings.theme,
+    ["light", "dark", "system"] as const,
+    (t) => onUpdate({ theme: t }),
+  );
+  const layoutRg = useRadioGroup<LayoutMode>(
+    settings.layout,
+    ["tabbed", "three-panel"] as const,
+    (l) => onUpdate({ layout: l }),
+    (l) => l === "three-panel" && threePanelDisabled,
+  );
+  const primaryTabRg = useRadioGroup<PrimaryTab>(
+    settings.primaryTab,
+    ["chat", "annotations"] as const,
+    (p) => onUpdate({ primaryTab: p }),
+  );
+  const panelOrderRg = useRadioGroup<PanelOrder>(
+    settings.panelOrder,
+    ["chat-editor-annotations", "annotations-editor-chat"] as const,
+    (p) => onUpdate({ panelOrder: p }),
+  );
+  const textSizeRg = useRadioGroup<TextSize>(settings.textSize, ["s", "m", "l"] as const, (t) =>
+    onUpdate({ textSize: t }),
+  );
+
+  // Track viewport width for three-panel availability (only while open)
+  useEffect(() => {
+    if (!open) return;
+    setViewportWidth(window.innerWidth);
+    const handler = () => setViewportWidth(window.innerWidth);
+    window.addEventListener("resize", handler);
+    return () => window.removeEventListener("resize", handler);
+  }, [open]);
+
+  return (
+    <>
+      {/* Theme */}
+      <div>
+        <div id="settings-theme-label" style={sectionLabelStyle}>
+          Theme
+        </div>
+        <div
+          role="radiogroup"
+          aria-labelledby="settings-theme-label"
+          onKeyDown={themeRg.handleKeyDown}
+          style={{ display: "flex", gap: "8px" }}
+        >
+          {(["light", "dark", "system"] as const).map((t) => (
+            <button
+              key={t}
+              data-testid={`theme-${t}-btn`}
+              role="radio"
+              aria-checked={settings.theme === t}
+              tabIndex={themeRg.tabIndexFor(t)}
+              onClick={() => onUpdate({ theme: t })}
+              style={cardStyle(settings.theme === t)}
+            >
+              {t === "light" ? "Light" : t === "dark" ? "Dark" : "System"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Layout mode */}
+      <div>
+        <div id="settings-layout-label" style={sectionLabelStyle}>
+          Layout
+        </div>
+        <div
+          role="radiogroup"
+          aria-labelledby="settings-layout-label"
+          onKeyDown={layoutRg.handleKeyDown}
+          style={{ display: "flex", gap: "8px" }}
+        >
+          <button
+            data-testid="layout-tabbed-btn"
+            role="radio"
+            aria-checked={settings.layout === "tabbed"}
+            tabIndex={layoutRg.tabIndexFor("tabbed")}
+            onClick={() => onUpdate({ layout: "tabbed" })}
+            style={cardStyle(settings.layout === "tabbed")}
+          >
+            <div style={{ fontSize: "18px", marginBottom: "2px" }}>{"[=|]"}</div>
+            Tabbed
+          </button>
+          <button
+            data-testid="layout-three-panel-btn"
+            role="radio"
+            aria-checked={settings.layout === "three-panel"}
+            aria-disabled={threePanelDisabled || undefined}
+            tabIndex={layoutRg.tabIndexFor("three-panel")}
+            onClick={() => {
+              if (!threePanelDisabled) onUpdate({ layout: "three-panel" });
+            }}
+            style={cardStyle(settings.layout === "three-panel", threePanelDisabled)}
+            title={threePanelDisabled ? "Requires viewport wider than 768px" : undefined}
+          >
+            <div style={{ fontSize: "18px", marginBottom: "2px" }}>{"[|||]"}</div>
+            Three-Panel
+          </button>
+        </div>
+        {threePanelDisabled && (
+          <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
+            Three-panel requires a wider viewport
+          </div>
+        )}
+      </div>
+
+      {/* Primary tab (tabbed mode only) */}
+      {settings.layout === "tabbed" && (
+        <div>
+          <div id="settings-default-tab-label" style={sectionLabelStyle}>
+            Default Tab
+          </div>
+          <div
+            role="radiogroup"
+            aria-labelledby="settings-default-tab-label"
+            onKeyDown={primaryTabRg.handleKeyDown}
+            style={{ display: "flex", gap: "8px" }}
+          >
+            <button
+              data-testid="default-tab-chat-btn"
+              role="radio"
+              aria-checked={settings.primaryTab === "chat"}
+              tabIndex={primaryTabRg.tabIndexFor("chat")}
+              onClick={() => onUpdate({ primaryTab: "chat" })}
+              style={cardStyle(settings.primaryTab === "chat")}
+            >
+              Chat
+            </button>
+            <button
+              data-testid="default-tab-annotations-btn"
+              role="radio"
+              aria-checked={settings.primaryTab === "annotations"}
+              tabIndex={primaryTabRg.tabIndexFor("annotations")}
+              onClick={() => onUpdate({ primaryTab: "annotations" })}
+              style={cardStyle(settings.primaryTab === "annotations")}
+            >
+              Annotations
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Panel order (three-panel mode only) */}
+      {settings.layout === "three-panel" && (
+        <div>
+          <div id="settings-panel-order-label" style={sectionLabelStyle}>
+            Panel Order
+          </div>
+          <div
+            role="radiogroup"
+            aria-labelledby="settings-panel-order-label"
+            onKeyDown={panelOrderRg.handleKeyDown}
+            style={{ display: "flex", gap: "8px" }}
+          >
+            <button
+              data-testid="panel-order-cea-btn"
+              role="radio"
+              aria-checked={settings.panelOrder === "chat-editor-annotations"}
+              tabIndex={panelOrderRg.tabIndexFor("chat-editor-annotations")}
+              onClick={() => onUpdate({ panelOrder: "chat-editor-annotations" })}
+              style={cardStyle(settings.panelOrder === "chat-editor-annotations")}
+            >
+              Chat | Editor | Ann.
+            </button>
+            <button
+              data-testid="panel-order-aec-btn"
+              role="radio"
+              aria-checked={settings.panelOrder === "annotations-editor-chat"}
+              tabIndex={panelOrderRg.tabIndexFor("annotations-editor-chat")}
+              onClick={() => onUpdate({ panelOrder: "annotations-editor-chat" })}
+              style={cardStyle(settings.panelOrder === "annotations-editor-chat")}
+            >
+              Ann. | Editor | Chat
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Text Size */}
+      <div>
+        <div id="settings-text-size-label" style={sectionLabelStyle}>
+          Text Size
+        </div>
+        <div
+          role="radiogroup"
+          aria-labelledby="settings-text-size-label"
+          onKeyDown={textSizeRg.handleKeyDown}
+          style={{ display: "flex", gap: "8px" }}
+        >
+          {(["s", "m", "l"] as const).map((size) => (
+            <button
+              key={size}
+              data-testid={`text-size-${size}-btn`}
+              role="radio"
+              aria-checked={settings.textSize === size}
+              tabIndex={textSizeRg.tabIndexFor(size)}
+              onClick={() => onUpdate({ textSize: size })}
+              style={cardStyle(settings.textSize === size)}
+            >
+              {size === "s" ? "Small" : size === "m" ? "Medium" : "Large"}
+            </button>
+          ))}
+        </div>
+        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
+          Reading density only — use browser zoom (Ctrl + =/−) to scale the whole UI.
+        </div>
+      </div>
+
+      {/* Reduce Motion */}
+      <div>
+        <label
+          data-testid="reduce-motion-toggle"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            cursor: "pointer",
+            fontSize: "12px",
+            color: "var(--tandem-fg)",
+            minHeight: "24px",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={settings.reduceMotion}
+            onChange={(e) => onUpdate({ reduceMotion: e.target.checked })}
+            style={{ accentColor: "var(--tandem-accent)" }}
+          />
+          <span>Reduce motion</span>
+        </label>
+        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
+          Disables smooth autoscroll and the annotation flash animation.
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/client/components/AppearanceSettings.tsx
+++ b/src/client/components/AppearanceSettings.tsx
@@ -16,29 +16,31 @@ interface AppearanceSettingsProps {
   onUpdate: (partial: Partial<TandemSettings>) => void;
 }
 
-const cardStyle = (selected: boolean, disabled?: boolean): React.CSSProperties => ({
-  flex: 1,
-  padding: "8px",
-  minHeight: "24px",
-  border: `2px solid ${selected ? "var(--tandem-accent)" : "var(--tandem-border)"}`,
-  borderRadius: "6px",
-  background: disabled
-    ? "var(--tandem-surface-muted)"
-    : selected
-      ? "var(--tandem-accent-bg)"
-      : "var(--tandem-surface)",
-  cursor: disabled ? "not-allowed" : "pointer",
-  textAlign: "center",
-  fontSize: "11px",
-  color: disabled
-    ? "var(--tandem-fg-subtle)"
-    : selected
-      ? "var(--tandem-accent-fg-strong)"
-      : "var(--tandem-fg-muted)",
-  fontWeight: selected ? 600 : 400,
-  opacity: disabled ? 0.6 : 1,
-  transition: "border-color 0.15s, background 0.15s",
-});
+function cardStyle(selected: boolean, disabled?: boolean): React.CSSProperties {
+  return {
+    flex: 1,
+    padding: "8px",
+    minHeight: "24px",
+    border: `2px solid ${selected ? "var(--tandem-accent)" : "var(--tandem-border)"}`,
+    borderRadius: "6px",
+    background: disabled
+      ? "var(--tandem-surface-muted)"
+      : selected
+        ? "var(--tandem-accent-bg)"
+        : "var(--tandem-surface)",
+    cursor: disabled ? "not-allowed" : "pointer",
+    textAlign: "center",
+    fontSize: "11px",
+    color: disabled
+      ? "var(--tandem-fg-subtle)"
+      : selected
+        ? "var(--tandem-accent-fg-strong)"
+        : "var(--tandem-fg-muted)",
+    fontWeight: selected ? 600 : 400,
+    opacity: disabled ? 0.6 : 1,
+    transition: "border-color 0.15s, background 0.15s",
+  };
+}
 
 export function AppearanceSettings({ open, settings, onUpdate }: AppearanceSettingsProps) {
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);

--- a/src/client/components/EditorSettings.tsx
+++ b/src/client/components/EditorSettings.tsx
@@ -1,0 +1,45 @@
+import type { TandemSettings } from "../hooks/useTandemSettings";
+import { sectionLabelStyle } from "./settingsStyles";
+
+interface EditorSettingsProps {
+  settings: TandemSettings;
+  onUpdate: (partial: Partial<TandemSettings>) => void;
+}
+
+export function EditorSettings({ settings, onUpdate }: EditorSettingsProps) {
+  return (
+    <div>
+      <div style={sectionLabelStyle}>
+        Editor Width:{" "}
+        <span style={{ fontWeight: 400, textTransform: "none" }}>
+          {settings.editorWidthPercent}%
+        </span>
+      </div>
+      <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginBottom: "6px" }}>
+        How much of the available space the editor text fills
+      </div>
+      <input
+        data-testid="editor-width-slider"
+        type="range"
+        min={50}
+        max={100}
+        step={5}
+        value={settings.editorWidthPercent}
+        onChange={(e) => onUpdate({ editorWidthPercent: Number(e.target.value) })}
+        style={{ width: "100%", accentColor: "var(--tandem-accent)" }}
+        aria-label="Editor width"
+      />
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontSize: "10px",
+          color: "var(--tandem-fg-subtle)",
+        }}
+      >
+        <span>50%</span>
+        <span>100%</span>
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -4,16 +4,12 @@ import {
   SELECTION_DWELL_MIN_MS,
   USER_NAME_MAX_LEN,
 } from "../../shared/constants";
-import { useRadioGroup } from "../hooks/useRadioGroup";
-import type {
-  LayoutMode,
-  PanelOrder,
-  PrimaryTab,
-  TandemSettings,
-  TextSize,
-  ThemePreference,
-} from "../hooks/useTandemSettings";
+import type { TandemSettings } from "../hooks/useTandemSettings";
 import { useUserName } from "../hooks/useUserName";
+import { AccessibilitySettings } from "./AccessibilitySettings";
+import { AppearanceSettings } from "./AppearanceSettings";
+import { EditorSettings } from "./EditorSettings";
+import { sectionLabelStyle } from "./settingsStyles";
 
 interface SettingsPopoverProps {
   open: boolean;
@@ -46,8 +42,6 @@ export function SettingsPopover({
 }: SettingsPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
-  const threePanelDisabled = viewportWidth < 768;
   const { userName, setUserName } = useUserName();
   const [nameInput, setNameInput] = useState(userName);
 
@@ -60,40 +54,6 @@ export function SettingsPopover({
       setNameInput(userName);
     }
   }, [userName, nameInput]);
-
-  const themeRg = useRadioGroup<ThemePreference>(
-    settings.theme,
-    ["light", "dark", "system"] as const,
-    (t) => onUpdate({ theme: t }),
-  );
-  const layoutRg = useRadioGroup<LayoutMode>(
-    settings.layout,
-    ["tabbed", "three-panel"] as const,
-    (l) => onUpdate({ layout: l }),
-    (l) => l === "three-panel" && threePanelDisabled,
-  );
-  const primaryTabRg = useRadioGroup<PrimaryTab>(
-    settings.primaryTab,
-    ["chat", "annotations"] as const,
-    (p) => onUpdate({ primaryTab: p }),
-  );
-  const panelOrderRg = useRadioGroup<PanelOrder>(
-    settings.panelOrder,
-    ["chat-editor-annotations", "annotations-editor-chat"] as const,
-    (p) => onUpdate({ panelOrder: p }),
-  );
-  const textSizeRg = useRadioGroup<TextSize>(settings.textSize, ["s", "m", "l"] as const, (t) =>
-    onUpdate({ textSize: t }),
-  );
-
-  // Track viewport width for three-panel availability (only while open)
-  useEffect(() => {
-    if (!open) return;
-    setViewportWidth(window.innerWidth);
-    const handler = () => setViewportWidth(window.innerWidth);
-    window.addEventListener("resize", handler);
-    return () => window.removeEventListener("resize", handler);
-  }, [open]);
 
   // Initial focus + focus return on close
   useEffect(() => {
@@ -161,39 +121,6 @@ export function SettingsPopover({
 
   if (!open) return null;
 
-  const sectionLabelStyle: React.CSSProperties = {
-    fontSize: "11px",
-    fontWeight: 600,
-    color: "var(--tandem-fg)",
-    marginBottom: "6px",
-    textTransform: "uppercase",
-    letterSpacing: "0.5px",
-  };
-
-  const cardStyle = (selected: boolean, disabled?: boolean): React.CSSProperties => ({
-    flex: 1,
-    padding: "8px",
-    minHeight: "24px",
-    border: `2px solid ${selected ? "var(--tandem-accent)" : "var(--tandem-border)"}`,
-    borderRadius: "6px",
-    background: disabled
-      ? "var(--tandem-surface-muted)"
-      : selected
-        ? "var(--tandem-accent-bg)"
-        : "var(--tandem-surface)",
-    cursor: disabled ? "not-allowed" : "pointer",
-    textAlign: "center",
-    fontSize: "11px",
-    color: disabled
-      ? "var(--tandem-fg-subtle)"
-      : selected
-        ? "var(--tandem-accent-fg-strong)"
-        : "var(--tandem-fg-muted)",
-    fontWeight: selected ? 600 : 400,
-    opacity: disabled ? 0.6 : 1,
-    transition: "border-color 0.15s, background 0.15s",
-  });
-
   return (
     <div
       ref={popoverRef}
@@ -252,10 +179,11 @@ export function SettingsPopover({
           }}
           aria-label="Close settings"
         >
-          {"\u00d7"}
+          {"×"}
         </button>
       </div>
 
+      {/* Display Name */}
       <div>
         <label htmlFor="settings-display-name" style={sectionLabelStyle}>
           Display Name
@@ -289,267 +217,14 @@ export function SettingsPopover({
         />
       </div>
 
-      <div>
-        <div id="settings-theme-label" style={sectionLabelStyle}>
-          Theme
-        </div>
-        <div
-          role="radiogroup"
-          aria-labelledby="settings-theme-label"
-          onKeyDown={themeRg.handleKeyDown}
-          style={{ display: "flex", gap: "8px" }}
-        >
-          {(["light", "dark", "system"] as const).map((t) => (
-            <button
-              key={t}
-              data-testid={`theme-${t}-btn`}
-              role="radio"
-              aria-checked={settings.theme === t}
-              tabIndex={themeRg.tabIndexFor(t)}
-              onClick={() => onUpdate({ theme: t })}
-              style={cardStyle(settings.theme === t)}
-            >
-              {t === "light" ? "Light" : t === "dark" ? "Dark" : "System"}
-            </button>
-          ))}
-        </div>
-      </div>
+      {/* Appearance: Theme, Layout, Primary Tab/Panel Order, Text Size, Reduce Motion */}
+      <AppearanceSettings open={open} settings={settings} onUpdate={onUpdate} />
 
-      {/* Layout mode */}
-      <div>
-        <div id="settings-layout-label" style={sectionLabelStyle}>
-          Layout
-        </div>
-        <div
-          role="radiogroup"
-          aria-labelledby="settings-layout-label"
-          onKeyDown={layoutRg.handleKeyDown}
-          style={{ display: "flex", gap: "8px" }}
-        >
-          <button
-            data-testid="layout-tabbed-btn"
-            role="radio"
-            aria-checked={settings.layout === "tabbed"}
-            tabIndex={layoutRg.tabIndexFor("tabbed")}
-            onClick={() => onUpdate({ layout: "tabbed" })}
-            style={cardStyle(settings.layout === "tabbed")}
-          >
-            <div style={{ fontSize: "18px", marginBottom: "2px" }}>{"[=|]"}</div>
-            Tabbed
-          </button>
-          <button
-            data-testid="layout-three-panel-btn"
-            role="radio"
-            aria-checked={settings.layout === "three-panel"}
-            aria-disabled={threePanelDisabled || undefined}
-            tabIndex={layoutRg.tabIndexFor("three-panel")}
-            onClick={() => {
-              if (!threePanelDisabled) onUpdate({ layout: "three-panel" });
-            }}
-            style={cardStyle(settings.layout === "three-panel", threePanelDisabled)}
-            title={threePanelDisabled ? "Requires viewport wider than 768px" : undefined}
-          >
-            <div style={{ fontSize: "18px", marginBottom: "2px" }}>{"[|||]"}</div>
-            Three-Panel
-          </button>
-        </div>
-        {threePanelDisabled && (
-          <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
-            Three-panel requires a wider viewport
-          </div>
-        )}
-      </div>
+      {/* Editor Width */}
+      <EditorSettings settings={settings} onUpdate={onUpdate} />
 
-      {/* Primary tab (tabbed mode only) */}
-      {settings.layout === "tabbed" && (
-        <div>
-          <div id="settings-default-tab-label" style={sectionLabelStyle}>
-            Default Tab
-          </div>
-          <div
-            role="radiogroup"
-            aria-labelledby="settings-default-tab-label"
-            onKeyDown={primaryTabRg.handleKeyDown}
-            style={{ display: "flex", gap: "8px" }}
-          >
-            <button
-              data-testid="default-tab-chat-btn"
-              role="radio"
-              aria-checked={settings.primaryTab === "chat"}
-              tabIndex={primaryTabRg.tabIndexFor("chat")}
-              onClick={() => onUpdate({ primaryTab: "chat" })}
-              style={cardStyle(settings.primaryTab === "chat")}
-            >
-              Chat
-            </button>
-            <button
-              data-testid="default-tab-annotations-btn"
-              role="radio"
-              aria-checked={settings.primaryTab === "annotations"}
-              tabIndex={primaryTabRg.tabIndexFor("annotations")}
-              onClick={() => onUpdate({ primaryTab: "annotations" })}
-              style={cardStyle(settings.primaryTab === "annotations")}
-            >
-              Annotations
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Panel order (three-panel mode only) */}
-      {settings.layout === "three-panel" && (
-        <div>
-          <div id="settings-panel-order-label" style={sectionLabelStyle}>
-            Panel Order
-          </div>
-          <div
-            role="radiogroup"
-            aria-labelledby="settings-panel-order-label"
-            onKeyDown={panelOrderRg.handleKeyDown}
-            style={{ display: "flex", gap: "8px" }}
-          >
-            <button
-              data-testid="panel-order-cea-btn"
-              role="radio"
-              aria-checked={settings.panelOrder === "chat-editor-annotations"}
-              tabIndex={panelOrderRg.tabIndexFor("chat-editor-annotations")}
-              onClick={() => onUpdate({ panelOrder: "chat-editor-annotations" })}
-              style={cardStyle(settings.panelOrder === "chat-editor-annotations")}
-            >
-              Chat | Editor | Ann.
-            </button>
-            <button
-              data-testid="panel-order-aec-btn"
-              role="radio"
-              aria-checked={settings.panelOrder === "annotations-editor-chat"}
-              tabIndex={panelOrderRg.tabIndexFor("annotations-editor-chat")}
-              onClick={() => onUpdate({ panelOrder: "annotations-editor-chat" })}
-              style={cardStyle(settings.panelOrder === "annotations-editor-chat")}
-            >
-              Ann. | Editor | Chat
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Editor width */}
-      <div>
-        <div style={sectionLabelStyle}>
-          Editor Width:{" "}
-          <span style={{ fontWeight: 400, textTransform: "none" }}>
-            {settings.editorWidthPercent}%
-          </span>
-        </div>
-        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginBottom: "6px" }}>
-          How much of the available space the editor text fills
-        </div>
-        <input
-          data-testid="editor-width-slider"
-          type="range"
-          min={50}
-          max={100}
-          step={5}
-          value={settings.editorWidthPercent}
-          onChange={(e) => onUpdate({ editorWidthPercent: Number(e.target.value) })}
-          style={{ width: "100%", accentColor: "var(--tandem-accent)" }}
-          aria-label="Editor width"
-        />
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            fontSize: "10px",
-            color: "var(--tandem-fg-subtle)",
-          }}
-        >
-          <span>50%</span>
-          <span>100%</span>
-        </div>
-      </div>
-
-      {/* Authorship tracking toggle */}
-      <div>
-        <div style={sectionLabelStyle}>Authorship</div>
-        <label
-          data-testid="authorship-toggle"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "8px",
-            cursor: "pointer",
-            fontSize: "12px",
-            color: "var(--tandem-fg)",
-            minHeight: "24px",
-          }}
-        >
-          <input
-            type="checkbox"
-            checked={settings.showAuthorship}
-            onChange={(e) => onUpdate({ showAuthorship: e.target.checked })}
-            style={{ accentColor: "var(--tandem-accent)" }}
-          />
-          <span>Show who wrote what</span>
-        </label>
-        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
-          Highlights text by author: <span style={{ color: "var(--tandem-author-user)" }}>you</span>{" "}
-          / <span style={{ color: "var(--tandem-author-claude)" }}>Claude</span>
-        </div>
-      </div>
-
-      <div>
-        <div id="settings-text-size-label" style={sectionLabelStyle}>
-          Text Size
-        </div>
-        <div
-          role="radiogroup"
-          aria-labelledby="settings-text-size-label"
-          onKeyDown={textSizeRg.handleKeyDown}
-          style={{ display: "flex", gap: "8px" }}
-        >
-          {(["s", "m", "l"] as const).map((size) => (
-            <button
-              key={size}
-              data-testid={`text-size-${size}-btn`}
-              role="radio"
-              aria-checked={settings.textSize === size}
-              tabIndex={textSizeRg.tabIndexFor(size)}
-              onClick={() => onUpdate({ textSize: size })}
-              style={cardStyle(settings.textSize === size)}
-            >
-              {size === "s" ? "Small" : size === "m" ? "Medium" : "Large"}
-            </button>
-          ))}
-        </div>
-        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
-          Reading density only — use browser zoom (Ctrl + =/−) to scale the whole UI.
-        </div>
-      </div>
-
-      <div>
-        <label
-          data-testid="reduce-motion-toggle"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "8px",
-            cursor: "pointer",
-            fontSize: "12px",
-            color: "var(--tandem-fg)",
-            minHeight: "24px",
-          }}
-        >
-          <input
-            type="checkbox"
-            checked={settings.reduceMotion}
-            onChange={(e) => onUpdate({ reduceMotion: e.target.checked })}
-            style={{ accentColor: "var(--tandem-accent)" }}
-          />
-          <span>Reduce motion</span>
-        </label>
-        <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
-          Disables smooth autoscroll and the annotation flash animation.
-        </div>
-      </div>
+      {/* Authorship */}
+      <AccessibilitySettings settings={settings} onUpdate={onUpdate} />
 
       {/* Selection sensitivity (dwell time) */}
       <div>

--- a/src/client/components/settingsStyles.ts
+++ b/src/client/components/settingsStyles.ts
@@ -1,0 +1,10 @@
+import type React from "react";
+
+export const sectionLabelStyle: React.CSSProperties = {
+  fontSize: "11px",
+  fontWeight: 600,
+  color: "var(--tandem-fg)",
+  marginBottom: "6px",
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+};

--- a/src/client/editor/toolbar/HighlightColorPicker.tsx
+++ b/src/client/editor/toolbar/HighlightColorPicker.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useRef, useState } from "react";
+import { HIGHLIGHT_COLORS } from "../../../shared/constants";
+import type { HighlightColor } from "../../../shared/types";
+import { ToolbarButton } from "./ToolbarButton";
+
+const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
+  { value: "yellow", label: "Yellow" },
+  { value: "red", label: "Red" },
+  { value: "green", label: "Green" },
+  { value: "blue", label: "Blue" },
+  { value: "purple", label: "Purple" },
+];
+
+interface HighlightColorPickerProps {
+  disabled?: boolean;
+  onHighlight: (color: HighlightColor) => void;
+}
+
+export function HighlightColorPicker({ disabled, onHighlight }: HighlightColorPickerProps) {
+  const [highlightColor, setHighlightColor] = useState<HighlightColor>("yellow");
+  const [showColorPicker, setShowColorPicker] = useState(false);
+  const colorPickerRef = useRef<HTMLDivElement>(null);
+
+  // Close color picker when clicking outside
+  useEffect(() => {
+    if (!showColorPicker) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      if (colorPickerRef.current && !colorPickerRef.current.contains(e.target as Node)) {
+        setShowColorPicker(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showColorPicker]);
+
+  function handleHighlight(e: React.MouseEvent) {
+    e.preventDefault();
+    onHighlight(highlightColor);
+  }
+
+  function handleColorPickerToggle(e: React.MouseEvent) {
+    e.preventDefault();
+    setShowColorPicker((prev) => !prev);
+  }
+
+  function handleColorSelect(color: HighlightColor) {
+    setHighlightColor(color);
+    setShowColorPicker(false);
+  }
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "2px", position: "relative" }}>
+      <ToolbarButton
+        label="Highlight"
+        disabled={disabled}
+        disabledTitle="Select text first"
+        onMouseDown={handleHighlight}
+        style={{ borderRadius: "4px 0 0 4px", borderRight: "none" }}
+      />
+      <button
+        disabled={disabled}
+        onMouseDown={handleColorPickerToggle}
+        title="Choose highlight color"
+        style={{
+          padding: "4px 6px",
+          fontSize: "13px",
+          border: "1px solid var(--tandem-border)",
+          borderRadius: "0 4px 4px 0",
+          background: disabled ? "var(--tandem-surface-muted)" : "var(--tandem-surface)",
+          cursor: disabled ? "not-allowed" : "pointer",
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        <span
+          style={{
+            display: "inline-block",
+            width: "12px",
+            height: "12px",
+            borderRadius: "2px",
+            background: HIGHLIGHT_COLORS[highlightColor],
+            border: "1px solid rgba(0,0,0,0.15)",
+          }}
+        />
+      </button>
+      {showColorPicker && (
+        <div
+          ref={colorPickerRef}
+          style={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            marginTop: "4px",
+            background: "var(--tandem-surface)",
+            border: "1px solid var(--tandem-border)",
+            borderRadius: "6px",
+            padding: "6px",
+            display: "flex",
+            gap: "4px",
+            zIndex: 10,
+            boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
+          }}
+        >
+          {HIGHLIGHT_COLOR_OPTIONS.map(({ value, label }) => (
+            <button
+              key={value}
+              title={label}
+              onClick={() => handleColorSelect(value)}
+              style={{
+                width: "24px",
+                height: "24px",
+                borderRadius: "4px",
+                border:
+                  value === highlightColor
+                    ? "2px solid var(--tandem-fg)"
+                    : "1px solid rgba(0,0,0,0.15)",
+                background: HIGHLIGHT_COLORS[value],
+                cursor: "pointer",
+                padding: 0,
+              }}
+            />
+          ))}
+          <button
+            data-testid="color-picker-close"
+            title="Close"
+            onClick={() => setShowColorPicker(false)}
+            style={{
+              width: "24px",
+              height: "24px",
+              borderRadius: "4px",
+              border: "1px solid var(--tandem-border)",
+              background: "var(--tandem-surface-muted)",
+              cursor: "pointer",
+              padding: 0,
+              fontSize: "13px",
+              color: "var(--tandem-fg-muted)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/client/editor/toolbar/ModeToggle.tsx
+++ b/src/client/editor/toolbar/ModeToggle.tsx
@@ -1,0 +1,86 @@
+import type { TandemMode } from "../../../shared/types";
+
+interface ModeToggleProps {
+  tandemMode: TandemMode;
+  onModeChange: (mode: TandemMode) => void;
+}
+
+export function ModeToggle({ tandemMode, onModeChange }: ModeToggleProps) {
+  return (
+    <div
+      data-testid="mode-toggle"
+      role="group"
+      aria-label="Claude collaboration mode"
+      style={{
+        display: "flex",
+        border: "1px solid var(--tandem-border-strong)",
+        borderRadius: "4px",
+        overflow: "hidden",
+      }}
+    >
+      <button
+        data-testid="mode-solo-btn"
+        title="Write undisturbed — Claude only responds when you message"
+        aria-pressed={tandemMode === "solo"}
+        onClick={() => onModeChange("solo")}
+        style={{
+          padding: "3px 10px",
+          fontSize: "12px",
+          border: "none",
+          cursor: "pointer",
+          background: tandemMode === "solo" ? "var(--tandem-accent)" : "transparent",
+          color: tandemMode === "solo" ? "var(--tandem-accent-fg)" : "var(--tandem-fg-muted)",
+          fontWeight: tandemMode === "solo" ? 600 : 400,
+          borderRight: "1px solid var(--tandem-border-strong)",
+          display: "flex",
+          alignItems: "center",
+          gap: "5px",
+        }}
+      >
+        {tandemMode === "solo" && (
+          <span
+            style={{
+              width: "6px",
+              height: "6px",
+              borderRadius: "50%",
+              background: "var(--tandem-fg-subtle)",
+              display: "inline-block",
+            }}
+          />
+        )}
+        Solo
+      </button>
+      <button
+        data-testid="mode-tandem-btn"
+        title="Full collaboration — Claude reacts to selections and document changes"
+        aria-pressed={tandemMode === "tandem"}
+        onClick={() => onModeChange("tandem")}
+        style={{
+          padding: "3px 10px",
+          fontSize: "12px",
+          border: "none",
+          cursor: "pointer",
+          background: tandemMode === "tandem" ? "var(--tandem-accent)" : "transparent",
+          color: tandemMode === "tandem" ? "var(--tandem-accent-fg)" : "var(--tandem-fg-muted)",
+          fontWeight: tandemMode === "tandem" ? 600 : 400,
+          display: "flex",
+          alignItems: "center",
+          gap: "5px",
+        }}
+      >
+        {tandemMode === "tandem" && (
+          <span
+            style={{
+              width: "6px",
+              height: "6px",
+              borderRadius: "50%",
+              background: "var(--tandem-success)",
+              display: "inline-block",
+            }}
+          />
+        )}
+        Tandem
+      </button>
+    </div>
+  );
+}

--- a/src/client/editor/toolbar/Toolbar.tsx
+++ b/src/client/editor/toolbar/Toolbar.tsx
@@ -1,22 +1,16 @@
 import type { Editor as TiptapEditor } from "@tiptap/react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as Y from "yjs";
-import { HIGHLIGHT_COLORS, Y_MAP_ANNOTATIONS } from "../../../shared/constants";
+import { Y_MAP_ANNOTATIONS } from "../../../shared/constants";
 import { toPmPos } from "../../../shared/positions/types";
 import type { Annotation, AnnotationType, HighlightColor, TandemMode } from "../../../shared/types";
 import { generateAnnotationId } from "../../../shared/utils";
 import { pmPosToFlatOffset } from "../../positions";
 import { FormattingToolbar } from "./FormattingToolbar";
+import { HighlightColorPicker } from "./HighlightColorPicker";
 import { InputGroup } from "./InputGroup";
+import { ModeToggle } from "./ModeToggle";
 import { ToolbarButton } from "./ToolbarButton";
-
-const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
-  { value: "yellow", label: "Yellow" },
-  { value: "red", label: "Red" },
-  { value: "green", label: "Green" },
-  { value: "blue", label: "Blue" },
-  { value: "purple", label: "Purple" },
-];
 
 type ToolbarMode = "idle" | "comment";
 
@@ -42,8 +36,6 @@ export function Toolbar({
   heldCount,
 }: ToolbarProps) {
   const [hasSelection, setHasSelection] = useState(false);
-  const [highlightColor, setHighlightColor] = useState<HighlightColor>("yellow");
-  const [showColorPicker, setShowColorPicker] = useState(false);
   const [mode, setMode] = useState<ToolbarMode>("idle");
   const [modeText, setModeText] = useState("");
   const [showReplacement, setShowReplacement] = useState(false);
@@ -51,7 +43,6 @@ export function Toolbar({
   const [sendToClaude, setSendToClaude] = useState(false);
   const capturedRangeRef = useRef<{ from: number; to: number } | null>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
-  const colorPickerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!editor) return;
@@ -74,20 +65,6 @@ export function Toolbar({
       commentInputRef.current.focus();
     }
   }, [mode]);
-
-  // Close color picker when clicking outside
-  useEffect(() => {
-    if (!showColorPicker) return;
-
-    function handleClickOutside(e: MouseEvent) {
-      if (colorPickerRef.current && !colorPickerRef.current.contains(e.target as Node)) {
-        setShowColorPicker(false);
-      }
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [showColorPicker]);
 
   function createAnnotation(
     type: AnnotationType,
@@ -136,19 +113,8 @@ export function Toolbar({
 
   // -- Highlight --
 
-  function handleHighlight(e: React.MouseEvent) {
-    e.preventDefault();
-    createAnnotation("highlight", "", { color: highlightColor });
-  }
-
-  function handleColorPickerToggle(e: React.MouseEvent) {
-    e.preventDefault();
-    setShowColorPicker((prev) => !prev);
-  }
-
-  function handleColorSelect(color: HighlightColor) {
-    setHighlightColor(color);
-    setShowColorPicker(false);
+  function handleHighlight(color: HighlightColor) {
+    createAnnotation("highlight", "", { color });
   }
 
   // -- Consolidated mode handlers --
@@ -267,102 +233,7 @@ export function Toolbar({
       />
 
       {/* Highlight with color picker */}
-      <div style={{ display: "flex", alignItems: "center", gap: "2px", position: "relative" }}>
-        <ToolbarButton
-          label="Highlight"
-          disabled={!canAnnotate || inInputMode}
-          disabledTitle="Select text first"
-          onMouseDown={handleHighlight}
-          style={{ borderRadius: "4px 0 0 4px", borderRight: "none" }}
-        />
-        <button
-          disabled={!canAnnotate || inInputMode}
-          onMouseDown={handleColorPickerToggle}
-          title="Choose highlight color"
-          style={{
-            padding: "4px 6px",
-            fontSize: "13px",
-            border: "1px solid var(--tandem-border)",
-            borderRadius: "0 4px 4px 0",
-            background:
-              !canAnnotate || inInputMode ? "var(--tandem-surface-muted)" : "var(--tandem-surface)",
-            cursor: !canAnnotate || inInputMode ? "not-allowed" : "pointer",
-            display: "flex",
-            alignItems: "center",
-          }}
-        >
-          <span
-            style={{
-              display: "inline-block",
-              width: "12px",
-              height: "12px",
-              borderRadius: "2px",
-              background: HIGHLIGHT_COLORS[highlightColor],
-              border: "1px solid rgba(0,0,0,0.15)",
-            }}
-          />
-        </button>
-        {showColorPicker && (
-          <div
-            ref={colorPickerRef}
-            style={{
-              position: "absolute",
-              top: "100%",
-              left: 0,
-              marginTop: "4px",
-              background: "var(--tandem-surface)",
-              border: "1px solid var(--tandem-border)",
-              borderRadius: "6px",
-              padding: "6px",
-              display: "flex",
-              gap: "4px",
-              zIndex: 10,
-              boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
-            }}
-          >
-            {HIGHLIGHT_COLOR_OPTIONS.map(({ value, label }) => (
-              <button
-                key={value}
-                title={label}
-                onClick={() => handleColorSelect(value)}
-                style={{
-                  width: "24px",
-                  height: "24px",
-                  borderRadius: "4px",
-                  border:
-                    value === highlightColor
-                      ? "2px solid var(--tandem-fg)"
-                      : "1px solid rgba(0,0,0,0.15)",
-                  background: HIGHLIGHT_COLORS[value],
-                  cursor: "pointer",
-                  padding: 0,
-                }}
-              />
-            ))}
-            <button
-              data-testid="color-picker-close"
-              title="Close"
-              onClick={() => setShowColorPicker(false)}
-              style={{
-                width: "24px",
-                height: "24px",
-                borderRadius: "4px",
-                border: "1px solid var(--tandem-border)",
-                background: "var(--tandem-surface-muted)",
-                cursor: "pointer",
-                padding: 0,
-                fontSize: "13px",
-                color: "var(--tandem-fg-muted)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              ✕
-            </button>
-          </div>
-        )}
-      </div>
+      <HighlightColorPicker disabled={!canAnnotate || inInputMode} onHighlight={handleHighlight} />
 
       <ToolbarButton
         label="Comment"
@@ -480,82 +351,7 @@ export function Toolbar({
         )}
         {/* Solo/Tandem mode toggle */}
         {tandemMode && onModeChange && (
-          <div
-            data-testid="mode-toggle"
-            role="group"
-            aria-label="Claude collaboration mode"
-            style={{
-              display: "flex",
-              border: "1px solid var(--tandem-border-strong)",
-              borderRadius: "4px",
-              overflow: "hidden",
-            }}
-          >
-            <button
-              data-testid="mode-solo-btn"
-              title="Write undisturbed — Claude only responds when you message"
-              aria-pressed={tandemMode === "solo"}
-              onClick={() => onModeChange("solo")}
-              style={{
-                padding: "3px 10px",
-                fontSize: "12px",
-                border: "none",
-                cursor: "pointer",
-                background: tandemMode === "solo" ? "var(--tandem-accent)" : "transparent",
-                color: tandemMode === "solo" ? "var(--tandem-accent-fg)" : "var(--tandem-fg-muted)",
-                fontWeight: tandemMode === "solo" ? 600 : 400,
-                borderRight: "1px solid var(--tandem-border-strong)",
-                display: "flex",
-                alignItems: "center",
-                gap: "5px",
-              }}
-            >
-              {tandemMode === "solo" && (
-                <span
-                  style={{
-                    width: "6px",
-                    height: "6px",
-                    borderRadius: "50%",
-                    background: "var(--tandem-fg-subtle)",
-                    display: "inline-block",
-                  }}
-                />
-              )}
-              Solo
-            </button>
-            <button
-              data-testid="mode-tandem-btn"
-              title="Full collaboration — Claude reacts to selections and document changes"
-              aria-pressed={tandemMode === "tandem"}
-              onClick={() => onModeChange("tandem")}
-              style={{
-                padding: "3px 10px",
-                fontSize: "12px",
-                border: "none",
-                cursor: "pointer",
-                background: tandemMode === "tandem" ? "var(--tandem-accent)" : "transparent",
-                color:
-                  tandemMode === "tandem" ? "var(--tandem-accent-fg)" : "var(--tandem-fg-muted)",
-                fontWeight: tandemMode === "tandem" ? 600 : 400,
-                display: "flex",
-                alignItems: "center",
-                gap: "5px",
-              }}
-            >
-              {tandemMode === "tandem" && (
-                <span
-                  style={{
-                    width: "6px",
-                    height: "6px",
-                    borderRadius: "50%",
-                    background: "var(--tandem-success)",
-                    display: "inline-block",
-                  }}
-                />
-              )}
-              Tandem
-            </button>
-          </div>
+          <ModeToggle tandemMode={tandemMode} onModeChange={onModeChange} />
         )}
         {onSettingsOpen && (
           <button


### PR DESCRIPTION
## Summary

- **`settingsStyles.ts`** — shared `sectionLabelStyle` constant used by all settings sub-components
- **`HighlightColorPicker`** — color swatch dropdown extracted from Toolbar; owns `highlightColor`/`showColorPicker` state, outside-click effect, and color selection handlers; callback signature is `onHighlight(color: HighlightColor) => void`
- **`ModeToggle`** — stateless Solo/Tandem mode toggle extracted from Toolbar; parent guard `{tandemMode && onModeChange && <ModeToggle />}` stays in Toolbar
- **`AppearanceSettings`** — Theme, Layout, conditional Primary Tab/Panel Order, Text Size, and Reduce Motion sections extracted from SettingsPopover; owns `viewportWidth` state and all 5 `useRadioGroup` calls; receives `open: boolean` to gate the resize effect
- **`EditorSettings`** — stateless editor-width slider section
- **`AccessibilitySettings`** — authorship toggle; deliberate thin wrapper for symmetry

**Visual reorder:** Text Size and Reduce Motion move from after Authorship into AppearanceSettings. New dialog order: Display Name → Appearance → Editor Width → Authorship → Selection Sensitivity.

Pure extraction — no behavior changes. All `data-testid` attributes preserved exactly.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 1428 passed / 3 skipped (one pre-existing flaky timeout test in `mcp-stdio.test.ts` unrelated to this change; confirmed failing on master before this PR)
- [ ] Manual: open Settings popover, verify all controls render and function correctly
- [ ] Manual: highlight with color picker, mode toggle, comment flow all work

Closes #402