### PR TITLE
fix(client): use translucent color-mix for flash animation (#308)

### DIFF
--- a/src/client/panels/SidePanel.tsx
+++ b/src/client/panels/SidePanel.tsx
@@ -489,7 +489,7 @@ export function SidePanel({
       </div>
       <style>{`
         @keyframes tandem-annotation-flash {
-          0% { background-color: var(--tandem-accent-bg); }
+          0% { background-color: color-mix(in srgb, var(--tandem-accent) 20%, transparent); }
           100% { background-color: transparent; }
         }
         .tandem-annotation-flash {


### PR DESCRIPTION
## Summary
- Replace opaque `var(--tandem-accent-bg)` with `color-mix(in srgb, var(--tandem-accent) 20%, transparent)` in the annotation flash keyframe
- Produces a translucent wash instead of an opaque color block in both light and dark themes

## Test plan
- [ ] Visual check: accept an annotation in light theme, verify flash is translucent
- [ ] Visual check: same in dark theme

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)