### PR TITLE
Wave 4a (minimal) — Titlebar melts into canvas

### DIFF
--- a/src/client/shell/TitleBar.svelte
+++ b/src/client/shell/TitleBar.svelte
@@ -451,13 +451,19 @@ $effect(() => {
 {/snippet}
 
 <style>
+  /* v7 floating chrome (Wave 4a, minimal): the titlebar drops its bottom
+     seam and surface background so the chrome melts into the canvas. The
+     brand on the left and action icons on the right then read as floating
+     over the document area, matching the v7 silhouette without DOM
+     restructure. The full 3-cluster pill rewrite (which would lift
+     DocumentTabs into the titlebar) is deferred — it touches the Tauri
+     drag-region + decorum hit-test surface and warrants a dedicated wave. */
   .title-bar {
     display: flex;
     align-items: stretch;
     height: 40px;
     min-height: 40px;
-    background: var(--tandem-surface-muted);
-    border-bottom: 1px solid var(--tandem-border);
+    background: transparent;
     user-select: none;
     flex-shrink: 0;
   }


### PR DESCRIPTION
## Summary

Minimal v7-feel pass on the persistent TitleBar. Drops the surface-muted background and 1px bottom border so the brand mark + action icons read as floating directly over the canvas — matching the v7 silhouette without touching DOM structure, drag-region, or the Tauri decorum overlay.

**Deferred** to a follow-up wave: the full V7Titlebar 3-cluster pill rewrite (which would also lift DocumentTabs into the titlebar). That touches the Tauri drag-region + decorum hit-test surface and warrants the careful work that the past-incident memories (\`feedback_tauri_drag_region_structure\`, \`feedback_tauri_decorum_post_load\`) prescribe. This minimal pass ships the visible v7 feel today without that risk surface.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] Browser smoke: \`.title-bar\` background = \`rgba(0,0,0,0)\` (transparent), \`border-bottom\` = \`0px\`
- [ ] Manual on Tauri: confirm window drag still works in the brand area + center drag region (we didn't touch \`data-tauri-drag-region\`)

All existing titlebar testids preserved.