### PR TITLE
chore(husky): skip pre-push checks on delete-only pushes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,20 @@
 #!/usr/bin/env sh
+
+# Skip checks on delete-only pushes (branch pruning) — there are no new commits
+# to verify, so running the full suite is pure waste. Git feeds pre-push one
+# line per ref on stdin: "<local ref> <local oid> <remote ref> <remote oid>".
+# A deletion carries an all-zero local oid; if every ref is a deletion, bail.
+only_deletes=1
+while read -r _local_ref local_oid _remote_ref _remote_oid; do
+	case "$local_oid" in
+		*[!0]*) only_deletes=0 ;; # any non-zero char => a real ref update
+	esac
+done
+if [ "$only_deletes" -eq 1 ]; then
+	echo "pre-push: delete-only push, skipping checks"
+	exit 0
+fi
+
 npx biome check src/ tests/
 npm test -- --run --reporter=dot
 cargo test --manifest-path src-tauri/Cargo.toml


### PR DESCRIPTION
## What

Guards the `pre-push` hook so it exits early when a push only deletes remote refs (branch pruning), instead of running the full Biome + vitest + `cargo test` suite.

## Why

`git push --delete` carries no new commits, but the hook ran the entire test suite anyway — minutes of wasted compute just to remove a ref. This surfaced during a branch-cleanup sweep where every `--delete` push spun up the full suite.

## How

Git feeds `pre-push` one line per ref on stdin: `<local ref> <local oid> <remote ref> <remote oid>`. A deletion carries an all-zero local OID. The guard reads each line and only skips when **every** ref is a deletion; any real ref update — including one bundled alongside a deletion — still runs the full suite.

Verified against four stdin shapes:
- delete-only → skip
- real push → run
- mixed (delete + real) → run
- empty stdin → skip

This PR's own push exercised the real-push path: the full suite ran and passed.