### PR TITLE
fix(doctor): unify JSON schemas + reject unknown flags (#884 follow-up)

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -21,7 +21,18 @@ import { join } from "node:path";
 const WS_PORT = 3478;
 const MCP_PORT = 3479;
 
-const JSON_MODE = process.argv.slice(2).includes("--json");
+// Argument parsing. The only recognized flag is --json; reject anything else
+// up-front so a typo like `--jsoon` doesn't silently produce TTY output that
+// the calling script can't parse. (Helpful when wiring doctor into CI or
+// editor extensions that depend on JSON for tooling.)
+const cliArgs = process.argv.slice(2);
+const unknownArgs = cliArgs.filter((arg) => arg !== "--json");
+if (unknownArgs.length > 0) {
+  console.error(`tandem doctor: unknown argument(s): ${unknownArgs.join(", ")}`);
+  console.error(`Usage: npm run doctor [--json]`);
+  process.exit(2);
+}
+const JSON_MODE = cliArgs.includes("--json");
 
 // ── Result recording ────────────────────────────────────────────────
 //
@@ -533,11 +544,16 @@ async function main() {
         : warnings > 0
           ? `${warnings} warning(s) — Tandem should work, but check the items above.`
           : "All checks passed. Tandem is ready.";
+    // Success-path JSON shape — kept identical to the crash-path doc below
+    // (same keys, same order) so consumers can parse one schema regardless
+    // of outcome. `crashed: false` is the success discriminant.
     const doc = {
       ok: failures === 0,
+      crashed: false,
       failures,
       warnings,
       summary,
+      error: null,
       results,
     };
     console.log(JSON.stringify(doc, null, 2));
@@ -563,7 +579,25 @@ main().catch((err) => {
     // can parse a result; details still go to stderr.
     console.error(`\n  Tandem Doctor crashed unexpectedly: ${err.message}`);
     console.error("  Please report this at https://github.com/bloknayrb/tandem/issues\n");
-    console.log(JSON.stringify({ ok: false, crashed: true, error: err.message, results }, null, 2));
+    // Mirror the success-path schema so JSON consumers see ONE shape with
+    // `crashed` as the discriminator — no missing/extra keys to special-case.
+    // `results ?? []` defends against a hypothetical future reassignment;
+    // the module-level `const` makes it always-defined today.
+    console.log(
+      JSON.stringify(
+        {
+          ok: false,
+          crashed: true,
+          failures,
+          warnings,
+          summary: `Tandem Doctor crashed unexpectedly: ${err.message}`,
+          error: err.message,
+          results: results ?? [],
+        },
+        null,
+        2,
+      ),
+    );
     process.exit(2);
   }
   console.error(`\n  Tandem Doctor crashed unexpectedly: ${err.message}`);


### PR DESCRIPTION
Follow-up to #884.

## Reject unknown CLI flags
Previously, \`tandem doctor --jsoon\` (typo) silently fell back to TTY mode while the calling script waited for JSON — surfaces as a confusing parse error downstream. Argv is now validated up-front; unknown flags print a clean error and exit 2.

## Unify success and crash JSON schemas
Before, success emitted \`{ok, failures, warnings, summary, results}\` and crash emitted \`{ok, crashed, error, results}\`. Consumers had to special-case which keys to look for. Now both shapes share the same key set with \`crashed\` as the discriminator and \`error: null\` on the success path. Crash path also fills failures/warnings/summary with safe values so the schema is regular.

\`results ?? []\` defends against a hypothetical future reassignment; the module-level \`const\` keeps it always-defined today.

## Smoke
- \`node scripts/doctor.mjs --json\` → new unified shape.
- \`node scripts/doctor.mjs --jsoon\` → exit 2, clean error.
- \`node scripts/doctor.mjs\` → TTY printer unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)