### PR TITLE
feat(tabs): port DocumentTabs + FileOpenDialog to Svelte 5 (#469, #478)

### DIFF
--- a/src/client/components/FileOpenDialog.svelte
+++ b/src/client/components/FileOpenDialog.svelte
@@ -1,121 +1,121 @@
 <script lang="ts">
-  import { API_BASE, readFileForUpload } from "../utils/fileUpload.js";
-  import {
-    addRecentFile,
-    clearRecentFiles,
-    loadRecentFiles,
-    saveRecentFiles,
-  } from "../utils/recentFiles.js";
+import { API_BASE, readFileForUpload } from "../utils/fileUpload.js";
+import {
+  addRecentFile,
+  clearRecentFiles,
+  loadRecentFiles,
+  saveRecentFiles,
+} from "../utils/recentFiles.js";
 
-  interface Props {
-    onClose: () => void;
-  }
+interface Props {
+  onClose: () => void;
+}
 
-  const { onClose }: Props = $props();
+const { onClose }: Props = $props();
 
-  type Mode = "path" | "upload";
+type Mode = "path" | "upload";
 
-  // #478: Default to "upload" (OS file picker) instead of "path"
-  let mode = $state<Mode>("upload");
-  let filePath = $state("");
-  let error = $state<string | null>(null);
-  let loading = $state(false);
-  let dragOver = $state(false);
-  let fileInputEl: HTMLInputElement | undefined = $state();
-  let recentFiles = $state<string[]>(loadRecentFiles());
+// #478: Default to "upload" (OS file picker) instead of "path"
+let mode = $state<Mode>("upload");
+let filePath = $state("");
+let error = $state<string | null>(null);
+let loading = $state(false);
+let dragOver = $state(false);
+let fileInputEl: HTMLInputElement | undefined = $state();
+let recentFiles = $state<string[]>(loadRecentFiles());
 
-  function pushRecent(path: string) {
-    recentFiles = (() => {
-      const updated = addRecentFile(recentFiles, path);
-      saveRecentFiles(updated);
-      return updated;
-    })();
-  }
+function pushRecent(path: string) {
+  recentFiles = (() => {
+    const updated = addRecentFile(recentFiles, path);
+    saveRecentFiles(updated);
+    return updated;
+  })();
+}
 
-  function handleClearRecent() {
-    clearRecentFiles();
-    recentFiles = [];
-  }
+function handleClearRecent() {
+  clearRecentFiles();
+  recentFiles = [];
+}
 
-  async function openByPath(pathToOpen: string) {
-    if (loading) return;
-    error = null;
-    loading = true;
-    try {
-      const res = await fetch(`${API_BASE}/open`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ filePath: pathToOpen }),
-      });
-      const data = await res.json();
-      if (!res.ok) {
-        error = data.message ?? "Failed to open file";
-        return;
-      }
-      pushRecent(pathToOpen);
-      onClose();
-    } catch (err) {
-      console.error("FileOpenDialog: path open failed", err);
-      if (err instanceof SyntaxError) {
-        error = "Server returned an unexpected response";
-      } else if (err instanceof TypeError) {
-        error = "Unexpected response format";
-      } else {
-        error = "Cannot reach server. Is it running?";
-      }
-    } finally {
-      loading = false;
+async function openByPath(pathToOpen: string) {
+  if (loading) return;
+  error = null;
+  loading = true;
+  try {
+    const res = await fetch(`${API_BASE}/open`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: pathToOpen }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      error = data.message ?? "Failed to open file";
+      return;
     }
-  }
-
-  function handlePathSubmit() {
-    if (!filePath.trim()) return;
-    openByPath(filePath.trim());
-  }
-
-  async function uploadFile(file: File) {
-    if (loading) return;
-    error = null;
-    loading = true;
-    try {
-      const content = await readFileForUpload(file);
-      const res = await fetch(`${API_BASE}/upload`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ fileName: file.name, content }),
-      });
-      const data = await res.json();
-      if (!res.ok) {
-        error = data.message ?? "Failed to open file";
-        return;
-      }
-      onClose();
-    } catch (err) {
-      console.error("FileOpenDialog: upload failed", err);
-      if (err instanceof SyntaxError) {
-        error = "Server returned an unexpected response";
-      } else if (err instanceof TypeError) {
-        error = "Unexpected response format";
-      } else {
-        error = "Cannot reach server. Is it running?";
-      }
-    } finally {
-      loading = false;
+    pushRecent(pathToOpen);
+    onClose();
+  } catch (err) {
+    console.error("FileOpenDialog: path open failed", err);
+    if (err instanceof SyntaxError) {
+      error = "Server returned an unexpected response";
+    } else if (err instanceof TypeError) {
+      error = "Unexpected response format";
+    } else {
+      error = "Cannot reach server. Is it running?";
     }
+  } finally {
+    loading = false;
   }
+}
 
-  function handleFileDrop(e: DragEvent) {
-    e.preventDefault();
-    dragOver = false;
-    const file = e.dataTransfer?.files[0];
-    if (file) uploadFile(file);
-  }
+function handlePathSubmit() {
+  if (!filePath.trim()) return;
+  openByPath(filePath.trim());
+}
 
-  function handleFileSelect(e: Event) {
-    const input = e.target as HTMLInputElement;
-    const file = input.files?.[0];
-    if (file) uploadFile(file);
+async function uploadFile(file: File) {
+  if (loading) return;
+  error = null;
+  loading = true;
+  try {
+    const content = await readFileForUpload(file);
+    const res = await fetch(`${API_BASE}/upload`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fileName: file.name, content }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      error = data.message ?? "Failed to open file";
+      return;
+    }
+    onClose();
+  } catch (err) {
+    console.error("FileOpenDialog: upload failed", err);
+    if (err instanceof SyntaxError) {
+      error = "Server returned an unexpected response";
+    } else if (err instanceof TypeError) {
+      error = "Unexpected response format";
+    } else {
+      error = "Cannot reach server. Is it running?";
+    }
+  } finally {
+    loading = false;
   }
+}
+
+function handleFileDrop(e: DragEvent) {
+  e.preventDefault();
+  dragOver = false;
+  const file = e.dataTransfer?.files[0];
+  if (file) uploadFile(file);
+}
+
+function handleFileSelect(e: Event) {
+  const input = e.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (file) uploadFile(file);
+}
 </script>
 
 <div

--- a/src/client/components/FileOpenDialog.svelte
+++ b/src/client/components/FileOpenDialog.svelte
@@ -1,0 +1,287 @@
+<script lang="ts">
+  import { API_BASE, readFileForUpload } from "../utils/fileUpload.js";
+  import {
+    addRecentFile,
+    clearRecentFiles,
+    loadRecentFiles,
+    saveRecentFiles,
+  } from "../utils/recentFiles.js";
+
+  interface Props {
+    onClose: () => void;
+  }
+
+  const { onClose }: Props = $props();
+
+  type Mode = "path" | "upload";
+
+  // #478: Default to "upload" (OS file picker) instead of "path"
+  let mode = $state<Mode>("upload");
+  let filePath = $state("");
+  let error = $state<string | null>(null);
+  let loading = $state(false);
+  let dragOver = $state(false);
+  let fileInputEl: HTMLInputElement | undefined = $state();
+  let recentFiles = $state<string[]>(loadRecentFiles());
+
+  function pushRecent(path: string) {
+    recentFiles = (() => {
+      const updated = addRecentFile(recentFiles, path);
+      saveRecentFiles(updated);
+      return updated;
+    })();
+  }
+
+  function handleClearRecent() {
+    clearRecentFiles();
+    recentFiles = [];
+  }
+
+  async function openByPath(pathToOpen: string) {
+    if (loading) return;
+    error = null;
+    loading = true;
+    try {
+      const res = await fetch(`${API_BASE}/open`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filePath: pathToOpen }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        error = data.message ?? "Failed to open file";
+        return;
+      }
+      pushRecent(pathToOpen);
+      onClose();
+    } catch (err) {
+      console.error("FileOpenDialog: path open failed", err);
+      if (err instanceof SyntaxError) {
+        error = "Server returned an unexpected response";
+      } else if (err instanceof TypeError) {
+        error = "Unexpected response format";
+      } else {
+        error = "Cannot reach server. Is it running?";
+      }
+    } finally {
+      loading = false;
+    }
+  }
+
+  function handlePathSubmit() {
+    if (!filePath.trim()) return;
+    openByPath(filePath.trim());
+  }
+
+  async function uploadFile(file: File) {
+    if (loading) return;
+    error = null;
+    loading = true;
+    try {
+      const content = await readFileForUpload(file);
+      const res = await fetch(`${API_BASE}/upload`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fileName: file.name, content }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        error = data.message ?? "Failed to open file";
+        return;
+      }
+      onClose();
+    } catch (err) {
+      console.error("FileOpenDialog: upload failed", err);
+      if (err instanceof SyntaxError) {
+        error = "Server returned an unexpected response";
+      } else if (err instanceof TypeError) {
+        error = "Unexpected response format";
+      } else {
+        error = "Cannot reach server. Is it running?";
+      }
+    } finally {
+      loading = false;
+    }
+  }
+
+  function handleFileDrop(e: DragEvent) {
+    e.preventDefault();
+    dragOver = false;
+    const file = e.dataTransfer?.files[0];
+    if (file) uploadFile(file);
+  }
+
+  function handleFileSelect(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file) uploadFile(file);
+  }
+</script>
+
+<div
+  role="dialog"
+  aria-modal="true"
+  aria-label="Open File"
+  tabindex={-1}
+  style="position: fixed; inset: 0; z-index: 1000; display: flex; align-items: flex-start; justify-content: center; padding-top: 80px; background: rgba(0,0,0,0.3);"
+  onclick={(e) => {
+    if (e.target === e.currentTarget) onClose();
+  }}
+  onkeydown={(e) => {
+    if (e.key === "Escape") onClose();
+  }}
+>
+  <div
+    style="background: var(--tandem-surface); border-radius: 8px; box-shadow: 0 8px 30px rgba(0,0,0,0.15); width: 440px; padding: 20px;"
+    data-testid="file-open-dialog"
+  >
+    <div style="display: flex; justify-content: space-between; margin-bottom: 16px;">
+      <h3 style="margin: 0; font-size: 15px; font-weight: 600; color: var(--tandem-fg);">
+        Open File
+      </h3>
+      <button
+        onclick={onClose}
+        style="background: none; border: none; cursor: pointer; font-size: 16px; color: var(--tandem-fg-subtle);"
+      >
+        ×
+      </button>
+    </div>
+
+    <!-- Mode toggle — #478: "Upload" renamed to "Open" -->
+    <div style="display: flex; gap: 8px; margin-bottom: 16px;">
+      <button
+        onclick={() => (mode = "path")}
+        style={`flex: 1; padding: 6px; font-size: 13px; border: 1px solid var(--tandem-border); border-radius: 4px; cursor: pointer; background: ${mode === "path" ? "var(--tandem-accent)" : "var(--tandem-surface)"}; color: ${mode === "path" ? "var(--tandem-accent-fg)" : "var(--tandem-fg)"};`}
+      >
+        File Path
+      </button>
+      <button
+        onclick={() => (mode = "upload")}
+        style={`flex: 1; padding: 6px; font-size: 13px; border: 1px solid var(--tandem-border); border-radius: 4px; cursor: pointer; background: ${mode === "upload" ? "var(--tandem-accent)" : "var(--tandem-surface)"}; color: ${mode === "upload" ? "var(--tandem-accent-fg)" : "var(--tandem-fg)"};`}
+      >
+        Open
+      </button>
+    </div>
+
+    {#if mode === "path"}
+      <div>
+        <!-- svelte-ignore a11y_autofocus -->
+        <input
+          autofocus
+          type="text"
+          placeholder="Paste absolute file path..."
+          bind:value={filePath}
+          onkeydown={(e) => {
+            if (e.key === "Enter") handlePathSubmit();
+          }}
+          style="width: 100%; padding: 8px 10px; font-size: 13px; border: 1px solid var(--tandem-border-strong); border-radius: 4px; box-sizing: border-box; background: var(--tandem-surface); color: var(--tandem-fg);"
+          data-testid="file-path-input"
+        />
+        <button
+          onclick={handlePathSubmit}
+          disabled={loading || !filePath.trim()}
+          style={`margin-top: 10px; width: 100%; padding: 8px; font-size: 13px; font-weight: 500; border: none; border-radius: 4px; cursor: ${loading ? "wait" : "pointer"}; background: ${loading ? "var(--tandem-fg-subtle)" : "var(--tandem-accent)"}; color: var(--tandem-accent-fg); opacity: ${!filePath.trim() ? 0.5 : 1};`}
+          data-testid="file-open-submit"
+        >
+          {loading ? "Opening..." : "Open"}
+        </button>
+
+        <!-- Recent files -->
+        {#if recentFiles.length > 0}
+          <div data-testid="recent-files-list" style="margin-top: 14px;">
+            <div
+              style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px;"
+            >
+              <span
+                style="font-size: 11px; color: var(--tandem-fg-subtle); text-transform: uppercase; letter-spacing: 0.05em;"
+              >
+                Recent
+              </span>
+              <button
+                data-testid="clear-recent-files"
+                onclick={handleClearRecent}
+                type="button"
+                style="background: none; border: none; color: var(--tandem-fg-subtle); font-size: 11px; cursor: pointer; padding: 0; text-decoration: underline;"
+              >
+                Clear all
+              </button>
+            </div>
+            <div
+              style="max-height: 150px; overflow-y: auto; display: flex; flex-direction: column; gap: 2px;"
+            >
+              {#each recentFiles as p, i (p)}
+                {@const parts = p.split(/[/\\]/)}
+                {@const filename = parts.at(-1) ?? p}
+                {@const dir = parts.slice(0, -1).join("/") || "/"}
+                <button
+                  type="button"
+                  data-testid={`recent-file-${i}`}
+                  onclick={() => {
+                    filePath = p;
+                    openByPath(p);
+                  }}
+                  style="background: none; border: none; padding: 6px 8px; border-radius: 4px; cursor: pointer; text-align: left; display: flex; flex-direction: column; gap: 1px;"
+                  onmouseenter={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.background =
+                      "var(--tandem-surface-muted)";
+                  }}
+                  onmouseleave={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+                  }}
+                >
+                  <span style="font-size: 13px; color: var(--tandem-fg);">{filename}</span>
+                  <span
+                    style="font-size: 11px; color: var(--tandem-fg-subtle); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 380px;"
+                  >
+                    {dir}
+                  </span>
+                </button>
+              {/each}
+            </div>
+          </div>
+        {/if}
+      </div>
+    {:else}
+      <!-- #478: "Uploading..." renamed to "Opening..." -->
+      <div
+        role="button"
+        tabindex={0}
+        ondragover={(e) => {
+          e.preventDefault();
+          dragOver = true;
+        }}
+        ondragleave={() => (dragOver = false)}
+        ondrop={handleFileDrop}
+        onclick={() => fileInputEl?.click()}
+        onkeydown={(e) => {
+          if (e.key === "Enter" || e.key === " ") fileInputEl?.click();
+        }}
+        style={`border: 2px dashed ${dragOver ? "var(--tandem-accent)" : "var(--tandem-border-strong)"}; border-radius: 6px; padding: 32px 16px; text-align: center; cursor: ${loading ? "wait" : "pointer"}; background: ${dragOver ? "var(--tandem-accent-bg)" : "var(--tandem-surface-muted)"}; transition: border-color 0.15s, background 0.15s;`}
+        data-testid="file-upload-zone"
+      >
+        <input
+          bind:this={fileInputEl}
+          type="file"
+          accept=".md,.txt,.html,.htm,.docx"
+          onchange={handleFileSelect}
+          style="display: none;"
+        />
+        <div style="font-size: 13px; color: var(--tandem-fg-muted);">
+          {loading ? "Opening..." : "Drop a file here or click to browse"}
+        </div>
+        <div style="font-size: 11px; color: var(--tandem-fg-subtle); margin-top: 6px;">
+          .md, .txt, .html, .docx
+        </div>
+      </div>
+    {/if}
+
+    {#if error}
+      <div
+        style="margin-top: 10px; padding: 8px 10px; font-size: 12px; color: var(--tandem-error-fg-strong); background: var(--tandem-error-bg); border-radius: 4px; border: 1px solid var(--tandem-error-border);"
+        data-testid="file-open-error"
+      >
+        {error}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/client/svelte-harness/Harness.svelte
+++ b/src/client/svelte-harness/Harness.svelte
@@ -1,35 +1,35 @@
 <script lang="ts">
-  import type { Component } from "svelte";
-  import { registry } from "./registry.js";
+import type { Component } from "svelte";
+import { registry } from "./registry.js";
 
-  const params = new URLSearchParams(window.location.search);
-  const componentName = params.get("component");
+const params = new URLSearchParams(window.location.search);
+const componentName = params.get("component");
 
-  let status = $state<"idle" | "loading" | "loaded" | "not-found" | "error">("idle");
-  let LoadedComponent = $state<Component | null>(null);
+let status = $state<"idle" | "loading" | "loaded" | "not-found" | "error">("idle");
+let LoadedComponent = $state<Component | null>(null);
 
-  $effect(() => {
-    if (!componentName) {
-      status = "idle";
-      return;
-    }
+$effect(() => {
+  if (!componentName) {
+    status = "idle";
+    return;
+  }
 
-    const loader = registry[componentName];
-    if (!loader) {
-      status = "not-found";
-      return;
-    }
+  const loader = registry[componentName];
+  if (!loader) {
+    status = "not-found";
+    return;
+  }
 
-    status = "loading";
-    loader()
-      .then((mod) => {
-        LoadedComponent = mod.default;
-        status = "loaded";
-      })
-      .catch(() => {
-        status = "error";
-      });
-  });
+  status = "loading";
+  loader()
+    .then((mod) => {
+      LoadedComponent = mod.default;
+      status = "loaded";
+    })
+    .catch(() => {
+      status = "error";
+    });
+});
 </script>
 
 {#if status === "idle"}

--- a/src/client/svelte-harness/registry.ts
+++ b/src/client/svelte-harness/registry.ts
@@ -11,6 +11,8 @@ import type { Component } from "svelte";
 export const registry: Record<string, () => Promise<{ default: Component<any> }>> = {
   HookDebug: () => import("./HookDebug.svelte"),
   Editor: () => import("./EditorHarness.svelte"),
+  DocumentTabs: () => import("../tabs/DocumentTabs.svelte"),
+  FileOpenDialog: () => import("../components/FileOpenDialog.svelte"),
   DocumentHealth: () => import("../panels/DocumentHealth.svelte"),
   ReviewSummary: () => import("../panels/ReviewSummary.svelte"),
   FilterSelect: () => import("../panels/FilterSelect.svelte"),

--- a/src/client/tabs/DocumentTabs.svelte
+++ b/src/client/tabs/DocumentTabs.svelte
@@ -1,0 +1,244 @@
+<script lang="ts">
+  import type { OpenTab } from "../types.js";
+  import FileOpenDialog from "../components/FileOpenDialog.svelte";
+  import TabItem from "./TabItem.svelte";
+
+  interface Props {
+    tabs: OpenTab[];
+    activeTabId: string | null;
+    onTabSwitch: (tabId: string) => void;
+    onTabClose: (tabId: string) => void;
+    reorder?: (fromId: string, toId: string, side?: "left" | "right") => void;
+    reduceMotion?: boolean;
+  }
+
+  const { tabs, activeTabId, onTabSwitch, onTabClose, reorder, reduceMotion = false }: Props =
+    $props();
+
+  const scrollBehavior: ScrollBehavior = $derived(reduceMotion ? "auto" : "smooth");
+
+  let showDialog = $state(false);
+
+  // Plain let — not reactive UI; just internal close-dedup guard
+  let closingIds = new Set<string>();
+
+  // Clean up stale entries when tabs change (closed tab removed from DOM)
+  $effect(() => {
+    const currentIds = new Set(tabs.map((t) => t.id));
+    for (const id of closingIds) {
+      if (!currentIds.has(id)) closingIds.delete(id);
+    }
+  });
+
+  function guardedClose(tabId: string) {
+    if (closingIds.has(tabId)) return;
+    closingIds.add(tabId);
+    onTabClose(tabId);
+  }
+
+  let scrollEl: HTMLDivElement | undefined = $state();
+  let canScrollLeft = $state(false);
+  let canScrollRight = $state(false);
+  let draggedId = $state<string | null>(null);
+  let dropTarget = $state<{ id: string; side: "left" | "right" } | null>(null);
+
+  function clearDragState() {
+    draggedId = null;
+    dropTarget = null;
+  }
+
+  function updateScrollState() {
+    const el = scrollEl;
+    if (!el) return;
+    canScrollLeft = el.scrollLeft > 0;
+    canScrollRight = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
+  }
+
+  // Set up scroll listeners and resize observer
+  $effect(() => {
+    const el = scrollEl;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    const observer = new ResizeObserver(updateScrollState);
+    observer.observe(el);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      observer.disconnect();
+    };
+  });
+
+  // Re-check overflow when tabs change
+  $effect(() => {
+    // Track tabs.length
+    void tabs.length;
+    updateScrollState();
+  });
+
+  // Auto-scroll active tab into view
+  $effect(() => {
+    if (!activeTabId || !scrollEl) return;
+    const el = scrollEl.querySelector(`[data-testid="tab-${activeTabId}"]`);
+    if (el) {
+      (el as HTMLElement).scrollIntoView({
+        inline: "nearest",
+        block: "nearest",
+        behavior: scrollBehavior,
+      });
+    }
+  });
+
+  // Clear drag state when tab list changes mid-drag
+  $effect(() => {
+    void tabs.length;
+    clearDragState();
+  });
+
+  // DnD handlers
+  function handleDragStart(e: DragEvent, id: string) {
+    draggedId = id;
+    if (e.dataTransfer) {
+      e.dataTransfer.setData("text/plain", id);
+      e.dataTransfer.effectAllowed = "move";
+    }
+  }
+
+  function handleDragOver(e: DragEvent, id: string) {
+    e.preventDefault();
+    if (!draggedId || draggedId === id) {
+      dropTarget = null;
+      return;
+    }
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const midX = rect.left + rect.width / 2;
+    const side = e.clientX < midX ? "left" : "right";
+    dropTarget = { id, side };
+  }
+
+  function handleDrop(e: DragEvent, targetId: string) {
+    e.preventDefault();
+    const fromId = e.dataTransfer?.getData("text/plain");
+    if (fromId && fromId !== targetId && reorder) {
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      const midX = rect.left + rect.width / 2;
+      const side = e.clientX < midX ? "left" : "right";
+      reorder(fromId, targetId, side);
+    }
+    clearDragState();
+  }
+
+  function handleDragEnd() {
+    clearDragState();
+  }
+
+  function handleDragLeave() {
+    dropTarget = null;
+  }
+
+  // Keyboard reordering (Alt+Arrow swaps with neighbor)
+  function handleKeyDown(e: KeyboardEvent, id: string) {
+    if (!e.altKey || !reorder) return;
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+
+    const idx = tabs.findIndex((t) => t.id === id);
+    if (idx === -1) return;
+
+    if (e.key === "ArrowLeft" && idx > 0) {
+      reorder(id, tabs[idx - 1].id);
+    } else if (e.key === "ArrowRight" && idx < tabs.length - 1) {
+      reorder(tabs[idx + 1].id, id);
+    }
+  }
+
+  function scrollLeft() {
+    scrollEl?.scrollBy({ left: -150, behavior: scrollBehavior });
+  }
+
+  function scrollRight() {
+    scrollEl?.scrollBy({ left: 150, behavior: scrollBehavior });
+  }
+
+  const singleTab = $derived(tabs.length <= 1);
+</script>
+
+<div
+  style="position: relative; display: flex; align-items: center; background: var(--tandem-surface-muted); border-bottom: 1px solid var(--tandem-border); min-height: 32px;"
+>
+  {#if canScrollLeft}
+    <button
+      data-testid="tab-scroll-left"
+      onclick={scrollLeft}
+      style="display: flex; align-items: center; justify-content: center; width: 28px; min-width: 28px; background: linear-gradient(to right, var(--tandem-surface-muted) 70%, transparent); border: none; cursor: pointer; font-size: 12px; color: var(--tandem-fg-muted); padding: 0; z-index: 1;"
+      title="Scroll tabs left"
+    >
+      ◀
+    </button>
+  {/if}
+
+  <div
+    bind:this={scrollEl}
+    data-testid="tab-scroll-container"
+    class="tab-scroll-hide"
+    style="display: flex; align-items: center; gap: 1px; flex: 1; overflow-x: auto; overflow-y: hidden; padding: 0 4px;"
+  >
+    {#each tabs as tab (tab.id)}
+      <TabItem
+        {tab}
+        isActive={tab.id === activeTabId}
+        onswitch={onTabSwitch}
+        onclose={guardedClose}
+        draggable={!singleTab}
+        ondragstart={handleDragStart}
+        ondragover={handleDragOver}
+        ondrop={handleDrop}
+        ondragend={handleDragEnd}
+        ondragleave={handleDragLeave}
+        dropIndicator={dropTarget?.id === tab.id ? dropTarget.side : null}
+        onkeydown={handleKeyDown}
+      />
+    {/each}
+  </div>
+
+  {#if canScrollRight}
+    <button
+      data-testid="tab-scroll-right"
+      onclick={scrollRight}
+      style="display: flex; align-items: center; justify-content: center; width: 28px; min-width: 28px; background: linear-gradient(to left, var(--tandem-surface-muted) 70%, transparent); border: none; cursor: pointer; font-size: 12px; color: var(--tandem-fg-muted); padding: 0; z-index: 1;"
+      title="Scroll tabs right"
+    >
+      ▶
+    </button>
+  {/if}
+
+  <button
+    onclick={() => (showDialog = true)}
+    data-testid="open-file-btn"
+    title="Open file"
+    style="background: none; border: 1px solid var(--tandem-border-strong); border-radius: 4px; cursor: pointer; font-size: 16px; line-height: 1; color: var(--tandem-fg-muted); padding: 2px 8px; margin-left: 4px; margin-right: 8px; flex-shrink: 0;"
+    onmouseenter={(e) => {
+      (e.currentTarget as HTMLButtonElement).style.color = "var(--tandem-accent)";
+      (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--tandem-accent)";
+    }}
+    onmouseleave={(e) => {
+      (e.currentTarget as HTMLButtonElement).style.color = "var(--tandem-fg-muted)";
+      (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--tandem-border-strong)";
+    }}
+  >
+    +
+  </button>
+
+  {#if showDialog}
+    <FileOpenDialog onClose={() => (showDialog = false)} />
+  {/if}
+</div>
+
+<style>
+  :global(.tab-scroll-hide) {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  :global(.tab-scroll-hide::-webkit-scrollbar) {
+    display: none;
+  }
+</style>

--- a/src/client/tabs/DocumentTabs.svelte
+++ b/src/client/tabs/DocumentTabs.svelte
@@ -1,165 +1,171 @@
 <script lang="ts">
-  import type { OpenTab } from "../types.js";
-  import FileOpenDialog from "../components/FileOpenDialog.svelte";
-  import TabItem from "./TabItem.svelte";
+import FileOpenDialog from "../components/FileOpenDialog.svelte";
+import type { OpenTab } from "../types.js";
+import TabItem from "./TabItem.svelte";
 
-  interface Props {
-    tabs: OpenTab[];
-    activeTabId: string | null;
-    onTabSwitch: (tabId: string) => void;
-    onTabClose: (tabId: string) => void;
-    reorder?: (fromId: string, toId: string, side?: "left" | "right") => void;
-    reduceMotion?: boolean;
+interface Props {
+  tabs: OpenTab[];
+  activeTabId: string | null;
+  onTabSwitch: (tabId: string) => void;
+  onTabClose: (tabId: string) => void;
+  reorder?: (fromId: string, toId: string, side?: "left" | "right") => void;
+  reduceMotion?: boolean;
+}
+
+const {
+  tabs,
+  activeTabId,
+  onTabSwitch,
+  onTabClose,
+  reorder,
+  reduceMotion = false,
+}: Props = $props();
+
+const scrollBehavior: ScrollBehavior = $derived(reduceMotion ? "auto" : "smooth");
+
+let showDialog = $state(false);
+
+// Plain let — not reactive UI; just internal close-dedup guard
+let closingIds = new Set<string>();
+
+// Clean up stale entries when tabs change (closed tab removed from DOM)
+$effect(() => {
+  const currentIds = new Set(tabs.map((t) => t.id));
+  for (const id of closingIds) {
+    if (!currentIds.has(id)) closingIds.delete(id);
   }
+});
 
-  const { tabs, activeTabId, onTabSwitch, onTabClose, reorder, reduceMotion = false }: Props =
-    $props();
+function guardedClose(tabId: string) {
+  if (closingIds.has(tabId)) return;
+  closingIds.add(tabId);
+  onTabClose(tabId);
+}
 
-  const scrollBehavior: ScrollBehavior = $derived(reduceMotion ? "auto" : "smooth");
+let scrollEl: HTMLDivElement | undefined = $state();
+let canScrollLeft = $state(false);
+let canScrollRight = $state(false);
+let draggedId = $state<string | null>(null);
+let dropTarget = $state<{ id: string; side: "left" | "right" } | null>(null);
 
-  let showDialog = $state(false);
+function clearDragState() {
+  draggedId = null;
+  dropTarget = null;
+}
 
-  // Plain let — not reactive UI; just internal close-dedup guard
-  let closingIds = new Set<string>();
+function updateScrollState() {
+  const el = scrollEl;
+  if (!el) return;
+  canScrollLeft = el.scrollLeft > 0;
+  canScrollRight = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
+}
 
-  // Clean up stale entries when tabs change (closed tab removed from DOM)
-  $effect(() => {
-    const currentIds = new Set(tabs.map((t) => t.id));
-    for (const id of closingIds) {
-      if (!currentIds.has(id)) closingIds.delete(id);
-    }
-  });
+// Set up scroll listeners and resize observer
+$effect(() => {
+  const el = scrollEl;
+  if (!el) return;
+  updateScrollState();
+  el.addEventListener("scroll", updateScrollState, { passive: true });
+  const observer = new ResizeObserver(updateScrollState);
+  observer.observe(el);
+  return () => {
+    el.removeEventListener("scroll", updateScrollState);
+    observer.disconnect();
+  };
+});
 
-  function guardedClose(tabId: string) {
-    if (closingIds.has(tabId)) return;
-    closingIds.add(tabId);
-    onTabClose(tabId);
+// Re-check overflow when tabs change
+$effect(() => {
+  // Track tabs.length
+  void tabs.length;
+  updateScrollState();
+});
+
+// Auto-scroll active tab into view
+$effect(() => {
+  if (!activeTabId || !scrollEl) return;
+  const el = scrollEl.querySelector(`[data-testid="tab-${activeTabId}"]`);
+  if (el) {
+    (el as HTMLElement).scrollIntoView({
+      inline: "nearest",
+      block: "nearest",
+      behavior: scrollBehavior,
+    });
   }
+});
 
-  let scrollEl: HTMLDivElement | undefined = $state();
-  let canScrollLeft = $state(false);
-  let canScrollRight = $state(false);
-  let draggedId = $state<string | null>(null);
-  let dropTarget = $state<{ id: string; side: "left" | "right" } | null>(null);
+// Clear drag state when tab list changes mid-drag
+$effect(() => {
+  void tabs.length;
+  clearDragState();
+});
 
-  function clearDragState() {
-    draggedId = null;
+// DnD handlers
+function handleDragStart(e: DragEvent, id: string) {
+  draggedId = id;
+  if (e.dataTransfer) {
+    e.dataTransfer.setData("text/plain", id);
+    e.dataTransfer.effectAllowed = "move";
+  }
+}
+
+function handleDragOver(e: DragEvent, id: string) {
+  e.preventDefault();
+  if (!draggedId || draggedId === id) {
     dropTarget = null;
+    return;
   }
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  const midX = rect.left + rect.width / 2;
+  const side = e.clientX < midX ? "left" : "right";
+  dropTarget = { id, side };
+}
 
-  function updateScrollState() {
-    const el = scrollEl;
-    if (!el) return;
-    canScrollLeft = el.scrollLeft > 0;
-    canScrollRight = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
-  }
-
-  // Set up scroll listeners and resize observer
-  $effect(() => {
-    const el = scrollEl;
-    if (!el) return;
-    updateScrollState();
-    el.addEventListener("scroll", updateScrollState, { passive: true });
-    const observer = new ResizeObserver(updateScrollState);
-    observer.observe(el);
-    return () => {
-      el.removeEventListener("scroll", updateScrollState);
-      observer.disconnect();
-    };
-  });
-
-  // Re-check overflow when tabs change
-  $effect(() => {
-    // Track tabs.length
-    void tabs.length;
-    updateScrollState();
-  });
-
-  // Auto-scroll active tab into view
-  $effect(() => {
-    if (!activeTabId || !scrollEl) return;
-    const el = scrollEl.querySelector(`[data-testid="tab-${activeTabId}"]`);
-    if (el) {
-      (el as HTMLElement).scrollIntoView({
-        inline: "nearest",
-        block: "nearest",
-        behavior: scrollBehavior,
-      });
-    }
-  });
-
-  // Clear drag state when tab list changes mid-drag
-  $effect(() => {
-    void tabs.length;
-    clearDragState();
-  });
-
-  // DnD handlers
-  function handleDragStart(e: DragEvent, id: string) {
-    draggedId = id;
-    if (e.dataTransfer) {
-      e.dataTransfer.setData("text/plain", id);
-      e.dataTransfer.effectAllowed = "move";
-    }
-  }
-
-  function handleDragOver(e: DragEvent, id: string) {
-    e.preventDefault();
-    if (!draggedId || draggedId === id) {
-      dropTarget = null;
-      return;
-    }
+function handleDrop(e: DragEvent, targetId: string) {
+  e.preventDefault();
+  const fromId = e.dataTransfer?.getData("text/plain");
+  if (fromId && fromId !== targetId && reorder) {
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
     const midX = rect.left + rect.width / 2;
     const side = e.clientX < midX ? "left" : "right";
-    dropTarget = { id, side };
+    reorder(fromId, targetId, side);
   }
+  clearDragState();
+}
 
-  function handleDrop(e: DragEvent, targetId: string) {
-    e.preventDefault();
-    const fromId = e.dataTransfer?.getData("text/plain");
-    if (fromId && fromId !== targetId && reorder) {
-      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      const midX = rect.left + rect.width / 2;
-      const side = e.clientX < midX ? "left" : "right";
-      reorder(fromId, targetId, side);
-    }
-    clearDragState();
+function handleDragEnd() {
+  clearDragState();
+}
+
+function handleDragLeave() {
+  dropTarget = null;
+}
+
+// Keyboard reordering (Alt+Arrow swaps with neighbor)
+function handleKeyDown(e: KeyboardEvent, id: string) {
+  if (!e.altKey || !reorder) return;
+  if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+  e.preventDefault();
+
+  const idx = tabs.findIndex((t) => t.id === id);
+  if (idx === -1) return;
+
+  if (e.key === "ArrowLeft" && idx > 0) {
+    reorder(id, tabs[idx - 1].id);
+  } else if (e.key === "ArrowRight" && idx < tabs.length - 1) {
+    reorder(tabs[idx + 1].id, id);
   }
+}
 
-  function handleDragEnd() {
-    clearDragState();
-  }
+function scrollLeft() {
+  scrollEl?.scrollBy({ left: -150, behavior: scrollBehavior });
+}
 
-  function handleDragLeave() {
-    dropTarget = null;
-  }
+function scrollRight() {
+  scrollEl?.scrollBy({ left: 150, behavior: scrollBehavior });
+}
 
-  // Keyboard reordering (Alt+Arrow swaps with neighbor)
-  function handleKeyDown(e: KeyboardEvent, id: string) {
-    if (!e.altKey || !reorder) return;
-    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
-    e.preventDefault();
-
-    const idx = tabs.findIndex((t) => t.id === id);
-    if (idx === -1) return;
-
-    if (e.key === "ArrowLeft" && idx > 0) {
-      reorder(id, tabs[idx - 1].id);
-    } else if (e.key === "ArrowRight" && idx < tabs.length - 1) {
-      reorder(tabs[idx + 1].id, id);
-    }
-  }
-
-  function scrollLeft() {
-    scrollEl?.scrollBy({ left: -150, behavior: scrollBehavior });
-  }
-
-  function scrollRight() {
-    scrollEl?.scrollBy({ left: 150, behavior: scrollBehavior });
-  }
-
-  const singleTab = $derived(tabs.length <= 1);
+const singleTab = $derived(tabs.length <= 1);
 </script>
 
 <div

--- a/src/client/tabs/TabItem.svelte
+++ b/src/client/tabs/TabItem.svelte
@@ -1,126 +1,126 @@
 <script lang="ts">
-  import { Y_MAP_DOCUMENT_META, Y_MAP_SAVED_AT_VERSION } from "../../shared/constants.js";
-  import type { OpenTab } from "../types.js";
+import { Y_MAP_DOCUMENT_META, Y_MAP_SAVED_AT_VERSION } from "../../shared/constants.js";
+import type { OpenTab } from "../types.js";
 
-  interface Props {
-    tab: OpenTab;
-    isActive: boolean;
-    onswitch: (id: string) => void;
-    onclose: (id: string) => void;
-    draggable: boolean;
-    ondragstart: (e: DragEvent, id: string) => void;
-    ondragover: (e: DragEvent, id: string) => void;
-    ondrop: (e: DragEvent, id: string) => void;
-    ondragend: () => void;
-    ondragleave: () => void;
-    dropIndicator: "left" | "right" | null;
-    onkeydown: (e: KeyboardEvent, id: string) => void;
+interface Props {
+  tab: OpenTab;
+  isActive: boolean;
+  onswitch: (id: string) => void;
+  onclose: (id: string) => void;
+  draggable: boolean;
+  ondragstart: (e: DragEvent, id: string) => void;
+  ondragover: (e: DragEvent, id: string) => void;
+  ondrop: (e: DragEvent, id: string) => void;
+  ondragend: () => void;
+  ondragleave: () => void;
+  dropIndicator: "left" | "right" | null;
+  onkeydown: (e: KeyboardEvent, id: string) => void;
+}
+
+const {
+  tab,
+  isActive,
+  onswitch,
+  onclose,
+  draggable,
+  ondragstart,
+  ondragover,
+  ondrop,
+  ondragend,
+  ondragleave,
+  dropIndicator,
+  onkeydown,
+}: Props = $props();
+
+const FORMAT_ICONS: Record<string, string> = {
+  md: "M",
+  txt: "T",
+  html: "H",
+  docx: "W",
+};
+
+// ---- useTabDirty logic inlined (hooks can't be imported into Svelte) ----
+let dirty = $state(false);
+// These don't drive UI; plain let keeps them non-reactive
+let editCount = 0;
+let baseline: number | null = null;
+
+$effect(() => {
+  // Track tab.ydoc and tab.readOnly
+  const { ydoc, readOnly } = tab;
+
+  if (readOnly) {
+    dirty = false;
+    return;
   }
 
-  const {
-    tab,
-    isActive,
-    onswitch,
-    onclose,
-    draggable,
-    ondragstart,
-    ondragover,
-    ondrop,
-    ondragend,
-    ondragleave,
-    dropIndicator,
-    onkeydown,
-  }: Props = $props();
+  const fragment = ydoc.getXmlFragment("default");
+  const meta = ydoc.getMap(Y_MAP_DOCUMENT_META);
 
-  const FORMAT_ICONS: Record<string, string> = {
-    md: "M",
-    txt: "T",
-    html: "H",
-    docx: "W",
+  let armed = false;
+  const armTimer = setTimeout(() => {
+    armed = true;
+    baseline = (meta.get(Y_MAP_SAVED_AT_VERSION) as number) ?? 0;
+    editCount = 0;
+    dirty = false;
+  }, 500);
+
+  const onFragmentChange = () => {
+    if (!armed) return;
+    editCount++;
+    dirty = true;
   };
+  fragment.observeDeep(onFragmentChange);
 
-  // ---- useTabDirty logic inlined (hooks can't be imported into Svelte) ----
-  let dirty = $state(false);
-  // These don't drive UI; plain let keeps them non-reactive
-  let editCount = 0;
-  let baseline: number | null = null;
-
-  $effect(() => {
-    // Track tab.ydoc and tab.readOnly
-    const { ydoc, readOnly } = tab;
-
-    if (readOnly) {
-      dirty = false;
-      return;
-    }
-
-    const fragment = ydoc.getXmlFragment("default");
-    const meta = ydoc.getMap(Y_MAP_DOCUMENT_META);
-
-    let armed = false;
-    const armTimer = setTimeout(() => {
-      armed = true;
-      baseline = (meta.get(Y_MAP_SAVED_AT_VERSION) as number) ?? 0;
+  const onMetaChange = () => {
+    if (!armed) return;
+    const saved = meta.get(Y_MAP_SAVED_AT_VERSION) as number | undefined;
+    if (saved !== undefined && saved !== baseline) {
+      baseline = saved;
       editCount = 0;
       dirty = false;
-    }, 500);
+    }
+  };
+  meta.observe(onMetaChange);
 
-    const onFragmentChange = () => {
-      if (!armed) return;
-      editCount++;
-      dirty = true;
-    };
-    fragment.observeDeep(onFragmentChange);
+  return () => {
+    clearTimeout(armTimer);
+    fragment.unobserveDeep(onFragmentChange);
+    meta.unobserve(onMetaChange);
+  };
+});
 
-    const onMetaChange = () => {
-      if (!armed) return;
-      const saved = meta.get(Y_MAP_SAVED_AT_VERSION) as number | undefined;
-      if (saved !== undefined && saved !== baseline) {
-        baseline = saved;
-        editCount = 0;
-        dirty = false;
-      }
-    };
-    meta.observe(onMetaChange);
+// Derived styles
+const tabStyle = $derived(
+  [
+    "display: flex",
+    "align-items: center",
+    "gap: 6px",
+    "padding: 4px 12px",
+    "font-size: 13px",
+    "cursor: pointer",
+    `background: ${isActive ? "var(--tandem-surface)" : "transparent"}`,
+    `color: ${isActive ? "var(--tandem-fg)" : "var(--tandem-fg-muted)"}`,
+    `border-top: ${isActive ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
+    `border-bottom: ${isActive ? "1px solid var(--tandem-surface)" : "1px solid transparent"}`,
+    `border-left: ${dropIndicator === "left" ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
+    `border-right: ${dropIndicator === "right" ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
+    "margin-bottom: -1px",
+    "user-select: none",
+    "white-space: nowrap",
+    "transition: background 0.15s, color 0.15s",
+    "flex-shrink: 0",
+  ].join("; "),
+);
 
-    return () => {
-      clearTimeout(armTimer);
-      fragment.unobserveDeep(onFragmentChange);
-      meta.unobserve(onMetaChange);
-    };
-  });
+let closeBtn: HTMLButtonElement | undefined = $state();
 
-  // Derived styles
-  const tabStyle = $derived(
-    [
-      "display: flex",
-      "align-items: center",
-      "gap: 6px",
-      "padding: 4px 12px",
-      "font-size: 13px",
-      "cursor: pointer",
-      `background: ${isActive ? "var(--tandem-surface)" : "transparent"}`,
-      `color: ${isActive ? "var(--tandem-fg)" : "var(--tandem-fg-muted)"}`,
-      `border-top: ${isActive ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
-      `border-bottom: ${isActive ? "1px solid var(--tandem-surface)" : "1px solid transparent"}`,
-      `border-left: ${dropIndicator === "left" ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
-      `border-right: ${dropIndicator === "right" ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
-      "margin-bottom: -1px",
-      "user-select: none",
-      "white-space: nowrap",
-      "transition: background 0.15s, color 0.15s",
-      "flex-shrink: 0",
-    ].join("; "),
-  );
-
-  let closeBtn: HTMLButtonElement | undefined = $state();
-
-  function handleMouseEnterClose() {
-    if (closeBtn) closeBtn.style.color = "var(--tandem-error)";
-  }
-  function handleMouseLeaveClose() {
-    if (closeBtn) closeBtn.style.color = "var(--tandem-fg-subtle)";
-  }
+function handleMouseEnterClose() {
+  if (closeBtn) closeBtn.style.color = "var(--tandem-error)";
+}
+function handleMouseLeaveClose() {
+  if (closeBtn) closeBtn.style.color = "var(--tandem-fg-subtle)";
+}
 </script>
 
 <!-- svelte-ignore a11y_interactive_supports_focus -->

--- a/src/client/tabs/TabItem.svelte
+++ b/src/client/tabs/TabItem.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+  import { Y_MAP_DOCUMENT_META, Y_MAP_SAVED_AT_VERSION } from "../../shared/constants.js";
+  import type { OpenTab } from "../types.js";
+
+  interface Props {
+    tab: OpenTab;
+    isActive: boolean;
+    onswitch: (id: string) => void;
+    onclose: (id: string) => void;
+    draggable: boolean;
+    ondragstart: (e: DragEvent, id: string) => void;
+    ondragover: (e: DragEvent, id: string) => void;
+    ondrop: (e: DragEvent, id: string) => void;
+    ondragend: () => void;
+    ondragleave: () => void;
+    dropIndicator: "left" | "right" | null;
+    onkeydown: (e: KeyboardEvent, id: string) => void;
+  }
+
+  const {
+    tab,
+    isActive,
+    onswitch,
+    onclose,
+    draggable,
+    ondragstart,
+    ondragover,
+    ondrop,
+    ondragend,
+    ondragleave,
+    dropIndicator,
+    onkeydown,
+  }: Props = $props();
+
+  const FORMAT_ICONS: Record<string, string> = {
+    md: "M",
+    txt: "T",
+    html: "H",
+    docx: "W",
+  };
+
+  // ---- useTabDirty logic inlined (hooks can't be imported into Svelte) ----
+  let dirty = $state(false);
+  // These don't drive UI; plain let keeps them non-reactive
+  let editCount = 0;
+  let baseline: number | null = null;
+
+  $effect(() => {
+    // Track tab.ydoc and tab.readOnly
+    const { ydoc, readOnly } = tab;
+
+    if (readOnly) {
+      dirty = false;
+      return;
+    }
+
+    const fragment = ydoc.getXmlFragment("default");
+    const meta = ydoc.getMap(Y_MAP_DOCUMENT_META);
+
+    let armed = false;
+    const armTimer = setTimeout(() => {
+      armed = true;
+      baseline = (meta.get(Y_MAP_SAVED_AT_VERSION) as number) ?? 0;
+      editCount = 0;
+      dirty = false;
+    }, 500);
+
+    const onFragmentChange = () => {
+      if (!armed) return;
+      editCount++;
+      dirty = true;
+    };
+    fragment.observeDeep(onFragmentChange);
+
+    const onMetaChange = () => {
+      if (!armed) return;
+      const saved = meta.get(Y_MAP_SAVED_AT_VERSION) as number | undefined;
+      if (saved !== undefined && saved !== baseline) {
+        baseline = saved;
+        editCount = 0;
+        dirty = false;
+      }
+    };
+    meta.observe(onMetaChange);
+
+    return () => {
+      clearTimeout(armTimer);
+      fragment.unobserveDeep(onFragmentChange);
+      meta.unobserve(onMetaChange);
+    };
+  });
+
+  // Derived styles
+  const tabStyle = $derived(
+    [
+      "display: flex",
+      "align-items: center",
+      "gap: 6px",
+      "padding: 4px 12px",
+      "font-size: 13px",
+      "cursor: pointer",
+      `background: ${isActive ? "var(--tandem-surface)" : "transparent"}`,
+      `color: ${isActive ? "var(--tandem-fg)" : "var(--tandem-fg-muted)"}`,
+      `border-top: ${isActive ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
+      `border-bottom: ${isActive ? "1px solid var(--tandem-surface)" : "1px solid transparent"}`,
+      `border-left: ${dropIndicator === "left" ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
+      `border-right: ${dropIndicator === "right" ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
+      "margin-bottom: -1px",
+      "user-select: none",
+      "white-space: nowrap",
+      "transition: background 0.15s, color 0.15s",
+      "flex-shrink: 0",
+    ].join("; "),
+  );
+
+  let closeBtn: HTMLButtonElement | undefined = $state();
+
+  function handleMouseEnterClose() {
+    if (closeBtn) closeBtn.style.color = "var(--tandem-error)";
+  }
+  function handleMouseLeaveClose() {
+    if (closeBtn) closeBtn.style.color = "var(--tandem-fg-subtle)";
+  }
+</script>
+
+<!-- svelte-ignore a11y_interactive_supports_focus -->
+<div
+  data-testid={`tab-${tab.id}`}
+  data-active={isActive}
+  role="tab"
+  tabindex={0}
+  {draggable}
+  style={tabStyle}
+  onclick={() => onswitch(tab.id)}
+  ondragstart={(e) => ondragstart(e, tab.id)}
+  ondragover={(e) => ondragover(e, tab.id)}
+  ondrop={(e) => ondrop(e, tab.id)}
+  ondragend={ondragend}
+  ondragleave={ondragleave}
+  onkeydown={(e) => onkeydown(e, tab.id)}
+>
+  {#if dirty}
+    <span
+      data-testid={`unsaved-indicator-${tab.id}`}
+      style="color: var(--tandem-warning); font-size: 10px;"
+    >
+      ●
+    </span>
+  {/if}
+
+  <span
+    style={`font-size: 10px; font-weight: 700; color: ${isActive ? "var(--tandem-accent)" : "var(--tandem-fg-subtle)"}; width: 14px; text-align: center;`}
+  >
+    {FORMAT_ICONS[tab.format] ?? "?"}
+  </span>
+
+  <span
+    data-testid={`tab-name-${tab.id}`}
+    title={tab.filePath}
+    style={`font-weight: ${isActive ? 500 : 400}; max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;`}
+  >
+    {tab.fileName}
+  </span>
+
+  {#if tab.readOnly}
+    <span
+      style="font-size: 9px; color: var(--tandem-warning-fg-strong); background: var(--tandem-warning-bg); padding: 0 3px; border-radius: 2px;"
+    >
+      RO
+    </span>
+  {/if}
+
+  <button
+    bind:this={closeBtn}
+    onclick={(e) => {
+      e.stopPropagation();
+      onclose(tab.id);
+    }}
+    ondragover={(e) => {
+      e.stopPropagation();
+      e.preventDefault();
+    }}
+    ondrop={(e) => {
+      e.stopPropagation();
+      e.preventDefault();
+    }}
+    onmouseenter={handleMouseEnterClose}
+    onmouseleave={handleMouseLeaveClose}
+    style="background: none; border: none; cursor: pointer; font-size: 14px; line-height: 1; color: var(--tandem-fg-subtle); padding: 0 2px; border-radius: 2px;"
+    title="Close document"
+  >
+    ×
+  </button>
+</div>


### PR DESCRIPTION
## Summary

- Ports `DocumentTabs.tsx` → `DocumentTabs.svelte` + `TabItem.svelte` (Svelte 5 runes)
- Ports `FileOpenDialog.tsx` → `FileOpenDialog.svelte`
- Closes #478: renames "Upload" tab → "Open" and makes it the default mode (per issue requirements)

## Key implementation notes

- `TabItem.svelte` is required because `$effect` cannot run inside `{#each}` blocks — each tab needs its own reactive dirty-tracking state. The `useTabDirty` React hook logic is inlined here.
- `closingIds` uses a plain `let Set` (not `$state`) — it's a dedup guard, not UI state. `$state` would trigger unnecessary re-renders on every close event.
- Scrollbar hiding uses `:global(.tab-scroll-hide)` in the `<style>` block since Svelte scopes styles by default.
- Both components registered in `svelte-harness/registry.ts` for manual dev preview via `?component=DocumentTabs` / `?component=FileOpenDialog`.

## #478 changes

| Before | After |
|--------|-------|
| "Upload" tab label | "Open" tab label |
| Default mode: File Path | Default mode: Open (OS file picker) |
| "Uploading..." loading text | "Opening..." loading text |

## Verification

- `npm run typecheck` — clean
- `npm test -- --run` — all pass
- `npx svelte-check` — 0 errors, 0 warnings
- `npm run check:tokens` — clean

Closes #469
Closes #478