### PR TITLE
Fix editor stuck in Review Only mode (CRDT clock conflict on session restore)

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -1155,7 +1155,7 @@ const dispatch: Partial<Record<ShortcutId, ShortcutHandler>> = {
     // is the common case (user has selected text in the editor).
     e.preventDefault();
     const hasSelection = !!editor && editor.state.selection.from !== editor.state.selection.to;
-    const reviewOnly = activeTab?.readOnly === true;
+    const reviewOnly = isReadOnly;
     const popupSuppressed = slashCommandMenuOpen || findBarOpen || paletteOpen;
     if (popupSuppressed) {
       // Palette/find UI is the active context; user understands why.
@@ -1380,9 +1380,8 @@ $effect(() => {
 
 // Raw-markdown source view (#1021). Only editable .md documents qualify
 // (read-only .md like CHANGELOG and non-.md formats are excluded).
-const canSourceView = $derived(
-  !!activeTab && activeTab.format === "md" && activeTab.readOnly !== true,
-);
+const isReadOnly = $derived(activeTab?.readOnly === true);
+const canSourceView = $derived(!!activeTab && activeTab.format === "md" && !isReadOnly);
 const inSourceView = $derived(!!activeTab && sourceViewTabs.has(activeTab.id));
 
 function toggleSourceView(): void {
@@ -1778,7 +1777,7 @@ const tutorial = createTutorial(
       claudeStatus={yjsSync.claudeStatus}
       claudeActive={yjsSync.claudeActive}
       claudeWorkingTool={yjsSync.claudeWorking?.tool ?? null}
-      readOnly={yjsSync.readOnly}
+      readOnly={isReadOnly}
       saving={saveStore.saving}
       {editor}
     />
@@ -1995,14 +1994,14 @@ const tutorial = createTutorial(
     ondrop={fileDrop.handleEditorDrop}
   >
     <ReviewOnlyBanner
-      visible={activeTab?.readOnly === true && activeTab?.format === "docx"}
+      visible={isReadOnly && activeTab?.format === "docx"}
       documentId={activeTab?.id}
     />
     {#snippet editorContent()}
       <Editor
         ydoc={activeTab!.ydoc}
         provider={activeTab!.provider}
-        readOnly={yjsSync.readOnly}
+        readOnly={isReadOnly}
         currentFilePath={activeTab!.filePath}
         format={activeTab!.format}
         {activeAnnotationId}

--- a/src/client/hooks/yjsSync.svelte.ts
+++ b/src/client/hooks/yjsSync.svelte.ts
@@ -13,7 +13,6 @@ import {
   Y_MAP_DOCUMENT_META,
   Y_MAP_GENERATION_ID,
   Y_MAP_OPEN_DOCUMENTS,
-  Y_MAP_READ_ONLY,
   Y_MAP_STORE_READ_ONLY,
 } from "../../shared/constants";
 import { sanitizeAnnotation } from "../../shared/sanitize";
@@ -47,7 +46,6 @@ export interface YjsSyncState {
   readonly claudeActive: boolean;
   /** #651: current MCP tool Claude is executing on the active doc, or null. */
   readonly claudeWorking: ClaudeWorking | null;
-  readonly readOnly: boolean;
   /** True when the annotation store is locked by another Tandem instance. Annotations won't be saved. */
   readonly storeReadOnly: boolean;
   /** @internal Internal CTRL_ROOM connection mechanism — not intended for consumer use. */
@@ -90,7 +88,6 @@ export function createYjsSync(): YjsSyncState {
   let claudeStatus = $state<string | null>(null);
   let claudeActive = $state(false);
   let claudeWorking = $state<ClaudeWorking | null>(null);
-  let readOnly = $state(false);
   let storeReadOnly = $state(false);
   let ready = $state(false);
   let serverRestarted = $state(false);
@@ -171,28 +168,9 @@ export function createYjsSync(): YjsSyncState {
     awarenessMap.observe(awarenessObserver);
     awarenessObserver();
 
-    const documentMetaMap = ydoc.getMap(Y_MAP_DOCUMENT_META);
-    let prevReadOnly = false;
-    const documentMetaObserver = (event: Y.YMapEvent<unknown>) => {
-      // keysChanged guard #1 (preserves original line 128)
-      if (!event.keysChanged.has(Y_MAP_READ_ONLY)) return;
-      const ro = (documentMetaMap.get(Y_MAP_READ_ONLY) as boolean | undefined) === true;
-      if (ro !== prevReadOnly) {
-        prevReadOnly = ro;
-        readOnly = ro;
-      }
-    };
-    documentMetaMap.observe(documentMetaObserver);
-    const initRo = (documentMetaMap.get(Y_MAP_READ_ONLY) as boolean | undefined) === true;
-    if (initRo !== prevReadOnly) {
-      prevReadOnly = initRo;
-      readOnly = initRo;
-    }
-
     return () => {
       annotationsMap.unobserve(annotationObserver);
       awarenessMap.unobserve(awarenessObserver);
-      documentMetaMap.unobserve(documentMetaObserver);
     };
   };
 
@@ -464,7 +442,6 @@ export function createYjsSync(): YjsSyncState {
         claudeStatus = null;
         claudeActive = false;
         claudeWorking = null;
-        readOnly = false;
       }
     });
 
@@ -611,9 +588,6 @@ export function createYjsSync(): YjsSyncState {
     },
     get claudeWorking() {
       return claudeWorking;
-    },
-    get readOnly() {
-      return readOnly;
     },
     get storeReadOnly() {
       return storeReadOnly;

--- a/src/client/svelte-harness/HookDebug.svelte
+++ b/src/client/svelte-harness/HookDebug.svelte
@@ -22,7 +22,7 @@ const snapshot = $derived({
   annotationCount: sync.annotations.length,
   claudeStatus: sync.claudeStatus,
   claudeActive: sync.claudeActive,
-  readOnly: sync.readOnly,
+  readOnly: sync.tabs.find((t) => t.id === sync.activeTabId)?.readOnly ?? false,
   hasBootstrapYdoc: sync.bootstrapYdoc !== null,
 });
 </script>

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -471,7 +471,10 @@ function handleAlreadyOpen(
   if (explicitReadOnly && !existing.readOnly) {
     addDoc(id, { ...existing, readOnly: true });
     const meta = doc.getMap(Y_MAP_DOCUMENT_META);
-    withInternal(doc, () => meta.set(Y_MAP_READ_ONLY, true));
+    withInternal(doc, () => {
+      meta.delete(Y_MAP_READ_ONLY);
+      meta.set(Y_MAP_READ_ONLY, true);
+    });
   }
 
   setActiveDocId(id);
@@ -936,6 +939,7 @@ async function clearAndReload(
       applyPreparedContent(doc, prepared, ctx);
       // Rewrite metadata + dirty-tracking baseline
       const meta = doc.getMap(Y_MAP_DOCUMENT_META);
+      meta.delete(Y_MAP_READ_ONLY);
       meta.set(Y_MAP_READ_ONLY, isDocx);
       meta.set("format", format);
       meta.set("documentId", id);
@@ -1000,6 +1004,9 @@ function writeDocMeta(
 ): void {
   const meta = doc.getMap(Y_MAP_DOCUMENT_META);
   withInternal(doc, () => {
+    // Tombstone any session-persisted value so CRDT clock conflicts (old session's
+    // higher-clock true) can't override the authoritative readOnly from the registry.
+    meta.delete(Y_MAP_READ_ONLY);
     meta.set(Y_MAP_READ_ONLY, readOnly);
     meta.set("format", format);
     meta.set("documentId", id);

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -1004,8 +1004,9 @@ function writeDocMeta(
 ): void {
   const meta = doc.getMap(Y_MAP_DOCUMENT_META);
   withInternal(doc, () => {
-    // Tombstone any session-persisted value so CRDT clock conflicts (old session's
-    // higher-clock true) can't override the authoritative readOnly from the registry.
+    // Tombstone any session-persisted value so a stale session's higher-clock
+    // write can't override the authoritative readOnly passed by the caller.
+    // The same delete-before-set pattern is required in handleAlreadyOpen.
     meta.delete(Y_MAP_READ_ONLY);
     meta.set(Y_MAP_READ_ONLY, readOnly);
     meta.set("format", format);


### PR DESCRIPTION
## Summary

- **Root cause**: When old session binaries (written by prior server code where `.docx` files were always read-only) were restored, their `documentMeta/readOnly` Y.js operations had high logical clocks that won over new server writes (which start at clock 0 with a fresh clientID). This left `.md` files stuck in Review Only mode.
- **Server fix**: Tombstone `Y_MAP_READ_ONLY` with `meta.delete()` before `meta.set()` in all three write sites (`writeDocMeta`, `handleAlreadyOpen`, `clearAndReload`) so session state can never win the CRDT comparison.
- **Client fix**: Source `readOnly` for StatusBar and Editor from `activeTab.readOnly` (the `openDocuments` broadcast list, always fresh from CTRL_ROOM which has no session state) rather than `yjsSync.readOnly` (per-doc Y.Map, subject to CRDT conflicts). Introduced a single `$derived isReadOnly` replacing all scattered `activeTab?.readOnly === true` expressions. Removed the now-dead `documentMetaObserver`, `readOnly` `$state`, and `readOnly` from `YjsSyncState` entirely.

## Test plan

- [ ] Open a `.md` file in Tauri dev — editor should be fully editable (no "Review Only" in status bar)
- [ ] Open a `.docx` file — should still show Review Only banner and be non-editable
- [ ] Open CHANGELOG.md via View Changelog button — should be read-only
- [ ] Close and restart dev server with existing sessions — `.md` files should open editable on next launch
- [ ] All unit tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)