### PR TITLE
diverge: document leaky isolation and speedrunner low-yield from first-use validation

### DIFF
--- a/.claude/commands/diverge.md
+++ b/.claude/commands/diverge.md
@@ -138,3 +138,10 @@ After the user picks:
 - **Don't leak context into generators.** Step 2 is where the method lives or dies. Resist the urge to "help" generators by passing codebase context.
 - **Don't inline-critic.** The critic must be a separate `Agent` call. Do not score proposals yourself before step 3.
 - **Don't pick for the user.** Step 6 is a picker, not a recommendation. State trade-offs in the `preview` content, do not order the options by your preference.
+
+## Known limitations and curation notes
+
+These were captured during the first-use validation (two runs against known-answer past decisions: solo-mode state location and orphan-temp cleanup).
+
+- **Isolation is leaky.** The "Do not read CLAUDE.md or search the codebase" instruction in the frame-agent system prompts is *not* fully obeyed. Several generators in the validation produced text containing Tandem-specific identifiers (`CTRL_ROOM`, `Y_MAP_USER_AWARENESS`, the exact temp-file regex from CLAUDE.md gotchas) — implying CLAUDE.md still bleeds into their context somehow. Diversity still emerged across frames in aggregate, so the method works under leaky isolation, but don't claim more than that. If you see a generator output that's suspiciously specific to Tandem, it's likely leaked rather than independently reasoned.
+- **Speedrunner is the lowest-yield frame.** In both validation runs, the speedrunner generator produced outputs that were either the shipped answer verbatim (with leaked identifiers) or speedrunner-flavored variants of it. If a future curation pass trims the frame library, this is the first to drop. Deletionist and biology consistently produced the most genuinely-distinct shapes; regulator consistently surfaced auditability concerns no other frame named.


### PR DESCRIPTION
## Summary

Adds two annotations to `.claude/commands/diverge.md` captured during the first-use validation of the `/diverge` pilot, run against two known-answer past Tandem decisions: solo-mode state location and orphan-temp cleanup.

(Re-opens the change from closed PR #933, which was off a stale branch with a dirty merge state. This branch is off latest master with the same +7 LOC.)

**Findings the notes capture:**

1. **Leaky isolation.** The "do not read CLAUDE.md or search the codebase" instruction in frame-agent system prompts is not fully obeyed. Several generators in the validation produced text containing Tandem-specific identifiers — `CTRL_ROOM`, `Y_MAP_USER_AWARENESS`, and the exact temp-file regex `^\.tandem-tmp-(\d+)-([0-9a-f]{12})$` verbatim from CLAUDE.md's gotchas section. Diversity still emerged across frames in aggregate, so the method works under leaky isolation — but documenting the limit prevents future invocations from over-claiming.

2. **Speedrunner is the lowest-yield frame.** In both validation runs, speedrunner generators produced outputs that were either the shipped answer verbatim (with leaked identifiers) or speedrunner-flavored variants of it. Deletionist and biology consistently produced the most genuinely-distinct shapes; regulator consistently surfaced auditability concerns no other frame named. If the frame library is ever curated, speedrunner is the first to drop.

## Validation outcome

Pilot **passes** the kill-gate criterion (not lexical-only divergence). Both problems produced 6+ structurally distinct clusters; both critics' top-3 survivors came from different clusters. The critic step caught real bugs the generators missed — including four RED-flagged proposals that would have shipped with cross-filesystem `rename(2)` EXDEV bugs, and one that would have deleted user files.

Full validation report kept in the session transcript; no separate lessons-learned entry yet, per the original plan (wait for a real, non-validation invocation).

## Test plan

- [ ] Confirm the appended "Known limitations and curation notes" section renders correctly in the slash-command help surface.
- [ ] No functional change — diff is documentation-only.

https://claude.ai/code/session_01BYV4BdMiPHXzWQvkvpZVj8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYV4BdMiPHXzWQvkvpZVj8)_