### PR TITLE
Wave 5 — Floating status pill + word-count cycle

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -1058,6 +1058,7 @@ const tutorial = createTutorial(
       heldCount={modeGate.heldCount}
       mode={modeState.tandemMode}
       onShowHeld={() => modeState.setTandemMode("tandem")}
+      {editor}
     />
 
     <SettingsPopover

--- a/src/client/status/StatusBar.svelte
+++ b/src/client/status/StatusBar.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+import type { Editor as TiptapEditor } from "@tiptap/core";
 import { untrack } from "svelte";
 import { USER_NAME_MAX_LEN } from "../../shared/constants";
 import { createUserName } from "../hooks/useUserName.svelte";
 import type { ConnectionStatus } from "../hooks/yjsSync.svelte";
+import { getCount, loadMode, modeLabel, nextMode, saveMode } from "./word-count-cycle";
 
 interface Props {
   connected: boolean;
@@ -17,6 +19,8 @@ interface Props {
   heldCount?: number;
   mode?: import("../../shared/types").TandemMode;
   onShowHeld?: () => void;
+  /** Editor for the active document — drives the word-count cycle. */
+  editor?: TiptapEditor | null;
 }
 
 let {
@@ -32,6 +36,7 @@ let {
   heldCount,
   mode,
   onShowHeld,
+  editor,
 }: Props = $props();
 
 const RECONNECTED_FLASH_MS = 2_000;
@@ -111,10 +116,45 @@ const showHeld = $derived((heldCount ?? 0) > 0 && mode === "solo");
 function commitName() {
   userNameState.setUserName(nameInput);
 }
+
+// Word-count cycle (W5). Mode persists in localStorage. The chip click
+// advances the cycle; count is derived live from editor doc state via
+// the per-update tick handler so the chip stays accurate as the user types.
+let wordMode = $state(loadMode());
+let editorTick = $state(0);
+$effect(() => {
+  const ed = editor;
+  if (!ed || ed.isDestroyed) return;
+  const handler = () => {
+    if (!ed.isDestroyed) editorTick++;
+  };
+  ed.on("update", handler);
+  ed.on("transaction", handler);
+  return () => {
+    ed.off("update", handler);
+    ed.off("transaction", handler);
+  };
+});
+const wordCount = $derived.by(() => {
+  void editorTick;
+  return getCount(editor ?? null, wordMode);
+});
+function cycleWordMode() {
+  const next = nextMode(wordMode);
+  wordMode = next;
+  saveMode(next);
+}
 </script>
 
+<!-- v7 floating chrome (Wave 5): the in-flow status bar lifts into a small
+     floating pill anchored bottom-left, applying the shared
+     .tandem-floating-pill recipe. The pill keeps every field the in-flow
+     bar carried (display name, connection, count, saving, held badge,
+     Review-Only, Claude state) plus a new word-count chip that cycles
+     through words / chars / sentences / paragraphs on click. -->
 <div
-  style="display: flex; align-items: center; justify-content: space-between; padding: 0 var(--tandem-space-4); height: 28px; border-top: 1px solid var(--tandem-border); background: var(--tandem-surface-muted); font-family: var(--tandem-font-mono); font-size: var(--tandem-text-xs); color: var(--tandem-fg-muted); user-select: none; gap: var(--tandem-space-3);"
+  class="tandem-floating-pill"
+  style="position: fixed; bottom: var(--tandem-space-3, 12px); left: var(--tandem-space-5, 22px); max-width: calc(100% - var(--tandem-space-7, 44px)); display: inline-flex; align-items: center; padding: 4px var(--tandem-space-3); height: var(--tandem-h-statusbar, 28px); font-family: var(--tandem-font-mono); font-size: var(--tandem-text-xs); color: var(--tandem-fg-muted); user-select: none; gap: var(--tandem-space-3); z-index: var(--tandem-z-sticky); overflow: hidden;"
 >
   <div style="display: flex; align-items: center; gap: var(--tandem-space-2);">
     <span
@@ -126,6 +166,18 @@ function commitName() {
       <span style="color: var(--tandem-fg-subtle);">
         {documentCount} doc{documentCount !== 1 ? "s" : ""} open
       </span>
+    {/if}
+    {#if editor}
+      <button
+        type="button"
+        data-testid="status-word-count"
+        onclick={cycleWordMode}
+        title={`Click to cycle: ${modeLabel(nextMode(wordMode))}`}
+        aria-label={`${wordCount} ${modeLabel(wordMode)} (click to change unit)`}
+        style="background: none; border: none; padding: 0; margin: 0; cursor: pointer; color: var(--tandem-fg-subtle); font: inherit; font-family: var(--tandem-font-mono);"
+      >
+        {wordCount.toLocaleString()} {modeLabel(wordMode)}
+      </button>
     {/if}
     {#if saving}
       <span

--- a/src/client/status/word-count-cycle.ts
+++ b/src/client/status/word-count-cycle.ts
@@ -1,0 +1,82 @@
+import type { Editor as TiptapEditor } from "@tiptap/core";
+
+export type WordCountMode = "words" | "characters" | "sentences" | "paragraphs";
+
+const STORAGE_KEY = "tandem-status-count-mode";
+
+const CYCLE: readonly WordCountMode[] = ["words", "characters", "sentences", "paragraphs"];
+
+const MODE_LABEL: Record<WordCountMode, string> = {
+  words: "words",
+  characters: "chars",
+  sentences: "sentences",
+  paragraphs: "paragraphs",
+};
+
+export function nextMode(current: WordCountMode): WordCountMode {
+  const i = CYCLE.indexOf(current);
+  return CYCLE[(i + 1) % CYCLE.length] ?? "words";
+}
+
+export function modeLabel(mode: WordCountMode): string {
+  return MODE_LABEL[mode];
+}
+
+export function loadMode(): WordCountMode {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw && (CYCLE as readonly string[]).includes(raw)) return raw as WordCountMode;
+  } catch {
+    // storage disabled — fall through
+  }
+  return "words";
+}
+
+export function saveMode(mode: WordCountMode): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // storage disabled — silent
+  }
+}
+
+/**
+ * Derive a count from the editor's current doc state. Returns 0 when the
+ * editor is absent so the status pill can render a placeholder without
+ * crashing on the empty-doc / pre-mount cases.
+ *
+ * Sentences uses a forgiving boundary regex: `[.!?]+` followed by whitespace
+ * or end-of-string. Paragraphs counts top-level paragraph + heading +
+ * blockquote children — the same set the outline panel walks.
+ */
+export function getCount(editor: TiptapEditor | null, mode: WordCountMode): number {
+  if (!editor || editor.isDestroyed) return 0;
+  const text = editor.state.doc.textContent;
+  switch (mode) {
+    case "characters":
+      return text.length;
+    case "words": {
+      const trimmed = text.trim();
+      if (!trimmed) return 0;
+      return trimmed.split(/\s+/).length;
+    }
+    case "sentences": {
+      const matches = text.match(/[^.!?]+[.!?]+(?:\s|$)/g);
+      return matches?.length ?? (text.trim() ? 1 : 0);
+    }
+    case "paragraphs": {
+      let count = 0;
+      editor.state.doc.forEach((node) => {
+        if (
+          node.type.name === "paragraph" ||
+          node.type.name === "heading" ||
+          node.type.name === "blockquote"
+        ) {
+          // Skip blocks with zero text — empty paragraphs shouldn't count.
+          if (node.textContent.trim()) count++;
+        }
+      });
+      return count;
+    }
+  }
+}

--- a/tests/client/status/word-count-cycle.test.ts
+++ b/tests/client/status/word-count-cycle.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getCount,
+  loadMode,
+  modeLabel,
+  nextMode,
+  saveMode,
+  type WordCountMode,
+} from "../../../src/client/status/word-count-cycle.js";
+
+describe("word-count-cycle — cycle order + persistence", () => {
+  it("cycles words → characters → sentences → paragraphs → words", () => {
+    expect(nextMode("words")).toBe("characters");
+    expect(nextMode("characters")).toBe("sentences");
+    expect(nextMode("sentences")).toBe("paragraphs");
+    expect(nextMode("paragraphs")).toBe("words");
+  });
+
+  it("modeLabel returns a short label for each mode", () => {
+    expect(modeLabel("words")).toBe("words");
+    expect(modeLabel("characters")).toBe("chars");
+    expect(modeLabel("sentences")).toBe("sentences");
+    expect(modeLabel("paragraphs")).toBe("paragraphs");
+  });
+
+  describe("loadMode / saveMode", () => {
+    let store: Map<string, string>;
+
+    beforeEach(() => {
+      store = new Map();
+      vi.stubGlobal("localStorage", {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => {
+          store.set(k, v);
+        },
+        removeItem: (k: string) => {
+          store.delete(k);
+        },
+        clear: () => store.clear(),
+        key: () => null,
+        get length() {
+          return store.size;
+        },
+      } satisfies Storage);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("defaults to 'words' when no stored value", () => {
+      expect(loadMode()).toBe("words");
+    });
+
+    it("round-trips a saved mode", () => {
+      saveMode("sentences");
+      expect(loadMode()).toBe("sentences");
+    });
+
+    it("rejects unknown stored values and defaults to 'words'", () => {
+      store.set("tandem-status-count-mode", "syllables");
+      expect(loadMode()).toBe("words");
+    });
+
+    it("survives a localStorage that throws (incognito)", () => {
+      vi.stubGlobal("localStorage", {
+        getItem: () => {
+          throw new Error("storage disabled");
+        },
+        setItem: () => {
+          throw new Error("storage disabled");
+        },
+        removeItem: () => {},
+        clear: () => {},
+        key: () => null,
+        length: 0,
+      } satisfies Storage);
+      expect(loadMode()).toBe("words");
+      expect(() => saveMode("characters")).not.toThrow();
+    });
+  });
+});
+
+describe("word-count-cycle — getCount derivations", () => {
+  function makeEditor(textContent: string, paragraphs: { text: string }[] = []) {
+    return {
+      isDestroyed: false,
+      state: {
+        doc: {
+          textContent,
+          forEach: (cb: (node: { type: { name: string }; textContent: string }) => void) => {
+            for (const p of paragraphs) cb({ type: { name: "paragraph" }, textContent: p.text });
+          },
+        },
+      },
+    };
+  }
+
+  it("returns 0 for null editor", () => {
+    for (const m of ["words", "characters", "sentences", "paragraphs"] as WordCountMode[]) {
+      expect(getCount(null, m)).toBe(0);
+    }
+  });
+
+  it("characters = raw text length", () => {
+    const e = makeEditor("hello world");
+    expect(getCount(e as never, "characters")).toBe(11);
+  });
+
+  it("words = whitespace-split tokens", () => {
+    expect(getCount(makeEditor("hello") as never, "words")).toBe(1);
+    expect(getCount(makeEditor("hello world") as never, "words")).toBe(2);
+    expect(getCount(makeEditor("   ") as never, "words")).toBe(0);
+    expect(getCount(makeEditor("") as never, "words")).toBe(0);
+    // Repeated whitespace doesn't double-count
+    expect(getCount(makeEditor("a   b   c") as never, "words")).toBe(3);
+  });
+
+  it("sentences = [.!?]+ boundary count", () => {
+    expect(getCount(makeEditor("One.") as never, "sentences")).toBe(1);
+    expect(getCount(makeEditor("One. Two! Three?") as never, "sentences")).toBe(3);
+    // No terminator → still 1 sentence if text non-empty
+    expect(getCount(makeEditor("trailing fragment") as never, "sentences")).toBe(1);
+    expect(getCount(makeEditor("") as never, "sentences")).toBe(0);
+  });
+
+  it("paragraphs = non-empty paragraph/heading/blockquote children", () => {
+    expect(
+      getCount(
+        makeEditor("body", [{ text: "first" }, { text: "" }, { text: "third" }]) as never,
+        "paragraphs",
+      ),
+    ).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fifth wave of the v7 floating-chrome handoff. The 28px in-flow status bar lifts into a small pill anchored bottom-left (12px from bottom, 22px from left) wearing the shared \`.tandem-floating-pill\` recipe from W3.

Every existing field is preserved per the wave plan: display-name input, connection state + reconnect timer + attempt count, document count, saving indicator, held badge, Review-Only pill, Claude status dot + label.

**New:** word-count chip cycles \`words → characters → sentences → paragraphs\` on click; mode persists in \`localStorage\` under \`tandem-status-count-mode\`.

- Counts are derived live from \`editor.state.doc\` via per-update tick handler — no \`@tiptap/extension-character-count\` dependency
- Pure helper module: \`src/client/status/word-count-cycle.ts\`
- All existing status-bar testids preserved (\`user-name-input\`, \`save-indicator\`, \`sb-held\`)
- New testid: \`status-word-count\`

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`vitest run tests/client/status\` — 15 / 15 (cycle order + persistence + each derivation)
- [ ] Manual: click word-count chip → cycles units, count updates live as user types
- [ ] Manual: confirm pill stays anchored bottom-left across rail toggles, dark/warm themes

Part of the v7 floating-chrome series. Independent of W4 (titlebar/tabs) — can land in either order.