### PR TITLE
fix(server): guard /api/events keepalive write against a dead socket

### DIFF
--- a/src/server/events/sse.ts
+++ b/src/server/events/sse.ts
@@ -30,9 +30,13 @@ export function sseHandler(req: Request, res: Response): void {
   // Immediate flush so the client knows the connection is alive
   res.write(": connected\n\n");
 
-  // keepalive must be declared before onEvent so the error handler can clear it
+  // keepalive must be declared before cleanup/onEvent so they can clear it
   // eslint-disable-next-line prefer-const
   let keepalive: ReturnType<typeof setInterval>;
+  function cleanup(): void {
+    clearInterval(keepalive);
+    unsubscribe(onEvent);
+  }
   const onEvent = (event: TandemEvent) => {
     try {
       writeEvent(res, event);
@@ -41,21 +45,32 @@ export function sseHandler(req: Request, res: Response): void {
         "[SSE] Write failed, cleaning up subscriber:",
         err instanceof Error ? err.message : err,
       );
-      clearInterval(keepalive);
-      unsubscribe(onEvent);
+      cleanup();
     }
   };
   subscribe(onEvent);
 
-  // Keepalive to detect broken connections
+  // Keepalive to detect broken connections. The write MUST be guarded: on an
+  // abruptly-closed socket (client SIGKILL / network drop, before req "close"
+  // fires) it throws EPIPE/ECONNRESET, and an unwrapped throw inside a
+  // setInterval callback is an uncaught exception — EPIPE/ECONNRESET are not
+  // known-Hocuspocus errors, so handleFatalError would process.exit(1) the
+  // whole server. Mirror the browser notify-stream keepalive guard.
   keepalive = setInterval(() => {
-    res.write(": keepalive\n\n");
+    try {
+      if (!res.writableEnded) res.write(": keepalive\n\n");
+    } catch (err) {
+      console.error(
+        "[SSE] Keepalive write failed, cleaning up subscriber:",
+        err instanceof Error ? err.message : err,
+      );
+      cleanup();
+    }
   }, CHANNEL_SSE_KEEPALIVE_MS);
 
   // Cleanup on disconnect
   req.on("close", () => {
-    clearInterval(keepalive);
-    unsubscribe(onEvent);
+    cleanup();
     console.error("[SSE] Client disconnected from /api/events");
   });
 

--- a/tests/server/sse-keepalive.test.ts
+++ b/tests/server/sse-keepalive.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression guard: the `/api/events` SSE keepalive write must not crash the
+ * server on a broken socket.
+ *
+ * On an abruptly-closed connection (client SIGKILL / network drop) the periodic
+ * `res.write(": keepalive")` throws EPIPE/ECONNRESET. Because that write runs
+ * inside a `setInterval` callback, an unwrapped throw becomes an *uncaught*
+ * exception — and EPIPE/ECONNRESET are not known-Hocuspocus errors, so the
+ * server's `handleFatalError` would `process.exit(1)` the whole process. The
+ * fix wraps the keepalive write (mirroring the browser notify-stream handler)
+ * and tears the subscriber down instead. This test pins that: a throwing
+ * keepalive must be swallowed and must clean up, never propagate.
+ */
+
+import type { Request, Response } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CHANNEL_SSE_KEEPALIVE_MS } from "../../src/shared/constants.js";
+
+const { subscribeSpy, unsubscribeSpy } = vi.hoisted(() => ({
+  subscribeSpy: vi.fn(),
+  unsubscribeSpy: vi.fn(),
+}));
+
+vi.mock("../../src/server/events/queue.js", () => ({
+  subscribe: subscribeSpy,
+  unsubscribe: unsubscribeSpy,
+  replaySince: vi.fn(() => []),
+}));
+
+import { sseHandler } from "../../src/server/events/sse.js";
+
+function makeReq(): Request {
+  return { headers: {}, on: vi.fn() } as unknown as Request;
+}
+
+/** A `res` whose keepalive write throws EPIPE, like a dead socket. */
+function makeThrowingRes(): { res: Response; write: ReturnType<typeof vi.fn> } {
+  const write = vi.fn((chunk: string) => {
+    if (chunk.includes("keepalive")) {
+      const err = new Error("write EPIPE") as NodeJS.ErrnoException;
+      err.code = "EPIPE";
+      throw err;
+    }
+    return true;
+  });
+  const res = { writeHead: vi.fn(), write, writableEnded: false } as unknown as Response;
+  return { res, write };
+}
+
+describe("/api/events keepalive is crash-safe", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    subscribeSpy.mockClear();
+    unsubscribeSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not propagate a throwing keepalive write (would crash the server)", () => {
+    const { res } = makeThrowingRes();
+    sseHandler(makeReq(), res);
+
+    // The regression: firing the keepalive interval must NOT throw out of the
+    // callback. Before the fix, the unguarded write's EPIPE escaped here.
+    expect(() => vi.advanceTimersByTime(CHANNEL_SSE_KEEPALIVE_MS)).not.toThrow();
+  });
+
+  it("tears down the subscriber when the keepalive write fails", () => {
+    const { res } = makeThrowingRes();
+    sseHandler(makeReq(), res);
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    const registered = subscribeSpy.mock.calls[0][0];
+
+    vi.advanceTimersByTime(CHANNEL_SSE_KEEPALIVE_MS);
+
+    // cleanup() ran: the exact subscriber callback was unsubscribed...
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+    expect(unsubscribeSpy).toHaveBeenCalledWith(registered);
+  });
+
+  it("clears the interval on failure so it does not fire again", () => {
+    const { res, write } = makeThrowingRes();
+    sseHandler(makeReq(), res);
+
+    vi.advanceTimersByTime(CHANNEL_SSE_KEEPALIVE_MS);
+    const keepaliveWrites = write.mock.calls.filter((c) =>
+      String(c[0]).includes("keepalive"),
+    ).length;
+
+    // Advancing further must not produce another keepalive write — the interval
+    // was cleared by cleanup(), not left running to throw every tick.
+    vi.advanceTimersByTime(CHANNEL_SSE_KEEPALIVE_MS * 3);
+    const after = write.mock.calls.filter((c) => String(c[0]).includes("keepalive")).length;
+    expect(after).toBe(keepaliveWrites);
+  });
+
+  it("keeps the subscriber alive when keepalive writes succeed", () => {
+    const write = vi.fn(() => true);
+    const res = { writeHead: vi.fn(), write, writableEnded: false } as unknown as Response;
+    sseHandler(makeReq(), res);
+
+    vi.advanceTimersByTime(CHANNEL_SSE_KEEPALIVE_MS * 3);
+
+    // Healthy connection: no teardown, and keepalives were actually written.
+    expect(unsubscribeSpy).not.toHaveBeenCalled();
+    expect(write.mock.calls.some((c) => String(c[0]).includes("keepalive"))).toBe(true);
+  });
+
+  it("does not write a keepalive once the response has ended", () => {
+    const write = vi.fn(() => true);
+    const res = { writeHead: vi.fn(), write, writableEnded: true } as unknown as Response;
+    sseHandler(makeReq(), res);
+
+    vi.advanceTimersByTime(CHANNEL_SSE_KEEPALIVE_MS * 2);
+    expect(write.mock.calls.some((c) => String(c[0]).includes("keepalive"))).toBe(false);
+  });
+});

--- a/tests/server/sse-keepalive.test.ts
+++ b/tests/server/sse-keepalive.test.ts
@@ -15,6 +15,7 @@
 import type { Request, Response } from "express";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CHANNEL_SSE_KEEPALIVE_MS } from "../../src/shared/constants.js";
+import type { TandemEvent } from "../../src/shared/events/types.js";
 
 const { subscribeSpy, unsubscribeSpy } = vi.hoisted(() => ({
   subscribeSpy: vi.fn(),
@@ -115,5 +116,78 @@ describe("/api/events keepalive is crash-safe", () => {
 
     vi.advanceTimersByTime(CHANNEL_SSE_KEEPALIVE_MS * 2);
     expect(write.mock.calls.some((c) => String(c[0]).includes("keepalive"))).toBe(false);
+  });
+
+  // The keepalive-write failure above and these two exercise the other call
+  // sites now routed through the shared cleanup() helper (onEvent's write
+  // failure and req "close"), so a refactor mistake in cleanup() itself
+  // (wrong closed-over `keepalive`/`onEvent`) would fail here too.
+
+  it("tears down the subscriber and clears the interval when onEvent's write fails", () => {
+    const write = vi.fn((chunk: string) => {
+      if (chunk.startsWith("id:")) {
+        const err = new Error("write EPIPE") as NodeJS.ErrnoException;
+        err.code = "EPIPE";
+        throw err;
+      }
+      return true;
+    });
+    const res = { writeHead: vi.fn(), write, writableEnded: false } as unknown as Response;
+    sseHandler(makeReq(), res);
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    const onEvent = subscribeSpy.mock.calls[0][0];
+
+    const event = {
+      id: "evt_1_a",
+      timestamp: 0,
+      type: "annotation:created",
+      payload: {
+        annotationId: "a1",
+        annotationType: "comment",
+        content: "hi",
+        textSnippet: "hi",
+      },
+    } as TandemEvent;
+
+    // A queued event delivered to a socket that has since gone bad must not
+    // throw out of the subscriber callback.
+    expect(() => onEvent(event)).not.toThrow();
+
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+    expect(unsubscribeSpy).toHaveBeenCalledWith(onEvent);
+
+    // cleanup() must also have cleared the keepalive interval.
+    const before = write.mock.calls.filter((c) => String(c[0]).includes("keepalive")).length;
+    vi.advanceTimersByTime(CHANNEL_SSE_KEEPALIVE_MS * 3);
+    const after = write.mock.calls.filter((c) => String(c[0]).includes("keepalive")).length;
+    expect(after).toBe(before);
+  });
+
+  it("tears down the subscriber and clears the interval on req close", () => {
+    const write = vi.fn(() => true);
+    const res = { writeHead: vi.fn(), write, writableEnded: false } as unknown as Response;
+    let closeHandler: (() => void) | undefined;
+    const req = {
+      headers: {},
+      on: vi.fn((event: string, cb: () => void) => {
+        if (event === "close") closeHandler = cb;
+      }),
+    } as unknown as Request;
+
+    sseHandler(req, res);
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    const registered = subscribeSpy.mock.calls[0][0];
+    expect(closeHandler).toBeDefined();
+
+    closeHandler?.();
+
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+    expect(unsubscribeSpy).toHaveBeenCalledWith(registered);
+
+    // cleanup() must also have cleared the keepalive interval.
+    const before = write.mock.calls.filter((c) => String(c[0]).includes("keepalive")).length;
+    vi.advanceTimersByTime(CHANNEL_SSE_KEEPALIVE_MS * 3);
+    const after = write.mock.calls.filter((c) => String(c[0]).includes("keepalive")).length;
+    expect(after).toBe(before);
   });
 });


### PR DESCRIPTION
## Problem

The periodic keepalive write on the `/api/events` SSE stream was unwrapped:

```js
keepalive = setInterval(() => {
  res.write(": keepalive\n\n");   // no try/catch
}, CHANNEL_SSE_KEEPALIVE_MS);
```

On an **abruptly-closed** connection (the channel shim / plugin monitor process is SIGKILL'd, or the network drops, *before* the `req` `"close"` event fires) that write throws `EPIPE`/`ECONNRESET`. Because it runs inside a `setInterval` callback, the throw is an **uncaught exception** — and `EPIPE`/`ECONNRESET` are not matched by `isKnownHocuspocusError` (`src/server/error-filter.ts`), so `handleFatalError` (`src/server/index.ts`) routes it to `process.exit(1)`. **A single dead SSE socket could take down the whole Tandem server.**

The browser's equivalent keepalive (`src/server/mcp/routes/notify-stream.ts`) already guards its write; only `/api/events` was missing the guard.

## Fix

- Wrap the keepalive write in try/catch with a `res.writableEnded` guard, mirroring `notify-stream.ts`.
- Route both the keepalive failure path and the existing `onEvent` write-failure path through a shared `cleanup()` that clears the interval and unsubscribes (removes duplicated teardown).

No behaviour change on a healthy connection; a broken socket now tears down its own subscriber instead of crashing the process.

## Tests

`tests/server/sse-keepalive.test.ts` (5 cases, fake timers):
- a throwing keepalive write does **not** propagate out of the interval callback (the crash path);
- a failed keepalive tears down the exact subscriber (`unsubscribe` called with the registered callback);
- the interval is cleared on failure (no repeat writes on subsequent ticks);
- a healthy connection is **not** torn down and keepalives are actually written;
- no keepalive is written once `res.writableEnded` is true.

Non-vacuous by construction: against the old unguarded code the throwing-write case fails, and the old keepalive path had no cleanup at all.

Full `npm run typecheck` clean; new suite green; pre-push gate (incl. cargo) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)