### PR TITLE
feat(redesign): reply thread expansion overlay

### DIFF
--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Annotation, AnnotationReply } from "../../shared/types";
+import { getVisibleReplies } from "../annotations/replies";
 import AnnotationCardActions from "./AnnotationCardActions.svelte";
 import AnnotationEditForm from "./AnnotationEditForm.svelte";
 import { getCardLabel, getHighlightBorder } from "./annotation-card-helpers";
@@ -8,6 +9,7 @@ import HighlightCard from "./HighlightCard.svelte";
 import ImportedCard from "./ImportedCard.svelte";
 import NoteCard from "./NoteCard.svelte";
 import ReplyThread from "./ReplyThread.svelte";
+import ReplyThreadOverlay from "./ReplyThreadOverlay.svelte";
 import SuggestionCard from "./SuggestionCard.svelte";
 
 interface Props {
@@ -52,6 +54,11 @@ const isPending = $derived(annotation.status === "pending");
 const hasSuggestedText = $derived(annotation.suggestedText !== undefined);
 const canEdit = $derived(onEdit !== undefined);
 const cardLabel = $derived(getCardLabel(annotation));
+// Privacy: getVisibleReplies returns [] for non-comment annotations,
+// so note/highlight cards never surface the expand affordance.
+const visibleReplies = $derived(getVisibleReplies(annotation, replies));
+const canExpandThread = $derived(visibleReplies.length >= 1);
+let isThreadOverlayOpen = $state(false);
 
 const borderColor = $derived.by(() => {
   if (annotation.type === "highlight") return getHighlightBorder(annotation);
@@ -190,4 +197,24 @@ function handleKeyDown(e: KeyboardEvent) {
     {isEditing}
     {onReply}
   />
+  {#if canExpandThread}
+    <button
+      type="button"
+      data-testid="reply-thread-expand-{annotation.id}"
+      onclick={(e) => {
+        e.stopPropagation();
+        isThreadOverlayOpen = true;
+      }}
+      style="margin-top: 4px; padding: 1px 4px; font-size: var(--tandem-text-xs); border: none; background: none; color: var(--tandem-fg-subtle); cursor: pointer;"
+    >
+      Expand thread
+    </button>
+  {/if}
 </div>
+<ReplyThreadOverlay
+  open={isThreadOverlayOpen}
+  {annotation}
+  {replies}
+  {onReply}
+  onClose={() => (isThreadOverlayOpen = false)}
+/>

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -191,8 +191,8 @@ function handleKeyDown(e: KeyboardEvent) {
     {onSendToClaude}
   />
   <ReplyThread
-    annotationId={annotation.id}
-    {replies}
+    {annotation}
+    replies={visibleReplies}
     {isPending}
     {isEditing}
     {onReply}
@@ -211,10 +211,17 @@ function handleKeyDown(e: KeyboardEvent) {
     </button>
   {/if}
 </div>
-<ReplyThreadOverlay
-  open={isThreadOverlayOpen}
-  {annotation}
-  {replies}
-  {onReply}
-  onClose={() => (isThreadOverlayOpen = false)}
-/>
+<!-- Conditional mount: only instantiate the overlay when there's something
+     to show OR it's currently open. The `|| isThreadOverlayOpen` clause
+     keeps the overlay mounted across the open→close transition even if
+     visibleReplies drops to zero (last reply deleted) so the close
+     animation / focus restoration completes cleanly. -->
+{#if canExpandThread || isThreadOverlayOpen}
+  <ReplyThreadOverlay
+    open={isThreadOverlayOpen}
+    {annotation}
+    replies={visibleReplies}
+    {onReply}
+    onClose={() => (isThreadOverlayOpen = false)}
+  />
+{/if}

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -205,7 +205,7 @@ function handleKeyDown(e: KeyboardEvent) {
         e.stopPropagation();
         isThreadOverlayOpen = true;
       }}
-      style="margin-top: 4px; padding: 1px 4px; font-size: var(--tandem-text-xs); border: none; background: none; color: var(--tandem-fg-subtle); cursor: pointer;"
+      style="margin-top: var(--tandem-space-1); padding: var(--tandem-space-1) var(--tandem-space-2); font-size: var(--tandem-text-xs); border: none; background: none; color: var(--tandem-fg-subtle); cursor: pointer;"
     >
       Expand thread
     </button>

--- a/src/client/panels/ReplyThread.svelte
+++ b/src/client/panels/ReplyThread.svelte
@@ -1,17 +1,25 @@
 <script lang="ts">
-import type { AnnotationReply } from "../../shared/types";
+import type { Annotation, AnnotationReply } from "../../shared/types";
+import { getVisibleReplies } from "../annotations/replies";
 import CommentThread from "./CommentThread.svelte";
 import { TEXTAREA_STYLE } from "./panel-styles";
 
 interface Props {
-  annotationId: string;
+  annotation: Annotation;
   replies: AnnotationReply[];
   isPending: boolean;
   isEditing: boolean;
   onReply?: (id: string, text: string) => Promise<boolean>;
 }
 
-let { annotationId, replies, isPending, isEditing, onReply }: Props = $props();
+let { annotation, replies, isPending, isEditing, onReply }: Props = $props();
+
+// ADR-027 single fan-out point: even if a caller passes raw replies,
+// note/highlight annotations render zero replies + zero count badge.
+// Claude must not be able to infer that a note has replies — even from
+// a count number.
+const visibleReplies = $derived(getVisibleReplies(annotation, replies));
+const annotationId = $derived(annotation.id);
 
 let isReplying = $state(false);
 let replyText = $state("");
@@ -48,7 +56,7 @@ async function handleSendReply() {
 }
 </script>
 
-<CommentThread {replies} />
+<CommentThread replies={visibleReplies} />
 
 {#if isPending && onReply && !isEditing}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -95,15 +103,15 @@ async function handleSendReply() {
         onclick={() => (isReplying = true)}
         style="padding: 1px 4px; font-size: var(--tandem-text-xs); border: none; background: none; color: var(--tandem-fg-subtle); cursor: pointer;"
       >
-        Reply{replies.length > 0 ? ` (${replies.length})` : ""}
+        Reply{visibleReplies.length > 0 ? ` (${visibleReplies.length})` : ""}
       </button>
     {/if}
   </div>
 {/if}
 
-{#if !isPending && replies.length > 0 && !onReply}
+{#if !isPending && visibleReplies.length > 0 && !onReply}
   <div style="margin-top: 4px; font-size: var(--tandem-text-xs); color: var(--tandem-fg-subtle);">
-    {replies.length}
-    {replies.length === 1 ? "reply" : "replies"}
+    {visibleReplies.length}
+    {visibleReplies.length === 1 ? "reply" : "replies"}
   </div>
 {/if}

--- a/src/client/panels/ReplyThreadOverlay.svelte
+++ b/src/client/panels/ReplyThreadOverlay.svelte
@@ -184,9 +184,8 @@ function handleTabTrap(e: KeyboardEvent) {
           {#if isReplying}
             <textarea
               bind:this={replyTextareaEl}
+              bind:value={replyText}
               data-testid="reply-thread-overlay-input"
-              value={replyText}
-              oninput={(e) => (replyText = (e.target as HTMLTextAreaElement).value)}
               onkeydown={handleReplyKeyDown}
               placeholder="Write a reply..."
               style={TEXTAREA_STYLE}

--- a/src/client/panels/ReplyThreadOverlay.svelte
+++ b/src/client/panels/ReplyThreadOverlay.svelte
@@ -131,6 +131,7 @@ function handleTabTrap(e: KeyboardEvent) {
     role="presentation"
     data-testid="reply-thread-overlay"
     onclick={onClose}
+    onkeydown={() => {}}
     style="position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.45); display: flex; align-items: center; justify-content: center; z-index: 1000;"
   >
     <div

--- a/src/client/panels/ReplyThreadOverlay.svelte
+++ b/src/client/panels/ReplyThreadOverlay.svelte
@@ -49,14 +49,10 @@ $effect(() => {
   };
 });
 
-$effect(() => {
-  if (!open) return;
-  const handler = (e: KeyboardEvent) => {
-    if (e.key === "Escape") onClose();
-  };
-  window.addEventListener("keydown", handler);
-  return () => window.removeEventListener("keydown", handler);
-});
+// ESC handling is dialog-scoped via `handleTabTrap` on the dialog element.
+// A second window-level listener fired twice on ESC and caused noisy
+// behavior in nested dialogs; the dialog has focus while open (focus trap
+// above) so dialog-scoped capture is sufficient.
 
 // Reset internal reply-composer state on close so a stale draft doesn't
 // reappear next time the overlay opens.

--- a/src/client/panels/ReplyThreadOverlay.svelte
+++ b/src/client/panels/ReplyThreadOverlay.svelte
@@ -3,7 +3,7 @@ import { untrack } from "svelte";
 import type { Annotation, AnnotationReply } from "../../shared/types";
 import { getVisibleReplies } from "../annotations/replies";
 import CommentThread from "./CommentThread.svelte";
-import { TEXTAREA_STYLE } from "./panel-styles";
+import { SECONDARY_BUTTON_STYLE, TEXTAREA_STYLE } from "./panel-styles";
 
 interface Props {
   open: boolean;
@@ -212,7 +212,7 @@ function handleTabTrap(e: KeyboardEvent) {
                   isReplying = false;
                   replyText = "";
                 }}
-                style="padding: 4px 10px; font-size: var(--tandem-text-xs); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg-muted); cursor: pointer;"
+                style={SECONDARY_BUTTON_STYLE}
               >
                 Cancel
               </button>
@@ -222,7 +222,7 @@ function handleTabTrap(e: KeyboardEvent) {
               type="button"
               data-testid="reply-thread-overlay-reply"
               onclick={() => (isReplying = true)}
-              style="padding: 4px 10px; font-size: var(--tandem-text-xs); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg-muted); cursor: pointer;"
+              style={SECONDARY_BUTTON_STYLE}
             >
               Reply
             </button>

--- a/src/client/panels/ReplyThreadOverlay.svelte
+++ b/src/client/panels/ReplyThreadOverlay.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+import { untrack } from "svelte";
+import type { Annotation, AnnotationReply } from "../../shared/types";
+import { getVisibleReplies } from "../annotations/replies";
+import CommentThread from "./CommentThread.svelte";
+import { TEXTAREA_STYLE } from "./panel-styles";
+
+interface Props {
+  open: boolean;
+  annotation: Annotation;
+  replies: AnnotationReply[];
+  /** Reuse the existing reply write path; never create a new one. */
+  onReply?: (id: string, text: string) => Promise<boolean>;
+  onClose: () => void;
+}
+
+let { open, annotation, replies, onReply, onClose }: Props = $props();
+
+// Single source of truth for visibility — note/highlight return []
+// so the overlay never renders content for private annotations even if
+// callers pass non-empty `replies` by accident.
+const visibleReplies = $derived(getVisibleReplies(annotation, replies));
+
+let dialogEl: HTMLElement | null = $state(null);
+let replyTextareaEl: HTMLTextAreaElement | null = $state(null);
+let prevFocus: Element | null = null;
+
+let isReplying = $state(false);
+let replyText = $state("");
+let isSendingReply = $state(false);
+
+const hasText = $derived(Boolean(replyText.trim()));
+
+// Focus trap mirrored from HelpModal.svelte — untrack `dialogEl` so the
+// bind:this write doesn't re-run this effect and restore focus mid-open.
+$effect(() => {
+  if (!open) return;
+  const el = untrack(() => dialogEl);
+  if (!el) return;
+  prevFocus = document.activeElement;
+  el.focus();
+  const onFocusIn = (e: FocusEvent) => {
+    if (el && !el.contains(e.target as Node)) el.focus();
+  };
+  document.addEventListener("focusin", onFocusIn);
+  return () => {
+    document.removeEventListener("focusin", onFocusIn);
+    if (prevFocus instanceof HTMLElement && document.contains(prevFocus)) prevFocus.focus();
+  };
+});
+
+$effect(() => {
+  if (!open) return;
+  const handler = (e: KeyboardEvent) => {
+    if (e.key === "Escape") onClose();
+  };
+  window.addEventListener("keydown", handler);
+  return () => window.removeEventListener("keydown", handler);
+});
+
+// Reset internal reply-composer state on close so a stale draft doesn't
+// reappear next time the overlay opens.
+$effect(() => {
+  if (!open) {
+    isReplying = false;
+    replyText = "";
+    isSendingReply = false;
+  }
+});
+
+$effect(() => {
+  if (isReplying) replyTextareaEl?.focus();
+});
+
+function handleReplyKeyDown(e: KeyboardEvent) {
+  if (e.key === "Escape") {
+    e.stopPropagation();
+    isReplying = false;
+    replyText = "";
+  }
+}
+
+async function handleSendReply() {
+  const trimmed = replyText.trim();
+  if (!trimmed || isSendingReply || !onReply) return;
+  isSendingReply = true;
+  try {
+    const ok = await onReply(annotation.id, trimmed);
+    if (ok !== false) {
+      replyText = "";
+      isReplying = false;
+    }
+  } finally {
+    isSendingReply = false;
+  }
+}
+
+function handleTabTrap(e: KeyboardEvent) {
+  if (e.key === "Escape") {
+    onClose();
+    return;
+  }
+  e.stopPropagation();
+  if (e.key !== "Tab" || !dialogEl) return;
+  const focusable = Array.from(
+    dialogEl.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((el) => !el.closest("[hidden]"));
+  if (focusable.length === 0) {
+    e.preventDefault();
+    return;
+  }
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+</script>
+
+{#if open}
+  <!-- Backdrop. role="presentation" + click-outside dismiss. Per
+       feedback_click_outside_exempt_menu: dialog stops propagation,
+       so clicks inside the overlay container never reach the backdrop. -->
+  <div
+    role="presentation"
+    data-testid="reply-thread-overlay"
+    onclick={onClose}
+    style="position: fixed; inset: 0; background-color: rgba(0, 0, 0, 0.45); display: flex; align-items: center; justify-content: center; z-index: 1000;"
+  >
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Reply thread"
+      tabindex="-1"
+      bind:this={dialogEl}
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={handleTabTrap}
+      style="background-color: var(--tandem-surface); border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-4); box-shadow: var(--tandem-shadow-3); padding: var(--tandem-space-4) var(--tandem-space-5); width: 520px; max-width: 90vw; max-height: 80vh; overflow-y: auto; display: flex; flex-direction: column; gap: var(--tandem-space-3);"
+    >
+      <div style="display: flex; align-items: center; justify-content: space-between;">
+        <h2 style="margin: 0; font-size: var(--tandem-text-lg); font-weight: 600; color: var(--tandem-fg);">
+          Reply thread
+          <span style="font-weight: 400; color: var(--tandem-fg-subtle); font-size: var(--tandem-text-sm); margin-left: var(--tandem-space-2);">
+            ({visibleReplies.length}
+            {visibleReplies.length === 1 ? "reply" : "replies"})
+          </span>
+        </h2>
+        <button
+          type="button"
+          data-testid="reply-thread-overlay-close"
+          onclick={onClose}
+          aria-label="Close reply thread"
+          style="background: none; border: none; cursor: pointer; font-size: 18px; color: var(--tandem-fg-muted); line-height: 1; padding: 2px 6px; border-radius: var(--tandem-r-2);"
+        >
+          ✕
+        </button>
+      </div>
+
+      <!-- Original comment context -->
+      <div
+        style="padding: var(--tandem-space-2) var(--tandem-space-3); background: var(--tandem-surface-muted); border-radius: var(--tandem-r-2); border-left: 3px solid var(--tandem-author-claude); font-size: var(--tandem-text-sm); color: var(--tandem-fg-muted); white-space: pre-wrap;"
+      >
+        {annotation.content}
+      </div>
+
+      <!-- Thread body -->
+      {#if visibleReplies.length === 0}
+        <p style="margin: 0; font-size: var(--tandem-text-sm); color: var(--tandem-fg-subtle);">
+          No replies yet.
+        </p>
+      {:else}
+        <CommentThread replies={visibleReplies} />
+      {/if}
+
+      <!-- Reply composer (reuses the same onReply write path; no new HTTP/MCP) -->
+      {#if onReply}
+        <div style="border-top: 1px solid var(--tandem-border); padding-top: var(--tandem-space-3);">
+          {#if isReplying}
+            <textarea
+              bind:this={replyTextareaEl}
+              data-testid="reply-thread-overlay-input"
+              value={replyText}
+              oninput={(e) => (replyText = (e.target as HTMLTextAreaElement).value)}
+              onkeydown={handleReplyKeyDown}
+              placeholder="Write a reply..."
+              style={TEXTAREA_STYLE}
+            ></textarea>
+            <div style="display: flex; gap: var(--tandem-space-2); margin-top: var(--tandem-space-2);">
+              <button
+                type="button"
+                data-testid="reply-thread-overlay-send"
+                onclick={handleSendReply}
+                disabled={!hasText || isSendingReply}
+                style="padding: 4px 10px; font-size: var(--tandem-text-xs); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-1); background: {hasText
+                  ? 'var(--tandem-accent-bg)'
+                  : 'var(--tandem-surface-muted)'}; color: {hasText
+                  ? 'var(--tandem-accent-fg-strong)'
+                  : 'var(--tandem-fg-subtle)'}; cursor: {hasText && !isSendingReply ? 'pointer' : 'default'};"
+              >
+                Send
+              </button>
+              <button
+                type="button"
+                data-testid="reply-thread-overlay-cancel"
+                onclick={() => {
+                  isReplying = false;
+                  replyText = "";
+                }}
+                style="padding: 4px 10px; font-size: var(--tandem-text-xs); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg-muted); cursor: pointer;"
+              >
+                Cancel
+              </button>
+            </div>
+          {:else}
+            <button
+              type="button"
+              data-testid="reply-thread-overlay-reply"
+              onclick={() => (isReplying = true)}
+              style="padding: 4px 10px; font-size: var(--tandem-text-xs); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg-muted); cursor: pointer;"
+            >
+              Reply
+            </button>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/src/client/panels/panel-styles.ts
+++ b/src/client/panels/panel-styles.ts
@@ -5,3 +5,11 @@
  */
 export const TEXTAREA_STYLE =
   "width: 100%; padding: 4px 6px; font-size: var(--tandem-text-xs); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-1); resize: vertical; font-family: inherit; min-height: 40px; box-sizing: border-box; background: var(--tandem-surface); color: var(--tandem-fg);";
+
+/**
+ * Shared style for small secondary buttons in the reply thread overlay
+ * (Cancel + idle Reply). The primary Send button has dynamic colors so it
+ * stays inline.
+ */
+export const SECONDARY_BUTTON_STYLE =
+  "padding: 4px 10px; font-size: var(--tandem-text-xs); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg-muted); cursor: pointer;";

--- a/tests/client/reply-thread.test.ts
+++ b/tests/client/reply-thread.test.ts
@@ -3,22 +3,39 @@
 import { render } from "@testing-library/svelte";
 import { describe, expect, it } from "vitest";
 import ReplyThread from "../../src/client/panels/ReplyThread.svelte";
+import type { Annotation, AnnotationReply } from "../../src/shared/types";
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: "annotation-1",
+    type: "comment",
+    author: "claude",
+    status: "pending",
+    content: "Body",
+    range: { from: 0, to: 1 },
+    timestamp: 0,
+    ...overrides,
+  } as Annotation;
+}
+
+function makeReply(overrides: Partial<AnnotationReply> = {}): AnnotationReply {
+  return {
+    id: "reply-1",
+    annotationId: "annotation-1",
+    author: "claude",
+    text: "Existing reply",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
 
 describe("ReplyThread", () => {
   it("renders existing replies when reply input is not available", () => {
-    const replies = [
-      {
-        id: "reply-1",
-        annotationId: "annotation-1",
-        author: "claude",
-        text: "Existing reply",
-        timestamp: Date.now(),
-      },
-    ];
+    const replies = [makeReply()];
 
     const { container } = render(ReplyThread, {
       props: {
-        annotationId: "annotation-1",
+        annotation: makeAnnotation(),
         replies,
         isPending: false,
         isEditing: false,
@@ -28,5 +45,52 @@ describe("ReplyThread", () => {
     expect(container.querySelector("[data-testid='comment-thread']")).toBeTruthy();
     expect(container.textContent).toContain("Existing reply");
     expect(container.textContent).toContain("reply");
+  });
+
+  // ADR-027: notes are user-private. Even a count badge on a note that has
+  // replies in the underlying Y.Map leaks information to Claude. The single
+  // fan-out point (getVisibleReplies inside ReplyThread) must drop them.
+  it("renders zero replies and zero count badge for a note annotation", () => {
+    const replies = [
+      makeReply({ id: "r1", text: "leak 1" }),
+      makeReply({ id: "r2", text: "leak 2" }),
+      makeReply({ id: "r3", text: "leak 3" }),
+    ];
+
+    const { container } = render(ReplyThread, {
+      props: {
+        annotation: makeAnnotation({ type: "note" }),
+        replies,
+        isPending: false,
+        isEditing: false,
+      },
+    });
+
+    // CommentThread renders nothing for empty replies.
+    expect(container.querySelector("[data-testid='comment-thread']")).toBeNull();
+    expect(container.textContent).not.toContain("leak");
+    // Read-only count badge (non-pending + no onReply) must not surface a count.
+    expect(container.textContent ?? "").not.toMatch(/\b3 replies\b/);
+    expect(container.textContent ?? "").not.toMatch(/\b3 reply\b/);
+  });
+
+  it("count badge in reply button reads zero for note annotation", () => {
+    const replies = [makeReply(), makeReply({ id: "r2" })];
+    const onReply = async () => true;
+
+    const { container } = render(ReplyThread, {
+      props: {
+        annotation: makeAnnotation({ type: "note" }),
+        replies,
+        isPending: true,
+        isEditing: false,
+        onReply,
+      },
+    });
+
+    // For a note with onReply (e.g. hypothetical surface), the button label
+    // omits the parenthesized count because visibleReplies is empty.
+    const button = container.querySelector("[data-testid='reply-btn-annotation-1']");
+    expect(button?.textContent?.trim()).toBe("Reply");
   });
 });


### PR DESCRIPTION
## Summary

Adds `ReplyThreadOverlay.svelte` — a modal that surfaces the full reply thread for a comment annotation with focus trap, ESC-to-close, and a reply composer that reuses the existing `onReply` write path. `AnnotationCard.svelte` gains an additive "Expand thread" button gated on `getVisibleReplies(annotation, replies).length >= 1`.

This is Unit 13 of the Tandem v1.0 first-feature-wave batch (Chain C+D follower).

## Storage shape & invariants (per task contract)

- **Reply storage:** replies live in `Y_MAP_ANNOTATION_REPLIES` keyed by `annotationId` (hydrated by `tandem_getAnnotations`); they are **not** embedded on the annotation object. The helper signature is `getVisibleReplies(annotation, replies)` — two args. This PR does not change the storage shape.
- **Coordinate math:** reply text is opaque to coordinate math (no flat-offset implications). This PR adds no new positions logic.
- **Origin tagging:** no new Y.Map write paths are introduced. The overlay reply composer reuses the existing `onReply` prop, so existing `MCP_ORIGIN`/server-side tagging applies unchanged.
- **Privacy (ADR-027):** the expand button and overlay content both gate on `getVisibleReplies(annotation, replies)`. Because that helper returns `[]` for `type !== "comment"`, note and highlight annotations never surface either affordance — single source of truth, no parallel `type === "comment"` check.
- **Per D5:** thread expansion only — no emoji or reaction UI.

## Chain dependencies

- Built on top of **Unit 0** (`fix/replies-privacy-guard`, PR #665) — uses `getVisibleReplies` from `src/client/annotations/replies.ts`.
- Independent of Unit 3 (#616 Y.Doc eviction, PR #668).

This branch was rebased onto `origin/fix/replies-privacy-guard`; the Unit 0 helper appears in this diff's first commit.

## Svelte 5 guardrails

- Focus-trap dialog ref accessed via `untrack(() => dialogEl)` inside `$effect` — mirrors `HelpModal.svelte`, avoids the `bind:this` re-run trap (`feedback_svelte_state_bind_this_loop`).
- `visibleReplies` and `canExpandThread` are `$derived` (not `const`) on prop-computed values.
- Click-outside dismiss via `role="presentation"` backdrop + `stopPropagation()` on the dialog container (exempts trigger + overlay per `feedback_click_outside_exempt_menu`).
- `CommentThread.svelte` is reused for rendering; no destructuring of getter-based returns.

## Test plan

- [x] `npm run typecheck` — clean (0 errors, 0 warnings)
- [x] `biome check --write` — clean on edited files
- [x] `npm test` — pre-existing flakes only (`mcp-stdio` port-contention, documented; `markdown-escaping` ReDoS timing; `file-opener-lifecycle` missing mammoth fixture in worktree node_modules). None touch annotation-card or reply paths.
- [ ] Manual smoke (Bryan): create a comment annotation, post a reply via existing reply path, verify the "Expand thread" button appears, open overlay, send a reply from overlay, ESC closes, focus returns to the expand button. Confirm note/highlight cards do **not** show the button.

## Files

- `src/client/panels/ReplyThreadOverlay.svelte` (new, 219 lines)
- `src/client/panels/AnnotationCard.svelte` (additive: import, derived gates, expand button, overlay mount)