### PR TITLE
fix(plugin): declare monitor in plugin.json for Claude Code event push (#376)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
-  "version": "0.6.2",
+  "version": "0.7.1",
   "description": "Edit and iterate on documents with Claude — no copy-paste, real-time push via plugin monitor",
   "author": {
     "name": "Tandem"
@@ -23,5 +23,12 @@
         "TANDEM_URL": "http://localhost:3479"
       }
     }
-  }
+  },
+  "monitors": [
+    {
+      "name": "tandem-events",
+      "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/monitor/index.js",
+      "description": "Tandem real-time document events (annotations, chat, selections)"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "dev:standalone": "concurrently \"vite\" \"tsx watch src/server/index.ts\"",
+    "dev:standalone": "concurrently --names client,server,monitor \"vite\" \"tsx watch src/server/index.ts\" \"tsx src/monitor/index.ts\"",
     "dev:client": "vite",
     "dev:server": "tsx watch src/server/index.ts",
     "build": "npm run typecheck && vite build && tsup",


### PR DESCRIPTION
## Summary
- Add `monitors` array to `.claude-plugin/plugin.json` declaring the `tandem-events` monitor
- Bump plugin version from stale `0.6.2` to `0.7.1`
- Add monitor process to `dev:standalone` concurrently command for local development

## Test plan
- [ ] Start Tandem, verify Claude Code receives push notifications when annotations are created
- [ ] `npm run dev:standalone` starts three processes (client, server, monitor)

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)