### PR TITLE
Move annotation filter chip into panel header

### DIFF
--- a/src/client/panels/FilterBar.svelte
+++ b/src/client/panels/FilterBar.svelte
@@ -11,7 +11,6 @@ interface Props {
   filterStatus: FilterStatus;
   hasFilters: boolean;
   open: boolean;
-  totalCount: number;
   onToggleOpen: () => void;
   onSetFilterType: (v: FilterType) => void;
   onSetFilterAuthor: (v: FilterAuthor) => void;
@@ -25,63 +24,15 @@ let {
   filterStatus,
   hasFilters,
   open,
-  totalCount,
   onToggleOpen,
   onSetFilterType,
   onSetFilterAuthor,
   onSetFilterStatus,
   onClearFilters,
 }: Props = $props();
-
-const filterLabel = $derived.by(() => {
-  if (!hasFilters) return "All";
-  const parts: string[] = [];
-  if (filterType !== "all") {
-    const labels: Record<FilterType, string> = {
-      all: "All",
-      highlight: "Highlights",
-      comment: "Comments",
-      note: "Notes",
-      "with-replacement": "With replacement",
-    };
-    parts.push(labels[filterType]);
-  }
-  if (filterAuthor !== "all") {
-    const labels: Record<FilterAuthor, string> = {
-      all: "Anyone",
-      claude: "Claude",
-      user: "You",
-      import: "Imported",
-    };
-    parts.push(labels[filterAuthor]);
-  }
-  if (filterStatus !== "all") {
-    const labels: Record<FilterStatus, string> = {
-      all: "Any status",
-      pending: "Pending",
-      accepted: "Accepted",
-      dismissed: "Dismissed",
-    };
-    parts.push(labels[filterStatus]);
-  }
-  return parts.join(" · ") || "All";
-});
 </script>
 
-{#if !open}
-  <!-- Collapsed summary chip -->
-  <div style="padding: 6px 16px; border-bottom: 1px solid var(--tandem-border);">
-    <button
-      data-testid="filter-bar-toggle"
-      onclick={onToggleOpen}
-      style="display: flex; align-items: center; gap: 4px; background: none; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-pill); padding: 3px 10px; font-size: var(--tandem-text-xs); color: var(--tandem-fg-subtle); cursor: pointer; white-space: nowrap;"
-    >
-      <span>{filterLabel} {totalCount}</span>
-      <span style="font-size: 9px; opacity: 0.7;">▾</span>
-      <span>Filter</span>
-    </button>
-  </div>
-{:else}
+{#if open}
   <!-- Expanded full filter row -->
   <div
     style="padding: 8px 16px; border-bottom: 1px solid var(--tandem-border); display: flex; gap: 4px; flex-wrap: wrap; align-items: center;"

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -186,6 +186,40 @@ const hasFilters = $derived(
   filterType !== "all" || filterAuthor !== "all" || filterStatus !== "all",
 );
 
+const filterLabel = $derived.by(() => {
+  if (!hasFilters) return "All";
+  const parts: string[] = [];
+  if (filterType !== "all") {
+    const labels: Record<FilterType, string> = {
+      all: "All",
+      highlight: "Highlights",
+      comment: "Comments",
+      note: "Notes",
+      "with-replacement": "With replacement",
+    };
+    parts.push(labels[filterType]);
+  }
+  if (filterAuthor !== "all") {
+    const labels: Record<FilterAuthor, string> = {
+      all: "Anyone",
+      claude: "Claude",
+      user: "You",
+      import: "Imported",
+    };
+    parts.push(labels[filterAuthor]);
+  }
+  if (filterStatus !== "all") {
+    const labels: Record<FilterStatus, string> = {
+      all: "Any status",
+      pending: "Pending",
+      accepted: "Accepted",
+      dismissed: "Dismissed",
+    };
+    parts.push(labels[filterStatus]);
+  }
+  return parts.join(" · ") || "All";
+});
+
 // `review` is a prop now (lifted to App.svelte) — see App.svelte for the single
 // useAnnotationReview() instantiation that both rails share.
 
@@ -384,6 +418,15 @@ function handleBulk(status: "accepted" | "dismissed") {
           ? "s"
           : ""}
       </span>
+      <button
+        data-testid="filter-bar-toggle"
+        onclick={() => (filterBarOpen = !filterBarOpen)}
+        style="display: flex; align-items: center; gap: 4px; background: none; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-pill); padding: 3px 10px; font-size: var(--tandem-text-xs); color: var(--tandem-fg-subtle); cursor: pointer; white-space: nowrap;"
+      >
+        <span>{filterLabel} {filteredData.filtered.length}</span>
+        <span style="font-size: 9px; opacity: 0.7;">▾</span>
+        <span>Filter</span>
+      </button>
     </div>
   </div>
 
@@ -394,7 +437,6 @@ function handleBulk(status: "accepted" | "dismissed") {
     {filterStatus}
     {hasFilters}
     open={filterBarOpen}
-    totalCount={filteredData.filtered.length}
     onToggleOpen={() => (filterBarOpen = !filterBarOpen)}
     onSetFilterType={(v) => { filterType = v; }}
     onSetFilterAuthor={(v) => { filterAuthor = v; }}


### PR DESCRIPTION
## Summary
- Inlined the collapsed "All N · Filter" pill into the Annotations panel header row instead of rendering as a separate strip below
- `FilterBar` now only renders the expanded filter row; the `filterLabel` derivation moves to `SidePanel` alongside the chip button
- Preserved the `filter-bar-toggle` testid so E2E helpers (`tests/e2e/helpers.ts`) continue to work

## Test plan
- [x] `svelte-check` clean
- [x] `npm test` (2170 passed)
- [ ] Verify in-app: chip appears in the Annotations header next to the pending-count badge; clicking expands the full filter row below


---
_Generated by [Claude Code](https://claude.ai/code/session_0154Whyo51bsNKsVPPNj3wEW)_