### PR TITLE
feat(client): toggle for inline annotation decorations

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -461,9 +461,7 @@ $effect(() => {
   });
 });
 
-// #596: mirror the authorship pattern for annotation-decoration visibility.
-// Plugin reads initial state from localStorage at construction; this effect
-// only dispatches subsequent flips.
+// #596: mirrors the authorship toggle pattern; plugin reads localStorage at init, this handles flips.
 let lastDispatchedDecorations: boolean | null = null;
 $effect(() => {
   const ed = editor;

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -30,6 +30,7 @@ import ToastContainer from "./components/ToastContainer.svelte";
 import UpdaterBanner from "./components/UpdaterBanner.svelte";
 import { isTauriRuntime } from "./cowork/cowork-helpers";
 import Editor from "./editor/Editor.svelte";
+import { annotationPluginKey } from "./editor/extensions/annotation";
 import { authorshipPluginKey } from "./editor/extensions/authorship";
 import { getFindState } from "./editor/extensions/find-replace.js";
 import FindReplaceBar from "./editor/find-replace/FindReplaceBar.svelte";
@@ -456,6 +457,27 @@ $effect(() => {
   if (firstRun) return;
   untrack(() => {
     const tr = ed.state.tr.setMeta(authorshipPluginKey, { type: "toggle", visible });
+    ed.view.dispatch(tr);
+  });
+});
+
+// #596: mirror the authorship pattern for annotation-decoration visibility.
+// Plugin reads initial state from localStorage at construction; this effect
+// only dispatches subsequent flips.
+let lastDispatchedDecorations: boolean | null = null;
+$effect(() => {
+  const ed = editor;
+  if (!ed) return;
+  const visible = settingsState.settings.showAnnotationDecorations;
+  if (lastDispatchedDecorations === visible) return;
+  const firstRun = lastDispatchedDecorations === null;
+  lastDispatchedDecorations = visible;
+  if (firstRun) return;
+  untrack(() => {
+    const tr = ed.state.tr.setMeta(annotationPluginKey, {
+      type: "toggle-decorations",
+      visible,
+    });
     ed.view.dispatch(tr);
   });
 });

--- a/src/client/components/AppearanceSettings.svelte
+++ b/src/client/components/AppearanceSettings.svelte
@@ -224,7 +224,7 @@ const densityRg = createRadioGroup<Density>(
 <div>
   <label
     data-testid="annotation-decorations-toggle"
-    style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+    style="display: flex; align-items: center; gap: var(--tandem-space-2); cursor: pointer; font-size: var(--tandem-text-sm); color: var(--tandem-fg); min-height: var(--tandem-space-5);"
   >
     <input
       type="checkbox"
@@ -238,8 +238,8 @@ const densityRg = createRadioGroup<Density>(
   <div
     style="font-size: var(--tandem-text-2xs); color: var(--tandem-fg-subtle); margin-top: var(--tandem-space-1);"
   >
-    Turn off to hide inline highlight, comment, and suggestion marks in the editor. Annotation
-    cards in the side panel stay visible.
+    Turn off to hide inline highlight, note, comment, and suggestion marks in the editor.
+    Annotation cards in the side panel stay visible.
   </div>
 </div>
 
@@ -247,7 +247,7 @@ const densityRg = createRadioGroup<Density>(
 <div>
   <label
     data-testid="reduce-motion-toggle"
-    style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+    style="display: flex; align-items: center; gap: var(--tandem-space-2); cursor: pointer; font-size: var(--tandem-text-sm); color: var(--tandem-fg); min-height: var(--tandem-space-5);"
   >
     <input
       type="checkbox"

--- a/src/client/components/AppearanceSettings.svelte
+++ b/src/client/components/AppearanceSettings.svelte
@@ -220,6 +220,29 @@ const densityRg = createRadioGroup<Density>(
   </div>
 </div>
 
+<!-- Annotation Decorations (#596) -->
+<div>
+  <label
+    data-testid="annotation-decorations-toggle"
+    style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"
+  >
+    <input
+      type="checkbox"
+      checked={settings.showAnnotationDecorations}
+      onchange={(e) =>
+        onUpdate({ showAnnotationDecorations: (e.target as HTMLInputElement).checked })}
+      style="accent-color: var(--tandem-accent);"
+    />
+    <span>Show annotation marks in editor</span>
+  </label>
+  <div
+    style="font-size: var(--tandem-text-2xs); color: var(--tandem-fg-subtle); margin-top: var(--tandem-space-1);"
+  >
+    Turn off to hide inline highlight, comment, and suggestion marks in the editor. Annotation
+    cards in the side panel stay visible.
+  </div>
+</div>
+
 <!-- Reduce Motion -->
 <div>
   <label

--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -4,6 +4,7 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import * as Y from "yjs";
 import {
+  ANNOTATION_DECORATIONS_TOGGLE_KEY,
   HIGHLIGHT_COLOR_VARS,
   normalizeHighlightColor,
   Y_MAP_ANNOTATIONS,
@@ -12,7 +13,18 @@ import { sanitizeAnnotation } from "../../../shared/sanitize";
 import type { Annotation } from "../../../shared/types";
 import { annotationToPmRange } from "../../positions";
 
-const annotationPluginKey = new PluginKey("tandemAnnotations");
+export const annotationPluginKey = new PluginKey("tandemAnnotations");
+
+/**
+ * Meta payload to toggle inline annotation decorations on/off (#596).
+ * `App.svelte` dispatches this when the `showAnnotationDecorations`
+ * setting flips; the plugin's apply() handler rebuilds (or empties)
+ * the decoration set accordingly.
+ */
+export interface AnnotationToggleMeta {
+  type: "toggle-decorations";
+  visible: boolean;
+}
 
 /**
  * Build a DecorationSet from all pending annotations in the Y.Map.
@@ -142,18 +154,38 @@ export const AnnotationExtension = Extension.create<{ ydoc: Y.Doc | null }>({
     let hasAnnotations = annotationsMap.size > 0;
     let recoveryAttempted = false;
 
+    // #596: localStorage mirror lets the plugin read the setting at init
+    // without coupling to the Svelte settings store. Default `true` (show
+    // marks) when unset, matching the schema default.
+    let visible = true;
+    try {
+      const stored = localStorage.getItem(ANNOTATION_DECORATIONS_TOGGLE_KEY);
+      if (stored === "false") visible = false;
+    } catch (err) {
+      console.warn("[annotation] localStorage unavailable", err);
+    }
+
     return [
       new Plugin({
         key: annotationPluginKey,
 
         state: {
           init(_, state) {
-            return buildDecorations(state.doc, annotationsMap, ydoc);
+            return visible
+              ? buildDecorations(state.doc, annotationsMap, ydoc)
+              : DecorationSet.empty;
           },
           apply(tr, decorationSet, _oldState, newState) {
-            if (tr.getMeta(annotationPluginKey)) {
-              return buildDecorations(newState.doc, annotationsMap, ydoc);
+            const meta = tr.getMeta(annotationPluginKey) as AnnotationToggleMeta | true | undefined;
+            if (meta && typeof meta === "object" && meta.type === "toggle-decorations") {
+              visible = meta.visible;
             }
+            if (meta) {
+              return visible
+                ? buildDecorations(newState.doc, annotationsMap, ydoc)
+                : DecorationSet.empty;
+            }
+            if (!visible) return DecorationSet.empty;
             if (tr.docChanged) {
               // Y.Map observer can fire before y-prosemirror populates the doc,
               // leaving decorationSet empty despite annotations in the map.

--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -15,12 +15,7 @@ import { annotationToPmRange } from "../../positions";
 
 export const annotationPluginKey = new PluginKey("tandemAnnotations");
 
-/**
- * Meta payload to toggle inline annotation decorations on/off (#596).
- * `App.svelte` dispatches this when the `showAnnotationDecorations`
- * setting flips; the plugin's apply() handler rebuilds (or empties)
- * the decoration set accordingly.
- */
+/** Dispatched by App.svelte when showAnnotationDecorations flips (#596). */
 export interface AnnotationToggleMeta {
   type: "toggle-decorations";
   visible: boolean;
@@ -154,9 +149,7 @@ export const AnnotationExtension = Extension.create<{ ydoc: Y.Doc | null }>({
     let hasAnnotations = annotationsMap.size > 0;
     let recoveryAttempted = false;
 
-    // #596: localStorage mirror lets the plugin read the setting at init
-    // without coupling to the Svelte settings store. Default `true` (show
-    // marks) when unset, matching the schema default.
+    // Read initial state from localStorage so the plugin stays decoupled from the Svelte store.
     let visible = true;
     try {
       const stored = localStorage.getItem(ANNOTATION_DECORATIONS_TOGGLE_KEY);

--- a/src/client/hooks/useTandemSettings.svelte.ts
+++ b/src/client/hooks/useTandemSettings.svelte.ts
@@ -1,4 +1,8 @@
-import { AUTHORSHIP_TOGGLE_KEY, TANDEM_SETTINGS_KEY } from "../../shared/constants.js";
+import {
+  ANNOTATION_DECORATIONS_TOGGLE_KEY,
+  AUTHORSHIP_TOGGLE_KEY,
+  TANDEM_SETTINGS_KEY,
+} from "../../shared/constants.js";
 import type { TandemSettings } from "./useTandemSettings.js";
 import { loadSettings, mergeAndClampSettings } from "./useTandemSettings.js";
 
@@ -61,6 +65,10 @@ export function createTandemSettings(): TandemSettingsState {
       localStorage.setItem(TANDEM_SETTINGS_KEY, JSON.stringify(next));
       // Mirror authorship toggle to dedicated key for ProseMirror plugin init
       localStorage.setItem(AUTHORSHIP_TOGGLE_KEY, String(next.showAuthorship));
+      localStorage.setItem(
+        ANNOTATION_DECORATIONS_TOGGLE_KEY,
+        String(next.showAnnotationDecorations),
+      );
     } catch {
       // localStorage unavailable (incognito/storage-disabled)
     }

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -103,6 +103,14 @@ export interface TandemSettings {
   holdAnnotationsWhileOffline: boolean;
   // #649: opt-in Word-style margin annotation view (PR 1 — minimum viable; collision resolution in PR 2; narrow-layout fallback in PR 3)
   marginView: boolean;
+  /**
+   * #596: when `false`, the editor's inline annotation marks (highlights,
+   * comment underlines, suggestion strikethroughs) are suppressed. Side-
+   * panel cards, margin bubbles, and the held-count badge are unaffected.
+   * Default `true` — the toggle is opt-in for users who want a cleaner
+   * editor surface while keeping the annotation list visible.
+   */
+  showAnnotationDecorations: boolean;
   // #659: AI provider registry. API keys live in the OS keychain
   // (`tandem-models` service) via `POST /api/models/secrets/:ref`; the
   // entries here only carry the opaque `apiKeyRef`.
@@ -139,7 +147,7 @@ function prefersReducedMotion(): boolean {
 const DEFAULTS: TandemSettings = {
   leftPanelVisible: false,
   rightPanelVisible: true,
-  schemaVersion: 7,
+  schemaVersion: 8,
   primaryTab: "annotations",
   panelOrder: "chat-editor-annotations",
   editorWidthPercent: 100,
@@ -160,6 +168,7 @@ const DEFAULTS: TandemSettings = {
   sidecarRetryStrategy: "exponential",
   holdAnnotationsWhileOffline: true,
   marginView: false,
+  showAnnotationDecorations: true,
   models: [],
   defaultModelId: null,
 };
@@ -274,8 +283,11 @@ function parseModels(raw: unknown): ModelRegistryEntry[] {
  *   plaintext `apiKey` values in place so `parseModels` can surface them
  *   via the transient `_legacyApiKey` field for the in-UI migration prompt.
  *   This is the load-bearing #659 step.
+ * v7→v8: introduce `showAnnotationDecorations: true` (#596). Default
+ *   preserves prior visual behavior; users opt in to suppress inline
+ *   annotation marks in the editor.
  */
-export const CURRENT_SCHEMA_VERSION = 7;
+export const CURRENT_SCHEMA_VERSION = 8;
 
 /**
  * Validate + clamp every known field on a parsed settings blob.
@@ -368,6 +380,8 @@ function normalizeKnownFields(parsed: Record<string, unknown>): TandemSettings {
         ? parsed.holdAnnotationsWhileOffline
         : DEFAULTS.holdAnnotationsWhileOffline,
     marginView: parsed.marginView === true,
+    showAnnotationDecorations:
+      parsed.showAnnotationDecorations === false ? false : DEFAULTS.showAnnotationDecorations,
     models: parseModels(parsed.models),
     defaultModelId:
       typeof parsed.defaultModelId === "string" && parsed.defaultModelId.length > 0
@@ -458,6 +472,12 @@ export function loadSettings(): TandemSettings {
           defaultModelId:
             firstEnabled && typeof firstEnabled.id === "string" ? firstEnabled.id : null,
         };
+      }
+      if (parsed.schemaVersion === 7) {
+        // v7→v8: introduce `showAnnotationDecorations: true`. Default
+        // preserves prior visual behavior; normalizeKnownFields handles
+        // the actual coercion on a blob that already carries the field.
+        parsed = { ...parsed, schemaVersion: 8 };
       }
       // Forward-compat: an on-disk version newer than what we can migrate
       // is loaded defensively and never written back. `_readOnly: true`

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -103,13 +103,7 @@ export interface TandemSettings {
   holdAnnotationsWhileOffline: boolean;
   // #649: opt-in Word-style margin annotation view (PR 1 — minimum viable; collision resolution in PR 2; narrow-layout fallback in PR 3)
   marginView: boolean;
-  /**
-   * #596: when `false`, the editor's inline annotation marks (highlights,
-   * comment underlines, suggestion strikethroughs) are suppressed. Side-
-   * panel cards, margin bubbles, and the held-count badge are unaffected.
-   * Default `true` — the toggle is opt-in for users who want a cleaner
-   * editor surface while keeping the annotation list visible.
-   */
+  // #596: when false, suppresses inline annotation marks in the editor; side-panel cards stay.
   showAnnotationDecorations: boolean;
   // #659: AI provider registry. API keys live in the OS keychain
   // (`tandem-models` service) via `POST /api/models/secrets/:ref`; the

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -100,6 +100,7 @@ export const Y_MAP_READ_ONLY = "readOnly";
 export const Y_MAP_STORE_READ_ONLY = "storeReadOnly";
 
 export const AUTHORSHIP_TOGGLE_KEY = "tandem:showAuthorship";
+export const ANNOTATION_DECORATIONS_TOGGLE_KEY = "tandem:showAnnotationDecorations";
 
 export const RECENT_FILES_KEY = "tandem:recentFiles";
 export const RECENT_FILES_CAP = 20;

--- a/tests/client/annotation-decoration.test.ts
+++ b/tests/client/annotation-decoration.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants";
 
@@ -73,10 +73,13 @@ function getPlugin(ydoc: Y.Doc) {
   return plugins[0];
 }
 
-function makeTr(opts: { docChanged: boolean; meta?: boolean }) {
+function makeTr(opts: { docChanged: boolean; meta?: boolean | object }) {
   return {
     docChanged: opts.docChanged,
-    getMeta: () => (opts.meta ? true : undefined),
+    getMeta: () => {
+      if (opts.meta === undefined) return undefined;
+      return opts.meta;
+    },
     setMeta: () => makeTr({ docChanged: false, meta: true }),
     mapping: {
       map: (pos: number) => pos,
@@ -251,6 +254,105 @@ describe("annotation plugin apply() recovery branch", () => {
     );
 
     expect(result).not.toBe(EMPTY_SENTINEL);
+  });
+});
+
+// --- #596: showAnnotationDecorations toggle ---
+
+describe("annotation plugin decoration-visibility toggle (#596)", () => {
+  function clearStoredToggle() {
+    try {
+      localStorage.removeItem("tandem:showAnnotationDecorations");
+    } catch {
+      // localStorage may not exist in this environment — fine.
+    }
+  }
+
+  beforeEach(clearStoredToggle);
+  // Avoid leaking a `"false"` setting into AR2 tests further down the file —
+  // those build plugins via init() and would otherwise see EMPTY_SENTINEL.
+  afterEach(clearStoredToggle);
+
+  it("plugin init returns empty DecorationSet when toggle is stored false", () => {
+    localStorage.setItem("tandem:showAnnotationDecorations", "false");
+    const ydoc = new Y.Doc();
+    addAnnotation(ydoc);
+    buildDecorationsResult = "non-empty";
+
+    const plugin = getPlugin(ydoc);
+    const initial = plugin.spec.state.init(null, fakeState);
+
+    expect(initial).toBe(EMPTY_SENTINEL);
+  });
+
+  it("plugin init returns built decorations when toggle is stored true", () => {
+    localStorage.setItem("tandem:showAnnotationDecorations", "true");
+    const ydoc = new Y.Doc();
+    addAnnotation(ydoc);
+    buildDecorationsResult = "non-empty";
+
+    const plugin = getPlugin(ydoc);
+    const initial = plugin.spec.state.init(null, fakeState);
+
+    expect(initial).not.toBe(EMPTY_SENTINEL);
+  });
+
+  it("apply() clears decorations on toggle-decorations meta with visible=false", () => {
+    const ydoc = new Y.Doc();
+    addAnnotation(ydoc);
+    buildDecorationsResult = "non-empty";
+
+    const plugin = getPlugin(ydoc);
+    const result = plugin.spec.state.apply(
+      makeTr({
+        docChanged: false,
+        meta: { type: "toggle-decorations", visible: false },
+      }),
+      { _stub: "previous-set" },
+      fakeState,
+      fakeState,
+    );
+
+    expect(result).toBe(EMPTY_SENTINEL);
+  });
+
+  it("apply() rebuilds decorations on toggle-decorations meta with visible=true", () => {
+    localStorage.setItem("tandem:showAnnotationDecorations", "false");
+    const ydoc = new Y.Doc();
+    addAnnotation(ydoc);
+    buildDecorationsResult = "non-empty";
+
+    const plugin = getPlugin(ydoc);
+    const result = plugin.spec.state.apply(
+      makeTr({
+        docChanged: false,
+        meta: { type: "toggle-decorations", visible: true },
+      }),
+      EMPTY_SENTINEL,
+      fakeState,
+      fakeState,
+    );
+
+    expect(result).not.toBe(EMPTY_SENTINEL);
+  });
+
+  it("apply() suppresses docChanged rebuild path when visible is false", () => {
+    localStorage.setItem("tandem:showAnnotationDecorations", "false");
+    const ydoc = new Y.Doc();
+    addAnnotation(ydoc);
+    // If the plugin ignored the toggle it would call buildDecorations on the
+    // recovery branch (empty + docChanged + hasAnnotations).
+    buildDecorationsResult = "non-empty";
+
+    const plugin = getPlugin(ydoc);
+    const result = plugin.spec.state.apply(
+      makeTr({ docChanged: true }),
+      EMPTY_SENTINEL,
+      fakeState,
+      fakeState,
+    );
+
+    expect(result).toBe(EMPTY_SENTINEL);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `showAnnotationDecorations: boolean` to `TandemSettings` (schema v7→v8, default `true`).
- When `false`, suppresses the editor's inline annotation marks (highlights, comment underlines, suggestion strikethroughs). Side-panel annotation cards, margin bubbles, and the held-count badge stay visible.
- Mechanism mirrors the existing authorship toggle: localStorage mirror at plugin init, `App.svelte` `$effect` dispatches plugin meta on flips, plugin `apply()` clears the decoration set when `visible=false`.
- UI lives in Appearance settings next to Reduce Motion.

Closes #596.

**Note for reviewers:** stacks on #789 (`test: pin schema-version assertions to CURRENT_SCHEMA_VERSION`). The cherry-picked commit is the second commit in this PR; once #789 merges, this branch can rebase to drop it. The schema bump and the constant pin are coupled — without the pin, every test in `use-tandem-settings-migration.test.ts` would need a literal `7` → `8` update.

## Test plan
- [x] `npm test` — 2490 passed, 13 skipped, 0 failed. Includes new tests for the visibility toggle path in `tests/client/annotation-decoration.test.ts`.
- [x] `npm run typecheck` — clean.
- [ ] Manual: toggle in Appearance settings hides/shows editor marks without touching side panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)