### PR TITLE
test(integrations): isolate channel-shim apply test from ambient dist state

### DIFF
--- a/src/server/integrations/api-routes.ts
+++ b/src/server/integrations/api-routes.ts
@@ -106,6 +106,14 @@ export interface IntegrationsRoutesDeps {
    * doesn't require the test process to own a real Claude install.
    */
   detectTargets?: typeof detectTargets;
+  /**
+   * Optional channel-shim decision override. Production leaves this undefined
+   * and calls the real `shouldRegisterChannelShim()`, which probes the disk
+   * (`existsSync(dist/channel/index.js)`). Tests inject a deterministic stub so
+   * apply-path assertions don't depend on whether the channel bundle happens to
+   * be built in the working tree.
+   */
+  shouldRegisterChannelShim?: typeof shouldRegisterChannelShim;
 }
 
 /**
@@ -598,7 +606,10 @@ function makeApplyHandler(deps: IntegrationsRoutesDeps): Handler {
         // path) — no broken entry is written. The `create`-wins guard in
         // applyConfig keeps a user-confirmed removal from deleting the entry
         // we just created.
-        const withChannelShim = shouldRegisterChannelShim(entry.kind, CHANNEL_DIST);
+        const withChannelShim = (deps.shouldRegisterChannelShim ?? shouldRegisterChannelShim)(
+          entry.kind,
+          CHANNEL_DIST,
+        );
         const create = buildMcpEntries(CHANNEL_DIST, {
           token,
           targetKind: entry.kind,

--- a/tests/server/integrations/api-routes.test.ts
+++ b/tests/server/integrations/api-routes.test.ts
@@ -690,7 +690,7 @@ describe("integrations API routes", () => {
     });
 
     describe("apply: with stubbed detectTargets (real applyConfig)", () => {
-      it("removes tandem-channel from the target config when listed in removals", async () => {
+      it("removes tandem-channel from the target config when the shim is not being (re)created", async () => {
         const tmpClaudeJson = path.join(tmpDir, ".claude.json");
         fs.writeFileSync(
           tmpClaudeJson,
@@ -715,11 +715,16 @@ describe("integrations API routes", () => {
         });
         // Inject a detector that returns the tmpdir path so applyConfig
         // writes there (and assertPathSafe accepts the tmpdir prefix).
+        // Force shouldRegisterChannelShim to false so this asserts the removal
+        // path deterministically — without the override the result depends on
+        // whether dist/channel/index.js happens to be built (existsSync), and
+        // the create-wins guard would keep the shim (covered by the next test).
         const app = makeApp({
           ...deps,
           detectTargets: () => [
             { label: "Claude Code", configPath: tmpClaudeJson, kind: "claude-code" },
           ],
+          shouldRegisterChannelShim: () => false,
         });
         const nonce = await freshNonce(app);
         const res = await request(
@@ -741,6 +746,59 @@ describe("integrations API routes", () => {
         expect(after.mcpServers.tandem).toBeDefined();
         // The nonce rotated because a write occurred.
         expect(body.nextNonce).not.toBe(nonce);
+      });
+
+      it("create-wins: keeps tandem-channel even when listed in removals if the shim is being registered (#985)", async () => {
+        const tmpClaudeJson = path.join(tmpDir, ".claude.json");
+        fs.writeFileSync(
+          tmpClaudeJson,
+          JSON.stringify({
+            mcpServers: {
+              "tandem-channel": { command: "node", args: ["/path/to/shim.js"] },
+            },
+          }),
+        );
+        await deps.store.write({
+          schemaVersion: INTEGRATIONS_SCHEMA_VERSION,
+          integrations: [
+            {
+              kind: "claude-code",
+              id: "cc-1",
+              label: "Claude Code",
+              configPath: tmpClaudeJson,
+              transport: "http",
+              url: "http://127.0.0.1:3479",
+            },
+          ],
+        });
+        // Force the shim to be registered this run. The create-wins guard in
+        // applyConfig must keep tandem-channel even though it's listed in
+        // removals — a removal can never delete an entry we're also creating.
+        const app = makeApp({
+          ...deps,
+          detectTargets: () => [
+            { label: "Claude Code", configPath: tmpClaudeJson, kind: "claude-code" },
+          ],
+          shouldRegisterChannelShim: () => true,
+        });
+        const nonce = await freshNonce(app);
+        const res = await request(
+          app,
+          "POST",
+          API_INTEGRATIONS_APPLY,
+          {
+            ids: ["cc-1"],
+            confirmationNonce: nonce,
+            removals: { "cc-1": ["tandem-channel"] },
+          },
+          TAURI_ORIGIN,
+        );
+        expect(res.status).toBe(200);
+        const body = res.body as { results: Array<{ status: string }> };
+        expect(body.results[0]?.status).toBe("applied");
+        const after = JSON.parse(fs.readFileSync(tmpClaudeJson, "utf-8"));
+        expect(after.mcpServers["tandem-channel"]).toBeDefined();
+        expect(after.mcpServers.tandem).toBeDefined();
       });
 
       it("nonce rotates after an applied result (not just any 200 response)", async () => {


### PR DESCRIPTION
## Problem

The integration apply route decides whether to register the `tandem-channel` MCP server via `shouldRegisterChannelShim(kind, CHANNEL_DIST)`, where `validateChannelShimPrereq` is just `existsSync(dist/channel/index.js)`. So the test **"removes tandem-channel from the target config when listed in removals"** in `tests/server/integrations/api-routes.test.ts` passed or failed depending on whether the channel bundle happened to be built in the working tree:

- **No `dist/channel/index.js`** → shim not registered → the explicit `removals: ["tandem-channel"]` sticks → test passes.
- **Built `dist/`** → #985's default-on registration + the "create-wins" guard in `applyConfig` keep the shim → removal assertion fails.

I hit this while building the Tauri stubs for `cargo test` during #979 (PR #991) and flagged it there. CI doesn't build `dist/` before unit tests so it's currently green, but it's a latent non-hermetic test that bites anyone who pushes with a built tree.

## Fix

Make the channel-shim decision injectable through `IntegrationsRoutesDeps`, matching the existing `detectTargets` override pattern (production leaves it undefined and calls the real disk-probing helper):

- The removal test now forces `shouldRegisterChannelShim: () => false` (shim not recreated → removal deterministically sticks).
- A new **create-wins** test forces `() => true` and asserts `tandem-channel` is **kept** despite being listed in `removals` — pinning #985's intended behavior that a removal can never delete an entry being created the same run.

## Verification

- `tests/server/integrations/api-routes.test.ts` passes **49/49 both with and without** `dist/channel/index.js` present (verified by creating the file and re-running) — now hermetic.
- `npm run typecheck` ✅; full pre-push hook (biome + npm test + cargo test) ✅.

No production behavior change — the new dep is optional and defaults to the real `shouldRegisterChannelShim`.

https://claude.ai/code/session_01TEjeaBsxvxSnxCsFM4CQ4P

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEjeaBsxvxSnxCsFM4CQ4P)_