### PR TITLE
refactor(tauri): return typed RejectionReason from extract_file_arg

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,31 @@ struct SidecarState(Mutex<Option<tauri_plugin_shell::process::CommandChild>>);
 /// events post directly.
 struct PendingOpens(Mutex<Vec<std::path::PathBuf>>);
 
+/// Why `extract_file_arg` rejected a candidate path. Carried in the `Err`
+/// variant of its return so callers can log a typed reason (and, in the
+/// future, surface a typed event to the WebView). See issue #630 — this is
+/// sub-task #1 of the broader rejection-surfacing work; downstream sub-tasks
+/// (Tauri event emission, buffered drain summaries, etc.) are tracked in a
+/// follow-up issue.
+///
+/// `Ok(None)` is used for the "no candidate arg" case (the user did not pass
+/// a file at all — e.g. cold-start with only flags). Only paths that were
+/// supplied but failed validation produce an `Err`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RejectionReason {
+    /// On Windows, the resolved absolute path contains a `:` outside the
+    /// drive-letter slot (index 1). Catches NTFS Alternate Data Stream
+    /// syntax like `file.md:Zone.Identifier`.
+    SuspiciousColon,
+    /// The candidate's extension (lowercased) is not in
+    /// `SUPPORTED_FILE_ASSOC_EXTS`. The string is the offending extension
+    /// (empty when the path had no extension at all).
+    UnsupportedExtension(String),
+    /// The resolved path does not exist as a regular file (missing, a
+    /// directory, or some other non-file inode).
+    NotAFile,
+}
+
 /// Extract a file path to open from a process's command-line args.
 ///
 /// Rules:
@@ -101,13 +126,24 @@ struct PendingOpens(Mutex<Vec<std::path::PathBuf>>);
 /// - Verify the extension is in `SUPPORTED_FILE_ASSOC_EXTS` (case-insensitive).
 /// - Verify the path exists as a regular file.
 ///
+/// Returns:
+/// - `Ok(Some(path))` — a validated, openable file path.
+/// - `Ok(None)` — no candidate file arg was supplied (cold-start without a
+///   file, all args were flags, etc.). Not a rejection.
+/// - `Err(RejectionReason::...)` — a candidate was supplied but failed
+///   validation. Callers log the typed reason at `log::warn!`.
+///
 /// This is `pub` so the integration test in `tests/file_association.rs` can
 /// exercise it.
 pub fn extract_file_arg(
     args: &[String],
     cwd: &std::path::Path,
-) -> Option<std::path::PathBuf> {
-    let candidate = args.iter().skip(1).find(|a| !a.starts_with('-') && a.as_str() != "--")?;
+) -> Result<Option<std::path::PathBuf>, RejectionReason> {
+    let Some(candidate) =
+        args.iter().skip(1).find(|a| !a.starts_with('-') && a.as_str() != "--")
+    else {
+        return Ok(None);
+    };
 
     let p = std::path::Path::new(candidate);
     let absolute: std::path::PathBuf =
@@ -128,10 +164,7 @@ pub fn extract_file_arg(
         let absolute_str = absolute.to_string_lossy();
         for (i, b) in absolute_str.as_bytes().iter().enumerate() {
             if *b == b':' && i != 1 {
-                log::warn!(
-                    "extract_file_arg: rejecting path with suspicious ':' at index {i}: {absolute_str}"
-                );
-                return None;
+                return Err(RejectionReason::SuspiciousColon);
             }
         }
     }
@@ -139,13 +172,10 @@ pub fn extract_file_arg(
     let ext = absolute
         .extension()
         .and_then(|e| e.to_str())
-        .map(|e| e.to_ascii_lowercase())?;
+        .map(|e| e.to_ascii_lowercase())
+        .unwrap_or_default();
     if !SUPPORTED_FILE_ASSOC_EXTS.contains(&ext.as_str()) {
-        log::warn!(
-            "extract_file_arg: rejecting unsupported extension '.{ext}' for {}",
-            absolute.display()
-        );
-        return None;
+        return Err(RejectionReason::UnsupportedExtension(ext));
     }
 
     // is_file() follows symlinks intentionally — the final read goes through
@@ -154,14 +184,10 @@ pub fn extract_file_arg(
     // duplicate that check without adding defense in depth, since a symlink
     // pointing at a disallowed target would be rejected on the server hop.
     if !absolute.is_file() {
-        log::warn!(
-            "extract_file_arg: path is not a regular file: {}",
-            absolute.display()
-        );
-        return None;
+        return Err(RejectionReason::NotAFile);
     }
 
-    Some(absolute)
+    Ok(Some(absolute))
 }
 
 /// POST `{ filePath }` to the sidecar's `/api/open` endpoint with the auth
@@ -381,23 +407,31 @@ pub fn run() {
             // Apple Events (RunEvent::Opened) — args won't contain the file
             // path. This call is a no-op there, intentionally defensive for
             // shell-invoke edge cases.
-            if let Some(path) = extract_file_arg(&args, &cwd_path) {
-                let app_handle = app.clone();
-                tauri::async_runtime::spawn(async move {
-                    let client = app_handle.state::<reqwest::Client>().inner().clone();
-                    let token = match token_store::get_or_create_token() {
-                        Ok(t) => Some(t),
-                        Err(e) => {
-                            log::warn!("Token retrieval failed for second-instance POST: {e}");
-                            None
+            match extract_file_arg(&args, &cwd_path) {
+                Ok(Some(path)) => {
+                    let app_handle = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let client = app_handle.state::<reqwest::Client>().inner().clone();
+                        let token = match token_store::get_or_create_token() {
+                            Ok(t) => Some(t),
+                            Err(e) => {
+                                log::warn!("Token retrieval failed for second-instance POST: {e}");
+                                None
+                            }
+                        };
+                        if let Err(e) =
+                            request_open_file(&client, token.as_deref(), &path).await
+                        {
+                            log::warn!("request_open_file (second-instance) failed: {e}");
                         }
-                    };
-                    if let Err(e) =
-                        request_open_file(&client, token.as_deref(), &path).await
-                    {
-                        log::warn!("request_open_file (second-instance) failed: {e}");
-                    }
-                });
+                    });
+                }
+                Ok(None) => {}
+                Err(reason) => {
+                    log::warn!(
+                        "extract_file_arg (second-instance) rejected candidate: {reason:?}"
+                    );
+                }
             }
         }))
         // Blocks reload shortcuts (F5, Ctrl+F5, Shift+F5, Ctrl+R, Ctrl+Shift+R) only.
@@ -443,7 +477,15 @@ pub fn run() {
             let cold_start_file: Option<std::path::PathBuf> = {
                 let args: Vec<String> = std::env::args().collect();
                 let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-                extract_file_arg(&args, &cwd)
+                match extract_file_arg(&args, &cwd) {
+                    Ok(opt) => opt,
+                    Err(reason) => {
+                        log::warn!(
+                            "extract_file_arg (cold-start) rejected candidate: {reason:?}"
+                        );
+                        None
+                    }
+                }
             };
             if let Some(ref p) = cold_start_file {
                 log::info!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,15 +99,45 @@ struct PendingOpens(Mutex<Vec<std::path::PathBuf>>);
 pub enum RejectionReason {
     /// On Windows, the resolved absolute path contains a `:` outside the
     /// drive-letter slot (index 1). Catches NTFS Alternate Data Stream
-    /// syntax like `file.md:Zone.Identifier`.
-    SuspiciousColon,
+    /// syntax like `file.md:Zone.Identifier`. Carries the resolved absolute
+    /// `path` and the byte `index` of the offending colon — both are
+    /// security-relevant (ADS detection) and were logged inline before the
+    /// typed-reason refactor.
+    SuspiciousColon { path: std::path::PathBuf, index: usize },
     /// The candidate's extension (lowercased) is not in
-    /// `SUPPORTED_FILE_ASSOC_EXTS`. The string is the offending extension
-    /// (empty when the path had no extension at all).
-    UnsupportedExtension(String),
-    /// The resolved path does not exist as a regular file (missing, a
+    /// `SUPPORTED_FILE_ASSOC_EXTS`. `ext` is the offending extension (empty
+    /// when the path had no extension at all); `path` is the resolved
+    /// absolute path.
+    UnsupportedExtension { ext: String, path: std::path::PathBuf },
+    /// The resolved `path` does not exist as a regular file (missing, a
     /// directory, or some other non-file inode).
-    NotAFile,
+    NotAFile { path: std::path::PathBuf },
+}
+
+impl std::fmt::Display for RejectionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RejectionReason::SuspiciousColon { path, index } => write!(
+                f,
+                "suspicious colon at byte index {index} in resolved path {}",
+                path.display()
+            ),
+            RejectionReason::UnsupportedExtension { ext, path } => {
+                if ext.is_empty() {
+                    write!(f, "missing/empty extension on path {}", path.display())
+                } else {
+                    write!(
+                        f,
+                        "unsupported extension '.{ext}' on path {}",
+                        path.display()
+                    )
+                }
+            }
+            RejectionReason::NotAFile { path } => {
+                write!(f, "not a regular file: {}", path.display())
+            }
+        }
+    }
 }
 
 /// Extract a file path to open from a process's command-line args.
@@ -131,7 +161,11 @@ pub enum RejectionReason {
 /// - `Ok(None)` — no candidate file arg was supplied (cold-start without a
 ///   file, all args were flags, etc.). Not a rejection.
 /// - `Err(RejectionReason::...)` — a candidate was supplied but failed
-///   validation. Callers log the typed reason at `log::warn!`.
+///   validation. Each variant carries the resolved absolute path (and, for
+///   `SuspiciousColon`, the offending byte index) so callers can log a
+///   human-readable, diagnostic reason via the `Display` impl (`{reason}`,
+///   not `{reason:?}`) — matching the path + index detail logged inline
+///   before the typed-reason refactor.
 ///
 /// This is `pub` so the integration test in `tests/file_association.rs` can
 /// exercise it.
@@ -164,7 +198,10 @@ pub fn extract_file_arg(
         let absolute_str = absolute.to_string_lossy();
         for (i, b) in absolute_str.as_bytes().iter().enumerate() {
             if *b == b':' && i != 1 {
-                return Err(RejectionReason::SuspiciousColon);
+                return Err(RejectionReason::SuspiciousColon {
+                    path: absolute.clone(),
+                    index: i,
+                });
             }
         }
     }
@@ -175,7 +212,7 @@ pub fn extract_file_arg(
         .map(|e| e.to_ascii_lowercase())
         .unwrap_or_default();
     if !SUPPORTED_FILE_ASSOC_EXTS.contains(&ext.as_str()) {
-        return Err(RejectionReason::UnsupportedExtension(ext));
+        return Err(RejectionReason::UnsupportedExtension { ext, path: absolute });
     }
 
     // is_file() follows symlinks intentionally — the final read goes through
@@ -184,7 +221,7 @@ pub fn extract_file_arg(
     // duplicate that check without adding defense in depth, since a symlink
     // pointing at a disallowed target would be rejected on the server hop.
     if !absolute.is_file() {
-        return Err(RejectionReason::NotAFile);
+        return Err(RejectionReason::NotAFile { path: absolute });
     }
 
     Ok(Some(absolute))
@@ -429,7 +466,7 @@ pub fn run() {
                 Ok(None) => {}
                 Err(reason) => {
                     log::warn!(
-                        "extract_file_arg (second-instance) rejected candidate: {reason:?}"
+                        "extract_file_arg (second-instance) rejected candidate: {reason}"
                     );
                 }
             }
@@ -481,7 +518,7 @@ pub fn run() {
                     Ok(opt) => opt,
                     Err(reason) => {
                         log::warn!(
-                            "extract_file_arg (cold-start) rejected candidate: {reason:?}"
+                            "extract_file_arg (cold-start) rejected candidate: {reason}"
                         );
                         None
                     }

--- a/src-tauri/tests/file_association.rs
+++ b/src-tauri/tests/file_association.rs
@@ -242,6 +242,78 @@ fn windows_relative_path_with_colon_rejected_after_resolution() {
 }
 
 #[test]
+fn display_renders_diagnostic_context() {
+    // The fixer commits switched the call sites from `{reason:?}` to `{reason}`
+    // (Display) specifically to recover the path + index diagnostic context in
+    // the log line. These assertions pin the exact rendered substrings so a
+    // format regression (dropping the index, mangling the empty-ext branch, or
+    // losing the path) fails CI. Substrings match `impl Display for
+    // RejectionReason` in `src-tauri/src/lib.rs`.
+    let p = PathBuf::from("/x/y.bin");
+
+    // Non-empty `ext`: renders the dotted extension and the path.
+    let unsupported = RejectionReason::UnsupportedExtension {
+        ext: "bin".to_string(),
+        path: p.clone(),
+    }
+    .to_string();
+    assert!(
+        unsupported.contains("unsupported extension '.bin'"),
+        "non-empty ext should render the dotted extension, got: {unsupported}"
+    );
+    assert!(
+        unsupported.contains("/x/y.bin"),
+        "non-empty ext should render the path, got: {unsupported}"
+    );
+
+    // Empty `ext`: the untested `ext.is_empty()` branch renders a distinct
+    // "missing/empty extension" message rather than `'.'`.
+    let empty_ext = RejectionReason::UnsupportedExtension {
+        ext: String::new(),
+        path: p.clone(),
+    }
+    .to_string();
+    assert!(
+        empty_ext.contains("missing/empty extension"),
+        "empty-ext branch should render the missing/empty message, got: {empty_ext}"
+    );
+    assert!(
+        empty_ext.contains("/x/y.bin"),
+        "empty-ext branch should still render the path, got: {empty_ext}"
+    );
+    assert!(
+        !empty_ext.contains("'.'"),
+        "empty-ext branch must NOT render a bare dotted extension, got: {empty_ext}"
+    );
+
+    // NotAFile: renders the path after a "not a regular file" prefix.
+    let not_a_file = RejectionReason::NotAFile { path: p.clone() }.to_string();
+    assert!(
+        not_a_file.contains("not a regular file"),
+        "NotAFile should render the not-a-regular-file prefix, got: {not_a_file}"
+    );
+    assert!(
+        not_a_file.contains("/x/y.bin"),
+        "NotAFile should render the path, got: {not_a_file}"
+    );
+
+    // SuspiciousColon: the offending byte index must appear in the output.
+    let suspicious = RejectionReason::SuspiciousColon {
+        path: p,
+        index: 4,
+    }
+    .to_string();
+    assert!(
+        suspicious.contains("byte index 4"),
+        "SuspiciousColon should render the offending byte index, got: {suspicious}"
+    );
+    assert!(
+        suspicious.contains("/x/y.bin"),
+        "SuspiciousColon should render the resolved path, got: {suspicious}"
+    );
+}
+
+#[test]
 fn warm_start_single_instance_args_shape() {
     // Reproduces the arg shape passed by `tauri-plugin-single-instance`:
     // `args[0]` is the executable path (potentially with spaces), `args[1]`

--- a/src-tauri/tests/file_association.rs
+++ b/src-tauri/tests/file_association.rs
@@ -48,9 +48,10 @@ fn flag_only_returns_ok_none() {
 #[test]
 fn nonexistent_file_returns_not_a_file() {
     let cwd = std::env::current_dir().unwrap();
+    let path = "/nope/does-not-exist.md";
     assert_eq!(
-        extract_file_arg(&args(&["/nope/does-not-exist.md"]), &cwd),
-        Err(RejectionReason::NotAFile),
+        extract_file_arg(&args(&[path]), &cwd),
+        Err(RejectionReason::NotAFile { path: PathBuf::from(path) }),
     );
 }
 
@@ -62,8 +63,29 @@ fn unsupported_extension_returns_unsupported_extension() {
     let result = extract_file_arg(&args(&[p.to_str().unwrap()]), &cwd);
     assert_eq!(
         result,
-        Err(RejectionReason::UnsupportedExtension("exe".to_string())),
+        Err(RejectionReason::UnsupportedExtension {
+            ext: "exe".to_string(),
+            path: p,
+        }),
         "extract_file_arg should reject unsupported .exe extension with typed reason"
+    );
+}
+
+#[test]
+fn no_extension_returns_unsupported_extension_with_empty_ext() {
+    // A path with no extension at all falls through the extension check with
+    // an empty `ext` string (this happens before the is_file() check, so the
+    // file need not exist). The variant still carries the resolved path.
+    let cwd = std::env::current_dir().unwrap();
+    let path = "/some/dir/README";
+    let result = extract_file_arg(&args(&[path]), &cwd);
+    assert_eq!(
+        result,
+        Err(RejectionReason::UnsupportedExtension {
+            ext: String::new(),
+            path: PathBuf::from(path),
+        }),
+        "a path with no extension should be rejected with an empty ext + the resolved path"
     );
 }
 
@@ -165,14 +187,23 @@ fn extension_check_is_case_insensitive() {
 fn windows_alternate_data_stream_path_is_rejected() {
     // NTFS ADS syntax `file.md:Zone.Identifier` contains a `:` at a position
     // other than the drive-letter slot (index 1). The test does NOT create a
-    // real ADS — we just verify the parser rejects the shape.
+    // real ADS — we just verify the parser rejects the shape and carries the
+    // resolved path + the offending colon's byte index.
     let cwd = std::env::current_dir().unwrap();
-    let result = extract_file_arg(&args(&["C:\\tmp\\file.md:Zone.Identifier"]), &cwd);
-    assert_eq!(
-        result,
-        Err(RejectionReason::SuspiciousColon),
-        "Path with colon outside drive-letter slot must be rejected with SuspiciousColon"
-    );
+    let candidate = "C:\\tmp\\file.md:Zone.Identifier";
+    let result = extract_file_arg(&args(&[candidate]), &cwd);
+    match result {
+        Err(RejectionReason::SuspiciousColon { path, index }) => {
+            assert_eq!(path, PathBuf::from(candidate));
+            assert_eq!(
+                path.to_string_lossy().as_bytes()[index],
+                b':',
+                "reported index must point at a colon"
+            );
+            assert_ne!(index, 1, "the offending colon must not be the drive-letter slot");
+        }
+        other => panic!("expected SuspiciousColon, got {other:?}"),
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -182,14 +213,22 @@ fn windows_relative_path_with_colon_rejected_after_resolution() {
     // in the candidate string, which the candidate-only scan correctly
     // rejects. The harder case is when `cwd.join(candidate)` is what would
     // be passed to the filesystem. We scan the resolved absolute path so the
-    // post-join colon position is what matters.
+    // post-join colon position is what matters — and the reported index lands
+    // on the resolved-path colon.
     let cwd = PathBuf::from("C:\\Users\\bryan");
     let result = extract_file_arg(&args(&["notes.md:Zone.Identifier"]), &cwd);
-    assert_eq!(
-        result,
-        Err(RejectionReason::SuspiciousColon),
-        "Relative path with ADS colon must be rejected with SuspiciousColon after resolution against cwd"
-    );
+    match result {
+        Err(RejectionReason::SuspiciousColon { path, index }) => {
+            assert_eq!(path, cwd.join("notes.md:Zone.Identifier"));
+            assert_eq!(
+                path.to_string_lossy().as_bytes()[index],
+                b':',
+                "reported index must point at the resolved-path colon"
+            );
+            assert_ne!(index, 1, "the offending colon must not be the drive-letter slot");
+        }
+        other => panic!("expected SuspiciousColon, got {other:?}"),
+    }
 }
 
 #[test]

--- a/src-tauri/tests/file_association.rs
+++ b/src-tauri/tests/file_association.rs
@@ -8,7 +8,7 @@
 use std::fs::File;
 use std::path::PathBuf;
 
-use app_lib::extract_file_arg;
+use app_lib::{extract_file_arg, RejectionReason};
 use tempfile::TempDir;
 
 /// Build a [exe, ...rest] arg list, mimicking the OS shape.
@@ -25,48 +25,55 @@ fn touch(dir: &TempDir, name: &str) -> PathBuf {
 }
 
 #[test]
-fn empty_args_returns_none() {
+fn empty_args_returns_ok_none() {
     let cwd = std::env::current_dir().unwrap();
-    assert!(extract_file_arg(&[], &cwd).is_none());
+    assert_eq!(extract_file_arg(&[], &cwd), Ok(None));
 }
 
 #[test]
-fn exe_only_returns_none() {
+fn exe_only_returns_ok_none() {
     let cwd = std::env::current_dir().unwrap();
-    assert!(extract_file_arg(&args(&[]), &cwd).is_none());
+    assert_eq!(extract_file_arg(&args(&[]), &cwd), Ok(None));
 }
 
 #[test]
-fn flag_only_returns_none() {
+fn flag_only_returns_ok_none() {
     let cwd = std::env::current_dir().unwrap();
-    assert!(extract_file_arg(&args(&["--debug", "-v", "--help"]), &cwd).is_none());
-}
-
-#[test]
-fn nonexistent_file_returns_none() {
-    let cwd = std::env::current_dir().unwrap();
-    assert!(extract_file_arg(&args(&["/nope/does-not-exist.md"]), &cwd).is_none());
-}
-
-#[test]
-fn unsupported_extension_returns_none() {
-    let dir = TempDir::new().unwrap();
-    let p = touch(&dir, "secret.exe");
-    let cwd = std::env::current_dir().unwrap();
-    let result = extract_file_arg(&args(&[p.to_str().unwrap()]), &cwd);
-    assert!(
-        result.is_none(),
-        "extract_file_arg should reject unsupported .exe extension"
+    assert_eq!(
+        extract_file_arg(&args(&["--debug", "-v", "--help"]), &cwd),
+        Ok(None),
     );
 }
 
 #[test]
-fn absolute_md_path_returns_some() {
+fn nonexistent_file_returns_not_a_file() {
+    let cwd = std::env::current_dir().unwrap();
+    assert_eq!(
+        extract_file_arg(&args(&["/nope/does-not-exist.md"]), &cwd),
+        Err(RejectionReason::NotAFile),
+    );
+}
+
+#[test]
+fn unsupported_extension_returns_unsupported_extension() {
+    let dir = TempDir::new().unwrap();
+    let p = touch(&dir, "secret.exe");
+    let cwd = std::env::current_dir().unwrap();
+    let result = extract_file_arg(&args(&[p.to_str().unwrap()]), &cwd);
+    assert_eq!(
+        result,
+        Err(RejectionReason::UnsupportedExtension("exe".to_string())),
+        "extract_file_arg should reject unsupported .exe extension with typed reason"
+    );
+}
+
+#[test]
+fn absolute_md_path_returns_ok_some() {
     let dir = TempDir::new().unwrap();
     let p = touch(&dir, "doc.md");
     let cwd = std::env::current_dir().unwrap();
     let result = extract_file_arg(&args(&[p.to_str().unwrap()]), &cwd);
-    assert_eq!(result, Some(p));
+    assert_eq!(result, Ok(Some(p)));
 }
 
 #[test]
@@ -75,7 +82,7 @@ fn relative_path_resolves_against_cwd() {
     touch(&dir, "notes.md");
     // Pretend the OS launched us with cwd=dir and a bare filename on argv.
     let result = extract_file_arg(&args(&["notes.md"]), dir.path());
-    assert_eq!(result, Some(dir.path().join("notes.md")));
+    assert_eq!(result, Ok(Some(dir.path().join("notes.md"))));
 }
 
 #[test]
@@ -87,7 +94,7 @@ fn leading_flags_then_file_takes_file() {
         &args(&["--debug", "-v", p.to_str().unwrap()]),
         &cwd,
     );
-    assert_eq!(result, Some(p));
+    assert_eq!(result, Ok(Some(p)));
 }
 
 #[test]
@@ -96,7 +103,7 @@ fn double_dash_separator_is_skipped() {
     let p = touch(&dir, "y.md");
     let cwd = std::env::current_dir().unwrap();
     let result = extract_file_arg(&args(&["--", p.to_str().unwrap()]), &cwd);
-    assert_eq!(result, Some(p));
+    assert_eq!(result, Ok(Some(p)));
 }
 
 #[test]
@@ -109,7 +116,7 @@ fn multiple_paths_takes_first() {
         &args(&[first.to_str().unwrap(), second.to_str().unwrap()]),
         &cwd,
     );
-    assert_eq!(result, Some(first));
+    assert_eq!(result, Ok(Some(first)));
     let _ = second; // suppress unused warning
 }
 
@@ -122,8 +129,9 @@ fn key_equals_value_flag_is_skipped_not_parsed() {
     let bogus = format!("--open={}", p.display());
     let cwd = std::env::current_dir().unwrap();
     let result = extract_file_arg(&args(&[bogus.as_str()]), &cwd);
-    assert!(
-        result.is_none(),
+    assert_eq!(
+        result,
+        Ok(None),
         "`--open=path` style flags must not have their value parsed as a file"
     );
 }
@@ -136,8 +144,8 @@ fn each_supported_extension_is_accepted() {
         let p = touch(&dir, &format!("doc.{ext}"));
         let result = extract_file_arg(&args(&[p.to_str().unwrap()]), &cwd);
         assert_eq!(
-            result.as_ref(),
-            Some(&p),
+            result,
+            Ok(Some(p.clone())),
             "extension '.{ext}' should be accepted"
         );
     }
@@ -149,7 +157,7 @@ fn extension_check_is_case_insensitive() {
     let p = touch(&dir, "DOC.MD");
     let cwd = std::env::current_dir().unwrap();
     let result = extract_file_arg(&args(&[p.to_str().unwrap()]), &cwd);
-    assert_eq!(result, Some(p));
+    assert_eq!(result, Ok(Some(p)));
 }
 
 #[cfg(target_os = "windows")]
@@ -160,9 +168,10 @@ fn windows_alternate_data_stream_path_is_rejected() {
     // real ADS — we just verify the parser rejects the shape.
     let cwd = std::env::current_dir().unwrap();
     let result = extract_file_arg(&args(&["C:\\tmp\\file.md:Zone.Identifier"]), &cwd);
-    assert!(
-        result.is_none(),
-        "Path with colon outside drive-letter slot must be rejected"
+    assert_eq!(
+        result,
+        Err(RejectionReason::SuspiciousColon),
+        "Path with colon outside drive-letter slot must be rejected with SuspiciousColon"
     );
 }
 
@@ -176,9 +185,10 @@ fn windows_relative_path_with_colon_rejected_after_resolution() {
     // post-join colon position is what matters.
     let cwd = PathBuf::from("C:\\Users\\bryan");
     let result = extract_file_arg(&args(&["notes.md:Zone.Identifier"]), &cwd);
-    assert!(
-        result.is_none(),
-        "Relative path with ADS colon must be rejected after resolution against cwd"
+    assert_eq!(
+        result,
+        Err(RejectionReason::SuspiciousColon),
+        "Relative path with ADS colon must be rejected with SuspiciousColon after resolution against cwd"
     );
 }
 
@@ -200,7 +210,7 @@ fn warm_start_single_instance_args_shape() {
     let result = extract_file_arg(&warm_args, &cwd);
     assert_eq!(
         result,
-        Some(target),
+        Ok(Some(target)),
         "warm-start arg shape must resolve the file path"
     );
 }

--- a/src-tauri/tests/file_association.rs
+++ b/src-tauri/tests/file_association.rs
@@ -48,10 +48,15 @@ fn flag_only_returns_ok_none() {
 #[test]
 fn nonexistent_file_returns_not_a_file() {
     let cwd = std::env::current_dir().unwrap();
-    let path = "/nope/does-not-exist.md";
+    // Use a relative candidate so the resolved path is `cwd.join(candidate)`
+    // on every platform. A `/`-rooted POSIX path would resolve differently on
+    // Windows (rooted-but-driveless → `is_absolute()` is false → joined onto
+    // cwd's drive as `C:\nope\...`), so asserting against `PathBuf::from(raw)`
+    // only held on Unix and broke the Windows rust-test job.
+    let candidate = "nope/does-not-exist.md";
     assert_eq!(
-        extract_file_arg(&args(&[path]), &cwd),
-        Err(RejectionReason::NotAFile { path: PathBuf::from(path) }),
+        extract_file_arg(&args(&[candidate]), &cwd),
+        Err(RejectionReason::NotAFile { path: cwd.join(candidate) }),
     );
 }
 
@@ -76,14 +81,19 @@ fn no_extension_returns_unsupported_extension_with_empty_ext() {
     // A path with no extension at all falls through the extension check with
     // an empty `ext` string (this happens before the is_file() check, so the
     // file need not exist). The variant still carries the resolved path.
+    //
+    // Use a relative candidate so the resolved path is `cwd.join(candidate)`
+    // on every platform — a `/`-rooted POSIX path resolves differently on
+    // Windows (joined onto cwd's drive), which would break the Windows
+    // rust-test job.
     let cwd = std::env::current_dir().unwrap();
-    let path = "/some/dir/README";
-    let result = extract_file_arg(&args(&[path]), &cwd);
+    let candidate = "some/dir/README";
+    let result = extract_file_arg(&args(&[candidate]), &cwd);
     assert_eq!(
         result,
         Err(RejectionReason::UnsupportedExtension {
             ext: String::new(),
-            path: PathBuf::from(path),
+            path: cwd.join(candidate),
         }),
         "a path with no extension should be rejected with an empty ext + the resolved path"
     );


### PR DESCRIPTION
## Summary

Refactors `extract_file_arg` in `src-tauri/src/lib.rs` to return `Result<Option<PathBuf>, RejectionReason>` instead of `Option<PathBuf>`, so callers receive a typed, diagnostic reason when a candidate path is rejected.

- New `RejectionReason` enum with three brace-struct variants that carry the diagnostic context inline:
  - `SuspiciousColon { path: PathBuf, index: usize }` — the resolved absolute path plus the byte index of the offending colon (NTFS Alternate Data Stream detection).
  - `UnsupportedExtension { ext: String, path: PathBuf }` — the offending extension (empty when the path had no extension at all) plus the resolved path.
  - `NotAFile { path: PathBuf }` — the resolved path that did not exist as a regular file.
- A hand-written `impl Display for RejectionReason` renders a human-readable diagnostic line per variant (e.g. `unsupported extension '.bin' on path …`, `missing/empty extension on path …` for the empty-`ext` branch, `not a regular file: …`, `suspicious colon at byte index N in resolved path …`).
- `Ok(None)` is preserved for the "no candidate arg" case (cold-start without a file). Only paths that were supplied but failed validation produce an `Err`.
- The `log::warn!` calls inside the function move to the two call sites (cold-start in `setup()` and the second-instance handler) and log a single structured line via the `Display` impl (`{reason}`, not `{reason:?}`), recovering the path + index diagnostic context.
- Integration tests in `src-tauri/tests/file_association.rs` assert on the typed variants (including the empty-`ext` and Windows ADS colon-index cases) and on the rendered `Display` output for every variant (`display_renders_diagnostic_context`), so a format regression — dropping the index, mangling the empty-ext branch, or losing the path — fails CI.

Partial fix for #630 — sub-task 1 of 8. The Tauri event-emission, buffered drain summaries, and other downstream sub-tasks are tracked under the parent issue.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test file_association` (requires GTK libs + sidecar/dist stubs per CLAUDE.md gotcha) — 16 passed, including the new `display_renders_diagnostic_context`
- [ ] Manual smoke: cold-start with `tandem.exe foo.bin` should log `extract_file_arg (cold-start) rejected candidate: unsupported extension '.bin' on path <resolved>/foo.bin`
- [ ] Manual smoke: cold-start with `tandem.exe sample.md` should still open the document normally
- [x] Diff review — no behavior change at the call sites (logged + ignored, same as before)

https://claude.ai/code/session_01XXe5nk1E68VgrQ55yunVe9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXe5nk1E68VgrQ55yunVe9)_