### PR TITLE
feat(client): add tabbed-left layout variant (#445)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -83,14 +83,15 @@ function ResizeHandle({ side, onMouseDown, testId }: ResizeHandleProps) {
 
 interface TabbedPanelContainerProps {
   width: number;
+  /** Which side of the viewport the panel sits on. Determines which edge gets the border. */
   borderSide: "left" | "right";
   showChat: boolean;
   pendingAnnotationBadge: number;
   onShowAnnotations: () => void;
   onShowChat: () => void;
   onChatMouseDown: () => void;
-  chatPanelProps: object;
-  sidePanelProps: object;
+  chatPanelProps: React.ComponentProps<typeof ChatSlot>;
+  sidePanelProps: React.ComponentProps<typeof SideSlot>;
 }
 
 function TabbedPanelContainer({
@@ -185,11 +186,8 @@ function TabbedPanelContainer({
         </button>
       </div>
       {/* Panel content — both panels stay mounted, toggle visibility via CSS */}
-      <ChatSlot {...(chatPanelProps as React.ComponentProps<typeof ChatSlot>)} visible={showChat} />
-      <SideSlot
-        {...(sidePanelProps as React.ComponentProps<typeof SideSlot>)}
-        visible={!showChat}
-      />
+      <ChatSlot {...chatPanelProps} visible={showChat} />
+      <SideSlot {...sidePanelProps} visible={!showChat} />
     </div>
   );
 }
@@ -609,7 +607,7 @@ export default function App() {
         <div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
           <TabbedPanelContainer
             width={panelLayout.left}
-            borderSide="right"
+            borderSide="left"
             showChat={showChat}
             pendingAnnotationBadge={pendingAnnotationBadge}
             onShowAnnotations={() => setShowChat(false)}
@@ -711,7 +709,7 @@ export default function App() {
           />
           <TabbedPanelContainer
             width={getRightWidth(panelLayout)}
-            borderSide="left"
+            borderSide="right"
             showChat={showChat}
             pendingAnnotationBadge={pendingAnnotationBadge}
             onShowAnnotations={() => setShowChat(false)}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,5 +1,5 @@
 import type { Editor as TiptapEditor } from "@tiptap/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isUploadPath } from "../shared/paths";
 import { toPmPos } from "../shared/positions/types";
 import type { CapturedAnchor } from "../shared/types";
@@ -41,6 +41,158 @@ import type { DocListEntry, OpenTab } from "./types";
 import { addRecentFile, loadRecentFiles, saveRecentFiles } from "./utils/recentFiles";
 
 export type { DocListEntry, OpenTab };
+
+// ---------------------------------------------------------------------------
+// Shared sub-components used by multiple layout arms
+// ---------------------------------------------------------------------------
+
+interface ResizeHandleProps {
+  side: "left" | "right";
+  onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void;
+  /** Override data-testid. Defaults to `{side}-panel-resize-handle`. */
+  testId?: string;
+}
+
+function ResizeHandle({ side, onMouseDown, testId }: ResizeHandleProps) {
+  const id = testId ?? `${side}-panel-resize-handle`;
+  const label = side === "left" ? "Resize left panel" : "Resize right panel";
+  return (
+    <div
+      data-testid={id}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      tabIndex={0}
+      onMouseDown={onMouseDown}
+      style={{
+        width: "4px",
+        cursor: "col-resize",
+        background: "transparent",
+        flexShrink: 0,
+        transition: "background 0.15s",
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLDivElement).style.background = "var(--tandem-border-strong)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLDivElement).style.background = "transparent";
+      }}
+    />
+  );
+}
+
+interface TabbedPanelContainerProps {
+  width: number;
+  borderSide: "left" | "right";
+  showChat: boolean;
+  pendingAnnotationBadge: number;
+  onShowAnnotations: () => void;
+  onShowChat: () => void;
+  onChatMouseDown: () => void;
+  chatPanelProps: object;
+  sidePanelProps: object;
+}
+
+function TabbedPanelContainer({
+  width,
+  borderSide,
+  showChat,
+  pendingAnnotationBadge,
+  onShowAnnotations,
+  onShowChat,
+  onChatMouseDown,
+  chatPanelProps,
+  sidePanelProps,
+}: TabbedPanelContainerProps) {
+  const borderStyle =
+    borderSide === "left"
+      ? { borderRight: "1px solid var(--tandem-border)" }
+      : { borderLeft: "1px solid var(--tandem-border)" };
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: `${width}px`,
+        ...borderStyle,
+      }}
+    >
+      {/* Panel toggle tabs */}
+      <div
+        style={{
+          display: "flex",
+          borderBottom: "1px solid var(--tandem-border)",
+          background: "var(--tandem-surface-muted)",
+        }}
+      >
+        <button
+          data-testid="annotations-tab"
+          onClick={onShowAnnotations}
+          style={{
+            flex: 1,
+            padding: "8px",
+            fontSize: "12px",
+            fontWeight: showChat ? 400 : 600,
+            border: "none",
+            borderBottom: showChat ? "none" : "2px solid var(--tandem-accent)",
+            background: "transparent",
+            cursor: "pointer",
+            color: showChat ? "var(--tandem-fg-muted)" : "var(--tandem-accent)",
+            position: "relative",
+          }}
+        >
+          Annotations
+          {showChat && pendingAnnotationBadge > 0 && (
+            <span
+              style={{
+                position: "absolute",
+                top: "2px",
+                right: "6px",
+                background: "var(--tandem-error)",
+                color: "var(--tandem-error-fg)",
+                fontSize: "9px",
+                width: "16px",
+                height: "16px",
+                borderRadius: "50%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontWeight: 700,
+              }}
+            >
+              {pendingAnnotationBadge > 9 ? "9+" : pendingAnnotationBadge}
+            </span>
+          )}
+        </button>
+        <button
+          data-testid="chat-tab"
+          onMouseDown={onChatMouseDown}
+          onClick={onShowChat}
+          style={{
+            flex: 1,
+            padding: "8px",
+            fontSize: "12px",
+            fontWeight: showChat ? 600 : 400,
+            border: "none",
+            borderBottom: showChat ? "2px solid var(--tandem-accent)" : "none",
+            background: "transparent",
+            cursor: "pointer",
+            color: showChat ? "var(--tandem-accent)" : "var(--tandem-fg-muted)",
+            position: "relative",
+          }}
+        >
+          Chat
+        </button>
+      </div>
+      {/* Panel content — both panels stay mounted, toggle visibility via CSS */}
+      <ChatSlot {...(chatPanelProps as React.ComponentProps<typeof ChatSlot>)} visible={showChat} />
+      <SideSlot
+        {...(sidePanelProps as React.ComponentProps<typeof SideSlot>)}
+        visible={!showChat}
+      />
+    </div>
+  );
+}
 
 export default function App() {
   useWebViewZoom();
@@ -377,27 +529,7 @@ export default function App() {
             </div>
           </div>
           {/* Left resize handle */}
-          <div
-            data-testid="left-panel-resize-handle"
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize left panel"
-            tabIndex={0}
-            onMouseDown={(e) => handleResizeStart(e, "left")}
-            style={{
-              width: "4px",
-              cursor: "col-resize",
-              background: "transparent",
-              flexShrink: 0,
-              transition: "background 0.15s",
-            }}
-            onMouseEnter={(e) => {
-              (e.currentTarget as HTMLDivElement).style.background = "var(--tandem-border-strong)";
-            }}
-            onMouseLeave={(e) => {
-              (e.currentTarget as HTMLDivElement).style.background = "transparent";
-            }}
-          />
+          <ResizeHandle side="left" onMouseDown={(e) => handleResizeStart(e, "left")} />
           {/* Editor (center) */}
           <div
             style={{
@@ -439,27 +571,7 @@ export default function App() {
             </div>
           </div>
           {/* Right resize handle */}
-          <div
-            data-testid="right-panel-resize-handle"
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize right panel"
-            tabIndex={0}
-            onMouseDown={(e) => handleResizeStart(e, "right")}
-            style={{
-              width: "4px",
-              cursor: "col-resize",
-              background: "transparent",
-              flexShrink: 0,
-              transition: "background 0.15s",
-            }}
-            onMouseEnter={(e) => {
-              (e.currentTarget as HTMLDivElement).style.background = "var(--tandem-border-strong)";
-            }}
-            onMouseLeave={(e) => {
-              (e.currentTarget as HTMLDivElement).style.background = "transparent";
-            }}
-          />
+          <ResizeHandle side="right" onMouseDown={(e) => handleResizeStart(e, "right")} />
           {/* Right panel */}
           <div
             style={{
@@ -488,6 +600,63 @@ export default function App() {
                 <SideSlot {...sidePanelProps} />
               ) : (
                 <ChatSlot {...chatPanelProps} visible={true} />
+              )}
+            </div>
+          </div>
+        </div>
+      ) : panelLayout.kind === "tabbed-left" ? (
+        /* ── Tabbed-Left layout: Panel+Tabs | Editor ── */
+        <div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
+          <TabbedPanelContainer
+            width={panelLayout.left}
+            borderSide="right"
+            showChat={showChat}
+            pendingAnnotationBadge={pendingAnnotationBadge}
+            onShowAnnotations={() => setShowChat(false)}
+            onShowChat={() => setShowChat(true)}
+            onChatMouseDown={captureSelectionForChat}
+            chatPanelProps={chatPanelProps}
+            sidePanelProps={sidePanelProps}
+          />
+          {/* Left resize handle (right edge of left panel) */}
+          <ResizeHandle side="left" onMouseDown={(e) => handleResizeStart(e, "left")} />
+          {/* Editor */}
+          <div
+            style={{
+              flex: 1,
+              overflow: "auto",
+              padding: "24px 48px",
+              border: fileDragOver ? "2px dashed var(--tandem-accent)" : "2px solid transparent",
+              background: fileDragOver ? "var(--tandem-accent-bg)" : undefined,
+              transition: "border-color 0.15s, background 0.15s",
+            }}
+            onDragOver={handleEditorDragOver}
+            onDragLeave={handleEditorDragLeave}
+            onDrop={handleEditorDrop}
+          >
+            <ReviewOnlyBanner
+              visible={activeTab?.readOnly === true && activeTab?.format === "docx"}
+              documentId={activeTab?.id}
+            />
+            <div
+              style={{
+                maxWidth: editorMaxWidth,
+                margin: editorMargin,
+              }}
+            >
+              {activeTab ? (
+                <Editor
+                  key={activeTab.id}
+                  ydoc={activeTab.ydoc}
+                  provider={activeTab.provider}
+                  readOnly={readOnly}
+                  reviewMode={reviewMode}
+                  activeAnnotationId={activeAnnotationId}
+                  onEditorReady={handleEditorReady}
+                  onAnnotationClick={handleAnnotationClick}
+                />
+              ) : (
+                <EmptyState connected={connected} claudeActive={claudeActive} />
               )}
             </div>
           </div>
@@ -534,107 +703,23 @@ export default function App() {
               )}
             </div>
           </div>
-          {/* Resize handle */}
-          <div
-            data-testid="panel-resize-handle"
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize panel"
-            tabIndex={0}
+          {/* Resize handle — testid preserved for E2E compatibility */}
+          <ResizeHandle
+            side="right"
             onMouseDown={(e) => handleResizeStart(e, "right")}
-            style={{
-              width: "4px",
-              cursor: "col-resize",
-              background: "transparent",
-              flexShrink: 0,
-              transition: "background 0.15s",
-            }}
-            onMouseEnter={(e) => {
-              (e.currentTarget as HTMLDivElement).style.background = "var(--tandem-border-strong)";
-            }}
-            onMouseLeave={(e) => {
-              (e.currentTarget as HTMLDivElement).style.background = "transparent";
-            }}
+            testId="panel-resize-handle"
           />
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              width: `${getRightWidth(panelLayout)}px`,
-              borderLeft: "1px solid var(--tandem-border)",
-            }}
-          >
-            {/* Panel toggle tabs */}
-            <div
-              style={{
-                display: "flex",
-                borderBottom: "1px solid var(--tandem-border)",
-                background: "var(--tandem-surface-muted)",
-              }}
-            >
-              <button
-                data-testid="annotations-tab"
-                onClick={() => setShowChat(false)}
-                style={{
-                  flex: 1,
-                  padding: "8px",
-                  fontSize: "12px",
-                  fontWeight: showChat ? 400 : 600,
-                  border: "none",
-                  borderBottom: showChat ? "none" : "2px solid var(--tandem-accent)",
-                  background: "transparent",
-                  cursor: "pointer",
-                  color: showChat ? "var(--tandem-fg-muted)" : "var(--tandem-accent)",
-                  position: "relative",
-                }}
-              >
-                Annotations
-                {showChat && pendingAnnotationBadge > 0 && (
-                  <span
-                    style={{
-                      position: "absolute",
-                      top: "2px",
-                      right: "6px",
-                      background: "var(--tandem-error)",
-                      color: "var(--tandem-error-fg)",
-                      fontSize: "9px",
-                      width: "16px",
-                      height: "16px",
-                      borderRadius: "50%",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      fontWeight: 700,
-                    }}
-                  >
-                    {pendingAnnotationBadge > 9 ? "9+" : pendingAnnotationBadge}
-                  </span>
-                )}
-              </button>
-              <button
-                data-testid="chat-tab"
-                onMouseDown={captureSelectionForChat}
-                onClick={() => setShowChat(true)}
-                style={{
-                  flex: 1,
-                  padding: "8px",
-                  fontSize: "12px",
-                  fontWeight: showChat ? 600 : 400,
-                  border: "none",
-                  borderBottom: showChat ? "2px solid var(--tandem-accent)" : "none",
-                  background: "transparent",
-                  cursor: "pointer",
-                  color: showChat ? "var(--tandem-accent)" : "var(--tandem-fg-muted)",
-                  position: "relative",
-                }}
-              >
-                Chat
-              </button>
-            </div>
-            {/* Panel content — both panels stay mounted, toggle visibility via CSS */}
-            <ChatSlot {...chatPanelProps} visible={showChat} />
-            <SideSlot {...sidePanelProps} visible={!showChat} />
-          </div>
+          <TabbedPanelContainer
+            width={getRightWidth(panelLayout)}
+            borderSide="left"
+            showChat={showChat}
+            pendingAnnotationBadge={pendingAnnotationBadge}
+            onShowAnnotations={() => setShowChat(false)}
+            onShowChat={() => setShowChat(true)}
+            onChatMouseDown={captureSelectionForChat}
+            chatPanelProps={chatPanelProps}
+            sidePanelProps={sidePanelProps}
+          />
         </div>
       )}
       <StatusBar

--- a/src/client/components/AppearanceSettings.tsx
+++ b/src/client/components/AppearanceSettings.tsx
@@ -16,6 +16,12 @@ interface AppearanceSettingsProps {
   onUpdate: (partial: Partial<TandemSettings>) => void;
 }
 
+const LAYOUT_OPTIONS: Array<{ value: LayoutMode; label: string; icon: string }> = [
+  { value: "tabbed", label: "Tabbed", icon: "[=|]" },
+  { value: "tabbed-left", label: "Tabbed-Left", icon: "[|=]" },
+  { value: "three-panel", label: "Three-Panel", icon: "[|||]" },
+];
+
 function cardStyle(selected: boolean, disabled?: boolean): React.CSSProperties {
   return {
     flex: 1,
@@ -53,7 +59,7 @@ export function AppearanceSettings({ open, settings, onUpdate }: AppearanceSetti
   );
   const layoutRg = useRadioGroup<LayoutMode>(
     settings.layout,
-    ["tabbed", "three-panel"] as const,
+    ["tabbed", "tabbed-left", "three-panel"] as const,
     (l) => onUpdate({ layout: l }),
     (l) => l === "three-panel" && threePanelDisabled,
   );
@@ -118,34 +124,29 @@ export function AppearanceSettings({ open, settings, onUpdate }: AppearanceSetti
           role="radiogroup"
           aria-labelledby="settings-layout-label"
           onKeyDown={layoutRg.handleKeyDown}
-          style={{ display: "flex", gap: "8px" }}
+          style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}
         >
-          <button
-            data-testid="layout-tabbed-btn"
-            role="radio"
-            aria-checked={settings.layout === "tabbed"}
-            tabIndex={layoutRg.tabIndexFor("tabbed")}
-            onClick={() => onUpdate({ layout: "tabbed" })}
-            style={cardStyle(settings.layout === "tabbed")}
-          >
-            <div style={{ fontSize: "18px", marginBottom: "2px" }}>{"[=|]"}</div>
-            Tabbed
-          </button>
-          <button
-            data-testid="layout-three-panel-btn"
-            role="radio"
-            aria-checked={settings.layout === "three-panel"}
-            aria-disabled={threePanelDisabled || undefined}
-            tabIndex={layoutRg.tabIndexFor("three-panel")}
-            onClick={() => {
-              if (!threePanelDisabled) onUpdate({ layout: "three-panel" });
-            }}
-            style={cardStyle(settings.layout === "three-panel", threePanelDisabled)}
-            title={threePanelDisabled ? "Requires viewport wider than 768px" : undefined}
-          >
-            <div style={{ fontSize: "18px", marginBottom: "2px" }}>{"[|||]"}</div>
-            Three-Panel
-          </button>
+          {LAYOUT_OPTIONS.map(({ value, label, icon }) => {
+            const disabled = value === "three-panel" && threePanelDisabled;
+            return (
+              <button
+                key={value}
+                data-testid={`layout-${value}-btn`}
+                role="radio"
+                aria-checked={settings.layout === value}
+                aria-disabled={disabled || undefined}
+                tabIndex={layoutRg.tabIndexFor(value)}
+                onClick={() => {
+                  if (!disabled) onUpdate({ layout: value });
+                }}
+                style={cardStyle(settings.layout === value, disabled)}
+                title={disabled ? "Requires viewport wider than 768px" : undefined}
+              >
+                <div style={{ fontSize: "18px", marginBottom: "2px" }}>{icon}</div>
+                {label}
+              </button>
+            );
+          })}
         </div>
         {threePanelDisabled && (
           <div style={{ fontSize: "10px", color: "var(--tandem-fg-subtle)", marginTop: "4px" }}>
@@ -154,8 +155,8 @@ export function AppearanceSettings({ open, settings, onUpdate }: AppearanceSetti
         )}
       </div>
 
-      {/* Primary tab (tabbed mode only) */}
-      {settings.layout === "tabbed" && (
+      {/* Default tab (tabbed and tabbed-left modes) */}
+      {(settings.layout === "tabbed" || settings.layout === "tabbed-left") && (
         <div>
           <div id="settings-default-tab-label" style={sectionLabelStyle}>
             Default Tab

--- a/src/client/hooks/useDragResize.ts
+++ b/src/client/hooks/useDragResize.ts
@@ -84,9 +84,9 @@ export function useDragResize({
         latestWidth = Math.max(PANEL_MIN_WIDTH, Math.min(PANEL_MAX_WIDTH, next));
         setPanelLayout((prev) => {
           if (side === "right") {
-            return prev.kind === "three-panel"
-              ? { ...prev, right: latestWidth }
-              : { kind: "tabbed", right: latestWidth };
+            if (prev.kind === "three-panel") return { ...prev, right: latestWidth };
+            if (prev.kind === "tabbed") return { kind: "tabbed", right: latestWidth };
+            return prev; // tabbed-left has no right handle
           }
           if (prev.kind === "three-panel") return { ...prev, left: latestWidth };
           if (prev.kind === "tabbed-left") return { ...prev, left: latestWidth };
@@ -100,10 +100,15 @@ export function useDragResize({
         dragListenersRef.current = null;
         document.body.style.userSelect = "";
         document.body.style.cursor = "";
-        try {
-          localStorage.setItem(storageKey, String(latestWidth));
-        } catch (err) {
-          console.warn(`[tandem] failed to persist ${storageKey}:`, err);
+        const current = panelLayoutRef.current;
+        const shouldPersist =
+          (side === "left" && "left" in current) || (side === "right" && "right" in current);
+        if (shouldPersist) {
+          try {
+            localStorage.setItem(storageKey, String(latestWidth));
+          } catch (err) {
+            console.warn(`[tandem] failed to persist ${storageKey}:`, err);
+          }
         }
       };
 

--- a/tests/client/panel-layout.test.ts
+++ b/tests/client/panel-layout.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   getRightWidth,
   PANEL_DEFAULT_WIDTH,
+  PANEL_MAX_WIDTH,
+  PANEL_MIN_WIDTH,
   type PanelLayout,
 } from "../../src/client/panel-layout.js";
 
@@ -19,5 +21,23 @@ describe("getRightWidth", () => {
   it("returns PANEL_DEFAULT_WIDTH for tabbed-left layout", () => {
     const layout: PanelLayout = { kind: "tabbed-left", left: 250 };
     expect(getRightWidth(layout)).toBe(PANEL_DEFAULT_WIDTH);
+  });
+});
+
+describe("tabbed-left layout variant", () => {
+  it("only carries a left width (no right property)", () => {
+    const layout: PanelLayout = { kind: "tabbed-left", left: 320 };
+    expect(layout.kind).toBe("tabbed-left");
+    expect("left" in layout).toBe(true);
+    expect("right" in layout).toBe(false);
+  });
+
+  it("PANEL_MIN_WIDTH and PANEL_MAX_WIDTH bound left panel width", () => {
+    // These bounds are enforced by loadPanelWidth — verify the constants are
+    // sane so the clamping contract is testable without localStorage.
+    expect(PANEL_MIN_WIDTH).toBeGreaterThan(0);
+    expect(PANEL_MAX_WIDTH).toBeGreaterThan(PANEL_MIN_WIDTH);
+    expect(PANEL_DEFAULT_WIDTH).toBeGreaterThanOrEqual(PANEL_MIN_WIDTH);
+    expect(PANEL_DEFAULT_WIDTH).toBeLessThanOrEqual(PANEL_MAX_WIDTH);
   });
 });


### PR DESCRIPTION
## Summary

Closes #445

- Adds `tabbed-left` as a third panel layout option, placing the combined Chat/Annotations panel on the left side of the editor
- Extracts `ResizeHandle` sub-component to eliminate 3-way duplication of the resize handle JSX across layout branches
- Extracts `TabbedPanelContainer` sub-component shared by both `tabbed` and `tabbed-left` layout branches, de-duplicating ~80 lines of tab/panel JSX
- Refactors `AppearanceSettings` layout buttons from two hardcoded `<button>` elements to a `LAYOUT_OPTIONS` array map, making it trivial to add future variants
- Extends the "Default Tab" section visibility condition to include `tabbed-left` (was `tabbed`-only)

## Test plan

1. Open Settings (Ctrl+,) → verify three layout buttons: "Tabbed", "Tabbed-Left", "Three-Panel"
2. Click "Tabbed-Left" → panel appears on the left, editor fills center-right
3. Toggle Chat ↔ Annotations in left panel → both display correctly
4. Drag resize handle (right edge of left panel) → panel widens/narrows smoothly
5. Reload page → left panel width persists from localStorage
6. Switch Tabbed-Left → Tabbed → Three-Panel → Tabbed-Left → layout restores correctly each time
7. Resize browser to <768px → verify graceful behavior (no overlaps or glitches)
8. Verify keyboard navigation through layout buttons in Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)