### PR TITLE
docs(readme): add in-document select-and-annotate screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Tandem is built to work with Anthropic's Claude out of the box. Other AI tools c
 *The main view. Your document fills the left side. The side panel on the right holds the AI's annotations and the chat conversation.*
 
 <p align="center">
+  <img src="docs/screenshots/05-review-mode.png" alt="A passage of text selected in the document, with a floating formatting toolbar above it and a small popup below offering color swatches and an Annotate button" width="800">
+</p>
+
+*Select any passage and a compact toolbar appears. Mark it with a color, or turn it into a note the AI can act on — and the AI sees the selection the moment you make it.*
+
+<p align="center">
   <img src="docs/screenshots/03-side-panel.png" alt="A close-up of annotation cards beside the document, including a replacement card showing the original text in red strikethrough and the proposed text in green, with Accept and Reject buttons" width="500">
 </p>
 
@@ -65,7 +71,7 @@ Tandem is built to work with Anthropic's Claude out of the box. Other AI tools c
   <img src="docs/screenshots/04-toolbar-actions.png" alt="The top of the editor showing several documents open in tabs, the formatting toolbar, a text selection, and the Solo and Tandem mode toggle" width="800">
 </p>
 
-*Several documents open in tabs, with the formatting toolbar above the text. Highlight a passage and the AI sees the selection as you make it. The Solo / Tandem toggle on the right controls whether the AI's annotations appear live or wait until you are ready.*
+*Several documents open in tabs, with the formatting toolbar above the text. The Solo / Tandem toggle on the right controls whether the AI's annotations appear live or wait until you are ready.*
 
 ## Who Tandem is for
 


### PR DESCRIPTION
## What

Adds one more example screenshot to the README's **See it in action** section so it's clearer what Tandem does at a glance.

The section already pictured the editor overview, annotation cards, the chat panel, and the tab bar — but not the core in-document gesture the intro describes ("You highlight a passage"). This adds `05-review-mode.png`, which shows a passage selected in the document with the floating toolbar and the inline **Annotate** popup (color swatches + Annotate button).

## Changes

- Insert the selection + Annotate popup screenshot right after the editor overview, so the visual flow reads: overview → select & annotate in the document → annotation cards appear → chat → tabs/toolbar.
- Add a caption for the new image.
- Trim the now-redundant "Highlight a passage and the AI sees the selection" line from the tab-bar caption, since the new screenshot's caption now makes that point.

## Notes

Uses an existing image already committed under `docs/screenshots/`. The other unused screenshots were left out on purpose: `06` is a thin status-bar strip, `07` shows an error toast, `08` is an awkwardly cropped tutorial card, and `09` shows a stale pre-redesign UI.

No code changes — README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETZpBzLGg5CjTqx6i72NM5

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETZpBzLGg5CjTqx6i72NM5)_