### PR TITLE
fix(#428): Windows code signing via Azure Trusted Signing + OIDC

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -9,6 +9,15 @@ jobs:
   build-tauri:
     permissions:
       contents: write
+      # OIDC token write for azure/login@v2 (Windows signing).
+      id-token: write
+    # `release` environment binds the OIDC token subject to
+    # `repo:bloknayrb/tandem:environment:release`, matching the federated
+    # credential on the tandem-ci-trusted-signing service principal. No
+    # protection rules attached -- the environment exists solely as the
+    # subject anchor.
+    environment:
+      name: release
     strategy:
       fail-fast: false
       matrix:
@@ -59,30 +68,65 @@ jobs:
       - name: Download Node.js sidecar
         run: node scripts/download-node-sidecar.mjs --target ${{ matrix.node-target }}
 
-      - name: Create self-signed code signing certificate
+      # Windows signing uses Azure Trusted Signing via the Microsoft-maintained
+      # dotnet/sign CLI. Authentication is OIDC -> federated credential on the
+      # tandem-ci-trusted-signing service principal -- no AZURE_CLIENT_SECRET
+      # needed. azure/login@v2 caches the auth session in the Azure CLI; the
+      # `sign` tool picks it up via DefaultAzureCredential -> AzureCliCredential.
+      - name: Azure OIDC login
         if: matrix.platform == 'windows-latest'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $cert = New-SelfSignedCertificate `
-            -Type CodeSigningCert `
-            -Subject "CN=Tandem Editor, O=Tandem" `
-            -CertStoreLocation Cert:\CurrentUser\My `
-            -NotAfter (Get-Date).AddYears(5)
-          if (-not $cert) { throw "Failed to create code signing certificate" }
-          echo "CERT_THUMBPRINT=$($cert.Thumbprint)" >> $env:GITHUB_ENV
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
 
-      - name: Configure Windows code signing
+      - name: Install dotnet sign CLI
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
+          dotnet tool install --global sign --prerelease
+          # Tauri runs signCommand as a raw subprocess that does NOT inherit
+          # PATH updates from $env:GITHUB_PATH reliably (KeyQ blog 2026). Resolve
+          # to the absolute install path and pin it into tauri.conf.json below.
+          $signExe = Join-Path $env:USERPROFILE '.dotnet\tools\sign.exe'
+          if (-not (Test-Path $signExe)) {
+            throw "sign.exe not found at $signExe after dotnet tool install"
+          }
+          echo "SIGN_EXE_PATH=$signExe" >> $env:GITHUB_ENV
+
+      - name: Inject bundle.windows.signCommand
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          # signCommand object form `{cmd, args}` avoids shell-quoting issues
+          # for the runner home path (which contains a backslash on Windows).
+          # Tauri replaces '%1' in args with the absolute path of each artifact
+          # being signed (inner tandem.exe before bundling; .msi and NSIS .exe
+          # after bundling).
+          # The Artifact Signing service (formerly Trusted Signing) handles
+          # RFC 3161 timestamping internally; no --timestamp-url flag is
+          # accepted on the `code artifact-signing` subcommand.
+          # --azure-credential-type=azure-cli pins the auth flow to the
+          # session cached by azure/login@v2 (deterministic; avoids
+          # DefaultAzureCredential trying managed identity / env first).
+          $signCommand = [ordered]@{
+            cmd  = $env:SIGN_EXE_PATH
+            args = @(
+              'code', 'artifact-signing',
+              '--artifact-signing-endpoint', 'https://eus.codesigning.azure.net/',
+              '--artifact-signing-account', 'Tandem',
+              '--artifact-signing-certificate-profile', 'tandem-prod',
+              '--azure-credential-type', 'azure-cli',
+              '--description', 'Tandem',
+              '--description-url', 'https://github.com/bloknayrb/tandem',
+              '%1'
+            )
+          }
           $config = Get-Content src-tauri/tauri.conf.json -Raw | ConvertFrom-Json -Depth 20
-          $config.bundle | Add-Member -NotePropertyName windows -NotePropertyValue @{
-            certificateThumbprint = $env:CERT_THUMBPRINT
-            digestAlgorithm = "sha256"
-            timestampUrl = "http://timestamp.digicert.com"
-          } -Force
-          $config | ConvertTo-Json -Depth 20 | Set-Content src-tauri/tauri.conf.json
+          # bundle.windows already exists (nsis.installerHooks); merge in signCommand.
+          $config.bundle.windows | Add-Member -NotePropertyName signCommand -NotePropertyValue $signCommand -Force
+          $config | ConvertTo-Json -Depth 20 | Set-Content src-tauri/tauri.conf.json -Encoding utf8
 
       - name: Validate updater signing key
         if: env.TAURI_SIGNING_PRIVATE_KEY == ''
@@ -146,6 +190,41 @@ jobs:
         if: always() && matrix.platform == 'macos-latest'
         shell: bash
         run: rm -f "$RUNNER_TEMP/private_keys/"*.p8 || true
+
+      # tauri-action does not always fail when bundle.windows.signCommand
+      # exits non-zero. Verify every produced artifact is signed and
+      # timestamped; fail the job loudly if anything is unsigned or stale.
+      - name: Verify Windows signatures
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          # Cargo binary name is `tandem-desktop` but Tauri renames the inner
+          # exe to `Tandem.exe` (productName) before bundling. Glob both.
+          # Wrap in -Force to follow file-association-handler files too if any.
+          $bundleFiles = @()
+          $bundleFiles += Get-ChildItem -Path 'src-tauri/target/release/bundle/nsis' -Filter '*.exe' -ErrorAction SilentlyContinue
+          $bundleFiles += Get-ChildItem -Path 'src-tauri/target/release/bundle/msi'  -Filter '*.msi' -ErrorAction SilentlyContinue
+          $bundleFiles += Get-ChildItem -Path 'src-tauri/target/release' -Filter '*.exe' -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -in @('Tandem.exe', 'tandem-desktop.exe') }
+          if ($bundleFiles.Count -eq 0) {
+            Write-Host '::error::Verify Windows signatures: no .exe/.msi artifacts found under src-tauri/target/release/'
+            exit 1
+          }
+          $errors = @()
+          foreach ($f in $bundleFiles) {
+            $sig = Get-AuthenticodeSignature -FilePath $f.FullName
+            if ($sig.Status -ne 'Valid') {
+              $errors += "$($f.FullName): Status=$($sig.Status) StatusMessage=$($sig.StatusMessage)"
+            } elseif (-not $sig.TimeStamperCertificate) {
+              $errors += "$($f.FullName): signature missing RFC 3161 timestamp"
+            } else {
+              Write-Host "ok: $($f.Name) signed by $($sig.SignerCertificate.Subject); timestamped"
+            }
+          }
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Host "::error::$_" }
+            exit 1
+          }
 
   release-check:
     permissions: {}

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -16,6 +16,10 @@ jobs:
     # credential on the tandem-ci-trusted-signing service principal. No
     # protection rules attached -- the environment exists solely as the
     # subject anchor.
+    # CAUTION: renaming or deleting this environment silently breaks the
+    # federated-credential subject match -- the Azure OIDC login fails
+    # with a confusing token-validation error rather than a clear "no such
+    # environment" message.
     environment:
       name: release
     strategy:
@@ -39,6 +43,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Enforce that Windows signing only runs on v* tag builds. The
+      # `release` environment's UI deployment-branch rule is defense in
+      # depth, but enforcement lives here so the workflow refuses to mint
+      # an OIDC token off a feature branch or workflow_dispatch.
+      - name: Refuse to sign outside tag builds
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          if (-not ('${{ github.ref }}'.StartsWith('refs/tags/v'))) {
+            Write-Host "::error::Windows signing is restricted to v* tag builds; got ref '${{ github.ref }}'"
+            exit 1
+          }
+          Write-Host "Tag ref OK: ${{ github.ref }}"
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
@@ -75,20 +93,31 @@ jobs:
       # `sign` tool picks it up via DefaultAzureCredential -> AzureCliCredential.
       - name: Azure OIDC login
         if: matrix.platform == 'windows-latest'
-        uses: azure/login@v2
+        # SHA-pinned to the commit v2 (moving tag) resolves to at plan time.
+        # Re-resolve and re-pin deliberately when bumping major versions.
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          # allow-no-subscriptions is REQUIRED for Trusted Signing -- the SP
+          # has no subscription role assignment, only the signer role on the
+          # cert profile. Standard azure/login refuses to proceed without
+          # subscriptions; do NOT remove this.
           allow-no-subscriptions: true
 
       - name: Install dotnet sign CLI
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          dotnet tool install --global sign --prerelease
-          # Tauri runs signCommand as a raw subprocess that does NOT inherit
-          # PATH updates from $env:GITHUB_PATH reliably (KeyQ blog 2026). Resolve
-          # to the absolute install path and pin it into tauri.conf.json below.
+          # Pin to a known-good prerelease. Stable `sign` 1.1.x exists but
+          # uses a different subcommand surface (the `trusted-signing` ->
+          # `artifact-signing` rename landed in this beta). Do NOT silently
+          # bump to 1.1.x without adjusting the subcommand below.
+          dotnet tool install --global sign --version 0.9.1-beta.26127.1
+          # Tauri runs signCommand as a raw subprocess that does NOT reliably
+          # inherit PATH updates from $env:GITHUB_PATH within the same job --
+          # `sign` resolves at job time but fails when Tauri spawns it later
+          # unless we pin to the absolute path.
           $signExe = Join-Path $env:USERPROFILE '.dotnet\tools\sign.exe'
           if (-not (Test-Path $signExe)) {
             throw "sign.exe not found at $signExe after dotnet tool install"
@@ -191,21 +220,28 @@ jobs:
         shell: bash
         run: rm -f "$RUNNER_TEMP/private_keys/"*.p8 || true
 
-      # tauri-action does not always fail when bundle.windows.signCommand
-      # exits non-zero. Verify every produced artifact is signed and
-      # timestamped; fail the job loudly if anything is unsigned or stale.
+      # tauri-action (observed 2026-05, no upstream issue found) does not
+      # always surface signCommand non-zero exits as job failure. Verify
+      # every produced artifact is signed and timestamped; fail the job
+      # loudly if anything is unsigned or stale. To safely remove this step:
+      # force-fail signCommand (e.g. break the cert profile name) and confirm
+      # the tauri-action build step fails with non-zero exit before deletion.
       - name: Verify Windows signatures
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          # Cargo binary name is `tandem-desktop` but Tauri renames the inner
-          # exe to `Tandem.exe` (productName) before bundling. Glob both.
-          # Wrap in -Force to follow file-association-handler files too if any.
+          # Three signed artifacts per Windows build (empirical, v0.11.2 log):
+          #   1. src-tauri/target/release/tandem-desktop.exe (cargo binary, signed in place by tauri-action)
+          #   2. src-tauri/target/release/bundle/nsis/Tandem_*-setup.exe
+          #   3. src-tauri/target/release/bundle/msi/Tandem_*_x64_en-US.msi
+          # The cargo binary keeps its Cargo.toml name (tandem-desktop.exe) --
+          # Tauri does NOT rename to productName before signing. signCommand
+          # is invoked on each path in turn (cargo binary actually signed
+          # twice: once after MSI bundling-patch, once after NSIS patch).
           $bundleFiles = @()
           $bundleFiles += Get-ChildItem -Path 'src-tauri/target/release/bundle/nsis' -Filter '*.exe' -ErrorAction SilentlyContinue
           $bundleFiles += Get-ChildItem -Path 'src-tauri/target/release/bundle/msi'  -Filter '*.msi' -ErrorAction SilentlyContinue
-          $bundleFiles += Get-ChildItem -Path 'src-tauri/target/release' -Filter '*.exe' -ErrorAction SilentlyContinue |
-            Where-Object { $_.Name -in @('Tandem.exe', 'tandem-desktop.exe') }
+          $bundleFiles += Get-ChildItem -Path 'src-tauri/target/release' -Filter 'tandem-desktop.exe' -ErrorAction SilentlyContinue
           if ($bundleFiles.Count -eq 0) {
             Write-Host '::error::Verify Windows signatures: no .exe/.msi artifacts found under src-tauri/target/release/'
             exit 1
@@ -218,7 +254,14 @@ jobs:
             } elseif (-not $sig.TimeStamperCertificate) {
               $errors += "$($f.FullName): signature missing RFC 3161 timestamp"
             } else {
-              Write-Host "ok: $($f.Name) signed by $($sig.SignerCertificate.Subject); timestamped"
+              # TODO(#428): after first signed rc, harden this by asserting
+              # the cert subject matches the expected Trusted Signing DN.
+              # With Individual validation, the CN reflects the validated
+              # legal name (e.g. CN=Bryan Kolb), NOT the Trusted Signing
+              # account name 'Tandem'. Capture the actual subject from the
+              # first green build log below and pin it via -match here.
+              $tsSubject = if ($sig.TimeStamperCertificate) { $sig.TimeStamperCertificate.Subject } else { '(none)' }
+              Write-Host "ok: $($f.Name) signed by '$($sig.SignerCertificate.Subject)'; timestamped by '$tsSubject'"
             }
           }
           if ($errors.Count -gt 0) {


### PR DESCRIPTION
Closes #428 (Windows side; pending end-to-end verification on a real release tag).

Companion to #661 (macOS side, merged 2026-05-15). With this PR merged + first green release run, every platform Tauri builds for is properly signed and notarized/timestamped.

## What's changing

Current `master` (lines 62-85 of `tauri-release.yml`) generates a fresh self-signed code-signing cert at job time via `New-SelfSignedCertificate` and bundles the Windows installer with it. SmartScreen treats unknown self-signed CAs as **worse than unsigned** — that block was actively hurting first-launch UX.

This PR replaces the self-signed dance with real Azure Trusted Signing, authenticated via OIDC federation (no long-lived client secret).

## Architecture

- Service principal `tandem-ci-trusted-signing` (already created in tenant `12b02edc-...`) holds the `Artifact Signing Certificate Profile Signer` role scoped to the `tandem-prod` certificate profile under the `Tandem` Trusted Signing account in East US.
- A federated identity credential on the SP trusts the GitHub Actions OIDC token whose subject is `repo:bloknayrb/tandem:environment:release`. The `build-tauri` job now runs under the `release` Environment so its OIDC token matches that subject. No protection rules attached to the environment — it exists only as the subject anchor.
- `azure/login@v2` exchanges the GitHub OIDC token for an Azure CLI session.
- `dotnet/sign` CLI (`sign code artifact-signing` subcommand; Microsoft renamed it from `trusted-signing` to `artifact-signing` in v0.9.1-beta.26127.1) reads that session via `DefaultAzureCredential` → `AzureCliCredential` and signs. Timestamping is handled by the Artifact Signing service — no `--timestamp-url` flag.
- `AZURE_CLIENT_SECRET` is no longer needed. Delete after first green release run.

## Why `dotnet/sign` and not `trusted-signing-cli`

The Tauri v2 docs currently recommend `trusted-signing-cli` (a Rust wrapper by Levminer, single-maintainer). The KeyQ 2026 blog post and Microsoft's own dotnet/sign docs both recommend the .NET Foundation tool instead. Same backing service, but maintained by Microsoft with no single-point-of-failure risk.

## Why runtime-inject the signCommand vs. checking it into `tauri.conf.json`

KeyQ surfaced a real gotcha: Tauri runs `signCommand` as a raw subprocess that does not reliably inherit `$env:GITHUB_PATH` updates. So `sign.exe` has to be referenced by absolute path, which is only known at job time (`$env:USERPROFILE\.dotnet\tools\sign.exe`). Injecting the signCommand at workflow time matches the existing pattern (the old self-signed step already did this) and keeps the checked-in config clean for local `tauri build` on Windows.

## Reviewer findings addressed (security-reviewer agent ran on the plan before I wrote code)

- ✅ Use OIDC instead of `AZURE_CLIENT_SECRET` (kills rotation + log-leak risk)
- ✅ `dotnet/sign` instead of single-maintainer Rust wrapper
- ✅ Object form `{cmd, args}` for signCommand (avoids shell-quoting on Windows home paths)
- ✅ Absolute path to `sign.exe` (Tauri's signCommand subprocess doesn't reliably inherit PATH)
- ✅ Post-sign smoke test — `Get-AuthenticodeSignature` on every artifact, fail on `Status != Valid` or missing timestamp (tauri-action doesn't always hard-fail when signCommand exits non-zero — this is the canary)
- ✅ `--azure-credential-type azure-cli` pins the auth path (deterministic; avoids `DefaultAzureCredential` trying managed identity / env first)

## Repo state already provisioned (not in diff)

**Secrets:** `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`. (`AZURE_CLIENT_SECRET` is present but unused after merge — delete after first green run.)
**Variables:** `AZURE_CODE_SIGNING_ACCOUNT_NAME=Tandem`, `AZURE_CERT_PROFILE_NAME=tandem-prod`, `AZURE_ENDPOINT=https://eus.codesigning.azure.net/`. Currently unused (workflow hardcodes for simplicity); if a future region migration matters, route them through the inject step then.
**GitHub Environment:** `release` (no protection rules).
**Azure SP federated credential:** `github-tandem-release-env` on app `aa139443-...`, subject `repo:bloknayrb/tandem:environment:release`.

## Test plan

- [ ] (CI on merge) Workflow YAML parses and the `release-check` summary job passes on a no-op commit
- [ ] (Manual, post-merge) Tag a prerelease (e.g. `v0.11.3-rc.1`) and confirm:
  - `Azure OIDC login` step succeeds (no client_secret)
  - `Install dotnet sign CLI` succeeds and `sign.exe` resolves at the expected path
  - `Inject bundle.windows.signCommand` produces a valid `tauri.conf.json` (no JSON parse errors downstream)
  - `tauri-action` Windows build log shows `signCommand` invoked on the inner exe and on both installer outputs (NSIS .exe + MSI .msi)
  - `Verify Windows signatures` step prints `ok:` for every artifact and exits 0
- [ ] (Manual, Windows 10/11) Download the released `.exe` and `.msi`, run `signtool verify /pa /v <file>` — expect chain `Tandem Editor → Microsoft Identity Verification Root CA → Microsoft ID Verified Code Signing Trusted Root` (or equivalent Trusted Signing chain). No SmartScreen "unrecognized app" dialog on launch (or a brief verified-publisher confirmation that disappears as reputation builds)
- [ ] After verify passes: `gh secret delete AZURE_CLIENT_SECRET`


## Post-review revisions (2026-05-15)

After three reviewers (security, code, comment) reviewed the initial commit, and four reviewers (security, code-architect, comment, sanity-check) reviewed the fix plan, the following went in as a single follow-up commit:

- **B1** — F4 cert-subject regex deferred. Azure Trusted Signing Individual validation issues certs with `CN=<verified legal name>` (not the account name). Verify step now logs the subject + timestamper without pattern-matching; harden via follow-up after first rc captures the real DN.
- **B2** — Verify-step third glob restricted to `tandem-desktop.exe` only (empirically confirmed against the v0.11.2 build log: cargo binary is signed in place at `target/release/tandem-desktop.exe`; Tauri does NOT rename to `Tandem.exe` before signing).
- **A1** — Workflow-level tag-ref guard: refuses to mint the OIDC token off anything but `refs/tags/v*` (enforcement, not just the environment UI rule).
- **A2** — `azure/login@v2` SHA-pinned to `a457da9ea143d694b1b9c7c869ebb04ebe844ef5`.
- **A3** — `sign` pinned to `0.9.1-beta.26127.1` (vs `--prerelease`), with comment explaining why-beta-over-stable.
- **A5** — F1 verify-globs comment now empirical (numbered list of the three signed artifacts).
- **F5/F7/F8** — comment hygiene per review.
- **T3** — `allow-no-subscriptions: true` documented.

## Pre-tag manual checklist

- [ ] (Manual, one-time, pre-tag) GitHub → Settings → Environments → `release` → Deployment branches and tags → "Selected branches and tags" → add rule `refs/tags/v*`. (Defense-in-depth; the workflow already refuses non-tag refs via the "Refuse to sign outside tag builds" step.)
