### PR TITLE
feat(documents): named file-open entry points (ADR-034 part 1/N)

### DIFF
--- a/src/server/documents/open.ts
+++ b/src/server/documents/open.ts
@@ -1,0 +1,54 @@
+/**
+ * Named file-open entry points (ADR-034, part 1/N).
+ *
+ * This module is the published seam for opening documents into a Tandem
+ * session. ADR-034 calls for four named entry points:
+ *
+ *   - `openFromDisk(filePath, opts?)` — opens an existing file path on disk.
+ *   - `openFromUpload(fileName, content)` — opens browser-uploaded content
+ *     under a synthetic `upload://` path; the content is never written back.
+ *   - `openScratchpad()` — opens an empty ephemeral markdown buffer.
+ *   - `openFromRestore(sessionEntry)` — restores a previously-open document
+ *     from disk-cached session state. **Not yet exposed in part 1.**
+ *
+ * Part 1 (this PR) is an additive seam: each named entry forwards to the
+ * existing implementation in `src/server/mcp/file-opener.ts`. Callers can
+ * migrate their imports at their own pace. A follow-up PR moves the
+ * shared internal pipeline (path resolution, content prep, finalization)
+ * into this module and deletes the file-opener.ts façade.
+ *
+ * The `kindOfOpenResult` helper derives a tagged variant from the
+ * existing boolean-flag `OpenFileResult` so callers that want to branch
+ * on an enum instead of three booleans can do so today without waiting
+ * for the full shape migration.
+ */
+
+export {
+  type OpenFileResult,
+  openFileByPath as openFromDisk,
+  openFileFromContent as openFromUpload,
+  openScratchpad,
+} from "../mcp/file-opener.js";
+
+import type { OpenFileResult } from "../mcp/file-opener.js";
+
+/**
+ * Tagged variant for `OpenFileResult.kind` — derived from the existing
+ * `restoredFromSession` / `alreadyOpen` / `forceReloaded` booleans.
+ * ADR-034 part 2 promotes this to a real discriminator on the result
+ * type; part 1 exposes it as a derivation so callers can adopt the
+ * vocabulary now.
+ *
+ *   - `fresh`            — first time this session, content loaded from disk/upload/empty
+ *   - `restored`         — disk-cached session state was applied; no disk re-read
+ *   - `already-open`     — caller asked for a doc that's already tracked; no-op switch
+ *   - `force-reloaded`   — caller passed `force: true`; doc state replaced from disk
+ */
+export type OpenResultKind = "fresh" | "restored" | "already-open" | "force-reloaded";
+
+export function kindOfOpenResult(result: OpenFileResult): OpenResultKind {
+  if (result.forceReloaded) return "force-reloaded";
+  if (result.alreadyOpen) return "already-open";
+  if (result.restoredFromSession) return "restored";
+  return "fresh";
+}

--- a/tests/server/documents-open.test.ts
+++ b/tests/server/documents-open.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for the ADR-034 named file-open seam.
+ *
+ * Part 1/N is an additive re-export module. The behaviour assertions
+ * here cover:
+ *   - `openFromDisk` / `openFromUpload` / `openScratchpad` reference the
+ *     same callable identities as the underlying file-opener exports.
+ *   - `kindOfOpenResult` correctly tags every `OpenFileResult` shape.
+ *
+ * Behaviour-level tests of the open-pipelines themselves live in
+ * `file-opener-*.test.ts`; this file only covers the seam.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  kindOfOpenResult,
+  openFromDisk,
+  openFromUpload,
+  openScratchpad,
+} from "../../src/server/documents/open.js";
+import {
+  openScratchpad as fileOpenerScratchpad,
+  type OpenFileResult,
+  openFileByPath,
+  openFileFromContent,
+} from "../../src/server/mcp/file-opener.js";
+
+describe("named entry points (ADR-034 seam)", () => {
+  it("openFromDisk === openFileByPath", () => {
+    expect(openFromDisk).toBe(openFileByPath);
+  });
+
+  it("openFromUpload === openFileFromContent", () => {
+    expect(openFromUpload).toBe(openFileFromContent);
+  });
+
+  it("openScratchpad re-export matches the file-opener export", () => {
+    expect(openScratchpad).toBe(fileOpenerScratchpad);
+  });
+});
+
+describe("kindOfOpenResult", () => {
+  function baseResult(overrides: Partial<OpenFileResult>): OpenFileResult {
+    return {
+      documentId: "doc-1",
+      filePath: "/tmp/doc-1.md",
+      fileName: "doc-1.md",
+      format: "md",
+      readOnly: false,
+      source: "file",
+      tokenEstimate: 0,
+      pageEstimate: 0,
+      restoredFromSession: false,
+      alreadyOpen: false,
+      forceReloaded: false,
+      ...overrides,
+    };
+  }
+
+  it("returns 'force-reloaded' when forceReloaded is true (highest priority)", () => {
+    expect(
+      kindOfOpenResult(
+        baseResult({ forceReloaded: true, alreadyOpen: true, restoredFromSession: true }),
+      ),
+    ).toBe("force-reloaded");
+  });
+
+  it("returns 'already-open' when alreadyOpen is true but not force-reloaded", () => {
+    expect(kindOfOpenResult(baseResult({ alreadyOpen: true, restoredFromSession: true }))).toBe(
+      "already-open",
+    );
+  });
+
+  it("returns 'restored' when only restoredFromSession is true", () => {
+    expect(kindOfOpenResult(baseResult({ restoredFromSession: true }))).toBe("restored");
+  });
+
+  it("returns 'fresh' when none of the flags are set", () => {
+    expect(kindOfOpenResult(baseResult({}))).toBe("fresh");
+  });
+});


### PR DESCRIPTION
## Summary

First slice of **ADR-034** (see #697): adds \`src/server/documents/open.ts\` as the additive published seam for opening documents.

Part 1 re-exports the three existing entry points under their ADR-034 names:
| New name | Existing | Source |
|---|---|---|
| \`openFromDisk\` | \`openFileByPath\` | filesystem path |
| \`openFromUpload\` | \`openFileFromContent\` | uploaded buffer |
| \`openScratchpad\` | (same) | empty ephemeral md |

The fourth named entry — \`openFromRestore(sessionEntry)\` — is **not yet exposed**. Session restore today uses a dynamic-import workaround in \`document-service.ts\` that needs lifting into a clean function before it can land as a public entry. That refactor is scoped to part 2/N.

### Tagged result variant (additive)

\`kindOfOpenResult(result)\` derives a discriminator from the existing boolean-flag \`OpenFileResult\` so callers can branch on an enum today without waiting for the full result-shape migration:

\`\`\`ts
type OpenResultKind = \"fresh\" | \"restored\" | \"already-open\" | \"force-reloaded\";
\`\`\`

Priority: \`force-reloaded\` > \`already-open\` > \`restored\` > \`fresh\`.

## What this PR does NOT do

- **Does not** migrate the 6 callers of \`openFileByPath\` to \`openFromDisk\` — keeping the diff minimal lets reviewers focus on the seam contract.
- **Does not** introduce \`openFromRestore\` — the session-restore caller needs a dependency lift first.
- **Does not** promote \`OpenResultKind\` to a real discriminator on the result type. Part 2/N does this once the migration to named entries is underway.
- **Does not** move the shared internal pipeline (path resolution / content prep / finalization) into the new module — that's part 2/N.

## Test plan

- [x] \`npx vitest run tests/server/documents-open.test.ts\` — 7/7 pass:
  - Three re-export identity assertions.
  - Four exhaustive kind-tag derivations (\`fresh\`, \`restored\`, \`already-open\`, \`force-reloaded\`).
- [x] \`npm run typecheck\` clean.

## Sequencing notes

- Pairs cleanly with PR 3 / #708 (DocumentRegistry). Both extract from the \`mcp/\` directory into a new \`documents/\` directory.
- Will rebase cleanly against #702 (ADR-031 origin helpers) — this PR only adds a new file plus a test file; no modifications to existing files.

Refs ADR-034 (in #697).

🤖 Generated with [Claude Code](https://claude.com/claude-code)