### PR TITLE
fix(settings): drop seeded font defaults + a11y per-format radio groups (#887 follow-up)

### DIFF
--- a/src/client/components/AppearanceSettings.svelte
+++ b/src/client/components/AppearanceSettings.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { DEFAULT_FONT_BY_EXTENSION } from "../../shared/constants";
 import { createRadioGroup } from "../hooks/useRadioGroup.svelte";
 import type {
   Density,
@@ -29,9 +28,10 @@ const FONT_OPTIONS = [
 ] as const;
 
 // Effective per-format value shown as the active radio: user override wins,
-// else the built-in default. Mirrors `resolveFont`'s first two tiers.
+// else falls through to the global Editor Font setting. Matches the
+// post-#887 `resolveFont` contract — no seeded per-format defaults.
 function effectiveFontFor(format: string): EditorFont {
-  return settings.fontByExtension?.[format] ?? DEFAULT_FONT_BY_EXTENSION[format] ?? "sans";
+  return settings.fontByExtension?.[format] ?? settings.editorFont;
 }
 
 function setFontFor(format: string, font: EditorFont): void {
@@ -90,6 +90,18 @@ const densityRg = createRadioGroup<Density>(
   ["compact", "cozy", "spacious"] as const,
   (d) => onUpdate({ density: d }),
 );
+// Per-format font radio groups (#811). Each group is its own RG instance so
+// arrow-key navigation is scoped to one row at a time. `createRadioGroup`
+// querySelectorAll's `[role="radio"]` within the container — the radio
+// buttons below already carry that attribute (was missing before #887).
+const fontByExtensionRgs: Record<string, ReturnType<typeof createRadioGroup<EditorFont>>> = {};
+for (const row of FONT_FORMAT_ROWS) {
+  fontByExtensionRgs[row.format] = createRadioGroup<EditorFont>(
+    () => effectiveFontFor(row.format),
+    ["sans", "serif", "mono"] as const,
+    (f) => setFontFor(row.format, f),
+  );
+}
 </script>
 
 <!-- Theme -->
@@ -252,6 +264,8 @@ const densityRg = createRadioGroup<Density>(
         <div
           role="radiogroup"
           aria-label={`Default font for ${row.label}`}
+          tabindex="0"
+          onkeydown={fontByExtensionRgs[row.format].handleKeyDown}
           style="display: flex; gap: var(--tandem-space-2); flex: 1;"
         >
           {#each FONT_OPTIONS as [value, label] (value)}
@@ -259,6 +273,7 @@ const densityRg = createRadioGroup<Density>(
               data-testid={`font-by-extension-${row.format}-${value}`}
               role="radio"
               aria-checked={effectiveFontFor(row.format) === value}
+              tabindex={fontByExtensionRgs[row.format].tabIndexFor(value)}
               onclick={() => setFontFor(row.format, value)}
               style={cardStyle(effectiveFontFor(row.format) === value)}
             >

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_FONT_BY_EXTENSION,
   SELECTION_DWELL_DEFAULT_MS,
   SELECTION_DWELL_MAX_MS,
   SELECTION_DWELL_MIN_MS,
@@ -96,8 +95,9 @@ export interface TandemSettings {
   /**
    * Per-format editor-font overrides (#811). Keyed by the normalized document
    * `format` string (`md` / `docx` / `html` / `txt` — see `detectFormat`),
-   * NOT raw extensions. A present entry wins over `DEFAULT_FONT_BY_EXTENSION`,
-   * which in turn wins over the global `editorFont`. See `resolveFont`.
+   * NOT raw extensions. A present entry overrides the global `editorFont`;
+   * absence falls through to the global setting (no seeded default). See
+   * `resolveFont`.
    */
   fontByExtension: Partial<Record<string, EditorFont>>;
   density: Density;
@@ -332,8 +332,7 @@ function parseFontByExtension(raw: unknown): Partial<Record<string, EditorFont>>
  * v9→v10: introduce `fontByExtension: {}` (#811, per-format editor font).
  *   Structural no-op — `normalizeKnownFields` runs `parseFontByExtension` on
  *   whatever is present. Empty default preserves fresh-install behavior: with
- *   no override, `resolveFont` falls back to `DEFAULT_FONT_BY_EXTENSION` then
- *   the global `editorFont`.
+ *   no override, `resolveFont` falls back to the global `editorFont`.
  */
 export const CURRENT_SCHEMA_VERSION = 10;
 
@@ -646,15 +645,23 @@ export function mergeAndClampSettings(
 
 /**
  * Resolve the effective editor font for a document of the given normalized
- * `format` (`md` / `docx` / `html` / `txt` — see `detectFormat`). Resolution
- * order (#811):
+ * `format` (`md` / `docx` / `html` / `txt` — see `detectFormat`).
+ *
+ * Resolution (post-#811 follow-up): two tiers only.
  *
  *   1. Per-format user override (`settings.fontByExtension[format]`)
- *   2. Per-format default (`DEFAULT_FONT_BY_EXTENSION[format]`)
- *   3. Global setting (`settings.editorFont`)
+ *   2. Global setting (`settings.editorFont`)
  *
- * A `null`/`undefined` format (no active tab) skips straight to the global
- * setting so the root font is never undefined during a Y.Doc swap.
+ * The previous third tier — `DEFAULT_FONT_BY_EXTENSION[format]` — was
+ * removed. Seeded defaults silently overrode the user's global pick
+ * for un-customized formats: changing the global font in Settings did
+ * nothing for `.docx` / `.html` / `.txt` until the user also clicked
+ * through every per-format radio group. The new contract: the global
+ * setting is the true default; per-format overrides exist only where
+ * the user has explicitly chosen one.
+ *
+ * A `null`/`undefined` format (no active tab) skips straight to the
+ * global setting so the root font is never undefined during a Y.Doc swap.
  */
 export function resolveFont(
   settings: Pick<TandemSettings, "fontByExtension" | "editorFont">,
@@ -663,8 +670,6 @@ export function resolveFont(
   if (format) {
     const override = settings.fontByExtension?.[format];
     if (override) return override;
-    const def = DEFAULT_FONT_BY_EXTENSION[format];
-    if (def) return def;
   }
   return settings.editorFont;
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -7,25 +7,13 @@ export const TANDEM_ISSUES_NEW_URL = `${TANDEM_REPO_URL}/issues/new`;
 /** File extensions the server accepts for opening. */
 export const SUPPORTED_EXTENSIONS = new Set([".md", ".txt", ".html", ".htm", ".docx"]);
 
-/**
- * Default editor font per normalized document format (#811).
- *
- * Keys are the format strings produced by `detectFormat` (which already
- * collapses extensions: `.markdown`→`md`, `.htm`→`html`), NOT raw file
- * extensions. Values are {@link EditorFont} keys. A format absent from this
- * map falls back to the global `editorFont` setting via `resolveFont`.
- *
- *   .md / .markdown → sans
- *   .docx           → serif
- *   .html / .htm    → sans
- *   .txt            → mono
- */
-export const DEFAULT_FONT_BY_EXTENSION: Record<string, "serif" | "sans" | "mono"> = {
-  md: "sans",
-  docx: "serif",
-  html: "sans",
-  txt: "mono",
-};
+// DEFAULT_FONT_BY_EXTENSION removed as a #887 follow-up: seeded defaults
+// silently overrode the user's global editor-font choice for un-customized
+// formats (changing Settings > Editor Font did nothing for .docx / .html /
+// .txt until the user clicked every per-format radio group). The global
+// setting is now the true default; `fontByExtension` is a sparse
+// user-overrides map.
+
 export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 export const SESSION_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
 export const TYPING_DEBOUNCE = 3000; // 3 seconds

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -428,32 +428,40 @@ describe("useTandemSettings — updateSettings write path", () => {
   });
 });
 
-describe("resolveFont — per-format resolution order (#811)", () => {
+describe("resolveFont — per-format resolution order (post-#887)", () => {
   const base = { editorFont: "sans" as const, fontByExtension: {} };
 
   it("falls back to the global editorFont for an unknown format", () => {
     expect(resolveFont({ ...base, editorFont: "mono" }, "rtf")).toBe("mono");
   });
 
-  it("uses the per-format default when no override is set", () => {
-    // DEFAULT_FONT_BY_EXTENSION: docx → serif, txt → mono, md/html → sans.
-    expect(resolveFont(base, "docx")).toBe("serif");
-    expect(resolveFont(base, "txt")).toBe("mono");
+  it("falls through to the global editorFont when no per-format override is set", () => {
+    // #887 follow-up: seeded DEFAULT_FONT_BY_EXTENSION removed. Every format
+    // without an explicit user override resolves to the global setting,
+    // including the ones the old map seeded (docx/txt/md/html).
+    expect(resolveFont(base, "docx")).toBe("sans");
+    expect(resolveFont(base, "txt")).toBe("sans");
     expect(resolveFont(base, "md")).toBe("sans");
     expect(resolveFont(base, "html")).toBe("sans");
   });
 
-  it("prefers a per-format user override over the default", () => {
-    expect(resolveFont({ ...base, fontByExtension: { docx: "mono" } }, "docx")).toBe("mono");
+  it("the global editorFont actually changes resolution for all formats", () => {
+    // Regression test for the silent-default bug: previously, switching the
+    // global font to "mono" did nothing for docx/txt/md/html.
+    const mono = { ...base, editorFont: "mono" as const };
+    expect(resolveFont(mono, "docx")).toBe("mono");
+    expect(resolveFont(mono, "txt")).toBe("mono");
+    expect(resolveFont(mono, "md")).toBe("mono");
+    expect(resolveFont(mono, "html")).toBe("mono");
+  });
+
+  it("prefers a per-format user override over the global setting", () => {
+    expect(resolveFont({ ...base, fontByExtension: { docx: "serif" } }, "docx")).toBe("serif");
   });
 
   it("falls back to the global setting when format is null/undefined", () => {
     expect(resolveFont({ ...base, editorFont: "serif" }, null)).toBe("serif");
     expect(resolveFont({ ...base, editorFont: "serif" }, undefined)).toBe("serif");
-  });
-
-  it("fresh install: md still resolves to sans (preserves prior behavior)", () => {
-    expect(resolveFont({ editorFont: "sans", fontByExtension: {} }, "md")).toBe("sans");
   });
 });
 


### PR DESCRIPTION
Follow-up to #887.

## Problem 1: silent default override
`DEFAULT_FONT_BY_EXTENSION` seeded `md→sans, docx→serif, html→sans, txt→mono`. The global Editor Font was the THIRD tier — changing it did nothing for the four pre-seeded formats until the user also clicked every per-format radio group. Most users never discovered that.

**Fix:** delete `DEFAULT_FONT_BY_EXTENSION` and collapse `resolveFont` to two tiers — per-format override → global. Sparse `fontByExtension` now means "user explicit override only"; the global setting is the true default. Regression test confirms changing the global font changes docx/txt/md/html resolution.

## Problem 2: per-format radio groups had no keyboard nav
The four per-format radio groups had `role=\"radio\"` on the buttons but no `tabindex`, no `onkeydown`, no `createRadioGroup` wiring — keyboard users were stuck on whatever was focused.

**Fix:** one `createRadioGroup` per format row, wired identically to the other RGs in the file.

## Tests
- `tests/client/useTandemSettings.test.ts` updated: removes assertions of seeded defaults, adds the global-font-affects-everything regression test.
- 86/86 client settings tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)