### PR TITLE
Follow-up: settings read-only honesty, shared keyboard-activation helper, NewTabMenu fuzzy search

### DIFF
--- a/docs/design-system-impl/testid-manifest.md
+++ b/docs/design-system-impl/testid-manifest.md
@@ -162,11 +162,11 @@ more lines in `__snapshots__/testid-set.snap.txt`.
 
 ### Settings — modal (Wave 9 + responsive)
 - `settings-modal{,-scrim,-content,-close-btn,-narrow-hamburger}`
-- `settings-readonly-banner` — forward-compat read-only notice, rendered on
-  BOTH settings surfaces (modal: between header and scroll body; popover: above
-  the scroll body) when `settings._readOnly` is set. Distinct from
-  `store-readonly-banner` (ShortcutEditorList's inline notice, popover-only —
-  suppressed inside the modal via `showReadOnlyBanner={false}`).
+- `settings-readonly-banner` — forward-compat read-only notice
+  (`SettingsReadonlyBanner.svelte`), rendered on BOTH settings surfaces
+  (modal: between header and scroll body; popover: above the scroll body)
+  when `settings._readOnly` is set. Distinct from `store-readonly-banner`
+  (SidePanel's annotation-store lock banner).
 - `settings-modal-sidebar-{version,footer}`,
   `settings-modal-mcp-status`, `settings-modal-tab-{*}`,
   `settings-modal-display-name`, `settings-modal-shortcuts-list`,

--- a/docs/design-system-impl/testid-manifest.md
+++ b/docs/design-system-impl/testid-manifest.md
@@ -162,6 +162,11 @@ more lines in `__snapshots__/testid-set.snap.txt`.
 
 ### Settings — modal (Wave 9 + responsive)
 - `settings-modal{,-scrim,-content,-close-btn,-narrow-hamburger}`
+- `settings-readonly-banner` — forward-compat read-only notice, rendered on
+  BOTH settings surfaces (modal: between header and scroll body; popover: above
+  the scroll body) when `settings._readOnly` is set. Distinct from
+  `store-readonly-banner` (ShortcutEditorList's inline notice, popover-only —
+  suppressed inside the modal via `showReadOnlyBanner={false}`).
 - `settings-modal-sidebar-{version,footer}`,
   `settings-modal-mcp-status`, `settings-modal-tab-{*}`,
   `settings-modal-display-name`, `settings-modal-shortcuts-list`,

--- a/src/client/components/AccessibilitySettings.svelte
+++ b/src/client/components/AccessibilitySettings.svelte
@@ -3,7 +3,7 @@ import type { SettingsTabContext } from "./SettingsModal.svelte";
 
 type Props = SettingsTabContext;
 
-let { settings, onUpdate }: Props = $props();
+let { settings, onUpdate, readOnly }: Props = $props();
 
 const sectionLabelStyle =
   "font-size: 11px; font-weight: 600; color: var(--tandem-fg); margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px;";
@@ -18,8 +18,9 @@ const sectionLabelStyle =
     <input
       type="checkbox"
       checked={settings.highContrast}
+      disabled={readOnly}
       onchange={(e) => onUpdate({ highContrast: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent);"
+      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
     />
     <span>High contrast</span>
   </label>
@@ -37,8 +38,9 @@ const sectionLabelStyle =
     <input
       type="checkbox"
       checked={settings.annotationPatterns}
+      disabled={readOnly}
       onchange={(e) => onUpdate({ annotationPatterns: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent);"
+      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
     />
     <span>Use pattern fills for annotations</span>
   </label>

--- a/src/client/components/AccessibilitySettings.svelte
+++ b/src/client/components/AccessibilitySettings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { disabledControlStyle } from "../utils/colors";
 import type { SettingsTabContext } from "./SettingsModal.svelte";
 
 type Props = SettingsTabContext;
@@ -20,7 +21,7 @@ const sectionLabelStyle =
       checked={settings.highContrast}
       disabled={readOnly}
       onchange={(e) => onUpdate({ highContrast: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+      style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
     />
     <span>High contrast</span>
   </label>
@@ -40,7 +41,7 @@ const sectionLabelStyle =
       checked={settings.annotationPatterns}
       disabled={readOnly}
       onchange={(e) => onUpdate({ annotationPatterns: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+      style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
     />
     <span>Use pattern fills for annotations</span>
   </label>

--- a/src/client/components/AppearanceSettings.svelte
+++ b/src/client/components/AppearanceSettings.svelte
@@ -7,6 +7,7 @@ import type {
   TextSize,
   ThemePreference,
 } from "../hooks/useTandemSettings.svelte";
+import { disabledControlStyle } from "../utils/colors";
 import type { SettingsTabContext } from "./SettingsModal.svelte";
 
 type Props = SettingsTabContext;
@@ -64,12 +65,11 @@ function cardStyle(selected: boolean, disabled?: boolean): string {
     `border: 2px solid ${selected ? "var(--tandem-accent)" : "var(--tandem-border)"};`,
     "border-radius: var(--tandem-r-3);",
     `background: ${disabled ? "var(--tandem-surface-muted)" : selected ? "var(--tandem-accent-bg)" : "var(--tandem-surface)"};`,
-    `cursor: ${disabled ? "not-allowed" : "pointer"};`,
+    disabledControlStyle(disabled ?? false),
     "text-align: center;",
     "font-size: 11px;",
     `color: ${disabled ? "var(--tandem-fg-subtle)" : selected ? "var(--tandem-accent-fg-strong)" : "var(--tandem-fg-muted)"};`,
     `font-weight: ${selected ? 600 : 400};`,
-    `opacity: ${disabled ? 0.6 : 1};`,
     "transition: border-color 0.15s, background 0.15s;",
   ].join(" ");
 }
@@ -153,7 +153,7 @@ for (const row of FONT_FORMAT_ROWS) {
           onUpdate({
             systemLightVariant: (e.target as HTMLInputElement).checked ? "warm" : "light",
           })}
-        style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+        style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
       />
       <span>Use Warm when system is light</span>
     </label>
@@ -249,7 +249,7 @@ for (const row of FONT_FORMAT_ROWS) {
       value={settings.accentHue}
       disabled={readOnly}
       oninput={(e) => onUpdate({ accentHue: Number((e.target as HTMLInputElement).value) })}
-      style="flex: 1; accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'auto'}; opacity: {readOnly ? 0.5 : 1};"
+      style="flex: 1; accent-color: var(--tandem-accent); {disabledControlStyle(readOnly, 'auto')}"
     />
   </div>
 </div>
@@ -376,7 +376,7 @@ for (const row of FONT_FORMAT_ROWS) {
             [field]: (e.target as HTMLInputElement).checked,
             ...(settings.decorationsMuted ? { decorationsMuted: false } : {}),
           })}
-        style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+        style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
       />
       <span>{label}</span>
     </label>
@@ -400,7 +400,7 @@ for (const row of FONT_FORMAT_ROWS) {
       checked={settings.reduceMotion}
       disabled={readOnly}
       onchange={(e) => onUpdate({ reduceMotion: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+      style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
     />
     <span>Reduce motion</span>
   </label>
@@ -421,7 +421,7 @@ for (const row of FONT_FORMAT_ROWS) {
       disabled={readOnly}
       onchange={(e) =>
         onUpdate({ formattingBarVisible: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+      style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
     />
     <span>Show formatting bar</span>
   </label>
@@ -442,7 +442,7 @@ for (const row of FONT_FORMAT_ROWS) {
       checked={settings.showRawMarkdown}
       disabled={readOnly}
       onchange={(e) => onUpdate({ showRawMarkdown: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+      style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
     />
     <span>Show raw markdown</span>
   </label>
@@ -464,7 +464,7 @@ for (const row of FONT_FORMAT_ROWS) {
       checked={settings.railHoverReveal}
       disabled={readOnly}
       onchange={(e) => onUpdate({ railHoverReveal: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+      style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
     />
     <span>Reveal rails on hover</span>
   </label>

--- a/src/client/components/AppearanceSettings.svelte
+++ b/src/client/components/AppearanceSettings.svelte
@@ -11,7 +11,7 @@ import type { SettingsTabContext } from "./SettingsModal.svelte";
 
 type Props = SettingsTabContext;
 
-let { settings, onUpdate }: Props = $props();
+let { settings, onUpdate, readOnly }: Props = $props();
 
 // #811: per-format editor font. Keyed by the normalized `format` string
 // (matches `detectFormat`: `.markdown`→md, `.htm`→html).
@@ -129,8 +129,9 @@ for (const row of FONT_FORMAT_ROWS) {
         role="radio"
         aria-checked={settings.theme === t}
         tabindex={themeRg.tabIndexFor(t)}
+        disabled={readOnly}
         onclick={() => onUpdate({ theme: t })}
-        style={cardStyle(settings.theme === t)}
+        style={cardStyle(settings.theme === t, readOnly)}
       >
         {t === "light" ? "Light" : t === "warm" ? "Warm" : t === "dark" ? "Dark" : "System"}
       </button>
@@ -147,11 +148,12 @@ for (const row of FONT_FORMAT_ROWS) {
       <input
         type="checkbox"
         checked={settings.systemLightVariant === "warm"}
+        disabled={readOnly}
         onchange={(e) =>
           onUpdate({
             systemLightVariant: (e.target as HTMLInputElement).checked ? "warm" : "light",
           })}
-        style="accent-color: var(--tandem-accent);"
+        style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
       />
       <span>Use Warm when system is light</span>
     </label>
@@ -179,8 +181,9 @@ for (const row of FONT_FORMAT_ROWS) {
       role="radio"
       aria-checked={settings.primaryTab === "chat"}
       tabindex={primaryTabRg.tabIndexFor("chat")}
+      disabled={readOnly}
       onclick={() => onUpdate({ primaryTab: "chat" })}
-      style={cardStyle(settings.primaryTab === "chat")}
+      style={cardStyle(settings.primaryTab === "chat", readOnly)}
     >
       Chat
     </button>
@@ -189,8 +192,9 @@ for (const row of FONT_FORMAT_ROWS) {
       role="radio"
       aria-checked={settings.primaryTab === "annotations"}
       tabindex={primaryTabRg.tabIndexFor("annotations")}
+      disabled={readOnly}
       onclick={() => onUpdate({ primaryTab: "annotations" })}
-      style={cardStyle(settings.primaryTab === "annotations")}
+      style={cardStyle(settings.primaryTab === "annotations", readOnly)}
     >
       Annotations
     </button>
@@ -214,8 +218,9 @@ for (const row of FONT_FORMAT_ROWS) {
         role="radio"
         aria-checked={settings.textSize === size}
         tabindex={textSizeRg.tabIndexFor(size)}
+        disabled={readOnly}
         onclick={() => onUpdate({ textSize: size })}
-        style={cardStyle(settings.textSize === size)}
+        style={cardStyle(settings.textSize === size, readOnly)}
       >
         {size === "s" ? "Small" : size === "m" ? "Medium" : "Large"}
       </button>
@@ -242,8 +247,9 @@ for (const row of FONT_FORMAT_ROWS) {
       step="1"
       aria-labelledby="settings-accent-color-label"
       value={settings.accentHue}
+      disabled={readOnly}
       oninput={(e) => onUpdate({ accentHue: Number((e.target as HTMLInputElement).value) })}
-      style="flex: 1; accent-color: var(--tandem-accent);"
+      style="flex: 1; accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'auto'}; opacity: {readOnly ? 0.5 : 1};"
     />
   </div>
 </div>
@@ -264,8 +270,9 @@ for (const row of FONT_FORMAT_ROWS) {
         role="radio"
         aria-checked={settings.editorFont === value}
         tabindex={editorFontRg.tabIndexFor(value)}
+        disabled={readOnly}
         onclick={() => onUpdate({ editorFont: value })}
-        style={cardStyle(settings.editorFont === value)}
+        style={cardStyle(settings.editorFont === value, readOnly)}
       >
         {label}
       </button>
@@ -282,9 +289,9 @@ for (const row of FONT_FORMAT_ROWS) {
     <button
       data-testid="font-by-extension-reset"
       type="button"
-      disabled={!hasFontOverrides}
+      disabled={readOnly || !hasFontOverrides}
       onclick={resetFontsToDefaults}
-      style={`background: none; border: none; padding: 0; font-size: var(--tandem-text-2xs); color: ${hasFontOverrides ? "var(--tandem-accent-fg-strong)" : "var(--tandem-fg-subtle)"}; cursor: ${hasFontOverrides ? "pointer" : "default"}; text-decoration: ${hasFontOverrides ? "underline" : "none"};`}
+      style={`background: none; border: none; padding: 0; font-size: var(--tandem-text-2xs); color: ${!readOnly && hasFontOverrides ? "var(--tandem-accent-fg-strong)" : "var(--tandem-fg-subtle)"}; cursor: ${!readOnly && hasFontOverrides ? "pointer" : "not-allowed"}; text-decoration: ${!readOnly && hasFontOverrides ? "underline" : "none"};`}
     >
       Reset to defaults
     </button>
@@ -309,8 +316,9 @@ for (const row of FONT_FORMAT_ROWS) {
               role="radio"
               aria-checked={effectiveFontFor(row.format) === value}
               tabindex={fontByExtensionRgs[row.format].tabIndexFor(value)}
+              disabled={readOnly}
               onclick={() => setFontFor(row.format, value)}
-              style={cardStyle(effectiveFontFor(row.format) === value)}
+              style={cardStyle(effectiveFontFor(row.format) === value, readOnly)}
             >
               {label}
             </button>
@@ -340,8 +348,9 @@ for (const row of FONT_FORMAT_ROWS) {
         role="radio"
         aria-checked={settings.density === value}
         tabindex={densityRg.tabIndexFor(value)}
+        disabled={readOnly}
         onclick={() => onUpdate({ density: value })}
-        style={cardStyle(settings.density === value)}
+        style={cardStyle(settings.density === value, readOnly)}
       >
         {label}
       </button>
@@ -361,12 +370,13 @@ for (const row of FONT_FORMAT_ROWS) {
       <input
         type="checkbox"
         checked={settings[field]}
+        disabled={readOnly}
         onchange={(e) =>
           onUpdate({
             [field]: (e.target as HTMLInputElement).checked,
             ...(settings.decorationsMuted ? { decorationsMuted: false } : {}),
           })}
-        style="accent-color: var(--tandem-accent);"
+        style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
       />
       <span>{label}</span>
     </label>
@@ -388,8 +398,9 @@ for (const row of FONT_FORMAT_ROWS) {
     <input
       type="checkbox"
       checked={settings.reduceMotion}
+      disabled={readOnly}
       onchange={(e) => onUpdate({ reduceMotion: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent);"
+      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
     />
     <span>Reduce motion</span>
   </label>
@@ -407,9 +418,10 @@ for (const row of FONT_FORMAT_ROWS) {
     <input
       type="checkbox"
       checked={settings.formattingBarVisible}
+      disabled={readOnly}
       onchange={(e) =>
         onUpdate({ formattingBarVisible: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent);"
+      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
     />
     <span>Show formatting bar</span>
   </label>
@@ -428,8 +440,9 @@ for (const row of FONT_FORMAT_ROWS) {
     <input
       type="checkbox"
       checked={settings.showRawMarkdown}
+      disabled={readOnly}
       onchange={(e) => onUpdate({ showRawMarkdown: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent);"
+      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
     />
     <span>Show raw markdown</span>
   </label>
@@ -449,8 +462,9 @@ for (const row of FONT_FORMAT_ROWS) {
     <input
       type="checkbox"
       checked={settings.railHoverReveal}
+      disabled={readOnly}
       onchange={(e) => onUpdate({ railHoverReveal: (e.target as HTMLInputElement).checked })}
-      style="accent-color: var(--tandem-accent);"
+      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
     />
     <span>Reveal rails on hover</span>
   </label>

--- a/src/client/components/CommandPalette.svelte
+++ b/src/client/components/CommandPalette.svelte
@@ -6,7 +6,7 @@ import type { Annotation } from "../../shared/types.js";
 import { type Action, getActionsMap } from "../actions/registry.svelte.js";
 import { scrollFade } from "../actions/scrollFade.svelte.js";
 import { STATIC_SHORTCUT_ROWS } from "../actions/static-shortcuts.js";
-import { scoreFields, toSegments } from "../utils/fuzzy-match.js";
+import { rankByScore, scoreFields, toSegments } from "../utils/fuzzy-match.js";
 import { walkHeadings } from "../utils/headings.js";
 
 // ---------------------------------------------------------------------------
@@ -71,14 +71,9 @@ type PaletteResult = ActionResult | HeadingResult | AnnotationResult | ShortcutR
 // Result derivations
 // ---------------------------------------------------------------------------
 
-// Ranking helper shared by all four modes below: attach a stable original
-// index alongside the max weighted-field score, then sort desc by score with
-// an origIndex tiebreak (JS sort is stable, but the explicit tiebreak
-// documents the intent and survives a future non-stable-sort refactor).
-function rankByScore<T>(scored: { result: T; score: number; origIndex: number }[]): T[] {
-  scored.sort((a, b) => b.score - a.score || a.origIndex - b.origIndex);
-  return scored.map((s) => s.result);
-}
+// Ranking shared by all four modes below (and the new-tab launcher):
+// `rankByScore` from utils/fuzzy-match sorts desc by score with a stable
+// origIndex tiebreak.
 
 // Commands: `>` prefix or no prefix
 const commandResults = $derived.by((): ActionResult[] => {

--- a/src/client/components/CoworkAdminDeclinedModal.svelte
+++ b/src/client/components/CoworkAdminDeclinedModal.svelte
@@ -13,6 +13,7 @@ import {
   noteUacDeclinedAt,
 } from "../cowork/coworkAdminDismiss.svelte";
 import { createCoworkStatus } from "../hooks/useCoworkStatus.svelte";
+import { activationKeydown } from "../utils/keyboard-activate";
 
 const FOCUSABLE_SELECTOR =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -138,7 +139,11 @@ async function handleDisable(): Promise<void> {
     tabindex="-1" + aria-label gives svelte-check an interactive path without firing
     the noninteractive-click rule; Escape is handled by the window keydown effect
     above. tabindex="-1" keeps the backdrop out of the tab order so the dialog's focus
-    trap still works. The click guard dismisses only on a backdrop (not dialog) click.
+    trap still works. Both the click guard and the keydown (`selfOnly`) dismiss only
+    on the backdrop itself — the dialog is a CHILD of this div, so an unguarded
+    keydown would preventDefault() Enter/Space bubbling from the dialog's buttons
+    and link, breaking keyboard activation of every control inside while also
+    dismissing the popup out from under the user.
   -->
   <div
     class="cad-backdrop"
@@ -150,12 +155,12 @@ async function handleDisable(): Promise<void> {
       // `busy` guard: don't dismiss while a disable is in flight (see Escape handler).
       if (!busy && e.target === e.currentTarget) dismissAdminPopup();
     }}
-    onkeydown={(e) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
+    onkeydown={activationKeydown(
+      () => {
         if (!busy) dismissAdminPopup();
-      }
-    }}
+      },
+      { selfOnly: true },
+    )}
   >
     <div
       bind:this={modalEl}

--- a/src/client/components/EditorSettings.svelte
+++ b/src/client/components/EditorSettings.svelte
@@ -6,7 +6,7 @@ import type { SettingsTabContext } from "./SettingsModal.svelte";
 
 type Props = SettingsTabContext;
 
-let { settings, onUpdate, notify }: Props = $props();
+let { settings, onUpdate, notify, readOnly }: Props = $props();
 
 const sectionLabelStyle =
   "font-size: 11px; font-weight: 600; color: var(--tandem-fg); margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px;";
@@ -18,6 +18,7 @@ const sectionLabelStyle =
 const isTauri = isTauriRuntime();
 
 function commitSaveDirectory(value: string | null) {
+  if (readOnly) return;
   // mergeAndClampSettings re-normalizes (trim → null), but coerce empty here
   // too so the optimistic UI state matches what gets persisted.
   const trimmed = value?.trim();
@@ -93,8 +94,9 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
         aria-checked={active}
         tabindex={measureRg.tabIndexFor(preset.value)}
         data-testid={`editor-measure-${preset.value}`}
+        disabled={readOnly}
         onclick={() => onUpdate({ editorMeasure: preset.value })}
-        style={`flex: 1; padding: 6px 4px; border: none; border-radius: var(--tandem-r-1); cursor: pointer; font-size: 11px; font-weight: ${active ? 600 : 400}; background: ${active ? "var(--tandem-accent)" : "transparent"}; color: ${active ? "var(--tandem-accent-fg)" : "var(--tandem-fg)"};`}
+        style={`flex: 1; padding: 6px 4px; border: none; border-radius: var(--tandem-r-1); cursor: ${readOnly ? "not-allowed" : "pointer"}; opacity: ${readOnly ? 0.5 : 1}; font-size: 11px; font-weight: ${active ? 600 : 400}; background: ${active ? "var(--tandem-accent)" : "transparent"}; color: ${active ? "var(--tandem-accent-fg)" : "var(--tandem-fg)"};`}
       >
         {preset.label}
       </button>
@@ -120,17 +122,19 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
         name="default-save-dir"
         data-testid="settings-default-save-folder-input"
         value={settings.defaultSaveDirectory ?? ""}
+        disabled={readOnly}
         onblur={(e) => commitSaveDirectory((e.currentTarget as HTMLInputElement).value)}
         placeholder="(default: AI working directory, then home)"
         aria-label="Default save folder path"
-        style="flex: 1; min-width: 0; padding: 6px 8px; font-size: 11px; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg);"
+        style="flex: 1; min-width: 0; padding: 6px 8px; font-size: 11px; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg); cursor: {readOnly ? 'not-allowed' : 'auto'}; opacity: {readOnly ? 0.5 : 1};"
       />
       {#if isTauri}
         <button
           type="button"
           data-testid="settings-default-save-folder-pick"
+          disabled={readOnly}
           onclick={pickSaveFolder}
-          style="padding: 6px 10px; font-size: 11px; white-space: nowrap; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg); cursor: pointer;"
+          style="padding: 6px 10px; font-size: 11px; white-space: nowrap; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
         >
           Choose…
         </button>
@@ -139,8 +143,8 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
         type="button"
         data-testid="settings-default-save-folder-reset"
         onclick={() => commitSaveDirectory(null)}
-        disabled={!settings.defaultSaveDirectory}
-        style={`padding: 6px 10px; font-size: 11px; white-space: nowrap; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: transparent; color: var(--tandem-fg-muted); cursor: ${settings.defaultSaveDirectory ? "pointer" : "default"}; opacity: ${settings.defaultSaveDirectory ? 1 : 0.5};`}
+        disabled={readOnly || !settings.defaultSaveDirectory}
+        style={`padding: 6px 10px; font-size: 11px; white-space: nowrap; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: transparent; color: var(--tandem-fg-muted); cursor: ${!readOnly && settings.defaultSaveDirectory ? "pointer" : "not-allowed"}; opacity: ${!readOnly && settings.defaultSaveDirectory ? 1 : 0.5};`}
       >
         Reset
       </button>
@@ -156,8 +160,9 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
       <input
         type="checkbox"
         checked={settings.smartTypography}
+        disabled={readOnly}
         onchange={(e) => onUpdate({ smartTypography: (e.target as HTMLInputElement).checked })}
-        style="accent-color: var(--tandem-accent);"
+        style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
       />
       <span>Smart typography</span>
     </label>
@@ -177,8 +182,9 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
       <input
         type="checkbox"
         checked={settings.spellcheck}
+        disabled={readOnly}
         onchange={(e) => onUpdate({ spellcheck: (e.target as HTMLInputElement).checked })}
-        style="accent-color: var(--tandem-accent);"
+        style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
       />
       <span>Spellcheck</span>
     </label>

--- a/src/client/components/EditorSettings.svelte
+++ b/src/client/components/EditorSettings.svelte
@@ -2,6 +2,7 @@
 import { isTauriRuntime } from "../cowork/cowork-helpers";
 import { createRadioGroup } from "../hooks/useRadioGroup.svelte";
 import type { EditorMeasure } from "../hooks/useTandemSettings";
+import { disabledControlStyle } from "../utils/colors";
 import type { SettingsTabContext } from "./SettingsModal.svelte";
 
 type Props = SettingsTabContext;
@@ -18,7 +19,6 @@ const sectionLabelStyle =
 const isTauri = isTauriRuntime();
 
 function commitSaveDirectory(value: string | null) {
-  if (readOnly) return;
   // mergeAndClampSettings re-normalizes (trim → null), but coerce empty here
   // too so the optimistic UI state matches what gets persisted.
   const trimmed = value?.trim();
@@ -96,7 +96,7 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
         data-testid={`editor-measure-${preset.value}`}
         disabled={readOnly}
         onclick={() => onUpdate({ editorMeasure: preset.value })}
-        style={`flex: 1; padding: 6px 4px; border: none; border-radius: var(--tandem-r-1); cursor: ${readOnly ? "not-allowed" : "pointer"}; opacity: ${readOnly ? 0.5 : 1}; font-size: 11px; font-weight: ${active ? 600 : 400}; background: ${active ? "var(--tandem-accent)" : "transparent"}; color: ${active ? "var(--tandem-accent-fg)" : "var(--tandem-fg)"};`}
+        style={`flex: 1; padding: 6px 4px; border: none; border-radius: var(--tandem-r-1); ${disabledControlStyle(readOnly)} font-size: 11px; font-weight: ${active ? 600 : 400}; background: ${active ? "var(--tandem-accent)" : "transparent"}; color: ${active ? "var(--tandem-accent-fg)" : "var(--tandem-fg)"};`}
       >
         {preset.label}
       </button>
@@ -126,7 +126,7 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
         onblur={(e) => commitSaveDirectory((e.currentTarget as HTMLInputElement).value)}
         placeholder="(default: AI working directory, then home)"
         aria-label="Default save folder path"
-        style="flex: 1; min-width: 0; padding: 6px 8px; font-size: 11px; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg); cursor: {readOnly ? 'not-allowed' : 'auto'}; opacity: {readOnly ? 0.5 : 1};"
+        style="flex: 1; min-width: 0; padding: 6px 8px; font-size: 11px; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg); {disabledControlStyle(readOnly, 'auto')}"
       />
       {#if isTauri}
         <button
@@ -134,7 +134,7 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
           data-testid="settings-default-save-folder-pick"
           disabled={readOnly}
           onclick={pickSaveFolder}
-          style="padding: 6px 10px; font-size: 11px; white-space: nowrap; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+          style="padding: 6px 10px; font-size: 11px; white-space: nowrap; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: var(--tandem-surface); color: var(--tandem-fg); {disabledControlStyle(readOnly)}"
         >
           Choose…
         </button>
@@ -144,7 +144,7 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
         data-testid="settings-default-save-folder-reset"
         onclick={() => commitSaveDirectory(null)}
         disabled={readOnly || !settings.defaultSaveDirectory}
-        style={`padding: 6px 10px; font-size: 11px; white-space: nowrap; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: transparent; color: var(--tandem-fg-muted); cursor: ${!readOnly && settings.defaultSaveDirectory ? "pointer" : "not-allowed"}; opacity: ${!readOnly && settings.defaultSaveDirectory ? 1 : 0.5};`}
+        style={`padding: 6px 10px; font-size: 11px; white-space: nowrap; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-1); background: transparent; color: var(--tandem-fg-muted); ${disabledControlStyle(readOnly || !settings.defaultSaveDirectory)}`}
       >
         Reset
       </button>
@@ -162,7 +162,7 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
         checked={settings.smartTypography}
         disabled={readOnly}
         onchange={(e) => onUpdate({ smartTypography: (e.target as HTMLInputElement).checked })}
-        style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+        style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
       />
       <span>Smart typography</span>
     </label>
@@ -184,7 +184,7 @@ const activeHint = $derived(PRESETS.find((p) => p.value === settings.editorMeasu
         checked={settings.spellcheck}
         disabled={readOnly}
         onchange={(e) => onUpdate({ spellcheck: (e.target as HTMLInputElement).checked })}
-        style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+        style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
       />
       <span>Spellcheck</span>
     </label>

--- a/src/client/components/NetworkSettings.svelte
+++ b/src/client/components/NetworkSettings.svelte
@@ -2,6 +2,7 @@
 import { isTauriRuntime } from "../cowork/cowork-helpers.js";
 import { createAppInfo } from "../hooks/useAppInfo.svelte.js";
 import type { SidecarRetryStrategy } from "../hooks/useTandemSettings.svelte.js";
+import { disabledControlStyle } from "../utils/colors.js";
 import CollapsibleSection from "./CollapsibleSection.svelte";
 import type { SettingsTabContext } from "./SettingsModal.svelte";
 
@@ -136,7 +137,7 @@ const tokenRotatedAt = $derived(appInfo.info?.tokenRotatedAt);
       disabled={readOnly}
       oninput={(e) =>
         onUpdate({ degradedBannerDelayMs: Number((e.target as HTMLInputElement).value) })}
-      style="width: 100%; accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'auto'}; opacity: {readOnly ? 0.5 : 1};"
+      style="width: 100%; accent-color: var(--tandem-accent); {disabledControlStyle(readOnly, 'auto')}"
       aria-label="Degraded banner delay"
     />
     <div
@@ -156,7 +157,7 @@ const tokenRotatedAt = $derived(appInfo.info?.tokenRotatedAt);
       disabled={readOnly}
       onchange={(e) =>
         onUpdate({ sidecarRetryStrategy: (e.target as HTMLSelectElement).value as SidecarRetryStrategy })}
-      style="width: 100%; padding: 6px 8px; font-size: 13px; color: var(--tandem-fg); background: var(--tandem-surface); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+      style="width: 100%; padding: 6px 8px; font-size: 13px; color: var(--tandem-fg); background: var(--tandem-surface); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); {disabledControlStyle(readOnly)}"
       aria-label="Reconnect retry strategy"
     >
       {#each RETRY_OPTIONS as opt (opt.value)}

--- a/src/client/components/NetworkSettings.svelte
+++ b/src/client/components/NetworkSettings.svelte
@@ -7,7 +7,7 @@ import type { SettingsTabContext } from "./SettingsModal.svelte";
 
 type Props = SettingsTabContext;
 
-const { open, settings, onUpdate, connected, reconnectAttempts }: Props = $props();
+const { open, settings, onUpdate, connected, reconnectAttempts, readOnly }: Props = $props();
 
 const appInfo = createAppInfo(() => open);
 const isTauri = isTauriRuntime();
@@ -133,9 +133,10 @@ const tokenRotatedAt = $derived(appInfo.info?.tokenRotatedAt);
       max="120000"
       step="5000"
       value={settings.degradedBannerDelayMs}
+      disabled={readOnly}
       oninput={(e) =>
         onUpdate({ degradedBannerDelayMs: Number((e.target as HTMLInputElement).value) })}
-      style="width: 100%; accent-color: var(--tandem-accent);"
+      style="width: 100%; accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'auto'}; opacity: {readOnly ? 0.5 : 1};"
       aria-label="Degraded banner delay"
     />
     <div
@@ -152,9 +153,10 @@ const tokenRotatedAt = $derived(appInfo.info?.tokenRotatedAt);
     <select
       data-testid="network-retry-strategy"
       value={settings.sidecarRetryStrategy}
+      disabled={readOnly}
       onchange={(e) =>
         onUpdate({ sidecarRetryStrategy: (e.target as HTMLSelectElement).value as SidecarRetryStrategy })}
-      style="width: 100%; padding: 6px 8px; font-size: 13px; color: var(--tandem-fg); background: var(--tandem-surface); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); cursor: pointer;"
+      style="width: 100%; padding: 6px 8px; font-size: 13px; color: var(--tandem-fg); background: var(--tandem-surface); border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
       aria-label="Reconnect retry strategy"
     >
       {#each RETRY_OPTIONS as opt (opt.value)}

--- a/src/client/components/SettingsModal.svelte
+++ b/src/client/components/SettingsModal.svelte
@@ -85,9 +85,9 @@ import { onMount, untrack } from "svelte";
 import { BYO_MODELS_ENABLED, TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
 import { scrollFade } from "../actions/scrollFade.svelte";
 import { createAppInfo } from "../hooks/useAppInfo.svelte";
-import { warningStateColors } from "../utils/colors";
 import { activationKeydown } from "../utils/keyboard-activate";
 import { openServerPath } from "../utils/server-paths";
+import SettingsReadonlyBanner from "./SettingsReadonlyBanner.svelte";
 import AccessibilitySettings from "./AccessibilitySettings.svelte";
 import AppearanceSettings from "./AppearanceSettings.svelte";
 import EditorSettings from "./EditorSettings.svelte";
@@ -616,18 +616,8 @@ async function handleViewChangelog(): Promise<void> {
 
       {#if readOnly}
         <!-- Non-flexing row between the header and the scroll body so every
-             tab shows it. Distinct testid from ShortcutEditorList's inline
-             store-readonly-banner (that one is suppressed inside the modal —
-             this banner covers the whole surface). -->
-        <div
-          class="settings-modal-readonly-banner"
-          data-testid="settings-readonly-banner"
-          role="note"
-          style="background: {warningStateColors.background}; border-block: 1px solid {warningStateColors.border}; color: {warningStateColors.color};"
-        >
-          Settings are read-only — they were saved by a newer version of Tandem. Changes are
-          disabled to protect them.
-        </div>
+             tab shows it. -->
+        <SettingsReadonlyBanner />
       {/if}
 
       <div class="settings-modal-content-body tandem-scroll-fade-y" use:scrollFade={"y"}>
@@ -858,13 +848,6 @@ async function handleViewChangelog(): Promise<void> {
     outline: none;
   }
 
-  .settings-modal-readonly-banner {
-    flex-shrink: 0;
-    padding: var(--tandem-space-2) var(--tandem-space-5);
-    font-size: var(--tandem-text-xs);
-    line-height: 1.4;
-  }
-
   .settings-modal-content-body {
     flex: 1;
     overflow-y: auto;
@@ -933,6 +916,12 @@ async function handleViewChangelog(): Promise<void> {
   :global(.settings-mode-btn:focus-visible) {
     outline: 2px solid var(--tandem-accent);
     outline-offset: 1px;
+  }
+  /* Forward-compat read-only store: the tab sets `disabled` on these radios;
+     the affordance lives here with the rest of the class's state variants. */
+  :global(.settings-mode-btn:disabled) {
+    cursor: not-allowed;
+    opacity: 0.5;
   }
 
   /* W9: narrow viewports collapse the persistent sidebar grid column into a

--- a/src/client/components/SettingsModal.svelte
+++ b/src/client/components/SettingsModal.svelte
@@ -23,6 +23,15 @@ export interface SettingsTabContext {
   connected: boolean;
   reconnectAttempts: number;
   /**
+   * True when the settings store is forward-compat read-only
+   * (`settings._readOnly` — on-disk schemaVersion is newer than this build).
+   * `onUpdate` silently no-ops in that state; tabs must `disabled` every
+   * control that writes settings so one-way-bound checkboxes/radios don't
+   * flip visually and go stale. Required (not optional) so the compiler
+   * forces every context constructor to thread it.
+   */
+  readOnly: boolean;
+  /**
    * Push a transient toast notification. Tabs use this for ephemeral
    * "saved" / "failed" feedback that doesn't warrant a dedicated banner.
    * Fixed strings only — never include raw `err.message` (path leak risk).
@@ -76,6 +85,7 @@ import { onMount, untrack } from "svelte";
 import { BYO_MODELS_ENABLED, TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
 import { scrollFade } from "../actions/scrollFade.svelte";
 import { createAppInfo } from "../hooks/useAppInfo.svelte";
+import { warningStateColors } from "../utils/colors";
 import { activationKeydown } from "../utils/keyboard-activate";
 import { openServerPath } from "../utils/server-paths";
 import AccessibilitySettings from "./AccessibilitySettings.svelte";
@@ -272,12 +282,19 @@ const activeTab = $derived(
 );
 const activeTabLabel = $derived(activeTab.label);
 
+// Forward-compat read-only: derived once here, threaded to every tab via
+// the context. The hook's silent no-op in `updateSettings` is the
+// load-bearing guard; `readOnly` exists so tabs can disable their write
+// controls for honest affordance (see SettingsTabContext.readOnly).
+const readOnly = $derived(settings._readOnly === true);
+
 const tabContext = $derived<SettingsTabContext>({
   open,
   settings,
   onUpdate,
   connected,
   reconnectAttempts,
+  readOnly,
   notify,
 });
 
@@ -597,6 +614,22 @@ async function handleViewChangelog(): Promise<void> {
         </button>
       </header>
 
+      {#if readOnly}
+        <!-- Non-flexing row between the header and the scroll body so every
+             tab shows it. Distinct testid from ShortcutEditorList's inline
+             store-readonly-banner (that one is suppressed inside the modal —
+             this banner covers the whole surface). -->
+        <div
+          class="settings-modal-readonly-banner"
+          data-testid="settings-readonly-banner"
+          role="note"
+          style="background: {warningStateColors.background}; border-block: 1px solid {warningStateColors.border}; color: {warningStateColors.color};"
+        >
+          Settings are read-only — they were saved by a newer version of Tandem. Changes are
+          disabled to protect them.
+        </div>
+      {/if}
+
       <div class="settings-modal-content-body tandem-scroll-fade-y" use:scrollFade={"y"}>
         <div class="settings-modal-content-inner">
           {#key activeTab.id}
@@ -823,6 +856,13 @@ async function handleViewChangelog(): Promise<void> {
     color: var(--tandem-fg);
     background: var(--tandem-surface-sunk);
     outline: none;
+  }
+
+  .settings-modal-readonly-banner {
+    flex-shrink: 0;
+    padding: var(--tandem-space-2) var(--tandem-space-5);
+    font-size: var(--tandem-text-xs);
+    line-height: 1.4;
   }
 
   .settings-modal-content-body {

--- a/src/client/components/SettingsModal.svelte
+++ b/src/client/components/SettingsModal.svelte
@@ -76,6 +76,7 @@ import { onMount, untrack } from "svelte";
 import { BYO_MODELS_ENABLED, TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
 import { scrollFade } from "../actions/scrollFade.svelte";
 import { createAppInfo } from "../hooks/useAppInfo.svelte";
+import { activationKeydown } from "../utils/keyboard-activate";
 import { openServerPath } from "../utils/server-paths";
 import AccessibilitySettings from "./AccessibilitySettings.svelte";
 import AppearanceSettings from "./AppearanceSettings.svelte";
@@ -435,12 +436,7 @@ async function handleViewChangelog(): Promise<void> {
     tabindex="-1"
     aria-label="Close settings"
     onclick={onClose}
-    onkeydown={(e) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        onClose();
-      }
-    }}
+    onkeydown={activationKeydown(onClose)}
     data-testid="settings-modal-scrim"
     style="position: fixed; inset: 0; background: color-mix(in srgb, var(--tandem-bg) 70%, transparent); z-index: var(--tandem-z-above-titlebar);"
   ></div>

--- a/src/client/components/SettingsPopover.svelte
+++ b/src/client/components/SettingsPopover.svelte
@@ -9,6 +9,7 @@ import { isTauriRuntime } from "../cowork/cowork-helpers";
 import { createAppInfo } from "../hooks/useAppInfo.svelte";
 import type { TandemSettings } from "../hooks/useTandemSettings.svelte";
 import { createUserName } from "../hooks/useUserName.svelte";
+import { warningStateColors } from "../utils/colors";
 import { openServerPath } from "../utils/server-paths";
 import AccessibilitySettings from "./AccessibilitySettings.svelte";
 import AppearanceSettings from "./AppearanceSettings.svelte";
@@ -96,6 +97,11 @@ let {
 
 let popoverEl: HTMLDivElement | undefined = $state();
 let inputEl: HTMLInputElement | undefined = $state();
+
+// Forward-compat read-only (see SettingsTabContext.readOnly in
+// SettingsModal): onUpdate silently no-ops, so write controls must be
+// disabled for honest affordance. Display name stays live (separate store).
+const readOnly = $derived(settings._readOnly === true);
 
 const userNameState = createUserName();
 let nameInput = $state(userNameState.userName);
@@ -401,6 +407,19 @@ function aboutRows() {
         </button>
       </header>
 
+      {#if readOnly}
+        <!-- Same testid as the SettingsModal banner (snapshot set dedups) —
+             rendered once per surface, above the scroll body. -->
+        <div
+          data-testid="settings-readonly-banner"
+          role="note"
+          style="flex-shrink: 0; padding: var(--tandem-space-2) var(--tandem-space-5); font-size: var(--tandem-text-xs); line-height: 1.4; background: {warningStateColors.background}; border-bottom: 1px solid {warningStateColors.border}; color: {warningStateColors.color};"
+        >
+          Settings are read-only — they were saved by a newer version of Tandem. Changes are
+          disabled to protect them.
+        </div>
+      {/if}
+
       <div style="flex: 1; overflow-y: auto; padding: var(--tandem-space-5);">
         <div style="display: flex; flex-direction: column; gap: var(--tandem-space-5); max-width: 620px;">
           {#if activeSection === "collaboration"}
@@ -438,8 +457,9 @@ function aboutRows() {
                   data-testid="default-mode-tandem-btn"
                   role="radio"
                   aria-checked={settings.defaultMode === "tandem"}
+                  disabled={readOnly}
                   onclick={() => onUpdate({ defaultMode: "tandem" })}
-                  style="flex: 1; padding: var(--tandem-space-2); min-height: 30px; border: 2px solid {settings.defaultMode === 'tandem' ? 'var(--tandem-accent)' : 'var(--tandem-border)'}; border-radius: var(--tandem-r-3); background: {settings.defaultMode === 'tandem' ? 'var(--tandem-accent-bg)' : 'var(--tandem-surface)'}; color: {settings.defaultMode === 'tandem' ? 'var(--tandem-accent-fg-strong)' : 'var(--tandem-fg-muted)'}; font-size: 12px; font-weight: {settings.defaultMode === 'tandem' ? 600 : 400}; cursor: pointer;"
+                  style="flex: 1; padding: var(--tandem-space-2); min-height: 30px; border: 2px solid {settings.defaultMode === 'tandem' ? 'var(--tandem-accent)' : 'var(--tandem-border)'}; border-radius: var(--tandem-r-3); background: {settings.defaultMode === 'tandem' ? 'var(--tandem-accent-bg)' : 'var(--tandem-surface)'}; color: {settings.defaultMode === 'tandem' ? 'var(--tandem-accent-fg-strong)' : 'var(--tandem-fg-muted)'}; font-size: 12px; font-weight: {settings.defaultMode === 'tandem' ? 600 : 400}; cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
                 >
                   Tandem
                 </button>
@@ -448,8 +468,9 @@ function aboutRows() {
                   data-testid="default-mode-solo-btn"
                   role="radio"
                   aria-checked={settings.defaultMode === "solo"}
+                  disabled={readOnly}
                   onclick={() => onUpdate({ defaultMode: "solo" })}
-                  style="flex: 1; padding: var(--tandem-space-2); min-height: 30px; border: 2px solid {settings.defaultMode === 'solo' ? 'var(--tandem-accent)' : 'var(--tandem-border)'}; border-radius: var(--tandem-r-3); background: {settings.defaultMode === 'solo' ? 'var(--tandem-accent-bg)' : 'var(--tandem-surface)'}; color: {settings.defaultMode === 'solo' ? 'var(--tandem-accent-fg-strong)' : 'var(--tandem-fg-muted)'}; font-size: 12px; font-weight: {settings.defaultMode === 'solo' ? 600 : 400}; cursor: pointer;"
+                  style="flex: 1; padding: var(--tandem-space-2); min-height: 30px; border: 2px solid {settings.defaultMode === 'solo' ? 'var(--tandem-accent)' : 'var(--tandem-border)'}; border-radius: var(--tandem-r-3); background: {settings.defaultMode === 'solo' ? 'var(--tandem-accent-bg)' : 'var(--tandem-surface)'}; color: {settings.defaultMode === 'solo' ? 'var(--tandem-accent-fg-strong)' : 'var(--tandem-fg-muted)'}; font-size: 12px; font-weight: {settings.defaultMode === 'solo' ? 600 : 400}; cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
                 >
                   Solo
                 </button>
@@ -466,8 +487,9 @@ function aboutRows() {
               <input
                 type="checkbox"
                 checked={settings.soloRailHidden}
+                disabled={readOnly}
                 onchange={(e) => onUpdate({ soloRailHidden: (e.target as HTMLInputElement).checked })}
-                style="accent-color: var(--tandem-accent);"
+                style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
               />
               <span>Hide side panel in Solo mode</span>
             </label>
@@ -482,6 +504,7 @@ function aboutRows() {
               {onUpdate}
               {connected}
               {reconnectAttempts}
+              {readOnly}
               notify={noopNotify}
             />
           {:else if activeSection === "editor"}
@@ -491,6 +514,7 @@ function aboutRows() {
               {onUpdate}
               {connected}
               {reconnectAttempts}
+              {readOnly}
               notify={noopNotify}
             />
           {:else if activeSection === "network"}
@@ -500,6 +524,7 @@ function aboutRows() {
               {onUpdate}
               {connected}
               {reconnectAttempts}
+              {readOnly}
               notify={noopNotify}
             />
           {:else if activeSection === "accessibility"}
@@ -509,6 +534,7 @@ function aboutRows() {
               {onUpdate}
               {connected}
               {reconnectAttempts}
+              {readOnly}
               notify={noopNotify}
             />
           {:else if activeSection === "claude-code"}
@@ -529,8 +555,9 @@ function aboutRows() {
                 max={SELECTION_DWELL_MAX_MS}
                 step={100}
                 value={settings.selectionDwellMs}
+                disabled={readOnly}
                 oninput={(e) => onUpdate({ selectionDwellMs: Number((e.target as HTMLInputElement).value) })}
-                style="width: 100%; accent-color: var(--tandem-accent);"
+                style="width: 100%; accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'auto'}; opacity: {readOnly ? 0.5 : 1};"
                 aria-label="Selection dwell time"
               />
               <div style="display: flex; justify-content: space-between; font-size: 10px; color: var(--tandem-fg-subtle);">
@@ -546,8 +573,9 @@ function aboutRows() {
               <input
                 type="checkbox"
                 checked={settings.selectionToolbar}
+                disabled={readOnly}
                 onchange={(e) => onUpdate({ selectionToolbar: (e.target as HTMLInputElement).checked })}
-                style="accent-color: var(--tandem-accent);"
+                style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
               />
               <span>Show floating selection toolbar</span>
             </label>
@@ -559,8 +587,9 @@ function aboutRows() {
               <input
                 type="checkbox"
                 checked={settings.marginView}
+                disabled={readOnly}
                 onchange={(e) => onUpdate({ marginView: (e.target as HTMLInputElement).checked })}
-                style="accent-color: var(--tandem-accent);"
+                style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
               />
               <span>Margin annotation view (Word-style)</span>
             </label>

--- a/src/client/components/SettingsPopover.svelte
+++ b/src/client/components/SettingsPopover.svelte
@@ -9,12 +9,13 @@ import { isTauriRuntime } from "../cowork/cowork-helpers";
 import { createAppInfo } from "../hooks/useAppInfo.svelte";
 import type { TandemSettings } from "../hooks/useTandemSettings.svelte";
 import { createUserName } from "../hooks/useUserName.svelte";
-import { warningStateColors } from "../utils/colors";
+import { disabledControlStyle } from "../utils/colors";
 import { openServerPath } from "../utils/server-paths";
 import AccessibilitySettings from "./AccessibilitySettings.svelte";
 import AppearanceSettings from "./AppearanceSettings.svelte";
 import EditorSettings from "./EditorSettings.svelte";
 import NetworkSettings from "./NetworkSettings.svelte";
+import SettingsReadonlyBanner from "./SettingsReadonlyBanner.svelte";
 import ShortcutEditorList from "./ShortcutEditorList.svelte";
 
 const HEADING_ID = "tandem-settings-heading";
@@ -408,16 +409,7 @@ function aboutRows() {
       </header>
 
       {#if readOnly}
-        <!-- Same testid as the SettingsModal banner (snapshot set dedups) —
-             rendered once per surface, above the scroll body. -->
-        <div
-          data-testid="settings-readonly-banner"
-          role="note"
-          style="flex-shrink: 0; padding: var(--tandem-space-2) var(--tandem-space-5); font-size: var(--tandem-text-xs); line-height: 1.4; background: {warningStateColors.background}; border-bottom: 1px solid {warningStateColors.border}; color: {warningStateColors.color};"
-        >
-          Settings are read-only — they were saved by a newer version of Tandem. Changes are
-          disabled to protect them.
-        </div>
+        <SettingsReadonlyBanner />
       {/if}
 
       <div style="flex: 1; overflow-y: auto; padding: var(--tandem-space-5);">
@@ -459,7 +451,7 @@ function aboutRows() {
                   aria-checked={settings.defaultMode === "tandem"}
                   disabled={readOnly}
                   onclick={() => onUpdate({ defaultMode: "tandem" })}
-                  style="flex: 1; padding: var(--tandem-space-2); min-height: 30px; border: 2px solid {settings.defaultMode === 'tandem' ? 'var(--tandem-accent)' : 'var(--tandem-border)'}; border-radius: var(--tandem-r-3); background: {settings.defaultMode === 'tandem' ? 'var(--tandem-accent-bg)' : 'var(--tandem-surface)'}; color: {settings.defaultMode === 'tandem' ? 'var(--tandem-accent-fg-strong)' : 'var(--tandem-fg-muted)'}; font-size: 12px; font-weight: {settings.defaultMode === 'tandem' ? 600 : 400}; cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+                  style="flex: 1; padding: var(--tandem-space-2); min-height: 30px; border: 2px solid {settings.defaultMode === 'tandem' ? 'var(--tandem-accent)' : 'var(--tandem-border)'}; border-radius: var(--tandem-r-3); background: {settings.defaultMode === 'tandem' ? 'var(--tandem-accent-bg)' : 'var(--tandem-surface)'}; color: {settings.defaultMode === 'tandem' ? 'var(--tandem-accent-fg-strong)' : 'var(--tandem-fg-muted)'}; font-size: 12px; font-weight: {settings.defaultMode === 'tandem' ? 600 : 400}; {disabledControlStyle(readOnly)}"
                 >
                   Tandem
                 </button>
@@ -470,7 +462,7 @@ function aboutRows() {
                   aria-checked={settings.defaultMode === "solo"}
                   disabled={readOnly}
                   onclick={() => onUpdate({ defaultMode: "solo" })}
-                  style="flex: 1; padding: var(--tandem-space-2); min-height: 30px; border: 2px solid {settings.defaultMode === 'solo' ? 'var(--tandem-accent)' : 'var(--tandem-border)'}; border-radius: var(--tandem-r-3); background: {settings.defaultMode === 'solo' ? 'var(--tandem-accent-bg)' : 'var(--tandem-surface)'}; color: {settings.defaultMode === 'solo' ? 'var(--tandem-accent-fg-strong)' : 'var(--tandem-fg-muted)'}; font-size: 12px; font-weight: {settings.defaultMode === 'solo' ? 600 : 400}; cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+                  style="flex: 1; padding: var(--tandem-space-2); min-height: 30px; border: 2px solid {settings.defaultMode === 'solo' ? 'var(--tandem-accent)' : 'var(--tandem-border)'}; border-radius: var(--tandem-r-3); background: {settings.defaultMode === 'solo' ? 'var(--tandem-accent-bg)' : 'var(--tandem-surface)'}; color: {settings.defaultMode === 'solo' ? 'var(--tandem-accent-fg-strong)' : 'var(--tandem-fg-muted)'}; font-size: 12px; font-weight: {settings.defaultMode === 'solo' ? 600 : 400}; {disabledControlStyle(readOnly)}"
                 >
                   Solo
                 </button>
@@ -489,7 +481,7 @@ function aboutRows() {
                 checked={settings.soloRailHidden}
                 disabled={readOnly}
                 onchange={(e) => onUpdate({ soloRailHidden: (e.target as HTMLInputElement).checked })}
-                style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+                style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
               />
               <span>Hide side panel in Solo mode</span>
             </label>
@@ -557,7 +549,7 @@ function aboutRows() {
                 value={settings.selectionDwellMs}
                 disabled={readOnly}
                 oninput={(e) => onUpdate({ selectionDwellMs: Number((e.target as HTMLInputElement).value) })}
-                style="width: 100%; accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'auto'}; opacity: {readOnly ? 0.5 : 1};"
+                style="width: 100%; accent-color: var(--tandem-accent); {disabledControlStyle(readOnly, 'auto')}"
                 aria-label="Selection dwell time"
               />
               <div style="display: flex; justify-content: space-between; font-size: 10px; color: var(--tandem-fg-subtle);">
@@ -575,7 +567,7 @@ function aboutRows() {
                 checked={settings.selectionToolbar}
                 disabled={readOnly}
                 onchange={(e) => onUpdate({ selectionToolbar: (e.target as HTMLInputElement).checked })}
-                style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+                style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
               />
               <span>Show floating selection toolbar</span>
             </label>
@@ -589,7 +581,7 @@ function aboutRows() {
                 checked={settings.marginView}
                 disabled={readOnly}
                 onchange={(e) => onUpdate({ marginView: (e.target as HTMLInputElement).checked })}
-                style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+                style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
               />
               <span>Margin annotation view (Word-style)</span>
             </label>

--- a/src/client/components/SettingsReadonlyBanner.svelte
+++ b/src/client/components/SettingsReadonlyBanner.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import { warningStateColors } from "../utils/colors";
+
+// Surface-wide forward-compat read-only notice, shared by SettingsModal and
+// SettingsPopover (same copy, same testid — the snapshot set dedups). Hosts
+// gate rendering on their own `readOnly`; this component is presentational.
+</script>
+
+<div
+  data-testid="settings-readonly-banner"
+  role="note"
+  style="flex-shrink: 0; padding: var(--tandem-space-2) var(--tandem-space-5); font-size: var(--tandem-text-xs); line-height: 1.4; background: {warningStateColors.background}; border-bottom: 1px solid {warningStateColors.border}; color: {warningStateColors.color};"
+>
+  Settings are read-only — they were saved by a newer version of Tandem. Changes are disabled to
+  protect them.
+</div>

--- a/src/client/components/ShortcutEditorList.svelte
+++ b/src/client/components/ShortcutEditorList.svelte
@@ -17,20 +17,13 @@ interface Props {
   settings: TandemSettings;
   onUpdate: (partial: Partial<TandemSettings>) => void;
   notify?: (severity: "info" | "warning" | "error", message: string) => void;
-  /**
-   * Show the inline read-only notice when the store is forward-compat
-   * read-only. The modal passes `false` (its surface-wide
-   * `settings-readonly-banner` already covers every tab); the popover keeps
-   * the default.
-   */
-  showReadOnlyBanner?: boolean;
 }
 
 // Destructure directly off $props() so each stays a live getter (capturing
 // into a local then re-destructuring freezes the getters — see SettingsModal
 // gotcha). `notify` is optional with a noop default because the popover
 // surface has no toast channel; conflict feedback is shown inline regardless.
-let { settings, onUpdate, notify = () => {}, showReadOnlyBanner = true }: Props = $props();
+let { settings, onUpdate, notify = () => {} }: Props = $props();
 
 let recordingId = $state<RemappableShortcutId | null>(null);
 let conflictError = $state<{ id: RemappableShortcutId; message: string } | null>(null);
@@ -140,15 +133,6 @@ const kbdStyle =
         Reset all
       </button>
     </div>
-
-    {#if readOnly && showReadOnlyBanner}
-      <div
-        data-testid="store-readonly-banner"
-        style="font-size: 11px; color: var(--tandem-warning-fg); margin-bottom: 8px;"
-      >
-        Settings are read-only (a newer client wrote them). Shortcut changes are disabled.
-      </div>
-    {/if}
 
     <div style="display: flex; flex-direction: column; gap: 4px;">
       {#each REMAPPABLE_SHORTCUT_IDS as id (id)}

--- a/src/client/components/ShortcutEditorList.svelte
+++ b/src/client/components/ShortcutEditorList.svelte
@@ -17,13 +17,20 @@ interface Props {
   settings: TandemSettings;
   onUpdate: (partial: Partial<TandemSettings>) => void;
   notify?: (severity: "info" | "warning" | "error", message: string) => void;
+  /**
+   * Show the inline read-only notice when the store is forward-compat
+   * read-only. The modal passes `false` (its surface-wide
+   * `settings-readonly-banner` already covers every tab); the popover keeps
+   * the default.
+   */
+  showReadOnlyBanner?: boolean;
 }
 
 // Destructure directly off $props() so each stays a live getter (capturing
 // into a local then re-destructuring freezes the getters — see SettingsModal
 // gotcha). `notify` is optional with a noop default because the popover
 // surface has no toast channel; conflict feedback is shown inline regardless.
-let { settings, onUpdate, notify = () => {} }: Props = $props();
+let { settings, onUpdate, notify = () => {}, showReadOnlyBanner = true }: Props = $props();
 
 let recordingId = $state<RemappableShortcutId | null>(null);
 let conflictError = $state<{ id: RemappableShortcutId; message: string } | null>(null);
@@ -134,7 +141,7 @@ const kbdStyle =
       </button>
     </div>
 
-    {#if readOnly}
+    {#if readOnly && showReadOnlyBanner}
       <div
         data-testid="store-readonly-banner"
         style="font-size: 11px; color: var(--tandem-warning-fg); margin-bottom: 8px;"

--- a/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
+++ b/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
@@ -10,6 +10,7 @@ import {
   LAUNCHER_ERROR_PATH_REJECTED,
 } from "../../../shared/launcher/contract";
 import { isTauriRuntime } from "../../cowork/cowork-helpers";
+import { disabledControlStyle } from "../../utils/colors";
 import { API_BASE } from "../../utils/fileUpload";
 import type { SettingsTabContext } from "../SettingsModal.svelte";
 
@@ -246,7 +247,7 @@ function handleReset() {
     disabled={ctx.readOnly}
     oninput={(e) =>
       ctx.onUpdate({ selectionDwellMs: Number((e.target as HTMLInputElement).value) })}
-    style="width: 100%; accent-color: var(--tandem-accent); cursor: {ctx.readOnly ? 'not-allowed' : 'auto'}; opacity: {ctx.readOnly ? 0.5 : 1};"
+    style="width: 100%; accent-color: var(--tandem-accent); {disabledControlStyle(ctx.readOnly, 'auto')}"
     aria-label="Selection dwell time"
   />
   <div
@@ -267,7 +268,7 @@ function handleReset() {
     disabled={ctx.readOnly}
     onchange={(e) =>
       ctx.onUpdate({ selectionToolbar: (e.target as HTMLInputElement).checked })}
-    style="accent-color: var(--tandem-accent); cursor: {ctx.readOnly ? 'not-allowed' : 'pointer'}; opacity: {ctx.readOnly ? 0.5 : 1};"
+    style="accent-color: var(--tandem-accent); {disabledControlStyle(ctx.readOnly)}"
   />
   <span>Show floating selection toolbar</span>
 </label>
@@ -281,7 +282,7 @@ function handleReset() {
     checked={ctx.settings.marginView}
     disabled={ctx.readOnly}
     onchange={(e) => ctx.onUpdate({ marginView: (e.target as HTMLInputElement).checked })}
-    style="accent-color: var(--tandem-accent); cursor: {ctx.readOnly ? 'not-allowed' : 'pointer'}; opacity: {ctx.readOnly ? 0.5 : 1};"
+    style="accent-color: var(--tandem-accent); {disabledControlStyle(ctx.readOnly)}"
   />
   <span>Margin annotation view (Word-style)</span>
 </label>

--- a/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
+++ b/src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte
@@ -243,9 +243,10 @@ function handleReset() {
     max={SELECTION_DWELL_MAX_MS}
     step={100}
     value={ctx.settings.selectionDwellMs}
+    disabled={ctx.readOnly}
     oninput={(e) =>
       ctx.onUpdate({ selectionDwellMs: Number((e.target as HTMLInputElement).value) })}
-    style="width: 100%; accent-color: var(--tandem-accent);"
+    style="width: 100%; accent-color: var(--tandem-accent); cursor: {ctx.readOnly ? 'not-allowed' : 'auto'}; opacity: {ctx.readOnly ? 0.5 : 1};"
     aria-label="Selection dwell time"
   />
   <div
@@ -263,9 +264,10 @@ function handleReset() {
   <input
     type="checkbox"
     checked={ctx.settings.selectionToolbar}
+    disabled={ctx.readOnly}
     onchange={(e) =>
       ctx.onUpdate({ selectionToolbar: (e.target as HTMLInputElement).checked })}
-    style="accent-color: var(--tandem-accent);"
+    style="accent-color: var(--tandem-accent); cursor: {ctx.readOnly ? 'not-allowed' : 'pointer'}; opacity: {ctx.readOnly ? 0.5 : 1};"
   />
   <span>Show floating selection toolbar</span>
 </label>
@@ -277,8 +279,9 @@ function handleReset() {
   <input
     type="checkbox"
     checked={ctx.settings.marginView}
+    disabled={ctx.readOnly}
     onchange={(e) => ctx.onUpdate({ marginView: (e.target as HTMLInputElement).checked })}
-    style="accent-color: var(--tandem-accent);"
+    style="accent-color: var(--tandem-accent); cursor: {ctx.readOnly ? 'not-allowed' : 'pointer'}; opacity: {ctx.readOnly ? 0.5 : 1};"
   />
   <span>Margin annotation view (Word-style)</span>
 </label>

--- a/src/client/components/settings-tabs/SettingsCollaborationTab.svelte
+++ b/src/client/components/settings-tabs/SettingsCollaborationTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { USER_NAME_MAX_LEN } from "../../../shared/constants";
 import { createUserName } from "../../hooks/useUserName.svelte";
+import { disabledControlStyle } from "../../utils/colors";
 import type { SettingsTabContext } from "../SettingsModal.svelte";
 
 // Keep `$props()` as a single proxy variable and read fields via `ctx.foo`.
@@ -61,7 +62,6 @@ $effect(() => {
       disabled={ctx.readOnly}
       onclick={() => ctx.onUpdate({ defaultMode: "tandem" })}
       class="settings-mode-btn"
-      style="cursor: {ctx.readOnly ? 'not-allowed' : 'pointer'}; opacity: {ctx.readOnly ? 0.5 : 1};"
     >
       Tandem
     </button>
@@ -73,7 +73,6 @@ $effect(() => {
       disabled={ctx.readOnly}
       onclick={() => ctx.onUpdate({ defaultMode: "solo" })}
       class="settings-mode-btn"
-      style="cursor: {ctx.readOnly ? 'not-allowed' : 'pointer'}; opacity: {ctx.readOnly ? 0.5 : 1};"
     >
       Solo
     </button>
@@ -92,7 +91,7 @@ $effect(() => {
     checked={ctx.settings.soloRailHidden}
     disabled={ctx.readOnly}
     onchange={(e) => ctx.onUpdate({ soloRailHidden: (e.target as HTMLInputElement).checked })}
-    style="accent-color: var(--tandem-accent); cursor: {ctx.readOnly ? 'not-allowed' : 'pointer'}; opacity: {ctx.readOnly ? 0.5 : 1};"
+    style="accent-color: var(--tandem-accent); {disabledControlStyle(ctx.readOnly)}"
   />
   <span>Hide side panel in Solo mode</span>
 </label>

--- a/src/client/components/settings-tabs/SettingsCollaborationTab.svelte
+++ b/src/client/components/settings-tabs/SettingsCollaborationTab.svelte
@@ -58,8 +58,10 @@ $effect(() => {
       data-testid="settings-modal-default-mode-tandem-btn"
       role="radio"
       aria-checked={ctx.settings.defaultMode === "tandem"}
+      disabled={ctx.readOnly}
       onclick={() => ctx.onUpdate({ defaultMode: "tandem" })}
       class="settings-mode-btn"
+      style="cursor: {ctx.readOnly ? 'not-allowed' : 'pointer'}; opacity: {ctx.readOnly ? 0.5 : 1};"
     >
       Tandem
     </button>
@@ -68,8 +70,10 @@ $effect(() => {
       data-testid="settings-modal-default-mode-solo-btn"
       role="radio"
       aria-checked={ctx.settings.defaultMode === "solo"}
+      disabled={ctx.readOnly}
       onclick={() => ctx.onUpdate({ defaultMode: "solo" })}
       class="settings-mode-btn"
+      style="cursor: {ctx.readOnly ? 'not-allowed' : 'pointer'}; opacity: {ctx.readOnly ? 0.5 : 1};"
     >
       Solo
     </button>
@@ -86,8 +90,9 @@ $effect(() => {
   <input
     type="checkbox"
     checked={ctx.settings.soloRailHidden}
+    disabled={ctx.readOnly}
     onchange={(e) => ctx.onUpdate({ soloRailHidden: (e.target as HTMLInputElement).checked })}
-    style="accent-color: var(--tandem-accent);"
+    style="accent-color: var(--tandem-accent); cursor: {ctx.readOnly ? 'not-allowed' : 'pointer'}; opacity: {ctx.readOnly ? 0.5 : 1};"
   />
   <span>Hide side panel in Solo mode</span>
 </label>

--- a/src/client/components/settings-tabs/SettingsModelsTab.svelte
+++ b/src/client/components/settings-tabs/SettingsModelsTab.svelte
@@ -2,6 +2,7 @@
 import { createModels } from "../../hooks/useModels.svelte";
 import type { ModelProvider, ModelRegistryEntry } from "../../hooks/useTandemSettings.svelte";
 import { createTandemSettings } from "../../hooks/useTandemSettings.svelte";
+import { disabledControlStyle } from "../../utils/colors";
 import ModelEditModal from "../ModelEditModal.svelte";
 import type { SettingsTabContext } from "../SettingsModal.svelte";
 
@@ -159,7 +160,7 @@ async function runLegacyMigration() {
         data-testid="model-add-btn"
         disabled={readOnly}
         onclick={openAdd}
-        style="padding: 6px var(--tandem-space-3); font-size: 13px; font-weight: 500; border: none; border-radius: var(--tandem-r-2); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1}; background: var(--tandem-accent); color: var(--tandem-accent-fg);"
+        style="padding: 6px var(--tandem-space-3); font-size: 13px; font-weight: 500; border: none; border-radius: var(--tandem-r-2); {disabledControlStyle(readOnly)} background: var(--tandem-accent); color: var(--tandem-accent-fg);"
       >
         Add your first model
       </button>
@@ -202,7 +203,7 @@ async function runLegacyMigration() {
                       checked={models.defaultModelId === entry.id}
                       disabled={readOnly}
                       onchange={() => models.setDefault(entry.id)}
-                      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+                      style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
                     />
                     <span>Default</span>
                   </label>
@@ -215,7 +216,7 @@ async function runLegacyMigration() {
                       checked={entry.enabled}
                       disabled={readOnly}
                       onchange={() => models.toggleEnabled(entry.id)}
-                      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+                      style="accent-color: var(--tandem-accent); {disabledControlStyle(readOnly)}"
                     />
                     <span>{entry.enabled ? "On" : "Off"}</span>
                   </label>
@@ -224,7 +225,7 @@ async function runLegacyMigration() {
                     data-testid={`model-edit-btn-${entry.id}`}
                     disabled={readOnly}
                     onclick={() => openEdit(entry)}
-                    style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-fg); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+                    style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-fg); {disabledControlStyle(readOnly)}"
                   >
                     Edit
                   </button>
@@ -234,7 +235,7 @@ async function runLegacyMigration() {
                       data-testid={`model-delete-confirm-${entry.id}`}
                       disabled={readOnly}
                       onclick={() => confirmDelete(entry.id)}
-                      style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-error-border); border-radius: var(--tandem-r-2); background: var(--tandem-error-bg); color: var(--tandem-error-fg-strong); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+                      style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-error-border); border-radius: var(--tandem-r-2); background: var(--tandem-error-bg); color: var(--tandem-error-fg-strong); {disabledControlStyle(readOnly)}"
                     >
                       Confirm
                     </button>
@@ -251,7 +252,7 @@ async function runLegacyMigration() {
                       data-testid={`model-delete-btn-${entry.id}`}
                       disabled={readOnly}
                       onclick={() => (pendingDeleteId = entry.id)}
-                      style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-error-fg); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
+                      style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-error-fg); {disabledControlStyle(readOnly)}"
                     >
                       Delete
                     </button>
@@ -269,7 +270,7 @@ async function runLegacyMigration() {
       data-testid="model-add-btn"
       disabled={readOnly}
       onclick={openAdd}
-      style="align-self: flex-start; padding: 6px var(--tandem-space-3); font-size: 13px; font-weight: 500; border: 1px solid var(--tandem-accent-border); border-radius: var(--tandem-r-2); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1}; background: var(--tandem-surface); color: var(--tandem-accent);"
+      style="align-self: flex-start; padding: 6px var(--tandem-space-3); font-size: 13px; font-weight: 500; border: 1px solid var(--tandem-accent-border); border-radius: var(--tandem-r-2); {disabledControlStyle(readOnly)} background: var(--tandem-surface); color: var(--tandem-accent);"
     >
       + Add model
     </button>

--- a/src/client/components/settings-tabs/SettingsModelsTab.svelte
+++ b/src/client/components/settings-tabs/SettingsModelsTab.svelte
@@ -5,11 +5,13 @@ import { createTandemSettings } from "../../hooks/useTandemSettings.svelte";
 import ModelEditModal from "../ModelEditModal.svelte";
 import type { SettingsTabContext } from "../SettingsModal.svelte";
 
-// `SettingsTabContext` is the registry's uniform Props contract; this
-// tab reads none of its fields directly (the Models registry hangs off
-// the shared `createTandemSettings()` singleton, mutated via `models`
-// below). We type via a no-op destructure for registry conformance.
-const {}: SettingsTabContext = $props();
+// `SettingsTabContext` is the registry's uniform Props contract; besides
+// `readOnly` this tab reads none of its fields directly (the Models
+// registry hangs off the shared `createTandemSettings()` singleton,
+// mutated via `models` below). Direct destructure off `$props()` keeps
+// `readOnly` a live getter (never capture-then-destructure — see the
+// SettingsTabContext doc-comment).
+const { readOnly }: SettingsTabContext = $props();
 
 // `createTandemSettings()` is a module-level singleton — calling it
 // here returns the same instance App.svelte uses. Mutations propagate
@@ -133,9 +135,9 @@ async function runLegacyMigration() {
         <button
           type="button"
           data-testid="models-legacy-migrate-btn"
-          disabled={migratingLegacy}
+          disabled={readOnly || migratingLegacy}
           onclick={runLegacyMigration}
-          style={`padding: 4px var(--tandem-space-3); font-size: 12px; font-weight: 500; border: 1px solid var(--tandem-warning-border); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-warning-fg-strong); cursor: ${migratingLegacy ? "wait" : "pointer"};`}
+          style={`padding: 4px var(--tandem-space-3); font-size: 12px; font-weight: 500; border: 1px solid var(--tandem-warning-border); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-warning-fg-strong); cursor: ${readOnly ? "not-allowed" : migratingLegacy ? "wait" : "pointer"}; opacity: ${readOnly ? 0.5 : 1};`}
         >
           {migratingLegacy ? "Migrating…" : "Migrate keys"}
         </button>
@@ -155,8 +157,9 @@ async function runLegacyMigration() {
       <button
         type="button"
         data-testid="model-add-btn"
+        disabled={readOnly}
         onclick={openAdd}
-        style="padding: 6px var(--tandem-space-3); font-size: 13px; font-weight: 500; border: none; border-radius: var(--tandem-r-2); cursor: pointer; background: var(--tandem-accent); color: var(--tandem-accent-fg);"
+        style="padding: 6px var(--tandem-space-3); font-size: 13px; font-weight: 500; border: none; border-radius: var(--tandem-r-2); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1}; background: var(--tandem-accent); color: var(--tandem-accent-fg);"
       >
         Add your first model
       </button>
@@ -197,8 +200,9 @@ async function runLegacyMigration() {
                       name="default-model"
                       data-testid={`model-default-${entry.id}`}
                       checked={models.defaultModelId === entry.id}
+                      disabled={readOnly}
                       onchange={() => models.setDefault(entry.id)}
-                      style="accent-color: var(--tandem-accent);"
+                      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
                     />
                     <span>Default</span>
                   </label>
@@ -209,16 +213,18 @@ async function runLegacyMigration() {
                       type="checkbox"
                       data-testid={`model-toggle-${entry.id}`}
                       checked={entry.enabled}
+                      disabled={readOnly}
                       onchange={() => models.toggleEnabled(entry.id)}
-                      style="accent-color: var(--tandem-accent);"
+                      style="accent-color: var(--tandem-accent); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
                     />
                     <span>{entry.enabled ? "On" : "Off"}</span>
                   </label>
                   <button
                     type="button"
                     data-testid={`model-edit-btn-${entry.id}`}
+                    disabled={readOnly}
                     onclick={() => openEdit(entry)}
-                    style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-fg); cursor: pointer;"
+                    style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-fg); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
                   >
                     Edit
                   </button>
@@ -226,8 +232,9 @@ async function runLegacyMigration() {
                     <button
                       type="button"
                       data-testid={`model-delete-confirm-${entry.id}`}
+                      disabled={readOnly}
                       onclick={() => confirmDelete(entry.id)}
-                      style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-error-border); border-radius: var(--tandem-r-2); background: var(--tandem-error-bg); color: var(--tandem-error-fg-strong); cursor: pointer;"
+                      style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-error-border); border-radius: var(--tandem-r-2); background: var(--tandem-error-bg); color: var(--tandem-error-fg-strong); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
                     >
                       Confirm
                     </button>
@@ -242,8 +249,9 @@ async function runLegacyMigration() {
                     <button
                       type="button"
                       data-testid={`model-delete-btn-${entry.id}`}
+                      disabled={readOnly}
                       onclick={() => (pendingDeleteId = entry.id)}
-                      style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-error-fg); cursor: pointer;"
+                      style="padding: 2px var(--tandem-space-2); font-size: 11px; border: 1px solid var(--tandem-border-strong); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-error-fg); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1};"
                     >
                       Delete
                     </button>
@@ -259,8 +267,9 @@ async function runLegacyMigration() {
     <button
       type="button"
       data-testid="model-add-btn"
+      disabled={readOnly}
       onclick={openAdd}
-      style="align-self: flex-start; padding: 6px var(--tandem-space-3); font-size: 13px; font-weight: 500; border: 1px solid var(--tandem-accent-border); border-radius: var(--tandem-r-2); cursor: pointer; background: var(--tandem-surface); color: var(--tandem-accent);"
+      style="align-self: flex-start; padding: 6px var(--tandem-space-3); font-size: 13px; font-weight: 500; border: 1px solid var(--tandem-accent-border); border-radius: var(--tandem-r-2); cursor: {readOnly ? 'not-allowed' : 'pointer'}; opacity: {readOnly ? 0.5 : 1}; background: var(--tandem-surface); color: var(--tandem-accent);"
     >
       + Add model
     </button>

--- a/src/client/components/settings-tabs/SettingsShortcutsTab.svelte
+++ b/src/client/components/settings-tabs/SettingsShortcutsTab.svelte
@@ -7,6 +7,8 @@ import ShortcutEditorList from "../ShortcutEditorList.svelte";
 let { settings, onUpdate, notify }: SettingsTabContext = $props();
 </script>
 
+<!-- showReadOnlyBanner={false}: the modal-level settings-readonly-banner
+     already covers this tab; the inline notice would be redundant here. -->
 <div data-testid="settings-modal-shortcuts-list">
-  <ShortcutEditorList {settings} {onUpdate} {notify} />
+  <ShortcutEditorList {settings} {onUpdate} {notify} showReadOnlyBanner={false} />
 </div>

--- a/src/client/components/settings-tabs/SettingsShortcutsTab.svelte
+++ b/src/client/components/settings-tabs/SettingsShortcutsTab.svelte
@@ -7,8 +7,6 @@ import ShortcutEditorList from "../ShortcutEditorList.svelte";
 let { settings, onUpdate, notify }: SettingsTabContext = $props();
 </script>
 
-<!-- showReadOnlyBanner={false}: the modal-level settings-readonly-banner
-     already covers this tab; the inline notice would be redundant here. -->
 <div data-testid="settings-modal-shortcuts-list">
-  <ShortcutEditorList {settings} {onUpdate} {notify} showReadOnlyBanner={false} />
+  <ShortcutEditorList {settings} {onUpdate} {notify} />
 </div>

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -192,15 +192,13 @@ function handleKeyDown(e: KeyboardEvent) {
     handleCancel();
   }
 }
-
-// Keyboard activation for the card root (plain tabindex, not roving — the card
-// is a heavyweight composite with inner tabbables like reply/accept buttons,
-// so we only act on Enter/Space when the event target IS the root itself; the
-// `selfOnly` guard keeps Enter in the reply composer and Space on inner
-// buttons from re-triggering onClick). Alt+]/Alt+[ registry navigation
-// (SidePanel) is unrelated and untouched by this handler.
 </script>
 
+<!-- Keyboard activation on the card root uses plain tabindex, not roving —
+     the card is a heavyweight composite with inner tabbables (reply/accept
+     buttons), so `selfOnly` keeps Enter in the reply composer and Space on
+     inner buttons from re-triggering onClick. Alt+]/Alt+[ registry navigation
+     (SidePanel) is unrelated. -->
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -3,6 +3,7 @@ import type { Annotation, AnnotationReply } from "../../shared/types";
 import { getVisibleReplies } from "../annotations/replies";
 import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
 import { createTandemSettings } from "../hooks/useTandemSettings.svelte";
+import { activationKeydown } from "../utils/keyboard-activate";
 import AnnotationCardActions from "./AnnotationCardActions.svelte";
 import AnnotationEditForm from "./AnnotationEditForm.svelte";
 import { getCardLabel, getHighlightBorder } from "./annotation-card-helpers";
@@ -195,16 +196,9 @@ function handleKeyDown(e: KeyboardEvent) {
 // Keyboard activation for the card root (plain tabindex, not roving — the card
 // is a heavyweight composite with inner tabbables like reply/accept buttons,
 // so we only act on Enter/Space when the event target IS the root itself; the
-// `e.target !== e.currentTarget` guard keeps Enter in the reply composer and
-// Space on inner buttons from re-triggering onClick). Alt+]/Alt+[ registry
-// navigation (SidePanel) is unrelated and untouched by this handler.
-function handleCardKeyDown(e: KeyboardEvent) {
-  if (e.target !== e.currentTarget) return;
-  if (e.key === "Enter" || e.key === " ") {
-    e.preventDefault();
-    onClick?.();
-  }
-}
+// `selfOnly` guard keeps Enter in the reply composer and Space on inner
+// buttons from re-triggering onClick). Alt+]/Alt+[ registry navigation
+// (SidePanel) is unrelated and untouched by this handler.
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -217,7 +211,7 @@ function handleCardKeyDown(e: KeyboardEvent) {
   in:cardEnter={{ enabled: lifecycleMotion, reduceMotion }}
   out:cardExit={{ enabled: lifecycleMotion, reduceMotion, id: annotation.id, modes: exitModes }}
   onclick={onClick}
-  onkeydown={handleCardKeyDown}
+  onkeydown={activationKeydown(() => onClick?.(), { selfOnly: true })}
   tabindex={onClick ? 0 : undefined}
   data-testid="annotation-card-{annotation.id}"
   data-annotation-id={annotation.id}

--- a/src/client/panels/PeekStrip.svelte
+++ b/src/client/panels/PeekStrip.svelte
@@ -39,13 +39,6 @@ function dotClass(a: Annotation): string {
   if (a.author === "import") return "import";
   return "user";
 }
-
-function handleKey(e: KeyboardEvent) {
-  if (e.key === "Enter" || e.key === " ") {
-    e.preventDefault();
-    onActivate();
-  }
-}
 </script>
 
 <!-- A sliver of the collapsed panel pokes out from the window edge so the
@@ -58,7 +51,8 @@ function handleKey(e: KeyboardEvent) {
      stays out of the Tab sequence to avoid cluttering the focus order. Kept
      at -1 (NOT collapsed?0:-1) so the #859 inert-restoration-focus fix below
      holds — a Tab-reachable strip with no focus ring would be the inverse of
-     that bug. -->
+     that bug. No onkeydown: this is a native button, so Enter/Space
+     synthesize a click natively → onclick covers keyboard activation. -->
 <!-- display:none when the rail is expanded so the peek doesn't overlay the
      full panel's inside edge. Always rendered (instance persists) — the
      snap equivalent of the bundle's opacity:0-when-expanded. -->
@@ -71,7 +65,6 @@ function handleKey(e: KeyboardEvent) {
   aria-expanded={!collapsed}
   style={collapsed ? "" : "display: none;"}
   onclick={onActivate}
-  onkeydown={handleKey}
 >
   <span class="peek-chevron" aria-hidden="true">
     {side === "left" ? "›" : "‹"}

--- a/src/client/tabs/NewTabMenu.svelte
+++ b/src/client/tabs/NewTabMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { ClosedTabRecord } from "../hooks/useClosedTabStack.svelte.js";
 import type { RecentFileEntry } from "../utils/recentFiles.js";
-import { highlightSegments, matchesQuery, toLauncherRow } from "./newTabLauncher.js";
+import { searchRows, toLauncherRow } from "./newTabLauncher.js";
 
 interface Props {
   recentFiles: RecentFileEntry[];
@@ -29,7 +29,7 @@ let menuEl: HTMLDivElement | null = $state(null);
 let searchInputEl: HTMLInputElement | null = $state(null);
 
 const rows = $derived(recentFiles.map((e) => toLauncherRow(e)));
-const filtered = $derived(rows.filter((r) => matchesQuery(r, query)));
+const filtered = $derived(searchRows(rows, query));
 const hasRecents = $derived(rows.length > 0);
 const hasQuery = $derived(query.trim().length > 0);
 
@@ -153,25 +153,25 @@ $effect(() => {
         </div>
       {:else}
         <div class="ntl-recents">
-          {#each filtered as row, i (row.path)}
+          {#each filtered as entry, i (entry.row.path)}
             <button
               type="button"
               data-nav-item
               class="ntl-recent"
               data-testid={`new-tab-recent-${i}`}
-              onclick={() => onOpen(row.path)}
-              title={row.path}
+              onclick={() => onOpen(entry.row.path)}
+              title={entry.row.path}
             >
-              <span class="ntl-pip ntl-pip-{row.pip}"></span>
+              <span class="ntl-pip ntl-pip-{entry.row.pip}"></span>
               <span class="ntl-body">
                 <span class="ntl-name">
-                  {#each highlightSegments(row.name, query) as seg, si (si)}
+                  {#each entry.nameSegments as seg, si (si)}
                     {#if seg.match}<mark>{seg.text}</mark>{:else}{seg.text}{/if}
                   {/each}
                 </span>
-                {#if row.dir}<span class="ntl-path">{row.dir}</span>{/if}
+                {#if entry.row.dir}<span class="ntl-path">{entry.row.dir}</span>{/if}
               </span>
-              {#if row.when}<span class="ntl-when">{row.when}</span>{/if}
+              {#if entry.row.when}<span class="ntl-when">{entry.row.when}</span>{/if}
             </button>
           {/each}
         </div>

--- a/src/client/tabs/newTabLauncher.ts
+++ b/src/client/tabs/newTabLauncher.ts
@@ -30,13 +30,10 @@ export interface LauncherRow {
   pip: PipClass;
 }
 
-/** Structural alias — keeps the launcher's existing segment naming. */
-export type NameSegment = MatchSegment;
-
 /** A launcher row paired with its name's matched/unmatched highlight runs. */
 export interface RankedRow {
   row: LauncherRow;
-  nameSegments: NameSegment[];
+  nameSegments: MatchSegment[];
 }
 
 const PIP_BY_EXT: Record<string, PipClass> = {

--- a/src/client/tabs/newTabLauncher.ts
+++ b/src/client/tabs/newTabLauncher.ts
@@ -1,14 +1,17 @@
 /**
  * Pure helpers for the a7 new-tab launcher (`NewTabMenu.svelte`).
  *
- * Kept out of the component so the row-shaping, search filter, and match
+ * Kept out of the component so the row-shaping, search ranking, and match
  * highlighting are unit-testable in isolation — the `.svelte` file is then just
  * rendering + keyboard wiring. Ported from the Claude Design a7 bundle's
  * `new-tab-utils.ts`, adapted to production's stored recents shape
  * (`RecentFileEntry` with a full path + `openedAt`, vs the bundle's pre-split
- * name/path/when/ext mock).
+ * name/path/when/ext mock). Search converges on the command palette's
+ * fuzzy-match stack (`utils/fuzzy-match.ts`) instead of a bespoke substring
+ * filter.
  */
 
+import { type MatchSegment, rankByScore, scoreFields, toSegments } from "../utils/fuzzy-match.js";
 import { formatWhen, type RecentFileEntry } from "../utils/recentFiles.js";
 
 /** File-type bucket driving the recents-row pip color. */
@@ -27,9 +30,13 @@ export interface LauncherRow {
   pip: PipClass;
 }
 
-export interface NameSegment {
-  text: string;
-  match: boolean;
+/** Structural alias — keeps the launcher's existing segment naming. */
+export type NameSegment = MatchSegment;
+
+/** A launcher row paired with its name's matched/unmatched highlight runs. */
+export interface RankedRow {
+  row: LauncherRow;
+  nameSegments: NameSegment[];
 }
 
 const PIP_BY_EXT: Record<string, PipClass> = {
@@ -72,34 +79,36 @@ export function toLauncherRow(entry: RecentFileEntry, now: number = Date.now()):
   };
 }
 
-/** Case-insensitive substring match on the row's name and directory. */
-export function matchesQuery(row: LauncherRow, query: string): boolean {
-  const q = query.trim().toLowerCase();
-  if (!q) return true;
-  return row.name.toLowerCase().includes(q) || row.dir.toLowerCase().includes(q);
-}
-
 /**
- * Split `name` into matched / unmatched segments for substring highlighting.
- * The template renders matched segments inside `<mark>`. An empty/whitespace
- * query yields a single unmatched segment (the whole name).
+ * Search + rank launcher rows with the command palette's fuzzy-match stack.
+ *
+ * Empty/whitespace query → all rows in input (recency) order, each with a
+ * single unmatched segment. Otherwise each row is scored via
+ * `scoreFields(q, name, dir)` — name is the primary field (full weight,
+ * supplies the highlight indices), dir the secondary (×0.75, indices never
+ * map onto the displayed name) — then sorted by `rankByScore` (score desc,
+ * recency tiebreak via original index). Non-matching rows are excluded.
+ *
+ * Deliberate behavior changes vs the old boolean `.includes()` filter:
+ * results rank by match quality rather than pure recency; subsequence
+ * matches are included (e.g. "chp" matches "chapter.md"); a dir-only match
+ * keeps the row but renders its name unhighlighted.
  */
-export function highlightSegments(name: string, query: string): NameSegment[] {
+export function searchRows(rows: LauncherRow[], query: string): RankedRow[] {
   const q = query.trim();
-  if (!q) return [{ text: name, match: false }];
-  const lower = name.toLowerCase();
-  const ql = q.toLowerCase();
-  const out: NameSegment[] = [];
-  let i = 0;
-  while (i < name.length) {
-    const idx = lower.indexOf(ql, i);
-    if (idx === -1) {
-      out.push({ text: name.slice(i), match: false });
-      break;
-    }
-    if (idx > i) out.push({ text: name.slice(i, idx), match: false });
-    out.push({ text: name.slice(idx, idx + ql.length), match: true });
-    i = idx + ql.length;
+  if (!q) {
+    return rows.map((row) => ({ row, nameSegments: toSegments(row.name, []) }));
   }
-  return out;
+  const scored: Array<{ result: RankedRow; score: number; origIndex: number }> = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    const fieldScore = scoreFields(q, row.name, row.dir);
+    if (!fieldScore) continue;
+    scored.push({
+      result: { row, nameSegments: toSegments(row.name, fieldScore.indices) },
+      score: fieldScore.score,
+      origIndex: i,
+    });
+  }
+  return rankByScore(scored);
 }

--- a/src/client/utils/colors.ts
+++ b/src/client/utils/colors.ts
@@ -12,3 +12,14 @@ export const warningStateColors = {
   border: "var(--tandem-warning-border)",
   color: "var(--tandem-warning-fg-strong)",
 } as const;
+
+/**
+ * Inline-style fragment for a control that can be `disabled` (e.g. by the
+ * forward-compat read-only settings store). One definition so the disabled
+ * affordance (cursor + dimming) can't drift across the ~30 settings controls
+ * that repeat it. `enabledCursor` covers sliders/text inputs whose enabled
+ * cursor isn't `pointer`.
+ */
+export function disabledControlStyle(disabled: boolean, enabledCursor = "pointer"): string {
+  return `cursor: ${disabled ? "not-allowed" : enabledCursor}; opacity: ${disabled ? 0.5 : 1};`;
+}

--- a/src/client/utils/fuzzy-match.ts
+++ b/src/client/utils/fuzzy-match.ts
@@ -1,14 +1,14 @@
 /**
- * Fuzzy matching + ranking for the command palette (C1).
+ * Fuzzy matching + ranking shared by the command palette (C1) and the
+ * new-tab launcher (`src/client/tabs/newTabLauncher.ts`).
  *
  * Two-tier scorer: an exact substring match always outranks a subsequence
  * match (see `fuzzyMatch` for the score bound reasoning), and within each
  * tier earlier / word-boundary-aligned matches score higher. Pure and
- * side-effect free so it's unit-testable independent of `CommandPalette.svelte`.
+ * side-effect free so it's unit-testable independent of the components.
  *
- * `toSegments` mirrors `highlightSegments` in `src/client/tabs/newTabLauncher.ts`
- * but takes explicit match indices (rather than re-deriving a substring range)
- * so it composes with `fuzzyMatch`'s subsequence output.
+ * `toSegments` takes explicit match indices (rather than re-deriving a
+ * substring range) so it composes with `fuzzyMatch`'s subsequence output.
  */
 
 /** A single fuzzy-match result: overall score plus the matched target indices. */
@@ -190,6 +190,20 @@ export function scoreFields(
   }
   if (scores.length === 0) return null;
   return { score: Math.max(...scores), indices: primaryMatch ? primaryMatch.indices : [] };
+}
+
+/**
+ * Sort scored candidates descending by score and return the results.
+ * The explicit `origIndex` tiebreak keeps equal-score candidates in their
+ * original (input) order — JS sort is stable, but the tiebreak documents the
+ * intent and survives a future non-stable-sort refactor. Sorts `scored` in
+ * place (callers always build the array fresh per query).
+ */
+export function rankByScore<T>(
+  scored: Array<{ result: T; score: number; origIndex: number }>,
+): T[] {
+  scored.sort((a, b) => b.score - a.score || a.origIndex - b.origIndex);
+  return scored.map((s) => s.result);
 }
 
 /**

--- a/src/client/utils/keyboard-activate.ts
+++ b/src/client/utils/keyboard-activate.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared Enter/Space keyboard-activation handler factory for non-native
+ * interactive elements (divs with role="button", composite card roots).
+ *
+ * Deliberately a plain handler factory, NOT a `use:` action: an action hides
+ * the keydown from svelte-check's static a11y analysis, which would force
+ * re-adding `a11y_click_events_have_key_events` suppressions that PR #1184
+ * removed. Keeping `onkeydown={activationKeydown(...)}` in the markup leaves
+ * the handler visible to the analyzer.
+ *
+ * Native `<button>` elements never need this — the platform synthesizes a
+ * click from Enter/Space; just use `onclick`.
+ */
+export interface ActivationOptions {
+  /** Ignore events bubbled from descendants (composite widgets / backdrops
+      with nested dialogs). Without this, a backdrop's `preventDefault()`
+      swallows Enter/Space activation of every control inside the dialog. */
+  selfOnly?: boolean;
+}
+
+export function activationKeydown(
+  handler: () => void,
+  opts: ActivationOptions = {},
+): (e: KeyboardEvent) => void {
+  return (e) => {
+    if (opts.selfOnly && e.target !== e.currentTarget) return;
+    if (e.key !== "Enter" && e.key !== " ") return;
+    e.preventDefault();
+    handler();
+  };
+}

--- a/tests/client/SettingsClaudeCodeTab.test.ts
+++ b/tests/client/SettingsClaudeCodeTab.test.ts
@@ -27,6 +27,7 @@ function makeProps() {
     onUpdate: vi.fn(),
     connected: true,
     reconnectAttempts: 0,
+    readOnly: false,
     notify: vi.fn(),
   };
 }

--- a/tests/client/cowork-admin-declined-modal-keyboard.test.ts
+++ b/tests/client/cowork-admin-declined-modal-keyboard.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+/**
+ * Mounted keyboard regression test for CoworkAdminDeclinedModal.
+ *
+ * The dialog is a CHILD of the backdrop div, so before the `selfOnly` guard
+ * (activationKeydown) the backdrop's keydown handler preventDefault()ed
+ * Enter/Space bubbling up from the dialog's buttons and link — breaking
+ * keyboard activation of every control inside AND dismissing the popup out
+ * from under the user. These tests pin the fix: Enter/Space on inner
+ * controls must NOT dismiss; Enter/Space on the backdrop itself still must.
+ *
+ * Kept separate from cowork-admin-declined-modal.test.ts, which is
+ * deliberately mount-free and exercises the REAL cowork-invoke exports
+ * (mocking useCoworkStatus here would be fine there too, but this file needs
+ * a mounted component while that one needs unmocked invoke helpers).
+ */
+
+import { fireEvent } from "@testing-library/dom";
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CoworkAdminDeclinedModal from "../../src/client/components/CoworkAdminDeclinedModal.svelte";
+import { _resetAdminDismissForTests } from "../../src/client/cowork/coworkAdminDismiss.svelte";
+
+// uacDeclined status so the modal renders. Everything else in the component
+// (cowork-invoke, dismiss module) stays real — no button is ever clicked, so
+// loadInvoke's Tauri-unavailable rejection is never hit.
+vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
+  createCoworkStatus: () => ({
+    status: {
+      osSupported: true,
+      coworkDetected: true,
+      enabled: true,
+      vethernetCidr: "172.30.16.0/28",
+      lanIpFallback: null,
+      useLanIpOverride: false,
+      workspaces: [],
+      uacDeclined: true,
+      uacDeclinedAt: "2026-07-14T00:00:00Z",
+      workspacesLastScannedAt: null,
+    },
+    loading: false,
+    error: null,
+    refetch: vi.fn(async () => {}),
+  }),
+}));
+
+describe("CoworkAdminDeclinedModal keyboard activation", () => {
+  beforeEach(() => {
+    // `dismissed` is module state — a dismissing test run would poison later
+    // cases (and other files sharing the worker) without this reset.
+    _resetAdminDismissForTests();
+  });
+
+  // No global auto-cleanup is wired in this repo's vitest setup; without this,
+  // each render() accumulates in document.body and screen queries collide.
+  afterEach(() => cleanup());
+
+  it("Enter on the retry button does NOT dismiss the modal (bubbled keydown ignored)", async () => {
+    render(CoworkAdminDeclinedModal);
+    const retry = screen.getByTestId("cowork-admin-declined-retry-btn");
+    await fireEvent.keyDown(retry, { key: "Enter" });
+    expect(screen.queryByTestId("cowork-admin-declined-modal")).not.toBeNull();
+  });
+
+  it("Space on the disable button does NOT dismiss the modal", async () => {
+    render(CoworkAdminDeclinedModal);
+    const disable = screen.getByTestId("cowork-admin-declined-disable-btn");
+    await fireEvent.keyDown(disable, { key: " " });
+    expect(screen.queryByTestId("cowork-admin-declined-modal")).not.toBeNull();
+  });
+
+  it("Enter bubbled from the Learn-more link keeps its default (link activation works)", async () => {
+    render(CoworkAdminDeclinedModal);
+    const link = screen.getByTestId("cowork-admin-declined-learn-more-link");
+    const e = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+    link.dispatchEvent(e);
+    expect(e.defaultPrevented).toBe(false);
+    expect(screen.queryByTestId("cowork-admin-declined-modal")).not.toBeNull();
+  });
+
+  it("Enter on the backdrop itself still dismisses (positive control)", async () => {
+    render(CoworkAdminDeclinedModal);
+    const backdrop = screen.getByTestId("cowork-admin-declined-backdrop");
+    await fireEvent.keyDown(backdrop, { key: "Enter" });
+    expect(screen.queryByTestId("cowork-admin-declined-modal")).toBeNull();
+  });
+});

--- a/tests/client/fuzzy-match.test.ts
+++ b/tests/client/fuzzy-match.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { fuzzyMatch, scoreFields, toSegments } from "../../src/client/utils/fuzzy-match.js";
+import {
+  fuzzyMatch,
+  rankByScore,
+  scoreFields,
+  toSegments,
+} from "../../src/client/utils/fuzzy-match.js";
 
 describe("fuzzyMatch", () => {
   it("returns null for an empty query", () => {
@@ -185,14 +190,21 @@ describe("fuzzyMatch", () => {
   });
 });
 
-describe("ranking tie stability", () => {
-  // CommandPalette.svelte sorts scored candidates with
-  // `(a, b) => b.score - a.score || a.origIndex - b.origIndex`. Verify that
-  // shape here: equal-score candidates must keep their original relative
-  // order rather than being reshuffled.
+describe("rankByScore", () => {
+  // The shared ranking used by CommandPalette and the new-tab launcher:
+  // sort desc by score with an origIndex tiebreak, then unwrap results.
+  it("sorts descending by score", () => {
+    const ranked = rankByScore([
+      { result: "low", score: 10, origIndex: 0 },
+      { result: "high", score: 30, origIndex: 1 },
+      { result: "mid", score: 20, origIndex: 2 },
+    ]);
+    expect(ranked).toEqual(["high", "mid", "low"]);
+  });
+
   it("keeps original insertion order for equal-score matches", () => {
     const candidates = ["Open Panel", "Open Folder", "Open Panel"].map((target, origIndex) => ({
-      target,
+      result: target,
       origIndex,
       score: fuzzyMatch("open", target)!.score,
     }));
@@ -200,8 +212,8 @@ describe("ranking tie stability", () => {
     // this case) to "Open Folder" too — all three share the "Open " prefix.
     expect(candidates[0].score).toBe(candidates[2].score);
 
-    const sorted = [...candidates].sort((a, b) => b.score - a.score || a.origIndex - b.origIndex);
-    expect(sorted.map((c) => c.origIndex)).toEqual([0, 1, 2]);
+    const ranked = rankByScore([...candidates]);
+    expect(ranked).toEqual(["Open Panel", "Open Folder", "Open Panel"]);
   });
 
   it("re-sorts equal-score candidates back to original order even when shuffled beforehand", () => {
@@ -209,12 +221,15 @@ describe("ranking tie stability", () => {
       { label: "Alpha Panel", origIndex: 0 },
       { label: "Alpha Folder", origIndex: 1 },
       { label: "Alpha Widget", origIndex: 2 },
-    ].map((c) => ({ ...c, score: fuzzyMatch("alpha", c.label)!.score }));
+    ].map((c) => ({
+      result: c.origIndex,
+      origIndex: c.origIndex,
+      score: fuzzyMatch("alpha", c.label)!.score,
+    }));
     // Shuffle input order to confirm the sort — not insertion order — is what
     // restores origIndex order.
     const shuffled = [scored[2], scored[0], scored[1]];
-    const sorted = shuffled.sort((a, b) => b.score - a.score || a.origIndex - b.origIndex);
-    expect(sorted.map((c) => c.origIndex)).toEqual([0, 1, 2]);
+    expect(rankByScore(shuffled)).toEqual([0, 1, 2]);
   });
 });
 

--- a/tests/client/keyboard-activate.test.ts
+++ b/tests/client/keyboard-activate.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from "vitest";
+import { activationKeydown } from "../../src/client/utils/keyboard-activate";
+
+function makeEvent(key: string): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+}
+
+describe("activationKeydown", () => {
+  it("fires the handler on Enter and prevents default", () => {
+    const handler = vi.fn();
+    const e = makeEvent("Enter");
+    activationKeydown(handler)(e);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("fires the handler on Space and prevents default", () => {
+    const handler = vi.fn();
+    const e = makeEvent(" ");
+    activationKeydown(handler)(e);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("ignores other keys and leaves default intact", () => {
+    const handler = vi.fn();
+    for (const key of ["Escape", "Tab", "a", "ArrowDown"]) {
+      const e = makeEvent(key);
+      activationKeydown(handler)(e);
+      expect(e.defaultPrevented).toBe(false);
+    }
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("selfOnly blocks events bubbled from a descendant (and never preventDefaults them)", () => {
+    const handler = vi.fn();
+    const parent = document.createElement("div");
+    const child = document.createElement("button");
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+    parent.addEventListener("keydown", activationKeydown(handler, { selfOnly: true }));
+
+    const e = makeEvent("Enter");
+    child.dispatchEvent(e);
+    expect(handler).not.toHaveBeenCalled();
+    // Critical for the CoworkAdminDeclinedModal fix: the bubbled keydown must
+    // keep its default so the inner button's native Enter activation works.
+    expect(e.defaultPrevented).toBe(false);
+
+    const self = makeEvent(" ");
+    parent.dispatchEvent(self);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(self.defaultPrevented).toBe(true);
+    parent.remove();
+  });
+
+  it("without selfOnly, bubbled events activate", () => {
+    const handler = vi.fn();
+    const parent = document.createElement("div");
+    const child = document.createElement("span");
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+    parent.addEventListener("keydown", activationKeydown(handler));
+
+    child.dispatchEvent(makeEvent("Enter"));
+    expect(handler).toHaveBeenCalledTimes(1);
+    parent.remove();
+  });
+});

--- a/tests/client/new-tab-launcher.test.ts
+++ b/tests/client/new-tab-launcher.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
-  highlightSegments,
-  matchesQuery,
+  type LauncherRow,
   pipClassFor,
+  searchRows,
   toLauncherRow,
 } from "../../src/client/tabs/newTabLauncher.js";
 
@@ -64,53 +64,80 @@ describe("toLauncherRow", () => {
   });
 });
 
-describe("matchesQuery", () => {
-  const row = toLauncherRow({ path: "~/writing/posts/launch-day.md", openedAt: 0 });
+describe("searchRows", () => {
+  const row = (path: string): LauncherRow => toLauncherRow({ path, openedAt: 0 });
 
-  it.each([
-    { why: "empty query matches everything", query: "", expected: true },
-    { why: "whitespace query matches everything", query: "   ", expected: true },
-    { why: "substring of the name", query: "launch", expected: true },
-    { why: "case-insensitive name match", query: "LAUNCH", expected: true },
-    { why: "substring of the directory", query: "posts", expected: true },
-    { why: "no match anywhere", query: "zzz", expected: false },
-  ])("$why", ({ query, expected }) => {
-    expect(matchesQuery(row, query)).toBe(expected);
-  });
-});
-
-describe("highlightSegments", () => {
-  it("returns one unmatched segment for an empty query", () => {
-    expect(highlightSegments("chapter.md", "")).toEqual([{ text: "chapter.md", match: false }]);
+  it("returns all rows in input (recency) order with a single unmatched segment for an empty query", () => {
+    const rows = [row("/a/first.md"), row("/b/second.md"), row("/c/third.md")];
+    for (const query of ["", "   "]) {
+      const result = searchRows(rows, query);
+      expect(result.map((e) => e.row.path)).toEqual(["/a/first.md", "/b/second.md", "/c/third.md"]);
+      expect(result[0].nameSegments).toEqual([{ text: "first.md", match: false }]);
+    }
   });
 
-  it("returns one unmatched segment for a whitespace query", () => {
-    expect(highlightSegments("chapter.md", "  ")).toEqual([{ text: "chapter.md", match: false }]);
-  });
-
-  it("marks a single case-insensitive match in the middle", () => {
-    expect(highlightSegments("chapter.md", "APT")).toEqual([
+  it("matches on the name and highlights the matched run", () => {
+    const result = searchRows([row("~/writing/chapter.md")], "apt");
+    expect(result).toHaveLength(1);
+    expect(result[0].nameSegments).toEqual([
       { text: "ch", match: false },
       { text: "apt", match: true },
       { text: "er.md", match: false },
     ]);
   });
 
-  it("marks every non-overlapping occurrence", () => {
-    expect(highlightSegments("aXaXa", "a")).toEqual([
-      { text: "a", match: true },
-      { text: "X", match: false },
-      { text: "a", match: true },
-      { text: "X", match: false },
-      { text: "a", match: true },
+  it("is case-insensitive", () => {
+    const result = searchRows([row("~/writing/chapter.md")], "APT");
+    expect(result).toHaveLength(1);
+    expect(result[0].nameSegments.filter((s) => s.match).map((s) => s.text)).toEqual(["apt"]);
+  });
+
+  it("includes a dir-only match but renders the name unhighlighted", () => {
+    // Indices come from the primary field (name) only — same tradeoff the
+    // command palette accepts for annotation snippets.
+    const result = searchRows([row("~/writing/posts/launch.md")], "posts");
+    expect(result).toHaveLength(1);
+    expect(result[0].nameSegments).toEqual([{ text: "launch.md", match: false }]);
+  });
+
+  it("excludes rows that match neither name nor dir", () => {
+    const rows = [row("/a/alpha.md"), row("/b/beta.md")];
+    const result = searchRows(rows, "zzz");
+    expect(result).toEqual([]);
+  });
+
+  it("ranks a name match above a dir match (secondary field is ×0.75)", () => {
+    // "draft" hits the DIR of the first (more recent) row but the NAME of the
+    // second — quality outranks recency now.
+    const rows = [row("/home/draft/notes.md"), row("/home/other/draft.md")];
+    const result = searchRows(rows, "draft");
+    expect(result.map((e) => e.row.path)).toEqual(["/home/other/draft.md", "/home/draft/notes.md"]);
+  });
+
+  it("breaks equal-score ties by recency (original index)", () => {
+    // Identical names in different dirs, query matches only the names →
+    // identical scores; input (recency) order must be preserved.
+    const rows = [row("/x/chapter.md"), row("/y/chapter.md"), row("/z/chapter.md")];
+    const result = searchRows(rows, "chapter");
+    expect(result.map((e) => e.row.path)).toEqual([
+      "/x/chapter.md",
+      "/y/chapter.md",
+      "/z/chapter.md",
     ]);
   });
 
-  it("returns one matched segment when the whole name matches", () => {
-    expect(highlightSegments("draft", "draft")).toEqual([{ text: "draft", match: true }]);
+  it("includes subsequence matches (deliberately more permissive than the old substring filter)", () => {
+    const result = searchRows([row("~/book/chapter.md")], "chp");
+    expect(result).toHaveLength(1);
+    expect(result[0].row.name).toBe("chapter.md");
   });
 
-  it("returns one unmatched segment when there is no match", () => {
-    expect(highlightSegments("chapter.md", "zzz")).toEqual([{ text: "chapter.md", match: false }]);
+  it("segments always reassemble to the full name", () => {
+    const rows = [row("~/book/chapter.md"), row("/x/aXaXa.txt")];
+    for (const query of ["chp", "a", "aaa", "chapter"]) {
+      for (const entry of searchRows(rows, query)) {
+        expect(entry.nameSegments.map((s) => s.text).join("")).toBe(entry.row.name);
+      }
+    }
   });
 });

--- a/tests/client/settings-readonly-ui.test.ts
+++ b/tests/client/settings-readonly-ui.test.ts
@@ -14,14 +14,21 @@
  */
 
 import { cleanup, render } from "@testing-library/svelte";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { tick } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AccessibilitySettings from "../../src/client/components/AccessibilitySettings.svelte";
 import AppearanceSettings from "../../src/client/components/AppearanceSettings.svelte";
 import EditorSettings from "../../src/client/components/EditorSettings.svelte";
+import NetworkSettings from "../../src/client/components/NetworkSettings.svelte";
 import SettingsModal from "../../src/client/components/SettingsModal.svelte";
+import SettingsPopover from "../../src/client/components/SettingsPopover.svelte";
 import ShortcutEditorList from "../../src/client/components/ShortcutEditorList.svelte";
+import SettingsClaudeCodeTab from "../../src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte";
 import SettingsCollaborationTab from "../../src/client/components/settings-tabs/SettingsCollaborationTab.svelte";
+import SettingsModelsTab from "../../src/client/components/settings-tabs/SettingsModelsTab.svelte";
 import { loadSettings, type TandemSettings } from "../../src/client/hooks/useTandemSettings";
+import { _resetTandemSettingsSingletonForTests } from "../../src/client/hooks/useTandemSettings.svelte.js";
+import { installLocalStorageStub } from "../helpers/local-storage-stub.js";
 
 // loadSettings() against empty localStorage yields a complete, valid
 // TandemSettings (same approach as useTandemSettings.test.ts) — no
@@ -45,7 +52,19 @@ function makeCtx(readOnly: boolean) {
 const byTestId = (container: HTMLElement, id: string) =>
   container.querySelector<HTMLElement>(`[data-testid='${id}']`);
 
-afterEach(() => cleanup());
+// NetworkSettings, SettingsClaudeCodeTab, and SettingsPopover each fetch
+// app-info / integration state on mount (`open: true`). A never-resolving
+// stub keeps every case in this file from making a real network call
+// without needing per-suite fetch wiring — none of these tests assert on
+// that fetched data, only on the readOnly-gated controls.
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 type ControlCase = {
   name: string;
@@ -116,6 +135,27 @@ const CASES: ControlCase[] = [
     name: "SettingsCollaborationTab solo-rail checkbox",
     component: SettingsCollaborationTab,
     testid: "settings-modal-solo-rail-hidden-toggle",
+    innerInput: true,
+  },
+  {
+    name: "NetworkSettings degraded-delay slider",
+    component: NetworkSettings,
+    testid: "network-degraded-delay-slider",
+  },
+  {
+    name: "NetworkSettings retry-strategy select",
+    component: NetworkSettings,
+    testid: "network-retry-strategy",
+  },
+  {
+    name: "SettingsClaudeCodeTab dwell-time slider",
+    component: SettingsClaudeCodeTab,
+    testid: "settings-modal-dwell-time-slider",
+  },
+  {
+    name: "SettingsClaudeCodeTab selection-toolbar checkbox",
+    component: SettingsClaudeCodeTab,
+    testid: "settings-modal-selection-toolbar-toggle",
     innerInput: true,
   },
 ];
@@ -199,6 +239,90 @@ describe("ShortcutEditorList under read-only", () => {
     expect(byTestId(container, "store-readonly-banner")).toBeNull();
     expect((byTestId(container, "shortcuts-reset-all") as HTMLButtonElement | null)?.disabled).toBe(
       true,
+    );
+  });
+});
+
+// SettingsPopover derives `readOnly` itself (not threaded via
+// SettingsTabContext — the popover predates the tabbed modal), so it needs
+// its own settings._readOnly-driven coverage rather than a makeCtx() case.
+describe("SettingsPopover — readOnly gating", () => {
+  function renderPopover(readOnlyStore: boolean) {
+    return render(SettingsPopover, {
+      props: {
+        open: true,
+        onClose: vi.fn(),
+        settings: makeSettings(readOnlyStore),
+        onUpdate: vi.fn(),
+      },
+    });
+  }
+
+  function goToCollaboration(container: HTMLElement) {
+    const btn = Array.from(container.querySelectorAll<HTMLButtonElement>(".settings-nav-btn")).find(
+      (b) => b.textContent?.includes("Collaboration"),
+    );
+    expect(btn, "Collaboration nav button not found").toBeTruthy();
+    btn?.click();
+  }
+
+  it("banner present iff settings._readOnly === true", () => {
+    const { container } = renderPopover(true);
+    expect(byTestId(container, "settings-readonly-banner")).toBeTruthy();
+    cleanup();
+    const { container: rw } = renderPopover(false);
+    expect(byTestId(rw, "settings-readonly-banner")).toBeNull();
+  });
+
+  it("Collaboration section's default-mode button and solo-rail checkbox disabled when readOnly", async () => {
+    const { container } = renderPopover(true);
+    goToCollaboration(container);
+    await tick();
+    expect(
+      (byTestId(container, "default-mode-tandem-btn") as HTMLButtonElement | null)?.disabled,
+    ).toBe(true);
+    const soloRail = byTestId(container, "solo-rail-hidden-toggle");
+    expect(soloRail?.querySelector<HTMLInputElement>("input")?.disabled).toBe(true);
+  });
+
+  it("Collaboration section's controls enabled when not readOnly", async () => {
+    const { container } = renderPopover(false);
+    goToCollaboration(container);
+    await tick();
+    expect(
+      (byTestId(container, "default-mode-tandem-btn") as HTMLButtonElement | null)?.disabled,
+    ).toBe(false);
+    const soloRail = byTestId(container, "solo-rail-hidden-toggle");
+    expect(soloRail?.querySelector<HTMLInputElement>("input")?.disabled).toBe(false);
+  });
+});
+
+// SettingsModelsTab hangs its Models registry off the module-level
+// `createTandemSettings()` singleton rather than the SettingsTabContext
+// `settings`/`onUpdate` props (see the component's own doc comment), so it
+// needs the singleton reset + a real localStorage backing rather than
+// makeSettings()/makeCtx() — those build a standalone TandemSettings object
+// the singleton never sees.
+describe("SettingsModelsTab — readOnly gating", () => {
+  beforeEach(() => {
+    installLocalStorageStub();
+    _resetTandemSettingsSingletonForTests();
+  });
+
+  afterEach(() => {
+    _resetTandemSettingsSingletonForTests();
+  });
+
+  it("empty-state add-model button disabled when readOnly", () => {
+    const { container } = render(SettingsModelsTab, { props: makeCtx(true) });
+    expect(byTestId(container, "models-empty-state")).toBeTruthy();
+    expect((byTestId(container, "model-add-btn") as HTMLButtonElement | null)?.disabled).toBe(true);
+  });
+
+  it("empty-state add-model button enabled when not readOnly", () => {
+    const { container } = render(SettingsModelsTab, { props: makeCtx(false) });
+    expect((byTestId(container, "model-add-btn") as HTMLButtonElement | null)?.disabled).toBe(
+      false,
     );
   });
 });

--- a/tests/client/settings-readonly-ui.test.ts
+++ b/tests/client/settings-readonly-ui.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment happy-dom
+
+/**
+ * Forward-compat read-only settings UI (settings._readOnly, schemaVersion
+ * newer than this build). The hook's silent no-op in `updateSettings` is the
+ * load-bearing guard; these tests pin the AFFORDANCE layer added on top:
+ * one-way-bound controls must be `disabled` (so a checkbox can't flip
+ * visually and go stale against a value that never persisted) and the
+ * surface-wide `settings-readonly-banner` must appear.
+ *
+ * Per component: representative write controls disabled + onUpdate never
+ * called on click when readOnly, enabled when not. Follows
+ * SettingsClaudeCodeTab.test.ts's partial-TandemSettings props pattern.
+ */
+
+import { cleanup, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AccessibilitySettings from "../../src/client/components/AccessibilitySettings.svelte";
+import AppearanceSettings from "../../src/client/components/AppearanceSettings.svelte";
+import EditorSettings from "../../src/client/components/EditorSettings.svelte";
+import SettingsModal from "../../src/client/components/SettingsModal.svelte";
+import ShortcutEditorList from "../../src/client/components/ShortcutEditorList.svelte";
+import SettingsCollaborationTab from "../../src/client/components/settings-tabs/SettingsCollaborationTab.svelte";
+import type { TandemSettings } from "../../src/client/hooks/useTandemSettings.svelte";
+
+function makeSettings(readOnlyStore: boolean): TandemSettings {
+  return {
+    theme: "light",
+    primaryTab: "chat",
+    textSize: "m",
+    editorFont: "sans",
+    density: "cozy",
+    accentHue: 240,
+    fontByExtension: {},
+    editorMeasure: "comfortable",
+    defaultSaveDirectory: null,
+    smartTypography: true,
+    spellcheck: true,
+    highContrast: false,
+    annotationPatterns: false,
+    reduceMotion: false,
+    formattingBarVisible: true,
+    showRawMarkdown: false,
+    railHoverReveal: true,
+    showAuthorship: true,
+    showComments: true,
+    showHighlights: true,
+    showNotes: true,
+    decorationsMuted: false,
+    systemLightVariant: "light",
+    defaultMode: "tandem",
+    soloRailHidden: false,
+    selectionDwellMs: 1000,
+    selectionToolbar: true,
+    marginView: false,
+    customShortcuts: {},
+    ...(readOnlyStore ? { _readOnly: true } : {}),
+  } as TandemSettings;
+}
+
+function makeCtx(readOnly: boolean) {
+  return {
+    open: true,
+    settings: makeSettings(readOnly),
+    onUpdate: vi.fn(),
+    connected: true,
+    reconnectAttempts: 0,
+    readOnly,
+    notify: vi.fn(),
+  };
+}
+
+const byTestId = (container: HTMLElement, id: string) =>
+  container.querySelector<HTMLElement>(`[data-testid='${id}']`);
+
+afterEach(() => cleanup());
+
+type ControlCase = {
+  name: string;
+  // biome-ignore lint/suspicious/noExplicitAny: component constructors differ
+  component: any;
+  testid: string;
+  /** Testid of an inner input when the target control is a label wrapper. */
+  innerInput?: boolean;
+};
+
+const CASES: ControlCase[] = [
+  {
+    name: "AppearanceSettings theme radio",
+    component: AppearanceSettings,
+    testid: "theme-dark-btn",
+  },
+  {
+    name: "AppearanceSettings density radio",
+    component: AppearanceSettings,
+    testid: "density-compact-btn",
+  },
+  {
+    name: "AppearanceSettings decoration checkbox",
+    component: AppearanceSettings,
+    testid: "appearance-show-comments",
+    innerInput: true,
+  },
+  {
+    name: "AppearanceSettings formatting-bar checkbox",
+    component: AppearanceSettings,
+    testid: "appearance-formatting-bar",
+    innerInput: true,
+  },
+  {
+    name: "AppearanceSettings hue slider",
+    component: AppearanceSettings,
+    testid: "accent-hue-slider",
+  },
+  {
+    name: "EditorSettings measure radio",
+    component: EditorSettings,
+    testid: "editor-measure-wide",
+  },
+  {
+    name: "EditorSettings smart-typography checkbox",
+    component: EditorSettings,
+    testid: "editor-smart-typography",
+    innerInput: true,
+  },
+  {
+    name: "EditorSettings spellcheck checkbox",
+    component: EditorSettings,
+    testid: "editor-spellcheck-toggle",
+    innerInput: true,
+  },
+  {
+    name: "AccessibilitySettings high-contrast checkbox",
+    component: AccessibilitySettings,
+    testid: "high-contrast-toggle",
+    innerInput: true,
+  },
+  {
+    name: "SettingsCollaborationTab default-mode radio",
+    component: SettingsCollaborationTab,
+    testid: "settings-modal-default-mode-solo-btn",
+  },
+  {
+    name: "SettingsCollaborationTab solo-rail checkbox",
+    component: SettingsCollaborationTab,
+    testid: "settings-modal-solo-rail-hidden-toggle",
+    innerInput: true,
+  },
+];
+
+function resolveControl(container: HTMLElement, c: ControlCase): HTMLElement {
+  const el = byTestId(container, c.testid);
+  expect(el, `${c.testid} not found`).toBeTruthy();
+  if (c.innerInput) {
+    const input = (el as HTMLElement).querySelector<HTMLInputElement>("input");
+    expect(input, `${c.testid} inner input not found`).toBeTruthy();
+    return input as HTMLElement;
+  }
+  return el as HTMLElement;
+}
+
+describe("settings read-only UI — controls disabled and writes blocked", () => {
+  for (const c of CASES) {
+    it(`${c.name}: disabled + no onUpdate when readOnly`, () => {
+      const ctx = makeCtx(true);
+      const { container } = render(c.component, { props: ctx });
+      const control = resolveControl(container, c) as HTMLInputElement | HTMLButtonElement;
+      expect(control.disabled).toBe(true);
+      control.click();
+      expect(ctx.onUpdate).not.toHaveBeenCalled();
+    });
+
+    it(`${c.name}: enabled when not readOnly`, () => {
+      const ctx = makeCtx(false);
+      const { container } = render(c.component, { props: ctx });
+      const control = resolveControl(container, c) as HTMLInputElement | HTMLButtonElement;
+      expect(control.disabled).toBe(false);
+    });
+  }
+});
+
+describe("settings-readonly-banner (modal-level)", () => {
+  function renderModal(readOnlyStore: boolean) {
+    return render(SettingsModal, {
+      props: {
+        open: true,
+        onClose: vi.fn(),
+        settings: makeSettings(readOnlyStore),
+        onUpdate: vi.fn(),
+        connected: true,
+        reconnectAttempts: 0,
+      },
+    });
+  }
+
+  it("present iff settings._readOnly === true", () => {
+    const { container } = renderModal(true);
+    expect(byTestId(container, "settings-readonly-banner")).toBeTruthy();
+    cleanup();
+    const { container: rw } = renderModal(false);
+    expect(byTestId(rw, "settings-readonly-banner")).toBeNull();
+  });
+
+  it("suppresses ShortcutEditorList's inline banner inside the modal's shortcuts tab", async () => {
+    const { container } = renderModal(true);
+    // Navigate to the shortcuts tab.
+    const tabBtn = byTestId(container, "settings-modal-tab-shortcuts");
+    expect(tabBtn).toBeTruthy();
+    tabBtn?.click();
+    await Promise.resolve();
+    expect(byTestId(container, "settings-modal-shortcuts-list")).toBeTruthy();
+    // The modal banner covers the surface; the inline one must be suppressed.
+    expect(byTestId(container, "store-readonly-banner")).toBeNull();
+    expect(byTestId(container, "settings-readonly-banner")).toBeTruthy();
+  });
+});
+
+describe("ShortcutEditorList inline banner prop", () => {
+  it("keeps its inline banner by default (popover surface)", () => {
+    const { container } = render(ShortcutEditorList, {
+      props: {
+        settings: makeSettings(true),
+        onUpdate: vi.fn(),
+      },
+    });
+    expect(byTestId(container, "store-readonly-banner")).toBeTruthy();
+  });
+
+  it("hides the inline banner when showReadOnlyBanner is false", () => {
+    const { container } = render(ShortcutEditorList, {
+      props: {
+        settings: makeSettings(true),
+        onUpdate: vi.fn(),
+        showReadOnlyBanner: false,
+      },
+    });
+    expect(byTestId(container, "store-readonly-banner")).toBeNull();
+  });
+});

--- a/tests/client/settings-readonly-ui.test.ts
+++ b/tests/client/settings-readonly-ui.test.ts
@@ -21,41 +21,13 @@ import EditorSettings from "../../src/client/components/EditorSettings.svelte";
 import SettingsModal from "../../src/client/components/SettingsModal.svelte";
 import ShortcutEditorList from "../../src/client/components/ShortcutEditorList.svelte";
 import SettingsCollaborationTab from "../../src/client/components/settings-tabs/SettingsCollaborationTab.svelte";
-import type { TandemSettings } from "../../src/client/hooks/useTandemSettings.svelte";
+import { loadSettings, type TandemSettings } from "../../src/client/hooks/useTandemSettings";
 
+// loadSettings() against empty localStorage yields a complete, valid
+// TandemSettings (same approach as useTandemSettings.test.ts) — no
+// hand-maintained field list to go stale as the schema grows.
 function makeSettings(readOnlyStore: boolean): TandemSettings {
-  return {
-    theme: "light",
-    primaryTab: "chat",
-    textSize: "m",
-    editorFont: "sans",
-    density: "cozy",
-    accentHue: 240,
-    fontByExtension: {},
-    editorMeasure: "comfortable",
-    defaultSaveDirectory: null,
-    smartTypography: true,
-    spellcheck: true,
-    highContrast: false,
-    annotationPatterns: false,
-    reduceMotion: false,
-    formattingBarVisible: true,
-    showRawMarkdown: false,
-    railHoverReveal: true,
-    showAuthorship: true,
-    showComments: true,
-    showHighlights: true,
-    showNotes: true,
-    decorationsMuted: false,
-    systemLightVariant: "light",
-    defaultMode: "tandem",
-    soloRailHidden: false,
-    selectionDwellMs: 1000,
-    selectionToolbar: true,
-    marginView: false,
-    customShortcuts: {},
-    ...(readOnlyStore ? { _readOnly: true } : {}),
-  } as TandemSettings;
+  return { ...loadSettings(), ...(readOnlyStore ? { _readOnly: true as const } : {}) };
 }
 
 function makeCtx(readOnly: boolean) {
@@ -80,7 +52,7 @@ type ControlCase = {
   // biome-ignore lint/suspicious/noExplicitAny: component constructors differ
   component: any;
   testid: string;
-  /** Testid of an inner input when the target control is a label wrapper. */
+  /** True when the testid marks a label wrapper — descend to its `<input>`. */
   innerInput?: boolean;
 };
 
@@ -201,7 +173,7 @@ describe("settings-readonly-banner (modal-level)", () => {
     expect(byTestId(rw, "settings-readonly-banner")).toBeNull();
   });
 
-  it("suppresses ShortcutEditorList's inline banner inside the modal's shortcuts tab", async () => {
+  it("shortcuts tab shows only the surface-wide banner (ShortcutEditorList's old inline notice is gone)", async () => {
     const { container } = renderModal(true);
     // Navigate to the shortcuts tab.
     const tabBtn = byTestId(container, "settings-modal-tab-shortcuts");
@@ -209,31 +181,24 @@ describe("settings-readonly-banner (modal-level)", () => {
     tabBtn?.click();
     await Promise.resolve();
     expect(byTestId(container, "settings-modal-shortcuts-list")).toBeTruthy();
-    // The modal banner covers the surface; the inline one must be suppressed.
+    // ShortcutEditorList no longer owns a banner — both settings surfaces
+    // render the surface-wide one, so no double-banner anywhere.
     expect(byTestId(container, "store-readonly-banner")).toBeNull();
     expect(byTestId(container, "settings-readonly-banner")).toBeTruthy();
   });
 });
 
-describe("ShortcutEditorList inline banner prop", () => {
-  it("keeps its inline banner by default (popover surface)", () => {
+describe("ShortcutEditorList under read-only", () => {
+  it("disables its controls without rendering its own banner (hosts own the banner)", () => {
     const { container } = render(ShortcutEditorList, {
       props: {
         settings: makeSettings(true),
         onUpdate: vi.fn(),
-      },
-    });
-    expect(byTestId(container, "store-readonly-banner")).toBeTruthy();
-  });
-
-  it("hides the inline banner when showReadOnlyBanner is false", () => {
-    const { container } = render(ShortcutEditorList, {
-      props: {
-        settings: makeSettings(true),
-        onUpdate: vi.fn(),
-        showReadOnlyBanner: false,
       },
     });
     expect(byTestId(container, "store-readonly-banner")).toBeNull();
+    expect((byTestId(container, "shortcuts-reset-all") as HTMLButtonElement | null)?.disabled).toBe(
+      true,
+    );
   });
 });

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -352,6 +352,7 @@ settings-modal-working-directory-pick
 settings-modal-working-directory-reset
 settings-modal-working-directory-save
 settings-popover
+settings-readonly-banner
 settings-shortcuts-list
 settings-sidebar-footer
 settings-sidebar-version


### PR DESCRIPTION
Implements the three improvements the PR #1184 review deliberately deferred as "future pass" work. One commit per unit.

## 1. `feat(settings)` — honest read-only affordance across all settings surfaces (9465ae3)

When the on-disk `schemaVersion` is newer than this build, `updateSettings` silently no-ops — but one-way `checked={...}` controls still flipped visually and went stale. Only ShortcutEditorList handled this correctly.

- `SettingsTabContext` gains a **required** `readOnly: boolean` (derived once in `SettingsModal` from `settings._readOnly`); required so svelte-check forces every context constructor — including the still-live `SettingsPopover` — to thread it.
- Per-control `disabled={readOnly}` (not `<fieldset disabled>`, which would over-disable live non-settings controls like restart-sidecar and the wizard buttons) across all 7 tab components + the popover's 6 inline controls. AppearanceSettings card-radios reuse `cardStyle()`'s existing, previously-unfed `disabled` arm.
- New surface-wide banner (`settings-readonly-banner`, warning tokens via `warningStateColors`) on both the modal and the popover. ShortcutEditorList gains `showReadOnlyBanner` (default true); the modal's shortcuts tab passes `false` so the inline notice doesn't double up.
- Display-name inputs stay live (separate store, not schema-versioned); action buttons that don't write settings stay live.
- Testid snapshot +1 line, manifest entry added.

**Accepted limitation:** non-settings `TandemSettings` writers (DecorationsMenu switches, formatbar hide, titlebar theme switch, rail toggles/PeekStrip, command-palette toggles) stay enabled-but-inert — all are buttons/switches with derived checked state, so none hold stale visual state. Most visible effect: panel visibility is frozen while read-only.

## 2. `refactor(client)` — shared Enter/Space activation helper + Cowork modal keyboard **bug fix** (fc44ea5)

Extracts the four duplicated Enter/Space keydown idioms into `activationKeydown()` (`src/client/utils/keyboard-activate.ts`) — a plain handler factory, not a `use:` action, so svelte-check's a11y analysis still sees the keydown in markup.

- **Bug fix:** `CoworkAdminDeclinedModal`'s dialog is a *child* of its backdrop, whose unguarded keydown `preventDefault()`ed Enter/Space bubbling from the dialog's buttons and the Learn-more link — keyboard activation of every control in that dialog was broken, and the popup dismissed out from under the user. The helper's `selfOnly` guard fixes it (new mounted regression test fails against the old markup, passes now).
- AnnotationCard and the SettingsModal scrim adopt the helper with identical semantics (existing keyboard test pins the card's contract).
- PeekStrip's `handleKey` is deleted outright — it's a native `<button>`, so Enter/Space synthesize a click natively.

## 3. `refactor(tabs)` — NewTabMenu converges on the fuzzy-match stack (85bf71b)

Replaces `newTabLauncher`'s boolean `.includes()` filter and bespoke substring highlighter with `searchRows()`, built on the command palette's primitives (`scoreFields` name×1/dir×0.75, `rankByScore`, `toSegments`). `rankByScore` moves from a CommandPalette-local function to a tested export in `utils/fuzzy-match.ts`.

**Deliberate behavior changes** (pinned in unit tests): results rank by match quality instead of pure recency (equal scores keep recency order); name matches outrank dir matches; subsequence matches are now included (`"chp"` matches `chapter.md`); dir-only matches keep the row but render the name unhighlighted — the same primary-field-indices tradeoff the palette accepts.

## Verification

- `npm run typecheck` + svelte-check `--fail-on-warnings`: 0 errors, 0 warnings
- Full `npm test`: 4726 passed, 19 skipped
- E2E (`settings-modal`, `shortcut-customization`, `new-tab-launcher`, `keyboard-shortcuts`, `accessibility`, `annotation-lifecycle`): 59 passed, 1 skipped
- `npm run check:tokens`: warning set byte-identical to master (all pre-existing)
- Manual Playwright smoke against the live dev app: seeded `schemaVersion: 99` → banner renders, radios/checkboxes disabled and un-flippable, shortcuts tab shows no duplicate inline banner, restoring a writable store re-enables everything; new-tab menu subsequence (`wlcm`) and substring (`welc`) queries rank and highlight correctly.
- Cowork regression test verified to fail 3/4 against master's component and pass with the fix.

Branch note: `claude/ux-writing-experience-xaxbs4` was restarted from `origin/master` (095a659) per the merged-PR rule; the remote branch had been deleted after #1184 merged, so this push recreated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZjWx4CWrjf31SVMngcD2a

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZjWx4CWrjf31SVMngcD2a)_