### PR TITLE
feat(editor): port Editor.tsx and toolbar to Svelte 5 (#468)

### DIFF
--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import { HocuspocusProvider } from "@hocuspocus/provider";
+  import { Editor as TiptapEditor } from "@tiptap/core";
+  import Collaboration from "@tiptap/extension-collaboration";
+  import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
+  import Highlight from "@tiptap/extension-highlight";
+  import Link from "@tiptap/extension-link";
+  import Placeholder from "@tiptap/extension-placeholder";
+  import Table from "@tiptap/extension-table";
+  import TableCell from "@tiptap/extension-table-cell";
+  import TableHeader from "@tiptap/extension-table-header";
+  import TableRow from "@tiptap/extension-table-row";
+  import StarterKit from "@tiptap/starter-kit";
+  import * as Y from "yjs";
+  import { readStoredName, subscribeToUserName } from "../hooks/useUserName";
+  import { AnnotationExtension } from "./extensions/annotation";
+  import { AuthorshipExtension } from "./extensions/authorship";
+  import { AwarenessExtension } from "./extensions/awareness";
+  import { MarkdownHtmlExtension } from "./extensions/markdown-html";
+  import "./editor.css";
+
+  interface Props {
+    ydoc: Y.Doc;
+    provider: HocuspocusProvider;
+    readOnly: boolean;
+    reviewMode?: boolean;
+    activeAnnotationId?: string | null;
+    onEditorReady?: (editor: TiptapEditor | null) => void;
+    onAnnotationClick?: (annotationId: string) => void;
+  }
+
+  const {
+    ydoc,
+    provider,
+    readOnly,
+    reviewMode,
+    activeAnnotationId,
+    onEditorReady,
+    onAnnotationClick,
+  }: Props = $props();
+
+  let editor = $state<TiptapEditor | null>(null);
+  let editorRoot: HTMLDivElement | null = null;
+
+  // -------------------------------------------------------------------------
+  // Editor lifecycle: re-create when (ydoc, provider) identity changes.
+  //
+  // Pattern matches CLAUDE.md gotcha "Y.XmlText must be attached before
+  // populating": Tiptap creates its own Y.XmlFragment binding via the
+  // Collaboration extension on the supplied ydoc. We must destroy any prior
+  // editor BEFORE creating the new one (avoid duplicate event subscriptions
+  // and torn observers). Cleanup runs before the effect re-runs.
+  // -------------------------------------------------------------------------
+  $effect(() => {
+    // Track identity of ydoc + provider so this effect re-runs on swap.
+    void ydoc;
+    void provider;
+
+    if (!editorRoot) return;
+
+    const next = new TiptapEditor({
+      element: editorRoot,
+      extensions: [
+        StarterKit.configure({ history: false }), // Yjs handles undo/redo
+        Highlight.configure({ multicolor: true }),
+        Link.configure({
+          openOnClick: false,
+          HTMLAttributes: { rel: "noopener noreferrer", target: "_blank" },
+        }),
+        Placeholder.configure({
+          placeholder: "Open a document with Claude to get started...",
+        }),
+        Table.configure({ resizable: true }),
+        TableRow,
+        TableCell,
+        TableHeader,
+        MarkdownHtmlExtension,
+        Collaboration.configure({ document: ydoc }),
+        CollaborationCursor.configure({
+          provider,
+          user: {
+            name: readStoredName(),
+            color: "var(--tandem-warning)",
+          },
+        }),
+        AnnotationExtension.configure({ ydoc }),
+        AuthorshipExtension.configure({ ydoc }),
+        AwarenessExtension.configure({ ydoc }),
+      ],
+      editorProps: {
+        attributes: {
+          class: "tandem-editor",
+          style:
+            "outline: none; min-height: 500px; font-size: var(--tandem-editor-font-size, 16px); line-height: 1.6;",
+        },
+      },
+      editable: !readOnly,
+    });
+
+    editor = next;
+    onEditorReady?.(next);
+
+    return () => {
+      onEditorReady?.(null);
+      next.destroy();
+      if (editor === next) editor = null;
+    };
+  });
+
+  // -- readOnly toggling without recreating the editor -----------------------
+  $effect(() => {
+    const ed = editor;
+    if (!ed) return;
+    ed.setEditable(!readOnly);
+  });
+
+  // -- Keep CollaborationCursor name synced with stored display name --------
+  $effect(() => {
+    const ed = editor;
+    if (!ed) return;
+    return subscribeToUserName((name) => ed.commands.updateUser({ name }));
+  });
+
+  // -- Apply active annotation highlight class -------------------------------
+  $effect(() => {
+    const ed = editor;
+    if (!ed) return;
+    const container = ed.view.dom;
+
+    container.querySelectorAll(".tandem-annotation-active").forEach((el) => {
+      el.classList.remove("tandem-annotation-active");
+    });
+
+    if (activeAnnotationId && reviewMode) {
+      container
+        .querySelectorAll(`[data-annotation-id="${CSS.escape(activeAnnotationId)}"]`)
+        .forEach((el) => {
+          el.classList.add("tandem-annotation-active");
+        });
+    }
+  });
+
+  function handleEditorClick(e: MouseEvent) {
+    const target = (e.target as HTMLElement).closest("[data-annotation-id]");
+    if (!target) return;
+    const annotationId = target.getAttribute("data-annotation-id");
+    if (annotationId && onAnnotationClick) {
+      onAnnotationClick(annotationId);
+    }
+  }
+</script>
+
+<div class={reviewMode ? "tandem-review-dimmed" : ""} onclick={handleEditorClick} role="presentation">
+  <div bind:this={editorRoot}></div>
+</div>

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import { HocuspocusProvider } from "@hocuspocus/provider";
   import { Editor as TiptapEditor } from "@tiptap/core";
   import Collaboration from "@tiptap/extension-collaboration";
@@ -94,14 +95,14 @@
             "outline: none; min-height: 500px; font-size: var(--tandem-editor-font-size, 16px); line-height: 1.6;",
         },
       },
-      editable: !readOnly,
+      editable: untrack(() => !readOnly),
     });
 
     editor = next;
-    onEditorReady?.(next);
+    untrack(() => onEditorReady?.(next));
 
     return () => {
-      onEditorReady?.(null);
+      untrack(() => onEditorReady?.(null));
       next.destroy();
       if (editor === next) editor = null;
     };

--- a/src/client/editor/toolbar/FormattingToolbar.svelte
+++ b/src/client/editor/toolbar/FormattingToolbar.svelte
@@ -1,0 +1,353 @@
+<script lang="ts">
+  import type { Editor as TiptapEditor } from "@tiptap/core";
+  import { yUndoPluginKey } from "y-prosemirror";
+  import ToolbarButton from "./ToolbarButton.svelte";
+
+  interface Props {
+    editor: TiptapEditor | null;
+    disabled?: boolean;
+  }
+
+  const { editor, disabled = false }: Props = $props();
+
+  type HeadingLevel = 1 | 2 | 3;
+  const HEADING_LEVELS: HeadingLevel[] = [1, 2, 3];
+  const HEADING_FONT_WEIGHTS: Record<HeadingLevel, number> = { 1: 700, 2: 600, 3: 500 };
+
+  // Force-reactive tick — Tiptap's isActive() is imperative; bump on transaction.
+  let tick = $state(0);
+  let showHeadingMenu = $state(false);
+  let headingMenuEl = $state<HTMLDivElement | null>(null);
+
+  $effect(() => {
+    if (!editor) return;
+    const handler = () => {
+      if (!editor.isDestroyed) tick++;
+    };
+    editor.on("transaction", handler);
+    return () => {
+      editor.off("transaction", handler);
+    };
+  });
+
+  $effect(() => {
+    if (!showHeadingMenu) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (headingMenuEl && !headingMenuEl.contains(e.target as Node)) {
+        showHeadingMenu = false;
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  });
+
+  function findActiveHeading(ed: TiptapEditor): HeadingLevel | null {
+    for (const level of HEADING_LEVELS) {
+      if (ed.isActive("heading", { level })) return level;
+    }
+    return null;
+  }
+
+  // Reactive computations depend on editor + tick (transaction counter).
+  const isEditable = $derived(editor ? editor.isEditable : false);
+  const isDisabled = $derived(!isEditable || !!disabled);
+
+  const undoState = $derived.by(() => {
+    void tick;
+    return editor ? yUndoPluginKey.getState(editor.state) : null;
+  });
+  const canUndo = $derived(!isDisabled && (undoState?.undoManager?.undoStack.length ?? 0) > 0);
+  const canRedo = $derived(!isDisabled && (undoState?.undoManager?.redoStack.length ?? 0) > 0);
+
+  const activeHeading = $derived.by(() => {
+    void tick;
+    return editor ? findActiveHeading(editor) : null;
+  });
+
+  // Reactive isActive readers
+  const isActiveBold = $derived.by(() => {
+    void tick;
+    return !!editor?.isActive("bold");
+  });
+  const isActiveItalic = $derived.by(() => {
+    void tick;
+    return !!editor?.isActive("italic");
+  });
+  const isActiveStrike = $derived.by(() => {
+    void tick;
+    return !!editor?.isActive("strike");
+  });
+  const isActiveCode = $derived.by(() => {
+    void tick;
+    return !!editor?.isActive("code");
+  });
+  const isActiveBulletList = $derived.by(() => {
+    void tick;
+    return !!editor?.isActive("bulletList");
+  });
+  const isActiveOrderedList = $derived.by(() => {
+    void tick;
+    return !!editor?.isActive("orderedList");
+  });
+  const isActiveBlockquote = $derived.by(() => {
+    void tick;
+    return !!editor?.isActive("blockquote");
+  });
+  const isActiveCodeBlock = $derived.by(() => {
+    void tick;
+    return !!editor?.isActive("codeBlock");
+  });
+  const isActiveLink = $derived.by(() => {
+    void tick;
+    return !!editor?.isActive("link");
+  });
+  const linkDisabled = $derived.by(() => {
+    void tick;
+    if (!editor) return true;
+    return (
+      isDisabled ||
+      (!editor.isActive("link") && editor.state.selection.from === editor.state.selection.to)
+    );
+  });
+
+  const headingLabel = $derived(activeHeading ? `H${activeHeading}` : "H");
+
+  function withPreventDefault(command: () => void) {
+    return (e: MouseEvent) => {
+      e.preventDefault();
+      command();
+    };
+  }
+
+  function handleHeadingToggle(level: HeadingLevel) {
+    return (e: MouseEvent) => {
+      e.preventDefault();
+      if (!editor || editor.isDestroyed) return;
+      editor.chain().focus().toggleHeading({ level }).run();
+      showHeadingMenu = false;
+    };
+  }
+
+  function handleLinkMouseDown(e: MouseEvent) {
+    e.preventDefault();
+    if (!editor) return;
+    if (editor.isActive("link")) {
+      editor.chain().focus().unsetLink().run();
+    } else {
+      const url = window.prompt("Enter URL:");
+      if (url) editor.chain().focus().setLink({ href: url }).run();
+    }
+  }
+</script>
+
+{#if editor}
+  <div style="display: flex; align-items: center; gap: 2px;">
+    <ToolbarButton
+      ariaLabel="Undo"
+      shortcut="Ctrl+Z"
+      disabled={!canUndo}
+      onMouseDown={withPreventDefault(() => editor.commands.undo())}
+      style="min-width: 30px; padding: 4px 6px;"
+    >
+      {#snippet children()}
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <path d="M4 7L1 4l3-3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M1 4h9a5 5 0 0 1 0 10H7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      {/snippet}
+    </ToolbarButton>
+    <ToolbarButton
+      ariaLabel="Redo"
+      shortcut="Ctrl+Shift+Z"
+      disabled={!canRedo}
+      onMouseDown={withPreventDefault(() => editor.commands.redo())}
+      style="min-width: 30px; padding: 4px 6px;"
+    >
+      {#snippet children()}
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 7l3-3-3-3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M15 4H6a5 5 0 0 0 0 10h3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      {/snippet}
+    </ToolbarButton>
+    <div style="width: 1px; height: 16px; background: var(--tandem-border); margin: 0 2px;"></div>
+
+    <ToolbarButton
+      label="B"
+      shortcut="Ctrl+B"
+      disabled={isDisabled}
+      active={isActiveBold}
+      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleBold().run())}
+      style="font-weight: 700; min-width: 30px;"
+    />
+    <ToolbarButton
+      label="I"
+      shortcut="Ctrl+I"
+      disabled={isDisabled}
+      active={isActiveItalic}
+      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleItalic().run())}
+      style="font-style: italic; min-width: 30px;"
+    />
+    <ToolbarButton
+      label="S"
+      shortcut="Ctrl+Shift+X"
+      disabled={isDisabled}
+      active={isActiveStrike}
+      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleStrike().run())}
+      style="text-decoration: line-through; min-width: 30px;"
+    />
+    <ToolbarButton
+      label="<>"
+      shortcut="Ctrl+E"
+      disabled={isDisabled}
+      active={isActiveCode}
+      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleCode().run())}
+      style="font-family: monospace; min-width: 30px;"
+    />
+
+    <!-- Heading dropdown -->
+    <div
+      bind:this={headingMenuEl}
+      style="position: relative;"
+      onkeydown={(e) => {
+        if (e.key === "Escape") showHeadingMenu = false;
+      }}
+      role="presentation"
+    >
+      <ToolbarButton
+        label={headingLabel}
+        disabled={isDisabled}
+        active={activeHeading !== null}
+        onMouseDown={(e: MouseEvent) => {
+          e.preventDefault();
+          showHeadingMenu = !showHeadingMenu;
+        }}
+        style="min-width: 30px;"
+      />
+      {#if showHeadingMenu}
+        <div
+          role="menu"
+          aria-label="Heading level"
+          style="position: absolute; top: 100%; left: 0; margin-top: 4px;
+            background: var(--tandem-surface); border: 1px solid var(--tandem-border);
+            border-radius: 6px; padding: 4px; display: flex; flex-direction: column;
+            gap: 2px; z-index: 10; box-shadow: 0 2px 8px rgba(0,0,0,0.1);"
+        >
+          {#each HEADING_LEVELS as level (level)}
+            <button
+              type="button"
+              role="menuitem"
+              onmousedown={handleHeadingToggle(level)}
+              style="padding: 4px 12px; font-size: 13px; border: none;
+                border-radius: 4px;
+                background: {activeHeading === level ? 'var(--tandem-accent-bg)' : 'transparent'};
+                color: {activeHeading === level ? 'var(--tandem-accent)' : 'var(--tandem-fg)'};
+                cursor: pointer; text-align: left;
+                font-weight: {HEADING_FONT_WEIGHTS[level]}; white-space: nowrap;"
+            >
+              Heading {level}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <div style="width: 1px; height: 16px; background: var(--tandem-border); margin: 0 2px;"></div>
+
+    <ToolbarButton
+      ariaLabel="Bullet list"
+      shortcut="Ctrl+Shift+8"
+      disabled={isDisabled}
+      active={isActiveBulletList}
+      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleBulletList().run())}
+      style="min-width: 30px; padding: 4px 6px;"
+    >
+      {#snippet children()}
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="2" cy="4" r="1.5" fill="currentColor" />
+          <circle cx="2" cy="8" r="1.5" fill="currentColor" />
+          <circle cx="2" cy="12" r="1.5" fill="currentColor" />
+          <rect x="5" y="3" width="9" height="2" rx="1" fill="currentColor" />
+          <rect x="5" y="7" width="9" height="2" rx="1" fill="currentColor" />
+          <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" />
+        </svg>
+      {/snippet}
+    </ToolbarButton>
+    <ToolbarButton
+      ariaLabel="Ordered list"
+      shortcut="Ctrl+Shift+7"
+      disabled={isDisabled}
+      active={isActiveOrderedList}
+      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleOrderedList().run())}
+      style="min-width: 30px; padding: 4px 6px;"
+    >
+      {#snippet children()}
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <rect x="5" y="3" width="9" height="2" rx="1" fill="currentColor" />
+          <rect x="5" y="7" width="9" height="2" rx="1" fill="currentColor" />
+          <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" />
+          <text x="0" y="5.5" font-size="4.5" fill="currentColor" font-family="monospace" font-weight="bold">1.</text>
+          <text x="0" y="9.5" font-size="4.5" fill="currentColor" font-family="monospace" font-weight="bold">2.</text>
+          <text x="0" y="13.5" font-size="4.5" fill="currentColor" font-family="monospace" font-weight="bold">3.</text>
+        </svg>
+      {/snippet}
+    </ToolbarButton>
+    <ToolbarButton
+      ariaLabel="Blockquote"
+      shortcut="Ctrl+Shift+B"
+      disabled={isDisabled}
+      active={isActiveBlockquote}
+      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleBlockquote().run())}
+      style="min-width: 30px; padding: 4px 6px;"
+    >
+      {#snippet children()}
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <rect x="0" y="2" width="3" height="12" rx="1.5" fill="currentColor" />
+          <rect x="5" y="4" width="9" height="2" rx="1" fill="currentColor" opacity="0.7" />
+          <rect x="5" y="8" width="7" height="2" rx="1" fill="currentColor" opacity="0.7" />
+          <rect x="5" y="12" width="8" height="2" rx="1" fill="currentColor" opacity="0.7" />
+        </svg>
+      {/snippet}
+    </ToolbarButton>
+
+    <div style="width: 1px; height: 16px; background: var(--tandem-border); margin: 0 2px;"></div>
+
+    <ToolbarButton
+      ariaLabel="Link"
+      shortcut="Ctrl+K"
+      disabled={linkDisabled}
+      active={isActiveLink}
+      onMouseDown={handleLinkMouseDown}
+      style="min-width: 30px; padding: 4px 6px;"
+    >
+      {#snippet children()}
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <path d="M6.5 8.5a3.5 3.5 0 0 0 5 0l2-2a3.5 3.5 0 0 0-5-5l-1 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M9.5 7.5a3.5 3.5 0 0 0-5 0l-2 2a3.5 3.5 0 0 0 5 5l1-1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      {/snippet}
+    </ToolbarButton>
+    <ToolbarButton
+      label="—"
+      ariaLabel="Horizontal rule"
+      disabled={isDisabled}
+      onMouseDown={withPreventDefault(() => editor.chain().focus().setHorizontalRule().run())}
+      style="min-width: 30px;"
+    />
+    <ToolbarButton
+      ariaLabel="Code block"
+      disabled={isDisabled}
+      active={isActiveCodeBlock}
+      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleCodeBlock().run())}
+      style="min-width: 30px; padding: 4px 6px;"
+    >
+      {#snippet children()}
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <path d="M5 4L1 8l4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M11 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M9 2l-2 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+        </svg>
+      {/snippet}
+    </ToolbarButton>
+  </div>
+{/if}

--- a/src/client/editor/toolbar/HighlightColorPicker.svelte
+++ b/src/client/editor/toolbar/HighlightColorPicker.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import { HIGHLIGHT_COLORS } from "../../../shared/constants";
+  import type { HighlightColor } from "../../../shared/types";
+  import ToolbarButton from "./ToolbarButton.svelte";
+
+  const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
+    { value: "yellow", label: "Yellow" },
+    { value: "green", label: "Green" },
+    { value: "blue", label: "Blue" },
+    { value: "pink", label: "Pink" },
+  ];
+
+  interface Props {
+    disabled?: boolean;
+    onHighlight: (color: HighlightColor) => void;
+  }
+
+  const { disabled = false, onHighlight }: Props = $props();
+
+  let highlightColor = $state<HighlightColor>("yellow");
+  let showColorPicker = $state(false);
+  let colorPickerEl = $state<HTMLDivElement | null>(null);
+
+  $effect(() => {
+    if (!showColorPicker) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (colorPickerEl && !colorPickerEl.contains(e.target as Node)) {
+        showColorPicker = false;
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  });
+
+  function handleHighlight(e: MouseEvent) {
+    e.preventDefault();
+    onHighlight(highlightColor);
+  }
+
+  function handleColorPickerToggle(e: MouseEvent) {
+    e.preventDefault();
+    showColorPicker = !showColorPicker;
+  }
+
+  function handleColorSelect(color: HighlightColor) {
+    highlightColor = color;
+    showColorPicker = false;
+  }
+</script>
+
+<div style="display: flex; align-items: center; gap: 2px; position: relative;">
+  <ToolbarButton
+    label="Highlight"
+    testId="toolbar-highlight-btn"
+    {disabled}
+    disabledTitle="Select text first"
+    onMouseDown={handleHighlight}
+    style="border-radius: 4px 0 0 4px; border-right: none;"
+  />
+  <button
+    data-testid="toolbar-highlight-color-toggle"
+    {disabled}
+    onmousedown={handleColorPickerToggle}
+    title="Choose highlight color"
+    style="padding: 4px 6px; font-size: 13px; border: 1px solid var(--tandem-border);
+      border-radius: 0 4px 4px 0;
+      background: {disabled ? 'var(--tandem-surface-muted)' : 'var(--tandem-surface)'};
+      cursor: {disabled ? 'not-allowed' : 'pointer'};
+      display: flex; align-items: center;"
+  >
+    <span
+      style="display: inline-block; width: 12px; height: 12px; border-radius: 2px;
+        background: {HIGHLIGHT_COLORS[highlightColor]};
+        border: 1px solid rgba(0,0,0,0.15);"
+    ></span>
+  </button>
+  {#if showColorPicker}
+    <div
+      bind:this={colorPickerEl}
+      style="position: absolute; top: 100%; left: 0; margin-top: 4px;
+        background: var(--tandem-surface); border: 1px solid var(--tandem-border);
+        border-radius: 6px; padding: 6px; display: flex; gap: 4px; z-index: 10;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.1);"
+    >
+      {#each HIGHLIGHT_COLOR_OPTIONS as { value, label } (value)}
+        <button
+          data-testid={`toolbar-highlight-color-${value}`}
+          title={label}
+          aria-label={label}
+          onclick={() => handleColorSelect(value)}
+          style="width: 24px; height: 24px; border-radius: 4px;
+            border: {value === highlightColor
+              ? '2px solid var(--tandem-fg)'
+              : '1px solid rgba(0,0,0,0.15)'};
+            background: {HIGHLIGHT_COLORS[value]};
+            cursor: pointer; padding: 0;"
+        ></button>
+      {/each}
+      <button
+        data-testid="color-picker-close"
+        title="Close"
+        aria-label="Close color picker"
+        onclick={() => (showColorPicker = false)}
+        style="width: 24px; height: 24px; border-radius: 4px;
+          border: 1px solid var(--tandem-border);
+          background: var(--tandem-surface-muted); cursor: pointer; padding: 0;
+          font-size: 13px; color: var(--tandem-fg-muted);
+          display: flex; align-items: center; justify-content: center;"
+      >
+        ✕
+      </button>
+    </div>
+  {/if}
+</div>

--- a/src/client/editor/toolbar/InputGroup.svelte
+++ b/src/client/editor/toolbar/InputGroup.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import ToolbarButton from "./ToolbarButton.svelte";
+
+  interface Props {
+    /** Bindable reference to the input element. Caller can read this to focus(). */
+    inputEl?: HTMLInputElement | null;
+    value: string;
+    onChange: (v: string) => void;
+    onKeyDown: (e: KeyboardEvent) => void;
+    onSubmit: () => void;
+    onCancel: () => void;
+    placeholder: string;
+    submitLabel: string;
+    borderColor: string;
+    canSubmit: boolean;
+    secondaryInput?: Snippet;
+    /** Optional prefix used to derive `data-testid` values for the input,
+     * submit, and cancel controls (e.g. `"toolbar-comment"` produces
+     * `toolbar-comment-input`, `toolbar-comment-submit`, `toolbar-comment-cancel`). */
+    testIdPrefix?: string;
+  }
+
+  let {
+    inputEl = $bindable(null),
+    value,
+    onChange,
+    onKeyDown,
+    onSubmit,
+    onCancel,
+    placeholder,
+    submitLabel,
+    borderColor,
+    canSubmit,
+    secondaryInput,
+    testIdPrefix,
+  }: Props = $props();
+
+  const inputStyle = $derived(
+    `padding: 3px 8px; font-size: 13px; border: 1px solid ${borderColor}; border-radius: 4px; outline: none; min-width: 120px; flex: 1 1 200px; background: var(--tandem-surface); color: var(--tandem-fg);`,
+  );
+</script>
+
+<div style="display: flex; align-items: center; gap: 4px;">
+  <input
+    bind:this={inputEl}
+    type="text"
+    data-testid={testIdPrefix ? `${testIdPrefix}-input` : undefined}
+    {value}
+    oninput={(e) => onChange((e.target as HTMLInputElement).value)}
+    onkeydown={onKeyDown}
+    {placeholder}
+    style={inputStyle}
+  />
+  {#if secondaryInput}{@render secondaryInput()}{/if}
+  <ToolbarButton
+    label={submitLabel}
+    testId={testIdPrefix ? `${testIdPrefix}-submit` : undefined}
+    disabled={!canSubmit}
+    onClick={onSubmit}
+  />
+  <ToolbarButton
+    label="Cancel"
+    testId={testIdPrefix ? `${testIdPrefix}-cancel` : undefined}
+    disabled={false}
+    onClick={onCancel}
+  />
+</div>

--- a/src/client/editor/toolbar/ModeToggle.svelte
+++ b/src/client/editor/toolbar/ModeToggle.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import type { TandemMode } from "../../../shared/types";
+
+  interface Props {
+    tandemMode: TandemMode;
+    onModeChange: (mode: TandemMode) => void;
+  }
+
+  const { tandemMode, onModeChange }: Props = $props();
+</script>
+
+<div
+  data-testid="mode-toggle"
+  role="group"
+  aria-label="Claude collaboration mode"
+  style="display: flex; border: 1px solid var(--tandem-border-strong); border-radius: 4px; overflow: hidden;"
+>
+  <button
+    data-testid="mode-solo-btn"
+    title="Write undisturbed — Claude only responds when you message"
+    aria-pressed={tandemMode === "solo"}
+    onclick={() => onModeChange("solo")}
+    style="padding: 3px 10px; font-size: 12px; border: none; cursor: pointer;
+      background: {tandemMode === 'solo' ? 'var(--tandem-accent)' : 'transparent'};
+      color: {tandemMode === 'solo' ? 'var(--tandem-accent-fg)' : 'var(--tandem-fg-muted)'};
+      font-weight: {tandemMode === 'solo' ? 600 : 400};
+      border-right: 1px solid var(--tandem-border-strong);
+      display: flex; align-items: center; gap: 5px;"
+  >
+    {#if tandemMode === "solo"}
+      <span
+        style="width: 6px; height: 6px; border-radius: 50%; background: var(--tandem-fg-subtle); display: inline-block;"
+      ></span>
+    {/if}
+    Solo
+  </button>
+  <button
+    data-testid="mode-tandem-btn"
+    title="Full collaboration — Claude reacts to selections and document changes"
+    aria-pressed={tandemMode === "tandem"}
+    onclick={() => onModeChange("tandem")}
+    style="padding: 3px 10px; font-size: 12px; border: none; cursor: pointer;
+      background: {tandemMode === 'tandem' ? 'var(--tandem-accent)' : 'transparent'};
+      color: {tandemMode === 'tandem' ? 'var(--tandem-accent-fg)' : 'var(--tandem-fg-muted)'};
+      font-weight: {tandemMode === 'tandem' ? 600 : 400};
+      display: flex; align-items: center; gap: 5px;"
+  >
+    {#if tandemMode === "tandem"}
+      <span
+        style="width: 6px; height: 6px; border-radius: 50%; background: var(--tandem-success); display: inline-block;"
+      ></span>
+    {/if}
+    Tandem
+  </button>
+</div>

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -1,0 +1,269 @@
+<script lang="ts">
+  import type { Editor as TiptapEditor } from "@tiptap/core";
+  import * as Y from "yjs";
+  import { Y_MAP_ANNOTATIONS } from "../../../shared/constants";
+  import { toPmPos } from "../../../shared/positions/types";
+  import type {
+    Annotation,
+    AnnotationType,
+    HighlightColor,
+    TandemMode,
+  } from "../../../shared/types";
+  import { generateAnnotationId } from "../../../shared/utils";
+  import { pmPosToFlatOffset } from "../../positions";
+  import FormattingToolbar from "./FormattingToolbar.svelte";
+  import HighlightColorPicker from "./HighlightColorPicker.svelte";
+  import InputGroup from "./InputGroup.svelte";
+  import ModeToggle from "./ModeToggle.svelte";
+  import ToolbarButton from "./ToolbarButton.svelte";
+
+  type ToolbarMode = "idle" | "comment" | "note";
+
+  interface Props {
+    editor: TiptapEditor | null;
+    ydoc: Y.Doc | null;
+    onSettingsOpen?: () => void;
+    /** Bindable settings button reference for keyboard-shortcut anchoring. */
+    settingsBtn?: HTMLButtonElement | null;
+    tandemMode?: TandemMode;
+    onModeChange?: (mode: TandemMode) => void;
+    heldCount?: number;
+  }
+
+  let {
+    editor,
+    ydoc,
+    onSettingsOpen,
+    settingsBtn = $bindable(null),
+    tandemMode,
+    onModeChange,
+    heldCount,
+  }: Props = $props();
+
+  let hasSelection = $state(false);
+  let mode = $state<ToolbarMode>("idle");
+  let modeText = $state("");
+  let capturedRange: { from: number; to: number } | null = null;
+  let commentInputEl = $state<HTMLInputElement | null>(null);
+  let noteInputEl = $state<HTMLInputElement | null>(null);
+
+  $effect(() => {
+    if (!editor) return;
+    const ed = editor;
+
+    function onSelectionUpdate() {
+      const { from, to } = ed.state.selection;
+      const next = from !== to;
+      if (hasSelection !== next) hasSelection = next;
+    }
+
+    ed.on("selectionUpdate", onSelectionUpdate);
+    return () => {
+      ed.off("selectionUpdate", onSelectionUpdate);
+    };
+  });
+
+  $effect(() => {
+    if (mode === "comment") commentInputEl?.focus();
+    else if (mode === "note") noteInputEl?.focus();
+  });
+
+  function createAnnotation(
+    type: AnnotationType,
+    content: string,
+    extras?: { color?: HighlightColor },
+  ) {
+    if (!editor || !ydoc) return;
+
+    const range = capturedRange ?? editor.state.selection;
+    const { from, to } = range;
+    if (from === to) return;
+
+    const flatFrom = pmPosToFlatOffset(editor.state.doc, toPmPos(from));
+    const flatTo = pmPosToFlatOffset(editor.state.doc, toPmPos(to));
+
+    const id = generateAnnotationId();
+    const annotation = {
+      id,
+      author: "user" as const,
+      type,
+      range: { from: flatFrom, to: flatTo },
+      content,
+      status: "pending" as const,
+      timestamp: Date.now(),
+      ...(extras?.color ? { color: extras.color } : {}),
+    } as Annotation;
+
+    ydoc.getMap(Y_MAP_ANNOTATIONS).set(id, annotation);
+    capturedRange = null;
+  }
+
+  function captureSelectionRange() {
+    if (!editor) return;
+    const { from, to } = editor.state.selection;
+    capturedRange = { from, to };
+  }
+
+  function resetAndFocusEditor() {
+    capturedRange = null;
+    editor?.chain().focus().run();
+  }
+
+  const inInputMode = $derived(mode !== "idle");
+
+  function handleHighlight(color: HighlightColor) {
+    createAnnotation("highlight", "", { color });
+  }
+
+  function handleModeStart(targetMode: ToolbarMode) {
+    return (e: MouseEvent) => {
+      e.preventDefault();
+      captureSelectionRange();
+      mode = targetMode;
+      modeText = "";
+    };
+  }
+
+  const startComment = handleModeStart("comment");
+  const startNote = handleModeStart("note");
+
+  function handleModeCancel() {
+    mode = "idle";
+    modeText = "";
+    resetAndFocusEditor();
+  }
+
+  function handleModeSubmit() {
+    if (mode === "note") {
+      createAnnotation("note", modeText.trim());
+    } else {
+      if (!modeText.trim()) {
+        handleModeCancel();
+        return;
+      }
+      createAnnotation("comment", modeText.trim());
+    }
+
+    mode = "idle";
+    modeText = "";
+    editor?.chain().focus().run();
+  }
+
+  function handleModeKeyDown(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleModeSubmit();
+    } else if (e.key === "Escape") {
+      handleModeCancel();
+    }
+  }
+
+  const canAnnotate = $derived(!!editor && !!ydoc && hasSelection);
+</script>
+
+<div
+  style="display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+    min-height: 42px; padding: 8px 16px;
+    border-bottom: 1px solid var(--tandem-border);
+    background: var(--tandem-surface-muted); user-select: none;"
+>
+  <span
+    style="font-weight: 700; font-size: 15px;
+      color: var(--tandem-accent); letter-spacing: -0.02em;"
+  >
+    Tandem
+  </span>
+  <div
+    style="width: 1px; height: 20px; background: var(--tandem-border); margin: 0 8px;"
+  ></div>
+
+  <FormattingToolbar {editor} disabled={inInputMode} />
+
+  <div
+    style="width: 1px; height: 20px; background: var(--tandem-border); margin: 0 8px;"
+  ></div>
+
+  <HighlightColorPicker
+    disabled={!canAnnotate || inInputMode}
+    onHighlight={handleHighlight}
+  />
+
+  <ToolbarButton
+    label="Comment"
+    testId="toolbar-comment-btn"
+    disabled={!canAnnotate || inInputMode}
+    disabledTitle="Select text first"
+    onMouseDown={startComment}
+  />
+  {#if mode === "comment"}
+    <InputGroup
+      bind:inputEl={commentInputEl}
+      value={modeText}
+      onChange={(v) => (modeText = v)}
+      onKeyDown={handleModeKeyDown}
+      onSubmit={handleModeSubmit}
+      onCancel={handleModeCancel}
+      placeholder="Add a comment..."
+      submitLabel="Add"
+      borderColor="var(--tandem-author-user)"
+      canSubmit={!!modeText.trim()}
+      testIdPrefix="toolbar-comment"
+    />
+  {/if}
+
+  <ToolbarButton
+    label="Note"
+    testId="toolbar-note-btn"
+    disabled={!canAnnotate || inInputMode}
+    disabledTitle="Select text first"
+    onMouseDown={startNote}
+  />
+  {#if mode === "note"}
+    <InputGroup
+      bind:inputEl={noteInputEl}
+      value={modeText}
+      onChange={(v) => (modeText = v)}
+      onKeyDown={handleModeKeyDown}
+      onSubmit={handleModeSubmit}
+      onCancel={handleModeCancel}
+      placeholder="Add a note to yourself..."
+      submitLabel="Add"
+      borderColor="var(--tandem-fg-muted)"
+      canSubmit={true}
+      testIdPrefix="toolbar-note"
+    />
+  {/if}
+
+  <div style="flex: 1;"></div>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    {#if (heldCount ?? 0) > 0}
+      <span
+        data-testid="held-badge"
+        style="padding: 1px 6px; font-size: 10px; font-weight: 600;
+          color: var(--tandem-warning-fg-strong);
+          background: var(--tandem-warning-bg);
+          border-radius: 9999px;"
+      >
+        {heldCount} held
+      </span>
+    {/if}
+    {#if tandemMode && onModeChange}
+      <ModeToggle {tandemMode} {onModeChange} />
+    {/if}
+    {#if onSettingsOpen}
+      <button
+        bind:this={settingsBtn}
+        data-testid="settings-btn"
+        onclick={onSettingsOpen}
+        title="Settings (Ctrl+,)"
+        aria-label="Settings"
+        aria-keyshortcuts="Control+Comma"
+        style="background: none; border: 1px solid var(--tandem-border-strong);
+          border-radius: 4px; cursor: pointer; color: var(--tandem-fg-muted);
+          font-size: 13px; padding: 4px 12px; min-height: 24px;"
+      >
+        Settings
+      </button>
+    {/if}
+  </div>
+</div>

--- a/src/client/editor/toolbar/ToolbarButton.svelte
+++ b/src/client/editor/toolbar/ToolbarButton.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    /** When provided as a snippet, the snippet is rendered inside the button.
+     * Otherwise `label` is rendered as a plain string. */
+    label?: string;
+    children?: Snippet;
+    ariaLabel?: string;
+    testId?: string;
+    shortcut?: string;
+    disabled?: boolean;
+    disabledTitle?: string;
+    active?: boolean;
+    onMouseDown?: (e: MouseEvent) => void;
+    onClick?: () => void;
+    style?: string;
+  }
+
+  const {
+    label,
+    children,
+    ariaLabel,
+    testId,
+    shortcut,
+    disabled = false,
+    disabledTitle,
+    active = false,
+    onMouseDown,
+    onClick,
+    style = "",
+  }: Props = $props();
+
+  const computed = $derived.by(() => {
+    let border = "1px solid var(--tandem-border)";
+    let background = "var(--tandem-surface)";
+    let color = "var(--tandem-fg)";
+
+    if (disabled) {
+      background = "var(--tandem-surface-muted)";
+      color = "var(--tandem-fg-subtle)";
+    } else if (active) {
+      border = "1px solid var(--tandem-accent)";
+      background = "var(--tandem-accent-bg)";
+      color = "var(--tandem-accent)";
+    }
+    return { border, background, color };
+  });
+
+  const ariaLabelValue = $derived(ariaLabel ?? (typeof label === "string" ? label : undefined));
+  const titleText = $derived(ariaLabelValue ?? "");
+  const titleAttr = $derived(
+    disabled && disabledTitle
+      ? disabledTitle
+      : shortcut
+        ? `${titleText} (${shortcut})`
+        : titleText,
+  );
+
+  const baseStyle =
+    "padding: 4px 10px; font-size: 13px; border-radius: 4px;";
+
+  const fullStyle = $derived(
+    `${baseStyle} cursor: ${disabled ? "not-allowed" : "pointer"}; ${style}; border: ${computed.border}; background: ${computed.background}; color: ${computed.color};`,
+  );
+</script>
+
+<button
+  type="button"
+  data-testid={testId}
+  {disabled}
+  title={titleAttr}
+  aria-label={ariaLabelValue}
+  onmousedown={onMouseDown}
+  onclick={onClick}
+  style={fullStyle}
+>
+  {#if children}{@render children()}{:else}{label}{/if}
+</button>

--- a/src/client/svelte-harness/EditorHarness.svelte
+++ b/src/client/svelte-harness/EditorHarness.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { HocuspocusProvider } from "@hocuspocus/provider";
+  import { onDestroy } from "svelte";
+  import * as Y from "yjs";
+  import Editor from "../editor/Editor.svelte";
+
+  // Fresh Y.Doc + a no-op-ish provider for harness rendering. The provider
+  // will attempt to connect; failure is fine — we only need the object so
+  // the CollaborationCursor extension constructs without throwing.
+  const ydoc = new Y.Doc();
+  const provider = new HocuspocusProvider({
+    url: "ws://localhost:3478",
+    name: "harness-doc",
+    document: ydoc,
+  });
+  // Disconnect immediately — the harness does not need a live connection,
+  // we only need a constructed provider so CollaborationCursor wires up.
+  provider.disconnect();
+
+  onDestroy(() => {
+    provider.destroy();
+    ydoc.destroy();
+  });
+</script>
+
+<div style="padding: 16px;">
+  <h2 style="margin: 0 0 12px 0;">Editor harness</h2>
+  <Editor {ydoc} {provider} readOnly={false} />
+</div>

--- a/src/client/svelte-harness/registry.ts
+++ b/src/client/svelte-harness/registry.ts
@@ -10,6 +10,7 @@ import type { Component } from "svelte";
 // biome-ignore lint/suspicious/noExplicitAny: intentional harness escape hatch
 export const registry: Record<string, () => Promise<{ default: Component<any> }>> = {
   HookDebug: () => import("./HookDebug.svelte"),
+  Editor: () => import("./EditorHarness.svelte"),
   DocumentHealth: () => import("../panels/DocumentHealth.svelte"),
   ReviewSummary: () => import("../panels/ReviewSummary.svelte"),
   FilterSelect: () => import("../panels/FilterSelect.svelte"),


### PR DESCRIPTION
## Summary

Ports the Tiptap editor and its toolbar from React to Svelte 5, alongside the existing `.tsx` originals (no-touch policy on React tree). Closes #468.

New Svelte components:
- `src/client/editor/Editor.svelte` — Tiptap + Y.js + Hocuspocus editor host
- `src/client/editor/toolbar/Toolbar.svelte`
- `src/client/editor/toolbar/FormattingToolbar.svelte`
- `src/client/editor/toolbar/ToolbarButton.svelte`
- `src/client/editor/toolbar/InputGroup.svelte`
- `src/client/editor/toolbar/ModeToggle.svelte`
- `src/client/editor/toolbar/HighlightColorPicker.svelte`

Harness:
- `src/client/svelte-harness/EditorHarness.svelte` mounts `Editor` with a fresh `Y.Doc` + `HocuspocusProvider` (immediately disconnected — harness doesn't need a live connection)
- `registry.ts` registers `"Editor"`

## Implementation notes

- Imports `Editor` from `@tiptap/core` rather than `@tiptap/react`, keeping the framework-agnostic surface.
- Single `$effect` block creates the Tiptap editor: cleanup runs before re-creation, ensuring destroy-before-create ordering when `(ydoc, provider)` identity changes.
- `readOnly`, display-name subscription, and active-annotation highlight are split into separate `$effect`s — each only depends on the props it patches, never re-creating the editor.
- `FormattingToolbar` uses a `tick` counter bumped on Tiptap `transaction` events to force `$derived` re-evaluation of `isActive(...)` (Tiptap's reads are imperative).
- All `data-testid` attributes preserved — `toolbar-highlight-btn`, `toolbar-highlight-color-toggle`, `toolbar-highlight-color-{yellow|green|blue|pink}`, `toolbar-comment-{btn,input,submit,cancel}`, `toolbar-note-{btn,input,submit,cancel}`, `settings-btn`, `mode-toggle`, `mode-{solo,tandem}-btn`, `held-badge`, `color-picker-close`.
- No `.tsx` file modified or deleted.

## Test plan

- [x] `npx svelte-check --tsconfig ./tsconfig.client.json` — 0 errors / 0 warnings
- [x] `npm run typecheck` — passes
- [x] `npm test -- --run` — 1716 passed (1 pre-existing flake in `tests/cli/mcp-stdio.test.ts`, unrelated to this PR)
- [ ] Manual: visit `/?harness&component=Editor` once a follow-up PR wires the Tiptap CSS into the harness page

## Out of scope

- Wiring the Svelte Editor into `App.tsx` or replacing the React tree — deferred to the integration PR
- Behavioural parity testing under real Hocuspocus connection — harness uses a disconnected provider