### PR TITLE
chore(ci): fail svelte-check on warnings, not just errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dev:server": "tsx watch src/server/index.ts",
     "build": "npm run typecheck && vite build && tsup",
     "build:server": "tsup",
-    "typecheck": "tsc -p tsconfig.server.json --noEmit && tsc --noEmit && svelte-check --tsconfig ./tsconfig.client.json --threshold error",
+    "typecheck": "tsc -p tsconfig.server.json --noEmit && tsc --noEmit && svelte-check --tsconfig ./tsconfig.client.json --fail-on-warnings",
     "server": "tsx src/server/index.ts",
     "start:server": "node dist/server/index.js",
     "channel": "tsx src/channel/index.ts",


### PR DESCRIPTION
## Summary

Part of #511. **Merge after PR #524 (a11y cleanup) CI is green.**

One-line change: replaces `--threshold error` with `--fail-on-warnings` in the `typecheck` script.

`--threshold error` only filtered *displayed* diagnostics — it did not change the exit code. `--fail-on-warnings` causes svelte-check to exit non-zero when any warnings exist, so future warning regressions block CI immediately.

PR #524 (#511 a11y cleanup) brings the warning count to 0, making this gate safe to enable.

## Test plan

- [ ] Merge PR #524 first and confirm CI green
- [ ] Verify `npm run typecheck` passes on this branch (0 warnings from PR #524)
- [ ] Introduce a deliberate a11y warning locally → confirm CI would fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)