### PR TITLE
fix(test): bind OS-assigned ports in platform.test.ts (#1014)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **New-tab morph — clear two-phase motion (A29, follow-up to #977)** — the `+`→menu morph now expands **horizontally into a clean capsule first, then vertically into the card**, instead of co-timing both axes. The radius is held at a literal capsule value (`14px`, half the pill height) through the horizontal unroll and squares to the card radius only as the height grows, so the shape never flashes a flat lozenge; the interior rows cascade in during the vertical phase. Close reverses it. The card fill persists through the whole collapse (a *filled* card shrinks back into the `+`, with no empty-box gap), and the card/pill shadows crossfade so there's no shadow pop at the handoff. On close, focus is **restored to the element that was focused before the menu opened** (typically the editor) rather than parked on the `+`, so no stray focus ring lingers on the pill; the closing body is `inert` so focus is never stranded in the clipped panel, and on close the in-menu search field is **blurred synchronously** so a keyboard shortcut fired in the same tick (e.g. Escape then `Ctrl+W`) is no longer swallowed by the still-focused input. Fully reduced-motion-correct (all timing derives from the shared morph tokens).
 
+### Fixed
+
+- **`tests/server/platform.test.ts` no longer binds hardcoded ports in the Windows reserved range (#1014)** — the three `waitForPort` tests bound fixed ports `49170`/`49171`/`49172`, which fall inside the IANA dynamic/ephemeral range that Windows reserves in chunks (Hyper-V/WSL/Docker). On such hosts those binds throw `EACCES` deterministically, failing the husky pre-push gate and forcing a blanket `HUSKY=0` bypass. The tests now bind an OS-assigned port (`listen(0)`) and use the resolved port, eliminating the reserved-range collision. Test-only; no production impact.
+
 ## [0.13.6] - 2026-06-04
 
 ### Added

--- a/tests/server/platform.test.ts
+++ b/tests/server/platform.test.ts
@@ -82,15 +82,29 @@ LISTEN 0      128    127.0.0.1:3478       0.0.0.0:*     users:(("node",pid=12345
       return new Promise<void>((resolve) => srv.close(() => resolve()));
     });
 
+    // Bind an OS-assigned ephemeral port (listen(0)), capture it, then release it.
+    // Hardcoded high ports (e.g. 49170-49172) collide with the Windows reserved
+    // ephemeral range (Hyper-V/WSL/Docker), throwing EACCES deterministically on
+    // such hosts. Port 0 always picks a guaranteed-bindable port. See #1014.
+    async function findFreePort(): Promise<number> {
+      const probe = net.createServer();
+      await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+      const port = (probe.address() as net.AddressInfo).port;
+      await new Promise<void>((resolve) => probe.close(() => resolve()));
+      return port;
+    }
+
     it("resolves immediately when port is free", async () => {
+      const port = await findFreePort();
       const start = Date.now();
-      await waitForPort(49170);
+      await waitForPort(port);
       expect(Date.now() - start).toBeLessThan(500);
     });
 
     it("resolves when occupied port is released mid-poll", async () => {
       holdServer = net.createServer();
-      await new Promise<void>((resolve) => holdServer!.listen(49171, "127.0.0.1", resolve));
+      await new Promise<void>((resolve) => holdServer!.listen(0, "127.0.0.1", resolve));
+      const port = (holdServer.address() as net.AddressInfo).port;
 
       // Release the port after 300ms
       setTimeout(() => {
@@ -99,7 +113,7 @@ LISTEN 0      128    127.0.0.1:3478       0.0.0.0:*     users:(("node",pid=12345
       }, 300);
 
       const start = Date.now();
-      await waitForPort(49171, 5000);
+      await waitForPort(port, 5000);
       const elapsed = Date.now() - start;
       expect(elapsed).toBeGreaterThanOrEqual(200);
       expect(elapsed).toBeLessThan(3000);
@@ -107,11 +121,12 @@ LISTEN 0      128    127.0.0.1:3478       0.0.0.0:*     users:(("node",pid=12345
 
     it("throws when port stays occupied past timeout", async () => {
       holdServer = net.createServer();
-      await new Promise<void>((resolve) => holdServer!.listen(49172, "127.0.0.1", resolve));
+      await new Promise<void>((resolve) => holdServer!.listen(0, "127.0.0.1", resolve));
+      const port = (holdServer.address() as net.AddressInfo).port;
 
       const start = Date.now();
-      await expect(waitForPort(49172, 500)).rejects.toThrow(
-        "Port 49172 still not available after 500ms",
+      await expect(waitForPort(port, 500)).rejects.toThrow(
+        `Port ${port} still not available after 500ms`,
       );
       expect(Date.now() - start).toBeGreaterThanOrEqual(400);
     });


### PR DESCRIPTION
## Summary

Fixes #1014. The three `waitForPort` tests in `tests/server/platform.test.ts` bound hardcoded ports `49170`/`49171`/`49172`. Those fall inside the IANA dynamic/ephemeral range (49152–65535), chunks of which Windows reserves for Hyper-V/WSL/Docker (`netsh int ipv4 show excludedportrange protocol=tcp`). On such hosts the binds throw `EACCES` deterministically, failing the husky pre-push gate and forcing a blanket `HUSKY=0` bypass that silently disables the *entire* pre-push suite (not just this test).

## Change

Bind an OS-assigned port via `listen(0)`, capture the resolved port from `server.address()`, and use it — for all three cases. Port `0` always picks a guaranteed-bindable port, eliminating the reserved-range collision. Added a small `findFreePort()` helper (bind-then-close) for the "resolves immediately when port is free" case.

Test-only; no production code touched. CI on Linux was already green (the ephemeral range isn't reserved there); this restores parity for Windows dev hosts.

## Verification

- `npx vitest run tests/server/platform.test.ts` → 16/16 pass
- CHANGELOG golden round-trip (`markdown-escaping`/`markdown-fidelity`) → pass

https://claude.ai/code/session_011Dx9Wdk84q9tFbYomuX1d3

---
_Generated by [Claude Code](https://claude.ai/code/session_011Dx9Wdk84q9tFbYomuX1d3)_