### PR TITLE
fix(paste): graceful image/softbreak/html tokens + link href XSS guard (#885 follow-up)

### DIFF
--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -25,6 +25,7 @@ import { MarkdownHtmlExtension } from "./extensions/markdown-html";
 import { SelectionDecorationExtension } from "./extensions/selection-decoration";
 import { SlashCommandExtension } from "./slash-menu";
 import { markdownToSlice } from "./utils/markdown-paste";
+import { isSafeExternalHref } from "./utils/url-safety";
 import "./editor.css";
 
 import { SUPPORTED_EXTENSIONS } from "../../shared/constants.js";
@@ -32,18 +33,9 @@ import { SUPPORTED_EXTENSIONS } from "../../shared/constants.js";
 /** File extensions that open as new Tandem tabs when clicked as relative links. .docx excluded — not navigable as a link target. */
 const INTERNAL_LINK_EXTS = new Set([...SUPPORTED_EXTENSIONS].filter((e) => e !== ".docx"));
 
-/**
- * Whitelist of safe external href prefixes that we'll hand off to the default
- * browser via window.open. Anything not in this list and not a relative path
- * (e.g. `javascript:`, `data:`, `vbscript:`) is treated as unsafe and ignored —
- * preventDefault has already been called by the time we check this, so the
- * browser won't navigate.
- */
-const SAFE_EXTERNAL_PREFIXES = ["http://", "https://", "mailto:", "ftp://", "//"] as const;
-
-function isSafeExternalHref(href: string): boolean {
-  return SAFE_EXTERNAL_PREFIXES.some((p) => href.startsWith(p));
-}
+// SAFE_EXTERNAL_PREFIXES + isSafeExternalHref hoisted to ./utils/url-safety.ts
+// so the click-time anchor intercept and the paste-time link sanitizer share
+// one allowlist (any drift would silently widen the XSS trust surface).
 
 /**
  * Resolve a relative href against an absolute file path.

--- a/src/client/editor/utils/markdown-paste.ts
+++ b/src/client/editor/utils/markdown-paste.ts
@@ -18,19 +18,14 @@ import { Slice } from "@tiptap/pm/model";
 import MarkdownIt from "markdown-it";
 import type { ParseSpec } from "prosemirror-markdown";
 import { MarkdownParser } from "prosemirror-markdown";
+import { sanitizeHrefForPaste } from "./url-safety";
 
-// XSS-relevant URL schemes that must NEVER reach a link `href` (or any other
-// URL-receiving attribute) from pasted markdown. Even with `html: false`
-// blocking inline HTML, a markdown link target `[click me](javascript:...)`
-// would otherwise produce a clickable XSS payload inside the editor.
-const UNSAFE_LINK_SCHEMES = /^(?:javascript|data|vbscript):/i;
-
-function sanitizeHref(raw: string | null | undefined): string | null {
-  if (!raw) return null;
-  const trimmed = raw.trim();
-  if (UNSAFE_LINK_SCHEMES.test(trimmed)) return null;
-  return trimmed;
-}
+// Link-href sanitization uses the shared ALLOWLIST in ./url-safety.ts
+// (http://, https://, mailto:, ftp://, //, plus fragments and relative
+// paths). The Editor's click-time anchor intercept uses the same allowlist
+// via isSafeExternalHref — one source of truth means a new XSS-relevant
+// scheme rejected by the click-time check is automatically rejected at
+// paste time too (no drift between the two defense layers).
 
 /**
  * markdown-it token -> Tiptap schema entity map.
@@ -95,11 +90,11 @@ function buildTokenSpec(schema: Schema): { [name: string]: ParseSpec } {
     link: {
       mark: "link",
       getAttrs: (tok) => ({
-        // sanitizeHref rejects javascript:/data:/vbscript: schemes so a
-        // crafted markdown link can't smuggle an XSS payload through paste.
-        // `html: false` on the tokenizer is the inline-HTML guard; this is
-        // the link-target guard. Both are load-bearing.
-        href: sanitizeHref(tok.attrGet("href")),
+        // sanitizeHrefForPaste rejects any unknown scheme (allowlist-based)
+        // so a crafted markdown link can't smuggle an XSS payload through
+        // paste. `html: false` on the tokenizer is the inline-HTML guard;
+        // this is the link-target guard. Both are load-bearing.
+        href: sanitizeHrefForPaste(tok.attrGet("href")),
         title: tok.attrGet("title") || null,
       }),
     },

--- a/src/client/editor/utils/markdown-paste.ts
+++ b/src/client/editor/utils/markdown-paste.ts
@@ -19,14 +19,29 @@ import MarkdownIt from "markdown-it";
 import type { ParseSpec } from "prosemirror-markdown";
 import { MarkdownParser } from "prosemirror-markdown";
 
+// XSS-relevant URL schemes that must NEVER reach a link `href` (or any other
+// URL-receiving attribute) from pasted markdown. Even with `html: false`
+// blocking inline HTML, a markdown link target `[click me](javascript:...)`
+// would otherwise produce a clickable XSS payload inside the editor.
+const UNSAFE_LINK_SCHEMES = /^(?:javascript|data|vbscript):/i;
+
+function sanitizeHref(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (UNSAFE_LINK_SCHEMES.test(trimmed)) return null;
+  return trimmed;
+}
+
 /**
  * markdown-it token -> Tiptap schema entity map.
  *
  * Scope (per issue #788): paragraphs, headings, bold/italic/code/strike, links,
- * bullet/ordered lists, blockquotes, fenced code blocks. Tables and images are
- * intentionally NOT mapped — pasted table/image markdown falls through to the
- * inline-text content of their surrounding block, which is acceptable for this
- * scope and keeps us from depending on schema nodes that may not be present.
+ * bullet/ordered lists, blockquotes, fenced code blocks. Images, tables, and
+ * other unmapped block-level tokens are silently dropped via `ignore: true`
+ * (#885 follow-up). Without an explicit `ignore`, the prosemirror-markdown
+ * `MarkdownParser` throws `Token type 'image' not supported by parser` and the
+ * caller falls back to plain text — losing ALL the user's surrounding
+ * formatting just because the pasted snippet happens to mention an image.
  */
 function buildTokenSpec(schema: Schema): { [name: string]: ParseSpec } {
   const tokens: { [name: string]: ParseSpec } = {
@@ -54,6 +69,25 @@ function buildTokenSpec(schema: Schema): { [name: string]: ParseSpec } {
     },
     hr: { node: "horizontalRule" },
     hardbreak: { node: "hardBreak" },
+    // markdown-it emits softbreak for an in-paragraph line break in the
+    // source. There's no Tiptap equivalent (StarterKit collapses these to
+    // spaces during DOM serialization anyway); drop the token cleanly so it
+    // doesn't surface as an "unsupported token" parser error. `noCloseToken`
+    // is required because softbreak/html_inline/html_block/image are emitted
+    // as single tokens (no `_open`/`_close` pair) — without it,
+    // prosemirror-markdown would register `softbreak_open`/`_close` handlers
+    // that never fire and the bare `softbreak` token still throws.
+    softbreak: { ignore: true, noCloseToken: true },
+    // `html: false` causes markdown-it to emit raw HTML as text tokens — but
+    // some plugins still surface html_block/html_inline tokens for things
+    // like comments. Ignore them defensively so the parser doesn't throw.
+    html_block: { ignore: true, noCloseToken: true },
+    html_inline: { ignore: true, noCloseToken: true },
+    // Images are tokens, not text — without an explicit mapping the parser
+    // would throw. We ignore (drop alt text + URL) rather than addText
+    // because Tiptap's image node is optional in StarterKit and we don't
+    // want to depend on it being present.
+    image: { ignore: true, noCloseToken: true },
     em: { mark: "italic" },
     strong: { mark: "bold" },
     s: { mark: "strike" },
@@ -61,7 +95,11 @@ function buildTokenSpec(schema: Schema): { [name: string]: ParseSpec } {
     link: {
       mark: "link",
       getAttrs: (tok) => ({
-        href: tok.attrGet("href"),
+        // sanitizeHref rejects javascript:/data:/vbscript: schemes so a
+        // crafted markdown link can't smuggle an XSS payload through paste.
+        // `html: false` on the tokenizer is the inline-HTML guard; this is
+        // the link-target guard. Both are load-bearing.
+        href: sanitizeHref(tok.attrGet("href")),
         title: tok.attrGet("title") || null,
       }),
     },

--- a/src/client/editor/utils/url-safety.ts
+++ b/src/client/editor/utils/url-safety.ts
@@ -1,0 +1,79 @@
+// URL-safety helpers shared between the editor's click-time anchor intercept
+// and the markdown-paste link sanitizer. Both surfaces must agree on which
+// hrefs are safe; drifting copies would silently widen the XSS trust surface.
+//
+// Design: ALLOWLIST, not blocklist. A new attacker-friendly scheme appearing
+// in the wild (e.g. `filesystem:`, `view-source:`) is rejected by default.
+// Blocklists are the recurring source of url-sanitization CVEs.
+
+/**
+ * External hrefs we'll hand off to the system browser via `window.open`.
+ * Anything not matching one of these prefixes AND not a relative path/fragment
+ * (see {@link isSafeHrefForPaste}) is considered unsafe.
+ *
+ *   - `http://` / `https://` — standard web URLs.
+ *   - `mailto:` — email composer.
+ *   - `ftp://` — legacy but harmless to navigate.
+ *   - `//` — protocol-relative; browsers expand to the page's scheme.
+ *     Safe in the Tauri/Vite app where the page scheme is always http(s)
+ *     or tauri://.
+ *
+ * Explicitly NOT allowed: `javascript:`, `data:`, `vbscript:`, `file:`,
+ * `blob:`, `filesystem:`, `view-source:`, any future XSS-relevant scheme.
+ */
+export const SAFE_EXTERNAL_PREFIXES = ["http://", "https://", "mailto:", "ftp://", "//"] as const;
+
+/**
+ * True if `href` is safe to hand to `window.open` from the editor's anchor
+ * intercept. Case-insensitive scheme match (CommonMark allows `HTTPS://`).
+ *
+ * This is the click-time check — the user has clicked an anchor, and we have
+ * to decide whether to navigate. It does NOT cover relative paths or
+ * fragments; those are handled by the caller before reaching this check.
+ */
+export function isSafeExternalHref(href: string): boolean {
+  const lower = href.toLowerCase();
+  return SAFE_EXTERNAL_PREFIXES.some((p) => lower.startsWith(p));
+}
+
+/**
+ * Sanitize an href encountered at MARKDOWN PASTE time. Returns the trimmed
+ * href when safe, or `null` when it should be dropped.
+ *
+ * Safe inputs (returns trimmed href):
+ *   - any {@link SAFE_EXTERNAL_PREFIXES} match (case-insensitive)
+ *   - in-page fragments: `#section`
+ *   - relative paths: `./other.md`, `../other.md`, `subdir/file.md`
+ *   - root-relative paths: `/abs/path.md`
+ *
+ * Unsafe inputs (returns null):
+ *   - any unknown scheme: `javascript:`, `data:`, `vbscript:`, `file:`, etc.
+ *
+ * Detection rule for "has a scheme": there's a `:` BEFORE any `/`, `#`, or
+ * `?`. A leading `:` (degenerate) is also unsafe. Whitespace is trimmed
+ * before evaluation so `   javascript:alert(1)` is recognized.
+ */
+export function sanitizeHrefForPaste(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  // Allowlisted external schemes.
+  if (isSafeExternalHref(trimmed)) return trimmed;
+
+  // Fragment-only link.
+  if (trimmed.startsWith("#")) return trimmed;
+
+  // Relative or root-absolute path: no scheme delimiter ahead of the first
+  // path/query/fragment separator. If `:` appears AFTER `/`/`#`/`?` (e.g.
+  // a literal `:` inside a filename or query string), the prefix is path-like.
+  const firstColon = trimmed.indexOf(":");
+  if (firstColon === -1) return trimmed; // no colon → relative/root path
+  const firstPathSep = Math.min(
+    ...["/", "#", "?"].map((ch) => trimmed.indexOf(ch)).filter((idx) => idx !== -1),
+  );
+  if (Number.isFinite(firstPathSep) && firstPathSep < firstColon) return trimmed;
+
+  // Has a scheme prefix that isn't allowlisted → drop.
+  return null;
+}

--- a/tests/client/markdown-paste.test.ts
+++ b/tests/client/markdown-paste.test.ts
@@ -108,6 +108,57 @@ describe("markdownToSlice", () => {
     expect(href).toBe("https://example.com");
   });
 
+  // #885 follow-up: links with XSS-relevant schemes must never produce a
+  // clickable link in the editor. Either markdown-it's CommonMark URL
+  // validator drops the link token entirely (preferred — link mark never
+  // created) or our `sanitizeHref` returns null at attr-build time. Both
+  // outcomes are safe; assert no link mark carries the literal unsafe href.
+  it.each([
+    "javascript:alert(1)",
+    "JavaScript:alert(1)",
+    "data:text/html,x",
+    "vbscript:msgbox",
+  ])("blocks unsafe link scheme: %s", (href) => {
+    const doc = parseToDoc(`click [me](${href})`);
+    const observedHrefs: unknown[] = [];
+    doc.descendants((node) => {
+      const link = node.marks.find((m) => m.type.name === "link");
+      if (link) observedHrefs.push(link.attrs.href);
+    });
+    expect(observedHrefs.every((h) => h !== href && h !== href.toLowerCase())).toBe(true);
+  });
+
+  it("preserves a safe link href when adjacent to an unsafe one", () => {
+    const doc = parseToDoc("[good](https://example.com) and [bad](javascript:alert(1))");
+    const hrefs: unknown[] = [];
+    doc.descendants((node) => {
+      const link = node.marks.find((m) => m.type.name === "link");
+      if (link) hrefs.push(link.attrs.href);
+    });
+    expect(hrefs).toContain("https://example.com");
+    expect(hrefs.every((h) => h !== "javascript:alert(1)")).toBe(true);
+  });
+
+  // #885 follow-up: an image in pasted markdown used to throw an
+  // "unsupported token" parser error and fall back to plain text, losing
+  // ALL surrounding formatting. Now the image is silently dropped and
+  // the rest of the markdown converts normally.
+  it("drops embedded images without losing surrounding formatting", () => {
+    const slice = markdownToSlice(
+      "**bold** then ![alt](https://example.com/x.png) and a [link](https://example.com)",
+      schema,
+    );
+    expect(slice).not.toBeNull();
+    let sawBold = false;
+    let sawLink = false;
+    slice!.content.descendants((node) => {
+      if (node.marks.some((m) => m.type.name === "bold")) sawBold = true;
+      if (node.marks.some((m) => m.type.name === "link")) sawLink = true;
+    });
+    expect(sawBold).toBe(true);
+    expect(sawLink).toBe(true);
+  });
+
   it("converts bullet lists", () => {
     const doc = parseToDoc("- one\n- two\n- three");
     const list = doc.firstChild!;

--- a/tests/client/url-safety.test.ts
+++ b/tests/client/url-safety.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSafeExternalHref,
+  SAFE_EXTERNAL_PREFIXES,
+  sanitizeHrefForPaste,
+} from "../../src/client/editor/utils/url-safety";
+
+describe("SAFE_EXTERNAL_PREFIXES", () => {
+  it("matches the documented allowlist exactly", () => {
+    expect([...SAFE_EXTERNAL_PREFIXES]).toEqual(["http://", "https://", "mailto:", "ftp://", "//"]);
+  });
+});
+
+describe("isSafeExternalHref", () => {
+  it.each(SAFE_EXTERNAL_PREFIXES)("accepts %s prefix", (prefix) => {
+    expect(isSafeExternalHref(`${prefix}example.com`)).toBe(true);
+  });
+
+  it("is case-insensitive (CommonMark allows uppercase schemes)", () => {
+    expect(isSafeExternalHref("HTTPS://example.com")).toBe(true);
+    expect(isSafeExternalHref("MailTo:foo@bar.com")).toBe(true);
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "JavaScript:alert(1)",
+    "data:text/html,x",
+    "vbscript:msgbox",
+    "file:///etc/passwd",
+    "blob:https://example.com/uuid",
+    "filesystem:http://example.com/temporary/x",
+    "view-source:https://example.com",
+  ])("rejects unsafe scheme %s", (href) => {
+    expect(isSafeExternalHref(href)).toBe(false);
+  });
+
+  it("rejects relative paths (caller must handle these separately)", () => {
+    expect(isSafeExternalHref("./other.md")).toBe(false);
+    expect(isSafeExternalHref("#section")).toBe(false);
+    expect(isSafeExternalHref("/abs/path")).toBe(false);
+  });
+});
+
+describe("sanitizeHrefForPaste", () => {
+  it("returns null for null/undefined/empty", () => {
+    expect(sanitizeHrefForPaste(null)).toBeNull();
+    expect(sanitizeHrefForPaste(undefined)).toBeNull();
+    expect(sanitizeHrefForPaste("")).toBeNull();
+    expect(sanitizeHrefForPaste("   ")).toBeNull();
+  });
+
+  it("accepts every allowlisted external prefix", () => {
+    expect(sanitizeHrefForPaste("https://example.com")).toBe("https://example.com");
+    expect(sanitizeHrefForPaste("mailto:foo@bar.com")).toBe("mailto:foo@bar.com");
+    expect(sanitizeHrefForPaste("ftp://example.com")).toBe("ftp://example.com");
+    expect(sanitizeHrefForPaste("//example.com/x")).toBe("//example.com/x");
+  });
+
+  it("accepts in-page fragments", () => {
+    expect(sanitizeHrefForPaste("#section")).toBe("#section");
+  });
+
+  it("accepts relative paths (no scheme prefix)", () => {
+    expect(sanitizeHrefForPaste("./other.md")).toBe("./other.md");
+    expect(sanitizeHrefForPaste("../up/file.md")).toBe("../up/file.md");
+    expect(sanitizeHrefForPaste("subdir/file.md")).toBe("subdir/file.md");
+    expect(sanitizeHrefForPaste("/abs/path.md")).toBe("/abs/path.md");
+  });
+
+  it("trims whitespace before evaluation", () => {
+    expect(sanitizeHrefForPaste("  https://example.com  ")).toBe("https://example.com");
+    // Leading whitespace doesn't sneak a bad scheme past the allowlist.
+    expect(sanitizeHrefForPaste("   javascript:alert(1)")).toBeNull();
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "JavaScript:alert(1)",
+    "data:text/html,x",
+    "vbscript:msgbox",
+    "file:///etc/passwd",
+    "blob:https://example.com/uuid",
+    "filesystem:http://example.com/temporary/x",
+    "view-source:https://example.com",
+  ])("rejects unsafe scheme: %s", (href) => {
+    expect(sanitizeHrefForPaste(href)).toBeNull();
+  });
+
+  it("accepts a path with a colon AFTER the first / (not a scheme)", () => {
+    // e.g. a query string or filename with a colon — not a URL scheme.
+    expect(sanitizeHrefForPaste("/path/to/file?x:1")).toBe("/path/to/file?x:1");
+    expect(sanitizeHrefForPaste("/dir#anchor:with:colons")).toBe("/dir#anchor:with:colons");
+  });
+
+  it("rejects a bare leading colon", () => {
+    expect(sanitizeHrefForPaste(":alert(1)")).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #885. Three correctness/security fixes for markdown paste.

## Bug 1 — entire paste falls back to plain text on common markdown
Pasting markdown that contained an image, an inline-HTML comment, or even a single in-paragraph line break (softbreak) used to throw `Token type 'X' not supported by parser`. The outer try/catch swallowed the error and the **entire** paste degraded to plain text — losing all the user's surrounding bold/list/heading formatting.

**Fix:** add `{ ignore: true, noCloseToken: true }` entries for `image`, `softbreak`, `html_block`, `html_inline`. `noCloseToken` is load-bearing — markdown-it emits these as single tokens, so without it prosemirror-markdown registers `_open`/`_close` handlers that never fire and the bare token still throws.

## Bug 2 — link target XSS
`html: false` blocks inline `<script>`/`<a onclick>` markup but did nothing to a markdown link `[click me](javascript:alert(1))` — paste-driven XSS.

**Fix:** sanitize link `href` before it reaches the link mark.

## Refactor (post-/simplify review) — unify URL safety into a shared allowlist
The first iteration of the href sanitizer used a narrow **blocklist** (`javascript:`, `data:`, `vbscript:`), but `Editor.svelte`'s click-time anchor intercept already used an **allowlist** (`SAFE_EXTERNAL_PREFIXES = http:// https:// mailto: ftp:// //`). Two surfaces, two drifting trust contracts — the click-time guard would catch `file:` / `blob:` / `filesystem:` / `view-source:` but the paste sanitizer would let them through.

Extracted both into `src/client/editor/utils/url-safety.ts`:
- `isSafeExternalHref(href)` — case-insensitive scheme allowlist (consumed by Editor.svelte's anchor intercept).
- `sanitizeHrefForPaste(raw)` — allows the same allowlist + fragments + relative/root paths, rejects everything else. "Has a scheme" detection treats a `:` as a scheme delimiter only when it appears before any `/`/`#`/`?` (so `/dir?x:1` is correctly path-like).

One source of truth for URL safety across the editor.

## Tests
- 21 markdown-paste assertions still green: image-mixed-with-bold/link no longer falls back to plain text; 4 parametrized scheme assertions + 1 mixed-link assertion confirm unsafe hrefs are blocked.
- 31 new url-safety unit tests cover the allowlist (every prefix, case-insensitive), fragments, relative paths, whitespace trimming, bare-colon rejection, and previously-uncovered schemes (`file:`, `blob:`, `filesystem:`, `view-source:`).
- Total 52/52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)