### PR TITLE
fix(server): harden tandem_edit cross-element merge and doc invariants

### DIFF
--- a/src/server/file-io/docx-html.ts
+++ b/src/server/file-io/docx-html.ts
@@ -3,6 +3,7 @@
 import type { ChildNode, Element, Text } from "domhandler";
 import * as htmlparser2 from "htmlparser2";
 import * as Y from "yjs";
+import { NODE_NAMES } from "../mcp/document-model.js";
 
 /** All marks that can appear on inline text (superset of mdast-ydoc) */
 const ALL_MARKS = [
@@ -120,7 +121,7 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
     // Top-level text node — wrap in paragraph
     const text = node.data;
     if (!text.trim()) return [];
-    const el = new Y.XmlElement("paragraph");
+    const el = new Y.XmlElement(NODE_NAMES.PARAGRAPH);
     const xmlText = new Y.XmlText();
     el.insert(0, [xmlText]);
     deferred.push({ xmlText, children: [node], marks: {} });
@@ -134,7 +135,7 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
   // Heading
   const headingMatch = tag.match(/^h([1-6])$/);
   if (headingMatch) {
-    const el = new Y.XmlElement("heading");
+    const el = new Y.XmlElement(NODE_NAMES.HEADING);
     el.setAttribute("level", parseInt(headingMatch[1]) as any);
     const xmlText = new Y.XmlText();
     el.insert(0, [xmlText]);
@@ -144,7 +145,7 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
 
   switch (tag) {
     case "p": {
-      const el = new Y.XmlElement("paragraph");
+      const el = new Y.XmlElement(NODE_NAMES.PARAGRAPH);
       const xmlText = new Y.XmlText();
       el.insert(0, [xmlText]);
       deferred.push({ xmlText, children: node.children, marks: {} });
@@ -152,7 +153,7 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
     }
 
     case "blockquote": {
-      const el = new Y.XmlElement("blockquote");
+      const el = new Y.XmlElement(NODE_NAMES.BLOCKQUOTE);
       const blockChildren = collectBlockChildren(node.children, deferred);
       for (const child of blockChildren) {
         el.insert(el.length, [child]);
@@ -161,7 +162,7 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
     }
 
     case "ul": {
-      const el = new Y.XmlElement("bulletList");
+      const el = new Y.XmlElement(NODE_NAMES.BULLET_LIST);
       for (const child of node.children) {
         if (isElement(child) && child.tagName.toLowerCase() === "li") {
           el.insert(el.length, [buildListItem(child, deferred)]);
@@ -171,7 +172,7 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
     }
 
     case "ol": {
-      const el = new Y.XmlElement("orderedList");
+      const el = new Y.XmlElement(NODE_NAMES.ORDERED_LIST);
       const start = parseInt(node.attribs.start || "1");
       if (start !== 1) {
         el.setAttribute("start", start as any);
@@ -185,7 +186,7 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
     }
 
     case "table": {
-      const el = new Y.XmlElement("table");
+      const el = new Y.XmlElement(NODE_NAMES.TABLE);
       // Walk tbody/thead/tfoot or direct tr children
       const rows = collectTableRows(node);
       for (const row of rows) {
@@ -195,7 +196,7 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
     }
 
     case "pre": {
-      const el = new Y.XmlElement("codeBlock");
+      const el = new Y.XmlElement(NODE_NAMES.CODE_BLOCK);
       const xmlText = new Y.XmlText();
       el.insert(0, [xmlText]);
       // Collect all text content from pre (which may contain a <code> child)
@@ -204,7 +205,7 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
     }
 
     case "img": {
-      const el = new Y.XmlElement("image");
+      const el = new Y.XmlElement(NODE_NAMES.IMAGE);
       el.setAttribute("src", node.attribs.src || "");
       if (node.attribs.alt) el.setAttribute("alt", node.attribs.alt);
       if (node.attribs.title) el.setAttribute("title", node.attribs.title);
@@ -212,12 +213,12 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
     }
 
     case "hr": {
-      return [new Y.XmlElement("horizontalRule")];
+      return [new Y.XmlElement(NODE_NAMES.HORIZONTAL_RULE)];
     }
 
     case "br": {
       // Top-level <br> — produce an empty paragraph
-      const el = new Y.XmlElement("paragraph");
+      const el = new Y.XmlElement(NODE_NAMES.PARAGRAPH);
       el.insert(0, [new Y.XmlText("")]);
       return [el];
     }
@@ -242,7 +243,7 @@ function domNodeToYxml(node: ChildNode, deferred: DeferredText[]): Y.XmlElement[
         return results;
       }
       // Pure inline content — wrap in paragraph
-      const el = new Y.XmlElement("paragraph");
+      const el = new Y.XmlElement(NODE_NAMES.PARAGRAPH);
       const xmlText = new Y.XmlText();
       el.insert(0, [xmlText]);
       deferred.push({ xmlText, children: node.children, marks: {} });
@@ -268,7 +269,7 @@ function collectBlockChildren(children: ChildNode[], deferred: DeferredText[]): 
     // Only flush if there's non-whitespace content
     const hasContent = inlineBuffer.some((n) => (isText(n) ? n.data.trim().length > 0 : true));
     if (hasContent) {
-      const el = new Y.XmlElement("paragraph");
+      const el = new Y.XmlElement(NODE_NAMES.PARAGRAPH);
       const xmlText = new Y.XmlText();
       el.insert(0, [xmlText]);
       deferred.push({ xmlText, children: inlineBuffer, marks: {} });
@@ -289,7 +290,7 @@ function collectBlockChildren(children: ChildNode[], deferred: DeferredText[]): 
 
   // Ensure at least one paragraph (Tiptap requires content in block containers)
   if (result.length === 0) {
-    const el = new Y.XmlElement("paragraph");
+    const el = new Y.XmlElement(NODE_NAMES.PARAGRAPH);
     el.insert(0, [new Y.XmlText("")]);
     result.push(el);
   }
@@ -299,7 +300,7 @@ function collectBlockChildren(children: ChildNode[], deferred: DeferredText[]): 
 
 /** Build a listItem Y.XmlElement from an <li> DOM node */
 function buildListItem(li: Element, deferred: DeferredText[]): Y.XmlElement {
-  const listItem = new Y.XmlElement("listItem");
+  const listItem = new Y.XmlElement(NODE_NAMES.LIST_ITEM);
   const blockChildren = collectBlockChildren(li.children, deferred);
   for (const child of blockChildren) {
     listItem.insert(listItem.length, [child]);
@@ -328,12 +329,12 @@ function collectTableRows(table: Element): Element[] {
 
 /** Build a tableRow Y.XmlElement from a <tr> */
 function buildTableRow(tr: Element, deferred: DeferredText[]): Y.XmlElement {
-  const row = new Y.XmlElement("tableRow");
+  const row = new Y.XmlElement(NODE_NAMES.TABLE_ROW);
   for (const child of tr.children) {
     if (!isElement(child)) continue;
     const tag = child.tagName.toLowerCase();
     if (tag === "td" || tag === "th") {
-      const nodeName = tag === "th" ? "tableHeader" : "tableCell";
+      const nodeName = tag === "th" ? NODE_NAMES.TABLE_HEADER : NODE_NAMES.TABLE_CELL;
       const cell = new Y.XmlElement(nodeName);
 
       // Copy colspan/rowspan
@@ -380,7 +381,7 @@ function processInlineNodes(
 
     // Hard break
     if (tag === "br") {
-      const embed = new Y.XmlElement("hardBreak");
+      const embed = new Y.XmlElement(NODE_NAMES.HARD_BREAK);
       xmlText.insertEmbed(xmlText.length, embed);
       continue;
     }

--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -1,5 +1,6 @@
 import type { PhrasingContent, Root, RootContent } from "mdast";
 import * as Y from "yjs";
+import { NODE_NAMES } from "../mcp/document-model.js";
 
 /**
  * Convert an MDAST tree into Y.Doc XmlFragment elements.
@@ -48,7 +49,7 @@ function blockToYxml(
 ): Y.XmlElement[] {
   switch (node.type) {
     case "heading": {
-      const el = new Y.XmlElement("heading");
+      const el = new Y.XmlElement(NODE_NAMES.HEADING);
       el.setAttribute("level", node.depth as any);
       const text = new Y.XmlText();
       el.insert(0, [text]);
@@ -57,7 +58,7 @@ function blockToYxml(
     }
 
     case "paragraph": {
-      const el = new Y.XmlElement("paragraph");
+      const el = new Y.XmlElement(NODE_NAMES.PARAGRAPH);
       const text = new Y.XmlText();
       el.insert(0, [text]);
       deferred.push({ xmlText: text, nodes: node.children });
@@ -65,7 +66,7 @@ function blockToYxml(
     }
 
     case "blockquote": {
-      const el = new Y.XmlElement("blockquote");
+      const el = new Y.XmlElement(NODE_NAMES.BLOCKQUOTE);
       for (const child of node.children) {
         const childEls = blockToYxml(child, deferred);
         for (const c of childEls) {
@@ -76,13 +77,13 @@ function blockToYxml(
     }
 
     case "list": {
-      const nodeName = node.ordered ? "orderedList" : "bulletList";
+      const nodeName = node.ordered ? NODE_NAMES.ORDERED_LIST : NODE_NAMES.BULLET_LIST;
       const el = new Y.XmlElement(nodeName);
       if (node.ordered && node.start != null && node.start !== 1) {
         el.setAttribute("start", node.start as any);
       }
       for (const item of node.children) {
-        const listItem = new Y.XmlElement("listItem");
+        const listItem = new Y.XmlElement(NODE_NAMES.LIST_ITEM);
         for (const child of item.children) {
           const childEls = blockToYxml(child, deferred);
           for (const c of childEls) {
@@ -95,7 +96,7 @@ function blockToYxml(
     }
 
     case "code": {
-      const el = new Y.XmlElement("codeBlock");
+      const el = new Y.XmlElement(NODE_NAMES.CODE_BLOCK);
       if (node.lang) {
         el.setAttribute("language", node.lang);
       }
@@ -106,11 +107,11 @@ function blockToYxml(
     }
 
     case "thematicBreak": {
-      return [new Y.XmlElement("horizontalRule")];
+      return [new Y.XmlElement(NODE_NAMES.HORIZONTAL_RULE)];
     }
 
     case "image": {
-      const el = new Y.XmlElement("image");
+      const el = new Y.XmlElement(NODE_NAMES.IMAGE);
       el.setAttribute("src", node.url);
       if (node.alt) el.setAttribute("alt", node.alt);
       if (node.title) el.setAttribute("title", node.title);
@@ -120,7 +121,7 @@ function blockToYxml(
     // html blocks, definitions, etc. — wrap as paragraphs to avoid data loss
     default: {
       if ("value" in node && typeof node.value === "string") {
-        const el = new Y.XmlElement("paragraph");
+        const el = new Y.XmlElement(NODE_NAMES.PARAGRAPH);
         const text = new Y.XmlText();
         el.insert(0, [text]);
         deferred.push({ xmlText: text, plainText: node.value });
@@ -189,7 +190,7 @@ function processInline(
         break;
 
       case "break": {
-        const embed = new Y.XmlElement("hardBreak");
+        const embed = new Y.XmlElement(NODE_NAMES.HARD_BREAK);
         xmlText.insertEmbed(xmlText.length, embed);
         break;
       }
@@ -231,15 +232,15 @@ export function yDocToMdast(doc: Y.Doc): Root {
 /** Convert a Y.XmlElement back to an MDAST block node */
 function yxmlToMdast(el: Y.XmlElement): RootContent | null {
   switch (el.nodeName) {
-    case "heading": {
+    case NODE_NAMES.HEADING: {
       const depth = Number(el.getAttribute("level") ?? 1) as 1 | 2 | 3 | 4 | 5 | 6;
       return { type: "heading", depth, children: deltaToPhrasingContent(el) };
     }
 
-    case "paragraph":
+    case NODE_NAMES.PARAGRAPH:
       return { type: "paragraph", children: deltaToPhrasingContent(el) };
 
-    case "blockquote": {
+    case NODE_NAMES.BLOCKQUOTE: {
       const children: RootContent[] = [];
       for (let i = 0; i < el.length; i++) {
         const child = el.get(i);
@@ -252,14 +253,14 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
       return { type: "blockquote", children: children as any };
     }
 
-    case "bulletList":
-    case "orderedList": {
-      const ordered = el.nodeName === "orderedList";
+    case NODE_NAMES.BULLET_LIST:
+    case NODE_NAMES.ORDERED_LIST: {
+      const ordered = el.nodeName === NODE_NAMES.ORDERED_LIST;
       const start = ordered ? Number(el.getAttribute("start")) || 1 : undefined;
       const listItems: any[] = [];
       for (let i = 0; i < el.length; i++) {
         const child = el.get(i);
-        if (child instanceof Y.XmlElement && child.nodeName === "listItem") {
+        if (child instanceof Y.XmlElement && child.nodeName === NODE_NAMES.LIST_ITEM) {
           const itemChildren: any[] = [];
           for (let j = 0; j < child.length; j++) {
             const grandchild = child.get(j);
@@ -280,7 +281,7 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
       } as any;
     }
 
-    case "codeBlock": {
+    case NODE_NAMES.CODE_BLOCK: {
       const lang = el.getAttribute("language") as string | undefined;
       let value = "";
       for (let i = 0; i < el.length; i++) {
@@ -292,10 +293,10 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
       return { type: "code", lang: lang || null, value } as any;
     }
 
-    case "horizontalRule":
+    case NODE_NAMES.HORIZONTAL_RULE:
       return { type: "thematicBreak" };
 
-    case "image": {
+    case NODE_NAMES.IMAGE: {
       return {
         type: "image",
         url: (el.getAttribute("src") as string) || "",
@@ -339,7 +340,7 @@ function deltaToPhrasingContent(el: Y.XmlElement): PhrasingContent[] {
       for (const op of delta) {
         // Embedded elements (hardBreak, etc.)
         if (typeof op.insert !== "string") {
-          if (op.insert instanceof Y.XmlElement && op.insert.nodeName === "hardBreak") {
+          if (op.insert instanceof Y.XmlElement && op.insert.nodeName === NODE_NAMES.HARD_BREAK) {
             result.push({ type: "break" });
           }
           continue;
@@ -399,7 +400,7 @@ function deltaToPhrasingContent(el: Y.XmlElement): PhrasingContent[] {
       }
     } else if (child instanceof Y.XmlElement) {
       // Non-text child elements embedded in a block (shouldn't happen often)
-      if (child.nodeName === "hardBreak") {
+      if (child.nodeName === NODE_NAMES.HARD_BREAK) {
         result.push({ type: "break" });
       }
     }

--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -5,6 +5,8 @@ import {
   headingPrefix,
   headingPrefixLength as sharedHeadingPrefixLength,
 } from "../../shared/offsets.js";
+import type { ElementPosition } from "../../shared/positions/index.js";
+import { MCP_ORIGIN } from "../events/origins.js";
 import { saveMarkdown } from "../file-io/markdown.js";
 
 /**
@@ -58,7 +60,7 @@ export function populateYDoc(doc: Y.Doc, text: string): void {
   const lines = text.split("\n");
   for (const line of lines) {
     if (line === "") {
-      const empty = new Y.XmlElement("paragraph");
+      const empty = new Y.XmlElement(NODE_NAMES.PARAGRAPH);
       empty.insert(0, [new Y.XmlText("")]);
       fragment.insert(fragment.length, [empty]);
       continue;
@@ -67,19 +69,19 @@ export function populateYDoc(doc: Y.Doc, text: string): void {
     let element: Y.XmlElement;
 
     if (line.startsWith("### ")) {
-      element = new Y.XmlElement("heading");
+      element = new Y.XmlElement(NODE_NAMES.HEADING);
       element.setAttribute("level", 3 as any);
       element.insert(0, [new Y.XmlText(line.slice(4))]);
     } else if (line.startsWith("## ")) {
-      element = new Y.XmlElement("heading");
+      element = new Y.XmlElement(NODE_NAMES.HEADING);
       element.setAttribute("level", 2 as any);
       element.insert(0, [new Y.XmlText(line.slice(3))]);
     } else if (line.startsWith("# ")) {
-      element = new Y.XmlElement("heading");
+      element = new Y.XmlElement(NODE_NAMES.HEADING);
       element.setAttribute("level", 1 as any);
       element.insert(0, [new Y.XmlText(line.slice(2))]);
     } else {
-      element = new Y.XmlElement("paragraph");
+      element = new Y.XmlElement(NODE_NAMES.PARAGRAPH);
       element.insert(0, [new Y.XmlText(line)]);
     }
 
@@ -229,7 +231,7 @@ export function extractText(doc: Y.Doc): string {
     const node = fragment.get(i);
     if (node instanceof Y.XmlElement) {
       const text = getElementText(node);
-      if (node.nodeName === "heading") {
+      if (node.nodeName === NODE_NAMES.HEADING) {
         const level = Number(node.getAttribute("level") ?? 1);
         lines.push(headingPrefix(level) + text);
       } else {
@@ -254,7 +256,7 @@ export function extractMarkdown(doc: Y.Doc): string {
  * Delegates to shared headingPrefixLength for the actual math.
  */
 export function getHeadingPrefixLength(node: Y.XmlElement): number {
-  if (node.nodeName === "heading") {
+  if (node.nodeName === NODE_NAMES.HEADING) {
     const level = Number(node.getAttribute("level") ?? 1);
     return sharedHeadingPrefixLength(level);
   }
@@ -309,23 +311,48 @@ export function findXmlText(element: Y.XmlElement): Y.XmlText | null {
 }
 
 /**
- * Textblock element types that are allowed to have direct XmlText children.
- * Container nodes (bulletList, blockquote, orderedList, table, etc.) must NOT
- * have XmlText created on them — their children are other XmlElements.
+ * Tiptap node names used by the server. Single source of truth for nodeName
+ * predicate checks — constructor sites that pass these strings to
+ * `new Y.XmlElement(...)` may also reference these constants.
+ *
+ * Mirrors the Tiptap schema in src/server/file-io/{mdast-ydoc,docx-html}.ts
+ * and src/client/editor/Editor.tsx. Update here when adding nodes.
  */
-const TEXTBLOCK_NODES = new Set(["paragraph", "heading", "codeBlock"]);
+export const NODE_NAMES = {
+  // Textblocks — may have direct Y.XmlText children.
+  PARAGRAPH: "paragraph",
+  HEADING: "heading",
+  CODE_BLOCK: "codeBlock",
+  // Containers — children must be Y.XmlElement.
+  BLOCKQUOTE: "blockquote",
+  BULLET_LIST: "bulletList",
+  ORDERED_LIST: "orderedList",
+  LIST_ITEM: "listItem",
+  TABLE: "table",
+  TABLE_ROW: "tableRow",
+  TABLE_CELL: "tableCell",
+  TABLE_HEADER: "tableHeader",
+  // Embeds — live inside Y.XmlText, never as fragment children.
+  HARD_BREAK: "hardBreak",
+  IMAGE: "image",
+  HORIZONTAL_RULE: "horizontalRule",
+} as const;
 
 /**
- * Find the first Y.XmlText child of a Y.XmlElement.
- * Creates one if the element is empty.
- *
- * Defense-in-depth: throws on non-textblock elements (containers like
- * bulletList, blockquote, etc.) to prevent phantom XmlText corruption.
- * The primary guard is the pre-transaction check in tandem_edit — this
- * catch exists for any future code path that bypasses that guard.
+ * Textblock element names — only these may have direct Y.XmlText children.
+ */
+export const TEXTBLOCK_NODE_NAMES = new Set<string>([
+  NODE_NAMES.PARAGRAPH,
+  NODE_NAMES.HEADING,
+  NODE_NAMES.CODE_BLOCK,
+]);
+
+/**
+ * Returns the first Y.XmlText child, creating one if missing.
+ * Throws on non-textblock elements — containers must hold XmlElement children only.
  */
 export function getOrCreateXmlText(element: Y.XmlElement): Y.XmlText {
-  if (!TEXTBLOCK_NODES.has(element.nodeName)) {
+  if (!TEXTBLOCK_NODE_NAMES.has(element.nodeName)) {
     throw new Error(
       `Cannot create XmlText on "${element.nodeName}" — only textblock elements ` +
         `(paragraph, heading, codeBlock) should have direct XmlText children. ` +
@@ -340,4 +367,149 @@ export function getOrCreateXmlText(element: Y.XmlElement): Y.XmlText {
       return textNode;
     })()
   );
+}
+
+/**
+ * Soft cap on the number of CRDT nodes a single embed may carry. The merge
+ * loop in `applyTextEdit` clones embeds via `Y.AbstractType.clone()`, which
+ * recurses through children. A tampered Y.Doc with deeply-nested embeds
+ * could blow the stack or eat memory mid-clone.
+ */
+const MAX_EMBED_NODES = 1024;
+
+/**
+ * Walk a Y.Doc's default fragment and check that every fragment-child is a
+ * textblock (or a recognized container/embed) with the expected child shape.
+ * Returns a list of human-readable invariant violations — empty when sound.
+ *
+ * Used as a defensive sanity check after Hocuspocus loads a doc — catches
+ * tampered session files or malformed updates planted by a localhost client.
+ * Does NOT mutate the doc; callers decide whether to log, reject, or repair.
+ */
+export function validateDocStructure(doc: Y.Doc): string[] {
+  const errors: string[] = [];
+  const fragment = doc.getXmlFragment("default");
+  for (let i = 0; i < fragment.length; i++) {
+    const node = fragment.get(i);
+    if (!(node instanceof Y.XmlElement)) {
+      errors.push(`fragment[${i}]: expected XmlElement, got ${typeof node}`);
+      continue;
+    }
+    const isTextblock = TEXTBLOCK_NODE_NAMES.has(node.nodeName);
+    for (let j = 0; j < node.length; j++) {
+      const child = node.get(j);
+      if (child instanceof Y.XmlText && !isTextblock) {
+        errors.push(`fragment[${i}] "${node.nodeName}": holds XmlText but is not a textblock`);
+        break;
+      }
+    }
+  }
+  return errors;
+}
+
+/**
+ * Iteratively count the AbstractType nodes inside an embed (root + descendants).
+ * Returns early once the count exceeds `max`, so cost is bounded.
+ */
+function embedExceedsCap(root: Y.AbstractType<any>, max: number): boolean {
+  let count = 0;
+  const stack: Y.AbstractType<any>[] = [root];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    count++;
+    if (count > max) return true;
+    if (cur instanceof Y.XmlElement || cur instanceof Y.XmlFragment) {
+      for (let i = 0; i < cur.length; i++) {
+        const child = cur.get(i);
+        if (child instanceof Y.AbstractType) stack.push(child);
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Apply a text edit to a Y.Doc fragment. Caller must have already validated
+ * the range and resolved start/end positions; this function performs the CRDT
+ * mutations inside Y.Doc transactions tagged with `origin`.
+ *
+ * Atomicity: in the cross-element branch, both XmlText nodes are resolved
+ * (via getOrCreateXmlText, which may throw) AND embed sizes are validated
+ * BEFORE any destructive mutation. Yjs transactions do not roll back on
+ * throw — doing the throw-eligible work first is what keeps the doc whole.
+ */
+export function applyTextEdit(
+  doc: Y.Doc,
+  fragment: Y.XmlFragment,
+  startPos: ElementPosition,
+  endPos: ElementPosition,
+  newText: string,
+  origin: symbol | string = MCP_ORIGIN,
+): void {
+  if (startPos.elementIndex !== endPos.elementIndex) {
+    doc.transact(() => {
+      const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
+      const endNode = fragment.get(endPos.elementIndex) as Y.XmlElement;
+
+      // Resolve both XmlTexts FIRST. getOrCreateXmlText is the only operation
+      // here that can throw — keep it ahead of any mutation.
+      const startText = getOrCreateXmlText(startNode);
+      const endText = getOrCreateXmlText(endNode);
+
+      // Validate every embed in the soon-to-be-merged delta before mutating.
+      // Cap the recursion clone() will perform so a tampered doc cannot DoS.
+      const preDelta = endText.toDelta();
+      for (const seg of preDelta) {
+        if (seg.insert instanceof Y.AbstractType && embedExceedsCap(seg.insert, MAX_EMBED_NODES)) {
+          throw new Error(
+            `Embed at edit boundary exceeds clone-size cap (${MAX_EMBED_NODES} nodes).`,
+          );
+        }
+      }
+
+      const startLen = startText.length;
+      if (startPos.textOffset < startLen) {
+        startText.delete(startPos.textOffset, startLen - startPos.textOffset);
+      }
+      if (endPos.textOffset > 0) {
+        endText.delete(0, endPos.textOffset);
+      }
+
+      const remaining = endText.toDelta();
+      let mergeOffset = startPos.textOffset;
+      for (const seg of remaining) {
+        const attrs = seg.attributes ? { ...seg.attributes } : undefined;
+        if (typeof seg.insert === "string") {
+          if (attrs) startText.insert(mergeOffset, seg.insert, attrs);
+          else startText.insert(mergeOffset, seg.insert);
+          mergeOffset += seg.insert.length;
+        } else {
+          // Detach embeds before re-inserting. AbstractType covers
+          // Y.XmlElement (hardBreak in practice) plus Y.XmlText / Y.Map /
+          // Y.Array embed types a malicious update could plant.
+          const embed = seg.insert instanceof Y.AbstractType ? seg.insert.clone() : seg.insert;
+          if (attrs) startText.insertEmbed(mergeOffset, embed, attrs);
+          else startText.insertEmbed(mergeOffset, embed);
+          mergeOffset += 1;
+        }
+      }
+
+      const removeCount = endPos.elementIndex - startPos.elementIndex;
+      fragment.delete(startPos.elementIndex + 1, removeCount);
+
+      startText.insert(startPos.textOffset, newText);
+    }, origin);
+  } else {
+    doc.transact(() => {
+      const node = fragment.get(startPos.elementIndex) as Y.XmlElement;
+      const textNode = getOrCreateXmlText(node);
+      const deleteLen = endPos.textOffset - startPos.textOffset;
+      if (deleteLen > 0) {
+        textNode.delete(startPos.textOffset, deleteLen);
+      }
+      if (newText.length > 0) {
+        textNode.insert(startPos.textOffset, newText);
+      }
+    }, origin);
+  }
 }

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -20,7 +20,13 @@ import { saveSession } from "../session/manager.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
 import { convertToMarkdown } from "./convert.js";
 // Document model (pure logic)
-import { extractText, findXmlText, getElementText, getOrCreateXmlText } from "./document-model.js";
+import {
+  applyTextEdit,
+  extractText,
+  getElementText,
+  NODE_NAMES,
+  TEXTBLOCK_NODE_NAMES,
+} from "./document-model.js";
 // Document service (state management)
 import {
   broadcastOpenDocs,
@@ -66,6 +72,7 @@ export {
 export type { RangeVerifyResult } from "./document-model.js";
 // Re-export for backward compatibility with existing consumers.
 export {
+  applyTextEdit,
   collectXmlTexts,
   detectFormat,
   docIdFromPath,
@@ -113,7 +120,7 @@ export function getOutline(fragment: Y.XmlFragment): OutlineEntry[] {
   const outline: OutlineEntry[] = [];
   for (let i = 0; i < fragment.length; i++) {
     const node = fragment.get(i);
-    if (node instanceof Y.XmlElement && node.nodeName === "heading") {
+    if (node instanceof Y.XmlElement && node.nodeName === NODE_NAMES.HEADING) {
       const level = Number(node.getAttribute("level") ?? 1);
       outline.push({ level, text: getElementText(node), index: i });
     }
@@ -136,7 +143,7 @@ export function getSection(
 
     const text = getElementText(node);
 
-    if (node.nodeName === "heading") {
+    if (node.nodeName === NODE_NAMES.HEADING) {
       const level = Number(node.getAttribute("level") ?? 1);
       if (inSection && level <= sectionLevel) break;
       if (text.trim().toLowerCase() === sectionName.trim().toLowerCase()) {
@@ -148,7 +155,7 @@ export function getSection(
     }
 
     if (inSection) {
-      if (node.nodeName === "heading") {
+      if (node.nodeName === NODE_NAMES.HEADING) {
         const level = Number(node.getAttribute("level") ?? 1);
         lines.push(headingPrefix(level) + text);
       } else {
@@ -333,74 +340,27 @@ export function registerDocumentTools(server: McpServer): void {
           );
         }
 
-        // Guard: container elements (bulletList, blockquote, etc.) have no direct
-        // XmlText child — editing them would corrupt the CRDT structure.
+        // Guard: only textblock elements (paragraph, heading, codeBlock) may
+        // be edited. Containers and embeds reject here so the helper's
+        // defense-in-depth throw stays unreachable on the happy path.
         const startNode = fragment.get(startPos.elementIndex);
-        if (startNode instanceof Y.XmlElement && !findXmlText(startNode)) {
+        if (startNode instanceof Y.XmlElement && !TEXTBLOCK_NODE_NAMES.has(startNode.nodeName)) {
           return mcpError(
             "INVALID_RANGE",
-            `Target element is a container (${startNode.nodeName}) — edit a specific paragraph or list item instead.`,
+            `Target element "${startNode.nodeName}" is not a textblock — edit a specific paragraph, heading, or code block instead.`,
           );
         }
         if (startPos.elementIndex !== endPos.elementIndex) {
           const endNode = fragment.get(endPos.elementIndex);
-          if (endNode instanceof Y.XmlElement && !findXmlText(endNode)) {
+          if (endNode instanceof Y.XmlElement && !TEXTBLOCK_NODE_NAMES.has(endNode.nodeName)) {
             return mcpError(
               "INVALID_RANGE",
-              `Target end element is a container (${endNode.nodeName}) — edit a specific paragraph or list item instead.`,
+              `Target end element "${endNode.nodeName}" is not a textblock — edit a specific paragraph, heading, or code block instead.`,
             );
           }
         }
 
-        if (startPos.elementIndex !== endPos.elementIndex) {
-          r.doc.transact(() => {
-            const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
-            const startText = getOrCreateXmlText(startNode);
-            const startLen = startText.length;
-            if (startPos.textOffset < startLen) {
-              startText.delete(startPos.textOffset, startLen - startPos.textOffset);
-            }
-
-            const deleteCount = endPos.elementIndex - startPos.elementIndex - 1;
-            for (let i = 0; i < deleteCount; i++) {
-              fragment.delete(startPos.elementIndex + 1, 1);
-            }
-
-            const endNode = fragment.get(startPos.elementIndex + 1) as Y.XmlElement;
-            const endText = getOrCreateXmlText(endNode);
-            if (endPos.textOffset > 0) {
-              endText.delete(0, endPos.textOffset);
-            }
-            const remaining = endText.toDelta();
-            let mergeOffset = startPos.textOffset;
-            for (const seg of remaining) {
-              if (typeof seg.insert === "string") {
-                startText.insert(mergeOffset, seg.insert, seg.attributes || {});
-                mergeOffset += seg.insert.length;
-              } else {
-                // Embed (hardBreak, image, etc.) — clone to detach from endText
-                const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-                startText.insertEmbed(mergeOffset, embed, seg.attributes || {});
-                mergeOffset += 1;
-              }
-            }
-            fragment.delete(startPos.elementIndex + 1, 1);
-
-            startText.insert(startPos.textOffset, newText);
-          }, MCP_ORIGIN);
-        } else {
-          r.doc.transact(() => {
-            const node = fragment.get(startPos.elementIndex) as Y.XmlElement;
-            const textNode = getOrCreateXmlText(node);
-            const deleteLen = endPos.textOffset - startPos.textOffset;
-            if (deleteLen > 0) {
-              textNode.delete(startPos.textOffset, deleteLen);
-            }
-            if (newText.length > 0) {
-              textNode.insert(startPos.textOffset, newText);
-            }
-          }, MCP_ORIGIN);
-        }
+        applyTextEdit(r.doc, fragment, startPos, endPos, newText);
 
         // Record authorship for the inserted text (Y.Map overlay strategy).
         // This runs in a separate transaction because anchoredRange() reads the

--- a/src/server/yjs/provider.ts
+++ b/src/server/yjs/provider.ts
@@ -2,6 +2,7 @@ import { Hocuspocus } from "@hocuspocus/server";
 import * as Y from "yjs";
 
 import { TAURI_HOSTNAME } from "../../shared/constants.js";
+import { validateDocStructure } from "../mcp/document-model.js";
 
 let hocuspocusInstance: Hocuspocus | null = null;
 const documents = new Map<string, Y.Doc>();
@@ -105,6 +106,17 @@ export async function startHocuspocus(port: number): Promise<Hocuspocus> {
 
       // The Hocuspocus-provided doc is now the authoritative instance
       documents.set(documentName, document);
+
+      // Sanity-check structure after merge. Catches tampered session files
+      // or malformed updates planted by a localhost client. Log only —
+      // tandem_edit's own guards reject malformed nodes at edit time.
+      const violations = validateDocStructure(document);
+      if (violations.length > 0) {
+        console.error(
+          `[Tandem] WARN: doc-structure invariants violated in ${documentName}:`,
+          violations.slice(0, 10).join("; "),
+        );
+      }
 
       // Notify event queue to reattach observers to the new doc instance
       if (onDocSwapped) {

--- a/tests/server/authorship-edit-integration.test.ts
+++ b/tests/server/authorship-edit-integration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
+import { applyTextEdit, extractText, resolveOffset } from "../../src/server/mcp/document.js";
 import { anchoredRange } from "../../src/server/positions.js";
 import { Y_MAP_AUTHORSHIP } from "../../src/shared/constants.js";
 import { toFlatOffset } from "../../src/shared/positions/types.js";
@@ -35,52 +35,7 @@ function applyEditWithAuthorship(
     return "Edit range overlaps with heading markup.";
   }
 
-  // Apply the edit (same-element only for simplicity — cross-element tested elsewhere)
-  if (startPos.elementIndex !== endPos.elementIndex) {
-    doc.transact(() => {
-      const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
-      const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.length;
-      if (startPos.textOffset < startLen) {
-        startText.delete(startPos.textOffset, startLen - startPos.textOffset);
-      }
-      const deleteCount = endPos.elementIndex - startPos.elementIndex - 1;
-      for (let i = 0; i < deleteCount; i++) {
-        fragment.delete(startPos.elementIndex + 1, 1);
-      }
-      const endNode = fragment.get(startPos.elementIndex + 1) as Y.XmlElement;
-      const endText = getOrCreateXmlText(endNode);
-      if (endPos.textOffset > 0) {
-        endText.delete(0, endPos.textOffset);
-      }
-      const remaining = endText.toDelta();
-      let mergeOffset = startPos.textOffset;
-      for (const seg of remaining) {
-        if (typeof seg.insert === "string") {
-          startText.insert(mergeOffset, seg.insert, seg.attributes || {});
-          mergeOffset += seg.insert.length;
-        } else {
-          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-          startText.insertEmbed(mergeOffset, embed, seg.attributes || {});
-          mergeOffset += 1;
-        }
-      }
-      fragment.delete(startPos.elementIndex + 1, 1);
-      startText.insert(startPos.textOffset, newText);
-    }, MCP_ORIGIN);
-  } else {
-    doc.transact(() => {
-      const node = fragment.get(startPos.elementIndex) as Y.XmlElement;
-      const textNode = getOrCreateXmlText(node);
-      const deleteLen = endPos.textOffset - startPos.textOffset;
-      if (deleteLen > 0) {
-        textNode.delete(startPos.textOffset, deleteLen);
-      }
-      if (newText.length > 0) {
-        textNode.insert(startPos.textOffset, newText);
-      }
-    }, MCP_ORIGIN);
-  }
+  applyTextEdit(doc, fragment, startPos, endPos, newText, MCP_ORIGIN);
 
   // Record authorship — mirrors document.ts logic
   if (newText.length > 0) {

--- a/tests/server/document-edit.test.ts
+++ b/tests/server/document-edit.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
+import {
+  applyTextEdit,
+  extractText,
+  getOrCreateXmlText,
+  resolveOffset,
+} from "../../src/server/mcp/document.js";
+import { validateDocStructure } from "../../src/server/mcp/document-model.js";
 import { makeDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
@@ -10,8 +16,8 @@ afterEach(() => {
 });
 
 /**
- * Replicate tandem_edit logic for testing.
- * Returns null on success, or an error string on failure.
+ * Test wrapper around `applyTextEdit` — mirrors the validation surface of
+ * tandem_edit but returns the error message instead of an MCP response.
  */
 function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): string | null {
   if (from > to) return `Invalid range: from (${from}) must be <= to (${to}).`;
@@ -26,55 +32,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): strin
     return "Edit range overlaps with heading markup.";
   }
 
-  if (startPos.elementIndex !== endPos.elementIndex) {
-    doc.transact(() => {
-      const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
-      const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.length;
-      if (startPos.textOffset < startLen) {
-        startText.delete(startPos.textOffset, startLen - startPos.textOffset);
-      }
-
-      const deleteCount = endPos.elementIndex - startPos.elementIndex - 1;
-      for (let i = 0; i < deleteCount; i++) {
-        fragment.delete(startPos.elementIndex + 1, 1);
-      }
-
-      const endNode = fragment.get(startPos.elementIndex + 1) as Y.XmlElement;
-      const endText = getOrCreateXmlText(endNode);
-      if (endPos.textOffset > 0) {
-        endText.delete(0, endPos.textOffset);
-      }
-      const remaining = endText.toDelta();
-      let mergeOffset = startPos.textOffset;
-      for (const seg of remaining) {
-        if (typeof seg.insert === "string") {
-          startText.insert(mergeOffset, seg.insert, seg.attributes || {});
-          mergeOffset += seg.insert.length;
-        } else {
-          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-          startText.insertEmbed(mergeOffset, embed, seg.attributes || {});
-          mergeOffset += 1;
-        }
-      }
-      fragment.delete(startPos.elementIndex + 1, 1);
-
-      startText.insert(startPos.textOffset, newText);
-    });
-  } else {
-    doc.transact(() => {
-      const node = fragment.get(startPos.elementIndex) as Y.XmlElement;
-      const textNode = getOrCreateXmlText(node);
-      const deleteLen = endPos.textOffset - startPos.textOffset;
-      if (deleteLen > 0) {
-        textNode.delete(startPos.textOffset, deleteLen);
-      }
-      if (newText.length > 0) {
-        textNode.insert(startPos.textOffset, newText);
-      }
-    });
-  }
-
+  applyTextEdit(doc, fragment, startPos, endPos, newText);
   return null;
 }
 
@@ -225,6 +183,105 @@ describe("formatted cross-element edits (regression #425)", () => {
     expect(delta[1].insert).toBe("second");
     expect(delta[1].attributes).toEqual({ bold: true });
   });
+
+  it("drops endText entirely when endPos.textOffset === endText.length", () => {
+    // Cross-element edit where the end of the range lies at the end of endText.
+    // The merge loop should produce nothing from endText; only newText should
+    // land in startText. Locks in the boundary in any future delta-walk variant.
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+
+    const p1 = new Y.XmlElement("paragraph");
+    fragment.insert(0, [p1]);
+    const t1 = new Y.XmlText();
+    p1.insert(0, [t1]);
+    t1.insert(0, "alpha");
+
+    const p2 = new Y.XmlElement("paragraph");
+    fragment.insert(1, [p2]);
+    const t2 = new Y.XmlText();
+    p2.insert(0, [t2]);
+    t2.insert(0, "beta");
+
+    // text: "alpha\nbeta" — replace "ha\nbeta" (offsets 3..10) with "X"
+    const err = applyEdit(doc, 3, 10, "X");
+    expect(err).toBeNull();
+    expect(extractText(doc)).toBe("alpX");
+    expect(fragment.length).toBe(1);
+  });
+
+  it("rejects oversized embeds at the merge boundary", () => {
+    // Build a Y.XmlElement embed with > 1024 nested AbstractType children.
+    // applyTextEdit must reject the merge before mutating the doc.
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+
+    const p1 = new Y.XmlElement("paragraph");
+    fragment.insert(0, [p1]);
+    const t1 = new Y.XmlText();
+    p1.insert(0, [t1]);
+    t1.insert(0, "abc");
+
+    const p2 = new Y.XmlElement("paragraph");
+    fragment.insert(1, [p2]);
+    const t2 = new Y.XmlText();
+    p2.insert(0, [t2]);
+
+    // Build a Y.XmlElement with 1100 children — over the 1024 cap.
+    const oversized = new Y.XmlElement("hardBreak");
+    for (let i = 0; i < 1100; i++) {
+      oversized.insert(i, [new Y.XmlElement("hardBreak")]);
+    }
+    t2.insert(0, "y");
+    t2.insertEmbed(0, oversized);
+    // p2 = <oversized><br>y, length 2
+
+    // Edit [3, 4) — pulls everything from p2 into p1. The oversized embed
+    // would be at the start of remaining; cap should kick in.
+    const before = extractText(doc);
+    expect(() => applyEdit(doc, 3, 4, "X")).toThrow(/clone-size cap/);
+    // Doc state unchanged because the throw happens pre-mutation.
+    expect(extractText(doc)).toBe(before);
+  });
+
+  it("preserves a hardBreak embed at the merge boundary", () => {
+    // Cross-element edit that pulls part of p2 (including a hardBreak embed)
+    // into p1. Verifies the AbstractType.clone() detach path on the embed.
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+
+    const p1 = new Y.XmlElement("paragraph");
+    fragment.insert(0, [p1]);
+    const t1 = new Y.XmlText();
+    p1.insert(0, [t1]);
+    t1.insert(0, "abc");
+
+    const p2 = new Y.XmlElement("paragraph");
+    fragment.insert(1, [p2]);
+    const t2 = new Y.XmlText();
+    p2.insert(0, [t2]);
+    t2.insert(0, "x");
+    t2.insertEmbed(1, new Y.XmlElement("hardBreak"));
+    t2.insert(2, "y");
+    // p2 = "x<br>y", XmlText length 3
+
+    // Flat offsets: 0..2='abc', 3=sep, 4='x', 5=embed, 6='y'
+    // Edit [2, 5) → drops "c", sep, "x"; keeps the embed onward.
+    const err = applyEdit(doc, 2, 5, "Z");
+    expect(err).toBeNull();
+
+    expect(fragment.length).toBe(1);
+    const merged = fragment.get(0) as Y.XmlElement;
+    const mergedText = merged.get(0) as Y.XmlText;
+    const delta = mergedText.toDelta();
+
+    // Expected: "abZ" + hardBreak + "y"
+    expect(delta.length).toBe(3);
+    expect(delta[0].insert).toBe("abZ");
+    expect(delta[1].insert).toBeInstanceOf(Y.XmlElement);
+    expect((delta[1].insert as Y.XmlElement).nodeName).toBe("hardBreak");
+    expect(delta[2].insert).toBe("y");
+  });
 });
 
 describe("getOrCreateXmlText container guard", () => {
@@ -238,6 +295,12 @@ describe("getOrCreateXmlText container guard", () => {
       "tableCell",
       "tableHeader",
       "listItem",
+      // Embed-type names — these live inside XmlText, not as fragment children,
+      // so they cannot reach the guard via tandem_edit. Listed here so the test
+      // documents the full set of non-textblock node names rejected.
+      "image",
+      "horizontalRule",
+      "hardBreak",
     ];
     for (const name of containers) {
       const d = new Y.Doc();
@@ -280,6 +343,42 @@ describe("getOrCreateXmlText container guard", () => {
     fragment.insert(0, [codeBlock]);
 
     expect(() => getOrCreateXmlText(codeBlock)).not.toThrow();
+    d.destroy();
+  });
+});
+
+describe("validateDocStructure", () => {
+  it("returns no violations for a well-formed doc", () => {
+    const d = makeDoc("Hello\nWorld");
+    expect(validateDocStructure(d)).toEqual([]);
+    d.destroy();
+  });
+
+  it("flags a fragment-child container that holds an XmlText", () => {
+    const d = new Y.Doc();
+    const fragment = d.getXmlFragment("default");
+    const bad = new Y.XmlElement("bulletList");
+    fragment.insert(0, [bad]);
+    bad.insert(0, [new Y.XmlText("phantom")]);
+
+    const violations = validateDocStructure(d);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]).toMatch(/bulletList.*XmlText/);
+    d.destroy();
+  });
+
+  it("accepts containers whose children are XmlElements", () => {
+    const d = new Y.Doc();
+    const fragment = d.getXmlFragment("default");
+    const list = new Y.XmlElement("bulletList");
+    fragment.insert(0, [list]);
+    const item = new Y.XmlElement("listItem");
+    list.insert(0, [item]);
+    const para = new Y.XmlElement("paragraph");
+    item.insert(0, [para]);
+    para.insert(0, [new Y.XmlText("hi")]);
+
+    expect(validateDocStructure(d)).toEqual([]);
     d.destroy();
   });
 });

--- a/tests/server/integration.test.ts
+++ b/tests/server/integration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
+import { applyTextEdit, extractText, resolveOffset } from "../../src/server/mcp/document.js";
 import { escapeRegex } from "../../src/server/mcp/response.js";
 import { makeDoc } from "../helpers/ydoc-factory.js";
 
@@ -31,52 +31,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boole
   const endPos = resolveOffset(fragment, to);
   if (!startPos || !endPos) return false;
   if (startPos.clampedFromPrefix || endPos.clampedFromPrefix) return false;
-
-  if (startPos.elementIndex !== endPos.elementIndex) {
-    doc.transact(() => {
-      const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
-      const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.length;
-      if (startPos.textOffset < startLen) {
-        startText.delete(startPos.textOffset, startLen - startPos.textOffset);
-      }
-      const deleteCount = endPos.elementIndex - startPos.elementIndex - 1;
-      for (let i = 0; i < deleteCount; i++) {
-        fragment.delete(startPos.elementIndex + 1, 1);
-      }
-      const endNode = fragment.get(startPos.elementIndex + 1) as Y.XmlElement;
-      const endText = getOrCreateXmlText(endNode);
-      if (endPos.textOffset > 0) {
-        endText.delete(0, endPos.textOffset);
-      }
-      const remaining = endText.toDelta();
-      let mergeOffset = startPos.textOffset;
-      for (const seg of remaining) {
-        if (typeof seg.insert === "string") {
-          startText.insert(mergeOffset, seg.insert, seg.attributes || {});
-          mergeOffset += seg.insert.length;
-        } else {
-          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-          startText.insertEmbed(mergeOffset, embed, seg.attributes || {});
-          mergeOffset += 1;
-        }
-      }
-      fragment.delete(startPos.elementIndex + 1, 1);
-      startText.insert(startPos.textOffset, newText);
-    });
-  } else {
-    doc.transact(() => {
-      const node = fragment.get(startPos.elementIndex) as Y.XmlElement;
-      const textNode = getOrCreateXmlText(node);
-      const deleteLen = endPos.textOffset - startPos.textOffset;
-      if (deleteLen > 0) {
-        textNode.delete(startPos.textOffset, deleteLen);
-      }
-      if (newText.length > 0) {
-        textNode.insert(startPos.textOffset, newText);
-      }
-    });
-  }
+  applyTextEdit(doc, fragment, startPos, endPos, newText);
   return true;
 }
 


### PR DESCRIPTION
Layered on top of PR #453. Addresses the CRDT, security, and code-quality review findings on that branch, plus the three follow-up hardening items that were originally deferred.

## Why a separate PR

PR #453 is open as a draft. This branch is a self-contained set of fixes that can either be merged into `fix/426-phantom-xmltext-guard` (so #453 ships hardened) or rebased onto master if #453 lands first. All changes target only files touched by #453 plus two adjacent file-io modules updated by the NODE_NAMES extraction.

## Core fixes (the agreed plan)

- **Extract `applyTextEdit` helper** to `document-model.ts`. The MCP handler and all three test helpers route through it, killing the four-way duplication of the merge loop. Tests now exercise the production path instead of stale local copies.
- **Atomic-on-throw transaction.** Resolve both XmlText nodes (and validate embed sizes) BEFORE any destructive mutation. Yjs has no rollback on throw — doing the throw-eligible work first keeps the doc whole if a defense-in-depth check fires.
- **Broadened embed clone** from `instanceof Y.XmlElement` to `instanceof Y.AbstractType`. Non-XmlElement embed types planted by a malicious update are now detached, not re-parented by reference.
- **Search-marker fast path preserved** when `seg.attributes` is absent (skip the `|| {}`); shallow-clone attributes when present so Yjs's in-place mutation can't bleed across iterations.
- **Consolidated fragment delete.** Single `fragment.delete(startIndex + 1, removeCount)` after the merge, replacing the per-intermediate loop + trailing endNode delete.
- **Pre-guard aligned with allowlist.** `tandem_edit` now checks `TEXTBLOCK_NODE_NAMES.has(...)` instead of `!findXmlText(...)`, so the helper's defense-in-depth throw is genuinely unreachable on the happy path.
- **JSDoc on `getOrCreateXmlText` trimmed** per the project comment guidance (no caller references).
- **New regression tests:** `endPos.textOffset === endText.length` boundary, hardBreak embed at the merge boundary, oversized-embed rejection, and extended container guard coverage.

## Out-of-scope hardening (now included per follow-up request)

### `NODE_NAMES` constant
Single source of truth for Tiptap node-name strings. Replaces literal predicate checks and `new Y.XmlElement("...")` constructor arguments across `document-model`, `document`, `mdast-ydoc`, and `docx-html`. `TEXTBLOCK_NODE_NAMES` derives from this set.

### Embed-clone cap
`Y.AbstractType.clone()` recurses through children; a tampered Y.Doc with deeply-nested embeds could blow the stack mid-merge. The merge now rejects embeds with > 1024 AbstractType descendants before any mutation. The size check is iterative (worklist + early exit) so the check itself stays bounded.

### Doc-structure validator
`validateDocStructure(doc)` walks the default fragment and reports invariant violations (notably: containers holding `XmlText`). Hocuspocus's `onLoadDocument` calls it after merging pre-existing content and logs warnings. Catches tampered session files and malformed updates planted by a localhost client. Log-only — `tandem_edit`'s runtime guards remain the primary barrier.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1603 passed (only failure is `setup-route.test.ts`, pre-existing on master and unrelated)
- [x] Targeted suites green: `document-edit` (28), `integration` (6), `authorship-edit-integration` (1), `authorship-marks-size` (3)
- [x] New regression tests cover: cross-element bold preservation, end-boundary skip, hardBreak embed clone, oversized-embed rejection, doc-structure validator

## Files changed (8)

- `src/server/mcp/document-model.ts` — `NODE_NAMES`, `TEXTBLOCK_NODE_NAMES`, `applyTextEdit`, `validateDocStructure`, embed-clone cap
- `src/server/mcp/document.ts` — pre-guard alignment, `applyTextEdit` call site, NODE_NAMES heading checks
- `src/server/yjs/provider.ts` — `validateDocStructure` log call after `onLoadDocument`
- `src/server/file-io/mdast-ydoc.ts` — NODE_NAMES propagation
- `src/server/file-io/docx-html.ts` — NODE_NAMES propagation
- `tests/server/document-edit.test.ts` — 5 new tests, helper rewritten to call `applyTextEdit`
- `tests/server/integration.test.ts` — helper rewritten
- `tests/server/authorship-edit-integration.test.ts` — helper rewritten (authorship recording preserved inline)

https://claude.ai/code/session_014WBiDubzryNNLHTiKBYgxr

---
_Generated by [Claude Code](https://claude.ai/code/session_014WBiDubzryNNLHTiKBYgxr)_