### PR TITLE
Wave 6 — Outline rail clears the floating status-pill lane

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,11 @@
         --tandem-fmtbar-top: 80px;
         --tandem-rail-top-clearance: 80px;
         --tandem-status-clearance: 36px;
+        /* Bottom inset that any "hugs-content" rail (outline) reserves
+           below itself so the floating status pill (W5) renders into
+           clear space. Sum of pill chrome (status-clearance) + a comfy
+           24px margin. Consumed by PanelSlot's outline branch in W6. */
+        --tandem-status-clearance-total: calc(var(--tandem-status-clearance) + var(--tandem-space-5, 24px));
         /* Light-mode floating-pill stack (matches v7 calm-v7.css). Warm/dark
            override --c7-pill-shadow inside their own theme blocks. */
         --c7-pill-shadow:

--- a/src/client/components/PanelSlot.svelte
+++ b/src/client/components/PanelSlot.svelte
@@ -42,9 +42,13 @@ type Props =
 
 let { kind, visible, ...rest }: Props = $props();
 
+// Outline rail hugs content + reserves bottom space for the floating status
+// pill (W5). Other kinds fill the full vertical space inside the rail.
 const wrapStyle = $derived(
   visible !== undefined
-    ? `display: ${visible ? "flex" : "none"}; flex-direction: column; flex: 1; min-height: 0;`
+    ? `display: ${visible ? "flex" : "none"}; flex-direction: column; flex: 1; min-height: 0;${
+        kind === "outline" ? " padding-bottom: var(--tandem-status-clearance-total, 88px);" : ""
+      }`
     : undefined,
 );
 </script>


### PR DESCRIPTION
## Summary

Sixth wave of the v7 floating-chrome handoff. The outline rail no longer paints into the bottom 60px of its container so the W5 floating status pill renders into visually clear space below it.

Pure CSS in two files:

- \`src/client/components/PanelSlot.svelte\` — outline branch of \`wrapStyle\` appends \`padding-bottom: var(--tandem-status-clearance-total, 88px)\`. Other kinds (\`chat\`, \`side\`) are unchanged
- \`index.html\` — new derived var \`--tandem-status-clearance-total = --tandem-status-clearance (36px) + --tandem-space-5 (24px) = 60px\`

The 88px fallback in the consumer matches the calm-v7.css design figure for the post-W4 layout where fmtbar-top drops to 52px and an outline rail max-height of \`calc(100% - 88px)\` would be the equivalent calculation.

Annotations + chat rails continue to fill their parent's full vertical space — the pill floats over their lower edge.

## Test plan
- [x] \`npm run typecheck\` — clean
- [ ] Manual: select Outline tab; confirm the list scrolls within the upper area and leaves the bottom-left status pill visually unobstructed

Independent of W4. Part of the v7 floating-chrome series.