### PR TITLE
fix(annotations): reject re-resolve of non-pending annotations (#694)

### DIFF
--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -496,6 +496,9 @@ export function registerAnnotationTools(server: McpServer): void {
       if (!raw) return mcpError("NOT_FOUND", `Annotation ${id} not found`);
 
       const ann = sanitizeAnnotation(raw, makeOnLossy(da.docHash));
+      if (ann.status !== "pending") {
+        return mcpError("ANNOTATION_NOT_PENDING", `Annotation ${id} is already ${ann.status}`);
+      }
       const updated = {
         ...ann,
         status: action === "accept" ? ("accepted" as const) : ("dismissed" as const),

--- a/tests/server/resolve-annotation.test.ts
+++ b/tests/server/resolve-annotation.test.ts
@@ -11,7 +11,8 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { beforeEach, describe, expect, it } from "vitest";
-import { registerAnnotationTools } from "../../src/server/mcp/annotations.js";
+import { MCP_ORIGIN } from "../../src/server/events/queue.js";
+import { createAnnotation, registerAnnotationTools } from "../../src/server/mcp/annotations.js";
 import { populateYDoc } from "../../src/server/mcp/document.js";
 import {
   addDoc,
@@ -20,6 +21,9 @@ import {
   setActiveDocId,
 } from "../../src/server/mcp/document-service.js";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
+import type { Annotation } from "../../src/shared/types.js";
+import { rangeOf } from "../helpers/ydoc-factory.js";
 
 let client: Client;
 
@@ -76,5 +80,75 @@ describe("tandem_resolveAnnotation NOT_FOUND error code", () => {
     const parsed = parseResult(result as { content: Array<{ type: string; text?: string }> });
     expect(parsed.message).toContain("not found");
     expect(parsed.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("tandem_resolveAnnotation precondition (issue #694)", () => {
+  it("rejects re-accept on an already-accepted annotation without bumping rev", async () => {
+    const ydoc = setupDoc("resolve-pre-1", "Hello world");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const id = createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "Original");
+
+    await client.callTool({
+      name: "tandem_resolveAnnotation",
+      arguments: { id, action: "accept" },
+    });
+
+    const accepted = map.get(id) as Annotation;
+    expect(accepted.status).toBe("accepted");
+    const revAfterFirst = accepted.rev;
+
+    const result = await client.callTool({
+      name: "tandem_resolveAnnotation",
+      arguments: { id, action: "accept" },
+    });
+    const parsed = parseResult(result as { content: Array<{ type: string; text?: string }> });
+    expect(parsed.code).toBe("ANNOTATION_NOT_PENDING");
+    expect(parsed.message).toContain("already accepted");
+
+    const after = map.get(id) as Annotation;
+    expect(after.status).toBe("accepted");
+    expect(after.rev).toBe(revAfterFirst);
+  });
+
+  it("rejects re-dismiss on an already-dismissed annotation without bumping rev", async () => {
+    const ydoc = setupDoc("resolve-pre-2", "Hello world");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const id = createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "Original");
+
+    const ann = map.get(id) as Annotation;
+    ydoc.transact(() => map.set(id, { ...ann, status: "dismissed" as const }), MCP_ORIGIN);
+    const revBefore = (map.get(id) as Annotation).rev;
+
+    const result = await client.callTool({
+      name: "tandem_resolveAnnotation",
+      arguments: { id, action: "dismiss" },
+    });
+    const parsed = parseResult(result as { content: Array<{ type: string; text?: string }> });
+    expect(parsed.code).toBe("ANNOTATION_NOT_PENDING");
+    expect(parsed.message).toContain("already dismissed");
+
+    const after = map.get(id) as Annotation;
+    expect(after.status).toBe("dismissed");
+    expect(after.rev).toBe(revBefore);
+  });
+
+  it("rejects accept on an already-dismissed annotation (cross-action)", async () => {
+    const ydoc = setupDoc("resolve-pre-3", "Hello world");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const id = createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "Original");
+
+    const ann = map.get(id) as Annotation;
+    ydoc.transact(() => map.set(id, { ...ann, status: "dismissed" as const }), MCP_ORIGIN);
+
+    const result = await client.callTool({
+      name: "tandem_resolveAnnotation",
+      arguments: { id, action: "accept" },
+    });
+    const parsed = parseResult(result as { content: Array<{ type: string; text?: string }> });
+    expect(parsed.code).toBe("ANNOTATION_NOT_PENDING");
+
+    const after = map.get(id) as Annotation;
+    expect(after.status).toBe("dismissed");
   });
 });


### PR DESCRIPTION
## Summary

- \`tandem_resolveAnnotation\` flipped status and bumped \`rev\` without checking the annotation was pending, allowing duplicate \`annotation:accepted\` / \`annotation:dismissed\` channel events on re-call.
- Add runtime precondition returning \`ANNOTATION_NOT_PENDING\` with the existing status echoed in the message (mirrors the pattern in \`tandem_editAnnotation\`).
- Bridge fix for v0.12.x. ADR-035 (annotation lifecycle module) later makes this structural via \`acceptPending\` / \`dismissPending\`; **PR 6 in the implementation plan removes this runtime check.**

Surfaced during the architectural grilling pass for ADR-031-037 (see #697).

## Test plan

- [x] \`npx vitest run tests/server/resolve-annotation.test.ts\` — 5 tests pass (2 pre-existing + 3 new).
- [x] \`npm run typecheck\` clean.
- New tests cover:
  - re-accept on already-accepted → \`ANNOTATION_NOT_PENDING\`, \`rev\` unchanged.
  - re-dismiss on already-dismissed → \`ANNOTATION_NOT_PENDING\`, \`rev\` unchanged.
  - cross-action (accept on dismissed) → \`ANNOTATION_NOT_PENDING\`, status unchanged.

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)