### PR TITLE
docs: archival + repo hygiene (consolidation PR3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist/
 .worktrees/
 private/
 *.log
+
+# Knowledge-graph generator output (regenerable artifact dump)
+graphify-out/
 .env
 .env.local
 
@@ -24,6 +27,8 @@ AGENTS.md
 .claude/plans/
 .claude/scheduled_tasks.lock
 .claude/.workflow-state/
+# Ephemeral PR working files (diffs, review scratch, body drafts)
+.claude/.pr*
 .clone/
 .superpowers/
 skills-lock.json

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,7 @@
+# Archived Documentation
+
+Historical research notes and superseded design docs kept for provenance. These are **not active guidance** — for current state see [`docs/roadmap.md`](../roadmap.md), [`docs/decisions.md`](../decisions.md), and [`CLAUDE.md`](../../CLAUDE.md).
+
+## Contents
+
+- [`agent-isolation-research.md`](agent-isolation-research.md) — research on running 5–15 parallel Claude Code agents on Tandem without cross-worktree contamination.

--- a/docs/archive/agent-isolation-research.md
+++ b/docs/archive/agent-isolation-research.md
@@ -96,7 +96,7 @@ can produce a Windows installer only via slow cross-compile, and the official
 Tauri docs say cross-compile is "last resort". (b) **Azure Trusted Signing**:
 the signing flow assumes a Windows host with the signing CLI present;
 running it from inside a Linux container is unproven. (c) **File-watcher
-performance**: bind-mounting `C:\Users\blokn\GitHub\tandem` into a Linux
+performance**: bind-mounting the repo working tree (e.g. `C:\Users\<you>\GitHub\tandem`) into a Linux
 container goes through the 9P file share, which kills inotify performance —
 this would hurt Vite HMR significantly. The Docker docs explicitly recommend
 keeping watched code inside the WSL2 ext4 FS, which means cloning the repo

--- a/docs/archive/agent-isolation-research.md
+++ b/docs/archive/agent-isolation-research.md
@@ -1,0 +1,318 @@
+# Agent Isolation Research
+
+How to run 5–15 parallel Claude Code agents on Tandem without cross-worktree
+contention, stash bleed, port collisions, `node_modules` corruption, or
+`src-tauri/target` clashes.
+
+**Audience:** Bryan (Windows 11, two-person project). Drafted 2026-05-15.
+
+## TL;DR
+
+If you only do one thing, **stop running the full vitest + cargo test suite
+in `pre-push`.** Replace it with:
+
+1. `vitest related --run` (only tests whose source files changed in the push)
+2. `vitest run tests/cli/mcp-stdio.test.ts tests/server/file-opener-lifecycle.test.ts`
+   gated behind `CI=1` (i.e. don't run locally; let GitHub Actions catch them)
+3. `cargo check` instead of `cargo test` locally; full `cargo test` in CI only
+
+That single change removes symptoms 3 and 6 entirely and makes symptom 5
+non-fatal (cargo check serialises on the lockfile cleanly; cargo test does not
+because it links binaries and races on `target/debug/deps/`).
+
+After that, keep using `git worktree` (it's what Anthropic ships and what the
+desktop app uses), but add three guardrails: a stash-name convention, a
+worktree-aware `node_modules` setup, and per-worktree port allocation for the
+server tests that *do* need TCP. Devcontainers/Docker/Codespaces are
+**not recommended for Tandem** because Tauri builds + Azure Trusted Signing +
+the Windows-host sidecar workflow all want to live on the Windows host.
+
+The rest of this doc is the evidence.
+
+---
+
+## Symptom → root cause map
+
+| # | Symptom | Root cause | Fixable without changing isolation model? |
+|---|---|---|---|
+| 1 | Agent writes to main repo instead of its worktree | Agent CWD drift; bash tool resets CWD between calls (CLAUDE.md note: "use absolute paths") | Yes — agent prompt discipline + a `cd` guard hook |
+| 2 | `git stash pop` resurfaces another agent's WIP | `refs/stash` is global across all worktrees in a repo | Yes — ban `git stash` for agents; use named branches instead |
+| 3 | mcp-stdio + file-opener tests flake under parallel pre-push | Spawned subprocess binds fixed 3478/3479; mammoth fixture missing from hoisted `node_modules` | Yes — move to CI; parameterise port; fix hoisting |
+| 4 | `node_modules` install costs 3min per worktree, junction symlink corrupts on main `npm install` | Each worktree is a fresh tree; junction shares a single physical directory which main repo mutates | Yes — pnpm content-addressable store, or copy-on-write reflink, or yarn PnP |
+| 5 | `cargo check` agents fight over `src-tauri/target/` | Cargo locks `target/` per invocation but not per worktree | Yes — `CARGO_TARGET_DIR` env per worktree |
+| 6 | Sidecar binary stub clobbering | Stubs live in tracked path `src-tauri/binaries/`; multiple worktrees write at once | Yes — stubs in worktree-local cache dir, not repo-tracked path |
+
+Every symptom is fixable without abandoning worktrees. None of them are
+inherent to the worktree model — they're all knobs we haven't turned yet.
+
+---
+
+## Option comparison
+
+### 1. Stronger git worktrees (status quo, tuned)
+
+**Description.** Keep `.claude/worktrees/agent-*` per Anthropic's recommended
+pattern. The CLI ships first-class `--worktree` flag support; the desktop app
+creates one per session automatically. Worktrees share `.git/`, `refs/`,
+hooks, and the object database; only `HEAD` and the index are per-worktree.
+Stash and reflog are shared.
+
+**Setup cost.** ~0 (already in use). One-time additions: `.worktreeinclude`
+file, `CARGO_TARGET_DIR` shim, pnpm migration (optional but recommended), an
+"agents shall not stash" convention enforced via a PreToolUse hook.
+
+**Per-agent overhead.** ~50MB disk (working tree) + node_modules (see below).
+RAM/CPU: only what each Claude Code process uses. Time to ready: ~5s for
+`git worktree add` + 3min for `npm install` (or ~10s with pnpm + content store).
+
+**Solves:** 1 (with `cd` discipline), 2 (with stash ban), 5 (with
+`CARGO_TARGET_DIR`), 6 (with cache-dir relocation).
+**Doesn't solve alone:** 3 (port collisions in tests — needs pre-push scope
+reduction), 4 (node_modules — needs pnpm or reflink).
+
+**Tandem-specific blockers.** None. This is what the official Claude Code
+desktop redesign already does.
+
+### 2. Per-agent Docker containers (Docker Desktop + WSL2)
+
+**Description.** Each agent runs in its own Linux container with a bind-mount
+of the repo (or a clone inside the container's overlay FS). Each container
+can bind its own loopback `127.0.0.1:3478/3479` because container network
+namespaces are isolated.
+
+**Setup cost.** Multi-hour. Need a Dockerfile that mirrors Tandem's toolchain
+(Node 24, Rust, GTK build deps for `cargo test`, Playwright browsers). Need a
+launcher script that spawns containers with the right mounts.
+
+**Per-agent overhead.** ~2–4GB RAM per container with Node + Vite + Rust
+toolchain loaded. ~5–10s cold start. ~10GB disk per image layer cache.
+
+**Solves:** 3 (independent network namespace = no port collision), 5 (each
+container has its own `target/`), 6 (each its own `binaries/`).
+**Doesn't solve:** 1, 2 (still same shared `.git` if you bind-mount).
+
+**Tandem-specific blockers.** Major. (a) **Tauri builds**: Linux containers
+can produce a Windows installer only via slow cross-compile, and the official
+Tauri docs say cross-compile is "last resort". (b) **Azure Trusted Signing**:
+the signing flow assumes a Windows host with the signing CLI present;
+running it from inside a Linux container is unproven. (c) **File-watcher
+performance**: bind-mounting `C:\Users\blokn\GitHub\tandem` into a Linux
+container goes through the 9P file share, which kills inotify performance —
+this would hurt Vite HMR significantly. The Docker docs explicitly recommend
+keeping watched code inside the WSL2 ext4 FS, which means cloning the repo
+*into* WSL2 — a separate physical checkout that defeats the purpose.
+
+**Verdict.** Heavy lift, breaks Tauri workflow, no clear win over tuned
+worktrees. **Reject.**
+
+### 3. GitHub Codespaces / Microsoft Dev Box
+
+**Description.** Cloud VM per agent, ~$0.18/hr compute + $0.07/GB-month
+storage on Codespaces.
+
+**Setup cost.** ~1hr to write a `.devcontainer/devcontainer.json` that
+provisions Node + Rust + Playwright. Codespaces has a `claude-cli` devcontainer
+feature.
+
+**Per-agent overhead.** Cloud-billed. 5–15 agents × 8h/day × $0.18/hr ≈
+**$8–$22/day** for a single dev's spawn rate. Plus 30–60s cold start unless
+prewarmed.
+
+**Solves:** All 6 symptoms — total isolation.
+**Doesn't solve:** Tauri Windows installer testing still requires a local
+Windows host. macOS bundle still requires a local Mac. So this only isolates
+the *non-platform-bound* work, which is the majority but not the polish phase.
+
+**Tandem-specific blockers.** Tauri build inside a Linux Codespace produces
+only Linux bundles cleanly. Bryan still needs the local Windows host for
+installer + Azure Trusted Signing validation, and the Mac for #428. So
+Codespaces would be a *parallel-work pool*, not a primary dev environment.
+
+**Verdict.** Worth keeping in pocket for the day Bryan wants to run a
+"feature factory" batch overnight. Not the daily driver. **Defer.**
+
+### 4. Hyper-V / Windows Sandbox / Multipass VMs
+
+**Description.** Full Windows VMs cloned from a golden snapshot.
+
+**Setup cost.** Hours. Building the golden image, scripting clone/spinup.
+
+**Per-agent overhead.** 4–8GB RAM, ~30s boot, ~20GB disk per VM.
+
+**Solves:** All 6 symptoms.
+**Doesn't solve:** Filesystem sharing back to the host (for Bryan to look at
+output) requires SMB or vmconnect — clunky.
+
+**Verdict.** Way too heavy for a two-person project. **Reject.**
+
+### 5. Devcontainers (VS Code spec)
+
+Same engine as Option 2 (Docker under the hood) with a VS Code UX layer.
+Anthropic does ship a `claude-cli` devcontainer feature, but each devcontainer
+is still a Docker container with the same Tauri/Windows-host blockers. Useful
+if Bryan wants a one-command "spin up a clean Linux env to triage a Linux-only
+bug" — not useful as the default agent isolation strategy. **Defer / niche.**
+
+### 6. Sandboxed test runners (no isolation change; just smaller blast radius)
+
+**Description.** Stop running heavy tests in `pre-push`. Keep husky doing
+biome + `npm test -- --changed` + `cargo check`, and push the rest to CI.
+Parameterise the few tests that need real TCP via env vars
+(`TANDEM_WS_PORT`, `TANDEM_MCP_PORT`).
+
+**Setup cost.** ~30 minutes. Edit `.husky/pre-push`, add `--changed` invocation,
+add `CI=1`-gated heavy tests, audit `tests/cli/mcp-stdio.test.ts` for fixed
+ports.
+
+**Per-agent overhead.** Reduces pre-push wall time from ~3min to ~10s for a
+typical change, and removes the parallel-vitest port collision window entirely
+because most agents won't bind any ports during their push.
+
+**Solves:** 3 directly. Makes 5 and 6 much less likely to fire because cargo
+tests stop running locally.
+
+**Verdict.** **Highest leverage change. Do this first regardless of which
+isolation strategy wins long-term.**
+
+### 7. Bazel / Nx remote build cache
+
+Overkill. Tandem's build is fast enough that the cache lookup overhead would
+match the build savings. **Reject.**
+
+### 8. Process-level isolation (Job Objects, sandbox-exec)
+
+Sandboxes the *process*, not the *filesystem*. Doesn't solve any of the six
+symptoms; they're all filesystem/network/state issues, not "agent escapes
+its CPU bucket" issues. **Reject.**
+
+---
+
+## Recommended setup for Tandem
+
+A four-part plan, ordered by leverage:
+
+### Part 1 — Pre-push diet (fixes symptom 3, 5, 6) — **do today**
+
+Edit `.husky/pre-push`:
+
+```sh
+#!/usr/bin/env sh
+set -e
+npx biome check src/ tests/
+# Only tests whose sources changed since origin/master
+git fetch origin master --quiet || true
+BASE=$(git merge-base HEAD origin/master 2>/dev/null || git rev-parse HEAD~1)
+npx vitest related --run $(git diff --name-only "$BASE"...HEAD | tr '\n' ' ')
+cargo check --manifest-path src-tauri/Cargo.toml
+```
+
+Move the full `npm test` + `cargo test` into a `pre-merge` GitHub Action
+(already exists for cargo per CLAUDE.md). The two flaky tests
+(`mcp-stdio.test.ts`, `file-opener-lifecycle.test.ts`) become CI-only.
+
+### Part 2 — Worktree hygiene (fixes symptoms 1, 2, 5, 6) — **do this week**
+
+1. **Stash ban.** Add a PreToolUse Bash hook that blocks `git stash` (or
+   `git stash push`) when CWD contains `.claude/worktrees/`. Force agents to
+   commit-to-branch instead — branches are per-worktree, stashes are global.
+2. **`CARGO_TARGET_DIR` per worktree.** In each agent's working dir set
+   `CARGO_TARGET_DIR=.cargo-target` (a path relative to the worktree). Cargo
+   honours it everywhere. Add a one-line `.envrc` template that
+   `WorktreeCreate` writes when the agent boots.
+3. **Sidecar stubs out of the tracked tree.** Move the
+   `src-tauri/binaries/node-sidecar-<triple>[.exe]` stub-creation logic into a
+   `scripts/cargo-test-prep.mjs` that writes into `$CARGO_TARGET_DIR/stubs/`
+   and points `tauri.conf.json`'s `bundle.externalBin` at that path via env
+   substitution. (Or simpler: keep the current location but skip `cargo test`
+   in pre-push entirely per Part 1 — clobbering only matters if two agents
+   actually run cargo test simultaneously.)
+4. **`.worktreeinclude`.** Add `.env`, `.env.local`, and any local-only
+   config so Anthropic's worktree creator copies them into each new worktree.
+   Without this, agents will silently fall back to default config.
+5. **Add `.claude/worktrees/` to `.gitignore`** (if not already — quick check
+   needed) so worktree contents never appear as untracked files in the main
+   checkout.
+
+### Part 3 — node_modules deduplication (fixes symptom 4) — **do this month**
+
+Three options, in order of preference:
+
+1. **pnpm with content-addressable store.** Migrate from npm to pnpm. Every
+   worktree gets a real `node_modules/` but all package files are hard-links
+   into a single global content store. Install in a fresh worktree takes
+   ~10s after the first time, costs ~zero extra disk. Main repo running `npm
+   install` no longer affects sibling worktrees because they each link from
+   the store, not from a shared `node_modules/`. **This is the right answer
+   for parallel-agent Node projects in 2026.** Risk: husky scripts and any
+   `node node_modules/...` references need a small audit.
+2. **Reflinks / dev drive.** Windows 11 Dev Drive (ReFS) supports
+   copy-on-write reflinks. `robocopy /MIR` with reflink semantics is fast.
+   More fragile than pnpm.
+3. **Status quo (junction).** Document the rule: "do not run `npm install` in
+   main repo while worktrees exist." Cheapest but error-prone.
+
+### Part 4 — Port parameterisation (cleanup) — **nice to have**
+
+For the rare case where two pre-push runs *do* both want to bind 3478/3479
+(e.g. CI=0 power user runs full suite locally):
+
+- Make `DEFAULT_WS_PORT` / `DEFAULT_MCP_PORT` read from
+  `process.env.TANDEM_WS_PORT` / `TANDEM_MCP_PORT` first.
+- In the test setup that spawns the server subprocess, pass
+  `TANDEM_WS_PORT=0` to let the OS assign, capture from server stdout/health
+  endpoint.
+
+This is the same pattern the current `tests/cli/mcp-stdio.test.ts` *already
+uses for its in-process TCP probes* (`listen(0, "127.0.0.1", ...)`). The bug
+is that the spawned `tsx src/server/index.ts` child reverts to the fixed
+constants. Closing that gap eliminates the last source of port flakes.
+
+---
+
+## What this plan does NOT do
+
+- **Does not give you bulletproof cross-platform sandboxing.** An agent that
+  decides to `rm -rf /` in its worktree can still walk up and rm the parent.
+  If you need that, Codespaces (Option 3) is the right escape hatch — defer
+  until a clear need.
+- **Does not parallelise Tauri release builds.** Those still need to run on
+  the Windows host with the Azure Trusted Signing CLI present. That's
+  acceptable: release builds are 1-2× per week, not 5-15× per day.
+- **Does not solve the "agent forgot it was in a worktree" problem fully.**
+  CWD drift in the bash tool is fundamental. The mitigation is the user-level
+  rule already in CLAUDE.md ("only use absolute file paths"), plus a hook
+  that warns when an `Edit`/`Write` tool targets a path outside the agent's
+  declared worktree root. Worth filing as a follow-up if symptom 1 recurs
+  after Parts 1-3.
+
+---
+
+## One-thing recommendation
+
+**Ship Part 1 today.** It removes 3 of the 6 symptoms in a 30-minute edit,
+costs no architecture change, and is independently valuable (faster local
+push loop for solo work too). Then come back for Parts 2 and 3 in the next
+quiet day.
+
+Everything else — containers, Codespaces, VMs — is more setup than the
+problem warrants for a two-person project where the only reason for the
+isolation is to run 5-15 Claude agents per day. Worktrees are the right tool
+when their sharp edges are filed down, and Anthropic has been investing
+heavily in making them sharper-edge-free (the May 2026 desktop redesign,
+`--worktree` flag, `.worktreeinclude`, `WorktreeCreate` hooks all landed in
+the past two months). Ride that wave.
+
+---
+
+## Sources
+
+- [Claude Code — Run parallel sessions with worktrees](https://code.claude.com/docs/en/worktrees)
+- [GitHub Copilot CLI uses global git stash in worktrees (issue #1725)](https://github.com/github/copilot-cli/issues/1725)
+- [Docker Desktop — WSL 2 best practices](https://docs.docker.com/desktop/features/wsl/best-practices/)
+- [INOTIFY events not supported in WSL2 (docker/for-win #12898)](https://github.com/docker/for-win/issues/12898)
+- [Tauri v2 — Windows Code Signing (Azure Trusted Signing)](https://v2.tauri.app/distribute/sign/windows/)
+- [Tauri v1 — Cross-Platform Compilation (signCommand caveats)](https://v1.tauri.app/v1/guides/building/cross-platform/)
+- [Vitest CLI — `--changed` and `related`](https://vitest.dev/guide/cli)
+- [Vitest #1113 — `--changed` only considers source files](https://github.com/vitest-dev/vitest/issues/1113)
+- [GitHub Codespaces pricing](https://github.com/pricing/calculator)
+- [Claude Code devcontainer feature (centminmod/claude-code-devcontainers)](https://github.com/centminmod/claude-code-devcontainers)

--- a/docs/semantic-tokens.md
+++ b/docs/semantic-tokens.md
@@ -1,0 +1,49 @@
+# Semantic Tokens
+
+Full reference for Tandem's CSS custom property families. The summary lives in `CLAUDE.md > Semantic Tokens`; this document is the full enumeration.
+
+Token families are defined in `index.html` `:root` (light theme) and `[data-theme="dark"]` (dark theme) blocks. Lint: `npm run check:tokens` (also runs on pre-commit via lint-staged) scans `src/client/` for raw hex/rgba violations.
+
+## Status families
+
+Each family exposes `--tandem-{name}`, `-fg`, `-fg-strong`, `-bg`, `-border` variants.
+
+- **`--tandem-success-*`** — green. Success toasts, completion states.
+- **`--tandem-warning-*`** — amber. Warnings, held-annotation banners, unsaved indicators.
+- **`--tandem-error-*`** — red. Error banners, destructive actions, flag annotations.
+- **`--tandem-info-*`** — blue. Informational banners, review-only mode.
+- **`--tandem-suggestion-*`** — violet. Replacement/suggestion annotations. Visually distinct from indigo accent. Exposes `--tandem-suggestion`, `-fg-strong`, `-bg`, `-border`.
+
+## Accent / authorship
+
+- **`--tandem-accent-border`** — single token for accent-family bordered elements.
+- **`--tandem-author-user`** / **`--tandem-author-claude`** — authorship colors. Blue/orange in light, adjusted in dark. Authorship decorations use `data-tandem-author` attributes (not CSS classes) per ADR-026.
+- **`--tandem-claude-focus-bg`** / **`--tandem-claude-focus-border`** — Claude focus paragraph indicator. Derived from `--tandem-author-claude` via `color-mix` (10% / 40% opacity against transparent). Used in `awareness.ts` for the paragraph gutter decoration.
+
+## Scales
+
+Use these instead of raw px literals in client surfaces:
+
+- **Spacing:** `--tandem-space-1..7`
+- **Radius:** `--tandem-r-1..5`, `--tandem-r-pill`, `--tandem-r-circle`
+- **Type:** `--tandem-text-2xs..3xl`
+- **Elevation:** `--tandem-shadow-1..4`
+- **Stacking:** `--tandem-z-base..tooltip`
+
+## Highlights
+
+CSS-facing highlight fills use `--tandem-highlight-yellow|green|blue|pink`. Keep `HIGHLIGHT_COLORS` raw rgba values for non-CSS export/runtime paths; Svelte surfaces should use `HIGHLIGHT_COLOR_VARS`.
+
+## Light vs dark derivation
+
+- **Light mode:** `--tandem-success-bg`, `--tandem-warning-bg`, and `--tandem-error-bg` are derived via `color-mix(in srgb, var(--tandem-{color}) 10%, var(--tandem-surface))`. `--tandem-accent-bg` (`#eef2ff`) and `--tandem-info-bg` (`#eff6ff`) use hand-picked hex. `--tandem-suggestion-bg` uses `color-mix` like the other status families.
+- **Dark mode:** all `*-bg` tokens use hand-coded saturated hex (e.g. `#052e16`, `#451a03`, `#450a0a`). `color-mix` produces washed-out surfaces against the dark neutral; hand-picked values read as intentionally colored.
+
+## Color utilities
+
+`src/client/utils/colors.ts` exports `warningStateColors` — import it instead of inlining all three CSS vars when you need the full set (e.g. `SidePanel.svelte` held-banner). Error/success/suggestion variants were removed in audit v2 (zero consumers); re-add the same shape if a future surface needs them.
+
+## Lint enforcement
+
+- `npm run check:tokens` runs `scripts/check-semantic-tokens.ts` against `src/client/**/*.{ts,svelte}`. Raw hex in client code is a regression; lint rule tracked in #356.
+- `rgba(0,0,0,...)` / `rgba(255,255,255,...)` alpha values for shadows and overlays are **exempt** — they're neutral, not semantic.

--- a/docs/v10-triage.md
+++ b/docs/v10-triage.md
@@ -1,0 +1,161 @@
+# v1.0 Triage — Mark each row
+
+For each row, replace the empty `Bryan` cell with one of: **Core** (must ship for v1.0), **Defer** (v1.1+), **Cut** (drop entirely), or **TBD**. To accept the recommendation in the `Rec` column, just type "ditto" or copy the rec value.
+
+Full plan context: `~/.claude/plans/it-occurs-to-rustling-newt.md`. Once this triage is locked, the wave list in §4 of the plan becomes concrete.
+
+**v1.0 thesis (your call, 2026-05-14):** every core feature rock-solid + redesign complete + pending decisions finalized. Quality over speed. Date is soft.
+
+---
+
+## 1A. Strategic "big-feature" candidates
+
+| ID   | Item                                                       | Effort                                                           | Risk                                                            | Rec                                                      | Bryan |
+| ---- | ---------------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------- | ----- |
+| #477 | Local LLM integration (PR-4 quartet #642–#645 + PRs 1/3/5) | LARGE                                                            | CRITICAL — PR-4 rewrites `.claude.json` on every user's machine | TBD — if Core, requires ≥2-week feature-flag soak        | Core  |
+| #576 | .docx write-back (docx-npm body export)                    | MEDIUM (10–13d body export; comment round-trip = separate spike) | HIGH                                                            | TBD — if Core, body export only (defer comments to v1.1) | Core  |
+
+## 1B. Polish / UX from open issues
+
+| ID   | Item                                    | Effort | Risk   | Rec                      | Bryan                          |
+| ---- | --------------------------------------- | ------ | ------ | ------------------------ | ------------------------------ |
+| #539 | Custom keyboard shortcut UI in settings | MEDIUM | LOW    | Defer                    | Core                           |
+| #595 | Drag-to-reorder tabs                    | SMALL  | LOW    | Defer                    | Completed already              |
+| #596 | Toggle text decorations                 | SMALL  | LOW    | Defer                    | Core                           |
+| #597 | Document statistics in status bar       | SMALL  | LOW    | Defer                    | Core                           |
+| #299 | "Show in file explorer"                 | SMALL  | LOW    | Defer                    | Defer                          |
+| #314 | Export annotations as file              | SMALL  | LOW    | Defer                    | Defer                          |
+| #265 | Welcome tutorial update                 | SMALL  | LOW    | Bundle into AR6 if cheap | Core                           |
+| #319 | Diagnostics dashboard                   | MEDIUM | LOW    | Defer                    | Defer                          |
+| #103 | Session management browser              | MEDIUM | LOW    | Defer                    | Defer                          |
+| #153 | Embedded/inline images in documents     | LARGE  | MEDIUM | Defer                    | Defer                          |
+| #269 | "UI/UX improvement" (vague scope)       | ??     | ??     | Triage scope or close    | This is basically the redesign |
+
+## 1C. Bug fixes & stability
+
+| ID   | Item                                        | Effort | Risk   | Rec                           | Bryan |
+| ---- | ------------------------------------------- | ------ | ------ | ----------------------------- | ----- |
+| #428 | macOS 26.1 M1 install bug                   | MEDIUM | HIGH   | **Core (production blocker)** | Core  |
+| #631 | `restart_sidecar` silent failure            | SMALL  | MEDIUM | **Core**                      | Core  |
+| #616 | Evict Y.Doc on cleanup failure              | SMALL  | LOW    | Defer                         | Core  |
+| #244 | E2E Windows tsx watch + Playwright deadlock | MEDIUM | LOW    | Defer (CI annoyance)          | Core  |
+
+## 1D. Architecture / refactors (defer-by-default)
+
+| ID   | Item                                        | Effort | Risk                                | Rec           | Bryan |
+| ---- | ------------------------------------------- | ------ | ----------------------------------- | ------------- | ----- |
+| #438 | Per-client identity (Code + Cowork)         | LARGE  | HIGH (prereq for #452 multi-Claude) | Defer (v1.1+) | Defer |
+| #320 | Annotation schema v1→v2 migration framework | MEDIUM | MEDIUM                              | Defer         | Defer |
+| #313 | Content-hash annotation identity            | MEDIUM | LOW                                 | Defer         | Core  |
+| #318 | Tombstone/GC for annotation store           | MEDIUM | LOW                                 | Defer         | Defer |
+| #315 | Extract DocumentStore interface             | SMALL  | LOW                                 | Defer         | Defer |
+| #321 | Hocuspocus WebSocket LAN auth               | MEDIUM | LOW                                 | Defer         | Defer |
+| #282 | Extract SSE consumer                        | SMALL  | LOW                                 | Defer         | Defer |
+| #633 | Extract matchShortcut helper                | SMALL  | LOW                                 | Defer         | Defer |
+| #560 | tauri-driver E2E harness                    | MEDIUM | LOW                                 | Defer         | Defer |
+| #632 | Workflow-nudge perf                         | SMALL  | LOW                                 | Defer         | Defer |
+
+## 1E. Cross-platform packaging
+
+| ID           | Item                                                 | Effort | Risk                     | Rec                                                       | Bryan         |
+| ------------ | ---------------------------------------------------- | ------ | ------------------------ | --------------------------------------------------------- | ------------- |
+| #428 cert    | Apple Developer cert + macOS notarization            | MEDIUM | CRITICAL (calendar gate) | **Core — start NOW**                                      | Core          |
+| #316         | macOS/Linux Cowork auto-setup                        | LARGE  | HIGH                     | Defer (Win Cowork works; macOS/Linux fall back to CLI)    | Core          |
+| #317         | OS-specific firewall scoping                         | MEDIUM | MEDIUM                   | Defer with #316                                           | Defer         |
+| #433         | Cowork installer TOCTOU hardening                    | MEDIUM | LOW                      | Defer                                                     | Defer         |
+| #552         | Verify titlebar on Linux/KDE                         | SMALL  | LOW                      | Defer                                                     | Defer         |
+| #378         | Windows file picker                                  | MEDIUM | LOW                      | Defer (current dialog works)                              | Defer         |
+| #566 vs #561 | Updater UX (modal vs banner vs native)               | MEDIUM | MEDIUM                   | Pick one for redesign coherence; else native (status quo) | Core (Banner) |
+| #630         | PR #628 follow-ups (RejectionReason, macOS coverage) | SMALL  | LOW                      | Bundle into #428 work                                     | Defer         |
+| #646         | Complete `TANDEM_TAURI_SIDECAR` migration cleanup    | SMALL  | LOW                      | Bundle with notarization wave                             | Defer         |
+
+## 1F. Cleanup of in-flight #477 spike (decided by 1A row)
+
+Current branch (`spike/477-sidecar-launcher`) holds the spike + PR-4 hardening pre-work.
+
+- If #477 is **Core for v1.0**: PRs 1/3/4/5 ship; PR-4 quartet (#642–#645) hardens; PR-4 must soak behind a feature flag for ≥2 weeks (v0.13.0 hidden → v1.0 exposed).
+- If #477 is **Deferred to v1.1**: spike findings doc lands as ADR; branch parks; #642–#646 stay open against #477; current branch closes.
+
+## 1G. Redesign new surfaces (HANDOFF.md)
+
+Per your redesign-complete rule: every shipped feature must have the new design. The "Core" surfaces below are those I judge necessary for the redesign to *feel* complete, even without #477/#576. Mark differently if you disagree.
+
+| Surface                                                                                                  | Effort | Risk                                            | Rec                                                | Bryan   |
+| -------------------------------------------------------------------------------------------------------- | ------ | ----------------------------------------------- | -------------------------------------------------- | ------- |
+| Selection mini-toolbar (Tiptap BubbleMenu) — B/I/S/code/heading/link + Highlight/Comment/Note/Ask Claude | MEDIUM | MEDIUM (suppression vs slash menu/find/palette) | **Core** (defines new toolbar UX)                  | Core    |
+| Slash command menu (typing `/` → block types)                                                            | MEDIUM | LOW                                             | **Core**                                           | Core    |
+| Authorship gutter (2px per-paragraph thread)                                                             | MEDIUM | MEDIUM (mechanism change — see D2)              | Decision D2                                        | Defer   |
+| Editor body fonts (Source Serif 4 / Inter Tight / JetBrains Mono)                                        | SMALL  | LOW                                             | **Core**                                           | Core    |
+| Paged .docx layout (white sheets on gray canvas)                                                         | MEDIUM | LOW                                             | **Core** for redesign-complete                     | Core    |
+| Annotation reply thread expansion (overlay/modal frame)                                                  | MEDIUM | LOW                                             | **Core** (collapsed thread already ships)          | Core    |
+| Annotation thread emoji reactions + status badge                                                         | MEDIUM | MEDIUM (new server data model, no spike)        | Decision D5 (rec: defer reactions; ship expansion) | Discard |
+| Solo-mode held-count badge → status bar (move from toolbar/titlebar)                                     | SMALL  | LOW                                             | **Core**                                           | Core    |
+| Settings sidebar nav (full tabbed modal) — ship as `SettingsModal.svelte` sibling                        | MEDIUM | MEDIUM                                          | **Core**                                           | Core    |
+| Settings → Network panel (sidecar bind mode, retry, telemetry, token rotation status)                    | MEDIUM | LOW                                             | **Core**                                           | Core    |
+| Diff / Apply-edit inline split view (hunk-by-hunk staging)                                               | LARGE  | HIGH (no spike yet)                             | Decision D3                                        | defer   |
+| First-run onboarding wizard (model select + default mode + shortcuts cheat-sheet)                        | MEDIUM | MEDIUM (couples to #477)                        | Decision D4                                        | core    |
+| Shortcuts modal (⌘/)                                                                                     | SMALL  | LOW                                             | **Core**                                           | core    |
+| Mobile / narrow-window layout (≤480px responsive)                                                        | LARGE  | LOW                                             | Decision D7 (rec: defer)                           | defer   |
+| AR5 Word-import batch-promote (.docx comments → private notes → batch convert)                           | MEDIUM | HIGH (annotation type migration on import)      | **Core** (deferred from v0.12.0 batch)             | Core    |
+| AR6 tutorial annotations (welcome.md teaches vocabulary)                                                 | MEDIUM | LOW                                             | **Core** (deferred from v0.12.0 batch)             | core    |
+| Connection-degradation banner (full polish — partial today)                                              | SMALL  | LOW                                             | **Core**                                           | core    |
+| Author chip/avatar on annotation cards                                                                   | SMALL  | LOW                                             | Decision D8                                        | defer   |
+| Authorship gutter pulses when Claude is reading (presence indicator)                                     | MEDIUM | LOW                                             | Decision D2-adjacent                               | defer   |
+| Empty state with slash menu (`empty` artboard)                                                           | SMALL  | LOW                                             | Bundle with slash menu work                        | core    |
+| Compact density variant (`compact` artboard)                                                             | SMALL  | LOW                                             | Decision D9 (resolve with D1)                      | defer   |
+
+## 1H. Redesign chores / migrations (verify status before shipping)
+
+| Item                                                                                 | Suspected Status                                     | Rec                                               | Bryan                                                                     |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------- |
+| Highlight palette migration (red/purple → pink/blue or sanitize-on-read fallback)    | Likely shipped v0.11.0 — verify                      | Verify; ship gap if any                           | i think shipped?                                                          |
+| `showAuthorship` default flip false→true + optional migration toast                  | Likely shipped v0.11.0 — verify                      | Verify; ship migration toast if missing           | ok                                                                        |
+| OKLCH `from var(...)` → `color-mix()` fallback for older WebView2 (Win 10)           | Status unclear                                       | **Core** if any tokens use OKLCH `from` syntax    | if this is a browser thing, we are deprecating the browser anyway, right? |
+| `--tandem-*` prefix audit on production CSS (no bare `--accent`/`--ink`/`--surface`) | Production already namespaced; design files use bare | **Core** if any bare-prefixed vars leak into prod | Core                                                                      |
+| `data-author` → `data-tandem-author` rename                                          | Shipped per CLAUDE.md                                | Done                                              | done                                                                      |
+
+## 1I. Speculative HANDOFF items explicitly NOT in scope
+
+Per HANDOFF "Things explicitly NOT designed":
+
+- Document Groups (roadmap 7b)
+- Multi-user collaboration (cursor stacking, presence, conflict resolution)
+- PWA, .xlsx/.csv, freeform annotation
+- MCP tool consolidation #259 (already shipped per CLAUDE.md)
+- Frameless window vibrancy / multi-window / file explorer sidebar
+
+These do not appear in the triage table. They are v2+. **Override:** add a row above if you want any pulled in.
+
+---
+
+## 2. Pending design decisions
+
+These block specific implementation work. Each unlocks a downstream wave.
+
+| #   | Decision                                                                                  | Options                                                                                                                                     | Rec                                            | Bryan                                                                     |
+| --- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------- |
+| D1  | Density × textSize collision (HANDOFF B1): both write font-size CSS variables             | (a) density controls spacing only, (b) density subsumes textSize, (c) status quo — verify and document                                      | TBD — verify current behavior first            | I think density should control interface, font size should control editor |
+| D2  | Authorship visual: per-character (current) vs per-paragraph 2px gutter (design) vs hybrid | (a) per-character, (b) gutter, (c) hybrid (gutter for dominant author + character for inline runs per HANDOFF)                              | (c) hybrid                                     | i think we should just do per-character                                   |
+| D3  | Diff/Apply-edit hunk-staging UX                                                           | (a) inline split-view (needs spike + impl, tight), (b) modal-based staging, (c) defer interactive staging — keep current ApplyChangesButton | (b) or (c)                                     | B                                                                         |
+| D4  | First-run onboarding wizard                                                               | (a) full-screen modal with model select, (b) overlay (no model select), (c) defer if #477 deferred                                          | Couples to #477 (1A)                           | Core - a + allow setup for more than one model                            |
+| D5  | Annotation reply thread reactions                                                         | (a) ship reactions (new server model), (b) ship expanded thread without reactions, (c) defer expansion entirely                             | (b)                                            | agreed                                                                    |
+| D6  | Updater UX                                                                                | (a) modal (#566), (b) banner (#561), (c) native dialog (status quo)                                                                         | (c) — current works; modal/banner is polish    | banner + indicator on settings icon                                       |
+| D7  | Mobile / narrow-window                                                                    | (a) ship full responsive, (b) ship narrow-settings only (HANDOFF C5), (c) defer                                                             | (c)                                            | defer                                                                     |
+| D8  | Author chip/avatar on annotation cards                                                    | (a) avatar (initial circle), (b) text label (current)                                                                                       | (a)                                            | defer, current implementation is fine for now                             |
+| D9  | Compact density artboard                                                                  | (a) ship as third density option, (b) reuse cozy/spacious                                                                                   | depends on D1                                  | defer                                                                     |
+| D10 | Selection mini-toolbar suppression rules (HANDOFF D3)                                     | suppress when slash query active, find bar focused, palette open (per HANDOFF)                                                              | Confirm per HANDOFF                            | ok                                                                        |
+| D11 | Editor body fonts                                                                         | (a) bundle locally in `dist/client/fonts/` (Tauri offline-friendly), (b) Google Fonts CDN                                                   | (a)                                            | agreed for 1.0                                                            |
+| D12 | macOS / Linux distribution at v1.0                                                        | (a) full parity (notarized macOS + AppImage Linux), (b) notarized macOS, Linux CLI-only, (c) Windows-only with macOS in v1.0.1              | (a) if cert+hardware ready, fallback (b) → (c) | we should aim for full parity for 1.0                                     |
+
+---
+
+## After you've marked everything
+
+When done:
+
+- This file gets folded back into `~/.claude/plans/it-occurs-to-rustling-newt.md`
+- Wave list in §4 of the plan locks
+- I verify §1H "likely shipped" items against current code (Wave 0 task #1)
+- Apple Developer cert procurement starts (Wave 0 calendar gate)
+- I park or close `spike/477-sidecar-launcher` based on the #477 row decision
+- I replace `docs/roadmap.md` v0.12.0+ sections with the new wave structure

--- a/docs/v10-triage.md
+++ b/docs/v10-triage.md
@@ -2,7 +2,7 @@
 
 For each row, replace the empty `Bryan` cell with one of: **Core** (must ship for v1.0), **Defer** (v1.1+), **Cut** (drop entirely), or **TBD**. To accept the recommendation in the `Rec` column, just type "ditto" or copy the rec value.
 
-Full plan context: `~/.claude/plans/it-occurs-to-rustling-newt.md`. Once this triage is locked, the wave list in §4 of the plan becomes concrete.
+Full plan context lives in a maintainer-local planning doc. Once this triage is locked, the wave list in §4 of that plan becomes concrete.
 
 **v1.0 thesis (your call, 2026-05-14):** every core feature rock-solid + redesign complete + pending decisions finalized. Quality over speed. Date is soft.
 
@@ -153,7 +153,7 @@ These block specific implementation work. Each unlocks a downstream wave.
 
 When done:
 
-- This file gets folded back into `~/.claude/plans/it-occurs-to-rustling-newt.md`
+- This file gets folded back into the maintainer-local planning doc
 - Wave list in §4 of the plan locks
 - I verify §1H "likely shipped" items against current code (Wave 0 task #1)
 - Apple Developer cert procurement starts (Wave 0 calendar gate)


### PR DESCRIPTION
## Summary

PR3 of the documentation-consolidation effort: **archival + repo hygiene**. Deliberately conservative on moves — the approved v0.13.0 release plan says to preserve the historical loose plans, so this does not mass-reorganize them.

## Changes

- **`.gitignore`** — ignore `graphify-out/` (regenerable knowledge-graph artifact dump, hundreds of cache files) and `.claude/.pr*` (ephemeral PR working files: diffs, body drafts, review scratch).
- **Track in place** — `docs/semantic-tokens.md` and `docs/v10-triage.md` were authored but never committed. `v10-triage.md` is the triage source-of-truth that `roadmap.md` references **6 times**; tracking it resolves the open question the v0.13.0 release plan flagged (whether the roadmap ref should be dropped or the file committed — now committed).
- **`docs/archive/`** — new directory + README. Moved the orphaned `agent-isolation-research.md` (untracked, zero inbound references) there.
- **Deleted** two `U+F03A`-mangled garbage diff files (`CUsers…tmp-pr*.diff`) at the repo root, via codepoint-matched removal.

## Deliberately NOT done

- **Mass-archiving the loose version plans / audits** (`v090-plan.md`, `v011-plan.md`, `audit-v1.md`, `audit-v2.md`, `run-b-plan.md`, etc.). The v0.13.0 release plan (`docs/plans/2026-05-21-v0.13.0-release.md:298`) explicitly says *"historical record — don't rewrite past version refs,"* and these are cross-referenced across CHANGELOG and other plans. Moving them is poor risk/reward (link breakage for cosmetic tidiness).
- Other untracked scratch (`CLAUDE.md.bak.*`, `.tmp-review-*.md`, `.claude/reviews/`, `.claude/hooks/README.md`) — left as-is; outside the consolidation's track/delete scope.

## Test plan

- [x] `git status` confirms `graphify-out/` + `.claude/.pr*` no longer surface as untracked
- [x] Link sweep: `agent-isolation-research.md` has no inbound refs except the new archive README (correct path)
- [x] Pre-commit lint-staged passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)