### PR TITLE
docs: dedup ADR-038 glossary + cross-link env vars (consolidation PR2)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,14 +4,7 @@
 
 > Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same 26 tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today. See [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration).
 
-The four terms used throughout this document:
-
-| Term | Meaning |
-|---|---|
-| **MCP contract** | The 26 active MCP tools at `http://127.0.0.1:3479/mcp` and the SSE event stream at `/api/events`. Available to every MCP client. |
-| **Default integration** | Claude. Auto-configured by the desktop app's integration wizard. Documented and tested. Recommended in all install flows. |
-| **Claude-specific extras** | Six features built on top of the MCP contract that only work with Claude today: channel push (channel shim + plugin monitor), `--dangerously-load-development-channels` flag wiring, auto-launcher, Cowork plugin bridge, Claude Code skill, and the plugin marketplace artifacts. |
-| **Best-effort, not validated** | What we say about other MCP clients today. We don't intentionally break them; we don't test them in CI. |
+Four terms — **MCP contract**, **default integration**, **Claude-specific extras**, and **best-effort, not validated** — are used throughout this document with the precise meanings defined in [ADR-038's term glossary](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration) (the single source of truth).
 
 Sections below labeled "Claude-default" describe features in the **Claude-specific extras** column. Generic MCP plumbing (the HTTP server, the SSE stream, the 26 tools) works for any MCP-capable client.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,6 +9,8 @@ Tandem is designed local-first. The server binds to `127.0.0.1` by default, docu
 - **Loopback detection is fail-closed.** Authentication middleware uses `req.socket.remoteAddress` exclusively — never the `Host` header — so DNS rebinding attacks cannot trick the server into treating a remote request as loopback. IPv6 variants (`::1`, `::ffff:127.0.0.1`) are normalized to `127.0.0.1`.
 - **Insecure LAN opt-in:** `TANDEM_ALLOW_UNAUTHENTICATED_LAN=1` disables the token requirement for non-loopback requests. Intended for trusted-network development only; never set it on a public network.
 
+See [configuration.md](configuration.md#environment-variables) for the full environment-variable reference (ports, bind host, auth token, app-data paths).
+
 ## CORS allowlist
 
 The server accepts cross-origin requests from two origins only:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -320,7 +320,7 @@ Previously-open documents are auto-restored when the server starts — no manual
 
 ### Further Reading
 
-- [MCP Tool Reference](mcp-tools.md) — Full documentation for all 29 tools (26 active, 3 deprecated stubs)
+- [MCP Tool Reference](mcp-tools.md) — Full documentation for all MCP tools
 - [Workflows](workflows.md) — Advanced Claude Code patterns: cross-referencing documents, multi-model collaboration, RFP drafting, session handoff details
 - [Architecture](architecture.md) — System design, coordinate systems, data flows
 


### PR DESCRIPTION
## Summary

PR2 of the documentation-consolidation effort: **single-source-of-truth dedup**. Stacked on PR1 (#852) — review/merge that first; this PR's base auto-retargets to `master` when PR1 lands.

Conservative scope: only collapse content that is **truly duplicated** and prone to drift. Contextual summaries that serve their local reader are kept (and were already linked to the canonical source).

## Changes

- **architecture.md** — the four-term glossary (MCP contract / default integration / Claude-specific extras / best-effort) was a near-verbatim copy of [ADR-038's glossary](decisions.md) in `decisions.md`. The two had **already drifted** — PR1 had to apply the same "26 active" fix to both. Replaced architecture.md's table with a link to the canonical ADR-038 glossary. The doc's intro blockquote (which paraphrases the policy in context) stays.
- **security.md** — added a cross-link to `configuration.md#environment-variables` for the full env-var reference. The security-implication mentions of `TANDEM_BIND_HOST` / `TANDEM_ALLOW_UNAUTHENTICATED_LAN` stay (they carry security context, not just config mechanics).
- **user-guide.md** — dropped the redundant `(26 active, 3 deprecated stubs)` parenthetical from the *Further Reading* link; the explanatory count stays in the body where it's introduced.

## Deliberately NOT changed

- **roadmap.md** — already link-only to ADR-038; nothing to dedup.
- **positioning.md / user-guide intro / architecture intro** — contextual *paraphrases* of the ADR-038 policy, already linked. Collapsing these would gut the docs; they are not verbatim copies.
- **Ports (3478/3479)** — already consistent across every live doc (only the archival `redesign-bundle/` copies use the old `localhost` form; out of scope).

## Test plan

- [x] `git diff` confirms docs-only, 3 files
- [x] ADR-038 anchor in the new architecture.md link matches the one used elsewhere in the repo
- [x] Pre-commit lint-staged passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)