### PR TITLE
fix(cowork): make admin-permission popup visible, dismissable, and disable-able

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2261,21 +2261,34 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
             false // No workspaces = nothing to uninstall = success (firewall still needs removing).
         };
 
-        // Firewall removal: failure is a SECURITY regression — propagate as Err.
-        let firewall_err = firewall::remove_cowork_rules().err();
+        // Firewall removal is ADVISORY, not fatal. Tandem never runs elevated, so a
+        // `netsh delete` on a rule a past elevated run wrote fails with "requires
+        // elevation" — surfacing as NetshFailure (run_netsh only classifies AdminDeclined
+        // for `add`), indistinguishable from other delete failures. Failing disable here
+        // traps exactly the non-admin user who needs the escape hatch. Leaving a rule is
+        // safe: the deny rule is retired, the allow rule is scoped to the VM subnet, and
+        // the server binds 127.0.0.1 only, so a leftover rule is inert. This aligns with
+        // reconcile_orphans (cowork_installer.rs), which already treats remove failures as
+        // non-fatal (§12). (Caveat: leaving the rule is inert only under the default
+        // loopback bind; a future TANDEM_BIND_HOST=routable + stale VM-CIDR rule is an
+        // untested composition — a later enable sweeps it via reconcile_orphans.)
+        let firewall_failed = match firewall::remove_cowork_rules() {
+            Ok(()) => false,
+            Err(fe) => {
+                log::warn!("[cowork] disable: firewall rule removal failed (non-fatal): {fe}");
+                true
+            }
+        };
 
-        // Persist meta regardless of workspace/firewall outcome so the UI reflects
-        // "user requested disable." An Err return still signals failure to the caller.
-        if let Err(e) = cowork_meta::update(|m| { m.enabled = false; }) {
+        // Persist meta regardless of workspace/firewall outcome. Clearing the UAC-declined
+        // flag is what makes the "Admin permission required" modal disappear: the user has
+        // resolved the blocked state by turning the feature off.
+        if let Err(e) = cowork_meta::update(|m| {
+            m.enabled = false;
+            m.uac_declined_last_attempt = false;
+            m.uac_declined_at = None;
+        }) {
             log::warn!("[cowork] failed to persist meta after disable: {e}");
-        }
-
-        if let Some(fe) = firewall_err {
-            return Err(format!(
-                "Cowork disable: firewall rule removal failed ({fe}). \
-                 An allow rule may still permit traffic on port 3479. \
-                 Remove 'Tandem Cowork' rules manually in Windows Defender Firewall."
-            ));
         }
 
         if workspace_all_failed {
@@ -2290,7 +2303,13 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
             ));
         }
 
-        Ok("Cowork disabled".to_string())
+        if firewall_failed {
+            Ok("Cowork disabled (a leftover firewall rule may remain — harmless; \
+                Tandem's server only listens on this computer)"
+                .to_string())
+        } else {
+            Ok("Cowork disabled".to_string())
+        }
     }
 }
 #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2271,7 +2271,9 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         // reconcile_orphans (cowork_installer.rs), which already treats remove failures as
         // non-fatal (§12). (Caveat: leaving the rule is inert only under the default
         // loopback bind; a future TANDEM_BIND_HOST=routable + stale VM-CIDR rule is an
-        // untested composition — a later enable sweeps it via reconcile_orphans.)
+        // untested composition. A later enable *may* clear it via reconcile_orphans, but
+        // that's best-effort — reconcile returns early if its scan fails — and the leftover
+        // is an inert allow rule, not a missing protection.)
         let firewall_failed = match firewall::remove_cowork_rules() {
             Ok(()) => false,
             Err(fe) => {
@@ -2282,12 +2284,18 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
 
         // Persist meta regardless of workspace/firewall outcome. Clearing the UAC-declined
         // flag is what makes the "Admin permission required" modal disappear: the user has
-        // resolved the blocked state by turning the feature off.
-        if let Err(e) = cowork_meta::update(|m| {
+        // resolved the blocked state by turning the feature off. Unlike the advisory
+        // firewall removal above, this write is the disable's CORE contract — if it fails,
+        // the on-disk state stays `enabled = true` with the UAC flag set, so the modal
+        // never goes away and the integration still reads as on. We therefore fail loud
+        // (Err in the success-path tail below) instead of returning a green toast over a
+        // stale state. Borrow in the warn so the Result survives for the later check.
+        let meta_persist = cowork_meta::update(|m| {
             m.enabled = false;
             m.uac_declined_last_attempt = false;
             m.uac_declined_at = None;
-        }) {
+        });
+        if let Err(e) = &meta_persist {
             log::warn!("[cowork] failed to persist meta after disable: {e}");
         }
 
@@ -2300,6 +2308,18 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
                 "Cowork disable failed: all {} workspace(s) failed to uninstall. Failures: {}",
                 workspaces.len(),
                 failure_summary.join("; ")
+            ));
+        }
+
+        // Workspace uninstall + firewall removal already ran (idempotent / inert), and the
+        // disable branch re-drives this whole path on a repeat call, so failing here strands
+        // nothing — a retry safely re-attempts the persist. Surface it so the user knows the
+        // disable didn't stick rather than discovering the modal is still up.
+        if let Err(e) = meta_persist {
+            return Err(format!(
+                "Cowork was turned off, but saving that state failed ({e}). Cowork is still \
+                 marked enabled and the admin-permission notice stays open. Try disabling \
+                 again; if it persists, restart Tandem."
             ));
         }
 

--- a/src/client/components/CoworkAdminDeclinedModal.svelte
+++ b/src/client/components/CoworkAdminDeclinedModal.svelte
@@ -55,6 +55,9 @@ $effect(() => {
   if (!visible) return;
   const handler = (e: KeyboardEvent) => {
     if (e.key === "Escape") {
+      // Don't let a dismiss race a disable in flight: if disable then fails, the
+      // modal would unmount and swallow the error while Cowork stays enabled.
+      if (busy) return;
       dismissAdminPopup();
       return;
     }
@@ -117,7 +120,9 @@ async function handleDisable(): Promise<void> {
     await coworkToggleIntegration(invoke, false);
     await coworkState.refetch();
   }, "Failed to disable Cowork");
-  confirmingDisable = false;
+  // Collapse the confirm panel only on success; on failure keep it up so the Disable
+  // button stays for a one-click retry (the error banner renders above it regardless).
+  if (!error) confirmingDisable = false;
 }
 </script>
 
@@ -141,12 +146,13 @@ async function handleDisable(): Promise<void> {
     tabindex="-1"
     aria-label="Dismiss admin permission notice"
     onclick={(e) => {
-      if (e.target === e.currentTarget) dismissAdminPopup();
+      // `busy` guard: don't dismiss while a disable is in flight (see Escape handler).
+      if (!busy && e.target === e.currentTarget) dismissAdminPopup();
     }}
     onkeydown={(e) => {
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
-        dismissAdminPopup();
+        if (!busy) dismissAdminPopup();
       }
     }}
   >

--- a/src/client/components/CoworkAdminDeclinedModal.svelte
+++ b/src/client/components/CoworkAdminDeclinedModal.svelte
@@ -6,6 +6,11 @@ import {
   type InvokeFn,
   loadInvoke,
 } from "../cowork/cowork-invoke";
+import {
+  adminPopupDismissed,
+  dismissAdminPopup,
+  noteUacDeclinedAt,
+} from "../cowork/coworkAdminDismiss.svelte";
 import { createCoworkStatus } from "../hooks/useCoworkStatus.svelte";
 
 const FOCUSABLE_SELECTOR =
@@ -15,14 +20,25 @@ const coworkState = createCoworkStatus(() => true);
 
 const uacDeclined = $derived(coworkState.status?.uacDeclined === true);
 
+// Session-scoped dismiss: the popup is hidden once the user presses Esc / clicks the
+// backdrop, and re-armed only on a genuinely new decline. `dismissed` lives in a module
+// so it survives the wizard-driven remount of this component (App.svelte gate).
+const visible = $derived(uacDeclined && !adminPopupDismissed());
+
 let modalEl: HTMLDivElement | undefined = $state();
 let confirmingDisable = $state(false);
 let busy = $state(false);
 let error = $state<string | null>(null);
 
+// Watch the declined timestamp: re-arm the popup on a new decline, ignore the
+// non-null → null transition that disabling produces.
+$effect(() => {
+  noteUacDeclinedAt(coworkState.status?.uacDeclinedAt ?? null);
+});
+
 // Title badge — surfaces the warning in the OS window/tab list
 $effect(() => {
-  if (!uacDeclined) return;
+  if (!visible) return;
   const prev = typeof document !== "undefined" ? document.title : null;
   if (typeof document !== "undefined" && !document.title.startsWith("⚠")) {
     document.title = `⚠ ${document.title}`;
@@ -34,10 +50,14 @@ $effect(() => {
   };
 });
 
-// Focus trap on Tab
+// Focus trap on Tab + Escape-to-dismiss
 $effect(() => {
-  if (!uacDeclined) return;
+  if (!visible) return;
   const handler = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      dismissAdminPopup();
+      return;
+    }
     if (e.key !== "Tab" || !modalEl) return;
     const focusables = modalEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
     if (focusables.length === 0) return;
@@ -63,7 +83,7 @@ $effect(() => {
 
 // Move focus into the modal on open
 $effect(() => {
-  if (!uacDeclined) return;
+  if (!visible) return;
   modalEl?.focus();
 });
 
@@ -106,8 +126,30 @@ async function handleDisable(): Promise<void> {
     Cowork status check failed: unable to determine if admin elevation was declined. Please
     restart Tandem to restore normal operation.
   </div>
-{:else if uacDeclined}
-  <div class="cad-backdrop" data-testid="cowork-admin-declined-backdrop">
+{:else if visible}
+  <!--
+    Backdrop a11y mirrors SettingsModal's scrim (PR #671): role="button" +
+    tabindex="-1" + aria-label gives svelte-check an interactive path without firing
+    the noninteractive-click rule; Escape is handled by the window keydown effect
+    above. tabindex="-1" keeps the backdrop out of the tab order so the dialog's focus
+    trap still works. The click guard dismisses only on a backdrop (not dialog) click.
+  -->
+  <div
+    class="cad-backdrop"
+    data-testid="cowork-admin-declined-backdrop"
+    role="button"
+    tabindex="-1"
+    aria-label="Dismiss admin permission notice"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) dismissAdminPopup();
+    }}
+    onkeydown={(e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        dismissAdminPopup();
+      }
+    }}
+  >
     <div
       bind:this={modalEl}
       class="cad-dialog"
@@ -122,9 +164,10 @@ async function handleDisable(): Promise<void> {
       </h2>
 
       <div class="cad-description">
-        Cowork integration requires Windows admin permission to configure firewall rules. Without
-        it, Tandem can't safely be reached from inside the Cowork VM. Port 3479 is currently
-        blocked by a deny rule to protect your machine.
+        Cowork integration needs Windows admin permission to add the firewall rule that lets
+        Claude inside the Cowork VM reach Tandem. Without it, that rule wasn't added, so Cowork
+        can't connect. Nothing was exposed — Tandem's server only listens on this computer
+        (127.0.0.1). You can dismiss this for now, or turn Cowork off below.
       </div>
 
       {#if error}
@@ -137,7 +180,9 @@ async function handleDisable(): Promise<void> {
         <div class="cad-warning-banner" data-testid="cowork-admin-declined-confirm-disable">
           <div class="cad-confirm-heading">Disable Cowork integration?</div>
           <div class="cad-confirm-body">
-            The deny rule will remain in place. You can re-enable Cowork later from Settings.
+            Cowork will be turned off. Any firewall rule a past admin run added is left in
+            place (it's harmless — the server only listens on this computer). You can
+            re-enable Cowork later from Settings.
           </div>
           <div class="cad-actions">
             <button
@@ -206,7 +251,9 @@ async function handleDisable(): Promise<void> {
     inset: 0;
     /* Theme-adaptive backdrop (cluster 3.2 modal recipe). */
     background: color-mix(in srgb, var(--tandem-bg) 70%, transparent);
-    z-index: var(--tandem-z-above-titlebar);
+    /* Sits above every other above-titlebar surface (Settings modal / wizard at +1)
+       so this critical notice is never painted behind the dialog that triggered it. */
+    z-index: calc(var(--tandem-z-above-titlebar) + 5);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/client/cowork/coworkAdminDismiss.svelte.ts
+++ b/src/client/cowork/coworkAdminDismiss.svelte.ts
@@ -1,0 +1,49 @@
+/**
+ * Session-scoped dismiss state for the Cowork "Admin permission required" modal
+ * (`CoworkAdminDeclinedModal`).
+ *
+ * Why module scope (not component `$state`): the modal only mounts when
+ * `isTauriRuntime() && !shouldShowWizard` (`App.svelte`), so opening/closing the
+ * integration wizard unmounts and remounts the component. Component-local dismiss
+ * state would reset on every wizard cycle and re-surface the popup from a stale
+ * `uacDeclinedAt`. Keeping the flag here makes "dismiss for the session" mean exactly
+ * that — it survives remounts and resets only on a full app relaunch (fresh module
+ * load) or a genuinely new decline.
+ */
+
+let dismissed = $state(false);
+// Plain `let`, NOT `$state`: read + written inside the watcher effect below. As $state
+// it would self-invalidate (effect_update_depth_exceeded). A non-reactive module let is
+// safe to compare-and-store, and surviving remount is the whole point.
+let lastSeenDeclinedAt: string | null = null;
+
+/** Whether the user has dismissed the popup for this session. */
+export function adminPopupDismissed(): boolean {
+  return dismissed;
+}
+
+/** Hide the popup for the session (Esc / click-outside). */
+export function dismissAdminPopup(): void {
+  dismissed = true;
+}
+
+/**
+ * Feed the latest `uacDeclinedAt` timestamp from the status poll. Re-arms the popup
+ * (clears `dismissed`) only on a genuinely NEW decline — a changed, non-null timestamp.
+ *
+ * Null transitions are deliberately ignored: disabling Cowork clears the declined flag
+ * (`uacDeclinedAt` goes non-null → null), and treating that as a "fresh decline" would
+ * flash the modal for one frame before the integration-off state propagates.
+ */
+export function noteUacDeclinedAt(at: string | null): void {
+  if (at !== lastSeenDeclinedAt) {
+    lastSeenDeclinedAt = at;
+    if (at !== null) dismissed = false;
+  }
+}
+
+/** Test-only reset of module state between cases. */
+export function _resetAdminDismissForTests(): void {
+  dismissed = false;
+  lastSeenDeclinedAt = null;
+}

--- a/tests/client/cowork-admin-declined-modal.test.ts
+++ b/tests/client/cowork-admin-declined-modal.test.ts
@@ -9,10 +9,11 @@ import type { CoworkStatus } from "../../src/client/types.js";
 // ---------------------------------------------------------------------------
 // Modal visibility condition
 //
-// CoworkAdminDeclinedModal renders when status.uacDeclined === true and
-// returns null otherwise. Tests here verify the condition logic without
-// mounting the component (consistent with the project's pure-function test
-// pattern).
+// CoworkAdminDeclinedModal renders when status.uacDeclined === true AND the
+// user hasn't dismissed it this session (visible = uacDeclined && !dismissed —
+// the dismiss half is covered in cowork-admin-dismiss.test.ts). These tests
+// verify the uacDeclined half without mounting the component (consistent with
+// the project's pure-function test pattern).
 // ---------------------------------------------------------------------------
 
 function makeStatus(overrides: Partial<CoworkStatus> = {}): CoworkStatus {

--- a/tests/client/cowork-admin-dismiss.test.ts
+++ b/tests/client/cowork-admin-dismiss.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetAdminDismissForTests,
+  adminPopupDismissed,
+  dismissAdminPopup,
+  noteUacDeclinedAt,
+} from "../../src/client/cowork/coworkAdminDismiss.svelte.js";
+
+// ---------------------------------------------------------------------------
+// Session-scoped dismiss state for CoworkAdminDeclinedModal.
+//
+// The modal's `visible` guard is `uacDeclined && !adminPopupDismissed()`. These
+// tests cover the re-arm semantics that the 30s status poll and the disable-clears-
+// the-flag path depend on. Module state is reset between cases.
+// ---------------------------------------------------------------------------
+
+describe("coworkAdminDismiss", () => {
+  beforeEach(() => {
+    _resetAdminDismissForTests();
+  });
+
+  it("starts not dismissed", () => {
+    expect(adminPopupDismissed()).toBe(false);
+  });
+
+  it("dismiss() hides it for the session", () => {
+    dismissAdminPopup();
+    expect(adminPopupDismissed()).toBe(true);
+  });
+
+  it("an unchanged timestamp does NOT re-arm a dismissed popup (30s poll is a no-op)", () => {
+    noteUacDeclinedAt("2026-06-22T00:00:00Z");
+    dismissAdminPopup();
+    expect(adminPopupDismissed()).toBe(true);
+    // Same timestamp arriving again on the next poll must not un-dismiss.
+    noteUacDeclinedAt("2026-06-22T00:00:00Z");
+    expect(adminPopupDismissed()).toBe(true);
+  });
+
+  it("a NEW non-null timestamp re-arms the popup (fresh decline)", () => {
+    noteUacDeclinedAt("2026-06-22T00:00:00Z");
+    dismissAdminPopup();
+    expect(adminPopupDismissed()).toBe(true);
+    noteUacDeclinedAt("2026-06-22T01:00:00Z");
+    expect(adminPopupDismissed()).toBe(false);
+  });
+
+  it("a non-null → null transition (disable cleared the flag) does NOT re-arm", () => {
+    noteUacDeclinedAt("2026-06-22T00:00:00Z");
+    dismissAdminPopup();
+    expect(adminPopupDismissed()).toBe(true);
+    // Disable clears uacDeclinedAt to null — must be ignored, not treated as a decline.
+    noteUacDeclinedAt(null);
+    expect(adminPopupDismissed()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Context

On Windows, enabling Cowork tries to add a `netsh` firewall allow-rule that needs admin elevation. Tandem never runs elevated, so when that fails the **Admin permission required** modal appears. Three defects made that flow broken and could trap a non-admin user with no way out:

1. **The popup rendered *behind* the dialog that triggered it.** Enabling Cowork from **Settings → Network** left the Settings modal painting over the admin popup (both stack at `--tandem-z-above-titlebar`), so it was invisible until Settings was dismissed.
2. **"Disable Cowork" errored out.** The disable path ran a non-elevated `netsh delete`, which fails with *"requires elevation"* and was treated as a hard error — so the escape hatch failed for exactly the non-admin users who needed it.
3. **The modal was undismissable** (no Esc / click-outside), and disable never cleared the declined flag, so even a successful disable wouldn't hide it.

## Changes

- **Z-index:** raise the admin modal's backdrop to `calc(--tandem-z-above-titlebar + 5)` so this critical notice always paints on top of the Settings modal / wizard.
- **Disable works without admin** (`src-tauri/src/lib.rs`): firewall removal is now **advisory, not fatal**. The deny rule is retired, the allow rule is VM-subnet-scoped, and the server binds `127.0.0.1` only, so a leftover rule is inert — this aligns disable with the already-non-fatal `reconcile_orphans` (§12). Disable also clears `uac_declined_last_attempt`/`uac_declined_at`, which is what makes the modal disappear.
- **Dismissal** (new `src/client/cowork/coworkAdminDismiss.svelte.ts`): Esc / click-outside dismiss the popup for the session. The dismiss flag lives in a module so it survives the wizard-driven remount of the component; it re-arms on a genuinely new decline and ignores the non-null→null transition that disabling produces.
- **Honesty copy fix:** the modal claimed *"Port 3479 is blocked by a deny rule"* — that rule is retired. Reworded to reflect reality (server is loopback-only; nothing exposed).

"Retry with admin" is unchanged — real UAC elevation is the separate, blocked Cowork transport redesign.

## Testing

- `npm run typecheck` + `svelte-check --fail-on-warnings`: clean
- `cargo check` + `cargo test` (Rust): pass
- Client suite: 1424/1424 pass, including new `cowork-admin-dismiss.test.ts` (re-arm on new timestamp; ignore null transition; stays dismissed on unchanged timestamp)

⚠️ **Needs manual verification on Windows desktop (non-admin scenario)** — the popup z-index, Esc/backdrop dismiss, and Disable-succeeds behavior live in the Tauri app and can't be exercised by unit tests or browser automation:
1. Settings → Network → Enable Cowork → confirm the popup appears **on top of** Settings.
2. Disable Cowork → succeeds (no error banner), integration off, popup gone; `cowork-meta.json` shows `enabled:false`, `uac_declined_last_attempt:false`.
3. Re-trigger → Esc hides it; backdrop click hides it; it stays hidden across a 30s poll **and** a wizard open/close; reappears on relaunch / new decline.

## Review

Plan reviewed by `svelte-migration-reviewer` + `security-reviewer` (caught the wizard-remount reset bug and the `$state` self-invalidation trap). Code reviewed by four `/simplify` cleanup agents (reuse / simplification / efficiency / altitude) — one minor cleanup applied, rest confirmed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)