### PR TITLE
chore(check-tokens): extend semantic-token lint with bundle-color blocklist

### DIFF
--- a/scripts/check-semantic-tokens.ts
+++ b/scripts/check-semantic-tokens.ts
@@ -20,6 +20,82 @@ const BOX_SHADOW_RE = /\bbox-shadow\s*:\s*[^;]*rgba?\s*\(/g;
 const NEUTRAL_RE = /(?:0\s*,\s*0\s*,\s*0|255\s*,\s*255\s*,\s*255)/;
 const CSS_KEYWORDS = ["color", "background", "border", "fill", "stroke", "style"];
 
+/**
+ * Bundle-token blocklist (issue #799 / Conflict #6 in the design-system-impl plan).
+ *
+ * These hex values were lifted from the redesign-bundle assets
+ * (docs/redesign-bundle/tandem/project/*.{css,jsx,html}) and are NOT part of
+ * the production-approved `--tandem-*` palette in index.html. They must never
+ * appear in src/client because the audit-doc-plus-reviewer-attention pathway
+ * is too soft a gate as bundle-explicit ports expand in later phases.
+ *
+ * Values are normalized: lowercase, 3-char shorthand expanded to 6-char so
+ * `#fff` and `#ffffff` compare equal. Pure neutrals (`#000`/`#000000`,
+ * `#fff`/`#ffffff`) are intentionally omitted — they are foundational CSS
+ * primitives used for masks/gradients, not bundle-origin design tokens.
+ * Approved bundle colors (e.g. `#d97757`, `#e89a78`) are also omitted:
+ * production already exposes them via `--tandem-author-claude` tokens.
+ *
+ * Adding a new bundle adoption? First add the hex to index.html's `:root` (or
+ * the matching theme block) under a new `--tandem-*` token, then remove it
+ * from this set. The CI gate is the contract — do not weaken it by
+ * deletion-only.
+ */
+export const BUNDLE_BLOCKLIST_HEX: ReadonlySet<string> = new Set([
+  "#1095d4",
+  "#222222",
+  "#28c840",
+  "#29261b",
+  "#2a78a4",
+  "#2d8a5e",
+  "#2a1215",
+  "#2a251f",
+  "#34c759",
+  "#3b7dd8",
+  "#5b5bd6",
+  "#5b9f4d",
+  "#5a4a2a",
+  "#5c2b2e",
+  "#666666",
+  "#7ac8ed",
+  "#999999",
+  "#b25bd6",
+  "#ecece6",
+  "#f57018",
+  "#aaaaaa",
+  "#bbbbbb",
+  "#c96442",
+  "#cccccc",
+  "#dddddd",
+  "#e81123",
+  "#f0eee9",
+  "#f0f0f0",
+  "#faf9f5",
+  "#febc2e",
+  "#fef4a8",
+  "#ff5f57",
+  "#ff8a80",
+]);
+
+/**
+ * Normalize a hex string (`#abc`, `#aaBBcc`, `#abcdef12`) to a comparable
+ * lowercase 6-char form (`#aabbcc`). 3- and 4-char shorthands expand the rgb
+ * component (4-char drops alpha); 8-char `#rrggbbaa` also drops alpha. So a
+ * bundle color with an alpha suffix still matches its base entry. Returns
+ * `null` for malformed input.
+ */
+export function normalizeHexForBlocklist(raw: string): string | null {
+  const m = /^#([0-9a-fA-F]{3,8})$/.exec(raw);
+  if (!m) return null;
+  const body = m[1].toLowerCase();
+  if (body.length === 3 || body.length === 4) {
+    return `#${body[0]}${body[0]}${body[1]}${body[1]}${body[2]}${body[2]}`;
+  }
+  if (body.length === 6) return `#${body}`;
+  if (body.length === 8) return `#${body.slice(0, 6)}`;
+  return null;
+}
+
 function hasCssIndicator(line: string): boolean {
   return CSS_KEYWORDS.some((kw) => line.includes(kw));
 }
@@ -34,7 +110,7 @@ function isNeutralRgba(line: string, matchIndex: number): boolean {
 export function collectFiles(dir: string): string[] {
   const entries = readdirSync(dir, { recursive: true, withFileTypes: true });
   return entries
-    .filter((e) => e.isFile() && /\.[tj]sx?$|\.svelte$/.test(e.name))
+    .filter((e) => e.isFile() && /\.[tj]sx?$|\.svelte$|\.css$|\.html$/.test(e.name))
     .map((e) => toSlash(join(e.parentPath, e.name)));
 }
 
@@ -69,11 +145,35 @@ export function checkContent(content: string, rel: string): string[] {
 
     const scanLine = line.replace(INLINE_BLOCK_COMMENT_RE, (m) => " ".repeat(m.length));
 
+    // Per-line dedupe of hex matches by character index so the bundle-blocklist
+    // pass below does not double-report a position the CSS-keyword pass
+    // already flagged. Position-keyed (not string-keyed) so multiple distinct
+    // occurrences of the same hex on the same line each get reported by
+    // whichever pass owns them.
+    const reportedHexAtIndex = new Set<number>();
+
     HEX_RE.lastIndex = 0;
     let hexMatch: RegExpExecArray | null;
     while ((hexMatch = HEX_RE.exec(scanLine)) !== null) {
       if (hasCssIndicator(line)) {
         violations.push(`${rel}:${i + 1}: ${hexMatch[0]}`);
+        reportedHexAtIndex.add(hexMatch.index);
+      }
+    }
+
+    // Bundle-blocklist pass: any hex in BUNDLE_BLOCKLIST_HEX is forbidden
+    // regardless of CSS-keyword context. Catches bundle-origin drift in
+    // string literals, prop defaults, and other non-CSS surfaces that the
+    // CSS-keyword heuristic intentionally skips.
+    HEX_RE.lastIndex = 0;
+    let bundleHexMatch: RegExpExecArray | null;
+    while ((bundleHexMatch = HEX_RE.exec(scanLine)) !== null) {
+      if (reportedHexAtIndex.has(bundleHexMatch.index)) continue;
+      const raw = bundleHexMatch[0];
+      const normalized = normalizeHexForBlocklist(raw);
+      if (normalized && BUNDLE_BLOCKLIST_HEX.has(normalized)) {
+        violations.push(`${rel}:${i + 1}: ${raw} [bundle-blocklist]`);
+        reportedHexAtIndex.add(bundleHexMatch.index);
       }
     }
 

--- a/scripts/check-semantic-tokens.ts
+++ b/scripts/check-semantic-tokens.ts
@@ -122,15 +122,22 @@ interface CommentState {
  * Mask comment regions in a single line while preserving column indices so
  * violation positions stay accurate. Maintains running state across lines for
  * multi-line CSS block comments (`/* ... *\/`) and HTML comments
- * (`<!-- ... -->`). HTML comments are only recognized when `html` is true so
- * `<!--` sequences in JS/TS/Svelte code (rare, but possible in strings) are
- * not treated as comment openers.
+ * (`<!-- ... -->`). HTML comments are recognized only when `html` is true,
+ * which the caller sets for `.html` and `.svelte` files (both use `<!-- -->`
+ * markup); for `.ts`/`.js`/`.css` files `<!--` is left as-is.
  *
  * Block comments and HTML comments are masked (replaced with spaces). A leading
  * `//` line comment (after whitespace) masks the remainder of the line, but
  * only when not already inside a block/HTML comment — matching the prior
  * line-start `//` skip behavior without dropping code that precedes a mid-line
  * `/*` opener.
+ *
+ * Known limitation: this scanner has no string-literal awareness, so a `/*`
+ * (or, in `.svelte`/`.html`, a `<!--`) inside a string literal is treated as a
+ * comment opener and masks the rest of the literal — a potential false
+ * negative. This matches the prior regex-based behavior (which was equally
+ * string-unaware) and is an accepted tradeoff for a lint gate; full
+ * string-literal parsing is out of scope.
  */
 function maskComments(line: string, state: CommentState, html: boolean): string {
   const out: string[] = [];
@@ -218,7 +225,9 @@ export function checkContent(content: string, rel: string): string[] {
   const violations: string[] = [];
 
   const lines = content.split("\n");
-  const isHtml = rel.endsWith(".html");
+  // `.svelte` files use the same `<!-- -->` markup comments as `.html`, and
+  // both are in `collectFiles` scope, so they get the same HTML-comment gate.
+  const isHtml = rel.endsWith(".html") || rel.endsWith(".svelte");
   const state: CommentState = { inBlockComment: false, inHtmlComment: false };
 
   for (let i = 0; i < lines.length; i++) {

--- a/scripts/check-semantic-tokens.ts
+++ b/scripts/check-semantic-tokens.ts
@@ -12,7 +12,6 @@ const SKIP_FILE_RELS = new Set([
   "src/client/svelte-harness/HookDebug.svelte",
 ]);
 
-const INLINE_BLOCK_COMMENT_RE = /\/\*.*?\*\//g;
 const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g;
 const RGBA_RE = /\brgba?\s*\(/g;
 const BORDER_RADIUS_RE = /\bborder-radius\s*:\s*\d+px\b/g;
@@ -83,6 +82,13 @@ export const BUNDLE_BLOCKLIST_HEX: ReadonlySet<string> = new Set([
  * component (4-char drops alpha); 8-char `#rrggbbaa` also drops alpha. So a
  * bundle color with an alpha suffix still matches its base entry. Returns
  * `null` for malformed input.
+ *
+ * Scope: only 3/4/6/8-digit hex bodies are recognized. Tokens with 9+ hex
+ * digits (e.g. `#c964421234`) are out of scope and return `null` — they also
+ * never reach this function because `HEX_RE`'s trailing `\b` won't match a
+ * blocklisted prefix embedded in a longer hex-like token. Such tokens are not
+ * valid CSS colors; treating an arbitrary-length hex run as a maskable bundle
+ * color would risk flagging unrelated identifiers/hashes.
  */
 export function normalizeHexForBlocklist(raw: string): string | null {
   const m = /^#([0-9a-fA-F]{3,8})$/.exec(raw);
@@ -107,6 +113,95 @@ function isNeutralRgba(line: string, matchIndex: number): boolean {
   return NEUTRAL_RE.test(window);
 }
 
+interface CommentState {
+  inBlockComment: boolean;
+  inHtmlComment: boolean;
+}
+
+/**
+ * Mask comment regions in a single line while preserving column indices so
+ * violation positions stay accurate. Maintains running state across lines for
+ * multi-line CSS block comments (`/* ... *\/`) and HTML comments
+ * (`<!-- ... -->`). HTML comments are only recognized when `html` is true so
+ * `<!--` sequences in JS/TS/Svelte code (rare, but possible in strings) are
+ * not treated as comment openers.
+ *
+ * Block comments and HTML comments are masked (replaced with spaces). A leading
+ * `//` line comment (after whitespace) masks the remainder of the line, but
+ * only when not already inside a block/HTML comment — matching the prior
+ * line-start `//` skip behavior without dropping code that precedes a mid-line
+ * `/*` opener.
+ */
+function maskComments(line: string, state: CommentState, html: boolean): string {
+  const out: string[] = [];
+  let i = 0;
+  const n = line.length;
+
+  while (i < n) {
+    if (state.inBlockComment) {
+      const close = line.indexOf("*/", i);
+      if (close === -1) {
+        // Rest of line is inside the block comment.
+        out.push(" ".repeat(n - i));
+        i = n;
+      } else {
+        out.push(" ".repeat(close + 2 - i));
+        i = close + 2;
+        state.inBlockComment = false;
+      }
+      continue;
+    }
+
+    if (state.inHtmlComment) {
+      const close = line.indexOf("-->", i);
+      if (close === -1) {
+        out.push(" ".repeat(n - i));
+        i = n;
+      } else {
+        out.push(" ".repeat(close + 3 - i));
+        i = close + 3;
+        state.inHtmlComment = false;
+      }
+      continue;
+    }
+
+    // Not currently inside a comment: find the next comment opener.
+    const blockOpen = line.indexOf("/*", i);
+    const htmlOpen = html ? line.indexOf("<!--", i) : -1;
+    // A line-comment opener only counts when everything before the `//` (from
+    // the absolute start of the line) is whitespace, preserving the original
+    // `trimmed.startsWith("//")` skip semantics for indented comments.
+    const slashes = line.indexOf("//", i);
+    const lineCommentOpen = slashes !== -1 && line.slice(0, slashes).trim() === "" ? slashes : -1;
+
+    const candidates = [blockOpen, htmlOpen, lineCommentOpen].filter((p) => p !== -1);
+    if (candidates.length === 0) {
+      out.push(line.slice(i));
+      break;
+    }
+
+    const next = Math.min(...candidates);
+    // Emit the visible code before the comment opener.
+    out.push(line.slice(i, next));
+
+    if (next === lineCommentOpen) {
+      // Mask the rest of the line.
+      out.push(" ".repeat(n - next));
+      i = n;
+    } else if (next === blockOpen && (htmlOpen === -1 || blockOpen <= htmlOpen)) {
+      state.inBlockComment = true;
+      out.push("  "); // mask the `/*`
+      i = next + 2;
+    } else {
+      state.inHtmlComment = true;
+      out.push("    "); // mask the `<!--`
+      i = next + 4;
+    }
+  }
+
+  return out.join("");
+}
+
 export function collectFiles(dir: string): string[] {
   const entries = readdirSync(dir, { recursive: true, withFileTypes: true });
   return entries
@@ -123,27 +218,18 @@ export function checkContent(content: string, rel: string): string[] {
   const violations: string[] = [];
 
   const lines = content.split("\n");
-  let inBlockComment = false;
+  const isHtml = rel.endsWith(".html");
+  const state: CommentState = { inBlockComment: false, inHtmlComment: false };
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    const trimmed = line.trimStart();
 
-    if (inBlockComment) {
-      if (line.includes("*/")) inBlockComment = false;
-      continue;
-    }
-
-    if (trimmed.startsWith("//")) continue;
-
-    if (trimmed.startsWith("/*")) {
-      if (!line.includes("*/")) {
-        inBlockComment = true;
-        continue;
-      }
-    }
-
-    const scanLine = line.replace(INLINE_BLOCK_COMMENT_RE, (m) => " ".repeat(m.length));
+    // Mask out comment regions (CSS block, HTML, and line-start `//`) while
+    // preserving column indices. The masked line is used for BOTH the
+    // CSS-keyword indicator checks and the regex passes so commented-out hex
+    // and keywords never produce false positives — including comments opened
+    // mid-line after live code, and code that follows a mid-line comment close.
+    const scanLine = maskComments(line, state, isHtml);
 
     // Per-line dedupe of hex matches by character index so the bundle-blocklist
     // pass below does not double-report a position the CSS-keyword pass
@@ -155,7 +241,7 @@ export function checkContent(content: string, rel: string): string[] {
     HEX_RE.lastIndex = 0;
     let hexMatch: RegExpExecArray | null;
     while ((hexMatch = HEX_RE.exec(scanLine)) !== null) {
-      if (hasCssIndicator(line)) {
+      if (hasCssIndicator(scanLine)) {
         violations.push(`${rel}:${i + 1}: ${hexMatch[0]}`);
         reportedHexAtIndex.add(hexMatch.index);
       }
@@ -191,7 +277,7 @@ export function checkContent(content: string, rel: string): string[] {
       violations.push(`${rel}:${i + 1}: ${radiusMatch[0]}`);
     }
 
-    if (line.includes("style")) {
+    if (scanLine.includes("style")) {
       BOX_SHADOW_RE.lastIndex = 0;
       let shadowMatch: RegExpExecArray | null;
       while ((shadowMatch = BOX_SHADOW_RE.exec(scanLine)) !== null) {

--- a/tests/cli/check-semantic-tokens.test.ts
+++ b/tests/cli/check-semantic-tokens.test.ts
@@ -267,8 +267,8 @@ describe("check-semantic-tokens", () => {
     });
 
     it("treats `<!--` as live code in non-html files (no HTML comment stripping)", () => {
-      // HTML comment recognition is gated on the `.html` extension; a literal
-      // `<!--` in a .ts string must not swallow a following bundle hex.
+      // HTML comment recognition is gated on the `.html`/`.svelte` extensions; a
+      // literal `<!--` in a .ts string must not swallow a following bundle hex.
       const violations = checkContent(
         `const s = "<!-- #f57018 -->";\n`,
         "src/client/components/NotHtml.ts",
@@ -276,6 +276,50 @@ describe("check-semantic-tokens", () => {
 
       expect(violations).toEqual([
         "src/client/components/NotHtml.ts:1: #f57018 [bundle-blocklist]",
+      ]);
+    });
+
+    it("does not flag a bundle hex inside a single-line HTML comment in a .svelte file", () => {
+      // `.svelte` markup uses `<!-- -->` comments just like `.html`, so the
+      // HTML-comment gate must apply to .svelte files too.
+      const violations = checkContent(
+        `<div>before</div><!-- legacy color was #c96442 --><div>after</div>\n`,
+        "src/client/components/SvelteComment.svelte",
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it("does not flag a bundle/CSS-keyword hex inside a multi-line HTML comment in a .svelte file", () => {
+      // A multi-line `<!-- -->` comment whose body contains a `color:` keyword
+      // (which would otherwise satisfy the CSS-indicator heuristic) must be
+      // masked across all spanned lines.
+      const violations = checkContent(
+        ["<!-- palette notes", "  legacy color: #c96442", "  bundle blue #1095d4", "-->"].join(
+          "\n",
+        ),
+        "src/client/components/SvelteMultiComment.svelte",
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it("flags a bundle hex in live .svelte markup/script (positive control)", () => {
+      // Bundle-blocklisted hex outside any comment is real, both in an inline
+      // style attribute (CSS context) and in a script string literal.
+      const violations = checkContent(
+        [
+          `<script lang="ts">`,
+          `  const c = "#f57018";`,
+          `</script>`,
+          `<div style="color: #c96442;">live</div>`,
+        ].join("\n"),
+        "src/client/components/SvelteLive.svelte",
+      );
+
+      expect(violations).toEqual([
+        "src/client/components/SvelteLive.svelte:2: #f57018 [bundle-blocklist]",
+        "src/client/components/SvelteLive.svelte:4: #c96442",
       ]);
     });
   });

--- a/tests/cli/check-semantic-tokens.test.ts
+++ b/tests/cli/check-semantic-tokens.test.ts
@@ -176,4 +176,107 @@ describe("check-semantic-tokens", () => {
       expect(violations).toEqual([]);
     });
   });
+
+  describe("comment stripping (#826 review)", () => {
+    it("does not flag a bundle hex inside a mid-line-opened CSS block comment", () => {
+      // The `/*` opens AFTER live code on the same line and the comment spans
+      // several lines. Hex inside the comment body must be ignored, while the
+      // live `color: var(--x)` declaration on the opener line stays clean.
+      const violations = checkContent(
+        ["  color: var(--x); /* legacy bundle", "   was #c96442 here", "   end */"].join("\n"),
+        "src/client/components/MidLineBlock.css",
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it("still flags live hex BEFORE a mid-line `/*` and AFTER a mid-line `*/`", () => {
+      // Code before the opener and after the closer on the same physical line
+      // must still be scanned. Both are CSS-context hex, so both are flagged.
+      const violations = checkContent(
+        [
+          "  color: #1095d4; /* bundle blue note",
+          "    #f57018 inside comment, ignored",
+          "  */ background: #28c840;",
+        ].join("\n"),
+        "src/client/components/AroundComment.css",
+      );
+
+      expect(violations).toEqual([
+        "src/client/components/AroundComment.css:1: #1095d4",
+        "src/client/components/AroundComment.css:3: #28c840",
+      ]);
+    });
+
+    it("does not flag a bundle hex inside an HTML comment in a .html file", () => {
+      const violations = checkContent(
+        `<div>before</div><!-- palette #f57018 --><div>after</div>\n`,
+        "src/client/index.html",
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it("does not flag a bundle hex inside a multi-line HTML comment", () => {
+      const violations = checkContent(
+        ["<!-- palette notes", "  warm tan #c96442", "  bundle blue #1095d4", "-->"].join("\n"),
+        "src/client/index.html",
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it("flags a bundle hex in live HTML code (positive control)", () => {
+      // Inline style with a bundle-blocklisted hex outside any comment is real.
+      const violations = checkContent(
+        `<div style="color: #f57018;">live</div>\n`,
+        "src/client/index.html",
+      );
+
+      expect(violations).toEqual(["src/client/index.html:1: #f57018"]);
+    });
+
+    it("flags live hex following an HTML comment close on the same line", () => {
+      const violations = checkContent(
+        `<!-- skip #c96442 --><span style="color: #1095d4">x</span>\n`,
+        "src/client/index.html",
+      );
+
+      expect(violations).toEqual(["src/client/index.html:1: #1095d4"]);
+    });
+
+    it("flags a bundle hex in live CSS code (positive control)", () => {
+      const violations = checkContent(
+        `.x { color: #f57018; }\n`,
+        "src/client/components/LiveCss.css",
+      );
+
+      expect(violations).toEqual(["src/client/components/LiveCss.css:1: #f57018"]);
+    });
+
+    it("does not flag a hex inside an indented `//` line comment", () => {
+      // Regression: an indented `// ...` comment must be masked even when it
+      // contains a CSS keyword (e.g. "style" in "Word-style") that would
+      // otherwise satisfy the CSS-indicator heuristic.
+      const violations = checkContent(
+        `  // #649: opt-in Word-style margin annotation view\n`,
+        "src/client/hooks/Example.ts",
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it("treats `<!--` as live code in non-html files (no HTML comment stripping)", () => {
+      // HTML comment recognition is gated on the `.html` extension; a literal
+      // `<!--` in a .ts string must not swallow a following bundle hex.
+      const violations = checkContent(
+        `const s = "<!-- #f57018 -->";\n`,
+        "src/client/components/NotHtml.ts",
+      );
+
+      expect(violations).toEqual([
+        "src/client/components/NotHtml.ts:1: #f57018 [bundle-blocklist]",
+      ]);
+    });
+  });
 });

--- a/tests/cli/check-semantic-tokens.test.ts
+++ b/tests/cli/check-semantic-tokens.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { checkContent, shouldSkipFile } from "../../scripts/check-semantic-tokens.js";
+import {
+  BUNDLE_BLOCKLIST_HEX,
+  checkContent,
+  normalizeHexForBlocklist,
+  shouldSkipFile,
+} from "../../scripts/check-semantic-tokens.js";
 
 describe("check-semantic-tokens", () => {
   it("flags raw hex colors inside Svelte style blocks", () => {
@@ -59,5 +64,116 @@ describe("check-semantic-tokens", () => {
     expect(violations).toEqual([
       "src/client/components/ShadowExample.svelte:1: box-shadow: 0 4px 12px rgba(",
     ]);
+  });
+
+  describe("bundle-token blocklist (#799)", () => {
+    it("normalizes hex shorthand and alpha forms to a 6-char lowercase key", () => {
+      // 3-char shorthand → expanded 6-char
+      expect(normalizeHexForBlocklist("#ccc")).toBe("#cccccc");
+      expect(normalizeHexForBlocklist("#CCC")).toBe("#cccccc");
+      // 4-char shorthand (#rgba) → drop alpha, expand rgb
+      expect(normalizeHexForBlocklist("#cccF")).toBe("#cccccc");
+      // 6-char passthrough lowercases
+      expect(normalizeHexForBlocklist("#FAF9F5")).toBe("#faf9f5");
+      // 8-char #rrggbbaa → drop alpha
+      expect(normalizeHexForBlocklist("#faf9f5aa")).toBe("#faf9f5");
+      // malformed → null
+      expect(normalizeHexForBlocklist("#xyz")).toBeNull();
+      expect(normalizeHexForBlocklist("notahex")).toBeNull();
+    });
+
+    it("publishes a non-empty blocklist that excludes pure neutrals and approved tokens", () => {
+      // Sanity: blocklist is populated.
+      expect(BUNDLE_BLOCKLIST_HEX.size).toBeGreaterThan(10);
+      // Pure neutrals are not on the blocklist — they're foundational primitives.
+      expect(BUNDLE_BLOCKLIST_HEX.has("#000000")).toBe(false);
+      expect(BUNDLE_BLOCKLIST_HEX.has("#ffffff")).toBe(false);
+      // Approved bundle colors (Claude author orange) are not on the blocklist.
+      expect(BUNDLE_BLOCKLIST_HEX.has("#d97757")).toBe(false);
+      expect(BUNDLE_BLOCKLIST_HEX.has("#e89a78")).toBe(false);
+      // All entries are normalized (lowercase, 6-char) so lookups are consistent.
+      for (const entry of BUNDLE_BLOCKLIST_HEX) {
+        expect(entry).toMatch(/^#[0-9a-f]{6}$/);
+      }
+    });
+
+    it("flags a bundle-blocklisted hex used in a non-CSS surface (string literal)", () => {
+      // `#F57018` is from the redesign bundle's calm-aesthetic palette. With no
+      // `color:`/`background:` keyword on the line, the CSS-keyword pass skips
+      // it; the bundle-blocklist pass must still surface it.
+      const violations = checkContent(
+        `const BUNDLE_ORANGE = "#F57018";\n`,
+        "src/client/components/BundleLeak.svelte",
+      );
+
+      expect(violations).toEqual([
+        "src/client/components/BundleLeak.svelte:1: #F57018 [bundle-blocklist]",
+      ]);
+    });
+
+    it("flags a bundle-blocklisted hex in a CSS surface only once (no double-report)", () => {
+      // `#c96442` is from the bundle. The CSS-keyword pass flags it first;
+      // the bundle-blocklist pass must dedupe so we don't get two violations
+      // for the same `file:line:hex`.
+      const violations = checkContent(
+        `<style>\n  .x { color: #c96442; }\n</style>\n`,
+        "src/client/components/DoubleCheck.svelte",
+      );
+
+      expect(violations).toEqual(["src/client/components/DoubleCheck.svelte:2: #c96442"]);
+    });
+
+    it("flags shorthand `#ccc` even though the literal is 3 characters", () => {
+      // `#ccc` normalizes to `#cccccc`, which is on the blocklist.
+      const violations = checkContent(
+        `const subtle = "#ccc";\n`,
+        "src/client/components/Shorthand.ts",
+      );
+
+      expect(violations).toEqual(["src/client/components/Shorthand.ts:1: #ccc [bundle-blocklist]"]);
+    });
+
+    it("lets approved adoptions through (production token values, neutrals, non-bundle hex)", () => {
+      // Each line uses an approved color: production tokens, pure neutrals,
+      // or hex values not present in the bundle. None should be flagged by the
+      // bundle-blocklist pass; the CSS-keyword pass still flags raw hex in
+      // CSS context, so we only assert blocklist behavior with non-CSS lines.
+      const violations = checkContent(
+        [
+          `const claudeOrange = "#d97757";`, // approved (bundle hex but in production tokens)
+          `const claudeOrangeDark = "#e89a78";`, // approved
+          `const lightBg = "#fafaf9";`, // approved (production token)
+          `const black = "#000";`, // pure neutral
+          `const white = "#fff";`, // pure neutral
+          `const arbitrary = "#abcdef";`, // not in bundle
+        ].join("\n"),
+        "src/client/components/Approved.ts",
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it("flags two distinct bundle hex values on the same non-CSS line", () => {
+      // Position-keyed dedupe (not value-keyed) so both occurrences land.
+      const violations = checkContent(
+        `const palette = ["#F57018", "#c96442"];\n`,
+        "src/client/components/Palette.ts",
+      );
+
+      expect(violations).toEqual([
+        "src/client/components/Palette.ts:1: #F57018 [bundle-blocklist]",
+        "src/client/components/Palette.ts:1: #c96442 [bundle-blocklist]",
+      ]);
+    });
+
+    it("does not flag a bundle hex inside a line comment", () => {
+      // Single-line comments are skipped wholesale by the scanner.
+      const violations = checkContent(
+        `// reference: bundle warm tan is #c96442\n`,
+        "src/client/components/CommentOnly.ts",
+      );
+
+      expect(violations).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
Fixes #799

## Summary
Adds a mechanical, CI-blocking gate to `scripts/check-semantic-tokens.ts` that rejects redesign-bundle hex values which are NOT part of production's approved `--tandem-*` token palette. Previously bundle-explicit ports relied on an audit-doc + reviewer-attention pathway that is too soft as the bundle expands; this hardens it into the existing `check:tokens` lint.

- Defines `BUNDLE_BLOCKLIST_HEX` from the bundle's CSS/JSX/HTML assets, excluding production-approved colors (e.g. `#d97757`, `#e89a78`) and pure neutrals (`#000`, `#fff`) used for masks/gradients.
- Adds `normalizeHexForBlocklist()` so `#ccc` and `#cccccc` compare equal.
- Extends `collectFiles()` to scan `.css` and `.html` (previously ts/tsx/svelte only), matching the globs lint-staged already invokes the script on.
- Bundle-blocklist pass runs alongside the existing CSS-keyword pass; position-keyed dedupe prevents double-reports for the same occurrence.

## Test plan
- [x] `npx biome check src/ tests/ scripts/` — clean
- [x] `npm run check:tokens` — exits 0 (warnings only)
- [x] `npx vitest run tests/cli/check-semantic-tokens.test.ts` — 13 tests pass (8 new: normalization, blocklist invariants, non-CSS surface detection, dedup, approved-adoption pass-through, comment skipping)

https://claude.ai/code/session_01XXe5nk1E68VgrQ55yunVe9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXe5nk1E68VgrQ55yunVe9)_