### PR TITLE
security(integrations): constrain IntegrationConfig.url to loopback only

### DIFF
--- a/src/server/integrations/schema.ts
+++ b/src/server/integrations/schema.ts
@@ -29,13 +29,49 @@ const AbsolutePath = z.string().min(1).refine(path.isAbsolute, {
   message: "configPath must be an absolute path",
 });
 
+/**
+ * Tandem's MCP HTTP endpoint is always loopback by design — the server
+ * binds to `127.0.0.1` by default, and LAN binding (`TANDEM_BIND_HOST`)
+ * still leaves Claude / other MCP clients connecting to a loopback URL
+ * because they share the host. There is no legitimate Tandem integration
+ * whose `url` field points to a remote host. Constraining `url` to
+ * loopback prevents a maliciously planted `~/.claude.json` entry
+ * (`url: "http://evil.example/mcp"`) from being preserved into Tandem's
+ * `integrations.json` via the wizard's "already configured" path.
+ *
+ * Accepts `http://127.0.0.1[:port][/path]` or `http://localhost[:port][/path]`.
+ * Rejects: non-`http` schemes, any other hostname, IP-literal forms other
+ * than `127.0.0.1` (which would also be loopback but are not used by Tandem
+ * and add attack surface — `127.0.0.2` etc. are valid loopback addresses
+ * but reaching them implies someone configured an alternate bind).
+ */
+const LoopbackUrl = z
+  .string()
+  .url()
+  .refine(
+    (value) => {
+      let parsed: URL;
+      try {
+        parsed = new URL(value);
+      } catch {
+        return false;
+      }
+      if (parsed.protocol !== "http:") return false;
+      return parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost";
+    },
+    {
+      message:
+        "url must be an http loopback URL (http://127.0.0.1 or http://localhost) — Tandem's MCP endpoint is always loopback",
+    },
+  );
+
 const ClaudeCodeIntegration = z.object({
   kind: z.literal("claude-code"),
   id: z.string().min(1),
   label: z.string().min(1),
   configPath: AbsolutePath,
   transport: z.literal("http"),
-  url: z.string().url(),
+  url: LoopbackUrl,
   tokenSecretRef: z.string().min(1).optional(),
 });
 
@@ -66,7 +102,7 @@ const OtherMcpIntegration = z.object({
   id: z.string().min(1),
   label: z.string().min(1),
   transport: z.union([z.literal("http"), z.literal("stdio")]),
-  url: z.string().url().optional(),
+  url: LoopbackUrl.optional(),
   configPath: AbsolutePath.optional(),
   tokenSecretRef: z.string().min(1).optional(),
 });
@@ -137,7 +173,7 @@ const ClaudeCodeIntegrationV1 = z
     label: z.string().min(1),
     configPath: AbsolutePath,
     transport: z.literal("http"),
-    url: z.string().url(),
+    url: LoopbackUrl,
   })
   .strict();
 

--- a/tests/server/integrations/schema.test.ts
+++ b/tests/server/integrations/schema.test.ts
@@ -211,6 +211,103 @@ describe("IntegrationConfigSchema", () => {
   });
 });
 
+describe("LoopbackUrl constraint", () => {
+  const baseClaudeCode = {
+    kind: "claude-code" as const,
+    id: "cc-1",
+    label: "Claude Code",
+    configPath: "/home/user/.claude.json",
+    transport: "http" as const,
+  };
+
+  it("accepts http://127.0.0.1", () => {
+    const result = IntegrationConfigSchema.safeParse({
+      ...baseClaudeCode,
+      url: "http://127.0.0.1:3479",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts http://localhost", () => {
+    const result = IntegrationConfigSchema.safeParse({
+      ...baseClaudeCode,
+      url: "http://localhost:3479",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an http loopback URL with a path", () => {
+    const result = IntegrationConfigSchema.safeParse({
+      ...baseClaudeCode,
+      url: "http://127.0.0.1:3479/mcp",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-loopback URL that would otherwise pass z.string().url()", () => {
+    const result = IntegrationConfigSchema.safeParse({
+      ...baseClaudeCode,
+      url: "http://evil.example/mcp",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an https URL even on loopback (Tandem's MCP endpoint is plain http)", () => {
+    const result = IntegrationConfigSchema.safeParse({
+      ...baseClaudeCode,
+      url: "https://127.0.0.1:3479",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a file:// URL", () => {
+    const result = IntegrationConfigSchema.safeParse({
+      ...baseClaudeCode,
+      url: "file:///etc/passwd",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an alternate loopback IP (127.0.0.2)", () => {
+    // 127.0.0.2 is technically loopback (127.0.0.0/8) but Tandem never binds
+    // there — accepting it would expand attack surface for no legitimate use.
+    const result = IntegrationConfigSchema.safeParse({
+      ...baseClaudeCode,
+      url: "http://127.0.0.2:3479",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a bracketed IPv6 loopback (Tandem's HTTP server binds IPv4 only)", () => {
+    const result = IntegrationConfigSchema.safeParse({
+      ...baseClaudeCode,
+      url: "http://[::1]:3479",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-loopback url on an other-mcp integration too", () => {
+    const result = IntegrationConfigSchema.safeParse({
+      kind: "other-mcp",
+      id: "om-1",
+      label: "Cursor",
+      transport: "http",
+      url: "http://10.0.0.1:8080",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an other-mcp integration with an absent url (stdio transport or default)", () => {
+    const result = IntegrationConfigSchema.safeParse({
+      kind: "other-mcp",
+      id: "om-1",
+      label: "Cursor",
+      transport: "stdio",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("IntegrationsFileSchema", () => {
   it("accepts an empty integrations file", () => {
     const result = IntegrationsFileSchema.safeParse(emptyIntegrationsFile());


### PR DESCRIPTION
## Summary

Closes the path identified by the PR 3c-ii adversarial security review **B3**: a maliciously planted `~/.claude.json` entry with `url: "http://evil.example/mcp"` would pass today's `z.string().url()` validator and be preserved by the wizard's "already configured" branch into Tandem's `integrations.json`. When PR 3c-ii-b's apply path lands, that URL would be written back into the user's Claude config. This PR shuts the door now, before 3c-ii-b builds on the surface.

## Fix

New `LoopbackUrl` zod refinement on `src/server/integrations/schema.ts`:

- **Accepts:** `http://127.0.0.1[:port][/path]`, `http://localhost[:port][/path]`.
- **Rejects:** non-loopback hostnames, `https://` (Tandem's MCP HTTP is plain http by design), `file://`, alternate loopback IPs (`127.0.0.2` etc. — technically loopback but Tandem never binds there, no legitimate use case), bracketed IPv6 loopback (`[::1]` — Tandem's HTTP server is IPv4 only).

Non-breaking for legitimate use: Tandem's MCP HTTP server binds to `127.0.0.1` by design, and `IntegrationConfig.url` is always *"the Tandem endpoint the MCP client will connect to."* No legitimate integration record points elsewhere.

## Applied to

- `ClaudeCodeIntegration.url`
- `OtherMcpIntegration.url` (optional)
- `ClaudeCodeIntegrationV1.url` (v1→v2 migration input — also tightened so a malformed v1 file fails fast at read time rather than after migration)

## Tests

10 new cases in a `LoopbackUrl constraint` describe block covering: positive cases (127.0.0.1, localhost, with path), negative cases (evil.example, https, file://, 127.0.0.2, [::1], non-loopback on other-mcp), plus a regression case for other-mcp with absent url (stdio default).

- [x] `npm run typecheck` clean.
- [x] Full vitest suite: 2354 passed / 11 skipped.

## Relationship to PR 3c-ii sequence

`docs/plans/477-pr-3c-ii-auto-config-removal.md` references security review B3. This PR is the early-land slice — the constraint at the schema boundary. The complementary work (re-validating extracted `McpEntry` shape in `src/server/integrations/existing-config.ts` so the wizard surfaces malformed entries with a warning rather than treating them as opaque) still lands in PR 3c-ii-b.

https://claude.ai/code/session_01H6L5SZpteqLe7UEtQQ5nSV

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6L5SZpteqLe7UEtQQ5nSV)_