### PR TITLE
chore(deps): align Node engine + svelte floor with Vite 8 toolchain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "husky": "^9.1.7",
         "knip": "^5.66.0",
         "lint-staged": "^16.4.0",
-        "svelte": "^5.37.0",
+        "svelte": "^5.46.4",
         "svelte-check": "^4.0.0",
         "tsup": "^8.5.1",
         "tsx": "^4.22.4",
@@ -81,7 +81,7 @@
         "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@axe-core/playwright": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12.0"
   },
   "lint-staged": {
     "**/*.{ts,tsx}": [
@@ -157,7 +157,7 @@
     "husky": "^9.1.7",
     "knip": "^5.66.0",
     "lint-staged": "^16.4.0",
-    "svelte": "^5.37.0",
+    "svelte": "^5.46.4",
     "svelte-check": "^4.0.0",
     "tsup": "^8.5.1",
     "tsx": "^4.22.4",


### PR DESCRIPTION
Follow-up hygiene to **#1138** (vite 6→8, `@sveltejs/vite-plugin-svelte` 5→7), which was merged but left two declared-version floors below what the new toolchain requires. Neither fails CI (npm treats both as warnings), so this is correctness/clarity, not a fix for breakage.

## Changes
- **`engines.node`: `>=22` → `>=22.12.0`** — Vite 8 and vite-plugin-svelte 7 both require `^20.19.0 || >=22.12.0`. The old `>=22` permitted Node 22.0–22.11, which would trip an unmet-engine warning. CI already runs `node-version: 22` (resolves to latest 22.x), so CI itself was unaffected.
- **`svelte`: `^5.37.0` → `^5.46.4`** — vite-plugin-svelte 7's peer floor is `svelte ^5.46.4`; the declared range sat below it. The resolved version (5.55.7) already satisfies the new floor, so **no dependency resolution changes** — only the declared range and its `package-lock.json` mirror. Verified the lockfile diff is exactly these two lines with zero other churn.

## Verification
- `package-lock.json` diff limited to the two mirrored root fields (resolved `svelte` unchanged at 5.55.7).
- Full toolchain validation rides on CI (`check` job: lint, typecheck, unit tests, `npm run build` on rolldown-based Vite 8, stdio smoke, Playwright E2E), which was already green on #1138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphZpWkmxSYFvbpmFHU46e

---
_Generated by [Claude Code](https://claude.ai/code/session_01QphZpWkmxSYFvbpmFHU46e)_