### PR TITLE
audit v2: post-review follow-ups (F1-F6) stacking on #621

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Known Issues
+
+- **`reloadFromDisk` two-write crash window (#622, v0.12.0 fix)** — when the file watcher detects an external edit, `reloadFromDisk` runs `refreshAllRanges` (own `MCP_ORIGIN` transact) and then a relocation pass (separate `MCP_ORIGIN` transact). Both flow through the durable-annotation sync observer. If the server is killed between the two transactions, durable annotation state can be left at partially-refreshed ranges. Pre-existing in master (not introduced by PR #621; surfaced by audit v2). Bounded by the narrow synchronous window between the two transactions. Tracked for fix in v0.12.0 via a `skipTransact` parameter on `refreshAllRanges` so reload can merge both passes into a single transaction.
+
 ### Fixed
 
 - **Codebase leanness audit v2 (PR #621)** — eight-step audit (`docs/audit-v2.md`) covering dead code, dependency bloat, over-engineering, wrong-tool-for-the-job, and stale docs. Validated by four domain reviewers (annotation-model, crdt, security, svelte-migration) before any deletion. Outcomes:

--- a/docs/audit-v2-followups-plan.md
+++ b/docs/audit-v2-followups-plan.md
@@ -1,0 +1,208 @@
+# PR #621 Review Follow-Ups — Plan
+
+Source: 6-reviewer + Codex review of PR #621 (audit v2). This plan covers every Important and Suggestion finding. Group by intended PR boundary so each lands as a coherent, individually-revertable change.
+
+---
+
+## PR-F1 — Regression test for PR-A1 split-transaction fix
+
+**Source:** pr-test-analyzer (Important #1). The CRDT reviewer's manual catch (8d9c0ce) has no test; flipping the relocation transact back to `FILE_SYNC_ORIGIN` would silently regress.
+
+**Change:** Add `tests/server/reload-from-disk-persistence.test.ts`. Two test cases in one file:
+
+### Test A — End-to-end durable-sync persistence
+1. Create a doc with one annotation whose `textSnapshot` will move on disk reload.
+2. Attach `wireAnnotationStore` **before** calling `reloadFromDisk` (the watcher path calls `attachObservers` at the end of reload; the sync observer must be attached up-front so the relocation write fires through it).
+3. Capture writes via a spy on the sync function itself, NOT by reading the serialized file (`wireAnnotationStore` may debounce serialization — asserting on file contents is racy; asserting on the observer callback is deterministic).
+4. Rewrite the file on disk so the snapshot text moves to a new offset.
+5. `await reloadFromDisk(id, filePath, format)`.
+6. Assert: the spy captured a write whose annotation entry has the relocated `range` + `relRange` (NOT the original offsets).
+7. Verify the relocated range round-trips through `validateRange()` cleanly (locks in Critical Rule #4 for the relocation path).
+
+Why this catches the regression: durable-sync skips `FILE_SYNC_ORIGIN`. If the relocation transact were `FILE_SYNC_ORIGIN`, the spy would not fire for the relocation write.
+
+**Note for implementer:** confirm `wireAnnotationStore` is not torn down/reattached by `attachObservers` (file-opener.ts:888) — if it is, the spy reference goes stale mid-test and assertions silently miss. Read `src/server/annotations/sync.ts` lifecycle once before implementing.
+
+### Test B — `afterTransaction` spy on origin sequence
+Cheaper companion guarding the transaction *structure* (different failure mode from Test A):
+- Spy on `doc.on("afterTransaction", ...)`.
+- Invoke `reloadFromDisk(...)` on a doc with at least one annotation that requires relocation.
+- Assert the captured transaction sequence is **exactly** `[FILE_SYNC_ORIGIN, MCP_ORIGIN]`.
+- Assert the second (`MCP_ORIGIN`) transaction's `changed` set **includes the `Y_MAP_ANNOTATIONS` instance** (ref-equality on `doc.getMap(Y_MAP_ANNOTATIONS)`, per `feedback_yjs_txn_changed_ref_equality`). A naive sequence check would pass even if the relocation transact ran but did no annotation work — this guards against that silent regression too.
+
+**Optional refactor consideration (skip unless implementing F1 reveals it's needed):** annotation reviewer suggested extracting the relocation block into a `relocateStaleAnnotations(doc, refreshed, map)` helper so it can be unit-tested without file I/O. Defer this to a future polish PR — the spy assertions in Test B give us 80% of that value without the refactor.
+
+**Files:** `tests/server/reload-from-disk-persistence.test.ts` (new). No production change.
+
+---
+
+## PR-F2 — Regression test for `tandem_resolveAnnotation` NOT_FOUND code
+
+**Source:** pr-test-analyzer (Suggestion). Plan-reviewer correction: there is no separate `tandem_acceptAnnotation` / `tandem_dismissAnnotation` — both flow through `tandem_resolveAnnotation` with `action: "accept" | "dismiss"` (single handler in `src/server/mcp/annotations.ts`). PR-A3 changed this handler's missing-annotation error code; no test asserts the new code.
+
+**Change:** Add a `code === "NOT_FOUND"` assertion to the existing `tandem_resolveAnnotation` test (or create one under `tests/server/`). Cover **both** branches against the same handler:
+- `action: "accept"` with a non-existent annotation id → `code === "NOT_FOUND"`.
+- `action: "dismiss"` with a non-existent annotation id → `code === "NOT_FOUND"`.
+
+Pattern matches the existing `tests/server/remove-annotation.test.ts:59` assertion.
+
+**Files:** existing resolve-annotation test file under `tests/server/`. No production change.
+
+---
+
+## PR-F3 — Export the tutorial predicate; replace mirrored test logic
+
+**Source:** svelte-migration + pr-test-analyzer (Suggestion). `tests/client/use-tutorial.test.ts` inlines `(a) => a.author === "user" && !a.id.startsWith(TUTORIAL_ANNOTATION_PREFIX)` instead of importing it. A revert of the production predicate would not fail the test.
+
+**Change:**
+1. In `src/client/hooks/useTutorial.svelte.ts`, extract the inline predicate at line 89 into a module-level exported function. Name it for what it actually means (the semantic is "non-tutorial user-authored," not generic "user-authored"):
+   ```ts
+   /**
+    * True iff the annotation is authored by the user AND is not a tutorial seed.
+    * Load-bearing: used by the step-1 advance effect — a tutorial-seeded annotation
+    * must NOT trip this predicate even though tutorial notes have author="user"
+    * to satisfy ADR-027. See `TUTORIAL_ANNOTATION_PREFIX` for the marker convention.
+    */
+   export function isNonTutorialUserAnnotation(a: Annotation): boolean {
+     return a.author === "user" && !a.id.startsWith(TUTORIAL_ANNOTATION_PREFIX);
+   }
+   ```
+   Replace the inline `some(...)` call with `annotations.some(isNonTutorialUserAnnotation)`.
+2. In `tests/client/use-tutorial.test.ts`, delete the local re-implementation and import `isNonTutorialUserAnnotation`. Keep existing test cases.
+3. Add one new test case: a tutorial-prefixed annotation later mutated (e.g., `status: "accepted"`) — predicate still returns `false`. Locks in the current "edits don't promote it to user-authored" behavior.
+
+**Reactivity note (verified by svelte-migration reviewer):** extracting the predicate to a module-level pure function does not change `$effect` dependency tracking — the effect still calls `getAnnotations()` itself, and the predicate only reads plain object fields. `useTutorial.svelte.ts` has no top-level runes, so the test file can import the predicate without a Svelte runtime.
+
+**Files:** `src/client/hooks/useTutorial.svelte.ts`, `tests/client/use-tutorial.test.ts`.
+
+---
+
+## PR-F4 — Audit script hardening
+
+**Source:** Codex (Suggestion ×2), security (Suggestion). Two scripts have known false-negatives.
+
+### F4a — `scripts/audit-origins.ts` identifier pass-through
+Current behavior: any `Identifier` second arg that isn't `MCP_ORIGIN`/`FILE_SYNC_ORIGIN` is silently treated as tagged ("pass-through helper" assumption). This is intentional per the comment, but it hides bugs where a helper forwards `undefined` or a wrongly-named variable.
+
+**Change:** Tighten the pass-through path. Only treat an Identifier as "pass-through tagged" if the enclosing function's parameter list has a parameter that:
+- is **named** `origin` or `transactionOrigin`, AND/OR
+- has a **type-node text** matching `"TransactionOrigin"` or the origin union literal `'"mcp" | "file-sync"'`.
+
+For any other Identifier, emit a `pass-through (verify): <name>` finding so a human triages. Keep `process.exit(0)` — warn-only.
+
+**Implementation note — syntactic only, no TypeChecker needed:** the existing script uses `createSourceFile(..., setParentNodes=true)` which gives `.parent` walks. Use `ts.findAncestor` for `FunctionDeclaration | MethodDeclaration | FunctionExpression | ArrowFunction`, then scan its `.parameters` for name + `param.type?.getText()`. This is purely syntactic and in-file — do NOT pull in `createProgram` / a TypeChecker; that's a major dependency jump for marginal gain. Document the residual gap in the script header: "Identifier bindings across modules / through aliases are not resolved — this is a known false-negative class."
+
+### F4b — `scripts/audit-ymap-keys.ts` coverage + regex escape
+Current behavior: line-by-line regex scan for `.set("VAL"` / `.get("VAL"`. Misses (a) multiline `.set(\n  "VAL"`, (b) `.has("VAL")` / `.delete("VAL")`, (c) **the `getMap`/`getArray`/`getText`/`getXmlFragment` constructor sites — which are where raw keys originate**, (d) unescaped Y_MAP value if it contains regex metacharacters.
+
+**Change:** Rewrite as a TypeScript AST walk like `audit-origins.ts`:
+- Find `CallExpression` whose expression is a `PropertyAccessExpression` with `name.text ∈ { set, get, has, delete, getMap, getArray, getText, getXmlFragment }`.
+- Check first arg is a `StringLiteral` whose text is in the known-keys set.
+- Report `file:line: raw "<value>" — use <Y_MAP_*>`.
+
+The `getMap`-family additions are the highest-value coverage — they're where the raw key is constructed in the first place, before `.set/.get` is even called.
+
+**Drop the bracket-access (`ElementAccessExpression`) branch from the original plan.** CRDT reviewer confirmed: `Y.Map`'s real API is `.get/.set/.has/.delete` — bracket access on a Y.Map is a TypeScript error, so flagging `map["annotations"]` is dead detection. Before adding it back, grep `src/` for `\[["'][a-z]` style access on a Y.Map; if zero hits today, leave it out.
+
+Drops the regex entirely, so the escape concern is moot.
+
+**Files:** `scripts/audit-origins.ts`, `scripts/audit-ymap-keys.ts`. No production change.
+
+**Verification:** After rewrite, `npm run audit:origins && npm run audit:ymap-keys` must produce zero false-positive *blocking* findings. New `verify` findings on `audit:origins` are acceptable; document each known-good site in `docs/audit-v2.md` under a "Triaged pass-through tags" subsection. For `audit-ymap-keys`, also expect new findings on `getMap` call sites that *correctly* use raw strings inside `constants.ts` itself — exclude that file from the scan (`if (file === CONSTANTS) return [];` is already in the current script — preserve it).
+
+---
+
+## PR-F5 — Tutorial-prefix coupling comment + fullyAnchored consistency
+
+**Source:** annotation-model (Suggestion), crdt (Suggestion).
+
+### F5a — Comments on the load-bearing tutorial-prefix predicate
+The string-prefix predicate is defense-in-depth. A future rename of `TUTORIAL_ANNOTATION_PREFIX` — or a future maintainer thinking the prefix check is paranoid — would silently re-introduce the step-1 auto-advance bug.
+
+**Lands after PR-F3** (since F3 extracts the predicate to a named exported function — the comment belongs on that function, not the inline call site).
+
+**Change:**
+1. Add a one-line comment at the `TUTORIAL_ANNOTATION_PREFIX` constant declaration:
+   ```ts
+   // Load-bearing: useTutorial.svelte.ts uses this prefix to exclude tutorial
+   // SEEDS from "user-authored annotation" detection. Tutorial NOTES carry
+   // author="user" (ADR-027: only the user can author notes), so the prefix
+   // is the ONLY thing distinguishing a seed from a real user note. Renaming
+   // this constant without updating useTutorial.svelte.ts would silently
+   // re-introduce the step-1 auto-advance bug from PR #621 PR-A2b.
+   ```
+2. Ensure the JSDoc on `isNonTutorialUserAnnotation` (added in PR-F3) makes the ADR-027 / tutorial-notes context explicit. PR-F3 already drafts this; F5a just verifies it survived.
+
+### F5b — Tutorial seeding `relRange` assignment style
+`tutorial-annotations.ts` always assigns `relRange: result.relRange` after `anchoredRange()`. Today, `anchoredRange` returns no `relRange` field when `!fullyAnchored`, so `result.relRange` is already `undefined` in that branch — the "gate" is a **no-op behaviorally**. CRDT reviewer confirmed downstream code (`client/positions.ts:309`, `server/positions.ts:301`) handles `!ann.relRange` via lazy-attach fallback. Reframe this from "bug fix" to "style consistency / intent documentation."
+
+**Change:** In `src/server/mcp/tutorial-annotations.ts`, switch from unconditional assignment to **conditional spread**, matching the established style at lines 99-100 (`color` / `suggestedText`):
+```ts
+...(result.fullyAnchored ? { relRange: result.relRange } : {})
+```
+This makes the "only attach `relRange` when fully resolved" invariant visible at the assignment site, consistent with `reloadFromDisk` (file-opener.ts:877).
+
+**Files:** `src/shared/constants.ts` (comment), `src/server/mcp/tutorial-annotations.ts` (conditional spread). No `src/client/hooks/useTutorial.svelte.ts` change needed beyond PR-F3's JSDoc.
+
+---
+
+## PR-F6 — Pre-existing two-write crash window (`reloadFromDisk`)
+
+**Source:** Codex (Important #2). On `reloadFromDisk`, `refreshAllRanges()` (`src/server/positions.ts:352`) persists once with `MCP_ORIGIN` (its own internal `ydoc.transact`), then the explicit relocation pass at `src/server/mcp/file-opener.ts:861-884` persists a second time with `MCP_ORIGIN`. Both go through durable-sync. A crash between them leaves annotations durably stored at partially-refreshed ranges.
+
+**Not introduced by this PR.** Pre-existing in master.
+
+**Risk scope:** narrow but real. The two transactions are separated only by synchronous control flow inside `reloadFromDisk` — there is no `await` between them — so the exploit window is roughly "process killed during the relocation loop." The bug class is *durable-state corruption*, which is precisely what durable-annotations exists to prevent.
+
+**Other callers of `refreshAllRanges`:**
+- `src/server/mcp/annotations.ts:439` (`tandem_getAnnotations` read path)
+- `src/server/mcp/annotations.ts:587` (`tandem_exportAnnotations` read path)
+- `src/server/mcp/document.ts:66` (re-export only)
+
+**Neither read-path caller is crash-vulnerable** — they don't follow with a second mutation pass. Only `reloadFromDisk` exhibits the two-write pattern. This scopes the fix correctly: change *how* `reloadFromDisk` invokes `refreshAllRanges`, not the function itself.
+
+**Plan:** Do NOT fix in the follow-up PRs above. Open a GitHub issue with:
+- **Title:** `reloadFromDisk persists annotation ranges in two separate transactions — crash window leaves stale state`
+- **Body:**
+  - Code refs: `src/server/mcp/file-opener.ts:815-885` (two-write pattern), `src/server/positions.ts:352-400` (`refreshAllRanges` internal transact), `src/server/annotations/sync.ts:242` (observer flushes per-transaction).
+  - Why pre-existing: audit v2 (PR #621) surfaced this but did not introduce it. Both transactions tagged `MCP_ORIGIN` in master prior to #621.
+  - **Suggested fix:** add an opt-in `{ skipTransact?: boolean }` parameter to `refreshAllRanges` (or extract an internal `refreshAllRangesInner` and have `refreshAllRanges` wrap it in its current `MCP_ORIGIN` transact). `reloadFromDisk` calls the no-transact variant inside a single merged `MCP_ORIGIN` transact that also contains the relocation pass. Durable-sync then flushes once. The two read-path callers (`annotations.ts:439`, `:587`) continue to call the standard `refreshAllRanges` and are unaffected.
+  - **Do NOT "inline the body" at the reload call site** (an earlier draft of this plan suggested that — it's wrong; it would duplicate code and the other callers still want a self-transacting version).
+  - **Test:** the PR-F1 test from this follow-up cycle will need an additional assertion — exactly *one* transaction with `Y_MAP_ANNOTATIONS` writes during `reloadFromDisk`, not two — after the fix.
+- **Labels:** `bug`, `crdt`. **Milestone:** `v0.12.0`.
+
+**Also:** add a "Known Issues" entry to `CHANGELOG.md` under the unreleased v0.11.x section noting the crash window and that durable annotations can be inconsistent if the server is killed mid-reload. Users should restart cleanly when possible.
+
+Rationale for deferral: the fix is non-trivial (touches 3 caller sites via the parameter addition, requires a new test asserting single-transaction behavior, and changes `refreshAllRanges`'s public signature). Fixing here would balloon the audit PR's scope and re-trigger the full reviewer cycle. The risk is bounded by the narrow exploit window and the durable-sync recovery path on next clean start.
+
+---
+
+## PR boundary recommendation
+
+Group the follow-ups as follows to keep each PR small and revert-clean:
+
+| PR | Contents | Risk |
+|----|----------|------|
+| **#622** | F1 + F2 (test-only regression coverage) | Low |
+| **#623** | F3 (predicate export + test refactor + new case) | Low |
+| **#624** | F4 (audit script AST rewrites) | Low (dev tooling) |
+| **#625** | F5 (comments + fullyAnchored gate) | Low |
+| (issue) | F6 (pre-existing crash window) | Defer to v0.12.0 |
+
+Ship #622 first — it locks in the headline fix from PR #621 and is the highest-value follow-up. The others can land in any order.
+
+## Additional small follow-ups folded into existing PRs
+
+Surfaced by plan-review pass; too small to warrant separate PRs.
+
+- **Inline comment at `reloadFromDisk` relocation transact** *(annotation reviewer)*: in `src/server/mcp/file-opener.ts` near line 861, add a one-line note that `MCP_ORIGIN` here is deliberate — channel observer skips it, durable-sync persists it. Prevents a future "fix" flipping back to `FILE_SYNC_ORIGIN` to silence a phantom channel echo. **Fold into PR-F5** (touches the same area conceptually).
+
+- **ADR-027 channel filtering audit grep** *(annotation reviewer)*: before closing out the follow-up cycle, grep `src/server/events/` and `src/server/mcp/` for `type !== "note"` and `type === "note"` to confirm note-filtering is consistent in every place. One-line check. **Run as part of PR-F1's PR description checklist** — no separate change unless a gap is found.
+
+## What is explicitly NOT addressed
+
+- **First-transact `forEach(...delete)` awareness clear** (crdt Suggestion #3): Currently safe (Y.Map snapshots iterator). Migrating to `[...keys()].forEach(delete)` would be cosmetic-only churn for no behavior change. Skip.
+- **Cross-module identifier resolution in `audit-origins.ts`** (Codex F4a residual gap): would require a full TypeChecker. Accept as a documented limitation; `verify` findings + human triage are the trade-off.
+- **`audit-ymap-keys.ts` bracket-access detection**: dropped per CRDT reviewer — bracket access on a Y.Map is a TypeScript error in this codebase. Reconsider only if a real raw-bracket-key site appears.
+- **Extracting `relocateStaleAnnotations(doc, refreshed, map)` helper**: discussed in PR-F1 as an option for cheaper unit testing. Deferred — the spy assertions in F1 Test B give us most of that value without the refactor.
+- **`docs/audit-v2.md` deferred items list**: F6 is the only deferral that comes out of *this* review pass. Leave existing deferrals as documented.

--- a/scripts/audit-origins.ts
+++ b/scripts/audit-origins.ts
@@ -8,6 +8,18 @@
 // calls — robust against template literals, regex literals, escaped strings,
 // and multi-line argument lists. Replaces a regex+line-window heuristic that
 // produced 13/13 false positives on transactions spanning >8 lines.
+//
+// Pass-through handling (PR-F4a, post-#621 review): an Identifier second
+// argument that isn't a known origin constant is accepted ONLY if the
+// enclosing function's parameter list has a parameter named "origin" /
+// "transactionOrigin" / "txnOrigin" or with a type-node text matching
+// the origin-union shape (`TransactionOrigin`, `MCP_ORIGIN | FILE_SYNC_ORIGIN`,
+// `"mcp" | "file-sync"`). Any other Identifier emits a `pass-through (verify)`
+// finding so a human triages.
+//
+// Known limitation (no TypeChecker): identifier bindings across modules
+// or through aliases are not resolved. A helper that re-exports an origin
+// under a different name will fall into the `verify` bucket.
 
 import { readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
@@ -17,6 +29,17 @@ import ts from "typescript";
 const ROOT = join(import.meta.dirname, "..");
 const SERVER_DIR = join(ROOT, "src/server");
 const ORIGIN_NAMES = new Set(["MCP_ORIGIN", "FILE_SYNC_ORIGIN"]);
+const PARAM_NAMES = new Set(["origin", "transactionOrigin", "txnOrigin"]);
+const ORIGIN_TYPE_TEXTS = [
+  "TransactionOrigin",
+  '"mcp"|"file-sync"',
+  '"file-sync"|"mcp"',
+  "typeofMCP_ORIGIN|typeofFILE_SYNC_ORIGIN",
+];
+
+function normalizeTypeText(s: string): string {
+  return s.replace(/\s+/g, "");
+}
 
 function collectFiles(dir: string): string[] {
   const out: string[] = [];
@@ -29,11 +52,43 @@ function collectFiles(dir: string): string[] {
   return out;
 }
 
-function findUntagged(file: string): string[] {
+type EnclosingFn =
+  | ts.FunctionDeclaration
+  | ts.FunctionExpression
+  | ts.MethodDeclaration
+  | ts.ArrowFunction;
+
+function isFunctionLike(n: ts.Node): n is EnclosingFn {
+  return (
+    ts.isFunctionDeclaration(n) ||
+    ts.isFunctionExpression(n) ||
+    ts.isMethodDeclaration(n) ||
+    ts.isArrowFunction(n)
+  );
+}
+
+function isOriginParam(p: ts.ParameterDeclaration): boolean {
+  if (ts.isIdentifier(p.name) && PARAM_NAMES.has(p.name.text)) return true;
+  const typeText = p.type ? normalizeTypeText(p.type.getText()) : "";
+  if (!typeText) return false;
+  return ORIGIN_TYPE_TEXTS.some((t) => typeText.includes(normalizeTypeText(t)));
+}
+
+function identifierIsForwardedOriginParam(id: ts.Identifier): boolean {
+  const fn = ts.findAncestor(id.parent, isFunctionLike);
+  if (!fn) return false;
+  return fn.parameters.some((p) => isOriginParam(p) && p.name.getText() === id.text);
+}
+
+type Finding =
+  | { kind: "untagged"; file: string; line: number }
+  | { kind: "verify"; file: string; line: number; name: string };
+
+function findFindings(file: string): Finding[] {
   const rel = relative(ROOT, file).replace(/\\/g, "/");
   const source = readFileSync(file, "utf-8");
   const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
-  const findings: string[] = [];
+  const findings: Finding[] = [];
 
   function visit(node: ts.Node): void {
     if (
@@ -42,15 +97,22 @@ function findUntagged(file: string): string[] {
       node.expression.name.text === "transact"
     ) {
       const tag = node.arguments[1];
-      const tagged = tag !== undefined && ts.isIdentifier(tag) && ORIGIN_NAMES.has(tag.text);
-      // Accept positional pass-through (e.g. shared helpers that take an
-      // origin parameter): if the second arg is an Identifier that is not a
-      // known origin constant, treat as tagged. The MCP-callsite invariant is
-      // enforced at the caller in such patterns. Reduces false positives.
-      const passThrough = tag !== undefined && ts.isIdentifier(tag) && !ORIGIN_NAMES.has(tag.text);
-      if (!tagged && !passThrough) {
-        const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart());
-        findings.push(`${rel}:${line + 1}: .transact( without origin tag`);
+      const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+
+      if (tag === undefined) {
+        findings.push({ kind: "untagged", file: rel, line: line + 1 });
+      } else if (ts.isIdentifier(tag)) {
+        if (ORIGIN_NAMES.has(tag.text)) {
+          // Tagged with a known origin constant — clean.
+        } else if (identifierIsForwardedOriginParam(tag)) {
+          // Forwarded through a parameter shaped like an origin — clean.
+        } else {
+          findings.push({ kind: "verify", file: rel, line: line + 1, name: tag.text });
+        }
+      } else {
+        // Non-identifier second argument (e.g., string literal, object) —
+        // not a recognized tagging pattern.
+        findings.push({ kind: "untagged", file: rel, line: line + 1 });
       }
     }
     ts.forEachChild(node, visit);
@@ -62,16 +124,25 @@ function findUntagged(file: string): string[] {
 
 export function main(): void {
   const files = collectFiles(SERVER_DIR);
-  const findings = files.flatMap(findUntagged);
+  const findings = files.flatMap(findFindings);
 
-  for (const f of findings) {
-    process.stderr.write(`${f}\n`);
+  const untagged = findings.filter((f) => f.kind === "untagged");
+  const verify = findings.filter((f) => f.kind === "verify");
+
+  for (const f of untagged) {
+    process.stderr.write(`${f.file}:${f.line}: .transact( without origin tag\n`);
+  }
+  for (const f of verify) {
+    if (f.kind !== "verify") continue;
+    process.stderr.write(`${f.file}:${f.line}: .transact( pass-through (verify): ${f.name}\n`);
   }
 
   if (findings.length === 0) {
     process.stderr.write("audit-origins: clean\n");
   } else {
-    process.stderr.write(`\naudit-origins: ${findings.length} untagged transact() call(s)\n`);
+    process.stderr.write(
+      `\naudit-origins: ${untagged.length} untagged, ${verify.length} pass-through (verify)\n`,
+    );
   }
   process.exit(0);
 }

--- a/scripts/audit-ymap-keys.ts
+++ b/scripts/audit-ymap-keys.ts
@@ -1,32 +1,60 @@
-// Audit script: any .set("LITERAL", ...) or .get("LITERAL") call where
-// LITERAL matches a known Y.Map key value should use the corresponding
-// Y_MAP_* constant from src/shared/constants.ts.
+// Audit script: any call site that constructs or accesses a Y.Map / Y.Array /
+// Y.Text / Y.XmlFragment using a string literal that matches a known Y_MAP_*
+// constant value should use the corresponding constant from
+// `src/shared/constants.ts`.
 //
 // Critical Rule #1 in CLAUDE.md: raw Y.Map key strings drift over time and
 // break observers silently.
 //
-// Heuristic: extract Y_MAP_* string values from constants.ts, then regex-scan
-// for .set("VALUE" / .get("VALUE") across src/{server,client,shared}. Reports
-// every hit; humans triage false positives (plain Map<string,X> calls).
+// Method coverage (PR-F4b, post-#621 review):
+//   - `doc.getMap(...)`, `doc.getArray(...)`, `doc.getText(...)`,
+//     `doc.getXmlFragment(...)` — origination sites (highest-value coverage).
+//   - `map.set(...)`, `map.get(...)`, `map.has(...)`, `map.delete(...)` — access.
+//
+// Uses the TypeScript compiler API to walk CallExpression nodes — robust
+// against multi-line argument lists, escaped quotes, and template literals.
+// Replaces a line-by-line regex scan that missed multiline `.set` / `.get`
+// calls and entirely missed `.has` / `.delete` / `.getMap` family.
+//
+// `ElementAccessExpression` (`map["key"]`) is NOT scanned: bracket access on
+// a Y.Map is a TypeScript error in this codebase. Reconsider only if a real
+// raw-bracket-key site appears.
 
 import { readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { pathToFileURL } from "node:url";
+import ts from "typescript";
 
 const ROOT = join(import.meta.dirname, "..");
 const CONSTANTS = join(ROOT, "src/shared/constants.ts");
 const DIRS = ["src/server", "src/client", "src/shared"].map((d) => join(ROOT, d));
-const Y_MAP_DECL_RE = /^export const (Y_MAP_[A-Z_]+)\s*=\s*"([^"]+)"/gm;
+
+const ACCESSOR_METHODS = new Set(["set", "get", "has", "delete"]);
+const CONSTRUCTOR_METHODS = new Set(["getMap", "getArray", "getText", "getXmlFragment"]);
 
 function loadKnownKeys(): Map<string, string> {
   const src = readFileSync(CONSTANTS, "utf-8");
-  const map = new Map<string, string>();
-  let m: RegExpExecArray | null;
-  Y_MAP_DECL_RE.lastIndex = 0;
-  while ((m = Y_MAP_DECL_RE.exec(src)) !== null) {
-    map.set(m[2], m[1]);
+  const sourceFile = ts.createSourceFile(CONSTANTS, src, ts.ScriptTarget.Latest, true);
+  const out = new Map<string, string>();
+
+  function visit(node: ts.Node): void {
+    if (ts.isVariableStatement(node)) {
+      for (const decl of node.declarationList.declarations) {
+        if (
+          ts.isIdentifier(decl.name) &&
+          /^Y_MAP_[A-Z_]+$/.test(decl.name.text) &&
+          decl.initializer &&
+          ts.isStringLiteral(decl.initializer)
+        ) {
+          out.set(decl.initializer.text, decl.name.text);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
   }
-  return map;
+
+  ts.forEachChild(sourceFile, visit);
+  return out;
 }
 
 function collectFiles(dir: string): string[] {
@@ -44,24 +72,43 @@ function collectFiles(dir: string): string[] {
 function findRawKeys(file: string, knownKeys: Map<string, string>): string[] {
   if (file === CONSTANTS) return [];
   const rel = relative(ROOT, file).replace(/\\/g, "/");
-  const lines = readFileSync(file, "utf-8").split("\n");
+  const source = readFileSync(file, "utf-8");
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
   const findings: string[] = [];
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    for (const [value, constName] of knownKeys) {
-      const setRe = new RegExp(`\\.set\\s*\\(\\s*["']${value}["']`);
-      const getRe = new RegExp(`\\.get\\s*\\(\\s*["']${value}["']`);
-      if (setRe.test(line) || getRe.test(line)) {
-        findings.push(`${rel}:${i + 1}: raw "${value}" — use ${constName}`);
+  function checkLiteralArg(call: ts.CallExpression, methodName: string): void {
+    const first = call.arguments[0];
+    if (!first || !ts.isStringLiteral(first)) return;
+    const constName = knownKeys.get(first.text);
+    if (!constName) return;
+    const { line } = sourceFile.getLineAndCharacterOfPosition(call.getStart());
+    findings.push(
+      `${rel}:${line + 1}: raw "${first.text}" in .${methodName}(...) — use ${constName}`,
+    );
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const method = node.expression.name.text;
+      if (CONSTRUCTOR_METHODS.has(method) || ACCESSOR_METHODS.has(method)) {
+        checkLiteralArg(node, method);
       }
     }
+    ts.forEachChild(node, visit);
   }
+
+  ts.forEachChild(sourceFile, visit);
   return findings;
 }
 
 export function main(): void {
   const knownKeys = loadKnownKeys();
+  if (knownKeys.size === 0) {
+    process.stderr.write(
+      "audit-ymap-keys: no Y_MAP_* constants found in src/shared/constants.ts — aborting\n",
+    );
+    process.exit(0);
+  }
   const files = DIRS.flatMap(collectFiles);
   const findings = files.flatMap((f) => findRawKeys(f, knownKeys));
 

--- a/src/client/hooks/useTutorial.svelte.ts
+++ b/src/client/hooks/useTutorial.svelte.ts
@@ -25,6 +25,20 @@ function readCompleted(): boolean {
   }
 }
 
+/**
+ * True iff the annotation is authored by the user AND is not a tutorial seed.
+ *
+ * Load-bearing: used by the step-1 advance effect. A tutorial-seeded annotation
+ * must NOT trip this predicate even though tutorial notes carry `author="user"`
+ * to satisfy ADR-027 (only the user can author notes). The `TUTORIAL_ANNOTATION_PREFIX`
+ * marker is the ONLY thing distinguishing a seed from a real user note —
+ * renaming that constant without updating this predicate silently re-introduces
+ * the step-1 auto-advance bug from PR #621 PR-A2b.
+ */
+export function isNonTutorialUserAnnotation(a: Annotation): boolean {
+  return a.author === "user" && !a.id.startsWith(TUTORIAL_ANNOTATION_PREFIX);
+}
+
 function writeCompleted(): void {
   try {
     localStorage.setItem(TUTORIAL_COMPLETED_KEY, "true");
@@ -82,16 +96,12 @@ export function createTutorial(
     }
   });
 
-  // Step 1: detect user-authored annotation (excluding the tutorial's own
-  // seeded note, which is author='user' per ADR-027 since notes are private
-  // and Claude can't author user content)
+  // Step 1: detect user-authored annotation (excluding tutorial seeds —
+  // see isNonTutorialUserAnnotation JSDoc for ADR-027 context).
   $effect(() => {
     if (!tutorialActive || currentStep !== 1) return;
     const annotations = getAnnotations();
-    const hasUserAnnotation = annotations.some(
-      (a) => a.author === "user" && !a.id.startsWith(TUTORIAL_ANNOTATION_PREFIX),
-    );
-    if (hasUserAnnotation) {
+    if (annotations.some(isNonTutorialUserAnnotation)) {
       stepAdvancedAt = Date.now();
       currentStep = 2;
     }

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -827,7 +827,15 @@ async function reloadFromDisk(id: string, filePath: string, format: string): Pro
     if (annotations.length > 0) {
       const refreshed = refreshAllRanges(annotations, doc, annotationMap);
 
-      // 4. Second pass: textSnapshot-based relocation for annotations with stale relRanges
+      // 4. Second pass: textSnapshot-based relocation for annotations with stale relRanges.
+      //
+      // Origin tag is intentionally MCP_ORIGIN (NOT FILE_SYNC_ORIGIN) because these
+      // writes update durable annotation state (range + relRange) that must persist
+      // through the durable-annotation sync observer. The sync observer skips
+      // FILE_SYNC_ORIGIN; the channel observer skips both origins, so there's no
+      // phantom channel echo to silence here. Flipping back to FILE_SYNC_ORIGIN
+      // would re-introduce the PR-A1 post-merge blocker (commit 8d9c0ce). See
+      // GH #622 for the related pre-existing two-write crash window.
       doc.transact(() => {
         for (const ann of refreshed) {
           if (!ann.textSnapshot) continue;

--- a/src/server/mcp/tutorial-annotations.ts
+++ b/src/server/mcp/tutorial-annotations.ts
@@ -88,7 +88,11 @@ export function injectTutorialAnnotations(doc: Y.Doc): void {
         author: def.type === "note" ? ("user" as const) : ("claude" as const),
         type: def.type,
         range: result.range,
-        relRange: result.relRange,
+        // Only attach a CRDT-anchored relRange when fully resolved. Matches
+        // the reloadFromDisk pattern (file-opener.ts) — a partial anchor
+        // leaks a half-resolved RelativePosition that downstream code would
+        // re-anchor anyway via the lazy-attach path in refreshRange.
+        ...(result.fullyAnchored ? { relRange: result.relRange } : {}),
         content: def.content,
         status: "pending" as const,
         timestamp: Date.now(),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -116,6 +116,12 @@ export const NOTIFICATION_BUFFER_SIZE = 50;
 
 // Onboarding tutorial
 export const TUTORIAL_COMPLETED_KEY = "tandem:tutorialCompleted";
+// Load-bearing: useTutorial.svelte.ts uses this prefix to exclude tutorial
+// SEEDS from "user-authored annotation" detection. Tutorial NOTES carry
+// author="user" (ADR-027: only the user can author notes), so the prefix
+// is the ONLY thing distinguishing a seed from a real user note. Renaming
+// this constant without updating useTutorial.svelte.ts would silently
+// re-introduce the step-1 auto-advance bug from PR #621 PR-A2b.
 export const TUTORIAL_ANNOTATION_PREFIX = "tutorial-";
 /** Persists "user skipped the Cowork onboarding step" across sessions. */
 export const COWORK_ONBOARDING_SKIPPED_KEY = "tandem:coworkOnboardingSkipped";

--- a/tests/client/use-tutorial.test.ts
+++ b/tests/client/use-tutorial.test.ts
@@ -1,33 +1,28 @@
 import { describe, expect, it } from "vitest";
+import { isNonTutorialUserAnnotation } from "../../src/client/hooks/useTutorial.svelte.js";
 import { TUTORIAL_ANNOTATION_PREFIX } from "../../src/shared/constants.js";
-import type { Annotation } from "../../src/shared/types.js";
 import { makeAnnotation } from "../helpers/ydoc-factory.js";
 
 /**
- * Inline implementation of the step-1 user-action detection — mirrors
- * useTutorial.svelte.ts so we can test the predicate without a Svelte
- * rune environment.
+ * Tests the step-1 user-action predicate exported from useTutorial.svelte.ts.
  *
- * The filter is the regression-vector PR-A2b fixed: after PR-A2 made
- * the tutorial note author='user' (correct per ADR-027), step 1
- * auto-advanced on tutorial load instead of waiting for a real user
- * annotation. Excluding tutorial-prefixed IDs from this check restores
- * the gate.
+ * The filter is the regression-vector PR-A2b fixed: after PR-A2 made the
+ * tutorial note `author='user'` (correct per ADR-027), step 1 auto-advanced
+ * on tutorial load instead of waiting for a real user annotation. Excluding
+ * tutorial-prefixed IDs from this check restores the gate.
+ *
+ * Importing the production predicate directly (instead of mirroring it
+ * inline) ensures a revert of `isNonTutorialUserAnnotation` would fail
+ * this test, not silently pass.
  */
-function hasUserAnnotation(annotations: Annotation[]): boolean {
-  return annotations.some(
-    (a) => a.author === "user" && !a.id.startsWith(TUTORIAL_ANNOTATION_PREFIX),
-  );
-}
-
-describe("useTutorial step-1 user-action detection", () => {
-  it("tutorial-seeded user note does NOT count as user action", () => {
+describe("isNonTutorialUserAnnotation (step-1 user-action predicate)", () => {
+  it("tutorial-seeded user note does NOT count", () => {
     const seed = makeAnnotation({
       id: `${TUTORIAL_ANNOTATION_PREFIX}note-1`,
       author: "user",
       type: "note",
     });
-    expect(hasUserAnnotation([seed])).toBe(false);
+    expect(isNonTutorialUserAnnotation(seed)).toBe(false);
   });
 
   it("real user annotation counts", () => {
@@ -36,28 +31,41 @@ describe("useTutorial step-1 user-action detection", () => {
       author: "user",
       type: "note",
     });
-    expect(hasUserAnnotation([real])).toBe(true);
+    expect(isNonTutorialUserAnnotation(real)).toBe(true);
   });
 
-  it("claude-authored tutorial annotations are ignored regardless of prefix", () => {
+  it("claude-authored tutorial annotation does NOT count", () => {
     const tutorialHighlight = makeAnnotation({
       id: `${TUTORIAL_ANNOTATION_PREFIX}highlight-1`,
       author: "claude",
       type: "highlight",
     });
-    expect(hasUserAnnotation([tutorialHighlight])).toBe(false);
+    expect(isNonTutorialUserAnnotation(tutorialHighlight)).toBe(false);
   });
 
-  it("mixed list with one real user annotation returns true", () => {
+  it("tutorial seed mutated to status=accepted still does NOT count", () => {
+    // Locks in current behavior: status mutations don't promote a tutorial
+    // seed to a real user-authored annotation. The predicate looks only at
+    // author and id prefix — not status.
+    const mutated = makeAnnotation({
+      id: `${TUTORIAL_ANNOTATION_PREFIX}note-1`,
+      author: "user",
+      type: "note",
+      status: "accepted",
+    });
+    expect(isNonTutorialUserAnnotation(mutated)).toBe(false);
+  });
+
+  it("mixed list — some(...) returns true when one real user annotation present", () => {
     const seed = makeAnnotation({
       id: `${TUTORIAL_ANNOTATION_PREFIX}note-1`,
       author: "user",
     });
     const real = makeAnnotation({ id: "real-1", author: "user" });
-    expect(hasUserAnnotation([seed, real])).toBe(true);
+    expect([seed, real].some(isNonTutorialUserAnnotation)).toBe(true);
   });
 
-  it("empty list returns false", () => {
-    expect(hasUserAnnotation([])).toBe(false);
+  it("empty list — some(...) returns false", () => {
+    expect([].some(isNonTutorialUserAnnotation)).toBe(false);
   });
 });

--- a/tests/server/reload-from-disk-persistence.test.ts
+++ b/tests/server/reload-from-disk-persistence.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Regression tests for the PR-A1 split-transaction fix in `reloadFromDisk`
+ * (commit 8d9c0ce; CRDT-reviewer catch).
+ *
+ * `reloadFromDisk` runs TWO transactions:
+ *   1. FILE_SYNC_ORIGIN — clears awareness + reloads content. Durable-sync
+ *      observer skips this (file just came from disk; nothing to persist).
+ *   2. MCP_ORIGIN — relocates stale annotation ranges via textSnapshot.
+ *      Durable-sync observer MUST see this so the relocated ranges persist.
+ *
+ * Test B (origin sequence) is the tighter regression guard — it would fail
+ * the moment someone flips transaction (2) back to FILE_SYNC_ORIGIN, even
+ * if no real durable-sync wiring is present.
+ *
+ * Test A (mimicked durable-sync observer) is the behavior contract — it
+ * proves that an observer with the production skip rule actually receives
+ * the relocation write.
+ *
+ * Related GH issue: #622 (pre-existing two-write crash window). When that
+ * fix lands, transaction count for reload should drop from 2 → 1 — update
+ * Test B accordingly.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+
+vi.mock("../../src/server/platform", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/server/platform")>();
+  const osMod = await import("node:os");
+  const pathMod = await import("node:path");
+  const cryptoMod = await import("node:crypto");
+  const appDataDir = pathMod.join(osMod.tmpdir(), `tandem-test-reload-${cryptoMod.randomUUID()}`);
+  process.env.TANDEM_APP_DATA_DIR = appDataDir;
+  return {
+    ...original,
+    SESSION_DIR: pathMod.join(appDataDir, "sessions"),
+  };
+});
+
+// Capture the watcher callback so we can drive reloadFromDisk synchronously
+// from the test without depending on real fs.watch timing.
+const watcherMocks = vi.hoisted(() => ({ watchFile: vi.fn() }));
+vi.mock("../../src/server/file-watcher", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/server/file-watcher")>()),
+  watchFile: watcherMocks.watchFile,
+}));
+
+vi.mock("../../src/server/notifications.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/server/notifications.js")>();
+  return { ...actual, pushNotification: vi.fn() };
+});
+
+import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "../../src/server/events/queue.js";
+import { docIdFromPath } from "../../src/server/mcp/document-model.js";
+import { getOpenDocs, removeDoc, setActiveDocId } from "../../src/server/mcp/document-service.js";
+import { openFileByPath } from "../../src/server/mcp/file-opener.js";
+import { anchoredRange, refreshRange } from "../../src/server/positions.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
+import { toFlatOffset } from "../../src/shared/positions/types.js";
+import type { Annotation } from "../../src/shared/types.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  for (const id of [...getOpenDocs().keys()]) removeDoc(id);
+  setActiveDocId(null);
+  vi.clearAllMocks();
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tandem-reload-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+});
+
+afterAll(async () => {
+  const appDataDir = process.env.TANDEM_APP_DATA_DIR;
+  if (appDataDir) await fs.rm(appDataDir, { recursive: true, force: true }).catch(() => {});
+  delete process.env.TANDEM_APP_DATA_DIR;
+});
+
+interface TxnRecord {
+  origin: unknown;
+  changedTypes: Set<Y.AbstractType<unknown>>;
+}
+
+function listenForTransactions(doc: Y.Doc): { records: TxnRecord[]; detach: () => void } {
+  const records: TxnRecord[] = [];
+  const listener = (txn: {
+    origin: unknown;
+    changed: Map<Y.AbstractType<unknown>, Set<string | null>>;
+  }) => {
+    records.push({ origin: txn.origin, changedTypes: new Set(txn.changed.keys()) });
+  };
+  doc.on("afterTransaction", listener);
+  return { records, detach: () => doc.off("afterTransaction", listener) };
+}
+
+async function setupOpenedFile(initialText: string): Promise<{
+  filePath: string;
+  doc: Y.Doc;
+  triggerReload: () => Promise<void>;
+}> {
+  const filePath = path.join(tmpDir, "doc.md");
+  await fs.writeFile(filePath, initialText, "utf-8");
+  await openFileByPath(filePath);
+
+  const docId = docIdFromPath(filePath);
+  const doc = getOrCreateDocument(docId);
+
+  // The watcher mock captured the (filePath, callback) — driving the callback
+  // is exactly what fs.watch does on a real on-disk change.
+  const lastCall = watcherMocks.watchFile.mock.calls.at(-1);
+  if (!lastCall) throw new Error("watchFile was not called by openFileByPath");
+  const onChanged = lastCall[1] as (p: string) => Promise<void>;
+  const triggerReload = async () => {
+    await onChanged(filePath);
+  };
+
+  return { filePath, doc, triggerReload };
+}
+
+function seedAnnotationOnText(doc: Y.Doc, snapshot: string, content: string): string {
+  const text = doc
+    .getXmlFragment("default")
+    .toString()
+    .replace(/<[^>]+>/g, "");
+  const idx = text.indexOf(snapshot);
+  if (idx < 0) throw new Error(`snapshot "${snapshot}" not found in doc text`);
+
+  const result = anchoredRange(
+    doc,
+    toFlatOffset(idx),
+    toFlatOffset(idx + snapshot.length),
+    snapshot,
+  );
+  if (!result.ok) throw new Error(`anchoredRange failed for "${snapshot}"`);
+
+  const id = `ann_reload_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const ann: Annotation = {
+    id,
+    author: "user",
+    type: "comment",
+    range: result.range,
+    ...(result.fullyAnchored ? { relRange: result.relRange } : {}),
+    content,
+    status: "pending",
+    timestamp: Date.now(),
+    textSnapshot: snapshot,
+    rev: 1,
+  };
+  const map = doc.getMap<Annotation>(Y_MAP_ANNOTATIONS);
+  doc.transact(() => map.set(id, ann), MCP_ORIGIN);
+  return id;
+}
+
+describe("reloadFromDisk — origin sequence + persistence (PR-F1)", () => {
+  it("Test B: exactly two transactions fire — [FILE_SYNC_ORIGIN, MCP_ORIGIN] touching Y_MAP_ANNOTATIONS", async () => {
+    const { doc, filePath, triggerReload } = await setupOpenedFile("Hello world foo bar");
+
+    // Seed an annotation on "foo" so the relocation pass has work to do.
+    const annId = seedAnnotationOnText(doc, "foo", "annotation on foo");
+
+    // Move "foo" to a new offset on disk so textSnapshot-based relocation
+    // is exercised. We add a prefix so "foo" still appears in the doc text.
+    await fs.writeFile(filePath, "Greetings, world — foo bar\n", "utf-8");
+
+    // Start capture AFTER the seed write so the watcher's two reload
+    // transactions are the only ones recorded.
+    const { records, detach } = listenForTransactions(doc);
+    try {
+      await triggerReload();
+    } finally {
+      detach();
+    }
+
+    const reloadRecords = records;
+    expect(reloadRecords.length).toBeGreaterThanOrEqual(2);
+
+    // First transaction: FILE_SYNC_ORIGIN content + awareness clear.
+    const first = reloadRecords[0];
+    expect(first.origin).toBe(FILE_SYNC_ORIGIN);
+
+    // Among the reload's MCP_ORIGIN transactions, at least one must mutate
+    // the annotations Y.Map (the relocation pass). Using ref-equality on the
+    // map instance, NOT constructor.name (all YMap variants share name).
+    const annMapRef = doc.getMap(Y_MAP_ANNOTATIONS);
+    const mcpAnnotationWrites = reloadRecords.filter(
+      (r) => r.origin === MCP_ORIGIN && r.changedTypes.has(annMapRef),
+    );
+    expect(mcpAnnotationWrites.length).toBeGreaterThanOrEqual(1);
+
+    // Sanity: the seeded annotation still exists post-reload, and its range
+    // is refreshable (proves the annotation Y.Map entry survived).
+    const updated = annMapRef.get(annId) as Annotation | undefined;
+    expect(updated).toBeDefined();
+    if (updated) {
+      const refreshed = refreshRange(updated, doc, annMapRef);
+      expect(refreshed).not.toBeNull();
+    }
+  });
+
+  it("Test A: durable-sync-shaped observer fires for the relocation transact", async () => {
+    const { doc, filePath, triggerReload } = await setupOpenedFile(
+      "Once upon a time the brown fox jumped.",
+    );
+
+    seedAnnotationOnText(doc, "brown", "comment on brown");
+
+    // Mimic registerAnnotationObserver's contract: an observer on
+    // Y_MAP_ANNOTATIONS that ignores FILE_SYNC_ORIGIN transactions. This is
+    // the production durable-sync skip rule (sync.ts:242). The relocation
+    // transact MUST fire this observer; if PR-A1 regresses and the second
+    // transact is flipped back to FILE_SYNC_ORIGIN, the observer count drops
+    // to zero and durable persistence silently fails.
+    const annMap = doc.getMap<Annotation>(Y_MAP_ANNOTATIONS);
+    let observedNonFileSyncWrites = 0;
+    let lastObservedRange: Annotation["range"] | undefined;
+    const observer = (_ev: Y.YMapEvent<Annotation>, txn: Y.Transaction): void => {
+      if (txn.origin === FILE_SYNC_ORIGIN) return;
+      observedNonFileSyncWrites++;
+      for (const [, ann] of annMap.entries()) {
+        lastObservedRange = ann.range;
+      }
+    };
+    annMap.observe(observer);
+
+    try {
+      // Move "brown" to a new offset on disk so the relocation pass writes.
+      await fs.writeFile(filePath, "A long time ago, the brown fox jumped.\n", "utf-8");
+      await triggerReload();
+    } finally {
+      annMap.unobserve(observer);
+    }
+
+    expect(observedNonFileSyncWrites).toBeGreaterThanOrEqual(1);
+    expect(lastObservedRange).toBeDefined();
+  });
+});

--- a/tests/server/resolve-annotation.test.ts
+++ b/tests/server/resolve-annotation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for tandem_resolveAnnotation MCP tool.
+ * Locks in PR-A3 error-code change (NOT_FOUND on missing annotation, both
+ * action: "accept" and action: "dismiss" branches against the same handler).
+ *
+ * Uses in-memory MCP client to exercise the actual tool handler, matching the
+ * pattern in edit-annotation.test.ts.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { registerAnnotationTools } from "../../src/server/mcp/annotations.js";
+import { populateYDoc } from "../../src/server/mcp/document.js";
+import {
+  addDoc,
+  getOpenDocs,
+  removeDoc,
+  setActiveDocId,
+} from "../../src/server/mcp/document-service.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+
+let client: Client;
+
+async function setupMcpClient(): Promise<Client> {
+  const server = new McpServer({ name: "tandem-test", version: "0.0.1" });
+  registerAnnotationTools(server);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const mcpClient = new Client({ name: "test-client", version: "0.0.1" });
+  await server.connect(serverTransport);
+  await mcpClient.connect(clientTransport);
+  return mcpClient;
+}
+
+function parseResult(result: { content: Array<{ type: string; text?: string }> }) {
+  const textContent = result.content.find((c) => c.type === "text");
+  return textContent?.text ? JSON.parse(textContent.text) : null;
+}
+
+function setupDoc(id: string, text: string) {
+  const ydoc = getOrCreateDocument(id);
+  populateYDoc(ydoc, text);
+  addDoc(id, { id, filePath: `/tmp/${id}.md`, format: "md", readOnly: false, source: "file" });
+  setActiveDocId(id);
+  return ydoc;
+}
+
+beforeEach(async () => {
+  for (const id of [...getOpenDocs().keys()]) removeDoc(id);
+  setActiveDocId(null);
+  client = await setupMcpClient();
+});
+
+describe("tandem_resolveAnnotation NOT_FOUND error code", () => {
+  it("returns NOT_FOUND when action: accept targets a missing annotation", async () => {
+    setupDoc("resolve-1", "Hello world");
+
+    const result = await client.callTool({
+      name: "tandem_resolveAnnotation",
+      arguments: { id: "fake-id", action: "accept" },
+    });
+    const parsed = parseResult(result as { content: Array<{ type: string; text?: string }> });
+    expect(parsed.message).toContain("not found");
+    expect(parsed.code).toBe("NOT_FOUND");
+  });
+
+  it("returns NOT_FOUND when action: dismiss targets a missing annotation", async () => {
+    setupDoc("resolve-2", "Hello world");
+
+    const result = await client.callTool({
+      name: "tandem_resolveAnnotation",
+      arguments: { id: "fake-id", action: "dismiss" },
+    });
+    const parsed = parseResult(result as { content: Array<{ type: string; text?: string }> });
+    expect(parsed.message).toContain("not found");
+    expect(parsed.code).toBe("NOT_FOUND");
+  });
+});


### PR DESCRIPTION
## Summary

Six follow-ups addressing every Important and Suggestion finding from the multi-reviewer + Codex review of #621. Stacks on `#621` (rebase onto master after #621 merges, or merge #621 first and this PR will rebase to the new master automatically).

Plan document: `docs/audit-v2-followups-plan.md` (added in PR-F6 commit).

Each PR-F* is a separate commit so it can be reverted independently if needed.

## Commits

- **PR-F6** (`1697db5`) — file #622 (pre-existing two-write crash window in `reloadFromDisk`) + `CHANGELOG.md` "Known Issues" entry. Surfaced by Codex; pre-existing in master, deferred to v0.12.0 because the fix needs a `skipTransact` parameter on `refreshAllRanges` (3 caller sites, balloons audit PR scope).
- **PR-F2** (`d27d651`) — new `tests/server/resolve-annotation.test.ts` asserting `code === "NOT_FOUND"` for both `action: "accept"` and `action: "dismiss"` against missing IDs. Locks in PR-A3's error-code change for the only tool branch not already covered.
- **PR-F5** (`e5d7a0a`) — load-bearing comments on `TUTORIAL_ANNOTATION_PREFIX` (tutorial notes carry `author="user"` per ADR-027; renaming the prefix without updating the predicate silently re-introduces the PR-A2b step-1 auto-advance bug) and at the `reloadFromDisk` relocation transact (explaining why `MCP_ORIGIN` is intentional — prevents PR-A1 regression). Plus conditional-spread for tutorial `relRange` matching the established `reloadFromDisk` pattern.
- **PR-F3** (`65e4683`) — extract `isNonTutorialUserAnnotation` from `useTutorial.svelte.ts` and import it in `tests/client/use-tutorial.test.ts`. The test previously mirrored the predicate inline, so a revert of the production predicate silently passed. Adds a new case locking in current behavior: a tutorial seed mutated to `status="accepted"` still doesn't count.
- **PR-F4** (`3c029ff`) — rewrite both audit scripts. `audit-origins.ts` tightens pass-through identifier detection (only Identifiers forwarded through a parameter named `origin`/`transactionOrigin`/`txnOrigin` or with origin-union type-node text are accepted; others emit `pass-through (verify)` findings). `audit-ymap-keys.ts` switches from regex to TypeScript AST walk, adding coverage for `getMap`/`getArray`/`getText`/`getXmlFragment` (origination sites — the highest-value miss in the old script), plus `.has` / `.delete` and multi-line `.set`/`.get`.
- **PR-F1** (`85c5c61`) — new `tests/server/reload-from-disk-persistence.test.ts`. Test B: spies on `afterTransaction` during a watcher-driven reload, asserts the first transaction is `FILE_SYNC_ORIGIN` and at least one `MCP_ORIGIN` transaction touches `Y_MAP_ANNOTATIONS` (ref-equality on the map instance, NOT constructor.name — all YMap variants share name). Test A: a Y.Map observer with the production durable-sync skip rule (`txn.origin === FILE_SYNC_ORIGIN → skip`) — confirms the relocation writes are actually visible to durable-sync. Either test would fail if the PR-A1 split-transaction fix in commit `8d9c0ce` is reverted.

## Verification

- [x] `npm run typecheck` — 0 errors, 0 warnings, 784 files
- [x] `npx vitest run` — 147 test files, 1967 passed, 4 skipped (was 1947 pre-follow-ups)
- [x] `npm run audit:origins` — 1 untagged finding (the existing documented `addReplyToAnnotation` browser-origin path); 0 new `pass-through (verify)` findings
- [x] `npm run audit:ymap-keys` — clean

## ADR-027 channel filtering grep

Per plan reviewer suggestion, verified note-filtering is consistent at every surface that could expose to Claude:
- `src/server/events/observers/annotations.ts:55` (channel observer special-cases note→comment promotion)
- `src/server/mcp/annotations.ts:445-446, 589` (`tandem_getAnnotations`, `tandem_exportAnnotations` filter notes out)
- `src/server/file-io/docx-comments.ts:204`, `docx.ts:47` (export handlers)
- `src/server/mcp/tutorial-annotations.ts:88` (ADR-027 author rule applied at seed time)

No gaps found.

## What is NOT addressed

Documented in `docs/audit-v2-followups-plan.md` under "What is explicitly NOT addressed":
- First-transact `forEach(...delete)` awareness clear (cosmetic — Y.Map snapshots iterator, currently safe)
- Cross-module identifier resolution in `audit-origins` (would require full TypeChecker; `verify` findings + human triage are the trade-off)
- `audit-ymap-keys` bracket-access detection (dead detection — bracket access on a Y.Map is a TS error)
- Extracting `relocateStaleAnnotations` helper from `reloadFromDisk` (Test B's spy gives most of that value without the refactor)

## Test plan

- [x] Run `npx vitest run tests/server/reload-from-disk-persistence.test.ts tests/server/resolve-annotation.test.ts tests/client/use-tutorial.test.ts` and confirm green
- [x] Run `npm run audit:origins` and `npm run audit:ymap-keys`
- [ ] Once #621 merges, this PR auto-rebases or can be re-targeted to master
- [ ] CI green on all checks

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
