### PR TITLE
test(rename): cover live-note withFileSync merge path for ADR-027 (#1041)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`tests/server/platform.test.ts` no longer binds hardcoded ports in the Windows reserved range (#1014)** — the three `waitForPort` tests bound fixed ports `49170`/`49171`/`49172`, which fall inside the IANA dynamic/ephemeral range that Windows reserves in chunks (Hyper-V/WSL/Docker). On such hosts those binds throw `EACCES` deterministically, failing the husky pre-push gate and forcing a blanket `HUSKY=0` bypass. The tests now bind an OS-assigned port (`listen(0)`) and use the resolved port, eliminating the reserved-range collision. Test-only; no production impact.
 - **Closed a test-coverage gap in `resolveWordComments` (#1012)** — the suite exercised the function only with a single `importCommentId` per call. Added two tests covering the multi-comment path: resolving two distinct comments in one call (each mapped to its *own* last-paragraph paraId) and the dedup-by-`commentId` filter (two suggestions sharing one comment, asserting a single `commentEx` entry). Test-only; the production path was already correct.
 
+### Tests
+
+- **Strengthened the ADR-027 note-privacy rename test to cover the live-note `withFileSync` merge path (#1041)** — the existing rename note-privacy test got zero channel events "for free" because `closeStore` re-converges the moved envelope to equal the live Y.Map, so `loadAndMerge`'s `withFileSync` block performed no mutation. The new variant defeats that convergence (flush a note at `rev 2`, then diverge the live Y.Map to `rev 1` via a `withInternal` write the durable-sync observer skips), so `loadAndMerge` actually runs `annMap.set` on a live note inside the `withFileSync` transaction during rename — then asserts the note still leaks neither via channel events nor via the `getDocumentStore` read path `tandem_getAnnotations` uses. Test-only; no `src/server/` change.
+
 ## [0.13.6] - 2026-06-04
 
 ### Added

--- a/tests/server/rename-document.test.ts
+++ b/tests/server/rename-document.test.ts
@@ -494,7 +494,6 @@ describe("renameDocument — note privacy (ADR-027)", () => {
     attachObservers(docId, doc);
     const { events, cleanup } = collectEvents();
 
-    const newPath = path.join(docDir, "private-renamed.md");
     const result = await renameDocument(docId, "private-renamed.md");
     expect(result.status).toBe("renamed");
 

--- a/tests/server/rename-document.test.ts
+++ b/tests/server/rename-document.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import { Y_MAP_ANNOTATIONS, Y_MAP_DOCUMENT_META } from "../../src/shared/constants.js";
-import { withBrowser } from "../../src/shared/origins.js";
+import { withBrowser, withInternal } from "../../src/shared/origins.js";
 
 // Mock the session manager — saveSession/deleteSession touch disk for the
 // .tandem session sidecar, which is orthogonal to what these tests exercise.
@@ -61,6 +61,7 @@ const {
   resetForTesting: queueReset,
 } = await import("../../src/server/events/queue.js");
 const { wireAnnotationStore } = await import("../../src/server/mcp/file-opener.js");
+const { getDocumentStore } = await import("../../src/server/mcp/document-store.js");
 const { collectEvents } = await import("../helpers/event-collector.js");
 
 let docDir = "";
@@ -432,5 +433,95 @@ describe("renameDocument — note privacy (ADR-027)", () => {
     const newEnvelope = await createStore(docHash(newPath), { filePath: newPath }).load();
     const moved = newEnvelope.annotations.find((a) => a.id === "note-1");
     expect(moved?.type).toBe("note");
+  });
+
+  // Companion to the survival test above, exercising the branch its comment
+  // calls out as proven-elsewhere. The survival case is "guaranteed structurally"
+  // precisely because closeStore re-converges the moved envelope to equal the
+  // live Y.Map, so loadAndMerge's `withFileSync` block performs ZERO mutations.
+  // This variant DEFEATS that convergence so the REAL merge branch runs a live-
+  // note write:
+  //
+  //   1. Flush a note at rev 2 (the "file" body) — this lands in the envelope.
+  //   2. Mutate the LIVE Y.Map note to rev 1 (a different "live" body) via
+  //      `withInternal`. The durable-sync observer skips `internal` writes
+  //      (DURABLE_SKIP = {file-sync, internal}), so NO debounced write is queued
+  //      and closeStore(oldHash) flushes nothing new — the moved envelope keeps
+  //      its rev-2 file body while the live Y.Map diverges to rev 1.
+  //   3. At re-wire, loadAndMerge sees file.rev(2) > ymap.rev(1) → pickWinner
+  //      returns "file" → `annMap.set("note-1", fileRec)` executes INSIDE the
+  //      `withFileSync(ydoc, …)` transaction. That is a live-note mutation that
+  //      *could* emit if the channel observer didn't gate on origin.
+  //
+  // Assert the gate holds on BOTH surfaces: no channel event leaks the note, and
+  // getDocumentStore (what tandem_getAnnotations reads) still hides it from Claude.
+  it("a withFileSync merge that mutates a live note post-flush emits no channel event and stays hidden from Claude", async () => {
+    const { docId, filePath, doc } = await openFileDoc("private.md", "body");
+    const annMap = doc.getMap(Y_MAP_ANNOTATIONS);
+
+    // Flush the note at rev 2 — this is the body that lands in the envelope and
+    // will WIN the merge (higher rev).
+    withBrowser(doc, () =>
+      annMap.set(
+        "note-1",
+        makeAnnotation("note-1", {
+          type: "note",
+          author: "user",
+          content: "FILE BODY — must never leak",
+          rev: 2,
+        }),
+      ),
+    );
+    await createStore(docHash(filePath), { filePath }).flush();
+
+    // Diverge the live Y.Map to rev 1 via `withInternal`. The durable-sync
+    // observer skips `internal`, so this queues no debounced write — closeStore
+    // re-converges nothing, and the moved envelope retains its rev-2 file body.
+    withInternal(doc, () =>
+      annMap.set(
+        "note-1",
+        makeAnnotation("note-1", {
+          type: "note",
+          author: "user",
+          content: "LIVE BODY — also private",
+          rev: 1,
+        }),
+      ),
+    );
+
+    // Start collecting channel events BEFORE the rename so the real withFileSync
+    // merge write (file rev 2 over live rev 1) is observed if it were to emit.
+    attachObservers(docId, doc);
+    const { events, cleanup } = collectEvents();
+
+    const newPath = path.join(docDir, "private-renamed.md");
+    const result = await renameDocument(docId, "private-renamed.md");
+    expect(result.status).toBe("renamed");
+
+    // The merge genuinely fired the file-wins branch: the live Y.Map note now
+    // carries the rev-2 file body (proving loadAndMerge ran annMap.set, not a
+    // structural no-op). If this assertion fails the test is no longer covering
+    // the intended branch.
+    const merged = annMap.get("note-1") as { rev?: number; content?: string } | undefined;
+    expect(merged?.rev).toBe(2);
+    expect(merged?.content).toBe("FILE BODY — must never leak");
+
+    // ADR-027 surface 1: no channel event leaked the note (the withFileSync
+    // write was skipped by the channel observer's origin gate).
+    const annEvents = events.filter(
+      (e) => e.type === "annotation:created" || e.type === "annotation:edited",
+    );
+    expect(annEvents).toHaveLength(0);
+    cleanup();
+    detachObservers(docId);
+
+    // ADR-027 surface 2: tandem_getAnnotations reads via getDocumentStore +
+    // the `type !== "note"` filter. Claude must see zero annotations here.
+    const store = getDocumentStore(docId);
+    expect(store).not.toBeNull();
+    const claudeVisible = store!.listAnnotationsRefreshed().filter((a) => a.type !== "note");
+    expect(claudeVisible).toHaveLength(0);
+    // And the note is still present in the doc (private, not deleted).
+    expect(store!.listAnnotationsRefreshed().some((a) => a.id === "note-1")).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #1041.

## What

Strengthens the ADR-027 note-privacy test in `tests/server/rename-document.test.ts` so it exercises the **real `withFileSync` merge branch** that mutates a live note during rename — the branch the existing test's own comment (~L415-418) explicitly notes was getting zero events "structurally" and "proven separately in event-queue.test.ts."

Test-only change. **No `src/server/` production code touched.**

## The uncovered branch

The existing `renameDocument` note-privacy test gets zero channel events "guaranteed structurally" because `closeStore(oldHash)` flushes the pending debounced write and re-converges the moved envelope to equal the live Y.Map. So `loadAndMerge`'s `withFileSync(ydoc, …)` block performs **no** `annMap.set`/`delete` at all — the no-events result is independent of origin filtering. The live-note merge-mutation path (a `withFileSync` write that *could* emit) was never executed.

## How the new variant covers it

1. Flush a note at `rev 2` (the "file" body) → lands in the envelope.
2. Diverge the live Y.Map note to `rev 1` via `withInternal`. The durable-sync observer skips `internal` (`DURABLE_SKIP = {file-sync, internal}`), so **no debounced write is queued** — `closeStore` flushes nothing new and the moved envelope keeps its `rev 2` file body while the live Y.Map sits at `rev 1`.
3. During re-wire, `loadAndMerge` sees `file.rev(2) > ymap.rev(1)` → `pickWinner` returns `"file"` → `annMap.set("note-1", fileRec)` executes **inside the `withFileSync` transaction**. That is the live-note mutation that could leak.

Assertions:
- The merge genuinely ran the file-wins branch (live Y.Map now carries the `rev 2` file body) — pins that the test isn't a structural no-op.
- **ADR-027 surface 1:** no `annotation:created` / `annotation:edited` channel event leaked the note (origin gate held).
- **ADR-027 surface 2:** `getDocumentStore(docId).listAnnotationsRefreshed().filter(a => a.type !== "note")` (the exact path `tandem_getAnnotations` reads) returns zero — Claude sees nothing.
- The note remains present (private, not deleted).

## Load-bearing check

Inverting the revs (so the file does **not** win the merge) makes the file-wins assertion fail — confirming the new test genuinely drives the merge branch rather than a no-op.

## Verification

- `npm run typecheck` — clean.
- `npx vitest run tests/server/rename-document.test.ts` — 16/16 pass (new variant included).
- `npx vitest run tests/server/event-queue.test.ts` — no regression (both files: 56/56 pass).

CHANGELOG entry added under `[Unreleased] → ### Tests`.

https://claude.ai/code/session_01HNhev2YjucCJYxwNvKnGAT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNhev2YjucCJYxwNvKnGAT)_