### PR TITLE
feat(local-model): provider-keyed authorship byline (#1123 M3, dark)

### DIFF
--- a/docs/plans/1123-m3-provider-authorship.md
+++ b/docs/plans/1123-m3-provider-authorship.md
@@ -1,0 +1,81 @@
+# #1123 M3 — Provider-keyed authorship (built dark)
+
+**Status:** REVISED after 3-agent prose review (annotation-model / architecture-dark / crdt-decoration). Agent feedback incorporated — see "Plan-review corrections" below. Phase **M3** of the local-model collaborator (#1123, ADR-039). Stacks on M2b (`feat/1123-m2b-models-ui-mount`, PR #1221) → M2a (#1220). Branch: `feat/1123-m3-provider-authorship`. Ships **DARK** behind `BYO_MODELS_ENABLED` (literal `const false`) — runtime byte-identical while dark. Flag flips at **M4 (v1.0)**.
+
+## Plan-review corrections (applied)
+
+- **§0 factual fix — the loop writes NO authorship ranges.** `document.ts:256/593` (authorship-range stamping) are Claude-**via-MCP** paths (`tandem_open` / `tandem_edit`). The local-model loop's tool registry (`tools.ts:68-142`) is get_outline / read_section / comment_on_quote / propose_replacement / reply_to_annotation — it has **no direct-text-edit tool**; `propose_replacement` creates a *comment-with-`suggestedText`* annotation (`tools.ts:294-302`), not an edit. So the loop authors exactly three record kinds: **annotation (comment), reply, chat message** — and **zero** `AuthorshipRange`s. All three reviewers converged on this; it collapses the decoration debate (see below).
+- **The identity source does not exist yet (High).** `LocalModelConfig` is `{endpoint, modelId, transport}` (`config.ts:17-24`); `resolveLocalModelConfig` READS `entry.provider`/`entry.displayName` (`config-source.ts:34`, both exist on `ModelsEntry`, `contract.ts:71-72`) but **discards** them (`:65-72`). M3 must extend the resolver's return to carry `{provider, displayName}`. Prerequisite, not assumed-done.
+- **`sanitizeAnnotation` is an ALLOWLIST, not passthrough (the one load-bearing gap).** `sanitize.ts:90-111` copies only enumerated `AnnotationBase` fields; unlisted fields are **stripped on every read**, and client cards read sanitized records (`yjsSync.svelte.ts:202`, `annotation.ts:102`). `agentIdentity` is a **required allowlist add** — without it the byline fix silently no-ops on the client. (Persistence itself is safe: `AnnotationRecordSchemaV1` is `.passthrough()`, `schema.ts:124`.)
+- **Threading needs two signature changes.** `DispatchCtx` (`tools.ts:40-45`, currently `{ydoc, isLicenseRestricted}`) must carry `agentIdentity`; `addReplyToAnnotation` (`annotations.ts:137`) builds the reply inline with no identity param → add an **optional** `agentIdentity` defaulted `undefined` so the MCP `tandem_annotationReply` caller stays byte-identical. `createAnnotation`'s `extras: Partial<Annotation>` (`annotations.ts:293`, spread last `:309`) carries it cleanly. `appendClaudeChatMessage` (`awareness.ts:55`) gains an optional identity param; `updateClaudeChatMessage` re-sets `{...existing, text}` so a streamed delta preserves it.
+- **Decoration re-scoped — ALL per-agent color → M4 (see §4.4).** The loop authors no `AuthorshipRange`, so the inline authorship-underline/gutter path (`authorship.ts`) is moot for it. A local-model *comment* does render three annotation-`author`-keyed surfaces (card dot, comment-body underline `annotation.ts:155`, margin leader `marginLeaderGeometry.ts:81`), all Claude-orange today. Because the whole feature is **dark until M4**, none of these are user-visible before the flag flips, so there is **no shippable half-state** to avoid by landing color early. M4 already owns the AuthorshipRange decoration + the flag flip + final choreography; folding the annotation-color surfaces into M4 designs the per-`provider` palette + token set + all surfaces as **one coherent, reviewed unit** and avoids two token passes. **M3 = identity + byline core only.** (Engineering-sequencing call; identical dark outcome to landing colors in M3. Reversible — flag Bryan if he wants the annotation colors in M3.)
+- **Privacy note added (§5):** when a user accepts/dismisses a local-model annotation, the notification routes to whatever agent is on the channel / MCP inbox (real Claude), not the local model — a cross-identity wrinkle, **not** an ADR-027 violation, moot while dark; M4 concern.
+
+---
+
+## 1. The gap & the dark guarantee
+
+**Gap.** The loop stamps its annotation/reply/chat writes `author:"claude"` (via `createAnnotation`/`addReplyToAnnotation`/`appendClaudeChatMessage`) — identical to real Claude. And the byline doesn't even read the record: `getAuthorLabel` (`annotation-card-helpers.ts:10-13`) and the chat byline (`ChatPanel.svelte:226`) resolve the agent name from `agentLabelSource()` — the user's **active/default** model — so an annotation already shows whatever model is currently default, not the one that wrote it (confirmed by all three reviewers). M3 carries the authoring agent's identity **on the record** so the byline reflects it.
+
+**Dark guarantee (every commit).** With `BYO_MODELS_ENABLED=false` the loop never runs → no record ever gets an `agentIdentity`. The field is optional; every read-path change falls back to today's exact output when it is absent (which is always, while dark, and for all pre-M3 + all real-Claude records). Verify per commit: absent-field byline is byte-identical; `check:tokens` + `typecheck` + `svelte-check` clean; existing suites green.
+
+## 2. Design decision (SETTLED — Option B)
+
+Keep `author:"claude"` as the **agent-role** marker (all privacy/channel/gating semantics unchanged — a local model IS an agent for gating). Add an optional identity the writer stamps:
+
+```
+// shared/types.ts
+export interface AgentIdentity { provider: ModelProvider; displayName: string }
+// on AnnotationBase, AnnotationReply, ChatMessage:
+agentIdentity?: AgentIdentity;
+```
+
+Add a code comment at the `author` type: **`"claude"` = agent-role, not literally Claude — the specific agent is `agentIdentity` when present.** Option B advantages the reviewers confirmed: zero union churn → zero compile break, zero privacy-gate reasoning (every `author` branch behaves exactly as today), **leaves the `assertNever` switch untouched** (`marginLeaderGeometry.ts:65-67`), backward-compatible (absent ⇒ today's `agentLabelSource()` fallback), and dark-safe by construction (only the flag-gated loop ever sets it). Option A (new `author` variant) rejected: ~20 role-branch sites incl. ADR-027 privacy (`mode.ts:83`, observers), the `assertNever` switch, three narrow unions — high blast radius + privacy-misbucket risk, and it still wouldn't say *which* model.
+
+Identity shape `{provider, displayName}` (not a registry `modelId` ref): records persist on disk and outlive the user-mutable registry — a ref would dangle on edit/delete; a self-contained snapshot also correctly **freezes who authored this at the time**.
+
+## 3. Scope (SETTLED)
+
+- **M3 (this plan) = identity + byline core.** Data model + config-identity plumbing + loop write-site stamping + byline read resolution. Fully additive, anchoring-orthogonal, dark-safe.
+- **M4 = all per-agent decoration color**, as one coherent unit: annotation card dot (`AnnotationCardHeader.svelte:39`), comment-body underline (`annotation.ts:155`), margin leader (`marginLeaderGeometry.ts:81` / `MarginColumn.svelte:272`), AND the AuthorshipRange underline/gutter (`authorship.ts` — loop writes none, pure M4). Keyed on the bounded `agentIdentity.provider` enum (NOT free-text `displayName`), via a new `data-tandem-agent` attribute + per-provider `--tandem-agent-*` tokens; the binary `author` gate at `authorship.ts:59` and `leaderColorForAuthor` stay untouched (color threads at the call sites). Plus the M4 notification-routing wrinkle (§5).
+
+## 4. Changes (M3-core)
+
+### 4.1 Type + schema + sanitize (`src/shared/`, `src/server/annotations/`)
+- `types.ts`: define `AgentIdentity` (import `ModelProvider` from `shared/models/contract.ts`); add optional `agentIdentity?` to `AnnotationBase` (:109), `AnnotationReply` (:67), `ChatMessage` (:401). Add the `author`-is-role comment.
+- `annotations/schema.ts`: add `agentIdentity: z.object({ provider: <the models provider enum>, displayName: z.string().max(120) }).optional()` to the annotation record (:106/:124 area) AND the reply record (:141) so it survives the durable round-trip + LWW `rev` merge (`types.ts:129`). Reuse the provider enum from the models contract (single source).
+- **`sanitize.ts` — REQUIRED allowlist add:** add `agentIdentity` to the `base` allowlist (`:90-111`) via a conditional spread of the absent field (dark-safe: adds nothing when absent). Verify the reply object's stored/read path carries it too. (Chat is read raw from the Y.Map — NOT allowlist-sanitized — so no chat strip hazard.)
+
+### 4.2 Identity source + threading (`src/server/local-model/`, `src/server/mcp/`)
+- **Extend the resolver:** `resolveLocalModelConfig` (`config-source.ts`) builds a prebuilt `agentIdentity: AgentIdentity` ONCE and carries it on `LocalModelConfig` (replacing the flat `provider`/`displayName` the resolver previously read and discarded). Both write paths read `config.agentIdentity` whole — no re-bundling, no per-dispatch allocation (post-`/simplify` altitude fix).
+- **Thread it:** `collaborator.ts` puts `agentIdentity` into `DispatchCtx` (`tools.ts:40-45`) for the loop turn; `annotateFromQuote`/`createAnnotation` pass it via `extras`; `addReplyToAnnotation` gains an optional `agentIdentity` param (defaulted `undefined`); chat via a new optional `appendClaudeChatMessage(..., agentIdentity)` param threaded from `collaborator.ts:145/150`.
+- **Real Claude-via-MCP writes leave `agentIdentity` undefined** (the MCP tools don't set it) → today's behavior preserved. Origin/self-wake unchanged (guards are origin-based `shouldSkipChannel`, not identity).
+
+### 4.3 Byline read resolution (`src/client/`)
+- `annotation-card-helpers.ts:10-13` `getAuthorLabel(author, agentLabel, agentIdentity?)`: `author==="claude"` AND `agentIdentity` present → `agentIdentity.displayName`; else today's `agentLabel.family`. Update the one call site (`AnnotationCardHeader.svelte:34`).
+- `ChatPanel.svelte:226`: per-message byline — `msg.agentIdentity?.displayName ?? agentLabel.family` when `author==="claude"`.
+- `annotation.ts:69-71` aria-label: same fallback (thread `agentIdentity` into the decoration read).
+- No other label site changes; absent identity = byte-identical today.
+
+## 5. Privacy invariants (ADR-027 — confirmed by review, must not regress)
+- Keeping `author:"claude"` preserves every privacy gate (agent can't write into note threads `annotations.ts:170`; note defense-in-depth `observers/annotations.ts:94`; Solo hold keys on `author==="user"` `mode.ts:83` and the loop self-holds in Solo `collaborator.ts:301`; note filters key on `type` not author). `agentIdentity` rides only on already-agent-authored records; never on a user note/comment; contains NO secret (provider enum + user-chosen displayName; never endpoint/apiKeyRef).
+- **Acknowledged disclosure:** `tandem_exportAnnotations` spreads `...ann` (`annotations.ts:714`), so `agentIdentity` appears in the exported sidecar/MCP result — acceptable (non-secret; notes are filtered out first at `:706`).
+- **M4 note (not M3):** accept/dismiss notifications for a local-model annotation route to whatever agent is on the channel/inbox (real Claude), not the local model — cross-identity wrinkle, not a privacy break, moot while dark.
+
+## 6. Testing
+- **Type/schema round-trip:** `agentIdentity` survives Zod (present + absent) and the durable `.passthrough()` + LWW `rev` merge; a record without it validates (backward-compat).
+- **Sanitize allowlist:** a sanitized annotation with `agentIdentity` set RETAINS it (regression guard for the load-bearing gap); absent stays absent.
+- **Byline:** `getAuthorLabel` returns `agentIdentity.displayName` when present, the active `agentLabel.family` when absent (today path); chat byline the same.
+- **Config identity:** the resolver surfaces `{provider, displayName}` from the registry default entry; the loop stamps it onto its three write kinds.
+- **Dark guarantee:** an `agentIdentity`-absent fixture renders byte-identical byline to pre-M3; the loop only stamps identity when a local config resolves.
+- **Privacy:** `agentIdentity` never attaches to a user note; the sanitize note-boundary is unaffected.
+- Full client + server suites green; typecheck + svelte-check + tokens clean.
+
+## 7. Decisions (all SETTLED by review)
+1. Option A vs B → **B** (additive field; unanimous).
+2. Scope → **M3 = byline/identity core; all per-agent color → M4** (dark ⇒ no shippable half-state; consolidates decoration). Reversible product call.
+3. Identity shape → **`{provider, displayName}`** (unanimous).
+4. Chat per-message identity → **add to `ChatMessage`** (unanimous; chat unsanitized so no strip hazard).
+
+## 8. Out of scope (M4)
+Flip `BYO_MODELS_ENABLED`; ALL per-agent decoration color (card/underline/leader/AuthorshipRange, per-`provider` palette + tokens); accept/dismiss notification routing to the authoring agent; final choreography/copy; chip loading-gate; E2E vs a stub OpenAI-compatible server; any `author:"claude"`→`"agent"` generalization.

--- a/docs/plans/1123-m3-provider-authorship.md
+++ b/docs/plans/1123-m3-provider-authorship.md
@@ -52,10 +52,13 @@ Identity shape `{provider, displayName}` (not a registry `modelId` ref): records
 - **Real Claude-via-MCP writes leave `agentIdentity` undefined** (the MCP tools don't set it) → today's behavior preserved. Origin/self-wake unchanged (guards are origin-based `shouldSkipChannel`, not identity).
 
 ### 4.3 Byline read resolution (`src/client/`)
-- `annotation-card-helpers.ts:10-13` `getAuthorLabel(author, agentLabel, agentIdentity?)`: `author==="claude"` AND `agentIdentity` present → `agentIdentity.displayName`; else today's `agentLabel.family`. Update the one call site (`AnnotationCardHeader.svelte:34`).
-- `ChatPanel.svelte:226`: per-message byline — `msg.agentIdentity?.displayName ?? agentLabel.family` when `author==="claude"`.
-- `annotation.ts:69-71` aria-label: same fallback (thread `agentIdentity` into the decoration read).
+- `annotation-card-helpers.ts` `getAuthorLabel(author, agentLabel, agentIdentity?)`: `author==="claude"` AND `agentIdentity` present → `agentIdentity.displayName`; else today's `agentLabel.family`. Update the call site (`AnnotationCardHeader.svelte`).
+- `ChatPanel.svelte`: per-message byline — `msg.agentIdentity?.displayName ?? agentLabel.family` when `author==="claude"`.
+- `CommentThread.svelte`: reply byline — `reply.agentIdentity?.displayName ?? agentLabel.family` (added post-review so the reply *render* matches the card + chat; without it a local-model reply showed the generic family label while its comment showed the model name — a visible inconsistency once lit).
+- `annotation.ts` aria-label: same fallback (thread `agentIdentity` into the decoration read).
 - No other label site changes; absent identity = byte-identical today.
+
+**displayName bound (post-review, 4/5 reviewers converged).** `AgentIdentitySchema.displayName` caps at `AGENT_DISPLAY_NAME_MAX` (120), but the Models registry is more permissive (client ≤256, server `ModelsEntrySchema` unbounded). An over-long name snapshotted onto a durable record fails `AnnotationRecordSchemaV1` on reload — and `parseAnnotationDoc` fails the WHOLE annotations array → the file is quarantined to `.corrupt` (replies drop individually). Fix: **clamp `displayName` to `AGENT_DISPLAY_NAME_MAX` at the single snapshot site** (`resolveLocalModelConfig`), the only place an `agentIdentity` is built — zero blast radius, and the shared constant keeps the clamp and the schema from drifting. Bounding `ModelsEntrySchema` at the source is left as a follow-up (its `.max()` could reject a pre-existing migrated registry entry — M2a's domain).
 
 ## 5. Privacy invariants (ADR-027 — confirmed by review, must not regress)
 - Keeping `author:"claude"` preserves every privacy gate (agent can't write into note threads `annotations.ts:170`; note defense-in-depth `observers/annotations.ts:94`; Solo hold keys on `author==="user"` `mode.ts:83` and the loop self-holds in Solo `collaborator.ts:301`; note filters key on `type` not author). `agentIdentity` rides only on already-agent-authored records; never on a user note/comment; contains NO secret (provider enum + user-chosen displayName; never endpoint/apiKeyRef).

--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -160,7 +160,10 @@ function buildDecorations(
             "data-annotation-id": ann.id,
             "data-annotation-type": ann.type,
             "data-annotation-author": ann.author,
-            "aria-label": `${agentLabel} comment annotation`,
+            // #1123 M3: prefer the specific authoring model's name when the
+            // local-model loop stamped one (survives sanitize via the allowlist
+            // add); else the active-model family label. Dark ⇒ always the latter.
+            "aria-label": `${ann.agentIdentity?.displayName ?? agentLabel} comment annotation`,
           };
         } else {
           // User/import comment → dashed blue underline

--- a/src/client/panels/AnnotationCardHeader.svelte
+++ b/src/client/panels/AnnotationCardHeader.svelte
@@ -31,7 +31,9 @@ let {
 
 const agentLabel = createAgentLabel();
 const displayType = $derived(getDisplayType(annotation));
-const authorLabel = $derived(getAuthorLabel(annotation.author, agentLabel.family));
+const authorLabel = $derived(
+  getAuthorLabel(annotation.author, agentLabel.family, annotation.agentIdentity),
+);
 // 6px authorship dot before the author label. Only user/claude carry an
 // author color (the two --tandem-author-* tokens); imports show the byline
 // instead, so the dot is omitted for them in the markup below.

--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -223,7 +223,9 @@ async function clearChat() {
               ? 'var(--tandem-accent)'
               : 'var(--tandem-fg-muted)'}; text-transform: uppercase;"
           >
-            {msg.author === "claude" ? agentLabel.family : "You"}
+            {msg.author === "claude"
+              ? (msg.agentIdentity?.displayName ?? agentLabel.family)
+              : "You"}
           </span>
           {#if msg.documentId}
             <span

--- a/src/client/panels/CommentThread.svelte
+++ b/src/client/panels/CommentThread.svelte
@@ -27,7 +27,10 @@ const agentLabel = createAgentLabel();
           >
             {#if kind === "claude"}
               <span class="ct-author-dot ct-author-dot--claude" aria-hidden="true"></span>
-              {agentLabel.family}
+              <!-- #1123 M3: a local-model reply bylines with its specific model
+                   name, matching the card + chat surfaces; else the active
+                   family label. Dark ⇒ agentIdentity absent ⇒ family label. -->
+              {reply.agentIdentity?.displayName ?? agentLabel.family}
             {:else if kind === "import"}
               <span data-testid="reply-import-byline-{reply.id}">
                 {reply.importAuthor ?? "Imported"}

--- a/src/client/panels/annotation-card-helpers.ts
+++ b/src/client/panels/annotation-card-helpers.ts
@@ -1,14 +1,21 @@
 import { HIGHLIGHT_COLOR_VARS, normalizeHighlightColor } from "../../shared/constants";
-import type { Annotation } from "../../shared/types";
+import type { AgentIdentity, Annotation } from "../../shared/types";
 
 /**
- * Author label for an annotation. The agent ("claude") branch renders the
- * user's configured model name (#438): pass `agentLabel` (the family label,
- * e.g. "Claude"/"GPT"). Falls back to a neutral "Assistant" when none is given.
- * `import` and `user` are author roles, not the agent, and are unaffected.
+ * Author label for an annotation. The agent ("claude") branch prefers the
+ * specific authoring model's `agentIdentity.displayName` (#1123 M3 — the
+ * local-model collaborator stamps it per record), then the user's active model
+ * family label (#438, e.g. "Claude"/"GPT"), then a neutral "Assistant". While
+ * BYO models are dark, `agentIdentity` is always absent so this is byte-
+ * identical to the pre-M3 label. `import` and `user` are author roles, not the
+ * agent, and are unaffected.
  */
-export function getAuthorLabel(author: Annotation["author"], agentLabel?: string): string {
-  if (author === "claude") return agentLabel ?? "Assistant";
+export function getAuthorLabel(
+  author: Annotation["author"],
+  agentLabel?: string,
+  agentIdentity?: AgentIdentity,
+): string {
+  if (author === "claude") return agentIdentity?.displayName ?? agentLabel ?? "Assistant";
   if (author === "import") return "Imported";
   return "You";
 }

--- a/src/server/annotations/schema.ts
+++ b/src/server/annotations/schema.ts
@@ -15,6 +15,7 @@
 
 import { z } from "zod";
 import {
+  AgentIdentitySchema,
   AnnotationStatusSchema,
   AnnotationTypeSchema,
   AuthorSchema,
@@ -120,6 +121,10 @@ export const AnnotationRecordSchemaV1 = z
     // New for v1 envelope: monotonically-increasing revision counter used for
     // last-writer-wins merge between in-memory Y.Map state and on-disk state.
     rev: z.number().int().nonnegative(),
+    // #1123 M3: authoring agent identity (local-model collaborator only).
+    // Preserved by `.passthrough()`; listed for parity + type-safety at the
+    // write site, mirroring the `heldInSolo` precedent on the reply record.
+    agentIdentity: AgentIdentitySchema.optional(),
   })
   .passthrough()
   // ADR-027: directedAt is removed from the model. All production read paths
@@ -154,6 +159,8 @@ export const AnnotationReplyRecordSchemaV1 = z
     // preserved by `.passthrough()`; listed explicitly for parity with the
     // annotation record and type-safety at the write site.
     heldInSolo: z.boolean().optional(),
+    // #1123 M3: authoring agent identity (local-model collaborator replies only).
+    agentIdentity: AgentIdentitySchema.optional(),
   })
   .passthrough();
 

--- a/src/server/local-model/collaborator.ts
+++ b/src/server/local-model/collaborator.ts
@@ -24,6 +24,7 @@
  */
 import { BYO_MODELS_ENABLED } from "../../shared/constants.js";
 import type { ChatMessagePayload, TandemEvent } from "../../shared/events/types.js";
+import type { AgentIdentity } from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
 import { getActiveDocId, requireDocument } from "../documents/registry.js";
 import { subscribe, unsubscribe } from "../events/queue.js";
@@ -116,6 +117,9 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
     replyTo?: string;
     token: object;
     abort: AbortController;
+    /** #1123 M3: stamped on the streamed chat reply so the bubble bylines the
+     *  specific local model. Absent ⇒ no stamp (byte-identical to pre-M3). */
+    agentIdentity?: AgentIdentity;
   }) {
     let liveId: string | null = null;
     let buffer = "";
@@ -145,6 +149,7 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
         liveId = appendClaudeChatMessage(buffer, {
           documentId: ctx.docName,
           ...(ctx.replyTo ? { replyTo: ctx.replyTo } : {}),
+          ...(ctx.agentIdentity ? { agentIdentity: ctx.agentIdentity } : {}),
         });
       } else {
         updateClaudeChatMessage(liveId, buffer);
@@ -195,7 +200,15 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
     const ydoc = open.doc;
     const includeFullText = extractText(ydoc).length <= INLINE_CHAR_LIMIT;
     const task = composeTask(req.task, req.selection);
-    const sink = makeSink({ docName: req.docName, replyTo: req.replyTo, token, abort });
+    // #1123 M3: the streamed chat reply is bylined with the config's prebuilt
+    // identity (the loop's annotation/reply writes get the same one in dispatch).
+    const sink = makeSink({
+      docName: req.docName,
+      replyTo: req.replyTo,
+      token,
+      abort,
+      agentIdentity: config.agentIdentity,
+    });
 
     try {
       const result = await deps.runTurn({

--- a/src/server/local-model/config-source.ts
+++ b/src/server/local-model/config-source.ts
@@ -69,6 +69,10 @@ export function resolveLocalModelConfig(): LocalModelConfig | null {
       // `/v1/chat/completions`, so `v1` is uniform for now. Ollama-native
       // `/api/chat` can become an optional per-entry transport later (M2/M4).
       transport: "v1",
+      // #1123 M3: build the byline identity ONCE here (the entry's provider +
+      // displayName were previously read and discarded). Threaded whole to both
+      // write paths so the fields are never re-bundled downstream.
+      agentIdentity: { provider: entry.provider, displayName: entry.displayName },
     };
   } catch (err) {
     // No error channel on this seam — a resolution failure means "inert". Today

--- a/src/server/local-model/config-source.ts
+++ b/src/server/local-model/config-source.ts
@@ -19,6 +19,7 @@
  * (validate-at-use / TOCTOU); this resolve-time check is defense-in-depth.
  */
 import { isLocalProvider } from "../../shared/models/contract.js";
+import { AGENT_DISPLAY_NAME_MAX } from "../../shared/types.js";
 import { getCachedModelsFile } from "../models/registry.js";
 import { type LocalModelConfig, validateEndpoint } from "./config.js";
 
@@ -71,8 +72,17 @@ export function resolveLocalModelConfig(): LocalModelConfig | null {
       transport: "v1",
       // #1123 M3: build the byline identity ONCE here (the entry's provider +
       // displayName were previously read and discarded). Threaded whole to both
-      // write paths so the fields are never re-bundled downstream.
-      agentIdentity: { provider: entry.provider, displayName: entry.displayName },
+      // write paths so the fields are never re-bundled downstream. CLAMP the
+      // displayName: the registry permits longer names (client ≤256, server
+      // schema unbounded) than the durable-record bound, and an over-long
+      // agentIdentity fails AnnotationRecordSchemaV1 on reload — corrupting the
+      // WHOLE annotations file (parseAnnotationDoc → corrupt → quarantine), not
+      // just the one record. Clamping here is the sole guard, since this is the
+      // only site that builds an agentIdentity.
+      agentIdentity: {
+        provider: entry.provider,
+        displayName: entry.displayName.slice(0, AGENT_DISPLAY_NAME_MAX),
+      },
     };
   } catch (err) {
     // No error channel on this seam — a resolution failure means "inert". Today

--- a/src/server/local-model/config.ts
+++ b/src/server/local-model/config.ts
@@ -12,6 +12,8 @@
  * we compare the literal hostname the URL parser produced, not a resolved IP.
  */
 
+import type { AgentIdentity } from "../../shared/types.js";
+
 export type LocalModelTransport = "v1" | "native";
 
 export interface LocalModelConfig {
@@ -21,6 +23,15 @@ export interface LocalModelConfig {
   modelId: string;
   /** Wire transport — OpenAI-compatible `/v1` or Ollama-native `/api/chat`. */
   transport: LocalModelTransport;
+  /**
+   * The authoring agent's identity (#1123 M3) — the registry entry's provider +
+   * display name, built ONCE by the resolver (which previously read and
+   * discarded these). Threaded whole to the two write paths that stamp the
+   * byline: the tool dispatch (annotations/replies, via loop.ts) and the chat
+   * streaming sink (via collaborator.ts). A prebuilt snapshot, so it freezes who
+   * authored at the time and never re-bundles the same fields downstream.
+   */
+  agentIdentity: AgentIdentity;
 }
 
 export type EndpointValidation =

--- a/src/server/local-model/loop.ts
+++ b/src/server/local-model/loop.ts
@@ -163,6 +163,9 @@ export async function runLoop(opts: RunLoopOpts): Promise<LoopResult> {
         const outcome = dispatch(tc.name, tc.args, {
           ydoc,
           isLicenseRestricted: opts.isLicenseRestricted,
+          // #1123 M3: the byline identity is prebuilt on the config (one source,
+          // no extra RunLoopOpts field, no per-dispatch allocation).
+          agentIdentity: config.agentIdentity,
         });
         const eff = outcome.effect;
         if (eff.kind === "blocked") metrics.blockedByLicense += 1;

--- a/src/server/local-model/tools.ts
+++ b/src/server/local-model/tools.ts
@@ -29,6 +29,7 @@ import type * as Y from "yjs";
 
 import { Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
 import { withMcp } from "../../shared/origins.js";
+import type { AgentIdentity } from "../../shared/types.js";
 import { addReplyToAnnotation, createAnnotation } from "../mcp/annotations.js";
 import { getOutline, getSection } from "../mcp/document.js";
 import { extractText } from "../mcp/document-model.js";
@@ -42,6 +43,10 @@ export interface DispatchCtx {
   /** True when editing must be blocked (trial expired). Defaults to the live
    *  license gate; injectable so tests don't touch the filesystem. */
   isLicenseRestricted?: () => boolean;
+  /** #1123 M3: the authoring agent's identity, stamped onto every annotation /
+   *  reply this dispatch writes so the client byline names the specific model.
+   *  Undefined ⇒ no stamp (byte-identical to pre-M3 + the MCP path). */
+  agentIdentity?: AgentIdentity;
 }
 
 export interface ToolOutcome {
@@ -218,6 +223,7 @@ function annotateFromQuote(
   args: Record<string, unknown>,
   body: string,
   extra?: Parameters<typeof createAnnotation>[5],
+  agentIdentity?: AgentIdentity,
 ): ToolOutcome {
   const quoted = asString(args.quoted_text);
   const occ = asOccurrence(args.occurrence_index);
@@ -233,7 +239,10 @@ function annotateFromQuote(
       },
     };
   }
-  const id = createAnnotation(annotations, ydoc, "comment", r.anchored, body, extra);
+  // #1123 M3: stamp the authoring agent. When absent, pass `extra` unchanged so
+  // the created record is byte-identical to pre-M3.
+  const mergedExtra = agentIdentity ? { ...extra, agentIdentity } : extra;
+  const id = createAnnotation(annotations, ydoc, "comment", r.anchored, body, mergedExtra);
   return {
     result: { ok: true, annotation_id: id },
     effect: {
@@ -290,7 +299,15 @@ export function dispatch(
       };
     }
     case "comment_on_quote":
-      return annotateFromQuote("comment", ydoc, annotations, args, asString(args.comment));
+      return annotateFromQuote(
+        "comment",
+        ydoc,
+        annotations,
+        args,
+        asString(args.comment),
+        undefined,
+        ctx.agentIdentity,
+      );
     case "propose_replacement":
       return annotateFromQuote(
         "replacement",
@@ -299,6 +316,7 @@ export function dispatch(
         args,
         asString(args.rationale) || "Suggested replacement.",
         { suggestedText: asString(args.suggested_text) },
+        ctx.agentIdentity,
       );
     case "reply_to_annotation": {
       const annotationId = asString(args.annotation_id);
@@ -309,6 +327,7 @@ export function dispatch(
         asString(args.text),
         "claude",
         withMcp,
+        ctx.agentIdentity,
       );
       return {
         result: reply.ok

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -9,6 +9,7 @@ import type { AnchoredRangeResult, RangeValidation } from "../../shared/position
 import type { SanitizationEvent } from "../../shared/sanitize.js";
 import { sanitizeAnnotation } from "../../shared/sanitize.js";
 import type {
+  AgentIdentity,
   Annotation,
   AnnotationReply,
   AnnotationType,
@@ -146,6 +147,14 @@ export function addReplyToAnnotation(
    * `withBrowser` so the lone HTTP caller doesn't need to pass it explicitly.
    */
   wrap: (doc: Y.Doc, fn: () => void) => void = withBrowser,
+  /**
+   * #1123 M3: the authoring agent's identity, stamped on the reply so the
+   * client byline names the specific local model. Passed ONLY by the
+   * local-model collaborator loop; the MCP `tandem_annotationReply` caller and
+   * the HTTP user-reply route leave it undefined, so their replies are
+   * byte-identical to pre-M3.
+   */
+  agentIdentity?: AgentIdentity,
 ): { ok: true; replyId: string } | { ok: false; error: string; code?: string } {
   const raw = annotationsMap.get(annotationId) as Annotation | undefined;
   if (!raw) return { ok: false, error: `Annotation ${annotationId} not found`, code: "NOT_FOUND" };
@@ -205,6 +214,8 @@ export function addReplyToAnnotation(
     ...(author === "user" && ann.type === "comment" && readModeState() === "solo"
       ? { heldInSolo: true }
       : {}),
+    // #1123 M3: agent byline (local-model collaborator only). Absent ⇒ omitted.
+    ...(agentIdentity ? { agentIdentity } : {}),
   };
 
   const repliesMap = getRepliesMap(ydoc);

--- a/src/server/mcp/awareness.ts
+++ b/src/server/mcp/awareness.ts
@@ -8,7 +8,13 @@ import {
   Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
 import { withMcp } from "../../shared/origins.js";
-import type { Annotation, AnnotationReply, ChatMessage, FlatOffset } from "../../shared/types.js";
+import type {
+  AgentIdentity,
+  Annotation,
+  AnnotationReply,
+  ChatMessage,
+  FlatOffset,
+} from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
 import { isStoreReadOnly } from "../annotations/store.js";
 import { getAnnotationEditedChannelKey, wasEmittedViaChannel } from "../events/queue.js";
@@ -54,7 +60,7 @@ export function resetInbox(): void {
  */
 export function appendClaudeChatMessage(
   text: string,
-  opts: { documentId?: string; replyTo?: string } = {},
+  opts: { documentId?: string; replyTo?: string; agentIdentity?: AgentIdentity } = {},
 ): string {
   const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
   const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
@@ -66,6 +72,10 @@ export function appendClaudeChatMessage(
     timestamp: Date.now(),
     ...(opts.documentId ? { documentId: opts.documentId } : {}),
     ...(opts.replyTo ? { replyTo: opts.replyTo } : {}),
+    // #1123 M3: agent byline (local-model collaborator only). `tandem_reply`
+    // omits it ⇒ real-Claude chat is byte-identical. updateClaudeChatMessage's
+    // `{...existing, text}` re-set carries it through every streamed delta.
+    ...(opts.agentIdentity ? { agentIdentity: opts.agentIdentity } : {}),
     read: true,
   };
   withMcp(ctrlDoc, () => chatMap.set(id, msg));

--- a/src/server/models/schema.ts
+++ b/src/server/models/schema.ts
@@ -13,16 +13,12 @@ import { z } from "zod";
 import {
   MODELS_ENTRY_MAX,
   MODELS_SCHEMA_VERSION,
-  type ModelProvider,
   type ModelsFile,
-  VALID_MODEL_PROVIDERS,
 } from "../../shared/models/contract.js";
-
-// Cast preserves the literal `ModelProvider` union (a bare `[string, ...]` cast
-// would widen `provider` to `string` and break assignability to `ModelsFile`).
-const ProviderSchema = z.enum(
-  VALID_MODEL_PROVIDERS as unknown as [ModelProvider, ...ModelProvider[]],
-);
+// Single source for the provider enum (#1123 M3): the same `z.enum` over
+// `VALID_MODEL_PROVIDERS`, defined once in shared/types.ts. Reused here rather
+// than re-constructed so the two can't drift.
+import { ModelProviderSchema } from "../../shared/types.js";
 
 /** Opaque keychain ref: base64url, ≤64. Matches the client + secrets-route shape. */
 const ApiKeyRef = z
@@ -40,7 +36,7 @@ const ParamsSchema = z.record(z.union([z.number(), z.string(), z.boolean()]));
 export const ModelsEntrySchema = z
   .object({
     id: z.string().min(1),
-    provider: ProviderSchema,
+    provider: ModelProviderSchema,
     displayName: z.string(),
     modelId: z.string(),
     apiKeyRef: ApiKeyRef.optional(),

--- a/src/shared/sanitize.ts
+++ b/src/shared/sanitize.ts
@@ -105,6 +105,11 @@ export function sanitizeAnnotation(
     // record) would see it as always-undefined. The marker gates the badge +
     // restart hold, NOT live hiding (that is server-authoritative mode-based).
     ...(typeof ann.heldInSolo === "boolean" ? { heldInSolo: ann.heldInSolo } : {}),
+    // #1123 M3: the authoring agent's identity (local-model collaborator only).
+    // sanitize is a strict allowlist, so without this line agentIdentity is
+    // stripped on EVERY Claude-facing read and the provider byline silently
+    // no-ops on the client. Dark-safe: absent ⇒ nothing added.
+    ...(ann.agentIdentity !== undefined ? { agentIdentity: ann.agentIdentity } : {}),
     audience: derivedAudience,
     ...(ann.promotedFrom !== undefined ? { promotedFrom: ann.promotedFrom } : {}),
     ...(ann.importSource !== undefined ? { importSource: ann.importSource } : {}),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { type ModelProvider, VALID_MODEL_PROVIDERS } from "./models/contract.js";
 import type { DocumentRange, RelativeRange } from "./positions/types.js";
 
 // Canonical definitions live in the positions module; re-exported for backward compatibility.
@@ -22,6 +23,24 @@ export const TandemModeSchema = z.enum(["solo", "tandem"]);
 export const AuthorSchema = z.enum(["user", "claude", "import"]);
 /** Reply authors. `import` carries Word-comment reply threads (#1000); such replies are user-private. */
 export const ReplyAuthorSchema = z.enum(["user", "claude", "import"]);
+/**
+ * Provider enum as a Zod schema, sourced from the models contract's
+ * `VALID_MODEL_PROVIDERS` so the two can't drift (#1123 M3). `z.enum` needs a
+ * non-empty tuple; the contract array is non-empty by construction.
+ */
+export const ModelProviderSchema = z.enum(
+  VALID_MODEL_PROVIDERS as unknown as [ModelProvider, ...ModelProvider[]],
+);
+/**
+ * Runtime schema for {@link AgentIdentity}. Bounded `displayName` (the value is
+ * user-chosen in the Models registry); `provider` is the closed enum. Used by
+ * the durable annotation/reply record schemas so a persisted identity
+ * round-trips through validation rather than surviving only on `.passthrough()`.
+ */
+export const AgentIdentitySchema = z.object({
+  provider: ModelProviderSchema,
+  displayName: z.string().max(120),
+});
 export const AnnotationActionSchema = z.enum(["accept", "dismiss"]);
 export const ExportFormatSchema = z.enum(["markdown", "json"]);
 export const DocumentFormatSchema = z.enum(["md", "txt", "html", "docx"]);
@@ -58,6 +77,22 @@ export type TandemMode = z.infer<typeof TandemModeSchema>;
 export type HighlightColor = z.infer<typeof HighlightColorSchema>;
 export type Severity = z.infer<typeof SeveritySchema>;
 export type ReplyAuthor = z.infer<typeof ReplyAuthorSchema>;
+
+/**
+ * Identity of the specific AI agent that authored a record (#1123 M3, ADR-039).
+ *
+ * Present ONLY on agent-authored records the local-model collaborator loop
+ * writes (`author: "claude"` annotations/replies/chat messages); absent for
+ * real Claude-via-MCP writes and everything that predates M3. A self-contained
+ * snapshot — NOT a reference into the mutable Models registry — so it survives a
+ * registry edit/delete and freezes who authored at the time. Carries NO secret:
+ * the closed `provider` enum plus the user-chosen `displayName` only, never an
+ * endpoint or key ref. See {@link AgentIdentitySchema} for the runtime shape.
+ */
+export interface AgentIdentity {
+  provider: ModelProvider;
+  displayName: string;
+}
 
 // --- Reply types ---
 
@@ -100,12 +135,24 @@ export interface AnnotationReply {
    * NOT live hiding (that is server-authoritative, mode-based).
    */
   heldInSolo?: boolean;
+  /**
+   * The specific AI agent that authored this reply (#1123 M3). Set only by the
+   * local-model collaborator loop; absent on user, import, and real-Claude
+   * replies. Drives the byline; the parent's `author` still governs privacy.
+   */
+  agentIdentity?: AgentIdentity;
 }
 
 // --- Annotation types ---
 
 interface AnnotationBase {
   id: string;
+  /**
+   * Author ROLE, not literal identity: `"claude"` marks any AI agent (real
+   * Claude via MCP *or* the local-model collaborator loop), which is what every
+   * privacy/gating branch keys on. The specific agent, when it's a local model,
+   * is carried separately in {@link agentIdentity} (#1123 M3).
+   */
   author: "user" | "claude" | "import";
   range: DocumentRange;
   /** CRDT-anchored range that survives edits. Falls back to `range` if absent. */
@@ -140,6 +187,14 @@ interface AnnotationBase {
    * across save → re-open (deterministic `importAnnotationId` dedup).
    */
   importSource?: { author: string; file: string; commentId?: string };
+  /**
+   * The specific AI agent that authored this annotation (#1123 M3). Set only by
+   * the local-model collaborator loop on its `author: "claude"` comments; absent
+   * on user/import annotations and real Claude-via-MCP writes. Drives the card
+   * byline. MUST be listed in `sanitizeAnnotation`'s allowlist or it is stripped
+   * on every Claude-facing read (see `src/shared/sanitize.ts`).
+   */
+  agentIdentity?: AgentIdentity;
 }
 
 /**
@@ -405,6 +460,13 @@ export interface ChatMessage {
   anchor?: CapturedAnchor;
   replyTo?: string;
   read: boolean;
+  /**
+   * The specific AI agent that authored this message (#1123 M3). Set only by the
+   * local-model collaborator's streamed reply; absent on user messages and real
+   * Claude (`tandem_reply`). Chat is read raw from the Y.Map (NOT allowlist-
+   * sanitized), so this needs no sanitize change to reach the byline.
+   */
+  agentIdentity?: AgentIdentity;
 }
 
 /** Server-to-client ephemeral notification (toast). Not persisted via CRDT. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,6 +32,17 @@ export const ModelProviderSchema = z.enum(
   VALID_MODEL_PROVIDERS as unknown as [ModelProvider, ...ModelProvider[]],
 );
 /**
+ * Max length of an agent `displayName` as persisted on a durable record. The
+ * Models registry's own `displayName` is more permissive (client caps at 256,
+ * the server `ModelsEntrySchema` is unbounded), so the resolver that builds an
+ * `agentIdentity` snapshot MUST clamp to this bound — otherwise an over-long
+ * registry name fails this schema on the durable round-trip and takes the whole
+ * annotations file down with it (`parseAnnotationDoc` → corrupt). Shared here so
+ * the clamp site and the schema can't drift (mirrors why `ModelProviderSchema`
+ * is shared). See `resolveLocalModelConfig`.
+ */
+export const AGENT_DISPLAY_NAME_MAX = 120;
+/**
  * Runtime schema for {@link AgentIdentity}. Bounded `displayName` (the value is
  * user-chosen in the Models registry); `provider` is the closed enum. Used by
  * the durable annotation/reply record schemas so a persisted identity
@@ -39,7 +50,7 @@ export const ModelProviderSchema = z.enum(
  */
 export const AgentIdentitySchema = z.object({
   provider: ModelProviderSchema,
-  displayName: z.string().max(120),
+  displayName: z.string().max(AGENT_DISPLAY_NAME_MAX),
 });
 export const AnnotationActionSchema = z.enum(["accept", "dismiss"]);
 export const ExportFormatSchema = z.enum(["markdown", "json"]);

--- a/tests/client/annotation-card-helpers.test.ts
+++ b/tests/client/annotation-card-helpers.test.ts
@@ -1,5 +1,34 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { formatRelativeTime } from "../../src/client/panels/annotation-card-helpers";
+import {
+  formatRelativeTime,
+  getAuthorLabel,
+} from "../../src/client/panels/annotation-card-helpers";
+
+// #1123 M3: the agent byline prefers the specific authoring model's
+// `agentIdentity.displayName`, then the active-model family label, then a
+// neutral fallback. While BYO models are dark, agentIdentity is always absent,
+// so the label must be byte-identical to the pre-M3 (family-or-fallback) form.
+describe("getAuthorLabel — agent byline (#1123 M3)", () => {
+  const identity = { provider: "local-ollama" as const, displayName: "Qwen 2.5" };
+
+  it("prefers agentIdentity.displayName over the family label for a claude author", () => {
+    expect(getAuthorLabel("claude", "Claude", identity)).toBe("Qwen 2.5");
+  });
+
+  it("falls back to the family label when agentIdentity is absent (dark / real Claude)", () => {
+    expect(getAuthorLabel("claude", "Claude")).toBe("Claude");
+    expect(getAuthorLabel("claude", "Claude", undefined)).toBe("Claude");
+  });
+
+  it("falls back to 'Assistant' when neither identity nor family is given", () => {
+    expect(getAuthorLabel("claude")).toBe("Assistant");
+  });
+
+  it("ignores agentIdentity for non-agent authors (roles, not the agent)", () => {
+    expect(getAuthorLabel("user", "Claude", identity)).toBe("You");
+    expect(getAuthorLabel("import", "Claude", identity)).toBe("Imported");
+  });
+});
 
 // `formatRelativeTime` reads `Date.now()`, so freeze the clock and express each
 // case as an offset from "now". The two branch boundaries (minute→hour at 60min,

--- a/tests/client/reply-thread.test.ts
+++ b/tests/client/reply-thread.test.ts
@@ -70,6 +70,29 @@ describe("ReplyThread — A13 disclosure", () => {
     expect(container.textContent).toContain("Existing reply");
   });
 
+  it("#1123 M3: a claude reply with agentIdentity bylines with the model name, not the family label", async () => {
+    const replies = [
+      makeReply({
+        text: "local model reply",
+        agentIdentity: { provider: "local-ollama", displayName: "Qwen 2.5" },
+      }),
+    ];
+    const { container } = render(ReplyThread, {
+      props: {
+        annotation: makeAnnotation(),
+        replies,
+        isPending: false,
+        isEditing: false,
+      },
+    });
+    await fireEvent.click(
+      container.querySelector("[data-testid='reply-toggle-annotation-1']") as Element,
+    );
+    // The specific model name renders; the generic family fallback ("Assistant"
+    // when no model is configured in this test's store) does not.
+    expect(container.textContent).toContain("Qwen 2.5");
+  });
+
   it("pluralises the toggle count", () => {
     const replies = [makeReply({ id: "r1" }), makeReply({ id: "r2" })];
     const { container } = render(ReplyThread, {

--- a/tests/server/annotations/schema.test.ts
+++ b/tests/server/annotations/schema.test.ts
@@ -5,6 +5,7 @@ import {
   type AnnotationDocV1,
   AnnotationRecordSchemaV1,
   type AnnotationRecordV1,
+  AnnotationReplyRecordSchemaV1,
   migrateToV1,
   parseAnnotationDoc,
   SCHEMA_VERSION,
@@ -577,6 +578,50 @@ describe("AnnotationRecordSchemaV1 — per-record shape", () => {
       const paths = result.error.issues.map((i) => i.path.join("."));
       expect(paths).toContain("directedAt");
     }
+  });
+});
+
+describe("AnnotationReplyRecordSchemaV1 — agentIdentity (#1123 M3)", () => {
+  const baseReply = {
+    id: "rep_ai",
+    annotationId: "ann_1_abc",
+    author: "claude" as const,
+    text: "a local-model reply",
+    timestamp: 1_700_000_000_100,
+    rev: 0,
+  };
+
+  it("accepts and round-trips an agentIdentity on a reply record", () => {
+    const withIdentity = {
+      ...baseReply,
+      agentIdentity: { provider: "local-ollama", displayName: "Qwen 2.5" },
+    };
+    expect(AnnotationReplyRecordSchemaV1.safeParse(withIdentity).success).toBe(true);
+    const parsed = parseAnnotationDoc({ ...validDoc, replies: [withIdentity] });
+    if (!parsed.ok) throw new Error("expected success");
+    expect((parsed.doc.replies[0] as Record<string, unknown>).agentIdentity).toEqual(
+      withIdentity.agentIdentity,
+    );
+  });
+
+  it("rejects a reply agentIdentity with an unknown provider", () => {
+    const bad = {
+      ...baseReply,
+      agentIdentity: { provider: "not-a-provider", displayName: "x" },
+    };
+    expect(AnnotationReplyRecordSchemaV1.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejects a reply agentIdentity.displayName over the durable bound (corruption guard)", () => {
+    const bad = {
+      ...baseReply,
+      agentIdentity: { provider: "local-ollama", displayName: "M".repeat(121) },
+    };
+    expect(AnnotationReplyRecordSchemaV1.safeParse(bad).success).toBe(false);
+  });
+
+  it("validates a reply with no agentIdentity (backward-compat / dark)", () => {
+    expect(AnnotationReplyRecordSchemaV1.safeParse(baseReply).success).toBe(true);
   });
 });
 

--- a/tests/server/annotations/schema.test.ts
+++ b/tests/server/annotations/schema.test.ts
@@ -538,6 +538,34 @@ describe("AnnotationRecordSchemaV1 — per-record shape", () => {
     expect(ann.relRange).toEqual(withRel.relRange);
   });
 
+  it("accepts and round-trips an agentIdentity (#1123 M3)", () => {
+    const withIdentity = {
+      ...baseAnnotation,
+      agentIdentity: { provider: "local-ollama", displayName: "Qwen 2.5" },
+    };
+    const result = AnnotationRecordSchemaV1.safeParse(withIdentity);
+    expect(result.success).toBe(true);
+    const parsed = parseAnnotationDoc({ ...validDoc, annotations: [withIdentity] });
+    if (!parsed.ok) throw new Error("expected success");
+    expect((parsed.doc.annotations[0] as Record<string, unknown>).agentIdentity).toEqual(
+      withIdentity.agentIdentity,
+    );
+  });
+
+  it("rejects an agentIdentity with an unknown provider (#1123 M3)", () => {
+    const bad = {
+      ...baseAnnotation,
+      agentIdentity: { provider: "not-a-provider", displayName: "x" },
+    };
+    const result = AnnotationRecordSchemaV1.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("validates a record with no agentIdentity (backward-compat / dark)", () => {
+    const result = AnnotationRecordSchemaV1.safeParse(baseAnnotation);
+    expect(result.success).toBe(true);
+  });
+
   it("rejects a record that still carries directedAt (ADR-027 regression)", () => {
     // Production paths (parseAnnotationDoc, migrateToV1) strip directedAt via
     // migrateFlagAndDirectedAt before reaching safeParse. This test verifies

--- a/tests/server/local-model/collaborator.test.ts
+++ b/tests/server/local-model/collaborator.test.ts
@@ -214,6 +214,10 @@ describe("collaborator — dispatch", () => {
     expect(msgs[0].author).toBe("claude");
     expect(msgs[0].text).toBe("Sure, done.");
     expect(msgs[0].documentId).toBe("doc-dispatch");
+    // #1123 M3: the streamed reply is bylined with the config's identity — proves
+    // collaborator.ts threads config.agentIdentity into the sink (not just that
+    // appendClaudeChatMessage can carry one, which the unit test covers).
+    expect(msgs[0].agentIdentity).toEqual(CONFIG.agentIdentity);
   });
 
   it("appends the selection context to the task", async () => {

--- a/tests/server/local-model/collaborator.test.ts
+++ b/tests/server/local-model/collaborator.test.ts
@@ -44,6 +44,7 @@ const CONFIG: LocalModelConfig = {
   endpoint: "http://127.0.0.1:11434",
   modelId: "m",
   transport: "v1",
+  agentIdentity: { provider: "local-ollama", displayName: "Test Model" },
 };
 
 function cleanResult(finalContent: string): LoopResult {
@@ -802,6 +803,22 @@ describe("updateClaudeChatMessage — shape preservation", () => {
   it("is a no-op when the message id is absent", () => {
     expect(() => updateClaudeChatMessage("does-not-exist", "x")).not.toThrow();
     expect(chatMap().has("does-not-exist")).toBe(false);
+  });
+
+  it("#1123 M3: stamps agentIdentity on append and preserves it across a streamed update", () => {
+    const identity = { provider: "local-ollama" as const, displayName: "Qwen 2.5" };
+    const id = appendClaudeChatMessage("partial", { documentId: "d3", agentIdentity: identity });
+    expect((chatMap().get(id) as ChatMessage).agentIdentity).toEqual(identity);
+    // The `{...existing, text}` re-set must carry the byline through every delta.
+    updateClaudeChatMessage(id, "partial + more");
+    const after = chatMap().get(id) as ChatMessage;
+    expect(after.text).toBe("partial + more");
+    expect(after.agentIdentity).toEqual(identity);
+  });
+
+  it("#1123 M3: omits agentIdentity when none is passed (tandem_reply / dark byte-identical)", () => {
+    const id = appendClaudeChatMessage("plain", { documentId: "d4" });
+    expect((chatMap().get(id) as ChatMessage).agentIdentity).toBeUndefined();
   });
 });
 

--- a/tests/server/local-model/loop.test.ts
+++ b/tests/server/local-model/loop.test.ts
@@ -4,7 +4,12 @@ import { runLoop } from "../../../src/server/local-model/loop.js";
 import { TOOLS } from "../../../src/server/local-model/tools.js";
 import { makeMarkdownDoc } from "../../helpers/ydoc-factory.js";
 
-const CONFIG = { endpoint: "http://127.0.0.1:11434", modelId: "m", transport: "v1" } as const;
+const CONFIG = {
+  endpoint: "http://127.0.0.1:11434",
+  modelId: "m",
+  transport: "v1",
+  agentIdentity: { provider: "local-ollama", displayName: "Test Model" },
+} as const;
 
 function v1ToolCall(name: string): Response {
   return new Response(

--- a/tests/server/local-model/loop.test.ts
+++ b/tests/server/local-model/loop.test.ts
@@ -2,7 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type * as Y from "yjs";
 import { runLoop } from "../../../src/server/local-model/loop.js";
 import { TOOLS } from "../../../src/server/local-model/tools.js";
-import { makeMarkdownDoc } from "../../helpers/ydoc-factory.js";
+import type { Annotation } from "../../../src/shared/types.js";
+import { getAnnotationsMap, makeMarkdownDoc } from "../../helpers/ydoc-factory.js";
 
 const CONFIG = {
   endpoint: "http://127.0.0.1:11434",
@@ -106,6 +107,22 @@ describe("runLoop — metric tallies", () => {
     stubFetch(() => v1ToolCallArgs("reply_to_annotation", { annotation_id: "nope", text: "hi" }));
     const r = await runLoop(base({ maxToolCalls: 1, maxTurns: 99 }));
     expect(r.metrics.replyFailures).toBe(1);
+  });
+});
+
+describe("runLoop — agent identity threading (#1123 M3)", () => {
+  it("stamps config.agentIdentity onto an annotation the loop produces", async () => {
+    // The PRODUCTION path is runLoop → dispatch (not a direct dispatch call).
+    // Deleting `agentIdentity: config.agentIdentity` in loop.ts must fail here.
+    stubFetch(() =>
+      v1ToolCallArgs("comment_on_quote", { quoted_text: "body text here", comment: "x" }),
+    );
+    const opts = base({ maxToolCalls: 1, maxTurns: 99 });
+    await runLoop(opts);
+    const map = getAnnotationsMap(opts.ydoc);
+    expect(map.size).toBe(1);
+    const ann = [...map.values()][0] as Annotation;
+    expect(ann.agentIdentity).toEqual(CONFIG.agentIdentity);
   });
 });
 

--- a/tests/server/local-model/tools.test.ts
+++ b/tests/server/local-model/tools.test.ts
@@ -331,6 +331,26 @@ describe("dispatch — agent identity stamping (#1123 M3)", () => {
     const ann = getAnnotationsMap(doc).get(id) as Annotation;
     expect(ann.agentIdentity).toBeUndefined();
   });
+
+  it("leaves agentIdentity absent on a replacement and a reply when ctx has none", () => {
+    doc = makeMarkdownDoc(FIXTURE);
+    const repl = dispatch(
+      "propose_replacement",
+      { quoted_text: "the first phase", suggested_text: "phase one", rationale: "r" },
+      { ydoc: doc },
+    );
+    const replId = (repl.result as { annotation_id: string }).annotation_id;
+    expect((getAnnotationsMap(doc).get(replId) as Annotation).agentIdentity).toBeUndefined();
+
+    const reply = dispatch(
+      "reply_to_annotation",
+      { annotation_id: replId, text: "t" },
+      { ydoc: doc },
+    );
+    const replyId = (reply.result as { reply_id: string }).reply_id;
+    const stored = doc.getMap(Y_MAP_ANNOTATION_REPLIES).get(replyId) as { agentIdentity?: unknown };
+    expect(stored.agentIdentity).toBeUndefined();
+  });
 });
 
 describe("dispatch — malformed input", () => {

--- a/tests/server/local-model/tools.test.ts
+++ b/tests/server/local-model/tools.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import type * as Y from "yjs";
 import { dispatch, TOOLS } from "../../../src/server/local-model/tools.js";
+import { Y_MAP_ANNOTATION_REPLIES } from "../../../src/shared/constants.js";
 import { MCP_ORIGIN } from "../../../src/shared/origins.js";
 import type { Annotation } from "../../../src/shared/types.js";
 import { getAnnotationsMap, makeMarkdownDoc } from "../../helpers/ydoc-factory.js";
@@ -269,6 +270,66 @@ describe("dispatch — license gate", () => {
       { ydoc: doc, isLicenseRestricted: () => false },
     );
     expect((out.result as { ok?: boolean }).ok).toBe(true);
+  });
+});
+
+describe("dispatch — agent identity stamping (#1123 M3)", () => {
+  const identity = { provider: "local-ollama" as const, displayName: "Qwen 2.5" };
+
+  it("stamps agentIdentity on a comment when ctx carries one", () => {
+    doc = makeMarkdownDoc(FIXTURE);
+    const out = dispatch(
+      "comment_on_quote",
+      { quoted_text: "the first phase", comment: "x" },
+      { ydoc: doc, agentIdentity: identity },
+    );
+    const id = (out.result as { annotation_id: string }).annotation_id;
+    const ann = getAnnotationsMap(doc).get(id) as Annotation;
+    expect(ann.agentIdentity).toEqual(identity);
+  });
+
+  it("stamps agentIdentity on a replacement", () => {
+    doc = makeMarkdownDoc(FIXTURE);
+    const out = dispatch(
+      "propose_replacement",
+      { quoted_text: "the first phase", suggested_text: "phase one", rationale: "shorter" },
+      { ydoc: doc, agentIdentity: identity },
+    );
+    const id = (out.result as { annotation_id: string }).annotation_id;
+    const ann = getAnnotationsMap(doc).get(id) as Annotation;
+    expect(ann.agentIdentity).toEqual(identity);
+    expect(ann.suggestedText).toBe("phase one");
+  });
+
+  it("stamps agentIdentity on a reply", () => {
+    doc = makeMarkdownDoc(FIXTURE);
+    const created = dispatch(
+      "comment_on_quote",
+      { quoted_text: "the first phase", comment: "needs detail" },
+      { ydoc: doc, agentIdentity: identity },
+    );
+    const annotationId = (created.result as { annotation_id: string }).annotation_id;
+    const out = dispatch(
+      "reply_to_annotation",
+      { annotation_id: annotationId, text: "detail here" },
+      { ydoc: doc, agentIdentity: identity },
+    );
+    const replyId = (out.result as { reply_id: string }).reply_id;
+    const replies = doc.getMap(Y_MAP_ANNOTATION_REPLIES);
+    const reply = replies.get(replyId) as { agentIdentity?: unknown };
+    expect(reply.agentIdentity).toEqual(identity);
+  });
+
+  it("leaves agentIdentity absent when ctx has none (byte-identical to pre-M3 / MCP path)", () => {
+    doc = makeMarkdownDoc(FIXTURE);
+    const out = dispatch(
+      "comment_on_quote",
+      { quoted_text: "the first phase", comment: "x" },
+      { ydoc: doc },
+    );
+    const id = (out.result as { annotation_id: string }).annotation_id;
+    const ann = getAnnotationsMap(doc).get(id) as Annotation;
+    expect(ann.agentIdentity).toBeUndefined();
   });
 });
 

--- a/tests/server/models/resolver.test.ts
+++ b/tests/server/models/resolver.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../src/server/models/registry.js";
 import { createModelStore } from "../../../src/server/models/store.js";
 import type { ModelsEntry, ModelsFile } from "../../../src/shared/models/contract.js";
+import { AgentIdentitySchema } from "../../../src/shared/types.js";
 
 const local: ModelsEntry = {
   id: "m-local",
@@ -125,5 +126,19 @@ describe("resolveLocalModelConfig (via server-side registry)", () => {
       provider: "local-ollama",
       displayName: "Qwen 2.5 (14B)",
     });
+  });
+
+  it("clamps an over-long displayName to the durable bound (#1123 M3 corruption guard)", async () => {
+    // The registry permits a longer displayName (client ≤256, server unbounded)
+    // than AgentIdentitySchema (120). Without the clamp, a stamped over-long name
+    // fails AnnotationRecordSchemaV1 on reload and quarantines the WHOLE
+    // annotations file. The resolver is the sole builder, so it must clamp.
+    const longName = "M".repeat(200);
+    await persistModelsFile(fileWith([{ ...local, displayName: longName }], "m-local"));
+    const config = resolveLocalModelConfig();
+    expect(config?.agentIdentity?.displayName.length).toBe(120);
+    expect(config?.agentIdentity?.displayName).toBe("M".repeat(120));
+    // And the clamped value validates against the durable schema.
+    expect(AgentIdentitySchema.safeParse(config?.agentIdentity).success).toBe(true);
   });
 });

--- a/tests/server/models/resolver.test.ts
+++ b/tests/server/models/resolver.test.ts
@@ -60,6 +60,8 @@ describe("resolveLocalModelConfig (via server-side registry)", () => {
       endpoint: "http://127.0.0.1:11434",
       modelId: "qwen2.5:14b-instruct",
       transport: "v1",
+      // #1123 M3: identity carried through for the byline.
+      agentIdentity: { provider: "local-ollama", displayName: "Local" },
     });
   });
 
@@ -109,6 +111,19 @@ describe("resolveLocalModelConfig (via server-side registry)", () => {
       endpoint: "http://127.0.0.1:11434",
       modelId: "qwen2.5:14b-instruct",
       transport: "v1",
+      agentIdentity: { provider: "local-ollama", displayName: "Local" },
+    });
+  });
+
+  it("carries the resolved entry's provider + displayName (#1123 M3 byline source)", async () => {
+    // The identity previously read-and-discarded is now surfaced so the loop can
+    // stamp `agentIdentity`. Distinct displayName so a hardcoded default can't
+    // pass this by accident.
+    await persistModelsFile(fileWith([{ ...local, displayName: "Qwen 2.5 (14B)" }], "m-local"));
+    const config = resolveLocalModelConfig();
+    expect(config?.agentIdentity).toEqual({
+      provider: "local-ollama",
+      displayName: "Qwen 2.5 (14B)",
     });
   });
 });

--- a/tests/shared/sanitize-agent-identity.test.ts
+++ b/tests/shared/sanitize-agent-identity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { SanitizationEvent } from "../../src/shared/sanitize";
+import { sanitizeAnnotation } from "../../src/shared/sanitize";
+import type { Annotation } from "../../src/shared/types";
+
+// #1123 M3: the `agentIdentity` byline field must survive `sanitizeAnnotation`.
+// sanitize is a strict ALLOWLIST — every Claude-facing annotation read routes
+// through it (client yjsSync, server collectAnnotations, addReplyToAnnotation's
+// parent read). If the allowlist ever drops the field, the provider byline
+// silently no-ops on the client even though the loop stamped it. This is the
+// one load-bearing gap two plan reviewers independently flagged.
+
+const baseAnn = {
+  id: "ai-test",
+  author: "claude" as const,
+  range: { from: 0, to: 5 },
+  content: "a local-model comment",
+  status: "pending" as const,
+  timestamp: 1000,
+};
+
+const identity = { provider: "local-ollama" as const, displayName: "Qwen 2.5" };
+
+function sanitize(ann: object): Annotation {
+  const events: SanitizationEvent[] = [];
+  return sanitizeAnnotation(ann as Annotation, (e) => events.push(e));
+}
+
+describe("#1123 M3: agentIdentity survives sanitizeAnnotation", () => {
+  it("preserves agentIdentity on an agent comment", () => {
+    const result = sanitize({ ...baseAnn, type: "comment", agentIdentity: identity });
+    expect(result.agentIdentity).toEqual(identity);
+  });
+
+  it("leaves agentIdentity absent when the input has none (dark-safe: no phantom)", () => {
+    const result = sanitize({ ...baseAnn, type: "comment" });
+    expect(result.agentIdentity).toBeUndefined();
+  });
+
+  it("survives the suggestion→comment migration (replacement records carry it)", () => {
+    // propose_replacement stores a comment with suggestedText; a legacy
+    // `suggestion` record takes the early-return migration path, which spreads
+    // `base` — the field must ride through that branch too.
+    const result = sanitize({
+      ...baseAnn,
+      type: "suggestion",
+      content: JSON.stringify({ newText: "x", reason: "y" }),
+      agentIdentity: identity,
+    });
+    expect(result.type).toBe("comment");
+    expect(result.agentIdentity).toEqual(identity);
+  });
+});


### PR DESCRIPTION
## #1123 M3 — Provider-keyed authorship byline (ships DARK)

Stacked on **M2b (#1221)** → M2a (#1220); retarget to `master` once those merge. Phase **M3** of the local-model collaborator (#1123, ADR-039).

The collaborator loop stamped its annotation/reply/chat writes `author:"claude"` — indistinguishable from real Claude — and the byline read the user's **active** model, not the one that authored the record. M3 carries the authoring agent's identity **on the record** so the byline names the specific model. **Every change is byte-identical while dark** (`BYO_MODELS_ENABLED=false`): the loop is the only writer that sets the field, so for all real-Claude and pre-M3 records it's absent and every read falls back exactly to today.

### Design (Option B — reviewed 3× in prose before code)
Keep `author:"claude"` as the agent-**role** marker (every privacy/gating branch and the `assertNever` switch stay untouched) and add an optional `agentIdentity: { provider, displayName }` to `AnnotationBase` / `AnnotationReply` / `ChatMessage`. A self-contained snapshot (not a registry ref) so it survives a registry edit and freezes who authored at the time. Rejected Option A (new `author` union variant): ~20 role-branch sites incl. ADR-027 privacy, and it still wouldn't say *which* model.

### What landed
- **Types + runtime:** `AgentIdentity` + `AgentIdentitySchema` in `shared/types.ts`; the provider enum is now a single shared `ModelProviderSchema` (server `models/schema.ts` imports it instead of re-constructing).
- **Identity source:** `resolveLocalModelConfig` builds the identity **once** and carries it on `LocalModelConfig` (the provider/displayName it previously read and discarded); both write paths read `config.agentIdentity` whole.
- **Threading (all optional + defaulted → MCP path byte-identical):** annotations/replies via `DispatchCtx.agentIdentity` → `createAnnotation` extras / `addReplyToAnnotation`'s new param; chat via `appendClaudeChatMessage` opts (the streamed-delta re-set carries it through).
- **Load-bearing fix:** `sanitizeAnnotation` is a strict **allowlist** and every Claude-facing annotation read routes through it — `agentIdentity` is added to the base allowlist, else the byline silently no-ops on the client. Durable record schemas list it explicitly.
- **Reads:** `getAuthorLabel` (card), `ChatPanel` per-message byline, agent-comment aria-label — all prefer `agentIdentity.displayName`, else the active family label, else `"Assistant"`.

### `/simplify` applied
Deduped the provider Zod enum (was constructed in two files) and refactored the config to carry a **prebuilt** `agentIdentity` rather than two flat fields re-bundled at two sites (also removes a per-dispatch allocation). Kept the `annotateFromQuote` merge param (centralizes the merge) and the 3 inline `?? family` fallbacks (three differently-shaped call sites, no pre-existing helper).

### Testing
New/extended: sanitize allowlist round-trip, durable-schema round-trip + unknown-provider reject + backward-compat, `getAuthorLabel` byline precedence, dispatch identity-stamping (comment/replacement/reply) + absent-when-none, resolver surfaces the prebuilt identity, chat append/update preserves the byline. Typecheck + svelte-check + biome clean; no new token violations. Client 1752 green; server local-model/models/annotations/shared suites green.

### Out of scope (M4)
All per-agent decoration **color** (card dot / comment underline / margin leader / AuthorshipRange) as one coherent unit; the flag flip; accept/dismiss notification routing to the authoring agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
