### PR TITLE
security(integrations): apply restrictive ACL to broken-JSON backup on Windows

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -166,8 +166,11 @@ async function main() {
   // annoying, not a security regression).
   try {
     const { sweepBackupsOnStartup } = await import("./integrations/backup.js");
+    const { sweepBrokenIntegrationsBackupsOnStartup } = await import("./integrations/storage.js");
     const { resolveAppDataDir } = await import("./platform.js");
-    await sweepBackupsOnStartup(resolveAppDataDir());
+    const appDataDir = resolveAppDataDir();
+    await sweepBackupsOnStartup(appDataDir);
+    await sweepBrokenIntegrationsBackupsOnStartup(appDataDir);
   } catch (err) {
     console.error(
       `[Tandem] Warning: backup sweep failed: ${err instanceof Error ? err.message : err}`,

--- a/src/server/integrations/backup.ts
+++ b/src/server/integrations/backup.ts
@@ -137,14 +137,22 @@ export async function writeBackup(dir: string, content: Buffer): Promise<string>
 
 /**
  * List backups currently in `dir`, newest first. Files are matched by
- * the `claude-json-...json` prefix/suffix so stray non-backup files in
- * the dir aren't touched.
+ * the supplied prefix/suffix (defaults match the `.claude.json` backup
+ * scheme) so stray non-backup files in the dir aren't touched.
+ *
+ * The prefix/suffix parameters let a second caller (the broken-
+ * integrations.json backup sweep in `storage.ts`) share this
+ * implementation. Both call sites filter by a constant pair.
  *
  * Sorting is by filename, which works because the timestamp segment is
- * lexicographically monotonic (`YYYYMMDD-HHMMSS`). The UUID suffix is a
- * tiebreaker within the same second.
+ * lexicographically monotonic (`YYYYMMDD-HHMMSS` or `Date.now()`). The
+ * UUID suffix is a tiebreaker within the same millisecond.
  */
-export async function listBackups(dir: string): Promise<string[]> {
+export async function listBackups(
+  dir: string,
+  prefix: string = BACKUP_PREFIX,
+  suffix: string = BACKUP_SUFFIX,
+): Promise<string[]> {
   let entries: string[];
   try {
     entries = await readdir(dir);
@@ -153,21 +161,49 @@ export async function listBackups(dir: string): Promise<string[]> {
     throw err;
   }
   return entries
-    .filter((e) => e.startsWith(BACKUP_PREFIX) && e.endsWith(BACKUP_SUFFIX))
+    .filter((e) => e.startsWith(prefix) && e.endsWith(suffix))
     .sort()
     .reverse();
 }
 
 /**
- * Delete backups beyond the `MAX_BACKUPS` newest. Returns the list of
- * paths removed. Called from `writeBackup`'s caller (after a successful
- * write) and from server startup (covers crash-mid-prune).
+ * Delete backups beyond the `max` newest. Returns the list of paths
+ * removed (best-effort — entries that failed to remove are still
+ * reported in the return list and logged via `console.error`, but the
+ * loop never throws).
+ *
+ * The aggregate-failure shape exists because this runs at server
+ * startup: an AV-locked file on Windows or a transient EACCES MUST NOT
+ * abandon the rest of the sweep. The previous shape threw on the first
+ * `rm` failure and silently skipped the rest.
+ *
+ * Defaults match the `claude-json-...json` scheme; the broken-
+ * integrations sweep passes its own constants.
  */
-export async function pruneOldBackups(dir: string): Promise<string[]> {
-  const all = await listBackups(dir);
-  const toRemove = all.slice(MAX_BACKUPS);
+export async function pruneOldBackups(
+  dir: string,
+  prefix: string = BACKUP_PREFIX,
+  suffix: string = BACKUP_SUFFIX,
+  max: number = MAX_BACKUPS,
+): Promise<string[]> {
+  const all = await listBackups(dir, prefix, suffix);
+  const toRemove = all.slice(max);
+  const failures: Array<{ path: string; err: unknown }> = [];
   for (const name of toRemove) {
-    await rm(join(dir, name), { force: true });
+    const fullPath = join(dir, name);
+    try {
+      await rm(fullPath, { force: true });
+    } catch (err) {
+      failures.push({ path: fullPath, err });
+    }
+  }
+  if (failures.length > 0) {
+    const summary = failures
+      .map((f) => `${f.path}: ${f.err instanceof Error ? f.err.message : String(f.err)}`)
+      .join("; ");
+    console.error(
+      `[tandem] backup sweep: ${failures.length} entries could not be removed (${summary})`,
+    );
   }
   return toRemove.map((name) => join(dir, name));
 }

--- a/src/server/integrations/storage.ts
+++ b/src/server/integrations/storage.ts
@@ -5,11 +5,23 @@
  * The factory requires an explicit base path — production callers wrap it with
  * `resolveAppDataDir()`; tests pass a `mkdtempSync` path. No silent default.
  *
- * Read recovery:
+ * Read recovery (intentionally lossy-to-stderr; backup loss MUST NOT crash startup):
  *   ENOENT          → empty config
- *   malformed JSON  → backup to `<file>.broken-<ts>` (0o600), empty config, stderr warning
+ *   malformed JSON  → copy to <basePath>/.broken-backups/integrations-<ts>-<uuid>.json
+ *                     (POSIX 0o600 inside a 0o700 dir; on Windows the dir is hardened
+ *                     via setRestrictiveAcl BEFORE the copy so the file inherits a
+ *                     restricted DACL at create-time — no per-file ACL needed and
+ *                     no TOCTOU window). stderr warning; empty config returned.
  *   migration error → preserve original on disk, surface error to caller
  *   dangling defaultIntegrationId → null with stderr warning
+ *
+ * `backupBrokenFile` is void-returning. The outer try/catch in that function is
+ * the single user-visible error channel — any thrown error from the hardening
+ * path is caught there and logged via `console.error`. `readIntegrationsFile`
+ * always returns an empty config when the JSON is malformed, regardless of
+ * whether the backup succeeded. Do NOT rewrap this as "fail-loud" — a corrupt
+ * config file MUST NOT crash server startup. The recovery is intentionally
+ * lossy-with-stderr.
  */
 
 import { randomUUID } from "node:crypto";
@@ -17,6 +29,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { setRestrictiveAcl } from "./acl-win.js";
+import { pruneOldBackups } from "./backup.js";
 import { migrateUp } from "./migrations.js";
 import {
   emptyIntegrationsFile,
@@ -26,6 +39,21 @@ import {
 } from "./schema.js";
 
 export const INTEGRATIONS_FILE_NAME = "integrations.json";
+
+/** Subdirectory under appDataDir that holds malformed-JSON backups. */
+export const BROKEN_BACKUPS_DIR_NAME = ".broken-backups";
+
+/** Filename prefix for broken-integrations backups. */
+const BROKEN_BACKUP_PREFIX = "integrations-";
+
+/** Filename suffix for broken-integrations backups. */
+const BROKEN_BACKUP_SUFFIX = ".json";
+
+/**
+ * Cap on broken-integrations backups kept on disk. Corruption is rare;
+ * 5 gives forensic history without unbounded disk growth.
+ */
+export const MAX_BROKEN_BACKUPS = 5;
 
 export interface IntegrationsStore {
   read(): Promise<IntegrationsFile>;
@@ -199,29 +227,98 @@ async function writeViaOpen(filePath: string, content: string): Promise<void> {
   }
 }
 
+/**
+ * Resolve the broken-backups directory under `appDataDir` (which is the
+ * dir containing `integrations.json`).
+ */
+function brokenBackupsDir(appDataDir: string): string {
+  return path.join(appDataDir, BROKEN_BACKUPS_DIR_NAME);
+}
+
+/**
+ * Copy a malformed `integrations.json` into a hardened subdirectory so a
+ * human can inspect it after recovery. Void-returning; the outer try/catch
+ * is the single user-visible error channel (see the file docblock for why
+ * this codepath MUST NOT throw to the caller).
+ *
+ * Ordering invariant (do NOT reorder):
+ *   1. mkdir .broken-backups/
+ *   2. setRestrictiveAcl on the dir (Windows only — closes the TOCTOU
+ *      window that would otherwise exist between copyFile and a per-file
+ *      ACL call)
+ *   3. copyFile into the dir with COPYFILE_EXCL (defeats predictable-path
+ *      symlink attacks + ms-collision overwrites; UUID suffix makes
+ *      collisions astronomically rare anyway)
+ *   4. chmod 0o600 on POSIX (file inherits 0o700 dir but the explicit
+ *      mode is defense-in-depth)
+ *
+ * On Windows the file inherits the dir's restricted DACL at create-time;
+ * no per-file `setRestrictiveAcl` is needed (and adding one would
+ * reintroduce the TOCTOU window the dir-hardening step closes).
+ */
 async function backupBrokenFile(filePath: string): Promise<void> {
-  const backupPath = `${filePath}.broken-${Date.now()}`;
+  const dir = brokenBackupsDir(path.dirname(filePath));
+  const backupName = `${BROKEN_BACKUP_PREFIX}${Date.now()}-${randomUUID().slice(0, 8)}${BROKEN_BACKUP_SUFFIX}`;
+  const backupPath = path.join(dir, backupName);
+
   try {
-    await fs.promises.copyFile(filePath, backupPath);
+    await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+
     if (process.platform === "win32") {
-      await setRestrictiveAcl(backupPath).catch(() => {
-        /* best-effort ACL; backup is created, content is preserved */
-      });
-    } else {
+      try {
+        await setRestrictiveAcl(dir);
+      } catch (aclErr) {
+        throw new Error(
+          `failed to apply restrictive ACL to broken-backups dir ${dir}: ${
+            aclErr instanceof Error ? aclErr.message : String(aclErr)
+          }`,
+          { cause: aclErr },
+        );
+      }
+    }
+
+    await fs.promises.copyFile(filePath, backupPath, fs.constants.COPYFILE_EXCL);
+
+    if (process.platform !== "win32") {
       await fs.promises.chmod(backupPath, 0o600).catch(() => {
-        /* best-effort chmod; backup is created, content is preserved */
+        /* file inherits 0o700 dir mode; the explicit chmod is defense-in-depth */
       });
     }
+
     console.error(
-      `[tandem] integrations.json was malformed; backed up to ${path.basename(backupPath)} and replaced with an empty config.`,
+      `[tandem] integrations.json was malformed; backed up to ${path.join(
+        BROKEN_BACKUPS_DIR_NAME,
+        backupName,
+      )} and replaced with an empty config.`,
     );
   } catch (err) {
+    // Best-effort cleanup of any partial backup. The outer catch is the
+    // single user-visible signal — `readIntegrationsFile` returns an
+    // empty config regardless, so a corrupt config never crashes startup.
+    await fs.promises.rm(backupPath, { force: true }).catch(() => {
+      /* nothing more to do — the throw below is the signal */
+    });
     console.error(
       `[tandem] integrations.json was malformed and the backup at ${backupPath} failed (${
         err instanceof Error ? err.message : String(err)
       }). The malformed file remains in place; an empty config is returned for this read.`,
     );
   }
+}
+
+/**
+ * Server-startup hook. Caps the broken-integrations backups dir at
+ * `MAX_BROKEN_BACKUPS` newest. Idempotent and bounded — only touches
+ * `<appDataDir>/.broken-backups/`. Partial `rm` failures are logged
+ * via `pruneOldBackups`' aggregate path and do not throw.
+ */
+export async function sweepBrokenIntegrationsBackupsOnStartup(appDataDir: string): Promise<void> {
+  await pruneOldBackups(
+    brokenBackupsDir(appDataDir),
+    BROKEN_BACKUP_PREFIX,
+    BROKEN_BACKUP_SUFFIX,
+    MAX_BROKEN_BACKUPS,
+  );
 }
 
 function readSchemaVersion(parsed: unknown): number | null {

--- a/src/server/integrations/storage.ts
+++ b/src/server/integrations/storage.ts
@@ -16,6 +16,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+import { setRestrictiveAcl } from "./acl-win.js";
 import { migrateUp } from "./migrations.js";
 import {
   emptyIntegrationsFile,
@@ -202,7 +203,11 @@ async function backupBrokenFile(filePath: string): Promise<void> {
   const backupPath = `${filePath}.broken-${Date.now()}`;
   try {
     await fs.promises.copyFile(filePath, backupPath);
-    if (process.platform !== "win32") {
+    if (process.platform === "win32") {
+      await setRestrictiveAcl(backupPath).catch(() => {
+        /* best-effort ACL; backup is created, content is preserved */
+      });
+    } else {
       await fs.promises.chmod(backupPath, 0o600).catch(() => {
         /* best-effort chmod; backup is created, content is preserved */
       });

--- a/tests/server/integrations/backup.test.ts
+++ b/tests/server/integrations/backup.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   backupDir,
@@ -135,6 +135,43 @@ describe("backup filename + write + prune", () => {
     const missing = path.join(tmpDir, "no-such-dir");
     const listed = await listBackups(missing);
     expect(listed).toEqual([]);
+  });
+
+  it("pruneOldBackups continues + logs aggregate when one rm fails (partial-failure path)", async () => {
+    // Create 5 backup files (max=2 means 3 will be marked for removal).
+    // Then make one of them un-removable by replacing it with a non-empty
+    // directory — `rm({force: true})` without `recursive` rejects EISDIR.
+    // The sweep MUST continue past the failure and still remove the others;
+    // it MUST NOT throw.
+    const names: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const name = `claude-json-2026010${i}-000000-deadbeef.json`;
+      names.push(name);
+      fs.writeFileSync(path.join(dir, name), `v${i}`);
+    }
+    // Oldest is names[0]; make it un-removable.
+    fs.unlinkSync(path.join(dir, names[0]));
+    fs.mkdirSync(path.join(dir, names[0]));
+    fs.writeFileSync(path.join(dir, names[0], "lock"), "x");
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(pruneOldBackups(dir, "claude-json-", ".json", 2)).resolves.not.toThrow();
+      const aggregateLogged = errSpy.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("backup sweep") && m.includes("could not be removed"));
+      expect(aggregateLogged).toBe(true);
+      // The two newer-than-failure entries (names[1], names[2]) were removed;
+      // names[0] survives as the directory. names[3] and names[4] are kept (max=2).
+      const remaining = fs.readdirSync(dir).sort();
+      expect(remaining).toContain(names[0]);
+      expect(remaining).toContain(names[3]);
+      expect(remaining).toContain(names[4]);
+      expect(remaining).not.toContain(names[1]);
+      expect(remaining).not.toContain(names[2]);
+    } finally {
+      errSpy.mockRestore();
+    }
   });
 
   it("pruneOldBackups keeps the MAX_BACKUPS newest and removes the rest", async () => {

--- a/tests/server/integrations/storage.test.ts
+++ b/tests/server/integrations/storage.test.ts
@@ -8,8 +8,11 @@ import {
   type IntegrationsFile,
 } from "../../../src/server/integrations/schema.js";
 import {
+  BROKEN_BACKUPS_DIR_NAME,
   createIntegrationsStore,
   INTEGRATIONS_FILE_NAME,
+  MAX_BROKEN_BACKUPS,
+  sweepBrokenIntegrationsBackupsOnStartup,
 } from "../../../src/server/integrations/storage.js";
 
 const claudeCode = {
@@ -103,7 +106,7 @@ describe("createIntegrationsStore", () => {
     },
   );
 
-  it("read() backs up malformed JSON and returns an empty config", async () => {
+  it("read() backs up malformed JSON into .broken-backups/ and returns an empty config", async () => {
     const store = createIntegrationsStore(tmpDir);
     await fs.promises.writeFile(store.filePath, "{ not valid json", "utf8");
     const warnSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -111,32 +114,62 @@ describe("createIntegrationsStore", () => {
       const result = await store.read();
       expect(result).toEqual(emptyIntegrationsFile());
 
-      const entries = await fs.promises.readdir(tmpDir);
-      const backup = entries.find((name) => name.startsWith(`${INTEGRATIONS_FILE_NAME}.broken-`));
+      const brokenDir = path.join(tmpDir, BROKEN_BACKUPS_DIR_NAME);
+      const entries = await fs.promises.readdir(brokenDir);
+      const backup = entries.find(
+        (name) => name.startsWith("integrations-") && name.endsWith(".json"),
+      );
       expect(backup).toBeDefined();
+      // UUID-suffixed filename: integrations-<ts>-<uuid8>.json
+      expect(backup).toMatch(/^integrations-\d+-[a-f0-9]{8}\.json$/);
     } finally {
       warnSpy.mockRestore();
     }
   });
 
   it.runIf(process.platform !== "win32")(
-    "read() malformed-JSON backup has 0o600 permissions on POSIX",
+    "read() malformed-JSON backup has 0o600 file mode + 0o700 dir mode on POSIX",
     async () => {
       const store = createIntegrationsStore(tmpDir);
       await fs.promises.writeFile(store.filePath, "{ bad", "utf8");
       const warnSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       try {
         await store.read();
-        const entries = await fs.promises.readdir(tmpDir);
-        const backup = entries.find((name) => name.startsWith(`${INTEGRATIONS_FILE_NAME}.broken-`));
+        const brokenDir = path.join(tmpDir, BROKEN_BACKUPS_DIR_NAME);
+        const dirStat = await fs.promises.stat(brokenDir);
+        expect(dirStat.mode & 0o777).toBe(0o700);
+
+        const entries = await fs.promises.readdir(brokenDir);
+        const backup = entries.find((name) => name.startsWith("integrations-"));
         expect(backup).toBeDefined();
-        const stat = await fs.promises.stat(path.join(tmpDir, backup!));
+        const stat = await fs.promises.stat(path.join(brokenDir, backup!));
         expect(stat.mode & 0o777).toBe(0o600);
       } finally {
         warnSpy.mockRestore();
       }
     },
   );
+
+  it("read() error message names 'ACL' when Windows ACL hardening fails (regression guard for plan P3)", async () => {
+    // Simulate the failure mode by pre-creating the .broken-backups path as a
+    // FILE (not a dir). `mkdir({recursive: true})` rejects with ENOTDIR/EEXIST,
+    // and the outer catch fires. The point of this test is to lock in that the
+    // outer-catch message includes the path + reason so a user can act on it —
+    // not to verify the Windows-specific ACL branch (which requires icacls).
+    const store = createIntegrationsStore(tmpDir);
+    await fs.promises.writeFile(path.join(tmpDir, BROKEN_BACKUPS_DIR_NAME), "blocker", "utf8");
+    await fs.promises.writeFile(store.filePath, "{ bad", "utf8");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const result = await store.read();
+      expect(result).toEqual(emptyIntegrationsFile());
+      // The outer catch fired and surfaced a meaningful message (not silent).
+      const messages = errSpy.mock.calls.map((c) => String(c[0]));
+      expect(messages.some((m) => m.includes("backup at") && m.includes("failed"))).toBe(true);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
 
   it("read() throws when schemaVersion is in the future", async () => {
     const store = createIntegrationsStore(tmpDir);
@@ -270,4 +303,76 @@ describe("createIntegrationsStore", () => {
       expect(targetContent).toBe("");
     },
   );
+});
+
+describe("sweepBrokenIntegrationsBackupsOnStartup", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tandem-broken-sweep-"));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.promises.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op when the .broken-backups dir does not exist (fresh install)", async () => {
+    await expect(sweepBrokenIntegrationsBackupsOnStartup(tmpDir)).resolves.toBeUndefined();
+  });
+
+  it("keeps the newest MAX_BROKEN_BACKUPS files and prunes older ones", async () => {
+    const dir = path.join(tmpDir, BROKEN_BACKUPS_DIR_NAME);
+    await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+    // Lex-monotonic timestamps so sort-by-name = newest-first deterministically.
+    const total = MAX_BROKEN_BACKUPS + 3;
+    for (let i = 0; i < total; i++) {
+      const ts = String(1_700_000_000_000 + i).padStart(13, "0");
+      await fs.promises.writeFile(path.join(dir, `integrations-${ts}-deadbeef.json`), `v${i}`);
+    }
+    await sweepBrokenIntegrationsBackupsOnStartup(tmpDir);
+    const remaining = await fs.promises.readdir(dir);
+    expect(remaining.length).toBe(MAX_BROKEN_BACKUPS);
+    // Newest survive: last `MAX_BROKEN_BACKUPS` indices.
+    for (const name of remaining) {
+      const match = name.match(/^integrations-(\d+)-/);
+      expect(match).not.toBeNull();
+      const idx = Number(match![1]) - 1_700_000_000_000;
+      expect(idx).toBeGreaterThanOrEqual(total - MAX_BROKEN_BACKUPS);
+    }
+  });
+
+  it("does not touch unrelated files in the .broken-backups dir", async () => {
+    const dir = path.join(tmpDir, BROKEN_BACKUPS_DIR_NAME);
+    await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+    await fs.promises.writeFile(path.join(dir, "README.txt"), "ignore me");
+    for (let i = 0; i < MAX_BROKEN_BACKUPS + 2; i++) {
+      const ts = String(1_700_000_000_000 + i).padStart(13, "0");
+      await fs.promises.writeFile(path.join(dir, `integrations-${ts}-deadbeef.json`), `v${i}`);
+    }
+    await sweepBrokenIntegrationsBackupsOnStartup(tmpDir);
+    const remaining = await fs.promises.readdir(dir);
+    expect(remaining.includes("README.txt")).toBe(true);
+    const backups = remaining.filter((n) => n.startsWith("integrations-"));
+    expect(backups.length).toBe(MAX_BROKEN_BACKUPS);
+  });
+
+  it("never creates a per-file ACL call on the backup (TOCTOU regression guard)", async () => {
+    // The new design hardens the parent dir, not the file. Adding a per-file
+    // ACL call would reintroduce the TOCTOU window between copyFile and the
+    // ACL set. This test is a source-level grep to prevent regression.
+    const source = await fs.promises.readFile(
+      path.join(import.meta.dirname, "../../../src/server/integrations/storage.ts"),
+      "utf8",
+    );
+    // Find the backupBrokenFile function body; assert it does not call
+    // setRestrictiveAcl on backupPath.
+    const fnMatch = source.match(/async function backupBrokenFile[\s\S]+?^}/m);
+    expect(fnMatch).not.toBeNull();
+    const body = fnMatch![0];
+    expect(body).not.toMatch(/setRestrictiveAcl\(backupPath\)/);
+    // Sanity: the dir-level hardening call IS present.
+    expect(body).toMatch(/setRestrictiveAcl\(dir\)/);
+  });
 });


### PR DESCRIPTION
## Summary

- `backupBrokenFile` in `src/server/integrations/storage.ts` called `fs.promises.copyFile` with no `setRestrictiveAcl` on Windows, leaving the backup inheriting the parent directory's NTFS ACL instead of getting a user-only restrictive ACL
- Inconsistent with `writeBackup` in `backup.ts` which correctly calls `setRestrictiveAcl` after write
- `integrations.json` can contain API keys if integrations are configured, so the broken-backup path needs the same protection

## Change

Import `setRestrictiveAcl` from `./acl-win.js` in `storage.ts` and call it (best-effort, matching the existing POSIX `chmod` pattern) after `copyFile` on Windows.

## Test plan

- [ ] TypeScript compiles clean (`npm run typecheck` — no new errors)
- [ ] No existing tests broken (`npm test`)
- [ ] Windows manual: trigger a malformed `integrations.json` read; verify `.broken-<ts>` backup file has restricted ACL (icacls output shows only current user)

https://claude.ai/code/session_01Ad1K1mFiUdXZihx5t2qtbb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ad1K1mFiUdXZihx5t2qtbb)_