### PR TITLE
feat(margin-view): MarginMode continuum + per-side empty-collapse (Stage C-1)

### DIFF
--- a/docs/plans/2026-05-28-stage-c-cleave-locks.md
+++ b/docs/plans/2026-05-28-stage-c-cleave-locks.md
@@ -90,9 +90,11 @@ The original C-1 → C-2 → C-3 sequence was rejected because:
 
 ### Global Mode, not per-side (architecture F1)
 
-Decision 3 — "stub triggered by viewport width alone, not collision pressure" — is GLOBAL by nature. With no per-side asymmetry source, `leftMode === rightMode` always holds. The only proposed per-side asymmetry was "density → collision pressure → mode," which was independently rejected on cycle grounds. Therefore: `Mode` is global; `leftMode` / `rightMode` enum is YAGNI.
+Decision 3 — "stub triggered by viewport width alone, not collision pressure" — is GLOBAL by nature. With no per-side *width* asymmetry source, the **shrink continuum** (`widthMode`) is global. The only proposed per-side *width* asymmetry was "density → collision pressure → mode," which was independently rejected on cycle grounds. Therefore: the width continuum is a single global `widthMode`; independent per-side *width* state is YAGNI.
 
-Future Stage E (issue #917) is the durable home for re-splitting if a real per-side asymmetry need ever surfaces.
+**AMENDED 2026-05-28 (Bryan):** there IS one sanctioned per-side exception — **presence, not pressure.** A side with no pending annotations collapses to `off` while the other keeps `widthMode`. Presence is a stable binary input (not density-derived), so it introduces no cycle and needs no hysteresis. Consequence: `leftMode`/`rightMode` are NOT YAGNI — they exist as **pure presence-clamps** over the global `widthMode` (`side.hasPending ? widthMode : 'off'`), and `leftMode === rightMode` no longer always holds. What stays YAGNI is *independent per-side width state* (two `$state`/`$effect` pairs). See [stage-c1 §2 + §3.5](2026-05-28-stage-c1-margin-mode-continuum.md), `[MF-10]`/`[MF-11]`.
+
+Future Stage E (issue #917) is the durable home for genuine per-side *width* re-splitting if a real asymmetry need ever surfaces.
 
 ### Single $effect, not two (CRDT F2 + Svelte F1 converge)
 

--- a/docs/plans/2026-05-28-stage-c1-margin-mode-continuum.md
+++ b/docs/plans/2026-05-28-stage-c1-margin-mode-continuum.md
@@ -1,0 +1,405 @@
+# Stage C-1 — Margin mode continuum + `MARGIN_TRACK_GEOMETRY` table
+
+> **Status:** review-hardened plan (agent-team coordinated 2026-05-28; supersedes the
+> pre-synthesis design draft). Lands on `feat/design-system-impl`, stacked on the
+> merged C-3 (#919) + A+B (#909). **Sibling:**
+> [Stage C-2 — density variants](2026-05-28-stage-c2-density-variants.md) stacks on
+> THIS slice. **Locked decisions:** [stage-c-cleave-locks.md](2026-05-28-stage-c-cleave-locks.md).
+> **Umbrella plan:** `~/.claude/plans/the-current-way-we-compiled-thimble.md` §5/§9/C1–C14.
+>
+> Produced by the `stage-c-coordinate` agent team (contract freeze → parallel
+> blueprints → svelte + crdt + annotation-model review → synthesis). The synthesis
+> caught a HIGH docx-regression and a stale per-side seam. Every `c1MustFix` is folded
+> in and tagged `[MF-n]`. **Amended 2026-05-28 (Bryan):** the strict-global decision now
+> carries one sanctioned per-side exception — a side with no pending annotations collapses
+> to `off` (presence, not pressure; loop-safe). Tagged `[MF-10]` (comment rewrite) +
+> `[MF-11]` (presence source + tests).
+
+## 1. Scope
+
+C-1 is the **foundation** the density variants (C-2) consume. It adds the per-mode
+geometry table + the width-driven mode continuum to `EditorStageModel`, and threads
+the resolved `mode` into `MarginColumn`. **Behaviorally invisible at the default
+`full` mode** — the only user-visible delta is that the single `full ↔ off` cliff
+(today's `narrowSticky`) becomes a `full → narrow → stub → off` ladder **for non-docx
+documents only**. C-2 later renders narrow/stub differently; C-1 ships the mode + the
+narrower track, and the existing C-3 bezier leaders + bubbles auto-fit it with no
+render change.
+
+## 2. Reconciled contract — what the agent team changed from the seam
+
+Two corrections, both verified against current code (`editor-stage.svelte.ts`,
+`App.svelte`):
+
+- **Global width-mode + per-side empty-collapse `[authority: cleave-locks §"Resolved
+  forks" F1 + Bryan 2026-05-28]`.** The seam mandated `marginLeftMode`/`marginRightMode`
+  as independently *width-driven* modes; that is rejected. The **shrink continuum**
+  (full → narrow → stub → off, driven by viewport width) is a **single global
+  `widthMode`** on the merits: both grid tracks are symmetric, so a width-driven mode is
+  inherently global, and the only proposed per-side *width* driver — density →
+  collision-pressure → mode — was rejected on cycle grounds (the exact density↔collision
+  feedback loop C-2 is built to avoid).
+  - **The one sanctioned asymmetry: presence, not pressure (Bryan).** A side with **no
+    rendered annotations** collapses to `off` regardless of `widthMode`; the other side
+    keeps `widthMode`. This is *not* the rejected driver — presence is a stable binary
+    input (collapsing an empty side cannot create or destroy annotations), so it adds **no
+    feedback loop and no hysteresis need**. It also kills a residual phantom-reserve
+    (umbrella defect #1 at side granularity): today a 0-annotation side still reserves a
+    full track and pushes content off-center. Asymmetric centering when one side is `off`
+    is already the intended grid behavior (umbrella §5), so this aligns rather than
+    conflicts.
+  - **Model shape `[MF-3]`:** keep **one** stateful `widthMode` (`$state` + the single
+    guarded `$effect` — the only loop-prone part stays singular). Derive two **pure**
+    per-side modes by clamping: `leftMode = leftHasPending ? widthMode : 'off'`,
+    `rightMode = rightHasPending ? widthMode : 'off'` (no effect, no hysteresis). Drop the
+    design draft's *independent* `leftMode`/`rightMode` width-state; the per-side getters
+    return these clamped values. Per-side *width* re-split (genuinely different sizes per
+    side) remains deferred to **Stage E / #917**.
+  - **"Empty" = no pending annotations on that side `[MF-11]` — SOURCE FROM THE UNGATED
+    UPSTREAM (CRITICAL, 3-reviewer + advisor converged).** The obvious wiring — "reuse the
+    existing C3 split arrays `marginNotes`/`marginComments`" — **builds a reactive cycle
+    and is forbidden.** Those arrays (`App.svelte:1032-1039`) are themselves gated on
+    `editorStage.effectivelyOn`; since the new `effectivelyOn = leftVisible || rightVisible`
+    depends on `leftMode → getLeftHasPending()`, sourcing presence off them closes
+    `effectivelyOn → marginNotes → getLeftHasPending → leftMode → leftVisible →
+    effectivelyOn` → cyclic `$derived` (crash, or latches "all-off" so margin view silently
+    renders nothing despite being on). **Correct source:** the **ungated**
+    `visibleAnnotations` (`App.svelte:193`, `= yjsSync.annotations`, declared upstream of
+    `editorStage` at `:685`), with the type/author split + `status === "pending"` predicate
+    applied **directly**. Share the *predicate*, never the gated *array*. Extract the
+    side-split predicate into a shared helper so the column and the presence booleans apply
+    identical logic (drift-prevention comes from one predicate, not one array).
+  - **Presence is `status==="pending"` ONLY — do NOT match the full render gate `[MF-11]`.**
+    `MarginColumn`'s actual render filter is `positions.has(a.id) && a.status === "pending"`
+    (`MarginColumn.svelte:79-81`), not pending alone. Presence deliberately omits
+    `positions.has`: that set comes from `createMarginPositions({getEnabled: () =>
+    editorStage.effectivelyOn})` (`App.svelte:1040-1046`) — also `effectivelyOn`-gated, so
+    adding it reintroduces the same cycle class. The resulting drift is **one-directional
+    and benign**: presence can over-count by at most one frame (a pending-but-unpositioned
+    annotation → side reserved-but-empty for ≤1 frame), but never under-counts (no pending
+    → nothing renders → no "collapsed-but-rendering"). Accept pending-only; the residual
+    is the deliberate price of loop-freedom. Do not claim exact render parity.
+  - Left = private notes (`type === "note"`), right = outbound comments+imports
+    (`author === "import" || type === "comment"`); `highlight` is inline → **neither side**,
+    correctly excluded from both booleans (`App.svelte:1032-1039` C3 split). Count per this
+    fixed assignment, never swapped. (Theoretical `author==="import" && type==="note"` would
+    double-count, but docx imports are always `type:"comment"`, so it cannot occur today —
+    pre-existing C3 property, noted not fixed.)
+  - **Recompute trigger is the annotation-set `$effect`, not the layer ResizeObserver
+    (document for future-proofing).** A presence flip (incl. pending→accepted, which removes
+    the last *pending* item) reassigns `visibleAnnotations` → the `useMarginPositions`
+    annotation-set effect re-runs → rAF recompute reads post-reflow `coordsAtPos`. Collapse
+    and recompute share one trigger, so there is no stale frame. The layer RO does *not*
+    fire on an interior track collapse (the container box is unchanged). State this so a
+    later refactor decoupling presence from `visibleAnnotations` doesn't silently introduce
+    a stale-anchor frame.
+  - **Caveat — this REVERSES the shipped A+B comment.** `editor-stage.svelte.ts:195-199`
+    explicitly says the per-side getters are retained because "Stage C re-splits them …
+    based on collision pressure." That stated intent is superseded: the width continuum is
+    global, and the per-side getters now carry *presence-collapse* (not pressure-split).
+    Line 194's `leftVisible === rightVisible === effectivelyOn` invariant **no longer
+    holds** under the empty-collapse rule. **[MF-10]:** C-1 must rewrite the 195-199
+    comment to record (a) global `widthMode`, (b) per-side presence-collapse to `off`,
+    (c) genuine per-side *width* re-split deferred to Stage E / #917 — otherwise the code
+    decides "global+presence" next to a comment promising "pressure-split." Deliberate
+    override of a prior cleave-lock — surfaced to Bryan, not folded silently.
+
+- **docx carve-out `[MF-1, CRDT-HIGH]`.** The `marginColumn` snippet (`App.svelte:1528`)
+  renders at **four** sites — docx `1585/1586` + non-docx `1615/1620` — and sources
+  `width/edgeInset/gap` from the `MARGIN_VIEW_*` consts (`1533-1535`). Threading
+  continuum geometry blindly rewrites docx margins at narrow/stub widths (violates the
+  umbrella plan's "non-docx only" lock §1) and a blanket `effectivelyOn = mode !== 'off'`
+  drops docx's auto-hide threshold to the stub→off floor. **Resolution:** continuum is
+  **non-docx only**; docx keeps the legacy `narrowSticky` path verbatim; the model
+  exposes one **format-clamped** `mode` getter (docx → `full|off`).
+
+## 3. Stage-model changes (`src/client/layout/editor-stage.svelte.ts`)
+
+### 3.1 Keep the legacy path intact `[MF-1, MF-7]`
+
+**Do not touch** `narrowSticky`, `nextNarrowSticky`, `narrowThresholdPx`, or
+`MIN_EDITOR_WIDTH_PX = 480`. This preserves `tests/client/editor-stage.test.ts:135-145`
+(`narrowThresholdPx(0) === 2*272 + 480 = 1024`) **byte-for-byte**.
+
+> **ch-floor REVERSED from the design draft.** The draft proposed replacing
+> `MIN_EDITOR_WIDTH_PX` with a `STUB_OFF_FLOOR_CH` ch-based floor. The reviewers showed
+> this (a) breaks the existing test, (b) makes the "narrowThresholdPx tests pass
+> unchanged" claim false, and (c) introduces a reactive read that **never converges on
+> font-load** (a font load fires no `resize`; only `{viewport,thresholds}` are tracked).
+> The `t2–t3` gap (≈264px) dwarfs any ch error, so a fixed-px floor loses nothing.
+> **Decision: keep `MIN_EDITOR_WIDTH_PX` as the floor for all three bands.** The
+> ch-floor (C6) is explicitly deferred; if ever adopted, thresholds must key on a
+> tracked `measureCh` signal, never `getComputedStyle` inside the effect.
+
+### 3.2 The geometry table
+
+```ts
+export type MarginMode = "full" | "narrow" | "stub" | "off";
+
+export const MARGIN_TRACK_GEOMETRY: Record<
+  MarginMode,
+  { column: number; inset: number; gap: number; reserve: number }
+> = {
+  full:   { column: 240, inset: 8, gap: 24, reserve: 272 }, // = today's MARGIN_VIEW_* scalars
+  narrow: { column: 160, inset: 8, gap: 24, reserve: 192 }, // ESTIMATE — lock in review/dogfood
+  stub:   { column: 28,  inset: 8, gap: 24, reserve: 60  }, // ESTIMATE — C13 anchor pill + zone
+  off:    { column: 0,   inset: 0, gap: 0,  reserve: 0   }, // gutters reabsorb the track
+};
+```
+
+- **Invariant (unit-tested):** `column + inset + gap === reserve` per non-off mode;
+  `off` all-zero.
+- **Single source of truth:** the grid template (via `stageLayerStyle`) and
+  `MarginColumn`'s `width/edgeInset/gap` both read from this table.
+- **Redefine the four `MARGIN_VIEW_*` exports off `MARGIN_TRACK_GEOMETRY.full`** — keep
+  all four (App:80-82 import the three scalars for the shared snippet; the unit test
+  imports `RESERVE_PER_SIDE_PX`). Values unchanged.
+- **`[MF-5]` Freeze the SHAPE, not invented px.** `full`/`off` rows are locked. The
+  estimates — `narrow.column` (160), `stub.column` (28), narrow/stub `reserve` — are
+  finalized in plan review + the manual visual pass. Add
+  `expect(GEOM.full.column).toBe(MARGIN_VIEW_COLUMN_WIDTH_PX)` so a future retune can't
+  silently shift the default-mode C-3 leaders.
+
+### 3.3 Thresholds + the pure mode helper
+
+```ts
+// Pure. Each boundary is derived from the geometry it gates; railsWidthPx + the
+// MIN_EDITOR_WIDTH_PX floor are additive and cancel in inter-band differences, so
+// band ordering is rails-independent.
+export function marginModeThresholds(railsWidthPx: number): {
+  t1: number; // full → narrow  = 2*GEOM.full.reserve   + rails + MIN_EDITOR_WIDTH_PX  (= narrowThresholdPx, delegate)
+  t2: number; // narrow → stub  = 2*GEOM.narrow.reserve + rails + MIN_EDITOR_WIDTH_PX
+  t3: number; // stub → off     = 2*GEOM.stub.reserve   + rails + MIN_EDITOR_WIDTH_PX
+} { /* t1 delegates to narrowThresholdPx(rails) for full-band identity */ }
+```
+
+`t1` delegates to the **unchanged** `narrowThresholdPx` (full-band identity → existing
+test stays valid). With locked reserves + rails=0: `t1 = 1024`, `t2 = 864`, `t3 = 600`.
+Inter-band gaps `t1−t2 = 160`, `t2−t3 = 264` — both `> 2*MARGIN_VIEW_HYSTERESIS_PX (=64)`,
+so 32px bands never overlap. **`[svelte-MED]`** Update the cleave-doc's stale `~180/~336`
+estimates to these real `160/264` numbers so the ordering test asserts against matching
+prose.
+
+```ts
+// Pure, numeric-in / MarginMode-out. Named `nextMarginMode` (a `nextMode` already lives
+// in word-count-cycle.ts — avoid the grep collision).
+//
+// [MF-2] MUST CLAMP on multi-band jumps. Compute the target band from width via
+// strict-< entry thresholds, apply per-boundary hysteresis ONLY against the boundary
+// adjacent to `prev`, and NEVER hold a `prev` more than one band from the current width
+// band. A multi-band jump (full → off in one frame) must SNAP, not stick.
+export function nextMarginMode(
+  prev: MarginMode,
+  viewportWidth: number,
+  thresholds: { t1: number; t2: number; t3: number },
+  hysteresisPx: number,
+): MarginMode { /* ... */ }
+```
+
+### 3.4 The width-driven mode `$state` + guarded `$effect`
+
+Mirror the shipped `narrowSticky` effect (`:171-181`):
+
+```ts
+let widthMode = $state<MarginMode>("full");
+$effect(() => {
+  const w = opts.getViewportWidth();
+  const th = thresholds;                  // tracked: {viewport, thresholds}
+  const prev = untrack(() => widthMode);  // NOT a tracked dep
+  const next = nextMarginMode(prev, w, th, MARGIN_VIEW_HYSTERESIS_PX);
+  if (next === prev) return;              // [MF-2/C10] literal last-value guard
+  widthMode = next;                       // one-way; never writes rail/settings
+});
+```
+
+- **No `marginView` in the effect** — on/off intent stays a `$derived` gate (mirrors
+  today's `effectivelyOn = getMarginView() && !narrowSticky`).
+- **No per-side rail boolean** — rail enters only via `railsWidthPx` inside the
+  threshold (the seam's "rail-closed-on-that-side" key is stale per #892).
+- **No ResizeObserver, no `dispose()`** `[CRDT-confirmed]` — viewport arrives via the
+  existing `getViewportWidth()` getter; the factory stays a getter-returning object
+  invoked once in App's effect root (C14 satisfied; adding teardown would regress A+B).
+
+### 3.5 Format-clamped `mode` getter + derived visibility `[MF-1, MF-3, MF-4, MF-10]`
+
+**`[MF-10]` first, before adding modes:** rewrite the `leftVisible`/`rightVisible`
+comment at `editor-stage.svelte.ts:195-199`. It currently promises Stage C "re-splits
+them … based on collision pressure" — the rejected driver. Replace with: the shrink
+continuum is a **global `widthMode`** (symmetric tracks, no per-side *width* asymmetry);
+the per-side getters now carry **presence-collapse** — a side with no pending annotations
+clamps to `off` while the other keeps `widthMode`; genuine per-side *width* re-split is
+deferred to Stage E / #917. **The `leftVisible === rightVisible === effectivelyOn`
+invariant (line 194) NO LONGER HOLDS** — empty-collapse is exactly what breaks it. Delete
+that invariant line rather than preserve it; any A+B code or test asserting it must be
+updated (grep for it before landing).
+
+
+```ts
+const isDocx = $derived(opts.getFormat() === "docx");
+
+// Global on/off gate × the global width continuum (widthMode is the single
+// $state written by the one guarded $effect in §3.4). docx keeps the legacy
+// full|off path verbatim — NO continuum, NO presence-collapse (carve-out below).
+const baseMode = $derived<MarginMode>(
+  isDocx
+    ? (opts.getMarginView() && !narrowSticky ? "full" : "off")
+    : (opts.getMarginView() ? widthMode : "off"),
+);
+
+// Presence-collapse [Bryan 2026-05-28]: a side with no PENDING annotations
+// clamps to off. Pure $derived — presence is a stable binary, no effect/loop.
+// docx is exempt (legacy both-sides-together): clamp only applies non-docx.
+const leftMode  = $derived<MarginMode>(
+  !isDocx && !opts.getLeftHasPending()  ? "off" : baseMode,
+);
+const rightMode = $derived<MarginMode>(
+  !isDocx && !opts.getRightHasPending() ? "off" : baseMode,
+);
+
+const leftVisible  = $derived(leftMode  !== "off");
+const rightVisible = $derived(rightMode !== "off");
+const effectivelyOn = $derived(leftVisible || rightVisible); // docx: == legacy gate
+const leftGeometry  = $derived(MARGIN_TRACK_GEOMETRY[leftMode]);
+const rightGeometry = $derived(MARGIN_TRACK_GEOMETRY[rightMode]);
+```
+
+- **Two new opts** `getLeftHasPending`/`getRightHasPending: () => boolean` — derive from
+  the **ungated** `visibleAnnotations` (`App.svelte:193`), applying a shared side-split
+  predicate + `status === "pending"`. **NOT** from the `effectivelyOn`-gated
+  `marginNotes`/`marginComments` (`:1032-1039`) — that closes a `$derived` cycle (see §2
+  `[MF-11]` CRITICAL). `positions.has` is deliberately excluded (also gated). `[MF-11]`
+- **docx carve-out preserved:** presence-collapse is `!isDocx`-gated, so the docx path
+  stays byte-identical to legacy (both sides share `baseMode`, no empty-side divergence).
+  Empty-collapse for docx margins is out of scope (umbrella "non-docx only" lock); revisit
+  with the docx-margin follow-up if ever wanted. **← assumption open for Bryan's veto.**
+- Expose **per-side** `leftMode`/`rightMode` + `leftGeometry`/`rightGeometry` getters (App
+  sources each call site's `width/edgeInset/gap` from its own side's geometry; an empty
+  side's geometry is the `off` row `{0,0,0}` → 0 track, centering reabsorbs it). The old
+  "one `mode`/`geometry`" surface from the pre-empty-collapse draft is replaced by the
+  per-side pair. `[MF-3]`
+- docx/non-docx App branches are mutually exclusive per active tab (`App.svelte:1581`).
+  Within a tab, the left call site gets `leftMode`/`leftGeometry`, the right gets
+  `rightMode`/`rightGeometry`; docx's two sides resolve equal (no presence-collapse), so
+  the carve-out is invisible there.
+- **`stageLayerStyle`** gains `leftReservePx`/`rightReservePx` for the non-docx branch,
+  sourced from `leftGeometry`/`rightGeometry` totals (`column+inset+gap`) — an empty side
+  is the `off` row → 0 reserve, which is the per-side empty-collapse landing in the grid.
+  The **docx branch stays byte-identical** (reads `effectivelyOn` → `position:relative`
+  | `display:contents`). Keep `effectivelyOn` in `StageLayerStyleInput` for docx; add
+  the reserves alongside `[svelte-LOW]`. Update the unit matrix to the new shape and add
+  the asymmetric cases (left-pending-only, right-pending-only); docx cases keep passing
+  `effectivelyOn` unchanged.
+
+## 4. App.svelte changes
+
+In the `marginColumn` snippet (`1528-1549`): replace the three module-const props with
+per-side geometry, and **add a `mode` prop**. The **left** call sites pass
+`{...editorStage.leftGeometry}` + `mode={editorStage.leftMode}`; the **right** call sites
+pass `{...editorStage.rightGeometry}` + `mode={editorStage.rightMode}`. Presence-collapse
++ format clamp both live in the getters, so docx still gets `full` geometry and an empty
+non-docx side gets `off` (0) geometry automatically — App threads side-correct values
+without branching. `createEditorStageModel` now also receives
+`getLeftHasPending`/`getRightHasPending`, **wired from the ungated `visibleAnnotations`
+(`:193`) through a shared side-split predicate** (extract the `type==="note"` /
+`author==="import"||type==="comment"` split into a helper both the C3 render arrays and
+these booleans call). **Do NOT wire them from `marginNotes`/`marginComments` (`:1032-1039`)
+— those are `effectivelyOn`-gated and close a `$derived` cycle (§2 `[MF-11]`).**
+`editor-stage.layerStyle` consumption and the `{#if leftVisible/rightVisible && activeTab}`
+guards are otherwise unchanged (the guards now genuinely diverge per side under
+empty-collapse — intended behavior, not a regression). **No track-width transition CSS**
+(Stage D). Restate the no-padding/no-border INVARIANT 3/4 in the PR description.
+
+## 5. MarginColumn.svelte — additive only `[shared-file: clean stack]`
+
+Add `mode: MarginMode` to `Props` (import `type MarginMode` from
+`../layout/editor-stage.svelte`). **Pure pass-through in C-1 — no template/render
+change.** `width/edgeInset/gap` arrive mode-resolved from App, so the existing
+`editorX`/`columnX`/`leaderStyle` `$derived` (lines 71-75) and the C-3 bezier leaders
+auto-fit the narrower track.
+
+> **`[MF-6]` REJECT** collapsing `width/edgeInset/gap` into an internal
+> `$derived(MARGIN_TRACK_GEOMETRY[mode])` — it rewrites lines 71-75, the exact geometry
+> the shipped C-3 leaders read, enlarging the shared diff into the C-3 surface. Keep the
+> numeric props App-sourced; `mode` is purely additive. This is what keeps C-1↔C-2 a
+> **clean stack** (C-1 edits only the Props interface; C-2 edits only the bubble
+> each-block — no textual overlap, no merge conflict).
+
+## 6. marginCollision.ts — documentation only `[MF-9]`
+
+Add a comment on `resolveCollisions` recording the stub-non-push contract: a stub must
+not advance the collision cursor; C-2 honors it by passing `height: undefined` for
+stubs, which `resolveCollisions` **already** skips (line 56, confirmed). **No logic
+change. NOT a shared file** (C-2 touches nothing there).
+
+## 7. AnnotationCard.svelte — NOT touched in C-1 `[MF-8]`
+
+The `density` prop introduction + behavior is **C-2-owned** (single owner; overrides
+cleave-locks L52/L59 which had placed the inert prop in C-1).
+
+## 8. Test plan
+
+- **UNIT** `MARGIN_TRACK_GEOMETRY` invariant (`it.each`): non-off → `column+inset+gap===reserve`;
+  off → all-zero; `GEOM.full.column === MARGIN_VIEW_COLUMN_WIDTH_PX`.
+- **UNIT** `marginModeThresholds`: `t1>t2>t3` for rails ∈ {0,300,600}; each gap `>64`,
+  asserted against locked reserves; `t1 === narrowThresholdPx(rails)`.
+- **UNIT** `nextMarginMode` bands (`it.each` + `why`): `w<t3→off` regardless of prev;
+  `[t3,t2)→stub`; `[t2,t1)→narrow`; `w≥t1→full`; deadband-wider holds prev;
+  deadband-narrower holds prev; **multi-band jump** `prev='full', w<t3 → 'off'` `[MF-2]`.
+- **UNIT** presence-collapse (`it.each` + `why`): non-docx, `widthMode='full'` —
+  both-pending → `leftMode=rightMode='full'`; left-only → `leftMode='full',
+  rightMode='off'`; right-only → mirror; neither → both `'off'`. **docx exempt:** same
+  four presence combos all resolve `leftMode===rightMode` (carve-out). `[MF-11]`
+- **UNIT** `stageLayerStyle` matrix (new input shape): docx on/off byte-identical;
+  non-docx both reserves 0 → both tracks `0px`; **asymmetric** (left-pending-only →
+  left `272px`, right `0px`) ; mixed; narrow → 192px; measure threading.
+- **UNIT (regression)** `nextNarrowSticky` + `narrowThresholdPx` tests unchanged `[MF-1]`.
+- **E2E** continuum sweep: `full → narrow → stub → off` viewport sweep; tracks narrow
+  monotonically (272→192→60→0); stage element never re-binds (INVARIANT 1).
+- **E2E** empty-collapse asymmetry: annotate one side only → that track holds
+  `widthMode` geometry, the empty side's track is `0px`, content recenters; removing the
+  last annotation collapses its track live (and adding the first re-expands it). `[MF-11]`
+- **E2E (cycle regression — the converged blocker)** margin view on + pending annotations
+  on a side **actually renders that column** (not silently empty). This is the assertion
+  that fails loudly if presence is ever re-wired off the `effectivelyOn`-gated arrays and
+  the `$derived` cycle latches "all-off". `[MF-11]`
+- **E2E** off-mode renders nothing + **no rail open**: both columns count 0, both tracks
+  `0px`, rail-visibility localStorage byte-identical before/after (reuse `:735` compare).
+- **E2E (regression)** **docx stays full|off**: docx tab at an intermediate viewport keeps
+  full-width margins — guards the CRDT-HIGH fix.
+- Gates: `typecheck` + `test` + `svelte-check` + `test:e2e -- margin-view` + `check:tokens`.
+
+## 9. Build sequence
+
+1. `MarginMode` + `MARGIN_TRACK_GEOMETRY`; redefine `MARGIN_VIEW_*` off `GEOM.full`. Invariant test (red→green).
+2. `marginModeThresholds` (keep `narrowThresholdPx`/`MIN_EDITOR_WIDTH_PX` untouched; `t1` delegates). Ordering test.
+3. Pure `nextMarginMode` (clamping) + `it.each` incl. multi-band row.
+4. `widthMode` `$state` + guarded `$effect`; add `getLeftHasPending`/`getRightHasPending` opts; `baseMode` + presence-clamped `leftMode`/`rightMode` + `leftVisible`/`rightVisible`/`effectivelyOn`/`leftGeometry`/`rightGeometry` getters; extend `stageLayerStyle` (per-side reserves); update matrix + presence-clamp test.
+5. App.svelte: wire `getLeftHasPending`/`getRightHasPending` from the **ungated** `visibleAnnotations` (`:193`) via a shared side-split predicate + `status==="pending"` — NOT the gated `marginNotes`/`marginComments` (`:1032-1039`) and NOT `positions.has` (cycle, §2 `[MF-11]`); thread per-side geometry + per-side `mode`; confirm `layerStyle` consumers unchanged. typecheck + svelte-check.
+6. MarginColumn: add `mode` prop (pass-through). marginCollision.ts comment.
+7. E2E continuum sweep + docx-stays-full regression.
+8. Full gate run.
+
+## 10. Risks
+
+| Risk | Sev | Mitigation |
+|---|---|---|
+| **Presence `$derived` cycle** (wiring off `effectivelyOn`-gated arrays) | **HIGH** | Source from ungated `visibleAnnotations` + shared predicate, exclude `positions.has`; cycle-regression E2E asserts a pending side renders `[MF-11]` |
+| `effect_update_depth_exceeded` under ResizeObserver chatter | HIGH | Literal `if(next===widthMode)return;` + `untrack`; mirrors shipped effect `[MF-2]` |
+| Hysteresis bands overlap → flicker | MED | Ordering test asserts each gap `>64` against locked reserves (160/264 with shipped estimates) |
+| docx margin regression (4 call sites) | — | Format-clamped `mode` getter + docx-stays-full E2E `[MF-1]` |
+| Redefining `MARGIN_VIEW_*` breaks a consumer | LOW | Keep all four exports `= GEOM.full.*`; grep-confirmed consumers App:80-82 + unit test |
+| C-3 leader regression from threaded geometry | LOW | `GEOM.full` byte-identical to today at default; C-3 bezier spec + continuum sweep guard |
+
+## 11. Open items for plan review / dogfood
+
+- **`narrow.column` / `stub.column` actual px** — visual taste; estimates (160/28) pending
+  the manual claude-in-chrome pass. `t2` is sensitive to `narrow.column`; re-assert the
+  gap-`>64` test against whatever is locked.
+- **Empty-side gutter — now RESOLVED by presence-collapse (Bryan 2026-05-28).** Previously
+  noted as "an empty side still reserves a track"; the empty-collapse rule sends a
+  no-pending side to `off` (0 track), so there is no longer a blank gutter. This also
+  retires a residual slice of umbrella defect #1 at side granularity.
+- **Both-empty at full width:** with margin view on but zero annotations anywhere, both
+  sides collapse to `0` — the editor renders full-measure with no tracks. Confirm this
+  reads as intended (no empty margins) and not as "margin view silently broke"; the
+  setting toggle still reflects on/off independent of presence. Quick dogfood check.

--- a/docs/plans/2026-05-28-stage-c2-density-variants.md
+++ b/docs/plans/2026-05-28-stage-c2-density-variants.md
@@ -1,0 +1,204 @@
+# Stage C-2 — Density variants (clamp-until-active + stub pill)
+
+> **Status:** review-hardened plan (agent-team coordinated 2026-05-28). **Stacks on
+> [Stage C-1](2026-05-28-stage-c1-margin-mode-continuum.md)** — do NOT start until C-1
+> merges (sequencing gate §0). Lands on `feat/design-system-impl`. **Locked decisions:**
+> [stage-c-cleave-locks.md](2026-05-28-stage-c-cleave-locks.md). **Umbrella plan:** §5,
+> C2/C13.
+>
+> Produced by the `stage-c-coordinate` agent team (svelte + annotation-model review →
+> synthesis). Every `c2MustFix` is folded in and tagged `[MF-n]`.
+
+## 0. Sequencing gate `[MF-8]`
+
+C-1 must merge first — it lands the `mode: MarginMode` prop on `MarginColumn`, threads
+it from App, and locks `MARGIN_TRACK_GEOMETRY`'s band thresholds. C-2 **designs against
+C-1's contract now** but implements/lands after. Before coding, **re-verify the three
+consumer identifiers against C-1's actual merged code** (not the seam prose):
+`editorStage.mode`, the `MarginMode` export path, and the `AnnotationCard.density`
+signature. C-2's E2E viewport widths are **derived from C-1's locked geometry** — read
+the merged `MARGIN_TRACK_GEOMETRY` numbers, never the estimates.
+
+## 1. Scope
+
+Density variants on the **production `AnnotationCard` dispatcher**, keyed on the
+`MarginMode` prop C-1 threads into `MarginColumn`:
+
+- **`clamped`** (narrow band, inactive): single-line teaser; body/actions/replies hidden.
+- **`stub`** (stub band, inactive): 22px anchor pill — author dot + status pip only.
+- **`full`**: today's card, unchanged.
+
+Implemented as **CSS density-modifier classes on the existing dispatcher + shared
+chrome** (plan C2 — NOT a flat `data-kind` bundle bubble). Preserves the left=notes /
+right=comments+imports side-split + `status==='pending'` filter (C3), `cardTint` at
+**exactly 6 branches** (C13), stub **never `display:none`** on the bubble wrapper, and
+ADR-027 (notes never reach Claude; collapse is display-only).
+
+## 2. New pure module — `src/client/panels/cardDensity.ts`
+
+Sibling pattern (mirrors `marginCollision.ts` / `marginLeaderGeometry.ts`) so density is
+unit-testable without mounting (`feedback_extract_helper_over_mount`).
+
+```ts
+import type { Annotation } from "../../shared/types";
+import type { MarginMode } from "../layout/editor-stage.svelte";
+
+export type Density = "full" | "clamped" | "stub";
+
+// Reads ONLY (mode, isActive, isEditing, author) — NEVER collision output
+// (heights / adjustedPositions). One-way density → collision-INPUT; the
+// height→density→height cycle is structurally impossible [MF-6, CRDT-F4, Svelte-F3].
+export function cardDensity(args: {
+  mode: MarginMode;
+  isActive: boolean;
+  isEditing: boolean;
+  author: Annotation["author"];
+}): Density {
+  if (args.isEditing) return "full";                 // edit forces full (min density floor)
+  if (args.isActive) return "full";                  // focused card always full
+  if (args.author === "import" && args.mode === "stub") return "clamped"; // import never stub [F4]
+  switch (args.mode) {
+    case "narrow": return "clamped";
+    case "stub":   return "stub";
+    default:       return "full"; // full + off (off column unmounts anyway)
+  }
+}
+```
+
+`cardDensity.test.ts` — `it.each` equivalence table with a `why` column
+(`feedback_iteach_equivalence_classes`): isEditing-override across every mode; off;
+full active+inactive; narrow active(full)/inactive(clamped); stub active(full)/inactive(stub);
+**import+stub+inactive → clamped** (never stub); import+active → full. Totality over
+`MarginMode × {active,inactive} × {editing,not} × {user,claude,import}`.
+
+## 3. AnnotationCard.svelte + the 5 variant files `[MF-1]`
+
+**`[MF-1]` the `:global()` collapse needs concrete hooks — the variant body is an
+unclassed `<div style=…>`.** Confirmed: `CommentCard.svelte:33`, `SuggestionCard.svelte:33`
+etc. have no class/testid for the body, so `:global()` has nothing to target. **Add to
+`filesToModify`** (the design draft omitted them):
+
+- **CommentCard, NoteCard, SuggestionCard, HighlightCard, ImportedCard:** add a stable
+  `aca-body` class to the body `<div>`.
+- **ReplyThread.svelte:** add a stable root class.
+
+In **AnnotationCard.svelte**:
+
+- Add `density?: Density = 'full'` prop (introduction + behavior is C-2-owned).
+- `const resolvedDensity = $derived(isEditing ? 'full' : density)` — the dispatcher is
+  the only place `isEditing` is known; it forces `full`.
+- Apply as classes on the root `.tandem-annotation-card`:
+  `class:is-density-clamped={resolvedDensity === 'clamped'}`,
+  `class:is-density-stub={resolvedDensity === 'stub'}`, plus `data-density={resolvedDensity}`
+  for E2E. **Do NOT branch the dispatch** — variants stay mounted (Svelte-F2).
+- `<style>`:
+  - **`[MF-3]` line-clamp full recipe.** `-webkit-line-clamp:1` alone is a no-op and
+    cannot span the snippet + body siblings. Pick ONE clamp target: **hide the snippet,
+    clamp `.aca-body`'s first paragraph** with the full recipe
+    `display:-webkit-box; -webkit-box-orient:vertical; -webkit-line-clamp:1; overflow:clip;`
+    (`overflow:clip`, not `hidden` — `feedback_overflow_hidden_vs_clip`). Hide the action
+    row (`.aca-row`), reply thread, and expand button in `clamped`.
+  - **`stub`:** KEEP `AnnotationCardHeader` (badge + 6px author dot) visible; HIDE the
+    snippet, `.aca-body`, `.aca-row`, reply thread, expand button. Status pip via the
+    stub surface below.
+- **`[MF-5]` stub status pip — do NOT use `cardTint` as a border.** `cardTint` returns
+  pale `-bg` fill tokens (verified `:80-88`, exactly 6 branches); a 3px border in a
+  near-surface fill is invisible. Use the matching **`-fg-strong`** token for the pip
+  only. **`cardTint` stays at 6 branches — no 7th `stub` branch** (C13).
+- **`[MF-7]` ReplyThreadOverlay close-on-→stub** guarded `$effect` (last-value guard,
+  `feedback_svelte_effect_depth_guard`):
+  ```ts
+  let prevDensity = resolvedDensity;
+  $effect(() => {
+    if (resolvedDensity === prevDensity) return;
+    prevDensity = resolvedDensity;
+    if (resolvedDensity === "stub") isThreadOverlayOpen = false;
+  });
+  ```
+- Stub-pill click reuses the dispatcher's existing root `onclick={onClick}` → sets
+  `activeAnnotationId` → density re-derives to `full` (Svelte-F6). No new handler.
+- **`[svelte-LOW]`** Drop the redundant `:not(.is-review-target)` qualifier — a clamped/
+  stub card is inactive by construction (active → `cardDensity` returns `full`, so neither
+  class is applied). Use `.is-density-clamped .aca-row { display:none }`.
+
+## 4. MarginColumn.svelte — density derivation + collision routing
+
+- Add `mode: MarginMode` to `Props` *(landed by C-1; C-2 consumes)*. Import `cardDensity`.
+- In the bubble `{#each placeable}` block: `{@const density = cardDensity({ mode, isActive: ann.id === activeAnnotationId, isEditing: false, author: ann.author })}` and pass `{density}` to `<AnnotationCard>`.
+- **Stub ↔ collision:** in the `adjustedPositions` `$derived.by` input, set
+  `height: density === 'stub' ? undefined : heights.get(a.id)` so a stub reuses the
+  EXISTING "unknown height ⇒ don't advance cursor" path (`marginCollision.ts:56`). Re-derive
+  density inside `adjustedPositions.by` over `placeable` (keyed on `mode` + `activeAnnotationId`
+  — both reactive, neither collision output → **no cycle**).
+- **`[MF-2]` editing-stub collision mismatch (annotation-MED, reachable).** A not-active
+  card being edited renders full-height (`resolvedDensity` forces `full`) but
+  `MarginColumn` computes density with `isEditing:false` → `stub` → `height:undefined` →
+  excluded from collision → **overlaps neighbors**. **Fix = force-active-on-edit:**
+  entering edit sets `activeAnnotationId`, so `(mode,isActive)` yields `full` in BOTH the
+  collision input and the render. (Reviewer's "skip when height absent" alternative is
+  flawed — a stub records a ~22px `clientHeight`, so absent-height can't identify stubs.)
+  Lock the mechanism here.
+- Keep the bubble wrapper `div` mounted with `pointer-events:auto` in stub mode (the CARD
+  collapses; the wrapper persists so the pill is clickable — **stub ≠ display:none**).
+- Leave the leader SVG block, the `status==='pending'` filter in `placeable`, and the
+  `getVisibleReplies` ADR-027 lookup unchanged (C3 + ADR-027).
+
+## 5. App.svelte
+
+In the `<MarginColumn>` invocation add `mode={editorStage.mode}`. No other C-2 change —
+the `marginNotes`/`marginComments` side-split and `effectivelyOn` gating stay exactly as
+today (C3).
+
+## 6. Correctness note the agent team flagged `[MF-4]`
+
+**Stub-push prose was wrong.** `resolveCollisions` sets `next = Math.max(top, cursor)` for
+EVERY bubble incl. `height:undefined` (line 54), so a stub **does not advance** the cursor
+but **can still be pushed down** by a preceding full bubble. Code comments + the PR must
+say: *"a stub never ADVANCES the cursor; it may still be displaced by a preceding full
+bubble."* E2E spec 4 tests only **adjacent** stubs (both `undefined` → genuinely share raw
+tops); do **not** strengthen it to assert raw-top in mixed full+stub stacks.
+
+## 7. Test plan
+
+- **UNIT** `cardDensity.test.ts` (`it.each` + `why`): the full equivalence table from §2
+  incl. import-never-stub and isEditing-override.
+- **UNIT** `marginCollision.test.ts` (add cases): `height:undefined` does not advance the
+  cursor; mixed full(height)+stub(undefined) — stub doesn't push but can be pushed.
+- **E2E** (`margin-view.spec.ts`, derive widths from C-1's locked geometry): (1) clamp-
+  until-active — narrow band, inactive comment `data-density='clamped'` + action row
+  hidden; click → `full` + actions visible + **assert the clamped element's rendered
+  height** (not just visibility) `[MF-3]`; (2) stub mode — header visible, body/actions
+  hidden, click → `full`; (3) stub wrapper persists (`[data-testid^='margin-bubble-']`
+  count>0, attached); (4) two **adjacent** inactive stubs share raw tops; (5) ADR-027 —
+  left-column note in stub keeps `data-margin-bubble-reply-count='0'`; (6) **no console
+  error** across `full→narrow→stub→full→edit` (effect-depth guard); (7) editing-stub does
+  not overlap (force-active-on-edit) `[MF-2]`.
+- **MANUAL** (claude-in-chrome): all 5 variants at `clamped` + `stub`; SuggestionCard
+  diff-box clamp acceptable; **ImportedCard never stub**; stub pip color per type
+  (`-fg-strong`) actually perceivable; reduced-motion unaffected (C-2 adds no motion).
+- **REGRESSION:** existing `margin-view.spec.ts` suite stays green (C-2 adds a `full`-
+  default prop reproducing today's behavior at `mode==='full'`).
+
+## 8. Build sequence
+
+0. **Gate:** C-1 merged; re-verify the 3 consumer identifiers against merged code.
+1. `cardDensity.ts` + `Density` type.
+2. `cardDensity.test.ts` `it.each` table FIRST (the equivalence classes are the spec); red→green.
+3. The 5 variant files + ReplyThread: add `aca-body` / root classes.
+4. AnnotationCard: `density` prop + `resolvedDensity` + classes/data-attr + clamp/stub `<style>` (full line-clamp recipe; `-fg-strong` pip; `cardTint` 6 branches) + guarded overlay-close `$effect`. svelte-check.
+5. MarginColumn: derive density, thread `{density}`, route stubs to `height:undefined`, force-active-on-edit. svelte-check.
+6. App.svelte: `mode={editorStage.mode}`.
+7. `typecheck` + `test`; then read C-1's geometry numbers, write E2E density specs, `test:e2e -- margin-view`.
+8. Manual chrome pass (5 variants × clamp/stub). `/simplify`, commit, PR.
+
+## 9. Risks
+
+| Risk | Sev | Mitigation |
+|---|---|---|
+| Editing-stub excluded from collision → overlap | MED | Force-active-on-edit `[MF-2]`; E2E spec 7 |
+| `:global()` collapse has no selector hooks | MED | Add `aca-body` + ReplyThread root class to the 6 files `[MF-1]`; E2E header-visible/body-hidden turns a rename into a test failure |
+| line-clamp no-op / can't span siblings | MED | Full `-webkit-box` recipe on a single named target (`.aca-body` first ¶); E2E asserts clamped height `[MF-3]` |
+| Stub pip invisible | LOW | `-fg-strong` token, not `cardTint` border; manual pass per type `[MF-5]` |
+| Density→collision cycle | — | `cardDensity` reads only inputs; one-way into collision input; documented `[MF-6]` |
+| SuggestionCard multi-block body clamps to diff line only | LOW | Accept documented single-visible-line; verify in manual pass |
+| Stub bubbles overlap leaders at dense clusters | LOW | Documented bundle behavior; light stub spacing deferred to Stage D / #916 |

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -75,12 +75,7 @@ import { createUpdaterBanner } from "./hooks/useUpdaterBanner.svelte";
 import { createViewportWidth } from "./hooks/useViewportWidth.svelte";
 import { createWebViewZoom } from "./hooks/useWebViewZoom.svelte";
 import { createYjsSync } from "./hooks/yjsSync.svelte";
-import {
-  createEditorStageModel,
-  MARGIN_VIEW_COLUMN_WIDTH_PX,
-  MARGIN_VIEW_EDGE_INSET_PX,
-  MARGIN_VIEW_GAP_PX,
-} from "./layout/editor-stage.svelte";
+import { createEditorStageModel } from "./layout/editor-stage.svelte";
 import { createLayoutModel } from "./layout/model.svelte";
 import { loadPanelWidth, PANEL_MAX_WIDTH, PANEL_MIN_WIDTH } from "./panel-layout";
 import {
@@ -90,6 +85,7 @@ import {
   sendNoteToClaude as marginSendNoteToClaude,
 } from "./panels/annotation-actions";
 import MarginColumn from "./panels/MarginColumn.svelte";
+import { isLeftMarginAnnotation, isRightMarginAnnotation } from "./panels/marginSides";
 import PeekStrip from "./panels/PeekStrip.svelte";
 import { useAnnotationReview } from "./panels/useAnnotationReview.svelte";
 import { pmSelectionToFlat } from "./positions";
@@ -689,6 +685,16 @@ const editorStage = createEditorStageModel({
   getLeftRailVisible: () => effectiveLeftVisible,
   getRightRailVisible: () => effectiveRightVisible,
   getViewportWidth: () => viewport.width,
+  // Presence-collapse inputs. Read the UNGATED `visibleAnnotations` (declared
+  // above, `= yjsSync.annotations`) through the shared side-split predicates +
+  // `status === "pending"` — the same set the column renders. NOT
+  // `marginNotes`/`marginComments` (declared below, `effectivelyOn`-gated):
+  // those would close a `$derived` cycle through `effectivelyOn`. See stage-c1
+  // [MF-11].
+  getLeftHasPending: () =>
+    visibleAnnotations.some((a) => a.status === "pending" && isLeftMarginAnnotation(a)),
+  getRightHasPending: () =>
+    visibleAnnotations.some((a) => a.status === "pending" && isRightMarginAnnotation(a)),
   leftRailWidthPx: leftPanelWidth,
   rightRailWidthPx: rightPanelWidth,
 });
@@ -1029,13 +1035,15 @@ const review = useAnnotationReview({
 // PR 1 ships minimum viable — bubbles appear at correct Y, naive scroll sync
 // via DOM nesting in the positioning layer. Collision resolution lands in
 // PR 2; rail-collapse and narrow-layout auto-disable in PR 3.
+// Side-split via the shared predicates (panels/marginSides) so these render
+// arrays and the editorStage presence-collapse booleans can never diverge.
+// Still gated on `effectivelyOn` here (the column only mounts when on); the
+// presence booleans deliberately read the ungated source instead (see above).
 const marginNotes = $derived(
-  editorStage.effectivelyOn ? visibleAnnotations.filter((a) => a.type === "note") : [],
+  editorStage.effectivelyOn ? visibleAnnotations.filter(isLeftMarginAnnotation) : [],
 );
 const marginComments = $derived(
-  editorStage.effectivelyOn
-    ? visibleAnnotations.filter((a) => a.author === "import" || a.type === "comment")
-    : [],
+  editorStage.effectivelyOn ? visibleAnnotations.filter(isRightMarginAnnotation) : [],
 );
 const marginPositions = createMarginPositions({
   getEditor: () => editor,
@@ -1526,13 +1534,21 @@ const tutorial = createTutorial(
          handlers are identical, so the distinct annotation wiring lives at the
          call site rather than in two near-identical bodies. -->
     {#snippet marginColumn(side: "left" | "right", annotations: readonly Annotation[])}
+      <!-- Per-side geometry + mode resolved from `side`: the format clamp (docx
+           → full|off) and presence-collapse (empty side → off) both live in the
+           editorStage getters, so each call site gets its side-correct width.
+           A side rendered here is never `off` (the {#if leftVisible/rightVisible}
+           guards gate mounting), so `geom` is always the live widthMode track. -->
+      {@const geom = side === "left" ? editorStage.leftGeometry : editorStage.rightGeometry}
+      {@const mode = side === "left" ? editorStage.leftMode : editorStage.rightMode}
       <MarginColumn
         {side}
         {annotations}
         positions={marginPositions.byId}
-        width={MARGIN_VIEW_COLUMN_WIDTH_PX}
-        edgeInset={MARGIN_VIEW_EDGE_INSET_PX}
-        gap={MARGIN_VIEW_GAP_PX}
+        width={geom.column}
+        edgeInset={geom.inset}
+        gap={geom.gap}
+        {mode}
         {activeAnnotationId}
         repliesById={marginReplies.byId}
         onClick={(ann) => {

--- a/src/client/layout/editor-stage.svelte.ts
+++ b/src/client/layout/editor-stage.svelte.ts
@@ -14,55 +14,94 @@
  * margins rendered; the grid gives those cases their full content width.
  *
  * Stage B drives `--editor-measure` from the `editorMeasure` reading-measure
- * preset (ch widths, or `100%` for "full"); the narrow → stub continuum +
- * animated tracks land in Stages C/D.
+ * preset (ch widths, or `100%` for "full"). Stage C-1 adds the
+ * full → narrow → stub → off width continuum (`widthMode`, a single global
+ * `$state`) plus a per-side presence-collapse (a side with no pending
+ * annotation hides while the other stays on); animated tracks land in Stage D.
  *
  * Factory invoked ONCE in App.svelte's `<script>` scope, mirroring
  * `createLayoutModel` (./model.svelte.ts). Returns getters so consumers see
  * reactivity through the settings/layout stores underneath. NOT a module-level
- * singleton — the internal `$effect` (narrow hysteresis) must run inside a
+ * singleton — the internal `$effect` (width-mode hysteresis) must run inside a
  * component effect root.
  */
 
 import { untrack } from "svelte";
 import { EDITOR_MEASURE_CH, type EditorMeasure } from "../hooks/useTandemSettings";
 
-// Margin-view layout constants. A margin track reserves a fixed-width bubble
-// column (COLUMN_WIDTH) + an edge inset (EDGE_INSET — breathing room against
-// the stage's outer edge) + a gap (GAP — the zone where leader lines connect
-// anchor text to bubbles). MarginColumn consumes all three via its
-// width/edgeInset/gap props, so RESERVE_PER_SIDE_PX is exactly the grid track
-// width that lets MarginColumn's existing absolute geometry land unchanged
-// inside a `position: relative` cell.
-export const MARGIN_VIEW_COLUMN_WIDTH_PX = 240;
-export const MARGIN_VIEW_EDGE_INSET_PX = 8;
-export const MARGIN_VIEW_GAP_PX = 24;
-export const MARGIN_VIEW_RESERVE_PER_SIDE_PX =
-  MARGIN_VIEW_COLUMN_WIDTH_PX + MARGIN_VIEW_EDGE_INSET_PX + MARGIN_VIEW_GAP_PX; // 272
+/**
+ * The four margin-track density modes along the width continuum. The shrink
+ * ladder is driven GLOBALLY by viewport width (`widthMode`); the model layers a
+ * per-side presence-collapse to `off` on top (a side with no pending annotation
+ * to render). Genuine per-side WIDTH divergence (different sizes per side) is
+ * deferred to Stage E / #917 — see
+ * docs/plans/2026-05-28-stage-c-cleave-locks.md §"Resolved forks" F1.
+ */
+export type MarginMode = "full" | "narrow" | "stub" | "off";
 
-// Below this readable content width the margin tracks auto-hide rather than
-// squeeze the editor into an unreadable strip. A hysteresis band keeps a
-// viewport drag through the threshold from flickering the tracks at 60fps.
-// Stage A preserves the single-band full↔off behavior of the old `narrowSticky`
-// flag; the full → narrow → stub → off continuum + re-quantified bands are
-// Stage C.
+export interface MarginTrackGeometry {
+  /** Bubble column width (px). */
+  readonly column: number;
+  /** Edge inset between the column and the stage's outer edge (px). */
+  readonly inset: number;
+  /** Leader-line gap zone between the text edge and the column's near edge (px). */
+  readonly gap: number;
+}
+
+/**
+ * Per-mode track geometry — the single source of truth for column widths.
+ * `full` is the shipped 240/8/24 (Stage A+B). `off` is all-zero: the grid track
+ * collapses and the `1fr` gutters reabsorb it (the per-side presence/visibility
+ * collapse lands here). The `narrow` (160) and `stub` (28) column widths are
+ * visual-taste ESTIMATES landed pending a dogfood pass (Bryan greenlit landing
+ * with estimates, 2026-05-28). `t2` in `marginModeThresholds` is sensitive to
+ * `narrow.column`; re-assert the band-gap test if these widths change.
+ */
+export const MARGIN_TRACK_GEOMETRY: Record<MarginMode, MarginTrackGeometry> = {
+  full: { column: 240, inset: 8, gap: 24 },
+  narrow: { column: 160, inset: 8, gap: 24 },
+  stub: { column: 28, inset: 8, gap: 24 },
+  off: { column: 0, inset: 0, gap: 0 },
+};
+
+/** Total horizontal width a margin track reserves for a mode's geometry. */
+export function marginReservePx(geometry: MarginTrackGeometry): number {
+  return geometry.column + geometry.inset + geometry.gap;
+}
+
+// Full-mode layout constants, derived from `MARGIN_TRACK_GEOMETRY.full` so the
+// table above is the single source of truth (a future tweak to full-mode
+// geometry flows to every consumer). MarginColumn now reads per-side geometry
+// from the model's `leftGeometry`/`rightGeometry` getters, not these constants;
+// `RESERVE_PER_SIDE_PX` is the full-mode grid track (used by the threshold math).
+export const MARGIN_VIEW_COLUMN_WIDTH_PX = MARGIN_TRACK_GEOMETRY.full.column; // 240
+export const MARGIN_VIEW_RESERVE_PER_SIDE_PX = marginReservePx(MARGIN_TRACK_GEOMETRY.full); // 272
+
+// Below this readable content width the margin tracks step down (and ultimately
+// auto-hide) rather than squeeze the editor into an unreadable strip. A
+// hysteresis band keeps a viewport drag through a boundary from flickering the
+// tracks at 60fps. Stage C-1 turns the single full↔off `narrowSticky` cliff
+// into the full → narrow → stub → off ladder via `marginModeThresholds` /
+// `nextMarginMode`; animated track widths are Stage D.
 export const MIN_EDITOR_WIDTH_PX = 480;
 export const MARGIN_VIEW_HYSTERESIS_PX = 32;
 
 /**
- * Width below which both margin tracks auto-hide. Reserves BOTH sides (worst
- * case) plus the open rails so the editor never drops under
- * `MIN_EDITOR_WIDTH_PX` with margins on. Pure for unit-testability.
+ * Width below which FULL margins (both sides) stop fitting above the min-editor
+ * floor — the legacy full↔off auto-hide threshold. Retained as the `t1`
+ * boundary of `marginModeThresholds` (below it, non-docx steps to `narrow`
+ * instead of off; docx keeps the off cliff). Pure for unit-testability.
  */
 export function narrowThresholdPx(railsWidthPx: number): number {
   return 2 * MARGIN_VIEW_RESERVE_PER_SIDE_PX + railsWidthPx + MIN_EDITOR_WIDTH_PX;
 }
 
 /**
- * Hysteresis-debounced narrow flag transition. Sticky entry at `< threshold`,
- * sticky exit at `> threshold + hysteresis`; inside the deadband the previous
- * value holds. A plain `width < threshold` boundary flickers when a user drags
- * across it because each side re-evaluates every frame. Pure for testability.
+ * Hysteresis-debounced 2-way narrow flag transition. Retained as the reference
+ * for the docx full↔off equivalence and as a regression anchor; the model now
+ * drives the 4-way continuum through `nextMarginMode`. Sticky entry at
+ * `< threshold`, sticky exit at `> threshold + hysteresis`; inside the deadband
+ * the previous value holds. Pure for testability.
  */
 export function nextNarrowSticky(
   prev: boolean,
@@ -75,15 +114,110 @@ export function nextNarrowSticky(
   return prev;
 }
 
+export interface MarginModeThresholds {
+  /** Min viewport width for `full` margins both sides — the legacy auto-hide
+   *  threshold (`=== narrowThresholdPx`). Below it: step to `narrow`. */
+  readonly t1: number;
+  /** Min viewport width for `narrow` margins. Below it: step to `stub`. */
+  readonly t2: number;
+  /** Min viewport width for `stub` margins. Below it: `off`. */
+  readonly t3: number;
+}
+
+/**
+ * Width thresholds for the mode continuum, parameterized by open-rail width.
+ * Each `tN` = both-sides reserve at that mode + open rails + the min-editor
+ * floor; below `tN` the margins can't hold that mode without squeezing the
+ * editor under `MIN_EDITOR_WIDTH_PX`, so they step down. `t1` delegates to the
+ * preserved `narrowThresholdPx` (full-mode reserve), keeping the legacy
+ * full↔off boundary intact. With the shipped estimates (rails 0): t1=1024,
+ * t2=864, t3=600 — band gaps 160 / 264, both wider than the 32px hysteresis so
+ * adjacent deadbands never overlap. Pure for unit-testability.
+ */
+export function marginModeThresholds(railsWidthPx: number): MarginModeThresholds {
+  const floor = railsWidthPx + MIN_EDITOR_WIDTH_PX;
+  return {
+    t1: narrowThresholdPx(railsWidthPx),
+    t2: 2 * marginReservePx(MARGIN_TRACK_GEOMETRY.narrow) + floor,
+    t3: 2 * marginReservePx(MARGIN_TRACK_GEOMETRY.stub) + floor,
+  };
+}
+
+const MODE_RANK: Record<MarginMode, number> = { off: 0, stub: 1, narrow: 2, full: 3 };
+
+/**
+ * Hysteresis-damped transition along the full → narrow → stub → off continuum.
+ * Generalizes `nextNarrowSticky`'s sticky-band logic to four modes:
+ *  - `shrink` = the WIDEST mode the raw thresholds permit at `w` (narrowing is
+ *    immediate at `< tN`);
+ *  - `widen`  = the widest mode permitted only after clearing `tN + hysteresis`
+ *    (widening is sticky);
+ *  - inside the deadband `[widen, shrink]` the previous mode holds.
+ * Clamps on multi-band jumps in BOTH directions (a viewport snapped huge→tiny
+ * lands at `off`, not one step down; tiny→huge lands at `full`). Pure for
+ * testability.
+ */
+export function nextMarginMode(
+  prev: MarginMode,
+  viewportWidth: number,
+  thresholds: MarginModeThresholds,
+  hysteresisPx: number,
+): MarginMode {
+  const { t1, t2, t3 } = thresholds;
+  const w = viewportWidth;
+  const h = hysteresisPx;
+  const shrink: MarginMode = w < t3 ? "off" : w < t2 ? "stub" : w < t1 ? "narrow" : "full";
+  const widen: MarginMode =
+    w > t1 + h ? "full" : w > t2 + h ? "narrow" : w > t3 + h ? "stub" : "off";
+  // shrink rank >= widen rank always (widen uses higher thresholds), so the
+  // deadband [widen, shrink] is well-formed.
+  if (MODE_RANK[prev] > MODE_RANK[shrink]) return shrink; // too wide for width → clamp down
+  if (MODE_RANK[prev] < MODE_RANK[widen]) return widen; // width cleared widen band → step up
+  return prev; // inside the deadband
+}
+
+/**
+ * Base (pre-presence) per-tab mode. docx clamps to the legacy `full | off`
+ * cliff keyed on whether the width permits full margins (`widthMode === "full"`,
+ * which flips at the same `narrowThresholdPx` boundary the old `narrowSticky`
+ * used — so docx never receives narrow/stub geometry). non-docx passes the
+ * width continuum through. Pure for unit-testability.
+ */
+export function resolveBaseMode(
+  isDocx: boolean,
+  marginOn: boolean,
+  widthMode: MarginMode,
+): MarginMode {
+  if (isDocx) return marginOn && widthMode === "full" ? "full" : "off";
+  return marginOn ? widthMode : "off";
+}
+
+/**
+ * Per-side mode after presence-collapse: a non-docx side with no pending
+ * annotation to render collapses to `off` while the other keeps `baseMode`.
+ * docx is exempt (legacy both-sides-together). Pure for unit-testability —
+ * presence is a stable binary input, never derived from the track width it
+ * produces, so this never closes a feedback loop. See cleave-locks F1 amendment.
+ */
+export function resolveSideMode(
+  baseMode: MarginMode,
+  isDocx: boolean,
+  hasPending: boolean,
+): MarginMode {
+  return !isDocx && !hasPending ? "off" : baseMode;
+}
+
 export interface StageLayerStyleInput {
   /** The grid stage is non-docx only; docx keeps its own (relative/contents) path. */
   isDocx: boolean;
-  /** marginView setting AND not auto-hidden by the narrow threshold. */
+  /** docx branch only: margins on (→ `position: relative`) vs off
+   *  (→ `display: contents`). */
   effectivelyOn: boolean;
-  /** A margin renders on the left (= effectivelyOn; rail-independent since #892). */
-  leftVisible: boolean;
-  /** A margin renders on the right (= effectivelyOn; rail-independent since #892). */
-  rightVisible: boolean;
+  /** non-docx left grid-track width (px) = the left side's mode geometry total
+   *  (`marginReservePx`); 0 when that side is `off` (hidden or empty-collapsed). */
+  leftReservePx: number;
+  /** non-docx right grid-track width (px). See `leftReservePx`. */
+  rightReservePx: number;
   /** Content reading measure as a CSS length: a ch width (`58ch`/`68ch`/`82ch`)
    *  or `"100%"` for the "full" preset, mapped via `EDITOR_MEASURE_CH`. */
   measure: string;
@@ -97,7 +231,8 @@ export interface StageLayerStyleInput {
  * - non-docx: a CSS Grid. The grid is present even with margins off (tracks
  *   collapse to 0), so toggling margins is a track-width change rather than a
  *   display-mode swap — content centering stays put and track widths become
- *   animatable (Stage D).
+ *   animatable (Stage D). Each track's width is its side's `marginReservePx`,
+ *   so a `narrow`/`stub`/empty-collapsed side renders the right (or zero) width.
  *
  * INVARIANT: the stage carries NO padding/border. `useMarginPositions` reads
  * `layer.getBoundingClientRect().top` (border-box top) as the bubble origin;
@@ -105,19 +240,16 @@ export interface StageLayerStyleInput {
  * every bubble by that amount. Keep spacing on `.editor-scroll` (the parent),
  * never here. The `.margin-track` cells carry the same no-padding/border rule.
  *
- * Pure (no runes) so it can be unit-tested across the format × visibility
- * matrix — the cheapest way to lock the per-side-reserve fix.
+ * Pure (no runes) so it can be unit-tested across the format × geometry matrix.
  */
 export function stageLayerStyle(input: StageLayerStyleInput): string {
   if (input.isDocx) {
     return input.effectivelyOn ? "position: relative;" : "display: contents;";
   }
-  const ml = input.leftVisible ? `${MARGIN_VIEW_RESERVE_PER_SIDE_PX}px` : "0px";
-  const mr = input.rightVisible ? `${MARGIN_VIEW_RESERVE_PER_SIDE_PX}px` : "0px";
   return (
     `--editor-measure: ${input.measure}; ` +
-    `--margin-left-track: ${ml}; ` +
-    `--margin-right-track: ${mr}; ` +
+    `--margin-left-track: ${input.leftReservePx}px; ` +
+    `--margin-right-track: ${input.rightReservePx}px; ` +
     "display: grid; align-items: stretch; " +
     "grid-template-columns: minmax(0, 1fr) var(--margin-left-track) " +
     "minmax(0, var(--editor-measure)) var(--margin-right-track) minmax(0, 1fr);"
@@ -131,26 +263,46 @@ export interface CreateEditorStageModelOpts {
   getMarginView: () => boolean;
   /** `settings.editorMeasure` — the reading-measure preset (→ ch width / `100%`). */
   getEditorMeasure: () => EditorMeasure;
-  /** Rail visibility per side. Feeds the narrow-threshold width budget only
+  /** Rail visibility per side. Feeds the mode-threshold width budget only
    *  (open rails shrink the editor); since #892 it no longer hides the margin
    *  on that side. */
   getLeftRailVisible: () => boolean;
   getRightRailVisible: () => boolean;
-  /** Live viewport width (drives the narrow auto-hide threshold). */
+  /** Live viewport width (drives the mode continuum thresholds). */
   getViewportWidth: () => number;
+  /** Whether the LEFT margin side (private notes) has any PENDING annotation to
+   *  render. Drives presence-collapse: an empty side's track goes to `off`.
+   *  MUST read the UNGATED annotation source (e.g. `visibleAnnotations`),
+   *  applying the same type/author split + `status === "pending"` predicate the
+   *  column renders — NEVER the `effectivelyOn`-gated render arrays, which would
+   *  close a `$derived` cycle through `effectivelyOn`. Excludes the column's
+   *  `positions.has` gate (also `effectivelyOn`-gated). See stage-c1 plan
+   *  [MF-11]. */
+  getLeftHasPending: () => boolean;
+  /** Whether the RIGHT margin side (outbound comments + imports) has any PENDING
+   *  annotation to render. See `getLeftHasPending`. */
+  getRightHasPending: () => boolean;
   /** Persisted-at-mount rail widths (stable; NOT the live drag width — see #683). */
   leftRailWidthPx: number;
   rightRailWidthPx: number;
 }
 
 export interface EditorStageModel {
-  /** marginView on AND not auto-hidden by the narrow threshold. */
+  /** Some margin renders (either side on). docx: `marginView && fits-full`. */
   readonly effectivelyOn: boolean;
-  /** A margin renders on the left. Tracks `effectivelyOn` (decoupled from rail
-   *  state since #892); kept per-side for Stage C + the docx path. */
+  /** A margin renders on the left (`leftMode !== "off"`). */
   readonly leftVisible: boolean;
-  /** A margin renders on the right. See `leftVisible`. */
+  /** A margin renders on the right (`rightMode !== "off"`). */
   readonly rightVisible: boolean;
+  /** Resolved LEFT-side mode (width continuum, presence- and format-clamped).
+   *  `off` when hidden or empty-collapsed. */
+  readonly leftMode: MarginMode;
+  /** Resolved RIGHT-side mode. See `leftMode`. */
+  readonly rightMode: MarginMode;
+  /** Track geometry for the LEFT side = `MARGIN_TRACK_GEOMETRY[leftMode]`. */
+  readonly leftGeometry: MarginTrackGeometry;
+  /** Track geometry for the RIGHT side. */
+  readonly rightGeometry: MarginTrackGeometry;
   /** Format-aware inline style for the `marginLayerEl` stage container. */
   readonly layerStyle: string;
 }
@@ -160,45 +312,52 @@ export function createEditorStageModel(opts: CreateEditorStageModelOpts): Editor
     (opts.getLeftRailVisible() ? opts.leftRailWidthPx : 0) +
       (opts.getRightRailVisible() ? opts.rightRailWidthPx : 0),
   );
-  const thresholdPx = $derived(narrowThresholdPx(railsWidthPx));
+  const thresholds = $derived(marginModeThresholds(railsWidthPx));
 
-  // Auto-hide flag. The hysteresis read needs the prior value (deadband), so
-  // this is `$state` written from a guarded `$effect` keyed on width — NOT a
-  // pure `$derived`. A one-way rail→width→flag flow that never writes back to
-  // rail/settings state (PR3 invariant: narrow-collapse must not clobber the
-  // user's persisted panel visibility).
-  let narrowSticky = $state(false);
+  // Global width-driven mode. Like the old `narrowSticky`, the hysteresis read
+  // needs the prior value, so this is `$state` written from a SINGLE guarded
+  // `$effect` keyed on width — NOT a pure `$derived`. A one-way
+  // rail→width→mode flow that never writes back to rail/settings state (the
+  // narrow-collapse must not clobber the user's persisted panel visibility).
+  // This is the ONLY loop-prone part of the model (cleave-locks F2: one
+  // `$state`, one `$effect`); the per-side modes below are pure `$derived`.
+  let widthMode = $state<MarginMode>("full");
   $effect(() => {
     const w = opts.getViewportWidth();
-    const t = thresholdPx;
-    // Read the prior value via `untrack` so `narrowSticky` is NOT a tracked
-    // dependency of this effect; otherwise the write below would re-trigger
-    // the effect (the deadband converges, but it's a wasted run). Tracked
-    // deps stay exactly {viewport width, threshold}, matching the original
-    // App.svelte hysteresis block.
-    const prev = untrack(() => narrowSticky);
-    narrowSticky = nextNarrowSticky(prev, w, t, MARGIN_VIEW_HYSTERESIS_PX);
+    const t = thresholds;
+    // Read the prior value via `untrack` so `widthMode` is NOT a tracked
+    // dependency of this effect; otherwise the write below would re-trigger it.
+    // Tracked deps stay exactly {viewport width, thresholds}.
+    const prev = untrack(() => widthMode);
+    const next = nextMarginMode(prev, w, t, MARGIN_VIEW_HYSTERESIS_PX);
+    // Literal last-value guard (`feedback_svelte_effect_depth_guard`): without
+    // it the write re-enters under ResizeObserver chatter even though the value
+    // has settled, tripping `effect_update_depth_exceeded`.
+    if (next === prev) return;
+    widthMode = next;
   });
 
-  const effectivelyOn = $derived(opts.getMarginView() && !narrowSticky);
-  // Margin visibility is DECOUPLED from rail state (#892 discussion). A rail
-  // opening no longer hides that side's margin: the old per-side coupling was a
-  // geometric hack from the absolute-positioning layout, where an open rail
-  // literally stole the horizontal space the margin needed. In the grid model
-  // the `1fr` gutters + the narrow auto-hide threshold handle "is there room?"
-  // — and the threshold already accounts for open-rail width (`railsWidthPx`),
-  // so when a rail opens the margins hide globally IF space runs out, rather
-  // than the (semantically arbitrary) "outline rail hides my private notes".
-  // Both sides therefore track `effectivelyOn` together; the per-side split is
-  // retained in the API/grid for Stage C + the docx path.
-  // INVARIANT (Stages A/B): `leftVisible === rightVisible === effectivelyOn`.
-  // The per-side getters are kept in the API surface because Stage C re-splits
-  // them (full → narrow → stub → off can differ side-to-side based on
-  // collision pressure). App.svelte must NOT assume they can diverge today —
-  // any code that fans out behavior per side is premature; collapse it back to
-  // `effectivelyOn` until Stage C lands the real split.
-  const leftVisible = $derived(effectivelyOn);
-  const rightVisible = $derived(effectivelyOn);
+  const isDocx = $derived(opts.getFormat() === "docx");
+
+  // docx keeps the legacy full↔off cliff; non-docx gets the width continuum.
+  const baseMode = $derived(resolveBaseMode(isDocx, opts.getMarginView(), widthMode));
+
+  // Presence-collapse (non-docx only; cleave-locks F1 amendment, Bryan
+  // 2026-05-28): a side with no pending annotation to render collapses to `off`
+  // while the other keeps `baseMode`. Pure `$derived` over the helper — presence
+  // is a stable binary input (it cannot be changed by the track width it
+  // produces), so no feedback loop and no hysteresis. CONSEQUENCE: the per-side
+  // getters NO LONGER satisfy `leftVisible === rightVisible` — that A/B-era
+  // invariant is retired here. Genuine per-side WIDTH divergence stays deferred
+  // to Stage E / #917.
+  const leftMode = $derived(resolveSideMode(baseMode, isDocx, opts.getLeftHasPending()));
+  const rightMode = $derived(resolveSideMode(baseMode, isDocx, opts.getRightHasPending()));
+
+  const leftVisible = $derived(leftMode !== "off");
+  const rightVisible = $derived(rightMode !== "off");
+  const effectivelyOn = $derived(leftVisible || rightVisible);
+  const leftGeometry = $derived(MARGIN_TRACK_GEOMETRY[leftMode]);
+  const rightGeometry = $derived(MARGIN_TRACK_GEOMETRY[rightMode]);
 
   // Per-session breadcrumb set: each bogus value warns once, not per-frame.
   // The lookup runs inside a `$derived` that re-evaluates on viewport / rail
@@ -206,10 +365,10 @@ export function createEditorStageModel(opts: CreateEditorStageModelOpts): Editor
   const warnedMeasures = new Set<string>();
   const layerStyle = $derived(
     stageLayerStyle({
-      isDocx: opts.getFormat() === "docx",
+      isDocx,
       effectivelyOn,
-      leftVisible,
-      rightVisible,
+      leftReservePx: marginReservePx(leftGeometry),
+      rightReservePx: marginReservePx(rightGeometry),
       // Belt-and-suspenders fallback. The on-load + on-write validators in
       // useTandemSettings already coerce a bogus value to DEFAULTS, so this
       // `??` only triggers if a TS-violating cast slips one through. Without
@@ -241,6 +400,18 @@ export function createEditorStageModel(opts: CreateEditorStageModelOpts): Editor
     },
     get rightVisible() {
       return rightVisible;
+    },
+    get leftMode() {
+      return leftMode;
+    },
+    get rightMode() {
+      return rightMode;
+    },
+    get leftGeometry() {
+      return leftGeometry;
+    },
+    get rightGeometry() {
+      return rightGeometry;
     },
     get layerStyle() {
       return layerStyle;

--- a/src/client/panels/MarginColumn.svelte
+++ b/src/client/panels/MarginColumn.svelte
@@ -2,6 +2,7 @@
 import { untrack } from "svelte";
 import type { Annotation, AnnotationReply } from "../../shared/types";
 import { getVisibleReplies } from "../annotations/replies";
+import type { MarginMode } from "../layout/editor-stage.svelte";
 import AnnotationCard from "./AnnotationCard.svelte";
 import { prunePlaceableHeights, resolveCollisions } from "./marginCollision";
 import { bezierLeaderPath, leaderColorForAuthor } from "./marginLeaderGeometry";
@@ -12,6 +13,11 @@ interface Props {
   /** Computed top offset in pixels (relative to the positioning layer), keyed by annotation id. */
   positions: ReadonlyMap<string, number>;
   side: "left" | "right";
+  /** Resolved track mode for this side (`full` | `narrow` | `stub`). The width
+   *  continuum. A column only mounts when its side is visible, so `off` never
+   *  reaches here. Pure pass-through in C-1 — the bubble density variants that
+   *  consume it (clamp-until-active, stub pill) land in C-2. */
+  mode: MarginMode;
   /** Column width in pixels. */
   width: number;
   /** Distance from the column edge to the nearest scroll-container edge. */
@@ -38,6 +44,10 @@ let {
   annotations,
   positions,
   side,
+  // `mode` is accepted but not yet consumed (C-1 is pure pass-through); C-2
+  // derives bubble density from it. Destructured so the prop typechecks and is
+  // ready at the call site without a later signature change.
+  mode: _mode,
   width,
   edgeInset,
   gap,

--- a/src/client/panels/marginCollision.ts
+++ b/src/client/panels/marginCollision.ts
@@ -32,6 +32,12 @@ const DEFAULT_GAP = 6;
  * still emitted at their natural `top` (they just don't participate as
  * push-sources, since we don't know their bottom edge).
  *
+ * STUB-NON-PUSH CONTRACT (Stage C): a `stub`-density bubble must not advance the
+ * collision cursor — stubs are anchor pips that overlap freely, not space-
+ * claiming cards. C-2 honors this by passing `height: undefined` for stubs,
+ * which lands in the unknown-height branch below (the cursor is not advanced).
+ * No logic change is needed here; this comment is the contract C-2 relies on.
+ *
  * Stable ordering for equal tops: input order is preserved by tagging the
  * original index pre-sort.
  */

--- a/src/client/panels/marginSides.ts
+++ b/src/client/panels/marginSides.ts
@@ -1,0 +1,31 @@
+/**
+ * Margin-view side assignment (the C3 side-split, extracted as pure predicates).
+ *
+ * Two consumers must agree on which side an annotation belongs to, or they
+ * drift:
+ *  - App.svelte's `marginNotes` / `marginComments` render arrays, and
+ *  - `EditorStageModel`'s per-side presence-collapse booleans
+ *    (`getLeftHasPending` / `getRightHasPending`).
+ * Sharing one predicate (not one array) is what keeps them in lockstep — and is
+ * required for loop-freedom: the presence booleans MUST read the UNGATED
+ * annotation source through these predicates, never the `effectivelyOn`-gated
+ * render arrays (which would close a `$derived` cycle). See stage-c1 plan
+ * [MF-11].
+ *
+ * Side assignment (fixed, never swapped — ADR-027 / C3 lock):
+ *  - LEFT  = private notes (`type === "note"`).
+ *  - RIGHT = outbound comments + imported Word comments
+ *    (`author === "import" || type === "comment"`).
+ *  - `highlight` is inline (not margin-rendered) → neither side.
+ */
+import type { Annotation } from "../../shared/types";
+
+/** True when `a` renders in the LEFT margin (private notes). */
+export function isLeftMarginAnnotation(a: Annotation): boolean {
+  return a.type === "note";
+}
+
+/** True when `a` renders in the RIGHT margin (outbound comments + imports). */
+export function isRightMarginAnnotation(a: Annotation): boolean {
+  return a.author === "import" || a.type === "comment";
+}

--- a/tests/client/editor-stage.test.ts
+++ b/tests/client/editor-stage.test.ts
@@ -1,29 +1,229 @@
 import { describe, expect, it } from "vitest";
 import {
+  MARGIN_TRACK_GEOMETRY,
+  MARGIN_VIEW_COLUMN_WIDTH_PX,
+  MARGIN_VIEW_HYSTERESIS_PX,
   MARGIN_VIEW_RESERVE_PER_SIDE_PX,
+  type MarginMode,
   MIN_EDITOR_WIDTH_PX,
+  marginModeThresholds,
+  marginReservePx,
   narrowThresholdPx,
+  nextMarginMode,
   nextNarrowSticky,
+  resolveBaseMode,
+  resolveSideMode,
   stageLayerStyle,
 } from "../../src/client/layout/editor-stage.svelte.js";
 
 /**
  * Editor stage model (Phase 3.5). The rune-based `createEditorStageModel`
- * needs a Svelte effect root + live settings/layout stores, so it's exercised
- * via Playwright (`margin-view.spec.ts`). The pure layout primitives —
- * `stageLayerStyle`, `nextNarrowSticky`, `narrowThresholdPx` — are unit-tested
- * here. `stageLayerStyle` in particular encodes the per-side-reserve fix
- * (defect #1): reserve must be taken ONLY on a side that actually renders a
- * margin, so the matrix below is the regression guard for that.
+ * needs a Svelte effect root + live stores, so the width-hysteresis `$effect`
+ * and the live presence-collapse wiring are exercised via Playwright
+ * (`margin-view.spec.ts`). Everything pure — the geometry table, the threshold
+ * + mode-continuum math, the base/side mode resolution, and `stageLayerStyle`
+ * — is unit-tested here. The mode-resolution chain (widthMode → baseMode →
+ * leftMode/rightMode) was deliberately extracted into pure helpers so the
+ * branching is testable without a mount.
  */
+
+describe("MARGIN_TRACK_GEOMETRY — geometry table is the source of truth", () => {
+  it("full mode matches the exported full-mode constants", () => {
+    expect(MARGIN_TRACK_GEOMETRY.full.column).toBe(MARGIN_VIEW_COLUMN_WIDTH_PX);
+    expect(marginReservePx(MARGIN_TRACK_GEOMETRY.full)).toBe(MARGIN_VIEW_RESERVE_PER_SIDE_PX);
+  });
+
+  it("non-off modes reserve column + inset + gap; off is all-zero", () => {
+    for (const mode of ["full", "narrow", "stub"] as const) {
+      const g = MARGIN_TRACK_GEOMETRY[mode];
+      expect(marginReservePx(g)).toBe(g.column + g.inset + g.gap);
+      expect(g.column).toBeGreaterThan(0);
+    }
+    expect(MARGIN_TRACK_GEOMETRY.off).toEqual({ column: 0, inset: 0, gap: 0 });
+    expect(marginReservePx(MARGIN_TRACK_GEOMETRY.off)).toBe(0);
+  });
+
+  it("reserves descend full > narrow > stub > off (monotonic 272/192/60/0)", () => {
+    const r = (m: MarginMode) => marginReservePx(MARGIN_TRACK_GEOMETRY[m]);
+    expect(r("full")).toBe(272);
+    expect(r("narrow")).toBe(192);
+    expect(r("stub")).toBe(60);
+    expect(r("off")).toBe(0);
+    expect(r("full")).toBeGreaterThan(r("narrow"));
+    expect(r("narrow")).toBeGreaterThan(r("stub"));
+    expect(r("stub")).toBeGreaterThan(r("off"));
+  });
+});
+
+describe("marginModeThresholds — ordered bands, t1 delegates to narrowThreshold", () => {
+  it.each([0, 300, 600])("t1 > t2 > t3 with rails=%i px", (rails) => {
+    const { t1, t2, t3 } = marginModeThresholds(rails);
+    expect(t1).toBeGreaterThan(t2);
+    expect(t2).toBeGreaterThan(t3);
+  });
+
+  it.each([0, 300, 600])("t1 === narrowThresholdPx(rails=%i)", (rails) => {
+    expect(marginModeThresholds(rails).t1).toBe(narrowThresholdPx(rails));
+  });
+
+  it.each([0, 300, 600])("every band gap exceeds the hysteresis (rails=%i)", (rails) => {
+    const { t1, t2, t3 } = marginModeThresholds(rails);
+    // Non-overlapping deadbands require each gap > hysteresis (a fast drag
+    // through a boundary must not flicker between adjacent modes).
+    expect(t1 - t2).toBeGreaterThan(MARGIN_VIEW_HYSTERESIS_PX);
+    expect(t2 - t3).toBeGreaterThan(MARGIN_VIEW_HYSTERESIS_PX);
+  });
+
+  it("matches the documented values at rails=0 (272/192/60 reserves)", () => {
+    expect(marginModeThresholds(0)).toEqual({
+      t1: 2 * 272 + MIN_EDITOR_WIDTH_PX, // 1024
+      t2: 2 * 192 + MIN_EDITOR_WIDTH_PX, // 864
+      t3: 2 * 60 + MIN_EDITOR_WIDTH_PX, // 600
+    });
+  });
+});
+
+describe("nextMarginMode — continuum bands + hysteresis + multi-band clamp", () => {
+  const T = marginModeThresholds(0); // { t1: 1024, t2: 864, t3: 600 }
+  const H = MARGIN_VIEW_HYSTERESIS_PX; // 32
+
+  // why: each row names the equivalence class the width falls in, so a missing
+  // band shows up as a missing row.
+  it.each<{ prev: MarginMode; w: number; expected: MarginMode; why: string }>([
+    { prev: "full", w: T.t1 + 1, expected: "full", why: "above t1 → full" },
+    { prev: "full", w: T.t1 - 1, expected: "narrow", why: "below t1 → step to narrow" },
+    { prev: "narrow", w: T.t2 - 1, expected: "stub", why: "below t2 → step to stub" },
+    { prev: "stub", w: T.t3 - 1, expected: "off", why: "below t3 → off" },
+    { prev: "stub", w: T.t3 + 1, expected: "stub", why: "just above t3 → stub" },
+    // multi-band jumps clamp in BOTH directions
+    { prev: "full", w: T.t3 - 1, expected: "off", why: "huge→tiny clamps straight to off" },
+    { prev: "off", w: T.t1 + H + 1, expected: "full", why: "tiny→huge clamps straight to full" },
+    // hysteresis deadband holds the prior mode
+    { prev: "narrow", w: T.t1 + 5, expected: "narrow", why: "in t1 deadband (<t1+H) holds prev" },
+    { prev: "full", w: T.t1 + 5, expected: "full", why: "in t1 deadband holds prev (other side)" },
+    { prev: "stub", w: T.t2 + 5, expected: "stub", why: "in t2 deadband holds prev" },
+    { prev: "narrow", w: T.t1 + H + 1, expected: "full", why: "cleared t1+H → widen to full" },
+  ])("prev=$prev w=$w → $expected ($why)", ({ prev, w, expected }) => {
+    expect(nextMarginMode(prev, w, T, H)).toBe(expected);
+  });
+
+  it("at exactly t1 the deadband holds prev (entry is strict <)", () => {
+    expect(nextMarginMode("full", T.t1, T, H)).toBe("full");
+    expect(nextMarginMode("narrow", T.t1, T, H)).toBe("narrow");
+  });
+
+  // docx equivalence: docx margins are on iff `widthMode === "full"`, and that
+  // must flip at the SAME width (and hysteresis) the legacy `nextNarrowSticky`
+  // flipped on↔off. This locks the byte-identical-docx-behavior claim directly,
+  // rather than relying on walking the algebra by hand. `prev` maps:
+  // full ⇄ !narrow(false); any narrower mode ⇄ narrow(true).
+  it.each([
+    { w: T.t1 - 1, why: "below t1: docx off / narrowSticky narrow" },
+    { w: T.t1, why: "at t1 (strict-< entry): both hold prev" },
+    { w: T.t1 + 5, why: "in deadband: both hold prev" },
+    { w: T.t1 + H + 1, why: "cleared t1+H: docx full / narrowSticky wide" },
+  ])("docx on === !narrowSticky at w=$w ($why)", ({ w }) => {
+    for (const startFull of [true, false]) {
+      const modePrev: MarginMode = startFull ? "full" : "narrow";
+      const docxOn = nextMarginMode(modePrev, w, T, H) === "full";
+      const narrowWide = !nextNarrowSticky(!startFull, w, T.t1, H);
+      expect(docxOn).toBe(narrowWide);
+    }
+  });
+});
+
+describe("resolveBaseMode — docx full|off cliff vs non-docx continuum", () => {
+  it.each<{ widthMode: MarginMode }>([
+    { widthMode: "full" },
+    { widthMode: "narrow" },
+    { widthMode: "stub" },
+    { widthMode: "off" },
+  ])("non-docx passes widthMode=$widthMode through when margin view on", ({ widthMode }) => {
+    expect(resolveBaseMode(false, true, widthMode)).toBe(widthMode);
+  });
+
+  it("non-docx → off when margin view is off, regardless of widthMode", () => {
+    expect(resolveBaseMode(false, false, "full")).toBe("off");
+  });
+
+  it("docx is full only when widthMode permits full margins, else off", () => {
+    expect(resolveBaseMode(true, true, "full")).toBe("full");
+    expect(resolveBaseMode(true, true, "narrow")).toBe("off"); // never narrow/stub
+    expect(resolveBaseMode(true, true, "stub")).toBe("off");
+    expect(resolveBaseMode(true, true, "off")).toBe("off");
+    expect(resolveBaseMode(true, false, "full")).toBe("off"); // margin view off
+  });
+});
+
+describe("resolveSideMode — presence-collapse (non-docx) vs docx exemption", () => {
+  // why: presence asymmetry is the ONE sanctioned per-side divergence.
+  it.each<{
+    base: MarginMode;
+    isDocx: boolean;
+    hasPending: boolean;
+    expected: MarginMode;
+    why: string;
+  }>([
+    {
+      base: "full",
+      isDocx: false,
+      hasPending: true,
+      expected: "full",
+      why: "non-docx, has pending → keep",
+    },
+    {
+      base: "full",
+      isDocx: false,
+      hasPending: false,
+      expected: "off",
+      why: "non-docx, empty → collapse",
+    },
+    {
+      base: "narrow",
+      isDocx: false,
+      hasPending: false,
+      expected: "off",
+      why: "collapse from any base",
+    },
+    { base: "off", isDocx: false, hasPending: true, expected: "off", why: "base off stays off" },
+    {
+      base: "full",
+      isDocx: true,
+      hasPending: false,
+      expected: "full",
+      why: "docx exempt — no collapse",
+    },
+    { base: "off", isDocx: true, hasPending: true, expected: "off", why: "docx follows base only" },
+  ])("base=$base docx=$isDocx pending=$hasPending → $expected ($why)", ({
+    base,
+    isDocx,
+    hasPending,
+    expected,
+  }) => {
+    expect(resolveSideMode(base, isDocx, hasPending)).toBe(expected);
+  });
+
+  it("non-docx full mode: the four presence combos (both/left/right/neither)", () => {
+    const base: MarginMode = "full";
+    // both pending
+    expect(resolveSideMode(base, false, true)).toBe("full");
+    // left-only: left keeps, right collapses
+    expect([resolveSideMode(base, false, true), resolveSideMode(base, false, false)]).toEqual([
+      "full",
+      "off",
+    ]);
+    // neither: both off
+    expect(resolveSideMode(base, false, false)).toBe("off");
+  });
+});
 
 describe("stageLayerStyle — docx keeps its legacy path", () => {
   it("docx + margins on → position: relative (not a grid)", () => {
     const s = stageLayerStyle({
       isDocx: true,
       effectivelyOn: true,
-      leftVisible: true,
-      rightVisible: true,
+      leftReservePx: MARGIN_VIEW_RESERVE_PER_SIDE_PX,
+      rightReservePx: MARGIN_VIEW_RESERVE_PER_SIDE_PX,
       measure: "100%",
     });
     expect(s).toBe("position: relative;");
@@ -33,23 +233,24 @@ describe("stageLayerStyle — docx keeps its legacy path", () => {
     const s = stageLayerStyle({
       isDocx: true,
       effectivelyOn: false,
-      leftVisible: false,
-      rightVisible: false,
+      leftReservePx: 0,
+      rightReservePx: 0,
       measure: "100%",
     });
     expect(s).toBe("display: contents;");
   });
 });
 
-describe("stageLayerStyle — non-docx grid reserves per side (defect #1)", () => {
-  const reserve = `${MARGIN_VIEW_RESERVE_PER_SIDE_PX}px`; // "272px"
+describe("stageLayerStyle — non-docx grid reserves per side (defect #1 + continuum)", () => {
+  const full = MARGIN_VIEW_RESERVE_PER_SIDE_PX; // 272
+  const narrow = marginReservePx(MARGIN_TRACK_GEOMETRY.narrow); // 192
 
-  it("both margins hidden → both tracks 0 (no phantom reserve)", () => {
+  it("both tracks 0 → no phantom reserve (both sides off / empty)", () => {
     const s = stageLayerStyle({
       isDocx: false,
       effectivelyOn: false,
-      leftVisible: false,
-      rightVisible: false,
+      leftReservePx: 0,
+      rightReservePx: 0,
       measure: "100%",
     });
     expect(s).toContain("display: grid;");
@@ -57,48 +258,48 @@ describe("stageLayerStyle — non-docx grid reserves per side (defect #1)", () =
     expect(s).toContain("--margin-right-track: 0px;");
   });
 
-  it("both margins shown → both tracks reserve the per-side width", () => {
+  it("both sides full → both tracks reserve the full per-side width", () => {
     const s = stageLayerStyle({
       isDocx: false,
       effectivelyOn: true,
-      leftVisible: true,
-      rightVisible: true,
+      leftReservePx: full,
+      rightReservePx: full,
       measure: "100%",
     });
-    expect(s).toContain(`--margin-left-track: ${reserve};`);
-    expect(s).toContain(`--margin-right-track: ${reserve};`);
+    expect(s).toContain(`--margin-left-track: ${full}px;`);
+    expect(s).toContain(`--margin-right-track: ${full}px;`);
   });
 
-  it("only left margin shown (right rail open) → only left reserves", () => {
+  it("asymmetric: left full, right empty-collapsed → left 272px, right 0px", () => {
     const s = stageLayerStyle({
       isDocx: false,
       effectivelyOn: true,
-      leftVisible: true,
-      rightVisible: false,
+      leftReservePx: full,
+      rightReservePx: 0,
       measure: "100%",
     });
-    expect(s).toContain(`--margin-left-track: ${reserve};`);
+    expect(s).toContain(`--margin-left-track: ${full}px;`);
     expect(s).toContain("--margin-right-track: 0px;");
   });
 
-  it("only right margin shown (left rail open) → only right reserves", () => {
+  it("narrow mode → both tracks reserve the narrow width (192px)", () => {
     const s = stageLayerStyle({
       isDocx: false,
       effectivelyOn: true,
-      leftVisible: false,
-      rightVisible: true,
+      leftReservePx: narrow,
+      rightReservePx: narrow,
       measure: "100%",
     });
-    expect(s).toContain("--margin-left-track: 0px;");
-    expect(s).toContain(`--margin-right-track: ${reserve};`);
+    expect(s).toContain(`--margin-left-track: ${narrow}px;`);
+    expect(s).toContain(`--margin-right-track: ${narrow}px;`);
   });
 
   it("threads the reading measure into --editor-measure", () => {
     const s = stageLayerStyle({
       isDocx: false,
       effectivelyOn: true,
-      leftVisible: false,
-      rightVisible: false,
+      leftReservePx: 0,
+      rightReservePx: 0,
       measure: "68%",
     });
     expect(s).toContain("--editor-measure: 68%;");
@@ -108,7 +309,7 @@ describe("stageLayerStyle — non-docx grid reserves per side (defect #1)", () =
   });
 });
 
-describe("nextNarrowSticky — hysteresis deadband", () => {
+describe("nextNarrowSticky — retained 2-way reference / regression anchor", () => {
   const T = 1000;
   const H = 32;
 
@@ -123,10 +324,8 @@ describe("nextNarrowSticky — hysteresis deadband", () => {
   });
 
   it("inside the deadband → holds the prior value (no flicker)", () => {
-    // A drag that overshoots the threshold by < H must not flip back.
     expect(nextNarrowSticky(true, T + 10, T, H)).toBe(true);
     expect(nextNarrowSticky(false, T + 10, T, H)).toBe(false);
-    // Exactly at the threshold is inside the band (entry is strict `< T`).
     expect(nextNarrowSticky(true, T, T, H)).toBe(true);
     expect(nextNarrowSticky(false, T, T, H)).toBe(false);
   });

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -88,6 +88,31 @@ async function setMarginView(
   await page.keyboard.press("Escape");
 }
 
+/**
+ * Create a user NOTE via the selection popup (no `tandem_note` MCP tool exists
+ * — notes are user-only). Notes are LEFT-side annotations, so this is how a
+ * test gives the left margin content; with Stage C-1 empty-collapse, the left
+ * column only mounts when a pending note exists. Returns the new note's id.
+ * Margin view must already be on so the bubble mounts. Selects the first
+ * paragraph's text as the anchor.
+ */
+async function seedNoteViaPopup(
+  page: import("@playwright/test").Page,
+  text: string,
+): Promise<string> {
+  const editor = page.locator(".tiptap");
+  await editor.click();
+  await editor.locator("p").first().selectText();
+  await openAnnotatePopup(page);
+  await page.locator("[data-testid='popup-annotation-input']").fill(text);
+  await page.locator("[data-testid='popup-note-submit']").click();
+  const annNode = page.locator("[data-annotation-id]").last();
+  await expect(annNode).toBeVisible({ timeout: 10_000 });
+  const id = await annNode.getAttribute("data-annotation-id");
+  if (!id) throw new Error("note popup did not yield an annotation id");
+  return id;
+}
+
 test("default off: margin columns are absent from the DOM", async ({ page }) => {
   await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
   await mcp.callTool("tandem_comment", {
@@ -120,11 +145,13 @@ test("toggle on: margin columns appear with a bubble for the comment", async ({ 
 
   await setMarginView(page, true);
 
-  // Both columns mount when marginView is on (column visibility itself isn't a
-  // useful Playwright assertion — the columns have no intrinsic height because
-  // their bubble children are absolutely positioned). Assert presence instead.
-  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(1);
+  // The comment is right-side (outbound). Stage C-1 empty-collapse: the LEFT
+  // side has no pending note, so its track collapses and the left column does
+  // NOT mount — only the side with content appears. (Column presence is the
+  // useful assertion; the columns have no intrinsic height since their bubble
+  // children are absolutely positioned.)
   await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
   // The comment bubble shows up in the right column with real geometry (allow
   // rAF + ResizeObserver to settle).
   const rightBubble = page
@@ -626,6 +653,11 @@ test("opening a rail keeps both margin columns (#892 decoupling)", async ({ page
   await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
 
   await setMarginView(page, true);
+  // Give the LEFT side content too (a note): with Stage C-1 empty-collapse the
+  // left column only mounts when a pending note exists, so #892 rail-decoupling
+  // is only observable on the left once a note is present. Without this the
+  // "left stays mounted when the left rail opens" assertion would be vacuous.
+  await seedNoteViaPopup(page, "left-side note");
   const leftCol = page.locator("[data-testid='margin-column-left']");
   const rightCol = page.locator("[data-testid='margin-column-right']");
   const leftHandle = page.locator("[data-testid='left-panel-resize-handle']");
@@ -669,18 +701,21 @@ test("PR3: narrow viewport hides both margin columns", async ({ page }) => {
   await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
 
   await setMarginView(page, true);
-  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(1);
+  // Comment-only doc: right side has content (mounts), left empty-collapses
+  // (Stage C-1). The right column is the "visible at wide" proxy.
   await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
 
-  // Shrink to a width well below threshold (reserve ≈ 544 + min 480 = 1024).
-  await page.setViewportSize({ width: 700, height: 900 });
+  // Shrink to a width well below the stub→off floor (t3 ≈ 600). Below it BOTH
+  // sides go off regardless of content, so even the populated right side hides.
+  await page.setViewportSize({ width: 500, height: 900 });
   await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
   await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(0);
 
-  // Grow back to a wide viewport → columns return.
+  // Grow back to a wide viewport → the populated right column returns.
   await page.setViewportSize({ width: 1600, height: 900 });
-  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(1);
   await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
 });
 
 /**
@@ -705,24 +740,25 @@ test("PR3: boundary resize does not flicker (hysteresis)", async ({ page }) => {
 
   await setMarginView(page, true);
 
-  // Estimated threshold with no rails open: 544 reserve + 480 min editor = 1024.
-  // Drive narrow first, then a 20px overshoot (still inside the 32px deadband
-  // → must remain narrow), then back below. End state: narrow (both hidden).
-  await page.setViewportSize({ width: 1000, height: 900 });
-  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
+  // Stage C-1: hysteresis is tested at the stub→off floor (t3 ≈ 600, rails
+  // closed). The comment is right-side, so the RIGHT column is the populated
+  // probe. Below t3 → off (right hidden); a small overshoot back above t3 but
+  // inside the 32px deadband must NOT re-show it; then drop below again.
+  const right = page.locator("[data-testid='margin-column-right']");
+  await page.setViewportSize({ width: 560, height: 900 }); // < t3 → off
+  await expect(right).toHaveCount(0);
 
-  await page.setViewportSize({ width: 1044, height: 900 });
-  // Inside the hysteresis band → must NOT flip back to visible. Wait for the
-  // resize → ResizeObserver → useViewportWidth rAF debounce → $effect → DOM
-  // chain to settle. `toHaveCount(0)` auto-retries up to its default timeout,
-  // so even if the chain runs longer than nextFrames covers, the assertion
-  // still holds as long as the column stays hidden.
+  await page.setViewportSize({ width: 620, height: 900 }); // in [t3, t3+H) → hold off
   await nextFrames(page);
-  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
-  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(0);
+  await expect(right).toHaveCount(0);
 
-  await page.setViewportSize({ width: 1000, height: 900 });
-  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
+  await page.setViewportSize({ width: 560, height: 900 });
+  await expect(right).toHaveCount(0);
+
+  // Clear the deadband (> t3 + H ≈ 632) → the stub re-shows, proving the column
+  // wasn't simply stuck off.
+  await page.setViewportSize({ width: 700, height: 900 });
+  await expect(right).toHaveCount(1);
 });
 
 /**
@@ -779,11 +815,12 @@ test("PR3: narrow-collapse does not overwrite persisted rail visibility", async 
  * reserve whenever margin view was effectively on (defect #1); the grid gives
  * each side its own track. The runtime residual we can assert at the E2E layer:
  * tracks carry the reserve only while margins render (on → non-zero, off → 0),
- * and (since #892) a rail opening does NOT collapse a track. The per-side
- * asymmetry itself (one side 0, the other reserved) is now a pure-function
- * property exercised in editor-stage.test.ts, since at runtime both sides track
- * together. We read the resolved grid-template-columns off the stage — [gutter,
- * marginL, content, marginR, gutter] — so tokens[1]/tokens[3] are the px reserves.
+ * and (since #892) a rail opening does NOT collapse a track. Stage C-1 adds the
+ * runtime per-side asymmetry: a side with no pending annotation empty-collapses
+ * to 0 while the other reserves — so a comment-only doc reserves the right track
+ * and zeroes the left at runtime. We read the resolved grid-template-columns off
+ * the stage — [gutter, marginL, content, marginR, gutter] — so tokens[1]/
+ * tokens[3] are the px reserves.
  */
 async function marginTracks(
   page: import("@playwright/test").Page,
@@ -808,26 +845,28 @@ test("Stage A: tracks reserve only while margins render, rail-independent", asyn
   await page.goto("/");
   await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
 
-  // Margins on, both rails closed → both sides reserve a track.
+  // Comment-only doc, margins on, both rails closed. Stage C-1 takes the
+  // per-side reserve down to ANNOTATION granularity: the RIGHT side has content
+  // (track reserves), the LEFT side has no pending note → empty-collapses to 0.
   await setMarginView(page, true);
-  await expect.poll(async () => (await marginTracks(page)).left).not.toBe("0px");
-  expect((await marginTracks(page)).right).not.toBe("0px");
+  await expect.poll(async () => (await marginTracks(page)).right).not.toBe("0px");
+  expect((await marginTracks(page)).left).toBe("0px");
 
-  // Open the LEFT rail (outline) → tracks UNCHANGED (#892 decoupling): the rail
-  // opening must not collapse either margin's reserve.
+  // Open the LEFT rail (outline) → the right track is UNCHANGED (#892
+  // decoupling); the left stays 0 (still no note — not because the rail opened).
   await page.keyboard.press("Alt+Shift+ArrowLeft");
   await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(1, {
     timeout: 3_000,
   });
-  expect((await marginTracks(page)).left).not.toBe("0px");
   expect((await marginTracks(page)).right).not.toBe("0px");
+  expect((await marginTracks(page)).left).toBe("0px");
 
   // Disable margin view → both tracks collapse to 0 (no phantom reserve — the
   // residual of defect #1: the old cascade reserved the full width even off).
   await page.keyboard.press("Alt+Shift+ArrowLeft"); // re-close the left rail
   await setMarginView(page, false);
-  await expect.poll(async () => (await marginTracks(page)).left).toBe("0px");
-  expect((await marginTracks(page)).right).toBe("0px");
+  await expect.poll(async () => (await marginTracks(page)).right).toBe("0px");
+  expect((await marginTracks(page)).left).toBe("0px");
 });
 
 /**
@@ -853,17 +892,194 @@ test("Stage A: margin tracks share the stage's top row (grid-row regression)", a
   await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
 
   await setMarginView(page, true);
-  await expect(page.locator(".margin-track")).toHaveCount(2, { timeout: 5_000 });
+  // Comment-only doc → only the RIGHT track renders (left empty-collapses,
+  // Stage C-1). One rendered `.margin-track` is enough to guard the grid-row
+  // pin — the bug would dump it a full content-height below the stage top.
+  await expect(page.locator(".margin-track")).toHaveCount(1, { timeout: 5_000 });
 
   const deltas = await page.evaluate(() => {
     const stage = document.querySelector("[data-testid='editor-stage']");
     const tracks = [...document.querySelectorAll(".margin-track")];
-    if (!stage || tracks.length !== 2) return null;
+    if (!stage || tracks.length === 0) return null;
     const stageTop = stage.getBoundingClientRect().top;
     return tracks.map((t) => Math.abs(t.getBoundingClientRect().top - stageTop));
   });
   expect(deltas).not.toBeNull();
-  // Each track's top within 1px of the stage top → all in grid row 1. The bug
+  // Each rendered track's top within 1px of the stage top → grid row 1. The bug
   // put them a full content-height (hundreds of px) below.
   for (const delta of deltas as number[]) expect(delta).toBeLessThan(1);
+});
+
+/**
+ * Stage C-1 — the CYCLE REGRESSION the plan review flagged as the HIGH blocker.
+ * The presence-collapse booleans (`getLeftHasPending`/`getRightHasPending`) MUST
+ * read the ungated `visibleAnnotations`, not the `effectivelyOn`-gated render
+ * arrays. If a future refactor re-wires them off the gated arrays, the `$derived`
+ * graph closes a loop through `effectivelyOn` and latches "all-off" — margin view
+ * silently renders NOTHING despite being on with a pending annotation. This test
+ * fails loudly in exactly that case: margin view on + a pending comment must
+ * render the right column AND its bubble.
+ */
+test("C-1: margin view on with a pending comment renders the column (cycle regression)", async ({
+  page,
+}) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "Margin candidate",
+    textSnapshot: TITLE_TEXT,
+  });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+
+  // The load-bearing assertion: the column renders (not silently empty).
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+  await expect(
+    page.locator("[data-testid='margin-column-right'] [data-testid^='margin-bubble-']").first(),
+  ).toBeVisible({ timeout: 5_000 });
+});
+
+/**
+ * Stage C-1 empty-collapse — a NOTE (left) + COMMENT (right) make BOTH sides
+ * present, so both columns mount and both tracks reserve width. The complement
+ * to the comment-only tests above (which prove the empty left side collapses).
+ */
+test("C-1: a note + a comment mount both columns (presence on both sides)", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "right-side comment",
+    textSnapshot: TITLE_TEXT,
+  });
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+  await seedNoteViaPopup(page, "left-side note");
+
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(1);
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+  const tracks = await marginTracks(page);
+  expect(tracks.left).not.toBe("0px");
+  expect(tracks.right).not.toBe("0px");
+});
+
+/**
+ * Stage C-1 empty-collapse is LIVE: adding the first note to a previously-empty
+ * left side expands its track (and removing the last would collapse it again —
+ * the symmetric direction is covered by the comment-only static tests). Proves
+ * the presence booleans recompute against `visibleAnnotations` as annotations
+ * change, not just at mount.
+ */
+test("C-1: adding the first note expands the collapsed left side live", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "right-side comment",
+    textSnapshot: TITLE_TEXT,
+  });
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+  // Comment-only start: left collapsed, right present.
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(0);
+
+  // Add the first left-side note → left expands live.
+  await seedNoteViaPopup(page, "first note");
+  await expect(page.locator("[data-testid='margin-column-left']")).toHaveCount(1);
+  await expect(page.locator("[data-testid='margin-column-right']")).toHaveCount(1);
+});
+
+/**
+ * Stage C-1 continuum — as the viewport narrows, the rendered margin track steps
+ * full → narrow → stub → off. We assert the right track (comment side) shrinks
+ * MONOTONICALLY across the bands, then disappears below the off floor —
+ * estimate-independent (it tests the ladder property, not the specific px so it
+ * survives a `narrow`/`stub` width tune). Rails are closed by setMarginView, so
+ * thresholds are t1≈1024 / t2≈864 / t3≈600.
+ */
+test("C-1: narrowing the viewport steps the margin track full→narrow→stub→off", async ({
+  page,
+}) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "Margin candidate",
+    textSnapshot: TITLE_TEXT,
+  });
+  await page.setViewportSize({ width: 1200, height: 900 });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+  const rightCol = page.locator("[data-testid='margin-column-right']");
+  const rightTrackPx = async () => parseFloat((await marginTracks(page)).right);
+
+  // full band (> t1): widest reserve.
+  await page.setViewportSize({ width: 1200, height: 900 });
+  await expect.poll(rightTrackPx).toBeGreaterThan(0);
+  const fullPx = await rightTrackPx();
+
+  // narrow band (t2 < w < t1): strictly narrower than full.
+  await page.setViewportSize({ width: 950, height: 900 });
+  await expect.poll(rightTrackPx).toBeLessThan(fullPx);
+  const narrowPx = await rightTrackPx();
+  expect(narrowPx).toBeGreaterThan(0);
+
+  // stub band (t3 < w < t2): strictly narrower than narrow.
+  await page.setViewportSize({ width: 750, height: 900 });
+  await expect.poll(rightTrackPx).toBeLessThan(narrowPx);
+  expect(await rightTrackPx()).toBeGreaterThan(0);
+
+  // off (< t3): the column unmounts entirely.
+  await page.setViewportSize({ width: 500, height: 900 });
+  await expect(rightCol).toHaveCount(0);
+});
+
+/**
+ * Stage C-1 docx carve-out (the CRDT-HIGH guard) — docx keeps its legacy
+ * relative/contents path and NEVER enters the continuum grid, so it can never
+ * receive narrow/stub track geometry. The stage element's computed display must
+ * not be `grid` for a docx tab, at a wide width (margins on → position:relative)
+ * and at an intermediate width where a non-docx doc would be `narrow` (docx →
+ * display:contents, off cliff). Either way: never a grid.
+ */
+test("C-1: docx keeps its legacy path — stage is never a grid", async ({ page }) => {
+  const docxDir = createFixtureDir("single-paragraph.docx");
+  try {
+    await mcp.callTool("tandem_open", { filePath: path.join(docxDir, "single-paragraph.docx") });
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await page.goto("/");
+    const stage = page.locator("[data-testid='editor-stage']");
+    await expect(stage).toHaveCount(1, { timeout: 10_000 });
+
+    await setMarginView(page, true);
+
+    const stageDisplay = () => stage.evaluate((el) => getComputedStyle(el as HTMLElement).display);
+
+    // Wide: margins on → docx uses position:relative (display stays block), not grid.
+    expect(await stageDisplay()).not.toBe("grid");
+
+    // Intermediate width (a non-docx doc would be `narrow` here): docx falls to
+    // its off cliff (display:contents) — still never a grid, never narrow geometry.
+    await page.setViewportSize({ width: 950, height: 900 });
+    await nextFrames(page);
+    expect(await stageDisplay()).not.toBe("grid");
+  } finally {
+    cleanupFixtureDir(docxDir);
+  }
 });


### PR DESCRIPTION
## Phase 3.5 Stage C-1 — margin-mode continuum

Replaces the hard margin-view on/off cliff with a four-step width continuum and reserves track space only where a margin actually renders. Stacks on Stages A+B (#909) and C-3 (#919); lands on the `feat/design-system-impl` umbrella.

### What changed
- **`MarginMode` continuum** — `full → narrow → stub → off`, backed by a `MARGIN_TRACK_GEOMETRY` table mapping each mode to column / inset / gap pixels. `MARGIN_VIEW_COLUMN_WIDTH_PX` and `..._RESERVE_PER_SIDE_PX` derive from the `full` entry (single source of truth).
- **Global width-mode, not per-side pressure** — one `MarginMode` `$state` is computed from viewport width with hysteresis-banded transitions (`t1`/`t2`/`t3`; band gaps 160/264 both exceed the 32px hysteresis) and written by a single guarded `$effect` (`if (next === prev) return;`), mirroring the loop-safe `narrowSticky` pattern. Per-side *pressure* would close a `rail → width → threshold → mode` reactive cycle — deliberately avoided.
- **Per-side empty-collapse (the one sanctioned asymmetry)** — a side with **no pending annotation** collapses to `off` while the other keeps its width-driven mode. This is *presence*, not pressure: loop-safe, and it removes defect #1's residual phantom reserve when only one side has content.
- **docx carve-out** — docx keeps the legacy `full|off` cliff via `widthMode === "full"` and never enters the grid stage.
- **`MarginColumn` `mode` prop** — pure pass-through in C-1; C-2 consumes it for density variants. `marginCollision` documents the STUB-NON-PUSH contract C-2 relies on.

### Cycle-fix (review HIGH/CRITICAL)
Presence booleans source from the **ungated** `visibleAnnotations` (`App.svelte:193`) through shared `marginSides` predicates — never the `effectivelyOn`-gated `marginNotes`/`marginComments` arrays, which would close `effectivelyOn → marginNotes → getLeftHasPending → leftMode → leftVisible → effectivelyOn`. Presence uses `status === "pending"` deliberately; the render gate additionally requires `positions.has(id)`, so presence over-counts by at most one frame (benign, one-directional).

### Testability
Mode-resolution is extracted as pure functions (`resolveBaseMode`, `resolveSideMode`, `nextMarginMode`) so the whole chain is unit-testable without a Svelte mount.

### Estimates (dogfood-tunable)
`narrow = 160` / `stub = 28` column widths are first-pass estimates, flagged for calibration against a live build.

## Test plan
- ✅ `npm run typecheck` + `svelte-check` — 0 errors / 0 warnings
- ✅ `npm test` (full suite) — 3119 passed, 20 skipped
- ✅ 54 new/updated editor-stage unit tests — geometry invariants, threshold ordering, `nextMarginMode` bands (`it.each` + multi-band clamp), presence combos, new stage-layer shape (incl. asymmetric), docx full↔off equivalence
- ✅ `tests/e2e/margin-view.spec.ts` — fixed 5 tests broken by empty-collapse + added 5 (cycle regression, note+comment both mount, live expand, continuum step, docx-never-grid)
- ✅ `/simplify` — removed orphaned `MARGIN_VIEW_EDGE_INSET_PX` / `MARGIN_VIEW_GAP_PX`
- ✅ Pre-push hook (full vitest + build + Rust tests) green

## Design record
`docs/plans/2026-05-28-stage-c1-margin-mode-continuum.md`, `...-stage-c2-density-variants.md`, `...-stage-c-cleave-locks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)