### PR TITLE
ci: disable Apple notarization for v0.12.0 (notary hang workaround)

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -211,9 +211,15 @@ jobs:
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_SIGNING_IDENTITY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER_ID }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
+          # Apple notarization intentionally DISABLED for v0.12.0 — Apple's notary
+          # service has been hanging multi-hour during this release (5+ separate
+          # notarytool submissions stalled with no response across several builds).
+          # macOS ships signed-but-not-notarized; first launch triggers Gatekeeper
+          # warning which user can bypass via right-click → Open. Re-enable by
+          # un-commenting these three lines once Apple's notary recovers:
+          # APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER_ID }}
+          # APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
+          # APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
         with:
           tagName: v__VERSION__
           releaseName: "Tandem v__VERSION__"


### PR DESCRIPTION
## Summary

Apple's notary service has been hanging multi-hour across 5+ separate notarytool submissions in the v0.12.0 release rollout. Each macOS job uploads the .app successfully via codesign, but notarytool's wait for Apple's response never returns (40-50+ min per job).

This ships v0.12.0 macOS as **signed-but-not-notarized**. Gatekeeper will warn on first launch; user bypasses via **right-click → Open** (single-user product, low blast radius).

## Re-enable

When Apple notary recovers, uncomment the three commented-out env vars in tauri-release.yml.

## Test plan
- [ ] CI green
- [ ] Re-tag v0.12.0 → all matrix jobs complete (no macOS hang)
- [ ] Filed: follow-up to re-enable notarization