### PR TITLE
refactor(client): extract App.tsx hooks and inline components (#400)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,28 +1,21 @@
 import type { Editor as TiptapEditor } from "@tiptap/react";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  DISCONNECT_DEBOUNCE_MS,
-  PANEL_WIDTH_KEYS,
-  type PanelSide,
-  PROLONGED_DISCONNECT_MS,
-  TANDEM_MODE_DEFAULT,
-  TANDEM_MODE_KEY,
-  Y_MAP_DWELL_MS,
-  Y_MAP_MODE,
-  Y_MAP_USER_AWARENESS,
-} from "../shared/constants";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isUploadPath } from "../shared/paths";
 import { toPmPos } from "../shared/positions/types";
-import type { CapturedAnchor, TandemMode } from "../shared/types";
-import { TandemModeSchema } from "../shared/types";
+import type { CapturedAnchor } from "../shared/types";
+import { ConnectionBanner } from "./components/ConnectionBanner";
+import { EmptyState } from "./components/EmptyState";
 import { HelpModal } from "./components/HelpModal";
 import { OnboardingTutorial } from "./components/OnboardingTutorial";
+import { ChatSlot, SideSlot } from "./components/PanelSlot";
 import { ReviewOnlyBanner } from "./components/ReviewOnlyBanner";
 import { SettingsPopover } from "./components/SettingsPopover";
 import { ToastContainer } from "./components/ToastContainer";
 import { Editor } from "./editor/Editor";
 import { authorshipPluginKey } from "./editor/extensions/authorship";
 import { Toolbar } from "./editor/toolbar/Toolbar";
+import { useConnectionBanner } from "./hooks/useConnectionBanner";
+import { useDragResize } from "./hooks/useDragResize";
 import { useFileDrop } from "./hooks/useFileDrop";
 import { useModeGate } from "./hooks/useModeGate";
 import { useNotifications } from "./hooks/useNotifications";
@@ -31,15 +24,14 @@ import { useSaveShortcut } from "./hooks/useSaveShortcut";
 import { useSettingsShortcut } from "./hooks/useSettingsShortcut";
 import { useTabCycleKeyboard } from "./hooks/useTabCycleKeyboard";
 import { useTabOrder } from "./hooks/useTabOrder";
+import { useTandemModeBroadcast } from "./hooks/useTandemModeBroadcast";
 import { TEXT_SIZE_PX, useTandemSettings } from "./hooks/useTandemSettings";
 import { useTheme } from "./hooks/useTheme";
 import { useTutorial } from "./hooks/useTutorial";
 import { useWebViewZoom } from "./hooks/useWebViewZoom";
 import { useYjsSync } from "./hooks/useYjsSync";
-import type { PanelLayout } from "./panel-layout";
-import { ChatPanel } from "./panels/ChatPanel";
+import { loadPanelWidth, type PanelLayout } from "./panel-layout";
 import { ReviewSummary } from "./panels/ReviewSummary";
-import { SidePanel } from "./panels/SidePanel";
 import { pmSelectionToFlat } from "./positions";
 import { StatusBar } from "./status/StatusBar";
 import { DocumentTabs } from "./tabs/DocumentTabs";
@@ -47,107 +39,6 @@ import type { DocListEntry, OpenTab } from "./types";
 import { addRecentFile, loadRecentFiles, saveRecentFiles } from "./utils/recentFiles";
 
 export type { DocListEntry, OpenTab };
-
-/** Connection-aware empty state shown when no document is open. */
-function EmptyState({ connected, claudeActive }: { connected: boolean; claudeActive: boolean }) {
-  const [showDisconnected, setShowDisconnected] = useState(false);
-
-  useEffect(() => {
-    if (connected) {
-      setShowDisconnected(false);
-      return;
-    }
-    const timer = setTimeout(() => setShowDisconnected(true), DISCONNECT_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [connected]);
-
-  return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        height: "100%",
-        color: "var(--tandem-fg-subtle)",
-        gap: "8px",
-      }}
-    >
-      {showDisconnected ? (
-        <span>Cannot reach the Tandem server. Is it running?</span>
-      ) : (
-        <>
-          <span>No document open. Click + in the tab bar or drop a file here.</span>
-          {connected && !claudeActive && (
-            <span style={{ fontSize: "0.85em", color: "var(--tandem-fg-subtle)" }}>
-              Tip: open Claude Code in this directory to start collaborating
-            </span>
-          )}
-        </>
-      )}
-    </div>
-  );
-}
-
-/** Red banner shown after prolonged disconnect (>30s). Dismissible. */
-function ConnectionBanner({ onDismiss }: { onDismiss: () => void }) {
-  return (
-    <div
-      style={{
-        padding: "8px 16px",
-        background: "var(--tandem-error-bg)",
-        borderBottom: "1px solid var(--tandem-error-border)",
-        fontSize: "13px",
-        color: "var(--tandem-error-fg-strong)",
-        textAlign: "center",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        gap: "12px",
-      }}
-    >
-      <span>Connection to the Tandem server has been lost. Ensure the server is running.</span>
-      <button
-        onClick={onDismiss}
-        style={{
-          background: "none",
-          border: "none",
-          cursor: "pointer",
-          color: "var(--tandem-error-fg-strong)",
-          fontSize: "16px",
-          lineHeight: 1,
-          padding: "0 4px",
-        }}
-        aria-label="Dismiss connection banner"
-      >
-        \u00d7
-      </button>
-    </div>
-  );
-}
-
-const PANEL_MIN_WIDTH = 200;
-const PANEL_MAX_WIDTH = 600;
-const PANEL_DEFAULT_WIDTH = 300;
-
-function loadPanelWidth(side: PanelSide): number {
-  const key = PANEL_WIDTH_KEYS[side];
-  try {
-    const saved = localStorage.getItem(key);
-    if (saved) {
-      const parsed = parseInt(saved, 10);
-      if (Number.isFinite(parsed)) {
-        return Math.max(PANEL_MIN_WIDTH, Math.min(PANEL_MAX_WIDTH, parsed));
-      }
-      // Non-finite saved value — fall through and warn so corrupt storage
-      // is diagnosable instead of silently reverting to the default.
-      console.warn(`[tandem] ignoring non-numeric panel width for ${key}: ${saved}`);
-    }
-  } catch (err) {
-    console.warn(`[tandem] localStorage unavailable reading ${key}:`, err);
-  }
-  return PANEL_DEFAULT_WIDTH;
-}
 
 export default function App() {
   useWebViewZoom();
@@ -194,53 +85,19 @@ export default function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabs.length]);
 
-  // Tandem mode — persisted to localStorage
-  const [tandemMode, setTandemMode] = useState<TandemMode>(() => {
-    try {
-      const saved = localStorage.getItem(TANDEM_MODE_KEY);
-      return TandemModeSchema.safeParse(saved).success
-        ? (saved as TandemMode)
-        : TANDEM_MODE_DEFAULT;
-    } catch (err) {
-      console.warn(`[tandem] localStorage unavailable reading ${TANDEM_MODE_KEY}:`, err);
-      return TANDEM_MODE_DEFAULT;
-    }
-  });
-  useEffect(() => {
-    try {
-      localStorage.setItem(TANDEM_MODE_KEY, tandemMode);
-    } catch (err) {
-      console.warn(`[tandem] failed to persist ${TANDEM_MODE_KEY}:`, err);
-    }
-  }, [tandemMode]);
+  const { settings, updateSettings } = useTandemSettings();
 
-  // Broadcast tandem mode to CTRL_ROOM Y.Map so the server (and Claude) can see it
-  useEffect(() => {
-    if (!bootstrapYdoc) return;
-    const awareness = bootstrapYdoc.getMap(Y_MAP_USER_AWARENESS);
-    awareness.set(Y_MAP_MODE, tandemMode);
-  }, [tandemMode, bootstrapYdoc]);
-
-  // Prolonged disconnect banner — shown after PROLONGED_DISCONNECT_MS of being disconnected
-  const [showDisconnectBanner, setShowDisconnectBanner] = useState(false);
-  const [disconnectBannerDismissed, setDisconnectBannerDismissed] = useState(false);
-  useEffect(() => {
-    if (disconnectedSince == null) {
-      setShowDisconnectBanner(false);
-      setDisconnectBannerDismissed(false);
-      return;
-    }
-    const elapsed = Date.now() - disconnectedSince;
-    const remaining = PROLONGED_DISCONNECT_MS - elapsed;
-    if (remaining <= 0) {
-      setShowDisconnectBanner(true);
-      return;
-    }
-    const timer = setTimeout(() => setShowDisconnectBanner(true), remaining);
-    return () => clearTimeout(timer);
-  }, [disconnectedSince]);
+  // Tandem mode — persisted to localStorage, broadcasts to CTRL_ROOM Y.Map
+  const { tandemMode, setTandemMode } = useTandemModeBroadcast(
+    bootstrapYdoc,
+    settings.selectionDwellMs,
+  );
 
   const { visibleAnnotations, heldCount } = useModeGate(annotations, tandemMode);
+
+  const { showBanner: showDisconnectBanner, dismiss: dismissConnectionBanner } =
+    useConnectionBanner(disconnectedSince);
+
   const openDocs = useMemo(() => tabs.map((t) => ({ id: t.id, fileName: t.fileName })), [tabs]);
 
   const { saving } = useSaveShortcut(activeTabId);
@@ -250,7 +107,6 @@ export default function App() {
   const { showReviewSummary, reviewSummaryData, dismissReviewSummary } =
     useReviewCompletion(annotations);
 
-  const { settings, updateSettings } = useTandemSettings();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const settingsBtnRef = useRef<HTMLButtonElement | null>(null);
 
@@ -267,13 +123,6 @@ export default function App() {
     openSettings();
   }, [openSettings]);
   useSettingsShortcut(toggleSettings);
-
-  // Broadcast selection dwell time to CTRL_ROOM so the server uses the user's setting
-  useEffect(() => {
-    if (!bootstrapYdoc) return;
-    const awareness = bootstrapYdoc.getMap(Y_MAP_USER_AWARENESS);
-    awareness.set(Y_MAP_DWELL_MS, settings.selectionDwellMs);
-  }, [settings.selectionDwellMs, bootstrapYdoc]);
 
   // Dispatch authorship toggle to the ProseMirror plugin when the setting changes
   useEffect(() => {
@@ -353,78 +202,7 @@ export default function App() {
     settings.editorWidthPercent < 100 ? `${settings.editorWidthPercent}%` : undefined;
   const editorMargin = settings.editorWidthPercent < 100 ? "0 auto" : undefined;
 
-  const panelLayoutRef = useRef(panelLayout);
-  panelLayoutRef.current = panelLayout;
-  const dragListenersRef = useRef<{
-    move: (e: MouseEvent) => void;
-    up: () => void;
-  } | null>(null);
-
-  // Clean up drag listeners if the component unmounts mid-drag
-  useEffect(() => {
-    return () => {
-      if (dragListenersRef.current) {
-        document.removeEventListener("mousemove", dragListenersRef.current.move);
-        document.removeEventListener("mouseup", dragListenersRef.current.up);
-        document.body.style.userSelect = "";
-        document.body.style.cursor = "";
-      }
-    };
-  }, []);
-
-  const handleResizeStart = useCallback((e: React.MouseEvent, side: PanelSide) => {
-    e.preventDefault();
-    const startX = e.clientX;
-    const current = panelLayoutRef.current;
-    // `left` is only defined in three-panel; fall back to the default so a
-    // stale mid-transition drag never reads undefined.
-    const startWidth =
-      side === "left"
-        ? current.kind === "three-panel"
-          ? current.left
-          : PANEL_DEFAULT_WIDTH
-        : current.right;
-    const storageKey = PANEL_WIDTH_KEYS[side];
-    let latestWidth = startWidth;
-
-    document.body.style.userSelect = "none";
-    document.body.style.cursor = "col-resize";
-
-    const onMouseMove = (ev: MouseEvent) => {
-      const delta = ev.clientX - startX;
-      // The left panel's handle sits on its right edge (drag right = wider).
-      // The right panel's handle sits on its left edge (drag right = narrower).
-      const next = side === "left" ? startWidth + delta : startWidth - delta;
-      latestWidth = Math.max(PANEL_MIN_WIDTH, Math.min(PANEL_MAX_WIDTH, next));
-      setPanelLayout((prev) => {
-        if (side === "right") {
-          return prev.kind === "three-panel"
-            ? { ...prev, right: latestWidth }
-            : { kind: "tabbed", right: latestWidth };
-        }
-        // Left handle is only rendered in three-panel, but guard anyway.
-        if (prev.kind !== "three-panel") return prev;
-        return { ...prev, left: latestWidth };
-      });
-    };
-
-    const onMouseUp = () => {
-      document.removeEventListener("mousemove", onMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
-      dragListenersRef.current = null;
-      document.body.style.userSelect = "";
-      document.body.style.cursor = "";
-      try {
-        localStorage.setItem(storageKey, String(latestWidth));
-      } catch (err) {
-        console.warn(`[tandem] failed to persist ${storageKey}:`, err);
-      }
-    };
-
-    dragListenersRef.current = { move: onMouseMove, up: onMouseUp };
-    document.addEventListener("mousemove", onMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
-  }, []);
+  const { handleResizeStart } = useDragResize({ panelLayout, setPanelLayout });
 
   const toggleReviewMode = useCallback(() => {
     setReviewMode((prev) => !prev);
@@ -469,6 +247,38 @@ export default function App() {
     activeTab?.fileName,
   );
 
+  // Shared props for SidePanel across all layout render sites
+  const sidePanelProps = {
+    annotations: visibleAnnotations,
+    editor: editorRef.current,
+    ydoc: activeTab?.ydoc ?? null,
+    heldCount,
+    tandemMode,
+    onModeChange: setTandemMode,
+    activeDocFormat: activeTab?.format,
+    documentId: activeTab?.id,
+    reviewMode,
+    onToggleReviewMode: toggleReviewMode,
+    onExitReviewMode: exitReviewMode,
+    activeAnnotationId,
+    onActiveAnnotationChange: setActiveAnnotationId,
+    reduceMotion: settings.reduceMotion,
+  } as const;
+
+  // Shared props for ChatPanel across all layout render sites
+  const chatPanelProps = {
+    ctrlYdoc: bootstrapYdoc,
+    editor: editorRef.current,
+    activeDocId: activeTabId,
+    openDocs,
+    claudeActive,
+    claudeStatus,
+    capturedAnchor,
+    onCapturedAnchorChange: setCapturedAnchor,
+    inputRef: chatInputRef,
+    reduceMotion: settings.reduceMotion,
+  } as const;
+
   if (!ready) {
     return (
       <div
@@ -501,9 +311,7 @@ export default function App() {
           Server restarted — refreshing documents
         </div>
       )}
-      {showDisconnectBanner && !disconnectBannerDismissed && (
-        <ConnectionBanner onDismiss={() => setDisconnectBannerDismissed(true)} />
-      )}
+      {showDisconnectBanner && <ConnectionBanner onDismiss={dismissConnectionBanner} />}
       <Toolbar
         editor={editorRef.current}
         ydoc={activeTab?.ydoc ?? null}
@@ -549,36 +357,9 @@ export default function App() {
             </div>
             <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
               {settings.panelOrder === "chat-editor-annotations" ? (
-                <ChatPanel
-                  ctrlYdoc={bootstrapYdoc}
-                  editor={editorRef.current}
-                  activeDocId={activeTabId}
-                  openDocs={openDocs}
-                  claudeActive={claudeActive}
-                  claudeStatus={claudeStatus}
-                  visible={true}
-                  capturedAnchor={capturedAnchor}
-                  onCapturedAnchorChange={setCapturedAnchor}
-                  inputRef={chatInputRef}
-                  reduceMotion={settings.reduceMotion}
-                />
+                <ChatSlot {...chatPanelProps} visible={true} />
               ) : (
-                <SidePanel
-                  annotations={visibleAnnotations}
-                  editor={editorRef.current}
-                  ydoc={activeTab?.ydoc ?? null}
-                  heldCount={heldCount}
-                  tandemMode={tandemMode}
-                  onModeChange={setTandemMode}
-                  activeDocFormat={activeTab?.format}
-                  documentId={activeTab?.id}
-                  reviewMode={reviewMode}
-                  onToggleReviewMode={toggleReviewMode}
-                  onExitReviewMode={exitReviewMode}
-                  activeAnnotationId={activeAnnotationId}
-                  onActiveAnnotationChange={setActiveAnnotationId}
-                  reduceMotion={settings.reduceMotion}
-                />
+                <SideSlot {...sidePanelProps} />
               )}
             </div>
           </div>
@@ -691,36 +472,9 @@ export default function App() {
             </div>
             <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
               {settings.panelOrder === "chat-editor-annotations" ? (
-                <SidePanel
-                  annotations={visibleAnnotations}
-                  editor={editorRef.current}
-                  ydoc={activeTab?.ydoc ?? null}
-                  heldCount={heldCount}
-                  tandemMode={tandemMode}
-                  onModeChange={setTandemMode}
-                  activeDocFormat={activeTab?.format}
-                  documentId={activeTab?.id}
-                  reviewMode={reviewMode}
-                  onToggleReviewMode={toggleReviewMode}
-                  onExitReviewMode={exitReviewMode}
-                  activeAnnotationId={activeAnnotationId}
-                  onActiveAnnotationChange={setActiveAnnotationId}
-                  reduceMotion={settings.reduceMotion}
-                />
+                <SideSlot {...sidePanelProps} />
               ) : (
-                <ChatPanel
-                  ctrlYdoc={bootstrapYdoc}
-                  editor={editorRef.current}
-                  activeDocId={activeTabId}
-                  openDocs={openDocs}
-                  claudeActive={claudeActive}
-                  claudeStatus={claudeStatus}
-                  visible={true}
-                  capturedAnchor={capturedAnchor}
-                  onCapturedAnchorChange={setCapturedAnchor}
-                  inputRef={chatInputRef}
-                  reduceMotion={settings.reduceMotion}
-                />
+                <ChatSlot {...chatPanelProps} visible={true} />
               )}
             </div>
           </div>
@@ -865,53 +619,8 @@ export default function App() {
               </button>
             </div>
             {/* Panel content — both panels stay mounted, toggle visibility via CSS */}
-            <div
-              style={{
-                display: showChat ? "flex" : "none",
-                flexDirection: "column",
-                flex: 1,
-                minHeight: 0,
-              }}
-            >
-              <ChatPanel
-                ctrlYdoc={bootstrapYdoc}
-                editor={editorRef.current}
-                activeDocId={activeTabId}
-                openDocs={openDocs}
-                claudeActive={claudeActive}
-                claudeStatus={claudeStatus}
-                visible={showChat}
-                capturedAnchor={capturedAnchor}
-                onCapturedAnchorChange={setCapturedAnchor}
-                inputRef={chatInputRef}
-                reduceMotion={settings.reduceMotion}
-              />
-            </div>
-            <div
-              style={{
-                display: showChat ? "none" : "flex",
-                flexDirection: "column",
-                flex: 1,
-                minHeight: 0,
-              }}
-            >
-              <SidePanel
-                annotations={visibleAnnotations}
-                editor={editorRef.current}
-                ydoc={activeTab?.ydoc ?? null}
-                heldCount={heldCount}
-                tandemMode={tandemMode}
-                onModeChange={setTandemMode}
-                activeDocFormat={activeTab?.format}
-                documentId={activeTab?.id}
-                reviewMode={reviewMode}
-                onToggleReviewMode={toggleReviewMode}
-                onExitReviewMode={exitReviewMode}
-                activeAnnotationId={activeAnnotationId}
-                onActiveAnnotationChange={setActiveAnnotationId}
-                reduceMotion={settings.reduceMotion}
-              />
-            </div>
+            <ChatSlot {...chatPanelProps} visible={showChat} />
+            <SideSlot {...sidePanelProps} visible={!showChat} />
           </div>
         </div>
       )}

--- a/src/client/components/ConnectionBanner.tsx
+++ b/src/client/components/ConnectionBanner.tsx
@@ -1,0 +1,40 @@
+interface ConnectionBannerProps {
+  onDismiss: () => void;
+}
+
+/** Red banner shown after prolonged disconnect (>30s). Dismissible. */
+export function ConnectionBanner({ onDismiss }: ConnectionBannerProps) {
+  return (
+    <div
+      style={{
+        padding: "8px 16px",
+        background: "var(--tandem-error-bg)",
+        borderBottom: "1px solid var(--tandem-error-border)",
+        fontSize: "13px",
+        color: "var(--tandem-error-fg-strong)",
+        textAlign: "center",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        gap: "12px",
+      }}
+    >
+      <span>Connection to the Tandem server has been lost. Ensure the server is running.</span>
+      <button
+        onClick={onDismiss}
+        style={{
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          color: "var(--tandem-error-fg-strong)",
+          fontSize: "16px",
+          lineHeight: 1,
+          padding: "0 4px",
+        }}
+        aria-label="Dismiss connection banner"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/src/client/components/EmptyState.tsx
+++ b/src/client/components/EmptyState.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { DISCONNECT_DEBOUNCE_MS } from "../../shared/constants";
+
+interface EmptyStateProps {
+  connected: boolean;
+  claudeActive: boolean;
+}
+
+/** Connection-aware empty state shown when no document is open. */
+export function EmptyState({ connected, claudeActive }: EmptyStateProps) {
+  const [showDisconnected, setShowDisconnected] = useState(false);
+
+  useEffect(() => {
+    if (connected) {
+      setShowDisconnected(false);
+      return;
+    }
+    const timer = setTimeout(() => setShowDisconnected(true), DISCONNECT_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [connected]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "100%",
+        color: "var(--tandem-fg-subtle)",
+        gap: "8px",
+      }}
+    >
+      {showDisconnected ? (
+        <span>Cannot reach the Tandem server. Is it running?</span>
+      ) : (
+        <>
+          <span>No document open. Click + in the tab bar or drop a file here.</span>
+          {connected && !claudeActive && (
+            <span style={{ fontSize: "0.85em", color: "var(--tandem-fg-subtle)" }}>
+              Tip: open Claude Code in this directory to start collaborating
+            </span>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/client/components/PanelSlot.tsx
+++ b/src/client/components/PanelSlot.tsx
@@ -39,7 +39,7 @@ type SideSlotProps = ComponentProps<typeof SidePanel> & { visible?: boolean };
 export function ChatSlot({ visible, ...props }: ChatSlotProps) {
   return (
     <SlotWrapper visible={visible}>
-      <ChatPanel {...props} />
+      <ChatPanel {...props} visible={visible} />
     </SlotWrapper>
   );
 }

--- a/src/client/components/PanelSlot.tsx
+++ b/src/client/components/PanelSlot.tsx
@@ -1,0 +1,54 @@
+import type { ComponentProps } from "react";
+import { ChatPanel } from "../panels/ChatPanel";
+import { SidePanel } from "../panels/SidePanel";
+
+/**
+ * Optional visibility wrapper shared by tabbed-layout panel slots.
+ *
+ * When `visible` is provided the slot wraps its child in a CSS display-flex/none
+ * div so the panel stays mounted (preserving local state) while toggling
+ * visibility. When `visible` is omitted the panel renders bare (three-panel
+ * layout, where both panels are always visible).
+ */
+
+interface SlotWrapperProps {
+  visible?: boolean;
+  children: React.ReactNode;
+}
+
+function SlotWrapper({ visible, children }: SlotWrapperProps) {
+  if (visible === undefined) return <>{children}</>;
+  return (
+    <div
+      style={{
+        display: visible ? "flex" : "none",
+        flexDirection: "column",
+        flex: 1,
+        minHeight: 0,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+type ChatSlotProps = ComponentProps<typeof ChatPanel> & { visible?: boolean };
+type SideSlotProps = ComponentProps<typeof SidePanel> & { visible?: boolean };
+
+/** Drop-in wrapper for ChatPanel that handles the display-toggle div in tabbed layout. */
+export function ChatSlot({ visible, ...props }: ChatSlotProps) {
+  return (
+    <SlotWrapper visible={visible}>
+      <ChatPanel {...props} />
+    </SlotWrapper>
+  );
+}
+
+/** Drop-in wrapper for SidePanel that handles the display-toggle div in tabbed layout. */
+export function SideSlot({ visible, ...props }: SideSlotProps) {
+  return (
+    <SlotWrapper visible={visible}>
+      <SidePanel {...props} />
+    </SlotWrapper>
+  );
+}

--- a/src/client/hooks/useConnectionBanner.ts
+++ b/src/client/hooks/useConnectionBanner.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { PROLONGED_DISCONNECT_MS } from "../../shared/constants";
+
+interface ConnectionBannerResult {
+  /** True when the prolonged-disconnect banner should be visible. */
+  showBanner: boolean;
+  /** Call to permanently hide the banner for the current disconnect episode. */
+  dismiss: () => void;
+}
+
+/**
+ * Tracks prolonged-disconnect state and surfaces a dismissible banner signal.
+ *
+ * Shows after PROLONGED_DISCONNECT_MS of continuous disconnection.
+ * Resets (hidden, undismissed) when the connection recovers.
+ */
+export function useConnectionBanner(disconnectedSince: number | null): ConnectionBannerResult {
+  const [showDisconnectBanner, setShowDisconnectBanner] = useState(false);
+  const [disconnectBannerDismissed, setDisconnectBannerDismissed] = useState(false);
+
+  useEffect(() => {
+    if (disconnectedSince == null) {
+      setShowDisconnectBanner(false);
+      setDisconnectBannerDismissed(false);
+      return;
+    }
+    const elapsed = Date.now() - disconnectedSince;
+    const remaining = PROLONGED_DISCONNECT_MS - elapsed;
+    if (remaining <= 0) {
+      setShowDisconnectBanner(true);
+      return;
+    }
+    const timer = setTimeout(() => setShowDisconnectBanner(true), remaining);
+    return () => clearTimeout(timer);
+  }, [disconnectedSince]);
+
+  return {
+    showBanner: showDisconnectBanner && !disconnectBannerDismissed,
+    dismiss: () => setDisconnectBannerDismissed(true),
+  };
+}

--- a/src/client/hooks/useDragResize.ts
+++ b/src/client/hooks/useDragResize.ts
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import {
+  type Dispatch,
+  type MouseEvent as ReactMouseEvent,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
 import { PANEL_WIDTH_KEYS, type PanelSide } from "../../shared/constants";
 import {
   PANEL_DEFAULT_WIDTH,
@@ -9,11 +16,11 @@ import {
 
 interface DragResizeOptions {
   panelLayout: PanelLayout;
-  setPanelLayout: React.Dispatch<React.SetStateAction<PanelLayout>>;
+  setPanelLayout: Dispatch<SetStateAction<PanelLayout>>;
 }
 
 interface DragResizeResult {
-  handleResizeStart: (e: React.MouseEvent, side: PanelSide) => void;
+  handleResizeStart: (e: ReactMouseEvent, side: PanelSide) => void;
 }
 
 /**
@@ -50,18 +57,18 @@ export function useDragResize({
   }, []);
 
   const handleResizeStart = useCallback(
-    (e: React.MouseEvent, side: PanelSide) => {
+    (e: ReactMouseEvent, side: PanelSide) => {
       e.preventDefault();
       const startX = e.clientX;
       const current = panelLayoutRef.current;
       // `left` is only defined in three-panel; fall back to the default so a
       // stale mid-transition drag never reads undefined.
-      const startWidth =
-        side === "left"
-          ? current.kind === "three-panel"
-            ? current.left
-            : PANEL_DEFAULT_WIDTH
-          : current.right;
+      let startWidth: number;
+      if (side === "left") {
+        startWidth = current.kind === "three-panel" ? current.left : PANEL_DEFAULT_WIDTH;
+      } else {
+        startWidth = current.right;
+      }
       const storageKey = PANEL_WIDTH_KEYS[side];
       let latestWidth = startWidth;
 

--- a/src/client/hooks/useDragResize.ts
+++ b/src/client/hooks/useDragResize.ts
@@ -1,0 +1,110 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { PANEL_WIDTH_KEYS, type PanelSide } from "../../shared/constants";
+import {
+  PANEL_DEFAULT_WIDTH,
+  PANEL_MAX_WIDTH,
+  PANEL_MIN_WIDTH,
+  type PanelLayout,
+} from "../panel-layout";
+
+interface DragResizeOptions {
+  panelLayout: PanelLayout;
+  setPanelLayout: React.Dispatch<React.SetStateAction<PanelLayout>>;
+}
+
+interface DragResizeResult {
+  handleResizeStart: (e: React.MouseEvent, side: PanelSide) => void;
+}
+
+/**
+ * Encapsulates drag-to-resize logic for side panels.
+ *
+ * Attaches and cleans up mousemove/mouseup listeners atomically so
+ * mid-drag unmount cannot leak listeners. The panelLayoutRef sync
+ * happens in render phase (not inside useEffect) so drag always reads
+ * current layout state.
+ */
+export function useDragResize({
+  panelLayout,
+  setPanelLayout,
+}: DragResizeOptions): DragResizeResult {
+  // Keep a ref current in render phase so drag callbacks read latest layout
+  const panelLayoutRef = useRef(panelLayout);
+  panelLayoutRef.current = panelLayout;
+
+  const dragListenersRef = useRef<{
+    move: (e: MouseEvent) => void;
+    up: () => void;
+  } | null>(null);
+
+  // Clean up drag listeners if the component unmounts mid-drag
+  useEffect(() => {
+    return () => {
+      if (dragListenersRef.current) {
+        document.removeEventListener("mousemove", dragListenersRef.current.move);
+        document.removeEventListener("mouseup", dragListenersRef.current.up);
+        document.body.style.userSelect = "";
+        document.body.style.cursor = "";
+      }
+    };
+  }, []);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent, side: PanelSide) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const current = panelLayoutRef.current;
+      // `left` is only defined in three-panel; fall back to the default so a
+      // stale mid-transition drag never reads undefined.
+      const startWidth =
+        side === "left"
+          ? current.kind === "three-panel"
+            ? current.left
+            : PANEL_DEFAULT_WIDTH
+          : current.right;
+      const storageKey = PANEL_WIDTH_KEYS[side];
+      let latestWidth = startWidth;
+
+      document.body.style.userSelect = "none";
+      document.body.style.cursor = "col-resize";
+
+      const onMouseMove = (ev: MouseEvent) => {
+        const delta = ev.clientX - startX;
+        // The left panel's handle sits on its right edge (drag right = wider).
+        // The right panel's handle sits on its left edge (drag right = narrower).
+        const next = side === "left" ? startWidth + delta : startWidth - delta;
+        latestWidth = Math.max(PANEL_MIN_WIDTH, Math.min(PANEL_MAX_WIDTH, next));
+        setPanelLayout((prev) => {
+          if (side === "right") {
+            return prev.kind === "three-panel"
+              ? { ...prev, right: latestWidth }
+              : { kind: "tabbed", right: latestWidth };
+          }
+          // Left handle is only rendered in three-panel, but guard anyway.
+          if (prev.kind !== "three-panel") return prev;
+          return { ...prev, left: latestWidth };
+        });
+      };
+
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+        dragListenersRef.current = null;
+        document.body.style.userSelect = "";
+        document.body.style.cursor = "";
+        try {
+          localStorage.setItem(storageKey, String(latestWidth));
+        } catch (err) {
+          console.warn(`[tandem] failed to persist ${storageKey}:`, err);
+        }
+      };
+
+      dragListenersRef.current = { move: onMouseMove, up: onMouseUp };
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [setPanelLayout],
+  );
+
+  return { handleResizeStart };
+}

--- a/src/client/hooks/useTandemModeBroadcast.ts
+++ b/src/client/hooks/useTandemModeBroadcast.ts
@@ -30,9 +30,8 @@ export function useTandemModeBroadcast(
   const [tandemMode, setTandemMode] = useState<TandemMode>(() => {
     try {
       const saved = localStorage.getItem(TANDEM_MODE_KEY);
-      return TandemModeSchema.safeParse(saved).success
-        ? (saved as TandemMode)
-        : TANDEM_MODE_DEFAULT;
+      const parsed = TandemModeSchema.safeParse(saved);
+      return parsed.success ? parsed.data : TANDEM_MODE_DEFAULT;
     } catch (err) {
       console.warn(`[tandem] localStorage unavailable reading ${TANDEM_MODE_KEY}:`, err);
       return TANDEM_MODE_DEFAULT;

--- a/src/client/hooks/useTandemModeBroadcast.ts
+++ b/src/client/hooks/useTandemModeBroadcast.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import * as Y from "yjs";
+import {
+  TANDEM_MODE_DEFAULT,
+  TANDEM_MODE_KEY,
+  Y_MAP_DWELL_MS,
+  Y_MAP_MODE,
+  Y_MAP_USER_AWARENESS,
+} from "../../shared/constants";
+import type { TandemMode } from "../../shared/types";
+import { TandemModeSchema } from "../../shared/types";
+
+interface TandemModeBroadcastResult {
+  tandemMode: TandemMode;
+  setTandemMode: (mode: TandemMode) => void;
+}
+
+/**
+ * Manages tandem mode state: persists to localStorage, and broadcasts both
+ * `Y_MAP_MODE` and `Y_MAP_DWELL_MS` to the CTRL_ROOM Y.Map so the server
+ * (and Claude) can see the current settings.
+ *
+ * @param bootstrapYdoc  The CTRL_ROOM Y.Doc from useYjsSync (may be null before ready).
+ * @param selectionDwellMs  The user's configured selection dwell time (from useTandemSettings).
+ */
+export function useTandemModeBroadcast(
+  bootstrapYdoc: Y.Doc | null,
+  selectionDwellMs: number,
+): TandemModeBroadcastResult {
+  const [tandemMode, setTandemMode] = useState<TandemMode>(() => {
+    try {
+      const saved = localStorage.getItem(TANDEM_MODE_KEY);
+      return TandemModeSchema.safeParse(saved).success
+        ? (saved as TandemMode)
+        : TANDEM_MODE_DEFAULT;
+    } catch (err) {
+      console.warn(`[tandem] localStorage unavailable reading ${TANDEM_MODE_KEY}:`, err);
+      return TANDEM_MODE_DEFAULT;
+    }
+  });
+
+  // Persist tandem mode to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(TANDEM_MODE_KEY, tandemMode);
+    } catch (err) {
+      console.warn(`[tandem] failed to persist ${TANDEM_MODE_KEY}:`, err);
+    }
+  }, [tandemMode]);
+
+  // Broadcast tandem mode to CTRL_ROOM Y.Map so the server (and Claude) can see it
+  useEffect(() => {
+    if (!bootstrapYdoc) return;
+    try {
+      const awareness = bootstrapYdoc.getMap(Y_MAP_USER_AWARENESS);
+      awareness.set(Y_MAP_MODE, tandemMode);
+    } catch (err) {
+      console.warn("[tandem] failed to broadcast tandem mode to Y.Map:", err);
+    }
+  }, [tandemMode, bootstrapYdoc]);
+
+  // Broadcast selection dwell time to CTRL_ROOM so the server uses the user's setting
+  useEffect(() => {
+    if (!bootstrapYdoc) return;
+    try {
+      const awareness = bootstrapYdoc.getMap(Y_MAP_USER_AWARENESS);
+      awareness.set(Y_MAP_DWELL_MS, selectionDwellMs);
+    } catch (err) {
+      console.warn("[tandem] failed to broadcast dwell ms to Y.Map:", err);
+    }
+  }, [selectionDwellMs, bootstrapYdoc]);
+
+  return { tandemMode, setTandemMode };
+}

--- a/src/client/panel-layout.ts
+++ b/src/client/panel-layout.ts
@@ -1,3 +1,5 @@
+import { PANEL_WIDTH_KEYS, type PanelSide } from "../shared/constants";
+
 /**
  * Client-local UI state describing the current side-panel arrangement.
  *
@@ -11,3 +13,26 @@
 export type PanelLayout =
   | { kind: "tabbed"; right: number }
   | { kind: "three-panel"; left: number; right: number };
+
+export const PANEL_MIN_WIDTH = 200;
+export const PANEL_MAX_WIDTH = 600;
+export const PANEL_DEFAULT_WIDTH = 300;
+
+export function loadPanelWidth(side: PanelSide): number {
+  const key = PANEL_WIDTH_KEYS[side];
+  try {
+    const saved = localStorage.getItem(key);
+    if (saved) {
+      const parsed = parseInt(saved, 10);
+      if (Number.isFinite(parsed)) {
+        return Math.max(PANEL_MIN_WIDTH, Math.min(PANEL_MAX_WIDTH, parsed));
+      }
+      // Non-finite saved value — fall through and warn so corrupt storage
+      // is diagnosable instead of silently reverting to the default.
+      console.warn(`[tandem] ignoring non-numeric panel width for ${key}: ${saved}`);
+    }
+  } catch (err) {
+    console.warn(`[tandem] localStorage unavailable reading ${key}:`, err);
+  }
+  return PANEL_DEFAULT_WIDTH;
+}


### PR DESCRIPTION
## Summary

- Extracts 7 concerns from `src/client/App.tsx`, reducing it from 956 to 665 LOC (~30% reduction)
- All extractions are pure moves — no logic changes, no new dependencies

## What moved where

| New file | What it contains |
|---|---|
| `panel-layout.ts` | `PANEL_MIN/MAX/DEFAULT_WIDTH`, `loadPanelWidth()` (constants + loader were inline in App) |
| `components/EmptyState.tsx` | Inline `EmptyState` component |
| `components/ConnectionBanner.tsx` | Inline `ConnectionBanner` component |
| `components/PanelSlot.tsx` | `ChatSlot` + `SideSlot` wrappers using `ComponentProps<>`, optional `visible` prop absorbs the CSS display-toggle div from tabbed layout |
| `hooks/useConnectionBanner.ts` | Prolonged-disconnect banner state; returns `{ showBanner, dismiss }` with dismissed-check folded in |
| `hooks/useTandemModeBroadcast.ts` | Owns `tandemMode` state, localStorage persist, and both Y.Map broadcasts (`Y_MAP_MODE` + `Y_MAP_DWELL_MS`); broadcasts wrapped in try/catch per plan review |
| `hooks/useDragResize.ts` | Panel drag-resize; cleanup `useEffect` + `dragListenersRef` + `handleResizeStart` moved atomically to prevent mid-drag unmount listener leak; `panelLayoutRef` sync remains in render phase |

## Minor fix bundled

The original `ConnectionBanner` JSX text child contained the literal 6-character string `×` (i.e., backslash + u + 0 + 0 + d + 7), not an escape sequence — JSX text children are not JS strings. This was rendering visibly wrong. Corrected to the actual `×` (U+00D7) character in the extracted file. One-character visual fix, called out explicitly since the task scope is "pure refactor."

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 1428 passed, 3 skipped; 1 pre-existing timeout failure in `mcp-stdio.test.ts > synthesizes -32000 for pending requests when the upstream dies mid-session` that reproduces identically on `master` (confirmed via stash-check), unrelated to this change
- [ ] Manual smoke test: tabbed layout chat/annotations toggle, three-panel resize handles, disconnect banner, empty state

Closes #400