### PR TITLE
chore(release): v0.18.0 — activate the plugin monitor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Edit and iterate on documents with any MCP-capable AI. Claude is the default and best-supported client today.",
   "author": {
     "name": "Tandem"
@@ -11,14 +11,14 @@
   "mcpServers": {
     "tandem": {
       "command": "npx",
-      "args": ["-y", "tandem-editor@0.17.0", "mcp-stdio"],
+      "args": ["-y", "tandem-editor@0.18.0", "mcp-stdio"],
       "env": {
         "TANDEM_URL": "http://127.0.0.1:3479"
       }
     },
     "tandem-channel": {
       "command": "npx",
-      "args": ["-y", "tandem-editor@0.17.0", "channel"],
+      "args": ["-y", "tandem-editor@0.18.0", "channel"],
       "env": {
         "TANDEM_URL": "http://127.0.0.1:3479"
       }
@@ -28,7 +28,7 @@
     "monitors": [
       {
         "name": "tandem-events",
-        "command": "npx -y tandem-editor@0.17.0 monitor",
+        "command": "npx -y tandem-editor@0.18.0 monitor",
         "description": "Tandem real-time document events (annotations, chat, selections)"
       }
     ]

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -15,9 +15,14 @@ prevents them drifting.
 ## The six version surfaces
 
 1. `package.json` — `version` (the reference value the CI guard compares against)
-2. `.claude-plugin/plugin.json` — THREE values in one file: the top-level
+2. `.claude-plugin/plugin.json` — FOUR values in one file: the top-level
    `version`, plus the `tandem-editor@<version>` npx pins in
-   `mcpServers.tandem.args` AND `mcpServers.tandem-channel.args`
+   `mcpServers.tandem.args`, `mcpServers.tandem-channel.args`, AND the
+   `experimental.monitors[].command` shell string
+   (`npx -y tandem-editor@<version> monitor` — added #1201; it lives in a
+   `command` string, invisible to the `args`-array walker, so it has its own
+   guard case in `plugin-version-pin.test.ts`. Miss it and the plugin monitor
+   stays pinned to the previous, dormant version)
 3. `src-tauri/Cargo.toml` — `[package].version` (the Cowork installer pins its
    npx spec via `env!("CARGO_PKG_VERSION")`; stale = ships a build pinning the
    WRONG published npm version)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Tandem will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),\
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-07-19
+
+### Added
+
+- **Real-time push now works for manually-launched Claude Code sessions, through the plugin monitor (#1201).** Until now, a Claude Code session received live document events (annotations, chat, selections) only if Tandem's own auto-launcher started it with a special flag — a session you started yourself by hand got nothing and had to poll for changes. The Tandem plugin now ships a *monitor* that Claude Code 2.1.212+ activates at launch and that pushes those events with no flag required. Install it once — `claude plugin marketplace add bloknayrb/tandem`, then `claude plugin install tandem@tandem-editor` — and every `claude` you start afterward wakes on document changes. (This is a Claude Code plugin capability; the desktop app and Cowork keep using their existing transports and are unchanged by this release.)
+
+  One caveat: if you install the plugin *and* also launch with `--dangerously-load-development-channels server:tandem-channel`, both transports deliver each event and you'll see it twice. For a hand-launched session, install the plugin and drop the flag.
+
+### Fixed
+
+- **The server no longer crashes when an event subscriber's connection drops abruptly (#1202).** The `/api/events` push stream sends a periodic keepalive; if the client socket had already died, that write threw from inside a timer where nothing caught it, and the unhandled error took the whole server process down. The keepalive and event writes are now guarded and clean up the dead subscriber instead of crashing.
+
+### Internal
+
+- **The `tandem_checkInbox` tool description now explains why to poll steadily (#1200).** A session can't tell from the server whether real-time push is actually reaching it, so the guidance to poll at a steady cadence — plus the note that polling dedups against already-pushed items, making it cheap and safe — now lives in the tool description itself. That reaches every MCP client, not only the ones that installed the Tandem skill.
+
 ## [0.17.0] - 2026-07-17
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-editor",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-editor",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@hocuspocus/provider": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Edit and iterate on documents with any MCP-capable AI (Claude by default). Real-time push via the channel shim.",
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-desktop"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-desktop"
-version = "0.17.0"
+version = "0.18.0"
 description = "Collaborative AI-human document editor"
 authors = ["Bryan Kolb"]
 license = "BUSL-1.1"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "identifier": "com.tandem.editor",
   "build": {
     "frontendDist": "../dist/client",


### PR DESCRIPTION
## What

Cut **v0.18.0**. The point of this release is to make the plugin monitor *functional for end users*: published `tandem-editor@0.17.0` has no `monitor` subcommand (it landed on master after the v0.17.0 tag, in #1201), and the plugin manifest pins the monitor to `@0.17.0`, so installing the plugin today registers a monitor entry that can't spawn. Publishing 0.18.0 with the subcommand + advancing the pins turns it on.

Once published, a manually-launched Claude Code 2.1.212+ session that has run `claude plugin install tandem@tandem-editor` receives real-time document push with **no** `--dangerously-…` flag.

## Ships (since v0.17.0)

- **#1201** — plugin monitor via the `npx … monitor` subcommand (headline)
- **#1202** — F13 `/api/events` keepalive crash fix (a dead-socket write was crashing the whole server via `process.exit(1)`)
- **#1200** — `tandem_checkInbox` polling guidance in the tool description

## Six-surface bump (0.17.0 → 0.18.0)

- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`
- `.claude-plugin/plugin.json` — **four** version strings: top-level `version` + the three `tandem-editor@` npx pins, **including `experimental.monitors[].command`** (the pin this release exists to advance)
- `package-lock.json`, `src-tauri/Cargo.lock` — regenerated, not hand-edited
- `.claude/skills/release/SKILL.md` — surface #2 corrected to enumerate the monitor-command pin (it previously listed only the two `mcpServers` pins)

## Verification

- `npm run typecheck` — clean
- `npm test -- --run` — 4840 passed (the lone failure was `version-baked.test.ts` reading a pre-build stale bundle; passes after the build below)
- Guard tests green: `plugin-version-pin.test.ts` (incl. the `experimental.monitors` walker), `plugin-manifest.test.ts`, `tests/cli/monitor.test.ts`
- **Release-critical monitor proof (run, not read):** `npm run build` then `node dist/cli/index.js monitor` → reaches `[Monitor] Tandem monitor starting`, i.e. the built CLI actually dispatches the subcommand rather than printing `Unknown command: monitor` (the dormant 0.17.0 behavior). `dist/monitor/index.js` present; `version-baked` + monitor `build-artifact` tests green post-build.

## Post-merge (not in this PR)

Merge → tag `v0.18.0` → signed draft release → publish draft (fires npm publish). Runs tight to minimize the manifest-on-master / runtime-on-npm window (`marketplace.json` sources the manifest from GitHub master while the runtime ships from npm). Then the acceptance test: install/refresh the plugin on a real 2.1.212 manual CLI and confirm an idle session wakes on a doc edit — the first true end-to-end run of the marketplace+npx monitor path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
