### PR TITLE
fix(file-io): surface .docx comment-extraction failure via notification (#696)

### DIFF
--- a/src/server/file-io/index.ts
+++ b/src/server/file-io/index.ts
@@ -1,7 +1,9 @@
 import * as crypto from "node:crypto";
 import fs from "fs/promises";
 import path from "path";
+import { generateNotificationId } from "../../shared/utils.js";
 import { extractText, populateYDoc } from "../mcp/document-model.js";
+import { pushNotification } from "../notifications.js";
 import { htmlToYDoc, loadDocx } from "./docx.js";
 import {
   type DocxComment,
@@ -41,6 +43,18 @@ const plaintextAdapter: FormatAdapter = {
   },
 };
 
+/**
+ * The production .docx open path goes through `populateDocFromContent` →
+ * `prepareContent` in `mcp/file-opener.ts`, which has its own dedup'd
+ * notification on comment-extraction failure. This adapter is a public API
+ * (`getAdapter("docx").load(doc, buffer)`) and any future caller — or a
+ * regression that routes through here — must not silently swallow comment
+ * loss. We surface the same user-visible notification here.
+ *
+ * ADR-036 will replace this with a `LoadResult.partial` containing a
+ * `LoadIssue` — see #696. The notification stays as a defensive fallback
+ * until the structural fix lands.
+ */
 const docxAdapter: FormatAdapter = {
   canSave: false,
   async load(doc, content) {
@@ -52,6 +66,14 @@ const docxAdapter: FormatAdapter = {
           "[docx-comments] Comment extraction failed; document will load without imported comments:",
           err,
         );
+        pushNotification({
+          id: generateNotificationId(),
+          type: "annotation-error",
+          severity: "warning",
+          message: "Failed to import Word comments. Document opened without comments.",
+          dedupKey: "docx-comments:format-adapter",
+          timestamp: Date.now(),
+        });
         return [] as DocxComment[];
       }),
     ]);

--- a/src/server/file-io/index.ts
+++ b/src/server/file-io/index.ts
@@ -79,7 +79,24 @@ const docxAdapter: FormatAdapter = {
     ]);
     htmlToYDoc(doc, html);
     if (comments.length > 0) {
-      injectCommentsAsAnnotations(doc, comments);
+      try {
+        injectCommentsAsAnnotations(doc, comments);
+      } catch (err) {
+        console.error(
+          "[docx-comments] injectCommentsAsAnnotations failed; document body loaded but comments missing:",
+          err,
+        );
+        pushNotification({
+          id: generateNotificationId(),
+          type: "annotation-error",
+          severity: "warning",
+          message: "Failed to attach Word comments to the document. Comments may be missing.",
+          dedupKey: "docx-inject:format-adapter",
+          timestamp: Date.now(),
+        });
+        // Do NOT rethrow — the document body has loaded; caller should
+        // proceed with no comments rather than aborting the open.
+      }
     }
   },
   save() {

--- a/tests/server/docx-adapter-comment-failure.test.ts
+++ b/tests/server/docx-adapter-comment-failure.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression test for #696: the docx FormatAdapter's `load()` must surface
+ * comment-extraction failures as a user-visible notification rather than
+ * silently swallowing them.
+ *
+ * The production .docx open path goes through `populateDocFromContent` →
+ * `prepareContent` in `mcp/file-opener.ts`, which has its own notification.
+ * This test exercises the parallel adapter path — `getAdapter("docx").load()`
+ * — that any future caller might reach. ADR-036 replaces this with a
+ * `LoadResult.partial` containing a `LoadIssue`.
+ *
+ * We feed `extractDocxComments` a buffer that is not a valid .docx archive
+ * so it rejects naturally. We also mock `loadDocx` and `htmlToYDoc` to keep
+ * the body-load half of the adapter side-effect-free.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+
+vi.mock("../../src/server/file-io/docx.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    loadDocx: vi.fn().mockResolvedValue("<p>Body</p>"),
+    htmlToYDoc: vi.fn(),
+  };
+});
+
+import { getAdapter } from "../../src/server/file-io/index.js";
+import {
+  getBuffer,
+  resetForTesting as resetNotifications,
+} from "../../src/server/notifications.js";
+
+beforeEach(() => {
+  resetNotifications();
+});
+
+describe("docx adapter — comment-extraction failures (#696)", () => {
+  it("pushes a warning notification when extractDocxComments rejects", async () => {
+    const adapter = getAdapter("docx");
+    const doc = new Y.Doc();
+
+    // Buffer.from("not-a-docx") fails the zip-archive parse in mammoth, so
+    // extractDocxComments rejects. Pre-#696 this would be silently swallowed.
+    await adapter.load(doc, Buffer.from("not-a-docx"));
+
+    const notifs = getBuffer().filter((n) => n.dedupKey === "docx-comments:format-adapter");
+    expect(notifs).toHaveLength(1);
+    expect(notifs[0].type).toBe("annotation-error");
+    expect(notifs[0].severity).toBe("warning");
+    expect(notifs[0].message).toContain("Word comments");
+  });
+
+  it("still resolves load() when comment extraction fails (comments are non-fatal)", async () => {
+    const adapter = getAdapter("docx");
+    const doc = new Y.Doc();
+
+    await expect(adapter.load(doc, Buffer.from("not-a-docx"))).resolves.toBeUndefined();
+  });
+
+  it("logs the underlying error via console.error for diagnostics", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const adapter = getAdapter("docx");
+    await adapter.load(new Y.Doc(), Buffer.from("not-a-docx"));
+
+    const docxCommentLogs = errSpy.mock.calls.filter((args) =>
+      String(args[0] ?? "").includes("[docx-comments] Comment extraction failed"),
+    );
+    expect(docxCommentLogs.length).toBeGreaterThanOrEqual(1);
+
+    errSpy.mockRestore();
+  });
+});

--- a/tests/server/format-adapter.test.ts
+++ b/tests/server/format-adapter.test.ts
@@ -1,7 +1,42 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import { getAdapter } from "../../src/server/file-io/index.js";
 import { extractText } from "../../src/server/mcp/document-model.js";
+
+// Mock the comments module so we can force injectCommentsAsAnnotations
+// to throw on the adapter path. The production path in file-opener.ts
+// has its own try/catch + snapshot/rollback; the adapter path now needs
+// the same surface per PR #701 review.
+vi.mock("../../src/server/file-io/docx-comments.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    extractDocxComments: vi.fn(async () => [
+      { id: "c1", author: "A", text: "x", range: { start: 0, end: 1 } },
+    ]),
+    injectCommentsAsAnnotations: vi.fn(() => {
+      throw new Error("inject failure (test)");
+    }),
+  };
+});
+
+// Same for docx body loader — we need htmlToYDoc to succeed deterministically.
+vi.mock("../../src/server/file-io/docx.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    loadDocx: vi.fn(async () => "<p>body</p>"),
+    htmlToYDoc: actual.htmlToYDoc,
+  };
+});
+
+vi.mock("../../src/server/notifications.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    pushNotification: vi.fn(),
+  };
+});
 
 describe("FormatAdapter registry", () => {
   it("returns markdown adapter for 'md'", () => {
@@ -67,5 +102,26 @@ describe("MarkdownAdapter", () => {
     expect(output).toContain("| :---- | -----: |");
     expect(output).toContain("| Ada   | **99** |");
     expect(output).toContain("| Empty |        |");
+  });
+});
+
+describe("DocxAdapter inject-failure surface (PR #701)", () => {
+  it("does NOT throw when injectCommentsAsAnnotations fails; fires notification instead", async () => {
+    const { pushNotification } = await import("../../src/server/notifications.js");
+    const adapter = getAdapter("docx");
+    const doc = new Y.Doc();
+
+    await expect(
+      adapter.load(doc, Buffer.from("any") as unknown as string),
+    ).resolves.toBeUndefined();
+
+    expect(pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "annotation-error",
+        severity: "warning",
+        dedupKey: "docx-inject:format-adapter",
+        message: expect.stringContaining("Word comments"),
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

The \`docxAdapter\` in \`src/server/file-io/index.ts\` wrapped \`extractDocxComments\` in a \`.catch(() => [])\` that silently returned an empty comment list on failure. Comment loss had no user-visible signal — only a \`console.error\` on the server stderr.

The production \`.docx\` open path goes through \`populateDocFromContent → prepareContent\` (in \`mcp/file-opener.ts\`), which already pushes a deduped warning notification. **The bug surfaces for any caller hitting the parallel adapter path** (\`getAdapter("docx").load(doc, buffer)\`) — a real risk for future code reusing the public API, and a latent silent-failure footgun today.

Surfaced during the ADR-036 grilling pass (see #697).

### Fix

- Push a \`severity: "warning"\` notification on \`extractDocxComments\` rejection.
- Distinct \`dedupKey: "docx-comments:format-adapter"\` so this path doesn't collide with the \`prepareContent\` dedup namespace — a file that hits both shows two toasts rather than one collapsed.
- Body load (\`loadDocx → htmlToYDoc\`) still completes — comment loss remains non-fatal, matching the issue's acceptance criterion.
- \`console.error\` line preserved for stderr diagnostics.

ADR-036 will replace this with \`LoadResult.partial { kind: "comments-failed" }\` in the format-adapter capability redesign (PR 7 in the plan). This is the v0.12.x bridge.

## Test plan

- [x] \`npx vitest run tests/server/docx-adapter-comment-failure.test.ts\` — 3 new tests pass:
  - Warning notification is pushed with the expected type / severity / dedupKey.
  - \`load()\` still resolves when extraction fails.
  - \`console.error\` line is emitted for diagnostics.
- [x] \`npx vitest run tests/server/format-adapter.test.ts\` — 8 existing tests still pass.
- [x] \`npm run typecheck\` clean.

Test feeds the adapter a non-\`.docx\` buffer so \`mammoth\`/\`extractDocxComments\` rejects naturally. Mocking \`docx.js\` keeps the body-load half side-effect-free.

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)