### PR TITLE
test(docx): cover resolveWordComments multi-comment path (#1012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`tests/server/platform.test.ts` no longer binds hardcoded ports in the Windows reserved range (#1014)** — the three `waitForPort` tests bound fixed ports `49170`/`49171`/`49172`, which fall inside the IANA dynamic/ephemeral range that Windows reserves in chunks (Hyper-V/WSL/Docker). On such hosts those binds throw `EACCES` deterministically, failing the husky pre-push gate and forcing a blanket `HUSKY=0` bypass. The tests now bind an OS-assigned port (`listen(0)`) and use the resolved port, eliminating the reserved-range collision. Test-only; no production impact.
+- **Closed a test-coverage gap in `resolveWordComments` (#1012)** — the suite exercised the function only with a single `importCommentId` per call. Added two tests covering the multi-comment path: resolving two distinct comments in one call (each mapped to its *own* last-paragraph paraId) and the dedup-by-`commentId` filter (two suggestions sharing one comment, asserting a single `commentEx` entry). Test-only; the production path was already correct.
 
 ## [0.13.6] - 2026-06-04
 

--- a/tests/server/docx-apply.test.ts
+++ b/tests/server/docx-apply.test.ts
@@ -689,6 +689,63 @@ describe("resolveWordComments", () => {
     expect(countCommentEx(extXml)).toBe(2);
   });
 
+  it("resolves multiple distinct comments in one call, each to its own last paraId (#1012)", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "word/comments.xml",
+      commentsXml([
+        { id: "10", paraIds: ["AAAA0001", "AAAA0002"] },
+        { id: "20", paraIds: ["BBBB0001"] },
+      ]),
+    );
+    zip.file("word/document.xml", "<stub/>");
+    zip.file(
+      "[Content_Types].xml",
+      `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/></Types>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>`,
+    );
+
+    const suggestions = [
+      { id: "s1", from: 0, to: 5, newText: "X", importCommentId: "10" },
+      { id: "s2", from: 6, to: 9, newText: "Y", importCommentId: "20" },
+    ];
+    expect(await resolveWordComments(zip, suggestions)).toBe(2);
+
+    const extXml = await zip.file("word/commentsExtended.xml")!.async("text");
+    expect(countCommentEx(extXml)).toBe(2);
+    expect(extXml).toContain('w15:paraId="AAAA0002"'); // comment 10's LAST paragraph
+    expect(extXml).not.toContain("AAAA0001"); // NOT its first paragraph
+    expect(extXml).toContain('w15:paraId="BBBB0001"'); // comment 20's only paragraph
+  });
+
+  it("dedups by commentId when two suggestions carry the same importCommentId (#1012)", async () => {
+    const zip = new JSZip();
+    zip.file("word/comments.xml", commentsXml([{ id: "30", paraIds: ["CCCC0001"] }]));
+    zip.file("word/document.xml", "<stub/>");
+    zip.file(
+      "[Content_Types].xml",
+      `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/></Types>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>`,
+    );
+
+    const suggestions = [
+      { id: "s1", from: 0, to: 5, newText: "X", importCommentId: "30" },
+      { id: "s2", from: 6, to: 9, newText: "Y", importCommentId: "30" },
+    ];
+    // Both suggestions resolve the same comment → a single commentEx entry.
+    expect(await resolveWordComments(zip, suggestions)).toBe(1);
+
+    const extXml = await zip.file("word/commentsExtended.xml")!.async("text");
+    expect(countCommentEx(extXml)).toBe(1);
+    expect(extXml).toContain('w15:paraId="CCCC0001"');
+  });
+
   it("returns 0 when no suggestions have importCommentId", async () => {
     const zip = new JSZip();
     const suggestions = [{ id: "s1", from: 0, to: 5, newText: "X" }];


### PR DESCRIPTION
## Summary

Closes #1012 — a test-coverage follow-up to the #1007 fix (merged in #1010). The `resolveWordComments` suite exercised the function only with a single `importCommentId` per call, leaving the multi-comment path untested. A regression that mismapped one comment's paraId onto another, or that broke dedup, would have passed the suite.

## Change

Two new tests in the `resolveWordComments` describe block:

1. **`resolves multiple distinct comments in one call, each to its own last paraId`** — two comments (`10` with paraIds `[AAAA0001, AAAA0002]`, `20` with `[BBBB0001]`) resolved in one call; asserts 2 `commentEx` entries, that comment 10 maps to its *last* paragraph (`AAAA0002`, not the anchor `AAAA0001`), and that comment 20 maps to `BBBB0001`.
2. **`dedups by commentId when two suggestions carry the same importCommentId`** — two suggestions on comment `30`; asserts the `seen`-set dedup collapses them to a single `commentEx` entry (return value `1`).

Test-only; no production code change. The production path was already correct — this just closes the coverage hole.

## Verification

- `npx vitest run tests/server/docx-apply.test.ts` → 33/33 pass (was 31)
- CHANGELOG golden round-trip (`markdown-escaping`/`markdown-fidelity`) → pass

https://claude.ai/code/session_011Dx9Wdk84q9tFbYomuX1d3

---
_Generated by [Claude Code](https://claude.ai/code/session_011Dx9Wdk84q9tFbYomuX1d3)_