### PR TITLE
fix(docx): carry table colspan through export (Tier-A fidelity)

### DIFF
--- a/src/server/file-io/docx-export.ts
+++ b/src/server/file-io/docx-export.ts
@@ -525,6 +525,18 @@ function blockToDocx(el: Y.XmlElement, ctx: BlockCtx, emit: EmitCtx): Array<Para
   }
 }
 
+/**
+ * Read a table-cell span attribute (`colspan`/`rowspan`) as a docx span count.
+ * Returns undefined for absent/≤1/non-integer values so the caller can omit the
+ * option entirely (a span of 1 is the default and must not be emitted).
+ */
+function readSpanAttr(cell: Y.XmlElement, attr: "colspan" | "rowspan"): number | undefined {
+  const raw = cell.getAttribute(attr);
+  if (raw == null) return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 1 ? n : undefined;
+}
+
 function tableToDocx(tableEl: Y.XmlElement, emit: EmitCtx): Table {
   const rows: TableRow[] = [];
   let hasPriorRow = false;
@@ -574,7 +586,13 @@ function tableToDocx(tableEl: Y.XmlElement, emit: EmitCtx): Table {
         }
       }
       if (cellChildren.length === 0) cellChildren.push(new Paragraph({ children: [] }));
-      cells.push(new TableCell({ children: cellChildren }));
+      // Carry a horizontal merge through to Word. The import preserves `colspan`
+      // on the cell element; without `columnSpan` here the export silently
+      // un-merges the cell (the priority loss the 0d scoreboard pinned).
+      // `rowspan` is intentionally NOT carried yet — docx vertical merge needs
+      // continuation cells on the rows below, a separate change.
+      const columnSpan = readSpanAttr(cell, "colspan");
+      cells.push(new TableCell({ children: cellChildren, ...(columnSpan ? { columnSpan } : {}) }));
     }
     rows.push(new TableRow({ children: cells }));
   }

--- a/tests/server/docx-roundtrip-fidelity.test.ts
+++ b/tests/server/docx-roundtrip-fidelity.test.ts
@@ -129,18 +129,17 @@ const CORPUS: Fixture[] = [
   {
     name: "merged-cell table",
     build: corpus.buildMergedTable,
-    status: "breaks",
-    reason:
-      "import preserves colspan; the exporter drops it (Tier-A: docx pkg supports columnSpan)",
+    status: "survives",
+    reason: "colspan round-trips — the exporter now emits columnSpan from the cell's colspan attr",
     check(rt) {
       // Import preserved the merge…
       expect(nodesOfType(rt.gen1, "tableCell").some((c) => Number(c.attrs.colspan) === 2)).toBe(
         true,
       );
-      // …but export drops it. CURRENT LOSS — when the exporter emits columnSpan,
-      // gen2 keeps the span → this flips → promote to survives.
+      // …and export now carries it through: gen2 keeps the colspan. (rowspan is
+      // not yet carried — a separate vertical-merge change.)
       expect(nodesOfType(rt.gen2, "tableCell").some((c) => Number(c.attrs.colspan) === 2)).toBe(
-        false,
+        true,
       );
     },
   },


### PR DESCRIPTION
## What

Table `colspan` (horizontal merge) now survives a `.docx` round-trip. The exporter built `new TableCell({ children })` without the cell's span, so saving silently **un-merged** merged cells.

First of the Tier-A fidelity fixes following the Phase 0d scoreboard (#1148).

## Why this one is special

The 0d scoreboard established that the mammoth **import** is the fidelity ceiling and the export is otherwise faithful. `colspan` is the **one case where the export itself was lossy**: the import already preserves `colspan` on the cell, and `docx@9.x` supports `columnSpan` — the exporter just wasn't passing it. So this is a clean, contained export-side win, not an import-ceiling fight.

## Change

- New `readSpanAttr(cell, "colspan")` helper: reads the attribute, returns a span count only for integer values `> 1` (so a span of `1` — the default — is never emitted).
- `tableToDocx` passes `columnSpan` to `TableCell` when present.
- `rowspan` is **intentionally not carried yet** — docx vertical merge requires continuation cells on the rows below, a separate change.

Coordinate-neutral: the `emit.pos` cursor math is untouched (span is a cell attribute, not content).

## Tests

- The 0d **"merged-cell table"** fixture flips `breaks → survives` — it drives the real adapter import→export→reimport and now asserts `gen2` keeps `colspan === 2`.
- The **"simple table"** fixture (4 cells, no span) is the negative control — a wrongly-emitted span would break its cell count.
- Full table-test surface (78 table-named tests + docx-export/comment-export) green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
