### PR TITLE
feat(hooks): port 21 React hooks to Svelte 5 runes (#467)

### DIFF
--- a/src/client/hooks/useAppInfo.svelte.ts
+++ b/src/client/hooks/useAppInfo.svelte.ts
@@ -1,0 +1,67 @@
+import type { AppInfoData } from "../types.js";
+import { _resetAppInfoCache, fetchAppInfo } from "./useAppInfo.js";
+
+// Re-export for tests
+export { _resetAppInfoCache };
+
+export interface AppInfoState {
+  readonly info: AppInfoData | null;
+  readonly loading: boolean;
+}
+
+/**
+ * Svelte 5 port of `useAppInfo`.
+ *
+ * Fetches app metadata from GET /api/info each time `open` transitions to
+ * true. The result is cached at module scope (shared with the React version)
+ * so repeated popover opens after the first are instant.
+ *
+ * Accepts a getter for `open` so callers with `$state` values propagate
+ * reactively.
+ */
+export function createAppInfo(getOpen: () => boolean): AppInfoState {
+  // Import module-level cache directly from the React version
+  // to share the same cache across both versions.
+  let info = $state<AppInfoData | null>(null);
+  let loading = $state(false);
+
+  $effect(() => {
+    if (!getOpen()) return;
+
+    let cancelled = false;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+
+    loading = true;
+
+    fetchAppInfo(controller.signal)
+      .then((data) => {
+        if (cancelled) return;
+        info = data;
+      })
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.name !== "AbortError") {
+          console.warn("[useAppInfo] failed to load /api/info:", err);
+        }
+      })
+      .finally(() => {
+        clearTimeout(timeout);
+        if (!cancelled) loading = false;
+      });
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeout);
+      controller.abort();
+    };
+  });
+
+  return {
+    get info() {
+      return info;
+    },
+    get loading() {
+      return loading;
+    },
+  };
+}

--- a/src/client/hooks/useConnectionBanner.svelte.ts
+++ b/src/client/hooks/useConnectionBanner.svelte.ts
@@ -1,0 +1,51 @@
+import { PROLONGED_DISCONNECT_MS } from "../../shared/constants.js";
+
+export interface ConnectionBannerState {
+  readonly showBanner: boolean;
+  dismiss: () => void;
+}
+
+/**
+ * Svelte 5 port of `useConnectionBanner`.
+ *
+ * Tracks prolonged-disconnect state and surfaces a dismissible banner signal.
+ * Shows after PROLONGED_DISCONNECT_MS of continuous disconnection.
+ * Resets (hidden, undismissed) when the connection recovers.
+ *
+ * Accepts a getter for `disconnectedSince` so callers with `$state` values
+ * propagate reactively.
+ */
+export function createConnectionBanner(
+  getDisconnectedSince: () => number | null,
+): ConnectionBannerState {
+  let showDisconnectBanner = $state(false);
+  let disconnectBannerDismissed = $state(false);
+
+  $effect(() => {
+    const disconnectedSince = getDisconnectedSince();
+    if (disconnectedSince == null) {
+      showDisconnectBanner = false;
+      disconnectBannerDismissed = false;
+      return;
+    }
+    const elapsed = Date.now() - disconnectedSince;
+    const remaining = PROLONGED_DISCONNECT_MS - elapsed;
+    if (remaining <= 0) {
+      showDisconnectBanner = true;
+      return;
+    }
+    const timer = setTimeout(() => {
+      showDisconnectBanner = true;
+    }, remaining);
+    return () => clearTimeout(timer);
+  });
+
+  return {
+    get showBanner() {
+      return showDisconnectBanner && !disconnectBannerDismissed;
+    },
+    dismiss() {
+      disconnectBannerDismissed = true;
+    },
+  };
+}

--- a/src/client/hooks/useCoworkStatus.svelte.ts
+++ b/src/client/hooks/useCoworkStatus.svelte.ts
@@ -1,0 +1,126 @@
+import { onDestroy } from "svelte";
+import { COWORK_STATUS_POLL_MS } from "../../shared/constants.js";
+import {
+  coworkGetStatus,
+  type InvokeFn,
+  loadInvoke,
+  TAURI_NOT_AVAILABLE,
+} from "../cowork/cowork-invoke.js";
+import type { CoworkStatus } from "../types.js";
+
+export interface CoworkStatusState {
+  readonly status: CoworkStatus | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Svelte 5 port of `useCoworkStatus`.
+ *
+ * Polls `cowork_get_status` every 30s while `active` is true. Stops polling
+ * when `active` flips false or on destroy. Runs as a no-op in non-Tauri
+ * environments (e.g. Vite dev).
+ *
+ * Accepts a getter for `active` so callers with `$state` values propagate
+ * reactively.
+ */
+export function createCoworkStatus(getActive: () => boolean): CoworkStatusState {
+  let status = $state<CoworkStatus | null>(null);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+
+  let invokeRef: InvokeFn | null = null;
+  let tauriMissing = false;
+  let mounted = true;
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  onDestroy(() => {
+    mounted = false;
+    if (intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  });
+
+  const refetch = async (): Promise<void> => {
+    if (tauriMissing) {
+      if (mounted) loading = false;
+      return;
+    }
+    const invoke = invokeRef;
+    if (!invoke) return;
+    try {
+      const next = await coworkGetStatus(invoke);
+      if (!mounted) return;
+      status = next;
+      error = null;
+    } catch (err) {
+      if (!mounted) return;
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg === TAURI_NOT_AVAILABLE) {
+        tauriMissing = true;
+        if (intervalId !== null) {
+          clearInterval(intervalId);
+          intervalId = null;
+        }
+        loading = false;
+        return;
+      }
+      error = msg;
+    } finally {
+      if (mounted) loading = false;
+    }
+  };
+
+  $effect(() => {
+    const active = getActive();
+    if (!active) {
+      loading = false;
+      return;
+    }
+
+    let cancelled = false;
+
+    loadInvoke()
+      .then((invoke) => {
+        if (cancelled) return;
+        invokeRef = invoke;
+        loading = true;
+        return refetch();
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        error = msg;
+        loading = false;
+      });
+
+    intervalId = setInterval(() => {
+      if (cancelled) return;
+      if (tauriMissing) return;
+      void refetch();
+    }, COWORK_STATUS_POLL_MS);
+
+    return () => {
+      cancelled = true;
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
+  });
+
+  return {
+    get status() {
+      return status;
+    },
+    get loading() {
+      return loading;
+    },
+    get error() {
+      return error;
+    },
+    refetch,
+  };
+}

--- a/src/client/hooks/useDragResize.svelte.ts
+++ b/src/client/hooks/useDragResize.svelte.ts
@@ -1,0 +1,95 @@
+import { PANEL_WIDTH_KEYS, type PanelSide } from "../../shared/constants.js";
+import {
+  getRightWidth,
+  PANEL_DEFAULT_WIDTH,
+  PANEL_MAX_WIDTH,
+  PANEL_MIN_WIDTH,
+  type PanelLayout,
+} from "../panel-layout.js";
+
+export interface DragResizeState {
+  handleResizeStart: (e: MouseEvent, side: PanelSide) => void;
+}
+
+/**
+ * Svelte 5 port of `useDragResize`.
+ *
+ * Encapsulates drag-to-resize logic for side panels. Attaches and cleans up
+ * mousemove/mouseup listeners atomically. Accepts getters for reactive inputs.
+ */
+export function createDragResize(
+  getPanelLayout: () => PanelLayout,
+  setPanelLayout: (updater: (prev: PanelLayout) => PanelLayout) => void,
+): DragResizeState {
+  let dragListeners: { move: (e: MouseEvent) => void; up: () => void } | null = null;
+
+  // Clean up drag listeners if the component is destroyed mid-drag
+  $effect(() => {
+    return () => {
+      if (dragListeners) {
+        document.removeEventListener("mousemove", dragListeners.move);
+        document.removeEventListener("mouseup", dragListeners.up);
+        document.body.style.userSelect = "";
+        document.body.style.cursor = "";
+        dragListeners = null;
+      }
+    };
+  });
+
+  const handleResizeStart = (e: MouseEvent, side: PanelSide) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const current = getPanelLayout();
+    let startWidth: number;
+    if (side === "left") {
+      startWidth = "left" in current ? current.left : PANEL_DEFAULT_WIDTH;
+    } else {
+      startWidth = getRightWidth(current);
+    }
+    const storageKey = PANEL_WIDTH_KEYS[side];
+    let latestWidth = startWidth;
+
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const delta = ev.clientX - startX;
+      const next = side === "left" ? startWidth + delta : startWidth - delta;
+      latestWidth = Math.max(PANEL_MIN_WIDTH, Math.min(PANEL_MAX_WIDTH, next));
+      setPanelLayout((prev) => {
+        if (side === "right") {
+          if (prev.kind === "three-panel") return { ...prev, right: latestWidth };
+          if (prev.kind === "tabbed") return { kind: "tabbed", right: latestWidth };
+          return prev;
+        }
+        if (prev.kind === "three-panel") return { ...prev, left: latestWidth };
+        if (prev.kind === "tabbed-left") return { ...prev, left: latestWidth };
+        return prev;
+      });
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      dragListeners = null;
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      const layoutNow = getPanelLayout();
+      const shouldPersist =
+        (side === "left" && "left" in layoutNow) || (side === "right" && "right" in layoutNow);
+      if (shouldPersist) {
+        try {
+          localStorage.setItem(storageKey, String(latestWidth));
+        } catch (err) {
+          console.warn(`[tandem] failed to persist ${storageKey}:`, err);
+        }
+      }
+    };
+
+    dragListeners = { move: onMouseMove, up: onMouseUp };
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  };
+
+  return { handleResizeStart };
+}

--- a/src/client/hooks/useFileDrop.svelte.ts
+++ b/src/client/hooks/useFileDrop.svelte.ts
@@ -1,0 +1,68 @@
+import { API_BASE, readFileForUpload } from "../utils/fileUpload.js";
+
+export interface FileDropState {
+  readonly fileDragOver: boolean;
+  handleEditorDragOver: (e: DragEvent) => void;
+  handleEditorDragLeave: (e: DragEvent) => void;
+  handleEditorDrop: (e: DragEvent) => Promise<void>;
+}
+
+/**
+ * Svelte 5 port of `useFileDrop`.
+ *
+ * Manages file drag-and-drop on the editor area.
+ * Uploads dropped files to the Tandem server via POST /api/upload.
+ */
+export function createFileDrop(): FileDropState {
+  let fileDragOver = $state(false);
+
+  const handleEditorDragOver = (e: DragEvent) => {
+    if (e.dataTransfer?.types.includes("Files")) {
+      e.preventDefault();
+      fileDragOver = true;
+    }
+  };
+
+  const handleEditorDragLeave = (e: DragEvent) => {
+    if (
+      e.currentTarget === e.target ||
+      !(e.currentTarget as Node).contains(e.relatedTarget as Node)
+    ) {
+      fileDragOver = false;
+    }
+  };
+
+  const handleEditorDrop = async (e: DragEvent) => {
+    fileDragOver = false;
+    if (!e.dataTransfer?.files.length) return;
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    const content = await readFileForUpload(file);
+    try {
+      const response = await fetch(`${API_BASE}/upload`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fileName: file.name, content }),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({ message: "Upload failed" }));
+        console.error(
+          "[useFileDrop] Upload failed:",
+          response.status,
+          (body as Record<string, string>).message ?? (body as Record<string, string>).error,
+        );
+      }
+    } catch {
+      console.error("[useFileDrop] Server unreachable — file drop ignored");
+    }
+  };
+
+  return {
+    get fileDragOver() {
+      return fileDragOver;
+    },
+    handleEditorDragOver,
+    handleEditorDragLeave,
+    handleEditorDrop,
+  };
+}

--- a/src/client/hooks/useModeGate.svelte.ts
+++ b/src/client/hooks/useModeGate.svelte.ts
@@ -1,0 +1,42 @@
+import type { Annotation, TandemMode } from "../../shared/types.js";
+import { shouldShowInMode } from "./useModeGate.js";
+
+export interface ModeGateState {
+  readonly visibleAnnotations: Annotation[];
+  readonly heldCount: number;
+}
+
+/**
+ * Svelte 5 port of `useModeGate`.
+ *
+ * Accepts getter functions for reactive inputs so callers with `$state`
+ * values propagate changes without re-calling the factory.
+ */
+export function createModeGate(
+  getAnnotations: () => Annotation[],
+  getMode: () => TandemMode,
+): ModeGateState {
+  const derived = $derived.by(() => {
+    const annotations = getAnnotations();
+    const mode = getMode();
+    const visibleAnnotations: Annotation[] = [];
+    let heldCount = 0;
+    for (const a of annotations) {
+      if (shouldShowInMode(a, mode)) {
+        visibleAnnotations.push(a);
+      } else if (a.status === "pending") {
+        heldCount++;
+      }
+    }
+    return { visibleAnnotations, heldCount };
+  });
+
+  return {
+    get visibleAnnotations() {
+      return derived.visibleAnnotations;
+    },
+    get heldCount() {
+      return derived.heldCount;
+    },
+  };
+}

--- a/src/client/hooks/useNotifications.svelte.ts
+++ b/src/client/hooks/useNotifications.svelte.ts
@@ -1,0 +1,111 @@
+import { onDestroy } from "svelte";
+import { DEFAULT_MCP_PORT, MAX_VISIBLE_TOASTS, TOAST_DISMISS_MS } from "../../shared/constants.js";
+import type { TandemNotification } from "../../shared/types.js";
+
+export interface Toast extends TandemNotification {
+  count: number;
+}
+
+export interface NotificationsState {
+  readonly toasts: Toast[];
+  dismiss: (id: string) => void;
+}
+
+/**
+ * Svelte 5 port of `useNotifications`.
+ *
+ * Opens an SSE connection to /api/notify-stream and manages a reactive toast list.
+ * Auto-dismisses toasts after their configured duration, with dedup support.
+ */
+export function createNotifications(): NotificationsState {
+  let toasts = $state<Toast[]>([]);
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const clearTimer = (id: string) => {
+    const timer = timers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timers.delete(id);
+    }
+  };
+
+  const scheduleDismiss = (id: string, severity: TandemNotification["severity"]) => {
+    const existing = timers.get(id);
+    if (existing) clearTimeout(existing);
+    const ms = TOAST_DISMISS_MS[severity] ?? TOAST_DISMISS_MS.info;
+    const timer = setTimeout(() => {
+      toasts = toasts.filter((t) => t.id !== id);
+      timers.delete(id);
+    }, ms);
+    timers.set(id, timer);
+  };
+
+  const dismiss = (id: string) => {
+    toasts = toasts.filter((t) => t.id !== id);
+    clearTimer(id);
+  };
+
+  const url = `http://localhost:${DEFAULT_MCP_PORT}/api/notify-stream`;
+  const es = new EventSource(url);
+
+  es.onmessage = (event) => {
+    let notification: TandemNotification;
+    try {
+      notification = JSON.parse(event.data) as TandemNotification;
+    } catch {
+      console.warn("[useNotifications] Malformed SSE data:", event.data);
+      return;
+    }
+
+    // Dedup: if incoming has a dedupKey matching an existing toast, replace and increment count
+    if (notification.dedupKey) {
+      const existingIdx = toasts.findIndex((t) => t.dedupKey === notification.dedupKey);
+      if (existingIdx !== -1) {
+        const existing = toasts[existingIdx];
+        clearTimer(existing.id);
+        const updated: Toast = { ...notification, count: existing.count + 1 };
+        const next = [...toasts];
+        next[existingIdx] = updated;
+        toasts = next;
+        scheduleDismiss(updated.id, updated.severity);
+        return;
+      }
+    }
+
+    const newToast: Toast = { ...notification, count: 1 };
+    const next = [...toasts, newToast];
+
+    // Enforce max visible toasts — evict oldest
+    while (next.length > MAX_VISIBLE_TOASTS) {
+      const evicted = next.shift()!;
+      clearTimer(evicted.id);
+    }
+
+    toasts = next;
+    scheduleDismiss(newToast.id, newToast.severity);
+  };
+
+  es.onerror = () => {
+    if (es.readyState === EventSource.CLOSED) {
+      console.warn(
+        "[useNotifications] EventSource permanently closed. " +
+          "Notifications will not be delivered. Is the server running?",
+      );
+    }
+  };
+
+  onDestroy(() => {
+    es.close();
+    for (const timer of timers.values()) {
+      clearTimeout(timer);
+    }
+    timers.clear();
+  });
+
+  return {
+    get toasts() {
+      return toasts;
+    },
+    dismiss,
+  };
+}

--- a/src/client/hooks/useRadioGroup.svelte.ts
+++ b/src/client/hooks/useRadioGroup.svelte.ts
@@ -1,0 +1,66 @@
+export interface RadioGroupHandlers<T extends string> {
+  handleKeyDown: (e: KeyboardEvent) => void;
+  tabIndexFor: (v: T) => 0 | -1;
+}
+
+/**
+ * Svelte 5 port of `useRadioGroup`.
+ *
+ * Roving tabindex + arrow-key navigation for a `role="radiogroup"` per
+ * WAI-ARIA Authoring Practices. Accepts getter functions for reactive inputs.
+ *
+ * `currentTarget` must be the radiogroup container element, passed as `e.currentTarget`
+ * from the Svelte `on:keydown` handler (or equivalent).
+ */
+export function createRadioGroup<T extends string>(
+  getValue: () => T,
+  values: readonly T[],
+  setValue: (next: T) => void,
+  isDisabled?: (v: T) => boolean,
+): RadioGroupHandlers<T> {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    const { key } = e;
+    if (
+      key !== "ArrowLeft" &&
+      key !== "ArrowRight" &&
+      key !== "ArrowUp" &&
+      key !== "ArrowDown" &&
+      key !== "Home" &&
+      key !== "End"
+    ) {
+      return;
+    }
+    const enabled = isDisabled ? values.filter((v) => !isDisabled(v)) : values;
+    if (enabled.length === 0) return;
+    e.preventDefault();
+
+    const value = getValue();
+    const idx = enabled.indexOf(value);
+    const last = enabled.length - 1;
+    let next: number;
+    if (key === "Home") next = 0;
+    else if (key === "End") next = last;
+    else if (key === "ArrowLeft" || key === "ArrowUp") next = idx <= 0 ? last : idx - 1;
+    else next = idx >= last ? 0 : idx + 1;
+
+    const nextValue = enabled[next];
+    setValue(nextValue);
+
+    // Index-based focus — no data attributes needed, no selector injection.
+    const container = (e as KeyboardEvent & { currentTarget: HTMLElement }).currentTarget;
+    const radios = container?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+    const domIdx = values.indexOf(nextValue);
+    radios?.[domIdx]?.focus();
+  };
+
+  const tabIndexFor = (v: T): 0 | -1 => {
+    if (isDisabled?.(v)) return -1;
+    const value = getValue();
+    const enabled = isDisabled ? values.filter((x) => !isDisabled(x)) : values;
+    // If the current value happens to be disabled, fall back to the first enabled value.
+    const tabStop = isDisabled?.(value) ? enabled[0] : value;
+    return v === tabStop ? 0 : -1;
+  };
+
+  return { handleKeyDown, tabIndexFor };
+}

--- a/src/client/hooks/useReviewCompletion.svelte.ts
+++ b/src/client/hooks/useReviewCompletion.svelte.ts
@@ -1,0 +1,63 @@
+import type { Annotation } from "../../shared/types.js";
+
+export interface ReviewCompletionState {
+  readonly pendingCount: number;
+  readonly showReviewSummary: boolean;
+  readonly reviewSummaryData: { accepted: number; dismissed: number; total: number } | null;
+  dismissReviewSummary: () => void;
+}
+
+/**
+ * Svelte 5 port of `useReviewCompletion`.
+ *
+ * Detects when all pending annotations become resolved and surfaces
+ * the review summary overlay. Accepts a getter for `annotations` so
+ * callers with `$state` values propagate reactively.
+ */
+export function createReviewCompletion(getAnnotations: () => Annotation[]): ReviewCompletionState {
+  let showReviewSummary = $state(false);
+  let reviewSummaryData = $state<{ accepted: number; dismissed: number; total: number } | null>(
+    null,
+  );
+  let prevPending = 0;
+
+  const counts = $derived.by(() => {
+    const annotations = getAnnotations();
+    let pendingCount = 0;
+    let acceptedCount = 0;
+    let dismissedCount = 0;
+    for (const a of annotations) {
+      if (a.status === "pending") pendingCount++;
+      else if (a.status === "accepted") acceptedCount++;
+      else if (a.status === "dismissed") dismissedCount++;
+    }
+    return { pendingCount, acceptedCount, dismissedCount };
+  });
+
+  $effect(() => {
+    const { pendingCount, acceptedCount, dismissedCount } = counts;
+    const total = acceptedCount + dismissedCount;
+    if (prevPending > 0 && pendingCount === 0 && total > 0) {
+      reviewSummaryData = { accepted: acceptedCount, dismissed: dismissedCount, total };
+      showReviewSummary = true;
+    }
+    prevPending = pendingCount;
+  });
+
+  const dismissReviewSummary = () => {
+    showReviewSummary = false;
+  };
+
+  return {
+    get pendingCount() {
+      return counts.pendingCount;
+    },
+    get showReviewSummary() {
+      return showReviewSummary;
+    },
+    get reviewSummaryData() {
+      return reviewSummaryData;
+    },
+    dismissReviewSummary,
+  };
+}

--- a/src/client/hooks/useReviewKeyboard.svelte.ts
+++ b/src/client/hooks/useReviewKeyboard.svelte.ts
@@ -1,0 +1,69 @@
+import { onDestroy, onMount } from "svelte";
+
+/**
+ * Svelte 5 port of `useReviewKeyboard`.
+ *
+ * Keyboard event handler for annotation review mode. Handles Tab/Shift+Tab
+ * (navigate), Y (accept), N (dismiss), E (examine/exit to annotation),
+ * Escape (exit review or cancel bulk), and Ctrl+Shift+R (toggle review mode).
+ *
+ * Accepts getter functions for `reviewMode` and `callbacks` so changes
+ * propagate without re-registering the listener.
+ */
+export function createReviewKeyboard(
+  getReviewMode: () => boolean,
+  getCallbacks: () => {
+    onToggleReviewMode: () => void;
+    onExitReviewMode: () => void;
+    navigateReview: (direction: "next" | "prev") => void;
+    acceptCurrent: () => void;
+    dismissCurrent: () => void;
+    scrollToCurrentAndExit: () => void;
+    cancelBulkOrExit: () => void;
+    undoLast: () => void;
+  },
+): void {
+  let handler: ((e: KeyboardEvent) => void) | null = null;
+
+  onMount(() => {
+    handler = (e: KeyboardEvent) => {
+      const callbacks = getCallbacks();
+
+      if (e.ctrlKey && e.shiftKey && e.key === "R") {
+        e.preventDefault();
+        callbacks.onToggleReviewMode();
+        return;
+      }
+
+      if (!getReviewMode()) return;
+
+      if (e.key === "Tab" && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        callbacks.navigateReview(e.shiftKey ? "prev" : "next");
+      } else if (e.key === "y" || e.key === "Y") {
+        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+        e.preventDefault();
+        callbacks.acceptCurrent();
+      } else if (e.key === "n" || e.key === "N") {
+        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+        e.preventDefault();
+        callbacks.dismissCurrent();
+      } else if (e.key === "z" || e.key === "Z") {
+        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+        e.preventDefault();
+        callbacks.undoLast();
+      } else if (e.key === "e" || e.key === "E") {
+        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+        e.preventDefault();
+        callbacks.scrollToCurrentAndExit();
+      } else if (e.key === "Escape") {
+        callbacks.cancelBulkOrExit();
+      }
+    };
+    window.addEventListener("keydown", handler);
+  });
+
+  onDestroy(() => {
+    if (handler) window.removeEventListener("keydown", handler);
+  });
+}

--- a/src/client/hooks/useSaveShortcut.svelte.ts
+++ b/src/client/hooks/useSaveShortcut.svelte.ts
@@ -1,0 +1,69 @@
+import { onDestroy, onMount } from "svelte";
+import { DEFAULT_MCP_PORT } from "../../shared/constants.js";
+
+export interface SaveShortcutState {
+  readonly saving: boolean;
+  triggerSave: () => Promise<void>;
+}
+
+/**
+ * Svelte 5 port of `useSaveShortcut`.
+ *
+ * Returns `saving` reactive state and a `triggerSave` method.
+ * Accepts a getter for `activeDocId` so changes propagate without
+ * re-creating the factory.
+ */
+export function createSaveShortcut(getActiveDocId: () => string | null): SaveShortcutState {
+  let saving = $state(false);
+  let inflight = false;
+
+  const triggerSave = async () => {
+    const activeDocId = getActiveDocId();
+    if (!activeDocId || inflight) return;
+    inflight = true;
+    saving = true;
+
+    try {
+      const resp = await fetch(`http://localhost:${DEFAULT_MCP_PORT}/api/save`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ documentId: activeDocId }),
+      });
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({}));
+        console.warn(
+          "[Tandem] Save failed:",
+          (body as Record<string, string>).message ?? resp.statusText,
+        );
+      }
+    } catch (err) {
+      console.warn("[Tandem] Save request failed:", err);
+    } finally {
+      inflight = false;
+      saving = false;
+    }
+  };
+
+  let handler: ((e: KeyboardEvent) => void) | null = null;
+
+  onMount(() => {
+    handler = (e: KeyboardEvent) => {
+      if (e.key === "s" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        void triggerSave();
+      }
+    };
+    window.addEventListener("keydown", handler);
+  });
+
+  onDestroy(() => {
+    if (handler) window.removeEventListener("keydown", handler);
+  });
+
+  return {
+    get saving() {
+      return saving;
+    },
+    triggerSave,
+  };
+}

--- a/src/client/hooks/useSettingsShortcut.svelte.ts
+++ b/src/client/hooks/useSettingsShortcut.svelte.ts
@@ -1,0 +1,26 @@
+import { onDestroy, onMount } from "svelte";
+import { isSettingsShortcut } from "./useSettingsShortcut.js";
+
+/**
+ * Svelte 5 port of `useSettingsShortcut`.
+ *
+ * Registers a keydown listener on mount and removes it on destroy.
+ * `onOpen` is called each time the shortcut fires — pass a stable reference
+ * (or a wrapper) if the callback captures reactive state.
+ */
+export function createSettingsShortcut(getOnOpen: () => () => void): void {
+  let handler: ((e: KeyboardEvent) => void) | null = null;
+
+  onMount(() => {
+    handler = (e: KeyboardEvent) => {
+      if (!isSettingsShortcut(e)) return;
+      e.preventDefault();
+      getOnOpen()();
+    };
+    window.addEventListener("keydown", handler);
+  });
+
+  onDestroy(() => {
+    if (handler) window.removeEventListener("keydown", handler);
+  });
+}

--- a/src/client/hooks/useTabCycleKeyboard.svelte.ts
+++ b/src/client/hooks/useTabCycleKeyboard.svelte.ts
@@ -1,0 +1,34 @@
+import { onDestroy, onMount } from "svelte";
+import { cycleTab } from "./useTabCycleKeyboard.js";
+
+/**
+ * Svelte 5 port of `useTabCycleKeyboard`.
+ *
+ * Uses getter functions so the latest tabs / activeTabId are always read
+ * inside the keydown handler without re-registering the listener.
+ */
+export function createTabCycleKeyboard(
+  getTabs: () => Array<{ id: string }>,
+  getActiveTabId: () => string | null,
+  setActiveTabId: (id: string) => void,
+): void {
+  let handler: ((e: KeyboardEvent) => void) | null = null;
+
+  onMount(() => {
+    handler = (e: KeyboardEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return;
+      if (e.key !== "Tab") return;
+
+      const nextId = cycleTab(getTabs(), getActiveTabId(), e.shiftKey);
+      if (!nextId) return;
+
+      e.preventDefault();
+      setActiveTabId(nextId);
+    };
+    window.addEventListener("keydown", handler);
+  });
+
+  onDestroy(() => {
+    if (handler) window.removeEventListener("keydown", handler);
+  });
+}

--- a/src/client/hooks/useTabDirty.svelte.ts
+++ b/src/client/hooks/useTabDirty.svelte.ts
@@ -1,0 +1,71 @@
+import { Y_MAP_DOCUMENT_META, Y_MAP_SAVED_AT_VERSION } from "../../shared/constants.js";
+import type { OpenTab } from "../types.js";
+
+export interface TabDirtyState {
+  readonly dirty: boolean;
+}
+
+/**
+ * Svelte 5 port of `useTabDirty`.
+ *
+ * Returns true if the tab's document has unsaved content changes.
+ * Accepts a getter for `tab` so callers with `$state` values propagate
+ * reactively. Adds `keysChanged` filtering on the meta observer (missing
+ * from the original React version).
+ */
+export function createTabDirty(getTab: () => OpenTab): TabDirtyState {
+  let dirty = $state(false);
+
+  $effect(() => {
+    const tab = getTab();
+
+    if (tab.readOnly) {
+      dirty = false;
+      return;
+    }
+
+    const { ydoc } = tab;
+    const fragment = ydoc.getXmlFragment("default");
+    const meta = ydoc.getMap(Y_MAP_DOCUMENT_META);
+
+    let armed = false;
+    let baseline: number | null = null;
+
+    const armTimer = setTimeout(() => {
+      armed = true;
+      baseline = (meta.get(Y_MAP_SAVED_AT_VERSION) as number) ?? 0;
+      dirty = false;
+    }, 500);
+
+    const onFragmentChange = () => {
+      if (!armed) return;
+      dirty = true;
+    };
+    fragment.observeDeep(onFragmentChange);
+
+    const onMetaChange = (event: import("yjs").YMapEvent<unknown>) => {
+      // keysChanged guard: only act on savedAtVersion changes
+      if (!event.keysChanged.has(Y_MAP_SAVED_AT_VERSION)) return;
+      if (!armed) return;
+      const saved = meta.get(Y_MAP_SAVED_AT_VERSION) as number | undefined;
+      if (saved !== undefined && saved !== baseline) {
+        baseline = saved;
+        editCount = 0;
+        dirty = false;
+      }
+    };
+    meta.observe(onMetaChange);
+
+    return () => {
+      clearTimeout(armTimer);
+      fragment.unobserveDeep(onFragmentChange);
+      meta.unobserve(onMetaChange);
+    };
+  });
+
+  return {
+    get dirty() {
+      return dirty;
+    },
+  };
+}

--- a/src/client/hooks/useTabDirty.svelte.ts
+++ b/src/client/hooks/useTabDirty.svelte.ts
@@ -50,7 +50,6 @@ export function createTabDirty(getTab: () => OpenTab): TabDirtyState {
       const saved = meta.get(Y_MAP_SAVED_AT_VERSION) as number | undefined;
       if (saved !== undefined && saved !== baseline) {
         baseline = saved;
-        editCount = 0;
         dirty = false;
       }
     };

--- a/src/client/hooks/useTabOrder.svelte.ts
+++ b/src/client/hooks/useTabOrder.svelte.ts
@@ -1,0 +1,56 @@
+import type { OpenTab } from "../types.js";
+import { applyReorder, reconcileOrder } from "./useTabOrder.js";
+
+export interface TabOrderState {
+  readonly orderedTabs: OpenTab[];
+  reorder: (fromId: string, toId: string, side?: "left" | "right") => void;
+}
+
+/**
+ * Svelte 5 port of `useTabOrder`.
+ *
+ * Client-local tab ordering. Reconciles server-broadcast tabs with a local
+ * ordering preference — preserving user reorder operations while tracking
+ * additions and removals from the server.
+ *
+ * Accepts a getter for `tabs` so callers with `$state` values propagate reactively.
+ */
+export function createTabOrder(getTabs: () => OpenTab[]): TabOrderState {
+  let localOrder = $state<string[]>([]);
+
+  // Sync localOrder when tabs change (additions/removals from server).
+  $effect(() => {
+    const tabs = getTabs();
+    const tabIds = tabs.map((t) => t.id);
+    const reconciled = reconcileOrder(localOrder, tabIds);
+    // Only update if something actually changed to avoid infinite loops
+    if (
+      localOrder.length !== reconciled.length ||
+      localOrder.some((id, i) => id !== reconciled[i])
+    ) {
+      localOrder = reconciled;
+    }
+  });
+
+  const orderedTabs = $derived.by(() => {
+    const tabs = getTabs();
+    const tabMap = new Map(tabs.map((t) => [t.id, t]));
+    const tabIds = tabs.map((t) => t.id);
+    const merged = reconcileOrder(localOrder, tabIds);
+    return merged.map((id) => tabMap.get(id)).filter(Boolean) as OpenTab[];
+  });
+
+  const reorder = (fromId: string, toId: string, side: "left" | "right" = "left") => {
+    if (fromId === toId) return;
+    const tabs = getTabs();
+    const validIds = new Set(tabs.map((t) => t.id));
+    localOrder = applyReorder(localOrder, fromId, toId, validIds, side);
+  };
+
+  return {
+    get orderedTabs() {
+      return orderedTabs;
+    },
+    reorder,
+  };
+}

--- a/src/client/hooks/useTandemModeBroadcast.svelte.ts
+++ b/src/client/hooks/useTandemModeBroadcast.svelte.ts
@@ -1,0 +1,87 @@
+import * as Y from "yjs";
+import {
+  TANDEM_MODE_DEFAULT,
+  TANDEM_MODE_KEY,
+  Y_MAP_DWELL_MS,
+  Y_MAP_MODE,
+  Y_MAP_USER_AWARENESS,
+} from "../../shared/constants.js";
+import type { TandemMode } from "../../shared/types.js";
+import { TandemModeSchema } from "../../shared/types.js";
+
+export interface TandemModeBroadcastState {
+  readonly tandemMode: TandemMode;
+  setTandemMode: (mode: TandemMode) => void;
+}
+
+/**
+ * Svelte 5 port of `useTandemModeBroadcast`.
+ *
+ * Manages tandem mode state: persists to localStorage, and broadcasts both
+ * `Y_MAP_MODE` and `Y_MAP_DWELL_MS` to the CTRL_ROOM Y.Map so the server
+ * (and Claude) can see the current settings.
+ *
+ * Accepts getter functions for reactive inputs.
+ */
+export function createTandemModeBroadcast(
+  getBootstrapYdoc: () => Y.Doc | null,
+  getSelectionDwellMs: () => number,
+): TandemModeBroadcastState {
+  let tandemMode = $state<TandemMode>(
+    (() => {
+      try {
+        const saved = localStorage.getItem(TANDEM_MODE_KEY);
+        const parsed = TandemModeSchema.safeParse(saved);
+        return parsed.success ? parsed.data : TANDEM_MODE_DEFAULT;
+      } catch (err) {
+        console.warn(`[tandem] localStorage unavailable reading ${TANDEM_MODE_KEY}:`, err);
+        return TANDEM_MODE_DEFAULT;
+      }
+    })(),
+  );
+
+  // Persist tandem mode to localStorage
+  $effect(() => {
+    const mode = tandemMode;
+    try {
+      localStorage.setItem(TANDEM_MODE_KEY, mode);
+    } catch (err) {
+      console.warn(`[tandem] failed to persist ${TANDEM_MODE_KEY}:`, err);
+    }
+  });
+
+  // Broadcast tandem mode to CTRL_ROOM Y.Map
+  $effect(() => {
+    const bootstrapYdoc = getBootstrapYdoc();
+    const mode = tandemMode;
+    if (!bootstrapYdoc) return;
+    try {
+      const awareness = bootstrapYdoc.getMap(Y_MAP_USER_AWARENESS);
+      awareness.set(Y_MAP_MODE, mode);
+    } catch (err) {
+      console.warn("[tandem] failed to broadcast tandem mode to Y.Map:", err);
+    }
+  });
+
+  // Broadcast selection dwell time to CTRL_ROOM
+  $effect(() => {
+    const bootstrapYdoc = getBootstrapYdoc();
+    const dwellMs = getSelectionDwellMs();
+    if (!bootstrapYdoc) return;
+    try {
+      const awareness = bootstrapYdoc.getMap(Y_MAP_USER_AWARENESS);
+      awareness.set(Y_MAP_DWELL_MS, dwellMs);
+    } catch (err) {
+      console.warn("[tandem] failed to broadcast dwell ms to Y.Map:", err);
+    }
+  });
+
+  return {
+    get tandemMode() {
+      return tandemMode;
+    },
+    setTandemMode(mode: TandemMode) {
+      tandemMode = mode;
+    },
+  };
+}

--- a/src/client/hooks/useTandemSettings.svelte.ts
+++ b/src/client/hooks/useTandemSettings.svelte.ts
@@ -1,0 +1,50 @@
+import { AUTHORSHIP_TOGGLE_KEY, TANDEM_SETTINGS_KEY } from "../../shared/constants.js";
+import type { TandemSettings } from "./useTandemSettings.js";
+import { loadSettings, mergeAndClampSettings } from "./useTandemSettings.js";
+
+// Re-export types and helpers for consumers that import from this module
+export type {
+  Density,
+  EditorFont,
+  LayoutMode,
+  PanelOrder,
+  PrimaryTab,
+  TandemSettings,
+  TextSize,
+  ThemePreference,
+} from "./useTandemSettings.js";
+export { loadSettings, mergeAndClampSettings, TEXT_SIZE_PX } from "./useTandemSettings.js";
+
+export interface TandemSettingsState {
+  readonly settings: TandemSettings;
+  updateSettings: (partial: Partial<TandemSettings>) => void;
+}
+
+/**
+ * Svelte 5 port of `useTandemSettings`.
+ *
+ * Manages persistent application settings with localStorage backing.
+ * All numeric values are clamped on write via `mergeAndClampSettings`.
+ */
+export function createTandemSettings(): TandemSettingsState {
+  let settings = $state<TandemSettings>(loadSettings());
+
+  const updateSettings = (partial: Partial<TandemSettings>) => {
+    const next = mergeAndClampSettings(settings, partial);
+    try {
+      localStorage.setItem(TANDEM_SETTINGS_KEY, JSON.stringify(next));
+      // Mirror authorship toggle to dedicated key for ProseMirror plugin init
+      localStorage.setItem(AUTHORSHIP_TOGGLE_KEY, String(next.showAuthorship));
+    } catch {
+      // localStorage unavailable (incognito/storage-disabled)
+    }
+    settings = next;
+  };
+
+  return {
+    get settings() {
+      return settings;
+    },
+    updateSettings,
+  };
+}

--- a/src/client/hooks/useTheme.svelte.ts
+++ b/src/client/hooks/useTheme.svelte.ts
@@ -1,0 +1,22 @@
+import type { ThemePreference } from "./useTandemSettings.js";
+import { applyTheme } from "./useTheme.js";
+
+// Re-export helpers for consumers
+export type { ResolvedTheme } from "./useTheme.js";
+export { applyTheme, resolveTheme, systemTheme } from "./useTheme.js";
+
+/**
+ * Svelte 5 port of `useTheme`.
+ *
+ * Apply the resolved theme to <html data-theme="…"> and, when the user's
+ * preference is "system", re-apply on OS-level changes.
+ *
+ * Accepts a getter for `pref` so callers with `$state` values propagate
+ * reactively.
+ */
+export function createTheme(getPref: () => ThemePreference): void {
+  $effect(() => {
+    const pref = getPref();
+    return applyTheme(pref);
+  });
+}

--- a/src/client/hooks/useTutorial.svelte.ts
+++ b/src/client/hooks/useTutorial.svelte.ts
@@ -1,0 +1,157 @@
+import type { Editor } from "@tiptap/core";
+import { TUTORIAL_ANNOTATION_PREFIX, TUTORIAL_COMPLETED_KEY } from "../../shared/constants.js";
+import type { Annotation } from "../../shared/types.js";
+import {
+  isTauriRuntime,
+  readCoworkOnboardingSkipped,
+  shouldShowCoworkOnboarding,
+} from "../cowork/cowork-helpers.js";
+import type { CoworkStatus } from "../types.js";
+import { createCoworkStatus } from "./useCoworkStatus.svelte.js";
+
+export interface TutorialState {
+  readonly tutorialActive: boolean;
+  readonly currentStep: number;
+  readonly coworkStatus: CoworkStatus | null;
+  dismissTutorial: () => void;
+  nextStep: () => void;
+}
+
+function readCompleted(): boolean {
+  try {
+    return localStorage.getItem(TUTORIAL_COMPLETED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writeCompleted(): void {
+  try {
+    localStorage.setItem(TUTORIAL_COMPLETED_KEY, "true");
+  } catch {
+    // Storage unavailable — tutorial will reappear next session
+  }
+}
+
+/**
+ * Svelte 5 port of `useTutorial`.
+ *
+ * Drives the onboarding tutorial through 4–5 steps. The Cowork step (index 3)
+ * is only present when running under Tauri AND the Rust side reports an
+ * eligible Cowork install that isn't already enabled.
+ *
+ * Accepts getter functions for reactive inputs.
+ */
+export function createTutorial(
+  getAnnotations: () => Annotation[],
+  getEditor: () => Editor | null,
+  getActiveTabFileName: () => string | undefined,
+): TutorialState {
+  let completed = $state(readCompleted());
+  let currentStep = $state(0);
+  let stepAdvancedAt = 0;
+  const coworkSkipped = readCoworkOnboardingSkipped();
+
+  const isWelcome = $derived(getActiveTabFileName() === "welcome.md");
+  const tutorialActive = $derived(!completed && isWelcome);
+
+  const tauri = isTauriRuntime();
+
+  // Cowork step eligibility — drives the step count so step 2 advances to
+  // the right completion index (3 when no Cowork, 4 when Cowork is inserted).
+  const coworkState = createCoworkStatus(() => tauri && tutorialActive);
+
+  const coworkStatusSettled = $derived(
+    !tauri || coworkState.status !== null || coworkState.error !== null,
+  );
+  const includeCoworkStep = $derived(
+    tauri && shouldShowCoworkOnboarding(coworkState.status, coworkSkipped),
+  );
+  const completionStep = $derived(coworkStatusSettled ? (includeCoworkStep ? 4 : 3) : Infinity);
+
+  // Step 0: detect any tutorial annotation resolved, or auto-skip if none exist
+  $effect(() => {
+    if (!tutorialActive || currentStep !== 0) return;
+    const annotations = getAnnotations();
+    const tutorialAnns = annotations.filter((a) => a.id.startsWith(TUTORIAL_ANNOTATION_PREFIX));
+    if (tutorialAnns.length === 0) return;
+    const resolved = tutorialAnns.some((a) => a.status !== "pending");
+    if (resolved) {
+      stepAdvancedAt = Date.now();
+      currentStep = 1;
+    }
+  });
+
+  // Step 1: detect user-authored annotation
+  $effect(() => {
+    if (!tutorialActive || currentStep !== 1) return;
+    const annotations = getAnnotations();
+    const hasUserAnnotation = annotations.some((a) => a.author === "user");
+    if (hasUserAnnotation) {
+      stepAdvancedAt = Date.now();
+      currentStep = 2;
+    }
+  });
+
+  // Step 2: detect editor content change
+  $effect(() => {
+    if (!tutorialActive || currentStep !== 2 || !isFinite(completionStep)) return;
+    const editor = getEditor();
+    if (!editor) return;
+
+    const handler = () => {
+      if (Date.now() - stepAdvancedAt < 2000) return;
+      if (!editor.isFocused) return;
+      stepAdvancedAt = Date.now();
+      currentStep = 3;
+    };
+
+    editor.on("update", handler);
+    return () => {
+      editor.off("update", handler);
+    };
+  });
+
+  // Completion step: auto-complete after 3 seconds
+  $effect(() => {
+    if (!tutorialActive || !isFinite(completionStep) || currentStep !== completionStep) return;
+    const timer = setTimeout(() => {
+      writeCompleted();
+      completed = true;
+    }, 3000);
+    return () => clearTimeout(timer);
+  });
+
+  // Clamp current step when completionStep changes
+  $effect(() => {
+    if (isFinite(completionStep)) {
+      if (currentStep > completionStep) {
+        currentStep = completionStep;
+      }
+    }
+  });
+
+  const dismissTutorial = () => {
+    writeCompleted();
+    completed = true;
+  };
+
+  const nextStep = () => {
+    stepAdvancedAt = Date.now();
+    currentStep = Math.min(currentStep + 1, completionStep);
+  };
+
+  return {
+    get tutorialActive() {
+      return tutorialActive;
+    },
+    get currentStep() {
+      return currentStep;
+    },
+    get coworkStatus() {
+      return coworkState.status;
+    },
+    dismissTutorial,
+    nextStep,
+  };
+}

--- a/src/client/hooks/useUserName.svelte.ts
+++ b/src/client/hooks/useUserName.svelte.ts
@@ -1,0 +1,36 @@
+import { onDestroy } from "svelte";
+import { persistUserName, readStoredName, subscribeToUserName } from "./useUserName.js";
+
+export interface UserNameState {
+  readonly userName: string;
+  setUserName: (next: string) => void;
+}
+
+/**
+ * Svelte 5 port of `useUserName`.
+ *
+ * Shared display-name state. Persists to localStorage and broadcasts via a
+ * custom event so every in-tab subscriber updates together; the `storage`
+ * event covers cross-tab.
+ */
+export function createUserName(): UserNameState {
+  let userName = $state(readStoredName());
+
+  const unsubscribe = subscribeToUserName((name) => {
+    userName = name;
+  });
+
+  onDestroy(unsubscribe);
+
+  const setUserName = (next: string) => {
+    const trimmed = persistUserName(next);
+    userName = trimmed;
+  };
+
+  return {
+    get userName() {
+      return userName;
+    },
+    setUserName,
+  };
+}

--- a/src/client/hooks/useWebViewZoom.svelte.ts
+++ b/src/client/hooks/useWebViewZoom.svelte.ts
@@ -1,0 +1,97 @@
+import { onDestroy, onMount } from "svelte";
+import { ZOOM_DEFAULT, ZOOM_MAX, ZOOM_MIN, ZOOM_STORAGE_KEY } from "../../shared/constants.js";
+
+/**
+ * Svelte 5 port of `useWebViewZoom`.
+ *
+ * Persists and restores WebView zoom level in Tauri desktop builds.
+ * Complete no-op in non-Tauri environments.
+ */
+export function createWebViewZoom(): void {
+  let teardown: (() => void) | null = null;
+
+  onMount(() => {
+    let tornDown = false;
+    let cleanup: (() => void) | undefined;
+
+    import("@tauri-apps/api/webview")
+      .then(({ getCurrentWebview }) => {
+        if (tornDown) return;
+
+        const webview = getCurrentWebview();
+
+        let currentZoom = ZOOM_DEFAULT;
+        try {
+          const raw = localStorage.getItem(ZOOM_STORAGE_KEY);
+          if (raw !== null) {
+            const parsed = Number(raw);
+            if (Number.isFinite(parsed)) {
+              currentZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, parsed));
+            } else {
+              console.warn(`[tandem] ignoring invalid stored zoom: ${raw}`);
+            }
+          }
+        } catch {
+          // localStorage unavailable
+        }
+
+        if (currentZoom !== ZOOM_DEFAULT) {
+          webview.setZoom(currentZoom).catch((err: unknown) => {
+            console.warn("[tandem] failed to restore zoom level:", err);
+          });
+        }
+
+        function persist(zoom: number): void {
+          try {
+            localStorage.setItem(ZOOM_STORAGE_KEY, String(zoom));
+          } catch {
+            // localStorage unavailable
+          }
+        }
+
+        const handleReset = (e: KeyboardEvent) => {
+          const mod = e.metaKey || e.ctrlKey;
+          if (!mod || e.key !== "0") return;
+          e.preventDefault();
+          e.stopPropagation();
+          currentZoom = ZOOM_DEFAULT;
+          webview.setZoom(ZOOM_DEFAULT).catch((err: unknown) => {
+            console.warn("[tandem] failed to reset zoom:", err);
+          });
+          persist(ZOOM_DEFAULT);
+        };
+
+        const ZOOM_STEP = 0.1;
+        const handleZoomTrack = (e: KeyboardEvent) => {
+          const mod = e.metaKey || e.ctrlKey;
+          if (!mod) return;
+          const isZoomIn = e.key === "+" || e.key === "=";
+          const isZoomOut = e.key === "-" || e.key === "_";
+          if (!isZoomIn && !isZoomOut) return;
+          const next = isZoomIn ? currentZoom + ZOOM_STEP : currentZoom - ZOOM_STEP;
+          currentZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round(next * 100) / 100));
+          persist(currentZoom);
+        };
+
+        window.addEventListener("keydown", handleReset, { capture: true });
+        window.addEventListener("keydown", handleZoomTrack, { capture: true });
+
+        cleanup = () => {
+          window.removeEventListener("keydown", handleReset, { capture: true });
+          window.removeEventListener("keydown", handleZoomTrack, { capture: true });
+        };
+      })
+      .catch(() => {
+        // Not running in Tauri — hook is a no-op
+      });
+
+    teardown = () => {
+      tornDown = true;
+      cleanup?.();
+    };
+  });
+
+  onDestroy(() => {
+    teardown?.();
+  });
+}


### PR DESCRIPTION
## Summary

- Creates `create*` factory functions in sibling `.svelte.ts` files for all 21 hooks (skipping `useAnnotationReview` per PR #470)
- Follows the getter-function pattern established in `yjsSync.svelte.ts` (#466): reactive inputs are passed as `() => value` getters so `$derived` and `$effect` track changes without re-invoking the factory
- `useTabDirty` adds `keysChanged.has(Y_MAP_SAVED_AT_VERSION)` filtering on the meta observer that was missing from the React original
- No originals modified or deleted; all 21 `.ts` files remain untouched

## Patterns used

- `$state` for consumer-visible reactive values
- `$derived` / `$derived.by` for pure computed values (replaces `useMemo`)
- `$effect` for side effects with cleanup return (replaces `useEffect`)
- `onMount` / `onDestroy` from `svelte` for imperative setup/teardown (keyboard listeners, SSE connections)
- Plain `let` for non-reactive internal state (timers, inflight flags, ref-like values)
- Getter-function inputs throughout: `createFoo(getValue: () => T)` not `createFoo(value: T)`

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test -- --run` — 1717 passed, 4 skipped (pre-existing flaky timeout test in mcp-stdio isolated separately)
- [x] `npx svelte-check --tsconfig ./tsconfig.client.json` — 0 errors, 0 warnings

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)