### PR TITLE
fix(#653): selection popup no longer steals focus or blocks drag-extend

### DIFF
--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -182,10 +182,35 @@ $effect(() => {
   requestAnimationFrame(() => textareaEl?.focus());
 });
 
+// Selection-popup focus policy (#653): do NOT auto-focus the textarea on popup
+// mount. Auto-focus stole focus from the editor, which (a) cleared the browser's
+// native ::selection visual and (b) made it impossible for the user to extend the
+// selection by mouse drag (the editor was no longer the focus owner). Users now
+// click the textarea explicitly to type — the popup itself stays out of the way.
+//
+// Selection visibility while focus is elsewhere is handled by
+// SelectionDecorationExtension (#652).
+//
+// requestCommentFocus (Ctrl+Alt+M shortcut, lines 175–183) still focuses the
+// textarea — that's an explicit "give me a comment input now" intent, not a
+// passive selection.
+
+// Re-capture the selection range whenever it changes while the popup is open,
+// so a user who drag-extends past the initial selection ends up annotating the
+// extended range. Skip when the textarea has focus — the editor's selection
+// won't be moving in that case (the textarea owns the cursor), and re-capturing
+// would race the submit handlers.
 $effect(() => {
-  if (showPopup) {
-    untrack(() => textareaEl?.focus());
-  }
+  if (!editor || !showPopup) return;
+  const ed = editor;
+  const onSelChange = () => {
+    if (document.activeElement === textareaEl) return;
+    captureSelectionRange();
+  };
+  ed.on("selectionUpdate", onSelChange);
+  return () => {
+    if (!ed.isDestroyed) ed.off("selectionUpdate", onSelChange);
+  };
 });
 
 $effect(() => {


### PR DESCRIPTION
## Summary

- Removed the auto-focus `$effect` (`Toolbar.svelte:185-189` on master) that focused the popup textarea on mount
- Added a `selectionUpdate` listener `$effect` that re-captures the editor selection range whenever it changes while the popup is open — so drag-extending past the initial selection updates the annotation target
- Editor keeps focus the entire time the popup is visible; users click the textarea explicitly to type

## Why

Bryan: *"the selected-text popup prevents the user from continuing to select text and also removes the visual indicator for text being in a selected state."*

Both symptoms had the same root cause: auto-focusing the textarea on popup mount stole focus from the editor. That broke (a) the browser's native `::selection` visual (focus is required for the native highlight to paint) and (b) selection extension via mouse drag (the editor was no longer the focus owner so drags created new selections instead of extending).

`captureSelectionRange()` was already snapshotting the range at popup-mount time; that data-layer workaround stays. This PR fixes the perceptual + interaction layer.

## Companion

#652 ships `SelectionDecorationExtension` to keep the selection visual intact during *any* focus loss (slash menu, find bar, palette, future popups). The two PRs are complementary and can land in either order.

## Scope discipline

The full HANDOFF.md vision is to replace this inline popup with a Tiptap BubbleMenu (tippy.js positioning, format buttons B/I/S/code/heading/link in the bubble itself, removing FormattingToolbar from the persistent top bar). That's a bigger refactor — slated for Wave 2 of the v1.0 plan. This PR fixes the current bug without that scope.

## What's preserved

- `requestCommentFocus` (Ctrl+Alt+M shortcut, lines 175–183) still focuses the textarea explicitly — that's a deliberate "I want to type now" intent distinct from passive selection
- All existing `document.activeElement === textareaEl` guards (no-dismiss-on-scroll, no-clear-text-on-resize, no-position-jitter) keep working
- `captureSelectionRange()` capture-on-mount (line 161) still seeds `capturedRange` when the popup first appears

## Reviewer notes (svelte-migration-reviewer pass — green)

- New `$effect` captures `editor` into local `ed` at run-time; cleanup `.off()` against the captured instance (avoids `feedback_svelte_prop_in_effect_cleanup.md` retry-storm pattern)
- No reactive loop introduced — `showPopup` is `$derived` from inputs that don't include `capturedRange`
- Race window between `dismissPopup` and a stale `selectionUpdate` is harmless (next `showPopup`-false re-run zeros `capturedRange`)

## Test plan

- [ ] Select text → popup appears → editor still has focus → native `::selection` visible
- [ ] Drag to extend the selection past the initial range → popup target follows (verify by submitting and inspecting the annotation range)
- [ ] Click textarea → focus moves there → start typing → comment text accumulates
- [ ] Submit comment → annotation created with the correct (possibly extended) range
- [ ] Ctrl+Alt+M (when text selected) → textarea focused immediately as before
- [ ] Existing E2E `toolbar-redesign.spec.ts` passes (uses `input.fill()` which Playwright focuses automatically)
- [x] `npm run typecheck` — 0 errors, 0 warnings
- [x] `npm test` — 2033 passed, 6 skipped
- [x] Svelte-migration-reviewer agent — green

Closes #653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)