### PR TITLE
docs(positions): document RelativeRange invariants on helpers

### DIFF
--- a/src/server/positions.ts
+++ b/src/server/positions.ts
@@ -102,7 +102,9 @@ export function resolveToElement(
  * Sole mint of `SerializedRelPos` — no other code path constructs the wire
  * shape. Readers (`relPosToFlatOffset` here + `relRangeToPmPositions` in
  * `src/client/positions.ts`) must tolerate `Y.createRelativePositionFromJSON`
- * throwing on stale items after `reloadFromDisk` replaces the Y.Doc content.
+ * throwing on stale items after `reloadFromDisk` replaces the Y.Doc content;
+ * see `docs/lessons-learned.md` "Dead CRDT RelativePositions Must Be Stripped,
+ * Not Preserved" for why the throw is expected rather than a bug.
  */
 export function flatOffsetToRelPos(
   doc: Y.Doc,
@@ -316,6 +318,11 @@ export function anchoredRange(
  * callers can distinguish healthy / updated / attached / repaired /
  * degraded / failed paths instead of treating every outcome as success.
  * If `map` is provided, persists changes back to the Y.Map.
+ *
+ * The lazy-attach and dead-relRange repair branches below are the two
+ * intentional `{fromRel, toRel}` re-assembly sites referenced by
+ * `anchoredRange`'s JSDoc — both repair existing annotations rather than
+ * minting new ones, so the shape duplication is deliberate, not a DRY gap.
  */
 export function refreshRange(ann: Annotation, ydoc: Y.Doc, map?: Y.Map<unknown>): RefreshResult {
   if (!ann.relRange) {

--- a/src/server/positions.ts
+++ b/src/server/positions.ts
@@ -98,6 +98,11 @@ export function resolveToElement(
 /**
  * Convert a flat text offset to a JSON-serialized Yjs RelativePosition.
  * Returns null if the offset falls in a heading prefix or can't be resolved.
+ *
+ * Sole mint of `SerializedRelPos` — no other code path constructs the wire
+ * shape. Readers (`relPosToFlatOffset` here + `relRangeToPmPositions` in
+ * `src/client/positions.ts`) must tolerate `Y.createRelativePositionFromJSON`
+ * throwing on stale items after `reloadFromDisk` replaces the Y.Doc content.
  */
 export function flatOffsetToRelPos(
   doc: Y.Doc,
@@ -259,6 +264,12 @@ export function validateRange(
  * Validate a range and create both flat and CRDT-anchored positions in one call.
  * Pass `opts.rejectHeadingOverlap: true` to also reject ranges that overlap
  * heading prefixes (same guard used by `tandem_edit`).
+ *
+ * Sole assembler of `RelativeRange` at annotation birth — `refreshRange`'s
+ * lazy-attach and dead-relRange repair branches are the only other sites that
+ * assemble the `{fromRel, toRel}` shape, and both live in this file. Wire-shape
+ * changes to `SerializedRelPos` require updating `SerializedRelPosSchema`,
+ * both readers, and any on-disk JSON predating the change.
  */
 export function anchoredRange(
   ydoc: Y.Doc,


### PR DESCRIPTION
## Summary

Adds JSDoc invariants on the two `RelativeRange` mint sites in `src/server/positions.ts`:

- **`flatOffsetToRelPos`** — sole mint of the `SerializedRelPos` wire shape; documents the reader contract (must tolerate stale-item throws after `reloadFromDisk`).
- **`anchoredRange`** — sole assembler of the `{fromRel, toRel}` shape at annotation birth; documents the other two assembly sites (`refreshRange` lazy-attach + dead-relRange repair) and the wire-shape-change checklist.

Origin: graphify pass over `src/` flagged `flatOffsetToRelPos` as a CRDT-reload choke-point and `RelativeRange` as load-bearing for CRDT serialization. The code is correct; the invariants were just undocumented.

Pure docs change — no behavior, no exports, no signatures.

## Test plan

- [x] `npm run typecheck` (pre-push hook)
- [x] `npm test` (pre-push hook — 2490 passed)
- [x] `cargo test` (pre-push hook — all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>