### PR TITLE
fix(client): command palette dismisses on Escape regardless of focus

### DIFF
--- a/src/client/components/CommandPalette.svelte
+++ b/src/client/components/CommandPalette.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Editor as TiptapEditor } from "@tiptap/core";
 import { TextSelection } from "prosemirror-state";
+import { onMount } from "svelte";
 import type { Annotation } from "../../shared/types.js";
 import { type Action, getActionsMap } from "../actions/registry.svelte.js";
 import { scrollFade } from "../actions/scrollFade.svelte.js";
@@ -168,6 +169,23 @@ $effect(() => {
     selectedIndex = 0;
     Promise.resolve().then(() => inputEl?.focus());
   }
+});
+
+// Escape must close the palette regardless of which descendant holds focus and
+// ahead of any nested handler that might consume the key. A capture-phase
+// window listener (gated on `open`) is the robust pattern the other modals use;
+// the modal-div `onkeydown` alone was unreliable. Registered once via onMount —
+// the handler reads `open`/`onClose` through the closure, so there's no
+// prop-read-in-cleanup retry-storm hazard.
+onMount(() => {
+  const onEscape = (e: KeyboardEvent) => {
+    if (e.key !== "Escape" || !open) return;
+    e.preventDefault();
+    e.stopPropagation();
+    close();
+  };
+  window.addEventListener("keydown", onEscape, { capture: true });
+  return () => window.removeEventListener("keydown", onEscape, { capture: true });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -420,3 +420,20 @@ test("Ctrl+Alt+T after closing via the X button (DocumentTabs path) reopens", as
   await page.keyboard.press("Control+Alt+t");
   await expect(sample2).toBeVisible();
 });
+
+test("Escape closes the command palette even when focus is outside it", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://127.0.0.1:5173");
+  await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
+
+  await page.keyboard.press("Control+Shift+P");
+  const palette = page.locator("[data-testid='command-palette']");
+  await expect(palette).toBeVisible({ timeout: 3_000 });
+
+  // Move focus out of the palette (the modal-level onkeydown only fired while a
+  // palette descendant held focus — the regression). A window-level Escape
+  // handler must dismiss the palette regardless of where focus sits.
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+  await page.keyboard.press("Escape");
+  await expect(palette).toHaveCount(0);
+});


### PR DESCRIPTION
## Bug

Pressing **Escape doesn't dismiss the command palette** in some cases (reported by Bryan).

## Root cause

The palette handled Escape only via an `onkeydown` on its modal element, so the key was caught **only while a palette descendant held focus**. Every other modal in the app (SettingsModal, HelpModal, IntegrationWizardModal, SettingsPopover, …) registers a window/document keydown listener instead. When focus sits outside the palette — an autofocus race, a click, or a WebView focus quirk — Escape never reached the handler and the palette stayed open.

This is **pre-existing**, not introduced by the 1.6 re-skin (that diff only re-indented the input element).

## Fix

Add a **capture-phase window keydown listener** (gated on `open`) that closes the palette on Escape ahead of any nested handler, registered via `onMount` so no prop is read in effect cleanup (avoids the v0.11.2 prop-in-effect-cleanup retry-storm). `close()` / reactivity already worked — backdrop-click dismisses the palette — so this only restores the path to it. Arrows/Enter still route through the existing `handleKeydown`.

## Test

Added an E2E regression test: opens the palette, **blurs focus out of it**, presses Escape, asserts it closes. Verified it **fails on the pre-fix code** and passes after (stash-verified locally) — my first attempt (focus left in the input) passed even pre-fix because Playwright autofocuses the input, so it didn't actually guard the bug.

## Verification

- `npm run typecheck` (incl. `svelte-check --fail-on-warnings`) ✅ · `npm run check:tokens` ✅ · pre-push vitest ✅
- **Full `npm run test:e2e` ✅** — confirms the capture-phase handler doesn't steal Escape from other surfaces (find bar, popups, modals).
- New regression test passes with the fix, fails without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)