### PR TITLE
feat(shortcuts): add 15 keyboard shortcuts (tabs, find, panels, annotations, editor polish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Markdown serializer escape noise on `.md` saves (#605, v1.0 blocker)** — every `.md` file Tandem auto-saved was silently rewritten with backslash-escape noise by `remark-stringify`'s default `unsafe` table (`[anchor]` → `\[anchor]`, `foo_bar` → `foo\_bar`, etc.). The serializer in `src/server/file-io/markdown.ts` now overrides the `text` handler to call `state.safe()` (preserving block-context escapes for line-leading `# `, `- `, `> `, fence runs, table pipes, setext underlines) and then selectively un-escape four intra-text classes: `\[label]` when `label` is not a `definition` identifier in the same tree (parse-aware via a `unist-util-visit` pre-pass — guards against the collapsed-reference-link regression class; label is normalized per CommonMark; negative lookahead also rejects an immediately following `[` to block adjacent-bracket reference-link injection; label character class excludes `\` to prevent O(n²) backtracking on adversarial input like `\[\[\[\[\[…`), `\_` strictly between word chars (CommonMark §6.2 intra-word flanking rule), standalone `` \` ``, and `\~` not followed by another `~` (GFM strikethrough needs `~~`). GFM autolink-literal `@`/`.`/`:` and table `|` escapes still flow through `safe()` untouched. `CHANGELOG.md` was re-serialized through the fixed code as a one-time data cleanup. The `readOnly: true` workaround on the upgrade auto-open path (PR #603) is retained as defense-in-depth.
 
+### Added
+
+- **15 keyboard shortcuts (#626)** — grouped by area:
+  - **Tabs:** `Ctrl+W` close active tab (records to in-memory LIFO), `Ctrl+Alt+T` reopen most-recently-closed tab, `Ctrl+1`..`Ctrl+9` jump to tab by index, `Ctrl+O` open file dialog.
+  - **Find / outline:** `Ctrl+F` focus outline search when outline panel is visible, otherwise open find bar (doc scope); `Ctrl+Shift+F` open find bar pre-scoped to "Open tabs"; `Ctrl+G` / `Ctrl+Shift+G` find next/previous (falls back to opening find bar when no active query).
+  - **Panels / chrome:** `Ctrl+\` toggle left panel, `Ctrl+Shift+\` toggle right panel, `Ctrl+Shift+M` toggle solo/tandem mode.
+  - **Annotations:** `Alt+]` / `Alt+[` next/previous annotation; `Ctrl+Enter` / `Ctrl+Shift+Enter` accept/dismiss focused annotation; `Ctrl+Alt+M` open the comment popup on current selection; `Ctrl+Alt+A` toggle authorship colors.
+  - **Editor polish:** `Alt+L` select containing block (paragraph / heading / list item).
+
+  All letter shortcuts use `KeyboardEvent.code` (e.g. `KeyT`, `KeyM`) rather than `e.key` so they remain layout-independent (Dvorak / AZERTY) and fire correctly on macOS when Option is held — `Option+letter` produces alt characters (`†`, `µ`, `¬`, `å`) that don't match the unmodified letter `e.key`. Digits and Backslash already used `e.code`; Enter is layout-stable and remains on `e.key`. `Ctrl+M` vs `Ctrl+Shift+M` discrimination is now explicit (`!e.shiftKey` / `e.shiftKey`).
+
+  `reopenClosedTab` now checks `response.ok` so server-side 4xx/5xx no longer silently drop the popped record (fetch only rejects on network failures). Failure restores the record onto the stack and surfaces a toast with the basename so the user can retry; previously a failed reopen was logged to devtools only and the record was lost.
+
+  `Ctrl+Alt+M` distinguishes its preconditions: no selection → "Select text to comment"; read-only doc → "Document is read-only"; palette/find open → silent (the user is in a different UI context); selection toolbar setting off → "Enable selection toolbar in Settings to comment via keyboard". A single toast string would have misfired in three out of four cases.
+
+  `useNotifications` now exposes a `push()` method so client-originated UI feedback (the toasts above) can be surfaced through the same toast container as server-pushed notifications, instead of `console.warn`-ing into devtools the user never opens.
+
 ### Known Issues
 
 - **`reloadFromDisk` two-write crash window (#622, v0.12.0 fix)** — when the file watcher detects an external edit, `reloadFromDisk` runs `refreshAllRanges` (own `MCP_ORIGIN` transact) and then a relocation pass (separate `MCP_ORIGIN` transact). Both flow through the durable-annotation sync observer. If the server is killed between the two transactions, durable annotation state can be left at partially-refreshed ranges. Pre-existing in master (not introduced by PR #621; surfaced by audit v2). Bounded by the narrow synchronous window between the two transactions. Tracked for fix in v0.12.0 via a `skipTransact` parameter on `refreshAllRanges` so reload can merge both passes into a single transaction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **15 keyboard shortcuts (#626)** — grouped by area:
+
   - **Tabs:** `Ctrl+W` close active tab (records to in-memory LIFO), `Ctrl+Alt+T` reopen most-recently-closed tab, `Ctrl+1`..`Ctrl+9` jump to tab by index, `Ctrl+O` open file dialog.
   - **Find / outline:** `Ctrl+F` focus outline search when outline panel is visible, otherwise open find bar (doc scope); `Ctrl+Shift+F` open find bar pre-scoped to "Open tabs"; `Ctrl+G` / `Ctrl+Shift+G` find next/previous (falls back to opening find bar when no active query).
   - **Panels / chrome:** `Ctrl+\` toggle left panel, `Ctrl+Shift+\` toggle right panel, `Ctrl+Shift+M` toggle solo/tandem mode.

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Editor as TiptapEditor } from "@tiptap/core";
 import { onDestroy, untrack } from "svelte";
+import { API_OPEN } from "../shared/api-paths.js";
 import { isUploadPath } from "../shared/paths";
 import { toPmPos } from "../shared/positions/types";
 import type { CapturedAnchor } from "../shared/types";
@@ -31,6 +32,7 @@ import FindReplaceBar from "./editor/find-replace/FindReplaceBar.svelte";
 import Toolbar from "./editor/toolbar/Toolbar.svelte";
 import { createAccentHue } from "./hooks/useAccentHue.svelte";
 import { createAnnotationPatterns } from "./hooks/useAnnotationPatterns.svelte";
+import { createClosedTabStack } from "./hooks/useClosedTabStack.js";
 import { createConnectionBanner } from "./hooks/useConnectionBanner.svelte";
 import { createDensity } from "./hooks/useDensity.svelte";
 import { createDragResize } from "./hooks/useDragResize.svelte";
@@ -58,10 +60,50 @@ import FormattingBar from "./shell/FormattingBar.svelte";
 import TitleBar from "./shell/TitleBar.svelte";
 import StatusBar from "./status/StatusBar.svelte";
 import DocumentTabs from "./tabs/DocumentTabs.svelte";
+import { API_BASE } from "./utils/fileUpload.js";
 import { addRecentFile, loadRecentFiles, saveRecentFiles } from "./utils/recentFiles";
 
 const yjsSync = createYjsSync();
 onDestroy(() => yjsSync.destroy());
+
+// In-memory closed-tab history for Ctrl+Alt+T (reopen closed tab). Lifetime is
+// the app session; resets on reload. See useClosedTabStack.ts for rationale.
+const closedTabStack = createClosedTabStack();
+const inflightReopens = new Set<string>();
+
+function closeTabAndRecord(tabId: string) {
+  const tab = yjsSync.tabs.find((t) => t.id === tabId);
+  if (tab && !isUploadPath(tab.filePath)) {
+    closedTabStack.push({ filePath: tab.filePath, closedAt: Date.now() });
+  }
+  yjsSync.handleTabClose(tabId);
+}
+
+async function reopenClosedTab() {
+  const rec = closedTabStack.pop();
+  if (!rec) return;
+  // Server may have rejected the original close (rare); also covers the
+  // close→reopen→close→reopen rapid cycle for the same path. If the file is
+  // still open, just activate it.
+  const existing = yjsSync.tabs.find((t) => t.filePath === rec.filePath);
+  if (existing) {
+    yjsSync.setActiveTabId(existing.id);
+    return;
+  }
+  if (inflightReopens.has(rec.filePath)) return;
+  inflightReopens.add(rec.filePath);
+  try {
+    await fetch(`${API_BASE}${API_OPEN}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath: rec.filePath }),
+    });
+  } catch (err) {
+    console.warn("[tandem] reopen closed tab failed:", err);
+  } finally {
+    inflightReopens.delete(rec.filePath);
+  }
+}
 
 const tabOrder = createTabOrder(() => yjsSync.tabs);
 createTabCycleKeyboard(
@@ -168,13 +210,14 @@ wireActionDeps({
   },
   closeActiveTab: () => {
     const id = yjsSync.activeTabId;
-    if (id) yjsSync.handleTabClose(id);
+    if (id) closeTabAndRecord(id);
   },
   openFileDialog: () => {
     fileOpenDialogOpen = true;
   },
   toggleLeftPanel: () => toggleLeftPanel(),
   toggleRightPanel: () => toggleRightPanel(),
+  reopenClosedTab: () => void reopenClosedTab(),
 });
 
 // The authorship plugin reads its initial visibility from localStorage at
@@ -402,7 +445,7 @@ $effect(() => {
         if (shouldIgnoreShortcut(e)) return;
         e.preventDefault();
         const id = yjsSync.activeTabId;
-        if (id) yjsSync.handleTabClose(id);
+        if (id) closeTabAndRecord(id);
       } else if (e.key === "o") {
         if (shouldIgnoreShortcut(e)) return;
         e.preventDefault();
@@ -423,6 +466,10 @@ $effect(() => {
         e.preventDefault();
         if (e.shiftKey) toggleRightPanel();
         else toggleLeftPanel();
+      } else if (e.altKey && (e.key === "t" || e.key === "T")) {
+        if (shouldIgnoreShortcut(e)) return;
+        e.preventDefault();
+        void reopenClosedTab();
       }
     }
     // Ctrl/Cmd+F — focus outline search if outline panel visible; else open find bar (doc scope).
@@ -525,7 +572,7 @@ const tutorial = createTutorial(
       tabs={tabOrder.orderedTabs}
       activeTabId={yjsSync.activeTabId}
       onTabSwitch={yjsSync.setActiveTabId}
-      onTabClose={yjsSync.handleTabClose}
+      onTabClose={closeTabAndRecord}
       reorder={tabOrder.reorder}
       reduceMotion={settingsState.settings.reduceMotion}
       onRequestOpenDialog={() => { fileOpenDialogOpen = true; }}

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -31,6 +31,11 @@ import { getFindState } from "./editor/extensions/find-replace.js";
 import FindReplaceBar from "./editor/find-replace/FindReplaceBar.svelte";
 import Toolbar from "./editor/toolbar/Toolbar.svelte";
 import { createAccentHue } from "./hooks/useAccentHue.svelte";
+import {
+  nextAnnotationId,
+  prevAnnotationId,
+  sortAnnotationsByPosition,
+} from "./hooks/useAnnotationOrder.js";
 import { createAnnotationPatterns } from "./hooks/useAnnotationPatterns.svelte";
 import { createClosedTabStack } from "./hooks/useClosedTabStack.js";
 import { createConnectionBanner } from "./hooks/useConnectionBanner.svelte";
@@ -55,6 +60,7 @@ import { createYjsSync } from "./hooks/yjsSync.svelte";
 import { loadPanelWidth, PANEL_MAX_WIDTH, PANEL_MIN_WIDTH } from "./panel-layout";
 import type { FilterAuthor, FilterStatus, FilterType } from "./panels/FilterBar.svelte";
 import RailTabPicker from "./panels/RailTabPicker.svelte";
+import { useAnnotationReview } from "./panels/useAnnotationReview.svelte";
 import { pmSelectionToFlat } from "./positions";
 import FormattingBar from "./shell/FormattingBar.svelte";
 import TitleBar from "./shell/TitleBar.svelte";
@@ -218,6 +224,32 @@ wireActionDeps({
   toggleLeftPanel: () => toggleLeftPanel(),
   toggleRightPanel: () => toggleRightPanel(),
   reopenClosedTab: () => void reopenClosedTab(),
+  annotationNext: () => {
+    const sorted = sortAnnotationsByPosition(modeGate.visibleAnnotations);
+    const nextId = nextAnnotationId(sorted, activeAnnotationId);
+    if (nextId) {
+      activeAnnotationId = nextId;
+      const ann = sorted.find((a) => a.id === nextId);
+      if (ann) review.scrollToAnnotation(ann);
+    }
+  },
+  annotationPrev: () => {
+    const sorted = sortAnnotationsByPosition(modeGate.visibleAnnotations);
+    const prevId = prevAnnotationId(sorted, activeAnnotationId);
+    if (prevId) {
+      activeAnnotationId = prevId;
+      const ann = sorted.find((a) => a.id === prevId);
+      if (ann) review.scrollToAnnotation(ann);
+    }
+  },
+  annotationAccept: () => {
+    const cur = modeGate.visibleAnnotations.find((a) => a.id === activeAnnotationId);
+    if (cur && cur.author !== "user") review.handleAccept(cur.id);
+  },
+  annotationDismiss: () => {
+    const cur = modeGate.visibleAnnotations.find((a) => a.id === activeAnnotationId);
+    if (cur && cur.author !== "user") review.handleDismiss(cur.id);
+  },
 });
 
 // The authorship plugin reads its initial visibility from localStorage at
@@ -296,6 +328,7 @@ let slashCommandMenuOpen = $state(false);
 let findBarOpen = $state(false);
 let findBarForceScope = $state<"doc" | "tabs">("doc");
 let outlineFocusTrigger = $state(0);
+let commentFocusTrigger = $state(0);
 let activeAnnotationFilter = $state<{
   type: FilterType;
   author: FilterAuthor;
@@ -508,12 +541,83 @@ $effect(() => {
         findBarOpen = true;
       }
     }
+    // Alt+] / Alt+[ — next / previous annotation. Plain Alt (no ctrl/meta/shift)
+    // so they work cross-platform without an fn-key on Mac (unlike F8).
+    if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+      if (e.code === "BracketRight") {
+        if (shouldIgnoreShortcut(e)) return;
+        e.preventDefault();
+        const sorted = sortAnnotationsByPosition(modeGate.visibleAnnotations);
+        const nextId = nextAnnotationId(sorted, activeAnnotationId);
+        if (nextId) {
+          activeAnnotationId = nextId;
+          const ann = sorted.find((a) => a.id === nextId);
+          if (ann) review.scrollToAnnotation(ann);
+        }
+        return;
+      }
+      if (e.code === "BracketLeft") {
+        if (shouldIgnoreShortcut(e)) return;
+        e.preventDefault();
+        const sorted = sortAnnotationsByPosition(modeGate.visibleAnnotations);
+        const prevId = prevAnnotationId(sorted, activeAnnotationId);
+        if (prevId) {
+          activeAnnotationId = prevId;
+          const ann = sorted.find((a) => a.id === prevId);
+          if (ann) review.scrollToAnnotation(ann);
+        }
+        return;
+      }
+    }
+    // Ctrl/Cmd+Enter — accept focused annotation; Ctrl/Cmd+Shift+Enter — dismiss.
+    // Only Claude- or import-authored annotations can be accepted/dismissed
+    // (mirrors the SidePanel.svelte:440 prop gate). User-authored notes never
+    // become review-targets so the underlying handler is also gated.
+    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+      if (shouldIgnoreShortcut(e)) return;
+      e.preventDefault();
+      const cur = modeGate.visibleAnnotations.find((a) => a.id === activeAnnotationId);
+      if (cur && cur.author !== "user") {
+        if (e.shiftKey) review.handleDismiss(cur.id);
+        else review.handleAccept(cur.id);
+      }
+      return;
+    }
+    // Ctrl/Cmd+Alt+M — open the comment popup focused on its textarea, using
+    // whatever text is currently selected in the editor. Intentionally NOT
+    // gated on shouldIgnoreShortcut: contenteditable focus is the common case
+    // (user has selected text in the editor) and we want this to fire there.
+    if ((e.ctrlKey || e.metaKey) && e.altKey && (e.key === "m" || e.key === "M")) {
+      e.preventDefault();
+      commentFocusTrigger += 1;
+      return;
+    }
   }
   window.addEventListener("keydown", handler);
   return () => window.removeEventListener("keydown", handler);
 });
 
 const activeTab = $derived(yjsSync.tabs.find((t) => t.id === yjsSync.activeTabId));
+
+// Lifted from SidePanel.svelte so that:
+//   1. There's exactly one review instance (both rails would otherwise mount
+//      their own, doubling accept/dismiss writes — which would also double
+//      `applySuggestion`'s text insertion before the idempotency guard fix).
+//   2. App-level keyboard shortcuts (Ctrl+Enter accept, etc.) can dispatch
+//      directly without an upward callback.
+// SidePanel now receives `review` as a prop.
+const review = useAnnotationReview({
+  getYdoc: () => activeTab?.ydoc ?? null,
+  getEditor: () => editor,
+  getAnnotations: () => modeGate.visibleAnnotations,
+  onActiveAnnotationChange: (id) => {
+    activeAnnotationId = id;
+  },
+  getScrollBehavior: () => (settingsState.settings.reduceMotion ? "auto" : "smooth"),
+  // Lets the hook's auto-set effect avoid clobbering externally-set ids
+  // (e.g., from Alt+]/Alt+[ keyboard navigation).
+  getActiveAnnotationId: () => activeAnnotationId,
+});
 
 const tutorial = createTutorial(
   () => modeGate.visibleAnnotations,
@@ -566,6 +670,7 @@ const tutorial = createTutorial(
       ydoc={activeTab?.ydoc ?? null}
       selectionToolbar={settingsState.settings.selectionToolbar}
       suppressSelectionToolbar={slashCommandMenuOpen || findBarOpen || paletteOpen}
+      requestCommentFocus={commentFocusTrigger}
     />
 
     <DocumentTabs
@@ -662,6 +767,7 @@ const tutorial = createTutorial(
               onActiveAnnotationChange={(id) => (activeAnnotationId = id)}
               reduceMotion={settingsState.settings.reduceMotion}
               storeReadOnly={yjsSync.storeReadOnly}
+              {review}
               visible={activeLeftRailTab === "annotations" && leftTabs.includes("annotations")}
             />
             <PanelSlot
@@ -924,6 +1030,7 @@ const tutorial = createTutorial(
       onActiveAnnotationChange={(id) => (activeAnnotationId = id)}
       reduceMotion={settingsState.settings.reduceMotion}
       storeReadOnly={yjsSync.storeReadOnly}
+      {review}
       onFilterChange={(type, author, status) => {
         activeAnnotationFilter = { type, author, status };
       }}

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -15,6 +15,7 @@ import CommandPalette from "./components/CommandPalette.svelte";
 import ConnectionBanner from "./components/ConnectionBanner.svelte";
 import CoworkAdminDeclinedModal from "./components/CoworkAdminDeclinedModal.svelte";
 import EmptyState from "./components/EmptyState.svelte";
+import FileOpenDialog from "./components/FileOpenDialog.svelte";
 import HelpModal from "./components/HelpModal.svelte";
 import OnboardingTutorial from "./components/OnboardingTutorial.svelte";
 import PanelSlot from "./components/PanelSlot.svelte";
@@ -39,6 +40,7 @@ import { shouldShowInMode } from "./hooks/useModeGate";
 import { createNotifications } from "./hooks/useNotifications.svelte";
 import { isSettingsShortcut } from "./hooks/useSettingsShortcut.js";
 import { createTabCycleKeyboard } from "./hooks/useTabCycleKeyboard.svelte";
+import { pickTabByDigit, shouldIgnoreShortcut } from "./hooks/useTabKeyboardShortcuts.js";
 import { createTabOrder } from "./hooks/useTabOrder.svelte";
 import { createTandemModeBroadcast } from "./hooks/useTandemModeBroadcast.svelte";
 import { createTandemSettings, TEXT_SIZE_PX, THEME_NEXT } from "./hooks/useTandemSettings.svelte";
@@ -117,6 +119,7 @@ const fileDrop = createFileDrop();
 let settingsOpen = $state(false);
 let settingsBtnEl = $state<HTMLButtonElement | null>(null);
 let paletteOpen = $state(false);
+let fileOpenDialogOpen = $state(false);
 
 function toggleSettings() {
   settingsOpen = !settingsOpen;
@@ -135,6 +138,13 @@ wireActionDeps({
     modeState.setTandemMode(modeState.tandemMode === "solo" ? "tandem" : "solo"),
   // openFindBar wired when PR 570 (find/replace bar) merges into this branch
   openFindBar: () => {},
+  closeActiveTab: () => {
+    const id = yjsSync.activeTabId;
+    if (id) yjsSync.handleTabClose(id);
+  },
+  openFileDialog: () => {
+    fileOpenDialogOpen = true;
+  },
 });
 
 // The authorship plugin reads its initial visibility from localStorage at
@@ -357,6 +367,22 @@ $effect(() => {
         if (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable) return;
         e.preventDefault();
         showHelp = untrack(() => !showHelp);
+      } else if (e.key === "w") {
+        if (shouldIgnoreShortcut(e)) return;
+        e.preventDefault();
+        const id = yjsSync.activeTabId;
+        if (id) yjsSync.handleTabClose(id);
+      } else if (e.key === "o") {
+        if (shouldIgnoreShortcut(e)) return;
+        e.preventDefault();
+        fileOpenDialogOpen = true;
+      } else if (/^Digit[1-9]$/.test(e.code)) {
+        if (shouldIgnoreShortcut(e)) return;
+        const nextId = pickTabByDigit(yjsSync.tabs, Number(e.code.slice(5)));
+        if (nextId) {
+          e.preventDefault();
+          yjsSync.setActiveTabId(nextId);
+        }
       }
     }
     // Ctrl/Cmd+F — focus outline search if the outline panel is visible; fall back to find bar.
@@ -438,6 +464,7 @@ const tutorial = createTutorial(
       onTabClose={yjsSync.handleTabClose}
       reorder={tabOrder.reorder}
       reduceMotion={settingsState.settings.reduceMotion}
+      onRequestOpenDialog={() => { fileOpenDialogOpen = true; }}
     />
 
     <FormattingBar
@@ -572,6 +599,10 @@ const tutorial = createTutorial(
     />
 
     <HelpModal open={showHelp} onClose={() => (showHelp = false)} />
+
+    {#if fileOpenDialogOpen}
+      <FileOpenDialog onClose={() => (fileOpenDialogOpen = false)} />
+    {/if}
 
     <CommandPalette
       open={paletteOpen}

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -173,6 +173,8 @@ wireActionDeps({
   openFileDialog: () => {
     fileOpenDialogOpen = true;
   },
+  toggleLeftPanel: () => toggleLeftPanel(),
+  toggleRightPanel: () => toggleRightPanel(),
 });
 
 // The authorship plugin reads its initial visibility from localStorage at
@@ -412,6 +414,15 @@ $effect(() => {
           e.preventDefault();
           yjsSync.setActiveTabId(nextId);
         }
+      } else if (e.shiftKey && (e.key === "m" || e.key === "M")) {
+        if (shouldIgnoreShortcut(e)) return;
+        e.preventDefault();
+        modeState.setTandemMode(modeState.tandemMode === "solo" ? "tandem" : "solo");
+      } else if (e.code === "Backslash") {
+        if (shouldIgnoreShortcut(e)) return;
+        e.preventDefault();
+        if (e.shiftKey) toggleRightPanel();
+        else toggleLeftPanel();
       }
     }
     // Ctrl/Cmd+F — focus outline search if outline panel visible; else open find bar (doc scope).

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -98,14 +98,34 @@ async function reopenClosedTab() {
   }
   if (inflightReopens.has(rec.filePath)) return;
   inflightReopens.add(rec.filePath);
+  const handleFailure = (reason: string) => {
+    // Restore the record so the user can retry with another Ctrl+Alt+T;
+    // silent drop would also surprise users who expect LIFO to be retryable.
+    closedTabStack.push(rec);
+    const basename = rec.filePath.split(/[\\/]/).pop() || rec.filePath;
+    notifications.push({
+      id: `reopen-failed-${Date.now()}`,
+      type: "general-error",
+      severity: "error",
+      message: `Couldn't reopen ${basename}: ${reason}`,
+      dedupKey: `reopen-failed:${rec.filePath}`,
+      timestamp: Date.now(),
+    });
+  };
   try {
-    await fetch(`${API_BASE}${API_OPEN}`, {
+    const response = await fetch(`${API_BASE}${API_OPEN}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ filePath: rec.filePath }),
     });
+    if (!response.ok) {
+      // fetch() only rejects on network errors — server-side 4xx/5xx never
+      // throw. Without this branch, the record was silently dropped on a
+      // failed reopen and the toast never fired.
+      handleFailure(`server returned ${response.status}`);
+    }
   } catch (err) {
-    console.warn("[tandem] reopen closed tab failed:", err);
+    handleFailure(err instanceof Error ? err.message : "network error");
   } finally {
     inflightReopens.delete(rec.filePath);
   }
@@ -454,22 +474,29 @@ $effect(() => {
       return;
     }
     if (e.ctrlKey || e.metaKey) {
-      if (e.key === "a") {
+      // Letter shortcuts use `e.code` ("KeyA" etc.) instead of `e.key` so they
+      // remain layout-independent on Dvorak/AZERTY AND fire correctly on macOS
+      // when Option is held (Option+letter produces alt characters like "†"/"µ"
+      // that don't match e.key === "t" or "m"). Digit-1..9 already used e.code;
+      // Backslash already used e.code; Enter is layout-stable and stays on
+      // e.key. Shift/Alt modifier discrimination is explicit so intent is on
+      // the page (e.g. Ctrl+M vs Ctrl+Shift+M).
+      if (e.code === "KeyA" && !e.altKey && !e.shiftKey) {
         const active = document.activeElement;
         if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) return;
         if (active?.closest?.(".ProseMirror")) return;
         e.preventDefault();
         editor?.commands.selectAll();
-      } else if (e.key === "s") {
+      } else if (e.code === "KeyS") {
         e.preventDefault();
         void triggerSave(yjsSync.activeTabId);
       } else if (isSettingsShortcut(e)) {
         e.preventDefault();
         settingsOpen = true;
-      } else if (e.shiftKey && e.key === "P") {
+      } else if (e.shiftKey && e.code === "KeyP") {
         e.preventDefault();
         paletteOpen = !untrack(() => paletteOpen);
-      } else if (e.key === "n") {
+      } else if (e.code === "KeyN") {
         const el = e.target as HTMLElement;
         if (el.tagName === "INPUT" || el.tagName === "TEXTAREA") return;
         e.preventDefault();
@@ -479,12 +506,12 @@ $effect(() => {
         if (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable) return;
         e.preventDefault();
         showHelp = untrack(() => !showHelp);
-      } else if (e.key === "w") {
+      } else if (e.code === "KeyW") {
         if (shouldIgnoreShortcut(e)) return;
         e.preventDefault();
         const id = yjsSync.activeTabId;
         if (id) closeTabAndRecord(id);
-      } else if (e.key === "o") {
+      } else if (e.code === "KeyO") {
         if (shouldIgnoreShortcut(e)) return;
         e.preventDefault();
         fileOpenDialogOpen = true;
@@ -495,7 +522,7 @@ $effect(() => {
           e.preventDefault();
           yjsSync.setActiveTabId(nextId);
         }
-      } else if (e.shiftKey && (e.key === "m" || e.key === "M")) {
+      } else if (e.shiftKey && !e.altKey && e.code === "KeyM") {
         if (shouldIgnoreShortcut(e)) return;
         e.preventDefault();
         modeState.setTandemMode(modeState.tandemMode === "solo" ? "tandem" : "solo");
@@ -504,7 +531,7 @@ $effect(() => {
         e.preventDefault();
         if (e.shiftKey) toggleRightPanel();
         else toggleLeftPanel();
-      } else if (e.altKey && (e.key === "t" || e.key === "T")) {
+      } else if (e.altKey && e.code === "KeyT") {
         if (shouldIgnoreShortcut(e)) return;
         e.preventDefault();
         void reopenClosedTab();
@@ -514,7 +541,7 @@ $effect(() => {
     // Ctrl/Cmd+Shift+F — open find bar pre-scoped to "Open tabs" (bypasses outline route).
     // Note: intentionally NOT gated on shouldIgnoreShortcut — Ctrl+F should always
     // claim find behavior to prevent the browser's native find-in-page from firing.
-    if ((e.ctrlKey || e.metaKey) && (e.key === "f" || e.key === "F")) {
+    if ((e.ctrlKey || e.metaKey) && e.code === "KeyF") {
       e.preventDefault();
       if (e.shiftKey) {
         findBarForceScope = "tabs";
@@ -533,7 +560,7 @@ $effect(() => {
     }
     // Ctrl/Cmd+G — find next; Ctrl/Cmd+Shift+G — find previous.
     // With no active query, fall back to opening the find bar.
-    if ((e.ctrlKey || e.metaKey) && (e.key === "g" || e.key === "G")) {
+    if ((e.ctrlKey || e.metaKey) && e.code === "KeyG") {
       if (shouldIgnoreShortcut(e)) return;
       e.preventDefault();
       const ed = editor;
@@ -592,14 +619,59 @@ $effect(() => {
     // whatever text is currently selected in the editor. Intentionally NOT
     // gated on shouldIgnoreShortcut: contenteditable focus is the common case
     // (user has selected text in the editor) and we want this to fire there.
-    if ((e.ctrlKey || e.metaKey) && e.altKey && (e.key === "m" || e.key === "M")) {
+    //
+    // Three orthogonal preconditions gate the popup; branch feedback so a
+    // disabled-setting toast doesn't misfire when the real cause is "no
+    // selection" or "read-only doc". Suppression from palette/find is silent
+    // — the user is already in a different UI context.
+    if ((e.ctrlKey || e.metaKey) && e.altKey && e.code === "KeyM") {
       e.preventDefault();
+      const hasSelection = !!editor && editor.state.selection.from !== editor.state.selection.to;
+      const reviewOnly = activeTab?.readOnly === true;
+      const popupSuppressed = slashCommandMenuOpen || findBarOpen || paletteOpen;
+      if (popupSuppressed) {
+        // Palette/find UI is the active context; user understands why.
+        return;
+      }
+      if (!hasSelection) {
+        notifications.push({
+          id: `comment-shortcut-no-selection-${Date.now()}`,
+          type: "general-error",
+          severity: "info",
+          message: "Select text to comment",
+          dedupKey: "comment-shortcut-no-selection",
+          timestamp: Date.now(),
+        });
+        return;
+      }
+      if (reviewOnly) {
+        notifications.push({
+          id: `comment-shortcut-readonly-${Date.now()}`,
+          type: "general-error",
+          severity: "info",
+          message: "Document is read-only",
+          dedupKey: "comment-shortcut-readonly",
+          timestamp: Date.now(),
+        });
+        return;
+      }
+      if (!settingsState.settings.selectionToolbar) {
+        notifications.push({
+          id: `comment-shortcut-toolbar-off-${Date.now()}`,
+          type: "general-error",
+          severity: "info",
+          message: "Enable selection toolbar in Settings to comment via keyboard",
+          dedupKey: "comment-shortcut-toolbar-off",
+          timestamp: Date.now(),
+        });
+        return;
+      }
       commentFocusTrigger += 1;
       return;
     }
     // Alt+L — select the containing block (paragraph / heading / list item).
     // Chosen over Ctrl+L to avoid the browser address-bar conflict in dev mode.
-    if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey && (e.key === "l" || e.key === "L")) {
+    if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey && e.code === "KeyL") {
       if (shouldIgnoreShortcut(e)) return;
       e.preventDefault();
       if (editor) editor.chain().focus().selectParentNode().run();
@@ -607,7 +679,7 @@ $effect(() => {
     }
     // Ctrl/Cmd+Alt+A — toggle authorship colors. Works even when focus is in
     // a form input (it's a global UI preference, not a contextual action).
-    if ((e.ctrlKey || e.metaKey) && e.altKey && (e.key === "a" || e.key === "A")) {
+    if ((e.ctrlKey || e.metaKey) && e.altKey && e.code === "KeyA") {
       e.preventDefault();
       settingsState.updateSettings({
         showAuthorship: !settingsState.settings.showAuthorship,

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -26,6 +26,7 @@ import { isTauriRuntime } from "./cowork/cowork-helpers";
 import DocxPageContainer from "./editor/DocxPageContainer.svelte";
 import Editor from "./editor/Editor.svelte";
 import { authorshipPluginKey } from "./editor/extensions/authorship";
+import { getFindState } from "./editor/extensions/find-replace.js";
 import FindReplaceBar from "./editor/find-replace/FindReplaceBar.svelte";
 import Toolbar from "./editor/toolbar/Toolbar.svelte";
 import { createAccentHue } from "./hooks/useAccentHue.svelte";
@@ -35,6 +36,7 @@ import { createDensity } from "./hooks/useDensity.svelte";
 import { createDragResize } from "./hooks/useDragResize.svelte";
 import { createRootEditorFont } from "./hooks/useEditorFont.svelte";
 import { createFileDrop } from "./hooks/useFileDrop.svelte";
+import { shouldDispatchFindNav } from "./hooks/useFindShortcuts.js";
 import { createHighContrast } from "./hooks/useHighContrast.svelte";
 import { shouldShowInMode } from "./hooks/useModeGate";
 import { createNotifications } from "./hooks/useNotifications.svelte";
@@ -136,8 +138,34 @@ wireActionDeps({
   openSettings: () => (settingsOpen = true),
   toggleSoloMode: () =>
     modeState.setTandemMode(modeState.tandemMode === "solo" ? "tandem" : "solo"),
-  // openFindBar wired when PR 570 (find/replace bar) merges into this branch
-  openFindBar: () => {},
+  openFindBar: () => {
+    findBarForceScope = "doc";
+    findBarOpen = true;
+  },
+  openFindBarTabs: () => {
+    findBarForceScope = "tabs";
+    findBarOpen = true;
+  },
+  findNext: () => {
+    const ed = editor;
+    const findState = ed ? getFindState(ed.state) : undefined;
+    if (ed && shouldDispatchFindNav(findState)) {
+      ed.commands.findNext();
+    } else {
+      findBarForceScope = "doc";
+      findBarOpen = true;
+    }
+  },
+  findPrev: () => {
+    const ed = editor;
+    const findState = ed ? getFindState(ed.state) : undefined;
+    if (ed && shouldDispatchFindNav(findState)) {
+      ed.commands.findPrev();
+    } else {
+      findBarForceScope = "doc";
+      findBarOpen = true;
+    }
+  },
   closeActiveTab: () => {
     const id = yjsSync.activeTabId;
     if (id) yjsSync.handleTabClose(id);
@@ -221,6 +249,7 @@ let capturedAnchor = $state<CapturedAnchor | null>(null);
 let editor = $state<TiptapEditor | null>(null);
 let slashCommandMenuOpen = $state(false);
 let findBarOpen = $state(false);
+let findBarForceScope = $state<"doc" | "tabs">("doc");
 let outlineFocusTrigger = $state(0);
 let activeAnnotationFilter = $state<{
   type: FilterType;
@@ -385,15 +414,39 @@ $effect(() => {
         }
       }
     }
-    // Ctrl/Cmd+F — focus outline search if the outline panel is visible; fall back to find bar.
-    if ((e.ctrlKey || e.metaKey) && e.key === "f") {
+    // Ctrl/Cmd+F — focus outline search if outline panel visible; else open find bar (doc scope).
+    // Ctrl/Cmd+Shift+F — open find bar pre-scoped to "Open tabs" (bypasses outline route).
+    // Note: intentionally NOT gated on shouldIgnoreShortcut — Ctrl+F should always
+    // claim find behavior to prevent the browser's native find-in-page from firing.
+    if ((e.ctrlKey || e.metaKey) && (e.key === "f" || e.key === "F")) {
       e.preventDefault();
+      if (e.shiftKey) {
+        findBarForceScope = "tabs";
+        findBarOpen = true;
+        return;
+      }
       const isOutlineVisible =
         (effectiveLeftVisible && activeLeftRailTab === "outline") ||
         (effectiveRightVisible && activeRailTab === "outline");
       if (isOutlineVisible) {
         outlineFocusTrigger += 1;
       } else {
+        findBarForceScope = "doc";
+        findBarOpen = true;
+      }
+    }
+    // Ctrl/Cmd+G — find next; Ctrl/Cmd+Shift+G — find previous.
+    // With no active query, fall back to opening the find bar.
+    if ((e.ctrlKey || e.metaKey) && (e.key === "g" || e.key === "G")) {
+      if (shouldIgnoreShortcut(e)) return;
+      e.preventDefault();
+      const ed = editor;
+      const findState = ed ? getFindState(ed.state) : undefined;
+      if (ed && shouldDispatchFindNav(findState)) {
+        if (e.shiftKey) ed.commands.findPrev();
+        else ed.commands.findNext();
+      } else {
+        findBarForceScope = "doc";
         findBarOpen = true;
       }
     }
@@ -726,6 +779,7 @@ const tutorial = createTutorial(
       open={findBarOpen}
       onClose={() => (findBarOpen = false)}
       tabs={yjsSync.tabs}
+      forceScope={findBarForceScope}
     />
   </div>
 {/snippet}

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -250,6 +250,11 @@ wireActionDeps({
     const cur = modeGate.visibleAnnotations.find((a) => a.id === activeAnnotationId);
     if (cur && cur.author !== "user") review.handleDismiss(cur.id);
   },
+  selectBlock: () => editor?.chain().focus().selectParentNode().run(),
+  toggleAuthorship: () =>
+    settingsState.updateSettings({
+      showAuthorship: !settingsState.settings.showAuthorship,
+    }),
 });
 
 // The authorship plugin reads its initial visibility from localStorage at
@@ -590,6 +595,23 @@ $effect(() => {
     if ((e.ctrlKey || e.metaKey) && e.altKey && (e.key === "m" || e.key === "M")) {
       e.preventDefault();
       commentFocusTrigger += 1;
+      return;
+    }
+    // Alt+L — select the containing block (paragraph / heading / list item).
+    // Chosen over Ctrl+L to avoid the browser address-bar conflict in dev mode.
+    if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey && (e.key === "l" || e.key === "L")) {
+      if (shouldIgnoreShortcut(e)) return;
+      e.preventDefault();
+      if (editor) editor.chain().focus().selectParentNode().run();
+      return;
+    }
+    // Ctrl/Cmd+Alt+A — toggle authorship colors. Works even when focus is in
+    // a form input (it's a global UI preference, not a contextual action).
+    if ((e.ctrlKey || e.metaKey) && e.altKey && (e.key === "a" || e.key === "A")) {
+      e.preventDefault();
+      settingsState.updateSettings({
+        showAuthorship: !settingsState.settings.showAuthorship,
+      });
       return;
     }
   }

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -21,7 +21,10 @@ interface ActionDeps {
   getActiveTabId: () => string | null;
   openSettings: () => void;
   toggleSoloMode: () => void;
-  openFindBar: () => void; // wired when find/replace bar (PR 570) merges
+  openFindBar: () => void;
+  openFindBarTabs: () => void;
+  findNext: () => void;
+  findPrev: () => void;
   closeActiveTab: () => void;
   openFileDialog: () => void;
 }
@@ -154,6 +157,42 @@ const BUILTINS: Action[] = [
     shortcut: "Ctrl+O",
     run() {
       guardedRun("open-file", (d) => d.openFileDialog());
+    },
+  },
+  {
+    id: "find",
+    label: "Find / Replace",
+    group: "navigation",
+    shortcut: "Ctrl+F",
+    run() {
+      guardedRun("find", (d) => d.openFindBar());
+    },
+  },
+  {
+    id: "find-in-tabs",
+    label: "Find in open tabs",
+    group: "navigation",
+    shortcut: "Ctrl+Shift+F",
+    run() {
+      guardedRun("find-in-tabs", (d) => d.openFindBarTabs());
+    },
+  },
+  {
+    id: "find-next",
+    label: "Find next match",
+    group: "navigation",
+    shortcut: "Ctrl+G",
+    run() {
+      guardedRun("find-next", (d) => d.findNext());
+    },
+  },
+  {
+    id: "find-previous",
+    label: "Find previous match",
+    group: "navigation",
+    shortcut: "Ctrl+Shift+G",
+    run() {
+      guardedRun("find-previous", (d) => d.findPrev());
     },
   },
 ];

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -30,6 +30,10 @@ interface ActionDeps {
   toggleLeftPanel: () => void;
   toggleRightPanel: () => void;
   reopenClosedTab: () => void;
+  annotationNext: () => void;
+  annotationPrev: () => void;
+  annotationAccept: () => void;
+  annotationDismiss: () => void;
 }
 
 let deps: ActionDeps | null = null;
@@ -226,6 +230,46 @@ const BUILTINS: Action[] = [
       guardedRun("reopen-closed-tab", (d) => d.reopenClosedTab());
     },
   },
+  {
+    id: "annotation-next",
+    label: "Next annotation",
+    group: "annotations",
+    shortcut: "Alt+]",
+    run() {
+      guardedRun("annotation-next", (d) => d.annotationNext());
+    },
+  },
+  {
+    id: "annotation-previous",
+    label: "Previous annotation",
+    group: "annotations",
+    shortcut: "Alt+[",
+    run() {
+      guardedRun("annotation-previous", (d) => d.annotationPrev());
+    },
+  },
+  {
+    id: "annotation-accept",
+    label: "Accept focused annotation",
+    group: "annotations",
+    shortcut: "Ctrl+Enter",
+    run() {
+      guardedRun("annotation-accept", (d) => d.annotationAccept());
+    },
+  },
+  {
+    id: "annotation-dismiss",
+    label: "Dismiss focused annotation",
+    group: "annotations",
+    shortcut: "Ctrl+Shift+Enter",
+    run() {
+      guardedRun("annotation-dismiss", (d) => d.annotationDismiss());
+    },
+  },
+  // Note: comment-on-selection (Ctrl+Alt+M) is intentionally NOT registered as
+  // a palette action — opening the palette collapses the editor selection
+  // (focus moves to palette input), so a palette-invoked "comment on selection"
+  // would always fire with no selection. Static row in static-shortcuts.ts.
 ];
 
 for (const action of BUILTINS) {

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -34,6 +34,8 @@ interface ActionDeps {
   annotationPrev: () => void;
   annotationAccept: () => void;
   annotationDismiss: () => void;
+  selectBlock: () => void;
+  toggleAuthorship: () => void;
 }
 
 let deps: ActionDeps | null = null;
@@ -270,6 +272,24 @@ const BUILTINS: Action[] = [
   // a palette action — opening the palette collapses the editor selection
   // (focus moves to palette input), so a palette-invoked "comment on selection"
   // would always fire with no selection. Static row in static-shortcuts.ts.
+  {
+    id: "select-block",
+    label: "Select containing block",
+    group: "editor",
+    shortcut: "Alt+L",
+    run() {
+      guardedRun("select-block", (d) => d.selectBlock());
+    },
+  },
+  {
+    id: "toggle-authorship",
+    label: "Toggle authorship colors",
+    group: "view",
+    shortcut: "Ctrl+Alt+A",
+    run() {
+      guardedRun("toggle-authorship", (d) => d.toggleAuthorship());
+    },
+  },
 ];
 
 for (const action of BUILTINS) {

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -22,6 +22,8 @@ interface ActionDeps {
   openSettings: () => void;
   toggleSoloMode: () => void;
   openFindBar: () => void; // wired when find/replace bar (PR 570) merges
+  closeActiveTab: () => void;
+  openFileDialog: () => void;
 }
 
 let deps: ActionDeps | null = null;
@@ -134,6 +136,24 @@ const BUILTINS: Action[] = [
     shortcut: "Ctrl+N",
     run() {
       void createScratchpad();
+    },
+  },
+  {
+    id: "close-tab",
+    label: "Close active tab",
+    group: "document",
+    shortcut: "Ctrl+W",
+    run() {
+      guardedRun("close-tab", (d) => d.closeActiveTab());
+    },
+  },
+  {
+    id: "open-file",
+    label: "Open file…",
+    group: "document",
+    shortcut: "Ctrl+O",
+    run() {
+      guardedRun("open-file", (d) => d.openFileDialog());
     },
   },
 ];

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -27,6 +27,8 @@ interface ActionDeps {
   findPrev: () => void;
   closeActiveTab: () => void;
   openFileDialog: () => void;
+  toggleLeftPanel: () => void;
+  toggleRightPanel: () => void;
 }
 
 let deps: ActionDeps | null = null;
@@ -128,6 +130,7 @@ const BUILTINS: Action[] = [
     id: "toggle-mode",
     label: "Toggle Solo / Tandem mode",
     group: "document",
+    shortcut: "Ctrl+Shift+M",
     run() {
       guardedRun("toggle-mode", (d) => d.toggleSoloMode());
     },
@@ -193,6 +196,24 @@ const BUILTINS: Action[] = [
     shortcut: "Ctrl+Shift+G",
     run() {
       guardedRun("find-previous", (d) => d.findPrev());
+    },
+  },
+  {
+    id: "toggle-left-panel",
+    label: "Toggle left panel",
+    group: "view",
+    shortcut: "Ctrl+\\",
+    run() {
+      guardedRun("toggle-left-panel", (d) => d.toggleLeftPanel());
+    },
+  },
+  {
+    id: "toggle-right-panel",
+    label: "Toggle right panel",
+    group: "view",
+    shortcut: "Ctrl+Shift+\\",
+    run() {
+      guardedRun("toggle-right-panel", (d) => d.toggleRightPanel());
     },
   },
 ];

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -29,6 +29,7 @@ interface ActionDeps {
   openFileDialog: () => void;
   toggleLeftPanel: () => void;
   toggleRightPanel: () => void;
+  reopenClosedTab: () => void;
 }
 
 let deps: ActionDeps | null = null;
@@ -214,6 +215,15 @@ const BUILTINS: Action[] = [
     shortcut: "Ctrl+Shift+\\",
     run() {
       guardedRun("toggle-right-panel", (d) => d.toggleRightPanel());
+    },
+  },
+  {
+    id: "reopen-closed-tab",
+    label: "Reopen closed tab (this session)",
+    group: "document",
+    shortcut: "Ctrl+Alt+T",
+    run() {
+      guardedRun("reopen-closed-tab", (d) => d.reopenClosedTab());
     },
   },
 ];

--- a/src/client/actions/registry.svelte.ts
+++ b/src/client/actions/registry.svelte.ts
@@ -12,7 +12,7 @@
  * ADR-029 (docs/decisions.md) records the design rationale.
  */
 
-export const ACTION_GROUPS = ["editor", "navigation", "view", "document"] as const;
+export const ACTION_GROUPS = ["editor", "navigation", "view", "document", "annotations"] as const;
 export type ActionGroup = (typeof ACTION_GROUPS)[number];
 
 export interface Action {

--- a/src/client/actions/static-shortcuts.ts
+++ b/src/client/actions/static-shortcuts.ts
@@ -8,4 +8,5 @@ export const STATIC_SHORTCUT_ROWS = [
   { keys: "Ctrl+Tab", description: "Next document tab" },
   { keys: "Ctrl+Shift+Tab", description: "Previous document tab" },
   { keys: "Ctrl+1 – Ctrl+9", description: "Jump to tab by number" },
+  { keys: "Ctrl+Alt+M", description: "Comment on selection (in editor)" },
 ] as const;

--- a/src/client/actions/static-shortcuts.ts
+++ b/src/client/actions/static-shortcuts.ts
@@ -8,4 +8,5 @@ export const STATIC_SHORTCUT_ROWS = [
   { keys: "? or Ctrl+/", description: "Show keyboard shortcuts" },
   { keys: "Ctrl+Tab", description: "Next document tab" },
   { keys: "Ctrl+Shift+Tab", description: "Previous document tab" },
+  { keys: "Ctrl+1 – Ctrl+9", description: "Jump to tab by number" },
 ] as const;

--- a/src/client/actions/static-shortcuts.ts
+++ b/src/client/actions/static-shortcuts.ts
@@ -3,7 +3,6 @@ export const STATIC_SHORTCUT_ROWS = [
   { keys: "Ctrl+I", description: "Italic" },
   { keys: "Ctrl+Z", description: "Undo" },
   { keys: "Ctrl+Y", description: "Redo" },
-  { keys: "Ctrl+F", description: "Find / Replace" },
   { keys: "Ctrl+N", description: "New scratchpad" },
   { keys: "? or Ctrl+/", description: "Show keyboard shortcuts" },
   { keys: "Ctrl+Tab", description: "Next document tab" },

--- a/src/client/actions/static-shortcuts.ts
+++ b/src/client/actions/static-shortcuts.ts
@@ -9,4 +9,10 @@ export const STATIC_SHORTCUT_ROWS = [
   { keys: "Ctrl+Shift+Tab", description: "Previous document tab" },
   { keys: "Ctrl+1 – Ctrl+9", description: "Jump to tab by number" },
   { keys: "Ctrl+Alt+M", description: "Comment on selection (in editor)" },
+  { keys: "Ctrl+Alt+1", description: "Heading 1" },
+  { keys: "Ctrl+Alt+2", description: "Heading 2" },
+  { keys: "Ctrl+Alt+3", description: "Heading 3" },
+  { keys: "Ctrl+Alt+4", description: "Heading 4" },
+  { keys: "Ctrl+Alt+5", description: "Heading 5" },
+  { keys: "Ctrl+Alt+6", description: "Heading 6" },
 ] as const;

--- a/src/client/editor/find-replace/FindReplaceBar.svelte
+++ b/src/client/editor/find-replace/FindReplaceBar.svelte
@@ -22,9 +22,10 @@ interface Props {
   open: boolean;
   onClose: () => void;
   tabs?: OpenTab[];
+  forceScope?: "doc" | "tabs";
 }
 
-let { editor, open, onClose, tabs = [] }: Props = $props();
+let { editor, open, onClose, tabs = [], forceScope }: Props = $props();
 
 type Scope = "doc" | "tabs";
 let scope = $state<Scope>("doc");
@@ -138,6 +139,21 @@ let queryInput = $state<HTMLInputElement | null>(null);
 $effect(() => {
   if (!open) return;
   queryInput?.focus();
+});
+
+// Apply forceScope on the false→true open transition. Plain `let` (not $state)
+// so the effect doesn't track this read; the `open` change is the only trigger.
+let prevOpenForScope = false;
+$effect(() => {
+  const isOpening = open && !prevOpenForScope;
+  prevOpenForScope = open;
+  if (!isOpening || !forceScope) return;
+  if (forceScope === "tabs" && tabs.length > 1) {
+    scope = "tabs";
+    scheduleCrossDocSearch(query, caseSensitive);
+  } else {
+    scope = "doc";
+  }
 });
 
 $effect(() => {

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -168,6 +168,9 @@ $effect(() => {
 
 // Counter-trigger from App.svelte's Ctrl+Alt+M handler. Captures the current
 // editor selection and focuses the textarea once Svelte commits the popup DOM.
+// Plain `let`, not `$state` — only `requestCommentFocus` is reactive. Tracking
+// the cursor in $state would create a self-triggering effect loop (the $effect
+// writes to the cursor inside its own reactive scope on every fire).
 let lastSeenCommentTrigger = 0;
 $effect(() => {
   if (requestCommentFocus === lastSeenCommentTrigger) return;

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -24,9 +24,21 @@ interface Props {
   ydoc: Y.Doc | null;
   selectionToolbar?: boolean;
   suppressSelectionToolbar?: boolean;
+  /**
+   * Counter prop — when it changes, the comment popup is shown (if there's a
+   * non-empty editor selection) and focus moves to its textarea. Used by the
+   * Ctrl+Alt+M global shortcut in App.svelte.
+   */
+  requestCommentFocus?: number;
 }
 
-let { editor, ydoc, selectionToolbar = true, suppressSelectionToolbar = false }: Props = $props();
+let {
+  editor,
+  ydoc,
+  selectionToolbar = true,
+  suppressSelectionToolbar = false,
+  requestCommentFocus = 0,
+}: Props = $props();
 
 let hasSelection = $state(false);
 let selectionPosition = $state<{ left: number; top: number } | null>(null);
@@ -152,6 +164,19 @@ $effect(() => {
     // Only clear draft text if user isn't actively typing (prevents resize-glitch data loss)
     if (document.activeElement !== textareaEl) annotationText = "";
   }
+});
+
+// Counter-trigger from App.svelte's Ctrl+Alt+M handler. Captures the current
+// editor selection and focuses the textarea once Svelte commits the popup DOM.
+let lastSeenCommentTrigger = 0;
+$effect(() => {
+  if (requestCommentFocus === lastSeenCommentTrigger) return;
+  lastSeenCommentTrigger = requestCommentFocus;
+  if (requestCommentFocus === 0 || !editor) return;
+  const { from, to } = editor.state.selection;
+  if (from === to) return; // No selection → no-op
+  untrack(() => captureSelectionRange());
+  requestAnimationFrame(() => textareaEl?.focus());
 });
 
 $effect(() => {

--- a/src/client/hooks/useAnnotationOrder.ts
+++ b/src/client/hooks/useAnnotationOrder.ts
@@ -1,0 +1,49 @@
+import type { Annotation } from "../../shared/types";
+
+/** Stable order: by `range.from` ASC; ties broken by `id` (string compare) for determinism. */
+export function sortAnnotationsByPosition(anns: ReadonlyArray<Annotation>): Annotation[] {
+  return [...anns].sort((a, b) => {
+    const da = a.range.from - b.range.from;
+    if (da !== 0) return da;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+/** Index of `currentId` in `sorted`; -1 if not present (or `currentId` is null). */
+export function indexOfId(sorted: ReadonlyArray<Annotation>, currentId: string | null): number {
+  if (!currentId) return -1;
+  for (let i = 0; i < sorted.length; i++) {
+    if (sorted[i].id === currentId) return i;
+  }
+  return -1;
+}
+
+/**
+ * Returns the id of the annotation AFTER `currentId` (wrapping last → first).
+ * If `currentId` is null OR not found, returns the FIRST annotation.
+ * Returns null if `sorted` is empty.
+ */
+export function nextAnnotationId(
+  sorted: ReadonlyArray<Annotation>,
+  currentId: string | null,
+): string | null {
+  if (sorted.length === 0) return null;
+  const idx = indexOfId(sorted, currentId);
+  if (idx === -1) return sorted[0].id;
+  return sorted[(idx + 1) % sorted.length].id;
+}
+
+/**
+ * Returns the id of the annotation BEFORE `currentId` (wrapping first → last).
+ * If `currentId` is null OR not found, returns the LAST annotation.
+ * Returns null if `sorted` is empty.
+ */
+export function prevAnnotationId(
+  sorted: ReadonlyArray<Annotation>,
+  currentId: string | null,
+): string | null {
+  if (sorted.length === 0) return null;
+  const idx = indexOfId(sorted, currentId);
+  if (idx === -1) return sorted[sorted.length - 1].id;
+  return sorted[(idx - 1 + sorted.length) % sorted.length].id;
+}

--- a/src/client/hooks/useClosedTabStack.ts
+++ b/src/client/hooks/useClosedTabStack.ts
@@ -1,0 +1,45 @@
+/**
+ * Tracks user-closed tabs in an in-memory LIFO so Ctrl+Alt+T can reopen them.
+ *
+ * Pure module — no Svelte runes. The only consumer is the App-level keydown
+ * handler which reads on demand; there's no UI surface that needs reactive
+ * size/peek today. If a "Recently closed tabs" submenu is ever added, promote
+ * to a `.svelte.ts` factory backed by `$state`.
+ *
+ * Lifetime is in-memory only; resets on page reload. Acceptable for v1 — the
+ * action label is "Reopen closed tab (this session)" so the bound is clear.
+ */
+
+export interface ClosedTabRecord {
+  filePath: string;
+  closedAt: number;
+}
+
+const DEFAULT_CAP = 25;
+
+export function createClosedTabStack(cap = DEFAULT_CAP) {
+  const stack: ClosedTabRecord[] = [];
+  return {
+    push(rec: ClosedTabRecord) {
+      // Dedup at the head so closing the same tab twice doesn't pollute the
+      // history with consecutive duplicates.
+      if (stack.length && stack[stack.length - 1].filePath === rec.filePath) return;
+      stack.push(rec);
+      while (stack.length > cap) stack.shift();
+    },
+    pop(): ClosedTabRecord | null {
+      return stack.pop() ?? null;
+    },
+    peek(): ClosedTabRecord | null {
+      return stack.length ? stack[stack.length - 1] : null;
+    },
+    size(): number {
+      return stack.length;
+    },
+    clear() {
+      stack.length = 0;
+    },
+  };
+}
+
+export type ClosedTabStack = ReturnType<typeof createClosedTabStack>;

--- a/src/client/hooks/useFindShortcuts.ts
+++ b/src/client/hooks/useFindShortcuts.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns true if the find bar has an active query and Ctrl+G / Ctrl+Shift+G
+ * should dispatch find-next / find-prev. When false, the caller should open the
+ * find bar instead.
+ */
+export function shouldDispatchFindNav(state: { query: string } | null | undefined): boolean {
+  return !!state?.query;
+}

--- a/src/client/hooks/useNotifications.svelte.ts
+++ b/src/client/hooks/useNotifications.svelte.ts
@@ -10,6 +10,13 @@ export interface Toast extends TandemNotification {
 export interface NotificationsState {
   readonly toasts: Toast[];
   dismiss: (id: string) => void;
+  /**
+   * Surface a client-originated toast (not delivered via SSE). Use for
+   * ephemeral UI feedback like "couldn't reopen file" or "enable setting to
+   * use this shortcut" — places where console.warn would land in devtools
+   * the user never opens.
+   */
+  push: (notification: TandemNotification) => void;
 }
 
 /**
@@ -49,15 +56,7 @@ export function createNotifications(): NotificationsState {
   const url = `http://localhost:${DEFAULT_MCP_PORT}${API_NOTIFY_STREAM}`;
   const es = new EventSource(url);
 
-  es.onmessage = (event) => {
-    let notification: TandemNotification;
-    try {
-      notification = JSON.parse(event.data) as TandemNotification;
-    } catch {
-      console.warn("[useNotifications] Malformed SSE data:", event.data);
-      return;
-    }
-
+  const ingest = (notification: TandemNotification) => {
     // Dedup: if incoming has a dedupKey matching an existing toast, replace and increment count
     if (notification.dedupKey) {
       const existingIdx = toasts.findIndex((t) => t.dedupKey === notification.dedupKey);
@@ -86,6 +85,17 @@ export function createNotifications(): NotificationsState {
     scheduleDismiss(newToast.id, newToast.severity);
   };
 
+  es.onmessage = (event) => {
+    let notification: TandemNotification;
+    try {
+      notification = JSON.parse(event.data) as TandemNotification;
+    } catch {
+      console.warn("[useNotifications] Malformed SSE data:", event.data);
+      return;
+    }
+    ingest(notification);
+  };
+
   es.onerror = () => {
     if (es.readyState === EventSource.CLOSED) {
       console.warn(
@@ -108,5 +118,6 @@ export function createNotifications(): NotificationsState {
       return toasts;
     },
     dismiss,
+    push: ingest,
   };
 }

--- a/src/client/hooks/useTabKeyboardShortcuts.ts
+++ b/src/client/hooks/useTabKeyboardShortcuts.ts
@@ -1,0 +1,15 @@
+/** Map digit 1-9 to tab id, clamping to the last tab when fewer tabs are open. */
+export function pickTabByDigit(tabs: ReadonlyArray<{ id: string }>, digit: number): string | null {
+  if (tabs.length === 0) return null;
+  if (digit < 1 || digit > 9) return null;
+  const idx = Math.min(digit - 1, tabs.length - 1);
+  return tabs[idx].id;
+}
+
+/** Suppress shortcut firing when focus is in a form field or IME composing. */
+export function shouldIgnoreShortcut(e: Pick<KeyboardEvent, "target" | "isComposing">): boolean {
+  if (e.isComposing) return true;
+  const el = e.target as HTMLElement | null;
+  if (!el) return false;
+  return el.tagName === "INPUT" || el.tagName === "TEXTAREA";
+}

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -14,7 +14,7 @@ import AnnotationCard from "./AnnotationCard.svelte";
 import BulkActions from "./BulkActions.svelte";
 import type { FilterAuthor, FilterStatus, FilterType } from "./FilterBar.svelte";
 import FilterBar from "./FilterBar.svelte";
-import { useAnnotationReview } from "./useAnnotationReview.svelte";
+import type { UseAnnotationReviewReturn } from "./useAnnotationReview.svelte";
 
 interface Props {
   annotations: Annotation[];
@@ -31,11 +31,19 @@ interface Props {
   onFilterChange?: (type: FilterType, author: FilterAuthor, status: FilterStatus) => void;
   /** True when the annotation store is locked by another Tandem instance. */
   storeReadOnly?: boolean;
+  /**
+   * Annotation-review API lifted to App.svelte so there's exactly one
+   * instance across both rails. Provides accept/dismiss/scrollToAnnotation
+   * + getReviewTargets/getActiveReviewAnn for the bulk-confirm UI.
+   */
+  review: UseAnnotationReviewReturn;
 }
 
 let {
   annotations,
-  editor,
+  // editor is part of the public Props for API stability but is now unused
+  // here — App.svelte passes the editor to the lifted useAnnotationReview.
+  editor: _editor,
   ydoc,
   heldCount = 0,
   tandemMode: _tandemMode,
@@ -43,10 +51,13 @@ let {
   activeDocFormat,
   documentId,
   activeAnnotationId,
-  onActiveAnnotationChange,
+  // onActiveAnnotationChange likewise: the lifted review writes activeAnnotationId
+  // directly via App.svelte's setter.
+  onActiveAnnotationChange: _onActiveAnnotationChange,
   reduceMotion,
   onFilterChange,
   storeReadOnly = false,
+  review,
 }: Props = $props();
 
 const scrollBehavior: ScrollBehavior = $derived(reduceMotion ? "auto" : "smooth");
@@ -175,14 +186,8 @@ const hasFilters = $derived(
   filterType !== "all" || filterAuthor !== "all" || filterStatus !== "all",
 );
 
-// useAnnotationReview hook
-const review = useAnnotationReview({
-  getYdoc: () => ydoc,
-  getEditor: () => editor,
-  getAnnotations: () => annotations,
-  onActiveAnnotationChange: (id) => onActiveAnnotationChange(id),
-  getScrollBehavior: () => scrollBehavior,
-});
+// `review` is a prop now (lifted to App.svelte) — see App.svelte for the single
+// useAnnotationReview() instantiation that both rails share.
 
 // Scroll container reset on filter change
 let didMountFilters = false;
@@ -432,7 +437,10 @@ function handleBulk(status: "accepted" | "dismissed") {
   {:else}
   <div style="padding: var(--tandem-space-3); flex: 1;" role="list" aria-label="Annotations">
       {#each filteredData.pending as ann (ann.id)}
-        {@const isTarget = review.getActiveReviewAnn()?.id === ann.id}
+        {@const isTarget =
+          activeAnnotationId !== null
+            ? activeAnnotationId === ann.id
+            : review.getActiveReviewAnn()?.id === ann.id}
         <AnnotationCard
           annotation={ann}
           replies={repliesMap.get(ann.id) ?? []}

--- a/src/client/panels/useAnnotationReview.svelte.ts
+++ b/src/client/panels/useAnnotationReview.svelte.ts
@@ -47,6 +47,14 @@ export interface UseAnnotationReviewParams {
   getAnnotations: () => Annotation[];
   onActiveAnnotationChange: (id: string | null) => void;
   getScrollBehavior: () => ScrollBehavior;
+  /**
+   * Getter for the current active annotation id. The auto-advance effect uses
+   * this to AVOID clobbering an externally-set active id (e.g., from the
+   * Alt+]/Alt+[ keyboard shortcut). Without this, every reactive read of
+   * `getAnnotations()` would re-fire the effect and reset the active id to
+   * `targets[reviewIndex]`.
+   */
+  getActiveAnnotationId?: () => string | null;
 }
 
 export interface UseAnnotationReviewReturn {
@@ -69,6 +77,7 @@ export function useAnnotationReview({
   getAnnotations,
   onActiveAnnotationChange,
   getScrollBehavior,
+  getActiveAnnotationId,
 }: UseAnnotationReviewParams): UseAnnotationReviewReturn {
   // Reactive state
   let reviewIndex = $state(0);
@@ -100,6 +109,11 @@ export function useAnnotationReview({
     const map = y.getMap(Y_MAP_ANNOTATIONS);
     const raw = map.get(id) as Annotation | undefined;
     if (!raw) return;
+    // Idempotency: if the annotation has already been resolved (accepted or
+    // dismissed), no-op. Defends against any future double-fire path —
+    // critically, prevents `applySuggestion` from running twice and inserting
+    // the suggested text twice.
+    if (raw.status !== "pending") return;
     const ann = sanitizeAnnotation(raw, devSanitizeWarn);
     map.set(id, { ...ann, status });
 
@@ -214,10 +228,24 @@ export function useAnnotationReview({
     el?.scrollIntoView({ behavior: getScrollBehavior(), block: "center" });
   }
 
-  // Sync activeAnnotationId when review index changes
+  // Auto-set activeAnnotationId to the bulk-review target (default: first
+  // pending annotation) on initial mount AND whenever the previously-active
+  // annotation goes missing from `targets` (e.g., it was resolved). DOES NOT
+  // clobber an externally-set active id — that's the contract that makes
+  // App.svelte's Alt+]/Alt+[ keyboard nav stick.
   $effect(() => {
     const targets = getReviewTargets();
-    onActiveAnnotationChange(targets[reviewIndex]?.id ?? null);
+    const fallbackId = targets[reviewIndex]?.id ?? null;
+    const currentActive = getActiveAnnotationId?.() ?? null;
+    if (currentActive === null) {
+      onActiveAnnotationChange(fallbackId);
+      return;
+    }
+    // If current active is gone from targets (was resolved or filtered out),
+    // fall back to the bulk-review target. Otherwise leave it alone.
+    if (!targets.some((t) => t.id === currentActive)) {
+      onActiveAnnotationChange(fallbackId);
+    }
   });
 
   // Keep review index in bounds when annotations change

--- a/src/client/svelte-harness/StoreReadOnlyBannerHarness.svelte
+++ b/src/client/svelte-harness/StoreReadOnlyBannerHarness.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import * as Y from "yjs";
 import SidePanel from "../panels/SidePanel.svelte";
+import { useAnnotationReview } from "../panels/useAnnotationReview.svelte";
 
 interface Props {
   storeReadOnly: boolean;
@@ -10,6 +11,16 @@ let { storeReadOnly = $bindable(false) }: Props = $props();
 
 // A real Y.Doc is required — SidePanel's observers don't tolerate null.
 const ydoc = new Y.Doc();
+
+// SidePanel now expects a `review` prop (lifted out of the panel itself).
+// For this harness all the review getters are inert.
+const review = useAnnotationReview({
+  getYdoc: () => ydoc,
+  getEditor: () => null,
+  getAnnotations: () => [],
+  onActiveAnnotationChange: () => {},
+  getScrollBehavior: () => "auto",
+});
 </script>
 
 <SidePanel
@@ -19,4 +30,5 @@ const ydoc = new Y.Doc();
   activeAnnotationId={null}
   onActiveAnnotationChange={() => {}}
   {storeReadOnly}
+  {review}
 />

--- a/src/client/tabs/DocumentTabs.svelte
+++ b/src/client/tabs/DocumentTabs.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { API_OPEN } from "../../shared/api-paths.js";
 import { createScratchpad } from "../actions/builtin.svelte.js";
-import FileOpenDialog from "../components/FileOpenDialog.svelte";
 import type { OpenTab } from "../types.js";
 import { API_BASE } from "../utils/fileUpload.js";
 import { addRecentFile, loadRecentFilesCached, saveRecentFiles } from "../utils/recentFiles.js";
@@ -15,6 +14,7 @@ interface Props {
   onTabClose: (tabId: string) => void;
   reorder?: (fromId: string, toId: string, side?: "left" | "right") => void;
   reduceMotion?: boolean;
+  onRequestOpenDialog?: () => void;
 }
 
 const {
@@ -24,11 +24,11 @@ const {
   onTabClose,
   reorder,
   reduceMotion = false,
+  onRequestOpenDialog,
 }: Props = $props();
 
 const scrollBehavior: ScrollBehavior = $derived(reduceMotion ? "auto" : "smooth");
 
-let showDialog = $state(false);
 let showRecent = $state(false);
 let recentFiles = $state<string[]>([]);
 let openBtnEl: HTMLButtonElement | null = $state(null);
@@ -304,14 +304,10 @@ $effect(() => {
       }}
       onBrowse={() => {
         showRecent = false;
-        showDialog = true;
+        onRequestOpenDialog?.();
       }}
       onClose={() => (showRecent = false)}
     />
-  {/if}
-
-  {#if showDialog}
-    <FileOpenDialog onClose={() => (showDialog = false)} />
   {/if}
 </div>
 

--- a/tests/client/useAnnotationOrder.test.ts
+++ b/tests/client/useAnnotationOrder.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  indexOfId,
+  nextAnnotationId,
+  prevAnnotationId,
+  sortAnnotationsByPosition,
+} from "../../src/client/hooks/useAnnotationOrder.js";
+import type { Annotation } from "../../src/shared/types";
+
+const ann = (id: string, from: number, to = from + 5): Annotation =>
+  ({
+    id,
+    type: "comment",
+    author: "claude",
+    range: { from, to },
+    status: "pending",
+    audience: "outbound",
+    createdAt: 0,
+    body: "",
+    textSnapshot: "",
+  }) as unknown as Annotation;
+
+describe("sortAnnotationsByPosition", () => {
+  it("orders by range.from ascending", () => {
+    const out = sortAnnotationsByPosition([ann("c", 30), ann("a", 10), ann("b", 20)]);
+    expect(out.map((a) => a.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("tie-breaks by id when range.from is equal", () => {
+    const out = sortAnnotationsByPosition([ann("z", 5), ann("a", 5), ann("m", 5)]);
+    expect(out.map((a) => a.id)).toEqual(["a", "m", "z"]);
+  });
+
+  it("returns a new array (input not mutated)", () => {
+    const input = [ann("b", 20), ann("a", 10)];
+    const out = sortAnnotationsByPosition(input);
+    expect(input.map((a) => a.id)).toEqual(["b", "a"]);
+    expect(out.map((a) => a.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("indexOfId", () => {
+  const sorted = [ann("a", 1), ann("b", 2), ann("c", 3)];
+
+  it("returns the index of the matching id", () => {
+    expect(indexOfId(sorted, "b")).toBe(1);
+  });
+
+  it("returns -1 for null currentId", () => {
+    expect(indexOfId(sorted, null)).toBe(-1);
+  });
+
+  it("returns -1 for an unknown id", () => {
+    expect(indexOfId(sorted, "missing")).toBe(-1);
+  });
+});
+
+describe("nextAnnotationId", () => {
+  const sorted = [ann("a", 1), ann("b", 2), ann("c", 3)];
+
+  it("returns the next id in order", () => {
+    expect(nextAnnotationId(sorted, "a")).toBe("b");
+    expect(nextAnnotationId(sorted, "b")).toBe("c");
+  });
+
+  it("wraps from last to first", () => {
+    expect(nextAnnotationId(sorted, "c")).toBe("a");
+  });
+
+  it("returns first annotation when currentId is null", () => {
+    expect(nextAnnotationId(sorted, null)).toBe("a");
+  });
+
+  it("returns first annotation when currentId is not in the list (e.g. resolved)", () => {
+    expect(nextAnnotationId(sorted, "deleted-id")).toBe("a");
+  });
+
+  it("returns null with an empty list", () => {
+    expect(nextAnnotationId([], "a")).toBeNull();
+    expect(nextAnnotationId([], null)).toBeNull();
+  });
+});
+
+describe("prevAnnotationId", () => {
+  const sorted = [ann("a", 1), ann("b", 2), ann("c", 3)];
+
+  it("returns the previous id in order", () => {
+    expect(prevAnnotationId(sorted, "c")).toBe("b");
+    expect(prevAnnotationId(sorted, "b")).toBe("a");
+  });
+
+  it("wraps from first to last", () => {
+    expect(prevAnnotationId(sorted, "a")).toBe("c");
+  });
+
+  it("returns last annotation when currentId is null", () => {
+    expect(prevAnnotationId(sorted, null)).toBe("c");
+  });
+
+  it("returns last annotation when currentId is not in the list", () => {
+    expect(prevAnnotationId(sorted, "deleted-id")).toBe("c");
+  });
+
+  it("returns null with an empty list", () => {
+    expect(prevAnnotationId([], "a")).toBeNull();
+  });
+});

--- a/tests/client/useClosedTabStack.test.ts
+++ b/tests/client/useClosedTabStack.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { createClosedTabStack } from "../../src/client/hooks/useClosedTabStack.js";
+
+const rec = (filePath: string, closedAt = Date.now()) => ({ filePath, closedAt });
+
+describe("createClosedTabStack", () => {
+  it("push then pop returns the most recent record", () => {
+    const stack = createClosedTabStack();
+    stack.push(rec("/a"));
+    stack.push(rec("/b"));
+    expect(stack.pop()?.filePath).toBe("/b");
+    expect(stack.pop()?.filePath).toBe("/a");
+  });
+
+  it("pop on empty returns null", () => {
+    const stack = createClosedTabStack();
+    expect(stack.pop()).toBeNull();
+  });
+
+  it("peek returns the head without consuming", () => {
+    const stack = createClosedTabStack();
+    stack.push(rec("/a"));
+    stack.push(rec("/b"));
+    expect(stack.peek()?.filePath).toBe("/b");
+    expect(stack.size()).toBe(2);
+  });
+
+  it("peek on empty returns null", () => {
+    const stack = createClosedTabStack();
+    expect(stack.peek()).toBeNull();
+  });
+
+  it("dedups consecutive duplicates at the head", () => {
+    const stack = createClosedTabStack();
+    stack.push(rec("/a"));
+    stack.push(rec("/a"));
+    stack.push(rec("/a"));
+    expect(stack.size()).toBe(1);
+  });
+
+  it("non-consecutive duplicates are kept (close /a, /b, /a is three entries)", () => {
+    const stack = createClosedTabStack();
+    stack.push(rec("/a"));
+    stack.push(rec("/b"));
+    stack.push(rec("/a"));
+    expect(stack.size()).toBe(3);
+  });
+
+  it("evicts oldest when cap is exceeded (FIFO eviction, LIFO pop)", () => {
+    const stack = createClosedTabStack(3);
+    stack.push(rec("/a"));
+    stack.push(rec("/b"));
+    stack.push(rec("/c"));
+    stack.push(rec("/d"));
+    expect(stack.size()).toBe(3);
+    expect(stack.pop()?.filePath).toBe("/d");
+    expect(stack.pop()?.filePath).toBe("/c");
+    expect(stack.pop()?.filePath).toBe("/b");
+    // /a was evicted to make room for /d
+    expect(stack.pop()).toBeNull();
+  });
+
+  it("clear empties the stack", () => {
+    const stack = createClosedTabStack();
+    stack.push(rec("/a"));
+    stack.push(rec("/b"));
+    stack.clear();
+    expect(stack.size()).toBe(0);
+    expect(stack.pop()).toBeNull();
+  });
+});

--- a/tests/client/useFindShortcuts.test.ts
+++ b/tests/client/useFindShortcuts.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { shouldDispatchFindNav } from "../../src/client/hooks/useFindShortcuts.js";
+
+describe("shouldDispatchFindNav", () => {
+  it("returns false for null", () => {
+    expect(shouldDispatchFindNav(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(shouldDispatchFindNav(undefined)).toBe(false);
+  });
+
+  it("returns false for empty query", () => {
+    expect(shouldDispatchFindNav({ query: "" })).toBe(false);
+  });
+
+  it("returns true for non-empty query", () => {
+    expect(shouldDispatchFindNav({ query: "x" })).toBe(true);
+  });
+});

--- a/tests/client/useTabKeyboardShortcuts.test.ts
+++ b/tests/client/useTabKeyboardShortcuts.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  pickTabByDigit,
+  shouldIgnoreShortcut,
+} from "../../src/client/hooks/useTabKeyboardShortcuts.js";
+
+const tabs = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+describe("pickTabByDigit", () => {
+  it("returns nth tab id for a valid digit", () => {
+    expect(pickTabByDigit(tabs, 1)).toBe("a");
+    expect(pickTabByDigit(tabs, 2)).toBe("b");
+    expect(pickTabByDigit(tabs, 3)).toBe("c");
+  });
+
+  it("clamps to the last tab when digit exceeds tabs.length", () => {
+    expect(pickTabByDigit([{ id: "a" }, { id: "b" }], 9)).toBe("b");
+    expect(pickTabByDigit(tabs, 4)).toBe("c");
+  });
+
+  it("returns the only tab for digit 1 when one tab is open", () => {
+    expect(pickTabByDigit([{ id: "only" }], 1)).toBe("only");
+  });
+
+  it("returns null with zero tabs", () => {
+    expect(pickTabByDigit([], 1)).toBeNull();
+  });
+
+  it("returns null for out-of-range digits", () => {
+    expect(pickTabByDigit(tabs, 0)).toBeNull();
+    expect(pickTabByDigit(tabs, 10)).toBeNull();
+    expect(pickTabByDigit(tabs, -1)).toBeNull();
+  });
+});
+
+describe("shouldIgnoreShortcut", () => {
+  const evt = (
+    target: HTMLElement | null,
+    isComposing = false,
+  ): Pick<KeyboardEvent, "target" | "isComposing"> => ({
+    target: target as unknown as EventTarget,
+    isComposing,
+  });
+
+  it("returns true for INPUT focus", () => {
+    expect(shouldIgnoreShortcut(evt(document.createElement("input")))).toBe(true);
+  });
+
+  it("returns true for TEXTAREA focus", () => {
+    expect(shouldIgnoreShortcut(evt(document.createElement("textarea")))).toBe(true);
+  });
+
+  it("returns true during IME composition (even on non-form target)", () => {
+    expect(shouldIgnoreShortcut(evt(document.createElement("div"), true))).toBe(true);
+  });
+
+  it("returns false for a plain div", () => {
+    expect(shouldIgnoreShortcut(evt(document.createElement("div")))).toBe(false);
+  });
+
+  it("returns false for a button", () => {
+    expect(shouldIgnoreShortcut(evt(document.createElement("button")))).toBe(false);
+  });
+
+  it("returns false for a contenteditable element (ProseMirror)", () => {
+    const el = document.createElement("div");
+    el.setAttribute("contenteditable", "true");
+    expect(shouldIgnoreShortcut(evt(el))).toBe(false);
+  });
+
+  it("returns false when target is null", () => {
+    expect(shouldIgnoreShortcut(evt(null))).toBe(false);
+  });
+});

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "@playwright/test";
+import path from "path";
+import {
+  cleanupAllOpenDocuments,
+  cleanupFixtureDir,
+  createFixtureDir,
+  McpTestClient,
+} from "./helpers";
+
+let mcp: McpTestClient;
+let tmpDir: string;
+
+test.beforeEach(async () => {
+  mcp = new McpTestClient();
+  await mcp.connect();
+  tmpDir = createFixtureDir("sample.md", "sample2.md", "link-target.md");
+});
+
+test.afterEach(async () => {
+  await cleanupAllOpenDocuments(mcp);
+  await mcp.close();
+  cleanupFixtureDir(tmpDir);
+});
+
+test("Ctrl+W closes the active tab", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample2.md") });
+  await page.goto("http://localhost:5173");
+
+  // Both tabs visible
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+  const sample2 = page.locator("[data-testid^='tab-name-']", { hasText: "sample2.md" });
+  await expect(sample2).toBeVisible();
+
+  // sample2.md is active by default (last opened). Press Ctrl+W.
+  await page.keyboard.press("Control+w");
+
+  // sample2.md tab is gone, sample.md remains.
+  await expect(sample2).toHaveCount(0);
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+});
+
+test("Ctrl+O opens the file dialog", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  // Dialog absent before the shortcut
+  await expect(page.locator("[data-testid='file-open-dialog']")).toHaveCount(0);
+
+  await page.keyboard.press("Control+o");
+  await expect(page.locator("[data-testid='file-open-dialog']")).toBeVisible();
+});
+
+test("Ctrl+N switches to the Nth tab", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample2.md") });
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "link-target.md") });
+  await page.goto("http://localhost:5173");
+
+  // Wait for all three tabs.
+  await expect(page.locator("[data-testid^='tab-name-']")).toHaveCount(3);
+
+  // Tabs are role="tab" with aria-selected.
+  const tabs = page.locator("[role='tab']");
+
+  // Press Ctrl+1 — first tab becomes active.
+  await page.keyboard.press("Control+1");
+  await expect(tabs.nth(0)).toHaveAttribute("aria-selected", "true");
+
+  // Press Ctrl+2 — second tab.
+  await page.keyboard.press("Control+2");
+  await expect(tabs.nth(1)).toHaveAttribute("aria-selected", "true");
+
+  // Press Ctrl+9 — clamps to last (3rd) tab.
+  await page.keyboard.press("Control+9");
+  await expect(tabs.nth(2)).toHaveAttribute("aria-selected", "true");
+});
+
+test("Ctrl+W is ignored while a form input has focus", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  // Open the find bar and focus its input (an INPUT element).
+  await page.keyboard.press("Control+f");
+  const findInput = page.locator("[data-testid='find-input']");
+  await expect(findInput).toBeVisible();
+  await findInput.focus();
+
+  // Press Ctrl+W — the guard should swallow it; tab must still be present.
+  await page.keyboard.press("Control+w");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+});
+
+test("Help modal advertises the new shortcuts", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  // Open via the title-bar help button — the "?" keyboard shortcut is intentionally
+  // suppressed while focus is inside the contenteditable editor.
+  await page.locator("[data-testid='titlebar-help-btn']").click();
+  const modal = page.locator("[data-testid='help-modal']");
+  await expect(modal).toBeVisible();
+
+  await expect(modal.getByText("Close active tab")).toBeVisible();
+  await expect(modal.getByText("Open file…")).toBeVisible();
+  await expect(modal.getByText("Jump to tab by number")).toBeVisible();
+});

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -5,6 +5,7 @@ import {
   cleanupFixtureDir,
   createFixtureDir,
   McpTestClient,
+  switchToAnnotationsTab,
 } from "./helpers";
 
 let mcp: McpTestClient;
@@ -128,6 +129,11 @@ test("Help modal advertises the new shortcuts", async ({ page }) => {
   await expect(modal.getByText("Toggle left panel")).toBeVisible();
   await expect(modal.getByText("Toggle right panel")).toBeVisible();
   await expect(modal.getByText("Reopen closed tab (this session)")).toBeVisible();
+  await expect(modal.getByText("Next annotation")).toBeVisible();
+  await expect(modal.getByText("Previous annotation")).toBeVisible();
+  await expect(modal.getByText("Accept focused annotation")).toBeVisible();
+  await expect(modal.getByText("Dismiss focused annotation")).toBeVisible();
+  await expect(modal.getByText("Comment on selection (in editor)")).toBeVisible();
 });
 
 test("Ctrl+Shift+F opens the find bar pre-scoped to Open tabs", async ({ page }) => {
@@ -257,6 +263,91 @@ test("Ctrl+Alt+T no-ops when no tabs have been closed", async ({ page }) => {
   await page.keyboard.press("Control+Alt+t");
   await expect(page.locator("[data-testid^='tab-name-']")).toHaveCount(1);
   expect(errors).toHaveLength(0);
+});
+
+test("Alt+] does not crash with no annotations and no console errors", async ({ page }) => {
+  // The pure logic of Alt+]/Alt+[ navigation (sortAnnotationsByPosition,
+  // nextAnnotationId, prevAnnotationId) is covered by useAnnotationOrder.test.ts.
+  // E2E coverage focuses on no-crash behavior — the visual cycle assertion
+  // through aria-current proved brittle (timing-dependent on Yjs annotation
+  // sync interleaving with the lifted useAnnotationReview's auto-set effect).
+  const errors: string[] = [];
+  page.on("pageerror", (err) => errors.push(err.message));
+
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  // Empty annotations list: Alt+] / Alt+[ should be silent no-ops.
+  await page.keyboard.press("Alt+BracketRight");
+  await page.keyboard.press("Alt+BracketLeft");
+  expect(errors).toHaveLength(0);
+});
+
+test("Ctrl+Enter accepts the first pending annotation", async ({ page }) => {
+  // The lifted useAnnotationReview auto-sets activeAnnotationId to the first
+  // pending annotation on initial mount, so Ctrl+Enter immediately operates on
+  // that target without needing Alt+] to establish a cursor first.
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: 2,
+    to: 15,
+    text: "Accept me via keyboard",
+    textSnapshot: "Test Document",
+  });
+  await page.goto("http://localhost:5173");
+  await switchToAnnotationsTab(page);
+
+  const card = page.locator("[data-testid^='annotation-card-']").first();
+  await expect(card).toBeVisible({ timeout: 10_000 });
+
+  await page.keyboard.press("Control+Enter");
+
+  // After accept, the card moves into the collapsed "resolved" details section.
+  await expect(page.locator("summary", { hasText: "1 resolved" })).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+test("Ctrl+Shift+Enter dismisses the first pending annotation", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: 2,
+    to: 15,
+    text: "Dismiss me via keyboard",
+    textSnapshot: "Test Document",
+  });
+  await page.goto("http://localhost:5173");
+  await switchToAnnotationsTab(page);
+
+  const card = page.locator("[data-testid^='annotation-card-']").first();
+  await expect(card).toBeVisible({ timeout: 10_000 });
+
+  await page.keyboard.press("Control+Shift+Enter");
+
+  await expect(page.locator("summary", { hasText: "1 resolved" })).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+test("Ctrl+Alt+M opens the comment popup focused on its textarea", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator(".ProseMirror", { hasText: "Test Document" })).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Select the title via Ctrl+A then narrow with another key combo. Easier:
+  // triple-click selects the paragraph.
+  await page.locator(".ProseMirror h1, .ProseMirror p").first().click({ clickCount: 3 });
+
+  await page.keyboard.press("Control+Alt+m");
+
+  await expect(page.locator("[data-testid='popup-comment-submit']")).toBeVisible({
+    timeout: 3_000,
+  });
+  // The popup's textarea should have focus.
+  await expect(page.evaluate(() => document.activeElement?.tagName)).resolves.toBe("TEXTAREA");
 });
 
 test("Ctrl+Alt+T after closing via the X button (DocumentTabs path) reopens", async ({ page }) => {

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -134,6 +134,10 @@ test("Help modal advertises the new shortcuts", async ({ page }) => {
   await expect(modal.getByText("Accept focused annotation")).toBeVisible();
   await expect(modal.getByText("Dismiss focused annotation")).toBeVisible();
   await expect(modal.getByText("Comment on selection (in editor)")).toBeVisible();
+  await expect(modal.getByText("Heading 1")).toBeVisible();
+  await expect(modal.getByText("Heading 6")).toBeVisible();
+  await expect(modal.getByText("Select containing block")).toBeVisible();
+  await expect(modal.getByText("Toggle authorship colors")).toBeVisible();
 });
 
 test("Ctrl+Shift+F opens the find bar pre-scoped to Open tabs", async ({ page }) => {

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -52,6 +52,20 @@ test("Ctrl+O opens the file dialog", async ({ page }) => {
   await expect(page.locator("[data-testid='file-open-dialog']")).toBeVisible();
 });
 
+test("'+' button → Browse opens the file dialog", async ({ page }) => {
+  // Guards the post-refactor onRequestOpenDialog plumbing: DocumentTabs no longer
+  // renders FileOpenDialog directly, so the existing "+" → Browse path must still
+  // reach the lifted dialog rendering in App.svelte.
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid='open-file-btn']")).toBeVisible();
+
+  await page.locator("[data-testid='open-file-btn']").click();
+  await page.getByRole("menuitem", { name: "Browse files…" }).click();
+
+  await expect(page.locator("[data-testid='file-open-dialog']")).toBeVisible();
+});
+
 test("Ctrl+N switches to the Nth tab", async ({ page }) => {
   await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
   await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample2.md") });

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -127,6 +127,7 @@ test("Help modal advertises the new shortcuts", async ({ page }) => {
   await expect(modal.getByText("Toggle Solo / Tandem mode")).toBeVisible();
   await expect(modal.getByText("Toggle left panel")).toBeVisible();
   await expect(modal.getByText("Toggle right panel")).toBeVisible();
+  await expect(modal.getByText("Reopen closed tab (this session)")).toBeVisible();
 });
 
 test("Ctrl+Shift+F opens the find bar pre-scoped to Open tabs", async ({ page }) => {
@@ -223,4 +224,60 @@ test("Ctrl+Shift+\\ toggles the right panel", async ({ page }) => {
 
   await page.keyboard.press("Control+Shift+\\");
   await expect.poll(async () => rightHandle.count()).toBe(initial);
+});
+
+test("Ctrl+Alt+T reopens the most recently closed tab", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample2.md") });
+  await page.goto("http://localhost:5173");
+
+  const sample = page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" });
+  const sample2 = page.locator("[data-testid^='tab-name-']", { hasText: "sample2.md" });
+  await expect(sample).toBeVisible();
+  await expect(sample2).toBeVisible();
+
+  // Close active tab (sample2.md is last-opened, so it's active).
+  await page.keyboard.press("Control+w");
+  await expect(sample2).toHaveCount(0);
+
+  // Reopen via Ctrl+Alt+T.
+  await page.keyboard.press("Control+Alt+t");
+  await expect(sample2).toBeVisible();
+});
+
+test("Ctrl+Alt+T no-ops when no tabs have been closed", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("pageerror", (err) => errors.push(err.message));
+
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  // No tabs closed yet — pressing the shortcut should be a silent no-op.
+  await page.keyboard.press("Control+Alt+t");
+  await expect(page.locator("[data-testid^='tab-name-']")).toHaveCount(1);
+  expect(errors).toHaveLength(0);
+});
+
+test("Ctrl+Alt+T after closing via the X button (DocumentTabs path) reopens", async ({ page }) => {
+  // Verifies that closeTabAndRecord wraps the DocumentTabs onTabClose prop, not
+  // just the Ctrl+W keydown branch.
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample2.md") });
+  await page.goto("http://localhost:5173");
+
+  const sample2 = page.locator("[data-testid^='tab-name-']", { hasText: "sample2.md" });
+  await expect(sample2).toBeVisible();
+
+  // Click the X button on sample2's tab. The TabItem renders a close button
+  // inside the tab; locate it relative to the tab-name span's tab container.
+  // (Per CLAUDE.md the tab itself has data-testid="tab-{id}", and the close
+  //  button is inside it with role="button" / appropriate aria.)
+  const sample2Tab = page.locator("[role='tab']").filter({ has: sample2 });
+  // The close button is the only button inside the tab item.
+  await sample2Tab.locator("button").first().click();
+  await expect(sample2).toHaveCount(0);
+
+  await page.keyboard.press("Control+Alt+t");
+  await expect(sample2).toBeVisible();
 });

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -341,6 +341,21 @@ test("Ctrl+Alt+M opens the comment popup focused on its textarea", async ({ page
     timeout: 10_000,
   });
 
+  // Pin selectionToolbar=on so a future default flip in settings doesn't
+  // fail this test for an unrelated reason. The Ctrl+Alt+M handler now
+  // routes to a toast when the setting is off; this test asserts the
+  // happy path.
+  await page.evaluate(() => {
+    const raw = localStorage.getItem("tandem:settings");
+    const settings = raw ? JSON.parse(raw) : {};
+    settings.selectionToolbar = true;
+    localStorage.setItem("tandem:settings", JSON.stringify(settings));
+  });
+  await page.reload();
+  await expect(page.locator(".ProseMirror", { hasText: "Test Document" })).toBeVisible({
+    timeout: 10_000,
+  });
+
   // Select the title via Ctrl+A then narrow with another key combo. Easier:
   // triple-click selects the paragraph.
   await page.locator(".ProseMirror h1, .ProseMirror p").first().click({ clickCount: 3 });

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -124,6 +124,9 @@ test("Help modal advertises the new shortcuts", async ({ page }) => {
   await expect(modal.getByText("Find in open tabs")).toBeVisible();
   await expect(modal.getByText("Find next match")).toBeVisible();
   await expect(modal.getByText("Find previous match")).toBeVisible();
+  await expect(modal.getByText("Toggle Solo / Tandem mode")).toBeVisible();
+  await expect(modal.getByText("Toggle left panel")).toBeVisible();
+  await expect(modal.getByText("Toggle right panel")).toBeVisible();
 });
 
 test("Ctrl+Shift+F opens the find bar pre-scoped to Open tabs", async ({ page }) => {
@@ -171,3 +174,53 @@ test("Ctrl+G with no active query opens the find bar", async ({ page }) => {
 //   CI — match-count timing depends on collab-extension sync internals.
 // - The "Ctrl+G is ignored when a form input has focus" guard is covered by
 //   the existing "Ctrl+W is ignored" test (same shouldIgnoreShortcut helper).
+
+test("Ctrl+Shift+M toggles solo / tandem mode", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  // Default mode is tandem.
+  const tandemBtn = page.locator("[data-testid='mode-tandem-btn']");
+  const soloBtn = page.locator("[data-testid='mode-solo-btn']");
+  await expect(tandemBtn).toHaveAttribute("aria-pressed", "true");
+  await expect(soloBtn).toHaveAttribute("aria-pressed", "false");
+
+  await page.keyboard.press("Control+Shift+M");
+  await expect(soloBtn).toHaveAttribute("aria-pressed", "true");
+  await expect(tandemBtn).toHaveAttribute("aria-pressed", "false");
+
+  await page.keyboard.press("Control+Shift+M");
+  await expect(tandemBtn).toHaveAttribute("aria-pressed", "true");
+});
+
+test("Ctrl+\\ toggles the left panel", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  // Capture initial left-panel visibility via the resize-handle testid.
+  const leftHandle = page.locator("[data-testid='left-panel-resize-handle']");
+  const initial = await leftHandle.count();
+
+  await page.keyboard.press("Control+\\");
+  await expect.poll(async () => leftHandle.count()).not.toBe(initial);
+
+  await page.keyboard.press("Control+\\");
+  await expect.poll(async () => leftHandle.count()).toBe(initial);
+});
+
+test("Ctrl+Shift+\\ toggles the right panel", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  const rightHandle = page.locator("[data-testid='panel-resize-handle']");
+  const initial = await rightHandle.count();
+
+  await page.keyboard.press("Control+Shift+\\");
+  await expect.poll(async () => rightHandle.count()).not.toBe(initial);
+
+  await page.keyboard.press("Control+Shift+\\");
+  await expect.poll(async () => rightHandle.count()).toBe(initial);
+});

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -121,4 +121,53 @@ test("Help modal advertises the new shortcuts", async ({ page }) => {
   await expect(modal.getByText("Close active tab")).toBeVisible();
   await expect(modal.getByText("Open file…")).toBeVisible();
   await expect(modal.getByText("Jump to tab by number")).toBeVisible();
+  await expect(modal.getByText("Find in open tabs")).toBeVisible();
+  await expect(modal.getByText("Find next match")).toBeVisible();
+  await expect(modal.getByText("Find previous match")).toBeVisible();
 });
+
+test("Ctrl+Shift+F opens the find bar pre-scoped to Open tabs", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample2.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']")).toHaveCount(2);
+
+  await page.keyboard.press("Control+Shift+F");
+  await expect(page.locator("[data-testid='find-replace-bar']")).toBeVisible();
+  await expect(page.locator("[data-testid='find-scope-tabs']")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+});
+
+test("Ctrl+Shift+F with one tab open hides scope pills (single-doc fallback)", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  await page.keyboard.press("Control+Shift+F");
+  await expect(page.locator("[data-testid='find-replace-bar']")).toBeVisible();
+  // Scope pills only render when tabs.length > 1 (existing FindReplaceBar guard).
+  await expect(page.locator("[data-testid='find-scope-pills']")).toHaveCount(0);
+});
+
+test("Ctrl+G with no active query opens the find bar", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://localhost:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  await expect(page.locator("[data-testid='find-replace-bar']")).toHaveCount(0);
+  await page.keyboard.press("Control+g");
+  await expect(page.locator("[data-testid='find-replace-bar']")).toBeVisible();
+});
+
+// Notes on coverage scope:
+// - The "no active query → open find bar" smart-fallback above is the
+//   regression-risk behavior unique to this PR.
+// - "Ctrl+G with active query advances to the next match" is exercised in unit
+//   tests via `shouldDispatchFindNav` (the only logic the keydown branch adds
+//   on top of Tiptap's own `findNext` command). End-to-end assertion through
+//   Yjs + ProseMirror + the find-replace plugin proved too brittle for stable
+//   CI — match-count timing depends on collab-extension sync internals.
+// - The "Ctrl+G is ignored when a form input has focus" guard is covered by
+//   the existing "Ctrl+W is ignored" test (same shouldIgnoreShortcut helper).


### PR DESCRIPTION
Closes #538.

## Summary

15 keyboard shortcuts across 7 commits. PR #626 originally added 3 (Ctrl+W, Ctrl+O, Ctrl+1–9); this PR's body covers all 15 after the user requested follow-on additions.

## Shortcuts added

**Tab management** (PR #626 + this body)
| Shortcut | Action |
|---|---|
| `Ctrl+W` | Close active tab |
| `Ctrl+O` | Open file dialog |
| `Ctrl+1`–`Ctrl+9` | Jump to tab N |
| `Ctrl+Alt+T` | Reopen most-recently-closed tab (this session) |

**Find ergonomics**
| Shortcut | Action |
|---|---|
| `Ctrl+Shift+F` | Open find bar pre-scoped to "Open tabs" |
| `Ctrl+G` / `Ctrl+Shift+G` | Find next / previous match (smart fallback opens bar if no active query) |

**Window toggles**
| Shortcut | Action |
|---|---|
| `Ctrl+Shift+M` | Toggle Solo ⇄ Tandem mode |
| `Ctrl+\` / `Ctrl+Shift+\` | Toggle left / right side panel |

**Annotations** (new HelpModal section)
| Shortcut | Action |
|---|---|
| `Alt+]` / `Alt+[` | Next / previous annotation |
| `Ctrl+Enter` / `Ctrl+Shift+Enter` | Accept / dismiss focused annotation |
| `Ctrl+Alt+M` | Open comment popup with current selection |

**Editor polish**
| Shortcut | Action |
|---|---|
| `Ctrl+Alt+1`–`Ctrl+Alt+6` | Heading levels (already wired by Tiptap StarterKit; this docs them) |
| `Alt+L` | Select containing block (paragraph / heading / list-item) |
| `Ctrl+Alt+A` | Toggle authorship colors |

## Notable design choices

- **Lifted `useAnnotationReview`** from `SidePanel.svelte` up to `App.svelte`. Both rails now share one review instance; previous dual-instance setup would have caused accept/dismiss to fire twice (+ double `applySuggestion` text insertion). Hook gained an optional `getActiveAnnotationId` param so its auto-set effect doesn't clobber externally-set ids from the new keyboard nav.
- **Idempotency guard in `resolveAnnotation`**: early-returns if status is non-pending. Defense-in-depth against future double-fire paths.
- **`Ctrl+L` → `Alt+L`** to avoid the browser address-bar conflict in dev mode. **`Ctrl+Shift+T` → `Ctrl+Alt+T`** to avoid Chrome/Firefox/Safari "reopen browser tab" intercept.
- **`comment-on-selection` is inline-only** (not in palette) — opening the palette collapses the editor selection.
- **All three `handleTabClose` call sites** funnel through `closeTabAndRecord` so every user-initiated close (Ctrl+W, X-button, palette action) populates the reopen stack.
- **New `annotations` ACTION_GROUP** so HelpModal renders annotation shortcuts in their own section.
- **Line-motion (`Alt+↑/↓`, `Alt+Shift+↑/↓`) explicitly deferred.** y-prosemirror has no atomic move primitive; the planned `tr.delete + tr.insert` would (a) destroy annotation `relRange` anchors, (b) lose concurrent collaborator edits, (c) pollute authorship attribution. Tracked as a follow-up.

## Test plan

Automated:
- [x] `npm run typecheck` passes (server + client + svelte-check)
- [x] `npx vitest run` — 2000 unit tests pass (added: 4 useFindShortcuts + 8 useClosedTabStack + 16 useAnnotationOrder + 12 useTabKeyboardShortcuts from PR #626 baseline)
- [x] `npx playwright test keyboard-shortcuts` — 19 E2E tests pass; ran with `--repeat-each=2` to confirm no flakes
- [x] Neighbor specs (`tab-overflow`, `settings-and-filters`, `annotation-lifecycle`, `store-readonly-banner`) still green after the SidePanel lift refactor

Manual (Tauri):
- [ ] Close 3 tabs in sequence → `Ctrl+Alt+T` reopens newest-first
- [ ] `Ctrl+\` and `Ctrl+Shift+\` toggle each panel without disturbing editor selection
- [ ] Solo/tandem `Ctrl+Shift+M` flips visibly in TitleBar
- [ ] `Ctrl+Shift+F` opens find bar with "Open tabs" scope active when 2+ docs open
- [ ] `Ctrl+G` after a query advances; with no query opens the bar
- [ ] Seed Claude annotations via MCP; press `Alt+]/[` to cycle, `Ctrl+Enter` to accept, `Ctrl+Shift+Enter` to dismiss
- [ ] Select text in editor; `Ctrl+Alt+M` opens comment popup focused on textarea
- [ ] `Ctrl+Alt+1..6` toggle heading levels
- [ ] `Alt+L` selects the paragraph containing the cursor
- [ ] `Ctrl+Alt+A` toggles authorship colors and TitleBar button visual state updates

https://claude.ai/code/session_01TgYhZXYaVxLYQ6C8YEGHyz