### PR TITLE
feat(#652): keep selection visible when editor loses focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
         --tandem-suggestion-bg: color-mix(in srgb, var(--tandem-suggestion) 10%, var(--tandem-surface));
         --tandem-suggestion-border: color-mix(in srgb, var(--tandem-suggestion) 40%, var(--tandem-border));
         --tandem-accent-border: oklch(0.84 0.10 var(--tandem-accent-h));
+        --tandem-selection-blurred-bg: color-mix(in srgb, var(--tandem-accent) 22%, transparent);
         --tandem-editor-font-family: var(--tandem-font-serif);
         --tandem-editor-font-size: 17px;
         --tandem-scrollbar-track: oklch(0.96 0.006 80);
@@ -187,6 +188,7 @@
         --tandem-suggestion-bg: #2e1065;
         --tandem-suggestion-border: #4c1d95;
         --tandem-accent-border: oklch(0.45 0.14 var(--tandem-accent-h));
+        --tandem-selection-blurred-bg: color-mix(in srgb, var(--tandem-accent) 32%, transparent);
         --tandem-scrollbar-track: oklch(0.16 0.012 270);
         --tandem-scrollbar-thumb: oklch(0.38 0.014 270);
         --tandem-highlight-yellow: rgba(255, 220, 0, 0.38);

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -21,6 +21,7 @@ import { AuthorshipExtension } from "./extensions/authorship";
 import { AwarenessExtension } from "./extensions/awareness";
 import { FindReplaceExtension } from "./extensions/find-replace";
 import { MarkdownHtmlExtension } from "./extensions/markdown-html";
+import { SelectionDecorationExtension } from "./extensions/selection-decoration";
 import { SlashCommandExtension } from "./extensions/slash-command";
 import "./editor.css";
 
@@ -154,6 +155,7 @@ $effect(() => {
       AwarenessExtension.configure({ ydoc }),
       SlashCommandExtension.configure({ onOpenChange: onSlashCommandMenuChange }),
       FindReplaceExtension,
+      SelectionDecorationExtension,
     ],
     editorProps: {
       attributes: {

--- a/src/client/editor/editor.css
+++ b/src/client/editor/editor.css
@@ -3,6 +3,19 @@
   font-size: var(--tandem-editor-font-size, 17px);
   line-height: 1.65;
 }
+/* Selection visibility when the editor loses focus.
+ * The browser's native ::selection background only paints while its containing
+ * element has focus. When an annotation popup or BubbleMenu input takes focus,
+ * the native highlight vanishes and users lose any visual signal of what's
+ * selected. SelectionDecorationExtension renders this class over the selection
+ * range; the focus-within rule below hides it during normal editing so native
+ * ::selection paints unobstructed. */
+.tandem-editor .tandem-selection-blurred {
+  background-color: var(--tandem-selection-blurred-bg);
+}
+.tandem-editor:focus-within .tandem-selection-blurred {
+  background-color: transparent;
+}
 .tandem-editor h1 {
   font-family: var(--tandem-editor-font-family);
   font-size: 2em;

--- a/src/client/editor/extensions/selection-decoration.ts
+++ b/src/client/editor/extensions/selection-decoration.ts
@@ -1,0 +1,43 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+export const selectionDecorationPluginKey = new PluginKey("tandemSelectionDecoration");
+
+/**
+ * Renders the active text-selection range as an inline decoration so the visual
+ * highlight survives focus loss. The browser's native `::selection` background only
+ * paints while its containing element has focus — when an annotation popup, BubbleMenu
+ * input, or any other surface takes focus, the native highlight vanishes and the user
+ * loses any signal of what they're about to act on. The decoration stays put.
+ *
+ * CSS in `editor.css` hides the decoration while `.tandem-editor:focus-within` so the
+ * native `::selection` paints unobstructed during normal editing; when focus leaves,
+ * the decoration becomes visible (a fainter accent fill — distinguishable from the
+ * active blue so the user knows the editor is no longer the focus owner).
+ *
+ * Only `TextSelection` is decorated. `NodeSelection` and `CellSelection` (tables)
+ * keep their own ProseMirror-provided visuals.
+ */
+export const SelectionDecorationExtension = Extension.create({
+  name: "tandemSelectionDecoration",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: selectionDecorationPluginKey,
+        props: {
+          decorations(state) {
+            const { selection } = state;
+            if (!(selection instanceof TextSelection)) return DecorationSet.empty;
+            const { from, to } = selection;
+            if (from === to) return DecorationSet.empty;
+            return DecorationSet.create(state.doc, [
+              Decoration.inline(from, to, { class: "tandem-selection-blurred" }),
+            ]);
+          },
+        },
+      }),
+    ];
+  },
+});


### PR DESCRIPTION
## Summary

- New `SelectionDecorationExtension` (~30 LOC PM plugin) wrapped as a Tiptap extension
- CSS class `.tandem-selection-blurred` painted via `--tandem-selection-blurred-bg` token (light + dark)
- Hidden when `.tandem-editor:focus-within` so native `::selection` paints unobstructed during editing
- Only `TextSelection` is decorated; `NodeSelection` / `CellSelection` keep PM's defaults

## Why

The annotation selection popup auto-focuses its textarea (`Toolbar.svelte:185-189`), stealing focus from the editor. Native `::selection` only paints while its containing element has focus, so the visual highlight vanished the moment the popup opened — the user lost any signal of what they were about to annotate. Bryan: *"the selected-text popup prevents the user from continuing to select text and also removes the visual indicator for text being in a selected state."*

`captureSelectionRange()` already preserves the selection at the data layer; this PR fixes the perceptual layer.

## Companion

#653 will replace the inline popup with a Tiptap BubbleMenu that doesn't steal focus in the first place — but the decoration plugin is still the right call: it makes selection visibility robust across all popup/menu surfaces (slash menu, find bar, palette, future surfaces).

## Test plan

- [ ] Select text in any document → see native `::selection` blue background as today
- [ ] Click on browser URL bar (or any non-editor element) → selection background switches to fainter accent fill, stays visible
- [ ] Click back into editor → fainter fill replaced by native `::selection`
- [ ] Empty selection (cursor only) → no decoration
- [ ] Verify in dark theme (different accent shade)
- [ ] Verify table cell selection still uses PM's CellSelection visual (not affected)
- [x] `npm run typecheck` — 0 errors, 0 warnings
- [x] `npm test` — 2033 passed, 6 skipped

Closes #652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)