### PR TITLE
docs(spike-f2): re-validate NO-GO verdict against current master

### DIFF
--- a/docs/spikes/marketplace-install-spike.md
+++ b/docs/spikes/marketplace-install-spike.md
@@ -1,7 +1,7 @@
 # Marketplace Install Spike (F2 — ADR-038 Phase 3 gate)
 
-**Status:** Spike complete — **NO-GO on marketplace one-command monitor activation in v2.1.143.**
-**Date:** 2026-05-17
+**Status:** Spike complete — **NO-GO on marketplace one-command monitor activation in v2.1.143.** Re-validated 2026-05-18 against current master (`.claude-plugin/plugin.json` + `marketplace.json` unchanged since the spike; Claude Code still v2.1.143). Verdict holds.
+**Date:** 2026-05-17 (initial); 2026-05-18 (re-validation)
 **Claude Code version tested:** 2.1.143
 **Refs:** [ADR-038](../decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration), [Plugin Monitor Viability Spike (Spike B)](./plugin-monitor-viability-spike.md), [#477](https://github.com/bloknayrb/tandem/issues/477).
 


### PR DESCRIPTION
## Summary

Re-validation of the [F2 marketplace-install spike](https://github.com/bloknayrb/tandem/blob/master/docs/spikes/marketplace-install-spike.md) (shipped 2026-05-17 via PR #726). Verdict was **NO-GO on marketplace one-command monitor activation in v2.1.143**.

Spot-checked against today's master:

- `.claude-plugin/plugin.json` + `marketplace.json` unchanged since the spike (still PR #722's `1cdcab9`).
- Claude Code still v2.1.143.

Ran:

```
claude plugin marketplace add bloknayrb/tandem
claude plugin install tandem@tandem-editor
claude -p "hi" --debug-file /tmp/log
grep -iE 'tandem|monitor|experimental' /tmp/log
```

Result identical to the original spike. MCP servers + skill activate; **zero** `monitor` / `experimental` entries. Verdict NO-GO still applies.

Phase 3 README (PR #734) is already structured around the NO-GO branch (Tauri desktop as the recommended non-developer install, channel-shim as the power-user path) so no README updates are needed from this re-validation.

## Test plan

- [x] Spike re-run executed; clean state cleanup via `plugin uninstall` + `marketplace remove`.
- No code touched.

https://claude.ai/code/session_01H6L5SZpteqLe7UEtQQ5nSV

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6L5SZpteqLe7UEtQQ5nSV)_