### PR TITLE
docs+ui(adr-038): MCP-first integration policy; Claude as default (Phases 1+2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Tandem"
   },
   "metadata": {
-    "description": "Tandem — collaborative AI-human document editor"
+    "description": "Tandem — collaborative AI-human document editor (MCP-first; Claude is the default integration)"
   },
   "plugins": [
     {
@@ -13,7 +13,7 @@
         "source": "github",
         "repo": "bloknayrb/tandem"
       },
-      "description": "Edit and iterate on documents with Claude — no copy-paste, real-time push via plugin monitor"
+      "description": "Edit and iterate on documents with any MCP-capable AI. Claude is the default and best-supported client today."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem",
   "version": "0.8.0",
-  "description": "Edit and iterate on documents with Claude — no copy-paste, real-time push via plugin monitor",
+  "description": "Edit and iterate on documents with any MCP-capable AI. Claude is the default and best-supported client today.",
   "author": {
     "name": "Tandem"
   },

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -43,3 +43,7 @@ git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
 - Check the existing CHANGELOG.md format to match style (indentation, heading levels, PR references)
 - If there's already an `[Unreleased]` section, show what to append, not a replacement
 - Omit empty categories (don't show "### Security" if there are no security commits)
+
+## Conventions
+
+Going forward, changelog entries follow [ADR-038](../../../docs/decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration) framing — write "your AI" / "the AI" generically; use "Claude" as the concrete example when a feature is Claude-specific (e.g. channel push, plugin monitor, cowork, auto-launcher, plugin marketplace). Past entries (v0.12.0 and earlier) are historical record and not rewritten.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Tandem -- Collaborative AI-Human Document Editor
 
+> **Scope of this file:** Claude Code project memory for contributors working on Tandem. Read by Claude when collaborating on this codebase. User-facing positioning and the MCP-first integration policy live in `README.md`, `docs/positioning.md`, and [ADR-038](docs/decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration). Tandem's integration contract is MCP; Claude is the default integration. This file is intentionally Claude-Code-specific because it IS Claude project memory — that's by design, not the product's positioning.
+
 ## Quick Reference
 - `npm run dev:server` -- Backend: Hocuspocus on :3478 + MCP HTTP on :3479
 - `npm run dev:client` -- Frontend: Vite on :5173
@@ -22,7 +24,7 @@
 - [Workflows](docs/workflows.md) -- Real-world usage patterns
 - [Agent Workflow](.claude/skills/issue-pipeline/SKILL.md) -- 10-step agent-driven issue pipeline (`/issue-pipeline`)
 - [Roadmap](docs/roadmap.md) -- Phase 2+ roadmap, future extensions
-- [Design Decisions](docs/decisions.md) -- ADRs (001-029)
+- [Design Decisions](docs/decisions.md) -- ADRs (001-038)
 - [Lessons Learned](docs/lessons-learned.md) -- 73 lessons including E2E testing gotchas, CORS-allowlist three-surface audits, DOM-nested scroll sync for content-anchored overlays, and schema-backed palette migrations
 
 ## Development Workflow

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ See the full [Roadmap](docs/roadmap.md) and [Known Limitations](docs/roadmap.md#
 - [Architecture](docs/architecture.md) — System design, data flows, coordinate systems, channel push
 - [Workflows](docs/workflows.md) — Claude Code usage patterns: text iteration, cross-referencing, multi-model
 - [Roadmap](docs/roadmap.md) — Phase 2+ roadmap, known issues, future extensions
-- [Design Decisions](docs/decisions.md) — ADR-001 through ADR-030
+- [Design Decisions](docs/decisions.md) — ADR-001 through ADR-038 (integration policy in [ADR-038](docs/decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration))
 - [Lessons Learned](docs/lessons-learned.md) — 73 implementation lessons
 
 ## CLI Commands

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -11,6 +11,7 @@
 ## ADR-003: MCP over REST for Claude Integration
 **Decision:** Expose tools via MCP (HTTP, formerly stdio) instead of a custom REST API.
 **Rationale:** Claude Code discovers MCP tools natively. No curl wrappers needed. Tools appear in Claude's tool list automatically. See ADR-012 for the stdio → HTTP migration.
+**See ADR-038:** the MCP contract here applies to any MCP-capable client, not only Claude. The title's "for Claude Integration" framing pre-dates ADR-038's policy.
 
 ## ADR-004: .docx Review-Only by Default
 **Decision:** .docx files open in review-only mode. Never overwrite the original.
@@ -116,9 +117,10 @@
 **Rationale:** Position bugs are the #1 source of annotation placement issues. Centralizing the logic makes it auditable and testable in isolation. The shared types enforce a consistent vocabulary across layers (`RangeValidation` instead of ad-hoc `{ valid, reason }` objects). Consumers import from one predictable location per layer.
 **Consequences:** `src/server/positions.ts` exports `validateRange`, `anchoredRange`, `resolveToElement`, `refreshRange`, `flatOffsetToRelPos`, `relPosToFlatOffset`. `src/client/positions.ts` exports `annotationToPmRange`, `pmSelectionToFlat`, `flatOffsetToPmPos`, `pmPosToFlatOffset`. Annotation and awareness extensions are significantly simpler — they delegate to the position module instead of containing conversion logic inline. 307 new server position tests + 168 expanded client tests.
 
-## ADR-019: Channel Shim for Push Notifications (Issue #106)
+## ADR-019: Channel Shim for Push Notifications (Issue #106) — Claude default integration
 
 **Status:** Accepted
+**See ADR-038:** documents the channel push transport for the Claude default integration. Other MCP-capable clients use the same `/api/events` SSE endpoint directly; the Claude Code subprocess + Channels API path described here is Claude-specific.
 **Context:** Claude Code previously relied on polling (`tandem_checkInbox`) to detect user actions — annotation accepts/dismisses, chat messages, document switches. Polling introduces latency (seconds between checks) and wastes tokens on empty responses. The Claude Code Channels API provides a push mechanism via `notifications/claude/channel`, but requires a stdio subprocess with specific SDK patterns.
 **Decision:** Implement a thin channel shim (`src/channel/index.ts`) as a separate process alongside the existing HTTP MCP server. The shim connects to the Tandem server's SSE endpoint (`GET /api/events`) and forwards events to Claude Code as channel notifications. Server-side Y.Map observers detect browser-originated changes and emit `TandemEvent` objects to an event queue. All MCP-initiated Y.Map writes are tagged with `doc.transact(() => { ... }, 'mcp')` to prevent echo.
 **Options considered:**
@@ -163,8 +165,9 @@
 **Rationale:** The old `suggestion` and `question` types weren't independent concepts — they were comments with extra metadata. Making that explicit in the type system reduces surface area (fewer schema values, fewer UI controls, fewer tool variants) without losing expressiveness. The `suggestedText` and `directedAt` fields are composable — a comment can be both a suggestion and directed at Claude.
 **Consequences:** `AnnotationTypeSchema` narrows from 5 to 3 values. Side panel filters replace "Suggestions"/"Questions" with "With replacement"/"For Claude". Browser toolbar collapses three buttons into one with toggles. `tandem_suggest` still works but is documented as a legacy shim. Existing annotations with `type: "suggestion"` or `type: "question"` are migrated on load.
 
-## ADR-023: Cowork Plugin Bridge — stdio via npx, not HTTP (PRs #301, #304)
+## ADR-023: Cowork Plugin Bridge — stdio via npx, not HTTP (PRs #301, #304) — Claude default integration
 **Status:** Accepted
+**See ADR-038:** documents the Cowork plugin bridge for the Claude default integration. Cowork is a Claude Desktop feature; the stdio-via-npx bridge described here is one of the six Claude-specific extras.
 **Context:** Claude Desktop's Cowork tab runs in an isolated VM and does NOT forward `localhost` HTTP MCP servers (either plugin-registered or globally registered in `claude_desktop_config.json`) into the VM. The Cowork support article confirms: *"Local MCP servers configured via claude_desktop_config.json... aren't available in Cowork."* Tandem originally registered a single plugin MCP entry: `{"type": "http", "url": "http://localhost:3479/mcp"}`. Cowork users saw zero `tandem_*` tools. We needed an empirical test and a distribution path that actually works.
 **Decision:** Ship a `tandem mcp-stdio` CLI subcommand (thin stdio↔HTTP proxy that speaks the MCP stdio transport, preflights `/health`, and relays JSON-RPC to `http://localhost:3479/mcp`). Plugin MCP entries use `{"command": "npx", "args": ["-y", "tandem-editor", "mcp-stdio"]}`. Same pattern for the channel shim. Global `claude_desktop_config.json` entries remain HTTP for host Desktop sessions.
 **Empirical findings (Phase 0 probes, 2026-04-15):**
@@ -188,6 +191,7 @@
 
 ## ADR-024: `bearer_methods_supported` is advisory metadata; Claude Code ignores it (Phase 2 spike)
 **Status:** Accepted (spike findings; enforcement change deferred to PR b)
+**See ADR-038:** the spike findings here are empirical observations against the Claude default integration. Equivalent validation against other MCP clients is best-effort.
 **Context:** The durable-annotations plan (`docs/superpowers/plans/2026-04-16-durable-annotations-cowork.md`) gates Phase 2 PR b (auth middleware) on two prerequisites. Task 5b asked: when `bearer_methods_supported` in the RFC 9728 Protected Resource Metadata is non-empty (e.g., `["header"]`), does Claude Code's MCP client change behavior — in particular, does it start sending an `Authorization` header? If yes, a conditional advertisement (`["header"]` when token active, `[]` when not — prescribed below) is necessary to avoid breaking the loopback-no-auth path. If no, the field is advisory and the flip has zero functional impact on connection behavior.
 
 The current server (`src/server/mcp/server.ts:207,217`) advertises `bearer_methods_supported: []` unconditionally. The endpoint was introduced in `c57d7210` (2026-03-26, "serve RFC 9728 metadata so newer Claude Code skips auth prompt") because, at that time, newer Claude Code versions were observed probing `/.well-known/oauth-protected-resource` before connecting, and without the endpoint the client offered "authenticate" instead of listing tools. That commit reports an empirical probe from Claude Code; this ADR records the same measurement one year later.
@@ -293,6 +297,7 @@ Probe instrumentation — `src/server/mcp/server.ts` patched to (a) advertise `b
 ## ADR-027: Annotation System Redesign — Audience-Based Model
 
 **Status:** Accepted
+**See ADR-038:** the `author: "claude" | "user" | "import"` constant and the `directedAt: enum(["claude"])` schema value defined here are preserved as pre-ADR-038 backward-compat artifacts. The wire-level string `"claude"` survives in exported annotation data; the data-model refactor milestone tied to `IntegrationConfig` (#477 PR 1) revisits both.
 **Context:** First-principles analysis of the annotation system (see `docs/annotation-system-analysis.md`) revealed that the type-based model (highlight / comment / flag) asks users "what kind of annotation?" when the natural question is "who is this for?" Users have three intents: instruct Claude, ask Claude a question, or leave a personal note. The current system encodes these indirectly through type choice and hidden sub-fields (`suggestedText`, `directedAt`), producing five visual presentations from three types. Additionally, `directedAt: "claude"` is vestigial — only Claude can set it (PR #382 removed the user's @Claude checkbox), meaning Claude directs comments at itself. `flag` overlaps with `highlight` (both mark text without additional info).
 **Decision:** Redesign around audience. Three user annotation types: `highlight` (visual marker, not sent to Claude), `note` (personal text annotation, findable but Claude doesn't act), `comment` (text annotation sent to Claude). Claude creates only comments (with optional `suggestedText` for tracked changes). Remove `flag` type, `directedAt` field, `tandem_highlight` tool, `tandem_flag` tool, `tandem_suggest` tool, and modal review mode. Notes have a "convert to comment" action. Import (Word) comments enter as notes for user triage. `checkInbox` surfaces only comments, not notes or highlights. Selection toolbar becomes a near-text popup with text input and two submit buttons ("Note to self" / "Comment") plus highlight color buttons.
 **Supersedes:** Parts of ADR-022 (type unification from 5→3). ADR-022's three types were `highlight`, `comment`, `flag`; ADR-027's three are `highlight`, `note`, `comment`.
@@ -308,6 +313,7 @@ Probe instrumentation — `src/server/mcp/server.ts` patched to (a) advertise `b
 ## ADR-028: Plugin Monitor URL and Auth Resolution — `userConfig` over Hardcoded Default
 
 **Status:** Proposed
+**See ADR-038:** the plugin monitor is one of the six Claude-specific extras built on top of the MCP contract. The URL/auth resolution policy here applies to the Claude monitor; other MCP clients connect to the same MCP HTTP endpoint without the plugin-host indirection.
 **Context:** `src/monitor/index.ts` hardcoded `http://localhost:3479` and `authFetch` in `src/shared/cli-runtime.ts` read only `TANDEM_AUTH_TOKEN`. In Cowork VM sessions the monitor connects to loopback inside the VM (not the host's server) and silently fails; in custom-port and LAN-dev setups the URL override was ignored entirely. Phase 0 probe (2026-05) confirmed: (a) Claude Code's `monitors[]` manifest schema (CLI 2.1.126) rejects `env` blocks — the proposed manifest-level env injection approach is impossible; (b) the documented channel for runtime config is `userConfig` + `CLAUDE_PLUGIN_OPTION_*` env exports.
 **Decision (v0.10.1):** Bake `CLAUDE_PLUGIN_OPTION_SERVER_URL` into `resolveTandemUrl()`'s precedence chain (before `TANDEM_URL`, after explicit override) and add peer function `resolveAuthToken()` with the same pattern for `CLAUDE_PLUGIN_OPTION_AUTH_TOKEN`. `authFetch` calls `resolveAuthToken()` instead of reading `TANDEM_AUTH_TOKEN` directly. Both the monitor and channel shim automatically benefit — no per-caller changes needed.
 **Precedence rationale:** The order is `explicit override → CLAUDE_PLUGIN_OPTION_* → TANDEM_*`. Plugin-host vars represent the per-install configured value (written into `settings.json` by the Cowork installer or set by the user via `userConfig` UI), so they are the canonical install-time configuration. `TANDEM_*` is reserved for ad-hoc per-shell overrides — common in dev workflows but secondary to a stable plugin install. The explicit programmatic override sits above both so test code (and any future caller that needs to force a value) can short-circuit env entirely. Operators relying on `TANDEM_URL` from a plugin context must clear `CLAUDE_PLUGIN_OPTION_SERVER_URL` (or unset both and use the loopback default).
@@ -672,3 +678,61 @@ Public surface (sketch):
 - Migrations stay in `useTandemSettings.ts`. The model trusts that `settingsState.settings` is v2-shaped.
 - Future features (rail collapse, density modes affecting rail width, additional `RailTab` values like `'search'` or `'history'`) land as model extensions, not as changes propagated across four files.
 - This is a client-only refactor; no ADR or memory entries about server architecture change. Pairs with no other ADR in this grilling pass — independent.
+
+## ADR-038: MCP-First Integration Policy; Claude as Default Integration
+
+**Status:** Accepted (2026-05-17)
+
+**Context:** Tandem started Claude-integrated because Claude Code was the MCP-capable client we built against. The integration contract — exposed via `src/server/mcp/`, the 26 MCP tools, and the channel API at `src/channel/` — is **MCP**, not Claude. But the docs, the marketing copy, several in-app surfaces (the Tauri "Claude Not Found" dialog, `sample/welcome.md`, the OnboardingTutorial, the EmptyState), the MCP tool descriptions (sent to *every* connecting MCP client during tool discovery), `package.json`'s npm-published description, and the `.claude-plugin/marketplace.json` install blurb all read as if Claude is the only possible integration. This conflicts with the multi-provider scope already locked in D4 (roadmap.md:462) — the v1.0 first-run wizard ships with a multi-provider model registry covering Anthropic + local LLM + OpenAI + Gemini — and with the top distribution risk recorded in `docs/positioning.md:75-77` ("Tandem currently requires Claude Code, which gates the audience to developers and technical users").
+
+This ADR records the policy that resolves the gap: Tandem is an MCP-first product; Claude is the default, deepest-supported integration; other MCP-capable clients are best-effort over the same MCP endpoint.
+
+**Decision §1 — canonical policy statement.** Every doc surface that states the policy quotes the following paragraphs verbatim:
+
+> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same 26 tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today.
+>
+> **Integration setup** runs through the integration setup wizard (#477 PR 3). Today's transitional behavior — Tandem auto-writing its MCP entry to Claude's config files on Tauri startup — is **deprecated when the wizard ships**. Going forward, every integration (Claude included) is configured via the wizard, never silently.
+
+Four terms have precise meanings; every doc surface uses them consistently:
+
+| Term | Meaning |
+|---|---|
+| **MCP contract** | The 26 MCP tools at `http://127.0.0.1:3479` and the SSE event stream at `/api/events`. Available to every MCP client. |
+| **Default integration** | Claude. Recommended in all install flows. Documented, tested, and the target of the first-run wizard's one-click setup. |
+| **Claude-specific extras** | Six features built on top of the MCP contract that only work with Claude today: (1) channel push (channel shim + plugin monitor), (2) `--dangerously-load-development-channels` flag wiring, (3) auto-launcher (#477 PR 4), (4) Cowork plugin bridge (`tandem mcp-stdio`), (5) Claude Code skill (`skills/tandem/SKILL.md`), (6) plugin marketplace artifacts (`.claude-plugin/`). |
+| **Best-effort, not validated** | What we say about other MCP clients today. We don't intentionally break them; we don't test them. The MCP HTTP endpoint is the same surface they all use. |
+
+**Claude-side dev tooling** (`CLAUDE.md`, `.claude/hooks/`, `.claude/agents/`, `.claude/skills/`) is contributor-facing automation for working ON Tandem — not user-facing integration. It is listed separately from "Claude-specific extras" to avoid conflation.
+
+**Decision §2 — auto-launch policy.** In v1.0, only Claude Code is auto-launched (#477 PR 4). Other entries in the multi-provider model registry (#477 PR 5) are recorded for configuration purposes but require user-driven startup. The wizard surfaces this asymmetry explicitly so users picking OpenAI / Gemini / a local LLM are not surprised that they have to launch the client themselves. Per-provider auto-launchers may be added in future ADRs.
+
+**Decision §2b — auto-configuration deprecation.** Today's silent configuration-writing behavior is deprecated. Two surfaces are affected:
+- (a) The Tauri-startup auto-write of Tandem's MCP entry to Claude's config files in `src-tauri/src/lib.rs`.
+- (b) The `tandem setup` CLI command in `src/cli/setup.ts`, which writes the same entries from the npm install path.
+
+Both are silent from the user's perspective today; both end when the integration setup wizard (#477 PR 3) ships. Replacements: the Tauri-startup behavior is replaced by first-run-wizard invocation; `tandem setup` becomes a TTY-mode wrapper that prompts for the same answers the GUI wizard collects. Auto-configuration code is removed in the same PR that lands the wizard. Until then, the existing behaviors continue to ship; users see a one-time toast on first launch after upgrade to v0.13.0+ announcing the upcoming change.
+
+**Auto-launch (§2) is unaffected by §2b.** §2 governs whether Tandem *spawns* the AI client at session start; §2b governs whether Tandem *writes its MCP entry to the AI client's config file* silently. The two are independent: auto-launch survives because it's the user-invoked Tandem app spawning a child process; auto-config dies because it's Tandem writing to another app's config without explicit consent. When the wizard ships and a user picks Claude, auto-launch still spawns Claude Code per the auto-launcher design.
+
+**Decision §3 — MCP and non-MCP providers.** MCP is the contract for *native* integrations. The multi-provider model registry (#477 PR 5) may include providers that don't speak MCP natively (OpenAI, Gemini); they integrate via Tandem's Agent SDK adapter (a future PR, likely ADR-039), not as direct MCP clients. Adapter-shim integrations are second-tier — the MCP contract is the canonical interface and the one that gets new tool surface first.
+
+**Decision §4 — Claude-specific code paths are encouraged, not tolerated.** Contributors may add Claude-specific code paths (additional channel push features, plugin manifests, hooks, skills, cowork extensions) without policy friction. The constraint is one-way: Claude-specific features are **additive**, not subtractive — the MCP contract continues to work for non-Claude clients. A Claude-specific feature that breaks the MCP contract for non-Claude clients is a regression; a Claude-specific feature that exists alongside the MCP contract is fine.
+
+**Consequences:**
+
+- User-facing copy uses "your AI" / "the AI" generically; Claude appears in concrete examples and as the default-recommended path. "Reference integration" remains technical contributor language and stays in this ADR; user-facing surfaces use plain language ("Claude works out of the box; other MCP clients need setup").
+- **Stays Claude-named-by-design** (no churn, no deprecation):
+  - `CLAUDE.md` body — Claude Code project memory for contributors working on Tandem.
+  - `.claude-plugin/marketplace.json` + `plugin.json` *structural* Claude-specificity — these are Claude-marketplace artifacts and the manifest schema is Claude's. (The descriptive blurb users read during `claude plugin install` is updated; the manifest structure stays.)
+  - `.claude/hooks/`, `.claude/agents/`, `.claude/skills/` — Claude Code dev-time automation.
+  - `src/server/mcp/launcher.ts` — auto-launcher is Claude-specific by design per §2.
+  - `src/client/components/CoworkOnboardingStep.svelte` — Cowork is a Claude Desktop feature per ADR-023.
+  - CSS tokens `--tandem-author-claude` / `--tandem-claude-focus-bg` — code-internal.
+- **Backward-compat artifacts preserved for v1.0; refactored when `IntegrationConfig` lands** (#477 PR 1):
+  - `author: "claude" | "user" | "import"` constant — the wire-level string `"claude"` survives in exported annotation data. User-facing deprecation messages are neutralized; the schema string is left for backward-compat.
+  - `directedAt: enum(["claude"])` schema value in `src/server/mcp/annotations.ts:347-376` — same rationale.
+  - `src/cli/setup.ts` `TargetKind = "claude-code" | "claude-desktop"` type — replaced by `IntegrationConfig`.
+- **Auto-launch parity:** v1.0 auto-launches Claude only. Per-provider auto-launchers are future work, each in its own ADR.
+- **MCP-bridge for non-MCP providers:** the OpenAI/Gemini adapter design is owned by a separate ADR (likely ADR-039) — this ADR commits to the approach but not the implementation.
+
+**Cross-references:** ADR-003 (MCP over REST), ADR-019 (Channel Shim — channel push transport), ADR-023 (Cowork Plugin Bridge — Cowork extra), ADR-024 (`bearer_methods_supported` — Claude Code empirical findings), ADR-027 (Annotation System Redesign — `author: "claude"` constant), ADR-028 (Plugin Monitor URL/Auth). Spike reports: `docs/spikes/plugin-monitor-viability-spike.md`, `docs/spikes/cli-session-resume-spike.md`, `docs/spikes/sidecar-launcher-spike.md`. Roadmap: `docs/roadmap.md` #477 + D4.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,6 +30,14 @@ The v0.12.0 prep batch (8 parallel units, PRs #634–#641) shipped 2026-05-14. W
 
 **Out of scope for v1.0:** authorship gutter (D2 picked per-character only), annotation thread reactions (D5), inline diff hunk-staging UI (D3 surface deferred — option B locked for v1.1 revisit), mobile/responsive (D7), author chip/avatar (D8), compact density (D9), most §1D refactors except #313.
 
+## Integration Policy (ADR-038)
+
+> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same 26 tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today.
+>
+> **Integration setup** runs through the integration setup wizard (#477 PR 3). Today's transitional behavior — Tandem auto-writing its MCP entry to Claude's config files on Tauri startup — is **deprecated when the wizard ships**.
+
+See [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration) for the full policy, the four-term glossary, the auto-launch and auto-configuration sub-decisions, and the list of Claude-specific extras vs Claude-side dev tooling. The integration picker work below (#477) is the materialization of this policy in code, not a new direction.
+
 ## Step 5: File I/O
 
 ### Goal
@@ -413,7 +421,7 @@ Remaining Cowork work (#316, #317, #322) is polish — making the installer turn
 
 First-run wizard that lets users choose their AI integration, plus dropping the browser distribution path entirely (Tauri-only going forward). The integration choice drives startup behavior, auto-launch strategy, and default layout. Triaged **Core** for v1.0 on 2026-05-14.
 
-**Motivation:** Claude's continuity features (CLAUDE.md, hooks, skills, memory) require spawning the real Claude Code CLI — an Agent SDK connection can't replicate them. The first-run wizard makes that explicit and exposes additional integration slots (Claude Desktop, local LLM, OpenAI, Gemini). The browser distribution path also added ongoing maintenance overhead (CORS, Host-header allowlist, `TANDEM_OPEN_BROWSER` branches, npm global install) without serving the primary Tauri user base.
+**Motivation:** The integration picker materializes [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration) — Tandem speaks MCP; Claude is the default. **The default integration's depth is a flagship feature**, not a constraint to route around: Claude's continuity features (CLAUDE.md, hooks, skills, memory) ride on top of the same `--session-id` + `--resume` spawn primitive Spike A validated, and the wizard's one-click Claude setup is what makes them accessible to non-developers. The wizard also exposes additional integration slots (Claude Desktop, local LLM, OpenAI, Gemini) per D4. The browser distribution path also added ongoing maintenance overhead (CORS, Host-header allowlist, `TANDEM_OPEN_BROWSER` branches, npm global install) without serving the primary Tauri user base.
 
 ### Phase 0: Required Spikes
 
@@ -429,9 +437,9 @@ All three Phase 0 spikes shipped. The two CLI integration spikes resolved 2026-0
 |----|---------|--------------|--------|
 | 1 | Schema + storage + migration framework (`IntegrationConfig` discriminated union, zod validator, atomic writes) | — | v1.0 wave 6 |
 | 2 | **Browser deprecation** — remove `TANDEM_OPEN_BROWSER`, `open-browser.ts`, npm CLI start path, CORS localhost wildcard | — (independent) | **SHIPPED** PR #637 |
-| 3 | First-run wizard UI — integration picker (D4 picked **option a, full-screen modal**), existing-user detection via `last-seen-version`, pre-selection from existing MCP config | PR 1 | v1.0 wave 6 |
-| 4 | Auto-launch + supervisor — spawn Claude Code CLI with correct flags, hook point after `Promise.all([startMcpServerHttp, startHocuspocus])`. **PR-4 quartet (#642–#645) hardens:** atomic `O_EXCL` temp+rename, mandatory `.claude.json` backup, schema validation, "backup-or-prompt" UX | PR 1 + #642–#645 quartet + ≥2-week feature-flag soak | v0.13.0 (hidden) → v1.0 (exposed) |
-| 5 | Multi-provider model registry (D4) — Anthropic + local LLM (#477) + OpenAI / Gemini / others; CRUD with per-model config; new Settings → Models page beyond the wizard | PR 4 | v1.0 wave 6 |
+| 3 | First-run wizard UI — integration picker (D4 picked **option a, full-screen modal**), existing-user detection via `last-seen-version`, pre-selection from existing MCP config. **Replaces auto-configuration of Claude** per ADR-038 §2b — every integration (Claude included) is configured via the wizard, never silently. `tandem setup` CLI becomes a TTY-mode wrapper around the wizard; auto-configuration code in `src-tauri/src/lib.rs` and `src/cli/setup.ts` is removed in this PR. | PR 1 | v1.0 wave 6 |
+| 4 | Auto-launch + supervisor — spawn Claude Code CLI with correct flags, hook point after `Promise.all([startMcpServerHttp, startHocuspocus])`. **PR-4 quartet (#642–#645) hardens:** atomic `O_EXCL` temp+rename, mandatory `.claude.json` backup, schema validation, "backup-or-prompt" UX. **Claude-specific by design** per ADR-038 §2 — other providers in the registry are user-driven startup for v1.0; per-provider auto-launchers are future work. | PR 1 + #642–#645 quartet + ≥2-week feature-flag soak | v0.13.0 (hidden) → v1.0 (exposed) |
+| 5 | Multi-provider model registry (D4) — Anthropic + local LLM (#477) + OpenAI / Gemini / others; CRUD with per-model config; new Settings → Models page beyond the wizard. Non-MCP providers (OpenAI, Gemini) integrate via Tandem's Agent SDK adapter per ADR-038 §3, not as direct MCP clients — adapter design owned by a future ADR (likely ADR-039); whether the adapter ships in v1.0 wave 6 or slips to v1.1 is open. | PR 4 | v1.0 wave 6 |
 
 ### Key Decisions (locked)
 
@@ -439,10 +447,21 @@ All three Phase 0 spikes shipped. The two CLI integration spikes resolved 2026-0
 - Tauri permissions use `core:` prefix
 - Hook point: AFTER `Promise.all([startMcpServerHttp, startHocuspocus])` fires, not at line 255
 - `TANDEM_OPEN_BROWSER` replaced with `TANDEM_TAURI_SIDECAR`
-- ~~Plugin monitor is canonical; launcher drops `--dangerously-load-development-channels`~~ **Overridden by Spike B (PR #712, 2026-05-17).** `--plugin-dir` does not activate `experimental.monitors[]` in Claude Code v2.1.143; the dev-channels flag remains functional. PR 4 keeps `--dangerously-load-development-channels server:tandem-channel` for v1.0. Revisit when Claude Code surfaces monitor activation via `--plugin-dir` or another zero-marketplace path (see `docs/spikes/plugin-monitor-viability-spike.md` "Follow-up issues").
+- ~~Plugin monitor is canonical; launcher drops `--dangerously-load-development-channels`~~ **Overridden by Spike B (PR #712, 2026-05-17) and grounded in [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration) §extras (auto-launcher is Claude-specific by design).** `--plugin-dir` does not activate `experimental.monitors[]` in Claude Code v2.1.143; the dev-channels flag remains functional. PR 4 keeps `--dangerously-load-development-channels server:tandem-channel` for v1.0. Revisit when Claude Code surfaces monitor activation via `--plugin-dir` or another zero-marketplace path (see `docs/spikes/plugin-monitor-viability-spike.md` "Follow-up issues", including F5 — the GitHub-marketplace install path validation promoted from a deferred item to a v1.0-blocking spike by the docs reframe).
 - Layout coupling server-side via extended `/api/info`; no client-side race
 - Existing users detected via `last-seen-version` file; wizard pre-selects based on existing MCP config
-- **D4 (2026-05-14):** first-run wizard is option (a) full-screen modal **with multi-provider model registry**. Anthropic + #477 local + OpenAI/Gemini/etc.; user CRUDs models with per-model config; the registry lives at Settings → Models, beyond the wizard.
+- **D4 (2026-05-14):** first-run wizard is option (a) full-screen modal **with multi-provider model registry**. Anthropic + #477 local + OpenAI/Gemini/etc.; user CRUDs models with per-model config; the registry lives at Settings → Models, beyond the wizard. Per [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration) §2, the wizard explicitly surfaces the auto-launch asymmetry — Claude auto-launches in v1.0; other providers require user-driven startup. Per ADR-038 §2b, the wizard *replaces* today's silent auto-configuration of Claude; auto-config code is removed in PR 3.
+
+### Deferred milestones (post-reframe)
+
+Tracked here so #477 PRs know what they inherit; not v1.0-blocking unless noted:
+
+- **Data-model refactor (PR 1):** when `IntegrationConfig` lands, `author: "claude" | "user" | "import"` becomes provider-keyed (or a `provider` sidecar field is added). `src/cli/setup.ts` `TargetKind` becomes registry-driven. CSS tokens `--tandem-author-claude` / `--tandem-claude-focus-bg` renamed when a second provider's authorship color is needed. See ADR-038 §consequences.
+- **Auto-configuration removal (PR 3):** `src-tauri/src/lib.rs` Tauri-startup auto-write + `src/cli/setup.ts` `tandem setup` command both removed in the PR that ships the wizard, per ADR-038 §2b. **Migration UX gap:** existing users have stale Tandem entries in `~/.claude.json` written by earlier Tandem versions; the wizard's first-run flow must detect pre-existing entries and either preserve them as "Claude Code: already configured" or re-prompt. Design decision owned by PR 3.
+- **F5 — GitHub-marketplace install validation:** promoted to a Phase 0-extended spike by the docs reframe (originally filed as a Spike B follow-up). Half-day probe of `claude plugin marketplace add github:bloknayrb/tandem` + `claude plugin install tandem@tandem-editor` against Claude Code v2.1.143+. Outcome determines whether the v1.0 README leads users to the marketplace one-command install or to the channel-shim install with `--dangerously-load-development-channels`. **Blocks the v1.0 marketing/documentation rewrite phase**, not the wizard PR itself.
+- **Per-provider auto-launchers:** ADR-038 §2 commits to Claude-only auto-launch for v1.0. If we add auto-launchers for Claude Desktop, local LLM, or OpenAI (via Agent SDK adapter), each gets its own ADR.
+- **MCP-bridge for non-MCP providers:** ADR-038 §3 commits to Agent SDK adapter for OpenAI/Gemini. Adapter design is a separate ADR (likely ADR-039); whether it ships in v1.0 wave 6 or slips to v1.1 is open.
+- **Other MCP-client validation:** Cursor, Continue.dev, Claude Desktop standalone (not via cowork) — none validated today. Tracked as follow-up; ADR-038 acknowledges the gap.
 
 ---
 
@@ -459,7 +478,7 @@ Triage source of truth: `docs/v10-triage.md` (per-row Core/Defer marks). Wave pl
 | D1  | Density × textSize collision                   | Density controls **interface chrome only**; font-size controls **editor body only**. Verified 2026-05-14 — `useDensity.ts` writes only `[data-density]` (→ `--tandem-space-*`); `App.svelte` writes only `--tandem-editor-font-size`. No collision. |
 | D2  | Authorship visual                              | **Per-character only**. Gutter and hybrid rejected. Defers the §1G gutter row in `docs/v10-triage.md`.                                    |
 | D3  | Diff/Apply-edit hunk staging                   | Option **B (modal-based)** locked for the v1.1 revisit; the surface itself defers from v1.0.                                              |
-| D4  | First-run wizard                               | Option **(a) full-screen modal** + **multi-provider model registry** (Anthropic + #477 local + OpenAI/Gemini/etc.). Settings → Models page beyond the wizard. |
+| D4  | First-run wizard                               | Option **(a) full-screen modal** + **multi-provider model registry** (Anthropic + #477 local + OpenAI/Gemini/etc.). Settings → Models page beyond the wizard. Per [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration) §2/§2b: wizard replaces silent auto-configuration of Claude; Claude is the only provider auto-launched in v1.0; non-MCP providers via Agent SDK adapter (ADR-039 TBD). |
 | D5  | Annotation reply thread                        | **Expanded thread, no reactions.**                                                                                                        |
 | D6  | Updater UX                                     | **Banner (#561) + small colored dot badge** on titlebar settings gear.                                                                    |
 | D7  | Mobile / narrow-window                         | **Defer.**                                                                                                                                |

--- a/docs/spikes/cli-session-resume-spike.md
+++ b/docs/spikes/cli-session-resume-spike.md
@@ -5,6 +5,8 @@
 **Claude Code version tested:** 2.1.143
 **Refs:** [#477](https://github.com/bloknayrb/tandem/issues/477) PR 4 (auto-launch supervisor), [#640](https://github.com/bloknayrb/tandem/pull/640) Spike C (precedent), `docs/roadmap.md:412–447`, anthropics/claude-code#44607.
 
+**Scope of validation:** validates the **Claude default integration** per [ADR-038](../decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration). Equivalent session-resume validation against other MCP-capable clients is best-effort and tracked separately.
+
 ## Goal
 
 Empirically validate that the auto-launch supervisor (#477 PR 4) can spawn Claude Code with a stable session identifier, kill and respawn, and have Claude recover prior conversation transcript. The *flag name* and contract semantics had to be probed against the installed binary; the multi-angle plan review surfaced conflicting assumptions about what flags actually exist in v2.1.143.

--- a/docs/spikes/docx-npm-spike.md
+++ b/docs/spikes/docx-npm-spike.md
@@ -5,6 +5,8 @@
 **Status:** Spike prototype only. NOT wired into MCP tools or the production
 save path. Verdict: **GO with caveats.**
 
+**Scope of validation:** this spike evaluates a file-format engine (docx write-back) and is independent of MCP-client integration. Listed alongside the integration spikes for completeness per [ADR-038](../decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration), which scopes the **Claude default integration** for the other spike reports.
+
 ## Goal
 
 Evaluate whether the [`docx`](https://www.npmjs.com/package/docx) npm package

--- a/docs/spikes/plugin-monitor-viability-spike.md
+++ b/docs/spikes/plugin-monitor-viability-spike.md
@@ -5,6 +5,8 @@
 **Claude Code version tested:** 2.1.143
 **Refs:** [#477](https://github.com/bloknayrb/tandem/issues/477) PR 4 (auto-launch supervisor), [Spike A](./cli-session-resume-spike.md), `docs/roadmap.md:421–447` (locked decision: "Plugin monitor is canonical; launcher drops `--dangerously-load-development-channels`").
 
+**Scope of validation:** validates the **Claude default integration** per [ADR-038](../decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration). The plugin monitor is one of the six Claude-specific extras; the channel shim is too. Other MCP clients receive events via the same `/api/events` SSE endpoint without either of these transports.
+
 ## Goal
 
 Validate two propositions:
@@ -123,7 +125,7 @@ The locked decision in `docs/roadmap.md:442` ("Plugin monitor is canonical; laun
 | # | Concern | Tracked |
 |---|---|---|
 | F1 | Revisit dropping `--dangerously-load-development-channels` when Claude Code surfaces monitor activation from `--plugin-dir` (or any other zero-marketplace path) | New issue, v1.1+ |
-| F2 | Publish Tandem to a GitHub-source marketplace and verify `claude plugin install tandem@tandem-editor` activates `experimental.monitors[].command` | New issue, v1.1+ |
+| F2 | Publish Tandem to a GitHub-source marketplace and verify `claude plugin install tandem@tandem-editor` activates `experimental.monitors[].command` | **Promoted to v1.0 marketing-rewrite blocker by [ADR-038](../decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration).** Half-day spike. Outcome determines whether the v1.0 README leads users to the marketplace one-command install or to the channel-shim install with `--dangerously-load-development-channels`. |
 | F3 | Update `docs/roadmap.md:442` to reflect that the "plugin monitor canonical / drop the flag" decision is conditional on Claude Code distribution changes, not a v1.0 invariant | Roadmap edit (small) |
 | F4 | Cross-platform reverification (macOS, Windows) before PR 4 commits to either path | PR 4 own follow-up |
 

--- a/docs/spikes/sidecar-launcher-spike.md
+++ b/docs/spikes/sidecar-launcher-spike.md
@@ -4,6 +4,8 @@
 **Date:** 2026-05-14
 **Refs:** [#477](https://github.com/bloknayrb/tandem/issues/477), integration system plan (`project_integration_system_plan.md`).
 
+**Scope of validation:** validates the **Claude default integration** per [ADR-038](../decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration). The launcher is Claude-specific by design (ADR-038 §2 — only Claude is auto-launched in v1.0; other providers in the model registry are user-driven startup).
+
 ## Goal
 
 Validate that the Tandem Node sidecar can be launched from a **non-Tauri parent**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem-editor",
   "version": "0.12.0",
-  "description": "Edit and iterate on documents with Claude — no copy-paste, real-time push via plugin monitor",
+  "description": "Edit and iterate on documents with any MCP-capable AI (Claude by default). Real-time push via plugin monitor or channel shim.",
   "repository": {
     "type": "git",
     "url": "https://github.com/bloknayrb/tandem"

--- a/sample/welcome.md
+++ b/sample/welcome.md
@@ -1,21 +1,21 @@
 # Welcome to Tandem
 
-Tandem lets you work on documents with Claude — highlight text and Claude sees it directly, no copy-paste needed. Because Claude connects via MCP, it brings all its knowledge and tools to the document.
+Tandem lets you work on documents with an AI — by default Claude, but any MCP-capable client can connect over MCP. You can highlight text and your AI sees it directly, no copy-paste needed. Because Tandem speaks MCP, your AI brings all its knowledge and tools to the document.
 
 ## Getting Started
 
 > Follow the tutorial in the bottom-left corner to learn the basics. You can dismiss it at any time. For a full walkthrough of all features, see the [User Guide](../docs/user-guide.md).
 
-Open Claude Code from any directory -- your Tandem tools are already configured. Both you and Claude can see and edit this document at the same time. Claude's cursor appears as a soft blue highlight on the paragraph being read.
+Open Claude Code from any directory — your Tandem tools are already configured. Both you and your AI can see and edit this document at the same time. Your AI's cursor appears as a soft blue highlight on the paragraph being read.
 
 ## Try These
 
-1. **Respond to a suggestion** -- Look at the highlighted text in this document. Open the side panel to accept or dismiss annotations, or press Ctrl+Shift+R for Review Mode.
-2. **Ask Claude a question** -- Select some text and press Ctrl+Shift+A, or type in the Chat panel.
-3. **Make an edit** -- Click anywhere in the document and start typing. You can simplify sentences, fix typos, or add new content.
+1. **Respond to a suggestion** — Look at the highlighted text in this document. Open the side panel to accept or dismiss annotations, or press Ctrl+Shift+R for Review Mode.
+2. **Ask a question** — Select some text and press Ctrl+Shift+A, or type in the Chat panel.
+3. **Make an edit** — Click anywhere in the document and start typing. You can simplify sentences, fix typos, or add new content.
 
 ## Sample Content
 
 The project launched in early 2025 with three core goals: simplify onboarding, reduce support tickets by 40%, and ship a self-service dashboard by Q3. The team completed the first two milestones ahead of schedule, but the dashboard timeline slipped due to an unexpected API redesign in May.
 
-> Once Claude connects, try asking it to help you improve this text -- you'll see highlights and suggestions appear in the side panel.
+> Once your AI connects, try asking it to help you improve this text — you'll see highlights and suggestions appear in the side panel.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -496,7 +496,7 @@ pub fn run() {
             });
 
             let open_i = MenuItem::with_id(app, MENU_OPEN, "Open Editor", true, None::<&str>)?;
-            let setup_i = MenuItem::with_id(app, MENU_SETUP, "Setup Claude", true, None::<&str>)?;
+            let setup_i = MenuItem::with_id(app, MENU_SETUP, "Setup AI Assistant", true, None::<&str>)?;
             let update_i = MenuItem::with_id(app, MENU_UPDATE, "Check for Updates", true, None::<&str>)?;
             let sep = PredefinedMenuItem::separator(app)?;
             let about_i = MenuItem::with_id(app, MENU_ABOUT, "About Tandem", true, None::<&str>)?;
@@ -1864,19 +1864,20 @@ fn is_leap(year: i64) -> bool {
     (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
 }
 
-/// Show a non-blocking dialog informing the user that Claude is not installed.
+/// Show a non-blocking dialog informing the user that no AI client was detected.
 fn show_no_claude_dialog(handle: &tauri::AppHandle) {
     use tauri_plugin_dialog::DialogExt;
 
     handle
         .dialog()
         .message(format!(
-            "No Claude installation found.\n\n\
-             Tandem works as a standalone editor, but AI collaboration \
-             features require Claude Desktop or Claude Code.\n\n\
+            "No AI client detected.\n\n\
+             Tandem works as a standalone editor. To collaborate with an AI, install \
+             an MCP-capable client. Claude (Claude Code or Claude Desktop) is the \
+             default and best-supported choice today.\n\n\
              Download Claude at: {CLAUDE_DOWNLOAD_URL}"
         ))
-        .title("Claude Not Found")
+        .title("No AI Client Detected")
         .show(|_| {});
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,8 +4,8 @@
  *
  * Usage:
  *   tandem            Start the Tandem server and open the editor
- *   tandem setup      Register Tandem MCP tools with Claude Code / Claude Desktop
- *   tandem setup --force  Register even if no Claude install is auto-detected
+ *   tandem setup      Register Tandem MCP tools with your AI client (Claude Code / Claude Desktop by default)
+ *   tandem setup --force  Register even if no AI install is auto-detected
  *   tandem --help     Show this help
  *   tandem --version  Show version
  */
@@ -46,7 +46,7 @@ if (args.includes("--help") || args.includes("-h")) {
 
 Usage:
   tandem                            Start Tandem server and open the editor
-  tandem setup                      Register MCP tools with Claude Code / Claude Desktop
+  tandem setup                      Register MCP tools with your AI client (Claude Code / Claude Desktop by default)
   tandem setup --force              Register to default paths regardless of detection
   tandem setup --with-channel-shim  Also register the stdio channel shim (legacy opt-in)
   tandem rotate-token               Rotate the auth token with a 60-second grace window

--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -207,7 +207,7 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
 
     {#if s.vethernetCidr !== null}
       <div data-testid="cowork-vethernet-cidr" style="font-size: 12px;">
-        Detected VM subnet: <code>{s.vethernetCidr}</code>
+        Detected Cowork environment: <code>{s.vethernetCidr}</code>
       </div>
     {/if}
 

--- a/src/client/components/EmptyState.svelte
+++ b/src/client/components/EmptyState.svelte
@@ -31,7 +31,7 @@ $effect(() => {
     <span>No document open. Click + in the tab bar or drop a file here.</span>
     {#if connected && !claudeActive}
       <span style="font-family: var(--tandem-font-sans); font-size: 13px; color: var(--tandem-fg-subtle);">
-        Tip: open Claude Code in this directory to start collaborating
+        Tandem works alongside Claude (the default integration) or any MCP-capable AI client.
       </span>
     {/if}
   {/if}

--- a/src/client/components/NetworkSettings.svelte
+++ b/src/client/components/NetworkSettings.svelte
@@ -66,7 +66,7 @@ const tokenRotatedAt = $derived(appInfo.info?.tokenRotatedAt);
       aria-hidden="true"
     ></span>
     <span style="font-size: 12px; color: var(--tandem-fg); flex: 1;">
-      {connected ? "Connected to claude-sidecar" : "Disconnected"}
+      {connected ? "Connected to Tandem server" : "Disconnected"}
       {#if reconnectAttempts > 0}
         <span style="color: var(--tandem-fg-subtle);">· {reconnectAttempts} retry attempt{reconnectAttempts === 1 ? "" : "s"}</span>
       {/if}

--- a/src/client/components/OnboardingTutorial.svelte
+++ b/src/client/components/OnboardingTutorial.svelte
@@ -25,7 +25,7 @@ const BASE_STEPS = [
   {
     id: "question",
     title: "Ask a question",
-    text: "Select text and click Comment to send a question to Claude — or click Note to keep a private thought to yourself. You can also use the Chat panel.",
+    text: "Select text and click Comment to send a question to your AI (Claude, in the default setup) — or click Note to keep a private thought to yourself. You can also use the Chat panel.",
   },
   {
     id: "edit",

--- a/src/client/components/SettingsModal.svelte
+++ b/src/client/components/SettingsModal.svelte
@@ -121,7 +121,7 @@ export const DEFAULT_SETTINGS_TABS: SettingsTab[] = [
   },
   {
     id: "claude-code",
-    label: "Claude Code/Cowork",
+    label: "AI Assistant",
     icon: "M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9L12 3Z",
     component: SettingsClaudeCodeTab,
   },

--- a/src/client/components/SettingsPopover.svelte
+++ b/src/client/components/SettingsPopover.svelte
@@ -58,7 +58,7 @@ const SECTIONS: Array<{ id: SettingsSection; label: string; icon: string }> = [
   },
   {
     id: "claude-code",
-    label: "Claude Code/Cowork",
+    label: "AI Assistant",
     icon: "M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9L12 3Z",
   },
   {
@@ -529,7 +529,7 @@ function aboutRows() {
                 </span>
               </div>
               <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-bottom: 6px;">
-                How long you must hold a selection before Claude notices it
+                How long you must hold a selection before your AI notices it
               </div>
               <input
                 data-testid="dwell-time-slider"

--- a/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
+++ b/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
@@ -11,6 +11,15 @@ import type { SettingsTabContext } from "../SettingsModal.svelte";
 let ctx: Partial<SettingsTabContext> = $props();
 </script>
 
+<p
+  style="font-size: 12px; line-height: 1.5; color: var(--tandem-fg-muted); margin: 0 0 var(--tandem-space-3);"
+>
+  Tandem connects to any MCP-capable AI client over its MCP endpoint. Claude (Claude Code and
+  Claude Desktop) is the default integration — auto-configured, tested, and the only client whose
+  channel-push, cowork, and auto-launch extras are validated today. Other clients can connect
+  manually using the MCP endpoint on the Network tab.
+</p>
+
 <div>
   <div class="settings-section-label">
     Selection Sensitivity:
@@ -19,7 +28,7 @@ let ctx: Partial<SettingsTabContext> = $props();
     </span>
   </div>
   <div style="font-size: 10px; color: var(--tandem-fg-subtle); margin-bottom: 6px;">
-    How long you must hold a selection before Claude notices it
+    How long you must hold a selection before your AI notices it
   </div>
   <input
     data-testid="settings-modal-dwell-time-slider"

--- a/src/client/editor/extensions/awareness.ts
+++ b/src/client/editor/extensions/awareness.ts
@@ -64,7 +64,7 @@ export function buildAwarenessDecorations(
 
           const label = document.createElement("span");
           label.className = "tandem-claude-cursor-label";
-          label.textContent = "Claude";
+          label.textContent = "AI";
           cursor.appendChild(label);
 
           return cursor;

--- a/src/client/editor/toolbar/ModeToggle.svelte
+++ b/src/client/editor/toolbar/ModeToggle.svelte
@@ -12,12 +12,12 @@ const { tandemMode, onModeChange }: Props = $props();
 <div
   data-testid="mode-toggle"
   role="group"
-  aria-label="Claude collaboration mode"
+  aria-label="AI collaboration mode"
   style="display: inline-flex; background: var(--tandem-surface-sunk); border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-2); padding: 2px; gap: 2px;"
 >
   <button
     data-testid="mode-solo-btn"
-    title="Write undisturbed — Claude only responds when you message"
+    title="Write undisturbed — your AI only responds when you message"
     aria-pressed={tandemMode === "solo"}
     onclick={() => onModeChange("solo")}
     style="height: 24px; padding: 0 10px; font-size: 12px; border: none; border-radius: var(--tandem-r-1); cursor: pointer;
@@ -35,7 +35,7 @@ const { tandemMode, onModeChange }: Props = $props();
   </button>
   <button
     data-testid="mode-tandem-btn"
-    title="Full collaboration — Claude reacts to selections and document changes"
+    title="Full collaboration — your AI reacts to selections and document changes"
     aria-pressed={tandemMode === "tandem"}
     onclick={() => onModeChange("tandem")}
     style="height: 24px; padding: 0 10px; font-size: 12px; border: none; border-radius: var(--tandem-r-1); cursor: pointer;

--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -198,7 +198,7 @@ function toggleAnchorExpand(msgId: string) {
       <div
         style="color: var(--tandem-fg-subtle); font-size: 13px; text-align: center; margin-top: 24px;"
       >
-        No messages yet. Select text and send a message to Claude.
+        No messages yet. Select text and send a message to your AI.
       </div>
     {/if}
     {#each messages as msg (msg.id)}
@@ -272,7 +272,7 @@ function toggleAnchorExpand(msgId: string) {
             ></span>
           {/each}
         </span>
-        <span>{claudeStatus ?? "Claude is thinking..."}</span>
+        <span>{claudeStatus ?? "Your AI is thinking..."}</span>
       </div>
     {/if}
     <div bind:this={messagesEndEl}></div>
@@ -307,7 +307,7 @@ function toggleAnchorExpand(msgId: string) {
       value={inputText}
       oninput={(e) => (inputText = (e.target as HTMLTextAreaElement).value)}
       onkeydown={handleKeyDown}
-      placeholder="Message Claude..."
+      placeholder="Message your AI..."
       rows={2}
       style="flex: 1; padding: var(--tandem-space-2); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-3); font-size: var(--tandem-text-base); resize: none; outline: none; font-family: inherit; background: var(--tandem-surface); color: var(--tandem-fg);"
     ></textarea>

--- a/src/client/shell/TitleBar.svelte
+++ b/src/client/shell/TitleBar.svelte
@@ -195,8 +195,8 @@ $effect(() => {
     {#if claudeActive}
       <span
         class="status-dot"
-        title="Claude is connected"
-        aria-label="Claude is connected"
+        title="AI assistant is connected"
+        aria-label="AI assistant is connected"
       ></span>
     {/if}
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -420,7 +420,7 @@ async function main() {
     console.error(`  WebSocket:   ws://127.0.0.1:${wsPort}`);
     console.error(`  Health:      http://127.0.0.1:${mcpPort}/health`);
     console.error("");
-    console.error("  Open Claude Code and ask Claude to review a document.");
+    console.error("  Open your AI client (Claude by default) and ask it to review a document.");
     console.error("");
   } else {
     // Stdio mode: MCP must start before Hocuspocus to beat Claude Code's init timeout

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -212,13 +212,13 @@ function notifyRangeFailure(
   });
 }
 
-/** Surface a deprecated-tool call to the user; without this, only Claude sees the failure. */
+/** Surface a deprecated-tool call to the user; without this, only the AI client sees the failure. */
 function notifyDeprecatedTool(toolName: string): void {
   pushNotification({
     id: generateNotificationId(),
     type: "annotation-error",
     severity: "warning",
-    message: `Claude tried a deprecated tool (${toolName}). Ask Claude to retry with tandem_comment.`,
+    message: `Your AI tried a deprecated tool (${toolName}). Ask it to retry with tandem_comment.`,
     toolName,
     errorCode: "DEPRECATED",
     dedupKey: `deprecated:${toolName}`,
@@ -373,7 +373,7 @@ export function registerAnnotationTools(server: McpServer): void {
         if (directedAt !== undefined)
           return mcpError(
             "DEPRECATED",
-            "directedAt is no longer supported — comments now always reach Claude. Drop the field from your call.",
+            "directedAt is no longer supported — comments now always reach the connected AI client. Drop the field from your call.",
           );
         const da = getDocAndAnnotations(documentId);
         if (!da) return noDocumentError();

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -512,13 +512,13 @@ export function registerDocumentTools(server: McpServer): void {
 
   server.tool(
     "tandem_status",
-    "Check editor status (no params), or set Claude's visible status text (pass text).",
+    "Check editor status (no params), or set your visible status text (pass text). The connected AI client's status appears in the editor's status bar.",
     {
       text: z.string().optional().describe("Status text to display — omit for read-only"),
       focusParagraph: z
         .number()
         .optional()
-        .describe("Index of paragraph Claude is focusing on (write mode only)"),
+        .describe("Index of paragraph the AI is focusing on (write mode only)"),
       focusOffset: z
         .number()
         .optional()

--- a/src/server/mcp/tutorial-annotations.ts
+++ b/src/server/mcp/tutorial-annotations.ts
@@ -21,7 +21,7 @@ const TUTORIAL_ANNOTATIONS: TutorialAnnotationDef[] = [
   {
     id: `${TUTORIAL_ANNOTATION_PREFIX}highlight-1`,
     type: "highlight",
-    targetText: "highlight text and Claude sees it",
+    targetText: "highlight text and your AI sees it",
     content: "This is a highlight \u2014 it marks text for attention without suggesting changes.",
     color: "yellow",
   },
@@ -29,7 +29,7 @@ const TUTORIAL_ANNOTATIONS: TutorialAnnotationDef[] = [
     id: `${TUTORIAL_ANNOTATION_PREFIX}comment-1`,
     type: "comment",
     targetText: "edit this document at the same time",
-    content: "Comments let you or Claude leave notes on specific text passages.",
+    content: "Comments let you or your AI leave notes on specific text passages.",
   },
   {
     id: `${TUTORIAL_ANNOTATION_PREFIX}suggest-1`,
@@ -43,7 +43,7 @@ const TUTORIAL_ANNOTATIONS: TutorialAnnotationDef[] = [
     type: "note",
     targetText: "accept or dismiss",
     content:
-      "Notes are personal \u2014 Claude won\u2019t act on them unless you convert them to comments.",
+      "Notes are personal \u2014 your AI won\u2019t act on them unless you convert them to comments.",
   },
 ];
 

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -41,7 +41,7 @@ async function openSettingsAndGotoCowork(page: import("@playwright/test").Page):
   await page.locator("[data-testid='settings-btn']").click();
   const popover = page.locator("[data-testid='settings-popover']");
   await expect(popover).toBeVisible({ timeout: 2_000 });
-  await popover.getByRole("button", { name: "Claude Code/Cowork" }).click();
+  await popover.getByRole("button", { name: "AI Assistant" }).click();
 }
 
 async function setMarginView(

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -65,7 +65,7 @@ test("settings popover opens via settings-btn and exposes dwell slider", async (
     "page",
   );
 
-  await popover.getByRole("button", { name: "Claude Code/Cowork" }).click();
+  await popover.getByRole("button", { name: "AI Assistant" }).click();
   // Dwell slider is present and adjustable — proves the new slider and its
   // testid are wired up. The actual broadcast into CTRL_ROOM is covered by
   // the event-queue-dwell unit test; here we just verify the UI surface.
@@ -142,7 +142,7 @@ test("settings dialog sections and About panel reflect the redesign closeout", a
     "Editor",
     "Accessibility",
     "Collaboration",
-    "Claude Code/Cowork",
+    "AI Assistant",
     "Shortcuts",
     "About",
   ]) {
@@ -184,7 +184,7 @@ test("selection toolbar toggle persists and drives toolbar visibility", async ({
   await page.locator("[data-testid='settings-btn']").click();
   const popover = page.locator("[data-testid='settings-popover']");
   await expect(popover).toBeVisible({ timeout: 2_000 });
-  await popover.getByRole("button", { name: "Claude Code/Cowork" }).click();
+  await popover.getByRole("button", { name: "AI Assistant" }).click();
 
   const toggle = popover.locator("[data-testid='selection-toolbar-toggle'] input");
   if (await toggle.isChecked()) {
@@ -209,7 +209,7 @@ test("selection toolbar toggle persists and drives toolbar visibility", async ({
 
   await page.locator("[data-testid='settings-btn']").click();
   const reopenedPopover = page.locator("[data-testid='settings-popover']");
-  await reopenedPopover.getByRole("button", { name: "Claude Code/Cowork" }).click();
+  await reopenedPopover.getByRole("button", { name: "AI Assistant" }).click();
   const reopenedToggle = reopenedPopover.locator("[data-testid='selection-toolbar-toggle'] input");
   if (!(await reopenedToggle.isChecked())) {
     await reopenedToggle.check();
@@ -519,7 +519,7 @@ test("dwell-time slider value persists across reload", async ({ page }) => {
   await page.locator("[data-testid='settings-btn']").click();
   const popover = page.locator("[data-testid='settings-popover']");
   await expect(popover).toBeVisible();
-  await popover.getByRole("button", { name: "Claude Code/Cowork" }).click();
+  await popover.getByRole("button", { name: "AI Assistant" }).click();
   const slider = popover.locator("[data-testid='dwell-time-slider']");
   await expect(slider).toBeVisible({ timeout: 2_000 });
 
@@ -549,7 +549,7 @@ test("dwell-time slider value persists across reload", async ({ page }) => {
   await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
   await page.locator("[data-testid='settings-btn']").click();
   const reloadedPopover = page.locator("[data-testid='settings-popover']");
-  await reloadedPopover.getByRole("button", { name: "Claude Code/Cowork" }).click();
+  await reloadedPopover.getByRole("button", { name: "AI Assistant" }).click();
   const reloadedSlider = reloadedPopover.locator("[data-testid='dwell-time-slider']");
   await expect(reloadedSlider).toHaveValue("2000");
 });

--- a/tests/e2e/settings-modal.spec.ts
+++ b/tests/e2e/settings-modal.spec.ts
@@ -99,7 +99,7 @@ test("tab switching shows tab-specific content", async ({ page }) => {
   await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
   await openSettingsModal(page);
 
-  // Claude Code/Cowork tab.
+  // AI Assistant tab (id preserved as "claude-code" for backward compatibility).
   await page.locator("[data-testid='settings-modal-tab-claude-code']").click();
   await expect(page.locator("[data-testid='settings-modal-dwell-time-slider']")).toBeVisible();
   await expect(

--- a/tests/fixtures/welcome-snapshot.md
+++ b/tests/fixtures/welcome-snapshot.md
@@ -1,21 +1,21 @@
 # Welcome to Tandem
 
-Tandem lets you work on documents with Claude — highlight text and Claude sees it directly, no copy-paste needed. Because Claude connects via MCP, it brings all its knowledge and tools to the document.
+Tandem lets you work on documents with an AI — by default Claude, but any MCP-capable client can connect over MCP. You can highlight text and your AI sees it directly, no copy-paste needed. Because Tandem speaks MCP, your AI brings all its knowledge and tools to the document.
 
 ## Getting Started
 
 > Follow the tutorial in the bottom-left corner to learn the basics. You can dismiss it at any time. For a full walkthrough of all features, see the [User Guide](../docs/user-guide.md).
 
-Open Claude Code from any directory -- your Tandem tools are already configured. Both you and Claude can see and edit this document at the same time. Claude's cursor appears as a soft blue highlight on the paragraph being read.
+Open Claude Code from any directory — your Tandem tools are already configured. Both you and your AI can see and edit this document at the same time. Your AI's cursor appears as a soft blue highlight on the paragraph being read.
 
 ## Try These
 
-1. **Respond to a suggestion** -- Look at the highlighted text in this document. Open the side panel to accept or dismiss annotations, or press Ctrl+Shift+R for Review Mode.
-2. **Ask Claude a question** -- Select some text and press Ctrl+Shift+A, or type in the Chat panel.
-3. **Make an edit** -- Click anywhere in the document and start typing. You can simplify sentences, fix typos, or add new content.
+1. **Respond to a suggestion** — Look at the highlighted text in this document. Open the side panel to accept or dismiss annotations, or press Ctrl+Shift+R for Review Mode.
+2. **Ask a question** — Select some text and press Ctrl+Shift+A, or type in the Chat panel.
+3. **Make an edit** — Click anywhere in the document and start typing. You can simplify sentences, fix typos, or add new content.
 
 ## Sample Content
 
 The project launched in early 2025 with three core goals: simplify onboarding, reduce support tickets by 40%, and ship a self-service dashboard by Q3. The team completed the first two milestones ahead of schedule, but the dashboard timeline slipped due to an unexpected API redesign in May.
 
-> Once Claude connects, try asking it to help you improve this text -- you'll see highlights and suggestions appear in the side panel.
+> Once your AI connects, try asking it to help you improve this text — you'll see highlights and suggestions appear in the side panel.

--- a/tests/server/tutorial-annotations.test.ts
+++ b/tests/server/tutorial-annotations.test.ts
@@ -34,7 +34,7 @@ const FIXTURE_PATH = path.join(__dirname, "..", "fixtures", "welcome-snapshot.md
 // If this list drifts from the production module, the count assertion below
 // will catch it.
 const EXPECTED_TARGETS = [
-  "highlight text and Claude sees it",
+  "highlight text and your AI sees it",
   "edit this document at the same time",
   "simplify onboarding",
   "accept or dismiss",


### PR DESCRIPTION
## Summary

Phases 1 and 2 of a three-phase docs/UX reframe. Records the **MCP-first integration policy** (Phase 1) as ADR-038 and follows up with the **UI surface sweep** (Phase 2) so user-visible strings describe Tandem's MCP contract generically, with Claude as the concrete default example rather than the assumed subject.

Phase 3 (README rewrite + positioning.md / architecture.md / mcp-tools.md updates) is gated on F2 (the marketplace install spike) and the integration setup wizard landing (#477 PR 3), and ships as a separate PR.

## Phase 1 — Policy on record (commit 1)

Pure docs/policy; zero code, zero test impact.

- **`docs/decisions.md` — ADR-038** with the canonical policy paragraph (every other doc surface quotes it verbatim) and a four-term glossary that gives "Claude-specific extras" a precise meaning:
  - §1 — Canonical policy statement
  - §2 — Auto-launch policy (Claude only in v1.0)
  - §2b — **Auto-configuration deprecation** (both the Tauri-startup auto-write and the `tandem setup` CLI command are deprecated when the wizard ships per #477 PR 3; auto-launch survives, auto-config dies)
  - §3 — MCP vs non-MCP providers (OpenAI/Gemini via Agent SDK adapter, separate future ADR)
  - §4 — Claude-specific code paths are **encouraged**, not tolerated — additive, never subtractive
  - Backward-compat artifacts (`author: "claude"`, `directedAt: enum(["claude"])`, `TargetKind`) preserved with an explicit data-model-refactor milestone
- **Back-references** appended to ADR-003, ADR-019, ADR-023, ADR-024, ADR-027, ADR-028. ADR-019 and ADR-023 titles suffixed with "Claude default integration" for index clarity.
- **`docs/roadmap.md`** — new Integration Policy subsection near the top; #477 motivation reframed (the wizard's depth on Claude is a flagship feature, not a constraint to route around); PR 3/4/5 rows updated; D4 cites ADR-038; new Deferred Milestones subsection.
- **Spike preambles** on `cli-session-resume-spike.md`, `plugin-monitor-viability-spike.md`, `sidecar-launcher-spike.md` labeling them as Claude-default-integration validation.
- **Spike B F2 promoted** from v1.1+ follow-up to a v1.0 marketing-rewrite blocker (the GitHub-marketplace install validation; the cleanest non-developer install path if it works).
- **`CLAUDE.md`** scope-clarifier paragraph + stale ADR-range fix (001-029 → 001-038).
- **`README.md`** stale ADR-range fix (001-030 → 001-038 with ADR-038 link).

## Phase 2 — UI surface sweep (commit 2)

27 files touched. Settings, in-app strings, sample doc, Tauri dialog, server-side tool descriptions, CLI help, npm + marketplace metadata, changelog skill conventions, E2E specs.

- **Settings tab label** "Claude Code/Cowork" → **"AI Assistant"** in both `SettingsPopover.svelte` and `SettingsModal.svelte`. Internal `id: "claude-code"` is preserved so the existing `data-testid='settings-modal-tab-claude-code'` selector keeps working. The `SettingsClaudeCodeTab.svelte` body gets a one-paragraph intro that quotes the ADR-038 framing.
- **In-app strings:** TitleBar status dot tooltip + aria-label, ChatPanel "thinking…" indicator + textarea placeholder + empty-state message, ModeToggle aria/tooltips, awareness cursor label ("Claude" → "AI"), EmptyState hint, NetworkSettings "Connected to claude-sidecar" label, OnboardingTutorial question step, CoworkSettings subnet label softened.
- **`sample/welcome.md`:** full rewrite leading with "documents with an AI — by default Claude" framing. Tutorial-annotation `targetText` strings in `tutorial-annotations.ts` updated to match the new copy; the pinned `tests/fixtures/welcome-snapshot.md` and `EXPECTED_TARGETS` in `tests/server/tutorial-annotations.test.ts` re-synced.
- **Tauri:** "Claude Not Found" dialog rewritten to **welcome** users without Claude installed (no "Tandem will configure it" promise — that lands with the wizard PR). Tray menu item "Setup Claude" → "Setup AI Assistant".
- **Server-side:** startup banner, deprecated-tool toast, `directedAt` deprecation message, and **`tandem_status` tool descriptions** (read by every MCP client during tool discovery) neutralized.
- **CLI help text** describes setup as targeting "your AI client" (Claude by default), not Claude exclusively.
- **`package.json` + `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json`** description blurbs rewritten — these ship to npmjs.com and to users during `claude plugin install`. Aligned to one canonical phrasing: "Edit and iterate on documents with any MCP-capable AI. Claude is the default and best-supported client today."
- **`.claude/skills/changelog/SKILL.md`** gains a `## Conventions` section documenting ADR-038 framing for future entries (history unchanged).
- **E2E specs** — text matchers updated for the new tab label across `settings-modal.spec.ts`, `settings-and-filters.spec.ts`, `margin-view.spec.ts`.

**Verification:** `npm run typecheck` clean. `npm test -- --run` — 2163 tests pass (the single tutorial-annotation regression caught by the pinned snapshot was fixed by syncing the fixture + EXPECTED_TARGETS).

## What's NOT in this PR (Phase 3 scope)

- **No README rewrite.** Phase 3 restructures the README around audience tiers (non-developer → desktop app + wizard; power user → npm + marketplace or channel shim).
- **No positioning.md / architecture.md / mcp-tools.md / user-guide.md / workflows.md rewrites.** Same gate.
- **No auto-configuration behavior change.** Auto-config code stays as-is; removal is the wizard PR's job per ADR-038 §2b.
- **No backward-compat schema breakage.** `author: "claude"` enum value and `directedAt: enum(["claude"])` survive as wire-level strings; refactored when `IntegrationConfig` (#477 PR 1) lands.

## Test plan

- [x] `grep -rn "ADR-038" docs/ CLAUDE.md README.md` — references across docs + decisions + spikes
- [x] `npm run typecheck` clean
- [x] `npm test -- --run` — 2163 pass / 12 skipped (no regressions)
- [ ] Read ADR-038 in isolation as a cold reader — does the four-term glossary land?
- [ ] Manual desktop-app launch with no Claude installed — verify the rewritten Tauri dialog welcomes the user instead of gating them out
- [ ] Open settings → verify the new "AI Assistant" tab label renders and the intro paragraph reads cleanly
- [ ] Open `sample/welcome.md` in a fresh session — verify the four tutorial annotations anchor correctly to the rewritten copy
- [ ] Inspect any MCP client's tool discovery output for `tandem_status` — confirm the description no longer asserts Claude as the assumed subject

https://claude.ai/code/session_01H6L5SZpteqLe7UEtQQ5nSV

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6L5SZpteqLe7UEtQQ5nSV)_