### PR TITLE
fix(v0.11.2): break Svelte effect_update_depth loop on Tauri launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-05-13
+
+### Fixed
+
+- **`effect_update_depth_exceeded` on Tauri launch (PR #614, closes #613)** — installed v0.11.1 desktop builds threw Svelte's effect-depth error immediately on launch; the dev build (`npm run dev:tauri`) did not reproduce, narrowing the trigger to production-mode effect-flush scheduling. Three defense-in-depth fixes: (1) the authorship-toggle effect in `App.svelte` no longer dispatches a ProseMirror transaction on its first run — the plugin already reads `localStorage[AUTHORSHIP_TOGGLE_KEY]` at construction so the editor starts in the correct state; (2) rail-tab reconcile effects now `untrack` their writes to break any read-then-write self-dep; (3) the SettingsPopover error-clear effect skips assignment when values are already null. The existing in-code comment had explicitly warned this dispatch could "exceed the 1000-update depth limit"; under prod's tighter effect scheduling it did.
+
 ## [0.11.1] - 2026-05-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-editor",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-editor",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "BUSL-1.1",
       "dependencies": {
         "@hocuspocus/provider": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Edit and iterate on documents with Claude — no copy-paste, real-time push via plugin monitor",
   "repository": {
     "type": "git",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "identifier": "com.tandem.editor",
   "build": {
     "frontendDist": "../dist/client",

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -141,16 +141,32 @@ wireActionDeps({
 // call to updateSettings() (which replaces the entire settings object even
 // when showAuthorship is unchanged) would dispatch a transaction, causing
 // FormattingToolbar's tick++ listener to fire inside Svelte's effect flush
-// and eventually exceed the 1000-update depth limit.
+// and eventually exceed the 1000-update depth limit (#613).
+//
+// First-run note: on the editor's initial availability we record the current
+// `visible` value WITHOUT dispatching. The authorship plugin reads
+// `localStorage[AUTHORSHIP_TOGGLE_KEY]` at construction time
+// (`useTandemSettings.svelte.ts` mirrors `showAuthorship` to that key on every
+// write) so the editor already starts in the correct state. Dispatching on
+// the first run was needed in the React era when the plugin had no localStorage
+// hook, and it is exactly the path that produced #613's prod-only effect-depth
+// loop — likely chained through y-prosemirror's transaction queue under prod's
+// tighter scheduling.
 let _lastAuthorshipVisible: boolean | undefined;
 $effect(() => {
   const ed = editor;
   if (!ed) return;
   const visible = settingsState.settings.showAuthorship;
+  if (_lastAuthorshipVisible === undefined) {
+    _lastAuthorshipVisible = visible;
+    return;
+  }
   if (_lastAuthorshipVisible === visible) return;
   _lastAuthorshipVisible = visible;
-  const tr = ed.state.tr.setMeta(authorshipPluginKey, { type: "toggle", visible });
-  ed.view.dispatch(tr);
+  untrack(() => {
+    const tr = ed.state.tr.setMeta(authorshipPluginKey, { type: "toggle", visible });
+    ed.view.dispatch(tr);
+  });
 });
 
 $effect(() => {
@@ -180,14 +196,24 @@ let activeLeftRailTab = $state<"annotations" | "chat" | "outline">(
 
 // Reconcile active-tab pointers whenever the persisted rail arrays change
 // (e.g. after settings load, cross-rail move, or external settings update).
+//
+// `untrack` around the write so the write back to activeLeftRailTab /
+// activeRailTab doesn't form a self-dep with this effect's includes() read.
+// Defensive against the prod-only #613 effect_update_depth shape.
 $effect(() => {
-  if (!settingsState.settings.leftRailTabs.includes(activeLeftRailTab)) {
-    activeLeftRailTab = settingsState.settings.leftRailTabs[0] ?? "annotations";
+  const leftTabs = settingsState.settings.leftRailTabs;
+  if (!leftTabs.includes(activeLeftRailTab)) {
+    untrack(() => {
+      activeLeftRailTab = leftTabs[0] ?? "annotations";
+    });
   }
 });
 $effect(() => {
-  if (!settingsState.settings.rightRailTabs.includes(activeRailTab)) {
-    activeRailTab = settingsState.settings.rightRailTabs[0] ?? "chat";
+  const rightTabs = settingsState.settings.rightRailTabs;
+  if (!rightTabs.includes(activeRailTab)) {
+    untrack(() => {
+      activeRailTab = rightTabs[0] ?? "chat";
+    });
   }
 });
 

--- a/src/client/components/SettingsPopover.svelte
+++ b/src/client/components/SettingsPopover.svelte
@@ -139,10 +139,14 @@ let activeSection = $state<SettingsSection>("appearance");
 // Clear stale fetch errors when the user navigates away from the section that
 // produced them. Without this, an error from Appearance's Changelog button
 // stays visible after switching to Editor and back.
+//
+// Only assign when the values are currently non-null. Setting null → null is a
+// no-op for primitives, but explicit guarding keeps this effect off the suspect
+// list for prod-only effect_update_depth chains (#613).
 $effect(() => {
   activeSection;
-  changelogError = null;
-  docsError = null;
+  if (changelogError !== null) changelogError = null;
+  if (docsError !== null) docsError = null;
 });
 
 // Idle-sync: sync only when NOT focused and value differs

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -623,8 +623,16 @@ describe("mcp-stdio per-request timeout", () => {
   /**
    * Spin up a fake Tandem server whose /mcp endpoint holds every POST
    * without replying. Used by half-open timeout tests.
+   *
+   * Returns `postsReceived` — a counter the caller can poll on to determine
+   * when the CLI's request reached the fake server (i.e. `httpReady` flipped,
+   * `preReadyBuffer` drained, and the per-request timer started ticking).
+   * Polling on this counter instead of `setTimeout(500)` is what makes the
+   * timeout tests robust under concurrent vitest load, where subprocess
+   * startup can easily exceed 500ms.
    */
-  async function makeHalfOpenServer(): Promise<{ port: number }> {
+  async function makeHalfOpenServer(): Promise<{ port: number; postsReceived: { count: number } }> {
+    const postsReceived = { count: 0 };
     timeoutServer = createServer((req, res) => {
       if (req.method === "GET" && req.url === "/health") {
         res.writeHead(200, { "Content-Type": "text/plain" });
@@ -633,8 +641,14 @@ describe("mcp-stdio per-request timeout", () => {
       }
       if (req.method === "POST" && req.url === "/mcp") {
         // Intentionally never respond — simulates a half-open upstream.
+        // Count POSTs on "end" so the increment fires only after the request
+        // body has fully arrived (matches when forwardToUpstream's await on
+        // fetch is past send).
         const chunks: Buffer[] = [];
         req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+          postsReceived.count += 1;
+        });
         return;
       }
       res.writeHead(404);
@@ -643,12 +657,32 @@ describe("mcp-stdio per-request timeout", () => {
     await new Promise<void>((r) => (timeoutServer as Server).listen(0, "127.0.0.1", r));
     const addr = (timeoutServer as Server).address();
     if (!addr || typeof addr === "string") throw new Error("server.address() unexpected");
-    return { port: addr.port };
+    return { port: addr.port, postsReceived };
+  }
+
+  /**
+   * Poll until the fake server has received at least `n` POSTs (or fail the
+   * test after `timeoutMs`). Decouples assertions from subprocess startup
+   * latency, which can easily exceed a fixed delay under load.
+   */
+  async function waitForPosts(
+    counter: { count: number },
+    n: number,
+    timeoutMs = 10_000,
+  ): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (counter.count >= n) return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    throw new Error(
+      `Only ${counter.count}/${n} POSTs reached the fake server within ${timeoutMs}ms`,
+    );
   }
 
   it("synthesizes -32000 after timeout when upstream accepts but never responds (half-open)", async () => {
     // Fake server: /health → 200, /mcp → holds the POST without replying.
-    const { port } = await makeHalfOpenServer();
+    const { port, postsReceived } = await makeHalfOpenServer();
     const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
     // Use a short timeout (500ms) so the test doesn't take 30s.
     child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
@@ -660,14 +694,17 @@ describe("mcp-stdio per-request timeout", () => {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
-    // Write after a short delay so httpReady is true (request goes through forwardToUpstream).
-    await new Promise((r) => setTimeout(r, 500));
+    // Send the request immediately — it sits in `preReadyBuffer` until
+    // httpReady flips, then forwardToUpstream fires and the 500ms timer
+    // starts. We don't care WHEN that happens; we poll until the POST
+    // arrived at the fake server, which proves the timer is running.
     child.stdin.write(
       `${JSON.stringify({ jsonrpc: "2.0", id: 10, method: "initialize", params: { protocolVersion: "2024-11-05", clientInfo: { name: "test", version: "0" }, capabilities: {} } })}\n`,
     );
+    await waitForPosts(postsReceived, 1);
 
-    // Expect -32000 after the 500ms timeout fires (plus processing slack).
-    const line = await readOneLine(child, 5_000);
+    // Expect -32000 within 500ms timer + processing slack.
+    const line = await readOneLine(child, 3_000);
     const parsed = JSON.parse(line) as {
       id: number;
       error?: { code: number; message: string; data?: { detail: string } };
@@ -680,7 +717,7 @@ describe("mcp-stdio per-request timeout", () => {
 
   it("synthesizes distinct -32000 for each concurrent pending request on timeout", async () => {
     // Fake server: /health → 200, /mcp → holds all POSTs without replying.
-    const { port } = await makeHalfOpenServer();
+    const { port, postsReceived } = await makeHalfOpenServer();
     const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
     child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
       env: {
@@ -691,8 +728,6 @@ describe("mcp-stdio per-request timeout", () => {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
-    // Wait for httpReady, then send 3 concurrent requests.
-    await new Promise((r) => setTimeout(r, 500));
     const makeRequest = (id: number) =>
       JSON.stringify({
         jsonrpc: "2.0",
@@ -707,9 +742,12 @@ describe("mcp-stdio per-request timeout", () => {
     child.stdin.write(`${makeRequest(20)}\n`);
     child.stdin.write(`${makeRequest(21)}\n`);
     child.stdin.write(`${makeRequest(22)}\n`);
+    // Wait until all 3 POSTs reached the fake server — confirms three timers
+    // are running before we start reading stdout.
+    await waitForPosts(postsReceived, 3);
 
-    // Collect 3 -32000 lines (allow 5s slack after 500ms timeout).
-    const lines = await readLines(child, 3, 5_000);
+    // Collect 3 -32000 lines (500ms timer + processing slack).
+    const lines = await readLines(child, 3, 3_000);
     expect(lines).toHaveLength(3);
 
     const receivedIds = new Set<number>();


### PR DESCRIPTION
## Summary

Hotfix for #613 — installed v0.11.1 desktop builds threw Svelte's \`effect_update_depth_exceeded\` immediately on launch. Dev build (\`npm run dev:tauri\`) didn't reproduce — the trigger is production-mode effect-flush scheduling.

Three defense-in-depth fixes in App.svelte + SettingsPopover.svelte:

- **Authorship effect no longer dispatches on its first run.** The plugin already reads \`localStorage[AUTHORSHIP_TOGGLE_KEY]\` at construction (mirrored on every \`updateSettings\` write), so the editor starts in the correct state. The first-run dispatch was a React-era leftover. The existing in-code comment had explicitly warned this dispatch could "exceed the 1000-update depth limit" via chained transactions through FormattingBar's \`_tick++\` listener — under prod's tighter scheduling, it did.
- **Rail-tab reconcile effects \`untrack()\` their writes** so the read-then-write inside the same effect can't form a subtle self-dep.
- **SettingsPopover error-clear effect** skips assignment when values are already null (\`changelogError\`, \`docsError\`).

## Bundled fix

Also includes \`fix(tests): poll postsReceived to unflake mcp-stdio timeout test\` — the half-open timeout suite was using a fixed 500ms setTimeout, which exceeded subprocess startup time under concurrent vitest load. Three consecutive pre-push runs on this branch hit the flake before bundling the fix in. The polling pattern is already proven elsewhere in the same file (lines 381-384, 484-488, 582-585, 779-782).

## Version

- \`package.json\`, \`package-lock.json\`, \`src-tauri/tauri.conf.json\`: \`0.11.1\` → \`0.11.2\`
- \`src-tauri/Cargo.toml\`: unchanged (own cadence)
- \`dist/server/\` rebuilt so \`tests/build/version-baked.test.ts\` sees the new version literal

## Test plan

- [x] \`npm run typecheck\` — clean (0 errors, 0 warnings, 795 files)
- [x] \`npx vitest run --project=client\` — 454/454 pass
- [x] \`npx vite build && npx vite preview\` — production bundle loads clean in Chrome with no \`effect_update_depth\` error
- [ ] Manual repro by Bryan on installed v0.11.2 .exe after Tauri Release workflow completes
- [ ] Confirm \`tauri.localhost\` build does not hit the loop

## Why this is the right fix without a confirmed trace

Bryan's \`npm run dev:tauri\` doesn't repro the bug, and the production browser preview also doesn't repro on a clean profile — meaning I couldn't capture the exact stack trace. But:

1. The authorship effect's own comment explicitly names \`effect_update_depth_exceeded\` and the dispatch chain through FormattingBar's \`_tick++\` listener as the failure mode the guard was meant to prevent — the guard misses on the FIRST run, which is the only run on Tauri launch.
2. The fix removes that first-run dispatch entirely by leaning on the existing localStorage handoff to the authorship plugin (\`AUTHORSHIP_TOGGLE_KEY\`), which is already kept in sync by \`useTandemSettings.svelte.ts\`. So the editor still starts with the correct authorship visibility — no behavior regression.
3. The two defensive \`untrack()\` / value-guard changes are zero-risk: each effect already settles on the first run; the changes just make the read-write decoupling explicit.

## Closes

- #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)