### PR TITLE
feat(server): surface normalizeAnnotation drop counts in snapshot (#351)

### DIFF
--- a/src/server/annotations/sync.ts
+++ b/src/server/annotations/sync.ts
@@ -154,16 +154,27 @@ function snapshot(ydoc: Y.Doc, docHash: string, meta: SyncMeta): AnnotationDocV1
   const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
   const repMap = ydoc.getMap(Y_MAP_ANNOTATION_REPLIES);
 
+  let annDrops = 0;
+  let replyDrops = 0;
+
   const annotations: AnnotationRecordV1[] = [];
   for (const value of annMap.values()) {
     const rec = normalizeAnnotation(value, docHash);
     if (rec) annotations.push(rec);
+    else annDrops++;
   }
 
   const replies: AnnotationReplyRecordV1[] = [];
   for (const value of repMap.values()) {
     const rec = normalizeReply(value);
     if (rec) replies.push(rec);
+    else replyDrops++;
+  }
+
+  if (annDrops > 0 || replyDrops > 0) {
+    console.error(
+      `[ANNOTATION-STORE] snapshot: dropped ${annDrops} annotation(s), ${replyDrops} reply(ies) in ${docHash}`,
+    );
   }
 
   const tombstones = [...(tombstonesByDoc.get(docHash) ?? [])];

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -241,6 +241,31 @@ describe("registerAnnotationObserver", () => {
     errorSpy.mockRestore();
   });
 
+  it("snapshot logs console.error when normalizeReply drops a non-object entry", async () => {
+    const ydoc = new Y.Doc();
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cleanup = registerAnnotationObserver(syncCtx(ydoc, store));
+
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const repMap = ydoc.getMap(Y_MAP_ANNOTATION_REPLIES);
+    ydoc.transact(() => {
+      annMap.set("ann_valid", annRecord({ id: "ann_valid" }));
+      repMap.set("rep_bad", "not-an-object" as unknown as Record<string, unknown>);
+    }, MCP_ORIGIN);
+
+    await store.flush();
+
+    const dropCalls = errorSpy.mock.calls.filter((args) =>
+      String(args[0]).includes("[ANNOTATION-STORE] snapshot: dropped"),
+    );
+    expect(dropCalls).toHaveLength(1);
+    expect(dropCalls[0][0]).toMatch(/dropped 0 annotation\(s\), 1 reply\(ies\)/);
+
+    cleanup();
+    errorSpy.mockRestore();
+  });
+
   it("cleanup unobserves both Y.Maps (further mutations don't write)", async () => {
     const ydoc = new Y.Doc();
     const store = createStore(HASH_A, { filePath: FILE_A });

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -217,6 +217,37 @@ describe("registerAnnotationObserver", () => {
     cleanup();
   });
 
+  it("snapshot logs console.error when normalizeAnnotation drops a non-object entry", async () => {
+    // Insert one valid annotation and one non-object value directly into the
+    // Y.Map, bypassing the normal mutation path. When the observer fires and
+    // snapshot() runs, it should drop the non-object entry and emit exactly one
+    // console.error with the drop count.
+    const ydoc = new Y.Doc();
+    const store = createStore(HASH_A, { filePath: FILE_A });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cleanup = registerAnnotationObserver(syncCtx(ydoc, store));
+
+    const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    // Use MCP_ORIGIN so the observer queues a snapshot.
+    ydoc.transact(() => {
+      annMap.set("ann_valid", annRecord({ id: "ann_valid" }));
+      // A non-object value — normalizeAnnotation returns null for these.
+      annMap.set("ann_bad", "not-an-object" as unknown as Record<string, unknown>);
+    }, MCP_ORIGIN);
+
+    await store.flush();
+
+    // Exactly one drop-count message, mentioning 1 annotation dropped.
+    const dropCalls = errorSpy.mock.calls.filter((args) =>
+      String(args[0]).includes("[ANNOTATION-STORE] snapshot: dropped"),
+    );
+    expect(dropCalls).toHaveLength(1);
+    expect(dropCalls[0][0]).toMatch(/dropped 1 annotation\(s\), 0 reply\(ies\)/);
+
+    cleanup();
+    errorSpy.mockRestore();
+  });
+
   it("cleanup unobserves both Y.Maps (further mutations don't write)", async () => {
     const ydoc = new Y.Doc();
     const store = createStore(HASH_A, { filePath: FILE_A });

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -218,26 +218,19 @@ describe("registerAnnotationObserver", () => {
   });
 
   it("snapshot logs console.error when normalizeAnnotation drops a non-object entry", async () => {
-    // Insert one valid annotation and one non-object value directly into the
-    // Y.Map, bypassing the normal mutation path. When the observer fires and
-    // snapshot() runs, it should drop the non-object entry and emit exactly one
-    // console.error with the drop count.
     const ydoc = new Y.Doc();
     const store = createStore(HASH_A, { filePath: FILE_A });
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const cleanup = registerAnnotationObserver(syncCtx(ydoc, store));
 
     const annMap = ydoc.getMap(Y_MAP_ANNOTATIONS);
-    // Use MCP_ORIGIN so the observer queues a snapshot.
     ydoc.transact(() => {
       annMap.set("ann_valid", annRecord({ id: "ann_valid" }));
-      // A non-object value — normalizeAnnotation returns null for these.
       annMap.set("ann_bad", "not-an-object" as unknown as Record<string, unknown>);
     }, MCP_ORIGIN);
 
     await store.flush();
 
-    // Exactly one drop-count message, mentioning 1 annotation dropped.
     const dropCalls = errorSpy.mock.calls.filter((args) =>
       String(args[0]).includes("[ANNOTATION-STORE] snapshot: dropped"),
     );


### PR DESCRIPTION
## Summary
- Add `annDrops`/`replyDrops` counters to `snapshot()` in `sync.ts`
- Log drop counts via `console.error` with `[ANNOTATION-STORE]` prefix when non-zero
- Add test verifying the console.error fires when a non-object entry is dropped

## Test plan
- [ ] `npm test` — new test passes
- [ ] Verify no false positives in normal operation (counters stay 0)

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)