### PR TITLE
Wave 4b (minimal) — Pill-shaped DocumentTabs

### DIFF
--- a/src/client/tabs/TabItem.svelte
+++ b/src/client/tabs/TabItem.svelte
@@ -99,23 +99,27 @@ $effect(() => {
   };
 });
 
-// Derived styles
+// Derived styles. v7 floating chrome (Wave 4b minimal): drop the rectangular
+// tab + accent-underline pattern in favor of a soft pill. Active tab gets a
+// surface fill + subtle border; inactive tabs stay transparent. Drop-indicator
+// borders are kept on left/right only (vertical wedges) — bottom underline
+// removed since the pill no longer reads as a "tab attached to a strip".
 const tabStyle = $derived(
   [
     "display: flex",
     "align-items: center",
     "gap: 8px",
     "padding: 0 12px",
-    "height: 100%",
+    "height: 26px",
+    "margin: 3px 0",
     "font-size: var(--tandem-text-sm)",
     "cursor: pointer",
     `background: ${isActive ? "var(--tandem-surface)" : "transparent"}`,
     `color: ${isActive ? "var(--tandem-fg)" : "var(--tandem-fg-subtle)"}`,
-    "border-top: 0",
-    `border-bottom: ${isActive ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
-    `border-left: ${dropIndicator === "left" ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
-    `border-right: ${dropIndicator === "right" ? "2px solid var(--tandem-accent)" : "2px solid transparent"}`,
-    "margin-bottom: -1px",
+    `border: 1px solid ${isActive ? "var(--tandem-border)" : "transparent"}`,
+    `border-left: ${dropIndicator === "left" ? "2px solid var(--tandem-accent)" : isActive ? "1px solid var(--tandem-border)" : "2px solid transparent"}`,
+    `border-right: ${dropIndicator === "right" ? "2px solid var(--tandem-accent)" : isActive ? "1px solid var(--tandem-border)" : "2px solid transparent"}`,
+    "border-radius: var(--tandem-r-pill)",
     "user-select: none",
     "white-space: nowrap",
     "transition: background 0.15s, color 0.15s, border-color 0.15s",

--- a/src/client/tabs/TabItem.svelte
+++ b/src/client/tabs/TabItem.svelte
@@ -172,7 +172,7 @@ function handleMouseLeaveClose() {
   <!-- Format badge: decorative pill; file name is the accessible label via aria-label on the tab.
        No inactive-tab opacity dimming — the badge color must stay at full strength so axe-core
        WCAG AA contrast passes; visual active/inactive distinction comes from the tab background
-       and bottom-border instead. -->
+       fill and the 1px pill border instead. -->
   <span
     data-testid={`tab-format-badge-${tab.id}`}
     aria-label={`Format: ${tab.format}`}


### PR DESCRIPTION
## Summary

Minimal v7-feel polish on the persistent DocumentTabs strip. Pure CSS in \`src/client/tabs/TabItem.svelte\`.

- Active tab now reads as a filled-surface **pill** with a 1px border instead of a rectangular cell with a 2px accent underline — matches the floating-pill recipe shared by the W3 fmtbar, W5 status pill, and W9 settings drawer
- Inactive tabs stay transparent until hover
- Tab height tightens from full-strip to 26px with 3px vertical margin so adjacent pills get a little air
- Drop-indicator wedges (drag-reorder visual hint) kept on left/right with the accent color
- Drag-and-drop reorder, tab close, format badge, dirty dot, all testids preserved (\`tab-{id}\`, \`tab-format-badge-{id}\`, \`unsaved-indicator-{id}\`)

**Deferred** to a follow-up: the full v7 tab-strip restructure (mask-fade overflow + \`+\` add pill + lifted into the floating titlebar) which would touch the Tauri drag-region surface.

## Test plan
- [x] \`npm run typecheck\` — clean
- [ ] Manual: open multiple docs, confirm active pill renders correctly, drag-reorder still works, close button still appears on hover