### PR TITLE
test(e2e): eliminate hardcoded waitForTimeout flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,4 +85,10 @@ jobs:
         if: failure()
         with:
           name: playwright-report
-          path: playwright-report/
+          # `test-results/` carries Playwright's trace.zip / video.webm /
+          # screenshot artifacts (configured in playwright.config.ts via
+          # trace/screenshot/video). Without this path, diagnosing a CI-only
+          # flake requires re-running the spec locally.
+          path: |
+            playwright-report/
+            test-results/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,14 @@ export default defineConfig({
   use: {
     baseURL: "http://127.0.0.1:5173",
     headless: true,
+    // Capture diagnostic artifacts only when a test ultimately fails (i.e.
+    // after Playwright exhausts its retries). Keeps green-test runs fast
+    // while giving us trace / screenshot / video to diagnose the residual
+    // flakes — `retries: 1` masks intermittent failures from CI output, and
+    // without these artifacts the underlying cause is invisible.
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
   // Two webServer entries instead of `npm run dev:standalone`:
   //   1. Vite dev server for the client

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -122,6 +122,27 @@ export async function switchToAnnotationsTab(page: Page): Promise<void> {
   }
 }
 
+/**
+ * Wait for `n` animation frames inside the page. Use after viewport resizes or
+ * other DOM mutations that propagate through ResizeObserver → Svelte `$state` →
+ * `$effect` → DOM, instead of `page.waitForTimeout(fixedMs)`.
+ *
+ * The full chain after `setViewportSize` is: CDP resize task → rAF #1 (e.g.
+ * `useViewportWidth.svelte.ts:16-30` debounce) → microtask ($effect + $derived)
+ * → rAF #2 (paint). Default `n=3` adds one frame of slack for CI load.
+ */
+export async function nextFrames(page: Page, n = 3): Promise<void> {
+  await page.evaluate(
+    (count) =>
+      new Promise<void>((resolve) => {
+        let i = 0;
+        const tick = () => (++i >= count ? resolve() : requestAnimationFrame(tick));
+        requestAnimationFrame(tick);
+      }),
+    n,
+  );
+}
+
 /** Success-payload shape for `tandem_status` consumed by `cleanupAllOpenDocuments`. */
 type StatusData = {
   openDocuments?: Array<{ documentId: string }>;

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -6,6 +6,7 @@ import {
   cleanupFixtureDir,
   createFixtureDir,
   McpTestClient,
+  nextFrames,
 } from "./helpers";
 
 /**
@@ -172,19 +173,26 @@ test("PR2: two overlapping comments produce non-overlapping bubbles", async ({ p
   );
   await expect(bubbles).toHaveCount(2, { timeout: 5_000 });
 
-  // Allow the collision sweep + bind:clientHeight to settle.
-  await page.waitForTimeout(150);
-
-  const boxes = await bubbles.evaluateAll((els) =>
-    els.map((el) => {
-      const r = el.getBoundingClientRect();
-      return { top: r.top, bottom: r.bottom };
-    }),
-  );
-  expect(boxes.length).toBe(2);
-  const [a, b] = [...boxes].sort((x, y) => x.top - y.top);
-  // The lower bubble's top must sit at or below the upper bubble's bottom.
-  expect(b.top).toBeGreaterThanOrEqual(a.bottom);
+  // Poll directly on the invariant — collapses "wait for collision sweep" and
+  // "assert no overlap" into one auto-retrying step. The initial measure →
+  // bind:clientHeight → adjustedPositions ping-pong takes ≥ 3 frames; a 5s
+  // budget absorbs CI load.
+  await expect
+    .poll(
+      async () =>
+        bubbles.evaluateAll((els) => {
+          const boxes = els.map((el) => {
+            const r = el.getBoundingClientRect();
+            return { top: r.top, bottom: r.bottom };
+          });
+          if (boxes.length !== 2) return false;
+          const [a, b] = [...boxes].sort((x, y) => x.top - y.top);
+          // The lower bubble's top must sit at or below the upper bubble's bottom.
+          return b.top >= a.bottom;
+        }),
+      { timeout: 5_000 },
+    )
+    .toBe(true);
 });
 
 test("PR3: leader lines render and slope with collision adjustment", async ({ page }) => {
@@ -561,8 +569,12 @@ test("PR3: boundary resize does not flicker (hysteresis)", async ({ page }) => {
   await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
 
   await page.setViewportSize({ width: 1044, height: 900 });
-  // Inside the hysteresis band → must NOT flip back to visible.
-  await page.waitForTimeout(80);
+  // Inside the hysteresis band → must NOT flip back to visible. Wait for the
+  // resize → ResizeObserver → useViewportWidth rAF debounce → $effect → DOM
+  // chain to settle. `toHaveCount(0)` auto-retries up to its default timeout,
+  // so even if the chain runs longer than nextFrames covers, the assertion
+  // still holds as long as the column stays hidden.
+  await nextFrames(page);
   await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
   await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(0);
 
@@ -599,11 +611,13 @@ test("PR3: narrow-collapse does not overwrite persisted rail visibility", async 
 
   // Sweep through the narrow boundary and back. Wait between transitions so
   // the $effect that drives narrowSticky actually runs — if it were ever to
-  // touch settings, this is when it would.
+  // touch settings, this is when it would. `nextFrames` covers the full
+  // resize → ResizeObserver → useViewportWidth rAF debounce → $effect → DOM
+  // chain deterministically (replaces a hardcoded 120ms wait).
   await page.setViewportSize({ width: 700, height: 900 });
-  await page.waitForTimeout(120);
+  await nextFrames(page);
   await page.setViewportSize({ width: 1600, height: 900 });
-  await page.waitForTimeout(120);
+  await nextFrames(page);
 
   // Settings must reflect the pre-sweep snapshot exactly.
   const after = await page.evaluate((key) => {

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -628,7 +628,12 @@ test("selections are buffered, not pushed as SSE events (#188)", async ({ page }
   await prose.click();
   await prose.locator("h1").first().selectText();
 
-  // Wait well past the maximum dwell time (3000ms max + headroom)
+  // Wait well past the maximum dwell time. Server-side, the timer is scheduled
+  // with `getDwellMs()` from awareness.ts:30-42, which reads CTRL_ROOM Y.Map.
+  // Default `SELECTION_DWELL_DEFAULT_MS` is 1000ms; the slider ceiling is 3000ms.
+  // 4000ms = 3000ms ceiling + 1000ms RTT headroom for the would-be SSE round-trip.
+  // This is a "prove a negative" wait — no shorter signal exists for the absence
+  // of an event. See ADR / issue #188 for the buffering rationale.
   await page.waitForTimeout(4000);
 
   // No selection:changed events should have been emitted

--- a/tests/e2e/settings-models.spec.ts
+++ b/tests/e2e/settings-models.spec.ts
@@ -299,14 +299,20 @@ test("v99 forward-compat boot — unknown field is preserved", async ({ page }) 
 
   // Install a setItem spy AFTER reload (which wipes window state) so it
   // captures any erroneous write to the settings key during the Models tab
-  // mount. Concrete signal beats "wait for settling".
+  // mount. Concrete signal beats "wait for settling". The original setItem
+  // is stashed on `window.__origSetItem` so the test can restore it after
+  // assertion — keeps the patch from leaking if context reuse is ever
+  // enabled (e.g. someone debugging with `--workers=1` + shared context).
   await page.evaluate((key) => {
-    const w = window as unknown as { __settingsWrites: string[] };
+    const w = window as unknown as {
+      __settingsWrites: string[];
+      __origSetItem: (k: string, v: string) => void;
+    };
     w.__settingsWrites = [];
-    const orig = Storage.prototype.setItem;
+    w.__origSetItem = Storage.prototype.setItem;
     Storage.prototype.setItem = function (k: string, v: string) {
       if (k === key) w.__settingsWrites.push(String(v));
-      return orig.call(this, k, v);
+      return w.__origSetItem.call(this, k, v);
     };
   }, TANDEM_SETTINGS_KEY);
 
@@ -315,9 +321,10 @@ test("v99 forward-compat boot — unknown field is preserved", async ({ page }) 
   await gotoModelsTab(page);
   await nextFrames(page); // flush mount effects
 
-  // Concrete assertion: no write landed on the settings key. Poll over a
-  // short window to absorb any future async-write path (currently writes
-  // are synchronous in useTandemSettings, so 0 should hold immediately).
+  // Concrete assertion: no write landed on the settings key. `useTandemSettings`
+  // writes are synchronous today, so a single read after `nextFrames` would
+  // suffice; the short poll exists to make the failure mode less brittle
+  // against minor timing shifts in the mount path.
   await expect
     .poll(
       async () =>
@@ -327,6 +334,13 @@ test("v99 forward-compat boot — unknown field is preserved", async ({ page }) 
       { timeout: 300, intervals: [50, 100, 100, 50] },
     )
     .toBe(0);
+
+  // Restore the patched setItem so subsequent navigations in this page (or
+  // shared-context fixtures, if ever introduced) are unaffected.
+  await page.evaluate(() => {
+    const w = window as unknown as { __origSetItem: (k: string, v: string) => void };
+    Storage.prototype.setItem = w.__origSetItem;
+  });
 
   // The settings blob must still contain `futureField` after the load.
   const settings = await page.evaluate((key) => {

--- a/tests/e2e/settings-models.spec.ts
+++ b/tests/e2e/settings-models.spec.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 import { TANDEM_SETTINGS_KEY } from "../../src/shared/constants";
-import { cleanupAllOpenDocuments, McpTestClient } from "./helpers";
+import { cleanupAllOpenDocuments, McpTestClient, nextFrames } from "./helpers";
 
 /**
  * Settings → Models tab E2E (Wave 2 PR 8b, #659).
@@ -297,12 +297,36 @@ test("v99 forward-compat boot — unknown field is preserved", async ({ page }) 
   }, TANDEM_SETTINGS_KEY);
   await page.reload();
 
-  // Navigate to Models tab without triggering a write — the tab itself
-  // mounts a parallel `createTandemSettings()` which inherits the
-  // _readOnly flag from loadSettings.
+  // Install a setItem spy AFTER reload (which wipes window state) so it
+  // captures any erroneous write to the settings key during the Models tab
+  // mount. Concrete signal beats "wait for settling".
+  await page.evaluate((key) => {
+    const w = window as unknown as { __settingsWrites: string[] };
+    w.__settingsWrites = [];
+    const orig = Storage.prototype.setItem;
+    Storage.prototype.setItem = function (k: string, v: string) {
+      if (k === key) w.__settingsWrites.push(String(v));
+      return orig.call(this, k, v);
+    };
+  }, TANDEM_SETTINGS_KEY);
+
+  // Navigate to Models tab — the tab mounts a parallel `createTandemSettings()`
+  // which inherits the _readOnly flag from loadSettings.
   await gotoModelsTab(page);
-  // Wait for any settling.
-  await page.waitForTimeout(100);
+  await nextFrames(page); // flush mount effects
+
+  // Concrete assertion: no write landed on the settings key. Poll over a
+  // short window to absorb any future async-write path (currently writes
+  // are synchronous in useTandemSettings, so 0 should hold immediately).
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(
+          () => (window as unknown as { __settingsWrites: string[] }).__settingsWrites.length,
+        ),
+      { timeout: 300, intervals: [50, 100, 100, 50] },
+    )
+    .toBe(0);
 
   // The settings blob must still contain `futureField` after the load.
   const settings = await page.evaluate((key) => {

--- a/tests/e2e/tab-overflow.spec.ts
+++ b/tests/e2e/tab-overflow.spec.ts
@@ -62,11 +62,16 @@ test("keyboard reorder with Alt+Arrow swaps tabs", async ({ page }) => {
   await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample2.md") });
   await page.goto("http://127.0.0.1:5173");
 
-  // Wait for sample2.md tab to appear
+  // Wait for sample2.md tab to appear.
   const sample2Name = page.locator("[data-testid^='tab-name-']", { hasText: "sample2.md" });
   await expect(sample2Name).toBeVisible();
 
-  // Get all tab names and find sample2's position
+  // The tab element (role='tab') owns the keyboard handler — focus must land
+  // there, not on the inner [tab-name-…] span. Match the drag test pattern below.
+  const tabs = page.locator("[data-testid^='tab-'][role='tab']");
+  const sample2Tab = tabs.filter({ hasText: "sample2.md" });
+
+  // Get all tab names and find sample2's position.
   const allNames = page.locator("[data-testid^='tab-name-']");
   const count = await allNames.count();
   let initialIdx = -1;
@@ -79,15 +84,14 @@ test("keyboard reorder with Alt+Arrow swaps tabs", async ({ page }) => {
   }
   expect(initialIdx).toBeGreaterThan(0); // sample2 should not be first
 
-  // Click the sample2 tab to focus it, then press Alt+ArrowLeft
-  await sample2Name.click();
-  await page.waitForTimeout(100);
+  // Click the tab itself, wait for focus to land (auto-retry), then press
+  // Alt+ArrowLeft. expect.poll on the post-reorder text absorbs Svelte
+  // reactivity → DOM update latency without a fixed sleep.
+  await sample2Tab.click();
+  await expect(sample2Tab).toBeFocused();
   await page.keyboard.press("Alt+ArrowLeft");
-  await page.waitForTimeout(300);
 
-  // sample2 should now be one position earlier
-  const newText = await allNames.nth(initialIdx - 1).textContent();
-  expect(newText).toBe("sample2.md");
+  await expect.poll(async () => allNames.nth(initialIdx - 1).textContent()).toBe("sample2.md");
 });
 
 test("mouse drag reorders tabs", async ({ page }) => {

--- a/tests/e2e/tab-overflow.spec.ts
+++ b/tests/e2e/tab-overflow.spec.ts
@@ -71,17 +71,10 @@ test("keyboard reorder with Alt+Arrow swaps tabs", async ({ page }) => {
   const tabs = page.locator("[data-testid^='tab-'][role='tab']");
   const sample2Tab = tabs.filter({ hasText: "sample2.md" });
 
-  // Get all tab names and find sample2's position.
+  // Get all tab names and find sample2's position. One round trip via
+  // `allTextContents()` beats a sequential `nth(i).textContent()` loop.
   const allNames = page.locator("[data-testid^='tab-name-']");
-  const count = await allNames.count();
-  let initialIdx = -1;
-  for (let i = 0; i < count; i++) {
-    const text = await allNames.nth(i).textContent();
-    if (text === "sample2.md") {
-      initialIdx = i;
-      break;
-    }
-  }
+  const initialIdx = (await allNames.allTextContents()).indexOf("sample2.md");
   expect(initialIdx).toBeGreaterThan(0); // sample2 should not be first
 
   // Click the tab itself, wait for focus to land (auto-retry), then press


### PR DESCRIPTION
## Summary

Replaces 6 of 8 brittle `page.waitForTimeout(N)` calls in the E2E suite with deterministic signals, plus diagnostic plumbing so the residual flakes that `retries: 1` masks become diagnosable in CI. Full plan: `.claude/plans/fix-flaky-tests.md`.

## What changed

**Category A — success tests racing UI events**
- `tab-overflow.spec.ts` "keyboard reorder with Alt+Arrow": click the `[role='tab']` element (not the inner name span — the tab owns the keyboard handler), assert focus actually landed via `expect(...).toBeFocused()`, and replace the 300ms post-keypress sleep with `expect.poll` on the reordered text. Matches the drag test's established pattern at lines 171-176.

**Category B — margin bubble collision settling**
- `margin-view.spec.ts` "PR2: bubbles do not overlap": collapse the 150ms "wait for collision sweep" + one-shot bounding-rect read into a single `expect.poll` on the invariant `b.top >= a.bottom`. Playwright's auto-retry absorbs the measure → `adjustedPositions` → remeasure ping-pong without a fixed sleep.

**Category C — absence tests for resize hysteresis & settings load**
- New `tests/e2e/helpers.ts` export `nextFrames(page, n=3)` awaits N requestAnimationFrames inside the page. Replaces fixed 80/120ms sleeps in `margin-view.spec.ts` hysteresis tests with a deterministic wait that covers the CDP-resize → ResizeObserver → `useViewportWidth` rAF debounce → `$effect` → DOM chain (≥ 2 rAFs minimum + 1 frame slack for CI load).
- `settings-models.spec.ts` v99 forward-compat: install a `Storage.prototype.setItem` spy and poll on `__settingsWrites.length === 0` instead of "wait for any settling". The test asserts a negative ("the loader's `_readOnly` clause must not write"); the spy is a concrete signal for that negative.

**Intentionally not changed**
- `settings-and-filters.spec.ts:632` — the 4000ms wait is justified (proving absence of an SSE event past the 3000ms dwell ceiling). Comment expanded to cite `awareness.ts:30-42` instead of a bare numeric justification.
- `scratchpad.spec.ts` and `tab-overflow.spec.ts:42,182` — `waitForSelector` without numeric arg is the canonical pattern.

**Diagnostic plumbing**
- `playwright.config.ts`: capture trace / screenshot / video on `retain-on-failure`. `retries: 1` is kept (matches the existing cross-platform CI tradeoff), but now the underlying cause of a retry-masked flake is recoverable from artifacts.
- `ci.yml`: upload `test-results/` alongside `playwright-report/` so traces actually reach the artifact bundle.

## Process

Spawned two adversarial reviews of the initial plan before writing code:
- `general-purpose` reviewer caught a focus-target bug in Category A (clicking the inner span vs `[role='tab']`), a coincidence hole in the "two consecutive identical reads" pattern for Category B, and pushed back on the 2-rAF assumption for Category C.
- `svelte-migration-reviewer` validated each timing claim against the Svelte 5 reactivity chain — confirmed `useTandemSettings.svelte.ts` writes are synchronous (no debounced effect, so no 600ms wait needed), traced the dwell-time propagation through `useTandemModeBroadcast` → CTRL_ROOM → `awareness.ts:getDwellMs`, and recommended ≥3 rAFs after `setViewportSize`.

Both reviews are incorporated. Revised plan is in `.claude/plans/fix-flaky-tests.md`.

## Test plan
- [x] `npm test` — 2462 passed, 13 skipped (no regressions)
- [x] Local `playwright test` on all 4 modified specs: 41 passed
- [x] Local `playwright test --repeat-each=5` on `tab-overflow.spec.ts` + `margin-view.spec.ts`: 100 passed (flake reduction confirmed under repetition)
- [x] `npx tsc --noEmit -p tsconfig.client.json` clean
- [x] `npx tsc --noEmit -p tsconfig.server.json` clean
- [ ] CI green (full E2E + repeat across Ubuntu/Windows)

https://claude.ai/code/session_01JzVpwG9SaWtHPB4owbkKLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzVpwG9SaWtHPB4owbkKLJ)_