### PR TITLE
test: audit test suite — fix ADR-027 privacy bug, tighten weak assertions, fill ADR-031 gaps

### DIFF
--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -70,6 +70,11 @@ const annotationTextTrimmed = $derived(annotationText.trim());
 let lastPlacement: SelectionToolbarPlacement | undefined;
 
 let pendingAffordanceFrame = 0;
+// Bounded retry counter: prevents a 60Hz infinite-rAF loop if `coordsAtPos`
+// keeps throwing (e.g. editor mounted in a detached / display:none subtree).
+// Reset on every non-throwing path; capped at MAX_AFFORDANCE_RETRIES.
+let affordanceRetryCount = 0;
+const MAX_AFFORDANCE_RETRIES = 3;
 
 function updateSelectionAffordance(ed: TiptapEditor) {
   const { from, to } = ed.state.selection;
@@ -78,6 +83,7 @@ function updateSelectionAffordance(ed: TiptapEditor) {
   if (!next) {
     selectionPosition = null;
     lastPlacement = undefined;
+    affordanceRetryCount = 0;
     return;
   }
 
@@ -94,6 +100,7 @@ function updateSelectionAffordance(ed: TiptapEditor) {
       previousPlacement: lastPlacement,
     });
     lastPlacement = nextPosition.placement;
+    affordanceRetryCount = 0;
     if (
       selectionPosition &&
       selectionPosition.left === nextPosition.left &&
@@ -108,7 +115,16 @@ function updateSelectionAffordance(ed: TiptapEditor) {
     // fires before the view's update cycle completes. The previous behavior
     // ("set selectionPosition = null") permanently hid the popup until
     // *another* selectionUpdate event arrived, which never happens for a
-    // one-shot `selectText()` in an E2E. Retry on the next paint instead.
+    // one-shot `selectText()` in an E2E. Retry on the next paint, bounded by
+    // MAX_AFFORDANCE_RETRIES so a persistently-unmeasured view (hidden /
+    // detached editor) can't pin the main thread.
+    if (affordanceRetryCount >= MAX_AFFORDANCE_RETRIES) {
+      affordanceRetryCount = 0;
+      selectionPosition = null;
+      lastPlacement = undefined;
+      return;
+    }
+    affordanceRetryCount += 1;
     cancelAnimationFrame(pendingAffordanceFrame);
     pendingAffordanceFrame = requestAnimationFrame(() => {
       if (!ed.isDestroyed) updateSelectionAffordance(ed);
@@ -126,7 +142,13 @@ $effect(() => {
 
   const cleanup = attachSelectionToolbarListener(ed, onSelectionUpdate);
   onSelectionUpdate();
-  return cleanup;
+  return () => {
+    // Cancel before delegating so a pending retry can't fire against a
+    // torn-down editor.
+    cancelAnimationFrame(pendingAffordanceFrame);
+    pendingAffordanceFrame = 0;
+    cleanup();
+  };
 });
 
 $effect(() => {

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -69,8 +69,6 @@ const annotationTextTrimmed = $derived(annotationText.trim());
 // $state (would risk effect_update_depth on every selection change).
 let lastPlacement: SelectionToolbarPlacement | undefined;
 
-let pendingAffordanceFrame = 0;
-
 function updateSelectionAffordance(ed: TiptapEditor) {
   const { from, to } = ed.state.selection;
   const next = from !== to;
@@ -103,16 +101,8 @@ function updateSelectionAffordance(ed: TiptapEditor) {
     }
     selectionPosition = { left: nextPosition.left, top: nextPosition.top };
   } catch {
-    // `coordsAtPos` throws when the PM view hasn't finished its measurement
-    // pass yet — common on a slow CI runner where the selectionUpdate event
-    // fires before the view's update cycle completes. The previous behavior
-    // ("set selectionPosition = null") permanently hid the popup until
-    // *another* selectionUpdate event arrived, which never happens for a
-    // one-shot `selectText()` in an E2E. Retry on the next paint instead.
-    cancelAnimationFrame(pendingAffordanceFrame);
-    pendingAffordanceFrame = requestAnimationFrame(() => {
-      if (!ed.isDestroyed) updateSelectionAffordance(ed);
-    });
+    selectionPosition = null;
+    lastPlacement = undefined;
   }
 }
 

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -69,6 +69,8 @@ const annotationTextTrimmed = $derived(annotationText.trim());
 // $state (would risk effect_update_depth on every selection change).
 let lastPlacement: SelectionToolbarPlacement | undefined;
 
+let pendingAffordanceFrame = 0;
+
 function updateSelectionAffordance(ed: TiptapEditor) {
   const { from, to } = ed.state.selection;
   const next = from !== to;
@@ -101,8 +103,16 @@ function updateSelectionAffordance(ed: TiptapEditor) {
     }
     selectionPosition = { left: nextPosition.left, top: nextPosition.top };
   } catch {
-    selectionPosition = null;
-    lastPlacement = undefined;
+    // `coordsAtPos` throws when the PM view hasn't finished its measurement
+    // pass yet — common on a slow CI runner where the selectionUpdate event
+    // fires before the view's update cycle completes. The previous behavior
+    // ("set selectionPosition = null") permanently hid the popup until
+    // *another* selectionUpdate event arrived, which never happens for a
+    // one-shot `selectText()` in an E2E. Retry on the next paint instead.
+    cancelAnimationFrame(pendingAffordanceFrame);
+    pendingAffordanceFrame = requestAnimationFrame(() => {
+      if (!ed.isDestroyed) updateSelectionAffordance(ed);
+    });
   }
 }
 

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -144,21 +144,10 @@ $effect(() => {
   }
 
   window.addEventListener("resize", scheduleUpdate);
-  // Grace period: PM auto-scrolls the selection into view after a programmatic
-  // selection change. That scroll bubbles to document-level with capture=true
-  // and would fire dismissPopup() before the user has a chance to interact
-  // with the freshly-mounted popup. Ignore scroll events for one paint after
-  // mount — by then any programmatic scroll has settled and only user-initiated
-  // scrolls remain. (Also closes a CI flake where this race was deterministic.)
-  let scrollDismissArmed = false;
-  requestAnimationFrame(() => {
-    scrollDismissArmed = true;
-  });
   const unsubscribeOutsideScroll = onOutsideEvent(
     () => toolbarEl,
     ["scroll"],
     () => {
-      if (!scrollDismissArmed) return;
       // Don't dismiss while the user is composing in the textarea
       if (document.activeElement === textareaEl) return;
       dismissPopup();

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -144,10 +144,21 @@ $effect(() => {
   }
 
   window.addEventListener("resize", scheduleUpdate);
+  // Grace period: PM auto-scrolls the selection into view after a programmatic
+  // selection change. That scroll bubbles to document-level with capture=true
+  // and would fire dismissPopup() before the user has a chance to interact
+  // with the freshly-mounted popup. Ignore scroll events for one paint after
+  // mount — by then any programmatic scroll has settled and only user-initiated
+  // scrolls remain. (Also closes a CI flake where this race was deterministic.)
+  let scrollDismissArmed = false;
+  requestAnimationFrame(() => {
+    scrollDismissArmed = true;
+  });
   const unsubscribeOutsideScroll = onOutsideEvent(
     () => toolbarEl,
     ["scroll"],
     () => {
+      if (!scrollDismissArmed) return;
       // Don't dismiss while the user is composing in the textarea
       if (document.activeElement === textareaEl) return;
       dismissPopup();

--- a/src/client/keychain/keychain-backend.ts
+++ b/src/client/keychain/keychain-backend.ts
@@ -184,5 +184,9 @@ export function createDefaultKeychainBackend(
   const useTauri = opts.force === "tauri" || (opts.force !== "http" && isTauriRuntime());
   return useTauri
     ? createTauriKeychainBackend({ invoke: opts.invoke })
-    : createHttpKeychainBackend({ fetchFn: opts.fetchFn, baseUrl: opts.baseUrl });
+    : createHttpKeychainBackend({
+        fetchFn: opts.fetchFn,
+        baseUrl: opts.baseUrl,
+        pathFor: opts.pathFor,
+      });
 }

--- a/src/server/events/observers/annotations.ts
+++ b/src/server/events/observers/annotations.ts
@@ -87,6 +87,11 @@ export function makeAnnotationsObserver(deps: {
       }
 
       if (action === "update" && ann.author === "claude") {
+        // ADR-027 defense-in-depth: a Claude-authored note is structurally
+        // impossible today, but file-sync echoes or future schema drift
+        // could produce one. Mirror the `add` branch's type guard above so
+        // the privacy invariant is locally explicit on both surfaces.
+        if (ann.type === "note") return undefined;
         if (ann.status === "accepted") {
           return {
             id: generateEventId(),

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -400,9 +400,11 @@ export function registerAnnotationTools(server: McpServer): void {
     "tandem_suggest",
     "DEPRECATED — use tandem_comment with suggestedText instead. Always returns an error.",
     {
-      from: z.number(),
-      to: z.number(),
-      newText: z.string(),
+      // All params optional: a deprecated stub must surface DEPRECATED for any
+      // call shape, including ones missing the legacy required params.
+      from: z.number().optional(),
+      to: z.number().optional(),
+      newText: z.string().optional(),
       reason: z.string().optional(),
       documentId: z.string().optional(),
       textSnapshot: z.string().optional(),
@@ -561,6 +563,16 @@ export function registerAnnotationTools(server: McpServer): void {
 
         // Sanitize legacy shapes before editing
         const ann = sanitizeAnnotation(raw, makeOnLossy(da.docHash));
+
+        // ADR-027: notes are user-private. Claude must not read or modify them
+        // via MCP. The note→comment promotion path runs from the browser, not
+        // through this tool.
+        if (ann.type === "note") {
+          return mcpError(
+            "INVALID_ARGUMENT",
+            "Cannot edit a note via MCP — notes are user-private (ADR-027).",
+          );
+        }
 
         if (ann.status !== "pending") {
           return mcpError("ANNOTATION_RESOLVED", `Cannot edit a ${ann.status} annotation`);

--- a/tests/client/keychain-backend.test.ts
+++ b/tests/client/keychain-backend.test.ts
@@ -168,4 +168,26 @@ describe("createDefaultKeychainBackend", () => {
     await backend.set("ref", "v");
     expect(fetchFn).toHaveBeenCalled();
   });
+
+  // The `pathFor` argument is the only way the Models registry separates its
+  // outbound third-party API keys (`/api/models/secrets/`, service
+  // `tandem-models`) from inbound MCP-client tokens
+  // (`/api/integrations/secrets/`, service `tandem-integrations`). Forgetting
+  // to forward it through the default factory silently commingles the two
+  // namespaces — and the bug shows up as a 503 KEYCHAIN_UNAVAILABLE in CI
+  // because the wrong route's mock doesn't fire.
+  it("forwards pathFor to the HTTP backend (Models registry namespace separation)", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    const backend = createDefaultKeychainBackend({
+      force: "http",
+      fetchFn: fetchFn as unknown as typeof fetch,
+      baseUrl: "http://127.0.0.1:3479",
+      pathFor: (ref) => `/api/models/secrets/${ref}`,
+    });
+    await backend.set("abc123", "v");
+    expect(fetchFn).toHaveBeenCalledWith(
+      "http://127.0.0.1:3479/api/models/secrets/abc123",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,6 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -120,6 +120,23 @@ export async function switchToAnnotationsTab(page: Page): Promise<void> {
   if ((await toggle.count()) > 0) {
     await toggle.click();
   }
+}
+
+/**
+ * Open the selection popup's annotate mode. Wave M (PR #776) split the popup
+ * into two surfaces — selection shows the action surface (formatting +
+ * highlight swatches + Annotate button); clicking Annotate reveals the
+ * textarea-bearing annotate mode (`popup-annotation-input`,
+ * `popup-comment-submit`, `popup-note-submit`). Tests that interact with the
+ * textarea or submit buttons must call this helper after selecting text.
+ */
+export async function openAnnotatePopup(page: Page): Promise<void> {
+  const annotateBtn = page.locator("[data-testid='popup-annotate-btn']");
+  await expect(annotateBtn).toBeVisible({ timeout: 3_000 });
+  await annotateBtn.click();
+  await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
+    timeout: 3_000,
+  });
 }
 
 /**

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -106,6 +106,22 @@ export function cleanupFixtureDir(dir: string): void {
  * testid in that mode. The helper detects this and no-ops, so tests that
  * switch layout mid-flight still work.
  */
+/**
+ * Click the selection popup's "Annotate" button to enter annotate mode and
+ * surface the textarea + Note/Comment submit buttons.
+ *
+ * Wave M (PR #776) restructured the selection popup into two modes: the
+ * default mode shows B/I, highlight swatches, and an Annotate button; the
+ * textarea (`popup-annotation-input`) and submit buttons (`popup-note-submit`,
+ * `popup-comment-submit`) only render after the user clicks Annotate (or
+ * presses Ctrl+Alt+M). Callers that need the textarea must invoke this
+ * helper after `selectText()` and before asserting input visibility.
+ */
+export async function enterAnnotateMode(page: Page): Promise<void> {
+  const annotateBtn = page.locator("[data-testid='popup-annotate-btn']");
+  await annotateBtn.click({ timeout: 5_000 });
+}
+
 export async function switchToAnnotationsTab(page: Page): Promise<void> {
   const tab = page.locator("[data-testid='annotations-tab']");
   // In three-panel mode the tab button does not exist — bail silently.

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -106,22 +106,6 @@ export function cleanupFixtureDir(dir: string): void {
  * testid in that mode. The helper detects this and no-ops, so tests that
  * switch layout mid-flight still work.
  */
-/**
- * Click the selection popup's "Annotate" button to enter annotate mode and
- * surface the textarea + Note/Comment submit buttons.
- *
- * Wave M (PR #776) restructured the selection popup into two modes: the
- * default mode shows B/I, highlight swatches, and an Annotate button; the
- * textarea (`popup-annotation-input`) and submit buttons (`popup-note-submit`,
- * `popup-comment-submit`) only render after the user clicks Annotate (or
- * presses Ctrl+Alt+M). Callers that need the textarea must invoke this
- * helper after `selectText()` and before asserting input visibility.
- */
-export async function enterAnnotateMode(page: Page): Promise<void> {
-  const annotateBtn = page.locator("[data-testid='popup-annotate-btn']");
-  await annotateBtn.click({ timeout: 5_000 });
-}
-
 export async function switchToAnnotationsTab(page: Page): Promise<void> {
   const tab = page.locator("[data-testid='annotations-tab']");
   // In three-panel mode the tab button does not exist — bail silently.

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -7,6 +7,7 @@ import {
   createFixtureDir,
   McpTestClient,
   nextFrames,
+  openAnnotatePopup,
   openSettingsPopover,
 } from "./helpers";
 
@@ -325,8 +326,8 @@ test("PR2: note bubble never exposes replies (ADR-027)", async ({ page }) => {
   // Create a real note via the selection popup (pattern: toolbar-redesign.spec.ts).
   await editor.click();
   await editor.locator("p").first().selectText();
+  await openAnnotatePopup(page);
   const popupInput = page.locator("[data-testid='popup-annotation-input']");
-  await expect(popupInput).toBeVisible({ timeout: 3_000 });
   await popupInput.fill("private note");
   await page.locator("[data-testid='popup-note-submit']").click();
 

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -5,7 +5,6 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
-  enterAnnotateMode,
   McpTestClient,
   nextFrames,
   openSettingsPopover,
@@ -326,7 +325,6 @@ test("PR2: note bubble never exposes replies (ADR-027)", async ({ page }) => {
   // Create a real note via the selection popup (pattern: toolbar-redesign.spec.ts).
   await editor.click();
   await editor.locator("p").first().selectText();
-  await enterAnnotateMode(page);
   const popupInput = page.locator("[data-testid='popup-annotation-input']");
   await expect(popupInput).toBeVisible({ timeout: 3_000 });
   await popupInput.fill("private note");

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -5,6 +5,7 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
+  enterAnnotateMode,
   McpTestClient,
   nextFrames,
   openSettingsPopover,
@@ -325,6 +326,7 @@ test("PR2: note bubble never exposes replies (ADR-027)", async ({ page }) => {
   // Create a real note via the selection popup (pattern: toolbar-redesign.spec.ts).
   await editor.click();
   await editor.locator("p").first().selectText();
+  await enterAnnotateMode(page);
   const popupInput = page.locator("[data-testid='popup-annotation-input']");
   await expect(popupInput).toBeVisible({ timeout: 3_000 });
   await popupInput.fill("private note");

--- a/tests/e2e/redesign-final-qa.spec.ts
+++ b/tests/e2e/redesign-final-qa.spec.ts
@@ -4,6 +4,7 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
+  enterAnnotateMode,
   McpTestClient,
   openSettingsPopover,
   switchToAnnotationsTab,
@@ -191,6 +192,7 @@ test.describe("forced colors / high contrast", () => {
     await expect(page.locator("[data-testid='toolbar-highlight-btn']")).toBeEnabled({
       timeout: 3_000,
     });
+    await enterAnnotateMode(page);
     await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
       timeout: 3_000,
     });

--- a/tests/e2e/redesign-final-qa.spec.ts
+++ b/tests/e2e/redesign-final-qa.spec.ts
@@ -191,7 +191,10 @@ test.describe("forced colors / high contrast", () => {
     await expect(page.locator("[data-testid='toolbar-highlight-btn']")).toBeEnabled({
       timeout: 3_000,
     });
-    await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
+    // Wave M: the action surface (Annotate button) mounts on selection;
+    // the textarea lives behind the Annotate click. Forced-colors mode
+    // applies to both surfaces, so we just verify the popup is reachable.
+    await expect(page.locator("[data-testid='popup-annotate-btn']")).toBeVisible({
       timeout: 3_000,
     });
   });

--- a/tests/e2e/redesign-final-qa.spec.ts
+++ b/tests/e2e/redesign-final-qa.spec.ts
@@ -4,7 +4,6 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
-  enterAnnotateMode,
   McpTestClient,
   openSettingsPopover,
   switchToAnnotationsTab,
@@ -192,7 +191,6 @@ test.describe("forced colors / high contrast", () => {
     await expect(page.locator("[data-testid='toolbar-highlight-btn']")).toBeEnabled({
       timeout: 3_000,
     });
-    await enterAnnotateMode(page);
     await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
       timeout: 3_000,
     });

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -6,6 +6,7 @@ import {
   cleanupFixtureDir,
   createFixtureDir,
   McpTestClient,
+  openAnnotatePopup,
   openSettingsPopover,
   switchToAnnotationsTab,
 } from "./helpers";
@@ -401,8 +402,9 @@ test("Solo/Tandem mode toggle switches via toolbar (Wave M: fade-not-hide)", asy
   // No held bucket — sb-held never renders.
   await expect(heldButton).toHaveCount(0);
 
-  // Switch back via the toggle.
-  await soloBtn.click();
+  // Switch back via the toggle. Wave M's toggle is two distinct buttons —
+  // each sets the mode unconditionally, so re-clicking solo would no-op.
+  await tandemBtn.click();
   await expect(tandemBtn).toHaveAttribute("aria-pressed", "true");
   await expect(soloBtn).toHaveAttribute("aria-pressed", "false");
   const tandemSaved = await page.evaluate((key) => localStorage.getItem(key), TANDEM_MODE_KEY);
@@ -664,9 +666,10 @@ test("note filter shows only notes, hides comments (ADR-027 C1)", async ({ page 
   const firstParagraph = editor.locator("p").first();
   await firstParagraph.selectText();
 
-  // AR3: the unified popup appears automatically on selection — no button click needed.
+  // Wave M (#776): selection shows the action surface; clicking Annotate
+  // reveals the textarea. Originally AR3 surfaced the textarea on selection.
+  await openAnnotatePopup(page);
   const noteInput = page.locator("[data-testid='popup-annotation-input']");
-  await expect(noteInput).toBeVisible({ timeout: 3_000 });
 
   // Type note content and submit via "Note to self".
   await noteInput.fill("my private note");

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -5,7 +5,6 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
-  enterAnnotateMode,
   McpTestClient,
   openSettingsPopover,
   switchToAnnotationsTab,
@@ -665,8 +664,7 @@ test("note filter shows only notes, hides comments (ADR-027 C1)", async ({ page 
   const firstParagraph = editor.locator("p").first();
   await firstParagraph.selectText();
 
-  // Wave M: textarea is gated behind the Annotate button in the popup.
-  await enterAnnotateMode(page);
+  // AR3: the unified popup appears automatically on selection — no button click needed.
   const noteInput = page.locator("[data-testid='popup-annotation-input']");
   await expect(noteInput).toBeVisible({ timeout: 3_000 });
 

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -5,6 +5,7 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
+  enterAnnotateMode,
   McpTestClient,
   openSettingsPopover,
   switchToAnnotationsTab,
@@ -664,7 +665,8 @@ test("note filter shows only notes, hides comments (ADR-027 C1)", async ({ page 
   const firstParagraph = editor.locator("p").first();
   await firstParagraph.selectText();
 
-  // AR3: the unified popup appears automatically on selection — no button click needed.
+  // Wave M: textarea is gated behind the Annotate button in the popup.
+  await enterAnnotateMode(page);
   const noteInput = page.locator("[data-testid='popup-annotation-input']");
   await expect(noteInput).toBeVisible({ timeout: 3_000 });
 

--- a/tests/e2e/slash-command-menu.spec.ts
+++ b/tests/e2e/slash-command-menu.spec.ts
@@ -4,7 +4,6 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
-  enterAnnotateMode,
   McpTestClient,
 } from "./helpers";
 
@@ -134,8 +133,6 @@ test("slash menu suppresses while annotation popup is open (D10)", async ({ page
   if (!box) throw new Error("paragraph not laid out");
   await page.mouse.click(box.x + 10, box.y + box.height / 2, { clickCount: 3 });
 
-  // Wave M: textarea is gated behind the Annotate button in the popup.
-  await enterAnnotateMode(page);
   const popupInput = page.getByTestId("popup-annotation-input");
   await expect(popupInput).toBeVisible();
   await popupInput.focus();

--- a/tests/e2e/slash-command-menu.spec.ts
+++ b/tests/e2e/slash-command-menu.spec.ts
@@ -4,6 +4,7 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
+  enterAnnotateMode,
   McpTestClient,
 } from "./helpers";
 
@@ -133,6 +134,8 @@ test("slash menu suppresses while annotation popup is open (D10)", async ({ page
   if (!box) throw new Error("paragraph not laid out");
   await page.mouse.click(box.x + 10, box.y + box.height / 2, { clickCount: 3 });
 
+  // Wave M: textarea is gated behind the Annotate button in the popup.
+  await enterAnnotateMode(page);
   const popupInput = page.getByTestId("popup-annotation-input");
   await expect(popupInput).toBeVisible();
   await popupInput.focus();

--- a/tests/e2e/slash-command-menu.spec.ts
+++ b/tests/e2e/slash-command-menu.spec.ts
@@ -5,6 +5,7 @@ import {
   cleanupFixtureDir,
   createFixtureDir,
   McpTestClient,
+  openAnnotatePopup,
 } from "./helpers";
 
 let mcp: McpTestClient;
@@ -125,16 +126,19 @@ test("slash menu inserts horizontal rule", async ({ page }) => {
 test("slash menu suppresses while annotation popup is open (D10)", async ({ page }) => {
   const editor = await openSample(page);
 
-  // Select text to open the selection toolbar. The popup mounts
-  // `popup-annotation-input` — the slash menu must refuse to activate while
-  // that surface is present (D10 forward suppression).
+  // Select text to open the selection toolbar. Wave M (PR #776) split the
+  // popup: selection shows the action surface (Annotate button + highlight
+  // swatches); clicking Annotate reveals `popup-annotation-input`. The slash
+  // menu must refuse to activate while either surface is mounted (D10
+  // forward suppression). We exercise the annotate-mode arm here because the
+  // test focuses the textarea below.
   const paragraph = editor.locator("p").first();
   const box = await paragraph.boundingBox();
   if (!box) throw new Error("paragraph not laid out");
   await page.mouse.click(box.x + 10, box.y + box.height / 2, { clickCount: 3 });
 
+  await openAnnotatePopup(page);
   const popupInput = page.getByTestId("popup-annotation-input");
-  await expect(popupInput).toBeVisible();
   await popupInput.focus();
 
   const slashMenu = page.getByRole("listbox", { name: "Slash commands" });

--- a/tests/e2e/toolbar-redesign.spec.ts
+++ b/tests/e2e/toolbar-redesign.spec.ts
@@ -4,6 +4,7 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
+  enterAnnotateMode,
   McpTestClient,
   switchToAnnotationsTab,
 } from "./helpers";
@@ -87,6 +88,7 @@ test("selection lights up annotation entry-points", async ({ page }) => {
   await expect(page.locator("[data-testid='toolbar-highlight-btn']")).toBeEnabled({
     timeout: 3_000,
   });
+  await enterAnnotateMode(page);
   await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
     timeout: 3_000,
   });
@@ -111,6 +113,7 @@ test("floating selection toolbar stays within a short viewport", async ({ page }
   // viewport the toolbar can lag the selection event by a frame or two under CI.
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
+  await enterAnnotateMode(page);
   // Confirm interactive state before reading boundingBox().
   await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
     timeout: 5_000,
@@ -137,12 +140,15 @@ test("floating selection toolbar exposes first-pass formatting actions", async (
 
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
-  await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
-    timeout: 5_000,
-  });
+  // Default mode exposes formatting + highlight + Annotate; verify those first.
   await expect(toolbar.getByRole("button", { name: "Bold" })).toBeVisible();
   await expect(toolbar.getByRole("button", { name: "Italic" })).toBeVisible();
   await expect(toolbar.getByRole("button", { name: /Highlight / })).toHaveCount(4);
+  // Enter annotate mode to surface the textarea + Comment submit button.
+  await enterAnnotateMode(page);
+  await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
+    timeout: 5_000,
+  });
   await expect(toolbar.getByRole("button", { name: "Comment on selection" })).toBeVisible();
   // Strike and Code were removed from the selection popup (see toolbar-ux-research.md).
   // Link lives in the top FormattingToolbar (with inline input), not the floating popup.
@@ -179,7 +185,8 @@ test("Comment flow creates a comment annotation", async ({ page }) => {
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Unified popup appears automatically on selection — popup visible = selection confirmed
+  // Wave M: textarea is gated behind the Annotate button in the popup.
+  await enterAnnotateMode(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("test comment");
@@ -204,7 +211,8 @@ test("Note flow creates a note annotation", async ({ page }) => {
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Unified popup appears automatically on selection — popup visible = selection confirmed
+  // Wave M: textarea is gated behind the Annotate button in the popup.
+  await enterAnnotateMode(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("test note");
@@ -236,7 +244,10 @@ test("#480 regression — popup appears on selection without creating an annotat
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Popup appears — but no annotation is created just by selecting text
+  // Popup appears — but no annotation is created just by selecting text.
+  // Wave M: enter annotate mode to surface the textarea, then assert that
+  // simply revealing it does not create an annotation.
+  await enterAnnotateMode(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 3_000 });
 
@@ -261,7 +272,8 @@ test("Comment submit is disabled when textarea is empty (no annotation created)"
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Popup appears — Comment button should be disabled when textarea is empty
+  // Wave M: enter annotate mode to surface the textarea + Comment button.
+  await enterAnnotateMode(page);
   await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
     timeout: 3_000,
   });
@@ -286,6 +298,7 @@ test("Enter key in popup textarea submits as Comment", async ({ page }) => {
   await editor.click();
   await editor.locator("p").first().selectText();
 
+  await enterAnnotateMode(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("enter key comment");
@@ -312,6 +325,7 @@ test("popup textarea and submit buttons are visible on selection", async ({ page
 
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
+  await enterAnnotateMode(page);
   await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
     timeout: 3_000,
   });
@@ -358,7 +372,8 @@ test("Escape dismisses the popup without creating an annotation", async ({ page 
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 10_000 });
 
-  // Type in the popup textarea, then Escape
+  // Wave M: enter annotate mode, then type and Escape.
+  await enterAnnotateMode(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 2_000 });
   await input.fill("draft");
@@ -384,6 +399,7 @@ test("Shift+Enter inserts a newline in the textarea without submitting", async (
   await editor.click();
   await editor.locator("p").first().selectText();
 
+  await enterAnnotateMode(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("line one");
@@ -410,7 +426,9 @@ test("suppressSelectionToolbar hides the popup when the find bar is open", async
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  const popup = page.locator("[data-testid='popup-annotation-input']");
+  // Use the popup wrapper (role=toolbar) as the visibility proxy — it's
+  // present in both default and annotate modes (post Wave M).
+  const popup = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(popup).toBeVisible({ timeout: 3_000 });
 
   // Open the find bar — App.svelte sets suppressSelectionToolbar when findBarOpen
@@ -430,10 +448,11 @@ test("popup highlight button creates a highlight annotation", async ({ page }) =
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  const popup = page.locator("[data-testid='popup-annotation-input']");
-  await expect(popup).toBeVisible({ timeout: 3_000 });
-
-  // Click the yellow highlight swatch inside the popup (distinct from FormattingBar path)
+  // Highlight swatch lives in the default-mode popup row — assert the popup
+  // wrapper is up (role=toolbar), then click the swatch directly.
+  await expect(page.getByRole("toolbar", { name: "Selection tools" })).toBeVisible({
+    timeout: 3_000,
+  });
   await page.locator("[data-testid='popup-highlight-yellow']").click();
 
   await expect(page.locator("[data-testid^='annotation-card-']")).toHaveCount(1, {

--- a/tests/e2e/toolbar-redesign.spec.ts
+++ b/tests/e2e/toolbar-redesign.spec.ts
@@ -5,6 +5,7 @@ import {
   cleanupFixtureDir,
   createFixtureDir,
   McpTestClient,
+  openAnnotatePopup,
   switchToAnnotationsTab,
 } from "./helpers";
 
@@ -87,9 +88,8 @@ test("selection lights up annotation entry-points", async ({ page }) => {
   await expect(page.locator("[data-testid='toolbar-highlight-btn']")).toBeEnabled({
     timeout: 3_000,
   });
-  await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
-    timeout: 3_000,
-  });
+  // Wave M: selection opens the action surface; Annotate reveals the textarea.
+  await openAnnotatePopup(page);
   await expect(page.locator("[data-testid='popup-note-submit']")).toBeVisible();
 });
 
@@ -111,8 +111,9 @@ test("floating selection toolbar stays within a short viewport", async ({ page }
   // viewport the toolbar can lag the selection event by a frame or two under CI.
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
-  // Confirm interactive state before reading boundingBox().
-  await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
+  // Confirm interactive state before reading boundingBox(). The Annotate
+  // button lives on the action surface that mounts on selection (Wave M).
+  await expect(page.locator("[data-testid='popup-annotate-btn']")).toBeVisible({
     timeout: 5_000,
   });
 
@@ -137,12 +138,12 @@ test("floating selection toolbar exposes first-pass formatting actions", async (
 
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
-  await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
-    timeout: 5_000,
-  });
+  // Bold/Italic/Highlight live on the action surface; "Comment on selection"
+  // lives in annotate mode (Wave M), so open it before asserting.
   await expect(toolbar.getByRole("button", { name: "Bold" })).toBeVisible();
   await expect(toolbar.getByRole("button", { name: "Italic" })).toBeVisible();
   await expect(toolbar.getByRole("button", { name: /Highlight / })).toHaveCount(4);
+  await openAnnotatePopup(page);
   await expect(toolbar.getByRole("button", { name: "Comment on selection" })).toBeVisible();
   // Strike and Code were removed from the selection popup (see toolbar-ux-research.md).
   // Link lives in the top FormattingToolbar (with inline input), not the floating popup.
@@ -179,9 +180,9 @@ test("Comment flow creates a comment annotation", async ({ page }) => {
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Unified popup appears automatically on selection — popup visible = selection confirmed
+  // Wave M: selection shows the action surface; click Annotate for the textarea.
+  await openAnnotatePopup(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
-  await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("test comment");
   await page.locator("[data-testid='popup-comment-submit']").click();
 
@@ -204,9 +205,9 @@ test("Note flow creates a note annotation", async ({ page }) => {
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Unified popup appears automatically on selection — popup visible = selection confirmed
+  // Wave M: selection shows the action surface; click Annotate for the textarea.
+  await openAnnotatePopup(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
-  await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("test note");
   await page.locator("[data-testid='popup-note-submit']").click();
 
@@ -236,9 +237,12 @@ test("#480 regression — popup appears on selection without creating an annotat
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Popup appears — but no annotation is created just by selecting text
-  const input = page.locator("[data-testid='popup-annotation-input']");
-  await expect(input).toBeVisible({ timeout: 3_000 });
+  // Popup action surface appears — but no annotation is created just by
+  // selecting text. (Wave M: textarea lives behind the Annotate button, but
+  // the #480 contract is about the action surface itself appearing.)
+  await expect(page.locator("[data-testid='popup-annotate-btn']")).toBeVisible({
+    timeout: 3_000,
+  });
 
   // No annotation yet — under AR3's unified popup, selecting text shows the
   // popup but never auto-creates an annotation (the original #480 contract still holds)
@@ -262,9 +266,7 @@ test("Comment submit is disabled when textarea is empty (no annotation created)"
   await editor.locator("p").first().selectText();
 
   // Popup appears — Comment button should be disabled when textarea is empty
-  await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
-    timeout: 3_000,
-  });
+  await openAnnotatePopup(page);
   await expect(page.locator("[data-testid='popup-comment-submit']")).toBeDisabled({
     timeout: 2_000,
   });
@@ -286,8 +288,8 @@ test("Enter key in popup textarea submits as Comment", async ({ page }) => {
   await editor.click();
   await editor.locator("p").first().selectText();
 
+  await openAnnotatePopup(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
-  await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("enter key comment");
   await input.press("Enter");
 
@@ -299,7 +301,7 @@ test("Enter key in popup textarea submits as Comment", async ({ page }) => {
   );
 });
 
-test("popup textarea and submit buttons are visible on selection", async ({ page }) => {
+test("popup textarea and submit buttons are visible after Annotate click", async ({ page }) => {
   await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
   await page.goto("/");
   await switchToAnnotationsTab(page);
@@ -312,9 +314,8 @@ test("popup textarea and submit buttons are visible on selection", async ({ page
 
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
-  await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
-    timeout: 3_000,
-  });
+  // Wave M: textarea + submit buttons live behind the Annotate button.
+  await openAnnotatePopup(page);
   await expect(page.locator("[data-testid='popup-note-submit']")).toBeVisible();
   await expect(page.locator("[data-testid='popup-comment-submit']")).toBeVisible();
 });
@@ -359,8 +360,8 @@ test("Escape dismisses the popup without creating an annotation", async ({ page 
   await expect(toolbar).toBeVisible({ timeout: 10_000 });
 
   // Type in the popup textarea, then Escape
+  await openAnnotatePopup(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
-  await expect(input).toBeVisible({ timeout: 2_000 });
   await input.fill("draft");
   await input.press("Escape");
 
@@ -384,8 +385,8 @@ test("Shift+Enter inserts a newline in the textarea without submitting", async (
   await editor.click();
   await editor.locator("p").first().selectText();
 
+  await openAnnotatePopup(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
-  await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("line one");
   await input.press("Shift+Enter");
 
@@ -410,7 +411,8 @@ test("suppressSelectionToolbar hides the popup when the find bar is open", async
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  const popup = page.locator("[data-testid='popup-annotation-input']");
+  // Wave M: the popup's action surface is what mounts on selection.
+  const popup = page.locator("[data-testid='popup-annotate-btn']");
   await expect(popup).toBeVisible({ timeout: 3_000 });
 
   // Open the find bar — App.svelte sets suppressSelectionToolbar when findBarOpen
@@ -430,8 +432,12 @@ test("popup highlight button creates a highlight annotation", async ({ page }) =
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  const popup = page.locator("[data-testid='popup-annotation-input']");
-  await expect(popup).toBeVisible({ timeout: 3_000 });
+  // Wave M: highlight swatches live in the action surface (not annotate mode),
+  // so we just need the popup to be mounted. The Annotate button is the
+  // visibility sentinel for the action surface.
+  await expect(page.locator("[data-testid='popup-annotate-btn']")).toBeVisible({
+    timeout: 3_000,
+  });
 
   // Click the yellow highlight swatch inside the popup (distinct from FormattingBar path)
   await page.locator("[data-testid='popup-highlight-yellow']").click();

--- a/tests/e2e/toolbar-redesign.spec.ts
+++ b/tests/e2e/toolbar-redesign.spec.ts
@@ -4,7 +4,6 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
-  enterAnnotateMode,
   McpTestClient,
   switchToAnnotationsTab,
 } from "./helpers";
@@ -88,7 +87,6 @@ test("selection lights up annotation entry-points", async ({ page }) => {
   await expect(page.locator("[data-testid='toolbar-highlight-btn']")).toBeEnabled({
     timeout: 3_000,
   });
-  await enterAnnotateMode(page);
   await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
     timeout: 3_000,
   });
@@ -113,7 +111,6 @@ test("floating selection toolbar stays within a short viewport", async ({ page }
   // viewport the toolbar can lag the selection event by a frame or two under CI.
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
-  await enterAnnotateMode(page);
   // Confirm interactive state before reading boundingBox().
   await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
     timeout: 5_000,
@@ -140,15 +137,12 @@ test("floating selection toolbar exposes first-pass formatting actions", async (
 
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
-  // Default mode exposes formatting + highlight + Annotate; verify those first.
-  await expect(toolbar.getByRole("button", { name: "Bold" })).toBeVisible();
-  await expect(toolbar.getByRole("button", { name: "Italic" })).toBeVisible();
-  await expect(toolbar.getByRole("button", { name: /Highlight / })).toHaveCount(4);
-  // Enter annotate mode to surface the textarea + Comment submit button.
-  await enterAnnotateMode(page);
   await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
     timeout: 5_000,
   });
+  await expect(toolbar.getByRole("button", { name: "Bold" })).toBeVisible();
+  await expect(toolbar.getByRole("button", { name: "Italic" })).toBeVisible();
+  await expect(toolbar.getByRole("button", { name: /Highlight / })).toHaveCount(4);
   await expect(toolbar.getByRole("button", { name: "Comment on selection" })).toBeVisible();
   // Strike and Code were removed from the selection popup (see toolbar-ux-research.md).
   // Link lives in the top FormattingToolbar (with inline input), not the floating popup.
@@ -185,8 +179,7 @@ test("Comment flow creates a comment annotation", async ({ page }) => {
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Wave M: textarea is gated behind the Annotate button in the popup.
-  await enterAnnotateMode(page);
+  // Unified popup appears automatically on selection — popup visible = selection confirmed
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("test comment");
@@ -211,8 +204,7 @@ test("Note flow creates a note annotation", async ({ page }) => {
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Wave M: textarea is gated behind the Annotate button in the popup.
-  await enterAnnotateMode(page);
+  // Unified popup appears automatically on selection — popup visible = selection confirmed
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("test note");
@@ -244,10 +236,7 @@ test("#480 regression — popup appears on selection without creating an annotat
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Popup appears — but no annotation is created just by selecting text.
-  // Wave M: enter annotate mode to surface the textarea, then assert that
-  // simply revealing it does not create an annotation.
-  await enterAnnotateMode(page);
+  // Popup appears — but no annotation is created just by selecting text
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 3_000 });
 
@@ -272,8 +261,7 @@ test("Comment submit is disabled when textarea is empty (no annotation created)"
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Wave M: enter annotate mode to surface the textarea + Comment button.
-  await enterAnnotateMode(page);
+  // Popup appears — Comment button should be disabled when textarea is empty
   await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
     timeout: 3_000,
   });
@@ -298,7 +286,6 @@ test("Enter key in popup textarea submits as Comment", async ({ page }) => {
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  await enterAnnotateMode(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("enter key comment");
@@ -325,7 +312,6 @@ test("popup textarea and submit buttons are visible on selection", async ({ page
 
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 5_000 });
-  await enterAnnotateMode(page);
   await expect(page.locator("[data-testid='popup-annotation-input']")).toBeVisible({
     timeout: 3_000,
   });
@@ -372,8 +358,7 @@ test("Escape dismisses the popup without creating an annotation", async ({ page 
   const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
   await expect(toolbar).toBeVisible({ timeout: 10_000 });
 
-  // Wave M: enter annotate mode, then type and Escape.
-  await enterAnnotateMode(page);
+  // Type in the popup textarea, then Escape
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 2_000 });
   await input.fill("draft");
@@ -399,7 +384,6 @@ test("Shift+Enter inserts a newline in the textarea without submitting", async (
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  await enterAnnotateMode(page);
   const input = page.locator("[data-testid='popup-annotation-input']");
   await expect(input).toBeVisible({ timeout: 3_000 });
   await input.fill("line one");
@@ -426,9 +410,7 @@ test("suppressSelectionToolbar hides the popup when the find bar is open", async
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Use the popup wrapper (role=toolbar) as the visibility proxy — it's
-  // present in both default and annotate modes (post Wave M).
-  const popup = page.getByRole("toolbar", { name: "Selection tools" });
+  const popup = page.locator("[data-testid='popup-annotation-input']");
   await expect(popup).toBeVisible({ timeout: 3_000 });
 
   // Open the find bar — App.svelte sets suppressSelectionToolbar when findBarOpen
@@ -448,11 +430,10 @@ test("popup highlight button creates a highlight annotation", async ({ page }) =
   await editor.click();
   await editor.locator("p").first().selectText();
 
-  // Highlight swatch lives in the default-mode popup row — assert the popup
-  // wrapper is up (role=toolbar), then click the swatch directly.
-  await expect(page.getByRole("toolbar", { name: "Selection tools" })).toBeVisible({
-    timeout: 3_000,
-  });
+  const popup = page.locator("[data-testid='popup-annotation-input']");
+  await expect(popup).toBeVisible({ timeout: 3_000 });
+
+  // Click the yellow highlight swatch inside the popup (distinct from FormattingBar path)
   await page.locator("[data-testid='popup-highlight-yellow']").click();
 
   await expect(page.locator("[data-testid^='annotation-card-']")).toHaveCount(1, {

--- a/tests/server/annotation-lifecycle.test.ts
+++ b/tests/server/annotation-lifecycle.test.ts
@@ -96,14 +96,19 @@ describe("dismissPending", () => {
 });
 
 describe("transactions are tagged with MCP_ORIGIN (channel-event skip)", () => {
-  it("acceptPending fires under MCP_ORIGIN", () => {
+  // ADR-031: catches a wrong-helper substitution (e.g. `withBrowser` for
+  // `withMcp`) that the raw-`doc.transact` pre-commit hook cannot see.
+  it.each([
+    ["acceptPending", (id: string, d: Y.Doc, m: Y.Map<unknown>) => acceptPending(id, d, m)],
+    ["dismissPending", (id: string, d: Y.Doc, m: Y.Map<unknown>) => dismissPending(id, d, m)],
+  ])("%s fires under MCP_ORIGIN", (_label, op) => {
     const map = getAnnotationsMap(doc);
     const id = createAnnotation(map, doc, "comment", rangeOf(0, 5, doc), "test");
 
     const origins: unknown[] = [];
     doc.on("beforeTransaction", (tr: Y.Transaction) => origins.push(tr.origin));
 
-    acceptPending(id, doc, map);
+    op(id, doc, map);
 
     expect(origins).toContain("mcp");
   });

--- a/tests/server/edit-annotation.test.ts
+++ b/tests/server/edit-annotation.test.ts
@@ -171,6 +171,30 @@ describe("tandem_editAnnotation", () => {
     expect(after.content).toBe("private note");
   });
 
+  // Pins guard order: the note-type check must run BEFORE the status check.
+  // If reordered, a non-pending note would surface as ANNOTATION_RESOLVED,
+  // leaking the note's existence to Claude. INVALID_ARGUMENT is the only
+  // safe response.
+  it("rejects edit on a non-pending note with INVALID_ARGUMENT (not ANNOTATION_RESOLVED)", async () => {
+    const ydoc = setupDoc("edit-4-note-resolved", "Hello world");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const id = createAnnotation(map, ydoc, "note", rangeOf(0, 5, ydoc), "private note");
+
+    const ann = map.get(id) as Annotation;
+    ydoc.transact(() => map.set(id, { ...ann, status: "accepted" as const }), MCP_ORIGIN);
+
+    const result = await client.callTool({
+      name: "tandem_editAnnotation",
+      arguments: { id, content: "Claude tries to edit a resolved private note" },
+    });
+    const parsed = parseResult(result as any);
+    expect(parsed.error).toBe(true);
+    expect(parsed.code).toBe("INVALID_ARGUMENT");
+
+    const after = map.get(id) as Annotation;
+    expect(after.content).toBe("private note");
+  });
+
   it("rejects when no editable fields provided for non-suggestion", async () => {
     const ydoc = setupDoc("edit-5", "Hello world");
     const map = ydoc.getMap(Y_MAP_ANNOTATIONS);

--- a/tests/server/edit-annotation.test.ts
+++ b/tests/server/edit-annotation.test.ts
@@ -133,6 +133,44 @@ describe("tandem_editAnnotation", () => {
     expect(after.content).toBe("Original");
   });
 
+  it("rejects edit on a dismissed annotation", async () => {
+    const ydoc = setupDoc("edit-4-dismissed", "Hello world");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const id = createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "Original");
+
+    const ann = map.get(id) as Annotation;
+    ydoc.transact(() => map.set(id, { ...ann, status: "dismissed" as const }), MCP_ORIGIN);
+
+    const result = await client.callTool({
+      name: "tandem_editAnnotation",
+      arguments: { id, content: "New text" },
+    });
+    const parsed = parseResult(result as any);
+    expect(parsed.error).toBe(true);
+    expect(parsed.code).toBe("ANNOTATION_RESOLVED");
+
+    const after = map.get(id) as Annotation;
+    expect(after.content).toBe("Original");
+  });
+
+  it("rejects edit on a user note (ADR-027 — notes are user-private)", async () => {
+    const ydoc = setupDoc("edit-4-note", "Hello world");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const id = createAnnotation(map, ydoc, "note", rangeOf(0, 5, ydoc), "private note");
+
+    const result = await client.callTool({
+      name: "tandem_editAnnotation",
+      arguments: { id, content: "Claude tries to edit a private note" },
+    });
+    const parsed = parseResult(result as any);
+    expect(parsed.error).toBe(true);
+    expect(parsed.code).toBe("INVALID_ARGUMENT");
+    expect(parsed.message).toMatch(/note/i);
+
+    const after = map.get(id) as Annotation;
+    expect(after.content).toBe("private note");
+  });
+
   it("rejects when no editable fields provided for non-suggestion", async () => {
     const ydoc = setupDoc("edit-5", "Hello world");
     const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
@@ -256,17 +294,5 @@ describe("tandem_comment via MCP", () => {
   });
 });
 
-describe("tandem_suggest deprecation stub", () => {
-  it("returns DEPRECATED error regardless of arguments", async () => {
-    setupDoc("suggest-deprecated-1", "Hello world");
-
-    const result = await client.callTool({
-      name: "tandem_suggest",
-      arguments: { from: 0, to: 5, newText: "Hi", reason: "brevity" },
-    });
-    const parsed = parseResult(result as any);
-    expect(parsed.error).toBe(true);
-    expect(parsed.code).toBe("DEPRECATED");
-    expect(parsed.message).toMatch(/deprecated/i);
-  });
-});
+// tandem_suggest deprecation: covered by mcp-tool-integration.test.ts's
+// parametrized it.each (which also pins the pushNotification side-effect).

--- a/tests/server/event-queue.test.ts
+++ b/tests/server/event-queue.test.ts
@@ -267,6 +267,79 @@ describe("origin filtering", () => {
     expect(events[0].type).toBe("annotation:dismissed");
     cleanup();
   });
+
+  // ADR-027: notes are user-private. The annotation:created skip on notes
+  // is pinned above; these extend the same guard to edit / accept / dismiss.
+  it("does NOT emit annotation:edited for user notes", () => {
+    const { events, cleanup } = collectEvents();
+    const map = doc.getMap(Y_MAP_ANNOTATIONS);
+
+    doc.transact(() => {
+      map.set("ann_note_edit", {
+        id: "ann_note_edit",
+        type: "note",
+        author: "user",
+        content: "before",
+        status: "pending",
+        textSnapshot: "PRIVATE",
+        range: { from: 0, to: 5 },
+        editedAt: 1000,
+      });
+    }, MCP_ORIGIN);
+
+    map.set("ann_note_edit", {
+      id: "ann_note_edit",
+      type: "note",
+      author: "user",
+      content: "after — must not leak",
+      status: "pending",
+      textSnapshot: "PRIVATE",
+      range: { from: 0, to: 5 },
+      editedAt: 2000,
+    });
+
+    expect(events).toHaveLength(0);
+    cleanup();
+  });
+
+  it("does NOT emit annotation:accepted or annotation:dismissed for user notes", () => {
+    const { events, cleanup } = collectEvents();
+    const map = doc.getMap(Y_MAP_ANNOTATIONS);
+
+    doc.transact(() => {
+      map.set("ann_note_status", {
+        id: "ann_note_status",
+        type: "note",
+        author: "user",
+        content: "private",
+        status: "pending",
+        textSnapshot: "PRIVATE",
+        range: { from: 0, to: 5 },
+      });
+    }, MCP_ORIGIN);
+
+    map.set("ann_note_status", {
+      id: "ann_note_status",
+      type: "note",
+      author: "user",
+      content: "private",
+      status: "accepted",
+      textSnapshot: "PRIVATE",
+      range: { from: 0, to: 5 },
+    });
+    map.set("ann_note_status", {
+      id: "ann_note_status",
+      type: "note",
+      author: "user",
+      content: "private",
+      status: "dismissed",
+      textSnapshot: "PRIVATE",
+      range: { from: 0, to: 5 },
+    });
+
+    expect(events).toHaveLength(0);
+    cleanup();
+  });
 });
 
 // --- Buffer eviction and replaySince ---

--- a/tests/server/event-queue.test.ts
+++ b/tests/server/event-queue.test.ts
@@ -302,7 +302,13 @@ describe("origin filtering", () => {
     cleanup();
   });
 
-  it("does NOT emit annotation:accepted or annotation:dismissed for user notes", () => {
+  // Synthetic `author: "claude", type: "note"` shape — structurally
+  // impossible in the live model, but we pin the observer's defense-in-depth
+  // type filter so a future code path that leaked a Claude-authored note
+  // (file-sync echo, schema drift) wouldn't surface status events. With
+  // `author: "user"` this assertion would pass via the author gate alone,
+  // which is misleading; using `author: "claude"` makes it load-bearing.
+  it("does NOT emit annotation:accepted or annotation:dismissed for claude-authored notes (synthetic)", () => {
     const { events, cleanup } = collectEvents();
     const map = doc.getMap(Y_MAP_ANNOTATIONS);
 
@@ -310,7 +316,7 @@ describe("origin filtering", () => {
       map.set("ann_note_status", {
         id: "ann_note_status",
         type: "note",
-        author: "user",
+        author: "claude",
         content: "private",
         status: "pending",
         textSnapshot: "PRIVATE",
@@ -321,7 +327,7 @@ describe("origin filtering", () => {
     map.set("ann_note_status", {
       id: "ann_note_status",
       type: "note",
-      author: "user",
+      author: "claude",
       content: "private",
       status: "accepted",
       textSnapshot: "PRIVATE",
@@ -330,7 +336,7 @@ describe("origin filtering", () => {
     map.set("ann_note_status", {
       id: "ann_note_status",
       type: "note",
-      author: "user",
+      author: "claude",
       content: "private",
       status: "dismissed",
       textSnapshot: "PRIVATE",

--- a/tests/server/integrations/existing-config.test.ts
+++ b/tests/server/integrations/existing-config.test.ts
@@ -167,14 +167,17 @@ describe("readExistingTandemEntries", () => {
     expect(cc?.tandemEntry).toBeUndefined();
   });
 
-  // Skipped: flakes on Windows dev machines where the real ~/.claude/ exists,
+  // Flakes on Windows dev machines where the real ~/.claude/ exists,
   // suggesting `homeOverride` isn't fully isolating from os.homedir() lookups.
-  // Passes in CI (clean home). See #736.
-  it.skip("returns no targets when no Claude install is detected (no .claude dir, no force)", async () => {
-    const installs = await readExistingTandemEntries({ homeOverride: tmpHome });
-    // No ~/.claude.json, no ~/.claude/, not forced — should be empty.
-    expect(installs).toEqual([]);
-  });
+  // Passes in CI (clean home) and on non-Windows. See #736.
+  it.skipIf(process.platform === "win32")(
+    "returns no targets when no Claude install is detected (no .claude dir, no force)",
+    async () => {
+      const installs = await readExistingTandemEntries({ homeOverride: tmpHome });
+      // No ~/.claude.json, no ~/.claude/, not forced — should be empty.
+      expect(installs).toEqual([]);
+    },
+  );
 
   it("extracts a tandem-channel entry even when no tandem entry is present", async () => {
     await fs.promises.writeFile(

--- a/tests/server/mcp-tool-integration.test.ts
+++ b/tests/server/mcp-tool-integration.test.ts
@@ -13,6 +13,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { registerAnnotationTools } from "../../src/server/mcp/annotations.js";
 import { registerAwarenessTools, resetInbox } from "../../src/server/mcp/awareness.js";
 import { populateYDoc, registerDocumentTools } from "../../src/server/mcp/document.js";
+import { extractMarkdown, extractText } from "../../src/server/mcp/document-model.js";
 import {
   addDoc,
   getOpenDocs,
@@ -83,6 +84,24 @@ describe("MCP tool integration — document tools", () => {
     expect(parsed.code).toBe("NO_DOCUMENT");
   });
 
+  // Critical Rule #5: tandem_getTextContent must use extractText, not
+  // extractMarkdown — the two produce different character offsets for the
+  // same Y.Doc, and Claude's annotation ranges are anchored to extractText's.
+  it("tandem_getTextContent matches extractText() (not extractMarkdown())", async () => {
+    const ydoc = setupDoc(
+      "mcp-doc-extract",
+      "# Heading One\n\nBody paragraph\n## Heading Two\nMore body",
+    );
+
+    const result = await client.callTool({ name: "tandem_getTextContent", arguments: {} });
+    const parsed = parseResult(result);
+    expect(parsed.error).toBe(false);
+    expect(parsed.data.text).toBe(extractText(ydoc));
+    expect(parsed.data.text).toContain("# Heading One");
+    expect(parsed.data.text).toContain("## Heading Two");
+    expect(parsed.data.text).not.toBe(extractMarkdown(ydoc));
+  });
+
   it("tandem_getOutline returns headings", async () => {
     setupDoc("mcp-doc-2", "# Title\n## Section\nContent");
 
@@ -140,6 +159,8 @@ describe("MCP tool integration — annotation tools", () => {
     ["tandem_highlight", {}, "mcp-ann-hl-noargs"],
     ["tandem_flag", { from: 0, to: 5 }, "mcp-ann-flag"],
     ["tandem_flag", {}, "mcp-ann-flag-noargs"],
+    ["tandem_suggest", { from: 0, to: 5, newText: "Hi", reason: "brevity" }, "mcp-ann-sug"],
+    ["tandem_suggest", {}, "mcp-ann-sug-noargs"],
   ] as const)("%s returns DEPRECATED error (args: %j)", async (toolName, args, docId) => {
     setupDoc(docId, "Hello world");
     resetNotifications();

--- a/tests/server/observers/factory.test.ts
+++ b/tests/server/observers/factory.test.ts
@@ -11,7 +11,12 @@
 import { describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import { makePerKeyChangeObserver } from "../../../src/server/events/observers/factory.js";
-import { FILE_SYNC_ORIGIN, MCP_ORIGIN } from "../../../src/shared/origins.js";
+import {
+  FILE_SYNC_ORIGIN,
+  INTERNAL_ORIGIN,
+  MCP_ORIGIN,
+  RELOAD_ORIGIN,
+} from "../../../src/shared/origins.js";
 
 // biome-ignore lint/suspicious/noExplicitAny: Y.Doc.transact's second arg is `unknown`.
 const rawTransact = (doc: Y.Doc, fn: () => void, origin?: unknown) =>
@@ -60,7 +65,7 @@ describe("makePerKeyChangeObserver — delete-path contract", () => {
     teardown();
   });
 
-  it("skips baseline channel-skip origins (MCP_ORIGIN, FILE_SYNC_ORIGIN)", () => {
+  it("skips every baseline channel-skip origin (ADR-031 table: mcp, file-sync, internal, reload)", () => {
     const doc = new Y.Doc();
     const map = doc.getMap<unknown>("samples");
     const derive = vi.fn();
@@ -71,18 +76,16 @@ describe("makePerKeyChangeObserver — delete-path contract", () => {
       pushEvent: () => {},
     });
 
-    rawTransact(
-      doc,
-      () => map.set("k", { id: "k", rev: 1, text: "x" } satisfies SamplePayload),
-      MCP_ORIGIN,
-    );
-    expect(derive).not.toHaveBeenCalled();
-
-    rawTransact(
-      doc,
-      () => map.set("k2", { id: "k2", rev: 1, text: "y" } satisfies SamplePayload),
-      FILE_SYNC_ORIGIN,
-    );
+    // ADR-031 observer-side complement to the predicate coverage in
+    // tests/shared/origins.test.ts.
+    const skipOrigins = [MCP_ORIGIN, FILE_SYNC_ORIGIN, INTERNAL_ORIGIN, RELOAD_ORIGIN] as const;
+    for (const [i, origin] of skipOrigins.entries()) {
+      rawTransact(
+        doc,
+        () => map.set(`k_${i}`, { id: `k_${i}`, rev: 1, text: "x" } satisfies SamplePayload),
+        origin,
+      );
+    }
     expect(derive).not.toHaveBeenCalled();
 
     teardown();

--- a/tests/server/reload.test.ts
+++ b/tests/server/reload.test.ts
@@ -12,6 +12,7 @@ import {
   anchoredRange,
   refreshAllRanges,
   refreshRange,
+  relPosToFlatOffset,
   validateRange,
 } from "../../src/server/positions.js";
 import { MCP_ORIGIN } from "../../src/shared/origins.js";
@@ -165,6 +166,14 @@ describe("reload: refreshRange dead relRange recovery", () => {
     expect(stored.range).toEqual({ from: 0, to: 5 });
     expect(stored.relRange).toBeDefined();
     expect(stored.relRange).not.toEqual(originalRelRange);
+    // Structural freshness check — independent of deep-equal serialization
+    // semantics. A re-anchored relRange must resolve to a valid flat offset
+    // in the new content (proves the strip-then-re-anchor path actually
+    // produced a usable RelativePosition rather than a dead reference).
+    expect(stored.relRange?.fromRel).toBeTruthy();
+    expect(stored.relRange?.toRel).toBeTruthy();
+    expect(relPosToFlatOffset(doc, stored.relRange!.fromRel)).toBe(0);
+    expect(relPosToFlatOffset(doc, stored.relRange!.toRel)).toBe(5);
   });
 });
 

--- a/tests/server/reload.test.ts
+++ b/tests/server/reload.test.ts
@@ -137,32 +137,34 @@ describe("reload: refreshRange dead relRange recovery", () => {
     doc = makeDoc("Hello world");
     const map = getAnnotationsMap(doc);
 
-    // Create annotation with CRDT-anchored range
     const result = anchoredRange(doc, toFlatOffset(0), toFlatOffset(5), "Hello");
     expect(result.ok).toBe(true);
     if (!result.ok) return;
+    expect("relRange" in result && result.relRange).toBeDefined();
+    const originalRelRange = "relRange" in result ? result.relRange : undefined;
 
     const ann = makeAnnotation({
       id: "ann_dead_rel",
       range: result.range,
-      relRange: "relRange" in result ? result.relRange : undefined,
+      relRange: originalRelRange,
       textSnapshot: "Hello",
     });
     doc.transact(() => map.set(ann.id, ann), MCP_ORIGIN);
 
-    // Replace content entirely — old CRDT items are garbage-collected
     doc.transact(() => {
       populateYDoc(doc, "Hello world reloaded");
     }, MCP_ORIGIN);
 
-    // refreshRange should detect dead relRange and attempt recovery
-    refreshRange(ann, doc, map);
-    const stored = map.get("ann_dead_rel") as Annotation;
-    expect(stored).toBeDefined();
+    // Preserving the dead relRange (vs. stripping/replacing it) blocks the
+    // lazy re-attachment recovery path — see CLAUDE.md "Dead CRDT
+    // RelativePositions must be stripped, not preserved".
+    const refreshResult = refreshRange(ann, doc, map);
+    expect(refreshResult.kind).toBe("repaired");
 
-    // The annotation should either have a fresh relRange or have relRange stripped
-    // Either outcome is acceptable — the annotation survives
-    expect(stored.range).toBeDefined();
+    const stored = map.get("ann_dead_rel") as Annotation;
+    expect(stored.range).toEqual({ from: 0, to: 5 });
+    expect(stored.relRange).toBeDefined();
+    expect(stored.relRange).not.toEqual(originalRelRange);
   });
 });
 

--- a/tests/server/replies-privacy-readwrite.test.ts
+++ b/tests/server/replies-privacy-readwrite.test.ts
@@ -8,17 +8,13 @@
  *   (c) reply on highlight — write returns INVALID_ARGUMENT; read drops any
  *                            rogue rows even if forced into the Y.Map.
  *   (d) orphan parent      — write returns NOT_FOUND when the parent has been
- *                            deleted (covered by existing NOT_FOUND path); the
- *                            channel observer skips emission when the parent
- *                            is absent.
+ *                            deleted (covered by existing NOT_FOUND path).
  *
- * Mirrors the channel-observer pattern in
- * `src/server/events/observers/replies.ts` and the read-path filter in
- * `src/server/mcp/annotations.ts#tandem_getAnnotations`.
+ * Channel-observer coverage for the same privacy guard lives in
+ * `tests/server/replies-privacy.test.ts` (note / highlight / orphan skip + the
+ * client-side `getVisibleReplies` mirror).
  */
 import { beforeEach, describe, expect, it } from "vitest";
-import { makeRepliesObserver } from "../../src/server/events/observers/replies.js";
-import type { TandemEvent } from "../../src/server/events/types.js";
 import {
   addReplyToAnnotation,
   collectRepliesForAnnotation,
@@ -141,63 +137,5 @@ describe("ADR-027 reply privacy (read path strips rogue rows)", () => {
     const ann = map.get(annId) as Annotation;
     const attached = ann.type === "comment" ? collectRepliesForAnnotation(repliesMap, annId) : [];
     expect(attached).toEqual([]);
-  });
-});
-
-describe("ADR-027 reply privacy (channel observer)", () => {
-  it("(d) skips emission when parent annotation is absent or not a comment", () => {
-    const ydoc = setupDoc("obs-1", "Hello world");
-    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
-    const commentId = createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "c");
-    const noteId = createAnnotation(map, ydoc, "note", rangeOf(6, 11, ydoc), "n");
-
-    const events: TandemEvent[] = [];
-    const off = makeRepliesObserver({
-      docName: "obs-1",
-      doc: ydoc,
-      pushEvent: (e) => events.push(e),
-    });
-
-    const repliesMap = ydoc.getMap(Y_MAP_ANNOTATION_REPLIES);
-
-    // (i) Reply on a note parent — observer must skip (parentAnn.type !== "comment").
-    const rogueNote: AnnotationReply = {
-      id: "rpl_obs_note",
-      annotationId: noteId,
-      author: "user",
-      text: "should be skipped",
-      timestamp: Date.now(),
-      rev: 1,
-    };
-    ydoc.transact(() => repliesMap.set(rogueNote.id, rogueNote));
-    expect(events).toHaveLength(0);
-
-    // (ii) Reply on an orphan parent (deleted) — observer must skip (!parentAnn).
-    const orphanId = "ann_orphan_does_not_exist";
-    const orphanReply: AnnotationReply = {
-      id: "rpl_obs_orphan",
-      annotationId: orphanId,
-      author: "user",
-      text: "should be skipped",
-      timestamp: Date.now(),
-      rev: 1,
-    };
-    ydoc.transact(() => repliesMap.set(orphanReply.id, orphanReply));
-    expect(events).toHaveLength(0);
-
-    // (iii) Reply on a comment parent — observer emits.
-    const goodReply: AnnotationReply = {
-      id: "rpl_obs_good",
-      annotationId: commentId,
-      author: "user",
-      text: "valid",
-      timestamp: Date.now(),
-      rev: 1,
-    };
-    ydoc.transact(() => repliesMap.set(goodReply.id, goodReply));
-    expect(events).toHaveLength(1);
-    expect(events[0].type).toBe("annotation:reply");
-
-    off();
   });
 });

--- a/tests/server/token-store.test.ts
+++ b/tests/server/token-store.test.ts
@@ -69,6 +69,19 @@ describe("token-store", () => {
       expect(read).toBe(token);
     });
 
+    // POSIX file permissions are the only access-control surface for the
+    // auth-token file on a shared host.
+    it.skipIf(process.platform === "win32")(
+      "writes the token file with mode 0o600 (owner-only read/write)",
+      async () => {
+        const token = crypto.randomBytes(32).toString("base64url");
+        await writeTokenToFile(token);
+        const stat = await fs.promises.stat(getTokenFilePath());
+
+        expect(stat.mode & 0o777).toBe(0o600);
+      },
+    );
+
     it("creates parent directories if missing", async () => {
       const originalTempDir = tempDir;
       // Re-route getTokenFilePath() to a deeply nested path that doesn't exist yet.


### PR DESCRIPTION
## Summary

Comprehensive audit of the 211-test-file repo (2477 tests baseline). The audit was planned, reviewed by four adversarial agents (security, CRDT, annotation-lifecycle, generalist), and the resulting fixes are scoped to a single PR.

The audit surfaced one real bug and several invariants that were structurally enforced but not pinned by any test. Three additional source fixes ride along: the Toolbar `coordsAtPos` CI flake, the keychain `pathFor` namespace-separation bug, and (in the latest push) an 18-test E2E adapt to Wave M's two-mode popup surface.

## Real fixes

1. **Privacy bug (ADR-027) in `tandem_editAnnotation`** — the handler did not gate on note type, so a Claude-initiated MCP call could mutate a user-private note. Added a guard returning `INVALID_ARGUMENT` before the existing status check, plus a regression test (`edit-annotation.test.ts`). Single source-file change: `src/server/mcp/annotations.ts`.

2. **Weak CRDT assertion** — `reload.test.ts` accepted "either outcome" for the dead-`relRange` recovery path. A regression that *preserved* a dead `relRange` (the documented anti-pattern in CLAUDE.md) would have passed. Tightened to assert `refreshResult.kind === "repaired"`, that the stored `relRange` is replaced, and (post-review) that the re-anchored `relRange` resolves back to the expected flat offsets — structural freshness check independent of serialization byte equality.

3. **Asymmetric deprecation surface** — `tandem_suggest`'s standalone test bypassed the `pushNotification` user-surface assertion that `tandem_highlight` / `tandem_flag` already enforce. Collapsed into the parametrized `it.each` in `mcp-tool-integration.test.ts` and made the source schema fully optional to match the other two deprecated stubs.

## Additional source fixes (bundled, not part of the test audit)

4. **`Toolbar.svelte` — CI flake fix + safety follow-up.** `coordsAtPos` was throwing on slow CI runs because `selectionUpdate` fires before the PM view's measurement pass completes; the popup permanently hid until another selection event arrived. Initial fix retried via `requestAnimationFrame`. **Post-review:** bounded the retry at 3 attempts with a reset-on-success counter (guards against a 60Hz infinite loop if the view stays unmeasured — e.g. editor mounted in a detached / `display:none` subtree), and the `$effect` cleanup now cancels any pending retry frame so a queued retry can't fire against a torn-down editor. Also added a one-paint grace period before arming the scroll-dismiss listener — PM's auto-scroll-into-view bubbled to document-level capture and was firing `dismissPopup()` before the user could interact with the freshly-mounted popup.

5. **`keychain-backend.ts` — `pathFor` forwarding (Models registry namespace separation).** `createDefaultKeychainBackend` was dropping the `pathFor` option, so any caller relying on the default factory routed all writes to `/api/integrations/secrets/...` regardless of intent — meaning Models registry writes landed under service `tandem-integrations` instead of `tandem-models`. Server-side `Keychain` instances are scoped per-route (`KEYCHAIN_SERVICE_MODELS` vs `KEYCHAIN_SERVICE`), so the keychain entries themselves never commingled — but the namespace-pollution bug surfaced as 503 `KEYCHAIN_UNAVAILABLE` in CI when the wrong route's mock didn't fire. Paired with a new client test (`tests/client/keychain-backend.test.ts`).

6. **18 E2E tests adapted to Wave M's two-mode popup (bonus — surfaced when CI failed on this PR).** Wave M (PR #776) split the selection popup into an **action surface** (mounts on selection: formatting + highlight swatches + `popup-annotate-btn`) and an **annotate mode** (mounts after clicking Annotate: `popup-annotation-input` textarea + submit buttons). 18 references to `popup-annotation-input` across 5 spec files were left over from the pre-Wave-M unified surface and broke on master immediately after f66f8f5 merged. Symptom looked like the same CI flake fixes 4 above tried to paper over, but the actual root cause was test-vs-code drift. Added a small `openAnnotatePopup(page)` helper in `tests/e2e/helpers.ts`; tests that interact with the textarea call it, tests that only need to verify the popup mounted now check `popup-annotate-btn` instead. Also fixed `settings-and-filters.spec.ts:359` which double-clicked `soloBtn` to switch back to Tandem — Wave M's two-button toggle sets the mode unconditionally, so a second click no-ops.

## Coverage additions

Regression guards for invariants the audit confirmed were structurally enforced but unpinned:

- **`event-queue.test.ts`** — notes skipped for `annotation:edited` / `annotation:accepted` / `annotation:dismissed` (only `annotation:created` was pinned). **Post-review:** the accepted/dismissed test was passing via the `author === "claude"` gate alone (misleading — `author: "user", type: "note"` filters by author, not type). Switched to a synthetic `author: "claude", type: "note"` shape and added a matching defense-in-depth `type === "note"` filter at the top of the Claude `update` branch in `observers/annotations.ts`, mirroring the existing guard in the `add` branch. The test is now load-bearing.
- **`edit-annotation.test.ts`** — edits rejected on dismissed annotations (was only tested for `accepted`) and on notes (ADR-027). **Post-review:** added a guard-order regression — a non-pending note must return `INVALID_ARGUMENT`, not `ANNOTATION_RESOLVED`. Pins that the note-type guard runs above the status check; reordering would leak the note's existence to Claude.
- **`observers/factory.test.ts`** — per-observer skip for the full ADR-031 origin set. `INTERNAL_ORIGIN` and `RELOAD_ORIGIN` were uncovered at the observer level.
- **`annotation-lifecycle.test.ts`** — parametrized the `MCP_ORIGIN` tag assertion across `acceptPending` + `dismissPending`.
- **`token-store.test.ts`** — auth-token file written with mode `0o600`. The LAN auth token is the highest-value secret on disk and had no permission test.
- **`mcp-tool-integration.test.ts`** — `tandem_getTextContent` returns `extractText()` output, not `extractMarkdown()` (Critical Rule #5). A refactor swapping the call site would silently shift every annotation offset Claude computes.

## Cleanup

- Deleted duplicated channel-observer block from `replies-privacy-readwrite.test.ts` (already covered by `replies-privacy.test.ts`, which additionally tests highlight parents and the client-side `getVisibleReplies` mirror).
- Converted the lone unconditional `.skip` in `integrations/existing-config.test.ts` to `skipIf(win32)` so the test actually runs on Linux + macOS instead of being permanently disabled.

## Numbers

| Metric | Before | After |
|---|---|---|
| vitest files passing | 191 | 192 |
| vitest cases passing | 2477 | 2487 |
| vitest cases skipped | 13 | 12 |
| vitest runtime | ~44s | ~35s |
| Playwright cases passing | 127 | 146 |
| Playwright cases failing | 18 | 0 |

Net: +10 vitest cases, −1 permanently-disabled, +19 Playwright cases passing (the 18 Wave M regressions fixed plus the previously-flaky Ctrl+N test now stable).

## Verification

- [x] `npm test` — 2487 / 12 skipped, all pass
- [x] `npm run typecheck` — clean
- [x] `npm run audit:origins` — clean
- [x] `npm run audit:ymap-keys` — clean
- [x] `npm run check:tokens` — clean
- [x] `npm run test:e2e` — 146 / 1 skipped, all pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (pre-push) — all pass

## Test plan

- [ ] CI green on all matrix builds
- [ ] Manual verification: the new `tandem_editAnnotation` guard rejects edits on notes when invoked through a real Claude session

## Follow-ups (intentionally out of scope)

- Coordinate round-trip tests for `blockquote` and `hardBreak` in `tests/client/coordinate-conversion.test.ts` — that test uses pure ProseMirror mocks, so adding mock variants wouldn't catch real-world regressions. Better addressed by a real-PM-harness rewrite in a future PR.
- Header-smuggling tests in `api-middleware.test.ts` (array Host header, CRLF, NUL) — the TypeScript signature on `isHostAllowed` already constrains the input, making these low-yield.
- Adversarial reviewer flagged 14 ADRs with no direct test mapping — most are architectural narratives without enforceable contracts, but a future audit could pin specific ones.

https://claude.ai/code/session_01G9V8HzXSqJyKuHNPD2LEyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9V8HzXSqJyKuHNPD2LEyA)_
