### PR TITLE
docs(CLAUDE.md): refresh stale file-map descriptions after #747

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,14 +53,14 @@ Three layers: Editor (Tiptap in Tauri desktop or browser) <-> Tandem Server (Hoc
 
 Key files for navigation:
 - `src/cli/index.ts` -- CLI entrypoint (`tandem` command), arg parsing, dispatches to start/setup
-- `src/cli/setup.ts` -- `tandem setup`: auto-detect Claude installs, write MCP config atomically
+- `src/cli/setup.ts` -- `tandem setup` orchestration; auto-config helpers (`detectTargets`, `applyConfig`, `installSkill`, `buildMcpEntries`) live in `src/server/integrations/apply.ts` since #477 PR 3c-ii-a
 - `src/cli/start.ts` -- `tandem start`: spawn server (browser distribution deprecated in #477 PR 2; Tauri sidecar sets `TANDEM_TAURI_SIDECAR=1`)
 - `src/server/index.ts` -- Entry point, port binding, console redirect
 - `src/server/open-browser.ts` -- Cross-platform browser launcher for npm-install path (execFile-based)
 - `src/server/mcp/` -- Tool definitions, `api-routes.ts`, `channel-routes.ts`, `file-opener.ts`, `document-service.ts`, `routes/info.ts`
 - `src/server/positions.ts` -- Server coordinate conversions (`validateRange`, `anchoredRange`, `resolveToElement`, `refreshRange`)
 - `src/server/events/` -- Channel event infrastructure (Y.Map observers, SSE)
-- `src/server/integrations/` -- `IntegrationConfig` schema, atomic storage, migration framework (#477 PR 1; no production consumer yet — wizard PR 3 wires it up)
+- `src/server/integrations/` -- `IntegrationConfig` schema (`schema.ts`), atomic storage (`storage.ts`), migration framework (`migrations.ts`), keychain backend (`keychain.ts`), existing-config reader (`existing-config.ts`), auto-config helpers (`apply.ts`), HTTP routes (`api-routes.ts`). Wired into the integration setup wizard (PR 3c-i) and `tandem setup` / `tandem rotate-token` via `apply.ts`.
 - `src/client/` -- Tiptap editor, Svelte 5 components, `.svelte.ts` rune-based hooks, types (`types.ts`)
 - `src/shared/` -- Types (`types.ts`), constants (`constants.ts`), offsets (`offsets.ts`), position types (`positions/`)
 


### PR DESCRIPTION
## Summary

Two stale lines in the `CLAUDE.md` file-map after recent integration-module work:

- `src/cli/setup.ts` line described it as the auto-config writer. Post-#477 PR 3c-ii-a (PR #747), the helpers (`detectTargets`, `applyConfig`, `installSkill`, `buildMcpEntries`) live in `src/server/integrations/apply.ts`. `tandem setup` is now thin orchestration. Updated.
- `src/server/integrations/` line was stuck at *"no production consumer yet — wizard PR 3 wires it up"*. Wizard PR 3c-i (#731), keychain bridge (#732), and library factor (#747) have all shipped — the module now has multiple production consumers. Expanded the file list to match current contents (`schema.ts`, `storage.ts`, `migrations.ts`, `keychain.ts`, `existing-config.ts`, `apply.ts`, `api-routes.ts`).

NIT follow-up from the contrarian completeness review of the PR 3c-ii plan. Two-line doc change.

## Test plan

- [x] No code, no test runs needed.

https://claude.ai/code/session_01H6L5SZpteqLe7UEtQQ5nSV

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6L5SZpteqLe7UEtQQ5nSV)_