### PR TITLE
Wave C — selection popup uses shared floating-pill recipe

### DIFF
--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -327,11 +327,15 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
 </script>
 
 {#if showPopup && selectionPosition}
+  <!-- Wave C: selection popup uses the shared .tandem-floating-pill recipe
+       (same shadow + warm/white/dark variants as the formatting bar and
+       titlebar pills). Replaces the previous inline 2-layer shadow. -->
   <div
     bind:this={toolbarEl}
     role="toolbar"
     aria-label="Selection tools"
-    style={`position: fixed; left: ${selectionPosition.left}px; top: ${selectionPosition.top}px; transform: translateX(-50%); display: flex; flex-direction: column; background: var(--tandem-surface); border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-4); box-shadow: 0 1px 2px color-mix(in srgb, var(--tandem-fg) 4%, transparent), 0 8px 28px color-mix(in srgb, var(--tandem-fg) 10%, transparent); z-index: var(--tandem-z-modal); min-width: 260px; max-width: 320px;`}
+    class="tandem-floating-pill"
+    style={`position: fixed; left: ${selectionPosition.left}px; top: ${selectionPosition.top}px; transform: translateX(-50%); display: flex; flex-direction: column; border-radius: var(--tandem-r-4); z-index: var(--tandem-z-modal); min-width: 260px; max-width: 320px;`}
   >
     <div style="display: flex; align-items: center; gap: 1px; padding: 4px; border-bottom: 1px solid var(--tandem-border);">
       <ToolbarButton


### PR DESCRIPTION
## Summary

Fourth wave of the post-W10 redesign-parity sweep. **Stacked on Wave B (#761) → A (#760) → D (#759)** — merge in order.

Small surgical wave. The selection annotation popup was the last surface with an inline 2-layer custom box-shadow. Replaced with the `.tandem-floating-pill` class so it inherits the same `--c7-pill-shadow` token + warm/white/dark variants the formatting bar and titlebar pills already use.

## What changed

- `src/client/editor/toolbar/Toolbar.svelte` — selection popup uses `.tandem-floating-pill`. Inline style now only carries position + size constraints; background/border/shadow come from the shared recipe.

## Why this is small

- Formatting bar already uses `.tandem-floating-pill` (shipped in W3).
- Wave A's rail-tab + ModeToggle active-segment shadows are intentional inset segment shadows matching the calm-v7 `.c7-rail-tabs span.on` / `.c7-seg button.on` recipes — not elevations.
- Plan's "decide once between `--tandem-shadow-2` and a new `--tandem-shadow-pill`" is moot: `--c7-pill-shadow` (defined in index.html, theme-aware) already matches the redesign exactly.

## Test plan

- [x] `npm run typecheck` — clean
- [ ] Manual: select text in a document → popup appears with the same elevation as the formatting bar (no longer looks like a "tooltip with custom shadow")
- [ ] Manual: switch to dark theme → popup inverts to dark-pill variant correctly

## Plan reference

Wave C in `~/.claude/plans/abstract-tinkering-kahan.md`. Next up: Wave F (placeholder fix + format-before-type + margin card hover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)