### PR TITLE
feat(dx): add Claude Code automation hooks, agents, and skills

### DIFF
--- a/.claude/agents/annotation-model-reviewer.md
+++ b/.claude/agents/annotation-model-reviewer.md
@@ -12,16 +12,18 @@ You are a specialized reviewer for Tandem's annotation data model and lifecycle 
 - All annotation creation must produce both flat `range` and CRDT `relRange` via `anchoredRange()`
 - Server-side Y.Map mutations must be wrapped in `doc.transact(() => { ... }, MCP_ORIGIN)` to prevent channel echo
 - Notes (`type: "note"`) are user-private per ADR-027 — never exposed to MCP tool responses or channel events
-- The channel event queue skips transactions with `MCP_ORIGIN` (Claude already knows) and `FILE_SYNC_ORIGIN` (disk echo, not user action)
-- `sanitizeAnnotation()` in `src/shared/sanitize.ts` strips notes and deprecated fields before MCP responses
+- The annotations observer in `src/server/events/observers/annotations.ts` skips transactions with `MCP_ORIGIN` and `FILE_SYNC_ORIGIN`, and filters notes structurally (only `type: "comment"` events reach the channel)
+- `sanitizeAnnotation()` in `src/shared/sanitize.ts` normalizes legacy shapes; note filtering for MCP responses happens in `tandem_getAnnotations`/`tandem_exportAnnotations` in `annotations.ts`
 
 ## Key Files
 
 Read these before reviewing changes:
-- `src/server/mcp/annotations.ts` — annotation CRUD (create, resolve, edit, delete)
-- `src/server/events/queue.ts` — channel event observer, origin filtering, `MCP_ORIGIN` and `FILE_SYNC_ORIGIN` constants
+- `src/server/mcp/annotations.ts` — annotation CRUD (create, resolve, edit, delete, reply); note filtering for MCP responses
+- `src/server/events/observers/annotations.ts` — channel event observer: origin filtering, note privacy, event emission (`annotation:created`, `annotation:edited`)
+- `src/server/events/origins.ts` — `MCP_ORIGIN` and `FILE_SYNC_ORIGIN` constants (re-exported from `queue.ts`)
+- `src/server/events/queue.ts` — wires observers, manages event queue
 - `src/shared/constants.ts` — Y.Map key constants, annotation type/status literals
-- `src/shared/sanitize.ts` — `sanitizeAnnotation()`, `sanitizeAnnotations()` — privacy filtering
+- `src/shared/sanitize.ts` — `sanitizeAnnotation()` — normalizes legacy annotation shapes
 - `src/server/positions.ts` — `anchoredRange()`, `validateRange()`, `refreshRange()`
 - `docs/decisions.md` — ADR-027 (audience/privacy model)
 
@@ -38,20 +40,21 @@ Read these before reviewing changes:
 - **Exception:** `refreshRange()` updates flat offsets on any annotation (this keeps coordinates fresh, not content).
 
 ### 3. MCP_ORIGIN Transaction Tagging
-- **Rule:** Every `doc.transact()` call in MCP tool handlers must pass `MCP_ORIGIN` as the origin argument. Bare `doc.transact(() => { ... })` without origin is a bug — it will echo the change back to Claude via the channel.
-- **Check:** Grep for `transact(` in `src/server/mcp/`. Every occurrence must have a second argument that is `MCP_ORIGIN`.
+- **Rule:** Every `doc.transact()` call in MCP tool handler call sites must pass `MCP_ORIGIN` as the origin argument. Bare `doc.transact(() => { ... })` without origin in an MCP handler will echo the change back to Claude via the channel.
+- **Check:** Grep for `transact(` in `src/server/mcp/`. Each MCP tool handler's transact call must pass `MCP_ORIGIN`.
+- **Exception:** Shared helpers like `addReplyToAnnotation()` accept an optional `origin` parameter — the helper itself may contain a bare `transact()` path, but this is safe as long as all MCP call sites pass `MCP_ORIGIN` when invoking the helper. Verify at the call site, not inside the helper.
 - **Exception:** `FILE_SYNC_ORIGIN` is used in the file-sync path (`src/server/file-io/`), not in MCP handlers.
 
 ### 4. ADR-027 Note Privacy
 - **Rule:** Annotations with `type: "note"` must never appear in:
-  - MCP tool responses (`tandem_getAnnotations`, `tandem_checkInbox`)
-  - Channel SSE events (`annotation:created`, `annotation:updated`)
-- **Check:** Verify `sanitizeAnnotations()` filters notes. Verify the channel observer in `queue.ts` does not emit events for note-type annotations.
+  - MCP tool responses (`tandem_getAnnotations`, `tandem_checkInbox`, `tandem_exportAnnotations`)
+  - Channel SSE events (`annotation:created`, `annotation:edited`)
+- **Check:** Verify `tandem_getAnnotations`/`tandem_exportAnnotations` filter notes before returning. Verify the annotations observer in `src/server/events/observers/annotations.ts` only emits events for `type: "comment"` (the `if (ann.type !== "comment") continue` guard on line 39).
 - **Also check:** `tandem_editAnnotation` should reject edits to notes (they're user-private, Claude can't modify them).
 
 ### 5. Channel Event Origin Filtering
-- **Rule:** The Y.Map observer in `queue.ts` must skip transactions with origin `MCP_ORIGIN` (Claude already saw the action) and `FILE_SYNC_ORIGIN` (disk echo, not a user action).
-- **Check:** The observer callback must inspect `transaction.origin` and early-return for both origins.
+- **Rule:** The annotations observer in `src/server/events/observers/annotations.ts` must skip transactions with origin `MCP_ORIGIN` (Claude already saw the action) and `FILE_SYNC_ORIGIN` (disk echo, not a user action).
+- **Check:** The observer callback (line 19) must inspect `txn.origin` and early-return for both origins.
 - **Edge case:** Ensure the observer doesn't accidentally skip legitimate user actions that happen to occur in the same Y.Map.
 
 ## Output Format
@@ -64,4 +67,4 @@ For each finding:
 - **Proof**: Concrete scenario that triggers the bug
 - **Recommendation**: Specific fix
 
-Start by reading `src/server/mcp/annotations.ts` and `src/server/events/queue.ts`, then work through each focus area systematically.
+Start by reading `src/server/mcp/annotations.ts` and `src/server/events/observers/annotations.ts`, then work through each focus area systematically.

--- a/.claude/agents/annotation-model-reviewer.md
+++ b/.claude/agents/annotation-model-reviewer.md
@@ -8,22 +8,22 @@ You are a specialized reviewer for Tandem's annotation data model and lifecycle 
 ## Architecture Context
 
 - Annotations are stored in `Y.Map('annotations')` keyed by annotation ID
-- Each annotation has: `id`, `type` ("highlight"|"comment"|"note"), `range` (flat offsets), optional `relRange` (CRDT-anchored), `status` ("pending"|"accepted"|"dismissed"), `author` ("user"|"claude"|"import")
+- Each annotation has: `id`, `type` ("highlight"|"comment"|"note"), `range` (flat offsets), optional `relRange` (CRDT-anchored), `status` ("pending"|"accepted"|"dismissed"), `author` ("user"|"claude"|"import"), optional `audience` ("private"|"outbound" — derived by sanitizeAnnotation on read; notes/highlights are always private, comments default to outbound)
 - All annotation creation must produce both flat `range` and CRDT `relRange` via `anchoredRange()`
 - Server-side Y.Map mutations must be wrapped in `doc.transact(() => { ... }, MCP_ORIGIN)` to prevent channel echo
 - Notes (`type: "note"`) are user-private per ADR-027 — never exposed to MCP tool responses or channel events
 - The annotations observer in `src/server/events/observers/annotations.ts` skips transactions with `MCP_ORIGIN` and `FILE_SYNC_ORIGIN`, and filters notes structurally (only `type: "comment"` events reach the channel)
-- `sanitizeAnnotation()` in `src/shared/sanitize.ts` normalizes legacy shapes; note filtering for MCP responses happens in `tandem_getAnnotations`/`tandem_exportAnnotations` in `annotations.ts`
+- `sanitizeAnnotation()` in `src/shared/sanitize.ts` normalizes legacy shapes and derives `audience`; note filtering for MCP responses happens in `tandem_getAnnotations`/`tandem_exportAnnotations` in `annotations.ts`
 
 ## Key Files
 
 Read these before reviewing changes:
 - `src/server/mcp/annotations.ts` — annotation CRUD (create, resolve, edit, delete, reply); note filtering for MCP responses
 - `src/server/events/observers/annotations.ts` — channel event observer: origin filtering, note privacy, event emission (`annotation:created`, `annotation:edited`)
-- `src/server/events/origins.ts` — `MCP_ORIGIN` and `FILE_SYNC_ORIGIN` constants (re-exported from `queue.ts`)
-- `src/server/events/queue.ts` — wires observers, manages event queue
+- `src/server/events/origins.ts` — canonical definition of `MCP_ORIGIN` and `FILE_SYNC_ORIGIN` constants (extracted to break circular dep)
+- `src/server/events/queue.ts` — wires observers, manages event queue; re-exports origin constants
 - `src/shared/constants.ts` — Y.Map key constants, annotation type/status literals
-- `src/shared/sanitize.ts` — `sanitizeAnnotation()` — normalizes legacy annotation shapes
+- `src/shared/sanitize.ts` — `sanitizeAnnotation()` — normalizes legacy shapes, derives `audience`; callers invoke per-element in their own filter/map loops
 - `src/server/positions.ts` — `anchoredRange()`, `validateRange()`, `refreshRange()`
 - `docs/decisions.md` — ADR-027 (audience/privacy model)
 
@@ -43,13 +43,13 @@ Read these before reviewing changes:
 - **Rule:** Every `doc.transact()` call in MCP tool handler call sites must pass `MCP_ORIGIN` as the origin argument. Bare `doc.transact(() => { ... })` without origin in an MCP handler will echo the change back to Claude via the channel.
 - **Check:** Grep for `transact(` in `src/server/mcp/`. Each MCP tool handler's transact call must pass `MCP_ORIGIN`.
 - **Exception:** Shared helpers like `addReplyToAnnotation()` accept an optional `origin` parameter — the helper itself may contain a bare `transact()` path, but this is safe as long as all MCP call sites pass `MCP_ORIGIN` when invoking the helper. Verify at the call site, not inside the helper.
-- **Exception:** `FILE_SYNC_ORIGIN` is used in the file-sync path (`src/server/file-io/`), not in MCP handlers.
+- **Exception:** `FILE_SYNC_ORIGIN` is used in `src/server/annotations/sync.ts`, not in MCP handlers.
 
 ### 4. ADR-027 Note Privacy
 - **Rule:** Annotations with `type: "note"` must never appear in:
   - MCP tool responses (`tandem_getAnnotations`, `tandem_checkInbox`, `tandem_exportAnnotations`)
   - Channel SSE events (`annotation:created`, `annotation:edited`)
-- **Check:** Verify `tandem_getAnnotations`/`tandem_exportAnnotations` filter notes before returning. Verify the annotations observer in `src/server/events/observers/annotations.ts` only emits events for `type: "comment"` (the `if (ann.type !== "comment") continue` guard on line 39).
+- **Check:** Verify `tandem_getAnnotations`/`tandem_exportAnnotations` in `src/server/mcp/annotations.ts` filter notes before returning. Verify the annotations observer in `src/server/events/observers/annotations.ts` only emits events for `type: "comment"` (the `if (ann.type !== "comment") continue` guard on line 39).
 - **Also check:** `tandem_editAnnotation` should reject edits to notes (they're user-private, Claude can't modify them).
 
 ### 5. Channel Event Origin Filtering

--- a/.claude/agents/annotation-model-reviewer.md
+++ b/.claude/agents/annotation-model-reviewer.md
@@ -1,0 +1,67 @@
+---
+name: annotation-model-reviewer
+description: Review Tandem annotation lifecycle for creation, state transitions, MCP_ORIGIN tagging, ADR-027 privacy, and channel event filtering correctness
+---
+
+You are a specialized reviewer for Tandem's annotation data model and lifecycle logic.
+
+## Architecture Context
+
+- Annotations are stored in `Y.Map('annotations')` keyed by annotation ID
+- Each annotation has: `id`, `type` ("highlight"|"comment"|"note"), `range` (flat offsets), optional `relRange` (CRDT-anchored), `status` ("pending"|"accepted"|"dismissed"), `author` ("user"|"claude"|"import")
+- All annotation creation must produce both flat `range` and CRDT `relRange` via `anchoredRange()`
+- Server-side Y.Map mutations must be wrapped in `doc.transact(() => { ... }, MCP_ORIGIN)` to prevent channel echo
+- Notes (`type: "note"`) are user-private per ADR-027 — never exposed to MCP tool responses or channel events
+- The channel event queue skips transactions with `MCP_ORIGIN` (Claude already knows) and `FILE_SYNC_ORIGIN` (disk echo, not user action)
+- `sanitizeAnnotation()` in `src/shared/sanitize.ts` strips notes and deprecated fields before MCP responses
+
+## Key Files
+
+Read these before reviewing changes:
+- `src/server/mcp/annotations.ts` — annotation CRUD (create, resolve, edit, delete)
+- `src/server/events/queue.ts` — channel event observer, origin filtering, `MCP_ORIGIN` and `FILE_SYNC_ORIGIN` constants
+- `src/shared/constants.ts` — Y.Map key constants, annotation type/status literals
+- `src/shared/sanitize.ts` — `sanitizeAnnotation()`, `sanitizeAnnotations()` — privacy filtering
+- `src/server/positions.ts` — `anchoredRange()`, `validateRange()`, `refreshRange()`
+- `docs/decisions.md` — ADR-027 (audience/privacy model)
+
+## Focus Areas
+
+### 1. Creation via anchoredRange
+- **Rule:** Every code path that creates an annotation must call `anchoredRange()` to produce both `range` (flat) and `relRange` (CRDT). Direct assignment of `range` without `relRange` is a bug.
+- **Check:** Search for Y.Map `set()` calls that write annotation objects. Verify `anchoredRange()` is in the call chain.
+- **Exception:** `refreshRange()` may update an existing `range` from a resolved `relRange` — this is correct (it's a refresh, not a creation).
+
+### 2. Pending-Only Mutations
+- **Rule:** Only annotations with `status: "pending"` may have their `range`, `suggestedText`, or `message` updated. Accepted or dismissed annotations are immutable (except for deletion).
+- **Check:** All mutation paths in `tandem_editAnnotation` and internal helpers must guard on `status === "pending"`.
+- **Exception:** `refreshRange()` updates flat offsets on any annotation (this keeps coordinates fresh, not content).
+
+### 3. MCP_ORIGIN Transaction Tagging
+- **Rule:** Every `doc.transact()` call in MCP tool handlers must pass `MCP_ORIGIN` as the origin argument. Bare `doc.transact(() => { ... })` without origin is a bug — it will echo the change back to Claude via the channel.
+- **Check:** Grep for `transact(` in `src/server/mcp/`. Every occurrence must have a second argument that is `MCP_ORIGIN`.
+- **Exception:** `FILE_SYNC_ORIGIN` is used in the file-sync path (`src/server/file-io/`), not in MCP handlers.
+
+### 4. ADR-027 Note Privacy
+- **Rule:** Annotations with `type: "note"` must never appear in:
+  - MCP tool responses (`tandem_getAnnotations`, `tandem_checkInbox`)
+  - Channel SSE events (`annotation:created`, `annotation:updated`)
+- **Check:** Verify `sanitizeAnnotations()` filters notes. Verify the channel observer in `queue.ts` does not emit events for note-type annotations.
+- **Also check:** `tandem_editAnnotation` should reject edits to notes (they're user-private, Claude can't modify them).
+
+### 5. Channel Event Origin Filtering
+- **Rule:** The Y.Map observer in `queue.ts` must skip transactions with origin `MCP_ORIGIN` (Claude already saw the action) and `FILE_SYNC_ORIGIN` (disk echo, not a user action).
+- **Check:** The observer callback must inspect `transaction.origin` and early-return for both origins.
+- **Edge case:** Ensure the observer doesn't accidentally skip legitimate user actions that happen to occur in the same Y.Map.
+
+## Output Format
+
+For each finding:
+- **Severity**: Critical / High / Medium / Low / Info
+- **Invariant**: Which focus area and specific rule is violated
+- **Location**: file:line
+- **Description**: What the bug is and why it matters
+- **Proof**: Concrete scenario that triggers the bug
+- **Recommendation**: Specific fix
+
+Start by reading `src/server/mcp/annotations.ts` and `src/server/events/queue.ts`, then work through each focus area systematically.

--- a/.claude/agents/svelte-migration-reviewer.md
+++ b/.claude/agents/svelte-migration-reviewer.md
@@ -17,8 +17,7 @@ You are a specialized reviewer for Svelte 5 reactive patterns in the Tandem code
 
 - `src/client/editor/` — Tiptap integration, extensions, decorations
 - `src/client/components/` — UI components (panels, toolbar, settings)
-- `src/client/stores/` — Svelte 5 rune-based stores (`.svelte.ts` files)
-- `src/client/hooks/` — Reactive hooks (`.svelte.ts` files)
+- `src/client/hooks/` — Svelte 5 rune-based hooks and stores (`.svelte.ts` files, e.g. `useTandemSettings.svelte.ts`, `yjsSync.svelte.ts`)
 
 ## Focus Areas
 

--- a/.claude/agents/svelte-migration-reviewer.md
+++ b/.claude/agents/svelte-migration-reviewer.md
@@ -1,0 +1,129 @@
+---
+name: svelte-migration-reviewer
+description: Review .svelte and .svelte.ts files for Svelte 5 reactive pattern violations and known gotchas
+---
+
+You are a specialized reviewer for Svelte 5 reactive patterns in the Tandem codebase. The project migrated from React to Svelte 5 (ADR-025) and has encountered specific reactive pitfalls that this review catches.
+
+## Architecture Context
+
+- Tandem uses Svelte 5 with runes (`$state`, `$derived`, `$effect`, `$props`)
+- Components live in `src/client/` — both `.svelte` files and `.svelte.ts` rune-based hooks
+- The editor uses Tiptap (ProseMirror) which has its own reactive model that can conflict with Svelte's
+- Biome handles formatting; `svelte-check` handles type diagnostics
+- These patterns have caused production bugs in past PRs — they are not theoretical
+
+## Key Files
+
+- `src/client/editor/` — Tiptap integration, extensions, decorations
+- `src/client/components/` — UI components (panels, toolbar, settings)
+- `src/client/stores/` — Svelte 5 rune-based stores (`.svelte.ts` files)
+- `src/client/hooks/` — Reactive hooks (`.svelte.ts` files)
+
+## Focus Areas
+
+### 1. $derived vs const
+- **Rule:** Any value computed from reactive state (`$state`, `$derived`, or `$props`) must use `$derived`, not plain `const`. A `const` is frozen at component mount time and will not update.
+- **Bug pattern:**
+  ```svelte
+  const items = someStore.items.filter(x => x.active)  // STALE after mount
+  ```
+  Must be:
+  ```svelte
+  const items = $derived(someStore.items.filter(x => x.active))
+  ```
+- **Check:** Look for `const x = <reactive>.something` patterns where the right-hand side reads from `$state`/`$derived`/`$props` without wrapping in `$derived()`.
+
+### 2. Getter Destructuring Loses Reactivity
+- **Rule:** Destructuring a reactive object (returned from a `.svelte.ts` hook or store) breaks reactivity. The destructured variables are snapshots, not live bindings.
+- **Bug pattern:**
+  ```ts
+  const { count, items } = useMyStore()  // count/items are frozen snapshots
+  ```
+  Must keep the object reference:
+  ```ts
+  const store = useMyStore()
+  // Use store.count, store.items at call sites
+  ```
+- **Check:** Look for destructuring assignments where the right side is a function call returning an object with reactive getters.
+
+### 3. $effect Depth / Nested Effects
+- **Rule:** `$effect` blocks must not trigger other `$effect` blocks by mutating shared `$state` in a way that creates circular dependencies. This manifests as `effect_update_depth_exceeded` runtime errors.
+- **Bug pattern:**
+  ```ts
+  $effect(() => {
+    editor.view.dispatch(...)  // dispatch triggers ProseMirror → Svelte sync → another $effect
+  })
+  ```
+- **Check:** Look for `$effect` blocks that call `editor.view.dispatch()`, mutate `$state` that other effects read, or call functions that transitively mutate reactive state. Guard with last-value checks:
+  ```ts
+  $effect(() => {
+    const newVal = computeValue()
+    if (newVal !== lastVal) { lastVal = newVal; apply(newVal) }
+  })
+  ```
+
+### 4. @keyframes Needs :global Wrapper
+- **Rule:** Svelte 5 scopes all `<style>` content. If a `@keyframes` animation is referenced via an inline `style=` attribute or a dynamic class, Svelte's scoping hash won't match. The keyframes must be wrapped in `:global`.
+- **Bug pattern:**
+  ```svelte
+  <div style="animation: fadeIn 0.3s">...</div>
+  <style>
+    @keyframes fadeIn { ... }  <!-- scoped, won't match inline reference -->
+  </style>
+  ```
+  Fix:
+  ```svelte
+  <style>
+    :global(@keyframes fadeIn) { ... }
+  </style>
+  ```
+- **Check:** Look for `@keyframes` in `<style>` blocks and verify they're wrapped in `:global()` if referenced from inline styles or dynamic attributes.
+
+### 5. bind:this + $effect Loop
+- **Rule:** Using `$state(null)` + `bind:this` + `$effect` that reads the bound ref creates an infinite reactive loop (`effect_update_depth_exceeded`). The bind assignment triggers the effect, which re-renders, which re-binds.
+- **Bug pattern:**
+  ```svelte
+  <script>
+    let el = $state<HTMLElement | null>(null)
+    $effect(() => {
+      if (el) el.scrollTop = 0  // reads el → triggers on bind → loop
+    })
+  </script>
+  <div bind:this={el}>...</div>
+  ```
+- **Fix:** Use `onMount`/`onDestroy` for DOM ref setup, or `untrack(() => el)` to read without subscribing.
+- **Check:** Look for `bind:this={someState}` where `someState` is `$state` AND an `$effect` reads that same variable.
+
+### 6. Async onMount State Mutation
+- **Rule:** `onMount(async () => { ... })` with `$state` mutations after `await` points can fire after component teardown, causing "setting state on destroyed component" errors.
+- **Bug pattern:**
+  ```ts
+  onMount(async () => {
+    const data = await fetchSomething()
+    items = data  // component may be destroyed by now
+  })
+  ```
+- **Fix:** Track mount status and guard mutations:
+  ```ts
+  let mounted = true
+  onMount(async () => {
+    const data = await fetchSomething()
+    if (!mounted) return
+    items = data
+  })
+  onDestroy(() => { mounted = false })
+  ```
+- **Also:** In tests, async `onMount` requires `await new Promise(r => setTimeout(r, 0))` + `tick()` before asserting on state it sets.
+
+## Output Format
+
+For each finding:
+- **Severity**: Critical / High / Medium / Low / Info
+- **Pattern**: Which focus area (1-6) is violated
+- **Location**: file:line
+- **Description**: What the reactive bug is
+- **Proof**: What user-visible behavior breaks (stale UI, crash, infinite loop)
+- **Recommendation**: Specific fix with code snippet
+
+Start by reading the most recently modified `.svelte` and `.svelte.ts` files (check `git diff` or `git log` for recent changes), then systematically check each focus area.

--- a/.claude/hooks/block-e2e-port-kill.sh
+++ b/.claude/hooks/block-e2e-port-kill.sh
@@ -14,11 +14,19 @@ COMMAND=$(printf '%s' "$INPUT" | node -e "
       const e = JSON.parse(d);
       const c = e.tool_input?.command || '';
       process.stdout.write(c);
-    } catch { process.exit(0); }
+    } catch {
+      process.stderr.write('Hook: failed to parse tool input\n');
+      process.exit(1);
+    }
   });
-" 2>/dev/null) || exit 0
+" 2>/dev/null) || {
+  echo "⚠ Could not parse tool input — blocking as a precaution."
+  exit 2
+}
 
 # Match commands that execute Playwright tests via known entrypoints
+# Known uncovered: bunx, ./node_modules/.bin/playwright, npm test alias
+# Best-effort detection — update regex if new invocation patterns emerge
 if [[ -n "$COMMAND" && "$COMMAND" =~ (npx[[:space:]]+playwright[[:space:]]+test|npm[[:space:]]+run[[:space:]]+test:e2e|npm[[:space:]]+exec[[:space:]]+playwright[[:space:]]+test|pnpm[[:space:]]+playwright[[:space:]]+test|yarn[[:space:]]+playwright[[:space:]]+test) ]]; then
   echo "⛔ E2E tests kill running dev server on :3478/:3479 via freePort()."
   echo "Before running, confirm with the user that no dev server is in use."

--- a/.claude/hooks/block-e2e-port-kill.sh
+++ b/.claude/hooks/block-e2e-port-kill.sh
@@ -18,7 +18,9 @@ COMMAND=$(printf '%s' "$INPUT" | node -e "
   });
 " 2>/dev/null) || exit 0
 
-if [[ -n "$COMMAND" && "$COMMAND" =~ (playwright|test:e2e) ]]; then
+# Only match commands that actually execute playwright or E2E tests
+# Require the keyword at a word boundary after a command prefix (npx, npm, node, etc.)
+if [[ -n "$COMMAND" && "$COMMAND" =~ (npx[[:space:]]+playwright|npm[[:space:]]+run[[:space:]]+test:e2e|node.*playwright) ]]; then
   echo "⛔ E2E tests kill running dev server on :3478/:3479 via freePort()."
   echo "Before running, confirm with the user that no dev server is in use."
   echo "Check: curl -sf http://127.0.0.1:3479/health || echo 'no server running'"

--- a/.claude/hooks/block-e2e-port-kill.sh
+++ b/.claude/hooks/block-e2e-port-kill.sh
@@ -18,9 +18,8 @@ COMMAND=$(printf '%s' "$INPUT" | node -e "
   });
 " 2>/dev/null) || exit 0
 
-# Only match commands that actually execute playwright or E2E tests
-# Require the keyword at a word boundary after a command prefix (npx, npm, node, etc.)
-if [[ -n "$COMMAND" && "$COMMAND" =~ (npx[[:space:]]+playwright|npm[[:space:]]+run[[:space:]]+test:e2e|node.*playwright) ]]; then
+# Match commands that execute Playwright tests via known entrypoints
+if [[ -n "$COMMAND" && "$COMMAND" =~ (npx[[:space:]]+playwright[[:space:]]+test|npm[[:space:]]+run[[:space:]]+test:e2e|npm[[:space:]]+exec[[:space:]]+playwright[[:space:]]+test|pnpm[[:space:]]+playwright[[:space:]]+test|yarn[[:space:]]+playwright[[:space:]]+test) ]]; then
   echo "⛔ E2E tests kill running dev server on :3478/:3479 via freePort()."
   echo "Before running, confirm with the user that no dev server is in use."
   echo "Check: curl -sf http://127.0.0.1:3479/health || echo 'no server running'"

--- a/.claude/hooks/block-e2e-port-kill.sh
+++ b/.claude/hooks/block-e2e-port-kill.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block E2E test commands that kill the dev server
+# freePort() in Playwright config kills :3478/:3479
+# Exit code 2 = block the tool call
+
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const e = JSON.parse(d);
+      const c = e.tool_input?.command || '';
+      process.stdout.write(c);
+    } catch { process.exit(0); }
+  });
+" 2>/dev/null) || exit 0
+
+if [[ -n "$COMMAND" && "$COMMAND" =~ (playwright|test:e2e) ]]; then
+  echo "⛔ E2E tests kill running dev server on :3478/:3479 via freePort()."
+  echo "Before running, confirm with the user that no dev server is in use."
+  echo "Check: curl -sf http://127.0.0.1:3479/health || echo 'no server running'"
+  exit 2
+fi

--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block Bash commands that skip Husky hooks
+# Exit code 2 = block the tool call
+
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const e = JSON.parse(d);
+      const c = e.tool_input?.command || '';
+      process.stdout.write(c);
+    } catch { process.exit(0); }
+  });
+" 2>/dev/null) || exit 0
+
+if [[ -n "$COMMAND" && "$COMMAND" =~ --no-verify ]]; then
+  echo "Blocked: --no-verify skips Husky hooks. If a hook fails, fix the underlying issue instead of bypassing it."
+  exit 2
+fi

--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -13,9 +13,15 @@ COMMAND=$(printf '%s' "$INPUT" | node -e "
       const e = JSON.parse(d);
       const c = e.tool_input?.command || '';
       process.stdout.write(c);
-    } catch { process.exit(0); }
+    } catch {
+      process.stderr.write('Hook: failed to parse tool input\n');
+      process.exit(1);
+    }
   });
-" 2>/dev/null) || exit 0
+" 2>/dev/null) || {
+  echo "⚠ Could not parse tool input — blocking as a precaution."
+  exit 2
+}
 
 if [[ -n "$COMMAND" && "$COMMAND" =~ --no-verify ]]; then
   echo "Blocked: --no-verify skips Husky hooks. If a hook fails, fix the underlying issue instead of bypassing it."

--- a/.claude/hooks/check-console-log.sh
+++ b/.claude/hooks/check-console-log.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# PostToolUse hook: warn if console.log() is used in server code
+# stdout is reserved for MCP wire (Critical Rule #3)
+# Exit 0 = no block, just warns via stderr
+
+set -euo pipefail
+trap 'exit 0' ERR
+
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const e = JSON.parse(d);
+      const f = e.tool_input?.file_path || '';
+      process.stdout.write(f);
+    } catch { process.exit(0); }
+  });
+")
+
+# Normalize Windows backslashes
+FILE_PATH="${FILE_PATH//\\//}"
+
+# Only check src/server/ .ts files, skip index.ts (where the redirect lives)
+if [[ -z "$FILE_PATH" ]] || [[ ! "$FILE_PATH" =~ /src/server/ ]] || [[ ! "$FILE_PATH" =~ \.ts$ ]] || [[ "$FILE_PATH" =~ /src/server/index\.ts$ ]]; then
+  exit 0
+fi
+
+VIOLATIONS=$(grep -nE "console\.log\(" "$FILE_PATH" 2>/dev/null || true)
+if [[ -n "$VIOLATIONS" ]]; then
+  echo "⚠ console.log() in server code corrupts MCP stdio wire. Use console.error() or console.warn() instead:"
+  echo "$VIOLATIONS"
+fi

--- a/.claude/hooks/check-token-violation.sh
+++ b/.claude/hooks/check-token-violation.sh
@@ -27,4 +27,8 @@ if [[ -z "$FILE_PATH" ]] || [[ ! "$FILE_PATH" =~ /src/client/ ]] || [[ ! "$FILE_
   exit 0
 fi
 
-npx tsx scripts/check-semantic-tokens.ts "$FILE_PATH" 2>&1 || true
+RC=0
+npx tsx scripts/check-semantic-tokens.ts "$FILE_PATH" 2>&1 || RC=$?
+if [[ $RC -ge 2 ]]; then
+  echo "⚠ Token scanner failed (exit $RC) — check skipped for this edit."
+fi

--- a/.claude/hooks/check-token-violation.sh
+++ b/.claude/hooks/check-token-violation.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# PostToolUse hook: warn on raw hex/rgba colors in client code
+# Delegates to scripts/check-semantic-tokens.ts for accurate detection
+# Exit 0 = no block, just warns
+
+set -euo pipefail
+trap 'exit 0' ERR
+
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const e = JSON.parse(d);
+      const f = e.tool_input?.file_path || '';
+      process.stdout.write(f);
+    } catch { process.exit(0); }
+  });
+")
+
+# Normalize Windows backslashes
+FILE_PATH="${FILE_PATH//\\//}"
+
+# Only check src/client/ .ts and .svelte files
+if [[ -z "$FILE_PATH" ]] || [[ ! "$FILE_PATH" =~ /src/client/ ]] || [[ ! "$FILE_PATH" =~ \.(ts|svelte)$ ]]; then
+  exit 0
+fi
+
+npx tsx scripts/check-semantic-tokens.ts "$FILE_PATH" 2>&1 || true

--- a/.claude/hooks/related-test.sh
+++ b/.claude/hooks/related-test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run matching vitest file after editing source
+# Maps src/{area}/ to tests/{area}/ via basename matching
+# Skips if no match or multiple matches (ambiguous)
+# Exit 0 = no block
+
+set -euo pipefail
+trap 'exit 0' ERR
+
+# Opt-out via environment variable
+if [[ -n "${TANDEM_SKIP_RELATED_TEST:-}" ]]; then
+  exit 0
+fi
+
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const e = JSON.parse(d);
+      const f = e.tool_input?.file_path || '';
+      process.stdout.write(f);
+    } catch { process.exit(0); }
+  });
+")
+
+# Normalize Windows backslashes
+FILE_PATH="${FILE_PATH//\\//}"
+
+# Only process .ts files in src/ (skip .svelte, .css, etc.)
+if [[ -z "$FILE_PATH" ]] || [[ ! "$FILE_PATH" =~ /src/ ]] || [[ ! "$FILE_PATH" =~ \.ts$ ]]; then
+  exit 0
+fi
+
+# Skip test files themselves
+if [[ "$FILE_PATH" =~ \.(test|spec)\.ts$ ]]; then
+  exit 0
+fi
+
+# Determine test area from source path
+AREA=""
+if [[ "$FILE_PATH" =~ /src/server/ ]]; then
+  AREA="server"
+elif [[ "$FILE_PATH" =~ /src/client/ ]]; then
+  AREA="client"
+elif [[ "$FILE_PATH" =~ /src/shared/ ]]; then
+  AREA="shared"
+elif [[ "$FILE_PATH" =~ /src/channel/ ]]; then
+  AREA="channel"
+elif [[ "$FILE_PATH" =~ /src/cli/ ]]; then
+  AREA="cli"
+else
+  exit 0
+fi
+
+# Extract basename without extension
+BASENAME=$(basename "$FILE_PATH" .ts)
+
+# Find matching test file(s)
+TEST_DIR="tests/$AREA"
+if [[ ! -d "$TEST_DIR" ]]; then
+  exit 0
+fi
+
+MATCHES=$(find "$TEST_DIR" -name "${BASENAME}.test.ts" 2>/dev/null || true)
+MATCH_COUNT=$(echo "$MATCHES" | grep -c . 2>/dev/null || echo 0)
+
+if [[ "$MATCH_COUNT" -eq 0 ]]; then
+  exit 0
+elif [[ "$MATCH_COUNT" -gt 1 ]]; then
+  echo "⚠ Ambiguous test mapping for $BASENAME ($MATCH_COUNT candidates), skipping."
+  exit 0
+fi
+
+TEST_FILE=$(echo "$MATCHES" | head -1)
+echo "Running related test: $TEST_FILE"
+npx vitest run --reporter=dot --bail=1 "$TEST_FILE" 2>&1 || true

--- a/.claude/hooks/related-test.sh
+++ b/.claude/hooks/related-test.sh
@@ -63,8 +63,8 @@ if [[ ! -d "$TEST_DIR" ]]; then
   exit 0
 fi
 
-MATCHES=$(find "$TEST_DIR" -name "${BASENAME}.test.ts" 2>/dev/null || true)
-MATCH_COUNT=$(echo "$MATCHES" | grep -c . 2>/dev/null || echo 0)
+mapfile -t MATCH_ARR < <(find "$TEST_DIR" -name "${BASENAME}.test.ts" 2>/dev/null)
+MATCH_COUNT=${#MATCH_ARR[@]}
 
 if [[ "$MATCH_COUNT" -eq 0 ]]; then
   exit 0
@@ -73,6 +73,6 @@ elif [[ "$MATCH_COUNT" -gt 1 ]]; then
   exit 0
 fi
 
-TEST_FILE=$(echo "$MATCHES" | head -1)
+TEST_FILE="${MATCH_ARR[0]}"
 echo "Running related test: $TEST_FILE"
 npx vitest run --reporter=dot --bail=1 "$TEST_FILE" 2>&1 || true

--- a/.claude/hooks/svelte-check-on-edit.sh
+++ b/.claude/hooks/svelte-check-on-edit.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run svelte-check after editing .svelte files
+# Complements typecheck-on-edit.sh which only handles .ts/.tsx
+# Non-blocking: always exits 0, surfaces errors as output
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const e = JSON.parse(d);
+      const f = e.tool_input?.file_path || '';
+      process.stdout.write(f);
+    } catch { process.exit(0); }
+  });
+")
+
+# Normalize Windows backslashes before any path checks
+FILE_PATH="${FILE_PATH//\\//}"
+
+# Only check .svelte files in src/client/
+if [[ -z "$FILE_PATH" || ! "$FILE_PATH" =~ \.svelte$ ]]; then
+  exit 0
+fi
+
+if [[ ! "$FILE_PATH" =~ src/client/ ]]; then
+  exit 0
+fi
+
+echo "Running svelte-check..."
+npx svelte-check --tsconfig tsconfig.client.json 2>&1 || true

--- a/.claude/hooks/svelte-check-on-edit.sh
+++ b/.claude/hooks/svelte-check-on-edit.sh
@@ -4,6 +4,12 @@
 # Non-blocking: always exits 0, surfaces errors as output
 
 set -euo pipefail
+trap 'exit 0' ERR
+
+# Opt-out via environment variable
+if [[ -n "${TANDEM_SKIP_SVELTE_CHECK:-}" ]]; then
+  exit 0
+fi
 
 INPUT=$(cat)
 FILE_PATH=$(printf '%s' "$INPUT" | node -e "

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,19 @@
             "command": "bash .claude/hooks/block-sensitive.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-no-verify.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-e2e-port-kill.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -30,6 +43,22 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/check-extract-markdown.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-console-log.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/svelte-check-on-edit.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-token-violation.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/related-test.sh"
           }
         ]
       }

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: changelog
+description: Generate a Keep a Changelog entry from git log since the last tag
+disable-model-invocation: true
+---
+
+# Generate Changelog Entry
+
+Generate a formatted CHANGELOG entry from commits since the last release tag.
+
+## Steps
+
+1. Find the last release tag:
+```bash
+git describe --tags --abbrev=0
+```
+
+2. List commits since that tag:
+```bash
+git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
+```
+
+3. Group commits into Keep a Changelog categories based on conventional commit prefixes:
+   - `feat(...)` → **Added** (new features) or **Changed** (enhancements to existing)
+   - `fix(...)` → **Fixed**
+   - `refactor(...)` → **Changed**
+   - `docs(...)` → **Documentation**
+   - `test(...)` → **Tests**
+   - `chore(...)` → **Maintenance**
+   - `perf(...)` → **Performance**
+   - Security-related commits → **Security**
+
+4. Format as a `## [Unreleased]` section. Each entry should be:
+   - Bold summary with PR number: `- **Description** (#N)`
+   - Group related commits into a single entry where appropriate
+   - Use imperative mood ("Add", "Fix", "Remove" — not "Added", "Fixes")
+
+5. Output the formatted block for the user to review and paste into `CHANGELOG.md`.
+
+## Important
+
+- Do NOT write directly to CHANGELOG.md — output the block for editorial review
+- Check the existing CHANGELOG.md format to match style (indentation, heading levels, PR references)
+- If there's already an `[Unreleased]` section, show what to append, not a replacement
+- Omit empty categories (don't show "### Security" if there are no security commits)

--- a/.claude/skills/e2e-debug/SKILL.md
+++ b/.claude/skills/e2e-debug/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: e2e-debug
+description: Debug Playwright E2E test failures — port conflicts, server startup, test isolation, and post-mortem analysis
+disable-model-invocation: true
+---
+
+# E2E Test Debugging
+
+Post-mortem guide for Playwright E2E failures in Tandem. Complements the `/e2e` skill (which covers the happy path).
+
+## Critical Warning
+
+E2E tests use `freePort()` which **kills any process on :3478/:3479**. Confirm with the user that no dev server is in use before running.
+
+## Pre-Flight Checklist
+
+Before running E2E tests, verify:
+
+```bash
+# 1. Server bundle exists (E2E uses pre-built server, not tsx)
+ls dist/server/index.js
+
+# 2. Ports are free (or confirm user is OK with kill)
+curl -sf http://127.0.0.1:3479/health && echo "⚠ Server running on :3479" || echo "✓ Port free"
+curl -sf http://127.0.0.1:3478 && echo "⚠ Hocuspocus running on :3478" || echo "✓ Port free"
+
+# 3. Client build exists (for webServer)
+ls dist/client/index.html
+```
+
+If `dist/server/index.js` is missing or stale:
+```bash
+npm run build:server
+```
+
+## Failure Categories
+
+### Timeout waiting for health endpoint
+**Symptom**: `Timed out waiting for http://127.0.0.1:3479/health`
+**Cause**: `dist/server/` is stale or missing
+**Fix**: `npm run build:server` then retry
+
+### net::ERR_CONNECTION_REFUSED on :5173
+**Symptom**: Client page fails to load
+**Cause**: Vite webServer not started (check `playwright.config.ts` webServer section)
+**Fix**: Verify `npm run dev` works standalone; check for port conflicts on :5173
+
+### Stale openDocuments / phantom tabs
+**Symptom**: Tests find unexpected documents open or wrong tab state
+**Cause**: Prior test crash left session state on disk
+**Fix**: Delete session directory:
+- Windows: `%LOCALAPPDATA%\tandem\Data\sessions\`
+- macOS: `~/Library/Application Support/tandem/sessions/`
+- Linux: `~/.local/share/tandem/sessions/`
+
+### data-testid not found
+**Symptom**: `locator.click: Error: strict mode violation` or element not found
+**Cause**: testid was renamed or component restructured
+**Fix**: Check CLAUDE.md Critical Rule #7 for the current testid list. Use `[data-testid="..."]` selectors, not CSS classes.
+
+### WebServer cold-start race
+**Symptom**: First test in suite fails, rest pass
+**Cause**: Known Playwright webServer cold-start issue (#230)
+**Fix**: The project uses a retry-on-first-failure workaround. If this regresses, check `playwright.config.ts` for the `retries` and `webServer.timeout` settings.
+
+## One-Off Debug Run
+
+For a single spec with browser visible:
+```bash
+npx playwright test tests/e2e/specific.spec.ts --headed --workers=1
+```
+
+For trace collection on failure:
+```bash
+npx playwright test tests/e2e/specific.spec.ts --trace on
+```
+
+View the trace:
+```bash
+npx playwright show-trace test-results/specific-spec-ts/trace.zip
+```
+
+## Common Patterns
+
+- **Display-toggled panels**: ChatPanel and SidePanel are always mounted (CSS `display` toggle). Use `toBeVisible()` not `toBeAttached()`.
+- **ESM __dirname**: E2E test files must use `import.meta.url` + `fileURLToPath`, not `__dirname`.
+- **Uploaded files are read-only**: `upload://` paths from test fixtures don't support `tandem_save`.


### PR DESCRIPTION
## Summary

- **6 new hooks**: `check-console-log.sh` (Critical Rule #3 — stdout reserved for MCP wire), `svelte-check-on-edit.sh` (type-check .svelte files), `check-token-violation.sh` (delegates to existing `scripts/check-semantic-tokens.ts`), `related-test.sh` (runs matching vitest after source edits), `block-no-verify.sh` (prevents bypassing Husky), `block-e2e-port-kill.sh` (warns E2E tests kill dev server ports)
- **2 new subagents**: `annotation-model-reviewer` (annotation lifecycle, MCP_ORIGIN tagging, ADR-027 privacy) and `svelte-migration-reviewer` (6 known Svelte 5 reactive gotchas from past production bugs)
- **2 new skills**: `/changelog` (generates Keep a Changelog entry from git log) and `/e2e-debug` (E2E failure post-mortem guide)
- **settings.json**: new `Bash` PreToolUse matcher + 4 additional PostToolUse entries

### Review fixes (f5e882f)

Multi-agent review found and fixed:
- **related-test.sh**: MATCH_COUNT bug ran full test suite when no matching test existed — replaced grep line-counting with `mapfile` array
- **block-no-verify.sh, block-e2e-port-kill.sh**: fail-open on JSON parse error → fail-closed (exit 2)
- **svelte-check-on-edit.sh**: missing `trap 'exit 0' ERR` (inconsistent with all other PostToolUse hooks); added `TANDEM_SKIP_SVELTE_CHECK` env-var opt-out
- **check-token-violation.sh**: scanner crashes (exit 2+) now surface a warning instead of being silently swallowed
- **annotation-model-reviewer.md**: fixed nonexistent `sanitizeAnnotations()` reference, added `audience` field, corrected `origins.ts`/`sync.ts` paths
- **svelte-migration-reviewer.md**: fixed nonexistent `src/client/stores/` path

## Test plan

- [ ] Edit a `src/server/*.ts` file with `console.log(` — verify warning appears
- [ ] Edit a `src/client/*.svelte` file — verify svelte-check runs
- [ ] Edit a `src/client/*.ts` file with raw `#ff0000` — verify token warning
- [ ] Edit a `src/server/*.ts` file that has a matching test — verify vitest runs
- [ ] Edit a `src/server/*.ts` file with NO matching test — verify no vitest output
- [ ] Attempt `git commit --no-verify` via Bash — verify it blocks
- [ ] Attempt `npm run test:e2e` via Bash — verify port-kill warning
- [ ] Invoke `/changelog` — verify it produces formatted output
- [ ] Invoke `/e2e-debug` — verify pre-flight checklist renders
- [ ] Set `TANDEM_SKIP_SVELTE_CHECK=1`, edit `.svelte` file — verify check skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
