### PR TITLE
Wave 2 — Edge-anchored side rails (v7 floating chrome)

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -951,8 +951,9 @@ const tutorial = createTutorial(
         {@const leftTabs = settingsState.settings.leftRailTabs}
         {@const iconOnlyLeft = leftTabs.length > 3}
         {@const disabledLeftTabs = settingsState.settings.rightRailTabs.length === 1 ? settingsState.settings.rightRailTabs : []}
+        <!-- v7 floating chrome (Wave 2): see matching comment on tabbedPanel snippet. -->
         <div
-          style={`display: flex; flex-direction: column; width: ${dragResizeLeft.width}px; border-right: 1px solid var(--tandem-border); background: var(--tandem-surface-muted);`}
+          style={`display: flex; flex-direction: column; width: ${dragResizeLeft.width}px; background: var(--tandem-surface-muted); border-radius: 0 var(--tandem-rail-inner-radius, 14px) var(--tandem-rail-inner-radius, 14px) 0; margin-top: var(--tandem-rail-top-clearance, 0); overflow: hidden;`}
         >
           <div
             style="display: flex; border-bottom: 1px solid var(--tandem-border); background: var(--tandem-surface-muted); min-height: 38px; align-items: stretch; padding: 0 var(--tandem-space-2); gap: 2px;"
@@ -1294,8 +1295,13 @@ const tutorial = createTutorial(
 {#snippet tabbedPanel(width: number, borderSide: "left" | "right")}
   {@const enabledTabs = settingsState.settings.rightRailTabs}
   {@const iconOnly = enabledTabs.length > 3}
+  <!-- v7 floating chrome (Wave 2): rail is anchored to the window edge with
+       the OUTER corners flat and the INNER (editor-facing) corners rounded,
+       so it reads as a floating panel peeking past the canvas. The
+       --tandem-rail-top-clearance var defaults to 0; Wave 3 will raise it
+       to ~52px when the fmtbar lifts out of the in-flow layout. -->
   <div
-    style={`display: flex; flex-direction: column; width: ${width}px; ${borderSide === "left" ? "border-right" : "border-left"}: 1px solid var(--tandem-border); background: var(--tandem-surface-muted);`}
+    style={`display: flex; flex-direction: column; width: ${width}px; background: var(--tandem-surface-muted); border-radius: ${borderSide === "right" ? "var(--tandem-rail-inner-radius, 14px) 0 0 var(--tandem-rail-inner-radius, 14px)" : "0 var(--tandem-rail-inner-radius, 14px) var(--tandem-rail-inner-radius, 14px) 0"}; margin-top: var(--tandem-rail-top-clearance, 0); overflow: hidden;`}
   >
     <div
       style="display: flex; border-bottom: 1px solid var(--tandem-border); background: var(--tandem-surface-muted); min-height: 38px; align-items: stretch; padding: 0 var(--tandem-space-2); gap: 2px;"


### PR DESCRIPTION
## Summary

Second wave of the v7 floating-chrome handoff (`docs/designs/handoff/tandem/project/`). Builds on the warm-tone tokens shipped in #738.

- Left + right rails get the V7Rail / V7OutlineRail anchored treatment: OUTER (window-edge) corners flat, INNER (editor-facing) corners rounded to 14px so each rail reads as a floating panel peeking past the canvas
- 1px border seam between rail and editor dropped — the rounded corner + the existing 4px resize-handle gap supply the visual separation
- New CSS variable \`--tandem-rail-top-clearance\` (default 0) seeded for W3, which will raise it to ~52px when the FormattingBar lifts out of in-flow layout (decoupling visual changes across waves so each PR is independently coherent)
- \`overflow: hidden\` on the rail clips internal content against the new corners

Pure CSS. No structural / testid / data-flow changes — all existing rail testids (\`panel-resize-handle\`, \`left-panel-resize-handle\`, \`rail-tab-picker-*\`, \`annotations-tab\`, \`outline-tab\`, etc.) preserved.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`vitest run tests/client\` — 640 / 640
- [x] Browser smoke (dark theme): both rails computed \`border-radius\` matches design (\`14px 0 0 14px\` right, \`0 14px 14px 0\` left); resize handles still 4px wide and operable
- [ ] Manual screenshot vs \`frame-three\` artboard once W3 (floating fmtbar) lands and the top clearance kicks in

Part of the v7 floating-chrome series. W3 (floating fmtbar + shared white-mode pill recipe) follows.