### PR TITLE
fix(launcher): replace timing-based resume guard with confirmation flag (#1169)

### DIFF
--- a/src/server/launcher/supervisor.ts
+++ b/src/server/launcher/supervisor.ts
@@ -305,6 +305,14 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
     });
 
     child.on("error", (err: NodeJS.ErrnoException) => {
+      // Cancel the confirmation timer — spawn errors don't flow through the
+      // exit handler, so confirmTimer must be cleared here too. Without this,
+      // the 30s timer from a failed resuming spawn would fire later and null
+      // out confirmTimer for a subsequent spawn.
+      if (confirmTimer) {
+        clearTimeout(confirmTimer);
+        confirmTimer = null;
+      }
       // CRITICAL: clear child state so status() doesn't lie about being
       // running and so subsequent start()/relaunch() actually re-attempt.
       // ENOENT is unrecoverable without user action — trip the breaker

--- a/src/server/launcher/supervisor.ts
+++ b/src/server/launcher/supervisor.ts
@@ -39,7 +39,13 @@ interface SpawnPlan {
 }
 
 const SESSION_FILE_NAME = "launcher-session.json";
-const RESUME_GRACE_MS = 5_000;
+/** How long a resumed spawn must run before its session is considered
+ * confirmed successful. If it exits non-zero before this threshold, the saved
+ * session is cleared so the next spawn starts fresh. Must be strictly greater
+ * than the longest observed `claude --resume <id>` probe time (~6 s on a slow
+ * machine) — the old 5 s grace window was shorter than that probe, causing
+ * the stale session to never be cleared (issue #1169). */
+export const RESUME_CONFIRM_MS = 30_000;
 const RESTART_BACKOFFS_MS = [1_000, 5_000, 30_000];
 /** Circuit breaker: if Claude crashes this many times within
  * CIRCUIT_BREAKER_WINDOW_MS, the supervisor gives up and surfaces via status.
@@ -81,6 +87,21 @@ export type SupervisorStatus =
       resuming: boolean;
     };
 
+/**
+ * Pure decision: should the saved session be cleared after a spawn exits?
+ * Exported for unit testing — all three parameters must be satisfied:
+ *   - we were attempting a resume (`resuming`)
+ *   - the process exited with an error code (not a signal kill — code is null on SIGTERM)
+ *   - the spawn never ran long enough to be considered successfully resumed
+ */
+export function shouldClearSession(opts: {
+  resuming: boolean;
+  code: number | null;
+  resumeConfirmed: boolean;
+}): boolean {
+  return opts.resuming && opts.code !== null && opts.code !== 0 && !opts.resumeConfirmed;
+}
+
 export function createSupervisor(opts: SupervisorOpts): Supervisor {
   let child: ChildProcess | null = null;
   let currentCwd: string | undefined;
@@ -89,6 +110,10 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
   let stopRequested = false;
   let restartIndex = 0;
   let restartTimer: NodeJS.Timeout | null = null;
+  /** Confirmation timer for the active spawn. Set in spawnOnce, cancelled in
+   * stopInternal and the exit handler. Module-scoped so stopInternal can
+   * cancel it if the user-stops the process before it confirms. */
+  let confirmTimer: NodeJS.Timeout | null = null;
   /** Circuit-breaker timestamps of recent restart attempts. */
   let recentAttempts: number[] = [];
   /** True once the breaker has tripped — supervisor refuses further restarts. */
@@ -261,6 +286,19 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
 
     const spawnedAt = Date.now();
 
+    // Track whether this spawn has run long enough to be considered a
+    // successful resume. Fresh spawns are inherently "confirmed" — only a
+    // --resume that exits early (conversation not found) should clear the
+    // saved session. The timer is cancelled in the exit handler and in
+    // stopInternal() so it never fires on a deliberate stop.
+    let resumeConfirmed = !plan.resuming;
+    if (plan.resuming) {
+      confirmTimer = setTimeout(() => {
+        resumeConfirmed = true;
+        confirmTimer = null;
+      }, RESUME_CONFIRM_MS);
+    }
+
     child.stderr?.on("data", (chunk: Buffer) => {
       const line = chunk.toString().trimEnd();
       if (line) console.error(`[Claude] ${line}`);
@@ -293,10 +331,20 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
       console.error(`[Launcher] Reaper exited (code=${code} signal=${signal} after ${ranFor}ms)`);
       child = null;
 
-      // If we were resuming and crashed inside the grace window, drop the
-      // saved session and retry fresh next time.
-      if (plan.resuming && code !== 0 && ranFor < RESUME_GRACE_MS) {
-        console.error("[Launcher] Resume failed within grace window — clearing saved session");
+      // Cancel the confirmation timer — the process has already exited.
+      if (confirmTimer) {
+        clearTimeout(confirmTimer);
+        confirmTimer = null;
+      }
+
+      // If the resume failed before being confirmed, drop the stale session so
+      // the next restart goes fresh. Guard code !== null to avoid clearing on
+      // signal kills (SIGTERM/SIGKILL set code=null, signal="SIGTERM"/"SIGKILL").
+      // The old ranFor < RESUME_GRACE_MS guard was broken because claude --resume
+      // takes ~6 s to detect a missing conversation — longer than RESUME_GRACE_MS
+      // was set (5 s), so the session was never cleared (issue #1169).
+      if (shouldClearSession({ resuming: plan.resuming, code, resumeConfirmed })) {
+        console.error("[Launcher] Resume failed before confirmation — clearing saved session");
         clearSavedSession();
       }
 
@@ -389,10 +437,13 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
     }
     try {
       await spawnOnce(plan);
-      // Reset backoff once a spawn lives past the resume window.
+      // Reset backoff once a spawn runs long enough to be considered stable.
+      // Must match RESUME_CONFIRM_MS — a doomed --resume exits at ~6s, so
+      // the old 5s timer fired while the process was still alive, resetting
+      // restartIndex before the exit and permanently neutering the backoff.
       setTimeout(() => {
         if (child) restartIndex = 0;
-      }, RESUME_GRACE_MS);
+      }, RESUME_CONFIRM_MS);
     } catch (err) {
       console.error("[Launcher] Spawn failed:", err);
     }
@@ -419,6 +470,10 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
     if (restartTimer) {
       clearTimeout(restartTimer);
       restartTimer = null;
+    }
+    if (confirmTimer) {
+      clearTimeout(confirmTimer);
+      confirmTimer = null;
     }
     const c = child;
     if (!c || c.killed) return;

--- a/tests/server/launcher/supervisor.test.ts
+++ b/tests/server/launcher/supervisor.test.ts
@@ -9,8 +9,10 @@ import {
 import { createIntegrationsStore } from "../../../src/server/integrations/storage.js";
 import {
   createSupervisor,
+  RESUME_CONFIRM_MS,
   resolveRouteCwd,
   resolveSafeCwd,
+  shouldClearSession,
 } from "../../../src/server/launcher/supervisor.js";
 import { REAPER_NOT_FOUND_MARKER } from "../../../src/shared/launcher/contract.js";
 
@@ -352,5 +354,41 @@ describe("supervisor — early spawn-failure surfacing (Fix A)", () => {
     } finally {
       await sup.stop();
     }
+  });
+});
+
+describe("shouldClearSession — resume-confirmation gate (issue #1169)", () => {
+  it("clears on non-zero exit while resuming and unconfirmed", () => {
+    expect(shouldClearSession({ resuming: true, code: 1, resumeConfirmed: false })).toBe(true);
+  });
+
+  it("does NOT clear on signal kill (code = null) while resuming and unconfirmed", () => {
+    // SIGTERM / SIGKILL: code is null. Must not invalidate a session just
+    // because the user stopped the supervisor before the confirm window elapsed.
+    expect(shouldClearSession({ resuming: true, code: null, resumeConfirmed: false })).toBe(false);
+  });
+
+  it("does NOT clear when resumeConfirmed is true, even on non-zero exit", () => {
+    // Claude ran long enough to confirm the session; a crash later should not
+    // remove the session so the next restart can attempt another --resume.
+    expect(shouldClearSession({ resuming: true, code: 1, resumeConfirmed: true })).toBe(false);
+  });
+
+  it("does NOT clear on non-zero exit when not resuming (fresh spawn)", () => {
+    expect(shouldClearSession({ resuming: false, code: 1, resumeConfirmed: false })).toBe(false);
+  });
+
+  it("does NOT clear on clean exit (code = 0) while resuming and unconfirmed", () => {
+    // User stopped Claude cleanly before the window elapsed — session is valid.
+    expect(shouldClearSession({ resuming: true, code: 0, resumeConfirmed: false })).toBe(false);
+  });
+});
+
+describe("RESUME_CONFIRM_MS threshold constraint (issue #1169)", () => {
+  it("is greater than 15_000 ms — must exceed the longest observed --resume probe time (~6 s)", () => {
+    // The old RESUME_GRACE_MS was 5_000, which was shorter than the ~6 s probe
+    // time. Any value <= 6_000 would recreate the bug. We use 15_000 as a
+    // conservative lower bound to guard against regressions.
+    expect(RESUME_CONFIRM_MS).toBeGreaterThan(15_000);
   });
 });

--- a/tests/server/launcher/supervisor.test.ts
+++ b/tests/server/launcher/supervisor.test.ts
@@ -385,10 +385,11 @@ describe("shouldClearSession — resume-confirmation gate (issue #1169)", () => 
 });
 
 describe("RESUME_CONFIRM_MS threshold constraint (issue #1169)", () => {
-  it("is greater than 15_000 ms — must exceed the longest observed --resume probe time (~6 s)", () => {
+  it("is at least 30_000 ms — must safely exceed the longest observed --resume probe time (~6 s)", () => {
     // The old RESUME_GRACE_MS was 5_000, which was shorter than the ~6 s probe
-    // time. Any value <= 6_000 would recreate the bug. We use 15_000 as a
-    // conservative lower bound to guard against regressions.
-    expect(RESUME_CONFIRM_MS).toBeGreaterThan(15_000);
+    // time. Any value <= 6_000 would recreate the bug. We require >= 30_000 ms
+    // (5× the observed probe time) as a meaningful safety margin. If you need
+    // to reduce this constant, update the bound here with justification.
+    expect(RESUME_CONFIRM_MS).toBeGreaterThanOrEqual(30_000);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the two interrelated bugs in the auto-launcher supervisor described in #1169.

**Bug 1 — stale session never cleared:**
`RESUME_GRACE_MS = 5_000` was shorter than the ~6s time `claude --resume <id>` needs to detect a missing conversation. So `ranFor < RESUME_GRACE_MS` was always false on a stale-session exit, meaning the session was never cleared and every restart cycle re-attempted the same doomed `--resume`.

**Bug 2 — backoff never escalated:**
The backoff reset timer also fired at `RESUME_GRACE_MS` (5s), while the doomed process was still alive (~6s exit). `restartIndex` reset to 0 before the exit, permanently neutering the exponential backoff — every retry showed "attempt 1".

**Root effect:** Any user whose `launcher-session.json` pointed at a stale conversation hit ~10 identical failed resume attempts over ~70s, then Claude ended up not running until manual intervention.

## Fix

Replace the wall-clock grace window with a per-spawn `resumeConfirmed` flag:
- Fresh spawns start confirmed; resuming spawns start unconfirmed
- `resumeConfirmed` is set to true after `RESUME_CONFIRM_MS` (30s) — safely above any observed `--resume` probe time
- On non-zero exit while unconfirmed, the saved session is cleared unconditionally
- `code !== null` guard prevents clearing on SIGTERM/SIGKILL (user-requested stops)
- `confirmTimer` is promoted to module scope so `stopInternal()` can cancel it on deliberate stop
- The backoff reset timer now uses `RESUME_CONFIRM_MS` instead of the old 5s constant

## Test plan

- [x] `shouldClearSession()` extracted as a pure exported function — 5 unit tests covering all branches
- [x] `RESUME_CONFIRM_MS` exported — threshold assertion test (> 15_000ms) guards against regression to a value shorter than the probe time
- [x] All 32 existing supervisor tests still pass (2 skipped Windows-specific)
- [x] `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wDqNH5Rfg5UHFcgcq5rVg

---
_Generated by [Claude Code](https://claude.ai/code/session_012wDqNH5Rfg5UHFcgcq5rVg)_