### PR TITLE
fix(cowork): reconcile firewall orphans before adding the allow rule (#1163)

### DIFF
--- a/src-tauri/src/cowork_installer.rs
+++ b/src-tauri/src/cowork_installer.rs
@@ -568,8 +568,9 @@ pub fn reconcile_stale_workspace_tokens(workspaces: &[PathBuf], current_token: &
     let mut rewritten = Vec::new();
     for ws_path in workspaces {
         // Write-time revalidation (#433): re-run the four-layer path guard
-        // before the per-workspace token rewrite. The orphan firewall-rule
-        // cleanup ran earlier on the enable path in lib.rs (before the add).
+        // before the per-workspace token rewrite. Per this function's ordering
+        // contract (§4), the caller has already run orphan firewall-rule cleanup
+        // and a successful firewall add before reaching here.
         let ws_path = match crate::cowork_workspace_scan::revalidate_resolved_path(ws_path) {
             Ok(p) => p,
             Err(reason) => {
@@ -1278,5 +1279,19 @@ mod tests {
         let content = fs::read_to_string(&entry_path).unwrap();
         let json: Value = serde_json::from_str(&content).unwrap();
         assert_eq!(json["mcpServers"]["tandem"]["env"]["TANDEM_AUTH_TOKEN"], "current-token");
+    }
+
+    #[test]
+    fn test_reconcile_stale_workspace_tokens_skips_when_current() {
+        // Pins the needs_update == false branch: a workspace already carrying the
+        // current token must not be reported or rewritten (avoids needless writes
+        // + lock contention on every enable).
+        let (_guard, _dir, ws_path) = temp_ws();
+        install_tandem_plugin_into_workspace(&ws_path, "current-token", DEFAULT_TANDEM_URL).unwrap();
+
+        let rewritten = reconcile_stale_workspace_tokens(&[ws_path], "current-token");
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+
+        assert!(rewritten.is_empty(), "no rewrite expected when token already current");
     }
 }

--- a/src-tauri/src/cowork_installer.rs
+++ b/src-tauri/src/cowork_installer.rs
@@ -74,16 +74,6 @@ pub struct WorkspaceWriteReport {
     pub cowork_settings: WriteStatus,
 }
 
-/// Summary of orphan reconciliation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ReconcileReport {
-    /// Names of orphan firewall rules that were removed.
-    pub removed_firewall_rules: Vec<String>,
-    /// Paths of workspace entries that had stale tokens and were rewritten.
-    pub rewritten_stale_entries: Vec<String>,
-}
-
 // ---------------------------------------------------------------------------
 // ACL guard (heuristic — full DACL inspection deferred to v0.8.1)
 // ---------------------------------------------------------------------------
@@ -523,48 +513,63 @@ pub fn apply_token_to_all_workspaces(token: &str) -> Vec<WorkspaceWriteReport> {
 // Orphan reconciliation
 // ---------------------------------------------------------------------------
 
-/// Scan for and reconcile orphan firewall rules and stale env blocks.
+/// Remove orphan `"Tandem Cowork*"` firewall rules left by a previous failed
+/// uninstall (security invariant §12). Returns the names of rules removed, or an
+/// empty vec on scan/remove failure.
 ///
-/// Removes firewall rules left by a previous failed uninstall and rewrites
-/// workspace entries whose `env.TANDEM_AUTH_TOKEN` does not match the current
-/// token (security invariant §12).
-pub fn reconcile_orphans(workspaces: &[PathBuf], current_token: &str) -> ReconcileReport {
+/// **Ordering contract (issue #1163):** on the enable path this MUST run *before*
+/// `firewall::add_cowork_allow_rule`. `scan_orphan_rules` matches by the name
+/// prefix `"Tandem Cowork"`, which is identical to the allow rule's own name, so
+/// it cannot distinguish a freshly-added rule from a true orphan — reconciling
+/// *after* the add would scan the just-added rule as an orphan and delete it,
+/// leaving every enable with no allow rule. The stale-token half of the old
+/// combined reconcile is split into [`reconcile_stale_workspace_tokens`], which
+/// runs *after* a successful add so a fail-closed firewall add never reaches a
+/// workspace write (invariant §4).
+pub fn reconcile_orphan_firewall_rules() -> Vec<String> {
     use crate::firewall;
 
     let orphan_rules = match firewall::scan_orphan_rules() {
         Ok(rules) => rules,
         Err(e) => {
+            // Warn (not silent) so callers know the scan was inconclusive rather
+            // than treating a failed scan as "no orphans".
             log::warn!(
                 "[cowork-install] reconcile: orphan rule scan failed ({e}) — skipping rule removal"
             );
-            // Return early with an empty report so callers know the scan was
-            // not conclusive, rather than silently treating failure as "no orphans".
-            return ReconcileReport {
-                removed_firewall_rules: vec![],
-                rewritten_stale_entries: vec![],
-            };
+            return vec![];
         }
     };
-    let mut removed_rules = Vec::new();
 
-    if !orphan_rules.is_empty() {
-        log::warn!(
-            "[cowork-install] reconcile: found {} orphan firewall rule(s): {:?}",
-            orphan_rules.len(),
-            orphan_rules
-        );
-        if let Err(e) = firewall::remove_cowork_rules() {
-            log::warn!("[cowork-install] reconcile: failed to remove orphan rules: {e}");
-        } else {
-            removed_rules = orphan_rules;
-        }
+    if orphan_rules.is_empty() {
+        return vec![];
     }
 
+    log::warn!(
+        "[cowork-install] reconcile: found {} orphan firewall rule(s): {:?}",
+        orphan_rules.len(),
+        orphan_rules
+    );
+    if let Err(e) = firewall::remove_cowork_rules() {
+        log::warn!("[cowork-install] reconcile: failed to remove orphan rules: {e}");
+        return vec![];
+    }
+    orphan_rules
+}
+
+/// Rewrite workspace plugin entries whose `env.TANDEM_AUTH_TOKEN` does not match
+/// the current token (security invariant §12). Returns the paths rewritten.
+///
+/// **Ordering contract (§4):** on the enable path this MUST run *after* a
+/// successful `firewall::add_cowork_allow_rule`. A fail-closed firewall add must
+/// not be followed by any workspace write, so this is intentionally split from
+/// [`reconcile_orphan_firewall_rules`] (which runs before the add).
+pub fn reconcile_stale_workspace_tokens(workspaces: &[PathBuf], current_token: &str) -> Vec<String> {
     let mut rewritten = Vec::new();
     for ws_path in workspaces {
         // Write-time revalidation (#433): re-run the four-layer path guard
-        // before the per-workspace token rewrite. Only the token rewrite is
-        // gated here — the orphan firewall-rule cleanup above already ran.
+        // before the per-workspace token rewrite. The orphan firewall-rule
+        // cleanup ran earlier on the enable path in lib.rs (before the add).
         let ws_path = match crate::cowork_workspace_scan::revalidate_resolved_path(ws_path) {
             Ok(p) => p,
             Err(reason) => {
@@ -630,10 +635,7 @@ pub fn reconcile_orphans(workspaces: &[PathBuf], current_token: &str) -> Reconci
         }
     }
 
-    ReconcileReport {
-        removed_firewall_rules: removed_rules,
-        rewritten_stale_entries: rewritten,
-    }
+    rewritten
 }
 
 // ---------------------------------------------------------------------------
@@ -1247,5 +1249,34 @@ mod tests {
         let content = fs::read_to_string(ws_path.join("cowork_plugins/installed_plugins.json")).unwrap();
         let json: Value = serde_json::from_str(&content).unwrap();
         assert_eq!(json["mcpServers"]["tandem"]["env"]["TANDEM_AUTH_TOKEN"], "new-token");
+    }
+
+    #[test]
+    fn test_reconcile_stale_workspace_tokens_rewrites_mismatch() {
+        // Net-new coverage enabled by the #1163 split: the token-rewrite half is
+        // now testable in isolation (the old combined reconcile_orphans was
+        // entangled with netsh). temp_ws() sets TANDEM_COWORK_ROOT_OVERRIDE and
+        // nests the ws under it so revalidate_resolved_path (#433) passes instead
+        // of skipping the rewrite — without it this test would fail red.
+        let (_guard, _dir, ws_path) = temp_ws();
+        install_tandem_plugin_into_workspace(&ws_path, "old-token", DEFAULT_TANDEM_URL).unwrap();
+
+        let rewritten = reconcile_stale_workspace_tokens(&[ws_path.clone()], "current-token");
+        std::env::remove_var("TANDEM_COWORK_ROOT_OVERRIDE");
+
+        // The reported path is the #433-revalidated (canonicalized) form, which on
+        // Windows carries the \\?\ extended-length prefix — assert on the suffix,
+        // not exact string equality, then verify the actual on-disk rewrite.
+        assert_eq!(rewritten.len(), 1, "stale entry should be reported as rewritten");
+        assert!(
+            rewritten[0].ends_with("installed_plugins.json"),
+            "unexpected rewritten path: {}",
+            rewritten[0]
+        );
+
+        let entry_path = ws_path.join("cowork_plugins/installed_plugins.json");
+        let content = fs::read_to_string(&entry_path).unwrap();
+        let json: Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(json["mcpServers"]["tandem"]["env"]["TANDEM_AUTH_TOKEN"], "current-token");
     }
 }

--- a/src-tauri/src/firewall.rs
+++ b/src-tauri/src/firewall.rs
@@ -320,7 +320,7 @@ pub fn remove_cowork_rules() -> Result<(), FirewallError> {
 /// stale rules from a previous failed uninstall.
 ///
 /// Returns `Err` on spawn failure or unexpected netsh errors so that
-/// `reconcile_orphans` can distinguish "no orphans" from "scan failed".
+/// `reconcile_orphan_firewall_rules` can distinguish "no orphans" from "scan failed".
 pub fn scan_orphan_rules() -> Result<Vec<String>, FirewallError> {
     let start = Instant::now();
     let output = Command::new("netsh")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2147,6 +2147,15 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         // strictly more restrictive, and a retired deny rule is inert under the
         // 127.0.0.1 loopback bind (same rationale as the disable path below).
         let removed_firewall_rules = cowork_installer::reconcile_orphan_firewall_rules();
+        // Log removals here, before the add — a fail-closed add bails below, so
+        // folding this into the post-add log would silently drop the audit trail
+        // for "removed an allow rule but then failed to replace it".
+        if !removed_firewall_rules.is_empty() {
+            log::info!(
+                "[cowork] orphan reconcile: removed {} firewall rule(s)",
+                removed_firewall_rules.len()
+            );
+        }
 
         // Add allow firewall rule.
         let firewall_result = firewall::add_cowork_allow_rule(&cidr);
@@ -2181,10 +2190,9 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         // fail-closed firewall add never reaches a workspace write (invariant §4).
         let rewritten_stale_entries =
             cowork_installer::reconcile_stale_workspace_tokens(&workspaces, &token);
-        if !removed_firewall_rules.is_empty() || !rewritten_stale_entries.is_empty() {
+        if !rewritten_stale_entries.is_empty() {
             log::info!(
-                "[cowork] orphan reconcile: removed {} rule(s), rewrote {} stale entry(s)",
-                removed_firewall_rules.len(),
+                "[cowork] reconcile: rewrote {} stale token entry(s)",
                 rewritten_stale_entries.len()
             );
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2134,6 +2134,20 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         let cidr = firewall::detect_vethernet_subnet()
             .map_err(|e| serde_json::to_string(&e).unwrap_or_else(|_| e.to_string()))?;
 
+        // Scan workspaces up-front (read-only) — reused for both reconcile and install.
+        let workspaces = find_cowork_workspaces();
+
+        // Orphan firewall reconciliation BEFORE the add (issue #1163): remove stale
+        // "Tandem Cowork*" rules from a previous failed uninstall first. The orphan
+        // scan matches by name prefix (identical to the allow rule's own name), so
+        // reconciling AFTER the add would scan the just-added rule as an orphan and
+        // delete it — leaving every enable with no allow rule. Trade-off: on an
+        // elevated run where cleanup succeeds but the add then errors, a leftover
+        // rule is dropped without replacement; for the VM-scoped allow rule that's
+        // strictly more restrictive, and a retired deny rule is inert under the
+        // 127.0.0.1 loopback bind (same rationale as the disable path below).
+        let removed_firewall_rules = cowork_installer::reconcile_orphan_firewall_rules();
+
         // Add allow firewall rule.
         let firewall_result = firewall::add_cowork_allow_rule(&cidr);
         if let Err(ref e) = firewall_result {
@@ -2163,14 +2177,15 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         // Resolve TANDEM_URL (host.docker.internal by default; LAN-IP if override set).
         let tandem_url = cowork_installer::resolve_tandem_url(&cowork_meta::load().map_err(|e| e.to_string())?);
 
-        // Orphan reconciliation (invariant §12).
-        let workspaces = find_cowork_workspaces();
-        let reconcile = cowork_installer::reconcile_orphans(&workspaces, &token);
-        if !reconcile.removed_firewall_rules.is_empty() || !reconcile.rewritten_stale_entries.is_empty() {
+        // Stale-token reconciliation (invariant §12) — AFTER the successful add, so a
+        // fail-closed firewall add never reaches a workspace write (invariant §4).
+        let rewritten_stale_entries =
+            cowork_installer::reconcile_stale_workspace_tokens(&workspaces, &token);
+        if !removed_firewall_rules.is_empty() || !rewritten_stale_entries.is_empty() {
             log::info!(
                 "[cowork] orphan reconcile: removed {} rule(s), rewrote {} stale entry(s)",
-                reconcile.removed_firewall_rules.len(),
-                reconcile.rewritten_stale_entries.len()
+                removed_firewall_rules.len(),
+                rewritten_stale_entries.len()
             );
         }
 
@@ -2280,10 +2295,10 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         // traps exactly the non-admin user who needs the escape hatch. Leaving a rule is
         // safe: the deny rule is retired, the allow rule is scoped to the VM subnet, and
         // the server binds 127.0.0.1 only, so a leftover rule is inert. This aligns with
-        // reconcile_orphans (cowork_installer.rs), which already treats remove failures as
-        // non-fatal (§12). (Caveat: leaving the rule is inert only under the default
+        // reconcile_orphan_firewall_rules (cowork_installer.rs), which already treats remove
+        // failures as non-fatal (§12). (Caveat: leaving the rule is inert only under the default
         // loopback bind; a future TANDEM_BIND_HOST=routable + stale VM-CIDR rule is an
-        // untested composition. A later enable *may* clear it via reconcile_orphans, but
+        // untested composition. A later enable *may* clear it via reconcile_orphan_firewall_rules, but
         // that's best-effort — reconcile returns early if its scan fails — and the leftover
         // is an inert allow rule, not a missing protection.)
         let firewall_failed = match firewall::remove_cowork_rules() {


### PR DESCRIPTION
## Summary

On the Windows Cowork **enable** path, `cowork_toggle_integration` added the `"Tandem Cowork"` allow firewall rule and *then* ran `reconcile_orphans`. Orphan reconciliation matches firewall rules by name prefix — and `RULE_NAME_PREFIX == RULE_NAME_ALLOW == "Tandem Cowork"` — so it scanned the just-added rule as an orphan and `remove_cowork_rules()` deleted **all** `"Tandem Cowork*"` rules, including the fresh one. **Every successful enable ended with no allow rule** (and logged `removed 1 rule(s)` where a clean enable should log 0).

Pre-existing; surfaced during PR #1162 review (security + comment-accuracy agents traced it independently). Inert under the shipped `127.0.0.1` loopback bind, but it silently defeats the rule's purpose and would block any future routable-`TANDEM_BIND_HOST` Cowork transport.

## Fix

Exclude-by-name is impossible (the orphan and the fresh rule are byte-identical names), so reordering orphan cleanup **before** the add is the only sound fix. But `reconcile_orphans` bundled two concerns — firewall cleanup and stale-workspace-token rewrites — and invariant **§4** forbids workspace writes when the firewall add fails-closed. So the function is **split**:

- `reconcile_orphan_firewall_rules()` — firewall scan + remove; runs **before** `add_cowork_allow_rule`.
- `reconcile_stale_workspace_tokens()` — per-workspace token rewrite; runs **after** a *successful* add, keeping the fail-closed bail between them so §4 holds.

The `#433` write-time `revalidate_resolved_path` guard travels with the token half (where the write happens). The vestigial `ReconcileReport` struct is removed; `lib.rs` reads the two returned `Vec`s for its log line. `find_cowork_workspaces()` is hoisted and reused (one scan instead of two).

### Disclosed trade-off
On an *elevated* run where cleanup succeeds but the add then errors, a leftover rule is dropped without replacement. For the VM-scoped allow rule that's strictly more restrictive; a retired deny rule is inert under the loopback bind (same rationale as the disable path). Documented inline.

## Tests

- New `test_reconcile_stale_workspace_tokens_rewrites_mismatch` — net-new coverage the old netsh-entangled function couldn't have. Uses the `temp_ws()` helper so the `#433` revalidation passes (suffix-matches the canonicalized `\?\` path, then verifies the on-disk token rewrite).
- `cargo test cowork_installer` — 16 passed. Full Rust suite green via husky pre-push.
- The firewall-ordering half stays netsh-bound (unit-untestable). **Manual check (Windows):** after enable, `netsh advfirewall firewall show rule name="Tandem Cowork"` should list the allow rule (today it's absent), and a true first-ever enable logs no reconcile line.

## Review

Plan reviewed by security-reviewer + general-purpose agents (two rounds); §4/§12 preservation and the test trap confirmed. `/simplify` pass (reuse / simplification / efficiency / altitude): clean, net efficiency improvement, one docstring cross-ref added.

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)