### PR TITLE
fix(browse-file): narrow error catch and extract runtime branch

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -90,7 +90,7 @@ import FormattingBar from "./shell/FormattingBar.svelte";
 import TitleBar from "./shell/TitleBar.svelte";
 import StatusBar from "./status/StatusBar.svelte";
 import DocumentTabs from "./tabs/DocumentTabs.svelte";
-import { browseNativeFile } from "./utils/browse-file";
+import { openFileForRuntime } from "./utils/browse-file";
 import { addRecentFile, loadRecentFiles, saveRecentFiles } from "./utils/recentFiles";
 import { openServerPath } from "./utils/server-paths";
 
@@ -327,24 +327,25 @@ if (import.meta.env.DEV) {
 let paletteOpen = $state(false);
 let fileOpenDialogOpen = $state(false);
 
-// In the desktop app, open files via the native OS picker directly. The
-// browser distribution has no native picker, so it falls back to the
-// FileOpenDialog modal (HTML upload + recent + browse).
-async function requestOpenFile() {
-  if (isTauriRuntime()) {
-    await browseNativeFile({
-      onError: (message) =>
-        notifications.push({
-          id: generateNotificationId(),
-          type: "general-error",
-          severity: "error",
-          message,
-          timestamp: Date.now(),
-        }),
-    });
-  } else {
-    fileOpenDialogOpen = true;
-  }
+// Open-file action: native picker in Tauri, FileOpenDialog modal in the
+// browser distribution. Error surfacing is owned by `openFileForRuntime` /
+// `browseNativeFile` via the `onError` callback; void callers can fire-and-
+// forget safely.
+function requestOpenFile(): Promise<void> {
+  return openFileForRuntime({
+    isTauri: isTauriRuntime(),
+    openModal: () => {
+      fileOpenDialogOpen = true;
+    },
+    onError: (message) =>
+      notifications.push({
+        id: generateNotificationId(),
+        type: "general-error",
+        severity: "error",
+        message,
+        timestamp: Date.now(),
+      }),
+  });
 }
 
 // Issue #660 — titlebar settings-icon update-available dot. Acknowledged

--- a/src/client/utils/browse-file.ts
+++ b/src/client/utils/browse-file.ts
@@ -27,20 +27,49 @@ export async function pickNativeFilePath(): Promise<string | null> {
  * record it in the recent-files list. Errors are surfaced through `onError`
  * (the caller decides how — e.g. a toast) since this runs fire-and-forget from
  * the tab menu / shortcut, with no modal to host inline error text.
+ *
+ * The try/catch is scoped to `pickNativeFilePath()` because that's the only
+ * call that can throw a true "plugin unavailable" failure. `openServerPath`
+ * returns `{ok:false}` cleanly; `saveRecentFiles` / `loadRecentFiles` swallow
+ * localStorage errors internally. Scoping keeps the "File picker unavailable"
+ * label factually accurate.
  */
 export async function browseNativeFile(
   opts: { onError?: (message: string) => void } = {},
 ): Promise<void> {
+  let selected: string | null;
   try {
-    const selected = await pickNativeFilePath();
-    if (!selected) return;
-    const result = await openServerPath(selected);
-    if (!result.ok) {
-      opts.onError?.(result.error);
-      return;
-    }
-    saveRecentFiles(addRecentFile(loadRecentFiles(), selected));
+    selected = await pickNativeFilePath();
   } catch (err) {
+    console.error("[tandem] native file picker unavailable:", err);
     opts.onError?.(`File picker unavailable: ${err instanceof Error ? err.message : err}`);
+    return;
+  }
+  if (!selected) return;
+  const result = await openServerPath(selected);
+  if (!result.ok) {
+    opts.onError?.(result.error);
+    return;
+  }
+  saveRecentFiles(addRecentFile(loadRecentFiles(), selected));
+}
+
+/**
+ * Runtime-branching open-file action: Tauri uses the native picker;
+ * the browser distribution falls back to a host-supplied modal opener.
+ *
+ * Extracted from App.svelte so the branch logic is unit-testable without a
+ * component mount. The host passes `isTauri` (typically `isTauriRuntime()`)
+ * and an `openModal` callback that flips its own modal state.
+ */
+export async function openFileForRuntime(deps: {
+  isTauri: boolean;
+  openModal: () => void;
+  onError?: (message: string) => void;
+}): Promise<void> {
+  if (deps.isTauri) {
+    await browseNativeFile({ onError: deps.onError });
+  } else {
+    deps.openModal();
   }
 }

--- a/tests/client/browse-file.test.ts
+++ b/tests/client/browse-file.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { browseNativeFile } from "../../src/client/utils/browse-file.js";
+import { browseNativeFile, openFileForRuntime } from "../../src/client/utils/browse-file.js";
 import { loadRecentFiles } from "../../src/client/utils/recentFiles.js";
 import * as serverPaths from "../../src/client/utils/server-paths.js";
 import { RECENT_FILES_KEY } from "../../src/shared/constants.js";
@@ -89,5 +89,41 @@ describe("browseNativeFile (Tauri native picker)", () => {
 
     expect(onError).toHaveBeenCalledWith(expect.stringContaining("File picker unavailable"));
     expect(vi.mocked(serverPaths.openServerPath)).not.toHaveBeenCalled();
+  });
+});
+
+describe("openFileForRuntime (runtime branch)", () => {
+  beforeEach(() => {
+    vi.mocked(serverPaths.openServerPath).mockReset();
+    try {
+      window.localStorage.removeItem(RECENT_FILES_KEY);
+    } catch {
+      // ignore
+    }
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Tauri branch: calls the native picker, does not open the modal", async () => {
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    vi.mocked(open).mockResolvedValue(null);
+    const openModal = vi.fn();
+
+    await openFileForRuntime({ isTauri: true, openModal });
+
+    expect(vi.mocked(open)).toHaveBeenCalledOnce();
+    expect(openModal).not.toHaveBeenCalled();
+  });
+
+  it("browser branch: opens the modal, does not call the native picker", async () => {
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    const openModal = vi.fn();
+
+    await openFileForRuntime({ isTauri: false, openModal });
+
+    expect(openModal).toHaveBeenCalledOnce();
+    expect(vi.mocked(open)).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to merged PR #894. Addresses two Medium findings + one test-gap from the post-merge `/pr-review-toolkit:review-pr` pass, after three plan-reviewing agents converged on the right shape.

- **Narrow `browseNativeFile`'s try/catch** to wrap only `pickNativeFilePath()`. The wide catch was mislabeling any unrelated throw as "File picker unavailable"; in practice `openServerPath` returns `{ok:false}` cleanly and `recentFiles` helpers already guard `localStorage` internally, so the narrow scope is faithful to what can actually throw. `console.warn` → `console.error` since this is a user-visible failure.
- **Extract `requestOpenFile`'s runtime branch** to `openFileForRuntime` in `browse-file.ts`. App.svelte becomes a thin wrapper; the Tauri-vs-browser fork is now unit-testable without component mount, which closes the rated-6 test gap the reviewer flagged.
- **Dropped** the proposed App.svelte outer try/catch — two reviewers independently flagged it as defensive theater with a double-toast risk if `notifications.push` itself throws.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run tests/client/browse-file.test.ts` — 6/6 pass (4 existing + 2 new branch tests)
- [ ] Manual: Ctrl+O in desktop dev build still opens native picker
- [ ] Manual: "+" menu "Browse files…" still opens native picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)