### PR TITLE
test(rename): adapt ADR-027 file-wins merge test to #1051 RMW semantics (fix master CI)

### DIFF
--- a/tests/server/rename-document.test.ts
+++ b/tests/server/rename-document.test.ts
@@ -767,7 +767,7 @@ describe("renameDocument — note privacy (ADR-027)", () => {
 
   // Companion to the survival test above, exercising the branch its comment
   // calls out as proven-elsewhere. The survival case is "guaranteed structurally"
-  // precisely because closeStore re-converges the moved envelope to equal the
+  // precisely because the rename converges the moved envelope to equal the
   // live Y.Map, so loadAndMerge's `withFileSync` block performs ZERO mutations.
   // This variant DEFEATS that convergence so the REAL merge branch runs a live-
   // note write:
@@ -776,12 +776,23 @@ describe("renameDocument — note privacy (ADR-027)", () => {
   //   2. Mutate the LIVE Y.Map note to rev 1 (a different "live" body) via
   //      `withInternal`. The durable-sync observer skips `internal` writes
   //      (DURABLE_SKIP = {file-sync, internal}), so NO debounced write is queued
-  //      and closeStore(oldHash) flushes nothing new — the moved envelope keeps
-  //      its rev-2 file body while the live Y.Map diverges to rev 1.
-  //   3. At re-wire, loadAndMerge sees file.rev(2) > ymap.rev(1) → pickWinner
-  //      returns "file" → `annMap.set("note-1", fileRec)` executes INSIDE the
+  //      — the envelope keeps its rev-2 file body while the live Y.Map diverges
+  //      to rev 1.
+  //   3. Force a store re-wire at the SAME path: loadAndMerge sees
+  //      file.rev(2) > ymap.rev(1) → pickWinner returns "file" →
+  //      `annMap.set("note-1", fileRec)` executes INSIDE the
   //      `withFileSync(ydoc, …)` transaction. That is a live-note mutation that
   //      *could* emit if the channel observer didn't gate on origin.
+  //
+  // NOTE (#1040/#1051): this scenario was originally driven through
+  // renameDocument, but the rename's envelope migration is now a read-modify-
+  // write that SNAPSHOTS the live Y.Doc into the new-hash envelope before the
+  // re-wire — by design, a rename can no longer apply stale file-side state
+  // over the live doc, so the file-wins branch is unreachable via rename. The
+  // explicit clearFileSyncContext + wireAnnotationStore below is the same
+  // re-wire step the rename used to reach it through, and is exactly how the
+  // file-wins path is still reached in production (open/reload of a doc whose
+  // envelope advanced past the live Y.Map).
   //
   // Assert the gate holds on BOTH surfaces: no channel event leaks the note, and
   // getDocumentStore (what tandem_getAnnotations reads) still hides it from Claude.
@@ -805,8 +816,8 @@ describe("renameDocument — note privacy (ADR-027)", () => {
     await createStore(docHash(filePath), { filePath }).flush();
 
     // Diverge the live Y.Map to rev 1 via `withInternal`. The durable-sync
-    // observer skips `internal`, so this queues no debounced write — closeStore
-    // re-converges nothing, and the moved envelope retains its rev-2 file body.
+    // observer skips `internal`, so this queues no debounced write — the
+    // envelope retains its rev-2 file body.
     withInternal(doc, () =>
       annMap.set(
         "note-1",
@@ -819,13 +830,18 @@ describe("renameDocument — note privacy (ADR-027)", () => {
       ),
     );
 
-    // Start collecting channel events BEFORE the rename so the real withFileSync
+    // Start collecting channel events BEFORE the re-wire so the real withFileSync
     // merge write (file rev 2 over live rev 1) is observed if it were to emit.
     attachObservers(docId, doc);
     const { events, cleanup } = collectEvents();
 
-    const result = await renameDocument(docId, "private-renamed.md");
-    expect(result.status).toBe("renamed");
+    // Force the re-wire: dispose the live context (dropping its in-memory
+    // ledger), then wire the store again at the same path so loadAndMerge reads
+    // the rev-2 envelope against the rev-1 live Y.Map and runs the file-wins
+    // merge inside withFileSync.
+    const { clearFileSyncContext } = await import("../../src/server/events/queue.js");
+    clearFileSyncContext(docId);
+    await wireAnnotationStore(docId, doc, filePath, { allowRecovery: false });
 
     // The merge genuinely fired the file-wins branch: the live Y.Map note now
     // carries the rev-2 file body (proving loadAndMerge ran annMap.set, not a
@@ -846,6 +862,7 @@ describe("renameDocument — note privacy (ADR-027)", () => {
 
     // ADR-027 surface 2: tandem_getAnnotations reads via getDocumentStore +
     // the `type !== "note"` filter. Claude must see zero annotations here.
+    // (getDocumentStore reflects the re-wired context registered above.)
     const store = getDocumentStore(docId);
     expect(store).not.toBeNull();
     const claudeVisible = store!.listAnnotationsRefreshed().filter((a) => a.type !== "note");


### PR DESCRIPTION
## What

Fixes master CI, red since the #1051 merge. `tests/server/rename-document.test.ts > note privacy (ADR-027) > a withFileSync merge that mutates a live note...` failed with `expected 1 to be 2`.

## Root cause — semantic conflict between two independently-green PRs

- **#1047** added a test driving the file-wins `withFileSync` live-note merge *through `renameDocument`*, relying on the old envelope `fs.rename` carrying the stale rev-2 file body to the new hash.
- **#1051** redesigned that exact mechanism: the envelope migration is now a read-modify-write that **snapshots the live Y.Doc** into the new-hash envelope before the re-wire. By design, a rename can no longer apply stale file-side state over the live doc — so the file-wins branch became unreachable via rename, and the test's load-bearing assertion (`merged.rev === 2`) failed.

Each PR was green on its own branch; the merge was textually clean. CI on the merged master caught it (and the pre-push suite blocked an unrelated branch push, which is how it surfaced locally).

## Fix

Drive the same branch via the production-real path instead: an explicit `clearFileSyncContext` + `wireAnnotationStore` re-wire at the same path — exactly how a stale-envelope file-wins merge is still reached in production (open/reload of a doc whose envelope advanced past the live Y.Map). This pattern is already used elsewhere in the same test file (the #1051 stale-merge regression tests).

All four assertions are unchanged: file-wins genuinely ran (rev 1 → 2 + file body), zero `annotation:*` channel events, Claude-invisible via the `tandem_getAnnotations` read path, note preserved. The comment block documents why rename no longer drives this branch.

## Verification

- `npx vitest run tests/server/rename-document.test.ts` — 21/21 pass
- `npx vitest run tests/server/annotations/sync.test.ts tests/server/event-queue.test.ts tests/build/version-baked.test.ts` — 104 pass
- `npm run typecheck` — clean
- Full pre-push suite (biome + full vitest + cargo test) — green

Test-only change; no `src/` modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
