### PR TITLE
fix(#631): surface restart_sidecar failures as generic toast

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,7 +25,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri_plugin_prevent_default::Flags;
@@ -689,7 +689,17 @@ fn restart_sidecar(app: tauri::AppHandle) {
         // Restart never re-injects the cold-start file: the original `setup()`
         // invocation already opened it and registered it in `openDocuments`.
         if let Err(e) = start_sidecar(&handle, &client, None).await {
+            // Detailed error stays in the log sink only — never user-visible.
+            // The emitted event carries a stable code, no error detail, so the
+            // WebView can surface a generic toast without leaking paths, env
+            // vars, errno text, or the auth token.
+            log::error!("[restart_sidecar] failed to restart sidecar: {e}");
             eprintln!("[restart_sidecar] failed to restart sidecar: {e}");
+            if let Err(emit_err) =
+                handle.emit("sidecar-restart-failed", "SIDECAR_RESTART_FAILED")
+            {
+                log::error!("[restart_sidecar] failed to emit failure event: {emit_err}");
+            }
         }
     });
 }

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -188,6 +188,40 @@ const openDocs = $derived(yjsSync.tabs.map((t) => ({ id: t.id, fileName: t.fileN
 const notifications = createNotifications();
 const fileDrop = createFileDrop();
 
+// Surface sidecar restart failures (Tauri-only) as a generic toast. The
+// Rust side emits "sidecar-restart-failed" with a stable code; the message
+// is hard-coded here so no path, errno text, env var, or auth token from
+// the underlying failure can ever reach the DOM. See #631.
+if (isTauriRuntime()) {
+  let unlisten: (() => void) | null = null;
+  let cancelled = false;
+  import("@tauri-apps/api/event")
+    .then(({ listen }) =>
+      listen("sidecar-restart-failed", () => {
+        notifications.push({
+          id: `sidecar-restart-failed-${Date.now()}`,
+          type: "general-error",
+          severity: "error",
+          message: "Sidecar failed to restart — see logs",
+          dedupKey: "sidecar-restart-failed",
+          timestamp: Date.now(),
+          errorCode: "SIDECAR_RESTART_FAILED",
+        });
+      }),
+    )
+    .then((un) => {
+      if (cancelled) un();
+      else unlisten = un;
+    })
+    .catch((err) => {
+      console.warn("[App] Failed to wire sidecar-restart-failed listener:", err);
+    });
+  onDestroy(() => {
+    cancelled = true;
+    unlisten?.();
+  });
+}
+
 let settingsOpen = $state(false);
 let settingsBtnEl = $state<HTMLButtonElement | null>(null);
 let paletteOpen = $state(false);

--- a/src/client/svelte-harness/NotificationsHarness.svelte
+++ b/src/client/svelte-harness/NotificationsHarness.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import { createNotifications, type NotificationsState } from "../hooks/useNotifications.svelte";
+
+interface Props {
+  onReady: (state: NotificationsState) => void;
+}
+
+let { onReady }: Props = $props();
+
+const notifications = createNotifications();
+$effect(() => {
+  onReady(notifications);
+});
+</script>
+
+<div data-testid="notifications-harness">
+  {#each notifications.toasts as toast (toast.id)}
+    <div data-testid="toast" data-dedup-key={toast.dedupKey ?? ""} data-count={toast.count}>
+      {toast.message}
+    </div>
+  {/each}
+</div>

--- a/tests/client/notification-dedup.test.ts
+++ b/tests/client/notification-dedup.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+
+/**
+ * Regression test for #631 / PR #664: confirms that `notifications.push`
+ * collapses repeated `sidecar-restart-failed` events via `dedupKey` (not via `id`).
+ *
+ * The dedup contract lives in `createNotifications.ingest`:
+ *   - If incoming has a `dedupKey` matching an existing toast, replace the
+ *     existing toast in place and bump `count`. Different `id` values on the
+ *     incoming notifications must NOT defeat dedup.
+ *   - If incoming has no `dedupKey` or a `dedupKey` not matching any visible
+ *     toast, append a new toast.
+ */
+
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NotificationsState } from "../../src/client/hooks/useNotifications.svelte";
+import NotificationsHarness from "../../src/client/svelte-harness/NotificationsHarness.svelte";
+import type { TandemNotification } from "../../src/shared/types.js";
+
+// Minimal EventSource stub: happy-dom does not implement EventSource, and we
+// don't want the hook to attempt a real network connection during the test.
+class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+  readyState = FakeEventSource.OPEN;
+  url: string;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onopen: ((event: Event) => void) | null = null;
+  constructor(url: string) {
+    this.url = url;
+  }
+  close() {
+    this.readyState = FakeEventSource.CLOSED;
+  }
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() {
+    return true;
+  }
+}
+
+function makeNotification(overrides: Partial<TandemNotification> = {}): TandemNotification {
+  return {
+    id: "id-default",
+    type: "general-error",
+    severity: "error",
+    message: "Sidecar failed to restart — see logs",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("createNotifications dedup", () => {
+  let state: NotificationsState | null = null;
+
+  beforeEach(() => {
+    vi.stubGlobal("EventSource", FakeEventSource);
+    state = null;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    state = null;
+  });
+
+  it("collapses 5 rapid sidecar-restart-failed pushes with same dedupKey but different ids into one toast", async () => {
+    const { container } = render(NotificationsHarness, {
+      props: {
+        onReady: (s: NotificationsState) => {
+          state = s;
+        },
+      },
+    });
+    await tick();
+    expect(state).not.toBeNull();
+    const api = state as NotificationsState;
+
+    for (let i = 0; i < 5; i++) {
+      api.push(
+        makeNotification({
+          id: `sidecar-restart-failed-${i}`,
+          dedupKey: "sidecar-restart-failed",
+        }),
+      );
+    }
+    await tick();
+
+    const toasts = container.querySelectorAll("[data-testid='toast']");
+    expect(toasts).toHaveLength(1);
+    // The visible toast should record that it was hit 5 times.
+    expect(toasts[0].getAttribute("data-count")).toBe("5");
+    expect(toasts[0].getAttribute("data-dedup-key")).toBe("sidecar-restart-failed");
+
+    // The hook's `toasts` getter agrees with the rendered DOM.
+    expect(api.toasts).toHaveLength(1);
+    expect(api.toasts[0].count).toBe(5);
+    expect(api.toasts[0].dedupKey).toBe("sidecar-restart-failed");
+  });
+
+  it("does not dedup notifications with different dedupKey values", async () => {
+    const { container } = render(NotificationsHarness, {
+      props: {
+        onReady: (s: NotificationsState) => {
+          state = s;
+        },
+      },
+    });
+    await tick();
+    const api = state as NotificationsState;
+
+    api.push(makeNotification({ id: "a-1", dedupKey: "key-a", message: "First (key-a)" }));
+    api.push(makeNotification({ id: "b-1", dedupKey: "key-b", message: "Second (key-b)" }));
+    api.push(makeNotification({ id: "c-1", dedupKey: "key-c", message: "Third (key-c)" }));
+    await tick();
+
+    const toasts = container.querySelectorAll("[data-testid='toast']");
+    expect(toasts).toHaveLength(3);
+    const dedupKeys = Array.from(toasts).map((t) => t.getAttribute("data-dedup-key"));
+    expect(dedupKeys).toEqual(["key-a", "key-b", "key-c"]);
+    for (const t of toasts) {
+      expect(t.getAttribute("data-count")).toBe("1");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Rust `restart_sidecar` (`src-tauri/src/lib.rs`) now emits a `sidecar-restart-failed` Tauri event with payload `"SIDECAR_RESTART_FAILED"` when the spawned restart task fails. The detailed error continues to go to `log::error!` / `eprintln!` only.
- `App.svelte` listens for that event (Tauri-only, mount-time, cleaned up on destroy) and pushes a hard-coded generic toast: **"Sidecar failed to restart — see logs"** with severity `error` and dedupKey `sidecar-restart-failed`.

Closes #631.

## Information disclosure check
- The displayed `message` string is a literal in the listener — not interpolated from the event payload.
- The event payload carries a stable code only; no `error.message`, path, errno text, env var, or `TANDEM_AUTH_TOKEN` reaches the DOM via this channel.
- `restart_sidecar` keeps its `fn(app)` signature (no `Result` return), so the existing `restartError = e.message` branch in `NetworkSettings.svelte` is not newly fed any Rust error string.

## Base branch
Chain B sequencing called for rebasing on Unit 1's branch `worktree-agent-a05dfd5969aa5ba14`, but that branch was not yet pushed at the time of this push. Falling back to `master` per the plan's instruction. `invoke_handler` chain is unchanged in this PR (the existing `restart_sidecar` registration is untouched), so there is no Unit 1 conflict surface to worry about.

## Test plan
- [x] `npm run typecheck` green
- [x] `cargo check` green (after stubbing `src-tauri/binaries/node-sidecar-*` per `feedback_tauri_build_resource_stubs`)
- [x] `npx biome check --write` clean on touched file
- [ ] Manual smoke (Bryan): `npm run dev:tauri`, click `network-restart-sidecar`, force a failure (e.g. occupy :3478 from outside), confirm a toast appears and the DOM contains no path/env/token

🤖 Generated with [Claude Code](https://claude.com/claude-code)