### PR TITLE
feat(models): mount + gate the BYO-models UI (#1123 M2b, dark)

### DIFF
--- a/docs/plans/1123-m2b-models-ui-mount.md
+++ b/docs/plans/1123-m2b-models-ui-mount.md
@@ -1,0 +1,137 @@
+# #1123 M2b — Models UI mount + per-provider gating (built dark)
+
+**Status:** REVISED after 3-agent plan review (dark-guarantee / Svelte-reactivity / altitude). Agent feedback incorporated — see "Plan-review corrections (round 1)" below. Stacked on M2a (PR #1220, branch `feat/1123-m2-model-registry-server-authority`); this branch is `feat/1123-m2b-models-ui-mount`. Retarget the PR to master once M2a merges.
+
+### Plan-review corrections (round 1 — applied before implementation)
+
+- **§3.8 force-on seam was a CRITICAL client-crash risk — DROPPED (dark-guarantee + altitude converged).** The tsup `define` + `process.env` fallback is a *server/cli* pattern (the license gate is server+cli). `BYO_MODELS_ENABLED` is imported by 7 **client** files built by **vite**, and `vite.config.ts` has **no `define` block**; the client bundle has no `process` shim. So the copied mechanism would fold `__BYO_MODELS_ENABLED__=undefined` → evaluate `process.env` → **`ReferenceError: process is not defined`, white-screen crash on every client load** (a guaranteed dark regression, worse than "flag true"). It also trades away R2-F's "literal `const false`, not env/define-overridable" dark guarantee. **Resolution:** keep `BYO_MODELS_ENABLED` a literal `const false` (production is dark until M4 regardless — a runtime env-read buys nothing). Cover flag-ON logic by (a) **mounting `SettingsModelsTab` / `FirstRunModelPickerModal` directly** in vitest — neither has an internal flag gate, only their call-sites do — and (b) a targeted `vi.mock` of `shared/constants` **only** where a flag-ON *gate* assertion adds value (does SettingsModal show the tab? does App mount the picker?). E2E `settings-models.spec.ts` stays `test.skip(!BYO_MODELS_ENABLED)` and **auto-enables at the M4 flip** — so M4 gets full E2E for free; M2b's logic is fully covered at the component layer meanwhile. **No production flag change ships in M2b.**
+- **§3.3 re-altituded — surface the outcome, don't read a shared flag (altitude).** `addModel` already does `const outcome = await writeThrough(...)` (`useModels.svelte.ts:406`) and discards it. Reading the reactive `_saveError` after an await is a fragile single-writer timing invariant and can't distinguish `reconciled` from `rolledback`. Instead: `addModel` returns `Promise<string | null>` (id on commit, `null` on non-commit), `updateModel` returns `Promise<boolean>` (committed?). The imperative branch-on-success flows (FirstRun, `handleSave`) key off the return; the declarative tab banner keeps the reactive `models.saveError` bind (fire-and-forget mutators). This also closes the tab's add/edit-path gap (a rolled-back save must not close the modal).
+- **Sticky `saveError` needs a non-write clear (Svelte Q4).** `_saveError` clears only on a successful write today, so a stale tab banner can co-show with a fresh modal validation error. Add `clearError()` to the store; call it on modal-open and at mutation-start.
+- **`setDefault` outcome guarded in FirstRun (Svelte Q2).** `setDefault` can itself roll back; don't call `onComplete()` blind — treat a `setDefault` failure as surfaced-but-non-fatal, or gate `onComplete` on it.
+- **§3.7 carriers named (dark-guarantee + Svelte).** Removing the legacy UI also updates `tests/client/use-models.test.ts:426-429` (asserts both removed members), deletes the E2E block `settings-models.spec.ts:294-345`, and regenerates `tests/design-system-impl/__snapshots__/testid-set.snap.txt` (drop `models-legacy-migration-banner|-migrate-btn|-migration-status`).
+- **§3.5 is a real state-machine change, not a drop-in mount (altitude).** Inserting an optional/skippable picker between wizard-dismiss and tutorial-show is a new gate that must let the tutorial through on skip. Its own commit; ordering §3.3 → §3.5 (don't mount a picker that finishes onboarding on a rolled-back add).
+- **Round-4 (M2a) superseded the "M4-offline reconcile deadlock surfaces blocked state" follow-up** — the `finally`-settle in `initializeStore` dissolved the deadlock, so there is no blocked state to surface. Not carried into M2b.
+- **Sequencing:** §3.1 (loading/reload) before §3.2/§3.4 (consume it); §3.3 before §3.5; §3.7 (pure deletion) as its own commit; testid-registry edits (§3.2 rebind, §3.7 removal) landed together to avoid collision.
+
+**Issue:** #1123 (local-model collaborator), phase **M2b**. ADR-039 canonical. Builds on M2a (client registry read/write-authority relocated to the server store). Ships **DARK** (`BYO_MODELS_ENABLED=false`) — every change adds a flag-ON branch **without changing any flag-OFF behavior**. The flag flips at **M4** (v1.0). M2b's deliverable: when M4 flips the flag, a complete, tested Models UI lights up.
+
+---
+
+## 0. The one-line goal
+
+M2a made the server the registry authority but left the UI unmounted (Settings Models tab filtered out, first-run picker never rendered, wizard shows "coming soon", chip forced null). M2b **mounts and wires** that UI behind the flag, closes the two M2b-BLOCKING gaps the M2a PR review surfaced, and adds a force-on test seam so the flag-ON paths are actually exercised.
+
+## 1. Dark guarantee (the load-bearing constraint — every commit)
+
+With `BYO_MODELS_ENABLED=false`, the app must stay **byte-identical to M2a**:
+- No Settings Models tab (`SettingsModal.svelte:181-184` filter keeps stripping it).
+- No titlebar chip (`App.svelte:1856` keeps forcing `defaultModelLabel={… : null}`).
+- `FirstRunModelPickerModal` never mounts (new mount site gated on the flag).
+- The wizard renders the `{#if !BYO_MODELS_ENABLED}` "coming soon" row; the new `{:else}` never renders.
+- No `GET /api/models` fetch, no store `loading` transition (store stays inert; `loadFromServer` is flag-gated).
+
+Verification per commit: `check:tokens` + `typecheck` + `svelte-check` clean; the existing M2a dark tests stay green; a grep-level confirmation that every new branch is behind `BYO_MODELS_ENABLED` (directly, or inside a component that only mounts when the flag is on).
+
+## 2. Anchors (verified on this branch head via the surface map)
+
+- `src/shared/constants.ts:18` — `BYO_MODELS_ENABLED = false` (currently a literal const).
+- `src/client/components/SettingsModal.svelte:155-162` (Models tab entry), `:181-184` (flag filter).
+- `src/client/components/settings-tabs/SettingsModelsTab.svelte` — `createModels()` at :19; local `saveError` :52 (set only in `handleSave` catch :91); `deleteModel` :97 / `setDefault` :202 / `toggleEnabled` :215 have **no error path**; legacy banner :117-147 (`{#if models.hasLegacyKeys}`); no loading skeleton.
+- `src/client/components/FirstRunModelPickerModal.svelte` — unmounted (doc-comment :2-11); `handleSave` :97-120 calls `setDefault(id)` + `onComplete()` **unconditionally** after `addModel`.
+- `src/client/App.svelte:257` (`modelsStore`), `:655-660` (`defaultModelLabel` derived), `:666-669` (`openModelsSettings`), `:1856` (chip null-gate), first-run render block ~`:2221-2245` (`shouldShowWizard` primary, tutorial behind).
+- `src/client/components/IntegrationWizardModal.svelte:873-880` — `{#if !BYO_MODELS_ENABLED}` coming-soon row (no `{:else}` yet).
+- `tests/e2e/settings-models.spec.ts:93-100` — `test.skip(!BYO_MODELS_ENABLED, …)` in `beforeEach`.
+
+## 3. Changes
+
+### 3.1 Store: re-add `loading` + `reload` (the skeleton's data source) — `useModels.svelte.ts`
+
+- Add `let _loading = $state(false)`; expose `readonly loading` on `ModelsState`. `loadFromServer` sets `_loading = true` before `fetchAndApply` and `false` in its `finally`. **Dark-safe:** `loadFromServer` early-returns while dark → `_loading` never leaves its `false` initial; nothing reads it while dark.
+- Add `reload(): Promise<void>` = clear `_loadInFlight`, then `loadFromServer()` (a user-triggered refetch after a 409 "changed elsewhere" notice). Flag-gated via `loadFromServer`.
+- These re-add the surface M2a deliberately deleted (dead-while-dark); now they have a consumer (the skeleton + a reload affordance).
+
+### 3.2 Close M2b-BLOCKING gap #1 — write-failure surfacing (`SettingsModelsTab.svelte`)
+
+Root problem (from the M2a silent-failure review): the store's write-through **rolls back and sets the reactive `_saveError` but does not throw**, so the tab's `try/catch` never fires for a rollback, and three mutators (`deleteModel`/`setDefault`/`toggleEnabled`) have no error path at all.
+
+Fix — a **declarative/imperative split**:
+- **Declarative (fire-and-forget mutators):** the tab-level error banner (testid `models-save-error`) binds `models.saveError` (the store's `$state`). Because it is reactive, a rollback from `setDefault`/`toggleEnabled`/`deleteModel` surfaces automatically with no "forget to check" risk.
+- **Imperative (branch-on-success):** `handleSave`'s add/edit path must not close the modal on a rolled-back write. `writeThrough` doesn't throw on rollback, so the `try/catch` alone misses it — instead key off the return: `addModel → Promise<string | null>` (null = didn't commit), `updateModel → Promise<boolean>`. `handleSave` closes the modal only on a truthy/non-null return; otherwise it leaves the modal open and the store banner shows the error. (See §3.3 for the store-side signature change.)
+- **Pre-write validation** (the `assertValidPatch` / `storeSecret` throws inside `handleSave` — the latter a real keychain-unavailable case) is caught by `handleSave`'s `catch` and shown **inside `ModelEditModal`** via a new `error` prop (small component change), not the tab banner. With per-provider gating (§3.4) the provider is always valid, so in practice this surfaces only keychain-unavailable.
+- **Sticky-error clear:** add `clearError()` to the store (sets `_saveError = null`); call it on modal-open and at mutation-start so a stale tab banner can't co-show with a fresh modal error.
+- After the 409-reconcile outcome (`saveError === "Model registry changed elsewhere; reloaded."`), the banner offers a `reload` affordance (§3.1) — the state was already adopted, so this is informational + optional refresh.
+
+### 3.3 Close M2b-BLOCKING gap #2 — FirstRun rolled-back default (`FirstRunModelPickerModal.svelte`)
+
+`addModel` returns an id even on a rolled-back write, so the current `setDefault(id)` + `onComplete()` run even when the add didn't land — pointing `defaultModelId` at a non-existent entry and finishing onboarding as if configured.
+
+Fix — surface the authoritative outcome the store already computes (it does `const outcome = await writeThrough(...)` at `useModels.svelte.ts:406` and currently discards it). Change the store signature: `addModel(...) → Promise<string | null>` (the id on `committed`, `null` on `reconciled`/`rolledback`). FirstRun then branches on the return, not a shared reactive flag:
+```
+const id = await models.addModel(...);
+if (id === null) return;              // didn't commit — modal stays open, models.saveError shows why
+const ok = await models.setDefault(id);
+onComplete();                          // completes even if setDefault rolled back (non-fatal; error surfaced)
+```
+This is robust without depending on the single-writer timing of a shared `_saveError` read, and distinguishes commit from non-commit precisely (a shared-flag read can't tell `reconciled` from `rolledback`). `setDefault` returns `Promise<boolean>` too so its rollback is *surfaced* (banner) but treated as non-fatal for onboarding (the model was added; a failed default is a minor follow-up). Surface `models.saveError` in the picker (testid `first-run-error` already exists). Two call sites touch the new `addModel` return (FirstRun uses it; `SettingsModelsTab.handleSave` gains the null-guard from §3.2); the M2a store tests asserting `typeof id === "string"` still pass on the commit path and the rollback tests assert on `models.models`, not the return.
+
+### 3.4 Per-provider gating (`SettingsModelsTab.svelte` + the add/edit modal)
+
+v1.0 ships **local providers only**; cloud BYO keys are v1.1 (`contract.ts` `LOCAL_MODEL_PROVIDERS` comment). Using `isLocalProvider` from the shared contract:
+- The provider picker in the add/edit modal renders local providers enabled and cloud providers **disabled** with a "coming in a future release" note.
+- If a registry somehow contains a cloud row (hand-edited `models.json`), render it read-only/disabled rather than hiding it (no silent disappearance).
+- **Dark-safe:** the tab only mounts when the flag is on.
+
+### 3.5 Mount `FirstRunModelPickerModal` in the first-run choreography (`App.svelte`)
+
+- Add a render site in the first-run block, gated `BYO_MODELS_ENABLED && <firstRunModelStep>` — while dark it never mounts (byte-identical). Wire `onComplete`/`handleSkip` to advance first-run state.
+- **Choreography:** the model picker is an **optional** post-wizard step (the integration wizard stays primary; the picker sequences after it and before the tutorial, mirroring the existing `shouldShowWizard` gating). It is skippable (`first-run-skip`). Final copy/ordering polish is M4-owned (`TODO(M4)`); M2b's job is a correct, store-wired mount that the flag flip lights up.
+- Reuse the existing first-run state machine rather than adding a parallel one; if a dedicated `showModelPicker` boolean is needed, derive it from the same server "first-run needed" signal the wizard/tutorial use.
+
+### 3.6 Wizard enabled `{:else}` branch (`IntegrationWizardModal.svelte:873-880`)
+
+Add the `{:else}` to the existing `{#if !BYO_MODELS_ENABLED}`: an **enabled** "Set up a local AI model" row that closes the wizard and opens the Models settings path (reuse `App.svelte`'s `openModelsSettings` via a wizard callback prop, or emit an event the App handles). While dark the `{#if}` (coming-soon) still renders; the `{:else}` only renders when lit.
+
+### 3.7 Remove the dead legacy-key UI (`SettingsModelsTab.svelte` + store)
+
+`hasLegacyKeys` can never be true off a `.strict()` server store (it never carries `_legacyApiKey`), so the `{#if models.hasLegacyKeys}` banner (`:117-147`) is dead. Remove, updating every carrier:
+- the banner + `runLegacyMigration` handler in `SettingsModelsTab.svelte`;
+- the `migrateLegacyKeys`/`hasLegacyKeys` members from `ModelsState` + the facade in `useModels.svelte.ts`;
+- `tests/client/use-models.test.ts:426-429` (asserts both removed members — would fail the client project);
+- the E2E block `tests/e2e/settings-models.spec.ts:294-345`;
+- `tests/design-system-impl/__snapshots__/testid-set.snap.txt` — drop `models-legacy-migration-banner` / `models-legacy-migrate-btn` / `models-legacy-migration-status` and regenerate;
+- the same three testids from the CLAUDE.md registry.
+
+(Legacy plaintext in localStorage is dropped by the reconcile's `projectEntry` — R2-D, already documented; there is no live migration path to preserve.)
+
+### 3.8 Flag-ON test coverage — NO production flag change (revised)
+
+The original "make `BYO_MODELS_ENABLED` env/define-overridable, mirroring the license gate" is **dropped** — it was a server/cli pattern that crashes the vite-built client bundle (see the round-1 corrections). `BYO_MODELS_ENABLED` stays a literal `const false`; nothing about the shipped dark behavior changes. Coverage for the new flag-ON paths comes from the test structure, not a runtime seam:
+- **Component logic (the bulk of M2b):** mount `SettingsModelsTab` and `FirstRunModelPickerModal` **directly** in vitest. Neither component has an internal `BYO_MODELS_ENABLED` gate — only their call-sites (`SettingsModal` filter, App first-run block) do — so a direct mount renders the full flag-ON UI. This covers per-provider gating, the reactive `saveError` bind, `clearError`, the loading skeleton, and the FirstRun add→setDefault→onComplete guard.
+- **Gate wiring (thin):** a targeted `vi.mock("shared/constants", …, { BYO_MODELS_ENABLED: true })` in a dedicated test file for the one-line gates worth asserting (SettingsModal includes the Models tab; App mounts the picker; the store's `loading` toggles in `loadFromServer`). Isolated to those files; production untouched.
+- **E2E:** `settings-models.spec.ts` stays `test.skip(!BYO_MODELS_ENABLED)` and **auto-enables at the M4 flip** — M4 inherits the full browser suite for free.
+
+No `tsup.config.ts` / `vite.config.ts` change; no boot warning needed; R2-F's "literal const, not overridable" dark guarantee is preserved intact.
+
+## 4. Testing
+
+- **Store:** `loading` toggles across a load (flag-on seam); `reload` refetches; dark → `loading` stays false + no fetch.
+- **SettingsModelsTab (flag-on seam):** a rolled-back `deleteModel`/`setDefault`/`toggleEnabled` surfaces `models.saveError` in the banner; a committed one clears it; per-provider gating (local enabled, cloud disabled + note); loading skeleton → list; legacy banner is gone.
+- **FirstRunModelPickerModal (flag-on seam):** a rolled-back add does NOT `setDefault`/`onComplete` (modal stays open, error shown); a committed add advances; skip advances with no write.
+- **App:** with the seam on, the chip renders `defaultModelLabel`; dark → null (unchanged).
+- **Wizard:** dark → coming-soon row; seam-on → enabled row opens Models settings.
+- **Dark regression:** every M2a dark test stays green; a test asserts `BYO_MODELS_ENABLED` (shipped default) is `false`.
+- Full suite green; typecheck + `svelte-check` + `check:tokens` clean.
+
+## 5. Decisions to settle in review
+
+1. **Force-on seam (§3.8)** — is the define+env mirror of the license gate the right mechanism, and is the boot-warning + shipped-default-false test sufficient to protect the dark guarantee? (Highest stakes.)
+2. **saveError unification (§3.2)** — binding the tab banner to the store's reactive `saveError` vs threading `WriteOutcome` out of every mutator. (Recommend the reactive bind — no API churn.)
+3. **First-run choreography (§3.5)** — model picker as an optional post-wizard step, skippable, final copy deferred to M4. Acceptable, or does M2b need the full ordering now?
+4. **Legacy-UI removal (§3.7)** — remove in M2b as one unit (dead code) vs keep the no-ops one more phase.
+5. **Cloud rows (§3.4)** — disabled "coming soon" vs omitted entirely at M4.
+
+## 6. Out of scope (M3 / M4)
+
+- **M3** — provider-keyed authorship (`author` beyond `"claude"`, authorship color, channel + Solo/Tandem for a non-Claude agent). M2b's mount is the seam M3 extends.
+- **M4** — flip `BYO_MODELS_ENABLED`; chat-target selection; typing presence; tutorial/user-guide copy; chip `loading`-gate; E2E vs a stub OpenAI-compatible server; final first-run choreography copy.
+- **Later cleanup** — drop `models`/`defaultModelId` from `TandemSettings` once the reconcile is field-proven.

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -29,6 +29,7 @@ import DocxConflictBanner from "./components/DocxConflictBanner.svelte";
 import EmptyState from "./components/EmptyState.svelte";
 import FidelityReportBanner from "./components/FidelityReportBanner.svelte";
 import FileOpenDialog from "./components/FileOpenDialog.svelte";
+import FirstRunModelPickerModal from "./components/FirstRunModelPickerModal.svelte";
 import HelpModal from "./components/HelpModal.svelte";
 import IntegrationWizardModal from "./components/IntegrationWizardModal.svelte";
 import LicenseBanner from "./components/LicenseBanner.svelte";
@@ -1839,6 +1840,30 @@ const tutorial = createTutorial(
   () => editor,
   () => activeTab?.fileName,
 );
+
+// First-run model picker (#1123 M2b) — an OPTIONAL, skippable step sequenced
+// AFTER the integration wizard and BEFORE the tutorial. Dismissed for the
+// session once completed or skipped. Declared after `createTutorial` so the
+// derived doesn't reference `tutorial` before it is assigned.
+//
+// Deliberate coupling (M4 revisits): the picker BORROWS the tutorial's first-run
+// signal (`tutorial.tutorialActive`) as its own existence condition rather than
+// introducing a parallel "first-run needed" state. That equivalence has two
+// known edges M4 owns: (a) a user who has no/disabled/already-completed tutorial
+// never sees the picker even though "connect a model on first run" is
+// conceptually orthogonal to the welcome tutorial; (b) `modelPickerDismissed` is
+// session-scoped, so a tutorial *replay* in a later session (with BYO on) would
+// re-summon the picker. Both are acceptable for the dark M2b mount — final
+// first-run choreography is M4 — but the coupling is a choice, not an accident.
+//
+// Dark guarantee: `BYO_MODELS_ENABLED` short-circuits the derived, so while dark
+// `shouldShowModelPicker` is always false — the picker never mounts and the
+// tutorial gate (`!shouldShowModelPicker`) reduces to today's exact
+// `tutorial.tutorialActive && !shouldShowWizard`.
+let modelPickerDismissed = $state(false);
+const shouldShowModelPicker = $derived(
+  BYO_MODELS_ENABLED && !shouldShowWizard && tutorial.tutorialActive && !modelPickerDismissed,
+);
 </script>
 
 <div
@@ -2173,7 +2198,18 @@ const tutorial = createTutorial(
     />
 
     {#if shouldShowWizard}
-      <IntegrationWizardModal open={true} onClose={closeIntegrationWizard} />
+      <IntegrationWizardModal
+        open={true}
+        onClose={closeIntegrationWizard}
+        onSetupModels={openModelsSettings}
+      />
+    {/if}
+
+    {#if shouldShowModelPicker}
+      <!-- Optional post-wizard model step (#1123 M2b, dark until M4). Skip or
+           complete dismisses it for the session, revealing the tutorial (gated
+           on `!shouldShowModelPicker` below). Never mounts while dark. -->
+      <FirstRunModelPickerModal onComplete={() => (modelPickerDismissed = true)} />
     {/if}
 
     {#if fileOpenDialogOpen}
@@ -2226,16 +2262,19 @@ const tutorial = createTutorial(
       <CoworkAdminDeclinedModal />
     {/if}
 
-    {#if tutorial.tutorialActive && !shouldShowWizard}
-      <!-- Sequenced behind the first-run wizard: the wizard scrim (z=100000)
-           buries the tutorial card (z=900) AND the welcome doc it points at, so
-           on a true first run the card waits until the wizard is dismissed
-           (shouldShowWizard→false). Mirrors the CoworkAdminDeclinedModal gate
-           above. Nothing harmful happens while buried: the user can't drive any
-           step forward under the scrim, and the only auto-advancing step (the
-           completion timer) is unreachable from the step-0 start state. (Claude
-           could in theory resolve a seed annotation via MCP and nudge step 0,
-           but that's real progress, not a lost step.) -->
+    {#if tutorial.tutorialActive && !shouldShowWizard && !shouldShowModelPicker}
+      <!-- Sequenced behind the first-run wizard AND the optional model picker
+           (#1123 M2b): the wizard scrim (z=100000) buries the tutorial card
+           (z=900) AND the welcome doc it points at, so on a true first run the
+           card waits until the wizard is dismissed (shouldShowWizard→false) and
+           the model picker is completed/skipped (shouldShowModelPicker→false).
+           While dark `shouldShowModelPicker` is always false, so this gate is
+           byte-identical to the pre-M2b wizard-only sequencing. Mirrors the
+           CoworkAdminDeclinedModal gate above. Nothing harmful happens while
+           buried: the user can't drive any step forward under the scrim, and the
+           only auto-advancing step (the completion timer) is unreachable from the
+           step-0 start state. (Claude could in theory resolve a seed annotation
+           via MCP and nudge step 0, but that's real progress, not a lost step.) -->
       <OnboardingTutorial
         currentStep={tutorial.currentStep}
         onNext={tutorial.nextStep}

--- a/src/client/components/FirstRunModelPickerModal.svelte
+++ b/src/client/components/FirstRunModelPickerModal.svelte
@@ -110,7 +110,16 @@ async function handleSave(e: SubmitEvent) {
       },
       isCloud ? apiKey.trim() : undefined,
     );
-    models.setDefault(id);
+    // `addModel` returns null when the write did NOT commit (rolled back /
+    // reconciled away) — do NOT finish onboarding with a phantom default, keep
+    // the modal open and surface the store's error.
+    if (id === null) {
+      saveError = models.saveError ?? "Failed to save model changes.";
+      return;
+    }
+    // A failed setDefault is non-fatal for onboarding (the model was added); its
+    // error surfaces via the store banner. Complete regardless.
+    await models.setDefault(id);
     onComplete();
   } catch (err) {
     saveError = err instanceof Error ? err.message : "Failed to save";

--- a/src/client/components/FirstRunModelPickerModal.svelte
+++ b/src/client/components/FirstRunModelPickerModal.svelte
@@ -3,11 +3,11 @@
  * First-run model picker: pick a provider, store the key in the OS
  * keychain, set as default. The caller's `onComplete` fires on save or skip.
  *
- * NOT CURRENTLY MOUNTED. This is intentional scaffolding for the BYO-models
- * first-run flow that lights up when `BYO_MODELS_ENABLED` flips at v1.0 — it
- * has no mount site today (the flag also strips the Settings → Models tab and
- * suppresses the titlebar model chip). Do not delete; wire it into the
- * first-run choreography when BYO ships.
+ * Mounted by `App.svelte` behind `shouldShowModelPicker` (an optional,
+ * skippable step after the integration wizard, before the tutorial), which is
+ * gated on `BYO_MODELS_ENABLED` — so this stays DARK (never mounts) until the
+ * flag flips at v1.0, when the Settings → Models tab and the titlebar model chip
+ * light up alongside it. Final first-run choreography copy is M4-owned.
  */
 import { untrack } from "svelte";
 import { isLocalProvider } from "../../shared/models/contract.js";
@@ -51,6 +51,10 @@ let apiKey = $state("");
 let endpoint = $state("http://localhost:11434");
 let saving = $state(false);
 let saveError = $state<string | null>(null);
+// Set once the add COMMITS. A retry after a setDefault failure re-attempts only
+// setDefault against this id — never a second addModel (which would duplicate the
+// entry). Lives for the modal's lifetime.
+let addedId = $state<string | null>(null);
 let dialogEl: HTMLElement | null = $state(null);
 let prevFocus: Element | null = null;
 
@@ -90,26 +94,40 @@ async function handleSave(e: SubmitEvent) {
   saving = true;
   saveError = null;
   try {
-    const id = await models.addModel(
-      {
-        provider,
-        displayName: displayName.trim() || currentProvider.label,
-        modelId: modelId.trim(),
-        enabled: true,
-        ...(isCloud ? {} : { endpoint: endpoint.trim() }),
-      },
-      isCloud ? apiKey.trim() : undefined,
-    );
-    // `addModel` returns null when the write did NOT commit (rolled back /
-    // reconciled away) — do NOT finish onboarding with a phantom default, keep
-    // the modal open and surface the store's error.
-    if (id === null) {
-      saveError = models.saveError ?? "Failed to save model changes.";
+    // Add the model once. If a prior attempt already committed the add but its
+    // setDefault failed, `addedId` is set — retry ONLY setDefault below.
+    if (addedId === null) {
+      const id = await models.addModel(
+        {
+          provider,
+          displayName: displayName.trim() || currentProvider.label,
+          modelId: modelId.trim(),
+          enabled: true,
+          ...(isCloud ? {} : { endpoint: endpoint.trim() }),
+        },
+        isCloud ? apiKey.trim() : undefined,
+      );
+      // `addModel` returns null when the write did NOT commit (rolled back /
+      // reconciled away) — do NOT finish onboarding with a phantom default, keep
+      // the modal open and surface the store's error.
+      if (id === null) {
+        saveError = models.saveError ?? "Failed to save model changes.";
+        return;
+      }
+      addedId = id;
+    }
+    // The model committed. Setting it as default can still roll back (a
+    // concurrent writer / blip). That is non-fatal — the model exists — but the
+    // store's list banner does NOT render in first-run, so surface it locally and
+    // let the user proceed via Skip rather than silently onboarding with no
+    // default. (Do NOT reuse `models.saveError` here: its "failed to save"
+    // wording would wrongly imply the model itself didn't save.)
+    const defaulted = await models.setDefault(addedId);
+    if (!defaulted) {
+      saveError =
+        "Model saved, but couldn't set it as the default. You can choose a default later in Settings.";
       return;
     }
-    // A failed setDefault is non-fatal for onboarding (the model was added); its
-    // error surfaces via the store banner. Complete regardless.
-    await models.setDefault(id);
     onComplete();
   } catch (err) {
     saveError = err instanceof Error ? err.message : "Failed to save";
@@ -119,6 +137,9 @@ async function handleSave(e: SubmitEvent) {
 }
 
 function handleSkip() {
+  // Drop any error left on the shared store singleton (e.g. a rolled-back add or
+  // setDefault) so it can't co-show on the next Settings → Models open.
+  models.clearError();
   onComplete();
 }
 </script>

--- a/src/client/components/FirstRunModelPickerModal.svelte
+++ b/src/client/components/FirstRunModelPickerModal.svelte
@@ -10,6 +10,7 @@
  * first-run choreography when BYO ships.
  */
 import { untrack } from "svelte";
+import { isLocalProvider } from "../../shared/models/contract.js";
 import { createModels } from "../hooks/useModels.svelte.js";
 import type { ModelProvider } from "../hooks/useTandemSettings.svelte.js";
 
@@ -27,34 +28,23 @@ interface ProviderOption {
   label: string;
   /** Default model ID surfaced as input placeholder + initial value. */
   defaultModelId: string;
-  /** Provider-specific copy: "API key" for cloud, "Endpoint URL" for local. */
-  isCloud: boolean;
 }
 
+// Local-first, matching ModelEditModal (§3.4): v1.0 ships local providers only,
+// so a fresh first run defaults to Ollama and cloud rows render disabled (their
+// BYO key support is v1.1). Cloud rows stay listed — disabled + "coming soon" —
+// so the roadmap is visible; M4 finalizes first-run copy. The cloud/local split
+// is derived from the contract's `isLocalProvider` (single source of truth,
+// same as ModelEditModal) rather than a hand-maintained per-option flag.
 const PROVIDER_OPTIONS: ProviderOption[] = [
-  {
-    value: "anthropic",
-    label: "Anthropic (Claude)",
-    defaultModelId: "claude-sonnet-4-6",
-    isCloud: true,
-  },
-  { value: "openai", label: "OpenAI", defaultModelId: "gpt-4o", isCloud: true },
-  { value: "gemini", label: "Gemini (Google)", defaultModelId: "gemini-2.0-flash", isCloud: true },
-  {
-    value: "local-ollama",
-    label: "Ollama (local)",
-    defaultModelId: "llama3.1:70b",
-    isCloud: false,
-  },
-  {
-    value: "local-llamacpp",
-    label: "llama.cpp (local)",
-    defaultModelId: "local-model",
-    isCloud: false,
-  },
+  { value: "local-ollama", label: "Ollama (local)", defaultModelId: "llama3.1:70b" },
+  { value: "local-llamacpp", label: "llama.cpp (local)", defaultModelId: "local-model" },
+  { value: "anthropic", label: "Anthropic (Claude)", defaultModelId: "claude-sonnet-4-6" },
+  { value: "openai", label: "OpenAI", defaultModelId: "gpt-4o" },
+  { value: "gemini", label: "Gemini (Google)", defaultModelId: "gemini-2.0-flash" },
 ];
 
-let provider = $state<ModelProvider>("anthropic");
+let provider = $state<ModelProvider>("local-ollama");
 let displayName = $state("");
 let modelId = $state(PROVIDER_OPTIONS[0].defaultModelId);
 let apiKey = $state("");
@@ -67,7 +57,7 @@ let prevFocus: Element | null = null;
 const currentProvider = $derived(
   PROVIDER_OPTIONS.find((p) => p.value === provider) ?? PROVIDER_OPTIONS[0],
 );
-const isCloud = $derived(currentProvider.isCloud);
+const isCloud = $derived(!isLocalProvider(provider));
 
 const canSave = $derived(
   modelId.trim().length > 0 && (isCloud ? apiKey.trim().length > 0 : endpoint.trim().length > 0),
@@ -173,16 +163,18 @@ function handleSkip() {
       <fieldset class="frm-providers" data-testid="first-run-providers">
         <legend class="frm-label">Provider</legend>
         {#each PROVIDER_OPTIONS as opt (opt.value)}
-          <label class="frm-provider-row">
+          {@const optDisabled = !isLocalProvider(opt.value)}
+          <label class="frm-provider-row" class:frm-provider-row-disabled={optDisabled}>
             <input
               type="radio"
               name="first-run-provider"
               value={opt.value}
               checked={provider === opt.value}
+              disabled={optDisabled}
               data-testid={`first-run-provider-${opt.value}`}
               onchange={() => selectProvider(opt.value)}
             />
-            <span>{opt.label}</span>
+            <span>{opt.label}{optDisabled ? " — coming soon" : ""}</span>
           </label>
         {/each}
       </fieldset>
@@ -356,6 +348,14 @@ function handleSkip() {
 }
 .frm-provider-row:hover {
   background: var(--tandem-surface-muted);
+}
+/* Cloud providers are disabled until v1.1 (their BYO key support ships then). */
+.frm-provider-row-disabled {
+  color: var(--tandem-fg-subtle);
+  cursor: not-allowed;
+}
+.frm-provider-row-disabled:hover {
+  background: none;
 }
 .frm-field {
   display: flex;

--- a/src/client/components/IntegrationWizardModal.svelte
+++ b/src/client/components/IntegrationWizardModal.svelte
@@ -53,9 +53,16 @@ import { computeDoneHeaderState } from "./integration-wizard-helpers.js";
 interface Props {
   open: boolean;
   onClose: () => void;
+  /**
+   * Close the wizard and open the Models settings path. Wired by App.svelte to
+   * `openModelsSettings`. Only invoked from the flag-ON "AI models" row, which
+   * never renders while `BYO_MODELS_ENABLED` is false — so this stays unused
+   * (and undefined-safe via `?.`) while dark.
+   */
+  onSetupModels?: () => void;
 }
 
-let { open, onClose }: Props = $props();
+let { open, onClose, onSetupModels }: Props = $props();
 
 // Absolute base URL because the Vite dev server does not proxy /api/* —
 // other client modules (yjsSync, useNotifications, fileUpload) follow the
@@ -876,6 +883,25 @@ const doneHeaderState = $derived(
                     <span class="iw-more-row-name">AI models</span>
                     <span class="iw-more-row-detail">Bring your own model — coming soon</span>
                   </div>
+                </div>
+              {:else}
+                <div class="iw-more-row">
+                  <div class="iw-more-row-text">
+                    <span class="iw-more-row-name">AI models</span>
+                    <span class="iw-more-row-detail">Set up a local AI model (Ollama or llama.cpp)</span>
+                  </div>
+                  <button
+                    type="button"
+                    class="iw-btn iw-btn-secondary iw-more-btn"
+                    onclick={() => {
+                      onClose();
+                      onSetupModels?.();
+                    }}
+                    aria-label="Set up a local AI model"
+                    data-testid="integration-wizard-models-setup"
+                  >
+                    Set up
+                  </button>
                 </div>
               {/if}
             </section>

--- a/src/client/components/ModelEditModal.svelte
+++ b/src/client/components/ModelEditModal.svelte
@@ -6,6 +6,12 @@ import CollapsibleSection from "./CollapsibleSection.svelte";
 interface Props {
   /** Existing entry when editing; `undefined` when adding. */
   entry?: ModelRegistryEntry;
+  /**
+   * Save-failure message to surface inside the dialog (pre-write keychain error,
+   * or a write that rolled back). Null when there's no error. Shown here rather
+   * than the tab banner because the modal is the active surface during a save.
+   */
+  error?: string | null;
   onCancel: () => void;
   /**
    * Save handler.
@@ -33,7 +39,7 @@ interface Props {
   }) => void;
 }
 
-const { entry, onCancel, onSave }: Props = $props();
+const { entry, error, onCancel, onSave }: Props = $props();
 
 const PROVIDER_OPTIONS: Array<{ value: ModelProvider; label: string }> = [
   { value: "anthropic", label: "Anthropic" },
@@ -240,6 +246,12 @@ function startReplacingKey() {
       </p>
     </CollapsibleSection>
 
+    {#if error}
+      <div role="alert" data-testid="model-edit-error" class="mem-error">
+        {error}
+      </div>
+    {/if}
+
     <div class="mem-actions">
       <button type="button" class="mem-btn mem-btn--ghost" onclick={onCancel}>
         Cancel
@@ -392,6 +404,15 @@ function startReplacingKey() {
     font-size: 11px;
     color: var(--tandem-fg-subtle);
     margin: 0;
+  }
+
+  .mem-error {
+    padding: var(--tandem-space-2) var(--tandem-space-3);
+    border: 1px solid var(--tandem-error-border);
+    border-radius: var(--tandem-r-2);
+    background: var(--tandem-error-bg);
+    color: var(--tandem-error-fg-strong);
+    font-size: 12px;
   }
 
   .mem-actions {

--- a/src/client/components/ModelEditModal.svelte
+++ b/src/client/components/ModelEditModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { untrack } from "svelte";
+import { isLocalProvider } from "../../shared/models/contract.js";
 import type { ModelProvider, ModelRegistryEntry } from "../hooks/useTandemSettings.svelte.js";
 import CollapsibleSection from "./CollapsibleSection.svelte";
 
@@ -41,13 +42,20 @@ interface Props {
 
 const { entry, error, onCancel, onSave }: Props = $props();
 
-const PROVIDER_OPTIONS: Array<{ value: ModelProvider; label: string }> = [
-  { value: "anthropic", label: "Anthropic" },
-  { value: "openai", label: "OpenAI" },
-  { value: "gemini", label: "Gemini" },
-  { value: "local-ollama", label: "Ollama (local)" },
-  { value: "local-llamacpp", label: "llama.cpp (local)" },
-];
+// v1.0 ships LOCAL providers only; cloud BYO keys are v1.1. `disabled` is
+// derived from the contract's `isLocalProvider` (single source of truth for the
+// local/cloud split) so the picker can never drift from what the collaborator
+// loop will actually resolve. Cloud options render disabled + a "coming soon"
+// note rather than being hidden, so the roadmap stays visible. Local-first order.
+const PROVIDER_OPTIONS: Array<{ value: ModelProvider; label: string; disabled: boolean }> = (
+  [
+    { value: "local-ollama", label: "Ollama (local)" },
+    { value: "local-llamacpp", label: "llama.cpp (local)" },
+    { value: "anthropic", label: "Anthropic" },
+    { value: "openai", label: "OpenAI" },
+    { value: "gemini", label: "Gemini" },
+  ] satisfies Array<{ value: ModelProvider; label: string }>
+).map((opt) => ({ ...opt, disabled: !isLocalProvider(opt.value) }));
 
 // Discrete $state per field, hydrated ONCE from the `entry` prop snapshot.
 // We deliberately don't track `entry` reactively: the parent unmounts and
@@ -57,7 +65,9 @@ const PROVIDER_OPTIONS: Array<{ value: ModelProvider; label: string }> = [
 // in the per-field $state below.
 const initialEntry = untrack(() => entry);
 
-let provider = $state<ModelProvider>(initialEntry?.provider ?? "anthropic");
+// Default a NEW entry to the first local provider (cloud is disabled below); an
+// existing entry keeps its stored provider even if it's a now-disabled cloud one.
+let provider = $state<ModelProvider>(initialEntry?.provider ?? "local-ollama");
 let displayName = $state(initialEntry?.displayName ?? "");
 let modelId = $state(initialEntry?.modelId ?? "");
 let endpoint = $state(initialEntry?.endpoint ?? "");
@@ -73,10 +83,10 @@ const hasExistingKey = initialEntry !== undefined && Boolean(initialEntry.apiKey
 let replacingKey = $state(initialEntry === undefined || !hasExistingKey);
 
 const isEditing = initialEntry !== undefined;
-const isCloud = $derived(
-  provider === "anthropic" || provider === "openai" || provider === "gemini",
-);
-const isLocal = $derived(provider.startsWith("local-"));
+// Derive both off the contract helper so the key/endpoint field gating and the
+// picker's disabled split can never disagree about what "cloud" means.
+const isLocal = $derived(isLocalProvider(provider));
+const isCloud = $derived(!isLocal);
 
 // Last 4 chars of the opaque `apiKeyRef` for the masked preview. The ref
 // is not sensitive (no read path exposes the plaintext from it), but it
@@ -160,9 +170,17 @@ function startReplacingKey() {
         bind:value={provider}
       >
         {#each PROVIDER_OPTIONS as opt (opt.value)}
-          <option value={opt.value}>{opt.label}</option>
+          <option value={opt.value} disabled={opt.disabled}>
+            {opt.label}{opt.disabled ? " — coming soon" : ""}
+          </option>
         {/each}
       </select>
+      {#if isCloud}
+        <span class="mem-provider-note" data-testid="model-edit-provider-note">
+          Cloud providers are coming in a future release. For now, choose a local
+          provider (Ollama or llama.cpp).
+        </span>
+      {/if}
     </label>
 
     <label class="mem-field">
@@ -404,6 +422,14 @@ function startReplacingKey() {
     font-size: 11px;
     color: var(--tandem-fg-subtle);
     margin: 0;
+  }
+
+  /* Shown when a now-disabled cloud provider is selected (an existing entry can
+     still carry one). Points the user back at the local providers. */
+  .mem-provider-note {
+    font-size: 11px;
+    color: var(--tandem-fg-subtle);
+    margin-top: 2px;
   }
 
   .mem-error {

--- a/src/client/components/ModelEditModal.svelte
+++ b/src/client/components/ModelEditModal.svelte
@@ -100,7 +100,11 @@ const canSave = $derived(
     modelId.trim().length > 0 &&
     // Cloud providers require either the existing key (not replacing) OR a
     // freshly-entered key (replacing). Local providers don't need a key.
-    (!isCloud || !replacingKey || apiKey.trim().length > 0),
+    (!isCloud || !replacingKey || apiKey.trim().length > 0) &&
+    // Local providers require an endpoint (the loop can't resolve an endpoint-less
+    // local model) — matches FirstRunModelPickerModal's canSave so the two pickers
+    // can't diverge on what a saveable local entry is.
+    (isCloud || endpoint.trim().length > 0),
 );
 
 function handleSubmit(e: SubmitEvent) {

--- a/src/client/components/settings-tabs/SettingsModelsTab.svelte
+++ b/src/client/components/settings-tabs/SettingsModelsTab.svelte
@@ -114,7 +114,40 @@ async function confirmDelete(id: string) {
 </script>
 
 <div style="display: flex; flex-direction: column; gap: var(--tandem-space-3);">
-  {#if models.models.length === 0}
+  {#if models.loading}
+    <!-- Load in flight: a skeleton, NOT the "No models configured" empty state —
+         `_models` is still [] mid-load and asserting "none" would be a lie. -->
+    <div
+      data-testid="models-loading"
+      aria-busy="true"
+      aria-label="Loading models"
+      style="display: flex; flex-direction: column; gap: 4px;"
+    >
+      {#each [0, 1, 2] as i (i)}
+        <div
+          style="height: 44px; border: 1px solid var(--tandem-border); border-radius: var(--tandem-r-3); background: var(--tandem-surface-muted);"
+        ></div>
+      {/each}
+    </div>
+  {:else if models.loadFailed}
+    <!-- Load threw: distinct from the empty state so we never claim "no models"
+         when the truth is the fetch failed. Offers a retry via `reload`. -->
+    <div
+      role="alert"
+      data-testid="models-load-error"
+      style="padding: var(--tandem-space-5) var(--tandem-space-3); text-align: center; border: 1px dashed var(--tandem-error-border); border-radius: var(--tandem-r-3); color: var(--tandem-fg-muted); font-size: 13px;"
+    >
+      <p style="margin: 0 0 var(--tandem-space-3) 0;">Couldn't load your models from the server.</p>
+      <button
+        type="button"
+        data-testid="models-reload-btn"
+        onclick={() => models.reload()}
+        style="padding: 6px var(--tandem-space-3); font-size: 13px; font-weight: 500; border: 1px solid var(--tandem-accent-border); border-radius: var(--tandem-r-2); cursor: pointer; background: var(--tandem-surface); color: var(--tandem-accent);"
+      >
+        Retry
+      </button>
+    </div>
+  {:else if models.models.length === 0}
     <div
       data-testid="models-empty-state"
       style="padding: var(--tandem-space-5) var(--tandem-space-3); text-align: center; border: 1px dashed var(--tandem-border-strong); border-radius: var(--tandem-r-3); color: var(--tandem-fg-muted); font-size: 13px;"
@@ -243,9 +276,11 @@ async function confirmDelete(id: string) {
 </div>
 
 <!-- List-level banner: the store's reactive `saveError`, set by a rolled-back
-     fire-and-forget mutator (default/toggle/delete). Save-flow errors show inside
-     the modal (see `modalError`), which sits above this. -->
-{#if models.saveError}
+     fire-and-forget mutator (default/toggle/delete). Suppressed while the editor
+     is open (the modal owns error display via `modalError` — else the same
+     message co-shows here behind the scrim) and while `loadFailed` (that state
+     renders its own message + retry above). -->
+{#if models.saveError && !editorOpen && !models.loadFailed}
   <div
     role="alert"
     data-testid="models-save-error"

--- a/src/client/components/settings-tabs/SettingsModelsTab.svelte
+++ b/src/client/components/settings-tabs/SettingsModelsTab.svelte
@@ -49,19 +49,24 @@ const grouped = $derived.by(() => {
 let editingEntry = $state<ModelRegistryEntry | undefined>(undefined);
 let editorOpen = $state(false);
 let pendingDeleteId = $state<string | null>(null);
-let saveError = $state<string | null>(null);
-let migratingLegacy = $state(false);
-let migrationStatus = $state<string | null>(null);
+// Modal-scoped error: a save failure (pre-write keychain throw OR a write that
+// rolled back) shown INSIDE the open ModelEditModal — the active surface during
+// a save. The list-level banner below binds the store's reactive `saveError`,
+// which surfaces failures from the fire-and-forget mutators (default/toggle/
+// delete) that have no modal.
+let modalError = $state<string | null>(null);
 
 function openAdd() {
   editingEntry = undefined;
-  saveError = null;
+  modalError = null;
+  models.clearError(); // drop a stale list banner so it can't co-show with a modal error
   editorOpen = true;
 }
 
 function openEdit(entry: ModelRegistryEntry) {
   editingEntry = entry;
-  saveError = null;
+  modalError = null;
+  models.clearError();
   editorOpen = true;
 }
 
@@ -74,78 +79,41 @@ async function handleSave(data: {
   enabled: boolean;
 }) {
   const { plaintextApiKey, ...patch } = data;
+  modalError = null;
   try {
-    if (editingEntry) {
-      await models.updateModel(editingEntry.id, patch, plaintextApiKey);
-    } else {
-      await models.addModel(patch, plaintextApiKey);
+    // The store rolls back WITHOUT throwing, so branch on the return, not the
+    // try/catch: a non-commit keeps the modal open with the error visible.
+    const committed = editingEntry
+      ? await models.updateModel(editingEntry.id, patch, plaintextApiKey)
+      : (await models.addModel(patch, plaintextApiKey)) !== null;
+    if (!committed) {
+      modalError = models.saveError ?? "Failed to save model changes.";
+      return;
     }
     editorOpen = false;
     editingEntry = undefined;
-    saveError = null;
   } catch (err) {
-    // Hygiene: never echo the plaintext or detailed server output. The
-    // error message in `useModels` is already shaped (`KEYCHAIN_UNAVAILABLE`
-    // / `HTTP_xxx`) — surface it as-is for diagnostic value without
-    // leaking secret-bearing payload.
-    saveError = err instanceof Error ? err.message : "Failed to save";
+    // Pre-write throw (keychain unavailable / store failed). Hygiene: never echo
+    // the plaintext or raw server output — `useModels` already shapes the message
+    // (`KEYCHAIN_UNAVAILABLE` / `STORE_FAILED`); surface it as-is.
+    modalError = err instanceof Error ? err.message : "Failed to save";
   }
+}
+
+function closeModal() {
+  editorOpen = false;
+  editingEntry = undefined;
+  modalError = null;
+  models.clearError();
 }
 
 async function confirmDelete(id: string) {
   await models.deleteModel(id);
   pendingDeleteId = null;
 }
-
-async function runLegacyMigration() {
-  migratingLegacy = true;
-  migrationStatus = null;
-  try {
-    const result = await models.migrateLegacyKeys();
-    if (result.failed > 0) {
-      migrationStatus = `Migrated ${result.migrated}; ${result.failed} failed. Retry?`;
-    } else if (result.migrated > 0) {
-      migrationStatus = `Migrated ${result.migrated} ${result.migrated === 1 ? "key" : "keys"} to OS keychain.`;
-    }
-  } finally {
-    migratingLegacy = false;
-  }
-}
 </script>
 
 <div style="display: flex; flex-direction: column; gap: var(--tandem-space-3);">
-  <!-- Legacy-key migration banner (#659). Appears only when a pre-v7 blob
-       carried plaintext `apiKey` values; one click migrates each to the
-       OS keychain and rewrites the entry with an opaque `apiKeyRef`.
-       Banner disappears as soon as the legacy fields are gone. -->
-  {#if models.hasLegacyKeys}
-    <div
-      data-testid="models-legacy-migration-banner"
-      role="note"
-      style="padding: var(--tandem-space-2) var(--tandem-space-3); border: 1px solid var(--tandem-warning-border); border-radius: var(--tandem-r-3); background: var(--tandem-warning-bg); color: var(--tandem-warning-fg-strong); font-size: 12px; line-height: 1.5; display: flex; flex-direction: column; gap: var(--tandem-space-2);"
-    >
-      <div>
-        <strong style="font-weight: 600;">Move API keys to OS keychain.</strong>
-        Existing keys were stored unencrypted in browser storage. Move them now to
-        encrypt them with your operating system's credential store.
-      </div>
-      <div style="display: flex; align-items: center; gap: var(--tandem-space-2);">
-        <button
-          type="button"
-          data-testid="models-legacy-migrate-btn"
-          disabled={readOnly || migratingLegacy}
-          onclick={runLegacyMigration}
-          style={`padding: 4px var(--tandem-space-3); font-size: 12px; font-weight: 500; border: 1px solid var(--tandem-warning-border); border-radius: var(--tandem-r-2); background: var(--tandem-surface); color: var(--tandem-warning-fg-strong); cursor: ${readOnly ? "not-allowed" : migratingLegacy ? "wait" : "pointer"}; opacity: ${readOnly ? 0.5 : 1};`}
-        >
-          {migratingLegacy ? "Migrating…" : "Migrate keys"}
-        </button>
-        {#if migrationStatus}
-          <span data-testid="models-legacy-migration-status">{migrationStatus}</span>
-        {/if}
-      </div>
-    </div>
-  {/if}
-
   {#if models.models.length === 0}
     <div
       data-testid="models-empty-state"
@@ -274,24 +242,24 @@ async function runLegacyMigration() {
   {/if}
 </div>
 
-{#if saveError}
+<!-- List-level banner: the store's reactive `saveError`, set by a rolled-back
+     fire-and-forget mutator (default/toggle/delete). Save-flow errors show inside
+     the modal (see `modalError`), which sits above this. -->
+{#if models.saveError}
   <div
     role="alert"
     data-testid="models-save-error"
     style="padding: var(--tandem-space-2) var(--tandem-space-3); border: 1px solid var(--tandem-error-border); border-radius: var(--tandem-r-3); background: var(--tandem-error-bg); color: var(--tandem-error-fg-strong); font-size: 12px;"
   >
-    {saveError}
+    {models.saveError}
   </div>
 {/if}
 
 {#if editorOpen}
   <ModelEditModal
     entry={editingEntry}
-    onCancel={() => {
-      editorOpen = false;
-      editingEntry = undefined;
-      saveError = null;
-    }}
+    error={modalError}
+    onCancel={closeModal}
     onSave={handleSave}
   />
 {/if}

--- a/src/client/hooks/useModels.svelte.ts
+++ b/src/client/hooks/useModels.svelte.ts
@@ -56,8 +56,15 @@ export interface ModelsState {
   readonly defaultModelId: string | null;
   /** Last write/load failure message, or null. Cleared on the next success or `clearError()`. */
   readonly saveError: string | null;
-  /** True while a server load is in flight (drives the Settings tab skeleton). */
+  /** True while a server load is in flight (drives the Settings tab loading state). */
   readonly loading: boolean;
+  /**
+   * True when the last server load threw (network / non-OK / bad JSON). Lets the
+   * Models tab render a "couldn't load — retry" state instead of asserting "No
+   * models configured" over an empty `_models` that is empty only because the
+   * load failed. Cleared on the next successful load.
+   */
+  readonly loadFailed: boolean;
   /**
    * Add a model. Returns the generated id when the write **committed**, or `null`
    * when it did not (rolled back / reconciled away) — so an imperative caller
@@ -92,6 +99,11 @@ let _defaultModelId = $state<string | null>(null);
 let _etag: string | null = null; // last-seen server ETag (not reactive — no UI reads it)
 let _saveError = $state<string | null>(null);
 let _loading = $state(false);
+// Distinct from `_saveError`: a load failure must not be confused with a
+// write/rollback error. The Models tab keys its "couldn't load" state on this so
+// its empty-state never asserts "No models configured" when the truth is the
+// fetch failed. Single writer: `loadFromServer` (true on catch, false on success).
+let _loadFailed = $state(false);
 let _loadInFlight: Promise<void> | null = null;
 
 // Reconcile gate (R2-B): every mutator awaits this before its POST, so a CRUD
@@ -321,10 +333,15 @@ export function loadFromServer(): Promise<void> {
     try {
       await fetchAndApply();
       _saveError = null;
-    } catch {
-      // Surface a load error; `_loadInFlight` clears in `finally` so a later
-      // load retries.
+      _loadFailed = false;
+    } catch (err) {
+      // Log the actual cause (network drop / non-OK status / bad JSON) — the
+      // user-facing string below collapses them all, and the sibling
+      // `writeThrough` path logs the same way. `_loadInFlight` clears in
+      // `finally` so a later load (or `reload()`) retries.
+      console.warn("[models] load failed", err);
       _saveError = "Failed to load models from the server.";
+      _loadFailed = true;
     } finally {
       _loading = false;
       _loadInFlight = null;
@@ -408,6 +425,9 @@ export function createModels(): ModelsState {
     get loading() {
       return _loading;
     },
+    get loadFailed() {
+      return _loadFailed;
+    },
     async addModel(entry, plaintextApiKey) {
       assertValidPatch(entry);
       const id = generateModelId();
@@ -463,6 +483,12 @@ export function createModels(): ModelsState {
           await keychain.delete(newRef);
         }
       }
+      // Report commit, not `landed`: in the rare `committed && !landed` window (a
+      // concurrent delete of `id` adopted on the stale-reload path), the write
+      // itself succeeded, so the caller closes the editor as "saved" — and the
+      // reactive list, now missing the concurrently-deleted row, already tells the
+      // honest story. Returning `false` here would reopen the editor with a
+      // misleading "save failed" when nothing the user did failed.
       return outcome === "committed";
     },
     async deleteModel(id) {
@@ -506,6 +532,7 @@ export function _resetModelsStoreForTests(): void {
   _etag = null;
   _saveError = null;
   _loading = false;
+  _loadFailed = false;
   _loadInFlight = null;
   _reconcileSettled = new Promise<void>((resolve) => {
     _resolveReconcile = resolve;

--- a/src/client/hooks/useModels.svelte.ts
+++ b/src/client/hooks/useModels.svelte.ts
@@ -54,31 +54,35 @@ import {
 export interface ModelsState {
   readonly models: readonly ModelRegistryEntry[];
   readonly defaultModelId: string | null;
-  /** Last write/load failure message, or null. Cleared on the next success. */
+  /** Last write/load failure message, or null. Cleared on the next success or `clearError()`. */
   readonly saveError: string | null;
+  /** True while a server load is in flight (drives the Settings tab skeleton). */
+  readonly loading: boolean;
+  /**
+   * Add a model. Returns the generated id when the write **committed**, or `null`
+   * when it did not (rolled back / reconciled away) — so an imperative caller
+   * (first-run picker, Settings save) can branch on success instead of reading the
+   * shared reactive `saveError` after the await (§3.3). The declarative tab banner
+   * still surfaces `saveError` for fire-and-forget mutators.
+   */
   addModel: (
     entry: Omit<ModelRegistryEntry, "id" | "apiKeyRef" | "_legacyApiKey">,
     plaintextApiKey?: string,
-  ) => Promise<string>;
+  ) => Promise<string | null>;
+  /** Update a model. Returns `true` when the write committed, `false` otherwise. */
   updateModel: (
     id: string,
     patch: Partial<Omit<ModelRegistryEntry, "id" | "apiKeyRef" | "_legacyApiKey">>,
     plaintextApiKey?: string,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   deleteModel: (id: string) => Promise<void>;
   toggleEnabled: (id: string) => Promise<void>;
-  setDefault: (id: string | null) => Promise<void>;
-  /**
-   * Legacy-key migration is vestigial now that the store loads from the server:
-   * the server schema is `.strict()` and never carries `_legacyApiKey`, so the
-   * store's entries never do either. Kept as a no-op so `SettingsModelsTab`'s
-   * legacy-migration banner still compiles; the banner + these methods are
-   * removed together in M2b when the Models UI is unhidden. (Legacy plaintext
-   * keys in localStorage are dropped by the reconcile's `projectEntry` — a
-   * pre-existing silent drop while the Models UI is dark; R2-D.)
-   */
-  migrateLegacyKeys: () => Promise<{ migrated: number; failed: number }>;
-  readonly hasLegacyKeys: boolean;
+  /** Set (or clear) the default model. Returns `true` when the write committed. */
+  setDefault: (id: string | null) => Promise<boolean>;
+  /** Re-fetch the registry from the server (user-triggered after a 409 notice). Flag-gated. */
+  reload: () => Promise<void>;
+  /** Clear a sticky `saveError` without a write (called on modal-open / mutation-start). */
+  clearError: () => void;
 }
 
 // --- Module-level singleton state -------------------------------------------
@@ -87,6 +91,7 @@ let _models = $state<ModelRegistryEntry[]>([]);
 let _defaultModelId = $state<string | null>(null);
 let _etag: string | null = null; // last-seen server ETag (not reactive — no UI reads it)
 let _saveError = $state<string | null>(null);
+let _loading = $state(false);
 let _loadInFlight: Promise<void> | null = null;
 
 // Reconcile gate (R2-B): every mutator awaits this before its POST, so a CRUD
@@ -311,6 +316,7 @@ async function fetchAndApply(): Promise<void> {
 export function loadFromServer(): Promise<void> {
   if (!BYO_MODELS_ENABLED) return Promise.resolve();
   if (_loadInFlight) return _loadInFlight;
+  _loading = true;
   _loadInFlight = (async () => {
     try {
       await fetchAndApply();
@@ -320,10 +326,21 @@ export function loadFromServer(): Promise<void> {
       // load retries.
       _saveError = "Failed to load models from the server.";
     } finally {
+      _loading = false;
       _loadInFlight = null;
     }
   })();
   return _loadInFlight;
+}
+
+/**
+ * User-triggered re-fetch (e.g. after a "changed elsewhere — reloaded" notice).
+ * Clears the in-flight dedup so it always hits the server. Flag-gated via
+ * `loadFromServer`, so it is a no-op while dark.
+ */
+export function reload(): Promise<void> {
+  _loadInFlight = null;
+  return loadFromServer();
 }
 
 /**
@@ -388,9 +405,8 @@ export function createModels(): ModelsState {
     get saveError() {
       return _saveError;
     },
-    get hasLegacyKeys() {
-      // Server-backed entries never carry `_legacyApiKey`; always false. See interface doc.
-      return _models.some((m) => typeof m._legacyApiKey === "string");
+    get loading() {
+      return _loading;
     },
     async addModel(entry, plaintextApiKey) {
       assertValidPatch(entry);
@@ -411,12 +427,14 @@ export function createModels(): ModelsState {
       // delete (never throws). Keying on the outcome (not reconstructed side
       // effects) also covers the reconcile-adopt orphan the old guard missed.
       if (apiKeyRef && outcome !== "committed") await keychain.delete(apiKeyRef);
-      return id;
+      // Return the id ONLY on commit so a branch-on-success caller (first-run
+      // picker, Settings save) never proceeds with an id whose entry didn't land.
+      return outcome === "committed" ? id : null;
     },
     async updateModel(id, patch, plaintextApiKey) {
       assertValidPatch(patch);
       const existing = _models.find((m) => m.id === id);
-      if (!existing) return;
+      if (!existing) return false;
       let newRef: string | undefined;
       if (plaintextApiKey !== undefined && plaintextApiKey.length > 0) {
         // Store the NEW secret but do NOT delete the old ref yet — a failed write
@@ -445,6 +463,7 @@ export function createModels(): ModelsState {
           await keychain.delete(newRef);
         }
       }
+      return outcome === "committed";
     },
     async deleteModel(id) {
       const ref = _models.find((m) => m.id === id)?.apiKeyRef;
@@ -465,14 +484,14 @@ export function createModels(): ModelsState {
       });
     },
     async setDefault(id) {
-      await writeThrough(() => {
+      const outcome = await writeThrough(() => {
         _defaultModelId = id;
       });
+      return outcome === "committed";
     },
-    async migrateLegacyKeys() {
-      // No-op: the store loads from the `.strict()` server, which never carries
-      // `_legacyApiKey`. Kept for interface stability (SettingsModelsTab wiring).
-      return { migrated: 0, failed: 0 };
+    reload,
+    clearError() {
+      _saveError = null;
     },
   };
 }
@@ -486,6 +505,7 @@ export function _resetModelsStoreForTests(): void {
   _defaultModelId = null;
   _etag = null;
   _saveError = null;
+  _loading = false;
   _loadInFlight = null;
   _reconcileSettled = new Promise<void>((resolve) => {
     _resolveReconcile = resolve;

--- a/tests/client/actions/reconcile-models-registry.test.ts
+++ b/tests/client/actions/reconcile-models-registry.test.ts
@@ -106,8 +106,9 @@ describe("reconcileModelsToServerOnce", () => {
     seedSettings();
     vi.stubGlobal("fetch", stubFetch());
     await initializeStore();
-    // If the gate were still pending, this write would never resolve.
-    await expect(createModels().setDefault(null)).resolves.toBeUndefined();
+    // If the gate were still pending, this write would never resolve. It commits
+    // (server 200) → `true`.
+    await expect(createModels().setDefault(null)).resolves.toBe(true);
   });
 
   it("preserves apiKeyRef and params in the projection", async () => {
@@ -145,7 +146,7 @@ describe("reconcileModelsToServerOnce", () => {
     _resetModelsReconcileGuardForTests();
     _resetModelsStoreForTests();
     await initializeStore();
-    await expect(createModels().setDefault(null)).resolves.toBeUndefined();
+    await expect(createModels().setDefault(null)).resolves.toBe(true);
   });
 
   it("does NOT fetch when there are no models", async () => {
@@ -185,8 +186,9 @@ describe("reconcileModelsToServerOnce", () => {
     // The mutator awaits the gate, then its own POST fails (500) and rolls back —
     // but it RESOLVES rather than hanging forever on a never-settled gate. A
     // permanent-pending gate would deadlock every CRUD op at M4.
+    // Its POST 500s → rollback → `false`, but it RESOLVES rather than hanging.
     const mutate = createModels().setDefault(null);
-    await expect(mutate).resolves.toBeUndefined();
+    await expect(mutate).resolves.toBe(false);
   });
 
   it("adopts the server and sets the flag on a 409 (a concurrent writer won)", async () => {

--- a/tests/client/first-run-model-picker.test.ts
+++ b/tests/client/first-run-model-picker.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment happy-dom
+
+/**
+ * First-run model picker (#1123 M2b §3.3 + §3.5).
+ *
+ * Two contracts, both exercised by a direct mount (the component has no internal
+ * `BYO_MODELS_ENABLED` gate — App's first-run block does):
+ *
+ *   §3.4 consistency — a fresh first run defaults to a LOCAL provider (Ollama),
+ *   not a cloud one whose BYO key support is v1.1.
+ *
+ *   §3.3 rolled-back-add guard — `addModel` returns an id only when the write
+ *   committed; on a rolled-back/reconciled write it returns null. The picker must
+ *   NOT `setDefault`/`onComplete` on null (which would finish onboarding pointing
+ *   at a phantom default) — it keeps the modal open and surfaces `saveError`.
+ *
+ * `createModels` is mocked so `addModel`'s outcome is controllable without a
+ * server round-trip.
+ */
+
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const addModel = vi.fn<(...args: unknown[]) => Promise<string | null>>();
+const setDefault = vi.fn<(...args: unknown[]) => Promise<boolean>>();
+let storeSaveError: string | null = null;
+
+vi.mock("../../src/client/hooks/useModels.svelte", () => ({
+  createModels: () => ({
+    addModel,
+    setDefault,
+    get saveError() {
+      return storeSaveError;
+    },
+  }),
+}));
+
+const { default: FirstRunModelPickerModal } = await import(
+  "../../src/client/components/FirstRunModelPickerModal.svelte"
+);
+
+beforeEach(() => {
+  addModel.mockReset();
+  setDefault.mockReset();
+  setDefault.mockResolvedValue(true);
+  storeSaveError = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FirstRunModelPickerModal — local-first default (§3.4)", () => {
+  it("defaults to Ollama and shows the endpoint field, not an API key", () => {
+    const { getByTestId, queryByTestId } = render(FirstRunModelPickerModal, {
+      props: { onComplete: vi.fn() },
+    });
+    const ollama = getByTestId("first-run-provider-local-ollama") as HTMLInputElement;
+    expect(ollama.checked).toBe(true);
+    expect(queryByTestId("first-run-endpoint")).not.toBeNull();
+    expect(queryByTestId("first-run-apikey")).toBeNull();
+  });
+
+  it("lists local providers before cloud providers", () => {
+    const { getByTestId } = render(FirstRunModelPickerModal, {
+      props: { onComplete: vi.fn() },
+    });
+    const fieldset = getByTestId("first-run-providers");
+    const values = Array.from(fieldset.querySelectorAll("input[type=radio]")).map(
+      (el) => (el as HTMLInputElement).value,
+    );
+    expect(values.slice(0, 2)).toEqual(["local-ollama", "local-llamacpp"]);
+  });
+
+  it("disables cloud radios and enables local ones (same local-only gate as the edit modal)", () => {
+    const { getByTestId } = render(FirstRunModelPickerModal, {
+      props: { onComplete: vi.fn() },
+    });
+    const radio = (v: string) => getByTestId(`first-run-provider-${v}`) as HTMLInputElement;
+    for (const v of ["local-ollama", "local-llamacpp"]) expect(radio(v).disabled).toBe(false);
+    for (const v of ["anthropic", "openai", "gemini"]) expect(radio(v).disabled).toBe(true);
+  });
+});
+
+describe("FirstRunModelPickerModal — rolled-back-add guard (§3.3)", () => {
+  it("does NOT setDefault/onComplete when addModel rolls back (returns null)", async () => {
+    addModel.mockResolvedValue(null);
+    storeSaveError = "Model registry changed elsewhere; reloaded.";
+    const onComplete = vi.fn();
+    const { getByTestId, findByTestId } = render(FirstRunModelPickerModal, {
+      props: { onComplete },
+    });
+
+    // Ollama default → modelId + endpoint prefilled → canSave true.
+    await fireEvent.click(getByTestId("first-run-save"));
+
+    expect(addModel).toHaveBeenCalledTimes(1);
+    expect(setDefault).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+    // The store's error is surfaced and the modal stays mounted.
+    const err = await findByTestId("first-run-error");
+    expect(err.textContent).toMatch(/changed elsewhere/i);
+    expect(getByTestId("first-run-model-modal")).toBeTruthy();
+  });
+
+  it("setDefault + onComplete run once addModel commits (returns an id)", async () => {
+    addModel.mockResolvedValue("new-id");
+    const onComplete = vi.fn();
+    const { getByTestId } = render(FirstRunModelPickerModal, {
+      props: { onComplete },
+    });
+
+    await fireEvent.click(getByTestId("first-run-save"));
+
+    expect(addModel).toHaveBeenCalledTimes(1);
+    expect(setDefault).toHaveBeenCalledWith("new-id");
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("completes onboarding even when setDefault rolls back (non-fatal)", async () => {
+    addModel.mockResolvedValue("new-id");
+    setDefault.mockResolvedValue(false);
+    const onComplete = vi.fn();
+    const { getByTestId } = render(FirstRunModelPickerModal, {
+      props: { onComplete },
+    });
+
+    await fireEvent.click(getByTestId("first-run-save"));
+
+    expect(setDefault).toHaveBeenCalledWith("new-id");
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("skip completes onboarding with no write", async () => {
+    const onComplete = vi.fn();
+    const { getByTestId } = render(FirstRunModelPickerModal, {
+      props: { onComplete },
+    });
+
+    await fireEvent.click(getByTestId("first-run-skip-secondary"));
+
+    expect(addModel).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/client/first-run-model-picker.test.ts
+++ b/tests/client/first-run-model-picker.test.ts
@@ -23,12 +23,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const addModel = vi.fn<(...args: unknown[]) => Promise<string | null>>();
 const setDefault = vi.fn<(...args: unknown[]) => Promise<boolean>>();
+const clearError = vi.fn();
 let storeSaveError: string | null = null;
 
 vi.mock("../../src/client/hooks/useModels.svelte", () => ({
   createModels: () => ({
     addModel,
     setDefault,
+    clearError,
     get saveError() {
       return storeSaveError;
     },
@@ -42,6 +44,7 @@ const { default: FirstRunModelPickerModal } = await import(
 beforeEach(() => {
   addModel.mockReset();
   setDefault.mockReset();
+  clearError.mockReset();
   setDefault.mockResolvedValue(true);
   storeSaveError = null;
 });
@@ -117,21 +120,7 @@ describe("FirstRunModelPickerModal — rolled-back-add guard (§3.3)", () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  it("completes onboarding even when setDefault rolls back (non-fatal)", async () => {
-    addModel.mockResolvedValue("new-id");
-    setDefault.mockResolvedValue(false);
-    const onComplete = vi.fn();
-    const { getByTestId } = render(FirstRunModelPickerModal, {
-      props: { onComplete },
-    });
-
-    await fireEvent.click(getByTestId("first-run-save"));
-
-    expect(setDefault).toHaveBeenCalledWith("new-id");
-    expect(onComplete).toHaveBeenCalledTimes(1);
-  });
-
-  it("skip completes onboarding with no write", async () => {
+  it("skip completes onboarding with no write and clears any store error", async () => {
     const onComplete = vi.fn();
     const { getByTestId } = render(FirstRunModelPickerModal, {
       props: { onComplete },
@@ -140,6 +129,41 @@ describe("FirstRunModelPickerModal — rolled-back-add guard (§3.3)", () => {
     await fireEvent.click(getByTestId("first-run-skip-secondary"));
 
     expect(addModel).not.toHaveBeenCalled();
+    expect(clearError).toHaveBeenCalledTimes(1); // don't leak a store error onto the singleton
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("a rolled-back setDefault keeps the modal open with a local error and does NOT complete", async () => {
+    addModel.mockResolvedValue("new-id");
+    setDefault.mockResolvedValue(false);
+    const onComplete = vi.fn();
+    const { getByTestId, findByTestId } = render(FirstRunModelPickerModal, {
+      props: { onComplete },
+    });
+
+    await fireEvent.click(getByTestId("first-run-save"));
+
+    expect(setDefault).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
+    const err = await findByTestId("first-run-error");
+    expect(err.textContent).toMatch(/couldn't set it as the default/i);
+    expect(getByTestId("first-run-model-modal")).toBeTruthy();
+  });
+
+  it("retrying after a setDefault failure re-attempts ONLY setDefault (no duplicate add)", async () => {
+    addModel.mockResolvedValue("new-id");
+    setDefault.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const onComplete = vi.fn();
+    const { getByTestId } = render(FirstRunModelPickerModal, {
+      props: { onComplete },
+    });
+
+    await fireEvent.click(getByTestId("first-run-save")); // add commits, setDefault fails
+    await fireEvent.click(getByTestId("first-run-save")); // retry
+
+    expect(addModel).toHaveBeenCalledTimes(1); // NOT re-added
+    expect(setDefault).toHaveBeenCalledTimes(2);
+    expect(setDefault).toHaveBeenLastCalledWith("new-id");
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/client/integration-wizard-cowork.test.ts
+++ b/tests/client/integration-wizard-cowork.test.ts
@@ -138,6 +138,18 @@ describe("integration wizard — Cowork sub-view gating", () => {
     expect(toggleIntegration).not.toHaveBeenCalled();
   });
 
+  it("shows the AI-models 'coming soon' line and NO Set-up button while dark", async () => {
+    // This file runs with the shipped `BYO_MODELS_ENABLED=false`, so the `{#if}`
+    // (coming-soon) branch renders, not the `{:else}` enabled row (§3.6).
+    const { container } = render(IntegrationWizardModal, {
+      props: { open: true, onClose: vi.fn() },
+    });
+    await tick();
+
+    expect(q(container, "integration-wizard-more")?.textContent).toMatch(/coming soon/i);
+    expect(q(container, "integration-wizard-models-setup")).toBeNull();
+  });
+
   it("cowork-enable-confirm-btn is the sole trigger of enable", async () => {
     const { container } = render(IntegrationWizardModal, {
       props: { open: true, onClose: vi.fn() },

--- a/tests/client/integration-wizard-models.test.ts
+++ b/tests/client/integration-wizard-models.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+
+/**
+ * "AI models" row in the unified onboarding wizard's "More integrations"
+ * section (#1123 M2b §3.6), FLAG-ON path.
+ *
+ * While dark the row renders a disabled "coming soon" line (asserted in
+ * `integration-wizard-cowork.test.ts`, which runs with the shipped
+ * `BYO_MODELS_ENABLED=false`). This file mocks the constant ON to exercise the
+ * `{:else}` enabled row: a "Set up" button that closes the wizard and invokes
+ * the `onSetupModels` callback (App wires it to `openModelsSettings`). This is
+ * the thin gate-wiring seam from the plan §3.8 — the constant stays a literal
+ * `false` in production; only this test flips it.
+ *
+ * The hook mocks mirror `integration-wizard-cowork.test.ts` so the MAIN view +
+ * "More integrations" section render with no real /api round-trip.
+ */
+
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/shared/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/shared/constants")>()),
+  BYO_MODELS_ENABLED: true,
+}));
+
+// isTauriRuntime → false: the Cowork row hides (its poller early-returns) but the
+// AI-models row is not Tauri-gated, so it still renders. Keeps the mock set lean.
+vi.mock("../../src/client/cowork/cowork-helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/client/cowork/cowork-helpers")>();
+  return { ...actual, isTauriRuntime: () => false };
+});
+
+vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
+  createCoworkStatus: () => ({
+    status: null,
+    loading: false,
+    error: null,
+    refetch: vi.fn(async () => {}),
+  }),
+}));
+
+vi.mock("../../src/client/hooks/useClaudeCliStatus.svelte", () => ({
+  createClaudeCliStatus: () => ({
+    presence: "INSTALLED_ON_PATH",
+    loading: false,
+    error: null,
+    installing: false,
+    installError: null,
+    install: vi.fn(async () => "INSTALLED_ON_PATH"),
+    refetch: vi.fn(async () => {}),
+  }),
+}));
+
+// Empty-connect MCP state — keeps the MAIN view + More section rendered.
+vi.mock("../../src/client/hooks/useIntegrationWizard.svelte", () => ({
+  createIntegrationWizard: () => ({
+    step: "connect",
+    detecting: false,
+    existing: [],
+    picked: [],
+    applyResults: [],
+    errorMessage: null,
+    keychainUnavailable: false,
+    begin: vi.fn(async () => {}),
+    save: vi.fn(async () => {}),
+    reset: vi.fn(),
+    setPicked: vi.fn(),
+    submitSecret: vi.fn(async () => {}),
+    cleanupUnsavedSecrets: vi.fn(async () => {}),
+  }),
+  detectedToPicked: vi.fn(() => null),
+}));
+
+const { default: IntegrationWizardModal } = await import(
+  "../../src/client/components/IntegrationWizardModal.svelte"
+);
+
+function q(container: HTMLElement, testid: string): HTMLElement | null {
+  return container.querySelector(`[data-testid='${testid}']`);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("integration wizard — AI models row (§3.6, flag ON)", () => {
+  it("renders the enabled 'Set up' models row (not the coming-soon line)", async () => {
+    const { container } = render(IntegrationWizardModal, {
+      props: { open: true, onClose: vi.fn() },
+    });
+    await tick();
+
+    const setup = q(container, "integration-wizard-models-setup");
+    expect(setup).toBeTruthy();
+    // The disabled coming-soon row must NOT be the one rendered.
+    expect(q(container, "integration-wizard-more")?.textContent).toMatch(/local AI model/i);
+    expect(q(container, "integration-wizard-more")?.textContent).not.toMatch(/coming soon/i);
+  });
+
+  it("Set up closes the wizard and invokes onSetupModels", async () => {
+    const onClose = vi.fn();
+    const onSetupModels = vi.fn();
+    const { container } = render(IntegrationWizardModal, {
+      props: { open: true, onClose, onSetupModels },
+    });
+    await tick();
+
+    (q(container, "integration-wizard-models-setup") as HTMLButtonElement).click();
+    await tick();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSetupModels).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/client/model-edit-modal.test.ts
+++ b/tests/client/model-edit-modal.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+
+/**
+ * Per-provider gating in the add/edit model modal (#1123 M2b §3.4).
+ *
+ * `ModelEditModal` has no internal `BYO_MODELS_ENABLED` gate — only its
+ * call-site (`SettingsModelsTab`, mounted only when the flag is on) does — so a
+ * direct mount renders the full flag-ON UI without any constant mock. The
+ * contract under test: v1.0 ships local providers only, so cloud `<option>`s are
+ * disabled with a "coming soon" label, a new entry defaults to a local provider,
+ * and an existing cloud entry keeps its (now-disabled) provider without silently
+ * disappearing.
+ */
+
+import { cleanup, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ModelEditModal from "../../src/client/components/ModelEditModal.svelte";
+import type { ModelRegistryEntry } from "../../src/client/hooks/useTandemSettings.svelte.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function mountAdd() {
+  return render(ModelEditModal, {
+    props: { onCancel: vi.fn(), onSave: vi.fn() },
+  });
+}
+
+function providerOptions(container: HTMLElement) {
+  const select = container.querySelector<HTMLSelectElement>('[data-testid="model-edit-provider"]');
+  if (!select) throw new Error("provider select not found");
+  return { select, options: Array.from(select.options) };
+}
+
+describe("ModelEditModal — per-provider gating (§3.4)", () => {
+  it("defaults a new entry to a local provider", () => {
+    const { container } = mountAdd();
+    const { select } = providerOptions(container);
+    expect(select.value).toBe("local-ollama");
+  });
+
+  it("disables cloud providers and enables local ones, cloud labelled 'coming soon'", () => {
+    const { container } = mountAdd();
+    const { options } = providerOptions(container);
+
+    const byValue = Object.fromEntries(options.map((o) => [o.value, o]));
+    // Local providers: enabled, no "coming soon".
+    for (const v of ["local-ollama", "local-llamacpp"]) {
+      expect(byValue[v].disabled).toBe(false);
+      expect(byValue[v].textContent).not.toMatch(/coming soon/i);
+    }
+    // Cloud providers: disabled, labelled "coming soon".
+    for (const v of ["anthropic", "openai", "gemini"]) {
+      expect(byValue[v].disabled).toBe(true);
+      expect(byValue[v].textContent).toMatch(/coming soon/i);
+    }
+  });
+
+  it("orders local providers first in the picker", () => {
+    const { container } = mountAdd();
+    const { options } = providerOptions(container);
+    expect(options.slice(0, 2).map((o) => o.value)).toEqual(["local-ollama", "local-llamacpp"]);
+  });
+
+  it("shows no cloud 'coming soon' note while a local provider is selected", () => {
+    const { queryByTestId } = mountAdd();
+    // Default provider is local-ollama → the note is gated off.
+    expect(queryByTestId("model-edit-provider-note")).toBeNull();
+    // Local providers use the endpoint field, not an API key.
+    expect(queryByTestId("model-edit-endpoint")).not.toBeNull();
+    expect(queryByTestId("model-edit-apikey")).toBeNull();
+  });
+
+  it("keeps an existing cloud entry's provider selected and surfaces the note (no silent hide)", () => {
+    const cloudEntry: ModelRegistryEntry = {
+      id: "c-1",
+      provider: "anthropic",
+      displayName: "My Claude",
+      modelId: "claude-opus-4-8",
+      apiKeyRef: "ref-abcd",
+      enabled: true,
+    };
+    const { container, queryByTestId } = render(ModelEditModal, {
+      props: { entry: cloudEntry, onCancel: vi.fn(), onSave: vi.fn() },
+    });
+    const { select, options } = providerOptions(container);
+    // The stored cloud provider is still the selected value — not dropped.
+    expect(select.value).toBe("anthropic");
+    // The option itself stays disabled (can't re-pick cloud), but present.
+    expect(options.find((o) => o.value === "anthropic")?.disabled).toBe(true);
+    // A cloud selection surfaces the "choose a local provider" note.
+    expect(queryByTestId("model-edit-provider-note")).not.toBeNull();
+  });
+});

--- a/tests/client/model-edit-modal.test.ts
+++ b/tests/client/model-edit-modal.test.ts
@@ -12,7 +12,7 @@
  * disappearing.
  */
 
-import { cleanup, render } from "@testing-library/svelte";
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import ModelEditModal from "../../src/client/components/ModelEditModal.svelte";
@@ -71,6 +71,20 @@ describe("ModelEditModal — per-provider gating (§3.4)", () => {
     // Local providers use the endpoint field, not an API key.
     expect(queryByTestId("model-edit-endpoint")).not.toBeNull();
     expect(queryByTestId("model-edit-apikey")).toBeNull();
+  });
+
+  it("requires an endpoint before a new local model can be saved", async () => {
+    const { getByTestId } = mountAdd();
+    const save = () => getByTestId("model-edit-save") as HTMLButtonElement;
+    // Default provider is local-ollama → endpoint field is present and empty.
+    await fireEvent.input(getByTestId("model-edit-displayname"), { target: { value: "My local" } });
+    await fireEvent.input(getByTestId("model-edit-modelid"), { target: { value: "qwen2.5:14b" } });
+    // displayName + modelId filled but endpoint still blank → save stays disabled.
+    expect(save().disabled).toBe(true);
+    await fireEvent.input(getByTestId("model-edit-endpoint"), {
+      target: { value: "http://127.0.0.1:11434" },
+    });
+    expect(save().disabled).toBe(false);
   });
 
   it("keeps an existing cloud entry's provider selected and surfaces the note (no silent hide)", () => {

--- a/tests/client/settings-models-tab.test.ts
+++ b/tests/client/settings-models-tab.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+
+/**
+ * SettingsModelsTab load/error/empty states + banner suppression (#1123 M2b
+ * review fixes). The tab has no internal `BYO_MODELS_ENABLED` gate (its call-site
+ * filter does), so a direct mount renders the flag-ON UI. `createModels` is
+ * mocked so the store's `loading`/`loadFailed`/`models`/`saveError` can be posed
+ * without a server.
+ *
+ * Contracts pinned:
+ *  - during a load, show a skeleton — never assert "No models configured";
+ *  - on a failed load, show a distinct "couldn't load — retry" state (not the
+ *    empty state), and Retry calls `reload()`;
+ *  - the list-level saveError banner is suppressed while the editor modal is open
+ *    (the modal owns error display) and while loadFailed (that state owns it).
+ */
+
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const reload = vi.fn(async () => {});
+
+interface StoreState {
+  models?: Array<Record<string, unknown>>;
+  defaultModelId?: string | null;
+  saveError?: string | null;
+  loading?: boolean;
+  loadFailed?: boolean;
+}
+let storeState: StoreState = {};
+
+vi.mock("../../src/client/hooks/useModels.svelte", () => ({
+  createModels: () => ({
+    get models() {
+      return storeState.models ?? [];
+    },
+    get defaultModelId() {
+      return storeState.defaultModelId ?? null;
+    },
+    get saveError() {
+      return storeState.saveError ?? null;
+    },
+    get loading() {
+      return storeState.loading ?? false;
+    },
+    get loadFailed() {
+      return storeState.loadFailed ?? false;
+    },
+    reload,
+    clearError: vi.fn(),
+    addModel: vi.fn(async () => "id"),
+    updateModel: vi.fn(async () => true),
+    deleteModel: vi.fn(async () => {}),
+    toggleEnabled: vi.fn(async () => {}),
+    setDefault: vi.fn(async () => true),
+  }),
+}));
+
+const { default: SettingsModelsTab } = await import(
+  "../../src/client/components/settings-tabs/SettingsModelsTab.svelte"
+);
+
+function mount() {
+  return render(SettingsModelsTab, { props: { readOnly: false } });
+}
+
+afterEach(() => {
+  storeState = {};
+  reload.mockClear();
+  cleanup();
+});
+
+describe("SettingsModelsTab — load / error / empty states", () => {
+  it("shows a skeleton (not the empty state) while loading", () => {
+    storeState = { loading: true, models: [] };
+    const { queryByTestId } = mount();
+    expect(queryByTestId("models-loading")).not.toBeNull();
+    expect(queryByTestId("models-empty-state")).toBeNull();
+  });
+
+  it("shows a distinct load-error state with a working Retry, not 'No models configured'", async () => {
+    storeState = {
+      loadFailed: true,
+      models: [],
+      saveError: "Failed to load models from the server.",
+    };
+    const { queryByTestId, getByTestId } = mount();
+    expect(queryByTestId("models-load-error")).not.toBeNull();
+    expect(queryByTestId("models-empty-state")).toBeNull();
+    // The bottom banner is suppressed while loadFailed owns the message.
+    expect(queryByTestId("models-save-error")).toBeNull();
+
+    await fireEvent.click(getByTestId("models-reload-btn"));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the empty state only when genuinely empty (loaded, no error)", () => {
+    storeState = { models: [] };
+    const { queryByTestId } = mount();
+    expect(queryByTestId("models-empty-state")).not.toBeNull();
+    expect(queryByTestId("models-loading")).toBeNull();
+    expect(queryByTestId("models-load-error")).toBeNull();
+  });
+
+  it("suppresses the list saveError banner while the editor modal is open", async () => {
+    storeState = {
+      saveError: "Model registry changed elsewhere; reloaded.",
+      models: [
+        {
+          id: "m1",
+          provider: "local-ollama",
+          displayName: "Local",
+          modelId: "qwen2.5:14b",
+          endpoint: "http://127.0.0.1:11434",
+          enabled: true,
+        },
+      ],
+    };
+    const { queryByTestId, getByTestId } = mount();
+    // With models present and no modal open, the banner shows.
+    expect(queryByTestId("models-save-error")).not.toBeNull();
+    // Open the add modal → the modal owns error display, banner is hidden.
+    await fireEvent.click(getByTestId("model-add-btn"));
+    expect(queryByTestId("models-save-error")).toBeNull();
+    expect(queryByTestId("model-edit-modal")).not.toBeNull();
+  });
+});

--- a/tests/client/use-models-loading.test.ts
+++ b/tests/client/use-models-loading.test.ts
@@ -77,4 +77,29 @@ describe("models store — loading / reload (flag mocked ON)", () => {
     expect(getCount).toBe(2); // a second GET actually hit the server
     expect(models.loading).toBe(false);
   });
+
+  it("sets loadFailed (and saveError) on a failed load; a successful reload clears both", async () => {
+    // First GET fails (500), second (reload) succeeds.
+    let call = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        call++;
+        if (call === 1) return new Response("nope", { status: 500 });
+        return new Response(JSON.stringify({ file: serverFile, etag: "e-ok" }), { status: 200 });
+      }),
+    );
+    const models = createModels();
+
+    await loadFromServer();
+    expect(models.loadFailed).toBe(true);
+    expect(models.loading).toBe(false);
+    expect(models.saveError).toBeTruthy();
+    expect(models.models).toEqual([]); // empty ONLY because the load failed
+
+    await models.reload();
+    expect(models.loadFailed).toBe(false);
+    expect(models.saveError).toBeNull();
+    expect(models.models.map((m) => m.id)).toEqual(["srv-1"]);
+  });
 });

--- a/tests/client/use-models-loading.test.ts
+++ b/tests/client/use-models-loading.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+/**
+ * `loading` / `reload` are flag-gated (`loadFromServer` early-returns while dark),
+ * so this file mocks `BYO_MODELS_ENABLED=true` to exercise the lit path. This is
+ * the ONLY seam used for flag-on coverage — a `vi.mock` of the constant, NOT a
+ * runtime env/define override (the production const stays a literal `false`; a
+ * build-define would crash the vite client bundle — see the M2b plan §3.8).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/shared/constants.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/shared/constants.js")>()),
+  BYO_MODELS_ENABLED: true,
+}));
+
+const { _resetModelsStoreForTests, createModels, loadFromServer } = await import(
+  "../../src/client/hooks/useModels.svelte.js"
+);
+
+const serverFile = {
+  schemaVersion: 1,
+  models: [
+    {
+      id: "srv-1",
+      provider: "local-ollama",
+      displayName: "Local",
+      modelId: "qwen2.5:14b",
+      enabled: true,
+    },
+  ],
+  defaultModelId: "srv-1",
+};
+
+let getCount = 0;
+
+function stubGet() {
+  return vi.fn(async () => {
+    getCount++;
+    return new Response(JSON.stringify({ file: serverFile, etag: `e-${getCount}` }), {
+      status: 200,
+    });
+  });
+}
+
+beforeEach(() => {
+  getCount = 0;
+  _resetModelsStoreForTests();
+  vi.stubGlobal("fetch", stubGet());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("models store — loading / reload (flag mocked ON)", () => {
+  it("loadFromServer toggles loading true→false and populates from the server", async () => {
+    const models = createModels();
+    expect(models.loading).toBe(false);
+
+    const p = loadFromServer(); // synchronous flag check + `_loading = true` before the await
+    expect(models.loading).toBe(true);
+
+    await p;
+    expect(models.loading).toBe(false);
+    expect(models.models.map((m) => m.id)).toEqual(["srv-1"]);
+    expect(models.defaultModelId).toBe("srv-1");
+  });
+
+  it("reload re-fetches even after a completed load (clears the in-flight dedup)", async () => {
+    const models = createModels();
+    await loadFromServer();
+    expect(getCount).toBe(1);
+
+    await models.reload();
+    expect(getCount).toBe(2); // a second GET actually hit the server
+    expect(models.loading).toBe(false);
+  });
+});

--- a/tests/client/use-models.test.ts
+++ b/tests/client/use-models.test.ts
@@ -220,7 +220,9 @@ describe("models store — CRUD", () => {
       enabled: true,
     });
 
-    await expect(models.updateModel("nonexistent", { displayName: "X" })).resolves.toBeUndefined();
+    // updateModel on an unknown id short-circuits to `false` (nothing committed);
+    // toggle/delete stay void no-ops. None throws.
+    await expect(models.updateModel("nonexistent", { displayName: "X" })).resolves.toBe(false);
     await expect(models.toggleEnabled("nonexistent")).resolves.toBeUndefined();
     await expect(models.deleteModel("nonexistent")).resolves.toBeUndefined();
     expect(models.models.length).toBe(1);
@@ -419,14 +421,6 @@ describe("models store — snapshot + dark gate", () => {
     // Dark build: the flag is a literal const false, so the load short-circuits.
     expect(fetchMock).not.toHaveBeenCalled();
     expect(getModelsSnapshot().models).toEqual([]);
-  });
-});
-
-describe("models store — legacy keys (vestigial)", () => {
-  it("hasLegacyKeys is false and migrateLegacyKeys is a no-op (server never carries _legacyApiKey)", async () => {
-    const models = createModels();
-    expect(models.hasLegacyKeys).toBe(false);
-    expect(await models.migrateLegacyKeys()).toEqual({ migrated: 0, failed: 0 });
   });
 });
 
@@ -697,5 +691,87 @@ describe("models store — concurrency (busy retry, persistent stale, adopt-orph
     expect(newRef).not.toBe(oldRef);
     expect(models.models.length).toBe(0); // adopted the entry-less server state
     expect(rec.deleted()).toContain(newRef); // committed-but-not-landed → new ref cleaned up
+  });
+});
+
+describe("models store — M2b outcome returns + clearError", () => {
+  it("addModel returns the id on commit and null on a rolled-back write", async () => {
+    // Commit: default stub 200s → a string id.
+    const models = createModels();
+    const okId = await models.addModel({
+      provider: "openai",
+      displayName: "G",
+      modelId: "gpt-4o",
+      enabled: true,
+    });
+    expect(typeof okId).toBe("string");
+
+    // Rollback: every models POST 500s → null (the entry didn't land).
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: { method?: string }) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (String(url).includes("/secrets/")) return new Response(null, { status: 204 });
+        if (method === "POST") return new Response("nope", { status: 500 });
+        return new Response(JSON.stringify({ file: serverFile, etag: "e" }), { status: 200 });
+      }),
+    );
+    const nullId = await models.addModel({
+      provider: "openai",
+      displayName: "H",
+      modelId: "gpt-4o",
+      enabled: true,
+    });
+    expect(nullId).toBeNull();
+  });
+
+  it("updateModel and setDefault return true on commit, false on a rolled-back write", async () => {
+    const models = createModels();
+    const id = await models.addModel({
+      provider: "anthropic",
+      displayName: "A",
+      modelId: "claude-opus-4-7",
+      enabled: true,
+    });
+
+    expect(await models.updateModel(id as string, { displayName: "A2" })).toBe(true);
+    expect(await models.setDefault(id)).toBe(true);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: { method?: string }) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (String(url).includes("/secrets/")) return new Response(null, { status: 204 });
+        if (method === "POST") return new Response("nope", { status: 500 });
+        return new Response(JSON.stringify({ file: serverFile, etag: "e" }), { status: 200 });
+      }),
+    );
+    expect(await models.updateModel(id as string, { displayName: "A3" })).toBe(false);
+    expect(await models.setDefault(null)).toBe(false);
+  });
+
+  it("clearError() clears a sticky saveError without a write", async () => {
+    const models = createModels();
+    const id = await models.addModel({
+      provider: "anthropic",
+      displayName: "A",
+      modelId: "claude-opus-4-7",
+      enabled: true,
+    });
+    // Force a rollback to set saveError.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: { method?: string }) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (String(url).includes("/secrets/")) return new Response(null, { status: 204 });
+        if (method === "POST") return new Response("nope", { status: 500 });
+        return new Response(JSON.stringify({ file: serverFile, etag: "e" }), { status: 200 });
+      }),
+    );
+    await models.setDefault(id);
+    expect(models.saveError).not.toBeNull();
+
+    models.clearError();
+    expect(models.saveError).toBeNull();
   });
 });

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -229,6 +229,7 @@ model-edit-btn-{*}
 model-edit-cancel
 model-edit-displayname
 model-edit-endpoint
+model-edit-error
 model-edit-modal
 model-edit-modelid
 model-edit-provider
@@ -236,9 +237,6 @@ model-edit-save
 model-row-{*}
 model-toggle-{*}
 models-empty-state
-models-legacy-migrate-btn
-models-legacy-migration-banner
-models-legacy-migration-status
 models-save-error
 network-degraded-delay-slider
 network-restart-sidecar

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -239,6 +239,9 @@ model-edit-save
 model-row-{*}
 model-toggle-{*}
 models-empty-state
+models-load-error
+models-loading
+models-reload-btn
 models-save-error
 network-degraded-delay-slider
 network-restart-sidecar

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -190,6 +190,7 @@ integration-wizard-install-claude
 integration-wizard-install-error
 integration-wizard-install-success
 integration-wizard-keychain-fallback
+integration-wizard-models-setup
 integration-wizard-more
 integration-wizard-pick-{*}
 integration-wizard-push-mode
@@ -233,6 +234,7 @@ model-edit-error
 model-edit-modal
 model-edit-modelid
 model-edit-provider
+model-edit-provider-note
 model-edit-save
 model-row-{*}
 model-toggle-{*}

--- a/tests/e2e/settings-models.spec.ts
+++ b/tests/e2e/settings-models.spec.ts
@@ -291,58 +291,10 @@ test("default selection persists across reload and the titlebar chip surfaces it
   expect(reloaded?.defaultModelId).toBe(rowId);
 });
 
-test("legacy plaintext key migration banner — appears, migrates, then disappears", async ({
-  page,
-}) => {
-  // Pre-seed a pre-v7 blob with a plaintext `apiKey` to drive the migration
-  // banner. The `_legacyApiKey` field is the in-memory marker `parseModels`
-  // sets; the banner triggers off `models.hasLegacyKeys`.
-  const LEGACY_KEY = "sk-test-DO-NOT-USE-anthropic-legacy";
-  await page.evaluate(
-    ({ key, legacy }) => {
-      localStorage.setItem(
-        key,
-        JSON.stringify({
-          schemaVersion: 6,
-          leftPanelVisible: false,
-          rightPanelVisible: true,
-          models: [
-            {
-              id: "legacy-1",
-              provider: "anthropic",
-              displayName: "Legacy entry",
-              modelId: "claude-opus-4-7",
-              apiKey: legacy,
-              enabled: true,
-            },
-          ],
-        }),
-      );
-    },
-    { key: TANDEM_SETTINGS_KEY, legacy: LEGACY_KEY },
-  );
-  await page.reload();
-  await gotoModelsTab(page);
-
-  // Banner is visible — the entry was loaded with a transient `_legacyApiKey`.
-  const banner = page.locator("[data-testid='models-legacy-migration-banner']");
-  await expect(banner).toBeVisible();
-
-  await page.locator("[data-testid='models-legacy-migrate-btn']").click();
-
-  // After migration the banner disappears and the entry now carries
-  // `apiKeyRef` instead of `_legacyApiKey`/`apiKey`.
-  await expect(banner).toHaveCount(0);
-  const persisted = await page.evaluate((key) => {
-    const raw = localStorage.getItem(key);
-    return raw ? JSON.parse(raw) : null;
-  }, TANDEM_SETTINGS_KEY);
-  expect(persisted?.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
-  expect(persisted?.models?.[0]?.apiKey).toBeUndefined();
-  expect(persisted?.models?.[0]?.apiKeyRef).toBeDefined();
-  // The plaintext must NEVER appear in localStorage post-migration.
-  expect(JSON.stringify(persisted)).not.toContain(LEGACY_KEY);
-});
+// The legacy plaintext-key migration banner was removed in #1123 M2b: the store
+// loads from the `.strict()` server (never carries `_legacyApiKey`), so
+// `hasLegacyKeys` could never be true. Legacy plaintext in localStorage is
+// dropped by the reconcile's `projectEntry` (R2-D). No banner, no test.
 
 test("v2 → current schema migration boot — Models tab renders with empty list, settings survive", async ({
   page,


### PR DESCRIPTION
## #1123 M2b — Models UI mount + gating (ships DARK)

Stacked on **M2a (#1220)** — base is `feat/1123-m2-model-registry-server-authority`; retarget to `master` once M2a merges. Phase **M2b** of the local-model collaborator (#1123, ADR-039).

M2a relocated the client Models registry to server authority but left the UI unmounted. M2b **mounts and wires** that UI behind `BYO_MODELS_ENABLED` (a literal `const false`), so when the flag flips at **M4 (v1.0)** a complete, tested Models UI lights up. **Every change is byte-identical while dark** — verified by a dedicated dark-guarantee review.

### What landed
- **Store API** (`useModels.svelte.ts`): `loading` / `reload()` / `clearError()`; `addModel → Promise<string | null>`, `updateModel`/`setDefault → Promise<boolean>` so callers branch on the authoritative commit outcome (not a shared reactive flag); removed the dead legacy-key members; new `loadFailed` flag distinct from `saveError`.
- **Per-provider gating** (`ModelEditModal`, `FirstRunModelPickerModal`): v1.0 ships **local providers only** — cloud options/radios render disabled + "coming soon", new entries default to `local-ollama`, and both the picker split and the key/endpoint field gating derive from the contract's `isLocalProvider` (single source of truth, can't drift from what the loop resolves). Both pickers require an endpoint before a local model is saveable.
- **First-run mount** (`App.svelte`): `FirstRunModelPickerModal` mounts as an optional, skippable step sequenced after the wizard and before the tutorial via `shouldShowModelPicker` (leads with `BYO_MODELS_ENABLED &&`). The tutorial-lifecycle coupling and its two M4-owned edges are documented inline.
- **Wizard row** (`IntegrationWizardModal`): the "AI models" More-row gains an enabled `{:else}` "Set up a local AI model" affordance (optional `onSetupModels` prop → `openModelsSettings`); the dark coming-soon row is unchanged.
- **Removed** the dead legacy-key migration UI + its E2E block.

### Closed gaps (from the adversarial review)
- The first-run picker no longer swallows a rolled-back `setDefault` — it surfaces a contextual error, keeps the modal open, and a retry can't duplicate the committed add (`addedId` guard).
- SettingsModelsTab no longer asserts "No models configured" during a load or after a load failure — a skeleton + a distinct "couldn't load — Retry" state replace it.
- Load-failure cause is logged; the list banner no longer co-shows with the modal or the load-error state.

### Testing
Flag-ON paths covered by direct component mounts + a targeted `vi.mock` of the constant for the one-line gates (per plan §3.8 — **no production flag change**; a build-define would crash the vite client bundle). E2E `settings-models.spec.ts` stays `test.skip(!BYO_MODELS_ENABLED)` and auto-enables at the M4 flip.

Client suite **1748 green**; typecheck + svelte-check + token check clean. The enforced testid snapshot is updated; the descriptive CLAUDE.md registry line is owned by concurrent design-track WIP and is folded in there.

### Out of scope
M3 (provider-keyed authorship) · M4 (flip the flag, final first-run choreography, chip loading-gate, E2E vs a stub server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
