### PR TITLE
fix(tutorial): re-anchor highlight-1 and comment-1 to current welcome.md

### DIFF
--- a/src/server/mcp/tutorial-annotations.ts
+++ b/src/server/mcp/tutorial-annotations.ts
@@ -21,14 +21,14 @@ const TUTORIAL_ANNOTATIONS: TutorialAnnotationDef[] = [
   {
     id: `${TUTORIAL_ANNOTATION_PREFIX}highlight-1`,
     type: "highlight",
-    targetText: "collaborative document editor",
+    targetText: "highlight text and Claude sees it",
     content: "This is a highlight \u2014 it marks text for attention without suggesting changes.",
     color: "yellow",
   },
   {
     id: `${TUTORIAL_ANNOTATION_PREFIX}comment-1`,
     type: "comment",
-    targetText: "review your documents",
+    targetText: "edit this document at the same time",
     content: "Comments let you or Claude leave notes on specific text passages.",
   },
   {


### PR DESCRIPTION
## Summary

- Two of the four tutorial annotations (`highlight-1`, `comment-1`) have been silently failing to inject since `acb81fd` (Mar 2026), which rewrote welcome.md's intro but didn't update the matching `targetText` anchors in `tutorial-annotations.ts`.
- `indexOf("collaborative document editor")` and `indexOf("review your documents")` returned -1 in current welcome.md, the injector logged `[tutorial] Target text ... not found` to stderr, and only the `suggest-1` and `note-1` tutorial annotations actually appeared.
- Re-points both anchors to phrases that exist verbatim in the current welcome.md (each occurs exactly once, so `indexOf` is unambiguous).

This restores the redesign's "teach the vocabulary in situ" tutorial behaviour. AR6 expansion (5-type tutorial + import example) remains v0.12.0 scope per `docs/roadmap.md`.

## Why this isn't AR6 scope creep

AR6 in [docs/roadmap.md:519](../blob/master/docs/roadmap.md#L519) covers *new* tutorial entries (audience-first variants + Word import batch-promote example). This PR only fixes the existing entries that already exist in code but no longer match the welcome.md copy. Pure defect repair, no new behaviour.

## Test plan

- [x] `npm run typecheck` clean
- [x] Anchor uniqueness verified: each replacement string occurs exactly once in `sample/welcome.md`
- [x] E2E `tests/e2e/onboarding-tutorial.spec.ts` does not depend on tutorial annotation text (only tutorial-overlay panel copy)
- [ ] Manual smoke: open `sample/welcome.md`, confirm yellow highlight on "highlight text and Claude sees it" and Claude comment on "edit this document at the same time"

🤖 Generated with [Claude Code](https://claude.com/claude-code)