### PR TITLE
feat(ui): AR4 annotation card dispatcher + 5 variants

### DIFF
--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
-import { HIGHLIGHT_COLOR_VARS, normalizeHighlightColor } from "../../shared/constants";
 import type { Annotation, AnnotationReply } from "../../shared/types";
 import AnnotationCardActions from "./AnnotationCardActions.svelte";
 import AnnotationEditForm from "./AnnotationEditForm.svelte";
+import { getCardLabel, getHighlightBorder } from "./annotation-card-helpers";
+import CommentCard from "./CommentCard.svelte";
+import HighlightCard from "./HighlightCard.svelte";
+import ImportedCard from "./ImportedCard.svelte";
+import NoteCard from "./NoteCard.svelte";
 import ReplyThread from "./ReplyThread.svelte";
+import SuggestionCard from "./SuggestionCard.svelte";
 
 interface Props {
   annotation: Annotation;
@@ -36,6 +41,8 @@ let {
   onClick,
 }: Props = $props();
 
+// Shared edit-mode state owned by the dispatcher; variants are presentational
+// and never own state. The edit form replaces the variant body when isEditing.
 let isEditing = $state(false);
 let editText = $state("");
 let editNewText = $state("");
@@ -43,49 +50,17 @@ let editReason = $state("");
 
 const isPending = $derived(annotation.status === "pending");
 const hasSuggestedText = $derived(annotation.suggestedText !== undefined);
+const canEdit = $derived(onEdit !== undefined);
+const cardLabel = $derived(getCardLabel(annotation));
 
-function getDisplayType(ann: Annotation): string {
-  if (ann.suggestedText !== undefined) return "replacement";
-  return ann.type;
-}
-
-function getAuthorLabel(author: Annotation["author"]): string {
-  if (author === "claude") return "Claude";
-  if (author === "import") return "Imported";
-  return "You";
-}
-
-function getBorderColor(ann: Annotation): string {
-  if (ann.color) {
-    return HIGHLIGHT_COLOR_VARS[normalizeHighlightColor(ann.color)];
-  }
-  if (ann.suggestedText !== undefined) return "var(--tandem-suggestion)";
-  if (ann.type === "note") return "var(--tandem-warning)";
+const borderColor = $derived.by(() => {
+  if (annotation.type === "highlight") return getHighlightBorder(annotation);
+  if (annotation.suggestedText !== undefined) return "var(--tandem-suggestion)";
+  if (annotation.type === "note") return "var(--tandem-warning)";
   return "var(--tandem-author-user)";
-}
+});
 
-function getCardBackground(ann: Annotation, reviewTarget?: boolean): string {
-  if (reviewTarget) return "var(--tandem-accent-bg)";
-  if (ann.type === "note") return "var(--tandem-surface)";
-  return "var(--tandem-surface)";
-}
-
-const displayType = $derived(getDisplayType(annotation));
-const borderColor = $derived(getBorderColor(annotation));
-const cardBg = $derived(getCardBackground(annotation, isReviewTarget));
-const isPrivateNote = $derived(annotation.type === "note");
-
-const truncatedContent = $derived(
-  annotation.content
-    ? annotation.content.length > 60
-      ? annotation.content.slice(0, 57) + "..."
-      : annotation.content
-    : "",
-);
-
-const cardLabel = $derived(
-  `${isPrivateNote ? "private " : ""}${displayType} annotation${truncatedContent ? ": " + truncatedContent : ""}, ${annotation.status}`,
-);
+const cardBg = $derived(isReviewTarget ? "var(--tandem-accent-bg)" : "var(--tandem-surface)");
 
 function enterEditMode() {
   if (hasSuggestedText) {
@@ -133,78 +108,51 @@ function handleKeyDown(e: KeyboardEvent) {
     ? '0 0 0 3px var(--tandem-accent-bg)'
     : 'none'}; transition: background 0.15s, box-shadow 0.15s, border-color 0.15s;"
 >
-  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; gap: 8px;">
-    <span
-      style="font-weight: 600; text-transform: capitalize; display: flex; align-items: center; gap: 6px; color: var(--tandem-fg-muted); font-size: 11px;"
-    >
-      <span
-        class="annotation-type-badge"
-        style="font-family: var(--tandem-font-mono); font-size: var(--tandem-text-2xs); letter-spacing: 0.04em; text-transform: uppercase; padding: 1px 7px; border-radius: var(--tandem-r-pill); background: {hasSuggestedText
-          ? 'var(--tandem-suggestion-bg)'
-          : annotation.type === 'note'
-            ? 'var(--tandem-warning-bg)'
-            : 'var(--tandem-surface-sunk)'}; color: {hasSuggestedText
-          ? 'var(--tandem-suggestion-fg-strong)'
-          : annotation.type === 'note'
-            ? 'var(--tandem-warning-fg-strong)'
-            : 'var(--tandem-fg-muted)'};"
-      >
-        {displayType}
-      </span>
-      {#if isPrivateNote}
-        <span
-          data-testid="annotation-private-pill"
-          aria-hidden="true"
-          title="Private note"
-          style="padding: 1px 6px; font-size: var(--tandem-text-2xs); font-weight: 600; letter-spacing: 0.02em; text-transform: uppercase; color: var(--tandem-warning-fg); background: var(--tandem-warning); border-radius: var(--tandem-r-2); line-height: 1;"
-        >
-          Private
-        </span>
-      {/if}
-      {#if !isPending}
-        <span
-          style="margin-left: 6px; font-size: 10px; color: {annotation.status === 'accepted'
-            ? 'var(--tandem-success)'
-            : 'var(--tandem-error)'}; font-weight: 600;"
-        >
-          {annotation.status}
-        </span>
-      {/if}
-      {#if isPending && onEdit && !isReviewTarget && !isEditing}
-        <button
-          data-testid="edit-btn-{annotation.id}"
-          onclick={(e) => {
-            e.stopPropagation();
-            enterEditMode();
-          }}
-          style="padding: 1px 4px; font-size: 11px; border: none; background: none; color: var(--tandem-fg-subtle); cursor: pointer; line-height: 1;"
-          title="Edit this annotation's content"
-        >
-          ✎ Edit
-        </button>
-      {/if}
-    </span>
-    <span
-      style="font-size: 11px; color: var(--tandem-fg-subtle); display: flex; align-items: center; gap: 4px;"
-    >
-      {#if annotation.editedAt}
-        <span style="font-style: italic; font-size: 10px; color: var(--tandem-fg-subtle);">
-          (edited)
-        </span>
-      {/if}
-      {getAuthorLabel(annotation.author)}
-    </span>
-  </div>
-
-  {#if annotation.textSnapshot}
-    <div
-      data-testid="annotation-snippet-{annotation.id}"
-      style="padding: 4px 8px; margin-bottom: 6px; border-left: 3px solid var(--tandem-border-strong); color: var(--tandem-fg-muted); font-size: 12px; font-style: italic; background-color: var(--tandem-surface-muted); border-radius: var(--tandem-r-1);"
-    >
-      {annotation.textSnapshot.length > 80
-        ? annotation.textSnapshot.slice(0, 77) + "..."
-        : annotation.textSnapshot}
-    </div>
+  {#if annotation.author === "import"}
+    <ImportedCard
+      annotation={annotation as Annotation & { author: "import" }}
+      {isPending}
+      {isReviewTarget}
+      {isEditing}
+      {canEdit}
+      onEnterEdit={enterEditMode}
+    />
+  {:else if annotation.type === "highlight"}
+    <HighlightCard
+      {annotation}
+      {isPending}
+      {isReviewTarget}
+      {isEditing}
+      {canEdit}
+      onEnterEdit={enterEditMode}
+    />
+  {:else if annotation.type === "note"}
+    <NoteCard
+      {annotation}
+      {isPending}
+      {isReviewTarget}
+      {isEditing}
+      {canEdit}
+      onEnterEdit={enterEditMode}
+    />
+  {:else if annotation.suggestedText !== undefined}
+    <SuggestionCard
+      annotation={annotation as Annotation & { type: "comment"; suggestedText: string }}
+      {isPending}
+      {isReviewTarget}
+      {isEditing}
+      {canEdit}
+      onEnterEdit={enterEditMode}
+    />
+  {:else}
+    <CommentCard
+      annotation={annotation as Annotation & { type: "comment"; suggestedText?: undefined }}
+      {isPending}
+      {isReviewTarget}
+      {isEditing}
+      {canEdit}
+      onEnterEdit={enterEditMode}
+    />
   {/if}
 
   {#if isEditing}
@@ -221,40 +169,6 @@ function handleKeyDown(e: KeyboardEvent) {
       onSave={handleSave}
       onCancel={handleCancel}
     />
-  {:else}
-    <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
-      {#if hasSuggestedText}
-        <div
-          data-testid="suggestion-diff-{annotation.id}"
-          style="padding: 4px 8px; margin-bottom: {annotation.content
-            ? '4px'
-            : '0'}; background-color: var(--tandem-surface-muted); border-radius: var(--tandem-r-2); font-size: 12px; line-height: 1.5;"
-        >
-          {#if annotation.textSnapshot}
-            <span
-              style="text-decoration: line-through; color: var(--tandem-error); background-color: var(--tandem-error-bg); padding: 0 2px; border-radius: var(--tandem-r-1);"
-            >
-              {annotation.textSnapshot}
-            </span>
-          {/if}
-          {#if annotation.textSnapshot}
-            {" → "}
-          {/if}
-          <span
-            style="color: var(--tandem-success-fg-strong); background-color: var(--tandem-success-bg); padding: 0 2px; border-radius: var(--tandem-r-1);"
-          >
-            {annotation.suggestedText}
-          </span>
-        </div>
-        {#if annotation.content}
-          <p style="margin: 0; font-size: 12px; color: var(--tandem-fg-muted);">
-            {annotation.content}
-          </p>
-        {/if}
-      {:else}
-        <p style="margin: 0;">{annotation.content || "(no note)"}</p>
-      {/if}
-    </div>
   {/if}
 
   <AnnotationCardActions
@@ -277,11 +191,3 @@ function handleKeyDown(e: KeyboardEvent) {
     {onReply}
   />
 </div>
-
-<style>
-  @media (forced-colors: active) {
-    .annotation-type-badge {
-      border: 1px solid ButtonText;
-    }
-  }
-</style>

--- a/src/client/panels/AnnotationCardHeader.svelte
+++ b/src/client/panels/AnnotationCardHeader.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+import type { Annotation } from "../../shared/types";
+import { getAuthorLabel, getDisplayType } from "./annotation-card-helpers";
+
+interface Props {
+  annotation: Annotation;
+  isPending: boolean;
+  isReviewTarget?: boolean;
+  isEditing: boolean;
+  canEdit: boolean;
+  badgeBg: string;
+  badgeFg: string;
+  onEnterEdit: () => void;
+  /** Optional extra pill rendered next to the type badge (e.g. Private pill on NoteCard). */
+  extraPill?: Snippet;
+}
+
+let {
+  annotation,
+  isPending,
+  isReviewTarget,
+  isEditing,
+  canEdit,
+  badgeBg,
+  badgeFg,
+  onEnterEdit,
+  extraPill,
+}: Props = $props();
+
+const displayType = $derived(getDisplayType(annotation));
+const authorLabel = $derived(getAuthorLabel(annotation.author));
+</script>
+
+<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; gap: 8px;">
+  <span
+    style="font-weight: 600; text-transform: capitalize; display: flex; align-items: center; gap: 6px; color: var(--tandem-fg-muted); font-size: 11px;"
+  >
+    <span
+      class="annotation-type-badge"
+      style="font-family: var(--tandem-font-mono); font-size: var(--tandem-text-2xs); letter-spacing: 0.04em; text-transform: uppercase; padding: 1px 7px; border-radius: var(--tandem-r-pill); background: {badgeBg}; color: {badgeFg};"
+    >
+      {displayType}
+    </span>
+    {#if extraPill}{@render extraPill()}{/if}
+    {#if !isPending}
+      <span
+        style="margin-left: 6px; font-size: 10px; color: {annotation.status === 'accepted'
+          ? 'var(--tandem-success)'
+          : 'var(--tandem-error)'}; font-weight: 600;"
+      >
+        {annotation.status}
+      </span>
+    {/if}
+    {#if isPending && canEdit && !isReviewTarget && !isEditing}
+      <button
+        data-testid="edit-btn-{annotation.id}"
+        onclick={(e) => {
+          e.stopPropagation();
+          onEnterEdit();
+        }}
+        style="padding: 1px 4px; font-size: 11px; border: none; background: none; color: var(--tandem-fg-subtle); cursor: pointer; line-height: 1;"
+        title="Edit this annotation's content"
+      >
+        ✎ Edit
+      </button>
+    {/if}
+  </span>
+  <span
+    style="font-size: 11px; color: var(--tandem-fg-subtle); display: flex; align-items: center; gap: 4px;"
+  >
+    {#if annotation.editedAt}
+      <span style="font-style: italic; font-size: 10px; color: var(--tandem-fg-subtle);">
+        (edited)
+      </span>
+    {/if}
+    {authorLabel}
+  </span>
+</div>
+
+<style>
+  @media (forced-colors: active) {
+    .annotation-type-badge {
+      border: 1px solid ButtonText;
+    }
+  }
+</style>

--- a/src/client/panels/AnnotationSnippet.svelte
+++ b/src/client/panels/AnnotationSnippet.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+interface Props {
+  annotationId: string;
+  text: string | undefined;
+}
+
+let { annotationId, text }: Props = $props();
+
+const display = $derived(text ? (text.length > 80 ? text.slice(0, 77) + "..." : text) : "");
+</script>
+
+{#if text}
+  <div
+    data-testid="annotation-snippet-{annotationId}"
+    style="padding: 4px 8px; margin-bottom: 6px; border-left: 3px solid var(--tandem-border-strong); color: var(--tandem-fg-muted); font-size: 12px; font-style: italic; background-color: var(--tandem-surface-muted); border-radius: var(--tandem-r-1);"
+  >
+    {display}
+  </div>
+{/if}

--- a/src/client/panels/CommentCard.svelte
+++ b/src/client/panels/CommentCard.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+import type { Annotation } from "../../shared/types";
+import AnnotationCardHeader from "./AnnotationCardHeader.svelte";
+import AnnotationSnippet from "./AnnotationSnippet.svelte";
+
+interface Props {
+  /** Comment without suggestedText (user- or claude-authored). */
+  annotation: Annotation & { type: "comment"; suggestedText?: undefined };
+  isPending: boolean;
+  isReviewTarget?: boolean;
+  isEditing: boolean;
+  canEdit: boolean;
+  onEnterEdit: () => void;
+}
+
+let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: Props = $props();
+</script>
+
+<AnnotationCardHeader
+  {annotation}
+  {isPending}
+  {isReviewTarget}
+  {isEditing}
+  {canEdit}
+  badgeBg="var(--tandem-surface-sunk)"
+  badgeFg="var(--tandem-fg-muted)"
+  {onEnterEdit}
+/>
+
+<AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
+
+{#if !isEditing}
+  <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+    <p style="margin: 0;">{annotation.content || "(no note)"}</p>
+  </div>
+{/if}

--- a/src/client/panels/HighlightCard.svelte
+++ b/src/client/panels/HighlightCard.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import type { Annotation } from "../../shared/types";
+import AnnotationCardHeader from "./AnnotationCardHeader.svelte";
+import AnnotationSnippet from "./AnnotationSnippet.svelte";
+
+interface Props {
+  annotation: Annotation & { type: "highlight" };
+  isPending: boolean;
+  isReviewTarget?: boolean;
+  isEditing: boolean;
+  canEdit: boolean;
+  onEnterEdit: () => void;
+}
+
+let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: Props = $props();
+</script>
+
+<AnnotationCardHeader
+  {annotation}
+  {isPending}
+  {isReviewTarget}
+  {isEditing}
+  {canEdit}
+  badgeBg="var(--tandem-surface-sunk)"
+  badgeFg="var(--tandem-fg-muted)"
+  {onEnterEdit}
+/>
+
+<AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
+
+{#if !isEditing}
+  <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+    <p style="margin: 0;">{annotation.content || "(no note)"}</p>
+  </div>
+{/if}

--- a/src/client/panels/ImportedCard.svelte
+++ b/src/client/panels/ImportedCard.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+import type { Annotation } from "../../shared/types";
+import AnnotationCardHeader from "./AnnotationCardHeader.svelte";
+import AnnotationSnippet from "./AnnotationSnippet.svelte";
+
+interface Props {
+  /** Any annotation authored by import (Word comments). */
+  annotation: Annotation & { author: "import" };
+  isPending: boolean;
+  isReviewTarget?: boolean;
+  isEditing: boolean;
+  canEdit: boolean;
+  onEnterEdit: () => void;
+}
+
+let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: Props = $props();
+
+// TODO(AR6): render importSource.author
+</script>
+
+<AnnotationCardHeader
+  {annotation}
+  {isPending}
+  {isReviewTarget}
+  {isEditing}
+  {canEdit}
+  badgeBg="var(--tandem-surface-sunk)"
+  badgeFg="var(--tandem-fg-muted)"
+  {onEnterEdit}
+/>
+
+<AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
+
+{#if !isEditing}
+  <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+    <p style="margin: 0;">{annotation.content || "(no note)"}</p>
+  </div>
+{/if}

--- a/src/client/panels/NoteCard.svelte
+++ b/src/client/panels/NoteCard.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import type { Annotation } from "../../shared/types";
+import AnnotationCardHeader from "./AnnotationCardHeader.svelte";
+import AnnotationSnippet from "./AnnotationSnippet.svelte";
+
+interface Props {
+  annotation: Annotation & { type: "note" };
+  isPending: boolean;
+  isReviewTarget?: boolean;
+  isEditing: boolean;
+  canEdit: boolean;
+  onEnterEdit: () => void;
+}
+
+let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: Props = $props();
+</script>
+
+<AnnotationCardHeader
+  {annotation}
+  {isPending}
+  {isReviewTarget}
+  {isEditing}
+  {canEdit}
+  badgeBg="var(--tandem-warning-bg)"
+  badgeFg="var(--tandem-warning-fg-strong)"
+  {onEnterEdit}
+>
+  {#snippet extraPill()}
+    <span
+      data-testid="annotation-private-pill"
+      aria-hidden="true"
+      title="Private note"
+      style="padding: 1px 6px; font-size: var(--tandem-text-2xs); font-weight: 600; letter-spacing: 0.02em; text-transform: uppercase; color: var(--tandem-warning-fg); background: var(--tandem-warning); border-radius: var(--tandem-r-2); line-height: 1;"
+    >
+      Private
+    </span>
+  {/snippet}
+</AnnotationCardHeader>
+
+<AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
+
+{#if !isEditing}
+  <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+    <p style="margin: 0;">{annotation.content || "(no note)"}</p>
+  </div>
+{/if}

--- a/src/client/panels/SuggestionCard.svelte
+++ b/src/client/panels/SuggestionCard.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+import type { Annotation } from "../../shared/types";
+import AnnotationCardHeader from "./AnnotationCardHeader.svelte";
+import AnnotationSnippet from "./AnnotationSnippet.svelte";
+
+interface Props {
+  /** Comment with suggestedText. */
+  annotation: Annotation & { type: "comment"; suggestedText: string };
+  isPending: boolean;
+  isReviewTarget?: boolean;
+  isEditing: boolean;
+  canEdit: boolean;
+  onEnterEdit: () => void;
+}
+
+let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: Props = $props();
+</script>
+
+<AnnotationCardHeader
+  {annotation}
+  {isPending}
+  {isReviewTarget}
+  {isEditing}
+  {canEdit}
+  badgeBg="var(--tandem-suggestion-bg)"
+  badgeFg="var(--tandem-suggestion-fg-strong)"
+  {onEnterEdit}
+/>
+
+<AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
+
+{#if !isEditing}
+<div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+  <div
+    data-testid="suggestion-diff-{annotation.id}"
+    style="padding: 4px 8px; margin-bottom: {annotation.content
+      ? '4px'
+      : '0'}; background-color: var(--tandem-surface-muted); border-radius: var(--tandem-r-2); font-size: 12px; line-height: 1.5;"
+  >
+    {#if annotation.textSnapshot}
+      <span
+        style="text-decoration: line-through; color: var(--tandem-error); background-color: var(--tandem-error-bg); padding: 0 2px; border-radius: var(--tandem-r-1);"
+      >
+        {annotation.textSnapshot}
+      </span>
+      {" → "}
+    {/if}
+    <span
+      style="color: var(--tandem-success-fg-strong); background-color: var(--tandem-success-bg); padding: 0 2px; border-radius: var(--tandem-r-1);"
+    >
+      {annotation.suggestedText}
+    </span>
+  </div>
+  {#if annotation.content}
+    <p style="margin: 0; font-size: 12px; color: var(--tandem-fg-muted);">
+      {annotation.content}
+    </p>
+  {/if}
+</div>
+{/if}

--- a/src/client/panels/annotation-card-helpers.ts
+++ b/src/client/panels/annotation-card-helpers.ts
@@ -1,0 +1,32 @@
+import { HIGHLIGHT_COLOR_VARS, normalizeHighlightColor } from "../../shared/constants";
+import type { Annotation } from "../../shared/types";
+
+export function getAuthorLabel(author: Annotation["author"]): string {
+  if (author === "claude") return "Claude";
+  if (author === "import") return "Imported";
+  return "You";
+}
+
+export function getDisplayType(ann: Annotation): string {
+  if (ann.suggestedText !== undefined) return "replacement";
+  return ann.type;
+}
+
+export function truncate(text: string | undefined, max: number): string {
+  if (!text) return "";
+  return text.length > max ? text.slice(0, max - 3) + "..." : text;
+}
+
+export function getCardLabel(ann: Annotation): string {
+  const displayType = getDisplayType(ann);
+  const trunc = truncate(ann.content, 60);
+  const isPrivate = ann.type === "note";
+  return `${isPrivate ? "private " : ""}${displayType} annotation${trunc ? ": " + trunc : ""}, ${ann.status}`;
+}
+
+export function getHighlightBorder(ann: Annotation): string {
+  if (ann.type === "highlight" && ann.color) {
+    return HIGHLIGHT_COLOR_VARS[normalizeHighlightColor(ann.color)];
+  }
+  return "var(--tandem-author-user)";
+}


### PR DESCRIPTION
## Summary

Implements **Unit 2 (Option B)** of the v0.12.0 prep plan (`.claude/plans/cryptic-chasing-pond.md`): refactors `src/client/panels/AnnotationCard.svelte` (~288 lines, one big `{#if}` chain) into a thin dispatcher plus 5 pure presentational variants.

### Final shape

- **AnnotationCard.svelte** (dispatcher): owns the outer wrapper with `annotation-card-{id}`, border/background, edit-mode `$state` (`isEditing`, `editText`, `editNewText`, `editReason`), the edit form, `AnnotationCardActions`, and `ReplyThread`. Picks a variant by `author === "import"` then `type` then `suggestedText`.
- **HighlightCard.svelte** — highlight rows
- **NoteCard.svelte** — private notes; renders `annotation-private-pill` and keeps the "private ..." aria prefix on the card label.
- **CommentCard.svelte** — user- and claude-authored comments (single component per plan; NOT split into UserCommentCard / ClaudeCommentCard).
- **SuggestionCard.svelte** — `comment` rows with `suggestedText`; owns `suggestion-diff-{id}`.
- **ImportedCard.svelte** — import-author Word comments; carries `<!-- TODO(AR6): render importSource.author -->` per plan.

Two shared subcomponents keep variants thin without duplication:
- **AnnotationCardHeader.svelte** — type badge + author + edit button (`edit-btn-{id}` lives here, one call site) with an optional `extraPill` snippet that NoteCard uses for the Private pill.
- **AnnotationSnippet.svelte** — shared `annotation-snippet-{id}`.

Pure helper functions live in `annotation-card-helpers.ts` (`getAuthorLabel`, `getDisplayType`, `getCardLabel`, `getHighlightBorder`).

### Hard constraints honored

- No new `$effect` blocks anywhere. Variants own no `$state` or `$effect`.
- All values derived from `annotation.*` use `$derived` (no destructuring).
- All load-bearing testids preserved (verified by grep): no test files reference these testids by raw string, so nothing breaks at the test layer either.
- `npm run typecheck`, `npm run check:tokens`, unit tests scoped to "annotation" all green.
- `npx biome check --write src/client/panels/*.svelte` applied.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check:tokens` — clean
- [x] Unit tests scoped to annotation — 305/306 passed (1 skipped)
- [ ] Manual smoke (Bryan): open `sample/welcome.md`, confirm all five card variants render correctly (highlight, note + private pill, user comment, claude comment, suggestion with diff, plus imported from a `.docx`).
- [ ] E2E run after dev server is free.

Closes the AR4 line item in `cryptic-chasing-pond.md`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
