### PR TITLE
ci(tauri-webdriver): port #560 harness to Windows/WebView2 (first green run)

### DIFF
--- a/.github/workflows/tauri-webdriver.yml
+++ b/.github/workflows/tauri-webdriver.yml
@@ -122,6 +122,15 @@ jobs:
         env:
           # Binary already built above; don't rebuild inside onPrepare.
           TAURI_SKIP_BUILD: "1"
+          # WebKitGTK defaults to GPU-accelerated compositing AND the DMA-BUF
+          # renderer; both fail with no GPU under xvfb (see the libEGL DRI3
+          # warnings) and crash the WebContent process — the editor shell never
+          # renders and the WebDriver session collapses. Force software rendering
+          # at both the WebKit layer (these two) and the GL stack (LIBGL_*, which
+          # is what emits the DRI3 probe failure). Standard headless-CI fix.
+          WEBKIT_DISABLE_COMPOSITING_MODE: "1"
+          WEBKIT_DISABLE_DMABUF_RENDERER: "1"
+          LIBGL_ALWAYS_SOFTWARE: "1"
         run: xvfb-run --auto-servernum npm test
 
       # Surface both backends' logs on every outcome so a failure is diagnosable

--- a/.github/workflows/tauri-webdriver.yml
+++ b/.github/workflows/tauri-webdriver.yml
@@ -28,6 +28,12 @@ permissions:
 jobs:
   webdriver:
     runs-on: ubuntu-latest
+    # The auto-launcher runs inside the Node server process; it tries to spawn
+    # Claude and is irrelevant to webview key-interception coverage. Disable it
+    # job-wide so neither the harness-started server nor any app-spawned sidecar
+    # runs it under CI.
+    env:
+      TANDEM_DISABLE_LAUNCHER: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -89,6 +95,24 @@ jobs:
       - name: Build Tauri debug binary
         run: cargo tauri build --debug --no-bundle
 
+      # A `--no-bundle` debug binary can't resolve `dist/server` (the `resources`
+      # aren't staged next to it), so it can't spawn its own Node sidecar and
+      # :3479 never comes up — the WebView then thrashes reconnecting and the
+      # WebDriver session destabilizes. Pre-start the server: the app's debug-only
+      # health-gate (src-tauri/src/lib.rs) sees :3479 healthy and skips its spawn,
+      # so the WebView connects to this one. `setsid` detaches it so it survives
+      # into the E2E step; output goes to a file we surface on failure.
+      - name: Start Tandem server (debug build reuses it via the health-gate)
+        run: |
+          setsid node dist/server/index.js > "$RUNNER_TEMP/tandem-server.log" 2>&1 &
+          for i in $(seq 1 60); do
+            curl -sf http://127.0.0.1:3479/health >/dev/null && { echo "server up"; exit 0; }
+            sleep 0.5
+          done
+          echo "server did not become healthy within 30s" >&2
+          cat "$RUNNER_TEMP/tandem-server.log" >&2
+          exit 1
+
       - name: Install harness dependencies
         working-directory: tests/tauri-driver
         run: npm install
@@ -99,3 +123,17 @@ jobs:
           # Binary already built above; don't rebuild inside onPrepare.
           TAURI_SKIP_BUILD: "1"
         run: xvfb-run --auto-servernum npm test
+
+      # Surface both backends' logs on every outcome so a failure is diagnosable
+      # without another blind ~10-min round. Both may be absent on an early crash
+      # (|| true keeps the always() steps green); an empty app log is NOT proof
+      # the app was healthy.
+      - name: Tandem server log
+        if: always()
+        run: cat "$RUNNER_TEMP/tandem-server.log" || true
+
+      - name: Tandem app log
+        if: always()
+        # Linux app_log_dir() = $HOME/.local/share/<bundle-id>/logs; file_name
+        # "tandem" → tandem.log (bundle id com.tandem.editor).
+        run: cat "$HOME/.local/share/com.tandem.editor/logs/tandem.log" || true

--- a/.github/workflows/tauri-webdriver.yml
+++ b/.github/workflows/tauri-webdriver.yml
@@ -2,13 +2,22 @@ name: Tauri WebDriver E2E
 
 # Webview-level key-interception coverage via tauri-driver (#560). Kept in a
 # separate workflow from ci.yml because it builds the full desktop binary and
-# runs a real WebView under xvfb — slower and heavier than the Playwright suite.
+# drives a real WebView — slower and heavier than the Playwright suite.
 #
-# Runs on Linux only: tauri-driver supports Linux (webkit2gtk-driver) and
-# Windows, but not macOS. Linux-under-xvfb is the cheapest reliable target.
+# Runs on WINDOWS (WebView2 + Microsoft Edge WebDriver). tauri-driver supports
+# Linux (WebKitGTK) and Windows (Edge), but NOT macOS. We deliberately target
+# Windows/WebView2 rather than Linux/WebKitGTK: WebKitGTK's WebDriver wedges on
+# native element/interaction commands (findElement, Actions/key injection) under
+# xvfb software rendering for a non-trivial app — `execute` works but
+# `findElement` hangs to the Mocha timeout and the session dies with
+# `hyper::Error(IncompleteMessage)`. Tauri's own maintainers call WebKitGTK
+# WebDriver "totally unstable". WebView2 is Chromium-backed, so native findElement
+# + key Actions are reliable — and the prevent-default plugin under test enforces
+# RELOAD via a platform-agnostic injected JS script (tauri-plugin-prevent-default
+# `assets/script.js`), so Windows coverage is equally valid (Tandem declares the
+# plugin with NO `platform-windows` feature, so there is no native-path divergence).
 
-# Runs on release tags + manual dispatch. tauri-driver needs the full desktop
-# binary + a real WebView under xvfb — too heavy to gate every PR (see #560 /
+# Runs on release tags + manual dispatch. Too heavy to gate every PR (see #560 /
 # batch scope-down decision), but cheap insurance on the handful of tag pushes:
 # it exercises webview-level key interception that the Playwright suite (real
 # browser, not the Tauri WebView) structurally cannot. Deliberately a separate
@@ -27,7 +36,7 @@ permissions:
 
 jobs:
   webdriver:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     # The auto-launcher runs inside the Node server process; it tries to spawn
     # Claude and is irrelevant to webview key-interception coverage. Disable it
     # job-wide so neither the harness-started server nor any app-spawned sidecar
@@ -38,20 +47,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Linux system dependencies
-        run: |
-          sudo apt-get update
-          # webkit2gtk-driver + xvfb are the WebDriver-specific additions on top
-          # of the standard Tauri build deps used elsewhere in CI.
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            patchelf \
-            libxdo-dev \
-            webkit2gtk-driver \
-            xvfb
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -85,13 +80,60 @@ jobs:
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version "^2" --locked
 
-      # No separate frontend build step: tauri.conf.json's
-      # `beforeBuildCommand: npm run build` produces the dist/client + dist/server
-      # bundles (the build resources tauri_build::build() checks) as part of the
-      # build below, so an explicit `npm run build` here would just build twice.
+      # WebView2 apps are driven by the Edge WebDriver matching the WebView2
+      # *Runtime* version — which on GitHub runners differs from the preinstalled
+      # Edge *browser* (and the runner's preinstalled msedgedriver matches the
+      # browser). A mismatch makes the WebDriver session HANG on connect (Tauri
+      # docs warn this). So: read the WebView2 Runtime version from the registry,
+      # resolve the matching Edge WebDriver for that major line, download it, and
+      # put it on PATH (tauri-driver auto-finds msedgedriver.exe on PATH — no
+      # --native-driver arg needed). Fail loudly at every step; never silently
+      # fall back to the browser-matched driver (that reintroduces the hang).
+      - name: Set up Edge WebDriver matching the WebView2 runtime
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # WebView2 Runtime version: HKLM (machine-wide, the runner default),
+          # falling back to HKCU (per-user install) before failing.
+          $guid = '{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}'
+          $pv = $null
+          foreach ($root in @(
+            'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients',
+            'HKCU:\SOFTWARE\Microsoft\EdgeUpdate\Clients'
+          )) {
+            try { $pv = (Get-ItemProperty "$root\$guid" -ErrorAction Stop).pv } catch {}
+            if ($pv) { break }
+          }
+          if (-not $pv) { throw 'Could not read WebView2 Runtime version from the registry' }
+          $major = $pv.Split('.')[0]
+          Write-Host "WebView2 Runtime: $pv (major $major)"
+
+          # Resolve the Edge WebDriver version for this major line. The
+          # LATEST_RELEASE_<major> file is a UTF-16 version string; strip BOM/CR
+          # by keeping only version characters. Edge/Chromium driver compat is
+          # by major version, so the latest in-major driver matches the runtime.
+          $relFile = "$env:RUNNER_TEMP\edge_latest_release"
+          Invoke-WebRequest "https://msedgedriver.microsoft.com/LATEST_RELEASE_$major" -OutFile $relFile -UseBasicParsing
+          $driverVersion = ([System.IO.File]::ReadAllText($relFile, [System.Text.Encoding]::Unicode) -replace '[^0-9.]', '')
+          if (-not $driverVersion) { throw "No Edge WebDriver published for major $major" }
+          Write-Host "Edge WebDriver: $driverVersion"
+
+          # Download + unzip; fail if the archive didn't yield the binary.
+          $zip = "$env:RUNNER_TEMP\edgedriver.zip"
+          $dir = "$env:RUNNER_TEMP\edgedriver"
+          Invoke-WebRequest "https://msedgedriver.microsoft.com/$driverVersion/edgedriver_win64.zip" -OutFile $zip -UseBasicParsing
+          Expand-Archive -Path $zip -DestinationPath $dir -Force
+          if (-not (Test-Path "$dir\msedgedriver.exe")) { throw "msedgedriver.exe missing after unzip" }
+
+          # Visible to SUBSEQUENT steps (the wdio run, where tauri-driver spawns).
+          Add-Content -Path $env:GITHUB_PATH -Value $dir
+          & "$dir\msedgedriver.exe" --version
+
       # `--debug` and `--no-bundle` are `tauri build` flags, so they must NOT sit
       # behind `--` (which forwards args to the underlying `cargo build`, where
-      # `--debug` is rejected: it is cargo's default, not an accepted flag).
+      # `--debug` is rejected: it is cargo's default, not an accepted flag). The
+      # beforeBuildCommand (`npm run build`) produces dist/client + dist/server.
+      # Output: src-tauri/target/debug/tandem-desktop.exe.
       - name: Build Tauri debug binary
         run: cargo tauri build --debug --no-bundle
 
@@ -99,50 +141,61 @@ jobs:
       # aren't staged next to it), so it can't spawn its own Node sidecar and
       # :3479 never comes up — the WebView then thrashes reconnecting and the
       # WebDriver session destabilizes. Pre-start the server: the app's debug-only
-      # health-gate (src-tauri/src/lib.rs) sees :3479 healthy and skips its spawn,
-      # so the WebView connects to this one. `setsid` detaches it so it survives
-      # into the E2E step; output goes to a file we surface on failure.
+      # health-gate (src-tauri/src/lib.rs ~1569, platform-neutral) sees :3479
+      # healthy and skips its spawn, so the WebView connects to this one.
+      # Start-Process detaches it so it survives into the E2E step; stdout/stderr
+      # go to separate files (Start-Process can't share one) we surface on failure.
       - name: Start Tandem server (debug build reuses it via the health-gate)
+        shell: pwsh
         run: |
-          setsid node dist/server/index.js > "$RUNNER_TEMP/tandem-server.log" 2>&1 &
-          for i in $(seq 1 60); do
-            curl -sf http://127.0.0.1:3479/health >/dev/null && { echo "server up"; exit 0; }
-            sleep 0.5
-          done
-          echo "server did not become healthy within 30s" >&2
-          cat "$RUNNER_TEMP/tandem-server.log" >&2
+          Start-Process node -ArgumentList 'dist/server/index.js' `
+            -RedirectStandardOutput "$env:RUNNER_TEMP\tandem-server.out.log" `
+            -RedirectStandardError  "$env:RUNNER_TEMP\tandem-server.err.log" `
+            -WindowStyle Hidden | Out-Null
+          $deadline = (Get-Date).AddSeconds(30)
+          while ((Get-Date) -lt $deadline) {
+            try {
+              if ((Invoke-WebRequest 'http://127.0.0.1:3479/health' -UseBasicParsing -TimeoutSec 5).StatusCode -eq 200) {
+                Write-Host 'server up'; exit 0
+              }
+            } catch {}
+            Start-Sleep -Milliseconds 500
+          }
+          Write-Host 'server did not become healthy within 30s'
+          Get-Content "$env:RUNNER_TEMP\tandem-server.err.log" -ErrorAction SilentlyContinue
           exit 1
 
       - name: Install harness dependencies
         working-directory: tests/tauri-driver
         run: npm install
 
-      - name: Run tauri-driver E2E (under xvfb)
+      # Re-check the pre-started server is still alive at test start: if it died
+      # between steps, fail fast with a clear signal instead of letting the
+      # WebView thrash-reconnect (which would look like a WebView/driver hang).
+      - name: Run tauri-driver E2E
         working-directory: tests/tauri-driver
+        shell: pwsh
         env:
           # Binary already built above; don't rebuild inside onPrepare.
           TAURI_SKIP_BUILD: "1"
-          # WebKitGTK defaults to GPU-accelerated compositing AND the DMA-BUF
-          # renderer; both fail with no GPU under xvfb (see the libEGL DRI3
-          # warnings) and crash the WebContent process — the editor shell never
-          # renders and the WebDriver session collapses. Force software rendering
-          # at both the WebKit layer (these two) and the GL stack (LIBGL_*, which
-          # is what emits the DRI3 probe failure). Standard headless-CI fix.
-          WEBKIT_DISABLE_COMPOSITING_MODE: "1"
-          WEBKIT_DISABLE_DMABUF_RENDERER: "1"
-          LIBGL_ALWAYS_SOFTWARE: "1"
-        run: xvfb-run --auto-servernum npm test
+        run: |
+          try { Invoke-WebRequest 'http://127.0.0.1:3479/health' -UseBasicParsing -TimeoutSec 5 | Out-Null }
+          catch { Write-Error 'Pre-started server is not healthy at test start'; exit 1 }
+          npm test
 
-      # Surface both backends' logs on every outcome so a failure is diagnosable
-      # without another blind ~10-min round. Both may be absent on an early crash
-      # (|| true keeps the always() steps green); an empty app log is NOT proof
-      # the app was healthy.
-      - name: Tandem server log
+      # Surface all logs on every outcome so a failure is diagnosable without
+      # another blind ~10-min round. Any may be absent on an early crash
+      # (SilentlyContinue keeps the always() step green); an empty app log is NOT
+      # proof the app was healthy.
+      - name: Dump logs
         if: always()
-        run: cat "$RUNNER_TEMP/tandem-server.log" || true
-
-      - name: Tandem app log
-        if: always()
-        # Linux app_log_dir() = $HOME/.local/share/<bundle-id>/logs; file_name
-        # "tandem" → tandem.log (bundle id com.tandem.editor).
-        run: cat "$HOME/.local/share/com.tandem.editor/logs/tandem.log" || true
+        shell: pwsh
+        run: |
+          Write-Host '=== server stdout ==='
+          Get-Content "$env:RUNNER_TEMP\tandem-server.out.log" -ErrorAction SilentlyContinue
+          Write-Host '=== server stderr ==='
+          Get-Content "$env:RUNNER_TEMP\tandem-server.err.log" -ErrorAction SilentlyContinue
+          # Windows app_log_dir() = %LOCALAPPDATA%\<bundle-id>\logs; file_name
+          # "tandem" -> tandem.log (bundle id com.tandem.editor).
+          Write-Host '=== app log ==='
+          Get-Content "$env:LOCALAPPDATA\com.tandem.editor\logs\tandem.log" -ErrorAction SilentlyContinue

--- a/.github/workflows/tauri-webdriver.yml
+++ b/.github/workflows/tauri-webdriver.yml
@@ -137,51 +137,68 @@ jobs:
       - name: Build Tauri debug binary
         run: cargo tauri build --debug --no-bundle
 
-      # A `--no-bundle` debug binary can't resolve `dist/server` (the `resources`
-      # aren't staged next to it), so it can't spawn its own Node sidecar and
-      # :3479 never comes up — the WebView then thrashes reconnecting and the
-      # WebDriver session destabilizes. Pre-start the server: the app's debug-only
-      # health-gate (src-tauri/src/lib.rs ~1569, platform-neutral) sees :3479
-      # healthy and skips its spawn, so the WebView connects to this one.
-      # Start-Process detaches it so it survives into the E2E step; stdout/stderr
-      # go to separate files (Start-Process can't share one) we surface on failure.
-      - name: Start Tandem server (debug build reuses it via the health-gate)
-        shell: pwsh
-        run: |
-          Start-Process node -ArgumentList 'dist/server/index.js' `
-            -RedirectStandardOutput "$env:RUNNER_TEMP\tandem-server.out.log" `
-            -RedirectStandardError  "$env:RUNNER_TEMP\tandem-server.err.log" `
-            -WindowStyle Hidden | Out-Null
-          $deadline = (Get-Date).AddSeconds(30)
-          while ((Get-Date) -lt $deadline) {
-            try {
-              if ((Invoke-WebRequest 'http://127.0.0.1:3479/health' -UseBasicParsing -TimeoutSec 5).StatusCode -eq 200) {
-                Write-Host 'server up'; exit 0
-              }
-            } catch {}
-            Start-Sleep -Milliseconds 500
-          }
-          Write-Host 'server did not become healthy within 30s'
-          Get-Content "$env:RUNNER_TEMP\tandem-server.err.log" -ErrorAction SilentlyContinue
-          exit 1
-
       - name: Install harness dependencies
         working-directory: tests/tauri-driver
         run: npm install
 
-      # Re-check the pre-started server is still alive at test start: if it died
-      # between steps, fail fast with a clear signal instead of letting the
-      # WebView thrash-reconnect (which would look like a WebView/driver hang).
-      - name: Run tauri-driver E2E
-        working-directory: tests/tauri-driver
+      # A `--no-bundle` debug binary can't resolve `dist/server` (the `resources`
+      # aren't staged next to it), so it can't spawn its own Node sidecar and
+      # :3479 never comes up — the WebView then thrashes reconnecting and the
+      # WebDriver session destabilizes. So pre-start the server: the app's
+      # debug-only health-gate (src-tauri/src/lib.rs ~1569, platform-neutral) sees
+      # :3479 healthy and skips its spawn, so the WebView connects to this one.
+      #
+      # The server is started INSIDE this step (not a prior one): a detached node
+      # spawned in an earlier step is reaped by the runner's per-step process-tree
+      # cleanup before the test runs — the first Windows run proved it (clean
+      # startup banner, went healthy, then vanished with no crash/shutdown trace).
+      # Started here it lives for exactly the test's lifetime; the `finally` stops
+      # it and runner cleanup reaps it when the step ends. The step runs from the
+      # repo root (no `working-directory`) so node resolves `dist/server/index.js`
+      # + `dist/client` against the right cwd; `npm test` runs under Push-Location.
+      # stdout/stderr go to separate files (Start-Process can't share one) that the
+      # always() "Dump logs" step surfaces.
+      - name: Run tauri-driver E2E (server started in-step so it survives to the test)
         shell: pwsh
         env:
           # Binary already built above; don't rebuild inside onPrepare.
           TAURI_SKIP_BUILD: "1"
         run: |
-          try { Invoke-WebRequest 'http://127.0.0.1:3479/health' -UseBasicParsing -TimeoutSec 5 | Out-Null }
-          catch { Write-Error 'Pre-started server is not healthy at test start'; exit 1 }
-          npm test
+          $ErrorActionPreference = 'Stop'
+          $serverOut = "$env:RUNNER_TEMP\tandem-server.out.log"
+          $serverErr = "$env:RUNNER_TEMP\tandem-server.err.log"
+          $server = Start-Process node -ArgumentList 'dist/server/index.js' `
+            -RedirectStandardOutput $serverOut `
+            -RedirectStandardError  $serverErr `
+            -WindowStyle Hidden -PassThru
+          $code = 1
+          try {
+            $deadline = (Get-Date).AddSeconds(30)
+            $healthy = $false
+            while ((Get-Date) -lt $deadline) {
+              try {
+                if ((Invoke-WebRequest 'http://127.0.0.1:3479/health' -UseBasicParsing -TimeoutSec 5).StatusCode -eq 200) {
+                  $healthy = $true; break
+                }
+              } catch {}
+              Start-Sleep -Milliseconds 500
+            }
+            if (-not $healthy) {
+              Write-Host 'server did not become healthy within 30s'
+              Get-Content $serverErr -ErrorAction SilentlyContinue
+            } else {
+              Write-Host 'server up'
+              Push-Location tests/tauri-driver
+              npm test
+              $code = $LASTEXITCODE
+              Pop-Location
+            }
+          } finally {
+            if ($server -and -not $server.HasExited) {
+              Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+            }
+          }
+          exit $code
 
       # Surface all logs on every outcome so a failure is diagnosable without
       # another blind ~10-min round. Any may be absent on an early crash

--- a/docs/release-smoke-checklist.md
+++ b/docs/release-smoke-checklist.md
@@ -13,7 +13,7 @@ matrix across OS versions, observer soak, accessibility) live in
 ## 0. CI signal (before touching hardware)
 
 - [ ] `tauri-release.yml` — every matrix build green, `release-check` summary green, artifacts + `latest.json` on the GitHub Release.
-- [ ] `tauri-webdriver.yml` — the tag-triggered run is green (webview-level key-interception E2E on Linux). A failure here doesn't block artifact publishing — it's a signal to investigate **before announcing** the release.
+- [ ] `tauri-webdriver.yml` — the tag-triggered run is green (webview-level key-interception E2E on Windows/WebView2). A failure here doesn't block artifact publishing — it's a signal to investigate **before announcing** the release.
 - [ ] CHANGELOG section for the version is final (the in-app View Changelog button serves this file).
 
 ## 1. Windows (10 22H2 or 11)

--- a/tests/tauri-driver/README.md
+++ b/tests/tauri-driver/README.md
@@ -14,10 +14,31 @@ context menu accessible.
 
 The Rust regression test `src-tauri/tests/prevent_default.rs` asserts the
 **flag value** but cannot prove the plugin actually intercepts keystrokes in a
-live WebView — its own comment documents the limitation. In particular, dropping
-`.with_flags(prevent_default_flags())` from the builder in `lib.rs` would still
-pass the Rust test. This harness closes that gap: it drives the real built
-binary and asserts that a reload shortcut does **not** reload the WebView.
+live WebView — its own comment documents the limitation. This harness closes
+that gap: it drives the real built binary and verifies the plugin's keydown
+listener actually fires `preventDefault()` on a reload shortcut.
+
+**How it discriminates (the non-obvious part).** The intuitive test — fire
+Ctrl+R, assert the page did not reload — is a **tautology** under WebDriver: a
+`browser.keys` Ctrl+R reaches page DOM listeners but does **not** drive WebView2's
+browser-chrome reload accelerator, so the page never reloads whether or not the
+plugin intercepts (proven on CI: a "did it reload?" sentinel test passed even
+with interception forced off). So the harness observes the **cause**, not the
+effect: it installs its own bubble-phase `window` keydown listener *after* the
+plugin's and reads `event.defaultPrevented`. With `Flags::RELOAD`, Ctrl+R/F5 come
+back `prevented: true`; force `.with_flags(Flags::empty())` and they flip to
+`prevented: false` and the specs go red — empirically verified both directions. A
+`fired` flag guards that the synthetic key reached the page at all, so a spec
+fails loudly instead of passing vacuously.
+
+**What it does and doesn't catch.** It catches reload interception being
+*disabled* — `prevent_default_flags()` losing `RELOAD`, the plugin being removed,
+or an explicit `Flags::empty()`. Note it does **not** flag merely dropping
+`.with_flags(prevent_default_flags())`: the builder falls back to
+`Flags::default() == Flags::all()`, which still contains `RELOAD` (it would
+instead over-block DevTools / context menu — a different regression). The
+reload-specific "does NOT intercept an ordinary key" control guards that
+direction.
 
 ## Platform support
 

--- a/tests/tauri-driver/README.md
+++ b/tests/tauri-driver/README.md
@@ -21,23 +21,41 @@ binary and asserts that a reload shortcut does **not** reload the WebView.
 
 ## Platform support
 
-| OS      | Status        | WebView driver                     |
-| ------- | ------------- | ---------------------------------- |
-| Linux   | ✅ supported  | `webkit2gtk-driver` (under `xvfb`) |
-| Windows | ✅ supported  | Edge WebDriver (auto-managed)      |
-| macOS   | ❌ unsupported | no WKWebView WebDriver exists      |
+| OS      | Status                | WebView driver                          |
+| ------- | --------------------- | --------------------------------------- |
+| Windows | ✅ supported (CI)     | Microsoft Edge WebDriver (WebView2)     |
+| Linux   | ⚠️ local-only         | `webkit2gtk-driver` (under `xvfb`)      |
+| macOS   | ❌ unsupported        | no WKWebView WebDriver exists           |
 
-CI runs this on Linux under `xvfb` (`.github/workflows/tauri-webdriver.yml`).
-It is intentionally **not** part of the default `npm run test:e2e` Playwright
-run, which exercises the browser frontend, not the Tauri shell.
+CI runs this on **Windows/WebView2** (`.github/workflows/tauri-webdriver.yml`).
+We moved off Linux/WebKitGTK because its WebDriver wedges on native element/key
+commands (`findElement`, Actions) under headless `xvfb` for a non-trivial app —
+`execute` works but `findElement` hangs to the Mocha timeout and the session
+dies (`hyper::Error(IncompleteMessage)`). Chromium-backed WebView2 drives those
+commands reliably. The plugin under test enforces RELOAD via a platform-agnostic
+injected JS script, so Windows coverage is equally valid. The Linux config still
+works locally under `xvfb` for quick checks; it is no longer the CI target.
+
+CI pre-starts the Node server (`node dist/server/index.js`) and the `--no-bundle`
+debug binary reuses it via the app's debug health-gate, so the harness does not
+exercise the app's own sidecar-spawn path — an acceptable trade for #560's
+webview-key-interception purpose. It is intentionally **not** part of the default
+`npm run test:e2e` Playwright run, which exercises the browser frontend.
 
 ## Prerequisites
 
-1. **Rust toolchain + Tauri system deps.** On Linux:
-   ```sh
-   sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
-     librsvg2-dev patchelf libxdo-dev webkit2gtk-driver xvfb
-   ```
+1. **Rust toolchain + Tauri system deps.**
+   - **Windows (the CI target):** the WebView2 Runtime ships with Windows. You
+     need a `msedgedriver.exe` whose version matches the **WebView2 Runtime**
+     (not necessarily the Edge browser) on `PATH` — the CI workflow reads the
+     runtime version from the registry and downloads the matching driver; locally,
+     install a matching Edge WebDriver and put it on `PATH` (tauri-driver
+     auto-finds it; or pass `--native-driver`).
+   - **Linux (local only):**
+     ```sh
+     sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+       librsvg2-dev patchelf libxdo-dev webkit2gtk-driver xvfb
+     ```
 2. **`tauri-driver`:**
    ```sh
    cargo install tauri-driver --locked
@@ -62,12 +80,12 @@ From `tests/tauri-driver/`:
 npm test
 ```
 
-This builds the debug desktop binary (`cargo tauri build -- --debug --no-bundle`),
+This builds the debug desktop binary (`cargo tauri build --debug --no-bundle`),
 starts `tauri-driver`, launches the app, and runs the specs. To skip the build
-and reuse an existing `src-tauri/target/debug/Tandem[.exe]`, set
+and reuse an existing `src-tauri/target/debug/tandem-desktop[.exe]`, set
 `TAURI_SKIP_BUILD=1`.
 
-On Linux, wrap with a virtual display:
+On Linux (local only), wrap with a virtual display:
 
 ```sh
 xvfb-run npm test

--- a/tests/tauri-driver/specs/prevent-default.e2e.ts
+++ b/tests/tauri-driver/specs/prevent-default.e2e.ts
@@ -2,27 +2,66 @@
 //
 // `prevent_default_flags()` returns `Flags::RELOAD`, so the plugin must swallow
 // the browser reload shortcuts (Ctrl+R, F5, ...) inside the Tauri WebView while
-// leaving everything else — DevTools, Find, Print, context menu — untouched.
+// leaving ordinary keys untouched. The Rust unit test
+// (`src-tauri/tests/prevent_default.rs`) only checks the flag *value*; it cannot
+// prove the plugin actually intercepts a keystroke in a live WebView.
 //
-// The Rust unit test (`src-tauri/tests/prevent_default.rs`) only checks the flag
-// value. This spec proves the *behavior*: it stamps a sentinel on `window`,
-// fires a reload shortcut, and asserts the sentinel survives. If the plugin
-// stopped intercepting reloads (e.g. `with_flags(...)` was dropped from the
-// builder), the WebView would reload, wipe the sentinel, and this test would
-// fail — the exact regression the Rust test cannot catch.
+// HOW THIS DISCRIMINATES (and why the obvious approach does NOT):
+// The intuitive test — fire Ctrl+R and assert the page did not reload — is a
+// TAUTOLOGY here. A WebDriver-injected Ctrl+R (`browser.keys`) reaches page DOM
+// listeners but does NOT drive WebView2's browser-chrome reload accelerator, so
+// the page never reloads whether or not the plugin intercepts. Proven on real
+// CI: with interception forced OFF (`.with_flags(Flags::empty())`, confirmed
+// compiled), a "did the page reload?" sentinel test still passed. So we cannot
+// observe the *effect* (a reload) — we observe the *cause* directly instead.
+//
+// The plugin injects a bubble-phase `window` keydown listener at page load
+// (tauri-plugin-prevent-default `assets/script.js`) that calls `preventDefault()`
+// for each registered shortcut. We install our OWN bubble-phase `window` listener
+// at test time — registered AFTER the plugin's, so within the same event dispatch
+// it runs later and observes `e.defaultPrevented`. Then:
+//   • Flags::RELOAD  → plugin prevents Ctrl+R → our probe sees prevented === true
+//   • Flags::empty   → plugin's shortcut map is empty → prevented === false  (RED)
+// `fired` (our listener ran at all) proves the synthetic key reached page DOM
+// listeners — the prerequisite that makes the whole approach valid; if it were
+// ever false the spec fails loudly instead of vacuously passing.
+//
+// Tandem declares the plugin with no `platform-windows` feature, so there is no
+// native interception path — the injected JS listener is the only mechanism, and
+// it is identical across WebView2 and WebKitGTK. There is no app-level Ctrl+R/F5
+// handler in the client, so the plugin's listener is the only thing that calls
+// preventDefault on these combos — which is exactly what makes `prevented`
+// discriminate a dropped/empty flag set.
 
-const SENTINEL = "__tandem_prevent_default_sentinel__";
+interface KeyProbe {
+  /** Our listener ran → the synthetic key reached page DOM listeners. */
+  fired: boolean;
+  /** A listener earlier in the dispatch (the plugin) called preventDefault. */
+  prevented: boolean;
+}
 
-/** Stamp a fresh sentinel value on `window` and return it. */
-async function stampSentinel(): Promise<number> {
+/**
+ * Fire a key combo and report whether its terminal keydown reached the page and
+ * whether the plugin's listener prevented its default.
+ *
+ * `matchKey` is the combo's terminal key (e.g. "r", "F5", "a") — the modifier
+ * keydowns in the combo (Control) are ignored so they don't register a spurious
+ * result. `requireCtrl` additionally demands `ctrlKey` so a bare "r" can't match
+ * the Ctrl+R probe. Match criteria are passed as plain data (not a serialized
+ * function) to keep the injected script free of dynamic code evaluation.
+ */
+async function probeKey(
+  keys: string[],
+  matchKey: string,
+  requireCtrl: boolean,
+): Promise<KeyProbe> {
   // Self-gate: these specs only discriminate on the live Tandem app. The
   // WebDriver session starts on about:blank (the `before` diagnostic captures
-  // that), and a reload shortcut fired at a static blank page trivially leaves
-  // any sentinel intact — a vacuous pass that would survive even a dropped
-  // `with_flags(...)`. The "renders the editor shell" spec already waits for the
-  // app to mount, but that is an ordering dependency between sibling specs;
-  // assert the precondition here so each sentinel spec is self-sufficient and
-  // can't silently no-op if the specs are reordered or that anchor is weakened.
+  // that); a key fired at a static blank page has no plugin listener, so a vacuous
+  // "not prevented" could masquerade as a result. The "renders the editor shell"
+  // spec already waits for the app to mount, but that is an ordering dependency
+  // between sibling specs — assert the precondition here so each spec is
+  // self-sufficient and can't silently no-op if reordered or that anchor weakens.
   const onRealApp = await browser.execute(
     () =>
       location.href !== "about:blank" &&
@@ -30,29 +69,42 @@ async function stampSentinel(): Promise<number> {
   );
   expect(onRealApp).toBe(true);
 
-  const value = Date.now();
+  // Install a fresh probe listener. Bubble phase on `window`, registered now
+  // (after the plugin's page-load listener), so it observes a defaultPrevented
+  // set earlier in the same dispatch. Remove any prior probe first so exactly one
+  // is live (can't use `{ once: true }`: it would auto-remove on the combo's
+  // leading Control keydown, before the terminal key arrives).
   await browser.execute(
-    (key: string, v: number) => {
-      (window as unknown as Record<string, number>)[key] = v;
+    (mk: string, needCtrl: boolean) => {
+      const w = window as unknown as Record<string, unknown>;
+      const prior = w.__tandemKeyProbeHandler as EventListener | undefined;
+      if (prior) window.removeEventListener("keydown", prior);
+      w.__tandemKeyProbe = { fired: false, prevented: false };
+      const handler = (e: KeyboardEvent) => {
+        if (e.key.toLowerCase() === mk.toLowerCase() && (!needCtrl || e.ctrlKey)) {
+          w.__tandemKeyProbe = { fired: true, prevented: e.defaultPrevented };
+        }
+      };
+      w.__tandemKeyProbeHandler = handler;
+      window.addEventListener("keydown", handler);
     },
-    SENTINEL,
-    value,
+    matchKey,
+    requireCtrl,
   );
-  return value;
-}
 
-/** Read the sentinel back; `undefined` means the page reloaded and lost it. */
-function readSentinel(): Promise<number | undefined> {
+  await browser.execute(() => document.body?.focus());
+  await browser.keys(keys);
+  await browser.pause(300);
+
   return browser.execute(
-    (key: string) => (window as unknown as Record<string, number | undefined>)[key],
-    SENTINEL,
+    () => (window as unknown as Record<string, KeyProbe>).__tandemKeyProbe,
   );
 }
 
 describe("prevent-default reload interception", () => {
   before(async () => {
-    // The desktop shell loads the editor frontend. Wait for the document body
-    // to be present so keystrokes land on a real, focused WebView.
+    // The desktop shell loads the editor frontend. Wait for readyState complete
+    // so keystrokes land on a real WebView.
     await browser.waitUntil(
       async () => (await browser.execute(() => document.readyState)) === "complete",
       { timeout: 30_000, timeoutMsg: "WebView never reached readyState=complete" },
@@ -88,17 +140,7 @@ describe("prevent-default reload interception", () => {
     // NOTE: an earlier async `fetch('/api/info')` probe here destabilized the
     // session — the async executeScript round-trip collapsed the WebDriver
     // connection and timed out the hook. The sync snapshot above is a pure DOM
-    // read (no await, no network), so it stays. The reload-interception specs
-    // need only the live WebView, not the backend: the prevent-default plugin
-    // enforces RELOAD via a platform-agnostic injected JS keydown listener
-    // (tauri-plugin-prevent-default `assets/script.js`) that calls
-    // `preventDefault()` — Tandem declares the plugin with no `platform-windows`
-    // feature, so there is no native interception path and the behavior is
-    // identical across WebView2 and WebKitGTK. There is no app-level Ctrl+R/F5
-    // handler in the client, so the plugin's listener is the only thing standing
-    // between a native reload shortcut and an actual document reload — which is
-    // exactly what makes the sentinel assertions below discriminate a dropped
-    // `with_flags(...)`.
+    // read (no await, no network), so it stays.
   });
 
   it("renders the editor shell in the WebView", async () => {
@@ -108,47 +150,29 @@ describe("prevent-default reload interception", () => {
     await titleBar.waitForExist({ timeout: 20_000 });
   });
 
-  it("swallows Ctrl+R so the WebView does not reload", async () => {
-    const stamped = await stampSentinel();
-    // Land keystrokes on the document, not on a detached element.
-    await browser.execute(() => document.body?.focus());
-
-    // Ctrl+R is a RELOAD shortcut → the plugin must preventDefault it.
-    await browser.keys(["Control", "r"]);
-
-    // Give a real reload time to happen if interception had failed.
-    await browser.pause(1_000);
-
-    const after = await readSentinel();
-    expect(after).toBe(stamped); // survived → no reload → interception worked
+  it("intercepts Ctrl+R (the plugin calls preventDefault)", async () => {
+    const probe = await probeKey(["Control", "r"], "r", true);
+    // fired proves the synthetic key reached page listeners (the approach is
+    // valid); prevented proves the plugin's RELOAD listener actually intercepted.
+    // With `with_flags(Flags::empty())` this flips to prevented:false → RED.
+    expect(probe.fired).toBe(true);
+    expect(probe.prevented).toBe(true);
   });
 
-  it("swallows F5 so the WebView does not reload", async () => {
-    const stamped = await stampSentinel();
-
-    await browser.keys(["F5"]);
-    await browser.pause(1_000);
-
-    const after = await readSentinel();
-    expect(after).toBe(stamped);
+  it("intercepts F5 (the plugin calls preventDefault)", async () => {
+    const probe = await probeKey(["F5"], "F5", false);
+    expect(probe.fired).toBe(true);
+    expect(probe.prevented).toBe(true);
   });
 
-  it("stays alive after an ordinary key (liveness smoke check, not a discrimination proof)", async () => {
-    // HONEST SCOPE: this only asserts the WebView is still alive and did not
-    // reload after a benign key — it does NOT prove interception is "reload-only
-    // and not too-broad". A too-broad flag bag that swallowed *every* key would
-    // also leave the sentinel intact, so this passes in both the correct and the
-    // over-broad state. We can't observe a global preventDefault directly via
-    // WebDriver. TODO(#560): to make this a real discriminating control, give the
-    // benign key an observable side effect (e.g. focus the `find-input` testid,
-    // type into it, and assert its value changed — proving the key reached the
-    // page and was NOT swallowed).
-    const stamped = await stampSentinel();
-
-    await browser.keys(["a"]);
-    await browser.pause(250);
-
-    const after = await readSentinel();
-    expect(after).toBe(stamped);
+  it("does NOT intercept an ordinary key (interception is reload-specific, not over-broad)", async () => {
+    // A real discrimination control: "a" is not a registered shortcut, so the
+    // plugin must leave it alone. `fired:true` re-proves key delivery; an
+    // over-broad flag bag that swallowed everything would set prevented:true and
+    // fail this — the asymmetry vs. the Ctrl+R/F5 specs is what proves the
+    // interception is scoped to reload shortcuts, not blanket key-swallowing.
+    const probe = await probeKey(["a"], "a", false);
+    expect(probe.fired).toBe(true);
+    expect(probe.prevented).toBe(false);
   });
 });

--- a/tests/tauri-driver/specs/prevent-default.e2e.ts
+++ b/tests/tauri-driver/specs/prevent-default.e2e.ts
@@ -42,6 +42,51 @@ describe("prevent-default reload interception", () => {
       async () => (await browser.execute(() => document.readyState)) === "complete",
       { timeout: 30_000, timeoutMsg: "WebView never reached readyState=complete" },
     );
+
+    // Diagnostic snapshot: this harness has never run green, so make it explain
+    // itself. Capture what the WebView actually rendered (did the Svelte app
+    // mount? is the title-bar present?) before any assertion. Synchronous DOM
+    // read — no network — so it returns even if the app is busy reconnecting.
+    try {
+      const snapshot = await browser.execute(() => {
+        const ids = Array.from(document.querySelectorAll("[data-testid]"))
+          .map((el) => el.getAttribute("data-testid"))
+          .slice(0, 40);
+        return {
+          title: document.title,
+          url: location.href,
+          hasTauriInternals:
+            typeof (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ !==
+            "undefined",
+          testidCount: document.querySelectorAll("[data-testid]").length,
+          testids: ids,
+          bodyTextHead: (document.body?.innerText ?? "").slice(0, 400),
+        };
+      });
+      console.log("[harness-diag] WebView snapshot:", JSON.stringify(snapshot));
+    } catch (e) {
+      console.log("[harness-diag] snapshot failed:", String(e));
+    }
+
+    // Probe whether the Node sidecar (:3479) the desktop app is supposed to
+    // spawn is actually reachable from the WebView origin. If this fails, the
+    // app can't connect and will sit reconnecting — the likely cause of a
+    // missing/late editor shell.
+    try {
+      const probe = await browser.execute(async () => {
+        try {
+          const r = await fetch("http://127.0.0.1:3479/api/info", {
+            signal: AbortSignal.timeout(3000),
+          });
+          return { ok: r.ok, status: r.status };
+        } catch (err) {
+          return { error: String(err) };
+        }
+      });
+      console.log("[harness-diag] /api/info probe:", JSON.stringify(probe));
+    } catch (e) {
+      console.log("[harness-diag] probe failed:", String(e));
+    }
   });
 
   it("renders the editor shell in the WebView", async () => {

--- a/tests/tauri-driver/specs/prevent-default.e2e.ts
+++ b/tests/tauri-driver/specs/prevent-default.e2e.ts
@@ -165,12 +165,15 @@ describe("prevent-default reload interception", () => {
     expect(probe.prevented).toBe(true);
   });
 
-  it("does NOT intercept an ordinary key (interception is reload-specific, not over-broad)", async () => {
-    // A real discrimination control: "a" is not a registered shortcut, so the
-    // plugin must leave it alone. `fired:true` re-proves key delivery; an
-    // over-broad flag bag that swallowed everything would set prevented:true and
-    // fail this — the asymmetry vs. the Ctrl+R/F5 specs is what proves the
-    // interception is scoped to reload shortcuts, not blanket key-swallowing.
+  it("does NOT intercept an ordinary key (not blanket key-swallowing)", async () => {
+    // Control with a deliberately SCOPED claim: "a" is in no `Flags` variant's
+    // accelerator set, so this guards only against a degenerate handler that
+    // preventDefaults *every* key — `prevented:true` here would mean blanket
+    // swallowing. It does NOT detect flag-set WIDENING (e.g. RELOAD →
+    // RELOAD|CONTEXT_MENU): those add accelerators that still aren't "a". That
+    // direction is covered by the Rust test (`src-tauri/tests/prevent_default.rs`
+    // asserts the flag bag is exactly `Flags::RELOAD`), so this spec doesn't
+    // duplicate it. `fired:true` also re-proves key delivery on a benign key.
     const probe = await probeKey(["a"], "a", false);
     expect(probe.fired).toBe(true);
     expect(probe.prevented).toBe(false);

--- a/tests/tauri-driver/specs/prevent-default.e2e.ts
+++ b/tests/tauri-driver/specs/prevent-default.e2e.ts
@@ -69,11 +69,18 @@ describe("prevent-default reload interception", () => {
     }
     // NOTE: an earlier async `fetch('/api/info')` probe here destabilized the
     // session — the async executeScript round-trip collapsed the WebDriver
-    // connection (UND_ERR_SOCKET) and timed out the hook. The sync snapshot
-    // above already shows whether the shell mounted; the app's own
-    // "Disconnected" banner (Linux WebView origin `tauri://localhost` is not in
-    // the server CORS allowlist) is a separate, non-blocking finding. The
-    // reload-interception specs need only the live WebView, not the backend.
+    // connection and timed out the hook. The sync snapshot above is a pure DOM
+    // read (no await, no network), so it stays. The reload-interception specs
+    // need only the live WebView, not the backend: the prevent-default plugin
+    // enforces RELOAD via a platform-agnostic injected JS keydown listener
+    // (tauri-plugin-prevent-default `assets/script.js`) that calls
+    // `preventDefault()` — Tandem declares the plugin with no `platform-windows`
+    // feature, so there is no native interception path and the behavior is
+    // identical across WebView2 and WebKitGTK. There is no app-level Ctrl+R/F5
+    // handler in the client, so the plugin's listener is the only thing standing
+    // between a native reload shortcut and an actual document reload — which is
+    // exactly what makes the sentinel assertions below discriminate a dropped
+    // `with_flags(...)`.
   });
 
   it("renders the editor shell in the WebView", async () => {

--- a/tests/tauri-driver/specs/prevent-default.e2e.ts
+++ b/tests/tauri-driver/specs/prevent-default.e2e.ts
@@ -67,26 +67,13 @@ describe("prevent-default reload interception", () => {
     } catch (e) {
       console.log("[harness-diag] snapshot failed:", String(e));
     }
-
-    // Probe whether the Node sidecar (:3479) the desktop app is supposed to
-    // spawn is actually reachable from the WebView origin. If this fails, the
-    // app can't connect and will sit reconnecting — the likely cause of a
-    // missing/late editor shell.
-    try {
-      const probe = await browser.execute(async () => {
-        try {
-          const r = await fetch("http://127.0.0.1:3479/api/info", {
-            signal: AbortSignal.timeout(3000),
-          });
-          return { ok: r.ok, status: r.status };
-        } catch (err) {
-          return { error: String(err) };
-        }
-      });
-      console.log("[harness-diag] /api/info probe:", JSON.stringify(probe));
-    } catch (e) {
-      console.log("[harness-diag] probe failed:", String(e));
-    }
+    // NOTE: an earlier async `fetch('/api/info')` probe here destabilized the
+    // session — the async executeScript round-trip collapsed the WebDriver
+    // connection (UND_ERR_SOCKET) and timed out the hook. The sync snapshot
+    // above already shows whether the shell mounted; the app's own
+    // "Disconnected" banner (Linux WebView origin `tauri://localhost` is not in
+    // the server CORS allowlist) is a separate, non-blocking finding. The
+    // reload-interception specs need only the live WebView, not the backend.
   });
 
   it("renders the editor shell in the WebView", async () => {

--- a/tests/tauri-driver/specs/prevent-default.e2e.ts
+++ b/tests/tauri-driver/specs/prevent-default.e2e.ts
@@ -15,6 +15,21 @@ const SENTINEL = "__tandem_prevent_default_sentinel__";
 
 /** Stamp a fresh sentinel value on `window` and return it. */
 async function stampSentinel(): Promise<number> {
+  // Self-gate: these specs only discriminate on the live Tandem app. The
+  // WebDriver session starts on about:blank (the `before` diagnostic captures
+  // that), and a reload shortcut fired at a static blank page trivially leaves
+  // any sentinel intact — a vacuous pass that would survive even a dropped
+  // `with_flags(...)`. The "renders the editor shell" spec already waits for the
+  // app to mount, but that is an ordering dependency between sibling specs;
+  // assert the precondition here so each sentinel spec is self-sufficient and
+  // can't silently no-op if the specs are reordered or that anchor is weakened.
+  const onRealApp = await browser.execute(
+    () =>
+      location.href !== "about:blank" &&
+      !!document.querySelector('[data-testid="title-bar"]'),
+  );
+  expect(onRealApp).toBe(true);
+
   const value = Date.now();
   await browser.execute(
     (key: string, v: number) => {
@@ -43,10 +58,13 @@ describe("prevent-default reload interception", () => {
       { timeout: 30_000, timeoutMsg: "WebView never reached readyState=complete" },
     );
 
-    // Diagnostic snapshot: this harness has never run green, so make it explain
-    // itself. Capture what the WebView actually rendered (did the Svelte app
-    // mount? is the title-bar present?) before any assertion. Synchronous DOM
-    // read — no network — so it returns even if the app is busy reconnecting.
+    // Diagnostic snapshot for failure triage: dump the WebView's DOM state at
+    // the top of the hook. NOTE: this fires PRE-navigation — readyState reaches
+    // "complete" on the initial about:blank before the Tandem frontend loads, so
+    // the snapshot typically shows url:about:blank / testidCount:0. It is NOT
+    // proof the app mounted (the "renders the editor shell" spec's title-bar
+    // waitForExist is); it just makes a failed run explain what the session saw.
+    // Synchronous DOM read — no network — so it returns even mid-reconnect.
     try {
       const snapshot = await browser.execute(() => {
         const ids = Array.from(document.querySelectorAll("[data-testid]"))

--- a/tests/tauri-driver/wdio.conf.ts
+++ b/tests/tauri-driver/wdio.conf.ts
@@ -10,8 +10,10 @@
 //
 // Platform support: `tauri-driver` works on Linux (webkit2gtk-driver) and
 // Windows (Edge WebDriver). macOS has no WKWebView WebDriver and is
-// unsupported — the harness is skipped there. CI runs it on Linux under xvfb
-// (see `.github/workflows/tauri-webdriver.yml`).
+// unsupported — the harness is skipped there. CI runs it on Windows/WebView2
+// (see `.github/workflows/tauri-webdriver.yml`): WebKitGTK's WebDriver wedges
+// on native element/key commands under headless xvfb, whereas Chromium-backed
+// WebView2 drives them reliably.
 //
 // This file is intentionally NOT wired into `npm run typecheck` (the project
 // tsconfigs scope to `src/`) because the WebdriverIO type packages are only
@@ -62,13 +64,21 @@ export const config: WebdriverIO.Config = {
   capabilities: [
     {
       // `tauri:options` is consumed by tauri-driver, which forwards the rest of
-      // the session to the platform's native WebView driver (WebKitWebDriver on
-      // Linux). Per the official Tauri v2 WebdriverIO example, the client sets NO
-      // `browserName`: WebKitWebDriver offers no browser named "wry", so supplying
-      // it fails W3C capability matching ("Failed to match capabilities"). tauri-
-      // driver reports the browser as "wry" itself once the session is created.
+      // the session to the platform's native WebView driver (Microsoft Edge
+      // WebDriver / msedgedriver on Windows). Per the official Tauri v2
+      // WebdriverIO example, the client sets NO `browserName`: the native driver
+      // offers no browser named "wry", so supplying it fails W3C capability
+      // matching; tauri-driver reports the browser as "wry" itself after the
+      // session is created. If a "session not created: Failed to match
+      // capabilities" error ever appears, the documented fix is to add
+      // `browserName: "wry"` here.
+      //
+      // `webviewOptions: {}` is required by the working Windows WebView2 example
+      // for capability matching. `application` is an absolute path (below) to
+      // avoid the "no msedge binary at <path>" cwd-resolution bug on Windows.
       "tauri:options": {
         application,
+        webviewOptions: {},
       },
     } as WebdriverIO.Capabilities,
   ],
@@ -89,12 +99,15 @@ export const config: WebdriverIO.Config = {
       if (!existsSync(application)) {
         throw new Error(
           `TAURI_SKIP_BUILD=1 but the debug binary is missing at ${application}. ` +
-            `Build it first with: cargo tauri build -- --debug --no-bundle`,
+            `Build it first with: cargo tauri build --debug --no-bundle`,
         );
       }
       return;
     }
-    const result = spawnSync("cargo", ["tauri", "build", "--", "--debug", "--no-bundle"], {
+    // `--debug`/`--no-bundle` are `tauri build` flags — they must NOT go behind
+    // `--` (which forwards to `cargo build`, where `--debug` is rejected). Matches
+    // the CI workflow's invocation.
+    const result = spawnSync("cargo", ["tauri", "build", "--debug", "--no-bundle"], {
       cwd: repoRoot,
       stdio: "inherit",
     });

--- a/tests/tauri-driver/wdio.conf.ts
+++ b/tests/tauri-driver/wdio.conf.ts
@@ -4,9 +4,11 @@
 // `src-tauri/tests/prevent_default.rs` asserts the *flag bag* returned by
 // `prevent_default_flags()` but cannot prove the plugin actually intercepts
 // keystrokes inside the live Tauri WebView. This harness drives the real
-// built desktop binary through `tauri-driver` so reload-shortcut interception
-// is covered end-to-end, and so a regression that removes `with_flags(...)`
-// from the builder (which the Rust test cannot catch) is caught here.
+// built desktop binary through `tauri-driver` and verifies the plugin's keydown
+// listener fires `preventDefault()` on a reload shortcut — so a regression that
+// disables reload interception (e.g. `prevent_default_flags()` losing `RELOAD`,
+// or the plugin being dropped) is caught here. See specs/prevent-default.e2e.ts
+// for why it observes `defaultPrevented` rather than an actual page reload.
 //
 // Platform support: `tauri-driver` works on Linux (webkit2gtk-driver) and
 // Windows (Edge WebDriver). macOS has no WKWebView WebDriver and is

--- a/tests/tauri-driver/wdio.conf.ts
+++ b/tests/tauri-driver/wdio.conf.ts
@@ -33,7 +33,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(dirname, "..", "..");
 
 // The built debug binary. The Cargo package is `tandem-desktop`
-// (src-tauri/Cargo.toml) and `cargo tauri build -- --no-bundle` skips the
+// (src-tauri/Cargo.toml) and `cargo tauri build --no-bundle` skips the
 // bundler's rename step, so the artifact is the raw cargo binary
 // `tandem-desktop` (`tandem-desktop.exe` on Windows) — NOT the `productName`
 // "Tandem", which only names the bundled installer. (The release workflow


### PR DESCRIPTION
## What

Makes the `tauri-driver` WebDriver E2E harness (#560) **run, run green, AND actually discriminate** — porting it from Linux/WebKitGTK to **Windows/WebView2** and reworking the specs so they genuinely catch the regression the harness exists for. This is the coverage proving the `prevent-default` plugin intercepts reload shortcuts *inside the live Tauri WebView* — which the Rust unit test (`src-tauri/tests/prevent_default.rs`, flag-value only) structurally cannot give.

## Why Windows, not Linux

WebKitGTK's WebDriver wedges on native element/key commands (`findElement`, W3C key Actions) under headless `xvfb` for a non-trivial app — `execute` works but `findElement` hangs to the Mocha timeout and the session dies (`hyper::Error(IncompleteMessage)`). Chromium-backed WebView2 drives those reliably. The plugin enforces RELOAD via a platform-agnostic injected JS keydown listener (`assets/script.js`) and Tandem declares it with no `platform-windows` feature, so there's no native-path divergence — Windows coverage is equally valid. (macOS has no WKWebView WebDriver; stays unsupported.)

## The CI mechanics solved

1. **msedgedriver ↔ WebView2-Runtime version match** — the driver must match the WebView2 *Runtime* (not the Edge browser); a mismatch hangs the session on connect. The workflow reads the Runtime version from the registry (HKLM→HKCU), resolves the matching driver via `LATEST_RELEASE_<major>`, downloads + validates it, and puts it on PATH. (Verified on real Windows hardware before the first CI round.)
2. **In-step server start** — a `--no-bundle` debug binary can't stage `dist/server`, so CI pre-starts a server the app's debug health-gate reuses. The first Windows run proved a server started in a *prior* step is reaped by the runner's per-step process-tree cleanup; it's now started inside the E2E step with a `finally` cleanup.

## The discrimination rework (the important part)

The first green run used a sentinel: fire Ctrl+R, assert the page didn't reload. **PR review flagged this might be a tautology, and a negative control proved it is.** Two findings, both empirically established on CI:

- **Dropping `.with_flags(prevent_default_flags())` does NOT disable reload.** The builder falls back to `Flags::default() == Flags::all()`, which still contains `RELOAD`. So the harness's original "catches a dropped `with_flags`" claim was wrong. (Docs corrected.)
- **A WebDriver-injected Ctrl+R never reloads WebView2 anyway.** With interception forced fully off (`.with_flags(Flags::empty())`, confirmed compiled), the sentinel specs *still passed* — `browser.keys` reaches page DOM listeners but not the browser-chrome reload accelerator. The sentinel test could never go red.

Fix: **observe the cause, not the effect.** The spec installs its own bubble-phase `window` keydown listener after the plugin's and reads `event.defaultPrevented`. A `fired` flag guards that the synthetic key reached the page (else the spec fails loud, not vacuous). Proven both directions on real CI:

| | Ctrl+R | F5 | "a" (control) | Result |
|---|---|---|---|---|
| `Flags::RELOAD` (shipping) | `fired:true, prevented:true` | `fired:true, prevented:true` | `fired:true, prevented:false` | **4 passing ✓** |
| `Flags::empty()` (negative control) | `fired:true, prevented:false` | `fired:true, prevented:false` | `fired:true, prevented:false` | **2 failing ✗** |

`prevented` flips true→false exactly when interception is removed, for exactly the reload keys; the benign control stays put both ways. That asymmetry is the proof the harness now catches a real reload-interception regression — not a tautology. (Green run: [27381118096](https://github.com/bloknayrb/tandem/actions/runs/27381118096); negative control red: [27381118861](https://github.com/bloknayrb/tandem/actions/runs/27381118861). The later doc-only commit doesn't touch the spec, so the green result stands.)

## Changes

- **`.github/workflows/tauri-webdriver.yml`** — `windows-latest`; registry-driven Edge WebDriver setup; in-step server start; `always()` log dump.
- **`tests/tauri-driver/wdio.conf.ts`** — ESM `__dirname` fix (`fileURLToPath(import.meta.url)` — the `"type":"module"` made the old `__dirname` throw at config-load, which is *why it never ran*); `webviewOptions: {}` for WebView2 capability matching; corrected `onPrepare` build args; corrected header framing.
- **`tests/tauri-driver/specs/prevent-default.e2e.ts`** — replaced the tautological sentinel with the `defaultPrevented` probe; self-gating precondition (`location !== about:blank` + title-bar) so specs can't no-op on the blank startup page; benign-key spec upgraded into a real reload-specific control; honest mechanism docs.
- **`tests/tauri-driver/README.md`**, **`docs/release-smoke-checklist.md`** — Windows/WebView2 platform tables; corrected regression framing.

## Honest scope

A failure here is a **release signal** (investigate-before-announce), not a publish gate — unchanged from #560's design (`workflow_dispatch` + tag push). The discrimination was validated against a throwaway negative-control branch that is not part of this PR and is deleted.

Refs #560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
