### PR TITLE
fix(server): use Y.js canonical length in cross-element edit path

### DIFF
--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -322,3 +322,35 @@ export function getOrCreateXmlText(element: Y.XmlElement): Y.XmlText {
     })()
   );
 }
+
+/**
+ * Merge the contents of `endText` into `startText` at `atOffset`, preserving
+ * inline formatting marks and embeds. Walks `endText.toDelta()` and copies
+ * each segment with its attributes via `insert` / `insertEmbed`.
+ *
+ * Index space: `atOffset` and the per-segment advance both use Y.XmlText's
+ * canonical length (string chars + 1 per embed) — never `toString().length`,
+ * which is inflated by markup tags.
+ *
+ * Embed handling: Y.AbstractType embeds (e.g., Y.XmlElement("hardBreak")) are
+ * cloned to detach from `endText` before its parent element is removed.
+ * Plain-object embeds are deep-copied by Yjs internally and pass through.
+ *
+ * Caveat: `seg.attributes === undefined` causes `Y.Text.insert` to inherit the
+ * destination's currentAttributes at `mergeOffset` — i.e., an unformatted
+ * source segment may pick up active formatting at the boundary in `startText`.
+ * This matches the same-element edit path and is intentional for v1.
+ */
+export function mergeXmlText(startText: Y.XmlText, endText: Y.XmlText, atOffset: number): void {
+  let mergeOffset = atOffset;
+  for (const seg of endText.toDelta()) {
+    if (typeof seg.insert === "string") {
+      startText.insert(mergeOffset, seg.insert, seg.attributes);
+      mergeOffset += seg.insert.length;
+    } else {
+      const embed = seg.insert instanceof Y.AbstractType ? seg.insert.clone() : seg.insert;
+      startText.insertEmbed(mergeOffset, embed, seg.attributes);
+      mergeOffset += 1;
+    }
+  }
+}

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -356,7 +356,7 @@ export function registerDocumentTools(server: McpServer): void {
           r.doc.transact(() => {
             const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
             const startText = getOrCreateXmlText(startNode);
-            const startLen = startText.toString().length;
+            const startLen = startText.length;
             if (startPos.textOffset < startLen) {
               startText.delete(startPos.textOffset, startLen - startPos.textOffset);
             }
@@ -371,9 +371,18 @@ export function registerDocumentTools(server: McpServer): void {
             if (endPos.textOffset > 0) {
               endText.delete(0, endPos.textOffset);
             }
-            const remainingText = endText.toString();
-            if (remainingText.length > 0) {
-              startText.insert(startPos.textOffset, remainingText);
+            const remaining = endText.toDelta();
+            let mergeOffset = startPos.textOffset;
+            for (const seg of remaining) {
+              if (typeof seg.insert === "string") {
+                startText.insert(mergeOffset, seg.insert, seg.attributes);
+                mergeOffset += seg.insert.length;
+              } else {
+                // Embed (hardBreak, image, etc.) — clone to detach from endText
+                const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+                startText.insertEmbed(mergeOffset, embed, seg.attributes);
+                mergeOffset += 1;
+              }
             }
             fragment.delete(startPos.elementIndex + 1, 1);
 

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -20,7 +20,13 @@ import { saveSession } from "../session/manager.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
 import { convertToMarkdown } from "./convert.js";
 // Document model (pure logic)
-import { extractText, findXmlText, getElementText, getOrCreateXmlText } from "./document-model.js";
+import {
+  extractText,
+  findXmlText,
+  getElementText,
+  getOrCreateXmlText,
+  mergeXmlText,
+} from "./document-model.js";
 // Document service (state management)
 import {
   broadcastOpenDocs,
@@ -77,6 +83,7 @@ export {
   getElementTextLength,
   getHeadingPrefixLength,
   getOrCreateXmlText,
+  mergeXmlText,
   populateYDoc,
   verifyAndResolveRange,
 } from "./document-model.js";
@@ -371,19 +378,7 @@ export function registerDocumentTools(server: McpServer): void {
             if (endPos.textOffset > 0) {
               endText.delete(0, endPos.textOffset);
             }
-            const remaining = endText.toDelta();
-            let mergeOffset = startPos.textOffset;
-            for (const seg of remaining) {
-              if (typeof seg.insert === "string") {
-                startText.insert(mergeOffset, seg.insert, seg.attributes);
-                mergeOffset += seg.insert.length;
-              } else {
-                // Embed (hardBreak, image, etc.) — clone to detach from endText
-                const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-                startText.insertEmbed(mergeOffset, embed, seg.attributes);
-                mergeOffset += 1;
-              }
-            }
+            mergeXmlText(startText, endText, startPos.textOffset);
             fragment.delete(startPos.elementIndex + 1, 1);
 
             startText.insert(startPos.textOffset, newText);

--- a/tests/crdt/authorship-marks-size.test.ts
+++ b/tests/crdt/authorship-marks-size.test.ts
@@ -49,7 +49,7 @@ function applyContinuousMarks(doc: Y.Doc): void {
     for (let i = 0; i < fragment.length; i++) {
       const el = fragment.get(i) as Y.XmlElement;
       const textNode = el.get(0) as Y.XmlText;
-      const len = textNode.toString().length;
+      const len = textNode.length;
       const author = i % 2 === 0 ? "user" : "claude";
       textNode.format(0, len, { author });
     }
@@ -63,7 +63,7 @@ function applyFragmentedMarks(doc: Y.Doc): void {
     for (let i = 0; i < fragment.length; i++) {
       const el = fragment.get(i) as Y.XmlElement;
       const textNode = el.get(0) as Y.XmlText;
-      const len = textNode.toString().length;
+      const len = textNode.length;
       for (let offset = 0; offset < len; offset += 10) {
         const end = Math.min(offset + 10, len);
         const author = Math.floor(offset / 10) % 2 === 0 ? "user" : "claude";

--- a/tests/server/authorship-edit-integration.test.ts
+++ b/tests/server/authorship-edit-integration.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
+import {
+  extractText,
+  getOrCreateXmlText,
+  mergeXmlText,
+  resolveOffset,
+} from "../../src/server/mcp/document.js";
 import { anchoredRange } from "../../src/server/positions.js";
 import { Y_MAP_AUTHORSHIP } from "../../src/shared/constants.js";
 import { toFlatOffset } from "../../src/shared/positions/types.js";
@@ -53,18 +58,7 @@ function applyEditWithAuthorship(
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remaining = endText.toDelta();
-      let mergeOffset = startPos.textOffset;
-      for (const seg of remaining) {
-        if (typeof seg.insert === "string") {
-          startText.insert(mergeOffset, seg.insert, seg.attributes);
-          mergeOffset += seg.insert.length;
-        } else {
-          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-          startText.insertEmbed(mergeOffset, embed, seg.attributes);
-          mergeOffset += 1;
-        }
-      }
+      mergeXmlText(startText, endText, startPos.textOffset);
       fragment.delete(startPos.elementIndex + 1, 1);
       startText.insert(startPos.textOffset, newText);
     }, MCP_ORIGIN);

--- a/tests/server/authorship-edit-integration.test.ts
+++ b/tests/server/authorship-edit-integration.test.ts
@@ -40,7 +40,7 @@ function applyEditWithAuthorship(
     doc.transact(() => {
       const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
       const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.toString().length;
+      const startLen = startText.length;
       if (startPos.textOffset < startLen) {
         startText.delete(startPos.textOffset, startLen - startPos.textOffset);
       }
@@ -53,9 +53,17 @@ function applyEditWithAuthorship(
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remainingText = endText.toString();
-      if (remainingText.length > 0) {
-        startText.insert(startPos.textOffset, remainingText);
+      const remaining = endText.toDelta();
+      let mergeOffset = startPos.textOffset;
+      for (const seg of remaining) {
+        if (typeof seg.insert === "string") {
+          startText.insert(mergeOffset, seg.insert, seg.attributes);
+          mergeOffset += seg.insert.length;
+        } else {
+          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+          startText.insertEmbed(mergeOffset, embed, seg.attributes);
+          mergeOffset += 1;
+        }
       }
       fragment.delete(startPos.elementIndex + 1, 1);
       startText.insert(startPos.textOffset, newText);

--- a/tests/server/document-edit.test.ts
+++ b/tests/server/document-edit.test.ts
@@ -30,7 +30,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): strin
     doc.transact(() => {
       const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
       const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.toString().length;
+      const startLen = startText.length;
       if (startPos.textOffset < startLen) {
         startText.delete(startPos.textOffset, startLen - startPos.textOffset);
       }
@@ -45,9 +45,17 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): strin
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remainingText = endText.toString();
-      if (remainingText.length > 0) {
-        startText.insert(startPos.textOffset, remainingText);
+      const remaining = endText.toDelta();
+      let mergeOffset = startPos.textOffset;
+      for (const seg of remaining) {
+        if (typeof seg.insert === "string") {
+          startText.insert(mergeOffset, seg.insert, seg.attributes);
+          mergeOffset += seg.insert.length;
+        } else {
+          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+          startText.insertEmbed(mergeOffset, embed, seg.attributes);
+          mergeOffset += 1;
+        }
       }
       fragment.delete(startPos.elementIndex + 1, 1);
 
@@ -172,6 +180,50 @@ describe("heading prefix rejection", () => {
     // offset 2 is still inside "## " prefix
     const err = applyEdit(doc, 2, 5, "X");
     expect(err).toContain("heading markup");
+  });
+});
+
+describe("formatted cross-element edits (regression #425)", () => {
+  it("preserves bold formatting when merging across paragraphs", () => {
+    // Build a doc with two paragraphs where the second has bold text:
+    //   "First paragraph"  (plain)
+    //   "Bold second"      (bold)
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+
+    const p1 = new Y.XmlElement("paragraph");
+    fragment.insert(0, [p1]);
+    const t1 = new Y.XmlText();
+    p1.insert(0, [t1]);
+    t1.insert(0, "First paragraph");
+
+    const p2 = new Y.XmlElement("paragraph");
+    fragment.insert(1, [p2]);
+    const t2 = new Y.XmlText();
+    p2.insert(0, [t2]);
+    t2.insert(0, "Bold second");
+    t2.format(0, 11, { bold: true });
+
+    // Verify setup: "First paragraph\nBold second"
+    expect(extractText(doc)).toBe("First paragraph\nBold second");
+
+    // Cross-element edit: replace " paragraph\nBold " with " and "
+    // offsets: "First" = 0..4, " paragraph" = 5..14, \n = 15, "Bold " = 16..20, "second" = 21..26
+    const err = applyEdit(doc, 5, 21, " and ");
+    expect(err).toBeNull();
+    expect(extractText(doc)).toBe("First and second");
+
+    // The surviving "second" text should retain bold formatting
+    const merged = fragment.get(0) as Y.XmlElement;
+    const mergedText = merged.get(0) as Y.XmlText;
+    const delta = mergedText.toDelta();
+
+    // Delta should be: [{insert: "First and "}, {insert: "second", attributes: {bold: true}}]
+    expect(delta.length).toBe(2);
+    expect(delta[0].insert).toBe("First and ");
+    expect(delta[0].attributes).toBeUndefined();
+    expect(delta[1].insert).toBe("second");
+    expect(delta[1].attributes).toEqual({ bold: true });
   });
 });
 

--- a/tests/server/document-edit.test.ts
+++ b/tests/server/document-edit.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
+import {
+  extractText,
+  getOrCreateXmlText,
+  mergeXmlText,
+  resolveOffset,
+} from "../../src/server/mcp/document.js";
 import { makeDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
@@ -45,18 +50,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): strin
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remaining = endText.toDelta();
-      let mergeOffset = startPos.textOffset;
-      for (const seg of remaining) {
-        if (typeof seg.insert === "string") {
-          startText.insert(mergeOffset, seg.insert, seg.attributes);
-          mergeOffset += seg.insert.length;
-        } else {
-          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-          startText.insertEmbed(mergeOffset, embed, seg.attributes);
-          mergeOffset += 1;
-        }
-      }
+      mergeXmlText(startText, endText, startPos.textOffset);
       fragment.delete(startPos.elementIndex + 1, 1);
 
       startText.insert(startPos.textOffset, newText);
@@ -224,6 +218,96 @@ describe("formatted cross-element edits (regression #425)", () => {
     expect(delta[0].attributes).toBeUndefined();
     expect(delta[1].insert).toBe("second");
     expect(delta[1].attributes).toEqual({ bold: true });
+  });
+
+  it("preserves hardBreak embed when merging across paragraphs", () => {
+    // p1: "First"
+    // p2: "Line one<hardBreak>after" — surviving suffix "<hardBreak>after"
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+
+    const p1 = new Y.XmlElement("paragraph");
+    fragment.insert(0, [p1]);
+    const t1 = new Y.XmlText();
+    p1.insert(0, [t1]);
+    t1.insert(0, "First");
+
+    const p2 = new Y.XmlElement("paragraph");
+    fragment.insert(1, [p2]);
+    const t2 = new Y.XmlText();
+    p2.insert(0, [t2]);
+    t2.insert(0, "Line one");
+    t2.insertEmbed(t2.length, new Y.XmlElement("hardBreak"));
+    t2.insert(t2.length, "after");
+
+    // Embed counts as 1 in canonical index space; extractText emits \n for embeds.
+    // Top-level fragment join is also \n. Both contribute to the flat offset.
+    expect(t2.length).toBe(8 + 1 + 5); // "Line one" + embed + "after" = 14
+    expect(extractText(doc)).toBe("First\nLine one\nafter");
+
+    // Replace "rst\nLine on" (offsets 2..13) with " " — the cut leaves "e<hardBreak>after"
+    // in the surviving suffix of p2.
+    const err = applyEdit(doc, 2, 13, " ");
+    expect(err).toBeNull();
+    expect(extractText(doc)).toBe("Fi e\nafter");
+
+    const merged = fragment.get(0) as Y.XmlElement;
+    const mergedText = merged.get(0) as Y.XmlText;
+    const delta = mergedText.toDelta();
+
+    // Expected delta: [{insert: "Fi "}, {insert: "e"}, {insert: <hardBreak>}, {insert: "after"}]
+    // Adjacent string segments may or may not be merged depending on currentAttributes
+    // boundaries, so assert structurally rather than counting segments.
+    const stringInserts = delta
+      .filter((d: { insert: unknown }) => typeof d.insert === "string")
+      .map((d: { insert: string }) => d.insert)
+      .join("");
+    expect(stringInserts).toBe("Fi eafter");
+
+    const embeds = delta.filter((d: { insert: unknown }) => d.insert instanceof Y.XmlElement);
+    expect(embeds.length).toBe(1);
+    expect((embeds[0].insert as Y.XmlElement).nodeName).toBe("hardBreak");
+
+    // The cloned embed must be a fresh instance — endText was deleted.
+    // Confirm fragment is now a single paragraph.
+    expect(fragment.length).toBe(1);
+  });
+
+  it("preserves combined marks (bold + italic) when merging across paragraphs", () => {
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+
+    const p1 = new Y.XmlElement("paragraph");
+    fragment.insert(0, [p1]);
+    const t1 = new Y.XmlText();
+    p1.insert(0, [t1]);
+    t1.insert(0, "Plain start");
+
+    const p2 = new Y.XmlElement("paragraph");
+    fragment.insert(1, [p2]);
+    const t2 = new Y.XmlText();
+    p2.insert(0, [t2]);
+    t2.insert(0, "fancy tail");
+    // Apply both bold and italic to the entire string
+    t2.format(0, 10, { bold: true, italic: true });
+
+    expect(extractText(doc)).toBe("Plain start\nfancy tail");
+
+    // Replace "n start\nfancy " (offsets 4..18) with " " — surviving suffix "tail" with both marks
+    const err = applyEdit(doc, 4, 18, " ");
+    expect(err).toBeNull();
+    expect(extractText(doc)).toBe("Plai tail");
+
+    const merged = fragment.get(0) as Y.XmlElement;
+    const mergedText = merged.get(0) as Y.XmlText;
+    const delta = mergedText.toDelta();
+
+    // Find the "tail" segment and verify it carries BOTH marks
+    const tailSeg = delta.find(
+      (d: { insert: unknown }) => typeof d.insert === "string" && d.insert.includes("tail"),
+    );
+    expect(tailSeg).toBeDefined();
+    expect(tailSeg?.attributes).toEqual({ bold: true, italic: true });
   });
 });
 

--- a/tests/server/integration.test.ts
+++ b/tests/server/integration.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
+import {
+  extractText,
+  getOrCreateXmlText,
+  mergeXmlText,
+  resolveOffset,
+} from "../../src/server/mcp/document.js";
 import { escapeRegex } from "../../src/server/mcp/response.js";
 import { makeDoc } from "../helpers/ydoc-factory.js";
 
@@ -49,18 +54,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boole
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remaining = endText.toDelta();
-      let mergeOffset = startPos.textOffset;
-      for (const seg of remaining) {
-        if (typeof seg.insert === "string") {
-          startText.insert(mergeOffset, seg.insert, seg.attributes);
-          mergeOffset += seg.insert.length;
-        } else {
-          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-          startText.insertEmbed(mergeOffset, embed, seg.attributes);
-          mergeOffset += 1;
-        }
-      }
+      mergeXmlText(startText, endText, startPos.textOffset);
       fragment.delete(startPos.elementIndex + 1, 1);
       startText.insert(startPos.textOffset, newText);
     });

--- a/tests/server/integration.test.ts
+++ b/tests/server/integration.test.ts
@@ -36,7 +36,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boole
     doc.transact(() => {
       const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
       const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.toString().length;
+      const startLen = startText.length;
       if (startPos.textOffset < startLen) {
         startText.delete(startPos.textOffset, startLen - startPos.textOffset);
       }
@@ -49,9 +49,17 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boole
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remainingText = endText.toString();
-      if (remainingText.length > 0) {
-        startText.insert(startPos.textOffset, remainingText);
+      const remaining = endText.toDelta();
+      let mergeOffset = startPos.textOffset;
+      for (const seg of remaining) {
+        if (typeof seg.insert === "string") {
+          startText.insert(mergeOffset, seg.insert, seg.attributes);
+          mergeOffset += seg.insert.length;
+        } else {
+          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+          startText.insertEmbed(mergeOffset, embed, seg.attributes);
+          mergeOffset += 1;
+        }
       }
       fragment.delete(startPos.elementIndex + 1, 1);
       startText.insert(startPos.textOffset, newText);


### PR DESCRIPTION
## Summary
- Replace `toString().length` with `xmlText.length` for correct CRDT index-space deletion bounds
- Replace `toString()` + `insert()` merge with `toDelta()` delta-walking that preserves inline formatting and embeds when merging remaining content across elements
- Fix the same pattern in 3 test file `applyEdit()` helpers and 1 authorship test

## Details
`Y.XmlText.toString()` includes XML markup tags (`<bold>text</bold>`), inflating string length beyond the CRDT index space used by `delete()`. The cross-element edit path used this inflated length for deletion bounds (over-deleting) and inserted the markup-laden string literally into the target element (corrupting formatting).

The delta-walking merge iterates `endText.toDelta()` segments, inserting each with its attributes preserved via `startText.insert(offset, text, attrs)` and `startText.insertEmbed(offset, embed, attrs)`.

Closes #425

## Test plan
- [ ] Cross-element edit on document with bold/italic formatting — verify no markup gibberish
- [ ] Cross-element edit spanning hardBreak embeds — verify line breaks preserved
- [ ] Single-element edits unaffected (different code path)
- [ ] `npm test` — all 1600 tests pass
- [ ] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)