### PR TITLE
fix(sidecar): scope health-reuse to debug builds + token-violation hook fix

### DIFF
--- a/.claude/hooks/check-token-violation.sh
+++ b/.claude/hooks/check-token-violation.sh
@@ -28,11 +28,16 @@ if [[ -z "$FILE_PATH" ]] || [[ ! "$FILE_PATH" =~ /src/client/ ]] || [[ ! "$FILE_
 fi
 
 RC=0
+# Scanner writes all output (per-violation file:line: token + summary) to stderr.
+# On PostToolUse exit 2, Claude Code shows stderr to Claude as feedback and
+# ignores stdout — so the BLOCKED framing below MUST also go to stderr,
+# otherwise Claude self-correct (continueOnBlock) has only the generic message
+# and not the actionable file:line details.
 npx tsx scripts/check-semantic-tokens.ts "$FILE_PATH" || RC=$?
 if [[ $RC -eq 1 ]]; then
-  echo "BLOCKED: Raw hex/rgba color tokens in client code — use semantic --tandem-* CSS variables."
-  echo "Fix: Replace raw color values with var(--tandem-*) tokens or import from src/client/utils/colors.ts."
+  echo "BLOCKED: Raw hex/rgba color tokens in client code — use semantic --tandem-* CSS variables." >&2
+  echo "Fix: Replace raw color values with var(--tandem-*) tokens or import from src/client/utils/colors.ts." >&2
   exit 2
 elif [[ $RC -ge 2 ]]; then
-  echo "⚠ Token scanner failed (exit $RC) — check skipped for this edit."
+  echo "⚠ Token scanner failed (exit $RC) — check skipped for this edit." >&2
 fi

--- a/.claude/hooks/check-token-violation.sh
+++ b/.claude/hooks/check-token-violation.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # PostToolUse hook: warn on raw hex/rgba colors in client code
 # Delegates to scripts/check-semantic-tokens.ts for accurate detection
-# Exit 0 = no block, just warns
+# Exit 2 + continueOnBlock = Claude self-corrects the violation; exit 0 = clean
 
 set -euo pipefail
 trap 'exit 0' ERR
@@ -28,7 +28,11 @@ if [[ -z "$FILE_PATH" ]] || [[ ! "$FILE_PATH" =~ /src/client/ ]] || [[ ! "$FILE_
 fi
 
 RC=0
-npx tsx scripts/check-semantic-tokens.ts "$FILE_PATH" 2>&1 || RC=$?
-if [[ $RC -ge 2 ]]; then
+npx tsx scripts/check-semantic-tokens.ts "$FILE_PATH" || RC=$?
+if [[ $RC -eq 1 ]]; then
+  echo "BLOCKED: Raw hex/rgba color tokens in client code — use semantic --tandem-* CSS variables."
+  echo "Fix: Replace raw color values with var(--tandem-*) tokens or import from src/client/utils/colors.ts."
+  exit 2
+elif [[ $RC -ge 2 ]]; then
   echo "⚠ Token scanner failed (exit $RC) — check skipped for this edit."
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,7 +54,8 @@
           },
           {
             "type": "command",
-            "command": "bash .claude/hooks/check-token-violation.sh"
+            "command": "bash .claude/hooks/check-token-violation.sh",
+            "continueOnBlock": true
           },
           {
             "type": "command",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 - [Agent Workflow](.claude/skills/issue-pipeline/SKILL.md) -- 10-step agent-driven issue pipeline (`/issue-pipeline`)
 - [Roadmap](docs/roadmap.md) -- Phase 2+ roadmap, future extensions
 - [Design Decisions](docs/decisions.md) -- ADRs (001-029)
-- [Lessons Learned](docs/lessons-learned.md) -- 67 lessons including E2E testing gotchas
+- [Lessons Learned](docs/lessons-learned.md) -- 68 lessons including E2E testing gotchas
 
 ## Critical Rules
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -587,7 +587,7 @@ graph TB
 On launch, the Rust core:
 
 1. Copies `sample/` files to the writable app-data dir (first run only — skips if destination exists)
-2. Checks whether the server is already healthy (`GET /health`) — skips spawn in dev mode if `npm run dev:standalone` is already running
+2. In **debug builds only** (`cfg!(debug_assertions)`), checks whether a server is already healthy (`GET /health`) and skips spawn if so — supports the `cargo tauri dev` + `npm run dev:standalone` workflow. Release builds always spawn their own sidecar (the early-return was gated after a stale `tsx watch` dev session was found answering `/health` for the installed app, producing a silent "Disconnected" state with mismatched auth/session). `freePort()` in the sidecar handles any port conflict on bind.
 3. Spawns `node-sidecar` (bundled Node.js binary named with target triple) with `dist/server/index.js` as the entry point and `TANDEM_DATA_DIR` set to the platform app-data dir
 4. Polls `GET http://localhost:3479/health` every 200ms with a 15s timeout
 5. On crash, retries up to `MAX_RESTARTS = 3` times with exponential backoff (1s, 2s, 4s)

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -621,3 +621,11 @@ Mirror the identical step already present in `tauri-release.yml`.
 **Problem:** In v0.11.0 planning, ~half of the scoped issues were already closed (#507, #492, #513–#522, #541) before implementation started. Dispatching agents to implement already-done work wastes significant time.
 
 **Solution:** Always spend 5 minutes running `gh issue view <N>` on every milestoned issue before writing any code. For QA-closeout batches especially, do the triage pass first — it may eliminate the entire batch.
+
+## 68. "Frozen Desktop UI" with Working Hover/Right-Click = Server Disconnected, Not JS-Hung
+
+**Problem:** A user reported the v0.11.0 desktop app appeared frozen — buttons unresponsive — but the mouse cursor still changed on hover, native tooltips showed, and right-click worked. This pattern is easy to misdiagnose as a Svelte reactive loop / JS infinite loop (and the codebase has prior incidents of both). The actual cause was a stale `tsx watch src/server/index.ts` from an old `npm run dev:server` session squatting on ports 3478/3479 — the installed app's `start_sidecar` (`src-tauri/src/lib.rs:377`) did `if check_health() { skip spawn }`, trusted the dev server, but the WS handshake failed silently because of mismatched auth/session state. The status bar in fact reported "Disconnected", but the symptom description focused on "frozen UI."
+
+**Solution (diagnostic):** When a desktop "frozen UI" is reported, **before** reading any Svelte/Tiptap code: (1) `Get-NetTCPConnection -LocalPort 3478,3479 -State Listen` and confirm the owning PID is a `node-sidecar.exe` (not a generic `node.exe` from a dev session); (2) `curl http://127.0.0.1:3479/health` to confirm version and `hasSession`; (3) look at the actual status-bar text — CSS hover, native tooltips, and right-click are all browser features that work without app JS, so "those still work" is consistent with disconnected just as much as with frozen JS.
+
+**Solution (code):** Gate the `check_health` reuse early-return in `start_sidecar` on `cfg!(debug_assertions)`. Release builds always spawn their own sidecar; `freePort()` resolves port conflicts cleanly. Also drop `stdio: "ignore"` from `taskkill` in `freePortWindows` so any future kill failure is logged and diagnosable instead of silent.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -373,9 +373,14 @@ fn build_http_client(timeout: Duration) -> Result<reqwest::Client, String> {
 /// Spawn the Node.js sidecar and wait for the health endpoint.
 /// Retries up to MAX_RESTARTS times with exponential backoff on crash.
 async fn start_sidecar(handle: &tauri::AppHandle, client: &reqwest::Client) -> Result<(), String> {
-    // Dev mode: skip spawn if server is already running (e.g. npm run dev:standalone)
-    if check_health(&client).await {
-        log::info!("Server already healthy — skipping sidecar spawn");
+    // Debug-only: skip spawn if a server is already running (e.g. `npm run dev:standalone`
+    // alongside `cargo tauri dev`). In release builds the installed app must own its
+    // sidecar exclusively — a stale `tsx watch` dev session, an older release process,
+    // or any other listener on the MCP/WS ports can answer /health but be incompatible
+    // with this app's auth token / session state, leaving the UI stuck on "Disconnected".
+    // The sidecar's own `freePort()` step on start handles port conflicts cleanly.
+    if cfg!(debug_assertions) && check_health(&client).await {
+        log::info!("Server already healthy — skipping sidecar spawn (debug build)");
         return Ok(());
     }
 

--- a/src/server/platform.ts
+++ b/src/server/platform.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import envPaths from "env-paths";
 import net from "net";
 import path from "path";
@@ -92,8 +92,27 @@ function freePortWindows(port: number): void {
   });
   const pid = out.trim().split(/\s+/).at(-1);
   if (pid && /^\d+$/.test(pid)) {
-    execSync(`taskkill /PID ${pid} /F`, { stdio: "ignore" });
-    console.error(`[Tandem] Killed stale PID ${pid} holding port ${port}`);
+    try {
+      const killOut = execFileSync("taskkill", ["/PID", pid, "/F"], {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      console.error(`[Tandem] Killed stale PID ${pid} holding port ${port}: ${killOut.trim()}`);
+    } catch (err) {
+      // Surface taskkill failure (permission denied, cross-session, race) so a
+      // subsequent port-bind EADDRINUSE is diagnosable. The prior `stdio: "ignore"`
+      // masked these and left the user with a silent "Disconnected" state.
+      const stderr =
+        err && typeof err === "object" && "stderr" in err
+          ? String((err as { stderr: unknown }).stderr ?? "")
+          : "";
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[Tandem] taskkill failed for PID ${pid} on port ${port}: ${message}${
+          stderr ? ` — stderr: ${stderr.trim()}` : ""
+        }`,
+      );
+    }
   }
 }
 

--- a/src/server/platform.ts
+++ b/src/server/platform.ts
@@ -97,7 +97,12 @@ function freePortWindows(port: number): void {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
       });
-      console.error(`[Tandem] Killed stale PID ${pid} holding port ${port}: ${killOut.trim()}`);
+      // Some taskkill paths exit 0 with empty stdout — avoid a dangling
+      // ": " in the log when there's no message to append.
+      const trimmed = killOut.trim();
+      console.error(
+        `[Tandem] Killed stale PID ${pid} holding port ${port}${trimmed ? `: ${trimmed}` : ""}`,
+      );
     } catch (err) {
       // Surface taskkill failure (permission denied, cross-session, race) so a
       // subsequent port-bind EADDRINUSE is diagnosable. The prior `stdio: "ignore"`


### PR DESCRIPTION
## Summary

Two unrelated fixes that landed together on a fix branch.

### fix(sidecar): scope health-reuse to debug builds; surface taskkill errors (c341605)

Release builds always spawn their own sidecar now. A stale `tsx watch src/server/index.ts` from a `npm run dev:server` session was squatting on :3478/:3479 and answering `/health`, so `start_sidecar` reused it and left the installed Tauri app's UI stuck on "Disconnected" — hover and right-click worked, but every action needing the server failed silently because the auth/session state didn't match.

- `check_health` early-return now gated on `cfg!(debug_assertions)` so it still helps `cargo tauri dev` + `npm run dev:standalone`.
- Dropped `stdio: "ignore"` from the Windows `taskkill` path so any future port-bind failure (permission denied, cross-session kill rejection, race) is logged instead of silent.
- `freePortWindows` now uses `execFileSync` (no shell) and surfaces stdout/stderr on failure.
- Docs: `architecture.md` sidecar lifecycle, `lessons-learned.md` #68.

### fix(hooks): promote token violation hook to blocking via continueOnBlock (0f8f983)

`scripts/check-semantic-tokens.ts` exits `1` for violations, but the hook only checked `rc >= 2` — silently dropping real violations. Fixed the exit-code mapping and enabled `continueOnBlock` so Claude self-corrects raw hex/rgba in the same turn.

## Test plan

- [ ] Install the built Tauri release while `npm run dev:server` is also running → installed app spawns its own sidecar on a free port (no health-reuse)
- [ ] `cargo tauri dev` with `dev:standalone` running → health-reuse still works
- [ ] Manually inject a raw `#abc123` into a `src/client/` file → hook now blocks with the violation report
- [ ] Windows: trigger a port-bind failure and confirm `taskkill` output is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)