### PR TITLE
feat(margin-view): add breathing-room gap and leader lines

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -534,7 +534,11 @@ const MARGIN_VIEW_RESERVE_PX =
 const editorMaxWidth = $derived.by(() => {
   const pct = settingsState.settings.editorWidthPercent;
   const reserve = settingsState.settings.marginView ? MARGIN_VIEW_RESERVE_PX : 0;
-  return reserve > 0 ? `calc(${pct}% - ${reserve}px)` : `${pct}%`;
+  // `max(0px, ...)` guards against `editorWidthPercent` settings that, on
+  // narrow viewports with marginView on, would compute a negative max-width.
+  // CSS clamps negative max-width to 0 anyway, but the explicit wrap keeps
+  // the resulting style declaration legible in devtools.
+  return reserve > 0 ? `max(0px, calc(${pct}% - ${reserve}px))` : `${pct}%`;
 });
 
 function captureSelectionForChat() {

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -520,10 +520,17 @@ function handleFilterChange(
   activeAnnotationFilter = { type, author, status };
 }
 
-// Margin annotation view reserves 240px column + 8px edge inset per side.
-// Subtract from available width so the editor text never sits underneath the
-// absolutely-positioned MarginColumn cards.
-const MARGIN_VIEW_RESERVE_PX = 2 * (240 + 8);
+// Margin annotation view reserves a column + edge inset + breathing-room gap
+// per side. Subtract from available width so the editor text never sits
+// underneath (or flush against) the absolutely-positioned MarginColumn cards.
+// `MARGIN_VIEW_GAP_PX` is the space between the editor's text edge and the
+// near edge of the margin column — it also defines the horizontal zone where
+// leader lines from anchor text to bubbles are drawn (see MarginColumn).
+const MARGIN_VIEW_COLUMN_WIDTH_PX = 240;
+const MARGIN_VIEW_EDGE_INSET_PX = 8;
+const MARGIN_VIEW_GAP_PX = 24;
+const MARGIN_VIEW_RESERVE_PX =
+  2 * (MARGIN_VIEW_COLUMN_WIDTH_PX + MARGIN_VIEW_EDGE_INSET_PX + MARGIN_VIEW_GAP_PX);
 const editorMaxWidth = $derived.by(() => {
   const pct = settingsState.settings.editorWidthPercent;
   const reserve = settingsState.settings.marginView ? MARGIN_VIEW_RESERVE_PX : 0;
@@ -1196,8 +1203,9 @@ const tutorial = createTutorial(
           side="left"
           annotations={marginNotes}
           positions={marginPositions.byId}
-          width={240}
-          edgeInset={8}
+          width={MARGIN_VIEW_COLUMN_WIDTH_PX}
+          edgeInset={MARGIN_VIEW_EDGE_INSET_PX}
+          gap={MARGIN_VIEW_GAP_PX}
           {activeAnnotationId}
           repliesById={marginReplies.byId}
           onClick={(ann) => {
@@ -1209,8 +1217,9 @@ const tutorial = createTutorial(
           side="right"
           annotations={marginComments}
           positions={marginPositions.byId}
-          width={240}
-          edgeInset={8}
+          width={MARGIN_VIEW_COLUMN_WIDTH_PX}
+          edgeInset={MARGIN_VIEW_EDGE_INSET_PX}
+          gap={MARGIN_VIEW_GAP_PX}
           {activeAnnotationId}
           repliesById={marginReplies.byId}
           onClick={(ann) => {

--- a/src/client/panels/MarginColumn.svelte
+++ b/src/client/panels/MarginColumn.svelte
@@ -51,6 +51,11 @@ let {
   onSendToClaude,
 }: Props = $props();
 
+// Vertical inset from the bubble's top edge to its padded content row. The
+// leader line endpoint is shifted down by this amount so a collision-pushed
+// bubble's connector lands near the title row rather than the empty corner.
+const LEADER_BUBBLE_INSET_PX = 12;
+
 // Only render annotations whose position is known this frame; without a top
 // offset there is nowhere to place the bubble.
 const placeable = $derived(
@@ -145,8 +150,8 @@ function recordHeight(id: string, h: number): void {
       {@const editorX = side === "right" ? 0 : gap}
       {@const columnX = side === "right" ? gap : 0}
       {@const isActive = ann.id === activeAnnotationId}
-      <!-- LEADER_BUBBLE_INSET_PX (12) shifts the bubble endpoint down from
-           the bubble's top edge into its padded content area, so a
+      <!-- LEADER_BUBBLE_INSET_PX shifts the bubble endpoint down from the
+           bubble's top edge into its padded content area, so a
            collision-pushed bubble's connector lands near the title row
            instead of pointing at the empty corner above it. -->
       <line
@@ -154,7 +159,7 @@ function recordHeight(id: string, h: number): void {
         x1={editorX}
         y1={rawTop}
         x2={columnX}
-        y2={adjTop + 12}
+        y2={adjTop + LEADER_BUBBLE_INSET_PX}
         stroke="currentColor"
         stroke-width={isActive ? 1.75 : 1}
         stroke-opacity={isActive ? 0.9 : 0.4}

--- a/src/client/panels/MarginColumn.svelte
+++ b/src/client/panels/MarginColumn.svelte
@@ -15,6 +15,10 @@ interface Props {
   width: number;
   /** Distance from the column edge to the nearest scroll-container edge. */
   edgeInset: number;
+  /** Horizontal gap between the editor's text edge and the near edge of this
+   *  column. Also defines the horizontal zone occupied by leader lines that
+   *  visually connect anchor text in the editor to the corresponding bubble. */
+  gap: number;
   activeAnnotationId: string | null;
   /** Raw replies grouped by annotation id. The component applies the
    *  `getVisibleReplies()` ADR-027 filter at the lookup site so notes /
@@ -35,6 +39,7 @@ let {
   side,
   width,
   edgeInset,
+  gap,
   activeAnnotationId,
   repliesById,
   onClick,
@@ -112,6 +117,42 @@ function recordHeight(id: string, h: number): void {
   heights = next;
 }
 </script>
+
+<!-- Leader-line SVG sits in the gap zone between the editor's text edge and
+     the column's near edge. Top/bottom stretch makes it cover the full layer
+     height so absolute Y coords (relative to the margin layer) line up with
+     `useMarginPositions` output. SVG default user units = pixels (no viewBox),
+     so we render lines directly at the computed Y offsets. Decorative only:
+     pointer-events: none, aria-hidden. -->
+<svg
+  data-testid="margin-leaders-{side}"
+  class="tandem-margin-leaders"
+  aria-hidden="true"
+  style="position: absolute; top: 0; bottom: 0; {side === 'right'
+    ? 'right'
+    : 'left'}: {edgeInset + width}px; width: {gap}px; pointer-events: none;"
+>
+  {#each placeable as ann (ann.id)}
+    {@const rawTop = positions.get(ann.id)}
+    {@const adjTop = adjustedPositions.get(ann.id)}
+    {#if rawTop !== undefined && adjTop !== undefined}
+      {@const editorX = side === "right" ? 0 : gap}
+      {@const columnX = side === "right" ? gap : 0}
+      {@const isActive = ann.id === activeAnnotationId}
+      <line
+        data-annotation-id={ann.id}
+        x1={editorX}
+        y1={rawTop}
+        x2={columnX}
+        y2={adjTop}
+        stroke={isActive ? "var(--tandem-fg-muted)" : "var(--tandem-border-strong)"}
+        stroke-width={isActive ? 1.5 : 1}
+        stroke-linecap="round"
+        fill="none"
+      />
+    {/if}
+  {/each}
+</svg>
 
 <div
   data-testid="margin-column-{side}"

--- a/src/client/panels/MarginColumn.svelte
+++ b/src/client/panels/MarginColumn.svelte
@@ -123,14 +123,20 @@ function recordHeight(id: string, h: number): void {
      height so absolute Y coords (relative to the margin layer) line up with
      `useMarginPositions` output. SVG default user units = pixels (no viewBox),
      so we render lines directly at the computed Y offsets. Decorative only:
-     pointer-events: none, aria-hidden. -->
+     pointer-events: none, aria-hidden.
+
+     Stroke is tinted by side (left = notes / user, right = comments / Claude)
+     to mirror the authorship decoration convention (ADR-026). Default uses
+     stroke-opacity to stay subtle; active review target ramps opacity + width
+     so the focused annotation's connector reads as the dominant line on the
+     page. -->
 <svg
   data-testid="margin-leaders-{side}"
   class="tandem-margin-leaders"
   aria-hidden="true"
   style="position: absolute; top: 0; bottom: 0; {side === 'right'
     ? 'right'
-    : 'left'}: {edgeInset + width}px; width: {gap}px; pointer-events: none;"
+    : 'left'}: {edgeInset + width}px; width: {gap}px; pointer-events: none; color: var(--tandem-author-{side === 'right' ? 'claude' : 'user'});"
 >
   {#each placeable as ann (ann.id)}
     {@const rawTop = positions.get(ann.id)}
@@ -139,14 +145,19 @@ function recordHeight(id: string, h: number): void {
       {@const editorX = side === "right" ? 0 : gap}
       {@const columnX = side === "right" ? gap : 0}
       {@const isActive = ann.id === activeAnnotationId}
+      <!-- LEADER_BUBBLE_INSET_PX (12) shifts the bubble endpoint down from
+           the bubble's top edge into its padded content area, so a
+           collision-pushed bubble's connector lands near the title row
+           instead of pointing at the empty corner above it. -->
       <line
         data-annotation-id={ann.id}
         x1={editorX}
         y1={rawTop}
         x2={columnX}
-        y2={adjTop}
-        stroke={isActive ? "var(--tandem-fg-muted)" : "var(--tandem-border-strong)"}
-        stroke-width={isActive ? 1.5 : 1}
+        y2={adjTop + 12}
+        stroke="currentColor"
+        stroke-width={isActive ? 1.75 : 1}
+        stroke-opacity={isActive ? 0.9 : 0.4}
         stroke-linecap="round"
         fill="none"
       />


### PR DESCRIPTION
## Summary

- At 100% editor width, margin comments sat flush against the editor's text edge (reserved space = column + edge inset, no gap). Added a 24px breathing-room gap on each side, folded into `MARGIN_VIEW_RESERVE_PX` so the centered editor naturally narrows by that amount.
- Render a subtle SVG leader line per bubble in the new gap zone, connecting `(editor_edge, rawTop)` to `(column_edge, adjustedTop + LEADER_BUBBLE_INSET_PX)` — so when collision pushes a bubble down, the line slopes down with it. Lines are decorative (`pointer-events: none`, `aria-hidden`).
- Stroke is tinted by side to mirror the authorship decoration convention (ADR-026): left/notes use `var(--tandem-author-user)`, right/comments use `var(--tandem-author-claude)`. Default stroke is `currentColor` at `stroke-width: 1` and `stroke-opacity: 0.4`; the active review target ramps to `stroke-width: 1.75` and `stroke-opacity: 0.9`.

## Files

- `src/client/App.svelte` — extracted `MARGIN_VIEW_COLUMN_WIDTH_PX` / `MARGIN_VIEW_EDGE_INSET_PX` / `MARGIN_VIEW_GAP_PX` constants; reserve now `2 * (col + inset + gap)`. Pass `gap` to both `MarginColumn` instances.
- `src/client/panels/MarginColumn.svelte` — accept `gap: number` prop. New sibling SVG before the column wrapper draws one `<line>` per placed annotation using existing `positions` (raw) and `adjustedPositions` (collision-adjusted) maps. SVG uses `top: 0; bottom: 0` to span the layer; no `viewBox` so user units = pixels. `LEADER_BUBBLE_INSET_PX = 12` named constant for the vertical endpoint offset.

## Test plan

- [ ] Toggle margin view on at 100% editor width — visible gap between text and bubbles, thin leader line connecting each bubble to its anchor text.
- [ ] Two overlapping comments — second bubble pushed down, leader line slopes correctly.
- [ ] Click a bubble — corresponding leader line gets the active stroke style (thicker, higher opacity).
- [ ] Toggle margin view off — no gap, no leader SVG (layer is `display: contents`).
- [ ] Existing E2E `tests/e2e/margin-view.spec.ts` still passes (testids `margin-column-{side}` and `margin-bubble-{id}` unchanged; new `margin-leaders-{side}` is a sibling).
- [ ] Dark theme — `--tandem-author-user` / `--tandem-author-claude` read subtly without disappearing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhFR2TL2jHsHNHuMG3XvJ5)_