### PR TITLE
fix(test,a11y): de-flake mcp-stdio concurrent-pending test + keyboard activation for FormattingToolbar

### DIFF
--- a/src/client/editor/toolbar/FormattingToolbar.svelte
+++ b/src/client/editor/toolbar/FormattingToolbar.svelte
@@ -116,6 +116,45 @@ const linkDisabled = $derived.by(() => {
 
 const headingLabel = $derived(activeHeading ? `H${activeHeading}` : "H");
 
+// Hoisted command handlers — prevents event-listener churn on each Tiptap
+// transaction (tick++) that would occur with inline lambda props. Mirrors the
+// $derived pattern in Toolbar.svelte.
+const handleUndo = $derived(withPreventDefault(() => editor?.commands.undo()));
+const handleRedo = $derived(withPreventDefault(() => editor?.commands.redo()));
+const handleBold = $derived(withPreventDefault(() => editor?.chain().focus().toggleBold().run()));
+const handleItalic = $derived(
+  withPreventDefault(() => editor?.chain().focus().toggleItalic().run()),
+);
+const handleStrike = $derived(
+  withPreventDefault(() => editor?.chain().focus().toggleStrike().run()),
+);
+const handleCode = $derived(withPreventDefault(() => editor?.chain().focus().toggleCode().run()));
+const handleBulletList = $derived(
+  withPreventDefault(() => editor?.chain().focus().toggleBulletList().run()),
+);
+const handleOrderedList = $derived(
+  withPreventDefault(() => editor?.chain().focus().toggleOrderedList().run()),
+);
+const handleBlockquote = $derived(
+  withPreventDefault(() => editor?.chain().focus().toggleBlockquote().run()),
+);
+const handleHorizontalRule = $derived(
+  withPreventDefault(() => editor?.chain().focus().setHorizontalRule().run()),
+);
+const handleCodeBlock = $derived(
+  withPreventDefault(() => editor?.chain().focus().toggleCodeBlock().run()),
+);
+
+// Keyboard activation: Enter/Space on a focused button fires `click` with
+// detail === 0. The mouse path uses `mousedown` so the editor selection
+// survives. Pair onMouseDown (mouse) with onClick={onKeyActivate(...)}
+// (keyboard, filtered on detail===0) so both routes work without double-firing.
+function onKeyActivate(handler: (e: MouseEvent) => void) {
+  return (e: MouseEvent) => {
+    if (e.detail === 0) handler(e);
+  };
+}
+
 function handleHeadingToggle(level: HeadingLevel) {
   return (e: MouseEvent) => {
     e.preventDefault();
@@ -160,7 +199,8 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
       ariaLabel="Undo"
       shortcut="Ctrl+Z"
       disabled={!canUndo}
-      onMouseDown={withPreventDefault(() => editor.commands.undo())}
+      onMouseDown={handleUndo}
+      onClick={onKeyActivate(handleUndo)}
       style="min-width: 30px; padding: 4px 6px;"
     >
       {#snippet children()}
@@ -174,7 +214,8 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
       ariaLabel="Redo"
       shortcut="Ctrl+Shift+Z"
       disabled={!canRedo}
-      onMouseDown={withPreventDefault(() => editor.commands.redo())}
+      onMouseDown={handleRedo}
+      onClick={onKeyActivate(handleRedo)}
       style="min-width: 30px; padding: 4px 6px;"
     >
       {#snippet children()}
@@ -191,7 +232,8 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
       shortcut="Ctrl+B"
       disabled={isDisabled}
       active={isActiveBold}
-      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleBold().run())}
+      onMouseDown={handleBold}
+      onClick={onKeyActivate(handleBold)}
       style="font-weight: 700; min-width: 30px;"
     />
     <ToolbarButton
@@ -199,7 +241,8 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
       shortcut="Ctrl+I"
       disabled={isDisabled}
       active={isActiveItalic}
-      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleItalic().run())}
+      onMouseDown={handleItalic}
+      onClick={onKeyActivate(handleItalic)}
       style="font-style: italic; min-width: 30px;"
     />
     <ToolbarButton
@@ -207,7 +250,8 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
       shortcut="Ctrl+Shift+X"
       disabled={isDisabled}
       active={isActiveStrike}
-      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleStrike().run())}
+      onMouseDown={handleStrike}
+      onClick={onKeyActivate(handleStrike)}
       style="text-decoration: line-through; min-width: 30px;"
     />
     <ToolbarButton
@@ -215,7 +259,8 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
       shortcut="Ctrl+E"
       disabled={isDisabled}
       active={isActiveCode}
-      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleCode().run())}
+      onMouseDown={handleCode}
+      onClick={onKeyActivate(handleCode)}
       style="font-family: monospace; min-width: 30px;"
     />
 
@@ -232,10 +277,16 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
         label={headingLabel}
         disabled={isDisabled}
         active={activeHeading !== null}
+        ariaHasPopup="menu"
+        ariaExpanded={showHeadingMenu}
         onMouseDown={(e: MouseEvent) => {
           e.preventDefault();
           showHeadingMenu = !showHeadingMenu;
         }}
+        onClick={onKeyActivate((e: MouseEvent) => {
+          e.preventDefault();
+          showHeadingMenu = !showHeadingMenu;
+        })}
         style="min-width: 30px;"
       />
       {#if showHeadingMenu}
@@ -248,10 +299,13 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
             gap: 2px; z-index: var(--tandem-z-dropdown); box-shadow: var(--tandem-shadow-1);"
         >
           {#each HEADING_LEVELS as level (level)}
+            {@const headingHandler = handleHeadingToggle(level)}
             <button
               type="button"
-              role="menuitem"
-              onmousedown={handleHeadingToggle(level)}
+              role="menuitemradio"
+              aria-checked={activeHeading === level}
+              onmousedown={headingHandler}
+              onclick={onKeyActivate(headingHandler)}
                 style="padding: 4px 12px; font-size: 13px; border: none;
                 border-radius: var(--tandem-r-2);
                 background: {activeHeading === level ? 'var(--tandem-accent-bg)' : 'transparent'};
@@ -273,7 +327,8 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
       shortcut="Ctrl+Shift+8"
       disabled={isDisabled}
       active={isActiveBulletList}
-      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleBulletList().run())}
+      onMouseDown={handleBulletList}
+      onClick={onKeyActivate(handleBulletList)}
       style="min-width: 30px; padding: 4px 6px;"
     >
       {#snippet children()}
@@ -292,7 +347,8 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
       shortcut="Ctrl+Shift+7"
       disabled={isDisabled}
       active={isActiveOrderedList}
-      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleOrderedList().run())}
+      onMouseDown={handleOrderedList}
+      onClick={onKeyActivate(handleOrderedList)}
       style="min-width: 30px; padding: 4px 6px;"
     >
       {#snippet children()}
@@ -311,7 +367,8 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
       shortcut="Ctrl+Shift+B"
       disabled={isDisabled}
       active={isActiveBlockquote}
-      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleBlockquote().run())}
+      onMouseDown={handleBlockquote}
+      onClick={onKeyActivate(handleBlockquote)}
       style="min-width: 30px; padding: 4px 6px;"
     >
       {#snippet children()}
@@ -339,7 +396,10 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
         shortcut="Ctrl+K"
         disabled={linkDisabled}
         active={isActiveLink || showLinkInput}
+        ariaHasPopup="dialog"
+        ariaExpanded={showLinkInput}
         onMouseDown={handleLinkMouseDown}
+        onClick={onKeyActivate(handleLinkMouseDown)}
         style="min-width: 30px; padding: 4px 6px;"
       >
         {#snippet children()}
@@ -375,6 +435,7 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
             type="button"
             data-testid="toolbar-link-submit"
             onmousedown={(e) => { e.preventDefault(); submitLinkInput(); }}
+            onclick={onKeyActivate((e) => { e.preventDefault(); submitLinkInput(); })}
             style="height: 26px; padding: 0 8px; font-size: 12px; font-weight: 500;
               border: 1px solid var(--tandem-accent-border); background: transparent;
               color: var(--tandem-accent); border-radius: var(--tandem-r-2); cursor: pointer;
@@ -384,6 +445,7 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
             type="button"
             data-testid="toolbar-link-cancel"
             onmousedown={(e) => { e.preventDefault(); dismissLinkInput(); }}
+            onclick={onKeyActivate((e) => { e.preventDefault(); dismissLinkInput(); })}
             style="height: 26px; padding: 0 8px; font-size: 12px; font-weight: 500;
               border: 1px solid var(--tandem-border); background: transparent;
               color: var(--tandem-fg-muted); border-radius: var(--tandem-r-2); cursor: pointer;"
@@ -395,14 +457,16 @@ function handleLinkInputKeyDown(e: KeyboardEvent) {
       label="—"
       ariaLabel="Horizontal rule"
       disabled={isDisabled}
-      onMouseDown={withPreventDefault(() => editor.chain().focus().setHorizontalRule().run())}
+      onMouseDown={handleHorizontalRule}
+      onClick={onKeyActivate(handleHorizontalRule)}
       style="min-width: 30px;"
     />
     <ToolbarButton
       ariaLabel="Code block"
       disabled={isDisabled}
       active={isActiveCodeBlock}
-      onMouseDown={withPreventDefault(() => editor.chain().focus().toggleCodeBlock().run())}
+      onMouseDown={handleCodeBlock}
+      onClick={onKeyActivate(handleCodeBlock)}
       style="min-width: 30px; padding: 4px 6px;"
     >
       {#snippet children()}

--- a/src/client/editor/toolbar/ToolbarButton.svelte
+++ b/src/client/editor/toolbar/ToolbarButton.svelte
@@ -15,6 +15,12 @@ interface Props {
   onMouseDown?: (e: MouseEvent) => void;
   onClick?: (e: MouseEvent) => void;
   style?: string;
+  /** For dropdown-trigger buttons: set to "menu" or "dialog" to advertise
+   *  the popup type to assistive technology. */
+  ariaHasPopup?: "menu" | "listbox" | "tree" | "grid" | "dialog";
+  /** For dropdown-trigger buttons: reflects whether the controlled popup
+   *  is currently expanded. Paired with ariaHasPopup. */
+  ariaExpanded?: boolean;
 }
 
 const {
@@ -29,6 +35,8 @@ const {
   onMouseDown,
   onClick,
   style = "",
+  ariaHasPopup,
+  ariaExpanded,
 }: Props = $props();
 
 const computed = $derived.by(() => {
@@ -67,6 +75,8 @@ const fullStyle = $derived(
   {disabled}
   title={titleAttr}
   aria-label={ariaLabelValue}
+  aria-haspopup={ariaHasPopup}
+  aria-expanded={ariaExpanded}
   onmousedown={onMouseDown}
   onclick={onClick}
   style={fullStyle}

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -39,6 +39,21 @@ async function readOneLine(
 }
 
 /**
+ * Polls `counter()` until it returns >= `n` or `timeoutMs` elapses.
+ * Throws a descriptive error on timeout so CI output names the bottleneck.
+ * Decouples assertions from subprocess startup latency; mirrors the
+ * `waitForPosts` helper inside the per-request-timeout describe block.
+ */
+async function waitForCount(counter: () => number, n: number, timeoutMs = 15_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (counter() >= n) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`Only ${counter()}/${n} items reached threshold within ${timeoutMs}ms`);
+}
+
+/**
  * Read up to `n` newline-delimited JSON-RPC lines from child stdout.
  * Returns as soon as n lines arrive or timeoutMs elapses (in which case
  * it resolves with whatever arrived — callers assert on the count).
@@ -480,12 +495,11 @@ describe("mcp-stdio error synthesis on upstream unavailability", () => {
       child.stdin.write(`${JSON.stringify(makeRequest(101))}\n`);
       child.stdin.write(`${JSON.stringify(makeRequest(102))}\n`);
 
-      // Poll until all three POSTs reach the server (preflight + drain must complete first).
-      for (let i = 0; i < 100; i++) {
-        if (heldResponses.length >= 3) break;
-        await new Promise((r) => setTimeout(r, 50));
-      }
-      expect(heldResponses.length).toBeGreaterThanOrEqual(3);
+      // Poll until all three POSTs reach the server (preflight + drain must
+      // complete first). 15s budget survives heavy CPU load (e.g. concurrent
+      // cargo compile); readLines below uses its own 10s budget, total ~25s
+      // well within the 30s test timeout.
+      await waitForCount(() => heldResponses.length, 3, 15_000);
 
       // Destroy all held responses to trigger forwardToUpstream.catch for each.
       for (const r of heldResponses) r.destroy();


### PR DESCRIPTION
Fixes #875 and #876.

## Issue #875 — de-flake mcp-stdio concurrent-pending test

The test "synthesizes -32000 for multiple concurrent pending requests on mid-session upstream death" was flaky under CPU starvation (e.g. concurrent `cargo test` compile). The root cause: it polled `heldResponses.length >= 3` for only 100×50ms = 5 seconds. When the machine is saturated, tsx/Node startup exceeds that window and 0 requests arrive, causing `expected 0 to be greater than or equal to 3`.

**Fix:**
- Add module-level `waitForCount(counter, n, timeoutMs)` helper alongside `readOneLine`/`readLines`, mirroring the `waitForPosts` pattern already used in the per-request-timeout describe block
- Replace the bare `for` loop + `expect` assertion with `await waitForCount(() => heldResponses.length, 3, 15_000)` — 3× longer window (15s vs 5s), throws a descriptive error naming the bottleneck on timeout
- `readLines` after still has its own 10s budget; total max ~25s well within the 30s test timeout

## Issue #876 — keyboard activation for FormattingToolbar buttons

`FormattingToolbar`'s buttons bound only `onMouseDown={withPreventDefault(...)}` with no `onClick`, so Tab→Enter keyboard activation didn't work. This is a pre-existing gap in the formatting bar surface, and it became more important when the selection popup (`Toolbar.svelte`, variant="popup") was added that reuses `FormattingToolbar`.

**Fix:**
- Add `onKeyActivate()` helper (same `e.detail === 0` guard as `Toolbar.svelte`) — keyboard Enter/Space fires `click` with `detail === 0`, mouse click fires with `detail >= 1`, so no double-firing
- Hoist all 11 command handlers to `$derived` (prevents event-listener churn on every Tiptap transaction tick, mirrors `Toolbar.svelte` quality level)
- Add `onClick={onKeyActivate(handler)}` to all 12 `ToolbarButton` instances: Undo, Redo, Bold, Italic, Strike, Code, Heading toggle, BulletList, OrderedList, Blockquote, HorizontalRule, CodeBlock
- Add `onclick={onKeyActivate(...)}` to heading menu items and link Apply/Cancel popup buttons
- **ARIA improvements** (pre-existing gaps, now more important since keyboard users can reach these controls):
  - Heading menu items: `role="menuitemradio"` + `aria-checked={activeHeading === level}` (was `role="menuitem"` with no active-state signal for screen readers)
  - Heading toggle button: `ariaHasPopup="menu"` + `ariaExpanded={showHeadingMenu}`
  - Link button: `ariaHasPopup="dialog"` + `ariaExpanded={showLinkInput}`
- Use `{@const headingHandler = handleHeadingToggle(level)}` in `#each` to share one closure per item (avoids double allocation)
- **`ToolbarButton.svelte`**: add `ariaHasPopup?: "menu" | "listbox" | "tree" | "grid" | "dialog"` and `ariaExpanded?: boolean` optional props, forwarded to `aria-haspopup` / `aria-expanded` on the native `<button>`

## Testing
- `npm test`: 2897 tests across 213 files — all pass
- `npm run typecheck`: 0 errors, 0 warnings
- `cargo test`: all pass

https://claude.ai/code/session_01Vogr4J21eHHHa5rPxajXCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vogr4J21eHHHa5rPxajXCZ)_