### PR TITLE
simplify: cleanup pass on PR #776 (drag-region helper, dead theme exports, comment diet)

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,12 +194,9 @@
           0 22px 38px -22px rgba(0, 0, 0, 0.50);
       }
 
-      /* Wave M: in Solo mode, comments and notes are de-emphasized — visible
-         but quiet — so the user's focus stays on their own writing.
-         Highlights stay normal because they're user-owned color flags.
-         `filter: opacity()` composes with the card's inline opacity, so
-         accepted cards (already at 0.6) layer the fade on top instead of
-         being clamped. */
+      /* `filter: opacity()` is used instead of plain `opacity:` so the fade
+         composes with cards that already carry an inline opacity (e.g.
+         accepted cards at 0.6) rather than being clamped by it. */
       [data-tandem-mode="solo"] [data-annotation-type="comment"],
       [data-tandem-mode="solo"] [data-annotation-type="note"],
       [data-tandem-mode="solo"] [data-testid="margin-column-left"] .margin-bubble,
@@ -261,11 +258,7 @@
       }
 
       [data-theme="dark"] {
-        /* Aligned to calm-v7.css dark canon: canvas 0.22, pill surface 0.27,
-           border 0.34, ink 0.94 — all at hue 280°. Previously surfaces were
-           270° and ink was 80° (warm yellow against cool violet), and the
-           whole palette ran ~4 stops too dark vs the v7 floating-chrome
-           intent. */
+        /* Tracks the calm-v7 dark canon at hue 280°. */
         --tandem-bg: oklch(0.22 0.012 280);
         --tandem-fg: oklch(0.94 0.006 280);
         --tandem-surface: oklch(0.27 0.012 280);
@@ -274,8 +267,7 @@
         --tandem-border: oklch(0.34 0.010 280);
         --tandem-border-strong: oklch(0.42 0.012 280);
         --tandem-fg-muted: oklch(0.74 0.008 280);
-        /* 0.70 vs v7's 0.74 — preserves WCAG AA 4.5:1 against the lighter
-           --tandem-surface-muted (0.25). */
+        /* 0.70 keeps WCAG AA 4.5:1 against --tandem-surface-muted (0.25). */
         --tandem-fg-subtle: oklch(0.70 0.008 280);
         --tandem-fg-faint: oklch(0.58 0.008 280);
         --tandem-accent-h: 275deg;

--- a/src/client/editor/toolbar/ModeToggle.svelte
+++ b/src/client/editor/toolbar/ModeToggle.svelte
@@ -13,6 +13,7 @@ const { tandemMode, onModeChange }: Props = $props();
      The Claude-active dot lives on the status bar, not duplicated here. -->
 <div
   data-testid="mode-toggle"
+  data-tauri-drag-region="false"
   class="mode-toggle"
   role="group"
   aria-label="AI collaboration mode"

--- a/src/client/hooks/useModeGate.ts
+++ b/src/client/hooks/useModeGate.ts
@@ -1,11 +1,9 @@
 import type { Annotation, TandemMode } from "../../shared/types.js";
 
 /**
- * Wave M: Solo mode no longer hides any annotations. Comments and notes are
- * de-emphasized via a CSS opacity rule keyed to `[data-tandem-mode="solo"]`
- * (see App.svelte's mode attribute + the fade rule in index.html / component
- * styles), so Claude's pending output stays visible-but-quiet rather than
- * disappearing into a "held" bucket. `heldCount` is therefore always 0 today.
+ * Solo mode no longer hides annotations; comments and notes are
+ * de-emphasized via the `[data-tandem-mode="solo"]` CSS rule in index.html.
+ * Kept as a hook point in case future modes want to filter the list.
  */
 export function shouldShowInMode(_ann: Annotation, _mode: TandemMode): boolean {
   return true;

--- a/src/client/hooks/useTandemSettings.svelte.ts
+++ b/src/client/hooks/useTandemSettings.svelte.ts
@@ -15,13 +15,7 @@ export type {
   TextSize,
   ThemePreference,
 } from "./useTandemSettings.js";
-export {
-  loadSettings,
-  mergeAndClampSettings,
-  TEXT_SIZE_PX,
-  THEME_LABEL,
-  THEME_NEXT,
-} from "./useTandemSettings.js";
+export { loadSettings, mergeAndClampSettings, TEXT_SIZE_PX } from "./useTandemSettings.js";
 
 export interface TandemSettingsState {
   readonly settings: TandemSettings;

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -12,22 +12,6 @@ export type PrimaryTab = "chat" | "annotations";
 export type PanelOrder = "chat-editor-annotations" | "annotations-editor-chat";
 export type TextSize = "s" | "m" | "l";
 export type ThemePreference = "light" | "dark" | "warm" | "system";
-
-export const THEME_NEXT: Record<ThemePreference, ThemePreference> = {
-  system: "dark",
-  dark: "warm",
-  warm: "light",
-  light: "system",
-};
-
-// Action-oriented labels: matches THEME_NEXT cycle so screen readers and
-// tooltips announce what clicking will do, not what the current theme is.
-export const THEME_LABEL: Record<ThemePreference, string> = {
-  light: "Switch to system theme",
-  dark: "Switch to warm theme",
-  warm: "Switch to light theme",
-  system: "Switch to dark theme",
-};
 export type SidecarRetryStrategy = "exponential" | "constant-2s" | "manual";
 
 /**

--- a/src/client/shell/TitleBar.svelte
+++ b/src/client/shell/TitleBar.svelte
@@ -38,16 +38,10 @@ interface Props {
   /** Open Settings popover. */
   onOpenSettings?: () => void;
   /**
-   * Open the new SettingsModal (Wave 1 stable prop slot). Wired separately
-   * from `onOpenSettings` so the existing gear keeps invoking the popover
-   * until Wave 2 retires it. Triggered today via the command palette /
-   * `Ctrl+Shift+,` shortcut registered in `actions/builtin.svelte.ts`.
-   * Intentionally unused inside this component — read inside `$effect` below
-   * so svelte-check sees a live reference and stays quiet about both the
-   * "declared but never read" error and the `state_referenced_locally`
-   * warning. Intentionally NOT wired to
-   * `aria-keyshortcuts` on the gear (that attribute describes shortcuts
-   * activating the labelled element; Ctrl+Shift+, opens a different surface).
+   * Stable prop slot reserved for the SettingsModal trigger. Currently
+   * unused inside this component (Ctrl+Shift+, is routed through
+   * `actions/builtin.svelte.ts`); destructured as `_onOpenSettingsModal`
+   * below so svelte-check accepts the declared-but-unread prop.
    */
   onOpenSettingsModal?: () => void;
   /** Bindable settings button reference (used for keyboard shortcut anchoring). */
@@ -73,7 +67,7 @@ let {
   onAuthorshipChange,
   onOpenHelp,
   onOpenSettings,
-  onOpenSettingsModal,
+  onOpenSettingsModal: _onOpenSettingsModal,
   settingsBtn = $bindable(null),
   updateAvailable = false,
 }: Props = $props();
@@ -214,31 +208,11 @@ function chooseHelp() {
   onOpenHelp?.();
   brandMenuOpen = false;
 }
-
-/**
- * `onOpenSettingsModal` is a Wave 1 stable prop slot, declared so Wave 2 can
- * retire `SettingsPopover` by replacing the gear's `onOpenSettings` wiring
- * with this prop without re-touching `TitleBar.svelte`. Today the trigger is
- * the `settings-modal` action (Ctrl+Shift+,) wired in
- * `actions/builtin.svelte.ts`, so the prop is intentionally unused inside
- * this component. Read it inside `$effect` (not a top-level expression) so
- * svelte-check sees a live reference and stays quiet about both the
- * "declared but never read" error and the `state_referenced_locally`
- * warning. Intentionally NOT exposed via `aria-keyshortcuts` on the gear
- * button — that attribute describes shortcuts that activate the labelled
- * element, and Ctrl+Shift+, opens a different surface.
- */
-$effect(() => {
-  void onOpenSettingsModal;
-});
 </script>
 
-<!-- Root carries the drag region; every interactive descendant
-     opts back out with `data-tauri-drag-region="false"`. This is the
-     documented Tauri 2 inverse-opt-out pattern. It gives the user every
-     non-button pixel of the titlebar as a grab surface. DocumentTabs and
-     NewTabMenu's bail-out guards honor the opt-out so menu dismissal
-     still works on clicks inside opted-out children. -->
+<!-- Root carries the drag region; interactive descendants opt back out
+     with `data-tauri-drag-region="false"` (Tauri 2 inverse-opt-out pattern)
+     so every non-button pixel is a window grab surface. -->
 <div class="title-bar" data-testid="title-bar" data-tauri-drag-region>
   <div class="title-bar-left">
     <button
@@ -252,8 +226,6 @@ $effect(() => {
       aria-expanded={brandMenuOpen}
       onclick={toggleBrandMenu}
     >
-      <!-- 256×256 source displayed at 32×32 — gives ~8× density so the
-           hover scale-up stays inside native resolution and stays crisp. -->
       <img class="brand-mark" src="/logo.png" alt="" width="32" height="32" />
       {#if isTauriRuntime() && updateAvailable}
         <span
@@ -334,9 +306,7 @@ $effect(() => {
 
   <div class="title-bar-actions">
     {#if tandemMode && onModeChange}
-      <span data-tauri-drag-region="false">
-        <ModeToggle {tandemMode} {onModeChange} />
-      </span>
+      <ModeToggle {tandemMode} {onModeChange} />
     {/if}
 
     {#if claudeActive}
@@ -446,10 +416,8 @@ $effect(() => {
 
 <style>
   /* 3-cluster floating chrome: brand left, center snippet (DocumentTabs),
-     actions right. The bar is transparent so each cluster reads as floating
-     over the canvas. Drag region is carried by the brand cluster and the
-     two flex gaps around the center — the center wrap is attribute-free so
-     interactive children (tab pills, close buttons) stay clickable. */
+     actions right. Transparent so each cluster reads as floating over the
+     canvas. */
   .title-bar {
     display: flex;
     align-items: center;
@@ -460,9 +428,7 @@ $effect(() => {
     flex-shrink: 0;
   }
 
-  /* Sibling drag spacers wrap the center + sit before the win controls.
-     `.title-bar-left` is `position: relative` so the absolutely-positioned
-     brand-menu anchors to it. */
+  /* `position: relative` anchors the absolutely-positioned brand-menu. */
   .title-bar-left {
     position: relative;
     display: flex;
@@ -470,18 +436,12 @@ $effect(() => {
     flex-shrink: 0;
   }
 
-  /* Flex-grow drag spacers. The wide pair flanks the center cluster
-     (DocumentTabs); a narrow one sits between actions and win controls so
-     even with a tab fill close to the cap there's a draggable column right
-     of the icon buttons. align-self defaults to inherit `align-items`, so
-     stretching to the full bar height happens automatically — explicitly
-     setting align-self: stretch breaks the flex-grow in some browsers. */
   .title-bar-spacer {
     flex: 1 1 0;
     min-width: var(--tandem-space-2);
     /* Stretch to the title-bar's full content height so the drag region
-       actually has a hit area; an empty div with no intrinsic content
-       collapses to 0px tall under flex `align-items: center`. */
+       actually has a hit area; an empty div under flex `align-items: center`
+       collapses to 0px tall otherwise. */
     align-self: stretch;
   }
 
@@ -492,10 +452,8 @@ $effect(() => {
 
   /* Cap at 60% so brand + actions stay readable when the center fills with
      many tabs; DocumentTabs handles its own horizontal scroll past the cap.
-     `position: relative; z-index` lifts the tab strip above tauri-plugin-decorum's
-     overlay drag-region (which is full-width and would otherwise intercept all
-     clicks on the tabs). The drag-region gaps on either side stay at the default
-     z so decorum's overlay handles window drag in those zones. */
+     `z-index` lifts the tab strip above tauri-plugin-decorum's overlay
+     drag-region so clicks on tab pills aren't intercepted. */
   .title-bar-center {
     display: flex;
     align-items: center;
@@ -506,9 +464,7 @@ $effect(() => {
     z-index: 99999;
   }
 
-  /* The Tandem icon IS the menu trigger — no chrome around it. The button is
-     sized to the icon; hover scales it up slightly for affordance. The
-     update-available dot pins to the top-right corner of the icon itself. */
+  /* The Tandem icon IS the menu trigger — no chrome around it. */
   .brand-btn {
     position: relative;
     display: inline-grid;
@@ -544,9 +500,8 @@ $effect(() => {
     flex-shrink: 0;
   }
 
-  /* Dropdown anchored to the icon. `tandem-floating-pill` supplies the
-     surface treatment; this rule positions + sizes the menu and packs the
-     items + heading + divider. */
+  /* Dropdown anchored to the icon — `tandem-floating-pill` supplies the
+     surface treatment; this rule only positions and packs the menu. */
   .brand-menu {
     position: absolute;
     top: calc(100% + 6px);
@@ -671,11 +626,9 @@ $effect(() => {
     color: var(--tandem-accent);
   }
 
-  /* Update-available dot — pinned to the top-right corner of the brand
-     icon when a Tauri updater event has fired and not been acknowledged
-     yet (issue #660). The brand-btn is `position: relative` so this
-     absolute positioning targets the button's box. WCAG AA against
-     --tandem-bg in both themes via the contrasting ring. */
+  /* Pinned to the top-right of the brand icon when an updater event has
+     fired and not been acknowledged. The contrasting ring keeps WCAG AA
+     against --tandem-bg in both themes. */
   .titlebar-settings-dot {
     position: absolute;
     top: 3px;
@@ -695,14 +648,11 @@ $effect(() => {
     }
   }
 
-  /* Bare window controls — no pill chrome, flush with the window's top-right
-     corner so they read as OS chrome distinct from the in-app actions. The
-     titlebar has `padding: 14px 14px 4px`; negative margin-top/-right cancel
-     the top and right padding so the close button sits at (0, 0) relative to
-     the window corner. `position: relative; z-index` lifts the cluster above
-     tauri-plugin-decorum's overlay drag-region (same rationale as
-     .title-bar-center / .title-bar-actions) so the buttons receive clicks
-     instead of the overlay treating them as drag surface. */
+  /* Bare window controls — no pill chrome, flush with the window's
+     top-right corner. Negative margins cancel the titlebar's top/right
+     padding so the close button sits at (0, 0) relative to the window
+     corner; `z-index` lifts the cluster above decorum's overlay drag
+     region so the buttons receive clicks. */
   .title-bar-controls {
     display: inline-flex;
     align-items: center;

--- a/src/client/tabs/DocumentTabs.svelte
+++ b/src/client/tabs/DocumentTabs.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { createScratchpad } from "../actions/builtin.svelte.js";
 import type { OpenTab } from "../types.js";
+import { isInActiveDragRegion } from "../utils/dismiss-outside.js";
 import { addRecentFile, loadRecentFilesCached, saveRecentFiles } from "../utils/recentFiles.js";
 import { openServerPath } from "../utils/server-paths.js";
 import NewTabMenu from "./NewTabMenu.svelte";
@@ -183,14 +184,7 @@ $effect(() => {
     if (!target) return;
     if (openBtnEl?.contains(target)) return;
     if ((target as Element).closest?.(".new-tab-menu")) return;
-    // Wave M: the titlebar root carries the drag region, with interactive
-    // descendants opting out via `data-tauri-drag-region="false"`. We only
-    // want to ignore clicks that landed in an actual drag area — not in an
-    // opted-out child like the new-tab button.
-    {
-      const drag = (target as Element).closest?.("[data-tauri-drag-region]");
-      if (drag && drag.getAttribute("data-tauri-drag-region") !== "false") return;
-    }
+    if (isInActiveDragRegion(target as Element)) return;
     showRecent = false;
   }
 

--- a/src/client/tabs/NewTabMenu.svelte
+++ b/src/client/tabs/NewTabMenu.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { clickOutside } from "../actions/clickOutside.svelte.js";
+import { isInActiveDragRegion } from "../utils/dismiss-outside.js";
 import { portal } from "../utils/portal.js";
 
 interface Props {
@@ -51,19 +52,12 @@ let menuEl: HTMLDivElement | null = $state(null);
 
 function handleOutsideClick(e: MouseEvent) {
   // The clickOutside action already filtered out clicks inside the menu.
-  // Also ignore:
-  //  - clicks on the anchor button (its own onclick would re-open the menu).
-  //  - clicks on a Tauri drag region (title-bar drag should not dismiss the menu).
+  // Also ignore the anchor button (its own onclick would re-open the menu)
+  // and clicks on an active Tauri drag region (title-bar drag is not a dismiss).
   const target = e.target as (Node & Element) | null;
   if (!target) return;
   if (anchorEl?.contains(target)) return;
-  // Wave M: honor `data-tauri-drag-region="false"` opt-outs so clicks on
-  // brand-menu items, tabs, etc. (which sit inside the root drag region but
-  // are explicitly opted out) still dismiss this menu.
-  {
-    const drag = target.closest?.("[data-tauri-drag-region]");
-    if (drag && drag.getAttribute("data-tauri-drag-region") !== "false") return;
-  }
+  if (isInActiveDragRegion(target)) return;
   onClose();
 }
 

--- a/src/client/utils/dismiss-outside.ts
+++ b/src/client/utils/dismiss-outside.ts
@@ -48,3 +48,15 @@ export function onOutsideEvent(
     for (const t of eventTypes) document.removeEventListener(t, handle, capture);
   };
 }
+
+/**
+ * True when `target` sits inside a Tauri drag region that has NOT been
+ * opted out via `data-tauri-drag-region="false"`. Used by outside-click
+ * dismiss handlers to ignore clicks on actual drag surface (which can't
+ * really be "outside" anything) while still honoring interactive
+ * descendants that opted themselves back into clickability.
+ */
+export function isInActiveDragRegion(target: Element): boolean {
+  const drag = target.closest?.("[data-tauri-drag-region]");
+  return !!drag && drag.getAttribute("data-tauri-drag-region") !== "false";
+}

--- a/tests/client/solo-tandem-mode.test.ts
+++ b/tests/client/solo-tandem-mode.test.ts
@@ -44,7 +44,7 @@ describe("shouldShowInMode", () => {
   });
 
   describe('mode = "solo"', () => {
-    it("shows pending claude annotations (Wave M: fade-not-hide)", () => {
+    it("shows pending claude annotations", () => {
       expect(
         shouldShowInMode(makeAnnotation({ author: "claude", status: "pending" }), "solo"),
       ).toBe(true);
@@ -100,7 +100,7 @@ describe("gateAnnotations (useModeGate hook logic)", () => {
     expect(result.heldCount).toBe(0);
   });
 
-  it("solo mode shows pending claude annotations (Wave M: fade-not-hide)", () => {
+  it("solo mode shows pending claude annotations", () => {
     const anns = [
       makeAnnotation({ id: "a1", author: "claude", status: "pending" }),
       makeAnnotation({ id: "a2", author: "claude", status: "pending" }),
@@ -131,7 +131,7 @@ describe("gateAnnotations (useModeGate hook logic)", () => {
     expect(result.heldCount).toBe(0);
   });
 
-  it("heldCount is 0 in solo mode (Wave M: fade-not-hide, no held bucket)", () => {
+  it("heldCount is 0 in solo mode (no held bucket)", () => {
     const anns = [
       makeAnnotation({ id: "a1", author: "claude", status: "pending" }),
       makeAnnotation({ id: "a2", author: "claude", status: "pending" }),

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -3,8 +3,6 @@ import {
   loadSettings,
   mergeAndClampSettings,
   type TandemSettings,
-  THEME_LABEL,
-  THEME_NEXT,
 } from "../../src/client/hooks/useTandemSettings.js";
 import {
   SELECTION_DWELL_DEFAULT_MS,
@@ -217,22 +215,6 @@ describe("loadSettings — theme", () => {
   it("falls back to 'system' for non-string values", () => {
     store.set(TANDEM_SETTINGS_KEY, JSON.stringify({ theme: true }));
     expect(loadSettings().theme).toBe("system");
-  });
-});
-
-describe("THEME_NEXT — cycle (W1: warm canvas inserted between dark and light)", () => {
-  it("cycles system → dark → warm → light → system", () => {
-    expect(THEME_NEXT.system).toBe("dark");
-    expect(THEME_NEXT.dark).toBe("warm");
-    expect(THEME_NEXT.warm).toBe("light");
-    expect(THEME_NEXT.light).toBe("system");
-  });
-
-  it("THEME_LABEL action verbs match the cycle", () => {
-    expect(THEME_LABEL.system).toBe("Switch to dark theme");
-    expect(THEME_LABEL.dark).toBe("Switch to warm theme");
-    expect(THEME_LABEL.warm).toBe("Switch to light theme");
-    expect(THEME_LABEL.light).toBe("Switch to system theme");
   });
 });
 


### PR DESCRIPTION
Subsumed into #776 via cherry-pick. The single commit on this branch (`da7ec01`) was rebased onto the current tip of `feat/wave-m-titlebar-status` as `484fedb` — minor conflict resolution in `TitleBar.svelte`'s `onOpenSettingsModal` JSDoc (HEAD had independently adopted the `_onOpenSettingsModal` destructure rename with a longer comment; took #780's shorter comment per the simplify intent).

Re-verified on the cherry-picked branch:
- `npm run typecheck` — 0 errors, 0 warnings
- `npx biome check src/ tests/` — clean
- `npm test --run` — 2361 passing, 13 skipped (matches PR description)
- The 94 tests covering the touched files (`useTandemSettings.test.ts`, `solo-tandem-mode.test.ts`) all green

Manual Tauri smoke checklist from this PR's "Test plan" still applies to #776 and remains the human gate.

Closing in favor of #776 — same diff, no separate review surface.