### PR TITLE
fix(client): truncate display name to USER_NAME_MAX_LEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **CHANGELOG.md no longer rewritten on upgrade** — On version upgrade the app auto-opens `CHANGELOG.md` so the user can see what changed. Previously this opened writable, and the 60-second autosave timer would round-trip the file through `remark-stringify` with default escaping, leaving cosmetic backslash-escape noise on disk (`[1.0.0]` → `\[1.0.0]`, escaped underscores and backticks). The upgrade auto-open path now passes `readOnly: true`, matching the existing "View Changelog" button in Settings; autosave skips read-only documents so the file is not re-serialized.
+- **Display name truncated to `USER_NAME_MAX_LEN` (closes #599)** — `resolveUserName` now slices to the 40-char limit, plugging the gap where `persistUserName` and `subscribeToUserName`'s storage handler could persist or broadcast unbounded names from programmatic `setUserName` calls or legacy localStorage values. The `<input maxlength>` cap on the typed-input path remains; this fix covers the non-UI entry points.
 
 ## \[0.11.0] - 2026-05-11
 

--- a/src/client/hooks/useUserName.ts
+++ b/src/client/hooks/useUserName.ts
@@ -1,7 +1,14 @@
-import { USER_NAME_DEFAULT, USER_NAME_EVENT, USER_NAME_KEY } from "../../shared/constants";
+import {
+  USER_NAME_DEFAULT,
+  USER_NAME_EVENT,
+  USER_NAME_KEY,
+  USER_NAME_MAX_LEN,
+} from "../../shared/constants";
 
 export function resolveUserName(stored: string | null | undefined): string {
-  return stored?.trim() || USER_NAME_DEFAULT;
+  const trimmed = stored?.trim();
+  if (!trimmed) return USER_NAME_DEFAULT;
+  return trimmed.slice(0, USER_NAME_MAX_LEN);
 }
 
 export function readStoredName(): string {

--- a/tests/client/user-name.test.ts
+++ b/tests/client/user-name.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { persistUserName, resolveUserName } from "../../src/client/hooks/useUserName.js";
-import { USER_NAME_DEFAULT, USER_NAME_EVENT, USER_NAME_KEY } from "../../src/shared/constants.js";
+import {
+  USER_NAME_DEFAULT,
+  USER_NAME_EVENT,
+  USER_NAME_KEY,
+  USER_NAME_MAX_LEN,
+} from "../../src/shared/constants.js";
 
 describe("resolveUserName", () => {
   it("returns stored name when valid", () => {
@@ -25,6 +30,16 @@ describe("resolveUserName", () => {
 
   it("trims whitespace from valid name", () => {
     expect(resolveUserName("  Bob  ")).toBe("Bob");
+  });
+
+  it("truncates names longer than USER_NAME_MAX_LEN", () => {
+    const long = "a".repeat(USER_NAME_MAX_LEN + 100);
+    expect(resolveUserName(long)).toHaveLength(USER_NAME_MAX_LEN);
+  });
+
+  it("does not truncate names exactly at USER_NAME_MAX_LEN", () => {
+    const exact = "a".repeat(USER_NAME_MAX_LEN);
+    expect(resolveUserName(exact)).toBe(exact);
   });
 });
 
@@ -79,6 +94,13 @@ describe("persistUserName — write + broadcast contract", () => {
 
   it("returns the trimmed value that was persisted", () => {
     expect(persistUserName("  Carol  ")).toBe("Carol");
+  });
+
+  it("truncates names longer than USER_NAME_MAX_LEN before persisting", () => {
+    const long = "B".repeat(USER_NAME_MAX_LEN + 50);
+    const returned = persistUserName(long);
+    expect(returned).toHaveLength(USER_NAME_MAX_LEN);
+    expect(store.get(USER_NAME_KEY)).toHaveLength(USER_NAME_MAX_LEN);
   });
 
   it("swallows localStorage.setItem errors (incognito/quota) but still dispatches", () => {


### PR DESCRIPTION
## Summary

- Closes #599.
- `persistUserName` called `resolveUserName` which trimmed whitespace but never sliced to `USER_NAME_MAX_LEN` (40). Programmatic `setUserName` calls and legacy localStorage values could therefore persist and broadcast unbounded names.
- The `<input maxlength>` attribute on `StatusBar.svelte` and `SettingsPopover.svelte` already caps the typed-input path, so the bug was only reachable via non-UI entry points — narrow blast radius, but worth one chokepoint fix.

## Why one slice, not two

The plan called for slicing in both `persistUserName` and `resolveUserName`. On closer reading, every call site already routes through `resolveUserName`:

- `persistUserName(name)` → `resolveUserName(name)` → sliced → written.
- `readStoredName()` → `resolveUserName(localStorage.getItem(...))` → sliced on read (covers legacy long values).
- `subscribeToUserName` storage handler → `resolveUserName(e.newValue)` → sliced on cross-tab change.

A single slice in `resolveUserName` is the chokepoint; duplicating it in `persistUserName` would be defense-in-depth against a refactor that hasn't happened. Kept it simple.

## Test plan

- [x] Three new unit tests in `tests/client/user-name.test.ts`:
  - `resolveUserName` slices a 140-char input to `USER_NAME_MAX_LEN`.
  - `resolveUserName` leaves a value exactly at the limit unchanged.
  - `persistUserName` writes the truncated value to localStorage.
- [x] `npm test -- --run tests/client/user-name.test.ts` — 14/14 pass.
- [x] `npm run typecheck` — clean (795 files, 0 errors, 0 warnings).
- [ ] Manual: type a long name in `settings-display-name`, click off, reopen settings — confirm display is truncated. (Existing `maxlength` input attribute already prevents this entry path; this is a regression-guard for non-UI paths.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)