### PR TITLE
fix(server): add textblock allowlist guard to getOrCreateXmlText

### DIFF
--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -309,10 +309,29 @@ export function findXmlText(element: Y.XmlElement): Y.XmlText | null {
 }
 
 /**
+ * Textblock element types that are allowed to have direct XmlText children.
+ * Container nodes (bulletList, blockquote, orderedList, table, etc.) must NOT
+ * have XmlText created on them — their children are other XmlElements.
+ */
+const TEXTBLOCK_NODES = new Set(["paragraph", "heading", "codeBlock"]);
+
+/**
  * Find the first Y.XmlText child of a Y.XmlElement.
  * Creates one if the element is empty.
+ *
+ * Defense-in-depth: throws on non-textblock elements (containers like
+ * bulletList, blockquote, etc.) to prevent phantom XmlText corruption.
+ * The primary guard is the pre-transaction check in tandem_edit — this
+ * catch exists for any future code path that bypasses that guard.
  */
 export function getOrCreateXmlText(element: Y.XmlElement): Y.XmlText {
+  if (!TEXTBLOCK_NODES.has(element.nodeName)) {
+    throw new Error(
+      `Cannot create XmlText on "${element.nodeName}" — only textblock elements ` +
+        `(paragraph, heading, codeBlock) should have direct XmlText children. ` +
+        `Edit a specific paragraph or list item instead.`,
+    );
+  }
   return (
     findXmlText(element) ??
     (() => {

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -356,7 +356,7 @@ export function registerDocumentTools(server: McpServer): void {
           r.doc.transact(() => {
             const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
             const startText = getOrCreateXmlText(startNode);
-            const startLen = startText.toString().length;
+            const startLen = startText.length;
             if (startPos.textOffset < startLen) {
               startText.delete(startPos.textOffset, startLen - startPos.textOffset);
             }
@@ -371,9 +371,18 @@ export function registerDocumentTools(server: McpServer): void {
             if (endPos.textOffset > 0) {
               endText.delete(0, endPos.textOffset);
             }
-            const remainingText = endText.toString();
-            if (remainingText.length > 0) {
-              startText.insert(startPos.textOffset, remainingText);
+            const remaining = endText.toDelta();
+            let mergeOffset = startPos.textOffset;
+            for (const seg of remaining) {
+              if (typeof seg.insert === "string") {
+                startText.insert(mergeOffset, seg.insert, seg.attributes || {});
+                mergeOffset += seg.insert.length;
+              } else {
+                // Embed (hardBreak, image, etc.) — clone to detach from endText
+                const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+                startText.insertEmbed(mergeOffset, embed, seg.attributes || {});
+                mergeOffset += 1;
+              }
             }
             fragment.delete(startPos.elementIndex + 1, 1);
 

--- a/tests/crdt/authorship-marks-size.test.ts
+++ b/tests/crdt/authorship-marks-size.test.ts
@@ -49,7 +49,7 @@ function applyContinuousMarks(doc: Y.Doc): void {
     for (let i = 0; i < fragment.length; i++) {
       const el = fragment.get(i) as Y.XmlElement;
       const textNode = el.get(0) as Y.XmlText;
-      const len = textNode.toString().length;
+      const len = textNode.length;
       const author = i % 2 === 0 ? "user" : "claude";
       textNode.format(0, len, { author });
     }
@@ -63,7 +63,7 @@ function applyFragmentedMarks(doc: Y.Doc): void {
     for (let i = 0; i < fragment.length; i++) {
       const el = fragment.get(i) as Y.XmlElement;
       const textNode = el.get(0) as Y.XmlText;
-      const len = textNode.toString().length;
+      const len = textNode.length;
       for (let offset = 0; offset < len; offset += 10) {
         const end = Math.min(offset + 10, len);
         const author = Math.floor(offset / 10) % 2 === 0 ? "user" : "claude";

--- a/tests/server/authorship-edit-integration.test.ts
+++ b/tests/server/authorship-edit-integration.test.ts
@@ -40,7 +40,7 @@ function applyEditWithAuthorship(
     doc.transact(() => {
       const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
       const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.toString().length;
+      const startLen = startText.length;
       if (startPos.textOffset < startLen) {
         startText.delete(startPos.textOffset, startLen - startPos.textOffset);
       }
@@ -53,9 +53,17 @@ function applyEditWithAuthorship(
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remainingText = endText.toString();
-      if (remainingText.length > 0) {
-        startText.insert(startPos.textOffset, remainingText);
+      const remaining = endText.toDelta();
+      let mergeOffset = startPos.textOffset;
+      for (const seg of remaining) {
+        if (typeof seg.insert === "string") {
+          startText.insert(mergeOffset, seg.insert, seg.attributes || {});
+          mergeOffset += seg.insert.length;
+        } else {
+          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+          startText.insertEmbed(mergeOffset, embed, seg.attributes || {});
+          mergeOffset += 1;
+        }
       }
       fragment.delete(startPos.elementIndex + 1, 1);
       startText.insert(startPos.textOffset, newText);

--- a/tests/server/document-edit.test.ts
+++ b/tests/server/document-edit.test.ts
@@ -227,6 +227,63 @@ describe("formatted cross-element edits (regression #425)", () => {
   });
 });
 
+describe("getOrCreateXmlText container guard", () => {
+  it("throws on container element types", () => {
+    const containers = [
+      "bulletList",
+      "orderedList",
+      "blockquote",
+      "table",
+      "tableRow",
+      "tableCell",
+      "tableHeader",
+      "listItem",
+    ];
+    for (const name of containers) {
+      const d = new Y.Doc();
+      const fragment = d.getXmlFragment("content");
+      const el = new Y.XmlElement(name);
+      fragment.insert(0, [el]);
+
+      expect(() => getOrCreateXmlText(el), `should throw for ${name}`).toThrow(
+        /Cannot create XmlText/,
+      );
+      d.destroy();
+    }
+  });
+
+  it("allows paragraph elements", () => {
+    const d = new Y.Doc();
+    const fragment = d.getXmlFragment("content");
+    const para = new Y.XmlElement("paragraph");
+    fragment.insert(0, [para]);
+
+    expect(() => getOrCreateXmlText(para)).not.toThrow();
+    d.destroy();
+  });
+
+  it("allows heading elements", () => {
+    const d = new Y.Doc();
+    const fragment = d.getXmlFragment("content");
+    const heading = new Y.XmlElement("heading");
+    heading.setAttribute("level", 2 as any);
+    fragment.insert(0, [heading]);
+
+    expect(() => getOrCreateXmlText(heading)).not.toThrow();
+    d.destroy();
+  });
+
+  it("allows codeBlock elements", () => {
+    const d = new Y.Doc();
+    const fragment = d.getXmlFragment("content");
+    const codeBlock = new Y.XmlElement("codeBlock");
+    fragment.insert(0, [codeBlock]);
+
+    expect(() => getOrCreateXmlText(codeBlock)).not.toThrow();
+    d.destroy();
+  });
+});
+
 describe("validation", () => {
   it("from > to returns error", () => {
     doc = makeDoc("Hello");

--- a/tests/server/document-edit.test.ts
+++ b/tests/server/document-edit.test.ts
@@ -30,7 +30,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): strin
     doc.transact(() => {
       const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
       const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.toString().length;
+      const startLen = startText.length;
       if (startPos.textOffset < startLen) {
         startText.delete(startPos.textOffset, startLen - startPos.textOffset);
       }
@@ -45,9 +45,17 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): strin
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remainingText = endText.toString();
-      if (remainingText.length > 0) {
-        startText.insert(startPos.textOffset, remainingText);
+      const remaining = endText.toDelta();
+      let mergeOffset = startPos.textOffset;
+      for (const seg of remaining) {
+        if (typeof seg.insert === "string") {
+          startText.insert(mergeOffset, seg.insert, seg.attributes || {});
+          mergeOffset += seg.insert.length;
+        } else {
+          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+          startText.insertEmbed(mergeOffset, embed, seg.attributes || {});
+          mergeOffset += 1;
+        }
       }
       fragment.delete(startPos.elementIndex + 1, 1);
 
@@ -172,6 +180,50 @@ describe("heading prefix rejection", () => {
     // offset 2 is still inside "## " prefix
     const err = applyEdit(doc, 2, 5, "X");
     expect(err).toContain("heading markup");
+  });
+});
+
+describe("formatted cross-element edits (regression #425)", () => {
+  it("preserves bold formatting when merging across paragraphs", () => {
+    // Build a doc with two paragraphs where the second has bold text:
+    //   "First paragraph"  (plain)
+    //   "Bold second"      (bold)
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+
+    const p1 = new Y.XmlElement("paragraph");
+    fragment.insert(0, [p1]);
+    const t1 = new Y.XmlText();
+    p1.insert(0, [t1]);
+    t1.insert(0, "First paragraph");
+
+    const p2 = new Y.XmlElement("paragraph");
+    fragment.insert(1, [p2]);
+    const t2 = new Y.XmlText();
+    p2.insert(0, [t2]);
+    t2.insert(0, "Bold second");
+    t2.format(0, 11, { bold: true });
+
+    // Verify setup: "First paragraph\nBold second"
+    expect(extractText(doc)).toBe("First paragraph\nBold second");
+
+    // Cross-element edit: replace " paragraph\nBold " with " and "
+    // offsets: "First" = 0..4, " paragraph" = 5..14, \n = 15, "Bold " = 16..20, "second" = 21..26
+    const err = applyEdit(doc, 5, 21, " and ");
+    expect(err).toBeNull();
+    expect(extractText(doc)).toBe("First and second");
+
+    // The surviving "second" text should retain bold formatting
+    const merged = fragment.get(0) as Y.XmlElement;
+    const mergedText = merged.get(0) as Y.XmlText;
+    const delta = mergedText.toDelta();
+
+    // Delta should be: [{insert: "First and "}, {insert: "second", attributes: {bold: true}}]
+    expect(delta.length).toBe(2);
+    expect(delta[0].insert).toBe("First and ");
+    expect(delta[0].attributes).toBeUndefined();
+    expect(delta[1].insert).toBe("second");
+    expect(delta[1].attributes).toEqual({ bold: true });
   });
 });
 

--- a/tests/server/integration.test.ts
+++ b/tests/server/integration.test.ts
@@ -36,7 +36,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boole
     doc.transact(() => {
       const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
       const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.toString().length;
+      const startLen = startText.length;
       if (startPos.textOffset < startLen) {
         startText.delete(startPos.textOffset, startLen - startPos.textOffset);
       }
@@ -49,9 +49,17 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boole
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remainingText = endText.toString();
-      if (remainingText.length > 0) {
-        startText.insert(startPos.textOffset, remainingText);
+      const remaining = endText.toDelta();
+      let mergeOffset = startPos.textOffset;
+      for (const seg of remaining) {
+        if (typeof seg.insert === "string") {
+          startText.insert(mergeOffset, seg.insert, seg.attributes || {});
+          mergeOffset += seg.insert.length;
+        } else {
+          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+          startText.insertEmbed(mergeOffset, embed, seg.attributes || {});
+          mergeOffset += 1;
+        }
       }
       fragment.delete(startPos.elementIndex + 1, 1);
       startText.insert(startPos.textOffset, newText);


### PR DESCRIPTION
## Summary
- Add `TEXTBLOCK_NODES` allowlist (`paragraph`, `heading`, `codeBlock`) to `getOrCreateXmlText()`
- Non-textblock elements (containers like blockquote, bulletList, table, etc.) now throw with a descriptive error
- This is defense-in-depth — the pre-transaction guards in `tandem_edit` remain the primary atomicity barrier
- Existing guards in `document.ts` lines 338-353 are preserved (Y.js transactions don't roll back on throw)

## Details
`getOrCreateXmlText()` unconditionally created XmlText children on any element. When called on container nodes (blockquote, bulletList, orderedList, table, tableRow, tableCell, tableHeader, listItem), this corrupted the CRDT structure — these elements should only contain XmlElement children.

Uses an allowlist (not denylist) so new container types added in the future are automatically excluded without requiring code changes.

Closes #426

## Test plan
- [ ] `getOrCreateXmlText` on container types throws descriptive error
- [ ] `getOrCreateXmlText` on textblock types works normally
- [ ] Existing `tandem_edit` behavior unchanged (pre-transaction guards handle containers)
- [ ] `npm test` — all pass
- [ ] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)