### PR TITLE
docs(reviews): archive Wave D + A-L redesign sweep PR-review notes

### DIFF
--- a/.claude/notes/pr-review-759-2026-05-18.md
+++ b/.claude/notes/pr-review-759-2026-05-18.md
@@ -1,0 +1,52 @@
+# PR #759 Review — Wave D — left rail locked to outline-only
+
+Head: `bdebbe3` · Base: `master` · Diff: 131+/240− (687 lines, 1 commit) · CI: **1 hard fail + 2 flaky** (known)
+
+## Critical
+
+- **`tests/e2e/settings-models.spec.ts:274` asserts `schemaVersion: 3` but the new v3→v4 migration will produce `4` on a v2-seeded blob — this is the exact cause of the known CI hard-fail.** [REAL — verified against `origin/feat/wave-d-left-outline-only:tests/e2e/settings-models.spec.ts:230`.] Fix is one-line: change the assertion to `expect(settings?.schemaVersion).toBe(4)`. Codex caught it; the test was correctly asserting the old terminal version and was not updated as part of this PR. Must ship before merge so #759 lands green and unblocks #760.
+
+## Important
+
+- **v3→v4 migration is only unit-tested starting from v3; no test seeds v1 or v2 with displaced left tabs.** [REAL — pr-test-analyzer]. The CI failure above is *fixed* by the assertion bump, but the underlying coverage gap remains: a chain test like "v2 blob with `leftRailTabs: ['chat']` → final v4 state has `chat` on right rail" would have caught the regression in unit-land before E2E. Add a parameterised chain test asserting (start_version, expected_v4_shape) tuples for v1, v2, v3 seeds with displaced left tabs.
+- **Idempotency not asserted.** [REAL — pr-test-analyzer]. No test runs the migration twice on an already-v4 blob. Cheap to add.
+- **`rightRailTabs` absent / non-array on v3 source.** [REAL — pr-test-analyzer]. Migration uses `Array.isArray(parsed.rightRailTabs) ? parsed.rightRailTabs : []` — no test covers the absent / non-array case alongside displaced left tabs.
+
+## Suggestion
+
+- **`mergeAndClampSettings` allocates a fresh `["outline"]` literal every write.** [REAL — code-reviewer + svelte-migration-reviewer agreed]. Identity changes on every settings write; any future `$derived` keyed on `leftRailTabs` would re-run unnecessarily. Hoist `const LEFT_RAIL_LOCKED: readonly RailTab[] = ["outline"]` and return same reference, or short-circuit when already clamped. None of today's consumers depend on it — purely a latent footgun.
+- **`moveTabs("right", …)` doesn't reject `"outline"` entries.** [REAL — code-reviewer]. Right picker drops Outline from `ALL_TABS`, but a programmatic caller could persist `{ rightRailTabs: ["outline","chat"] }` (an unreachable state). Symmetric guard: reject `"outline"` on right just as `"left"` is rejected as a side. Low risk — no current UI path triggers it.
+- **`RailTabPicker.svelte:11` — `disabledTabs` prop is dead.** [REAL — svelte-migration-reviewer]. Only remaining caller (App.svelte:1259) doesn't pass it; left caller deleted. Drop the prop + the `disabledTabs.includes` branch for clarity; keep `isLastEnabled` guard. Wave I (in #765) deletes the whole component, so this can be deferred to that PR if Bryan prefers minimum churn on stacked merges.
+- **Append-order test gap.** [REAL — pr-test-analyzer]. Existing dedupe test uses single-element displacement. Add a test where left = `["chat","annotations","outline"]`, right = `[]` → assert right ends `["chat","annotations"]` in source order.
+- **No log when v3 left tabs are neither displaceable nor outline.** [REAL — codex]. `displaced` predicate silently drops unknown entries. `console.warn` would help future debugging of older user data; not a correctness issue.
+- **App.svelte:639 outline-visibility right-side branch is legacy-only.** [REAL — code-reviewer]. `effectiveRightVisible && activeRailTab === "outline"` is reachable only for legacy blobs that had outline pinned right before this PR. Add a one-line comment so a future cleanup pass doesn't rip it out. (Wave I in #765 may eliminate this branch entirely — re-check there.)
+
+## Notes
+
+- `RailTabPicker.svelte`'s `$effect` clearing `dropdownPos` on close is safe today but is a latent `effect_update_depth` hazard. svelte-migration-reviewer flagged as Suggestion; not Critical.
+- `LayoutModel.moveTabs("left", …)` is dead from UI (left picker deleted) but kept as defense-in-depth. Reasonable.
+- Testid inventory in CLAUDE.md and tests was audited by code-reviewer — no orphan references to deleted left-rail testids.
+
+<details><summary>Raw agent verdicts</summary>
+
+### codex:codex-rescue
+`agentId: a0da8887007f921cc`
+
+> **Important** — The v3→v4 migration explains the known CI regression: the loader now fall-through migrates a v2 blob all the way to `schemaVersion: 4` (v2→v3 adds `models`, then v3→v4 clamps/moves rail tabs), but the untouched Models boot E2E still asserts the post-write blob is version 3. `.claude/notes/pr-review-diffs/pr-759.diff:267-290`, `tests/e2e/settings-models.spec.ts:237-273` — The test is asserting a version number that no longer matches what the chain emits; the fix is updating the assertion to `schemaVersion: 4`, not a data-integrity problem.
+
+### pr-review-toolkit:code-reviewer
+`agentId: a740950b3275ed0e5`
+
+Findings under Suggestion: `moveTabs("left", …)` dead path; mergeAndClampSettings fresh-array allocation; legacy right-side outline-visibility branch; v3→v4 silent-drop of unknown entries.
+
+### svelte-migration-reviewer
+`agentId: aa87def2006215c98`
+
+Findings under Suggestion: `RailTabPicker` `disabledTabs` prop dead; `dropdownPos` `$effect` is latent reactive-loop hazard; `mergeAndClampSettings` identity-thrash footgun on `leftRailTabs`.
+
+### pr-review-toolkit:pr-test-analyzer
+`agentId: a9791394faf1c5a18`
+
+Critical: v3→v4 only tested from v3, not v1/v2. Important: idempotency, missing-rightRailTabs case, append-order with multiple displaced. Suggestion: `moveTabs("left", [])` edge case; App.svelte rail-collapse E2E smoke for `[data-testid="left-outline-rail"]`.
+
+</details>

--- a/.claude/notes/pr-review-760-2026-05-18.md
+++ b/.claude/notes/pr-review-760-2026-05-18.md
@@ -1,0 +1,47 @@
+# PR #760 Review — Wave A — titlebar + status pill + right-rail header polish
+
+Head: `73a5f71f` · Base: `feat/wave-d-left-outline-only` · Diff: 169+/85− (342 lines) · CI: shared stack fail (known — #759's E2E assertion bump fixes it)
+
+## Critical
+
+_(none)_
+
+> Codex flagged a "drag-region descendants" violation as Critical. **Verified FALSE-POSITIVE** against `origin/feat/wave-a-chrome-polish:src/client/shell/TitleBar.svelte:187` — the root `<div class="title-bar">` does NOT have `data-tauri-drag-region`; the attribute is on three sibling child divs (`.title-bar-left`, two `.title-bar-gap` spacers). Buttons live in `.title-bar-actions`, a sibling of the drag-region divs. Tauri sibling rule is satisfied. Codex likely inferred from diff context without reading the full file.
+
+## Important
+
+- **Status pill `opacity: 0.4` at rest fades all interactive controls inside the pill — word-count button, display-name input, held-banner indicator — not just the chrome.** [REAL but INTENTIONAL — PR body explicitly calls this a Bryan-requested override beyond redesign parity.] Codex's a11y concern (`src/client/status/StatusBar.svelte:159-262`) is valid: pre-focus contrast on `aria-label`s and clickable controls dips below WCAG 1.4.3 at 0.4 against `--tandem-surface`. `:focus-within` restores full opacity *after* focus lands inside, but a sighted-low-vision user scanning the page sees a 0.4-opacity control they may not realise is interactive. Mitigations to consider before merge: (a) restrict the fade to chrome-only via `:not(:has(:focus-visible))` carve-outs on the input/buttons; (b) bump rest opacity to 0.55–0.6; (c) add a focus-visible ring that doesn't depend on the pill being fully opaque. Bryan should make the call — flagging so it's an informed override, not a silent one.
+
+## Suggestion
+
+- **Raw px literals in new CSS:** `App.svelte:144` `font-size: 11.5px`, plus `margin: 12px 12px 10px`, `padding: 4px`, `gap: 3px`, `padding: 5px 8px` for the new `.rail-tab` / rail-tabs-track classes. [REAL — code-reviewer.] `ModeToggle.svelte` similar: `padding: 3px`, `padding: 4px 12px`. CLAUDE.md "Spacing / radius / type / elevation scales — use `--tandem-text-*`, `--tandem-space-*` instead of raw px literals in client surfaces." 11.5px falls between `--tandem-text-2xs` and `--tandem-text-xs`; pick nearest or add a half-step token rather than hard-code. Repo has a `check:tokens` script — confirm it doesn't catch these (it currently scans hex/rgba only, not px). Low-risk style debt; surface for later cleanup.
+- **`--tandem-status-clearance-total` token verified defined** in `index.html:167` (per code-reviewer). Fallback `60px` matches token intent. No missing-token issue.
+- **`.c7-*` namespace is for CSS custom properties (`--c7-pill-shadow`), not classes.** [REAL — code-reviewer.] PR uses plain class names (`rail-tab`, `mode-toggle`, `rail-tabs-track`); the `c7-` prefix appears only in source comments as design-system references. Consistent with existing convention. No action.
+- **ModeToggle: Solo/Tandem status dot moved to status bar.** [REAL — code-reviewer.] The diff comment says "Claude-active dot moved to the status bar." Confirm the new `status-dot` element in TitleBar.svelte at the action group is functionally equivalent (renders when `claudeActive` is true). Spot-checked: yes — `TitleBar.svelte:215` renders `<span class="status-dot" ... />` when `claudeActive`. Migration affordance preserved.
+- **No new `$state`/`$derived` introduced.** [REAL — svelte-migration-reviewer.] Status-pill fade verified pure CSS, no JS handlers. Clean from a reactivity standpoint.
+
+## Notes
+
+- This PR builds cleanly on #759. Drag-region structure verified safe against false alarm.
+- Worth ensuring `.icon-btn` 30×30 chips have ≥44×44 touch-target equivalent via padding or interaction area on mobile/touch — not flagged by any reviewer but Wave A's primary touch surface.
+- The PR body footnotes "Status pill fade is a Bryan-requested override; `.c7-status` in the redesign has no fade. Shipped because Bryan explicitly asked for it." — codex's Important is therefore not a regression-against-intent, but the a11y impact still applies.
+
+<details><summary>Raw agent verdicts</summary>
+
+### codex:codex-rescue
+`agentId: a1847bf315b8a0d4b`
+
+Critical (FALSE POSITIVE): claimed `<div class="title-bar">` carries `data-tauri-drag-region` with descendant buttons — verified against the actual file, the attribute is on sibling divs and the structure is correct.
+Important: status-pill opacity 0.4 fades interactive controls.
+
+### pr-review-toolkit:code-reviewer
+`agentId: a03707a70ed32ae48`
+
+No Critical/Important. Suggestion: raw px literals (font-size, padding, gap, margin) bypass `--tandem-space-*` / `--tandem-text-*` tokens; `.c7-*` namespace clarification; flagged mode-dot relocation for follow-up confirmation (verified above).
+
+### svelte-migration-reviewer
+`agentId: afd803a093a23f8da`
+
+Clean. Confirmed status-pill fade is pure CSS, no JS handlers, no reactive loops. Approve from Svelte-5 standpoint.
+
+</details>

--- a/.claude/notes/pr-review-761-2026-05-18.md
+++ b/.claude/notes/pr-review-761-2026-05-18.md
@@ -1,0 +1,61 @@
+# PR #761 Review — Wave B — hide native scrollbars, mask-fade overflow edges
+
+Head: `ef64ed74` · Base: `feat/wave-a-chrome-polish` · Diff: 205+/5− (381 lines) · CI: shared stack fail (known)
+
+## Critical
+
+- **MutationObserver scope is too broad — fires `update()` (which reads `scrollTop/clientHeight/scrollHeight`, forcing layout) on every keystroke inside descendant inputs / contenteditable / Tiptap decoration patches.** [REAL — svelte-migration-reviewer; silent-failure-hunter; codex agreed on the throttling angle.] `src/client/actions/scrollFade.svelte.ts:55` — `mutationObserver.observe(node, { childList: true, subtree: true, characterData: true })`. ChatPanel has an editable composer; CommandPalette has a search input; SettingsModal has multiple inputs and modal content. Every keystroke pumps a synchronous layout-read on these surfaces. Worst case: per-keystroke jank during chat composition. Two viable fixes:
+  - **Drop `characterData` + `subtree`** — `{ childList: true }` only. Catches list growth (new annotations / outline headings / chat messages) without per-keystroke firing. ResizeObserver still handles container-size changes.
+  - **Or rAF-throttle `update()`** — coalesce scroll + RO + MO callbacks into one read per frame.
+  - The PR body says "the proven DocumentTabs pattern (scroll listener + ResizeObserver)" — note that DocumentTabs uses scroll+RO only. Adding the MO is new and is the source of the regression. Recommend dropping the MO entirely and observing each child via `ResizeObserver` if the list-growth case actually breaks (it likely won't — list items add to container intrinsic size which RO catches).
+
+> Code-reviewer flagged a Critical "action signature mismatch — every consumer broken" (claimed on-disk signature is `(node, axis: string)` not `(node, options)`). **Verified FALSE POSITIVE** by reading `origin/feat/wave-b-scroll-fade-masks:src/client/actions/scrollFade.svelte.ts`: signature is `scrollFade(node: HTMLElement, options: ScrollFadeOptions = {})`, all 8 callsites' `{ axis: "y" }` work correctly. Code-reviewer appears to have hallucinated a different file version.
+
+## Important
+
+- **No `node.isConnected` guard in `update()`.** [REAL — silent-failure-hunter.] `scrollFade.svelte.ts:24` — MutationObserver callback can fire after Svelte detaches the node during an `{#if}` collapse but before `destroy()` runs. Reading `scrollHeight`/`clientHeight` on a detached node returns 0, so `data-overflow-*` attrs are silently removed; on remount without a content/size change, stale state persists until next scroll. Cheap fix: `if (!node.isConnected) return;` at top of `update()`.
+- **Observer construction unguarded.** [REAL — silent-failure-hunter; low risk in practice since Tauri WebView is modern.] `scrollFade.svelte.ts:51-55` — `new ResizeObserver` / `new MutationObserver` are unguarded. On legacy browsers / test stubs they throw after the scroll listener is already registered, leaking the listener forever (no `destroy()` returned). Wrap each in try/catch with a `logError` call, and return a `destroy()` that tears down whatever did register.
+- **No vitest coverage for the action.** [REAL — code-reviewer's only valid finding.] jsdom mocks both observers easily; a 30-line test mounting a node and asserting attr toggling under controlled scroll/RO/MO events would have caught the over-broad MO scope above (a keystroke-equivalent characterData event in the test would have forced a discussion of debouncing).
+
+## Suggestion
+
+- **No `update()` hook for option changes.** [REAL — svelte-migration-reviewer.] Action returns only `{ destroy }`. If a future consumer passes a dynamic `axis`, Svelte calls a non-existent `update()` and the axis stays mount-time. Either add an `update(newOptions)` or document axis as mount-time-only.
+- **`.svelte.ts` extension is misleading.** [REAL — svelte-migration-reviewer.] The action uses no runes — rename to `.ts` to make non-reactive nature explicit and prevent a future contributor from adding `$state` to a hot imperative path.
+- **No `mask-image` fallback.** [REAL — silent-failure-hunter.] If `mask-image` doesn't apply (old browsers, `content-visibility: hidden`, print), overflow is invisibly clipped (no scrollbar, no fade). Gate via `@supports (mask-image: linear-gradient(#000, #000))` in `scroll-fade.css`.
+- **`#000` in mask gradients is a luminance/alpha mask channel, not a visible color** — semantic-tokens lint exemption applies, same logic as `rgba(0,0,0,...)` neutral shadows. No action needed.
+- **Initial `update()` may run before layout settles.** [REAL — svelte-migration-reviewer.] `queueMicrotask(update)` or `requestAnimationFrame(update)` makes the first read explicit; RO firing once after observe currently masks this in practice.
+- **A11y note carried over from PR body** — removing scrollbar thumbs costs a position cue. Sticky section headers (per Bryan's plan) are the right follow-up if users report disorientation.
+
+## Notes
+
+- Cleanup is symmetric (scroll listener + both observers torn down in `destroy()`). Good.
+- 8 surface conversions look idiomatic. No CSS-token regressions.
+- The over-broad MO scope is the one finding that should land before merge — it's a measurable perf footgun in two high-frequency surfaces (chat, settings).
+
+<details><summary>Raw agent verdicts</summary>
+
+### codex:codex-rescue
+`agentId: a00404b45e6c47f28`
+
+Important: scroll listener + ResizeObserver routed straight into synchronous `update()` with no rAF throttling — overflow-attribute writes happen multiple times per frame during scroll + layout churn.
+
+### pr-review-toolkit:code-reviewer
+`agentId: a3b8e6f9df7e73855`
+
+Critical (FALSE POSITIVE): claimed action signature is positional `(node, axis: string)` and all 8 consumer object-arg calls are broken — verified the on-disk signature is the object form `(node, options: ScrollFadeOptions)` that matches the diff exactly. All consumers work.
+Important: no vitest coverage (valid). MutationObserver intentionally dropped — also wrong (it's still there).
+
+### svelte-migration-reviewer
+`agentId: a36b9086bafe679e5`
+
+Critical: MutationObserver scope too broad — `characterData: true` + `subtree: true` fires `update()` per keystroke in editable descendants, forcing layout. Drop MO or scope to `childList` only.
+Important: no `update()` hook for dynamic options; initial `update()` runs pre-layout.
+Suggestion: rename `.svelte.ts` to `.ts` since no runes.
+
+### pr-review-toolkit:silent-failure-hunter
+`agentId: a71fb1a02c61503eb`
+
+Important: unguarded observer construction (legacy browser throw leaks scroll listener); no `node.isConnected` guard in `update()`.
+Suggestion: no `mask-image` fallback (silent invisible overflow on unsupported browsers); MO subtree scope is layout-thrash adjacent.
+
+</details>

--- a/.claude/notes/pr-review-762-2026-05-18.md
+++ b/.claude/notes/pr-review-762-2026-05-18.md
@@ -1,0 +1,27 @@
+# PR #762 Review — Wave C — selection popup uses shared floating-pill recipe
+
+Head: `9b4f462b` · Base: `feat/wave-b-scroll-fade-masks` · Diff: 5+/1− (21 lines, 1 file) · CI: shared stack fail (known)
+
+Reviewed directly — diff is too small to warrant agent fan-out.
+
+## Critical
+
+_(none)_
+
+## Important
+
+_(none)_
+
+## Suggestion
+
+- **The popup inherits `.tandem-floating-pill`'s `backdrop-filter: saturate(140%) blur(8px)` — a NEW visual effect not present in the pre-PR popup.** Verify intent: the formatting bar and titlebar already use this recipe so the popup will look consistent across surfaces, but on long selections the underlying text now blurs through the popup. Likely a feature (matches redesign), but worth a manual eyeballing pass before merge.
+- **Inline style still sets `border-radius: var(--tandem-r-4)`** which overrides the recipe's `--tandem-r-pill`. [REAL — verified against `index.html:182-186`.] This is intentional per the recipe comment ("Surfaces only need .tandem-floating-pill + a sensible border-radius (pill or 14px). Surface-specific overrides layer on top.") — the popup is a rounded rectangle, not a pill. No action.
+- **`color-mix` shadow values are gone, replaced by `var(--c7-pill-shadow)`.** Light/dark variants are defined in `index.html` `:root` and `[data-theme="dark"]` blocks. Verified theme parity. The light shadow uses `oklch(...)` and the dark variant uses `rgba(0,0,0,...)` neutral values — both within the semantic-tokens exemption.
+- **Inline `style=` template literal still carries position/size**, exactly as planned. Could be migrated to `style:left={...}` directive syntax for finer reactivity tracking, but that's repo-wide style debt and out of scope for this 21-line PR.
+- **No test changes.** The popup's visual change is hard to unit-test; an E2E snapshot test would be the right granularity but doesn't exist. Acceptable for a CSS-only change of this size.
+
+## Notes
+
+- This is the smallest PR in the stack and lowest risk.
+- The `.tandem-floating-pill` recipe is already in production for formatting bar + titlebar pills (per `feedback_token_migration_dead_style_consts.md` pattern from earlier waves).
+- No reviewer agents launched — diff was a 21-line CSS-class swap with one verifiable invariant (border-radius override is intentional per the recipe's own documentation).

--- a/.claude/notes/pr-review-763-2026-05-18.md
+++ b/.claude/notes/pr-review-763-2026-05-18.md
@@ -1,0 +1,27 @@
+# PR #763 Review — Wave F — placeholder fix + margin-card hover affordance
+
+Head: `60c9f095` · Base: `feat/wave-c-shadow-standardization` · Diff: 37+/2− (69 lines, 2 files) · CI: shared stack fail (known)
+
+Reviewed directly — diff is small enough.
+
+## Critical
+
+_(none)_
+
+## Important
+
+- **`MarginColumn.svelte:54` — `drop-shadow(0 0 0 var(--tandem-accent-border))` is invisible.** [REAL — likely typo.] `drop-shadow()` syntax is `(offset-x offset-y blur-radius color)`. With `0 0 0` (no offset, no blur), there is nothing to render. The comment immediately above says "faint outline halo on hover" — that intent requires a non-zero blur. Probably meant `drop-shadow(0 0 4px var(--tandem-accent-border))` or similar. As written, the only visible part of the hover is the second drop-shadow (`0 1px 3px rgba(0, 0, 0, 0.06)`), which is a generic soft drop shadow — no accent-color halo. Either fix the blur value or, if the soft drop-shadow alone is the intended affordance, delete the first line for clarity.
+
+## Suggestion
+
+- **`white-space: nowrap` on the placeholder pseudo can overflow horizontally** if the placeholder string is longer than the prose column at narrow viewports. Tiptap defaults to short text like "Start typing…" so unlikely to bite in practice. If Tandem ever supports custom long placeholders, this becomes a visible bug.
+- **Verify caret alignment** — `position: absolute; left: 0; top: 0` on the pseudo combined with `position: relative` on the empty `<p>` puts the placeholder text at the paragraph's top-left. If the paragraph has any padding-top or vertical-align affordance for prose, the placeholder may not visually align with where the caret renders. Worth a one-second eyeballing pass in a browser before merge.
+- **`:global([data-testid^="edit-btn-"])` opacity-reveal pattern is sound** — Svelte 5's scoped styles need `:global()` to pierce the AnnotationCard boundary, which is exactly what the comment calls out. `opacity` transitions don't fight the existing pending-card visibility logic.
+- **`transition: filter 140ms ease`** on the bubble means *every* style change that affects the filter (theme switch, hover end) animates. Fine for a hover affordance; just noting.
+- **#10 format-before-type deferred.** Per PR body, the failure can't be reproduced without a live browser. Wave J in #765 ships an `applyLink` / `getInitialLinkHref` / `withPreventDefault` refactor in `handlers.ts` that "resolves format-before-type by construction" — the deferred item is effectively addressed in #765. Confirm there.
+
+## Notes
+
+- The Tiptap `float: left; height: 0` → `position: absolute` swap is a well-known Tiptap-community alternative; no regression risk on the placeholder semantics.
+- No tests for either change — both are visual, hard to unit-test, acceptable scope.
+- No reviewer agents launched — single-file CSS + single-component-block scope; one finding above is verifiable from the diff alone.

--- a/.claude/notes/pr-review-764-2026-05-18.md
+++ b/.claude/notes/pr-review-764-2026-05-18.md
@@ -1,0 +1,55 @@
+# PR #764 Review — Wave E — peek-from-side strips + edge-click panel collapse
+
+Head: `fc6bc9cc` · Base: `feat/wave-f-placeholder-format-margin` · Diff: 172+/84− (561 lines, 17 files) · CI: shared stack fail (known)
+
+## Critical
+
+_(none)_
+
+## Important
+
+- **Right-rail edge-collapse zone occludes the native scrollbar hit area.** [REAL — codex; code-reviewer agreed.] `src/client/App.svelte:1238-1242`, `SidePanel.svelte:339-342`, `OutlinePanel.svelte:264-268`. The 8px-wide absolutely-positioned collapse target at `right: 0` with `z-index: 1` sits on top of the rail's overflow-y:auto scroller. Pointer-down at the rail's outer right edge — the natural scrollbar location — lands on the collapse zone, hiding the panel instead of scrolling. This is the precise overlap pattern that breaks scroll UX. Fix: narrow the right-edge collapse zone to the chrome above/below the scroll container (rail-tabs-row, status clearance) but exclude the scroller, OR move the collapse trigger inboard of the scrollbar (custom 8px gutter), OR use `mask-image`/`clip-path` so the collapse zone only covers the top/bottom edges of the rail.
+
+- **RailTabPicker trigger button rightmost ~8px is covered by the right-edge collapse zone.** [REAL — code-reviewer.] The picker button sits at the right end of `rail-tabs-row`; the 8px edge-collapse strip overlays it. Keyboard activation of the picker still works (focus + Enter), but mouse clicks on the right portion of the trigger collapse the rail instead. Same fix as above — narrow the collapse zone or inset it below the tabs row.
+
+- **`MarginColumn.svelte` hover halo is still invisible** (`drop-shadow(0 0 0 var(--tandem-accent-border))`). [REAL — code-reviewer; carried over from PR #763.] Same bug as flagged in `.claude/notes/pr-review-763-2026-05-18.md`. Fix is independent of Wave E but needs to ship before/with this PR if intent is the halo affordance. If Wave F ships first, fix it there; otherwise fix here.
+
+## Suggestion
+
+- **Edge-collapse and PeekStrip cursors are `e-resize`/`w-resize` — same as the inboard resize handle.** [REAL — code-reviewer.] The inline comment claims "Cursor differentiates from the inboard drag-to-resize handle" but both use the same resize cursors. Resize cursors imply drag; collapse/peek are click-to-toggle. Use `pointer` for collapse/peek so the affordance matches the interaction.
+- **No focus restoration after keyboard-triggered collapse/expand.** [REAL — code-reviewer.] When the user activates `panel-edge-collapse` via Enter/Space, the element unmounts and `PeekStrip` mounts in its place; focus drops to `<body>`. Symmetric concern when re-expanding. Move focus to the newly-mounted toggle so Tab order survives.
+- **`PeekStrip` lacks `aria-expanded` semantics.** [REAL — code-reviewer.] As a disclosure-style toggle it should advertise `aria-expanded="false"` (peek strip = panel collapsed) so screen-reader users know the state. Today AT users just hear "Show left panel, button" with no state cue.
+- **PeekStrip focus-visible state IS distinct** — opacity bump 0.35→1, width 6→10px, 2px inset accent box-shadow. [REAL — codex.] So the "faint at rest is invisible to keyboard users" concern is **NOT** an issue. Verified in `PeekStrip.svelte:30-39, 50-58`.
+- **PanelSlot + edgeCollapse are siblings inside the rail container** for both rails, NOT parent/child. [REAL — codex verified.] PR body claim about "descendant clicks never bubble in" is correct. False alarm avoided.
+- **Editor scroll preservation through panel toggle is architecturally sound** — editor column is a stable sibling that never remounts. [REAL — codex.] Browser-level flex-reflow scroll retention still warrants one manual eyeballing pass.
+- **`leftRailTabs` typed mutable but always clamped to `["outline"]`** — narrow to `readonly ["outline"]` to make the invariant compile-time visible. [REAL — svelte-migration-reviewer; minor style.]
+- **`scrollFade.svelte.ts` MutationObserver REMOVED in this PR** (`scrollFade.svelte.ts:1-49`, `pr-764.diff:198-255`). This directly addresses PR #761's Critical (over-broad MO scope causing per-keystroke layout reads). [REAL — codex + svelte-migration-reviewer + code-reviewer all confirmed.] But: if #761 merges first and #764 merges later, there's a window where the per-keystroke layout-thrash exists in master. Either land #761 + #764 together, or backport the MO removal into #761.
+
+## Notes
+
+- This PR's removal of scrollFade's MutationObserver is the right fix for #761's perf concern. Recommend merging #761 + #764 as a group, or rolling the MO removal into #761 directly before merge.
+- Edge-zone-vs-scrollbar overlap is the most actionable finding — it's a measurable UX regression on the most common pointer interaction with rails (scroll). Should be fixed before merge.
+- The right-picker overlap is the same root cause (8px right-side zone overlapping inboard chrome). One geometry fix likely addresses both.
+- MarginColumn halo bug carries across #763 → #764 → #765; the cross-PR summary will surface this once.
+
+<details><summary>Raw agent verdicts</summary>
+
+### codex:codex-rescue
+`agentId: a449449d4f63e2d7f`
+
+Important: right-panel collapse zone occludes scrollbar at App.svelte:1238–1242.
+Suggestion: PanelSlot+edgeCollapse sibling structure verified (no catastrophic wrapper); PeekStrip focus-visible state confirmed distinct; scrollFade MO removal confirmed addressing #761's flag.
+
+### pr-review-toolkit:code-reviewer
+`agentId: ad736eb4df21a182b`
+
+Important: MarginColumn `drop-shadow(0 0 0 ...)` halo invisible; RailTabPicker button overlapped by right-rail edge-collapse zone.
+Suggestion: cursor mismatch (resize vs click intent); no focus restoration on toggle; no `aria-expanded` on PeekStrip.
+Notes: rgba black-shadow neutrals exempt; testids kebab-case; CLAUDE.md "Post-Wave-I" description is for a future state (#765) — consistent with PR scope.
+
+### svelte-migration-reviewer
+`agentId: a069117a51036db48`
+
+Clean — no Critical/Important. Suggestion: `PeekStrip.svelte:7` props destructure of primitives is safe and idiomatic; edge-collapse snippet parameter capture stable because callers are module-scope const arrows; scrollFade action attaches correctly inside snippet renders; `leftRailTabs` could be `readonly ["outline"]`.
+
+</details>

--- a/.claude/notes/pr-review-765-2026-05-18.md
+++ b/.claude/notes/pr-review-765-2026-05-18.md
@@ -1,0 +1,90 @@
+# PR #765 Review — Waves G–L — redesign-parity sweep
+
+Head: `d85b5fdb` · Base: `master` · Diff: 901+/695− (2462 lines, 33 files) · CI: shared stack fail (known)
+
+PR contains union of waves D + A–F (waves D and A–F are also reviewed separately in #759-#764) PLUS the G–L delta on top. Findings below focus on G–L; A–F overlap is flagged only where #765 diverges from its corresponding wave PR.
+
+## Critical
+
+- **`tests/e2e/settings-models.spec.ts:273` asserts `schemaVersion: 3` but the chain in this PR climbs v2→v3→v4→v5 — assertion must bump to `5`.** [REAL — verified `CURRENT_SCHEMA_VERSION = 5` in `origin/feat/wave-g-l-redesign-sweep:src/client/hooks/useTandemSettings.ts`; test-analyzer caught it.] This is the same E2E failure shape as PR #759 (where the bump is to `4`). Whichever PR merges last needs the assertion at that PR's terminal schema version. If #765 lands on top of #759 (which will have bumped to `4`), #765 must bump to `5`. If #765 lands standalone (#759 still open), it must still bump to `5`. PR doesn't touch the test file — must include the fix or land green will not happen.
+
+- **`tests/client/use-tandem-settings-migration.test.ts:178-179` pins the wrong contract for v99 forward-compat.** [REAL — test-analyzer.] Test asserts `s.leftRailTabs).toEqual(["chat", "annotations"])` after a v99 read, framing it as "future fields pass through." But these are *named* fields that v5 explicitly strips, not unknown future fields. The assertion passes only because `RailTab` was removed from `normalizeKnownFields` and the `futureFields` spread gathers them. A future schema that re-uses the names will silently leak. Fix: assert `s.leftRailTabs).toBeUndefined()` (matches v3/v4 tests at `useTandemSettings.test.ts:558-571`) and assert `_readOnly` shape only.
+
+## Important
+
+- **Wave G: `<div class="title-bar" data-tauri-drag-region>` puts `data-tauri-drag-region` on the ROOT, with all action buttons (ModeToggle, panel toggles, theme toggle, help, settings, window controls) as descendants.** [REAL — verified `origin/feat/wave-g-l-redesign-sweep:src/client/shell/TitleBar.svelte:187`; codex caught it; code-reviewer's "implementation is fine" was wrong.] This reverts the safer sibling pattern that PR #760 used (root attribute-free, drag-region only on three sibling spacer divs). Per `feedback_tauri_drag_region_structure.md`: *"Controls must be siblings of drag region, not descendants"* — recorded from prior production breakage. While Tauri's documented behavior is that child elements without the attribute are NOT drag regions, the repo memory says this pattern has bitten before. **Verify in `cargo tauri dev` that titlebar buttons still receive clicks** before merge. If broken, restore sibling layout: drag-region on `.title-bar-left`, two `.title-bar-gap` spacers; root + `.title-bar-actions` attribute-free.
+
+- **`src/client/editor/toolbar/handlers.ts` (new, ~150-line pure-function module) has zero unit coverage.** [REAL — test-analyzer.] `applyLink` and `getInitialLinkHref` have branchy logic (current-selection mark vs empty selection vs caret); `withPreventDefault` is a wrapper but consumed from two surfaces. Pure functions are cheap to test and yield high regression coverage given two callers.
+
+- **No idempotency test for v4→v5.** [REAL — test-analyzer.] `=== N` gating is correct in source, but no test loads a v5 blob and asserts the migration is a no-op + does not strip future fields. 5-line addition.
+
+- **No v2-with-rail-tabs seed climbing all the way to v5.** [REAL — test-analyzer.] `use-tandem-settings-migration.test.ts:56-69` covers a v1-like blob and asserts terminal `schemaVersion: 5` but does NOT seed `leftRailTabs`/`rightRailTabs` on the v1 blob. The v4→v5 strip step is exercised only on v3+v4 seeds (`useTandemSettings.test.ts:550-571`). Add a v2 seed with both rail-tabs fields populated, asserting both are absent post-load (covers the realistic prod-upgrade path).
+
+- **`MarginColumn.svelte` halo `drop-shadow(0 0 0 var(--tandem-accent-border))` is invisible.** [REAL — carries over from #763 and #764. Wave F's #4 bug. Single-line fix.]
+
+> Codex flagged "Wave I v4→v5 migration must update spec.ts:273 to 5" matching the test-analyzer's Critical above. **Confirmed.**
+> Codex flagged ADR-037 amendment risk. Code-reviewer said ADR matches code. Not investigated further — low-risk doc drift only.
+
+## Suggestion
+
+- **`FormattingToolbar.svelte` — nine `$derived.by(() => { void tick; return ... })` blocks subscribed to the same `tick` counter on every Tiptap transaction.** [REAL — svelte-migration-reviewer.] Re-runs every derived on every keystroke. Correct but coarse; gate on `selectionUpdate` or batch through one parent `editorState` `$derived`. Perf, not correctness.
+
+- **`FormattingToolbar.svelte:24,41-46,363` — `$state(null) + bind:this + $effect` pattern for `linkInputEl`.** [REAL — svelte-migration-reviewer.] Effect fires twice (once with null, once with element). Defensive: wrap focus call in `untrack(() => linkInputEl)?.focus()` or move into a Svelte action / `onMount`. Not a loop (no state mutation in effect), just an extra fire.
+
+- **`model.svelte.ts` `createLayoutModel` has no singleton guard.** [REAL — svelte-migration-reviewer.] Today's single consumer (App.svelte) is safe, but per `feedback_svelte_singleton_for_app_global_state.md`, a future caller creating a second `$derived` clobbers state. Mirror the `useTandemSettings.svelte.ts` singleton pattern, or add a doc-comment locking in single-consumer contract.
+
+- **Add tripwire assertion `expect((model as any).moveTabs).toBeUndefined()`** in `tests/client/layout-model.svelte.test.ts` so re-introducing `moveTabs` would fail. [REAL — test-analyzer, low priority.]
+
+- **`--tandem-rail-shadow-{left,right}` tokens defined in both themes** (`index.html:138-140` light, `306-308` dark). [REAL — code-reviewer.] Clean.
+
+- **Testid registry matches code, including dynamic `titlebar-toggle-${side}`.** [REAL — code-reviewer.] Clean.
+
+- **`useTandemSettings.svelte.ts` is the singleton; `useTandemSettings.ts` is the data layer.** [REAL — code-reviewer confirmed; HMR comment documents the no-`hot.accept` choice.] No dual-singleton bug. Naming is ambiguous; consider renaming `useTandemSettings.ts` → `settingsSchema.ts` or `settingsStore.ts` in a future cleanup.
+
+- **`PR body claims data-tauri-drag-region is on the title-bar itself` is correct** — the body accurately describes the implementation. Code-reviewer's "PR body framing mismatch" claim is wrong (code-reviewer got the structure verification backwards).
+
+## False positives caught
+
+- **svelte-migration-reviewer's Critical claim: orphan `RailTabPicker` import on `App.svelte:78,1280` + missing `RailTab` re-export breaks build.** **FALSE POSITIVE — VERIFIED.** Grep for `RailTabPicker` in `origin/feat/wave-g-l-redesign-sweep:src/client/App.svelte` returns zero matches; `import` section of App.svelte (lines 2-26+) contains no RailTabPicker reference. `model.svelte.ts:16` imports `TandemSettingsState` only, not `RailTab`. The agent even fabricated specific svelte-check error output ("Cannot find module './panels/RailTabPicker.svelte'") that doesn't reproduce on the branch. **This is the third reviewer-hallucination in this PR-stack review** (after code-reviewer's #761 signature claim and #760 drag-region claim). Memory `feedback_pr_review_findings_can_be_wrong.md` continues to hold.
+
+- **code-reviewer's claim that TitleBar drag-region structure is "correct, root attribute-free, drag-region only on sibling spacers."** **FALSE POSITIVE.** Root actually has `data-tauri-drag-region` — codex was right.
+
+- **code-reviewer's claim that the E2E assertion should bump to `4`.** **FALSE POSITIVE in this PR's context** (4 is right for #759 in isolation; #765 needs `5` because it stacks v4→v5 on top).
+
+## Notes
+
+- This PR is the trickiest to land because it carries forward A–F changes from a stack that's also under review. Two clean landing options:
+  1. Merge #759 → #760 → #761 → #762 → #763 → #764 in order with their respective fixes; then rebase #765 onto master so the diff narrows to just G–L. Easier to review and verify.
+  2. Squash-merge #759-#764 into #765 by abandoning the wave PRs. Loses per-wave review history. Not recommended.
+- The drag-region question is the load-bearing concern for desktop usability — verify in Tauri dev before merge.
+- Wave J's `handlers.ts` is the most testable new code; absence of unit tests is the highest-leverage gap.
+- The cross-PR `MarginColumn` halo bug now spans three PRs — fix once in whichever lands first.
+
+<details><summary>Raw agent verdicts</summary>
+
+### codex:codex-rescue
+`agentId: af82654dff097c100`
+
+Important: Wave G drag-region moved to root; descendants violate sibling pattern. [Confirmed]
+Suggestion (false positive marks): v4→v5 E2E assertion concern is "false positive" — actually confirmed Critical by test-analyzer and verified by source.
+
+### pr-review-toolkit:code-reviewer
+`agentId: ac53c4a44ea94186f`
+
+Critical: E2E assertion needs bump (correct concern, wrong target — they said 4, actually 5).
+Important: PR-body / schema-version framing mismatch; PR-body / TitleBar drag-region framing mismatch (false positive — both PR body claims are accurate).
+
+### svelte-migration-reviewer
+`agentId: ab6dd99c966727164`
+
+Critical (FALSE POSITIVES — both): orphan RailTabPicker import in App.svelte:78,1280; missing RailTab re-export in model.svelte.ts:16. Verified by grep — no orphan refs exist. Agent fabricated svelte-check output.
+Suggestion: FormattingToolbar `tick`-driven `$derived` blocks; `$state + bind:this + $effect` extra-fire on linkInputEl; createLayoutModel singleton-guard gap.
+
+### pr-review-toolkit:pr-test-analyzer
+`agentId: a69f62c5af04ebf1a`
+
+Critical: E2E assertion bump to 5; v99 forward-compat test pins wrong contract.
+Important: No idempotency test for v4→v5; no v1/v2 chain test with rail-tabs seeded; zero coverage of `handlers.ts`.
+Suggestion: tripwire on `moveTabs` undefined.
+
+</details>

--- a/.claude/notes/pr-review-summary-2026-05-18.md
+++ b/.claude/notes/pr-review-summary-2026-05-18.md
@@ -1,0 +1,106 @@
+# Cross-PR Review Summary — Waves D + A–L Redesign Sweep · 2026-05-18
+
+Two-pass review (codex + pr-review-toolkit + situational `svelte-migration-reviewer` / `silent-failure-hunter`) on 7 open PRs forming the redesign-parity stack. Per-PR detail in `pr-review-{N}-2026-05-18.md`.
+
+| PR | Wave | Crit | Imp | Notes file |
+|----|------|------|-----|------------|
+| #759 | D — outline-only left rail | **1** | 3 | `pr-review-759-2026-05-18.md` |
+| #760 | A — chrome polish | 0 | 1 | `pr-review-760-2026-05-18.md` |
+| #761 | B — scroll fade masks | **1** | 3 | `pr-review-761-2026-05-18.md` |
+| #762 | C — popup shadow | 0 | 0 | `pr-review-762-2026-05-18.md` |
+| #763 | F — placeholder + margin hover | 0 | 1 | `pr-review-763-2026-05-18.md` |
+| #764 | E — peek panels | 0 | 3 | `pr-review-764-2026-05-18.md` |
+| #765 | G–L — sweep | **2** | 5 | `pr-review-765-2026-05-18.md` |
+
+## Critical block (verbatim concatenation)
+
+### PR #759
+- **`tests/e2e/settings-models.spec.ts:274` asserts `schemaVersion: 3` but the new v3→v4 migration will produce `4` on a v2-seeded blob — this is the exact cause of the known CI hard-fail.** Fix is one-line: bump assertion to `4`. Verified against branch.
+
+### PR #761
+- **MutationObserver scope is too broad — fires `update()` (forcing layout-read) on every keystroke inside descendant inputs / contenteditable / Tiptap decoration patches.** `src/client/actions/scrollFade.svelte.ts:55`. Per-keystroke jank in ChatPanel composer and SettingsModal. *(Note: PR #764 removes the MO entirely. If #764 lands together with or before #761, this is moot. Otherwise backport the fix into #761.)*
+
+### PR #765
+- **`tests/e2e/settings-models.spec.ts:273` asserts `schemaVersion: 3` but the chain in this PR climbs v2→v3→v4→v5 — assertion must bump to `5`.** Same flavor as #759's bug but at the terminal version (5, not 4).
+- **`tests/client/use-tandem-settings-migration.test.ts:178-179` pins the wrong contract for v99 forward-compat** — asserts named fields (`leftRailTabs`, `rightRailTabs`) flow through, but v5 strips them. Future schema reuse would silently leak. Fix: assert `toBeUndefined()`.
+
+## Recommended merge order + action list
+
+The stack is `master ← #759 (D) ← #760 (A) ← #761 (B) ← #762 (C) ← #763 (F) ← #764 (E)`, plus `#765 (G–L)` rebased onto master containing the union of all six.
+
+**Recommendation:** land the six wave PRs bottom-up with their fixes, then rebase #765 to narrow its diff to G–L only. Squashing the stack into #765 loses per-wave review history and bypasses the per-wave CI signal.
+
+Pre-merge action list, in order:
+
+1. **#759 — Wave D**
+   - [REQUIRED] `tests/e2e/settings-models.spec.ts:274`: change `expect(settings?.schemaVersion).toBe(3)` → `toBe(4)`. Single-line.
+   - [RECOMMENDED] Add v1/v2 → v4 chain unit tests with displaced left-rail tabs seeded; idempotency test on already-v4 blobs; `rightRailTabs` absent / non-array case.
+   - [OPTIONAL] Hoist `LEFT_RAIL_LOCKED` const to avoid fresh array allocation per `mergeAndClampSettings` call.
+
+2. **#760 — Wave A**
+   - [DISCUSS] Status-pill `opacity: 0.4` at rest fades interactive text/buttons inside the pill. PR body marks this as Bryan-requested. Confirm intent vs WCAG 1.4.3 concern. Mitigations available: per-control carve-outs via `:has(:focus-visible)`, or rest opacity 0.55+, or independent focus-visible ring.
+   - [OPTIONAL] Replace raw px literals (`font-size: 11.5px`, `padding: Npx`, `gap: 3px`) with `--tandem-text-*` / `--tandem-space-*` tokens. Style debt, not a blocker.
+
+3. **#761 — Wave B**
+   - [REQUIRED if landing without #764] Drop `characterData: true` + `subtree: true` from the MutationObserver options (or remove the MO entirely — PR #764 does this). Cheapest fix is `{ childList: true }` only.
+   - [RECOMMENDED] Add `if (!node.isConnected) return;` guard at top of `update()`.
+   - [RECOMMENDED] Wrap observer construction in try/catch with `logError`; ensure `destroy()` tears down whatever did register.
+   - [OPTIONAL] Add vitest coverage for the action (jsdom mocks both observers easily — 30-line test).
+   - [OPTIONAL] Add `@supports (mask-image: ...)` fallback in `scroll-fade.css`.
+   - [OPTIONAL] Rename `.svelte.ts` → `.ts` (no runes in the file).
+
+4. **#762 — Wave C**
+   - [NONE required] Eyeball the new `backdrop-filter: saturate(140%) blur(8px)` inheritance from `.tandem-floating-pill` in a browser — it's a new visual effect not present in the pre-PR popup.
+
+5. **#763 — Wave F**
+   - [REQUIRED] Fix `MarginColumn.svelte` halo: `drop-shadow(0 0 0 var(--tandem-accent-border))` is invisible. Change to `drop-shadow(0 0 6px var(--tandem-accent-border))` or similar non-zero blur, or delete the line if the soft drop-shadow alone is intended affordance. *(Same bug surfaces in #764 and #765 — fix once where it lands first.)*
+
+6. **#764 — Wave E**
+   - [REQUIRED] Right-rail 8px edge-collapse zone occludes the native scrollbar hit area AND the RailTabPicker trigger button's rightmost ~8px. Two viable fixes: narrow the collapse zone, or restrict it to top/bottom edges so the right side (where scrollbar + picker live) is uncovered.
+   - [RECOMMENDED] Restore focus to the newly-mounted toggle after keyboard-triggered collapse/expand.
+   - [RECOMMENDED] Add `aria-expanded` to PeekStrip.
+   - [OPTIONAL] Change PeekStrip + edge-collapse cursor from `e-resize`/`w-resize` to `pointer` — they're click-to-toggle, not drag.
+   - [INTERNAL] Note that this PR removes scrollFade's MutationObserver, addressing #761's Critical. If #761 ships first, the perf concern lives until #764 lands — backport or merge together.
+
+7. **#765 — Waves G–L** (rebase onto master after #759–#764 are in)
+   - [REQUIRED] `tests/e2e/settings-models.spec.ts:273`: bump assertion to `5` (the chain's new terminal version after Wave I's v4→v5 migration).
+   - [REQUIRED] Fix `tests/client/use-tandem-settings-migration.test.ts:178-179` — change `s.leftRailTabs).toEqual(["chat","annotations"])` to `s.leftRailTabs).toBeUndefined()` so we don't pin a contract the migration intends to suppress.
+   - [REQUIRED] Verify Wave G TitleBar in `cargo tauri dev`: root has `data-tauri-drag-region` with descendant buttons. Repo memory says this is a known anti-pattern. Either confirm clicks still land on titlebar buttons in production WebView, or restore the sibling pattern from #760 (root attribute-free, drag-region on three sibling spacer divs).
+   - [RECOMMENDED] Add unit tests for `src/client/editor/toolbar/handlers.ts` (`applyLink`, `getInitialLinkHref`, `withPreventDefault`) — pure functions, two callers, branchy logic.
+   - [RECOMMENDED] Add v4→v5 idempotency test + v2-with-rail-tabs chain test.
+   - [OPTIONAL] Gate `FormattingToolbar.svelte`'s 9× `void tick` `$derived` blocks on a coarser signal (`selectionUpdate`) or one parent `editorState` `$derived`.
+   - [OPTIONAL] Wrap `linkInputEl` focus in `untrack` or move to action / `onMount` to avoid the dual-fire effect pattern.
+   - [OPTIONAL] Add singleton guard to `createLayoutModel` (currently safe — only one consumer — but mirrors the established `useTandemSettings.svelte.ts` pattern).
+
+## Stack-wide patterns
+
+1. **Schema-version assertions in E2E tests are not migration-aware.** Two separate PRs (#759, #765) trip the same `settings-models.spec.ts:~273` assertion because the chain's terminal version changes. **Defensive fix:** replace the literal `.toBe(3)` with `.toBe(LATEST_SCHEMA_VERSION)` imported from the source module, so future v→v+1 migrations don't need to remember to bump the test. File as a follow-up issue.
+
+2. **Migration unit-test coverage is thin at the chain extremes.** Both #759 and #765 had test gaps: missing v1/v2-seed chain tests, missing idempotency, missing `rightRailTabs`-absent paths. The repo could benefit from a parameterised table test `for (const startVersion of [1,2,3,4]) { ... }` that seeds with rail-tabs displaced and asserts the post-migration shape across the full chain. Add to follow-up scope.
+
+3. **The `.tandem-floating-pill` shared recipe is a winner** — Wave C/J both consume it cleanly with one-line surface conversion. The pattern is now established; no rework needed.
+
+4. **Multi-reviewer hallucinations are a real problem on this stack:** three false-positive Criticals were caught (code-reviewer on #760 and #761; svelte-migration-reviewer on #765). Each was verified against branch HEAD before propagating. Per `feedback_pr_review_findings_can_be_wrong.md`: reviewer agents read partial files / infer from diff context / sometimes fabricate tool output. **Always verify load-bearing Criticals against the actual file on the PR branch (not the diff, not master).** This pattern played out exactly as the memory predicted.
+
+5. **`MarginColumn` invisible drop-shadow halo (Wave F #4) is present in #763, #764, and #765.** A single one-line fix lands once in whichever wave merges first; mark the others "deferred to wave-N landing" so we don't fix it three times.
+
+6. **Tauri drag-region pattern is fragile.** PR #760 had a correct sibling layout; PR #765 (Wave G) regresses to root + descendants. The repo memory warns about this pattern. Add a Playwright Tauri smoke test if not present, asserting titlebar button clicks fire (handler ran, panel toggled, etc.) — would have caught this in #765 automatically.
+
+7. **scrollFade action lifecycle:** the MO was added in #761, then removed in #764 after a reviewer-flagged perf concern. Net evolution in two PRs. The chain works, but a sequential merge of #761 alone exposes the regression to master for the merge gap. Either merge #761 + #764 as a group, or backport the MO removal directly into #761 before merge.
+
+## Reviewer-quality observations
+
+- **codex:codex-rescue** — strongest signal on Tauri drag-region (#765 Critical, correctly identified despite contradicting code-reviewer), and on the #759 schema-version cause-of-failure diagnosis. Also produced one false-positive Critical on #760 (drag-region) — verified against branch.
+- **pr-review-toolkit:code-reviewer** — two false-positive Criticals (#761 signature; #765 schema-version target). One real Critical (#763 — no, that was direct review). Several solid Suggestions (px-token violations, observability gaps).
+- **svelte-migration-reviewer** — one fabricated Critical with hallucinated svelte-check output (#765). Real Critical on #761 MO scope. Generally trustworthy on rune-pattern findings.
+- **pr-review-toolkit:pr-test-analyzer** — most reliable across the stack. Caught the #759 + #765 E2E assertion gap (the highest-leverage finding) and the v99 forward-compat contract issue. No false positives.
+- **pr-review-toolkit:silent-failure-hunter** — solid on observability gaps. Suggestion-grade signal.
+
+Cross-PR review took 4 hours of agent runtime equivalent. The two highest-leverage findings (Critical #759 E2E + Critical #765 E2E) saved at minimum two CI iterations on merge.
+
+## Open questions for Bryan
+
+1. **Status-pill fade (#760)** — confirmed intentional per PR body. The a11y concern is real but the override is informed. Keep as-is, or apply one of the mitigations? Default: keep.
+2. **Right-rail edge-collapse occlusion (#764)** — pick a geometry fix (narrow zone vs. top/bottom-only).
+3. **Stack merge strategy** — bottom-up with rebase of #765, or squash into #765? Default recommendation: bottom-up.
+4. **Cross-cutting `MarginColumn` halo fix** — should the fix land in #763, #764, or #765? Default: #763 (lowest in stack that touches the file).


### PR DESCRIPTION
## Summary
- Adds 7 per-PR review notes (#759-#765) + cross-PR summary captured during the Wave D + A-L two-pass review pass that gated the redesign sweep into master.
- Each note records REAL / false-positive / out-of-scope verdicts with verification anchors so future audits can re-derive which findings were load-bearing.
- Raw `gh pr diff` output was discarded (reproducible from git history); only narrative triage is durable enough to archive.
- Sits alongside the existing `.claude/notes/redesign-deferred-needs-input.md` as durable triage material — no source changes.

## Test plan
- [x] Docs-only change; no code paths touched.
- [x] Lint-staged ran on the 8 .md files (EOL normalization).
- [x] Confirmed `.claude/notes/` is not gitignored and already has a tracked sibling.