### PR TITLE
feat(margin-view): rail-collapse + narrow-viewport auto-hide (#683)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Margin view auto-collapses on rail open or narrow viewport (#683)** — opening the left rail now hides only the left margin column; opening the right rail hides only the right column. When the viewport gets narrow enough that margin reserve + open rails + readable editor would crowd, both columns hide together. A 32px hysteresis band on the viewport threshold prevents flicker when a user drags through the boundary. New `useViewportWidth` rune store provides the rAF-debounced subscription.
+
 ## [0.12.0] - 2026-05-15
 
 ### Fixed

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -495,9 +495,14 @@ const viewport = createViewportWidth();
 // preserves margin annotations on the un-collapsed side and matches the user
 // mental model that "rail replaces margin." Both columns hide together when
 // `narrowSticky === true`.
+//
+// The threshold reads the persisted-at-mount rail widths (not the live
+// `dragResizeLeft/Right.width`) so it stays stable while a user is mid-drag.
+// Without this, the boundary slides under the drag and margin columns flip
+// on/off as the cursor moves — the 32px hysteresis below only absorbs
+// viewport-axis jitter, not threshold drift.
 const railsWidthPx = $derived(
-  (effectiveLeftVisible ? dragResizeLeft.width : 0) +
-    (effectiveRightVisible ? dragResizeRight.width : 0),
+  (effectiveLeftVisible ? leftPanelWidth : 0) + (effectiveRightVisible ? rightPanelWidth : 0),
 );
 const marginNarrowThresholdPx = $derived(
   MARGIN_VIEW_RESERVE_PX + railsWidthPx + MIN_EDITOR_WIDTH_PX,

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -59,6 +59,7 @@ import { createTheme } from "./hooks/useTheme.svelte";
 import { createTutorial } from "./hooks/useTutorial.svelte";
 import { createUpdateAvailable } from "./hooks/useUpdateAvailable.svelte";
 import { createUpdaterBanner } from "./hooks/useUpdaterBanner.svelte";
+import { createViewportWidth } from "./hooks/useViewportWidth.svelte";
 import { createWebViewZoom } from "./hooks/useWebViewZoom.svelte";
 import { createYjsSync } from "./hooks/yjsSync.svelte";
 import { createLayoutModel } from "./layout/model.svelte";
@@ -478,9 +479,49 @@ const MARGIN_VIEW_EDGE_INSET_PX = 8;
 const MARGIN_VIEW_GAP_PX = 24;
 const MARGIN_VIEW_RESERVE_PX =
   2 * (MARGIN_VIEW_COLUMN_WIDTH_PX + MARGIN_VIEW_EDGE_INSET_PX + MARGIN_VIEW_GAP_PX);
+
+// Below this readable editor width, margin columns auto-hide rather than
+// squeeze the editor into an unreadable strip. Pairs with a 32px hysteresis
+// band (`MARGIN_VIEW_HYSTERESIS_PX`) so a viewport drag through the threshold
+// doesn't flicker columns on/off at 60fps.
+const MIN_EDITOR_WIDTH_PX = 480;
+const MARGIN_VIEW_HYSTERESIS_PX = 32;
+
+const viewport = createViewportWidth();
+
+// Per-side rail-replaces-margin behavior (#683): when a rail is open, hide the
+// margin column on that side. Reasoning: rail + margin on the same side leaves
+// the editor crushed and visually competes for the same gutter. Hiding by side
+// preserves margin annotations on the un-collapsed side and matches the user
+// mental model that "rail replaces margin." Both columns hide together when
+// `narrowSticky === true`.
+const railsWidthPx = $derived(
+  (effectiveLeftVisible ? dragResizeLeft.width : 0) +
+    (effectiveRightVisible ? dragResizeRight.width : 0),
+);
+const marginNarrowThresholdPx = $derived(
+  MARGIN_VIEW_RESERVE_PX + railsWidthPx + MIN_EDITOR_WIDTH_PX,
+);
+
+// Hysteresis-debounced narrow flag. A plain `width < threshold` boundary
+// flickers when a user drags through it because each side of the threshold
+// re-evaluates on every frame. Sticky entry at `< threshold`, sticky exit at
+// `> threshold + HYSTERESIS` gives a 32px deadband.
+let narrowSticky = $state(false);
+$effect(() => {
+  const w = viewport.width;
+  const t = marginNarrowThresholdPx;
+  if (w < t) narrowSticky = true;
+  else if (w > t + MARGIN_VIEW_HYSTERESIS_PX) narrowSticky = false;
+});
+
+const marginViewEffectivelyOn = $derived(settingsState.settings.marginView && !narrowSticky);
+const marginLeftVisible = $derived(marginViewEffectivelyOn && !effectiveLeftVisible);
+const marginRightVisible = $derived(marginViewEffectivelyOn && !effectiveRightVisible);
+
 const editorMaxWidth = $derived.by(() => {
   const pct = settingsState.settings.editorWidthPercent;
-  const reserve = settingsState.settings.marginView ? MARGIN_VIEW_RESERVE_PX : 0;
+  const reserve = marginViewEffectivelyOn ? MARGIN_VIEW_RESERVE_PX : 0;
   // `max(0px, ...)` guards against `editorWidthPercent` settings that, on
   // narrow viewports with marginView on, would compute a negative max-width.
   // CSS clamps negative max-width to 0 anyway, but the explicit wrap keeps
@@ -761,12 +802,10 @@ const review = useAnnotationReview({
 // via DOM nesting in the positioning layer. Collision resolution lands in
 // PR 2; rail-collapse and narrow-layout auto-disable in PR 3.
 const marginNotes = $derived(
-  settingsState.settings.marginView
-    ? modeGate.visibleAnnotations.filter((a) => a.type === "note")
-    : [],
+  marginViewEffectivelyOn ? modeGate.visibleAnnotations.filter((a) => a.type === "note") : [],
 );
 const marginComments = $derived(
-  settingsState.settings.marginView
+  marginViewEffectivelyOn
     ? modeGate.visibleAnnotations.filter((a) => a.author === "import" || a.type === "comment")
     : [],
 );
@@ -775,7 +814,7 @@ const marginPositions = createMarginPositions({
   getYdoc: () => activeTab?.ydoc ?? null,
   getAnnotations: () => [...marginNotes, ...marginComments],
   getLayerEl: () => marginLayerEl,
-  getEnabled: () => settingsState.settings.marginView,
+  getEnabled: () => marginViewEffectivelyOn,
 });
 // Replies feed the bubble reply count + thread preview. We observe the raw
 // Y.Map here; MarginColumn applies the `getVisibleReplies()` ADR-027 filter
@@ -1128,7 +1167,7 @@ const tutorial = createTutorial(
          guard. -->
     <div
       bind:this={marginLayerEl}
-      style={settingsState.settings.marginView ? "position: relative;" : "display: contents;"}
+      style={marginViewEffectivelyOn ? "position: relative;" : "display: contents;"}
     >
       <!-- Editor renders paged white-sheet layout for .docx via the `.tandem-paged`
            class (driven by the `format` prop / `isPaged` $derived inside Editor.svelte).
@@ -1149,7 +1188,7 @@ const tutorial = createTutorial(
           {/if}
         </div>
       {/if}
-      {#if settingsState.settings.marginView && activeTab}
+      {#if marginLeftVisible && activeTab}
         <MarginColumn
           side="left"
           annotations={marginNotes}
@@ -1164,6 +1203,8 @@ const tutorial = createTutorial(
             review.scrollToAnnotation(ann);
           }}
         />
+      {/if}
+      {#if marginRightVisible && activeTab}
         <MarginColumn
           side="right"
           annotations={marginComments}

--- a/src/client/hooks/useViewportWidth.svelte.ts
+++ b/src/client/hooks/useViewportWidth.svelte.ts
@@ -1,0 +1,37 @@
+/**
+ * Reactive window.innerWidth rune store, rAF-debounced.
+ *
+ * Pattern lifted from Toolbar.svelte's local viewport tracker so consumers
+ * (margin-view, future responsive surfaces) share a single subscription
+ * shape. Each call to `createViewportWidth()` mounts its own listener +
+ * rAF; cheap relative to the resize event itself.
+ *
+ * Cleanup MUST call both `removeEventListener` AND `cancelAnimationFrame` —
+ * a queued frame after listener removal leaks across HMR reloads and would
+ * fire into a destroyed effect root.
+ */
+export function createViewportWidth(): { readonly width: number } {
+  let width = $state(window.innerWidth);
+
+  $effect(() => {
+    let frame: number | null = null;
+    const schedule = () => {
+      if (frame !== null) return;
+      frame = requestAnimationFrame(() => {
+        width = window.innerWidth;
+        frame = null;
+      });
+    };
+    window.addEventListener("resize", schedule);
+    return () => {
+      window.removeEventListener("resize", schedule);
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
+  });
+
+  return {
+    get width() {
+      return width;
+    },
+  };
+}

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -373,3 +373,137 @@ test("toggle off after on: columns disappear (validates display:contents wrapper
   await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
   await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(0);
 });
+
+/**
+ * #683 PR3 — Per-side rail-replaces-margin behavior. Opening the LEFT rail
+ * hides only the left margin column; the right column remains. Opening the
+ * RIGHT rail hides the right column. Default is per-side so margin
+ * annotations on the un-collapsed side stay visible — reasoning lives in
+ * App.svelte's `marginLeftVisible` / `marginRightVisible` derived blocks.
+ */
+test("PR3: opening a rail hides only that side's margin column", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "Margin candidate",
+    textSnapshot: TITLE_TEXT,
+  });
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+  const leftCol = page.locator("[data-testid='margin-column-left']");
+  const rightCol = page.locator("[data-testid='margin-column-right']");
+  await expect(leftCol).toHaveCount(1);
+  await expect(rightCol).toHaveCount(1);
+
+  // Open the LEFT rail → left column hides, right stays. The titlebar toggle
+  // is the same control surfaced to the user.
+  await page.locator("[data-testid='titlebar-toggle-left']").click();
+  await expect(leftCol).toHaveCount(0);
+  await expect(rightCol).toHaveCount(1);
+
+  // Close left, open right → right column hides, left returns.
+  await page.locator("[data-testid='titlebar-toggle-left']").click();
+  await expect(leftCol).toHaveCount(1);
+  await page.locator("[data-testid='titlebar-toggle-right']").click();
+  await expect(leftCol).toHaveCount(1);
+  await expect(rightCol).toHaveCount(0);
+});
+
+/**
+ * #683 PR3 — Narrow-viewport auto-hide. Below a computed threshold (margin
+ * reserve + open rails + minimum readable editor width), BOTH columns hide
+ * regardless of rail state, so the editor never gets crushed.
+ */
+test("PR3: narrow viewport hides both margin columns", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "Margin candidate",
+    textSnapshot: TITLE_TEXT,
+  });
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(1);
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+
+  // Shrink to a width well below threshold (reserve ≈ 544 + min 480 = 1024).
+  await page.setViewportSize({ width: 700, height: 900 });
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(0);
+
+  // Grow back to a wide viewport → columns return.
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(1);
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+});
+
+/**
+ * #683 PR3 — Hysteresis. The narrowSticky entry/exit bands are offset by
+ * MARGIN_VIEW_HYSTERESIS_PX (32) so a viewport drag through the threshold
+ * doesn't flip columns on/off at 60fps. We resize across the boundary three
+ * times (narrow → just-over → narrow) and confirm the columns end up in the
+ * narrow state without thrashing back to visible on the brief overshoot.
+ */
+test("PR3: boundary resize does not flicker (hysteresis)", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "Margin candidate",
+    textSnapshot: TITLE_TEXT,
+  });
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+
+  // Estimated threshold with no rails open: 544 reserve + 480 min editor = 1024.
+  // Drive narrow first, then a 20px overshoot (still inside the 32px deadband
+  // → must remain narrow), then back below. End state: narrow (both hidden).
+  await page.setViewportSize({ width: 1000, height: 900 });
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
+
+  await page.setViewportSize({ width: 1044, height: 900 });
+  // Inside the hysteresis band → must NOT flip back to visible.
+  await page.waitForTimeout(80);
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(0);
+
+  await page.setViewportSize({ width: 1000, height: 900 });
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
+});
+
+/**
+ * #683 PR3 — Disabling margin view restores the unreserved editor max-width.
+ * Without the reserve, the editor wrapper's `max-width` style is just the
+ * raw percent (no `max(0px, calc(…))` wrapping).
+ */
+test("PR3: disabling margin view restores editor max-width", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+
+  // The editor wrapper is the immediate parent of `.tandem-editor` (when not paged).
+  const wrapper = page
+    .locator(".tandem-editor")
+    .locator("xpath=ancestor::div[contains(@style,'max-width')][1]");
+
+  await setMarginView(page, true);
+  await expect.poll(async () => (await wrapper.getAttribute("style")) ?? "").toContain("max(");
+
+  await setMarginView(page, false);
+  await expect.poll(async () => (await wrapper.getAttribute("style")) ?? "").not.toContain("max(");
+});

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -44,10 +44,28 @@ async function openSettingsAndGotoCowork(page: import("@playwright/test").Page):
   await popover.getByRole("button", { name: "Claude Code/Cowork" }).click();
 }
 
+/**
+ * #683 PR3 — Per-side rail-replaces-margin gates margin columns on rail
+ * visibility. The product default has `rightPanelVisible=true`, which would
+ * hide the right margin column out of the box. Toggle each rail off only if
+ * currently visible (read via `aria-pressed` on the titlebar toggles) so we
+ * exercise the on-state of margin view, not the rail-default.
+ */
+async function closeBothRails(page: import("@playwright/test").Page): Promise<void> {
+  for (const side of ["left", "right"] as const) {
+    const btn = page.locator(`[data-testid='titlebar-toggle-${side}']`);
+    if ((await btn.getAttribute("aria-pressed")) === "true") {
+      await btn.click();
+      await expect(btn).toHaveAttribute("aria-pressed", "false");
+    }
+  }
+}
+
 async function setMarginView(
   page: import("@playwright/test").Page,
   enabled: boolean,
 ): Promise<void> {
+  if (enabled) await closeBothRails(page);
   await openSettingsAndGotoCowork(page);
   const popover = page.locator("[data-testid='settings-popover']");
   const toggleInput = popover.locator("[data-testid='margin-view-toggle'] input");

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -516,18 +516,19 @@ test("PR3: narrow-collapse does not overwrite persisted rail visibility", async 
   await page.goto("/");
   await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
 
-  // Seed a known panel-visibility state directly in settings so the assertion
-  // doesn't depend on product defaults that may drift.
-  await page.evaluate((key) => {
-    const raw = localStorage.getItem(key);
-    const parsed = raw ? JSON.parse(raw) : {};
-    parsed.rightPanelVisible = true;
-    parsed.leftPanelVisible = false;
-    localStorage.setItem(key, JSON.stringify(parsed));
-  }, TANDEM_SETTINGS_KEY);
-  await page.reload();
-  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+  // `setMarginView` closes both rails as a setup side effect (so existing
+  // tests don't trip on the default-right-rail visible behaviour). Run it
+  // first, THEN snapshot the rail state — this test is checking that the
+  // viewport sweep doesn't write to settings, not that the setup helper
+  // leaves them untouched.
   await setMarginView(page, true);
+
+  const before = await page.evaluate((key) => {
+    const raw = localStorage.getItem(key);
+    return raw
+      ? (JSON.parse(raw) as { rightPanelVisible?: unknown; leftPanelVisible?: unknown })
+      : null;
+  }, TANDEM_SETTINGS_KEY);
 
   // Sweep through the narrow boundary and back. Wait between transitions so
   // the $effect that drives narrowSticky actually runs — if it were ever to
@@ -537,15 +538,15 @@ test("PR3: narrow-collapse does not overwrite persisted rail visibility", async 
   await page.setViewportSize({ width: 1600, height: 900 });
   await page.waitForTimeout(120);
 
-  // Settings must reflect the seeded values exactly.
-  const persisted = await page.evaluate((key) => {
+  // Settings must reflect the pre-sweep snapshot exactly.
+  const after = await page.evaluate((key) => {
     const raw = localStorage.getItem(key);
     return raw
       ? (JSON.parse(raw) as { rightPanelVisible?: unknown; leftPanelVisible?: unknown })
       : null;
   }, TANDEM_SETTINGS_KEY);
-  expect(persisted?.rightPanelVisible).toBe(true);
-  expect(persisted?.leftPanelVisible).toBe(false);
+  expect(after?.rightPanelVisible).toBe(before?.rightPanelVisible);
+  expect(after?.leftPanelVisible).toBe(before?.leftPanelVisible);
 });
 
 /**

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -504,6 +504,51 @@ test("PR3: boundary resize does not flicker (hysteresis)", async ({ page }) => {
 });
 
 /**
+ * #683 PR3 — Auto-hide must not write user-intent state. The narrow-collapse
+ * flag is local to App.svelte; sweeping the viewport through and back across
+ * the threshold must leave `rightPanelVisible`/`leftPanelVisible` in
+ * `tandem:settings` untouched. Without this guarantee, a window resize would
+ * silently overwrite the user's persisted panel preferences.
+ */
+test("PR3: narrow-collapse does not overwrite persisted rail visibility", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+
+  // Seed a known panel-visibility state directly in settings so the assertion
+  // doesn't depend on product defaults that may drift.
+  await page.evaluate((key) => {
+    const raw = localStorage.getItem(key);
+    const parsed = raw ? JSON.parse(raw) : {};
+    parsed.rightPanelVisible = true;
+    parsed.leftPanelVisible = false;
+    localStorage.setItem(key, JSON.stringify(parsed));
+  }, TANDEM_SETTINGS_KEY);
+  await page.reload();
+  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+  await setMarginView(page, true);
+
+  // Sweep through the narrow boundary and back. Wait between transitions so
+  // the $effect that drives narrowSticky actually runs — if it were ever to
+  // touch settings, this is when it would.
+  await page.setViewportSize({ width: 700, height: 900 });
+  await page.waitForTimeout(120);
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.waitForTimeout(120);
+
+  // Settings must reflect the seeded values exactly.
+  const persisted = await page.evaluate((key) => {
+    const raw = localStorage.getItem(key);
+    return raw
+      ? (JSON.parse(raw) as { rightPanelVisible?: unknown; leftPanelVisible?: unknown })
+      : null;
+  }, TANDEM_SETTINGS_KEY);
+  expect(persisted?.rightPanelVisible).toBe(true);
+  expect(persisted?.leftPanelVisible).toBe(false);
+});
+
+/**
  * #683 PR3 — Disabling margin view restores the unreserved editor max-width.
  * Without the reserve, the editor wrapper's `max-width` style is just the
  * raw percent (no `max(0px, calc(…))` wrapping).


### PR DESCRIPTION
Closes #683. Margin view PR 3 of 3 from the Wave 1b plan.

## Summary

- **Per-side rail-replaces-margin** — opening the left rail hides only the left `MarginColumn`; opening the right rail hides only the right column. Annotations on the un-collapsed side stay visible. Matches the "rail replaces margin" mental model.
- **Narrow-viewport auto-hide** — below `MARGIN_VIEW_RESERVE_PX + open-rail widths + 480px min editor`, both columns hide so the editor doesn't get crushed.
- **32px hysteresis band** — sticky entry at `< threshold`, sticky exit at `> threshold + 32`, prevents flicker when a user drags through the boundary.
- **`useViewportWidth.svelte.ts`** — new rAF-debounced rune store. Cleanup releases both the resize listener and any queued frame to avoid HMR leaks.

## Plan trade-off (per-side vs. hide-both-when-either)

Defaulting to **per-side** (shipped here). Alternative — hide BOTH columns when either rail opens — is simpler but loses information on the un-collapsed side. Reviewer can redirect if preferred; the conditional render at `App.svelte` would collapse to a single `if (marginViewEffectivelyOn && !(effectiveLeftVisible || effectiveRightVisible))` guard.

## Test plan

- [x] `npm run typecheck` — 0 errors / 0 warnings
- [x] `npm test` — 2170 passed / 12 skipped
- [ ] `npm run test:e2e tests/e2e/margin-view.spec.ts` — 4 new specs cover open-left-rail / open-right-rail (per-side hide), narrow viewport (both hidden), boundary hysteresis (overshoot inside deadband does not flip back), and disabling margin view (max-width restored)
- [ ] Manual: drag window across 1000–1100px boundary with margin view on — columns stay narrow across the deadband, no flicker

https://claude.ai/code/session_01XgZwoqkPbyNfE3yFdjPgiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgZwoqkPbyNfE3yFdjPgiP)_