### PR TITLE
Add PreToolUse hook gating ExitPlanMode on agent review

### DIFF
--- a/.claude/hooks/block-plan-without-agent-review.mjs
+++ b/.claude/hooks/block-plan-without-agent-review.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// PreToolUse hook body for ExitPlanMode. Invoked by the bash wrapper.
+// Reads the hook stdin envelope, scans the session transcript, and exits:
+//   0  = allow (Agent review verified, or bypass token present in plan body)
+//   2  = block (stderr explains how to unblock)
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import readline from "node:readline";
+
+const BYPASS_TOKEN = "Agent feedback incorporated";
+const PLANS_DIR = path.join(os.homedir(), ".claude", "plans");
+const TRANSCRIPT_BYTE_CAP = 50 * 1024 * 1024;
+const REVIEWER_TOOL_NAMES = new Set(["Agent", "Task"]);
+
+function block(reason) {
+  process.stderr.write(`Blocked (fail-closed): ${reason}.\n`);
+  process.exit(2);
+}
+
+async function readEnvelope() {
+  let raw = "";
+  for await (const chunk of process.stdin) raw += chunk;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    block("could not parse hook stdin JSON");
+  }
+}
+
+function isUserPlanPath(fp) {
+  if (typeof fp !== "string" || !fp) return false;
+  if (!/[\\/]\.claude[\\/]plans[\\/][^\\/]+\.md$/.test(fp)) return false;
+  let resolved;
+  try {
+    resolved = fs.realpathSync(fp);
+  } catch {
+    resolved = path.resolve(fp);
+  }
+  const rel = path.relative(PLANS_DIR, resolved);
+  return rel && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+async function scanTranscript(transcriptPath) {
+  let stat;
+  try {
+    stat = fs.statSync(transcriptPath);
+  } catch (e) {
+    block(`could not stat transcript: ${e.message}`);
+  }
+  if (stat.size > TRANSCRIPT_BYTE_CAP) {
+    block(`transcript exceeds ${TRANSCRIPT_BYTE_CAP}-byte cap (${stat.size})`);
+  }
+
+  let planPath = null;
+  let agentAfterPlanWrite = false;
+
+  const rl = readline.createInterface({
+    input: fs.createReadStream(transcriptPath, { encoding: "utf8" }),
+    crlfDelay: Infinity,
+  });
+  for await (const line of rl) {
+    if (!line) continue;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const content = msg?.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const item of content) {
+      if (item?.type !== "tool_use") continue;
+      const name = item.name;
+      if (name === "Write" || name === "Edit") {
+        if (isUserPlanPath(item.input?.file_path)) {
+          planPath = item.input.file_path;
+          agentAfterPlanWrite = false;
+        }
+      } else if (REVIEWER_TOOL_NAMES.has(name) && planPath) {
+        agentAfterPlanWrite = true;
+      }
+    }
+  }
+  return { planPath, agentAfterPlanWrite };
+}
+
+const envelope = await readEnvelope();
+const transcriptPath = envelope.transcript_path;
+if (!transcriptPath) block("hook stdin missing transcript_path");
+
+const { planPath, agentAfterPlanWrite } = await scanTranscript(transcriptPath);
+if (!planPath) block("no plan-file Write/Edit under ~/.claude/plans/ in session transcript");
+if (agentAfterPlanWrite) process.exit(0);
+
+try {
+  const resolved = fs.realpathSync(planPath);
+  const rel = path.relative(PLANS_DIR, resolved);
+  if (rel && !rel.startsWith("..") && !path.isAbsolute(rel)) {
+    const head = fs.readFileSync(resolved, "utf8").slice(0, 4096);
+    if (head.replace(/^\s+/, "").startsWith(BYPASS_TOKEN)) process.exit(0);
+  }
+} catch {
+  /* fall through to block */
+}
+
+const planBasename = path.basename(planPath);
+process.stderr.write(
+  `Blocked: ExitPlanMode requires Agent review of the current plan revision.\n` +
+    `\n` +
+    `Plan file: ~/.claude/plans/${planBasename}\n` +
+    `\n` +
+    `Unblock via EITHER:\n` +
+    `  A. Spawn at least one Agent call (e.g. svelte-migration-reviewer,\n` +
+    `     crdt-reviewer, annotation-model-reviewer, security-reviewer, or a\n` +
+    `     general-purpose adversarial reviewer) AFTER the most recent edit to\n` +
+    `     the plan file, then re-call ExitPlanMode. The hook detects the\n` +
+    `     Agent tool_use in the session transcript.\n` +
+    `\n` +
+    `  B. Edit the plan file so its body begins with the exact literal prefix:\n` +
+    `        ${BYPASS_TOKEN}\n` +
+    `     Use this only when review actually happened out-of-band; the user\n` +
+    `     will see this attestation when they review the plan.\n`
+);
+process.exit(2);

--- a/.claude/hooks/block-plan-without-agent-review.mjs
+++ b/.claude/hooks/block-plan-without-agent-review.mjs
@@ -9,8 +9,12 @@ import path from "node:path";
 import readline from "node:readline";
 
 const BYPASS_TOKEN = "Agent feedback incorporated";
-const PLANS_DIR = path.join(os.homedir(), ".claude", "plans");
+const PLANS_DIR = (() => {
+  const raw = path.join(os.homedir(), ".claude", "plans");
+  try { return fs.realpathSync(raw); } catch { return raw; }
+})();
 const TRANSCRIPT_BYTE_CAP = 50 * 1024 * 1024;
+const PLAN_HEAD_BYTE_CAP = 4096;
 const REVIEWER_TOOL_NAMES = new Set(["Agent", "Task"]);
 
 function block(reason) {
@@ -97,7 +101,15 @@ try {
   const resolved = fs.realpathSync(planPath);
   const rel = path.relative(PLANS_DIR, resolved);
   if (rel && !rel.startsWith("..") && !path.isAbsolute(rel)) {
-    const head = fs.readFileSync(resolved, "utf8").slice(0, 4096);
+    const fd = fs.openSync(resolved, "r");
+    let head;
+    try {
+      const buf = Buffer.alloc(PLAN_HEAD_BYTE_CAP);
+      const n = fs.readSync(fd, buf, 0, PLAN_HEAD_BYTE_CAP, 0);
+      head = buf.subarray(0, n).toString("utf8");
+    } finally {
+      fs.closeSync(fd);
+    }
     if (head.replace(/^\s+/, "").startsWith(BYPASS_TOKEN)) process.exit(0);
   }
 } catch {

--- a/.claude/hooks/block-plan-without-agent-review.sh
+++ b/.claude/hooks/block-plan-without-agent-review.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Thin wrapper. Real logic lives in the .mjs alongside.
+set -uo pipefail
+exec node "$(dirname "$0")/block-plan-without-agent-review.mjs"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,6 +49,15 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/nudge-simplify-before-commit.sh\""
           }
         ]
+      },
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-plan-without-agent-review.sh\""
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,9 @@ Wired in `.claude/settings.json`. PreToolUse hooks exit 2 to block; PostToolUse 
 - `block-no-verify.sh` -- Blocks `--no-verify` flag (Husky bypass); fail-closed on parse error
 - `nudge-simplify-before-commit.sh` -- Warns on `git commit` when source edits have happened since last `/simplify` (one-shot per edit batch)
 
+**PreToolUse — `ExitPlanMode` matcher:**
+- `block-plan-without-agent-review.sh` (+ `.mjs` body) -- Blocks plan-approval requests unless the session transcript shows an `Agent`/`Task` tool call after the most recent `Write`/`Edit` to a plan file under user-level `~/.claude/plans/` (project-level `<repo>/.claude/plans/` is intentionally excluded). Bypass: prepend `Agent feedback incorporated` to the plan body. Fail-closed on missing/oversize (>50 MB) transcripts and on plan paths that don't `realpath` under `~/.claude/plans/`.
+
 **PostToolUse — unmatched (every tool):**
 - `track-workflow-events.sh` -- Records markers used by nudge hooks: `last-plan-write`, `last-source-edit`, `last-agent-call`, `last-simplify`, and `last-commit` (detected from successful `git commit` invocations in `Bash` tool calls). Also clears the `stop-nudged` marker on successful commit so the stop reminder can re-fire after the next edit cycle. Fast-paths uninteresting tools to skip the node spawn.
 


### PR DESCRIPTION
## Summary

Adds a Claude Code PreToolUse hook on `ExitPlanMode` that blocks plan-approval requests unless agents have reviewed the plan. Two unblock paths:

- **A. Mechanical proof:** the session transcript at `transcript_path` shows an `Agent` (or `Task`) tool call after the most recent `Write`/`Edit` to a plan file under user-level `~/.claude/plans/`.
- **B. Manual override:** the plan body begins with the literal token `Agent feedback incorporated` (leading whitespace tolerated). User-visible attestation.

## Design notes

- **Path scope is user-level only.** Project-level `<repo>/.claude/plans/` is excluded so unrelated scratch writes don't reset the gate.
- **Symlink-safe.** Plan paths are validated via `fs.realpathSync` and must resolve under `~/.claude/plans/` before being read for the bypass-token check.
- **Bounded resource use.** Transcript scanned via `readline` streaming; fail-closed at a 50 MB cap.
- **Two-file split.** Real logic lives in `block-plan-without-agent-review.mjs`; bash wrapper is two lines. Keeps Node regexes out of bash quoting.
- **Tool-name resilience.** Accepts both `Agent` and `Task` as the reviewer-tool name.

See `/root/.claude/plans/create-a-hook-that-federated-llama.md` for the full design context, adversarial-review findings folded in, and the "acknowledged residual gaps" section.

## Test plan

- [x] Synthetic-transcript suite (9 cases) all pass: no-Agent → block, Agent → allow, Task synonym → allow, re-write after Agent → block, bypass token → allow, project-level path → reject, symlink escape → reject, missing transcript_path → fail-closed, oversize transcript → fail-closed.
- [ ] End-to-end in a real Claude Code session: enter plan mode → ExitPlanMode without review → confirm block; spawn reviewer Agent → confirm allow; edit plan → confirm re-blocks; prepend bypass token → confirm allow.

https://claude.ai/code/session_01QCuZk51RzGYNxDjfuhJahM


---
_Generated by [Claude Code](https://claude.ai/code/session_01QCuZk51RzGYNxDjfuhJahM)_