### PR TITLE
feat(#649): margin annotation view scaffolding (PR 1 of 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 - [Agent Workflow](.claude/skills/issue-pipeline/SKILL.md) -- 10-step agent-driven issue pipeline (`/issue-pipeline`)
 - [Roadmap](docs/roadmap.md) -- Phase 2+ roadmap, future extensions
 - [Design Decisions](docs/decisions.md) -- ADRs (001-029)
-- [Lessons Learned](docs/lessons-learned.md) -- 68 lessons including E2E testing gotchas
+- [Lessons Learned](docs/lessons-learned.md) -- 71 lessons including E2E testing gotchas, CORS-allowlist three-surface audits, and DOM-nested scroll sync for content-anchored overlays
 
 ## Development Workflow
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -654,3 +654,22 @@ Mirror the identical step already present in `tauri-release.yml`.
 **Companion lesson:** For reactive-race regressions where the bug requires interleaving an async event (a Yjs awareness ping re-deriving an upstream prop) *between* dragstart and drop, the synchronous `page.evaluate` recipe is not sufficient — the race never opens. Move that regression guard into a Vitest component test that uses `render` + `rerender` from `@testing-library/svelte` to simulate the mid-drag prop change explicitly. See `tests/client/DocumentTabs.svelte.test.ts` case B.
 
 **Key insight:** Playwright is a mouse simulator, not a DOM-event simulator. Whenever the production handler is listening on a non-pointer event family (drag, paste, contextmenu, etc.), assume Playwright's high-level helpers won't fire it and dispatch the event explicitly. Verify by running the proposed spec against a bugged version of the code *before* trusting it as a regression guard.
+
+## 71. DOM-Nested Positioning Beats Manual Scroll Sync for Content-Anchored Overlays
+
+**Problem:** PR #657 (#649 margin annotation view PR 1) needed to render bubbles in the document gutter at the vertical position of their anchor text, and have those bubbles follow the text as the user scrolls. The natural-but-wrong design is "margin column is a sibling of the editor at the scroll-container box level, with a `scroll` listener that re-applies `transform: translateY(-scrollTop)` to all bubbles." That path forces an rAF-throttled scroll listener, drags in identity-comparison plumbing to avoid the `effect_update_depth_exceeded` Svelte gotcha (see lessons in `feedback_svelte_state_bind_this_loop` and `feedback_svelte_effect_depth_guard` for prior incidents in this repo), and still produces sub-frame jitter on fast scrolls because the listener fires after layout has already painted.
+
+**Solution:** Nest the overlay inside a `position: relative` positioning layer that wraps the editor content, all inside the existing `.editor-scroll` overflow container. Compute each bubble's `top` as `view.coordsAtPos(pos).top - layer.getBoundingClientRect().top`. That value is **scroll-invariant** by construction — both terms shift by the same `scrollTop` when the user scrolls, so the difference is constant. The bubble scrolls naturally because it lives inside the layer, which is inside the scrolling content.
+
+**Recompute triggers (still required):**
+- `editor.on("transaction", ...)` — doc edits move anchors
+- `ResizeObserver` on the positioning layer — width/font changes reflow
+- **Not** `scroll` — by design
+
+**Failure handling:**
+1. **`coordsAtPos` throws on invalid positions** (deleted nodes, mid-transaction Y.js state, freshly-inserted but not-yet-rendered ranges). Wrap per-annotation in `try/catch` and skip the offending bubble for the frame — one stale anchor must not kill the whole render pass.
+2. **Sub-pixel jitter from reflow is real.** Compare last and next position maps with a 0.5px tolerance before re-assigning the reactive `$state`. Without the tolerance, a `clientHeight: 700.0` → `699.7` reflow propagates into every downstream `$effect` that reads the map.
+
+**Where this lives:** `src/client/hooks/useMarginPositions.svelte.ts` (composable), `src/client/panels/MarginColumn.svelte` (overlay container), `src/client/App.svelte` (positioning-layer wrapper around the editor branch). See PR #657 commit `49ec66f`.
+
+**Key insight:** Whenever a brief sounds like *"X should appear next to Y and follow it as the user scrolls,"* the right move is DOM nesting, not listener plumbing. The "free scroll sync" comes from putting the overlay inside the same scrolling content as its anchor — the browser does the work the listener would have done, and you only need to react to actual layout changes. Reach for this pattern for sticky-position indicators, gutter dots, inline suggestion previews, comment bubbles, and similar content-anchored UI.

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -1040,9 +1040,27 @@ const tutorial = createTutorial(
     <!-- Positioning layer for margin annotation bubbles (#649). The layer
          wraps editor content so its block height matches the editor's, and
          scroll sync between text and bubbles is free (both live inside the
-         same scrolling block). When marginView is off, the layer is a
-         transparent passthrough. -->
-    <div bind:this={marginLayerEl} style="position: relative;">
+         same scrolling block).
+
+         INVARIANT 1 — no re-bind: this <div> must remain mounted across
+         marginView toggles. `marginLayerEl` is a $state ref read inside
+         useMarginPositions's $effect, which subscribes; re-binding via
+         {#if}/{#key} would cause listener teardown/rebuild storms (the
+         feedback_svelte_state_bind_this_loop pattern). Use `display:
+         contents` when off — wrapper is layout-invisible, so default-off
+         users get the master-branch layout with no new containing block,
+         and the bind stays stable.
+
+         INVARIANT 2 — getEnabled() short-circuit ordering: recompute()
+         reads layer.getBoundingClientRect() ONLY after the getEnabled()
+         early-return. `display: contents` elements return a zero-size
+         rect, so bypassing that guard would silently produce
+         layerTop=0 and page-relative bubble offsets. Don't move the
+         guard. -->
+    <div
+      bind:this={marginLayerEl}
+      style={settingsState.settings.marginView ? "position: relative;" : "display: contents;"}
+    >
       <!-- DocxPageContainer wraps Editor for .docx; format is stable per activeTab.id key guard —
            both branches share the same onEditorReady to update the editor ref -->
       {#if activeTab?.format === "docx"}

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -45,6 +45,7 @@ import { createRootEditorFont } from "./hooks/useEditorFont.svelte";
 import { createFileDrop } from "./hooks/useFileDrop.svelte";
 import { shouldDispatchFindNav } from "./hooks/useFindShortcuts.js";
 import { createHighContrast } from "./hooks/useHighContrast.svelte";
+import { createMarginPositions } from "./hooks/useMarginPositions.svelte";
 import { shouldShowInMode } from "./hooks/useModeGate";
 import { createNotifications } from "./hooks/useNotifications.svelte";
 import { isSettingsShortcut } from "./hooks/useSettingsShortcut.js";
@@ -59,6 +60,7 @@ import { createWebViewZoom } from "./hooks/useWebViewZoom.svelte";
 import { createYjsSync } from "./hooks/yjsSync.svelte";
 import { loadPanelWidth, PANEL_MAX_WIDTH, PANEL_MIN_WIDTH } from "./panel-layout";
 import type { FilterAuthor, FilterStatus, FilterType } from "./panels/FilterBar.svelte";
+import MarginColumn from "./panels/MarginColumn.svelte";
 import RailTabPicker from "./panels/RailTabPicker.svelte";
 import { useAnnotationReview } from "./panels/useAnnotationReview.svelte";
 import { pmSelectionToFlat } from "./positions";
@@ -349,6 +351,7 @@ let activeAnnotationId = $state<string | null>(null);
 let showHelp = $state(false);
 let capturedAnchor = $state<CapturedAnchor | null>(null);
 let editor = $state<TiptapEditor | null>(null);
+let marginLayerEl = $state<HTMLDivElement | null>(null);
 let slashCommandMenuOpen = $state(false);
 let findBarOpen = $state(false);
 let findBarForceScope = $state<"doc" | "tabs">("doc");
@@ -713,6 +716,28 @@ const review = useAnnotationReview({
   getActiveAnnotationId: () => activeAnnotationId,
 });
 
+// #649: Word-style margin annotation view.
+// PR 1 ships minimum viable — bubbles appear at correct Y, naive scroll sync
+// via DOM nesting in the positioning layer. Collision resolution lands in
+// PR 2; rail-collapse and narrow-layout auto-disable in PR 3.
+const marginNotes = $derived(
+  settingsState.settings.marginView
+    ? modeGate.visibleAnnotations.filter((a) => a.type === "note")
+    : [],
+);
+const marginComments = $derived(
+  settingsState.settings.marginView
+    ? modeGate.visibleAnnotations.filter((a) => a.author === "import" || a.type === "comment")
+    : [],
+);
+const marginPositions = createMarginPositions({
+  getEditor: () => editor,
+  getYdoc: () => activeTab?.ydoc ?? null,
+  getAnnotations: () => [...marginNotes, ...marginComments],
+  getLayerEl: () => marginLayerEl,
+  getEnabled: () => settingsState.settings.marginView,
+});
+
 const tutorial = createTutorial(
   () => modeGate.visibleAnnotations,
   () => editor,
@@ -1012,25 +1037,62 @@ const tutorial = createTutorial(
         onSlashCommandMenuChange={(open) => (slashCommandMenuOpen = open)}
       />
     {/snippet}
-    <!-- DocxPageContainer wraps Editor for .docx; format is stable per activeTab.id key guard —
-         both branches share the same onEditorReady to update the editor ref -->
-    {#if activeTab?.format === "docx"}
-      <DocxPageContainer>
-        {#key activeTab.id}
-          {@render editorContent()}
-        {/key}
-      </DocxPageContainer>
-    {:else}
-      <div style={`max-width: ${editorMaxWidth ?? "68ch"}; margin: ${editorMargin ?? "0 auto"};`}>
-        {#if activeTab}
+    <!-- Positioning layer for margin annotation bubbles (#649). The layer
+         wraps editor content so its block height matches the editor's, and
+         scroll sync between text and bubbles is free (both live inside the
+         same scrolling block). When marginView is off, the layer is a
+         transparent passthrough. -->
+    <div bind:this={marginLayerEl} style="position: relative;">
+      <!-- DocxPageContainer wraps Editor for .docx; format is stable per activeTab.id key guard —
+           both branches share the same onEditorReady to update the editor ref -->
+      {#if activeTab?.format === "docx"}
+        <DocxPageContainer>
           {#key activeTab.id}
             {@render editorContent()}
           {/key}
-        {:else}
-          <EmptyState connected={yjsSync.connected} claudeActive={yjsSync.claudeActive} />
-        {/if}
-      </div>
-    {/if}
+        </DocxPageContainer>
+      {:else}
+        <div style={`max-width: ${editorMaxWidth ?? "68ch"}; margin: ${editorMargin ?? "0 auto"};`}>
+          {#if activeTab}
+            {#key activeTab.id}
+              {@render editorContent()}
+            {/key}
+          {:else}
+            <EmptyState connected={yjsSync.connected} claudeActive={yjsSync.claudeActive} />
+          {/if}
+        </div>
+      {/if}
+      {#if settingsState.settings.marginView && activeTab}
+        <MarginColumn
+          side="left"
+          annotations={marginNotes}
+          positions={marginPositions.byId}
+          width={240}
+          edgeInset={8}
+          {activeAnnotationId}
+          repliesById={new Map()}
+          onClick={(ann) => {
+            activeAnnotationId = ann.id;
+            review.scrollToAnnotation(ann);
+          }}
+        />
+        <MarginColumn
+          side="right"
+          annotations={marginComments}
+          positions={marginPositions.byId}
+          width={240}
+          edgeInset={8}
+          {activeAnnotationId}
+          repliesById={new Map()}
+          onClick={(ann) => {
+            activeAnnotationId = ann.id;
+            review.scrollToAnnotation(ann);
+          }}
+          onAccept={review.handleAccept}
+          onDismiss={review.handleDismiss}
+        />
+      {/if}
+    </div>
     <!-- Find/Replace bar — always mounted so query persists; overlaid at bottom of editor column -->
     <FindReplaceBar
       {editor}

--- a/src/client/components/SettingsPopover.svelte
+++ b/src/client/components/SettingsPopover.svelte
@@ -560,6 +560,19 @@ function aboutRows() {
               />
               <span>Show floating selection toolbar</span>
             </label>
+
+            <label
+              data-testid="margin-view-toggle"
+              style="display: flex; align-items: center; gap: var(--tandem-space-2); cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+            >
+              <input
+                type="checkbox"
+                checked={settings.marginView}
+                onchange={(e) => onUpdate({ marginView: (e.target as HTMLInputElement).checked })}
+                style="accent-color: var(--tandem-accent);"
+              />
+              <span>Margin annotation view (Word-style)</span>
+            </label>
             {#if isTauriRuntime()}
               {#await import("./CoworkSettings.svelte")}
                 <div

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -267,7 +267,12 @@ async function handleEditorClick(e: MouseEvent) {
 }
 </script>
 
-<div bind:this={editorRoot} onclick={handleEditorClick} role="presentation"></div>
+<div
+  bind:this={editorRoot}
+  onclick={handleEditorClick}
+  role="presentation"
+  data-testid="editor-root"
+></div>
 
 <style>
   /* Apply editor font to the Tiptap content DOM (inside Tiptap's own element tree). */

--- a/src/client/hooks/useMarginPositions.svelte.ts
+++ b/src/client/hooks/useMarginPositions.svelte.ts
@@ -1,0 +1,131 @@
+import type { Editor as TiptapEditor } from "@tiptap/core";
+import type * as Y from "yjs";
+import type { Annotation } from "../../shared/types.js";
+import { annotationToPmRange } from "../positions.js";
+
+export interface MarginPositions {
+  /** Vertical offset in pixels from the positioning layer's top, keyed by annotation id. */
+  readonly byId: ReadonlyMap<string, number>;
+}
+
+export interface CreateMarginPositionsOpts {
+  getEditor: () => TiptapEditor | null;
+  getYdoc: () => Y.Doc | null;
+  getAnnotations: () => readonly Annotation[];
+  getLayerEl: () => HTMLElement | null;
+  /** When false, the composable parks itself: no listeners, no recompute. */
+  getEnabled: () => boolean;
+}
+
+/**
+ * Computes vertical offsets for margin-view annotation bubbles.
+ *
+ * Each offset is the bubble's `top` relative to a positioning layer that wraps
+ * the editor. Because the layer scrolls together with the editor content,
+ * scroll position is NOT a recompute trigger — only doc transactions and
+ * layout reflows are.
+ *
+ * Failure modes handled:
+ *   - `coordsAtPos` throws on positions inside deleted/mid-transaction nodes →
+ *     that annotation is skipped for the frame, others still render.
+ *   - Effect depth: the last-value guard (`mapsEqual`) prevents floating-point
+ *     jitter from re-triggering `$effect`s downstream.
+ */
+export function createMarginPositions(opts: CreateMarginPositionsOpts): MarginPositions {
+  let byId = $state<Map<string, number>>(new Map());
+  let scheduled = false;
+
+  function recompute(): void {
+    scheduled = false;
+    if (!opts.getEnabled()) {
+      if (byId.size > 0) byId = new Map();
+      return;
+    }
+    const editor = opts.getEditor();
+    const layer = opts.getLayerEl();
+    const ydoc = opts.getYdoc();
+    if (!editor || !layer || !ydoc) {
+      if (byId.size > 0) byId = new Map();
+      return;
+    }
+
+    const layerTop = layer.getBoundingClientRect().top;
+    const next = new Map<string, number>();
+    for (const ann of opts.getAnnotations()) {
+      const range = annotationToPmRange(ann, editor.state.doc, ydoc);
+      if (!range) continue;
+      try {
+        const coords = editor.view.coordsAtPos(range.from);
+        next.set(ann.id, coords.top - layerTop);
+      } catch {
+        // Stale or mid-transaction position — skip this annotation for now.
+        // Next transaction or layout change will retry.
+      }
+    }
+
+    if (mapsEqual(byId, next)) return;
+    byId = next;
+  }
+
+  function schedule(): void {
+    if (scheduled) return;
+    scheduled = true;
+    requestAnimationFrame(recompute);
+  }
+
+  // Wire/teardown listeners when editor or layer becomes available (or disabled flips).
+  $effect(() => {
+    if (!opts.getEnabled()) return;
+    const editor = opts.getEditor();
+    const layer = opts.getLayerEl();
+    if (!editor || !layer) return;
+
+    const onTx = (): void => schedule();
+    editor.on("transaction", onTx);
+
+    const ro = new ResizeObserver(() => schedule());
+    ro.observe(layer);
+
+    schedule();
+
+    return () => {
+      editor.off("transaction", onTx);
+      ro.disconnect();
+    };
+  });
+
+  // Recompute when the annotation set changes (additions, deletions, edits).
+  $effect(() => {
+    // Touch the annotations array so this effect tracks its identity.
+    void opts.getAnnotations();
+    schedule();
+  });
+
+  return {
+    get byId() {
+      return byId;
+    },
+  };
+}
+
+/**
+ * Equal within a 0.5px tolerance. Subpixel jitter from layout reflow should
+ * NOT trigger downstream re-renders.
+ *
+ * Exported for unit testing only.
+ */
+export function _mapsEqualForTesting(
+  a: ReadonlyMap<string, number>,
+  b: ReadonlyMap<string, number>,
+): boolean {
+  return mapsEqual(a, b);
+}
+
+function mapsEqual(a: ReadonlyMap<string, number>, b: ReadonlyMap<string, number>): boolean {
+  if (a.size !== b.size) return false;
+  for (const [k, v] of a) {
+    const bv = b.get(k);
+    if (bv === undefined || Math.abs(bv - v) > 0.5) return false;
+  }
+  return true;
+}

--- a/src/client/hooks/useMarginPositions.svelte.ts
+++ b/src/client/hooks/useMarginPositions.svelte.ts
@@ -17,6 +17,83 @@ export interface CreateMarginPositionsOpts {
   getEnabled: () => boolean;
 }
 
+export interface ComputeResult {
+  positions: Map<string, number>;
+  /** Annotations whose range resolved (i.e. we tried to read coords). */
+  attempted: number;
+  /** Of those attempted, how many threw from coordsAtPos. */
+  thrown: number;
+}
+
+/**
+ * Pure helper: compute per-annotation top offsets relative to a layer.
+ *
+ * Extracted from `createMarginPositions` so the loop body is unit-testable
+ * without a live Tiptap view or Svelte effect root.
+ *
+ * - Annotations whose range fails to resolve are silently skipped (not counted
+ *   as attempted — they're not anchor-staleness signals).
+ * - `coordsAtPos` throws on stale/mid-transaction positions → counted as
+ *   `thrown` so the caller can detect systemic failure (e.g. detached view).
+ * - Non-finite `coords.top` (NaN/Infinity from degenerate layout, e.g.
+ *   `display: none` ancestor) is skipped — it would render as `top: NaNpx`
+ *   and defeat the `mapsEqual` tolerance check (NaN-vs-anything is always
+ *   "unequal", causing per-frame re-render storms).
+ */
+export function _computeNextPositionsForTesting(
+  annotations: readonly Annotation[],
+  resolveRange: (ann: Annotation) => { from: number; to: number } | null,
+  coordsAtPos: (pos: number) => { top: number },
+  layerTop: number,
+): ComputeResult {
+  const positions = new Map<string, number>();
+  let attempted = 0;
+  let thrown = 0;
+  for (const ann of annotations) {
+    const range = resolveRange(ann);
+    if (!range) continue;
+    attempted++;
+    try {
+      const coords = coordsAtPos(range.from);
+      if (!Number.isFinite(coords.top)) continue;
+      positions.set(ann.id, coords.top - layerTop);
+    } catch {
+      thrown++;
+    }
+  }
+  return { positions, attempted, thrown };
+}
+
+export interface Scheduler {
+  schedule: () => void;
+  cancel: () => void;
+}
+
+/**
+ * rAF-throttled callback runner. One pending frame at a time; `cancel`
+ * aborts the pending frame without running the callback.
+ *
+ * Extracted for unit-testability — `vi.useFakeTimers({ toFake:
+ * ['requestAnimationFrame', 'cancelAnimationFrame'] })` can drive it.
+ */
+export function createScheduler(fn: () => void): Scheduler {
+  let rafId: number | null = null;
+  return {
+    schedule(): void {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        fn();
+      });
+    },
+    cancel(): void {
+      if (rafId === null) return;
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    },
+  };
+}
+
 /**
  * Computes vertical offsets for margin-view annotation bubbles.
  *
@@ -28,15 +105,17 @@ export interface CreateMarginPositionsOpts {
  * Failure modes handled:
  *   - `coordsAtPos` throws on positions inside deleted/mid-transaction nodes →
  *     that annotation is skipped for the frame, others still render.
+ *   - 100% of attempted anchors throwing → systemic (detached view, post-reload
+ *     Y.Doc swap); emit a single warn per recompute.
+ *   - Non-finite coords → skipped before the mapsEqual tolerance can be
+ *     defeated by NaN comparisons.
  *   - Effect depth: the last-value guard (`mapsEqual`) prevents floating-point
  *     jitter from re-triggering `$effect`s downstream.
  */
 export function createMarginPositions(opts: CreateMarginPositionsOpts): MarginPositions {
   let byId = $state<Map<string, number>>(new Map());
-  let scheduled = false;
 
   function recompute(): void {
-    scheduled = false;
     if (!opts.getEnabled()) {
       if (byId.size > 0) byId = new Map();
       return;
@@ -50,28 +129,25 @@ export function createMarginPositions(opts: CreateMarginPositionsOpts): MarginPo
     }
 
     const layerTop = layer.getBoundingClientRect().top;
-    const next = new Map<string, number>();
-    for (const ann of opts.getAnnotations()) {
-      const range = annotationToPmRange(ann, editor.state.doc, ydoc);
-      if (!range) continue;
-      try {
-        const coords = editor.view.coordsAtPos(range.from);
-        next.set(ann.id, coords.top - layerTop);
-      } catch {
-        // Stale or mid-transaction position — skip this annotation for now.
-        // Next transaction or layout change will retry.
-      }
+    const annotations = opts.getAnnotations();
+    const { positions, attempted, thrown } = _computeNextPositionsForTesting(
+      annotations,
+      (ann) => annotationToPmRange(ann, editor.state.doc, ydoc),
+      (pos) => editor.view.coordsAtPos(pos),
+      layerTop,
+    );
+
+    if (attempted > 0 && thrown === attempted) {
+      console.warn(
+        `[margin] coordsAtPos threw for all ${attempted} annotations — view may be detached`,
+      );
     }
 
-    if (mapsEqual(byId, next)) return;
-    byId = next;
+    if (mapsEqual(byId, positions)) return;
+    byId = positions;
   }
 
-  function schedule(): void {
-    if (scheduled) return;
-    scheduled = true;
-    requestAnimationFrame(recompute);
-  }
+  const scheduler = createScheduler(recompute);
 
   // Wire/teardown listeners when editor or layer becomes available (or disabled flips).
   $effect(() => {
@@ -80,25 +156,25 @@ export function createMarginPositions(opts: CreateMarginPositionsOpts): MarginPo
     const layer = opts.getLayerEl();
     if (!editor || !layer) return;
 
-    const onTx = (): void => schedule();
+    const onTx = (): void => scheduler.schedule();
     editor.on("transaction", onTx);
 
-    const ro = new ResizeObserver(() => schedule());
+    const ro = new ResizeObserver(() => scheduler.schedule());
     ro.observe(layer);
 
-    schedule();
+    scheduler.schedule();
 
     return () => {
       editor.off("transaction", onTx);
       ro.disconnect();
+      scheduler.cancel();
     };
   });
 
   // Recompute when the annotation set changes (additions, deletions, edits).
   $effect(() => {
-    // Touch the annotations array so this effect tracks its identity.
     void opts.getAnnotations();
-    schedule();
+    scheduler.schedule();
   });
 
   return {

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -56,6 +56,8 @@ export interface TandemSettings {
   sidecarRetryStrategy: SidecarRetryStrategy;
   // TODO(v0.11.0): wire to annotation queuing in useModeGate
   holdAnnotationsWhileOffline: boolean;
+  // #649: opt-in Word-style margin annotation view (PR 1 — minimum viable; collision resolution in PR 2; narrow-layout fallback in PR 3)
+  marginView: boolean;
 }
 
 export const TEXT_SIZE_PX: Record<TextSize, number> = { s: 14, m: 16, l: 18 };
@@ -96,6 +98,7 @@ const DEFAULTS: TandemSettings = {
   degradedBannerDelayMs: 30000,
   sidecarRetryStrategy: "exponential",
   holdAnnotationsWhileOffline: true,
+  marginView: false,
 };
 
 const VALID_RAIL_TABS: RailTab[] = ["annotations", "chat", "outline"];
@@ -243,6 +246,7 @@ export function loadSettings(): TandemSettings {
             : DEFAULTS.holdAnnotationsWhileOffline,
         leftRailTabs: parseRailTabs(parsed.leftRailTabs, leftRailTabsFallback),
         rightRailTabs: parseRailTabs(parsed.rightRailTabs, DEFAULTS.rightRailTabs),
+        marginView: parsed.marginView === true,
       };
     } catch (err) {
       // Corrupt blob — log so "my prefs reset" reports are diagnosable instead

--- a/src/client/panels/MarginColumn.svelte
+++ b/src/client/panels/MarginColumn.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+import type { Annotation, AnnotationReply } from "../../shared/types";
+import AnnotationCard from "./AnnotationCard.svelte";
+
+interface Props {
+  /** Annotations destined for this side. Caller filters by type/author. */
+  annotations: readonly Annotation[];
+  /** Computed top offset in pixels (relative to the positioning layer), keyed by annotation id. */
+  positions: ReadonlyMap<string, number>;
+  side: "left" | "right";
+  /** Column width in pixels. */
+  width: number;
+  /** Distance from the column edge to the nearest scroll-container edge. */
+  edgeInset: number;
+  activeAnnotationId: string | null;
+  repliesById: Map<string, AnnotationReply[]>;
+  onClick: (annotation: Annotation) => void;
+  onAccept?: (id: string) => void;
+  onDismiss?: (id: string) => void;
+  onRemove?: (id: string) => void;
+  onEdit?: (id: string, content: string) => void;
+  onReply?: (id: string, text: string) => Promise<boolean>;
+  onSendToClaude?: (id: string) => void;
+}
+
+let {
+  annotations,
+  positions,
+  side,
+  width,
+  edgeInset,
+  activeAnnotationId,
+  repliesById,
+  onClick,
+  onAccept,
+  onDismiss,
+  onRemove,
+  onEdit,
+  onReply,
+  onSendToClaude,
+}: Props = $props();
+
+// Only render annotations whose position is known this frame; without a top
+// offset there is nowhere to place the bubble.
+const placeable = $derived(
+  annotations.filter((a) => positions.has(a.id) && a.status === "pending"),
+);
+</script>
+
+<div
+  data-testid="margin-column-{side}"
+  aria-label={side === "left" ? "Note bubbles" : "Comment bubbles"}
+  style="position: absolute; top: 0; {side}: {edgeInset}px; width: {width}px; pointer-events: none;"
+>
+  {#each placeable as ann (ann.id)}
+    {@const top = positions.get(ann.id) ?? 0}
+    <div
+      data-testid="margin-bubble-{ann.id}"
+      style="position: absolute; top: {top}px; {side}: 0; width: {width}px; pointer-events: auto;"
+    >
+      <AnnotationCard
+        annotation={ann}
+        replies={repliesById.get(ann.id) ?? []}
+        isReviewTarget={ann.id === activeAnnotationId}
+        onClick={() => onClick(ann)}
+        onAccept={ann.author !== "user" ? onAccept : undefined}
+        onDismiss={ann.author !== "user" ? onDismiss : undefined}
+        onRemove={ann.author === "user" ? onRemove : undefined}
+        onSendToClaude={ann.type === "note" ? onSendToClaude : undefined}
+        {onEdit}
+        {onReply}
+      />
+    </div>
+  {/each}
+</div>

--- a/tests/client/useMarginPositions.test.ts
+++ b/tests/client/useMarginPositions.test.ts
@@ -1,13 +1,34 @@
-import { describe, expect, it } from "vitest";
-import { _mapsEqualForTesting as mapsEqual } from "../../src/client/hooks/useMarginPositions.svelte.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _computeNextPositionsForTesting as computeNextPositions,
+  createScheduler,
+  _mapsEqualForTesting as mapsEqual,
+} from "../../src/client/hooks/useMarginPositions.svelte.js";
+import type { Annotation } from "../../src/shared/types.js";
 
 /**
- * Position tracking ships in PR 1 (#649). The composable depends on Svelte
- * runes and a real ProseMirror view, so we exercise it through manual smoke
- * testing rather than vitest. The pure-logic equality helper *is* unit-tested
- * here because it gates downstream re-renders — getting the tolerance wrong
- * causes either UI thrashing or stale-bubble bugs that are hard to diagnose.
+ * Position tracking ships in PR 1 (#649). The full composable depends on
+ * Svelte runes + a real ProseMirror view + a Y.Doc, so we exercise that
+ * end-to-end through Playwright and manual smoke. The pure-logic primitives
+ * (`mapsEqual`, `computeNextPositions`, `createScheduler`) ARE unit-tested
+ * here — they gate downstream re-renders and silent-failure signals, and
+ * getting them wrong causes UI thrashing or systemic-failure blind spots
+ * that are hard to diagnose at runtime.
  */
+
+function ann(id: string, overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id,
+    type: "comment",
+    author: "claude",
+    status: "pending",
+    range: { from: 0, to: 1 },
+    content: "",
+    timestamp: 0,
+    ...overrides,
+  } as Annotation;
+}
+
 describe("useMarginPositions / mapsEqual", () => {
   it("treats two empty maps as equal", () => {
     expect(mapsEqual(new Map(), new Map())).toBe(true);
@@ -50,5 +71,216 @@ describe("useMarginPositions / mapsEqual", () => {
     const a = new Map([["x", 100]]);
     const b = new Map([["y", 100]]);
     expect(mapsEqual(a, b)).toBe(false);
+  });
+});
+
+describe("useMarginPositions / computeNextPositions", () => {
+  it("returns empty result for empty annotation list", () => {
+    const r = computeNextPositions(
+      [],
+      () => ({ from: 0, to: 0 }),
+      () => ({ top: 0 }),
+      0,
+    );
+    expect(r.positions.size).toBe(0);
+    expect(r.attempted).toBe(0);
+    expect(r.thrown).toBe(0);
+  });
+
+  it("does NOT count null-range annotations as attempted (they aren't anchor-staleness signals)", () => {
+    const r = computeNextPositions(
+      [ann("a"), ann("b"), ann("c")],
+      () => null,
+      () => ({ top: 0 }),
+      0,
+    );
+    expect(r.positions.size).toBe(0);
+    expect(r.attempted).toBe(0);
+    expect(r.thrown).toBe(0);
+  });
+
+  it("sets position relative to layerTop and counts attempted", () => {
+    const r = computeNextPositions(
+      [ann("a")],
+      () => ({ from: 5, to: 10 }),
+      () => ({ top: 150 }),
+      50,
+    );
+    expect(r.positions.get("a")).toBe(100);
+    expect(r.attempted).toBe(1);
+    expect(r.thrown).toBe(0);
+  });
+
+  it("skips annotations where coords.top is NaN (would defeat mapsEqual tolerance)", () => {
+    const r = computeNextPositions(
+      [ann("a")],
+      () => ({ from: 0, to: 0 }),
+      () => ({ top: Number.NaN }),
+      0,
+    );
+    expect(r.positions.has("a")).toBe(false);
+    expect(r.attempted).toBe(1);
+    expect(r.thrown).toBe(0);
+  });
+
+  it("skips annotations where coords.top is Infinity (degenerate layout)", () => {
+    const r = computeNextPositions(
+      [ann("a")],
+      () => ({ from: 0, to: 0 }),
+      () => ({ top: Number.POSITIVE_INFINITY }),
+      0,
+    );
+    expect(r.positions.has("a")).toBe(false);
+    expect(r.attempted).toBe(1);
+  });
+
+  it("counts thrown when coordsAtPos throws — one stale anchor doesn't blank the column", () => {
+    const r = computeNextPositions(
+      [ann("a"), ann("b"), ann("c")],
+      () => ({ from: 0, to: 0 }),
+      (pos) => {
+        if (pos === 0) {
+          // a, b, c all resolve to from:0 in this contrived test; the throw
+          // matters per call. Use a counter instead.
+        }
+        return { top: 0 };
+      },
+      0,
+    );
+    // All three pass — sanity baseline for the next case.
+    expect(r.positions.size).toBe(3);
+    expect(r.thrown).toBe(0);
+
+    let call = 0;
+    const r2 = computeNextPositions(
+      [ann("a"), ann("b"), ann("c")],
+      () => ({ from: 0, to: 0 }),
+      () => {
+        call++;
+        if (call === 2) throw new Error("stale position");
+        return { top: 100 };
+      },
+      0,
+    );
+    expect(r2.positions.has("a")).toBe(true);
+    expect(r2.positions.has("b")).toBe(false);
+    expect(r2.positions.has("c")).toBe(true);
+    expect(r2.attempted).toBe(3);
+    expect(r2.thrown).toBe(1);
+  });
+
+  it("reports thrown === attempted when every coordsAtPos throws — caller uses this as systemic signal", () => {
+    const r = computeNextPositions(
+      [ann("a"), ann("b"), ann("c")],
+      () => ({ from: 0, to: 0 }),
+      () => {
+        throw new Error("view detached");
+      },
+      0,
+    );
+    expect(r.positions.size).toBe(0);
+    expect(r.attempted).toBe(3);
+    expect(r.thrown).toBe(3);
+  });
+
+  it("does not raise the systemic signal when some throw and some succeed", () => {
+    let call = 0;
+    const r = computeNextPositions(
+      [ann("a"), ann("b"), ann("c")],
+      () => ({ from: 0, to: 0 }),
+      () => {
+        call++;
+        if (call % 2 === 0) throw new Error("stale");
+        return { top: 100 };
+      },
+      0,
+    );
+    expect(r.attempted).toBe(3);
+    expect(r.thrown).toBe(1);
+    // attempted !== thrown so caller will NOT warn
+    expect(r.thrown === r.attempted).toBe(false);
+  });
+});
+
+describe("useMarginPositions / createScheduler", () => {
+  let rafCallbacks: Map<number, FrameRequestCallback>;
+  let nextRafId: number;
+
+  beforeEach(() => {
+    rafCallbacks = new Map();
+    nextRafId = 1;
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback): number => {
+      const id = nextRafId++;
+      rafCallbacks.set(id, cb);
+      return id;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (id: number): void => {
+      rafCallbacks.delete(id);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function flushRaf(): void {
+    const pending = Array.from(rafCallbacks.entries());
+    rafCallbacks.clear();
+    for (const [, cb] of pending) cb(performance.now());
+  }
+
+  it("fires the callback once per schedule()", () => {
+    const fn = vi.fn();
+    const s = createScheduler(fn);
+    s.schedule();
+    flushRaf();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces multiple schedule() calls in the same tick into one frame", () => {
+    const fn = vi.fn();
+    const s = createScheduler(fn);
+    s.schedule();
+    s.schedule();
+    s.schedule();
+    flushRaf();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() prevents a pending frame from firing", () => {
+    const fn = vi.fn();
+    const s = createScheduler(fn);
+    s.schedule();
+    s.cancel();
+    flushRaf();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("schedule after cancel queues a new frame", () => {
+    const fn = vi.fn();
+    const s = createScheduler(fn);
+    s.schedule();
+    s.cancel();
+    s.schedule();
+    flushRaf();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-scheduling after the frame fires queues another", () => {
+    const fn = vi.fn();
+    const s = createScheduler(fn);
+    s.schedule();
+    flushRaf();
+    s.schedule();
+    flushRaf();
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancel() is a no-op when nothing is scheduled", () => {
+    const fn = vi.fn();
+    const s = createScheduler(fn);
+    expect(() => s.cancel()).not.toThrow();
+    flushRaf();
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/tests/client/useMarginPositions.test.ts
+++ b/tests/client/useMarginPositions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { _mapsEqualForTesting as mapsEqual } from "../../src/client/hooks/useMarginPositions.svelte.js";
+
+/**
+ * Position tracking ships in PR 1 (#649). The composable depends on Svelte
+ * runes and a real ProseMirror view, so we exercise it through manual smoke
+ * testing rather than vitest. The pure-logic equality helper *is* unit-tested
+ * here because it gates downstream re-renders — getting the tolerance wrong
+ * causes either UI thrashing or stale-bubble bugs that are hard to diagnose.
+ */
+describe("useMarginPositions / mapsEqual", () => {
+  it("treats two empty maps as equal", () => {
+    expect(mapsEqual(new Map(), new Map())).toBe(true);
+  });
+
+  it("considers identical maps equal", () => {
+    const a = new Map([
+      ["a", 100],
+      ["b", 200],
+    ]);
+    const b = new Map([
+      ["a", 100],
+      ["b", 200],
+    ]);
+    expect(mapsEqual(a, b)).toBe(true);
+  });
+
+  it("considers subpixel jitter (≤0.5px) equal — prevents UI thrash from layout reflow", () => {
+    const a = new Map([["x", 100]]);
+    const b = new Map([["x", 100.3]]);
+    expect(mapsEqual(a, b)).toBe(true);
+  });
+
+  it("considers shifts >0.5px unequal — real position changes must propagate", () => {
+    const a = new Map([["x", 100]]);
+    const b = new Map([["x", 101]]);
+    expect(mapsEqual(a, b)).toBe(false);
+  });
+
+  it("considers maps with different sizes unequal", () => {
+    const a = new Map([["x", 100]]);
+    const b = new Map([
+      ["x", 100],
+      ["y", 200],
+    ]);
+    expect(mapsEqual(a, b)).toBe(false);
+  });
+
+  it("considers maps with same size but different keys unequal", () => {
+    const a = new Map([["x", 100]]);
+    const b = new Map([["y", 100]]);
+    expect(mapsEqual(a, b)).toBe(false);
+  });
+});

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -256,6 +256,47 @@ describe("loadSettings — reduceMotion", () => {
   });
 });
 
+describe("loadSettings — marginView", () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = installLocalStorageStub();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to false when no settings are stored", () => {
+    expect(loadSettings().marginView).toBe(false);
+  });
+
+  it("defaults to false when settings exist but marginView key is absent", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ theme: "dark" }));
+    expect(loadSettings().marginView).toBe(false);
+  });
+
+  it("returns true for literal boolean true", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ marginView: true }));
+    expect(loadSettings().marginView).toBe(true);
+  });
+
+  it("returns false for the string 'true' (strict === true guard)", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ marginView: "true" }));
+    expect(loadSettings().marginView).toBe(false);
+  });
+
+  it("returns false for the number 1 (truthy non-boolean)", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ marginView: 1 }));
+    expect(loadSettings().marginView).toBe(false);
+  });
+
+  it("returns false for literal boolean false", () => {
+    store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ marginView: false }));
+    expect(loadSettings().marginView).toBe(false);
+  });
+});
+
 describe("useTandemSettings — updateSettings write path", () => {
   // mergeAndClampSettings is the pure core of updateSettings — exercising it
   // directly covers the clamp-on-write contract without spinning up a React
@@ -286,11 +327,17 @@ describe("useTandemSettings — updateSettings write path", () => {
     degradedBannerDelayMs: 30000,
     sidecarRetryStrategy: "exponential",
     holdAnnotationsWhileOffline: true,
+    marginView: false,
   };
 
   it("clamps editorWidthPercent above 100 down to 100", () => {
     const next = mergeAndClampSettings(BASE, { editorWidthPercent: 120 });
     expect(next.editorWidthPercent).toBe(100);
+  });
+
+  it("round-trips marginView=true through merge (write-side covers the strict-true load guard)", () => {
+    const next = mergeAndClampSettings(BASE, { marginView: true });
+    expect(next.marginView).toBe(true);
   });
 
   it("clamps editorWidthPercent below 40 up to 40", () => {
@@ -567,6 +614,7 @@ describe("mergeAndClampSettings — rail array clamps", () => {
     degradedBannerDelayMs: 30000,
     sidecarRetryStrategy: "exponential",
     holdAnnotationsWhileOffline: true,
+    marginView: false,
   };
 
   it("clamps leftRailTabs [] to default", () => {

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test } from "@playwright/test";
+import path from "path";
+import { TANDEM_SETTINGS_KEY } from "../../src/shared/constants";
+import {
+  cleanupAllOpenDocuments,
+  cleanupFixtureDir,
+  createFixtureDir,
+  McpTestClient,
+} from "./helpers";
+
+/**
+ * E2E coverage for #649 PR1 — Word-style margin annotation view.
+ *
+ * The composable underneath (`useMarginPositions`) requires a real Tiptap
+ * view + Y.Doc + Svelte effect root, so unit tests only cover its pure
+ * helpers. These specs exercise the toggle, persistence, default-off
+ * layout invariant, and the bubble click → activeAnnotationId contract.
+ */
+
+let mcp: McpTestClient;
+let tmpDir: string;
+
+// "# Test Document" — heading prefix is 2 chars, title spans 2..15.
+const TITLE_FROM = 2;
+const TITLE_TO = 15;
+const TITLE_TEXT = "Test Document";
+
+test.beforeEach(async () => {
+  mcp = new McpTestClient();
+  await mcp.connect();
+  tmpDir = createFixtureDir("sample.md");
+});
+
+test.afterEach(async () => {
+  await cleanupAllOpenDocuments(mcp);
+  await mcp.close();
+  cleanupFixtureDir(tmpDir);
+});
+
+async function openSettingsAndGotoCowork(page: import("@playwright/test").Page): Promise<void> {
+  await page.locator("[data-testid='settings-btn']").click();
+  const popover = page.locator("[data-testid='settings-popover']");
+  await expect(popover).toBeVisible({ timeout: 2_000 });
+  await popover.getByRole("button", { name: "Claude Code/Cowork" }).click();
+}
+
+async function setMarginView(
+  page: import("@playwright/test").Page,
+  enabled: boolean,
+): Promise<void> {
+  await openSettingsAndGotoCowork(page);
+  const popover = page.locator("[data-testid='settings-popover']");
+  const toggleInput = popover.locator("[data-testid='margin-view-toggle'] input");
+  if ((await toggleInput.isChecked()) !== enabled) {
+    await toggleInput.click();
+  }
+  await expect(toggleInput).toBeChecked({ checked: enabled });
+  // Close popover so it doesn't intercept later interactions.
+  await page.keyboard.press("Escape");
+}
+
+test("default off: margin columns are absent from the DOM", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "Margin candidate",
+    textSnapshot: TITLE_TEXT,
+  });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+
+  // Annotation decoration must render (proves the doc/annotation pipeline ran).
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+  // Columns absent before opt-in.
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(0);
+});
+
+test("toggle on: margin columns appear with a bubble for the comment", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "Margin candidate",
+    textSnapshot: TITLE_TEXT,
+  });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+
+  // Both columns mount when marginView is on (column visibility itself isn't a
+  // useful Playwright assertion — the columns have no intrinsic height because
+  // their bubble children are absolutely positioned). Assert presence instead.
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(1);
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+  // The comment bubble shows up in the right column with real geometry (allow
+  // rAF + ResizeObserver to settle).
+  const rightBubble = page
+    .locator("[data-testid='margin-column-right'] [data-testid^='margin-bubble-']")
+    .first();
+  await expect(rightBubble).toBeVisible({ timeout: 5_000 });
+});
+
+test("toggle state persists across reload", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+
+  await setMarginView(page, true);
+
+  const savedValue = await page.evaluate((key) => {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as { marginView?: unknown }).marginView : null;
+  }, TANDEM_SETTINGS_KEY);
+  expect(savedValue).toBe(true);
+
+  await page.reload();
+  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+
+  await openSettingsAndGotoCowork(page);
+  const reloadedToggleInput = page.locator(
+    "[data-testid='settings-popover'] [data-testid='margin-view-toggle'] input",
+  );
+  await expect(reloadedToggleInput).toBeChecked();
+});
+
+test("toggle off after on: columns disappear (validates display:contents wrapper fix)", async ({
+  page,
+}) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "Margin candidate",
+    textSnapshot: TITLE_TEXT,
+  });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+
+  await setMarginView(page, true);
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+  // Also wait for a real bubble to confirm the on-state is fully wired before
+  // we toggle off (otherwise the toggle-off race might pass for the wrong reason).
+  await expect(
+    page.locator("[data-testid='margin-column-right'] [data-testid^='margin-bubble-']").first(),
+  ).toBeVisible({ timeout: 5_000 });
+
+  await setMarginView(page, false);
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

Closes the scaffolding portion of #649 — Word-style margin comment bubbles. Adds an opt-in **Margin annotation view** behind a new `marginView` setting. Comments (Claude-created + Word imports) bubble out into a right gutter; user notes go left. Highlights stay inline.

This is **PR 1 of 3** (staging plan in the issue). It ships the minimum viable feature: positioning, rendering, accept/dismiss. Collision resolution, reply threads, rail-collapse, and narrow-layout fallback are explicitly deferred.

## Architecture

- **`useMarginPositions.svelte.ts`** — composable that converts annotation ranges to vertical offsets via `view.coordsAtPos()` measured against a layer ref. Recomputes on editor `transaction` + `ResizeObserver`, rAF-throttled. Wraps `coordsAtPos` in try/catch so one stale anchor (deleted/mid-transaction) doesn't kill the frame. Last-value guard with 0.5px tolerance prevents the `effect_update_depth_exceeded` class of Svelte bug from subpixel layout jitter.
- **`MarginColumn.svelte`** — absolutely-positioned column inside the editor's positioning layer; each bubble wraps the existing `AnnotationCard` at its computed `top` offset. Scroll sync is **free** because the layer lives inside the editor's scroll container and scrolls with content — no scroll listener needed.
- **`App.svelte`** — wraps the editor branch in a `position: relative` positioning layer (`bind:this={marginLayerEl}`); derives left/right annotation lists from `modeGate.visibleAnnotations` and renders the columns when `marginView` is on.

## What's in PR 1

- [x] `marginView` setting in `tandem:settings` (default off, opt-in)
- [x] Toggle in Settings popover (`data-testid="margin-view-toggle"`)
- [x] Position tracking with effect-depth guard + coordsAtPos failure handling
- [x] `MarginColumn` renders bubbles at correct Y; scroll sync via DOM nesting
- [x] Accept/Dismiss/Click wired to the existing `review` controller
- [x] `data-testid="editor-root"` for downstream E2E
- [x] 6 unit tests for `mapsEqual` tolerance

## Deferred (per advisor staging plan, see issue #649)

- **PR 2** — collision resolution + connector lines + Solo mode hold + reply thread subscription lifted to App level + Edit/Reply/Remove/SendToClaude handlers lifted from `SidePanel`
- **PR 3** — rail-collapse behavior (left and right) + narrow-layout auto-disable with empirically-determined threshold + full E2E coverage

## Test plan

- [ ] Toggle on via Settings → bubbles appear in the gutters next to their anchor text
- [ ] Scrolling the editor moves bubbles together with the text (no manual sync code)
- [ ] Typing into the editor (transactions) re-anchors bubbles within a frame
- [ ] Resizing the editor container reflows bubbles
- [ ] Accept/Dismiss from a bubble updates the annotation (same as sidebar)
- [ ] Click on a bubble focuses + scrolls to the annotation
- [ ] Toggle off → bubbles disappear, the sidebar list still works as before
- [ ] No console errors about effect depth or coordsAtPos throws

## Verification done

- `npm run typecheck` — clean
- `npm test` — 2040 pass; one unrelated pre-existing test-pollution flake in `tests/server/setup-api.test.ts` (passes in isolation, fails only in the full suite, regardless of this branch)
- Manual browser smoke — **not yet performed**; the dev server was in use during commit. Recommend a smoke pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)