### PR TITLE
fix(server): annotation-store lock recovery with 30s retry (#494)

### DIFF
--- a/src/client/components/ApplyChangesButton.svelte
+++ b/src/client/components/ApplyChangesButton.svelte
@@ -1,73 +1,73 @@
 <script lang="ts">
-  import type { Annotation } from "../../shared/types";
-  import { API_BASE } from "../utils/fileUpload";
+import type { Annotation } from "../../shared/types";
+import { API_BASE } from "../utils/fileUpload";
 
-  interface Props {
-    annotations: Annotation[];
-    activeDocFormat: string | undefined;
-    documentId: string | undefined;
+interface Props {
+  annotations: Annotation[];
+  activeDocFormat: string | undefined;
+  documentId: string | undefined;
+}
+
+let { annotations, activeDocFormat, documentId }: Props = $props();
+
+let applying = $state(false);
+
+const accepted = $derived(annotations.filter((a) => a.status === "accepted"));
+const pending = $derived(annotations.filter((a) => a.status === "pending"));
+const disabled = $derived(accepted.length === 0 || applying);
+
+async function handleClick() {
+  if (disabled || !documentId) return;
+
+  let message = `Apply ${accepted.length} change(s) as tracked revisions?\n\nThe changes will appear as tracked revisions in Word — you can Accept or Reject each one individually.\n\nYour original file will be backed up.`;
+
+  if (pending.length > 0) {
+    message += `\n\n⚠ ${pending.length} annotation(s) are still pending review and will not be applied.`;
   }
 
-  let { annotations, activeDocFormat, documentId }: Props = $props();
+  if (!confirm(message)) return;
 
-  let applying = $state(false);
+  applying = true;
+  try {
+    const res = await fetch(`${API_BASE}/apply-changes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ documentId }),
+    });
+    const body = await res.json().catch((parseErr: unknown) => {
+      console.error("[ApplyChanges] Failed to parse response JSON:", parseErr);
+      return null;
+    });
 
-  const accepted = $derived(annotations.filter((a) => a.status === "accepted"));
-  const pending = $derived(annotations.filter((a) => a.status === "pending"));
-  const disabled = $derived(accepted.length === 0 || applying);
-
-  async function handleClick() {
-    if (disabled || !documentId) return;
-
-    let message = `Apply ${accepted.length} change(s) as tracked revisions?\n\nThe changes will appear as tracked revisions in Word — you can Accept or Reject each one individually.\n\nYour original file will be backed up.`;
-
-    if (pending.length > 0) {
-      message += `\n\n⚠ ${pending.length} annotation(s) are still pending review and will not be applied.`;
+    if (!res.ok) {
+      alert(body?.message ?? `Apply failed (HTTP ${res.status}).`);
+      return;
     }
 
-    if (!confirm(message)) return;
-
-    applying = true;
-    try {
-      const res = await fetch(`${API_BASE}/apply-changes`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ documentId }),
-      });
-      const body = await res.json().catch((parseErr: unknown) => {
-        console.error("[ApplyChanges] Failed to parse response JSON:", parseErr);
-        return null;
-      });
-
-      if (!res.ok) {
-        alert(body?.message ?? `Apply failed (HTTP ${res.status}).`);
-        return;
+    const data = body?.data;
+    if (data) {
+      const parts = [`Applied ${data.applied ?? 0} tracked change(s).`];
+      if (data.rejected > 0) {
+        parts.push(`${data.rejected} could not be applied.`);
       }
-
-      const data = body?.data;
-      if (data) {
-        const parts = [`Applied ${data.applied ?? 0} tracked change(s).`];
-        if (data.rejected > 0) {
-          parts.push(`${data.rejected} could not be applied.`);
-        }
-        if (data.backupPath) {
-          parts.push(`\nBackup saved to:\n${data.backupPath}`);
-        }
-        alert(parts.join(" "));
-      } else {
-        alert("Changes applied successfully.");
+      if (data.backupPath) {
+        parts.push(`\nBackup saved to:\n${data.backupPath}`);
       }
-    } catch (err) {
-      console.error("[ApplyChanges] Request failed:", err);
-      alert(
-        err instanceof TypeError
-          ? "Could not reach the server."
-          : `Apply failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    } finally {
-      applying = false;
+      alert(parts.join(" "));
+    } else {
+      alert("Changes applied successfully.");
     }
+  } catch (err) {
+    console.error("[ApplyChanges] Request failed:", err);
+    alert(
+      err instanceof TypeError
+        ? "Could not reach the server."
+        : `Apply failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    applying = false;
   }
+}
 </script>
 
 {#if activeDocFormat === "docx"}

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -1,154 +1,154 @@
 <script lang="ts">
-  import { untrack } from "svelte";
-  import { HocuspocusProvider } from "@hocuspocus/provider";
-  import { Editor as TiptapEditor } from "@tiptap/core";
-  import Collaboration from "@tiptap/extension-collaboration";
-  import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
-  import Highlight from "@tiptap/extension-highlight";
-  import Link from "@tiptap/extension-link";
-  import Placeholder from "@tiptap/extension-placeholder";
-  import Table from "@tiptap/extension-table";
-  import TableCell from "@tiptap/extension-table-cell";
-  import TableHeader from "@tiptap/extension-table-header";
-  import TableRow from "@tiptap/extension-table-row";
-  import StarterKit from "@tiptap/starter-kit";
-  import * as Y from "yjs";
-  import { readStoredName, subscribeToUserName } from "../hooks/useUserName";
-  import { AnnotationExtension } from "./extensions/annotation";
-  import { AuthorshipExtension } from "./extensions/authorship";
-  import { AwarenessExtension } from "./extensions/awareness";
-  import { MarkdownHtmlExtension } from "./extensions/markdown-html";
-  import "./editor.css";
+import { HocuspocusProvider } from "@hocuspocus/provider";
+import { Editor as TiptapEditor } from "@tiptap/core";
+import Collaboration from "@tiptap/extension-collaboration";
+import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
+import Highlight from "@tiptap/extension-highlight";
+import Link from "@tiptap/extension-link";
+import Placeholder from "@tiptap/extension-placeholder";
+import Table from "@tiptap/extension-table";
+import TableCell from "@tiptap/extension-table-cell";
+import TableHeader from "@tiptap/extension-table-header";
+import TableRow from "@tiptap/extension-table-row";
+import StarterKit from "@tiptap/starter-kit";
+import { untrack } from "svelte";
+import * as Y from "yjs";
+import { readStoredName, subscribeToUserName } from "../hooks/useUserName";
+import { AnnotationExtension } from "./extensions/annotation";
+import { AuthorshipExtension } from "./extensions/authorship";
+import { AwarenessExtension } from "./extensions/awareness";
+import { MarkdownHtmlExtension } from "./extensions/markdown-html";
+import "./editor.css";
 
-  interface Props {
-    ydoc: Y.Doc;
-    provider: HocuspocusProvider;
-    readOnly: boolean;
-    reviewMode?: boolean;
-    activeAnnotationId?: string | null;
-    onEditorReady?: (editor: TiptapEditor | null) => void;
-    onAnnotationClick?: (annotationId: string) => void;
-  }
+interface Props {
+  ydoc: Y.Doc;
+  provider: HocuspocusProvider;
+  readOnly: boolean;
+  reviewMode?: boolean;
+  activeAnnotationId?: string | null;
+  onEditorReady?: (editor: TiptapEditor | null) => void;
+  onAnnotationClick?: (annotationId: string) => void;
+}
 
-  const {
-    ydoc,
-    provider,
-    readOnly,
-    reviewMode,
-    activeAnnotationId,
-    onEditorReady,
-    onAnnotationClick,
-  }: Props = $props();
+const {
+  ydoc,
+  provider,
+  readOnly,
+  reviewMode,
+  activeAnnotationId,
+  onEditorReady,
+  onAnnotationClick,
+}: Props = $props();
 
-  let editor = $state<TiptapEditor | null>(null);
-  let editorRoot: HTMLDivElement | null = null;
+let editor = $state<TiptapEditor | null>(null);
+let editorRoot: HTMLDivElement | null = null;
 
-  // -------------------------------------------------------------------------
-  // Editor lifecycle: re-create when (ydoc, provider) identity changes.
-  //
-  // Pattern matches CLAUDE.md gotcha "Y.XmlText must be attached before
-  // populating": Tiptap creates its own Y.XmlFragment binding via the
-  // Collaboration extension on the supplied ydoc. We must destroy any prior
-  // editor BEFORE creating the new one (avoid duplicate event subscriptions
-  // and torn observers). Cleanup runs before the effect re-runs.
-  // -------------------------------------------------------------------------
-  $effect(() => {
-    // Track identity of ydoc + provider so this effect re-runs on swap.
-    void ydoc;
-    void provider;
+// -------------------------------------------------------------------------
+// Editor lifecycle: re-create when (ydoc, provider) identity changes.
+//
+// Pattern matches CLAUDE.md gotcha "Y.XmlText must be attached before
+// populating": Tiptap creates its own Y.XmlFragment binding via the
+// Collaboration extension on the supplied ydoc. We must destroy any prior
+// editor BEFORE creating the new one (avoid duplicate event subscriptions
+// and torn observers). Cleanup runs before the effect re-runs.
+// -------------------------------------------------------------------------
+$effect(() => {
+  // Track identity of ydoc + provider so this effect re-runs on swap.
+  void ydoc;
+  void provider;
 
-    if (!editorRoot) return;
+  if (!editorRoot) return;
 
-    const next = new TiptapEditor({
-      element: editorRoot,
-      extensions: [
-        StarterKit.configure({ history: false }), // Yjs handles undo/redo
-        Highlight.configure({ multicolor: true }),
-        Link.configure({
-          openOnClick: false,
-          HTMLAttributes: { rel: "noopener noreferrer", target: "_blank" },
-        }),
-        Placeholder.configure({
-          placeholder: "Open a document with Claude to get started...",
-        }),
-        Table.configure({ resizable: true }),
-        TableRow,
-        TableCell,
-        TableHeader,
-        MarkdownHtmlExtension,
-        Collaboration.configure({ document: ydoc }),
-        CollaborationCursor.configure({
-          provider,
-          user: {
-            name: readStoredName(),
-            color: "var(--tandem-warning)",
-          },
-        }),
-        AnnotationExtension.configure({ ydoc }),
-        AuthorshipExtension.configure({ ydoc }),
-        AwarenessExtension.configure({ ydoc }),
-      ],
-      editorProps: {
-        attributes: {
-          class: "tandem-editor",
-          style:
-            "outline: none; min-height: 500px; font-size: var(--tandem-editor-font-size, 16px); line-height: 1.6;",
+  const next = new TiptapEditor({
+    element: editorRoot,
+    extensions: [
+      StarterKit.configure({ history: false }), // Yjs handles undo/redo
+      Highlight.configure({ multicolor: true }),
+      Link.configure({
+        openOnClick: false,
+        HTMLAttributes: { rel: "noopener noreferrer", target: "_blank" },
+      }),
+      Placeholder.configure({
+        placeholder: "Open a document with Claude to get started...",
+      }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableCell,
+      TableHeader,
+      MarkdownHtmlExtension,
+      Collaboration.configure({ document: ydoc }),
+      CollaborationCursor.configure({
+        provider,
+        user: {
+          name: readStoredName(),
+          color: "var(--tandem-warning)",
         },
+      }),
+      AnnotationExtension.configure({ ydoc }),
+      AuthorshipExtension.configure({ ydoc }),
+      AwarenessExtension.configure({ ydoc }),
+    ],
+    editorProps: {
+      attributes: {
+        class: "tandem-editor",
+        style:
+          "outline: none; min-height: 500px; font-size: var(--tandem-editor-font-size, 16px); line-height: 1.6;",
       },
-      editable: untrack(() => !readOnly),
-    });
-
-    editor = next;
-    untrack(() => onEditorReady?.(next));
-
-    return () => {
-      untrack(() => onEditorReady?.(null));
-      next.destroy();
-      if (editor === next) editor = null;
-    };
+    },
+    editable: untrack(() => !readOnly),
   });
 
-  // -- readOnly toggling without recreating the editor -----------------------
-  $effect(() => {
-    const ed = editor;
-    if (!ed) return;
-    ed.setEditable(!readOnly);
+  editor = next;
+  untrack(() => onEditorReady?.(next));
+
+  return () => {
+    untrack(() => onEditorReady?.(null));
+    next.destroy();
+    if (editor === next) editor = null;
+  };
+});
+
+// -- readOnly toggling without recreating the editor -----------------------
+$effect(() => {
+  const ed = editor;
+  if (!ed) return;
+  ed.setEditable(!readOnly);
+});
+
+// -- Keep CollaborationCursor name synced with stored display name --------
+$effect(() => {
+  const ed = editor;
+  if (!ed) return;
+  return subscribeToUserName((name) => ed.commands.updateUser({ name }));
+});
+
+// -- Apply active annotation highlight class -------------------------------
+$effect(() => {
+  const ed = editor;
+  if (!ed) return;
+  const container = ed.view.dom;
+
+  container.querySelectorAll(".tandem-annotation-active").forEach((el) => {
+    el.classList.remove("tandem-annotation-active");
   });
 
-  // -- Keep CollaborationCursor name synced with stored display name --------
-  $effect(() => {
-    const ed = editor;
-    if (!ed) return;
-    return subscribeToUserName((name) => ed.commands.updateUser({ name }));
-  });
-
-  // -- Apply active annotation highlight class -------------------------------
-  $effect(() => {
-    const ed = editor;
-    if (!ed) return;
-    const container = ed.view.dom;
-
-    container.querySelectorAll(".tandem-annotation-active").forEach((el) => {
-      el.classList.remove("tandem-annotation-active");
-    });
-
-    if (activeAnnotationId && reviewMode) {
-      container
-        .querySelectorAll(`[data-annotation-id="${CSS.escape(activeAnnotationId)}"]`)
-        .forEach((el) => {
-          el.classList.add("tandem-annotation-active");
-        });
-    }
-  });
-
-  function handleEditorClick(e: MouseEvent) {
-    const target = (e.target as HTMLElement).closest("[data-annotation-id]");
-    if (!target) return;
-    const annotationId = target.getAttribute("data-annotation-id");
-    if (annotationId && onAnnotationClick) {
-      onAnnotationClick(annotationId);
-    }
+  if (activeAnnotationId && reviewMode) {
+    container
+      .querySelectorAll(`[data-annotation-id="${CSS.escape(activeAnnotationId)}"]`)
+      .forEach((el) => {
+        el.classList.add("tandem-annotation-active");
+      });
   }
+});
+
+function handleEditorClick(e: MouseEvent) {
+  const target = (e.target as HTMLElement).closest("[data-annotation-id]");
+  if (!target) return;
+  const annotationId = target.getAttribute("data-annotation-id");
+  if (annotationId && onAnnotationClick) {
+    onAnnotationClick(annotationId);
+  }
+}
 </script>
 
 <div class={reviewMode ? "tandem-review-dimmed" : ""} onclick={handleEditorClick} role="presentation">

--- a/src/client/editor/toolbar/FormattingToolbar.svelte
+++ b/src/client/editor/toolbar/FormattingToolbar.svelte
@@ -1,143 +1,143 @@
 <script lang="ts">
-  import type { Editor as TiptapEditor } from "@tiptap/core";
-  import { yUndoPluginKey } from "y-prosemirror";
-  import ToolbarButton from "./ToolbarButton.svelte";
+import type { Editor as TiptapEditor } from "@tiptap/core";
+import { yUndoPluginKey } from "y-prosemirror";
+import ToolbarButton from "./ToolbarButton.svelte";
 
-  interface Props {
-    editor: TiptapEditor | null;
-    disabled?: boolean;
-  }
+interface Props {
+  editor: TiptapEditor | null;
+  disabled?: boolean;
+}
 
-  const { editor, disabled = false }: Props = $props();
+const { editor, disabled = false }: Props = $props();
 
-  type HeadingLevel = 1 | 2 | 3;
-  const HEADING_LEVELS: HeadingLevel[] = [1, 2, 3];
-  const HEADING_FONT_WEIGHTS: Record<HeadingLevel, number> = { 1: 700, 2: 600, 3: 500 };
+type HeadingLevel = 1 | 2 | 3;
+const HEADING_LEVELS: HeadingLevel[] = [1, 2, 3];
+const HEADING_FONT_WEIGHTS: Record<HeadingLevel, number> = { 1: 700, 2: 600, 3: 500 };
 
-  // Force-reactive tick — Tiptap's isActive() is imperative; bump on transaction.
-  let tick = $state(0);
-  let showHeadingMenu = $state(false);
-  let headingMenuEl = $state<HTMLDivElement | null>(null);
+// Force-reactive tick — Tiptap's isActive() is imperative; bump on transaction.
+let tick = $state(0);
+let showHeadingMenu = $state(false);
+let headingMenuEl = $state<HTMLDivElement | null>(null);
 
-  $effect(() => {
-    if (!editor) return;
-    const handler = () => {
-      if (!editor.isDestroyed) tick++;
-    };
-    editor.on("transaction", handler);
-    return () => {
-      editor.off("transaction", handler);
-    };
-  });
+$effect(() => {
+  if (!editor) return;
+  const handler = () => {
+    if (!editor.isDestroyed) tick++;
+  };
+  editor.on("transaction", handler);
+  return () => {
+    editor.off("transaction", handler);
+  };
+});
 
-  $effect(() => {
-    if (!showHeadingMenu) return;
-    function handleClickOutside(e: MouseEvent) {
-      if (headingMenuEl && !headingMenuEl.contains(e.target as Node)) {
-        showHeadingMenu = false;
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  });
-
-  function findActiveHeading(ed: TiptapEditor): HeadingLevel | null {
-    for (const level of HEADING_LEVELS) {
-      if (ed.isActive("heading", { level })) return level;
-    }
-    return null;
-  }
-
-  // Reactive computations depend on editor + tick (transaction counter).
-  const isEditable = $derived(editor ? editor.isEditable : false);
-  const isDisabled = $derived(!isEditable || !!disabled);
-
-  const undoState = $derived.by(() => {
-    void tick;
-    return editor ? yUndoPluginKey.getState(editor.state) : null;
-  });
-  const canUndo = $derived(!isDisabled && (undoState?.undoManager?.undoStack.length ?? 0) > 0);
-  const canRedo = $derived(!isDisabled && (undoState?.undoManager?.redoStack.length ?? 0) > 0);
-
-  const activeHeading = $derived.by(() => {
-    void tick;
-    return editor ? findActiveHeading(editor) : null;
-  });
-
-  // Reactive isActive readers
-  const isActiveBold = $derived.by(() => {
-    void tick;
-    return !!editor?.isActive("bold");
-  });
-  const isActiveItalic = $derived.by(() => {
-    void tick;
-    return !!editor?.isActive("italic");
-  });
-  const isActiveStrike = $derived.by(() => {
-    void tick;
-    return !!editor?.isActive("strike");
-  });
-  const isActiveCode = $derived.by(() => {
-    void tick;
-    return !!editor?.isActive("code");
-  });
-  const isActiveBulletList = $derived.by(() => {
-    void tick;
-    return !!editor?.isActive("bulletList");
-  });
-  const isActiveOrderedList = $derived.by(() => {
-    void tick;
-    return !!editor?.isActive("orderedList");
-  });
-  const isActiveBlockquote = $derived.by(() => {
-    void tick;
-    return !!editor?.isActive("blockquote");
-  });
-  const isActiveCodeBlock = $derived.by(() => {
-    void tick;
-    return !!editor?.isActive("codeBlock");
-  });
-  const isActiveLink = $derived.by(() => {
-    void tick;
-    return !!editor?.isActive("link");
-  });
-  const linkDisabled = $derived.by(() => {
-    void tick;
-    if (!editor) return true;
-    return (
-      isDisabled ||
-      (!editor.isActive("link") && editor.state.selection.from === editor.state.selection.to)
-    );
-  });
-
-  const headingLabel = $derived(activeHeading ? `H${activeHeading}` : "H");
-
-  function withPreventDefault(command: () => void) {
-    return (e: MouseEvent) => {
-      e.preventDefault();
-      command();
-    };
-  }
-
-  function handleHeadingToggle(level: HeadingLevel) {
-    return (e: MouseEvent) => {
-      e.preventDefault();
-      if (!editor || editor.isDestroyed) return;
-      editor.chain().focus().toggleHeading({ level }).run();
+$effect(() => {
+  if (!showHeadingMenu) return;
+  function handleClickOutside(e: MouseEvent) {
+    if (headingMenuEl && !headingMenuEl.contains(e.target as Node)) {
       showHeadingMenu = false;
-    };
-  }
-
-  function handleLinkMouseDown(e: MouseEvent) {
-    e.preventDefault();
-    if (!editor) return;
-    if (editor.isActive("link")) {
-      editor.chain().focus().unsetLink().run();
-    } else {
-      const url = window.prompt("Enter URL:");
-      if (url) editor.chain().focus().setLink({ href: url }).run();
     }
   }
+  document.addEventListener("mousedown", handleClickOutside);
+  return () => document.removeEventListener("mousedown", handleClickOutside);
+});
+
+function findActiveHeading(ed: TiptapEditor): HeadingLevel | null {
+  for (const level of HEADING_LEVELS) {
+    if (ed.isActive("heading", { level })) return level;
+  }
+  return null;
+}
+
+// Reactive computations depend on editor + tick (transaction counter).
+const isEditable = $derived(editor ? editor.isEditable : false);
+const isDisabled = $derived(!isEditable || !!disabled);
+
+const undoState = $derived.by(() => {
+  void tick;
+  return editor ? yUndoPluginKey.getState(editor.state) : null;
+});
+const canUndo = $derived(!isDisabled && (undoState?.undoManager?.undoStack.length ?? 0) > 0);
+const canRedo = $derived(!isDisabled && (undoState?.undoManager?.redoStack.length ?? 0) > 0);
+
+const activeHeading = $derived.by(() => {
+  void tick;
+  return editor ? findActiveHeading(editor) : null;
+});
+
+// Reactive isActive readers
+const isActiveBold = $derived.by(() => {
+  void tick;
+  return !!editor?.isActive("bold");
+});
+const isActiveItalic = $derived.by(() => {
+  void tick;
+  return !!editor?.isActive("italic");
+});
+const isActiveStrike = $derived.by(() => {
+  void tick;
+  return !!editor?.isActive("strike");
+});
+const isActiveCode = $derived.by(() => {
+  void tick;
+  return !!editor?.isActive("code");
+});
+const isActiveBulletList = $derived.by(() => {
+  void tick;
+  return !!editor?.isActive("bulletList");
+});
+const isActiveOrderedList = $derived.by(() => {
+  void tick;
+  return !!editor?.isActive("orderedList");
+});
+const isActiveBlockquote = $derived.by(() => {
+  void tick;
+  return !!editor?.isActive("blockquote");
+});
+const isActiveCodeBlock = $derived.by(() => {
+  void tick;
+  return !!editor?.isActive("codeBlock");
+});
+const isActiveLink = $derived.by(() => {
+  void tick;
+  return !!editor?.isActive("link");
+});
+const linkDisabled = $derived.by(() => {
+  void tick;
+  if (!editor) return true;
+  return (
+    isDisabled ||
+    (!editor.isActive("link") && editor.state.selection.from === editor.state.selection.to)
+  );
+});
+
+const headingLabel = $derived(activeHeading ? `H${activeHeading}` : "H");
+
+function withPreventDefault(command: () => void) {
+  return (e: MouseEvent) => {
+    e.preventDefault();
+    command();
+  };
+}
+
+function handleHeadingToggle(level: HeadingLevel) {
+  return (e: MouseEvent) => {
+    e.preventDefault();
+    if (!editor || editor.isDestroyed) return;
+    editor.chain().focus().toggleHeading({ level }).run();
+    showHeadingMenu = false;
+  };
+}
+
+function handleLinkMouseDown(e: MouseEvent) {
+  e.preventDefault();
+  if (!editor) return;
+  if (editor.isActive("link")) {
+    editor.chain().focus().unsetLink().run();
+  } else {
+    const url = window.prompt("Enter URL:");
+    if (url) editor.chain().focus().setLink({ href: url }).run();
+  }
+}
 </script>
 
 {#if editor}

--- a/src/client/editor/toolbar/HighlightColorPicker.svelte
+++ b/src/client/editor/toolbar/HighlightColorPicker.svelte
@@ -1,51 +1,51 @@
 <script lang="ts">
-  import { HIGHLIGHT_COLORS } from "../../../shared/constants";
-  import type { HighlightColor } from "../../../shared/types";
-  import ToolbarButton from "./ToolbarButton.svelte";
+import { HIGHLIGHT_COLORS } from "../../../shared/constants";
+import type { HighlightColor } from "../../../shared/types";
+import ToolbarButton from "./ToolbarButton.svelte";
 
-  const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
-    { value: "yellow", label: "Yellow" },
-    { value: "green", label: "Green" },
-    { value: "blue", label: "Blue" },
-    { value: "pink", label: "Pink" },
-  ];
+const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
+  { value: "yellow", label: "Yellow" },
+  { value: "green", label: "Green" },
+  { value: "blue", label: "Blue" },
+  { value: "pink", label: "Pink" },
+];
 
-  interface Props {
-    disabled?: boolean;
-    onHighlight: (color: HighlightColor) => void;
-  }
+interface Props {
+  disabled?: boolean;
+  onHighlight: (color: HighlightColor) => void;
+}
 
-  const { disabled = false, onHighlight }: Props = $props();
+const { disabled = false, onHighlight }: Props = $props();
 
-  let highlightColor = $state<HighlightColor>("yellow");
-  let showColorPicker = $state(false);
-  let colorPickerEl = $state<HTMLDivElement | null>(null);
+let highlightColor = $state<HighlightColor>("yellow");
+let showColorPicker = $state(false);
+let colorPickerEl = $state<HTMLDivElement | null>(null);
 
-  $effect(() => {
-    if (!showColorPicker) return;
-    function handleClickOutside(e: MouseEvent) {
-      if (colorPickerEl && !colorPickerEl.contains(e.target as Node)) {
-        showColorPicker = false;
-      }
+$effect(() => {
+  if (!showColorPicker) return;
+  function handleClickOutside(e: MouseEvent) {
+    if (colorPickerEl && !colorPickerEl.contains(e.target as Node)) {
+      showColorPicker = false;
     }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  });
-
-  function handleHighlight(e: MouseEvent) {
-    e.preventDefault();
-    onHighlight(highlightColor);
   }
+  document.addEventListener("mousedown", handleClickOutside);
+  return () => document.removeEventListener("mousedown", handleClickOutside);
+});
 
-  function handleColorPickerToggle(e: MouseEvent) {
-    e.preventDefault();
-    showColorPicker = !showColorPicker;
-  }
+function handleHighlight(e: MouseEvent) {
+  e.preventDefault();
+  onHighlight(highlightColor);
+}
 
-  function handleColorSelect(color: HighlightColor) {
-    highlightColor = color;
-    showColorPicker = false;
-  }
+function handleColorPickerToggle(e: MouseEvent) {
+  e.preventDefault();
+  showColorPicker = !showColorPicker;
+}
+
+function handleColorSelect(color: HighlightColor) {
+  highlightColor = color;
+  showColorPicker = false;
+}
 </script>
 
 <div style="display: flex; align-items: center; gap: 2px; position: relative;">

--- a/src/client/editor/toolbar/InputGroup.svelte
+++ b/src/client/editor/toolbar/InputGroup.svelte
@@ -1,44 +1,44 @@
 <script lang="ts">
-  import type { Snippet } from "svelte";
-  import ToolbarButton from "./ToolbarButton.svelte";
+import type { Snippet } from "svelte";
+import ToolbarButton from "./ToolbarButton.svelte";
 
-  interface Props {
-    /** Bindable reference to the input element. Caller can read this to focus(). */
-    inputEl?: HTMLInputElement | null;
-    value: string;
-    onChange: (v: string) => void;
-    onKeyDown: (e: KeyboardEvent) => void;
-    onSubmit: () => void;
-    onCancel: () => void;
-    placeholder: string;
-    submitLabel: string;
-    borderColor: string;
-    canSubmit: boolean;
-    secondaryInput?: Snippet;
-    /** Optional prefix used to derive `data-testid` values for the input,
-     * submit, and cancel controls (e.g. `"toolbar-comment"` produces
-     * `toolbar-comment-input`, `toolbar-comment-submit`, `toolbar-comment-cancel`). */
-    testIdPrefix?: string;
-  }
+interface Props {
+  /** Bindable reference to the input element. Caller can read this to focus(). */
+  inputEl?: HTMLInputElement | null;
+  value: string;
+  onChange: (v: string) => void;
+  onKeyDown: (e: KeyboardEvent) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  placeholder: string;
+  submitLabel: string;
+  borderColor: string;
+  canSubmit: boolean;
+  secondaryInput?: Snippet;
+  /** Optional prefix used to derive `data-testid` values for the input,
+   * submit, and cancel controls (e.g. `"toolbar-comment"` produces
+   * `toolbar-comment-input`, `toolbar-comment-submit`, `toolbar-comment-cancel`). */
+  testIdPrefix?: string;
+}
 
-  let {
-    inputEl = $bindable(null),
-    value,
-    onChange,
-    onKeyDown,
-    onSubmit,
-    onCancel,
-    placeholder,
-    submitLabel,
-    borderColor,
-    canSubmit,
-    secondaryInput,
-    testIdPrefix,
-  }: Props = $props();
+let {
+  inputEl = $bindable(null),
+  value,
+  onChange,
+  onKeyDown,
+  onSubmit,
+  onCancel,
+  placeholder,
+  submitLabel,
+  borderColor,
+  canSubmit,
+  secondaryInput,
+  testIdPrefix,
+}: Props = $props();
 
-  const inputStyle = $derived(
-    `padding: 3px 8px; font-size: 13px; border: 1px solid ${borderColor}; border-radius: 4px; outline: none; min-width: 120px; flex: 1 1 200px; background: var(--tandem-surface); color: var(--tandem-fg);`,
-  );
+const inputStyle = $derived(
+  `padding: 3px 8px; font-size: 13px; border: 1px solid ${borderColor}; border-radius: 4px; outline: none; min-width: 120px; flex: 1 1 200px; background: var(--tandem-surface); color: var(--tandem-fg);`,
+);
 </script>
 
 <div style="display: flex; align-items: center; gap: 4px;">

--- a/src/client/editor/toolbar/ModeToggle.svelte
+++ b/src/client/editor/toolbar/ModeToggle.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import type { TandemMode } from "../../../shared/types";
+import type { TandemMode } from "../../../shared/types";
 
-  interface Props {
-    tandemMode: TandemMode;
-    onModeChange: (mode: TandemMode) => void;
-  }
+interface Props {
+  tandemMode: TandemMode;
+  onModeChange: (mode: TandemMode) => void;
+}
 
-  const { tandemMode, onModeChange }: Props = $props();
+const { tandemMode, onModeChange }: Props = $props();
 </script>
 
 <div

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -1,164 +1,159 @@
 <script lang="ts">
-  import type { Editor as TiptapEditor } from "@tiptap/core";
-  import * as Y from "yjs";
-  import { Y_MAP_ANNOTATIONS } from "../../../shared/constants";
-  import { toPmPos } from "../../../shared/positions/types";
-  import type {
-    Annotation,
-    AnnotationType,
-    HighlightColor,
-    TandemMode,
-  } from "../../../shared/types";
-  import { generateAnnotationId } from "../../../shared/utils";
-  import { pmPosToFlatOffset } from "../../positions";
-  import FormattingToolbar from "./FormattingToolbar.svelte";
-  import HighlightColorPicker from "./HighlightColorPicker.svelte";
-  import InputGroup from "./InputGroup.svelte";
-  import ModeToggle from "./ModeToggle.svelte";
-  import ToolbarButton from "./ToolbarButton.svelte";
+import type { Editor as TiptapEditor } from "@tiptap/core";
+import * as Y from "yjs";
+import { Y_MAP_ANNOTATIONS } from "../../../shared/constants";
+import { toPmPos } from "../../../shared/positions/types";
+import type { Annotation, AnnotationType, HighlightColor, TandemMode } from "../../../shared/types";
+import { generateAnnotationId } from "../../../shared/utils";
+import { pmPosToFlatOffset } from "../../positions";
+import FormattingToolbar from "./FormattingToolbar.svelte";
+import HighlightColorPicker from "./HighlightColorPicker.svelte";
+import InputGroup from "./InputGroup.svelte";
+import ModeToggle from "./ModeToggle.svelte";
+import ToolbarButton from "./ToolbarButton.svelte";
 
-  type ToolbarMode = "idle" | "comment" | "note";
+type ToolbarMode = "idle" | "comment" | "note";
 
-  interface Props {
-    editor: TiptapEditor | null;
-    ydoc: Y.Doc | null;
-    onSettingsOpen?: () => void;
-    /** Bindable settings button reference for keyboard-shortcut anchoring. */
-    settingsBtn?: HTMLButtonElement | null;
-    tandemMode?: TandemMode;
-    onModeChange?: (mode: TandemMode) => void;
-    heldCount?: number;
+interface Props {
+  editor: TiptapEditor | null;
+  ydoc: Y.Doc | null;
+  onSettingsOpen?: () => void;
+  /** Bindable settings button reference for keyboard-shortcut anchoring. */
+  settingsBtn?: HTMLButtonElement | null;
+  tandemMode?: TandemMode;
+  onModeChange?: (mode: TandemMode) => void;
+  heldCount?: number;
+}
+
+let {
+  editor,
+  ydoc,
+  onSettingsOpen,
+  settingsBtn = $bindable(null),
+  tandemMode,
+  onModeChange,
+  heldCount,
+}: Props = $props();
+
+let hasSelection = $state(false);
+let mode = $state<ToolbarMode>("idle");
+let modeText = $state("");
+let capturedRange: { from: number; to: number } | null = null;
+let commentInputEl = $state<HTMLInputElement | null>(null);
+let noteInputEl = $state<HTMLInputElement | null>(null);
+
+$effect(() => {
+  if (!editor) return;
+  const ed = editor;
+
+  function onSelectionUpdate() {
+    const { from, to } = ed.state.selection;
+    const next = from !== to;
+    if (hasSelection !== next) hasSelection = next;
   }
 
-  let {
-    editor,
-    ydoc,
-    onSettingsOpen,
-    settingsBtn = $bindable(null),
-    tandemMode,
-    onModeChange,
-    heldCount,
-  }: Props = $props();
+  ed.on("selectionUpdate", onSelectionUpdate);
+  return () => {
+    ed.off("selectionUpdate", onSelectionUpdate);
+  };
+});
 
-  let hasSelection = $state(false);
-  let mode = $state<ToolbarMode>("idle");
-  let modeText = $state("");
-  let capturedRange: { from: number; to: number } | null = null;
-  let commentInputEl = $state<HTMLInputElement | null>(null);
-  let noteInputEl = $state<HTMLInputElement | null>(null);
+$effect(() => {
+  if (mode === "comment") commentInputEl?.focus();
+  else if (mode === "note") noteInputEl?.focus();
+});
 
-  $effect(() => {
-    if (!editor) return;
-    const ed = editor;
+function createAnnotation(
+  type: AnnotationType,
+  content: string,
+  extras?: { color?: HighlightColor },
+) {
+  if (!editor || !ydoc) return;
 
-    function onSelectionUpdate() {
-      const { from, to } = ed.state.selection;
-      const next = from !== to;
-      if (hasSelection !== next) hasSelection = next;
-    }
+  const range = capturedRange ?? editor.state.selection;
+  const { from, to } = range;
+  if (from === to) return;
 
-    ed.on("selectionUpdate", onSelectionUpdate);
-    return () => {
-      ed.off("selectionUpdate", onSelectionUpdate);
-    };
-  });
+  const flatFrom = pmPosToFlatOffset(editor.state.doc, toPmPos(from));
+  const flatTo = pmPosToFlatOffset(editor.state.doc, toPmPos(to));
 
-  $effect(() => {
-    if (mode === "comment") commentInputEl?.focus();
-    else if (mode === "note") noteInputEl?.focus();
-  });
+  const id = generateAnnotationId();
+  const annotation = {
+    id,
+    author: "user" as const,
+    type,
+    range: { from: flatFrom, to: flatTo },
+    content,
+    status: "pending" as const,
+    timestamp: Date.now(),
+    ...(extras?.color ? { color: extras.color } : {}),
+  } as Annotation;
 
-  function createAnnotation(
-    type: AnnotationType,
-    content: string,
-    extras?: { color?: HighlightColor },
-  ) {
-    if (!editor || !ydoc) return;
+  ydoc.getMap(Y_MAP_ANNOTATIONS).set(id, annotation);
+  capturedRange = null;
+}
 
-    const range = capturedRange ?? editor.state.selection;
-    const { from, to } = range;
-    if (from === to) return;
+function captureSelectionRange() {
+  if (!editor) return;
+  const { from, to } = editor.state.selection;
+  capturedRange = { from, to };
+}
 
-    const flatFrom = pmPosToFlatOffset(editor.state.doc, toPmPos(from));
-    const flatTo = pmPosToFlatOffset(editor.state.doc, toPmPos(to));
+function resetAndFocusEditor() {
+  capturedRange = null;
+  editor?.chain().focus().run();
+}
 
-    const id = generateAnnotationId();
-    const annotation = {
-      id,
-      author: "user" as const,
-      type,
-      range: { from: flatFrom, to: flatTo },
-      content,
-      status: "pending" as const,
-      timestamp: Date.now(),
-      ...(extras?.color ? { color: extras.color } : {}),
-    } as Annotation;
+const inInputMode = $derived(mode !== "idle");
 
-    ydoc.getMap(Y_MAP_ANNOTATIONS).set(id, annotation);
-    capturedRange = null;
-  }
+function handleHighlight(color: HighlightColor) {
+  createAnnotation("highlight", "", { color });
+}
 
-  function captureSelectionRange() {
-    if (!editor) return;
-    const { from, to } = editor.state.selection;
-    capturedRange = { from, to };
-  }
-
-  function resetAndFocusEditor() {
-    capturedRange = null;
-    editor?.chain().focus().run();
-  }
-
-  const inInputMode = $derived(mode !== "idle");
-
-  function handleHighlight(color: HighlightColor) {
-    createAnnotation("highlight", "", { color });
-  }
-
-  function handleModeStart(targetMode: ToolbarMode) {
-    return (e: MouseEvent) => {
-      e.preventDefault();
-      captureSelectionRange();
-      mode = targetMode;
-      modeText = "";
-    };
-  }
-
-  const startComment = handleModeStart("comment");
-  const startNote = handleModeStart("note");
-
-  function handleModeCancel() {
-    mode = "idle";
+function handleModeStart(targetMode: ToolbarMode) {
+  return (e: MouseEvent) => {
+    e.preventDefault();
+    captureSelectionRange();
+    mode = targetMode;
     modeText = "";
-    resetAndFocusEditor();
-  }
+  };
+}
 
-  function handleModeSubmit() {
-    if (mode === "note") {
-      createAnnotation("note", modeText.trim());
-    } else {
-      if (!modeText.trim()) {
-        handleModeCancel();
-        return;
-      }
-      createAnnotation("comment", modeText.trim());
-    }
+const startComment = handleModeStart("comment");
+const startNote = handleModeStart("note");
 
-    mode = "idle";
-    modeText = "";
-    editor?.chain().focus().run();
-  }
+function handleModeCancel() {
+  mode = "idle";
+  modeText = "";
+  resetAndFocusEditor();
+}
 
-  function handleModeKeyDown(e: KeyboardEvent) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      handleModeSubmit();
-    } else if (e.key === "Escape") {
+function handleModeSubmit() {
+  if (mode === "note") {
+    createAnnotation("note", modeText.trim());
+  } else {
+    if (!modeText.trim()) {
       handleModeCancel();
+      return;
     }
+    createAnnotation("comment", modeText.trim());
   }
 
-  const canAnnotate = $derived(!!editor && !!ydoc && hasSelection);
+  mode = "idle";
+  modeText = "";
+  editor?.chain().focus().run();
+}
+
+function handleModeKeyDown(e: KeyboardEvent) {
+  if (e.key === "Enter") {
+    e.preventDefault();
+    handleModeSubmit();
+  } else if (e.key === "Escape") {
+    handleModeCancel();
+  }
+}
+
+const canAnnotate = $derived(!!editor && !!ydoc && hasSelection);
 </script>
 
 <div

--- a/src/client/editor/toolbar/ToolbarButton.svelte
+++ b/src/client/editor/toolbar/ToolbarButton.svelte
@@ -1,68 +1,63 @@
 <script lang="ts">
-  import type { Snippet } from "svelte";
+import type { Snippet } from "svelte";
 
-  interface Props {
-    /** When provided as a snippet, the snippet is rendered inside the button.
-     * Otherwise `label` is rendered as a plain string. */
-    label?: string;
-    children?: Snippet;
-    ariaLabel?: string;
-    testId?: string;
-    shortcut?: string;
-    disabled?: boolean;
-    disabledTitle?: string;
-    active?: boolean;
-    onMouseDown?: (e: MouseEvent) => void;
-    onClick?: () => void;
-    style?: string;
+interface Props {
+  /** When provided as a snippet, the snippet is rendered inside the button.
+   * Otherwise `label` is rendered as a plain string. */
+  label?: string;
+  children?: Snippet;
+  ariaLabel?: string;
+  testId?: string;
+  shortcut?: string;
+  disabled?: boolean;
+  disabledTitle?: string;
+  active?: boolean;
+  onMouseDown?: (e: MouseEvent) => void;
+  onClick?: () => void;
+  style?: string;
+}
+
+const {
+  label,
+  children,
+  ariaLabel,
+  testId,
+  shortcut,
+  disabled = false,
+  disabledTitle,
+  active = false,
+  onMouseDown,
+  onClick,
+  style = "",
+}: Props = $props();
+
+const computed = $derived.by(() => {
+  let border = "1px solid var(--tandem-border)";
+  let background = "var(--tandem-surface)";
+  let color = "var(--tandem-fg)";
+
+  if (disabled) {
+    background = "var(--tandem-surface-muted)";
+    color = "var(--tandem-fg-subtle)";
+  } else if (active) {
+    border = "1px solid var(--tandem-accent)";
+    background = "var(--tandem-accent-bg)";
+    color = "var(--tandem-accent)";
   }
+  return { border, background, color };
+});
 
-  const {
-    label,
-    children,
-    ariaLabel,
-    testId,
-    shortcut,
-    disabled = false,
-    disabledTitle,
-    active = false,
-    onMouseDown,
-    onClick,
-    style = "",
-  }: Props = $props();
+const ariaLabelValue = $derived(ariaLabel ?? (typeof label === "string" ? label : undefined));
+const titleText = $derived(ariaLabelValue ?? "");
+const titleAttr = $derived(
+  disabled && disabledTitle ? disabledTitle : shortcut ? `${titleText} (${shortcut})` : titleText,
+);
 
-  const computed = $derived.by(() => {
-    let border = "1px solid var(--tandem-border)";
-    let background = "var(--tandem-surface)";
-    let color = "var(--tandem-fg)";
+const baseStyle = "padding: 4px 10px; font-size: 13px; border-radius: 4px;";
 
-    if (disabled) {
-      background = "var(--tandem-surface-muted)";
-      color = "var(--tandem-fg-subtle)";
-    } else if (active) {
-      border = "1px solid var(--tandem-accent)";
-      background = "var(--tandem-accent-bg)";
-      color = "var(--tandem-accent)";
-    }
-    return { border, background, color };
-  });
-
-  const ariaLabelValue = $derived(ariaLabel ?? (typeof label === "string" ? label : undefined));
-  const titleText = $derived(ariaLabelValue ?? "");
-  const titleAttr = $derived(
-    disabled && disabledTitle
-      ? disabledTitle
-      : shortcut
-        ? `${titleText} (${shortcut})`
-        : titleText,
-  );
-
-  const baseStyle =
-    "padding: 4px 10px; font-size: 13px; border-radius: 4px;";
-
-  const fullStyle = $derived(
-    `${baseStyle} cursor: ${disabled ? "not-allowed" : "pointer"}; ${style}; border: ${computed.border}; background: ${computed.background}; color: ${computed.color};`,
-  );
+const fullStyle = $derived(
+  `${baseStyle} cursor: ${disabled ? "not-allowed" : "pointer"}; ${style}; border: ${computed.border}; background: ${computed.background}; color: ${computed.color};`,
+);
 </script>
 
 <button

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -1,118 +1,118 @@
 <script lang="ts">
-  import { HIGHLIGHT_COLORS } from "../../shared/constants";
-  import type { Annotation, AnnotationReply } from "../../shared/types";
-  import AnnotationCardActions from "./AnnotationCardActions.svelte";
-  import AnnotationEditForm from "./AnnotationEditForm.svelte";
-  import ReplyThread from "./ReplyThread.svelte";
+import { HIGHLIGHT_COLORS } from "../../shared/constants";
+import type { Annotation, AnnotationReply } from "../../shared/types";
+import AnnotationCardActions from "./AnnotationCardActions.svelte";
+import AnnotationEditForm from "./AnnotationEditForm.svelte";
+import ReplyThread from "./ReplyThread.svelte";
 
-  interface Props {
-    annotation: Annotation;
-    replies?: AnnotationReply[];
-    isReviewTarget?: boolean;
-    onAccept?: (id: string) => void;
-    onDismiss?: (id: string) => void;
-    onUndo?: (id: string) => boolean;
-    onEdit?: (id: string, newContent: string) => void;
-    onReply?: (id: string, text: string) => Promise<boolean>;
-    onRemove?: (id: string) => void;
-    /** Whether this annotation was recently resolved and can be undone */
-    undoable?: boolean;
-    onClick?: () => void;
+interface Props {
+  annotation: Annotation;
+  replies?: AnnotationReply[];
+  isReviewTarget?: boolean;
+  onAccept?: (id: string) => void;
+  onDismiss?: (id: string) => void;
+  onUndo?: (id: string) => boolean;
+  onEdit?: (id: string, newContent: string) => void;
+  onReply?: (id: string, text: string) => Promise<boolean>;
+  onRemove?: (id: string) => void;
+  /** Whether this annotation was recently resolved and can be undone */
+  undoable?: boolean;
+  onClick?: () => void;
+}
+
+let {
+  annotation,
+  replies = [],
+  isReviewTarget,
+  onAccept,
+  onDismiss,
+  onUndo,
+  onEdit,
+  onReply,
+  onRemove,
+  undoable,
+  onClick,
+}: Props = $props();
+
+let isEditing = $state(false);
+let editText = $state("");
+let editNewText = $state("");
+let editReason = $state("");
+
+const isPending = $derived(annotation.status === "pending");
+const hasSuggestedText = $derived(annotation.suggestedText !== undefined);
+
+function getDisplayType(ann: Annotation): string {
+  if (ann.suggestedText !== undefined) return "replacement";
+  return ann.type;
+}
+
+function getAuthorLabel(author: Annotation["author"]): string {
+  if (author === "claude") return "Claude";
+  if (author === "import") return "Imported";
+  return "You";
+}
+
+function getBorderColor(ann: Annotation): string {
+  if (ann.color) {
+    return HIGHLIGHT_COLORS[ann.color] || "var(--tandem-border)";
   }
+  if (ann.suggestedText !== undefined) return "var(--tandem-suggestion)";
+  if (ann.type === "note") return "var(--tandem-warning)";
+  return "var(--tandem-author-user)";
+}
 
-  let {
-    annotation,
-    replies = [],
-    isReviewTarget,
-    onAccept,
-    onDismiss,
-    onUndo,
-    onEdit,
-    onReply,
-    onRemove,
-    undoable,
-    onClick,
-  }: Props = $props();
+function getCardBackground(ann: Annotation, reviewTarget?: boolean): string {
+  if (reviewTarget) return "var(--tandem-accent-bg)";
+  if (ann.type === "note") return "var(--tandem-warning-bg)";
+  return "var(--tandem-surface)";
+}
 
-  let isEditing = $state(false);
-  let editText = $state("");
-  let editNewText = $state("");
-  let editReason = $state("");
+const displayType = $derived(getDisplayType(annotation));
+const borderColor = $derived(getBorderColor(annotation));
+const cardBg = $derived(getCardBackground(annotation, isReviewTarget));
+const isPrivateNote = $derived(annotation.type === "note");
 
-  const isPending = $derived(annotation.status === "pending");
-  const hasSuggestedText = $derived(annotation.suggestedText !== undefined);
+const truncatedContent = $derived(
+  annotation.content
+    ? annotation.content.length > 60
+      ? annotation.content.slice(0, 57) + "..."
+      : annotation.content
+    : "",
+);
 
-  function getDisplayType(ann: Annotation): string {
-    if (ann.suggestedText !== undefined) return "replacement";
-    return ann.type;
+const cardLabel = $derived(
+  `${isPrivateNote ? "private " : ""}${displayType} annotation${truncatedContent ? ": " + truncatedContent : ""}, ${annotation.status}`,
+);
+
+function enterEditMode() {
+  if (hasSuggestedText) {
+    editNewText = annotation.suggestedText ?? "";
+    editReason = annotation.content;
+  } else {
+    editText = annotation.content;
   }
+  isEditing = true;
+}
 
-  function getAuthorLabel(author: Annotation["author"]): string {
-    if (author === "claude") return "Claude";
-    if (author === "import") return "Imported";
-    return "You";
+function handleSave() {
+  const newContent = hasSuggestedText
+    ? JSON.stringify({ suggestedText: editNewText, content: editReason })
+    : editText;
+  onEdit?.(annotation.id, newContent);
+  isEditing = false;
+}
+
+function handleCancel() {
+  isEditing = false;
+}
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (e.key === "Escape") {
+    e.stopPropagation();
+    handleCancel();
   }
-
-  function getBorderColor(ann: Annotation): string {
-    if (ann.color) {
-      return HIGHLIGHT_COLORS[ann.color] || "var(--tandem-border)";
-    }
-    if (ann.suggestedText !== undefined) return "var(--tandem-suggestion)";
-    if (ann.type === "note") return "var(--tandem-warning)";
-    return "var(--tandem-author-user)";
-  }
-
-  function getCardBackground(ann: Annotation, reviewTarget?: boolean): string {
-    if (reviewTarget) return "var(--tandem-accent-bg)";
-    if (ann.type === "note") return "var(--tandem-warning-bg)";
-    return "var(--tandem-surface)";
-  }
-
-  const displayType = $derived(getDisplayType(annotation));
-  const borderColor = $derived(getBorderColor(annotation));
-  const cardBg = $derived(getCardBackground(annotation, isReviewTarget));
-  const isPrivateNote = $derived(annotation.type === "note");
-
-  const truncatedContent = $derived(
-    annotation.content
-      ? annotation.content.length > 60
-        ? annotation.content.slice(0, 57) + "..."
-        : annotation.content
-      : "",
-  );
-
-  const cardLabel = $derived(
-    `${isPrivateNote ? "private " : ""}${displayType} annotation${truncatedContent ? ": " + truncatedContent : ""}, ${annotation.status}`,
-  );
-
-  function enterEditMode() {
-    if (hasSuggestedText) {
-      editNewText = annotation.suggestedText ?? "";
-      editReason = annotation.content;
-    } else {
-      editText = annotation.content;
-    }
-    isEditing = true;
-  }
-
-  function handleSave() {
-    const newContent = hasSuggestedText
-      ? JSON.stringify({ suggestedText: editNewText, content: editReason })
-      : editText;
-    onEdit?.(annotation.id, newContent);
-    isEditing = false;
-  }
-
-  function handleCancel() {
-    isEditing = false;
-  }
-
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === "Escape") {
-      e.stopPropagation();
-      handleCancel();
-    }
-  }
+}
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->

--- a/src/client/panels/AnnotationCardActions.svelte
+++ b/src/client/panels/AnnotationCardActions.svelte
@@ -1,34 +1,34 @@
 <script lang="ts">
-  interface Props {
-    annotationId: string;
-    isPending: boolean;
-    isEditing: boolean;
-    undoable?: boolean;
-    onAccept?: (id: string) => void;
-    onDismiss?: (id: string) => void;
-    onUndo?: (id: string) => boolean;
-    onRemove?: (id: string) => void;
+interface Props {
+  annotationId: string;
+  isPending: boolean;
+  isEditing: boolean;
+  undoable?: boolean;
+  onAccept?: (id: string) => void;
+  onDismiss?: (id: string) => void;
+  onUndo?: (id: string) => boolean;
+  onRemove?: (id: string) => void;
+}
+
+let { annotationId, isPending, isEditing, undoable, onAccept, onDismiss, onUndo, onRemove }: Props =
+  $props();
+
+let undoError = $state(false);
+let undoTimer: ReturnType<typeof setTimeout> | null = null;
+
+function handleUndo(e: MouseEvent) {
+  e.stopPropagation();
+  if (!onUndo) return;
+  const ok = onUndo(annotationId);
+  if (!ok) {
+    undoError = true;
+    if (undoTimer) clearTimeout(undoTimer);
+    undoTimer = setTimeout(() => {
+      undoError = false;
+      undoTimer = null;
+    }, 3000);
   }
-
-  let { annotationId, isPending, isEditing, undoable, onAccept, onDismiss, onUndo, onRemove }: Props =
-    $props();
-
-  let undoError = $state(false);
-  let undoTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function handleUndo(e: MouseEvent) {
-    e.stopPropagation();
-    if (!onUndo) return;
-    const ok = onUndo(annotationId);
-    if (!ok) {
-      undoError = true;
-      if (undoTimer) clearTimeout(undoTimer);
-      undoTimer = setTimeout(() => {
-        undoError = false;
-        undoTimer = null;
-      }, 3000);
-    }
-  }
+}
 </script>
 
 {#if isPending && !isEditing && (onAccept || onDismiss)}

--- a/src/client/panels/AnnotationEditForm.svelte
+++ b/src/client/panels/AnnotationEditForm.svelte
@@ -1,33 +1,33 @@
 <script lang="ts">
-  import { TEXTAREA_STYLE } from "./panel-styles";
+import { TEXTAREA_STYLE } from "./panel-styles";
 
-  interface Props {
-    annotationId: string;
-    hasSuggestedText: boolean;
-    editText: string;
-    editNewText: string;
-    editReason: string;
-    onChangeEditText: (value: string) => void;
-    onChangeEditNewText: (value: string) => void;
-    onChangeEditReason: (value: string) => void;
-    onKeyDown: (e: KeyboardEvent) => void;
-    onSave: () => void;
-    onCancel: () => void;
-  }
+interface Props {
+  annotationId: string;
+  hasSuggestedText: boolean;
+  editText: string;
+  editNewText: string;
+  editReason: string;
+  onChangeEditText: (value: string) => void;
+  onChangeEditNewText: (value: string) => void;
+  onChangeEditReason: (value: string) => void;
+  onKeyDown: (e: KeyboardEvent) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
 
-  let {
-    annotationId,
-    hasSuggestedText,
-    editText,
-    editNewText,
-    editReason,
-    onChangeEditText,
-    onChangeEditNewText,
-    onChangeEditReason,
-    onKeyDown,
-    onSave,
-    onCancel,
-  }: Props = $props();
+let {
+  annotationId,
+  hasSuggestedText,
+  editText,
+  editNewText,
+  editReason,
+  onChangeEditText,
+  onChangeEditNewText,
+  onChangeEditReason,
+  onKeyDown,
+  onSave,
+  onCancel,
+}: Props = $props();
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->

--- a/src/client/panels/BulkActions.svelte
+++ b/src/client/panels/BulkActions.svelte
@@ -1,38 +1,38 @@
 <script lang="ts">
-  interface Props {
-    bulkConfirm: "accept" | "dismiss" | null;
-    pendingCount: number;
-    allPendingCount: number;
-    onConfirmAccept: () => void;
-    onConfirmDismiss: () => void;
-    onCancel: () => void;
-    onRequestAccept: () => void;
-    onRequestDismiss: () => void;
-    /** Bind to get a reference to the confirm button for programmatic focus. */
-    confirmRef?: HTMLButtonElement | null;
-  }
+interface Props {
+  bulkConfirm: "accept" | "dismiss" | null;
+  pendingCount: number;
+  allPendingCount: number;
+  onConfirmAccept: () => void;
+  onConfirmDismiss: () => void;
+  onCancel: () => void;
+  onRequestAccept: () => void;
+  onRequestDismiss: () => void;
+  /** Bind to get a reference to the confirm button for programmatic focus. */
+  confirmRef?: HTMLButtonElement | null;
+}
 
-  let {
-    bulkConfirm,
-    pendingCount,
-    allPendingCount,
-    onConfirmAccept,
-    onConfirmDismiss,
-    onCancel,
-    onRequestAccept,
-    onRequestDismiss,
-    confirmRef = $bindable(null),
-  }: Props = $props();
+let {
+  bulkConfirm,
+  pendingCount,
+  allPendingCount,
+  onConfirmAccept,
+  onConfirmDismiss,
+  onCancel,
+  onRequestAccept,
+  onRequestDismiss,
+  confirmRef = $bindable(null),
+}: Props = $props();
 
-  const isAccept = $derived(bulkConfirm === "accept");
-  const countLabel = $derived(
-    pendingCount === allPendingCount
-      ? `${pendingCount} annotations?`
-      : `${pendingCount} of ${allPendingCount} pending?`,
-  );
+const isAccept = $derived(bulkConfirm === "accept");
+const countLabel = $derived(
+  pendingCount === allPendingCount
+    ? `${pendingCount} annotations?`
+    : `${pendingCount} of ${allPendingCount} pending?`,
+);
 
-  const smallBtnBase =
-    "padding: 2px 8px; font-size: 11px; border: 1px solid var(--tandem-border-strong); border-radius: 3px; cursor: pointer;";
+const smallBtnBase =
+  "padding: 2px 8px; font-size: 11px; border: 1px solid var(--tandem-border-strong); border-radius: 3px; cursor: pointer;";
 </script>
 
 {#if pendingCount > 1}

--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -1,164 +1,164 @@
 <script lang="ts">
-  import type { Editor as TiptapEditor } from "@tiptap/core";
-  import * as Y from "yjs";
-  import { DEFAULT_MCP_PORT, Y_MAP_CHAT } from "../../shared/constants";
-  import type { FlatOffset } from "../../shared/positions/types";
-  import type { CapturedAnchor, ChatMessage } from "../../shared/types";
-  import { generateMessageId } from "../../shared/utils";
-  import { flatOffsetToPmPos } from "../positions";
+import type { Editor as TiptapEditor } from "@tiptap/core";
+import * as Y from "yjs";
+import { DEFAULT_MCP_PORT, Y_MAP_CHAT } from "../../shared/constants";
+import type { FlatOffset } from "../../shared/positions/types";
+import type { CapturedAnchor, ChatMessage } from "../../shared/types";
+import { generateMessageId } from "../../shared/utils";
+import { flatOffsetToPmPos } from "../positions";
 
-  const TYPING_DOT_DELAYS = [0, 0.2, 0.4];
+const TYPING_DOT_DELAYS = [0, 0.2, 0.4];
 
-  interface Props {
-    ctrlYdoc: Y.Doc | null;
-    editor: TiptapEditor | null;
-    activeDocId: string | null;
-    openDocs: Array<{ id: string; fileName: string }>;
-    claudeActive?: boolean;
-    claudeStatus?: string | null;
-    visible?: boolean;
-    capturedAnchor: CapturedAnchor | null;
-    onCapturedAnchorChange: (anchor: CapturedAnchor | null) => void;
-    /** Bind to get a reference to the textarea element. */
-    inputEl?: HTMLTextAreaElement | null;
-    reduceMotion?: boolean;
+interface Props {
+  ctrlYdoc: Y.Doc | null;
+  editor: TiptapEditor | null;
+  activeDocId: string | null;
+  openDocs: Array<{ id: string; fileName: string }>;
+  claudeActive?: boolean;
+  claudeStatus?: string | null;
+  visible?: boolean;
+  capturedAnchor: CapturedAnchor | null;
+  onCapturedAnchorChange: (anchor: CapturedAnchor | null) => void;
+  /** Bind to get a reference to the textarea element. */
+  inputEl?: HTMLTextAreaElement | null;
+  reduceMotion?: boolean;
+}
+
+let {
+  ctrlYdoc,
+  editor,
+  activeDocId,
+  openDocs,
+  claudeActive,
+  claudeStatus,
+  visible,
+  capturedAnchor,
+  onCapturedAnchorChange,
+  inputEl = $bindable(null),
+  reduceMotion,
+}: Props = $props();
+
+const scrollBehavior: ScrollBehavior = $derived(reduceMotion ? "auto" : "smooth");
+
+let messages = $state<ChatMessage[]>([]);
+let inputText = $state("");
+
+let messagesEndEl: HTMLDivElement | undefined = $state();
+let internalInputEl: HTMLTextAreaElement | undefined = $state();
+
+// Keep external binding in sync
+$effect(() => {
+  inputEl = internalInputEl ?? null;
+});
+
+// Observe Y.Map('chat') for changes
+$effect(() => {
+  if (!ctrlYdoc) return;
+  const chatMap = ctrlYdoc.getMap(Y_MAP_CHAT);
+
+  const observer = () => {
+    const msgs: ChatMessage[] = [];
+    chatMap.forEach((value) => {
+      msgs.push(value as ChatMessage);
+    });
+    msgs.sort((a, b) => a.timestamp - b.timestamp || a.id.localeCompare(b.id));
+    messages = msgs;
+  };
+
+  chatMap.observe(observer);
+  observer(); // initial load
+  return () => chatMap.unobserve(observer);
+});
+
+// Auto-scroll to bottom on new messages or when typing indicator appears
+let prevClaudeActive = false;
+$effect(() => {
+  void messages; // track message changes
+  const active = !!claudeActive;
+  const sb = scrollBehavior;
+
+  if (!active && prevClaudeActive) {
+    prevClaudeActive = false;
+    return;
   }
+  prevClaudeActive = active;
+  messagesEndEl?.scrollIntoView({ behavior: sb });
+});
 
-  let {
-    ctrlYdoc,
-    editor,
-    activeDocId,
-    openDocs,
-    claudeActive,
-    claudeStatus,
-    visible,
-    capturedAnchor,
-    onCapturedAnchorChange,
-    inputEl = $bindable(null),
-    reduceMotion,
-  }: Props = $props();
-
-  const scrollBehavior: ScrollBehavior = $derived(reduceMotion ? "auto" : "smooth");
-
-  let messages = $state<ChatMessage[]>([]);
-  let inputText = $state("");
-
-  let messagesEndEl: HTMLDivElement | undefined = $state();
-  let internalInputEl: HTMLTextAreaElement | undefined = $state();
-
-  // Keep external binding in sync
-  $effect(() => {
-    inputEl = internalInputEl ?? null;
-  });
-
-  // Observe Y.Map('chat') for changes
-  $effect(() => {
-    if (!ctrlYdoc) return;
-    const chatMap = ctrlYdoc.getMap(Y_MAP_CHAT);
-
-    const observer = () => {
-      const msgs: ChatMessage[] = [];
-      chatMap.forEach((value) => {
-        msgs.push(value as ChatMessage);
-      });
-      msgs.sort((a, b) => a.timestamp - b.timestamp || a.id.localeCompare(b.id));
-      messages = msgs;
-    };
-
-    chatMap.observe(observer);
-    observer(); // initial load
-    return () => chatMap.unobserve(observer);
-  });
-
-  // Auto-scroll to bottom on new messages or when typing indicator appears
-  let prevClaudeActive = false;
-  $effect(() => {
-    void messages; // track message changes
-    const active = !!claudeActive;
-    const sb = scrollBehavior;
-
-    if (!active && prevClaudeActive) {
-      prevClaudeActive = false;
-      return;
-    }
-    prevClaudeActive = active;
+// Scroll to bottom when panel becomes visible
+$effect(() => {
+  const vis = visible;
+  const sb = scrollBehavior;
+  if (vis) {
     messagesEndEl?.scrollIntoView({ behavior: sb });
-  });
-
-  // Scroll to bottom when panel becomes visible
-  $effect(() => {
-    const vis = visible;
-    const sb = scrollBehavior;
-    if (vis) {
-      messagesEndEl?.scrollIntoView({ behavior: sb });
-    }
-  });
-
-  const unreadCount = $derived(messages.filter((m) => m.author === "claude" && !m.read).length);
-
-  function sendMessage() {
-    if (!ctrlYdoc || !inputText.trim()) return;
-    const chatMap = ctrlYdoc.getMap(Y_MAP_CHAT);
-
-    const msg: ChatMessage = {
-      id: generateMessageId(),
-      author: "user",
-      text: inputText.trim(),
-      timestamp: Date.now(),
-      ...(activeDocId ? { documentId: activeDocId } : {}),
-      ...(capturedAnchor ? { anchor: capturedAnchor } : {}),
-      read: false,
-    };
-
-    chatMap.set(msg.id, msg);
-    inputText = "";
-    onCapturedAnchorChange(null);
   }
+});
 
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      sendMessage();
-    }
+const unreadCount = $derived(messages.filter((m) => m.author === "claude" && !m.read).length);
+
+function sendMessage() {
+  if (!ctrlYdoc || !inputText.trim()) return;
+  const chatMap = ctrlYdoc.getMap(Y_MAP_CHAT);
+
+  const msg: ChatMessage = {
+    id: generateMessageId(),
+    author: "user",
+    text: inputText.trim(),
+    timestamp: Date.now(),
+    ...(activeDocId ? { documentId: activeDocId } : {}),
+    ...(capturedAnchor ? { anchor: capturedAnchor } : {}),
+    read: false,
+  };
+
+  chatMap.set(msg.id, msg);
+  inputText = "";
+  onCapturedAnchorChange(null);
+}
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    sendMessage();
   }
+}
 
-  function scrollToAnchor(anchor: { from: FlatOffset; to: FlatOffset }, docId?: string) {
-    if (!editor || (docId && docId !== activeDocId)) return;
-    try {
-      const pmFrom = flatOffsetToPmPos(editor.state.doc, anchor.from);
-      const pmTo = flatOffsetToPmPos(editor.state.doc, anchor.to);
-      editor.chain().focus().setTextSelection({ from: pmFrom, to: pmTo }).scrollIntoView().run();
-    } catch (err) {
-      console.warn(
-        "[ChatPanel] Could not scroll to anchor:",
-        err instanceof Error ? err.message : err,
-      );
-    }
+function scrollToAnchor(anchor: { from: FlatOffset; to: FlatOffset }, docId?: string) {
+  if (!editor || (docId && docId !== activeDocId)) return;
+  try {
+    const pmFrom = flatOffsetToPmPos(editor.state.doc, anchor.from);
+    const pmTo = flatOffsetToPmPos(editor.state.doc, anchor.to);
+    editor.chain().focus().setTextSelection({ from: pmFrom, to: pmTo }).scrollIntoView().run();
+  } catch (err) {
+    console.warn(
+      "[ChatPanel] Could not scroll to anchor:",
+      err instanceof Error ? err.message : err,
+    );
   }
+}
 
-  function getDocFileName(docId?: string): string | null {
-    if (!docId) return null;
-    const doc = openDocs.find((d) => d.id === docId);
-    return doc?.fileName ?? null;
+function getDocFileName(docId?: string): string | null {
+  if (!docId) return null;
+  const doc = openDocs.find((d) => d.id === docId);
+  return doc?.fileName ?? null;
+}
+
+async function clearChat() {
+  try {
+    await fetch(`http://localhost:${DEFAULT_MCP_PORT}/api/chat`, { method: "DELETE" });
+  } catch (err) {
+    console.warn("[ChatPanel] Failed to clear chat:", err);
   }
+}
 
-  async function clearChat() {
-    try {
-      await fetch(`http://localhost:${DEFAULT_MCP_PORT}/api/chat`, { method: "DELETE" });
-    } catch (err) {
-      console.warn("[ChatPanel] Failed to clear chat:", err);
-    }
-  }
+// Anchor expand state — keyed by message id
+let expandedAnchors = $state(new Set<string>());
 
-  // Anchor expand state — keyed by message id
-  let expandedAnchors = $state(new Set<string>());
-
-  function toggleAnchorExpand(msgId: string) {
-    const next = new Set(expandedAnchors);
-    if (next.has(msgId)) next.delete(msgId);
-    else next.add(msgId);
-    expandedAnchors = next;
-  }
+function toggleAnchorExpand(msgId: string) {
+  const next = new Set(expandedAnchors);
+  if (next.has(msgId)) next.delete(msgId);
+  else next.add(msgId);
+  expandedAnchors = next;
+}
 </script>
 
 <div

--- a/src/client/panels/CommentThread.svelte
+++ b/src/client/panels/CommentThread.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
-  import type { AnnotationReply } from "../../shared/types";
+import type { AnnotationReply } from "../../shared/types";
 
-  interface Props {
-    replies: AnnotationReply[];
-  }
+interface Props {
+  replies: AnnotationReply[];
+}
 
-  let { replies }: Props = $props();
+let { replies }: Props = $props();
 
-  function formatTime(timestamp: number): string {
-    const date = new Date(timestamp);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMin = Math.floor(diffMs / 60_000);
-    if (diffMin < 1) return "just now";
-    if (diffMin < 60) return `${diffMin}m ago`;
-    const diffHr = Math.floor(diffMin / 60);
-    if (diffHr < 24) return `${diffHr}h ago`;
-    return date.toLocaleDateString();
-  }
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return date.toLocaleDateString();
+}
 </script>
 
 {#if replies.length > 0}

--- a/src/client/panels/DocumentHealth.svelte
+++ b/src/client/panels/DocumentHealth.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  // Placeholder component — no analysis available yet.
+// Placeholder component — no analysis available yet.
 </script>
 
 <div style="padding: 8px; color: var(--tandem-fg);">

--- a/src/client/panels/FilterBar.svelte
+++ b/src/client/panels/FilterBar.svelte
@@ -1,31 +1,31 @@
 <script lang="ts">
-  import FilterSelect from "./FilterSelect.svelte";
+import FilterSelect from "./FilterSelect.svelte";
 
-  export type FilterType = "highlight" | "comment" | "note" | "all" | "with-replacement";
-  export type FilterAuthor = "all" | "claude" | "user" | "import";
-  export type FilterStatus = "all" | "pending" | "accepted" | "dismissed";
+export type FilterType = "highlight" | "comment" | "note" | "all" | "with-replacement";
+export type FilterAuthor = "all" | "claude" | "user" | "import";
+export type FilterStatus = "all" | "pending" | "accepted" | "dismissed";
 
-  interface Props {
-    filterType: FilterType;
-    filterAuthor: FilterAuthor;
-    filterStatus: FilterStatus;
-    hasFilters: boolean;
-    onSetFilterType: (v: FilterType) => void;
-    onSetFilterAuthor: (v: FilterAuthor) => void;
-    onSetFilterStatus: (v: FilterStatus) => void;
-    onClearFilters: () => void;
-  }
+interface Props {
+  filterType: FilterType;
+  filterAuthor: FilterAuthor;
+  filterStatus: FilterStatus;
+  hasFilters: boolean;
+  onSetFilterType: (v: FilterType) => void;
+  onSetFilterAuthor: (v: FilterAuthor) => void;
+  onSetFilterStatus: (v: FilterStatus) => void;
+  onClearFilters: () => void;
+}
 
-  let {
-    filterType,
-    filterAuthor,
-    filterStatus,
-    hasFilters,
-    onSetFilterType,
-    onSetFilterAuthor,
-    onSetFilterStatus,
-    onClearFilters,
-  }: Props = $props();
+let {
+  filterType,
+  filterAuthor,
+  filterStatus,
+  hasFilters,
+  onSetFilterType,
+  onSetFilterAuthor,
+  onSetFilterStatus,
+  onClearFilters,
+}: Props = $props();
 </script>
 
 <div

--- a/src/client/panels/FilterSelect.svelte
+++ b/src/client/panels/FilterSelect.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  export interface FilterSelectProps {
-    value: string;
-    onChange: (v: string) => void;
-    options: Array<{ value: string; label: string }>;
-    testId?: string;
-  }
+export interface FilterSelectProps {
+  value: string;
+  onChange: (v: string) => void;
+  options: Array<{ value: string; label: string }>;
+  testId?: string;
+}
 
-  let { value, onChange, options, testId }: FilterSelectProps = $props();
+let { value, onChange, options, testId }: FilterSelectProps = $props();
 </script>
 
 <select

--- a/src/client/panels/ReplyThread.svelte
+++ b/src/client/panels/ReplyThread.svelte
@@ -1,46 +1,46 @@
 <script lang="ts">
-  import type { AnnotationReply } from "../../shared/types";
-  import CommentThread from "./CommentThread.svelte";
-  import { TEXTAREA_STYLE } from "./panel-styles";
+import type { AnnotationReply } from "../../shared/types";
+import CommentThread from "./CommentThread.svelte";
+import { TEXTAREA_STYLE } from "./panel-styles";
 
-  interface Props {
-    annotationId: string;
-    replies: AnnotationReply[];
-    isPending: boolean;
-    isEditing: boolean;
-    onReply?: (id: string, text: string) => Promise<boolean>;
+interface Props {
+  annotationId: string;
+  replies: AnnotationReply[];
+  isPending: boolean;
+  isEditing: boolean;
+  onReply?: (id: string, text: string) => Promise<boolean>;
+}
+
+let { annotationId, replies, isPending, isEditing, onReply }: Props = $props();
+
+let isReplying = $state(false);
+let replyText = $state("");
+let isSendingReply = $state(false);
+
+const hasText = $derived(Boolean(replyText.trim()));
+
+function handleReplyKeyDown(e: KeyboardEvent) {
+  if (e.key === "Escape") {
+    e.stopPropagation();
+    isReplying = false;
+    replyText = "";
   }
+}
 
-  let { annotationId, replies, isPending, isEditing, onReply }: Props = $props();
-
-  let isReplying = $state(false);
-  let replyText = $state("");
-  let isSendingReply = $state(false);
-
-  const hasText = $derived(Boolean(replyText.trim()));
-
-  function handleReplyKeyDown(e: KeyboardEvent) {
-    if (e.key === "Escape") {
-      e.stopPropagation();
-      isReplying = false;
+async function handleSendReply() {
+  const trimmed = replyText.trim();
+  if (!trimmed || isSendingReply) return;
+  isSendingReply = true;
+  try {
+    const ok = await onReply?.(annotationId, trimmed);
+    if (ok !== false) {
       replyText = "";
+      isReplying = false;
     }
+  } finally {
+    isSendingReply = false;
   }
-
-  async function handleSendReply() {
-    const trimmed = replyText.trim();
-    if (!trimmed || isSendingReply) return;
-    isSendingReply = true;
-    try {
-      const ok = await onReply?.(annotationId, trimmed);
-      if (ok !== false) {
-        replyText = "";
-        isReplying = false;
-      }
-    } finally {
-      isSendingReply = false;
-    }
-  }
+}
 </script>
 
 <CommentThread {replies} />

--- a/src/client/panels/ReviewSummary.svelte
+++ b/src/client/panels/ReviewSummary.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  interface Props {
-    accepted: number;
-    dismissed: number;
-    total: number;
-    onDismiss: () => void;
-  }
+interface Props {
+  accepted: number;
+  dismissed: number;
+  total: number;
+  onDismiss: () => void;
+}
 
-  let { accepted, dismissed, total, onDismiss }: Props = $props();
+let { accepted, dismissed, total, onDismiss }: Props = $props();
 
-  const acceptRate = $derived(total > 0 ? Math.round((accepted / total) * 100) : 0);
-  const emoji = $derived(acceptRate >= 80 ? "✅" : acceptRate >= 50 ? "📋" : "🔍");
+const acceptRate = $derived(total > 0 ? Math.round((accepted / total) * 100) : 0);
+const emoji = $derived(acceptRate >= 80 ? "✅" : acceptRate >= 50 ? "📋" : "🔍");
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -18,7 +18,6 @@ interface Props {
   editor: TiptapEditor | null;
   ydoc: Y.Doc | null;
   heldCount?: number;
-  storeReadOnly?: boolean;
   tandemMode?: TandemMode;
   onModeChange?: (mode: TandemMode) => void;
   activeDocFormat?: string;
@@ -36,7 +35,6 @@ let {
   editor,
   ydoc,
   heldCount = 0,
-  storeReadOnly = false,
   tandemMode: _tandemMode,
   onModeChange,
   activeDocFormat,
@@ -270,16 +268,6 @@ function handleBulk(status: "accepted" | "dismissed") {
   data-testid="annotation-list-scroll-container"
   style="width: 100%; background: var(--tandem-surface-muted); display: flex; flex-direction: column; overflow-y: auto;"
 >
-  <!-- Store read-only banner: shown while another Tandem process holds the annotation lock -->
-  {#if storeReadOnly}
-    <div
-      data-testid="store-readonly-banner"
-      style="padding: 6px 16px; background: {warningStateColors.background}; border-bottom: 1px solid {warningStateColors.border}; font-size: 12px; color: {warningStateColors.color};"
-    >
-      Annotations are read-only — another Tandem process holds the store lock.
-    </div>
-  {/if}
-
   <!-- Held-annotation banner -->
   {#if heldCount > 0}
     <div

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -18,6 +18,7 @@
     editor: TiptapEditor | null;
     ydoc: Y.Doc | null;
     heldCount?: number;
+    storeReadOnly?: boolean;
     tandemMode?: TandemMode;
     onModeChange?: (mode: TandemMode) => void;
     activeDocFormat?: string;
@@ -35,6 +36,7 @@
     editor,
     ydoc,
     heldCount = 0,
+    storeReadOnly = false,
     tandemMode: _tandemMode,
     onModeChange,
     activeDocFormat,
@@ -270,6 +272,16 @@
   data-testid="annotation-list-scroll-container"
   style="width: 100%; background: var(--tandem-surface-muted); display: flex; flex-direction: column; overflow-y: auto;"
 >
+  <!-- Store read-only banner: shown while another Tandem process holds the annotation lock -->
+  {#if storeReadOnly}
+    <div
+      data-testid="store-readonly-banner"
+      style="padding: 6px 16px; background: {warningStateColors.background}; border-bottom: 1px solid {warningStateColors.border}; font-size: 12px; color: {warningStateColors.color};"
+    >
+      Annotations are read-only — another Tandem process holds the store lock.
+    </div>
+  {/if}
+
   <!-- Held-annotation banner -->
   {#if heldCount > 0}
     <div

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -1,270 +1,268 @@
 <script lang="ts">
-  import type { Editor as TiptapEditor } from "@tiptap/core";
-  import * as Y from "yjs";
-  import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../shared/constants";
-  import { sanitizeAnnotation } from "../../shared/sanitize";
-  import type { Annotation, AnnotationReply, TandemMode } from "../../shared/types";
-  import ApplyChangesButton from "../components/ApplyChangesButton.svelte";
-  import { warningStateColors } from "../utils/colors";
-  import { API_BASE } from "../utils/fileUpload";
-  import AnnotationCard from "./AnnotationCard.svelte";
-  import BulkActions from "./BulkActions.svelte";
-  import type { FilterAuthor, FilterStatus, FilterType } from "./FilterBar.svelte";
-  import FilterBar from "./FilterBar.svelte";
-  import { useAnnotationReview } from "./useAnnotationReview.svelte";
+import type { Editor as TiptapEditor } from "@tiptap/core";
+import * as Y from "yjs";
+import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../shared/constants";
+import { sanitizeAnnotation } from "../../shared/sanitize";
+import type { Annotation, AnnotationReply, TandemMode } from "../../shared/types";
+import ApplyChangesButton from "../components/ApplyChangesButton.svelte";
+import { warningStateColors } from "../utils/colors";
+import { API_BASE } from "../utils/fileUpload";
+import AnnotationCard from "./AnnotationCard.svelte";
+import BulkActions from "./BulkActions.svelte";
+import type { FilterAuthor, FilterStatus, FilterType } from "./FilterBar.svelte";
+import FilterBar from "./FilterBar.svelte";
+import { useAnnotationReview } from "./useAnnotationReview.svelte";
 
-  interface Props {
-    annotations: Annotation[];
-    editor: TiptapEditor | null;
-    ydoc: Y.Doc | null;
-    heldCount?: number;
-    storeReadOnly?: boolean;
-    tandemMode?: TandemMode;
-    onModeChange?: (mode: TandemMode) => void;
-    activeDocFormat?: string;
-    documentId?: string;
-    reviewMode: boolean;
-    onToggleReviewMode: () => void;
-    onExitReviewMode: () => void;
-    activeAnnotationId: string | null;
-    onActiveAnnotationChange: (id: string | null) => void;
-    reduceMotion?: boolean;
+interface Props {
+  annotations: Annotation[];
+  editor: TiptapEditor | null;
+  ydoc: Y.Doc | null;
+  heldCount?: number;
+  storeReadOnly?: boolean;
+  tandemMode?: TandemMode;
+  onModeChange?: (mode: TandemMode) => void;
+  activeDocFormat?: string;
+  documentId?: string;
+  reviewMode: boolean;
+  onToggleReviewMode: () => void;
+  onExitReviewMode: () => void;
+  activeAnnotationId: string | null;
+  onActiveAnnotationChange: (id: string | null) => void;
+  reduceMotion?: boolean;
+}
+
+let {
+  annotations,
+  editor,
+  ydoc,
+  heldCount = 0,
+  storeReadOnly = false,
+  tandemMode: _tandemMode,
+  onModeChange,
+  activeDocFormat,
+  documentId,
+  reviewMode,
+  onToggleReviewMode,
+  onExitReviewMode,
+  activeAnnotationId,
+  onActiveAnnotationChange,
+  reduceMotion,
+}: Props = $props();
+
+const scrollBehavior: ScrollBehavior = $derived(reduceMotion ? "auto" : "smooth");
+
+// Filter state
+let filterType = $state<FilterType>("all");
+let filterAuthor = $state<FilterAuthor>("all");
+let filterStatus = $state<FilterStatus>("all");
+let bulkConfirm = $state<"accept" | "dismiss" | null>(null);
+
+// Scroll container ref
+let scrollContainerEl: HTMLDivElement | undefined = $state();
+
+// Confirm button element (from BulkActions)
+let confirmBtnEl: HTMLButtonElement | null = $state(null);
+
+// Focus confirm button when bulk confirmation appears
+$effect(() => {
+  if (bulkConfirm) confirmBtnEl?.focus();
+});
+
+// Reset bulk confirm when filters change
+$effect(() => {
+  // read filter state to establish reactivity
+  void filterType;
+  void filterAuthor;
+  void filterStatus;
+  bulkConfirm = null;
+});
+
+// Replies: observe Y.Map(annotationReplies)
+let repliesMap = $state(new Map<string, AnnotationReply[]>());
+
+$effect(() => {
+  if (!ydoc) {
+    repliesMap = new Map();
+    return;
   }
 
-  let {
-    annotations,
-    editor,
-    ydoc,
-    heldCount = 0,
-    storeReadOnly = false,
-    tandemMode: _tandemMode,
-    onModeChange,
-    activeDocFormat,
-    documentId,
-    reviewMode,
-    onToggleReviewMode,
-    onExitReviewMode,
-    activeAnnotationId,
-    onActiveAnnotationChange,
-    reduceMotion,
-  }: Props = $props();
+  const ymap = ydoc.getMap(Y_MAP_ANNOTATION_REPLIES);
 
-  const scrollBehavior: ScrollBehavior = $derived(reduceMotion ? "auto" : "smooth");
+  function rebuild() {
+    const grouped = new Map<string, AnnotationReply[]>();
+    ymap.forEach((value) => {
+      const reply = value as AnnotationReply;
+      if (reply && typeof reply === "object" && reply.annotationId) {
+        const list = grouped.get(reply.annotationId) ?? [];
+        list.push(reply);
+        grouped.set(reply.annotationId, list);
+      }
+    });
+    for (const list of grouped.values()) {
+      list.sort((a, b) => a.timestamp - b.timestamp);
+    }
+    repliesMap = grouped;
+  }
 
-  // Filter state
-  let filterType = $state<FilterType>("all");
-  let filterAuthor = $state<FilterAuthor>("all");
-  let filterStatus = $state<FilterStatus>("all");
-  let bulkConfirm = $state<"accept" | "dismiss" | null>(null);
+  rebuild();
+  ymap.observe(rebuild);
+  return () => ymap.unobserve(rebuild);
+});
 
-  // Scroll container ref
-  let scrollContainerEl: HTMLDivElement | undefined = $state();
+// Single-pass filtering + categorization
+const filteredData = $derived.by(() => {
+  const filtered: Annotation[] = [];
+  const allPending: Annotation[] = [];
 
-  // Confirm button element (from BulkActions)
-  let confirmBtnEl: HTMLButtonElement | null = $state(null);
+  for (const a of annotations) {
+    if (a.status === "pending") allPending.push(a);
+    let matchType: boolean;
+    if (filterType === "all") matchType = true;
+    else if (filterType === "with-replacement") matchType = a.suggestedText !== undefined;
+    else matchType = a.type === filterType;
+    const matchAuthor = filterAuthor === "all" || a.author === filterAuthor;
+    const matchStatus = filterStatus === "all" || a.status === filterStatus;
+    if (matchType && matchAuthor && matchStatus) filtered.push(a);
+  }
 
-  // Focus confirm button when bulk confirmation appears
-  $effect(() => {
-    if (bulkConfirm) confirmBtnEl?.focus();
-  });
+  const pending = filtered.filter((a) => a.status === "pending");
+  const resolved = filtered.filter((a) => a.status !== "pending");
 
-  // Reset bulk confirm when filters change
-  $effect(() => {
-    // read filter state to establish reactivity
-    void filterType;
-    void filterAuthor;
-    void filterStatus;
-    bulkConfirm = null;
-  });
+  return { filtered, pending, resolved, allPending };
+});
 
-  // Replies: observe Y.Map(annotationReplies)
-  let repliesMap = $state(new Map<string, AnnotationReply[]>());
+const hasFilters = $derived(
+  filterType !== "all" || filterAuthor !== "all" || filterStatus !== "all",
+);
 
-  $effect(() => {
-    if (!ydoc) {
-      repliesMap = new Map();
+// useAnnotationReview hook
+const review = useAnnotationReview({
+  getYdoc: () => ydoc,
+  getEditor: () => editor,
+  getAnnotations: () => annotations,
+  onActiveAnnotationChange: (id) => onActiveAnnotationChange(id),
+  getReviewMode: () => reviewMode,
+  onToggleReviewMode: () => onToggleReviewMode(),
+  onExitReviewMode: () => onExitReviewMode(),
+  getBulkConfirm: () => bulkConfirm,
+  setBulkConfirm: (v) => (bulkConfirm = v),
+  getScrollBehavior: () => scrollBehavior,
+});
+
+// Scroll container reset on filter change
+let didMountFilters = false;
+$effect(() => {
+  // track filter state
+  void filterType;
+  void filterAuthor;
+  void filterStatus;
+
+  if (!didMountFilters) {
+    didMountFilters = true;
+    return;
+  }
+
+  if (activeAnnotationId) {
+    const card = document.querySelector(`[data-testid="annotation-card-${activeAnnotationId}"]`);
+    if (card) {
+      card.scrollIntoView({ block: "center" });
       return;
     }
+    console.warn(
+      `[tandem] SidePanel: active annotation ${activeAnnotationId} not found on filter change; scrolling to top`,
+    );
+  }
+  scrollContainerEl?.scrollTo({ top: 0 });
+});
 
-    const ymap = ydoc.getMap(Y_MAP_ANNOTATION_REPLIES);
+// Scroll to and flash annotation card when activeAnnotationId changes externally
+$effect(() => {
+  const aid = activeAnnotationId;
+  if (!aid) return;
+  const sb = scrollBehavior;
 
-    function rebuild() {
-      const grouped = new Map<string, AnnotationReply[]>();
-      ymap.forEach((value) => {
-        const reply = value as AnnotationReply;
-        if (reply && typeof reply === "object" && reply.annotationId) {
-          const list = grouped.get(reply.annotationId) ?? [];
-          list.push(reply);
-          grouped.set(reply.annotationId, list);
-        }
-      });
-      for (const list of grouped.values()) {
-        list.sort((a, b) => a.timestamp - b.timestamp);
-      }
-      repliesMap = grouped;
-    }
-
-    rebuild();
-    ymap.observe(rebuild);
-    return () => ymap.unobserve(rebuild);
-  });
-
-  // Single-pass filtering + categorization
-  const filteredData = $derived.by(() => {
-    const filtered: Annotation[] = [];
-    const allPending: Annotation[] = [];
-
-    for (const a of annotations) {
-      if (a.status === "pending") allPending.push(a);
-      let matchType: boolean;
-      if (filterType === "all") matchType = true;
-      else if (filterType === "with-replacement") matchType = a.suggestedText !== undefined;
-      else matchType = a.type === filterType;
-      const matchAuthor = filterAuthor === "all" || a.author === filterAuthor;
-      const matchStatus = filterStatus === "all" || a.status === filterStatus;
-      if (matchType && matchAuthor && matchStatus) filtered.push(a);
-    }
-
-    const pending = filtered.filter((a) => a.status === "pending");
-    const resolved = filtered.filter((a) => a.status !== "pending");
-
-    return { filtered, pending, resolved, allPending };
-  });
-
-  const hasFilters = $derived(
-    filterType !== "all" || filterAuthor !== "all" || filterStatus !== "all",
-  );
-
-  // useAnnotationReview hook
-  const review = useAnnotationReview({
-    getYdoc: () => ydoc,
-    getEditor: () => editor,
-    getAnnotations: () => annotations,
-    onActiveAnnotationChange: (id) => onActiveAnnotationChange(id),
-    getReviewMode: () => reviewMode,
-    onToggleReviewMode: () => onToggleReviewMode(),
-    onExitReviewMode: () => onExitReviewMode(),
-    getBulkConfirm: () => bulkConfirm,
-    setBulkConfirm: (v) => (bulkConfirm = v),
-    getScrollBehavior: () => scrollBehavior,
-  });
-
-  // Scroll container reset on filter change
-  let didMountFilters = false;
-  $effect(() => {
-    // track filter state
-    void filterType;
-    void filterAuthor;
-    void filterStatus;
-
-    if (!didMountFilters) {
-      didMountFilters = true;
-      return;
-    }
-
-    if (activeAnnotationId) {
-      const card = document.querySelector(`[data-testid="annotation-card-${activeAnnotationId}"]`);
-      if (card) {
-        card.scrollIntoView({ block: "center" });
-        return;
-      }
+  const timer = setTimeout(() => {
+    const card = document.querySelector(`[data-testid="annotation-card-${aid}"]`);
+    if (card) {
+      card.scrollIntoView({ behavior: sb, block: "nearest" });
+      card.classList.add("tandem-annotation-flash");
+      const onEnd = () => card.classList.remove("tandem-annotation-flash");
+      card.addEventListener("animationend", onEnd, { once: true });
+    } else {
       console.warn(
-        `[tandem] SidePanel: active annotation ${activeAnnotationId} not found on filter change; scrolling to top`,
+        `[tandem] SidePanel: active annotation ${aid} not found after 50ms delay; scroll-to-card skipped`,
       );
     }
-    scrollContainerEl?.scrollTo({ top: 0 });
+  }, 50);
+
+  return () => clearTimeout(timer);
+});
+
+function handleEdit(id: string, newContent: string) {
+  if (!ydoc) return;
+  const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+  const raw = map.get(id) as Annotation | undefined;
+  if (!raw) return;
+  const ann = sanitizeAnnotation(raw, (event) => {
+    console.warn("[sanitize]", event);
   });
 
-  // Scroll to and flash annotation card when activeAnnotationId changes externally
-  $effect(() => {
-    const aid = activeAnnotationId;
-    if (!aid) return;
-    const sb = scrollBehavior;
+  if (ann.suggestedText !== undefined) {
+    try {
+      const parsed = JSON.parse(newContent) as { suggestedText: string; content: string };
+      map.set(id, {
+        ...ann,
+        suggestedText: parsed.suggestedText,
+        content: parsed.content,
+        editedAt: Date.now(),
+      });
+    } catch {
+      console.warn(`[SidePanel] Failed to parse edit payload for annotation ${id}`);
+    }
+    return;
+  }
+  map.set(id, { ...ann, content: newContent, editedAt: Date.now() });
+}
 
-    const timer = setTimeout(() => {
-      const card = document.querySelector(`[data-testid="annotation-card-${aid}"]`);
-      if (card) {
-        card.scrollIntoView({ behavior: sb, block: "nearest" });
-        card.classList.add("tandem-annotation-flash");
-        const onEnd = () => card.classList.remove("tandem-annotation-flash");
-        card.addEventListener("animationend", onEnd, { once: true });
-      } else {
-        console.warn(
-          `[tandem] SidePanel: active annotation ${aid} not found after 50ms delay; scroll-to-card skipped`,
-        );
-      }
-    }, 50);
-
-    return () => clearTimeout(timer);
-  });
-
-  function handleEdit(id: string, newContent: string) {
-    if (!ydoc) return;
-    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
-    const raw = map.get(id) as Annotation | undefined;
-    if (!raw) return;
-    const ann = sanitizeAnnotation(raw, (event) => {
-      console.warn("[sanitize]", event);
+async function handleRemove(annotationId: string): Promise<void> {
+  try {
+    const resp = await fetch(`${API_BASE}/remove-annotation`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotationId, documentId }),
     });
-
-    if (ann.suggestedText !== undefined) {
-      try {
-        const parsed = JSON.parse(newContent) as { suggestedText: string; content: string };
-        map.set(id, {
-          ...ann,
-          suggestedText: parsed.suggestedText,
-          content: parsed.content,
-          editedAt: Date.now(),
-        });
-      } catch {
-        console.warn(`[SidePanel] Failed to parse edit payload for annotation ${id}`);
-      }
-      return;
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ message: "Unknown error" }));
+      console.error("[Tandem] Remove annotation failed:", err);
     }
-    map.set(id, { ...ann, content: newContent, editedAt: Date.now() });
+  } catch (e) {
+    console.error("[Tandem] Remove annotation failed:", e);
   }
+}
 
-  async function handleRemove(annotationId: string): Promise<void> {
-    try {
-      const resp = await fetch(`${API_BASE}/remove-annotation`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ annotationId, documentId }),
-      });
-      if (!resp.ok) {
-        const err = await resp.json().catch(() => ({ message: "Unknown error" }));
-        console.error("[Tandem] Remove annotation failed:", err);
-      }
-    } catch (e) {
-      console.error("[Tandem] Remove annotation failed:", e);
-    }
-  }
-
-  async function handleReply(annotationId: string, text: string): Promise<boolean> {
-    try {
-      const res = await fetch(`${API_BASE}/annotation-reply`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ annotationId, text, documentId }),
-      });
-      if (!res.ok) {
-        const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-        console.warn(
-          `[SidePanel] Reply failed (${res.status}): ${data.message ?? "unknown error"}`,
-        );
-        return false;
-      }
-      return true;
-    } catch (err) {
-      console.error("[SidePanel] Reply request failed:", err);
+async function handleReply(annotationId: string, text: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/annotation-reply`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotationId, text, documentId }),
+    });
+    if (!res.ok) {
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+      console.warn(`[SidePanel] Reply failed (${res.status}): ${data.message ?? "unknown error"}`);
       return false;
     }
+    return true;
+  } catch (err) {
+    console.error("[SidePanel] Reply request failed:", err);
+    return false;
   }
+}
 
-  function handleBulk(status: "accepted" | "dismissed") {
-    for (const ann of filteredData.pending) review.resolveAnnotation(ann.id, status);
-    bulkConfirm = null;
-  }
+function handleBulk(status: "accepted" | "dismissed") {
+  for (const ann of filteredData.pending) review.resolveAnnotation(ann.id, status);
+  bulkConfirm = null;
+}
 </script>
 
 <div

--- a/src/client/svelte-harness/EditorHarness.svelte
+++ b/src/client/svelte-harness/EditorHarness.svelte
@@ -1,26 +1,26 @@
 <script lang="ts">
-  import { HocuspocusProvider } from "@hocuspocus/provider";
-  import { onDestroy } from "svelte";
-  import * as Y from "yjs";
-  import Editor from "../editor/Editor.svelte";
+import { HocuspocusProvider } from "@hocuspocus/provider";
+import { onDestroy } from "svelte";
+import * as Y from "yjs";
+import Editor from "../editor/Editor.svelte";
 
-  // Fresh Y.Doc + a no-op-ish provider for harness rendering. The provider
-  // will attempt to connect; failure is fine — we only need the object so
-  // the CollaborationCursor extension constructs without throwing.
-  const ydoc = new Y.Doc();
-  const provider = new HocuspocusProvider({
-    url: "ws://localhost:3478",
-    name: "harness-doc",
-    document: ydoc,
-  });
-  // Disconnect immediately — the harness does not need a live connection,
-  // we only need a constructed provider so CollaborationCursor wires up.
-  provider.disconnect();
+// Fresh Y.Doc + a no-op-ish provider for harness rendering. The provider
+// will attempt to connect; failure is fine — we only need the object so
+// the CollaborationCursor extension constructs without throwing.
+const ydoc = new Y.Doc();
+const provider = new HocuspocusProvider({
+  url: "ws://localhost:3478",
+  name: "harness-doc",
+  document: ydoc,
+});
+// Disconnect immediately — the harness does not need a live connection,
+// we only need a constructed provider so CollaborationCursor wires up.
+provider.disconnect();
 
-  onDestroy(() => {
-    provider.destroy();
-    ydoc.destroy();
-  });
+onDestroy(() => {
+  provider.destroy();
+  ydoc.destroy();
+});
 </script>
 
 <div style="padding: 16px;">

--- a/src/client/svelte-harness/HookDebug.svelte
+++ b/src/client/svelte-harness/HookDebug.svelte
@@ -1,30 +1,30 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
-  import { createYjsSync } from "../hooks/yjsSync.svelte";
+import { onDestroy } from "svelte";
+import { createYjsSync } from "../hooks/yjsSync.svelte";
 
-  const sync = createYjsSync();
+const sync = createYjsSync();
 
-  onDestroy(() => {
-    sync.destroy();
-  });
+onDestroy(() => {
+  sync.destroy();
+});
 
-  // Build a JSON-safe snapshot of the hook's reactive state.
-  const snapshot = $derived({
-    ready: sync.ready,
-    connected: sync.connected,
-    connectionStatus: sync.connectionStatus,
-    reconnectAttempts: sync.reconnectAttempts,
-    disconnectedSince: sync.disconnectedSince,
-    serverRestarted: sync.serverRestarted,
-    activeTabId: sync.activeTabId,
-    tabIds: sync.tabs.map((t) => t.id),
-    tabCount: sync.tabs.length,
-    annotationCount: sync.annotations.length,
-    claudeStatus: sync.claudeStatus,
-    claudeActive: sync.claudeActive,
-    readOnly: sync.readOnly,
-    hasBootstrapYdoc: sync.bootstrapYdoc !== null,
-  });
+// Build a JSON-safe snapshot of the hook's reactive state.
+const snapshot = $derived({
+  ready: sync.ready,
+  connected: sync.connected,
+  connectionStatus: sync.connectionStatus,
+  reconnectAttempts: sync.reconnectAttempts,
+  disconnectedSince: sync.disconnectedSince,
+  serverRestarted: sync.serverRestarted,
+  activeTabId: sync.activeTabId,
+  tabIds: sync.tabs.map((t) => t.id),
+  tabCount: sync.tabs.length,
+  annotationCount: sync.annotations.length,
+  claudeStatus: sync.claudeStatus,
+  claudeActive: sync.claudeActive,
+  readOnly: sync.readOnly,
+  hasBootstrapYdoc: sync.bootstrapYdoc !== null,
+});
 </script>
 
 <div class="debug">

--- a/src/server/annotations/store.ts
+++ b/src/server/annotations/store.ts
@@ -226,6 +226,11 @@ async function tryReclaimStaleLock(lockPath: string): Promise<boolean> {
   return true;
 }
 
+/** Returns true while another process holds the store lock and writes are disabled. */
+export function isStoreReadOnly(): boolean {
+  return readOnly;
+}
+
 /** Release the store lock. Safe to call repeatedly; no-op if we don't own it. */
 export async function releaseStoreLock(): Promise<void> {
   if (isFeatureDisabled()) return;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -145,37 +145,41 @@ process.on("SIGINT", () => shutdown("SIGINT"));
 async function main() {
   console.error(`[Tandem] Starting server (transport: ${transportMode})...`);
 
-  // Take the durable-annotation store lock before anything else touches
-  // app-data. The port 3479 bind is the primary concurrent-writer guard;
-  // this is a belt-and-braces fallback for port-bind races and edge cases.
-  //
-  // Retry loop: on a live-PID readonly result we wait up to 30 seconds before
-  // giving up, logging to stderr every 5s. This handles a slow filesystem
-  // unmount or a previous instance that is still shutting down.
+  // Take the durable-annotation store lock before accepting connections.
+  // HTTP mode: retry up to 30s when a live PID holds the lock, logging every 5s.
+  // Stdio mode: single attempt only — the MCP init timeout cannot survive a retry loop.
   {
-    const RETRY_INTERVAL_MS = 5_000;
-    const RETRY_DEADLINE_MS = 30_000;
-    const retryStart = Date.now();
     let lock: "locked" | "readonly" = "readonly";
-    let lockErr: unknown = undefined;
+    let lockErr: unknown;
 
-    try {
-      lock = await acquireStoreLock();
-    } catch (err) {
-      lockErr = err;
-    }
-
-    while (
-      lock === "readonly" &&
-      lockErr === undefined &&
-      Date.now() - retryStart < RETRY_DEADLINE_MS
-    ) {
-      const elapsed = Date.now() - retryStart;
-      const remaining = Math.ceil((RETRY_DEADLINE_MS - elapsed) / 1000);
-      process.stderr.write(
-        `[Tandem] store lock held by another process, retrying in 5s... (${remaining}s remaining)\n`,
-      );
-      await new Promise<void>((resolve) => setTimeout(resolve, RETRY_INTERVAL_MS));
+    if (transportMode === "http") {
+      // HTTP mode: retry up to 30s — browser has no init deadline
+      const RETRY_INTERVAL_MS = 5_000;
+      const RETRY_DEADLINE_MS = 30_000;
+      const retryStart = Date.now();
+      try {
+        lock = await acquireStoreLock();
+      } catch (err) {
+        lockErr = err;
+      }
+      while (
+        lock === "readonly" &&
+        lockErr === undefined &&
+        Date.now() - retryStart < RETRY_DEADLINE_MS
+      ) {
+        const remaining = Math.ceil((RETRY_DEADLINE_MS - (Date.now() - retryStart)) / 1000);
+        process.stderr.write(
+          `[Tandem] store lock held by another process, retrying in 5s... (${remaining}s remaining)\n`,
+        );
+        await new Promise<void>((r) => setTimeout(r, RETRY_INTERVAL_MS));
+        try {
+          lock = await acquireStoreLock();
+        } catch (err) {
+          lockErr = err;
+        }
+      }
+    } else {
+      // Stdio mode: single attempt only — MCP init timeout cannot tolerate a retry loop
       try {
         lock = await acquireStoreLock();
       } catch (err) {
@@ -198,14 +202,14 @@ async function main() {
       });
     } else if (lock === "readonly") {
       console.error(
-        "[Tandem] Annotation store is read-only after 30s retry (another process holds the lock); writes disabled for this session.",
+        "[Tandem] Annotation store is read-only (another process holds the lock); writes disabled for this session.",
       );
       pushNotification({
         id: `store-readonly-${Date.now()}`,
         type: "save-error",
         severity: "warning",
         message:
-          "Another Tandem process is running — annotations won't be saved this session. Close the other instance and restart.",
+          "Annotation store is read-only (another process holds the lock); annotation writes are disabled for this session. Close the other Tandem instance and restart.",
         dedupKey: "annotation-store:readonly",
         timestamp: Date.now(),
       });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -148,14 +148,57 @@ async function main() {
   // Take the durable-annotation store lock before anything else touches
   // app-data. The port 3479 bind is the primary concurrent-writer guard;
   // this is a belt-and-braces fallback for port-bind races and edge cases.
-  // `readonly` is tolerable — load() still works; queueWrite becomes a no-op,
-  // but without a user-visible warning a second instance silently drops every
-  // annotation for a whole session. Push a toast so the user sees it.
-  try {
-    const lock = await acquireStoreLock();
-    if (lock === "readonly") {
+  //
+  // Retry loop: on a live-PID readonly result we wait up to 30 seconds before
+  // giving up, logging to stderr every 5s. This handles a slow filesystem
+  // unmount or a previous instance that is still shutting down.
+  {
+    const RETRY_INTERVAL_MS = 5_000;
+    const RETRY_DEADLINE_MS = 30_000;
+    const retryStart = Date.now();
+    let lock: "locked" | "readonly" = "readonly";
+    let lockErr: unknown = undefined;
+
+    try {
+      lock = await acquireStoreLock();
+    } catch (err) {
+      lockErr = err;
+    }
+
+    while (
+      lock === "readonly" &&
+      lockErr === undefined &&
+      Date.now() - retryStart < RETRY_DEADLINE_MS
+    ) {
+      const elapsed = Date.now() - retryStart;
+      const remaining = Math.ceil((RETRY_DEADLINE_MS - elapsed) / 1000);
+      process.stderr.write(
+        `[Tandem] store lock held by another process, retrying in 5s... (${remaining}s remaining)\n`,
+      );
+      await new Promise<void>((resolve) => setTimeout(resolve, RETRY_INTERVAL_MS));
+      try {
+        lock = await acquireStoreLock();
+      } catch (err) {
+        lockErr = err;
+      }
+    }
+
+    if (lockErr !== undefined) {
+      // acquireStoreLock is designed to degrade internally, but defend against
+      // future refactors. A hard throw here would lose the same "nothing is
+      // saving" signal, so we still notify.
+      console.error("[Tandem] acquireStoreLock threw:", lockErr);
+      pushNotification({
+        id: `store-lock-error-${Date.now()}`,
+        type: "save-error",
+        severity: "error",
+        message: `Annotation store failed to initialize: ${(lockErr as Error)?.message ?? "unknown error"}. Annotations won't be saved this session.`,
+        dedupKey: "annotation-store:lock-error",
+        timestamp: Date.now(),
+      });
+    } else if (lock === "readonly") {
       console.error(
-        "[Tandem] Annotation store is read-only (another process holds the lock); writes disabled for this session.",
+        "[Tandem] Annotation store is read-only after 30s retry (another process holds the lock); writes disabled for this session.",
       );
       pushNotification({
         id: `store-readonly-${Date.now()}`,
@@ -167,19 +210,6 @@ async function main() {
         timestamp: Date.now(),
       });
     }
-  } catch (err) {
-    // acquireStoreLock is designed to degrade internally, but defend against
-    // future refactors. A hard throw here would lose the same "nothing is
-    // saving" signal, so we still notify.
-    console.error("[Tandem] acquireStoreLock threw:", err);
-    pushNotification({
-      id: `store-lock-error-${Date.now()}`,
-      type: "save-error",
-      severity: "error",
-      message: `Annotation store failed to initialize: ${(err as Error)?.message ?? "unknown error"}. Annotations won't be saved this session.`,
-      dedupKey: "annotation-store:lock-error",
-      timestamp: Date.now(),
-    });
   }
 
   // Clean up sessions older than 30 days

--- a/src/server/mcp/awareness.ts
+++ b/src/server/mcp/awareness.ts
@@ -12,6 +12,7 @@ import type { Annotation, ChatMessage, FlatOffset } from "../../shared/types.js"
 import { TandemModeSchema } from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
 import { docHash } from "../annotations/doc-hash.js";
+import { isStoreReadOnly } from "../annotations/store.js";
 import { MCP_ORIGIN } from "../events/queue.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
 import { collectAnnotations, refreshRange } from "./annotations.js";
@@ -190,6 +191,7 @@ export function registerAwarenessTools(server: McpServer): void {
         summary,
         hasNew,
         mode,
+        storeReadOnly: isStoreReadOnly(),
         userActions,
         userResponses,
         chatMessages,

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -13,6 +13,7 @@ import { headingPrefix } from "../../shared/offsets.js";
 import type { AuthorshipRange } from "../../shared/types.js";
 import { TandemModeSchema, toFlatOffset } from "../../shared/types.js";
 import { generateAuthorshipId } from "../../shared/utils.js";
+import { isStoreReadOnly } from "../annotations/store.js";
 import { MCP_ORIGIN } from "../events/queue.js";
 // Position system
 import { anchoredRange, resolveToElement, validateRange } from "../positions.js";
@@ -553,6 +554,7 @@ export function registerDocumentTools(server: McpServer): void {
         return mcpSuccess({
           running: true,
           mode,
+          storeReadOnly: isStoreReadOnly(),
           activeDocument: active
             ? { documentId: active.id, filePath: active.filePath, format: active.format }
             : null,


### PR DESCRIPTION
## Summary

- Wraps `acquireStoreLock()` in `src/server/index.ts` with a 30-second retry loop — logs to stderr every 5s, fires the user-visible warning toast only once after the deadline is exhausted
- Exports `isStoreReadOnly()` from `src/server/annotations/store.ts` as a getter for the module-scoped `readOnly` flag
- Adds `storeReadOnly: boolean` to `tandem_status` and `tandem_checkInbox` MCP response payloads so Claude Code can detect and surface the degraded state
- Adds `storeReadOnly` prop and persistent warning banner to `SidePanel.svelte` (in-progress Svelte port) using the existing `warningStateColors` infrastructure

## Notes

- No `proper-lockfile` dependency added — the codebase already implements PID-based locking via `fs.open("wx")` + `process.kill(pid, 0)` liveness check
- The "flush open docs on re-acquire" requirement is a no-op at startup (retry loop runs before `restoreOpenDocuments`; `scheduleWrite` drops writes when `readOnly`, so nothing accumulates)
- Client banner lives in `SidePanel.svelte` (Svelte port) only — `SidePanel.tsx` (React) is excluded per migration rules; `storeReadOnly` in MCP payloads is fully live regardless
- Server typecheck (`tsc -p tsconfig.server.json --noEmit`) passes clean; client typecheck errors are pre-existing on `feature/v0.10.0-svelte` (Svelte runes not recognized by plain `tsc`)

## Test plan

- [ ] Start a second Tandem instance while one is running — confirm the second logs "store lock held, retrying in 5s..." to stderr for up to 30s before degrading to read-only
- [ ] Kill the first instance mid-retry — confirm the second acquires the lock and starts normally
- [ ] Call `tandem_status` — confirm `storeReadOnly` field is present (`false` when lock owned, `true` when read-only)
- [ ] Call `tandem_checkInbox` — confirm `storeReadOnly` field is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)