### PR TITLE
polish(margin-view): hoist leader derived, drop dead class, add E2E

### DIFF
--- a/src/client/panels/MarginColumn.svelte
+++ b/src/client/panels/MarginColumn.svelte
@@ -51,10 +51,25 @@ let {
   onSendToClaude,
 }: Props = $props();
 
-// Vertical inset from the bubble's top edge to its padded content row. The
-// leader line endpoint is shifted down by this amount so a collision-pushed
-// bubble's connector lands near the title row rather than the empty corner.
+// Vertical inset from the bubble's top edge to its padded content row.
+// Mirrors `--tandem-space-3` (AnnotationCard's `padding` token) at the default
+// `cozy` density. Compact (10px) and spacious (16px) density modes shift the
+// title row by ±2-4px from this constant; matching exactly would require
+// reading `getComputedStyle(...).getPropertyValue("--tandem-space-3")` per
+// render — accepted as a known minor misalignment for now.
 const LEADER_BUBBLE_INSET_PX = 12;
+
+// Component-level $derived values for the leader SVG. `side`, `edgeInset`,
+// `gap`, `width` come from $props() and are themselves reactive, so these
+// recompute precisely when a prop changes. Hoisting `editorX`/`columnX` out
+// of the {#each} block avoids recomputing the same ternary per iteration;
+// `leaderStyle` collapses the previously dense inline-style template.
+const authorVar = $derived(side === "right" ? "claude" : "user");
+const editorX = $derived(side === "right" ? 0 : gap);
+const columnX = $derived(side === "right" ? gap : 0);
+const leaderStyle = $derived(
+  `position: absolute; top: 0; bottom: 0; ${side}: ${edgeInset + width}px; width: ${gap}px; pointer-events: none; color: var(--tandem-author-${authorVar});`,
+);
 
 // Only render annotations whose position is known this frame; without a top
 // offset there is nowhere to place the bubble.
@@ -135,20 +150,11 @@ function recordHeight(id: string, h: number): void {
      stroke-opacity to stay subtle; active review target ramps opacity + width
      so the focused annotation's connector reads as the dominant line on the
      page. -->
-<svg
-  data-testid="margin-leaders-{side}"
-  class="tandem-margin-leaders"
-  aria-hidden="true"
-  style="position: absolute; top: 0; bottom: 0; {side === 'right'
-    ? 'right'
-    : 'left'}: {edgeInset + width}px; width: {gap}px; pointer-events: none; color: var(--tandem-author-{side === 'right' ? 'claude' : 'user'});"
->
+<svg data-testid="margin-leaders-{side}" aria-hidden="true" style={leaderStyle}>
   {#each placeable as ann (ann.id)}
     {@const rawTop = positions.get(ann.id)}
     {@const adjTop = adjustedPositions.get(ann.id)}
     {#if rawTop !== undefined && adjTop !== undefined}
-      {@const editorX = side === "right" ? 0 : gap}
-      {@const columnX = side === "right" ? gap : 0}
       {@const isActive = ann.id === activeAnnotationId}
       <!-- LEADER_BUBBLE_INSET_PX shifts the bubble endpoint down from the
            bubble's top edge into its padded content area, so a

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -169,6 +169,76 @@ test("PR2: two overlapping comments produce non-overlapping bubbles", async ({ p
   expect(b.top).toBeGreaterThanOrEqual(a.bottom);
 });
 
+test("PR3: leader lines render and slope with collision adjustment", async ({ page }) => {
+  // Two adjacent comments on the same line force a collision: the lower
+  // bubble's `adjTop > rawTop`, so its leader connects raw editor anchor
+  // to pushed-down bubble (sloped). The upper bubble is uncollided, so its
+  // leader's `y2 - y1 === LEADER_BUBBLE_INSET_PX` (12) exactly.
+  //
+  // We read `y1`/`y2` directly off the SVG `<line>` attributes — these are
+  // the values the component wrote, untainted by viewport scroll, device
+  // pixel rounding, or layer-relative coordinate math (lesson #71). Sort
+  // by `y1` since `placeable` is annotation-array order, not visual order.
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_FROM + 4,
+    text: "first",
+    textSnapshot: TITLE_TEXT.slice(0, 4),
+  });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM + 5,
+    to: TITLE_TO,
+    text: "second",
+    textSnapshot: TITLE_TEXT.slice(5),
+  });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+
+  const leaderSvg = page.locator("[data-testid='margin-leaders-right']");
+  await expect(leaderSvg).toHaveCount(1, { timeout: 5_000 });
+  const lines = leaderSvg.locator("line[data-annotation-id]");
+  await expect(lines).toHaveCount(2, { timeout: 5_000 });
+
+  // Poll until the collision sweep has produced a visibly sloped lower line.
+  // The `> 12` predicate is what proves `adjTop > rawTop` (a real push), not
+  // just the constant LEADER_BUBBLE_INSET_PX offset.
+  await expect
+    .poll(
+      async () => {
+        const ys = await lines.evaluateAll((els) =>
+          els.map((el) => ({
+            y1: parseFloat(el.getAttribute("y1") ?? "NaN"),
+            y2: parseFloat(el.getAttribute("y2") ?? "NaN"),
+          })),
+        );
+        if (ys.length !== 2) return null;
+        if (!ys.every(({ y1, y2 }) => Number.isFinite(y1) && Number.isFinite(y2))) return null;
+        const sorted = [...ys].sort((a, b) => a.y1 - b.y1);
+        return sorted[1].y2 - sorted[1].y1;
+      },
+      { timeout: 5_000, message: "lower leader line must slope (collision pushed bubble down)" },
+    )
+    .toBeGreaterThan(12);
+
+  // Now snapshot once and verify both lines independently. Upper line is
+  // uncollided — `y2 - y1 === LEADER_BUBBLE_INSET_PX` exactly (no float ops
+  // between the assignment and the attribute), with <1px tolerance for any
+  // future subpixel jitter.
+  const ys = await lines.evaluateAll((els) =>
+    els.map((el) => ({
+      y1: parseFloat(el.getAttribute("y1") ?? "NaN"),
+      y2: parseFloat(el.getAttribute("y2") ?? "NaN"),
+    })),
+  );
+  const [upper, lower] = [...ys].sort((a, b) => a.y1 - b.y1);
+  expect(Math.abs(upper.y2 - upper.y1 - 12)).toBeLessThan(1);
+  expect(lower.y2 - lower.y1).toBeGreaterThan(12);
+});
+
 test("PR2: comment with a reply shows reply count in the bubble", async ({ page }) => {
   const open = await mcp.callTool("tandem_open", {
     filePath: path.join(tmpDir, "sample.md"),


### PR DESCRIPTION
## Summary

Follow-up polish for #711 addressing review findings. **This branch is stacked on top of #711's commits** — the diff currently shows 4 commits (3 from #711 plus the polish commit `9fe3fdd`). Once #711 merges, this PR's diff will narrow to just `9fe3fdd`.

Changes in `polish(margin-view): hoist leader derived, drop dead class, add E2E`:

- **Hoist leader `$derived` values to component scope.** `authorVar`, `editorX`, `columnX`, `leaderStyle` are declared once at the top of `MarginColumn.svelte`'s script. The dense inline-style template on the `<svg>` collapses to `style={leaderStyle}`, and the per-iteration `{@const editorX = ...}` / `{@const columnX = ...}` move out of the `{#each}` (they only depend on props, not the iteration variable). `isActive` stays as `{@const}` since it depends on `ann.id`.
- **Drop `class="tandem-margin-leaders"`** from the leader SVG. No CSS rule targets it; the testid is sufficient.
- **Sync note on `LEADER_BUBBLE_INSET_PX = 12`** documenting its coupling to `--tandem-space-3` (AnnotationCard's `padding` token) and the known ±2-4px visual misalignment in compact (10px) and spacious (16px) density modes. Matching exactly would require `getComputedStyle()` per render; accepted as a known minor visual offset.
- **New E2E test `PR3: leader lines render and slope with collision adjustment`** in `tests/e2e/margin-view.spec.ts`. Creates two adjacent comments to force a collision, asserts:
  - `[data-testid='margin-leaders-right']` mounts with exactly two `<line data-annotation-id>` children
  - Upper line (uncollided): `|y2 - y1 - 12| < 1` — proves `adjTop === rawTop` plus the constant `LEADER_BUBBLE_INSET_PX` offset
  - Lower line (collision-pushed): `y2 - y1 > 12` — proves the collision sweep actually pushed `adjTop` below `rawTop`

  Reads SVG attributes via `parseFloat` (not `getBoundingClientRect`) for determinism across scroll / DPI; sorts by `y1` for upper/lower ID since `placeable` is annotation-array order, not visual order; uses `expect.poll` instead of a fixed `waitForTimeout` to wait for the collision sweep to settle.

Also: the description on #711 has been updated so the stroke-color / stroke-width text matches what actually shipped (author tokens at 1 / 1.75 px, not border-strong at 1 / 1.5 px).

## Test plan

- [x] `npm run typecheck` — clean (svelte-check 0 errors, 0 warnings)
- [x] `npx vitest run tests/client/marginCollision.test.ts` — 15/15 pass
- [x] `npx playwright test tests/e2e/margin-view.spec.ts` — 8/8 pass (7 existing + 1 new)

https://claude.ai/code/session_01BhFR2TL2jHsHNHuMG3XvJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_014Rgut6DpTpT7dBtciS7nxt)_