### PR TITLE
chore(v1.0-§1H): verify redesign migrations shipped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 - [Agent Workflow](.claude/skills/issue-pipeline/SKILL.md) -- 10-step agent-driven issue pipeline (`/issue-pipeline`)
 - [Roadmap](docs/roadmap.md) -- Phase 2+ roadmap, future extensions
 - [Design Decisions](docs/decisions.md) -- ADRs (001-029)
-- [Lessons Learned](docs/lessons-learned.md) -- 72 lessons including E2E testing gotchas, CORS-allowlist three-surface audits, and DOM-nested scroll sync for content-anchored overlays
+- [Lessons Learned](docs/lessons-learned.md) -- 73 lessons including E2E testing gotchas, CORS-allowlist three-surface audits, DOM-nested scroll sync for content-anchored overlays, and schema-backed palette migrations
 
 ## Development Workflow
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -694,3 +694,16 @@ rg "ws://localhost" src/client
 Migrate every match in lockstep with the validator change. WebSocket URLs (`ws://localhost`) can be left alone *only if* the server's WebSocket gate is origin-based (Hocuspocus's is), not Host-based — the Origin header is the page origin, not the WS URL host.
 
 **Key insight:** "Narrow the allowlist" looks like a server-only change, but every client that hard-codes a hostname is implicitly part of the allowlist contract. Server tests passing don't prove the change is safe — they prove the validator works. The validator working is exactly what makes silent client-side regressions appear.
+
+## 73. Schema-Backed Enums Make Palette Migrations Self-Sanitizing
+
+**Problem:** When a UI palette changes (e.g. highlight colors `{red, yellow, green, blue, purple}` → `{yellow, green, blue, pink}`), old persisted annotations and stale clients can still produce legacy values. Naive renderers either crash, render an unstyled fallback, or leak the legacy color into the new UI.
+
+**Solution:** Two layers, both already in place for highlights as of v0.11.0 (verified during v1.0 §1H audit on master):
+
+1. **Zod schema as the boundary gate.** `HighlightColorSchema = z.enum(["yellow", "green", "blue", "pink"])` in `src/shared/types.ts`. Every MCP tool input is parsed through this schema, so a `tandem_addHighlight({ color: "red" })` call fails validation at the tool boundary with a clear error — it never reaches the Y.Map.
+2. **`normalizeHighlightColor()` as the read-time sanitizer.** `src/shared/constants.ts` exports `normalizeHighlightColor(color)` that returns `color as HighlightColor` if it's a key of `HIGHLIGHT_COLORS`, else falls back to `"yellow"`. Used by the renderer and toolbar so a legacy `"red"` highlight loaded from disk renders as yellow without throwing.
+
+**Verification (v1.0 §1H, 2026-05-14):** Grepping `src/client` for `"red"` / `"purple"` in highlight contexts returns zero matches. `HIGHLIGHT_COLORS` / `HIGHLIGHT_COLOR_VARS` / `HighlightColorSchema` all agree on `{yellow, green, blue, pink}`. The `showAuthorship` default is `true` in `useTandemSettings.ts`, and the loader preserves an explicit `false` while defaulting missing/legacy values to `true` (`parsed.showAuthorship === false ? false : DEFAULTS.showAuthorship`) — same self-sanitizing pattern, applied to a boolean default flip instead of an enum.
+
+**Key insight:** A palette or default-value migration doesn't need a one-shot migration script if both write paths (schema validation) and read paths (normalize-on-read) are owned. The schema rejects new bad data, the normalizer absorbs old bad data, and the system converges without a flag day. Worth checking both layers exist whenever someone proposes "let's change the default of X" — if only one is in place, you'll get either crashes (no normalizer) or silent persistence of the old default (no schema gate).


### PR DESCRIPTION
## Summary

Unit 15 of the v1.0 batch (§1H verification). Confirms that the two "likely shipped" redesign migrations are in fact present on master; no gap-shipping code needed. Captures the schema-gate + normalize-on-read pattern as lesson #73 so future palette/default migrations follow the same shape.

## Verification report

### 1. Highlight palette `{red, yellow, green, blue, purple}` → `{yellow, green, blue, pink}` — SHIPPED

- `src/shared/types.ts`: `HighlightColorSchema = z.enum(["yellow", "green", "blue", "pink"])` — zod rejects legacy colors at every MCP tool boundary.
- `src/shared/constants.ts`: `HIGHLIGHT_COLORS` and `HIGHLIGHT_COLOR_VARS` agree on the same four-color set; `normalizeHighlightColor()` falls back to `"yellow"` for any unknown stored color (read-time sanitizer for legacy annotations loaded from disk / older clients).
- `rg '"red"|"purple"' src/client` returns zero hits in highlight contexts.

Net: both write-path (schema) and read-path (normalizer) layers are present. A `tandem_addHighlight({ color: "red" })` call fails validation cleanly at the boundary; a legacy `"red"` highlight loaded from disk renders as yellow without throwing.

### 2. `showAuthorship` default flip `false` → `true` — SHIPPED

- `src/client/hooks/useTandemSettings.ts` line 84: `showAuthorship: true` in `DEFAULTS`.
- Loader (line 198): `parsed.showAuthorship === false ? false : DEFAULTS.showAuthorship` — preserves explicit user-set `false`, defaults any missing / legacy value to `true`. Same self-sanitizing shape as the highlight palette migration but applied to a boolean instead of an enum.
- Migration toast: the plan called this "optional"; no toast is shipped. Not filing a gap — the silent migration is consistent with how every other settings default change has shipped, and the visual change (orange/blue authorship colors appearing on first run) is its own signal.

### Bonus checks

- `rg 'data-author[^-]' src/client` → zero hits. All authorship decorations use `data-tandem-author` (per ADR-026).
- `rg 'var\(--accent\)|var\(--ink\)|var\(--surface\)' src/client` → zero hits. All semantic CSS variables are `--tandem-*` prefixed.

## Changes

- `docs/lessons-learned.md`: add lesson #73 documenting the schema-gate + normalize-on-read pattern, with the verification report inlined for future reference.
- `CLAUDE.md`: bump lessons-learned count `72 → 73`.

Pure docs diff (`+14 / -1`). No source code touched.

## Test plan

- [x] `npm run check:tokens` — clean.
- [x] No source-code touched, so `typecheck` / `test` deltas are N/A. Pre-push hook surfaced unrelated `tests/cli/mcp-stdio.test.ts` flakes (5 failures across the half-open / per-request-timeout / upstream-unavailable suites) — same pattern as the existing `fix/mcp-stdio-flake` branch tracks; not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)