### PR TITLE
refactor(margin): read layer rect per coordsAtPos iteration (#918)

### DIFF
--- a/src/client/hooks/useMarginPositions.svelte.ts
+++ b/src/client/hooks/useMarginPositions.svelte.ts
@@ -39,12 +39,20 @@ export interface ComputeResult {
  *   `display: none` ancestor) is skipped — it would render as `top: NaNpx`
  *   and defeat the `mapsEqual` tolerance check (NaN-vs-anything is always
  *   "unequal", causing per-frame re-render storms).
+ *
+ * `getLayerTop` is read per iteration (not once before the loop) so the layer
+ * rect and each annotation's `coordsAtPos` read always observe the same layout.
+ * Today this is defensive, not load-bearing: the loop is synchronous (JS
+ * run-to-completion) and `coordsAtPos` is a pure read, so nothing invalidates
+ * layout mid-loop and a read-once `layerTop` would be identical. The per-call
+ * read future-proofs the invariant against a DOM write ever being introduced
+ * into the loop body, and makes the read-consistency contract explicit.
  */
 export function _computeNextPositionsForTesting(
   annotations: readonly Annotation[],
   resolveRange: (ann: Annotation) => { from: number; to: number } | null,
   coordsAtPos: (pos: number) => { top: number },
-  layerTop: number,
+  getLayerTop: () => number,
 ): ComputeResult {
   const positions = new Map<string, number>();
   let attempted = 0;
@@ -56,7 +64,7 @@ export function _computeNextPositionsForTesting(
     try {
       const coords = coordsAtPos(range.from);
       if (!Number.isFinite(coords.top)) continue;
-      positions.set(ann.id, coords.top - layerTop);
+      positions.set(ann.id, coords.top - getLayerTop());
     } catch {
       thrown++;
     }
@@ -128,13 +136,12 @@ export function createMarginPositions(opts: CreateMarginPositionsOpts): MarginPo
       return;
     }
 
-    const layerTop = layer.getBoundingClientRect().top;
     const annotations = opts.getAnnotations();
     const { positions, attempted, thrown } = _computeNextPositionsForTesting(
       annotations,
       (ann) => annotationToPmRange(ann, editor.state.doc, ydoc),
       (pos) => editor.view.coordsAtPos(pos),
-      layerTop,
+      () => layer.getBoundingClientRect().top,
     );
 
     if (attempted > 0 && thrown === attempted) {

--- a/src/client/hooks/useMarginPositions.svelte.ts
+++ b/src/client/hooks/useMarginPositions.svelte.ts
@@ -43,10 +43,12 @@ export interface ComputeResult {
  * `getLayerTop` is read per iteration (not once before the loop) so the layer
  * rect and each annotation's `coordsAtPos` read always observe the same layout.
  * Today this is defensive, not load-bearing: the loop is synchronous (JS
- * run-to-completion) and `coordsAtPos` is a pure read, so nothing invalidates
- * layout mid-loop and a read-once `layerTop` would be identical. The per-call
- * read future-proofs the invariant against a DOM write ever being introduced
- * into the loop body, and makes the read-consistency contract explicit.
+ * run-to-completion) and `coordsAtPos` is a read-only call (it may force a
+ * layout reflow, but writes nothing), so nothing invalidates layout mid-loop
+ * and a read-once `layerTop` would be identical. The per-call read future-proofs
+ * the invariant against a DOM write ever being introduced *between* iterations
+ * (it does not guard a write placed before `coordsAtPos` within one iteration),
+ * and makes the read-consistency contract explicit.
  */
 export function _computeNextPositionsForTesting(
   annotations: readonly Annotation[],

--- a/tests/client/useMarginPositions.test.ts
+++ b/tests/client/useMarginPositions.test.ts
@@ -80,7 +80,7 @@ describe("useMarginPositions / computeNextPositions", () => {
       [],
       () => ({ from: 0, to: 0 }),
       () => ({ top: 0 }),
-      0,
+      () => 0,
     );
     expect(r.positions.size).toBe(0);
     expect(r.attempted).toBe(0);
@@ -92,7 +92,7 @@ describe("useMarginPositions / computeNextPositions", () => {
       [ann("a"), ann("b"), ann("c")],
       () => null,
       () => ({ top: 0 }),
-      0,
+      () => 0,
     );
     expect(r.positions.size).toBe(0);
     expect(r.attempted).toBe(0);
@@ -104,10 +104,31 @@ describe("useMarginPositions / computeNextPositions", () => {
       [ann("a")],
       () => ({ from: 5, to: 10 }),
       () => ({ top: 150 }),
-      50,
+      () => 50,
     );
     expect(r.positions.get("a")).toBe(100);
     expect(r.attempted).toBe(1);
+    expect(r.thrown).toBe(0);
+  });
+
+  it("reads getLayerTop per iteration, not once before the loop (read-consistency contract)", () => {
+    // The layer rect and each annotation's coordsAtPos read must observe the
+    // same layout. We model a layer whose top differs per call (50, 80, 110)
+    // against a constant coords.top of 150. Per-iteration reading yields
+    // 150-50, 150-80, 150-110 → 100/70/40. A read-once impl would capture 50
+    // for all three and return 100/100/100, so this fails if the fix regresses.
+    let call = 0;
+    const layerTops = [50, 80, 110];
+    const r = computeNextPositions(
+      [ann("a"), ann("b"), ann("c")],
+      () => ({ from: 0, to: 0 }),
+      () => ({ top: 150 }),
+      () => layerTops[call++],
+    );
+    expect(r.positions.get("a")).toBe(100);
+    expect(r.positions.get("b")).toBe(70);
+    expect(r.positions.get("c")).toBe(40);
+    expect(r.attempted).toBe(3);
     expect(r.thrown).toBe(0);
   });
 
@@ -116,7 +137,7 @@ describe("useMarginPositions / computeNextPositions", () => {
       [ann("a")],
       () => ({ from: 0, to: 0 }),
       () => ({ top: Number.NaN }),
-      0,
+      () => 0,
     );
     expect(r.positions.has("a")).toBe(false);
     expect(r.attempted).toBe(1);
@@ -128,7 +149,7 @@ describe("useMarginPositions / computeNextPositions", () => {
       [ann("a")],
       () => ({ from: 0, to: 0 }),
       () => ({ top: Number.POSITIVE_INFINITY }),
-      0,
+      () => 0,
     );
     expect(r.positions.has("a")).toBe(false);
     expect(r.attempted).toBe(1);
@@ -145,7 +166,7 @@ describe("useMarginPositions / computeNextPositions", () => {
         }
         return { top: 0 };
       },
-      0,
+      () => 0,
     );
     // All three pass — sanity baseline for the next case.
     expect(r.positions.size).toBe(3);
@@ -160,7 +181,7 @@ describe("useMarginPositions / computeNextPositions", () => {
         if (call === 2) throw new Error("stale position");
         return { top: 100 };
       },
-      0,
+      () => 0,
     );
     expect(r2.positions.has("a")).toBe(true);
     expect(r2.positions.has("b")).toBe(false);
@@ -176,7 +197,7 @@ describe("useMarginPositions / computeNextPositions", () => {
       () => {
         throw new Error("view detached");
       },
-      0,
+      () => 0,
     );
     expect(r.positions.size).toBe(0);
     expect(r.attempted).toBe(3);
@@ -193,7 +214,7 @@ describe("useMarginPositions / computeNextPositions", () => {
         if (call % 2 === 0) throw new Error("stale");
         return { top: 100 };
       },
-      0,
+      () => 0,
     );
     expect(r.attempted).toBe(3);
     expect(r.thrown).toBe(1);

--- a/tests/client/useMarginPositions.test.ts
+++ b/tests/client/useMarginPositions.test.ts
@@ -115,8 +115,10 @@ describe("useMarginPositions / computeNextPositions", () => {
     // The layer rect and each annotation's coordsAtPos read must observe the
     // same layout. We model a layer whose top differs per call (50, 80, 110)
     // against a constant coords.top of 150. Per-iteration reading yields
-    // 150-50, 150-80, 150-110 → 100/70/40. A read-once impl would capture 50
-    // for all three and return 100/100/100, so this fails if the fix regresses.
+    // 150-50, 150-80, 150-110 → 100/70/40. The regression this guards is a
+    // refactor that hoists getLayerTop() above the loop: it would increment
+    // `call` once (capturing 50) and return 100/100/100, failing b and c.
+    // (All inputs succeed here, so getLayerTop is called once per annotation.)
     let call = 0;
     const layerTops = [50, 80, 110];
     const r = computeNextPositions(
@@ -130,6 +132,34 @@ describe("useMarginPositions / computeNextPositions", () => {
     expect(r.positions.get("c")).toBe(40);
     expect(r.attempted).toBe(3);
     expect(r.thrown).toBe(0);
+    expect(call).toBe(3); // one read per placed annotation, in order
+  });
+
+  it("calls getLayerTop once per placed annotation, skipping throws (per-iteration × throw)", () => {
+    // getLayerTop() sits on the success path (RHS of positions.set), so a
+    // thrown coordsAtPos must NOT consume a layerTops entry. Here `b` throws:
+    // `a` pairs with layerTops[0]=50 → 100, and `c` pairs with the NEXT entry
+    // layerTops[1]=80 → 70 (not [2]). If a refactor read layer tops eagerly or
+    // off a shared counter that advanced on the throw, `c` would mispair.
+    let layerCall = 0;
+    const layerTops = [50, 80];
+    let coordsCall = 0;
+    const r = computeNextPositions(
+      [ann("a"), ann("b"), ann("c")],
+      () => ({ from: 0, to: 0 }),
+      () => {
+        coordsCall++;
+        if (coordsCall === 2) throw new Error("stale position");
+        return { top: 150 };
+      },
+      () => layerTops[layerCall++],
+    );
+    expect(r.positions.get("a")).toBe(100); // 150 - 50
+    expect(r.positions.has("b")).toBe(false); // threw
+    expect(r.positions.get("c")).toBe(70); // 150 - 80, the second (not third) read
+    expect(r.attempted).toBe(3);
+    expect(r.thrown).toBe(1);
+    expect(layerCall).toBe(2); // only the two placed annotations consumed a read
   });
 
   it("skips annotations where coords.top is NaN (would defeat mapsEqual tolerance)", () => {


### PR DESCRIPTION
## What

`useMarginPositions` read the positioning layer's `top` **once** before the per-annotation loop and reused that frozen value for every bubble. This threads the read as a `getLayerTop: () => number` callback invoked **per iteration**, so the layer rect and each annotation's `coordsAtPos` read always observe the same layout.

## Why (honest framing — not a live-bug fix)

Issue #918 framed this as active "Y drift on a busy frame." A plan review (CRDT reviewer + advisor, verified against `prosemirror-view` source) established that the cited mechanism **cannot actually fire today**: the loop is synchronous (JS run-to-completion) and `view.coordsAtPos` is a pure read with no DOM write, so layout cannot invalidate between iterations — a read-once `layerTop` is identical to a per-iteration read in production.

So this is a **defensive read-consistency** change, not a bug fix:
- Makes the "both reads see the same layout" invariant explicit.
- Future-proofs against a DOM write ever being introduced into the loop body.
- Regression-locks the contract with a test.

It is deliberately **not** described as fixing observed drift, because none reproduces.

## Changes
- `src/client/hooks/useMarginPositions.svelte.ts` — pure helper's 4th param `layerTop: number` → `getLayerTop: () => number`, called per iteration; live caller passes `() => layer.getBoundingClientRect().top` (derived from the existing `getLayerEl()` — `App.svelte` untouched). JSDoc updated.
- `tests/client/useMarginPositions.test.ts` — updated existing call sites to getters; added a per-iteration-read **contract** test (distinct `getLayerTop` returns vs constant `coordsAtPos` top → 100/70/40; a read-once impl would yield 100/100/100).

## Verification
- `npm run typecheck` — clean (0 errors/warnings).
- `npx vitest run useMarginPositions` — 21/21 pass.
- Full pre-push gate green: `biome check` + full `npm test` + `cargo test`.
- Playwright E2E intentionally skipped (its `freePort()` kills :3478/:3479). Manual margin-rendering check deferred to review — but note this change is behavior-preserving in production by construction.

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)