### PR TITLE
fix(server): canonical Y.js length + delta-walking merge in cross-element edits

### DIFF
--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -308,11 +308,25 @@ export function findXmlText(element: Y.XmlElement): Y.XmlText | null {
   return null;
 }
 
+const TEXTBLOCK_NODES = new Set(["paragraph", "heading", "codeBlock"]);
+
 /**
  * Find the first Y.XmlText child of a Y.XmlElement.
  * Creates one if the element is empty.
+ *
+ * Throws if called on a container node (blockquote, bulletList, etc.) — only
+ * textblock elements (paragraph, heading, codeBlock) should have direct XmlText
+ * children. The pre-transaction guards in document.ts are the atomicity barrier;
+ * this throw is defense-in-depth only.
  */
 export function getOrCreateXmlText(element: Y.XmlElement): Y.XmlText {
+  if (!TEXTBLOCK_NODES.has(element.nodeName)) {
+    throw new Error(
+      `Cannot create XmlText on "${element.nodeName}" — only textblock elements ` +
+        `(paragraph, heading, codeBlock) should have direct XmlText children. ` +
+        `Edit a specific paragraph or list item instead.`,
+    );
+  }
   return (
     findXmlText(element) ??
     (() => {

--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -311,6 +311,25 @@ export function findXmlText(element: Y.XmlElement): Y.XmlText | null {
 const TEXTBLOCK_NODES = new Set(["paragraph", "heading", "codeBlock"]);
 
 /**
+ * Merge all delta segments from `source` into `target` at `offset`,
+ * preserving inline formatting and embeds. Passes `?? {}` for attributes
+ * to prevent Y.js formatting inheritance on plain text segments.
+ */
+export function mergeXmlTextDelta(target: Y.XmlText, source: Y.XmlText, offset: number): void {
+  let pos = offset;
+  for (const seg of source.toDelta()) {
+    if (typeof seg.insert === "string") {
+      target.insert(pos, seg.insert, seg.attributes ?? {});
+      pos += seg.insert.length;
+    } else {
+      const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+      target.insertEmbed(pos, embed, seg.attributes ?? {});
+      pos += 1;
+    }
+  }
+}
+
+/**
  * Find the first Y.XmlText child of a Y.XmlElement.
  * Creates one if the element is empty.
  *

--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -308,21 +308,23 @@ export function findXmlText(element: Y.XmlElement): Y.XmlText | null {
   return null;
 }
 
-const TEXTBLOCK_NODES = new Set(["paragraph", "heading", "codeBlock"]);
+export const TEXTBLOCK_NODES = new Set(["paragraph", "heading", "codeBlock"]);
 
 /**
  * Merge all delta segments from `source` into `target` at `offset`,
- * preserving inline formatting and embeds. Passes `?? {}` for attributes
- * to prevent Y.js formatting inheritance on plain text segments.
+ * preserving inline formatting and embeds. XmlElement embeds (hardBreak)
+ * are cloned to avoid moving attached nodes out of `source`.
  */
 export function mergeXmlTextDelta(target: Y.XmlText, source: Y.XmlText, offset: number): void {
   let pos = offset;
   for (const seg of source.toDelta()) {
+    // Pass {} (not undefined) — Y.js insert(pos, str, undefined) inherits
+    // formatting from the preceding character; insert(pos, str, {}) terminates it.
     if (typeof seg.insert === "string") {
       target.insert(pos, seg.insert, seg.attributes ?? {});
       pos += seg.insert.length;
     } else {
-      const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+      const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : { ...seg.insert };
       target.insertEmbed(pos, embed, seg.attributes ?? {});
       pos += 1;
     }
@@ -330,13 +332,8 @@ export function mergeXmlTextDelta(target: Y.XmlText, source: Y.XmlText, offset: 
 }
 
 /**
- * Find the first Y.XmlText child of a Y.XmlElement.
- * Creates one if the element is empty.
- *
- * Throws if called on a container node (blockquote, bulletList, etc.) — only
- * textblock elements (paragraph, heading, codeBlock) should have direct XmlText
- * children. The pre-transaction guards in document.ts are the atomicity barrier;
- * this throw is defense-in-depth only.
+ * Return the XmlText child of a textblock element, creating one if empty.
+ * Throws on non-textblock nodes (containers like blockquote, bulletList, etc.).
  */
 export function getOrCreateXmlText(element: Y.XmlElement): Y.XmlText {
   if (!TEXTBLOCK_NODES.has(element.nodeName)) {

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -356,7 +356,7 @@ export function registerDocumentTools(server: McpServer): void {
           r.doc.transact(() => {
             const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
             const startText = getOrCreateXmlText(startNode);
-            const startLen = startText.toString().length;
+            const startLen = startText.length;
             if (startPos.textOffset < startLen) {
               startText.delete(startPos.textOffset, startLen - startPos.textOffset);
             }
@@ -371,9 +371,17 @@ export function registerDocumentTools(server: McpServer): void {
             if (endPos.textOffset > 0) {
               endText.delete(0, endPos.textOffset);
             }
-            const remainingText = endText.toString();
-            if (remainingText.length > 0) {
-              startText.insert(startPos.textOffset, remainingText);
+            const remaining = endText.toDelta();
+            let mergeOffset = startPos.textOffset;
+            for (const seg of remaining) {
+              if (typeof seg.insert === "string") {
+                startText.insert(mergeOffset, seg.insert, seg.attributes ?? {});
+                mergeOffset += seg.insert.length;
+              } else {
+                const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+                startText.insertEmbed(mergeOffset, embed, seg.attributes ?? {});
+                mergeOffset += 1;
+              }
             }
             fragment.delete(startPos.elementIndex + 1, 1);
 

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -22,10 +22,10 @@ import { convertToMarkdown } from "./convert.js";
 // Document model (pure logic)
 import {
   extractText,
-  findXmlText,
   getElementText,
   getOrCreateXmlText,
   mergeXmlTextDelta,
+  TEXTBLOCK_NODES,
 } from "./document-model.js";
 // Document service (state management)
 import {
@@ -85,6 +85,7 @@ export {
   getOrCreateXmlText,
   mergeXmlTextDelta,
   populateYDoc,
+  TEXTBLOCK_NODES,
   verifyAndResolveRange,
 } from "./document-model.js";
 export type { OpenDoc } from "./document-service.js";
@@ -340,21 +341,22 @@ export function registerDocumentTools(server: McpServer): void {
           );
         }
 
-        // Guard: container elements (bulletList, blockquote, etc.) have no direct
-        // XmlText child — editing them would corrupt the CRDT structure.
+        // Guard: only textblock elements (paragraph, heading, codeBlock) may be
+        // edited. This must reject before the transaction to prevent partial-commit
+        // corruption — Y.js transactions don't roll back on throw.
         const startNode = fragment.get(startPos.elementIndex);
-        if (startNode instanceof Y.XmlElement && !findXmlText(startNode)) {
+        if (!(startNode instanceof Y.XmlElement) || !TEXTBLOCK_NODES.has(startNode.nodeName)) {
           return mcpError(
             "INVALID_RANGE",
-            `Target element is a container (${startNode.nodeName}) — edit a specific paragraph or list item instead.`,
+            `Target element is a container (${startNode instanceof Y.XmlElement ? startNode.nodeName : "unknown"}) — edit a specific paragraph or list item instead.`,
           );
         }
         if (startPos.elementIndex !== endPos.elementIndex) {
           const endNode = fragment.get(endPos.elementIndex);
-          if (endNode instanceof Y.XmlElement && !findXmlText(endNode)) {
+          if (!(endNode instanceof Y.XmlElement) || !TEXTBLOCK_NODES.has(endNode.nodeName)) {
             return mcpError(
               "INVALID_RANGE",
-              `Target end element is a container (${endNode.nodeName}) — edit a specific paragraph or list item instead.`,
+              `Target end element is a container (${endNode instanceof Y.XmlElement ? endNode.nodeName : "unknown"}) — edit a specific paragraph or list item instead.`,
             );
           }
         }

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -20,7 +20,13 @@ import { saveSession } from "../session/manager.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
 import { convertToMarkdown } from "./convert.js";
 // Document model (pure logic)
-import { extractText, findXmlText, getElementText, getOrCreateXmlText } from "./document-model.js";
+import {
+  extractText,
+  findXmlText,
+  getElementText,
+  getOrCreateXmlText,
+  mergeXmlTextDelta,
+} from "./document-model.js";
 // Document service (state management)
 import {
   broadcastOpenDocs,
@@ -77,6 +83,7 @@ export {
   getElementTextLength,
   getHeadingPrefixLength,
   getOrCreateXmlText,
+  mergeXmlTextDelta,
   populateYDoc,
   verifyAndResolveRange,
 } from "./document-model.js";
@@ -371,18 +378,7 @@ export function registerDocumentTools(server: McpServer): void {
             if (endPos.textOffset > 0) {
               endText.delete(0, endPos.textOffset);
             }
-            const remaining = endText.toDelta();
-            let mergeOffset = startPos.textOffset;
-            for (const seg of remaining) {
-              if (typeof seg.insert === "string") {
-                startText.insert(mergeOffset, seg.insert, seg.attributes ?? {});
-                mergeOffset += seg.insert.length;
-              } else {
-                const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-                startText.insertEmbed(mergeOffset, embed, seg.attributes ?? {});
-                mergeOffset += 1;
-              }
-            }
+            mergeXmlTextDelta(startText, endText, startPos.textOffset);
             fragment.delete(startPos.elementIndex + 1, 1);
 
             startText.insert(startPos.textOffset, newText);

--- a/tests/crdt/authorship-marks-size.test.ts
+++ b/tests/crdt/authorship-marks-size.test.ts
@@ -49,7 +49,7 @@ function applyContinuousMarks(doc: Y.Doc): void {
     for (let i = 0; i < fragment.length; i++) {
       const el = fragment.get(i) as Y.XmlElement;
       const textNode = el.get(0) as Y.XmlText;
-      const len = textNode.toString().length;
+      const len = textNode.length;
       const author = i % 2 === 0 ? "user" : "claude";
       textNode.format(0, len, { author });
     }
@@ -63,7 +63,7 @@ function applyFragmentedMarks(doc: Y.Doc): void {
     for (let i = 0; i < fragment.length; i++) {
       const el = fragment.get(i) as Y.XmlElement;
       const textNode = el.get(0) as Y.XmlText;
-      const len = textNode.toString().length;
+      const len = textNode.length;
       for (let offset = 0; offset < len; offset += 10) {
         const end = Math.min(offset + 10, len);
         const author = Math.floor(offset / 10) % 2 === 0 ? "user" : "claude";

--- a/tests/server/authorship-edit-integration.test.ts
+++ b/tests/server/authorship-edit-integration.test.ts
@@ -40,7 +40,7 @@ function applyEditWithAuthorship(
     doc.transact(() => {
       const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
       const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.toString().length;
+      const startLen = startText.length;
       if (startPos.textOffset < startLen) {
         startText.delete(startPos.textOffset, startLen - startPos.textOffset);
       }
@@ -53,9 +53,17 @@ function applyEditWithAuthorship(
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remainingText = endText.toString();
-      if (remainingText.length > 0) {
-        startText.insert(startPos.textOffset, remainingText);
+      const remaining = endText.toDelta();
+      let mergeOffset = startPos.textOffset;
+      for (const seg of remaining) {
+        if (typeof seg.insert === "string") {
+          startText.insert(mergeOffset, seg.insert, seg.attributes ?? {});
+          mergeOffset += seg.insert.length;
+        } else {
+          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+          startText.insertEmbed(mergeOffset, embed, seg.attributes ?? {});
+          mergeOffset += 1;
+        }
       }
       fragment.delete(startPos.elementIndex + 1, 1);
       startText.insert(startPos.textOffset, newText);

--- a/tests/server/authorship-edit-integration.test.ts
+++ b/tests/server/authorship-edit-integration.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
+import {
+  extractText,
+  getOrCreateXmlText,
+  mergeXmlTextDelta,
+  resolveOffset,
+} from "../../src/server/mcp/document.js";
 import { anchoredRange } from "../../src/server/positions.js";
 import { Y_MAP_AUTHORSHIP } from "../../src/shared/constants.js";
 import { toFlatOffset } from "../../src/shared/positions/types.js";
@@ -53,18 +58,7 @@ function applyEditWithAuthorship(
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remaining = endText.toDelta();
-      let mergeOffset = startPos.textOffset;
-      for (const seg of remaining) {
-        if (typeof seg.insert === "string") {
-          startText.insert(mergeOffset, seg.insert, seg.attributes ?? {});
-          mergeOffset += seg.insert.length;
-        } else {
-          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-          startText.insertEmbed(mergeOffset, embed, seg.attributes ?? {});
-          mergeOffset += 1;
-        }
-      }
+      mergeXmlTextDelta(startText, endText, startPos.textOffset);
       fragment.delete(startPos.elementIndex + 1, 1);
       startText.insert(startPos.textOffset, newText);
     }, MCP_ORIGIN);

--- a/tests/server/document-edit.test.ts
+++ b/tests/server/document-edit.test.ts
@@ -212,7 +212,7 @@ describe("cross-element edits with formatting", () => {
     });
 
     // "First line\nplain bold end"
-    // offset 6 = start of "line", offset 17 = after "plain " (11+6)
+    // offset 6 = start of "line", offset 17 = start of "bold" (11 + 6)
     const err = applyEdit(doc, 6, 17, " ");
     expect(err).toBeNull();
 
@@ -259,6 +259,109 @@ describe("cross-element edits with formatting", () => {
     const boldSeg = delta.find((d: any) => d.attributes?.bold === true);
     expect(boldSeg).toBeDefined();
     expect(boldSeg!.insert).toBe("bold");
+  });
+
+  it("correctly deletes from formatted start element (Bug A regression)", () => {
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    doc.transact(() => {
+      const p1 = new Y.XmlElement("paragraph");
+      fragment.insert(0, [p1]);
+      const t1 = new Y.XmlText();
+      p1.insert(0, [t1]);
+      t1.insert(0, "Hello world");
+      t1.format(0, 5, { bold: true });
+
+      const p2 = new Y.XmlElement("paragraph");
+      fragment.insert(1, [p2]);
+      const t2 = new Y.XmlText();
+      p2.insert(0, [t2]);
+      t2.insert(0, "Second");
+    });
+
+    // "Hello world\nSecond" — delete from offset 3 to 14 ("ond")
+    // startText = "Hello world" with bold on "Hello", startLen should be 11
+    // With toString().length it would be 24 (<bold>Hello</bold> world) → over-delete
+    const err = applyEdit(doc, 3, 15, "X");
+    expect(err).toBeNull();
+
+    const resultEl = fragment.get(0) as Y.XmlElement;
+    const resultText = resultEl.get(0) as Y.XmlText;
+    const delta = resultText.toDelta();
+
+    expect(extractText(doc)).toBe("HelXond");
+    const boldSeg = delta.find((d: any) => d.attributes?.bold === true);
+    expect(boldSeg).toBeDefined();
+    expect((boldSeg!.insert as string).startsWith("Hel")).toBe(true);
+  });
+
+  it("preserves hardBreak embed in cross-element merge", () => {
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    doc.transact(() => {
+      const p1 = new Y.XmlElement("paragraph");
+      fragment.insert(0, [p1]);
+      const t1 = new Y.XmlText();
+      p1.insert(0, [t1]);
+      t1.insert(0, "AAA");
+
+      const p2 = new Y.XmlElement("paragraph");
+      fragment.insert(1, [p2]);
+      const t2 = new Y.XmlText();
+      p2.insert(0, [t2]);
+      t2.insert(0, "before");
+      const br = new Y.XmlElement("hardBreak");
+      t2.insertEmbed(6, br);
+      t2.insert(7, "after");
+    });
+
+    // "AAA\nbefore[hardBreak]after" — delete from 3 to 4 (just the newline)
+    const err = applyEdit(doc, 3, 4, "");
+    expect(err).toBeNull();
+
+    const resultEl = fragment.get(0) as Y.XmlElement;
+    const resultText = resultEl.get(0) as Y.XmlText;
+    const delta = resultText.toDelta();
+
+    const embedSeg = delta.find((d: any) => typeof d.insert !== "string");
+    expect(embedSeg).toBeDefined();
+    const allText = delta
+      .filter((d: any) => typeof d.insert === "string")
+      .map((d: any) => d.insert)
+      .join("");
+    expect(allText).toContain("before");
+    expect(allText).toContain("after");
+  });
+
+  it("plain text after bold stays plain via ?? {} inheritance prevention", () => {
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    doc.transact(() => {
+      const p1 = new Y.XmlElement("paragraph");
+      fragment.insert(0, [p1]);
+      const t1 = new Y.XmlText();
+      p1.insert(0, [t1]);
+      t1.insert(0, "bold start");
+      t1.format(0, 10, { bold: true });
+
+      const p2 = new Y.XmlElement("paragraph");
+      fragment.insert(1, [p2]);
+      const t2 = new Y.XmlText();
+      p2.insert(0, [t2]);
+      t2.insert(0, "plain text");
+    });
+
+    // "bold start\nplain text" — delete from 5 to 11 (end of "start" + newline)
+    const err = applyEdit(doc, 5, 11, "");
+    expect(err).toBeNull();
+
+    const resultEl = fragment.get(0) as Y.XmlElement;
+    const resultText = resultEl.get(0) as Y.XmlText;
+    const delta = resultText.toDelta();
+
+    const plainSeg = delta.find((d: any) => d.insert === "plain text");
+    expect(plainSeg).toBeDefined();
+    expect(plainSeg!.attributes?.bold).toBeUndefined();
   });
 });
 

--- a/tests/server/document-edit.test.ts
+++ b/tests/server/document-edit.test.ts
@@ -30,7 +30,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): strin
     doc.transact(() => {
       const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
       const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.toString().length;
+      const startLen = startText.length;
       if (startPos.textOffset < startLen) {
         startText.delete(startPos.textOffset, startLen - startPos.textOffset);
       }
@@ -45,9 +45,17 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): strin
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remainingText = endText.toString();
-      if (remainingText.length > 0) {
-        startText.insert(startPos.textOffset, remainingText);
+      const remaining = endText.toDelta();
+      let mergeOffset = startPos.textOffset;
+      for (const seg of remaining) {
+        if (typeof seg.insert === "string") {
+          startText.insert(mergeOffset, seg.insert, seg.attributes ?? {});
+          mergeOffset += seg.insert.length;
+        } else {
+          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+          startText.insertEmbed(mergeOffset, embed, seg.attributes ?? {});
+          mergeOffset += 1;
+        }
       }
       fragment.delete(startPos.elementIndex + 1, 1);
 
@@ -188,4 +196,111 @@ describe("validation", () => {
     expect(err).toBeNull();
     expect(extractText(doc)).toBe("HelXYZlo");
   });
+});
+
+describe("cross-element edits with formatting", () => {
+  it("preserves bold formatting in merged text", () => {
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    doc.transact(() => {
+      const p1 = new Y.XmlElement("paragraph");
+      fragment.insert(0, [p1]);
+      const t1 = new Y.XmlText();
+      p1.insert(0, [t1]);
+      t1.insert(0, "First line");
+
+      const p2 = new Y.XmlElement("paragraph");
+      fragment.insert(1, [p2]);
+      const t2 = new Y.XmlText();
+      p2.insert(0, [t2]);
+      t2.insert(0, "plain bold end");
+      t2.format(6, 4, { bold: true });
+    });
+
+    // "First line\nplain bold end"
+    // offset 6 = start of "line", offset 17 = after "plain " (11+6)
+    const err = applyEdit(doc, 6, 17, " ");
+    expect(err).toBeNull();
+
+    const resultEl = fragment.get(0) as Y.XmlElement;
+    const resultText = resultEl.get(0) as Y.XmlText;
+    const delta = resultText.toDelta();
+
+    const boldSeg = delta.find((d: any) => d.attributes?.bold === true);
+    expect(boldSeg).toBeDefined();
+    expect(boldSeg!.insert).toBe("bold");
+  });
+
+  it("handles multi-segment delta with mixed formatting", () => {
+    doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    doc.transact(() => {
+      const p1 = new Y.XmlElement("paragraph");
+      fragment.insert(0, [p1]);
+      const t1 = new Y.XmlText();
+      p1.insert(0, [t1]);
+      t1.insert(0, "AAA");
+
+      const p2 = new Y.XmlElement("paragraph");
+      fragment.insert(1, [p2]);
+      const t2 = new Y.XmlText();
+      p2.insert(0, [t2]);
+      t2.insert(0, "normalitalicbold");
+      t2.format(6, 6, { italic: true });
+      t2.format(12, 4, { bold: true });
+    });
+
+    // "AAA\nnormalitalicbold" — delete from 3 to 10 ("normal" = 4..9)
+    const err = applyEdit(doc, 3, 10, "");
+    expect(err).toBeNull();
+
+    const resultEl = fragment.get(0) as Y.XmlElement;
+    const resultText = resultEl.get(0) as Y.XmlText;
+    const delta = resultText.toDelta();
+
+    const italicSeg = delta.find((d: any) => d.attributes?.italic === true);
+    expect(italicSeg).toBeDefined();
+    expect(italicSeg!.insert).toBe("italic");
+
+    const boldSeg = delta.find((d: any) => d.attributes?.bold === true);
+    expect(boldSeg).toBeDefined();
+    expect(boldSeg!.insert).toBe("bold");
+  });
+});
+
+describe("getOrCreateXmlText container guard", () => {
+  const containerTypes = [
+    "blockquote",
+    "bulletList",
+    "orderedList",
+    "table",
+    "tableRow",
+    "listItem",
+    "tableCell",
+    "tableHeader",
+  ];
+
+  for (const nodeType of containerTypes) {
+    it(`throws on container node: ${nodeType}`, () => {
+      const testDoc = new Y.Doc();
+      const frag = testDoc.getXmlFragment("default");
+      const el = new Y.XmlElement(nodeType);
+      frag.insert(0, [el]);
+      expect(() => getOrCreateXmlText(el)).toThrow("Cannot create XmlText");
+      testDoc.destroy();
+    });
+  }
+
+  const textblockTypes = ["paragraph", "heading", "codeBlock"];
+  for (const nodeType of textblockTypes) {
+    it(`succeeds on textblock node: ${nodeType}`, () => {
+      const testDoc = new Y.Doc();
+      const frag = testDoc.getXmlFragment("default");
+      const el = new Y.XmlElement(nodeType);
+      frag.insert(0, [el]);
+      const text = getOrCreateXmlText(el);
+      expect(text).toBeInstanceOf(Y.XmlText);
+      testDoc.destroy();
+    });
+  }
 });

--- a/tests/server/document-edit.test.ts
+++ b/tests/server/document-edit.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
+import {
+  extractText,
+  getOrCreateXmlText,
+  mergeXmlTextDelta,
+  resolveOffset,
+} from "../../src/server/mcp/document.js";
 import { makeDoc } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
@@ -45,18 +50,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): strin
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remaining = endText.toDelta();
-      let mergeOffset = startPos.textOffset;
-      for (const seg of remaining) {
-        if (typeof seg.insert === "string") {
-          startText.insert(mergeOffset, seg.insert, seg.attributes ?? {});
-          mergeOffset += seg.insert.length;
-        } else {
-          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-          startText.insertEmbed(mergeOffset, embed, seg.attributes ?? {});
-          mergeOffset += 1;
-        }
-      }
+      mergeXmlTextDelta(startText, endText, startPos.textOffset);
       fragment.delete(startPos.elementIndex + 1, 1);
 
       startText.insert(startPos.textOffset, newText);

--- a/tests/server/integration.test.ts
+++ b/tests/server/integration.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { extractText, getOrCreateXmlText, resolveOffset } from "../../src/server/mcp/document.js";
+import {
+  extractText,
+  getOrCreateXmlText,
+  mergeXmlTextDelta,
+  resolveOffset,
+} from "../../src/server/mcp/document.js";
 import { escapeRegex } from "../../src/server/mcp/response.js";
 import { makeDoc } from "../helpers/ydoc-factory.js";
 
@@ -49,18 +54,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boole
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remaining = endText.toDelta();
-      let mergeOffset = startPos.textOffset;
-      for (const seg of remaining) {
-        if (typeof seg.insert === "string") {
-          startText.insert(mergeOffset, seg.insert, seg.attributes ?? {});
-          mergeOffset += seg.insert.length;
-        } else {
-          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
-          startText.insertEmbed(mergeOffset, embed, seg.attributes ?? {});
-          mergeOffset += 1;
-        }
-      }
+      mergeXmlTextDelta(startText, endText, startPos.textOffset);
       fragment.delete(startPos.elementIndex + 1, 1);
       startText.insert(startPos.textOffset, newText);
     });

--- a/tests/server/integration.test.ts
+++ b/tests/server/integration.test.ts
@@ -36,7 +36,7 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boole
     doc.transact(() => {
       const startNode = fragment.get(startPos.elementIndex) as Y.XmlElement;
       const startText = getOrCreateXmlText(startNode);
-      const startLen = startText.toString().length;
+      const startLen = startText.length;
       if (startPos.textOffset < startLen) {
         startText.delete(startPos.textOffset, startLen - startPos.textOffset);
       }
@@ -49,9 +49,17 @@ function applyEdit(doc: Y.Doc, from: number, to: number, newText: string): boole
       if (endPos.textOffset > 0) {
         endText.delete(0, endPos.textOffset);
       }
-      const remainingText = endText.toString();
-      if (remainingText.length > 0) {
-        startText.insert(startPos.textOffset, remainingText);
+      const remaining = endText.toDelta();
+      let mergeOffset = startPos.textOffset;
+      for (const seg of remaining) {
+        if (typeof seg.insert === "string") {
+          startText.insert(mergeOffset, seg.insert, seg.attributes ?? {});
+          mergeOffset += seg.insert.length;
+        } else {
+          const embed = seg.insert instanceof Y.XmlElement ? seg.insert.clone() : seg.insert;
+          startText.insertEmbed(mergeOffset, embed, seg.attributes ?? {});
+          mergeOffset += 1;
+        }
       }
       fragment.delete(startPos.elementIndex + 1, 1);
       startText.insert(startPos.textOffset, newText);


### PR DESCRIPTION
## Summary

- **#425**: Replace `toString().length` with `Y.XmlText.length` (canonical CRDT index-space length) in the cross-element edit path. Replace `toString()` + `insert()` merge with `toDelta()` delta-walking that preserves inline formatting and embeds via `mergeXmlTextDelta()` helper.
- **#426**: Add `TEXTBLOCK_NODES` allowlist guard to `getOrCreateXmlText()` — throws on container nodes (blockquote, bulletList, orderedList, table, tableRow, listItem, tableCell, tableHeader) to prevent phantom XmlText creation. Pre-transaction guards in `tandem_edit` (lines 338–353) remain as the atomicity barrier since Y.js transactions don't roll back on throw.
- Use `?? {}` in attribute passthrough to prevent Y.js formatting inheritance on plain text segments.
- Extract `mergeXmlTextDelta()` helper to eliminate copy-paste across production code and 3 test files.
- New tests: bold formatting preservation, multi-segment delta with mixed formatting, container guard (8 container types + 3 textblock types).

Closes #425, closes #426

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1612 tests pass, 0 failures
- [x] New tests verify bold/italic preservation in cross-element merge
- [x] New tests verify `getOrCreateXmlText` throws on all 8 container types
- [x] New tests verify `getOrCreateXmlText` succeeds on all 3 textblock types
- [ ] Manual: cross-element edit on formatted text in browser preserves formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)