### PR TITLE
ci(updater): guard against harness leaking into production client bundle (#660)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify harness components stripped from client bundle
+        run: node scripts/ci/verify-harness-stripped.mjs
+
       - name: Stdio smoke test
         run: node scripts/ci/stdio-smoke.mjs
         timeout-minutes: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **CI guard: harness components must not leak into production client bundle (Wave 2 PR 7)** — new `scripts/ci/verify-harness-stripped.mjs` runs after `npm run build` and greps `dist/client/` for known harness symbols (`UpdateAvailableHarness`, `harness-acknowledge`, etc.). Defends against a future commit accidentally importing a harness component from a production-shipping module, which would expose internal state (e.g. acknowledge buttons, version accessors) to end users. Pairs with the #660 audit confirming every settings-open path routes through the ack-clearing wrapper.
+
 ### Changed
 
 - **Network settings split into Connection / Advanced (Wave 2 PR 6)** — connection status, transport, and the restart-sidecar button stay always-visible; loopback port, degraded-banner delay, reconnect strategy, hold-while-offline, and token rotation collapsed under a new "Advanced" disclosure. Disclosure state is ephemeral (resets each time the modal opens). New `CollapsibleSection.svelte` primitive uses native `<details>/<summary>` for free keyboard a11y.

--- a/scripts/ci/verify-harness-stripped.mjs
+++ b/scripts/ci/verify-harness-stripped.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * CI smoke test: assert dev-only harness components do NOT leak into the
+ * production client bundle.
+ *
+ * The svelte-harness directory exists so unit and E2E tests can mount the
+ * updater dot, updater banner, error boundary, etc. without standing up
+ * the full App.svelte. Those harnesses are intentionally permissive about
+ * exposing internal state (e.g. `harness-acknowledge` button, version
+ * accessor) — fine for tests, embarrassing in production.
+ *
+ * Vite includes only the HTML entries explicitly listed in
+ * `rollupOptions.input`. The harness lives at the repo root in its own
+ * `svelte-harness.html` and is NOT listed there, so it's never bundled —
+ * but a future change could accidentally import a harness component from
+ * a production-shipping module and pull it into the main chunk graph.
+ * This script catches that regression at CI time.
+ *
+ * Strategy: post-build, grep the emitted JS/CSS/HTML for harness-specific
+ * symbols. A hit fails the build with a pointer at which file leaked.
+ *
+ * Exits 0 on pass (no hits), 1 on any hit. Diagnostics to stderr.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = join(__dirname, "../..");
+const distClient = join(repoRoot, "dist/client");
+
+// Markers chosen so each is unambiguously a harness artefact. testid strings
+// are easier to grep than component names because component names get
+// minified — testids survive as raw string literals.
+const HARNESS_MARKERS = [
+  "harness-acknowledge",
+  "harness-version",
+  "harness-banner-dismiss",
+  "UpdateAvailableHarness",
+  "UpdaterBannerHarness",
+  "ConnectionBannerHarness",
+  "ErrorBoundaryHarness",
+  "StoreReadOnlyBannerHarness",
+  "NotificationsHarness",
+  "EditorHarness",
+  "harness-root",
+];
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) {
+      yield* walk(p);
+    } else {
+      yield p;
+    }
+  }
+}
+
+let leaks = 0;
+for (const file of walk(distClient)) {
+  if (!/\.(js|css|html|map)$/.test(file)) continue;
+  // Skip .map files — sourcemaps reference the original module paths
+  // (svelte-harness/...) which would false-positive on the source path
+  // marker without telling us anything about runtime exposure.
+  if (file.endsWith(".map")) continue;
+  const content = readFileSync(file, "utf8");
+  for (const marker of HARNESS_MARKERS) {
+    if (content.includes(marker)) {
+      process.stderr.write(`[verify-harness-stripped] LEAK: ${file} contains "${marker}"\n`);
+      leaks += 1;
+    }
+  }
+}
+
+if (leaks > 0) {
+  process.stderr.write(
+    `[verify-harness-stripped] ${leaks} harness marker(s) leaked into dist/client. ` +
+      `Check that no production-shipping module imports from svelte-harness/.\n`,
+  );
+  process.exit(1);
+}
+
+process.stderr.write("[verify-harness-stripped] OK\n");


### PR DESCRIPTION
Wave 2 PR 7 from the multi-PR plan, closing the open audit item on issue #660.

## Audit findings (the "ack bypass" concern was already addressed)

Plan claimed `App.svelte:245` sets `settingsModalOpen = true` outside the ack wrapper. That line number has shifted; the current code (`src/client/App.svelte`):

- **Direct writes to `settingsOpen` / `settingsModalOpen`** outside the `WithAck` helpers exist only inside `if (import.meta.env.DEV) { window.__tandemTest = { openSettingsModal: () => { settingsModalOpen = true; } } }` — the dev-only E2E test backdoor. That's intentional and stays.
- All production entry points (gear button, `Ctrl+,`, `Ctrl+Shift+,`, command palette action) route through `toggleSettings` / `openSettingsModalWithAck` / `openSettingsPopoverWithAck`, all of which call `updateAvailable.acknowledge()`.

## Dot lifecycle already covered

The unit-test gap the plan flagged is closed:

- `tests/client/update-available.test.ts` — dot appears on event, clears on acknowledge (+ writes localStorage), no flicker when same-version pre-ack'd, re-appears on newer version.
- `tests/client/updater-channel-sync.test.ts` — cross-surface clear in both directions, exactly-one Tauri listener regardless of consumer count.
- `tests/client/updater-channel-race.test.ts` — refcount-flap race.

All use `__resetUpdaterChannelForTests()` between cases, which is the explicit equivalent of the `vi.resetModules()` the plan called for.

## What this PR adds: CI guard

The remaining defensive piece — making sure a future commit can't accidentally import a harness component (`UpdateAvailableHarness`, `UpdaterBannerHarness`, etc.) from a production-shipping module and leak internals (`harness-acknowledge`, version accessor) into end-user bundles.

- `scripts/ci/verify-harness-stripped.mjs` — post-build, grep `dist/client/*.{js,css,html}` for known harness markers. Fails with a pointer at the leaking file. Skips `.map` files (sourcemaps legitimately reference original module paths).
- Wired into the `check` workflow between `Build` and `Stdio smoke test`.
- Currently passes on master: no harness symbol appears in `dist/client/`.

## Test plan

- [x] `npm run build && node scripts/ci/verify-harness-stripped.mjs` — exits 0
- [x] `npm run typecheck` — 0 errors / 0 warnings
- [x] `npm test` — full suite green
- [ ] Manual: introduce a deliberate `import UpdateAvailableHarness from "./svelte-harness/UpdateAvailableHarness.svelte"` in App.svelte → rebuild → script fails as expected (post-merge audit)

https://claude.ai/code/session_01XgZwoqkPbyNfE3yFdjPgiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgZwoqkPbyNfE3yFdjPgiP)_