### PR TITLE
fix(license): remove NODE_ENV dev-mode signature bypass in license webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- License webhook (`/webhooks/license`) now requires a configured webhook secret in every environment. Removed the `NODE_ENV=development` signature-verification bypass — an auth-exempt, publicly reachable license-signing endpoint must never accept unsigned payloads, and a NODE_ENV-gated bypass is a production backdoor waiting for a misconfigured deploy. Missing secret now returns `503`; unsigned/forged requests return `401`. To test locally, configure `POLAR_WEBHOOK_SECRET`/`PADDLE_WEBHOOK_SECRET` and sign the payload.
+
 ## [0.14.2] - 2026-06-14
 
 ### Changed

--- a/src/server/license/webhook.ts
+++ b/src/server/license/webhook.ts
@@ -97,8 +97,6 @@ export function verifyPaddleSignature(
  * Generates and delivers Ed25519-signed licenses upon successful checkout.
  */
 export async function handleLicenseWebhook(req: Request, res: Response): Promise<void> {
-  const isDev = process.env.NODE_ENV === "development";
-
   try {
     // express.raw({ type: 'application/json' }) passes the original request bytes as a Buffer.
     // This preserves the exact bytes that Polar/Paddle signed for HMAC verification.
@@ -111,6 +109,20 @@ export async function handleLicenseWebhook(req: Request, res: Response): Promise
     let customerEmail = "";
     let isTestPurchase = false;
 
+    // A webhook secret is mandatory in every environment. There is deliberately
+    // no dev-mode bypass: this endpoint is auth-exempt and publicly reachable (it
+    // serves external payment processors), and signing licenses is the most
+    // sensitive operation the server performs. A NODE_ENV-gated bypass is a
+    // production backdoor waiting for a misconfigured deploy — to test locally,
+    // configure POLAR_WEBHOOK_SECRET/PADDLE_WEBHOOK_SECRET and sign the payload.
+    if (!polarSecret && !paddleSecret) {
+      console.error("Webhook Error: no webhook secret configured; cannot verify signatures.");
+      res
+        .status(503)
+        .json({ error: "Licensing server configuration error: webhook secret not configured" });
+      return;
+    }
+
     // 1. Signature Verification & Event Parsing
     const polarSig = req.headers["webhook-signature"] || req.headers["stripe-signature"];
     const paddleSig = req.headers["paddle-signature"];
@@ -119,9 +131,6 @@ export async function handleLicenseWebhook(req: Request, res: Response): Promise
       isVerified = verifyPolarSignature(rawBody, polarSig as string, polarSecret);
     } else if (paddleSig && paddleSecret) {
       isVerified = verifyPaddleSignature(rawBody, paddleSig as string, paddleSecret);
-    } else if (isDev) {
-      // In development, signature checks are bypassed if webhook secrets are missing
-      isVerified = true;
     }
 
     if (!isVerified) {
@@ -154,13 +163,10 @@ export async function handleLicenseWebhook(req: Request, res: Response): Promise
       customerName = transaction?.customer?.name || "Valued Customer";
       customerEmail = transaction?.customer?.email;
       isTestPurchase = transaction?.billing_details?.is_test || false;
-    } else if (isDev) {
-      // Allow custom test payload in development
-      customerName = payload.name || "Test User";
-      customerEmail = payload.email;
-      isTestPurchase = true;
     } else {
-      // Unhandled/ignored event types
+      // Unhandled/ignored event types. (Note: a signed payload reached this point,
+      // so a local dev test must send a real order.created/transaction.completed
+      // shape — there is no longer a dev-only custom-payload branch.)
       res.status(200).json({ status: "ignored", event: payload.event });
       return;
     }

--- a/tests/server/webhook.test.ts
+++ b/tests/server/webhook.test.ts
@@ -13,33 +13,31 @@ import {
 import { startMcpServerHttp } from "../../src/server/mcp/server.js";
 import { allocPort } from "../helpers/alloc-port.js";
 
+// Build a valid Polar `webhook-signature` header for a payload + secret. Mirrors
+// the signing scheme verified by verifyPolarSignature (t=<ts>,v1=<hmac>).
+function signPolar(payload: string, secret: string): string {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const hash = crypto.createHmac("sha256", secret).update(`${timestamp}.${payload}`).digest("hex");
+  return `t=${timestamp},v1=${hash}`;
+}
+
 describe("Webhook Licensing", () => {
   describe("verifyPolarSignature", () => {
     it("should successfully verify a valid Polar signature", () => {
       const secret = "polar_test_secret";
       const payload = JSON.stringify({ event: "order.created", data: {} });
-      const timestamp = Math.floor(Date.now() / 1000).toString();
-
-      const signedPayload = `${timestamp}.${payload}`;
-      const hash = crypto.createHmac("sha256", secret).update(signedPayload).digest("hex");
-
-      const signatureHeader = `t=${timestamp},v1=${hash}`;
-
-      const isValid = verifyPolarSignature(payload, signatureHeader, secret);
+      const isValid = verifyPolarSignature(payload, signPolar(payload, secret), secret);
       expect(isValid).toBe(true);
     });
 
     it("should reject tampered payload", () => {
       const secret = "polar_test_secret";
       const payload = JSON.stringify({ event: "order.created", data: {} });
-      const timestamp = Math.floor(Date.now() / 1000).toString();
-
-      const signedPayload = `${timestamp}.${payload}`;
-      const hash = crypto.createHmac("sha256", secret).update(signedPayload).digest("hex");
-
-      const signatureHeader = `t=${timestamp},v1=${hash}`;
-
-      const isValid = verifyPolarSignature(payload + "tampered", signatureHeader, secret);
+      const isValid = verifyPolarSignature(
+        payload + "tampered",
+        signPolar(payload, secret),
+        secret,
+      );
       expect(isValid).toBe(false);
     });
   });
@@ -61,6 +59,7 @@ describe("Webhook Licensing", () => {
   });
 
   describe("handleLicenseWebhook", () => {
+    const POLAR_SECRET = "polar_test_secret";
     let testPrivateKey: string;
 
     beforeAll(() => {
@@ -73,10 +72,12 @@ describe("Webhook Licensing", () => {
 
     beforeEach(() => {
       process.env.TANDEM_PRIVATE_KEY = testPrivateKey;
+      process.env.POLAR_WEBHOOK_SECRET = POLAR_SECRET;
     });
 
     afterEach(() => {
       delete process.env.TANDEM_PRIVATE_KEY;
+      delete process.env.POLAR_WEBHOOK_SECRET;
     });
 
     const mockResponse = () => {
@@ -86,26 +87,25 @@ describe("Webhook Licensing", () => {
       return res as Response;
     };
 
-    it("should generate a valid personal license on Polar order.created in dev mode", async () => {
-      const bodyPayload = {
-        event: "order.created",
-        data: {
-          customer: { name: "John Doe", email: "john@example.com" },
-          is_test: true,
-        },
-      };
-      const req: Partial<Request> = {
+    // Build a signed request for a Polar payload using POLAR_SECRET.
+    const signedReq = (bodyPayload: unknown): Request => {
+      const raw = JSON.stringify(bodyPayload);
+      return {
         // express.raw() passes req.body as a Buffer; mirror that in unit tests
-        body: Buffer.from(JSON.stringify(bodyPayload)),
-        headers: {},
-      };
+        body: Buffer.from(raw),
+        headers: { "webhook-signature": signPolar(raw, POLAR_SECRET) },
+      } as Partial<Request> as Request;
+    };
 
+    it("should generate a valid personal license on a signed Polar order.created", async () => {
       const res = mockResponse();
-
-      const oldEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = "development";
-
-      await handleLicenseWebhook(req as Request, res);
+      await handleLicenseWebhook(
+        signedReq({
+          event: "order.created",
+          data: { customer: { name: "John Doe", email: "john@example.com" }, is_test: true },
+        }),
+        res,
+      );
 
       expect(res.status).toHaveBeenCalledWith(200);
       const jsonResponse = (res.json as any).mock.calls[0][0];
@@ -118,29 +118,17 @@ describe("Webhook Licensing", () => {
       const decoded = JSON.parse(Buffer.from(jsonResponse.license, "base64").toString("utf-8"));
       expect(decoded.metadata.email).toBe("john@example.com");
       expect(decoded.metadata.type).toBe("personal");
-
-      process.env.NODE_ENV = oldEnv;
     });
 
     it("should assign grandfathered type if email is in grandfather list", async () => {
-      const bodyPayload = {
-        event: "order.created",
-        data: {
-          customer: { name: "Bryan Kolb", email: "bryan@tandem.chat" },
-          is_test: true,
-        },
-      };
-      const req: Partial<Request> = {
-        body: Buffer.from(JSON.stringify(bodyPayload)),
-        headers: {},
-      };
-
       const res = mockResponse();
-
-      const oldEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = "development";
-
-      await handleLicenseWebhook(req as Request, res);
+      await handleLicenseWebhook(
+        signedReq({
+          event: "order.created",
+          data: { customer: { name: "Bryan Kolb", email: "bryan@tandem.chat" }, is_test: true },
+        }),
+        res,
+      );
 
       expect(res.status).toHaveBeenCalledWith(200);
       const jsonResponse = (res.json as any).mock.calls[0][0];
@@ -148,8 +136,65 @@ describe("Webhook Licensing", () => {
       const decoded = JSON.parse(Buffer.from(jsonResponse.license, "base64").toString("utf-8"));
       expect(decoded.metadata.type).toBe("grandfathered");
       expect(decoded.metadata.expiresAt).toBeNull(); // Grandfathered never expires
+    });
 
+    it("rejects an unsigned request with 401 — no dev bypass, even in NODE_ENV=development", async () => {
+      const oldEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+      const res = mockResponse();
+      await handleLicenseWebhook(
+        {
+          body: Buffer.from(
+            JSON.stringify({
+              event: "order.created",
+              data: { customer: { name: "Mallory", email: "mallory@evil.test" } },
+            }),
+          ),
+          headers: {}, // no signature header
+        } as Partial<Request> as Request,
+        res,
+      );
       process.env.NODE_ENV = oldEnv;
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      const jsonResponse = (res.json as any).mock.calls[0][0];
+      expect(jsonResponse.license).toBeUndefined();
+    });
+
+    it("rejects a forged signature with 401", async () => {
+      const res = mockResponse();
+      const raw = JSON.stringify({
+        event: "order.created",
+        data: { customer: { email: "mallory@evil.test" } },
+      });
+      await handleLicenseWebhook(
+        {
+          body: Buffer.from(raw),
+          headers: { "webhook-signature": signPolar(raw, "wrong-secret") },
+        } as Partial<Request> as Request,
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect((res.json as any).mock.calls[0][0].license).toBeUndefined();
+    });
+
+    it("returns 503 when no webhook secret is configured (misconfiguration is loud, not bypassed)", async () => {
+      delete process.env.POLAR_WEBHOOK_SECRET;
+      const oldEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+      const res = mockResponse();
+      await handleLicenseWebhook(
+        {
+          body: Buffer.from(JSON.stringify({ event: "order.created", data: {} })),
+          headers: {},
+        } as Partial<Request> as Request,
+        res,
+      );
+      process.env.NODE_ENV = oldEnv;
+
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect((res.json as any).mock.calls[0][0].license).toBeUndefined();
     });
   });
 
@@ -163,6 +208,7 @@ describe("Webhook Licensing", () => {
   });
 
   describe("Webhook Route Integration (HTTP Server)", () => {
+    const POLAR_SECRET = "polar_test_secret";
     let serverInstance: any;
     let serverPort: number;
     let testPrivateKey: string;
@@ -215,6 +261,7 @@ describe("Webhook Licensing", () => {
 
     beforeEach(async () => {
       process.env.TANDEM_PRIVATE_KEY = testPrivateKey;
+      process.env.POLAR_WEBHOOK_SECRET = POLAR_SECRET;
       serverPort = await allocPort();
       // startMcpServerHttp(port, bindHost, authToken)
       serverInstance = await startMcpServerHttp(serverPort, "127.0.0.1", "test-token");
@@ -222,37 +269,45 @@ describe("Webhook Licensing", () => {
 
     afterEach(async () => {
       delete process.env.TANDEM_PRIVATE_KEY;
+      delete process.env.POLAR_WEBHOOK_SECRET;
       await new Promise<void>((resolve) => {
         serverInstance.close(() => resolve());
       });
     });
 
-    it("should process webhook requests on /webhooks/license without auth header", async () => {
-      const payload = {
+    it("should process a signed webhook on /webhooks/license without an auth header", async () => {
+      const body = JSON.stringify({
         event: "order.created",
         data: {
           customer: { name: "Integration Tester", email: "tester@example.com" },
           is_test: true,
         },
-      };
+      });
 
-      const oldEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = "development";
-
-      const { status, body } = await rawPost(
+      const { status, body: resBody } = await rawPost(
         serverPort,
         "/webhooks/license",
-        {},
-        JSON.stringify(payload),
+        { "webhook-signature": signPolar(body, POLAR_SECRET) },
+        body,
       );
 
-      process.env.NODE_ENV = oldEnv;
-
       expect(status).toBe(200);
-      expect(body.status).toBe("success");
-      expect(body.license).toBeDefined();
+      expect(resBody.status).toBe("success");
+      expect(resBody.license).toBeDefined();
       // metadata is omitted from the response (PII reduction)
-      expect(body.metadata).toBeUndefined();
+      expect(resBody.metadata).toBeUndefined();
+    });
+
+    it("rejects an unsigned webhook with 401 (auth-exempt route is still signature-gated)", async () => {
+      const body = JSON.stringify({
+        event: "order.created",
+        data: { customer: { email: "mallory@evil.test" } },
+      });
+
+      const { status, body: resBody } = await rawPost(serverPort, "/webhooks/license", {}, body);
+
+      expect(status).toBe(401);
+      expect(resBody.license).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Context

Surfaced by the automated security review during the `/pr-review-toolkit:review-pr` pass on **#1135**. The finding is in `src/server/license/webhook.ts`, which is **not** part of #1135 — it was introduced by **#1133** (licensing) and is already on `master`. Fixed here separately so #1135 stays scoped to its one concern.

## The vulnerability (HIGH — authentication bypass)

`/webhooks/license` is **auth-exempt and publicly reachable**: it's mounted before `authMiddleware` with no Host-header check (it serves external payment processors), and it signs Ed25519 licenses with the server's private key — the most sensitive operation the server performs.

Two `NODE_ENV === "development"` branches turned that into a backdoor:
- One set `isVerified = true` whenever webhook secrets were missing.
- A second accepted an arbitrary custom `{name, email}` payload.

Any deploy running with `NODE_ENV` unset/`"development"` and no secret would mint validly-signed licenses for anyone who can reach the endpoint. `NODE_ENV` is the wrong gate for a security boundary — it's one misconfiguration away from production.

## What changed

- **Removed both `NODE_ENV`-gated branches.** `isVerified` is now only ever set by a real HMAC verification (`verifyPolarSignature`/`verifyPaddleSignature`).
- **Require a configured secret in every environment.** If neither `POLAR_WEBHOOK_SECRET` nor `PADDLE_WEBHOOK_SECRET` is set → **503** before any parsing (loud misconfiguration, not a silent fail-open). An empty-string secret is falsy → treated as *not configured*, so a blank env var can't re-open the hole.
- Unsigned/forged requests → **401**, as before. Unknown events → **200 `{status:"ignored"}`**.
- **Unchanged:** the 5-minute replay window (`MAX_WEBHOOK_AGE_S`), `timingSafeEqual`, and both verify functions (byte-identical to master).

To test locally: configure `POLAR_WEBHOOK_SECRET`/`PADDLE_WEBHOOK_SECRET` and sign the payload (the test helper `signPolar()` shows the scheme).

## Tests

Rewrote `tests/server/webhook.test.ts` to sign with a real test secret instead of relying on the removed bypass, and added negative coverage:
- 401 on an unsigned request **even with `NODE_ENV=development`** (proves the bypass is dead).
- 401 on a forged signature.
- 503 when no secret is configured.
- Happy paths preserved at both the unit and HTTP-integration layer (real `startMcpServerHttp` through `/webhooks/license`).

## Review

Adversarially reviewed with the `security-reviewer` agent, which traced every path to `crypto.sign` and could not refute the closure (it confirmed the falsy-empty-string handling is load-bearing-safe and that no other consumer relied on the removed bypass).

## Verification

- `npm run typecheck` — clean.
- `npm test` (full suite via pre-push hook) — green.
- `tests/server/webhook.test.ts` — 11/11.

## Follow-up (out of scope)

Worth considering separately: whether `is_test` (Polar/Paddle test-mode) purchases should produce licenses the verifier rejects in production. Not addressed here — this PR only closes the bypass.

---
_Generated by [Claude Code](https://claude.com/claude-code)_