### PR TITLE
security(apply): harden .broken-backups/ ACL on Windows

### DIFF
--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -19,6 +19,7 @@
 import { randomUUID } from "node:crypto";
 import {
   chmodSync,
+  constants as fsConstants,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -555,9 +556,34 @@ export async function applyConfig(configPath: string, ops: ApplyOps): Promise<vo
       );
       try {
         if (process.platform === "win32") {
+          // Windows ignores the POSIX `mode` arg on mkdir, so harden the
+          // dir with an explicit DACL BEFORE writing the backup file.
+          // Mirrors the ordering invariant in
+          // `storage.ts#backupBrokenFile`: dir-level ACL closes the
+          // TOCTOU window that a per-file ACL would otherwise open
+          // between copyFile and the ACL set. Fail loud — orphaning a
+          // half-hardened dir is worse than aborting the backup
+          // outright. The inner `catch (copyErr)` below surfaces a
+          // named error and refuses to overwrite the malformed config.
+          try {
+            await setRestrictiveAcl(brokenBackupDir);
+          } catch (aclErr) {
+            throw new Error(
+              `failed to apply restrictive ACL to broken-backups dir ${brokenBackupDir}: ${
+                aclErr instanceof Error ? aclErr.message : String(aclErr)
+              }`,
+              { cause: aclErr },
+            );
+          }
           // Windows doesn't honor POSIX modes — fall back to plain copy.
-          // The randomUUID-suffixed path makes collisions effectively impossible.
-          await copyFile(configPath, backupPath);
+          // The randomUUID-suffixed path makes collisions effectively
+          // impossible. COPYFILE_EXCL refuses to overwrite an existing
+          // target, defeating any predictable-path symlink/pre-create
+          // attack the UUID suffix might still leave reachable. The
+          // newly-created file inherits the hardened DACL of the parent
+          // dir at create-time (see the ACL call above), so no per-file
+          // ACL is required.
+          await copyFile(configPath, backupPath, fsConstants.COPYFILE_EXCL);
         } else {
           // Open with mode 0o600 + `wx` so the file is created exclusively
           // at the right mode (no copyFile + chmodSync race window where

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -579,10 +579,16 @@ export async function applyConfig(configPath: string, ops: ApplyOps): Promise<vo
           // The randomUUID-suffixed path makes collisions effectively
           // impossible. COPYFILE_EXCL refuses to overwrite an existing
           // target, defeating any predictable-path symlink/pre-create
-          // attack the UUID suffix might still leave reachable. The
-          // newly-created file inherits the hardened DACL of the parent
-          // dir at create-time (see the ACL call above), so no per-file
-          // ACL is required.
+          // attack the UUID suffix might still leave reachable. NOTE:
+          // `setRestrictiveAcl` (acl-win.ts) calls `icacls /grant:r
+          // *<SID>:F` without (OI)(CI) inheritance flags, so the new
+          // file does NOT inherit the parent dir's SID-only ACE.
+          // Instead it receives the DACL synthesized from the process
+          // token's default (typically user + SYSTEM + Administrators),
+          // which is narrow enough to prevent cross-tenant leak in
+          // standard contexts. If broader access is observed, the dir
+          // ACE should be made inheritable in acl-win.ts (this would
+          // also benefit storage.ts which uses the same helper).
           await copyFile(configPath, backupPath, fsConstants.COPYFILE_EXCL);
         } else {
           // Open with mode 0o600 + `wx` so the file is created exclusively

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -19,8 +19,8 @@
 import { randomUUID } from "node:crypto";
 import {
   chmodSync,
-  constants as fsConstants,
   existsSync,
+  constants as fsConstants,
   lstatSync,
   mkdirSync,
   readdirSync,

--- a/tests/server/integrations/apply-acl.test.ts
+++ b/tests/server/integrations/apply-acl.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Regression coverage for #807. The inline malformed-`~/.claude.json`
+ * backup block inside `applyConfig` (see `apply.ts:537-573`) MUST harden
+ * the `.broken-backups/` dir with an explicit DACL on Windows BEFORE
+ * writing the backup file. Otherwise the dir lives at the OS default
+ * (broad inheritance) for the full copyFile window and any sibling
+ * process can list its contents — older backups can carry other
+ * vendors' API keys.
+ *
+ * This file covers two invariants:
+ *   1. Behavioural: when `setRestrictiveAcl` throws on Windows, the
+ *      backup aborts with a named error and no orphan file is written.
+ *   2. Source-level (TOCTOU regression-grep): `apply.ts` must never call
+ *      `setRestrictiveAcl(backupPath)` — only the parent dir is
+ *      hardened. A per-file ACL call would reintroduce the window
+ *      between copyFile and the ACL set.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted mock target — `vi.mock` is hoisted above imports, so the
+// stub must be hoisted alongside it.
+const aclStub = vi.hoisted(() => ({
+  setRestrictiveAcl: vi.fn(async (_path: string) => {
+    /* default: no-op, like the POSIX branch of the real impl */
+  }),
+}));
+
+vi.mock("../../../src/server/integrations/acl-win.js", () => ({
+  setRestrictiveAcl: aclStub.setRestrictiveAcl,
+  // The real module also exports assertNoBroadAce; preserve the shape
+  // even though apply.ts doesn't import it.
+  assertNoBroadAce: vi.fn(async () => {}),
+}));
+
+const { applyConfig } = await import("../../../src/server/integrations/apply.js");
+
+describe("applyConfig — broken-backups ACL hardening on Windows (#807)", () => {
+  let tmpDir: string;
+  let appDataDir: string;
+  let configPath: string;
+  let prevAppDataDir: string | undefined;
+  let prevPlatform: PropertyDescriptor | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tandem-807-acl-"));
+    appDataDir = path.join(tmpDir, "app-data");
+    fs.mkdirSync(appDataDir);
+    configPath = path.join(tmpDir, ".claude.json");
+    prevAppDataDir = process.env.TANDEM_APP_DATA_DIR;
+    process.env.TANDEM_APP_DATA_DIR = appDataDir;
+
+    // Fake `process.platform === "win32"` so the Windows-only ACL
+    // branch executes on POSIX CI hosts. Restore in afterEach. The real
+    // `setRestrictiveAcl` is mocked above, so no icacls spawn happens.
+    prevPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    aclStub.setRestrictiveAcl.mockReset();
+  });
+
+  afterEach(async () => {
+    if (prevAppDataDir === undefined) delete process.env.TANDEM_APP_DATA_DIR;
+    else process.env.TANDEM_APP_DATA_DIR = prevAppDataDir;
+
+    if (prevPlatform) Object.defineProperty(process, "platform", prevPlatform);
+
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("aborts the backup with a named error when setRestrictiveAcl throws — no orphan file on disk", async () => {
+    // Mock the ACL helper to throw. The hardened apply path must
+    //   (a) translate the bare ACL throw into a named, actionable error
+    //       so the outer catch can surface it,
+    //   (b) leave NO backup file under `.broken-backups/` (the dir is
+    //       still half-hardened — refusing to write the secret-bearing
+    //       payload into it is the whole point), and
+    //   (c) refuse to overwrite the original malformed config.
+    aclStub.setRestrictiveAcl.mockRejectedValueOnce(new Error("icacls: access denied"));
+
+    const malformed = "{ this is not json";
+    fs.writeFileSync(configPath, malformed);
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(
+        applyConfig(configPath, {
+          create: { tandem: { type: "http", url: "http://127.0.0.1:3479/mcp" } },
+          remove: [],
+        }),
+      ).rejects.toThrow(/failed to apply restrictive ACL to broken-backups dir/);
+
+      // The error message must name the failure surface so a human can
+      // act on it (silent ACL swallow is exactly what #805 fixed in
+      // storage.ts; the same invariant applies to apply.ts). The outer
+      // catch in applyConfig logs the chained `cause` via
+      // `err instanceof Error ? err.message : err` — the substring
+      // "ACL" appears in both the named throw and the chained message.
+      const messages = errSpy.mock.calls.map((c) => c.map(String).join(" "));
+      expect(messages.some((m) => m.includes("backup failed") && m.includes("ACL"))).toBe(true);
+    } finally {
+      errSpy.mockRestore();
+    }
+
+    // No orphan file in .broken-backups/ — the abort fired BEFORE
+    // copyFile, so the dir is either empty or absent.
+    const brokenDir = path.join(appDataDir, ".broken-backups");
+    if (fs.existsSync(brokenDir)) {
+      const entries = fs.readdirSync(brokenDir);
+      expect(entries).toEqual([]);
+    }
+
+    // Original malformed bytes are preserved on disk — backup-failure
+    // contract says we refuse to overwrite without a backup.
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(malformed);
+  });
+
+  it("calls setRestrictiveAcl on the DIR path (not the file path) — TOCTOU invariant", async () => {
+    // Happy path with the mock as a passthrough. `setRestrictiveAcl`
+    // gets called several times during a full applyConfig run (atomic
+    // write tmpfile, dest after cross-device copy, …). We only care
+    // about the call on the broken-backups dir — assert it happens,
+    // and assert it NEVER happens on a path that looks like a backup
+    // *file* (UUID-suffixed). A refactor that moves the call onto
+    // `backupPath` would break this test (paired with the source-grep
+    // below).
+    aclStub.setRestrictiveAcl.mockResolvedValue(undefined);
+
+    const malformed = "{ this is not json";
+    fs.writeFileSync(configPath, malformed);
+
+    await applyConfig(configPath, {
+      create: { tandem: { type: "http", url: "http://127.0.0.1:3479/mcp" } },
+      remove: [],
+    });
+
+    const brokenDir = path.join(appDataDir, ".broken-backups");
+    const callPaths = aclStub.setRestrictiveAcl.mock.calls.map((c) => String(c[0]));
+    // Dir-level hardening fired exactly once with the dir path.
+    expect(callPaths.filter((p) => p === brokenDir)).toEqual([brokenDir]);
+    // Per-file ACL never fired on any backup file (UUID-suffixed name).
+    const backupFileRe = /\.broken-\d+-[0-9a-f-]+$/;
+    expect(callPaths.filter((p) => backupFileRe.test(p))).toEqual([]);
+  });
+});
+
+describe("apply.ts source — TOCTOU regression guard (#807)", () => {
+  it("never calls setRestrictiveAcl on a backup FILE path (only on the dir)", async () => {
+    // Source-level grep mirrors the storage.ts regression guard at
+    // tests/server/integrations/storage.test.ts:361. Reintroducing a
+    // per-file ACL call would re-open the TOCTOU window between copyFile
+    // and the ACL set.
+    const source = await fs.promises.readFile(
+      path.resolve(import.meta.dirname, "../../../src/server/integrations/apply.ts"),
+      "utf8",
+    );
+    expect(source).not.toMatch(/setRestrictiveAcl\(backup(File)?Path\)/);
+    // Sanity: the dir-level hardening call IS present in apply.ts.
+    expect(source).toMatch(/setRestrictiveAcl\(brokenBackupDir\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #807. PR #805 fixed the equivalent TOCTOU in `storage.ts#backupBrokenFile`, but the **inline malformed-`~/.claude.json` backup block inside `applyConfig`** (`src/server/integrations/apply.ts:537-573`) still relied on `mkdirSync(..., { mode: 0o700 })` alone. Windows ignores POSIX modes on `mkdir`, so `.broken-backups/` lived at the OS default (broad inheritance) for the full `copyFile` window. Older backups in that dir can carry other vendors' API keys — sibling-listing leaks across co-tenants.

- Add `setRestrictiveAcl(brokenBackupDir)` on Windows **before** `copyFile`. Mirrors the ordering invariant in `storage.ts#backupBrokenFile` (dir-level ACL closes the TOCTOU window that a per-file ACL would otherwise open between `copyFile` and the ACL set).
- Add `fs.constants.COPYFILE_EXCL` to the Windows `copyFile` (defeats predictable-path symlink / pre-create attacks the UUID suffix might still leave reachable). POSIX branch is unchanged — `open(..., "wx", 0o600)` is already exclusive-create.
- Fail loud on ACL error: throw a named `Error` (with `cause: aclErr`) inside the inner `try` so the existing `catch (copyErr)` surfaces the message via `console.error` and refuses to overwrite the malformed config. No orphan half-hardened dir; no silent ACL swallow.
- Storage.ts is **not** touched (PR #805 already fixed it and has a regression-grep test that fails on changes there).

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npx vitest run tests/server/integrations/apply-acl.test.ts tests/server/integrations/apply.test.ts tests/server/integrations/apply-malformed.test.ts tests/server/integrations/storage.test.ts` — 68 passed, 1 skipped
- [x] New behavioural test: mock `setRestrictiveAcl` to throw → `applyConfig` aborts with the named error, no orphan file in `.broken-backups/`, original malformed config preserved.
- [x] New behavioural test: `setRestrictiveAcl` is called on the dir path (not the UUID-suffixed file path).
- [x] New source-grep test: `apply.ts` must never call `setRestrictiveAcl(backupPath)` / `setRestrictiveAcl(backupFilePath)` — only on `brokenBackupDir`. Mirrors the equivalent guard in `tests/server/integrations/storage.test.ts:361`.
- [ ] Manual Windows verification deferred — covered by the mocked-Windows behavioural tests (`Object.defineProperty(process, "platform", { value: "win32" })` + `vi.mock` on `acl-win.js`).

Fixes #807

https://claude.ai/code/session_01XXe5nk1E68VgrQ55yunVe9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXe5nk1E68VgrQ55yunVe9)_