### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased]
 
+## \[0.9.1] - 2026-05-01
+
+Hotfix patch bundling ADR-027 surface cleanup and file-I/O correctness fixes before the v0.10.0 Svelte conversion. All changes are patch-class; no MCP API changes.
+
 ### Fixed
 
-- **Imported Word reviewer comments now surface to Claude by default (#482)** — `.docx` reviewer comments are imported as `author: "import"`, `type: "comment"` (was `type: "note"` in the unreleased PR #474 plan). Reverts the `tandem_getAnnotations` `includeImports` opt-in introduced in PR #474 — Claude can read imported comments alongside its own without an explicit flag, which matches the .docx review workflow. The opt-in plumbing (`includeImports` parameter, `importsExcluded` response field) is removed. Existing on-disk records with `author: "import", type: "note"` migrate transparently on read via `sanitizeAnnotation` (one-line clause; emits a `import-note-to-comment` migration-log event); on next import the durable record is rewritten in place. Safe because PR #474 was never tagged in a release.
+- **Imported Word reviewer comments now surface to Claude by default (#482)** — `.docx` reviewer comments are imported as `author: "import"`, `type: "comment"` (was `type: "note"` in the unreleased PR #474 plan). Reverts the `tandem_getAnnotations` `includeImports` opt-in introduced in PR #474 — Claude can read imported comments alongside its own without an explicit flag, which matches the .docx review workflow. The opt-in plumbing (`includeImports` parameter, `importsExcluded` response field) is removed. Existing on-disk records with `author: "import", type: "note"` migrate transparently on read via `sanitizeAnnotation`; on next import the durable record is rewritten in place. Safe because PR #474 was never tagged in a release.
+- **Markdown tables preserved across Tiptap round-trip (#379)** — bidirectional MDAST↔Y.Doc table conversion added to `mdast-ydoc.ts`. Tables with mixed column alignment, inline marks in cells, and empty cells all survive load/save cycles. Flat-offset alignment preserved so annotations anchored after a table resolve correctly.
+- **HTML blocks and insertion-order fixed in mdast-ydoc (#496)** — raw HTML blocks (`<div>`, `<details>`, etc.) now round-trip as `html` nodes instead of being dropped. Insertion-order bug in `blockToYxml` fixed — the two-pass Y.XmlText attach-before-populate pattern now applied uniformly to all block types.
+- **Channel shim per-request timeouts (#364)** — event bridge and `run.ts` now use bounded request-response fetches with split SSE handshake/body watchdogs and a 1 MB SSE frame buffer cap. `tandem_reply` returns a structured timeout error instead of hanging indefinitely.
+- **Sanitize coercions routed to migration-log (#483)** — lossy ADR-027 type coercions in `sanitize.ts` (e.g. `flag` → `note`) now emit a `migration-log.ts` entry (once per doc/kind) instead of silently rewriting records, restoring the forensic trail for ADR-027 transitions.
+- **Doc hash required for collection logs (#495)** — annotation collection log entries now require a `docHash` field, preventing cross-document log pollution from unkeyed writes.
+- **Standalone monitor gated on backend readiness (#491)** — `dev:standalone` waits for the backend health endpoint before starting the monitor, eliminating the startup race that caused spurious connection errors.
+
+### Tests
+
+- **E2E toolbar regression guard (#484)** — Playwright coverage for the redesigned toolbar (ADR-027 note/comment/highlight flow), including a regression guard for the note button empty-annotation bug (#480).
 
 ## \[0.9.0] - 2026-04-28
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -450,7 +450,7 @@ Additional decisions from #439: highlight palette switches from 5 to 4 colors (y
 
 **Distribution coordination:** v0.9.0 was the first release where three surfaces (npm tarball, Cowork plugin via npx, Tauri desktop) must stay version-coherent. npm publish (GitHub Release trigger) before Tauri build. Rollback strategy per surface documented in `docs/v090-plan.md`.
 
-**v0.9.1 — ADR-027 hotfix patch (planned).** Bundles cleanup of the post-PR #474 surface area before the v0.10.0 Svelte conversion lands. Patch-class scope only:
+**v0.9.1 — RELEASED (2026-05-01).** ADR-027 surface cleanup + file-I/O correctness fixes. Word reviewer comments import as `comment` (not `note`) so Claude sees them without a flag (#482/#489); markdown tables and HTML blocks now survive Tiptap round-trips (#379/#496); channel shim bounded timeouts (#364/#487); sanitize coercions routed to migration-log (#483/#488); doc hash required for collection logs (#495); standalone monitor gated on backend readiness (#491); E2E toolbar regression guard (#484/#490).
 
 | Issue | Concern |
 |-------|---------|
@@ -473,8 +473,8 @@ After PR #474 merges, #473 closes automatically via `closingIssuesReferences`.
 
 | Release | Concern | Scope |
 |---------|---------|-------|
-| v0.10.0 | Full Svelte conversion | #312 Phases 2-4: Vite plugin (#465), useYjsSync rune (#466), all hooks (#467), Editor+toolbar (#468), DocumentTabs (#469), panels (#470), settings/modals/misc (#471), App.svelte+React removal (#472). Co-resident polish: #478 (rename "Upload" → "Open" in #469's FileOpenDialog port). Folded into #471 (Svelte SettingsPopover): #383 (bug report link), #457 (documentation in settings) |
-| v0.11.0 | Dark theme + UI polish | #59, `editor.css` dark overrides, #311, WCAG AA contrast, #369 verification. Polish bundle: #475 (temporary scratchpad — `priority:high`; introduces in-memory document model, kept out of v0.10.0 to avoid building it twice across React/Svelte), #479 (internal links open within Tandem) |
+| v0.10.0 | Full Svelte conversion | #312 Phases 2-4: Vite plugin (#465), useYjsSync rune (#466), all hooks (#467), Editor+toolbar (#468), DocumentTabs (#469), panels (#470), settings/modals/misc (#471), App.svelte+React removal (#472). Co-resident polish: #478 (rename "Upload" → "Open" in #469's FileOpenDialog port), #494 (silent annotation loss when store is read-only — lock recovery: 30s \`retryStoreLock()\` retry loop in \`index.ts\`, flush open docs on re-acquire, persistent warning banner during read-only window, \`storeReadOnly\` field on \`tandem_status\`/\`tandem_checkInbox\`). Folded into #471 (Svelte SettingsPopover): #383 (bug report link), #457 (documentation in settings) |
+| v0.11.0 | Dark theme + UI polish | #59, `editor.css` dark overrides, #311, WCAG AA contrast, #369 verification. Polish bundle: #475 (temporary scratchpad — `priority:high`; introduces in-memory document model, kept out of v0.10.0 to avoid building it twice across React/Svelte), #479 (internal links open within Tandem), #492 (re-highlighting same text toggles the highlight off — behavior change kept out of v0.10.0 to avoid mixing behavioral change into the mechanical Svelte port) |
 | v0.12.0 | Desktop UI Tier 1 + Cowork cross-platform | #269 §1.1-1.5, #316, #317, #319, #322, #378, #380 (PR f already shipped in v0.8.0). Multi-client + installer hardening: #438 (per-client identity spec, prerequisite), #452 (multiple Claude Code chats concurrent, depends on #438), #433 (Cowork installer TOCTOU — sequence **last**, after #316/#317 rewrite `find_cowork_workspaces()` for macOS/Linux), #428 install bug on M1 / 26.1 (distinct from the v1.0 notarization gate) |
 | v0.13.0 | Desktop UI Tier 2 + first-run | #265, #103, #269 §2.1-2.4/§3.1/§3.4 |
 | v1.0.0 | Verification + bump | Soak test, notarization, update flow, accessibility gate, version bump |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Edit and iterate on documents with Claude — no copy-paste, real-time push via plugin monitor",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Version bump and CHANGELOG for v0.9.1 — ADR-027 surface cleanup + file-I/O correctness fixes.

All code is already on master. This PR only bumps `package.json` and writes the release notes.

## What's in v0.9.1

- **#482** Word reviewer comments import as `comment` (not `note`) — Claude sees them without a flag
- **#379** Markdown tables preserved across Tiptap round-trip
- **#496** HTML blocks + insertion-order fix in mdast-ydoc
- **#364** Channel shim per-request timeouts
- **#483** Sanitize coercions routed to migration-log
- **#495** Doc hash required for collection logs
- **#491** Standalone monitor gated on backend readiness
- **#484** E2E toolbar regression guard

## Release process

Merging this PR triggers the GitHub Release (via tag push), which triggers npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)