### PR TITLE
chore: /simplify pass on today's changes

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -137,32 +137,19 @@ wireActionDeps({
   openFindBar: () => {},
 });
 
-// Guard: only dispatch when visibility actually changes. Without this, every
-// call to updateSettings() (which replaces the entire settings object even
-// when showAuthorship is unchanged) would dispatch a transaction, causing
-// FormattingToolbar's tick++ listener to fire inside Svelte's effect flush
-// and eventually exceed the 1000-update depth limit (#613).
-//
-// First-run note: on the editor's initial availability we record the current
-// `visible` value WITHOUT dispatching. The authorship plugin reads
-// `localStorage[AUTHORSHIP_TOGGLE_KEY]` at construction time
-// (`useTandemSettings.svelte.ts` mirrors `showAuthorship` to that key on every
-// write) so the editor already starts in the correct state. Dispatching on
-// the first run was needed in the React era when the plugin had no localStorage
-// hook, and it is exactly the path that produced #613's prod-only effect-depth
-// loop — likely chained through y-prosemirror's transaction queue under prod's
-// tighter scheduling.
-let _lastAuthorshipVisible: boolean | undefined;
+// The authorship plugin reads its initial visibility from localStorage at
+// construction time, so dispatch only on subsequent changes — first-run
+// dispatch was the path that produced an effect-depth loop under prod
+// scheduling (transaction → tick → effect rerun → dispatch …).
+let lastDispatchedAuthorship: boolean | null = null;
 $effect(() => {
   const ed = editor;
   if (!ed) return;
   const visible = settingsState.settings.showAuthorship;
-  if (_lastAuthorshipVisible === undefined) {
-    _lastAuthorshipVisible = visible;
-    return;
-  }
-  if (_lastAuthorshipVisible === visible) return;
-  _lastAuthorshipVisible = visible;
+  if (lastDispatchedAuthorship === visible) return;
+  const firstRun = lastDispatchedAuthorship === null;
+  lastDispatchedAuthorship = visible;
+  if (firstRun) return;
   untrack(() => {
     const tr = ed.state.tr.setMeta(authorshipPluginKey, { type: "toggle", visible });
     ed.view.dispatch(tr);
@@ -194,12 +181,7 @@ let activeLeftRailTab = $state<"annotations" | "chat" | "outline">(
   settingsState.settings.leftRailTabs[0] ?? "annotations",
 );
 
-// Reconcile active-tab pointers whenever the persisted rail arrays change
-// (e.g. after settings load, cross-rail move, or external settings update).
-//
-// `untrack` around the write so the write back to activeLeftRailTab /
-// activeRailTab doesn't form a self-dep with this effect's includes() read.
-// Defensive against the prod-only #613 effect_update_depth shape.
+// `untrack` so the write doesn't form a self-dep with the includes() read.
 $effect(() => {
   const leftTabs = settingsState.settings.leftRailTabs;
   if (!leftTabs.includes(activeLeftRailTab)) {

--- a/src/client/components/SettingsPopover.svelte
+++ b/src/client/components/SettingsPopover.svelte
@@ -137,17 +137,11 @@ let docsLoading = $state(false);
 let docsError = $state<string | null>(null);
 let activeSection = $state<SettingsSection>("appearance");
 
-// Clear stale fetch errors when the user navigates away from the section that
-// produced them. Without this, an error from Appearance's Changelog button
-// stays visible after switching to Editor and back.
-//
-// Only assign when the values are currently non-null. Setting null → null is a
-// no-op for primitives, but explicit guarding keeps this effect off the suspect
-// list for prod-only effect_update_depth chains (#613).
+// Clear stale fetch errors when the user navigates between sections.
 $effect(() => {
   activeSection;
-  if (changelogError !== null) changelogError = null;
-  if (docsError !== null) docsError = null;
+  changelogError = null;
+  docsError = null;
 });
 
 // Idle-sync: sync only when NOT focused and value differs

--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -177,18 +177,16 @@ export const AnnotationExtension = Extension.create<{ ydoc: Y.Doc | null }>({
         },
 
         view(editorView) {
-          // Coalesce a burst of Y.Map observer fires into a single rebuild.
-          // On initial sync (force-reload, session restore, docx import), the
-          // Y.Map observer can fire dozens to hundreds of times in one tick.
-          // Without coalescing, each fire dispatches a transaction that calls
-          // `buildDecorations()` — O(n) over every annotation in the map —
-          // making the load O(n²). rAF is enough to merge a single event-loop
-          // burst; per-event dispatches still feel instant. See #610.
+          // Coalesce bursts of Y.Map observer fires into a single rebuild —
+          // initial sync (force-reload, session restore, docx import) can fire
+          // the observer hundreds of times per tick, each rebuilding O(n).
           let rafId: number | null = null;
+          let rebuiltSinceMount = false;
           function scheduleRebuild() {
             if (rafId !== null) return;
             rafId = requestAnimationFrame(() => {
               rafId = null;
+              rebuiltSinceMount = true;
               const tr = editorView.state.tr.setMeta(annotationPluginKey, true);
               editorView.dispatch(tr);
             });
@@ -201,13 +199,11 @@ export const AnnotationExtension = Extension.create<{ ydoc: Y.Doc | null }>({
           };
           annotationsMap.observe(observer);
 
-          // Post-sync settle: y-prosemirror can populate the editor doc after
-          // the Y.Map observer has already attached and (silently) fired with
-          // a still-empty PM doc. Mirrors authorship.ts:223 — the same hazard
-          // pattern in a separate decoration plugin. The 500ms delay is the
-          // documented post-sync settling window.
+          // y-prosemirror can populate the editor doc after the Y.Map observer
+          // attached and fired against an empty PM doc; rebuild once if the
+          // observer never fired during the settling window.
           const syncRebuild = setTimeout(() => {
-            if (annotationsMap.size > 0) observer();
+            if (!rebuiltSinceMount && rafId === null && annotationsMap.size > 0) observer();
           }, 500);
 
           return {

--- a/src/client/editor/toolbar/FormattingToolbar.svelte
+++ b/src/client/editor/toolbar/FormattingToolbar.svelte
@@ -22,15 +22,9 @@ let showLinkInput = $state(false);
 let linkInputValue = $state("");
 let linkInputEl = $state<HTMLInputElement | null>(null);
 
-// Capture `editor` into a local `const` so the cleanup `.off()` runs against
-// the same instance we attached to. Without the capture, Svelte 5's reactive
-// prop getter returns the CURRENT value at cleanup time — which becomes `null`
-// during tab switch when `onEditorReady(null)` fires from the previous
-// editor's destroy. Calling `.off()` on null throws inside Svelte's effect
-// flush, the effect is retried, and the editor never finishes mounting (a
-// multi-second freeze + missing .ProseMirror element). Captured `ed` matches
-// the safe pattern in `FormattingBar.svelte` and the other `editor.off`
-// callsites in the codebase.
+// Capture `editor` so cleanup `.off()` runs against the instance we attached
+// to — the reactive prop getter returns the CURRENT value at cleanup time,
+// which is null during tab switch and would throw inside the effect flush.
 $effect(() => {
   const ed = editor;
   if (!ed || ed.isDestroyed) return;

--- a/src/client/utils/fileUpload.ts
+++ b/src/client/utils/fileUpload.ts
@@ -3,10 +3,6 @@ import { DEFAULT_MCP_PORT } from "../../shared/constants";
 /**
  * Origin of the Tandem server for client-side fetches. Path constants live in
  * `src/shared/api-paths.ts`; clients build URLs as `${API_BASE}${API_FOO}`.
- *
- * Prior to #283 this string ended in `/api`, and callers concatenated bare
- * path tails like `/scratchpad`. That left routes drift-prone (the registration
- * site says `"/api/scratchpad"` while the client says `"/scratchpad"`).
  */
 export const API_BASE = `http://localhost:${DEFAULT_MCP_PORT}`;
 

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -195,10 +195,8 @@ export async function openFileFromContent(
   const id = docIdFromPath(syntheticPath);
 
   const doc = getOrCreateDocument(id);
-  // Route the upload through the shared batched populate so the upload path
-  // also fixes #609 (large markdown drag-drop freeze). Display name is the
-  // uploaded filename, not the synthetic upload path, so notifications don't
-  // leak the internal path shape to the user.
+  // Display name is the uploaded filename, not the synthetic upload path, so
+  // notifications don't leak the internal path shape to the user.
   await populateDocFromContent(doc, format, content, {
     displayName: fileName,
     dedupSource: syntheticPath,
@@ -403,15 +401,10 @@ interface PopulateContext {
 }
 
 /**
- * Load file content from disk into the Y.Doc. Thin wrapper around
- * populateDocFromContent — reads the buffer once (the caller has already
- * validated `resolved` via resolveAndValidatePath: size limit, extension
- * allowlist, UNC rejection) and delegates the parse + transact + cleanup logic
- * to the shared helper used by openFileFromContent.
+ * Load file content from disk into the Y.Doc. Reads the buffer once and
+ * delegates the parse + transact + cleanup to populateDocFromContent.
  */
 async function loadContentIntoDoc(doc: Y.Doc, format: string, resolved: string): Promise<void> {
-  // Single read site collapses what would otherwise be multiple fs.readFile
-  // call sites into one — fewer "uncontrolled path" sinks for CodeQL.
   const buffer = await fs.readFile(resolved);
   await populateDocFromContent(doc, format, buffer, {
     displayName: path.basename(resolved),
@@ -422,23 +415,12 @@ async function loadContentIntoDoc(doc: Y.Doc, format: string, resolved: string):
 /**
  * Shared populate path for openFileByPath (disk) and openFileFromContent
  * (upload). Async I/O and parsing happen OUTSIDE the transaction; the Y.Doc
- * mutation runs INSIDE one doc.transact(..., MCP_ORIGIN). Without batching,
- * mdastToYDoc fires thousands of tiny CRDT updates that flood y-prosemirror
- * and freeze the client on large markdown docs (#609). Precedent:
- * clearAndReload and reloadFromDisk (same file) use the same shape — async
- * I/O outside, Y.Doc mutation inside a single MCP_ORIGIN transact.
+ * mutation runs INSIDE one doc.transact(..., MCP_ORIGIN) so mdastToYDoc's
+ * many tiny inserts arrive as one update.
  *
  * MCP_ORIGIN is safe here (Critical Rule #2): the durable-annotation sync
  * observer and the channel event queue are attached later via
- * wireAnnotationStore (called from finalizeDocOpen, which runs after this
- * returns). No observer is watching during initial populate, so there is no
- * echo to suppress.
- *
- * On the success path, injectCommentsAsAnnotations' inner MCP_ORIGIN transact
- * is flattened by Yjs into the outer one — inner is a no-op wrapper. On the
- * failure path, the cleanup transact in the catch is a fresh top-level
- * transact: Yjs has already run the failed transact's finally
- * (afterTransaction + update emit) before the catch fires.
+ * wireAnnotationStore, after this returns — no observer to echo.
  */
 async function populateDocFromContent(
   doc: Y.Doc,
@@ -473,28 +455,22 @@ async function populateDocFromContent(
     applyToDoc = () => {
       htmlToYDoc(doc, html);
       if (comments.length > 0) {
-        // injectCommentsAsAnnotations opens an inner MCP_ORIGIN transact that
-        // Yjs flattens into ours, so writes land directly on this transaction's
-        // change set. Yjs does NOT roll back inner-transact writes on throw —
-        // without the snapshot/undo dance below, the doc would commit with N-of-M
-        // partial comments and re-open would hit importAnnotationId dedup,
-        // permanently dropping the failing comment with no surfaced error.
+        // Yjs does not roll back inner-transact writes on throw, so snapshot
+        // pre-inject annotation keys and undo any new ones if inject fails —
+        // otherwise an N-of-M commit collides with importAnnotationId dedup
+        // on next open and silently drops the failing comment.
         const annotMap = doc.getMap(Y_MAP_ANNOTATIONS);
         const before = new Set(annotMap.keys());
         try {
           injectCommentsAsAnnotations(doc, comments);
         } catch (err) {
-          for (const k of annotMap.keys()) {
+          for (const k of [...annotMap.keys()]) {
             if (!before.has(k)) annotMap.delete(k);
           }
           console.error(
             "[docx-comments] inject failed mid-transact; document loads without imported comments:",
             err,
           );
-          // Symmetric with the extract-failure notification ~30 lines above:
-          // both modes mean "docx loaded without (some) comments" from the
-          // user's perspective. Distinct dedupKey namespace so a file that
-          // hits both modes shows two toasts, not one collapsed one.
           pushNotification({
             id: generateNotificationId(),
             type: "annotation-error",
@@ -526,16 +502,10 @@ async function populateDocFromContent(
       doc.transact(() => {
         const fragment = doc.getXmlFragment("default");
         fragment.delete(0, fragment.length);
-        // Defensive: htmlToYDoc/loadMarkdown/populateYDoc shouldn't touch
-        // annotations, but injectCommentsAsAnnotations can leave partial entries
-        // even if the inner containment caught the throw (Yjs does not roll
-        // back inner-transact writes). REPLIES is not touched during populate,
-        // so leave it alone.
-        // MAINTENANCE: if a future populate helper writes to Y_MAP_ANNOTATION_REPLIES
-        // (e.g. importing a format with threaded comments), this cleanup must
-        // clear them too — the cleanup is silently incomplete until that happens.
+        // injectCommentsAsAnnotations can leave partial entries even when its
+        // own catch fires (Yjs does not roll back inner-transact writes).
         const annotations = doc.getMap(Y_MAP_ANNOTATIONS);
-        annotations.forEach((_, k) => annotations.delete(k));
+        for (const k of [...annotations.keys()]) annotations.delete(k);
       }, MCP_ORIGIN);
     } catch (cleanupErr) {
       console.error(
@@ -543,10 +513,8 @@ async function populateDocFromContent(
         cleanupErr,
       );
     }
-    // Keep the first console.error argument a static literal; pass
-    // user-controlled values (format, displayName, err) as trailing args so
-    // util.format never treats them as a format string. Defuses CodeQL's
-    // externally-controlled format string alert.
+    // Static-literal first arg; user-controlled values arrive as trailing args
+    // so util.format doesn't treat them as a format string.
     console.error(
       "[Tandem] populateDocFromContent: populate failed; partial state cleared before rethrow.",
       { format, displayName: ctx.displayName },

--- a/src/shared/api-paths.ts
+++ b/src/shared/api-paths.ts
@@ -3,8 +3,6 @@
  *
  * Server route registration (`src/server/mcp/{api,channel}-routes.ts`) and every
  * client/CLI/channel-shim/monitor caller import from here so a rename hits one file.
- *
- * See #283.
  */
 
 // --- Channel / event stream (SSE + push-back) -------------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -41,8 +41,6 @@ export const ToolErrorCodeSchema = z.enum([
  * `/api/channel-error` on terminal failure. The server logs them; defining
  * them as a closed set lets call sites import the constants instead of
  * free-form strings, and the route handler can validate before logging.
- *
- * See #284.
  */
 export const ChannelErrorCodeSchema = z.enum(["CHANNEL_CONNECT_FAILED", "MONITOR_CONNECT_FAILED"]);
 export type ChannelErrorCode = z.infer<typeof ChannelErrorCodeSchema>;

--- a/tests/channel/run-timeouts.test.ts
+++ b/tests/channel/run-timeouts.test.ts
@@ -20,32 +20,12 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { countMatches, expectFetchWithTimeoutEndpoint } from "../helpers/fetch-source-asserts.js";
 
 const RUN_TS_PATH = fileURLToPath(new URL("../../src/channel/run.ts", import.meta.url));
 const EVENT_BRIDGE_PATH = fileURLToPath(
   new URL("../../src/channel/event-bridge.ts", import.meta.url),
 );
-
-function countMatches(src: string, re: RegExp): number {
-  return src.match(re)?.length ?? 0;
-}
-
-function expectFetchWithTimeoutEndpoint(src: string, endpoint: string, timeoutConstant: string) {
-  const escapedTimeout = timeoutConstant.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // Accept either the literal path or the `API_*` constant that resolves to it
-  // (post-#283 the channel/server use the constants from src/shared/api-paths.ts).
-  const escapedEndpoint = endpoint.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const constantName = `API${endpoint
-    .replace(/^\//, "")
-    .replace(/^api\//, "")
-    .replace(/-/g, "_")
-    .toUpperCase()
-    .replace(/^/, "_")}`;
-  const endpointAlternation = `(?:${escapedEndpoint}|${constantName})`;
-  expect(src).toMatch(
-    new RegExp(`fetchWithTimeout\\([\\s\\S]*?${endpointAlternation}[\\s\\S]*?${escapedTimeout}`),
-  );
-}
 
 describe("channel/run.ts timeout coverage", () => {
   it("does not import authFetch directly — all HTTP goes through fetchWithTimeout", async () => {

--- a/tests/helpers/docx-fixtures.ts
+++ b/tests/helpers/docx-fixtures.ts
@@ -1,0 +1,41 @@
+/**
+ * Synthetic .docx Buffer with N inline Word comments anchored to short text
+ * ranges. Used by the file-opener batching/cleanup test suites.
+ */
+export async function buildDocxWithComments(commentCount: number): Promise<Buffer> {
+  const JSZip = (await import("jszip")).default;
+  const zip = new JSZip();
+
+  const runs: string[] = [];
+  const commentEls: string[] = [];
+  for (let i = 1; i <= commentCount; i++) {
+    runs.push(
+      `<w:commentRangeStart w:id="${i}"/>` +
+        `<w:r><w:t>Word${i}</w:t></w:r>` +
+        `<w:commentRangeEnd w:id="${i}"/>` +
+        `<w:r><w:t> spacer </w:t></w:r>`,
+    );
+    commentEls.push(
+      `<w:comment w:id="${i}" w:author="Author${i}" w:date="2026-01-01T00:00:00Z">` +
+        `<w:p><w:r><w:t>Body of comment ${i}</w:t></w:r></w:p>` +
+        `</w:comment>`,
+    );
+  }
+
+  zip.file(
+    "word/document.xml",
+    `<?xml version="1.0"?>` +
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:body><w:p>${runs.join("")}</w:p></w:body>` +
+      `</w:document>`,
+  );
+  zip.file(
+    "word/comments.xml",
+    `<?xml version="1.0"?>` +
+      `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `${commentEls.join("")}` +
+      `</w:comments>`,
+  );
+
+  return (await zip.generateAsync({ type: "nodebuffer" })) as Buffer;
+}

--- a/tests/helpers/fetch-source-asserts.ts
+++ b/tests/helpers/fetch-source-asserts.ts
@@ -1,0 +1,30 @@
+import { expect } from "vitest";
+
+/**
+ * Assert that `src` contains a `fetchWithTimeout(...)` call against `endpoint`
+ * paired with the given timeout constant. The endpoint may appear as the
+ * literal path (`/api/foo-bar`) or as the corresponding `API_*` identifier
+ * (`API_FOO_BAR`) — both are accepted so callers using the centralized
+ * `src/shared/api-paths.ts` constants pass without test churn.
+ */
+export function expectFetchWithTimeoutEndpoint(
+  src: string,
+  endpoint: string,
+  timeoutConstant: string,
+): void {
+  const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedEndpoint = escapeRe(endpoint);
+  const escapedTimeout = escapeRe(timeoutConstant);
+  const constantName = `API_${endpoint
+    .replace(/^\/api\//, "")
+    .replace(/-/g, "_")
+    .toUpperCase()}`;
+  const endpointAlternation = `(?:${escapedEndpoint}|${constantName})`;
+  expect(src).toMatch(
+    new RegExp(`fetchWithTimeout\\([\\s\\S]*?${endpointAlternation}[\\s\\S]*?${escapedTimeout}`),
+  );
+}
+
+export function countMatches(src: string, re: RegExp): number {
+  return src.match(re)?.length ?? 0;
+}

--- a/tests/monitor/runtime-fetches.test.ts
+++ b/tests/monitor/runtime-fetches.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { countMatches, expectFetchWithTimeoutEndpoint } from "../helpers/fetch-source-asserts.js";
 import {
   ControllableStream,
   createFetchStub,
@@ -9,25 +10,6 @@ import {
 } from "./fetch-harness.js";
 
 const MONITOR_PATH = fileURLToPath(new URL("../../src/monitor/index.ts", import.meta.url));
-
-function countMatches(src: string, re: RegExp): number {
-  return src.match(re)?.length ?? 0;
-}
-
-function expectFetchWithTimeoutEndpoint(src: string, endpoint: string, timeoutConstant: string) {
-  const escapedEndpoint = endpoint.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const escapedTimeout = timeoutConstant.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // Accept either the literal path or the `API_*` constant that resolves to it
-  // (post-#283 the monitor uses the constants from src/shared/api-paths.ts).
-  const constantName = `API_${endpoint
-    .replace(/^\/api\//, "")
-    .replace(/-/g, "_")
-    .toUpperCase()}`;
-  const endpointAlternation = `(?:${escapedEndpoint}|${constantName})`;
-  expect(src).toMatch(
-    new RegExp(`fetchWithTimeout\\([\\s\\S]*?${endpointAlternation}[\\s\\S]*?${escapedTimeout}`),
-  );
-}
 
 describe("monitor authenticated fetch surface", () => {
   let stub: ReturnType<typeof createFetchStub>;

--- a/tests/server/file-opener-cleanup-on-failure.test.ts
+++ b/tests/server/file-opener-cleanup-on-failure.test.ts
@@ -84,6 +84,7 @@ import { openFileByPath } from "../../src/server/mcp/file-opener.js";
 import { pushNotification } from "../../src/server/notifications.js";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
+import { buildDocxWithComments } from "../helpers/docx-fixtures.js";
 
 let tmpDir: string;
 
@@ -113,47 +114,6 @@ afterAll(async () => {
 interface UpdateRecord {
   origin: unknown;
   changedTypes: Set<Y.AbstractType<unknown>>;
-}
-
-// Synthetic .docx Buffer with N inline Word comments. Same shape as the helper
-// in file-opener-transact-batching.test.ts; duplicated inline to keep test
-// files independent.
-async function buildDocxWithComments(commentCount: number): Promise<Buffer> {
-  const JSZip = (await import("jszip")).default;
-  const zip = new JSZip();
-
-  const runs: string[] = [];
-  const commentEls: string[] = [];
-  for (let i = 1; i <= commentCount; i++) {
-    runs.push(
-      `<w:commentRangeStart w:id="${i}"/>` +
-        `<w:r><w:t>Word${i}</w:t></w:r>` +
-        `<w:commentRangeEnd w:id="${i}"/>` +
-        `<w:r><w:t> spacer </w:t></w:r>`,
-    );
-    commentEls.push(
-      `<w:comment w:id="${i}" w:author="Author${i}" w:date="2026-01-01T00:00:00Z">` +
-        `<w:p><w:r><w:t>Body of comment ${i}</w:t></w:r></w:p>` +
-        `</w:comment>`,
-    );
-  }
-
-  zip.file(
-    "word/document.xml",
-    `<?xml version="1.0"?>` +
-      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
-      `<w:body><w:p>${runs.join("")}</w:p></w:body>` +
-      `</w:document>`,
-  );
-  zip.file(
-    "word/comments.xml",
-    `<?xml version="1.0"?>` +
-      `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
-      `${commentEls.join("")}` +
-      `</w:comments>`,
-  );
-
-  return (await zip.generateAsync({ type: "nodebuffer" })) as Buffer;
 }
 
 describe("populateDocFromContent — cleanup on populate failure", () => {

--- a/tests/server/file-opener-transact-batching.test.ts
+++ b/tests/server/file-opener-transact-batching.test.ts
@@ -58,6 +58,7 @@ import { pushNotification } from "../../src/server/notifications.js";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import { UPLOAD_PREFIX } from "../../src/shared/paths.js";
+import { buildDocxWithComments } from "../helpers/docx-fixtures.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DOCX_FIXTURE = path.resolve(__dirname, "../e2e/fixtures/single-paragraph.docx");
@@ -84,49 +85,8 @@ afterAll(async () => {
   delete process.env.TANDEM_APP_DATA_DIR;
 });
 
-// Build a synthetic .docx Buffer with N inline Word comments anchored to short
-// text ranges. Pattern lifted from tests/server/docx-comments.test.ts:297-338.
-// Used by the M1a docx-with-comments batching test below.
-async function buildDocxWithComments(commentCount: number): Promise<Buffer> {
-  const JSZip = (await import("jszip")).default;
-  const zip = new JSZip();
-
-  const runs: string[] = [];
-  const commentEls: string[] = [];
-  for (let i = 1; i <= commentCount; i++) {
-    runs.push(
-      `<w:commentRangeStart w:id="${i}"/>` +
-        `<w:r><w:t>Word${i}</w:t></w:r>` +
-        `<w:commentRangeEnd w:id="${i}"/>` +
-        `<w:r><w:t> spacer </w:t></w:r>`,
-    );
-    commentEls.push(
-      `<w:comment w:id="${i}" w:author="Author${i}" w:date="2026-01-01T00:00:00Z">` +
-        `<w:p><w:r><w:t>Body of comment ${i}</w:t></w:r></w:p>` +
-        `</w:comment>`,
-    );
-  }
-
-  zip.file(
-    "word/document.xml",
-    `<?xml version="1.0"?>` +
-      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
-      `<w:body><w:p>${runs.join("")}</w:p></w:body>` +
-      `</w:document>`,
-  );
-  zip.file(
-    "word/comments.xml",
-    `<?xml version="1.0"?>` +
-      `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
-      `${commentEls.join("")}` +
-      `</w:comments>`,
-  );
-
-  return (await zip.generateAsync({ type: "nodebuffer" })) as Buffer;
-}
-
-// Build a stress-shape markdown that mirrors the document that triggered #609:
-// many headings, nested lists, inline code spans, bold/italic runs.
+// Build a stress-shape markdown: many headings, nested lists, inline code,
+// bold/italic — mirrors the document that surfaced the pre-batching freeze.
 function buildStressMarkdown(sectionCount: number): string {
   const sections: string[] = ["# Stress fixture", ""];
   for (let i = 0; i < sectionCount; i++) {


### PR DESCRIPTION
## Summary

Ran `/simplify` over today's 6 commits (`0780ab6..HEAD`) — code reuse, quality, and efficiency review agents in parallel — then applied the actionable findings.

## Changes

**Code quality**
- `App.svelte`: collapsed the `_lastAuthorshipVisible` dual-purpose flag (suppress-first-run + change-gate) into a single `lastDispatchedAuthorship` sentinel; trimmed the 14-line authorship-effect narrative and the rail-tab reconciliation narrative.
- `SettingsPopover.svelte`: dropped the `if (changelogError !== null) changelogError = null;` no-op guards on the section-change effect — Svelte's `$state` already short-circuits same-value writes.
- `FormattingToolbar.svelte`, `fileUpload.ts`, `api-paths.ts`, `types.ts`: trimmed narrative/issue-reference comments per project guidance (keep WHY, not WHAT/PR refs).
- `file-opener.ts`: trimmed the long `populateDocFromContent` narrative + the docx inject snapshot/undo essay; left the short WHY for both.

**Efficiency**
- `annotation.ts`: gated the 500 ms post-sync `setTimeout` on a new `rebuiltSinceMount` flag — it now no-ops when the observer already fired during the settling window, removing a duplicate O(n) rebuild on initial sync.
- `file-opener.ts`: replaced `Map.forEach` while deleting with `for (const k of [...map.keys()])` — Y.Map iteration under concurrent mutation is undefined.

**Code reuse**
- `tests/helpers/docx-fixtures.ts`: extracted `buildDocxWithComments` from two duplicated copies in `file-opener-{transact-batching,cleanup-on-failure}.test.ts` (~40 lines each).
- `tests/helpers/fetch-source-asserts.ts`: extracted `expectFetchWithTimeoutEndpoint` + `countMatches` from two duplicated copies in `tests/channel/run-timeouts.test.ts` and `tests/monitor/runtime-fetches.test.ts`; unifies the API-constant-name reconstruction.

**Net:** 14 files changed, 119 insertions / 240 deletions.

## Test plan

- [ ] `npm run typecheck` (pre-existing baseUrl deprecation warning is unrelated)
- [ ] `npx vitest run tests/server/file-opener-transact-batching.test.ts tests/server/file-opener-cleanup-on-failure.test.ts tests/channel/run-timeouts.test.ts tests/monitor/runtime-fetches.test.ts tests/client/annotation-decoration.test.ts`
- [ ] Smoke: open `sample/welcome.md`, toggle authorship, open a large markdown via drag-drop, force-reload a doc — verify no console warnings, decorations render once
- [ ] Settings popover: trigger a changelog/docs error, switch sections, switch back — error clears as before

## Findings deliberately skipped

- `populateDocFromContent` parameter sprawl (`source: string | Buffer` + `Buffer.isBuffer` branching) — splitting was suggested but adds API surface for marginal clarity gain.
- `dismiss-outside.ts` invites misuse for `scroll` events without `capture: true` — latent, current callers are correct.
- Pre-existing `Map.forEach` while deleting in `clearAndReload` / `reloadFromDisk` — same defect shape but pre-existing code, out of scope for this pass.
- `clickOutside` Svelte action vs. new `onOutsideEvent` helper — partial overlap, but the action's late-binding limitations make consolidation non-trivial.

https://claude.ai/code/session_01NNEXEryZgGyTwS4h6AAQ1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNEXEryZgGyTwS4h6AAQ1U)_