### PR TITLE
fix(client): make annotation undo persistent until page reload (#415)

### DIFF
--- a/src/client/panels/AnnotationCard.tsx
+++ b/src/client/panels/AnnotationCard.tsx
@@ -35,7 +35,7 @@ export interface AnnotationCardProps {
   isReviewTarget?: boolean;
   onAccept?: (id: string) => void;
   onDismiss?: (id: string) => void;
-  onUndo?: (id: string) => void;
+  onUndo?: (id: string) => boolean;
   onEdit?: (id: string, newContent: string) => void;
   onReply?: (id: string, text: string) => Promise<boolean>;
   /** Whether this annotation was recently resolved and can be undone */

--- a/src/client/panels/AnnotationCardActions.tsx
+++ b/src/client/panels/AnnotationCardActions.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export interface AnnotationCardActionsProps {
   annotationId: string;
@@ -20,6 +20,8 @@ export function AnnotationCardActions({
   onUndo,
 }: AnnotationCardActionsProps) {
   const [undoError, setUndoError] = useState(false);
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (undoTimerRef.current) clearTimeout(undoTimerRef.current); }, []);
 
   if (isPending && !isEditing && (onAccept || onDismiss)) {
     return (
@@ -78,7 +80,8 @@ export function AnnotationCardActions({
             const ok = onUndo(annotationId);
             if (!ok) {
               setUndoError(true);
-              setTimeout(() => setUndoError(false), 3000);
+              if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+              undoTimerRef.current = setTimeout(() => setUndoError(false), 3000);
             }
           }}
           style={{

--- a/src/client/panels/AnnotationCardActions.tsx
+++ b/src/client/panels/AnnotationCardActions.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 export interface AnnotationCardActionsProps {
   annotationId: string;
   isPending: boolean;
@@ -5,7 +7,7 @@ export interface AnnotationCardActionsProps {
   undoable?: boolean;
   onAccept?: (id: string) => void;
   onDismiss?: (id: string) => void;
-  onUndo?: (id: string) => void;
+  onUndo?: (id: string) => boolean;
 }
 
 export function AnnotationCardActions({
@@ -17,6 +19,8 @@ export function AnnotationCardActions({
   onDismiss,
   onUndo,
 }: AnnotationCardActionsProps) {
+  const [undoError, setUndoError] = useState(false);
+
   if (isPending && !isEditing && (onAccept || onDismiss)) {
     return (
       <div style={{ display: "flex", gap: "6px", marginTop: "6px" }}>
@@ -66,12 +70,16 @@ export function AnnotationCardActions({
 
   if (!isPending && undoable && onUndo) {
     return (
-      <div style={{ marginTop: "4px", position: "relative" }}>
+      <div style={{ marginTop: "4px" }}>
         <button
           data-testid="undo-btn"
           onClick={(e) => {
             e.stopPropagation();
-            onUndo(annotationId);
+            const ok = onUndo(annotationId);
+            if (!ok) {
+              setUndoError(true);
+              setTimeout(() => setUndoError(false), 3000);
+            }
           }}
           style={{
             padding: "1px 6px",
@@ -85,22 +93,17 @@ export function AnnotationCardActions({
         >
           Undo
         </button>
-        <div
-          data-testid="undo-countdown"
-          style={{
-            height: "2px",
-            marginTop: "2px",
-            borderRadius: "1px",
-            backgroundColor: "var(--tandem-accent)",
-            animation: "undo-countdown-shrink 10s linear forwards",
-          }}
-        />
-        <style>
-          {`@keyframes undo-countdown-shrink {
-              from { width: 100%; }
-              to { width: 0%; }
-            }`}
-        </style>
+        {undoError && (
+          <div
+            style={{
+              fontSize: "11px",
+              color: "var(--tandem-error-fg)",
+              marginTop: "2px",
+            }}
+          >
+            Can't undo — text has changed.
+          </div>
+        )}
       </div>
     );
   }

--- a/src/client/panels/useAnnotationReview.ts
+++ b/src/client/panels/useAnnotationReview.ts
@@ -77,6 +77,14 @@ export function useAnnotationReview({
 
   const [recentlyResolved, setRecentlyResolved] = useState<Set<string>>(new Set());
   const lastResolvedRef = useRef<string | null>(null);
+  const pendingRemovalTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  useEffect(
+    () => () => {
+      for (const timer of pendingRemovalTimers.current.values()) clearTimeout(timer);
+    },
+    [],
+  );
 
   // Keyboard review targets only pending annotations (unfiltered)
   const reviewTargets = useMemo(
@@ -110,6 +118,35 @@ export function useAnnotationReview({
     setRecentlyResolved((prev) => new Set(prev).add(id));
   }
 
+  function scheduleRemoval(id: string) {
+    const existing = pendingRemovalTimers.current.get(id);
+    if (existing) clearTimeout(existing);
+    pendingRemovalTimers.current.set(
+      id,
+      setTimeout(() => {
+        pendingRemovalTimers.current.delete(id);
+        setRecentlyResolved((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }, 3000),
+    );
+  }
+
+  function removeFromResolved(id: string) {
+    const timer = pendingRemovalTimers.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      pendingRemovalTimers.current.delete(id);
+    }
+    setRecentlyResolved((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }
+
   /** Revert a resolved annotation back to pending, undoing text changes for accepted suggestions.
    * Returns true on success, false when the text-changed guard fires (undo blocked). */
   function undoResolveAnnotation(id: string): boolean {
@@ -117,11 +154,12 @@ export function useAnnotationReview({
     if (!y) return false;
     const map = y.getMap(Y_MAP_ANNOTATIONS);
     const raw = map.get(id) as Annotation | undefined;
-    if (!raw || raw.status === "pending") return false;
+    if (!raw || raw.status === "pending") {
+      removeFromResolved(id);
+      return false;
+    }
     const ann = sanitizeAnnotation(raw);
 
-    // If it was an accepted annotation with suggestedText, revert the text edit first.
-    // If text revert fails, don't revert status — half-undo is worse than no undo.
     if (ann.status === "accepted" && ann.suggestedText !== undefined && editorRef.current) {
       try {
         const newText = ann.suggestedText;
@@ -130,11 +168,13 @@ export function useAnnotationReview({
           const resolved = annotationToPmRange(ann, editorRef.current.state.doc, y);
           if (!resolved) {
             console.warn(`[undo] Cannot resolve range for annotation ${id}, skipping`);
+            scheduleRemoval(id);
             return false;
           }
           const currentText = editorRef.current.state.doc.textBetween(resolved.from, resolved.to);
           if (currentText !== newText) {
             console.warn(`[undo] Text changed since accept for annotation ${id}, skipping`);
+            scheduleRemoval(id);
             return false;
           }
           editorRef.current
@@ -146,18 +186,13 @@ export function useAnnotationReview({
         }
       } catch (err) {
         console.warn(`[undo] Failed to revert text for annotation ${id}:`, err);
+        scheduleRemoval(id);
         return false;
       }
     }
 
-    // Revert status to pending
     map.set(id, { ...ann, status: "pending" as const });
-
-    setRecentlyResolved((prev) => {
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
-    });
+    removeFromResolved(id);
     if (lastResolvedRef.current === id) {
       lastResolvedRef.current = null;
     }

--- a/src/client/panels/useAnnotationReview.ts
+++ b/src/client/panels/useAnnotationReview.ts
@@ -48,7 +48,7 @@ interface UseAnnotationReviewParams {
 
 export interface UseAnnotationReviewReturn {
   resolveAnnotation: (id: string, status: "accepted" | "dismissed") => void;
-  undoResolveAnnotation: (id: string) => void;
+  undoResolveAnnotation: (id: string) => boolean;
   handleAccept: (id: string) => void;
   handleDismiss: (id: string) => void;
   scrollToAnnotation: (ann: Annotation) => void;
@@ -75,18 +75,10 @@ export function useAnnotationReview({
   const reviewIndexRef = useRef(0);
   const confirmRef = useRef<HTMLButtonElement | null>(null);
 
-  // Track recently resolved annotations for timed undo (10s window)
+  // Track recently resolved annotations for session-scoped undo (persists until page reload)
   const [recentlyResolved, setRecentlyResolved] = useState<Set<string>>(new Set());
   // Track the last resolved annotation ID for keyboard undo (Z key)
   const lastResolvedRef = useRef<string | null>(null);
-  // Timer IDs for undo window expiry — cancel on undo or unmount
-  const undoTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
-  useEffect(() => {
-    const timers = undoTimersRef.current;
-    return () => {
-      for (const t of timers.values()) clearTimeout(t);
-    };
-  }, []);
 
   // Keyboard review targets only pending annotations (unfiltered)
   const reviewTargets = useMemo(
@@ -116,32 +108,19 @@ export function useAnnotationReview({
       }
     }
 
-    // Track for timed undo
+    // Track for session-scoped undo (IDs stay until page reload)
     lastResolvedRef.current = id;
     setRecentlyResolved((prev) => new Set(prev).add(id));
-    const existingTimer = undoTimersRef.current.get(id);
-    if (existingTimer) clearTimeout(existingTimer);
-    const timerId = setTimeout(() => {
-      undoTimersRef.current.delete(id);
-      setRecentlyResolved((prev) => {
-        const next = new Set(prev);
-        next.delete(id);
-        return next;
-      });
-      if (lastResolvedRef.current === id) {
-        lastResolvedRef.current = null;
-      }
-    }, 10_000);
-    undoTimersRef.current.set(id, timerId);
   }
 
-  /** Revert a resolved annotation back to pending, undoing text changes for accepted suggestions */
-  function undoResolveAnnotation(id: string) {
+  /** Revert a resolved annotation back to pending, undoing text changes for accepted suggestions.
+   * Returns true on success, false when the text-changed guard fires (undo blocked). */
+  function undoResolveAnnotation(id: string): boolean {
     const y = ydocRef.current;
-    if (!y) return;
+    if (!y) return false;
     const map = y.getMap(Y_MAP_ANNOTATIONS);
     const raw = map.get(id) as Annotation | undefined;
-    if (!raw || raw.status === "pending") return;
+    if (!raw || raw.status === "pending") return false;
     const ann = sanitizeAnnotation(raw);
 
     // If it was an accepted annotation with suggestedText, revert the text edit first.
@@ -154,12 +133,12 @@ export function useAnnotationReview({
           const resolved = annotationToPmRange(ann, editorRef.current.state.doc, y);
           if (!resolved) {
             console.warn(`[undo] Cannot resolve range for annotation ${id}, skipping`);
-            return;
+            return false;
           }
           const currentText = editorRef.current.state.doc.textBetween(resolved.from, resolved.to);
           if (currentText !== newText) {
             console.warn(`[undo] Text changed since accept for annotation ${id}, skipping`);
-            return;
+            return false;
           }
           editorRef.current
             .chain()
@@ -170,19 +149,13 @@ export function useAnnotationReview({
         }
       } catch (err) {
         console.warn(`[undo] Failed to revert text for annotation ${id}:`, err);
-        return;
+        return false;
       }
     }
 
     // Revert status to pending
     map.set(id, { ...ann, status: "pending" as const });
 
-    // Clean up undo tracking
-    const timer = undoTimersRef.current.get(id);
-    if (timer) {
-      clearTimeout(timer);
-      undoTimersRef.current.delete(id);
-    }
     setRecentlyResolved((prev) => {
       const next = new Set(prev);
       next.delete(id);
@@ -191,6 +164,7 @@ export function useAnnotationReview({
     if (lastResolvedRef.current === id) {
       lastResolvedRef.current = null;
     }
+    return true;
   }
 
   function handleAccept(id: string) {

--- a/src/client/panels/useAnnotationReview.ts
+++ b/src/client/panels/useAnnotationReview.ts
@@ -75,9 +75,7 @@ export function useAnnotationReview({
   const reviewIndexRef = useRef(0);
   const confirmRef = useRef<HTMLButtonElement | null>(null);
 
-  // Track recently resolved annotations for session-scoped undo (persists until page reload)
   const [recentlyResolved, setRecentlyResolved] = useState<Set<string>>(new Set());
-  // Track the last resolved annotation ID for keyboard undo (Z key)
   const lastResolvedRef = useRef<string | null>(null);
 
   // Keyboard review targets only pending annotations (unfiltered)
@@ -108,7 +106,6 @@ export function useAnnotationReview({
       }
     }
 
-    // Track for session-scoped undo (IDs stay until page reload)
     lastResolvedRef.current = id;
     setRecentlyResolved((prev) => new Set(prev).add(id));
   }


### PR DESCRIPTION
## Summary
- Remove 10s `setTimeout` and `undoTimersRef` from `useAnnotationReview` — undo is now session-scoped
- `undoResolveAnnotation` returns `boolean` (false when text-changed guard fires)
- Replace countdown bar with inline error "Can't undo — text has changed." (3s auto-clear)
- Timer cleanup via `useRef` + `useEffect` to prevent stale state updates on unmount

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Manual: resolve annotation, verify Undo button persists indefinitely (no countdown)
- [ ] Manual: accept suggestion, edit the text, click Undo — verify "Can't undo" message appears for 3s

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)