### PR TITLE
fix(#622): merge reloadFromDisk transacts via skipTransact

### DIFF
--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -866,18 +866,23 @@ async function reloadFromDisk(id: string, filePath: string, format: string): Pro
     );
 
     if (annotations.length > 0) {
-      const refreshed = refreshAllRanges(annotations, doc, annotationMap);
-
-      // 4. Second pass: textSnapshot-based relocation for annotations with stale relRanges.
+      // Merge the refresh + textSnapshot relocation passes into a single
+      // MCP_ORIGIN transaction. Origin tag is intentionally MCP_ORIGIN (NOT
+      // FILE_SYNC_ORIGIN): these writes update durable annotation state
+      // (range + relRange) that must persist through the durable-annotation
+      // sync observer. The sync observer skips FILE_SYNC_ORIGIN; the channel
+      // observer skips both origins, so there's no phantom channel echo to
+      // silence here. Flipping to FILE_SYNC_ORIGIN would re-introduce the
+      // PR-A1 post-merge blocker (commit 8d9c0ce).
       //
-      // Origin tag is intentionally MCP_ORIGIN (NOT FILE_SYNC_ORIGIN) because these
-      // writes update durable annotation state (range + relRange) that must persist
-      // through the durable-annotation sync observer. The sync observer skips
-      // FILE_SYNC_ORIGIN; the channel observer skips both origins, so there's no
-      // phantom channel echo to silence here. Flipping back to FILE_SYNC_ORIGIN
-      // would re-introduce the PR-A1 post-merge blocker (commit 8d9c0ce). See
-      // GH #622 for the related pre-existing two-write crash window.
+      // Merging into one transact closes the pre-existing two-write crash
+      // window (GH #622) — a process kill between the refresh and relocation
+      // passes previously left annotations durably stored at partially
+      // refreshed ranges.
       doc.transact(() => {
+        const refreshed = refreshAllRanges(annotations, doc, annotationMap, { skipTransact: true });
+
+        // 4. Second pass: textSnapshot-based relocation for annotations with stale relRanges.
         for (const ann of refreshed) {
           if (!ann.textSnapshot) continue;
 

--- a/src/server/positions.ts
+++ b/src/server/positions.ts
@@ -348,17 +348,31 @@ export function refreshRange(ann: Annotation, ydoc: Y.Doc, map?: Y.Map<unknown>)
   return updated;
 }
 
-/** Refresh all annotations in a batch, wrapping Y.Map writes in a transaction. */
+/**
+ * Refresh all annotations in a batch, wrapping Y.Map writes in a transaction.
+ *
+ * When `skipTransact` is true, writes happen inline without wrapping a
+ * `ydoc.transact`. The caller is responsible for providing an outer
+ * transaction with the appropriate origin. Used by `reloadFromDisk` to merge
+ * this pass with the subsequent textSnapshot relocation pass into a single
+ * `MCP_ORIGIN` transaction (closes the two-write crash window — GH #622).
+ */
 export function refreshAllRanges(
   annotations: Annotation[],
   ydoc: Y.Doc,
   map: Y.Map<unknown>,
+  opts?: { skipTransact?: boolean },
 ): Annotation[] {
   const results: Annotation[] = [];
-  ydoc.transact(() => {
+  const run = () => {
     for (const ann of annotations) {
       results.push(refreshRange(ann, ydoc, map));
     }
-  }, MCP_ORIGIN);
+  };
+  if (opts?.skipTransact) {
+    run();
+  } else {
+    ydoc.transact(run, MCP_ORIGIN);
+  }
   return results;
 }

--- a/tests/server/reload-from-disk-persistence.test.ts
+++ b/tests/server/reload-from-disk-persistence.test.ts
@@ -16,9 +16,9 @@
  * proves that an observer with the production skip rule actually receives
  * the relocation write.
  *
- * Related GH issue: #622 (pre-existing two-write crash window). When that
- * fix lands, transaction count for reload should drop from 2 → 1 — update
- * Test B accordingly.
+ * Related GH issue: #622 (pre-existing two-write crash window). The fix
+ * merges the two MCP_ORIGIN transactions into one via `skipTransact` —
+ * Test C below is the dedicated single-transaction regression guard.
  */
 
 import fs from "node:fs/promises";
@@ -238,5 +238,40 @@ describe("reloadFromDisk — origin sequence + persistence (PR-F1)", () => {
 
     expect(observedNonFileSyncWrites).toBeGreaterThanOrEqual(1);
     expect(lastObservedRange).toBeDefined();
+  });
+
+  it("Test C (#622): exactly ONE MCP_ORIGIN transaction writes to Y_MAP_ANNOTATIONS during reload", async () => {
+    // Closes the two-write crash window: refreshAllRanges + textSnapshot
+    // relocation are now merged into a single MCP_ORIGIN transact via
+    // `skipTransact: true`. A process kill between the two passes can no
+    // longer leave annotations durably stored at partially-refreshed ranges.
+    const { doc, filePath, triggerReload } = await setupOpenedFile("Hello world foo bar baz");
+
+    // Seed an annotation on "foo" so both passes have work to do (refresh +
+    // textSnapshot relocation, since we move "foo" on disk below).
+    seedAnnotationOnText(doc, "foo", "annotation on foo");
+
+    // Move "foo" to a different offset so relocation actually runs.
+    await fs.writeFile(filePath, "Greetings, world — foo bar baz\n", "utf-8");
+
+    const { records, detach } = listenForTransactions(doc);
+    try {
+      await triggerReload();
+    } finally {
+      detach();
+    }
+
+    const annMapRef = doc.getMap(Y_MAP_ANNOTATIONS);
+    const mcpAnnotationWrites = records.filter(
+      (r) => r.origin === MCP_ORIGIN && r.changedTypes.has(annMapRef),
+    );
+
+    expect(mcpAnnotationWrites).toHaveLength(1);
+
+    // The legitimate FILE_SYNC_ORIGIN content txn must still exist (durable
+    // sync skips it intentionally — this assertion guards against an
+    // overzealous fix that flips it to MCP_ORIGIN).
+    const fileSyncTxns = records.filter((r) => r.origin === FILE_SYNC_ORIGIN);
+    expect(fileSyncTxns.length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary

- Close the two-write crash window in `reloadFromDisk`: a process kill between the `refreshAllRanges` pass and the `textSnapshot` relocation pass previously left annotations durably stored at partially-refreshed ranges. Both passes now run inside a single `MCP_ORIGIN` transaction, so durable-sync flushes once and the relocated state is atomic.
- Add `skipTransact?: boolean` opt-in to `refreshAllRanges`. When true, the function does its writes inline without wrapping its own `doc.transact`; the caller provides the outer transaction. Existing read-path callers (`annotations.ts:439`, `:587`) keep the default self-transacting behavior and are unaffected.
- The content-repopulate transact in `reloadFromDisk` remains a separate `FILE_SYNC_ORIGIN` transaction — durable-sync intentionally skips that origin (`sync.ts:242`).

Per the documented fix shape in `docs/audit-v2-followups-plan.md:149-172`.

Closes #622

## Test plan

- [x] `npm run typecheck` — green
- [x] `npx vitest run tests/server/reload-from-disk-persistence.test.ts tests/server/reload.test.ts tests/server/positions.test.ts` — 39 passed
- [x] Test C (new): asserts exactly ONE `MCP_ORIGIN` transaction writes to `Y_MAP_ANNOTATIONS` during reload, and that the legitimate `FILE_SYNC_ORIGIN` content txn still exists (guards against an overzealous fix flipping it to `MCP_ORIGIN`)
- [x] Existing Test A (durable-sync-shaped observer fires for relocation) + Test B (origin sequence) still pass with merged transact

🤖 Generated with [Claude Code](https://claude.com/claude-code)