### PR TITLE
Knowledge-graph pilot: 25 hand-curated concept/rule/ADR nodes

### DIFF
--- a/.claude/knowledge-graph/README.md
+++ b/.claude/knowledge-graph/README.md
@@ -1,0 +1,56 @@
+# Knowledge Graph (Pilot)
+
+A small hand-curated graph of Tandem's **concepts, critical rules, and most-cited ADRs**. Built for Claude (me) to answer questions like "what governs writes to Y.Doc?" or "which rules apply when I touch coordinate-system code?" — the prose docs encode this implicitly; the graph makes it queryable.
+
+**Status:** Pilot (started 2026-05-18).
+
+**Kill criterion:** Review on **2026-06-01**. If I haven't run a query that surprised me in two weeks, delete this directory.
+
+## Why this exists (and what was deliberately cut)
+
+Two adversarial reviews of the original 150-node plan landed hard:
+
+- **Maintenance decay > build time.** Tandem ships ~20 PRs/week. A large graph rots faster than it pays off. Stale graph is *worse* than no graph because structured data looks authoritative.
+- **No query the graph wins that grep loses.** For most tasks (add MCP tool, fix a bug, refactor a function), `grep` is faster and authoritative. The one class of query grep loses: "what *constraints* govern a concept that spans multiple modules?" — e.g., the origin contract, coordinate-system rules.
+
+The pilot keeps only the slice that survives that critique: **concept ⇄ rule ⇄ ADR**, no file-level or MCP-tool nodes (those are grep's job).
+
+## Layout
+
+- `nodes/<id>.md` — one file per node, YAML frontmatter + prose body
+- `edges.json` — typed relationships between nodes
+- `../../scripts/kg.mjs` — query CLI (`npm run kg neighbors <id>` etc.)
+- `../../scripts/kg-lint.mjs` — validator (`npm run kg:lint`)
+
+## Node schema (frontmatter)
+
+```yaml
+---
+id: concept-y-doc           # kebab-case, stable
+type: concept               # concept | rule | adr
+name: Y.Doc                 # human-readable
+last_verified: 2026-05-18   # bump when content is checked
+sources:                    # file paths and doc anchors
+  - src/server/yjs/
+  - docs/architecture.md#y-map-observer-ownership
+---
+```
+
+The body is prose — short summary in the first sentence, expert-targeted detail below.
+
+## Edge types (7)
+
+- `governs` — rule → concept it constrains
+- `decided_by` — concept → ADR that decided its design
+- `supersedes` — ADR → ADR it replaces (currently unused — add if I find verifiable cases)
+- `implemented_in` — concept → file or symbol
+- `refines` — child concept → parent concept
+- `related` — bidirectional "see also"
+- `enforced_by` — rule → hook / script / lint that enforces it
+
+## Maintenance
+
+- `npm run kg:lint` validates every `source:` path exists and every edge endpoint resolves
+- Bump `last_verified` when you re-read a node's body and confirm it
+- If a node's `last_verified` is more than 60 days old, lint warns (not fails)
+- This is project memory for Claude, not user-facing docs — keep prose terse and current rather than comprehensive

--- a/.claude/knowledge-graph/edges.json
+++ b/.claude/knowledge-graph/edges.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "_note": "Edge types: governs | decided_by | supersedes | implemented_in | refines | related | enforced_by",
+  "edges": [
+    { "from": "rule-ymap-key-constants", "to": "concept-y-doc", "type": "governs" },
+    { "from": "rule-origin-helpers", "to": "concept-origin-contract", "type": "governs" },
+    { "from": "rule-origin-helpers", "to": "concept-y-doc", "type": "governs" },
+    { "from": "rule-stdout-reserved", "to": "concept-mcp-transport", "type": "governs" },
+    { "from": "rule-validate-range", "to": "concept-coord-flat-offset", "type": "governs" },
+    { "from": "rule-validate-range", "to": "concept-coord-yjs-relative", "type": "governs" },
+    { "from": "rule-extract-text-not-markdown", "to": "concept-coord-flat-offset", "type": "governs" },
+    { "from": "rule-edit-rejects-heading-markup", "to": "concept-coord-flat-offset", "type": "governs" },
+
+    { "from": "concept-y-doc", "to": "adr-031", "type": "decided_by" },
+    { "from": "concept-origin-contract", "to": "adr-031", "type": "decided_by" },
+    { "from": "concept-coord-flat-offset", "to": "adr-018", "type": "decided_by" },
+    { "from": "concept-coord-prosemirror", "to": "adr-018", "type": "decided_by" },
+    { "from": "concept-coord-yjs-relative", "to": "adr-018", "type": "decided_by" },
+    { "from": "concept-annotation-lifecycle", "to": "adr-027", "type": "decided_by" },
+    { "from": "concept-multi-doc", "to": "adr-033", "type": "decided_by" },
+    { "from": "concept-file-watcher", "to": "adr-034", "type": "decided_by" },
+    { "from": "concept-mcp-transport", "to": "adr-038", "type": "decided_by" },
+    { "from": "concept-channel-events", "to": "adr-038", "type": "decided_by" },
+
+    { "from": "concept-channel-events", "to": "concept-origin-contract", "type": "refines", "note": "Channel emission is a property of the origin contract" },
+    { "from": "concept-awareness", "to": "concept-y-doc", "type": "refines", "note": "Awareness lives in a Y.Map subkey" },
+    { "from": "concept-annotation-lifecycle", "to": "concept-y-doc", "type": "refines", "note": "Annotations live in Y.Map('annotations')" },
+    { "from": "concept-multi-doc", "to": "concept-y-doc", "type": "refines", "note": "One Y.Doc per documentId" },
+
+    { "from": "concept-file-watcher", "to": "concept-origin-contract", "type": "related", "note": "reloadFromDisk uses withReload origin" },
+    { "from": "concept-coord-flat-offset", "to": "concept-coord-yjs-relative", "type": "related", "note": "AnchoredRange pairs them" },
+    { "from": "concept-coord-flat-offset", "to": "concept-coord-prosemirror", "type": "related", "note": "Converted at client/server boundary" },
+    { "from": "adr-033", "to": "adr-034", "type": "related", "note": "Registry exposes the file-open named entry points" },
+    { "from": "concept-solo-tandem-mode", "to": "concept-annotation-lifecycle", "type": "related", "note": "Mode gates whether Claude surfaces annotations" },
+    { "from": "concept-annotation-lifecycle", "to": "concept-coord-yjs-relative", "type": "related", "note": "Annotation ranges use AnchoredRange (flat + Y.RelativePosition)" }
+  ]
+}

--- a/.claude/knowledge-graph/nodes/adr-018.md
+++ b/.claude/knowledge-graph/nodes/adr-018.md
@@ -1,0 +1,19 @@
+---
+id: adr-018
+type: adr
+name: ADR-018 — Unified Position Modules
+last_verified: 2026-05-18
+sources:
+  - docs/decisions.md#adr-018-unified-position-modules-issue-68
+  - src/shared/positions/
+  - src/server/positions.ts
+  - src/client/positions.ts
+---
+
+# ADR-018 — Unified Position Modules
+
+Consolidates coordinate-system code into three modules — `src/shared/positions/` (types), `src/server/positions.ts`, `src/client/positions.ts` — instead of scattered conversion helpers. Establishes the three-coordinate-system model: flat offsets (`concept-coord-flat-offset`), ProseMirror positions (`concept-coord-prosemirror`), Y.RelativePositions (`concept-coord-yjs-relative`).
+
+Refined by `adr-032` (position module results as tagged variants), which adds tagged-variant return types so the three coordinate kinds can't be silently confused at call sites.
+
+Full ADR text: see `docs/decisions.md`.

--- a/.claude/knowledge-graph/nodes/adr-027.md
+++ b/.claude/knowledge-graph/nodes/adr-027.md
@@ -1,0 +1,19 @@
+---
+id: adr-027
+type: adr
+name: ADR-027 — Annotation System Redesign (audience-based)
+last_verified: 2026-05-18
+sources:
+  - docs/decisions.md#adr-027-annotation-system-redesign--audience-based-model
+  - src/server/annotations/
+---
+
+# ADR-027 — Annotation System Redesign
+
+Replaces the earlier multi-type annotation model (5 types, `directedAt` field) with an audience-based model: 3 types (`highlight`, `comment`, `note`) and an implicit audience derived from author + type. `directedAt` is deprecated and stripped on read.
+
+**Privacy contract:** `note` is user-private. Claude never reads notes via MCP tools or channel events. The MCP read paths and channel event filtering strip note entries before responding. This is the load-bearing rule reviewed by the `annotation-model-reviewer` agent.
+
+Refined by `adr-035` (Annotation Lifecycle Module) which extracts the pending → accepted/dismissed state machine into a single module.
+
+One of the two most-referenced ADRs (14 cross-references in repo).

--- a/.claude/knowledge-graph/nodes/adr-031.md
+++ b/.claude/knowledge-graph/nodes/adr-031.md
@@ -1,0 +1,19 @@
+---
+id: adr-031
+type: adr
+name: ADR-031 — Origin-Tagged Transaction Wrappers
+last_verified: 2026-05-18
+sources:
+  - docs/decisions.md#adr-031-origin-tagged-transaction-wrappers
+  - src/shared/origins.ts
+---
+
+# ADR-031 — Origin-Tagged Transaction Wrappers
+
+Establishes the five-origin contract for Y.Doc writes (`concept-origin-contract`): `mcp`, `file-sync`, `internal`, `reload`, `browser`. Each origin has defined behavior for the three observer-skip-sets (channel events, durable-sync, tombstone ledger). The wrapper choice is the contract — picking the wrong helper is a silent bug.
+
+Includes a worked-example enumeration ("how to choose") covering every write path in the codebase: session restore, file-watcher reload, MCP handlers, durable-sync echoes, browser edits, etc.
+
+Enforced by `rule-origin-helpers` (pre-commit hook blocks raw `doc.transact`).
+
+One of the load-bearing ADRs (13 cross-references). The `crdt-reviewer` agent specifically checks for origin-tag correctness.

--- a/.claude/knowledge-graph/nodes/adr-033.md
+++ b/.claude/knowledge-graph/nodes/adr-033.md
@@ -1,0 +1,17 @@
+---
+id: adr-033
+type: adr
+name: ADR-033 — Document Registry and Named Hocuspocus Lifecycle
+last_verified: 2026-05-18
+sources:
+  - docs/decisions.md#adr-033-document-registry-and-named-hocuspocus-lifecycle-interface
+  - src/server/documents/
+---
+
+# ADR-033 — Document Registry
+
+Single registry that owns document lifecycle (open, close, switch, force-reload) and exposes a named interface for Hocuspocus events (`onLoadDocument`, `onDocSwapped`, etc.). Replaces the earlier ad-hoc map + scattered lifecycle hooks.
+
+Why a registry: the previous design had document-open code, the file watcher, and the durable-sync observer each tracking lifecycle independently, which produced subtle bugs (e.g., observers reattached to the wrong Y.Doc instance after Hocuspocus swapped). The registry centralizes the lifecycle so Hocuspocus's `onDocSwapped` callback knows exactly which observers to reattach.
+
+See also `adr-034` (file-open pipeline), which is the named entry-point pattern this registry exposes.

--- a/.claude/knowledge-graph/nodes/adr-034.md
+++ b/.claude/knowledge-graph/nodes/adr-034.md
@@ -1,0 +1,18 @@
+---
+id: adr-034
+type: adr
+name: ADR-034 — File-Open Pipeline with Named Entry Points
+last_verified: 2026-05-18
+sources:
+  - docs/decisions.md#adr-034-file-open-pipeline-with-named-entry-points-and-shared-core
+  - src/server/mcp/file-opener.ts
+  - src/server/mcp/document-service.ts
+---
+
+# ADR-034 — File-Open Pipeline
+
+Defines named entry points (`openFileByPath`, the `POST /api/open` HTTP route, MCP `tandem_open`, Tauri file-association handlers) that all converge on a single shared core. The named entry points carry intent (was this triggered by Tauri cold start? a user click? an MCP tool?), the shared core does the work.
+
+Why named entry points: earlier code had each entry path replicate the file-open logic, which produced drift (e.g., one path would re-anchor word-comment ranges, another wouldn't). Named entry points make the call-site intent explicit while the shared core enforces invariants once.
+
+Inline-cites ADRs 003, 018, 019, 023, 024, 027, 028, 031, 032, 033 — the file-open path touches almost every subsystem. Often the right answer to "where do I add this?" is "in the shared core, and possibly a new named entry point."

--- a/.claude/knowledge-graph/nodes/adr-038.md
+++ b/.claude/knowledge-graph/nodes/adr-038.md
@@ -1,0 +1,22 @@
+---
+id: adr-038
+type: adr
+name: ADR-038 — MCP-First Integration Policy
+last_verified: 2026-05-18
+sources:
+  - docs/decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration
+  - README.md
+  - docs/positioning.md
+---
+
+# ADR-038 — MCP-First Integration Policy
+
+Tandem's integration contract is **MCP**; Claude is the **default** integration but not the only one. Other AI clients that speak MCP can integrate; the channel shim is the push-notification transport on top. This is the product-positioning ADR — see also `docs/positioning.md` and the README.
+
+**Implications:**
+- MCP tool surface is the API contract (29 tools today)
+- Channel events use the MCP Channels spec, not a Tandem-specific protocol
+- New features should land as MCP tools or extensions to existing ones rather than parallel REST endpoints
+- The Tauri desktop app's sidecar speaks the same MCP surface as the standalone server
+
+The most-referenced ADR in the repo (14 cross-references) because it's the policy that constrains every new integration decision.

--- a/.claude/knowledge-graph/nodes/concept-annotation-lifecycle.md
+++ b/.claude/knowledge-graph/nodes/concept-annotation-lifecycle.md
@@ -1,0 +1,23 @@
+---
+id: concept-annotation-lifecycle
+type: concept
+name: Annotation lifecycle
+last_verified: 2026-05-18
+sources:
+  - src/server/annotations/
+  - docs/decisions.md#adr-027-annotation-system-redesign--audience-based-model
+---
+
+# Annotation lifecycle
+
+Annotations live in `Y.Map('annotations')` (governed by `rule-ymap-key-constants`), keyed by stable id. State machine: **pending → accepted | dismissed**. `tandem_editAnnotation` only works on pending; accepted/dismissed return an error.
+
+Types (3): `highlight` (user-only, color-coded), `comment` (Claude-created, may include `suggestedText`), `note` (personal, **not surfaced to Claude** per ADR-027). The `directedAt` field is deprecated and stripped on read.
+
+Authors (3): `"user"`, `"claude"`, `"import"` (Word comments from .docx files).
+
+**ADR-027 privacy contract:** notes are user-private — Claude never reads them via MCP tools or channel events. The MCP read paths (`tandem_getAnnotations`, channel event filtering) strip note entries before responding.
+
+Lifecycle module (`adr-035`) provides the canonical state transitions; durable-sync writes annotations to disk on a debounce. The durable-sync observer skips `file-sync` and `internal` origins (see `concept-origin-contract`).
+
+Annotation ranges use `AnchoredRange` (flat offset + Y.RelativePosition); the Y.RelativePosition survives concurrent edits and is re-anchored after `reloadFromDisk`.

--- a/.claude/knowledge-graph/nodes/concept-awareness.md
+++ b/.claude/knowledge-graph/nodes/concept-awareness.md
@@ -1,0 +1,20 @@
+---
+id: concept-awareness
+type: concept
+name: Awareness (presence + dwell)
+last_verified: 2026-05-18
+sources:
+  - src/server/mcp/awareness.ts
+  - src/client/cowork/
+  - src/shared/constants.ts
+---
+
+# Awareness
+
+User presence + selection state stored in per-document `Y.Map(awareness)`. Drives the cowork sidebar, paragraph-focus indicators, and selection-event channel pushes.
+
+**Dwell-time gating:** selection events only fire after the user holds a selection steady for the configured dwell time (default 1s). This prevents firehose-spam on every cursor move and is what makes the channel push tractable for Claude to react to.
+
+Awareness writes are `browser`-origin, so they generate channel events (see `concept-channel-events`).
+
+The Claude focus paragraph indicator (gutter decoration in `awareness.ts`) uses `--tandem-claude-focus-bg` / `--tandem-claude-focus-border`, derived from `--tandem-author-claude` via `color-mix` — Claude's "current paragraph" while editing.

--- a/.claude/knowledge-graph/nodes/concept-channel-events.md
+++ b/.claude/knowledge-graph/nodes/concept-channel-events.md
@@ -1,0 +1,20 @@
+---
+id: concept-channel-events
+type: concept
+name: Channel events (push)
+last_verified: 2026-05-18
+sources:
+  - src/server/events/
+  - src/channel/
+  - docs/decisions.md#adr-019-channel-shim-for-push-notifications-issue-106--claude-default-integration
+---
+
+# Channel events
+
+Server-Sent Events stream from the server to Claude Code via the channel shim, replacing polling. The shim uses the low-level MCP `Server` class (not `McpServer`) because the Channels spec requires explicit `setRequestHandler()` wiring.
+
+Event emission is **gated by origin** (see `concept-origin-contract`): only `browser`-origin writes emit channel events. Internal-purpose origins (`mcp`, `file-sync`, `internal`, `reload`) skip the event queue, so Claude's own writes don't echo back as user events.
+
+**Meta keys use underscores only.** The Channels API silently drops meta keys containing hyphens. Use `document_id`, `annotation_id`, `event_type` — never `document-id`. This is a real footgun documented in lessons-learned.
+
+The channel shim is the *default* integration with Claude per ADR-038 (MCP-first policy); REST polling is the fallback.

--- a/.claude/knowledge-graph/nodes/concept-coord-flat-offset.md
+++ b/.claude/knowledge-graph/nodes/concept-coord-flat-offset.md
@@ -1,0 +1,24 @@
+---
+id: concept-coord-flat-offset
+type: concept
+name: Flat text offset
+last_verified: 2026-05-18
+sources:
+  - src/server/positions.ts
+  - src/shared/positions/
+  - docs/architecture.md
+---
+
+# Flat text offset
+
+Server-side coordinate: an integer character index into the output of `extractText()`. **Includes heading prefixes** (e.g., `## ` counts as 3 characters), which is the user-visible view that MCP tools operate on.
+
+This is the canonical input/output coordinate for all MCP range tools. Range inputs are validated by `validateRange()` and converted to `AnchoredRange` (flat offsets + Y.RelativePositions) via `anchoredRange()` in one call — see `rule-validate-range`.
+
+Heading prefixes in flat offsets are why `tandem_edit` rejects ranges that overlap heading markup (`rule-edit-rejects-heading-markup`): editing the `## ` itself would corrupt block structure.
+
+Conversion functions live in `src/server/positions.ts`:
+- `resolveToElement(flatOffset)` — flat → Y.XmlElement + intra-element position
+- `refreshRange(range)` — re-derives flat offsets from Y.RelativePositions after edits, strips dead `relRange` anchors
+
+`tandem_getTextContent` uses `extractText()` — never `extractMarkdown()`, which would shift offsets out of the annotation coordinate system (`rule-extract-text-not-markdown`).

--- a/.claude/knowledge-graph/nodes/concept-coord-prosemirror.md
+++ b/.claude/knowledge-graph/nodes/concept-coord-prosemirror.md
@@ -1,0 +1,17 @@
+---
+id: concept-coord-prosemirror
+type: concept
+name: ProseMirror position
+last_verified: 2026-05-18
+sources:
+  - src/client/positions.ts
+  - src/shared/positions/
+---
+
+# ProseMirror position
+
+Client-side structural coordinate used by Tiptap. Tracks block boundaries (paragraph open/close tokens count as positions), not raw character index — so a `pos` of 5 may be "inside paragraph 1, character 4" rather than "5 chars from doc start."
+
+Conversion to flat offsets happens at the client/server boundary (`src/client/positions.ts`). Decorations and selection anchors use ProseMirror positions internally because that's Tiptap's native coordinate; everything that crosses the wire to the server gets converted.
+
+The three-coordinate-system design (flat / ProseMirror / Y.RelativePosition) is unified by the position modules — see `concept-coord-flat-offset` and `concept-coord-yjs-relative`, both decided by `adr-018`.

--- a/.claude/knowledge-graph/nodes/concept-coord-yjs-relative.md
+++ b/.claude/knowledge-graph/nodes/concept-coord-yjs-relative.md
@@ -1,0 +1,19 @@
+---
+id: concept-coord-yjs-relative
+type: concept
+name: Y.RelativePosition
+last_verified: 2026-05-18
+sources:
+  - src/shared/positions/
+  - src/server/positions.ts
+---
+
+# Y.RelativePosition
+
+CRDT-anchored position that survives concurrent edits and reorderings. Stored alongside flat offsets in `AnchoredRange` (created by `anchoredRange()`); the relative position is the durable anchor, the flat offset is the cached value at write time.
+
+Created in one call with the flat offset via `anchoredRange(start, end)` — never construct one manually. The `relRange` survives normal edits but **dies when the Y.Doc instance is replaced** (e.g., after `reloadFromDisk`).
+
+`refreshRange` (in `src/server/positions.ts`) strips dead `relRange` anchors and re-anchors from the cached flat offset. Critical: a stale `relRange` that resolves to `null` blocks the lazy re-attachment recovery path — deletion is better than preservation. See lessons-learned for the case study.
+
+When `buildDecorations()` (client) falls back to flat offsets because the `relRange` failed to resolve, it emits `console.warn` — check the browser console for CRDT degradation signals.

--- a/.claude/knowledge-graph/nodes/concept-file-watcher.md
+++ b/.claude/knowledge-graph/nodes/concept-file-watcher.md
@@ -1,0 +1,21 @@
+---
+id: concept-file-watcher
+type: concept
+name: File watcher
+last_verified: 2026-05-18
+sources:
+  - src/server/file-io/
+  - docs/decisions.md#adr-034-file-open-pipeline-with-named-entry-points-and-shared-core
+---
+
+# File watcher
+
+`fs.watch` on every open file; external edits trigger `reloadFromDisk` which replaces Y.Doc content under the `withReload` origin wrapper.
+
+**Suppression at arrival, not delivery.** `suppressNextChange()` is consumed in the `fs.watch` callback (event arrival), not inside the debounce timer (event delivery). Consuming at delivery creates a race: an *external* edit arriving within the debounce window would consume the suppression token meant for the server's own write.
+
+**Reload distinguishes from file-sync echoes.** A user editing the file in another editor → `reloadFromDisk` uses `withReload` (channel skips, durable-sync **persists** the re-anchored relRanges). A server-side save echoed back through the watcher → `withFileSync` (everything skips). See `concept-origin-contract`.
+
+After `reloadFromDisk` swaps Y.Doc content, dead `Y.RelativePosition` anchors must be **stripped, not preserved** — `refreshRange` re-anchors annotations from the cached flat offset and deletes the stale `relRange` field.
+
+Read-only documents (e.g., `CHANGELOG.md` opened by "View Changelog") bypass the 60s autosave timer to prevent round-tripping through `remark-stringify` and rewriting the file with escape noise (lesson #69, issue #605).

--- a/.claude/knowledge-graph/nodes/concept-mcp-transport.md
+++ b/.claude/knowledge-graph/nodes/concept-mcp-transport.md
@@ -1,0 +1,24 @@
+---
+id: concept-mcp-transport
+type: concept
+name: MCP transport (HTTP + stdio)
+last_verified: 2026-05-18
+sources:
+  - src/server/mcp/server.ts
+  - docs/decisions.md#adr-012-streamable-http-transport-replacing-stdio
+  - docs/decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration
+---
+
+# MCP transport
+
+Two transports for the same tool surface:
+- **HTTP** (default): port 3479, used by the Tauri desktop app and standalone `dev:server`. Tools register in `createMcpServer()`.
+- **stdio**: used by the deprecated browser-distribution sidecar and CI smoke tests.
+
+**stdout is reserved in stdio mode** (`rule-stdout-reserved`). `console.log/warn/info` redirect to stderr in `index.ts` as defense-in-depth — a dependency that logs to stdout will corrupt the wire.
+
+**MCP must start before Hocuspocus in stdio mode** — the init timeout fires if the order is reversed. HTTP mode doesn't have this ordering constraint.
+
+Tool registration is split across 5 files: `document.ts` (11 tools), `annotations.ts` (10), `navigation.ts` (3), `awareness.ts` (3), `docx-apply.ts` (2). The tool count is snapshotted at startup from `_registeredTools` (private SDK field) and exposed via `/api/info`.
+
+ADR-038 establishes MCP as the default integration; the channel shim is the push transport on top.

--- a/.claude/knowledge-graph/nodes/concept-multi-doc.md
+++ b/.claude/knowledge-graph/nodes/concept-multi-doc.md
@@ -1,0 +1,21 @@
+---
+id: concept-multi-doc
+type: concept
+name: Multi-document (documentId)
+last_verified: 2026-05-18
+sources:
+  - src/server/documents/
+  - src/shared/constants.ts
+  - docs/decisions.md#adr-010-docidfrompath-for-multi-document-room-names
+  - docs/decisions.md#adr-033-document-registry-and-named-hocuspocus-lifecycle-interface
+---
+
+# Multi-document
+
+Each open file gets a `documentId` (hash of absolute path via `docIdFromPath`) which becomes the Hocuspocus room name. All MCP tools accept an optional `documentId` parameter, defaulting to the active document.
+
+The server broadcasts the open-documents list via `Y.Map('documentMeta')` on the `CTRL_ROOM` Y.Doc — clients render tabs from this. **`CTRL_ROOM` is reserved** — never use as a document ID.
+
+**Startup ordering (HTTP mode):** documents that should appear on startup must be opened *before* Hocuspocus binds the WebSocket port. A stale browser tab that reconnects mid-startup can CRDT-merge an incomplete `openDocuments` list, removing tabs added after the bind. Stdio mode has no startup-document opens.
+
+The document registry (`adr-033`) is the canonical lifecycle interface; file-open / close / switch all converge there. File-open specifically uses the named entry-point pipeline in `adr-034`.

--- a/.claude/knowledge-graph/nodes/concept-origin-contract.md
+++ b/.claude/knowledge-graph/nodes/concept-origin-contract.md
@@ -1,0 +1,32 @@
+---
+id: concept-origin-contract
+type: concept
+name: Origin contract (5 tags)
+last_verified: 2026-05-18
+sources:
+  - src/shared/origins.ts
+  - docs/decisions.md#adr-031-origin-tagged-transaction-wrappers
+---
+
+# Origin contract
+
+Every Y.Doc write is tagged with one of five origin values: `mcp`, `file-sync`, `internal`, `reload`, `browser`. Observers (channel events, durable-annotation sync, tombstone ledger) inspect the origin to decide whether to react. Picking the wrong wrapper is a silent bug — the wrapper choice IS the contract.
+
+| Origin     | Channel events | Durable-sync | Tombstones |
+|------------|----------------|--------------|------------|
+| `mcp`      | skip           | persist      | record     |
+| `file-sync`| skip           | skip         | skip       |
+| `internal` | skip           | skip         | skip       |
+| `reload`   | skip           | persist      | record     |
+| `browser`  | **emit**       | persist      | record     |
+
+Only `browser` writes emit channel events — this is how the channel shim distinguishes "user did something" from server-internal noise.
+
+Wrapper helpers in `src/shared/origins.ts`:
+- `withMcp` — Claude-initiated writes from MCP tool handlers
+- `withFileSync` — echoes from the durable-annotation file-writer
+- `withInternal` — session restore, mdast/docx population, tutorial seeding, scratchpad seeding, force-reload, server metadata broadcasts
+- `withReload` — file-watcher `reloadFromDisk` flow (origin distinct from `file-sync` so durable-sync persists re-anchored relRanges)
+- `withBrowser` — user edits from the browser
+
+Raw `doc.transact(...)` is blocked everywhere in `src/` by the pre-commit hook `.claude/hooks/block-raw-transact.sh` and a Biome AST rule for dynamic-dispatch bypasses. Test-only synthetic Y.Docs use `transactForTest` (sentinel origin `"test"`, allowlisted).

--- a/.claude/knowledge-graph/nodes/concept-solo-tandem-mode.md
+++ b/.claude/knowledge-graph/nodes/concept-solo-tandem-mode.md
@@ -1,0 +1,17 @@
+---
+id: concept-solo-tandem-mode
+type: concept
+name: Solo / Tandem mode
+last_verified: 2026-05-18
+sources:
+  - src/server/mcp/awareness.ts
+  - src/shared/constants.ts
+---
+
+# Solo / Tandem mode
+
+A single boolean (`"solo" | "tandem"`) that tells Claude whether the user is currently collaborating or working alone. Returned by `tandem_status` and `tandem_checkInbox` so MCP handlers can adapt — in Solo mode, Claude holds annotations rather than surfacing them.
+
+Stored **once globally**, not per-document: under `CTRL_ROOM`'s `Y_MAP_USER_AWARENESS` map at key `Y_MAP_MODE`. Mode changes broadcast to all open documents.
+
+The two-mode design replaced an earlier per-document setting; storing in `CTRL_ROOM` means a single UI toggle covers every tab.

--- a/.claude/knowledge-graph/nodes/concept-y-doc.md
+++ b/.claude/knowledge-graph/nodes/concept-y-doc.md
@@ -1,0 +1,22 @@
+---
+id: concept-y-doc
+type: concept
+name: Y.Doc
+last_verified: 2026-05-18
+sources:
+  - src/server/yjs/
+  - src/server/events/
+  - docs/architecture.md#y-map-observer-ownership
+---
+
+# Y.Doc
+
+Per-document Yjs CRDT instance; the authoritative collaborative state for one open file. The server owns the canonical Y.Doc, browser tabs sync to it via Hocuspocus over WebSocket.
+
+Each open file gets exactly one Y.Doc keyed by `documentId` (hash of file path, see `concept-multi-doc`). Annotations, awareness, document metadata, and content all live as Y.Map / Y.XmlFragment subkeys on this root — see `Y_MAP_*` constants in `src/shared/constants.ts` (governed by `rule-ymap-key-constants`).
+
+Every write to a Y.Doc — server-side or browser-side — must go through one of the five origin-tagged wrappers in `src/shared/origins.ts` (governed by `rule-origin-helpers`, decided by `adr-031`). The chosen origin determines which observers (channel events, durable-annotation sync, tombstone ledger) react to the change.
+
+Hocuspocus replaces the Y.Doc instance on `onLoadDocument`. The `onDocSwapped` callback in `provider.ts` reattaches server event-queue observers to the new instance — a runtime warning fires if the callback is missing (see lessons-learned).
+
+A reserved Y.Doc named `CTRL_ROOM` holds server-wide state (Solo/Tandem mode, open-documents list) — never use `CTRL_ROOM` as a document ID.

--- a/.claude/knowledge-graph/nodes/rule-e2e-data-testid.md
+++ b/.claude/knowledge-graph/nodes/rule-e2e-data-testid.md
@@ -1,0 +1,19 @@
+---
+id: rule-e2e-data-testid
+type: rule
+name: E2E tests use data-testid
+last_verified: 2026-05-18
+sources:
+  - tests/e2e/
+  - CLAUDE.md
+---
+
+# Rule: E2E tests use data-testid attributes
+
+Playwright E2E tests select elements by `data-testid` (kebab-case), never by class name, role, or text content (except when testing accessible labels).
+
+**Why this matters:** Svelte component refactors, class-name churn, and i18n changes all break tests that select by anything-but-testid. Testid is the only selector that survives normal UI evolution.
+
+**Convention:** kebab-case, semantic name (`accept-btn`, `annotation-card-{id}`, `palette-input`). When adding new interactive elements that ship to production, add a testid even if no test currently uses it — adding testid retroactively after a regression is more expensive than adding it preemptively.
+
+The full canonical list of testids in active use is in `CLAUDE.md` under the E2E section — when adding new ones, append to that list to keep it discoverable.

--- a/.claude/knowledge-graph/nodes/rule-edit-rejects-heading-markup.md
+++ b/.claude/knowledge-graph/nodes/rule-edit-rejects-heading-markup.md
@@ -1,0 +1,19 @@
+---
+id: rule-edit-rejects-heading-markup
+type: rule
+name: tandem_edit rejects heading markup ranges
+last_verified: 2026-05-18
+sources:
+  - src/server/mcp/document.ts
+  - src/server/positions.ts
+---
+
+# Rule: tandem_edit rejects heading markup ranges
+
+Ranges that overlap heading prefixes (e.g., the `## ` at the start of a level-2 heading) return `INVALID_RANGE`. Target text content only — never the markup characters.
+
+**Why this matters:** flat offsets include heading prefixes (see `concept-coord-flat-offset`) because that's the user-visible view. But editing the `## ` itself would corrupt the block structure — Y.XmlElement heading nodes carry the level as an attribute, not as inline characters. An edit that "deletes" the prefix would leave a malformed heading element.
+
+The validator detects overlap with the prefix range during `validateRange()` and short-circuits before any Y.Doc write happens.
+
+**Practical implication for Claude:** when computing an edit range that starts at the beginning of a heading line, advance past the prefix (count `# ` characters) before issuing the call. The error message includes the offending range so the next attempt can correct.

--- a/.claude/knowledge-graph/nodes/rule-extract-text-not-markdown.md
+++ b/.claude/knowledge-graph/nodes/rule-extract-text-not-markdown.md
@@ -1,0 +1,20 @@
+---
+id: rule-extract-text-not-markdown
+type: rule
+name: tandem_getTextContent uses extractText
+last_verified: 2026-05-18
+sources:
+  - src/server/mcp/document.ts
+  - .claude/hooks/check-extract-markdown.sh
+  - docs/decisions.md#adr-021-extracttext-for-tandem_gettextcontent-issue-148
+---
+
+# Rule: tandem_getTextContent uses extractText, never extractMarkdown
+
+`tandem_getTextContent` uses `extractText()` for **all** files, including `.md`. Never use `extractMarkdown()` from a tool that returns offsets — it shifts character offsets relative to the annotation coordinate system.
+
+**Why this matters:** annotation ranges are flat offsets into `extractText()` output (see `concept-coord-flat-offset`). If `getTextContent` returned `extractMarkdown()` instead, the offsets Claude saw wouldn't match the offsets the server expected back on writes — annotations would land at the wrong characters.
+
+**If you need actual markdown:** use `tandem_save` and read the file directly. `extractMarkdown()` exists for the save path, not for the read path.
+
+**Enforced by:** `.claude/hooks/check-extract-markdown.sh` warns on PostToolUse for any `extractMarkdown()` usage outside the save path.

--- a/.claude/knowledge-graph/nodes/rule-origin-helpers.md
+++ b/.claude/knowledge-graph/nodes/rule-origin-helpers.md
@@ -1,0 +1,26 @@
+---
+id: rule-origin-helpers
+type: rule
+name: Origin-tag every Y.Doc write
+last_verified: 2026-05-18
+sources:
+  - src/shared/origins.ts
+  - .claude/hooks/check-raw-transact.sh
+  - scripts/audit-origins.ts
+  - docs/decisions.md#adr-031-origin-tagged-transaction-wrappers
+---
+
+# Rule: Origin-tag every Y.Doc write
+
+Raw `doc.transact(...)` is forbidden anywhere in `src/`. Every write must go through one of the five wrappers in `src/shared/origins.ts`: `withMcp`, `withFileSync`, `withInternal`, `withReload`, `withBrowser`. See `concept-origin-contract` for the decision table.
+
+**Why this matters:** the origin determines which observers react (channel events, durable-sync, tombstone ledger). Picking the wrong wrapper is a silent bug — no exception thrown, just the wrong side-effects (or no side-effects).
+
+**Enforced by (all warn-only as of 2026-05-18):**
+- PostToolUse hook `.claude/hooks/check-raw-transact.sh` — warns on stderr during Claude Code edits
+- `npm run audit:origins` — static TS-compiler walk; warn-only finding list
+- Test-only synthetic Y.Docs allowed via `transactForTest` (sentinel origin `"test"`)
+
+**Drift note:** `CLAUDE.md` and ADR-031 prose describe this as "pre-commit hook blocks" with a "Biome AST rule." Neither is currently wired — lint-staged runs eslint/biome/check-tokens only. The warn surface is real and effective but stronger language in the docs overstates the guardrail. Flag for separate cleanup.
+
+**How to choose:** see the worked-example table in `src/shared/origins.ts` and `adr-031`. Short version: ask "what should happen?" — if Claude initiated it (MCP handler) use `withMcp`; if a file-watcher reload use `withReload`; if startup/seeding/cleanup use `withInternal`; if a user did it in the browser use `withBrowser`; if it's an echo from the file-writer use `withFileSync`.

--- a/.claude/knowledge-graph/nodes/rule-stdout-reserved.md
+++ b/.claude/knowledge-graph/nodes/rule-stdout-reserved.md
@@ -1,0 +1,21 @@
+---
+id: rule-stdout-reserved
+type: rule
+name: stdout is reserved (stdio MCP)
+last_verified: 2026-05-18
+sources:
+  - src/server/index.ts
+  - .claude/hooks/check-console-log.sh
+---
+
+# Rule: stdout is reserved
+
+`console.log`, `console.warn`, `console.info` all redirect to stderr in `src/server/index.ts` as defense-in-depth for the MCP stdio transport. Any byte written to stdout that isn't a valid JSON-RPC frame corrupts the wire and disconnects Claude.
+
+**Why this matters:** stdio MCP uses stdin/stdout for the protocol. A single `console.log("debug")` from a dependency will break the session — and the failure looks like "MCP just dropped" rather than "your log line was misinterpreted as a frame."
+
+**Enforced by:**
+- Process-level redirect in `src/server/index.ts` (catches application code)
+- Hook `.claude/hooks/check-console-log.sh` warns on `console.log()` introductions in `src/server/`
+
+**Applies to:** any new dependency added to the server bundle. If a dep logs to stdout, it bypasses the redirect (already in the dep) — vet noisy deps before adding.

--- a/.claude/knowledge-graph/nodes/rule-validate-range.md
+++ b/.claude/knowledge-graph/nodes/rule-validate-range.md
@@ -1,0 +1,18 @@
+---
+id: rule-validate-range
+type: rule
+name: Use validateRange + anchoredRange
+last_verified: 2026-05-18
+sources:
+  - src/server/positions.ts
+---
+
+# Rule: Use validateRange + anchoredRange
+
+Range inputs (from MCP tools, channel events, etc.) must pass through `validateRange()` before use, and any range stored on an annotation or used for re-anchoring must be produced by `anchoredRange()` — which creates the `{flat, relRange}` pair in one call.
+
+**Why this matters:** raw flat offsets become invalid the moment the document changes. The `relRange` (Y.RelativePosition) is the durable anchor that survives edits. Storing only the flat offset means annotations drift on the next edit.
+
+`anchoredRange()` is the single chokepoint that guarantees the invariant "every persisted range has both a flat offset and a relRange." Bypassing it produces annotations that look right until the document is edited and then silently misalign.
+
+**Applies to:** every MCP tool that accepts a `range` parameter (`tandem_edit`, `tandem_comment`, `tandem_highlight`, `tandem_suggest`, `tandem_flag`, `tandem_resolveRange`, etc.) and every server-side range construction.

--- a/.claude/knowledge-graph/nodes/rule-ymap-key-constants.md
+++ b/.claude/knowledge-graph/nodes/rule-ymap-key-constants.md
@@ -1,0 +1,19 @@
+---
+id: rule-ymap-key-constants
+type: rule
+name: Y.Map keys from constants only
+last_verified: 2026-05-18
+sources:
+  - src/shared/constants.ts
+  - CLAUDE.md
+---
+
+# Rule: Y.Map key strings from constants only
+
+Use `Y_MAP_ANNOTATIONS`, `Y_MAP_AWARENESS`, `Y_MAP_DOCUMENT_META`, `Y_MAP_USER_AWARENESS`, `Y_MAP_MODE`, etc. from `src/shared/constants.ts` — **never raw string literals** for Y.Map keys.
+
+**Why this matters:** a typo in a raw string is silent and the resulting Y.Map will be empty (or a parallel map will exist that no observer is watching). Constants are typo-loud (typecheck fails) and grep-able for ownership.
+
+**Enforced by:** convention + code review. Not currently hooked, but a regex linter (`.claude/hooks/check-ymap-keys.sh`) warns on PostToolUse for new raw-string Y.Map accesses.
+
+Applies to: every Y.Map access on `concept-y-doc`, `CTRL_ROOM`, and per-document Y.Docs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@
 - [Roadmap](docs/roadmap.md) -- Phase 2+ roadmap, future extensions
 - [Design Decisions](docs/decisions.md) -- ADRs (001-038)
 - [Lessons Learned](docs/lessons-learned.md) -- 73 lessons including E2E testing gotchas, CORS-allowlist three-surface audits, DOM-nested scroll sync for content-anchored overlays, and schema-backed palette migrations
+- [Knowledge Graph](.claude/knowledge-graph/README.md) -- **PILOT (review 2026-06-01).** 25 hand-curated concept/rule/ADR nodes with cross-edges. Query via `npm run kg neighbors <id>` / `npm run kg rules-for <id-or-file>`. Validate via `npm run kg:lint`. Kill if no surprising query in two weeks.
 
 ## Development Workflow
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "audit:dead-code": "knip",
     "audit:origins": "tsx scripts/audit-origins.ts",
     "audit:ymap-keys": "tsx scripts/audit-ymap-keys.ts",
+    "kg": "node scripts/kg.mjs",
+    "kg:lint": "node scripts/kg-lint.mjs",
     "prepare": "husky",
     "prepublishOnly": "npm run build"
   },

--- a/scripts/kg-lint.mjs
+++ b/scripts/kg-lint.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Knowledge graph validator. Fails on:
+//   - missing required frontmatter fields
+//   - `source:` paths that don't exist (file refs only; doc anchors not checked)
+//   - edge endpoints that don't resolve to a node
+//   - duplicate node ids
+// Warns on:
+//   - last_verified older than 60 days
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..");
+const NODES_DIR = join(ROOT, ".claude/knowledge-graph/nodes");
+const EDGES_PATH = join(ROOT, ".claude/knowledge-graph/edges.json");
+
+const REQUIRED = ["id", "type", "name", "last_verified", "sources"];
+const VALID_TYPES = new Set(["concept", "rule", "adr"]);
+const VALID_EDGES = new Set([
+  "governs",
+  "decided_by",
+  "supersedes",
+  "implemented_in",
+  "refines",
+  "related",
+  "enforced_by",
+]);
+
+const errors = [];
+const warnings = [];
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return null;
+  const fm = {};
+  let currentKey = null;
+  for (const line of match[1].split("\n")) {
+    if (/^\s*-\s/.test(line) && currentKey) {
+      const val = line.replace(/^\s*-\s*/, "").trim();
+      if (!Array.isArray(fm[currentKey])) fm[currentKey] = [];
+      fm[currentKey].push(val);
+    } else {
+      const kv = line.match(/^([a-z_]+):\s*(.*)$/);
+      if (kv) {
+        currentKey = kv[1];
+        const v = kv[2].trim();
+        fm[currentKey] = v === "" ? [] : v;
+      }
+    }
+  }
+  return fm;
+}
+
+const nodes = new Map();
+
+for (const file of readdirSync(NODES_DIR)) {
+  if (!file.endsWith(".md")) continue;
+  const path = join(NODES_DIR, file);
+  const text = readFileSync(path, "utf8");
+  const fm = parseFrontmatter(text);
+  if (!fm) {
+    errors.push(`${file}: no parseable frontmatter`);
+    continue;
+  }
+  for (const key of REQUIRED) {
+    if (
+      fm[key] === undefined ||
+      fm[key] === "" ||
+      (Array.isArray(fm[key]) && fm[key].length === 0)
+    ) {
+      errors.push(`${file}: missing required field "${key}"`);
+    }
+  }
+  if (fm.id) {
+    if (nodes.has(fm.id)) errors.push(`${file}: duplicate node id "${fm.id}"`);
+    nodes.set(fm.id, { ...fm, _file: file });
+  }
+  if (fm.type && !VALID_TYPES.has(fm.type)) {
+    errors.push(`${file}: invalid type "${fm.type}" (allowed: ${[...VALID_TYPES].join("|")})`);
+  }
+  if (fm.id && file !== `${fm.id}.md`) {
+    errors.push(`${file}: filename should be "${fm.id}.md" to match id`);
+  }
+  for (const source of fm.sources || []) {
+    const cleanPath = source.replace(/[#:].*$/, "");
+    const absPath = resolve(ROOT, cleanPath);
+    if (!existsSync(absPath)) {
+      errors.push(`${file}: source path does not exist: ${source}`);
+    }
+  }
+  if (fm.last_verified) {
+    const verified = new Date(fm.last_verified);
+    if (isNaN(verified.getTime())) {
+      errors.push(`${file}: last_verified is not a valid date: ${fm.last_verified}`);
+    } else {
+      const days = (Date.now() - verified.getTime()) / 86400000;
+      if (days > 60) {
+        warnings.push(`${file}: last_verified is ${Math.round(days)} days old — re-read and bump`);
+      }
+    }
+  }
+}
+
+const edgesData = JSON.parse(readFileSync(EDGES_PATH, "utf8"));
+if (!Array.isArray(edgesData.edges)) {
+  errors.push(`edges.json: missing "edges" array`);
+} else {
+  for (const [i, e] of edgesData.edges.entries()) {
+    const loc = `edges[${i}]`;
+    if (!e.from || !e.to || !e.type) {
+      errors.push(`${loc}: missing from/to/type`);
+      continue;
+    }
+    if (!VALID_EDGES.has(e.type)) {
+      errors.push(`${loc}: invalid edge type "${e.type}"`);
+    }
+    if (!nodes.has(e.from)) errors.push(`${loc}: from "${e.from}" does not resolve`);
+    if (!nodes.has(e.to)) errors.push(`${loc}: to "${e.to}" does not resolve`);
+    if (e.from === e.to) errors.push(`${loc}: self-edge (${e.from} -> ${e.to})`);
+  }
+}
+
+console.log(`Loaded ${nodes.size} nodes, ${edgesData.edges?.length ?? 0} edges`);
+
+if (warnings.length) {
+  console.warn(`\n${warnings.length} warning(s):`);
+  for (const w of warnings) console.warn(`  ⚠  ${w}`);
+}
+
+if (errors.length) {
+  console.error(`\n${errors.length} error(s):`);
+  for (const e of errors) console.error(`  ✗  ${e}`);
+  process.exit(1);
+}
+
+console.log("\nKnowledge graph OK ✓");

--- a/scripts/kg.mjs
+++ b/scripts/kg.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Knowledge graph query CLI. See .claude/knowledge-graph/README.md for the
+// schema and kill criterion.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..");
+const NODES_DIR = join(ROOT, ".claude/knowledge-graph/nodes");
+const EDGES_PATH = join(ROOT, ".claude/knowledge-graph/edges.json");
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return null;
+  const fm = {};
+  let currentKey = null;
+  for (const line of match[1].split("\n")) {
+    if (/^\s*-\s/.test(line) && currentKey) {
+      const val = line.replace(/^\s*-\s*/, "").trim();
+      if (!Array.isArray(fm[currentKey])) fm[currentKey] = [];
+      fm[currentKey].push(val);
+    } else {
+      const kv = line.match(/^([a-z_]+):\s*(.*)$/);
+      if (kv) {
+        currentKey = kv[1];
+        const v = kv[2].trim();
+        fm[currentKey] = v === "" ? [] : v;
+      }
+    }
+  }
+  return { frontmatter: fm, body: match[2] };
+}
+
+function loadNodes() {
+  const nodes = new Map();
+  for (const file of readdirSync(NODES_DIR)) {
+    if (!file.endsWith(".md")) continue;
+    const text = readFileSync(join(NODES_DIR, file), "utf8");
+    const parsed = parseFrontmatter(text);
+    if (!parsed) continue;
+    const id = parsed.frontmatter.id;
+    if (!id) continue;
+    nodes.set(id, { ...parsed.frontmatter, _body: parsed.body, _path: file });
+  }
+  return nodes;
+}
+
+function loadEdges() {
+  return JSON.parse(readFileSync(EDGES_PATH, "utf8")).edges;
+}
+
+function fmt(node) {
+  return `${node.id.padEnd(36)}  [${node.type}] ${node.name}`;
+}
+
+function cmdList(nodes, args) {
+  const filter = args[0];
+  for (const node of [...nodes.values()].sort((a, b) => a.id.localeCompare(b.id))) {
+    if (filter && node.type !== filter) continue;
+    console.log(fmt(node));
+  }
+}
+
+function cmdShow(nodes, args) {
+  const id = args[0];
+  const node = nodes.get(id);
+  if (!node) {
+    console.error(`No node: ${id}`);
+    process.exit(1);
+  }
+  console.log(`# ${node.name}\n`);
+  console.log(`id: ${node.id}`);
+  console.log(`type: ${node.type}`);
+  console.log(`last_verified: ${node.last_verified}`);
+  console.log(`\nsources:`);
+  for (const s of node.sources || []) console.log(`  - ${s}`);
+  console.log(`\n${node._body.trim()}`);
+}
+
+function cmdNeighbors(nodes, edges, args) {
+  const id = args[0];
+  if (!nodes.has(id)) {
+    console.error(`No node: ${id}`);
+    process.exit(1);
+  }
+  const out = edges.filter((e) => e.from === id);
+  const inc = edges.filter((e) => e.to === id);
+  console.log(`# Neighbors of ${id}\n`);
+  if (out.length) {
+    console.log("Outgoing:");
+    for (const e of out) {
+      const target = nodes.get(e.to);
+      const tname = target ? target.name : "(unknown)";
+      console.log(`  --${e.type}--> ${e.to.padEnd(36)} ${tname}${e.note ? `  (${e.note})` : ""}`);
+    }
+  }
+  if (inc.length) {
+    console.log("\nIncoming:");
+    for (const e of inc) {
+      const src = nodes.get(e.from);
+      const sname = src ? src.name : "(unknown)";
+      console.log(
+        `  ${e.from.padEnd(36)} --${e.type}--> ${id} ${sname ? `(${sname})` : ""}${e.note ? `  [${e.note}]` : ""}`,
+      );
+    }
+  }
+  if (!out.length && !inc.length) console.log("(no edges)");
+}
+
+function cmdRulesFor(nodes, edges, args) {
+  const target = args[0];
+  // Two modes: (a) target is a node id → list rules with `governs` edge to it
+  // (b) target is a file path → list rules whose `sources` include that path
+  const ruleIds = new Set();
+  if (nodes.has(target)) {
+    for (const e of edges) {
+      if (e.to === target && e.type === "governs") {
+        ruleIds.add(e.from);
+      }
+    }
+  } else {
+    for (const node of nodes.values()) {
+      if (node.type !== "rule") continue;
+      for (const s of node.sources || []) {
+        if (target.includes(s) || s.includes(target)) {
+          ruleIds.add(node.id);
+          break;
+        }
+      }
+    }
+    // Also: rules governing concepts whose sources match
+    for (const node of nodes.values()) {
+      if (node.type !== "concept") continue;
+      const matches = (node.sources || []).some((s) => target.includes(s) || s.includes(target));
+      if (!matches) continue;
+      for (const e of edges) {
+        if (e.to === node.id && e.type === "governs") ruleIds.add(e.from);
+      }
+    }
+  }
+  if (!ruleIds.size) {
+    console.log(`No rules found governing ${target}`);
+    return;
+  }
+  console.log(`# Rules governing ${target}\n`);
+  for (const rid of ruleIds) {
+    const r = nodes.get(rid);
+    if (r) console.log(`- ${r.name}  (${rid})`);
+  }
+}
+
+function cmdSearch(nodes, args) {
+  const q = (args[0] || "").toLowerCase();
+  if (!q) {
+    console.error("Usage: kg search <query>");
+    process.exit(1);
+  }
+  for (const node of nodes.values()) {
+    const hay = `${node.id} ${node.name} ${node._body}`.toLowerCase();
+    if (hay.includes(q)) console.log(fmt(node));
+  }
+}
+
+function help() {
+  console.log(`Tandem knowledge graph query CLI
+
+Usage:
+  kg list [<type>]              list all nodes (optional filter: concept|rule|adr)
+  kg show <id>                  show full node body
+  kg neighbors <id>             show edges into and out of a node
+  kg rules-for <id-or-file>     list rules governing a concept (by id) or file path
+  kg search <text>              substring search across all nodes
+`);
+}
+
+const [, , cmd, ...args] = process.argv;
+const nodes = loadNodes();
+const edges = loadEdges();
+
+switch (cmd) {
+  case "list":
+    cmdList(nodes, args);
+    break;
+  case "show":
+    cmdShow(nodes, args);
+    break;
+  case "neighbors":
+  case "n":
+    cmdNeighbors(nodes, edges, args);
+    break;
+  case "rules-for":
+    cmdRulesFor(nodes, edges, args);
+    break;
+  case "search":
+    cmdSearch(nodes, args);
+    break;
+  default:
+    help();
+    process.exit(cmd ? 1 : 0);
+}


### PR DESCRIPTION
## Summary

Small hand-curated knowledge graph of Tandem's concepts, critical rules, and most-cited ADRs — answering the one class of question grep loses: *"what constraints govern a concept that spans modules?"* (e.g., which rules apply to coordinate-system code, which ADRs decided the origin contract).

- **25 nodes**: 12 concepts, 7 critical rules, 6 most-cited ADRs (031, 027, 038, 033, 034, 018)
- **28 typed edges** across 4 active types (`governs`, `decided_by`, `refines`, `related`)
- **Query CLI**: `npm run kg list|show|neighbors|rules-for|search`
- **Validator**: `npm run kg:lint` (source paths exist, edge endpoints resolve, frontmatter complete, `last_verified` < 60 days)
- **Source-of-truth**: `.claude/knowledge-graph/nodes/<id>.md` (YAML frontmatter + prose) + `edges.json`

## Why this shape (and what was cut)

Two adversarial reviews of an earlier 150-node plan converged on:
- Maintenance decay > build time in a repo shipping ~20 PRs/week
- Module / MCP-tool nodes rot fastest and pay off least (grep is faster and authoritative)
- The prose docs already inline-cite most relationships (ADR-034 alone cites 10 other ADRs)

The pilot keeps only the slice that survives that critique. **File-level nodes, MCP-tool nodes, and the lay-reader audience were explicitly cut.**

## Kill criterion

**Review on 2026-06-01.** If no surprising query in two weeks, delete the directory. Re-evaluate whether a graph-shaped artifact (vs. tighter prose / a docs index) is the right tool here.

## Real drift surfaced on first lint run

`kg-lint` immediately caught that CLAUDE.md and ADR-031 prose claim "pre-commit hook blocks raw `doc.transact`" with a "Biome AST rule." Actual state: warn-only PostToolUse hook + warn-only `audit:origins` script, neither wired into `lint-staged`. `rule-origin-helpers.md` reflects reality and flags the docs drift for separate cleanup. Worth a follow-up to either tighten the guard (move into `lint-staged`) or soften the docs.

## Test plan

- [x] `npm run kg:lint` — passes (25 nodes, 28 edges)
- [x] `npm run kg list rule` — lists all 7
- [x] `npm run kg neighbors concept-y-doc` — shows 1 outgoing + 5 incoming edges
- [x] `npm run kg rules-for concept-coord-flat-offset` — returns 3 governing rules
- [x] `npm run kg rules-for src/server/positions.ts` — returns the same 3 (path-based query)
- [x] `npm run kg search tombstone` — finds 4 hits
- [x] Three parallel `/simplify` review agents — fixes applied (unused imports, narration comments removed, `import.meta.dirname` per project convention)
- [ ] **Two-week usage trial** — Claude runs queries during normal work; decision on 2026-06-01

## Out of scope

- File-level / module / MCP-tool nodes (deferred — grep covers these)
- Interactive HTML viewer / generated `docs/knowledge-graph/` markdown views (Phase 2 if pilot survives)
- Wiring `kg:lint` into `lint-staged` or pre-commit (deliberate — pilot may be deleted)
- Fixing the CLAUDE.md / ADR-031 drift around the raw-transact guard (separate concern)

https://claude.ai/code/session_013KqAiuRmgKTW9319CKvqDG

---
_Generated by [Claude Code](https://claude.ai/code/session_013KqAiuRmgKTW9319CKvqDG)_