### PR TITLE
test: pin schema-version assertions to CURRENT_SCHEMA_VERSION

### DIFF
--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -275,7 +275,7 @@ function parseModels(raw: unknown): ModelRegistryEntry[] {
  *   via the transient `_legacyApiKey` field for the in-UI migration prompt.
  *   This is the load-bearing #659 step.
  */
-const CURRENT_SCHEMA_VERSION = 7;
+export const CURRENT_SCHEMA_VERSION = 7;
 
 /**
  * Validate + clamp every known field on a parsed settings blob.

--- a/tests/client/use-tandem-settings-migration.test.ts
+++ b/tests/client/use-tandem-settings-migration.test.ts
@@ -1,17 +1,10 @@
 /**
- * Migration chain coverage for `loadSettings` (#659 Wave 2 PR 8a).
+ * Migration chain coverage for `loadSettings`.
  *
- * The existing `useTandemSettings.test.ts` covers the v1→v2 migration and
- * the v2 leftSlot.kind→leftRailTabs fallback. This file pins down:
- *
- *   1. v1→v3: a v1 blob (with `layout`/`panelHidden`) walks the full
- *      chain in one load and ends at schemaVersion=3 with models=[].
- *   2. v2→v3: a v2 blob gets `models: []` added without touching other fields.
- *   3. v3 forward-compat: an on-disk `schemaVersion: 99` blob loads
- *      defensively as `_readOnly: true`; subsequent `updateSettings` calls
- *      are no-ops (verified via the createTandemSettings facade).
- *   4. v3 forward-compat preserves unknown future fields so a user who
- *      bounces back to the newer client doesn't see a regression.
+ * Pins the full v1→current migration chain: panel layout coercions (v1→v2),
+ * models array addition (v2→v3), rail-tab teardown (v4→v5), wizard flag
+ * removal (v5→v6), defaultModelId introduction (v6→v7), and any subsequent
+ * migrations. Forward-compat (schemaVersion: 99) is also covered.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -53,7 +46,7 @@ describe("loadSettings — migration chain", () => {
     store.set(TANDEM_SETTINGS_KEY, JSON.stringify(partial));
   }
 
-  it("v1 blob (layout=three-panel) climbs to v6 with models=[] and rail-tab fields stripped", () => {
+  it("v1 blob (layout=three-panel) migrates fully with models=[] and rail-tab fields stripped", () => {
     writeRaw({
       schemaVersion: 1,
       layout: "three-panel",
@@ -68,7 +61,7 @@ describe("loadSettings — migration chain", () => {
     expect(s.models).toEqual([]);
   });
 
-  it("v1 blob (panelHidden=true) climbs to v6 with both panels hidden", () => {
+  it("v1 blob (panelHidden=true) migrates fully with both panels hidden", () => {
     writeRaw({ schemaVersion: 1, panelHidden: true });
     const s = loadSettings();
     expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
@@ -195,11 +188,10 @@ describe("loadSettings — migration chain", () => {
     expect(s._readOnly).toBeUndefined();
   });
 
-  it("v2 seed with rail-tabs climbs to v6 with both fields absent (realistic prod-upgrade path)", () => {
+  it("v2 seed with rail-tabs migrates fully with both fields absent (realistic prod-upgrade path)", () => {
     // A v2 blob from before Wave D where the user had Chat on the left
-    // rail. After climbing v2→v3 (models added) → v3→v4 (no-op) →
-    // v4→v5 (rail-tab fields stripped) → v5→v6 (showIntegrationWizard
-    // stripped) the typed return must carry none of those names.
+    // rail. After the full migration chain the typed return must carry
+    // none of those names.
     writeRaw({
       schemaVersion: 2,
       leftRailTabs: ["chat", "outline"],
@@ -214,11 +206,11 @@ describe("loadSettings — migration chain", () => {
     expect(s._readOnly).toBeUndefined();
   });
 
-  // v3 sources climb the chain to v6 in memory. The v3→v4 step's displaced-
-  // tab plumbing is no longer observable to consumers because v4→v5 strips
-  // the rail-tab fields entirely. These cases pin down "no crash on weird
-  // v3 input + final state is rail-tab-free at v6."
-  it("v3 with displaced left tabs climbs to v6 with rail-tab fields stripped", () => {
+  // v3 sources climb the full chain. The v3→v4 step's displaced-tab plumbing
+  // is no longer observable to consumers because v4→v5 strips the rail-tab
+  // fields entirely. These cases pin down "no crash on weird v3 input + final
+  // state is rail-tab-free."
+  it("v3 with displaced left tabs migrates fully with rail-tab fields stripped", () => {
     writeRaw({
       schemaVersion: 3,
       leftRailTabs: ["chat", "outline"],
@@ -231,7 +223,7 @@ describe("loadSettings — migration chain", () => {
     expect(s.rightRailTabs).toBeUndefined();
   });
 
-  it("v3 with corrupt rightRailTabs climbs to v6 without crashing", () => {
+  it("v3 with corrupt rightRailTabs migrates fully without crashing", () => {
     writeRaw({
       schemaVersion: 3,
       leftRailTabs: ["chat", "outline"],
@@ -244,9 +236,9 @@ describe("loadSettings — migration chain", () => {
     expect(s.rightRailTabs).toBeUndefined();
   });
 
-  it("v4 blobs climb to v6 stripping rail-tab fields", () => {
+  it("v4 blobs migrate fully stripping rail-tab fields", () => {
     writeRaw({
-      schemaVersion: 5,
+      schemaVersion: 4,
       leftRailTabs: ["outline"],
       rightRailTabs: ["annotations", "chat"],
       models: [],
@@ -324,7 +316,7 @@ describe("loadSettings — migration chain", () => {
     expect(s.showIntegrationWizard).toBeUndefined();
   });
 
-  it("v1 blob with showIntegrationWizard climbs to v6 stripping it", () => {
+  it("v1 blob with showIntegrationWizard migrates fully stripping it", () => {
     writeRaw({
       schemaVersion: 1,
       layout: "tabbed",
@@ -335,7 +327,7 @@ describe("loadSettings — migration chain", () => {
     expect(s.showIntegrationWizard).toBeUndefined();
   });
 
-  it("v2 blob with showIntegrationWizard climbs to v6 stripping it", () => {
+  it("v2 blob with showIntegrationWizard migrates fully stripping it", () => {
     writeRaw({
       schemaVersion: 2,
       leftPanelVisible: true,
@@ -346,7 +338,7 @@ describe("loadSettings — migration chain", () => {
     expect(s.showIntegrationWizard).toBeUndefined();
   });
 
-  it("v3 blob with showIntegrationWizard climbs to v6 stripping it", () => {
+  it("v3 blob with showIntegrationWizard migrates fully stripping it", () => {
     writeRaw({
       schemaVersion: 3,
       models: [],

--- a/tests/client/use-tandem-settings-migration.test.ts
+++ b/tests/client/use-tandem-settings-migration.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadSettings } from "../../src/client/hooks/useTandemSettings.js";
+import { CURRENT_SCHEMA_VERSION, loadSettings } from "../../src/client/hooks/useTandemSettings.js";
 import { TANDEM_SETTINGS_KEY } from "../../src/shared/constants.js";
 
 function installLocalStorageStub() {
@@ -61,7 +61,7 @@ describe("loadSettings — migration chain", () => {
       textSize: "l",
     });
     const s = loadSettings();
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.leftPanelVisible).toBe(true);
     expect(s.rightPanelVisible).toBe(true);
     expect(s.textSize).toBe("l");
@@ -71,7 +71,7 @@ describe("loadSettings — migration chain", () => {
   it("v1 blob (panelHidden=true) climbs to v6 with both panels hidden", () => {
     writeRaw({ schemaVersion: 1, panelHidden: true });
     const s = loadSettings();
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.leftPanelVisible).toBe(false);
     expect(s.rightPanelVisible).toBe(false);
     expect(s.models).toEqual([]);
@@ -86,7 +86,7 @@ describe("loadSettings — migration chain", () => {
       theme: "dark",
     });
     const s = loadSettings();
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.leftPanelVisible).toBe(true);
     expect(s.rightPanelVisible).toBe(false);
     expect(s.editorWidthPercent).toBe(80);
@@ -187,7 +187,7 @@ describe("loadSettings — migration chain", () => {
       models: [],
     });
     const s = loadSettings() as Record<string, unknown>;
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.theme).toBe("dark");
     // The migration chain's `=== N` gates are exclusive — re-running on
     // an already-v6 blob is a no-op. _readOnly is reserved for the v99+
@@ -208,7 +208,7 @@ describe("loadSettings — migration chain", () => {
       rightPanelVisible: true,
     });
     const s = loadSettings() as Record<string, unknown>;
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.leftRailTabs).toBeUndefined();
     expect(s.rightRailTabs).toBeUndefined();
     expect(s._readOnly).toBeUndefined();
@@ -226,7 +226,7 @@ describe("loadSettings — migration chain", () => {
       models: [],
     });
     const s = loadSettings();
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.leftRailTabs).toBeUndefined();
     expect(s.rightRailTabs).toBeUndefined();
   });
@@ -239,7 +239,7 @@ describe("loadSettings — migration chain", () => {
       models: [],
     });
     const s = loadSettings();
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.leftRailTabs).toBeUndefined();
     expect(s.rightRailTabs).toBeUndefined();
   });
@@ -253,7 +253,7 @@ describe("loadSettings — migration chain", () => {
       theme: "dark",
     });
     const s = loadSettings();
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.leftRailTabs).toBeUndefined();
     expect(s.rightRailTabs).toBeUndefined();
     expect(s.theme).toBe("dark");
@@ -306,7 +306,7 @@ describe("loadSettings — migration chain", () => {
       theme: "dark",
     });
     const s = loadSettings() as Record<string, unknown>;
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.showIntegrationWizard).toBeUndefined();
     expect(s.theme).toBe("dark");
   });
@@ -331,7 +331,7 @@ describe("loadSettings — migration chain", () => {
       showIntegrationWizard: true,
     });
     const s = loadSettings() as Record<string, unknown>;
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.showIntegrationWizard).toBeUndefined();
   });
 
@@ -342,7 +342,7 @@ describe("loadSettings — migration chain", () => {
       showIntegrationWizard: true,
     });
     const s = loadSettings() as Record<string, unknown>;
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.showIntegrationWizard).toBeUndefined();
   });
 
@@ -353,7 +353,7 @@ describe("loadSettings — migration chain", () => {
       showIntegrationWizard: true,
     });
     const s = loadSettings() as Record<string, unknown>;
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.showIntegrationWizard).toBeUndefined();
   });
 });

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  CURRENT_SCHEMA_VERSION,
   loadSettings,
   mergeAndClampSettings,
   type TandemSettings,
@@ -54,7 +55,7 @@ describe("loadSettings — selectionDwellMs clamping", () => {
     const settings = loadSettings();
     expect(settings.leftPanelVisible).toBe(false);
     expect(settings.rightPanelVisible).toBe(true);
-    expect(settings.schemaVersion).toBe(7);
+    expect(settings.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(settings.editorWidthPercent).toBe(100);
     expect(settings.selectionDwellMs).toBe(SELECTION_DWELL_DEFAULT_MS);
   });
@@ -536,7 +537,7 @@ describe("v4→v5 picker teardown migration", () => {
       rightRailTabs: ["annotations", "chat"],
     });
     const s = loadSettings() as Record<string, unknown>;
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.leftRailTabs).toBeUndefined();
     expect(s.rightRailTabs).toBeUndefined();
   });
@@ -548,7 +549,7 @@ describe("v4→v5 picker teardown migration", () => {
       rightRailTabs: ["annotations"],
     });
     const s = loadSettings() as Record<string, unknown>;
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.leftRailTabs).toBeUndefined();
     expect(s.rightRailTabs).toBeUndefined();
   });
@@ -559,12 +560,12 @@ describe("v4→v5 picker teardown migration", () => {
       showIntegrationWizard: true,
     });
     const s = loadSettings() as Record<string, unknown>;
-    expect(s.schemaVersion).toBe(7);
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(s.showIntegrationWizard).toBeUndefined();
   });
 
   it("default load reports schemaVersion 6", () => {
-    expect(loadSettings().schemaVersion).toBe(7);
+    expect(loadSettings().schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
   });
 });
 

--- a/tests/e2e/settings-models.spec.ts
+++ b/tests/e2e/settings-models.spec.ts
@@ -336,7 +336,7 @@ test("legacy plaintext key migration banner — appears, migrates, then disappea
   expect(JSON.stringify(persisted)).not.toContain(LEGACY_KEY);
 });
 
-test("v2 → v7 migration boot — Models tab renders with empty list, settings survive", async ({
+test("v2 → current schema migration boot — Models tab renders with empty list, settings survive", async ({
   page,
 }) => {
   await page.evaluate((key) => {

--- a/tests/e2e/settings-models.spec.ts
+++ b/tests/e2e/settings-models.spec.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";
+import { CURRENT_SCHEMA_VERSION } from "../../src/client/hooks/useTandemSettings";
 import { TANDEM_SETTINGS_KEY } from "../../src/shared/constants";
 import { cleanupAllOpenDocuments, McpTestClient, nextFrames } from "./helpers";
 
@@ -328,7 +329,7 @@ test("legacy plaintext key migration banner — appears, migrates, then disappea
     const raw = localStorage.getItem(key);
     return raw ? JSON.parse(raw) : null;
   }, TANDEM_SETTINGS_KEY);
-  expect(persisted?.schemaVersion).toBe(7);
+  expect(persisted?.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
   expect(persisted?.models?.[0]?.apiKey).toBeUndefined();
   expect(persisted?.models?.[0]?.apiKeyRef).toBeDefined();
   // The plaintext must NEVER appear in localStorage post-migration.
@@ -369,7 +370,7 @@ test("v2 → v7 migration boot — Models tab renders with empty list, settings 
   }, TANDEM_SETTINGS_KEY);
   expect(settings?.theme).toBe("dark");
   expect(settings?.textSize).toBe("l");
-  expect(settings?.schemaVersion).toBe(7);
+  expect(settings?.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
   expect(settings?.models?.length).toBe(1);
   expect(settings?.models?.[0]?.displayName).toBe("Migration sentinel");
   // v7 introduces `defaultModelId` initialized to null on the migration.


### PR DESCRIPTION
## Summary
- Promote `CURRENT_SCHEMA_VERSION` in `src/client/hooks/useTandemSettings.ts` from module-private to named export.
- Substitute hardcoded `7` literals in `tests/client/use-tandem-settings-migration.test.ts`, `tests/client/useTandemSettings.test.ts`, and `tests/e2e/settings-models.spec.ts` for the constant.
- Bumping the schema version now requires editing one place (the const) instead of ~20 scattered assertions.

Intentional literals kept as-is:
- `99` (forward-compat sentinel for `_readOnly` testing).
- `3` in `tests/server/integrations/migrations.test.ts` (pins a specific v1→v3 migration target, not a moving "current").

Closes #770. Closes #766.

## Test plan
- [x] `npx vitest run tests/client/use-tandem-settings-migration.test.ts tests/client/useTandemSettings.test.ts` — 97 passed.
- [x] `npm run typecheck` — clean.
- [ ] CI green (Playwright suite covers `settings-models.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)