### PR TITLE
fix(margin): re-read layer rect per iteration to prevent Y-axis drift (#918)

### DIFF
--- a/src/client/hooks/useMarginPositions.svelte.ts
+++ b/src/client/hooks/useMarginPositions.svelte.ts
@@ -39,12 +39,19 @@ export interface ComputeResult {
  *   `display: none` ancestor) is skipped — it would render as `top: NaNpx`
  *   and defeat the `mapsEqual` tolerance check (NaN-vs-anything is always
  *   "unequal", causing per-frame re-render storms).
+ * - `getLayerTop` is a function, not a pre-captured number, so the layer rect
+ *   is re-read on every iteration. `coordsAtPos` forces a layout flush; if the
+ *   layer reflows between iterations (ResizeObserver, bind:clientHeight, IME
+ *   composition), a single pre-captured rect is stale for subsequent
+ *   annotations, causing Y drift. Calling `getLayerTop()` **after**
+ *   `coordsAtPos` in the same iteration reads the rect in the flush that
+ *   `coordsAtPos` already triggered — free when stable, correct when not.
  */
 export function _computeNextPositionsForTesting(
   annotations: readonly Annotation[],
   resolveRange: (ann: Annotation) => { from: number; to: number } | null,
   coordsAtPos: (pos: number) => { top: number },
-  layerTop: number,
+  getLayerTop: () => number,
 ): ComputeResult {
   const positions = new Map<string, number>();
   let attempted = 0;
@@ -56,7 +63,7 @@ export function _computeNextPositionsForTesting(
     try {
       const coords = coordsAtPos(range.from);
       if (!Number.isFinite(coords.top)) continue;
-      positions.set(ann.id, coords.top - layerTop);
+      positions.set(ann.id, coords.top - getLayerTop());
     } catch {
       thrown++;
     }
@@ -128,13 +135,12 @@ export function createMarginPositions(opts: CreateMarginPositionsOpts): MarginPo
       return;
     }
 
-    const layerTop = layer.getBoundingClientRect().top;
     const annotations = opts.getAnnotations();
     const { positions, attempted, thrown } = _computeNextPositionsForTesting(
       annotations,
       (ann) => annotationToPmRange(ann, editor.state.doc, ydoc),
       (pos) => editor.view.coordsAtPos(pos),
-      layerTop,
+      () => layer.getBoundingClientRect().top,
     );
 
     if (attempted > 0 && thrown === attempted) {

--- a/tests/client/useMarginPositions.test.ts
+++ b/tests/client/useMarginPositions.test.ts
@@ -80,7 +80,7 @@ describe("useMarginPositions / computeNextPositions", () => {
       [],
       () => ({ from: 0, to: 0 }),
       () => ({ top: 0 }),
-      0,
+      () => 0,
     );
     expect(r.positions.size).toBe(0);
     expect(r.attempted).toBe(0);
@@ -92,7 +92,7 @@ describe("useMarginPositions / computeNextPositions", () => {
       [ann("a"), ann("b"), ann("c")],
       () => null,
       () => ({ top: 0 }),
-      0,
+      () => 0,
     );
     expect(r.positions.size).toBe(0);
     expect(r.attempted).toBe(0);
@@ -104,7 +104,7 @@ describe("useMarginPositions / computeNextPositions", () => {
       [ann("a")],
       () => ({ from: 5, to: 10 }),
       () => ({ top: 150 }),
-      50,
+      () => 50,
     );
     expect(r.positions.get("a")).toBe(100);
     expect(r.attempted).toBe(1);
@@ -116,7 +116,7 @@ describe("useMarginPositions / computeNextPositions", () => {
       [ann("a")],
       () => ({ from: 0, to: 0 }),
       () => ({ top: Number.NaN }),
-      0,
+      () => 0,
     );
     expect(r.positions.has("a")).toBe(false);
     expect(r.attempted).toBe(1);
@@ -128,10 +128,36 @@ describe("useMarginPositions / computeNextPositions", () => {
       [ann("a")],
       () => ({ from: 0, to: 0 }),
       () => ({ top: Number.POSITIVE_INFINITY }),
-      0,
+      () => 0,
     );
     expect(r.positions.has("a")).toBe(false);
     expect(r.attempted).toBe(1);
+  });
+
+  it("re-reads layerTop per iteration — mid-loop layer reflow does not cause Y drift", () => {
+    // Simulate the layer shifting by 10px after the first coordsAtPos call
+    // (e.g. a ResizeObserver flush or bind:clientHeight reflow). With a
+    // pre-captured layerTop the second annotation's offset would be wrong
+    // (210 - 100 = 110 instead of 100). With getLayerTop() called per
+    // iteration after coordsAtPos, both offsets are 100.
+    let coordsCall = 0;
+    let layerTopCall = 0;
+    const r = computeNextPositions(
+      [ann("a"), ann("b")],
+      () => ({ from: 0, to: 0 }),
+      () => {
+        const top = coordsCall === 0 ? 200 : 210;
+        coordsCall++;
+        return { top };
+      },
+      () => {
+        const top = layerTopCall === 0 ? 100 : 110;
+        layerTopCall++;
+        return top;
+      },
+    );
+    expect(r.positions.get("a")).toBe(100); // 200 - 100
+    expect(r.positions.get("b")).toBe(100); // 210 - 110
   });
 
   it("counts thrown when coordsAtPos throws — one stale anchor doesn't blank the column", () => {
@@ -145,7 +171,7 @@ describe("useMarginPositions / computeNextPositions", () => {
         }
         return { top: 0 };
       },
-      0,
+      () => 0,
     );
     // All three pass — sanity baseline for the next case.
     expect(r.positions.size).toBe(3);
@@ -160,7 +186,7 @@ describe("useMarginPositions / computeNextPositions", () => {
         if (call === 2) throw new Error("stale position");
         return { top: 100 };
       },
-      0,
+      () => 0,
     );
     expect(r2.positions.has("a")).toBe(true);
     expect(r2.positions.has("b")).toBe(false);
@@ -176,7 +202,7 @@ describe("useMarginPositions / computeNextPositions", () => {
       () => {
         throw new Error("view detached");
       },
-      0,
+      () => 0,
     );
     expect(r.positions.size).toBe(0);
     expect(r.attempted).toBe(3);
@@ -193,7 +219,7 @@ describe("useMarginPositions / computeNextPositions", () => {
         if (call % 2 === 0) throw new Error("stale");
         return { top: 100 };
       },
-      0,
+      () => 0,
     );
     expect(r.attempted).toBe(3);
     expect(r.thrown).toBe(1);


### PR DESCRIPTION
## Summary

- `layer.getBoundingClientRect().top` was captured once before the `coordsAtPos` loop in `_computeNextPositionsForTesting`. Since each `coordsAtPos` call forces a layout flush, any reflow between iterations (ResizeObserver, `bind:clientHeight` from MarginColumn's height write, IME composition) left `layerTop` stale for subsequent annotations, causing Y drift in margin bubble positions.
- Changed `layerTop: number` → `getLayerTop: () => number` so the layer rect is re-read after each `coordsAtPos` call in the same layout flush — essentially free when layout is stable, and correct when it's not.
- Added regression test that simulates a mid-loop layer shift and verifies each annotation's offset remains accurate relative to its own layout snapshot.

Closes #918.

## Test plan

- [x] `npm test` — all 3041 tests pass (1 skipped: build-artifact requires `npm run build:server` first)
- [x] `npm run typecheck` — clean (0 errors, 0 warnings)
- [x] `cargo test` — all 21 Rust tests pass
- [x] New regression test: `re-reads layerTop per iteration — mid-loop layer reflow does not cause Y drift`

https://claude.ai/code/session_017RTDAkZY4rJU7A6s37rSn4

---
_Generated by [Claude Code](https://claude.ai/code/session_017RTDAkZY4rJU7A6s37rSn4)_