### PR TITLE
docs(security): CodeQL path-injection rationale for document-service FS sinks (#1042)

### DIFF
--- a/src/server/mcp/document-service.ts
+++ b/src/server/mcp/document-service.ts
@@ -81,7 +81,16 @@ export {
 /** Internal alias for the registry's view of open docs — used by closures below. */
 const openDocs = getOpenDocs();
 
-/** Non-throwing existence probe (fs.access has no boolean variant). */
+/**
+ * Non-throwing existence probe (fs.access has no boolean variant).
+ *
+ * Safe FS sink (CodeQL js/path-injection): the sole caller is renameDocument,
+ * which passes `newPath` only AFTER it has cleared validateRenameFilename, the
+ * inline separator/null-byte guard, rejectUnsafeWindowsPrefix, and the
+ * assertPathSafe realpath/symlink walk. CodeQL cannot trace those barriers
+ * across the function boundary, so a path-injection alert here is a false
+ * positive — see issue #1042 for the Security-tab dismissal rationale.
+ */
 const pathExists = (p: string): Promise<boolean> =>
   fs
     .access(p)
@@ -141,7 +150,11 @@ export async function saveDocumentToDisk(
 
   savingDocs.add(docId);
   try {
-    // Guard against overwriting external modifications
+    // Guard against overwriting external modifications.
+    // Safe FS sink (CodeQL js/path-injection): `docState.filePath` is the
+    // registry's server-managed path (only ever set by openFileByPath /
+    // resolveAndValidatePath / a validated rename or save-as) — never raw user
+    // input. An alert here is a false positive; dismiss per issue #1042.
     try {
       const stat = await fs.stat(docState.filePath);
       // Compare to the session's mtime — if the file changed externally, skip
@@ -731,6 +744,15 @@ export async function renameDocument(docId: string, newName: string): Promise<Re
     unwatchFile(oldPath);
 
     // --- Phase 2: commit (point of no return) ---
+    // Safe FS sink (CodeQL js/path-injection): `oldPath` is the registry's
+    // server-managed `docState.filePath` (only ever set by openFileByPath /
+    // resolveAndValidatePath); `newPath` was built from path.dirname(oldPath) +
+    // path.basename(newName) and then cleared validateRenameFilename, the inline
+    // separator/null-byte guard, rejectUnsafeWindowsPrefix, and assertPathSafe
+    // above. Both entry points (POST /api/rename, tandem_rename) additionally
+    // path.basename() the raw input — CodeQL's recognized taint terminator —
+    // before it reaches renameDocument. Any alert here is a false positive;
+    // dismiss per issue #1042.
     try {
       await fs.rename(oldPath, newPath);
     } catch (err) {
@@ -822,6 +844,11 @@ export async function renameDocument(docId: string, newName: string): Promise<Re
     // step 2 removes it last). Best-effort: a read/merge failure must not flip the
     // committed rename to "error" — at worst we degrade to the prior live-only
     // snapshot. In the common case (live == file) this is an idempotent no-op.
+    // Safe FS sink (CodeQL js/path-injection): `oldPath` is the registry's
+    // server-managed `docState.filePath`, and the envelope is read/written under
+    // `docHash(oldPath)` — a fixed-length hash with no path component. No
+    // user-controlled string reaches this store's filesystem path; an alert here
+    // is a false positive (dismiss per issue #1042).
     try {
       const oldFile = await createStore(oldHash, { filePath: oldPath }).load();
       mergeEnvelopeForward(doc, oldFile, newHash);
@@ -936,6 +963,9 @@ export async function renameDocument(docId: string, newName: string): Promise<Re
       // real mtime and DO NOT markClean: unsaved edits must stay dirty so the next
       // autosave writes them to newPath.
       const meta = doc.getMap(Y_MAP_DOCUMENT_META);
+      // Safe FS sink (CodeQL js/path-injection): `newPath` is the validated
+      // rename target (see the Phase-0 barriers above) — not raw user input.
+      // An alert here is a false positive; dismiss per issue #1042.
       const stat = await fs.stat(newPath).catch(() => null);
       withFileSync(doc, () => {
         meta.set("fileName", fileName);


### PR DESCRIPTION
## What

Closes the verification half of #1042. PR #1038 (merged) removed `src/server/mcp/document-service.ts` from `paths-ignore` and intended per-sink `// codeql[js/path-injection]` suppressions as the long-term mechanism. On inspection those inline markers were never actually added, and — more importantly — **they would not have worked**: this repo uses GitHub's *default* code-scanning setup (there is no CodeQL workflow under `.github/workflows/`, only `.github/codeql/codeql-config.yml`), and GitHub code scanning does not honor inline `// codeql[...]` source-suppression comments. That syntax is a standalone CodeQL-CLI feature, not a hosted-scanning one. On GitHub, false-positive alerts are dismissed in the Security tab.

So this PR does the two things actually in scope for an agent that cannot reach the Security tab:

1. **Verified the path-handling is genuinely safe** at each flagged FS sink (analysis below).
2. **Added sink-local prose justification comments** at each genuinely-safe sink — matching the repo's established convention (`convert.ts`, `file-opener.ts`, `routes/rename.ts` all use prose CodeQL-rationale comments, not `// codeql[...]` markers) — so the rationale is discoverable in-source.

**Comment-only change. No executable code was modified.** No `src/server/` behavior changes.

## Safety analysis (all four sinks are false positives)

Every path reaching a filesystem sink in `document-service.ts` is either server-managed registry state or a name that has cleared the full Phase-0 validation barrier in `renameDocument`. The two public entry points both `path.basename()` the raw input — CodeQL's recognized taint terminator — before it ever reaches `renameDocument`:
- `POST /api/rename` → `src/server/mcp/routes/rename.ts` (`path.basename(rawDocumentId)`, `path.basename(rawNewName)`)
- `tandem_rename` MCP tool → `src/server/mcp/document.ts` (same)

`renameDocument` then independently re-validates `newName` through, in order: `validateRenameFilename` (rejects separators, `.`/`..`, Windows-illegal chars + control chars, trailing space/dot, reserved device names), an **inline** `newName.includes("/")||"\\"||"\0"` guard (the barrier CodeQL recognizes locally), `rejectUnsafeWindowsPrefix` (UNC + `\\?\`), and `assertPathSafe` (realpath/symlink walk). `newPath` is `path.resolve(path.join(path.dirname(oldPath), path.basename(newName)))`.

| Sink | Variable | Why safe |
|---|---|---|
| `fs.access(p)` in `pathExists` | `newPath` | Only caller is `renameDocument`, after all Phase-0 barriers |
| `fs.rename(oldPath, newPath)` | both | `oldPath` = server-managed `docState.filePath`; `newPath` validated above |
| `createStore(oldHash, …).load()` | `oldPath` | Store keyed on `docHash(oldPath)` — a fixed-length hash, no path component; `oldPath` is server-managed |
| `fs.stat(newPath)` (post-commit) | `newPath` | Validated rename target |
| `fs.stat(docState.filePath)` (save) | `docState.filePath` | Server-managed registry path, never raw input |

CodeQL cannot trace the cross-function barriers (validation lives in `renameDocument`/the route; the sinks are in helpers or later phases), which is why these surface as alerts despite being safe.

## Action required from @bloknayrb (Security tab)

After the next CodeQL scan on `master`, any `js/path-injection` alert on `document-service.ts` should be **dismissed as "Won't fix / False positive"** with this rationale:

> Server-managed paths validated by `openFileByPath`/`assertPathSafe` before storage in `openDocs`; `path.basename()` applied at the HTTP (`POST /api/rename`) and MCP (`tandem_rename`) boundaries, and `renameDocument` re-validates `newName` via `validateRenameFilename` + an inline separator/null-byte guard + `rejectUnsafeWindowsPrefix` + `assertPathSafe` before constructing `newPath`. CodeQL cannot trace these barriers across function boundaries. False positive — see in-source comments + issue #1042.

Note: GitHub's default code-scanning setup does not honor inline `// codeql[...]` suppression comments, so dismissal must happen in the Security tab; the in-source comments document the rationale for future readers.

## Verification

- `npm run typecheck` — passes (only the pre-existing `tsconfig.server.json` `baseUrl` deprecation notice, unrelated and in a file not touched here).
- No test changes needed: comment-only diff, no behavioral change. The existing `rename-document.test.ts` / `rename-route.test.ts` / `filename-safety.test.ts` suites already cover the validation barriers cited above.
- The CodeQL scan itself runs in CI / the Security tab post-merge — documented here, not fabricated.

https://claude.ai/code/session_01EX5LjJFcXh6tEy7RCYcYbb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EX5LjJFcXh6tEy7RCYcYbb)_