### PR TITLE
fix(tauri): add tokio macros feature for tokio::join! compilation

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4879,7 +4879,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["time", "macros"] }
 keyring = "3"
 base64 = "0.22"
 dirs = "6"


### PR DESCRIPTION
## Summary

- `tokio::join!` at `src-tauri/src/lib.rs:791` requires the `macros` feature flag
- `Cargo.toml` only declared `features = ["time"]`, causing a compile error: `could not find join in tokio`
- Adds `"macros"` to the tokio feature list — the only missing feature across the crate

## Test plan
- [x] `cargo build --manifest-path src-tauri/Cargo.toml` compiles clean
- [x] Verified no other tokio features are missing (only `time` and `macros` are used)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)