### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-10
+
 ### Added
 
 - **Structured output for typed MCP clients (#1080)** — six data-returning tools (`tandem_status`, `tandem_getTextContent`, `tandem_getAnnotations`, `tandem_checkInbox`, `tandem_listDocuments`, `tandem_search`) now advertise an MCP `outputSchema` and emit `structuredContent` alongside the unchanged text envelope, so non-Claude clients can validate responses end-to-end. Error responses from these tools carry the MCP-level `isError: true` flag. Per ADR-027 the annotation schemas structurally exclude `type: "note"` — user-private notes cannot appear in structured payloads. Tool descriptions across the catalog were also tightened (~5% smaller model-visible catalog), and stale `tandem_getAnnotations` documentation claiming notes were readable via `type: "note"` was corrected.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "description": "Edit and iterate on documents with any MCP-capable AI (Claude by default). Real-time push via the channel shim.",
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-desktop"
-version = "0.13.6"
+version = "0.14.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-desktop"
-version = "0.13.6"
+version = "0.14.0"
 description = "Collaborative AI-human document editor"
 authors = ["Bryan Kolb"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "identifier": "com.tandem.editor",
   "build": {
     "frontendDist": "../dist/client",


### PR DESCRIPTION
## Release v0.14.0

Version bump + changelog promotion for v0.14.0. Rolls up everything merged to master since v0.13.6 (231 commits).

### Highlights
- **.docx write-back suite**: body export (#576), Word-comment export on save (#1068), external-conflict detection with keep-vs-reload (#1069)
- **Data safety**: pre-overwrite document backups + shutdown flush, in-product restore (#1086), stale-tab generation gate, store-lock reclaim (#1077)
- **Supportability**: Copy Diagnostics / Open Log Folder, cross-platform uninstall scrub, Node 22 CLI guard, opt-in crash reporting (#921)
- **Release confidence**: webdriver E2E on release tags + manual smoke checklist (first execution is this release)
- **AI discoverability cluster** (#1018/#1022): Connect AI entry points, loud-failure notices, first-run leads with Claude Code
- **MCP**: structured output for six data-returning tools (#1080); silent auto-config removed in favor of the wizard (#477 PR 3c-ii-c)
- Raw-markdown source view (#1021), in-app rename (#1017), default save folder (#1023), annotation panel ordering (#1056)

Delivers v0.14.0's planned scope per docs/roadmap.md (AR5/AR6 hardening shipped early in v0.13.6; 3c-ii-c and #576 land here).

### Post-merge
1. Annotated tag `v0.14.0` on the merge commit → `tauri-release.yml` builds/signs installers, `tauri-webdriver.yml` runs as release signal
2. GitHub release published by CI → triggers npm publish
3. First execution of `docs/release-smoke-checklist.md` (Windows + macOS hardware pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
