### PR TITLE
test(editor): slash command plugin state machine tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Semantic token foundation expanded for redesign wave 2 (#521)** — added radius, font-size, shadow, z-index, editor-font-size, and highlight-color token families in `index.html`, plus checker rules that now flag raw `border-radius: <n>px` and inline `box-shadow: ... rgba(...)` in `src/client/`.
 - **Read-only/info surfaces now use the shared info token family (#521)** — `ReviewOnlyBanner`, `ConnectionBanner`, `ToastContainer`, `StatusBar`, and related chrome now consume the shared token scales instead of hardcoded radius/text/shadow values.
 
+### Tests
+
+- **Plugin state machine unit tests for slash command menu (#517)** — added 7 Vitest tests in `tests/client/slash-command.test.ts` that exercise the ProseMirror plugin via a real Tiptap Editor in happy-dom: active state on `/` insertion, close meta, select meta, non-empty selection guard, query filtering with index clamping, ArrowDown wrap-around, and Enter-to-execute.
+
 ### Removed
 
 - **`ReviewSummary` overlay removed with review mode already gone (#521)** — the dead component and `App.svelte` mount path are deleted rather than carried forward as unreachable redesign debt.

--- a/tests/client/slash-command.test.ts
+++ b/tests/client/slash-command.test.ts
@@ -1,9 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   filterSlashCommands,
   findSlashCommandMatch,
   SLASH_COMMANDS,
+  SlashCommandExtension,
+  slashCommandPluginKey,
 } from "../../src/client/editor/extensions/slash-command";
+
+function makeEditor() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const editor = new Editor({
+    element: container,
+    extensions: [StarterKit.configure({ history: false }), SlashCommandExtension],
+    content: "",
+  });
+  return { editor, container };
+}
 
 describe("slash command parsing", () => {
   it("finds a slash command at the start of a textblock", () => {
@@ -27,5 +42,100 @@ describe("slash command filtering", () => {
   it("matches labels and aliases", () => {
     expect(filterSlashCommands("h2").map((command) => command.id)).toEqual(["heading-2"]);
     expect(filterSlashCommands("ordered").map((command) => command.id)).toEqual(["numbered-list"]);
+  });
+});
+
+describe("slash command plugin state", () => {
+  let editor: Editor;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    ({ editor, container } = makeEditor());
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    container.remove();
+  });
+
+  it("sets active state when '/' is typed at cursor with empty selection", () => {
+    editor.chain().focus().insertContent("/").run();
+    const state = slashCommandPluginKey.getState(editor.state);
+    expect(state?.active).not.toBeNull();
+    expect(state?.active?.query).toBe("");
+  });
+
+  it("clears active state on close meta", () => {
+    editor.chain().focus().insertContent("/").run();
+    editor.view.dispatch(editor.state.tr.setMeta(slashCommandPluginKey, { type: "close" }));
+    const state = slashCommandPluginKey.getState(editor.state);
+    expect(state?.active).toBeNull();
+  });
+
+  it("updates selectedIndex on select meta", () => {
+    editor.chain().focus().insertContent("/").run();
+    const before = slashCommandPluginKey.getState(editor.state);
+    expect(before?.active).not.toBeNull();
+    editor.view.dispatch(
+      editor.state.tr.setMeta(slashCommandPluginKey, { type: "select", selectedIndex: 3 }),
+    );
+    const state = slashCommandPluginKey.getState(editor.state);
+    expect(state?.active?.selectedIndex).toBe(3);
+  });
+
+  it("returns null active when selection is non-empty", () => {
+    editor.commands.setContent("<p>hello /world</p>");
+    editor.commands.setTextSelection({ from: 1, to: 5 });
+    const state = slashCommandPluginKey.getState(editor.state);
+    expect(state?.active).toBeNull();
+  });
+
+  it("filters items by query and clamps selectedIndex", () => {
+    editor.chain().focus().insertContent("/h").run();
+    const state = slashCommandPluginKey.getState(editor.state);
+    expect(state?.active?.query).toBe("h");
+    expect(filterSlashCommands("h")).toHaveLength(2);
+    expect(state?.active?.selectedIndex).toBeLessThan(filterSlashCommands("h").length);
+  });
+});
+
+describe("slash command plugin keyboard handling", () => {
+  let editor: Editor;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    ({ editor, container } = makeEditor());
+    editor.chain().focus().insertContent("/").run();
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    container.remove();
+  });
+
+  it("ArrowDown wraps selectedIndex modulo item count", () => {
+    const before = slashCommandPluginKey.getState(editor.state);
+    expect(before?.active).not.toBeNull();
+
+    for (let i = 0; i < SLASH_COMMANDS.length; i++) {
+      editor.view.dom.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }),
+      );
+    }
+
+    const state = slashCommandPluginKey.getState(editor.state);
+    expect(state?.active?.selectedIndex).toBe(0);
+  });
+
+  it("Enter executes the selected command and closes the menu", () => {
+    const before = slashCommandPluginKey.getState(editor.state);
+    expect(before?.active).not.toBeNull();
+
+    editor.view.dom.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+    );
+
+    const state = slashCommandPluginKey.getState(editor.state);
+    expect(state?.active).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds 7 Vitest unit tests covering the ProseMirror plugin state machine inside `SlashCommandExtension`, exercising the behavioral seam without needing new exports
- Tests run in `happy-dom` via the existing `client` vitest project (browser conditions, real Tiptap `Editor` instance)
- All 12 tests pass (5 pre-existing parser/filter tests + 7 new plugin tests)

## Tests added (`tests/client/slash-command.test.ts`)

**`slash command plugin state` (5 tests)**
1. Sets `active` with `query: ""` when `/` is typed with empty selection
2. Clears `active` to null on a `close` meta dispatch
3. Updates `selectedIndex` on a `select` meta dispatch
4. Returns null `active` when selection is non-empty
5. Filters items by query (`/h` → 2 headings) and clamps `selectedIndex` within bounds

**`slash command plugin keyboard handling` (2 tests)**
6. ArrowDown wraps `selectedIndex` modulo total command count (N presses → back to 0)
7. Enter executes the selected command and sets `active` to null

## Approach

Uses `editor.view.dom.dispatchEvent(new KeyboardEvent(..., { bubbles: true, cancelable: true }))` — events propagate through ProseMirror's `handleKeyDown` chain in happy-dom without issue. No new exports were added to the production module.

Closes #517