### PR TITLE
fix(channel): add per-request timeouts to event bridge and run.ts (#364)

### DIFF
--- a/src/channel/event-bridge.ts
+++ b/src/channel/event-bridge.ts
@@ -66,11 +66,7 @@ export async function startEventBridge(mcp: Server, tandemUrl: string): Promise<
         } catch (reportErr) {
           console.error(
             "[Channel] Could not report failure to server:",
-            describeFetchError(
-              reportErr,
-              "/api/channel-error",
-              CHANNEL_ERROR_REPORT_TIMEOUT_MS,
-            ),
+            describeFetchError(reportErr, "/api/channel-error", CHANNEL_ERROR_REPORT_TIMEOUT_MS),
           );
         }
         process.exit(1);
@@ -148,11 +144,7 @@ async function connectAndStream(
     ).catch((err) => {
       console.error(
         "[Channel] clearAwareness failed (non-fatal):",
-        describeFetchError(
-          err,
-          "/api/channel-awareness clear",
-          CHANNEL_AWARENESS_FETCH_TIMEOUT_MS,
-        ),
+        describeFetchError(err, "/api/channel-awareness clear", CHANNEL_AWARENESS_FETCH_TIMEOUT_MS),
       );
     });
   }
@@ -300,11 +292,7 @@ async function getCachedMode(tandemUrl: string): Promise<string> {
   const now = Date.now();
   if (now - cachedModeAt < MODE_CACHE_TTL_MS) return cachedMode;
   try {
-    const res = await fetchWithTimeout(
-      `${tandemUrl}/api/mode`,
-      {},
-      CHANNEL_MODE_FETCH_TIMEOUT_MS,
-    );
+    const res = await fetchWithTimeout(`${tandemUrl}/api/mode`, {}, CHANNEL_MODE_FETCH_TIMEOUT_MS);
     if (res.ok) {
       const { mode } = (await res.json()) as { mode: string };
       cachedMode = mode;

--- a/src/channel/event-bridge.ts
+++ b/src/channel/event-bridge.ts
@@ -1,13 +1,28 @@
 /**
  * SSE event bridge: connects to Tandem server's /api/events endpoint
  * and pushes received events to Claude Code as channel notifications.
+ *
+ * Per-request timeouts (#364) mirror the monitor pattern: every outbound
+ * fetch has a bounded deadline, the SSE body has an inactivity watchdog,
+ * and the parse buffer is capped so a malformed upstream can't OOM us.
+ * Without these, a half-open Tandem server wedges the bridge silently.
  */
 
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { authFetch } from "../shared/cli-runtime.js";
-import { CHANNEL_MAX_RETRIES, CHANNEL_RETRY_DELAY_MS } from "../shared/constants.js";
+import {
+  CHANNEL_AWARENESS_FETCH_TIMEOUT_MS,
+  CHANNEL_CONNECT_FETCH_TIMEOUT_MS,
+  CHANNEL_ERROR_REPORT_TIMEOUT_MS,
+  CHANNEL_MAX_RETRIES,
+  CHANNEL_MAX_SSE_BUFFER_BYTES,
+  CHANNEL_MODE_FETCH_TIMEOUT_MS,
+  CHANNEL_RETRY_DELAY_MS,
+  CHANNEL_SSE_INACTIVITY_TIMEOUT_MS,
+} from "../shared/constants.js";
 import type { TandemEvent } from "../shared/events/types.js";
 import { formatEventContent, formatEventMeta, parseTandemEvent } from "../shared/events/types.js";
+import { describeFetchError, fetchWithTimeout } from "../shared/fetch-with-timeout.js";
 
 const AWARENESS_DEBOUNCE_MS = 500;
 const MODE_CACHE_TTL_MS = 2000;
@@ -36,18 +51,26 @@ export async function startEventBridge(mcp: Server, tandemUrl: string): Promise<
       if (retries >= CHANNEL_MAX_RETRIES) {
         console.error("[Channel] SSE connection exhausted, reporting error and exiting");
         try {
-          await authFetch(`${tandemUrl}/api/channel-error`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              error: "CHANNEL_CONNECT_FAILED",
-              message: `Channel shim lost connection after ${CHANNEL_MAX_RETRIES} retries.`,
-            }),
-          });
+          await fetchWithTimeout(
+            `${tandemUrl}/api/channel-error`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                error: "CHANNEL_CONNECT_FAILED",
+                message: `Channel shim lost connection after ${CHANNEL_MAX_RETRIES} retries.`,
+              }),
+            },
+            CHANNEL_ERROR_REPORT_TIMEOUT_MS,
+          );
         } catch (reportErr) {
           console.error(
             "[Channel] Could not report failure to server:",
-            reportErr instanceof Error ? reportErr.message : reportErr,
+            describeFetchError(
+              reportErr,
+              "/api/channel-error",
+              CHANNEL_ERROR_REPORT_TIMEOUT_MS,
+            ),
           );
         }
         process.exit(1);
@@ -67,13 +90,41 @@ async function connectAndStream(
   const headers: Record<string, string> = { Accept: "text/event-stream" };
   if (lastEventId) headers["Last-Event-ID"] = lastEventId;
 
-  const res = await authFetch(`${tandemUrl}/api/events`, { headers });
+  // Split handshake timeout from body lifetime. Using AbortSignal.timeout on
+  // the fetch would kill the response body ReadableStream when the timeout
+  // fires — every SSE stream would abort at CHANNEL_CONNECT_FETCH_TIMEOUT_MS.
+  // A local AbortController cleared in `finally` after the handshake settles
+  // means the body stream is no longer governed by it.
+  const connectCtrl = new AbortController();
+  const connectTimer = setTimeout(
+    () => connectCtrl.abort(new Error("handshake timeout")),
+    CHANNEL_CONNECT_FETCH_TIMEOUT_MS,
+  );
+  let res: Response;
+  try {
+    res = await authFetch(`${tandemUrl}/api/events`, { headers, signal: connectCtrl.signal });
+  } finally {
+    clearTimeout(connectTimer);
+  }
   if (!res.ok) throw new Error(`SSE endpoint returned ${res.status}`);
   if (!res.body) throw new Error("SSE endpoint returned no body");
 
   const reader = res.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+
+  // Inactivity watchdog. A healthy stream emits keepalive comments
+  // periodically; if no bytes arrive for CHANNEL_SSE_INACTIVITY_TIMEOUT_MS,
+  // cancel the reader. reader.cancel() resolves a pending read() with
+  // {done: true} (does not reject), so we surface the cause via a flag.
+  let lastActivityAt = Date.now();
+  let inactivityTimedOut = false;
+  const watchdog = setInterval(() => {
+    if (Date.now() - lastActivityAt > CHANNEL_SSE_INACTIVITY_TIMEOUT_MS) {
+      inactivityTimedOut = true;
+      reader.cancel(new Error("SSE inactivity timeout")).catch(() => {});
+    }
+  }, CHANNEL_SSE_INACTIVITY_TIMEOUT_MS / 4);
 
   // Debounced awareness: only send the latest status after a quiet period
   let awarenessTimer: ReturnType<typeof setTimeout> | null = null;
@@ -82,18 +133,26 @@ async function connectAndStream(
   const AWARENESS_CLEAR_MS = 3000; // Reset active state after 3s of no new events
 
   function clearAwareness(documentId?: string) {
-    authFetch(`${tandemUrl}/api/channel-awareness`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        documentId: documentId ?? null,
-        status: "idle",
-        active: false,
-      }),
-    }).catch((err) => {
+    fetchWithTimeout(
+      `${tandemUrl}/api/channel-awareness`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          documentId: documentId ?? null,
+          status: "idle",
+          active: false,
+        }),
+      },
+      CHANNEL_AWARENESS_FETCH_TIMEOUT_MS,
+    ).catch((err) => {
       console.error(
         "[Channel] clearAwareness failed (non-fatal):",
-        err instanceof Error ? err.message : err,
+        describeFetchError(
+          err,
+          "/api/channel-awareness clear",
+          CHANNEL_AWARENESS_FETCH_TIMEOUT_MS,
+        ),
       );
     });
   }
@@ -102,16 +161,27 @@ async function connectAndStream(
     if (!pendingAwareness) return;
     const event = pendingAwareness;
     pendingAwareness = null;
-    authFetch(`${tandemUrl}/api/channel-awareness`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        documentId: event.documentId,
-        status: `processing: ${event.type}`,
-        active: true,
-      }),
-    }).catch((err) => {
-      console.error("[Channel] Awareness update failed:", err instanceof Error ? err.message : err);
+    fetchWithTimeout(
+      `${tandemUrl}/api/channel-awareness`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          documentId: event.documentId,
+          status: `processing: ${event.type}`,
+          active: true,
+        }),
+      },
+      CHANNEL_AWARENESS_FETCH_TIMEOUT_MS,
+    ).catch((err) => {
+      console.error(
+        "[Channel] Awareness update failed:",
+        describeFetchError(
+          err,
+          "/api/channel-awareness update",
+          CHANNEL_AWARENESS_FETCH_TIMEOUT_MS,
+        ),
+      );
     });
 
     // Auto-clear after timeout so the indicator doesn't stick
@@ -125,81 +195,100 @@ async function connectAndStream(
     awarenessTimer = setTimeout(flushAwareness, AWARENESS_DEBOUNCE_MS);
   }
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) throw new Error("SSE stream ended");
-
-    buffer += decoder.decode(value, { stream: true });
-
-    let boundary: number;
-    while ((boundary = buffer.indexOf("\n\n")) !== -1) {
-      const frame = buffer.slice(0, boundary);
-      buffer = buffer.slice(boundary + 2);
-
-      if (frame.startsWith(":")) continue;
-
-      let eventId: string | undefined;
-      let data: string | undefined;
-
-      for (const line of frame.split("\n")) {
-        if (line.startsWith("id: ")) eventId = line.slice(4);
-        else if (line.startsWith("data: ")) data = line.slice(6);
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        if (inactivityTimedOut) throw new Error("SSE inactivity timeout");
+        throw new Error("SSE stream ended");
       }
+      lastActivityAt = Date.now();
 
-      if (!data) continue;
+      buffer += decoder.decode(value, { stream: true });
 
-      let event: TandemEvent | null;
-      try {
-        event = parseTandemEvent(JSON.parse(data));
-      } catch {
-        console.error(
-          "[Channel] Malformed SSE event data (skipping), eventId=%s:",
-          eventId,
-          data.slice(0, 200),
+      if (buffer.length > CHANNEL_MAX_SSE_BUFFER_BYTES) {
+        throw new Error(
+          `SSE buffer exceeded ${CHANNEL_MAX_SSE_BUFFER_BYTES} bytes without a frame boundary`,
         );
-        // Permanently unparseable — advance past it to prevent infinite re-delivery on reconnect.
-        if (eventId) onEventId(eventId);
-        continue;
-      }
-      if (!event) {
-        console.error(
-          "[Channel] Invalid SSE event structure (skipping), eventId=%s:",
-          eventId,
-          data.slice(0, 200),
-        );
-        if (eventId) onEventId(eventId);
-        continue;
       }
 
-      // Solo mode: intentionally suppressed (not a delivery failure) — advance past it.
-      if (event.type !== "chat:message") {
-        const mode = await getCachedMode(tandemUrl);
-        if (mode === "solo") {
-          console.error(`[Channel] Solo mode: suppressed ${event.type} event`);
+      let boundary: number;
+      while ((boundary = buffer.indexOf("\n\n")) !== -1) {
+        const frame = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+
+        if (frame.startsWith(":")) continue;
+
+        let eventId: string | undefined;
+        let data: string | undefined;
+
+        for (const line of frame.split("\n")) {
+          if (line.startsWith("id: ")) eventId = line.slice(4);
+          else if (line.startsWith("data: ")) data = line.slice(6);
+        }
+
+        if (!data) continue;
+
+        let event: TandemEvent | null;
+        try {
+          event = parseTandemEvent(JSON.parse(data));
+        } catch {
+          console.error(
+            "[Channel] Malformed SSE event data (skipping), eventId=%s:",
+            eventId,
+            data.slice(0, 200),
+          );
+          // Permanently unparseable — advance past it to prevent infinite re-delivery on reconnect.
           if (eventId) onEventId(eventId);
           continue;
         }
+        if (!event) {
+          console.error(
+            "[Channel] Invalid SSE event structure (skipping), eventId=%s:",
+            eventId,
+            data.slice(0, 200),
+          );
+          if (eventId) onEventId(eventId);
+          continue;
+        }
+
+        // Solo mode: intentionally suppressed (not a delivery failure) — advance past it.
+        if (event.type !== "chat:message") {
+          const mode = await getCachedMode(tandemUrl);
+          if (mode === "solo") {
+            console.error(`[Channel] Solo mode: suppressed ${event.type} event`);
+            if (eventId) onEventId(eventId);
+            continue;
+          }
+        }
+
+        try {
+          await mcp.notification({
+            method: "notifications/claude/channel",
+            params: {
+              content: formatEventContent(event),
+              meta: formatEventMeta(event),
+            },
+          });
+        } catch (err) {
+          console.error("[Channel] MCP notification failed (transport broken?):", err);
+          throw err;
+        }
+
+        // Advance only after notification succeeds so a transport failure
+        // doesn't silently skip events on reconnect.
+        if (eventId) onEventId(eventId);
+
+        scheduleAwareness(event);
       }
-
-      try {
-        await mcp.notification({
-          method: "notifications/claude/channel",
-          params: {
-            content: formatEventContent(event),
-            meta: formatEventMeta(event),
-          },
-        });
-      } catch (err) {
-        console.error("[Channel] MCP notification failed (transport broken?):", err);
-        throw err;
-      }
-
-      // Advance only after notification succeeds so a transport failure
-      // doesn't silently skip events on reconnect.
-      if (eventId) onEventId(eventId);
-
-      scheduleAwareness(event);
     }
+  } finally {
+    // Single source of truth for timer cleanup — every exit path (success,
+    // throw, reader.cancel) runs through here so awareness/inactivity
+    // timers can't leak across reconnects.
+    clearInterval(watchdog);
+    if (awarenessTimer) clearTimeout(awarenessTimer);
+    if (clearAwarenessTimer) clearTimeout(clearAwarenessTimer);
   }
 }
 
@@ -211,7 +300,11 @@ async function getCachedMode(tandemUrl: string): Promise<string> {
   const now = Date.now();
   if (now - cachedModeAt < MODE_CACHE_TTL_MS) return cachedMode;
   try {
-    const res = await authFetch(`${tandemUrl}/api/mode`);
+    const res = await fetchWithTimeout(
+      `${tandemUrl}/api/mode`,
+      {},
+      CHANNEL_MODE_FETCH_TIMEOUT_MS,
+    );
     if (res.ok) {
       const { mode } = (await res.json()) as { mode: string };
       cachedMode = mode;
@@ -222,7 +315,7 @@ async function getCachedMode(tandemUrl: string): Promise<string> {
   } catch (err) {
     console.error(
       "[Channel] Mode check failed, delivering event (fail-open):",
-      err instanceof Error ? err.message : err,
+      describeFetchError(err, "/api/mode", CHANNEL_MODE_FETCH_TIMEOUT_MS),
     );
     cachedModeAt = now;
   }

--- a/src/channel/run.ts
+++ b/src/channel/run.ts
@@ -15,8 +15,17 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { authFetch, redirectConsoleToStderr, resolveTandemUrl } from "../shared/cli-runtime.js";
-import { DEFAULT_MCP_PORT } from "../shared/constants.js";
+import { redirectConsoleToStderr, resolveTandemUrl } from "../shared/cli-runtime.js";
+import {
+  CHANNEL_PERMISSION_FETCH_TIMEOUT_MS,
+  CHANNEL_REPLY_FETCH_TIMEOUT_MS,
+  DEFAULT_MCP_PORT,
+} from "../shared/constants.js";
+import {
+  describeFetchError,
+  fetchWithTimeout,
+  isAbortOrTimeoutError,
+} from "../shared/fetch-with-timeout.js";
 import { startEventBridge } from "./event-bridge.js";
 
 export interface RunChannelOptions {
@@ -83,15 +92,26 @@ export async function runChannel(opts: RunChannelOptions = {}): Promise<void> {
     if (req.params.name === "tandem_reply") {
       const args = req.params.arguments as Record<string, unknown>;
       try {
-        const res = await authFetch(`${tandemUrl}/api/channel-reply`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(args),
-        });
+        const res = await fetchWithTimeout(
+          `${tandemUrl}/api/channel-reply`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(args),
+          },
+          CHANNEL_REPLY_FETCH_TIMEOUT_MS,
+        );
         let data: unknown;
         try {
           data = await res.json();
-        } catch {
+        } catch (parseErr) {
+          // Re-throw timeout/abort errors so they surface as structured
+          // failures to Claude. AbortSignal.timeout fires DURING `res.json()`
+          // (headers landed but body hung); without this re-throw, the bare
+          // catch swallows AbortError and reports a fake-success "Non-JSON
+          // response" payload — exactly the silent-failure pattern #364
+          // exists to prevent.
+          if (isAbortOrTimeoutError(parseErr)) throw parseErr;
           data = { message: "Non-JSON response" };
         }
         if (!res.ok) {
@@ -111,7 +131,11 @@ export async function runChannel(opts: RunChannelOptions = {}): Promise<void> {
           content: [
             {
               type: "text" as const,
-              text: `Failed to send reply: ${err instanceof Error ? err.message : String(err)}`,
+              text: `Failed to send reply: ${describeFetchError(
+                err,
+                "/api/channel-reply",
+                CHANNEL_REPLY_FETCH_TIMEOUT_MS,
+              )}`,
             },
           ],
           isError: true,
@@ -133,23 +157,30 @@ export async function runChannel(opts: RunChannelOptions = {}): Promise<void> {
 
   mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }) => {
     try {
-      const res = await authFetch(`${tandemUrl}/api/channel-permission`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          requestId: params.request_id,
-          toolName: params.tool_name,
-          description: params.description,
-          inputPreview: params.input_preview,
-        }),
-      });
+      const res = await fetchWithTimeout(
+        `${tandemUrl}/api/channel-permission`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            requestId: params.request_id,
+            toolName: params.tool_name,
+            description: params.description,
+            inputPreview: params.input_preview,
+          }),
+        },
+        CHANNEL_PERMISSION_FETCH_TIMEOUT_MS,
+      );
       if (!res.ok) {
         console.error(
           `[Channel] Permission relay got HTTP ${res.status} — browser may not see prompt`,
         );
       }
     } catch (err) {
-      console.error("[Channel] Failed to forward permission request:", err);
+      console.error(
+        "[Channel] Failed to forward permission request:",
+        describeFetchError(err, "/api/channel-permission", CHANNEL_PERMISSION_FETCH_TIMEOUT_MS),
+      );
     }
   });
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -115,6 +115,22 @@ export const CHANNEL_SSE_KEEPALIVE_MS = 15_000; // 15 seconds
 export const CHANNEL_MAX_RETRIES = 5;
 export const CHANNEL_RETRY_DELAY_MS = 2_000;
 
+// Channel shim per-request timeouts. Mirror the monitor pattern (#364) so a
+// half-open Tandem server can't wedge `tandem_reply`, the permission relay,
+// or the event-bridge SSE handshake / awareness / mode / error-report POSTs.
+// Intentionally separate constants per endpoint so a slow endpoint doesn't
+// hold up a faster one — and so log lines name a meaningful threshold.
+export const CHANNEL_CONNECT_FETCH_TIMEOUT_MS = 10_000; // /api/events handshake
+export const CHANNEL_SSE_INACTIVITY_TIMEOUT_MS = 60_000; // No-bytes watchdog on SSE body
+export const CHANNEL_MODE_FETCH_TIMEOUT_MS = 2_000; // /api/mode cache refresh
+export const CHANNEL_AWARENESS_FETCH_TIMEOUT_MS = 5_000; // /api/channel-awareness POST
+export const CHANNEL_ERROR_REPORT_TIMEOUT_MS = 3_000; // /api/channel-error POST on exit
+export const CHANNEL_REPLY_FETCH_TIMEOUT_MS = 5_000; // /api/channel-reply (tandem_reply)
+export const CHANNEL_PERMISSION_FETCH_TIMEOUT_MS = 5_000; // /api/channel-permission relay
+// Bound the SSE buffer so a misbehaving server that never emits frame
+// boundaries can't wedge the bridge with unbounded string growth.
+export const CHANNEL_MAX_SSE_BUFFER_BYTES = 1_000_000;
+
 /** Auth token filename inside the app-data directory. */
 export const TOKEN_FILE_NAME = "auth-token";
 

--- a/src/shared/fetch-with-timeout.ts
+++ b/src/shared/fetch-with-timeout.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared fetch-with-timeout helper.
+ *
+ * Used by `src/monitor/index.ts` and `src/channel/` (event-bridge + run) to
+ * give every outbound HTTP call a bounded deadline. Without this, a half-open
+ * upstream wedges the caller silently — see #336 (silent failures) and #364
+ * (event-bridge transport timeout symmetry).
+ *
+ * Pure native `fetch` + `AbortSignal.timeout` so it can be imported from any
+ * surface without dragging in server deps. Routes through `authFetch` so the
+ * `TANDEM_AUTH_TOKEN` header is forwarded automatically when set.
+ *
+ * `describeFetchError` formats timeout aborts as `<endpoint> timed out after
+ * <ms>ms` so logs name the hung endpoint instead of the generic
+ * "operation was aborted" string from AbortError/TimeoutError.
+ */
+
+import { authFetch } from "./cli-runtime.js";
+
+/**
+ * Fetch with a per-request deadline.
+ *
+ * **Do not use for SSE handshake-then-stream patterns** — applying a fetch-level
+ * timeout to a streaming response also aborts the body `ReadableStream` when
+ * the timeout fires, killing the stream at `timeoutMs`. Use a local
+ * `AbortController` cleared after the handshake settles for that case.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const signal = AbortSignal.timeout(timeoutMs);
+  return authFetch(url, { ...init, signal });
+}
+
+/**
+ * Format a fetch error for logs. Recognizes `TimeoutError` / `AbortError`
+ * (both names that `AbortSignal.timeout` and manual aborts produce) and tags
+ * them with the endpoint + threshold so log lines name the hung request.
+ */
+export function describeFetchError(err: unknown, endpoint: string, timeoutMs: number): string {
+  if (err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError")) {
+    return `${endpoint} timed out after ${timeoutMs}ms`;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** True iff `err` is an AbortError or TimeoutError (the names produced by
+ *  AbortSignal.timeout and manual aborts). Channel callers re-throw these
+ *  through broad catches so timeouts surface as structured errors instead of
+ *  being swallowed as "non-JSON response" fake-success. */
+export function isAbortOrTimeoutError(err: unknown): boolean {
+  return err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
+}

--- a/tests/channel/fetch-with-timeout.test.ts
+++ b/tests/channel/fetch-with-timeout.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the shared `fetchWithTimeout` helper that channel/ and monitor/
+ * route through. Mirrors `tests/monitor/timeouts.test.ts` patterns.
+ *
+ * Coverage:
+ *  - timeout fires within bounded ms
+ *  - clearTimeout fires on success path (no leaked AbortSignal.timeout timer)
+ *  - AbortError propagates as a thrown error (not silent fake-success)
+ *  - late response after timeout is discarded by AbortSignal
+ *  - describeFetchError tags the endpoint and threshold
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  describeFetchError,
+  fetchWithTimeout,
+  isAbortOrTimeoutError,
+} from "../../src/shared/fetch-with-timeout.js";
+import { createFetchStub, installMonitorFakeTimers } from "../monitor/fetch-harness.js";
+
+describe("fetchWithTimeout", () => {
+  let stub: ReturnType<typeof createFetchStub>;
+
+  beforeEach(() => {
+    installMonitorFakeTimers();
+    stub = createFetchStub();
+    stub.install();
+  });
+  afterEach(() => {
+    stub.restore();
+    vi.useRealTimers();
+  });
+
+  it("aborts a hung fetch within the configured deadline", async () => {
+    stub.on("/api/slow", (_url, init) => {
+      const signal = init?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          // AbortSignal.timeout produces TimeoutError (DOMException name).
+          // Surface that name so callers can pattern-match correctly.
+          reject(new DOMException("aborted", "TimeoutError"));
+        });
+      });
+    });
+
+    const p = fetchWithTimeout("http://localhost/api/slow", {}, 1_000);
+    await vi.advanceTimersByTimeAsync(1_500);
+    await expect(p).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("returns the response on success without leaking the abort timer", async () => {
+    let resolvedAbortFired = false;
+    stub.on("/api/fast", (_url, init) => {
+      const signal = init?.signal;
+      signal?.addEventListener("abort", () => {
+        resolvedAbortFired = true;
+      });
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    });
+
+    const res = await fetchWithTimeout("http://localhost/api/fast", {}, 5_000);
+    expect(res.ok).toBe(true);
+    // Advance well past the timeout window — if the AbortSignal.timeout timer
+    // still fired, the abort handler would set the flag. AbortSignal.timeout
+    // is built on setTimeout, so the fake-timer surface controls it.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(resolvedAbortFired).toBe(false);
+  });
+
+  it("isAbortOrTimeoutError matches both AbortError and TimeoutError", () => {
+    expect(isAbortOrTimeoutError(new DOMException("a", "AbortError"))).toBe(true);
+    expect(isAbortOrTimeoutError(new DOMException("t", "TimeoutError"))).toBe(true);
+    expect(isAbortOrTimeoutError(new Error("plain"))).toBe(false);
+    expect(isAbortOrTimeoutError("string")).toBe(false);
+  });
+
+  it("describeFetchError tags timeout aborts with endpoint + ms", () => {
+    const err = new DOMException("aborted", "TimeoutError");
+    expect(describeFetchError(err, "/api/x", 2_000)).toBe("/api/x timed out after 2000ms");
+    const abort = new DOMException("aborted", "AbortError");
+    expect(describeFetchError(abort, "/api/y", 3_000)).toBe("/api/y timed out after 3000ms");
+    expect(describeFetchError(new Error("boom"), "/api/z", 1_000)).toBe("boom");
+  });
+});

--- a/tests/channel/reply-abort.test.ts
+++ b/tests/channel/reply-abort.test.ts
@@ -91,11 +91,7 @@ describe("tandem_reply AbortError handling", () => {
       });
     });
 
-    const p = callReplyLike(
-      "http://localhost/api/channel-reply",
-      { text: "hi" },
-      1_000,
-    );
+    const p = callReplyLike("http://localhost/api/channel-reply", { text: "hi" }, 1_000);
     await vi.advanceTimersByTimeAsync(1_500);
     const result = await p;
 
@@ -130,11 +126,7 @@ describe("tandem_reply AbortError handling", () => {
         headers: { "Content-Type": "application/json" },
       });
     });
-    const result = await callReplyLike(
-      "http://localhost/api/channel-reply",
-      { text: "hi" },
-      5_000,
-    );
+    const result = await callReplyLike("http://localhost/api/channel-reply", { text: "hi" }, 5_000);
     expect(result.isError).toBeUndefined();
     expect(JSON.parse(result.text)).toEqual({ ok: true, id: "abc" });
   });

--- a/tests/channel/reply-abort.test.ts
+++ b/tests/channel/reply-abort.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Behavior test for the `tandem_reply` AbortError re-throw (#364).
+ *
+ * Reproduces the silent-failure pattern: `fetchWithTimeout` resolves with a
+ * Response (headers landed) but `res.json()` hangs and the AbortSignal fires
+ * during the body read. Before #364, a bare `catch {}` swallowed the
+ * AbortError and reported `data = { message: "Non-JSON response" }` with
+ * `res.ok === true` — a fake-success returned to Claude with no `isError`.
+ *
+ * This test reproduces the run.ts handler logic in isolation (the handler
+ * body is not exported) and asserts that the AbortError surfaces as a
+ * structured `isError: true` response, not a fake-success.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  describeFetchError,
+  fetchWithTimeout,
+  isAbortOrTimeoutError,
+} from "../../src/shared/fetch-with-timeout.js";
+import { createFetchStub, installMonitorFakeTimers } from "../monitor/fetch-harness.js";
+
+/** Reproduce the run.ts tandem_reply call+parse logic. Kept tight to the
+ *  catch shape we're guarding so a future regression in run.ts has a
+ *  matching regression here. */
+async function callReplyLike(
+  url: string,
+  args: unknown,
+  timeoutMs: number,
+): Promise<{ isError?: boolean; text: string }> {
+  try {
+    const res = await fetchWithTimeout(
+      url,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(args),
+      },
+      timeoutMs,
+    );
+    let data: unknown;
+    try {
+      data = await res.json();
+    } catch (parseErr) {
+      if (isAbortOrTimeoutError(parseErr)) throw parseErr;
+      data = { message: "Non-JSON response" };
+    }
+    if (!res.ok) {
+      return { isError: true, text: `Reply failed (${res.status}): ${JSON.stringify(data)}` };
+    }
+    return { text: JSON.stringify(data) };
+  } catch (err) {
+    return {
+      isError: true,
+      text: `Failed to send reply: ${describeFetchError(err, "/api/channel-reply", timeoutMs)}`,
+    };
+  }
+}
+
+describe("tandem_reply AbortError handling", () => {
+  let stub: ReturnType<typeof createFetchStub>;
+
+  beforeEach(() => {
+    installMonitorFakeTimers();
+    stub = createFetchStub();
+    stub.install();
+  });
+  afterEach(() => {
+    stub.restore();
+    vi.useRealTimers();
+  });
+
+  it("surfaces a body-side timeout as isError (not fake-success Non-JSON response)", async () => {
+    // Headers land immediately so the caller enters res.json(); the body
+    // ReadableStream is bound to the AbortSignal, which fires when
+    // AbortSignal.timeout expires.
+    stub.on("/api/channel-reply", (_url, init) => {
+      const signal = init?.signal;
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // Abort plumbs through to controller.error so res.json() rejects.
+          signal?.addEventListener("abort", () => {
+            controller.error(new DOMException("aborted", "TimeoutError"));
+          });
+          // Never enqueue, never close — the body just hangs.
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const p = callReplyLike(
+      "http://localhost/api/channel-reply",
+      { text: "hi" },
+      1_000,
+    );
+    await vi.advanceTimersByTimeAsync(1_500);
+    const result = await p;
+
+    expect(result.isError).toBe(true);
+    expect(result.text).toMatch(/timed out after 1000ms/);
+    // The fake-success path would report this string instead.
+    expect(result.text).not.toMatch(/Non-JSON response/);
+  });
+
+  it("returns isError on connection-level timeout before headers arrive", async () => {
+    stub.on("/api/channel-reply", (_url, init) => {
+      const signal = init?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "TimeoutError"));
+        });
+      });
+    });
+
+    const p = callReplyLike("http://localhost/api/channel-reply", { text: "hi" }, 1_000);
+    await vi.advanceTimersByTimeAsync(1_500);
+    const result = await p;
+
+    expect(result.isError).toBe(true);
+    expect(result.text).toMatch(/\/api\/channel-reply timed out after 1000ms/);
+  });
+
+  it("returns success payload on normal 200 JSON response", async () => {
+    stub.on("/api/channel-reply", () => {
+      return new Response(JSON.stringify({ ok: true, id: "abc" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const result = await callReplyLike(
+      "http://localhost/api/channel-reply",
+      { text: "hi" },
+      5_000,
+    );
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.text)).toEqual({ ok: true, id: "abc" });
+  });
+});

--- a/tests/channel/run-timeouts.test.ts
+++ b/tests/channel/run-timeouts.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Static-analysis smoke tests for `src/channel/run.ts` timeout coverage (#364).
+ *
+ * `runChannel` builds an MCP `Server` and registers handlers inline — there
+ * is no exported `tandem_reply` function we can call in isolation. Rather
+ * than ship a refactor solely for testability, we assert on the source that:
+ *
+ *   1. The three `authFetch`-shaped callsites (tandem_reply via
+ *      /api/channel-reply, /api/channel-permission, plus the event-bridge
+ *      proxies) all flow through `fetchWithTimeout`.
+ *   2. The JSON-parse catch in `tandem_reply` re-throws AbortError /
+ *      TimeoutError instead of swallowing them as fake-success "Non-JSON
+ *      response" — this is the silent-failure pattern #364 closes.
+ *
+ * Static asserts catch a regression where a future edit adds a fresh
+ * `authFetch` call to run.ts without a deadline. Behavior tests for the
+ * underlying primitive live in `fetch-with-timeout.test.ts`.
+ */
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const RUN_TS_PATH = fileURLToPath(new URL("../../src/channel/run.ts", import.meta.url));
+const EVENT_BRIDGE_PATH = fileURLToPath(
+  new URL("../../src/channel/event-bridge.ts", import.meta.url),
+);
+
+describe("channel/run.ts timeout coverage", () => {
+  it("does not import authFetch directly — all HTTP goes through fetchWithTimeout", async () => {
+    const src = await readFile(RUN_TS_PATH, "utf8");
+    // No bare `authFetch(` call sites. The import line is also gone since
+    // run.ts now only consumes redirectConsoleToStderr + resolveTandemUrl.
+    expect(src).not.toMatch(/\bauthFetch\s*\(/);
+  });
+
+  it("wraps /api/channel-reply with fetchWithTimeout", async () => {
+    const src = await readFile(RUN_TS_PATH, "utf8");
+    expect(src).toMatch(/fetchWithTimeout\([\s\S]*?\/api\/channel-reply/);
+    expect(src).toMatch(/CHANNEL_REPLY_FETCH_TIMEOUT_MS/);
+  });
+
+  it("wraps /api/channel-permission with fetchWithTimeout", async () => {
+    const src = await readFile(RUN_TS_PATH, "utf8");
+    expect(src).toMatch(/fetchWithTimeout\([\s\S]*?\/api\/channel-permission/);
+    expect(src).toMatch(/CHANNEL_PERMISSION_FETCH_TIMEOUT_MS/);
+  });
+
+  it("re-throws AbortError/TimeoutError from the JSON-parse catch", async () => {
+    const src = await readFile(RUN_TS_PATH, "utf8");
+    // The inner catch now uses `isAbortOrTimeoutError(parseErr)` then throws.
+    // Without this, a body-side timeout reads as fake-success "Non-JSON response".
+    expect(src).toMatch(/isAbortOrTimeoutError\(parseErr\)\s*\)\s*throw\s+parseErr/);
+  });
+});
+
+describe("channel/event-bridge.ts timeout coverage", () => {
+  it("wraps every authFetch callsite with fetchWithTimeout (handshake exempt)", async () => {
+    const src = await readFile(EVENT_BRIDGE_PATH, "utf8");
+    // The SSE handshake retains a raw authFetch (intentional — the split
+    // controller pattern is documented inline). Assert exactly one bare
+    // authFetch call remains, and it is the handshake.
+    const bareAuthFetch = src.match(/\bauthFetch\s*\(/g) ?? [];
+    expect(bareAuthFetch.length).toBe(1);
+    expect(src).toMatch(/authFetch\(`\$\{tandemUrl\}\/api\/events`/);
+  });
+
+  it("uses split AbortController for the SSE handshake (not AbortSignal.timeout on the body)", async () => {
+    const src = await readFile(EVENT_BRIDGE_PATH, "utf8");
+    expect(src).toMatch(/new AbortController\(\)/);
+    expect(src).toMatch(/clearTimeout\(connectTimer\)/);
+  });
+
+  it("includes an SSE inactivity watchdog and bounded buffer", async () => {
+    const src = await readFile(EVENT_BRIDGE_PATH, "utf8");
+    expect(src).toMatch(/CHANNEL_SSE_INACTIVITY_TIMEOUT_MS/);
+    expect(src).toMatch(/CHANNEL_MAX_SSE_BUFFER_BYTES/);
+    expect(src).toMatch(/reader\.cancel\(/);
+  });
+
+  it("clears watchdog and awareness timers in finally (no leaked timers across reconnects)", async () => {
+    const src = await readFile(EVENT_BRIDGE_PATH, "utf8");
+    expect(src).toMatch(/finally\s*\{[\s\S]*?clearInterval\(watchdog\)/);
+    expect(src).toMatch(/finally\s*\{[\s\S]*?clearTimeout\(awarenessTimer\)/);
+    expect(src).toMatch(/finally\s*\{[\s\S]*?clearTimeout\(clearAwarenessTimer\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #364. The channel shim's outbound HTTP calls had no per-request deadlines — a half-open Tandem server would wedge the bridge silently. This mirrors the per-request timeout pattern from PR #363 (`src/cli/mcp-stdio.ts`) and the existing `src/monitor/` SSE watchdog into `src/channel/`.

The literal `Map<id, setTimeout>` from #363 doesn't apply here — the event bridge emits `mcp.notification()` (no id) and `tandem_reply` is the only request-shaped surface. The "mirror" in practice is a bounded-deadline fetch helper, an SSE inactivity watchdog, and a buffer cap.

## Wrapped callsites (8 total)

`src/channel/event-bridge.ts` (6):
1. `/api/channel-error` failure-report POST — `CHANNEL_ERROR_REPORT_TIMEOUT_MS` (3s)
2. `/api/events` SSE handshake — `CHANNEL_CONNECT_FETCH_TIMEOUT_MS` (10s) via split `AbortController` cleared in `finally` after handshake settles, so the body `ReadableStream` is not aborted at handshake-timeout
3. SSE reader loop — new inactivity watchdog `CHANNEL_SSE_INACTIVITY_TIMEOUT_MS` (60s) + buffer cap `CHANNEL_MAX_SSE_BUFFER_BYTES` (1 MB)
4. `clearAwareness` POST `/api/channel-awareness` — `CHANNEL_AWARENESS_FETCH_TIMEOUT_MS` (5s)
5. `flushAwareness` POST `/api/channel-awareness` — `CHANNEL_AWARENESS_FETCH_TIMEOUT_MS` (5s)
6. `/api/mode` cache refresh — `CHANNEL_MODE_FETCH_TIMEOUT_MS` (2s)

`src/channel/run.ts` (2):
7. `tandem_reply` → `/api/channel-reply` — `CHANNEL_REPLY_FETCH_TIMEOUT_MS` (5s)
8. `setNotificationHandler(PermissionRequestSchema)` → `/api/channel-permission` — `CHANNEL_PERMISSION_FETCH_TIMEOUT_MS` (5s)

## AbortError re-throw fix (the silent-failure-prevention bit)

`src/channel/run.ts:92-96` previously wrapped `await res.json()` in a bare `catch {}` that defaulted `data = { message: "Non-JSON response" }`. When `AbortSignal.timeout` fires during `res.json()` (headers landed but the body hangs), the AbortError was swallowed and a fake-success — `res.ok === true`, no `isError` — was returned to Claude. Exactly the silent-failure pattern #364 exists to prevent.

The inner catch now re-throws via `isAbortOrTimeoutError(parseErr)` so the timeout surfaces through the outer catch as `isError: true` with a `/api/channel-reply timed out after 5000ms` message. Covered by `tests/channel/reply-abort.test.ts`.

## Implementation notes

- New shared helper `src/shared/fetch-with-timeout.ts` — `fetchWithTimeout`, `describeFetchError`, `isAbortOrTimeoutError`. Routes through existing `authFetch` so `TANDEM_AUTH_TOKEN` still propagates.
- New constants in `src/shared/constants.ts` (channel-prefixed). `STDIO_REQUEST_TIMEOUT_MS` intentionally stays in `src/cli/mcp-stdio.ts` — its `TANDEM_REQUEST_TIMEOUT_MS` env override and parsing helper are stdio-specific.
- Timer cleanup: SSE watchdog (`setInterval`) and awareness debounce/clear timers all clear in a single `try/finally` around the reader loop, so reconnects don't leak timers.
- Handshake comment documents why `AbortSignal.timeout(...)` on the SSE fetch is wrong — it would abort the body stream at handshake-timeout.

## Tests

`tests/channel/` (new):
- `fetch-with-timeout.test.ts` — timeout fires within deadline, success path doesn't leak the abort timer, `describeFetchError` tags endpoint + ms.
- `reply-abort.test.ts` — reproduces the body-side AbortError path; asserts `isError: true` with timeout message instead of `Non-JSON response` fake-success.
- `run-timeouts.test.ts` — static-analysis assertions that all `authFetch`-shaped callsites in `run.ts` and `event-bridge.ts` flow through `fetchWithTimeout`, the JSON-parse re-throw is in place, and timer cleanup is in `finally`.

`npm run typecheck` clean. `npx vitest run tests/channel tests/monitor` — 61/61 pass. Full suite: 1687 pass / 1 unrelated Windows file-copy flake (`tests/server/file-opener-lifecycle.test.ts` `copyfile` of a `mammoth` test fixture).

## Test plan

- [x] Unit: timeout fires, AbortError re-throws as structured error, fetch-with-timeout cleanup verified
- [x] `npm run typecheck` clean
- [ ] Manual half-open server check (plan.md step 2): kill dev server, bind :3479 with a no-op TCP listener, spawn channel shim, observe `[Channel] /api/events timed out after 10000ms` within 10s
- [ ] Manual hung-body check (plan.md step 3): server returns 200 on `/api/events` but never writes; observe `SSE inactivity timeout` within 60s
- [ ] Manual `tandem_reply` slow upstream (plan.md step 5): verify `isError: true` returns within 5s instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
