### PR TITLE
chore(vite): pin dev server to :5173 with strictPort

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
   server: {
     host: "127.0.0.1",
     port: 5173,
+    strictPort: true,
     proxy: {
       "/ws": {
         target: "ws://127.0.0.1:3478",


### PR DESCRIPTION
## Summary
- Add `strictPort: true` to the Vite dev-server config so `:5173` conflicts fail loudly instead of silently bumping to `:5174`.
- Prevents the stale-`:5173` trap (lesson #835) where `cargo tauri dev` keeps loading the WebView against the original port while Vite quietly serves from a different one — which nearly masked the fix in #894 during manual verification.

## Test plan
- [ ] `npm run dev` with another Vite already on :5173 → exits with a port-in-use error (instead of starting on :5174).
- [ ] `cargo tauri dev` from a clean state still launches normally on :5173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)