### PR TITLE
test: stabilize full vitest suite on local Windows runs

### DIFF
--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -807,14 +807,16 @@ describe("mcp-stdio per-request timeout", () => {
     const stdoutChunks: string[] = [];
     child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c.toString("utf8")));
 
-    // Wait for httpReady, then send the request.
-    await new Promise((r) => setTimeout(r, 500));
+    // Write immediately — the request buffers in preReadyBuffer until httpReady
+    // flips. We poll on `heldRes` below (NOT a fixed sleep) so the test
+    // tolerates subprocess startup latency under concurrent vitest load.
     child.stdin.write(
       `${JSON.stringify({ jsonrpc: "2.0", id: 30, method: "initialize", params: { protocolVersion: "2024-11-05", clientInfo: { name: "test", version: "0" }, capabilities: {} } })}\n`,
     );
 
-    // Poll until server has the POST, then wait for timer to fire first.
-    for (let i = 0; i < 60; i++) {
+    // Poll until the server has the POST (i.e. the per-request timer started).
+    // 200 × 50ms = 10s budget absorbs slow `--import tsx` startup under load.
+    for (let i = 0; i < 200; i++) {
       if (heldRes) break;
       await new Promise((r) => setTimeout(r, 50));
     }
@@ -843,7 +845,7 @@ describe("mcp-stdio per-request timeout", () => {
     }).length;
     // Exactly one -32000 for id=30 — timer fired first, catch found map empty.
     expect(errorCount).toBe(1);
-  }, 10_000);
+  }, 15_000);
 
   it("process exits in <3s after half-open timeout fires (no orphan handles)", async () => {
     // Regression guard: after the per-request timer fires and the proxy sends a
@@ -853,7 +855,7 @@ describe("mcp-stdio per-request timeout", () => {
     // exercising the real natural-exit path. SIGTERM would bypass the Node event
     // loop entirely and cannot detect orphan timer handles that block clean exit.
     // The timer has already fired and been cleared from the map before stdin.end().
-    const { port } = await makeHalfOpenServer();
+    const { port, postsReceived } = await makeHalfOpenServer();
     const cliEntry = resolve(__dirname, "../../src/cli/index.ts");
     child = spawn(process.execPath, ["--import", "tsx", cliEntry, "mcp-stdio"], {
       env: {
@@ -864,10 +866,17 @@ describe("mcp-stdio per-request timeout", () => {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
-    await new Promise((r) => setTimeout(r, 500));
+    // Write immediately — the request buffers in preReadyBuffer until httpReady
+    // flips, then forwardToUpstream fires. Poll for the POST (NOT a fixed sleep)
+    // so the test tolerates subprocess startup latency under concurrent vitest
+    // load, where `--import tsx` startup can far exceed 500ms. The ordering is
+    // load-bearing: waitForPosts returns the moment the POST arrives = the 300ms
+    // timer has only just started, so readOneLine's listener attaches well
+    // before the -32000 is emitted.
     child.stdin.write(
       `${JSON.stringify({ jsonrpc: "2.0", id: 40, method: "initialize", params: { protocolVersion: "2024-11-05", clientInfo: { name: "test", version: "0" }, capabilities: {} } })}\n`,
     );
+    await waitForPosts(postsReceived, 1);
 
     // Wait for the -32000 to arrive (timer fired).
     const line = await readOneLine(child, 3_000);
@@ -887,7 +896,7 @@ describe("mcp-stdio per-request timeout", () => {
       });
     });
     expect(closed).toBe(true);
-  }, 10_000);
+  }, 15_000);
 });
 
 describe("parseTimeoutMs", () => {

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -870,9 +870,10 @@ describe("mcp-stdio per-request timeout", () => {
     // flips, then forwardToUpstream fires. Poll for the POST (NOT a fixed sleep)
     // so the test tolerates subprocess startup latency under concurrent vitest
     // load, where `--import tsx` startup can far exceed 500ms. The ordering is
-    // load-bearing: waitForPosts returns the moment the POST arrives = the 300ms
-    // timer has only just started, so readOneLine's listener attaches well
-    // before the -32000 is emitted.
+    // load-bearing: the 300ms timer is armed just before http.send, so when
+    // waitForPosts returns (POST received) it has been running only for the
+    // network round-trip — ~290ms still remain, so readOneLine's listener
+    // attaches well before the -32000 is emitted.
     child.stdin.write(
       `${JSON.stringify({ jsonrpc: "2.0", id: 40, method: "initialize", params: { protocolVersion: "2024-11-05", clientInfo: { name: "test", version: "0" }, capabilities: {} } })}\n`,
     );

--- a/tests/server/document-service.test.ts
+++ b/tests/server/document-service.test.ts
@@ -639,115 +639,128 @@ describe("saveDocumentAsToDisk", () => {
     expect(deleteSession).not.toHaveBeenCalled();
   });
 
-  it("allows a target path outside home/tmp — Save-As is user-driven, not PATH_REJECTED (#827 user decision)", async () => {
-    const os = await import("node:os");
-    const fsReal = await import("node:fs/promises");
-    const pathMod = await import("node:path");
-    const { atomicWrite } = await import("../../src/server/file-io/index.js");
+  // POSIX-only: Probe 1 asserts the literal absolute path reaches atomicWrite,
+  // but win32 path.resolve rewrites "/etc/x" → "C:\etc\x". The path-widening
+  // behavior itself works on win32; only the hard-coded POSIX assertion doesn't.
+  // Linux CI exercises this; win32 path policy is covered by the UNC test below.
+  it.skipIf(process.platform === "win32")(
+    "allows a target path outside home/tmp — Save-As is user-driven, not PATH_REJECTED (#827 user decision)",
+    async () => {
+      const os = await import("node:os");
+      const fsReal = await import("node:fs/promises");
+      const pathMod = await import("node:path");
+      const { atomicWrite } = await import("../../src/server/file-io/index.js");
 
-    // Probe 1: an absolute path that exists outside both homedir() and
-    // tmpdir() (`/etc`) must no longer be refused by the home/tmp
-    // confinement. The old behavior returned PATH_REJECTED here; the user
-    // decision is that any absolute path the user pointed the native Save
-    // dialog at passes the path-safety gate (symlink + UNC guards aside).
-    // Stub atomicWrite to a no-op so we assert the path-policy DECISION
-    // without writing into a system directory (`/etc` would pollute and may
-    // even be writable as root in CI).
-    vi.mocked(atomicWrite).mockClear();
-    vi.mocked(atomicWrite).mockResolvedValueOnce(undefined);
-    addDoc("path-allow", {
-      id: "path-allow",
-      filePath: "upload://scratchpad/x/Scratchpad.md",
-      format: "md",
-      readOnly: false,
-      source: "upload",
-    });
-    const doc = getOrCreateDocument("path-allow");
-    const frag = doc.getXmlFragment("default");
-    const p = new Y.XmlElement("paragraph");
-    frag.insert(0, [p]);
-    p.insert(0, [new Y.XmlText("content")]);
-
-    const result = await saveDocumentAsToDisk("path-allow", "/etc/tandem-evil-827.md", "md");
-    // The key assertion: the home/tmp confinement no longer rejects this.
-    expect(result.errorCode).not.toBe("PATH_REJECTED");
-    // The path-safety gate let it through to the (stubbed) write.
-    expect(atomicWrite).toHaveBeenCalledWith("/etc/tandem-evil-827.md", expect.any(String));
-
-    // Probe 2: end-to-end save into a freshly created dir outside the home
-    // tree, proving the widening lets a legitimate user-chosen external
-    // location through to a real disk write (atomicWrite delegates to the
-    // real impl for non-stubbed calls).
-    const writableDir = await fsReal.mkdtemp(pathMod.join(os.tmpdir(), "tandem-saveas-"));
-    try {
-      addDoc("path-allow-2", {
-        id: "path-allow-2",
-        filePath: "upload://scratchpad/y/Scratchpad.md",
-        format: "md",
-        readOnly: false,
-        source: "upload",
-      });
-      const doc2 = getOrCreateDocument("path-allow-2");
-      const frag2 = doc2.getXmlFragment("default");
-      const p2 = new Y.XmlElement("paragraph");
-      frag2.insert(0, [p2]);
-      p2.insert(0, [new Y.XmlText("content")]);
-
-      const okResult = await saveDocumentAsToDisk(
-        "path-allow-2",
-        pathMod.join(writableDir, "Promoted.md"),
-        "md",
-      );
-      expect(okResult.errorCode).not.toBe("PATH_REJECTED");
-      expect(okResult.status).toBe("saved");
-    } finally {
-      await fsReal.rm(writableDir, { recursive: true, force: true }).catch(() => {});
-    }
-  });
-
-  it("still rejects a symlinked target path with PATH_REJECTED and writes nothing (#827 keeps symlink guard)", async () => {
-    const os = await import("node:os");
-    const fsReal = await import("node:fs/promises");
-    const pathMod = await import("node:path");
-    const { atomicWrite } = await import("../../src/server/file-io/index.js");
-    vi.mocked(atomicWrite).mockClear();
-
-    // Create a real symlinked directory and aim the Save-As target through
-    // it. assertPathSafe's realpath/symlink walk must still refuse: a planted
-    // symlink redirecting the write is a genuine attack we keep guarding,
-    // even though the home/tmp root confinement was widened.
-    const baseDir = await fsReal.mkdtemp(pathMod.join(os.tmpdir(), "tandem-symlink-"));
-    const realDir = pathMod.join(baseDir, "real");
-    const linkDir = pathMod.join(baseDir, "link");
-    await fsReal.mkdir(realDir);
-    await fsReal.symlink(realDir, linkDir, "dir");
-
-    try {
-      addDoc("symlink-reject", {
-        id: "symlink-reject",
+      // Probe 1: an absolute path that exists outside both homedir() and
+      // tmpdir() (`/etc`) must no longer be refused by the home/tmp
+      // confinement. The old behavior returned PATH_REJECTED here; the user
+      // decision is that any absolute path the user pointed the native Save
+      // dialog at passes the path-safety gate (symlink + UNC guards aside).
+      // Stub atomicWrite to a no-op so we assert the path-policy DECISION
+      // without writing into a system directory (`/etc` would pollute and may
+      // even be writable as root in CI).
+      vi.mocked(atomicWrite).mockClear();
+      vi.mocked(atomicWrite).mockResolvedValueOnce(undefined);
+      addDoc("path-allow", {
+        id: "path-allow",
         filePath: "upload://scratchpad/x/Scratchpad.md",
         format: "md",
         readOnly: false,
         source: "upload",
       });
-      const doc = getOrCreateDocument("symlink-reject");
+      const doc = getOrCreateDocument("path-allow");
       const frag = doc.getXmlFragment("default");
       const p = new Y.XmlElement("paragraph");
       frag.insert(0, [p]);
       p.insert(0, [new Y.XmlText("content")]);
 
-      const result = await saveDocumentAsToDisk(
-        "symlink-reject",
-        pathMod.join(linkDir, "Promoted.md"),
-        "md",
-      );
-      expect(result.status).toBe("error");
-      expect(result.errorCode).toBe("PATH_REJECTED");
-      expect(atomicWrite).not.toHaveBeenCalled();
-    } finally {
-      await fsReal.rm(baseDir, { recursive: true, force: true }).catch(() => {});
-    }
-  });
+      const result = await saveDocumentAsToDisk("path-allow", "/etc/tandem-evil-827.md", "md");
+      // The key assertion: the home/tmp confinement no longer rejects this.
+      expect(result.errorCode).not.toBe("PATH_REJECTED");
+      // The path-safety gate let it through to the (stubbed) write.
+      expect(atomicWrite).toHaveBeenCalledWith("/etc/tandem-evil-827.md", expect.any(String));
+
+      // Probe 2: end-to-end save into a freshly created dir outside the home
+      // tree, proving the widening lets a legitimate user-chosen external
+      // location through to a real disk write (atomicWrite delegates to the
+      // real impl for non-stubbed calls).
+      const writableDir = await fsReal.mkdtemp(pathMod.join(os.tmpdir(), "tandem-saveas-"));
+      try {
+        addDoc("path-allow-2", {
+          id: "path-allow-2",
+          filePath: "upload://scratchpad/y/Scratchpad.md",
+          format: "md",
+          readOnly: false,
+          source: "upload",
+        });
+        const doc2 = getOrCreateDocument("path-allow-2");
+        const frag2 = doc2.getXmlFragment("default");
+        const p2 = new Y.XmlElement("paragraph");
+        frag2.insert(0, [p2]);
+        p2.insert(0, [new Y.XmlText("content")]);
+
+        const okResult = await saveDocumentAsToDisk(
+          "path-allow-2",
+          pathMod.join(writableDir, "Promoted.md"),
+          "md",
+        );
+        expect(okResult.errorCode).not.toBe("PATH_REJECTED");
+        expect(okResult.status).toBe("saved");
+      } finally {
+        await fsReal.rm(writableDir, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  );
+
+  // POSIX-only: real fsReal.symlink() throws EPERM on win32 without Developer
+  // Mode/admin, so the fixture can't be built. The symlink-rejection behavior
+  // (assertPathSafe's realpath walk) is exercised on Linux CI.
+  it.skipIf(process.platform === "win32")(
+    "still rejects a symlinked target path with PATH_REJECTED and writes nothing (#827 keeps symlink guard)",
+    async () => {
+      const os = await import("node:os");
+      const fsReal = await import("node:fs/promises");
+      const pathMod = await import("node:path");
+      const { atomicWrite } = await import("../../src/server/file-io/index.js");
+      vi.mocked(atomicWrite).mockClear();
+
+      // Create a real symlinked directory and aim the Save-As target through
+      // it. assertPathSafe's realpath/symlink walk must still refuse: a planted
+      // symlink redirecting the write is a genuine attack we keep guarding,
+      // even though the home/tmp root confinement was widened.
+      const baseDir = await fsReal.mkdtemp(pathMod.join(os.tmpdir(), "tandem-symlink-"));
+      const realDir = pathMod.join(baseDir, "real");
+      const linkDir = pathMod.join(baseDir, "link");
+      await fsReal.mkdir(realDir);
+      await fsReal.symlink(realDir, linkDir, "dir");
+
+      try {
+        addDoc("symlink-reject", {
+          id: "symlink-reject",
+          filePath: "upload://scratchpad/x/Scratchpad.md",
+          format: "md",
+          readOnly: false,
+          source: "upload",
+        });
+        const doc = getOrCreateDocument("symlink-reject");
+        const frag = doc.getXmlFragment("default");
+        const p = new Y.XmlElement("paragraph");
+        frag.insert(0, [p]);
+        p.insert(0, [new Y.XmlText("content")]);
+
+        const result = await saveDocumentAsToDisk(
+          "symlink-reject",
+          pathMod.join(linkDir, "Promoted.md"),
+          "md",
+        );
+        expect(result.status).toBe("error");
+        expect(result.errorCode).toBe("PATH_REJECTED");
+        expect(atomicWrite).not.toHaveBeenCalled();
+      } finally {
+        await fsReal.rm(baseDir, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  );
 
   it("rejects a UNC target path on win32 with INVALID_PATH and writes nothing (#827 Low)", async () => {
     const pathMod = (await import("node:path")).default;


### PR DESCRIPTION
## Summary

Two test-only fixes so the **full vitest suite runs green on a local Windows machine**. Neither surfaces in CI (which runs on `ubuntu-latest`), but both block the husky pre-push hook locally because that hook runs the entire suite. No production code changes.

### 1. Gate POSIX-only Save-As path tests on win32 (`8fb6a85`)

Two `#827` Save-As tests in `document-service.test.ts` are inherently POSIX:

- **"allows a target path outside home/tmp"** hardcodes `/etc/tandem-evil-827.md`. On Windows `path.resolve` rewrites that to `C:\etc\...`, so the assertion no longer exercises the intended "outside home/tmp" case.
- **"still rejects a symlinked target path"** calls a real `fs.symlink()`, which throws `EPERM` on Windows without Developer Mode / elevation.

Both now use `it.skipIf(process.platform === "win32")` with a comment explaining why. The UNC-sibling test is left untouched — it already simulates the platform via `Object.defineProperty(process, "platform", ...)` and never touches the real filesystem. (Most of the line count is Biome reindentation from wrapping the two tests; `git show -w` is ~no-op.)

### 2. Harden mcp-stdio timeout tests against subprocess startup latency (`ed4ccd2`)

Two timing tests in `mcp-stdio.test.ts` used a fixed `setTimeout(500)` to wait for the `--import tsx` subprocess to come up. Under full-suite parallel load, tsx startup can exceed that budget, so `readOneLine(3000)` times out *before* the product assertions are ever reached — a flake in the harness, not the product.

Both now poll on observable progress instead of sleeping a fixed interval:

- **"process exits in <3s after half-open timeout fires"** — write immediately, then `waitForPosts(postsReceived, 1)` (ordering is load-bearing; commented).
- **"does not synthesize double -32000"** — request buffers in `preReadyBuffer`, so the fixed presleep is removed and the `heldRes` poll budget widened to 10s.

Per-test timeouts bumped 10s -> 15s for headroom. Validated with 3 consecutive full-suite runs (2769 passed, 0 failures).

## Test plan

- [x] `npm test` green locally on Windows (3 consecutive clean runs)
- [x] Husky pre-push full suite + build passes (branch pushed cleanly)
- [x] CI remains green (Linux never hit either issue)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>