### PR TITLE
refactor(#477 PR 3c-ii-a): move auto-config helpers to src/server/integrations/apply.ts

### DIFF
--- a/docs/plans/477-pr-3c-ii-auto-config-removal.md
+++ b/docs/plans/477-pr-3c-ii-auto-config-removal.md
@@ -1,0 +1,133 @@
+# PR 3c-ii — Auto-configuration removal per ADR-038 §2b
+
+> Plan file. Revised 2026-05-18 after three adversarial reviews (security, contrarian, completeness).
+
+## Goal
+
+Replace the silent Tandem-writes-Claude's-config behavior with explicit wizard-driven setup, per **ADR-038 §2b**. The ADR's literal wording was "TTY-mode wrapper that prompts for the same answers the GUI wizard collects" — the contrarian review correctly flagged this as YAGNI for power users. **Amended in this PR series:** `tandem setup` becomes non-interactive `tandem setup --apply [--target=…]` instead of a TTY prompt flow. The amendment will be noted in ADR-038 §2b when 3c-ii-c ships.
+
+## Constraint: don't strand upgraders, don't break power users
+
+- Existing `~/.claude.json` entries from prior Tandem versions are preserved by the wizard (re-validated against an allowlist).
+- `tandem rotate-token` (`src/cli/rotate-token.ts`) still needs silent file-writes — it's auth rotation, not initial config. The library factor in 3c-ii-a keeps `applyConfigWithToken` callable; rotate-token continues to use it.
+- `tandem setup --apply` stays scriptable for CI / dotfile users.
+
+## Sub-PR split (3 PRs)
+
+### PR 3c-ii-a — Server library factor (pure refactor, no behavior change)
+
+**Scope.**
+- Move from `src/cli/setup.ts` to `src/server/integrations/apply.ts`:
+  - `applyConfig`, `applyConfigWithToken`
+  - `detectTargets` (including MSIX detection)
+  - `buildMcpEntries`
+  - `validateChannelShimPrereq`
+  - `installSkill`
+  - `TargetKind`, `DetectedTarget`, `McpEntry`, `McpEntries` types
+- `src/cli/setup.ts` re-exports for back-compat (so `tandem rotate-token` and existing tests don't break).
+- `src/cli/skill-content.ts` stays in `src/cli/` (it's imported by `installSkill`; cross-boundary import is fine since `apply.ts` is server-side and `skill-content.ts` is just a constant string export).
+- `src/server/mcp/routes/setup.ts` imports from `apply.ts` instead of `../../../cli/setup.js`.
+- `src/server/integrations/existing-config.ts` already imports `detectTargets` — repoint to `./apply.js`.
+- Tests:
+  - Move `tests/cli/setup.test.ts` test cases that cover the moved helpers to `tests/server/integrations/apply.test.ts` (heavy lift; tests stay coverage-equivalent).
+  - Keep `tests/cli/setup.test.ts` for `runSetup` (CLI orchestration) only.
+  - All paths green: `npm run typecheck && npm test`.
+
+**No schema change. No behavior change. No deletions yet.** This is the prerequisite refactor so 3c-ii-b and 3c-ii-c have a clean import surface.
+
+**Touches.** Server-side library only. No client, no Tauri, no docs (except code refs in moved tests).
+
+**Risk: low.** Pure refactor.
+
+### PR 3c-ii-b — Wizard apply path + first-run auto-open (gated on redesign wave settling)
+
+**Scope.**
+- **Schema bump v2 → v3** in `src/server/integrations/schema.ts`:
+  - Add optional `apply: "create" | "update" | "skip"` field on `IntegrationConfig` (default `"create"`).
+  - Bump `INTEGRATIONS_SCHEMA_VERSION` to 3.
+  - Add v2→v3 migration in `src/server/integrations/migrations.ts` (no-op data-wise; sets `apply: "create"` on read for v2 files).
+- **New separate endpoint `POST /api/integrations/apply`** (contrarian S1). Keeps intent and side-effect cleanly separated:
+  - `POST /api/integrations` continues to persist Tandem's intent to `integrations.json` (pure).
+  - `POST /api/integrations/apply` reads the persisted file, iterates integrations with `apply !== "skip"`, calls the library `applyConfig` for each.
+  - Wizard's `save()` calls both in sequence: persist → apply.
+- **Path-traversal mitigation (security B1).** Apply path validates `configPath` against the set returned by `detectTargets()`. UNC paths rejected (mirror `hasUncPrefix` from `src/server/mcp/routes/_shared.ts:7-9`). `configPath` from the request body is **ignored** — server uses its own `detectTargets()` enumeration. The wizard's `configPath` field in `IntegrationConfig` becomes informational (display-only); apply uses target enumeration.
+- **`installSkill` destination home-derived only (security B2).** No request body controls path.
+- **Existing-entry preservation with re-validation (security B3).** When the wizard surfaces "already configured" entries from `readExistingTandemEntries`, the entries are validated against a strict schema:
+  - HTTP entries: `url` must start `http://127.0.0.1:` or `http://localhost:`.
+  - Stdio entries: `command` must be `node`, `npx`, or a known sidecar binary name; `args` must be string array.
+  - Entries failing validation are surfaced to the user with a warning and `apply: "skip"` (preserved on disk but Tandem won't re-write them).
+- **Idempotency: diff and offer "update" (contrarian B2).** When `readExistingTandemEntries` finds a Tandem entry that differs from what the wizard would write (token added/removed, channel shim added/removed), the detect step surfaces this as a diff item ("Update existing entry?" with both shapes shown). `apply` field is set per-integration based on the user's pick.
+- **Channel shim handling (contrarian S3).** The current `applyConfig` silently DELETES stale `tandem-channel` entries when `withChannelShim` is false. The wizard's diff step surfaces this as a removal item the user must confirm. The library `applyConfig` gets a new `confirmStaleRemoval: boolean` param; the wizard sets it to `false` and pre-resolves removals in the diff step. CLI default stays `true` for back-compat until 3c-ii-c.
+- **First-run wizard auto-open — transport-agnostic (contrarian B3).** Move `showIntegrationWizard` from a settings toggle to a derived state in `useTandemSettings.ts`:
+  - Wizard auto-opens when `integrations.json` is empty/missing AND `readExistingTandemEntries` finds nothing.
+  - Works in both Tauri AND npm-browser (driven by the `integrations.json` state on the server, not `window.__TAURI__`).
+  - Settings toggle becomes a "Reopen wizard" affordance (manual reopen).
+  - `last-seen-version` records "user dismissed wizard" so subsequent launches don't re-prompt.
+- **`show_no_claude_dialog` trigger relocates (contrarian N4).** Currently fires from `run_setup()` when zero targets detected; in 3c-ii-c that function dies. Move the trigger to the wizard's detect-step "no integrations found" state, surfaced as a non-blocking dialog inside the modal.
+- **E2E spec update:** `tests/e2e/integration-wizard.spec.ts` updates — auto-open on first run, toggle becomes "Reopen" affordance.
+
+**Touches.** `src/client/App.svelte` (mount conditional), `src/client/hooks/useTandemSettings.ts`, `src/client/hooks/useIntegrationWizard.svelte.ts`, `src/client/components/IntegrationWizardModal.svelte`, `src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte`, `src/server/integrations/api-routes.ts`, `src/server/integrations/schema.ts`, `src/server/integrations/migrations.ts`, `src/server/integrations/existing-config.ts` (re-validation), `src/server/integrations/apply.ts` (param additions), E2E spec.
+
+**Risk: medium.** Touches App.svelte + wizard UI surface during/after redesign wave.
+
+**Gate:** wait for the redesign session's current wave to land first (per user decision). Confirmed via webhook on PR #742 close or master inspection.
+
+### PR 3c-ii-c — Delete `/api/setup` + Tauri `run_setup()` + rewrite `tandem setup` as `--apply` wrapper
+
+**Scope.**
+- Delete `src/server/mcp/routes/setup.ts`.
+- Deregister `/api/setup` route in `src/server/mcp/api-routes.ts`. Remove `API_SETUP` constant from `src/shared/api-paths.ts`.
+- Delete `tests/server/setup-route.test.ts` and `tests/server/setup-api.test.ts` (if they exist).
+- Delete `src-tauri/src/lib.rs:run_setup()`, `SETUP_URL` const, and its call site. Replace startup behavior with a no-op (the client handles wizard auto-open via the transport-agnostic detection from 3c-ii-b).
+- Rewrite `src/cli/setup.ts:runSetup()` as a non-interactive wrapper:
+  - `tandem setup` (no args) → reads `integrations.json`; if empty, prints "Run `tandem` to launch the editor and complete first-run setup, or use `--apply` to write default Claude config non-interactively." If non-empty, prints `--apply` invocation hint.
+  - `tandem setup --apply [--target=claude-code|claude-desktop]` → calls `applyConfig` for the picked target(s) using `detectTargets()` + `buildMcpEntries()`. Same write behavior as today's `runSetup` but explicit. Defaults to all detected targets.
+  - `tandem setup --apply --force` → preserves `--force` semantics (write to default paths even if not detected).
+  - `tandem setup --apply --with-channel-shim` → preserves `--with-channel-shim` flag.
+  - Skill install runs unconditionally as a side-effect of any `--apply` invocation, since it's per-user not per-integration (contrarian S5).
+- `src/cli/index.ts` help text updated.
+- `tests/cli/setup.test.ts` rewritten: assertions on `--apply`, `--force`, `--with-channel-shim`, "no args" output.
+- **Doc sweep (completeness audit):**
+  - `README.md` lines 25, 27, 37, 41, 43, 47, 49, 52, 215-219, 233, 268, 290 — flip to wizard-first language.
+  - `docs/architecture.md` lines 40, 302, 428, 661-667, 764, 821 — describe new flow.
+  - `docs/user-guide.md` lines 31, 266, 268 — update.
+  - `docs/workflows.md` lines 9, 17, 20, 61 — update.
+  - `docs/decisions.md` ADR-038 §2b — add "Status: implemented in PR 3c-ii-{a..c}" + amendment note about TTY → `--apply`.
+  - `CLAUDE.md` line 56 — update `src/cli/setup.ts` description.
+  - `CHANGELOG.md` — Breaking-Changes entry for v0.13.0 (silent auto-config removed; wizard required for first-run; `tandem setup --apply` replaces `tandem setup`).
+  - `docs/roadmap.md:444` — expand 3c-ii row into a/b/c sub-rows matching the 3a/3b/3c-i pattern.
+  - `src-tauri/src/integrations_probe.rs:120` — update sidecar.json doc-comment to reflect the wizard's writer responsibility.
+
+**Touches.** Server route deletion, CLI rewrite, Tauri Rust, doc sweep.
+
+**Risk: low-medium.** Pure deletion + CLI rewrite + doc updates. Independent of redesign work.
+
+**Gate:** ships after 3c-ii-a (library factor) and 3c-ii-b (wizard apply path) land. The contrarian S4 suggested gating on "one shipped release telemetry" — for a two-person project with no telemetry, that's not actionable. Compromise: user confirms a + b work in a real Tauri build before c lands.
+
+## Migration UX gap (ADR-038 §2b)
+
+Handled in 3c-ii-b: wizard's detect step surfaces existing entries with re-validation per security review B3. User clicks through with `apply: "skip"` to preserve. The wizard never silently rewrites or deletes.
+
+## Open questions for adversarial review (resolved in revision)
+
+1. **`applyConfig` location?** → `src/server/integrations/apply.ts`. (Resolved.)
+2. **Atomic-per-batch errors?** → Per-integration error, non-fatal, reported in response. (Resolved.)
+3. **TTY vs `--apply`?** → `--apply` non-interactive. (Resolved — ADR-038 §2b amended.)
+4. **`--with-channel-shim` survival?** → Preserved as flag. (Resolved.)
+5. **Settings toggle?** → Repurposed as "Reopen wizard" affordance. (Resolved.)
+
+## Sequencing
+
+- 3c-ii-a (server-only library factor) — **starts now**.
+- 3c-ii-b (wizard apply + first-run auto-open) — gated on redesign wave settling.
+- 3c-ii-c (deletion + CLI rewrite + doc sweep) — gated on a + b.
+
+## Soak override
+
+User explicitly waived the ≥1-week PR 3c-i soak gate. Recording the override here.
+
+## Files of record
+
+`/home/user/tandem/docs/plans/477-pr-3c-ii-auto-config-removal.md` (this file).
+
+ADR-038 §2b citation: `/home/user/tandem/docs/decisions.md:692-715`.

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,306 +1,40 @@
-import { randomUUID } from "node:crypto";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { copyFile, mkdir, rename, unlink, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { DEFAULT_MCP_PORT } from "../shared/constants.js";
-import { SKILL_CONTENT } from "./skill-content.js";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-// Paths are anchored to the package root (dist/cli/ resolves up two levels).
-const PACKAGE_ROOT = resolve(__dirname, "../..");
-const CHANNEL_DIST = resolve(PACKAGE_ROOT, "dist/channel/index.js");
-
-const MCP_URL = `http://127.0.0.1:${DEFAULT_MCP_PORT}`;
-
-export interface McpEntry {
-  type?: "http";
-  url?: string;
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  headers?: Record<string, string>;
-}
-
-export interface McpEntries {
-  tandem: McpEntry;
-  "tandem-channel"?: McpEntry;
-}
-
-export interface BuildMcpEntriesOptions {
-  /** Include the legacy stdio channel shim. Defaults to false — the plugin
-   *  monitor handles event push for modern installs. Users on older setups
-   *  can run `tandem setup --with-channel-shim` to preserve the shim. */
-  withChannelShim?: boolean;
-  nodeBinary?: string;
-  /** Auth token to embed in HTTP entry headers and stdio shim env.
-   *  When omitted (first-run before token provisioned), headers/env are omitted
-   *  and backward compatibility is preserved. */
-  token?: string;
-  /** Target kind controls entry shape. Claude Code uses HTTP (direct);
-   *  Claude Desktop uses stdio (npx bridge) because Cowork sessions can
-   *  only surface stdio MCP servers. */
-  targetKind?: TargetKind;
-}
-
-export function buildMcpEntries(
-  channelPath: string,
-  opts: BuildMcpEntriesOptions = {},
-): McpEntries {
-  const isDesktop = opts.targetKind === "claude-desktop";
-
-  let tandemEntry: McpEntry;
-  if (isDesktop) {
-    const env: Record<string, string> = { TANDEM_URL: MCP_URL };
-    if (opts.token) {
-      env.TANDEM_AUTH_TOKEN = opts.token;
-    }
-    tandemEntry = {
-      command: "npx",
-      args: ["-y", "tandem-editor", "mcp-stdio"],
-      env,
-    };
-  } else {
-    tandemEntry = { type: "http", url: `${MCP_URL}/mcp` };
-    if (opts.token) {
-      tandemEntry.headers = { Authorization: `Bearer ${opts.token}` };
-    }
-  }
-  const entries: McpEntries = { tandem: tandemEntry };
-
-  if (opts.withChannelShim) {
-    const shimEnv: Record<string, string> = { TANDEM_URL: MCP_URL };
-    if (opts.token) {
-      shimEnv.TANDEM_AUTH_TOKEN = opts.token;
-    }
-    entries["tandem-channel"] = {
-      command: opts.nodeBinary ?? "node",
-      args: [channelPath],
-      env: shimEnv,
-    };
-  }
-  return entries;
-}
-
-export type TargetKind = "claude-code" | "claude-desktop";
-
-export interface DetectedTarget {
-  label: string;
-  configPath: string;
-  kind: TargetKind;
-}
-
-export interface DetectOptions {
-  homeOverride?: string;
-  localAppDataOverride?: string;
-  force?: boolean;
-}
-
-export function detectTargets(opts: DetectOptions = {}): DetectedTarget[] {
-  const home = opts.homeOverride ?? homedir();
-  const targets: DetectedTarget[] = [];
-
-  // Claude Code — cross-platform.
-  // MCP servers are configured in ~/.claude.json under the "mcpServers" key.
-  // Detect if the file exists OR if ~/.claude directory exists (Claude Code is installed).
-  // With --force, always include regardless.
-  const claudeCodeConfig = join(home, ".claude.json");
-  const claudeCodeDir = join(home, ".claude");
-  if (opts.force || existsSync(claudeCodeConfig) || existsSync(claudeCodeDir)) {
-    targets.push({ label: "Claude Code", configPath: claudeCodeConfig, kind: "claude-code" });
-  }
-
-  // Claude Desktop — platform-specific.
-  // Only detect if the config file already exists (user has launched Desktop at least once).
-  // With --force, always include.
-  let desktopConfig: string | null = null;
-  if (process.platform === "win32") {
-    const appdata = process.env.APPDATA ?? join(home, "AppData", "Roaming");
-    desktopConfig = join(appdata, "Claude", "claude_desktop_config.json");
-  } else if (process.platform === "darwin") {
-    desktopConfig = join(
-      home,
-      "Library",
-      "Application Support",
-      "Claude",
-      "claude_desktop_config.json",
-    );
-  } else {
-    desktopConfig = join(home, ".config", "claude", "claude_desktop_config.json");
-  }
-
-  if (desktopConfig && (opts.force || existsSync(desktopConfig))) {
-    targets.push({ label: "Claude Desktop", configPath: desktopConfig, kind: "claude-desktop" });
-  }
-
-  // Claude Desktop (MSIX) — Windows only.
-  // MSIX-packaged installs (Microsoft Store) redirect %APPDATA% to a per-package
-  // LocalCache dir. The config lives under %LOCALAPPDATA%\Packages\Claude_*\
-  // LocalCache\Roaming\Claude\. Multiple package families may exist.
-  if (process.platform === "win32") {
-    const localAppData =
-      opts.localAppDataOverride ?? process.env.LOCALAPPDATA ?? join(home, "AppData", "Local");
-    const packagesDir = join(localAppData, "Packages");
-    try {
-      const entries = readdirSync(packagesDir);
-      for (const pkg of entries.filter((n) => n.startsWith("Claude_"))) {
-        const msixConfig = join(
-          packagesDir,
-          pkg,
-          "LocalCache",
-          "Roaming",
-          "Claude",
-          "claude_desktop_config.json",
-        );
-        if (opts.force || existsSync(msixConfig)) {
-          const suffix =
-            entries.filter((n) => n.startsWith("Claude_")).length > 1
-              ? ` (${pkg.slice(0, 12)}…)`
-              : "";
-          targets.push({
-            label: `Claude Desktop MSIX${suffix}`,
-            configPath: msixConfig,
-            kind: "claude-desktop",
-          });
-        }
-      }
-    } catch {
-      // %LOCALAPPDATA%\Packages doesn't exist or isn't readable — not an MSIX install
-    }
-  }
-
-  return targets;
-}
+import {
+  applyConfig,
+  buildMcpEntries,
+  CHANNEL_DIST,
+  detectTargets,
+  installSkill,
+  PACKAGE_ROOT,
+  validateChannelShimPrereq,
+} from "../server/integrations/apply.js";
 
 /**
- * Atomic write: write to a temp file in the SAME directory as the destination,
- * then rename. Using the same directory avoids EXDEV errors on Windows when
- * %TEMP% and %APPDATA% are on different drives.
+ * Back-compat re-exports.
+ *
+ * The helpers below now live in `src/server/integrations/apply.ts`
+ * (#477 PR 3c-ii-a — server library factor). External consumers
+ * (`tandem rotate-token`, tests, anything that bundles against the
+ * CLI surface) keep importing from `src/cli/setup.js` for now. The
+ * re-export goes away in PR 3c-ii-c when `runSetup` is rewritten as
+ * a non-interactive `--apply` wrapper and the CLI surface is reduced.
  */
-async function atomicWrite(content: string, dest: string): Promise<void> {
-  const tmp = join(dirname(dest), `.tandem-setup-${randomUUID()}.tmp`);
-  await writeFile(tmp, content, "utf-8");
-  try {
-    await rename(tmp, dest);
-  } catch (err) {
-    // EXDEV: cross-device link — fall back to copy + delete
-    if ((err as NodeJS.ErrnoException).code === "EXDEV") {
-      await copyFile(tmp, dest);
-      await unlink(tmp).catch((cleanupErr: Error) => {
-        console.error(`  Warning: could not remove temp file ${tmp}: ${cleanupErr.message}`);
-      });
-    } else {
-      await unlink(tmp).catch((cleanupErr: Error) => {
-        console.error(`  Warning: could not remove temp file ${tmp}: ${cleanupErr.message}`);
-      });
-      throw err;
-    }
-  }
-}
-
-export async function applyConfig(configPath: string, entries: McpEntries): Promise<void> {
-  // Read existing config or start fresh — no existsSync guard needed.
-  // ENOENT and malformed JSON start fresh; other errors (permissions, disk) propagate.
-  let existing: { mcpServers?: Record<string, McpEntry> } = {};
-  try {
-    existing = JSON.parse(readFileSync(configPath, "utf-8"));
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") {
-      // File doesn't exist yet — start fresh
-    } else if (err instanceof SyntaxError) {
-      // Don't silently wipe the user's other mcpServers. Copy the malformed
-      // file to a .broken-<ts> sibling first so they can recover it. If the
-      // backup itself fails, refuse to overwrite — runSetup's per-target
-      // try/catch reports the partial failure.
-      const backupPath = `${configPath}.broken-${Date.now()}`;
-      try {
-        await copyFile(configPath, backupPath);
-        console.error(
-          `  Warning: ${configPath} contains malformed JSON — backed up to ${basename(backupPath)}, replacing with fresh config`,
-        );
-      } catch (copyErr) {
-        console.error(
-          `  Warning: ${configPath} contains malformed JSON and backup failed (${
-            copyErr instanceof Error ? copyErr.message : copyErr
-          }) — refusing to overwrite. Fix the JSON manually and rerun 'tandem setup'.`,
-        );
-        throw copyErr;
-      }
-    } else {
-      throw err; // Permission errors, disk errors, etc. should not be silently swallowed
-    }
-  }
-
-  const merged = {
-    ...(existing.mcpServers ?? {}),
-    ...entries,
-  };
-  // Remove stale tandem-channel entry left by older Tauri installers.
-  // The channel shim is Claude Code-only; Cowork can't use it.
-  if (!entries["tandem-channel"]) {
-    if (merged["tandem-channel"]) {
-      console.error(
-        `  Warning: removed stale tandem-channel entry from ${configPath} (legacy Tauri install artifact)`,
-      );
-    }
-    delete merged["tandem-channel"];
-  }
-  const updated = { ...existing, mcpServers: merged };
-
-  await mkdir(dirname(configPath), { recursive: true });
-  await atomicWrite(JSON.stringify(updated, null, 2) + "\n", configPath);
-}
-
-/**
- * Install the Tandem skill to ~/.claude/skills/tandem/SKILL.md.
- * Claude Code auto-discovers skills in this directory and uses the description
- * field to trigger them when tandem_* tools are present.
- */
-export async function installSkill(opts: { homeOverride?: string } = {}): Promise<void> {
-  const home = opts.homeOverride ?? homedir();
-  const skillPath = join(home, ".claude", "skills", "tandem", "SKILL.md");
-  await mkdir(dirname(skillPath), { recursive: true });
-  await atomicWrite(SKILL_CONTENT, skillPath);
-}
-
-/**
- * Returns true if the channel-shim build artifact exists at the given path.
- * Exported so the prereq check can be tested without spawning runSetup.
- */
-export function validateChannelShimPrereq(channelPath: string): boolean {
-  return existsSync(channelPath);
-}
-
-/**
- * Write the given token into all detected Claude MCP config files.
- * Returns the number of configs successfully updated and any per-target errors.
- */
-export async function applyConfigWithToken(
-  token: string | null,
-  opts: { force?: boolean; withChannelShim?: boolean } = {},
-): Promise<{ updated: number; errors: string[] }> {
-  const targets = detectTargets({ force: opts.force });
-
-  let updated = 0;
-  const errors: string[] = [];
-  for (const t of targets) {
-    const entries = buildMcpEntries(CHANNEL_DIST, {
-      withChannelShim: opts.withChannelShim,
-      token: token ?? undefined,
-      targetKind: t.kind,
-    });
-    try {
-      await applyConfig(t.configPath, entries);
-      updated++;
-    } catch (err) {
-      errors.push(`${t.label}: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-  return { updated, errors };
-}
+export {
+  applyConfig,
+  applyConfigWithToken,
+  type BuildMcpEntriesOptions,
+  buildMcpEntries,
+  type DetectedTarget,
+  type DetectOptions,
+  detectTargets,
+  installSkill,
+  type McpEntries,
+  type McpEntry,
+  type TargetKind,
+  validateChannelShimPrereq,
+} from "../server/integrations/apply.js";
 
 /** Run the setup command. Writes MCP config to all detected Claude installs. */
 export async function runSetup(

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -1,0 +1,334 @@
+/**
+ * Library helpers for applying Tandem's MCP entries to a Claude (or other
+ * MCP-capable) client's config file.
+ *
+ * This module is the destination of the PR 3c-ii-a (#477) library factor —
+ * the helpers originally lived in `src/cli/setup.ts` from when only the
+ * `tandem setup` CLI wrote config. They moved here so the integration setup
+ * wizard (PR 3c-i) and the `/api/setup` route share a single implementation
+ * with `tandem setup` / `tandem rotate-token`, and the dependency direction
+ * (server → CLI) is reversed (server is the source of truth, CLI is a
+ * consumer).
+ *
+ * **No behavior change versus the pre-3c-ii-a location.** The code is
+ * byte-identical (modulo import paths) to what was in `src/cli/setup.ts`
+ * before this PR. The pending changes that ADR-038 §2b prescribes
+ * (idempotent diff/update, path-traversal hardening, explicit
+ * channel-shim removal confirmation) land in PR 3c-ii-b alongside the
+ * wizard's new apply endpoint.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { copyFile, mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SKILL_CONTENT } from "../../cli/skill-content.js";
+import { DEFAULT_MCP_PORT } from "../../shared/constants.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Paths are anchored to the package root. The CLI bundle (`dist/cli/`) and
+// the server bundle (`dist/server/`) both sit one level below `dist/`, so
+// `../..` resolves to the package root in either bundle. In tsx dev,
+// `__dirname` is `src/server/integrations/`, so we need `../../..`.
+const PACKAGE_ROOT = (() => {
+  const fromBundle = resolve(__dirname, "../..");
+  if (existsSync(join(fromBundle, "package.json"))) return fromBundle;
+  return resolve(__dirname, "../../..");
+})();
+const CHANNEL_DIST = resolve(PACKAGE_ROOT, "dist/channel/index.js");
+
+const MCP_URL = `http://127.0.0.1:${DEFAULT_MCP_PORT}`;
+
+export interface McpEntry {
+  type?: "http";
+  url?: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  headers?: Record<string, string>;
+}
+
+export interface McpEntries {
+  tandem: McpEntry;
+  "tandem-channel"?: McpEntry;
+}
+
+export interface BuildMcpEntriesOptions {
+  /** Include the legacy stdio channel shim. Defaults to false — the plugin
+   *  monitor handles event push for modern installs. Users on older setups
+   *  can run `tandem setup --with-channel-shim` to preserve the shim. */
+  withChannelShim?: boolean;
+  nodeBinary?: string;
+  /** Auth token to embed in HTTP entry headers and stdio shim env.
+   *  When omitted (first-run before token provisioned), headers/env are omitted
+   *  and backward compatibility is preserved. */
+  token?: string;
+  /** Target kind controls entry shape. Claude Code uses HTTP (direct);
+   *  Claude Desktop uses stdio (npx bridge) because Cowork sessions can
+   *  only surface stdio MCP servers. */
+  targetKind?: TargetKind;
+}
+
+export function buildMcpEntries(
+  channelPath: string,
+  opts: BuildMcpEntriesOptions = {},
+): McpEntries {
+  const isDesktop = opts.targetKind === "claude-desktop";
+
+  let tandemEntry: McpEntry;
+  if (isDesktop) {
+    const env: Record<string, string> = { TANDEM_URL: MCP_URL };
+    if (opts.token) {
+      env.TANDEM_AUTH_TOKEN = opts.token;
+    }
+    tandemEntry = {
+      command: "npx",
+      args: ["-y", "tandem-editor", "mcp-stdio"],
+      env,
+    };
+  } else {
+    tandemEntry = { type: "http", url: `${MCP_URL}/mcp` };
+    if (opts.token) {
+      tandemEntry.headers = { Authorization: `Bearer ${opts.token}` };
+    }
+  }
+  const entries: McpEntries = { tandem: tandemEntry };
+
+  if (opts.withChannelShim) {
+    const shimEnv: Record<string, string> = { TANDEM_URL: MCP_URL };
+    if (opts.token) {
+      shimEnv.TANDEM_AUTH_TOKEN = opts.token;
+    }
+    entries["tandem-channel"] = {
+      command: opts.nodeBinary ?? "node",
+      args: [channelPath],
+      env: shimEnv,
+    };
+  }
+  return entries;
+}
+
+export type TargetKind = "claude-code" | "claude-desktop";
+
+export interface DetectedTarget {
+  label: string;
+  configPath: string;
+  kind: TargetKind;
+}
+
+export interface DetectOptions {
+  homeOverride?: string;
+  localAppDataOverride?: string;
+  force?: boolean;
+}
+
+export function detectTargets(opts: DetectOptions = {}): DetectedTarget[] {
+  const home = opts.homeOverride ?? homedir();
+  const targets: DetectedTarget[] = [];
+
+  // Claude Code — cross-platform.
+  // MCP servers are configured in ~/.claude.json under the "mcpServers" key.
+  // Detect if the file exists OR if ~/.claude directory exists (Claude Code is installed).
+  // With --force, always include regardless.
+  const claudeCodeConfig = join(home, ".claude.json");
+  const claudeCodeDir = join(home, ".claude");
+  if (opts.force || existsSync(claudeCodeConfig) || existsSync(claudeCodeDir)) {
+    targets.push({ label: "Claude Code", configPath: claudeCodeConfig, kind: "claude-code" });
+  }
+
+  // Claude Desktop — platform-specific.
+  // Only detect if the config file already exists (user has launched Desktop at least once).
+  // With --force, always include.
+  let desktopConfig: string | null = null;
+  if (process.platform === "win32") {
+    const appdata = process.env.APPDATA ?? join(home, "AppData", "Roaming");
+    desktopConfig = join(appdata, "Claude", "claude_desktop_config.json");
+  } else if (process.platform === "darwin") {
+    desktopConfig = join(
+      home,
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude_desktop_config.json",
+    );
+  } else {
+    desktopConfig = join(home, ".config", "claude", "claude_desktop_config.json");
+  }
+
+  if (desktopConfig && (opts.force || existsSync(desktopConfig))) {
+    targets.push({ label: "Claude Desktop", configPath: desktopConfig, kind: "claude-desktop" });
+  }
+
+  // Claude Desktop (MSIX) — Windows only.
+  // MSIX-packaged installs (Microsoft Store) redirect %APPDATA% to a per-package
+  // LocalCache dir. The config lives under %LOCALAPPDATA%\Packages\Claude_*\
+  // LocalCache\Roaming\Claude\. Multiple package families may exist.
+  if (process.platform === "win32") {
+    const localAppData =
+      opts.localAppDataOverride ?? process.env.LOCALAPPDATA ?? join(home, "AppData", "Local");
+    const packagesDir = join(localAppData, "Packages");
+    try {
+      const entries = readdirSync(packagesDir);
+      for (const pkg of entries.filter((n) => n.startsWith("Claude_"))) {
+        const msixConfig = join(
+          packagesDir,
+          pkg,
+          "LocalCache",
+          "Roaming",
+          "Claude",
+          "claude_desktop_config.json",
+        );
+        if (opts.force || existsSync(msixConfig)) {
+          const suffix =
+            entries.filter((n) => n.startsWith("Claude_")).length > 1
+              ? ` (${pkg.slice(0, 12)}…)`
+              : "";
+          targets.push({
+            label: `Claude Desktop MSIX${suffix}`,
+            configPath: msixConfig,
+            kind: "claude-desktop",
+          });
+        }
+      }
+    } catch {
+      // %LOCALAPPDATA%\Packages doesn't exist or isn't readable — not an MSIX install
+    }
+  }
+
+  return targets;
+}
+
+/**
+ * Atomic write: write to a temp file in the SAME directory as the destination,
+ * then rename. Using the same directory avoids EXDEV errors on Windows when
+ * %TEMP% and %APPDATA% are on different drives.
+ */
+async function atomicWrite(content: string, dest: string): Promise<void> {
+  const tmp = join(dirname(dest), `.tandem-setup-${randomUUID()}.tmp`);
+  await writeFile(tmp, content, "utf-8");
+  try {
+    await rename(tmp, dest);
+  } catch (err) {
+    // EXDEV: cross-device link — fall back to copy + delete
+    if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+      await copyFile(tmp, dest);
+      await unlink(tmp).catch((cleanupErr: Error) => {
+        console.error(`  Warning: could not remove temp file ${tmp}: ${cleanupErr.message}`);
+      });
+    } else {
+      await unlink(tmp).catch((cleanupErr: Error) => {
+        console.error(`  Warning: could not remove temp file ${tmp}: ${cleanupErr.message}`);
+      });
+      throw err;
+    }
+  }
+}
+
+export async function applyConfig(configPath: string, entries: McpEntries): Promise<void> {
+  // Read existing config or start fresh — no existsSync guard needed.
+  // ENOENT and malformed JSON start fresh; other errors (permissions, disk) propagate.
+  let existing: { mcpServers?: Record<string, McpEntry> } = {};
+  try {
+    existing = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      // File doesn't exist yet — start fresh
+    } else if (err instanceof SyntaxError) {
+      // Don't silently wipe the user's other mcpServers. Copy the malformed
+      // file to a .broken-<ts> sibling first so they can recover it. If the
+      // backup itself fails, refuse to overwrite — runSetup's per-target
+      // try/catch reports the partial failure.
+      const backupPath = `${configPath}.broken-${Date.now()}`;
+      try {
+        await copyFile(configPath, backupPath);
+        console.error(
+          `  Warning: ${configPath} contains malformed JSON — backed up to ${basename(backupPath)}, replacing with fresh config`,
+        );
+      } catch (copyErr) {
+        console.error(
+          `  Warning: ${configPath} contains malformed JSON and backup failed (${
+            copyErr instanceof Error ? copyErr.message : copyErr
+          }) — refusing to overwrite. Fix the JSON manually and rerun 'tandem setup'.`,
+        );
+        throw copyErr;
+      }
+    } else {
+      throw err; // Permission errors, disk errors, etc. should not be silently swallowed
+    }
+  }
+
+  const merged = {
+    ...(existing.mcpServers ?? {}),
+    ...entries,
+  };
+  // Remove stale tandem-channel entry left by older Tauri installers.
+  // The channel shim is Claude Code-only; Cowork can't use it.
+  if (!entries["tandem-channel"]) {
+    if (merged["tandem-channel"]) {
+      console.error(
+        `  Warning: removed stale tandem-channel entry from ${configPath} (legacy Tauri install artifact)`,
+      );
+    }
+    delete merged["tandem-channel"];
+  }
+  const updated = { ...existing, mcpServers: merged };
+
+  await mkdir(dirname(configPath), { recursive: true });
+  await atomicWrite(JSON.stringify(updated, null, 2) + "\n", configPath);
+}
+
+/**
+ * Install the Tandem skill to ~/.claude/skills/tandem/SKILL.md.
+ * Claude Code auto-discovers skills in this directory and uses the description
+ * field to trigger them when tandem_* tools are present.
+ */
+export async function installSkill(opts: { homeOverride?: string } = {}): Promise<void> {
+  const home = opts.homeOverride ?? homedir();
+  const skillPath = join(home, ".claude", "skills", "tandem", "SKILL.md");
+  await mkdir(dirname(skillPath), { recursive: true });
+  await atomicWrite(SKILL_CONTENT, skillPath);
+}
+
+/**
+ * Returns true if the channel-shim build artifact exists at the given path.
+ * Exported so the prereq check can be tested without spawning runSetup.
+ */
+export function validateChannelShimPrereq(channelPath: string): boolean {
+  return existsSync(channelPath);
+}
+
+/** Re-exported for `tandem setup` orchestration in `src/cli/setup.ts`. */
+export { CHANNEL_DIST, PACKAGE_ROOT };
+
+/**
+ * Write the given token into all detected Claude MCP config files.
+ * Returns the number of configs successfully updated and any per-target errors.
+ */
+export async function applyConfigWithToken(
+  token: string | null,
+  opts: { force?: boolean; withChannelShim?: boolean } = {},
+): Promise<{ updated: number; errors: string[] }> {
+  const targets = detectTargets({ force: opts.force });
+
+  let updated = 0;
+  const errors: string[] = [];
+  for (const t of targets) {
+    const entries = buildMcpEntries(CHANNEL_DIST, {
+      withChannelShim: opts.withChannelShim,
+      token: token ?? undefined,
+      targetKind: t.kind,
+    });
+    try {
+      await applyConfig(t.configPath, entries);
+      updated++;
+    } catch (err) {
+      errors.push(`${t.label}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return { updated, errors };
+}

--- a/src/server/integrations/existing-config.ts
+++ b/src/server/integrations/existing-config.ts
@@ -10,12 +10,12 @@
  * "already configured" state.
  *
  * This reader is intentionally **non-mutating** — it only reads the
- * existing Claude config files via `detectTargets` from `src/cli/setup.ts`
+ * existing Claude config files via `detectTargets` from `./apply.ts`
  * and parses out the `tandem` / `tandem-channel` MCP entries if present.
  * ADR-038 §2b removal of the auto-writer is owned by PR 3c, not this
  * module.
  *
- * Error semantics mirror `src/cli/setup.ts:applyConfig` — ENOENT means
+ * Error semantics mirror `src/server/integrations/apply.ts:applyConfig` — ENOENT means
  * the user has never run that Claude variant; malformed JSON means we
  * cannot trust the file (caller decides whether to surface a recovery
  * prompt or proceed as if the entry is absent).
@@ -23,12 +23,7 @@
 
 import { readFile } from "node:fs/promises";
 
-import {
-  type DetectedTarget,
-  type DetectOptions,
-  detectTargets,
-  type McpEntry,
-} from "../../cli/setup.js";
+import { type DetectedTarget, type DetectOptions, detectTargets, type McpEntry } from "./apply.js";
 
 export type ExistingConfigReadStatus = "ok" | "missing" | "malformed" | "error";
 

--- a/src/server/mcp/routes/setup.ts
+++ b/src/server/mcp/routes/setup.ts
@@ -5,7 +5,7 @@ import {
   type DetectedTarget,
   detectTargets,
   installSkill,
-} from "../../../cli/setup.js";
+} from "../../integrations/apply.js";
 import type { Handler } from "./_shared.js";
 import { isValidChannelPath, isValidNodeBinary } from "./_shared.js";
 


### PR DESCRIPTION
## Summary

First sub-PR of **#477 PR 3c-ii** (auto-configuration removal per [ADR-038](https://github.com/bloknayrb/tandem/blob/master/docs/decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration) §2b). Pure library factor — zero behavior change, pre-requisite for the schema bump and wizard apply path in PR 3c-ii-b.

The auto-config helpers originally lived in `src/cli/setup.ts` from when only the `tandem setup` CLI wrote MCP config. They now live alongside the rest of the integrations module so the wizard, the `/api/setup` route, `tandem setup`, and `tandem rotate-token` share a single library implementation. The dependency direction (server → CLI) is reversed: server is the source of truth, CLI is a consumer.

## What moved

`src/cli/setup.ts` → `src/server/integrations/apply.ts`:

- `applyConfig`, `applyConfigWithToken`
- `detectTargets` (including MSIX detection)
- `buildMcpEntries`
- `validateChannelShimPrereq`
- `installSkill`
- `atomicWrite` helper
- Types: `TargetKind`, `DetectedTarget`, `McpEntry`, `McpEntries`, `BuildMcpEntriesOptions`, `DetectOptions`
- Constants: `PACKAGE_ROOT`, `CHANNEL_DIST` (used by `runSetup`)

## What stayed

`runSetup` is the only thing left in `src/cli/setup.ts` — it's CLI orchestration. It will be rewritten in PR 3c-ii-c as a non-interactive `--apply` wrapper.

`src/cli/setup.ts` keeps back-compat re-exports for the moved names so `tandem rotate-token`, existing tests, and any other consumer keep importing from `src/cli/setup.js` unchanged. The re-export layer is removed in 3c-ii-c.

## Direct-import callers updated

- `src/server/integrations/existing-config.ts` → `./apply.js`
- `src/server/mcp/routes/setup.ts` → `../../integrations/apply.js`

(Both server-internal imports — keeping the cross-module import path short.)

## Plan

`docs/plans/477-pr-3c-ii-auto-config-removal.md` records the three-PR split agreed for #477 PR 3c-ii after three adversarial reviews (security, contrarian, completeness) surfaced:

- Path-traversal mitigation needed on the wizard's new apply path (security B1).
- npm CLI first-run flow has no surface in the original plan — needs transport-agnostic auto-open (contrarian B3).
- `apply` field is a schema bump, not "pure additive" (contrarian B1).
- `tandem setup` should become non-interactive `--apply` instead of a TTY prompt rewrite (contrarian S2; amends ADR-038 §2b wording).
- ~17 doc surfaces missed across README, architecture, user-guide, workflows, CLAUDE.md, CHANGELOG, ADR-038 §2b status (completeness).

All concerns are tracked in the plan and land in PR 3c-ii-b / 3c-ii-c respectively.

## Verification

- [x] `npm run typecheck` — clean.
- [x] `npm test` — 187 test files, 2344 passed / 11 skipped. No test relocations needed (back-compat re-exports keep `tests/cli/setup.test.ts` green).
- [x] No behavior change. Pure refactor.

## Test plan

- [ ] Manual: `tandem setup` on a clean profile still writes `~/.claude.json` and installs the skill (CLI orchestration unchanged).
- [ ] Manual: `tandem rotate-token` still rotates the token across all detected configs.

https://claude.ai/code/session_01H6L5SZpteqLe7UEtQQ5nSV

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6L5SZpteqLe7UEtQQ5nSV)_