### PR TITLE
fix(ci): pass --debug/--no-bundle to tauri CLI, not cargo

### DIFF
--- a/.github/workflows/tauri-webdriver.yml
+++ b/.github/workflows/tauri-webdriver.yml
@@ -78,8 +78,11 @@ jobs:
       # `beforeBuildCommand: npm run build` produces the dist/client + dist/server
       # bundles (the build resources tauri_build::build() checks) as part of the
       # build below, so an explicit `npm run build` here would just build twice.
+      # `--debug` and `--no-bundle` are `tauri build` flags, so they must NOT sit
+      # behind `--` (which forwards args to the underlying `cargo build`, where
+      # `--debug` is rejected: it is cargo's default, not an accepted flag).
       - name: Build Tauri debug binary
-        run: cargo tauri build -- --debug --no-bundle
+        run: cargo tauri build --debug --no-bundle
 
       - name: Install harness dependencies
         working-directory: tests/tauri-driver


### PR DESCRIPTION
## What

The tag-triggered **Tauri WebDriver E2E** run for `v0.14.0` ([run 27293728930](https://github.com/bloknayrb/tandem/actions/runs/27293728930)) failed at the **Build Tauri debug binary** step:

```
error: unexpected argument '--debug' found
  tip: `--debug` is the default for `cargo build`; instead `--release` is supported
```

The step ran `cargo tauri build -- --debug --no-bundle`. The `--` separator forwards everything after it to the underlying `cargo build`, which rejects `--debug`. But `--debug` and `--no-bundle` are **`tauri build` CLI flags**, not cargo flags — they belong *before* any separator. Dropping the `--` lets `cargo-tauri` parse them.

## Why it didn't block the release

`tauri-webdriver.yml` is a non-gating release **signal** (webview-level key-interception E2E), not a gate. The shipped v0.14.0 installers are built by `tauri-release.yml` via `tauri-action`, a separate and correct path — so artifacts and signatures were unaffected. This was the first tag-triggered run of the new workflow, surfacing a latent command bug.

## Change

One line in `.github/workflows/tauri-webdriver.yml` (+ a comment explaining the separator pitfall). Build-setup only — no product or test-logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)