### PR TITLE
fix(deps): patch rustls-webpki, postcss, brace-expansion vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2611,7 +2611,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3125,7 +3127,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6592,7 +6596,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2109,6 +2109,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3617,9 +3627,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4256,9 +4266,13 @@ dependencies = [
 
 [[package]]
 name = "tandem-desktop"
-version = "0.6.2"
+version = "0.8.0"
 dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "keyring",
  "log",
+ "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
  "serde_json",


### PR DESCRIPTION
## Summary

Addresses 3 of 4 Dependabot alerts surfaced by the v0.8.0 tag push. Lockfile-only changes — no code modifications.

### Patched (Tier 1)
- **rustls-webpki** 0.103.12 → 0.103.13 (HIGH: DoS via malformed CRL BIT STRING in TLS cert validation)
- **postcss** 8.5.8 → 8.5.10 (MEDIUM: XSS in CSS stringify output — dev-only, never ships)
- **brace-expansion** 1.1.12 → 1.1.14, 5.0.4 → 5.0.5 (MEDIUM: zero-step sequence hang — dev-only)

### Accepted & Dismissed (Tier 2)
- **uuid** (MEDIUM, alert #27) — dismissed as `not_used`. The vulnerability is in `uuid.v3/v5/v6` with a `buf` parameter. Neither our code nor any dependency (`@hocuspocus/server` and `@tiptap/extension-unique-id` both import only `v4`) calls the vulnerable API. Fix requires Hocuspocus v4 (breaking) and `@tiptap/extension-unique-id` has no patched version.
- **rand** 0.7.3 (LOW, alert #22) — dismissed as `tolerable_risk`. Locked in Tauri's build-script chain (`selectors` → `phf_codegen`). Our direct `rand@0.8.6` dep is already patched. The vulnerability requires a custom logger calling `rand::rng()` which doesn't exist in this codebase.

### Note: Cargo.lock catch-up
The `Cargo.lock` was stale — still pinned at `tandem-desktop` 0.6.2 with `keyring`, `base64`, `dirs`, and `rand 0.8.6` missing from the dep list (predates the cowork PR). Running `cargo update -p rustls-webpki` caught the lockfile up to the current `Cargo.toml`, which is why the diff is larger than a pure security patch.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (1490/1490)
- [x] `npm audit` shows only uuid (accepted)
- [x] `cargo tree -p rustls-webpki --depth 0` shows 0.103.13
- [ ] CI passes
- [ ] Dismiss alerts #22 and #27 on Dependabot dashboard after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
