### PR TITLE
feat(theme): extract --tandem-suggestion* token family (#340)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Full file-level detail: [docs/architecture.md](docs/architecture.md#file-map)
 - **`--tandem-claude-focus-bg`** / **`--tandem-claude-focus-border`** — Claude focus paragraph indicator. Derived from `--tandem-author-claude` via `color-mix` (10% / 40% opacity against transparent). Used in `awareness.ts` for the paragraph gutter decoration.
 - **Light mode:** `--tandem-success-bg`, `--tandem-warning-bg`, and `--tandem-error-bg` are derived via `color-mix(in srgb, var(--tandem-{color}) 10%, var(--tandem-surface))`. `--tandem-accent-bg` (`#eef2ff`) and `--tandem-info-bg` (`#eff6ff`) use hand-picked hex. `--tandem-suggestion-bg` uses `color-mix` like the other status families.
 - **Dark mode:** all `*-bg` tokens use hand-coded saturated hex (e.g. `#052e16`, `#451a03`, `#450a0a`). `color-mix` produces washed-out surfaces against the dark neutral; hand-picked values read as intentionally colored.
-- **`src/client/utils/colors.ts`** exports `errorStateColors`, `successStateColors`, `warningStateColors` — import these instead of inlining all three CSS vars when you need the full set (e.g. `SidePanel.tsx` held-banner).
+- **`src/client/utils/colors.ts`** exports `errorStateColors`, `successStateColors`, `warningStateColors`, `suggestionStateColors` — import these instead of inlining all three CSS vars when you need the full set (e.g. `SidePanel.tsx` held-banner).
 - Raw hex in client code is a regression; lint rule tracked in #356.
 
 ## Desktop App (Tauri)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,11 @@ Full file-level detail: [docs/architecture.md](docs/architecture.md#file-map)
 - **`--tandem-warning-*`** — amber. Warnings, held-annotation banners, unsaved indicators. `--tandem-warning`, `-fg`, `-fg-strong`, `-bg`, `-border`.
 - **`--tandem-error-*`** — red. Error banners, destructive actions, flag annotations. `--tandem-error`, `-fg`, `-fg-strong`, `-bg`, `-border`.
 - **`--tandem-info-*`** — blue. Informational banners, review-only mode. `--tandem-info`, `-fg`, `-fg-strong`, `-bg`, `-border`.
+- **`--tandem-suggestion-*`** — violet. Replacement/suggestion annotations. `--tandem-suggestion`, `-fg-strong`, `-bg`, `-border`. Visually distinct from indigo accent.
 - **`--tandem-accent-border`** — single token for accent-family bordered elements.
 - **`--tandem-author-user`** / **`--tandem-author-claude`** — authorship colors. Blue/orange in light, adjusted in dark.
 - **`--tandem-claude-focus-bg`** / **`--tandem-claude-focus-border`** — Claude focus paragraph indicator. Derived from `--tandem-author-claude` via `color-mix` (10% / 40% opacity against transparent). Used in `awareness.ts` for the paragraph gutter decoration.
-- **Light mode:** `--tandem-success-bg`, `--tandem-warning-bg`, and `--tandem-error-bg` are derived via `color-mix(in srgb, var(--tandem-{color}) 10%, var(--tandem-surface))`. `--tandem-accent-bg` (`#eef2ff`) and `--tandem-info-bg` (`#eff6ff`) use hand-picked hex.
+- **Light mode:** `--tandem-success-bg`, `--tandem-warning-bg`, and `--tandem-error-bg` are derived via `color-mix(in srgb, var(--tandem-{color}) 10%, var(--tandem-surface))`. `--tandem-accent-bg` (`#eef2ff`) and `--tandem-info-bg` (`#eff6ff`) use hand-picked hex. `--tandem-suggestion-bg` uses `color-mix` like the other status families.
 - **Dark mode:** all `*-bg` tokens use hand-coded saturated hex (e.g. `#052e16`, `#451a03`, `#450a0a`). `color-mix` produces washed-out surfaces against the dark neutral; hand-picked values read as intentionally colored.
 - **`src/client/utils/colors.ts`** exports `errorStateColors`, `successStateColors`, `warningStateColors` — import these instead of inlining all three CSS vars when you need the full set (e.g. `SidePanel.tsx` held-banner).
 - Raw hex in client code is a regression; lint rule tracked in #356.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -429,7 +429,7 @@ The probe produces a decision document filed as an ADR. The result determines th
 
 | Release | Concern | Scope |
 |---------|---------|-------|
-| v0.8.0 | Token hygiene + annotation correctness | #313, #318, #340, #355, #356, #308, #344, #351, #364, #369, #376, #377, #379, #381, #382, #396, #415 |
+| v0.8.0 | Token hygiene + annotation correctness | #260, #313, #318, #340, #355, #356, #308, #344, #351, #364, #369, #376, #377, #379, #381, #382, #396, #415 |
 | v0.9.0 | MCP API cleanup + distribution | #259, PR e, #316, #317, #322, #341, ADR-023 CI smoke test |
 
 **v0.8.0** — Token hygiene (#340, #355, #356) is a quality gate for dark theme: dark mode CAN function without them, but shipping with hardcoded rgba decorations and no lint enforcement means regressions. Annotation correctness (#313, #318) is data integrity. #369 (dark-mode scrollbars) is a standalone visual fix that lands here as a prerequisite, not part of the full dark theme release. #377 (annotation offset resolving to wrong text) is a position-related bug — if investigation reveals it's systemic rather than a one-off, #260 moves into scope per the deferral criterion. #376 (monitor not pushing events) is a usability bug in the event push pipeline. #379 (Tiptap markdown round-trip drops tables and mangles formatting) is a data integrity issue — opening a file with tables and saving it silently destroys content. #381 (remove Accept/Reject from user annotations) and #382 (remove Replace/@Claude checkboxes from user toolbar) simplify the annotation UX — settle this before any framework migration so the simpler UI is what gets ported. #396 (HTTP API silent-failure gaps) is pre-v1.0 observability hardening — continuation of v0.6.4's #336 work but for the HTTP route layer instead of the stdio bridge; 1-3 line fixes per site, lands as one small PR.
@@ -493,13 +493,13 @@ Net result: ~28 tools (down from 31).
 - **Observer soak test:** 6 concurrent documents, rapid tab switching, Y.Doc swaps, reconnect after network drop — no leaks
 - **Uninstaller:** Strips all integration entries cleanly
 - **npm tarball:** `npm pack` → install → `npx -y tandem-editor --version` on Linux + Windows
-- **Zero open position-related bugs** (#260 deferral criterion)
+- **Zero open position-related bugs** (#260 completed in v0.8.0; residual issues #425, #426 are non-blocking)
 
 ### Deferred to Post-v1.0
 
 | Item | Reason |
 |------|--------|
-| #260 — Coordinate system refactoring | All known position bugs fixed, tests solid, abstraction stable. Refactoring pre-1.0 risks regression. **Deferral criterion:** zero open position-related bugs at v1.0 branch cut. If any surface, #260 moves into scope. |
+| ~~#260 — Coordinate system refactoring~~ | **Completed in v0.8.0** (PR #423). Pulled into scope after #377 investigation revealed three compounding bugs. Pre-existing issues filed as #425, #426. |
 | #24 — Tailwind CSS 4 | Token system is correct. Tailwind is a code-style question, not correctness. |
 | #153 — Inline images | Nice-to-have |
 | #244 — Windows Playwright deadlock | CI workaround exists |

--- a/index.html
+++ b/index.html
@@ -53,6 +53,10 @@
         --tandem-info-fg-strong: #1e40af;
         --tandem-info-bg: #eff6ff;
         --tandem-info-border: #bfdbfe;
+        --tandem-suggestion: #7c3aed;
+        --tandem-suggestion-fg-strong: #5b21b6;
+        --tandem-suggestion-bg: color-mix(in srgb, var(--tandem-suggestion) 10%, var(--tandem-surface));
+        --tandem-suggestion-border: color-mix(in srgb, var(--tandem-suggestion) 40%, var(--tandem-border));
         --tandem-accent-border: #c7d2fe;
         --tandem-scrollbar-track: #f1f5f9;
         --tandem-scrollbar-thumb: #cbd5e1;
@@ -95,6 +99,10 @@
         --tandem-info-fg-strong: #bfdbfe;
         --tandem-info-bg: #0c4a6e;
         --tandem-info-border: #0369a1;
+        --tandem-suggestion: #a78bfa;
+        --tandem-suggestion-fg-strong: #ddd6fe;
+        --tandem-suggestion-bg: #2e1065;
+        --tandem-suggestion-border: #4c1d95;
         --tandem-accent-border: #4338ca;
         --tandem-scrollbar-track: #1e293b;
         --tandem-scrollbar-thumb: #475569;

--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -61,7 +61,7 @@ function buildDecorations(
           attrs = {
             class: "tandem-suggestion",
             style:
-              "background: var(--tandem-accent-bg); text-decoration: underline wavy var(--tandem-accent); text-underline-offset: 3px;",
+              "background: var(--tandem-suggestion-bg); text-decoration: underline wavy var(--tandem-suggestion); text-underline-offset: 3px;",
             "data-annotation-id": ann.id,
             "aria-label": "Replacement annotation",
           };

--- a/src/client/panels/AnnotationCard.tsx
+++ b/src/client/panels/AnnotationCard.tsx
@@ -59,7 +59,7 @@ function getBorderColor(annotation: Annotation): string {
   if (annotation.color) {
     return HIGHLIGHT_COLORS[annotation.color] || "var(--tandem-border)";
   }
-  if (annotation.suggestedText !== undefined) return "var(--tandem-accent)"; // replacement
+  if (annotation.suggestedText !== undefined) return "var(--tandem-suggestion)"; // replacement
   if (annotation.directedAt === "claude") return "var(--tandem-accent)"; // question for Claude
   if (annotation.type === "flag") return "var(--tandem-error)";
   return "var(--tandem-author-user)"; // plain comment

--- a/src/client/utils/colors.ts
+++ b/src/client/utils/colors.ts
@@ -30,3 +30,12 @@ export const warningStateColors = {
   border: "var(--tandem-warning-border)",
   color: "var(--tandem-warning-fg-strong)",
 } as const;
+
+/**
+ * Suggestion state colors (replacement annotations, violet UI surfaces).
+ */
+export const suggestionStateColors = {
+  background: "var(--tandem-suggestion-bg)",
+  border: "var(--tandem-suggestion-border)",
+  color: "var(--tandem-suggestion-fg-strong)",
+} as const;


### PR DESCRIPTION
## Summary

Extracts a `--tandem-suggestion*` token family (violet) from the generic `--tandem-accent` (indigo), restoring the visual distinction between:

- **Accent (indigo)** — UI controls, tabs, buttons, questions for Claude
- **Suggestion (violet)** — replacement/suggestion annotations

Changes:
- New CSS tokens in both light and dark themes (`index.html`)
- Rewired suggestion decoration styles in `annotation.ts` and `AnnotationCard.tsx`
- Added `suggestionStateColors` export in `colors.ts`
- Documented in CLAUDE.md Semantic Tokens section
- Updated roadmap to reflect #260 completion

## Test plan

- [x] Typecheck clean
- [x] All 1486 tests pass
- [ ] Visual: suggestion annotations render in violet (wavy underline + card border)
- [ ] Visual: questions for Claude still render in indigo
- [ ] Visual: both light and dark themes look correct

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
