### PR TITLE
feat(annotations): export annotations as sidecar file next to document (#314)

### DIFF
--- a/src/server/file-io/docx.ts
+++ b/src/server/file-io/docx.ts
@@ -30,21 +30,25 @@ export async function loadDocx(content: Buffer): Promise<string> {
  * Includes a text snippet from the document for context.
  */
 export function exportAnnotations(doc: Y.Doc, annotations: Annotation[]): string {
-  if (annotations.length === 0) {
+  // Defense-in-depth (ADR-027): notes are user-private and must never appear in
+  // an export, regardless of what the caller passes. The MCP tool already
+  // filters them out, but this function is privacy-safe on its own.
+  const visible = annotations.filter((a) => a.type !== "note");
+  if (visible.length === 0) {
     return "# Document Review\n\nNo annotations found.";
   }
 
   const fragment = doc.getXmlFragment("default");
   const fullText = extractFullText(fragment);
 
-  // Group by derived category using field presence, not raw type
-  type GroupKey = "highlights" | "comments" | "suggestions" | "notes";
+  // Group by derived category using field presence, not raw type.
+  // Notes are already filtered out above (ADR-027), so there is no notes group.
+  type GroupKey = "highlights" | "comments" | "suggestions";
   const groups: Partial<Record<GroupKey, Annotation[]>> = {};
-  for (const ann of annotations) {
+  for (const ann of visible) {
     let key: GroupKey;
     if (ann.type === "highlight") key = "highlights";
     else if (ann.suggestedText !== undefined) key = "suggestions";
-    else if (ann.type === "note") key = "notes";
     else key = "comments";
     if (!groups[key]) groups[key] = [];
     groups[key]?.push(ann);
@@ -56,10 +60,9 @@ export function exportAnnotations(doc: Y.Doc, annotations: Annotation[]): string
     highlights: "Highlights",
     comments: "Comments",
     suggestions: "Suggestions",
-    notes: "Notes",
   };
 
-  const groupOrder: GroupKey[] = ["highlights", "comments", "suggestions", "notes"];
+  const groupOrder: GroupKey[] = ["highlights", "comments", "suggestions"];
 
   for (const key of groupOrder) {
     const anns = groups[key];

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -30,6 +30,7 @@ import { acceptPending, dismissPending } from "../annotations/lifecycle.js";
 import { relaySanitizationEvent } from "../annotations/migration-log.js";
 import { nextRev } from "../annotations/schema.js";
 import { exportAnnotations } from "../file-io/docx.js";
+import { atomicWrite } from "../file-io/index.js";
 import { pushNotification } from "../notifications.js";
 import { anchoredRange, refreshAllRanges } from "../positions.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
@@ -620,30 +621,47 @@ export function registerAnnotationTools(server: McpServer): void {
 
   server.tool(
     "tandem_exportAnnotations",
-    "Export all annotations as a formatted summary. Useful for review reports, especially on read-only .docx files.",
+    "Export all annotations as a formatted summary. Useful for review reports, especially on read-only .docx files. Set writeToDisk:true to additionally write a sharable sidecar file (e.g. `<doc>.annotations.json`) next to the document.",
     {
       format: ExportFormatSchema.optional().describe("Output format (default: markdown)"),
       documentId: z
         .string()
         .optional()
         .describe("Target document ID (defaults to active document)"),
+      writeToDisk: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, write the export to a sidecar file next to the document so it can be shared/backed up. Defaults to <docPath>.annotations.json (or .annotations.md for markdown). Overwrites any existing sidecar.",
+        ),
+      outputPath: z
+        .string()
+        .optional()
+        .describe(
+          "Custom absolute path for the sidecar file (only used when writeToDisk is true). Defaults to <docPath>.annotations.{json|md}.",
+        ),
     },
-    withErrorBoundary("tandem_exportAnnotations", async ({ format, documentId }) => {
-      const da = getDocAndAnnotations(documentId);
-      if (!da) return noDocumentError();
+    withErrorBoundary(
+      "tandem_exportAnnotations",
+      async ({ format, documentId, writeToDisk, outputPath }) => {
+        const da = getDocAndAnnotations(documentId);
+        if (!da) return noDocumentError();
 
-      const annotations = refreshAllRanges(
-        collectAnnotations(da.map, da.docHash),
-        da.ydoc,
-        da.map,
-      ).map((r) => r.annotation);
-      // Notes are user-private (ADR-027) — exclude from exports.
-      const exportable = annotations.filter((a) => a.type !== "note");
-      const { ydoc } = da;
+        const annotations = refreshAllRanges(
+          collectAnnotations(da.map, da.docHash),
+          da.ydoc,
+          da.map,
+        ).map((r) => r.annotation);
+        // Notes are user-private (ADR-027) — exclude from exports.
+        const exportable = annotations.filter((a) => a.type !== "note");
+        const { ydoc, filePath } = da;
 
-      const repliesMap = getRepliesMap(ydoc);
+        const repliesMap = getRepliesMap(ydoc);
 
-      if (format === "json") {
+        // Build the enriched JSON list up-front. It is derived from the already
+        // note-filtered `exportable` and is the ONLY annotation collection
+        // serialized to disk, so user-private notes (ADR-027) can never leak
+        // into the sidecar.
         const fullText = extractText(ydoc);
         const enriched = exportable.map((ann) => ({
           ...ann,
@@ -654,12 +672,49 @@ export function registerAnnotationTools(server: McpServer): void {
             Math.min(fullText.length, ann.range.to),
           ),
         }));
-        return mcpSuccess({ annotations: enriched, count: enriched.length });
-      }
 
-      const markdown = exportAnnotations(ydoc, exportable);
-      return mcpSuccess({ markdown, count: exportable.length });
-    }),
+        const isJson = format === "json";
+        // The markdown summary is computed once and reused for both the
+        // response and (when requested) the sidecar — no double work.
+        const markdown = isJson ? undefined : exportAnnotations(ydoc, exportable);
+
+        // Sidecar write (#314): persist a sharable export next to the document.
+        let writtenPath: string | undefined;
+        if (writeToDisk) {
+          // `upload://` (and scratchpad `upload://scratchpad/...`) paths are
+          // synthetic — there is no stable filesystem location to write next to.
+          if (filePath.startsWith("upload://")) {
+            return mcpError(
+              "INVALID_PATH",
+              "Cannot write an annotation sidecar for an uploaded or scratchpad document — it has no file on disk. Save the document to a real path first.",
+            );
+          }
+
+          // Overwrite-on-collision is intentional: the sidecar mirrors the
+          // current annotation state, so a stale copy should be replaced.
+          const sidecarPath = outputPath ?? `${filePath}.annotations.${isJson ? "json" : "md"}`;
+          const contents = isJson
+            ? JSON.stringify({ annotations: enriched, count: enriched.length }, null, 2)
+            : (markdown ?? "");
+          await atomicWrite(sidecarPath, contents);
+          writtenPath = sidecarPath;
+        }
+
+        if (isJson) {
+          return mcpSuccess({
+            annotations: enriched,
+            count: enriched.length,
+            ...(writtenPath ? { writtenPath } : {}),
+          });
+        }
+
+        return mcpSuccess({
+          markdown,
+          count: exportable.length,
+          ...(writtenPath ? { writtenPath } : {}),
+        });
+      },
+    ),
   );
 
   server.tool(

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as Y from "yjs";
 import { z } from "zod";
@@ -692,7 +693,15 @@ export function registerAnnotationTools(server: McpServer): void {
 
           // Overwrite-on-collision is intentional: the sidecar mirrors the
           // current annotation state, so a stale copy should be replaced.
-          const sidecarPath = outputPath ?? `${filePath}.annotations.${isJson ? "json" : "md"}`;
+          // Resolve + reject UNC paths to match the rest of the file-writing
+          // MCP surface (convert.ts / document-service.ts) — Windows NTLM
+          // hardening; never write to a `\\host\share` path.
+          const sidecarPath = path.resolve(
+            outputPath ?? `${filePath}.annotations.${isJson ? "json" : "md"}`,
+          );
+          if (sidecarPath.startsWith("\\\\") || sidecarPath.startsWith("//")) {
+            return mcpError("INVALID_PATH", "UNC paths are not supported for security reasons.");
+          }
           const contents = isJson
             ? JSON.stringify({ annotations: enriched, count: enriched.length }, null, 2)
             : (markdown ?? "");

--- a/tests/server/docx.test.ts
+++ b/tests/server/docx.test.ts
@@ -347,7 +347,7 @@ describe("exportAnnotations", () => {
     expect(result).toContain("No annotations found");
   });
 
-  it("exports notes under the Notes group heading", () => {
+  it("excludes notes entirely (ADR-027 defense-in-depth)", () => {
     loadHtml("<p>Hello world test content</p>");
 
     const annotations: Annotation[] = [
@@ -359,9 +359,36 @@ describe("exportAnnotations", () => {
       }),
     ];
 
+    // A list of only notes is treated as empty — notes are user-private and
+    // must never appear in an export, regardless of the caller.
     const result = exportAnnotations(doc, annotations);
-    expect(result).toContain("## Notes");
-    expect(result).toContain("Personal reminder");
+    expect(result).not.toContain("## Notes");
+    expect(result).not.toContain("Personal reminder");
+    expect(result).toContain("No annotations found");
+  });
+
+  it("filters out notes even when mixed with visible annotations", () => {
+    loadHtml("<p>Hello world test content</p>");
+
+    const annotations: Annotation[] = [
+      makeAnnotation({
+        id: "c1",
+        type: "comment",
+        range: { from: 0, to: 5 },
+        content: "Public comment",
+      }),
+      makeAnnotation({
+        id: "n1",
+        type: "note",
+        range: { from: 6, to: 11 },
+        content: "Private reminder",
+      }),
+    ];
+
+    const result = exportAnnotations(doc, annotations);
+    expect(result).toContain("Public comment");
+    expect(result).not.toContain("Private reminder");
+    expect(result).not.toContain("## Notes");
   });
 
   it("generates markdown grouped by type", () => {

--- a/tests/server/mcp-tool-integration.test.ts
+++ b/tests/server/mcp-tool-integration.test.ts
@@ -6,11 +6,14 @@
  * mcpSuccess/mcpError response formatting.
  */
 
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { beforeEach, describe, expect, it } from "vitest";
-import { registerAnnotationTools } from "../../src/server/mcp/annotations.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAnnotation, registerAnnotationTools } from "../../src/server/mcp/annotations.js";
 import { registerAwarenessTools, resetInbox } from "../../src/server/mcp/awareness.js";
 import { populateYDoc, registerDocumentTools } from "../../src/server/mcp/document.js";
 import { extractMarkdown, extractText } from "../../src/server/mcp/document-model.js";
@@ -29,8 +32,10 @@ import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import { MCP_ORIGIN } from "../../src/shared/origins.js";
 import type { Annotation } from "../../src/shared/types.js";
+import { rangeOf } from "../helpers/ydoc-factory.js";
 
 let client: Client;
+const sidecarTempFiles: string[] = [];
 
 async function setupMcpClient(): Promise<Client> {
   const server = new McpServer({ name: "tandem-test", version: "0.0.1" });
@@ -56,6 +61,21 @@ function setupDoc(id: string, text: string) {
   const ydoc = getOrCreateDocument(id);
   populateYDoc(ydoc, text);
   addDoc(id, { id, filePath: `/tmp/${id}.md`, format: "md", readOnly: false, source: "file" });
+  setActiveDocId(id);
+  return ydoc;
+}
+
+/** Register a doc at an explicit filePath (used for sidecar-export disk writes). */
+function setupDocAtPath(id: string, text: string, filePath: string, source = "file") {
+  const ydoc = getOrCreateDocument(id);
+  populateYDoc(ydoc, text);
+  addDoc(id, {
+    id,
+    filePath,
+    format: "md",
+    readOnly: false,
+    source: source as "file" | "upload",
+  });
   setActiveDocId(id);
   return ydoc;
 }
@@ -325,6 +345,136 @@ describe("MCP tool integration — annotation tools", () => {
     expect(filteredParsed.data.annotations.every((a: Annotation) => a.author === "import")).toBe(
       true,
     );
+  });
+});
+
+describe("MCP tool integration — tandem_exportAnnotations sidecar write (#314)", () => {
+  afterEach(async () => {
+    for (const f of sidecarTempFiles.splice(0)) {
+      await fs.rm(f, { force: true });
+    }
+  });
+
+  function uniqueDocPath(): string {
+    return join(tmpdir(), `tandem-export-${Date.now()}-${Math.random().toString(36).slice(2)}.md`);
+  }
+
+  it("writes a JSON sidecar next to the document and omits notes (ADR-027)", async () => {
+    const docPath = uniqueDocPath();
+    const sidecarPath = `${docPath}.annotations.json`;
+    sidecarTempFiles.push(sidecarPath);
+
+    const ydoc = setupDocAtPath("mcp-export-json", "Hello world test content", docPath);
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+
+    // A Claude comment (should appear) and a user-private note (must NOT appear).
+    createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "A public comment");
+    createAnnotation(map, ydoc, "note", rangeOf(6, 11, ydoc), "A private reminder");
+
+    const result = await client.callTool({
+      name: "tandem_exportAnnotations",
+      arguments: { format: "json", writeToDisk: true },
+    });
+    const parsed = parseResult(result);
+    expect(parsed.error).toBe(false);
+    expect(parsed.data.writtenPath).toBe(sidecarPath);
+    // Response itself excludes the note.
+    expect(parsed.data.count).toBe(1);
+
+    const raw = await fs.readFile(sidecarPath, "utf-8");
+    // The note content must be entirely absent from the on-disk sidecar.
+    expect(raw).not.toContain("A private reminder");
+    expect(raw).toContain("A public comment");
+
+    const onDisk = JSON.parse(raw);
+    expect(onDisk.count).toBe(1);
+    expect(onDisk.annotations).toHaveLength(1);
+    expect(onDisk.annotations[0].type).toBe("comment");
+    expect(onDisk.annotations.some((a: Annotation) => a.type === "note")).toBe(false);
+  });
+
+  it("writes a markdown sidecar with the .annotations.md extension", async () => {
+    const docPath = uniqueDocPath();
+    const sidecarPath = `${docPath}.annotations.md`;
+    sidecarTempFiles.push(sidecarPath);
+
+    const ydoc = setupDocAtPath("mcp-export-md", "Hello world test content", docPath);
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "A public comment");
+    createAnnotation(map, ydoc, "note", rangeOf(6, 11, ydoc), "A private reminder");
+
+    const result = await client.callTool({
+      name: "tandem_exportAnnotations",
+      arguments: { writeToDisk: true },
+    });
+    const parsed = parseResult(result);
+    expect(parsed.error).toBe(false);
+    expect(parsed.data.writtenPath).toBe(sidecarPath);
+
+    const raw = await fs.readFile(sidecarPath, "utf-8");
+    expect(raw).toContain("# Document Review");
+    expect(raw).toContain("A public comment");
+    expect(raw).not.toContain("A private reminder");
+  });
+
+  it("honors a custom outputPath", async () => {
+    const docPath = uniqueDocPath();
+    const customPath = join(
+      tmpdir(),
+      `tandem-custom-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    sidecarTempFiles.push(customPath);
+
+    const ydoc = setupDocAtPath("mcp-export-custom", "Hello world", docPath);
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "Custom path comment");
+
+    const result = await client.callTool({
+      name: "tandem_exportAnnotations",
+      arguments: { format: "json", writeToDisk: true, outputPath: customPath },
+    });
+    const parsed = parseResult(result);
+    expect(parsed.error).toBe(false);
+    expect(parsed.data.writtenPath).toBe(customPath);
+    const raw = await fs.readFile(customPath, "utf-8");
+    expect(raw).toContain("Custom path comment");
+  });
+
+  it("rejects writeToDisk for upload:// (and scratchpad) documents", async () => {
+    const ydoc = setupDocAtPath(
+      "mcp-export-upload",
+      "Hello world",
+      "upload://abc123/uploaded.md",
+      "upload",
+    );
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "Some comment");
+
+    const result = await client.callTool({
+      name: "tandem_exportAnnotations",
+      arguments: { format: "json", writeToDisk: true },
+    });
+    const parsed = parseResult(result);
+    expect(parsed.error).toBe(true);
+    expect(parsed.code).toBe("INVALID_PATH");
+  });
+
+  it("does not write a sidecar when writeToDisk is omitted", async () => {
+    const docPath = uniqueDocPath();
+    const sidecarPath = `${docPath}.annotations.json`;
+
+    const ydoc = setupDocAtPath("mcp-export-nodisk", "Hello world", docPath);
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "A comment");
+
+    const result = await client.callTool({
+      name: "tandem_exportAnnotations",
+      arguments: { format: "json" },
+    });
+    const parsed = parseResult(result);
+    expect(parsed.error).toBe(false);
+    expect(parsed.data.writtenPath).toBeUndefined();
+    await expect(fs.access(sidecarPath)).rejects.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary
Adds an opt-in way to write annotations to a sharable file next to the document.

- `tandem_exportAnnotations` (`src/server/mcp/annotations.ts`) gains optional `writeToDisk` and `outputPath` args. When `writeToDisk` is set, the export is written to `<docPath>.annotations.json` (or `.annotations.md` for markdown) via the existing `atomicWrite` helper; `outputPath` overrides the location. Overwrites on collision (documented in code).
- **ADR-027 privacy:** only the already note-filtered list is serialized, and `exportAnnotations()` (`src/server/file-io/docx.ts`) now filters `type === "note"` internally as defense-in-depth (dead "notes" render group removed).
- `upload://` and scratchpad (`upload://scratchpad/...`) paths return `INVALID_PATH` (no stable filesystem path).

## Test plan
- [x] `npm run typecheck` clean.
- [x] Updated `docx.test.ts` (notes-excluded + mixed-list) and added 5 end-to-end sidecar-write tests in `mcp-tool-integration.test.ts`, including an assertion that a `note` annotation is absent from the written sidecar.
- [ ] CI `check` job shares a pre-existing flaky failure on `master` (docx fixture + ReDoS timing), unrelated to this change.

Closes #314

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoQKJNSChBhZ4HALEFnuTy)_