### PR TITLE
feat(settings): inline hint for margin view when rails are open (#723)

### DIFF
--- a/src/client/components/SettingsPopover.svelte
+++ b/src/client/components/SettingsPopover.svelte
@@ -589,6 +589,12 @@ function aboutRows() {
               />
               <span>Margin annotation view (Word-style)</span>
             </label>
+            <div
+              data-testid="margin-view-hint"
+              style="font-size: 10px; color: var(--tandem-fg-subtle);"
+            >
+              Margin columns appear where rails are collapsed — open rails hide that side.
+            </div>
             {#if isTauriRuntime()}
               {#await import("./CoworkSettings.svelte")}
                 <div

--- a/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
+++ b/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
@@ -247,6 +247,12 @@ function handleReset() {
   />
   <span>Margin annotation view (Word-style)</span>
 </label>
+<div
+  data-testid="settings-modal-margin-view-hint"
+  style="font-size: 10px; color: var(--tandem-fg-subtle);"
+>
+  Margin columns appear where rails are collapsed — open rails hide that side.
+</div>
 
 {#if wdLoaded && !hasIntegration && lastLoadError}
   <div


### PR DESCRIPTION
## Summary
Adds an inline hint under the "Margin annotation view" toggle in both settings surfaces so it's no longer surprising that toggling margin view on while a rail is open only shows one margin column.

- `SettingsPopover.svelte` — hint with `data-testid="margin-view-hint"`
- `settings-tabs/SettingsClaudeCodeTab.svelte` — hint with `data-testid="settings-modal-margin-view-hint"`
- Hint copy: "Margin columns appear where rails are collapsed — open rails hide that side."
- Uses the existing inline subtle-text pattern with `var(--tandem-fg-subtle)` (no raw hex; passes token lint).

Purely additive, no behavior change.

Closes #723

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoQKJNSChBhZ4HALEFnuTy)_