### PR TITLE
feat(integrations): Windows ACL hardening on .claude.json (#643)

### DIFF
--- a/src/server/integrations/acl-win.ts
+++ b/src/server/integrations/acl-win.ts
@@ -1,29 +1,34 @@
 /**
  * Windows DACL hardening for files that contain bearer tokens (`~/.claude.json`
  * and similar). Every function in this module is a no-op on non-Windows
- * platforms — POSIX paths get `chmod 0o600` through Node's native `mode`
- * argument, which is the right primitive there.
+ * platforms — POSIX paths use `chmod 0o600` instead.
  *
  * Security contract:
- * - `icacls` and `powershell` are always invoked via `execFile` with an argv
- *   array, never via a shell. Paths flow from `homedir()` which is
- *   user-controlled via `HOME`/`USERPROFILE`; any shell-style invocation is
- *   a command-injection bug.
- * - Broad-principal detection (`assertNoBroadAce`) reads the file's SDDL via
- *   PowerShell `(Get-Acl).Sddl`. SDDL uses locale-independent 2-letter
- *   shortcuts for well-known SIDs (`WD`=Everyone, `AU`=Authenticated Users,
- *   `BU`=BUILTIN\Users) — substring-matching English names from `icacls`
- *   default output false-negatives on non-English Windows (where the
- *   resolver returns "Utilisateurs", "Benutzer", etc.).
+ * - `icacls`, `whoami`, and `powershell` are always invoked via `execFile`
+ *   with an argv array, never via a shell. Paths flow from `homedir()`
+ *   which is user-controlled via `HOME`/`USERPROFILE`; any shell-style
+ *   invocation is a command-injection bug.
+ * - Broad-principal detection (`assertNoBroadAce`) reads the file's SDDL
+ *   via PowerShell `(Get-Acl).Sddl`. SDDL uses locale-independent 2-letter
+ *   shortcuts for well-known SIDs (`WD`=Everyone, `AU`=Authenticated
+ *   Users, `BU`=BUILTIN\Users). Parsing `icacls` default output instead
+ *   would false-negative on non-English Windows (where the resolver
+ *   returns "Utilisateurs", "Benutzer", etc.) and on partial-success
+ *   exit-0 cases where icacls's "Failed processing N files" summary is
+ *   also localised.
+ * - `setRestrictiveAcl` grants by **SID** (resolved once per process via
+ *   `whoami /user`), not by `process.env.USERNAME`. USERNAME is
+ *   in-process spoofable; a poisoned USERNAME could direct the grant at
+ *   a different local user whose name happens to collide, or contain
+ *   characters icacls parses unexpectedly (`:`, `/`, embedded UPNs).
  * - `setRestrictiveAcl` calls `/inheritance:r` THEN `/grant:r`. Without
  *   `:r` on both flags, inherited ACEs from the parent dir survive and
- *   `/grant` adds the user as an additional principal instead of replacing
- *   the ACL.
- * - The bearer-token write must precede the ACL-set only when the tempfile
- *   already inherits a restrictive DACL from a known-restrictive parent dir
- *   (on Windows, `homedir()` qualifies — only the user + SYSTEM +
- *   Administrators by default). The atomic-write caller in `apply.ts`
- *   relies on this assumption; the icacls call is explicit defence in depth.
+ *   `/grant` adds the user as an additional principal instead of
+ *   replacing the ACL.
+ * - The tempfile self-verify (`assertNoBroadAce` at the end of
+ *   `setRestrictiveAcl`) is load-bearing — icacls is documented to exit
+ *   0 on partial failure (silent no-op). The SDDL re-read is the only
+ *   trustworthy signal that the DACL is actually correct.
  * - PowerShell paths are passed via the `TANDEM_ACL_PATH` env var, not
  *   interpolated into the script string. This avoids every quoting /
  *   escaping pitfall for paths that contain spaces, apostrophes, or
@@ -31,27 +36,48 @@
  */
 
 import { execFile } from "node:child_process";
+import { join } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Resolve a Windows system binary by absolute path under `%SystemRoot%`.
+ * Bypasses `PATH` so a git-bash / MSYS / Cygwin shadow (e.g. their own
+ * `whoami` that doesn't understand Windows flags) can't intercept us.
+ * `icacls` and `whoami` both live in `System32`.
+ */
+function systemBin(name: string): string {
+  return join(process.env.SystemRoot ?? "C:\\Windows", "System32", name);
+}
 
 /**
  * Run a PowerShell script, preferring PowerShell 7 (`pwsh.exe`) and falling
  * back to Windows PowerShell 5.1 (`powershell.exe`). pwsh is more reliable —
  * 5.1's auto-module-load has been observed to fail intermittently for
  * `Microsoft.PowerShell.Security` in CI sandboxes and on some user setups.
+ *
+ * Fallback is gated on `ENOENT` only. A spawn error of `EACCES` or `EPERM`
+ * almost always reflects an AppLocker / WDAC policy denial — silently
+ * routing around it via the legacy shell is the wrong defence posture
+ * (admin's policy is a real security boundary). The original error is
+ * preserved as `cause` on the fallback's failure for log forensics.
  */
 async function runPowerShell(script: string, env: NodeJS.ProcessEnv): Promise<{ stdout: string }> {
   const args = ["-NoProfile", "-NonInteractive", "-Command", script];
   try {
     return await execFileAsync("pwsh.exe", args, { env });
   } catch (err) {
-    // ENOENT or spawn failure → fall back to legacy Windows PowerShell.
-    // Any other error (e.g. the script itself failed) propagates from the
-    // fallback invocation below so the caller sees a real diagnosis.
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== "ENOENT") throw err;
-    return await execFileAsync("powershell.exe", args, { env });
+    try {
+      return await execFileAsync("powershell.exe", args, { env });
+    } catch (fallbackErr) {
+      throw new Error(
+        `runPowerShell: both pwsh.exe and powershell.exe failed (pwsh: ${(err as Error).message})`,
+        { cause: fallbackErr },
+      );
+    }
   }
 }
 
@@ -73,21 +99,48 @@ const BROAD_SDDL_FRAGMENTS = [
 ] as const;
 
 /**
+ * Cached SID of the current Windows user. `whoami /user` is the cheapest
+ * locale-independent way to get this. Resolved once per process; cleared
+ * to `null` only on test reset.
+ */
+let cachedCurrentUserSid: string | null = null;
+
+/** Reset for tests only. Production callers MUST NOT depend on resetting. */
+export function _resetCurrentUserSidForTests(): void {
+  cachedCurrentUserSid = null;
+}
+
+/**
+ * Resolve the SID of the current user via `whoami /user /fo csv /nh`. CSV
+ * output is locale-independent and parses cleanly without PowerShell.
+ */
+async function getCurrentUserSid(): Promise<string> {
+  if (cachedCurrentUserSid !== null) return cachedCurrentUserSid;
+  const { stdout } = await execFileAsync(systemBin("whoami.exe"), ["/user", "/fo", "csv", "/nh"]);
+  // CSV row format: `"DOMAIN\user","S-1-5-21-..."` — extract the second column.
+  const match = stdout.match(/"(S-[\d-]+)"\s*$/m);
+  if (!match) {
+    throw new Error(`getCurrentUserSid: could not parse SID from whoami output: ${stdout.trim()}`);
+  }
+  cachedCurrentUserSid = match[1];
+  return cachedCurrentUserSid;
+}
+
+/**
  * Set a restrictive DACL on `path`: break inheritance, then grant Full
- * Control to the current user only. On non-Windows, no-op.
+ * Control to the current user (by SID, not name) only. On non-Windows,
+ * no-op.
  *
- * @throws if the `icacls` invocation fails or the verify step finds a broad
- * ACE on the result.
+ * Includes a post-set SDDL re-verify on `path` because icacls is
+ * documented to exit 0 even when "Failed processing N files" — the SDDL
+ * read is the only trustworthy signal that the DACL is actually correct.
+ *
+ * @throws if any step (SID resolve, icacls, verify) fails.
  */
 export async function setRestrictiveAcl(path: string): Promise<void> {
   if (process.platform !== "win32") return;
 
-  const user = process.env.USERNAME;
-  if (!user || user.trim() === "") {
-    throw new Error(
-      "setRestrictiveAcl: USERNAME env var is empty; refusing to set ACL without a principal",
-    );
-  }
+  const sid = await getCurrentUserSid();
 
   // icacls processes flags left-to-right in one invocation:
   //   /inheritance:r — remove ALL inherited entries (`:d` would copy them
@@ -95,11 +148,18 @@ export async function setRestrictiveAcl(path: string): Promise<void> {
   //   /grant:r       — replace any existing explicit ACE for the user
   //                    rather than ADD a new one (no `:r` → duplicates
   //                    accumulate over repeated runs).
-  // Combining saves a process spawn; the contract is identical to the
-  // serialised form. Callers MUST follow up with `assertNoBroadAce` on
-  // the final destination path — that is the load-bearing security check
-  // and we don't duplicate it here to keep this function single-spawn.
-  await execFileAsync("icacls", [path, "/inheritance:r", "/grant:r", `${user}:F`]);
+  //   *<SID>:F       — grant Full Control by SID. The `*` prefix tells
+  //                    icacls to interpret the principal as a raw SID
+  //                    rather than a name to look up.
+  try {
+    await execFileAsync(systemBin("icacls.exe"), [path, "/inheritance:r", "/grant:r", `*${sid}:F`]);
+  } catch (err) {
+    throw new Error(`setRestrictiveAcl: icacls failed on ${path}: ${(err as Error).message}`, {
+      cause: err,
+    });
+  }
+
+  await assertNoBroadAce(path);
 }
 
 /**
@@ -112,7 +172,6 @@ export async function setRestrictiveAcl(path: string): Promise<void> {
 export async function assertNoBroadAce(path: string): Promise<void> {
   if (process.platform !== "win32") return;
 
-  // Script reads the path from an env var to avoid every quoting pitfall.
   // `-LiteralPath` ensures wildcards in the path are not expanded. The
   // explicit `Import-Module` is defensive — `Get-Acl` lives in
   // `Microsoft.PowerShell.Security` which usually auto-loads, but the

--- a/src/server/integrations/acl-win.ts
+++ b/src/server/integrations/acl-win.ts
@@ -1,0 +1,137 @@
+/**
+ * Windows DACL hardening for files that contain bearer tokens (`~/.claude.json`
+ * and similar). Every function in this module is a no-op on non-Windows
+ * platforms — POSIX paths get `chmod 0o600` through Node's native `mode`
+ * argument, which is the right primitive there.
+ *
+ * Security contract:
+ * - `icacls` and `powershell` are always invoked via `execFile` with an argv
+ *   array, never via a shell. Paths flow from `homedir()` which is
+ *   user-controlled via `HOME`/`USERPROFILE`; any shell-style invocation is
+ *   a command-injection bug.
+ * - Broad-principal detection (`assertNoBroadAce`) reads the file's SDDL via
+ *   PowerShell `(Get-Acl).Sddl`. SDDL uses locale-independent 2-letter
+ *   shortcuts for well-known SIDs (`WD`=Everyone, `AU`=Authenticated Users,
+ *   `BU`=BUILTIN\Users) — substring-matching English names from `icacls`
+ *   default output false-negatives on non-English Windows (where the
+ *   resolver returns "Utilisateurs", "Benutzer", etc.).
+ * - `setRestrictiveAcl` calls `/inheritance:r` THEN `/grant:r`. Without
+ *   `:r` on both flags, inherited ACEs from the parent dir survive and
+ *   `/grant` adds the user as an additional principal instead of replacing
+ *   the ACL.
+ * - The bearer-token write must precede the ACL-set only when the tempfile
+ *   already inherits a restrictive DACL from a known-restrictive parent dir
+ *   (on Windows, `homedir()` qualifies — only the user + SYSTEM +
+ *   Administrators by default). The atomic-write caller in `apply.ts`
+ *   relies on this assumption; the icacls call is explicit defence in depth.
+ * - PowerShell paths are passed via the `TANDEM_ACL_PATH` env var, not
+ *   interpolated into the script string. This avoids every quoting /
+ *   escaping pitfall for paths that contain spaces, apostrophes, or
+ *   backticks.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Run a PowerShell script, preferring PowerShell 7 (`pwsh.exe`) and falling
+ * back to Windows PowerShell 5.1 (`powershell.exe`). pwsh is more reliable —
+ * 5.1's auto-module-load has been observed to fail intermittently for
+ * `Microsoft.PowerShell.Security` in CI sandboxes and on some user setups.
+ */
+async function runPowerShell(script: string, env: NodeJS.ProcessEnv): Promise<{ stdout: string }> {
+  const args = ["-NoProfile", "-NonInteractive", "-Command", script];
+  try {
+    return await execFileAsync("pwsh.exe", args, { env });
+  } catch (err) {
+    // ENOENT or spawn failure → fall back to legacy Windows PowerShell.
+    // Any other error (e.g. the script itself failed) propagates from the
+    // fallback invocation below so the caller sees a real diagnosis.
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") throw err;
+    return await execFileAsync("powershell.exe", args, { env });
+  }
+}
+
+/**
+ * SDDL ACE-string fragments that flag a broad-principal grant. These
+ * shortcuts are locale-independent — they appear verbatim in the SDDL
+ * regardless of Windows display language.
+ *
+ * Each pattern matches the principal-SID position of an SDDL ACE,
+ * which is the last token before the closing `)`. Example ACE:
+ *   `(A;;FA;;;WD)`  ← Everyone has Full Access
+ *
+ * Reference: https://learn.microsoft.com/windows/win32/secauthz/sid-strings
+ */
+const BROAD_SDDL_FRAGMENTS = [
+  ";WD)", // Everyone (S-1-1-0)
+  ";AU)", // Authenticated Users (S-1-5-11)
+  ";BU)", // BUILTIN\Users (S-1-5-32-545)
+] as const;
+
+/**
+ * Set a restrictive DACL on `path`: break inheritance, then grant Full
+ * Control to the current user only. On non-Windows, no-op.
+ *
+ * @throws if the `icacls` invocation fails or the verify step finds a broad
+ * ACE on the result.
+ */
+export async function setRestrictiveAcl(path: string): Promise<void> {
+  if (process.platform !== "win32") return;
+
+  const user = process.env.USERNAME;
+  if (!user || user.trim() === "") {
+    throw new Error(
+      "setRestrictiveAcl: USERNAME env var is empty; refusing to set ACL without a principal",
+    );
+  }
+
+  // icacls processes flags left-to-right in one invocation:
+  //   /inheritance:r — remove ALL inherited entries (`:d` would copy them
+  //                    as explicit, defeating the purpose)
+  //   /grant:r       — replace any existing explicit ACE for the user
+  //                    rather than ADD a new one (no `:r` → duplicates
+  //                    accumulate over repeated runs).
+  // Combining saves a process spawn; the contract is identical to the
+  // serialised form. Callers MUST follow up with `assertNoBroadAce` on
+  // the final destination path — that is the load-bearing security check
+  // and we don't duplicate it here to keep this function single-spawn.
+  await execFileAsync("icacls", [path, "/inheritance:r", "/grant:r", `${user}:F`]);
+}
+
+/**
+ * Read the SDDL of `path` and assert no well-known broad principal is
+ * granted access. Uses PowerShell `Get-Acl` so the principal check works
+ * regardless of Windows display language.
+ *
+ * @throws if any broad-principal SDDL shortcut appears in the file's ACL.
+ */
+export async function assertNoBroadAce(path: string): Promise<void> {
+  if (process.platform !== "win32") return;
+
+  // Script reads the path from an env var to avoid every quoting pitfall.
+  // `-LiteralPath` ensures wildcards in the path are not expanded. The
+  // explicit `Import-Module` is defensive — `Get-Acl` lives in
+  // `Microsoft.PowerShell.Security` which usually auto-loads, but the
+  // auto-load fails in some sandboxed shells (e.g. CI runners with
+  // restricted module paths).
+  const script =
+    "Import-Module Microsoft.PowerShell.Security; (Get-Acl -LiteralPath $env:TANDEM_ACL_PATH).Sddl";
+
+  const { stdout } = await runPowerShell(script, {
+    ...process.env,
+    TANDEM_ACL_PATH: path,
+  });
+
+  const sddl = stdout.trim();
+  for (const fragment of BROAD_SDDL_FRAGMENTS) {
+    if (sddl.includes(fragment)) {
+      throw new Error(
+        `assertNoBroadAce: ${path} has a broad-principal ACE (SDDL fragment ${fragment}). SDDL:\n${sddl}`,
+      );
+    }
+  }
+}

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -26,7 +26,16 @@ import {
   realpathSync,
   statSync,
 } from "node:fs";
-import { copyFile, mkdir, open, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -34,7 +43,7 @@ import { fileURLToPath } from "node:url";
 import { SKILL_CONTENT } from "../../cli/skill-content.js";
 import { DEFAULT_MCP_PORT } from "../../shared/constants.js";
 import { resolveAppDataDir } from "../platform.js";
-import { assertNoBroadAce, setRestrictiveAcl } from "./acl-win.js";
+import { setRestrictiveAcl } from "./acl-win.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -362,68 +371,83 @@ export function detectTargets(opts: DetectOptions = {}): DetectedTarget[] {
 
 /**
  * Atomic write: write to a temp file in the SAME directory as the destination,
- * tighten its DACL on Windows, then rename. Using the same directory avoids
- * EXDEV errors when `%TEMP%` and `%APPDATA%` are on different drives.
+ * tighten its mode/DACL, then rename. Same-directory tempfile avoids EXDEV
+ * errors when `%TEMP%` and `%APPDATA%` are on different drives.
  *
- * Sequence on Windows (security-load-bearing):
- * 1. Create tempfile and write content. The tempfile inherits its parent
- *    dir's DACL — on Windows, `homedir()` is OS-restricted to user + SYSTEM
- *    + Administrators by default, so the inherited DACL is already narrow.
- * 2. Set restrictive DACL on the tempfile (break inheritance, grant only
- *    current user). This is explicit defence in depth on top of #1.
- * 3. Rename tempfile to destination. On Windows, rename preserves the
- *    file's DACL — the destination keeps the restrictive ACL set in #2,
- *    NOT the destination directory's default.
- * 4. Re-verify the destination DACL has no broad-principal ACE. If
- *    verification fails, unlink the destination and propagate the error
- *    rather than leave a bearer token at a permissive ACL.
- *
- * POSIX path: writeFile sets mode at open via the `mode` argument (the
- * caller passes `0o600` for token-bearing files via Node's `chmod`).
+ * Sequence (security-load-bearing):
+ * 1. Write tempfile. On Windows the tempfile inherits its parent dir's
+ *    DACL (`homedir()` is OS-restricted by default to user + SYSTEM +
+ *    Administrators); on POSIX it lands at `0o666 & ~umask` (typically
+ *    `0o644` — world-readable, hence step 2's chmod).
+ * 2. Tighten on the tempfile:
+ *    - Windows: `setRestrictiveAcl` breaks inheritance and grants Full
+ *      Control to the current user's SID only, then self-verifies via
+ *      SDDL read. The verify is load-bearing — icacls exits 0 even when
+ *      "Failed processing N files".
+ *    - POSIX: `chmod(tmp, 0o600)` — user-only read/write.
+ * 3. Rename tempfile to dest. The kernel preserves mode (POSIX) and DACL
+ *    (Windows `MoveFileEx`) across the rename, so the tightened
+ *    permissions survive into the destination.
+ * 4. On cleanup failure after a write/ACL/rename error, the original
+ *    failure propagates with the cleanup error attached via `cause` so
+ *    operators can diagnose a leaked tempfile or dest from a single log
+ *    line rather than chasing a stray `console.error`.
  */
 async function atomicWrite(content: string, dest: string): Promise<void> {
   const tmp = join(dirname(dest), `.tandem-setup-${randomUUID()}.tmp`);
   await writeFile(tmp, content, "utf-8");
 
-  if (process.platform === "win32") {
-    try {
+  try {
+    if (process.platform === "win32") {
       await setRestrictiveAcl(tmp);
-    } catch (aclErr) {
-      await unlink(tmp).catch((cleanupErr: Error) => {
-        console.error(`  Warning: could not remove temp file ${tmp}: ${cleanupErr.message}`);
-      });
-      throw aclErr;
+    } else {
+      await chmod(tmp, 0o600);
     }
+  } catch (tightenErr) {
+    await unlinkOrLeak(tmp, tightenErr);
+    throw tightenErr;
   }
 
   try {
     await rename(tmp, dest);
   } catch (err) {
-    // EXDEV: cross-device link — fall back to copy + delete
+    // EXDEV: cross-device link — fall back to copy + delete. The copy
+    // preserves the source mode on POSIX (file is created via copyFile's
+    // default which honors the source's mode bits); on Windows the
+    // destination DACL is recomputed from the dest dir, so we re-run
+    // setRestrictiveAcl on the dest after the cross-device copy.
     if ((err as NodeJS.ErrnoException).code === "EXDEV") {
       await copyFile(tmp, dest);
-      await unlink(tmp).catch((cleanupErr: Error) => {
-        console.error(`  Warning: could not remove temp file ${tmp}: ${cleanupErr.message}`);
-      });
+      await unlinkOrLeak(tmp, err);
+      if (process.platform === "win32") await setRestrictiveAcl(dest);
+      else await chmod(dest, 0o600);
     } else {
-      await unlink(tmp).catch((cleanupErr: Error) => {
-        console.error(`  Warning: could not remove temp file ${tmp}: ${cleanupErr.message}`);
-      });
+      await unlinkOrLeak(tmp, err);
       throw err;
     }
   }
+}
 
-  if (process.platform === "win32") {
-    try {
-      await assertNoBroadAce(dest);
-    } catch (verifyErr) {
-      await unlink(dest).catch((cleanupErr: Error) => {
-        console.error(
-          `  Warning: could not remove dest after ACL verify failure: ${cleanupErr.message}`,
-        );
-      });
-      throw verifyErr;
+/**
+ * Attempt to delete `path` after a write/ACL/rename failure. On cleanup
+ * success we just return; on cleanup failure we attach the cleanup error
+ * as `cause` to the original failure (mutating `originalErr`) so operators
+ * see a single composite log line rather than a free-floating
+ * `console.error`. Bearer-token-bearing files that fail cleanup MUST be
+ * surfaced, not silently logged.
+ */
+async function unlinkOrLeak(path: string, originalErr: unknown): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (cleanupErr) {
+    if (originalErr instanceof Error && originalErr.cause === undefined) {
+      (originalErr as { cause?: unknown }).cause = cleanupErr;
     }
+    console.error(
+      `  Warning: could not remove ${path} after a previous failure: ${
+        (cleanupErr as Error).message
+      }`,
+    );
   }
 }
 

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -17,7 +17,15 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 import { copyFile, mkdir, open, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve, sep } from "node:path";
@@ -26,6 +34,7 @@ import { fileURLToPath } from "node:url";
 import { SKILL_CONTENT } from "../../cli/skill-content.js";
 import { DEFAULT_MCP_PORT } from "../../shared/constants.js";
 import { resolveAppDataDir } from "../platform.js";
+import { assertNoBroadAce, setRestrictiveAcl } from "./acl-win.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -41,6 +50,15 @@ const PACKAGE_ROOT = (() => {
 const CHANNEL_DIST = resolve(PACKAGE_ROOT, "dist/channel/index.js");
 
 const MCP_URL = `http://127.0.0.1:${DEFAULT_MCP_PORT}`;
+
+/**
+ * Refuse to read a config larger than 5 MiB. The realistic `.claude.json` is
+ * single-digit kilobytes; anything beyond that is either accidental corruption
+ * (log files dropped in) or a deliberate DoS aimed at making the wizard's
+ * read-parse-rewrite path exhaust memory. The cap is generous enough that no
+ * legitimate user hits it.
+ */
+const MAX_CONFIG_BYTES = 5 * 1024 * 1024;
 
 export interface McpEntry {
   type?: "http";
@@ -344,12 +362,40 @@ export function detectTargets(opts: DetectOptions = {}): DetectedTarget[] {
 
 /**
  * Atomic write: write to a temp file in the SAME directory as the destination,
- * then rename. Using the same directory avoids EXDEV errors on Windows when
- * %TEMP% and %APPDATA% are on different drives.
+ * tighten its DACL on Windows, then rename. Using the same directory avoids
+ * EXDEV errors when `%TEMP%` and `%APPDATA%` are on different drives.
+ *
+ * Sequence on Windows (security-load-bearing):
+ * 1. Create tempfile and write content. The tempfile inherits its parent
+ *    dir's DACL — on Windows, `homedir()` is OS-restricted to user + SYSTEM
+ *    + Administrators by default, so the inherited DACL is already narrow.
+ * 2. Set restrictive DACL on the tempfile (break inheritance, grant only
+ *    current user). This is explicit defence in depth on top of #1.
+ * 3. Rename tempfile to destination. On Windows, rename preserves the
+ *    file's DACL — the destination keeps the restrictive ACL set in #2,
+ *    NOT the destination directory's default.
+ * 4. Re-verify the destination DACL has no broad-principal ACE. If
+ *    verification fails, unlink the destination and propagate the error
+ *    rather than leave a bearer token at a permissive ACL.
+ *
+ * POSIX path: writeFile sets mode at open via the `mode` argument (the
+ * caller passes `0o600` for token-bearing files via Node's `chmod`).
  */
 async function atomicWrite(content: string, dest: string): Promise<void> {
   const tmp = join(dirname(dest), `.tandem-setup-${randomUUID()}.tmp`);
   await writeFile(tmp, content, "utf-8");
+
+  if (process.platform === "win32") {
+    try {
+      await setRestrictiveAcl(tmp);
+    } catch (aclErr) {
+      await unlink(tmp).catch((cleanupErr: Error) => {
+        console.error(`  Warning: could not remove temp file ${tmp}: ${cleanupErr.message}`);
+      });
+      throw aclErr;
+    }
+  }
+
   try {
     await rename(tmp, dest);
   } catch (err) {
@@ -364,6 +410,19 @@ async function atomicWrite(content: string, dest: string): Promise<void> {
         console.error(`  Warning: could not remove temp file ${tmp}: ${cleanupErr.message}`);
       });
       throw err;
+    }
+  }
+
+  if (process.platform === "win32") {
+    try {
+      await assertNoBroadAce(dest);
+    } catch (verifyErr) {
+      await unlink(dest).catch((cleanupErr: Error) => {
+        console.error(
+          `  Warning: could not remove dest after ACL verify failure: ${cleanupErr.message}`,
+        );
+      });
+      throw verifyErr;
     }
   }
 }
@@ -385,6 +444,19 @@ async function atomicWrite(content: string, dest: string): Promise<void> {
 export async function applyConfig(configPath: string, ops: ApplyOps): Promise<void> {
   // Security gate: refuse symlinks, refuse paths outside home/tmpdir.
   assertPathSafe(configPath);
+
+  // Size guard runs before any read — fail closed on oversized files. ENOENT
+  // falls through so fresh-install (no .claude.json yet) stays the common path.
+  try {
+    const { size } = statSync(configPath);
+    if (size > MAX_CONFIG_BYTES) {
+      throw new Error(
+        `${configPath} is ${size} bytes; refusing to read (cap: ${MAX_CONFIG_BYTES}).`,
+      );
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
 
   // Read existing config or start fresh — no existsSync guard needed.
   // ENOENT and malformed JSON start fresh; other errors (permissions, disk) propagate.

--- a/tests/server/integrations/acl-win.test.ts
+++ b/tests/server/integrations/acl-win.test.ts
@@ -1,11 +1,18 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { assertNoBroadAce, setRestrictiveAcl } from "../../../src/server/integrations/acl-win.js";
+import {
+  _resetCurrentUserSidForTests,
+  assertNoBroadAce,
+  setRestrictiveAcl,
+} from "../../../src/server/integrations/acl-win.js";
 
 const WIN_ONLY = process.platform === "win32";
+const execFileAsync = promisify(execFile);
 
 describe.skipIf(!WIN_ONLY)("acl-win — Windows DACL hardening", () => {
   let tmpDir: string;
@@ -22,8 +29,9 @@ describe.skipIf(!WIN_ONLY)("acl-win — Windows DACL hardening", () => {
     const filePath = path.join(tmpDir, "secret.json");
     fs.writeFileSync(filePath, '{"token":"sentinel"}');
     await setRestrictiveAcl(filePath);
-    // assertNoBroadAce throws if any of the BROAD_SIDS appear. If
-    // setRestrictiveAcl did its job, this succeeds silently.
+    // setRestrictiveAcl self-verifies via assertNoBroadAce — a second
+    // call here is belt-and-suspenders that the verify works
+    // independently of the set path.
     await expect(assertNoBroadAce(filePath)).resolves.toBeUndefined();
   });
 
@@ -35,16 +43,31 @@ describe.skipIf(!WIN_ONLY)("acl-win — Windows DACL hardening", () => {
     await expect(assertNoBroadAce(filePath)).resolves.toBeUndefined();
   });
 
-  it("assertNoBroadAce throws when Everyone has Read access", async () => {
-    const filePath = path.join(tmpDir, "leaky.json");
-    fs.writeFileSync(filePath, '{"token":"sentinel"}');
-    // Grant Everyone (SID S-1-1-0) read access via icacls. Use the SID
-    // form so the test works on non-English Windows.
-    const { execFile } = await import("node:child_process");
-    const { promisify } = await import("node:util");
-    const execFileAsync = promisify(execFile);
-    await execFileAsync("icacls", [filePath, "/grant", "*S-1-1-0:R"]);
-    await expect(assertNoBroadAce(filePath)).rejects.toThrow(/broad-principal/);
+  // Table-driven coverage for every broad-principal SID — a future drop of
+  // any entry from BROAD_SDDL_FRAGMENTS would silently weaken the gate.
+  const BROAD_CASES: Array<{ name: string; sid: string }> = [
+    { name: "Everyone", sid: "S-1-1-0" },
+    { name: "Authenticated Users", sid: "S-1-5-11" },
+    { name: "BUILTIN\\Users", sid: "S-1-5-32-545" },
+  ];
+  for (const { name, sid } of BROAD_CASES) {
+    it(`assertNoBroadAce throws when ${name} (${sid}) has Read access`, async () => {
+      const filePath = path.join(tmpDir, `leaky-${sid}.json`);
+      fs.writeFileSync(filePath, '{"token":"sentinel"}');
+      // Use the *SID form so the grant lands locale-independently.
+      await execFileAsync("icacls", [filePath, "/grant", `*${sid}:R`]);
+      await expect(assertNoBroadAce(filePath)).rejects.toThrow(/broad-principal/);
+    });
+  }
+
+  it("setRestrictiveAcl throws when icacls cannot act on the path", async () => {
+    // Non-existent path → icacls exits non-zero. setRestrictiveAcl must
+    // wrap the error with the path in the message for forensics.
+    _resetCurrentUserSidForTests();
+    const filePath = path.join(tmpDir, "does-not-exist.json");
+    await expect(setRestrictiveAcl(filePath)).rejects.toThrow(
+      new RegExp(`setRestrictiveAcl: icacls failed on .*does-not-exist`),
+    );
   });
 });
 
@@ -63,7 +86,7 @@ describe("acl-win — source contract", () => {
     // regex itself doesn't trip security scanners.
     const shellExec = new RegExp(
       String.raw`(?:^|[^A-Za-z_])` + // word boundary that doesn't include `F` (rules out `execFile`)
-        String.raw`(?:exec|spawn)\s*\(\s*["'\x60][^"'\x60]*(?:icacls|powershell)`,
+        String.raw`(?:exec|spawn)(?:Sync)?\s*\(\s*["'\x60][^"'\x60]*(?:icacls|powershell|whoami)`,
       "im",
     );
     expect(source).not.toMatch(shellExec);

--- a/tests/server/integrations/acl-win.test.ts
+++ b/tests/server/integrations/acl-win.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { assertNoBroadAce, setRestrictiveAcl } from "../../../src/server/integrations/acl-win.js";
+
+const WIN_ONLY = process.platform === "win32";
+
+describe.skipIf(!WIN_ONLY)("acl-win — Windows DACL hardening", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tandem-acl-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("setRestrictiveAcl applies a DACL with no broad-principal ACE", async () => {
+    const filePath = path.join(tmpDir, "secret.json");
+    fs.writeFileSync(filePath, '{"token":"sentinel"}');
+    await setRestrictiveAcl(filePath);
+    // assertNoBroadAce throws if any of the BROAD_SIDS appear. If
+    // setRestrictiveAcl did its job, this succeeds silently.
+    await expect(assertNoBroadAce(filePath)).resolves.toBeUndefined();
+  });
+
+  it("setRestrictiveAcl is idempotent across repeat calls", async () => {
+    const filePath = path.join(tmpDir, "secret.json");
+    fs.writeFileSync(filePath, '{"token":"sentinel"}');
+    await setRestrictiveAcl(filePath);
+    await setRestrictiveAcl(filePath);
+    await expect(assertNoBroadAce(filePath)).resolves.toBeUndefined();
+  });
+
+  it("assertNoBroadAce throws when Everyone has Read access", async () => {
+    const filePath = path.join(tmpDir, "leaky.json");
+    fs.writeFileSync(filePath, '{"token":"sentinel"}');
+    // Grant Everyone (SID S-1-1-0) read access via icacls. Use the SID
+    // form so the test works on non-English Windows.
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+    await execFileAsync("icacls", [filePath, "/grant", "*S-1-1-0:R"]);
+    await expect(assertNoBroadAce(filePath)).rejects.toThrow(/broad-principal/);
+  });
+});
+
+describe("acl-win — source contract", () => {
+  it("never invokes icacls or PowerShell via a shell", async () => {
+    // Path traversal: read the acl-win.ts source and grep for shell-style
+    // invocations. The contract is the argv-array form only — string-command
+    // shell invocations would re-introduce command-injection surface for
+    // user-controlled paths flowing from homedir().
+    const source = await fs.promises.readFile(
+      path.join(__dirname, "../../../src/server/integrations/acl-win.ts"),
+      "utf-8",
+    );
+    // String-command invocations would look like e.g. `exec("icacls ...")` or
+    // `spawn("icacls ...")`. Build the pattern from a non-literal so the
+    // regex itself doesn't trip security scanners.
+    const shellExec = new RegExp(
+      String.raw`(?:^|[^A-Za-z_])` + // word boundary that doesn't include `F` (rules out `execFile`)
+        String.raw`(?:exec|spawn)\s*\(\s*["'\x60][^"'\x60]*(?:icacls|powershell)`,
+      "im",
+    );
+    expect(source).not.toMatch(shellExec);
+    expect(source).not.toMatch(/shell\s*:\s*true/);
+  });
+});
+
+describe.skipIf(WIN_ONLY)("acl-win — POSIX no-op", () => {
+  it("setRestrictiveAcl resolves without effect on non-Windows", async () => {
+    await expect(setRestrictiveAcl("/dev/null")).resolves.toBeUndefined();
+  });
+
+  it("assertNoBroadAce resolves without effect on non-Windows", async () => {
+    await expect(assertNoBroadAce("/dev/null")).resolves.toBeUndefined();
+  });
+});

--- a/tests/server/integrations/apply.test.ts
+++ b/tests/server/integrations/apply.test.ts
@@ -212,3 +212,45 @@ describe("applyConfig — malformed-JSON backup", () => {
     ).rejects.toBeInstanceOf(PathRejectedError);
   });
 });
+
+describe("applyConfig — 5MB size guard", () => {
+  let tmpDir: string;
+  let configPath: string;
+  let savedAppData: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tandem-size-guard-"));
+    configPath = path.join(tmpDir, ".claude.json");
+    savedAppData = process.env.TANDEM_APP_DATA_DIR;
+    process.env.TANDEM_APP_DATA_DIR = tmpDir;
+  });
+
+  afterEach(async () => {
+    if (savedAppData === undefined) delete process.env.TANDEM_APP_DATA_DIR;
+    else process.env.TANDEM_APP_DATA_DIR = savedAppData;
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("accepts a config just under the 5 MiB cap", async () => {
+    // 5 MiB - 1 KiB padding so the JSON object header fits without crossing.
+    const padding = "x".repeat(5 * 1024 * 1024 - 1024);
+    fs.writeFileSync(configPath, JSON.stringify({ mcpServers: {}, _pad: padding }));
+    // Should not throw — boundary case proves the cap isn't off-by-one strict.
+    await applyConfig(configPath, {
+      create: { tandem: { type: "http", url: "http://127.0.0.1:3479/mcp" } },
+      remove: [],
+    });
+  });
+
+  it("rejects a config above the 5 MiB cap", async () => {
+    // 5 MiB + 1 byte of padding.
+    const padding = "x".repeat(5 * 1024 * 1024 + 1);
+    fs.writeFileSync(configPath, JSON.stringify({ _pad: padding }));
+    await expect(
+      applyConfig(configPath, {
+        create: { tandem: { type: "http", url: "http://127.0.0.1:3479/mcp" } },
+        remove: [],
+      }),
+    ).rejects.toThrow(/refusing to read/);
+  });
+});


### PR DESCRIPTION
Closes #643. Second of the PR-4 hardening quartet (✅#642 → #643 → #644 → #645 → PR 4 main).

## Summary

- **Write-with-ACL-then-rename** atomic write on Windows: tempfile gets a restrictive DACL (break inheritance + grant current user only) BEFORE rename to dest. Previous flow could leave a bearer token at the destination's inherited (potentially permissive) DACL.
- **Post-rename DACL verify**: if a broad-principal ACE (Everyone/Authenticated Users/BUILTIN\Users) survived, the destination is unlinked and the error propagates — never leave the token at a permissive ACL.
- **5 MiB size guard** before reading `.claude.json`. Realistic configs are single-digit KB; the cap is generous DoS prevention.
- New module `src/server/integrations/acl-win.ts` — `icacls` + `Get-Acl` via `execFile` (argv array, never shell).

## Security-critical details

- **Locale-independent broad-ACE detection.** SDDL ACE-string shortcuts (`WD`/`AU`/`BU`) appear verbatim regardless of Windows display language. `icacls`'s default output resolves SIDs to localized names which break on non-English Windows; we use PowerShell `(Get-Acl).Sddl`.
- **No shell-style invocations.** Pinned by a source-grep test in `acl-win.test.ts`.
- **PowerShell paths via env var**, not interpolated into the script string. Defeats every quoting pitfall.
- **pwsh.exe preferred over powershell.exe**, falls back on ENOENT. PS 5.1's `Microsoft.PowerShell.Security` auto-load has been observed to fail in some sandboxed shells.

## Out of scope

- The existing `.broken-backups` Windows fallback at `apply.ts:423-426` uses plain `copyFile` and inherits the destination DACL. Same bug class but #644's territory (backup-hardening); will be addressed in the next PR of the quartet.

## Test plan

- [x] `npm test` — 2497 passed locally on Windows (1 skip for pwsh broad-ACE setup).
- [x] `npm run typecheck` — clean.
- [x] Source-grep CI gate: no shell-style icacls/powershell invocation in `acl-win.ts`.
- [ ] GH Actions: Linux/macOS runners hit the POSIX no-op branch; Windows runner exercises the real ACL path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)