### PR TITLE
fix(server): bake APP_VERSION at build time and harden CHANGELOG path resolution (#509)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,7 @@ Full file-level detail: [docs/architecture.md](docs/architecture.md#file-map)
 ### MCP / Server
 - **Channel shim uses low-level `Server`, not `McpServer`.** The Channels spec requires `import { Server } from '@modelcontextprotocol/sdk/server/index.js'` with explicit `setRequestHandler()` calls. The HTTP MCP server uses the high-level `McpServer` wrapper.
 - **Channel meta keys use underscores only.** The Channels API silently drops meta keys containing hyphens. Use `document_id`, `annotation_id`, `event_type` -- not `document-id`.
-- **`APP_VERSION` is read from `package.json`** via `createRequire` in `src/server/mcp/server.ts`. Don't hardcode version strings. `findChangelogPath()` in the same file walks up from `__dirname` to find `CHANGELOG.md` (handles both `src/server/mcp/` in dev and `dist/server/` in production).
-- **`__MCP_SDK_VERSION__` is injected by tsup at build time.** `require("@modelcontextprotocol/sdk/package.json")` resolves to `dist/cjs/package.json` (a CJS type marker without `version`), not the root. `tsup.config.ts` walks the resolved path back past `dist/` to read the real version. The `typeof` guard in `server.ts` falls back to `"0.0.0-unknown"` in dev/test (no tsup).
+- **`APP_VERSION` is baked at build time** via the `__APP_VERSION__` tsup define in `src/server/mcp/server.ts`. Falls back to `createRequire("../../package.json")` in tsx dev and vitest. `__MCP_SDK_VERSION__` follows the same pattern. `findChangelogPath()` in the same file walks up from `__dirname` to find `CHANGELOG.md` (handles both `src/server/mcp/` in dev and `dist/server/` in production).
 - **MCP must start before Hocuspocus** in stdio mode -- init timeout fires if order is reversed.
 
 ### Client / UI

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -23,16 +23,8 @@ import { registerDocumentTools } from "./document.js";
 import { registerApplyTools } from "./docx-apply.js";
 import { registerNavigationTools } from "./navigation.js";
 
-// __APP_VERSION__ is injected by tsup at build time (see tsup.config.ts, server entry).
-// In test environments (Vitest runs .ts directly, no tsup) and tsx dev the global is
-// absent, so we fall back to createRequire. In the packaged Tauri sidecar
-// ../../package.json does not exist relative to the bundle — the baked define is
-// the only reliable source there.
-//
-// Path layout for the createRequire fallback:
-//   bundled prod:  dist/server/index.js  → ../../package.json  (repo root) ✓
-//   dev / vitest:  src/server/mcp/server.ts → ../../../package.json  (repo root) ✓
-//   Tauri pkg:     resource_dir/dist/server/index.js → no package.json (define wins)
+// Injected by tsup at build time; absent in tsx dev and vitest, where createRequire
+// reads ../../package.json. Tauri pkg has no package.json — define is the only source.
 declare const __APP_VERSION__: string;
 const esmRequire = createRequire(import.meta.url);
 function _readVersionFromDisk(): string {

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -23,17 +23,31 @@ import { registerDocumentTools } from "./document.js";
 import { registerApplyTools } from "./docx-apply.js";
 import { registerNavigationTools } from "./navigation.js";
 
+// __APP_VERSION__ is injected by tsup at build time (see tsup.config.ts, server entry).
+// In test environments (Vitest runs .ts directly, no tsup) and tsx dev the global is
+// absent, so we fall back to createRequire. In the packaged Tauri sidecar
+// ../../package.json does not exist relative to the bundle — the baked define is
+// the only reliable source there.
+//
+// Path layout for the createRequire fallback:
+//   bundled prod:  dist/server/index.js  → ../../package.json  (repo root) ✓
+//   dev / vitest:  src/server/mcp/server.ts → ../../../package.json  (repo root) ✓
+//   Tauri pkg:     resource_dir/dist/server/index.js → no package.json (define wins)
+declare const __APP_VERSION__: string;
 const esmRequire = createRequire(import.meta.url);
-let APP_VERSION = "0.0.0-unknown";
-try {
-  APP_VERSION = (esmRequire("../../package.json") as { version: string }).version;
-} catch (err) {
-  console.error(
-    `[Tandem] Could not read version from package.json: ${err instanceof Error ? err.message : err}`,
-  );
+function _readVersionFromDisk(): string {
+  for (const rel of ["../../package.json", "../../../package.json"]) {
+    try {
+      return (esmRequire(rel) as { version: string }).version;
+    } catch {
+      // try next candidate
+    }
+  }
+  console.error("[Tandem] Could not read version from package.json (all candidates failed)");
+  return "0.0.0-unknown";
 }
-
-export { APP_VERSION };
+export const APP_VERSION: string =
+  typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : _readVersionFromDisk();
 
 // __MCP_SDK_VERSION__ is injected by tsup at build time (see tsup.config.ts).
 // In test environments (Vitest runs .ts directly, no tsup), the global is absent.
@@ -46,11 +60,25 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // dist/server/ → dist/client/ (tsup bundles server into dist/server/index.js)
 const CLIENT_DIST = join(__dirname, "../client");
 
-// Resolve CHANGELOG.md by walking up from __dirname until we find a directory
-// that contains both package.json and CHANGELOG.md. This works in both dev
-// (src/server/mcp/) and production (dist/server/) without hardcoding depth.
-// Capped at 5 levels to avoid runaway traversal.
-function findChangelogPath(startDir: string): string | undefined {
+// Resolve CHANGELOG.md. Checks direct __dirname-relative paths first so the
+// function works reliably in the packaged Tauri sidecar layout, where package.json
+// does NOT exist alongside the bundle (breaking the walk-based anchor).
+//
+// Layout reference:
+//   dev:        src/server/mcp/  →  ../../CHANGELOG.md  (repo root)
+//   bundled:    dist/server/     →  ../../CHANGELOG.md  (repo root)
+//   Tauri pkg:  resource_dir/dist/server/  →  ../../CHANGELOG.md  (resource_dir root)
+//               CHANGELOG.md IS present in resource_dir via tauri.conf.json resources.
+//
+// Falls back to a package.json-anchored walk for unusual layouts.
+export function findChangelogPath(startDir: string): string | undefined {
+  // Fast direct probes (covers all three layouts above)
+  for (const rel of ["../../CHANGELOG.md", "../CHANGELOG.md"]) {
+    const candidate = join(startDir, rel);
+    if (existsSync(candidate)) return candidate;
+  }
+  // Fallback: walk up looking for package.json + CHANGELOG.md co-located
+  // (covers unusual / monorepo layouts). Capped at 5 levels.
   let dir = startDir;
   for (let i = 0; i < 5; i++) {
     const candidate = join(dir, "CHANGELOG.md");

--- a/tests/build/version-baked.test.ts
+++ b/tests/build/version-baked.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Verifies that the real package version is baked into the server bundle by tsup.
+ *
+ * Requires `npm run build` (or `npm run build:server`) to have been run first.
+ * If dist/server/index.js does not exist the test suite is skipped — this is
+ * expected in CI runs that only run unit tests without a prior build step.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = join(__dirname, "../..");
+
+const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as { version: string };
+
+const bundlePath = join(repoRoot, "dist/server/index.js");
+
+describe.skipIf(!existsSync(bundlePath))("version baked into server bundle", () => {
+  it("dist/server/index.js contains the literal version string", () => {
+    const bundle = readFileSync(bundlePath, "utf8");
+    // tsup inlines __APP_VERSION__ as a JSON-stringified string literal,
+    // e.g. "0.10.0" — verify the exact version appears in the bundle.
+    expect(bundle).toContain(JSON.stringify(pkg.version));
+  });
+
+  it("dist/server/index.js does not contain the unknown fallback as APP_VERSION", () => {
+    const bundle = readFileSync(bundlePath, "utf8");
+    // The fallback string should not appear as the assigned value — it may
+    // appear as a string literal in source comments but not as the live value.
+    // We look for the assignment pattern that would indicate the define failed.
+    expect(bundle).not.toMatch(/APP_VERSION\s*=\s*["']0\.0\.0-unknown["']/);
+  });
+});

--- a/tests/server/app-version.test.ts
+++ b/tests/server/app-version.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Tests that APP_VERSION resolves to the real package version at runtime.
+ *
+ * Vitest runs .ts files directly via tsx (no tsup), so __APP_VERSION__ is
+ * not defined — this exercises the createRequire fallback path in server.ts.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { APP_VERSION } from "../../src/server/mcp/server.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf8")) as {
+  version: string;
+};
+
+describe("APP_VERSION", () => {
+  it("matches the version in package.json", () => {
+    expect(APP_VERSION).toBe(pkg.version);
+  });
+
+  it("is not the unknown fallback", () => {
+    expect(APP_VERSION).not.toBe("0.0.0-unknown");
+  });
+});

--- a/tests/server/changelog-path.test.ts
+++ b/tests/server/changelog-path.test.ts
@@ -30,9 +30,8 @@ describe("findChangelogPath", () => {
   });
 
   it("returns undefined for a deeply nested temp-like dir with no CHANGELOG.md ancestors", () => {
-    // Use a path that is unlikely to have CHANGELOG.md anywhere in its hierarchy
-    const result = findChangelogPath("/tmp/no-such-project/a/b/c/d/e/f");
-    // May return undefined or a path — we only assert it does not throw
-    expect(typeof result === "string" || result === undefined).toBe(true);
+    // Use a path that is unlikely to have CHANGELOG.md anywhere in its hierarchy.
+    // Not throwing is sufficient — no assertion needed.
+    findChangelogPath("/tmp/no-such-project/a/b/c/d/e/f");
   });
 });

--- a/tests/server/changelog-path.test.ts
+++ b/tests/server/changelog-path.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for findChangelogPath().
+ *
+ * Packaged Tauri verification is manual — integration test requires an actual build.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { findChangelogPath } from "../../src/server/mcp/server.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+describe("findChangelogPath", () => {
+  it("returns a non-null path when called from the dev tree", () => {
+    // Tests live in tests/server/ — two levels up from src/server/mcp/
+    // but findChangelogPath walks up from __dirname so we pass the actual
+    // server/mcp directory to mirror the runtime call site.
+    const mcpDir = join(__dirname, "../../src/server/mcp");
+    const result = findChangelogPath(mcpDir);
+    expect(result).not.toBeUndefined();
+  });
+
+  it("returned path exists on disk", () => {
+    const mcpDir = join(__dirname, "../../src/server/mcp");
+    const result = findChangelogPath(mcpDir);
+    expect(result).not.toBeUndefined();
+    expect(existsSync(result!)).toBe(true);
+  });
+
+  it("returns undefined for a deeply nested temp-like dir with no CHANGELOG.md ancestors", () => {
+    // Use a path that is unlikely to have CHANGELOG.md anywhere in its hierarchy
+    const result = findChangelogPath("/tmp/no-such-project/a/b/c/d/e/f");
+    // May return undefined or a path — we only assert it does not throw
+    expect(typeof result === "string" || result === undefined).toBe(true);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -41,6 +41,7 @@ export default defineConfig([
     ...selfContained,
     define: {
       __MCP_SDK_VERSION__: JSON.stringify(mcpSdkPkg.version),
+      __APP_VERSION__: JSON.stringify(pkg.version),
     },
   },
   {


### PR DESCRIPTION
## Summary

- Adds `__APP_VERSION__: JSON.stringify(pkg.version)` to the server entry's tsup `define` block, mirroring the existing `__MCP_SDK_VERSION__` pattern
- Changes `APP_VERSION` to prefer the baked define, with a `createRequire` fallback that tries both `../../package.json` (bundled prod layout) and `../../../package.json` (dev/vitest layout)
- `findChangelogPath()` now fast-probes `../../CHANGELOG.md` and `../CHANGELOG.md` relative to `__dirname` before falling back to the `package.json`-anchored walk — covers dev, bundled prod, and packaged Tauri sidecar layouts
- Adds three test files: `tests/server/app-version.test.ts`, `tests/server/changelog-path.test.ts`, `tests/build/version-baked.test.ts`

## Root cause

In the packaged Tauri sidecar, `node-sidecar` runs `resource_dir/dist/server/index.js`. The old `createRequire("../../package.json")` resolves to `resource_dir/package.json` which does not exist — causing the `"0.0.0-unknown"` fallback shown in Settings. The tsup `define` bakes the version as a string literal at build time, making it available regardless of the install layout.

## Test plan

- [x] `npm test -- tests/server/app-version.test.ts tests/server/changelog-path.test.ts` — 5/5 pass
- [x] `npm run typecheck` — clean
- [x] `npm run build:server` — succeeds
- [x] `npm test -- tests/build/version-baked.test.ts` — 2/2 pass (bundle contains `"0.9.1"`)
- [x] `curl http://127.0.0.1:3495/api/info` against built bundle returns `"version":"0.9.1"`
- [ ] Manual: packaged Tauri install — Settings shows real version (requires full `cargo tauri build`)

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)