### PR TITLE
feat(redesign): wire density, high-contrast, and annotation-patterns (#514)

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,13 @@
         --tandem-editor-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         --tandem-scrollbar-track: #f1f5f9;
         --tandem-scrollbar-thumb: #cbd5e1;
+        /* density spacing scale — cozy defaults */
+        --tandem-space-1: 4px;
+        --tandem-space-2: 8px;
+        --tandem-space-3: 12px;
+        --tandem-space-4: 16px;
+        --tandem-space-5: 24px;
+        --tandem-space-6: 32px;
       }
 
       [data-theme="dark"] {
@@ -110,6 +117,36 @@
         --tandem-scrollbar-track: #1e293b;
         --tandem-scrollbar-thumb: #475569;
       }
+
+      /* density spacing scale — cozy is the default (matches :root values) */
+      [data-density="compact"] {
+        --tandem-space-1: 2px;
+        --tandem-space-2: 6px;
+        --tandem-space-3: 10px;
+        --tandem-space-4: 12px;
+        --tandem-space-5: 16px;
+        --tandem-space-6: 24px;
+      }
+
+      [data-density="spacious"] {
+        --tandem-space-1: 6px;
+        --tandem-space-2: 12px;
+        --tandem-space-3: 16px;
+        --tandem-space-4: 24px;
+        --tandem-space-5: 32px;
+        --tandem-space-6: 48px;
+      }
+
+      /* high-contrast overlay — overrides border/fg tokens for WCAG AAA readability.
+         Source order puts this before forced-colors so the OS wins over our toggle. */
+      [data-high-contrast="true"] {
+        --tandem-border: var(--tandem-fg);
+        --tandem-border-strong: var(--tandem-fg);
+        --tandem-fg-muted: var(--tandem-fg);
+      }
+
+      /* [data-annotation-patterns="true"] — pattern-fill hooks for annotation decorations.
+         CSS consumers land in follow-up issues (#518 authorship gutter etc.) */
 
       /* Windows High Contrast — let the OS drive everything. */
       @media (forced-colors: active) {

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -20,9 +20,12 @@ import Editor from "./editor/Editor.svelte";
 import { authorshipPluginKey } from "./editor/extensions/authorship";
 import Toolbar from "./editor/toolbar/Toolbar.svelte";
 import { createAccentHue } from "./hooks/useAccentHue.svelte";
+import { createAnnotationPatterns } from "./hooks/useAnnotationPatterns.svelte";
 import { createConnectionBanner } from "./hooks/useConnectionBanner.svelte";
+import { createDensity } from "./hooks/useDensity.svelte";
 import { createDragResize } from "./hooks/useDragResize.svelte";
 import { createFileDrop } from "./hooks/useFileDrop.svelte";
+import { createHighContrast } from "./hooks/useHighContrast.svelte";
 import { createModeGate } from "./hooks/useModeGate.svelte";
 import { createNotifications } from "./hooks/useNotifications.svelte";
 import { createReviewCompletion } from "./hooks/useReviewCompletion.svelte";
@@ -130,6 +133,9 @@ $effect(() => {
 
 createTheme(() => settingsState.settings.theme);
 createAccentHue(() => settingsState.settings.accentHue);
+createDensity(() => settingsState.settings.density);
+createHighContrast(() => settingsState.settings.highContrast);
+createAnnotationPatterns(() => settingsState.settings.annotationPatterns);
 
 $effect(() => {
   const px = TEXT_SIZE_PX[settingsState.settings.textSize];
@@ -248,7 +254,7 @@ const tutorial = createTutorial(
   <div style="display: flex; flex-direction: column; height: 100vh;">
     {#if yjsSync.serverRestarted}
       <div
-        style="padding: 8px 16px; background: var(--tandem-warning-bg); border-bottom: 1px solid var(--tandem-warning-border); font-size: 13px; color: var(--tandem-warning-fg-strong); text-align: center;"
+        style="padding: var(--tandem-space-2) var(--tandem-space-4); background: var(--tandem-warning-bg); border-bottom: 1px solid var(--tandem-warning-border); font-size: 13px; color: var(--tandem-warning-fg-strong); text-align: center;"
       >
         Server restarted — refreshing documents
       </div>
@@ -283,7 +289,7 @@ const tutorial = createTutorial(
           style={`display: flex; flex-direction: column; width: ${panelLayout.left}px; border-right: 1px solid var(--tandem-border);`}
         >
           <div
-            style="padding: 6px 12px; font-size: 11px; font-weight: 600; color: var(--tandem-fg-muted); border-bottom: 1px solid var(--tandem-border); background: var(--tandem-surface-muted); text-transform: uppercase; letter-spacing: 0.5px;"
+            style="padding: var(--tandem-space-2) var(--tandem-space-3); font-size: 11px; font-weight: 600; color: var(--tandem-fg-muted); border-bottom: 1px solid var(--tandem-border); background: var(--tandem-surface-muted); text-transform: uppercase; letter-spacing: 0.5px;"
           >
             {settingsState.settings.panelOrder === "chat-editor-annotations" ? "Chat" : "Annotations"}
           </div>
@@ -332,7 +338,7 @@ const tutorial = createTutorial(
           style={`display: flex; flex-direction: column; width: ${getRightWidth(panelLayout)}px; border-left: 1px solid var(--tandem-border);`}
         >
           <div
-            style="padding: 6px 12px; font-size: 11px; font-weight: 600; color: var(--tandem-fg-muted); border-bottom: 1px solid var(--tandem-border); background: var(--tandem-surface-muted); text-transform: uppercase; letter-spacing: 0.5px;"
+            style="padding: var(--tandem-space-2) var(--tandem-space-3); font-size: 11px; font-weight: 600; color: var(--tandem-fg-muted); border-bottom: 1px solid var(--tandem-border); background: var(--tandem-surface-muted); text-transform: uppercase; letter-spacing: 0.5px;"
           >
             {settingsState.settings.panelOrder === "chat-editor-annotations" ? "Annotations" : "Chat"}
           </div>
@@ -536,7 +542,7 @@ const tutorial = createTutorial(
       <button
         data-testid="annotations-tab"
         onclick={() => (showChat = false)}
-        style={`flex: 1; padding: 8px; font-size: 12px; font-weight: ${showChat ? 400 : 600}; border: none; border-bottom: ${showChat ? "none" : "2px solid var(--tandem-accent)"}; background: transparent; cursor: pointer; color: ${showChat ? "var(--tandem-fg-muted)" : "var(--tandem-accent)"}; position: relative;`}
+        style={`flex: 1; padding: var(--tandem-space-2); font-size: 12px; font-weight: ${showChat ? 400 : 600}; border: none; border-bottom: ${showChat ? "none" : "2px solid var(--tandem-accent)"}; background: transparent; cursor: pointer; color: ${showChat ? "var(--tandem-fg-muted)" : "var(--tandem-accent)"}; position: relative;`}
       >
         Annotations
         {#if showChat && pendingAnnotationBadge > 0}
@@ -551,7 +557,7 @@ const tutorial = createTutorial(
         data-testid="chat-tab"
         onmousedown={captureSelectionForChat}
         onclick={() => (showChat = true)}
-        style={`flex: 1; padding: 8px; font-size: 12px; font-weight: ${showChat ? 600 : 400}; border: none; border-bottom: ${showChat ? "2px solid var(--tandem-accent)" : "none"}; background: transparent; cursor: pointer; color: ${showChat ? "var(--tandem-accent)" : "var(--tandem-fg-muted)"}; position: relative;`}
+        style={`flex: 1; padding: var(--tandem-space-2); font-size: 12px; font-weight: ${showChat ? 600 : 400}; border: none; border-bottom: ${showChat ? "2px solid var(--tandem-accent)" : "none"}; background: transparent; cursor: pointer; color: ${showChat ? "var(--tandem-accent)" : "var(--tandem-fg-muted)"}; position: relative;`}
       >
         Chat
       </button>

--- a/src/client/components/AccessibilitySettings.svelte
+++ b/src/client/components/AccessibilitySettings.svelte
@@ -32,3 +32,41 @@ const sectionLabelStyle =
     <span style="color: var(--tandem-author-claude);">Claude</span>
   </div>
 </div>
+
+<div>
+  <div style={sectionLabelStyle}>Contrast</div>
+  <label
+    data-testid="high-contrast-toggle"
+    style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+  >
+    <input
+      type="checkbox"
+      checked={settings.highContrast}
+      onchange={(e) => onUpdate({ highContrast: (e.target as HTMLInputElement).checked })}
+      style="accent-color: var(--tandem-accent);"
+    />
+    <span>High contrast</span>
+  </label>
+  <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-top: 4px;">
+    Increases border and text contrast for improved readability.
+  </div>
+</div>
+
+<div>
+  <div style={sectionLabelStyle}>Annotation Patterns</div>
+  <label
+    data-testid="annotation-patterns-toggle"
+    style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+  >
+    <input
+      type="checkbox"
+      checked={settings.annotationPatterns}
+      onchange={(e) => onUpdate({ annotationPatterns: (e.target as HTMLInputElement).checked })}
+      style="accent-color: var(--tandem-accent);"
+    />
+    <span>Use pattern fills for annotations</span>
+  </label>
+  <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-top: 4px;">
+    Adds visual patterns to annotation decorations (color-blind friendly).
+  </div>
+</div>

--- a/src/client/components/AccessibilitySettings.svelte
+++ b/src/client/components/AccessibilitySettings.svelte
@@ -16,7 +16,7 @@ const sectionLabelStyle =
   <div style={sectionLabelStyle}>Authorship</div>
   <label
     data-testid="authorship-toggle"
-    style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+    style="display: flex; align-items: center; gap: var(--tandem-space-2); cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
   >
     <input
       type="checkbox"
@@ -26,7 +26,7 @@ const sectionLabelStyle =
     />
     <span>Show who wrote what</span>
   </label>
-  <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-top: 4px;">
+  <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-top: var(--tandem-space-1);">
     Highlights text by author:
     <span style="color: var(--tandem-author-user);">you</span> /
     <span style="color: var(--tandem-author-claude);">Claude</span>
@@ -37,7 +37,7 @@ const sectionLabelStyle =
   <div style={sectionLabelStyle}>Contrast</div>
   <label
     data-testid="high-contrast-toggle"
-    style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+    style="display: flex; align-items: center; gap: var(--tandem-space-2); cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
   >
     <input
       type="checkbox"
@@ -47,7 +47,7 @@ const sectionLabelStyle =
     />
     <span>High contrast</span>
   </label>
-  <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-top: 4px;">
+  <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-top: var(--tandem-space-1);">
     Increases border and text contrast for improved readability.
   </div>
 </div>
@@ -56,7 +56,7 @@ const sectionLabelStyle =
   <div style={sectionLabelStyle}>Annotation Patterns</div>
   <label
     data-testid="annotation-patterns-toggle"
-    style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+    style="display: flex; align-items: center; gap: var(--tandem-space-2); cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
   >
     <input
       type="checkbox"
@@ -66,7 +66,7 @@ const sectionLabelStyle =
     />
     <span>Use pattern fills for annotations</span>
   </label>
-  <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-top: 4px;">
+  <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-top: var(--tandem-space-1);">
     Adds visual patterns to annotation decorations (color-blind friendly).
   </div>
 </div>

--- a/src/client/components/AppearanceSettings.svelte
+++ b/src/client/components/AppearanceSettings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { createRadioGroup } from "../hooks/useRadioGroup.svelte";
 import type {
+  Density,
   EditorFont,
   LayoutMode,
   PanelOrder,
@@ -43,7 +44,7 @@ const LAYOUT_OPTIONS: Array<{ value: LayoutMode; label: string; icon: string }> 
 function cardStyle(selected: boolean, disabled?: boolean): string {
   return [
     "flex: 1;",
-    "padding: 8px;",
+    "padding: var(--tandem-space-2);",
     "min-height: 24px;",
     `border: 2px solid ${selected ? "var(--tandem-accent)" : "var(--tandem-border)"};`,
     "border-radius: 6px;",
@@ -89,6 +90,11 @@ const editorFontRg = createRadioGroup<EditorFont>(
   ["sans", "serif", "mono"] as const,
   (f) => onUpdate({ editorFont: f }),
 );
+const densityRg = createRadioGroup<Density>(
+  () => settings.density,
+  ["compact", "cozy", "spacious"] as const,
+  (d) => onUpdate({ density: d }),
+);
 </script>
 
 <!-- Theme -->
@@ -99,7 +105,7 @@ const editorFontRg = createRadioGroup<EditorFont>(
     aria-labelledby="settings-theme-label"
     tabindex="0"
     onkeydown={themeRg.handleKeyDown}
-    style="display: flex; gap: 8px;"
+    style="display: flex; gap: var(--tandem-space-2);"
   >
     {#each (["light", "dark", "system"] as const) as t (t)}
       <button
@@ -159,7 +165,7 @@ const editorFontRg = createRadioGroup<EditorFont>(
       aria-labelledby="settings-default-tab-label"
       tabindex="0"
       onkeydown={primaryTabRg.handleKeyDown}
-      style="display: flex; gap: 8px;"
+      style="display: flex; gap: var(--tandem-space-2);"
     >
       <button
         data-testid="default-tab-chat-btn"
@@ -194,7 +200,7 @@ const editorFontRg = createRadioGroup<EditorFont>(
       aria-labelledby="settings-panel-order-label"
       tabindex="0"
       onkeydown={panelOrderRg.handleKeyDown}
-      style="display: flex; gap: 8px;"
+      style="display: flex; gap: var(--tandem-space-2);"
     >
       <button
         data-testid="panel-order-cea-btn"
@@ -228,7 +234,7 @@ const editorFontRg = createRadioGroup<EditorFont>(
     aria-labelledby="settings-text-size-label"
     tabindex="0"
     onkeydown={textSizeRg.handleKeyDown}
-    style="display: flex; gap: 8px;"
+    style="display: flex; gap: var(--tandem-space-2);"
   >
     {#each (["s", "m", "l"] as const) as size (size)}
       <button
@@ -278,7 +284,7 @@ const editorFontRg = createRadioGroup<EditorFont>(
     aria-labelledby="settings-editor-font-label"
     tabindex="0"
     onkeydown={editorFontRg.handleKeyDown}
-    style="display: flex; gap: 8px;"
+    style="display: flex; gap: var(--tandem-space-2);"
   >
     {#each ([["sans", "Sans-serif"], ["serif", "Serif"], ["mono", "Monospace"]] as const) as [value, label] (value)}
       <button
@@ -288,6 +294,31 @@ const editorFontRg = createRadioGroup<EditorFont>(
         tabindex={editorFontRg.tabIndexFor(value)}
         onclick={() => onUpdate({ editorFont: value })}
         style={cardStyle(settings.editorFont === value)}
+      >
+        {label}
+      </button>
+    {/each}
+  </div>
+</div>
+
+<!-- Density -->
+<div>
+  <div id="settings-density-label" style={sectionLabelStyle}>Spacing Density</div>
+  <div
+    role="radiogroup"
+    aria-labelledby="settings-density-label"
+    tabindex="0"
+    onkeydown={densityRg.handleKeyDown}
+    style="display: flex; gap: var(--tandem-space-2);"
+  >
+    {#each ([["compact", "Compact"], ["cozy", "Cozy"], ["spacious", "Spacious"]] as const) as [value, label] (value)}
+      <button
+        data-testid={`density-${value}-btn`}
+        role="radio"
+        aria-checked={settings.density === value}
+        tabindex={densityRg.tabIndexFor(value)}
+        onclick={() => onUpdate({ density: value })}
+        style={cardStyle(settings.density === value)}
       >
         {label}
       </button>

--- a/src/client/components/SettingsPopover.svelte
+++ b/src/client/components/SettingsPopover.svelte
@@ -151,7 +151,7 @@ const sectionLabelStyle =
     aria-modal="true"
     aria-labelledby={HEADING_ID}
     tabindex={-1}
-    style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); max-height: calc(100vh - 32px); overflow-y: auto; width: {POPOVER_WIDTH}px; background: var(--tandem-surface); color: var(--tandem-fg); border: 1px solid var(--tandem-border); border-radius: 8px; box-shadow: 0 4px 24px rgba(0,0,0,0.12); padding: 16px; z-index: 9999; display: flex; flex-direction: column; gap: 14px; outline: none;"
+    style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); max-height: calc(100vh - 32px); overflow-y: auto; width: {POPOVER_WIDTH}px; background: var(--tandem-surface); color: var(--tandem-fg); border: 1px solid var(--tandem-border); border-radius: 8px; box-shadow: 0 4px 24px rgba(0,0,0,0.12); padding: var(--tandem-space-4); z-index: 9999; display: flex; flex-direction: column; gap: 14px; outline: none;"
   >
     <!-- Header -->
     <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -233,7 +233,7 @@ const sectionLabelStyle =
         data-testid="view-changelog-btn"
         onclick={() => void handleViewChangelog()}
         disabled={changelogLoading || appInfo.loading}
-        style="width: 100%; padding: 8px; font-size: 13px; font-weight: 500; border: 1px solid var(--tandem-border-strong); border-radius: 4px; cursor: {changelogLoading || appInfo.loading ? 'not-allowed' : 'pointer'}; background: var(--tandem-surface-muted); color: var(--tandem-fg); opacity: {changelogLoading || appInfo.loading ? 0.6 : 1};"
+        style="width: 100%; padding: var(--tandem-space-2); font-size: 13px; font-weight: 500; border: 1px solid var(--tandem-border-strong); border-radius: 4px; cursor: {changelogLoading || appInfo.loading ? 'not-allowed' : 'pointer'}; background: var(--tandem-surface-muted); color: var(--tandem-fg); opacity: {changelogLoading || appInfo.loading ? 0.6 : 1};"
       >
         {changelogLoading ? "Opening…" : "View Changelog"}
       </button>
@@ -250,7 +250,7 @@ const sectionLabelStyle =
         href="https://github.com/bloknayrb/tandem/issues/new"
         target="_blank"
         rel="noreferrer"
-        style="display: block; width: 100%; padding: 8px; font-size: 13px; font-weight: 500; border: 1px solid var(--tandem-border-strong); border-radius: 4px; background: var(--tandem-surface-muted); color: var(--tandem-fg); text-align: center; text-decoration: none; box-sizing: border-box;"
+        style="display: block; width: 100%; padding: var(--tandem-space-2); font-size: 13px; font-weight: 500; border: 1px solid var(--tandem-border-strong); border-radius: 4px; background: var(--tandem-surface-muted); color: var(--tandem-fg); text-align: center; text-decoration: none; box-sizing: border-box;"
       >
         Report a bug
       </a>

--- a/src/client/components/ToastContainer.svelte
+++ b/src/client/components/ToastContainer.svelte
@@ -45,7 +45,7 @@ let { toasts, onDismiss }: Props = $props();
 {#if toasts.length > 0}
   <div
     data-testid="toast-container"
-    style="position: fixed; bottom: 40px; right: 16px; z-index: 1000; display: flex; flex-direction: column; gap: 8px; max-width: 360px; pointer-events: none;"
+    style="position: fixed; bottom: 40px; right: var(--tandem-space-4); z-index: 1000; display: flex; flex-direction: column; gap: var(--tandem-space-2); max-width: 360px; pointer-events: none;"
   >
     {#each toasts as toast (toast.id)}
       {@const borderColor = SEVERITY_TOKENS[toast.severity]}

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -168,8 +168,8 @@ const canAnnotate = $derived(!!editor && !!ydoc && hasSelection);
 </script>
 
 <div
-  style="display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
-    min-height: 42px; padding: 8px 16px;
+  style="display: flex; flex-wrap: wrap; align-items: center; gap: var(--tandem-space-2);
+    min-height: 42px; padding: var(--tandem-space-2) var(--tandem-space-4);
     border-bottom: 1px solid var(--tandem-border);
     background: var(--tandem-surface-muted); user-select: none;"
 >
@@ -241,7 +241,7 @@ const canAnnotate = $derived(!!editor && !!ydoc && hasSelection);
   {/if}
 
   <div style="flex: 1;"></div>
-  <div style="display: flex; align-items: center; gap: 12px;">
+  <div style="display: flex; align-items: center; gap: var(--tandem-space-3);">
     {#if (heldCount ?? 0) > 0}
       <span
         data-testid="held-badge"
@@ -266,7 +266,7 @@ const canAnnotate = $derived(!!editor && !!ydoc && hasSelection);
         aria-keyshortcuts="Control+Comma"
         style="background: none; border: 1px solid var(--tandem-border-strong);
           border-radius: 4px; cursor: pointer; color: var(--tandem-fg-muted);
-          font-size: 13px; padding: 4px 12px; min-height: 24px;"
+          font-size: 13px; padding: var(--tandem-space-1) var(--tandem-space-3); min-height: 24px;"
       >
         Settings
       </button>

--- a/src/client/hooks/useAnnotationPatterns.svelte.ts
+++ b/src/client/hooks/useAnnotationPatterns.svelte.ts
@@ -1,0 +1,15 @@
+import { applyAnnotationPatterns } from "./useAnnotationPatterns.js";
+
+export { applyAnnotationPatterns } from "./useAnnotationPatterns.js";
+
+/**
+ * Svelte 5 effect that applies [data-annotation-patterns] to <html> whenever
+ * the setting changes. Accepts a getter so callers with $state values propagate
+ * reactively.
+ */
+export function createAnnotationPatterns(getEnabled: () => boolean): void {
+  $effect(() => {
+    const cleanup = applyAnnotationPatterns(getEnabled());
+    return cleanup;
+  });
+}

--- a/src/client/hooks/useAnnotationPatterns.ts
+++ b/src/client/hooks/useAnnotationPatterns.ts
@@ -1,0 +1,11 @@
+export function applyAnnotationPatterns(
+  enabled: boolean,
+  root: HTMLElement = document.documentElement,
+): () => void {
+  if (enabled) {
+    root.setAttribute("data-annotation-patterns", "true");
+  } else {
+    root.removeAttribute("data-annotation-patterns");
+  }
+  return () => root.removeAttribute("data-annotation-patterns");
+}

--- a/src/client/hooks/useDensity.svelte.ts
+++ b/src/client/hooks/useDensity.svelte.ts
@@ -1,0 +1,16 @@
+import { applyDensity } from "./useDensity.js";
+import type { Density } from "./useTandemSettings.js";
+
+export { applyDensity } from "./useDensity.js";
+
+/**
+ * Svelte 5 effect that applies [data-density] to <html> whenever the
+ * density setting changes. Accepts a getter so callers with $state values
+ * propagate reactively.
+ */
+export function createDensity(getDensity: () => Density): void {
+  $effect(() => {
+    const cleanup = applyDensity(getDensity());
+    return cleanup;
+  });
+}

--- a/src/client/hooks/useDensity.ts
+++ b/src/client/hooks/useDensity.ts
@@ -1,0 +1,9 @@
+import type { Density } from "./useTandemSettings.js";
+
+export function applyDensity(
+  density: Density,
+  root: HTMLElement = document.documentElement,
+): () => void {
+  root.setAttribute("data-density", density);
+  return () => root.removeAttribute("data-density");
+}

--- a/src/client/hooks/useHighContrast.svelte.ts
+++ b/src/client/hooks/useHighContrast.svelte.ts
@@ -1,0 +1,15 @@
+import { applyHighContrast } from "./useHighContrast.js";
+
+export { applyHighContrast } from "./useHighContrast.js";
+
+/**
+ * Svelte 5 effect that applies [data-high-contrast] to <html> whenever the
+ * setting changes. Accepts a getter so callers with $state values propagate
+ * reactively.
+ */
+export function createHighContrast(getEnabled: () => boolean): void {
+  $effect(() => {
+    const cleanup = applyHighContrast(getEnabled());
+    return cleanup;
+  });
+}

--- a/src/client/hooks/useHighContrast.ts
+++ b/src/client/hooks/useHighContrast.ts
@@ -1,0 +1,11 @@
+export function applyHighContrast(
+  enabled: boolean,
+  root: HTMLElement = document.documentElement,
+): () => void {
+  if (enabled) {
+    root.setAttribute("data-high-contrast", "true");
+  } else {
+    root.removeAttribute("data-high-contrast");
+  }
+  return () => root.removeAttribute("data-high-contrast");
+}

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -125,7 +125,7 @@ function handleKeyDown(e: KeyboardEvent) {
   role="listitem"
   aria-label={cardLabel}
   aria-current={isReviewTarget ? "true" : undefined}
-  style="padding: var(--tandem-space-2) 10px; margin-bottom: var(--tandem-space-2); border-left: 3px solid {borderColor}; background: {cardBg}; border-radius: 0 4px 4px 0; font-size: 13px; opacity: {isPending
+  style="padding: var(--tandem-space-2) var(--tandem-space-3); margin-bottom: var(--tandem-space-2); border-left: 3px solid {borderColor}; background: {cardBg}; border-radius: 0 4px 4px 0; font-size: 13px; opacity: {isPending
     ? 1
     : 0.6}; cursor: {onClick
     ? 'pointer'

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -125,7 +125,7 @@ function handleKeyDown(e: KeyboardEvent) {
   role="listitem"
   aria-label={cardLabel}
   aria-current={isReviewTarget ? "true" : undefined}
-  style="padding: 8px 10px; margin-bottom: 6px; border-left: 3px solid {borderColor}; background: {cardBg}; border-radius: 0 4px 4px 0; font-size: 13px; opacity: {isPending
+  style="padding: var(--tandem-space-2) 10px; margin-bottom: var(--tandem-space-2); border-left: 3px solid {borderColor}; background: {cardBg}; border-radius: 0 4px 4px 0; font-size: 13px; opacity: {isPending
     ? 1
     : 0.6}; cursor: {onClick
     ? 'pointer'

--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -167,10 +167,10 @@ function toggleAnchorExpand(msgId: string) {
 >
   <!-- Header -->
   <div
-    style="padding: 12px 16px; border-bottom: 1px solid var(--tandem-border); font-weight: 600; font-size: 14px; display: flex; justify-content: space-between; align-items: center;"
+    style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border); font-weight: 600; font-size: 14px; display: flex; justify-content: space-between; align-items: center;"
   >
     Chat
-    <div style="display: flex; align-items: center; gap: 8px;">
+    <div style="display: flex; align-items: center; gap: var(--tandem-space-2);">
       {#if unreadCount > 0}
         <span
           style="background: var(--tandem-accent); color: var(--tandem-accent-fg); border-radius: 10px; padding: 2px 8px; font-size: 11px;"
@@ -192,7 +192,7 @@ function toggleAnchorExpand(msgId: string) {
   </div>
 
   <!-- Messages -->
-  <div style="flex: 1; overflow: auto; padding: 12px; min-height: 0;">
+  <div style="flex: 1; overflow: auto; padding: var(--tandem-space-3); min-height: 0;">
     {#if messages.length === 0}
       <div
         style="color: var(--tandem-fg-subtle); font-size: 13px; text-align: center; margin-top: 24px;"
@@ -202,7 +202,7 @@ function toggleAnchorExpand(msgId: string) {
     {/if}
     {#each messages as msg (msg.id)}
       <div
-        style="margin-bottom: 12px; padding: 8px 12px; border-radius: 8px; background: {msg.author ===
+        style="margin-bottom: var(--tandem-space-3); padding: var(--tandem-space-2) var(--tandem-space-3); border-radius: 8px; background: {msg.author ===
         'user'
           ? 'var(--tandem-accent-bg)'
           : 'var(--tandem-surface)'}; border: 1px solid {msg.author === 'user'
@@ -262,7 +262,7 @@ function toggleAnchorExpand(msgId: string) {
 
     {#if claudeActive}
       <div
-        style="padding: 8px 12px; margin-bottom: 8px; font-size: 12px; color: var(--tandem-author-claude); display: flex; align-items: center; gap: 8px;"
+        style="padding: var(--tandem-space-2) var(--tandem-space-3); margin-bottom: var(--tandem-space-2); font-size: 12px; color: var(--tandem-author-claude); display: flex; align-items: center; gap: var(--tandem-space-2);"
       >
         <span style="display: inline-flex; gap: 3px;">
           {#each TYPING_DOT_DELAYS as delay (delay)}
@@ -280,7 +280,7 @@ function toggleAnchorExpand(msgId: string) {
   <!-- Anchor indicator -->
   {#if capturedAnchor}
     <div
-      style="padding: 4px 12px; background: var(--tandem-accent-bg); border-top: 1px solid var(--tandem-accent-border); font-size: 11px; color: var(--tandem-accent-fg-strong); display: flex; justify-content: space-between; align-items: center;"
+      style="padding: var(--tandem-space-1) var(--tandem-space-3); background: var(--tandem-accent-bg); border-top: 1px solid var(--tandem-accent-border); font-size: 11px; color: var(--tandem-accent-fg-strong); display: flex; justify-content: space-between; align-items: center;"
     >
       <span>
         with selection: &ldquo;{capturedAnchor.textSnapshot.slice(0, 40)}{capturedAnchor.textSnapshot
@@ -299,7 +299,7 @@ function toggleAnchorExpand(msgId: string) {
 
   <!-- Input area -->
   <div
-    style="padding: 8px 12px; border-top: 1px solid var(--tandem-border); display: flex; gap: 8px;"
+    style="padding: var(--tandem-space-2) var(--tandem-space-3); border-top: 1px solid var(--tandem-border); display: flex; gap: var(--tandem-space-2);"
   >
     <textarea
       bind:this={internalInputEl}
@@ -308,12 +308,12 @@ function toggleAnchorExpand(msgId: string) {
       onkeydown={handleKeyDown}
       placeholder="Message Claude..."
       rows={2}
-      style="flex: 1; padding: 8px; border: 1px solid var(--tandem-border-strong); border-radius: 6px; font-size: 13px; resize: none; outline: none; font-family: inherit; background: var(--tandem-surface); color: var(--tandem-fg);"
+      style="flex: 1; padding: var(--tandem-space-2); border: 1px solid var(--tandem-border-strong); border-radius: 6px; font-size: 13px; resize: none; outline: none; font-family: inherit; background: var(--tandem-surface); color: var(--tandem-fg);"
     ></textarea>
     <button
       onclick={sendMessage}
       disabled={!inputText.trim()}
-      style="padding: 8px 12px; background: {inputText.trim()
+      style="padding: var(--tandem-space-2) var(--tandem-space-3); background: {inputText.trim()
         ? 'var(--tandem-accent)'
         : 'var(--tandem-border-strong)'}; color: {inputText.trim()
         ? 'var(--tandem-accent-fg)'

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -291,7 +291,7 @@ function handleBulk(status: "accepted" | "dismissed") {
   <!-- Held-annotation banner -->
   {#if heldCount > 0}
     <div
-      style="padding: 6px 16px; background: {warningStateColors.background}; border-bottom: 1px solid {warningStateColors.border}; font-size: 12px; color: {warningStateColors.color}; display: flex; justify-content: space-between; align-items: center;"
+      style="padding: var(--tandem-space-2) var(--tandem-space-4); background: {warningStateColors.background}; border-bottom: 1px solid {warningStateColors.border}; font-size: 12px; color: {warningStateColors.color}; display: flex; justify-content: space-between; align-items: center;"
     >
       <span data-testid="held-banner">
         {heldCount} annotation{heldCount !== 1 ? "s" : ""} held
@@ -306,7 +306,7 @@ function handleBulk(status: "accepted" | "dismissed") {
   {/if}
 
   <!-- Header -->
-  <div style="padding: 12px 16px; border-bottom: 1px solid var(--tandem-border);">
+  <div style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border);">
     <div style="display: flex; justify-content: space-between; align-items: center;">
       <h3 style="font-size: 14px; font-weight: 600; margin: 0;">
         Annotations
@@ -357,7 +357,7 @@ function handleBulk(status: "accepted" | "dismissed") {
   <!-- Review mode indicator -->
   {#if reviewMode && review.getReviewTargets().length > 0}
     <div
-      style="padding: 8px 16px; background: var(--tandem-accent-bg); border-bottom: 1px solid var(--tandem-border); font-size: 12px; color: var(--tandem-accent-fg-strong);"
+      style="padding: var(--tandem-space-2) var(--tandem-space-4); background: var(--tandem-accent-bg); border-bottom: 1px solid var(--tandem-border); font-size: 12px; color: var(--tandem-accent-fg-strong);"
     >
       <div aria-live="polite" style="font-weight: 600; margin-bottom: 2px;">
         Reviewing {review.getReviewIndex() + 1} / {review.getReviewTargets().length}
@@ -385,7 +385,7 @@ function handleBulk(status: "accepted" | "dismissed") {
   />
 
   <!-- Apply as tracked changes (docx only) -->
-  <div style="padding: 4px 16px 0;">
+  <div style="padding: var(--tandem-space-1) var(--tandem-space-4) 0;">
     <ApplyChangesButton {annotations} {activeDocFormat} {documentId} />
   </div>
 
@@ -403,7 +403,7 @@ function handleBulk(status: "accepted" | "dismissed") {
   />
 
   <!-- Annotation list -->
-  <div style="padding: 8px 16px; flex: 1;" role="list" aria-label="Annotations">
+  <div style="padding: var(--tandem-space-2) var(--tandem-space-4); flex: 1;" role="list" aria-label="Annotations">
     {#if filteredData.filtered.length === 0}
       <p role="status" style="font-size: 13px; color: var(--tandem-fg-subtle); margin-top: 8px;">
         {hasFilters

--- a/tests/client/useAnnotationPatterns.test.ts
+++ b/tests/client/useAnnotationPatterns.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { applyAnnotationPatterns } from "../../src/client/hooks/useAnnotationPatterns";
+
+/**
+ * Minimal HTMLElement stub that tracks attributes.
+ */
+function makeEl() {
+  const attrs = new Map<string, string>();
+  return {
+    setAttribute: (name: string, value: string) => attrs.set(name, value),
+    removeAttribute: (name: string) => attrs.delete(name),
+    getAttribute: (name: string) => attrs.get(name) ?? null,
+  } as unknown as HTMLElement;
+}
+
+describe("applyAnnotationPatterns", () => {
+  let el: HTMLElement;
+  beforeEach(() => {
+    el = makeEl();
+  });
+
+  it("sets data-annotation-patterns to 'true' when enabled", () => {
+    applyAnnotationPatterns(true, el);
+    expect(el.getAttribute("data-annotation-patterns")).toBe("true");
+  });
+
+  it("leaves attribute absent when disabled", () => {
+    applyAnnotationPatterns(false, el);
+    expect(el.getAttribute("data-annotation-patterns")).toBeNull();
+  });
+
+  it("removes attribute when toggled from true to false", () => {
+    applyAnnotationPatterns(true, el);
+    expect(el.getAttribute("data-annotation-patterns")).toBe("true");
+    applyAnnotationPatterns(false, el);
+    expect(el.getAttribute("data-annotation-patterns")).toBeNull();
+  });
+
+  it("cleanup removes data-annotation-patterns", () => {
+    const cleanup = applyAnnotationPatterns(true, el);
+    expect(el.getAttribute("data-annotation-patterns")).toBe("true");
+    cleanup();
+    expect(el.getAttribute("data-annotation-patterns")).toBeNull();
+  });
+
+  it("cleanup is idempotent when attribute was not set", () => {
+    const cleanup = applyAnnotationPatterns(false, el);
+    expect(el.getAttribute("data-annotation-patterns")).toBeNull();
+    cleanup();
+    expect(el.getAttribute("data-annotation-patterns")).toBeNull();
+  });
+
+  it("defaults to document.documentElement when no element passed", () => {
+    const attrs = new Map<string, string>();
+    const root = {
+      setAttribute: (name: string, value: string) => attrs.set(name, value),
+      removeAttribute: (name: string) => attrs.delete(name),
+      getAttribute: (name: string) => attrs.get(name) ?? null,
+    };
+    vi.stubGlobal("document", { documentElement: root });
+    applyAnnotationPatterns(true);
+    expect(attrs.get("data-annotation-patterns")).toBe("true");
+    vi.unstubAllGlobals();
+  });
+});

--- a/tests/client/useDensity.test.ts
+++ b/tests/client/useDensity.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { applyDensity } from "../../src/client/hooks/useDensity";
+
+/**
+ * Minimal HTMLElement stub that tracks dataset/attribute values,
+ * mirroring the pattern used in useTheme.test.ts.
+ */
+function makeEl() {
+  const attrs = new Map<string, string>();
+  return {
+    setAttribute: (name: string, value: string) => attrs.set(name, value),
+    removeAttribute: (name: string) => attrs.delete(name),
+    getAttribute: (name: string) => attrs.get(name) ?? null,
+  } as unknown as HTMLElement;
+}
+
+describe("applyDensity", () => {
+  let el: HTMLElement;
+  beforeEach(() => {
+    el = makeEl();
+  });
+
+  it("sets data-density to 'compact'", () => {
+    applyDensity("compact", el);
+    expect(el.getAttribute("data-density")).toBe("compact");
+  });
+
+  it("sets data-density to 'spacious'", () => {
+    applyDensity("spacious", el);
+    expect(el.getAttribute("data-density")).toBe("spacious");
+  });
+
+  it("sets data-density to 'cozy'", () => {
+    applyDensity("cozy", el);
+    expect(el.getAttribute("data-density")).toBe("cozy");
+  });
+
+  it("cleanup removes data-density", () => {
+    const cleanup = applyDensity("compact", el);
+    expect(el.getAttribute("data-density")).toBe("compact");
+    cleanup();
+    expect(el.getAttribute("data-density")).toBeNull();
+  });
+
+  it("switching density updates the attribute", () => {
+    applyDensity("compact", el);
+    expect(el.getAttribute("data-density")).toBe("compact");
+    applyDensity("spacious", el);
+    expect(el.getAttribute("data-density")).toBe("spacious");
+  });
+
+  it("defaults to document.documentElement when no element passed", () => {
+    const attrs = new Map<string, string>();
+    const root = {
+      setAttribute: (name: string, value: string) => attrs.set(name, value),
+      removeAttribute: (name: string) => attrs.delete(name),
+      getAttribute: (name: string) => attrs.get(name) ?? null,
+    };
+    vi.stubGlobal("document", { documentElement: root });
+    applyDensity("spacious");
+    expect(attrs.get("data-density")).toBe("spacious");
+    vi.unstubAllGlobals();
+  });
+});

--- a/tests/client/useHighContrast.test.ts
+++ b/tests/client/useHighContrast.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { applyHighContrast } from "../../src/client/hooks/useHighContrast";
+
+/**
+ * Minimal HTMLElement stub that tracks attributes.
+ */
+function makeEl() {
+  const attrs = new Map<string, string>();
+  return {
+    setAttribute: (name: string, value: string) => attrs.set(name, value),
+    removeAttribute: (name: string) => attrs.delete(name),
+    getAttribute: (name: string) => attrs.get(name) ?? null,
+  } as unknown as HTMLElement;
+}
+
+describe("applyHighContrast", () => {
+  let el: HTMLElement;
+  beforeEach(() => {
+    el = makeEl();
+  });
+
+  it("sets data-high-contrast to 'true' when enabled", () => {
+    applyHighContrast(true, el);
+    expect(el.getAttribute("data-high-contrast")).toBe("true");
+  });
+
+  it("leaves attribute absent when disabled", () => {
+    applyHighContrast(false, el);
+    expect(el.getAttribute("data-high-contrast")).toBeNull();
+  });
+
+  it("removes attribute when toggled from true to false", () => {
+    applyHighContrast(true, el);
+    expect(el.getAttribute("data-high-contrast")).toBe("true");
+    applyHighContrast(false, el);
+    expect(el.getAttribute("data-high-contrast")).toBeNull();
+  });
+
+  it("cleanup removes data-high-contrast", () => {
+    const cleanup = applyHighContrast(true, el);
+    expect(el.getAttribute("data-high-contrast")).toBe("true");
+    cleanup();
+    expect(el.getAttribute("data-high-contrast")).toBeNull();
+  });
+
+  it("cleanup is idempotent when attribute was not set", () => {
+    const cleanup = applyHighContrast(false, el);
+    expect(el.getAttribute("data-high-contrast")).toBeNull();
+    cleanup();
+    expect(el.getAttribute("data-high-contrast")).toBeNull();
+  });
+
+  it("defaults to document.documentElement when no element passed", () => {
+    const attrs = new Map<string, string>();
+    const root = {
+      setAttribute: (name: string, value: string) => attrs.set(name, value),
+      removeAttribute: (name: string) => attrs.delete(name),
+      getAttribute: (name: string) => attrs.get(name) ?? null,
+    };
+    vi.stubGlobal("document", { documentElement: root });
+    applyHighContrast(true);
+    expect(attrs.get("data-high-contrast")).toBe("true");
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--tandem-space-1..6` CSS custom property density scale to `:root` with `[data-density="compact"]` and `[data-density="spacious"]` overrides, placing cozy as the default
- Adds `[data-high-contrast="true"]` overlay that tightens `--tandem-border`, `--tandem-border-strong`, and `--tandem-fg-muted` — positioned before `@media (forced-colors: active)` so the OS wins
- Adds `[data-annotation-patterns="true"]` attribute hook with a comment placeholder for follow-up CSS consumers (#518)
- Wires all three settings via new `createDensity` / `createHighContrast` / `createAnnotationPatterns` Svelte 5 effect hooks in `App.svelte`
- Adds density radio group to `AppearanceSettings.svelte` and high-contrast + annotation-patterns toggles to `AccessibilitySettings.svelte`
- Migrates chrome padding/gap values in `App.svelte`, `SidePanel`, `ChatPanel`, `AnnotationCard`, `Toolbar`, `SettingsPopover`, `ToastContainer`, and `AppearanceSettings` to `var(--tandem-space-N)` tokens

Part B of #514. Part A (accent hue + editor font) landed in PR #531.

## Test plan

- [ ] `npm test -- useDensity useHighContrast useAnnotationPatterns` — 18 tests pass
- [ ] `npm run typecheck` — clean (0 errors, 0 warnings)
- [ ] `npm run check:tokens` — clean
- [ ] Open Settings → Appearance: verify Spacing Density radio shows Compact / Cozy / Spacious; switching changes element spacing
- [ ] Open Settings → Accessibility: verify High contrast toggle darkens borders; Annotation patterns toggle sets `[data-annotation-patterns]` on `<html>`
- [ ] Compact density should visibly reduce spacing in toolbar, panels, and annotation cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)