### PR TITLE
feat(client): add View Changelog button in settings (#437)

### DIFF
--- a/src/client/components/SettingsPopover.tsx
+++ b/src/client/components/SettingsPopover.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useEffect, useRef, useState } from "react";
+import React, { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import {
   SELECTION_DWELL_MAX_MS,
   SELECTION_DWELL_MIN_MS,
@@ -8,6 +8,7 @@ import { isTauriRuntime } from "../cowork/cowork-helpers";
 import { useAppInfo } from "../hooks/useAppInfo";
 import type { TandemSettings } from "../hooks/useTandemSettings";
 import { useUserName } from "../hooks/useUserName";
+import { API_BASE } from "../utils/fileUpload";
 import { AccessibilitySettings } from "./AccessibilitySettings";
 import { AppearanceSettings } from "./AppearanceSettings";
 import { EditorSettings } from "./EditorSettings";
@@ -53,6 +54,42 @@ export function SettingsPopover({
   const { userName, setUserName } = useUserName();
   const [nameInput, setNameInput] = useState(userName);
   const { info: appInfo, loading: appInfoLoading } = useAppInfo(open);
+  const [changelogLoading, setChangelogLoading] = useState(false);
+  const [changelogError, setChangelogError] = useState<string | null>(null);
+
+  const handleViewChangelog = useCallback(async () => {
+    const changelogPath = appInfo?.changelogPath;
+    if (!changelogPath) {
+      setChangelogError("Changelog file not found.");
+      return;
+    }
+    setChangelogLoading(true);
+    setChangelogError(null);
+    try {
+      const res = await fetch(`${API_BASE}/open`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filePath: changelogPath, readOnly: true }),
+      });
+      if (!res.ok) {
+        let msg = "Failed to open changelog.";
+        try {
+          const data = (await res.json()) as { message?: string };
+          if (data.message) msg = data.message;
+        } catch {
+          // ignore JSON parse failure
+        }
+        if (res.status === 404) msg = "Changelog file not found.";
+        setChangelogError(msg);
+        return;
+      }
+      onClose();
+    } catch {
+      setChangelogError("Server unavailable.");
+    } finally {
+      setChangelogLoading(false);
+    }
+  }, [appInfo, onClose]);
 
   // Idle-sync: commit c9a63de dropped the always-sync effect because it
   // clobbered in-progress edits. This version syncs only when the input
@@ -268,6 +305,40 @@ export function SettingsPopover({
           <span>{(SELECTION_DWELL_MIN_MS / 1000).toFixed(1)}s</span>
           <span>{(SELECTION_DWELL_MAX_MS / 1000).toFixed(1)}s</span>
         </div>
+      </div>
+
+      {/* View Changelog — opens CHANGELOG.md as a read-only tab */}
+      <div>
+        <button
+          data-testid="view-changelog-btn"
+          onClick={handleViewChangelog}
+          disabled={changelogLoading || appInfoLoading}
+          style={{
+            width: "100%",
+            padding: "8px",
+            fontSize: "13px",
+            fontWeight: 500,
+            border: "1px solid var(--tandem-border-strong)",
+            borderRadius: "4px",
+            cursor: changelogLoading || appInfoLoading ? "not-allowed" : "pointer",
+            background: "var(--tandem-surface-muted)",
+            color: "var(--tandem-fg)",
+            opacity: changelogLoading || appInfoLoading ? 0.6 : 1,
+          }}
+        >
+          {changelogLoading ? "Opening…" : "View Changelog"}
+        </button>
+        {changelogError && (
+          <div
+            style={{
+              marginTop: "6px",
+              fontSize: "11px",
+              color: "var(--tandem-error-fg)",
+            }}
+          >
+            {changelogError}
+          </div>
+        )}
       </div>
 
       {/* Cowork integration — Tauri desktop only (CLI / pure web callers don't

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -83,4 +83,6 @@ export interface AppInfoData {
   storagePath?: string;
   /** Loopback-only: mtime of the auth token file in ms, or null if not yet created. */
   tokenRotatedAt?: number | null;
+  /** Absolute path to CHANGELOG.md on the server host. Undefined if not found at startup. */
+  changelogPath?: string;
 }

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -131,7 +131,15 @@ export async function openFileByPath(
         forceReloaded: true,
       };
     }
-    return handleAlreadyOpen(id, getOrCreateDocument(id), format, resolved, readOnly);
+    return handleAlreadyOpen(
+      id,
+      getOrCreateDocument(id),
+      format,
+      resolved,
+      readOnly,
+      existing,
+      options?.readOnly === true,
+    );
   }
 
   // Normal open
@@ -261,6 +269,12 @@ async function resolveAndValidatePath(filePath: string): Promise<ResolvedPath> {
 /**
  * Handle the non-force already-open branch: activate the doc and broadcast.
  * This is the only place that sets alreadyOpen: true in the return value.
+ *
+ * If the caller explicitly requests readOnly: true and the existing record
+ * is not already read-only, we upgrade the document to read-only in both the
+ * open-docs registry and the Y.Doc metadata so clients see the correct flag.
+ * We never downgrade an existing readOnly:true document — the explicit signal
+ * only upgrades.
  */
 function handleAlreadyOpen(
   id: string,
@@ -268,7 +282,16 @@ function handleAlreadyOpen(
   format: string,
   resolved: string,
   readOnly: boolean,
+  existing: OpenDoc,
+  explicitReadOnly: boolean,
 ): OpenFileResult {
+  // Upgrade to read-only when explicitly requested and not already read-only.
+  if (explicitReadOnly && !existing.readOnly) {
+    addDoc(id, { ...existing, readOnly: true });
+    const meta = doc.getMap(Y_MAP_DOCUMENT_META);
+    doc.transact(() => meta.set("readOnly", true), MCP_ORIGIN);
+  }
+
   setActiveDocId(id);
   broadcastOpenDocs();
   return {

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -88,12 +88,20 @@ interface ResolvedPath {
  * Open a file by its absolute path on disk.
  * Throws on errors (ENOENT, EACCES, EBUSY, etc.) — caller maps to MCP or HTTP responses.
  * Pass `force: true` to reload from disk even if already open (clears all document state).
+ * Pass `readOnly: true` to force the document open in read-only mode (e.g. CHANGELOG.md).
  */
 export async function openFileByPath(
   filePath: string,
-  options?: { force?: boolean },
+  options?: { force?: boolean; readOnly?: boolean },
 ): Promise<OpenFileResult> {
-  const { resolved, format, readOnly, id } = await resolveAndValidatePath(filePath);
+  const {
+    resolved,
+    format,
+    readOnly: derivedReadOnly,
+    id,
+  } = await resolveAndValidatePath(filePath);
+  // Caller may override the derived readOnly (e.g. force changelog read-only).
+  const readOnly = options?.readOnly === true ? true : derivedReadOnly;
   const fileName = path.basename(resolved);
   const openDocs = getOpenDocs();
   const existing = openDocs.get(id);

--- a/src/server/mcp/routes/info.ts
+++ b/src/server/mcp/routes/info.ts
@@ -14,12 +14,17 @@ export interface InfoHandlerDeps {
   storagePath: string;
   /** Returns the absolute path to the auth token file. */
   getTokenFilePath: () => string;
+  /**
+   * Absolute path to CHANGELOG.md on disk, resolved at server startup.
+   * Undefined if the file does not exist (e.g. stripped production builds).
+   */
+  changelogPath?: string;
 }
 
 /**
  * GET /api/info — returns app metadata for the client About panel.
  *
- * Public fields (always returned): version, toolCount, mcpSdkVersion, transport.
+ * Public fields (always returned): version, toolCount, mcpSdkVersion, transport, changelogPath.
  * Sensitive fields (loopback-only): storagePath, tokenRotatedAt.
  */
 export function makeInfoHandler(deps: InfoHandlerDeps): Handler {
@@ -50,6 +55,11 @@ export function makeInfoHandler(deps: InfoHandlerDeps): Handler {
       mcpSdkVersion: deps.mcpSdkVersion,
       transport: "http",
     };
+
+    // changelogPath is not sensitive — include whenever the file exists on disk.
+    if (deps.changelogPath !== undefined) {
+      body.changelogPath = deps.changelogPath;
+    }
 
     if (loopback) {
       body.storagePath = deps.storagePath;

--- a/src/server/mcp/routes/open.ts
+++ b/src/server/mcp/routes/open.ts
@@ -3,13 +3,16 @@ import { openFileByPath } from "../file-opener.js";
 import { sendApiError } from "./_shared.js";
 
 export async function handleOpen(req: Request, res: Response): Promise<void> {
-  const { filePath, force } = (req.body ?? {}) as Record<string, unknown>;
+  const { filePath, force, readOnly } = (req.body ?? {}) as Record<string, unknown>;
   if (!filePath || typeof filePath !== "string") {
     res.status(400).json({ error: "BAD_REQUEST", message: "filePath is required" });
     return;
   }
   try {
-    const result = await openFileByPath(filePath, { force: force === true });
+    const result = await openFileByPath(filePath, {
+      force: force === true,
+      readOnly: readOnly === true,
+    });
     res.json({ data: result });
   } catch (err: unknown) {
     sendApiError(res, err);

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -46,15 +46,24 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // dist/server/ → dist/client/ (tsup bundles server into dist/server/index.js)
 const CLIENT_DIST = join(__dirname, "../client");
 
-// Resolve CHANGELOG.md at module load time so it's ready before any request
-// comes in. The path is dist/server/ at runtime → root is "../../..".
-// In dev (src/server/mcp/) the root is also "../../../" relative to this file.
-// We check existence once and store undefined if the file isn't present (e.g.
-// stripped distribution builds) — the handler simply omits the field.
-const _changelogCandidate = join(__dirname, "../../..", "CHANGELOG.md");
-const CHANGELOG_PATH: string | undefined = existsSync(_changelogCandidate)
-  ? _changelogCandidate
-  : undefined;
+// Resolve CHANGELOG.md by walking up from __dirname until we find a directory
+// that contains both package.json and CHANGELOG.md. This works in both dev
+// (src/server/mcp/) and production (dist/server/) without hardcoding depth.
+// Capped at 5 levels to avoid runaway traversal.
+function findChangelogPath(startDir: string): string | undefined {
+  let dir = startDir;
+  for (let i = 0; i < 5; i++) {
+    const candidate = join(dir, "CHANGELOG.md");
+    if (existsSync(candidate) && existsSync(join(dir, "package.json"))) {
+      return candidate;
+    }
+    const parent = join(dir, "..");
+    if (parent === dir) break; // filesystem root
+    dir = parent;
+  }
+  return undefined;
+}
+const CHANGELOG_PATH: string | undefined = findChangelogPath(__dirname);
 
 // McpServer is long-lived (tool registrations survive close/reconnect).
 // Transport is ephemeral — rotated on each new initialize request.

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -46,6 +46,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // dist/server/ → dist/client/ (tsup bundles server into dist/server/index.js)
 const CLIENT_DIST = join(__dirname, "../client");
 
+// Resolve CHANGELOG.md at module load time so it's ready before any request
+// comes in. The path is dist/server/ at runtime → root is "../../..".
+// In dev (src/server/mcp/) the root is also "../../../" relative to this file.
+// We check existence once and store undefined if the file isn't present (e.g.
+// stripped distribution builds) — the handler simply omits the field.
+const _changelogCandidate = join(__dirname, "../../..", "CHANGELOG.md");
+const CHANGELOG_PATH: string | undefined = existsSync(_changelogCandidate)
+  ? _changelogCandidate
+  : undefined;
+
 // McpServer is long-lived (tool registrations survive close/reconnect).
 // Transport is ephemeral — rotated on each new initialize request.
 let mcpServer: McpServer | null = null;
@@ -325,6 +335,7 @@ export async function startMcpServerHttp(
       mcpSdkVersion: MCP_SDK_VERSION,
       storagePath: SESSION_DIR,
       getTokenFilePath,
+      changelogPath: CHANGELOG_PATH,
     },
   );
 

--- a/tests/server/file-opener-edge-cases.test.ts
+++ b/tests/server/file-opener-edge-cases.test.ts
@@ -8,6 +8,9 @@ import {
   openFileFromContent,
   SUPPORTED_EXTENSIONS,
 } from "../../src/server/mcp/file-opener.js";
+import { handleOpen } from "../../src/server/mcp/routes/open.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { Y_MAP_DOCUMENT_META } from "../../src/shared/constants.js";
 
 let tmpDir: string;
 
@@ -194,5 +197,143 @@ describe("SUPPORTED_EXTENSIONS", () => {
     expect(SUPPORTED_EXTENSIONS.has(".pdf")).toBe(false);
     expect(SUPPORTED_EXTENSIONS.has(".js")).toBe(false);
     expect(SUPPORTED_EXTENSIONS.has(".py")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readOnly option
+// ---------------------------------------------------------------------------
+
+describe("openFileByPath — readOnly option", () => {
+  it("opens a file as read-only when readOnly:true is passed", async () => {
+    const f = path.join(tmpDir, "ro.md");
+    await fs.writeFile(f, "# Read-only content");
+
+    const result = await openFileByPath(f, { readOnly: true });
+
+    expect(result.readOnly).toBe(true);
+    expect(result.alreadyOpen).toBe(false);
+    // Y.Doc metadata should also reflect the flag
+    const doc = getOrCreateDocument(result.documentId);
+    const meta = doc.getMap(Y_MAP_DOCUMENT_META);
+    expect(meta.get("readOnly")).toBe(true);
+  });
+
+  it("opens a file as writable by default (no readOnly option)", async () => {
+    const f = path.join(tmpDir, "rw.md");
+    await fs.writeFile(f, "# Writable content");
+
+    const result = await openFileByPath(f);
+
+    expect(result.readOnly).toBe(false);
+  });
+
+  it("upgrading an already-open file to readOnly:true updates registry and Y.Doc meta", async () => {
+    const f = path.join(tmpDir, "upgrade-ro.md");
+    await fs.writeFile(f, "# Upgrade to read-only");
+
+    // Open normally (writable)
+    const first = await openFileByPath(f);
+    expect(first.readOnly).toBe(false);
+
+    // Re-open with readOnly:true — should upgrade in-place
+    const second = await openFileByPath(f, { readOnly: true });
+    expect(second.alreadyOpen).toBe(true);
+    expect(second.readOnly).toBe(true);
+
+    // Open-docs registry should reflect the upgrade
+    const openDocs = getOpenDocs();
+    expect(openDocs.get(first.documentId)?.readOnly).toBe(true);
+
+    // Y.Doc metadata should reflect the upgrade
+    const doc = getOrCreateDocument(first.documentId);
+    const meta = doc.getMap(Y_MAP_DOCUMENT_META);
+    expect(meta.get("readOnly")).toBe(true);
+  });
+
+  it("does not downgrade a read-only doc when re-opened without readOnly option", async () => {
+    const f = path.join(tmpDir, "no-downgrade.md");
+    await fs.writeFile(f, "# No downgrade");
+
+    // Open with readOnly:true
+    await openFileByPath(f, { readOnly: true });
+
+    // Re-open without specifying readOnly — should NOT downgrade
+    const second = await openFileByPath(f);
+    expect(second.alreadyOpen).toBe(true);
+    // readOnly reflects the re-open's derived value (false for .md), but the
+    // registry and Y.Doc should NOT have been downgraded
+    const openDocs = getOpenDocs();
+    expect(openDocs.get(second.documentId)?.readOnly).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/open — readOnly via HTTP route
+// ---------------------------------------------------------------------------
+
+describe("handleOpen — readOnly propagation", () => {
+  it("opens a file as read-only when body contains readOnly:true", async () => {
+    const f = path.join(tmpDir, "api-ro.md");
+    await fs.writeFile(f, "# API read-only test");
+
+    let capturedBody: unknown;
+    const req = { body: { filePath: f, readOnly: true } } as Parameters<typeof handleOpen>[0];
+    const res = {
+      json: (body: unknown) => {
+        capturedBody = body;
+      },
+      status: () => res,
+    } as unknown as Parameters<typeof handleOpen>[1];
+
+    await handleOpen(req, res);
+
+    expect((capturedBody as { data: { readOnly: boolean } }).data.readOnly).toBe(true);
+  });
+
+  it("returns BAD_REQUEST when filePath is missing", async () => {
+    let capturedStatus: number | undefined;
+    let capturedBody: unknown;
+
+    const req = { body: {} } as Parameters<typeof handleOpen>[0];
+    const res = {
+      status: (code: number) => {
+        capturedStatus = code;
+        return res;
+      },
+      json: (body: unknown) => {
+        capturedBody = body;
+      },
+    } as unknown as Parameters<typeof handleOpen>[1];
+
+    await handleOpen(req, res);
+
+    expect(capturedStatus).toBe(400);
+    expect((capturedBody as { error: string }).error).toBe("BAD_REQUEST");
+  });
+
+  it("propagates readOnly:true to an already-open document", async () => {
+    const f = path.join(tmpDir, "api-already-open-ro.md");
+    await fs.writeFile(f, "# Already-open read-only upgrade");
+
+    // Open the document first (writable)
+    await openFileByPath(f);
+
+    let capturedBody: unknown;
+    const req = {
+      body: { filePath: f, readOnly: true },
+    } as Parameters<typeof handleOpen>[0];
+    const res = {
+      json: (body: unknown) => {
+        capturedBody = body;
+      },
+      status: () => res,
+    } as unknown as Parameters<typeof handleOpen>[1];
+
+    await handleOpen(req, res);
+
+    const data = (capturedBody as { data: { readOnly: boolean; alreadyOpen: boolean } }).data;
+    expect(data.alreadyOpen).toBe(true);
+    expect(data.readOnly).toBe(true);
   });
 });

--- a/tests/server/info-route.test.ts
+++ b/tests/server/info-route.test.ts
@@ -156,18 +156,15 @@ describe("GET /api/info — public shape contract", () => {
 
   it("includes changelogPath when CHANGELOG.md exists in the repo root", async () => {
     // The integration server resolves CHANGELOG.md relative to server.ts at startup.
-    // This test verifies the field is present in the response (file exists in this repo).
+    // CHANGELOG.md is present in this repo root, so the field must appear in the response.
+    // The unit test suite covers the absent-file case via makeInfoHandler({ changelogPath: undefined }).
     const { status, body } = await rawGet(port, "/api/info", `127.0.0.1:${port}`);
     const b = body as Record<string, unknown>;
 
     expect(status).toBe(200);
-    // changelogPath is present and points to an absolute path ending in CHANGELOG.md
-    if ("changelogPath" in b) {
-      expect(typeof b.changelogPath).toBe("string");
-      expect(String(b.changelogPath)).toMatch(/CHANGELOG\.md$/);
-    }
-    // Note: we don't assert presence because a stripped distribution without the file
-    // will omit the field — that is intentional behaviour.
+    expect("changelogPath" in b).toBe(true);
+    expect(typeof b.changelogPath).toBe("string");
+    expect(String(b.changelogPath)).toMatch(/CHANGELOG\.md$/);
   });
 });
 

--- a/tests/server/info-route.test.ts
+++ b/tests/server/info-route.test.ts
@@ -153,6 +153,22 @@ describe("GET /api/info — public shape contract", () => {
     expect("transport" in b).toBe(true);
     expect(b.transport).toBe("http");
   });
+
+  it("includes changelogPath when CHANGELOG.md exists in the repo root", async () => {
+    // The integration server resolves CHANGELOG.md relative to server.ts at startup.
+    // This test verifies the field is present in the response (file exists in this repo).
+    const { status, body } = await rawGet(port, "/api/info", `127.0.0.1:${port}`);
+    const b = body as Record<string, unknown>;
+
+    expect(status).toBe(200);
+    // changelogPath is present and points to an absolute path ending in CHANGELOG.md
+    if ("changelogPath" in b) {
+      expect(typeof b.changelogPath).toBe("string");
+      expect(String(b.changelogPath)).toMatch(/CHANGELOG\.md$/);
+    }
+    // Note: we don't assert presence because a stripped distribution without the file
+    // will omit the field — that is intentional behaviour.
+  });
 });
 
 // ── Unit tests for handler branches not reachable via loopback integration ────
@@ -187,6 +203,7 @@ const BASE_DEPS = {
   mcpSdkVersion: "0.0.0",
   storagePath: "/tmp/sessions",
   getTokenFilePath: () => `/tmp/token-file-${Date.now()}`,
+  changelogPath: "/tmp/CHANGELOG.md",
 };
 
 describe("GET /api/info — non-loopback branch (unit)", () => {
@@ -240,5 +257,62 @@ describe("GET /api/info — ENOENT token stat branch (unit)", () => {
     expect("tokenRotatedAt" in body).toBe(true);
     // ENOENT path → null (not a number)
     expect(body.tokenRotatedAt).toBeNull();
+  });
+});
+
+describe("GET /api/info — changelogPath field (unit)", () => {
+  it("includes changelogPath in response when dep is set", async () => {
+    const handler = makeInfoHandler(BASE_DEPS);
+    const req = makeMockReq("127.0.0.1");
+    const res = makeMockRes();
+
+    await (handler as (req: unknown, res: unknown, next: unknown) => Promise<void>)(
+      req,
+      res,
+      () => {},
+    );
+
+    const body = res._body as Record<string, unknown>;
+    expect(body).not.toBeNull();
+    // changelogPath is a public field — present for all callers when dep is set
+    expect("changelogPath" in body).toBe(true);
+    expect(body.changelogPath).toBe("/tmp/CHANGELOG.md");
+  });
+
+  it("omits changelogPath from response when dep is undefined", async () => {
+    const handler = makeInfoHandler({ ...BASE_DEPS, changelogPath: undefined });
+    const req = makeMockReq("127.0.0.1");
+    const res = makeMockRes();
+
+    await (handler as (req: unknown, res: unknown, next: unknown) => Promise<void>)(
+      req,
+      res,
+      () => {},
+    );
+
+    const body = res._body as Record<string, unknown>;
+    expect(body).not.toBeNull();
+    expect("changelogPath" in body).toBe(false);
+  });
+
+  it("includes changelogPath for non-loopback callers (not a sensitive field)", async () => {
+    const handler = makeInfoHandler(BASE_DEPS);
+    const req = makeMockReq("192.168.1.100");
+    const res = makeMockRes();
+
+    await (handler as (req: unknown, res: unknown, next: unknown) => Promise<void>)(
+      req,
+      res,
+      () => {},
+    );
+
+    const body = res._body as Record<string, unknown>;
+    expect(body).not.toBeNull();
+    // changelogPath is public — should appear even for non-loopback callers
+    expect("changelogPath" in body).toBe(true);
+    expect(body.changelogPath).toBe("/tmp/CHANGELOG.md");
+    // Sensitive fields still absent
+    expect("storagePath" in body).toBe(false);
+    expect("tokenRotatedAt" in body).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a **View Changelog** button to the Settings popover that opens `CHANGELOG.md` as a read-only tab via the existing `/api/open` endpoint
- Server resolves `CHANGELOG.md` path once at startup in `server.ts` using `existsSync`; exposed via `/api/info` as `changelogPath` (non-sensitive public field)
- Client reads `changelogPath` from `useAppInfo` before opening — avoids hardcoded paths and gracefully handles absent builds where the file doesn't exist
- `/api/open` and `openFileByPath` now accept `readOnly: true` to force read-only mode independent of file format (`.md` is normally editable)
- Inline error state on the button maps 404 → "Changelog file not found." and network failure → "Server unavailable."; loading/disabled guard prevents double-clicks

Closes #437

---

**Stacked on #435 (feat/issue-435-version-in-ui)** — base is `feat/issue-435-version-in-ui`, not `master`.

---

## Test plan

- [ ] **Settings Panel Opens**: Click gear icon → Settings popover opens with all sections
- [ ] **Changelog Button Exists**: "View Changelog" button visible after appearance settings, before Cowork section
- [ ] **Button Triggers File Open**: Click → new tab opens with CHANGELOG.md content; tab label shows "CHANGELOG.md"; popover closes
- [ ] **Read-Only Mode**: Verify the opened tab is read-only (editing should be blocked)
- [ ] **Loading State**: Click button → label changes to "Opening…", button is disabled during fetch
- [ ] **Error Handling**: If `CHANGELOG.md` unavailable on server, error message renders below button ("Changelog file not found."); app does not crash
- [ ] **Settings Re-Open**: Reopen settings after closing → button still works on second click
- [ ] **Tauri**: Verify on Tauri desktop build — path resolves to bundled resource
- [ ] **Web**: Verify on `localhost` web mode — path resolves to project root

🤖 Generated with [Claude Code](https://claude.com/claude-code)