### PR TITLE
fix(release): bump tauri.conf.json to 0.15.0 + guard fourth version surface

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -44,9 +44,13 @@ git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
 - If there's already an `[Unreleased]` section, show what to append, not a replacement
 - Omit empty categories (don't show "### Security" if there are no security commits)
 
-## Releasing — bump version in three places
+## Releasing — bump version in FOUR places
 
-When cutting a release (`chore(release): vX.Y.Z`), bump the version in `package.json`, `.claude-plugin/plugin.json`, AND `src-tauri/Cargo.toml`'s `[package].version`. None of the three bump automatically, so any one drifts if you forget it. `tests/plugin-manifest.test.ts` fails if `package.json`/`plugin.json` diverge; `tests/plugin/plugin-version-pin.test.ts` fails if any of the three diverge (it also checks that `plugin.json`'s pinned `tandem-editor@<version>` npx specs match) — treat either failure as "you bumped one, not all three." The Cargo version matters beyond CI: the Cowork installer pins its npx spec via `env!("CARGO_PKG_VERSION")`, so a stale Cargo version ships a build that pins the WRONG published npm version.
+When cutting a release (`chore(release): vX.Y.Z`), bump the version in `package.json`, `.claude-plugin/plugin.json` (top-level **and** both `tandem-editor@<version>` npx pins), `src-tauri/Cargo.toml`'s `[package].version`, AND `src-tauri/tauri.conf.json`'s `version`. None bump automatically, so any one drifts if you forget it. Then regenerate the lockfiles (`npm install --package-lock-only`; `cargo update --manifest-path src-tauri/Cargo.toml -p tandem-desktop --precise <version> --offline`) or `npm ci` / rust CI will fail on drift.
+
+`tests/plugin/plugin-version-pin.test.ts` fails if any of the four diverge (it also checks `plugin.json`'s pinned npx specs); `tests/plugin-manifest.test.ts` fails if `package.json`/`plugin.json` diverge — treat either failure as "you bumped some, not all." Why each surface matters beyond CI:
+- **Cargo.toml** — the Cowork installer pins its npx spec via `env!("CARGO_PKG_VERSION")`; a stale value ships a build pinning the WRONG published npm version.
+- **tauri.conf.json** — drives the desktop bundle artifact names (`Tandem_<version>_x64.dmg`, …) AND the tauri-action `__VERSION__` that names/targets the GitHub release. A stale value builds correctly-coded installers under the wrong version number and **uploads them onto the PREVIOUS release** (this bit v0.15.0: 0.14.3-named artifacts clobbered the published v0.14.3 release before the guard was added). No `CARGO_PKG_VERSION`-style derivation exists for it, so it rots silently.
 
 ## Conventions
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "identifier": "com.tandem.editor",
   "build": {
     "frontendDist": "../dist/client",

--- a/tests/plugin/plugin-version-pin.test.ts
+++ b/tests/plugin/plugin-version-pin.test.ts
@@ -10,6 +10,13 @@
  *     marketplace (its own top-level `version` field was already 5 minors stale).
  *   - `src-tauri/Cargo.toml` — the Cowork installer pins via `env!("CARGO_PKG_VERSION")`,
  *     which is only correct while the Rust crate version equals the npm version.
+ *   - `src-tauri/tauri.conf.json` — drives the desktop bundle artifact names
+ *     (`Tandem_<version>_x64.dmg`, …) AND the tauri-action `__VERSION__` that
+ *     names/targets the GitHub release. A stale value here builds correctly-coded
+ *     installers under the WRONG version and uploads them onto the PREVIOUS
+ *     release (observed on v0.15.0: 0.14.3-named artifacts clobbered the
+ *     published v0.14.3 release). This surface has no CARGO_PKG_VERSION-style
+ *     derivation, so it silently rots.
  *
  * This test fails CI the moment any of them diverges from package.json.
  * (`src/server/integrations/apply.ts` build-injects the version from package.json
@@ -34,6 +41,10 @@ const plugin = JSON.parse(readFileSync(join(repoRoot, ".claude-plugin/plugin.jso
 
 const cargoToml = readFileSync(join(repoRoot, "src-tauri/Cargo.toml"), "utf8");
 
+const tauriConf = JSON.parse(readFileSync(join(repoRoot, "src-tauri/tauri.conf.json"), "utf8")) as {
+  version: string;
+};
+
 /** Pull the version from the first `[package]` table in Cargo.toml. */
 function cargoPackageVersion(toml: string): string {
   const pkgSection = toml.split(/^\[/m).find((s) => s.startsWith("package]"));
@@ -56,6 +67,12 @@ describe("plugin/version pin drift guard", () => {
     // The Cowork installer pins tandem-editor via env!("CARGO_PKG_VERSION"),
     // so a divergent crate version would pin the WRONG npm package version.
     expect(cargoPackageVersion(cargoToml)).toBe(expected);
+  });
+
+  it("src-tauri/tauri.conf.json version matches package.json", () => {
+    // Drives desktop artifact names and the tauri-action release __VERSION__.
+    // A stale value ships mis-versioned installers onto the wrong release.
+    expect(tauriConf.version).toBe(expected);
   });
 
   it("every plugin.json npx tandem-editor entry pins the package.json version", () => {


### PR DESCRIPTION
## Problem

The `v0.15.0` release build produced `0.14.3`-named desktop artifacts and uploaded them **onto the published v0.14.3 GitHub release** (clobbering its real installers, including `latest.json`). Root cause: `src-tauri/tauri.conf.json` still read `0.14.3`.

`tauri.conf.json`'s `version` drives (a) the desktop bundle artifact names (`Tandem_<version>_x64.dmg`, …) and (b) the tauri-action `__VERSION__` that names/targets the release. It has no `CARGO_PKG_VERSION`-style derivation, and it was absent from both the release skill's bump list and the `plugin-version-pin` guard — so it rotted silently.

## Fix

- Bump `src-tauri/tauri.conf.json` → `0.15.0`.
- Extend `tests/plugin/plugin-version-pin.test.ts` to assert `tauri.conf.json` version == `package.json` (now guards **all four** surfaces).
- Correct `.claude/skills/changelog/SKILL.md`: document all four bump surfaces + the lockfile-regen step.

v0.14.3's clobbered assets are being restored separately by re-running its original build. After this merges, the `v0.15.0` tag is re-pointed to the fixed commit for a clean release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)