### PR TITLE
fix(shell): open CHANGELOG read-only on upgrade auto-open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Tandem will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **CHANGELOG.md no longer rewritten on upgrade** — On version upgrade the app auto-opens `CHANGELOG.md` so the user can see what changed. Previously this opened writable, and the 60-second autosave timer would round-trip the file through `remark-stringify` with default escaping, leaving cosmetic backslash-escape noise on disk (`[1.0.0]` → `\[1.0.0]`, escaped underscores and backticks). The upgrade auto-open path now passes `readOnly: true`, matching the existing "View Changelog" button in Settings; autosave skips read-only documents so the file is not re-serialized.
+
 ## \[0.11.0] - 2026-05-11
 
 ### Added

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -355,10 +355,12 @@ async function main() {
     const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
     // Open CHANGELOG.md as active tab on first startup after an update.
+    // Opened read-only so the 60s autosave timer does not round-trip the file
+    // through the markdown serializer and rewrite it with escape noise.
     try {
       const versionStatus = await checkVersionChange(APP_VERSION, LAST_SEEN_VERSION_FILE);
       if (versionStatus === "upgraded") {
-        await openFileByPath(path.join(projectRoot, "CHANGELOG.md"));
+        await openFileByPath(path.join(projectRoot, "CHANGELOG.md"), { readOnly: true });
         console.error(`[Tandem] Opened CHANGELOG.md (upgraded to v${APP_VERSION})`);
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

- On every upgrade the server auto-opens `CHANGELOG.md` so the user sees what changed.
- Opening it writable meant the 60s autosave timer round-tripped the file through `remark-stringify` with default escaping, leaving cosmetic backslash-escape noise on disk (`[1.0.0]` → `\[1.0.0]`, escaped underscores and backticks). This caused dirty working trees on dev machines and silent rewrites of users' shipped `CHANGELOG.md` on their installs.
- Fix: pass `readOnly: true` to the upgrade-path `openFileByPath` call, matching what the existing "View Changelog" button in Settings already does. `autoSaveAllToDisk` (`document-service.ts:219`) already skips read-only documents, so no save-path change is needed.

## Why no new test?

The mechanism is already covered by `tests/server/file-opener-edge-cases.test.ts`:
- `:208` — fresh-open with `{ readOnly: true }` opens the file read-only.
- `:231` — re-opening an already-open writable file with `{ readOnly: true }` upgrades both the open-docs registry and the Y.Doc meta.
- `:258`, `:276`, `:315` — additional readOnly variants via the API route.

The new line in `src/server/index.ts` is 3 LOC of glue that calls `openFileByPath(file, { readOnly: true })`. Adding a startup-flow test would require refactoring `main()` and mocking `checkVersionChange`/`LAST_SEEN_VERSION_FILE` — disproportionate for the change size.

## Follow-up (v1.0 blocker, separate PR)

The underlying `remark-stringify` over-escape still affects **any** `.md` file a user round-trips through Tandem (e.g., open `notes.md`, edit, autosave — file now has `\[`, `\_`, etc.). Will be tracked as a v1.0-tagged issue with proper golden-file fixtures in `src/server/file-io/markdown.ts`.

## Test plan

- [x] `npm run typecheck` — clean (795 files, 0 errors, 0 warnings)
- [x] `npm test -- --run tests/server/file-opener-edge-cases.test.ts` — 26/26 pass
- [ ] Local manual: bump `package.json` patch, `npm run build && npm run start:server` → CHANGELOG opens with read-only banner; attempt edit blocked; after 60s autosave window `git status` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)