### PR TITLE
chore(wave-1): cross-unit simplify pass — consolidate updater event channel

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default permissions. Cowork tauri::commands are enumerated in src/lib.rs invoke_handler! (commands: cowork_scan_workspaces, cowork_toggle_integration, cowork_rescan, cowork_get_status, cowork_get_meta, cowork_detect_vethernet_subnet, cowork_apply_token, cowork_install_into_workspace, cowork_uninstall_from_workspace, cowork_set_lan_ip_override, cowork_retry_admin_elevation).",
+  "description": "Default permissions. Cowork tauri::commands are enumerated in src/lib.rs invoke_handler! (commands: cowork_scan_workspaces, cowork_toggle_integration, cowork_rescan, cowork_get_status, cowork_get_meta, cowork_detect_vethernet_subnet, cowork_apply_token, cowork_install_into_workspace, cowork_uninstall_from_workspace, cowork_set_lan_ip_override, cowork_retry_admin_elevation, install_update).",
   "windows": [
     "main"
   ],

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,7 +25,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri_plugin_prevent_default::Flags;
@@ -653,6 +653,7 @@ pub fn run() {
             cowork_set_lan_ip_override,
             cowork_retry_admin_elevation,
             restart_sidecar,
+            install_update,
         ])
         .build(tauri::generate_context!())
         .unwrap_or_else(|e| panic!("Failed to build Tauri application: {e}"))
@@ -1968,11 +1969,55 @@ async fn check_for_update(app: &tauri::AppHandle, manual: bool) {
     let version = update.version.clone();
     log::info!("Update available: v{version}");
 
+    // Auto-check path (D6 locked decision): surface as an in-app banner via the
+    // updater event channel rather than blocking the user with a native dialog.
+    // The "Restart to install" CTA invokes `install_update` to kick off the
+    // download+install flow below. Manual checks (tray menu) keep the dialog so
+    // the user gets immediate feedback on their explicit action.
+    if !manual {
+        if let Err(e) = app.emit(
+            "tandem://update-available",
+            serde_json::json!({ "version": version }),
+        ) {
+            log::warn!("Failed to emit update-available event: {e}");
+        }
+        return;
+    }
+
     if !show_update_available_dialog(app, &version) {
         log::info!("User declined update to v{version}");
         return;
     }
 
+    perform_install(app, update, &version).await;
+}
+
+/// Tauri command — invoked by the in-app updater banner's "Restart to install"
+/// CTA. Re-runs `updater.check()` (so we always operate on the most recent
+/// release the server advertises) and dispatches the install flow.
+#[tauri::command]
+async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
+    let updater = app
+        .updater()
+        .map_err(|e| format!("Updater not configured: {e}"))?;
+    let update = updater
+        .check()
+        .await
+        .map_err(|e| format!("Update check failed: {e}"))?
+        .ok_or_else(|| "No update available".to_string())?;
+    let version = update.version.clone();
+    perform_install(&app, update, &version).await;
+    Ok(())
+}
+
+/// Shared install flow: kill sidecar, await port + file-lock release, then
+/// download+install via the Tauri updater plugin. On success the application
+/// is restarted; on failure a native dialog surfaces the error.
+async fn perform_install(
+    app: &tauri::AppHandle,
+    update: tauri_plugin_updater::Update,
+    version: &str,
+) {
     // Kill sidecar BEFORE install — on Windows, the NSIS installer runs during
     // download_and_install() and needs to replace node-sidecar.exe on disk.
     // If the process is still running, the file is locked and install fails.

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -57,6 +57,7 @@ import { createTandemModeBroadcast } from "./hooks/useTandemModeBroadcast.svelte
 import { createTandemSettings, TEXT_SIZE_PX, THEME_NEXT } from "./hooks/useTandemSettings.svelte";
 import { createTheme } from "./hooks/useTheme.svelte";
 import { createTutorial } from "./hooks/useTutorial.svelte";
+import { createUpdateAvailable } from "./hooks/useUpdateAvailable.svelte";
 import { createWebViewZoom } from "./hooks/useWebViewZoom.svelte";
 import { createYjsSync } from "./hooks/yjsSync.svelte";
 import { loadPanelWidth, PANEL_MAX_WIDTH, PANEL_MIN_WIDTH } from "./panel-layout";
@@ -195,8 +196,27 @@ let settingsBtnEl = $state<HTMLButtonElement | null>(null);
 let paletteOpen = $state(false);
 let fileOpenDialogOpen = $state(false);
 
+// Issue #660 — titlebar settings-icon update-available dot. Acknowledged
+// whenever the user opens settings (popover OR modal — any tab counts). Do
+// NOT destructure: the `showDot` getter loses reactivity when pulled out.
+const updateAvailable = createUpdateAvailable();
+
 function toggleSettings() {
+  // Acknowledge on the false→true transition only (closing settings via the
+  // gear shouldn't re-clear an already-acknowledged dot, but acknowledge() is
+  // idempotent so this is defence-in-depth).
+  if (!settingsOpen) updateAvailable.acknowledge();
   settingsOpen = !settingsOpen;
+}
+
+function openSettingsModalWithAck() {
+  updateAvailable.acknowledge();
+  settingsModalOpen = true;
+}
+
+function openSettingsPopoverWithAck() {
+  updateAvailable.acknowledge();
+  settingsOpen = true;
 }
 
 function cycleTheme() {
@@ -207,8 +227,8 @@ function cycleTheme() {
 // after the reactive state they depend on is available.
 wireActionDeps({
   getActiveTabId: () => yjsSync.activeTabId,
-  openSettings: () => (settingsOpen = true),
-  openSettingsModal: () => (settingsModalOpen = true),
+  openSettings: openSettingsPopoverWithAck,
+  openSettingsModal: openSettingsModalWithAck,
   toggleSoloMode: () =>
     modeState.setTandemMode(modeState.tandemMode === "solo" ? "tandem" : "solo"),
   openFindBar: () => {
@@ -502,10 +522,10 @@ $effect(() => {
         // `isSettingsShortcut` even though that predicate also rejects shift —
         // shielding the order against future predicate edits.
         e.preventDefault();
-        settingsModalOpen = true;
+        openSettingsModalWithAck();
       } else if (isSettingsShortcut(e)) {
         e.preventDefault();
-        settingsOpen = true;
+        openSettingsPopoverWithAck();
       } else if (e.shiftKey && e.code === "KeyP") {
         e.preventDefault();
         paletteOpen = !untrack(() => paletteOpen);
@@ -770,7 +790,8 @@ const tutorial = createTutorial(
     onAuthorshipChange={(visible) => settingsState.updateSettings({ showAuthorship: visible })}
     onOpenHelp={() => (showHelp = true)}
     onOpenSettings={toggleSettings}
-    onOpenSettingsModal={() => (settingsModalOpen = true)}
+    onOpenSettingsModal={openSettingsModalWithAck}
+    updateAvailable={updateAvailable.showDot}
     bind:settingsBtn={settingsBtnEl}
   />
   {#if !yjsSync.ready}

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -21,6 +21,7 @@ import HelpModal from "./components/HelpModal.svelte";
 import OnboardingTutorial from "./components/OnboardingTutorial.svelte";
 import PanelSlot from "./components/PanelSlot.svelte";
 import ReviewOnlyBanner from "./components/ReviewOnlyBanner.svelte";
+import SettingsModal from "./components/SettingsModal.svelte";
 import SettingsPopover from "./components/SettingsPopover.svelte";
 import ToastContainer from "./components/ToastContainer.svelte";
 import { isTauriRuntime } from "./cowork/cowork-helpers";
@@ -48,7 +49,7 @@ import { createHighContrast } from "./hooks/useHighContrast.svelte";
 import { createMarginPositions } from "./hooks/useMarginPositions.svelte";
 import { shouldShowInMode } from "./hooks/useModeGate";
 import { createNotifications } from "./hooks/useNotifications.svelte";
-import { isSettingsShortcut } from "./hooks/useSettingsShortcut.js";
+import { isSettingsModalShortcut, isSettingsShortcut } from "./hooks/useSettingsShortcut.js";
 import { createTabCycleKeyboard } from "./hooks/useTabCycleKeyboard.svelte";
 import { pickTabByDigit, shouldIgnoreShortcut } from "./hooks/useTabKeyboardShortcuts.js";
 import { createTabOrder } from "./hooks/useTabOrder.svelte";
@@ -189,6 +190,7 @@ const notifications = createNotifications();
 const fileDrop = createFileDrop();
 
 let settingsOpen = $state(false);
+let settingsModalOpen = $state(false);
 let settingsBtnEl = $state<HTMLButtonElement | null>(null);
 let paletteOpen = $state(false);
 let fileOpenDialogOpen = $state(false);
@@ -206,6 +208,7 @@ function cycleTheme() {
 wireActionDeps({
   getActiveTabId: () => yjsSync.activeTabId,
   openSettings: () => (settingsOpen = true),
+  openSettingsModal: () => (settingsModalOpen = true),
   toggleSoloMode: () =>
     modeState.setTandemMode(modeState.tandemMode === "solo" ? "tandem" : "solo"),
   openFindBar: () => {
@@ -493,6 +496,13 @@ $effect(() => {
       } else if (e.code === "KeyS") {
         e.preventDefault();
         void triggerSave(yjsSync.activeTabId);
+      } else if (isSettingsModalShortcut(e)) {
+        // Wave 1: Ctrl+Shift+, opens the new SettingsModal sibling component
+        // (see `components/SettingsModal.svelte`). Must be tested before
+        // `isSettingsShortcut` even though that predicate also rejects shift —
+        // shielding the order against future predicate edits.
+        e.preventDefault();
+        settingsModalOpen = true;
       } else if (isSettingsShortcut(e)) {
         e.preventDefault();
         settingsOpen = true;
@@ -760,6 +770,7 @@ const tutorial = createTutorial(
     onAuthorshipChange={(visible) => settingsState.updateSettings({ showAuthorship: visible })}
     onOpenHelp={() => (showHelp = true)}
     onOpenSettings={toggleSettings}
+    onOpenSettingsModal={() => (settingsModalOpen = true)}
     bind:settingsBtn={settingsBtnEl}
   />
   {#if !yjsSync.ready}
@@ -930,6 +941,17 @@ const tutorial = createTutorial(
       onUpdate={settingsState.updateSettings}
       returnFocusEl={settingsBtnEl}
       anchorEl={settingsBtnEl}
+      connected={yjsSync.connected}
+      reconnectAttempts={yjsSync.reconnectAttempts}
+    />
+
+    <SettingsModal
+      open={settingsModalOpen}
+      onClose={() => (settingsModalOpen = false)}
+      settings={settingsState.settings}
+      onUpdate={settingsState.updateSettings}
+      returnFocusEl={settingsBtnEl}
+      triggerEl={settingsBtnEl}
       connected={yjsSync.connected}
       reconnectAttempts={yjsSync.reconnectAttempts}
     />

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -23,6 +23,7 @@ import PanelSlot from "./components/PanelSlot.svelte";
 import ReviewOnlyBanner from "./components/ReviewOnlyBanner.svelte";
 import SettingsPopover from "./components/SettingsPopover.svelte";
 import ToastContainer from "./components/ToastContainer.svelte";
+import UpdaterBanner from "./components/UpdaterBanner.svelte";
 import { isTauriRuntime } from "./cowork/cowork-helpers";
 import DocxPageContainer from "./editor/DocxPageContainer.svelte";
 import Editor from "./editor/Editor.svelte";
@@ -56,6 +57,7 @@ import { createTandemModeBroadcast } from "./hooks/useTandemModeBroadcast.svelte
 import { createTandemSettings, TEXT_SIZE_PX, THEME_NEXT } from "./hooks/useTandemSettings.svelte";
 import { createTheme } from "./hooks/useTheme.svelte";
 import { createTutorial } from "./hooks/useTutorial.svelte";
+import { createUpdaterBanner } from "./hooks/useUpdaterBanner.svelte";
 import { createWebViewZoom } from "./hooks/useWebViewZoom.svelte";
 import { createYjsSync } from "./hooks/yjsSync.svelte";
 import { loadPanelWidth, PANEL_MAX_WIDTH, PANEL_MIN_WIDTH } from "./panel-layout";
@@ -181,6 +183,7 @@ const connectionBanner = createConnectionBanner(
   () => yjsSync.disconnectedSince,
   () => settingsState.settings.degradedBannerDelayMs,
 );
+const updaterBanner = createUpdaterBanner();
 createWebViewZoom();
 
 const openDocs = $derived(yjsSync.tabs.map((t) => ({ id: t.id, fileName: t.fileName })));
@@ -775,6 +778,15 @@ const tutorial = createTutorial(
       >
         Server restarted — refreshing documents
       </div>
+    {/if}
+
+    {#if isTauriRuntime() && updaterBanner.showBanner && updaterBanner.availableVersion}
+      <UpdaterBanner
+        version={updaterBanner.availableVersion}
+        installing={updaterBanner.installing}
+        onInstall={() => { updaterBanner.install(); }}
+        onDismiss={updaterBanner.dismiss}
+      />
     {/if}
 
     {#if connectionBanner.showBanner}

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -20,6 +20,12 @@ import { type Action, registerAction } from "./registry.svelte.js";
 interface ActionDeps {
   getActiveTabId: () => string | null;
   openSettings: () => void;
+  /**
+   * Open the new SettingsModal (Wave 1 sibling component). Separate from
+   * `openSettings`, which targets the legacy SettingsPopover until Wave 2
+   * retires it.
+   */
+  openSettingsModal: () => void;
   toggleSoloMode: () => void;
   openFindBar: () => void;
   openFindBarTabs: () => void;
@@ -131,6 +137,15 @@ const BUILTINS: Action[] = [
     shortcut: "Ctrl+,",
     run() {
       guardedRun("settings", (d) => d.openSettings());
+    },
+  },
+  {
+    id: "settings-modal",
+    label: "Open settings (new)",
+    group: "view",
+    shortcut: "Ctrl+Shift+,",
+    run() {
+      guardedRun("settings-modal", (d) => d.openSettingsModal());
     },
   },
   {

--- a/src/client/components/SettingsModal.svelte
+++ b/src/client/components/SettingsModal.svelte
@@ -1,0 +1,676 @@
+<script lang="ts" module>
+import type { Component } from "svelte";
+import type { TandemSettings } from "../hooks/useTandemSettings.svelte";
+
+/**
+ * Context passed to every settings tab body component.
+ *
+ * Wave 2 retires `SettingsPopover.svelte` and consolidates onto this modal.
+ * Tab body components must accept this prop shape. Treat this contract as
+ * stable: new fields should be added with defaults rather than breaking
+ * existing tab implementations.
+ *
+ * **Do not destructure** the context with `const` — pass it through to
+ * children so reactivity is preserved (see `feedback_svelte_getter_destructuring`).
+ */
+export interface SettingsTabContext {
+  open: boolean;
+  settings: TandemSettings;
+  onUpdate: (partial: Partial<TandemSettings>) => void;
+  connected: boolean;
+  reconnectAttempts: number;
+}
+
+/**
+ * Registry entry for one tab in the SettingsModal sidebar.
+ *
+ * `icon` is an SVG path `d` attribute string, rendered in a 24x24 viewBox
+ * with `stroke="currentColor"` (matches the existing `SettingsPopover` shape).
+ *
+ * Wave 2 (e.g. Network 2.0 panel, integrations registry) ships additional
+ * tabs by passing an extended array to the `tabs` prop. The defaults from
+ * `DEFAULT_SETTINGS_TABS` cover the same sections the popover renders.
+ */
+export interface SettingsTab {
+  id: string;
+  label: string;
+  icon: string;
+  component: Component<SettingsTabContext>;
+}
+</script>
+
+<script lang="ts">
+import { onMount, untrack } from "svelte";
+import { TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
+import { API_OPEN } from "../../shared/api-paths";
+import { createAppInfo } from "../hooks/useAppInfo.svelte";
+import { API_BASE } from "../utils/fileUpload";
+import AccessibilitySettings from "./AccessibilitySettings.svelte";
+import AppearanceSettings from "./AppearanceSettings.svelte";
+import EditorSettings from "./EditorSettings.svelte";
+import NetworkSettings from "./NetworkSettings.svelte";
+import SettingsCollaborationTab from "./settings-tabs/SettingsCollaborationTab.svelte";
+import SettingsClaudeCodeTab from "./settings-tabs/SettingsClaudeCodeTab.svelte";
+import SettingsShortcutsTab from "./settings-tabs/SettingsShortcutsTab.svelte";
+import SettingsAboutTab from "./settings-tabs/SettingsAboutTab.svelte";
+
+const HEADING_ID = "tandem-settings-modal-heading";
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Default tabs — mirror the sections exposed by `SettingsPopover.svelte`.
+ *
+ * Wave 2 will retire the popover; any Wave 2 additions land here as new
+ * entries (or via the `tabs` prop) without touching this default array.
+ *
+ * **About the `as unknown as Component<SettingsTabContext>` casts:** the
+ * existing settings sub-components (`AppearanceSettings`, `EditorSettings`,
+ * `NetworkSettings`, `AccessibilitySettings`) declare narrower `Props`
+ * interfaces — they only read a subset of the context fields. Svelte 5
+ * silently drops unknown props when a component uses non-rest destructuring
+ * in `$props()`, which is the desired runtime behavior: pass the uniform
+ * context to every tab and let each component consume what it needs. The
+ * casts are load-bearing; do not "fix" them by widening the sub-component
+ * Props interfaces — that would force every Wave 2 settings panel to
+ * declare fields it doesn't read.
+ */
+export const DEFAULT_SETTINGS_TABS: SettingsTab[] = [
+  {
+    id: "appearance",
+    label: "Appearance",
+    icon: "M12 3v2M12 19v2M5 12H3M21 12h-2M6.3 6.3 4.9 4.9M19.1 19.1l-1.4-1.4M6.3 17.7l-1.4 1.4M19.1 4.9l-1.4 1.4M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z",
+    component: AppearanceSettings as unknown as Component<SettingsTabContext>,
+  },
+  {
+    id: "editor",
+    label: "Editor",
+    icon: "M4 4h11M4 9h16M4 14h11M4 19h16",
+    component: EditorSettings as unknown as Component<SettingsTabContext>,
+  },
+  {
+    id: "network",
+    label: "Network",
+    icon: "M3 12h18M3 12a9 9 0 0 1 18 0M3 12a9 9 0 0 0 18 0M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18",
+    component: NetworkSettings as unknown as Component<SettingsTabContext>,
+  },
+  {
+    id: "accessibility",
+    label: "Accessibility",
+    icon: "M12 3a2 2 0 1 1 0 4 2 2 0 0 1 0-4ZM4 9h16M9 9v5l-2 7M15 9v5l2 7M9 14h6",
+    component: AccessibilitySettings as unknown as Component<SettingsTabContext>,
+  },
+  {
+    id: "collaboration",
+    label: "Collaboration",
+    icon: "M17 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2M10 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8ZM21 21v-2a4 4 0 0 0-3-3.87M16 3.13A4 4 0 0 1 16 11",
+    component: SettingsCollaborationTab as unknown as Component<SettingsTabContext>,
+  },
+  {
+    id: "claude-code",
+    label: "Claude Code/Cowork",
+    icon: "M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9L12 3Z",
+    component: SettingsClaudeCodeTab as unknown as Component<SettingsTabContext>,
+  },
+  {
+    id: "shortcuts",
+    label: "Shortcuts",
+    icon: "M3 7h2v2H3V7Zm0 4h2v2H3v-2Zm0 4h2v2H3v-2Zm4-8h2v2H7V7Zm0 4h2v2H7v-2Zm0 4h10v2H7v-2Zm4-8h10v2H11V7Zm0 4h6v2h-6v-2Zm8 0h2v2h-2v-2Z",
+    component: SettingsShortcutsTab as unknown as Component<SettingsTabContext>,
+  },
+  {
+    id: "about",
+    label: "About",
+    icon: "M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18Zm0 4v6m0 4h.01",
+    component: SettingsAboutTab as unknown as Component<SettingsTabContext>,
+  },
+];
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  settings: TandemSettings;
+  onUpdate: (partial: Partial<TandemSettings>) => void;
+  returnFocusEl?: HTMLElement | null;
+  /**
+   * Trigger element to exempt from click-outside dismissal. The modal
+   * container is exempted automatically.
+   */
+  triggerEl?: HTMLElement | null;
+  connected?: boolean;
+  reconnectAttempts?: number;
+  /**
+   * Optional override for the tabs list. Defaults to `DEFAULT_SETTINGS_TABS`.
+   * Wave 2 lands additional tabs additively via this prop.
+   */
+  tabs?: SettingsTab[];
+}
+
+let {
+  open,
+  onClose,
+  settings,
+  onUpdate,
+  returnFocusEl = null,
+  triggerEl = null,
+  connected = false,
+  reconnectAttempts = 0,
+  tabs = DEFAULT_SETTINGS_TABS,
+}: Props = $props();
+
+let modalEl: HTMLDivElement | undefined = $state();
+const appInfo = createAppInfo(() => open);
+let changelogLoading = $state(false);
+let changelogError = $state<string | null>(null);
+
+const resolvedTabs = $derived(tabs.length > 0 ? tabs : DEFAULT_SETTINGS_TABS);
+let activeTabId = $state<string>(DEFAULT_SETTINGS_TABS[0].id);
+// Always settle on a tab that exists in the current registry — handles the
+// case where a caller passes a tabs prop that omits the previously active id.
+const activeTab = $derived(
+  resolvedTabs.find((t) => t.id === activeTabId) ?? resolvedTabs[0],
+);
+const activeTabLabel = $derived(activeTab.label);
+
+const tabContext = $derived<SettingsTabContext>({
+  open,
+  settings,
+  onUpdate,
+  connected,
+  reconnectAttempts,
+});
+
+// Initial focus on open. We deliberately avoid reading the bound modalEl
+// from inside an $effect — that combination produces the
+// $state+bind:this+$effect reactive loop (feedback_svelte_state_bind_this_loop).
+// onMount fires only once after the first DOM commit, so it's safe to read
+// modalEl there; on subsequent opens we re-focus via the open-watching
+// effect that uses untrack() to avoid registering modalEl as a dependency.
+onMount(() => {
+  if (open) modalEl?.focus();
+});
+
+$effect(() => {
+  if (!open) return;
+  // Reading modalEl inside untrack() avoids the reactive loop while still
+  // letting us focus on each open->true transition.
+  untrack(() => modalEl?.focus());
+  return () => {
+    returnFocusEl?.focus();
+  };
+});
+
+// Click-outside dismissal. Exempts BOTH the trigger element AND the modal
+// container (feedback_click_outside_exempt_menu). Using .contains() is safe
+// here because the modal is rendered inline (no portal); if a future caller
+// portals it, swap to `.closest()` per feedback_portal_breaks_contains.
+$effect(() => {
+  if (!open) return;
+  const handler = (e: PointerEvent) => {
+    const target = e.target as Node | null;
+    if (!target) return;
+    if (triggerEl?.contains(target)) return;
+    if (modalEl && !modalEl.contains(target)) {
+      onClose();
+    }
+  };
+  // Defer to next tick so the click that opened the modal doesn't immediately
+  // close it.
+  const timer = setTimeout(() => document.addEventListener("pointerdown", handler), 0);
+  return () => {
+    clearTimeout(timer);
+    document.removeEventListener("pointerdown", handler);
+  };
+});
+
+// Escape + focus trap. Identical wrap-around behavior to SettingsPopover —
+// re-query focusables on every Tab press because the 640px breakpoint
+// reflows the sidebar into a row, which changes the focusable set.
+$effect(() => {
+  if (!open) return;
+  const handler = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      onClose();
+      return;
+    }
+    if (e.key !== "Tab" || !modalEl) return;
+    const focusables = modalEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    if (!modalEl.contains(active)) {
+      e.preventDefault();
+      first.focus();
+      return;
+    }
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+  window.addEventListener("keydown", handler);
+  return () => window.removeEventListener("keydown", handler);
+});
+
+// Clear stale view-changelog errors when tab changes.
+$effect(() => {
+  activeTabId;
+  changelogError = null;
+});
+
+async function handleViewChangelog(): Promise<void> {
+  const filePath = appInfo.info?.changelogPath;
+  if (!filePath) {
+    changelogError = "Changelog file not found.";
+    return;
+  }
+  changelogLoading = true;
+  changelogError = null;
+  try {
+    const res = await fetch(`${API_BASE}${API_OPEN}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath, readOnly: true }),
+    });
+    if (!res.ok) {
+      let msg = "Failed to open changelog.";
+      try {
+        const data = (await res.json()) as { message?: string };
+        if (data.message) msg = data.message;
+      } catch {
+        // ignore JSON parse failure
+      }
+      if (res.status === 404) msg = "Changelog file not found.";
+      changelogError = msg;
+      return;
+    }
+    onClose();
+  } catch (err) {
+    console.warn("[Tandem] Failed to open changelog:", err);
+    changelogError = "Server unavailable.";
+  } finally {
+    changelogLoading = false;
+  }
+}
+</script>
+
+{#if open}
+  <div
+    aria-hidden="true"
+    onclick={onClose}
+    data-testid="settings-modal-scrim"
+    style="position: fixed; inset: 0; background: color-mix(in srgb, var(--tandem-bg) 70%, transparent); z-index: 9998;"
+  ></div>
+  <div
+    bind:this={modalEl}
+    data-testid="settings-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby={HEADING_ID}
+    tabindex={-1}
+    class="settings-modal"
+  >
+    <aside class="settings-modal-sidebar">
+      <div class="settings-modal-sidebar-head">
+        <div id={HEADING_ID} class="settings-modal-sidebar-title">Settings</div>
+        {#if appInfo.info}
+          <span
+            class="settings-modal-version-chip"
+            data-testid="settings-modal-sidebar-version"
+          >
+            v{appInfo.info.version}
+          </span>
+        {/if}
+      </div>
+
+      <nav aria-label="Settings sections" class="settings-modal-sidebar-nav">
+        {#each resolvedTabs as tab (tab.id)}
+          <button
+            type="button"
+            aria-current={activeTabId === tab.id ? "page" : undefined}
+            data-active={activeTabId === tab.id ? "true" : "false"}
+            data-testid={`settings-modal-tab-${tab.id}`}
+            onclick={() => (activeTabId = tab.id)}
+            class="settings-modal-nav-btn"
+          >
+            <svg
+              aria-hidden="true"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              style="flex-shrink: 0;"
+            >
+              <path d={tab.icon} />
+            </svg>
+            <span>{tab.label}</span>
+          </button>
+        {/each}
+      </nav>
+
+      <div
+        class="settings-modal-sidebar-foot"
+        data-testid="settings-modal-sidebar-footer"
+      >
+        <button
+          type="button"
+          data-testid="settings-modal-view-changelog-btn"
+          onclick={() => void handleViewChangelog()}
+          disabled={changelogLoading || appInfo.loading}
+          class="settings-modal-sidebar-link"
+        >
+          {changelogLoading ? "Opening…" : "Changelog"}
+        </button>
+        {#if changelogError}
+          <div
+            role="alert"
+            data-testid="settings-modal-changelog-error"
+            style="font-size: 11px; color: var(--tandem-error-fg); padding: 0 var(--tandem-space-2);"
+          >
+            {changelogError}
+          </div>
+        {/if}
+        <a
+          href={TANDEM_ISSUES_NEW_URL}
+          target="_blank"
+          rel="noreferrer"
+          data-testid="settings-modal-report-bug-link"
+          class="settings-modal-sidebar-link"
+        >
+          Report a bug
+        </a>
+        <div
+          class="settings-modal-sidebar-status"
+          data-testid="settings-modal-mcp-status"
+          aria-live="polite"
+        >
+          <span
+            class="settings-modal-status-dot"
+            data-state={connected
+              ? "connected"
+              : reconnectAttempts > 0
+                ? "reconnecting"
+                : "disconnected"}
+          ></span>
+          <span class="settings-modal-status-label">
+            {#if connected}
+              MCP connected
+            {:else if reconnectAttempts > 0}
+              Reconnecting…
+            {:else}
+              MCP offline
+            {/if}
+          </span>
+        </div>
+      </div>
+    </aside>
+
+    <section class="settings-modal-content" data-testid="settings-modal-content">
+      <header class="settings-modal-content-head">
+        <h2 class="settings-modal-content-title">{activeTabLabel}</h2>
+        <button
+          type="button"
+          onclick={onClose}
+          data-testid="settings-modal-close-btn"
+          class="settings-modal-close"
+          aria-label="Close settings"
+        >
+          ×
+        </button>
+      </header>
+
+      <div class="settings-modal-content-body">
+        <div class="settings-modal-content-inner">
+          {#key activeTab.id}
+            <activeTab.component {...tabContext} />
+          {/key}
+        </div>
+      </div>
+    </section>
+  </div>
+{/if}
+
+<style>
+  .settings-modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(900px, calc(100vw - 32px));
+    height: min(680px, calc(100vh - 32px));
+    background: var(--tandem-surface);
+    color: var(--tandem-fg);
+    border: 1px solid var(--tandem-border);
+    border-radius: var(--tandem-r-4);
+    box-shadow: var(--tandem-shadow-3);
+    z-index: 9999;
+    display: grid;
+    grid-template-columns: 188px minmax(0, 1fr);
+    outline: none;
+    overflow: hidden;
+  }
+
+  .settings-modal-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: var(--tandem-space-4);
+    padding: var(--tandem-space-5) var(--tandem-space-3);
+    border-right: 1px solid var(--tandem-border);
+    background: var(--tandem-surface-muted);
+    overflow-y: auto;
+  }
+
+  .settings-modal-sidebar-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--tandem-space-2);
+    padding: 0 var(--tandem-space-2);
+  }
+
+  .settings-modal-sidebar-title {
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--tandem-fg);
+  }
+
+  .settings-modal-version-chip {
+    font-family: var(--tandem-font-mono);
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--tandem-fg-subtle);
+    padding: 1px 6px;
+    border: 1px solid var(--tandem-border);
+    border-radius: var(--tandem-r-pill);
+    background: var(--tandem-surface);
+    line-height: 1.5;
+  }
+
+  .settings-modal-sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+  }
+
+  .settings-modal-nav-btn {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--tandem-space-2);
+    min-height: 34px;
+    padding: 0 var(--tandem-space-3);
+    border: 1px solid transparent;
+    border-radius: var(--tandem-r-3);
+    background: transparent;
+    color: var(--tandem-fg-muted);
+    font-size: 13px;
+    font-weight: 500;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .settings-modal-nav-btn:hover {
+    background: var(--tandem-surface);
+    color: var(--tandem-fg);
+  }
+
+  .settings-modal-nav-btn:focus-visible {
+    outline: 2px solid var(--tandem-accent);
+    outline-offset: 1px;
+  }
+
+  .settings-modal-nav-btn[data-active="true"] {
+    background: var(--tandem-accent-bg);
+    color: var(--tandem-accent-fg-strong);
+    font-weight: 600;
+  }
+
+  .settings-modal-sidebar-foot {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: var(--tandem-space-3) var(--tandem-space-2) 0;
+    margin-top: auto;
+    border-top: 1px solid var(--tandem-border);
+  }
+
+  .settings-modal-sidebar-link {
+    appearance: none;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: var(--tandem-r-2);
+    color: var(--tandem-fg-muted);
+    font-size: 12px;
+    font-weight: 500;
+    text-align: left;
+    text-decoration: none;
+    padding: 6px var(--tandem-space-2);
+    cursor: pointer;
+  }
+
+  .settings-modal-sidebar-link:hover:not(:disabled),
+  .settings-modal-sidebar-link:focus-visible {
+    color: var(--tandem-fg);
+    background: var(--tandem-surface);
+    outline: none;
+  }
+
+  .settings-modal-sidebar-link:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .settings-modal-sidebar-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px var(--tandem-space-2);
+    font-size: 11px;
+    color: var(--tandem-fg-subtle);
+  }
+
+  .settings-modal-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--tandem-fg-subtle);
+    flex-shrink: 0;
+  }
+
+  .settings-modal-status-dot[data-state="connected"] {
+    background: var(--tandem-success);
+  }
+
+  .settings-modal-status-dot[data-state="reconnecting"] {
+    background: var(--tandem-warning);
+  }
+
+  .settings-modal-status-dot[data-state="disconnected"] {
+    background: var(--tandem-error);
+  }
+
+  .settings-modal-status-label {
+    font-family: var(--tandem-font-mono);
+    font-size: 10px;
+    letter-spacing: 0.02em;
+  }
+
+  .settings-modal-content {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .settings-modal-content-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 56px;
+    padding: 0 var(--tandem-space-5);
+    border-bottom: 1px solid var(--tandem-border);
+    background: var(--tandem-surface);
+  }
+
+  .settings-modal-content-title {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--tandem-fg);
+    margin: 0;
+  }
+
+  .settings-modal-close {
+    background: none;
+    border: 1px solid transparent;
+    cursor: pointer;
+    color: var(--tandem-fg-subtle);
+    font-size: 18px;
+    line-height: 1;
+    padding: 4px 8px;
+    min-width: 30px;
+    min-height: 30px;
+    border-radius: var(--tandem-r-2);
+  }
+
+  .settings-modal-close:hover,
+  .settings-modal-close:focus-visible {
+    color: var(--tandem-fg);
+    background: var(--tandem-surface-muted);
+    outline: none;
+  }
+
+  .settings-modal-content-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--tandem-space-5);
+  }
+
+  .settings-modal-content-inner {
+    display: flex;
+    flex-direction: column;
+    gap: var(--tandem-space-5);
+    max-width: 620px;
+  }
+
+  @media (max-width: 640px) {
+    .settings-modal {
+      grid-template-columns: 1fr;
+      grid-template-rows: minmax(auto, 45%) 1fr;
+    }
+
+    .settings-modal-sidebar {
+      border-right: none;
+      border-bottom: 1px solid var(--tandem-border);
+      padding: var(--tandem-space-3);
+    }
+  }
+</style>

--- a/src/client/components/UpdaterBanner.svelte
+++ b/src/client/components/UpdaterBanner.svelte
@@ -1,42 +1,48 @@
 <script lang="ts">
 interface Props {
+  version: string;
+  installing: boolean;
+  onInstall: () => void;
   onDismiss: () => void;
-  onRetry: () => void;
 }
 
-let { onDismiss, onRetry }: Props = $props();
+let { version, installing, onInstall, onDismiss }: Props = $props();
+
+const ctaLabel = $derived(installing ? "Installing…" : "Restart to install");
 </script>
 
 <div
   class="tandem-banner tandem-banner--info"
   role="status"
   aria-live="polite"
-  data-testid="connection-banner"
+  data-testid="updater-banner"
 >
   <span class="tandem-banner__icon" aria-hidden="true">
-    <!-- Cloud-off glyph; inherits currentColor -->
+    <!-- Down-arrow-in-cloud glyph; inherits currentColor -->
     <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M2 2l20 20" />
-      <path d="M5.16 5.26A6 6 0 008 17h11a4 4 0 00.74-7.93" />
-      <path d="M12 7a5 5 0 014.9 4" />
+      <path d="M20 16.58A5 5 0 0018 7h-1.26A8 8 0 104 15.25" />
+      <path d="M12 12v8" />
+      <path d="M8 16l4 4 4-4" />
     </svg>
   </span>
   <span class="tandem-banner__message">
-    Connection to the Tandem server has been lost. Ensure the server is running.
+    Tandem v{version} is available.
   </span>
   <button
     type="button"
     class="tandem-banner__cta"
-    data-testid="connection-banner-retry"
-    onclick={onRetry}
+    data-testid="updater-banner-install"
+    onclick={onInstall}
+    disabled={installing}
   >
-    Retry now
+    {ctaLabel}
   </button>
   <button
     type="button"
     class="tandem-banner__dismiss"
+    data-testid="updater-banner-dismiss"
     onclick={onDismiss}
-    aria-label="Dismiss connection banner"
+    aria-label="Dismiss update notification"
   >
     <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
       <path d="M6 6l12 12M6 18L18 6" />
@@ -55,7 +61,6 @@ let { onDismiss, onRetry }: Props = $props();
   line-height: 1.4;
   text-align: center;
   border-bottom: 1px solid transparent;
-  /* Subtle slide-in from above on appearance */
   animation: tandem-banner-slide-in 180ms ease-out;
 }
 
@@ -90,13 +95,18 @@ let { onDismiss, onRetry }: Props = $props();
   transition: background-color 120ms ease-out, border-color 120ms ease-out;
 }
 
-.tandem-banner__cta:hover {
+.tandem-banner__cta:hover:not(:disabled) {
   background: color-mix(in srgb, var(--tandem-info) 14%, transparent);
 }
 
 .tandem-banner__cta:focus-visible {
   outline: 2px solid var(--tandem-info-fg-strong);
   outline-offset: 2px;
+}
+
+.tandem-banner__cta:disabled {
+  cursor: progress;
+  opacity: 0.7;
 }
 
 .tandem-banner__dismiss {
@@ -154,7 +164,7 @@ let { onDismiss, onRetry }: Props = $props();
     border-color: CanvasText;
     color: CanvasText;
   }
-  .tandem-banner__cta:hover,
+  .tandem-banner__cta:hover:not(:disabled),
   .tandem-banner__dismiss:hover {
     background: Highlight;
     color: HighlightText;

--- a/src/client/components/settings-tabs/SettingsAboutTab.svelte
+++ b/src/client/components/settings-tabs/SettingsAboutTab.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+import { API_OPEN } from "../../../shared/api-paths";
+import { createAppInfo } from "../../hooks/useAppInfo.svelte";
+import { API_BASE } from "../../utils/fileUpload";
+import type { SettingsTabContext } from "../SettingsModal.svelte";
+
+let { open, settings: _settings, onUpdate: _onUpdate }: SettingsTabContext = $props();
+
+const appInfo = createAppInfo(() => open);
+let docsLoading = $state(false);
+let docsError = $state<string | null>(null);
+
+async function handleViewDocumentation(): Promise<void> {
+  const filePath = appInfo.info?.workflowsPath;
+  if (!filePath) {
+    docsError = "Documentation file not found.";
+    return;
+  }
+  docsLoading = true;
+  docsError = null;
+  try {
+    const res = await fetch(`${API_BASE}${API_OPEN}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filePath, readOnly: true }),
+    });
+    if (!res.ok) {
+      let msg = "Failed to open documentation.";
+      try {
+        const data = (await res.json()) as { message?: string };
+        if (data.message) msg = data.message;
+      } catch {
+        // ignore JSON parse failure
+      }
+      if (res.status === 404) msg = "Documentation file not found.";
+      docsError = msg;
+      return;
+    }
+  } catch (err) {
+    console.warn("[Tandem] Failed to open documentation:", err);
+    docsError = "Server unavailable.";
+  } finally {
+    docsLoading = false;
+  }
+}
+
+const aboutRows = $derived.by(() => {
+  const info = appInfo.info;
+  if (!info) return [];
+
+  const rows: Array<{ label: string; value: string }> = [
+    { label: "Version", value: `Tandem v${info.version}` },
+    {
+      label: "Tools",
+      value:
+        info.toolCount === null ? "Tool count unavailable" : `${info.toolCount} tools available`,
+    },
+    { label: "MCP SDK", value: `MCP SDK ${info.mcpSdkVersion}` },
+    { label: "Transport", value: info.transport?.toUpperCase() ?? "—" },
+  ];
+
+  if (info.storagePath) rows.push({ label: "Storage", value: info.storagePath });
+  if (info.tokenRotatedAt !== undefined) {
+    rows.push({
+      label: "Token",
+      value:
+        info.tokenRotatedAt === null
+          ? "Token not created"
+          : `Token rotated ${new Date(info.tokenRotatedAt).toLocaleString()}`,
+    });
+  }
+  if (info.changelogPath) rows.push({ label: "Changelog", value: info.changelogPath });
+
+  return rows;
+});
+
+const sectionLabelStyle =
+  "font-size: 11px; font-weight: 600; color: var(--tandem-fg); margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px;";
+</script>
+
+<div>
+  <button
+    type="button"
+    data-testid="settings-modal-view-documentation-btn"
+    onclick={() => void handleViewDocumentation()}
+    disabled={docsLoading || appInfo.loading}
+    style="width: 100%; padding: var(--tandem-space-2); font-size: 13px; font-weight: 500; border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); cursor: {docsLoading || appInfo.loading ? 'not-allowed' : 'pointer'}; background: var(--tandem-surface-muted); color: var(--tandem-fg); opacity: {docsLoading || appInfo.loading ? 0.6 : 1};"
+  >
+    {docsLoading ? "Opening…" : "View Documentation"}
+  </button>
+  {#if docsError}
+    <div style="margin-top: 6px; font-size: 11px; color: var(--tandem-error-fg);">
+      {docsError}
+    </div>
+  {/if}
+</div>
+
+<div
+  data-testid="settings-modal-app-info-footer"
+  style="border-top: 1px solid var(--tandem-border); padding-top: 10px;"
+>
+  <div style={sectionLabelStyle}>About</div>
+  {#if appInfo.loading}
+    <div style="font-size: 11px; color: var(--tandem-fg-subtle);">Loading...</div>
+  {:else if appInfo.info}
+    <dl
+      style="display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 5px 12px; margin: 0; font-size: 11px;"
+    >
+      {#each aboutRows as row (row.label)}
+        <dt style="color: var(--tandem-fg-subtle);">{row.label}</dt>
+        <dd
+          style="margin: 0; color: var(--tandem-fg-muted); overflow-wrap: anywhere;"
+        >
+          {row.value}
+        </dd>
+      {/each}
+    </dl>
+  {:else}
+    <div style="font-size: 11px; color: var(--tandem-fg-subtle);">
+      App info unavailable.
+    </div>
+  {/if}
+</div>

--- a/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
+++ b/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+import { SELECTION_DWELL_MAX_MS, SELECTION_DWELL_MIN_MS } from "../../../shared/constants";
+import { isTauriRuntime } from "../../cowork/cowork-helpers";
+import type { SettingsTabContext } from "../SettingsModal.svelte";
+
+let { settings, onUpdate }: SettingsTabContext = $props();
+
+const sectionLabelStyle =
+  "font-size: 11px; font-weight: 600; color: var(--tandem-fg); margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px;";
+</script>
+
+<div>
+  <div style={sectionLabelStyle}>
+    Selection Sensitivity:
+    <span style="font-weight: 400; text-transform: none;">
+      {(settings.selectionDwellMs / 1000).toFixed(1)}s
+    </span>
+  </div>
+  <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-bottom: 6px;">
+    How long you must hold a selection before Claude notices it
+  </div>
+  <input
+    data-testid="settings-modal-dwell-time-slider"
+    type="range"
+    min={SELECTION_DWELL_MIN_MS}
+    max={SELECTION_DWELL_MAX_MS}
+    step={100}
+    value={settings.selectionDwellMs}
+    oninput={(e) =>
+      onUpdate({ selectionDwellMs: Number((e.target as HTMLInputElement).value) })}
+    style="width: 100%; accent-color: var(--tandem-accent);"
+    aria-label="Selection dwell time"
+  />
+  <div
+    style="display: flex; justify-content: space-between; font-size: 10px; color: var(--tandem-fg-subtle);"
+  >
+    <span>{(SELECTION_DWELL_MIN_MS / 1000).toFixed(1)}s</span>
+    <span>{(SELECTION_DWELL_MAX_MS / 1000).toFixed(1)}s</span>
+  </div>
+</div>
+
+<label
+  data-testid="settings-modal-selection-toolbar-toggle"
+  style="display: flex; align-items: center; gap: var(--tandem-space-2); cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+>
+  <input
+    type="checkbox"
+    checked={settings.selectionToolbar}
+    onchange={(e) =>
+      onUpdate({ selectionToolbar: (e.target as HTMLInputElement).checked })}
+    style="accent-color: var(--tandem-accent);"
+  />
+  <span>Show floating selection toolbar</span>
+</label>
+
+<label
+  data-testid="settings-modal-margin-view-toggle"
+  style="display: flex; align-items: center; gap: var(--tandem-space-2); cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+>
+  <input
+    type="checkbox"
+    checked={settings.marginView}
+    onchange={(e) => onUpdate({ marginView: (e.target as HTMLInputElement).checked })}
+    style="accent-color: var(--tandem-accent);"
+  />
+  <span>Margin annotation view (Word-style)</span>
+</label>
+
+{#if isTauriRuntime()}
+  {#await import("../CoworkSettings.svelte")}
+    <div
+      data-testid="settings-modal-cowork-suspense-fallback"
+      style="font-size: 12px; color: var(--tandem-fg-subtle);"
+    >
+      Loading Cowork integration...
+    </div>
+  {:then mod}
+    {@const CoworkSettingsComp = mod.default}
+    <CoworkSettingsComp />
+  {/await}
+{/if}

--- a/src/client/components/settings-tabs/SettingsCollaborationTab.svelte
+++ b/src/client/components/settings-tabs/SettingsCollaborationTab.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+import { USER_NAME_MAX_LEN } from "../../../shared/constants";
+import { createUserName } from "../../hooks/useUserName.svelte";
+import type { SettingsTabContext } from "../SettingsModal.svelte";
+
+// Tab body components for SettingsModal accept the full SettingsTabContext
+// even when they don't use every field — the modal passes the same shape
+// to every tab so Wave 2 additions are uniform.
+let { settings, onUpdate }: SettingsTabContext = $props();
+
+const userNameState = createUserName();
+let nameInput = $state(userNameState.userName);
+let inputEl: HTMLInputElement | undefined = $state();
+
+// Idle-sync: keep nameInput aligned with the underlying store when the user
+// isn't actively editing. Same pattern as SettingsPopover.
+$effect(() => {
+  const currentUserName = userNameState.userName;
+  if (nameInput !== currentUserName && document.activeElement !== inputEl) {
+    nameInput = currentUserName;
+  }
+});
+
+const sectionLabelStyle =
+  "font-size: 11px; font-weight: 600; color: var(--tandem-fg); margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px;";
+</script>
+
+<div>
+  <label for="settings-modal-display-name" style={sectionLabelStyle}>Display Name</label>
+  <input
+    bind:this={inputEl}
+    id="settings-modal-display-name"
+    data-testid="settings-modal-display-name"
+    type="text"
+    value={nameInput}
+    oninput={(e) => {
+      nameInput = (e.target as HTMLInputElement).value;
+    }}
+    onblur={() => userNameState.setUserName(nameInput)}
+    onkeydown={(e) => {
+      if (e.key === "Enter") (e.currentTarget as HTMLInputElement).blur();
+      if (e.key === "Escape") {
+        nameInput = userNameState.userName;
+        (e.currentTarget as HTMLInputElement).blur();
+      }
+    }}
+    maxlength={USER_NAME_MAX_LEN}
+    style="width: 100%; padding: 8px 10px; font-size: 13px; color: var(--tandem-fg); background: var(--tandem-surface); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); outline: none;"
+  />
+</div>
+
+<div>
+  <div id="settings-modal-default-mode-label" style={sectionLabelStyle}>Default Mode</div>
+  <div
+    role="radiogroup"
+    aria-labelledby="settings-modal-default-mode-label"
+    style="display: flex; gap: var(--tandem-space-2);"
+  >
+    <button
+      type="button"
+      data-testid="settings-modal-default-mode-tandem-btn"
+      role="radio"
+      aria-checked={settings.defaultMode === "tandem"}
+      onclick={() => onUpdate({ defaultMode: "tandem" })}
+      style="flex: 1; padding: var(--tandem-space-2); min-height: 30px; border: 2px solid {settings.defaultMode === 'tandem' ? 'var(--tandem-accent)' : 'var(--tandem-border)'}; border-radius: var(--tandem-r-3); background: {settings.defaultMode === 'tandem' ? 'var(--tandem-accent-bg)' : 'var(--tandem-surface)'}; color: {settings.defaultMode === 'tandem' ? 'var(--tandem-accent-fg-strong)' : 'var(--tandem-fg-muted)'}; font-size: 12px; font-weight: {settings.defaultMode === 'tandem' ? 600 : 400}; cursor: pointer;"
+    >
+      Tandem
+    </button>
+    <button
+      type="button"
+      data-testid="settings-modal-default-mode-solo-btn"
+      role="radio"
+      aria-checked={settings.defaultMode === "solo"}
+      onclick={() => onUpdate({ defaultMode: "solo" })}
+      style="flex: 1; padding: var(--tandem-space-2); min-height: 30px; border: 2px solid {settings.defaultMode === 'solo' ? 'var(--tandem-accent)' : 'var(--tandem-border)'}; border-radius: var(--tandem-r-3); background: {settings.defaultMode === 'solo' ? 'var(--tandem-accent-bg)' : 'var(--tandem-surface)'}; color: {settings.defaultMode === 'solo' ? 'var(--tandem-accent-fg-strong)' : 'var(--tandem-fg-muted)'}; font-size: 12px; font-weight: {settings.defaultMode === 'solo' ? 600 : 400}; cursor: pointer;"
+    >
+      Solo
+    </button>
+  </div>
+  <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-top: var(--tandem-space-1);">
+    Sets the preferred starting mode for new sessions.
+  </div>
+</div>
+
+<label
+  data-testid="settings-modal-solo-rail-hidden-toggle"
+  style="display: flex; align-items: center; gap: var(--tandem-space-2); cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+>
+  <input
+    type="checkbox"
+    checked={settings.soloRailHidden}
+    onchange={(e) => onUpdate({ soloRailHidden: (e.target as HTMLInputElement).checked })}
+    style="accent-color: var(--tandem-accent);"
+  />
+  <span>Hide side panel in Solo mode</span>
+</label>
+<div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-top: var(--tandem-space-1);">
+  When enabled, the annotation panel hides automatically when you enter Solo mode and
+  restores when you return to Tandem.
+</div>

--- a/src/client/components/settings-tabs/SettingsShortcutsTab.svelte
+++ b/src/client/components/settings-tabs/SettingsShortcutsTab.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+import { ACTION_GROUPS, getActionsMap } from "../../actions/registry.svelte.js";
+import type { SettingsTabContext } from "../SettingsModal.svelte";
+
+// Tab body components take the full context for uniformity even when they
+// don't reference settings/onUpdate. Underscore the unused destructure.
+let { settings: _settings, onUpdate: _onUpdate }: SettingsTabContext = $props();
+
+// Static shortcuts not yet in the action registry (modifier-key / nav).
+const STATIC_SHORTCUT_ROWS = [
+  { keys: "Ctrl+B", description: "Bold" },
+  { keys: "Ctrl+I", description: "Italic" },
+  { keys: "Ctrl+Z", description: "Undo" },
+  { keys: "Ctrl+Y", description: "Redo" },
+  { keys: "Ctrl+F", description: "Find / Replace" },
+  { keys: "?", description: "Show keyboard shortcuts" },
+  { keys: "Ctrl+Tab", description: "Next document tab" },
+  { keys: "Ctrl+Shift+Tab", description: "Previous document tab" },
+];
+
+const registryShortcutSections = $derived.by(() => {
+  const actionsMap = getActionsMap();
+  const byGroup = new Map<string, Array<{ keys: string; description: string }>>();
+  for (const action of actionsMap.values()) {
+    if (!action.shortcut) continue;
+    const rows = byGroup.get(action.group) ?? [];
+    rows.push({ keys: action.shortcut, description: action.label });
+    byGroup.set(action.group, rows);
+  }
+  return ACTION_GROUPS.map((g) => ({
+    title: g.charAt(0).toUpperCase() + g.slice(1),
+    rows: byGroup.get(g) ?? [],
+  })).filter((s) => s.rows.length > 0);
+});
+
+const sectionLabelStyle =
+  "font-size: 11px; font-weight: 600; color: var(--tandem-fg); margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px;";
+</script>
+
+<div
+  data-testid="settings-modal-shortcuts-list"
+  style="display: flex; flex-direction: column; gap: var(--tandem-space-4);"
+>
+  {#each registryShortcutSections as section (section.title)}
+    <section>
+      <div style={sectionLabelStyle}>{section.title}</div>
+      <div
+        style="display: grid; grid-template-columns: minmax(120px, max-content) 1fr; gap: 6px 14px; align-items: center;"
+      >
+        {#each section.rows as row (row.keys + row.description)}
+          <kbd
+            style="justify-self: start; padding: 1px 6px; font-family: var(--tandem-font-mono); font-size: 11px; color: var(--tandem-fg); background: var(--tandem-surface-muted); border: 1px solid var(--tandem-border-strong); border-bottom-width: 2px; border-radius: var(--tandem-r-2);"
+          >
+            {row.keys}
+          </kbd>
+          <span style="font-size: 13px; color: var(--tandem-fg-muted);">
+            {row.description}
+          </span>
+        {/each}
+      </div>
+    </section>
+  {/each}
+  <section>
+    <div style={sectionLabelStyle}>Other</div>
+    <div
+      style="display: grid; grid-template-columns: minmax(120px, max-content) 1fr; gap: 6px 14px; align-items: center;"
+    >
+      {#each STATIC_SHORTCUT_ROWS as row (row.keys + row.description)}
+        <kbd
+          style="justify-self: start; padding: 1px 6px; font-family: var(--tandem-font-mono); font-size: 11px; color: var(--tandem-fg); background: var(--tandem-surface-muted); border: 1px solid var(--tandem-border-strong); border-bottom-width: 2px; border-radius: var(--tandem-r-2);"
+        >
+          {row.keys}
+        </kbd>
+        <span style="font-size: 13px; color: var(--tandem-fg-muted);">
+          {row.description}
+        </span>
+      {/each}
+    </div>
+  </section>
+</div>

--- a/src/client/hooks/useSettingsShortcut.ts
+++ b/src/client/hooks/useSettingsShortcut.ts
@@ -1,8 +1,27 @@
 // `e.code` (not `e.key`) so non-QWERTY layouts still hit; bail during IME.
+//
+// Reject Shift because Wave 1 routes `Ctrl+Shift+,` to the new SettingsModal
+// (see `isSettingsModalShortcut` below). Without the `!shiftKey` guard,
+// Ctrl+Shift+, would match this predicate first and open the popover.
 export function isSettingsShortcut(
-  e: Pick<KeyboardEvent, "code" | "ctrlKey" | "metaKey" | "isComposing">,
+  e: Pick<KeyboardEvent, "code" | "ctrlKey" | "metaKey" | "shiftKey" | "isComposing">,
 ): boolean {
   if (e.isComposing) return false;
   if (e.code !== "Comma") return false;
+  if (e.shiftKey) return false;
+  return e.ctrlKey || e.metaKey;
+}
+
+/**
+ * Wave 1 shortcut for opening the new `SettingsModal` (sibling to the popover).
+ * Wave 2 retires the popover; this predicate becomes the only settings
+ * shortcut at that point.
+ */
+export function isSettingsModalShortcut(
+  e: Pick<KeyboardEvent, "code" | "ctrlKey" | "metaKey" | "shiftKey" | "isComposing">,
+): boolean {
+  if (e.isComposing) return false;
+  if (e.code !== "Comma") return false;
+  if (!e.shiftKey) return false;
   return e.ctrlKey || e.metaKey;
 }

--- a/src/client/hooks/useUpdateAvailable.svelte.ts
+++ b/src/client/hooks/useUpdateAvailable.svelte.ts
@@ -1,0 +1,142 @@
+import { isTauriRuntime } from "@client/cowork/cowork-helpers.js";
+
+/**
+ * Titlebar settings-icon update-available dot badge (issue #660, D6 sub-piece).
+ *
+ * Pairs with the in-app updater banner from Unit 8 (PR #669). Both surfaces
+ * listen to the same Tauri updater event and share the same
+ * `tandem:updater-dismissed-v{version}` localStorage key — dismissing the
+ * banner or opening settings acknowledges the dot, and vice-versa. The two
+ * listeners are intentionally separate during Wave 2 so the units can land
+ * independently; a follow-up consolidates them after #669 merges.
+ *
+ * Security: Event source is `@tauri-apps/plugin-updater` only — never a
+ * postMessage, MCP channel event, or Hocuspocus signal. Render is gated on
+ * `isTauriRuntime()` in TitleBar (defence in depth — the listener never
+ * attaches in non-Tauri builds either).
+ */
+export const UPDATE_AVAILABLE_EVENT = "tandem://update-available";
+
+const DISMISS_KEY_PREFIX = "tandem:updater-dismissed-v";
+
+export interface UpdateAvailableState {
+  /** Latest version reported by the updater, or `null` if none / acknowledged. */
+  readonly availableVersion: string | null;
+  /** True iff the dot should render right now. */
+  readonly showDot: boolean;
+  /**
+   * Acknowledge the current update — called when the user opens settings (any
+   * tab) or dismisses the paired banner. Writes the same localStorage key the
+   * banner uses so both surfaces stay in sync.
+   *
+   * Do NOT destructure this return value — the `showDot` / `availableVersion`
+   * getters lose reactivity when destructured (see
+   * feedback_svelte_getter_destructuring).
+   */
+  acknowledge: () => void;
+}
+
+function dismissKey(version: string): string {
+  return `${DISMISS_KEY_PREFIX}${version}`;
+}
+
+function readDismissed(version: string): boolean {
+  try {
+    return window.localStorage.getItem(dismissKey(version)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeDismissed(version: string): void {
+  try {
+    window.localStorage.setItem(dismissKey(version), "1");
+  } catch {
+    /* localStorage may be disabled (incognito, strict modes); silently skip */
+  }
+}
+
+/**
+ * Subscribes to the Tauri updater event channel and exposes the dot-badge
+ * state. Non-Tauri environments return a static no-op (listener never
+ * attaches; `showDot` is always `false`).
+ *
+ * Svelte 5 guardrails (feedback_svelte_prop_in_effect_cleanup,
+ * feedback_svelte_onmount_async_test_flush):
+ *   - The Tauri `unlisten` fn is captured into a ref object that the cleanup
+ *     closes over — cleanup never re-reads `$state` or props.
+ *   - The async dynamic-import path uses a `cancelled` flag flipped on
+ *     cleanup so a listener attached after unmount is immediately torn down.
+ */
+export function createUpdateAvailable(): UpdateAvailableState {
+  let version = $state<string | null>(null);
+  // Bumped every time `acknowledge()` runs so `showDot` re-evaluates without
+  // having to mutate `version` (the banner cares about `version` separately).
+  let acknowledgedFor = $state<string | null>(null);
+
+  if (isTauriRuntime()) {
+    $effect(() => {
+      // `unlistenRef` holds the unsubscribe fn captured at attach time. The
+      // cleanup closes over this const — it never re-reads any $state.
+      const unlistenRef: { fn: (() => void) | null } = { fn: null };
+      let cancelled = false;
+
+      (async () => {
+        try {
+          const { listen } = await import("@tauri-apps/api/event");
+          if (cancelled) return;
+          const off = await listen<{ version: string }>(UPDATE_AVAILABLE_EVENT, (event) => {
+            const next = event.payload?.version ?? null;
+            if (!next) return;
+            version = next;
+            // A new version supersedes any prior in-session acknowledgement.
+            // Persisted dismissals (localStorage) are still keyed per-version
+            // and are checked in the `showDot` getter.
+            if (acknowledgedFor !== next) acknowledgedFor = null;
+          });
+          if (cancelled) {
+            off();
+            return;
+          }
+          unlistenRef.fn = off;
+        } catch (err) {
+          console.warn("[useUpdateAvailable] listen() failed:", err);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+        const off = unlistenRef.fn;
+        unlistenRef.fn = null;
+        if (off) {
+          try {
+            off();
+          } catch (err) {
+            console.warn("[useUpdateAvailable] unlisten threw:", err);
+          }
+        }
+      };
+    });
+  }
+
+  return {
+    get availableVersion() {
+      return version;
+    },
+    get showDot() {
+      const v = version;
+      if (!v) return false;
+      if (acknowledgedFor === v) return false;
+      if (readDismissed(v)) return false;
+      return true;
+    },
+    acknowledge() {
+      const v = version;
+      if (!v) return;
+      // Writes the SAME key shape the banner uses so opening settings also
+      // dismisses the banner (and dismissing the banner also clears the dot).
+      writeDismissed(v);
+      acknowledgedFor = v;
+    },
+  };
+}

--- a/src/client/hooks/useUpdateAvailable.svelte.ts
+++ b/src/client/hooks/useUpdateAvailable.svelte.ts
@@ -1,23 +1,29 @@
-import { isTauriRuntime } from "@client/cowork/cowork-helpers.js";
+import {
+  acknowledgeVersion,
+  getAcknowledgedFor,
+  getAvailableVersion,
+  readDismissed,
+  subscribeToUpdaterChannel,
+  UPDATE_AVAILABLE_EVENT,
+} from "@client/hooks/useUpdaterChannel.svelte.js";
 
 /**
  * Titlebar settings-icon update-available dot badge (issue #660, D6 sub-piece).
  *
- * Pairs with the in-app updater banner from Unit 8 (PR #669). Both surfaces
- * listen to the same Tauri updater event and share the same
- * `tandem:updater-dismissed-v{version}` localStorage key — dismissing the
- * banner or opening settings acknowledges the dot, and vice-versa. The two
- * listeners are intentionally separate during Wave 2 so the units can land
- * independently; a follow-up consolidates them after #669 merges.
+ * Pairs with the in-app updater banner (`createUpdaterBanner`, Unit 8). Both
+ * surfaces share the same module-level listener + acknowledgement state via
+ * `useUpdaterChannel.svelte.ts`, so dismissing the banner clears the dot live
+ * and opening settings clears the banner live. The shared primitive also keeps
+ * the Tauri listener attached exactly once regardless of how many surfaces
+ * subscribe.
  *
  * Security: Event source is `@tauri-apps/plugin-updater` only — never a
  * postMessage, MCP channel event, or Hocuspocus signal. Render is gated on
- * `isTauriRuntime()` in TitleBar (defence in depth — the listener never
- * attaches in non-Tauri builds either).
+ * `isTauriRuntime()` in TitleBar (defence in depth — the channel never fires
+ * outside Tauri either).
  */
-export const UPDATE_AVAILABLE_EVENT = "tandem://update-available";
-
-const DISMISS_KEY_PREFIX = "tandem:updater-dismissed-v";
+// Re-exported for back-compat with any direct imports of the event name.
+export { UPDATE_AVAILABLE_EVENT };
 
 export interface UpdateAvailableState {
   /** Latest version reported by the updater, or `null` if none / acknowledged. */
@@ -36,107 +42,30 @@ export interface UpdateAvailableState {
   acknowledge: () => void;
 }
 
-function dismissKey(version: string): string {
-  return `${DISMISS_KEY_PREFIX}${version}`;
-}
-
-function readDismissed(version: string): boolean {
-  try {
-    return window.localStorage.getItem(dismissKey(version)) === "1";
-  } catch {
-    return false;
-  }
-}
-
-function writeDismissed(version: string): void {
-  try {
-    window.localStorage.setItem(dismissKey(version), "1");
-  } catch {
-    /* localStorage may be disabled (incognito, strict modes); silently skip */
-  }
-}
-
 /**
- * Subscribes to the Tauri updater event channel and exposes the dot-badge
- * state. Non-Tauri environments return a static no-op (listener never
- * attaches; `showDot` is always `false`).
- *
- * Svelte 5 guardrails (feedback_svelte_prop_in_effect_cleanup,
- * feedback_svelte_onmount_async_test_flush):
- *   - The Tauri `unlisten` fn is captured into a ref object that the cleanup
- *     closes over — cleanup never re-reads `$state` or props.
- *   - The async dynamic-import path uses a `cancelled` flag flipped on
- *     cleanup so a listener attached after unmount is immediately torn down.
+ * Subscribes to the shared updater channel and exposes the dot-badge state.
+ * Non-Tauri environments still subscribe (the channel is a no-op there);
+ * `showDot` simply stays `false` because no event fires.
  */
 export function createUpdateAvailable(): UpdateAvailableState {
-  let version = $state<string | null>(null);
-  // Bumped every time `acknowledge()` runs so `showDot` re-evaluates without
-  // having to mutate `version` (the banner cares about `version` separately).
-  let acknowledgedFor = $state<string | null>(null);
-
-  if (isTauriRuntime()) {
-    $effect(() => {
-      // `unlistenRef` holds the unsubscribe fn captured at attach time. The
-      // cleanup closes over this const — it never re-reads any $state.
-      const unlistenRef: { fn: (() => void) | null } = { fn: null };
-      let cancelled = false;
-
-      (async () => {
-        try {
-          const { listen } = await import("@tauri-apps/api/event");
-          if (cancelled) return;
-          const off = await listen<{ version: string }>(UPDATE_AVAILABLE_EVENT, (event) => {
-            const next = event.payload?.version ?? null;
-            if (!next) return;
-            version = next;
-            // A new version supersedes any prior in-session acknowledgement.
-            // Persisted dismissals (localStorage) are still keyed per-version
-            // and are checked in the `showDot` getter.
-            if (acknowledgedFor !== next) acknowledgedFor = null;
-          });
-          if (cancelled) {
-            off();
-            return;
-          }
-          unlistenRef.fn = off;
-        } catch (err) {
-          console.warn("[useUpdateAvailable] listen() failed:", err);
-        }
-      })();
-
-      return () => {
-        cancelled = true;
-        const off = unlistenRef.fn;
-        unlistenRef.fn = null;
-        if (off) {
-          try {
-            off();
-          } catch (err) {
-            console.warn("[useUpdateAvailable] unlisten threw:", err);
-          }
-        }
-      };
-    });
-  }
+  $effect(() => {
+    const unsubscribe = subscribeToUpdaterChannel();
+    return unsubscribe;
+  });
 
   return {
     get availableVersion() {
-      return version;
+      return getAvailableVersion();
     },
     get showDot() {
-      const v = version;
+      const v = getAvailableVersion();
       if (!v) return false;
-      if (acknowledgedFor === v) return false;
+      if (getAcknowledgedFor() === v) return false;
       if (readDismissed(v)) return false;
       return true;
     },
     acknowledge() {
-      const v = version;
-      if (!v) return;
-      // Writes the SAME key shape the banner uses so opening settings also
-      // dismisses the banner (and dismissing the banner also clears the dot).
-      writeDismissed(v);
-      acknowledgedFor = v;
+      acknowledgeVersion(getAvailableVersion());
     },
   };
 }

--- a/src/client/hooks/useUpdaterBanner.svelte.ts
+++ b/src/client/hooks/useUpdaterBanner.svelte.ts
@@ -1,0 +1,140 @@
+import { isTauriRuntime } from "@client/cowork/cowork-helpers.js";
+
+/**
+ * Event emitted from `src-tauri/src/lib.rs` when the periodic auto-update check
+ * detects an available release. Payload is `{ version: string }`. The manual
+ * "Check for Updates" tray menu still surfaces a native dialog — the banner is
+ * only driven by the background event channel (D6 locked decision).
+ */
+export const UPDATE_AVAILABLE_EVENT = "tandem://update-available";
+
+const DISMISS_KEY_PREFIX = "tandem:updater-dismissed-v";
+
+export interface UpdaterBannerState {
+  /** Latest version reported by the updater, or `null` if none / dismissed. */
+  readonly availableVersion: string | null;
+  /** Whether install is currently in flight (CTA disabled). */
+  readonly installing: boolean;
+  /** True iff the banner should render right now. */
+  readonly showBanner: boolean;
+  dismiss: () => void;
+  install: () => Promise<void>;
+}
+
+function dismissKey(version: string): string {
+  return `${DISMISS_KEY_PREFIX}${version}`;
+}
+
+function readDismissed(version: string): boolean {
+  try {
+    return window.localStorage.getItem(dismissKey(version)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeDismissed(version: string): void {
+  try {
+    window.localStorage.setItem(dismissKey(version), "1");
+  } catch {
+    /* localStorage may be disabled (incognito, strict modes); silently skip */
+  }
+}
+
+/**
+ * Subscribes to the Tauri updater event channel and exposes a banner state.
+ *
+ * Svelte 5 guardrail (feedback_svelte_prop_in_effect_cleanup): the `unlisten`
+ * fn is captured into a `const` that the cleanup closes over; we never
+ * re-read `$state` from inside the cleanup.
+ *
+ * Non-Tauri environments early-return a static no-op state.
+ */
+export function createUpdaterBanner(): UpdaterBannerState {
+  let version = $state<string | null>(null);
+  let installing = $state(false);
+  // Re-readable in render via getter; updated when dismiss() or new version fires.
+  let dismissedFor = $state<string | null>(null);
+
+  if (isTauriRuntime()) {
+    $effect(() => {
+      // `unlistenRef` holds the unsubscribe fn captured at attach time. The
+      // cleanup closes over this const — it never re-reads any $state.
+      const unlistenRef: { fn: (() => void) | null } = { fn: null };
+      let cancelled = false;
+
+      (async () => {
+        try {
+          const { listen } = await import("@tauri-apps/api/event");
+          if (cancelled) return;
+          const off = await listen<{ version: string }>(UPDATE_AVAILABLE_EVENT, (event) => {
+            const next = event.payload?.version ?? null;
+            if (!next) return;
+            version = next;
+            // A new version supersedes any previous dismissal record.
+            if (dismissedFor !== next) dismissedFor = null;
+          });
+          if (cancelled) {
+            off();
+            return;
+          }
+          unlistenRef.fn = off;
+        } catch (err) {
+          console.warn("[useUpdaterBanner] listen() failed:", err);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+        const off = unlistenRef.fn;
+        unlistenRef.fn = null;
+        if (off) {
+          try {
+            off();
+          } catch (err) {
+            console.warn("[useUpdaterBanner] unlisten threw:", err);
+          }
+        }
+      };
+    });
+  }
+
+  async function install(): Promise<void> {
+    const v = version;
+    if (!v || installing) return;
+    installing = true;
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      // Fire-and-forget from the JS side: on success Rust calls app.restart(),
+      // which tears down the WebView; awaiting here is fine because the
+      // promise simply never resolves in that case.
+      await invoke("install_update");
+    } catch (err) {
+      console.warn("[useUpdaterBanner] install_update failed:", err);
+      installing = false;
+    }
+  }
+
+  return {
+    get availableVersion() {
+      return version;
+    },
+    get installing() {
+      return installing;
+    },
+    get showBanner() {
+      const v = version;
+      if (!v) return false;
+      if (dismissedFor === v) return false;
+      if (readDismissed(v)) return false;
+      return true;
+    },
+    dismiss() {
+      const v = version;
+      if (!v) return;
+      writeDismissed(v);
+      dismissedFor = v;
+    },
+    install,
+  };
+}

--- a/src/client/hooks/useUpdaterBanner.svelte.ts
+++ b/src/client/hooks/useUpdaterBanner.svelte.ts
@@ -1,14 +1,14 @@
-import { isTauriRuntime } from "@client/cowork/cowork-helpers.js";
+import {
+  acknowledgeVersion,
+  getAcknowledgedFor,
+  getAvailableVersion,
+  readDismissed,
+  subscribeToUpdaterChannel,
+  UPDATE_AVAILABLE_EVENT,
+} from "@client/hooks/useUpdaterChannel.svelte.js";
 
-/**
- * Event emitted from `src-tauri/src/lib.rs` when the periodic auto-update check
- * detects an available release. Payload is `{ version: string }`. The manual
- * "Check for Updates" tray menu still surfaces a native dialog — the banner is
- * only driven by the background event channel (D6 locked decision).
- */
-export const UPDATE_AVAILABLE_EVENT = "tandem://update-available";
-
-const DISMISS_KEY_PREFIX = "tandem:updater-dismissed-v";
+// Re-exported for back-compat with any direct imports of the event name.
+export { UPDATE_AVAILABLE_EVENT };
 
 export interface UpdaterBannerState {
   /** Latest version reported by the updater, or `null` if none / dismissed. */
@@ -21,86 +21,26 @@ export interface UpdaterBannerState {
   install: () => Promise<void>;
 }
 
-function dismissKey(version: string): string {
-  return `${DISMISS_KEY_PREFIX}${version}`;
-}
-
-function readDismissed(version: string): boolean {
-  try {
-    return window.localStorage.getItem(dismissKey(version)) === "1";
-  } catch {
-    return false;
-  }
-}
-
-function writeDismissed(version: string): void {
-  try {
-    window.localStorage.setItem(dismissKey(version), "1");
-  } catch {
-    /* localStorage may be disabled (incognito, strict modes); silently skip */
-  }
-}
-
 /**
- * Subscribes to the Tauri updater event channel and exposes a banner state.
+ * Subscribes to the shared updater channel (see useUpdaterChannel.svelte.ts)
+ * and exposes a banner state. Acknowledgements are cross-surface synced with
+ * `createUpdateAvailable` (the titlebar dot): dismissing the banner also
+ * clears the dot live, and opening settings clears the banner live.
  *
- * Svelte 5 guardrail (feedback_svelte_prop_in_effect_cleanup): the `unlisten`
- * fn is captured into a `const` that the cleanup closes over; we never
- * re-read `$state` from inside the cleanup.
- *
- * Non-Tauri environments early-return a static no-op state.
+ * Non-Tauri environments still subscribe (the channel is a no-op there) so
+ * the consumer surface is identical across runtimes; `showBanner` simply
+ * stays `false` because no event ever fires.
  */
 export function createUpdaterBanner(): UpdaterBannerState {
-  let version = $state<string | null>(null);
   let installing = $state(false);
-  // Re-readable in render via getter; updated when dismiss() or new version fires.
-  let dismissedFor = $state<string | null>(null);
 
-  if (isTauriRuntime()) {
-    $effect(() => {
-      // `unlistenRef` holds the unsubscribe fn captured at attach time. The
-      // cleanup closes over this const — it never re-reads any $state.
-      const unlistenRef: { fn: (() => void) | null } = { fn: null };
-      let cancelled = false;
-
-      (async () => {
-        try {
-          const { listen } = await import("@tauri-apps/api/event");
-          if (cancelled) return;
-          const off = await listen<{ version: string }>(UPDATE_AVAILABLE_EVENT, (event) => {
-            const next = event.payload?.version ?? null;
-            if (!next) return;
-            version = next;
-            // A new version supersedes any previous dismissal record.
-            if (dismissedFor !== next) dismissedFor = null;
-          });
-          if (cancelled) {
-            off();
-            return;
-          }
-          unlistenRef.fn = off;
-        } catch (err) {
-          console.warn("[useUpdaterBanner] listen() failed:", err);
-        }
-      })();
-
-      return () => {
-        cancelled = true;
-        const off = unlistenRef.fn;
-        unlistenRef.fn = null;
-        if (off) {
-          try {
-            off();
-          } catch (err) {
-            console.warn("[useUpdaterBanner] unlisten threw:", err);
-          }
-        }
-      };
-    });
-  }
+  $effect(() => {
+    const unsubscribe = subscribeToUpdaterChannel();
+    return unsubscribe;
+  });
 
   async function install(): Promise<void> {
-    const v = version;
+    const v = getAvailableVersion();
     if (!v || installing) return;
     installing = true;
     try {
@@ -117,23 +57,20 @@ export function createUpdaterBanner(): UpdaterBannerState {
 
   return {
     get availableVersion() {
-      return version;
+      return getAvailableVersion();
     },
     get installing() {
       return installing;
     },
     get showBanner() {
-      const v = version;
+      const v = getAvailableVersion();
       if (!v) return false;
-      if (dismissedFor === v) return false;
+      if (getAcknowledgedFor() === v) return false;
       if (readDismissed(v)) return false;
       return true;
     },
     dismiss() {
-      const v = version;
-      if (!v) return;
-      writeDismissed(v);
-      dismissedFor = v;
+      acknowledgeVersion(getAvailableVersion());
     },
     install,
   };

--- a/src/client/hooks/useUpdaterChannel.svelte.ts
+++ b/src/client/hooks/useUpdaterChannel.svelte.ts
@@ -1,0 +1,174 @@
+import { isTauriRuntime } from "@client/cowork/cowork-helpers.js";
+
+/**
+ * Shared primitive consumed by `createUpdaterBanner` (Unit 8, PR #669) and
+ * `createUpdateAvailable` (Unit 10, PR #675).
+ *
+ * Both hooks need to:
+ *   1. Subscribe to the Tauri `tandem://update-available` event.
+ *   2. Track the latest reported version reactively.
+ *   3. Read/write the same `tandem:updater-dismissed-v{version}` localStorage
+ *      key so that "dismiss the banner" and "open settings to ack the dot" are
+ *      cross-surface synced.
+ *
+ * Doing this twice meant two parallel `$effect`-based listeners, two copies of
+ * the `unlistenRef`/`cancelled` boilerplate, and per-hook acknowledgement state
+ * that could not see the other surface's mutation — dismissing the banner would
+ * NOT clear the dot until the next mount.
+ *
+ * This module hoists the listener + ack state to a module singleton so both
+ * consumers observe the same reactive `version` and the same `acknowledgedFor`
+ * signal. A `subscribe()` ref-count keeps the underlying Tauri listener alive
+ * exactly as long as at least one consumer is mounted.
+ *
+ * Svelte 5 guardrails:
+ *   - `subscribe()` returns an unsubscribe fn captured into a `const` so
+ *     consumers can call it from `$effect` cleanup without reading any `$state`
+ *     (feedback_svelte_prop_in_effect_cleanup).
+ *   - The async dynamic-import path uses a `cancelled` flag flipped on full
+ *     teardown so a listener attached after the last unsubscribe is torn down
+ *     immediately.
+ */
+export const UPDATE_AVAILABLE_EVENT = "tandem://update-available";
+
+const DISMISS_KEY_PREFIX = "tandem:updater-dismissed-v";
+
+function dismissKey(version: string): string {
+  return `${DISMISS_KEY_PREFIX}${version}`;
+}
+
+/** Reads the persisted dismissal flag for `version`. localStorage may be
+ * disabled (incognito, strict modes); failure returns `false` rather than
+ * throwing. */
+export function readDismissed(version: string): boolean {
+  try {
+    return window.localStorage.getItem(dismissKey(version)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Writes the persisted dismissal flag for `version`. Silently no-ops if
+ * localStorage is unavailable. */
+export function writeDismissed(version: string): void {
+  try {
+    window.localStorage.setItem(dismissKey(version), "1");
+  } catch {
+    /* localStorage may be disabled (incognito, strict modes); silently skip */
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Module-singleton reactive state.
+//
+// `version` is the latest version reported by the updater event channel.
+// `acknowledgedFor` tracks the version that has been ack'd in-memory this
+// session (either via banner-dismiss or settings-open). Both consumer hooks
+// expose getters that close over this state, so a mutation from either
+// surface is observed by the other on the next reactive read.
+// ──────────────────────────────────────────────────────────────────────────────
+let version = $state<string | null>(null);
+let acknowledgedFor = $state<string | null>(null);
+
+let refCount = 0;
+let unlisten: (() => void) | null = null;
+let cancelled = false;
+
+/** Returns the latest version reported by the updater, or `null` if none. */
+export function getAvailableVersion(): string | null {
+  return version;
+}
+
+/** Returns the in-memory ack signal — the version that has been ack'd this
+ * session, or `null`. */
+export function getAcknowledgedFor(): string | null {
+  return acknowledgedFor;
+}
+
+/**
+ * Marks `v` as acknowledged in-memory AND persists the dismissal flag so the
+ * ack survives a reload. Called from the banner's dismiss and from
+ * settings-open. Both consumer hooks observe the in-memory `acknowledgedFor`
+ * reactively so the cross-surface sync is live, not just on next mount.
+ */
+export function acknowledgeVersion(v: string | null): void {
+  if (!v) return;
+  writeDismissed(v);
+  acknowledgedFor = v;
+}
+
+/**
+ * Subscribes to the Tauri updater event channel. Reference-counted: the first
+ * subscribe attaches the listener, the last unsubscribe detaches it.
+ *
+ * Returns an unsubscribe function. Call from `$effect` cleanup; never throws.
+ *
+ * Outside Tauri, no listener is attached but the ref-count is still tracked
+ * so the return type is consistent.
+ */
+export function subscribeToUpdaterChannel(): () => void {
+  refCount += 1;
+  if (refCount === 1 && isTauriRuntime()) {
+    cancelled = false;
+    (async () => {
+      try {
+        const { listen } = await import("@tauri-apps/api/event");
+        if (cancelled) return;
+        const off = await listen<{ version: string }>(UPDATE_AVAILABLE_EVENT, (event) => {
+          const next = event.payload?.version ?? null;
+          if (!next) return;
+          version = next;
+          // A new version supersedes any previous in-memory ack. Persisted
+          // per-version dismissals (localStorage) are still checked by the
+          // consumer-side `showDot`/`showBanner` getters.
+          if (acknowledgedFor !== next) acknowledgedFor = null;
+        });
+        if (cancelled) {
+          off();
+          return;
+        }
+        unlisten = off;
+      } catch (err) {
+        console.warn("[useUpdaterChannel] listen() failed:", err);
+      }
+    })();
+  }
+  let unsubscribed = false;
+  return () => {
+    if (unsubscribed) return;
+    unsubscribed = true;
+    refCount = Math.max(0, refCount - 1);
+    if (refCount === 0) {
+      cancelled = true;
+      const off = unlisten;
+      unlisten = null;
+      if (off) {
+        try {
+          off();
+        } catch (err) {
+          console.warn("[useUpdaterChannel] unlisten threw:", err);
+        }
+      }
+    }
+  };
+}
+
+/**
+ * Test-only reset. Clears the singleton state so tests can simulate a fresh
+ * process. Not exported from the public surface of either consumer hook.
+ */
+export function __resetUpdaterChannelForTests(): void {
+  version = null;
+  acknowledgedFor = null;
+  refCount = 0;
+  cancelled = true;
+  const off = unlisten;
+  unlisten = null;
+  if (off) {
+    try {
+      off();
+    } catch {
+      /* swallow */
+    }
+  }
+}

--- a/src/client/hooks/useUpdaterChannel.svelte.ts
+++ b/src/client/hooks/useUpdaterChannel.svelte.ts
@@ -70,9 +70,23 @@ export function writeDismissed(version: string): void {
 let version = $state<string | null>(null);
 let acknowledgedFor = $state<string | null>(null);
 
-let refCount = 0;
+let refCount: number = 0;
 let unlisten: (() => void) | null = null;
 let cancelled = false;
+// In-flight token defeats a refcount-flap race: subscribe → unsubscribe →
+// subscribe within one tick attaches two listeners concurrently, and without
+// a token discriminator the first one to resolve `listen()` would win and
+// `unlisten` would leak. Each async subscribe captures `++pending`; when
+// `listen()` resolves the branch bails unless its token still equals the
+// current `pending`. `__resetUpdaterChannelForTests` resets this counter to
+// keep the module-singleton clean across tests.
+let pending = 0;
+
+/** Reads `refCount` through a function indirection so TypeScript does not
+ * narrow its value across the outer `=== 1` check in the closure below. */
+function getRefCount(): number {
+  return refCount;
+}
 
 /** Returns the latest version reported by the updater, or `null` if none. */
 export function getAvailableVersion(): string | null {
@@ -110,10 +124,15 @@ export function subscribeToUpdaterChannel(): () => void {
   refCount += 1;
   if (refCount === 1 && isTauriRuntime()) {
     cancelled = false;
+    const myToken = ++pending;
     (async () => {
       try {
         const { listen } = await import("@tauri-apps/api/event");
-        if (cancelled) return;
+        // Pre-listen bail: a later subscribe superseded us, full teardown
+        // cancelled us, or the ref-count dropped to 0 via test reset.
+        // Read through `getRefCount()` to defeat TS narrowing of `refCount`
+        // from the outer `=== 1` check.
+        if (cancelled || myToken !== pending || getRefCount() === 0) return;
         const off = await listen<{ version: string }>(UPDATE_AVAILABLE_EVENT, (event) => {
           const next = event.payload?.version ?? null;
           if (!next) return;
@@ -123,7 +142,10 @@ export function subscribeToUpdaterChannel(): () => void {
           // consumer-side `showDot`/`showBanner` getters.
           if (acknowledgedFor !== next) acknowledgedFor = null;
         });
-        if (cancelled) {
+        // Re-check after listen() resolves: a later subscribe may have
+        // superseded us, or an unsubscribe may have cancelled us. Tear down
+        // immediately to avoid leaking a listener.
+        if (cancelled || myToken !== pending || getRefCount() === 0) {
           off();
           return;
         }
@@ -162,6 +184,10 @@ export function __resetUpdaterChannelForTests(): void {
   acknowledgedFor = null;
   refCount = 0;
   cancelled = true;
+  // Also reset the in-flight token; otherwise an in-progress async
+  // subscribe from a prior test could outlive the reset and bypass the
+  // refCount===0 guard via a stale token comparison.
+  pending = 0;
   const off = unlisten;
   unlisten = null;
   if (off) {
@@ -171,4 +197,12 @@ export function __resetUpdaterChannelForTests(): void {
       /* swallow */
     }
   }
+}
+
+/**
+ * Test-only introspection. Returns whether a persistent listener is
+ * currently attached (i.e. the singleton holds an `unlisten` fn).
+ */
+export function __hasActiveListenerForTests(): boolean {
+  return unlisten !== null;
 }

--- a/src/client/shell/TitleBar.svelte
+++ b/src/client/shell/TitleBar.svelte
@@ -28,6 +28,13 @@ interface Props {
   onOpenHelp?: () => void;
   /** Open Settings popover. */
   onOpenSettings?: () => void;
+  /**
+   * Open the new SettingsModal (Wave 1 sibling component). Wired separately
+   * from `onOpenSettings` so the existing gear keeps invoking the popover
+   * until Wave 2 retires it. Triggered today via the command palette /
+   * `Ctrl+Shift+,` shortcut registered in `actions/builtin.svelte.ts`.
+   */
+  onOpenSettingsModal?: () => void;
   /** Bindable settings button reference (used for keyboard shortcut anchoring). */
   settingsBtn?: HTMLButtonElement | null;
 }
@@ -46,6 +53,7 @@ let {
   onAuthorshipChange,
   onOpenHelp,
   onOpenSettings,
+  onOpenSettingsModal,
   settingsBtn = $bindable(null),
 }: Props = $props();
 
@@ -141,6 +149,23 @@ async function closeWindow() {
 }
 
 const themeLabel = $derived(THEME_LABEL[theme]);
+
+/**
+ * `onOpenSettingsModal` is a Wave 1 stable prop slot, declared so Wave 2 can
+ * retire `SettingsPopover` by replacing the gear's `onOpenSettings` wiring
+ * with this prop without re-touching `TitleBar.svelte`. Today the trigger is
+ * the `settings-modal` action (Ctrl+Shift+,) wired in
+ * `actions/builtin.svelte.ts`, so the prop is intentionally unused inside
+ * this component. Read it inside `$effect` (not a top-level expression) so
+ * svelte-check sees a live reference and stays quiet about both the
+ * "declared but never read" error and the `state_referenced_locally`
+ * warning. Intentionally NOT exposed via `aria-keyshortcuts` on the gear
+ * button — that attribute describes shortcuts that activate the labelled
+ * element, and Ctrl+Shift+, opens a different surface.
+ */
+$effect(() => {
+  void onOpenSettingsModal;
+});
 </script>
 
 <div class="title-bar" data-testid="title-bar">

--- a/src/client/shell/TitleBar.svelte
+++ b/src/client/shell/TitleBar.svelte
@@ -37,6 +37,14 @@ interface Props {
   onOpenSettingsModal?: () => void;
   /** Bindable settings button reference (used for keyboard shortcut anchoring). */
   settingsBtn?: HTMLButtonElement | null;
+  /**
+   * Whether a Tauri updater event has fired and not yet been acknowledged
+   * (issue #660, D6 sub-piece). Renders a small dot on the gear icon. Driven
+   * by `createUpdateAvailable()`; non-Tauri builds never render the dot
+   * regardless of this prop (the hook returns `false` outside Tauri AND the
+   * dot is wrapped in an `{#if isTauriRuntime()}` guard below).
+   */
+  updateAvailable?: boolean;
 }
 
 let {
@@ -55,6 +63,7 @@ let {
   onOpenSettings,
   onOpenSettingsModal,
   settingsBtn = $bindable(null),
+  updateAvailable = false,
 }: Props = $props();
 
 let win = $state<TauriWindow | null>(null);
@@ -286,12 +295,13 @@ $effect(() => {
     {/if}
 
     {#if onOpenSettings}
+      <span class="settings-btn-wrap">
       <button
         bind:this={settingsBtn}
         type="button"
         class="icon-btn"
         data-testid="settings-btn"
-        aria-label="Settings"
+        aria-label={updateAvailable ? "Settings (update available)" : "Settings"}
         aria-keyshortcuts="Control+Comma"
         title="Settings (Ctrl+,)"
         onclick={onOpenSettings}
@@ -307,6 +317,14 @@ $effect(() => {
           <circle cx="8" cy="8" r="2" stroke="currentColor" stroke-width="1.3" fill="none" />
         </svg>
       </button>
+      {#if isTauriRuntime() && updateAvailable}
+        <span
+          class="titlebar-settings-dot"
+          data-testid="titlebar-update-available-dot"
+          aria-hidden="true"
+        ></span>
+      {/if}
+      </span>
     {/if}
   </div>
 
@@ -521,6 +539,40 @@ $effect(() => {
   .icon-btn.active {
     background: var(--tandem-accent-bg);
     color: var(--tandem-accent);
+  }
+
+  /* Wraps the gear button so the update-available dot can position absolute
+     against it without restructuring the button. The wrap is otherwise
+     transparent (inherits inline-flex from .title-bar-actions). */
+  .settings-btn-wrap {
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+
+  /* Issue #660 — small colored dot at top-right of the gear icon when an
+     updater event has fired and not yet been acknowledged. WCAG AA against
+     --tandem-surface-muted in both themes; 2px contrasting ring matches the
+     existing .status-dot pattern. No animation: spec calls for
+     reduced-motion-aware design and a static dot is the simplest path that
+     satisfies both reduced-motion users and the WCAG AA contrast bar. */
+  .titlebar-settings-dot {
+    position: absolute;
+    top: 3px;
+    right: 3px;
+    width: 7px;
+    height: 7px;
+    border-radius: var(--tandem-r-circle);
+    background: var(--tandem-info);
+    box-shadow: 0 0 0 2px var(--tandem-surface-muted);
+    pointer-events: none;
+  }
+
+  @media (forced-colors: active) {
+    .titlebar-settings-dot {
+      background: Highlight;
+      box-shadow: 0 0 0 2px Canvas;
+    }
   }
 
   .title-bar-controls {

--- a/src/client/svelte-harness/UpdateAvailableHarness.svelte
+++ b/src/client/svelte-harness/UpdateAvailableHarness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import { createUpdateAvailable } from "../hooks/useUpdateAvailable.svelte";
+
+const updater = createUpdateAvailable();
+</script>
+
+{#if updater.showDot}
+  <span data-testid="titlebar-update-available-dot"></span>
+{/if}
+<button type="button" data-testid="harness-acknowledge" onclick={() => updater.acknowledge()}>
+  acknowledge
+</button>
+<output data-testid="harness-version">{updater.availableVersion ?? ""}</output>

--- a/src/client/svelte-harness/UpdaterBannerHarness.svelte
+++ b/src/client/svelte-harness/UpdaterBannerHarness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import { createUpdaterBanner } from "../hooks/useUpdaterBanner.svelte";
+
+const banner = createUpdaterBanner();
+</script>
+
+{#if banner.showBanner}
+  <span data-testid="updater-banner-visible"></span>
+{/if}
+<button type="button" data-testid="harness-banner-dismiss" onclick={() => banner.dismiss()}>
+  dismiss
+</button>
+<output data-testid="harness-banner-version">{banner.availableVersion ?? ""}</output>

--- a/src/client/svelte-harness/registry.ts
+++ b/src/client/svelte-harness/registry.ts
@@ -30,6 +30,7 @@ export const registry: Record<string, () => Promise<{ default: Component<any> }>
   AppearanceSettings: () => import("../components/AppearanceSettings.svelte"),
   EditorSettings: () => import("../components/EditorSettings.svelte"),
   SettingsPopover: () => import("../components/SettingsPopover.svelte"),
+  SettingsModal: () => import("../components/SettingsModal.svelte"),
   CoworkSettings: () => import("../components/CoworkSettings.svelte"),
   CoworkOnboardingStep: () => import("../components/CoworkOnboardingStep.svelte"),
   CoworkAdminDeclinedModal: () => import("../components/CoworkAdminDeclinedModal.svelte"),

--- a/tests/client/update-available.test.ts
+++ b/tests/client/update-available.test.ts
@@ -15,6 +15,7 @@ vi.mock("@tauri-apps/api/event", () => ({
   }),
 }));
 
+import { __resetUpdaterChannelForTests } from "../../src/client/hooks/useUpdaterChannel.svelte";
 import UpdateAvailableHarness from "../../src/client/svelte-harness/UpdateAvailableHarness.svelte";
 
 const DISMISS_KEY_PREFIX = "tandem:updater-dismissed-v";
@@ -26,6 +27,8 @@ describe("createUpdateAvailable", () => {
     (window as unknown as { __TAURI_INTERNALS__: unknown }).__TAURI_INTERNALS__ = {};
     emit = null;
     unlistenSpy.mockClear();
+    // Reset the module-singleton channel state so each test starts clean.
+    __resetUpdaterChannelForTests();
   });
 
   afterEach(() => {

--- a/tests/client/update-available.test.ts
+++ b/tests/client/update-available.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Captured by the test so it can emit a synthetic update-available event.
+let emit: ((payload: { version: string }) => void) | null = null;
+const unlistenSpy = vi.fn();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (_event: string, cb: (e: { payload: { version: string } }) => void) => {
+    emit = (payload) => cb({ payload });
+    return unlistenSpy;
+  }),
+}));
+
+import UpdateAvailableHarness from "../../src/client/svelte-harness/UpdateAvailableHarness.svelte";
+
+const DISMISS_KEY_PREFIX = "tandem:updater-dismissed-v";
+
+describe("createUpdateAvailable", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // Pretend we're in Tauri so the hook attaches its listener.
+    (window as unknown as { __TAURI_INTERNALS__: unknown }).__TAURI_INTERNALS__ = {};
+    emit = null;
+    unlistenSpy.mockClear();
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("renders the dot after an update-available event and clears it on acknowledge", async () => {
+    const { container } = render(UpdateAvailableHarness);
+    // Wait for the async dynamic import + listen() to resolve.
+    await new Promise((r) => setTimeout(r, 0));
+    await tick();
+
+    expect(container.querySelector("[data-testid='titlebar-update-available-dot']")).toBeNull();
+    expect(emit).toBeTruthy();
+
+    emit?.({ version: "0.12.0" });
+    await tick();
+    expect(container.querySelector("[data-testid='titlebar-update-available-dot']")).toBeTruthy();
+
+    (container.querySelector("[data-testid='harness-acknowledge']") as HTMLButtonElement).click();
+    await tick();
+    expect(container.querySelector("[data-testid='titlebar-update-available-dot']")).toBeNull();
+    expect(window.localStorage.getItem(`${DISMISS_KEY_PREFIX}0.12.0`)).toBe("1");
+  });
+
+  it("does not flicker on cold start when the same version was previously acknowledged", async () => {
+    window.localStorage.setItem(`${DISMISS_KEY_PREFIX}0.12.0`, "1");
+
+    const { container } = render(UpdateAvailableHarness);
+    await new Promise((r) => setTimeout(r, 0));
+    await tick();
+
+    emit?.({ version: "0.12.0" });
+    await tick();
+    // Persisted dismissal must short-circuit the getter — the dot never appears.
+    expect(container.querySelector("[data-testid='titlebar-update-available-dot']")).toBeNull();
+  });
+
+  it("re-shows the dot when a newer version arrives after a prior acknowledge", async () => {
+    window.localStorage.setItem(`${DISMISS_KEY_PREFIX}0.12.0`, "1");
+
+    const { container } = render(UpdateAvailableHarness);
+    await new Promise((r) => setTimeout(r, 0));
+    await tick();
+
+    emit?.({ version: "0.12.0" });
+    await tick();
+    expect(container.querySelector("[data-testid='titlebar-update-available-dot']")).toBeNull();
+
+    emit?.({ version: "0.13.0" });
+    await tick();
+    expect(container.querySelector("[data-testid='titlebar-update-available-dot']")).toBeTruthy();
+  });
+});

--- a/tests/client/updater-channel-race.test.ts
+++ b/tests/client/updater-channel-race.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+/**
+ * Regression test for the refcount-flap race in `useUpdaterChannel`
+ * (M6 + L30 of the Wave-1 simplify pass).
+ *
+ * Scenario: a consumer mounts and lets the singleton's listen() request
+ * start (refCount 0→1, pending=1, branch A awaiting `listen(...)`),
+ * then unmounts AND a fresh consumer mounts BEFORE branch A resolves.
+ * Pre-fix, branch A's `off` would be stored as `unlisten` and then
+ * overwritten by branch B — leaking branch A's listener (its off()
+ * never called).
+ *
+ * The in-flight token defeats this: each async subscribe captures
+ * `++pending`; on resume the branch bails (and calls its own `off()` if
+ * it already got that far) unless its `myToken` still equals the
+ * current `pending`.
+ *
+ * Asserts the *outcome* — exactly one persistent listener, no leaked
+ * uncalled off()s — rather than internal call counts (which are
+ * sensitive to vitest+Svelte dynamic-import mocking quirks).
+ */
+
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Track every off() returned by listen(), so the test can assert that no
+// listener leaks across the race. Each listen() call resolution is
+// deferred so the test can interleave mounts/unmounts before any
+// listen() promise settles.
+const listenResolvers: Array<() => void> = [];
+const offSpies: Array<ReturnType<typeof vi.fn>> = [];
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(
+    (_event: string, _cb: (e: { payload: { version: string } }) => void) =>
+      new Promise<() => void>((resolve) => {
+        const off = vi.fn();
+        offSpies.push(off);
+        // Defer until the test releases the resolvers — gives us a
+        // window inside which to flap refcount and start a second
+        // branch before either listen() settles.
+        listenResolvers.push(() => resolve(off));
+      }),
+  ),
+}));
+
+import {
+  __hasActiveListenerForTests,
+  __resetUpdaterChannelForTests,
+} from "../../src/client/hooks/useUpdaterChannel.svelte";
+import UpdateAvailableHarness from "../../src/client/svelte-harness/UpdateAvailableHarness.svelte";
+
+describe("useUpdaterChannel refcount-flap race", () => {
+  beforeEach(() => {
+    (window as unknown as { __TAURI_INTERNALS__: unknown }).__TAURI_INTERNALS__ = {};
+    listenResolvers.length = 0;
+    offSpies.length = 0;
+    __resetUpdaterChannelForTests();
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("mount → unmount → mount with deferred listen() resolution leaves no leaked off()s", async () => {
+    // Mount #1: $effect subscribes. refCount 0 → 1, pending=1, branch A
+    // starts and pauses at `await import` then `await listen(...)`.
+    const consumer1 = render(UpdateAvailableHarness);
+    // Give the effect time to run and the dynamic import to resolve.
+    await tick();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Branch A has now called listen(...) — its promise is pending
+    // (held open by listenResolvers).
+    expect(offSpies.length).toBeGreaterThanOrEqual(1);
+
+    // Unmount triggers $effect cleanup → unsubscribe. refCount → 0,
+    // cancelled = true. Branch A's off() can NOT run yet because
+    // branch A's `await listen` is still pending — `unlisten` is null.
+    consumer1.unmount();
+
+    // Re-mount synchronously: a fresh $effect runs. refCount 0 → 1,
+    // pending=2, cancelled reset to false, branch B starts.
+    const consumer2 = render(UpdateAvailableHarness);
+    await tick();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Branch B has called listen too.
+    expect(offSpies.length).toBeGreaterThanOrEqual(2);
+
+    // Now release both listen() promises so the post-listen guards run.
+    for (const resolver of listenResolvers) resolver();
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await tick();
+
+    // Outcome: exactly one persistent listener attached (branch B's).
+    expect(__hasActiveListenerForTests()).toBe(true);
+
+    // No leaks: pre-fix, branch A would have stored its off() as
+    // `unlisten` only to be overwritten by branch B, leaving branch A's
+    // off() forever uncalled (two uncalled offs). With the token fix,
+    // branch A bails post-listen and calls its own off() immediately.
+    const uncalledOffs = offSpies.filter((s) => s.mock.calls.length === 0);
+    expect(uncalledOffs.length).toBeLessThanOrEqual(1);
+    expect(uncalledOffs.length).toBeGreaterThanOrEqual(1);
+
+    // Final teardown: unmounting the live consumer must call off() on
+    // the surviving listener and return the singleton to idle.
+    consumer2.unmount();
+    await tick();
+    expect(uncalledOffs[0]).toHaveBeenCalledTimes(1);
+    expect(__hasActiveListenerForTests()).toBe(false);
+  });
+});

--- a/tests/client/updater-channel-sync.test.ts
+++ b/tests/client/updater-channel-sync.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+/**
+ * Cross-surface sync test for the shared updater channel primitive
+ * (useUpdaterChannel.svelte.ts). Both the titlebar dot
+ * (`createUpdateAvailable`) and the in-app updater banner
+ * (`createUpdaterBanner`) consume the same module-singleton listener +
+ * acknowledgement state. This test proves:
+ *
+ *   1. A single Tauri event fires both surfaces simultaneously.
+ *   2. Dismissing the banner clears the dot live (no remount needed).
+ *   3. Acknowledging the dot clears the banner live (no remount needed).
+ *
+ * Pre-extraction these surfaces had two independent listeners and two
+ * unrelated in-memory ack stores, so cross-surface clear required a remount.
+ */
+
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let emit: ((payload: { version: string }) => void) | null = null;
+const unlistenSpy = vi.fn();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (_event: string, cb: (e: { payload: { version: string } }) => void) => {
+    emit = (payload) => cb({ payload });
+    return unlistenSpy;
+  }),
+}));
+
+import { __resetUpdaterChannelForTests } from "../../src/client/hooks/useUpdaterChannel.svelte";
+import UpdateAvailableHarness from "../../src/client/svelte-harness/UpdateAvailableHarness.svelte";
+import UpdaterBannerHarness from "../../src/client/svelte-harness/UpdaterBannerHarness.svelte";
+
+describe("useUpdaterChannel cross-surface sync", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    (window as unknown as { __TAURI_INTERNALS__: unknown }).__TAURI_INTERNALS__ = {};
+    emit = null;
+    unlistenSpy.mockClear();
+    __resetUpdaterChannelForTests();
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("a single event reveals both surfaces; dismissing the banner clears the dot live", async () => {
+    const dot = render(UpdateAvailableHarness);
+    const banner = render(UpdaterBannerHarness);
+    await new Promise((r) => setTimeout(r, 0));
+    await tick();
+
+    expect(dot.container.querySelector("[data-testid='titlebar-update-available-dot']")).toBeNull();
+    expect(banner.container.querySelector("[data-testid='updater-banner-visible']")).toBeNull();
+
+    emit?.({ version: "1.0.0" });
+    await tick();
+
+    expect(
+      dot.container.querySelector("[data-testid='titlebar-update-available-dot']"),
+    ).toBeTruthy();
+    expect(banner.container.querySelector("[data-testid='updater-banner-visible']")).toBeTruthy();
+
+    (
+      banner.container.querySelector("[data-testid='harness-banner-dismiss']") as HTMLButtonElement
+    ).click();
+    await tick();
+
+    expect(dot.container.querySelector("[data-testid='titlebar-update-available-dot']")).toBeNull();
+    expect(banner.container.querySelector("[data-testid='updater-banner-visible']")).toBeNull();
+  });
+
+  it("acknowledging the dot clears the banner live", async () => {
+    const dot = render(UpdateAvailableHarness);
+    const banner = render(UpdaterBannerHarness);
+    await new Promise((r) => setTimeout(r, 0));
+    await tick();
+
+    emit?.({ version: "1.0.0" });
+    await tick();
+
+    expect(banner.container.querySelector("[data-testid='updater-banner-visible']")).toBeTruthy();
+
+    (
+      dot.container.querySelector("[data-testid='harness-acknowledge']") as HTMLButtonElement
+    ).click();
+    await tick();
+
+    expect(banner.container.querySelector("[data-testid='updater-banner-visible']")).toBeNull();
+    expect(dot.container.querySelector("[data-testid='titlebar-update-available-dot']")).toBeNull();
+  });
+
+  it("attaches exactly one Tauri listener regardless of how many consumers mount", async () => {
+    const { listen } = await import("@tauri-apps/api/event");
+    const listenMock = listen as unknown as ReturnType<typeof vi.fn>;
+    listenMock.mockClear();
+
+    render(UpdateAvailableHarness);
+    render(UpdaterBannerHarness);
+    render(UpdateAvailableHarness);
+    await new Promise((r) => setTimeout(r, 0));
+    await tick();
+
+    expect(listenMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

End-of-wave cross-cut simplify pass for the Tandem v1.0 first-feature-wave batch (14 PRs). Looks for duplication invented in parallel by units that didn't share a base.

**One finding worth landing:** PRs #669 (Unit 8 — in-app updater banner) and #675 (Unit 10 — titlebar settings-icon dot) both subscribe to the same `tandem://update-available` Tauri event and share the same `tandem:updater-dismissed-v{version}` localStorage key. They each grew an independent copy of:

- the `UPDATE_AVAILABLE_EVENT` constant + dismiss-key helpers (`dismissKey` / `readDismissed` / `writeDismissed`),
- the `unlistenRef` / `cancelled` async-listen `$effect` boilerplate, and
- per-hook in-memory acknowledgement state.

The PR #675 description itself flags this: _"The two listeners are intentionally separate during Wave 2 so the units can land independently; a follow-up consolidates them after #669 merges."_ This is that follow-up.

Two consequences of the unconsolidated shape:

1. Two Tauri listeners attached for what is a single event channel.
2. Acknowledging on one surface only cleared the other on next remount — dismiss the banner and the dot stayed lit until the next reload.

Shape: a small module-singleton primitive `useUpdaterChannel.svelte.ts` owns the listener + reactive ack state. The Tauri listener is reference-counted so it attaches exactly once across N consumers. Both `createUpdaterBanner` and `createUpdateAvailable` keep their UI-specific concerns (install-in-flight, banner-vs-dot label) but now consume getters off the singleton.

## Cross-surface sync test

A new test (`tests/client/updater-channel-sync.test.ts`) proves the consolidation:

- A single event reveals both surfaces simultaneously.
- Dismissing the banner clears the dot **live** (no remount).
- Acknowledging the dot clears the banner **live** (no remount).
- The Tauri `listen()` is called exactly once regardless of consumer count.

The pre-existing `tests/client/update-available.test.ts` still passes — its three scenarios continue to exercise `createUpdateAvailable` end-to-end through the new primitive.

## Patterns checked and skipped (intentionally not extracted)

| Pattern | Verdict |
|---|---|
| Focus-trap helpers (HelpModal / SettingsModal #671 / ReplyThreadOverlay #673) | **Skip.** HelpModal uses `focusin` redirect; SettingsModal uses Tab-keydown wrap with `FOCUSABLE_SELECTOR` re-queried per press (640px reflow); ReplyThreadOverlay mirrors HelpModal. Three implementations, two approaches, one with unique reflow semantics. Premature abstraction. |
| Click-outside helpers | **Skip.** Same set of modals; each has different exemption-list needs (trigger element, dialog itself, portal-aware checks). |
| Tauri event listener pattern (`useTauriEvent`) | **Folded in.** The only two consumers are the two updater hooks above, both covered by the singleton. Not generalised on sample size 2. |
| `isTauriRuntime()` gating | **Verified clean.** All sites import from `@client/cowork/cowork-helpers`. |
| CSS dot primitives (`.status-dot`, `.claude-dot`, `.held-dot` from #666, `.titlebar-settings-dot` from #675) | **Skip.** Different sizes (6px vs 7px), different positioning contexts (inline gap vs absolute over icon). Coincidental similarity. |
| Modal scaffolding (`Modal.svelte` primitive) | **Skip.** Three copies is better than premature abstraction here — extraction would force one of {HelpModal, SettingsModal, ReplyThreadOverlay} to change semantics. |
| Toast emission from Tauri (#664) | **Skip.** Single consumer; no other unit emits client-side toasts from a Rust event. |
| `getVisibleReplies` consumers (Units 13/14) | **Skip.** The helper already lives in `src/client/annotations/replies.ts` and both #673 and #674 import it from there — no duplication. |

## Merge order

**This PR depends on #669 and #675.** It must merge AFTER both. The base merges of those PRs are included as merge commits on this branch so the diff is reviewable today; the actual PR commit (`fea34b5`) only adds the new primitive and refactors the two hooks. Once #669 and #675 are on master, this branch will rebase cleanly to a single commit.

## Test plan

- [x] `npm run typecheck` — 810 files, 0 errors
- [x] `npm test` — 2068 passed, 4 skipped, 159 test files
- [x] `npx biome check --write` — clean
- [ ] Manual: confirm in Tauri dev that emitting `tandem://update-available` reveals both banner and dot, and that dismissing either clears both without a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)