### PR TITLE
fix(e2e): stabilize redesign QA flows for #522

### DIFF
--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -366,7 +366,7 @@ test("bulk-confirm resets when filter-status changes", async ({ page }) => {
   await expect(confirm).not.toBeVisible({ timeout: 2_000 });
 });
 
-test("Solo/Tandem mode toggle switches via toolbar and holds pending annotations", async ({
+test("Solo/Tandem mode toggle switches via toolbar and surfaces held annotations in status", async ({
   page,
 }) => {
   await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
@@ -391,9 +391,9 @@ test("Solo/Tandem mode toggle switches via toolbar and holds pending annotations
   await expect(tandemBtn).toHaveAttribute("aria-pressed", "true");
   await expect(soloBtn).toHaveAttribute("aria-pressed", "false");
 
-  // In Tandem mode the held banner is absent — the annotation is visible.
-  const heldBanner = page.getByTestId("held-banner");
-  await expect(heldBanner).toHaveCount(0);
+  // In Tandem mode the held affordance is absent — the annotation is visible.
+  const heldButton = page.getByTestId("sb-held");
+  await expect(heldButton).toHaveCount(0);
 
   // Switch to solo. Assert via localStorage (race-free) + aria-pressed
   // (visible state). Avoid asserting through tandem_status because Y.Map
@@ -404,22 +404,20 @@ test("Solo/Tandem mode toggle switches via toolbar and holds pending annotations
   const soloSaved = await page.evaluate((key) => localStorage.getItem(key), TANDEM_MODE_KEY);
   expect(soloSaved).toBe("solo");
 
-  // The held banner must appear in Solo mode — this is the feature's actual
-  // contract, not just the localStorage bit. Catches regressions where the
-  // toggle updates storage but fails to drive the useModeGate hook.
-  await expect(heldBanner).toBeVisible({ timeout: 2_000 });
-  // Preserve the count + pluralization contract the old regex locator asserted.
-  await expect(heldBanner).toHaveText(/\d+ annotation(s)? held/);
+  // The held affordance must appear in Solo mode and expose the actionable
+  // count in the status bar, which is the contract called for by #519.
+  await expect(heldButton).toBeVisible({ timeout: 2_000 });
+  await expect(heldButton).toHaveText(/\d+ held/);
+  await heldButton.click();
 
-  // Switch back.
-  await tandemBtn.click();
+  // Switch back through the status bar affordance.
   await expect(tandemBtn).toHaveAttribute("aria-pressed", "true");
   await expect(soloBtn).toHaveAttribute("aria-pressed", "false");
   const tandemSaved = await page.evaluate((key) => localStorage.getItem(key), TANDEM_MODE_KEY);
   expect(tandemSaved).toBe("tandem");
 
-  // Banner must clear when back in Tandem.
-  await expect(heldBanner).toHaveCount(0, { timeout: 2_000 });
+  // The held affordance clears when back in Tandem.
+  await expect(heldButton).toHaveCount(0, { timeout: 2_000 });
 });
 
 test("layout switches between tabbed and three-panel", async ({ page }) => {

--- a/tests/e2e/toolbar-redesign.spec.ts
+++ b/tests/e2e/toolbar-redesign.spec.ts
@@ -116,8 +116,14 @@ test("floating selection toolbar stays within a short viewport", async ({ page }
   await editor.click();
   await editor.locator("p").first().selectText();
 
+  // Wait for the toolbar to mount before measuring its position — on a short
+  // viewport the toolbar can lag the selection event by a frame or two under CI.
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
+  // Confirm interactive state before reading boundingBox().
+  await expect(page.locator("[data-testid='toolbar-comment-btn']")).toBeEnabled({
+    timeout: 5_000,
+  });
 
   const box = await toolbar.boundingBox();
   const viewport = page.viewportSize();
@@ -140,6 +146,9 @@ test("floating selection toolbar exposes first-pass formatting actions", async (
 
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
+  await expect(page.locator("[data-testid='toolbar-comment-btn']")).toBeEnabled({
+    timeout: 5_000,
+  });
   await expect(toolbar.getByRole("button", { name: "Bold" })).toBeVisible();
   await expect(toolbar.getByRole("button", { name: "Italic" })).toBeVisible();
   await expect(toolbar.getByRole("button", { name: "Strike" })).toBeVisible();
@@ -205,8 +214,10 @@ test("Note flow creates a note annotation", async ({ page }) => {
   await editor.click();
   await editor.locator("p").first().selectText();
 
+  const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
+  await expect(toolbar).toBeVisible({ timeout: 10_000 });
   const noteBtn = page.locator("[data-testid='toolbar-note-btn']");
-  await expect(noteBtn).toBeEnabled({ timeout: 3_000 });
+  await expect(noteBtn).toBeEnabled({ timeout: 5_000 });
   await noteBtn.click();
 
   const input = page.locator("[data-testid='toolbar-note-input']");
@@ -244,8 +255,10 @@ test("#480 regression — clicking Note opens input instead of creating an empty
   await editor.click();
   await editor.locator("p").first().selectText();
 
+  const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
+  await expect(toolbar).toBeVisible({ timeout: 10_000 });
   const noteBtn = page.locator("[data-testid='toolbar-note-btn']");
-  await expect(noteBtn).toBeEnabled({ timeout: 3_000 });
+  await expect(noteBtn).toBeEnabled({ timeout: 5_000 });
   await noteBtn.click();
 
   // Input mounts → confirms the inline-flow path, not the regressed
@@ -296,6 +309,8 @@ test("Highlight quick-action creates a highlight annotation", async ({ page }) =
   await editor.click();
   await editor.locator("p").first().selectText();
 
+  const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
+  await expect(toolbar).toBeVisible({ timeout: 10_000 });
   const highlightBtn = page.locator("[data-testid='toolbar-highlight-btn']");
   await expect(highlightBtn).toBeEnabled({ timeout: 3_000 });
   await highlightBtn.click();
@@ -317,14 +332,17 @@ test("Escape cancels Note input without creating annotation", async ({ page }) =
   await editor.click();
   await editor.locator("p").first().selectText();
 
+  const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
+  await expect(toolbar).toBeVisible({ timeout: 10_000 });
   const noteBtn = page.locator("[data-testid='toolbar-note-btn']");
-  await expect(noteBtn).toBeEnabled({ timeout: 3_000 });
+  await expect(noteBtn).toBeEnabled({ timeout: 5_000 });
   await noteBtn.click();
 
   const input = page.locator("[data-testid='toolbar-note-input']");
   await expect(input).toBeVisible({ timeout: 2_000 });
   await input.fill("draft");
   await input.press("Escape");
+  await expect(input).toBeHidden({ timeout: 5_000 });
 
   await expect(page.locator("[data-testid^='annotation-card-']")).toHaveCount(0, {
     timeout: 2_000,


### PR DESCRIPTION
Stabilizes the remaining redesign QA coverage for #522 by waiting on the actual floating selection toolbar before asserting actions, and by updating the Solo/Tandem held-annotation check to use the status-bar affordance.

Verification:
- npx playwright test tests/e2e/toolbar-redesign.spec.ts
- npm run test:e2e (51 passed, 0 flaky)

Scope is intentionally limited to the two e2e specs that were part of the QA closeout.