### PR TITLE
feat(lint): add semantic token enforcement script (#356)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "doctor": "node scripts/doctor.mjs",
     "dev:tauri": "node scripts/download-node-sidecar.mjs && cargo tauri dev",
     "build:tauri": "cargo tauri build",
+    "check:tokens": "tsx scripts/check-semantic-tokens.ts",
     "prepare": "husky",
     "prepublishOnly": "npm run build"
   },
@@ -63,6 +64,9 @@
     "*.{ts,tsx}": [
       "eslint --fix",
       "biome check --write"
+    ],
+    "src/client/**/*.{ts,tsx}": [
+      "tsx scripts/check-semantic-tokens.ts"
     ],
     "*.mjs": [
       "eslint --fix",

--- a/scripts/check-semantic-tokens.ts
+++ b/scripts/check-semantic-tokens.ts
@@ -1,0 +1,97 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const toSlash = (p: string) => p.replace(/\\/g, "/");
+
+const ROOT = join(import.meta.dirname, "..");
+const CLIENT_DIR = join(ROOT, "src/client");
+const SKIP_FILE_NORM = toSlash(join(ROOT, "src/client/utils/colors.ts"));
+
+const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g;
+const RGBA_RE = /\brgba?\s*\(/g;
+const NEUTRAL_RE = /(?:0\s*,\s*0\s*,\s*0|255\s*,\s*255\s*,\s*255)/;
+const CSS_KEYWORDS = ["color", "background", "border", "fill", "stroke", "style"];
+
+function hasCssIndicator(line: string): boolean {
+  return CSS_KEYWORDS.some((kw) => line.includes(kw));
+}
+
+function isNeutralRgba(line: string, matchIndex: number): boolean {
+  const parenPos = line.indexOf("(", matchIndex);
+  if (parenPos === -1) return false;
+  const window = line.slice(parenPos + 1, parenPos + 21);
+  return NEUTRAL_RE.test(window);
+}
+
+function collectFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { recursive: true, withFileTypes: true });
+  return entries
+    .filter((e) => e.isFile() && /\.[tj]sx?$/.test(e.name))
+    .map((e) => toSlash(join(e.parentPath, e.name)));
+}
+
+function checkFile(filePath: string): string[] {
+  const violations: string[] = [];
+  const rel = toSlash(relative(ROOT, filePath));
+
+  if (filePath === SKIP_FILE_NORM) return violations;
+  if (/\.(test|spec)\.[tj]sx?$/.test(filePath)) return violations;
+
+  const lines = readFileSync(filePath, "utf-8").split("\n");
+  let inBlockComment = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trimStart();
+
+    if (inBlockComment) {
+      if (line.includes("*/")) inBlockComment = false;
+      continue;
+    }
+
+    if (trimmed.startsWith("//")) continue;
+
+    if (trimmed.startsWith("/*")) {
+      if (!line.includes("*/")) {
+        inBlockComment = true;
+      }
+      continue;
+    }
+
+    HEX_RE.lastIndex = 0;
+    let hexMatch: RegExpExecArray | null;
+    while ((hexMatch = HEX_RE.exec(line)) !== null) {
+      if (hasCssIndicator(line)) {
+        violations.push(`${rel}:${i + 1}: ${hexMatch[0]}`);
+      }
+    }
+
+    RGBA_RE.lastIndex = 0;
+    let rgbaMatch: RegExpExecArray | null;
+    while ((rgbaMatch = RGBA_RE.exec(line)) !== null) {
+      if (!isNeutralRgba(line, rgbaMatch.index)) {
+        violations.push(`${rel}:${i + 1}: ${rgbaMatch[0]}`);
+      }
+    }
+  }
+
+  return violations;
+}
+
+const files = collectFiles(CLIENT_DIR);
+const allViolations: string[] = [];
+
+for (const file of files) {
+  allViolations.push(...checkFile(file));
+}
+
+if (allViolations.length > 0) {
+  for (const v of allViolations) {
+    process.stderr.write(`${v}\n`);
+  }
+  process.stderr.write(`\ncheck-semantic-tokens: ${allViolations.length} violation(s) found\n`);
+  process.exit(1);
+} else {
+  process.stderr.write("check-semantic-tokens: clean\n");
+  process.exit(0);
+}

--- a/scripts/check-semantic-tokens.ts
+++ b/scripts/check-semantic-tokens.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync } from "node:fs";
-import { join, relative } from "node:path";
+import { join, relative, resolve } from "node:path";
 
 const toSlash = (p: string) => p.replace(/\\/g, "/");
 
@@ -7,6 +7,7 @@ const ROOT = join(import.meta.dirname, "..");
 const CLIENT_DIR = join(ROOT, "src/client");
 const SKIP_FILE_NORM = toSlash(join(ROOT, "src/client/utils/colors.ts"));
 
+const INLINE_BLOCK_COMMENT_RE = /\/\*.*?\*\//g;
 const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g;
 const RGBA_RE = /\brgba?\s*\(/g;
 const NEUTRAL_RE = /(?:0\s*,\s*0\s*,\s*0|255\s*,\s*255\s*,\s*255)/;
@@ -54,13 +55,15 @@ function checkFile(filePath: string): string[] {
     if (trimmed.startsWith("/*")) {
       if (!line.includes("*/")) {
         inBlockComment = true;
+        continue;
       }
-      continue;
     }
+
+    const scanLine = line.replace(INLINE_BLOCK_COMMENT_RE, (m) => " ".repeat(m.length));
 
     HEX_RE.lastIndex = 0;
     let hexMatch: RegExpExecArray | null;
-    while ((hexMatch = HEX_RE.exec(line)) !== null) {
+    while ((hexMatch = HEX_RE.exec(scanLine)) !== null) {
       if (hasCssIndicator(line)) {
         violations.push(`${rel}:${i + 1}: ${hexMatch[0]}`);
       }
@@ -68,8 +71,8 @@ function checkFile(filePath: string): string[] {
 
     RGBA_RE.lastIndex = 0;
     let rgbaMatch: RegExpExecArray | null;
-    while ((rgbaMatch = RGBA_RE.exec(line)) !== null) {
-      if (!isNeutralRgba(line, rgbaMatch.index)) {
+    while ((rgbaMatch = RGBA_RE.exec(scanLine)) !== null) {
+      if (!isNeutralRgba(scanLine, rgbaMatch.index)) {
         violations.push(`${rel}:${i + 1}: ${rgbaMatch[0]}`);
       }
     }
@@ -78,7 +81,11 @@ function checkFile(filePath: string): string[] {
   return violations;
 }
 
-const files = collectFiles(CLIENT_DIR);
+const explicitFiles = process.argv.slice(2);
+const files =
+  explicitFiles.length > 0
+    ? explicitFiles.map((f) => toSlash(resolve(f)))
+    : collectFiles(CLIENT_DIR);
 const allViolations: string[] = [];
 
 for (const file of files) {


### PR DESCRIPTION
## Summary

- New `scripts/check-semantic-tokens.ts` — standalone lint script that scans `src/client/**/*.{ts,tsx}` for raw hex colors and `rgba()` calls that should use `var(--tandem-*)` tokens
- Hex check requires a CSS property indicator (`color`, `background`, `border`, `fill`, `stroke`, `style`) on the same line — avoids false positives on element IDs and TS type annotations
- `rgba()`/`rgb()` calls using `0,0,0` or `255,255,255` (neutral shadows/overlays) are exempt per CLAUDE.md
- Skips `colors.ts` (token definition site), test/spec files, and comment lines (// and /* */)
- Added `npm run check:tokens` script and lint-staged entry for `src/client/**/*.{ts,tsx}`
- Current codebase passes clean (exit 0)

Closes #356

## Test plan

- [x] `npm run check:tokens` exits 0 on clean codebase
- [x] Injecting `color: "#ff0000"` into a client file → exit 1
- [x] `const id = "#my-element"` (no CSS keyword) → exit 0 (no false positive)
- [x] `const t: string = "#abc"` (TS type annotation) → exit 0 (no false positive)
- [x] `rgba(0, 0, 0, 0.2)` (neutral shadow) → exit 0 (exempt)
- [x] `rgba(128, 0, 255, 1)` (non-neutral) → exit 1
- [x] `/* color: #aaa */` (single-line block comment) → exit 0 (skipped)
- [x] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)