### PR TITLE
feat(launcher): PR 4b — palette, working-dir picker, project-context skill (#477)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@napi-rs/keyring": "^1.3.0",
         "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tiptap/core": "^2.11.0",
         "@tiptap/extension-collaboration": "^2.11.0",
         "@tiptap/extension-collaboration-cursor": "^2.11.0",
@@ -2107,6 +2108,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/tauri"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@napi-rs/keyring": "^1.3.0",
     "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tiptap/core": "^2.11.0",
     "@tiptap/extension-collaboration": "^2.11.0",
     "@tiptap/extension-collaboration-cursor": "^2.11.0",

--- a/skills/tandem/SKILL.md
+++ b/skills/tandem/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: tandem
+version: 2
 description: >
   Use when tandem_* MCP tools are available, the user asks about Tandem
   document editing, or iterating on text collaboratively. Provides workflow
@@ -93,3 +94,15 @@ When starting a new Claude session with Tandem already running:
 ## Multi-Document
 
 When multiple documents are open, always pass `documentId` explicitly — omitting it targets the active document, which may have changed since your last call. Use `tandem_listDocuments` to see what's available. Cross-reference by reading both docs via `tandem_getTextContent({ documentId: "..." })` and annotating the relevant one.
+
+## Project Context Discovery
+
+Tandem auto-launches you in a single working directory (the user's home by default, or whatever they configured under Settings → Claude Code → Working directory). The document the user opens may live elsewhere — a different project, a different repo. When you're working on a file outside your launch cwd:
+
+1. **Read `<docDir>/CLAUDE.md`** if it exists — it's the project's own playbook.
+2. **Walk up** the directory tree from `<docDir>` looking for `CLAUDE.md`, `.claude/`, `README.md`, or `package.json`/`Cargo.toml`/`pyproject.toml` to identify the project root.
+3. **Surface a relaunch nudge** when you detect project-scoped Claude tools you can't load mid-session:
+   - `.claude/skills/`, `.claude/agents/`, `.claude/hooks/`, or a `.mcp.json` you haven't loaded
+   - Tell the user: *"I see project-specific Claude tools at `<path>`. I can't load them in this session — open the command palette and run `Relaunch Claude in this folder` if you'd like me to pick them up."*
+
+The user is in control: relaunch ends the current conversation, so only suggest it when the project-scoped tools materially change what you can help with.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "shell:default",
     "fs:default",
     "dialog:default",
-    "dialog:allow-message"
+    "dialog:allow-message",
+    "dialog:allow-open"
   ]
 }

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -367,6 +367,19 @@ function openSettingsPopoverWithAck() {
 // after the reactive state they depend on is available.
 wireActionDeps({
   getActiveTabId: () => yjsSync.activeTabId,
+  getActiveDocumentPath: () => {
+    const tab = yjsSync.tabs.find((t) => t.id === yjsSync.activeTabId);
+    return tab && !isUploadPath(tab.filePath) ? tab.filePath : null;
+  },
+  notify: (severity, message) => {
+    notifications.push({
+      id: `launcher-${Date.now()}`,
+      type: "launcher",
+      severity,
+      message,
+      timestamp: Date.now(),
+    });
+  },
   openSettings: openSettingsPopoverWithAck,
   openSettingsModal: openSettingsModalWithAck,
   toggleSoloMode: () =>

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -136,25 +136,36 @@ export async function triggerSave(activeDocId: string | null): Promise<void> {
 
 let launcherInflight = false;
 
-async function fetchLauncherStatus(): Promise<LauncherStatus | null> {
+type FetchResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; kind: "not-built" | "network" | "server-error"; detail?: string };
+
+async function fetchLauncherStatus(): Promise<FetchResult<LauncherStatus>> {
+  let res: Response;
   try {
-    const res = await fetch(`${API_BASE}${API_LAUNCHER_STATUS}`);
-    if (!res.ok) return null;
-    return (await res.json()) as LauncherStatus;
-  } catch {
-    return null;
+    res = await fetch(`${API_BASE}${API_LAUNCHER_STATUS}`);
+  } catch (err) {
+    return { ok: false, kind: "network", detail: err instanceof Error ? err.message : String(err) };
   }
+  if (res.status === 404) return { ok: false, kind: "not-built" };
+  if (!res.ok) return { ok: false, kind: "server-error", detail: `HTTP ${res.status}` };
+  return { ok: true, value: (await res.json()) as LauncherStatus };
 }
 
-async function fetchLauncherNonce(): Promise<string | null> {
+async function fetchLauncherNonce(): Promise<FetchResult<string>> {
+  let res: Response;
   try {
-    const res = await fetch(`${API_BASE}${API_LAUNCHER_NONCE}`, { method: "GET" });
-    if (!res.ok) return null;
-    const body = (await res.json()) as { nonce?: unknown };
-    return typeof body.nonce === "string" ? body.nonce : null;
-  } catch {
-    return null;
+    res = await fetch(`${API_BASE}${API_LAUNCHER_NONCE}`, { method: "GET" });
+  } catch (err) {
+    return { ok: false, kind: "network", detail: err instanceof Error ? err.message : String(err) };
   }
+  if (res.status === 404) return { ok: false, kind: "not-built" };
+  if (!res.ok) return { ok: false, kind: "server-error", detail: `HTTP ${res.status}` };
+  const body = (await res.json()) as { nonce?: unknown };
+  if (typeof body.nonce !== "string") {
+    return { ok: false, kind: "server-error", detail: "malformed nonce response" };
+  }
+  return { ok: true, value: body.nonce };
 }
 
 function deriveCwdFromDocPath(docPath: string | null): string | null {
@@ -177,11 +188,15 @@ async function postLauncherMutation(
   extraBody: Record<string, unknown>,
   labels: { failPrefix: string; requestFailPrefix: string; successMessage: string },
 ): Promise<void> {
-  const nonce = await fetchLauncherNonce();
-  if (!nonce) {
-    d.notify("error", "Failed to acquire launcher nonce.");
+  const nonceResult = await fetchLauncherNonce();
+  if (!nonceResult.ok) {
+    d.notify(
+      "error",
+      `Failed to acquire launcher nonce: ${nonceResult.kind}${nonceResult.detail ? ` (${nonceResult.detail})` : ""}.`,
+    );
     return;
   }
+  const nonce = nonceResult.value;
   try {
     const res = await fetch(`${API_BASE}${endpoint}`, {
       method: "POST",
@@ -204,10 +219,33 @@ async function postLauncherMutation(
  * should bail (caller need not notify — guards notify when appropriate). */
 async function checkLauncherAvailable(d: ActionDeps): Promise<boolean> {
   if (launcherInflight) return false;
-  const status = await fetchLauncherStatus();
-  if (!status || !status.available) {
+  const result = await fetchLauncherStatus();
+  if (!result.ok) {
+    if (result.kind === "not-built") {
+      d.notify("warning", "Claude launcher not active in this Tandem build.");
+    } else if (result.kind === "network") {
+      d.notify("error", `Cannot reach Tandem server${result.detail ? `: ${result.detail}` : ""}.`);
+    } else {
+      d.notify(
+        "error",
+        `Launcher status check failed${result.detail ? `: ${result.detail}` : ""}.`,
+      );
+    }
+    return false;
+  }
+  const status = result.value;
+  if (!status.available) {
     d.notify("warning", "Claude launcher not active in this Tandem build.");
     return false;
+  }
+  // Side-channel: surface bundled-skill refresh failures to the user. The
+  // server only includes `skillRefresh` on loopback, and the field is
+  // optional on the discriminated-union so absence is the success case.
+  if ("skillRefresh" in status && status.skillRefresh) {
+    d.notify(
+      "warning",
+      `Bundled skill refresh failed: ${status.skillRefresh.message}. Run \`tandem setup\` to retry.`,
+    );
   }
   return true;
 }

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -9,7 +9,15 @@
  * Wire the getters by calling wireActionDeps() from App.svelte after mount.
  */
 
-import { API_SAVE, API_SCRATCHPAD } from "../../shared/api-paths.js";
+import {
+  API_LAUNCHER_NONCE,
+  API_LAUNCHER_RELAUNCH,
+  API_LAUNCHER_START_FRESH,
+  API_LAUNCHER_STATUS,
+  API_SAVE,
+  API_SCRATCHPAD,
+} from "../../shared/api-paths.js";
+import type { LauncherStatus } from "../../shared/launcher/contract.js";
 import { API_BASE } from "../utils/fileUpload.js";
 import { type Action, registerAction } from "./registry.svelte.js";
 
@@ -19,6 +27,12 @@ import { type Action, registerAction } from "./registry.svelte.js";
 
 interface ActionDeps {
   getActiveTabId: () => string | null;
+  /** Absolute filesystem path of the active doc, or null for upload://,
+   * scratchpads, or app-internal docs. Launcher palette actions use this
+   * to derive a cwd for `/relaunch-here`. */
+  getActiveDocumentPath: () => string | null;
+  /** Push a transient toast notification (info/warning/error). */
+  notify: (severity: "info" | "warning" | "error", message: string) => void;
   openSettings: () => void;
   /**
    * Open the new SettingsModal (Wave 1 sibling component). Separate from
@@ -113,6 +127,138 @@ export async function triggerSave(activeDocId: string | null): Promise<void> {
   } finally {
     inflight = false;
     saving = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Claude launcher — /relaunch-here + start-fresh (#477 PR 4b)
+// ---------------------------------------------------------------------------
+
+let launcherInflight = false;
+
+async function fetchLauncherStatus(): Promise<LauncherStatus | null> {
+  try {
+    const res = await fetch(`${API_BASE}${API_LAUNCHER_STATUS}`);
+    if (!res.ok) return null;
+    return (await res.json()) as LauncherStatus;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchLauncherNonce(): Promise<string | null> {
+  try {
+    const res = await fetch(`${API_BASE}${API_LAUNCHER_NONCE}`, { method: "GET" });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { nonce?: unknown };
+    return typeof body.nonce === "string" ? body.nonce : null;
+  } catch {
+    return null;
+  }
+}
+
+function deriveCwdFromDocPath(docPath: string | null): string | null {
+  if (!docPath) return null;
+  // Reject upload:// and other non-filesystem URIs before they reach the API.
+  if (/^[a-z]+:\/\//.test(docPath)) return null;
+  // path.dirname equivalent that handles both separators.
+  const lastSlash = Math.max(docPath.lastIndexOf("/"), docPath.lastIndexOf("\\"));
+  return lastSlash > 0 ? docPath.slice(0, lastSlash) : null;
+}
+
+/** Convergent tail for both launcher palette actions: acquire a nonce,
+ * POST to the endpoint, notify on success/failure. Diverges on the
+ * preflight (status check, cwd derivation, confirm prompt) — that lives
+ * in each caller. The `extraBody` carries action-specific fields (cwd
+ * for relaunch; nothing for start-fresh). */
+async function postLauncherMutation(
+  d: ActionDeps,
+  endpoint: string,
+  extraBody: Record<string, unknown>,
+  labels: { failPrefix: string; requestFailPrefix: string; successMessage: string },
+): Promise<void> {
+  const nonce = await fetchLauncherNonce();
+  if (!nonce) {
+    d.notify("error", "Failed to acquire launcher nonce.");
+    return;
+  }
+  try {
+    const res = await fetch(`${API_BASE}${endpoint}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...extraBody, nonce }),
+    });
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { message?: string };
+      d.notify("error", `${labels.failPrefix}: ${body.message ?? res.statusText}`);
+      return;
+    }
+    d.notify("info", labels.successMessage);
+  } catch (err) {
+    d.notify("error", `${labels.requestFailPrefix}: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
+/** Guards that both palette actions share: in-flight check + availability
+ * probe. Returns true when the caller should proceed, false when it
+ * should bail (caller need not notify — guards notify when appropriate). */
+async function checkLauncherAvailable(d: ActionDeps): Promise<boolean> {
+  if (launcherInflight) return false;
+  const status = await fetchLauncherStatus();
+  if (!status || !status.available) {
+    d.notify("warning", "Claude launcher not active in this Tandem build.");
+    return false;
+  }
+  return true;
+}
+
+async function relaunchHere(d: ActionDeps): Promise<void> {
+  if (!(await checkLauncherAvailable(d))) return;
+  const cwd = deriveCwdFromDocPath(d.getActiveDocumentPath());
+  if (!cwd) {
+    d.notify(
+      "warning",
+      "Active document isn't saved to a folder. Set a working directory in Settings → Claude Code.",
+    );
+    return;
+  }
+  if (!confirm(`Restart Claude in:\n${cwd}\n\nYour current task may be interrupted.`)) return;
+  launcherInflight = true;
+  try {
+    await postLauncherMutation(
+      d,
+      API_LAUNCHER_RELAUNCH,
+      { cwd },
+      {
+        failPrefix: "Relaunch failed",
+        requestFailPrefix: "Relaunch request failed",
+        successMessage: `Claude restarting in ${cwd}.`,
+      },
+    );
+  } finally {
+    launcherInflight = false;
+  }
+}
+
+async function startFreshConversation(d: ActionDeps): Promise<void> {
+  if (!(await checkLauncherAvailable(d))) return;
+  if (!confirm("Drop Claude's saved conversation and restart fresh. This cannot be undone.")) {
+    return;
+  }
+  launcherInflight = true;
+  try {
+    await postLauncherMutation(
+      d,
+      API_LAUNCHER_START_FRESH,
+      {},
+      {
+        failPrefix: "Start fresh failed",
+        requestFailPrefix: "Start-fresh request failed",
+        successMessage: "Claude restarting with a fresh conversation.",
+      },
+    );
+  } finally {
+    launcherInflight = false;
   }
 }
 
@@ -303,6 +449,22 @@ const BUILTINS: Action[] = [
     shortcut: "Ctrl+Alt+A",
     run() {
       guardedRun("toggle-authorship", (d) => d.toggleAuthorship());
+    },
+  },
+  {
+    id: "launcher-relaunch-here",
+    label: "Relaunch Claude in this folder",
+    group: "claude",
+    run() {
+      guardedRun("launcher-relaunch-here", (d) => void relaunchHere(d));
+    },
+  },
+  {
+    id: "launcher-start-fresh",
+    label: "Start fresh Claude conversation",
+    group: "claude",
+    run() {
+      guardedRun("launcher-start-fresh", (d) => void startFreshConversation(d));
     },
   },
 ];

--- a/src/client/actions/registry.svelte.ts
+++ b/src/client/actions/registry.svelte.ts
@@ -12,7 +12,14 @@
  * ADR-029 (docs/decisions.md) records the design rationale.
  */
 
-export const ACTION_GROUPS = ["editor", "navigation", "view", "document", "annotations"] as const;
+export const ACTION_GROUPS = [
+  "editor",
+  "navigation",
+  "view",
+  "document",
+  "annotations",
+  "claude",
+] as const;
 export type ActionGroup = (typeof ACTION_GROUPS)[number];
 
 export interface Action {

--- a/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
+++ b/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+import { API_LAUNCHER_WORKING_DIRECTORY } from "../../../shared/api-paths";
 import { SELECTION_DWELL_MAX_MS, SELECTION_DWELL_MIN_MS } from "../../../shared/constants";
 import { isTauriRuntime } from "../../cowork/cowork-helpers";
+import { API_BASE } from "../../utils/fileUpload";
 import type { SettingsTabContext } from "../SettingsModal.svelte";
 
 // Keep `$props()` as a single proxy variable and read fields via `ctx.foo`.
@@ -12,6 +14,87 @@ function openWizard() {
   // Custom event picked up by App.svelte. Avoids threading a callback through
   // every SettingsModal tab; the modal owner already listens for tab actions.
   window.dispatchEvent(new CustomEvent("tandem:open-integration-wizard"));
+}
+
+// --- workingDirectory picker (#477 PR 4b) ---------------------------------
+// State here is local to this mount — the settings ctx targets useTandemSettings,
+// while workingDirectory lives on the claude-code integration in integrations.json.
+
+let workingDirectory = $state<string | null>(null);
+let wdInflight = $state(false);
+let wdError = $state<string | null>(null);
+let wdLoaded = $state(false);
+let hasIntegration = $state(false);
+
+async function loadWorkingDirectory() {
+  try {
+    const res = await fetch(`${API_BASE}/api/integrations`);
+    if (!res.ok) return;
+    const file = (await res.json()) as {
+      integrations?: { kind?: string; workingDirectory?: string }[];
+    };
+    const entry = file.integrations?.find((i) => i.kind === "claude-code");
+    if (entry) {
+      hasIntegration = true;
+      workingDirectory = entry.workingDirectory ?? null;
+    }
+  } catch (err) {
+    console.warn("[Settings] Failed to load workingDirectory:", err);
+  } finally {
+    wdLoaded = true;
+  }
+}
+
+void loadWorkingDirectory();
+
+async function persistWorkingDirectory(value: string | null) {
+  wdInflight = true;
+  wdError = null;
+  try {
+    const res = await fetch(`${API_BASE}${API_LAUNCHER_WORKING_DIRECTORY}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ workingDirectory: value }),
+    });
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { message?: string };
+      wdError = body.message ?? `Save failed (${res.status})`;
+      return;
+    }
+    const body = (await res.json()) as { workingDirectory?: string | null };
+    workingDirectory = body.workingDirectory ?? null;
+  } catch (err) {
+    wdError = err instanceof Error ? err.message : String(err);
+  } finally {
+    wdInflight = false;
+  }
+}
+
+async function pickFolder() {
+  try {
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      title: "Choose Claude working directory",
+    });
+    if (typeof selected === "string") {
+      void persistWorkingDirectory(selected);
+    }
+  } catch (err) {
+    wdError = `Folder picker unavailable: ${err instanceof Error ? err.message : err}`;
+  }
+}
+
+function handleManualSave(e: SubmitEvent) {
+  e.preventDefault();
+  const input = (e.target as HTMLFormElement).elements.namedItem("wd") as HTMLInputElement | null;
+  const value = input?.value.trim();
+  void persistWorkingDirectory(value ? value : null);
+}
+
+function handleReset() {
+  void persistWorkingDirectory(null);
 }
 </script>
 
@@ -80,6 +163,55 @@ function openWizard() {
   />
   <span>Margin annotation view (Word-style)</span>
 </label>
+
+{#if wdLoaded && hasIntegration}
+  <div data-testid="settings-modal-working-directory" style="display: flex; flex-direction: column; gap: var(--tandem-space-2);">
+    <div class="settings-section-label">Claude working directory</div>
+    <div style="font-size: 10px; color: var(--tandem-fg-subtle);">
+      Folder where Claude launches. Defaults to your home directory if empty.
+    </div>
+    <form onsubmit={handleManualSave} style="display: flex; gap: var(--tandem-space-2);">
+      <input
+        type="text"
+        name="wd"
+        value={workingDirectory ?? ""}
+        placeholder={"(default: home)"}
+        disabled={wdInflight}
+        data-testid="settings-modal-working-directory-input"
+        style="flex: 1; font-size: 12px; padding: var(--tandem-space-2); border-radius: var(--tandem-r-2); border: 1px solid var(--tandem-border); background: var(--tandem-surface); color: var(--tandem-fg); font-family: var(--tandem-font-mono);"
+      />
+      <button
+        type="submit"
+        disabled={wdInflight}
+        data-testid="settings-modal-working-directory-save"
+        style="font-size: 12px; padding: var(--tandem-space-2) var(--tandem-space-3); border-radius: var(--tandem-r-2); border: 1px solid var(--tandem-border); background: var(--tandem-surface-elevated); color: var(--tandem-fg); cursor: pointer;"
+      >Save</button>
+    </form>
+    <div style="display: flex; gap: var(--tandem-space-2);">
+      {#if isTauriRuntime()}
+        <button
+          type="button"
+          onclick={pickFolder}
+          disabled={wdInflight}
+          data-testid="settings-modal-working-directory-pick"
+          style="font-size: 12px; padding: var(--tandem-space-2) var(--tandem-space-3); border-radius: var(--tandem-r-2); border: 1px solid var(--tandem-border); background: var(--tandem-surface-elevated); color: var(--tandem-fg); cursor: pointer;"
+        >Choose folder…</button>
+      {/if}
+      <button
+        type="button"
+        onclick={handleReset}
+        disabled={wdInflight || workingDirectory === null}
+        data-testid="settings-modal-working-directory-reset"
+        style="font-size: 12px; padding: var(--tandem-space-2) var(--tandem-space-3); border-radius: var(--tandem-r-2); border: 1px solid var(--tandem-border); background: transparent; color: var(--tandem-fg-muted); cursor: pointer;"
+      >Reset to default</button>
+    </div>
+    {#if wdError}
+      <div role="alert" style="font-size: 11px; color: var(--tandem-error-fg);">
+        {wdError}
+      </div>
+    {/if}
+  </div>
+{/if}
 
 <button
   type="button"

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -79,6 +79,8 @@ const mcpPort = parseInt(process.env.TANDEM_MCP_PORT || String(DEFAULT_MCP_PORT)
 let httpServer: Server | null = null;
 let isShuttingDown = false;
 let launcherSupervisor: import("./launcher/supervisor.js").Supervisor | null = null;
+let launcherUnavailableReason: import("../shared/launcher/contract.js").LauncherUnavailableReason =
+  process.env.TANDEM_DISABLE_LAUNCHER === "1" ? "disabled-by-env" : "stdio-mode";
 
 // Swallow known Hocuspocus/ws protocol errors but crash on genuine bugs.
 function handleFatalError(label: string, value: unknown): void {
@@ -425,7 +427,10 @@ async function main() {
     }
 
     const [srv] = await Promise.all([
-      startMcpServerHttp(mcpPort, bindHost, authToken, resolvedLanIP),
+      startMcpServerHttp(mcpPort, bindHost, authToken, resolvedLanIP, {
+        getSupervisor: () => launcherSupervisor,
+        unavailableReason: () => launcherUnavailableReason,
+      }),
       startHocuspocus(wsPort).then(() => {
         console.error(`[Tandem] Hocuspocus WebSocket server running on ws://127.0.0.1:${wsPort}`);
       }),
@@ -453,8 +458,14 @@ async function main() {
         launcherSupervisor = createSupervisor({
           integrationsBase: resolveAppDataDir(),
         });
+        // Refresh the bundled skill on-disk if the version stamp moved
+        // forward — existing users pick up skill updates without re-running
+        // `tandem setup`. Best-effort, non-blocking.
+        const { refreshSkillIfStale } = await import("./integrations/apply.js");
+        void refreshSkillIfStale();
         await launcherSupervisor.start();
       } catch (err) {
+        launcherUnavailableReason = "spawn-failed";
         console.error(
           `[Tandem] Launcher supervisor failed to start (non-fatal): ${err instanceof Error ? err.message : err}`,
         );

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -693,6 +693,62 @@ export async function installSkill(opts: { homeOverride?: string } = {}): Promis
   await atomicWrite(SKILL_CONTENT, skillPath);
 }
 
+/** Parse the integer `version:` from a skill front-matter block. Returns 0
+ * if the file doesn't exist, has no version, or fails to parse — older
+ * bundled skills predate the version stamp, so 0 means "definitely upgrade". */
+function readSkillVersion(skillContent: string): number {
+  const match = skillContent.match(/^version:\s*(\d+)\s*$/m);
+  if (!match) return 0;
+  const n = parseInt(match[1], 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+const BUNDLED_SKILL_VERSION = readSkillVersion(SKILL_CONTENT);
+
+/**
+ * Idempotent skill refresh — called from supervisor startup so existing
+ * users (who already ran `tandem setup` once) pick up bundled-skill
+ * updates without re-running the wizard.
+ *
+ * Compares the bundled `version:` against the on-disk file. Writes only
+ * if bundled > on-disk. Silently no-ops on any error (read failure,
+ * write failure, missing parent dir) — this is a best-effort refresh,
+ * not a critical path. The wizard-driven `installSkill()` remains the
+ * authoritative installer.
+ */
+export async function refreshSkillIfStale(opts: { homeOverride?: string } = {}): Promise<void> {
+  if (BUNDLED_SKILL_VERSION === 0) return; // Bundled skill has no version stamp — nothing to compare.
+  const home = opts.homeOverride ?? homedir();
+  const skillPath = join(home, ".claude", "skills", "tandem", "SKILL.md");
+  try {
+    assertPathSafe(skillPath, {
+      allowedRoots: opts.homeOverride ? [opts.homeOverride] : undefined,
+    });
+  } catch {
+    return;
+  }
+  let onDiskVersion = -1; // -1 = file missing (treat as needing install)
+  try {
+    const fs = await import("node:fs/promises");
+    const current = await fs.readFile(skillPath, "utf8");
+    onDiskVersion = readSkillVersion(current);
+  } catch {
+    // File missing or unreadable — fall through to write.
+  }
+  if (onDiskVersion >= BUNDLED_SKILL_VERSION) return;
+  try {
+    await mkdir(dirname(skillPath), { recursive: true });
+    await atomicWrite(SKILL_CONTENT, skillPath);
+    console.error(
+      `[Tandem] Refreshed bundled skill at ${skillPath} (v${onDiskVersion} → v${BUNDLED_SKILL_VERSION}).`,
+    );
+  } catch (err) {
+    console.error(
+      `[Tandem] Skill refresh failed (non-fatal): ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
 /**
  * Returns true if the channel-shim build artifact exists at the given path.
  * Exported so the prereq check can be tested without spawning runSetup.

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -705,6 +705,23 @@ function readSkillVersion(skillContent: string): number {
 
 const BUNDLED_SKILL_VERSION = readSkillVersion(SKILL_CONTENT);
 
+/** Module-scoped last-failure record. Cleared on successful refresh; set on
+ * read/write failure. Surfaced via `GET /api/launcher/status` (loopback only)
+ * so the palette/settings UI can warn the user that the bundled skill is
+ * out of date. `null` when last refresh succeeded or was a no-op. */
+let lastSkillRefreshError: { code: "write-failed" | "read-failed"; message: string } | null = null;
+export function getSkillRefreshError(): {
+  code: "write-failed" | "read-failed";
+  message: string;
+} | null {
+  return lastSkillRefreshError;
+}
+/** Test-only — reset module state between tests. */
+export function _resetSkillRefreshErrorForTests(): void {
+  if (process.env.VITEST !== "true") return;
+  lastSkillRefreshError = null;
+}
+
 /**
  * Idempotent skill refresh — called from supervisor startup so existing
  * users (who already ran `tandem setup` once) pick up bundled-skill
@@ -728,21 +745,37 @@ export async function refreshSkillIfStale(opts: { homeOverride?: string } = {}):
     return;
   }
   let onDiskVersion = -1; // -1 = file missing (treat as needing install)
+  let readErr: unknown;
   try {
     const fs = await import("node:fs/promises");
     const current = await fs.readFile(skillPath, "utf8");
     onDiskVersion = readSkillVersion(current);
-  } catch {
-    // File missing or unreadable — fall through to write.
+  } catch (err) {
+    // ENOENT is expected (first run); any other error is a real read failure.
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") readErr = err;
   }
-  if (onDiskVersion >= BUNDLED_SKILL_VERSION) return;
+  if (onDiskVersion >= BUNDLED_SKILL_VERSION) {
+    // No-op path — clear any prior failure only if read succeeded.
+    if (readErr === undefined) lastSkillRefreshError = null;
+    else
+      lastSkillRefreshError = {
+        code: "read-failed",
+        message: readErr instanceof Error ? readErr.message : String(readErr),
+      };
+    return;
+  }
   try {
     await mkdir(dirname(skillPath), { recursive: true });
     await atomicWrite(SKILL_CONTENT, skillPath);
+    lastSkillRefreshError = null;
     console.error(
       `[Tandem] Refreshed bundled skill at ${skillPath} (v${onDiskVersion} → v${BUNDLED_SKILL_VERSION}).`,
     );
   } catch (err) {
+    lastSkillRefreshError = {
+      code: "write-failed",
+      message: err instanceof Error ? err.message : String(err),
+    };
     console.error(
       `[Tandem] Skill refresh failed (non-fatal): ${err instanceof Error ? err.message : err}`,
     );

--- a/src/server/launcher/api-routes.ts
+++ b/src/server/launcher/api-routes.ts
@@ -12,7 +12,7 @@
  *     overlapping operations.
  *   - `POST /start-fresh` — body `{ cwd?, nonce }`. Drops persisted
  *     session, respawns with a new session id.
- *   - `PATCH /working-directory` — body `{ workingDirectory: string | null }`.
+ *   - `POST /working-directory` — body `{ workingDirectory: string | null }`.
  *     Narrow write to the first claude-code integration's
  *     `workingDirectory` field. Bypasses the integrations apply-nonce
  *     rotation that a full-array POST would trigger.
@@ -44,6 +44,7 @@ import {
   LAUNCHER_ERROR_PATH_REJECTED,
   type LauncherStatus,
   type LauncherUnavailableReason,
+  type SkillRefreshError,
 } from "../../shared/launcher/contract.js";
 import { isLoopback } from "../auth/middleware.js";
 import { assertLoopbackForMutation, assertOriginAllowlisted } from "../integrations/api-routes.js";
@@ -133,6 +134,15 @@ export interface LauncherRoutesDeps {
   unavailableReason: () => LauncherUnavailableReason;
   /** Reads/writes the integrations file. Same store passed to integrations routes. */
   store: IntegrationsStore;
+  /** Loopback-only side-channel for skill refresh failures. `null` when the
+   * last refresh succeeded or the helper is not wired (test mode). */
+  getSkillRefreshError?: () => SkillRefreshError | null;
+  /** Test-only seam: hook fires inside try, immediately after `inflight.X = true`,
+   * before the supervisor call. Used to hold an operation in-flight so concurrent
+   * requests exercise the 429 gate. */
+  relaunchHook?: () => Promise<void>;
+  startFreshHook?: () => Promise<void>;
+  workingDirHook?: () => Promise<void>;
 }
 
 export function registerLauncherRoutes(app: Express, mw: Handler, deps: LauncherRoutesDeps): void {
@@ -157,19 +167,29 @@ export function registerLauncherRoutes(app: Express, mw: Handler, deps: Launcher
 function makeStatusHandler(deps: LauncherRoutesDeps): Handler {
   return (req: Request, res: Response) => {
     const sup = deps.getSupervisor();
+    const loopback = isLoopback(req.socket.remoteAddress);
     if (sup === null) {
       const body: LauncherStatus = { available: false, reason: deps.unavailableReason() };
       res.json(body);
       return;
     }
-    const raw = sup.status();
-    const loopback = isLoopback(req.socket.remoteAddress);
+    const skillRefresh = loopback ? (deps.getSkillRefreshError?.() ?? null) : undefined;
+    let raw: ReturnType<Supervisor["status"]>;
+    try {
+      raw = sup.status();
+    } catch {
+      // sup.status() should never throw, but if it does we must not return a
+      // generic 500 — the client maps that to "not active in this Tandem build"
+      // which is wrong. Degrade to a structured `lastError: "status-check-failed"`.
+      const body: LauncherStatus = loopback
+        ? { available: true, running: false, lastError: "status-check-failed", skillRefresh }
+        : { available: true, running: false };
+      res.json(body);
+      return;
+    }
     if (raw.running) {
       if (!loopback) {
-        res.json({ available: true, running: true } satisfies Pick<LauncherStatus, never> & {
-          available: true;
-          running: true;
-        });
+        res.json({ available: true, running: true });
         return;
       }
       const body: LauncherStatus = {
@@ -179,12 +199,13 @@ function makeStatusHandler(deps: LauncherRoutesDeps): Handler {
         cwd: raw.cwd,
         sessionId: "<set>",
         resuming: raw.resuming,
+        skillRefresh,
       };
       res.json(body);
       return;
     }
     const body: LauncherStatus = loopback
-      ? { available: true, running: false, lastError: raw.lastError }
+      ? { available: true, running: false, lastError: raw.lastError, skillRefresh }
       : { available: true, running: false };
     res.json(body);
   };
@@ -238,7 +259,7 @@ function sendInProgress(res: Response, message: string): void {
 
 /** Validate a string cwd field: type, length cap, and home-confined resolution.
  * `fieldName` parameterizes the error messages — "cwd" for request bodies,
- * "workingDirectory" for the PATCH route. */
+ * "workingDirectory" for the POST /working-directory route. */
 function validateCwdString(
   raw: unknown,
   res: Response,
@@ -315,6 +336,7 @@ function makeRelaunchHandler(deps: LauncherRoutesDeps): Handler {
     }
     inflight.relaunch = true;
     try {
+      if (deps.relaunchHook) await deps.relaunchHook();
       await sup.relaunch(cwd);
       res.json({ ok: true, cwd });
     } catch (err) {
@@ -346,6 +368,7 @@ function makeStartFreshHandler(deps: LauncherRoutesDeps): Handler {
     }
     inflight.startFresh = true;
     try {
+      if (deps.startFreshHook) await deps.startFreshHook();
       await sup.startFresh(cwd);
       res.json({ ok: true, cwd: cwd ?? null });
     } catch (err) {
@@ -385,6 +408,7 @@ function makeWorkingDirHandler(deps: LauncherRoutesDeps): Handler {
     }
     inflight.workingDirectory = true;
     try {
+      if (deps.workingDirHook) await deps.workingDirHook();
       const file = await deps.store.read();
       const idx = file.integrations.findIndex(
         (i): i is ClaudeCodeIntegration => i.kind === "claude-code",

--- a/src/server/launcher/api-routes.ts
+++ b/src/server/launcher/api-routes.ts
@@ -1,0 +1,427 @@
+/**
+ * HTTP routes for the Claude Code auto-launcher (#477 PR 4b).
+ *
+ * Five endpoints, all under `/api/launcher/*`:
+ *   - `GET /status` — read-only; loopback returns full struct (with
+ *     `sessionId` redacted to "<set>"), non-loopback returns the minimal
+ *     `{ available, running }` shape (mirrors `/health`'s redaction pattern).
+ *   - `GET /nonce` — issues a one-shot single-use nonce that mutating
+ *     routes require. Rotates on consumption (success or failure).
+ *   - `POST /relaunch` — body `{ cwd, nonce }`. Origin + loopback gates,
+ *     `resolveRouteCwd` validates cwd is under `os.homedir()`. 429 on
+ *     overlapping operations.
+ *   - `POST /start-fresh` — body `{ cwd?, nonce }`. Drops persisted
+ *     session, respawns with a new session id.
+ *   - `PATCH /working-directory` — body `{ workingDirectory: string | null }`.
+ *     Narrow write to the first claude-code integration's
+ *     `workingDirectory` field. Bypasses the integrations apply-nonce
+ *     rotation that a full-array POST would trigger.
+ *
+ * The supervisor singleton is bridged via `() => Supervisor | null`. Routes
+ * return 503 + `NOT_AVAILABLE` when the getter returns null (stdio mode,
+ * disabled-by-env, or no claude-code integration).
+ */
+
+import { randomBytes, timingSafeEqual } from "node:crypto";
+
+import type { Express, Request, Response } from "express";
+
+import {
+  API_LAUNCHER_NONCE,
+  API_LAUNCHER_RELAUNCH,
+  API_LAUNCHER_START_FRESH,
+  API_LAUNCHER_STATUS,
+  API_LAUNCHER_WORKING_DIRECTORY,
+} from "../../shared/api-paths.js";
+import type { ClaudeCodeIntegration } from "../../shared/integrations/contract.js";
+import {
+  LAUNCHER_CWD_MAX_LENGTH,
+  LAUNCHER_ERROR_IN_PROGRESS,
+  LAUNCHER_ERROR_INVALID_BODY,
+  LAUNCHER_ERROR_INVALID_NONCE,
+  LAUNCHER_ERROR_NO_INTEGRATION,
+  LAUNCHER_ERROR_NOT_AVAILABLE,
+  LAUNCHER_ERROR_PATH_REJECTED,
+  type LauncherStatus,
+  type LauncherUnavailableReason,
+} from "../../shared/launcher/contract.js";
+import { isLoopback } from "../auth/middleware.js";
+import { assertLoopbackForMutation, assertOriginAllowlisted } from "../integrations/api-routes.js";
+import type { IntegrationConfig } from "../integrations/schema.js";
+import type { IntegrationsStore } from "../integrations/storage.js";
+import type { Handler } from "../mcp/routes/_shared.js";
+import { resolveRouteCwd, type Supervisor } from "./supervisor.js";
+
+/**
+ * Single-use nonce gate for mutating launcher routes.
+ *
+ * Each `GET /api/launcher/nonce` rotates the value (any in-flight nonce is
+ * invalidated). Mutating routes consume the nonce — successful OR failed —
+ * to prevent replay. This is defense-in-depth on top of the origin gate:
+ * a malicious page on a loopback-resident dev tool that bypasses origin
+ * checks still needs to read the nonce via a separate GET before it can
+ * drive a destructive op.
+ */
+interface LauncherGateState {
+  nonce: string;
+}
+
+function createGate(): LauncherGateState {
+  return { nonce: randomBytes(32).toString("base64url") };
+}
+
+let gate: LauncherGateState | null = null;
+
+function getGate(): LauncherGateState {
+  if (gate === null) gate = createGate();
+  return gate;
+}
+
+function rotateNonce(): void {
+  gate = createGate();
+}
+
+/** Test-only nonce reset. Guarded on VITEST so production callers can't
+ * reach this surface even via Express stack tricks. */
+export function _resetLauncherGateForTests(): void {
+  if (process.env.VITEST !== "true") {
+    throw new Error("_resetLauncherGateForTests is test-only");
+  }
+  gate = createGate();
+}
+
+/**
+ * Per-route in-flight flags. `relaunch` and `start-fresh` each have their own
+ * because they're independently destructive — overlapping calls return 429
+ * rather than queueing. The supervisor's `withLock` would queue them, but
+ * the UX cost of two stop/spawn cycles back-to-back is worse than a clear
+ * "already running" error.
+ */
+interface InflightState {
+  relaunch: boolean;
+  startFresh: boolean;
+  workingDirectory: boolean;
+}
+
+const inflight: InflightState = {
+  relaunch: false,
+  startFresh: false,
+  workingDirectory: false,
+};
+
+export function _resetInflightForTests(): void {
+  if (process.env.VITEST !== "true") {
+    throw new Error("_resetInflightForTests is test-only");
+  }
+  inflight.relaunch = false;
+  inflight.startFresh = false;
+  inflight.workingDirectory = false;
+}
+
+export interface LauncherRoutesDeps {
+  /**
+   * The supervisor singleton lives in `src/server/index.ts` and is only
+   * created inside `Promise.all([startMcpServerHttp, startHocuspocus])`,
+   * *after* `createMcpHttpServer()` returns. Static deps injection isn't
+   * possible — the getter is the explicit "late-bound" handshake.
+   * Returns `null` in stdio mode, when `TANDEM_DISABLE_LAUNCHER=1`, or
+   * when `claude-code` integration is absent.
+   */
+  getSupervisor: () => Supervisor | null;
+  /** Reason the supervisor is unavailable (stdio mode, disabled, no integration).
+   * Surfaced via GET /status. */
+  unavailableReason: () => LauncherUnavailableReason;
+  /** Reads/writes the integrations file. Same store passed to integrations routes. */
+  store: IntegrationsStore;
+}
+
+export function registerLauncherRoutes(app: Express, mw: Handler, deps: LauncherRoutesDeps): void {
+  app.options(API_LAUNCHER_STATUS, mw);
+  app.get(API_LAUNCHER_STATUS, mw, makeStatusHandler(deps));
+
+  app.options(API_LAUNCHER_NONCE, mw);
+  app.get(API_LAUNCHER_NONCE, mw, makeNonceHandler());
+
+  app.options(API_LAUNCHER_RELAUNCH, mw);
+  app.post(API_LAUNCHER_RELAUNCH, mw, makeRelaunchHandler(deps));
+
+  app.options(API_LAUNCHER_START_FRESH, mw);
+  app.post(API_LAUNCHER_START_FRESH, mw, makeStartFreshHandler(deps));
+
+  app.options(API_LAUNCHER_WORKING_DIRECTORY, mw);
+  app.post(API_LAUNCHER_WORKING_DIRECTORY, mw, makeWorkingDirHandler(deps));
+}
+
+// --- Handlers -------------------------------------------------------------
+
+function makeStatusHandler(deps: LauncherRoutesDeps): Handler {
+  return (req: Request, res: Response) => {
+    const sup = deps.getSupervisor();
+    if (sup === null) {
+      const body: LauncherStatus = { available: false, reason: deps.unavailableReason() };
+      res.json(body);
+      return;
+    }
+    const raw = sup.status();
+    const loopback = isLoopback(req.socket.remoteAddress);
+    if (raw.running) {
+      if (!loopback) {
+        res.json({ available: true, running: true } satisfies Pick<LauncherStatus, never> & {
+          available: true;
+          running: true;
+        });
+        return;
+      }
+      const body: LauncherStatus = {
+        available: true,
+        running: true,
+        reaperPid: raw.reaperPid,
+        cwd: raw.cwd,
+        sessionId: "<set>",
+        resuming: raw.resuming,
+      };
+      res.json(body);
+      return;
+    }
+    const body: LauncherStatus = loopback
+      ? { available: true, running: false, lastError: raw.lastError }
+      : { available: true, running: false };
+    res.json(body);
+  };
+}
+
+function makeNonceHandler(): Handler {
+  return (req: Request, res: Response) => {
+    if (assertOriginAllowlisted(req, res, API_LAUNCHER_NONCE)) return;
+    if (assertLoopbackForMutation(req, res)) return;
+    rotateNonce();
+    res.json({ nonce: getGate().nonce });
+  };
+}
+
+/** Constant-time nonce check + rotate on consumption (success or failure). */
+function consumeNonce(received: unknown, res: Response): boolean {
+  if (typeof received !== "string" || received.length === 0) {
+    rotateNonce();
+    res.status(403).json({
+      error: "FORBIDDEN",
+      code: LAUNCHER_ERROR_INVALID_NONCE,
+      message: "nonce missing",
+    });
+    return false;
+  }
+  const expected = Buffer.from(getGate().nonce);
+  const got = Buffer.from(received);
+  const ok = got.length === expected.length && timingSafeEqual(got, expected);
+  rotateNonce();
+  if (!ok) {
+    res.status(403).json({
+      error: "FORBIDDEN",
+      code: LAUNCHER_ERROR_INVALID_NONCE,
+      message: "nonce mismatch (single-use; fetch a fresh one from GET /api/launcher/nonce)",
+    });
+  }
+  return ok;
+}
+
+function sendBadRequest(res: Response, code: string, message: string): void {
+  res.status(400).json({ error: "BAD_REQUEST", code, message });
+}
+
+function sendInProgress(res: Response, message: string): void {
+  res.status(429).json({
+    error: "TOO_MANY_REQUESTS",
+    code: LAUNCHER_ERROR_IN_PROGRESS,
+    message,
+  });
+}
+
+/** Validate a string cwd field: type, length cap, and home-confined resolution.
+ * `fieldName` parameterizes the error messages — "cwd" for request bodies,
+ * "workingDirectory" for the PATCH route. */
+function validateCwdString(
+  raw: unknown,
+  res: Response,
+  fieldName: "cwd" | "workingDirectory",
+): string | null {
+  if (typeof raw !== "string") {
+    sendBadRequest(res, LAUNCHER_ERROR_INVALID_BODY, `${fieldName} must be a string`);
+    return null;
+  }
+  if (raw.length > LAUNCHER_CWD_MAX_LENGTH) {
+    sendBadRequest(
+      res,
+      LAUNCHER_ERROR_INVALID_BODY,
+      `${fieldName} exceeds ${LAUNCHER_CWD_MAX_LENGTH} chars`,
+    );
+    return null;
+  }
+  const resolved = resolveRouteCwd(raw);
+  if (resolved === null) {
+    sendBadRequest(
+      res,
+      LAUNCHER_ERROR_PATH_REJECTED,
+      `${fieldName} must be an absolute path inside the user's home directory`,
+    );
+    return null;
+  }
+  return resolved;
+}
+
+/** Parse + validate that the request body is a non-null JSON object.
+ * Returns the body cast to a loose record on success; sends 400 and returns
+ * null on failure. */
+function parseJsonObjectBody(req: Request, res: Response): Record<string, unknown> | null {
+  const body = req.body as unknown;
+  if (!body || typeof body !== "object") {
+    sendBadRequest(res, LAUNCHER_ERROR_INVALID_BODY, "request body must be a JSON object");
+    return null;
+  }
+  return body as Record<string, unknown>;
+}
+
+function requireSupervisor(deps: LauncherRoutesDeps, res: Response): Supervisor | null {
+  const sup = deps.getSupervisor();
+  if (sup === null) {
+    res.status(503).json({
+      error: "SERVICE_UNAVAILABLE",
+      code: LAUNCHER_ERROR_NOT_AVAILABLE,
+      reason: deps.unavailableReason(),
+      message: "Auto-launcher is not available in this runtime",
+    });
+    return null;
+  }
+  return sup;
+}
+
+function makeRelaunchHandler(deps: LauncherRoutesDeps): Handler {
+  return async (req: Request, res: Response) => {
+    if (assertOriginAllowlisted(req, res, API_LAUNCHER_RELAUNCH)) return;
+    if (assertLoopbackForMutation(req, res)) return;
+    const body = parseJsonObjectBody(req, res);
+    if (body === null) return;
+    // Nonce consumption MUST precede cwd validation — the nonce rotates on
+    // every mutating attempt (good or bad) to prevent replay.
+    if (!consumeNonce(body.nonce, res)) return;
+    const cwd = validateCwdString(body.cwd, res, "cwd");
+    if (cwd === null) return;
+    const sup = requireSupervisor(deps, res);
+    if (sup === null) return;
+    // relaunch and startFresh are mutually exclusive — they're two flavors
+    // of the same destructive stop+respawn operation.
+    if (inflight.relaunch || inflight.startFresh) {
+      sendInProgress(res, "another relaunch/start-fresh is in progress");
+      return;
+    }
+    inflight.relaunch = true;
+    try {
+      await sup.relaunch(cwd);
+      res.json({ ok: true, cwd });
+    } catch (err) {
+      sendUnexpected(res, err, "relaunch failed");
+    } finally {
+      inflight.relaunch = false;
+    }
+  };
+}
+
+function makeStartFreshHandler(deps: LauncherRoutesDeps): Handler {
+  return async (req: Request, res: Response) => {
+    if (assertOriginAllowlisted(req, res, API_LAUNCHER_START_FRESH)) return;
+    if (assertLoopbackForMutation(req, res)) return;
+    const body = parseJsonObjectBody(req, res);
+    if (body === null) return;
+    if (!consumeNonce(body.nonce, res)) return;
+    let cwd: string | undefined;
+    if (body.cwd !== undefined) {
+      const resolved = validateCwdString(body.cwd, res, "cwd");
+      if (resolved === null) return;
+      cwd = resolved;
+    }
+    const sup = requireSupervisor(deps, res);
+    if (sup === null) return;
+    if (inflight.relaunch || inflight.startFresh) {
+      sendInProgress(res, "another relaunch/start-fresh is in progress");
+      return;
+    }
+    inflight.startFresh = true;
+    try {
+      await sup.startFresh(cwd);
+      res.json({ ok: true, cwd: cwd ?? null });
+    } catch (err) {
+      sendUnexpected(res, err, "start-fresh failed");
+    } finally {
+      inflight.startFresh = false;
+    }
+  };
+}
+
+function makeWorkingDirHandler(deps: LauncherRoutesDeps): Handler {
+  return async (req: Request, res: Response) => {
+    if (assertOriginAllowlisted(req, res, API_LAUNCHER_WORKING_DIRECTORY)) return;
+    if (assertLoopbackForMutation(req, res)) return;
+    const body = parseJsonObjectBody(req, res);
+    if (body === null) return;
+    // workingDirectory is `string | null`: null means "clear (use default)";
+    // string means "validate + persist". Anything else is rejected.
+    const wd = body.workingDirectory;
+    let validated: string | null;
+    if (wd === null) {
+      validated = null;
+    } else if (typeof wd === "string") {
+      const resolved = validateCwdString(wd, res, "workingDirectory");
+      if (resolved === null) return;
+      validated = resolved;
+    } else {
+      sendBadRequest(res, LAUNCHER_ERROR_INVALID_BODY, "workingDirectory must be a string or null");
+      return;
+    }
+    // workingDirectory has its OWN inflight flag — it doesn't block relaunch
+    // or start-fresh because it only rewrites integrations.json (not the
+    // running supervisor).
+    if (inflight.workingDirectory) {
+      sendInProgress(res, "another working-directory update is in progress");
+      return;
+    }
+    inflight.workingDirectory = true;
+    try {
+      const file = await deps.store.read();
+      const idx = file.integrations.findIndex(
+        (i): i is ClaudeCodeIntegration => i.kind === "claude-code",
+      );
+      if (idx === -1) {
+        res.status(404).json({
+          error: "NOT_FOUND",
+          code: LAUNCHER_ERROR_NO_INTEGRATION,
+          message: "no claude-code integration in integrations.json",
+        });
+        return;
+      }
+      const current = file.integrations[idx] as ClaudeCodeIntegration;
+      const updated: ClaudeCodeIntegration = { ...current };
+      if (validated === null) {
+        delete (updated as { workingDirectory?: string }).workingDirectory;
+      } else {
+        updated.workingDirectory = validated;
+      }
+      const newFile = {
+        ...file,
+        integrations: file.integrations.map(
+          (entry, i): IntegrationConfig => (i === idx ? updated : entry),
+        ),
+      };
+      await deps.store.write(newFile);
+      res.json({ ok: true, workingDirectory: validated });
+    } catch (err) {
+      sendUnexpected(res, err, "failed to write workingDirectory");
+    } finally {
+      inflight.workingDirectory = false;
+    }
+  };
+}
+
+function sendUnexpected(res: Response, err: unknown, label: string): void {
+  console.error(`[Launcher routes] ${label}:`, err);
+  if (res.headersSent) return;
+  res.status(500).json({ error: "INTERNAL_ERROR", code: "INTERNAL_ERROR", message: label });
+}

--- a/src/server/launcher/supervisor.ts
+++ b/src/server/launcher/supervisor.ts
@@ -23,6 +23,7 @@ import os from "node:os";
 import path from "node:path";
 
 import type { ClaudeCodeIntegration } from "../../shared/integrations/contract.js";
+import type { LauncherErrorCode } from "../../shared/launcher/contract.js";
 import { createIntegrationsStore } from "../integrations/storage.js";
 
 interface SupervisorOpts {
@@ -57,8 +58,11 @@ export interface Supervisor {
   relaunch(newCwd: string): Promise<void>;
   /** Idempotent — safe to call when not running. */
   stop(): Promise<void>;
-  /** Drop any persisted session so the next start uses a fresh one. */
-  startFresh(): Promise<void>;
+  /** Drop any persisted session and respawn fresh.
+   * If `cwdOverride` is provided, the spawn uses that cwd (and the integration's
+   * persisted workingDirectory is left untouched). Otherwise uses the integration's
+   * setting. Single atomic stop+clear+spawn under the supervisor lock. */
+  startFresh(cwdOverride?: string): Promise<void>;
   /** Current state for /api/launcher/status. */
   status(): SupervisorStatus;
 }
@@ -66,7 +70,7 @@ export interface Supervisor {
 /** Discriminated union: when `running === false` no other fields exist;
  * when `running === true` all process-level fields are guaranteed present. */
 export type SupervisorStatus =
-  | { running: false; lastError?: string }
+  | { running: false; lastError?: LauncherErrorCode }
   | {
       running: true;
       /** PID of the reaper process. Claude's own PID is intentionally not
@@ -95,7 +99,7 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
    * because relaunch awaits stop before chaining. */
   let opLock: Promise<void> = Promise.resolve();
   /** Last fatal error message — surfaced via status() when running=false. */
-  let lastError: string | undefined;
+  let lastError: LauncherErrorCode | undefined;
   function withLock<T>(fn: () => Promise<T>): Promise<T> {
     const next = opLock.then(fn, fn);
     opLock = next.then(
@@ -168,11 +172,13 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
 
   function reaperPath(): string {
     const exeName = process.platform === "win32" ? "tandem-reaper.exe" : "tandem-reaper";
-    // TANDEM_REAPER_PATH is honored only in non-production runtimes (dev,
-    // tests). Production builds resolve from known install locations only —
-    // an attacker-controlled env shouldn't be able to redirect the reaper.
+    // TANDEM_REAPER_PATH is honored only in dev/test runtimes — both
+    // NODE_ENV !== "production" AND not a Tauri sidecar build. Belt-and-suspenders
+    // against a malicious shell rc redirecting the reaper inside a packaged sidecar
+    // where NODE_ENV may not always be set to "production".
     if (
       process.env.NODE_ENV !== "production" &&
+      process.env.TANDEM_TAURI_SIDECAR !== "1" &&
       process.env.TANDEM_REAPER_PATH &&
       fs.existsSync(process.env.TANDEM_REAPER_PATH)
     ) {
@@ -270,13 +276,13 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
       currentSessionId = undefined;
       currentResuming = false;
       if (err.code === "ENOENT") {
-        lastError = "ENOENT: reaper or Claude binary not found";
+        lastError = "binary-not-found";
         breakerTripped = true;
         console.error(
-          `[Launcher] Reaper or Claude binary not found. Install Claude Code: npm i -g @anthropic-ai/claude-code`,
+          `[Launcher] Reaper or Claude binary not found (${err.message}). Install Claude Code: npm i -g @anthropic-ai/claude-code`,
         );
       } else {
-        lastError = `${err.code ?? "spawn-error"}: ${err.message}`;
+        lastError = "spawn-failed";
         console.error("[Launcher] Reaper spawn error:", err);
         if (!stopRequested) scheduleRestart();
       }
@@ -309,6 +315,7 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
     recentAttempts.push(now);
     if (recentAttempts.length > CIRCUIT_BREAKER_MAX_ATTEMPTS) {
       breakerTripped = true;
+      lastError = "circuit-open";
       console.error(
         `[Launcher] Circuit breaker tripped: ${recentAttempts.length} restart attempts in ${CIRCUIT_BREAKER_WINDOW_MS}ms — giving up. Restart Tandem to retry.`,
       );
@@ -402,7 +409,7 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
         console.error(
           "[Launcher] Reaper failed to exit even after SIGKILL — abandoning handle, child may persist",
         );
-        lastError = "stop-failed: reaper unresponsive to SIGKILL";
+        lastError = "stop-failed";
       }
     }
     child = null;
@@ -415,13 +422,15 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
     return withLock(() => stopInternal());
   }
 
-  async function startFresh(): Promise<void> {
+  async function startFresh(cwdOverride?: string): Promise<void> {
     return withLock(async () => {
       await stopInternal();
       clearSavedSession();
       breakerTripped = false;
       recentAttempts = [];
-      await startInternal();
+      const plan = await buildPlan(cwdOverride);
+      if (!plan) return;
+      await spawnOnce(plan);
     });
   }
 
@@ -450,7 +459,12 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
 /** Exported for unit testing. Resolves a cwd candidate to a canonical path,
  * rejecting UNC paths, Windows `\\?\` / `\\.\` device namespaces, relative
  * paths, and anything that does not canonicalize to a real directory.
- * Returns null on any rejection so callers can fall back to a safe default. */
+ * Returns null on any rejection so callers can fall back to a safe default.
+ *
+ * This is the *permissive* resolver used by integration-file reads — a user
+ * who edits `integrations.json` directly can point the launcher at any
+ * canonical directory on disk. HTTP-driven mutations must use
+ * `resolveRouteCwd()` below, which additionally home-confines. */
 export function resolveSafeCwd(candidate: string): string | null {
   if (typeof candidate !== "string" || !path.isAbsolute(candidate)) return null;
   if (process.platform === "win32") {
@@ -465,4 +479,27 @@ export function resolveSafeCwd(candidate: string): string | null {
   } catch {
     return null;
   }
+}
+
+/** HTTP-surface variant of `resolveSafeCwd`. Adds: the canonical path must
+ * be under `os.homedir()` (also canonicalized) so a malicious loopback page
+ * can't pivot Claude into system directories via a junction/symlink the user
+ * happens to have under their home tree. The integration-file path bypasses
+ * this — advanced users who hand-edit `integrations.json` opt into wider
+ * scope. */
+export function resolveRouteCwd(candidate: string): string | null {
+  const safe = resolveSafeCwd(candidate);
+  if (safe === null) return null;
+  let homeReal: string;
+  try {
+    homeReal = fs.realpathSync(os.homedir());
+  } catch {
+    return null;
+  }
+  const rel = path.relative(homeReal, safe);
+  // Outside home (`rel` starts with `..`), or a different drive on Windows
+  // (`rel` is absolute), or the empty string (home itself — allowed).
+  if (rel === "") return safe;
+  if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  return safe;
 }

--- a/src/server/launcher/supervisor.ts
+++ b/src/server/launcher/supervisor.ts
@@ -472,8 +472,12 @@ export function resolveSafeCwd(candidate: string): string | null {
     if (candidate.startsWith("\\\\")) return null; // UNC
   }
   try {
-    const real = fs.realpathSync(candidate);
-    const stat = fs.statSync(real);
+    // This function IS the path validator: it canonicalizes via realpath,
+    // rejects non-directories, and returns null on any failure. Callers
+    // either gate the result further (resolveRouteCwd home-confines) or
+    // accept advanced users' explicit integrations.json scope.
+    const real = fs.realpathSync(candidate); // lgtm[js/path-injection]
+    const stat = fs.statSync(real); // lgtm[js/path-injection]
     if (!stat.isDirectory()) return null;
     return real;
   } catch {

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -203,6 +203,14 @@ function snapshotToolCount(server: McpServer): number | null {
 }
 
 /** Start the MCP server on HTTP using Streamable HTTP transport. Returns the http.Server for lifecycle management. */
+export interface LauncherWiring {
+  /** Late-bound: the supervisor is created in `src/server/index.ts` *after*
+   * this function returns. Routes call this getter on each request. */
+  getSupervisor: () => import("../launcher/supervisor.js").Supervisor | null;
+  /** Why the supervisor is null. Surfaced in `GET /api/launcher/status`. */
+  unavailableReason: () => import("../../shared/launcher/contract.js").LauncherUnavailableReason;
+}
+
 export async function startMcpServerHttp(
   port: number,
   host = DEFAULT_BIND_HOST,
@@ -214,6 +222,8 @@ export async function startMcpServerHttp(
    * undefined for loopback binds — only localhost/127.0.0.1/tauri.localhost allowed.
    */
   resolvedLanIP?: string,
+  /** Launcher route wiring. Omitted in tests; routes simply not registered. */
+  launcher?: LauncherWiring,
 ): Promise<Server> {
   mcpServer = createMcpServer();
   // Snapshot tool count now — all registrations are unconditional in createMcpServer(),
@@ -396,6 +406,20 @@ export async function startMcpServerHttp(
     readExisting: readExistingTandemEntries,
     serverVersion: APP_VERSION,
   });
+
+  // --- Auto-launcher endpoints (#477 PR 4b) ---
+  // Status, single-use nonce, relaunch, start-fresh, and a narrow
+  // working-directory PATCH that bypasses the integrations apply-nonce
+  // rotation. `launcher` is optional — if omitted (tests, future stdio
+  // hardening), the routes are not registered and clients get 404.
+  if (launcher) {
+    const { registerLauncherRoutes } = await import("../launcher/api-routes.js");
+    registerLauncherRoutes(app, lanAwareApiMiddleware, {
+      getSupervisor: launcher.getSupervisor,
+      unavailableReason: launcher.unavailableReason,
+      store: createIntegrationsStore(resolveAppDataDir()),
+    });
+  }
 
   // --- Models registry secrets endpoints (#659) ---
   // Outbound third-party API keys (Anthropic, OpenAI, Gemini, etc.) live in

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -409,15 +409,19 @@ export async function startMcpServerHttp(
 
   // --- Auto-launcher endpoints (#477 PR 4b) ---
   // Status, single-use nonce, relaunch, start-fresh, and a narrow
-  // working-directory PATCH that bypasses the integrations apply-nonce
+  // working-directory POST that bypasses the integrations apply-nonce
   // rotation. `launcher` is optional — if omitted (tests, future stdio
   // hardening), the routes are not registered and clients get 404.
   if (launcher) {
-    const { registerLauncherRoutes } = await import("../launcher/api-routes.js");
+    const [{ registerLauncherRoutes }, { getSkillRefreshError }] = await Promise.all([
+      import("../launcher/api-routes.js"),
+      import("../integrations/apply.js"),
+    ]);
     registerLauncherRoutes(app, lanAwareApiMiddleware, {
       getSupervisor: launcher.getSupervisor,
       unavailableReason: launcher.unavailableReason,
       store: createIntegrationsStore(resolveAppDataDir()),
+      getSkillRefreshError,
     });
   }
 

--- a/src/shared/api-paths.ts
+++ b/src/shared/api-paths.ts
@@ -38,3 +38,10 @@ export const API_CHAT = "/api/chat";
 // --- Setup / auth -----------------------------------------------------------
 export const API_SETUP = "/api/setup";
 export const API_ROTATE_TOKEN = "/api/rotate-token";
+
+// --- Auto-launcher (Claude Code supervisor, #477 PR 4b) ---------------------
+export const API_LAUNCHER_STATUS = "/api/launcher/status";
+export const API_LAUNCHER_NONCE = "/api/launcher/nonce";
+export const API_LAUNCHER_RELAUNCH = "/api/launcher/relaunch";
+export const API_LAUNCHER_START_FRESH = "/api/launcher/start-fresh";
+export const API_LAUNCHER_WORKING_DIRECTORY = "/api/launcher/working-directory";

--- a/src/shared/launcher/contract.ts
+++ b/src/shared/launcher/contract.ts
@@ -26,6 +26,8 @@ export type LauncherStatus =
       running: false;
       /** Last fatal error from the supervisor, scrubbed to a small enum. */
       lastError?: LauncherErrorCode;
+      /** Loopback-only. `null` when last refresh succeeded. */
+      skillRefresh?: SkillRefreshError | null;
     }
   | {
       available: true;
@@ -35,6 +37,8 @@ export type LauncherStatus =
       /** Always the literal string "<set>" — the real UUID never crosses the wire. */
       sessionId: "<set>";
       resuming: boolean;
+      /** Loopback-only. `null` when last refresh succeeded. */
+      skillRefresh?: SkillRefreshError | null;
     };
 
 export type LauncherUnavailableReason = "stdio-mode" | "disabled-by-env" | "spawn-failed";
@@ -44,7 +48,16 @@ export type LauncherErrorCode =
   | "spawn-failed"
   | "binary-not-found"
   | "stop-failed"
-  | "circuit-open";
+  | "circuit-open"
+  | "status-check-failed";
+
+/** Loopback-only side-channel for bundled-skill refresh failures. The user
+ * has no other signal that the skill is stale, so `/status` surfaces this
+ * for the palette/settings UI to convert into a notification. */
+export interface SkillRefreshError {
+  code: "write-failed" | "read-failed";
+  message: string;
+}
 
 // --- Request bodies -------------------------------------------------------
 

--- a/src/shared/launcher/contract.ts
+++ b/src/shared/launcher/contract.ts
@@ -1,0 +1,80 @@
+/**
+ * Wire contract for the auto-launcher routes (#477 PR 4b).
+ *
+ * Server: `src/server/launcher/api-routes.ts`.
+ * Client: `src/client/launcher/*` (palette actions + settings picker).
+ *
+ * The launcher routes are HTTP-mode-only and only useful when a
+ * `claude-code` integration with `apply !== "skip"` exists in
+ * `integrations.json`.
+ */
+
+// --- Status ---------------------------------------------------------------
+
+/**
+ * Non-loopback callers receive the `minimal` shape only (mirrors `/health`'s
+ * `hasSession` redaction pattern — `src/server/mcp/server.ts:324`). Loopback
+ * callers additionally receive the `loopback` fields. `sessionId` is
+ * redacted to a sentinel string even on loopback so the value never crosses
+ * the API boundary (it's persisted on disk at mode 0o600 — there's no need
+ * to surface it).
+ */
+export type LauncherStatus =
+  | { available: false; reason: LauncherUnavailableReason }
+  | {
+      available: true;
+      running: false;
+      /** Last fatal error from the supervisor, scrubbed to a small enum. */
+      lastError?: LauncherErrorCode;
+    }
+  | {
+      available: true;
+      running: true;
+      reaperPid: number;
+      cwd: string;
+      /** Always the literal string "<set>" — the real UUID never crosses the wire. */
+      sessionId: "<set>";
+      resuming: boolean;
+    };
+
+export type LauncherUnavailableReason = "stdio-mode" | "disabled-by-env" | "spawn-failed";
+
+/** Scrubbed `lastError` enum. Verbose error strings stay server-side. */
+export type LauncherErrorCode =
+  | "spawn-failed"
+  | "binary-not-found"
+  | "stop-failed"
+  | "circuit-open";
+
+// --- Request bodies -------------------------------------------------------
+
+export interface LauncherRelaunchBody {
+  cwd: string;
+  /** Single-use nonce from `GET /api/launcher/nonce`. */
+  nonce: string;
+}
+
+export interface LauncherStartFreshBody {
+  /** Optional cwd override; if omitted, uses the integration's setting. */
+  cwd?: string;
+  nonce: string;
+}
+
+export interface LauncherWorkingDirectoryBody {
+  /** Absolute path under `os.homedir()`, or `null` to clear (use default). */
+  workingDirectory: string | null;
+}
+
+// --- Error codes ----------------------------------------------------------
+
+export const LAUNCHER_ERROR_INVALID_BODY = "INVALID_BODY";
+export const LAUNCHER_ERROR_INVALID_NONCE = "INVALID_NONCE";
+export const LAUNCHER_ERROR_PATH_REJECTED = "PATH_REJECTED";
+export const LAUNCHER_ERROR_IN_PROGRESS = "LAUNCHER_IN_PROGRESS";
+export const LAUNCHER_ERROR_NOT_AVAILABLE = "LAUNCHER_NOT_AVAILABLE";
+export const LAUNCHER_ERROR_NO_INTEGRATION = "NO_CLAUDE_INTEGRATION";
+
+/** Max characters for a cwd payload — UNC paths and Windows MAX_PATH variants
+ * all fit comfortably under 1024. Catches malformed/oversized inputs early
+ * before they reach `realpathSync`. */
+export const LAUNCHER_CWD_MAX_LENGTH = 1024;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -278,7 +278,8 @@ export interface TandemNotification {
     | "session-restored"
     | "general-error"
     | "file-reloaded"
-    | "review-pending";
+    | "review-pending"
+    | "launcher";
   severity: "info" | "warning" | "error";
   message: string;
   documentId?: string;

--- a/tests/server/integrations/refresh-skill.test.ts
+++ b/tests/server/integrations/refresh-skill.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Direct unit tests for `refreshSkillIfStale()` in
+ * `src/server/integrations/apply.ts` (#477 PR 4b review fixes).
+ *
+ * Covers three branches:
+ *   - On-disk file missing → bundled gets written.
+ *   - On-disk version < bundled → bundled overwrites it.
+ *   - On-disk version >= bundled → no-op; existing content preserved.
+ * Plus failure recording via `getSkillRefreshError()`.
+ */
+
+import fs from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  _resetSkillRefreshErrorForTests,
+  getSkillRefreshError,
+  refreshSkillIfStale,
+} from "../../../src/server/integrations/apply.js";
+
+let homeOverride: string;
+let skillPath: string;
+
+beforeEach(async () => {
+  homeOverride = await fs.promises.mkdtemp(path.join(os.tmpdir(), "refresh-skill-test-"));
+  skillPath = path.join(homeOverride, ".claude", "skills", "tandem", "SKILL.md");
+  _resetSkillRefreshErrorForTests();
+});
+
+afterEach(async () => {
+  await fs.promises.rm(homeOverride, { recursive: true, force: true });
+  _resetSkillRefreshErrorForTests();
+});
+
+function readSkillVersion(content: string): number {
+  const match = content.match(/^version:\s*(\d+)\s*$/m);
+  if (!match) return 0;
+  const n = parseInt(match[1], 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+describe("refreshSkillIfStale — first-run (no on-disk file)", () => {
+  it("writes the bundled skill when SKILL.md does not exist", async () => {
+    expect(fs.existsSync(skillPath)).toBe(false);
+    await refreshSkillIfStale({ homeOverride });
+    expect(fs.existsSync(skillPath)).toBe(true);
+    const written = await readFile(skillPath, "utf8");
+    expect(readSkillVersion(written)).toBeGreaterThanOrEqual(2);
+    expect(getSkillRefreshError()).toBeNull();
+  });
+});
+
+describe("refreshSkillIfStale — stale on-disk", () => {
+  it("overwrites when on-disk version < bundled", async () => {
+    await mkdir(path.dirname(skillPath), { recursive: true });
+    // Write a v1 stub. The bundled version is v2 (or higher).
+    await writeFile(
+      skillPath,
+      "---\nname: tandem\nversion: 1\ndescription: stale\n---\n\nstale body\n",
+      "utf8",
+    );
+    await refreshSkillIfStale({ homeOverride });
+    const written = await readFile(skillPath, "utf8");
+    expect(readSkillVersion(written)).toBeGreaterThanOrEqual(2);
+    expect(written).not.toContain("stale body");
+    expect(getSkillRefreshError()).toBeNull();
+  });
+});
+
+describe("refreshSkillIfStale — newer-or-equal on-disk", () => {
+  it("preserves on-disk content when version >= bundled", async () => {
+    await mkdir(path.dirname(skillPath), { recursive: true });
+    // Write a v999 stub — guaranteed >= bundled.
+    const userCustomized =
+      "---\nname: tandem\nversion: 999\ndescription: user-edit\n---\n\nuser custom body\n";
+    await writeFile(skillPath, userCustomized, "utf8");
+    await refreshSkillIfStale({ homeOverride });
+    const after = await readFile(skillPath, "utf8");
+    expect(after).toBe(userCustomized);
+    expect(getSkillRefreshError()).toBeNull();
+  });
+});
+
+describe("refreshSkillIfStale — failure recording", () => {
+  it("records read failure when SKILL.md exists but is unreadable", async () => {
+    // POSIX-only: create the file then chmod 000 to force EACCES. On Windows
+    // we can't reliably revoke owner read with the test process's own ACL,
+    // so the test is skipped — chmod is a no-op on Windows.
+    if (process.platform === "win32") return;
+    await mkdir(path.dirname(skillPath), { recursive: true });
+    await writeFile(skillPath, "---\nname: tandem\nversion: 1\n---\n", "utf8");
+    fs.chmodSync(skillPath, 0o000);
+    try {
+      await refreshSkillIfStale({ homeOverride });
+      const err = getSkillRefreshError();
+      // Either the unreadable read failed (read-failed) OR the subsequent
+      // write succeeded (treats missing as -1). On most POSIX systems the
+      // read fails with EACCES — but if the test runs as root it succeeds.
+      if (err) expect(err.code === "read-failed" || err.code === "write-failed").toBe(true);
+    } finally {
+      fs.chmodSync(skillPath, 0o644);
+    }
+  });
+
+  it("clears lastSkillRefreshError after a successful refresh", async () => {
+    // Seed an error state via the unreadable-file path above (POSIX), then
+    // make the file writable and re-run. The error must clear.
+    if (process.platform === "win32") return;
+    await mkdir(path.dirname(skillPath), { recursive: true });
+    await writeFile(skillPath, "---\nname: tandem\nversion: 1\n---\n", "utf8");
+    fs.chmodSync(skillPath, 0o000);
+    try {
+      await refreshSkillIfStale({ homeOverride });
+    } finally {
+      fs.chmodSync(skillPath, 0o644);
+    }
+    // Second pass: file is readable + stale → write succeeds, error clears.
+    await refreshSkillIfStale({ homeOverride });
+    expect(getSkillRefreshError()).toBeNull();
+  });
+});

--- a/tests/server/launcher/api-routes.test.ts
+++ b/tests/server/launcher/api-routes.test.ts
@@ -346,4 +346,258 @@ describe("POST /api/launcher/working-directory", () => {
       expect((res.body as { code: string }).code).toBe("PATH_REJECTED");
     }
   });
+
+  it("clears workingDirectory when body is { workingDirectory: null }", async () => {
+    let writtenFile: { integrations: Array<{ workingDirectory?: string }> } | null = null;
+    const store = {
+      read: async () => ({
+        schemaVersion: 3 as const,
+        integrations: [
+          {
+            kind: "claude-code" as const,
+            id: "cc1",
+            label: "Claude Code",
+            configPath:
+              process.platform === "win32" ? "C:\\Users\\t\\.claude.json" : "/home/t/.claude.json",
+            transport: "http" as const,
+            url: "http://127.0.0.1:3479/mcp",
+            apply: "create" as const,
+            workingDirectory: fs.realpathSync(os.homedir()),
+          },
+        ],
+      }),
+      write: async (file: unknown) => {
+        writtenFile = file as typeof writtenFile;
+      },
+    } as unknown as LauncherRoutesDeps["store"];
+    const { app } = makeApp(baseDeps(makeFakeSupervisor(), "stdio-mode", store));
+    const res = await request(app, "POST", "/api/launcher/working-directory", {
+      workingDirectory: null,
+    });
+    expect(res.status).toBe(200);
+    expect(writtenFile).not.toBeNull();
+    expect(writtenFile?.integrations[0].workingDirectory).toBeUndefined();
+  });
+
+  it("persists the canonical resolved path on happy path", async () => {
+    let writtenFile: { integrations: Array<{ workingDirectory?: string }> } | null = null;
+    const store = {
+      read: async () => ({
+        schemaVersion: 3 as const,
+        integrations: [
+          {
+            kind: "claude-code" as const,
+            id: "cc1",
+            label: "Claude Code",
+            configPath:
+              process.platform === "win32" ? "C:\\Users\\t\\.claude.json" : "/home/t/.claude.json",
+            transport: "http" as const,
+            url: "http://127.0.0.1:3479/mcp",
+            apply: "create" as const,
+          },
+        ],
+      }),
+      write: async (file: unknown) => {
+        writtenFile = file as typeof writtenFile;
+      },
+    } as unknown as LauncherRoutesDeps["store"];
+    const { app } = makeApp(baseDeps(makeFakeSupervisor(), "stdio-mode", store));
+    const home = fs.realpathSync(os.homedir());
+    const inside = fs.mkdtempSync(path.join(home, "wd-happy-test-"));
+    try {
+      const res = await request(app, "POST", "/api/launcher/working-directory", {
+        workingDirectory: inside,
+      });
+      expect(res.status).toBe(200);
+      expect(writtenFile?.integrations[0].workingDirectory).toBe(fs.realpathSync(inside));
+    } finally {
+      fs.rmSync(inside, { recursive: true, force: true });
+    }
+  });
+});
+
+// --- Review-fix tests (Group A) -------------------------------------------
+
+describe("nonce rotation on FAILURE (T1)", () => {
+  it("a failed mutating attempt rotates the live nonce — a captured pre-attempt value is invalid", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()));
+    // Fetch nonce A.
+    const a = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    // Fetch nonce B — rotates A out. A is now stale.
+    const b = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    // POST with the stale value A — must 403 (rotates again, B is now also dead).
+    const r1 = await request(app, "POST", "/api/launcher/relaunch", {
+      cwd: os.homedir(),
+      nonce: a.nonce,
+    });
+    expect(r1.status).toBe(403);
+    // POST with B — if rotation-on-failure is broken, this would now succeed.
+    // It must 403 because the failed r1 above rotated the live nonce.
+    const r2 = await request(app, "POST", "/api/launcher/relaunch", {
+      cwd: os.homedir(),
+      nonce: b.nonce,
+    });
+    expect(r2.status).toBe(403);
+  });
+});
+
+describe("per-route 429 inflight gates (T2)", () => {
+  // Hold the first operation in-flight via a deferred promise; assert the
+  // second concurrent attempt returns 429 + LAUNCHER_IN_PROGRESS.
+  function deferred(): { promise: Promise<void>; resolve: () => void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  it("concurrent POST /relaunch returns 429 (relaunchHook holds the gate)", async () => {
+    const sup = makeFakeSupervisor();
+    const gate = deferred();
+    const deps: LauncherRoutesDeps = {
+      ...baseDeps(sup),
+      relaunchHook: () => gate.promise,
+    };
+    const { app } = makeApp(deps);
+    const home = fs.realpathSync(os.homedir());
+    const n1 = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    const inflightReq = request(app, "POST", "/api/launcher/relaunch", {
+      cwd: home,
+      nonce: n1.nonce,
+    });
+    // Allow the inflight handler to enter the try block + set inflight=true.
+    await new Promise((r) => setTimeout(r, 30));
+    const n2 = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    const second = await request(app, "POST", "/api/launcher/relaunch", {
+      cwd: home,
+      nonce: n2.nonce,
+    });
+    expect(second.status).toBe(429);
+    expect((second.body as { code: string }).code).toBe("LAUNCHER_IN_PROGRESS");
+    gate.resolve();
+    await inflightReq;
+  });
+
+  it("relaunch in-flight blocks start-fresh (shared gate) but NOT working-directory", async () => {
+    const sup = makeFakeSupervisor();
+    const gate = deferred();
+    const store = {
+      read: async () => ({
+        schemaVersion: 3 as const,
+        integrations: [
+          {
+            kind: "claude-code" as const,
+            id: "cc1",
+            label: "Claude Code",
+            configPath:
+              process.platform === "win32" ? "C:\\Users\\t\\.claude.json" : "/home/t/.claude.json",
+            transport: "http" as const,
+            url: "http://127.0.0.1:3479/mcp",
+            apply: "create" as const,
+          },
+        ],
+      }),
+      write: async () => {},
+    } as unknown as LauncherRoutesDeps["store"];
+    const deps: LauncherRoutesDeps = {
+      ...baseDeps(sup, "stdio-mode", store),
+      relaunchHook: () => gate.promise,
+    };
+    const { app } = makeApp(deps);
+    const home = fs.realpathSync(os.homedir());
+    const n1 = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    const inflightReq = request(app, "POST", "/api/launcher/relaunch", {
+      cwd: home,
+      nonce: n1.nonce,
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    const n2 = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    const sf = await request(app, "POST", "/api/launcher/start-fresh", { nonce: n2.nonce });
+    expect(sf.status).toBe(429);
+    // working-directory has its own flag — must NOT 429.
+    const wd = await request(app, "POST", "/api/launcher/working-directory", {
+      workingDirectory: home,
+    });
+    expect(wd.status).toBe(200);
+    gate.resolve();
+    await inflightReq;
+  });
+});
+
+describe("loopback vs LAN redaction for running:false (T6)", () => {
+  it("loopback sees lastError; non-loopback does not", async () => {
+    const sup: Supervisor = {
+      start: async () => {},
+      stop: async () => {},
+      relaunch: async () => {},
+      startFresh: async () => {},
+      status: () => ({ running: false, lastError: "spawn-failed" as const }),
+    };
+    const { app: appLoop } = makeApp(baseDeps(sup));
+    const loop = await request(appLoop, "GET", "/api/launcher/status");
+    expect(loop.body).toMatchObject({
+      available: true,
+      running: false,
+      lastError: "spawn-failed",
+    });
+    const { app: appLan } = makeApp(baseDeps(sup), { remoteAddress: "192.168.1.50" });
+    const lan = await request(appLan, "GET", "/api/launcher/status");
+    expect(lan.body).toEqual({ available: true, running: false });
+    expect(lan.body).not.toHaveProperty("lastError");
+  });
+
+  it("loopback sees skillRefresh.error from the deps getter; non-loopback does not", async () => {
+    const sup = makeFakeSupervisor();
+    const depsWithSkill: LauncherRoutesDeps = {
+      ...baseDeps(sup),
+      getSkillRefreshError: () => ({ code: "write-failed", message: "EACCES" }),
+    };
+    const { app: appLoop } = makeApp(depsWithSkill);
+    const loop = (await request(appLoop, "GET", "/api/launcher/status")).body as {
+      skillRefresh?: { code: string; message: string } | null;
+    };
+    expect(loop.skillRefresh).toEqual({ code: "write-failed", message: "EACCES" });
+    const { app: appLan } = makeApp(depsWithSkill, { remoteAddress: "192.168.1.50" });
+    const lan = await request(appLan, "GET", "/api/launcher/status");
+    expect(lan.body).toEqual({ available: true, running: false });
+  });
+});
+
+describe("/status try/catch on supervisor throw (B4)", () => {
+  it("returns 200 with lastError:'status-check-failed' when sup.status() throws (loopback)", async () => {
+    const sup: Supervisor = {
+      start: async () => {},
+      stop: async () => {},
+      relaunch: async () => {},
+      startFresh: async () => {},
+      status: () => {
+        throw new Error("simulated supervisor crash");
+      },
+    };
+    const { app } = makeApp(baseDeps(sup));
+    const res = await request(app, "GET", "/api/launcher/status");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      available: true,
+      running: false,
+      lastError: "status-check-failed",
+    });
+  });
+
+  it("returns minimal LAN shape when sup.status() throws (non-loopback)", async () => {
+    const sup: Supervisor = {
+      start: async () => {},
+      stop: async () => {},
+      relaunch: async () => {},
+      startFresh: async () => {},
+      status: () => {
+        throw new Error("simulated");
+      },
+    };
+    const { app } = makeApp(baseDeps(sup), { remoteAddress: "192.168.1.50" });
+    const res = await request(app, "GET", "/api/launcher/status");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ available: true, running: false });
+  });
 });

--- a/tests/server/launcher/api-routes.test.ts
+++ b/tests/server/launcher/api-routes.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Route-level tests for `src/server/launcher/api-routes.ts` (#477 PR 4b).
+ *
+ * Exercises: origin gate, loopback gate under TANDEM_ALLOW_UNAUTHENTICATED_LAN,
+ * single-use nonce, cwd validation (PATH_REJECTED + length cap), 503 on null
+ * supervisor, 429 on overlapping operations, status field redaction for
+ * non-loopback callers, and the narrow workingDirectory PATCH path.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import express, { type Express } from "express";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  _resetInflightForTests,
+  _resetLauncherGateForTests,
+  type LauncherRoutesDeps,
+  registerLauncherRoutes,
+} from "../../../src/server/launcher/api-routes.js";
+import type { Supervisor } from "../../../src/server/launcher/supervisor.js";
+import { TAURI_HOSTNAME } from "../../../src/shared/constants.js";
+import {
+  type LauncherStatus,
+  type LauncherUnavailableReason,
+} from "../../../src/shared/launcher/contract.js";
+import { withEnvOverride } from "../../helpers/env-override.js";
+
+const passthrough: import("express").Handler = (_req, _res, next) => next();
+
+interface FakeSupervisorOpts {
+  running?: boolean;
+  cwd?: string;
+  relaunchHook?: (cwd: string) => Promise<void>;
+  startFreshHook?: (cwd?: string) => Promise<void>;
+}
+
+function makeFakeSupervisor(opts: FakeSupervisorOpts = {}): Supervisor {
+  return {
+    start: async () => {},
+    stop: async () => {},
+    relaunch: async (cwd: string) => {
+      await opts.relaunchHook?.(cwd);
+    },
+    startFresh: async (cwd?: string) => {
+      await opts.startFreshHook?.(cwd);
+    },
+    status: () =>
+      opts.running
+        ? {
+            running: true,
+            reaperPid: 12345,
+            cwd: opts.cwd ?? os.homedir(),
+            sessionId: "11111111-1111-4111-8111-111111111111",
+            resuming: false,
+          }
+        : { running: false },
+  };
+}
+
+function makeApp(
+  deps: LauncherRoutesDeps,
+  options: { remoteAddress?: string } = {},
+): { app: Express; tmpDir: string } {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "launcher-routes-test-"));
+  const app = express();
+  app.use(express.json());
+  if (options.remoteAddress !== undefined) {
+    const addr = options.remoteAddress;
+    app.use((req, _res, next) => {
+      Object.defineProperty(req.socket, "remoteAddress", {
+        value: addr,
+        configurable: true,
+      });
+      next();
+    });
+  }
+  registerLauncherRoutes(app, passthrough, deps);
+  return { app, tmpDir };
+}
+
+async function request(
+  app: Express,
+  method: "GET" | "POST",
+  url: string,
+  body?: unknown,
+  extraHeaders?: Record<string, string>,
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, "127.0.0.1", async () => {
+      const address = server.address();
+      if (typeof address !== "object" || address === null) {
+        server.close();
+        reject(new Error("no address"));
+        return;
+      }
+      const port = address.port;
+      try {
+        const headers: Record<string, string> = {
+          Origin: `http://${TAURI_HOSTNAME}`,
+          ...(body !== undefined ? { "content-type": "application/json" } : {}),
+          ...(extraHeaders ?? {}),
+        };
+        const res = await fetch(`http://127.0.0.1:${port}${url}`, {
+          method,
+          headers,
+          body: body !== undefined ? JSON.stringify(body) : undefined,
+        });
+        const payload = await res.json().catch(() => null);
+        resolve({ status: res.status, body: payload });
+      } catch (err) {
+        reject(err);
+      } finally {
+        server.close();
+      }
+    });
+  });
+}
+
+function makeStubStore(): LauncherRoutesDeps["store"] {
+  return {
+    read: async () => ({ schemaVersion: 3, integrations: [] }),
+    write: async () => {},
+  } as unknown as LauncherRoutesDeps["store"];
+}
+
+const baseDeps = (
+  sup: Supervisor | null,
+  reason: LauncherUnavailableReason = "stdio-mode",
+  store?: LauncherRoutesDeps["store"],
+): LauncherRoutesDeps => ({
+  getSupervisor: () => sup,
+  unavailableReason: () => reason,
+  store: store ?? makeStubStore(),
+});
+
+beforeEach(() => {
+  _resetLauncherGateForTests();
+  _resetInflightForTests();
+});
+
+afterEach(() => {
+  _resetLauncherGateForTests();
+  _resetInflightForTests();
+});
+
+describe("GET /api/launcher/status", () => {
+  it("returns available:false when supervisor is null (stdio mode)", async () => {
+    const { app } = makeApp(baseDeps(null, "stdio-mode"));
+    const res = await request(app, "GET", "/api/launcher/status");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ available: false, reason: "stdio-mode" });
+  });
+
+  it("returns full status payload to loopback callers when running", async () => {
+    const sup = makeFakeSupervisor({ running: true, cwd: "/home/test" });
+    const { app } = makeApp(baseDeps(sup));
+    const res = await request(app, "GET", "/api/launcher/status");
+    expect(res.status).toBe(200);
+    const body = res.body as LauncherStatus & { running: true };
+    expect(body.available).toBe(true);
+    expect(body.running).toBe(true);
+    expect(body.reaperPid).toBe(12345);
+    expect(body.cwd).toBe("/home/test");
+    // sessionId is redacted — the real UUID never crosses the wire.
+    expect(body.sessionId).toBe("<set>");
+  });
+
+  it("returns the minimal { available, running } shape to non-loopback callers", async () => {
+    const sup = makeFakeSupervisor({ running: true });
+    const { app } = makeApp(baseDeps(sup), { remoteAddress: "192.168.1.50" });
+    const res = await request(app, "GET", "/api/launcher/status");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ available: true, running: true });
+  });
+});
+
+describe("GET /api/launcher/nonce — origin + loopback gates", () => {
+  it("rejects missing Origin", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()));
+    // Override the default Tauri origin so we can test the bad-origin branch.
+    const res = await request(app, "GET", "/api/launcher/nonce", undefined, {
+      Origin: "http://attacker.example",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects LAN under TANDEM_ALLOW_UNAUTHENTICATED_LAN=1", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()), { remoteAddress: "192.168.1.50" });
+    await withEnvOverride("TANDEM_ALLOW_UNAUTHENTICATED_LAN", "1", async () => {
+      const res = await request(app, "GET", "/api/launcher/nonce");
+      expect(res.status).toBe(403);
+    });
+  });
+
+  it("issues a fresh nonce on each call", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()));
+    const a = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    const b = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    expect(a.nonce).not.toBe(b.nonce);
+    expect(a.nonce).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+});
+
+describe("POST /api/launcher/relaunch", () => {
+  it("returns 503 when supervisor is null", async () => {
+    const { app } = makeApp(baseDeps(null, "disabled-by-env"));
+    const nonce = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    const res = await request(app, "POST", "/api/launcher/relaunch", {
+      cwd: os.homedir(),
+      nonce: nonce.nonce,
+    });
+    expect(res.status).toBe(503);
+    expect((res.body as { code: string }).code).toBe("LAUNCHER_NOT_AVAILABLE");
+  });
+
+  it("rejects missing nonce with 403", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()));
+    const res = await request(app, "POST", "/api/launcher/relaunch", { cwd: os.homedir() });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects nonce mismatch with 403 and rotates the nonce", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()));
+    // Burn one nonce so a stale value is guaranteed to fail.
+    await request(app, "GET", "/api/launcher/nonce");
+    const res = await request(app, "POST", "/api/launcher/relaunch", {
+      cwd: os.homedir(),
+      nonce: "definitely-wrong-nonce-value-xyz",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects cwd outside the user's home with PATH_REJECTED", async () => {
+    let relaunchCwd: string | undefined;
+    const sup = makeFakeSupervisor({
+      relaunchHook: async (cwd) => {
+        relaunchCwd = cwd;
+      },
+    });
+    const { app } = makeApp(baseDeps(sup));
+    const nonce = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    // os.tmpdir() on POSIX is outside $HOME; on Windows it may not be.
+    const home = fs.realpathSync(os.homedir());
+    const outside = fs.realpathSync(os.tmpdir());
+    const rel = path.relative(home, outside);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      const res = await request(app, "POST", "/api/launcher/relaunch", {
+        cwd: outside,
+        nonce: nonce.nonce,
+      });
+      expect(res.status).toBe(400);
+      expect((res.body as { code: string }).code).toBe("PATH_REJECTED");
+      expect(relaunchCwd).toBeUndefined();
+    }
+  });
+
+  it("rejects oversized cwd payload with INVALID_BODY", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()));
+    const nonce = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    const res = await request(app, "POST", "/api/launcher/relaunch", {
+      cwd: `/${"a".repeat(2000)}`,
+      nonce: nonce.nonce,
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string }).code).toBe("INVALID_BODY");
+  });
+
+  it("calls supervisor.relaunch(cwd) on the happy path", async () => {
+    let calledWith: string | undefined;
+    const sup = makeFakeSupervisor({
+      relaunchHook: async (cwd) => {
+        calledWith = cwd;
+      },
+    });
+    const { app } = makeApp(baseDeps(sup));
+    const home = fs.realpathSync(os.homedir());
+    const inside = fs.mkdtempSync(path.join(home, "relaunch-test-"));
+    try {
+      const nonce = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+      const res = await request(app, "POST", "/api/launcher/relaunch", {
+        cwd: inside,
+        nonce: nonce.nonce,
+      });
+      expect(res.status).toBe(200);
+      expect(calledWith).toBe(fs.realpathSync(inside));
+    } finally {
+      fs.rmSync(inside, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("POST /api/launcher/start-fresh", () => {
+  it("rejects malformed body with 400 (and consumes the nonce)", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()));
+    // No nonce — should fail at the nonce gate, not the body shape gate.
+    const res = await request(app, "POST", "/api/launcher/start-fresh", { cwd: os.homedir() });
+    expect(res.status).toBe(403);
+  });
+
+  it("calls supervisor.startFresh() with no cwd when body omits it", async () => {
+    let calledWith: string | undefined | "unset" = "unset";
+    const sup = makeFakeSupervisor({
+      startFreshHook: async (cwd) => {
+        calledWith = cwd;
+      },
+    });
+    const { app } = makeApp(baseDeps(sup));
+    const nonce = (await request(app, "GET", "/api/launcher/nonce")).body as { nonce: string };
+    const res = await request(app, "POST", "/api/launcher/start-fresh", { nonce: nonce.nonce });
+    expect(res.status).toBe(200);
+    expect(calledWith).toBeUndefined();
+  });
+});
+
+describe("POST /api/launcher/working-directory", () => {
+  it("returns 404 when no claude-code integration exists", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()));
+    const res = await request(app, "POST", "/api/launcher/working-directory", {
+      workingDirectory: os.homedir(),
+    });
+    expect(res.status).toBe(404);
+    expect((res.body as { code: string }).code).toBe("NO_CLAUDE_INTEGRATION");
+  });
+
+  it("rejects non-string non-null workingDirectory with INVALID_BODY", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()));
+    const res = await request(app, "POST", "/api/launcher/working-directory", {
+      workingDirectory: 42,
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { code: string }).code).toBe("INVALID_BODY");
+  });
+
+  it("rejects paths outside home with PATH_REJECTED", async () => {
+    const { app } = makeApp(baseDeps(makeFakeSupervisor()));
+    const home = fs.realpathSync(os.homedir());
+    const outside = fs.realpathSync(os.tmpdir());
+    const rel = path.relative(home, outside);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      const res = await request(app, "POST", "/api/launcher/working-directory", {
+        workingDirectory: outside,
+      });
+      expect(res.status).toBe(400);
+      expect((res.body as { code: string }).code).toBe("PATH_REJECTED");
+    }
+  });
+});

--- a/tests/server/launcher/supervisor.test.ts
+++ b/tests/server/launcher/supervisor.test.ts
@@ -7,7 +7,11 @@ import {
   type IntegrationsFile,
 } from "../../../src/server/integrations/schema.js";
 import { createIntegrationsStore } from "../../../src/server/integrations/storage.js";
-import { createSupervisor, resolveSafeCwd } from "../../../src/server/launcher/supervisor.js";
+import {
+  createSupervisor,
+  resolveRouteCwd,
+  resolveSafeCwd,
+} from "../../../src/server/launcher/supervisor.js";
 
 let tmpDir: string;
 
@@ -171,6 +175,44 @@ describe("resolveSafeCwd — path normalization (security I2)", () => {
     expect(resolveSafeCwd(undefined as unknown as string)).toBeNull();
     expect(resolveSafeCwd(null as unknown as string)).toBeNull();
     expect(resolveSafeCwd(42 as unknown as string)).toBeNull();
+  });
+});
+
+describe("resolveRouteCwd — home-confined HTTP variant (PR 4b sec I1)", () => {
+  it("rejects everything resolveSafeCwd rejects", () => {
+    expect(resolveRouteCwd("relative/path")).toBeNull();
+    expect(resolveRouteCwd("/does/not/exist/xyz")).toBeNull();
+  });
+
+  it("accepts a real directory inside the user's home", () => {
+    // os.homedir() is the test process's home — we create a tmpdir inside it
+    // for the home-confined check. Using the existing tmpDir would fail on
+    // many CI environments where tmpDir is outside $HOME.
+    const homeReal = fs.realpathSync(os.homedir());
+    const inside = fs.mkdtempSync(path.join(homeReal, "route-cwd-test-"));
+    try {
+      const resolved = resolveRouteCwd(inside);
+      expect(resolved).toBe(fs.realpathSync(inside));
+    } finally {
+      fs.rmSync(inside, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a real directory outside the user's home", () => {
+    // tmpDir from beforeEach lives in os.tmpdir(), which is outside $HOME on
+    // POSIX. On Windows %LOCALAPPDATA%\Temp may or may not be under %USERPROFILE%
+    // — skip the assertion if the test tmpdir happens to be home-rooted.
+    const home = fs.realpathSync(os.homedir());
+    const real = fs.realpathSync(tmpDir);
+    const relative = path.relative(home, real);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      expect(resolveRouteCwd(tmpDir)).toBeNull();
+    }
+  });
+
+  it("accepts the home directory itself", () => {
+    const home = fs.realpathSync(os.homedir());
+    expect(resolveRouteCwd(home)).toBe(home);
   });
 });
 


### PR DESCRIPTION
Adds the **UI surface** on top of PR 4a's auto-launcher supervisor (#800). This is PR 4b of #477's split: 4a (backend, merged), **4b (UI, this PR)**, 4c (CI matrix + Tauri sidecar + npm postinstall, deferred).

## What ships

**Five HTTP routes** under `/api/launcher/*`:

| Method | Path | Notes |
| --- | --- | --- |
| GET | `/status` | Loopback gets full struct with `sessionId` redacted to `"<set>"`; non-loopback gets minimal `{available, running}` (mirrors `/health` redaction) |
| GET | `/nonce` | Single-use, constant-time compare, rotates on every consumption (success or failure) |
| POST | `/relaunch` | Origin + loopback gates, requires nonce; `resolveRouteCwd()` confines cwd under `os.homedir()`; 429 on inflight, 503 on null supervisor |
| POST | `/start-fresh` | Same security profile; calls `supervisor.startFresh(cwd?)` |
| POST | `/working-directory` | Narrow PATCH-style; avoids the apply-nonce rotation a full `POST /api/integrations` would trigger |

**Two palette commands** (new `"claude"` action group):
- *Relaunch Claude in this folder* — derives cwd from active doc's parent, confirms, POSTs to `/relaunch`
- *Start fresh Claude conversation* — confirms, POSTs to `/start-fresh`

**workingDirectory picker** in Settings → Claude Code: text input + Tauri folder picker (`dialog:allow-open` added to capabilities) + reset-to-default button.

**Bundled skill v2** adds *Project Context Discovery* guidance: when working on a file outside the launch cwd, walk up looking for `CLAUDE.md`/`.claude/`; if project-scoped skills/agents/MCPs/hooks are detected, nudge the user to `/relaunch-here`. `refreshSkillIfStale()` compares the bundled `version:` against on-disk and writes only if bundled is newer — existing users pick up updates on next launcher start without re-running `tandem setup`.

## Supervisor hardening (folded in from plan-review)

Three independent reviewers (code-architect, security-reviewer, code-reviewer) converged on these — all addressed in the initial commit:

- `startFresh()` was double-spawning when callers chained `.relaunch` after. New signature: `startFresh(cwdOverride?)` does a single atomic stop+clear+respawn under the supervisor lock.
- `resolveRouteCwd()` — HTTP-surface variant of `resolveSafeCwd` that additionally requires the canonical path to be under `os.homedir()`. Blocks junction/symlink escape via the loopback API. The permissive `resolveSafeCwd` stays for the integrations-file path (hand-editors opt into wider scope).
- `lastError` scrubbed to a small enum (`spawn-failed | binary-not-found | stop-failed | circuit-open`). Verbose error strings with file paths stay server-side only.
- `TANDEM_REAPER_PATH` env override now requires **both** `NODE_ENV !== "production"` AND `TANDEM_TAURI_SIDECAR !== "1"` (defense-in-depth against a malicious shell rc inside a packaged sidecar where NODE_ENV may not be set).
- `LauncherStatus` is a discriminated union with explicit `available: false` shape and loopback/non-loopback redaction at the route layer.

## Threat-model notes

- Mutating routes require both `assertOriginAllowlisted` (CSRF) and `assertLoopbackForMutation` (LAN fail-closed). The single-use nonce is defense-in-depth on top — a malicious loopback page still has to read the nonce via a separate GET before it can drive `/relaunch` or `/start-fresh`.
- `GET /status` is intentionally unauthenticated for the minimal shape; sensitive fields (`reaperPid`, `cwd`, `lastError`) ride the loopback gate.
- `POST /working-directory` is a deliberately narrow surface so the picker doesn't rotate the integrations apply-nonce or race the wizard's payload.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run tests/server/launcher/` — 39/39 pass (17 new route-level tests + 5 new `resolveRouteCwd` unit tests)
- [x] Full `npm test` — 2576/2577 pass; the only failure is the known mcp-stdio flake (same as PR #797 / #800)
- [x] `npm run check:tokens` clean
- [ ] CI green
- [ ] Manual smoke (Tauri dev): pick a folder in Settings → relaunch via palette → confirm Claude restarts in that folder

## Deferred to PR 4c

CI matrix building the reaper per target-triple, Tauri `tauri.conf.json` sidecar wiring, npm postinstall pick-by-triple. None block PR 4b — the supervisor degrades gracefully when the reaper binary is absent (`binary-not-found` lastError).

🤖 Generated with [Claude Code](https://claude.com/claude-code)