### PR TITLE
test(documents): cover dirty.ts race-handling + lifecycle (#890 follow-up)

### DIFF
--- a/tests/server/documents-dirty.test.ts
+++ b/tests/server/documents-dirty.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import {
+  clearDirtyState,
+  isDirty,
+  markClean,
+  markCleanIfUnchanged,
+  registerDirtyObserver,
+  resetForTesting,
+  snapshotDirtyVersion,
+} from "../../src/server/documents/dirty.js";
+
+afterEach(() => {
+  resetForTesting();
+});
+
+function attachAndEdit(docId: string, doc: Y.Doc, text: string): void {
+  const fragment = doc.getXmlFragment("default");
+  const p = new Y.XmlElement("paragraph");
+  p.insert(0, [new Y.XmlText(text)]);
+  fragment.insert(fragment.length, [p]);
+  void docId;
+}
+
+describe("dirty.ts — observer + version", () => {
+  it("starts clean before any edits", () => {
+    const docId = "doc-a";
+    const doc = new Y.Doc();
+    registerDirtyObserver(docId, doc);
+    expect(isDirty(docId)).toBe(false);
+  });
+
+  it("marks dirty when the body fragment changes", () => {
+    const docId = "doc-b";
+    const doc = new Y.Doc();
+    registerDirtyObserver(docId, doc);
+    attachAndEdit(docId, doc, "hello");
+    expect(isDirty(docId)).toBe(true);
+  });
+
+  it("annotation-map writes do NOT mark the doc dirty", () => {
+    // Critical Rule: dirty observes the body XmlFragment only — annotations,
+    // awareness, savedAtVersion meta, and ctrl-room writes must not trigger
+    // an autosave.
+    const docId = "doc-c";
+    const doc = new Y.Doc();
+    registerDirtyObserver(docId, doc);
+    doc.getMap("annotations").set("ann-1", { id: "ann-1" });
+    expect(isDirty(docId)).toBe(false);
+  });
+});
+
+describe("dirty.ts — race handling", () => {
+  it("markCleanIfUnchanged with unchanged snapshot clears the dirty flag", () => {
+    const docId = "doc-d";
+    const doc = new Y.Doc();
+    registerDirtyObserver(docId, doc);
+    attachAndEdit(docId, doc, "edit");
+    const snap = snapshotDirtyVersion(docId);
+    expect(isDirty(docId)).toBe(true);
+
+    const cleared = markCleanIfUnchanged(docId, snap);
+    expect(cleared).toBe(true);
+    expect(isDirty(docId)).toBe(false);
+  });
+
+  it("markCleanIfUnchanged with a stale snapshot leaves the doc dirty", () => {
+    // The whole point of the snapshot/compare-on-clean dance is to avoid the
+    // lost-update race: an edit that lands DURING the disk write must keep
+    // the doc dirty so the next autosave pass picks it up.
+    const docId = "doc-e";
+    const doc = new Y.Doc();
+    registerDirtyObserver(docId, doc);
+    attachAndEdit(docId, doc, "first");
+    const snap = snapshotDirtyVersion(docId);
+
+    // Simulate a concurrent edit landing during the (hypothetical) async write.
+    attachAndEdit(docId, doc, "second");
+
+    const cleared = markCleanIfUnchanged(docId, snap);
+    expect(cleared).toBe(false);
+    expect(isDirty(docId)).toBe(true);
+  });
+
+  it("markClean unconditionally clears the flag at the current version", () => {
+    const docId = "doc-f";
+    const doc = new Y.Doc();
+    registerDirtyObserver(docId, doc);
+    attachAndEdit(docId, doc, "edit-1");
+    attachAndEdit(docId, doc, "edit-2");
+    expect(isDirty(docId)).toBe(true);
+
+    markClean(docId);
+    expect(isDirty(docId)).toBe(false);
+  });
+});
+
+describe("dirty.ts — lifecycle", () => {
+  it("re-registering the observer on a swapped Y.Doc preserves dirty state", () => {
+    // Hocuspocus replaces the Y.Doc instance on swap (see ADR / provider.ts).
+    // The dirty-version must NOT reset across the swap, or an edited doc that
+    // reconnects would silently lose its pending-save flag.
+    const docId = "doc-g";
+    const docA = new Y.Doc();
+    registerDirtyObserver(docId, docA);
+    attachAndEdit(docId, docA, "before-swap");
+    expect(isDirty(docId)).toBe(true);
+
+    const docB = new Y.Doc();
+    registerDirtyObserver(docId, docB);
+    expect(isDirty(docId)).toBe(true);
+  });
+
+  it("clearDirtyState detaches and drops tracking entirely", () => {
+    const docId = "doc-h";
+    const doc = new Y.Doc();
+    registerDirtyObserver(docId, doc);
+    attachAndEdit(docId, doc, "edit");
+    clearDirtyState(docId);
+
+    // After clear, even further edits don't show up (no observer attached).
+    attachAndEdit(docId, doc, "post-clear");
+    expect(isDirty(docId)).toBe(false);
+  });
+
+  it("isDirty returns false for an unknown docId", () => {
+    expect(isDirty("never-registered")).toBe(false);
+  });
+});

--- a/tests/server/documents-dirty.test.ts
+++ b/tests/server/documents-dirty.test.ts
@@ -14,12 +14,11 @@ afterEach(() => {
   resetForTesting();
 });
 
-function attachAndEdit(docId: string, doc: Y.Doc, text: string): void {
+function attachAndEdit(doc: Y.Doc, text: string): void {
   const fragment = doc.getXmlFragment("default");
   const p = new Y.XmlElement("paragraph");
   p.insert(0, [new Y.XmlText(text)]);
   fragment.insert(fragment.length, [p]);
-  void docId;
 }
 
 describe("dirty.ts — observer + version", () => {
@@ -34,7 +33,7 @@ describe("dirty.ts — observer + version", () => {
     const docId = "doc-b";
     const doc = new Y.Doc();
     registerDirtyObserver(docId, doc);
-    attachAndEdit(docId, doc, "hello");
+    attachAndEdit(doc, "hello");
     expect(isDirty(docId)).toBe(true);
   });
 
@@ -55,7 +54,7 @@ describe("dirty.ts — race handling", () => {
     const docId = "doc-d";
     const doc = new Y.Doc();
     registerDirtyObserver(docId, doc);
-    attachAndEdit(docId, doc, "edit");
+    attachAndEdit(doc, "edit");
     const snap = snapshotDirtyVersion(docId);
     expect(isDirty(docId)).toBe(true);
 
@@ -71,11 +70,11 @@ describe("dirty.ts — race handling", () => {
     const docId = "doc-e";
     const doc = new Y.Doc();
     registerDirtyObserver(docId, doc);
-    attachAndEdit(docId, doc, "first");
+    attachAndEdit(doc, "first");
     const snap = snapshotDirtyVersion(docId);
 
     // Simulate a concurrent edit landing during the (hypothetical) async write.
-    attachAndEdit(docId, doc, "second");
+    attachAndEdit(doc, "second");
 
     const cleared = markCleanIfUnchanged(docId, snap);
     expect(cleared).toBe(false);
@@ -86,8 +85,8 @@ describe("dirty.ts — race handling", () => {
     const docId = "doc-f";
     const doc = new Y.Doc();
     registerDirtyObserver(docId, doc);
-    attachAndEdit(docId, doc, "edit-1");
-    attachAndEdit(docId, doc, "edit-2");
+    attachAndEdit(doc, "edit-1");
+    attachAndEdit(doc, "edit-2");
     expect(isDirty(docId)).toBe(true);
 
     markClean(docId);
@@ -103,7 +102,7 @@ describe("dirty.ts — lifecycle", () => {
     const docId = "doc-g";
     const docA = new Y.Doc();
     registerDirtyObserver(docId, docA);
-    attachAndEdit(docId, docA, "before-swap");
+    attachAndEdit(docA, "before-swap");
     expect(isDirty(docId)).toBe(true);
 
     const docB = new Y.Doc();
@@ -115,11 +114,11 @@ describe("dirty.ts — lifecycle", () => {
     const docId = "doc-h";
     const doc = new Y.Doc();
     registerDirtyObserver(docId, doc);
-    attachAndEdit(docId, doc, "edit");
+    attachAndEdit(doc, "edit");
     clearDirtyState(docId);
 
     // After clear, even further edits don't show up (no observer attached).
-    attachAndEdit(docId, doc, "post-clear");
+    attachAndEdit(doc, "post-clear");
     expect(isDirty(docId)).toBe(false);
   });
 


### PR DESCRIPTION
Follow-up to #890. The dirty-tracking module that gates autosave shipped without direct unit coverage — \`tests/server/dirty-state.test.ts\` only exercised the \`Y_MAP_SAVED_AT_VERSION\` baseline. The race-handling logic (\`snapshotDirtyVersion\` + \`markCleanIfUnchanged\`) was implicit-tested only through full-stack autosave runs.

## What this adds
9 focused cases in a new \`tests/server/documents-dirty.test.ts\`:

**Observer + version**
- Pre-edit document is clean.
- Body-fragment edits mark dirty.
- Annotation-map writes do NOT mark dirty (the body-only contract).

**Race handling**
- \`markCleanIfUnchanged\` with the same snapshot clears.
- \`markCleanIfUnchanged\` with a stale snapshot keeps dirty (lost-update guard — the whole point of the snapshot dance).
- \`markClean\` unconditionally clears at current version.

**Lifecycle**
- Re-registering the observer on a swapped Y.Doc preserves dirty state — Hocuspocus's \`onLoadDocument\` replaces the Y.Doc instance, and the version counter must NOT reset.
- \`clearDirtyState\` detaches the observer and drops tracking.
- \`isDirty\` returns false for unknown docIds.

All 9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)