### PR TITLE
ci: auto-run /code-review high on new PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,7 +6,6 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - 'CHANGELOG.md'
       - '.claude/**'
 
 concurrency:
@@ -17,7 +16,6 @@ permissions:
   contents: read
   pull-requests: write
   issues: read # gh issue view (in --allowedTools) needs read; omitting the key entirely would set it to none
-  id-token: write # required by claude-code-action per docs/setup.md, even with API-key auth
 
 jobs:
   review:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review, reopened]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -16,16 +16,17 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
+  issues: read # gh issue view (in --allowedTools) needs read; omitting the key entirely would set it to none
   id-token: write # required by claude-code-action per docs/setup.md, even with API-key auth
 
 jobs:
   review:
     if: >
       github.event.pull_request.draft == false &&
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.type != 'Bot' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # cost guard: cap a hung/runaway LLM run (default is 360)
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,43 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'CHANGELOG.md'
+      - '.claude/**'
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write # required by claude-code-action per docs/setup.md, even with API-key auth
+
+jobs:
+  review:
+    if: >
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1 # bundled /code-review skill uses `gh pr diff`; no history needed
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR: ${{ github.event.pull_request.number }}
+
+            /code-review high --comment
+          claude_args: >-
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh search:*),Read,Grep,Glob"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-code-review.yml` — runs Claude Code's bundled `/code-review` skill at **high** effort on newly-opened (and undrafted / reopened) PRs and posts findings back to the PR.
- Invokes the bundled skill directly via `anthropics/claude-code-action@v1` with `prompt: /code-review high --comment` (prefixed with REPO/PR identifiers so the headless runner resolves the current PR).
- `--allowedTools` grants both comment surfaces (`gh pr comment:*` + `mcp__github_inline_comment__create_inline_comment`) so whichever mechanism `--comment` uses is available.

## Guards (cost + security)
- **Trigger** is `opened`, `ready_for_review`, `reopened` (not `synchronize`). The skill self-checks for a prior review, so re-runs self-skip; adding push re-runs later is safe. `ready_for_review` ensures a PR opened as a draft still gets reviewed once undrafted.
- **`timeout-minutes: 15`** caps a hung/runaway LLM run (GitHub's default is 360m) — the direct cost cap.
- `if:` skips **draft**, **bot** (`user.type != 'Bot'` — covers Dependabot, Renovate, github-actions, etc.), and **fork** PRs. Fork PRs never receive secrets under `pull_request`, so the guard turns a confusing red check into a clean skip and closes the prompt-injection surface.
- `paths-ignore` excludes docs-only PRs (`**/*.md`, `docs/**`, `CHANGELOG.md`, `.claude/**`). Not a required check, so skipped path-only PRs reporting no check is fine.
- `concurrency` cancels superseded runs per PR (inert under current triggers; harmless, and live once `synchronize` is ever added).
- `permissions` minimal: `contents: read`, `pull-requests: write`, `issues: read` (for `gh issue view` context — read, not write), `id-token: write` (required by claude-code-action even on API-key auth).

## Prerequisite (one-time, manual)
Add repo secret `ANTHROPIC_API_KEY` under Settings → Secrets → Actions. Without it the action exits at startup.

## Test plan
- [ ] Confirm `ANTHROPIC_API_KEY` secret is set on the repo.
- [ ] Open a small throwaway PR touching a `.ts` file; confirm the **Claude Code Review** check appears and completes green within ~5 min.
- [ ] Confirm review findings post to the PR (note whether inline comments, a summary comment, or both — settles the `--comment` mechanism for future tuning).
- [ ] Confirm the review reflects **high** effort (broader coverage), not the terse low/medium set.
- [ ] Open a draft PR → job skipped; mark it ready → job runs (`ready_for_review`). Open a docs-only PR → workflow skipped.

## Review-fix commit (post multi-agent review)
`8e9f244` hardens the workflow per a `/pr-review-toolkit:review-pr` pass: job timeout, broadened bot guard, `issues: write`→`read` (adversarial review caught that removing the key would silently break `gh issue view` behind a green check, since a `permissions:` block sets unlisted scopes to `none`), and the `ready_for_review`/`reopened` triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
