### PR TITLE
Wave 8 — .docx batch-promote with always-visible checkboxes

### DIFF
--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -26,6 +26,9 @@ interface Props {
   /** Whether this annotation was recently resolved and can be undone */
   undoable?: boolean;
   onClick?: () => void;
+  /** Batch-selection state — forwarded to ImportedCard only. */
+  selected?: boolean;
+  onToggleSelect?: (id: string) => void;
 }
 
 let {
@@ -41,6 +44,8 @@ let {
   onSendToClaude,
   undoable,
   onClick,
+  selected = false,
+  onToggleSelect,
 }: Props = $props();
 
 // Shared edit-mode state owned by the dispatcher; variants are presentational
@@ -123,6 +128,8 @@ function handleKeyDown(e: KeyboardEvent) {
       {isEditing}
       {canEdit}
       onEnterEdit={enterEditMode}
+      {selected}
+      {onToggleSelect}
     />
   {:else if annotation.type === "highlight"}
     <HighlightCard

--- a/src/client/panels/BatchPromoteBar.svelte
+++ b/src/client/panels/BatchPromoteBar.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+interface Props {
+  selectedCount: number;
+  onPromote: () => void;
+  onClear: () => void;
+}
+
+let { selectedCount, onPromote, onClear }: Props = $props();
+</script>
+
+{#if selectedCount > 0}
+  <div
+    data-testid="batch-promote-bar"
+    role="region"
+    aria-label="Batch promote imported notes"
+    style="position: sticky; top: 0; z-index: var(--tandem-z-base); display: flex; align-items: center; gap: var(--tandem-space-2); padding: var(--tandem-space-2) var(--tandem-space-4); background: var(--tandem-accent-bg); border-bottom: 1px solid var(--tandem-accent-border); font-size: var(--tandem-text-xs); color: var(--tandem-accent-fg-strong);"
+  >
+    <span data-testid="batch-promote-count" style="flex: 1; font-weight: 500;">
+      {selectedCount} selected
+    </span>
+    <button
+      data-testid="batch-promote-clear"
+      onclick={onClear}
+      style="padding: 3px 10px; border: 1px solid transparent; background: none; color: var(--tandem-fg-subtle); border-radius: var(--tandem-r-pill); cursor: pointer; font-size: var(--tandem-text-xs);"
+    >
+      Clear
+    </button>
+    <button
+      data-testid="batch-promote-confirm"
+      onclick={onPromote}
+      style="padding: 3px 12px; border: 1px solid var(--tandem-accent); background: var(--tandem-accent); color: var(--tandem-accent-fg); border-radius: var(--tandem-r-pill); cursor: pointer; font-size: var(--tandem-text-xs); font-weight: 500;"
+    >
+      Send {selectedCount} to Claude
+    </button>
+  </div>
+{/if}

--- a/src/client/panels/ImportedCard.svelte
+++ b/src/client/panels/ImportedCard.svelte
@@ -11,28 +11,66 @@ interface Props {
   isEditing: boolean;
   canEdit: boolean;
   onEnterEdit: () => void;
+  /** When provided, render an always-visible selection checkbox. */
+  selected?: boolean;
+  onToggleSelect?: (id: string) => void;
 }
 
-let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: Props = $props();
-
-// TODO(AR6): render importSource.author
+let {
+  annotation,
+  isPending,
+  isReviewTarget,
+  isEditing,
+  canEdit,
+  onEnterEdit,
+  selected = false,
+  onToggleSelect,
+}: Props = $props();
 </script>
 
-<AnnotationCardHeader
-  {annotation}
-  {isPending}
-  {isReviewTarget}
-  {isEditing}
-  {canEdit}
-  badgeBg="var(--tandem-surface-sunk)"
-  badgeFg="var(--tandem-fg-muted)"
-  {onEnterEdit}
-/>
+<div style="display: flex; align-items: flex-start; gap: var(--tandem-space-2);">
+  {#if onToggleSelect}
+    <input
+      type="checkbox"
+      data-testid="annotation-select-checkbox-{annotation.id}"
+      checked={selected}
+      onclick={(e) => e.stopPropagation()}
+      onchange={() => onToggleSelect?.(annotation.id)}
+      aria-label={`Select ${annotation.importSource?.author ?? "import"} comment for batch promote`}
+      style="margin-top: 4px; flex-shrink: 0; cursor: pointer;"
+    />
+  {/if}
 
-<AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
+  <div style="flex: 1; min-width: 0;">
+    <AnnotationCardHeader
+      {annotation}
+      {isPending}
+      {isReviewTarget}
+      {isEditing}
+      {canEdit}
+      badgeBg="var(--tandem-surface-sunk)"
+      badgeFg="var(--tandem-fg-muted)"
+      {onEnterEdit}
+    />
 
-{#if !isEditing}
-  <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
-    <p style="margin: 0;">{annotation.content || "(no note)"}</p>
+    {#if annotation.importSource?.author}
+      <!-- Reviewer attribution byline. Imports carry the original Word
+           commenter's name; surfacing it lets the user decide which
+           reviewer's comments to promote without opening the source file. -->
+      <div
+        data-testid="annotation-import-byline-{annotation.id}"
+        style="font-size: var(--tandem-text-2xs); color: var(--tandem-fg-subtle); margin-bottom: 4px;"
+      >
+        From: <span style="font-weight: 500;">{annotation.importSource.author}</span>
+      </div>
+    {/if}
+
+    <AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
+
+    {#if !isEditing}
+      <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+        <p style="margin: 0;">{annotation.content || "(no note)"}</p>
+      </div>
+    {/if}
   </div>
-{/if}
+</div>

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -10,10 +10,12 @@ import { warningStateColors } from "../utils/colors";
 import AnnotationCard from "./AnnotationCard.svelte";
 import {
   editAnnotation,
+  promoteNotesToComments,
   removeAnnotation,
   replyToAnnotation,
   sendNoteToClaude,
 } from "./annotation-actions";
+import BatchPromoteBar from "./BatchPromoteBar.svelte";
 import BulkActions from "./BulkActions.svelte";
 import type { FilterAuthor, FilterStatus, FilterType } from "./FilterBar.svelte";
 import FilterBar from "./FilterBar.svelte";
@@ -289,6 +291,46 @@ function handleBulk(status: "accepted" | "dismissed") {
   for (const ann of filteredData.reviewPending) review.resolveAnnotation(ann.id, status);
   bulkConfirm = null;
 }
+
+// Batch-promote selection for imported notes (W8). Set lives in SidePanel
+// so cards stay presentational; the promoted set re-renders on every
+// annotation list change but we prune stale ids in an effect rather than
+// inline so prune isn't a render-time side effect.
+let selectedImportIds = $state(new Set<string>());
+
+$effect(() => {
+  // Prune against the FILTERED visible list, not the raw annotations list:
+  // if FilterBar hides imports, the BatchPromoteBar must clear too, otherwise
+  // the user sees "N selected / Send N to Claude" with no visible cards.
+  const validIds = new Set(
+    filteredData.pending.filter((a) => a.author === "import" && a.type === "note").map((a) => a.id),
+  );
+  let dirty = false;
+  for (const id of selectedImportIds) {
+    if (!validIds.has(id)) {
+      selectedImportIds.delete(id);
+      dirty = true;
+    }
+  }
+  if (dirty) selectedImportIds = new Set(selectedImportIds);
+});
+
+function toggleImportSelection(id: string) {
+  const next = new Set(selectedImportIds);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  selectedImportIds = next;
+}
+
+function handleBatchPromote() {
+  const ids = Array.from(selectedImportIds);
+  promoteNotesToComments(ydoc, ids);
+  selectedImportIds = new Set();
+}
+
+function handleClearSelection() {
+  selectedImportIds = new Set();
+}
 </script>
 
 <div
@@ -389,6 +431,13 @@ function handleBulk(status: "accepted" | "dismissed") {
     <ApplyChangesButton {annotations} {activeDocFormat} {documentId} />
   </div>
 
+  <!-- Batch-promote bar: appears when one or more imported notes are checked. -->
+  <BatchPromoteBar
+    selectedCount={selectedImportIds.size}
+    onPromote={handleBatchPromote}
+    onClear={handleClearSelection}
+  />
+
   <!-- Bulk actions -->
   <BulkActions
     {bulkConfirm}
@@ -430,6 +479,10 @@ function handleBulk(status: "accepted" | "dismissed") {
           onEdit={handleEdit}
           onReply={handleReply}
           onClick={() => review.scrollToAnnotation(ann)}
+          selected={selectedImportIds.has(ann.id)}
+          onToggleSelect={ann.author === "import" && ann.type === "note"
+            ? toggleImportSelection
+            : undefined}
         />
       {/each}
       {#if filteredData.resolved.length > 0}

--- a/src/client/panels/annotation-actions.ts
+++ b/src/client/panels/annotation-actions.ts
@@ -34,23 +34,44 @@ export function editAnnotation(ydoc: Y.Doc | null, id: string, newContent: strin
   map.set(id, { ...ann, content: newContent, editedAt: Date.now() });
 }
 
+/**
+ * Build the promotion payload — shared between the single-card
+ * `sendNoteToClaude` path and the batch `promoteNotesToComments` helper so
+ * the two can't drift on the channel-event gate's invariants (note→comment,
+ * author "import" → "user", audience → "outbound", `promotedFrom: "note"`).
+ */
+function promotedAnnotation(ann: Annotation): Annotation {
+  // Strip note/highlight-specific fields when collapsing to the comment
+  // variant — the discriminated union rejects a `color` on a comment.
+  const {
+    color: _color,
+    suggestedText: _suggestedText,
+    ...rest
+  } = ann as Annotation & {
+    color?: unknown;
+    suggestedText?: unknown;
+  };
+  return {
+    ...rest,
+    type: "comment" as const,
+    author: ann.author === "import" ? ("user" as const) : ann.author,
+    audience: "outbound" as const,
+    promotedFrom: "note" as const,
+  };
+}
+
 export function sendNoteToClaude(ydoc: Y.Doc | null, annotationId: string): void {
   if (!ydoc) return;
   const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
   const raw = map.get(annotationId) as Annotation | undefined;
   if (!raw) return;
   const ann = sanitizeAnnotation(raw, warn);
-  // Promote note → comment, audience → outbound, and re-author import-sourced
-  // notes as user (the user is endorsing the imported reviewer comment as
-  // their own ask to Claude). The annotations observer's note→comment add-
-  // event path gates on `author === "user"`, so keeping `author: "import"`
-  // here would silently fail to surface the new comment to the channel.
-  map.set(annotationId, {
-    ...ann,
-    type: "comment" as const,
-    author: ann.author === "import" ? ("user" as const) : ann.author,
-    audience: "outbound" as const,
-    promotedFrom: "note" as const,
+  // withBrowser tags the transact as user-originated so the channel queue
+  // emits the note→comment promotion event. A bare map.set produces an
+  // undefined-origin transact that the skip set's evolution could quietly
+  // start dropping.
+  withBrowser(ydoc, () => {
+    map.set(annotationId, promotedAnnotation(ann));
   });
 }
 
@@ -70,13 +91,7 @@ export function promoteNotesToComments(ydoc: Y.Doc | null, annotationIds: string
       if (!raw) continue;
       const ann = sanitizeAnnotation(raw, warn);
       if (ann.type !== "note") continue;
-      map.set(id, {
-        ...ann,
-        type: "comment" as const,
-        author: ann.author === "import" ? ("user" as const) : ann.author,
-        audience: "outbound" as const,
-        promotedFrom: "note" as const,
-      });
+      map.set(id, promotedAnnotation(ann));
       promoted++;
     }
   });

--- a/src/client/panels/annotation-actions.ts
+++ b/src/client/panels/annotation-actions.ts
@@ -1,6 +1,7 @@
 import type * as Y from "yjs";
 import { API_ANNOTATION_REPLY, API_REMOVE_ANNOTATION } from "../../shared/api-paths";
 import { Y_MAP_ANNOTATIONS } from "../../shared/constants";
+import { withBrowser } from "../../shared/origins";
 import { sanitizeAnnotation } from "../../shared/sanitize";
 import type { Annotation } from "../../shared/types";
 import { API_BASE } from "../utils/fileUpload";
@@ -39,7 +40,47 @@ export function sendNoteToClaude(ydoc: Y.Doc | null, annotationId: string): void
   const raw = map.get(annotationId) as Annotation | undefined;
   if (!raw) return;
   const ann = sanitizeAnnotation(raw, warn);
-  map.set(annotationId, { ...ann, type: "comment" });
+  // Promote note → comment, audience → outbound, and re-author import-sourced
+  // notes as user (the user is endorsing the imported reviewer comment as
+  // their own ask to Claude). The annotations observer's note→comment add-
+  // event path gates on `author === "user"`, so keeping `author: "import"`
+  // here would silently fail to surface the new comment to the channel.
+  map.set(annotationId, {
+    ...ann,
+    type: "comment" as const,
+    author: ann.author === "import" ? ("user" as const) : ann.author,
+    audience: "outbound" as const,
+    promotedFrom: "note" as const,
+  });
+}
+
+/**
+ * Batch variant of `sendNoteToClaude`. Single Y.Doc transact so the durable
+ * sync observer sees one batched write per submission rather than N inflight
+ * mutations. The observer fans out to per-annotation channel events on its
+ * own — batching here is purely a write-coalescing optimization.
+ */
+export function promoteNotesToComments(ydoc: Y.Doc | null, annotationIds: string[]): number {
+  if (!ydoc || annotationIds.length === 0) return 0;
+  const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+  let promoted = 0;
+  withBrowser(ydoc, () => {
+    for (const id of annotationIds) {
+      const raw = map.get(id) as Annotation | undefined;
+      if (!raw) continue;
+      const ann = sanitizeAnnotation(raw, warn);
+      if (ann.type !== "note") continue;
+      map.set(id, {
+        ...ann,
+        type: "comment" as const,
+        author: ann.author === "import" ? ("user" as const) : ann.author,
+        audience: "outbound" as const,
+        promotedFrom: "note" as const,
+      });
+      promoted++;
+    }
+  });
+  return promoted;
 }
 
 export async function removeAnnotation(

--- a/src/server/file-io/docx-comments.ts
+++ b/src/server/file-io/docx-comments.ts
@@ -175,12 +175,31 @@ export function calculateCommentRanges(
  * Inject extracted comments into a Y.Doc's annotation map.
  * Must be called AFTER htmlToYDoc has populated the document content,
  * so that anchoredRange can create CRDT-anchored positions.
+ *
+ * Imports land as **private notes** (`type: "note"`, `audience: "private"`,
+ * `author: "import"`) per the v7 W8 batch-promote flow. They carry the
+ * reviewer attribution in `importSource: { author, file }` rather than
+ * inlining `[author]` in the content body, so the UI can render a "From:
+ * <author>" byline. The user batch-promotes notes to comments via
+ * `BatchPromoteBar`, which flips `audience: "private"` → `"outbound"`,
+ * `author: "import"` → `"user"`, and `type: "note"` → `"comment"`. Only
+ * after that promotion do they surface to Claude via channel events or
+ * `tandem_getAnnotations`.
+ *
+ * The fileName argument is best-effort — uploads and force-reload paths
+ * that don't have a meaningful file name fall back to "unknown".
  */
-export function injectCommentsAsAnnotations(doc: Y.Doc, comments: DocxComment[]): number {
+export function injectCommentsAsAnnotations(
+  doc: Y.Doc,
+  comments: DocxComment[],
+  fileName?: string,
+): number {
   if (comments.length === 0) return 0;
 
   const map = doc.getMap(Y_MAP_ANNOTATIONS);
+  const sourceFile = fileName ?? "unknown";
   let injected = 0;
+  let migrated = 0;
 
   withInternal(doc, () => {
     for (const comment of comments) {
@@ -194,37 +213,42 @@ export function injectCommentsAsAnnotations(doc: Y.Doc, comments: DocxComment[])
 
       const id = importAnnotationId(comment.commentId, comment.from, comment.to, comment.bodyText);
 
-      // Dedup: idempotent re-import. Same .docx → same id → skip the write,
-      // but if a pre-existing record was stored under the prior PR #474 model
-      // as `type: "note"`, rewrite it in place to `type: "comment"`. The
-      // rewrite triggers the sync observer and lets the on-disk durable
-      // record catch up to the corrected ADR-027 model (#482).
+      // Dedup: idempotent re-import. Same .docx → same id → skip the write.
+      // Legacy records stored under the pre-W8 model as `type: "comment"`
+      // with content prefix `[author] ` are migrated in place to the new
+      // private-note shape. This lets users opening an existing import-
+      // populated file get the batch-promote UX without re-importing.
       if (map.has(id)) {
         const existing = map.get(id) as Annotation | undefined;
-        if (existing && existing.type === "note" && existing.author === "import") {
+        if (
+          existing &&
+          existing.author === "import" &&
+          (existing.type === "comment" || existing.audience !== "private")
+        ) {
           map.set(id, {
             ...existing,
-            type: "comment" as const,
+            type: "note" as const,
+            audience: "private" as const,
+            content: comment.bodyText,
+            importSource: { author: comment.authorName, file: sourceFile },
             rev: nextRev(existing),
           });
+          migrated++;
         }
         continue;
       }
 
-      const content =
-        comment.authorName !== "Unknown"
-          ? `[${comment.authorName}] ${comment.bodyText}`
-          : comment.bodyText;
-
       const annotation: Annotation = {
         id,
         author: "import" as const,
-        type: "comment" as const,
+        type: "note" as const,
+        audience: "private" as const,
         range: { from: result.range.from, to: result.range.to },
-        content,
+        content: comment.bodyText,
         status: "pending" as const,
         timestamp: comment.date ? new Date(comment.date).getTime() : Date.now(),
         rev: nextRev(),
+        importSource: { author: comment.authorName, file: sourceFile },
         ...(result.fullyAnchored ? { relRange: result.relRange } : {}),
       };
 
@@ -233,8 +257,11 @@ export function injectCommentsAsAnnotations(doc: Y.Doc, comments: DocxComment[])
     }
   });
 
-  if (injected > 0 || comments.length > 0) {
-    console.error(`[docx-comments] Imported ${injected}/${comments.length} Word comments`);
+  if (injected > 0 || migrated > 0 || comments.length > 0) {
+    console.error(
+      `[docx-comments] Imported ${injected}/${comments.length} Word comments as private notes` +
+        (migrated > 0 ? ` (migrated ${migrated} legacy records to note shape)` : ""),
+    );
   }
 
   return injected;

--- a/src/server/file-io/index.ts
+++ b/src/server/file-io/index.ts
@@ -18,7 +18,7 @@ export {
   type ApplyOutput,
   applyTrackedChanges,
 } from "./docx-apply.js";
-export type { FormatAdapter, LoadIssue, Prepared } from "./types.js";
+export type { ApplyContext, FormatAdapter, LoadIssue, Prepared } from "./types.js";
 
 // -- Adapter implementations (ADR-036 two-phase parse/apply) --
 
@@ -80,7 +80,7 @@ const docxAdapter: FormatAdapter = {
     ]);
     return { format: "docx", html, comments, issues };
   },
-  apply(doc, prepared) {
+  apply(doc, prepared, ctx) {
     if (prepared.format !== "docx") return [];
     htmlToYDoc(doc, prepared.html);
     const out: LoadIssue[] = [];
@@ -93,7 +93,7 @@ const docxAdapter: FormatAdapter = {
       const annotMap = doc.getMap(Y_MAP_ANNOTATIONS);
       const before = new Set(annotMap.keys());
       try {
-        injectCommentsAsAnnotations(doc, prepared.comments);
+        injectCommentsAsAnnotations(doc, prepared.comments, ctx?.fileName);
       } catch (err) {
         for (const k of annotMap.keys()) {
           if (!before.has(k)) annotMap.delete(k);

--- a/src/server/file-io/types.ts
+++ b/src/server/file-io/types.ts
@@ -75,6 +75,18 @@ export type Prepared =
  * `save` entirely — callers check `if (adapter.save)` instead of a
  * boolean flag.
  */
+/**
+ * Optional apply-time context. Adapters that need source metadata (e.g. the
+ * docx adapter stamps `importSource.file` on imported comments so the UI can
+ * render "From: <author>" bylines) read it here. Adapters that don't need it
+ * ignore it. Optional so the format-adapter contract stays narrow for
+ * call sites that don't have a meaningful fileName (uploads / scratchpads
+ * pass `undefined` which makes the docx adapter fall back to "unknown").
+ */
+export interface ApplyContext {
+  fileName?: string;
+}
+
 export interface FormatAdapter {
   /** Async pre-parse — no doc dependency. */
   parse(content: string | Buffer): Promise<Prepared>;
@@ -84,7 +96,7 @@ export interface FormatAdapter {
    * Returns `LoadIssue`s discovered during apply (e.g. mid-transact inject-
    * failed); combine with `prepared.issues` for the full set.
    */
-  apply(doc: Y.Doc, prepared: Prepared): LoadIssue[];
+  apply(doc: Y.Doc, prepared: Prepared, ctx?: ApplyContext): LoadIssue[];
 
   /**
    * Serialize a Y.Doc back to file content. Optional — formats that

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -434,7 +434,7 @@ export function registerAnnotationTools(server: McpServer): void {
 
   server.tool(
     "tandem_getAnnotations",
-    'Read all annotations, optionally filtered by author/type/status. User notes are always excluded — they are private to the user (ADR-027). For checking new user actions, prefer tandem_checkInbox. Imported Word reviewer comments surface as comments (`author: "import", type: "comment"`) by default — filter via `author: "import"` if you want to scope to them. The `notesExcluded` field in the response reports how many notes were filtered out.',
+    'Read all annotations, optionally filtered by author/type/status. User notes are always excluded — they are private to the user (ADR-027). For checking new user actions, prefer tandem_checkInbox. Imported Word reviewer comments land as **private notes** (`author: "import", type: "note", audience: "private"`) and are excluded by default; the user batch-promotes them via the side rail before Claude sees them, at which point they become `author: "user", type: "comment"`. The `notesExcluded` field in the response reports how many notes were filtered out (including any not-yet-promoted imports).',
     {
       author: AuthorSchema.optional().describe("Filter by author"),
       type: z.enum(["highlight", "comment"]).optional().describe("Filter by type"),

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -429,7 +429,7 @@ async function prepareContent(format: string, source: string | Buffer): Promise<
  */
 function applyPreparedContent(doc: Y.Doc, prepared: Prepared, ctx: PopulateContext): void {
   const adapter = getAdapter(prepared.format);
-  const applyIssues = adapter.apply(doc, prepared);
+  const applyIssues = adapter.apply(doc, prepared, { fileName: ctx.displayName });
   for (const issue of prepared.issues) notifyIssue(issue, ctx);
   for (const issue of applyIssues) notifyIssue(issue, ctx);
 }
@@ -872,7 +872,7 @@ async function reloadFromDisk(id: string, filePath: string, format: string): Pro
       // not a user-initiated open; surfacing inject failures via toast on
       // every file-watcher reload would be noisy. The original surface in
       // openFileByPath catches inject failures during the initial open.
-      reloadAdapter.apply(doc, reloadPrepared);
+      reloadAdapter.apply(doc, reloadPrepared, { fileName: path.basename(filePath) });
     });
 
     // 3. Refresh all annotation ranges in a batch transaction (sanitize legacy shapes)

--- a/src/shared/sanitize.ts
+++ b/src/shared/sanitize.ts
@@ -139,14 +139,12 @@ export function sanitizeAnnotation(
     } as Annotation;
   }
 
-  // Imported Word reviewer comments stored under the unreleased PR #474
-  // model as `type: "note"` need to surface to Claude as comments per
-  // ADR-027 (#482). MUST run before the flag/note clause below — otherwise
-  // the `type === "note"` branch shadows this rewrite into a no-op.
-  if (ann.author === "import" && ann.type === "note") {
-    emit({ kind: "import-note-to-comment", id: ann.id });
-    return { ...base, type: "comment" } as Annotation;
-  }
+  // W8 (PR #756) reverses the #482 policy: imported Word reviewer comments
+  // are now first-class private notes (`author: "import", type: "note",
+  // audience: "private"`) until the user batch-promotes them via the
+  // BatchPromoteBar. The previous import-note→comment rewrite leaked
+  // un-promoted imports to Claude on every MCP read; falling through to
+  // the note branch below keeps them in the private bucket.
 
   if (ann.type === "flag" || ann.type === "note") {
     if (ann.type === "flag") {

--- a/tests/server/docx-comments.test.ts
+++ b/tests/server/docx-comments.test.ts
@@ -378,7 +378,7 @@ describe("injectCommentsAsAnnotations", () => {
     htmlToYDoc(doc, "<p>Hello World</p>");
   });
 
-  it("injects comments as annotations with correct fields", () => {
+  it("injects comments as private notes with importSource attribution (W8)", () => {
     const comments: DocxComment[] = [
       {
         commentId: "1",
@@ -390,7 +390,7 @@ describe("injectCommentsAsAnnotations", () => {
       },
     ];
 
-    const count = injectCommentsAsAnnotations(doc, comments);
+    const count = injectCommentsAsAnnotations(doc, comments, "review.docx");
     expect(count).toBe(1);
 
     const map = doc.getMap(Y_MAP_ANNOTATIONS);
@@ -402,14 +402,16 @@ describe("injectCommentsAsAnnotations", () => {
 
     expect(key).toMatch(/^import-[0-9a-f]{12}$/);
     expect(ann.author).toBe("import");
-    expect(ann.type).toBe("comment");
+    expect(ann.type).toBe("note");
+    expect(ann.audience).toBe("private");
     expect(ann.status).toBe("pending");
-    expect(ann.content).toBe("[Alice] Good point");
+    expect(ann.content).toBe("Good point");
+    expect(ann.importSource).toEqual({ author: "Alice", file: "review.docx" });
     expect(ann.range).toEqual({ from: 0, to: 5 });
     expect(ann.timestamp).toBe(new Date("2026-01-15T10:30:00Z").getTime());
   });
 
-  it("omits author prefix when authorName is Unknown", () => {
+  it('falls back to "unknown" file when fileName is omitted', () => {
     const comments: DocxComment[] = [
       {
         commentId: "2",
@@ -425,6 +427,7 @@ describe("injectCommentsAsAnnotations", () => {
     const map = doc.getMap(Y_MAP_ANNOTATIONS);
     const ann = Array.from(map.values())[0] as Record<string, unknown>;
     expect(ann.content).toBe("Just a note");
+    expect(ann.importSource).toEqual({ author: "Unknown", file: "unknown" });
   });
 
   it("returns 0 for empty comments array", () => {
@@ -506,6 +509,44 @@ describe("injectCommentsAsAnnotations", () => {
     const idsAfterSecond = Array.from(doc.getMap(Y_MAP_ANNOTATIONS).keys()).sort();
     expect(doc.getMap(Y_MAP_ANNOTATIONS).size).toBe(2);
     expect(idsAfterSecond).toEqual(idsAfterFirst);
+  });
+
+  it('migrates legacy `type: "comment"` import records to the W8 private-note shape', () => {
+    // Simulate a pre-W8 record: an import-author comment with `[author] ` content prefix
+    // and no importSource. Re-importing the same .docx should rewrite it in place to
+    // `type: "note"`, `audience: "private"` with the bodyText content + importSource.
+    const map = doc.getMap(Y_MAP_ANNOTATIONS);
+    const comment: DocxComment = {
+      commentId: "legacy",
+      authorName: "Carol",
+      bodyText: "Original body",
+      from: 0,
+      to: 5,
+    };
+    // Stand in for a real importAnnotationId by writing directly under the id
+    // we'll compute on re-import — the function is deterministic, so we mirror it:
+    const reimportComments = [comment];
+    injectCommentsAsAnnotations(doc, reimportComments, "old.docx");
+    const realId = Array.from(map.keys())[0];
+    const real = map.get(realId) as Record<string, unknown>;
+    expect(real.type).toBe("note");
+
+    // Now stomp the in-doc record back to the legacy shape and re-import:
+    map.set(realId, {
+      ...(real as Record<string, unknown>),
+      type: "comment",
+      content: "[Carol] Original body",
+      audience: undefined,
+      importSource: undefined,
+    } as never);
+
+    const migrated = injectCommentsAsAnnotations(doc, reimportComments, "new.docx");
+    expect(migrated).toBe(0); // dedup hits — but migration runs
+    const after = map.get(realId) as Record<string, unknown>;
+    expect(after.type).toBe("note");
+    expect(after.audience).toBe("private");
+    expect(after.content).toBe("Original body");
+    expect(after.importSource).toEqual({ author: "Carol", file: "new.docx" });
   });
 });
 

--- a/tests/shared/sanitize-ar1.test.ts
+++ b/tests/shared/sanitize-ar1.test.ts
@@ -70,19 +70,21 @@ describe("AR1: audience derivation for legacy annotations (no audience field)", 
     expect(events.some((e) => e.kind === "unknown-type")).toBe(true);
   });
 
-  it("import annotation gets audience:private (user triages before Claude sees them)", () => {
-    // import-note-to-comment rewrites type to "comment" per ADR-027,
-    // but audience stays "private" — the new routing signal for AR1.
+  it("W8: import-author notes pass through as private notes (not rewritten to comments)", () => {
+    // W8 (PR #756) reverses the #482 policy — imports stay as private notes
+    // until the user batch-promotes them. Sanitize must NOT silently rewrite
+    // type or it leaks un-promoted imports to Claude via tandem_getAnnotations.
     const { result, events } = collect({ ...baseAnn, author: "import", type: "note" });
-    expect(result.type).toBe("comment");
+    expect(result.type).toBe("note");
     expect(result.audience).toBe("private");
-    expect(events.some((e) => e.kind === "import-note-to-comment")).toBe(true);
-    expect(events.some((e) => e.kind === ("audience-derived" as string))).toBe(false);
+    expect(events.some((e) => e.kind === "import-note-to-comment")).toBe(false);
   });
 
-  it("import comment annotation gets audience:private (not yet promoted by user)", () => {
-    // An import annotation already stored as type:"comment" (after ADR-027 migration)
-    // should still be private until the user explicitly promotes it.
+  it("legacy import comment annotation gets audience:private (not yet promoted by user)", () => {
+    // An import annotation stored as type:"comment" under the pre-W8 model
+    // is still private — the docx-comments injector migrates it back to a
+    // note on next re-import, but until that happens AR1 must mark it private
+    // so Claude's view at least respects audience.
     const { result, events } = collect({ ...baseAnn, author: "import", type: "comment" });
     expect(result.audience).toBe("private");
     expect(events.some((e) => e.kind === ("audience-derived" as string))).toBe(false);


### PR DESCRIPTION
## Summary

Imported Word reviewer comments now land as **private notes** (ADR-027) instead of visible-to-Claude comments. The user batch-selects which to promote via per-card checkboxes and a sticky promote bar in the annotations rail; only after promotion does Claude see them.

Closes #577.

## Server

- `docx-comments.ts`: imports write `type: "note", audience: "private", author: "import"` with `importSource: { author, file }`. The `[author] ` content prefix is dropped — the UI renders the byline instead, so the raw bodyText is what users edit.
- Legacy `type: "comment"` import records are migrated in place on re-import so users opening an existing import-populated file get the batch-promote UX without re-importing.
- `FormatAdapter.apply()` gains an optional `ctx: ApplyContext` parameter so the docx adapter can stamp `importSource.file`.
- `tandem_getAnnotations` description updated to describe the import-as-private-note + batch-promote flow.

## Client

- `sendNoteToClaude` and new `promoteNotesToComments(ydoc, ids[])` flip `author: "import" → "user"` alongside `type: note → comment` so the channel observer's `author === "user"` gate actually fires the promotion event. Batch helper wraps N writes in one `withBrowser` transaction.
- `ImportedCard` renders "From: <author>" byline + always-visible selection checkbox.
- New `BatchPromoteBar` — sticky "<N> selected / Clear / Send N to Claude" at the top of the annotations rail.
- `SidePanel` prunes selection against the filtered visible list so the bar clears when FilterBar hides imports.

## ADR-027 invariants preserved

- Channel observer `add` gate (`author === "user" && type === "comment"`): unchanged.
- `tandem_getAnnotations` always excludes `type === "note"`: unchanged.
- Migration moves legacy records from `comment` → `note`, which moves data INTO the private bucket. Legacy comment-shaped imports were visible to Claude on read; now they're not.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 2359 passed (1 new migration test)
- [x] Updated server tests in `tests/server/docx-comments.test.ts` for the new private-note shape
- [ ] Visual: open a .docx with reviewer comments — verify imports appear as Notes with checkbox + "From: <author>" byline, are NOT in `tandem_getAnnotations`, and are NOT visible to Claude via channel
- [ ] Visual: check 2-3 boxes → BatchPromoteBar shows count → click Send → comments fire channel events to Claude; checkboxes clear
- [ ] Open a .docx that was already imported under the old shape — verify on re-import the records migrate to the note shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)