### PR TITLE
Wave 10 — slash-menu floating-pill polish + keyboard-hint footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,6 +187,58 @@
           0 22px 38px -22px rgba(0, 0, 0, 0.50);
       }
 
+      /* Slash command menu — v7 floating-card variant.
+         Inherits floating-pill bg/border/shadow then overrides border-radius
+         to a card shape (menus aren't pill-shaped) and stacks an item list
+         with a keyboard-hint footer. */
+      .tandem-slash-menu {
+        border-radius: var(--tandem-r-4);
+        min-width: 200px;
+        padding: var(--tandem-space-1);
+        z-index: var(--tandem-z-popover, 1100);
+      }
+      .tandem-slash-menu__item {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        padding: var(--tandem-space-1) var(--tandem-space-3);
+        border: 1px solid transparent;
+        border-radius: var(--tandem-r-2);
+        background: transparent;
+        color: var(--tandem-fg);
+        font: inherit;
+        font-size: var(--tandem-text-sm);
+        text-align: left;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      .tandem-slash-menu__item:hover {
+        background: color-mix(in srgb, var(--tandem-fg) 5%, transparent);
+      }
+      .tandem-slash-menu__item[aria-selected="true"] {
+        background: var(--tandem-accent-bg);
+        color: var(--tandem-accent-fg-strong);
+        border-color: var(--tandem-accent-border);
+      }
+      .tandem-slash-menu__hint {
+        display: flex;
+        gap: var(--tandem-space-3);
+        padding: var(--tandem-space-1) var(--tandem-space-3);
+        margin-top: var(--tandem-space-1);
+        border-top: 1px solid var(--tandem-border);
+        font-size: var(--tandem-text-2xs);
+        color: var(--tandem-fg-faint);
+      }
+      .tandem-slash-menu__hint kbd {
+        font-family: var(--tandem-font-mono);
+        font-size: var(--tandem-text-2xs);
+        padding: 0 4px;
+        border: 1px solid var(--tandem-border);
+        border-radius: var(--tandem-r-1);
+        background: var(--tandem-surface-muted);
+        color: var(--tandem-fg-subtle);
+      }
+
       [data-theme="dark"] {
         --tandem-bg: oklch(0.18 0.012 270);
         --tandem-fg: oklch(0.94 0.005 80);

--- a/src/client/editor/slash-menu/extension.ts
+++ b/src/client/editor/slash-menu/extension.ts
@@ -91,6 +91,25 @@ function clearChildren(element: HTMLDivElement) {
   while (element.firstChild) element.removeChild(element.firstChild);
 }
 
+function buildHintRow(): HTMLDivElement {
+  const hint = document.createElement("div");
+  hint.className = "tandem-slash-menu__hint";
+  const groups: Array<[string, string]> = [
+    ["↑↓", "navigate"],
+    ["↵", "insert"],
+    ["esc", "close"],
+  ];
+  for (const [key, label] of groups) {
+    const span = document.createElement("span");
+    const kbd = document.createElement("kbd");
+    kbd.textContent = key;
+    span.appendChild(kbd);
+    span.appendChild(document.createTextNode(` ${label}`));
+    hint.appendChild(span);
+  }
+  return hint;
+}
+
 function renderSlashCommandMenu(
   element: HTMLDivElement,
   active: ActiveSlashCommand,
@@ -100,49 +119,42 @@ function renderSlashCommandMenu(
 ) {
   const commands = filterSlashCommands(active.query);
   clearChildren(element);
-  element.setAttribute("role", "listbox");
-  element.setAttribute("aria-label", "Slash commands");
+  element.className = "tandem-floating-pill tandem-slash-menu";
 
+  // Listbox holds ONLY the option buttons so ARIA's "listbox children must
+  // be options" rule isn't violated by the hint footer.
+  const listbox = document.createElement("div");
+  listbox.setAttribute("role", "listbox");
+  listbox.setAttribute("aria-label", "Slash commands");
+
+  // Empty results are filtered upstream by resolveActiveSlashCommand (the
+  // menu closes), so commands.length is always > 0 by the time we render.
   commands.forEach((command, index) => {
     const button = document.createElement("button");
     button.type = "button";
     button.role = "option";
     button.id = `slash-command-${command.id}`;
+    button.className = "tandem-slash-menu__item";
     button.setAttribute("aria-selected", String(index === active.selectedIndex));
     button.textContent = command.label;
     button.dataset.commandId = command.id;
-    button.style.cssText =
-      "display: block; width: 100%; padding: 7px 10px; border: 0; border-radius: var(--tandem-r-2); " +
-      "background: transparent; color: var(--tandem-fg); font: inherit; font-size: 13px; " +
-      "text-align: left; cursor: pointer;";
-
-    if (index === active.selectedIndex) {
-      button.style.background = "var(--tandem-accent-bg)";
-      button.style.color = "var(--tandem-accent)";
-    }
 
     button.addEventListener("mouseenter", () => dispatchSelection(index));
     button.addEventListener("mousedown", (e) => {
       e.preventDefault();
       executeCommand(command);
     });
-    element.appendChild(button);
+    listbox.appendChild(button);
   });
+
+  element.appendChild(listbox);
+  element.appendChild(buildHintRow());
 
   const coords = editor.view.coordsAtPos(active.from);
   element.style.display = "block";
   element.style.position = "fixed";
   element.style.left = `${Math.max(8, coords.left)}px`;
   element.style.top = `${coords.bottom + 8}px`;
-  element.style.zIndex = "1100";
-  element.style.minWidth = "180px";
-  element.style.padding = "4px";
-  element.style.border = "1px solid var(--tandem-border)";
-  element.style.borderRadius = "6px";
-  element.style.background = "var(--tandem-surface)";
-  element.style.boxShadow =
-    "0 1px 2px color-mix(in srgb, var(--tandem-fg) 4%, transparent), " +
-    "0 8px 28px color-mix(in srgb, var(--tandem-fg) 10%, transparent)";
 }
 
 function executeSlashCommand(editor: TiptapEditor, active: ActiveSlashCommand) {


### PR DESCRIPTION
## Summary

Visual polish on the existing slash command menu using the v7 floating-pill recipe and semantic tokens, plus a keyboard-hint footer row.

## What changed

- Menu container now consumes `.tandem-floating-pill .tandem-slash-menu` so it picks up the shared bg/border/shadow/backdrop-filter triple (matches fmtbar, status pill, titlebar clusters). Override radius to card shape — menus aren't pill-shaped.
- Items use `.tandem-slash-menu__item` with separate hover (subtle neutral) and `[aria-selected="true"]` (accent triple) states. Previous render collapsed both into one inline rule per button.
- New `.tandem-slash-menu__hint` footer row shows "↑↓ navigate / ↵ insert / esc close" using mono `<kbd>` chips. Built with `createElement` + `textContent` (no `innerHTML`).
- Listbox is now an inner `<div role="listbox">` so the hint row sits as a sibling, not a child — ARIA's "listbox children must be options" rule is satisfied. E2E selectors (`getByRole("listbox" / "option")`) unaffected.

## Test plan

- [x] `npm run typecheck` clean
- [x] `tests/client/slash-command.test.ts` — 12 passed
- [ ] Visual: trigger `/` in the editor — verify card uses the same shadow/border/backdrop as other floating pills; selected item shows accent, hovered (non-selected) shows subtle neutral; hint footer visible
- [ ] Theme cycle: verify menu reads correctly in light, dark, warm

🤖 Generated with [Claude Code](https://claude.com/claude-code)