### PR TITLE
feat(margin-view): cubic-bezier leaders + per-author anchor dots (Stage C-3)

### DIFF
--- a/docs/plans/2026-05-28-stage-c-cleave-locks.md
+++ b/docs/plans/2026-05-28-stage-c-cleave-locks.md
@@ -1,0 +1,138 @@
+# Stage C cleave locks — Phase 3.5 (post-review)
+
+> **Status:** scoping crystallized. Per-stage detailed plans (C-3 first) follow this doc.
+> **Branch:** `feat/design-system-impl` umbrella → Stage C sub-PRs.
+> **Inputs that produced these locks:**
+> - PR #909 (Stages A+B shipped) — 2 review rounds, all findings addressed.
+> - 4-agent adversarial review of the original Stage C scoping note (CRDT, Svelte, annotation-model, architecture).
+> - advisor() reconcile call — locked the synthesis, added 3 cheap pre-C-3 checks (all executed: see "Pre-C-3 checks" below).
+> - Plan §12 review-hardened constraints C1–C14.
+>
+> The original plan at `~/.claude/plans/the-current-way-we-compiled-thimble.md` §9 specified A / B / C / D as four sub-PRs. The "C" envelope is too big for one PR; this doc locks the C-internal split.
+
+## Reordered stage envelopes
+
+C is split into three independently-shippable sub-PRs. **Order: C-3 → C-1 → C-2.**
+The original C-1 → C-2 → C-3 sequence was rejected because:
+
+- C-3 (bezier leaders + anchor dots) is the highest-visibility win and couples to NOTHING downstream — it ships against today's `effectivelyOn` boolean.
+- C-1's proposed "throwaway single-track render path" is unnecessary: `MarginColumn.svelte:207` already calls the dispatcher today. C-1 just threads `density` as a prop with default `'full'` matching today's behavior.
+- C-2 is the largest review surface and benefits from landing AFTER mode + leader infrastructure are stable.
+
+### C-3 — Bezier leaders + anchor dots + atomic X/Y reads (smallest, first)
+
+**Scope:**
+
+- Replace `MarginColumn.svelte:153-177`'s straight `<line>` leaders with cubic-bezier `<path>` elements.
+- Add `<circle>` anchor dots at the text-edge endpoint.
+- Extend `useMarginPositions` to return `{byId: ReadonlyMap<id, {top: number, anchorX: number}>}` written from ONE `recompute()` body — replaces the existing vertical-only return shape. Sibling `useMarginAnchorsX` hook is REJECTED (one-frame X/Y desync, violates §10 anchor-jitter rule).
+- ~~Anchor dot color is **per-side, not per-bubble** (per advisor): one stroke color per SVG, matches the leader stroke.~~ **REVERSED 2026-05-28 during C-3 plan review.** Bundle source (`MarginFrame.svelte:135-137`) is per-AUTHOR (`claude` / `user` / `fg-subtle`), not per-side. Per `feedback_bundle_vs_production` — stroke color is decoration AND carries authorship information per ADR-026 → bundle-faithful is correct. C-3 V2 plan uses per-element `data-tandem-author` + per-element color. Imports render with `--tandem-fg-subtle` (bundle's "other" branch), not as Claude orange.
+- The leader endpoint reads (text-track + margin-track `getBoundingClientRect()`) must execute on the SAME rAF tick as the vertical `layerTop` recompute (Plan §12 C9 — same-frame requirement).
+
+**Touch surface:**
+
+- `src/client/panels/MarginColumn.svelte` — bezier path generation + dot circles + SVG `overflow: visible`.
+- `src/client/hooks/useMarginPositions.svelte.ts` — return-shape extension + horizontal reads inside the existing `recompute()`.
+- `tests/client/marginPositions.test.ts` — anchor-x atomicity test (X+Y in same map entry).
+- Possibly `editor-stage.svelte.ts` — `bind:this` refs for text-track + margin-track if not already available (today the stage element is bound; the inner cells may need their own refs).
+
+**Estimated:** ~150–200 LOC, 2 core files + 1 test.
+
+**Why first:** zero coupling to Mode state. Ships visual delight (bezier curves are the dominant bundle aesthetic upgrade) without touching any of the downstream cleave decisions.
+
+### C-1 — Global Mode continuum + geometry table + density prop wire-up
+
+**Scope:**
+
+- Replace `effectivelyOn: boolean` with `Mode: 'full' | 'narrow' | 'stub' | 'off'` (single global, NOT per-side — fork-lock resolution, see "Resolved forks" below).
+- Pure helper `nextMode(prev, viewport, thresholds, hysteresis) → Mode` mirroring `nextNarrowSticky` (`editor-stage.svelte.ts:67-76`). Single `$state<Mode>`, single `$effect`, single helper.
+- Effect MUST include explicit last-value guard: `if (next === prev) return;` (Plan §12 C10 — `effect_update_depth_exceeded` prevention under `ResizeObserver` chatter).
+- Export `MARGIN_TRACK_GEOMETRY: Record<Mode, {column, inset, gap, reserve}>` (Plan §12 / CRDT review F3). Geometry invariant test: `column + inset + gap === reserve` per mode.
+- Grid template reads track widths from `MARGIN_TRACK_GEOMETRY[mode]`. MarginColumn's `width` / `edgeInset` / `gap` props read from the same constant. The constant is the single source of truth — drift impossible.
+- Thread `density?: Density = 'full'` as optional prop into `AnnotationCard.svelte` (backwards-compatible: 3 call sites verified at `MarginColumn.svelte:207`, `SidePanel.svelte:456`, `SidePanel.svelte:481`). C-1 itself does NOT change density behavior — `'full'` default matches today. C-2 implements the variants.
+- `MIN_EDITOR_WIDTH_PX` → ch-based stub→off floor (Plan §12 C6). The unit conversion happens OUTSIDE `narrowThresholdPx` — the pure helper stays numeric-in/numeric-out (CRDT review F6).
+- Restate the no-padding/no-border invariant in C-1 scope; extend the off→on→narrow→stub→off matrix E2E test (CRDT review F5).
+
+**Touch surface:**
+
+- `src/client/layout/editor-stage.svelte.ts` — Mode state + helper + `MARGIN_TRACK_GEOMETRY` + extended `stageLayerStyle`.
+- `src/client/panels/AnnotationCard.svelte` — `density?: Density = 'full'` prop (passes through unused in C-1).
+- `tests/client/editor-stage.test.ts` — `nextMode` pure-function tests + geometry-invariant test.
+- `tests/e2e/margin-view.spec.ts` — extended mode-cycle remount test.
+
+**Estimated:** ~250 LOC, 4 files.
+
+**Why second:** establishes the mode + geometry vocabulary that C-2 builds on. Behaviorally invisible by default (Mode 'full' = today's `effectivelyOn === true`); only the narrow-threshold split into narrow/stub bands is user-visible.
+
+### C-2 — Density variants on dispatcher
+
+**Scope:**
+
+- `density: Density` as a CLASS on the AnnotationCard root (`is-density-clamped` / `is-density-stub`), NOT a dispatch branch. Variants stay mounted (annotation review F2). CSS hides body / actions / etc. in stub/clamped modes.
+- Variant Svelte files (`CommentCard`, `NoteCard`, `SuggestionCard`, `HighlightCard`, `ImportedCard`) gain author-appropriate stub-label markup in a header slot. Per Plan §12 C13 stub-pill metadata surface: 6px author dot retained, per-row border-color from `cardTint` for status pip, hover/focus expands to full card before accept/dismiss.
+- `cardTint` keeps EXACTLY 6 branches (Plan §12 C13 — no 7th "stub" branch).
+- MarginColumn derives `density` per-bubble from `(mode, isActive, isEditing)`:
+  - `isEditing` ⇒ `'full'` (forces minimum density — Svelte review F2 + ReplyThreadOverlay must close on density→stub transition per annotation review F5).
+  - Otherwise: lookup in static table keyed on `(mode, isActive)`. NEVER reads `adjustedPositions` or `heights` (the density↔collision cycle is structurally rejected — CRDT F4 + Svelte F3).
+  - `ImportedCard` is never `'stub'` (annotation review F4 — batch-promote needs the body).
+- Stub-pill click uses the SAME `onClick` path that the dispatcher already forwards (Svelte review F6) → sets `activeAnnotationId` → density re-derives.
+- Keep `status === "pending"` filter at the dispatcher level (annotation review F3).
+
+**Touch surface:**
+
+- `AnnotationCard.svelte` + 5 variant cards + `MarginColumn.svelte` (density derivation) + `cardTint` definition + CSS.
+
+**Estimated:** ~250 LOC, 7+ files.
+
+**Why last:** largest review surface, fully unblocked once C-1 lands.
+
+## Resolved forks
+
+### Global Mode, not per-side (architecture F1)
+
+Decision 3 — "stub triggered by viewport width alone, not collision pressure" — is GLOBAL by nature. With no per-side asymmetry source, `leftMode === rightMode` always holds. The only proposed per-side asymmetry was "density → collision pressure → mode," which was independently rejected on cycle grounds. Therefore: `Mode` is global; `leftMode` / `rightMode` enum is YAGNI.
+
+Future Stage E (issue #917) is the durable home for re-splitting if a real per-side asymmetry need ever surfaces.
+
+### Single $effect, not two (CRDT F2 + Svelte F1 converge)
+
+Mode transitions: ONE `$state<Mode>`, ONE `$effect`, ONE pure helper. Mirrors today's `nextNarrowSticky` pattern. Two independent per-side `$effect`s would multiply `effect_update_depth_exceeded` surface area and gain nothing (global mode renders per-side redundant anyway).
+
+### Extend `useMarginPositions`, don't sibling-hook (CRDT F1)
+
+> **REVERSED 2026-05-28 during C-3 plan review.** Primary source (`docs/design-system-impl/bundle/extracted/c4-margin-column/MarginFrame.svelte:97`) shows the bundle's leader endpoints derive X from `doc.getBoundingClientRect().right` — the text-container's right edge, a GEOMETRIC column-X, not a glyph-X from `coordsAtPos`. With column-X endpoints, neither hook-extension nor sibling-hook is needed: leader X is a per-side geometric constant (already today's `editorX` at `MarginColumn.svelte:68`). `anchorX` deferred to whichever future stage actually consumes it. See `docs/plans/2026-05-28-stage-c3-bezier-leaders-anchor-dots.md` V2 for the reduced scope.
+
+X and Y reads atomic in ONE map entry, written from ONE `recompute()` body. Sibling `useMarginAnchorsX` causes one-frame chase between bubble Y (existing hook) and leader X (new hook) — exactly the "anchor jitter during transitions" §10 forbids. Vertical-only minimalism loses to atomicity.
+
+### Density decoupled from collision output (CRDT F4 + Svelte F3)
+
+`density = isEditing ? 'full' : table[(mode, isActive)]`. Period. No reads of `adjustedPositions`. No reads of `heights`. The 0.5px tolerance in `mapsEqual` damps but does not break the density → height → collision → density cycle if it's ever closed; the only safe answer is to never close it.
+
+### Density on card root, not at dispatch (Svelte F2 + annotation F2)
+
+Variants stay mounted. `density` is a CSS class on the root + a header-slot stub-label. Dispatch logic unchanged — preserves the 5-file split's per-type label discipline (the variants are still what decide what a "stub label" looks like for each author/type pair).
+
+## Cross-cutting locks (no controversy)
+
+- `isEditing` forces minimum density `'full'`.
+- `ImportedCard` never renders as `'stub'`.
+- `ReplyThreadOverlay` closes on density→stub transition.
+- `status === "pending"` filter remains at dispatcher level.
+- `±32px` hysteresis for ALL three bands as starting point; per-boundary tuning deferred to issue #916.
+- Reduced-motion guard for Stage D motion is dual-mechanism (`@media (prefers-reduced-motion: no-preference)` AND `body:not(.tandem-reduce-motion)`) per Plan §12 C11.
+
+## Pre-C-3 checks (advisor 2026-05-28 — all executed)
+
+1. **Hysteresis band spacing computed with concrete numbers.** Estimated boundaries: T1 (full→narrow) ≈ 1044px, T2 (narrow→stub) ≈ 864px, T3 (stub→off) ≈ 528px. Gaps T1−T2 ≈ 180, T2−T3 ≈ 336. Both well over the 64px (= 2·hysteresis) overlap floor. 32px-everywhere is safe; per-boundary tuning is taste, not correctness. The T2 number is sensitive to chosen narrow-column width (currently estimated at 160px; lock the actual value in the C-1 detailed plan with `MARGIN_TRACK_GEOMETRY[narrow]`).
+2. **Deferred items filed as GitHub issues.** #916 (per-boundary hysteresis tuning), #917 (hypothetical Stage E collision-pressure asymmetry placeholder). Both cite this doc + PR #909.
+3. **Per-side anchor dot color.** Locked above in C-3 scope.
+4. **AnnotationCard caller backwards-compat.** Verified: 3 production call sites (`MarginColumn.svelte:207`, `SidePanel.svelte:456` and `:481`) — all accept an optional new prop without modification.
+
+## Out of scope (Stage D and beyond)
+
+- Animated track-width transitions live in Stage D, NOT any of C-1/C-2/C-3.
+- Conflict #9's Applied-Overrides entry in `conflicts-resolved.md` is Stage D's deliverable (Plan §12 C1).
+
+## Next step
+
+Write `docs/plans/2026-05-28-stage-c3-bezier-leaders-anchor-dots.md` — the detailed Stage C-3 implementation plan — then run an adversarial agent review against THAT plan (per `feedback_multi_round_plan_review` + Plan §12 C-architectural-review-F5), then code.

--- a/docs/plans/2026-05-28-stage-c3-bezier-leaders-anchor-dots.md
+++ b/docs/plans/2026-05-28-stage-c3-bezier-leaders-anchor-dots.md
@@ -1,0 +1,303 @@
+# Stage C-3 — Bezier leaders + anchor dots (V2)
+
+> **Status:** V2, post-adversarial-review. Replaces V1 (which proposed extending `useMarginPositions` to emit `{top, anchorX}` per id). V2 collapses to pure visual upgrade — zero hook changes.
+> **Branch:** sub-PR off `feat/design-system-impl` (proposed: `design-impl/3.5-c3-bezier-leaders`).
+> **Inputs:**
+> - `docs/plans/2026-05-28-stage-c-cleave-locks.md` (cleave + locks; two locks tombstoned this turn).
+> - `~/.claude/plans/the-current-way-we-compiled-thimble.md` §4 / §10 / §12 (bundle reference + anchor-jitter rule).
+> - 3-agent adversarial review of V1 (CRDT / Svelte / annotation-model).
+> - Primary-source check of `MarginFrame.svelte` (the C4 bundle) to verify endpoint semantics.
+> **Order in Stage C envelope:** FIRST. Independent of C-1 / C-2.
+
+## 0. What changed from V1
+
+V1 proposed `MarginPositions.byId: ReadonlyMap<string, {top, anchorX}>` to make X/Y reads atomic. Three reviewers converged on rejecting this:
+
+1. **`coordsAtPos(range.from).left` is glyph-X, not text-edge-X.** Per `MarginFrame.svelte:97` (the C4 bundle source), leader endpoints derive from `doc.getBoundingClientRect().right` — the text container's geometric right edge, NOT a per-anchor glyph position. So `anchorX` was always the wrong number.
+2. **Adding `anchorX` to `mapsEqual` doubles per-frame re-render rate** (per-component 0.5px tolerance on independent jitter sources).
+3. **Pure-function helpers can't be exported from `<script lang="ts">`** and imported by vitest — V1's test plan was un-runnable.
+
+V2 drops `anchorX` entirely, matches the bundle's geometric column-X endpoints, extracts helpers to a sibling `.ts` file, and uses per-AUTHOR stroke color (also bundle-faithful, also reversing a cleave-locks lock).
+
+Net: touch surface shrinks from V1's ~200 LOC / 3 core files to ~130 LOC / 2 core files. `useMarginPositions.svelte.ts` is completely untouched.
+
+## 1. Goal
+
+Replace today's straight-line `<line>` leaders (`MarginColumn.svelte:163-174`) with cubic-bezier `<path>` leaders matching the C4 bundle's `MarginFrame.svelte:151-156` shape, add per-bubble `<circle>` anchor dots at the text-edge endpoint, and color each leader+dot pair by the annotation's `author` field (per `MarginFrame.svelte:135-137`).
+
+User-visible delta:
+- Leader curves gently into the bubble title row instead of cutting across in a straight line.
+- A small filled circle marks the text-edge endpoint.
+- Import-authored annotations (`.docx` comments) render with a neutral `--tandem-fg-subtle` color instead of Claude's orange — distinguishable from Claude's own comments at a glance.
+
+Non-goals (explicit C-1 / C-2 / Stage D scope):
+- Mode continuum (`Mode: 'full' | 'narrow' | 'stub' | 'off'`).
+- Density variants (clamp-until-active, stub-pill).
+- Geometry constant table (`MARGIN_TRACK_GEOMETRY`).
+- Animated track-width transitions (Stage D).
+- Hook return-shape changes.
+
+## 2. Touch surface (file:line evidence)
+
+### 2.1 NEW: `src/client/panels/marginLeaderGeometry.ts`
+
+Pure module. Sibling pattern matches `src/client/panels/marginCollision.ts`. Importable from both `.svelte` template and vitest.
+
+```ts
+/**
+ * Cubic-bezier leader geometry for margin-view annotation connectors.
+ *
+ * Endpoints + control-point placement match `MarginFrame.svelte` from the C4
+ * design bundle (`docs/design-system-impl/bundle/extracted/c4-margin-column/`):
+ * horizontal tangents at both endpoints, control points offset 10px / 8px
+ * inward from the endpoint columns. The result is a smooth "lays into" curve
+ * even at large vertical deltas (collision-pushed bubbles).
+ *
+ * Endpoints are GEOMETRIC column-X — per side, the leader runs from the
+ * text-track edge to the margin-column edge. NOT glyph-X. Anchor dot sits at
+ * the bezier's text-edge endpoint and inherits the same X.
+ */
+
+export type LeaderSide = "left" | "right";
+
+export interface LeaderEndpoints {
+  /** SVG-local X at the text-edge endpoint (= dot center X). */
+  readonly startX: number;
+  /** SVG-local Y at the text-edge endpoint (= dot center Y = raw anchor top). */
+  readonly startY: number;
+  /** SVG-local X at the bubble-edge endpoint. */
+  readonly endX: number;
+  /** SVG-local Y at the bubble-edge endpoint (= bubble title row baseline). */
+  readonly endY: number;
+  /** Which side the bubble column sits on — flips control-point sign. */
+  readonly side: LeaderSide;
+}
+
+/**
+ * Build the SVG path `d` attribute for one bezier leader. Mirrors the bundle's
+ * `M ax,ay C cx1,ay cx2,by bx,by` shape (MarginFrame.svelte:151-156).
+ *
+ * Control points sit 10px inward from startX and 8px inward from endX along
+ * the X axis, sharing the endpoint Y. "Inward" flips with side: for a
+ * right-side bubble, the leader runs left→right, so cx1 = startX + 10 and
+ * cx2 = endX − 8. For a left-side bubble it's mirrored.
+ *
+ * All coordinate values are rounded to 1 decimal (`toFixed(1)`) — matching
+ * the bundle, and stable across float-arithmetic jitter for snapshot tests.
+ */
+export function bezierLeaderPath(e: LeaderEndpoints): string {
+  const inward = e.side === "right" ? 1 : -1;
+  const cx1 = e.startX + 10 * inward;
+  const cx2 = e.endX - 8 * inward;
+  return (
+    `M ${e.startX.toFixed(1)},${e.startY.toFixed(1)} ` +
+    `C ${cx1.toFixed(1)},${e.startY.toFixed(1)} ` +
+    `${cx2.toFixed(1)},${e.endY.toFixed(1)} ` +
+    `${e.endX.toFixed(1)},${e.endY.toFixed(1)}`
+  );
+}
+
+/**
+ * Per-annotation stroke + dot color, keyed on annotation `author`. Matches
+ * `MarginFrame.svelte:135-137`. Imports get the neutral fg-subtle tone so a
+ * Word-comment-derived annotation reads distinct from a Claude comment at a
+ * glance. The strings are CSS `color` values (CSS custom properties), used
+ * directly on `stroke` / `fill` attributes.
+ *
+ * Exhaustiveness: the `assertNever` final branch breaks the build if
+ * `Annotation.author` grows a fourth value — without this guard, a new
+ * author silently buckets into fg-subtle (the import treatment), which is
+ * the WRONG default for whatever the new value would mean.
+ */
+type AnnotationAuthor = "claude" | "user" | "import";
+
+function assertNever(value: never): never {
+  throw new Error(`unhandled annotation author: ${String(value)}`);
+}
+
+export function leaderColorForAuthor(author: AnnotationAuthor): string {
+  switch (author) {
+    case "claude":
+      return "var(--tandem-author-claude)";
+    case "user":
+      return "var(--tandem-author-user)";
+    case "import":
+      return "var(--tandem-fg-subtle)";
+    default:
+      return assertNever(author);
+  }
+}
+```
+
+### 2.2 `src/client/panels/MarginColumn.svelte`
+
+**Hook return shape unchanged.** `positions: ReadonlyMap<string, number>` continues to emit scalar Y offsets. No prop-type change.
+
+**`leaderStyle` change.** Drop the `--tandem-author-{authorVar}` inheritance (line 71) — color is now per-element. Keep the rest of the inline-style (positioning, pointer-events, dims). `authorVar` and `editorX`/`columnX` `$derived` blocks (lines 67-72) collapse to just `editorX`/`columnX`:
+
+```svelte
+const editorX = $derived(side === "right" ? 0 : gap);
+const columnX = $derived(side === "right" ? gap : 0);
+const leaderStyle = $derived(
+  `position: absolute; top: 0; bottom: 0; ${side}: ${edgeInset + width}px; ` +
+  `width: ${gap}px; pointer-events: none;`,
+);
+```
+
+**Import the new helpers:**
+
+```ts
+import { bezierLeaderPath, leaderColorForAuthor } from "./marginLeaderGeometry";
+```
+
+**SVG markup replacement** (lines 153-177):
+
+```svelte
+<svg data-testid="margin-leaders-{side}" aria-hidden="true" style={leaderStyle}>
+  {#each placeable as ann (ann.id)}
+    {@const rawTop = positions.get(ann.id)}
+    {@const adjTopRaw = adjustedPositions.get(ann.id)}
+    {#if rawTop !== undefined}
+      {@const isActive = ann.id === activeAnnotationId}
+      {@const adjTop = adjTopRaw ?? rawTop}
+      {@const endY = adjTop + LEADER_BUBBLE_INSET_PX}
+      {@const color = leaderColorForAuthor(ann.author)}
+      {@const d = bezierLeaderPath({
+        startX: editorX,
+        startY: rawTop,
+        endX: columnX,
+        endY,
+        side,
+      })}
+      <path
+        data-annotation-id={ann.id}
+        data-tandem-author={ann.author}
+        d={d}
+        stroke={color}
+        stroke-width={isActive ? 1.8 : 1.1}
+        stroke-opacity={isActive ? 0.82 : 0.38}
+        stroke-linecap="round"
+        fill="none"
+      />
+      <circle
+        data-testid="margin-anchor-dot"
+        data-annotation-id={ann.id}
+        data-tandem-author={ann.author}
+        cx={editorX}
+        cy={rawTop}
+        r={isActive ? 3 : 2}
+        fill={color}
+        fill-opacity={isActive ? 0.72 : 0.42}
+      />
+    {/if}
+  {/each}
+</svg>
+```
+
+Key fixes incorporated from the V1 review:
+- `adjTop = adjTopRaw ?? rawTop` fallback handles the one-frame race where `placeable` updates before `adjustedPositions` `$derived.by` re-runs. Consistent with line 185's existing pattern.
+- `data-tandem-author` on each `<path>` and `<circle>` for ADR-026 attribute-queryable authorship (annotation review F2).
+- Per-element `stroke`/`fill` color resolved via the pure helper.
+
+**`adjustedPositions` reads unchanged.** Lines 93-100 continue to read `positions.get(a.id) ?? 0` (scalar). No shape-change cascade through the collision sweep.
+
+**Bubble-render reads unchanged.** Line 185's `{@const top = adjustedPositions.get(ann.id) ?? positions.get(ann.id) ?? 0}` survives as-is.
+
+### 2.3 `useMarginPositions.svelte.ts`
+
+**Untouched.** Hook return shape, `_computeNextPositionsForTesting`, `mapsEqual`, `createScheduler` — all preserved. The pre-existing layer-rect-precedes-loop atomicity bug (CRDT review HIGH-2) is filed as issue #918 to address separately; documenting it as preserved behavior, not regressed.
+
+### 2.4 No App.svelte / docx-path changes
+
+Same as V1: this PR only touches the non-docx `MarginColumn` render path.
+
+## 3. Why per-author color instead of per-side (reversal of cleave-locks decision)
+
+Cleave-locks doc locked per-side stroke color. Primary source (`MarginFrame.svelte:135-137`) is per-author: `claude` → claude token, `user` → user token, ELSE → `--tandem-fg-subtle`. Per `feedback_bundle_vs_production`: bundle-faithful for decoration; stroke color carries authorship information per ADR-026 → bundle-faithful is correct.
+
+Cost of per-author over per-side: one extra attribute per SVG element (`data-tandem-author={ann.author}`, plus per-element `stroke`/`fill`). No structural complexity.
+
+Benefit: Word-comment-derived annotations render as visually distinct from Claude comments (was the annotation review F3 "import gets Claude tone by silence" concern). Doesn't add a token — uses existing `--tandem-fg-subtle`.
+
+## 4. Tests
+
+### 4.1 NEW: `tests/client/marginLeaderGeometry.test.ts`
+
+Pure-function unit tests. `bezierLeaderPath` + `leaderColorForAuthor` test cases use `it.each` with `why` column per `feedback_iteach_equivalence_classes`:
+
+- **`leaderColorForAuthor` equivalence classes:** `claude` / `user` / `import` → respective CSS-var strings. Coverage of every value of `Annotation.author` (the `assertNever` branch is unreachable under TS — coverage proof is that all three cases exist).
+- **`bezierLeaderPath` side flip:** right side → cp1.x > startX, cp2.x < endX; left side → cp1.x < startX, cp2.x > endX. Snapshot 4 endpoint shapes (small ΔY, large ΔY, ΔY = 0, negative ΔY for collision-up-pushed bubbles).
+- **`bezierLeaderPath` rounding stability:** `(startX, startY, endX, endY) = (0.001, 0.001, 50.001, 100.001)` produces same `d` as the integer-equivalent input (verifies 1dp rounding eliminates float jitter).
+
+### 4.1b NEW: `tests/client/MarginColumn.import-author.test.ts`
+
+Integration: mount `MarginColumn` with a synthetic `author: "import"` annotation prop. Assert the rendered `<path>` and `<circle>` carry `data-tandem-author="import"` AND `stroke` resolves to `var(--tandem-fg-subtle)`. Closes the "no .docx fixture in welcome.md" gap from V1 §4.2 without requiring a docx pipeline mock. Tests the integration path that the pure-function `leaderColorForAuthor` test alone can't prove: that `ann.author` actually reaches the helper unmutated.
+
+### 4.2 `tests/e2e/margin-view.spec.ts` (extends existing file)
+
+- **Anchor dot count == bubble count per side.** Open `sample/welcome.md` with margin view on. Assert `[data-testid="margin-leaders-left"] [data-testid="margin-anchor-dot"]` count matches left placeable count; same for right. (Per-id selectors use `data-annotation-id`, NOT testid — note IDs aren't a queryable testid surface per ADR-027.)
+- **Per-author color.** Assert one Claude comment's `<path stroke>` resolves to `var(--tandem-author-claude)`, one note's path resolves to `var(--tandem-author-user)`. (Imported annotation case: deferred — `sample/welcome.md` has no `.docx` import; cover in a future fixture or pure-function-only.)
+- **`data-tandem-author` attribute exposed on path and circle** for both Claude- and user-authored placeables (ADR-026 attribute-queryable surface).
+
+### 4.3 Visual baseline
+
+Regenerate `tests/e2e/screenshots/margin-view-*.png` baselines, Linux-gated per `feedback_playwright_pixel_diff_platform_gating`. The bezier + dot change is the user-visible point of this PR — baseline update is the deliverable, not a regression.
+
+## 5. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Bezier control points at `±10` / `±8` look squashed for small `endX - startX` (narrow gap zone) | The gap zone is 24px today (Plan §5 `MARGIN_VIEW_GAP_PX`); `+10` and `-8` leave 6px of "straight" middle, well-shaped. C-1's narrower modes shrink the gap → if it gets <20px, control-point offsets need to scale. C-1 owns that; for C-3 (no mode change), it doesn't arise. |
+| Anchor dot at `(editorX, rawTop)` could collide with bubble border when `placeable` includes a bubble whose `adjTop ≈ rawTop` (no collision push) | Dot sits at the TEXT-edge X (column 0 or `gap`), bubble starts at column-X + `edgeInset`. They're separated by `gap + edgeInset` minimum (24 + 8 = 32px today). Cannot collide. |
+| Per-author color leaves `author === "user"` notes with the EXISTING `data-annotation-id` left-side surface unchanged | Today's `<line data-annotation-id={ann.id}>` already exposes per-note IDs as an attribute, but NOT as a testid. V2 originally proposed `data-testid="margin-anchor-dot-{ann.id}"` which WOULD have been a new privacy regression (testids are the documented, stable, queryable surface per CLAUDE.md). Fixed in V2 post-review: testid is non-id-bearing (`data-testid="margin-anchor-dot"`); per-id queries continue to use `data-annotation-id` for E2E selector continuity. Per-element `data-tandem-author="user"` adds zero new identity bits — only a per-author bucket, which LEFT-side placement already encodes. |
+| Bundle-faithful `+10` / `-8` offsets are baked into a pure helper, hiding the dependency | Document the bundle source (`MarginFrame.svelte:151-156`) in the helper's JSDoc (done above). A future bundle update to those numbers requires editing one helper. |
+| Pre-existing layer-rect atomicity bug (CRDT review HIGH-2) | Filed as issue #918. C-3 preserves the bug; documenting that the bezier curve doesn't make it worse than today's straight line (both render with the same Y values). |
+| Snapshot test for `bezierLeaderPath` could drift on font-rendering changes | The helper is pure (no DOM, no fonts). Snapshot is over the `d` STRING, not over a rendered path. Stable across platforms. |
+| Removing `--tandem-author-{authorVar}` from `leaderStyle` (line 71) silently regresses something that depends on the SVG root inheriting that color | Confirmed unused: `<line>` at line 169 uses `stroke="currentColor"` which only resolves through the inheritance — V2 replaces that with explicit per-element `stroke={color}`. No other consumer reads `style.color` on the SVG root. |
+
+## 6. Verification gates
+
+- `npm run typecheck` — catches any prop-shape drift.
+- `npm test -- marginLeaderGeometry` — pure-function tests.
+- `npx svelte-check src/client/panels/MarginColumn.svelte` — Svelte template type-check + `<style>` validity.
+- `npm run test:e2e -- margin-view` — selector + computed-style assertions cross-platform; pixel-diff Linux-only.
+- Manual dogfood: `npm run dev:standalone` from this worktree → `sample/welcome.md` with margin view on → bezier curves visible, anchor dots visible, Claude/user color distinction holds. If a `.docx` is convenient, verify import = fg-subtle.
+- `npm run check:tokens` — confirm no raw hex slipped in.
+
+## 7. Out of scope
+
+- **`anchorX` glyph-position reads.** If a future stage needs per-glyph X (e.g. C-2 review-target highlight that points at the EXACT word), it extends `useMarginPositions` then. C-3 doesn't pay that complexity tax up front.
+- **Anchor dot click-to-scroll.** SVG retains `pointer-events: none`. Bubble's existing `onClick` handles navigation.
+- **A new `--tandem-author-import` token.** Use existing `--tandem-fg-subtle` (matches bundle). If a future product need wants a distinct import tone, add the token in that PR.
+- **Animated path morphing on collision-resolve.** Stage D.
+- **Issue #918's atomicity fix.** Filed; not blocking C-3.
+
+## 8. PR description scaffolding
+
+```
+feat(margin-view): cubic-bezier leaders + per-author anchor dots (C-3)
+
+Stage C-3 of Phase 3.5. See docs/plans/2026-05-28-stage-c-cleave-locks.md
+and docs/plans/2026-05-28-stage-c3-bezier-leaders-anchor-dots.md (V2).
+
+- Replaces straight `<line>` leaders with cubic-bezier `<path>` matching the
+  C4 design bundle's shape.
+- Adds `<circle>` anchor dots at the text-edge endpoint.
+- Per-author stroke color (claude / user / fg-subtle) — `.docx` imports
+  render distinct from Claude comments.
+- `data-tandem-author` exposed on path + circle per ADR-026.
+
+Pure visual upgrade: zero hook changes. `useMarginPositions` return shape
+preserved. The original V1 plan's `anchorX` extension was reversed during
+plan review (bundle endpoints are geometric column-X, not glyph-X) —
+detail in the V2 plan §0.
+
+Refs: #909, #918 (pre-existing atomicity bug to address separately).
+```
+
+## 9. Next steps
+
+1. **One annotation-model re-review of V2** (per advisor: CRDT + Svelte findings collapsed with the scope cut, only annotation-model concerns remain load-bearing — testid privacy doc note, ADR-026 attribute, import-tone decision documented).
+2. Reconcile any V2-specific findings.
+3. Code.
+4. `/pr-review-toolkit:review-pr` cycle.

--- a/src/client/panels/MarginColumn.svelte
+++ b/src/client/panels/MarginColumn.svelte
@@ -4,6 +4,7 @@ import type { Annotation, AnnotationReply } from "../../shared/types";
 import { getVisibleReplies } from "../annotations/replies";
 import AnnotationCard from "./AnnotationCard.svelte";
 import { prunePlaceableHeights, resolveCollisions } from "./marginCollision";
+import { bezierLeaderPath, leaderColorForAuthor } from "./marginLeaderGeometry";
 
 interface Props {
   /** Annotations destined for this side. Caller filters by type/author. */
@@ -62,13 +63,15 @@ const LEADER_BUBBLE_INSET_PX = 12;
 // Component-level $derived values for the leader SVG. `side`, `edgeInset`,
 // `gap`, `width` come from $props() and are themselves reactive, so these
 // recompute precisely when a prop changes. Hoisting `editorX`/`columnX` out
-// of the {#each} block avoids recomputing the same ternary per iteration;
-// `leaderStyle` collapses the previously dense inline-style template.
-const authorVar = $derived(side === "right" ? "claude" : "user");
+// of the {#each} block avoids recomputing the same ternary per iteration.
+// Per-element stroke/fill colors are resolved at render time from
+// `leaderColorForAuthor` — the SVG root no longer carries an inherited color
+// (side ≠ author after Stage C-3: imports render distinct from Claude even
+// though both sit on the right side).
 const editorX = $derived(side === "right" ? 0 : gap);
 const columnX = $derived(side === "right" ? gap : 0);
 const leaderStyle = $derived(
-  `position: absolute; top: 0; bottom: 0; ${side}: ${edgeInset + width}px; width: ${gap}px; pointer-events: none; color: var(--tandem-author-${authorVar});`,
+  `position: absolute; top: 0; bottom: 0; ${side}: ${edgeInset + width}px; width: ${gap}px; pointer-events: none;`,
 );
 
 // Only render annotations whose position is known this frame; without a top
@@ -138,39 +141,57 @@ function recordHeight(id: string, h: number): void {
 }
 </script>
 
-<!-- Leader-line SVG sits in the gap zone between the editor's text edge and
-     the column's near edge. Top/bottom stretch makes it cover the full layer
-     height so absolute Y coords (relative to the margin layer) line up with
+<!-- Leader SVG sits in the gap zone between the editor's text edge and the
+     column's near edge. Top/bottom stretch covers the full layer height so
+     absolute Y coords (relative to the margin layer) line up with
      `useMarginPositions` output. SVG default user units = pixels (no viewBox),
-     so we render lines directly at the computed Y offsets. Decorative only:
+     so we render at computed Y offsets directly. Decorative only:
      pointer-events: none, aria-hidden.
 
-     Stroke is tinted by side (left = notes / user, right = comments / Claude)
-     to mirror the authorship decoration convention (ADR-026). Default uses
-     stroke-opacity to stay subtle; active review target ramps opacity + width
-     so the focused annotation's connector reads as the dominant line on the
-     page. -->
+     Stroke + dot fill are PER-AUTHOR (ADR-026), not per-side: matches the C4
+     bundle (MarginFrame.svelte:135-137 — claude / user / fg-subtle). Active
+     review target ramps opacity + width so the focused annotation's connector
+     reads as the dominant line on the page.
+
+     `adjTop ?? rawTop` fallback handles a one-frame race where `placeable`
+     updates (annotation added) before `adjustedPositions` `$derived.by`
+     re-runs — without it, the leader+dot disappears for one tick. Consistent
+     with the bubble's own fallback chain in the next block. -->
 <svg data-testid="margin-leaders-{side}" aria-hidden="true" style={leaderStyle}>
   {#each placeable as ann (ann.id)}
     {@const rawTop = positions.get(ann.id)}
-    {@const adjTop = adjustedPositions.get(ann.id)}
-    {#if rawTop !== undefined && adjTop !== undefined}
+    {@const adjTopRaw = adjustedPositions.get(ann.id)}
+    {#if rawTop !== undefined}
       {@const isActive = ann.id === activeAnnotationId}
-      <!-- LEADER_BUBBLE_INSET_PX shifts the bubble endpoint down from the
-           bubble's top edge into its padded content area, so a
-           collision-pushed bubble's connector lands near the title row
-           instead of pointing at the empty corner above it. -->
-      <line
+      {@const adjTop = adjTopRaw ?? rawTop}
+      {@const endY = adjTop + LEADER_BUBBLE_INSET_PX}
+      {@const color = leaderColorForAuthor(ann.author)}
+      {@const d = bezierLeaderPath({
+        startX: editorX,
+        startY: rawTop,
+        endX: columnX,
+        endY,
+        side,
+      })}
+      <path
         data-annotation-id={ann.id}
-        x1={editorX}
-        y1={rawTop}
-        x2={columnX}
-        y2={adjTop + LEADER_BUBBLE_INSET_PX}
-        stroke="currentColor"
-        stroke-width={isActive ? 1.75 : 1}
-        stroke-opacity={isActive ? 0.9 : 0.4}
+        data-tandem-author={ann.author}
+        {d}
+        stroke={color}
+        stroke-width={isActive ? 1.8 : 1.1}
+        stroke-opacity={isActive ? 0.82 : 0.38}
         stroke-linecap="round"
         fill="none"
+      />
+      <circle
+        data-testid="margin-anchor-dot"
+        data-annotation-id={ann.id}
+        data-tandem-author={ann.author}
+        cx={editorX}
+        cy={rawTop}
+        r={isActive ? 3 : 2}
+        fill={color}
+        fill-opacity={isActive ? 0.72 : 0.42}
       />
     {/if}
   {/each}

--- a/src/client/panels/marginLeaderGeometry.ts
+++ b/src/client/panels/marginLeaderGeometry.ts
@@ -1,0 +1,85 @@
+/**
+ * Cubic-bezier leader geometry for margin-view annotation connectors.
+ *
+ * Endpoints + control-point placement match `MarginFrame.svelte` from the C4
+ * design bundle: horizontal tangents at both endpoints, control points offset
+ * 10px / 8px inward from the endpoint columns. Smooth "lays into" curve even
+ * at large vertical deltas (collision-pushed bubbles).
+ *
+ * Endpoints are GEOMETRIC column-X, not glyph-X. The leader runs from the
+ * text-track edge to the margin-column edge; the anchor dot sits at the
+ * bezier's text-edge endpoint (same X as the bezier start).
+ *
+ * Sibling pattern matches `marginCollision.ts` — pure module, importable from
+ * both `.svelte` template and vitest.
+ */
+
+import type { Annotation } from "../../shared/types.js";
+
+export type LeaderSide = "left" | "right";
+
+export interface LeaderEndpoints {
+  /** SVG-local X at the text-edge endpoint (= dot center X). */
+  readonly startX: number;
+  /** SVG-local Y at the text-edge endpoint (= dot center Y = raw anchor top). */
+  readonly startY: number;
+  /** SVG-local X at the bubble-edge endpoint. */
+  readonly endX: number;
+  /** SVG-local Y at the bubble-edge endpoint (= bubble title row baseline). */
+  readonly endY: number;
+  /** Which side the bubble column sits on — flips control-point sign. */
+  readonly side: LeaderSide;
+}
+
+/**
+ * Build the SVG path `d` attribute for one bezier leader. Mirrors the bundle's
+ * `M ax,ay C cx1,ay cx2,by bx,by` shape (MarginFrame.svelte:151-156).
+ *
+ * Control points sit 10px inward from startX and 8px inward from endX along
+ * the X axis, sharing the endpoint Y. "Inward" flips with side: for a
+ * right-side bubble the leader runs left→right, so cx1 = startX + 10 and
+ * cx2 = endX − 8. For a left-side bubble it's mirrored.
+ *
+ * Coordinate values are rounded to 1 decimal (`toFixed(1)`) — matching the
+ * bundle, and stable across float-arithmetic jitter for snapshot tests.
+ */
+export function bezierLeaderPath(e: LeaderEndpoints): string {
+  const inward = e.side === "right" ? 1 : -1;
+  const cx1 = e.startX + 10 * inward;
+  const cx2 = e.endX - 8 * inward;
+  return (
+    `M ${e.startX.toFixed(1)},${e.startY.toFixed(1)} ` +
+    `C ${cx1.toFixed(1)},${e.startY.toFixed(1)} ` +
+    `${cx2.toFixed(1)},${e.endY.toFixed(1)} ` +
+    `${e.endX.toFixed(1)},${e.endY.toFixed(1)}`
+  );
+}
+
+function assertNever(value: never): never {
+  throw new Error(`unhandled annotation author: ${String(value)}`);
+}
+
+/**
+ * Per-annotation stroke + dot color, keyed on annotation `author`. Matches
+ * `MarginFrame.svelte:135-137`. Imports get the neutral fg-subtle tone so a
+ * Word-comment-derived annotation reads distinct from a Claude comment at a
+ * glance. Returned strings are CSS `color` values (custom-property refs),
+ * used directly on `stroke` / `fill` attributes.
+ *
+ * The `default` branch is unreachable under TS; `assertNever` exists so a
+ * future fourth `Annotation.author` value breaks the build rather than
+ * silently bucketing into the import treatment (which would be the wrong
+ * default for whatever the new value would mean).
+ */
+export function leaderColorForAuthor(author: Annotation["author"]): string {
+  switch (author) {
+    case "claude":
+      return "var(--tandem-author-claude)";
+    case "user":
+      return "var(--tandem-author-user)";
+    case "import":
+      return "var(--tandem-fg-subtle)";
+    default:
+      return assertNever(author);
+  }
+}

--- a/tests/client/MarginColumn.import-author.test.ts
+++ b/tests/client/MarginColumn.import-author.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+
+import { render } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import MarginColumn from "../../src/client/panels/MarginColumn.svelte";
+import type { Annotation } from "../../src/shared/types";
+
+// Closes the gap from the V2 plan §4.1b — `leaderColorForAuthor` is unit-tested
+// in marginLeaderGeometry.test.ts, but pure-function correctness can't prove
+// that an import-authored annotation reaches the SVG with author intact (a
+// sanitizer between the prop and the render call could silently re-bucket
+// imports as Claude). This test mounts MarginColumn with a synthetic
+// import-authored annotation and asserts `data-tandem-author="import"` lands
+// on the rendered path + circle.
+
+function importComment(id: string): Annotation {
+  return {
+    id,
+    author: "import",
+    type: "comment",
+    range: { from: 0, to: 5 },
+    content: "Word comment text",
+    status: "pending",
+    timestamp: 1_700_000_000_000,
+    importSource: { author: "Alice", file: "/test.docx" },
+  };
+}
+
+describe("MarginColumn — import-author render path", () => {
+  it('renders <path> and <circle> with data-tandem-author="import" for an import-authored annotation', () => {
+    const ann = importComment("ann-1");
+    const positions = new Map<string, number>([["ann-1", 100]]);
+    const { container } = render(MarginColumn, {
+      annotations: [ann],
+      positions,
+      side: "right",
+      width: 240,
+      edgeInset: 8,
+      gap: 24,
+      activeAnnotationId: null,
+      repliesById: new Map(),
+      onClick: () => {},
+    });
+
+    const path = container.querySelector<SVGPathElement>('path[data-annotation-id="ann-1"]');
+    const circle = container.querySelector<SVGCircleElement>('circle[data-annotation-id="ann-1"]');
+
+    expect(path, "leader <path> must render for the import-authored annotation").not.toBeNull();
+    expect(circle, "anchor <circle> must render alongside the leader").not.toBeNull();
+
+    expect(path?.getAttribute("data-tandem-author")).toBe("import");
+    expect(circle?.getAttribute("data-tandem-author")).toBe("import");
+
+    // The exact stroke string flows through `leaderColorForAuthor` — guard the
+    // integration, not the CSS variable's resolved value (happy-dom doesn't
+    // resolve custom properties; that's an E2E concern).
+    expect(path?.getAttribute("stroke")).toBe("var(--tandem-fg-subtle)");
+    expect(circle?.getAttribute("fill")).toBe("var(--tandem-fg-subtle)");
+  });
+});

--- a/tests/client/marginLeaderGeometry.test.ts
+++ b/tests/client/marginLeaderGeometry.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  bezierLeaderPath,
+  type LeaderEndpoints,
+  leaderColorForAuthor,
+} from "../../src/client/panels/marginLeaderGeometry";
+
+describe("leaderColorForAuthor", () => {
+  // Equivalence classes cover every value of Annotation["author"]. The
+  // assertNever branch is unreachable under TS; coverage proof is that all
+  // three cases below resolve to distinct CSS variables.
+  it.each([
+    {
+      author: "claude" as const,
+      expected: "var(--tandem-author-claude)",
+      why: "Claude-authored comment / suggestion → claude tone",
+    },
+    {
+      author: "user" as const,
+      expected: "var(--tandem-author-user)",
+      why: "user-authored note / highlight → user tone",
+    },
+    {
+      author: "import" as const,
+      expected: "var(--tandem-fg-subtle)",
+      why: ".docx Word-comment-derived → neutral subtle tone, distinct from Claude",
+    },
+  ])("maps $author → $expected ($why)", ({ author, expected }) => {
+    expect(leaderColorForAuthor(author)).toBe(expected);
+  });
+});
+
+describe("bezierLeaderPath", () => {
+  // Geometry: leader runs from the editor's text edge (startX, startY) to
+  // the bubble column's near edge (endX, endY). Control points sit 10px / 8px
+  // INWARD from each endpoint along the X axis. "Inward" flips with side.
+  const baseRight: LeaderEndpoints = {
+    startX: 0,
+    startY: 100,
+    endX: 24,
+    endY: 130,
+    side: "right",
+  };
+  const baseLeft: LeaderEndpoints = {
+    startX: 24,
+    startY: 100,
+    endX: 0,
+    endY: 130,
+    side: "left",
+  };
+
+  it("right-side control points are +10 inward from startX and −8 inward from endX", () => {
+    const d = bezierLeaderPath(baseRight);
+    // M 0,100 C 10,100 16,130 24,130 — cp1.x = startX + 10, cp2.x = endX − 8
+    expect(d).toBe("M 0.0,100.0 C 10.0,100.0 16.0,130.0 24.0,130.0");
+  });
+
+  it("left-side control points mirror the sign (cp1.x < startX, cp2.x > endX)", () => {
+    const d = bezierLeaderPath(baseLeft);
+    // M 24,100 C 14,100 8,130 0,130 — cp1.x = startX − 10, cp2.x = endX + 8
+    expect(d).toBe("M 24.0,100.0 C 14.0,100.0 8.0,130.0 0.0,130.0");
+  });
+
+  it.each([
+    {
+      dy: 0,
+      why: "ΔY = 0 (bubble at exactly the anchor height): horizontal sweep, no collision push",
+    },
+    { dy: 200, why: "large +ΔY (collision pushed bubble far below anchor): tall sweep" },
+    { dy: -50, why: "negative ΔY (collision pushed bubble above anchor — rare but possible)" },
+  ])("produces a valid M..C path for ΔY=$dy ($why)", ({ dy }) => {
+    const d = bezierLeaderPath({ ...baseRight, endY: baseRight.startY + dy });
+    expect(d).toMatch(
+      /^M \d+\.\d+,\d+\.\d+ C \d+\.\d+,\d+\.\d+ \d+\.\d+,-?\d+\.\d+ \d+\.\d+,-?\d+\.\d+$/,
+    );
+  });
+
+  it("rounds float-jittery inputs to 1dp (stable snapshots)", () => {
+    const jittery = bezierLeaderPath({
+      startX: 0.001,
+      startY: 100.0001,
+      endX: 24.0001,
+      endY: 130.0001,
+      side: "right",
+    });
+    const clean = bezierLeaderPath(baseRight);
+    expect(jittery).toBe(clean);
+  });
+});

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -163,6 +163,7 @@ integration-wizard-step-review
 integration-wizard-step-saving
 integration-wizard-step-secrets
 left-outline-rail
+margin-anchor-dot
 margin-bubble-{*}
 margin-column-{*}
 margin-leaders-{*}

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -203,16 +203,33 @@ test("PR2: two overlapping comments produce non-overlapping bubbles", async ({ p
     .toBe(true);
 });
 
-test("PR3: leader lines render and slope with collision adjustment", async ({ page }) => {
+// Extract (startY, endY) from a `bezierLeaderPath` output:
+//   "M sx.x,sy.y C cp1x,sy.y cp2x,ey.y ex.x,ey.y"
+// Both Y coordinates are 1dp-rounded by the helper, so a tight numeric
+// extraction is safe and platform-stable.
+function extractStartEndY(d: string): { startY: number; endY: number } | null {
+  // M <sx>,<sy> C <cp1x>,<cp1y> <cp2x>,<cp2y> <ex>,<ey>
+  const m = d.match(
+    /^M -?\d+(?:\.\d+)?,(-?\d+(?:\.\d+)?) C -?\d+(?:\.\d+)?,-?\d+(?:\.\d+)? -?\d+(?:\.\d+)?,-?\d+(?:\.\d+)? -?\d+(?:\.\d+)?,(-?\d+(?:\.\d+)?)$/,
+  );
+  if (!m) return null;
+  const startY = parseFloat(m[1]);
+  const endY = parseFloat(m[2]);
+  if (!Number.isFinite(startY) || !Number.isFinite(endY)) return null;
+  return { startY, endY };
+}
+
+test("PR3 (C-3): bezier leaders render and slope with collision adjustment", async ({ page }) => {
   // Two adjacent comments on the same line force a collision: the lower
   // bubble's `adjTop > rawTop`, so its leader connects raw editor anchor
-  // to pushed-down bubble (sloped). The upper bubble is uncollided, so its
-  // leader's `y2 - y1 === LEADER_BUBBLE_INSET_PX` (12) exactly.
+  // to pushed-down bubble (visibly tall bezier). The upper bubble is
+  // uncollided, so its leader's `endY - startY === LEADER_BUBBLE_INSET_PX`
+  // (12) exactly.
   //
-  // We read `y1`/`y2` directly off the SVG `<line>` attributes — these are
-  // the values the component wrote, untainted by viewport scroll, device
-  // pixel rounding, or layer-relative coordinate math (lesson #71). Sort
-  // by `y1` since `placeable` is annotation-array order, not visual order.
+  // We extract startY/endY from the SVG `<path>` `d` attribute — these are
+  // the values the component wrote, untainted by viewport scroll or device
+  // pixel rounding (lesson #71). Sort by startY since `placeable` is
+  // annotation-array order, not visual order.
   await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
   await mcp.callTool("tandem_comment", {
     from: TITLE_FROM,
@@ -234,43 +251,92 @@ test("PR3: leader lines render and slope with collision adjustment", async ({ pa
 
   const leaderSvg = page.locator("[data-testid='margin-leaders-right']");
   await expect(leaderSvg).toHaveCount(1, { timeout: 5_000 });
-  const lines = leaderSvg.locator("line[data-annotation-id]");
-  await expect(lines).toHaveCount(2, { timeout: 5_000 });
+  const leaders = leaderSvg.locator("path[data-annotation-id]");
+  await expect(leaders).toHaveCount(2, { timeout: 5_000 });
 
-  // Poll until the collision sweep has produced a visibly sloped lower line.
-  // The `> 12` predicate is what proves `adjTop > rawTop` (a real push), not
-  // just the constant LEADER_BUBBLE_INSET_PX offset.
+  // Poll until the collision sweep has produced a visibly tall lower leader.
+  // The `> 12` predicate proves `adjTop > rawTop` (a real push), not just
+  // the constant LEADER_BUBBLE_INSET_PX offset.
   await expect
     .poll(
       async () => {
-        const ys = await lines.evaluateAll((els) =>
-          els.map((el) => ({
-            y1: parseFloat(el.getAttribute("y1") ?? "NaN"),
-            y2: parseFloat(el.getAttribute("y2") ?? "NaN"),
-          })),
-        );
+        const ds = await leaders.evaluateAll((els) => els.map((el) => el.getAttribute("d") ?? ""));
+        const ys = ds
+          .map(extractStartEndY)
+          .filter((v): v is { startY: number; endY: number } => v !== null);
         if (ys.length !== 2) return null;
-        if (!ys.every(({ y1, y2 }) => Number.isFinite(y1) && Number.isFinite(y2))) return null;
-        const sorted = [...ys].sort((a, b) => a.y1 - b.y1);
-        return sorted[1].y2 - sorted[1].y1;
+        const sorted = [...ys].sort((a, b) => a.startY - b.startY);
+        return sorted[1].endY - sorted[1].startY;
       },
-      { timeout: 5_000, message: "lower leader line must slope (collision pushed bubble down)" },
+      { timeout: 5_000, message: "lower leader must span > 12px (collision push, not just inset)" },
     )
     .toBeGreaterThan(12);
 
-  // Now snapshot once and verify both lines independently. Upper line is
-  // uncollided — `y2 - y1 === LEADER_BUBBLE_INSET_PX` exactly (no float ops
-  // between the assignment and the attribute), with <1px tolerance for any
-  // future subpixel jitter.
-  const ys = await lines.evaluateAll((els) =>
-    els.map((el) => ({
-      y1: parseFloat(el.getAttribute("y1") ?? "NaN"),
-      y2: parseFloat(el.getAttribute("y2") ?? "NaN"),
-    })),
+  // Snapshot once and verify both leaders independently. Upper leader is
+  // uncollided — `endY - startY === LEADER_BUBBLE_INSET_PX` (12) within 1px
+  // tolerance for the 1dp rounding in `bezierLeaderPath`.
+  const ds = await leaders.evaluateAll((els) => els.map((el) => el.getAttribute("d") ?? ""));
+  const ys = ds
+    .map(extractStartEndY)
+    .filter((v): v is { startY: number; endY: number } => v !== null);
+  const [upper, lower] = [...ys].sort((a, b) => a.startY - b.startY);
+  expect(Math.abs(upper.endY - upper.startY - 12)).toBeLessThan(1);
+  expect(lower.endY - lower.startY).toBeGreaterThan(12);
+});
+
+test("C-3: per-author stroke color (Claude on right) + anchor dot count matches bubbles", async ({
+  page,
+}) => {
+  // Two Claude-authored comments give us a deterministic right-side render
+  // with `data-tandem-author="claude"` on every path + circle. Anchor-dot
+  // count must equal bubble count per side (one dot per pending placeable).
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_FROM + 4,
+    text: "first claude",
+    textSnapshot: TITLE_TEXT.slice(0, 4),
+  });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM + 5,
+    to: TITLE_TO,
+    text: "second claude",
+    textSnapshot: TITLE_TEXT.slice(5),
+  });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+
+  const rightLeaders = page.locator("[data-testid='margin-leaders-right']");
+  await expect(rightLeaders).toHaveCount(1, { timeout: 5_000 });
+
+  const rightBubbles = page.locator(
+    "[data-testid='margin-column-right'] [data-testid^='margin-bubble-']",
   );
-  const [upper, lower] = [...ys].sort((a, b) => a.y1 - b.y1);
-  expect(Math.abs(upper.y2 - upper.y1 - 12)).toBeLessThan(1);
-  expect(lower.y2 - lower.y1).toBeGreaterThan(12);
+  await expect(rightBubbles).toHaveCount(2, { timeout: 5_000 });
+
+  // Per-author stroke on the path attribute (resolution to the CSS variable
+  // is unit-tested elsewhere; here we verify the attribute itself).
+  const claudePaths = rightLeaders.locator("path[data-tandem-author='claude']");
+  await expect(claudePaths).toHaveCount(2, { timeout: 5_000 });
+  const strokes = await claudePaths.evaluateAll((els) =>
+    els.map((el) => el.getAttribute("stroke")),
+  );
+  for (const stroke of strokes) {
+    expect(stroke).toBe("var(--tandem-author-claude)");
+  }
+
+  // Anchor dots: count matches placeable bubbles per side; testid is
+  // non-id-bearing (ADR-027 — note IDs are NOT a queryable testid surface).
+  // Per-id queries continue to use `data-annotation-id` if needed.
+  const rightDots = rightLeaders.locator("circle[data-testid='margin-anchor-dot']");
+  await expect(rightDots).toHaveCount(2, { timeout: 5_000 });
+  const claudeDots = rightLeaders.locator(
+    "circle[data-testid='margin-anchor-dot'][data-tandem-author='claude']",
+  );
+  await expect(claudeDots).toHaveCount(2, { timeout: 5_000 });
 });
 
 test("PR2: comment with a reply shows reply count in the bubble", async ({ page }) => {


### PR DESCRIPTION
## Summary

Stage C-3 of Phase 3.5 — pure visual upgrade matching the C4 design bundle's margin connector shape. Independently shippable; zero hook changes.

- `<line>` leaders → cubic-bezier `<path>` with horizontal-tangent control points 10px/8px inward from each endpoint (matches `MarginFrame.svelte:151-156`).
- New `<circle>` anchor dots at the text-edge endpoint.
- Per-AUTHOR stroke + fill color (claude / user / fg-subtle), **not** per-side. `.docx` imports render distinct from Claude even though both sit on the right margin.
- `data-tandem-author` on both `<path>` and `<circle>` per ADR-026.
- New pure helper `src/client/panels/marginLeaderGeometry.ts` (sibling pattern matches `marginCollision.ts`) with exhaustive `assertNever` on the author switch so a future fourth value breaks the build instead of silently bucketing as "import".
- `adjTop ?? rawTop` one-frame race fallback (consistent with bubble's existing line-185 chain).

## Plan + lock trail

- `docs/plans/2026-05-28-stage-c-cleave-locks.md` — Stage C cleave + 5 resolved forks. Two locks were tombstoned during this PR's plan review and the tombstones are committed here (`anchorX` hook-extension reversed; per-side color reversed to per-author).
- `docs/plans/2026-05-28-stage-c3-bezier-leaders-anchor-dots.md` — V2 plan after 3-agent adversarial review of V1 dropped the hook return-shape change. Detailed file:line touch surface, test plan, risks table.

The cleave-doc reversals are evidenced by `MarginFrame.svelte` primary source — the bundle's endpoints derive from `doc.getBoundingClientRect().right` (geometric column-X), not `coordsAtPos` (glyph-X), and its stroke color is keyed on `b.author`. Per `feedback_bundle_vs_production`: decoration → bundle-faithful.

## Verification

- `npm run typecheck` — 851 files, 0 errors, 0 warnings.
- `npm test` — 3080 tests, 3059 passing, 20 skipped, 1 snapshot regenerated for `margin-anchor-dot` testid addition (commit 51a608a). 4 margin-related unit-test files pass: 45 tests.
- `npm run check:tokens` — 11 pre-existing warnings in `editor.css`/`NewTabMenu.svelte`; none in changed files.
- E2E: updated PR3 `<line>` → `<path>` `d` extraction + added C-3 anchor-dot / per-author color tests (CI runs).
- Husky pre-push: full unit suite + Rust + svelte-check green.

## Test plan

- [ ] CI green (unit + E2E + Rust)
- [ ] Visual dogfood: open `sample/welcome.md` with margin view on; bezier curves visible; anchor dots visible; Claude/user color distinction holds
- [ ] If a `.docx` is convenient: verify import-authored annotations render with `--tandem-fg-subtle` (distinct from Claude orange)
- [ ] Visual baseline regen on Linux CI (or pause for review if pixel-diff fails)

## Refs

- #909 (Stages A+B umbrella PR)
- #916 (deferred: per-boundary hysteresis tuning)
- #917 (deferred: hypothetical Stage E)
- #918 (pre-existing layer-rect atomicity bug surfaced by V1 review — not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)