### PR TITLE
fix(#616): evict Y.Doc on populate-cleanup failure

### DIFF
--- a/src/server/events/observers/awareness.ts
+++ b/src/server/events/observers/awareness.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../shared/constants.js";
 import type { FlatOffset } from "../../../shared/types.js";
 import { getOrCreateDocument } from "../../yjs/provider.js";
-import { MCP_ORIGIN } from "../origins.js";
+import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "../origins.js";
 import type { BufferedSelection } from "../types.js";
 
 /**
@@ -51,7 +51,12 @@ export function makeAwarenessObserver(deps: {
   let selectionDwellTimer: ReturnType<typeof setTimeout> | null = null;
 
   const awarenessObs = (event: Y.YMapEvent<unknown>, txn: Y.Transaction) => {
-    if (txn.origin === MCP_ORIGIN) return;
+    // Skip server-tagged transactions for symmetry with annotations/replies
+    // observers. This observer never calls pushEvent (it only buffers
+    // selections), so the filter is defense-in-depth: if a future selection
+    // write is tagged FILE_SYNC_ORIGIN (e.g. seeded from disk), we must not
+    // buffer it as a user-driven selection event.
+    if (txn.origin === MCP_ORIGIN || txn.origin === FILE_SYNC_ORIGIN) return;
 
     if (event.keysChanged.has(Y_MAP_SELECTION)) {
       const selection = userAwareness.get(Y_MAP_SELECTION) as

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -635,6 +635,11 @@ function evictPartialDocState(doc: Y.Doc, docId: string | undefined): void {
     clearFileSyncContext(docId);
   }
 
+  // `clearFileSyncContext` MUST run before the `doc.transact` clear. It detaches
+  // the durable-sync observer first; otherwise clearing the maps would fire the
+  // observer with empty-map delete events and persist an empty snapshot to the
+  // on-disk annotation file — destroying durable annotations for the docId we
+  // intended to evict-and-reopen.
   doc.transact(() => {
     const annotations = doc.getMap(Y_MAP_ANNOTATIONS);
     annotations.forEach((_, k) => annotations.delete(k));

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -155,7 +155,7 @@ export async function openFileByPath(
   const doc = getOrCreateDocument(id);
   const restoredFromSession = await maybeRestoreSession(resolved, doc, fileName);
   if (!restoredFromSession) {
-    await loadContentIntoDoc(doc, format, resolved);
+    await loadContentIntoDoc(doc, format, resolved, id);
   }
   await finalizeDocOpen(id, doc, resolved, fileName, format, readOnly);
 
@@ -205,7 +205,7 @@ export async function openFileFromContent(
   const doc = getOrCreateDocument(id);
   // Display name is the uploaded filename, not the synthetic upload path, so
   // notifications don't leak the internal path shape to the user.
-  await populateDocFromContent(doc, format, content, {
+  await populateDocFromContent(doc, format, content, id, {
     displayName: fileName,
     dedupSource: syntheticPath,
   });
@@ -518,9 +518,14 @@ function applyPreparedContent(doc: Y.Doc, prepared: PreparedContent, ctx: Popula
  * allowlist, UNC rejection) and delegates the parse + transact + cleanup logic
  * to the shared helper used by openFileFromContent.
  */
-async function loadContentIntoDoc(doc: Y.Doc, format: string, resolved: string): Promise<void> {
+async function loadContentIntoDoc(
+  doc: Y.Doc,
+  format: string,
+  resolved: string,
+  docId: string,
+): Promise<void> {
   const buffer = await fs.readFile(resolved);
-  await populateDocFromContent(doc, format, buffer, {
+  await populateDocFromContent(doc, format, buffer, docId, {
     displayName: path.basename(resolved),
     dedupSource: resolved,
   });
@@ -540,6 +545,7 @@ async function populateDocFromContent(
   doc: Y.Doc,
   format: string,
   source: string | Buffer,
+  docId: string | undefined,
   ctx: PopulateContext,
 ): Promise<void> {
   const prepared = await prepareContent(format, source, ctx);
@@ -552,6 +558,7 @@ async function populateDocFromContent(
     // transact's _transaction by the time the catch fires, so this is not
     // nested. MCP_ORIGIN is correct here for the same reason it's correct
     // above — Critical Rule #2 and observer attach order.
+    let cleanupOk = true;
     try {
       doc.transact(() => {
         const fragment = doc.getXmlFragment("default");
@@ -562,21 +569,91 @@ async function populateDocFromContent(
         for (const k of [...annotations.keys()]) annotations.delete(k);
       }, MCP_ORIGIN);
     } catch (cleanupErr) {
+      cleanupOk = false;
       console.error(
         "[Tandem] populateDocFromContent: cleanup after populate failure also failed:",
         cleanupErr,
       );
+      // Evict the cached Y.Doc state in-place (#616). If the targeted
+      // cleanup-on-failure pass above threw, the Y.Doc is in an
+      // indeterminate state — a partial XmlFragment plus possibly partial
+      // annotations / reply / awareness entries. Re-opening the same
+      // documentId would then merge fresh content on top of poisoned state.
+      // Evict by clearing every CRDT map + the content fragment in a single
+      // FILE_SYNC_ORIGIN transact so durable-annotation sync skips it (no
+      // re-persist of the half-cleared snapshot) and the channel event
+      // queue skips it (no SSE flood). Also drops the file-sync context
+      // with phase "close" so any tombstone ledger keyed to the prior
+      // docHash is released (eviction = fresh-start semantics, not a swap).
+      // Failures here are logged and swallowed; we still want to rethrow
+      // the ORIGINAL populate error, not eviction noise.
+      try {
+        evictPartialDocState(doc, docId);
+      } catch (evictErr) {
+        console.error(
+          "[Tandem] populateDocFromContent: eviction after cleanup failure also failed:",
+          evictErr,
+        );
+      }
     }
     // Static-literal first arg; user-controlled values arrive as trailing args
     // so util.format doesn't treat them as a format string.
     console.error(
       "[Tandem] populateDocFromContent: populate failed; partial state cleared before rethrow.",
-      { format, displayName: ctx.displayName },
+      { format, displayName: ctx.displayName, cleanupOk },
       err,
     );
     throw err;
   }
 }
+
+/**
+ * Evict a cached Y.Doc's content + annotation state in-place (#616).
+ *
+ * Called only from the cleanup-after-populate-failure path when the targeted
+ * cleanup pass itself throws — at that point the Y.Doc is in an indeterminate
+ * partial state and a subsequent open of the same `documentId` would merge
+ * fresh content on top of poisoned CRDT state. Eviction restores the doc to
+ * the same fresh-instance shape `getOrCreateDocument(id)` would have produced.
+ *
+ * Single-transaction in-place clear (per `feedback_inplace_clear_over_destroy`
+ * and Critical Rule #2). The transaction is tagged `FILE_SYNC_ORIGIN`:
+ *   - the durable-annotation sync observer skips it (no re-persist of the
+ *     half-cleared state),
+ *   - the channel event queue skips it (no SSE flood of phantom deletions).
+ *
+ * Also drops the per-doc file-sync context with phase `"close"` (not `"swap"`)
+ * because eviction is fresh-start semantics: the tombstone ledger keyed to
+ * the prior docHash belongs to a superseded state and must be released.
+ */
+function evictPartialDocState(doc: Y.Doc, docId: string | undefined): void {
+  if (docId) {
+    // Drop the per-doc file-sync context with phase "close" (the registry's
+    // clearFileSyncContext path). A no-op if no context was ever registered
+    // for this docId — common during open, since wireAnnotationStore runs
+    // AFTER populate.
+    clearFileSyncContext(docId);
+  }
+
+  doc.transact(() => {
+    const annotations = doc.getMap(Y_MAP_ANNOTATIONS);
+    annotations.forEach((_, k) => annotations.delete(k));
+
+    const annotationReplies = doc.getMap(Y_MAP_ANNOTATION_REPLIES);
+    annotationReplies.forEach((_, k) => annotationReplies.delete(k));
+
+    const awareness = doc.getMap(Y_MAP_AWARENESS);
+    awareness.forEach((_, k) => awareness.delete(k));
+
+    const userAwareness = doc.getMap(Y_MAP_USER_AWARENESS);
+    userAwareness.forEach((_, k) => userAwareness.delete(k));
+
+    const fragment = doc.getXmlFragment("default");
+    fragment.delete(0, fragment.length);
+  }, FILE_SYNC_ORIGIN);
+}
+
+export { evictPartialDocState as __testEvictPartialDocState };
 
 /**
  * Finalize a normal (non-force) document open: register in open-docs map,

--- a/tests/server/evict-on-cleanup-failure.test.ts
+++ b/tests/server/evict-on-cleanup-failure.test.ts
@@ -25,10 +25,13 @@ vi.mock("../../src/server/notifications.js", async (importOriginal) => {
   };
 });
 
+import type { DocStore } from "../../src/server/annotations/store.js";
 import {
   getTombstones,
   recordTombstone,
+  registerAnnotationObserver,
   resetForTesting as resetSyncForTesting,
+  type SyncContext,
 } from "../../src/server/annotations/sync.js";
 import {
   attachObservers,
@@ -119,50 +122,54 @@ describe("evictPartialDocState (#616)", () => {
     expect(received).toEqual([]);
   });
 
-  it("drops the per-doc file-sync context with phase 'close' (tombstone ledger empty)", async () => {
+  it("drops the per-doc file-sync context with phase 'close' (tombstone ledger empty)", () => {
     const doc = makePoisonedDoc();
 
-    // Seed a tombstone ledger keyed to the docHash, then register a sync
-    // context disposer so clearFileSyncContext (called via "close") fires
-    // the close-phase branch in registerAnnotationObserver — which is what
-    // drops `tombstonesByDoc[docHash]`.
+    // Minimal DocStore: only `queueWrite` is reachable from this test (and the
+    // FILE_SYNC_ORIGIN filter should prevent even that). The other methods are
+    // wired to throw if surprised so the test fails loud on unexpected use.
+    const queueWrite = vi.fn();
+    const store = {
+      load: async () => {
+        throw new Error("store.load should not be called");
+      },
+      queueWrite,
+      flush: async () => undefined,
+      clear: async () => undefined,
+      isReadOnly: () => false,
+      isDisabled: () => false,
+    } satisfies DocStore;
+
+    const ctx: SyncContext = {
+      ydoc: doc,
+      store,
+      docHash: DOC_HASH,
+      meta: { filePath: "/tmp/x" },
+    };
+
+    // Register the REAL observer. Its close-phase disposer is what drops
+    // `tombstonesByDoc[docHash]`; we want to exercise that contract end-to-end,
+    // not a comment-only stand-in.
+    const cleanup = registerAnnotationObserver(ctx);
+
+    // Seed the ledger AFTER registration so the observer is in place when
+    // eviction fires.
     recordTombstone(DOC_HASH, "ann-1", 0);
     expect(getTombstones(DOC_HASH)).toHaveLength(1);
 
-    // Minimal SyncContext + a cleanup that matches the
-    // registerAnnotationObserver disposer contract: phase "close" should
-    // drop the ledger. We simulate that contract directly so the test
-    // doesn't depend on the file-sync registry's internals — it asserts
-    // that eviction invokes the cleanup with phase "close".
-    const cleanup = vi.fn((phase?: "swap" | "close") => {
-      if (phase === "close") {
-        // Mirror the real disposer's close-phase behavior.
-        // (See registerAnnotationObserver in src/server/annotations/sync.ts)
-        // We can't import the private map; instead we use the public reset
-        // hook below to assert the ledger is empty post-eviction.
-      }
-    });
-    setFileSyncContext(
-      DOC_ID,
-      // Cast: this is a structural stand-in; only `store`/`docHash`/`meta`
-      // are read by the registry when it forwards to the cleanup.
-      {
-        ydoc: doc,
-        store: { clear: async () => undefined } as never,
-        docHash: DOC_HASH,
-        meta: { filePath: "/tmp/x" },
-      },
-      cleanup,
-    );
+    setFileSyncContext(DOC_ID, ctx, cleanup);
 
     __testEvictPartialDocState(doc, DOC_ID);
 
-    // Eviction MUST have called the disposer with phase "close" (not "swap").
-    expect(cleanup).toHaveBeenCalledWith("close");
+    // Real assertion: the close-phase disposer ran and dropped the ledger.
+    expect(getTombstones(DOC_HASH)).toHaveLength(0);
 
-    // And calling it a second time is a no-op (registry deleted the entry).
-    __testEvictPartialDocState(doc, DOC_ID);
-    expect(cleanup).toHaveBeenCalledTimes(1);
+    // The FILE_SYNC_ORIGIN eviction transact must not have queued any
+    // user-intent writes back to the store.
+    expect(queueWrite).not.toHaveBeenCalled();
+
+    // Second eviction is a no-op against the registry (entry deleted).
+    expect(() => __testEvictPartialDocState(doc, DOC_ID)).not.toThrow();
   });
 
   it("is a no-op against the file-sync registry when docId has no context (open-path case)", () => {

--- a/tests/server/evict-on-cleanup-failure.test.ts
+++ b/tests/server/evict-on-cleanup-failure.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit 3 / #616 — Evict Y.Doc on populate-cleanup failure.
+ *
+ * When `populateDocFromContent` catches a populate failure, it runs a targeted
+ * cleanup pass. If THAT pass also throws, the cached Y.Doc is in an
+ * indeterminate state and `evictPartialDocState` is invoked to clear every
+ * CRDT map + the XmlFragment in a single FILE_SYNC_ORIGIN transaction, and
+ * to drop the per-doc file-sync context with phase "close" (releasing the
+ * tombstone ledger keyed to the prior docHash).
+ *
+ * Filename note: the upstream plan calls for `.spec.ts`, but vitest's
+ * `include` glob matches `.test.ts` only — using the latter so the assertions
+ * actually run.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+
+// Notifications are a shared singleton buffer; mock to silence.
+vi.mock("../../src/server/notifications.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    pushNotification: vi.fn(),
+  };
+});
+
+import {
+  getTombstones,
+  recordTombstone,
+  resetForTesting as resetSyncForTesting,
+} from "../../src/server/annotations/sync.js";
+import {
+  attachObservers,
+  detachObservers,
+  resetForTesting as resetQueueForTesting,
+  setFileSyncContext,
+  subscribe,
+  unsubscribe,
+} from "../../src/server/events/queue.js";
+import { __testEvictPartialDocState } from "../../src/server/mcp/file-opener.js";
+import {
+  Y_MAP_ANNOTATION_REPLIES,
+  Y_MAP_ANNOTATIONS,
+  Y_MAP_AWARENESS,
+  Y_MAP_USER_AWARENESS,
+} from "../../src/shared/constants.js";
+import { useTmpAnnotationsEnvWithFlag } from "../helpers/annotation-store-env.js";
+
+useTmpAnnotationsEnvWithFlag("tandem-evict-test-");
+
+const DOC_ID = "evict-test-doc";
+const DOC_HASH = "evict-test-hash";
+
+beforeEach(() => {
+  resetQueueForTesting();
+  resetSyncForTesting();
+});
+
+afterEach(() => {
+  resetQueueForTesting();
+  resetSyncForTesting();
+});
+
+/**
+ * Build a Y.Doc in the "partial / poisoned" shape that
+ * `evictPartialDocState` exists to handle: every CRDT map populated, the
+ * XmlFragment populated. Mirrors what an interrupted populate could leave.
+ */
+function makePoisonedDoc(): Y.Doc {
+  const doc = new Y.Doc();
+  doc.transact(() => {
+    doc.getMap(Y_MAP_ANNOTATIONS).set("ann-1", { id: "ann-1" });
+    doc.getMap(Y_MAP_ANNOTATION_REPLIES).set("rep-1", { id: "rep-1" });
+    doc.getMap(Y_MAP_AWARENESS).set("aw-1", { focus: "x" });
+    doc.getMap(Y_MAP_USER_AWARENESS).set("u-1", { name: "x" });
+    const xf = doc.getXmlFragment("default");
+    const para = new Y.XmlElement("paragraph");
+    para.insert(0, [new Y.XmlText("partial")]);
+    xf.insert(0, [para]);
+  });
+  return doc;
+}
+
+describe("evictPartialDocState (#616)", () => {
+  it("clears every CRDT map and the XmlFragment", () => {
+    const doc = makePoisonedDoc();
+
+    expect(doc.getMap(Y_MAP_ANNOTATIONS).size).toBe(1);
+    expect(doc.getMap(Y_MAP_ANNOTATION_REPLIES).size).toBe(1);
+    expect(doc.getMap(Y_MAP_AWARENESS).size).toBe(1);
+    expect(doc.getMap(Y_MAP_USER_AWARENESS).size).toBe(1);
+    expect(doc.getXmlFragment("default").length).toBe(1);
+
+    __testEvictPartialDocState(doc, DOC_ID);
+
+    expect(doc.getMap(Y_MAP_ANNOTATIONS).size).toBe(0);
+    expect(doc.getMap(Y_MAP_ANNOTATION_REPLIES).size).toBe(0);
+    expect(doc.getMap(Y_MAP_AWARENESS).size).toBe(0);
+    expect(doc.getMap(Y_MAP_USER_AWARENESS).size).toBe(0);
+    expect(doc.getXmlFragment("default").length).toBe(0);
+  });
+
+  it("channel observers see no events during the eviction transaction (FILE_SYNC_ORIGIN)", () => {
+    const doc = makePoisonedDoc();
+    attachObservers(DOC_ID, doc);
+
+    const received: string[] = [];
+    const cb = (ev: { type: string }) => received.push(ev.type);
+    subscribe(cb);
+    try {
+      __testEvictPartialDocState(doc, DOC_ID);
+    } finally {
+      unsubscribe(cb);
+      detachObservers(DOC_ID);
+    }
+
+    // Origin tag FILE_SYNC_ORIGIN — both annotation and reply observers skip.
+    expect(received).toEqual([]);
+  });
+
+  it("drops the per-doc file-sync context with phase 'close' (tombstone ledger empty)", async () => {
+    const doc = makePoisonedDoc();
+
+    // Seed a tombstone ledger keyed to the docHash, then register a sync
+    // context disposer so clearFileSyncContext (called via "close") fires
+    // the close-phase branch in registerAnnotationObserver — which is what
+    // drops `tombstonesByDoc[docHash]`.
+    recordTombstone(DOC_HASH, "ann-1", 0);
+    expect(getTombstones(DOC_HASH)).toHaveLength(1);
+
+    // Minimal SyncContext + a cleanup that matches the
+    // registerAnnotationObserver disposer contract: phase "close" should
+    // drop the ledger. We simulate that contract directly so the test
+    // doesn't depend on the file-sync registry's internals — it asserts
+    // that eviction invokes the cleanup with phase "close".
+    const cleanup = vi.fn((phase?: "swap" | "close") => {
+      if (phase === "close") {
+        // Mirror the real disposer's close-phase behavior.
+        // (See registerAnnotationObserver in src/server/annotations/sync.ts)
+        // We can't import the private map; instead we use the public reset
+        // hook below to assert the ledger is empty post-eviction.
+      }
+    });
+    setFileSyncContext(
+      DOC_ID,
+      // Cast: this is a structural stand-in; only `store`/`docHash`/`meta`
+      // are read by the registry when it forwards to the cleanup.
+      {
+        ydoc: doc,
+        store: { clear: async () => undefined } as never,
+        docHash: DOC_HASH,
+        meta: { filePath: "/tmp/x" },
+      },
+      cleanup,
+    );
+
+    __testEvictPartialDocState(doc, DOC_ID);
+
+    // Eviction MUST have called the disposer with phase "close" (not "swap").
+    expect(cleanup).toHaveBeenCalledWith("close");
+
+    // And calling it a second time is a no-op (registry deleted the entry).
+    __testEvictPartialDocState(doc, DOC_ID);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op against the file-sync registry when docId has no context (open-path case)", () => {
+    const doc = makePoisonedDoc();
+    // No setFileSyncContext call. wireAnnotationStore runs AFTER populate, so
+    // during the normal cleanup-failure path the registry is empty for this id.
+    // Eviction must still clear the CRDT state and not throw.
+    expect(() => __testEvictPartialDocState(doc, DOC_ID)).not.toThrow();
+    expect(doc.getMap(Y_MAP_ANNOTATIONS).size).toBe(0);
+  });
+
+  it("a freshly-created Y.Doc against the same documentId is clean post-eviction", () => {
+    const doc = makePoisonedDoc();
+    __testEvictPartialDocState(doc, DOC_ID);
+
+    // Same id, same doc instance (in-place clear is the contract — we never
+    // destroy/recreate). All four CRDT maps + XmlFragment are empty: a
+    // subsequent populate from disk lands on the same shape a fresh
+    // getOrCreateDocument(id) would have produced.
+    expect(doc.getMap(Y_MAP_ANNOTATIONS).size).toBe(0);
+    expect(doc.getMap(Y_MAP_ANNOTATION_REPLIES).size).toBe(0);
+    expect(doc.getMap(Y_MAP_AWARENESS).size).toBe(0);
+    expect(doc.getMap(Y_MAP_USER_AWARENESS).size).toBe(0);
+    expect(doc.getXmlFragment("default").length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `evictPartialDocState(doc, docId)` invoked from the cleanup-after-populate-failure path when targeted cleanup itself throws
- Single in-place `doc.transact(..., FILE_SYNC_ORIGIN)` clears `Y_MAP_ANNOTATIONS`, `Y_MAP_ANNOTATION_REPLIES`, `Y_MAP_AWARENESS`, `Y_MAP_USER_AWARENESS`, plus the default `XmlFragment`
- Calls `clearFileSyncContext(docId)` which fires the disposer with phase ` + '`' + 'close' + '`' + ` (releases per-doc tombstone ledger — eviction is fresh-start, not Y.Doc replacement)

## Why these choices
- **In-place clear, not destroy/recreate** per ` + '`' + 'feedback_inplace_clear_over_destroy' + '`' + ` — observer reattach via ` + '`' + 'onDocSwapped' + '`' + ` would break for orphan cleanups.
- **FILE_SYNC_ORIGIN** so the durable-annotation sync observer skips re-persisting state we just lost, and the channel event queue skips emitting a flood of phantom deletes.
- **Phase ` + '`' + 'close' + '`' + `**, not ` + '`' + 'swap' + '`' + ` — ` + '`' + 'swap' + '`' + ` keeps the per-doc tombstone ledger alive (correct for Y.Doc replacement), but eviction is "discard partial state, start fresh on next open" so the ledger must drop.

## Test plan
- [x] ` + '`' + 'npm run typecheck' + '`' + ` green
- [x] New ` + '`' + 'tests/server/evict-on-cleanup-failure.test.ts' + '`' + ` — 5/5 pass:
  - every CRDT map + XmlFragment cleared
  - channel observers see zero events during the eviction transaction (origin filter works)
  - file-sync disposer invoked with phase ` + '`' + 'close' + '`' + `
  - no-op safety when no context registered
  - post-eviction state is fresh-instance-shape
- [x] ` + '`' + 'biome check --write' + '`' + ` clean

## Unblocks
Units 13 (reply thread expansion) and 14 (margin view PR 2) of the v1.0 first-feature-wave batch.

Builds on PR #612. Closes #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)