### PR TITLE
feat(client): auto-open scratchpad when no document is open (#842)

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -9,7 +9,9 @@ import { isPendingReviewTarget } from "../shared/types";
 import { generateNotificationId } from "../shared/utils";
 import {
   createScratchpad,
+  SCRATCHPAD_EMPTY_STATE_DEBOUNCE_MS,
   saveStore,
+  shouldAutoOpenScratchpad,
   triggerSave,
   triggerSaveAs,
   wireActionDeps,
@@ -972,6 +974,35 @@ $effect(() => {
 });
 
 const activeTab = $derived(yjsSync.tabs.find((t) => t.id === yjsSync.activeTabId));
+
+// #842: when the user reaches the empty tab-bar state (e.g. closes the last
+// tab) with a live connection, auto-open a fresh scratchpad instead of
+// stranding them on "No document open."
+//
+// The debounce is load-bearing, not cosmetic: on initial connect `connected`
+// flips true before the server's `openDocuments` list syncs, so `tabs` is
+// briefly empty. Firing immediately would race the startup doc
+// (welcome.md / CHANGELOG.md, opened server-side before HTTP bind) and open a
+// stray scratchpad ahead of it. The timer also rides out the transient
+// `activeTab === null` during a Y.Doc swap (reload-from-disk) and never fires
+// during the disconnect-debounce window (gate requires `connected`). The
+// startup doc arriving within the window re-runs this effect, cleanup clears
+// the pending timer, and the gate no longer passes — so no scratchpad opens.
+$effect(() => {
+  if (
+    !shouldAutoOpenScratchpad({
+      connected: yjsSync.connected,
+      tabCount: yjsSync.tabs.length,
+      activeTabId: yjsSync.activeTabId,
+    })
+  ) {
+    return;
+  }
+  const timer = setTimeout(() => {
+    void createScratchpad();
+  }, SCRATCHPAD_EMPTY_STATE_DEBOUNCE_MS);
+  return () => clearTimeout(timer);
+});
 
 // Lifted from SidePanel.svelte so that:
 //   1. There's exactly one review instance (both rails would otherwise mount

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -93,6 +93,38 @@ let inflight = false;
 
 let scratchpadInflight = false;
 
+/**
+ * Debounce (ms) before auto-opening a scratchpad once the empty state is
+ * reached. The window absorbs three transients that must NOT trigger an
+ * auto-open:
+ *   1. Initial connect — `connected` flips true before the server's
+ *      `openDocuments` list has synced, so `tabs` is briefly empty. The
+ *      startup doc (welcome.md / CHANGELOG.md) arrives within this window.
+ *   2. Y.Doc swap (reload-from-disk) — `activeTab` is momentarily null while
+ *      the tab entry is replaced.
+ *   3. Tab-switch churn during reconcile.
+ * It must comfortably exceed the time for the bootstrap `openDocuments`
+ * broadcast to land after `connected` flips.
+ */
+export const SCRATCHPAD_EMPTY_STATE_DEBOUNCE_MS = 400;
+
+/**
+ * Pure gate for the App-level auto-open-scratchpad effect (#842). Returns true
+ * only when the user has genuinely reached the empty tab-bar state with a live
+ * server connection — never during the disconnect-debounce window (which fails
+ * the `connected` check) and never with a doc still open.
+ *
+ * Extracted as a pure function so the precedence/timing logic is unit-testable
+ * without standing up a Svelte component or a Hocuspocus provider.
+ */
+export function shouldAutoOpenScratchpad(state: {
+  connected: boolean;
+  tabCount: number;
+  activeTabId: string | null;
+}): boolean {
+  return state.connected && state.tabCount === 0 && state.activeTabId === null;
+}
+
 export async function createScratchpad(): Promise<void> {
   if (scratchpadInflight) return;
   scratchpadInflight = true;

--- a/tests/client/actions/scratchpad-empty-state.test.ts
+++ b/tests/client/actions/scratchpad-empty-state.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+/**
+ * Unit coverage for the pure auto-open-scratchpad gate (#842).
+ *
+ * When the user reaches the empty tab-bar state with a live connection,
+ * App.svelte debounces and then opens a fresh scratchpad rather than leaving
+ * them on "No document open." The timing logic (debounce, startup-doc
+ * precedence) lives in the App.svelte `$effect`, but the decision of *whether*
+ * the empty state qualifies is extracted into `shouldAutoOpenScratchpad` so the
+ * three correctness-critical guards can be asserted without standing up a
+ * Svelte component or a Hocuspocus provider:
+ *
+ *   1. Never fire while disconnected — the disconnect-debounce window must show
+ *      "Cannot reach the Tandem server", not spawn a scratchpad. The gate fails
+ *      because `connected` is false.
+ *   2. Never fire when a doc is still open (`tabCount > 0` or `activeTabId`
+ *      set) — this is the normal editing case.
+ *   3. Fire only when connected AND no tab AND no active id.
+ */
+
+import { describe, expect, it } from "vitest";
+import { shouldAutoOpenScratchpad } from "../../../src/client/actions/builtin.svelte.js";
+
+describe("shouldAutoOpenScratchpad", () => {
+  it.each([
+    {
+      why: "connected + empty tab bar + no active id → genuine empty state",
+      connected: true,
+      tabCount: 0,
+      activeTabId: null,
+      expected: true,
+    },
+    {
+      why: "disconnected (disconnect-debounce window) → never auto-open",
+      connected: false,
+      tabCount: 0,
+      activeTabId: null,
+      expected: false,
+    },
+    {
+      why: "a tab is still open → normal editing, not empty state",
+      connected: true,
+      tabCount: 1,
+      activeTabId: "doc-1",
+      expected: false,
+    },
+    {
+      why: "tabs present but no active id (reconcile churn) → not empty state",
+      connected: true,
+      tabCount: 2,
+      activeTabId: null,
+      expected: false,
+    },
+    {
+      why: "active id set but tab list momentarily empty (swap churn) → wait",
+      connected: true,
+      tabCount: 0,
+      activeTabId: "doc-1",
+      expected: false,
+    },
+    {
+      why: "disconnected with a tab still open → never auto-open",
+      connected: false,
+      tabCount: 1,
+      activeTabId: "doc-1",
+      expected: false,
+    },
+  ])("$why", ({ connected, tabCount, activeTabId, expected }) => {
+    expect(shouldAutoOpenScratchpad({ connected, tabCount, activeTabId })).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #842 — "Tandem should default to scratchpad instead of 'No document open'."

When the user reaches the empty tab-bar state with a live connection (the common case being closing the last open tab), Tandem now auto-opens a fresh scratchpad instead of stranding them on the "No document open" message.

- New App-level `$effect` in `App.svelte` fires `createScratchpad()` (the existing `Ctrl+N` / `tandem_scratchpad` path) once the empty state settles.
- The decision is factored into a pure, unit-tested `shouldAutoOpenScratchpad({ connected, tabCount, activeTabId })` in `builtin.svelte.ts` so the precedence/timing contract is verifiable without a live Hocuspocus provider.

## Why the debounce matters (correctness, not polish)

A `SCRATCHPAD_EMPTY_STATE_DEBOUNCE_MS` (400ms) timer gates the auto-open. This is load-bearing for three constraints called out in the issue scope and CLAUDE.md:

1. **Must not preempt startup precedence.** On initial connect, `yjsSync.connected` flips true *before* the server's `openDocuments` list has synced, so `tabs` is briefly empty. The server opens the startup doc (`welcome.md` on first run / `CHANGELOG.md` on upgrade) *before* HTTP bind, and it arrives within the debounce window. When it lands, the effect re-runs, the cleanup clears the pending timer, and the gate no longer passes — so no stray scratchpad opens ahead of it.
2. **Must not fire during a transient disconnect.** `EmptyState.svelte` also renders the "Cannot reach the Tandem server" message during the disconnect-debounce window. The gate requires `connected`, so the auto-open never fires while disconnected.
3. **Rides out Y.Doc-swap churn.** During a reload-from-disk swap, `activeTab` is momentarily null; the debounce absorbs that.

## Testing

- `tests/client/actions/scratchpad-empty-state.test.ts` — 6 equivalence-class cases pinning the gate decision (connected+empty → open; disconnected → never; tab/active-id present → never; reconcile/swap churn → wait). Passes.
- `npm run typecheck` (tsc server + client + svelte-check `--fail-on-warnings`) — clean.
- `npm run check:tokens` — no new violations (change adds no CSS/colors).

### Manual verification still needed (not coverable in CI / this worktree)

Per the no-fake-verification rule, the end-to-end behavior wants a manual pass on a live `npm run dev:standalone` (full Playwright E2E was intentionally skipped here — its `webServer` kills ports :3478/:3479, which would stomp a concurrent agent sharing this worktree). Suggested checks:

- [ ] Fresh session (wipe sessions dir) → opens **welcome.md**, NOT a scratchpad.
- [ ] Upgrade path (sessions dir + bumped version) → opens **CHANGELOG.md**, NOT a scratchpad.
- [ ] Normal session, close the last tab → a **Scratchpad.md** tab opens.
- [ ] Kill the server mid-session → the **disconnect message** shows, no scratchpad attempt.

## Notes for review

- **Known UX consequence (matches the literal issue):** closing the auto-opened scratchpad re-triggers the gate and opens another. This is faithful to "default to scratchpad." If a "exit to truly empty" affordance or a once-per-session guard is wanted, that's a deliberate product follow-up — out of scope for this no-decision unit.
- **Multi-client race (out of scope, one-line flag):** each connected browser client independently races `POST /api/scratchpad` on initial empty state. `scratchpadInflight` is module-scoped (per-client) and `openScratchpad()` mints a fresh UUID per call (`src/server/mcp/file-opener.ts:243`), so two clients would create two scratchpads. Not introduced by this PR and not refactored here.
- **Persistence/recovery deliberately not implemented** — that's issue #864 (still an open question). This only opens a fresh ephemeral scratchpad.
- **Pre-existing test flakes:** the full `npm test` run shows a handful of failures in `useTauriFileDrop.test.ts`, `mcp-stdio.test.ts`, `setup-*.test.ts`, and `apply-malformed.test.ts`. All are timeouts under heavy Windows-local parallel load and **pass in isolation** (verified against the clean-stashed base too). None touch the empty-state/scratchpad path.
- **Pre-push bypass:** the husky pre-push hook failed on a single flaky `useTauriFileDrop` timeout (5s, unrelated to this client-only change; passes in isolation). Pushed with the authorized `HUSKY=0 git push` per the universal instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)