### PR TITLE
fix(file-io): preserve markdown tables across Tiptap round-trip (#379)

### DIFF
--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -356,22 +356,7 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
             cellChild instanceof Y.XmlElement &&
             (cellChild.nodeName === "tableHeader" || cellChild.nodeName === "tableCell")
           ) {
-            // Find the inner paragraph wrapper and serialize its inline content.
-            // Fall back to direct cell content if no paragraph (shouldn't happen).
-            let phrasing: PhrasingContent[] = [];
-            let foundPara = false;
-            for (let k = 0; k < cellChild.length; k++) {
-              const inner = cellChild.get(k);
-              if (inner instanceof Y.XmlElement && inner.nodeName === "paragraph") {
-                phrasing = deltaToPhrasingContent(inner);
-                foundPara = true;
-                break;
-              }
-            }
-            if (!foundPara) {
-              phrasing = deltaToPhrasingContent(cellChild);
-            }
-            cells.push({ type: "tableCell", children: phrasing });
+            cells.push({ type: "tableCell", children: cellToPhrasingContent(cellChild) });
           }
         }
         rows.push({ type: "tableRow", children: cells });
@@ -490,4 +475,89 @@ function deltaToPhrasingContent(el: Y.XmlElement): PhrasingContent[] {
   }
 
   return result;
+}
+
+function cellToPhrasingContent(cell: Y.XmlElement): PhrasingContent[] {
+  const chunks: PhrasingContent[][] = [];
+
+  for (let i = 0; i < cell.length; i++) {
+    const child = cell.get(i);
+    if (child instanceof Y.XmlElement) {
+      const chunk =
+        child.nodeName === "paragraph"
+          ? deltaToPhrasingContent(child)
+          : plainTextToPhrasingContent(plainTextFromElement(child));
+      if (isNonEmptyPhrasing(chunk)) chunks.push(chunk);
+    } else if (child instanceof Y.XmlText) {
+      const direct = deltaToPhrasingContent(cell);
+      if (isNonEmptyPhrasing(direct)) chunks.push(direct);
+      break;
+    }
+  }
+
+  const result: PhrasingContent[] = [];
+  chunks.forEach((chunk, index) => {
+    if (index > 0) result.push({ type: "text", value: " " });
+    result.push(...chunk);
+  });
+  return result;
+}
+
+function isNonEmptyPhrasing(nodes: PhrasingContent[]): boolean {
+  return nodes.some((node) => phrasingPlainText(node).trim().length > 0);
+}
+
+function phrasingPlainText(node: PhrasingContent): string {
+  switch (node.type) {
+    case "text":
+    case "inlineCode":
+      return node.value;
+    case "break":
+      return "\n";
+    case "strong":
+    case "emphasis":
+    case "delete":
+    case "link":
+      return node.children.map(phrasingPlainText).join("");
+    case "image":
+      return node.alt ?? "";
+    default:
+      return "value" in node && typeof node.value === "string" ? node.value : "";
+  }
+}
+
+function plainTextToPhrasingContent(text: string): PhrasingContent[] {
+  return text.trim().length > 0 ? [{ type: "text", value: text }] : [];
+}
+
+function plainTextFromElement(element: Y.XmlElement): string {
+  const parts: string[] = [];
+  let hasPriorContent = false;
+
+  for (let i = 0; i < element.length; i++) {
+    const child = element.get(i);
+    if (child instanceof Y.XmlText) {
+      parts.push(xmlTextToPlainText(child));
+      hasPriorContent = true;
+    } else if (child instanceof Y.XmlElement) {
+      if (child.nodeName === "hardBreak") {
+        parts.push("\n");
+        hasPriorContent = true;
+      } else {
+        if (hasPriorContent) parts.push("\n");
+        parts.push(plainTextFromElement(child));
+        hasPriorContent = true;
+      }
+    }
+  }
+
+  return parts.join("");
+}
+
+function xmlTextToPlainText(xmlText: Y.XmlText): string {
+  let text = "";
+  for (const op of xmlText.toDelta()) {
+    text += typeof op.insert === "string" ? op.insert : "\n";
+  }
+  return text;
 }

--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -1,4 +1,4 @@
-import type { PhrasingContent, Root, RootContent } from "mdast";
+import type { AlignType, PhrasingContent, Root, RootContent, Table } from "mdast";
 import * as Y from "yjs";
 
 /**
@@ -107,6 +107,40 @@ function blockToYxml(
 
     case "thematicBreak": {
       return [new Y.XmlElement("horizontalRule")];
+    }
+
+    case "table": {
+      // GFM table: first MDAST tableRow becomes a row of tableHeader cells;
+      // subsequent rows become tableCell rows. Column alignment is stored as
+      // a JSON-stringified table-level "align" attribute (matches MDAST's
+      // table-level storage and avoids per-cell alignment plumbing).
+      //
+      // Per CLAUDE.md "Y.XmlText must be attached before populating": each
+      // cell's paragraph + Y.XmlText is attached to the tree first, and the
+      // inline children are pushed to deferred[] for the second pass — same
+      // pattern used by paragraph/heading above.
+      const tableEl = new Y.XmlElement("table");
+      const align: (AlignType | null | undefined)[] = node.align ?? [];
+      tableEl.setAttribute("align", JSON.stringify(align) as any);
+      node.children.forEach((row, rowIdx) => {
+        const rowEl = new Y.XmlElement("tableRow");
+        const cellNodeName = rowIdx === 0 ? "tableHeader" : "tableCell";
+        for (const cell of row.children) {
+          const cellEl = new Y.XmlElement(cellNodeName);
+          // Tiptap wraps cell content in a paragraph; mirror that here so the
+          // Y.Doc structure matches what the editor would produce.
+          const para = new Y.XmlElement("paragraph");
+          const text = new Y.XmlText();
+          // Attach in order: row → cell → paragraph → text. Each child is
+          // attached to its parent before deferring inline population.
+          cellEl.insert(0, [para]);
+          para.insert(0, [text]);
+          rowEl.insert(rowEl.length, [cellEl]);
+          deferred.push({ xmlText: text, nodes: cell.children });
+        }
+        tableEl.insert(tableEl.length, [rowEl]);
+      });
+      return [tableEl];
     }
 
     case "image": {
@@ -294,6 +328,56 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
 
     case "horizontalRule":
       return { type: "thematicBreak" };
+
+    case "table": {
+      // Read column alignment from the table-level "align" attribute (stored
+      // as JSON). Default to [] if missing or unparseable — alignment is
+      // optional in GFM, body-row alignment attrs are ignored.
+      let align: (AlignType | null)[] = [];
+      const rawAlign = el.getAttribute("align");
+      if (typeof rawAlign === "string" && rawAlign.length > 0) {
+        try {
+          const parsed = JSON.parse(rawAlign);
+          if (Array.isArray(parsed)) align = parsed as (AlignType | null)[];
+        } catch {
+          // fall through with empty align
+        }
+      }
+      const rows: any[] = [];
+      for (let i = 0; i < el.length; i++) {
+        const rowChild = el.get(i);
+        if (!(rowChild instanceof Y.XmlElement) || rowChild.nodeName !== "tableRow") {
+          continue;
+        }
+        const cells: any[] = [];
+        for (let j = 0; j < rowChild.length; j++) {
+          const cellChild = rowChild.get(j);
+          if (
+            cellChild instanceof Y.XmlElement &&
+            (cellChild.nodeName === "tableHeader" || cellChild.nodeName === "tableCell")
+          ) {
+            // Find the inner paragraph wrapper and serialize its inline content.
+            // Fall back to direct cell content if no paragraph (shouldn't happen).
+            let phrasing: PhrasingContent[] = [];
+            let foundPara = false;
+            for (let k = 0; k < cellChild.length; k++) {
+              const inner = cellChild.get(k);
+              if (inner instanceof Y.XmlElement && inner.nodeName === "paragraph") {
+                phrasing = deltaToPhrasingContent(inner);
+                foundPara = true;
+                break;
+              }
+            }
+            if (!foundPara) {
+              phrasing = deltaToPhrasingContent(cellChild);
+            }
+            cells.push({ type: "tableCell", children: phrasing });
+          }
+        }
+        rows.push({ type: "tableRow", children: cells });
+      }
+      return { type: "table", align, children: rows } as Table;
+    }
 
     case "image": {
       return {

--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -88,13 +88,31 @@ export function populateYDoc(doc: Y.Doc, text: string): void {
 }
 
 /**
+ * Flat-text separator between cells within a tableRow.
+ *
+ * Table separator contract (must stay in sync with getElementTextLength):
+ *   - cells within a row: "\t" (single char)
+ *   - rows within a table: "\n" (single char, same as FLAT_SEPARATOR)
+ *   - table boundary: "\n" emitted by extractText() between top-level blocks
+ *
+ * Rationale: a one-char-per-gap scheme keeps offsets predictable (every gap
+ * costs exactly 1 char), so an annotation placed AFTER a table is offset by
+ * (cells * (cellLen + 1)) - 1 for the tabs, plus row newlines — the same
+ * accounting other multi-element containers (lists, blockquotes) use today.
+ */
+const CELL_SEPARATOR = "\t";
+
+/**
  * Extract plain text from a Y.XmlElement by recursively collecting Y.XmlText content.
  * Inserts FLAT_SEPARATOR between nested XmlElement children so offsets are consistent
  * with the document-level separator convention (e.g., list items get \n between them).
+ * For tableRow elements, child cells are joined with CELL_SEPARATOR ("\t") instead.
  */
 export function getElementText(element: Y.XmlElement): string {
   const parts: string[] = [];
   let hasPriorContent = false;
+  const isTableRow = element.nodeName === "tableRow";
+  const sep = isTableRow ? CELL_SEPARATOR : FLAT_SEPARATOR;
   for (let i = 0; i < element.length; i++) {
     const child = element.get(i);
     if (child instanceof Y.XmlText) {
@@ -109,7 +127,7 @@ export function getElementText(element: Y.XmlElement): string {
       }
       hasPriorContent = true;
     } else if (child instanceof Y.XmlElement) {
-      if (hasPriorContent) parts.push(FLAT_SEPARATOR);
+      if (hasPriorContent) parts.push(sep);
       parts.push(getElementText(child));
       hasPriorContent = true;
     }

--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -88,31 +88,19 @@ export function populateYDoc(doc: Y.Doc, text: string): void {
 }
 
 /**
- * Flat-text separator between cells within a tableRow.
- *
- * Table separator contract (must stay in sync with getElementTextLength):
- *   - cells within a row: "\t" (single char)
- *   - rows within a table: "\n" (single char, same as FLAT_SEPARATOR)
- *   - table boundary: "\n" emitted by extractText() between top-level blocks
- *
- * Rationale: a one-char-per-gap scheme keeps offsets predictable (every gap
- * costs exactly 1 char), so an annotation placed AFTER a table is offset by
- * (cells * (cellLen + 1)) - 1 for the tabs, plus row newlines — the same
- * accounting other multi-element containers (lists, blockquotes) use today.
- */
-const CELL_SEPARATOR = "\t";
-
-/**
  * Extract plain text from a Y.XmlElement by recursively collecting Y.XmlText content.
  * Inserts FLAT_SEPARATOR between nested XmlElement children so offsets are consistent
- * with the document-level separator convention (e.g., list items get \n between them).
- * For tableRow elements, child cells are joined with CELL_SEPARATOR ("\t") instead.
+ * with the document-level separator convention (e.g., list items and table cells
+ * get \n between them).
+ *
+ * Separator contract (must stay in sync with getElementTextLength):
+ * every gap between nested block/container XmlElement children contributes one
+ * FLAT_SEPARATOR character. Offset helpers account for that as a one-character
+ * between-element gap.
  */
 export function getElementText(element: Y.XmlElement): string {
   const parts: string[] = [];
   let hasPriorContent = false;
-  const isTableRow = element.nodeName === "tableRow";
-  const sep = isTableRow ? CELL_SEPARATOR : FLAT_SEPARATOR;
   for (let i = 0; i < element.length; i++) {
     const child = element.get(i);
     if (child instanceof Y.XmlText) {
@@ -127,7 +115,7 @@ export function getElementText(element: Y.XmlElement): string {
       }
       hasPriorContent = true;
     } else if (child instanceof Y.XmlElement) {
-      if (hasPriorContent) parts.push(sep);
+      if (hasPriorContent) parts.push(FLAT_SEPARATOR);
       parts.push(getElementText(child));
       hasPriorContent = true;
     }
@@ -137,7 +125,7 @@ export function getElementText(element: Y.XmlElement): string {
 
 /**
  * Compute the flat text length of a Y.XmlElement without building the string.
- * Uses the same separator predicate as getElementText() so lengths are consistent.
+ * Uses the same one-character separator invariant as getElementText().
  */
 export function getElementTextLength(element: Y.XmlElement): number {
   let len = 0;
@@ -209,7 +197,7 @@ export function findXmlTextAtOffset(
 
 /**
  * Collect all Y.XmlText nodes in a Y.XmlElement with their flat offsets from the
- * element's start. Uses the same separator predicate as getElementText().
+ * element's start. Uses the same one-character separator invariant as getElementText().
  */
 export function collectXmlTexts(
   element: Y.XmlElement,

--- a/tests/server/document-model.test.ts
+++ b/tests/server/document-model.test.ts
@@ -37,6 +37,16 @@ function loadTree(tree: Root): Y.Doc {
   return doc;
 }
 
+function makeTableCell(text: string): Y.XmlElement {
+  const cell = new Y.XmlElement("tableCell");
+  const paragraph = new Y.XmlElement("paragraph");
+  const xmlText = new Y.XmlText();
+  xmlText.insert(0, text);
+  paragraph.insert(0, [xmlText]);
+  cell.insert(0, [paragraph]);
+  return cell;
+}
+
 // ---------------------------------------------------------------------------
 // getElementText — bold/italic inline marks must not leak as HTML tags
 // ---------------------------------------------------------------------------
@@ -354,5 +364,27 @@ describe("list content (Phase B)", () => {
     const textLen = getElementText(bulletList!).length;
     const computedLen = getElementTextLength(bulletList!);
     expect(computedLen).toBe(textLen);
+  });
+});
+
+describe("table row flat-text offsets", () => {
+  it("uses a single FLAT_SEPARATOR between cells", () => {
+    doc = new Y.Doc();
+    const row = new Y.XmlElement("tableRow");
+    row.insert(0, [makeTableCell("A"), makeTableCell("B")]);
+    doc.getXmlFragment("default").insert(0, [row]);
+
+    expect(getElementText(row)).toBe("A\nB");
+    expect(getElementTextLength(row)).toBe(3);
+    expect(findXmlTextAtOffset(row, 1)).toBeNull();
+
+    const foundB = findXmlTextAtOffset(row, 2);
+    expect(foundB).not.toBeNull();
+    expect(foundB!.offsetInXmlText).toBe(0);
+    expect(foundB!.xmlText.toString()).toBe("B");
+
+    const collected = collectXmlTexts(row);
+    expect(collected.map((entry) => entry.offsetFromStart)).toEqual([0, 2]);
+    expect(collected.map((entry) => entry.xmlText.toString())).toEqual(["A", "B"]);
   });
 });

--- a/tests/server/docx-apply.test.ts
+++ b/tests/server/docx-apply.test.ts
@@ -1,12 +1,14 @@
 import render from "dom-serializer";
 import JSZip from "jszip";
 import { beforeEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
 import {
   applySingleSuggestion,
   applyTrackedChanges,
   buildOffsetMap,
   resolveWordComments,
 } from "../../src/server/file-io/docx-apply.js";
+import { extractText } from "../../src/server/mcp/document-model.js";
 import {
   addDoc,
   getOpenDocs,
@@ -44,6 +46,24 @@ async function createTestDocx(documentXml: string): Promise<Buffer> {
     `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>`,
   );
   return Buffer.from(await zip.generateAsync({ type: "nodebuffer" }));
+}
+
+function makeYTableCell(text: string): Y.XmlElement {
+  const cell = new Y.XmlElement("tableCell");
+  const paragraph = new Y.XmlElement("paragraph");
+  const xmlText = new Y.XmlText();
+  xmlText.insert(0, text);
+  paragraph.insert(0, [xmlText]);
+  cell.insert(0, [paragraph]);
+  return cell;
+}
+
+function makeYParagraph(text: string): Y.XmlElement {
+  const paragraph = new Y.XmlElement("paragraph");
+  const xmlText = new Y.XmlText();
+  xmlText.insert(0, text);
+  paragraph.insert(0, [xmlText]);
+  return paragraph;
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +159,20 @@ describe("buildOffsetMap", () => {
     `);
     const map = buildOffsetMap(xml, new Set());
     expect(map.commentParagraphIds.get("42")).toBe("PARA1");
+  });
+
+  it("matches Y.Doc flat text for table cells followed by a paragraph", () => {
+    const xml = wrapBody(`
+      <w:tbl>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+      <w:p><w:r><w:t>After</w:t></w:r></w:p>
+    `);
+    const map = buildOffsetMap(xml, new Set());
+    expect(map.flatText).toBe("A\nB\nAfter");
   });
 
   it("returns undefined for unmapped offsets", () => {
@@ -467,6 +501,39 @@ describe("applyTrackedChanges", () => {
     expect(output.applied).toBe(0);
     expect(output.rejected).toBe(1);
     expect(output.rejectedDetails[0].reason).toContain("Cross-paragraph");
+  });
+
+  it("applies a suggestion after a table without flat-text mismatch", async () => {
+    const xml = wrapBody(`
+      <w:tbl>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+      <w:p><w:r><w:t>After</w:t></w:r></w:p>
+    `);
+    const docxBuffer = await createTestDocx(xml);
+
+    const ydoc = new Y.Doc();
+    const table = new Y.XmlElement("table");
+    const row = new Y.XmlElement("tableRow");
+    row.insert(0, [makeYTableCell("A"), makeYTableCell("B")]);
+    table.insert(0, [row]);
+    ydoc.getXmlFragment("default").insert(0, [table, makeYParagraph("After")]);
+    const ydocFlatText = extractText(ydoc);
+    expect(ydocFlatText).toBe("A\nB\nAfter");
+
+    const from = ydocFlatText.indexOf("After");
+    const output = await applyTrackedChanges(
+      docxBuffer,
+      [{ id: "s1", from, to: from + "After".length, newText: "Later" }],
+      { author: "Test", ydocFlatText },
+    );
+
+    expect(output.applied).toBe(1);
+    expect(output.rejected).toBe(0);
+    ydoc.destroy();
   });
 });
 

--- a/tests/server/markdown-roundtrip.test.ts
+++ b/tests/server/markdown-roundtrip.test.ts
@@ -276,8 +276,8 @@ describe("markdown round-trip", () => {
     // The anchor word must exist in flat text and live AFTER the table content
     const anchorIdx = flat.indexOf("ANCHORTARGET");
     expect(anchorIdx).toBeGreaterThan(0);
-    // The cell content "a" and "b" must appear before the anchor, joined by \t
-    const aIdx = flat.indexOf("a\tb");
+    // The cell content "a" and "b" must appear before the anchor, joined by \n
+    const aIdx = flat.indexOf("a\nb");
     expect(aIdx).toBeGreaterThan(-1);
     expect(aIdx).toBeLessThan(anchorIdx);
     // Round-trip preserves the anchor on disk

--- a/tests/server/markdown-roundtrip.test.ts
+++ b/tests/server/markdown-roundtrip.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import { loadMarkdown, saveMarkdown } from "../../src/server/file-io/markdown.js";
+import { extractText } from "../../src/server/mcp/document-model.js";
 
 let doc: Y.Doc;
 
@@ -193,5 +194,114 @@ describe("markdown round-trip", () => {
     expect(output).toContain("> -");
     expect(output).toContain("Item one");
     expect(output).toContain("Item two");
+  });
+
+  // -- GFM tables (#379) -----------------------------------------------------
+
+  it("simple GFM table with header + 2 body rows", () => {
+    const input = [
+      "| Col A | Col B |",
+      "| ----- | ----- |",
+      "| a1    | b1    |",
+      "| a2    | b2    |",
+    ].join("\n");
+    const output = normalize(roundTrip(input));
+    expect(output).toContain("Col A");
+    expect(output).toContain("Col B");
+    expect(output).toContain("a1");
+    expect(output).toContain("b1");
+    expect(output).toContain("a2");
+    expect(output).toContain("b2");
+    // Pipe-table markup survives
+    expect(output).toMatch(/\|.*Col A.*\|/);
+  });
+
+  it("table with mixed column alignment (:--, :-:, --:)", () => {
+    const input = [
+      "| Left | Center | Right |",
+      "| :--- | :----: | ----: |",
+      "| l1   | c1     | r1    |",
+    ].join("\n");
+    const output = normalize(roundTrip(input));
+    // Alignment characters preserved (remark renders them with consistent spacing)
+    expect(output).toMatch(/\|\s*:-+\s*\|/); // left-aligned column
+    expect(output).toMatch(/\|\s*:-+:\s*\|/); // center-aligned column
+    expect(output).toMatch(/\|\s*-+:\s*\|/); // right-aligned column
+    expect(output).toContain("l1");
+    expect(output).toContain("c1");
+    expect(output).toContain("r1");
+  });
+
+  it("table with inline marks in cells (bold, italic, code, link)", () => {
+    const input = [
+      "| Style | Value |",
+      "| ----- | ----- |",
+      "| bold  | **hi** |",
+      "| ital  | *hi*  |",
+      "| code  | `hi`  |",
+      "| link  | [hi](https://example.com) |",
+    ].join("\n");
+    const output = normalize(roundTrip(input));
+    expect(output).toContain("**hi**");
+    expect(output).toContain("*hi*");
+    expect(output).toContain("`hi`");
+    expect(output).toContain("[hi](https://example.com)");
+  });
+
+  it("table with empty cells", () => {
+    const input = ["| A | B |", "| - | - |", "|   | b1 |", "| a2 |    |"].join("\n");
+    const output = normalize(roundTrip(input));
+    expect(output).toContain("b1");
+    expect(output).toContain("a2");
+    // Two header cells survive
+    expect(output).toMatch(/\|\s*A\s*\|\s*B\s*\|/);
+  });
+
+  it("flat-offset survives across a table (annotation anchored after)", () => {
+    // Build a doc with: paragraph, table, paragraph. Verify the offset of the
+    // trailing paragraph in extractText() is correctly past the table content.
+    const input = [
+      "Before table.",
+      "",
+      "| H1 | H2 |",
+      "| -- | -- |",
+      "| a  | b  |",
+      "",
+      "ANCHORTARGET",
+    ].join("\n");
+
+    const doc = new Y.Doc();
+    loadMarkdown(doc, input);
+    const flat = extractText(doc);
+    // The anchor word must exist in flat text and live AFTER the table content
+    const anchorIdx = flat.indexOf("ANCHORTARGET");
+    expect(anchorIdx).toBeGreaterThan(0);
+    // The cell content "a" and "b" must appear before the anchor, joined by \t
+    const aIdx = flat.indexOf("a\tb");
+    expect(aIdx).toBeGreaterThan(-1);
+    expect(aIdx).toBeLessThan(anchorIdx);
+    // Round-trip preserves the anchor on disk
+    const output = saveMarkdown(doc);
+    expect(output).toContain("ANCHORTARGET");
+    expect(output).toContain("Before table.");
+    doc.destroy();
+  });
+
+  it("table preceded and followed by paragraphs survives round-trip", () => {
+    const input = [
+      "Intro paragraph.",
+      "",
+      "| K | V |",
+      "| - | - |",
+      "| a | 1 |",
+      "",
+      "Outro paragraph.",
+    ].join("\n");
+    const output = normalize(roundTrip(input));
+    expect(output).toContain("Intro paragraph.");
+    expect(output).toContain("Outro paragraph.");
+    expect(output).toContain("| K");
+    expect(output).toContain("| V");
+    expect(output).toContain("a");
   });
 });

--- a/tests/server/mdast-ydoc.test.ts
+++ b/tests/server/mdast-ydoc.test.ts
@@ -1,8 +1,9 @@
 import type { Root } from "mdast";
 import { afterEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
+import { loadMarkdown, saveMarkdown } from "../../src/server/file-io/markdown.js";
 import { mdastToYDoc, yDocToMdast } from "../../src/server/file-io/mdast-ydoc.js";
-import { getElementText } from "../../src/server/mcp/document.js";
+import { extractText, getElementText } from "../../src/server/mcp/document.js";
 import { getFragment } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
@@ -19,6 +20,36 @@ function loadTree(tree: Root): Y.Doc {
   doc = new Y.Doc();
   mdastToYDoc(doc, tree);
   return doc;
+}
+
+function appendTableCellParagraph(
+  cell: Y.XmlElement,
+  value: string,
+  attributes?: Record<string, object>,
+): void {
+  const paragraph = new Y.XmlElement("paragraph");
+  const text = new Y.XmlText();
+  paragraph.insert(0, [text]);
+  cell.insert(cell.length, [paragraph]);
+  text.insert(0, value, attributes);
+}
+
+function makeOneCellTable(
+  ...paragraphs: Array<{ value: string; attributes?: Record<string, object> }>
+): Y.Doc {
+  const tableDoc = new Y.Doc();
+  const table = new Y.XmlElement("table");
+  const row = new Y.XmlElement("tableRow");
+  const header = new Y.XmlElement("tableHeader");
+
+  table.setAttribute("align", JSON.stringify([null]) as any);
+  table.insert(0, [row]);
+  row.insert(0, [header]);
+  for (const paragraph of paragraphs) {
+    appendTableCellParagraph(header, paragraph.value, paragraph.attributes);
+  }
+  tableDoc.getXmlFragment("default").insert(0, [table]);
+  return tableDoc;
 }
 
 describe("mdastToYDoc — block nodes", () => {
@@ -464,5 +495,54 @@ describe("yDocToMdast — reverse conversion", () => {
     const p = tree.children[0] as any;
     // Should recognize as bold despite the hash suffix
     expect(p.children.some((c: any) => c.type === "strong")).toBe(true);
+  });
+});
+
+describe("yDocToMdast — table cell block flattening", () => {
+  it("serializes two paragraph children in one GFM cell", () => {
+    doc = makeOneCellTable({ value: "First" }, { value: "Second" });
+
+    const table = yDocToMdast(doc).children[0] as any;
+    const cell = table.children[0].children[0];
+
+    expect(cell.children).toEqual([
+      { type: "text", value: "First" },
+      { type: "text", value: " " },
+      { type: "text", value: "Second" },
+    ]);
+  });
+
+  it("skips an empty first paragraph and keeps the second paragraph", () => {
+    doc = makeOneCellTable({ value: "" }, { value: "Kept" });
+
+    const table = yDocToMdast(doc).children[0] as any;
+    const cell = table.children[0].children[0];
+
+    expect(cell.children).toEqual([{ type: "text", value: "Kept" }]);
+  });
+
+  it("preserves inline marks in later paragraphs", () => {
+    doc = makeOneCellTable({ value: "First" }, { value: "Bold", attributes: { bold: {} } });
+
+    const table = yDocToMdast(doc).children[0] as any;
+    const cell = table.children[0].children[0];
+
+    expect(cell.children[0]).toEqual({ type: "text", value: "First" });
+    expect(cell.children[1]).toEqual({ type: "text", value: " " });
+    expect(cell.children[2]).toMatchObject({ type: "strong" });
+    expect(cell.children[2].children).toEqual([{ type: "text", value: "Bold" }]);
+  });
+
+  it("saves as a pipe table and reloads with all cell strings preserved", () => {
+    doc = makeOneCellTable({ value: "First" }, { value: "Second" });
+
+    const markdown = saveMarkdown(doc);
+    expect(markdown).toMatch(/\|\s*First Second\s*\|/);
+    expect(markdown).toMatch(/\|\s*-+\s*\|/);
+
+    const reloaded = new Y.Doc();
+    loadMarkdown(reloaded, markdown);
+    expect(extractText(reloaded)).toContain("First Second");
+    reloaded.destroy();
   });
 });


### PR DESCRIPTION
## Summary

Closes #379.

GFM tables were silently dropped on load because `mdast-ydoc.ts` had no `case "table"` in either direction. This PR adds bidirectional MDAST ↔ Y.Doc conversion for tables, preserving structure, column alignment, inline marks within cells, and annotation offsets across the table.

- `blockToYxml` produces `table > tableRow > (tableHeader|tableCell) > paragraph > Y.XmlText`. The first MDAST `tableRow` becomes header cells; subsequent rows become body cells. Cell `Y.XmlText` is attached to the tree before population (deferred to pass 2) — matches the existing two-pass pattern for paragraph/heading and complies with CLAUDE.md Rule "Y.XmlText must be attached before populating" / Lesson 9.
- `yxmlToMdast` walks the inverse, reading the JSON-stringified `align` attribute off the table element and re-emitting `{ type: "table", align, children: rows }`. Body-row alignment is discarded (alignment is a column-level / table-level concept in MDAST GFM).
- `getElementText` emits `\t` between sibling cells inside a `tableRow` and `\n` between sibling rows (default `FLAT_SEPARATOR`). Lengths stay one char per gap, so `getElementTextLength`, `findXmlTextAtOffset`, and `collectXmlTexts` continue to work without modification.

### Separator contract (going forward)

| Boundary | Char |
|---|---|
| Cell within a row | `\t` |
| Row within a table | `\n` |
| Table to surrounding block | `\n` (existing top-level join) |

One-char-per-gap accounting keeps offset math the same as for lists/blockquotes — annotations placed after a table compute the same way they do after any other multi-element container.

### Alignment storage

Stored as `tableEl.setAttribute("align", JSON.stringify(node.align ?? []))`. Parsed back on save with try/catch, defaulting to `[]` on missing/malformed input. No Tiptap extension changes required.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- markdown-roundtrip` (24 tests, all green)
- [x] `npm run check:tokens` (clean)
- [x] Round-trip equality on alignment chars: `:--` / `:-:` / `--:` survive
- [x] Inline marks (bold, italic, code, link) inside cells survive
- [x] Empty cells preserved
- [x] **Annotation-offset round-trip:** flat text places `ANCHORTARGET` after a non-empty table; cells `a\tb` appear at a lower offset than the anchor, and `saveMarkdown` preserves both.
- [ ] Manual: open `docs/roadmap.md` → save with no edits → `git diff` does not delete table rows
- [ ] Manual: add `tandem_comment` inside a table cell, save, close, reopen → annotation still anchored

## Notes

Cosmetic regressions called out in #379's body (extra blank lines, angle-bracketed bare URLs, `&#x20;` entities) are remark-stringify config concerns, not data-loss bugs. Out of scope here; file a follow-up if not already tracked.