### PR TITLE
feat(margin-view): per-card density variants (Stage C-2)

### DIFF
--- a/docs/plans/2026-05-28-stage-c2-density-variants.md
+++ b/docs/plans/2026-05-28-stage-c2-density-variants.md
@@ -9,6 +9,57 @@
 > Produced by the `stage-c-coordinate` agent team (svelte + annotation-model review →
 > synthesis). Every `c2MustFix` is folded in and tagged `[MF-n]`.
 
+## 0a. Implementation resolution (2026-05-28, after bundle-source + advisor review)
+
+Reading the source-of-truth C4 bundle (`AnnotationBubble.svelte` / `MarginFrame.svelte`
+in `tandem-design-impl`) + an advisor pass during implementation **superseded three
+points of the reviewed design below.** Recorded here (not silently rewritten) so the
+reviewed plan stays an honest artifact:
+
+1. **`stub` now wins over `isActive` AND `isEditing`** (was: "active/editing always →
+   full"). C-1 merged `stub` as a **~28px-wide** track (PR #927). A 28px track cannot
+   hold a full card OR an edit form. In the bundle a collapsed pill never expands
+   *itself* either — `isCollapsed` and `isActive` are orthogonal axes; clicking a pill
+   swaps it for a full bubble in the *parent's* state, and the bundle's pills live in a
+   **128px-wide** `narrow` column that holds that full bubble. Production's 28px track
+   can't, so a stub stays a pip regardless of active/editing. **This fixes the clipping
+   bug** (a full card spilling the 28px track) that motivated C-2. `cardDensity` order
+   is now: `if (mode==='stub') return 'stub'` first; `AnnotationCard.resolvedDensity` is
+   `density==='stub' ? 'stub' : isEditing ? 'full' : density`.
+2. **`[F4]` import carve-out DROPPED as unreachable.** Imports are `.docx`-only and
+   `.docx` uses the legacy `full|off` margin path — it never enters the narrow/stub
+   continuum — so `author` is not an input to `cardDensity` at all (signature is now
+   `{mode, isActive, isEditing}`).
+3. **`[MF-2]` force-active-on-edit is unnecessary**, and **`[MF-1]`/§3 "KEEP the header
+   visible in stub" was wrong** (advisor: the header's badge + name still overflow 28px).
+   The stub recipe additionally hides `.ach-type` and collapses `.ach-author` text
+   (`font-size:0`), leaving only the 6px `.ach-dot` as the pip. Acceptance gate is now a
+   `scrollWidth ≤ clientWidth` E2E assertion (the card fits its column), not "header
+   visible / body hidden". The editing-stub collision mismatch dissolves because a stub
+   passes `height:undefined` regardless of editing.
+
+4. **Active-full-at-narrow fit VERIFIED (advisor blocker, resolved empirically).** The
+   stub-band `scrollWidth ≤ clientWidth` gate runs on a pip that trivially fits; the case
+   that could still clip is the *active/full* card at narrow=160, where a richer card type
+   renders its full body in the slimmest non-stub track. SuggestionCard is the worst case
+   (its `suggestion-diff-{id}` box holds padded, background-filled old→new spans, wider
+   min-content than a plain comment). Added a 4th C-2 E2E spec — a lone suggestion
+   (auto-selected → active → `full` at narrow) with a realistic multi-word `suggestedText`
+   — asserting the same `scrollWidth ≤ clientWidth + 1` gate plus a within-column box check.
+   **It passes:** the diff-box spans wrap inside the 160px track, no horizontal spill. No
+   recipe fix (`min-width:0` / `overflow-wrap`) was needed; if a future card type fails the
+   gate, that's the documented fix.
+
+**UX cut to bless (Bryan's call):** at the stub band (sub-~600px viewport) the margin
+can no longer read or act on a comment in place — it's a navigation pip only. Clicking it
+selects/scrolls but does not expand. Reading/acting requires widening the viewport (the
+narrow band shows a full card) or the side rail. **Second-order consequence:** two
+annotations anchored to the same text line produce overlapping stub pips (the documented
+STUB-NON-PUSH behavior — stubs don't advance the collision cursor), so in dense same-line
+clusters the pips intercept each other's clicks and you can't reliably select the intended
+one. Edge case, not pervasive, but it strengthens the case for the follow-up. A stub-click
+→ side-rail affordance is filed as a follow-up, NOT part of C-2.
+
 ## 0. Sequencing gate `[MF-8]`
 
 C-1 must merge first — it lands the `mode: MarginMode` prop on `MarginColumn`, threads
@@ -173,9 +224,13 @@ tops); do **not** strengthen it to assert raw-top in mixed full+stub stacks.
   left-column note in stub keeps `data-margin-bubble-reply-count='0'`; (6) **no console
   error** across `full→narrow→stub→full→edit` (effect-depth guard); (7) editing-stub does
   not overlap (force-active-on-edit) `[MF-2]`.
+- **E2E** active-full-at-narrow fit (§0a #4, advisor blocker): a lone suggestion →
+  active → `full` at narrow=160; `scrollWidth ≤ clientWidth + 1` + within-column box. The
+  diff box wraps; no spill. (Covers the *active/full* SuggestionCard — the clamped/stub
+  cases hide or collapse the diff, so only this band renders it at the slim track.)
 - **MANUAL** (claude-in-chrome): all 5 variants at `clamped` + `stub`; SuggestionCard
-  diff-box clamp acceptable; **ImportedCard never stub**; stub pip color per type
-  (`-fg-strong`) actually perceivable; reduced-motion unaffected (C-2 adds no motion).
+  diff-box clamp acceptable (inactive); **ImportedCard never stub**; stub pip color per
+  type (`-fg-strong`) actually perceivable; reduced-motion unaffected (C-2 adds no motion).
 - **REGRESSION:** existing `margin-view.spec.ts` suite stays green (C-2 adds a `full`-
   default prop reproducing today's behavior at `mode==='full'`).
 

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+import { untrack } from "svelte";
 import type { Annotation, AnnotationReply } from "../../shared/types";
 import { getVisibleReplies } from "../annotations/replies";
 import AnnotationCardActions from "./AnnotationCardActions.svelte";
 import AnnotationEditForm from "./AnnotationEditForm.svelte";
 import { getCardLabel, getHighlightBorder } from "./annotation-card-helpers";
 import CommentCard from "./CommentCard.svelte";
+import type { Density } from "./cardDensity";
 import HighlightCard from "./HighlightCard.svelte";
 import ImportedCard from "./ImportedCard.svelte";
 import NoteCard from "./NoteCard.svelte";
@@ -36,6 +38,15 @@ interface Props {
   /** Batch-selection state — forwarded to ImportedCard only. */
   selected?: boolean;
   onToggleSelect?: (id: string) => void;
+  /**
+   * Margin-view density. `full` (default) reproduces today's card; `clamped`
+   * (narrow band) shows the header + a single-line body teaser; `stub` (stub
+   * band) collapses to a ~22px anchor pip. Resolved against `isEditing` below
+   * — editing always forces `full`. Only MarginColumn passes a non-default
+   * value; the side panel leaves it `full`, so existing call sites are
+   * unaffected.
+   */
+  density?: Density;
 }
 
 let {
@@ -54,6 +65,7 @@ let {
   onClick,
   selected = false,
   onToggleSelect,
+  density = "full",
 }: Props = $props();
 
 // Shared edit-mode state owned by the dispatcher; variants are presentational
@@ -72,6 +84,31 @@ const cardLabel = $derived(getCardLabel(annotation));
 const visibleReplies = $derived(getVisibleReplies(annotation, replies));
 const canExpandThread = $derived(visibleReplies.length >= 1);
 let isThreadOverlayOpen = $state(false);
+
+// `stub` wins over everything: the ~28px stub track can't hold an edit form any
+// more than it can hold a full card, so a card that is mid-edit when the
+// viewport shrinks to the stub band collapses to a pip (the edit state persists
+// in the parent and the form reappears when the viewport widens). In the
+// narrow/full bands editing forces `full` — the edit form needs the body, and
+// the dispatcher is the only place `isEditing` is known (the pure `cardDensity`
+// helper MarginColumn calls passes `isEditing: false`). This keeps the render in
+// lockstep with `cardDensity`, whose stub-geometry rule already ignores editing.
+const resolvedDensity = $derived<Density>(
+  density === "stub" ? "stub" : isEditing ? "full" : density,
+);
+
+// Close the reply-thread overlay if the card collapses to a stub — the pip has
+// no affordance to manage an open overlay. Last-value guard so the effect can't
+// re-enter under reactive churn (`feedback_svelte_effect_depth_guard`).
+// Seed with the mount-time density via `untrack` (an intentional non-reactive
+// read — the effect below owns subsequent transitions; subscribing here would
+// be the very re-entrancy the guard prevents).
+let prevDensity: Density = untrack(() => resolvedDensity);
+$effect(() => {
+  if (resolvedDensity === prevDensity) return;
+  prevDensity = resolvedDensity;
+  if (resolvedDensity === "stub") isThreadOverlayOpen = false;
+});
 
 // Per-type body tint replaces the old 3px left-edge border (Conflict #8
 // "lift color" interpretation, sub-PR 1.5 — full-taxonomy tints so every type
@@ -127,9 +164,12 @@ function handleKeyDown(e: KeyboardEvent) {
 <div
   class="tandem-annotation-card"
   class:is-review-target={isReviewTarget}
+  class:is-density-clamped={resolvedDensity === "clamped"}
+  class:is-density-stub={resolvedDensity === "stub"}
   onclick={onClick}
   data-testid="annotation-card-{annotation.id}"
   data-annotation-type={annotation.type}
+  data-density={resolvedDensity}
   data-claude-typing={claudeTyping ? "true" : undefined}
   role="listitem"
   aria-label={cardLabel}
@@ -355,5 +395,75 @@ function handleKeyDown(e: KeyboardEvent) {
       outline: 1px solid ButtonText;
       outline-offset: 1px;
     }
+  }
+
+  /* ───────────────── Density variants (Stage C-2) ─────────────────
+     Margin-view density modifiers layered over the existing dispatcher (NOT a
+     flat data-kind bubble). A clamped/stub card is inactive by construction —
+     active or editing resolves to `full` in cardDensity — so these classes are
+     never present on a focused card; no `:not(.is-review-target)` qualifier is
+     needed. The collapse pierces child-component boundaries via `:global()`:
+     `.aca-body` (variant body), `[data-testid^="annotation-snippet-"]`
+     (AnnotationSnippet), `.aca-row`/`.aca-undo-row`/`.aca-standalone`
+     (AnnotationCardActions), `.art-root` (ReplyThread), and the header pieces
+     `.ach-row`/`.ach-type`/`.ach-author`/`.ach-dot` (AnnotationCardHeader). */
+
+  /* Clamped (narrow band, inactive): keep the full header, hide the snippet,
+     show a single-line body teaser, drop actions + replies. The full
+     `-webkit-box` recipe is required — `-webkit-line-clamp` alone is a no-op —
+     and `overflow: clip` (not `hidden`) avoids creating a focus-autoscroll
+     scroll container (`feedback_overflow_hidden_vs_clip`). */
+  .is-density-clamped :global(.aca-body) {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
+    overflow: clip;
+  }
+  .is-density-clamped :global([data-testid^="annotation-snippet-"]),
+  .is-density-clamped :global(.aca-row),
+  .is-density-clamped :global(.aca-undo-row),
+  .is-density-clamped :global(.aca-standalone),
+  .is-density-clamped :global(.art-root),
+  .is-density-clamped .tandem-expand-thread {
+    display: none;
+  }
+
+  /* Stub (stub band, inactive): a ~22px anchor pip — the 6px author dot only.
+     The stub column is ~28px wide; the card's default 12px padding + the
+     header's badge/author text would overflow ~100px and clip at the window
+     edge (the bug the continuum exposed). Shrinking the padding, collapsing the
+     header chrome, and `overflow: clip` keep the card's footprint inside the
+     column — verified by the E2E scrollWidth gate. */
+  .is-density-stub {
+    padding: var(--tandem-space-1);
+    min-height: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: clip;
+  }
+  .is-density-stub :global([data-testid^="annotation-snippet-"]),
+  .is-density-stub :global(.aca-body),
+  .is-density-stub :global(.aca-row),
+  .is-density-stub :global(.aca-undo-row),
+  .is-density-stub :global(.aca-standalone),
+  .is-density-stub :global(.art-root),
+  .is-density-stub :global(.ach-type),
+  .is-density-stub .tandem-expand-thread {
+    display: none;
+  }
+  .is-density-stub :global(.ach-row) {
+    margin-bottom: 0;
+    justify-content: center;
+    gap: 0;
+  }
+  /* font-size:0 collapses the author label + "(edited)" text to nothing; the
+     6px `.ach-dot` keeps its explicit dimensions, so the dot survives as the
+     pip. (Imports never reach stub density — see cardDensity — and carry no
+     dot, so this only ever shows a user/claude dot.) */
+  .is-density-stub :global(.ach-author) {
+    font-size: 0;
+    gap: 0;
   }
 </style>

--- a/src/client/panels/CommentCard.svelte
+++ b/src/client/panels/CommentCard.svelte
@@ -30,7 +30,7 @@ let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: 
 <AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
 
 {#if !isEditing}
-  <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+  <div class="aca-body" style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
     <p style="margin: 0;">{annotation.content || "(no note)"}</p>
   </div>
 {/if}

--- a/src/client/panels/HighlightCard.svelte
+++ b/src/client/panels/HighlightCard.svelte
@@ -29,7 +29,7 @@ let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: 
 <AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
 
 {#if !isEditing}
-  <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+  <div class="aca-body" style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
     <p style="margin: 0;">{annotation.content || "(no note)"}</p>
   </div>
 {/if}

--- a/src/client/panels/ImportedCard.svelte
+++ b/src/client/panels/ImportedCard.svelte
@@ -68,7 +68,7 @@ let {
     <AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
 
     {#if !isEditing}
-      <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+      <div class="aca-body" style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
         <p style="margin: 0;">{annotation.content || "(no note)"}</p>
       </div>
     {/if}

--- a/src/client/panels/MarginColumn.svelte
+++ b/src/client/panels/MarginColumn.svelte
@@ -4,6 +4,7 @@ import type { Annotation, AnnotationReply } from "../../shared/types";
 import { getVisibleReplies } from "../annotations/replies";
 import type { MarginMode } from "../layout/editor-stage.svelte";
 import AnnotationCard from "./AnnotationCard.svelte";
+import { cardDensity } from "./cardDensity";
 import { prunePlaceableHeights, resolveCollisions } from "./marginCollision";
 import { bezierLeaderPath, leaderColorForAuthor } from "./marginLeaderGeometry";
 
@@ -15,8 +16,8 @@ interface Props {
   side: "left" | "right";
   /** Resolved track mode for this side (`full` | `narrow` | `stub`). The width
    *  continuum. A column only mounts when its side is visible, so `off` never
-   *  reaches here. Pure pass-through in C-1 — the bubble density variants that
-   *  consume it (clamp-until-active, stub pill) land in C-2. */
+   *  reaches here. C-2 derives bubble density from it (`cardDensity`):
+   *  `narrow`→clamp-until-active, `stub`→anchor pip. */
   mode: MarginMode;
   /** Column width in pixels. */
   width: number;
@@ -44,10 +45,10 @@ let {
   annotations,
   positions,
   side,
-  // `mode` is accepted but not yet consumed (C-1 is pure pass-through); C-2
-  // derives bubble density from it. Destructured so the prop typechecks and is
-  // ready at the call site without a later signature change.
-  mode: _mode,
+  // C-2: drives per-bubble density (`cardDensity`) for both the collision input
+  // and the rendered card. `off` never reaches here (the column unmounts when a
+  // side collapses), so only `full` | `narrow` | `stub` are live.
+  mode,
   width,
   edgeInset,
   gap,
@@ -99,6 +100,21 @@ const placeable = $derived(
 // (`feedback_svelte_effect_depth_guard`).
 let heights = $state<Map<string, number>>(new Map());
 
+// Per-annotation density — the SINGLE source of truth shared by the collision
+// input below and the rendered card prop, so the two can't drift (`isEditing:
+// false`; the dispatcher re-resolves editing→full internally for narrow/full,
+// and at stub mode every card is a pip regardless — cardDensity's stub-geometry
+// rule). Built from the same `placeable` the each-block iterates, both inputs
+// reactive (mode + activeAnnotationId), no collision output read → no cycle.
+const densityById = $derived(
+  new Map(
+    placeable.map((a) => [
+      a.id,
+      cardDensity({ mode, isActive: a.id === activeAnnotationId, isEditing: false }),
+    ]),
+  ),
+);
+
 // Collision-resolved tops. Sweep input is built from `placeable` + `positions`
 // + `heights`; the result is a brand-new Map. Reads from `positions` happen
 // synchronously inside this $derived, so dependency tracking is automatic and
@@ -107,7 +123,11 @@ const adjustedPositions = $derived.by(() => {
   const input = placeable.map((a) => ({
     id: a.id,
     top: positions.get(a.id) ?? 0,
-    height: heights.get(a.id),
+    // A stub passes `height: undefined` so it lands in resolveCollisions'
+    // unknown-height branch: it does not advance the cursor (the STUB-NON-PUSH
+    // contract in marginCollision.ts), though a preceding full bubble can still
+    // push it down.
+    height: densityById.get(a.id) === "stub" ? undefined : heights.get(a.id),
   }));
   return resolveCollisions(input);
 });
@@ -215,6 +235,11 @@ function recordHeight(id: string, h: number): void {
   {#each placeable as ann (ann.id)}
     {@const top = adjustedPositions.get(ann.id) ?? positions.get(ann.id) ?? 0}
     {@const visibleReplies = getVisibleReplies(ann, repliesById.get(ann.id))}
+    <!-- Same `densityById` map the collision input reads — single source of
+         truth, so the rendered density and the stub→undefined-height routing
+         can never diverge. (`?? "full"` only satisfies the non-null type; the
+         key is always present since the map is built from `placeable`.) -->
+    {@const density = densityById.get(ann.id) ?? "full"}
     <!-- Svelte 5 function-binding form on `bind:clientHeight` below
          (`bind:prop={getter, setter}`) — the only form that supports
          per-key dispatch into a Map. A plain `bind:clientHeight={x}`
@@ -239,6 +264,7 @@ function recordHeight(id: string, h: number): void {
         annotation={ann}
         replies={visibleReplies}
         isReviewTarget={ann.id === activeAnnotationId}
+        {density}
         onClick={() => onClick(ann)}
         onAccept={ann.author !== "user" ? onAccept : undefined}
         onDismiss={ann.author !== "user" ? onDismiss : undefined}

--- a/src/client/panels/NoteCard.svelte
+++ b/src/client/panels/NoteCard.svelte
@@ -40,7 +40,7 @@ let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: 
 <AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
 
 {#if !isEditing}
-  <div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+  <div class="aca-body" style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
     <p style="margin: 0;">{annotation.content || "(no note)"}</p>
   </div>
 {/if}

--- a/src/client/panels/ReplyThread.svelte
+++ b/src/client/panels/ReplyThread.svelte
@@ -56,6 +56,10 @@ async function handleSendReply() {
 }
 </script>
 
+<!-- `art-root` is the density-collapse hook: the card dispatcher hides the
+     whole reply region in clamped/stub via `:global(.art-root)`. Plain block
+     wrapper, so full-density vertical flow is unchanged. -->
+<div class="art-root">
 <CommentThread replies={visibleReplies} />
 
 {#if isPending && onReply && !isEditing}
@@ -115,3 +119,13 @@ async function handleSendReply() {
     {visibleReplies.length === 1 ? "reply" : "replies"}
   </div>
 {/if}
+</div>
+
+<style>
+  /* Layout-transparent in full density (no box) so the reply region keeps its
+     exact vertical flow; the dispatcher's clamped/stub `display:none` override
+     wins on specificity. */
+  .art-root {
+    display: contents;
+  }
+</style>

--- a/src/client/panels/SuggestionCard.svelte
+++ b/src/client/panels/SuggestionCard.svelte
@@ -30,7 +30,7 @@ let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: 
 <AnnotationSnippet annotationId={annotation.id} text={annotation.textSnapshot} />
 
 {#if !isEditing}
-<div style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
+<div class="aca-body" style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
   <div
     data-testid="suggestion-diff-{annotation.id}"
     style="padding: 4px 8px; margin-bottom: {annotation.content

--- a/src/client/panels/cardDensity.ts
+++ b/src/client/panels/cardDensity.ts
@@ -1,0 +1,55 @@
+/**
+ * Margin-bubble density resolution — pure helper extracted from the card
+ * dispatcher so the density rule is unit-testable without mounting Svelte
+ * (`feedback_extract_helper_over_mount`). Sibling to `marginCollision.ts` /
+ * `marginLeaderGeometry.ts`.
+ *
+ * Density is a CSS-modifier concern layered over the EXISTING `AnnotationCard`
+ * dispatcher and its five variants (plan C2 — NOT a flat `data-kind` bubble).
+ *
+ *   full    — today's card, every section visible.
+ *   clamped — narrow band, inactive: header + a single-line body teaser; the
+ *             snippet, action row, replies, and expand button are hidden.
+ *   stub    — stub band: a ~22px anchor pip (author dot only); the whole card
+ *             body AND the header's text chrome collapse.
+ *
+ * One-way dependency: density reads ONLY (mode, isActive, isEditing) — NEVER
+ * collision output (heights / adjustedPositions). The height → density → height
+ * cycle is therefore structurally impossible (`feedback_svelte_effect_depth_guard`,
+ * plan [MF-6]).
+ *
+ * Stub geometry note (divergence from plan §5 "stub click → full in place" and
+ * bundle `AnnotationBubble`): the C-1 stub track is ~28px wide (merged in PR
+ * #927), which cannot hold a full card. In the C4 bundle a collapsed pill never
+ * expands *itself* either — `isCollapsed` and `isActive` are orthogonal axes;
+ * clicking a pill swaps it for a full bubble in the *parent's* state, and the
+ * bundle's pills live in a 128px-wide `narrow` column that can hold that full
+ * bubble. Production's 28px track can't, so here `stub` wins over `isActive` /
+ * `isEditing`: a stub stays a pip. Reading/acting on a stubbed annotation happens
+ * after the viewport widens (the narrow band shows a full card) or via the side
+ * rail. A click-to-side-rail affordance for the pip is a tracked follow-up, NOT
+ * part of C-2's density scope. Imports (which would lose their byline in a pip)
+ * are unaffected: imports are .docx-only and .docx uses the legacy full|off
+ * margin path — it never enters the narrow/stub continuum — so `author` is not
+ * an input here (plan [F4] import carve-out dropped as unreachable).
+ */
+import type { MarginMode } from "../layout/editor-stage.svelte";
+
+export type Density = "full" | "clamped" | "stub";
+
+export function cardDensity(args: {
+  mode: MarginMode;
+  isActive: boolean;
+  isEditing: boolean;
+}): Density {
+  // Stub track (~28px) fits only an anchor pip — for everyone, active or
+  // editing. See the stub-geometry note above: there is no room to expand in
+  // place, so stub wins over active/editing.
+  if (args.mode === "stub") return "stub";
+  // Narrow/full bands have room: a focused or editing card expands to full
+  // (bundle: `-webkit-line-clamp:1` → `unset` on `.is-active`).
+  if (args.isEditing || args.isActive) return "full";
+  // Inactive narrow → a single-line teaser; `full` band keeps full density;
+  // `off` never reaches here (the column unmounts) but falls through safely.
+  return args.mode === "narrow" ? "clamped" : "full";
+}

--- a/tests/client/cardDensity.test.ts
+++ b/tests/client/cardDensity.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { MarginMode } from "../../src/client/layout/editor-stage.svelte";
+import { cardDensity, type Density } from "../../src/client/panels/cardDensity";
+
+interface Case {
+  mode: MarginMode;
+  isActive: boolean;
+  isEditing: boolean;
+  expected: Density;
+  why: string;
+}
+
+// Equivalence classes over MarginMode × {active,inactive} × {editing,not}. The
+// `why` column names the rule each row exercises so a missing class is visible
+// (`feedback_iteach_equivalence_classes`). `author` is intentionally NOT an
+// input — imports are .docx-only and .docx never enters the narrow/stub
+// continuum (legacy full|off path), so the plan [F4] import carve-out is
+// unreachable; see the stub-geometry note in cardDensity.ts.
+const cases: Case[] = [
+  // --- stub band wins over active AND editing (28px track fits only a pip) ---
+  { mode: "stub", isActive: false, isEditing: false, expected: "stub", why: "stub inactive → pip" },
+  {
+    mode: "stub",
+    isActive: true,
+    isEditing: false,
+    expected: "stub",
+    why: "stub stays a pip even when active (no in-place expand at 28px)",
+  },
+  {
+    mode: "stub",
+    isActive: false,
+    isEditing: true,
+    expected: "stub",
+    why: "stub stays a pip even when editing (edit affordance is hidden in stub)",
+  },
+  {
+    mode: "stub",
+    isActive: true,
+    isEditing: true,
+    expected: "stub",
+    why: "stub wins over both overrides",
+  },
+
+  // --- narrow band: active/editing expand to full, else a one-line teaser ---
+  {
+    mode: "narrow",
+    isActive: false,
+    isEditing: false,
+    expected: "clamped",
+    why: "narrow inactive → clamped teaser",
+  },
+  {
+    mode: "narrow",
+    isActive: true,
+    isEditing: false,
+    expected: "full",
+    why: "active expands narrow → full",
+  },
+  {
+    mode: "narrow",
+    isActive: false,
+    isEditing: true,
+    expected: "full",
+    why: "editing expands narrow → full",
+  },
+  {
+    mode: "narrow",
+    isActive: true,
+    isEditing: true,
+    expected: "full",
+    why: "narrow active+editing → full",
+  },
+
+  // --- full band: always full -------------------------------------------------
+  { mode: "full", isActive: false, isEditing: false, expected: "full", why: "full band, inactive" },
+  { mode: "full", isActive: true, isEditing: false, expected: "full", why: "full band, active" },
+  { mode: "full", isActive: false, isEditing: true, expected: "full", why: "full band, editing" },
+
+  // --- off band: full (column unmounts before this is rendered) --------------
+  {
+    mode: "off",
+    isActive: false,
+    isEditing: false,
+    expected: "full",
+    why: "off band falls through to full",
+  },
+  {
+    mode: "off",
+    isActive: true,
+    isEditing: true,
+    expected: "full",
+    why: "off band, overrides irrelevant",
+  },
+];
+
+describe("cardDensity", () => {
+  it.each(cases)("$mode active=$isActive editing=$isEditing → $expected ($why)", ({
+    mode,
+    isActive,
+    isEditing,
+    expected,
+  }) => {
+    expect(cardDensity({ mode, isActive, isEditing })).toBe(expected);
+  });
+
+  it("is total over the full input space (no undefined return)", () => {
+    const modes: MarginMode[] = ["full", "narrow", "stub", "off"];
+    const valid: Density[] = ["full", "clamped", "stub"];
+    for (const mode of modes) {
+      for (const isActive of [true, false]) {
+        for (const isEditing of [true, false]) {
+          expect(valid).toContain(cardDensity({ mode, isActive, isEditing }));
+        }
+      }
+    }
+  });
+});

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -1083,3 +1083,269 @@ test("C-1: docx keeps its legacy path — stage is never a grid", async ({ page 
     cleanupFixtureDir(docxDir);
   }
 });
+
+/**
+ * Stage C-2 — density variants. The `MarginMode` continuum (C-1) drives a
+ * per-card density (`cardDensity`): in the NARROW band an inactive card clamps
+ * to a one-line teaser and the active (focused) card expands to full; in the
+ * STUB band EVERY card is a ~22px pip regardless of active/editing — the 28px
+ * stub track can't hold card chrome (see the stub-geometry note in
+ * cardDensity.ts; this is the resolved divergence from plan §5 "stub click →
+ * full in place" and the C4 bundle, where the collapsed pill also never expands
+ * itself but lives in a 128px-wide column that production's 28px track is not).
+ * Widths reuse the C-1 ladder (1200=full / 950=narrow / 750=stub / 500=off),
+ * proven deterministic above. The card carries `data-density` for assertions.
+ *
+ * A lone annotation is auto-selected as the review target by
+ * `useAnnotationReview`, which forces it to `full` in the narrow band. So these
+ * specs seed TWO comments and click one to fix which is active — the other is
+ * then deterministically inactive (clamped at narrow / a pip at stub).
+ */
+async function seedTwoComments(): Promise<{ idA: string; idB: string }> {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  const a = (await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_FROM + 4,
+    text: "first comment — the one these specs activate",
+    textSnapshot: TITLE_TEXT.slice(0, 4),
+  })) as { error: false; data: { annotationId: string } } | { error: true };
+  const b = (await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM + 5,
+    to: TITLE_TO,
+    text: "a fairly long second comment body so the clamp visibly collapses it to one line",
+    textSnapshot: TITLE_TEXT.slice(5),
+  })) as { error: false; data: { annotationId: string } } | { error: true };
+  if (a.error !== false || b.error !== false) throw new Error("tandem_comment failed");
+  return { idA: a.data.annotationId, idB: b.data.annotationId };
+}
+
+test("C-2: narrow band clamps the inactive card while the active one stays full", async ({
+  page,
+}) => {
+  const { idA, idB } = await seedTwoComments();
+  await page.setViewportSize({ width: 950, height: 900 }); // narrow band
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+
+  // Scope through the `margin-bubble-{id}` wrapper: the `annotation-card-{id}`
+  // testid also appears in the always-mounted (display:none) side panel, so a
+  // bare card selector matches two elements.
+  const cardA = page.locator(
+    `[data-testid='margin-bubble-${idA}'] [data-testid='annotation-card-${idA}']`,
+  );
+  const cardB = page.locator(
+    `[data-testid='margin-bubble-${idB}'] [data-testid='annotation-card-${idB}']`,
+  );
+  await expect(cardA).toBeVisible({ timeout: 5_000 });
+  await expect(cardB).toBeVisible({ timeout: 5_000 });
+
+  // Force A active → A full, B inactive → clamped. Deterministic regardless of
+  // which card the review hook auto-selects on load.
+  await cardA.click();
+  await expect(cardA).toHaveAttribute("data-density", "full", { timeout: 5_000 });
+  await expect(cardB).toHaveAttribute("data-density", "clamped", { timeout: 5_000 });
+  // Action row is hidden in clamped (the accept button lives in `.aca-row`).
+  await expect(cardB.locator("[data-testid^='accept-btn-']")).toBeHidden();
+
+  // [MF-3] — the clamped card is actually SHORTER, not just missing its action
+  // row. Capture B's clamped height, activate B (which clamps A), assert B grew.
+  const clampedBox = await cardB.boundingBox();
+  expect(clampedBox).not.toBeNull();
+
+  await cardB.click();
+  await expect(cardB).toHaveAttribute("data-density", "full", { timeout: 5_000 });
+  await expect(cardA).toHaveAttribute("data-density", "clamped", { timeout: 5_000 });
+  await expect(cardB.locator("[data-testid^='accept-btn-']")).toBeVisible();
+  await expect
+    .poll(async () => (await cardB.boundingBox())?.height ?? 0, {
+      timeout: 5_000,
+      message: "activated (full) card must be taller than the clamped teaser",
+    })
+    .toBeGreaterThan((clampedBox as { height: number }).height);
+});
+
+test("C-2: stub band collapses every card to a pip that fits the column and stays a pip when clicked", async ({
+  page,
+}) => {
+  const { idA, idB } = await seedTwoComments();
+  await page.setViewportSize({ width: 750, height: 900 }); // stub band
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+
+  // Scope through `margin-bubble-{id}` — the card testid is also present in the
+  // always-mounted (display:none) side panel.
+  const bubbleA = page.locator(`[data-testid='margin-bubble-${idA}']`);
+  const cardA = bubbleA.locator(`[data-testid='annotation-card-${idA}']`);
+  const cardB = page.locator(
+    `[data-testid='margin-bubble-${idB}'] [data-testid='annotation-card-${idB}']`,
+  );
+  await expect(cardA).toBeVisible({ timeout: 5_000 });
+  await expect(cardB).toBeVisible({ timeout: 5_000 });
+
+  // Both cards are pips in the stub band — active state is irrelevant.
+  await expect(cardA).toHaveAttribute("data-density", "stub", { timeout: 5_000 });
+  await expect(cardB).toHaveAttribute("data-density", "stub", { timeout: 5_000 });
+
+  // Body / snippet / actions collapse in stub; the wrapper persists so the pip
+  // is clickable (stub ≠ display:none).
+  await expect(cardA.locator(".aca-body")).toBeHidden();
+  await expect(cardA.locator("[data-testid^='accept-btn-']")).toBeHidden();
+
+  // THE ACCEPTANCE GATE (advisor): the stub card must FIT inside its column —
+  // no horizontal spill past the column edge (the clipping bug the continuum
+  // exposed). `scrollWidth > clientWidth` is precisely the overflow signature;
+  // a 1px tolerance absorbs sub-pixel rounding.
+  const fit = await cardA.evaluate((el) => {
+    const e = el as HTMLElement;
+    return { scrollWidth: e.scrollWidth, clientWidth: e.clientWidth };
+  });
+  expect(fit.scrollWidth).toBeLessThanOrEqual(fit.clientWidth + 1);
+
+  // The card's rendered box must also sit within its column wrapper.
+  const within = await bubbleA.evaluate((wrapper) => {
+    const card = wrapper.querySelector("[data-testid^='annotation-card-']") as HTMLElement | null;
+    if (!card) return false;
+    const w = wrapper.getBoundingClientRect();
+    const c = card.getBoundingClientRect();
+    return c.right <= w.right + 1 && c.left >= w.left - 1;
+  });
+  expect(within).toBe(true);
+
+  // A stub stays a pip even when it's the ACTIVE review target — the 28px stub
+  // track has no room to expand in place. `useAnnotationReview` auto-selects one
+  // card on load (it carries `is-review-target` / `aria-current`); assert that
+  // active margin card is STILL `stub`. (We assert on the auto-active card
+  // rather than clicking: both comments anchor to the same title line, so their
+  // stub pips overlap — STUB-NON-PUSH — and would intercept each other's click.
+  // The density code path is identical for click- vs auto-set active. Reading/
+  // acting on a stub happens after widening or via the rail — tracked follow-up.)
+  const activeStub = page.locator(
+    "[data-testid='margin-column-right'] .tandem-annotation-card.is-review-target",
+  );
+  await expect(activeStub).toHaveAttribute("data-density", "stub", { timeout: 5_000 });
+  await expect(activeStub.locator(".aca-body")).toBeHidden();
+});
+
+/**
+ * Stage C-2 — the ACTIVE-FULL-AT-NARROW fit guard (advisor). The stub-band
+ * scrollWidth gate above runs on a pip that trivially fits; the case that can
+ * still clip is the *active/full* card at narrow=160, where a richer card type
+ * renders its full body inside the slimmest non-stub track. SuggestionCard is
+ * the worst offender: its diff box (`suggestion-diff-{id}`) holds a
+ * strikethrough-old → new pair of padded, background-filled spans whose
+ * min-content is wider than the plain comment we measured for the stub
+ * diagnosis. A lone annotation auto-selects as the review target → active →
+ * `full` in the narrow band, so a single suggestion exercises exactly this
+ * path. The acceptance gate is the same one the stub spec uses, one band over
+ * and one card type richer: the card root must not spill past its column.
+ */
+test("C-2: an active suggestion at narrow fits its column (no diff-box spill)", async ({
+  page,
+}) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  const created = (await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "tighten the heading",
+    // A realistic multi-word replacement — the diff box must wrap it inside the
+    // 160px narrow track, not push the card wider than the column.
+    suggestedText: "Comprehensive Project Title",
+    textSnapshot: TITLE_TEXT,
+  })) as { error: false; data: { annotationId: string } } | { error: true };
+  if (created.error !== false) throw new Error("tandem_comment (suggestion) failed");
+  const id = created.data.annotationId;
+
+  await page.setViewportSize({ width: 950, height: 900 }); // narrow band
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+
+  const bubble = page.locator(`[data-testid='margin-bubble-${id}']`);
+  const card = bubble.locator(`[data-testid='annotation-card-${id}']`);
+  await expect(card).toBeVisible({ timeout: 5_000 });
+
+  // Lone annotation → auto review target → active → full at narrow. The diff
+  // box must actually render (this is the body that the stub band hides and the
+  // clamped band collapses — here it's the full, unclamped suggestion).
+  await expect(card).toHaveAttribute("data-density", "full", { timeout: 5_000 });
+  await expect(card.locator(`[data-testid='suggestion-diff-${id}']`)).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // THE ACCEPTANCE GATE: the full suggestion card must FIT its narrow column —
+  // the diff-box spans must wrap, not spill horizontally past the card edge.
+  // `scrollWidth > clientWidth` is the overflow signature; 1px absorbs rounding.
+  const fit = await card.evaluate((el) => {
+    const e = el as HTMLElement;
+    return { scrollWidth: e.scrollWidth, clientWidth: e.clientWidth };
+  });
+  expect(fit.scrollWidth).toBeLessThanOrEqual(fit.clientWidth + 1);
+
+  // And the rendered box sits within its column wrapper (catches a spill that a
+  // card-internal `overflow:clip` would hide from scrollWidth but still paint
+  // past the column edge).
+  const within = await bubble.evaluate((wrapper) => {
+    const c = wrapper.querySelector("[data-testid^='annotation-card-']") as HTMLElement | null;
+    if (!c) return false;
+    const w = wrapper.getBoundingClientRect();
+    const r = c.getBoundingClientRect();
+    return r.right <= w.right + 1 && r.left >= w.left - 1;
+  });
+  expect(within).toBe(true);
+});
+
+test("C-2: density sweep full→narrow→stub→full emits no console errors", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+
+  const { idA, idB } = await seedTwoComments();
+  await page.setViewportSize({ width: 1200, height: 900 });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+  await expect(page.locator("[data-annotation-id]").first()).toBeVisible({ timeout: 15_000 });
+
+  await setMarginView(page, true);
+  // Scope through `margin-bubble-{id}` — the card testid is also present in the
+  // always-mounted (display:none) side panel.
+  const cardA = page.locator(
+    `[data-testid='margin-bubble-${idA}'] [data-testid='annotation-card-${idA}']`,
+  );
+  const cardB = page.locator(
+    `[data-testid='margin-bubble-${idB}'] [data-testid='annotation-card-${idB}']`,
+  );
+  await expect(cardA).toBeVisible({ timeout: 5_000 });
+
+  // Fix A active so B is deterministically inactive — B then steps through every
+  // density as the viewport sweeps the bands (an active card would stay `full`
+  // in the narrow band and never exercise `clamped`). At this 1200 full band
+  // both cards are still `full`; B only diverges once we drop to narrow.
+  await cardA.click();
+  await expect(cardA).toHaveClass(/is-review-target/, { timeout: 5_000 });
+
+  // full → narrow (clamped) → stub → back to full, with a frame settle between
+  // each so the density `$effect` (overlay-close guard) actually runs. A retry
+  // storm from a missing last-value guard would surface as console errors here.
+  await expect(cardB).toHaveAttribute("data-density", "full", { timeout: 5_000 });
+  await page.setViewportSize({ width: 950, height: 900 });
+  await expect(cardB).toHaveAttribute("data-density", "clamped", { timeout: 5_000 });
+  await page.setViewportSize({ width: 750, height: 900 });
+  await expect(cardB).toHaveAttribute("data-density", "stub", { timeout: 5_000 });
+  await page.setViewportSize({ width: 1200, height: 900 });
+  await expect(cardB).toHaveAttribute("data-density", "full", { timeout: 5_000 });
+  await nextFrames(page);
+
+  // Filter to app/effect errors — ignore benign Y.js "Invalid access" stderr
+  // noise documented in CLAUDE.md (it can surface as a console error in dev).
+  const appErrors = errors.filter((e) => !/Invalid access|favicon/i.test(e));
+  expect(appErrors, `unexpected console errors: ${appErrors.join("\n")}`).toEqual([]);
+});


### PR DESCRIPTION
Supersedes #929 (auto-closed by GitHub when C-1's head branch was deleted on merge of #927 — the base branch of #929 disappeared). Same branch, same commit (`e0e6298`), now retargeted onto the umbrella. C-1 (#927) is already merged, so this PR's diff is just the C-2 commit.

Phase 3.5 margin-view redesign, on `feat/design-system-impl`.

## Problem

C-1 collapses the margin **track** (`full → narrow → stub → off`) but kept rendering the full ~158px `AnnotationCard` inside it. At the 28px **stub** track the card spilled and clipped past the column edge.

## Fix — collapse the *card* to match its *track*

A pure `cardDensity({mode, isActive, isEditing}) → "full" | "clamped" | "stub"` helper that reads only inputs (never collision output), so there's no height→density→height cycle:

- **`full`** — today's card, unchanged (full band, or active/editing in narrow).
- **`clamped`** — narrow band, inactive: one-line teaser; body / actions / replies hidden.
- **`stub`** — stub band: ~22px navigation pip (author dot + status pip), *every* card regardless of active/editing.

`stub` wins over `isActive`/`isEditing` because a 28px track can't hold card chrome or an edit form — bundle-faithful (C4's collapsed-pill and active are orthogonal axes; its pills live in a 128px column, production's is 28px). Resolved divergence from plan §5's "stub click → full in place."

`MarginColumn` derives a single `densityById` map consumed by both the height calc and the render block, eliminating the prior lockstep-by-convention drift between two duplicate `cardDensity` calls.

## UX cut (Bryan blessed, 2026-05-28)

At the stub band (sub-~600px viewport) a margin card is a click-to-select pip — **not readable/actionable in place**. Reading/acting is via widening or the side rail. Second-order: same-line annotations make overlapping pips (STUB-NON-PUSH) that intercept each other's clicks. Follow-up: **#928** (stub-click → side-rail).

## Verification

- **Unit** (`cardDensity.test.ts`): 14-row `it.each` equivalence table (mode × active × editing) + totality.
- **E2E** (`margin-view.spec.ts`, 4 C-2 specs): narrow clamp + reactivation height delta; stub fit gate (`scrollWidth ≤ clientWidth` + within-column) + stays-stub-when-active; active-full **SuggestionCard** fits narrow without diff-box spill; density sweep emits no console errors.
- Full suite **3133 passed, 20 skipped**; `typecheck` + `svelte-check` 0/0; CI rust-test green on ubuntu + windows.
- Reviewed clean by `svelte-migration-reviewer` (reactive cycle structurally absent; overlay-close `$effect` last-value guarded) and `annotation-model-reviewer` (ADR-027 display-only collapse intact; pending filter + side-split + 6-branch `cardTint` preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)