### PR TITLE
Wave 3 — Floating fmtbar pill + shared .tandem-floating-pill recipe

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,43 @@
         --tandem-z-modal: 1000;
         --tandem-z-toast: 1100;
         --tandem-z-tooltip: 10000;
+        /* v7 floating chrome clearance/position vars — consumed by W2-W6
+           rails, fmtbar, status pill. The defaults below match the layout
+           with the TitleBar (40px) + in-flow DocumentTabs (32px) above the
+           editor area, totalling ~72px of header chrome. Once W4 lifts the
+           tabs into the floating titlebar (no in-flow strip), these
+           defaults drop to 52px to match calm-v7.css. --tandem-fmtbar-top
+           is the fmtbar pill's anchor in the absolute overlay layer. */
+        --tandem-fmtbar-top: 80px;
+        --tandem-rail-top-clearance: 80px;
+        --tandem-status-clearance: 36px;
+        /* Light-mode floating-pill stack (matches v7 calm-v7.css). Warm/dark
+           override --c7-pill-shadow inside their own theme blocks. */
+        --c7-pill-shadow:
+          0 1px 1px rgba(0, 0, 0, 0.04),
+          0 6px 14px -6px rgba(0, 0, 0, 0.10),
+          0 22px 38px -22px rgba(0, 0, 0, 0.16);
+      }
+
+      /* Shared white-mode floating-pill recipe. Applied to every floating
+         chrome surface introduced by Waves 3-6: fmtbar, titlebar clusters,
+         tab pills, +/add pill, mode segment, status pill, mini-toolbar,
+         wincontrols. Surfaces only need .tandem-floating-pill + a sensible
+         border-radius (pill or 14px). Surface-specific overrides (padding,
+         max-width, drag-region) layer on top. */
+      .tandem-floating-pill {
+        background: var(--tandem-surface);
+        border: 1px solid var(--tandem-border);
+        border-radius: var(--tandem-r-pill);
+        box-shadow: var(--c7-pill-shadow);
+        backdrop-filter: saturate(140%) blur(8px);
+        -webkit-backdrop-filter: saturate(140%) blur(8px);
+      }
+      [data-theme="dark"] .tandem-floating-pill {
+        --c7-pill-shadow:
+          0 1px 1px rgba(0, 0, 0, 0.30),
+          0 6px 14px -6px rgba(0, 0, 0, 0.40),
+          0 22px 38px -22px rgba(0, 0, 0, 0.50);
       }
 
       [data-theme="dark"] {

--- a/src/client/shell/FormattingBar.svelte
+++ b/src/client/shell/FormattingBar.svelte
@@ -57,14 +57,19 @@ function handleHighlight(color: HighlightColor) {
 </script>
 
 <!-- v7 floating chrome (Wave 3): the persistent format bar is now a floating
-     pill centered over the editor at top: var(--tandem-fmtbar-top, 52px).
-     The wrapper is pointer-events: none so clicks pass through to the editor
-     where the pill is not; the pill itself is pointer-events: auto. The wrap
-     is also -webkit-app-region: drag (Tauri) so the strip above/around the
-     pill remains drag-region, while the pill is no-drag for button clicks. -->
+     pill centered horizontally over the document area at
+     top: var(--tandem-fmtbar-top). Anchored via `position: fixed` (not
+     absolute) so it stays viewport-aligned across containing-block changes
+     in W4. Drag-region is intentionally NOT set on the wrap: the TitleBar
+     already provides the window drag-region above it, and combining
+     -webkit-app-region: drag with pointer-events: none is unreliable in
+     WebView2 (Tauri-on-Windows) — clicks land on the editor underneath
+     instead of moving the window. The pill itself sets no-drag so its
+     buttons remain clickable on macOS where the surrounding titlebar
+     drag-region might otherwise capture them. -->
 <div
   class="tandem-fmtbar-wrap"
-  style="position: absolute; top: var(--tandem-fmtbar-top, 52px); left: 0; right: 0; display: flex; justify-content: center; pointer-events: none; z-index: var(--tandem-z-sticky); -webkit-app-region: drag;"
+  style="position: fixed; top: var(--tandem-fmtbar-top, 52px); left: 0; right: 0; display: flex; justify-content: center; pointer-events: none; z-index: var(--tandem-z-sticky);"
 >
   <div
     data-testid="formatting-bar"

--- a/src/client/shell/FormattingBar.svelte
+++ b/src/client/shell/FormattingBar.svelte
@@ -56,20 +56,28 @@ function handleHighlight(color: HighlightColor) {
 }
 </script>
 
+<!-- v7 floating chrome (Wave 3): the persistent format bar is now a floating
+     pill centered over the editor at top: var(--tandem-fmtbar-top, 52px).
+     The wrapper is pointer-events: none so clicks pass through to the editor
+     where the pill is not; the pill itself is pointer-events: auto. The wrap
+     is also -webkit-app-region: drag (Tauri) so the strip above/around the
+     pill remains drag-region, while the pill is no-drag for button clicks. -->
 <div
-  data-testid="formatting-bar"
-  style="display: flex; align-items: center; height: var(--tandem-h-fmtbar, 36px);
-    padding: 0 var(--tandem-space-3);
-    border-bottom: 1px solid var(--tandem-border);
-    background: var(--tandem-surface-muted);
-    user-select: none; position: relative; z-index: 4;"
+  class="tandem-fmtbar-wrap"
+  style="position: absolute; top: var(--tandem-fmtbar-top, 52px); left: 0; right: 0; display: flex; justify-content: center; pointer-events: none; z-index: var(--tandem-z-sticky); -webkit-app-region: drag;"
 >
-  <div style="flex: 1; display: flex; align-items: center; gap: 2px; overflow: hidden; min-width: 0;">
-    <FormattingToolbar {editor} />
-    <div style="width: 1px; height: 16px; background: var(--tandem-border); margin: 0 2px; flex-shrink: 0;"></div>
-    <HighlightColorPicker
-      disabled={!canHighlight}
-      onHighlight={handleHighlight}
-    />
+  <div
+    data-testid="formatting-bar"
+    class="tandem-floating-pill"
+    style="display: inline-flex; align-items: center; height: var(--tandem-h-fmtbar, 36px); padding: 0 var(--tandem-space-3); user-select: none; pointer-events: auto; -webkit-app-region: no-drag; max-width: calc(100% - var(--tandem-space-6));"
+  >
+    <div style="display: flex; align-items: center; gap: 2px; overflow: hidden; min-width: 0;">
+      <FormattingToolbar {editor} />
+      <div style="width: 1px; height: 16px; background: var(--tandem-border); margin: 0 2px; flex-shrink: 0;"></div>
+      <HighlightColorPicker
+        disabled={!canHighlight}
+        onHighlight={handleHighlight}
+      />
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Third wave of the v7 floating-chrome handoff. The persistent format bar lifts out of in-flow layout and becomes a centered pill anchored to the absolute overlay layer above the editor wrap.

- **Wrap is pointer-events: none** so clicks pass through to the editor wherever the pill is not; the pill itself is pointer-events: auto
- **Wrap is -webkit-app-region: drag** so the band around the pill remains a Tauri drag region; the pill carries no-drag so buttons stay clickable
- **Shared \`.tandem-floating-pill\` class** introduced in \`index.html\` — background/border/radius/shadow/backdrop-filter recipe consumed by every floating chrome surface across W3-W6 (fmtbar today; titlebar clusters, tab pills, +/add pill, mode segment, status pill, wincontrols across W4-W6)
- **\`--c7-pill-shadow\` stack** lifted verbatim from \`docs/designs/handoff/tandem/project/calm-v7.css\` (light + dark variants)
- **New clearance vars** (\`--tandem-fmtbar-top\`, \`--tandem-rail-top-clearance\`, \`--tandem-status-clearance\`) seeded at 80px while the in-flow DocumentTabs strip still occupies the band immediately below the TitleBar; W4 will drop these to 52px once tabs lift into the floating titlebar
- **\`formatting-bar\` testid preserved**; Toolbar.svelte (selection popup) untouched

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`vitest run tests/client\` — 640 / 640
- [x] Browser smoke (dark theme): pill rendered at y=80-116, centered, no collision with in-flow tabs (y=40-72) or editor-scroll content; pill carries the recipe (border-radius: 9999px, pill shadow, surface background)
- [ ] Manual: select text → confirm Toolbar popup (selection mini) still anchors correctly
- [ ] Manual on Tauri: window drag still works around the pill; pill buttons remain clickable

Part of the v7 floating-chrome series. W4a (V7Titlebar 3-cluster rewrite) and W4b (DocumentTabs v7 polish) follow.