### PR TITLE
fix(tauri-driver): un-break the WebDriver E2E harness (ESM `__dirname`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,17 +72,17 @@
   "lint-staged": {
     "**/*.{ts,tsx}": [
       "eslint --fix",
-      "biome check --write"
+      "biome check --write --no-errors-on-unmatched"
     ],
     "src/**/*.{svelte,css,html}": [
-      "biome check --write"
+      "biome check --write --no-errors-on-unmatched"
     ],
     "**/*.mjs": [
       "eslint --fix",
-      "biome check --write"
+      "biome check --write --no-errors-on-unmatched"
     ],
     "**/*.json !package-lock.json": [
-      "biome check --write"
+      "biome check --write --no-errors-on-unmatched"
     ],
     "src/client/**/*.{ts,tsx,svelte,css,html}": [
       "tsx scripts/check-semantic-tokens.ts"

--- a/tests/tauri-driver/wdio.conf.ts
+++ b/tests/tauri-driver/wdio.conf.ts
@@ -21,9 +21,12 @@ import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-// Repo root is two levels up from tests/tauri-driver/.
-const repoRoot = path.resolve(__dirname, "..", "..");
+// Repo root is two levels up from tests/tauri-driver/. `__dirname` does not
+// exist in ESM (package.json sets "type": "module"); derive it from import.meta.
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(dirname, "..", "..");
 
 // The built debug binary. The Cargo package is `tandem-desktop`
 // (src-tauri/Cargo.toml) and `cargo tauri build -- --no-bundle` skips the


### PR DESCRIPTION
## Context

The Tauri WebDriver E2E harness (`tests/tauri-driver/`, #560) is the only coverage proving the `prevent-default` plugin actually intercepts reload shortcuts **inside the live Tauri WebView** — a regression `src-tauri/tests/prevent_default.rs` structurally cannot catch. It runs on tag pushes via `tauri-webdriver.yml` as a release *signal*.

**It has never run green.** During the v0.14.1 release pass the WebDriver job failed identically to the v0.14.0 tag and the #560 introduction branch — the harness has been dead since `66f99c8`. The failure is at config *load*, before any spec runs.

## Root cause

`tests/tauri-driver/package.json` sets `"type": "module"`, so WebdriverIO loads `wdio.conf.ts` via `tsx` as an ES module — where `__dirname` is undefined. Line 26 (`path.resolve(__dirname, "..", "..")`) threw `__dirname is not defined in ES module scope`. It's the sole CJS-global in the harness; the spec file is clean.

## Changes

1. **`wdio.conf.ts`** — derive the directory from `import.meta.url` (`path.dirname(fileURLToPath(import.meta.url))`). `repoRoot` resolution is unchanged.
2. **`package.json` (lint-staged)** — add `--no-errors-on-unmatched` to the `biome check` invocations. Discovered while committing: biome ignores `tests/tauri-driver/**`, but lint-staged still routes those files to `biome check`, which exits 1 ("no files were processed") when *every* staged file is biome-ignored. Editing only harness files was uncommittable; the #560 commit slipped through by co-staging non-ignored `.ts`. The flag changes the exit code only in the zero-files case.

## Verification

- **Local config-load smoke test** (proves the ESM fix, no full build): from `tests/tauri-driver/`, `npx tsx -e "import('./wdio.conf.ts').then(m => console.log(m.config.specs))"` now prints `[ './specs/**/*.e2e.ts' ]` instead of throwing. Importing executes the previously-throwing top-level line without invoking `onPrepare`/`beforeSession`.
- **Authoritative end-to-end** (after merge): `gh workflow run tauri-webdriver.yml --ref master` — the workflow already exposes `workflow_dispatch`. Expect it to get past config-load into `cargo tauri build` → `tauri-driver` → the three reload-interception specs.

## Honest scope

This un-breaks config *load*. It does **not** guarantee the first CI run is green: nothing has ever gotten past line 26, so a downstream failure (build env, sidecar/reaper, xvfb/webkit2gtk-driver) could surface — that'd be a new finding, not a defect here. Refs #560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)