### PR TITLE
feat(hooks): workflow-nudge hooks + Development Workflow doc

### DIFF
--- a/.claude/hooks/_workflow-state.sh
+++ b/.claude/hooks/_workflow-state.sh
@@ -90,10 +90,13 @@ _ws_is_git_commit() {
   [[ "$cmd" =~ ^[[:space:]]*git([[:space:]]+(-[^[:space:]]+|--[^[:space:]=]+(=[^[:space:]]+)?)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$) ]]
 }
 
-# Return 0 if the (forward-slashed) path looks like a source-tree edit:
+# Return 0 if the path looks like a source-tree edit:
 # under src/ or src-tauri/, not a test, not markdown, not generated.
+# Self-normalizes \ -> / so callers can pass JSON-derived paths directly on
+# Windows; Windows filenames cannot contain literal backslashes, so the
+# substitution is unambiguous.
 _ws_is_source_edit() {
-  local p="$1"
+  local p="${1//\\//}"
   [[ -n "$p" ]] || return 1
   [[ "$p" =~ (^|/)src(-tauri)?/ ]] || return 1
   [[ "$p" =~ \.(test|spec)\.[tj]sx?$ ]] && return 1

--- a/.claude/hooks/_workflow-state.sh
+++ b/.claude/hooks/_workflow-state.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Shared helpers for workflow-nudge hooks.
+# Source this file; do not execute it directly.
+
+# Marker filenames (single source of truth — referenced across multiple hooks).
+readonly _WS_MARK_PLAN_WRITE="last-plan-write"
+readonly _WS_MARK_SOURCE_EDIT="last-source-edit"
+readonly _WS_MARK_AGENT_CALL="last-agent-call"
+readonly _WS_MARK_SIMPLIFY="last-simplify"
+readonly _WS_MARK_COMMIT="last-commit"
+readonly _WS_MARK_STOP_NUDGED="stop-nudged"
+
+# Parse session_id from stdin JSON. Falls back to "pid-$$" if missing so parallel
+# sessions without IDs don't share a state dir. Sanitizes the value to a safe
+# path segment and refuses leading-dot variants so traversal patterns ("..",
+# "../x") can't escape the state root.
+_ws_session_id() {
+  local input="$1"
+  local fallback="pid-${PPID:-$$}"
+  printf '%s' "$input" | PID_FALLBACK="$fallback" node -e "
+    let d='';
+    process.stdin.on('data', c => d += c);
+    process.stdin.on('end', () => {
+      const fb = process.env.PID_FALLBACK || 'default';
+      let s = '';
+      try { s = (JSON.parse(d).session_id || ''); } catch {}
+      s = String(s).replace(/[^a-zA-Z0-9_-]/g, '_');
+      if (!s) s = fb;
+      process.stdout.write(s);
+    });
+  " 2>/dev/null || printf '%s' "$fallback"
+}
+
+# Resolve and create the per-session state directory. Echoes its path.
+_ws_state_dir() {
+  local session_id="$1"
+  local dir=".claude/.workflow-state/${session_id}"
+  mkdir -p "$dir" 2>/dev/null || true
+  printf '%s' "$dir"
+}
+
+# Touch a marker file inside the state dir. Optional payload as a third arg.
+# Writes via temp+rename so a pre-planted symlink at the marker path can't
+# redirect the write outside the state dir.
+_ws_mark() {
+  local state_dir="$1"
+  local name="$2"
+  local payload="${3:-}"
+  local file="${state_dir}/${name}"
+  local tmp="${file}.tmp.$$"
+  if [[ -n "$payload" ]]; then
+    printf '%s\n' "$payload" > "$tmp" || return 1
+  else
+    : > "$tmp" || return 1
+  fi
+  mv -f "$tmp" "$file"
+}
+
+# Read a marker payload, or empty if missing.
+_ws_payload() {
+  local file="${1}/${2}"
+  [[ -f "$file" ]] && cat "$file" || printf ''
+}
+
+# Return 0 if file $1 exists and is newer than $2 (or $2 is missing).
+_ws_newer_than() {
+  local a="$1"
+  local b="$2"
+  [[ -f "$a" ]] || return 1
+  [[ ! -f "$b" ]] && return 0
+  [[ "$a" -nt "$b" ]]
+}
+
+# Echo the mtime of a marker as epoch seconds, or "0" if missing.
+_ws_mtime() {
+  local file="$1"
+  if [[ -f "$file" ]]; then
+    stat -c %Y "$file" 2>/dev/null || stat -f %m "$file" 2>/dev/null || printf '0'
+  else
+    printf '0'
+  fi
+}
+
+# Return 0 if $1 looks like a real `git commit` invocation (not commit-tree /
+# commit-graph) and not just a substring of a quoted message body. Accepts
+# pre-`commit` git options like `-C path` or `--no-pager`. Anchors to the
+# string start to avoid matching `git commit` inside `-m "..."` text.
+_ws_is_git_commit() {
+  local cmd="$1"
+  [[ "$cmd" =~ ^[[:space:]]*git([[:space:]]+(-[^[:space:]]+|--[^[:space:]=]+(=[^[:space:]]+)?)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$) ]]
+}
+
+# Return 0 if the (forward-slashed) path looks like a source-tree edit:
+# under src/ or src-tauri/, not a test, not markdown, not generated.
+_ws_is_source_edit() {
+  local p="$1"
+  [[ -n "$p" ]] || return 1
+  [[ "$p" =~ (^|/)src(-tauri)?/ ]] || return 1
+  [[ "$p" =~ \.(test|spec)\.[tj]sx?$ ]] && return 1
+  [[ "$p" =~ \.md$ ]] && return 1
+  [[ "$p" =~ /dist/ ]] && return 1
+  [[ "$p" =~ /node_modules/ ]] && return 1
+  return 0
+}

--- a/.claude/hooks/nudge-plan-review.sh
+++ b/.claude/hooks/nudge-plan-review.sh
@@ -42,7 +42,7 @@ PLAN_HASH=$(printf '%s' "$PLAN_PATH" | node -e "
   process.stdin.on('end', () => {
     process.stdout.write(require('crypto').createHash('sha1').update(d).digest('hex').slice(0, 16));
   });
-" 2>/dev/null || printf 'unknown')
+" 2>/dev/null || printf 'unknown-%s' "$$")
 NUDGE_MARK="${STATE_DIR}/nudged-plan-${PLAN_HASH}"
 [[ -f "$NUDGE_MARK" ]] && exit 0
 : > "$NUDGE_MARK"

--- a/.claude/hooks/nudge-plan-review.sh
+++ b/.claude/hooks/nudge-plan-review.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Edit|Write).
+# Nudges to dispatch adversarial agent review when a plan was written this
+# session but no Agent tool has run since. Never blocks; exit 0 always.
+
+set -uo pipefail
+trap 'exit 0' ERR
+
+# shellcheck source=_workflow-state.sh
+source "$(dirname "$0")/_workflow-state.sh"
+
+INPUT=$(cat)
+SESSION_ID=$(_ws_session_id "$INPUT")
+STATE_DIR=$(_ws_state_dir "$SESSION_ID")
+
+FILE_PATH=$(printf '%s' "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const e = JSON.parse(d);
+      const fp = ((e.tool_input && e.tool_input.file_path) || '').replace(/\\\\/g, '/');
+      process.stdout.write(fp);
+    } catch { process.stdout.write(''); }
+  });
+" 2>/dev/null) || exit 0
+
+_ws_is_source_edit "$FILE_PATH" || exit 0
+
+PLAN_MARK="${STATE_DIR}/${_WS_MARK_PLAN_WRITE}"
+AGENT_MARK="${STATE_DIR}/${_WS_MARK_AGENT_CALL}"
+
+[[ -f "$PLAN_MARK" ]] || exit 0
+_ws_newer_than "$AGENT_MARK" "$PLAN_MARK" && exit 0
+
+# Suppress repeats per plan file.
+PLAN_PATH=$(cat "$PLAN_MARK" 2>/dev/null || printf '')
+[[ -z "$PLAN_PATH" ]] && exit 0
+PLAN_HASH=$(printf '%s' "$PLAN_PATH" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    process.stdout.write(require('crypto').createHash('sha1').update(d).digest('hex').slice(0, 16));
+  });
+" 2>/dev/null || printf 'unknown')
+NUDGE_MARK="${STATE_DIR}/nudged-plan-${PLAN_HASH}"
+[[ -f "$NUDGE_MARK" ]] && exit 0
+: > "$NUDGE_MARK"
+
+cat >&2 <<'EOF'
+⚠ Plan written this session but no Agent tool calls since.
+   Per CLAUDE.md workflow: dispatch adversarial agents to review the plan before writing code.
+   (One-shot reminder. Run any Agent tool to suppress for this plan.)
+EOF
+
+exit 0

--- a/.claude/hooks/nudge-pr-review.sh
+++ b/.claude/hooks/nudge-pr-review.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# PostToolUse hook (Bash).
+# After a successful `gh pr create`, nudge to run /pr-review-toolkit:review-pr.
+
+set -uo pipefail
+trap 'exit 0' ERR
+
+INPUT=$(cat)
+
+# Fast path: only consider Bash tool calls. Avoids matching commit-message
+# bodies that happen to mention "gh pr create" in unrelated tool payloads.
+[[ "$INPUT" =~ \"tool_name\"[[:space:]]*:[[:space:]]*\"Bash\" ]] || exit 0
+
+EXTRACTED=$(printf '%s' "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const e = JSON.parse(d);
+      const cmd = ((e.tool_input && e.tool_input.command) || '').replace(/\n/g, ' ');
+      const tr = e.tool_response;
+      let ec = '';
+      if (tr && typeof tr === 'object') {
+        if (typeof tr.exit_code === 'number') ec = String(tr.exit_code);
+        else if (typeof tr.exitCode === 'number') ec = String(tr.exitCode);
+      }
+      process.stdout.write(cmd + '\n' + ec);
+    } catch { process.stdout.write('\n'); }
+  });
+" 2>/dev/null) || exit 0
+
+mapfile -t FIELDS <<< "$EXTRACTED"
+COMMAND="${FIELDS[0]:-}"
+EXIT_CODE="${FIELDS[1]:-}"
+
+# Anchor to start of command so a commit message containing "gh pr create"
+# doesn't trigger the nudge.
+[[ "$COMMAND" =~ ^[[:space:]]*gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$) ]] || exit 0
+
+# Only fire on success. If exit code is unknown, fire anyway (best effort).
+if [[ -n "$EXIT_CODE" && "$EXIT_CODE" != "0" ]]; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+✓ PR opened. Next step per CLAUDE.md workflow: /pr-review-toolkit:review-pr.
+   When review feedback lands, plan the fixes and have agents review the plan before implementing.
+EOF
+
+exit 0

--- a/.claude/hooks/nudge-simplify-before-commit.sh
+++ b/.claude/hooks/nudge-simplify-before-commit.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash).
+# Nudges to run /simplify when source edits have happened since the last
+# /simplify run. Never blocks; exit 0 always.
+
+set -uo pipefail
+trap 'exit 0' ERR
+
+# shellcheck source=_workflow-state.sh
+source "$(dirname "$0")/_workflow-state.sh"
+
+INPUT=$(cat)
+SESSION_ID=$(_ws_session_id "$INPUT")
+STATE_DIR=$(_ws_state_dir "$SESSION_ID")
+
+COMMAND=$(printf '%s' "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const e = JSON.parse(d);
+      process.stdout.write((e.tool_input && e.tool_input.command) || '');
+    } catch { process.stdout.write(''); }
+  });
+" 2>/dev/null) || exit 0
+
+_ws_is_git_commit "$COMMAND" || exit 0
+
+EDIT_MARK="${STATE_DIR}/${_WS_MARK_SOURCE_EDIT}"
+SIMPLIFY_MARK="${STATE_DIR}/${_WS_MARK_SIMPLIFY}"
+
+[[ -f "$EDIT_MARK" ]] || exit 0
+_ws_newer_than "$SIMPLIFY_MARK" "$EDIT_MARK" && exit 0
+
+# Suppress repeat firings for the same edit (retried commit after hook fail).
+EDIT_TS=$(_ws_mtime "$EDIT_MARK")
+NUDGE_MARK="${STATE_DIR}/nudged-simplify-${EDIT_TS}"
+[[ -f "$NUDGE_MARK" ]] && exit 0
+: > "$NUDGE_MARK"
+
+cat >&2 <<'EOF'
+⚠ Source edits since last /simplify run. Consider /simplify before committing.
+   This is a one-shot reminder; the commit will proceed.
+EOF
+
+exit 0

--- a/.claude/hooks/sessionstart-prune-state.sh
+++ b/.claude/hooks/sessionstart-prune-state.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SessionStart hook.
+# Prunes workflow-state directories older than 7 days so the dir stays bounded.
+
+set -uo pipefail
+trap 'exit 0' ERR
+
+STATE_ROOT=".claude/.workflow-state"
+[[ -d "$STATE_ROOT" ]] || exit 0
+
+find "$STATE_ROOT" -maxdepth 1 -mindepth 1 -type d -mtime +7 -exec rm -rf {} + 2>/dev/null || true
+
+exit 0

--- a/.claude/hooks/stop-cycle-check.sh
+++ b/.claude/hooks/stop-cycle-check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Stop hook.
+# Fires every agent turn end. If the session has uncommitted source edits,
+# emit one informational reminder per session.
+
+set -uo pipefail
+trap 'exit 0' ERR
+
+# shellcheck source=_workflow-state.sh
+source "$(dirname "$0")/_workflow-state.sh"
+
+INPUT=$(cat)
+SESSION_ID=$(_ws_session_id "$INPUT")
+STATE_DIR=$(_ws_state_dir "$SESSION_ID")
+
+NUDGED_MARK="${STATE_DIR}/${_WS_MARK_STOP_NUDGED}"
+[[ -f "$NUDGED_MARK" ]] && exit 0
+
+EDIT_MARK="${STATE_DIR}/${_WS_MARK_SOURCE_EDIT}"
+COMMIT_MARK="${STATE_DIR}/${_WS_MARK_COMMIT}"
+
+[[ -f "$EDIT_MARK" ]] || exit 0
+_ws_newer_than "$COMMIT_MARK" "$EDIT_MARK" && exit 0
+
+: > "$NUDGED_MARK"
+
+cat >&2 <<'EOF'
+ℹ Session has uncommitted source edits. Workflow:
+   plan → agent review → implement → /simplify → verify → manual test → commit → PR → /pr-review-toolkit:review-pr.
+EOF
+
+exit 0

--- a/.claude/hooks/track-workflow-events.sh
+++ b/.claude/hooks/track-workflow-events.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# PostToolUse hook (unmatched — runs on every tool).
+# Records workflow state markers used by nudge hooks.
+# Hot path: fires on every tool call. Pre-filter with a bash regex before
+# spawning node so 90% of tool calls (Read/Grep/Glob/LS/etc.) exit immediately.
+
+set -uo pipefail
+trap 'exit 0' ERR
+
+# shellcheck source=_workflow-state.sh
+source "$(dirname "$0")/_workflow-state.sh"
+
+INPUT=$(cat)
+
+# Fast path: short-circuit for tools we don't track. Avoids node spawn (~50ms
+# on Windows) for the vast majority of tool calls.
+if [[ ! "$INPUT" =~ \"tool_name\"[[:space:]]*:[[:space:]]*\"(Edit|Write|Agent|Task|Skill|Bash)\" ]]; then
+  exit 0
+fi
+
+SESSION_ID=$(_ws_session_id "$INPUT")
+STATE_DIR=$(_ws_state_dir "$SESSION_ID")
+
+# Newline-delimited extraction (NOT null-delimited: command substitution
+# strips NULs and collapses every field into the first slot). Newlines inside
+# field values are stripped — we only need prefix matches downstream.
+EXTRACTED=$(printf '%s' "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data', c => d += c);
+  process.stdin.on('end', () => {
+    try {
+      const e = JSON.parse(d);
+      const tr = e.tool_response;
+      let ec = '';
+      if (tr && typeof tr === 'object') {
+        if (typeof tr.exit_code === 'number') ec = String(tr.exit_code);
+        else if (typeof tr.exitCode === 'number') ec = String(tr.exitCode);
+      }
+      const fp = ((e.tool_input && e.tool_input.file_path) || '').replace(/\\\\/g, '/');
+      const esc = v => String(v == null ? '' : v).replace(/\n/g, '');
+      process.stdout.write([
+        esc(e.tool_name || ''),
+        esc(fp),
+        esc((e.tool_input && e.tool_input.skill) || ''),
+        esc((e.tool_input && e.tool_input.command) || ''),
+        esc(ec),
+      ].join('\n'));
+    } catch { process.stdout.write(['','','','',''].join('\n')); }
+  });
+" 2>/dev/null) || exit 0
+
+mapfile -t FIELDS <<< "$EXTRACTED"
+TOOL_NAME="${FIELDS[0]:-}"
+FILE_PATH="${FIELDS[1]:-}"
+SKILL_NAME="${FIELDS[2]:-}"
+COMMAND="${FIELDS[3]:-}"
+EXIT_CODE="${FIELDS[4]:-}"
+
+case "$TOOL_NAME" in
+  Edit|Write)
+    if [[ "$FILE_PATH" =~ (^|/)\.claude/plans/.+\.md$ ]]; then
+      _ws_mark "$STATE_DIR" "$_WS_MARK_PLAN_WRITE" "$FILE_PATH"
+    fi
+    if _ws_is_source_edit "$FILE_PATH"; then
+      _ws_mark "$STATE_DIR" "$_WS_MARK_SOURCE_EDIT" "$FILE_PATH"
+    fi
+    ;;
+  Agent|Task)
+    _ws_mark "$STATE_DIR" "$_WS_MARK_AGENT_CALL"
+    ;;
+  Skill)
+    if [[ "$SKILL_NAME" == "simplify" || "$SKILL_NAME" == *":simplify" ]]; then
+      _ws_mark "$STATE_DIR" "$_WS_MARK_SIMPLIFY"
+    fi
+    ;;
+  Bash)
+    if _ws_is_git_commit "$COMMAND" && [[ "${EXIT_CODE:-1}" == "0" ]]; then
+      _ws_mark "$STATE_DIR" "$_WS_MARK_COMMIT"
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/track-workflow-events.sh
+++ b/.claude/hooks/track-workflow-events.sh
@@ -76,6 +76,15 @@ case "$TOOL_NAME" in
   Bash)
     if _ws_is_git_commit "$COMMAND" && [[ "${EXIT_CODE:-1}" == "0" ]]; then
       _ws_mark "$STATE_DIR" "$_WS_MARK_COMMIT"
+      # Clear stop-nudged so the next post-commit edit cycle re-fires the
+      # reminder. Without this, stop-cycle-check.sh's per-session early-return
+      # short-circuits forever after the first nudge.
+      rm -f "${STATE_DIR}/${_WS_MARK_STOP_NUDGED}" 2>/dev/null || true
+      # Surface systemic clear-failure (Windows file lock, AV scanner) to
+      # stderr so it's visible in hook logs without escalating to a hard fail.
+      if [[ -f "${STATE_DIR}/${_WS_MARK_STOP_NUDGED}" ]]; then
+        echo "warn: stop-nudged mark survived commit clear at $(date -Iseconds 2>/dev/null || date)" >&2
+      fi
     fi
     ;;
 esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/sessionstart-prune-state.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",
@@ -7,6 +18,10 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/block-sensitive.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/nudge-plan-review.sh"
           }
         ]
       },
@@ -20,11 +35,23 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/block-e2e-port-kill.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/nudge-simplify-before-commit.sh"
           }
         ]
       }
     ],
     "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/track-workflow-events.sh"
+          }
+        ]
+      },
       {
         "matcher": "Edit|Write",
         "hooks": [
@@ -60,6 +87,25 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/related-test.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/nudge-pr-review.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/stop-cycle-check.sh"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ AGENTS.md
 .claude/settings.local.json
 .claude/plans/
 .claude/scheduled_tasks.lock
+.claude/.workflow-state/
 .clone/
 .superpowers/
 skills-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,14 @@
 - [Design Decisions](docs/decisions.md) -- ADRs (001-029)
 - [Lessons Learned](docs/lessons-learned.md) -- 68 lessons including E2E testing gotchas
 
+## Development Workflow
+
+Quality over speed. Claude is an AI — time and effort have no cost. Never abbreviate steps. The only goal is the best possible work product.
+
+For every feature or fix: draft a plan (`/plan`), spawn adversarial agents to review the plan from multiple angles before writing any code, implement, run `/simplify`, then verify (`npm run typecheck` + `npm test`; add `npm run test:e2e` for client/integration changes), run whatever manual testing is possible (browser automation via `claude-in-chrome`, MCP probing, etc.), and prompt Bryan to complete any testing that requires human interaction before continuing. Then commit and open the PR with `/commit-commands:commit-push-pr`. After `/pr-review-toolkit:review-pr` surfaces findings, repeat: plan the fixes, adversarial agent review, implement, update PR.
+
+This is a two-person project (Bryan + Claude). Scope gates are minimal — if you encounter something broken while working, fix it rather than filing it for later. For small tangential fixes, bundle them in; for larger detours, note them and finish the current task first.
+
 ## Critical Rules
 
 These WILL break things if violated:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ Wired in `.claude/settings.json`. PreToolUse hooks exit 2 to block; PostToolUse 
 - `nudge-simplify-before-commit.sh` -- Warns on `git commit` when source edits have happened since last `/simplify` (one-shot per edit batch)
 
 **PostToolUse — unmatched (every tool):**
-- `track-workflow-events.sh` -- Records markers used by nudge hooks: `last-plan-write`, `last-source-edit`, `last-agent-call`, `last-simplify`, `last-commit`. Fast-paths uninteresting tools to skip the node spawn.
+- `track-workflow-events.sh` -- Records markers used by nudge hooks: `last-plan-write`, `last-source-edit`, `last-agent-call`, `last-simplify`, and `last-commit` (detected from successful `git commit` invocations in `Bash` tool calls). Also clears the `stop-nudged` marker on successful commit so the stop reminder can re-fire after the next edit cycle. Fast-paths uninteresting tools to skip the node spawn.
 
 **PostToolUse — `Edit|Write` matcher:**
 - `typecheck-on-edit.sh` -- Runs `tsc --noEmit` after `.ts`/`.tsx` edits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,14 +168,22 @@ Generic skills (accessibility, frontend-design, nodejs-backend-patterns, playwri
 
 ### Hooks (`.claude/hooks/`)
 
-Wired in `.claude/settings.json`. PreToolUse hooks exit 2 to block; PostToolUse hooks exit 0 (warn only).
+Wired in `.claude/settings.json`. PreToolUse hooks exit 2 to block; PostToolUse hooks exit 0 (warn only). Workflow-nudge hooks emit stderr but never block. Per-session state lives in `.claude/.workflow-state/<session_id>/` (gitignored, pruned at SessionStart after 7 days).
+
+**SessionStart — `startup` matcher:**
+- `sessionstart-prune-state.sh` -- Removes workflow-state dirs older than 7 days
 
 **PreToolUse — `Edit|Write` matcher:**
 - `block-sensitive.sh` -- Blocks edits to `.env`, `package-lock.json`, and other sensitive files
+- `nudge-plan-review.sh` -- Warns when a `.claude/plans/*.md` was written this session but no `Agent` tool has run before a source edit (one-shot per plan)
 
 **PreToolUse — `Bash` matcher:**
 - `block-no-verify.sh` -- Blocks `--no-verify` flag (Husky bypass); fail-closed on parse error
 - `block-e2e-port-kill.sh` -- Blocks E2E test commands that kill dev server ports (:3478/:3479)
+- `nudge-simplify-before-commit.sh` -- Warns on `git commit` when source edits have happened since last `/simplify` (one-shot per edit batch)
+
+**PostToolUse — unmatched (every tool):**
+- `track-workflow-events.sh` -- Records markers used by nudge hooks: `last-plan-write`, `last-source-edit`, `last-agent-call`, `last-simplify`, `last-commit`. Fast-paths uninteresting tools to skip the node spawn.
 
 **PostToolUse — `Edit|Write` matcher:**
 - `typecheck-on-edit.sh` -- Runs `tsc --noEmit` after `.ts`/`.tsx` edits
@@ -186,6 +194,12 @@ Wired in `.claude/settings.json`. PreToolUse hooks exit 2 to block; PostToolUse 
 - `check-token-violation.sh` -- Runs `scripts/check-semantic-tokens.ts` for raw hex/rgba in `src/client/`
 - `format-on-edit.sh` -- Runs Biome format on edited files
 - `related-test.sh` -- Runs matching vitest after source edits (opt-out: `TANDEM_SKIP_RELATED_TEST=1`)
+
+**PostToolUse — `Bash` matcher:**
+- `nudge-pr-review.sh` -- Reminds to run `/pr-review-toolkit:review-pr` after a successful `gh pr create`
+
+**Stop:**
+- `stop-cycle-check.sh` -- Informational nudge at turn end if session has uncommitted source edits (one-shot per session)
 
 ### Agents (`.claude/agents/`)
 

--- a/tests/hooks/test_workflow_state.sh
+++ b/tests/hooks/test_workflow_state.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Manual test fixture for .claude/hooks/_workflow-state.sh helpers and
+# track-workflow-events.sh's commit-clears-nudge behavior.
+#
+# Run from repo root:  bash tests/hooks/test_workflow_state.sh
+# Hard-fails on the first failing case (set -e + explicit guard).
+#
+# Pure bash; no bats dependency. CI-eligible from day one if wired into a
+# job that does `bash tests/hooks/test_workflow_state.sh`.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOKS_DIR="${REPO_ROOT}/.claude/hooks"
+
+# shellcheck source=../../.claude/hooks/_workflow-state.sh
+source "${HOOKS_DIR}/_workflow-state.sh"
+
+PASS_COUNT=0
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+# -----------------------------------------------------------------------------
+# _ws_is_source_edit
+# -----------------------------------------------------------------------------
+
+_ws_is_source_edit "src/client/App.svelte" \
+  && pass || fail "forward-slash src path should be a source edit"
+
+# Windows backslash path — this is the fix.
+_ws_is_source_edit 'src\client\App.svelte' \
+  && pass || fail "backslash-normalized src path should be a source edit"
+
+# Regression guard: exclusion (tests/) must survive backslash normalization.
+_ws_is_source_edit 'tests\client\foo.test.ts' \
+  && fail "backslash-normalized tests path must NOT be a source edit" \
+  || pass
+
+_ws_is_source_edit "src-tauri/src/lib.rs" \
+  && pass || fail "src-tauri path should be a source edit"
+
+_ws_is_source_edit "tests/client/foo.test.ts" \
+  && fail "tests/ path must NOT be a source edit" \
+  || pass
+
+_ws_is_source_edit "src/client/App.svelte.test.ts" \
+  && fail ".test.ts file under src/ must NOT be a source edit" \
+  || pass
+
+_ws_is_source_edit "src/notes/foo.md" \
+  && fail ".md file under src/ must NOT be a source edit" \
+  || pass
+
+_ws_is_source_edit "src/node_modules/x/index.js" \
+  && fail "node_modules under src/ must NOT be a source edit" \
+  || pass
+
+_ws_is_source_edit "" \
+  && fail "empty path must NOT be a source edit" \
+  || pass
+
+# -----------------------------------------------------------------------------
+# track-workflow-events.sh: commit clears stop-nudged
+# -----------------------------------------------------------------------------
+
+# Build a per-test session dir under a temp root.
+TMP_ROOT="$(mktemp -d 2>/dev/null || mktemp -d -t hookstest)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# We can't intercept the hook's internal _ws_state_dir resolution from outside
+# without env injection, so we test by invoking the hook with a known
+# session_id and then introspecting the state dir it creates under cwd.
+SESSION_ID="test-commit-clears-nudge-$$"
+EXPECTED_DIR="${REPO_ROOT}/.claude/.workflow-state/${SESSION_ID}"
+rm -rf "$EXPECTED_DIR" 2>/dev/null || true
+mkdir -p "$EXPECTED_DIR"
+
+# Pre-plant a stop-nudged mark in the session state dir.
+: > "${EXPECTED_DIR}/${_WS_MARK_STOP_NUDGED}"
+[[ -f "${EXPECTED_DIR}/${_WS_MARK_STOP_NUDGED}" ]] || fail "could not pre-plant stop-nudged mark"
+
+# Successful git commit -> nudge mark cleared.
+COMMIT_INPUT=$(cat <<EOF
+{"session_id":"${SESSION_ID}","tool_name":"Bash","tool_input":{"command":"git commit -m test"},"tool_response":{"exit_code":0}}
+EOF
+)
+cd "$REPO_ROOT"
+printf '%s' "$COMMIT_INPUT" | bash "${HOOKS_DIR}/track-workflow-events.sh" \
+  || fail "track-workflow-events.sh exited nonzero on successful-commit input"
+
+[[ ! -f "${EXPECTED_DIR}/${_WS_MARK_STOP_NUDGED}" ]] \
+  && pass || fail "stop-nudged mark must be cleared after successful git commit"
+
+[[ -f "${EXPECTED_DIR}/${_WS_MARK_COMMIT}" ]] \
+  && pass || fail "last-commit mark must be written on successful git commit"
+
+# Failed git commit -> nudge mark preserved.
+SESSION_ID="test-failed-commit-preserves-nudge-$$"
+EXPECTED_DIR="${REPO_ROOT}/.claude/.workflow-state/${SESSION_ID}"
+rm -rf "$EXPECTED_DIR" 2>/dev/null || true
+mkdir -p "$EXPECTED_DIR"
+: > "${EXPECTED_DIR}/${_WS_MARK_STOP_NUDGED}"
+
+FAILED_COMMIT_INPUT=$(cat <<EOF
+{"session_id":"${SESSION_ID}","tool_name":"Bash","tool_input":{"command":"git commit -m test"},"tool_response":{"exit_code":1}}
+EOF
+)
+printf '%s' "$FAILED_COMMIT_INPUT" | bash "${HOOKS_DIR}/track-workflow-events.sh" \
+  || fail "track-workflow-events.sh exited nonzero on failed-commit input"
+
+[[ -f "${EXPECTED_DIR}/${_WS_MARK_STOP_NUDGED}" ]] \
+  && pass || fail "stop-nudged mark must survive failed git commit"
+
+[[ ! -f "${EXPECTED_DIR}/${_WS_MARK_COMMIT}" ]] \
+  && pass || fail "last-commit mark must NOT be written on failed git commit"
+
+# Cleanup test session dirs.
+rm -rf "${REPO_ROOT}/.claude/.workflow-state/test-commit-clears-nudge-"* \
+       "${REPO_ROOT}/.claude/.workflow-state/test-failed-commit-preserves-nudge-"* 2>/dev/null || true
+
+echo "OK: ${PASS_COUNT} assertions passed."


### PR DESCRIPTION
## Summary

Codifies the development workflow we actually follow into both **prose** (`CLAUDE.md`) and **enforcement** (Claude Code hooks). The hooks are stderr nudges — they never block — to avoid training reflexive `[skip-gates]` bypasses while still surfacing the workflow at the right moments.

## What's in here

**Two commits:**

1. `feat(hooks)` — seven new bash hooks under `.claude/hooks/`:
   - `nudge-plan-review.sh` — warns when source edits happen after a plan write but before any `Agent` tool runs (one-shot per plan)
   - `nudge-simplify-before-commit.sh` — warns on `git commit` when source edits have happened since last `/simplify` (one-shot per edit batch)
   - `nudge-pr-review.sh` — reminds to run `/pr-review-toolkit:review-pr` after a successful `gh pr create`
   - `stop-cycle-check.sh` — informational nudge at turn end if session has uncommitted source edits (one-shot per session)
   - `sessionstart-prune-state.sh` — housekeeping (>7d state dirs)
   - `track-workflow-events.sh` — unmatched `PostToolUse` that records markers; uses a bash-regex fast-path to skip the node spawn for uninteresting tool calls (Read, Grep, Glob, etc.)
   - `_workflow-state.sh` — shared helpers (session-id parse with PID fallback, state dir, marker constants, `_ws_is_git_commit`, `_ws_is_source_edit`, `_ws_newer_than`, `_ws_mtime`, symlink-safe `_ws_mark` via temp+rename)

   Wired in `.claude/settings.json`; state dir `.claude/.workflow-state/` added to `.gitignore`. Hooks listing in `CLAUDE.md → Claude Code Automation → Hooks` updated.

2. `docs(claude-md)` — adds a `## Development Workflow` section to `CLAUDE.md` codifying the cycle the hooks enforce: plan → adversarial agent review → implement → `/simplify` → verify → manual test → commit → PR → `/pr-review-toolkit:review-pr` → plan fixes → review → implement → update PR. Also captures the quality-over-speed principle and the two-person-project scope policy.

## Why nudges, not gates

Earlier draft used hard `git commit` gates requiring fresh test/typecheck/`/simplify` evidence. Adversarial review of the plan surfaced two genuine problems with that approach:

1. The gate trips on micro-edits (any edit invalidates the test-pass marker, but `npm test` runs the full suite — slow enough that reflexive `[skip-gates: minor]` becomes habit within a week, making the gate worse than nothing).
2. `typecheck`/`test` enforcement is largely covered by existing `typecheck-on-edit.sh` + `related-test.sh` + Husky pre-push.

The novel signal is `/simplify` adherence and the plan-review-before-implement loop. Both make sense as nudges (informational, one-shot, never block).

## Adversarial-review fixes applied before push

Both rounds of agent review (correctness + security) caught concrete bugs that would have shipped broken otherwise:

- **NUL-delimited multi-field extraction** — command substitution (`$(...)`) strips NUL bytes, collapsing every field into the first slot. Switched to newline-delimited `mapfile -t`.
- **`--amend --no-edit` skip** false-positives on commit messages containing those flag strings — skip removed entirely (a one-shot nudge on a metadata amend is harmless).
- **PR-review fast-path** false-positives on commit messages containing `gh pr create` — gated on `tool_name=Bash` + anchored `^gh pr create` regex.
- **git commit detection** — handles `git -C path commit`, `git --git-dir=x commit`, `git -c k=v commit`; rejects `git commit-tree` / `commit-graph` / `commitish` (12/12 edge cases verified).
- **`session_id` sanitizer** — rejects dot-only segments (no path traversal); falls back to `pid-$PPID` when missing (no shared `default/` collisions across parallel sessions).
- **Windows backslash normalization** — done inside the node parser; verified end-to-end with a literal-backslash JSON fixture round-tripping `C:\Users\foo\src\server\index.ts` → `last-source-edit` marker.
- **Empty `PLAN_PATH`** early-exits instead of producing a stable SHA1-of-empty hash that would burn the per-plan one-shot globally.
- **`_ws_mark` writes** go through temp+rename so a planted symlink at the marker path can't redirect writes outside the state dir.

## Test plan

- [x] Synthetic-JSON fixtures verify each hook's behavior end-to-end (positive + negative cases, retry suppression, Windows paths, fast-path short-circuit)
- [x] All 12 git-commit edge cases pass (`git -C`, `--git-dir=`, `-c k=v`, `commit-tree`, `commit-graph`, `commitish`, prefix-only "echo git commit")
- [ ] Real-world dogfood — first session after merge will exercise the hooks live
- [ ] Verify `Stop` hook doesn't fire after every tool turn (per-session marker suppresses)
- [ ] Verify `SessionStart` matcher fires the prune hook

## Out of scope

- Hard commit gates (re-evaluate in a month if nudges aren't enough)
- "Fix-don't-file" enforcement — pure judgment call, no signal to hook on
- Adversarial review beyond a session-level nudge — too many false positives if stricter

🤖 Generated with [Claude Code](https://claude.com/claude-code)