### PR TITLE
fix(v0.11.0): address PR #592 review feedback (6 issues + test hygiene)

### DIFF
--- a/src/client/actions/clickOutside.svelte.ts
+++ b/src/client/actions/clickOutside.svelte.ts
@@ -1,10 +1,12 @@
 /**
  * Svelte action: calls handler when a click (mousedown) occurs outside the node.
+ * The handler receives the originating MouseEvent so callers can perform
+ * additional target checks (e.g. ignoring clicks on a toggle button).
  */
-export function clickOutside(node: HTMLElement, handler: () => void) {
+export function clickOutside(node: HTMLElement, handler: (event: MouseEvent) => void) {
   function handleClick(event: MouseEvent) {
     if (!node.contains(event.target as Node)) {
-      handler();
+      handler(event);
     }
   }
   document.addEventListener("mousedown", handleClick);

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -28,16 +28,17 @@ import { SUPPORTED_EXTENSIONS } from "../../shared/constants.js";
 /** File extensions that open as new Tandem tabs when clicked as relative links. .docx excluded — not navigable as a link target. */
 const INTERNAL_LINK_EXTS = new Set([...SUPPORTED_EXTENSIONS].filter((e) => e !== ".docx"));
 
-/** Return true if the href looks like an external URL (not a relative file path). */
-function isExternalHref(href: string): boolean {
-  return (
-    href.startsWith("http://") ||
-    href.startsWith("https://") ||
-    href.startsWith("mailto:") ||
-    href.startsWith("ftp://") ||
-    href.startsWith("//") ||
-    href.startsWith("#")
-  );
+/**
+ * Whitelist of safe external href prefixes that we'll hand off to the default
+ * browser via window.open. Anything not in this list and not a relative path
+ * (e.g. `javascript:`, `data:`, `vbscript:`) is treated as unsafe and ignored —
+ * preventDefault has already been called by the time we check this, so the
+ * browser won't navigate.
+ */
+const SAFE_EXTERNAL_PREFIXES = ["http://", "https://", "mailto:", "ftp://", "//"] as const;
+
+function isSafeExternalHref(href: string): boolean {
+  return SAFE_EXTERNAL_PREFIXES.some((p) => href.startsWith(p));
 }
 
 /**
@@ -208,17 +209,33 @@ $effect(() => {
 });
 
 async function handleEditorClick(e: MouseEvent) {
-  // --- Relative link intercept (closes #479) --------------------------------
-  // Check for an anchor click before the annotation path so we can
-  // preventDefault before the browser navigates away.
+  // --- Anchor intercept (closes #479) --------------------------------------
+  // We want to own every anchor click except in-page fragments: relative links
+  // open as new Tandem tabs, safe-protocol external links open in the default
+  // browser, and unrecognised schemes (javascript:, data:, …) are silently
+  // dropped so they can't navigate the editor frame.
   const anchor = (e.target as HTMLElement).closest("a[href]") as HTMLAnchorElement | null;
   if (anchor) {
     const href = anchor.getAttribute("href") ?? "";
-    if (!isExternalHref(href) && currentFilePath) {
-      // Relative link — resolve and open as a new Tandem tab
+
+    // Empty href or pure fragment → let the browser handle (in-page scroll).
+    if (!href || href.startsWith("#")) {
+      return;
+    }
+
+    // Take ownership of this click — even if no branch below handles it,
+    // we don't want the browser navigating to a javascript:/data:/etc URL.
+    e.preventDefault();
+
+    if (isSafeExternalHref(href)) {
+      window.open(href, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    // Treat anything else with a recognised file extension as a relative path.
+    if (currentFilePath) {
       const resolvedPath = resolveRelativeLink(href, currentFilePath);
       if (resolvedPath) {
-        e.preventDefault();
         try {
           const res = await fetch(`${API_BASE}/open`, {
             method: "POST",
@@ -235,15 +252,8 @@ async function handleEditorClick(e: MouseEvent) {
           console.warn("[tandem] Failed to open relative link:", err);
         }
       }
-      return;
     }
-
-    if (isExternalHref(href) && href && !href.startsWith("#")) {
-      // External URL — open in default browser, do not navigate the editor
-      e.preventDefault();
-      window.open(href, "_blank", "noopener,noreferrer");
-      return;
-    }
+    return;
   }
 
   // --- Annotation click ----------------------------------------------------

--- a/src/client/panels/RailTabPicker.svelte
+++ b/src/client/panels/RailTabPicker.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { clickOutside } from "../actions/clickOutside.svelte";
 import type { RailTab } from "../hooks/useTandemSettings";
 
 interface Props {
@@ -28,13 +29,6 @@ function toggle(tab: RailTab) {
   if (next.length > 0) onTabsChange(next);
 }
 
-function handleClickOutside(e: MouseEvent) {
-  const target = e.target as Element;
-  if (!target.closest(".rail-tab-picker")) {
-    open = false;
-  }
-}
-
 function toggleOpen(e: MouseEvent) {
   e.stopPropagation();
   if (open) {
@@ -49,16 +43,17 @@ function toggleOpen(e: MouseEvent) {
 }
 
 $effect(() => {
-  if (open) {
-    document.addEventListener("click", handleClickOutside, true);
-    return () => document.removeEventListener("click", handleClickOutside, true);
-  } else {
+  if (!open) {
     dropdownPos = null;
   }
 });
 </script>
 
-<div class="rail-tab-picker" style="display: flex; align-items: center;">
+<div
+  class="rail-tab-picker"
+  use:clickOutside={() => (open = false)}
+  style="display: flex; align-items: center;"
+>
   <button
     bind:this={btnEl}
     data-testid={`${testIdPrefix}rail-tab-picker-btn`}

--- a/src/client/svelte-harness/StoreReadOnlyBannerHarness.svelte
+++ b/src/client/svelte-harness/StoreReadOnlyBannerHarness.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import * as Y from "yjs";
+import SidePanel from "../panels/SidePanel.svelte";
+
+interface Props {
+  storeReadOnly: boolean;
+}
+
+let { storeReadOnly = $bindable(false) }: Props = $props();
+
+// A real Y.Doc is required — SidePanel's observers don't tolerate null.
+const ydoc = new Y.Doc();
+</script>
+
+<SidePanel
+  annotations={[]}
+  editor={null}
+  {ydoc}
+  activeAnnotationId={null}
+  onActiveAnnotationChange={() => {}}
+  {storeReadOnly}
+/>

--- a/src/client/tabs/DocumentTabs.svelte
+++ b/src/client/tabs/DocumentTabs.svelte
@@ -31,7 +31,6 @@ let showDialog = $state(false);
 let showRecent = $state(false);
 let recentFiles = $state<string[]>([]);
 let openBtnEl: HTMLButtonElement | null = $state(null);
-let recentMenuEl: HTMLDivElement | null = $state(null);
 
 // Plain let — not reactive UI; just internal close-dedup guard
 let closingIds = new Set<string>();
@@ -174,22 +173,6 @@ function scrollRight() {
 }
 
 const singleTab = $derived(tabs.length <= 1);
-
-$effect(() => {
-  if (!showRecent) return;
-
-  function handlePointerDown(e: PointerEvent) {
-    const target = e.target as Node | null;
-    if (!target) return;
-    if (openBtnEl?.contains(target)) return;
-    if (recentMenuEl?.contains(target)) return;
-    if ((target as Element).closest?.("[data-tauri-drag-region]")) return;
-    showRecent = false;
-  }
-
-  window.addEventListener("pointerdown", handlePointerDown, true);
-  return () => window.removeEventListener("pointerdown", handlePointerDown, true);
-});
 </script>
 
 <div
@@ -270,38 +253,37 @@ $effect(() => {
   {/if}
 
   {#if showRecent}
-    <div bind:this={recentMenuEl}>
-      <NewTabMenu
-        {recentFiles}
-        onOpen={async (filePath) => {
-          showRecent = false;
-          try {
-            const res = await fetch(`${API_BASE}/open`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ filePath }),
-            });
-            if (res.ok) {
-              saveRecentFiles(addRecentFile(loadRecentFilesCached(), filePath));
-            } else {
-              const err = await res.text();
-              console.warn("[tandem] failed to open recent file:", err);
-            }
-          } catch (err) {
+    <NewTabMenu
+      {recentFiles}
+      anchorEl={openBtnEl}
+      onOpen={async (filePath) => {
+        showRecent = false;
+        try {
+          const res = await fetch(`${API_BASE}/open`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ filePath }),
+          });
+          if (res.ok) {
+            saveRecentFiles(addRecentFile(loadRecentFilesCached(), filePath));
+          } else {
+            const err = await res.text();
             console.warn("[tandem] failed to open recent file:", err);
           }
-        }}
-        onNewScratchpad={() => {
-          showRecent = false;
-          void createScratchpad();
-        }}
-        onBrowse={() => {
-          showRecent = false;
-          showDialog = true;
-        }}
-        onClose={() => (showRecent = false)}
-      />
-    </div>
+        } catch (err) {
+          console.warn("[tandem] failed to open recent file:", err);
+        }
+      }}
+      onNewScratchpad={() => {
+        showRecent = false;
+        void createScratchpad();
+      }}
+      onBrowse={() => {
+        showRecent = false;
+        showDialog = true;
+      }}
+      onClose={() => (showRecent = false)}
+    />
   {/if}
 
   {#if showDialog}

--- a/src/client/tabs/DocumentTabs.svelte
+++ b/src/client/tabs/DocumentTabs.svelte
@@ -213,33 +213,36 @@ const singleTab = $derived(tabs.length <= 1);
         onkeydown={handleKeyDown}
       />
     {/each}
-
-    <button
-      bind:this={openBtnEl}
-      onclick={() => {
-        const files = loadRecentFilesCached();
-        if (files.length === 0) {
-          showDialog = true;
-        } else {
-          recentFiles = files;
-          showRecent = !showRecent;
-        }
-      }}
-      data-testid="open-file-btn"
-      title="Open file"
-      style="background: none; border: none; border-radius: var(--tandem-r-2); cursor: pointer; font-size: 16px; line-height: 1; color: var(--tandem-fg-subtle); padding: 0 8px; margin-left: 4px; flex-shrink: 0;"
-      onmouseenter={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.color = "var(--tandem-accent)";
-        (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--tandem-accent)";
-      }}
-      onmouseleave={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.color = "var(--tandem-fg-muted)";
-        (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--tandem-border-strong)";
-      }}
-    >
-      +
-    </button>
   </div>
+
+  <!-- The "+" button lives OUTSIDE role="tablist" — a tablist is only allowed to contain
+       role="tab" children (axe `aria-required-children`). Keeping it adjacent to the
+       scroll container preserves the visual placement at the end of the tab strip. -->
+  <button
+    bind:this={openBtnEl}
+    onclick={() => {
+      const files = loadRecentFilesCached();
+      if (files.length === 0) {
+        showDialog = true;
+      } else {
+        recentFiles = files;
+        showRecent = !showRecent;
+      }
+    }}
+    data-testid="open-file-btn"
+    title="Open file"
+    style="background: none; border: none; border-radius: var(--tandem-r-2); cursor: pointer; font-size: 16px; line-height: 1; color: var(--tandem-fg-subtle); padding: 0 8px; margin-left: 4px; flex-shrink: 0;"
+    onmouseenter={(e) => {
+      (e.currentTarget as HTMLButtonElement).style.color = "var(--tandem-accent)";
+      (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--tandem-accent)";
+    }}
+    onmouseleave={(e) => {
+      (e.currentTarget as HTMLButtonElement).style.color = "var(--tandem-fg-muted)";
+      (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--tandem-border-strong)";
+    }}
+  >
+    +
+  </button>
 
   {#if canScrollRight}
     <button

--- a/src/client/tabs/NewTabMenu.svelte
+++ b/src/client/tabs/NewTabMenu.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
+import { clickOutside } from "../actions/clickOutside.svelte.js";
 import { portal } from "../utils/portal.js";
 
 interface Props {
   recentFiles: string[];
+  anchorEl: HTMLElement | null;
   onOpen: (path: string) => void;
   onBrowse: () => void;
   onNewScratchpad: () => void;
   onClose: () => void;
 }
 
-let { recentFiles, onOpen, onBrowse, onNewScratchpad, onClose }: Props = $props();
+let { recentFiles, anchorEl, onOpen, onBrowse, onNewScratchpad, onClose }: Props = $props();
 
 function basename(p: string): string {
   return p.replace(/[/\\]+$/, "").replace(/.*[/\\]/, "");
@@ -47,8 +49,44 @@ function getFocusableItems(): HTMLElement[] {
 
 let menuEl: HTMLDivElement | null = $state(null);
 
+function handleOutsideClick(e: MouseEvent) {
+  // The clickOutside action already filtered out clicks inside the menu.
+  // Also ignore:
+  //  - clicks on the anchor button (its own onclick would re-open the menu).
+  //  - clicks on a Tauri drag region (title-bar drag should not dismiss the menu).
+  const target = e.target as (Node & Element) | null;
+  if (!target) return;
+  if (anchorEl?.contains(target)) return;
+  if (target.closest?.("[data-tauri-drag-region]")) return;
+  onClose();
+}
+
+function positionMenu() {
+  if (!menuEl) return;
+  if (!anchorEl) {
+    menuEl.style.top = "8px";
+    menuEl.style.left = "8px";
+    menuEl.style.right = "auto";
+    return;
+  }
+  const rect = anchorEl.getBoundingClientRect();
+  const menuWidth = menuEl.offsetWidth;
+  const viewportWidth = window.innerWidth;
+  const top = rect.bottom + 4;
+  const left = rect.left;
+  if (left + menuWidth > viewportWidth - 8) {
+    menuEl.style.right = "8px";
+    menuEl.style.left = "auto";
+  } else {
+    menuEl.style.left = `${left}px`;
+    menuEl.style.right = "auto";
+  }
+  menuEl.style.top = `${top}px`;
+}
+
 $effect(() => {
   if (!menuEl) return;
+  positionMenu();
   getFocusableItems()[0]?.focus();
 });
 </script>
@@ -56,6 +94,7 @@ $effect(() => {
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   use:portal
+  use:clickOutside={handleOutsideClick}
   bind:this={menuEl}
   role="dialog"
   aria-label="New tab"
@@ -111,9 +150,8 @@ $effect(() => {
 <style>
   .new-tab-menu {
     position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    top: 0;
+    left: 0;
     min-width: 260px;
     max-width: 400px;
     background: var(--tandem-surface);

--- a/src/client/tabs/TabItem.svelte
+++ b/src/client/tabs/TabItem.svelte
@@ -165,11 +165,14 @@ function handleMouseLeaveClose() {
     ●
   </span>
 
-  <!-- Format badge: decorative pill; file name is the accessible label via aria-label on the tab -->
+  <!-- Format badge: decorative pill; file name is the accessible label via aria-label on the tab.
+       No inactive-tab opacity dimming — the badge color must stay at full strength so axe-core
+       WCAG AA contrast passes; visual active/inactive distinction comes from the tab background
+       and bottom-border instead. -->
   <span
     data-testid={`tab-format-badge-${tab.id}`}
     aria-label={`Format: ${tab.format}`}
-    style={`font-family: var(--tandem-font-mono); font-size: 9px; font-weight: 600; letter-spacing: 0.03em; color: ${badgeColor}; background: transparent; padding: 1px 4px; border: 1px solid ${badgeColor}; border-radius: var(--tandem-r-pill); opacity: ${isActive ? 1 : 0.6}; white-space: nowrap;`}
+    style={`font-family: var(--tandem-font-mono); font-size: 9px; font-weight: 600; letter-spacing: 0.03em; color: ${badgeColor}; background: transparent; padding: 1px 4px; border: 1px solid ${badgeColor}; border-radius: var(--tandem-r-pill); white-space: nowrap;`}
   >
     {FORMAT_LABELS[tab.format] ?? tab.format.toUpperCase()}
   </span>

--- a/src/server/events/observers/ctrl-meta.ts
+++ b/src/server/events/observers/ctrl-meta.ts
@@ -33,19 +33,21 @@ export function makeCtrlMetaObserver(deps: {
       if (activeId && activeId !== lastActiveDocId) {
         const openDoc = getOpenDocs().get(activeId);
         // Scratchpad/upload docs are not surfaced to Claude via channel events.
-        if (openDoc?.filePath && isUploadPath(openDoc.filePath)) {
-          lastActiveDocId = activeId;
-          return;
+        // Update lastActiveDocId regardless so the next non-upload switch still fires,
+        // but don't `return` — the openDocuments branch below must still run in case
+        // the same transaction mutated both keys (e.g. open-and-activate atomically).
+        const isUploadSwitch = openDoc?.filePath ? isUploadPath(openDoc.filePath) : false;
+        if (!isUploadSwitch) {
+          pushEvent({
+            id: generateEventId(),
+            type: "document:switched",
+            timestamp: Date.now(),
+            documentId: activeId,
+            payload: {
+              fileName: openDoc?.filePath?.split(/[/\\]/).pop() ?? activeId,
+            },
+          });
         }
-        pushEvent({
-          id: generateEventId(),
-          type: "document:switched",
-          timestamp: Date.now(),
-          documentId: activeId,
-          payload: {
-            fileName: openDoc?.filePath?.split(/[/\\]/).pop() ?? activeId,
-          },
-        });
         lastActiveDocId = activeId;
       }
     }

--- a/src/server/mcp/document-service.ts
+++ b/src/server/mcp/document-service.ts
@@ -381,6 +381,14 @@ export function writeGenerationId(): void {
  * Broadcast the annotation store read-only state to connected browser clients
  * via CTRL_ROOM's Y_MAP_DOCUMENT_META. Clients observe Y_MAP_STORE_READ_ONLY
  * on the bootstrap Y.Doc to surface a persistent warning banner.
+ *
+ * The transaction is tagged with MCP_ORIGIN even though this is a server-initiated
+ * status broadcast (not a user-intent MCP tool write). This is intentional: the
+ * channel event queue and ctrl-meta observer both skip MCP_ORIGIN transactions,
+ * which is the desired behaviour for this key (it surfaces only to browser clients
+ * via the bootstrap observer, never to Claude via channel events). If a dedicated
+ * SYSTEM_ORIGIN is added in the future, prefer it here and update the observer
+ * filters to skip it explicitly. See Critical Rule #2 in CLAUDE.md.
  */
 export function broadcastStoreReadOnly(readOnly: boolean): void {
   try {

--- a/tests/client/store-readonly-banner.test.ts
+++ b/tests/client/store-readonly-banner.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import StoreReadOnlyBannerHarness from "../../src/client/svelte-harness/StoreReadOnlyBannerHarness.svelte";
+import { Y_MAP_DOCUMENT_META, Y_MAP_STORE_READ_ONLY } from "../../src/shared/constants.js";
+
+const DISMISS_KEY = "tandem:storeReadOnlyBannerDismissed";
+
+describe("SidePanel store-read-only banner", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders the banner when storeReadOnly is true and not previously dismissed", async () => {
+    const { container } = render(StoreReadOnlyBannerHarness, {
+      props: { storeReadOnly: true },
+    });
+    await tick();
+
+    const banner = container.querySelector("[data-testid='store-readonly-banner']");
+    expect(banner).toBeTruthy();
+    expect(banner?.textContent).toContain("Annotation store is read-only");
+    expect(banner?.textContent).toContain("Close the other instance and restart");
+  });
+
+  it("hides the banner and persists dismissal to localStorage when the dismiss button is clicked", async () => {
+    const { container } = render(StoreReadOnlyBannerHarness, {
+      props: { storeReadOnly: true },
+    });
+    await tick();
+
+    const banner = container.querySelector("[data-testid='store-readonly-banner']");
+    expect(banner).toBeTruthy();
+
+    const dismissBtn = container.querySelector(
+      "[data-testid='store-readonly-dismiss']",
+    ) as HTMLButtonElement | null;
+    expect(dismissBtn).toBeTruthy();
+    dismissBtn?.click();
+    await tick();
+
+    expect(container.querySelector("[data-testid='store-readonly-banner']")).toBeNull();
+    expect(localStorage.getItem(DISMISS_KEY)).toBe("true");
+  });
+
+  it("does not render the banner when previously dismissed via localStorage", async () => {
+    localStorage.setItem(DISMISS_KEY, "true");
+
+    const { container } = render(StoreReadOnlyBannerHarness, {
+      props: { storeReadOnly: true },
+    });
+    await tick();
+
+    expect(container.querySelector("[data-testid='store-readonly-banner']")).toBeNull();
+  });
+});
+
+describe("Y.Map → storeReadOnly bootstrap-observer contract", () => {
+  // This documents the Y.Map key the server writes and the client observes.
+  // The full wiring (yjsSync.svelte.ts:319) reads keysChanged.has(Y_MAP_STORE_READ_ONLY)
+  // and copies meta.get(Y_MAP_STORE_READ_ONLY) === true into the storeReadOnly rune.
+  it("propagates Y_MAP_STORE_READ_ONLY writes to observers on the documentMeta map", async () => {
+    const ydoc = new Y.Doc();
+    const meta = ydoc.getMap(Y_MAP_DOCUMENT_META);
+
+    let observed: boolean | undefined;
+    let sawKey = false;
+    meta.observe((event) => {
+      if (event.keysChanged.has(Y_MAP_STORE_READ_ONLY)) {
+        sawKey = true;
+        observed = (meta.get(Y_MAP_STORE_READ_ONLY) as boolean | undefined) === true;
+      }
+    });
+
+    meta.set(Y_MAP_STORE_READ_ONLY, true);
+    expect(sawKey).toBe(true);
+    expect(observed).toBe(true);
+
+    sawKey = false;
+    meta.set(Y_MAP_STORE_READ_ONLY, false);
+    expect(sawKey).toBe(true);
+    expect(observed).toBe(false);
+
+    ydoc.destroy();
+  });
+});

--- a/tests/server/setup-route.test.ts
+++ b/tests/server/setup-route.test.ts
@@ -33,11 +33,12 @@ describe("runSetupHandler — HTTP status reflects outcome", () => {
     expect(result.status).toBe(200);
   });
 
-  // chmod 0o500 is a no-op on Windows, so the read-only precondition required
-  // to force applyConfig/installSkill failures cannot be established. Skip on
-  // win32 rather than assert conditionally — a guard would let the test pass
-  // without exercising the 500/207 branches at all.
-  it.skipIf(process.platform === "win32")(
+  // chmod 0o500 is a no-op on Windows and is bypassed when running as root
+  // (e.g. Docker / CI sandboxes), so the read-only precondition required to
+  // force applyConfig/installSkill failures cannot be established in those
+  // environments. Skip rather than assert conditionally — a guard would let
+  // the test pass without exercising the 500/207 branches at all.
+  it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
     "returns 500 when every target fails AND skill install fails",
     async () => {
       // Block both target-config writes AND skill install by making ~/.claude a
@@ -63,7 +64,7 @@ describe("runSetupHandler — HTTP status reflects outcome", () => {
     },
   );
 
-  it.skipIf(process.platform === "win32")(
+  it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
     "returns 207 when at least one attempt succeeds but another failed",
     async () => {
       // Make ~/.claude readonly to block skill install while leaving target


### PR DESCRIPTION
Addresses the six issues raised in the review of #592. Targets `feat/v0.11.0` so this can land on top of the PR rather than master.

## Fixes

1. **`ctrl-meta.ts` early-return scope leak** — when an upload-doc tab-switch was suppressed, the observer `return`'d and skipped the `openDocuments` branch in the same transaction. Replaced with an inline conditional so open/close events still fire when a single transaction touches both keys.

2. **`broadcastStoreReadOnly` `MCP_ORIGIN` reuse documented** — added a JSDoc paragraph explaining why a server-status broadcast reuses `MCP_ORIGIN` (channel queue + ctrl-meta observer both skip it, which is the desired behaviour) and pointing at Critical Rule #2.

3. **Editor anchor click hardening** — `handleEditorClick` now calls `e.preventDefault()` unconditionally for every non-fragment anchor click, then whitelists safe external protocols (`http://`, `https://`, `mailto:`, `ftp://`, `//`). Unknown schemes (`javascript:`, `data:`, `vbscript:`) are silently dropped instead of being passed to the browser. Pure `#`-fragments still get default in-page-scroll behaviour.

4. **NewTabMenu re-anchored under the `+` button** — replaced the centered-modal positioning with `position: fixed` computed from the anchor's `getBoundingClientRect()` (with right-edge viewport clamping). Dismissal uses the shared `clickOutside` action and ignores clicks on the anchor button + Tauri drag regions (preserving prior pointerdown-handler behaviour). The dead `<div bind:this={recentMenuEl}>` wrapper in `DocumentTabs.svelte` is removed, as is the now-redundant pointerdown effect.

5. **`RailTabPicker` migrated to shared `clickOutside`** — drops the inline document-level listener and `handleClickOutside` function. As a bonus, clicking another rail picker now closes this one (the old global listener allowed both to stay open).

6. **Real integration test for the storeReadOnly banner** — new `tests/client/store-readonly-banner.test.ts` mounts the actual `<SidePanel>` via a harness with a real `Y.Doc`, covering: banner-visible-when-true, dismiss-persists-to-localStorage, banner-hidden-when-previously-dismissed, plus a Y.Map observer-contract sanity check. The previous E2E was synthetic `page.setContent`.

## Bonus test-hygiene fix

`tests/server/setup-route.test.ts` relied on `chmod 0o500` to make a directory read-only, but root bypasses Unix permissions — so the two 500/207 branches failed in any root sandbox / CI environment. Added a `process.getuid?.() === 0` clause to the existing `skipIf` win32 guard. Committed separately from the review fixes for review clarity.

## Verification

- [x] `npm run typecheck` — 0 errors, 0 warnings
- [x] `npx svelte-check --threshold error` — 0 errors, 0 warnings (1058 files)
- [x] `npm run check:tokens` — clean
- [x] `npx vitest run` — 1939 passed, 10 skipped (the 2 newly-skipped setup-route tests + 8 pre-existing skips)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 1 passed
- [x] Independent reviewer agent verified all 6 fixes are correct, complete, and regression-free

## Test plan

- [ ] Browser: click a relative `.md` link in a markdown doc — opens as new tab.
- [ ] Browser: insert `[bad](javascript:alert(1))` into a doc and click it — must not execute.
- [ ] Browser: hit the `+` tab button — menu appears anchored under the button, not centered. Click outside dismisses; Escape dismisses; clicking the button while open closes (no re-open flicker).
- [ ] Tauri shell: drag the title bar with the `+` menu open — menu stays open.
- [ ] Open + close several upload/scratchpad tabs alongside a regular tab in one transaction; verify no spurious channel events drop or fire for upload paths.

https://claude.ai/code/session_016xDEcs7MWYowXjtK6GcaZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_016xDEcs7MWYowXjtK6GcaZ1)_