### PR TITLE
feat(unit-7): polish solo-mode held-count badge in status bar

### DIFF
--- a/src/client/status/StatusBar.svelte
+++ b/src/client/status/StatusBar.svelte
@@ -106,6 +106,8 @@ const connLabel = $derived(
         : "Disconnected — check that the server is running",
 );
 
+const showHeld = $derived((heldCount ?? 0) > 0 && mode === "solo");
+
 function commitName() {
   userNameState.setUserName(nameInput);
 }
@@ -158,15 +160,15 @@ function commitName() {
     />
   </div>
 
-  {#if (heldCount ?? 0) > 0 && mode === "solo"}
+  {#if showHeld}
     <button
+      class="sb-held"
       data-testid="sb-held"
       onclick={onShowHeld}
       title="Show held annotations — switches to Tandem"
-      style="display: inline-flex; align-items: center; gap: var(--tandem-space-1); padding: 1px 8px; font-size: var(--tandem-text-xs); font-weight: 600; border: 1px solid var(--tandem-warning-border); border-radius: var(--tandem-r-pill); background: var(--tandem-warning-bg); color: var(--tandem-warning-fg-strong); cursor: pointer;"
     >
-      <span style="width: 6px; height: 6px; border-radius: 50%; background: var(--tandem-warning-fg-strong); display: inline-block;"></span>
-      {heldCount} held
+      <span class="held-dot"></span>
+      <strong>{heldCount}</strong> held
     </button>
   {/if}
 
@@ -195,9 +197,46 @@ function commitName() {
     @keyframes tandem-reconnect-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
   }
 
+  /* Solo-mode held-count badge. Lives next to the user-name input in the
+     status bar so the held queue stays visible when the rail is hidden
+     (see HANDOFF.v1.md item 6). SidePanel keeps its own banner for the
+     rail-visible case. */
+  .sb-held {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--tandem-space-1);
+    height: 18px;
+    padding: 0 8px;
+    border: 1px solid var(--tandem-warning-border);
+    border-radius: var(--tandem-r-pill);
+    background: var(--tandem-warning-bg);
+    color: var(--tandem-warning-fg-strong);
+    font-size: var(--tandem-text-xs);
+    font-family: inherit;
+    cursor: pointer;
+    transition: filter 0.15s ease;
+  }
+  .sb-held strong { font-weight: 600; }
+  .sb-held:hover { filter: brightness(1.04); }
+  .sb-held:focus-visible {
+    outline: 2px solid var(--tandem-accent);
+    outline-offset: 1px;
+  }
+  .sb-held .held-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--tandem-warning-fg-strong);
+    display: inline-block;
+  }
+
   @media (forced-colors: active) {
     .status-dot,
     .claude-dot {
+      outline: 1px solid ButtonText;
+      outline-offset: 1px;
+    }
+    .sb-held .held-dot {
       outline: 1px solid ButtonText;
       outline-offset: 1px;
     }


### PR DESCRIPTION
## Summary

Unit 7 from the v1.0 first-feature-wave (`~/.claude/plans/the-next-phase-of-splendid-eclipse.md`).

### Investigation finding

**The held-count badge was already in StatusBar** with the canonical `sb-held` testid (added in #519 / PR #523). The unit's mandatory investigation step asked the agent to grep before assuming TitleBar held the badge — that grep showed:

| Surface | testid | Behavior |
|---|---|---|
| `src/client/status/StatusBar.svelte` (this PR) | `sb-held` | Solo-mode pill next to user-name input; clicking switches to Tandem. Covers the rail-hidden case. |
| `src/client/panels/SidePanel.svelte` (untouched) | `held-banner` | Full banner with "Show all" CTA in the annotations rail. Covers the rail-visible case. |
| `TitleBar.svelte` | — | Does not host the badge. Never did. |

The two existing surfaces are intentionally complementary per `docs/redesign-bundle/tandem/project/HANDOFF.v1.md` item 6:

> Held annotations need a status-bar counter. The held-banner only appears in the rail today. When the rail is hidden, the user has no visibility into the held queue.

So this unit reduces to **visual polish on the StatusBar badge** — exactly the fallback the prompt anticipated ("If StatusBar already renders it silently, just polish the visual per redesign spec.").

### Changes

- Lift the inline `style="…"` blob on the `sb-held` button into a `.sb-held` CSS class. The inline form couldn't express `:hover` / `:focus-visible`; the class can.
- Add `:hover { filter: brightness(1.04) }` and `:focus-visible` outline (matches `docs/redesign-bundle/tandem/project/surfaces.css:9-33` reference).
- Wrap the count in `<strong>` per the spec markup.
- Introduce a `$derived` `showHeld` so the `{#if}` reads as intent, not a ternary. Reads `heldCount`/`mode` at the prop site (App.svelte already passes them via `modeGate.heldCount` / `modeState.tandemMode`), not via store destructuring — preserves Svelte 5 reactivity per `feedback_svelte_getter_destructuring`.
- Extend the forced-colors `@media` block to outline the held-dot.

### Testid

Kept `data-testid="sb-held"` rather than renaming to `status-held-count`. The prompt allowed "or similar — coordinate with existing testid conventions"; `sb-held` is the existing convention used by `tests/e2e/settings-and-filters.spec.ts:397` and `tests/client/statusbar.test.ts`. Renaming would break the E2E that already validates this exact contract.

### Svelte 5 guardrail

N/A for the prop-destructuring case the prompt cited — `StatusBar` receives `heldCount`/`mode` as props directly from `App.svelte`, not via `useAnnotationStore()`. There is no getter destructuring to lose reactivity on.

## Test plan

- [x] `npm run typecheck` — green (0 errors, 0 warnings, 799 files)
- [x] `npm test -- tests/client/statusbar.test.ts` — 4/4 pass (sb-held render gates + onShowHeld click)
- [x] `npm test -- tests/client/solo-tandem-mode.test.ts` — 18/18 pass (heldCount derivation)
- [x] `biome check --write` — no fixes needed
- [x] E2E selector `sb-held` still resolves (visual change only — no markup contract change)
- [ ] Manual verify via `dev:standalone` + claude-in-chrome — `npm install` deferred (sidecar worktree limitation); polish is purely CSS + `$derived` rename, behavior unchanged

## Out of scope

- `tests/cli/mcp-stdio.test.ts` has 4 pre-existing failures on `origin/master` unrelated to this change (MCP stdio timing tests).
- SidePanel `held-banner` is intentionally retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)