### PR TITLE
fix(doctor): parse v2 JSON lockfile instead of flagging it unparseable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`tandem doctor` no longer flags a valid lockfile as "unparseable content"** — the annotation store-lock check still parsed the lock as a bare PID (`parseInt`), but locks have been v2 JSON (`{pid, startedAtMs, app}`) since #1077. A healthy lock therefore reported a spurious warning ("unparseable content: `{…}`"). The doctor now reuses the store's `parseLockfile` (which reads both v2 JSON and legacy raw-PID formats) so a live lock reports the holder PID and liveness correctly. The pure lock format/parsing moved to `src/server/annotations/lockfile.ts` so the CLI doctor can read a lock without pulling in the store's file-io/notifications/platform dependency graph; `store.ts` re-exports it unchanged.
+
 ## [0.14.0] - 2026-06-10
 
 ### Added

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -28,6 +28,7 @@ import { request } from "node:http";
 import { createConnection } from "node:net";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
+import { parseLockfile } from "../server/annotations/lockfile.js";
 import { DEFAULT_MCP_PORT, DEFAULT_WS_PORT } from "../shared/constants.js";
 
 export type DoctorStatus = "pass" | "warn" | "fail";
@@ -529,8 +530,10 @@ function checkAnnotationStore(r: Recorder): void {
 
   try {
     const raw = readFileSync(lockPath, "utf-8").trim();
-    const pid = Number.parseInt(raw, 10);
-    if (!Number.isFinite(pid)) {
+    // Current locks are v2 JSON (`{pid, startedAtMs, app}`, #1077); older ones
+    // are a bare PID. parseLockfile reads both and returns null for true garbage.
+    const lock = parseLockfile(raw);
+    if (lock === null) {
       r.warn(
         `Annotation store lock at ${lockPath} has unparseable content: "${raw}"`,
         "Restart Tandem or delete the lock file if no server is running.",
@@ -538,6 +541,7 @@ function checkAnnotationStore(r: Recorder): void {
       );
       return;
     }
+    const { pid } = lock;
     if (isPidLive(pid)) {
       r.pass(`Annotation store lock held by live PID ${pid}`, undefined, {
         lockHeld: true,

--- a/src/server/annotations/lockfile.ts
+++ b/src/server/annotations/lockfile.ts
@@ -1,0 +1,56 @@
+/**
+ * `store.lock` payload format + parsing, isolated from {@link ../store.ts} so
+ * that lightweight consumers (the `tandem doctor` CLI) can read a lock without
+ * pulling in the store's file-io / notifications / platform dependency graph.
+ *
+ * Two on-disk formats, both must stay readable:
+ *   - v2 (#1077): JSON `{pid, startedAtMs?, app}` — written by current versions.
+ *   - legacy: a bare PID string — written by older versions.
+ */
+
+/** App identifier stamped into v2 lockfiles. */
+export const LOCK_APP_ID = "tandem";
+
+/** Parsed contents of `store.lock` (v2 JSON or legacy raw-PID). */
+export interface LockfileContents {
+  pid: number;
+  /** v2 only — epoch ms when the holder took the lock. */
+  startedAtMs?: number;
+  /** v2 only — always `"tandem"` when written by Tandem. */
+  app?: string;
+}
+
+/** Serialize the v2 lockfile payload for the current process. */
+export function lockfilePayload(): string {
+  return JSON.stringify({ pid: process.pid, startedAtMs: Date.now(), app: LOCK_APP_ID });
+}
+
+/**
+ * Parse `store.lock` contents. Two formats:
+ *   - v2 (#1077): JSON `{pid, startedAtMs?, app}` — written by current versions.
+ *   - legacy: a bare PID string — written by older versions; must stay readable.
+ *
+ * Returns `null` for garbage content (callers treat that as a stale lock).
+ */
+export function parseLockfile(raw: string): LockfileContents | null {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      const pid = parsed.pid;
+      if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return null;
+      return {
+        pid,
+        startedAtMs: typeof parsed.startedAtMs === "number" ? parsed.startedAtMs : undefined,
+        app: typeof parsed.app === "string" ? parsed.app : undefined,
+      };
+    } catch {
+      return null;
+    }
+  }
+  // Legacy raw-PID format. parseInt (not Number()) preserves the historical
+  // tolerance for trailing junk after the digits.
+  const pid = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(pid) || pid <= 0) return null;
+  return { pid };
+}

--- a/src/server/annotations/store.ts
+++ b/src/server/annotations/store.ts
@@ -25,6 +25,7 @@ import path from "node:path";
 import { atomicWrite } from "../file-io/index.js";
 import { pushNotification } from "../notifications.js";
 import { resolveAppDataDir } from "../platform.js";
+import { type LockfileContents, lockfilePayload, parseLockfile } from "./lockfile.js";
 import {
   isTandemLikeProcessName,
   type ProcessIdentity,
@@ -126,53 +127,10 @@ async function ensureDirReady(): Promise<void> {
 // Lockfile (concurrent-writer guard)
 // ---------------------------------------------------------------------------
 
-/** App identifier stamped into v2 lockfiles. */
-const LOCK_APP_ID = "tandem";
-
-/** Parsed contents of `store.lock` (v2 JSON or legacy raw-PID). */
-export interface LockfileContents {
-  pid: number;
-  /** v2 only — epoch ms when the holder took the lock. */
-  startedAtMs?: number;
-  /** v2 only — always `"tandem"` when written by Tandem. */
-  app?: string;
-}
-
-/** Serialize the v2 lockfile payload for the current process. */
-function lockfilePayload(): string {
-  return JSON.stringify({ pid: process.pid, startedAtMs: Date.now(), app: LOCK_APP_ID });
-}
-
-/**
- * Parse `store.lock` contents. Two formats:
- *   - v2 (#1077): JSON `{pid, startedAtMs?, app}` — written by current versions.
- *   - legacy: a bare PID string — written by older versions; must stay readable.
- *
- * Returns `null` for garbage content (callers treat that as a stale lock).
- * Exported for testing.
- */
-export function parseLockfile(raw: string): LockfileContents | null {
-  const trimmed = raw.trim();
-  if (trimmed.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-      const pid = parsed.pid;
-      if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return null;
-      return {
-        pid,
-        startedAtMs: typeof parsed.startedAtMs === "number" ? parsed.startedAtMs : undefined,
-        app: typeof parsed.app === "string" ? parsed.app : undefined,
-      };
-    } catch {
-      return null;
-    }
-  }
-  // Legacy raw-PID format. parseInt (not Number()) preserves the historical
-  // tolerance for trailing junk after the digits.
-  const pid = Number.parseInt(trimmed, 10);
-  if (!Number.isFinite(pid) || pid <= 0) return null;
-  return { pid };
-}
+// Lockfile format + parsing live in ./lockfile.ts so the `tandem doctor` CLI can
+// read a lock without pulling in this module's file-io/notifications/platform
+// deps (imported above). Re-exported here for existing importers (tests, callers).
+export { type LockfileContents, parseLockfile };
 
 /**
  * Signal-0 liveness check. ESRCH = no such process; EPERM = exists but we


### PR DESCRIPTION
## What

During the v0.14.0 npm-path smoke pass, `tandem doctor` reported a spurious warning against a perfectly healthy server:

```
[WARN] Annotation store lock at …\store.lock has unparseable content: "{"pid":15520,"startedAtMs":…,"app":"tandem"}"
```

The store-lock check still parsed the lock as a **bare PID** (`Number.parseInt(raw, 10)`), but lockfiles have been **v2 JSON** (`{pid, startedAtMs, app}`) since #1077 (v0.14.0). So every current, valid lock parsed to `NaN` → "unparseable content". Cosmetic (it's a `WARN`, server works), but it reads as a problem when nothing is wrong.

## Fix

The store already has a `parseLockfile()` that reads **both** v2 JSON and legacy raw-PID formats (and returns `null` for true garbage). The doctor now delegates to it instead of duplicating a stale parser.

To avoid dragging the store's `file-io` / `notifications` / `platform` dependency graph into the CLI bundle, the pure lock format/parsing moved to a new lightweight `src/server/annotations/lockfile.ts`:

- `parseLockfile`, `lockfilePayload`, `LockfileContents`, `LOCK_APP_ID` — no heavy imports
- `store.ts` imports them for internal use and **re-exports** `parseLockfile` / `LockfileContents`, so the existing test import path (`tests/server/annotations/store.test.ts`) is unchanged
- `doctor.ts` imports `parseLockfile` from the new module

The check lives in `runDoctor` (the pure collector shared by the CLI **and** the `/api/diagnostics` route behind the desktop **Copy Diagnostics** button), so both surfaces are fixed.

## Verification

- `npm run typecheck` clean
- `store.test.ts` + `diagnostics-format.test.ts` pass (36 tests) — `parseLockfile`'s JSON/legacy/garbage cases are covered there
- End-to-end: wrote a real v2-JSON `store.lock` and ran the doctor from source — it now reports the holder PID + liveness instead of "unparseable content"

No annotation-schema, coordinate-system, or lock-format change — parsing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)