### PR TITLE
Wave 1 — Warm canvas theme tokens (v7 floating chrome foundation)

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,41 @@
         --tandem-page-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
       }
 
+      /* Warm canvas theme — v7 floating chrome. OKLCH values come straight
+         from calm-v7.css. Foundational tokens only: surface family + border
+         + scrollbars + page metaphor + the shared pill-shadow used by every
+         floating-pill surface (titlebar clusters, fmtbar, tabs, status,
+         rails, wincontrols). Component-level adoption happens in W3-W6. */
+      [data-theme="warm"] {
+        --tandem-bg: oklch(0.945 0.012 70);
+        --tandem-fg: oklch(0.22 0.012 280);
+        --tandem-surface: oklch(0.975 0.005 75);
+        --tandem-surface-muted: oklch(0.960 0.010 75);
+        --tandem-surface-sunk: oklch(0.920 0.014 65);
+        --tandem-border: oklch(0.91 0.006 75);
+        --tandem-border-strong: oklch(0.84 0.008 75);
+        --tandem-fg-muted: oklch(0.48 0.008 280);
+        --tandem-fg-subtle: oklch(0.54 0.008 280);
+        --tandem-fg-faint: oklch(0.64 0.005 280);
+        --tandem-scrollbar-track: oklch(0.94 0.012 70);
+        --tandem-scrollbar-thumb: oklch(0.78 0.010 75);
+        --tandem-page-bg: oklch(0.925 0.012 70);
+        --tandem-page-paper: oklch(0.985 0.005 75);
+        --tandem-page-shadow: 0 2px 8px oklch(0 0 0 / 0.12);
+        /* Floating-pill shadow stack — consumed by the shared
+           .tandem-floating-pill class introduced in W3. Three light/dark
+           variants of the same shape are exposed so each surface can pick
+           the right contrast against its canvas. */
+        --c7-pill-shadow:
+          0 1px 1px oklch(0 0 0 / 0.03),
+          0 4px 10px -4px oklch(0 0 0 / 0.10),
+          0 16px 30px -18px oklch(0 0 0 / 0.18);
+        --c7-pill-shadow-white:
+          0 1px 1px oklch(0 0 0 / 0.04),
+          0 6px 14px -6px oklch(0 0 0 / 0.10),
+          0 22px 38px -22px oklch(0 0 0 / 0.16);
+      }
+
       /* density spacing scale — cozy is the default (matches :root values) */
       [data-density="compact"] {
         --tandem-space-1: 2px;

--- a/src/client/components/AppearanceSettings.svelte
+++ b/src/client/components/AppearanceSettings.svelte
@@ -36,7 +36,7 @@ function cardStyle(selected: boolean, disabled?: boolean): string {
 
 const themeRg = createRadioGroup<ThemePreference>(
   () => settings.theme,
-  ["light", "dark", "system"] as const,
+  ["light", "warm", "dark", "system"] as const,
   (t) => onUpdate({ theme: t }),
 );
 const primaryTabRg = createRadioGroup<PrimaryTab>(
@@ -71,7 +71,7 @@ const densityRg = createRadioGroup<Density>(
     onkeydown={themeRg.handleKeyDown}
     style="display: flex; gap: var(--tandem-space-2);"
   >
-    {#each (["light", "dark", "system"] as const) as t (t)}
+    {#each (["light", "warm", "dark", "system"] as const) as t (t)}
       <button
         data-testid={`theme-${t}-btn`}
         role="radio"
@@ -80,7 +80,7 @@ const densityRg = createRadioGroup<Density>(
         onclick={() => onUpdate({ theme: t })}
         style={cardStyle(settings.theme === t)}
       >
-        {t === "light" ? "Light" : t === "dark" ? "Dark" : "System"}
+        {t === "light" ? "Light" : t === "warm" ? "Warm" : t === "dark" ? "Dark" : "System"}
       </button>
     {/each}
   </div>
@@ -180,7 +180,7 @@ const densityRg = createRadioGroup<Density>(
     onkeydown={editorFontRg.handleKeyDown}
     style="display: flex; gap: var(--tandem-space-2);"
   >
-    {#each ([["sans", "Sans-serif"], ["serif", "Serif"], ["mono", "Monospace"]] as const) as [value, label] (value)}
+    {#each ([["sans", "Sans-serif"], ["serif", "Serif (Source Serif 4)"], ["mono", "Monospace"]] as const) as [value, label] (value)}
       <button
         data-testid={`editor-font-${value}-btn`}
         role="radio"

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -11,11 +11,12 @@ export type Density = "compact" | "cozy" | "spacious";
 export type PrimaryTab = "chat" | "annotations";
 export type PanelOrder = "chat-editor-annotations" | "annotations-editor-chat";
 export type TextSize = "s" | "m" | "l";
-export type ThemePreference = "light" | "dark" | "system";
+export type ThemePreference = "light" | "dark" | "warm" | "system";
 
 export const THEME_NEXT: Record<ThemePreference, ThemePreference> = {
   system: "dark",
-  dark: "light",
+  dark: "warm",
+  warm: "light",
   light: "system",
 };
 
@@ -23,7 +24,8 @@ export const THEME_NEXT: Record<ThemePreference, ThemePreference> = {
 // tooltips announce what clicking will do, not what the current theme is.
 export const THEME_LABEL: Record<ThemePreference, string> = {
   light: "Switch to system theme",
-  dark: "Switch to light theme",
+  dark: "Switch to warm theme",
+  warm: "Switch to light theme",
   system: "Switch to dark theme",
 };
 export type SidecarRetryStrategy = "exponential" | "constant-2s" | "manual";
@@ -307,7 +309,10 @@ function normalizeKnownFields(parsed: Record<string, unknown>): TandemSettings {
         ? parsed.textSize
         : DEFAULTS.textSize,
     theme:
-      parsed.theme === "light" || parsed.theme === "dark" || parsed.theme === "system"
+      parsed.theme === "light" ||
+      parsed.theme === "dark" ||
+      parsed.theme === "warm" ||
+      parsed.theme === "system"
         ? parsed.theme
         : DEFAULTS.theme,
     accentHue:

--- a/src/client/hooks/useTauriTheme.svelte.ts
+++ b/src/client/hooks/useTauriTheme.svelte.ts
@@ -25,8 +25,12 @@ export function _resetForTests(): void {
   if (typeof window !== "undefined") window.__TANDEM_INITIAL_THEME__ = undefined;
 }
 
-/** Write-through setter: keeps tauriTheme.current and the window bootstrap seed in sync. */
-function setTauriTheme(next: ResolvedTheme): void {
+/**
+ * Write-through setter: keeps tauriTheme.current and the window bootstrap seed in sync.
+ * Narrowed to "light" | "dark" — the OS reports only those two; "warm" is a
+ * user-pref-only resolved theme (W1) that never originates from the OS bridge.
+ */
+function setTauriTheme(next: "light" | "dark"): void {
   tauriTheme.current = next;
   if (typeof window !== "undefined") window.__TANDEM_INITIAL_THEME__ = next;
 }
@@ -76,7 +80,7 @@ export function initTauriTheme(): void {
     if (!document.hasFocus() || !invokeRef) return;
     invokeRef("get_app_theme")
       .then((theme) => {
-        const resolved: ResolvedTheme = theme === "dark" ? "dark" : "light";
+        const resolved: "light" | "dark" = theme === "dark" ? "dark" : "light";
         if (tauriTheme.current !== resolved) {
           setTauriTheme(resolved);
           pollErrorLogged = false;

--- a/src/client/hooks/useTheme.svelte.ts
+++ b/src/client/hooks/useTheme.svelte.ts
@@ -42,15 +42,16 @@ export function resolveTheme(pref: ThemePreference): ResolvedTheme {
  *
  * Colors are hardcoded hex approximations of --tandem-bg so the meta tag
  * is set synchronously before the next paint without a getComputedStyle
- * round-trip. Must match the light/dark --tandem-bg values in index.html:
+ * round-trip. Must match the light/dark/warm --tandem-bg values in index.html:
  *   light: oklch(0.985 0.004 80)  ≈ #fafaf9
  *   dark:  oklch(0.18 0.012 270)  ≈ #1c1c24
+ *   warm:  oklch(0.945 0.012 70)  ≈ #f1ead9
  */
-function syncThemeColorMeta(resolved: "light" | "dark"): void {
+function syncThemeColorMeta(resolved: ResolvedTheme): void {
   try {
     const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
     if (meta) {
-      meta.content = resolved === "dark" ? "#1c1c24" : "#fafaf9";
+      meta.content = resolved === "dark" ? "#1c1c24" : resolved === "warm" ? "#f1ead9" : "#fafaf9";
     }
   } catch {
     // Guard against SSR or DOM-less test environments where document may throw.

--- a/src/client/hooks/useTheme.ts
+++ b/src/client/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-export type ResolvedTheme = "light" | "dark";
+export type ResolvedTheme = "light" | "dark" | "warm";
 
 // systemTheme, resolveTheme, applyTheme live in useTheme.svelte.ts — they need
 // access to tauriTheme (a Svelte $state) for live OS theme updates in Tauri.

--- a/src/client/shell/TitleBar.svelte
+++ b/src/client/shell/TitleBar.svelte
@@ -258,6 +258,16 @@ $effect(() => {
               fill="currentColor"
             />
           </svg>
+        {:else if theme === "warm"}
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="8" cy="8" r="3.2" fill="currentColor" />
+            <g stroke="currentColor" stroke-width="1.4" stroke-linecap="round">
+              <line x1="8" y1="1.5" x2="8" y2="3" />
+              <line x1="8" y1="13" x2="8" y2="14.5" />
+              <line x1="1.5" y1="8" x2="3" y2="8" />
+              <line x1="13" y1="8" x2="14.5" y2="8" />
+            </g>
+          </svg>
         {:else}
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
             <path

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -3,6 +3,8 @@ import {
   loadSettings,
   mergeAndClampSettings,
   type TandemSettings,
+  THEME_LABEL,
+  THEME_NEXT,
 } from "../../src/client/hooks/useTandemSettings.js";
 import {
   SELECTION_DWELL_DEFAULT_MS,
@@ -199,7 +201,7 @@ describe("loadSettings — theme", () => {
     expect(loadSettings().theme).toBe("system");
   });
 
-  it.each(["light", "dark", "system"] as const)("accepts '%s'", (value) => {
+  it.each(["light", "dark", "warm", "system"] as const)("accepts '%s'", (value) => {
     store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ theme: value }));
     expect(loadSettings().theme).toBe(value);
   });
@@ -212,6 +214,22 @@ describe("loadSettings — theme", () => {
   it("falls back to 'system' for non-string values", () => {
     store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ theme: true }));
     expect(loadSettings().theme).toBe("system");
+  });
+});
+
+describe("THEME_NEXT — cycle (W1: warm canvas inserted between dark and light)", () => {
+  it("cycles system → dark → warm → light → system", () => {
+    expect(THEME_NEXT.system).toBe("dark");
+    expect(THEME_NEXT.dark).toBe("warm");
+    expect(THEME_NEXT.warm).toBe("light");
+    expect(THEME_NEXT.light).toBe("system");
+  });
+
+  it("THEME_LABEL action verbs match the cycle", () => {
+    expect(THEME_LABEL.system).toBe("Switch to dark theme");
+    expect(THEME_LABEL.dark).toBe("Switch to warm theme");
+    expect(THEME_LABEL.warm).toBe("Switch to light theme");
+    expect(THEME_LABEL.light).toBe("Switch to system theme");
   });
 });
 

--- a/tests/client/useTheme.test.ts
+++ b/tests/client/useTheme.test.ts
@@ -80,6 +80,10 @@ describe("resolveTheme", () => {
     expect(resolveTheme("dark")).toBe("dark");
   });
 
+  it("passes 'warm' through (W1: v7 floating chrome canvas tone)", () => {
+    expect(resolveTheme("warm")).toBe("warm");
+  });
+
   it("delegates 'system' to the current systemTheme() result", () => {
     expect(resolveTheme("system")).toBe("light");
     vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
@@ -146,6 +150,12 @@ describe("useTheme — DOM side effects (via applyTheme)", () => {
     const { attrs } = installDomStubs();
     applyTheme("dark");
     expect(attrs.get("data-theme")).toBe("dark");
+  });
+
+  it("sets data-theme='warm' when pref is 'warm' (W1)", () => {
+    const { attrs } = installDomStubs();
+    applyTheme("warm");
+    expect(attrs.get("data-theme")).toBe("warm");
   });
 
   it("cleanup removes data-theme (non-system pref)", () => {


### PR DESCRIPTION
## Summary

First merge-able wave of the v7 floating-chrome design handoff (`docs/designs/handoff/tandem/project/`). Adds the foundation tokens that W2-W6 will paint against — no structural component touched.

- `ThemePreference` gains a fourth `"warm"` option; `THEME_NEXT` cycles `system → dark → warm → light → system` and `THEME_LABEL` action verbs match
- `[data-theme="warm"]` block in `index.html` provides the full OKLCH token set lifted verbatim from `calm-v7.css`, plus the shared `--c7-pill-shadow` stack that W3-W6's floating-pill surfaces will consume
- `ResolvedTheme` widened; `useTauriTheme.setTauriTheme` narrowed to `"light" | "dark"` (OS bridge never emits warm — it's user-pref-only)
- `AppearanceSettings` exposes warm as a fourth radio; serif label clarified to "Serif (Source Serif 4)"
- `TitleBar` theme-toggle icon gains a distinct filled-sun variant for warm

W0 spike on a throwaway branch verified Chromium-based WebView accepts the full token surface; the Tauri-specific risk paths (drag-region, decorum hit-test, prevent-default v5) only surface in W4a where they belong.

## Test plan
- [x] `npm run typecheck` — clean (`0 ERRORS 0 WARNINGS`)
- [x] `vitest run tests/client/useTheme.test.ts tests/client/useTandemSettings.test.ts tests/client/useTauriTheme.test.ts` — 114 / 114
- [x] Browser smoke: `localStorage.setItem('tandem:settings', '{"theme":"warm"}')` → reload → `data-theme="warm"`, `body bg = oklch(0.945 0.012 70)`, `--tandem-surface = oklch(0.975 0.005 75)`, `meta[name=theme-color] = "#f1ead9"`
- [ ] Manual Settings → Appearance → click Warm card

Part of the v7 floating-chrome series. W2 (edge-anchored rails) follows.