### PR TITLE
Wave 7 — Align legacy highlight palette migration with v7 design (red → pink)

### DIFF
--- a/src/server/annotations/schema.ts
+++ b/src/server/annotations/schema.ts
@@ -180,8 +180,14 @@ export type TombstoneRecordV1 = z.infer<typeof TombstoneRecordSchemaV1>;
 // Color migration helpers
 // ---------------------------------------------------------------------------
 
+// Align legacy color remap with the v7 design handoff palette
+// (docs/designs/handoff/tandem/project/calm-v7.css):
+// - red → pink (warm-family remap; the prior red→yellow remap predated the
+//   v7 palette decision and silently collapsed two visually distinct
+//   highlights into one)
+// - purple → blue (cool-family remap; unchanged)
 const LEGACY_COLOR_MAP: Record<"red" | "purple", HighlightColor> = {
-  red: "yellow",
+  red: "pink",
   purple: "blue",
 };
 

--- a/tests/server/annotations/schema.test.ts
+++ b/tests/server/annotations/schema.test.ts
@@ -401,7 +401,8 @@ describe("highlight color migration", () => {
     const { doc, droppedAnnotations } = migrateToV1(legacy);
     expect(droppedAnnotations).toBe(0);
     expect(doc.annotations).toHaveLength(3);
-    expect(doc.annotations[0]?.color).toBe("yellow");
+    // W7 palette migration: red → pink (was red → yellow before v7).
+    expect(doc.annotations[0]?.color).toBe("pink");
     expect(doc.annotations[1]?.color).toBe("blue");
     expect(doc.annotations[2]?.color).toBe("yellow");
   });
@@ -417,7 +418,8 @@ describe("highlight color migration", () => {
     };
     const result = parseAnnotationDoc(docWithOldColors);
     if (!result.ok) throw new Error("expected success");
-    expect(result.doc.annotations[0]?.color).toBe("yellow");
+    // W7 palette migration: red → pink (was red → yellow before v7).
+    expect(result.doc.annotations[0]?.color).toBe("pink");
     expect(result.doc.annotations[1]?.color).toBe("blue");
     expect(result.doc.annotations[2]?.color).toBe("blue");
   });


### PR DESCRIPTION
## Summary

Seventh wave of the v7 floating-chrome handoff. Most of the palette migration already shipped in earlier work (the v7 4-color set yellow/green/blue/pink is already the live palette), but the \`LEGACY_COLOR_MAP\` in \`src/server/annotations/schema.ts\` was still mapping the v0.x red/purple highlights to yellow/blue — collapsing two visually distinct highlights into one.

This PR aligns the remap with the v7 handoff recommendation:

- \`red → pink\` (warm-family remap, was \`red → yellow\`)
- \`purple → blue\` (unchanged)

Existing test cases in \`tests/server/annotations/schema.test.ts\` updated to assert the new expected post-migration colors.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`vitest run tests/server/annotations/schema.test.ts\` — 41 / 41

Independent of any chrome wave; ships standalone.