### PR TITLE
fix(cli): make npm/CLI setup path honest for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The desktop app bundles the editor, the server it talks to, and storage for the 
 
 ### Other ways to install
 
-If you use a terminal, you can also install Tandem with `npm install -g tandem-editor`, then run `tandem` to launch — the first-run wizard connects Claude. (For a scripted, non-interactive setup, run `tandem setup --apply` once first.) This works the same as the desktop app and is mostly useful if you already have Node.js installed.
+If you use a terminal, you can also install Tandem with `npm install -g tandem-editor` (Node.js 22 or newer required), then run `tandem` — it starts the server and prints a `http://127.0.0.1:3479` URL to open the editor in your browser, where the first-run wizard connects Claude. (For a scripted, non-interactive setup, run `tandem setup --apply` once first.) This is mostly useful if you already have Node.js installed; the desktop app is the recommended experience.
 
 ### Got stuck
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -31,6 +31,8 @@ import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { parseLockfile } from "../server/annotations/lockfile.js";
 import { DEFAULT_MCP_PORT, DEFAULT_WS_PORT } from "../shared/constants.js";
+import type { ClaudeCliPresence } from "../shared/integrations/contract.js";
+import { detectClaudeCli } from "../shared/integrations/detect-claude-cli.js";
 
 // Injected by tsup into dist/cli. Absent in tsx dev / vitest (typeof-guarded at
 // use). This is the version the `npx` bridge entries are pinned to.
@@ -651,7 +653,7 @@ function checkUserMcpConfig(r: Recorder): void {
   if (!existsSync(claudeCodePath)) {
     r.warn(
       "~/.claude.json not found",
-      "Run: tandem setup  (or ignore if using project-local .mcp.json)",
+      "Run: tandem setup --apply  (or ignore if using project-local .mcp.json)",
     );
     return;
   }
@@ -664,23 +666,66 @@ function checkUserMcpConfig(r: Recorder): void {
     // source text, and ~/.claude.json carries bearer tokens / API keys. This
     // check survives the /api/diagnostics filter, so its message reaches the
     // Copy Diagnostics clipboard — destined for public issues.
-    r.warn("~/.claude.json is malformed JSON", "Run: tandem setup to rewrite it");
+    r.warn("~/.claude.json is malformed JSON", "Run: tandem setup --apply to rewrite it");
     return;
   }
 
   const servers = config?.mcpServers ?? {};
   if (!servers.tandem) {
-    r.warn("tandem not registered in ~/.claude.json", "Run: tandem setup");
+    r.warn("tandem not registered in ~/.claude.json", "Run: tandem setup --apply");
   } else {
     r.pass("tandem registered in ~/.claude.json");
   }
   if (!servers["tandem-channel"]) {
     r.warn(
       "tandem-channel not registered in ~/.claude.json — Claude Code will poll instead of receiving real-time push",
-      "Run: tandem setup",
+      "Run: tandem setup --apply",
     );
   } else {
     r.pass("tandem-channel registered in ~/.claude.json");
+  }
+}
+
+// ── Check: Claude CLI presence ──────────────────────────────────────
+//
+// A config-presence check (checkUserMcpConfig / checkMcpJson) can pass on a
+// machine where the `claude` binary was never installed — Tandem's AI features
+// then silently do nothing with no clue why. This binary probe names that gap.
+// Pure filesystem probe (no spawn); shares the wizard's detector via a leaf.
+
+/**
+ * Pure decision step, split out of {@link checkClaudeCli} so the
+ * presence→status mapping is directly unit-testable without probing the real
+ * filesystem — see tests/cli/doctor.test.ts.
+ */
+export function evaluateClaudeCli(presence: ClaudeCliPresence): {
+  status: "pass" | "warn";
+  message: string;
+  fix?: string;
+} {
+  if (presence === "INSTALLED_ON_PATH") {
+    return { status: "pass", message: "Claude Code CLI found on PATH" };
+  }
+  if (presence === "INSTALLED_NOT_ON_PATH") {
+    return {
+      status: "warn",
+      message: "Claude Code CLI installed but not on PATH (found in ~/.local/bin)",
+      fix: "Open a new terminal, or add ~/.local/bin to your PATH, then run `claude` once",
+    };
+  }
+  return {
+    status: "warn",
+    message: "Claude Code CLI not found — Tandem's AI collaboration needs an MCP client",
+    fix: "Install Claude Code from https://claude.com/claude-code (or connect another MCP client)",
+  };
+}
+
+function checkClaudeCli(r: Recorder): void {
+  const result = evaluateClaudeCli(detectClaudeCli());
+  if (result.status === "pass") {
+    r.pass(result.message);
+  } else {
+    r.warn(result.message, result.fix);
   }
 }
 
@@ -708,17 +753,17 @@ async function checkPorts(
   r: Recorder,
   wsPort: number,
   mcpPort: number,
+  startHint: string,
 ): Promise<{ ws: boolean; mcp: boolean }> {
   const [ws, mcp] = await Promise.all([probePort(wsPort), probePort(mcpPort)]);
 
   if (ws && mcp) {
     r.pass(`Ports ${wsPort} (WebSocket) + ${mcpPort} (MCP HTTP) in use`, undefined, { ws, mcp });
   } else if (!ws && !mcp) {
-    r.fail(
-      `Ports ${wsPort} + ${mcpPort} not listening — server not running`,
-      "npm run dev:standalone",
-      { ws, mcp },
-    );
+    r.fail(`Ports ${wsPort} + ${mcpPort} not listening — server not running`, startHint, {
+      ws,
+      mcp,
+    });
   } else {
     r.warn(
       `Partial: port ${wsPort} ${ws ? "up" : "down"}, port ${mcpPort} ${mcp ? "up" : "down"}`,
@@ -908,19 +953,16 @@ async function isViteDevServer(port: number): Promise<boolean> {
   return result?.status === 200;
 }
 
-async function checkHealth(r: Recorder, mcpPort: number): Promise<boolean> {
+async function checkHealth(r: Recorder, mcpPort: number, startHint: string): Promise<boolean> {
   const result = await httpGet(`http://127.0.0.1:${mcpPort}/health`);
 
   if (!result) {
-    r.fail(`Server not responding on 127.0.0.1:${mcpPort}`, "npm run dev:standalone");
+    r.fail(`Server not responding on 127.0.0.1:${mcpPort}`, startHint);
     return false;
   }
 
   if (result.error) {
-    r.fail(
-      `Server not responding on 127.0.0.1:${mcpPort} (${result.error})`,
-      "npm run dev:standalone",
-    );
+    r.fail(`Server not responding on 127.0.0.1:${mcpPort} (${result.error})`, startHint);
     return false;
   }
 
@@ -1282,6 +1324,13 @@ export async function runDoctor(opts: RunDoctorOptions = {}): Promise<DoctorRepo
   const cwd = process.cwd();
   const repo = probeTandemEditorRepo(cwd);
   const devRepo = repo === "yes";
+  // "Server not running" fixes differ by install kind: a source checkout starts
+  // the server with `npm run dev:standalone`; a global/desktop install has no
+  // such script — the user launches the app (or `tandem`). Pointing global-install
+  // users at `npm run dev:standalone` is a dead end (#new-user-friction audit).
+  const startHint = devRepo
+    ? "npm run dev:standalone"
+    : "Launch the Tandem desktop app, or run `tandem` in a terminal";
 
   await r.check("node-version", () => checkNodeVersion(r));
   await r.check("node-modules", () => checkNodeModules(r));
@@ -1303,13 +1352,14 @@ export async function runDoctor(opts: RunDoctorOptions = {}): Promise<DoctorRepo
   }
   await r.check("mcp-json", () => checkMcpJson(r));
   await r.check("user-mcp-config", () => checkUserMcpConfig(r));
+  await r.check("claude-cli", () => checkClaudeCli(r));
   await r.check("annotation-store", () => checkAnnotationStore(r));
   await r.check("stale-global", () => checkStaleGlobal(r));
 
   // `check` returns undefined when the check crashed (it records its own
   // fail). Treating both ports as down is the honest reading: we did not
   // observe them up. Do NOT cast this away — see Recorder.check.
-  const ports = await r.check("ports", () => checkPorts(r, wsPort, mcpPort));
+  const ports = await r.check("ports", () => checkPorts(r, wsPort, mcpPort, startHint));
   const ws = ports?.ws ?? false;
   const mcp = ports?.mcp ?? false;
 
@@ -1322,7 +1372,7 @@ export async function runDoctor(opts: RunDoctorOptions = {}): Promise<DoctorRepo
   if (mcp) {
     // A crashed health check means we never established health — don't run
     // the SSE check on an unverified server.
-    const healthy = (await r.check("health", () => checkHealth(r, mcpPort))) ?? false;
+    const healthy = (await r.check("health", () => checkHealth(r, mcpPort, startHint))) ?? false;
     if (healthy) {
       await r.check("sse", () => checkSseEndpoint(r, mcpPort));
     }

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -3,6 +3,8 @@ import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { DEFAULT_MCP_PORT } from "../shared/constants.js";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SERVER_DIST = resolve(__dirname, "../server/index.js");
 
@@ -13,11 +15,18 @@ export function runStart(): void {
     process.exit(1);
   }
 
-  console.error(
-    "[Tandem] Browser distribution is deprecated; the Tauri desktop app is the primary form factor.",
-  );
-  console.error("[Tandem] See https://github.com/bloknayrb/tandem/issues/477 for context.");
+  // Lead with the actionable next step (the URL to open) — `tandem` starts the
+  // server but opens no window, so a new user needs to be told where the editor
+  // lives. The desktop-app recommendation follows as context, not as an alarming
+  // "deprecated" banner ahead of any instruction (#new-user-friction audit).
+  const editorUrl =
+    process.env.TANDEM_URL ?? `http://127.0.0.1:${process.env.TANDEM_MCP_PORT ?? DEFAULT_MCP_PORT}`;
   console.error("[Tandem] Starting server...");
+  console.error(`[Tandem] When it's ready, open the editor in your browser at ${editorUrl}`);
+  console.error(
+    "[Tandem] The desktop app is the primary way to run Tandem — running in a browser " +
+      "works but isn't the recommended experience (https://github.com/bloknayrb/tandem/issues/477).",
+  );
 
   const proc = spawn("node", [SERVER_DIST], {
     stdio: "inherit",

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -39,12 +39,11 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { basename, delimiter, dirname, join, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { SKILL_CONTENT } from "../../cli/skill-content.js";
 import { DEFAULT_MCP_PORT } from "../../shared/constants.js";
-import type { ClaudeCliPresence } from "../../shared/integrations/contract.js";
 import { resolveAppDataDir } from "../platform.js";
 import { setRestrictiveAcl } from "./acl-win.js";
 import { backupDir, pruneOldBackups, shouldBackup, writeBackup } from "./backup.js";
@@ -459,53 +458,14 @@ export function detectTargets(opts: DetectOptions = {}): DetectedTarget[] {
   return targets;
 }
 
-export interface DetectClaudeCliOptions {
-  /** Override `homedir()` — tests anchor the native-location probe under a tmpdir. */
-  homeOverride?: string;
-  /** Override `process.env.PATH` — tests inject a controlled PATH. */
-  pathOverride?: string;
-  /** Override `process.platform` — tests exercise the win32 `.exe` branch. */
-  platformOverride?: NodeJS.Platform;
-}
-
-/**
- * Probe whether the `claude` CLI binary is present, independent of any config
- * file. This is the **binary** detector; {@link detectTargets} is the separate
- * **config-presence** detector (it answers "has Claude ever written a config
- * here?", which stays true after an uninstall and is true on a machine that
- * only has Claude Desktop).
- *
- * Pure filesystem probe — deliberately no `execFile`/spawn (no shell-injection
- * surface, no hang on a wedged binary). Returns:
- *   - `INSTALLED_ON_PATH` — `claude[.exe]` found on the server process's PATH.
- *   - `INSTALLED_NOT_ON_PATH` — found only in `~/.local/bin` (the native
- *     installer's target, which is typically NOT on the server's PATH at
- *     install time → the usual immediately-post-install state).
- *   - `NOT_INSTALLED` — neither.
- *
- * PATH wins over `~/.local/bin`: if it's on PATH it's usable right now, which
- * is the more useful signal for the wizard.
- */
-export function detectClaudeCli(opts: DetectClaudeCliOptions = {}): ClaudeCliPresence {
-  const platform = opts.platformOverride ?? process.platform;
-  const home = opts.homeOverride ?? homedir();
-  const binName = platform === "win32" ? "claude.exe" : "claude";
-
-  // `delimiter` is platform-specific (`;` on win32, `:` elsewhere). When a
-  // platformOverride disagrees with the host, the override is for test
-  // ergonomics only — real callers never pass it, so host `delimiter` is fine.
-  const pathVar = opts.pathOverride ?? process.env.PATH ?? "";
-  for (const dir of pathVar.split(delimiter)) {
-    if (dir.length === 0) continue;
-    if (existsSync(join(dir, binName))) return "INSTALLED_ON_PATH";
-  }
-
-  // Native install location — same `~/.local/bin` on every platform per the
-  // official installer's documented uninstall paths (Windows included).
-  if (existsSync(join(home, ".local", "bin", binName))) return "INSTALLED_NOT_ON_PATH";
-
-  return "NOT_INSTALLED";
-}
+// The `claude` binary probe moved to a shared built-ins-only leaf so
+// `tandem doctor` can reuse it without importing apply.ts's server-coupled
+// deps. Re-exported here so existing importers (install-claude-cli, api-routes,
+// tests) keep their `./apply.js` import path.
+export {
+  type DetectClaudeCliOptions,
+  detectClaudeCli,
+} from "../../shared/integrations/detect-claude-cli.js";
 
 /**
  * Atomic write: write to a temp file in the SAME directory as the destination,

--- a/src/shared/integrations/detect-claude-cli.ts
+++ b/src/shared/integrations/detect-claude-cli.ts
@@ -41,7 +41,19 @@ export interface DetectClaudeCliOptions {
 export function detectClaudeCli(opts: DetectClaudeCliOptions = {}): ClaudeCliPresence {
   const platform = opts.platformOverride ?? process.platform;
   const home = opts.homeOverride ?? homedir();
-  const binName = platform === "win32" ? "claude.exe" : "claude";
+
+  // On Windows `claude` is exposed under several names depending on how it was
+  // installed: the native installer drops `claude.exe`, while
+  // `npm i -g @anthropic-ai/claude-code` writes cmd-shim wrappers
+  // (`claude.cmd` / `claude.ps1`) plus a bare `claude` bash shim. Probing
+  // `claude.exe` alone reported a perfectly usable npm-global install as
+  // NOT_INSTALLED — the exact false "not installed" warning this check exists to
+  // avoid — so we check every candidate. POSIX only ever has the bare `claude`.
+  const binNames =
+    platform === "win32"
+      ? ["claude.exe", "claude.cmd", "claude.bat", "claude.ps1", "claude"]
+      : ["claude"];
+  const foundIn = (dir: string): boolean => binNames.some((name) => existsSync(join(dir, name)));
 
   // `delimiter` is platform-specific (`;` on win32, `:` elsewhere). When a
   // platformOverride disagrees with the host, the override is for test
@@ -49,12 +61,12 @@ export function detectClaudeCli(opts: DetectClaudeCliOptions = {}): ClaudeCliPre
   const pathVar = opts.pathOverride ?? process.env.PATH ?? "";
   for (const dir of pathVar.split(delimiter)) {
     if (dir.length === 0) continue;
-    if (existsSync(join(dir, binName))) return "INSTALLED_ON_PATH";
+    if (foundIn(dir)) return "INSTALLED_ON_PATH";
   }
 
   // Native install location — same `~/.local/bin` on every platform per the
   // official installer's documented uninstall paths (Windows included).
-  if (existsSync(join(home, ".local", "bin", binName))) return "INSTALLED_NOT_ON_PATH";
+  if (foundIn(join(home, ".local", "bin"))) return "INSTALLED_NOT_ON_PATH";
 
   return "NOT_INSTALLED";
 }

--- a/src/shared/integrations/detect-claude-cli.ts
+++ b/src/shared/integrations/detect-claude-cli.ts
@@ -1,0 +1,60 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, join } from "node:path";
+
+import type { ClaudeCliPresence } from "./contract.js";
+
+/**
+ * Pure-built-ins probe for the `claude` CLI binary, extracted to a shared leaf
+ * so both the server integration layer (`apply.ts` re-exports it) AND the
+ * built-ins-only CLI (`tandem doctor`) can call it without the CLI bundle
+ * dragging in `apply.ts`'s server-coupled deps (platform/ACL/backup).
+ */
+
+export interface DetectClaudeCliOptions {
+  /** Override `homedir()` — tests anchor the native-location probe under a tmpdir. */
+  homeOverride?: string;
+  /** Override `process.env.PATH` — tests inject a controlled PATH. */
+  pathOverride?: string;
+  /** Override `process.platform` — tests exercise the win32 `.exe` branch. */
+  platformOverride?: NodeJS.Platform;
+}
+
+/**
+ * Probe whether the `claude` CLI binary is present, independent of any config
+ * file. This is the **binary** detector; `detectTargets` is the separate
+ * **config-presence** detector (it answers "has Claude ever written a config
+ * here?", which stays true after an uninstall and is true on a machine that
+ * only has Claude Desktop).
+ *
+ * Pure filesystem probe — deliberately no `execFile`/spawn (no shell-injection
+ * surface, no hang on a wedged binary). Returns:
+ *   - `INSTALLED_ON_PATH` — `claude[.exe]` found on the process's PATH.
+ *   - `INSTALLED_NOT_ON_PATH` — found only in `~/.local/bin` (the native
+ *     installer's target, which is typically NOT on the process's PATH at
+ *     install time → the usual immediately-post-install state).
+ *   - `NOT_INSTALLED` — neither.
+ *
+ * PATH wins over `~/.local/bin`: if it's on PATH it's usable right now, which
+ * is the more useful signal for callers.
+ */
+export function detectClaudeCli(opts: DetectClaudeCliOptions = {}): ClaudeCliPresence {
+  const platform = opts.platformOverride ?? process.platform;
+  const home = opts.homeOverride ?? homedir();
+  const binName = platform === "win32" ? "claude.exe" : "claude";
+
+  // `delimiter` is platform-specific (`;` on win32, `:` elsewhere). When a
+  // platformOverride disagrees with the host, the override is for test
+  // ergonomics only — real callers never pass it, so host `delimiter` is fine.
+  const pathVar = opts.pathOverride ?? process.env.PATH ?? "";
+  for (const dir of pathVar.split(delimiter)) {
+    if (dir.length === 0) continue;
+    if (existsSync(join(dir, binName))) return "INSTALLED_ON_PATH";
+  }
+
+  // Native install location — same `~/.local/bin` on every platform per the
+  // official installer's documented uninstall paths (Windows included).
+  if (existsSync(join(home, ".local", "bin", binName))) return "INSTALLED_NOT_ON_PATH";
+
+  return "NOT_INSTALLED";
+}

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -297,6 +297,54 @@ describe("a crashing check does not take down the report", () => {
   });
 });
 
+// ── "server not running" fix hint must match the install kind ──
+// A source checkout starts the server with `npm run dev:standalone`; a
+// global/desktop install has no such script. Pointing a global user at
+// `dev:standalone` is the dead-end this branch exists to prevent — so the
+// NEGATIVE assertion below (the global fix must NOT say dev:standalone) is the
+// load-bearing one. A future refactor that collapses/flips the ternary would
+// otherwise silently reintroduce the friction bug with green tests.
+describe("'server not running' fix hint is install-kind aware", () => {
+  let repoDir: string;
+  let cwdSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  afterEach(() => {
+    cwdSpy?.mockRestore();
+    cwdSpy = undefined;
+    if (repoDir) rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Seed a cwd whose package.json `name` decides the dev-repo gate, then run
+   * doctor against two guaranteed-down ports (OS-assigned then immediately
+   * closed) so the ports check takes its fail path and exposes `.fix`.
+   */
+  async function portsFixInCwd(pkgName: string): Promise<string | undefined> {
+    repoDir = mkdtempSync(join(tmpdir(), "tandem-starthint-"));
+    writeFileSync(
+      join(repoDir, "package.json"),
+      JSON.stringify({ name: pkgName, version: "0.2.0" }),
+    );
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(repoDir);
+
+    const [wsPort, mcpPort] = await Promise.all([allocPort(), allocPort()]);
+    const report = await runDoctor({ wsPort, mcpPort });
+    return report.results.find((res) => res.check === "ports")?.fix;
+  }
+
+  it("points a dev checkout at npm run dev:standalone", async () => {
+    const fix = await portsFixInCwd("tandem-editor");
+    expect(fix).toContain("dev:standalone");
+  });
+
+  it("points a global/desktop install at the app, NOT dev:standalone", async () => {
+    const fix = await portsFixInCwd("someones-app");
+    expect(fix).toBeDefined();
+    expect(fix).not.toContain("dev:standalone");
+    expect(fix).toContain("desktop app");
+  });
+});
+
 describe("summarizeDoctorResults", () => {
   // Shared by the CLI summary AND /api/diagnostics' filtered recomputation —
   // the equivalence class that matters is failures-AND-warnings: failures must

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  evaluateClaudeCli,
   evaluateNpmStaleness,
   evaluateOrphanedVite,
   evaluateStaleGlobal,
@@ -390,6 +391,28 @@ describe("evaluateStaleGlobal", () => {
     expect(result?.message).toContain("0.14.3");
     expect(result?.fix).toContain("npm uninstall -g tandem-editor");
     expect(result?.data).toEqual({ globalVersion: "0.2.11", bundledVersion: "0.14.3" });
+  });
+});
+
+describe("evaluateClaudeCli", () => {
+  it("passes when the CLI is on PATH", () => {
+    const result = evaluateClaudeCli("INSTALLED_ON_PATH");
+    expect(result.status).toBe("pass");
+    expect(result.fix).toBeUndefined();
+  });
+
+  it("warns with a PATH fix when installed but not on PATH", () => {
+    const result = evaluateClaudeCli("INSTALLED_NOT_ON_PATH");
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("not on PATH");
+    expect(result.fix).toContain("PATH");
+  });
+
+  it("warns with an install fix when the CLI is absent", () => {
+    const result = evaluateClaudeCli("NOT_INSTALLED");
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("not found");
+    expect(result.fix).toContain("claude.com/claude-code");
   });
 });
 

--- a/tests/server/integrations/detect-claude-cli.test.ts
+++ b/tests/server/integrations/detect-claude-cli.test.ts
@@ -90,6 +90,23 @@ describe("detectClaudeCli", () => {
     });
   });
 
+  it("detects an npm-global cmd-shim on win32 (claude.cmd, no claude.exe)", () => {
+    // `npm i -g @anthropic-ai/claude-code` on Windows writes `claude.cmd` /
+    // `claude.ps1` shims — never a `claude.exe`. Probing only `claude.exe`
+    // would report this usable install as NOT_INSTALLED. Regression guard.
+    const binDir = seedBin("pathdir", "claude.cmd");
+    const home = join(root, "home");
+    mkdirSync(home, { recursive: true });
+
+    const presence = detectClaudeCli({
+      platformOverride: "win32",
+      pathOverride: binDir,
+      homeOverride: home,
+    });
+
+    expect(presence).toBe("INSTALLED_ON_PATH");
+  });
+
   it("ignores empty PATH segments without throwing", () => {
     const home = join(root, "home");
     mkdirSync(home, { recursive: true });


### PR DESCRIPTION
## Why

A fresh-eyes audit of the new-user journey (install → connect Claude → first edit) found the **terminal/npm path** littered with guidance that points at dead ends or no-op commands. This PR is the fix-strings-only slice (WS-C) of that overhaul — it changes user-facing guidance and adds one diagnostic, without touching the deliberate `tandem setup` no-op contract.

## What

- **Doctor "Fix:" strings → the command that actually writes config.** Bare `tandem setup` only prints guidance (deliberate — #477 PR 3c-ii-c, ADR-038 §2b, pinned by `tests/cli/setup.test.ts`). The doctor was telling users to run it to *fix* a missing config. Every such fix string now points at `tandem setup --apply`.
- **Install-kind-aware "server not running" fixes.** The ports/health checks hardcoded `npm run dev:standalone` — a dead end for a global/desktop install. A `startHint` derived from the existing dev-repo probe branches the fix text (dev checkout → `npm run dev:standalone`; installed → launch the desktop app or run `tandem`).
- **`tandem` launch banner leads with the actionable URL.** It used to print a "Browser distribution is deprecated" banner *first* and never say where the editor lives. Now it leads with "Starting server…" + the canonical `http://127.0.0.1:3479` URL (honoring `TANDEM_URL` / `TANDEM_MCP_PORT`), with the deprecation demoted to context.
- **README npm blurb** states the Node 22+ floor and corrects "run `tandem` to launch" (it starts the server and prints a URL — it opens no window).
- **New `claude-cli` doctor check.** A config-presence pass can pass green on a machine with no MCP client installed at all. The check reuses the wizard's `detectClaudeCli` probe, extracted to a built-ins-only shared leaf (`src/shared/integrations/detect-claude-cli.ts`) so the CLI bundle doesn't drag in `apply.ts`'s server-coupled deps (platform/ACL/backup).

## Scope guard

Bare `tandem setup` behavior is unchanged — its no-op-printer contract and regression test stay intact. This PR only corrects the *other* surfaces that misdirected users to it.

## Verification

- `npm run typecheck` clean.
- `tests/cli/doctor.test.ts`: 92 pass (incl. 3 new `evaluateClaudeCli` tests — on-PATH → pass/no-fix; not-on-PATH → warn/PATH-fix; not-installed → warn/claude.com-fix).
- Leaf-importer suite (detect-claude-cli / doctor / api-routes / install-claude-cli): 178 pass.
- A true clean `npm install -g` verification needs a clean VM (this machine carries the global — the stale-global snag WS-D documents); recorded as a skip per the no-release-hardware constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)