### PR TITLE
fix(annotations): route lossy sanitize coercions to migration-log (#483)

### DIFF
--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -22,7 +22,10 @@ function buildDecorations(
   const maxPos = doc.content.size;
 
   annotationsMap.forEach((value) => {
-    const ann = sanitizeAnnotation(value as Annotation);
+    const ann = sanitizeAnnotation(value as Annotation, (event) => {
+      // Browser DevTools breadcrumb — only forensic trail client-side.
+      console.warn("[sanitize]", event);
+    });
     if (ann.status !== "pending") return;
     if (!ann.range && !ann.relRange) return;
 

--- a/src/client/hooks/useYjsSync.ts
+++ b/src/client/hooks/useYjsSync.ts
@@ -90,7 +90,11 @@ export function useYjsSync(): YjsSyncResult {
     const annotationObserver = () => {
       const anns: Annotation[] = [];
       annotationsMap.forEach((value) => {
-        anns.push(sanitizeAnnotation(value as Annotation));
+        anns.push(
+          sanitizeAnnotation(value as Annotation, (event) => {
+            console.warn("[sanitize]", event);
+          }),
+        );
       });
       setAnnotations(anns);
     };

--- a/src/client/panels/SidePanel.tsx
+++ b/src/client/panels/SidePanel.tsx
@@ -140,7 +140,9 @@ export function SidePanel({
     const map = y.getMap(Y_MAP_ANNOTATIONS);
     const raw = map.get(id) as Annotation | undefined;
     if (!raw) return;
-    const ann = sanitizeAnnotation(raw);
+    const ann = sanitizeAnnotation(raw, (event) => {
+      console.warn("[sanitize]", event);
+    });
 
     // If the annotation has suggestedText, newContent is JSON-encoded
     // {suggestedText, content} from the AnnotationCard edit form.

--- a/src/client/panels/useAnnotationReview.ts
+++ b/src/client/panels/useAnnotationReview.ts
@@ -2,10 +2,16 @@ import type { Editor as TiptapEditor } from "@tiptap/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as Y from "yjs";
 import { Y_MAP_ANNOTATIONS } from "../../shared/constants";
+import type { SanitizationEvent } from "../../shared/sanitize";
 import { sanitizeAnnotation } from "../../shared/sanitize";
 import type { Annotation } from "../../shared/types";
 import { useReviewKeyboard } from "../hooks/useReviewKeyboard";
 import { annotationToPmRange } from "../positions";
+
+/** Browser DevTools breadcrumb — only forensic trail client-side when sanitize coerces. */
+const devSanitizeWarn = (event: SanitizationEvent): void => {
+  console.warn("[sanitize]", event);
+};
 
 /** Apply an annotation's replacement text in the editor */
 function applySuggestion(ann: Annotation, editor: TiptapEditor, ydoc: Y.Doc | null): boolean {
@@ -100,7 +106,7 @@ export function useAnnotationReview({
     const map = y.getMap(Y_MAP_ANNOTATIONS);
     const raw = map.get(id) as Annotation | undefined;
     if (!raw) return;
-    const ann = sanitizeAnnotation(raw);
+    const ann = sanitizeAnnotation(raw, devSanitizeWarn);
     map.set(id, { ...ann, status });
     // Only annotations with suggestedText trigger a text replacement when
     // accepted. For plain comments/highlights/flags, accepting is just a
@@ -158,7 +164,7 @@ export function useAnnotationReview({
       removeFromResolved(id);
       return false;
     }
-    const ann = sanitizeAnnotation(raw);
+    const ann = sanitizeAnnotation(raw, devSanitizeWarn);
 
     if (ann.status === "accepted" && ann.suggestedText !== undefined && editorRef.current) {
       try {

--- a/src/server/annotations/migration-log.ts
+++ b/src/server/annotations/migration-log.ts
@@ -16,7 +16,16 @@
  * shared dependency-free home both can import from.
  */
 
-export type LegacyMigrationKind = "flag" | "directedAt" | "legacy-type";
+import type { SanitizationEvent } from "../../shared/sanitize.js";
+
+export type LegacyMigrationKind =
+  | "flag"
+  | "directedAt"
+  | "legacy-type"
+  | "flag-to-note"
+  | "question-to-comment"
+  | "malformed-suggestion-json"
+  | "unknown-type";
 
 /** Dedup state — `${docHash}:${kind}`. Cleared on doc close via `forgetDoc`. */
 const loggedLegacyMigrations = new Set<string>();
@@ -51,4 +60,28 @@ export function forgetDoc(docHash: string): void {
 /** Reset all dedup state. Tests only. */
 export function resetMigrationLog(): void {
   loggedLegacyMigrations.clear();
+}
+
+/**
+ * Server-side relay for `sanitizeAnnotation`'s `onLossy` callback. Maps the
+ * shared `SanitizationEvent` discriminated union to a `LegacyMigrationKind`
+ * and routes through the dedup'd `logLegacyMigration` channel so silent
+ * sanitize coercions become visible in the migration trail.
+ *
+ * Imported lazily by callers that already have a docHash/docName in hand.
+ * Callers without one pass `undefined` and accept un-deduped logging.
+ */
+
+export function relaySanitizationEvent(
+  docHash: string | undefined,
+  event: SanitizationEvent,
+): void {
+  switch (event.kind) {
+    case "flag-to-note":
+    case "question-to-comment":
+    case "malformed-suggestion-json":
+    case "unknown-type":
+      logLegacyMigration(docHash, event.kind);
+      return;
+  }
 }

--- a/src/server/annotations/sync.ts
+++ b/src/server/annotations/sync.ts
@@ -59,7 +59,7 @@ import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../shared/consta
 import { type RawAnnotation, sanitizeAnnotation } from "../../shared/sanitize.js";
 import { AnnotationTypeSchema } from "../../shared/types.js";
 import { FILE_SYNC_ORIGIN } from "../events/origins.js";
-import { forgetDoc, logLegacyMigration } from "./migration-log.js";
+import { forgetDoc, logLegacyMigration, relaySanitizationEvent } from "./migration-log.js";
 import {
   type AnnotationDocV1,
   type AnnotationRecordV1,
@@ -133,7 +133,9 @@ function normalizeAnnotation(raw: unknown, docHash?: string): AnnotationRecordV1
     logLegacyMigration(docHash, "legacy-type");
   }
 
-  const sanitized = sanitizeAnnotation(obj as unknown as RawAnnotation);
+  const sanitized = sanitizeAnnotation(obj as unknown as RawAnnotation, (event) =>
+    relaySanitizationEvent(docHash, event),
+  );
   return {
     ...sanitized,
     rev: typeof obj.rev === "number" ? obj.rev : 0,

--- a/src/server/events/observers/annotations.ts
+++ b/src/server/events/observers/annotations.ts
@@ -1,6 +1,7 @@
 import * as Y from "yjs";
 import { Y_MAP_ANNOTATIONS } from "../../../shared/constants.js";
 import { sanitizeAnnotation } from "../../../shared/sanitize.js";
+import { relaySanitizationEvent } from "../../annotations/migration-log.js";
 import type { Annotation } from "../../../shared/types.js";
 import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "../origins.js";
 import type { TandemEvent } from "../types.js";
@@ -23,7 +24,7 @@ export function makeAnnotationsObserver(deps: {
 
       let ann: Annotation;
       try {
-        ann = sanitizeAnnotation(raw);
+        ann = sanitizeAnnotation(raw, (event) => relaySanitizationEvent(docName, event));
       } catch (err) {
         console.warn(`[EventQueue] sanitizeAnnotation failed for key=${key}:`, err);
         continue;

--- a/src/server/events/observers/annotations.ts
+++ b/src/server/events/observers/annotations.ts
@@ -1,8 +1,8 @@
 import * as Y from "yjs";
 import { Y_MAP_ANNOTATIONS } from "../../../shared/constants.js";
 import { sanitizeAnnotation } from "../../../shared/sanitize.js";
-import { relaySanitizationEvent } from "../../annotations/migration-log.js";
 import type { Annotation } from "../../../shared/types.js";
+import { relaySanitizationEvent } from "../../annotations/migration-log.js";
 import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "../origins.js";
 import type { TandemEvent } from "../types.js";
 import { generateEventId } from "../types.js";

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -3,8 +3,8 @@ import * as Y from "yjs";
 import { z } from "zod";
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
 import type { AnchoredRangeResult, RangeValidation } from "../../shared/positions/index.js";
-import { sanitizeAnnotation } from "../../shared/sanitize.js";
 import type { SanitizationEvent } from "../../shared/sanitize.js";
+import { sanitizeAnnotation } from "../../shared/sanitize.js";
 import type {
   Annotation,
   AnnotationReply,

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
 import type { AnchoredRangeResult, RangeValidation } from "../../shared/positions/index.js";
 import { sanitizeAnnotation } from "../../shared/sanitize.js";
+import type { SanitizationEvent } from "../../shared/sanitize.js";
 import type {
   Annotation,
   AnnotationReply,
@@ -25,6 +26,7 @@ import {
   generateReplyId,
 } from "../../shared/utils.js";
 import { docHash } from "../annotations/doc-hash.js";
+import { relaySanitizationEvent } from "../annotations/migration-log.js";
 import { nextRev } from "../annotations/schema.js";
 import { recordTombstone } from "../annotations/sync.js";
 import { MCP_ORIGIN } from "../events/queue.js";
@@ -38,11 +40,21 @@ import { mcpError, mcpSuccess, noDocumentError, withErrorBoundary } from "./resp
 /** Get the Y.Doc and annotations Y.Map for a document, or null if no doc is open */
 function getDocAndAnnotations(
   documentId?: string,
-): { ydoc: Y.Doc; map: Y.Map<unknown>; filePath: string } | null {
+): { ydoc: Y.Doc; map: Y.Map<unknown>; filePath: string; docHash: string } | null {
   const doc = getCurrentDoc(documentId);
   if (!doc) return null;
   const ydoc = getOrCreateDocument(doc.docName);
-  return { ydoc, map: ydoc.getMap(Y_MAP_ANNOTATIONS), filePath: doc.filePath };
+  return {
+    ydoc,
+    map: ydoc.getMap(Y_MAP_ANNOTATIONS),
+    filePath: doc.filePath,
+    docHash: docHash(doc.filePath),
+  };
+}
+
+/** Build an `onLossy` callback that relays to the migration-log for the given doc. */
+function makeOnLossy(hash: string | undefined): (event: SanitizationEvent) => void {
+  return (event) => relaySanitizationEvent(hash, event);
 }
 
 /** Get the annotation replies Y.Map for a document. */
@@ -112,7 +124,7 @@ export function addReplyToAnnotation(
   const raw = annotationsMap.get(annotationId) as Annotation | undefined;
   if (!raw) return { ok: false, error: `Annotation ${annotationId} not found`, code: "NOT_FOUND" };
 
-  const ann = sanitizeAnnotation(raw);
+  const ann = sanitizeAnnotation(raw, makeOnLossy(undefined));
   if (ann.status !== "pending") {
     return {
       ok: false,
@@ -260,8 +272,9 @@ export { type RawAnnotation, sanitizeAnnotation } from "../../shared/sanitize.js
 
 /** Collect all annotations from the Y.Map as an array, skipping malformed entries.
  *  Applies sanitizeAnnotation() to normalize legacy shapes. */
-export function collectAnnotations(map: Y.Map<unknown>): Annotation[] {
+export function collectAnnotations(map: Y.Map<unknown>, docHashKey?: string): Annotation[] {
   const result: Annotation[] = [];
+  const onLossy = makeOnLossy(docHashKey);
   map.forEach((value, key) => {
     const ann = value as Record<string, unknown>;
     if (
@@ -274,7 +287,7 @@ export function collectAnnotations(map: Y.Map<unknown>): Annotation[] {
       typeof (ann.range as Record<string, unknown>).from === "number" &&
       typeof (ann.range as Record<string, unknown>).to === "number"
     ) {
-      result.push(sanitizeAnnotation(ann as unknown as Annotation));
+      result.push(sanitizeAnnotation(ann as unknown as Annotation, onLossy));
     } else {
       console.warn(`[Tandem] Skipping malformed annotation entry: ${key}`);
     }
@@ -430,7 +443,7 @@ export function registerAnnotationTools(server: McpServer): void {
         const da = getDocAndAnnotations(documentId);
         if (!da) return noDocumentError();
 
-        let results = refreshAllRanges(collectAnnotations(da.map), da.ydoc, da.map);
+        let results = refreshAllRanges(collectAnnotations(da.map, da.docHash), da.ydoc, da.map);
         if (author) results = results.filter((a) => a.author === author);
         if (type) results = results.filter((a) => a.type === type);
         if (status) results = results.filter((a) => a.status === status);
@@ -489,7 +502,7 @@ export function registerAnnotationTools(server: McpServer): void {
       const raw = da.map.get(id) as Annotation | undefined;
       if (!raw) return mcpError("INVALID_RANGE", `Annotation ${id} not found`);
 
-      const ann = sanitizeAnnotation(raw);
+      const ann = sanitizeAnnotation(raw, makeOnLossy(da.docHash));
       const updated = {
         ...ann,
         status: action === "accept" ? ("accepted" as const) : ("dismissed" as const),
@@ -542,7 +555,7 @@ export function registerAnnotationTools(server: McpServer): void {
         if (!raw) return mcpError("INVALID_RANGE", `Annotation ${id} not found`);
 
         // Sanitize legacy shapes before editing
-        const ann = sanitizeAnnotation(raw);
+        const ann = sanitizeAnnotation(raw, makeOnLossy(da.docHash));
 
         if (ann.status !== "pending") {
           return mcpError("INVALID_RANGE", `Cannot edit a ${ann.status} annotation`);
@@ -596,7 +609,7 @@ export function registerAnnotationTools(server: McpServer): void {
       const da = getDocAndAnnotations(documentId);
       if (!da) return noDocumentError();
 
-      const annotations = refreshAllRanges(collectAnnotations(da.map), da.ydoc, da.map);
+      const annotations = refreshAllRanges(collectAnnotations(da.map, da.docHash), da.ydoc, da.map);
       const { ydoc } = da;
 
       const repliesMap = getRepliesMap(ydoc);

--- a/src/server/mcp/docx-apply.ts
+++ b/src/server/mcp/docx-apply.ts
@@ -15,6 +15,8 @@ import {
   atomicWriteBuffer,
 } from "../file-io/index.js";
 import { relPosToFlatOffset } from "../positions.js";
+import { docHash } from "../annotations/doc-hash.js";
+import { relaySanitizationEvent } from "../annotations/migration-log.js";
 import { sanitizeAnnotation } from "./annotations.js";
 import { extractText } from "./document-model.js";
 import { getCurrentDoc, requireDocument } from "./document-service.js";
@@ -83,8 +85,11 @@ export async function applyChangesCore(
   const suggestions: AcceptedSuggestion[] = [];
   let pendingCount = 0;
 
+  const applyDocHash = docHash(filePath);
   for (const [, raw] of map) {
-    const ann = sanitizeAnnotation(raw as Annotation);
+    const ann = sanitizeAnnotation(raw as Annotation, (event) =>
+      relaySanitizationEvent(applyDocHash, event),
+    );
     if (ann.suggestedText === undefined) continue;
     if (ann.status === "pending") {
       pendingCount++;

--- a/src/server/mcp/docx-apply.ts
+++ b/src/server/mcp/docx-apply.ts
@@ -9,14 +9,14 @@ import path from "path";
 import { z } from "zod";
 import { Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
 import type { Annotation } from "../../shared/types.js";
+import { docHash } from "../annotations/doc-hash.js";
+import { relaySanitizationEvent } from "../annotations/migration-log.js";
 import {
   type AcceptedSuggestion,
   applyTrackedChanges,
   atomicWriteBuffer,
 } from "../file-io/index.js";
 import { relPosToFlatOffset } from "../positions.js";
-import { docHash } from "../annotations/doc-hash.js";
-import { relaySanitizationEvent } from "../annotations/migration-log.js";
 import { sanitizeAnnotation } from "./annotations.js";
 import { extractText } from "./document-model.js";
 import { getCurrentDoc, requireDocument } from "./document-service.js";

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -20,6 +20,7 @@ import { UPLOAD_PREFIX } from "../../shared/paths.js";
 import type { Annotation } from "../../shared/types.js";
 import { generateNotificationId } from "../../shared/utils.js";
 import { docHash } from "../annotations/doc-hash.js";
+import { relaySanitizationEvent } from "../annotations/migration-log.js";
 import { createStore } from "../annotations/store.js";
 import { loadAndMerge } from "../annotations/sync.js";
 import {
@@ -636,7 +637,14 @@ async function reloadFromDisk(id: string, filePath: string, format: string): Pro
     // 3. Refresh all annotation ranges in a batch transaction (sanitize legacy shapes)
     const annotationMap = doc.getMap(Y_MAP_ANNOTATIONS);
     const annotations: Annotation[] = [];
-    annotationMap.forEach((val) => annotations.push(sanitizeAnnotation(val as Annotation)));
+    const reloadDocHash = docHash(filePath);
+    annotationMap.forEach((val) =>
+      annotations.push(
+        sanitizeAnnotation(val as Annotation, (event) =>
+          relaySanitizationEvent(reloadDocHash, event),
+        ),
+      ),
+    );
 
     if (annotations.length > 0) {
       const refreshed = refreshAllRanges(annotations, doc, annotationMap);

--- a/src/shared/sanitize.ts
+++ b/src/shared/sanitize.ts
@@ -4,6 +4,30 @@ import type { Annotation } from "./types.js";
 export type RawAnnotation = Omit<Annotation, "type"> & { type: string };
 
 /**
+ * Discriminated union describing a lossy rewrite performed by
+ * `sanitizeAnnotation`. Reported via the required `onLossy` callback so
+ * callers can route the event to their own observability sink (server:
+ * migration-log; client: dev console).
+ *
+ * NEW kinds added here MUST be handled in `relaySanitizationEvent`
+ * (`src/server/annotations/migration-log.ts`) — extend
+ * `LegacyMigrationKind` in lockstep.
+ */
+export type SanitizationEvent =
+  | { kind: "flag-to-note"; id: string }
+  | { kind: "question-to-comment"; id: string }
+  | { kind: "malformed-suggestion-json"; id: string }
+  | { kind: "unknown-type"; id: string; rawType: string };
+
+/**
+ * Required callback invoked once per lossy rewrite. Sync only — Promise
+ * returns are forbidden at the type level. Errors thrown from the callback
+ * are caught inside `sanitizeAnnotation` and logged to stderr; sanitize
+ * never aborts mid-`.map()` because of a faulty relay.
+ */
+export type OnLossy = (event: SanitizationEvent) => void;
+
+/**
  * Normalize a legacy annotation into the unified shape.
  * - `suggestion` → `comment` with `suggestedText` + `content` (parsed from JSON)
  * - `question` → `comment` (directedAt removed per ADR-027)
@@ -17,8 +41,16 @@ export type RawAnnotation = Omit<Annotation, "type"> & { type: string };
  *   here is load-bearing: without it every sanitize-then-write cycle in the
  *   MCP tools would reset `rev` to undefined and the sync observer would
  *   serialize `rev: 0` forever.
+ *
+ * `onLossy` is REQUIRED. Lossy rewrites — `flag→note`, `question→comment`,
+ * malformed-suggestion-JSON, unknown-type → comment — fire one event each.
+ * Making the callback required is the TS-level enforcement that prevents a
+ * forgotten callsite from silently regressing observability.
  */
-export function sanitizeAnnotation(input: Annotation | RawAnnotation): Annotation {
+export function sanitizeAnnotation(
+  input: Annotation | RawAnnotation,
+  onLossy: OnLossy,
+): Annotation {
   const ann = input as RawAnnotation;
 
   // Build a base with only AnnotationBase fields (strip legacy type-specific fields)
@@ -35,6 +67,17 @@ export function sanitizeAnnotation(input: Annotation | RawAnnotation): Annotatio
     ...(typeof ann.rev === "number" ? { rev: ann.rev } : {}),
   };
 
+  const emit = (event: SanitizationEvent): void => {
+    try {
+      onLossy(event);
+    } catch (err) {
+      // Never abort sanitize because of a faulty relay. The whole point of
+      // the callback is observability — if it throws, log to stderr (which
+      // the server redirects from console.warn) and move on.
+      console.warn(`[sanitizeAnnotation] onLossy threw for ${event.kind}:`, err);
+    }
+  };
+
   if (ann.type === "suggestion") {
     let suggestedText: string | undefined;
     let content: string;
@@ -43,15 +86,14 @@ export function sanitizeAnnotation(input: Annotation | RawAnnotation): Annotatio
       suggestedText = parsed.newText;
       content = parsed.reason ?? "";
     } catch {
-      console.warn(
-        `[sanitizeAnnotation] Malformed JSON in legacy suggestion ${ann.id}, treating as plain comment`,
-      );
+      emit({ kind: "malformed-suggestion-json", id: ann.id });
       content = ann.content;
     }
     return { ...base, type: "comment", content, suggestedText } as Annotation;
   }
 
   if (ann.type === "question") {
+    emit({ kind: "question-to-comment", id: ann.id });
     return { ...base, type: "comment" } as Annotation;
   }
 
@@ -64,6 +106,9 @@ export function sanitizeAnnotation(input: Annotation | RawAnnotation): Annotatio
   }
 
   if (ann.type === "flag" || ann.type === "note") {
+    if (ann.type === "flag") {
+      emit({ kind: "flag-to-note", id: ann.id });
+    }
     return { ...base, type: "note" } as Annotation;
   }
 
@@ -75,9 +120,7 @@ export function sanitizeAnnotation(input: Annotation | RawAnnotation): Annotatio
     } as Annotation;
   }
 
-  // Truly unknown type — coerce to comment with warning
-  console.warn(
-    `[sanitizeAnnotation] Unknown type "${ann.type}" for ${ann.id}, coercing to "comment"`,
-  );
+  // Truly unknown type — coerce to comment
+  emit({ kind: "unknown-type", id: ann.id, rawType: ann.type });
   return { ...base, type: "comment" } as Annotation;
 }

--- a/tests/server/annotations.test.ts
+++ b/tests/server/annotations.test.ts
@@ -321,7 +321,7 @@ describe("sanitizeAnnotation", () => {
       type: "suggestion",
       content: JSON.stringify({ newText: "Hi", reason: "brevity" }),
     };
-    const result = sanitizeAnnotation(legacy as unknown as Annotation);
+    const result = sanitizeAnnotation(legacy as unknown as Annotation, () => {});
     expect(result.type).toBe("comment");
     expect(result.suggestedText).toBe("Hi");
     expect(result.content).toBe("brevity");
@@ -329,7 +329,7 @@ describe("sanitizeAnnotation", () => {
 
   it("converts legacy suggestion with malformed JSON to plain comment", () => {
     const legacy = { ...base, type: "suggestion", content: "not-json" };
-    const result = sanitizeAnnotation(legacy as unknown as Annotation);
+    const result = sanitizeAnnotation(legacy as unknown as Annotation, () => {});
     expect(result.type).toBe("comment");
     expect(result.suggestedText).toBeUndefined();
     expect(result.content).toBe("not-json");
@@ -341,7 +341,7 @@ describe("sanitizeAnnotation", () => {
       type: "suggestion",
       content: JSON.stringify({ newText: "Hi" }),
     };
-    const result = sanitizeAnnotation(legacy as unknown as Annotation);
+    const result = sanitizeAnnotation(legacy as unknown as Annotation, () => {});
     expect(result.type).toBe("comment");
     expect(result.suggestedText).toBe("Hi");
     expect(result.content).toBe("");
@@ -349,28 +349,28 @@ describe("sanitizeAnnotation", () => {
 
   it("converts legacy question to comment (directedAt stripped per ADR-027)", () => {
     const legacy = { ...base, type: "question" };
-    const result = sanitizeAnnotation(legacy as unknown as Annotation);
+    const result = sanitizeAnnotation(legacy as unknown as Annotation, () => {});
     expect(result.type).toBe("comment");
     expect(result.directedAt).toBeUndefined();
   });
 
   it("strips stray color from non-highlight entries", () => {
     const withStrayColor = { ...base, type: "comment", color: "yellow" };
-    const result = sanitizeAnnotation(withStrayColor as unknown as Annotation);
+    const result = sanitizeAnnotation(withStrayColor as unknown as Annotation, () => {});
     expect(result.type).toBe("comment");
     expect(result.color).toBeUndefined();
   });
 
   it("preserves color on highlight entries", () => {
     const highlight = { ...base, type: "highlight", color: "yellow" };
-    const result = sanitizeAnnotation(highlight as unknown as Annotation);
+    const result = sanitizeAnnotation(highlight as unknown as Annotation, () => {});
     expect(result.type).toBe("highlight");
     expect(result.color).toBe("yellow");
   });
 
   it("passes through valid comment with suggestedText unchanged", () => {
     const comment = { ...base, type: "comment", suggestedText: "replacement" };
-    const result = sanitizeAnnotation(comment as unknown as Annotation);
+    const result = sanitizeAnnotation(comment as unknown as Annotation, () => {});
     expect(result.type).toBe("comment");
     expect(result.suggestedText).toBe("replacement");
     expect(result.content).toBe("test");
@@ -378,14 +378,14 @@ describe("sanitizeAnnotation", () => {
 
   it("strips directedAt from comments (ADR-027)", () => {
     const comment = { ...base, type: "comment", directedAt: "claude" as const };
-    const result = sanitizeAnnotation(comment as unknown as Annotation);
+    const result = sanitizeAnnotation(comment as unknown as Annotation, () => {});
     expect(result.type).toBe("comment");
     expect(result.directedAt).toBeUndefined();
   });
 
   it("migrates flag to note (ADR-027)", () => {
     const flag = { ...base, type: "flag" };
-    const result = sanitizeAnnotation(flag as unknown as Annotation);
+    const result = sanitizeAnnotation(flag as unknown as Annotation, () => {});
     expect(result.type).toBe("note");
   });
 
@@ -397,37 +397,73 @@ describe("sanitizeAnnotation", () => {
       textSnapshot: "original",
       editedAt: 2000,
     };
-    const result = sanitizeAnnotation(legacy as unknown as Annotation);
+    const result = sanitizeAnnotation(legacy as unknown as Annotation, () => {});
     expect(result.textSnapshot).toBe("original");
     expect(result.editedAt).toBe(2000);
   });
 
-  it("warns and coerces truly unknown types to comment", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("invokes onLossy and coerces truly unknown types to comment", () => {
+    const events: import("../../src/shared/sanitize.js").SanitizationEvent[] = [];
     const unknown = { ...base, type: "foobar" };
-    const result = sanitizeAnnotation(unknown as unknown as Annotation);
+    const result = sanitizeAnnotation(unknown as unknown as Annotation, (e) => events.push(e));
     expect(result.type).toBe("comment");
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown type "foobar"'));
-    warnSpy.mockRestore();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "unknown-type", id: base.id, rawType: "foobar" });
   });
 
-  it("does not warn for valid comment type", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("invokes onLossy for legacy flag → note migration", () => {
+    const events: import("../../src/shared/sanitize.js").SanitizationEvent[] = [];
+    const flag = { ...base, type: "flag" };
+    const result = sanitizeAnnotation(flag as unknown as Annotation, (e) => events.push(e));
+    expect(result.type).toBe("note");
+    expect(events).toEqual([{ kind: "flag-to-note", id: base.id }]);
+  });
+
+  it("invokes onLossy for legacy question → comment migration", () => {
+    const events: import("../../src/shared/sanitize.js").SanitizationEvent[] = [];
+    const q = { ...base, type: "question" };
+    const result = sanitizeAnnotation(q as unknown as Annotation, (e) => events.push(e));
+    expect(result.type).toBe("comment");
+    expect(events).toEqual([{ kind: "question-to-comment", id: base.id }]);
+  });
+
+  it("invokes onLossy for malformed-suggestion-json", () => {
+    const events: import("../../src/shared/sanitize.js").SanitizationEvent[] = [];
+    const legacy = { ...base, type: "suggestion", content: "not-json" };
+    sanitizeAnnotation(legacy as unknown as Annotation, (e) => events.push(e));
+    expect(events).toEqual([{ kind: "malformed-suggestion-json", id: base.id }]);
+  });
+
+  it("does not invoke onLossy for valid comment type", () => {
+    const events: import("../../src/shared/sanitize.js").SanitizationEvent[] = [];
     const comment = { ...base, type: "comment" };
-    sanitizeAnnotation(comment as unknown as Annotation);
-    expect(warnSpy).not.toHaveBeenCalled();
+    sanitizeAnnotation(comment as unknown as Annotation, (e) => events.push(e));
+    expect(events).toHaveLength(0);
+  });
+
+  it("catches throws inside onLossy without aborting sanitize", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const unknown = { ...base, type: "foobar" };
+    const result = sanitizeAnnotation(unknown as unknown as Annotation, () => {
+      throw new Error("relay boom");
+    });
+    expect(result.type).toBe("comment");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[sanitizeAnnotation] onLossy threw"),
+      expect.any(Error),
+    );
     warnSpy.mockRestore();
   });
 
   it("preserves textSnapshot: '' (empty string)", () => {
     const ann = { ...base, type: "comment", textSnapshot: "" };
-    const result = sanitizeAnnotation(ann as unknown as Annotation);
+    const result = sanitizeAnnotation(ann as unknown as Annotation, () => {});
     expect(result.textSnapshot).toBe("");
   });
 
   it("preserves editedAt: 0", () => {
     const ann = { ...base, type: "comment", editedAt: 0 };
-    const result = sanitizeAnnotation(ann as unknown as Annotation);
+    const result = sanitizeAnnotation(ann as unknown as Annotation, () => {});
     expect(result.editedAt).toBe(0);
   });
 

--- a/tests/server/annotations/sync.test.ts
+++ b/tests/server/annotations/sync.test.ts
@@ -53,6 +53,19 @@ import {
 } from "../../helpers/annotation-fixtures.js";
 import { useTmpAnnotationsEnvWithFlag } from "../../helpers/annotation-store-env.js";
 
+/**
+ * Filter `errorSpy.mock.calls` to only the `legacy-type` migration lines.
+ * After #483, `sanitizeAnnotation` also routes `flag-to-note`,
+ * `question-to-comment`, `malformed-suggestion-json`, and `unknown-type`
+ * events through the same migration-log channel — these tests pre-date
+ * #483 and assert the count of the legacy-type umbrella line specifically.
+ */
+function legacyTypeLogs(errorSpy: ReturnType<typeof vi.spyOn>): unknown[][] {
+  return errorSpy.mock.calls.filter((args) =>
+    String(args[0]).includes("legacy migration: legacy-type"),
+  );
+}
+
 function syncCtx(ydoc: Y.Doc, store: DocStore, overrides: Partial<SyncContext> = {}): SyncContext {
   return {
     ydoc,
@@ -321,7 +334,7 @@ describe("legacy-type sanitize on write", () => {
     const parsed = parseAnnotationDoc(raw);
     expect(parsed.ok).toBe(true);
 
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(legacyTypeLogs(errorSpy)).toHaveLength(1);
     cleanup();
     errorSpy.mockRestore();
   });
@@ -459,8 +472,9 @@ describe("legacy-type sanitize on write", () => {
     }, MCP_ORIGIN);
     await store.flush();
 
-    // Two legacy records, one docHash → exactly one warning.
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    // Two legacy records, one docHash → exactly one legacy-type warning
+    // (sanitize-derived events are counted separately).
+    expect(legacyTypeLogs(errorSpy)).toHaveLength(1);
     cleanup();
     errorSpy.mockRestore();
   });
@@ -477,7 +491,7 @@ describe("legacy-type sanitize on write", () => {
       MCP_ORIGIN,
     );
     await store.flush();
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(legacyTypeLogs(errorSpy)).toHaveLength(1);
     cleanup1("close");
 
     // Fresh observer for the same docHash — dedupe state should have been
@@ -488,7 +502,7 @@ describe("legacy-type sanitize on write", () => {
       MCP_ORIGIN,
     );
     await store.flush();
-    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(legacyTypeLogs(errorSpy)).toHaveLength(2);
 
     cleanup2("close");
     errorSpy.mockRestore();
@@ -506,7 +520,7 @@ describe("legacy-type sanitize on write", () => {
       MCP_ORIGIN,
     );
     await store.flush();
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(legacyTypeLogs(errorSpy)).toHaveLength(1);
     cleanup1("swap");
 
     const cleanup2 = registerAnnotationObserver(syncCtx(ydoc, store));
@@ -515,8 +529,8 @@ describe("legacy-type sanitize on write", () => {
       MCP_ORIGIN,
     );
     await store.flush();
-    // Same docHash, swap semantics → no additional warning.
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    // Same docHash, swap semantics → no additional legacy-type warning.
+    expect(legacyTypeLogs(errorSpy)).toHaveLength(1);
 
     cleanup2("close");
     errorSpy.mockRestore();
@@ -577,9 +591,9 @@ describe("legacy-type sanitize on write", () => {
     await storeA.flush();
     await storeB.flush();
 
-    // Two different docHashes → two independent log entries.
+    // Two different docHashes → two independent legacy-type log entries.
     // If dedupe collapsed to a single boolean, the second would be suppressed.
-    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(legacyTypeLogs(errorSpy)).toHaveLength(2);
 
     cleanupA();
     cleanupB();
@@ -620,7 +634,7 @@ describe("legacy-type sanitize on write", () => {
     // Without the docHash fix, normalizeAnnotation is called without docHash
     // and the guard `if (!isCanonical && docHash && ...)` short-circuits → 0.
     // With the fix, docHash is passed and the log fires → 1.
-    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(legacyTypeLogs(errorSpy)).toHaveLength(1);
 
     cleanup();
     errorSpy.mockRestore();


### PR DESCRIPTION
## Summary

Closes #483.

`src/shared/sanitize.ts` previously emitted `console.warn` on two lossy paths (malformed legacy-suggestion JSON, truly unknown annotation type). These bypassed the dedup'd `migration-log.ts` channel that the rest of the v0→v1 migration trail uses. This PR routes them — plus two pre-existing silent rewrites — through that channel.

### What changed

- `sanitizeAnnotation` now takes a **required** `onLossy: (event: SanitizationEvent) => void` callback. Required (not optional) so TS enforces the migration; a forgotten callsite is a compile error, not a silent regression.
- `SanitizationEvent` is a discriminated union covering all four lossy rewrites:
  - `flag-to-note` (ADR-027 audience model — was already silent)
  - `question-to-comment` (ADR-027 — was already silent)
  - `malformed-suggestion-json` (was `console.warn`)
  - `unknown-type` (was `console.warn`)
- Sanitize wraps the callback in try/catch and logs to stderr if it throws — never aborts mid-`.map()` because of a faulty relay. `Promise` returns are forbidden at the type level.
- Server-side relay `relaySanitizationEvent(docHash, event)` lives in `migration-log.ts` and maps every `SanitizationEvent.kind` onto a `LegacyMigrationKind`, so the dedup `Set` behaves identically to existing migration logs (once per `(docHash, kind)`).

### Callsites updated (7+ — Phase B reviewer's audit caught the prior plan undercounting):

**Server (relays via `relaySanitizationEvent`):**
- `src/server/annotations/sync.ts` — `normalizeAnnotation`
- `src/server/events/observers/annotations.ts` — `makeAnnotationsObserver`
- `src/server/mcp/annotations.ts` — `addReplyToAnnotation`, `collectAnnotations`, `acceptOrDismiss`, `editAnnotation`
- `src/server/mcp/file-opener.ts` — `reloadFromDisk`
- `src/server/mcp/docx-apply.ts` — `applyChangesCore`

**Client (DevTools breadcrumb — only forensic trail browser-side):**
- `src/client/editor/extensions/annotation.ts`
- `src/client/hooks/useYjsSync.ts`
- `src/client/panels/SidePanel.tsx`
- `src/client/panels/useAnnotationReview.ts`

### Tests

- `tests/server/annotations.test.ts` — the prior `warns and coerces truly unknown types` test relied on stub-not-invoked false positives. Replaced with explicit assertions that the callback **is invoked** with the correct event for each lossy path: `unknown-type`, `flag-to-note`, `question-to-comment`, `malformed-suggestion-json`. Plus a new `catches throws inside onLossy` test guarding the try/catch contract.
- `tests/server/annotations/sync.test.ts` — pre-existing dedup tests now filter `errorSpy` calls to the `legacy-type` umbrella line via a new `legacyTypeLogs()` helper, since sanitize-derived events now share the same channel.

### Coordination with #482

`LegacyMigrationKind` is extended with the new variants AND #482 (`.docx import note→comment`) will reuse this `onLossy` plumbing — adding one more variant (`import-note-to-comment`). #483 lands first.

### Out of scope

The issue body suggested a `logError`/`errorIds.ts` Sentry layer. Neither exists in the tree; introducing one is a separate roadmap item. This PR uses the existing `migration-log.ts` sink as the v0.9.1 hotfix sink.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- --run tests/server/annotations.test.ts tests/server/annotations/sync.test.ts` (97 passed)
- [x] Full `npm test` — only one unrelated pre-existing failure (`file-opener-lifecycle.test.ts` Windows symlink-traversal issue with worktree's `node_modules`; passes on main repo)
- [ ] Manual: open a session file with a legacy `type: "suggestion"` + non-JSON `content`, confirm exactly one `[ANNOTATION-STORE] legacy migration: malformed-suggestion-json in <docHash>` line in stderr
- [ ] Manual: repeat with `type: "foobar"`; expect one `unknown-type` line
- [ ] Manual: close + reopen the doc; confirm log fires again (forgetDoc cleared dedupe)