### PR TITLE
Wave 4b maximalist — mask-fade overflow + floating-pill + add button + neutral .ro badge + wincontrols pill

### DIFF
--- a/.claude/notes/redesign-deferred-needs-input.md
+++ b/.claude/notes/redesign-deferred-needs-input.md
@@ -1,0 +1,53 @@
+# Redesign items deferred — need Bryan's input
+
+Drafted overnight during the W4b + W8 + W10 batch (2026-05-17/18).
+
+## 1. macOS wincontrols / system traffic-lights conflict
+
+**Status:** Tonight's W4b ships `.tandem-wincontrols` pill styling on all Tauri
+platforms (Win/Mac/Linux) because `src-tauri/tauri.conf.json` has
+`"decorations": false`, which hides system traffic-lights on macOS too.
+
+**Plan intent:** Windows-only `.tandem-wincontrols` pill; macOS relies on
+system traffic-lights drawn over the canvas (handoff design assumption).
+
+**Conflict:** Honoring the plan needs platform-conditional Tauri config —
+either:
+- `decorations: true` + `titleBarStyle: "Overlay"` on macOS only (Tauri
+  supports per-platform window config via `tauri.macos.conf.json`); or
+- Runtime feature detection + custom controls hidden when system controls
+  exist.
+
+**Risk:** Decorations changes ripple through CSP, drag-region, decorum
+hit-test, and the title-bar height math. Not safe to ship without a Mac
+build/QA pass.
+
+**Decision needed:** confirm we want the macOS switch, or keep
+cross-platform custom controls (current shipped behavior) and update the
+plan's wording.
+
+## 2. W10 stretch slope
+
+Slash-menu polish landed tonight as visual-only (no data-model changes).
+Items I noticed while reading but didn't touch — flag if you want them
+folded in:
+
+- Slash-menu shows `/heading`, `/bullet`, etc. with no section dividers —
+  the design groups them. Tonight's polish stops at the floating-pill
+  recipe + keyboard nav; section grouping is a content question (which
+  items group together?).
+- Empty-state copy ("No matching commands") could use a friendlier prompt.
+
+## 3. W7 highlight palette legacy data
+
+Already shipped (#743) — visible legacy `red`/`purple` annotations get
+remapped to `pink`/`blue` on read. Confirm you're seeing the remap in
+practice on any of your real files; if not, the migration shim is
+behaving unexpectedly.
+
+## 4. Highlight from Margin View
+
+Margin-view annotation cards (PR #720/#721) — bubble layout is fine but
+the "tap-to-edit" affordance is subtle. Possible touch-up: hover state
+on the bubble border, or a small edit icon on hover.
+Not blocking; surfacing for taste.

--- a/src/client/shell/TitleBar.svelte
+++ b/src/client/shell/TitleBar.svelte
@@ -354,7 +354,7 @@ $effect(() => {
   </div>
 
   {#if isTauriRuntime()}
-    <div class="title-bar-controls">
+    <div class="title-bar-controls tandem-floating-pill">
       <button
         type="button"
         class="title-bar-btn"
@@ -616,9 +616,17 @@ $effect(() => {
     }
   }
 
+  /* Wincontrols pill: 30×30 buttons inside a single rounded clip.
+     `.tandem-floating-pill` (from index.html) supplies the bg/border/shadow;
+     this rule sets the pill shape + size and ensures buttons clip to the
+     rounded edges. Margin pulls the cluster slightly clear of the gear so
+     it reads as a separate group. */
   .title-bar-controls {
-    display: flex;
-    height: 100%;
+    display: inline-flex;
+    align-items: center;
+    height: 30px;
+    margin: 0 var(--tandem-space-2) 0 var(--tandem-space-1);
+    overflow: hidden;
     flex-shrink: 0;
   }
 
@@ -626,17 +634,18 @@ $effect(() => {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 46px;
-    height: 100%;
+    width: 36px;
+    height: 30px;
     border: none;
     background: transparent;
     color: var(--tandem-fg-muted);
     cursor: pointer;
-    transition: background 0.1s;
+    padding: 0;
+    transition: background 0.1s, color 0.1s;
   }
 
   .title-bar-btn:hover:not(:disabled) {
-    background: var(--tandem-surface);
+    background: color-mix(in srgb, var(--tandem-fg) 6%, transparent);
     color: var(--tandem-fg);
   }
 

--- a/src/client/tabs/DocumentTabs.svelte
+++ b/src/client/tabs/DocumentTabs.svelte
@@ -173,14 +173,6 @@ function handleKeyDown(e: KeyboardEvent, id: string) {
   }
 }
 
-function scrollLeft() {
-  scrollEl?.scrollBy({ left: -150, behavior: scrollBehavior });
-}
-
-function scrollRight() {
-  scrollEl?.scrollBy({ left: 150, behavior: scrollBehavior });
-}
-
 const singleTab = $derived(tabs.length <= 1);
 
 $effect(() => {
@@ -201,25 +193,27 @@ $effect(() => {
 </script>
 
 <!-- Transparent container so pill TabItems read as standalone chips against
-     the canvas behind TitleBar's center cluster (the only host). -->
+     the canvas behind TitleBar's center cluster (the only host).
+
+     Mask-fade overflow: when the scroller has hidden content on either side
+     we apply `.has-overflow` (both sides) or `.overflow-left` / `.overflow-right`
+     (one side) modifier classes on `.tab-scroll-mask`. The mask is a 22px
+     linear-gradient fade matching the v7 design recipe — replaces the prior
+     left/right arrow buttons, which became redundant with native trackpad
+     scroll + the visual cue from the fade. -->
 <div
   style="position: relative; display: flex; align-items: center; background: transparent; min-height: 32px; z-index: var(--tandem-z-base);"
 >
-  {#if canScrollLeft}
-    <button
-      data-testid="tab-scroll-left"
-      onclick={scrollLeft}
-      style="display: flex; align-items: center; justify-content: center; width: 28px; min-width: 28px; background: linear-gradient(to right, var(--tandem-bg) 70%, transparent); border: none; cursor: pointer; font-size: 12px; color: var(--tandem-fg-muted); padding: 0; z-index: 1;"
-      title="Scroll tabs left"
-    >
-      ◀
-    </button>
-  {/if}
-
   <div
     bind:this={scrollEl}
     data-testid="tab-scroll-container"
-    class="tab-scroll-hide"
+    class={[
+      "tab-scroll-hide",
+      "tab-scroll-mask",
+      canScrollLeft && canScrollRight && "has-overflow",
+      canScrollLeft && !canScrollRight && "overflow-left",
+      !canScrollLeft && canScrollRight && "overflow-right",
+    ]}
     role="tablist"
     aria-label="Open documents"
     style="display: flex; align-items: stretch; gap: 2px; flex: 1; overflow-x: auto; overflow-y: hidden;"
@@ -244,7 +238,8 @@ $effect(() => {
 
   <!-- The "+" button lives OUTSIDE role="tablist" — a tablist is only allowed to contain
        role="tab" children (axe `aria-required-children`). Keeping it adjacent to the
-       scroll container preserves the visual placement at the end of the tab strip. -->
+       scroll container preserves the visual placement at the end of the tab strip.
+       28×28 floating-pill recipe matches the v7 .c7-tab-add design. -->
   <button
     bind:this={openBtnEl}
     onclick={() => {
@@ -252,30 +247,12 @@ $effect(() => {
       showRecent = !showRecent;
     }}
     data-testid="open-file-btn"
+    class="tandem-floating-pill tab-add-pill"
     title="Open file"
-    style="background: none; border: none; border-radius: var(--tandem-r-2); cursor: pointer; font-size: 16px; line-height: 1; color: var(--tandem-fg-subtle); padding: 0 8px; margin-left: 4px; flex-shrink: 0;"
-    onmouseenter={(e) => {
-      (e.currentTarget as HTMLButtonElement).style.color = "var(--tandem-accent)";
-      (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--tandem-accent)";
-    }}
-    onmouseleave={(e) => {
-      (e.currentTarget as HTMLButtonElement).style.color = "var(--tandem-fg-muted)";
-      (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--tandem-border-strong)";
-    }}
+    aria-label="Open file"
   >
     +
   </button>
-
-  {#if canScrollRight}
-    <button
-      data-testid="tab-scroll-right"
-      onclick={scrollRight}
-      style="display: flex; align-items: center; justify-content: center; width: 28px; min-width: 28px; background: linear-gradient(to left, var(--tandem-bg) 70%, transparent); border: none; cursor: pointer; font-size: 12px; color: var(--tandem-fg-muted); padding: 0; z-index: 1;"
-      title="Scroll tabs right"
-    >
-      ▶
-    </button>
-  {/if}
 
   {#if showRecent}
     <NewTabMenu
@@ -310,5 +287,79 @@ $effect(() => {
   }
   :global(.tab-scroll-hide::-webkit-scrollbar) {
     display: none;
+  }
+
+  /* Mask-fade overflow: 22px linear-gradient fade on whichever edge has
+     hidden content. Matches the v7 .c7-tabs design recipe (calm-v7.css). */
+  :global(.tab-scroll-mask.has-overflow) {
+    mask-image: linear-gradient(
+      90deg,
+      transparent 0,
+      #000 22px,
+      #000 calc(100% - 22px),
+      transparent 100%
+    );
+    -webkit-mask-image: linear-gradient(
+      90deg,
+      transparent 0,
+      #000 22px,
+      #000 calc(100% - 22px),
+      transparent 100%
+    );
+  }
+  :global(.tab-scroll-mask.overflow-right) {
+    mask-image: linear-gradient(
+      90deg,
+      #000 0,
+      #000 calc(100% - 22px),
+      transparent 100%
+    );
+    -webkit-mask-image: linear-gradient(
+      90deg,
+      #000 0,
+      #000 calc(100% - 22px),
+      transparent 100%
+    );
+  }
+  :global(.tab-scroll-mask.overflow-left) {
+    mask-image: linear-gradient(
+      90deg,
+      transparent 0,
+      #000 22px,
+      #000 100%
+    );
+    -webkit-mask-image: linear-gradient(
+      90deg,
+      transparent 0,
+      #000 22px,
+      #000 100%
+    );
+  }
+
+  /* 28×28 floating-pill `+` add-tab button. Inherits the white/dark/warm
+     background + border + shadow from `.tandem-floating-pill`; this rule
+     only sets the size/shape/hover. */
+  .tab-add-pill {
+    display: inline-grid;
+    place-items: center;
+    width: 28px;
+    height: 28px;
+    margin-left: var(--tandem-space-2);
+    border-radius: var(--tandem-r-circle);
+    color: var(--tandem-fg-subtle);
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    flex-shrink: 0;
+    padding: 0;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+  }
+  .tab-add-pill:hover {
+    color: var(--tandem-accent);
+    border-color: var(--tandem-accent-border);
+  }
+  .tab-add-pill:focus-visible {
+    outline: 2px solid var(--tandem-accent);
+    outline-offset: 1px;
   }
 </style>

--- a/src/client/tabs/TabItem.svelte
+++ b/src/client/tabs/TabItem.svelte
@@ -191,7 +191,8 @@ function handleMouseLeaveClose() {
 
   {#if tab.readOnly}
     <span
-      style="font-family: var(--tandem-font-mono); font-size: var(--tandem-text-2xs); color: var(--tandem-warning-fg-strong); background: var(--tandem-warning-bg); border: 1px solid var(--tandem-warning-border); padding: 0 4px; border-radius: var(--tandem-r-pill);"
+      class="tab-ro-badge"
+      aria-label="Read-only"
     >
       RO
     </span>
@@ -220,3 +221,17 @@ function handleMouseLeaveClose() {
     ×
   </button>
 </div>
+
+<style>
+  .tab-ro-badge {
+    font-family: var(--tandem-font-mono);
+    font-size: 9.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--tandem-fg-faint);
+    background: color-mix(in srgb, var(--tandem-fg) 5%, transparent);
+    padding: 1px 5px;
+    border-radius: var(--tandem-r-1);
+    flex-shrink: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary

Polish pass on the DocumentTabs strip and TitleBar wincontrols per the v7 calm-v7.css design handoff. Completes the W4b half of the v7 floating-chrome roadmap (W4b minimal — pill TabItem — shipped in #748).

## What changed

- **DocumentTabs mask-fade overflow** — scroll container now applies a 22px linear-gradient mask-image fade on whichever edge has hidden content (`.has-overflow` / `.overflow-left` / `.overflow-right`). The left/right scroll arrow buttons are removed — they were redundant once the visual fade communicates the affordance and native trackpad scroll handles the interaction.
- **`+` add-tab pill restyle** — open-file button is a 28×28 circle consuming the shared `.tandem-floating-pill` recipe. Inline JS hover handlers replaced with CSS hover.
- **`.ro` badge neutralized** — read-only indicator drops the warning-tone amber treatment for a quiet neutral mono chip (`color-mix 5%` over `--tandem-fg`). The dirty dot already conveys "modified"; read-only is informational, not alarming.
- **Wincontrols pill** — Tauri min/max/close cluster wraps in `.tandem-floating-pill` so it reads as a single rounded pill matching the v7 `.c7-wincontrols` design. Decorations remain disabled in `tauri.conf` so the cluster renders on every Tauri platform; the macOS-traffic-light switch is tracked separately in `.claude/notes/redesign-deferred-needs-input.md`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2358 passed / 8 skipped
- [ ] Visual: open multiple files, scroll the tab strip in browser/Tauri — verify the 22px fade renders on both edges and `+` pill has the same shadow/border as other floating pills
- [ ] Visual: open a read-only file (changelog) — verify RO badge reads as neutral chip
- [ ] Visual (Tauri only): verify min/max/close cluster reads as one pill

## Deferred

- macOS traffic-light switch: needs Tauri `decorations: true` + `titleBarStyle: "Overlay"` on macOS only. Tracked in `.claude/notes/redesign-deferred-needs-input.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)