### PR TITLE
docs(plans): v0.13.0 release plan + adversarial-review findings

### DIFF
--- a/docs/plans/2026-05-21-v0.13.0-release.md
+++ b/docs/plans/2026-05-21-v0.13.0-release.md
@@ -1,6 +1,6 @@
 # Plan: v0.13.0 Release — Stability Bug-Bash + Redesign Chrome (Waves 1, 2)
 
-> **Status (2026-05-21):** DRAFT — awaiting adversarial review
+> **Status (2026-05-23):** READY — adversarial review complete, plan approved; awaiting execution
 > **Target version:** v0.12.0 → **v0.13.0** (minor)
 > **Owner:** Bryan
 > **Type:** scheduled minor — Waves 1 + 2 close-out per `docs/roadmap.md` ("Active — Toward v1.0")

--- a/docs/plans/2026-05-21-v0.13.0-release.md
+++ b/docs/plans/2026-05-21-v0.13.0-release.md
@@ -1,0 +1,460 @@
+# Plan: v0.13.0 Release — Stability Bug-Bash + Redesign Chrome (Waves 1, 2)
+
+> **Status (2026-05-21):** DRAFT — awaiting adversarial review
+> **Target version:** v0.12.0 → **v0.13.0** (minor)
+> **Owner:** Bryan
+> **Type:** scheduled minor — Waves 1 + 2 close-out per `docs/roadmap.md` ("Active — Toward v1.0")
+> **Branch:** `claude/0-13-0-checklist-YUxSO`
+
+## Release Thesis
+
+v0.12.0 (2026-05-15) shipped the 8-unit prep batch (#634–#641), Wave 1 (SettingsModal sibling, status-bar held-count, ConnectionBanner polish, updater banner+dot, slash menu, paged docx, ReplyThreadOverlay, margin view PR1+PR2 via #662–#674/#679), and Wave 1b's #680/#683 prep. Since v0.12.0 (the actual `v0.12.0..HEAD` range, starting at #739) 52 commits have landed for v0.13.0:
+
+- **Wave 1b finish-out** — #680 D11 fonts re-land, #683 margin view PR 3 of 3, #681 `openServerPath` retrofit, #682 `SettingsTabContext` typing (all merged 2026-05-17).
+- **Wave 2** — Settings → Network panel split (PR 6), harness-bundle CI guard (PR 7), Models registry (PR 8a + 8b data model + edit modal, then #784 multi-provider + keychain + first-run picker), `IntegrationConfig.url` loopback hardening (#753), #477 PR 3c-ii-a/3c-ii-b (server library factor + wizard apply path), launcher PR 4a (#800) + PR 4b (#477 launcher UI), integrations probe hardening quartet (#794–#797), Wave 3–10 floating-pill/titlebar/tabs/outline/status redesign, Wave M titlebar dropdown + dark-mode v7 alignment.
+
+Per `docs/roadmap.md` line 538 the release-cadence table assigns Waves 1 + 2 to v0.13.0. Both waves are merged; this release is the version cut + CHANGELOG promotion + tag + publish.
+
+**Goal:** Ship v0.13.0 cleanly — full CHANGELOG audit, three version-file bumps, tag, GitHub Release, npm publish, Tauri release matrix, smoke-test, then update the roadmap.
+
+**Non-goals for this release:**
+
+- New code work. The release PR must be docs/version-file only; if any in-flight code work needs to land first, do it on a separate PR that merges to `main` before the release PR is opened.
+- Wave 3+ (annotation migration #313/AR5/AR6, #477 PRs 1/3/4/5 exposure, #576 docx body export, #316 Cowork macOS/Linux). Those land in v0.14.0 / v0.15.0 / v0.16.0.
+- Re-litigating `src-tauri/Cargo.toml`'s historical version drift (currently `0.9.1`); see §"Risks" below.
+
+## Scope Inventory
+
+### Items already in `CHANGELOG.md` `[Unreleased]`
+
+Per `git show HEAD:CHANGELOG.md` lines 8–31:
+
+- **Added** — Models tab + edit modal (#659/PR 8b), Models data model + `useModels` (#659/PR 8a), schema v2→v3 migration with forward-compat read-only mode, D11 bundled fonts re-land (#680), margin view auto-collapses on rail open or narrow viewport (#683).
+- **Security** — harness-stripped CI guard (Wave 2 PR 7).
+- **Changed** — Network settings split into Connection / Advanced (Wave 2 PR 6).
+- **Fixed** — Selection toolbar places itself clear of fixed chrome (#680).
+
+### Items LANDED but MISSING from `[Unreleased]`
+
+Walking `git log v0.12.0..HEAD` (52 commits since 2026-05-15) against the current `[Unreleased]` section, these need entries:
+
+**Wave 3–10 redesign sweep:**
+
+- #739 Wave 2 — edge-anchored side rails with inner-rounded corners
+- #740 Wave 3 — Floating fmtbar pill + shared `.tandem-floating-pill` recipe
+- #741 Wave 5 — Floating pill status bar + word-count cycle
+- #742 Wave 6 — Outline rail clears the floating status pill lane
+- #743 Wave 7 — legacy palette remap aligned with v7 design
+- #745 Wave 9 — Narrow-viewport Settings sidebar drawer + hamburger
+- #746 Wave 4a (minimal) — drop bar seam + surface so chrome melts into canvas
+- #748 Wave 4b (minimal) — Pill-shaped DocumentTabs
+- #752 Wave 4a maximalist — lift DocumentTabs into TitleBar center cluster
+- #755 Wave 4b maximalist — mask-fade overflow + floating-pill `+` add button + neutral `.ro` badge + wincontrols pill
+- #756 Wave 8 — .docx batch-promote with always-visible checkboxes
+- #757 Wave 10 — slash menu floating-pill polish + keyboard-hint footer
+- #758 — Post-Wave correctness fixes across 9 sites
+- #759 Wave D — left rail locked to outline-only
+- #760 Wave A — titlebar + status pill + right-rail header polish
+- #761 Wave B — hide native scrollbars, mask-fade overflow edges
+- #762 Wave C — selection popup uses shared floating-pill recipe
+- #763 Wave F — placeholder fix + margin-card hover affordance
+- #764 Wave E — peek-from-side strips + edge-click panel collapse
+- #765 Waves G–L — redesign-parity sweep (titlebar, rails, picker teardown, popup, composer, slide)
+- #776 Wave M — titlebar dropdown, solo fade, dark mode v7 alignment
+
+**Models registry expansion (post PR 8a/8b):**
+
+- #784 — multi-provider Models registry: keychain secrets, default selection, first-run picker
+
+**Integrations / launcher / #477:**
+
+- #747 — #477 PR 3c-ii-a: server library factor (move auto-config helpers to `src/server/integrations/apply.ts`)
+- #773 — #477 PR 3c-ii-b: wizard apply path + first-run auto-open
+- #753 — `IntegrationConfig.url` constrained to loopback only (Security)
+- #794 — integrations-probe sidecar pointer validation hardening (#642)
+- #795 — Windows ACL hardening on `.claude.json` (#643)
+- #796 — backup non-default `.claude.json` before overwrite (#644)
+- #797 — malformed-input matrix + shape gates + BOM strip (#645)
+- #800 — launcher PR 4a: native cross-platform reaper + auto-launcher
+- #477 PR 4b (commit 0c8978a) — launcher UI: palette commands, working-dir picker, project-context skill
+- 1a73f41, f20f1a9 — PR #801 review findings + CodeQL FP suppression
+
+**Editor / status / annotation surfaces:**
+
+- #791 — toggle for inline annotation decorations
+- #792 — page count in word-count cycle
+- #790 — extract `THEME_OPTIONS` from TitleBar
+
+**Tests / hooks / docs:**
+
+- #785 — eliminate hardcoded `waitForTimeout` flakes in e2e
+- #786 — test-suite audit (ADR-027 privacy bug fix, weak assertions, ADR-031 gaps)
+- #787 — remove `block-e2e-port-kill` PreToolUse hook
+- #789 — pin schema-version assertions to `CURRENT_SCHEMA_VERSION`
+- #793 — document `RelativeRange` invariants on helpers
+- #769 — knowledge-graph pilot (25 hand-curated concept/rule/ADR nodes)
+- #771 — knowledge-graph review-findings address pass
+- #772 — `ws` dependency bump (npm_and_yarn group)
+- #774, #775 — design-notes archival
+- #777, #778 — comprehensive README rewrite + new CLI / config / troubleshooting / security docs
+- #744 — Phase-3-docs roadmap update
+- #749 — roadmap: flip 3c-i + 3c-ii-a to SHIPPED
+- #750 — re-validate spike-f2 NO-GO verdict against current master
+- #751 — refresh CLAUDE.md file-map descriptions after #747
+
+### Loose ends (not blocking; close before or alongside release)
+
+- **#660** (settings-icon update-available dot badge) — code already shipped (`useUpdateAvailable.svelte.ts`, `titlebar-update-available-dot` testid in `TitleBar.svelte:237`, acknowledge wiring in `App.svelte:330–362`). Issue is open. Close issue with link to the merged commit(s) before release tag.
+
+## Release PR Contents
+
+Single PR off `claude/0-13-0-checklist-YUxSO` (current working branch) targeting `main`. Docs/version-file only.
+
+### 1. `CHANGELOG.md`
+
+Promote `## [Unreleased]` → `## [0.13.0] - YYYY-MM-DD` (date = tag day). Expand the section so it captures **everything in §"Scope Inventory" above** under Keep-a-Changelog categories. Suggested grouping:
+
+```
+## [0.13.0] - YYYY-MM-DD
+
+### Added
+- Models registry surfaces (PR 8a/8b/#784) — keep as one summary entry
+- Schema v2 → v3 migration + read-only forward-compat
+- D11 bundled fonts re-land (#680)
+- Margin view auto-collapse on rail open / narrow viewport (#683)
+- Status-bar word-count cycle (#741) + page count (#792)
+- Floating-pill design system primitives (#740, #762, #757)
+- Outline rail clears status pill lane (#742)
+- Narrow-viewport Settings sidebar drawer + hamburger (#745)
+- Inline annotation decoration toggle (#791)
+- Knowledge-graph pilot (#769)
+- **Auto-launcher (#800, #477 PR 4b) — enabled by default for users with a `claude-code` integration whose `apply !== "skip"`.** Spawns + supervises Claude Code CLI alongside the Tandem server. New palette commands "Relaunch Claude in this folder" and "Start fresh Claude conversation" appear in the command palette. Working-dir picker in Settings → Integrations. Opt out with `TANDEM_DISABLE_LAUNCHER=1`.
+- **First-run wizard auto-open + apply path (#477 PR 3c-ii-b / #773) — enabled by default.** On first launch with no `integrations.json`, the integration setup wizard opens automatically. Subsequent launches do not re-open. Applies via `POST /api/integrations/apply` against detected `~/.claude.json` locations with path-traversal hardening and atomic backup-then-rewrite.
+
+### Changed
+- Network settings split into Connection / Advanced (Wave 2 PR 6)
+- Wave 3–10 redesign sweep (titlebar/rails/tabs/status/outline/popup) — single multi-line entry referencing wave letters + PR numbers
+- Wave M dark mode v7 alignment + titlebar dropdown (#776)
+- README + docs rewrite (#777, #778)
+- THEME_OPTIONS extracted from TitleBar (#790)
+- Models registry: legacy migration banner + keychain secrets + first-run picker (#784)
+
+### Fixed
+- Selection toolbar avoids fixed chrome (#680)
+- Annotation palette remap aligned with v7 (#743)
+- Post-Wave correctness fixes across 9 sites (#758)
+- Wave F placeholder + margin-card hover (#763)
+- Launcher PR #801 review findings (f20f1a9) + CodeQL FP suppression (1a73f41)
+
+### Security
+- Harness-bundle CI guard (Wave 2 PR 7)
+- **`IntegrationConfig.url` tightened to `http://127.0.0.1[:port][/path]` only (#753, #758)** — rejects `localhost`, IPv6 loopback `[::1]`, alternate 127.x.x.x addresses, `https`, and embedded credentials (`http://user:pw@…`). Legacy `http://localhost` entries are silently normalized to `http://127.0.0.1` on next read; hand-edited entries pointing at any other host shape are surfaced as invalid and re-prompt the wizard.
+- Integrations probe sidecar pointer validation (#794 / #642) — canonicalize-before-allowlist, Windows reparse-walk fail-closed, POSIX hardlink + world-writable parent rejection at sidecar spawn time
+- Windows ACL hardening on `.claude.json` (#795 / #643)
+- **`.claude.json` backup before overwrite (#796 / #644)** — backups written to `${appDataDir}/.backups/` (Windows: `%LOCALAPPDATA%\tandem\Data\.backups`) with mode `0o600` (POSIX) / restrictive DACL (Windows), capped at `MAX_BACKUPS=3`. Token rotation triggers a backup, so up to 3 superseded bearer tokens may persist on disk per integration; rotate locally then delete the backup folder if a tighter retention is required.
+- Malformed-input matrix + shape gates + BOM strip (#797 / #645)
+
+### Internal
+- `ws` transitive dependency bump 8.19.0 → 8.20.1 (#772) — dependabot, no CVE cited
+- E2E waitForTimeout flake removal (#785)
+- Test-suite audit — ADR-027 privacy bug fix, weak-assertion sweep, ADR-031 gap fill (#786)
+- Schema-version assertions pinned to `CURRENT_SCHEMA_VERSION` (#789)
+- Remove `block-e2e-port-kill` PreToolUse hook (#787)
+- Document `RelativeRange` invariants (#793)
+- #477 PR 3c-ii-a server library factor (#747)
+- Refresh CLAUDE.md file-map (#751)
+- Roadmap updates: 3c-i + 3c-ii-a SHIPPED (#749), Phase-3-docs SHIPPED (#744), spike-f2 re-validation (#750)
+- Design-notes archive (#774, #775)
+```
+
+Final wording during execution: walk `git log v0.12.0..HEAD --no-merges --reverse` once with the [Unreleased] block open and reconcile commit-by-commit. Use [ADR-038](../decisions.md#adr-038) framing per `.claude/skills/changelog/SKILL.md`.
+
+### 2. `package.json` + `package-lock.json`
+
+Use `npm version 0.13.0 --no-git-tag-version` from the repo root. This single command updates:
+
+- `package.json` line 3: `0.12.0` → `0.13.0`
+- `package-lock.json` line 3 (root version) and line 9 (self-package): both `0.12.0` → `0.13.0`
+
+Do NOT hand-edit `package.json` alone — leaving the lockfile at 0.12.0 would cause `npm ci` to fail on the next CI run with a lockfile-mismatch error.
+
+### 3. `src-tauri/tauri.conf.json`
+
+`0.12.0` → `0.13.0` (line 4). **CRITICAL — same value as `package.json`** per `docs/plans/2026-04-17-v0.6.3-release.md` lesson: drift here caused the v0.6.1 startup crash.
+
+### 4. `src-tauri/Cargo.toml` + `Cargo.lock`
+
+**MUST bump to `0.13.0`** — reviewer correction to the original plan. The crate version is rendered in user-facing dialogs via `env!("CARGO_PKG_VERSION")`:
+
+- `src-tauri/src/lib.rs:556` — tray menu "About Tandem" dialog
+- `src-tauri/src/lib.rs:1922` — auto-updater "up-to-date" dialog
+
+Currently `0.9.1` (line 3 of `src-tauri/Cargo.toml`); the "About Tandem" dialog therefore renders the wrong version. This is a quiet bug that compounds at every release until fixed.
+
+Steps:
+
+1. Edit `src-tauri/Cargo.toml` line 3: `version = "0.9.1"` → `version = "0.13.0"`.
+2. Regenerate the lockfile: `cargo update -p tandem-desktop` (crate name is `tandem-desktop`, per `src-tauri/Cargo.toml:2` — not `tandem`).
+3. Stage the `Cargo.lock` changes alongside `Cargo.toml`.
+
+This adds Cargo.lock churn to the release PR; accept the diff. After this release every version cut should bump Cargo.toml in lockstep with `package.json` and `tauri.conf.json` — add a checklist item in `.claude/skills/changelog/SKILL.md` (or wherever the release runbook lives) so it doesn't drift again.
+
+### 4b. (Optional) `tests/client/update-available.test.ts` fixture refresh
+
+Lines 47, 54, 58, 64, 71, 77, 83 hardcode `"0.12.0"` as the simulated new-version fixture. Once v0.13.0 ships, the test simulates "0.12.0 is the new available version" which is a downgrade scenario — semantically stale but the assertions still pass (the test treats version as an opaque string). **Recommended:** bump the fixture to `"0.13.1"` (or `"0.14.0-test"`) in the same release PR so it reads sensibly. Not a release blocker.
+
+### 5. `docs/roadmap.md`
+
+Update the release-cadence table (line 538): mark v0.13.0 row as "Released YYYY-MM-DD". Wave 1 / Wave 1b / Wave 2 rows in the "Working wave plan" table can stay as-is (the "shipped 2026-05-15" / "merged 2026-05-17" inline notes already reflect ground truth).
+
+### 6. `.claude/.workflow-state/<session_id>/` — N/A (gitignored)
+
+## Documentation Updates
+
+In addition to the three version-file edits above, the release PR must sweep these docs. Group all of this into the same release PR — splitting docs and version bump into two PRs invites them drifting against each other.
+
+### Must-update (load-bearing)
+
+#### `CLAUDE.md` — §"Status" block (lines 160–162)
+
+The current status sentence stops at v0.11.0. Extend with a v0.12.0 sentence (currently missing!) and a v0.13.0 sentence. Suggested append:
+
+```
+v0.12.0 complete: 8-unit prep batch (PRs #634–#641) — #477 PR-2 browser deprecation, #477 Phase 0 sidecar spike, #576 spikes A+B, AR4, anchor-drift test, release scaffolding. v0.13.0 complete: Waves 1+2 — stability bug-bash (SettingsModal sibling, status-bar held-count, ConnectionBanner polish, updater banner+dot), redesign chrome (floating-pill system across titlebar/rails/tabs/status/outline/popup, Wave M dark-mode v7 alignment), Settings → Network panel split (Connection visible + Advanced collapsed), multi-provider Models registry (Anthropic + OpenAI + Gemini + Ollama + llama.cpp, keychain secrets, first-run picker), schema v2→v3 migration with read-only forward-compat, D11 bundled fonts, margin annotation view (#649 PR1–PR3), .docx batch-promote (Wave 8), narrow-viewport Settings drawer (Wave 9), slash-menu polish (Wave 10), #477 PR 3c-ii-a/3c-ii-b (server library factor + wizard apply path; hidden), launcher PR 4a/4b (reaper + UI; feature-flag hidden), integrations-probe hardening quartet (#794–#797), `IntegrationConfig.url` loopback constraint, comprehensive README + docs rewrite.
+```
+
+Verify factual accuracy by walking the CHANGELOG `[0.13.0]` block — these two should agree.
+
+#### `docs/roadmap.md`
+
+Already in §"Release PR Contents" item 5, but listing the specific edits here:
+
+- **Release-cadence table (line 538):** add a `Released YYYY-MM-DD` column note for the `v0.13.0` row. Suggested phrasing matching the prior pattern: `| v0.13.0    | Stability bug-bash + redesign chrome (sibling-component pattern)                       | Waves 1, 2    | Released YYYY-MM-DD |`. May need a fourth column on the table OR fold the date inline into the Concern column.
+- **"Active — Toward v1.0" wave table (lines ~18–27):** add `Released in v0.13.0` markers to Wave 1, Wave 1b, and Wave 2 rows. Move the table's current "in flight" wave pointer from Wave 0/1 to Wave 3 (next wave for v0.14.0).
+- **Cowork integration status (line 412–416):** the v0.13.0 deferral note ("Deferred from v0.9.0 to v0.13.0") needs an update — these items are NOT shipping in v0.13.0 either; they're now Wave 5 / v0.16.0 per the release-cadence table. Reconcile by updating to "Deferred from v0.9.0 to v0.16.0" or similar.
+- **#477 PR table rows (lines 443–450):** PR 3c-ii-a (#747) and 3c-ii-b (#773) ship in v0.13.0 — confirm the SHIPPED markers reflect this. PR 3c-ii-c is still pending (delete `/api/setup`, rewrite `tandem setup`); keep its v0.13.0 target only if it lands before tag-push, otherwise reroute to v0.14.0.
+- **Line 443 / Line 450 "hidden → exposed" wording correction.** The text says PR 3c-i is "v0.13.0 (hidden) → v1.0 (exposed)" and PR 4 is "v0.13.0 (hidden) → v1.0 (exposed)". The merged code does not implement a feature flag — both ship default-ON with a `TANDEM_DISABLE_LAUNCHER=1` opt-out for the launcher and no opt-out for the wizard. Update the wording to "v0.13.0 (default-on, kill-switch via env)" or similar so the roadmap reflects shipped reality, not the original aspiration.
+
+#### `README.md`
+
+The README was rewritten in #777/#778 for a lay reader. Two items:
+
+- **§"Where Tandem is headed" (line ~111):** verify the section's forward-looking language doesn't already promise something v0.13.0 has shipped. If it lists "soon: Models registry / Settings rework" — those are now done; demote to "shipped in v0.13.0" or remove the bullet.
+- **§"Other ways to install" (line ~84):** confirm the `npm install -g tandem-editor` instructions don't pin a version. They shouldn't, but verify.
+
+No version badges in the README to bump (grepped — clean).
+
+#### `CHANGELOG.md`
+
+Already covered in §"Release PR Contents" item 1.
+
+### Should-update (cross-references)
+
+#### `docs/architecture.md` — file map
+
+The launcher work (#800, #477 PR 4b) added new source files. Grep `docs/architecture.md` for the §"File map" section and check whether any of these are mentioned:
+
+- `src/server/launcher/` (or wherever the cross-platform reaper lives)
+- `src/server/integrations/apply.ts` (moved from `src/cli/setup.ts` in #747)
+- New rune stores added in waves 3–10 (status pill, floating chrome composables)
+
+If file-map entries describe `src/cli/setup.ts` as containing auto-config helpers, that's stale — those now live in `src/server/integrations/apply.ts` per the file map in CLAUDE.md (already updated in #751).
+
+#### `docs/mcp-tools.md`
+
+This release doesn't add new MCP tools. Spot-check the doc says "26 active" still (it does in CLAUDE.md line 162). No edit expected; verify before merging.
+
+#### `docs/decisions.md` — ADR statuses
+
+- **ADR-038 §2/§2b** — the auto-configuration removal sub-decision is partly resolved by #747 + #773 in this release. Confirm the ADR-038 status block doesn't claim "deprecated when the wizard ships" if the wizard has effectively shipped (hidden behind apply path). Leave the language alone if there's any ambiguity — ADR text is durable.
+- **ADR-039** — referenced as TBD in ADR-038 §3. If ADR-039 hasn't been drafted, no edit needed; if a stub exists, no edit needed for this release.
+
+#### `docs/lessons-learned.md`
+
+Current count is 73 (verified — last entry is `## 73. Schema-Backed Enums Make Palette Migrations Self-Sanitizing`). If Wave 1/1b/2 produced any new lessons worth capturing — most likely candidates:
+
+- The BubbleMenu positioning fix from #680 (selection toolbar avoiding fixed chrome)
+- The harness-bundle leak that motivated Wave 2 PR 7 (CI guard)
+- The schema v2→v3 read-only forward-compat pattern (prevents downgrade clobber)
+
+**Decision:** include any new lessons as part of this release PR ONLY if they fall out naturally from CHANGELOG drafting. Don't grow the PR scope to mine lessons retroactively — the working-tree dev cycle is the right place to add lessons, not a release PR.
+
+#### `docs/troubleshooting.md`, `docs/configuration.md`, `docs/cli.md`, `docs/security.md`
+
+These four new docs landed in #777. Verify they don't reference v0.12.0 as the current version (`grep` over them returned no matches — clean). Spot-check that any `tandem doctor` or `tandem setup` instructions reflect the post-#747/#773 reality (the helpers moved from `src/cli/setup.ts` to `src/server/integrations/apply.ts`, but user-facing CLI behavior should be unchanged in v0.13.0; PR 3c-ii-c is what changes `tandem setup` itself).
+
+#### `docs/positioning.md`
+
+No version refs. The MCP-first framing landed in PR #734 (v0.12.0). No edit needed.
+
+#### `docs/v10-triage.md`
+
+**Referenced by `docs/roadmap.md` but does not exist in this clone.** Likely Bryan-local (`~/.claude/plans/...`). Confirm with Bryan whether the roadmap should drop the reference or whether the file lives elsewhere. **Not a v0.13.0 blocker** — pre-existing inconsistency.
+
+### Should-NOT-update (out of scope)
+
+- `docs/v011-plan.md`, `docs/v090-plan.md`, `docs/audit-v1.md`, `docs/audit-v2.md`, `docs/redesign-bundle/**` — historical record. Don't rewrite past version refs.
+- `docs/redesign-bundle/tandem/project/HANDOFF.v3.md` and siblings — design artifacts; leave alone.
+- `sample/welcome.md` — no version refs. Don't add any; the file is intentionally evergreen.
+
+### Documentation-update checklist (subset of pre-tag list)
+
+- [ ] `CLAUDE.md` §Status extended through v0.13.0 (and v0.12.0 backfill if missing)
+- [ ] `docs/roadmap.md` cadence table reflects v0.13.0 ship + cleared "in flight" pointer
+- [ ] `docs/roadmap.md` Cowork deferral target updated (v0.13.0 → v0.16.0)
+- [ ] `docs/roadmap.md` #477 PR rows reflect 3c-ii-a + 3c-ii-b shipped in v0.13.0
+- [ ] `README.md` "Where Tandem is headed" section reconciled with what shipped
+- [ ] `docs/architecture.md` file map spot-checked for launcher + apply.ts moves
+- [ ] `docs/mcp-tools.md` "26 active" count unchanged (no edit expected; verify)
+- [ ] `docs/decisions.md` ADR-038 status block re-read; no edit if ambiguous
+- [ ] Bryan confirms whether `docs/v10-triage.md` should be removed from roadmap refs (separate issue, not v0.13.0 blocker)
+
+## Release Sequence
+
+Steps run in order; **do not parallelize tag-push with verification gates**.
+
+### Phase 1 — Pre-flight verification (on `claude/0-13-0-checklist-YUxSO`)
+
+1. Confirm working tree clean, branch in sync with `origin/claude/0-13-0-checklist-YUxSO`.
+2. Pull latest `main` and merge or rebase onto it (resolve conflicts if any).
+3. `npm ci` (clean install — guarantees lockfile match).
+4. `npm run typecheck` → must be clean.
+5. `npm test` → must be green.
+6. `npm run test:e2e` → must be green. **Warning: stop any local `dev:server` first**, per `.claude/skills/e2e/SKILL.md`.
+7. `npm run build` → confirm `dist/server/`, `dist/channel/`, `dist/cli/`, `dist/client/` artifacts produced.
+8. `npm run check:tokens` → must be clean.
+9. **`npm run doctor`** against a sample workspace — confirm server health, MCP endpoint reachable.
+10. **Optional but recommended:** `cargo tauri build` locally on at least one host (Linux is the CI default). Expected non-zero exit when signing key absent is OK per `docs/plans/2026-04-17-v0.6.3-release.md` lesson; the installer artifact should still be produced.
+
+### Phase 2 — Release PR
+
+11. Make the file edits per §"Release PR Contents" + §"Documentation Updates".
+12. `git add` exact files: `CHANGELOG.md`, `package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `docs/roadmap.md`, `CLAUDE.md`, optional `README.md`, optional `tests/client/update-available.test.ts`. Do NOT use `git add -A`.
+13. Commit: `chore(release): v0.13.0`.
+14. Push: `git push -u origin claude/0-13-0-checklist-YUxSO`.
+15. Open PR via `mcp__github__create_pull_request` targeting `main`. Title `chore(release): v0.13.0`. Body = the new `## [0.13.0]` block from `CHANGELOG.md` as the PR description (so reviewers see it inline). Also call out in the PR body: (a) the `Cargo.toml` 0.9.1→0.13.0 catch-up bump (one-time correction), (b) the launcher and wizard apply paths are default-ON with `TANDEM_DISABLE_LAUNCHER=1` opt-out, (c) the `resolveSafeCwd` / `resolveRouteCwd` asymmetry noted in the CodeQL FP suppression review (1a73f41) for transparency.
+16. **Bryan-review the `## [0.13.0]` CHANGELOG block** before requesting merge. AI-drafted block is a starting point; final wording is Bryan's call. This is an explicit gate, not optional.
+17. Wait for CI: typecheck / lint / tests / build / `cargo test` / harness-bundle CI guard (Wave 2 PR 7) all green.
+18. Self-review the diff. Confirm only the expected files are touched (no stray dist/ artifacts, no node_modules churn).
+19. Request review or merge.
+
+### Phase 3 — Tag + release
+
+20. **Merge release PR to `main`** via `mcp__github__merge_pull_request` (squash; commit message = PR title).
+21. Pull `main` locally; verify the merge commit lands.
+22. **Verify the `npm` GitHub Environment** is intact at https://github.com/bloknayrb/tandem/settings/environments — must exist, must have `NPM_TOKEN` secret bound, must NOT have a manual-approval gate (else `publish.yml` will stall waiting for approval after the release is promoted). Same for the `release` environment used by `tauri-release.yml`.
+23. Create annotated tag: `git tag -a v0.13.0 -m "v0.13.0"` on the merge commit.
+24. Push tag: `git push origin v0.13.0`.
+    - This triggers `.github/workflows/tauri-release.yml` (matrix: macOS aarch64 + x86_64, Ubuntu 22.04, Windows). Build takes ~25–40 min.
+25. **Wait for the Tauri matrix to complete.** If any platform fails, fix forward — do not retroactively delete and recreate the tag; investigate per `tauri-release.yml` per-job logs.
+26. **Wait for the `release-check` summary job to go GREEN** (`tauri-release.yml:307–317`). This job fails if any platform's matrix job failed; each platform uploads to the draft independently, so a partial-artifact draft is possible even when individual jobs look green. Do NOT promote the draft to "Published" until `release-check` is green — otherwise `publish.yml` fires on an incomplete artifact set.
+27. The Tauri release job creates a GitHub Release draft (`releaseDraft: true` at `tauri-release.yml:227`) with the platform-bundled artifacts attached. Once `release-check` is green, promote the draft to "Published":
+    - GitHub Release notes = the `## [0.13.0]` block from `CHANGELOG.md`
+    - Mark as the latest release (auto)
+    - **Publishing the release fires the `release: { types: [published] }` trigger** in `.github/workflows/publish.yml`, which runs `npm publish --provenance --access public` on `tandem-editor`.
+28. Wait for `publish.yml` to complete. Confirm the new version appears on https://www.npmjs.com/package/tandem-editor.
+
+### Phase 4 — Smoke tests + housekeeping
+
+29. **Manual smoke (Windows preferred, since it's the primary distribution) — NON-NEGOTIABLE.** Since #660's E2E test was never written, this is the only validation that the dot badge actually works.
+    - Install prior v0.12.0 .msi
+    - Let Tauri auto-updater discover v0.13.0 via the new `latest.json` published by `tauri-release.yml`
+    - Open `sample/welcome.md` post-update; confirm annotations + tabs intact
+    - Trigger or simulate an updater-available event; confirm the titlebar dot appears; click into settings; confirm it clears
+    - Open the "About Tandem" tray menu item; confirm it renders `v0.13.0` (catches a Cargo.toml regression)
+    - `tandem doctor` clean
+30. **Launcher smoke:** confirm "Relaunch Claude in this folder" appears in the command palette when a `claude-code` integration is present and that `TANDEM_DISABLE_LAUNCHER=1` removes it. Verify a Claude Code child process actually spawns and is reaped on Tandem exit.
+31. **MCP regression:** existing Claude Code workspace with `.mcp.json` pointing at the released `tandem-editor` (npx) → `tandem_status` returns ok, all 26 active MCP tools enumerate.
+32. **First-run wizard regression (#477 PR 3c-ii-b):** with no `~/.tandem/integrations.json`, on first launch the wizard appears, the user can apply an integration, and `~/.claude.json` is backed up before overwrite per #796.
+33. **Close #660** with a comment linking to the merged commit(s) implementing `useUpdateAvailable.svelte.ts`. The acceptance-criteria E2E test should be filed as a separate follow-up issue; do NOT block release on it.
+34. Update `docs/roadmap.md` "Working wave plan" table if any wording needs to flip ("shipped 2026-05-15" → "released in v0.13.0").
+
+## Release Verification Checklist (pre-tag)
+
+- [ ] Working tree clean, branch synced
+- [ ] `npm ci` clean
+- [ ] `npm run typecheck` green
+- [ ] `npm test` green
+- [ ] `npm run test:e2e` green
+- [ ] `npm run build` green
+- [ ] `npm run check:tokens` clean
+- [ ] `npm run doctor` clean
+- [ ] (Optional) `cargo tauri build` on Linux produces artifact
+- [ ] CHANGELOG `[Unreleased]` promoted to `[0.13.0]` with the date filled in
+- [ ] All 52 commits since v0.12.0 reconciled into the new section
+- [ ] Launcher + wizard apply disclosed as default-ON with opt-out documented (NOT framed as "hidden")
+- [ ] `#753` CHANGELOG entry reflects the strict 127.0.0.1-literal rejection of localhost/IPv6/alt-127/`https`/userinfo
+- [ ] `#796` CHANGELOG entry discloses up-to-3 backup retention of bearer tokens
+- [ ] `ws` bump moved out of §Security (or GHSA verified before keeping it there)
+- [ ] `npm version 0.13.0 --no-git-tag-version` run → `package.json` + `package-lock.json` both at `0.13.0`
+- [ ] `src-tauri/tauri.conf.json` `0.13.0`
+- [ ] `src-tauri/Cargo.toml` `0.13.0` + `cargo update -p tandem-desktop` to refresh `Cargo.lock`
+- [ ] `tests/client/update-available.test.ts` fixture refresh (optional, recommended)
+- [ ] `CLAUDE.md` §Status backfilled for v0.12.0 + extended through v0.13.0
+- [ ] `docs/roadmap.md` cadence table + Cowork deferral target + #477 PR rows + "hidden → exposed" wording all reconciled
+- [ ] `README.md` "Where Tandem is headed" reviewed
+- [ ] PR opened, CI green, diff is docs/version-files only (no `dist/`, no `node_modules`)
+- [ ] Bryan-reviewed the `## [0.13.0]` block in the PR
+- [ ] PR merged to `main`
+- [ ] `npm` + `release` GitHub Environments verified (no manual-approval gates; secrets bound)
+- [ ] `v0.13.0` tag pushed
+- [ ] Tauri matrix complete (all 4 platforms)
+- [ ] `release-check` summary job GREEN
+- [ ] GitHub Release draft promoted to published (triggers `publish.yml`)
+- [ ] `tandem-editor` 0.13.0 visible on npm
+- [ ] Windows auto-update smoke green ("About Tandem" dialog renders `v0.13.0`)
+- [ ] Launcher smoke green (palette commands appear; opt-out kill switch removes them)
+- [ ] MCP regression smoke green
+- [ ] First-run wizard smoke green
+- [ ] #660 closed (E2E follow-up filed separately)
+
+## Risks & Open Questions
+
+1. **`src-tauri/Cargo.toml` MUST bump to 0.13.0** — see §"Release PR Contents" item 4. **Reviewer correction (release-mechanics, 2026-05-21):** the original "leave at 0.9.1" recommendation was wrong. `env!("CARGO_PKG_VERSION")` is rendered in user-facing dialogs at `src-tauri/src/lib.rs:556` (About) and `:1922` (up-to-date). Cargo.lock churn is acceptable; the crate name is `tandem-desktop`.
+
+2. **Tauri matrix flakes.** The `release` environment binds the OIDC token subject for Windows signing per `tauri-release.yml:18–22`. If signing fails, the Windows job exits red but other platforms may succeed. Plan: investigate the specific failure, fix forward, never rename or delete the `release` environment (silent break per the in-file CAUTION comment). The `release-check` summary job is the canonical gate (Phase 3 step 26).
+
+3. **CHANGELOG triage time.** 52 commits is large; the AI can produce a draft but Bryan should eyeball the final grouping before tag-push. Phase 2 step 16 is the explicit "Bryan-review the CHANGELOG" gate.
+
+4. **Launcher + wizard apply are default-ON, not feature-flag hidden** (security + scope reviewers, 2026-05-21). Roadmap line 450 says PR-4 "v0.13.0 hidden → v1.0 exposed" and line 443 says the same for #773, but the merged code does not implement a feature flag — only the `TANDEM_DISABLE_LAUNCHER=1` kill switch. **Decision (Bryan, 2026-05-21):** ship with default-ON disclosure, opt-out via the env var. The roadmap text needs an in-line correction (see §"Documentation Updates" → `docs/roadmap.md`). The CHANGELOG `### Added` entries above disclose this. If a future reviewer suggests "this is hidden," point them here.
+
+5. **Auto-updater rollback path.** If v0.13.0 ships a bad build, users who auto-updated cannot easily roll back. Mitigations:
+   - Run the Windows smoke (Phase 4 step 29) BEFORE publishing the GitHub Release draft — drafts don't trigger the updater.
+   - If a regression is discovered post-publish, ship v0.13.1 as the fix forward rather than yanking.
+
+6. **npm publish environment + provenance.** `publish.yml:11–13` requires `id-token: write` and the `npm` GitHub Environment. **Phase 3 step 22 is the verification gate** — confirm the environment exists, the `NPM_TOKEN` secret is bound + unrotated, and no manual-approval rule is attached (else publish stalls waiting for human approval after release-publish fires).
+
+7. **#660 closure timing.** The acceptance criteria in the issue lists "E2E test: simulate updater event → assert dot visible → click settings → assert dot gone" as required, but no such test exists in `tests/e2e/`. **Recommendation:** file a follow-up issue capturing the missing E2E and close #660 once the implementation commits are linked. The Phase 4 step 29 manual smoke is the substitute validation for this release.
+
+8. **CodeQL FP suppression asymmetry (`1a73f41`).** `resolveSafeCwd` in `src/server/launcher/supervisor.ts` accepts any canonical directory by design (advanced users hand-editing `integrations.json`); `resolveRouteCwd` home-confines. The asymmetry means an `integrations.json` planted by a separate compromise (e.g. another app on the box writing to `~/.local/share/tandem/`) can set any directory as Claude's spawn cwd. Not a v0.13.0 regression — same surface as PR 4a — but worth release-PR acknowledgement per Phase 2 step 15.
+
+9. **Stale browser tabs across upgrade.** Per CLAUDE.md gotcha "Stale browser tabs merge old CRDT state back." Users upgrading from v0.12.0 with an open browser tab risk reverting their Y.Doc. Not new in v0.13.0, but worth noting in the release announcement if there is one.
+
+10. **#796 backup retention on disk.** Up to 3 superseded bearer tokens may persist in `${appDataDir}/.backups/` per integration after token rotation. Mode `0o600` (POSIX) / restrictive DACL (Windows). Disclosed in CHANGELOG §Security. Users wanting tighter retention should clear the directory manually after rotation.
+
+## Version Justification
+
+**Why minor (0.13.0), not patch (0.12.1)?**
+
+- New user-visible features in `[Unreleased]`: Models registry, schema v2→v3 migration, bundled fonts, margin auto-collapse, narrow-viewport settings drawer, floating-pill chrome, status-bar polish, decoration toggle.
+- **New default-ON surfaces** for users who completed `tandem setup`: auto-launcher (#800 + #477 PR 4b), wizard apply path + first-run auto-open (#773). Disclosed below; opt-out via `TANDEM_DISABLE_LAUNCHER=1`.
+- Pre-1.0 minors are how Tandem signals "shipped a wave's worth of work." Pattern matches every prior release in the v1.0 series (v0.11.x patches for hotfixes; v0.12.0 + v0.13.0 for waves).
+
+**What would trigger a major?** Nothing pre-1.0. v1.0 itself is reserved for the exit-criteria gates in `docs/roadmap.md:546`.
+
+## Progress Tracking (live updates)
+
+- [x] Plan reviewed by adversarial agents (3 parallel: release-mechanics, scope/CHANGELOG, security — 2026-05-21)
+- [x] Plan updated per feedback — Cargo.toml bump reversed to required; package-lock.json added to scope; launcher/wizard reframed default-ON with opt-out disclosure; #753/#796/#772 CHANGELOG wording corrected; release-check + npm-environment gates added
+- [ ] Phase 1 — Pre-flight verification
+- [ ] Phase 2 — Release PR opened
+- [ ] Phase 2 — Release PR merged
+- [ ] Phase 3 — `v0.13.0` tag pushed
+- [ ] Phase 3 — Tauri matrix green
+- [ ] Phase 3 — GitHub Release published
+- [ ] Phase 3 — npm `tandem-editor@0.13.0` published
+- [ ] Phase 4 — Windows smoke green
+- [ ] Phase 4 — MCP regression smoke green
+- [ ] Phase 4 — First-run wizard smoke green
+- [ ] Phase 4 — #660 closed
+- [ ] v0.13.0 RELEASED

--- a/docs/plans/2026-05-21-v0.13.0-release.md
+++ b/docs/plans/2026-05-21-v0.13.0-release.md
@@ -19,9 +19,9 @@ Per `docs/roadmap.md` line 538 the release-cadence table assigns Waves 1 + 2 to 
 
 **Non-goals for this release:**
 
-- New code work. The release PR must be docs/version-file only; if any in-flight code work needs to land first, do it on a separate PR that merges to `main` before the release PR is opened.
+- New code work. The release PR must be docs/version-file only; if any in-flight code work needs to land first, do it on a separate PR that merges to `master` before the release PR is opened.
 - Wave 3+ (annotation migration #313/AR5/AR6, #477 PRs 1/3/4/5 exposure, #576 docx body export, #316 Cowork macOS/Linux). Those land in v0.14.0 / v0.15.0 / v0.16.0.
-- Re-litigating `src-tauri/Cargo.toml`'s historical version drift (currently `0.9.1`); see §"Risks" below.
+- Debating whether to fix `src-tauri/Cargo.toml`'s historical version drift — that decision is made: bump to `0.13.0` (see §"Release PR Contents" item 4). The non-goal is reopening the discussion, not skipping the fix.
 
 ## Scope Inventory
 
@@ -108,7 +108,7 @@ Walking `git log v0.12.0..HEAD` (52 commits since 2026-05-15) against the curren
 
 ## Release PR Contents
 
-Single PR off `claude/0-13-0-checklist-YUxSO` (current working branch) targeting `main`. Docs/version-file only.
+Single PR off `claude/0-13-0-checklist-YUxSO` (current working branch) targeting `master`. Docs/version-file only.
 
 ### 1. `CHANGELOG.md`
 
@@ -167,7 +167,9 @@ Promote `## [Unreleased]` → `## [0.13.0] - YYYY-MM-DD` (date = tag day). Expan
 - Design-notes archive (#774, #775)
 ```
 
-Final wording during execution: walk `git log v0.12.0..HEAD --no-merges --reverse` once with the [Unreleased] block open and reconcile commit-by-commit. Use [ADR-038](../decisions.md#adr-038) framing per `.claude/skills/changelog/SKILL.md`.
+Final wording during execution: run `git fetch --tags` first (the tag exists remotely but may not be fetched locally), then walk `git log v0.12.0..HEAD --no-merges --reverse` once with the [Unreleased] block open and reconcile commit-by-commit. Use [ADR-038](../decisions.md#adr-038) framing per `.claude/skills/changelog/SKILL.md`.
+
+**Structural note:** The current `[Unreleased]` section has two separate `### Added` subsections (the second covers D11 fonts + margin view, added after the network split + security sections). Merge them into a single `### Added` block when promoting to `[0.13.0]` to comply with Keep-a-Changelog format.
 
 ### 2. `package.json` + `package-lock.json`
 
@@ -201,7 +203,7 @@ This adds Cargo.lock churn to the release PR; accept the diff. After this releas
 
 ### 4b. (Optional) `tests/client/update-available.test.ts` fixture refresh
 
-Lines 47, 54, 58, 64, 71, 77, 83 hardcode `"0.12.0"` as the simulated new-version fixture. Once v0.13.0 ships, the test simulates "0.12.0 is the new available version" which is a downgrade scenario — semantically stale but the assertions still pass (the test treats version as an opaque string). **Recommended:** bump the fixture to `"0.13.1"` (or `"0.14.0-test"`) in the same release PR so it reads sensibly. Not a release blocker.
+Lines 47, 54, 58, 64, 71, 77 hardcode `"0.12.0"` as the simulated new-version fixture. (Line 83 is an assertion with no version string; line 81 uses `"0.13.0"` *intentionally* as the "newer version" in the third test case.) Once v0.13.0 ships, the test simulates "0.12.0 is the new available version" which is a downgrade scenario — semantically stale but the assertions still pass (the test treats version as an opaque string). **Recommended:** bump the six `"0.12.0"` fixtures to `"0.13.1"` (or `"0.14.0-test"`) **and** bump line 81's `"0.13.0"` to `"0.14.0"` (or `"0.15.0-test"`) so the third test still exercises a "newer version arrives" scenario. Not a release blocker.
 
 ### 5. `docs/roadmap.md`
 
@@ -220,7 +222,7 @@ In addition to the three version-file edits above, the release PR must sweep the
 The current status sentence stops at v0.11.0. Extend with a v0.12.0 sentence (currently missing!) and a v0.13.0 sentence. Suggested append:
 
 ```
-v0.12.0 complete: 8-unit prep batch (PRs #634–#641) — #477 PR-2 browser deprecation, #477 Phase 0 sidecar spike, #576 spikes A+B, AR4, anchor-drift test, release scaffolding. v0.13.0 complete: Waves 1+2 — stability bug-bash (SettingsModal sibling, status-bar held-count, ConnectionBanner polish, updater banner+dot), redesign chrome (floating-pill system across titlebar/rails/tabs/status/outline/popup, Wave M dark-mode v7 alignment), Settings → Network panel split (Connection visible + Advanced collapsed), multi-provider Models registry (Anthropic + OpenAI + Gemini + Ollama + llama.cpp, keychain secrets, first-run picker), schema v2→v3 migration with read-only forward-compat, D11 bundled fonts, margin annotation view (#649 PR1–PR3), .docx batch-promote (Wave 8), narrow-viewport Settings drawer (Wave 9), slash-menu polish (Wave 10), #477 PR 3c-ii-a/3c-ii-b (server library factor + wizard apply path; hidden), launcher PR 4a/4b (reaper + UI; feature-flag hidden), integrations-probe hardening quartet (#794–#797), `IntegrationConfig.url` loopback constraint, comprehensive README + docs rewrite.
+v0.12.0 complete: 8-unit prep batch (PRs #634–#641) — #477 PR-2 browser deprecation, #477 Phase 0 sidecar spike, #576 spikes A+B, AR4, anchor-drift test, release scaffolding. v0.13.0 complete: Waves 1+2 — stability bug-bash (SettingsModal sibling, status-bar held-count, ConnectionBanner polish, updater banner+dot), redesign chrome (floating-pill system across titlebar/rails/tabs/status/outline/popup, Wave M dark-mode v7 alignment), Settings → Network panel split (Connection visible + Advanced collapsed), multi-provider Models registry (Anthropic + OpenAI + Gemini + Ollama + llama.cpp, keychain secrets, first-run picker), schema v2→v3 migration with read-only forward-compat, D11 bundled fonts, margin annotation view (#649 PR1–PR3), .docx batch-promote (Wave 8), narrow-viewport Settings drawer (Wave 9), slash-menu polish (Wave 10), #477 PR 3c-ii-a/3c-ii-b (server library factor + wizard apply path; default-ON), launcher PR 4a/4b (reaper + UI; default-ON with `TANDEM_DISABLE_LAUNCHER=1` opt-out), integrations-probe hardening quartet (#794–#797), `IntegrationConfig.url` loopback constraint, comprehensive README + docs rewrite.
 ```
 
 Verify factual accuracy by walking the CHANGELOG `[0.13.0]` block — these two should agree.
@@ -262,7 +264,7 @@ If file-map entries describe `src/cli/setup.ts` as containing auto-config helper
 
 #### `docs/mcp-tools.md`
 
-This release doesn't add new MCP tools. Spot-check the doc says "26 active" still (it does in CLAUDE.md line 162). No edit expected; verify before merging.
+This release doesn't add new MCP tools. Spot-check the doc says "26 active" still (it does in `docs/mcp-tools.md` line 5; CLAUDE.md line 162 says "26 MCP tools" without the "active" qualifier — both are correct, just differently worded). No edit expected; verify before merging.
 
 #### `docs/decisions.md` — ADR statuses
 
@@ -316,7 +318,7 @@ Steps run in order; **do not parallelize tag-push with verification gates**.
 ### Phase 1 — Pre-flight verification (on `claude/0-13-0-checklist-YUxSO`)
 
 1. Confirm working tree clean, branch in sync with `origin/claude/0-13-0-checklist-YUxSO`.
-2. Pull latest `main` and merge or rebase onto it (resolve conflicts if any).
+2. `git fetch origin --tags` — ensures `v0.12.0` tag is available locally for `git log v0.12.0..HEAD` invocations. Then pull latest `master` and merge or rebase onto it (resolve conflicts if any).
 3. `npm ci` (clean install — guarantees lockfile match).
 4. `npm run typecheck` → must be clean.
 5. `npm test` → must be green.
@@ -332,7 +334,7 @@ Steps run in order; **do not parallelize tag-push with verification gates**.
 12. `git add` exact files: `CHANGELOG.md`, `package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `docs/roadmap.md`, `CLAUDE.md`, optional `README.md`, optional `tests/client/update-available.test.ts`. Do NOT use `git add -A`.
 13. Commit: `chore(release): v0.13.0`.
 14. Push: `git push -u origin claude/0-13-0-checklist-YUxSO`.
-15. Open PR via `mcp__github__create_pull_request` targeting `main`. Title `chore(release): v0.13.0`. Body = the new `## [0.13.0]` block from `CHANGELOG.md` as the PR description (so reviewers see it inline). Also call out in the PR body: (a) the `Cargo.toml` 0.9.1→0.13.0 catch-up bump (one-time correction), (b) the launcher and wizard apply paths are default-ON with `TANDEM_DISABLE_LAUNCHER=1` opt-out, (c) the `resolveSafeCwd` / `resolveRouteCwd` asymmetry noted in the CodeQL FP suppression review (1a73f41) for transparency.
+15. Open PR via `mcp__github__create_pull_request` targeting `master`. Title `chore(release): v0.13.0`. Body = the new `## [0.13.0]` block from `CHANGELOG.md` as the PR description (so reviewers see it inline). Also call out in the PR body: (a) the `Cargo.toml` 0.9.1→0.13.0 catch-up bump (one-time correction), (b) the launcher and wizard apply paths are default-ON with `TANDEM_DISABLE_LAUNCHER=1` opt-out, (c) the `resolveSafeCwd` / `resolveRouteCwd` asymmetry noted in the CodeQL FP suppression review (1a73f41) for transparency.
 16. **Bryan-review the `## [0.13.0]` CHANGELOG block** before requesting merge. AI-drafted block is a starting point; final wording is Bryan's call. This is an explicit gate, not optional.
 17. Wait for CI: typecheck / lint / tests / build / `cargo test` / harness-bundle CI guard (Wave 2 PR 7) all green.
 18. Self-review the diff. Confirm only the expected files are touched (no stray dist/ artifacts, no node_modules churn).
@@ -340,14 +342,14 @@ Steps run in order; **do not parallelize tag-push with verification gates**.
 
 ### Phase 3 — Tag + release
 
-20. **Merge release PR to `main`** via `mcp__github__merge_pull_request` (squash; commit message = PR title).
-21. Pull `main` locally; verify the merge commit lands.
+20. **Merge release PR to `master`** via `mcp__github__merge_pull_request` (squash; commit message = PR title).
+21. Pull `master` locally; verify the merge commit lands.
 22. **Verify the `npm` GitHub Environment** is intact at https://github.com/bloknayrb/tandem/settings/environments — must exist, must have `NPM_TOKEN` secret bound, must NOT have a manual-approval gate (else `publish.yml` will stall waiting for approval after the release is promoted). Same for the `release` environment used by `tauri-release.yml`.
 23. Create annotated tag: `git tag -a v0.13.0 -m "v0.13.0"` on the merge commit.
 24. Push tag: `git push origin v0.13.0`.
     - This triggers `.github/workflows/tauri-release.yml` (matrix: macOS aarch64 + x86_64, Ubuntu 22.04, Windows). Build takes ~25–40 min.
 25. **Wait for the Tauri matrix to complete.** If any platform fails, fix forward — do not retroactively delete and recreate the tag; investigate per `tauri-release.yml` per-job logs.
-26. **Wait for the `release-check` summary job to go GREEN** (`tauri-release.yml:307–317`). This job fails if any platform's matrix job failed; each platform uploads to the draft independently, so a partial-artifact draft is possible even when individual jobs look green. Do NOT promote the draft to "Published" until `release-check` is green — otherwise `publish.yml` fires on an incomplete artifact set.
+26. **Wait for the `release-check` summary job to go GREEN** (`tauri-release.yml:293–303`). This job fails if any platform's matrix job failed; each platform uploads to the draft independently, so a partial-artifact draft is possible even when individual jobs look green. Do NOT promote the draft to "Published" until `release-check` is green — otherwise `publish.yml` fires on an incomplete artifact set.
 27. The Tauri release job creates a GitHub Release draft (`releaseDraft: true` at `tauri-release.yml:227`) with the platform-bundled artifacts attached. Once `release-check` is green, promote the draft to "Published":
     - GitHub Release notes = the `## [0.13.0]` block from `CHANGELOG.md`
     - Mark as the latest release (auto)
@@ -395,7 +397,7 @@ Steps run in order; **do not parallelize tag-push with verification gates**.
 - [ ] `README.md` "Where Tandem is headed" reviewed
 - [ ] PR opened, CI green, diff is docs/version-files only (no `dist/`, no `node_modules`)
 - [ ] Bryan-reviewed the `## [0.13.0]` block in the PR
-- [ ] PR merged to `main`
+- [ ] PR merged to `master`
 - [ ] `npm` + `release` GitHub Environments verified (no manual-approval gates; secrets bound)
 - [ ] `v0.13.0` tag pushed
 - [ ] Tauri matrix complete (all 4 platforms)
@@ -412,7 +414,7 @@ Steps run in order; **do not parallelize tag-push with verification gates**.
 
 1. **`src-tauri/Cargo.toml` MUST bump to 0.13.0** — see §"Release PR Contents" item 4. **Reviewer correction (release-mechanics, 2026-05-21):** the original "leave at 0.9.1" recommendation was wrong. `env!("CARGO_PKG_VERSION")` is rendered in user-facing dialogs at `src-tauri/src/lib.rs:556` (About) and `:1922` (up-to-date). Cargo.lock churn is acceptable; the crate name is `tandem-desktop`.
 
-2. **Tauri matrix flakes.** The `release` environment binds the OIDC token subject for Windows signing per `tauri-release.yml:18–22`. If signing fails, the Windows job exits red but other platforms may succeed. Plan: investigate the specific failure, fix forward, never rename or delete the `release` environment (silent break per the in-file CAUTION comment). The `release-check` summary job is the canonical gate (Phase 3 step 26).
+2. **Tauri matrix flakes.** The `release` environment binds the OIDC token subject for Windows signing per `tauri-release.yml:14–22` (subject-binding comment at 14–18, CAUTION about renaming at 19–22). If signing fails, the Windows job exits red but other platforms may succeed. Plan: investigate the specific failure, fix forward, never rename or delete the `release` environment (silent break per the in-file CAUTION comment). The `release-check` summary job is the canonical gate (Phase 3 step 26).
 
 3. **CHANGELOG triage time.** 52 commits is large; the AI can produce a draft but Bryan should eyeball the final grouping before tag-push. Phase 2 step 16 is the explicit "Bryan-review the CHANGELOG" gate.
 


### PR DESCRIPTION
## Summary

Adds `docs/plans/2026-05-21-v0.13.0-release.md` — the working plan for cutting v0.13.0 (Waves 1 + 2 per `docs/roadmap.md`). Three parallel adversarial reviewers (release-mechanics, scope/CHANGELOG, security) walked the plan and the merged code; their findings are folded in.

This PR is the **plan**, not the release itself. The actual release PR will be a separate commit that promotes `CHANGELOG.md [Unreleased]` → `[0.13.0]`, bumps version files, and updates roadmap/CLAUDE.md.

## Key decisions captured

- **`src-tauri/Cargo.toml` MUST bump in lockstep.** `env!("CARGO_PKG_VERSION")` is rendered in user-facing dialogs at `src-tauri/src/lib.rs:556` (About) and `:1922` (up-to-date). It's been pinned at `0.9.1` while package.json drifted to 0.12.0 — bump in this release.
- **`package-lock.json` + `Cargo.lock`** added to version-bump scope. Use `npm version 0.13.0 --no-git-tag-version` + `cargo update -p tandem-desktop` (crate name is `tandem-desktop`, not `tandem`).
- **Launcher (#800, #477 PR 4b) + wizard apply (#773) ship default-ON.** Gated only by `TANDEM_DISABLE_LAUNCHER=1` (kill switch). Plan and CHANGELOG disclose this rather than the original "hidden behind feature flag" framing.
- **`#753` loopback hardening** wording reflects the strict 127.0.0.1-literal rejection of `localhost` / IPv6 loopback / alt-127 / `https` / userinfo, with legacy `http://localhost` silently normalized on read.
- **`#796` backup retention** discloses up-to-3 bearer-token persistence in `${appDataDir}/.backups/` (mode 0o600 / Windows DACL).
- **`#772` ws bump** moved from §Security to §Internal (dependabot transitive, no CVE).
- **Release sequence** adds explicit gates: Bryan-review of the CHANGELOG block, `npm`/`release` GitHub Environment verification, `release-check` summary job must be green before promoting the GitHub Release draft, and a non-negotiable Windows manual smoke that includes the "About Tandem" version check.

## Test plan

This is a docs-only addition; no behavior change.

- [x] Plan references match repo state at HEAD (file paths, line numbers, PR numbers verified by reviewers)
- [ ] Bryan reviews the plan and either approves or sends back for another iteration

## Follow-up

When the plan is approved, the next PR opens against `master` with the actual version bumps + CHANGELOG promotion. The plan tracks its own progress checklist under §"Progress Tracking".

https://claude.ai/code/session_01VtqcHarAY7Xj96Ss9DfxHT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtqcHarAY7Xj96Ss9DfxHT)_