### PR TITLE
fix(ci): expand useEffect one-liner to satisfy Biome format check

### DIFF
--- a/src/client/panels/AnnotationCardActions.tsx
+++ b/src/client/panels/AnnotationCardActions.tsx
@@ -21,7 +21,12 @@ export function AnnotationCardActions({
 }: AnnotationCardActionsProps) {
   const [undoError, setUndoError] = useState(false);
   const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => () => { if (undoTimerRef.current) clearTimeout(undoTimerRef.current); }, []);
+  useEffect(
+    () => () => {
+      if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    },
+    [],
+  );
 
   if (isPending && !isEditing && (onAccept || onDismiss)) {
     return (


### PR DESCRIPTION
## Summary

- Expands a useEffect cleanup one-liner in `AnnotationCardActions.tsx` that Biome 2.x requires to be multi-line
- This violation exists on master but was masked by the lint failure that precedes the Biome step in CI — it surfaced visibly on branches where lint passes (e.g. `fix/260-coordinate-bugs`, `fix/415-persistent-undo`)

## Context for PR #423 session

This PR fixes a Biome format issue **not present in #423's diff** — `AnnotationCardActions.tsx` is untouched by that branch. No conflict expected. After this merges, #423 should rebase off updated master to pick up the clean baseline, but no changes to its files are needed.

## Test plan

- [ ] CI Biome format check passes on this branch
- [ ] No functional change — formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)