### PR TITLE
feat(schema): schema foundations for v0.9.0 redesign

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,7 +155,7 @@ Claude calls tandem_open("invoice.docx")
     → Browser receives updated list, adds second tab
     → DocumentTabs renders both tabs, second tab active
 
-Claude calls tandem_highlight({ from: 10, to: 20, color: "red", documentId: "report-a1b2c3" })
+Claude calls tandem_highlight({ from: 10, to: 20, color: "yellow", documentId: "report-a1b2c3" })
     → Targets report.md even though invoice.docx is the active document
 ```
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -360,7 +360,7 @@ Highlight text with a color and optional note.
 |-----------|------|----------|-------------|
 | `from` | number | yes | Start position |
 | `to` | number | yes | End position |
-| `color` | enum | yes | `yellow`, `red`, `green`, `blue`, `purple` |
+| `color` | enum | yes | `yellow`, `green`, `blue`, `pink` |
 | `note` | string | no | Optional note for the highlight |
 | `documentId` | string | no | Target document ID (defaults to active document) |
 | `textSnapshot` | string | no | Expected text at range — returns `RANGE_MOVED` with relocated range on mismatch, or `RANGE_GONE` if deleted |
@@ -372,7 +372,7 @@ Highlight text with a color and optional note.
 
 **Example:**
 ```
-tandem_highlight({ from: 42, to: 67, color: "red", note: "This figure doesn't match the invoice" })
+tandem_highlight({ from: 42, to: 67, color: "yellow", note: "This figure doesn't match the invoice" })
 ```
 
 ---
@@ -491,7 +491,7 @@ Read all annotations, optionally filtered. For checking new user actions, prefer
       "content": "This figure doesn't match the invoice",
       "status": "pending",
       "timestamp": 1710936000000,
-      "color": "red"
+      "color": "yellow"
     }
   ],
   "count": 1

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -52,7 +52,7 @@ Select text to reveal formatting buttons: **Bold**, **Italic**, **Headings** (H1
 
 When text is selected, annotation buttons appear alongside the formatting toolbar:
 
-- **Highlight** — Mark text with a colored background. A dropdown lets you pick from 5 colors: yellow, red, green, blue, or purple. An explicit ✕ button closes the color picker.
+- **Highlight** — Mark text with a colored background. A dropdown lets you pick from 4 colors: yellow, green, blue, or pink. An explicit ✕ button closes the color picker.
 - **Comment** — Attach a note to the selected text. Two optional toggles appear:
   - **Replace** — Propose replacement text. A text input appears for the new wording. Accepting the annotation applies the replacement automatically.
   - **@Claude** — Direct the comment to Claude as a question. Claude sees the selected text and your comment, and can respond with annotations, chat messages, or both.
@@ -125,7 +125,7 @@ Annotations are how Claude's feedback shows up in the document. There are three 
 
 ### Highlight
 
-Colored background on the annotated text. Choose from 5 colors (yellow, red, green, blue, purple) via the toolbar's color picker dropdown. Use highlights to mark notable passages — green for good, red for problems, yellow for "check this."
+Colored background on the annotated text. Choose from 4 colors (yellow, green, blue, pink) via the toolbar's color picker dropdown. Use highlights to mark notable passages — green for good, yellow for problems, pink for style/tone.
 
 ### Comment
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -97,7 +97,7 @@ Claude: tandem_resolveRange({ pattern: "$12.4 million" })
 
 Claude: tandem_highlight({
   from: 342, to: 355,
-  color: "red",
+  color: "yellow",
   note: "Q3 revenue was updated to $13.1M in the latest financial report"
 })
 ```
@@ -161,7 +161,7 @@ Claude: tandem_highlight({ from: 342, to: 355, color: "green", note: "Matches in
   documentId: "progress-report-f-1a2b3c" })
 
 // Discrepancy found
-Claude: tandem_highlight({ from: 487, to: 498, color: "red", note: "Invoice shows $2.6M -- $200K discrepancy",
+Claude: tandem_highlight({ from: 487, to: 498, color: "yellow", note: "Invoice shows $2.6M -- $200K discrepancy",
   documentId: "progress-report-f-1a2b3c" })
 
 // Not in invoice

--- a/skills/tandem/SKILL.md
+++ b/skills/tandem/SKILL.md
@@ -38,7 +38,7 @@ Standard workflow:
 
 Choose the right type for each finding:
 
-- **`tandem_highlight`** — Visual marker with a short note. Colors (full set): `green` (verified/good), `red` (problem), `yellow` (needs attention), `blue` (informational), `purple` (style/tone). Prefer the first three for review work; `blue`/`purple` are available when a fourth/fifth category is meaningful. Use when the finding is self-evident from the color and a brief note.
+- **`tandem_highlight`** — Visual marker with a short note. Colors: `green` (verified/good), `yellow` (needs attention), `blue` (informational), `pink` (style/tone). Use when the finding is self-evident from the color and a brief note.
 - **`tandem_comment`** — Observation requiring explanation. Use when you need more than one sentence to convey reasoning.
 - **`tandem_suggest`** — Specific text replacement. **Prefer over comment when you can provide replacement text** — the user gets one-click accept/reject. Cannot create new paragraphs.
 - **`tandem_flag`** — Factual errors, compliance risks, missing required content. Signals a blocking issue the user must address before the document ships.

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -189,8 +189,9 @@ export default function App() {
     return { kind: "tabbed", right: loadPanelWidth("right") };
   });
 
-  // Transition between variants when the user toggles layout mid-session.
-  // Preserves `right` across both directions and `left` on return to three-panel.
+  // Transition between layout variants when the user toggles mid-session.
+  // Each variant extracts the widths it needs from the previous layout,
+  // falling back to localStorage if the previous variant lacked that dimension.
   useEffect(() => {
     setPanelLayout((prev) => {
       if (settings.layout === "three-panel") {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -32,7 +32,7 @@ import { useTheme } from "./hooks/useTheme";
 import { useTutorial } from "./hooks/useTutorial";
 import { useWebViewZoom } from "./hooks/useWebViewZoom";
 import { useYjsSync } from "./hooks/useYjsSync";
-import { loadPanelWidth, type PanelLayout } from "./panel-layout";
+import { getRightWidth, loadPanelWidth, type PanelLayout } from "./panel-layout";
 import { ReviewSummary } from "./panels/ReviewSummary";
 import { pmSelectionToFlat } from "./positions";
 import { StatusBar } from "./status/StatusBar";
@@ -181,11 +181,13 @@ export default function App() {
     setActiveAnnotationId(annotationId);
   }, []);
 
-  const [panelLayout, setPanelLayout] = useState<PanelLayout>(() =>
-    settings.layout === "three-panel"
-      ? { kind: "three-panel", left: loadPanelWidth("left"), right: loadPanelWidth("right") }
-      : { kind: "tabbed", right: loadPanelWidth("right") },
-  );
+  const [panelLayout, setPanelLayout] = useState<PanelLayout>(() => {
+    if (settings.layout === "three-panel")
+      return { kind: "three-panel", left: loadPanelWidth("left"), right: loadPanelWidth("right") };
+    if (settings.layout === "tabbed-left")
+      return { kind: "tabbed-left", left: loadPanelWidth("left") };
+    return { kind: "tabbed", right: loadPanelWidth("right") };
+  });
 
   // Transition between variants when the user toggles layout mid-session.
   // Preserves `right` across both directions and `left` on return to three-panel.
@@ -193,10 +195,18 @@ export default function App() {
     setPanelLayout((prev) => {
       if (settings.layout === "three-panel") {
         if (prev.kind === "three-panel") return prev;
-        return { kind: "three-panel", left: loadPanelWidth("left"), right: prev.right };
+        const right = "right" in prev ? prev.right : loadPanelWidth("right");
+        const left = "left" in prev ? prev.left : loadPanelWidth("left");
+        return { kind: "three-panel", left, right };
+      }
+      if (settings.layout === "tabbed-left") {
+        if (prev.kind === "tabbed-left") return prev;
+        const left = "left" in prev ? prev.left : loadPanelWidth("left");
+        return { kind: "tabbed-left", left };
       }
       if (prev.kind === "tabbed") return prev;
-      return { kind: "tabbed", right: prev.right };
+      const right = "right" in prev ? prev.right : loadPanelWidth("right");
+      return { kind: "tabbed", right };
     });
   }, [settings.layout]);
 
@@ -454,7 +464,7 @@ export default function App() {
             style={{
               display: "flex",
               flexDirection: "column",
-              width: `${panelLayout.right}px`,
+              width: `${getRightWidth(panelLayout)}px`,
               borderLeft: "1px solid var(--tandem-border)",
             }}
           >
@@ -549,7 +559,7 @@ export default function App() {
             style={{
               display: "flex",
               flexDirection: "column",
-              width: `${panelLayout.right}px`,
+              width: `${getRightWidth(panelLayout)}px`,
               borderLeft: "1px solid var(--tandem-border)",
             }}
           >

--- a/src/client/components/EditorSettings.tsx
+++ b/src/client/components/EditorSettings.tsx
@@ -21,7 +21,7 @@ export function EditorSettings({ settings, onUpdate }: EditorSettingsProps) {
       <input
         data-testid="editor-width-slider"
         type="range"
-        min={50}
+        min={40}
         max={100}
         step={5}
         value={settings.editorWidthPercent}
@@ -37,7 +37,7 @@ export function EditorSettings({ settings, onUpdate }: EditorSettingsProps) {
           color: "var(--tandem-fg-subtle)",
         }}
       >
-        <span>50%</span>
+        <span>40%</span>
         <span>100%</span>
       </div>
     </div>

--- a/src/client/editor/toolbar/HighlightColorPicker.tsx
+++ b/src/client/editor/toolbar/HighlightColorPicker.tsx
@@ -5,10 +5,9 @@ import { ToolbarButton } from "./ToolbarButton";
 
 const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
   { value: "yellow", label: "Yellow" },
-  { value: "red", label: "Red" },
   { value: "green", label: "Green" },
   { value: "blue", label: "Blue" },
-  { value: "purple", label: "Purple" },
+  { value: "pink", label: "Pink" },
 ];
 
 interface HighlightColorPickerProps {

--- a/src/client/hooks/useDragResize.ts
+++ b/src/client/hooks/useDragResize.ts
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { PANEL_WIDTH_KEYS, type PanelSide } from "../../shared/constants";
 import {
+  getRightWidth,
   PANEL_DEFAULT_WIDTH,
   PANEL_MAX_WIDTH,
   PANEL_MIN_WIDTH,
@@ -67,7 +68,7 @@ export function useDragResize({
       if (side === "left") {
         startWidth = current.kind === "three-panel" ? current.left : PANEL_DEFAULT_WIDTH;
       } else {
-        startWidth = current.right;
+        startWidth = getRightWidth(current);
       }
       const storageKey = PANEL_WIDTH_KEYS[side];
       let latestWidth = startWidth;

--- a/src/client/hooks/useDragResize.ts
+++ b/src/client/hooks/useDragResize.ts
@@ -62,11 +62,11 @@ export function useDragResize({
       e.preventDefault();
       const startX = e.clientX;
       const current = panelLayoutRef.current;
-      // `left` is only defined in three-panel; fall back to the default so a
-      // stale mid-transition drag never reads undefined.
+      // `left` is present in three-panel and tabbed-left; fall back to the
+      // default so a stale mid-transition drag never reads undefined.
       let startWidth: number;
       if (side === "left") {
-        startWidth = current.kind === "three-panel" ? current.left : PANEL_DEFAULT_WIDTH;
+        startWidth = "left" in current ? current.left : PANEL_DEFAULT_WIDTH;
       } else {
         startWidth = getRightWidth(current);
       }
@@ -88,9 +88,9 @@ export function useDragResize({
               ? { ...prev, right: latestWidth }
               : { kind: "tabbed", right: latestWidth };
           }
-          // Left handle is only rendered in three-panel, but guard anyway.
-          if (prev.kind !== "three-panel") return prev;
-          return { ...prev, left: latestWidth };
+          if (prev.kind === "three-panel") return { ...prev, left: latestWidth };
+          if (prev.kind === "tabbed-left") return { ...prev, left: latestWidth };
+          return prev;
         });
       };
 

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -7,7 +7,9 @@ import {
   TANDEM_SETTINGS_KEY,
 } from "../../shared/constants";
 
-export type LayoutMode = "tabbed" | "three-panel";
+export type LayoutMode = "tabbed" | "three-panel" | "tabbed-left";
+export type EditorFont = "serif" | "sans" | "mono";
+export type Density = "compact" | "cozy" | "spacious";
 export type PrimaryTab = "chat" | "annotations";
 export type PanelOrder = "chat-editor-annotations" | "annotations-editor-chat";
 export type TextSize = "s" | "m" | "l";
@@ -23,6 +25,13 @@ export interface TandemSettings {
   reduceMotion: boolean;
   textSize: TextSize;
   theme: ThemePreference;
+  accentHue: number;
+  editorFont: EditorFont;
+  density: Density;
+  defaultMode: "solo" | "tandem";
+  highContrast: boolean;
+  annotationPatterns: boolean;
+  selectionToolbar: boolean;
 }
 
 export const TEXT_SIZE_PX: Record<TextSize, number> = { s: 14, m: 16, l: 18 };
@@ -44,10 +53,17 @@ const DEFAULTS: TandemSettings = {
   panelOrder: "chat-editor-annotations",
   editorWidthPercent: 50,
   selectionDwellMs: SELECTION_DWELL_DEFAULT_MS,
-  showAuthorship: false,
+  showAuthorship: true,
   reduceMotion: false,
   textSize: "m",
   theme: "system",
+  accentHue: 239,
+  editorFont: "sans",
+  density: "cozy",
+  defaultMode: "tandem",
+  highContrast: false,
+  annotationPatterns: false,
+  selectionToolbar: true,
 };
 
 /**
@@ -72,7 +88,9 @@ export function loadSettings(): TandemSettings {
       const parsed = JSON.parse(saved);
       return {
         layout:
-          parsed.layout === "three-panel" || parsed.layout === "tabbed"
+          parsed.layout === "three-panel" ||
+          parsed.layout === "tabbed" ||
+          parsed.layout === "tabbed-left"
             ? parsed.layout
             : DEFAULTS.layout,
         primaryTab: parsed.primaryTab === "annotations" ? "annotations" : "chat",
@@ -81,7 +99,7 @@ export function loadSettings(): TandemSettings {
             ? "annotations-editor-chat"
             : "chat-editor-annotations",
         editorWidthPercent: Math.max(
-          50,
+          40,
           Math.min(100, Number(parsed.editorWidthPercent) || DEFAULTS.editorWidthPercent),
         ),
         selectionDwellMs: Math.max(
@@ -102,6 +120,27 @@ export function loadSettings(): TandemSettings {
           parsed.theme === "light" || parsed.theme === "dark" || parsed.theme === "system"
             ? parsed.theme
             : DEFAULTS.theme,
+        accentHue:
+          typeof parsed.accentHue === "number" && parsed.accentHue >= 0 && parsed.accentHue <= 360
+            ? parsed.accentHue
+            : DEFAULTS.accentHue,
+        editorFont:
+          parsed.editorFont === "serif" ||
+          parsed.editorFont === "sans" ||
+          parsed.editorFont === "mono"
+            ? parsed.editorFont
+            : DEFAULTS.editorFont,
+        density:
+          parsed.density === "compact" || parsed.density === "cozy" || parsed.density === "spacious"
+            ? parsed.density
+            : DEFAULTS.density,
+        defaultMode:
+          parsed.defaultMode === "solo" || parsed.defaultMode === "tandem"
+            ? parsed.defaultMode
+            : DEFAULTS.defaultMode,
+        highContrast: parsed.highContrast === true,
+        annotationPatterns: parsed.annotationPatterns === true,
+        selectionToolbar: parsed.selectionToolbar === false ? false : DEFAULTS.selectionToolbar,
       };
     } catch (err) {
       // Corrupt blob — log so "my prefs reset" reports are diagnosable instead
@@ -124,11 +163,12 @@ export function mergeAndClampSettings(
   const merged = { ...prev, ...partial };
   return {
     ...merged,
-    editorWidthPercent: Math.max(50, Math.min(100, merged.editorWidthPercent)),
+    editorWidthPercent: Math.max(40, Math.min(100, merged.editorWidthPercent)),
     selectionDwellMs: Math.max(
       SELECTION_DWELL_MIN_MS,
       Math.min(SELECTION_DWELL_MAX_MS, merged.selectionDwellMs),
     ),
+    accentHue: Math.max(0, Math.min(360, merged.accentHue)),
   };
 }
 

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -6,6 +6,7 @@ import {
   SELECTION_DWELL_MIN_MS,
   TANDEM_SETTINGS_KEY,
 } from "../../shared/constants";
+import type { TandemMode } from "../../shared/types.js";
 
 export type LayoutMode = "tabbed" | "three-panel" | "tabbed-left";
 export type EditorFont = "serif" | "sans" | "mono";
@@ -28,7 +29,7 @@ export interface TandemSettings {
   accentHue: number;
   editorFont: EditorFont;
   density: Density;
-  defaultMode: "solo" | "tandem";
+  defaultMode: TandemMode;
   highContrast: boolean;
   annotationPatterns: boolean;
   selectionToolbar: boolean;
@@ -73,7 +74,9 @@ const DEFAULTS: TandemSettings = {
  * ranges on load so corrupted storage cannot wedge the app at an invalid
  * setting. Non-numeric or missing values fall back to the default via the
  * `Number(x) || DEFAULT` idiom (note: this treats `0` as falsy, which is
- * intentional — `0` is not a valid dwell or width anyway).
+ * intentional — `0` is not a valid dwell or width anyway). `accentHue` is
+ * the exception: hue 0 (red) is valid, so it uses an explicit `typeof`
+ * range check instead.
  */
 export function loadSettings(): TandemSettings {
   let saved: string | null;
@@ -109,7 +112,7 @@ export function loadSettings(): TandemSettings {
             Number(parsed.selectionDwellMs) || SELECTION_DWELL_DEFAULT_MS,
           ),
         ),
-        showAuthorship: parsed.showAuthorship === true,
+        showAuthorship: parsed.showAuthorship === false ? false : DEFAULTS.showAuthorship,
         reduceMotion:
           typeof parsed.reduceMotion === "boolean" ? parsed.reduceMotion : prefersReducedMotion(),
         textSize:
@@ -168,7 +171,9 @@ export function mergeAndClampSettings(
       SELECTION_DWELL_MIN_MS,
       Math.min(SELECTION_DWELL_MAX_MS, merged.selectionDwellMs),
     ),
-    accentHue: Math.max(0, Math.min(360, merged.accentHue)),
+    accentHue: Number.isFinite(merged.accentHue)
+      ? Math.max(0, Math.min(360, merged.accentHue))
+      : DEFAULTS.accentHue,
   };
 }
 

--- a/src/client/panel-layout.ts
+++ b/src/client/panel-layout.ts
@@ -3,8 +3,9 @@ import { PANEL_WIDTH_KEYS, type PanelSide } from "../shared/constants";
 /**
  * Client-local UI state describing the current side-panel arrangement.
  *
- * Discriminated union so `left` is present if and only if the layout is
- * three-panel — illegal states ("tabbed with a left width") cannot exist.
+ * Discriminated union: each variant carries only the width(s) it uses.
+ * `right` is present in layouts with a right panel (tabbed, three-panel).
+ * `left` is present in layouts with a left panel (three-panel, tabbed-left).
  *
  * Purely in-memory: widths still persist individually via `PANEL_WIDTH_KEYS`
  * in localStorage. Keeping this client-side (not in `src/shared/types.ts`)

--- a/src/client/panel-layout.ts
+++ b/src/client/panel-layout.ts
@@ -12,11 +12,16 @@ import { PANEL_WIDTH_KEYS, type PanelSide } from "../shared/constants";
  */
 export type PanelLayout =
   | { kind: "tabbed"; right: number }
-  | { kind: "three-panel"; left: number; right: number };
+  | { kind: "three-panel"; left: number; right: number }
+  | { kind: "tabbed-left"; left: number };
 
 export const PANEL_MIN_WIDTH = 200;
 export const PANEL_MAX_WIDTH = 600;
 export const PANEL_DEFAULT_WIDTH = 300;
+
+export function getRightWidth(layout: PanelLayout): number {
+  return "right" in layout ? layout.right : PANEL_DEFAULT_WIDTH;
+}
 
 export function loadPanelWidth(side: PanelSide): number {
   const key = PANEL_WIDTH_KEYS[side];

--- a/src/server/annotations/schema.ts
+++ b/src/server/annotations/schema.ts
@@ -18,6 +18,7 @@ import {
   AnnotationStatusSchema,
   AnnotationTypeSchema,
   AuthorSchema,
+  type HighlightColor,
   HighlightColorSchema,
   ReplyAuthorSchema,
 } from "../../shared/types.js";
@@ -165,6 +166,18 @@ export type AnnotationReplyRecordV1 = z.infer<typeof AnnotationReplyRecordSchema
 export type TombstoneRecordV1 = z.infer<typeof TombstoneRecordSchemaV1>;
 
 // ---------------------------------------------------------------------------
+// Color migration helpers
+// ---------------------------------------------------------------------------
+
+const LEGACY_COLOR_MAP: Record<string, HighlightColor> = { red: "yellow", purple: "blue" };
+
+function migrateHighlightColor(ann: Record<string, unknown>): void {
+  if (typeof ann.color === "string" && ann.color in LEGACY_COLOR_MAP) {
+    ann.color = LEGACY_COLOR_MAP[ann.color];
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Parse + migrate
 // ---------------------------------------------------------------------------
 
@@ -217,6 +230,16 @@ export function parseAnnotationDoc(raw: unknown): ParseAnnotationDocResult {
     return { ok: false, error: "future", schemaVersion };
   }
 
+  // Migrate legacy highlight colors before validation.
+  const cand = candidate as { annotations?: unknown };
+  if (Array.isArray(cand.annotations)) {
+    for (const ann of cand.annotations) {
+      if (ann && typeof ann === "object") {
+        migrateHighlightColor(ann as Record<string, unknown>);
+      }
+    }
+  }
+
   const result = AnnotationDocSchemaV1.safeParse(candidate);
   if (!result.success) {
     return { ok: false, error: "corrupt" };
@@ -267,6 +290,7 @@ export function migrateToV1(raw: unknown): MigrationResult {
       continue;
     }
     const withRev = { rev: 0, ...(ann as object) };
+    migrateHighlightColor(withRev as Record<string, unknown>);
     const parsed = AnnotationRecordSchemaV1.safeParse(withRev);
     if (parsed.success) annotations.push(parsed.data);
     else droppedAnnotations++;

--- a/src/server/annotations/schema.ts
+++ b/src/server/annotations/schema.ts
@@ -78,9 +78,10 @@ const RelativeRangeSchema = z
 // ---------------------------------------------------------------------------
 
 /**
- * Per-annotation envelope record. Structurally matches `AnnotationBase` from
+ * Per-annotation envelope record. Largely mirrors `AnnotationBase` from
  * `src/shared/types.ts`, plus the optional type-discriminator fields
- * (`color` / `suggestedText` / `directedAt`), plus the new required `rev`.
+ * (`color` / `suggestedText` / `directedAt`), plus the required `rev`.
+ * Fields not listed here (e.g. `heldInSolo`) are preserved via `.passthrough()`.
  */
 export const AnnotationRecordSchemaV1 = z
   .object({
@@ -169,11 +170,15 @@ export type TombstoneRecordV1 = z.infer<typeof TombstoneRecordSchemaV1>;
 // Color migration helpers
 // ---------------------------------------------------------------------------
 
-const LEGACY_COLOR_MAP: Record<string, HighlightColor> = { red: "yellow", purple: "blue" };
+const LEGACY_COLOR_MAP: Record<"red" | "purple", HighlightColor> = {
+  red: "yellow",
+  purple: "blue",
+};
 
 function migrateHighlightColor(ann: Record<string, unknown>): void {
-  if (typeof ann.color === "string" && ann.color in LEGACY_COLOR_MAP) {
-    ann.color = LEGACY_COLOR_MAP[ann.color];
+  const color = ann.color;
+  if (typeof color === "string" && color in LEGACY_COLOR_MAP) {
+    ann.color = LEGACY_COLOR_MAP[color as keyof typeof LEGACY_COLOR_MAP];
   }
 }
 
@@ -230,12 +235,16 @@ export function parseAnnotationDoc(raw: unknown): ParseAnnotationDocResult {
     return { ok: false, error: "future", schemaVersion };
   }
 
-  // Migrate legacy highlight colors before validation.
-  const cand = candidate as { annotations?: unknown };
+  // Migrate legacy highlight colors before validation. Clone each annotation
+  // so the caller's input objects are not mutated as a side effect of parsing.
+  const cand = candidate as { annotations?: unknown[] };
   if (Array.isArray(cand.annotations)) {
-    for (const ann of cand.annotations) {
+    for (let i = 0; i < cand.annotations.length; i++) {
+      const ann = cand.annotations[i];
       if (ann && typeof ann === "object") {
-        migrateHighlightColor(ann as Record<string, unknown>);
+        const cloned = { ...(ann as Record<string, unknown>) };
+        migrateHighlightColor(cloned);
+        cand.annotations[i] = cloned;
       }
     }
   }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -13,7 +13,9 @@ export const DISCONNECT_DEBOUNCE_MS = 3000; // 3 seconds before showing "server 
 export const PROLONGED_DISCONNECT_MS = 30_000; // 30 seconds before showing App-level disconnect banner
 export const OVERLAY_STALE_DEBOUNCE = 200; // 200ms
 
-export const HIGHLIGHT_COLORS: Record<string, string> = {
+import type { HighlightColor } from "./types.js";
+
+export const HIGHLIGHT_COLORS: Record<HighlightColor, string> = {
   yellow: "rgba(255, 235, 59, 0.3)",
   green: "rgba(76, 175, 80, 0.3)",
   blue: "rgba(33, 150, 243, 0.3)",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -15,10 +15,9 @@ export const OVERLAY_STALE_DEBOUNCE = 200; // 200ms
 
 export const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: "rgba(255, 235, 59, 0.3)",
-  red: "rgba(244, 67, 54, 0.3)",
   green: "rgba(76, 175, 80, 0.3)",
   blue: "rgba(33, 150, 243, 0.3)",
-  purple: "rgba(156, 39, 176, 0.3)",
+  pink: "rgba(236, 72, 153, 0.3)",
 };
 
 export const TANDEM_MODE_DEFAULT = "tandem" as const;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -16,7 +16,7 @@ export { toFlatOffset, toPmPos, toSerializedRelPos } from "./positions/types.js"
 export const AnnotationTypeSchema = z.enum(["highlight", "comment", "flag"]);
 
 export const AnnotationStatusSchema = z.enum(["pending", "accepted", "dismissed"]);
-export const HighlightColorSchema = z.enum(["yellow", "red", "green", "blue", "purple"]);
+export const HighlightColorSchema = z.enum(["yellow", "green", "blue", "pink"]);
 export const SeveritySchema = z.enum(["info", "warning", "error", "success"]);
 export const TandemModeSchema = z.enum(["solo", "tandem"]);
 export const AuthorSchema = z.enum(["user", "claude", "import"]);
@@ -91,6 +91,8 @@ interface AnnotationBase {
    * `rev: 0` by the merge/sync code.
    */
   rev?: number;
+  /** When true, this annotation was created while Solo mode was active and is held back from display. */
+  heldInSolo?: boolean;
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -91,7 +91,7 @@ interface AnnotationBase {
    * `rev: 0` by the merge/sync code.
    */
   rev?: number;
-  /** When true, this annotation was created while Solo mode was active and is held back from display. */
+  /** When true, marks this annotation as created during Solo mode. Consumers use this to hold back display until mode changes. */
   heldInSolo?: boolean;
 }
 

--- a/tests/client/panel-layout.test.ts
+++ b/tests/client/panel-layout.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRightWidth,
+  PANEL_DEFAULT_WIDTH,
+  type PanelLayout,
+} from "../../src/client/panel-layout.js";
+
+describe("getRightWidth", () => {
+  it("returns right width for tabbed layout", () => {
+    const layout: PanelLayout = { kind: "tabbed", right: 400 };
+    expect(getRightWidth(layout)).toBe(400);
+  });
+
+  it("returns right width for three-panel layout", () => {
+    const layout: PanelLayout = { kind: "three-panel", left: 250, right: 350 };
+    expect(getRightWidth(layout)).toBe(350);
+  });
+
+  it("returns PANEL_DEFAULT_WIDTH for tabbed-left layout", () => {
+    const layout: PanelLayout = { kind: "tabbed-left", left: 250 };
+    expect(getRightWidth(layout)).toBe(PANEL_DEFAULT_WIDTH);
+  });
+});

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -313,6 +313,10 @@ describe("useTandemSettings — updateSettings write path", () => {
     expect(mergeAndClampSettings(BASE, { accentHue: 400 }).accentHue).toBe(360);
     expect(mergeAndClampSettings(BASE, { accentHue: 180 }).accentHue).toBe(180);
   });
+
+  it("falls back to default accentHue for NaN", () => {
+    expect(mergeAndClampSettings(BASE, { accentHue: NaN }).accentHue).toBe(239);
+  });
 });
 
 describe("loadSettings — new fields (PR 2: Schema Foundations)", () => {
@@ -337,6 +341,11 @@ describe("loadSettings — new fields (PR 2: Schema Foundations)", () => {
   it("preserves stored showAuthorship: false (user choice)", () => {
     writeRawSettings({ showAuthorship: false });
     expect(loadSettings().showAuthorship).toBe(false);
+  });
+
+  it("defaults showAuthorship to true for upgrading users (key absent from existing blob)", () => {
+    writeRawSettings({ layout: "three-panel", editorWidthPercent: 75 });
+    expect(loadSettings().showAuthorship).toBe(true);
   });
 
   it("accepts tabbed-left as a valid layout", () => {

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -128,9 +128,9 @@ describe("loadSettings — editorWidthPercent clamping (regression guard)", () =
     expect(loadSettings().editorWidthPercent).toBe(100);
   });
 
-  it("clamps editorWidthPercent below 50 up to 50", () => {
+  it("clamps editorWidthPercent below 40 up to 40", () => {
     store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ editorWidthPercent: 10 }));
-    expect(loadSettings().editorWidthPercent).toBe(50);
+    expect(loadSettings().editorWidthPercent).toBe(40);
   });
 });
 
@@ -253,10 +253,17 @@ describe("useTandemSettings — updateSettings write path", () => {
     panelOrder: "chat-editor-annotations",
     editorWidthPercent: 75,
     selectionDwellMs: SELECTION_DWELL_DEFAULT_MS,
-    showAuthorship: false,
+    showAuthorship: true,
     reduceMotion: false,
     textSize: "m",
     theme: "system",
+    accentHue: 239,
+    editorFont: "sans",
+    density: "cozy",
+    defaultMode: "tandem",
+    highContrast: false,
+    annotationPatterns: false,
+    selectionToolbar: true,
   };
 
   it("clamps editorWidthPercent above 100 down to 100", () => {
@@ -264,9 +271,9 @@ describe("useTandemSettings — updateSettings write path", () => {
     expect(next.editorWidthPercent).toBe(100);
   });
 
-  it("clamps editorWidthPercent below 50 up to 50", () => {
+  it("clamps editorWidthPercent below 40 up to 40", () => {
     const next = mergeAndClampSettings(BASE, { editorWidthPercent: 10 });
-    expect(next.editorWidthPercent).toBe(50);
+    expect(next.editorWidthPercent).toBe(40);
   });
 
   it("clamps selectionDwellMs above max down to SELECTION_DWELL_MAX_MS", () => {
@@ -299,5 +306,123 @@ describe("useTandemSettings — updateSettings write path", () => {
     });
     expect(next.editorWidthPercent).toBe(80);
     expect(next.selectionDwellMs).toBe(1500);
+  });
+
+  it("clamps accentHue to [0, 360]", () => {
+    expect(mergeAndClampSettings(BASE, { accentHue: -10 }).accentHue).toBe(0);
+    expect(mergeAndClampSettings(BASE, { accentHue: 400 }).accentHue).toBe(360);
+    expect(mergeAndClampSettings(BASE, { accentHue: 180 }).accentHue).toBe(180);
+  });
+});
+
+describe("loadSettings — new fields (PR 2: Schema Foundations)", () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = installLocalStorageStub();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function writeRawSettings(partial: Record<string, unknown>) {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify(partial));
+  }
+
+  it("defaults showAuthorship to true", () => {
+    expect(loadSettings().showAuthorship).toBe(true);
+  });
+
+  it("preserves stored showAuthorship: false (user choice)", () => {
+    writeRawSettings({ showAuthorship: false });
+    expect(loadSettings().showAuthorship).toBe(false);
+  });
+
+  it("accepts tabbed-left as a valid layout", () => {
+    writeRawSettings({ layout: "tabbed-left" });
+    expect(loadSettings().layout).toBe("tabbed-left");
+  });
+
+  it("preserves accentHue: 0 (red) — not falsy-defaulted", () => {
+    writeRawSettings({ accentHue: 0 });
+    expect(loadSettings().accentHue).toBe(0);
+  });
+
+  it("defaults accentHue to 239 when absent", () => {
+    expect(loadSettings().accentHue).toBe(239);
+  });
+
+  it("falls back to default accentHue for non-numeric values", () => {
+    writeRawSettings({ accentHue: "garbage" });
+    expect(loadSettings().accentHue).toBe(239);
+  });
+
+  it.each(["serif", "sans", "mono"] as const)("accepts editorFont '%s'", (font) => {
+    writeRawSettings({ editorFont: font });
+    expect(loadSettings().editorFont).toBe(font);
+  });
+
+  it("falls back to 'sans' for unknown editorFont", () => {
+    writeRawSettings({ editorFont: "comic-sans" });
+    expect(loadSettings().editorFont).toBe("sans");
+  });
+
+  it("defaults editorFont to 'sans' when absent", () => {
+    expect(loadSettings().editorFont).toBe("sans");
+  });
+
+  it.each(["compact", "cozy", "spacious"] as const)("accepts density '%s'", (d) => {
+    writeRawSettings({ density: d });
+    expect(loadSettings().density).toBe(d);
+  });
+
+  it("falls back to 'cozy' for unknown density", () => {
+    writeRawSettings({ density: "ultra-tight" });
+    expect(loadSettings().density).toBe("cozy");
+  });
+
+  it.each(["solo", "tandem"] as const)("accepts defaultMode '%s'", (mode) => {
+    writeRawSettings({ defaultMode: mode });
+    expect(loadSettings().defaultMode).toBe(mode);
+  });
+
+  it("falls back to 'tandem' for unknown defaultMode", () => {
+    writeRawSettings({ defaultMode: "pair" });
+    expect(loadSettings().defaultMode).toBe("tandem");
+  });
+
+  it("accepts highContrast: true", () => {
+    writeRawSettings({ highContrast: true });
+    expect(loadSettings().highContrast).toBe(true);
+  });
+
+  it("defaults highContrast to false for non-boolean values", () => {
+    writeRawSettings({ highContrast: "yes" });
+    expect(loadSettings().highContrast).toBe(false);
+  });
+
+  it("accepts annotationPatterns: true", () => {
+    writeRawSettings({ annotationPatterns: true });
+    expect(loadSettings().annotationPatterns).toBe(true);
+  });
+
+  it("defaults annotationPatterns to false for non-boolean values", () => {
+    writeRawSettings({ annotationPatterns: 1 });
+    expect(loadSettings().annotationPatterns).toBe(false);
+  });
+
+  it("accepts selectionToolbar: false", () => {
+    writeRawSettings({ selectionToolbar: false });
+    expect(loadSettings().selectionToolbar).toBe(false);
+  });
+
+  it("defaults selectionToolbar to true when absent", () => {
+    expect(loadSettings().selectionToolbar).toBe(true);
+  });
+
+  it("defaults selectionToolbar to true for non-boolean values", () => {
+    writeRawSettings({ selectionToolbar: "nope" });
+    expect(loadSettings().selectionToolbar).toBe(true);
   });
 });

--- a/tests/server/annotation-tools.test.ts
+++ b/tests/server/annotation-tools.test.ts
@@ -35,7 +35,7 @@ describe("tandem_highlight tool logic", () => {
     const ydoc = setupDoc("hl-2", "Hello world test content here");
     const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
 
-    for (const color of ["yellow", "red", "green", "blue", "purple"] as const) {
+    for (const color of ["yellow", "green", "blue", "pink"] as const) {
       const id = createAnnotation(map, ydoc, "highlight", rangeOf(0, 5, ydoc), "", { color });
       const stored = map.get(id) as Annotation;
       expect(stored.color).toBe(color);
@@ -339,7 +339,7 @@ describe("annotation on multi-document", () => {
     const map2 = ydoc2.getMap(Y_MAP_ANNOTATIONS);
 
     createAnnotation(map1, ydoc1, "comment", rangeOf(0, 3), "on doc 1");
-    createAnnotation(map2, ydoc2, "highlight", rangeOf(0, 3), "", { color: "red" });
+    createAnnotation(map2, ydoc2, "highlight", rangeOf(0, 3), "", { color: "yellow" });
 
     expect(collectAnnotations(map1)).toHaveLength(1);
     expect(collectAnnotations(map2)).toHaveLength(1);

--- a/tests/server/annotations.test.ts
+++ b/tests/server/annotations.test.ts
@@ -49,10 +49,10 @@ describe("createAnnotation", () => {
   it("extras override defaults", () => {
     doc = makeDoc("test");
     const map = getAnnotationsMap(doc);
-    const id = createAnnotation(map, doc, "highlight", rangeOf(0, 4), "", { color: "red" });
+    const id = createAnnotation(map, doc, "highlight", rangeOf(0, 4), "", { color: "yellow" });
 
     const stored = map.get(id) as Annotation;
-    expect(stored.color).toBe("red");
+    expect(stored.color).toBe("yellow");
   });
 });
 

--- a/tests/server/annotations/schema.test.ts
+++ b/tests/server/annotations/schema.test.ts
@@ -403,6 +403,46 @@ describe("highlight color migration", () => {
     expect(result.doc.annotations[1]?.color).toBe("blue");
     expect(result.doc.annotations[2]?.color).toBe("blue");
   });
+
+  it("migrateToV1 passes through annotations without a color field", () => {
+    const legacy = {
+      annotations: [
+        {
+          id: "ann_comment",
+          author: "user",
+          type: "comment",
+          range: { from: 0, to: 5 },
+          content: "A note",
+          status: "pending",
+          timestamp: 1,
+        },
+      ],
+    };
+    const { doc, droppedAnnotations } = migrateToV1(legacy);
+    expect(droppedAnnotations).toBe(0);
+    expect(doc.annotations).toHaveLength(1);
+    expect(doc.annotations[0]?.color).toBeUndefined();
+  });
+
+  it("migrateToV1 drops annotations with unknown future colors", () => {
+    const legacy = {
+      annotations: [
+        {
+          id: "ann_orange",
+          author: "claude",
+          type: "highlight",
+          range: { from: 0, to: 5 },
+          content: "",
+          status: "pending",
+          timestamp: 1,
+          color: "orange",
+        },
+      ],
+    };
+    const { doc, droppedAnnotations } = migrateToV1(legacy);
+    expect(droppedAnnotations).toBe(1);
+    expect(doc.annotations).toHaveLength(0);
+  });
 });
 
 describe("AnnotationRecordSchemaV1 — per-record shape", () => {

--- a/tests/server/annotations/schema.test.ts
+++ b/tests/server/annotations/schema.test.ts
@@ -344,6 +344,67 @@ describe("migrateToV1", () => {
   });
 });
 
+describe("highlight color migration", () => {
+  it("migrateToV1 maps legacy red to yellow and purple to blue", () => {
+    const legacy = {
+      annotations: [
+        {
+          id: "ann_red",
+          author: "claude",
+          type: "highlight",
+          range: { from: 0, to: 5 },
+          content: "",
+          status: "pending",
+          timestamp: 1,
+          color: "red",
+        },
+        {
+          id: "ann_purple",
+          author: "user",
+          type: "highlight",
+          range: { from: 6, to: 10 },
+          content: "",
+          status: "pending",
+          timestamp: 2,
+          color: "purple",
+        },
+        {
+          id: "ann_yellow",
+          author: "user",
+          type: "highlight",
+          range: { from: 11, to: 15 },
+          content: "",
+          status: "pending",
+          timestamp: 3,
+          color: "yellow",
+        },
+      ],
+    };
+    const { doc, droppedAnnotations } = migrateToV1(legacy);
+    expect(droppedAnnotations).toBe(0);
+    expect(doc.annotations).toHaveLength(3);
+    expect(doc.annotations[0]?.color).toBe("yellow");
+    expect(doc.annotations[1]?.color).toBe("blue");
+    expect(doc.annotations[2]?.color).toBe("yellow");
+  });
+
+  it("parseAnnotationDoc migrates legacy colors in v1 files", () => {
+    const docWithOldColors: AnnotationDocV1 = {
+      ...validDoc,
+      annotations: [
+        { ...baseAnnotation, id: "ann_r", type: "highlight", color: "red" as never },
+        { ...baseAnnotation, id: "ann_p", type: "highlight", color: "purple" as never },
+        { ...baseAnnotation, id: "ann_b", type: "highlight", color: "blue" },
+      ],
+    };
+    const result = parseAnnotationDoc(docWithOldColors);
+    if (!result.ok) throw new Error("expected success");
+    expect(result.doc.annotations[0]?.color).toBe("yellow");
+    expect(result.doc.annotations[1]?.color).toBe("blue");
+    expect(result.doc.annotations[2]?.color).toBe("blue");
+  });
+});
+
 describe("AnnotationRecordSchemaV1 — per-record shape", () => {
   it("accepts a relRange with Yjs-shaped SerializedRelPos values", () => {
     // SerializedRelPos is opaque at the type level; on the wire it's an object


### PR DESCRIPTION
## Summary

Schema foundations for the v0.9.0 redesign (ADR-026). Adds types, defaults, parsing, and migration logic — no new UI rendering.

- **#440** — `heldInSolo?: boolean` on `AnnotationBase` (Solo-mode annotation hold-back)
- **#442** — 7 new `TandemSettings` fields: `accentHue`, `editorFont`, `density`, `defaultMode`, `highContrast`, `annotationPatterns`, `selectionToolbar`; flips `showAuthorship` default to `true`
- **#444** — Editor width minimum lowered from 50% to 40% (both clamp sites + slider)
- **#450** — Highlight palette migrated from 5 colors (yellow/red/green/blue/purple) to 4 (yellow/green/blue/pink); `migrateToV1()` and `parseAnnotationDoc()` map `red→yellow`, `purple→blue`
- **LayoutMode** — `tabbed-left` variant added to type system, `PanelLayout` union, and `App.tsx` init/transition (no render branch yet)

### Key decisions

- `accentHue` uses explicit range check `(typeof x === 'number' && x >= 0 && x <= 360)`, NOT the falsy-0 idiom — hue 0 (red) is valid
- `showAuthorship` default flip is intentional per ADR-026; existing user preferences preserved
- `tabbed-left` render logic deferred to PR 7 (#445) which depends on this PR

Closes #440, #442, #444, #450

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1597 pass, 4 skip (pre-existing)
- [x] New tests: `accentHue: 0` preserved (not falsy-defaulted)
- [x] New tests: `tabbed-left` accepted as valid layout
- [x] New tests: all 7 new settings fields — valid, invalid, absent cases
- [x] New tests: `migrateToV1` maps red→yellow, purple→blue
- [x] New tests: `parseAnnotationDoc` migrates legacy colors in v1 files
- [x] New tests: `mergeAndClampSettings` clamps `accentHue` to [0, 360]
- [ ] Manual: editor width slider goes down to 40%
- [ ] Manual: load annotation file with `color: "red"` → loads as yellow
- [ ] Manual: fresh profile → `showAuthorship` is `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
