### PR TITLE
fix(client): capture editor ref in FormattingToolbar effect cleanup

### DIFF
--- a/src/client/editor/toolbar/FormattingToolbar.svelte
+++ b/src/client/editor/toolbar/FormattingToolbar.svelte
@@ -22,14 +22,24 @@ let showLinkInput = $state(false);
 let linkInputValue = $state("");
 let linkInputEl = $state<HTMLInputElement | null>(null);
 
+// Capture `editor` into a local `const` so the cleanup `.off()` runs against
+// the same instance we attached to. Without the capture, Svelte 5's reactive
+// prop getter returns the CURRENT value at cleanup time — which becomes `null`
+// during tab switch when `onEditorReady(null)` fires from the previous
+// editor's destroy. Calling `.off()` on null throws inside Svelte's effect
+// flush, the effect is retried, and the editor never finishes mounting (a
+// multi-second freeze + missing .ProseMirror element). Captured `ed` matches
+// the safe pattern in `FormattingBar.svelte` and the other `editor.off`
+// callsites in the codebase.
 $effect(() => {
-  if (!editor) return;
+  const ed = editor;
+  if (!ed || ed.isDestroyed) return;
   const handler = () => {
-    if (!editor.isDestroyed) tick++;
+    if (!ed.isDestroyed) tick++;
   };
-  editor.on("transaction", handler);
+  ed.on("transaction", handler);
   return () => {
-    editor.off("transaction", handler);
+    if (!ed.isDestroyed) ed.off("transaction", handler);
   };
 });
 


### PR DESCRIPTION
## Summary

Fixes the v0.11.2 tab-switch freeze (Bryan reported in #613 follow-up). Bug was a Svelte 5 reactivity issue, not a perf cost: `FormattingToolbar.svelte`'s `$effect` cleanup read the `editor` prop directly. Svelte 5 props are reactive getters — at cleanup time the getter returned `null` (the previous editor's destroy fires `onEditorReady(null)`), so `editor.off(...)` threw `TypeError: Cannot read properties of null (reading 'off')` inside Svelte's effect flush. Svelte retried the broken effect ~1000× before giving up, producing the multi-second freeze and missing `.ProseMirror` element users observed.

Captured `editor` into a local `const ed` — the same pattern already used by `FormattingBar.svelte`, `FindReplaceBar.svelte`, `OutlinePanel.svelte`, and `useTutorial.svelte.ts`. `FormattingToolbar` was the one site reading the prop in cleanup.

## How I found it

Three Explore agents + crdt-reviewer + svelte-migration-reviewer + plan-stress-test consumed a full investigation cycle theorizing about Tiptap reconstruction cost, persistent-per-tab editor mount refactors, CollaborationCursor presence broadcasts, and observer debouncing — none of which was the bug. Then I reproduced via `claude-in-chrome` with a `_debug=1` probe and **read the console**. The exception was right there.

Two new feedback memories capture the lessons:
- `feedback_svelte_prop_in_effect_cleanup.md` — Svelte 5 prop-in-cleanup gotcha
- `feedback_check_console_before_perf_hypothesis.md` — Check console before instrumenting perf

## Measured impact

Repro: 5 tabs (CHANGELOG, redesign-request-for-claude-design.md @ 105 blocks/256 XML elements, anthropic-contracts, anthropic-why @ 85 authorship ranges, second CHANGELOG @ 189 blocks/792 XML elements), annotations panel active. DevTools `longtask` PerformanceObserver capturing wall-clock duration of the synchronous freeze:

| Tab switch | Before fix (v0.11.2) | After fix |
|---|---|---|
| → redesign-request | **6,742ms** (`.ProseMirror` element never appeared) | **411ms** (50ms warm) |
| → CHANGELOG.md (189 blocks) | **5,822ms** + multiple 4–8s secondary freezes recurring for minutes | 358–517ms |
| → anthropic-why (85 authorship) | **5,094ms** | **64ms** |
| → anthropic-contracts | n/a | 175ms |
| → revision-request (warm) | n/a | 50ms |

The recurring secondary freezes (4–8s every ~30s after a switch) are gone — those were the same exception re-firing on every Y.Doc transaction (autosave, etc.) that propagated to the broken effect.

## Test plan

- [x] `npm test` — 1943 passed, 4 skipped (full suite)
- [x] `npx svelte-check` on the modified file — 0 errors
- [x] Manual repro in `vite preview` build with `claude-in-chrome` — fix verified across 6+ tab switches into varying-size docs
- [ ] Manual smoke test in a Tauri debug build (deferred — fix is Svelte reactivity correctness, not Tauri-specific; preview build uses the same production-mode bundler scheduling)
- [ ] Bryan installs the next release and confirms

## Related

- Closes the v0.11.2 follow-up symptom Bryan reported after #613 was supposedly fixed
- v0.11.3 hotfix candidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
