### PR TITLE
fix(hooks): strip CRs from jq stdout on Windows (#882 follow-up)

### DIFF
--- a/.claude/hooks/track-workflow-events.sh
+++ b/.claude/hooks/track-workflow-events.sh
@@ -31,8 +31,10 @@ STATE_DIR=$(_ws_state_dir "$SESSION_ID")
 # the same order, newline-joined: tool_name, file_path (\\ -> /), skill,
 # command, exit_code.
 if command -v jq >/dev/null 2>&1; then
-  # esc replaces embedded newlines with SOH (\u0001), matching the node parser;
-  # the file_path branch additionally maps \\ -> / before the newline pass.
+  # esc replaces embedded newlines with SOH (\u0001) as a field-internal placeholder so
+  # each field stays on one line (an improvement over node's newline-stripping,
+  # which loses information). The file_path branch additionally maps \\ -> /
+  # before the newline pass.
   # exit_code mirrors node exactly: prefer .exit_code if it is a number, else
   # .exitCode if it is a number, else "" -- per-field number test (not `//`)
   # avoids picking a non-numeric .exit_code over a numeric .exitCode.
@@ -48,6 +50,13 @@ if command -v jq >/dev/null 2>&1; then
          else (.tool_response.exitCode | numstr) end)
     ] | join("\n")
   ' 2>/dev/null) || exit 0
+  # Windows-native jq (chocolatey build) opens stdout in text mode and emits
+  # CRLF separators. `mapfile -t` strips trailing \n but leaves \r on every
+  # field, so FIELDS[0] becomes "Bash\r" and the case match below never fires
+  # -- every workflow marker (last-source-edit, last-commit, etc.) goes
+  # unwritten on Windows. Strip CRs once here so the jq and node branches emit
+  # byte-identical output.
+  EXTRACTED=$(printf '%s' "$EXTRACTED" | tr -d '\r')
 else
   # Fallback parser when jq is unavailable. Identical field contract.
   EXTRACTED=$(printf '%s' "$INPUT" | node -e "


### PR DESCRIPTION
Follow-up to #882. The chocolatey-built jq on Windows opens stdout in text mode and emits CRLF, but `mapfile -t` only strips `\n`, leaving `\r` on every field. As a result `TOOL_NAME` became `"Bash\r"`, the `case` match never fired, and **every workflow marker (last-source-edit, last-commit, etc.) went unwritten on Windows** since #882 landed.

## Fix
Add `EXTRACTED=\$(printf '%s' "\$EXTRACTED" | tr -d '\r')` immediately after the jq invocation. Scoped to the jq branch (node fallback is unaffected); single strip point, no per-field repetition.

## Comment cleanup
The inline comment claimed the SOH (U+0001) escape "matches the node parser." That's inaccurate — the node fallback strips newlines entirely (`.replace(/\n/g, '')`), losing information; the jq version preserves them as SOH placeholders. Rewritten to describe what jq actually does.

## Verification
- `bash tests/hooks/test_workflow_state.sh` on Windows with chocolatey jq 1.8.1: **13/13 assertions passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)