### PR TITLE
ci(#428): re-enable macOS notarization + verification gate + runbook

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -211,15 +211,20 @@ jobs:
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_SIGNING_IDENTITY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # Apple notarization intentionally DISABLED for v0.12.0 — Apple's notary
-          # service has been hanging multi-hour during this release (5+ separate
-          # notarytool submissions stalled with no response across several builds).
-          # macOS ships signed-but-not-notarized; first launch triggers Gatekeeper
-          # warning which user can bypass via right-click → Open. Re-enable by
-          # un-commenting these three lines once Apple's notary recovers:
-          # APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER_ID }}
-          # APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
-          # APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
+          # Apple notarization (issue #428). Re-enabled after the v0.12.0-era
+          # notary-service outage that originally forced these three lines to be
+          # commented out. When the notary trio is unset they expand to empty
+          # strings and tauri-action skips notarization (and skips signing too
+          # when APPLE_CERTIFICATE is also empty) — the same graceful no-op the
+          # build had while disabled. Populate the App Store Connect API key
+          # secrets (APPLE_API_ISSUER_ID, APPLE_API_KEY_ID, APPLE_API_KEY_BASE64)
+          # plus APPLE_CERTIFICATE / APPLE_CERTIFICATE_PASSWORD / APPLE_TEAM_ID
+          # and the APPLE_SIGNING_IDENTITY variable to activate. The "Verify
+          # macOS signature + notarization" step below then asserts the produced
+          # .app is signed and has a stapled notarization ticket.
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
         with:
           tagName: v__VERSION__
           releaseName: "Tandem v__VERSION__"
@@ -233,6 +238,62 @@ jobs:
         if: always() && matrix.platform == 'macos-latest'
         shell: bash
         run: rm -f "$RUNNER_TEMP/private_keys/"*.p8 || true
+
+      # Mirror of "Verify Windows signatures" for macOS: tauri-action does not
+      # reliably fail the job when notarization is skipped or fails, so assert
+      # the produced .app is both code-signed and carries a STAPLED notarization
+      # ticket. The stapled ticket is the load-bearing fix for the Gatekeeper
+      # "damaged"/"unidentified developer" first-launch error (#428) — and
+      # `xcrun stapler validate` checks it fully offline, with none of the
+      # network/policy flakiness `spctl --assess` exhibits on CI runners.
+      #
+      # When APPLE_CERTIFICATE is unset (pre-cert state) the build ships
+      # unsigned BY DESIGN, so skip the gate with a ::notice:: to keep current
+      # releases green; the check auto-enforces the moment signing secrets land.
+      - name: Verify macOS signature + notarization
+        if: always() && matrix.platform == 'macos-latest'
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+        run: |
+          if [ -z "$APPLE_CERTIFICATE" ]; then
+            echo "::notice::APPLE_CERTIFICATE unset — macOS bundle ships unsigned/un-notarized by design (see #428). Skipping verification until signing secrets are populated."
+            exit 0
+          fi
+          shopt -s nullglob
+          apps=(src-tauri/target/*/release/bundle/macos/*.app src-tauri/target/release/bundle/macos/*.app)
+          if [ ${#apps[@]} -eq 0 ]; then
+            echo "::error::Verify macOS: no .app bundle found under src-tauri/target/**/release/bundle/macos/"
+            exit 1
+          fi
+          errors=0
+          for app in "${apps[@]}"; do
+            echo "--- verifying $app"
+            # --deep --strict also validates the nested node-sidecar binary.
+            if ! codesign --verify --deep --strict --verbose=2 "$app"; then
+              echo "::error::$app: codesign --verify failed"
+              errors=1
+              continue
+            fi
+            if ! xcrun stapler validate "$app"; then
+              echo "::error::$app: notarization ticket not stapled — tauri-action notarization was skipped or failed"
+              errors=1
+              continue
+            fi
+            echo "ok: $app code-signed + notarization-stapled"
+          done
+          # .dmg stapling is best-effort (tauri does not always staple the disk
+          # image itself); warn but do not fail — the stapled .app inside is the
+          # artifact Gatekeeper evaluates on first launch.
+          for dmg in src-tauri/target/*/release/bundle/dmg/*.dmg src-tauri/target/release/bundle/dmg/*.dmg; do
+            [ -e "$dmg" ] || continue
+            if xcrun stapler validate "$dmg" >/dev/null 2>&1; then
+              echo "ok: $dmg stapled"
+            else
+              echo "::warning::$dmg: not stapled (acceptable — the embedded .app is stapled)"
+            fi
+          done
+          if [ "$errors" -ne 0 ]; then exit 1; fi
 
       # tauri-action (observed 2026-05, no upstream issue found) does not
       # always surface signCommand non-zero exits as job failure. Verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **macOS notarization re-enabled in the release pipeline (#428)** — the App Store Connect API key trio (`APPLE_API_ISSUER` / `APPLE_API_KEY` / `APPLE_API_KEY_PATH`) was commented out during the v0.12.0-era Apple notary-service outage; it is now re-enabled in `tauri-release.yml`. The path stays a graceful no-op while the signing secrets are unset (build ships unsigned exactly as before), and activates the moment `APPLE_CERTIFICATE` and the API-key secrets are populated. A new **"Verify macOS signature + notarization"** CI gate mirrors the existing Windows signature check: it fails the release job if a produced `.app` is unsigned or missing a stapled notarization ticket (via `codesign --verify --deep --strict` + `xcrun stapler validate`, an offline deterministic check), and skips with a `::notice::` while unsigned-by-design. Added `docs/428-macos-notarization-runbook.md` covering enrollment confirmation, Developer ID cert + `.p8` API-key generation, the exact GitHub Secrets/Variables to populate, the notary-health check, and the throwaway-RC-tag smoke test. No application code changed.
+
 ## [0.13.5] - 2026-05-29
 
 ### Added

--- a/docs/428-macos-notarization-runbook.md
+++ b/docs/428-macos-notarization-runbook.md
@@ -1,0 +1,228 @@
+# macOS Code-Signing & Notarization Runbook (#428)
+
+**Goal:** ship a Tandem macOS build that launches cleanly on a fresh Mac with
+**no Gatekeeper warning** — no "Tandem is damaged and can't be opened", no
+"unidentified developer", no right-click → Open workaround.
+
+This requires three things to be true at once:
+
+1. An **active Apple Developer Program** membership (the calendar gate).
+2. The signing/notarization **secrets populated** in the GitHub repo.
+3. Apple's **notary service healthy** at build time.
+
+The release workflow (`.github/workflows/tauri-release.yml`) is already wired
+for all of this. The notary trio was re-enabled on the
+`claude/highest-impact-prioritization-vksRg` branch; until the secrets are
+populated the build ships unsigned **by design** and the verification gate
+no-ops with a `::notice::`. The moment the secrets land, signing + notarization
++ stapling activate and the gate enforces them.
+
+---
+
+## 0. Confirm enrollment cleared (you, not CI)
+
+This is the one thing that cannot be checked from the repo. Verify on Apple's side:
+
+- Go to <https://developer.apple.com/account> → **Membership details**.
+- Confirm **Account status / Membership** shows **active** (not "Pending",
+  "Enrollment in progress", or expired).
+- Note your **Team ID** — the 10-character alphanumeric string (e.g.
+  `A1B2C3D4E5`). You'll need it for `APPLE_TEAM_ID`.
+
+If it still says pending, nothing below will work yet — Apple's identity
+verification can lag a few business days after payment.
+
+---
+
+## 1. Generate the Developer ID Application certificate
+
+This is the cert that signs the `.app`. It is **not** the same as a Mac App
+Store cert — for direct distribution (DMG download) you need **Developer ID
+Application**.
+
+On a Mac with Xcode / the signing identity:
+
+1. Keychain Access → Certificate Assistant → **Request a Certificate from a
+   Certificate Authority** (save the `.certSigningRequest` to disk), **or** use
+   the Apple Developer portal's "Create a New Certificate" flow.
+2. Apple Developer portal → **Certificates** → **+** → **Developer ID
+   Application** → upload the CSR → download the `.cer`.
+3. Double-click the `.cer` to install it into the login keychain (it pairs with
+   the private key the CSR created).
+4. In Keychain Access, find **"Developer ID Application: <Your Name> (TEAMID)"**,
+   right-click → **Export** → save as a `.p12` and set a strong password. That
+   password becomes `APPLE_CERTIFICATE_PASSWORD`.
+5. Base64-encode the `.p12` for GitHub Secrets:
+   ```bash
+   base64 -i Certificates.p12 | pbcopy   # macOS — copies to clipboard
+   ```
+   That value becomes `APPLE_CERTIFICATE`.
+6. The full identity string ("Developer ID Application: Your Name (TEAMID)") is
+   `APPLE_SIGNING_IDENTITY`. You can list it with:
+   ```bash
+   security find-identity -v -p codesigning
+   ```
+
+---
+
+## 2. Create an App Store Connect API key (for notarization)
+
+The workflow notarizes via the App Store Connect API key (not Apple-ID +
+app-specific-password), which is the modern, non-interactive path `notarytool`
+and `tauri-action` prefer.
+
+1. Go to <https://appstoreconnect.apple.com/access/integrations/api> → **Keys**.
+   (App Store Connect → Users and Access → **Integrations** → **App Store
+   Connect API**.)
+2. Generate a key with the **Developer** role (sufficient for notarization).
+3. Record:
+   - **Key ID** → `APPLE_API_KEY_ID`
+   - **Issuer ID** (shown at the top of the Keys page) → `APPLE_API_ISSUER_ID`
+4. Download the `.p8` private key. **You can only download it once.** Then
+   base64-encode it:
+   ```bash
+   base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
+   ```
+   That value becomes `APPLE_API_KEY_BASE64`.
+
+> The workflow's "Decode App Store Connect API key" step writes the `.p8` back
+> to `$RUNNER_TEMP/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8` and exports
+> `APPLE_API_KEY_PATH`, then wipes it after the build. The filename must match
+> `APPLE_API_KEY_ID`, which is why both are needed.
+
+---
+
+## 3. Populate GitHub Secrets and Variables
+
+Repo → **Settings** → **Secrets and variables** → **Actions**.
+
+**Secrets** (encrypted, never printed):
+
+| Name | Value |
+|------|-------|
+| `APPLE_CERTIFICATE` | base64 of the `.p12` (step 1.5) |
+| `APPLE_CERTIFICATE_PASSWORD` | the `.p12` export password (step 1.4) |
+| `APPLE_TEAM_ID` | 10-char Team ID (step 0) |
+| `APPLE_API_ISSUER_ID` | App Store Connect issuer ID (step 2.3) |
+| `APPLE_API_KEY_ID` | API key ID (step 2.3) |
+| `APPLE_API_KEY_BASE64` | base64 of the `.p8` (step 2.4) |
+
+**Variables** (not sensitive — the identity string is printed in every signed
+binary):
+
+| Name | Value |
+|------|-------|
+| `APPLE_SIGNING_IDENTITY` | `Developer ID Application: Your Name (TEAMID)` |
+
+> Already present and unrelated to Apple: `TAURI_SIGNING_PRIVATE_KEY`,
+> `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (the **updater** Ed25519 key, separate
+> from Apple signing), and the Azure Trusted Signing config for Windows.
+
+---
+
+## 4. Confirm Apple's notary service is healthy
+
+The notary trio was originally disabled because Apple's notary service hung for
+multi-hour stretches during the v0.12.0 release. Before cutting a real release
+tag, confirm it's responsive. On your Mac, with the API key:
+
+```bash
+xcrun notarytool history \
+  --key AuthKey_XXXXXXXXXX.p8 \
+  --key-id   "$APPLE_API_KEY_ID" \
+  --issuer   "$APPLE_API_ISSUER_ID"
+```
+
+A prompt response (even an empty history) means the service is up. A multi-minute
+hang means it's degraded — hold the release rather than letting CI stall.
+
+System status: <https://developer.apple.com/system-status/> (watch the
+"Developer ID Notary Service" row).
+
+---
+
+## 5. Smoke-test with a throwaway release-candidate tag
+
+Do **not** debug signing on a real `vX.Y.Z` tag. The workflow triggers on any
+`v*` tag, so use a disposable RC tag:
+
+```bash
+git tag v0.0.0-rc-notarize-1
+git push origin v0.0.0-rc-notarize-1
+```
+
+Then watch the **two macOS matrix jobs** (`aarch64-apple-darwin` and
+`x86_64-apple-darwin`):
+
+- The **"Verify macOS signature + notarization"** step must print
+  `ok: …app code-signed + notarization-stapled` for each `.app`. If
+  `APPLE_CERTIFICATE` is missing it will instead print the skip `::notice::` —
+  which tells you the secret didn't take.
+- `tauri-action` produces a **draft** release (`releaseDraft: true`), so the RC
+  won't go public. Delete the draft release and the RC tag afterward:
+  ```bash
+  git push --delete origin v0.0.0-rc-notarize-1
+  git tag -d v0.0.0-rc-notarize-1
+  # delete the draft release in the GitHub UI (Releases → … → Delete)
+  ```
+
+### Verify on a real Mac (the actual acceptance test)
+
+Download the DMG from the draft release onto a Mac that has **never run a dev
+build** (or clear the quarantine state), and confirm:
+
+```bash
+# Gatekeeper assessment — should say "accepted" / "source=Notarized Developer ID"
+spctl --assess --type open --context context:primary-signature -vvv /Volumes/Tandem*/Tandem.app
+
+# Stapled ticket present (offline check)
+xcrun stapler validate /Volumes/Tandem*/Tandem.app
+```
+
+Best of all: double-click the DMG, drag to Applications, launch from Finder.
+**No warning dialog = #428 satisfied.** This is the gate that matters for the
+v1.0 install matrix (D12, macOS 14 + macOS 26.1 M1).
+
+---
+
+## 6. Re-enable for the real release
+
+Once the RC is green and a real Mac launches the app cleanly, no code change is
+needed — the signing path is permanent. Cut the real `vX.Y.Z` tag and the same
+steps run against it.
+
+---
+
+## What the workflow already does for you
+
+- **`tauri-release.yml` → "Decode App Store Connect API key"** — base64-decodes
+  `APPLE_API_KEY_BASE64` to a `umask 077` file, exports `APPLE_API_KEY_PATH`,
+  no-ops cleanly when the secret is unset.
+- **`tauri-release.yml` → `tauri-apps/tauri-action@v0`** — infers the signing
+  identity from `APPLE_CERTIFICATE`, signs the `.app`, and submits to the notary
+  via the API key trio (`APPLE_API_ISSUER` / `APPLE_API_KEY` /
+  `APPLE_API_KEY_PATH`). All empty → graceful skip.
+- **`tauri-release.yml` → "Wipe App Store Connect API key"** — removes the
+  decoded `.p8` from the runner (`if: always()`).
+- **`tauri-release.yml` → "Verify macOS signature + notarization"** — fails the
+  job if a produced `.app` is unsigned or missing a stapled notarization ticket,
+  *once* `APPLE_CERTIFICATE` is set. Uses `codesign --verify --deep --strict`
+  plus `xcrun stapler validate` (offline, deterministic — no `spctl` CI
+  flakiness). Skips with a `::notice::` while unsigned-by-design.
+- **`release-check` job** — fails if any matrix build (incl. either macOS arch)
+  failed, blocking a half-signed release.
+
+## Gotchas
+
+- **Developer ID Application, not Mac App Store / Apple Development.** The wrong
+  cert type signs fine but Gatekeeper still rejects it for direct distribution.
+- **The `.p8` downloads once.** If you lose it, revoke and reissue the key.
+- **`APPLE_API_KEY_ID` must match the filename.** The decode step builds
+  `AuthKey_${APPLE_API_KEY_ID}.p8`; a mismatch makes `notarytool` fail to find
+  the key.
+- **Stapling needs network at build time** (notarization is an online round
+  trip) but the *stapled result* is verified offline — which is exactly why the
+  app then launches with no network on the user's machine.
+- **Notary latency is unpredictable.** Submissions usually take minutes but can
+  spike. If CI times out mid-notarization, re-run the macOS jobs rather than
+  re-cutting the tag.


### PR DESCRIPTION
## Why

While discussing the single highest-impact lever toward v1.0, we landed on the **macOS notarization / Apple Developer cert gate (#428)** — the one remaining critical-path item with irreducible external latency (Apple enrollment + notary service), gating a third of the D12 "full parity" install matrix. Bryan's enrollment appears to have cleared, so this PR tees up everything on the repo side so the path activates the moment the signing secrets are populated.

## What changed

**`.github/workflows/tauri-release.yml`**
- **Re-enabled the notary trio** (`APPLE_API_ISSUER` / `APPLE_API_KEY` / `APPLE_API_KEY_PATH`) that was commented out during the v0.12.0-era Apple notary-service outage. When the secrets are unset these expand to empty strings and `tauri-action` skips notarization (and signing) — the **same graceful no-op** the build had while disabled. No risk to current releases.
- **New "Verify macOS signature + notarization" step**, mirroring the existing "Verify Windows signatures" gate. Fails the job if a produced `.app` is unsigned or missing a **stapled notarization ticket** — using `codesign --verify --deep --strict` + `xcrun stapler validate` (fully offline/deterministic; deliberately avoids `spctl --assess` network/policy flakiness on CI). Skips with a `::notice::` while `APPLE_CERTIFICATE` is unset, so it stays green today and **auto-enforces the moment signing secrets land**.

**`docs/428-macos-notarization-runbook.md`** (new)
- End-to-end: confirm enrollment, generate the Developer ID Application cert + `.p8` App Store Connect API key, the exact GitHub **Secrets/Variables** to populate, a notary-health check, and a throwaway-`v*-rc`-tag smoke test plus the real-Mac acceptance test.

**`CHANGELOG.md`** — `[Unreleased] → ### Changed` entry.

## What still requires Bryan (can't be done from CI)

1. Confirm `developer.apple.com/account` → Membership shows **active** + note the Team ID.
2. Populate the Actions secrets (`APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_API_ISSUER_ID`, `APPLE_API_KEY_ID`, `APPLE_API_KEY_BASE64`) and the `APPLE_SIGNING_IDENTITY` variable — see the runbook §1–3.
3. Cut a disposable RC tag to smoke-test the macOS jobs, then verify on a real Mac.

## Verification
- `tauri-release.yml` passes `yaml.safe_load`; the new shell step passes `bash -n`.
- No application code touched — workflow + docs only.

https://claude.ai/code/session_018cyb5wCjVJTHzrjMKtKMBj

---
_Generated by [Claude Code](https://claude.ai/code/session_018cyb5wCjVJTHzrjMKtKMBj)_