### PR TITLE
chore(ci): add cargo test to CI and unit+Rust tests to pre-push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,23 @@ on:
   pull_request:
 
 jobs:
+  rust-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Rust unit tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
   check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Linux system dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
         shell: bash
         run: |
           mkdir -p src-tauri/binaries dist/channel dist/server dist/client
-          touch "src-tauri/binaries/node-sidecar-$(rustc -Vv | grep '^host' | cut -d' ' -f2)"
+          TRIPLE="$(rustc -Vv | grep '^host' | cut -d' ' -f2)"
+          touch "src-tauri/binaries/node-sidecar-${TRIPLE}"
+          touch "src-tauri/binaries/node-sidecar-${TRIPLE}.exe"
 
       - name: Rust unit tests
         run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           workspaces: src-tauri
 
+      - name: Create sidecar stub for build script
+        shell: bash
+        run: |
+          mkdir -p src-tauri/binaries
+          touch "src-tauri/binaries/node-sidecar-$(rustc -Vv | grep '^host' | cut -d' ' -f2)"
+
       - name: Rust unit tests
         run: cargo test --manifest-path src-tauri/Cargo.toml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           workspaces: src-tauri
 
-      - name: Create sidecar stub for build script
+      - name: Create stubs for tauri_build resource checks
         shell: bash
         run: |
-          mkdir -p src-tauri/binaries
+          mkdir -p src-tauri/binaries dist/channel dist/server dist/client
           touch "src-tauri/binaries/node-sidecar-$(rustc -Vv | grep '^host' | cut -d' ' -f2)"
 
       - name: Rust unit tests

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,4 @@
 #!/usr/bin/env sh
 npx biome check src/ tests/
+npm test -- --run --reporter=dot
+cargo test --manifest-path src-tauri/Cargo.toml


### PR DESCRIPTION
## Summary

- **`ci.yml`**: New `rust-test` job runs `cargo test` on `ubuntu-latest` + `windows-latest` (matrix). Closes the gap where 17 existing Rust unit tests (`prevent_default`, `firewall`, `cowork_installer`, `cowork_workspace_scan`) ran nowhere in automation.
- **`.husky/pre-push`**: Extends the hook from Biome-only to also run `npm test -- --run --reporter=dot` (vitest) and `cargo test`. Would have caught the PR #557 test-mock-drift failure locally before push.

## Background

The existing Playwright suite is browser-only (no `tauri-driver`, targets `localhost:5173`). `cargo test` is the only automation that actually covers the desktop-primary surface. Neither was gated anywhere.

Discovered while diagnosing why a Tauri-specific test failure (`TitleBar.test.ts`) slipped through to CI — the pre-push hook had no test execution at all.

## Not included

- Playwright on pre-push: browser-only, 5-10min on Windows (single worker + cold build), tests the non-primary form factor. Already runs on every PR.
- `tauri-driver` E2E: tracked separately.

## Test plan

- [ ] CI `rust-test` job appears green on this PR (both matrix legs)
- [ ] Local: `git push` with a broken Vitest test → hook blocks
- [ ] Local: `git push` with a broken Rust test → hook blocks
- [ ] Local: clean push → hook completes in <30s (warm caches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)