### PR TITLE
fix(annotations): add PRIVATE pill to note cards (#481)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ These WILL break things if violated:
 4. **Ranges use `validateRange()` + `anchoredRange()`**, not raw offsets. `anchoredRange()` creates both flat + Yjs RelativePosition in one call.
 5. **`tandem_getTextContent` uses `extractText()`, never `extractMarkdown()`.** Even for .md files. `extractMarkdown()` shifts character offsets relative to the annotation coordinate system. If you need actual markdown, use `tandem_save` and read the file.
 6. **`tandem_edit` rejects heading markup ranges.** Ranges that overlap heading prefixes (e.g., `## `) return INVALID_RANGE -- target text content only.
-7. **E2E tests use `data-testid` attributes** (kebab-case). Key selectors: `accept-btn`, `dismiss-btn`, `edit-btn`, `review-mode-btn`, `annotation-card-{id}`, `tab-{id}`, `file-open-dialog`, `file-path-input`, `open-file-btn`, `toast-container`, `settings-popover`, `settings-display-name`, `dwell-time-slider`, `view-changelog-btn`, `app-info-footer`, `left-panel-resize-handle`, `right-panel-resize-handle`, `panel-resize-handle`, `cowork-settings-suspense-fallback`.
+7. **E2E tests use `data-testid` attributes** (kebab-case). Key selectors: `accept-btn`, `dismiss-btn`, `edit-btn`, `review-mode-btn`, `annotation-card-{id}`, `annotation-private-pill`, `tab-{id}`, `file-open-dialog`, `file-path-input`, `open-file-btn`, `toast-container`, `settings-popover`, `settings-display-name`, `dwell-time-slider`, `view-changelog-btn`, `app-info-footer`, `left-panel-resize-handle`, `right-panel-resize-handle`, `panel-resize-handle`, `cowork-settings-suspense-fallback`.
 
 ## Architecture
 

--- a/src/client/panels/AnnotationCard.tsx
+++ b/src/client/panels/AnnotationCard.tsx
@@ -132,7 +132,8 @@ export const AnnotationCard = React.memo(function AnnotationCard({
       ? annotation.content.slice(0, 57) + "..."
       : annotation.content
     : "";
-  const cardLabel = `${displayType} annotation${truncatedContent ? ": " + truncatedContent : ""}, ${annotation.status}`;
+  const isPrivateNote = annotation.type === "note";
+  const cardLabel = `${isPrivateNote ? "private " : ""}${displayType} annotation${truncatedContent ? ": " + truncatedContent : ""}, ${annotation.status}`;
 
   return (
     <div
@@ -165,6 +166,26 @@ export const AnnotationCard = React.memo(function AnnotationCard({
           }}
         >
           {displayType}
+          {isPrivateNote && (
+            <span
+              data-testid="annotation-private-pill"
+              aria-hidden="true"
+              title="Private note"
+              style={{
+                padding: "1px 6px",
+                fontSize: "10px",
+                fontWeight: 600,
+                letterSpacing: "0.02em",
+                textTransform: "uppercase",
+                color: "var(--tandem-warning-fg)",
+                background: "var(--tandem-warning)",
+                borderRadius: "3px",
+                lineHeight: 1,
+              }}
+            >
+              Private
+            </span>
+          )}
           {!isPending && (
             <span
               style={{


### PR DESCRIPTION
Closes #481

## Summary
- Adds a small uppercase "PRIVATE" pill to the side-panel header of note (`type === "note"`) annotation cards.
- Uses existing `--tandem-warning` (saturated amber) bg with `--tandem-warning-fg` text — visible against the card's `--tandem-warning-bg` surface in both light and dark themes.
- Pill is `aria-hidden="true"`; the card's `aria-label` is mutated to include "private" so screen readers announce notes as "private note annotation: ..." (not duplicated by the pill).
- New test-id `annotation-private-pill` added to CLAUDE.md inventory; consumed by #484 E2E smoke tests.

## Why
Per ADR-027's audience-based model, notes are user-private (Claude does not see them). Color-only differentiation (amber bg + amber border) was too subtle at-a-glance during PR #474 manual testing. The pill makes the affordance explicit so v0.10.0's Svelte rewrite preserves it.

## Manual-test checklist
- [x] Open `sample/welcome.md` (or any doc) in `npm run dev:standalone`.
- [x] Create a personal note via the editor toolbar; create a Claude comment on a separate sentence.
- [x] Note card shows amber border + amber bg + uppercase "PRIVATE" pill in the header.
- [x] Comment card shows blue border, no pill.
- [x] Toggle dark mode (settings popover). Pill stays legible (amber on darker amber).
- [x] Replacement / highlight / comment cards unaffected (no pill).
- [ ] `npm run check:tokens` passes (no raw hex).
- [ ] Screen reader on note card announces "private note annotation: ...".

## Notes
- Issue #481 is currently closed; will be reopened when this PR enters review (manager handles reopen).
- Inline style follows the adjacent status pill pattern; no new module-level const (per `feedback_token_migration_dead_style_consts`).
- No new tokens introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)