### PR TITLE
chore(spikes): finish TANDEM_OPEN_BROWSER → TANDEM_TAURI_SIDECAR migration (#646)

### DIFF
--- a/scripts/spikes/probe-launcher.mjs
+++ b/scripts/spikes/probe-launcher.mjs
@@ -4,7 +4,7 @@
 // Simulates what a stand-alone `tandem-launcher` binary (spawned by Claude
 // Code via the MCP `command`/`args` shape) would do:
 //   1. Resolve sidecar path from a pointer file (or --exe override).
-//   2. Spawn the sidecar with TANDEM_AUTH_TOKEN + TANDEM_OPEN_BROWSER=0
+//   2. Spawn the sidecar with TANDEM_AUTH_TOKEN + TANDEM_TAURI_SIDECAR=1
 //      and a minimal allowlisted env (PATH, SystemRoot, HOME, etc.).
 //      NOTE: TANDEM_BIND_HOST is intentionally never set → server binds 127.0.0.1.
 //   3. Race a 20s health-poll of http://127.0.0.1:3479/health against the
@@ -165,7 +165,7 @@ async function main() {
   // exposes parent-process secrets to the sidecar and any grandchildren.
   const env = {
     TANDEM_AUTH_TOKEN: token,
-    TANDEM_OPEN_BROWSER: "0",
+    TANDEM_TAURI_SIDECAR: "1",
   };
   for (const key of [
     "PATH",

--- a/src-tauri/src/integrations_probe.rs
+++ b/src-tauri/src/integrations_probe.rs
@@ -11,7 +11,7 @@
 //!    launcher cannot rely on the Tauri build-time triple. We test reading a
 //!    pointer file written by `tandem setup` instead.
 //! 2. **Launch command shape** — build a `std::process::Command` with the
-//!    correct env vars (`TANDEM_AUTH_TOKEN`, `TANDEM_OPEN_BROWSER=0`,
+//!    correct env vars (`TANDEM_AUTH_TOKEN`, `TANDEM_TAURI_SIDECAR=1`,
 //!    `TANDEM_BIND_HOST` defaulted/omitted so the server binds 127.0.0.1).
 //! 3. **Config rewrite** — merge a tandem entry into an existing
 //!    `mcpServers` map without clobbering siblings, preserving the
@@ -314,7 +314,7 @@ pub fn read_sidecar_pointer(path: &Path) -> Result<UnvalidatedSidecarLocation, S
 pub fn build_launch_env(auth_token: &str, app_data_dir: &Path) -> BTreeMap<String, String> {
     let mut env = BTreeMap::new();
     env.insert("TANDEM_AUTH_TOKEN".into(), auth_token.into());
-    env.insert("TANDEM_OPEN_BROWSER".into(), "0".into());
+    env.insert("TANDEM_TAURI_SIDECAR".into(), "1".into());
     env.insert(
         "TANDEM_DATA_DIR".into(),
         app_data_dir.to_string_lossy().into_owned(),
@@ -407,7 +407,10 @@ mod tests {
     fn build_launch_env_never_sets_bind_host() {
         let env = build_launch_env("synthetic-token", Path::new("/tmp/tandem"));
         assert!(!env.contains_key("TANDEM_BIND_HOST"));
-        assert_eq!(env.get("TANDEM_OPEN_BROWSER").map(String::as_str), Some("0"));
+        assert_eq!(
+            env.get("TANDEM_TAURI_SIDECAR").map(String::as_str),
+            Some("1")
+        );
         assert_eq!(
             env.get("TANDEM_AUTH_TOKEN").map(String::as_str),
             Some("synthetic-token")


### PR DESCRIPTION
## Summary

Completes the env-var migration tracked in #646. The production readers/writers were already migrated when the browser-open path was removed entirely (`src/server/mcp/server.ts`, `src/cli/start.ts`) by the #477 PR-2 browser deprecation, and `src/server/index.ts` / `src-tauri/src/lib.rs` now key off `TANDEM_TAURI_SIDECAR`.

The only sites still referencing the now-dead `TANDEM_OPEN_BROWSER=0` were two spike/dev files. This swaps them to `TANDEM_TAURI_SIDECAR=1` to match how the real sidecar is launched:

- `scripts/spikes/probe-launcher.mjs` — env block + header comment
- `src-tauri/src/integrations_probe.rs` — `build_launch_env` insert, module doc comment, and the `build_launch_env_never_sets_bind_host` test assertion

After this, `grep -rn "TANDEM_OPEN_BROWSER" src/ src-tauri/ scripts/` returns nothing.

Closes #646.

## Test plan

- [x] `grep -rn "TANDEM_OPEN_BROWSER"` across `src/`, `src-tauri/`, `scripts/` → no matches
- [ ] CI: `cargo test integrations_probe` (`build_launch_env_never_sets_bind_host` now asserts `TANDEM_TAURI_SIDECAR=1`) — Rust can't compile locally in this container (no GTK libs); change is a literal-string swap mirrored across doc/insert/assertion

https://claude.ai/code/session_01C7fEXT8QuuygJ8FJq5nwza

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7fEXT8QuuygJ8FJq5nwza)_