### PR TITLE
refactor(client): extract THEME_OPTIONS from TitleBar

### DIFF
--- a/src/client/shell/TitleBar.svelte
+++ b/src/client/shell/TitleBar.svelte
@@ -6,13 +6,7 @@ import type { TandemMode } from "../../shared/types";
 import ModeToggle from "../editor/toolbar/ModeToggle.svelte";
 import { type ThemePreference } from "../hooks/useTandemSettings.svelte";
 import { onOutsideEvent } from "../utils/dismiss-outside";
-
-const THEME_OPTIONS = [
-  { value: "system", label: "Match system" },
-  { value: "light", label: "Light" },
-  { value: "dark", label: "Dark" },
-  { value: "warm", label: "Warm" },
-] as const satisfies readonly { value: ThemePreference; label: string }[];
+import { THEME_OPTIONS } from "./theme-options";
 
 interface Props {
   /**

--- a/src/client/shell/theme-options.ts
+++ b/src/client/shell/theme-options.ts
@@ -1,19 +1,8 @@
 import type { ThemePreference } from "../hooks/useTandemSettings.svelte";
 
-/**
- * Canonical theme dropdown contents for the titlebar gear menu.
- *
- * The order matches the dropdown's intent (default-first), which differs
- * from `AppearanceSettings`' button row (light-first). Surfaces with a
- * different ordering or label policy should still import `THEME_VALUES`
- * for the underlying `ThemePreference[]` so the list of valid themes
- * stays single-source.
- */
 export const THEME_OPTIONS = [
   { value: "system", label: "Match system" },
   { value: "light", label: "Light" },
   { value: "dark", label: "Dark" },
   { value: "warm", label: "Warm" },
 ] as const satisfies readonly { value: ThemePreference; label: string }[];
-
-export const THEME_VALUES: readonly ThemePreference[] = THEME_OPTIONS.map((o) => o.value);

--- a/src/client/shell/theme-options.ts
+++ b/src/client/shell/theme-options.ts
@@ -1,0 +1,19 @@
+import type { ThemePreference } from "../hooks/useTandemSettings.svelte";
+
+/**
+ * Canonical theme dropdown contents for the titlebar gear menu.
+ *
+ * The order matches the dropdown's intent (default-first), which differs
+ * from `AppearanceSettings`' button row (light-first). Surfaces with a
+ * different ordering or label policy should still import `THEME_VALUES`
+ * for the underlying `ThemePreference[]` so the list of valid themes
+ * stays single-source.
+ */
+export const THEME_OPTIONS = [
+  { value: "system", label: "Match system" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "warm", label: "Warm" },
+] as const satisfies readonly { value: ThemePreference; label: string }[];
+
+export const THEME_VALUES: readonly ThemePreference[] = THEME_OPTIONS.map((o) => o.value);


### PR DESCRIPTION
## Summary
- Move `THEME_OPTIONS` from inline in `TitleBar.svelte` to a new module `src/client/shell/theme-options.ts`.
- Also exports `THEME_VALUES`, the bare `ThemePreference[]` order, for surfaces that just need the value list.
- `AppearanceSettings` is intentionally left untouched — its button ordering and labels differ from the titlebar dropdown, so folding it into the same constant would be a UX change, not a refactor.

Closes #781.

## Test plan
- [x] `npm run typecheck` — clean.
- [ ] CI passes existing tests (no behavior change; titlebar dropdown renders identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)