### PR TITLE
Fix post-Wave correctness issues (origin tagging, rev bumps, security, CRDT)

### DIFF
--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -305,14 +305,12 @@ $effect(() => {
   const validIds = new Set(
     filteredData.pending.filter((a) => a.author === "import" && a.type === "note").map((a) => a.id),
   );
-  let dirty = false;
-  for (const id of selectedImportIds) {
-    if (!validIds.has(id)) {
-      selectedImportIds.delete(id);
-      dirty = true;
-    }
-  }
-  if (dirty) selectedImportIds = new Set(selectedImportIds);
+  // Read+write of selectedImportIds is wrapped in untrack() so the reactive
+  // write doesn't re-trigger this effect and cause a double-run loop.
+  untrack(() => {
+    const pruned = new Set([...selectedImportIds].filter((id) => validIds.has(id)));
+    if (pruned.size !== selectedImportIds.size) selectedImportIds = pruned;
+  });
 });
 
 function toggleImportSelection(id: string) {

--- a/src/client/panels/annotation-actions.ts
+++ b/src/client/panels/annotation-actions.ts
@@ -17,21 +17,24 @@ export function editAnnotation(ydoc: Y.Doc | null, id: string, newContent: strin
   if (!raw) return;
   const ann = sanitizeAnnotation(raw, warn);
 
-  if (ann.suggestedText !== undefined) {
-    try {
-      const parsed = JSON.parse(newContent) as { suggestedText: string; content: string };
-      map.set(id, {
-        ...ann,
-        suggestedText: parsed.suggestedText,
-        content: parsed.content,
-        editedAt: Date.now(),
-      });
-    } catch {
-      console.warn(`[annotation-actions] Failed to parse edit payload for annotation ${id}`);
+  withBrowser(ydoc, () => {
+    if (ann.suggestedText !== undefined) {
+      try {
+        const parsed = JSON.parse(newContent) as { suggestedText: string; content: string };
+        map.set(id, {
+          ...ann,
+          suggestedText: parsed.suggestedText,
+          content: parsed.content,
+          editedAt: Date.now(),
+          rev: (ann.rev ?? 0) + 1,
+        });
+      } catch {
+        console.warn(`[annotation-actions] Failed to parse edit payload for annotation ${id}`);
+      }
+      return;
     }
-    return;
-  }
-  map.set(id, { ...ann, content: newContent, editedAt: Date.now() });
+    map.set(id, { ...ann, content: newContent, editedAt: Date.now(), rev: (ann.rev ?? 0) + 1 });
+  });
 }
 
 /**
@@ -57,6 +60,7 @@ function promotedAnnotation(ann: Annotation): Annotation {
     author: ann.author === "import" ? ("user" as const) : ann.author,
     audience: "outbound" as const,
     promotedFrom: "note" as const,
+    rev: (ann.rev ?? 0) + 1,
   };
 }
 

--- a/src/client/positions.ts
+++ b/src/client/positions.ts
@@ -313,6 +313,10 @@ export function annotationToPmRange(
       console.warn(
         `[positions] annotationToPmRange: inverted rel range for ${ann.id}, falling back to flat`,
       );
+    } else {
+      console.warn(
+        `[positions] annotationToPmRange: relRange resolved to null for ${ann.id}, falling back to flat`,
+      );
     }
   }
   // Fall back to flat offsets

--- a/src/client/shell/TitleBar.svelte
+++ b/src/client/shell/TitleBar.svelte
@@ -35,10 +35,15 @@ interface Props {
   /** Open Settings popover. */
   onOpenSettings?: () => void;
   /**
-   * Open the new SettingsModal (Wave 1 sibling component). Wired separately
+   * Open the new SettingsModal (Wave 1 stable prop slot). Wired separately
    * from `onOpenSettings` so the existing gear keeps invoking the popover
    * until Wave 2 retires it. Triggered today via the command palette /
    * `Ctrl+Shift+,` shortcut registered in `actions/builtin.svelte.ts`.
+   * Intentionally unused inside this component — destructured as
+   * `_onOpenSettingsModal` so the compiler treats it as an acknowledged
+   * no-op rather than an oversight. Intentionally NOT wired to
+   * `aria-keyshortcuts` on the gear (that attribute describes shortcuts
+   * activating the labelled element; Ctrl+Shift+, opens a different surface).
    */
   onOpenSettingsModal?: () => void;
   /** Bindable settings button reference (used for keyboard shortcut anchoring). */
@@ -68,7 +73,7 @@ let {
   onAuthorshipChange,
   onOpenHelp,
   onOpenSettings,
-  onOpenSettingsModal,
+  onOpenSettingsModal: _onOpenSettingsModal,
   settingsBtn = $bindable(null),
   updateAvailable = false,
 }: Props = $props();
@@ -165,23 +170,6 @@ async function closeWindow() {
 }
 
 const themeLabel = $derived(THEME_LABEL[theme]);
-
-/**
- * `onOpenSettingsModal` is a Wave 1 stable prop slot, declared so Wave 2 can
- * retire `SettingsPopover` by replacing the gear's `onOpenSettings` wiring
- * with this prop without re-touching `TitleBar.svelte`. Today the trigger is
- * the `settings-modal` action (Ctrl+Shift+,) wired in
- * `actions/builtin.svelte.ts`, so the prop is intentionally unused inside
- * this component. Read it inside `$effect` (not a top-level expression) so
- * svelte-check sees a live reference and stays quiet about both the
- * "declared but never read" error and the `state_referenced_locally`
- * warning. Intentionally NOT exposed via `aria-keyshortcuts` on the gear
- * button — that attribute describes shortcuts that activate the labelled
- * element, and Ctrl+Shift+, opens a different surface.
- */
-$effect(() => {
-  void onOpenSettingsModal;
-});
 </script>
 
 <div class="title-bar" data-testid="title-bar">

--- a/src/server/file-io/docx-comments.ts
+++ b/src/server/file-io/docx-comments.ts
@@ -201,6 +201,12 @@ export function injectCommentsAsAnnotations(
   let injected = 0;
   let migrated = 0;
 
+  // `withInternal` here is the authoritative origin. When callers invoke
+  // this function inside an outer `withInternal` or `withReload` transact
+  // (as file-opener.ts does), Y.js nested transactions inherit the outermost
+  // origin — so the effective origin becomes whatever the outer call used.
+  // This is intentional: a reload path calling this inside `withReload` wants
+  // reload semantics (durable-sync persists, channel skips).
   withInternal(doc, () => {
     for (const comment of comments) {
       const result = anchoredRange(doc, toFlatOffset(comment.from), toFlatOffset(comment.to));

--- a/src/server/integrations/schema.ts
+++ b/src/server/integrations/schema.ts
@@ -57,11 +57,13 @@ const LoopbackUrl = z
         return false;
       }
       if (parsed.protocol !== "http:") return false;
-      return parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost";
+      // Reject URLs with embedded credentials (userinfo bypass: http://evil.com@127.0.0.1/)
+      if (parsed.username !== "" || parsed.password !== "") return false;
+      return parsed.hostname === "127.0.0.1";
     },
     {
       message:
-        "url must be an http loopback URL (http://127.0.0.1 or http://localhost) — Tandem's MCP endpoint is always loopback",
+        "url must be an http loopback URL (http://127.0.0.1) — Tandem's MCP endpoint is always loopback",
     },
   );
 

--- a/src/server/integrations/storage.ts
+++ b/src/server/integrations/storage.ts
@@ -79,7 +79,13 @@ async function readIntegrationsFile(filePath: string): Promise<IntegrationsFile>
   }
 
   const migrated = migrateUp(parsed, version, INTEGRATIONS_SCHEMA_VERSION);
-  const result = IntegrationsFileSchema.safeParse(migrated);
+  // Normalize legacy http://localhost URLs to http://127.0.0.1 before schema
+  // validation. The LoopbackUrl validator accepts only 127.0.0.1; files written
+  // before this tightening may carry localhost URLs (auto-config always wrote
+  // 127.0.0.1, but manual edits could differ). Normalize silently here; the
+  // corrected value is persisted on the next write.
+  const normalized = normalizeLocalhostUrls(migrated);
+  const result = IntegrationsFileSchema.safeParse(normalized);
   if (!result.success) {
     throw new Error(
       `integrations.json failed validation after migration (${result.error.message}). Original file preserved at ${filePath}.`,
@@ -223,6 +229,29 @@ function readSchemaVersion(parsed: unknown): number | null {
     return (parsed as { schemaVersion: number }).schemaVersion;
   }
   return null;
+}
+
+/**
+ * Replace `http://localhost` with `http://127.0.0.1` in any `url` field across
+ * all integration records. Operates on the raw unknown post-migration shape so
+ * it runs before Zod validation (which now rejects localhost). Safe to call on
+ * any value — non-object / non-array inputs are returned unchanged.
+ */
+function normalizeLocalhostUrls(data: unknown): unknown {
+  if (Array.isArray(data)) return data.map(normalizeLocalhostUrls);
+  if (data === null || typeof data !== "object") return data;
+  const obj = data as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    if (key === "url" && typeof obj[key] === "string") {
+      result[key] = (obj[key] as string).replace(/^http:\/\/localhost([:\/]|$)/, (m) =>
+        m.replace("localhost", "127.0.0.1"),
+      );
+    } else {
+      result[key] = normalizeLocalhostUrls(obj[key]);
+    }
+  }
+  return result;
 }
 
 function enforceReferentialIntegrity(file: IntegrationsFile): IntegrationsFile {

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -379,7 +379,9 @@ export function registerAnnotationTools(server: McpServer): void {
         if (!da) return noDocumentError();
         const from = toFlatOffset(rawFrom);
         const to = toFlatOffset(rawTo);
-        const result = anchoredRange(da.ydoc, from, to, textSnapshot);
+        const result = anchoredRange(da.ydoc, from, to, textSnapshot, {
+          rejectHeadingOverlap: true,
+        });
         if (!result.ok) {
           notifyRangeFailure(result, "tandem_comment", documentId);
           return rangeFailureToError(result);

--- a/src/server/positions.ts
+++ b/src/server/positions.ts
@@ -257,15 +257,20 @@ export function validateRange(
 
 /**
  * Validate a range and create both flat and CRDT-anchored positions in one call.
- *
+ * Pass `opts.rejectHeadingOverlap: true` to also reject ranges that overlap
+ * heading prefixes (same guard used by `tandem_edit`).
  */
 export function anchoredRange(
   ydoc: Y.Doc,
   from: FlatOffset,
   to: FlatOffset,
   textSnapshot?: string,
+  opts?: { rejectHeadingOverlap?: boolean },
 ): AnchoredRangeResult | (RangeValidation & { ok: false }) {
-  const validation = validateRange(ydoc, from, to, { textSnapshot });
+  const validation = validateRange(ydoc, from, to, {
+    textSnapshot,
+    rejectHeadingOverlap: opts?.rejectHeadingOverlap,
+  });
   if (!validation.ok) return validation;
 
   const range: DocumentRange = { from, to };

--- a/src/shared/sanitize.ts
+++ b/src/shared/sanitize.ts
@@ -18,6 +18,12 @@ export type SanitizationEvent =
   | { kind: "question-to-comment"; id: string }
   | { kind: "malformed-suggestion-json"; id: string }
   | { kind: "unknown-type"; id: string; rawType: string }
+  /**
+   * @deprecated Never emitted by `sanitizeAnnotation` since Wave 8 (PR #756)
+   * reversed the import-note→comment rewrite. Retained in the union so that
+   * log-parsing tools and `relaySanitizationEvent` don't break on event streams
+   * that pre-date W8. Do not add new call sites.
+   */
   | { kind: "import-note-to-comment"; id: string }
   | { kind: "audience-conflict-resolved"; id: string };
 

--- a/tests/server/integrations/schema.test.ts
+++ b/tests/server/integrations/schema.test.ts
@@ -228,12 +228,12 @@ describe("LoopbackUrl constraint", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts http://localhost", () => {
+  it("rejects http://localhost (schema now requires http://127.0.0.1 to match API middleware)", () => {
     const result = IntegrationConfigSchema.safeParse({
       ...baseClaudeCode,
       url: "http://localhost:3479",
     });
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 
   it("accepts an http loopback URL with a path", () => {
@@ -264,6 +264,15 @@ describe("LoopbackUrl constraint", () => {
     const result = IntegrationConfigSchema.safeParse({
       ...baseClaudeCode,
       url: "file:///etc/passwd",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a userinfo-bypass URL (http://evil.com@127.0.0.1/)", () => {
+    // URL.hostname resolves to "127.0.0.1" but the effective host is evil.com.
+    const result = IntegrationConfigSchema.safeParse({
+      ...baseClaudeCode,
+      url: "http://evil.com@127.0.0.1:3479",
     });
     expect(result.success).toBe(false);
   });


### PR DESCRIPTION
## Summary

Multi-angle adversarial review of recent Wave commits surfaced 9 correctness/security issues. All fixes verified with `npm test` (2354 pass) and `svelte-check --fail-on-warnings` (0 errors, 0 warnings).

- **`annotation-actions.ts`**: `editAnnotation` called `map.set` without `withBrowser` origin tag (Critical Rule #2 violation) and without bumping `rev` (LWW divergence vs `tandem_editAnnotation`); `promotedAnnotation()` also missing `rev` bump — fixed both
- **`SidePanel.svelte`**: prune effect read+wrote `selectedImportIds` in the same reactive scope, causing a double-run loop; wrapped the write side in `untrack()`
- **`TitleBar.svelte`**: `$effect(() => { void onOpenSettingsModal; })` was a hack to silence svelte-check on an intentionally unused prop; replaced with `_onOpenSettingsModal` alias in `$props()` destructuring (the idiomatic Svelte 5 pattern)
- **`positions.ts` (server)**: `anchoredRange` now accepts `opts.rejectHeadingOverlap`; `tandem_comment` passes it, matching the guard already present on `tandem_edit` — fixes a bug where Claude could annotate heading prefixes via `tandem_comment`
- **`positions.ts` (client)**: silent flat-offset fallback when `relRangeToPmPositions` returns null now emits `console.warn` (inverted-range case already had one)
- **`integrations/schema.ts`**: `LoopbackUrl` tightened to `127.0.0.1` only (removes inconsistency with API middleware's DNS-rebinding guard); userinfo bypass (`http://evil.com@127.0.0.1/`) now explicitly rejected
- **`integrations/storage.ts`**: pre-validation normalization of `localhost` → `127.0.0.1` so existing `integrations.json` files written before this tightening are upgraded gracefully rather than throwing on startup
- **`sanitize.ts`**: `import-note-to-comment` union member now documented as never-emitted since Wave 8 (retained for log-parsing compat)
- **`docx-comments.ts`**: added comment explaining Y.js nested-transaction origin inheritance for the reload path

## Test plan

- [ ] `npm test` — all 2354 tests pass
- [ ] `npm run typecheck` — 0 errors, 0 svelte-check warnings
- [ ] Manually edit a comment in the sidebar and verify it round-trips through the durable store with an incremented `rev`
- [ ] Attempt `tandem_comment` on a heading prefix range — should return `INVALID_RANGE` error
- [ ] Integration wizard: verify `http://localhost` is rejected; `http://127.0.0.1` accepted; `http://evil.com@127.0.0.1` rejected

https://claude.ai/code/session_01VKU2LNz48XQz5xCn4gRNgZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKU2LNz48XQz5xCn4gRNgZ)_