### PR TITLE
ci: grant id-token: write to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: read # gh issue view (in --allowedTools) needs read; omitting the key entirely would set it to none
+  id-token: write # claude-code-action fetches an OIDC token; the permissions block zeroes unlisted scopes
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
- The `Claude Code Review` workflow (`claude-code-action@v1`) has been failing on every PR with `Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?`
- The action mints an OIDC token, but the workflow's `permissions:` block listed only `contents`, `pull-requests`, and `issues`. An explicit `permissions:` block zeroes every unlisted scope, so `id-token` was effectively `none`.
- Add `id-token: write` to restore automated reviews. Surfaced while shipping the v0.13.0 release (the `review` check was the only red on PR #861, non-blocking since master isn't protected).

## Test plan
- [ ] This PR touches `.github/workflows/`, so it triggers the review workflow itself — a green `review` check here confirms the fix.