### PR TITLE
test(launcher): homeOverride seam for resolveRouteCwd cross-platform tests (#803 T7)

### DIFF
--- a/src/server/launcher/supervisor.ts
+++ b/src/server/launcher/supervisor.ts
@@ -490,13 +490,23 @@ export function resolveSafeCwd(candidate: string): string | null {
  * can't pivot Claude into system directories via a junction/symlink the user
  * happens to have under their home tree. The integration-file path bypasses
  * this — advanced users who hand-edit `integrations.json` opt into wider
- * scope. */
-export function resolveRouteCwd(candidate: string): string | null {
+ * scope.
+ *
+ * `opts.homeOverride` is a test-only seam: passing an explicit "home" lets
+ * cross-platform unit tests stand up a tmpdir, treat it as $HOME, and
+ * assert outside-home rejection deterministically on every platform.
+ * Mirrors the `refreshSkillIfStale(opts: { homeOverride? })` pattern in
+ * `src/server/integrations/apply.ts`. Production callers leave it unset
+ * and get `os.homedir()`. */
+export function resolveRouteCwd(
+  candidate: string,
+  opts: { homeOverride?: string } = {},
+): string | null {
   const safe = resolveSafeCwd(candidate);
   if (safe === null) return null;
   let homeReal: string;
   try {
-    homeReal = fs.realpathSync(os.homedir());
+    homeReal = fs.realpathSync(opts.homeOverride ?? os.homedir());
   } catch {
     return null;
   }

--- a/tests/server/launcher/supervisor.test.ts
+++ b/tests/server/launcher/supervisor.test.ts
@@ -216,6 +216,52 @@ describe("resolveRouteCwd — home-confined HTTP variant (PR 4b sec I1)", () => 
   });
 });
 
+describe("resolveRouteCwd — homeOverride seam (cross-platform determinism, #803 T7)", () => {
+  /** Treat a tmpdir as "$HOME" so the home-confinement check is exercised
+   * deterministically on every platform — no dependency on whether the
+   * process's real $HOME happens to encompass `os.tmpdir()` (Windows CI
+   * sometimes does, POSIX never does). Mirrors the `refreshSkillIfStale`
+   * homeOverride pattern in `src/server/integrations/apply.ts`. */
+  let fakeHome: string;
+  let outside: string;
+
+  beforeEach(() => {
+    fakeHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "fake-home-")));
+    outside = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "outside-home-")));
+  });
+
+  afterEach(() => {
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("accepts the override home itself", () => {
+    expect(resolveRouteCwd(fakeHome, { homeOverride: fakeHome })).toBe(fakeHome);
+  });
+
+  it("accepts a real directory inside the override home", () => {
+    const inside = fs.realpathSync(fs.mkdtempSync(path.join(fakeHome, "child-")));
+    expect(resolveRouteCwd(inside, { homeOverride: fakeHome })).toBe(inside);
+  });
+
+  it("rejects a real directory outside the override home", () => {
+    // `outside` and `fakeHome` are siblings under os.tmpdir() — path.relative
+    // produces "..something" so the rejection fires on every platform.
+    expect(resolveRouteCwd(outside, { homeOverride: fakeHome })).toBeNull();
+  });
+
+  it("rejects when the override home doesn't exist (realpathSync throws)", () => {
+    const ghost = path.join(os.tmpdir(), "does-not-exist-home-xyz-#803");
+    const inside = fs.realpathSync(fs.mkdtempSync(path.join(fakeHome, "child-")));
+    expect(resolveRouteCwd(inside, { homeOverride: ghost })).toBeNull();
+  });
+
+  it("still rejects everything resolveSafeCwd rejects when override is set", () => {
+    expect(resolveRouteCwd("relative/path", { homeOverride: fakeHome })).toBeNull();
+    expect(resolveRouteCwd("/does/not/exist/xyz", { homeOverride: fakeHome })).toBeNull();
+  });
+});
+
 describe("supervisor — concurrent operation safety (security I4)", () => {
   it("concurrent stop() calls don't reject", async () => {
     const sup = createSupervisor({ integrationsBase: tmpDir });

--- a/tests/server/launcher/supervisor.test.ts
+++ b/tests/server/launcher/supervisor.test.ts
@@ -198,18 +198,6 @@ describe("resolveRouteCwd — home-confined HTTP variant (PR 4b sec I1)", () => 
     }
   });
 
-  it("rejects a real directory outside the user's home", () => {
-    // tmpDir from beforeEach lives in os.tmpdir(), which is outside $HOME on
-    // POSIX. On Windows %LOCALAPPDATA%\Temp may or may not be under %USERPROFILE%
-    // — skip the assertion if the test tmpdir happens to be home-rooted.
-    const home = fs.realpathSync(os.homedir());
-    const real = fs.realpathSync(tmpDir);
-    const relative = path.relative(home, real);
-    if (relative.startsWith("..") || path.isAbsolute(relative)) {
-      expect(resolveRouteCwd(tmpDir)).toBeNull();
-    }
-  });
-
   it("accepts the home directory itself", () => {
     const home = fs.realpathSync(os.homedir());
     expect(resolveRouteCwd(home)).toBe(home);


### PR DESCRIPTION
## Summary

PR #801 follow-up T7.

The existing `resolveRouteCwd` outside-home rejection test is platform-fragile — `os.tmpdir()` sits outside `os.homedir()` on POSIX but is sometimes home-rooted on Windows CI, so the assertion was gated behind a `path.relative` heuristic and silently skipped when the gate failed.

- Add an optional `homeOverride` parameter to `resolveRouteCwd` (mirrors the `refreshSkillIfStale({ homeOverride })` seam in `src/server/integrations/apply.ts`). Production callers leave it unset and pick up `os.homedir()`.
- Add 5 deterministic test cases that stand up a tmpdir, treat it as "$HOME", and assert: home-itself accept, in-home accept, outside-home reject, ghost-home reject (realpathSync throw), and resolveSafeCwd rejection pass-through.

Fixes #803 (partial — covers T7; E5/E6/E7 and T8 land in sibling PRs).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run tests/server/launcher/supervisor.test.ts` — 25 passed / 2 skipped

https://claude.ai/code/session_01XXe5nk1E68VgrQ55yunVe9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXe5nk1E68VgrQ55yunVe9)_