### PR TITLE
feat(layout): LayoutModel rune store (ADR-037)

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -62,6 +62,7 @@ import { createUpdateAvailable } from "./hooks/useUpdateAvailable.svelte";
 import { createUpdaterBanner } from "./hooks/useUpdaterBanner.svelte";
 import { createWebViewZoom } from "./hooks/useWebViewZoom.svelte";
 import { createYjsSync } from "./hooks/yjsSync.svelte";
+import { createLayoutModel } from "./layout/model.svelte";
 import { loadPanelWidth, PANEL_MAX_WIDTH, PANEL_MIN_WIDTH } from "./panel-layout";
 import type { FilterAuthor, FilterStatus, FilterType } from "./panels/FilterBar.svelte";
 import MarginColumn from "./panels/MarginColumn.svelte";
@@ -168,6 +169,7 @@ const modeState = createTandemModeBroadcast(
   () => yjsSync.bootstrapYdoc,
   () => settingsState.settings.selectionDwellMs,
 );
+const layoutModel = createLayoutModel(settingsState, modeState);
 const modeGate = $derived.by(() => {
   const annotations = yjsSync.annotations;
   const mode = modeState.tandemMode;
@@ -456,61 +458,18 @@ const dragResizeRight = createDragResize({
   getVisible: () => effectiveRightVisible,
 });
 
-// Left rail: no solo override (outline stays visible in solo mode).
-// Right rail: suppressed in solo when soloRailHidden is set.
-const effectiveLeftVisible = $derived(settingsState.settings.leftPanelVisible);
-const effectiveRightVisible = $derived(
-  settingsState.settings.rightPanelVisible &&
-    !(modeState.tandemMode === "solo" && settingsState.settings.soloRailHidden),
-);
-
-function toggleLeftPanel() {
-  settingsState.updateSettings({ leftPanelVisible: !settingsState.settings.leftPanelVisible });
-}
-
-function toggleRightPanel() {
-  if (effectiveRightVisible) {
-    settingsState.updateSettings({ rightPanelVisible: false });
-  } else {
-    // Also clear soloRailHidden so the panel actually shows in solo mode.
-    settingsState.updateSettings({
-      rightPanelVisible: true,
-      ...(modeState.tandemMode === "solo" ? { soloRailHidden: false } : {}),
-    });
-  }
-}
-
-// Returns true if committed, false if blocked (would empty the other rail).
-function moveTabsBetweenRails(
+// Panel visibility + tab-move semantics are encapsulated by `layoutModel`
+// (ADR-037). The model owns the orphan-rail rule, the solo-mode override
+// for the right rail, and the `soloRailHidden`-clearing side-effect when
+// toggling the right panel back on in solo mode.
+const effectiveLeftVisible = $derived(layoutModel.leftVisible);
+const effectiveRightVisible = $derived(layoutModel.rightVisible);
+const toggleLeftPanel = () => layoutModel.toggleLeft();
+const toggleRightPanel = () => layoutModel.toggleRight();
+const moveTabsBetweenRails = (
   side: "left" | "right",
   newTabsForSide: ("annotations" | "chat" | "outline")[],
-): boolean {
-  const leftTabs = settingsState.settings.leftRailTabs;
-  const rightTabs = settingsState.settings.rightRailTabs;
-  const currentSide = side === "left" ? leftTabs : rightTabs;
-  const otherTabs = side === "left" ? rightTabs : leftTabs;
-  const newlyAdded = newTabsForSide.filter((t) => !currentSide.includes(t));
-  if (newlyAdded.length === 0) {
-    settingsState.updateSettings(
-      side === "left" ? { leftRailTabs: newTabsForSide } : { rightRailTabs: newTabsForSide },
-    );
-    return true;
-  }
-  const prunedOther = otherTabs.filter((t) => !newlyAdded.includes(t));
-  if (prunedOther.length === 0) {
-    console.warn(
-      "[tandem] cross-rail tab move blocked — would leave the %s rail empty",
-      side === "left" ? "right" : "left",
-    );
-    return false;
-  }
-  settingsState.updateSettings(
-    side === "left"
-      ? { leftRailTabs: newTabsForSide, rightRailTabs: prunedOther }
-      : { rightRailTabs: newTabsForSide, leftRailTabs: prunedOther },
-  );
-  return true;
-}
+): boolean => layoutModel.moveTabs(side, newTabsForSide);
 
 function handleFilterChange(
   type: (typeof activeAnnotationFilter)["type"],

--- a/src/client/layout/model.svelte.ts
+++ b/src/client/layout/model.svelte.ts
@@ -1,0 +1,120 @@
+/**
+ * Layout model (ADR-037).
+ *
+ * Encapsulates the panel-visibility + rail-tab invariants previously spread
+ * across `App.svelte`: derived visibility (with solo-mode suppression),
+ * toggle handlers, cross-rail tab moves with the orphan-rail rule.
+ *
+ * Returned shape uses getters so consumers see reactivity through the
+ * settings store underneath — same pattern as `useTandemSettings.svelte.ts`.
+ *
+ * Orphan-rail rule (block-toggle): `moveTabs` returns `false` and emits a
+ * console.warn if the proposed move would leave the *other* rail empty.
+ * The current behaviour is preserved (no auto-swap, no silent drop).
+ */
+
+import type { RailTab, TandemSettingsState } from "../hooks/useTandemSettings.svelte.js";
+
+/** Sliver of the mode store the layout model needs. */
+export interface LayoutModeStateLike {
+  readonly tandemMode: "solo" | "tandem";
+}
+
+export interface LayoutModel {
+  /** Effective visibility (`settings.leftPanelVisible`, no solo override on the left). */
+  readonly leftVisible: boolean;
+  /** Effective visibility — `settings.rightPanelVisible && !(solo && soloRailHidden)`. */
+  readonly rightVisible: boolean;
+  /** The settings-backed left rail tab ordering. */
+  readonly leftTabs: ReadonlyArray<RailTab>;
+  /** The settings-backed right rail tab ordering. */
+  readonly rightTabs: ReadonlyArray<RailTab>;
+  /** Toggle the left panel's persisted visibility. */
+  toggleLeft(): void;
+  /** Toggle the right panel; on show, also clears `soloRailHidden` in solo mode. */
+  toggleRight(): void;
+  /**
+   * Replace one rail's tab order. If the proposed move would empty the OTHER
+   * rail, the move is blocked and `false` is returned (block-toggle).
+   * Returns `true` if the update was applied.
+   */
+  moveTabs(side: "left" | "right", newTabsForSide: ReadonlyArray<RailTab>): boolean;
+}
+
+export function createLayoutModel(
+  settingsState: TandemSettingsState,
+  modeState: LayoutModeStateLike,
+): LayoutModel {
+  const leftVisible = $derived(settingsState.settings.leftPanelVisible);
+  const rightVisible = $derived(
+    settingsState.settings.rightPanelVisible &&
+      !(modeState.tandemMode === "solo" && settingsState.settings.soloRailHidden),
+  );
+
+  function toggleLeft(): void {
+    settingsState.updateSettings({
+      leftPanelVisible: !settingsState.settings.leftPanelVisible,
+    });
+  }
+
+  function toggleRight(): void {
+    if (rightVisible) {
+      settingsState.updateSettings({ rightPanelVisible: false });
+      return;
+    }
+    settingsState.updateSettings({
+      rightPanelVisible: true,
+      ...(modeState.tandemMode === "solo" ? { soloRailHidden: false } : {}),
+    });
+  }
+
+  function moveTabs(side: "left" | "right", newTabsForSide: ReadonlyArray<RailTab>): boolean {
+    const leftTabs = settingsState.settings.leftRailTabs;
+    const rightTabs = settingsState.settings.rightRailTabs;
+    const currentSide = side === "left" ? leftTabs : rightTabs;
+    const otherTabs = side === "left" ? rightTabs : leftTabs;
+    const next = [...newTabsForSide];
+
+    const newlyAdded = next.filter((t) => !currentSide.includes(t));
+    if (newlyAdded.length === 0) {
+      settingsState.updateSettings(
+        side === "left" ? { leftRailTabs: next } : { rightRailTabs: next },
+      );
+      return true;
+    }
+
+    const prunedOther = otherTabs.filter((t) => !newlyAdded.includes(t));
+    if (prunedOther.length === 0) {
+      console.warn(
+        "[tandem] cross-rail tab move blocked — would leave the %s rail empty",
+        side === "left" ? "right" : "left",
+      );
+      return false;
+    }
+
+    settingsState.updateSettings(
+      side === "left"
+        ? { leftRailTabs: next, rightRailTabs: prunedOther }
+        : { rightRailTabs: next, leftRailTabs: prunedOther },
+    );
+    return true;
+  }
+
+  return {
+    get leftVisible() {
+      return leftVisible;
+    },
+    get rightVisible() {
+      return rightVisible;
+    },
+    get leftTabs() {
+      return settingsState.settings.leftRailTabs;
+    },
+    get rightTabs() {
+      return settingsState.settings.rightRailTabs;
+    },
+    toggleLeft,
+    toggleRight,
+    moveTabs,
+  };
+}

--- a/tests/client/layout-model.svelte.test.ts
+++ b/tests/client/layout-model.svelte.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the ADR-037 LayoutModel.
+ *
+ * Verifies that the model encapsulates the layout invariants (panel
+ * visibility derivation with solo-mode suppression, toggle behaviour,
+ * orphan-rail rule on cross-rail tab moves).
+ *
+ * The model takes a settings store + a mode-state-like shape; we stub
+ * both with plain Svelte 5 `$state` so the test exercises the reactive
+ * contract end-to-end without pulling in `useTandemSettings`.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  RailTab,
+  TandemSettings,
+  TandemSettingsState,
+} from "../../src/client/hooks/useTandemSettings.svelte.js";
+import { createLayoutModel } from "../../src/client/layout/model.svelte.js";
+
+function makeSettingsState(initial: Partial<TandemSettings>): TandemSettingsState {
+  let settings = $state<TandemSettings>({
+    // Minimal defaults — only the fields the layout model reads matter for tests.
+    leftPanelVisible: true,
+    rightPanelVisible: true,
+    soloRailHidden: false,
+    leftRailTabs: ["outline"] as RailTab[],
+    rightRailTabs: ["annotations", "chat"] as RailTab[],
+    primaryTab: "annotations",
+    showAuthorship: true,
+    theme: "system",
+    textSize: "md",
+    density: "comfortable",
+    editorFont: "serif",
+    editorWidthPx: 720,
+    panelOrder: "left-first",
+    dwellTimeMs: 1000,
+    degradedBannerDelayMs: 5000,
+    sidecarRetryStrategy: "exponential",
+    networkHoldAnnotations: false,
+    reduceMotion: false,
+    ...initial,
+  } as TandemSettings);
+
+  return {
+    get settings() {
+      return settings;
+    },
+    updateSettings(partial: Partial<TandemSettings>) {
+      settings = { ...settings, ...partial };
+    },
+  };
+}
+
+describe("LayoutModel visibility", () => {
+  it("leftVisible mirrors settings.leftPanelVisible", () => {
+    const settings = makeSettingsState({ leftPanelVisible: true });
+    const model = createLayoutModel(settings, { tandemMode: "tandem" });
+    expect(model.leftVisible).toBe(true);
+
+    settings.updateSettings({ leftPanelVisible: false });
+    expect(model.leftVisible).toBe(false);
+  });
+
+  it("rightVisible is true when settings.rightPanelVisible and not solo-hidden", () => {
+    const settings = makeSettingsState({ rightPanelVisible: true, soloRailHidden: false });
+    const model = createLayoutModel(settings, { tandemMode: "tandem" });
+    expect(model.rightVisible).toBe(true);
+  });
+
+  it("rightVisible is suppressed in solo mode when soloRailHidden is set", () => {
+    const settings = makeSettingsState({ rightPanelVisible: true, soloRailHidden: true });
+    const model = createLayoutModel(settings, { tandemMode: "solo" });
+    expect(model.rightVisible).toBe(false);
+  });
+
+  it("rightVisible stays true in tandem mode even when soloRailHidden is set", () => {
+    const settings = makeSettingsState({ rightPanelVisible: true, soloRailHidden: true });
+    const model = createLayoutModel(settings, { tandemMode: "tandem" });
+    expect(model.rightVisible).toBe(true);
+  });
+});
+
+describe("LayoutModel.toggleLeft", () => {
+  it("flips leftPanelVisible", () => {
+    const settings = makeSettingsState({ leftPanelVisible: true });
+    const model = createLayoutModel(settings, { tandemMode: "tandem" });
+    model.toggleLeft();
+    expect(settings.settings.leftPanelVisible).toBe(false);
+    model.toggleLeft();
+    expect(settings.settings.leftPanelVisible).toBe(true);
+  });
+});
+
+describe("LayoutModel.toggleRight", () => {
+  it("hides the right panel when currently visible", () => {
+    const settings = makeSettingsState({ rightPanelVisible: true, soloRailHidden: false });
+    const model = createLayoutModel(settings, { tandemMode: "tandem" });
+    model.toggleRight();
+    expect(settings.settings.rightPanelVisible).toBe(false);
+  });
+
+  it("shows the right panel and clears soloRailHidden in solo mode", () => {
+    const settings = makeSettingsState({ rightPanelVisible: false, soloRailHidden: true });
+    const model = createLayoutModel(settings, { tandemMode: "solo" });
+    model.toggleRight();
+    expect(settings.settings.rightPanelVisible).toBe(true);
+    expect(settings.settings.soloRailHidden).toBe(false);
+  });
+
+  it("does NOT touch soloRailHidden when toggling on in tandem mode", () => {
+    const settings = makeSettingsState({ rightPanelVisible: false, soloRailHidden: true });
+    const model = createLayoutModel(settings, { tandemMode: "tandem" });
+    model.toggleRight();
+    expect(settings.settings.rightPanelVisible).toBe(true);
+    expect(settings.settings.soloRailHidden).toBe(true);
+  });
+});
+
+describe("LayoutModel.moveTabs orphan-rail rule", () => {
+  it("reordering within the same side commits without touching the other rail", () => {
+    const settings = makeSettingsState({
+      leftRailTabs: ["outline"],
+      rightRailTabs: ["annotations", "chat"],
+    });
+    const model = createLayoutModel(settings, { tandemMode: "tandem" });
+    const ok = model.moveTabs("right", ["chat", "annotations"]);
+    expect(ok).toBe(true);
+    expect(settings.settings.rightRailTabs).toEqual(["chat", "annotations"]);
+    expect(settings.settings.leftRailTabs).toEqual(["outline"]);
+  });
+
+  it("moves a tab across rails when the source still has remaining tabs", () => {
+    const settings = makeSettingsState({
+      leftRailTabs: ["outline"],
+      rightRailTabs: ["annotations", "chat"],
+    });
+    const model = createLayoutModel(settings, { tandemMode: "tandem" });
+    // Move "chat" to left — right still has "annotations".
+    const ok = model.moveTabs("left", ["outline", "chat"]);
+    expect(ok).toBe(true);
+    expect(settings.settings.leftRailTabs).toEqual(["outline", "chat"]);
+    expect(settings.settings.rightRailTabs).toEqual(["annotations"]);
+  });
+
+  it("BLOCKS a move that would empty the other rail (orphan-rail rule)", () => {
+    const settings = makeSettingsState({
+      leftRailTabs: ["outline"],
+      rightRailTabs: ["annotations"],
+    });
+    const model = createLayoutModel(settings, { tandemMode: "tandem" });
+    // Move "annotations" to left would leave right empty.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ok = model.moveTabs("left", ["outline", "annotations"]);
+    expect(ok).toBe(false);
+    expect(settings.settings.leftRailTabs).toEqual(["outline"]);
+    expect(settings.settings.rightRailTabs).toEqual(["annotations"]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("blocked"),
+      expect.stringContaining("right"),
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+// vi.spyOn is referenced above
+import { vi } from "vitest";


### PR DESCRIPTION
## Summary

Implements **ADR-037** (see #697): extract the panel-visibility + rail-tab layout invariants from \`App.svelte\` into a dedicated rune store at \`src/client/layout/model.svelte.ts\`. The model encapsulates:

- **Visibility derivation** — \`leftVisible\` mirrors \`settings.leftPanelVisible\`; \`rightVisible\` is \`rightPanelVisible && !(solo && soloRailHidden)\`.
- **Toggle behaviour** — \`toggleLeft\` flips the persisted boolean; \`toggleRight\` additionally clears \`soloRailHidden\` when re-showing the right panel in solo mode (otherwise the toggle would be a no-op from the user's perspective).
- **Orphan-rail rule (block-toggle)** — \`moveTabs(side, newTabsForSide)\` returns \`false\` and emits a \`console.warn\` if the proposed move would leave the *other* rail empty. Current behaviour preserved; no auto-swap, no silent drop.

App.svelte's \`effectiveLeftVisible\` / \`effectiveRightVisible\` / \`toggleLeftPanel\` / \`toggleRightPanel\` / \`moveTabsBetweenRails\` are now thin shims over \`layoutModel\` — same local names, same call sites, so the template needs no changes.

This is part of the broader ADR pass surfaced by \`/improve-codebase-architecture\` (2026-05-15). Independent of PR 1 (ADR-031) and the other ADR work; reviewable in isolation.

## Commit sequence

1. **\`feat(layout): introduce LayoutModel rune store\`** — \`src/client/layout/model.svelte.ts\` with 11 unit tests at \`tests/client/layout-model.svelte.test.ts\` covering visibility, toggles, reordering, cross-rail moves, and the orphan-rail block.
2. **\`feat(layout): migrate App.svelte to LayoutModel\`** — replace inline derivation + functions with model getters and forwarding shims (-53 / +12 lines in App.svelte).

## Test plan

- [x] \`npx vitest run tests/client/layout-model.svelte.test.ts\` — 11/11 pass.
- [x] \`npx vitest run tests/client\` — **575 tests pass** (564 pre-existing + 11 new).
- [x] \`npm run typecheck\` — clean.
- [ ] **Manual smoke** — open Tandem, toggle left/right panels with the title bar buttons, drag a tab between rails, attempt to drain one rail entirely (expect block + warn). _Pending Bryan's manual verification._

## Why a getter-based factory (not a class)

ADR-037 originally framed the model as a class wrapping \`\$derived.by\` in getters; the implementation uses the closure-based factory pattern instead (matching \`useTandemSettings.svelte.ts\`) because:

- The codebase already standardised on \`create*\`-returning-an-object-with-getters for every other reactive store (settings, mode broadcast, density, theme, accent hue, etc.).
- Classes with rune fields are still a sharp edge in Svelte 5; the closure form has no instance-identity gotchas (e.g. \`feedback_svelte_getter_destructuring\`).
- Behaviour is identical from the consumer's perspective; the getters return the underlying \`\$derived\` values directly.

Refs ADR-037 (in #697).

🤖 Generated with [Claude Code](https://claude.com/claude-code)