### PR TITLE
Address PR #769 review findings

### DIFF
--- a/.claude/knowledge-graph/README.md
+++ b/.claude/knowledge-graph/README.md
@@ -38,15 +38,22 @@ sources:                    # file paths and doc anchors
 
 The body is prose — short summary in the first sentence, expert-targeted detail below.
 
-## Edge types (7)
+## Edge types
+
+**In use today (4):**
 
 - `governs` — rule → concept it constrains
 - `decided_by` — concept → ADR that decided its design
-- `supersedes` — ADR → ADR it replaces (currently unused — add if I find verifiable cases)
-- `implemented_in` — concept → file or symbol
-- `refines` — child concept → parent concept
+- `refines` — child concept → parent concept (or ADR → ADR refinement)
 - `related` — bidirectional "see also"
+
+**Reserved (not yet used, validator still accepts them):**
+
+- `supersedes` — ADR → ADR it replaces
+- `implemented_in` — concept → file or symbol
 - `enforced_by` — rule → hook / script / lint that enforces it
+
+Reserved types are kept in `VALID_EDGES` so a contributor can add a single edge mid-trial without also editing the validator. Drop unused ones at the kill-date review if they're still unused.
 
 ## Maintenance
 
@@ -54,3 +61,4 @@ The body is prose — short summary in the first sentence, expert-targeted detai
 - Bump `last_verified` when you re-read a node's body and confirm it
 - If a node's `last_verified` is more than 60 days old, lint warns (not fails)
 - This is project memory for Claude, not user-facing docs — keep prose terse and current rather than comprehensive
+- **Prose `id` references inside a node body are not validated** — only edge endpoints in `edges.json` are. If you want a relationship enforced, add it to `edges.json`.

--- a/.claude/knowledge-graph/edges.json
+++ b/.claude/knowledge-graph/edges.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "_note": "Edge types: governs | decided_by | supersedes | implemented_in | refines | related | enforced_by",
+  "_note": "In-use: governs | decided_by | refines | related. Reserved: supersedes | implemented_in | enforced_by.",
   "edges": [
     { "from": "rule-ymap-key-constants", "to": "concept-y-doc", "type": "governs" },
     { "from": "rule-origin-helpers", "to": "concept-origin-contract", "type": "governs" },
@@ -21,6 +21,11 @@
     { "from": "concept-file-watcher", "to": "adr-034", "type": "decided_by" },
     { "from": "concept-mcp-transport", "to": "adr-038", "type": "decided_by" },
     { "from": "concept-channel-events", "to": "adr-038", "type": "decided_by" },
+
+    { "from": "adr-032", "to": "adr-018", "type": "refines", "note": "Tagged-variant return types for the modules ADR-018 consolidated" },
+    { "from": "adr-035", "to": "adr-027", "type": "refines", "note": "Lifecycle module makes the audience-based privacy contract un-bypassable" },
+    { "from": "adr-035", "to": "adr-031", "type": "related", "note": "Lifecycle invokes withMcp / withInternal exclusively" },
+    { "from": "adr-035", "to": "adr-032", "type": "related", "note": "LifecycleResult uses tagged variants per ADR-032" },
 
     { "from": "concept-channel-events", "to": "concept-origin-contract", "type": "refines", "note": "Channel emission is a property of the origin contract" },
     { "from": "concept-awareness", "to": "concept-y-doc", "type": "refines", "note": "Awareness lives in a Y.Map subkey" },

--- a/.claude/knowledge-graph/nodes/adr-032.md
+++ b/.claude/knowledge-graph/nodes/adr-032.md
@@ -1,0 +1,18 @@
+---
+id: adr-032
+type: adr
+name: ADR-032 — Position Module Results as Tagged Variants
+last_verified: 2026-05-19
+sources:
+  - docs/decisions.md#adr-032-position-module-results-as-tagged-variants
+  - src/shared/positions/
+  - src/server/positions.ts
+---
+
+# ADR-032 — Position Module Results as Tagged Variants
+
+Continuation of `adr-018`. Promotes every high-level position result (`refreshRange`, `annotationToPmRange`, `anchoredRange`, `validateRange`) to a tagged-variant return type so the three coordinate kinds and degradation paths can't be silently confused at call sites. Callers that care switch on `kind` with an exhaustive `never` fallthrough; callers that don't destructure `.annotation` / `.from` / `.to`.
+
+**Why this matters for the graph:** `concept-coord-*` nodes were decided by `adr-018`; the result-type discipline that surfaces "inverted CRDT range" and "stripped, can't re-anchor" failures as named variants comes from this ADR. Diagnostic emission (toasts, banners) is a caller responsibility — the position module stays pure.
+
+Status: accepted, implementation pending (grilling pass 2026-05-15).

--- a/.claude/knowledge-graph/nodes/adr-035.md
+++ b/.claude/knowledge-graph/nodes/adr-035.md
@@ -1,0 +1,19 @@
+---
+id: adr-035
+type: adr
+name: ADR-035 — Annotation Lifecycle Module
+last_verified: 2026-05-19
+sources:
+  - docs/decisions.md#adr-035-annotation-lifecycle-module
+  - src/server/annotations/
+---
+
+# ADR-035 — Annotation Lifecycle Module
+
+Builds on `adr-027` (audience model), `adr-031` (origin tagging), and `adr-032` (tagged result variants). Introduces `AnnotationLifecycle` (`src/server/annotations/lifecycle.ts`) as the single seam for all annotation mutations: origin-tagged writes, rev bumps, status transitions, sanitize-on-write, and a branded `ChannelEligible` type that turns ADR-027's privacy guarantee into a TypeScript invariant.
+
+**Separate state-machine methods** (`createComment`, `acceptPending`, `dismissPending`, `promoteNoteToComment`, etc.) — not a single `apply(action)` — so preconditions live in method signatures. Fixes the re-accept bug (`acceptPending` rejects non-pending) as a structural consequence of the typing discipline. MCP tool handlers in `src/server/mcp/annotations.ts` become thin adapters that translate `LifecycleResult` into MCP response envelopes.
+
+**Imported `.docx` comments enter as notes** (`author: "import"`, `audience: "private"`) and require explicit user promotion via `promoteNoteToComment` to surface to Claude — reverses ADR-027's earlier "imports auto-surface" stance. Tombstone tracking stays observer-driven in `sync.ts` (widened snapshot, not lifecycle coupling).
+
+Status: accepted, implementation pending (grilling pass 2026-05-15).

--- a/.claude/knowledge-graph/nodes/rule-origin-helpers.md
+++ b/.claude/knowledge-graph/nodes/rule-origin-helpers.md
@@ -12,7 +12,7 @@ sources:
 
 # Rule: Origin-tag every Y.Doc write
 
-Raw `doc.transact(...)` is forbidden anywhere in `src/`. Every write must go through one of the five wrappers in `src/shared/origins.ts`: `withMcp`, `withFileSync`, `withInternal`, `withReload`, `withBrowser`. See `concept-origin-contract` for the decision table.
+Raw `doc.transact(...)` should not appear in `src/` — every write must go through one of the five wrappers in `src/shared/origins.ts`: `withMcp`, `withFileSync`, `withInternal`, `withReload`, `withBrowser`. See `concept-origin-contract` for the decision table.
 
 **Why this matters:** the origin determines which observers react (channel events, durable-sync, tombstone ledger). Picking the wrong wrapper is a silent bug — no exception thrown, just the wrong side-effects (or no side-effects).
 

--- a/scripts/kg-lint.mjs
+++ b/scripts/kg-lint.mjs
@@ -29,6 +29,9 @@ const VALID_EDGES = new Set([
 const errors = [];
 const warnings = [];
 
+// Minimal YAML subset: handles `key: value` and `- item` only. Does not handle
+// quoted strings with colons, multi-line scalars, or nested maps. Sufficient
+// for the current node schema; swap for the `yaml` package if the schema grows.
 function parseFrontmatter(text) {
   const match = text.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!match) return null;

--- a/scripts/kg.mjs
+++ b/scripts/kg.mjs
@@ -9,6 +9,9 @@ const ROOT = join(import.meta.dirname, "..");
 const NODES_DIR = join(ROOT, ".claude/knowledge-graph/nodes");
 const EDGES_PATH = join(ROOT, ".claude/knowledge-graph/edges.json");
 
+// Minimal YAML subset: handles `key: value` and `- item` only. Does not handle
+// quoted strings with colons, multi-line scalars, or nested maps. Sufficient
+// for the current node schema; swap for the `yaml` package if the schema grows.
 function parseFrontmatter(text) {
   const match = text.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!match) return null;


### PR DESCRIPTION
Follow-up on the `/review` of #769. Addresses the four substantive findings; two original findings were dismissed after verification (`scripts/kg.mjs` is present; `engines.node` is `>=22` so `import.meta.dirname` works). Plan was reviewed by two adversarial agents before implementing — both flipped findings A, B, and D from the initial draft.

## Changes

- **Add `adr-032` and `adr-035` nodes** + 4 edges. The prose in `concept-annotation-lifecycle`, `adr-027`, and `adr-018` already referenced these ADRs (both are real, accepted entries in `docs/decisions.md`); the references were dangling because no nodes existed. Adding nodes improves graph connectedness — the original review's plan to *strip* the references would have weakened the pilot at exactly the wrong moment.
- **Soften the lede in `rule-origin-helpers.md`** from "is forbidden anywhere in `src/`" to "should not appear in `src/`". Verified that `lint-staged` does not invoke `check-raw-transact.sh` or `audit:origins`, so the existing drift note in the body is accurate and the original "forbidden" wording contradicted it.
- **Promote unused edge types to a "Reserved (not yet used)" subheading** in the README. Kept them in `VALID_EDGES` so a contributor can add a `supersedes` edge during the 2-week trial without also editing the validator.
- **Note in README that prose `id` references are not validated** — only `edges.json` endpoints are.
- **Document the frontmatter parser's YAML-subset limitations inline** in `scripts/kg.mjs` and `scripts/kg-lint.mjs`. Deferred swapping in the `yaml` package — both reviewers flagged a new devDep as scope creep for a pilot that may be deleted on 2026-06-01.

## Verification

- `npm run kg:lint` — passes (27 nodes, 32 edges)
- `npm run kg neighbors adr-035` — returns the 3 new outgoing edges
- `npm run kg rules-for concept-y-doc` — unchanged (2 rules)

## Explicitly not addressed

- CI hookup of `kg:lint` (PR #769 deliberately defers)
- ADR-031 / CLAUDE.md drift around the `doc.transact` guard (separate concern called out in the original PR description)
- CLAUDE.md placement of the KG entry (revisit at 2026-06-01 kill-date review)

https://claude.ai/code/session_011HXdpyqVq1FALZqJ3Aa1S2

---
_Generated by [Claude Code](https://claude.ai/code/session_011HXdpyqVq1FALZqJ3Aa1S2)_