### PR TITLE
fix(tauri-driver): drop client `browserName` so the WebDriver session is created

### DIFF
--- a/tests/tauri-driver/wdio.conf.ts
+++ b/tests/tauri-driver/wdio.conf.ts
@@ -62,11 +62,14 @@ export const config: WebdriverIO.Config = {
   capabilities: [
     {
       // `tauri:options` is consumed by tauri-driver, which forwards the rest of
-      // the session to the platform's native WebView driver.
+      // the session to the platform's native WebView driver (WebKitWebDriver on
+      // Linux). Per the official Tauri v2 WebdriverIO example, the client sets NO
+      // `browserName`: WebKitWebDriver offers no browser named "wry", so supplying
+      // it fails W3C capability matching ("Failed to match capabilities"). tauri-
+      // driver reports the browser as "wry" itself once the session is created.
       "tauri:options": {
         application,
       },
-      browserName: "wry",
     } as WebdriverIO.Capabilities,
   ],
 


### PR DESCRIPTION
## Context

Stacked on #1127 (merged), which fixed the ESM `__dirname` config-load bug. With that fix the tauri-driver harness (#560) now runs end-to-end for the first time and reaches `POST http://localhost:4444/session`, where it fails:

```
session not created: WebDriverError: Failed to match capabilities
```

(workflow_dispatch run 27358088310.)

## Root cause

The capabilities object set `browserName: "wry"`. `tauri-driver`'s native WebView driver (WebKitWebDriver on Linux) offers no browser named "wry", so W3C capability matching rejects the client-supplied `browserName` before the session is created — tauri-driver returns the error fast, before forwarding.

The **official Tauri v2 WebdriverIO example** ([`tauri-docs Example/webdriverio.mdx`](https://github.com/tauri-apps/tauri-docs/blob/v2/src/content/docs/develop/Tests/WebDriver/Example/webdriverio.mdx), pinned to wdio `^9.19`) sets **only** `tauri:options` — no `browserName` — and its own doc output shows it passing (`[wry 0.12.1 linux] ... 3 passing`). The `wry` label is **server-supplied by tauri-driver after** session creation, not a client capability.

## Change

One line: remove `browserName: "wry"` from the capability object so it matches the proven-working official shape (`{ "tauri:options": { application } }`).

I deliberately did **not** also add `wdio:enforceWebDriverClassic: true`: the official example runs on wdio 9.19 (BiDi-default era) without it and passes, so WebDriver BiDi is not the blocker. Keeping this a single-variable change isolates the fix on the ~10-min CI round.

## How this was diagnosed

Plan → two adversarial review agents (which conflicted on whether `browserName: "wry"` is required) → reconciled against the live official example as the primary source (it omits `browserName` and is green on wdio 9.19). Full pipeline, plan saved locally.

## Verification

- **Local:** `npx tsx -e "import('./wdio.conf.ts').then(m=>console.log(m.config.capabilities))"` now yields `[{"tauri:options":{...}}]` (loads clean, no browserName).
- **Authoritative (CI):** `gh workflow run tauri-webdriver.yml --ref master` after merge. Success = session created (no "Failed to match capabilities"), WebView loads the editor shell, and the reload-interception specs pass.

## Honest scope

This targets **session creation**. Getting past it reaches the next never-before-run layer (app launch under tauri-driver, sidecar startup on :3478/:3479 serving the WebView, the specs' waits/assertions). A new failure there would be a separate finding, not a defect here — getting fully green may take another iteration. Refs #560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)