### PR TITLE
polish: API path centralization, channel error enum, dismiss-outside helper (#283/#284/#589)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- **Centralize Tandem HTTP API paths into shared constants (closes #283)** — every `/api/*` path (registration + every client/CLI/channel/monitor fetch) now flows through `src/shared/api-paths.ts`. `API_BASE` in `src/client/utils/fileUpload.ts` no longer carries the `/api` suffix; clients build URLs as `${API_BASE}${API_FOO}`. Renaming a route now touches one file instead of N. Source-level coverage tests in `tests/channel/run-timeouts.test.ts` and `tests/monitor/runtime-fetches.test.ts` accept either the literal path or the resolved `API_*` constant.
+
 ## [0.11.2] - 2026-05-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Centralize Tandem HTTP API paths into shared constants (closes #283)** — every `/api/*` path (registration + every client/CLI/channel/monitor fetch) now flows through `src/shared/api-paths.ts`. `API_BASE` in `src/client/utils/fileUpload.ts` no longer carries the `/api` suffix; clients build URLs as `${API_BASE}${API_FOO}`. Renaming a route now touches one file instead of N. Source-level coverage tests in `tests/channel/run-timeouts.test.ts` and `tests/monitor/runtime-fetches.test.ts` accept either the literal path or the resolved `API_*` constant.
 - **Define `ChannelErrorCodeSchema` enum for `/api/channel-error` payloads (closes #284)** — channel-shim and monitor failure codes (`CHANNEL_CONNECT_FAILED`, `MONITOR_CONNECT_FAILED`) are now z.enum constants in `src/shared/types.ts` instead of free-form strings. The server route handler validates the incoming `error` field and returns 400 on unknown codes (still logs the rejected value so the diagnostic trail survives). Mirrors the existing `ToolErrorCodeSchema` pattern.
+- **Extract shared `onOutsideEvent` dismiss helper (closes #589)** — `Toolbar.svelte` (scroll-based dismiss) and `HighlightColorPicker.svelte` (mousedown-based dismiss) both rolled their own document-listener + `contains(event.target)` guard. Consolidates into `src/client/utils/dismiss-outside.ts`. Capture-phase parity preserved at each call site.
 
 ## [0.11.2] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 - **Centralize Tandem HTTP API paths into shared constants (closes #283)** — every `/api/*` path (registration + every client/CLI/channel/monitor fetch) now flows through `src/shared/api-paths.ts`. `API_BASE` in `src/client/utils/fileUpload.ts` no longer carries the `/api` suffix; clients build URLs as `${API_BASE}${API_FOO}`. Renaming a route now touches one file instead of N. Source-level coverage tests in `tests/channel/run-timeouts.test.ts` and `tests/monitor/runtime-fetches.test.ts` accept either the literal path or the resolved `API_*` constant.
+- **Define `ChannelErrorCodeSchema` enum for `/api/channel-error` payloads (closes #284)** — channel-shim and monitor failure codes (`CHANNEL_CONNECT_FAILED`, `MONITOR_CONNECT_FAILED`) are now z.enum constants in `src/shared/types.ts` instead of free-form strings. The server route handler validates the incoming `error` field and returns 400 on unknown codes (still logs the rejected value so the diagnostic trail survives). Mirrors the existing `ToolErrorCodeSchema` pattern.
 
 ## [0.11.2] - 2026-05-13
 

--- a/src/channel/event-bridge.ts
+++ b/src/channel/event-bridge.ts
@@ -9,6 +9,12 @@
  */
 
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  API_CHANNEL_AWARENESS,
+  API_CHANNEL_ERROR,
+  API_EVENTS,
+  API_MODE,
+} from "../shared/api-paths.js";
 import { authFetch } from "../shared/cli-runtime.js";
 import {
   CHANNEL_AWARENESS_FETCH_TIMEOUT_MS,
@@ -52,7 +58,7 @@ export async function startEventBridge(mcp: Server, tandemUrl: string): Promise<
         console.error("[Channel] SSE connection exhausted, reporting error and exiting");
         try {
           await fetchWithTimeout(
-            `${tandemUrl}/api/channel-error`,
+            `${tandemUrl}${API_CHANNEL_ERROR}`,
             {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -66,7 +72,7 @@ export async function startEventBridge(mcp: Server, tandemUrl: string): Promise<
         } catch (reportErr) {
           console.error(
             "[Channel] Could not report failure to server:",
-            describeFetchError(reportErr, "/api/channel-error", CHANNEL_ERROR_REPORT_TIMEOUT_MS),
+            describeFetchError(reportErr, API_CHANNEL_ERROR, CHANNEL_ERROR_REPORT_TIMEOUT_MS),
           );
         }
         process.exit(1);
@@ -98,7 +104,7 @@ async function connectAndStream(
   );
   let res: Response;
   try {
-    res = await authFetch(`${tandemUrl}/api/events`, { headers, signal: connectCtrl.signal });
+    res = await authFetch(`${tandemUrl}${API_EVENTS}`, { headers, signal: connectCtrl.signal });
   } finally {
     clearTimeout(connectTimer);
   }
@@ -130,7 +136,7 @@ async function connectAndStream(
 
   function clearAwareness(documentId?: string) {
     fetchWithTimeout(
-      `${tandemUrl}/api/channel-awareness`,
+      `${tandemUrl}${API_CHANNEL_AWARENESS}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -144,7 +150,11 @@ async function connectAndStream(
     ).catch((err) => {
       console.error(
         "[Channel] clearAwareness failed (non-fatal):",
-        describeFetchError(err, "/api/channel-awareness clear", CHANNEL_AWARENESS_FETCH_TIMEOUT_MS),
+        describeFetchError(
+          err,
+          `${API_CHANNEL_AWARENESS} clear`,
+          CHANNEL_AWARENESS_FETCH_TIMEOUT_MS,
+        ),
       );
     });
   }
@@ -154,7 +164,7 @@ async function connectAndStream(
     const event = pendingAwareness;
     pendingAwareness = null;
     fetchWithTimeout(
-      `${tandemUrl}/api/channel-awareness`,
+      `${tandemUrl}${API_CHANNEL_AWARENESS}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -170,7 +180,7 @@ async function connectAndStream(
         "[Channel] Awareness update failed:",
         describeFetchError(
           err,
-          "/api/channel-awareness update",
+          `${API_CHANNEL_AWARENESS} update`,
           CHANNEL_AWARENESS_FETCH_TIMEOUT_MS,
         ),
       );
@@ -292,7 +302,11 @@ async function getCachedMode(tandemUrl: string): Promise<string> {
   const now = Date.now();
   if (now - cachedModeAt < MODE_CACHE_TTL_MS) return cachedMode;
   try {
-    const res = await fetchWithTimeout(`${tandemUrl}/api/mode`, {}, CHANNEL_MODE_FETCH_TIMEOUT_MS);
+    const res = await fetchWithTimeout(
+      `${tandemUrl}${API_MODE}`,
+      {},
+      CHANNEL_MODE_FETCH_TIMEOUT_MS,
+    );
     if (res.ok) {
       const { mode } = (await res.json()) as { mode: string };
       cachedMode = mode;
@@ -303,7 +317,7 @@ async function getCachedMode(tandemUrl: string): Promise<string> {
   } catch (err) {
     console.error(
       "[Channel] Mode check failed, delivering event (fail-open):",
-      describeFetchError(err, "/api/mode", CHANNEL_MODE_FETCH_TIMEOUT_MS),
+      describeFetchError(err, API_MODE, CHANNEL_MODE_FETCH_TIMEOUT_MS),
     );
     cachedModeAt = now;
   }

--- a/src/channel/event-bridge.ts
+++ b/src/channel/event-bridge.ts
@@ -29,6 +29,7 @@ import {
 import type { TandemEvent } from "../shared/events/types.js";
 import { formatEventContent, formatEventMeta, parseTandemEvent } from "../shared/events/types.js";
 import { describeFetchError, fetchWithTimeout } from "../shared/fetch-with-timeout.js";
+import { CHANNEL_CONNECT_FAILED } from "../shared/types.js";
 
 const AWARENESS_DEBOUNCE_MS = 500;
 const MODE_CACHE_TTL_MS = 2000;
@@ -63,7 +64,7 @@ export async function startEventBridge(mcp: Server, tandemUrl: string): Promise<
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
-                error: "CHANNEL_CONNECT_FAILED",
+                error: CHANNEL_CONNECT_FAILED,
                 message: `Channel shim lost connection after ${CHANNEL_MAX_RETRIES} retries.`,
               }),
             },

--- a/src/channel/run.ts
+++ b/src/channel/run.ts
@@ -15,6 +15,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { API_CHANNEL_PERMISSION, API_CHANNEL_REPLY } from "../shared/api-paths.js";
 import { redirectConsoleToStderr, resolveTandemUrl } from "../shared/cli-runtime.js";
 import {
   CHANNEL_PERMISSION_FETCH_TIMEOUT_MS,
@@ -93,7 +94,7 @@ export async function runChannel(opts: RunChannelOptions = {}): Promise<void> {
       const args = req.params.arguments as Record<string, unknown>;
       try {
         const res = await fetchWithTimeout(
-          `${tandemUrl}/api/channel-reply`,
+          `${tandemUrl}${API_CHANNEL_REPLY}`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -133,7 +134,7 @@ export async function runChannel(opts: RunChannelOptions = {}): Promise<void> {
               type: "text" as const,
               text: `Failed to send reply: ${describeFetchError(
                 err,
-                "/api/channel-reply",
+                API_CHANNEL_REPLY,
                 CHANNEL_REPLY_FETCH_TIMEOUT_MS,
               )}`,
             },
@@ -158,7 +159,7 @@ export async function runChannel(opts: RunChannelOptions = {}): Promise<void> {
   mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }) => {
     try {
       const res = await fetchWithTimeout(
-        `${tandemUrl}/api/channel-permission`,
+        `${tandemUrl}${API_CHANNEL_PERMISSION}`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -179,7 +180,7 @@ export async function runChannel(opts: RunChannelOptions = {}): Promise<void> {
     } catch (err) {
       console.error(
         "[Channel] Failed to forward permission request:",
-        describeFetchError(err, "/api/channel-permission", CHANNEL_PERMISSION_FETCH_TIMEOUT_MS),
+        describeFetchError(err, API_CHANNEL_PERMISSION, CHANNEL_PERMISSION_FETCH_TIMEOUT_MS),
       );
     }
   });

--- a/src/cli/rotate-token.ts
+++ b/src/cli/rotate-token.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { promises as fsPromises } from "node:fs";
 import path from "node:path";
+import { API_ROTATE_TOKEN } from "../shared/api-paths.js";
 import { getTokenFilePath, readTokenFromFile } from "../shared/auth/token-file.js";
 import { resolveAuthTokenCandidate, resolveTandemUrl } from "../shared/cli-runtime.js";
 import { applyConfigWithToken } from "./setup.js";
@@ -69,7 +70,7 @@ export async function rotateToken(): Promise<void> {
   let serverRejected = false;
   let serverRejectedStatus = 0;
   try {
-    const resp = await fetch(`${serverUrl}/api/rotate-token`, {
+    const resp = await fetch(`${serverUrl}${API_ROTATE_TOKEN}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -9,7 +9,7 @@
  * Wire the getters by calling wireActionDeps() from App.svelte after mount.
  */
 
-import { DEFAULT_MCP_PORT } from "../../shared/constants.js";
+import { API_SAVE, API_SCRATCHPAD } from "../../shared/api-paths.js";
 import { API_BASE } from "../utils/fileUpload.js";
 import { type Action, registerAction } from "./registry.svelte.js";
 
@@ -56,7 +56,7 @@ export async function createScratchpad(): Promise<void> {
   if (scratchpadInflight) return;
   scratchpadInflight = true;
   try {
-    const res = await fetch(`${API_BASE}/scratchpad`, { method: "POST" });
+    const res = await fetch(`${API_BASE}${API_SCRATCHPAD}`, { method: "POST" });
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
       console.warn(
@@ -76,7 +76,7 @@ export async function triggerSave(activeDocId: string | null): Promise<void> {
   inflight = true;
   saving = true;
   try {
-    const resp = await fetch(`http://localhost:${DEFAULT_MCP_PORT}/api/save`, {
+    const resp = await fetch(`${API_BASE}${API_SAVE}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ documentId: activeDocId }),

--- a/src/client/components/ApplyChangesButton.svelte
+++ b/src/client/components/ApplyChangesButton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { API_APPLY_CHANGES } from "../../shared/api-paths";
 import type { Annotation } from "../../shared/types";
 import { API_BASE } from "../utils/fileUpload";
 
@@ -29,7 +30,7 @@ async function handleClick() {
 
   applying = true;
   try {
-    const res = await fetch(`${API_BASE}/apply-changes`, {
+    const res = await fetch(`${API_BASE}${API_APPLY_CHANGES}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ documentId }),

--- a/src/client/components/FileOpenDialog.svelte
+++ b/src/client/components/FileOpenDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { API_OPEN, API_UPLOAD } from "../../shared/api-paths.js";
 import { API_BASE, readFileForUpload } from "../utils/fileUpload.js";
 import {
   addRecentFile,
@@ -42,7 +43,7 @@ async function openByPath(pathToOpen: string) {
   error = null;
   loading = true;
   try {
-    const res = await fetch(`${API_BASE}/open`, {
+    const res = await fetch(`${API_BASE}${API_OPEN}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ filePath: pathToOpen }),
@@ -79,7 +80,7 @@ async function uploadFile(file: File) {
   loading = true;
   try {
     const content = await readFileForUpload(file);
-    const res = await fetch(`${API_BASE}/upload`, {
+    const res = await fetch(`${API_BASE}${API_UPLOAD}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ fileName: file.name, content }),

--- a/src/client/components/ReviewOnlyBanner.svelte
+++ b/src/client/components/ReviewOnlyBanner.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { API_CONVERT } from "../../shared/api-paths";
 import { API_BASE } from "../utils/fileUpload";
 
 const DISMISS_KEY = "tandem:reviewOnlyBannerDismissed";
@@ -27,7 +28,7 @@ async function handleConvert() {
   converting = true;
   error = null;
   try {
-    const res = await fetch(`${API_BASE}/convert`, {
+    const res = await fetch(`${API_BASE}${API_CONVERT}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ documentId }),

--- a/src/client/components/SettingsPopover.svelte
+++ b/src/client/components/SettingsPopover.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { API_OPEN } from "../../shared/api-paths";
 import {
   SELECTION_DWELL_MAX_MS,
   SELECTION_DWELL_MIN_MS,
@@ -232,7 +233,7 @@ async function openReadOnlyFile(
   setLoading(true);
   setError(null);
   try {
-    const res = await fetch(`${API_BASE}/open`, {
+    const res = await fetch(`${API_BASE}${API_OPEN}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ filePath, readOnly: true }),

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -13,6 +13,7 @@ import TableRow from "@tiptap/extension-table-row";
 import StarterKit from "@tiptap/starter-kit";
 import { untrack } from "svelte";
 import * as Y from "yjs";
+import { API_OPEN } from "../../shared/api-paths.js";
 import { readStoredName, subscribeToUserName } from "../hooks/useUserName";
 import { API_BASE } from "../utils/fileUpload.js";
 import { AnnotationExtension } from "./extensions/annotation";
@@ -237,7 +238,7 @@ async function handleEditorClick(e: MouseEvent) {
       const resolvedPath = resolveRelativeLink(href, currentFilePath);
       if (resolvedPath) {
         try {
-          const res = await fetch(`${API_BASE}/open`, {
+          const res = await fetch(`${API_BASE}${API_OPEN}`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ filePath: resolvedPath }),

--- a/src/client/editor/toolbar/HighlightColorPicker.svelte
+++ b/src/client/editor/toolbar/HighlightColorPicker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { HIGHLIGHT_COLOR_VARS } from "../../../shared/constants";
 import type { HighlightColor } from "../../../shared/types";
+import { onOutsideEvent } from "../../utils/dismiss-outside";
 import ToolbarButton from "./ToolbarButton.svelte";
 
 const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
@@ -23,13 +24,14 @@ let colorPickerEl = $state<HTMLDivElement | null>(null);
 
 $effect(() => {
   if (!showColorPicker) return;
-  function handleClickOutside(e: MouseEvent) {
-    if (colorPickerEl && !colorPickerEl.contains(e.target as Node)) {
+  return onOutsideEvent(
+    () => colorPickerEl,
+    ["mousedown"],
+    () => {
       showColorPicker = false;
-    }
-  }
-  document.addEventListener("mousedown", handleClickOutside);
-  return () => document.removeEventListener("mousedown", handleClickOutside);
+    },
+    { capture: false },
+  );
 });
 
 function handleHighlight(e: MouseEvent) {

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -11,6 +11,7 @@ import { toPmPos } from "../../../shared/positions/types";
 import type { Annotation, AnnotationType, HighlightColor } from "../../../shared/types";
 import { generateAnnotationId } from "../../../shared/utils";
 import { pmPosToFlatOffset } from "../../positions";
+import { onOutsideEvent } from "../../utils/dismiss-outside";
 import { toggleHighlight } from "./highlight-toggle";
 import {
   attachSelectionToolbarListener,
@@ -108,11 +109,19 @@ $effect(() => {
   }
 
   window.addEventListener("resize", scheduleUpdate);
-  document.addEventListener("scroll", handleScrollDismiss, true);
+  const unsubscribeOutsideScroll = onOutsideEvent(
+    () => toolbarEl,
+    ["scroll"],
+    () => {
+      // Don't dismiss while the user is composing in the textarea
+      if (document.activeElement === textareaEl) return;
+      dismissPopup();
+    },
+  );
   return () => {
     cancelAnimationFrame(frame);
     window.removeEventListener("resize", scheduleUpdate);
-    document.removeEventListener("scroll", handleScrollDismiss, true);
+    unsubscribeOutsideScroll();
   };
 });
 
@@ -221,14 +230,6 @@ function onKeyActivate(handler: (e: MouseEvent) => void) {
   return (e: MouseEvent) => {
     if (e.detail === 0) handler(e);
   };
-}
-
-function handleScrollDismiss(event: Event) {
-  // Don't dismiss if scroll originated inside the popup (e.g., textarea scrolling)
-  if (toolbarEl && event.target instanceof Node && toolbarEl.contains(event.target)) return;
-  // Don't dismiss while the user is composing in the textarea
-  if (document.activeElement === textareaEl) return;
-  dismissPopup();
 }
 
 function dismissPopup() {

--- a/src/client/hooks/useAppInfo.ts
+++ b/src/client/hooks/useAppInfo.ts
@@ -1,3 +1,4 @@
+import { API_INFO } from "../../shared/api-paths";
 import type { AppInfoData } from "../types";
 import { API_BASE } from "../utils/fileUpload";
 
@@ -25,9 +26,9 @@ export function _resetAppInfoCache(): void {
  */
 export async function fetchAppInfo(signal: AbortSignal): Promise<AppInfoData> {
   if (cachedInfo !== null) return cachedInfo;
-  const resp = await fetch(`${API_BASE}/info`, { signal });
+  const resp = await fetch(`${API_BASE}${API_INFO}`, { signal });
   if (!resp.ok) {
-    throw new Error(`/api/info responded ${resp.status} ${resp.statusText}`);
+    throw new Error(`${API_INFO} responded ${resp.status} ${resp.statusText}`);
   }
   const data = (await resp.json()) as AppInfoData;
   cachedInfo = data;

--- a/src/client/hooks/useFileDrop.svelte.ts
+++ b/src/client/hooks/useFileDrop.svelte.ts
@@ -1,3 +1,4 @@
+import { API_UPLOAD } from "../../shared/api-paths.js";
 import { API_BASE, readFileForUpload } from "../utils/fileUpload.js";
 
 export interface FileDropState {
@@ -39,7 +40,7 @@ export function createFileDrop(): FileDropState {
     const file = e.dataTransfer.files[0];
     const content = await readFileForUpload(file);
     try {
-      const response = await fetch(`${API_BASE}/upload`, {
+      const response = await fetch(`${API_BASE}${API_UPLOAD}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ fileName: file.name, content }),

--- a/src/client/hooks/useNotifications.svelte.ts
+++ b/src/client/hooks/useNotifications.svelte.ts
@@ -1,4 +1,5 @@
 import { onDestroy } from "svelte";
+import { API_NOTIFY_STREAM } from "../../shared/api-paths.js";
 import { DEFAULT_MCP_PORT, MAX_VISIBLE_TOASTS, TOAST_DISMISS_MS } from "../../shared/constants.js";
 import type { TandemNotification } from "../../shared/types.js";
 
@@ -45,7 +46,7 @@ export function createNotifications(): NotificationsState {
     clearTimer(id);
   };
 
-  const url = `http://localhost:${DEFAULT_MCP_PORT}/api/notify-stream`;
+  const url = `http://localhost:${DEFAULT_MCP_PORT}${API_NOTIFY_STREAM}`;
   const es = new EventSource(url);
 
   es.onmessage = (event) => {

--- a/src/client/hooks/yjsSync.svelte.ts
+++ b/src/client/hooks/yjsSync.svelte.ts
@@ -1,5 +1,6 @@
 import { HocuspocusProvider } from "@hocuspocus/provider";
 import * as Y from "yjs";
+import { API_CLOSE } from "../../shared/api-paths.js";
 import {
   CTRL_ROOM,
   DEFAULT_MCP_PORT,
@@ -402,7 +403,7 @@ export function createYjsSync(): YjsSyncState {
     }
 
     // Tell the server to close the document — broadcast reconciles tabs.
-    fetch(`http://localhost:${DEFAULT_MCP_PORT}/api/close`, {
+    fetch(`http://localhost:${DEFAULT_MCP_PORT}${API_CLOSE}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ documentId: tabId }),

--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Editor as TiptapEditor } from "@tiptap/core";
 import * as Y from "yjs";
+import { API_CHAT } from "../../shared/api-paths";
 import { DEFAULT_MCP_PORT, Y_MAP_CHAT } from "../../shared/constants";
 import type { FlatOffset } from "../../shared/positions/types";
 import type { CapturedAnchor, ChatMessage } from "../../shared/types";
@@ -145,7 +146,7 @@ function getDocFileName(docId?: string): string | null {
 
 async function clearChat() {
   try {
-    await fetch(`http://localhost:${DEFAULT_MCP_PORT}/api/chat`, { method: "DELETE" });
+    await fetch(`http://localhost:${DEFAULT_MCP_PORT}${API_CHAT}`, { method: "DELETE" });
   } catch (err) {
     console.warn("[ChatPanel] Failed to clear chat:", err);
   }

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -2,6 +2,7 @@
 import type { Editor as TiptapEditor } from "@tiptap/core";
 import { untrack } from "svelte";
 import * as Y from "yjs";
+import { API_ANNOTATION_REPLY, API_REMOVE_ANNOTATION } from "../../shared/api-paths";
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../shared/constants";
 import { sanitizeAnnotation } from "../../shared/sanitize";
 import type { Annotation, AnnotationReply, TandemMode } from "../../shared/types";
@@ -276,7 +277,7 @@ function handleSendToClaude(annotationId: string): void {
 
 async function handleRemove(annotationId: string): Promise<void> {
   try {
-    const resp = await fetch(`${API_BASE}/remove-annotation`, {
+    const resp = await fetch(`${API_BASE}${API_REMOVE_ANNOTATION}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ annotationId, documentId }),
@@ -292,7 +293,7 @@ async function handleRemove(annotationId: string): Promise<void> {
 
 async function handleReply(annotationId: string, text: string): Promise<boolean> {
   try {
-    const res = await fetch(`${API_BASE}/annotation-reply`, {
+    const res = await fetch(`${API_BASE}${API_ANNOTATION_REPLY}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ annotationId, text, documentId }),

--- a/src/client/tabs/DocumentTabs.svelte
+++ b/src/client/tabs/DocumentTabs.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { API_OPEN } from "../../shared/api-paths.js";
 import { createScratchpad } from "../actions/builtin.svelte.js";
 import FileOpenDialog from "../components/FileOpenDialog.svelte";
 import type { OpenTab } from "../types.js";
@@ -273,7 +274,7 @@ $effect(() => {
       onOpen={async (filePath) => {
         showRecent = false;
         try {
-          const res = await fetch(`${API_BASE}/open`, {
+          const res = await fetch(`${API_BASE}${API_OPEN}`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ filePath }),

--- a/src/client/utils/dismiss-outside.ts
+++ b/src/client/utils/dismiss-outside.ts
@@ -1,0 +1,50 @@
+/**
+ * Document-level "event landed outside this node" subscription helper.
+ *
+ * Replaces the duplicated `contains(target)` guard that previously lived in
+ * both `Toolbar.svelte` (scroll-based dismiss) and `HighlightColorPicker.svelte`
+ * (mousedown-based dismiss). See #589.
+ *
+ * Call sites still decide what "dismiss" means and apply any caller-specific
+ * extra guards (e.g. Toolbar skips dismiss while the user is composing in a
+ * textarea). This module only owns the contains-check and listener lifecycle.
+ */
+
+export type OutsideEventType = "mousedown" | "scroll";
+
+/**
+ * Attach a document-level handler that fires when one of `eventTypes` lands
+ * outside the element returned by `getElement`. Returns a cleanup function
+ * that removes the listeners — pass it back from `$effect` to scope the
+ * subscription to the effect's lifetime.
+ *
+ * `getElement` is a getter rather than a plain `HTMLElement` so that callers
+ * using `bind:this` (which is null on first effect run) work without
+ * special-casing.
+ *
+ * @param getElement Accessor returning the host element, or null if it hasn't mounted yet.
+ * @param eventTypes Events to listen for. `"scroll"` always needs `capture: true` to fire for inner-scroll containers.
+ * @param onOutside Fired when the event target is non-null and not contained by the element.
+ * @param options.capture Defaults to `true` (matches both prior call sites).
+ */
+export function onOutsideEvent(
+  getElement: () => HTMLElement | null,
+  eventTypes: readonly OutsideEventType[],
+  onOutside: (event: Event) => void,
+  options: { capture?: boolean } = {},
+): () => void {
+  const { capture = true } = options;
+
+  function handle(event: Event) {
+    const el = getElement();
+    if (!el) return;
+    if (event.target instanceof Node && el.contains(event.target)) return;
+    onOutside(event);
+  }
+
+  for (const t of eventTypes) document.addEventListener(t, handle, capture);
+
+  return () => {
+    for (const t of eventTypes) document.removeEventListener(t, handle, capture);
+  };
+}

--- a/src/client/utils/fileUpload.ts
+++ b/src/client/utils/fileUpload.ts
@@ -1,6 +1,14 @@
 import { DEFAULT_MCP_PORT } from "../../shared/constants";
 
-export const API_BASE = `http://localhost:${DEFAULT_MCP_PORT}/api`;
+/**
+ * Origin of the Tandem server for client-side fetches. Path constants live in
+ * `src/shared/api-paths.ts`; clients build URLs as `${API_BASE}${API_FOO}`.
+ *
+ * Prior to #283 this string ended in `/api`, and callers concatenated bare
+ * path tails like `/scratchpad`. That left routes drift-prone (the registration
+ * site says `"/api/scratchpad"` while the client says `"/scratchpad"`).
+ */
+export const API_BASE = `http://localhost:${DEFAULT_MCP_PORT}`;
 
 /** Encode an ArrayBuffer as base64 (safe for large files). */
 export function arrayBufferToBase64(buf: ArrayBuffer): string {

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -20,6 +20,12 @@
 
 import { resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  API_CHANNEL_AWARENESS,
+  API_CHANNEL_ERROR,
+  API_EVENTS,
+  API_MODE,
+} from "../shared/api-paths.js";
 import { authFetch, resolveTandemUrl } from "../shared/cli-runtime.js";
 import {
   CHANNEL_MAX_RETRIES,
@@ -95,7 +101,7 @@ export async function main(): Promise<void> {
         console.error("[Monitor] SSE connection exhausted, exiting");
         try {
           await fetchWithTimeout(
-            `${TANDEM_URL}/api/channel-error`,
+            `${TANDEM_URL}${API_CHANNEL_ERROR}`,
             {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -166,7 +172,7 @@ export async function connectAndStream(
   );
   let res: Response;
   try {
-    res = await authFetch(`${TANDEM_URL}/api/events`, { headers, signal: connectCtrl.signal });
+    res = await authFetch(`${TANDEM_URL}${API_EVENTS}`, { headers, signal: connectCtrl.signal });
   } finally {
     clearTimeout(connectTimer);
   }
@@ -201,7 +207,7 @@ export async function connectAndStream(
 
   function clearAwareness(documentId?: string) {
     const p = fetchWithTimeout(
-      `${TANDEM_URL}/api/channel-awareness`,
+      `${TANDEM_URL}${API_CHANNEL_AWARENESS}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -215,7 +221,7 @@ export async function connectAndStream(
     ).catch((err) => {
       console.error(
         "[Monitor] Awareness clear failed:",
-        describeFetchError(err, "/api/channel-awareness clear", AWARENESS_FETCH_TIMEOUT_MS),
+        describeFetchError(err, `${API_CHANNEL_AWARENESS} clear`, AWARENESS_FETCH_TIMEOUT_MS),
       );
     });
     trackAwareness(p);
@@ -230,7 +236,7 @@ export async function connectAndStream(
     // needs a non-null id to send the shutdown clear.
     if (event.documentId) shutdownTimers.lastDocumentId = event.documentId;
     const p = fetchWithTimeout(
-      `${TANDEM_URL}/api/channel-awareness`,
+      `${TANDEM_URL}${API_CHANNEL_AWARENESS}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -244,7 +250,7 @@ export async function connectAndStream(
     ).catch((err) => {
       console.error(
         "[Monitor] Awareness update failed:",
-        describeFetchError(err, "/api/channel-awareness update", AWARENESS_FETCH_TIMEOUT_MS),
+        describeFetchError(err, `${API_CHANNEL_AWARENESS} update`, AWARENESS_FETCH_TIMEOUT_MS),
       );
     });
     trackAwareness(p);
@@ -388,7 +394,7 @@ async function finalClearAwareness(): Promise<boolean> {
   if (shutdownTimers.lastDocumentId === null) return true;
   try {
     const res = await fetchWithTimeout(
-      `${TANDEM_URL}/api/channel-awareness`,
+      `${TANDEM_URL}${API_CHANNEL_AWARENESS}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -408,7 +414,7 @@ async function finalClearAwareness(): Promise<boolean> {
   } catch (err) {
     console.error(
       "[Monitor] Shutdown awareness clear failed:",
-      describeFetchError(err, "/api/channel-awareness shutdown", AWARENESS_FETCH_TIMEOUT_MS),
+      describeFetchError(err, `${API_CHANNEL_AWARENESS} shutdown`, AWARENESS_FETCH_TIMEOUT_MS),
     );
     return false;
   }
@@ -484,14 +490,14 @@ type FetchModeResult = { ok: true; mode: TandemMode } | { ok: false; reason: str
 /** Fetch + validate /api/mode. Callers apply their own failure policy. */
 async function fetchMode(): Promise<FetchModeResult> {
   try {
-    const res = await fetchWithTimeout(`${TANDEM_URL}/api/mode`, {}, MODE_FETCH_TIMEOUT_MS);
+    const res = await fetchWithTimeout(`${TANDEM_URL}${API_MODE}`, {}, MODE_FETCH_TIMEOUT_MS);
     if (!res.ok) return { ok: false, reason: `status ${res.status}` };
     const body = (await res.json()) as { mode?: unknown };
     const parsed = TandemModeSchema.safeParse(body.mode);
     if (!parsed.success) return { ok: false, reason: `invalid mode ${JSON.stringify(body.mode)}` };
     return { ok: true, mode: parsed.data };
   } catch (err) {
-    return { ok: false, reason: describeFetchError(err, "/api/mode", MODE_FETCH_TIMEOUT_MS) };
+    return { ok: false, reason: describeFetchError(err, API_MODE, MODE_FETCH_TIMEOUT_MS) };
   }
 }
 

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -35,7 +35,7 @@ import {
 import type { TandemEvent } from "../shared/events/types.js";
 import { formatEventContent, parseTandemEvent } from "../shared/events/types.js";
 import { describeFetchError, fetchWithTimeout } from "../shared/fetch-with-timeout.js";
-import { type TandemMode, TandemModeSchema } from "../shared/types.js";
+import { MONITOR_CONNECT_FAILED, type TandemMode, TandemModeSchema } from "../shared/types.js";
 
 const IS_VITEST = process.env.VITEST === "true";
 
@@ -106,7 +106,7 @@ export async function main(): Promise<void> {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
-                error: "MONITOR_CONNECT_FAILED",
+                error: MONITOR_CONNECT_FAILED,
                 message: `Monitor lost connection after ${CHANNEL_MAX_RETRIES} retries.`,
               }),
             },

--- a/src/server/mcp/api-routes.ts
+++ b/src/server/mcp/api-routes.ts
@@ -1,5 +1,21 @@
 import type { Express, NextFunction, Request, Response } from "express";
 
+import {
+  API_ANNOTATION_REPLY,
+  API_APPLY_CHANGES,
+  API_CLOSE,
+  API_CONVERT,
+  API_INFO,
+  API_MODE,
+  API_NOTIFY_STREAM,
+  API_OPEN,
+  API_REMOVE_ANNOTATION,
+  API_ROTATE_TOKEN,
+  API_SAVE,
+  API_SCRATCHPAD,
+  API_SETUP,
+  API_UPLOAD,
+} from "../../shared/api-paths.js";
 import { TAURI_HOSTNAME } from "../../shared/constants.js";
 import type { Handler } from "./routes/_shared.js";
 import { handleAnnotationReply } from "./routes/annotation-reply.js";
@@ -102,53 +118,53 @@ export function registerApiRoutes(
   infoHandlerDeps: Parameters<typeof makeInfoHandler>[0],
 ): void {
   // App metadata endpoint — consumed by the client's About panel
-  app.get("/api/info", mw, makeInfoHandler(infoHandlerDeps));
+  app.get(API_INFO, mw, makeInfoHandler(infoHandlerDeps));
 
   // SSE notification stream for browser toasts
-  app.get("/api/notify-stream", mw, handleNotifyStream);
+  app.get(API_NOTIFY_STREAM, mw, handleNotifyStream);
 
   // NOTE: /api/mode is GET-only — no OPTIONS registration
-  app.get("/api/mode", mw, handleMode);
+  app.get(API_MODE, mw, handleMode);
 
-  app.options("/api/open", mw);
-  app.post("/api/open", mw, largeBody, handleOpen);
+  app.options(API_OPEN, mw);
+  app.post(API_OPEN, mw, largeBody, handleOpen);
 
-  app.options("/api/close", mw);
-  app.post("/api/close", mw, largeBody, handleClose);
+  app.options(API_CLOSE, mw);
+  app.post(API_CLOSE, mw, largeBody, handleClose);
 
-  app.options("/api/save", mw);
-  app.post("/api/save", mw, largeBody, handleSave);
+  app.options(API_SAVE, mw);
+  app.post(API_SAVE, mw, largeBody, handleSave);
 
-  app.options("/api/upload", mw);
-  app.post("/api/upload", mw, largeBody, handleUpload);
+  app.options(API_UPLOAD, mw);
+  app.post(API_UPLOAD, mw, largeBody, handleUpload);
 
-  app.options("/api/scratchpad", mw);
-  app.post("/api/scratchpad", mw, handleScratchpad);
+  app.options(API_SCRATCHPAD, mw);
+  app.post(API_SCRATCHPAD, mw, handleScratchpad);
 
-  app.options("/api/convert", mw);
-  app.post("/api/convert", mw, largeBody, handleConvert);
+  app.options(API_CONVERT, mw);
+  app.post(API_CONVERT, mw, largeBody, handleConvert);
 
-  app.options("/api/apply-changes", mw);
-  app.post("/api/apply-changes", mw, largeBody, handleApplyChanges);
+  app.options(API_APPLY_CHANGES, mw);
+  app.post(API_APPLY_CHANGES, mw, largeBody, handleApplyChanges);
 
-  app.options("/api/setup", mw);
-  app.post("/api/setup", mw, largeBody, makeSetupHandler({ token }));
+  app.options(API_SETUP, mw);
+  app.post(API_SETUP, mw, largeBody, makeSetupHandler({ token }));
 
   // Annotation reply: browser user posts a reply to an annotation thread
-  app.options("/api/annotation-reply", mw);
-  app.post("/api/annotation-reply", mw, largeBody, handleAnnotationReply);
+  app.options(API_ANNOTATION_REPLY, mw);
+  app.post(API_ANNOTATION_REPLY, mw, largeBody, handleAnnotationReply);
 
-  app.options("/api/remove-annotation", mw);
-  app.post("/api/remove-annotation", mw, largeBody, handleRemoveAnnotation);
+  app.options(API_REMOVE_ANNOTATION, mw);
+  app.post(API_REMOVE_ANNOTATION, mw, largeBody, handleRemoveAnnotation);
 
   // Token rotation: CLI calls this to activate the 60-second grace window and swap the
   // in-memory current token to the NEW token that was already written to disk.
   // Auth is handled by app.use("/api", authMiddleware) — request must carry Bearer <OLD token>.
   // previousToken is NOT accepted from the request body — the handler captures it from
   // getCurrentToken() to prevent callers from injecting arbitrary strings into the grace slot.
-  app.options("/api/rotate-token", mw);
+  app.options(API_ROTATE_TOKEN, mw);
   app.post(
-    "/api/rotate-token",
+    API_ROTATE_TOKEN,
     mw,
     largeBody,
     makeRotateTokenHandler({ setCurrentToken, getCurrentToken }),

--- a/src/server/mcp/channel-routes.ts
+++ b/src/server/mcp/channel-routes.ts
@@ -1,4 +1,14 @@
 import type { Express, Request, Response } from "express";
+import {
+  API_CHANNEL_AWARENESS,
+  API_CHANNEL_ERROR,
+  API_CHANNEL_PERMISSION,
+  API_CHANNEL_PERMISSION_VERDICT,
+  API_CHANNEL_REPLY,
+  API_CHAT,
+  API_EVENTS,
+  API_LAUNCH_CLAUDE,
+} from "../../shared/api-paths.js";
 import { CTRL_ROOM, Y_MAP_AWARENESS, Y_MAP_CHAT } from "../../shared/constants.js";
 import type { ClaudeAwareness } from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
@@ -22,11 +32,11 @@ const PERMISSION_TTL_MS = 30_000; // Stale after 30s (terminal answer already wo
 /** Register channel-related routes (/api/events, /api/channel-*, /api/launch-claude) on the Express app. */
 export function registerChannelRoutes(app: Express, apiMiddleware: Handler): void {
   // SSE event stream for channel shim
-  app.get("/api/events", apiMiddleware, sseHandler);
+  app.get(API_EVENTS, apiMiddleware, sseHandler);
 
   // Channel awareness: shim posts Claude's status for browser StatusBar
-  app.options("/api/channel-awareness", apiMiddleware);
-  app.post("/api/channel-awareness", apiMiddleware, (req: Request, res: Response) => {
+  app.options(API_CHANNEL_AWARENESS, apiMiddleware);
+  app.post(API_CHANNEL_AWARENESS, apiMiddleware, (req: Request, res: Response) => {
     const { documentId, status, active, focusParagraph, focusOffset } = (req.body ?? {}) as Record<
       string,
       unknown
@@ -53,8 +63,8 @@ export function registerChannelRoutes(app: Express, apiMiddleware: Handler): voi
   });
 
   // Channel error: shim reports errors for browser display
-  app.options("/api/channel-error", apiMiddleware);
-  app.post("/api/channel-error", apiMiddleware, (req: Request, res: Response) => {
+  app.options(API_CHANNEL_ERROR, apiMiddleware);
+  app.post(API_CHANNEL_ERROR, apiMiddleware, (req: Request, res: Response) => {
     const { error, message } = (req.body ?? {}) as Record<string, unknown>;
     console.error(`[Channel] Error: ${error} — ${message}`);
     // Could broadcast to browser via Y.Map in the future
@@ -62,8 +72,8 @@ export function registerChannelRoutes(app: Express, apiMiddleware: Handler): voi
   });
 
   // Channel reply: shim forwards Claude's chat replies
-  app.options("/api/channel-reply", apiMiddleware);
-  app.post("/api/channel-reply", apiMiddleware, (req: Request, res: Response) => {
+  app.options(API_CHANNEL_REPLY, apiMiddleware);
+  app.post(API_CHANNEL_REPLY, apiMiddleware, (req: Request, res: Response) => {
     const { text, documentId, replyTo } = (req.body ?? {}) as Record<string, unknown>;
     if (typeof text !== "string") {
       res.status(400).json({ error: "BAD_REQUEST", message: "text is required" });
@@ -87,8 +97,8 @@ export function registerChannelRoutes(app: Express, apiMiddleware: Handler): voi
 
   // Channel permission relay: shim forwards Claude Code's tool approval prompts
   // Pending requests stored for browser polling (SSE push to browser is a follow-up)
-  app.options("/api/channel-permission", apiMiddleware);
-  app.post("/api/channel-permission", apiMiddleware, (req: Request, res: Response) => {
+  app.options(API_CHANNEL_PERMISSION, apiMiddleware);
+  app.post(API_CHANNEL_PERMISSION, apiMiddleware, (req: Request, res: Response) => {
     const { requestId, toolName, description, inputPreview } = (req.body ?? {}) as Record<
       string,
       unknown
@@ -109,7 +119,7 @@ export function registerChannelRoutes(app: Express, apiMiddleware: Handler): voi
   });
 
   // Browser polls for pending permission requests
-  app.get("/api/channel-permission", apiMiddleware, (_req: Request, res: Response) => {
+  app.get(API_CHANNEL_PERMISSION, apiMiddleware, (_req: Request, res: Response) => {
     // Evict stale requests before returning
     const now = Date.now();
     for (const [id, perm] of pendingPermissions) {
@@ -119,8 +129,8 @@ export function registerChannelRoutes(app: Express, apiMiddleware: Handler): voi
   });
 
   // Browser submits verdict
-  app.options("/api/channel-permission-verdict", apiMiddleware);
-  app.post("/api/channel-permission-verdict", apiMiddleware, (req: Request, res: Response) => {
+  app.options(API_CHANNEL_PERMISSION_VERDICT, apiMiddleware);
+  app.post(API_CHANNEL_PERMISSION_VERDICT, apiMiddleware, (req: Request, res: Response) => {
     const { requestId, approved } = (req.body ?? {}) as Record<string, unknown>;
     if (typeof requestId !== "string") {
       res.status(400).json({ error: "BAD_REQUEST", message: "requestId is required" });
@@ -133,8 +143,8 @@ export function registerChannelRoutes(app: Express, apiMiddleware: Handler): voi
   });
 
   // Clear chat history
-  app.options("/api/chat", apiMiddleware);
-  app.delete("/api/chat", apiMiddleware, (_req: Request, res: Response) => {
+  app.options(API_CHAT, apiMiddleware);
+  app.delete(API_CHAT, apiMiddleware, (_req: Request, res: Response) => {
     const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
     const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
     const count = chatMap.size;
@@ -147,8 +157,8 @@ export function registerChannelRoutes(app: Express, apiMiddleware: Handler): voi
   });
 
   // Claude Code launcher
-  app.options("/api/launch-claude", apiMiddleware);
-  app.post("/api/launch-claude", apiMiddleware, async (_req: Request, res: Response) => {
+  app.options(API_LAUNCH_CLAUDE, apiMiddleware);
+  app.post(API_LAUNCH_CLAUDE, apiMiddleware, async (_req: Request, res: Response) => {
     try {
       const { launchClaude } = await import("./launcher.js");
       const result = launchClaude();

--- a/src/server/mcp/channel-routes.ts
+++ b/src/server/mcp/channel-routes.ts
@@ -10,7 +10,7 @@ import {
   API_LAUNCH_CLAUDE,
 } from "../../shared/api-paths.js";
 import { CTRL_ROOM, Y_MAP_AWARENESS, Y_MAP_CHAT } from "../../shared/constants.js";
-import type { ClaudeAwareness } from "../../shared/types.js";
+import { ChannelErrorCodeSchema, type ClaudeAwareness } from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
 import { MCP_ORIGIN } from "../events/queue.js";
 import { sseHandler } from "../events/sse.js";
@@ -66,7 +66,18 @@ export function registerChannelRoutes(app: Express, apiMiddleware: Handler): voi
   app.options(API_CHANNEL_ERROR, apiMiddleware);
   app.post(API_CHANNEL_ERROR, apiMiddleware, (req: Request, res: Response) => {
     const { error, message } = (req.body ?? {}) as Record<string, unknown>;
-    console.error(`[Channel] Error: ${error} — ${message}`);
+    // Validate the code so a future caller can't smuggle a free-form string
+    // through unfiltered logs. Out-of-schema codes are logged as UNKNOWN_CODE
+    // (keeps the diagnostic trail) and reported as 400 so the caller notices.
+    const parsed = ChannelErrorCodeSchema.safeParse(error);
+    if (!parsed.success) {
+      console.error(`[Channel] Error: UNKNOWN_CODE (${String(error)}) — ${message}`);
+      res
+        .status(400)
+        .json({ error: "BAD_REQUEST", message: "error must be a known ChannelErrorCode" });
+      return;
+    }
+    console.error(`[Channel] Error: ${parsed.data} — ${message}`);
     // Could broadcast to browser via Y.Map in the future
     res.json({ ok: true });
   });

--- a/src/shared/api-paths.ts
+++ b/src/shared/api-paths.ts
@@ -1,0 +1,42 @@
+/**
+ * Single source of truth for Tandem's internal HTTP path strings.
+ *
+ * Server route registration (`src/server/mcp/{api,channel}-routes.ts`) and every
+ * client/CLI/channel-shim/monitor caller import from here so a rename hits one file.
+ *
+ * See #283.
+ */
+
+// --- Channel / event stream (SSE + push-back) -------------------------------
+export const API_EVENTS = "/api/events";
+export const API_NOTIFY_STREAM = "/api/notify-stream";
+export const API_CHANNEL_AWARENESS = "/api/channel-awareness";
+export const API_CHANNEL_ERROR = "/api/channel-error";
+export const API_CHANNEL_REPLY = "/api/channel-reply";
+export const API_CHANNEL_PERMISSION = "/api/channel-permission";
+export const API_CHANNEL_PERMISSION_VERDICT = "/api/channel-permission-verdict";
+export const API_LAUNCH_CLAUDE = "/api/launch-claude";
+
+// --- Mode / metadata --------------------------------------------------------
+export const API_MODE = "/api/mode";
+export const API_INFO = "/api/info";
+
+// --- Document lifecycle -----------------------------------------------------
+export const API_OPEN = "/api/open";
+export const API_CLOSE = "/api/close";
+export const API_SAVE = "/api/save";
+export const API_UPLOAD = "/api/upload";
+export const API_SCRATCHPAD = "/api/scratchpad";
+export const API_CONVERT = "/api/convert";
+export const API_APPLY_CHANGES = "/api/apply-changes";
+
+// --- Annotations ------------------------------------------------------------
+export const API_ANNOTATION_REPLY = "/api/annotation-reply";
+export const API_REMOVE_ANNOTATION = "/api/remove-annotation";
+
+// --- Chat -------------------------------------------------------------------
+export const API_CHAT = "/api/chat";
+
+// --- Setup / auth -----------------------------------------------------------
+export const API_SETUP = "/api/setup";
+export const API_ROTATE_TOKEN = "/api/rotate-token";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -36,6 +36,19 @@ export const ToolErrorCodeSchema = z.enum([
   "PERMISSION_DENIED",
 ]);
 
+/**
+ * Identifier strings the channel shim or monitor can POST to
+ * `/api/channel-error` on terminal failure. The server logs them; defining
+ * them as a closed set lets call sites import the constants instead of
+ * free-form strings, and the route handler can validate before logging.
+ *
+ * See #284.
+ */
+export const ChannelErrorCodeSchema = z.enum(["CHANNEL_CONNECT_FAILED", "MONITOR_CONNECT_FAILED"]);
+export type ChannelErrorCode = z.infer<typeof ChannelErrorCodeSchema>;
+export const CHANNEL_CONNECT_FAILED: ChannelErrorCode = "CHANNEL_CONNECT_FAILED";
+export const MONITOR_CONNECT_FAILED: ChannelErrorCode = "MONITOR_CONNECT_FAILED";
+
 // --- Derived TypeScript types ---
 
 export type AnnotationType = z.infer<typeof AnnotationTypeSchema>;

--- a/tests/channel/run-timeouts.test.ts
+++ b/tests/channel/run-timeouts.test.ts
@@ -31,10 +31,19 @@ function countMatches(src: string, re: RegExp): number {
 }
 
 function expectFetchWithTimeoutEndpoint(src: string, endpoint: string, timeoutConstant: string) {
-  const escapedEndpoint = endpoint.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const escapedTimeout = timeoutConstant.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Accept either the literal path or the `API_*` constant that resolves to it
+  // (post-#283 the channel/server use the constants from src/shared/api-paths.ts).
+  const escapedEndpoint = endpoint.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const constantName = `API${endpoint
+    .replace(/^\//, "")
+    .replace(/^api\//, "")
+    .replace(/-/g, "_")
+    .toUpperCase()
+    .replace(/^/, "_")}`;
+  const endpointAlternation = `(?:${escapedEndpoint}|${constantName})`;
   expect(src).toMatch(
-    new RegExp(`fetchWithTimeout\\([\\s\\S]*?${escapedEndpoint}[\\s\\S]*?${escapedTimeout}`),
+    new RegExp(`fetchWithTimeout\\([\\s\\S]*?${endpointAlternation}[\\s\\S]*?${escapedTimeout}`),
   );
 }
 
@@ -76,7 +85,7 @@ describe("channel/event-bridge.ts timeout coverage", () => {
     // authFetch call remains, and it is the handshake.
     const bareAuthFetch = src.match(/\bauthFetch\s*\(/g) ?? [];
     expect(bareAuthFetch.length).toBe(1);
-    expect(src).toMatch(/authFetch\(`\$\{tandemUrl\}\/api\/events`/);
+    expect(src).toMatch(/authFetch\(`\$\{tandemUrl\}(?:\/api\/events|\$\{API_EVENTS\})`/);
   });
 
   it("pairs every request-response endpoint with fetchWithTimeout and its timeout budget", async () => {
@@ -84,7 +93,12 @@ describe("channel/event-bridge.ts timeout coverage", () => {
     expectFetchWithTimeoutEndpoint(src, "/api/channel-error", "CHANNEL_ERROR_REPORT_TIMEOUT_MS");
     expectFetchWithTimeoutEndpoint(src, "/api/mode", "CHANNEL_MODE_FETCH_TIMEOUT_MS");
 
-    expect(countMatches(src, /fetchWithTimeout\([\s\S]*?\/api\/channel-awareness/g)).toBe(2);
+    expect(
+      countMatches(
+        src,
+        /fetchWithTimeout\([\s\S]*?(?:\/api\/channel-awareness|API_CHANNEL_AWARENESS)/g,
+      ),
+    ).toBe(2);
     expect(countMatches(src, /CHANNEL_AWARENESS_FETCH_TIMEOUT_MS/g)).toBeGreaterThanOrEqual(2);
   });
 

--- a/tests/monitor/runtime-fetches.test.ts
+++ b/tests/monitor/runtime-fetches.test.ts
@@ -17,8 +17,15 @@ function countMatches(src: string, re: RegExp): number {
 function expectFetchWithTimeoutEndpoint(src: string, endpoint: string, timeoutConstant: string) {
   const escapedEndpoint = endpoint.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const escapedTimeout = timeoutConstant.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Accept either the literal path or the `API_*` constant that resolves to it
+  // (post-#283 the monitor uses the constants from src/shared/api-paths.ts).
+  const constantName = `API_${endpoint
+    .replace(/^\/api\//, "")
+    .replace(/-/g, "_")
+    .toUpperCase()}`;
+  const endpointAlternation = `(?:${escapedEndpoint}|${constantName})`;
   expect(src).toMatch(
-    new RegExp(`fetchWithTimeout\\([\\s\\S]*?${escapedEndpoint}[\\s\\S]*?${escapedTimeout}`),
+    new RegExp(`fetchWithTimeout\\([\\s\\S]*?${endpointAlternation}[\\s\\S]*?${escapedTimeout}`),
   );
 }
 
@@ -58,9 +65,14 @@ describe("monitor authenticated fetch surface", () => {
     expect(src).not.toMatch(/async function fetchWithTimeout\(/);
     expectFetchWithTimeoutEndpoint(src, "/api/channel-error", "ERROR_REPORT_TIMEOUT_MS");
     expectFetchWithTimeoutEndpoint(src, "/api/mode", "MODE_FETCH_TIMEOUT_MS");
-    expect(countMatches(src, /fetchWithTimeout\([\s\S]*?\/api\/channel-awareness/g)).toBe(3);
+    expect(
+      countMatches(
+        src,
+        /fetchWithTimeout\([\s\S]*?(?:\/api\/channel-awareness|API_CHANNEL_AWARENESS)/g,
+      ),
+    ).toBe(3);
     expect(src.match(/\bauthFetch\s*\(/g)?.length ?? 0).toBe(1);
-    expect(src).toMatch(/authFetch\(`\$\{TANDEM_URL\}\/api\/events`/);
+    expect(src).toMatch(/authFetch\(`\$\{TANDEM_URL\}(?:\/api\/events|\$\{API_EVENTS\})`/);
   });
 
   it("authenticates the SSE handshake with plugin URL and token", async () => {


### PR DESCRIPTION
## Summary

Three independent polish refactors batched per the issues' own scoping guidance.

- **#283** — Every `/api/*` path now flows through `src/shared/api-paths.ts`. Server route registrations + every client/CLI/channel/monitor fetch import the constants. `API_BASE` in `src/client/utils/fileUpload.ts` no longer carries the `/api` suffix; clients build URLs as `${API_BASE}${API_FOO}`. Renaming a route is now a one-file change.
- **#284** — `ChannelErrorCodeSchema` (z.enum) replaces free-form `error` strings on `/api/channel-error`. Two typed constants exported (`CHANNEL_CONNECT_FAILED`, `MONITOR_CONNECT_FAILED`). Route handler validates incoming payloads and returns 400 BAD_REQUEST on unknown codes (still logs the rejected value for the diagnostic trail).
- **#589** — `onOutsideEvent` helper in `src/client/utils/dismiss-outside.ts` consolidates the duplicated "event landed outside this container" guard used by `Toolbar.svelte` (scroll dismiss) and `HighlightColorPicker.svelte` (mousedown dismiss). Capture-phase parity preserved at each call site.

Each commit is self-contained and closes its respective issue. Static-analysis tests in `tests/channel/run-timeouts.test.ts` and `tests/monitor/runtime-fetches.test.ts` were updated to accept either the literal path or the resolved `API_*` constant.

## Test plan

- [x] `npm run typecheck` clean (tsc server + tsc client + svelte-check)
- [x] `npm test` — 1941 passed (1947 total, 6 skipped)
- [x] Biome formatter clean
- [x] Local cargo test passes (pre-push hook)
- [x] code-reviewer agent: no high-confidence issues on #283
- [x] svelte-migration-reviewer agent: no high-confidence issues on #589

Closes #283
Closes #284
Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)