### PR TITLE
feat(local-model): per-agent decoration color + first-run polish (#1123 M4)

### DIFF
--- a/docs/plans/1123-m4-dark-mechanism.md
+++ b/docs/plans/1123-m4-dark-mechanism.md
@@ -1,0 +1,96 @@
+# 1123 M4 — Finish the local-model dark mechanism
+
+**Status:** dark mechanism IMPLEMENTED (unmerged, Bryan-gated) · **Agent feedback incorporated** (4 adversarial plan reviews: design / dark-safety / scope / test — 2026-07-22) · **Branch:** `feat/1123-m4-dark-mechanism` off M3 head (`fc179b1`, PR #1222) · stacks M2a #1220 ← M2b #1221 ← M3 #1222 ← **M4**.
+
+**What shipped in this PR (all dark, byte-identical):** `agentColor()` per-provider token helper + 4 new `--tandem-agent-*` tokens; per-agent color on card dot / comment underline / margin leader / reply byline / chat author / peek dot; chip loading-gate (extracted `resolveDefaultModelChip`); first-run picker decoupled from the tutorial + persisted dismissal (extracted `resolveModelFirstRunNeeded`); (d) AuthorshipRange-zero tripwire; skip-guarded E2E. **What remains for M4-true-completion (out of this PR):** the `BYO_MODELS_ENABLED` flag flip (Bryan's v1.0 call) and the two documented flip-time deliverables — accept/dismiss per-agent routing/delivery and the E2E stub-server loop harness. CLAUDE.md Status + the `annotation-author-dot-{id}` testid-registry line are deferred to merge (the working tree carries an unrelated uncommitted DS edit to CLAUDE.md).
+
+## The guarantee (unchanged from M1a–M3)
+
+The track ships **DARK** behind `BYO_MODELS_ENABLED` — a hard literal `const false` at `src/shared/constants.ts:18`, **no env/define/function seam** (a client-bundled `define` read crashes the vite bundle; rejected in M2b). The flag flips **only** at v1.0, and that flip is **explicitly Bryan's launch call (ADR-039)** — **out of scope** for this or any autonomous PR.
+
+Every change is **runtime byte-identical while dark.** The mechanism activates only when a record carries `agentIdentity` (the optional `{provider, displayName}` snapshot from M3), set **solely by the flag-gated collaborator loop** — so when dark, no record carries it and every new branch falls through to the exact current color/behavior. Verified airtight at the data level by the dark-safety + scope reviews: `agentIdentity` is set only at the loop's `dispatch`/chat writes, always on `author:"claude"` `type:"comment"`/reply/chat records, never on a note; `sanitizeAnnotation` only passes it through, never adds it.
+
+**M4's target:** implement the remaining dark mechanism so the *only* step left for v1.0 is flipping the one const.
+
+## Color design — per-`provider` CSS tokens (revised per design review)
+
+`provider` is a **closed 5-enum** (`src/shared/models/contract.ts:35`: `anthropic | openai | gemini | local-ollama | local-llamacpp`), so per-agent color keys on it via **CSS tokens**, not a hashed inline color. This dissolves three problems the hashed approach had: theme adaptation is free (tokens carry light/dark values like `--tandem-author-*`, which lift ~+0.09 L for dark — they are *not* single-color), the token lint is sidestepped, and it's rename-stable (`agentIdentity` is a frozen snapshot, so hashing the editable `displayName` would repaint one agent across a rename). Same-provider collision is a non-issue: the M3 byline already distinguishes agents textually and the loop is single-stream (ADR-039).
+
+`src/client/utils/agent-color.ts`:
+```ts
+import type { AgentIdentity, ModelProvider } from "../../shared/types.js";
+const AGENT_COLOR_VARS: Record<ModelProvider, string> = {
+  anthropic: "var(--tandem-author-claude)",   // Claude family → existing coral (reuse, no new token)
+  openai: "var(--tandem-agent-openai)",
+  gemini: "var(--tandem-agent-gemini)",
+  "local-ollama": "var(--tandem-agent-local-ollama)",
+  "local-llamacpp": "var(--tandem-agent-local-llamacpp)",
+};
+export function agentColor(identity?: AgentIdentity): string {
+  if (!identity) return "var(--tandem-author-claude)"; // exact current literal ⇒ byte-identical dark
+  return AGENT_COLOR_VARS[identity.provider] ?? "var(--tandem-author-claude)";
+}
+```
+New tokens `--tandem-agent-{openai,gemini,local-ollama,local-llamacpp}` in `index.html` `:root` + `[data-theme="dark"]` blocks, hand-tuned like `--tandem-author-claude` (distinct hues; local-* tuned clearly apart from the coral so a local agent reads as visually distinct from Claude-via-MCP). Only `local-*` are exercised by the loop today (cloud BYO is v1.1); the full 5-entry map is cheap and bounded.
+
+## Scope — decided, with rationale
+
+### IN — per-agent decoration/name color on the reachable surfaces
+All gate `agentColor` **inside the existing `claude` branch**; `identity === undefined` → exact `var(--tandem-author-claude)` ⇒ byte-identical dark. Tests assert the **full** emitted style string/DOM equals today (not just the color token — the underline interpolates the token mid-string).
+
+- **(a) Card dot** — `AnnotationCardHeader.svelte:40-42` `dotColor` `$derived`, claude branch → `agentColor(annotation.agentIdentity)`. **Prereq:** the dot span (~:91) has no stable selector — add a `data-testid` so a render test can read its `style`.
+- **(b) Comment underline** — `annotation.ts:159` (plain-comment claude branch; `ann.agentIdentity` already in scope at :166). Swap the token in the inline `style`.
+- **(c) Margin leader** — `marginLeaderGeometry.ts` `leaderColorForAuthor` + `MarginColumn.svelte:272`. Add a **required** `agentIdentity: AgentIdentity | undefined` param (required so a call site passing only `author` fails typecheck — converts a silent regression to a compile error), claude branch → `agentColor`.
+- **(e) Reply byline color** — `CommentThread.svelte` `.ct-author.is-claude` / `.ct-author-dot--claude` (~:84-102). Replies carry `agentIdentity` and the name already renders (M3); convert the class-driven claude color to an inline `agentColor(reply.agentIdentity)` so color follows the name.
+- **(f) Chat author color** — `ChatPanel.svelte` (~:269,:274). Chat carries `agentIdentity`, name renders (M3); same class→inline treatment.
+- **(g) Peek-strip dot** — `PeekStrip.svelte:169-170` `.peek-dot.claude`, **if** a trivial dot recolor; assess at implementation — document-exclude if it needs disproportionate restructuring.
+
+### EXCLUDED — with concrete rationale (documented so un-excluding can't silently ship a hole)
+- **(d) AuthorshipRange per-agent color — unreachable, not deferred.** The loop's dispatch (`tools.ts:289-344`) is reads + `comment_on_quote` + `propose_replacement` + `reply_to_annotation`; it **never writes document body text** (grep `authorship` in `src/server/local-model/` = zero). `propose_replacement` is a *comment carrying `suggestedText`*, not body text; when a human accepts it, `applySuggestion` attributes the inserted text `author:"user"` (`useAnnotationReview.svelte.ts` → `authorship.ts:276`), and the server resolve path is a pure status flip. So the loop emits **zero** `AuthorshipRange` entries. `AuthorshipRange` also carries only `author:"user"|"claude"` (no `agentIdentity`) and is CSS-attribute-driven → coloring needs a durable-schema addition + CSS→inline conversion for a path with no data. **Tripwire test** (`tools.test.ts`): assert the dispatch tool set writes no `AuthorshipRange`, so adding a body-edit tool later breaks a test pointing here.
+- **Suggestion underline stays violet** — a claude comment *with* `suggestedText` renders the `--tandem-suggestion` violet branch (`annotation.ts:144-154`), author-agnostic **by design** (M3's byline didn't touch it either). So an agent's `propose_replacement` shows an agent-colored card dot but a violet underline — intentional, not an oversight.
+- **Claude focus-paragraph gutter** (`--tandem-claude-focus-bg`) — unreachable: the loop never sets typing-presence/focus awareness (`withTypingPresence` is MCP-only; the collaborator writes only the CTRL_ROOM chat map). Same class as (d); revisit only if the loop ever sets focus presence.
+
+### DEFERRED to flip-time (documented obligations, NOT built now)
+- **Accept/dismiss routing to the authoring agent — dropped from M4.** Two reviews showed this is unbuildable-with-meaning dark: the collaborator subscription **ignores accept/dismiss entirely** (`collaborator.ts:298-310` — it wakes only on `chat:message`), ADR-039 is **single-agent** so "route to *the* authoring agent" has no multi-agent target, and the on-accept behavior is undefined. The earlier plan's "add a `provider` payload now to avoid a later wire change" justification is **wrong** — the accept/dismiss event is a *transient* channel event (not durable, not a versioned wire schema), so adding a meta field at flip costs nothing (consumers ignore unknown keys, no migration). Building it now is speculative surface with zero consumer. **Left as a named flip-time deliverable**, treated exactly like (d)'s "revisit" discipline. `formatEventContent`/`formatEventMeta` stay untouched this PR.
+- **E2E stub-server loop harness** — the M4 E2E (below) is a skip-guarded skeleton that, even at flip, only covers the byline/color *rendering* path against injected records. Standing up a stub OpenAI-compatible server to drive the loop end-to-end (a real model turn → annotation) remains a **flip-time deliverable**; named here so it isn't silently assumed done.
+
+### OUT — the flag flip. Bryan's v1.0 call.
+
+### IN — titlebar chip loading-gate
+`defaultModelLabel` (`App.svelte:656-661`) ignores `models.loading` → empty→label pop on a lit boot (Settings→Models already gates on loading; the chip is the asymmetric gap). **Extract** the derivation to a pure `resolveDefaultModelChip({ defaultModelId, models, loading })` returning `null` while `loading` — inline-in-App is untestable, and extraction lets a unit test prove the pop is gone. Keep the `BYO_MODELS_ENABLED ? … : null` prop wrapper (`App.svelte:1881`) so dark stays `null`.
+
+### IN — first-run choreography decouple
+`shouldShowModelPicker` (`App.svelte:1849-1866`) borrows `tutorial.tutorialActive`, giving two edges: a no/completed-tutorial user never sees the picker; a tutorial replay re-summons it (session-scoped `modelPickerDismissed`). Check whether `useFirstRunNeeded.svelte.ts` (exists, unit-tested) already models this and **wire the picker to it** / extend it; the new signal takes explicit `{ byoEnabled, hasConfiguredDefault, dismissed }` and has **no tutorial input** (the structural proof of decoupling). **`BYO_MODELS_ENABLED &&` must stay the leading short-circuit conjunct.** Persist `dismissed` if edge (b) requires it survive a replay.
+
+## Steps (granular commits, one M4 PR on #1222)
+
+1. `index.html` agent tokens + `agent-color.ts` + `tests/client/agent-color.test.ts`.
+2. (a) card dot + `data-testid` + `tests/client/annotation-card-header.test.ts`.
+3. (b) comment underline + extend `tests/client/annotation-decoration.test.ts` (full-string assertion).
+4. (c) margin leader (required param) + extend `tests/client/marginLeaderGeometry.test.ts` (`it.each`: claude+identity distinct; claude+undefined == today; user/import ignore identity).
+5. (e) reply color + (f) chat color + (g) peek dot [if trivial] + tests (`reply-thread.test.ts`, chat/peek render tests).
+6. Chip gate: extract `resolveDefaultModelChip` + wire App/TitleBar + test (loading→null; loaded→label; no-default→null).
+7. First-run decouple: wire/extend `useFirstRunNeeded`; two **separate** edge tests (no-tutorial-user sees; replay doesn't re-summon).
+8. (d) tripwire test (zero AuthorshipRange from dispatch) in `tools.test.ts`.
+9. E2E skip-guarded spec (`tests/e2e/agent-identity.spec.ts`) — selectors must resolve against current markup (grep testids); body asserts the *lit* behavior (agent byline + agent-distinct decoration color vs a real-Claude annotation in the same doc).
+10. Docs: CLAUDE.md Status + roadmap/ADR-039 note (mechanism complete; only the flag flip + the two named flip-time deliverables remain) + this plan → done.
+
+## Test non-negotiables (from test review — the M3 "delete a line, suite stays green" trap)
+
+- **Every wiring site needs a LIT assertion** (identity present → NOT `var(--tandem-author-claude)`), not just the helper's unit test — a dark-only test passes even if the site is never wired.
+- **agentColor:** `expect(agentColor(undefined)).toBe("var(--tandem-author-claude)")` (exact literal — the byte-identical gate in miniature) + a pinned `(provider) → exact token` vector (guards silent map drift; self-comparison misses it).
+- **Full style string** asserted at (b) (mid-string interpolation).
+- **Required leader param** (step 4) is itself a compile-time guard on the call site.
+- **Chip + first-run** tested via the extracted pure helpers (inline-in-App is unreachable); first-run edges are **two separate** cases.
+- **(d) tripwire** as above.
+
+## Verify
+
+`npm run typecheck`, svelte-check (edited `.svelte`), biome, `npm run check:tokens` (tokens/`var()` pass — no raw hex/rgba), client + server unit suites, E2E spec compiles + selectors resolve. Each color/gate/first-run test asserts the dark fallback equals today.
+
+## Invariants / risks
+
+- **Byte-identical dark** is the gate: assert the fallback, not just the lit path.
+- **No new durable schema, no CRDT/origin/Y.Map change** (dark-safety review confirmed): decoration edits are pure render derivations; `agentIdentity` already lives on records (M3); AuthorshipRange untouched; accept/dismiss event untouched (deferred).
+- **Token lint**: `agentColor` emits `var(--tandem-*)` only.
+- **Stack depth 4** (M2a←M2b←M3←M4), all Bryan-gated, merge in order; rebase M4 if M3 changes.

--- a/index.html
+++ b/index.html
@@ -94,6 +94,15 @@
         --tandem-author-claude-bg: color-mix(in srgb, var(--tandem-author-claude) 10%, var(--tandem-surface));
         --tandem-claude-focus-bg: color-mix(in srgb, var(--tandem-author-claude) 10%, transparent);
         --tandem-claude-focus-border: color-mix(in srgb, var(--tandem-author-claude) 40%, transparent);
+        /* Per-agent authorship colors (#1123 M4, ADR-039). Keyed to the closed
+           `provider` enum; `anthropic` reuses --tandem-author-claude (Claude
+           family). Distinct, well-spaced hues avoiding author-user (245) and
+           author-claude coral (~40). Dark until the BYO_MODELS_ENABLED flip, so
+           these are only ever consumed once an annotation carries agentIdentity. */
+        --tandem-agent-openai: oklch(0.60 0.12 160);
+        --tandem-agent-gemini: oklch(0.55 0.15 285);
+        --tandem-agent-local-ollama: oklch(0.58 0.11 200);
+        --tandem-agent-local-llamacpp: oklch(0.58 0.15 330);
         /* #1006 A8 composer — text- and border-grade coral for controls keyed
            to the Claude/annotation action (the annotate composer's Send
            button). Hand-picked hex rather than color-mix because they must
@@ -488,6 +497,12 @@
         --tandem-author-claude-bg: #4d2419;
         --tandem-claude-focus-bg: color-mix(in srgb, var(--tandem-author-claude) 10%, transparent);
         --tandem-claude-focus-border: color-mix(in srgb, var(--tandem-author-claude) 40%, transparent);
+        /* Per-agent authorship colors — dark (#1123 M4). Light seeds lifted for
+           dark legibility (higher L, slightly lower C), hues fixed. */
+        --tandem-agent-openai: oklch(0.72 0.11 160);
+        --tandem-agent-gemini: oklch(0.70 0.13 285);
+        --tandem-agent-local-ollama: oklch(0.70 0.10 200);
+        --tandem-agent-local-llamacpp: oklch(0.72 0.13 330);
         /* #1006 dark coral grades — see the :root counterparts for ratios. */
         --tandem-author-claude-fg-strong: #f0a988;
         --tandem-author-claude-border: #b56a4b;
@@ -621,6 +636,10 @@
           --tandem-accent-fg-strong: HighlightText;
           --tandem-author-user: CanvasText;
           --tandem-author-claude: CanvasText;
+          --tandem-agent-openai: CanvasText;
+          --tandem-agent-gemini: CanvasText;
+          --tandem-agent-local-ollama: CanvasText;
+          --tandem-agent-local-llamacpp: CanvasText;
           --tandem-author-claude-fg-strong: CanvasText;
           --tandem-author-claude-border: ButtonText;
           --tandem-author-user-bg: Canvas;

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -107,6 +107,8 @@ import DocumentTabs from "./tabs/DocumentTabs.svelte";
 import { tabIdsToCloseOthers, tabIdsToCloseRight } from "./tabs/tab-context-menu.js";
 import { isRenamable } from "./types.js";
 import { openFileForRuntime } from "./utils/browse-file";
+import { resolveDefaultModelChip } from "./utils/model-chip";
+import { resolveModelFirstRunNeeded } from "./utils/model-first-run";
 import { addRecentFile, loadRecentFiles, saveRecentFiles } from "./utils/recentFiles";
 import { openServerPath } from "./utils/server-paths";
 
@@ -653,12 +655,16 @@ function openSettingsModalWithAck() {
   settingsModalOpen = true;
 }
 
-const defaultModelLabel = $derived.by(() => {
-  const id = modelsStore.defaultModelId;
-  if (id === null) return null;
-  const entry = modelsStore.models.find((m) => m.id === id);
-  return entry ? entry.displayName : null;
-});
+// #1123 M4: the loading gate (returns null while a registry load is in flight)
+// lives in `resolveDefaultModelChip` so it's unit-testable; the `? : null`
+// BYO wrapper at the prop keeps the chip dark-hidden.
+const defaultModelLabel = $derived(
+  resolveDefaultModelChip({
+    defaultModelId: modelsStore.defaultModelId,
+    models: modelsStore.models,
+    loading: modelsStore.loading,
+  }),
+);
 
 // `initialTabId` is applied only on the closed → open transition, so a
 // mid-open chip click leaves the user's current tab alone.
@@ -1841,28 +1847,47 @@ const tutorial = createTutorial(
   () => activeTab?.fileName,
 );
 
-// First-run model picker (#1123 M2b) — an OPTIONAL, skippable step sequenced
-// AFTER the integration wizard and BEFORE the tutorial. Dismissed for the
-// session once completed or skipped. Declared after `createTutorial` so the
-// derived doesn't reference `tutorial` before it is assigned.
+// First-run model picker (#1123) — an OPTIONAL, skippable step sequenced AFTER
+// the integration wizard and BEFORE the tutorial.
 //
-// Deliberate coupling (M4 revisits): the picker BORROWS the tutorial's first-run
-// signal (`tutorial.tutorialActive`) as its own existence condition rather than
-// introducing a parallel "first-run needed" state. That equivalence has two
-// known edges M4 owns: (a) a user who has no/disabled/already-completed tutorial
-// never sees the picker even though "connect a model on first run" is
-// conceptually orthogonal to the welcome tutorial; (b) `modelPickerDismissed` is
-// session-scoped, so a tutorial *replay* in a later session (with BYO on) would
-// re-summon the picker. Both are acceptable for the dark M2b mount — final
-// first-run choreography is M4 — but the coupling is a choice, not an accident.
+// M4 decoupled the picker from the tutorial: M2b borrowed `tutorial.tutorialActive`
+// as its existence condition, which meant a no/completed-tutorial user never saw
+// it and a tutorial *replay* re-summoned it. The signal now keys on the model
+// registry's own state (`resolveModelFirstRunNeeded`, which takes NO tutorial
+// input) — show once BYO is on, the wizard isn't showing, the registry has
+// settled with no configured default, and the user hasn't dismissed it. Dismissal
+// is PERSISTED (localStorage) so a skip isn't re-nagged on the next launch.
 //
-// Dark guarantee: `BYO_MODELS_ENABLED` short-circuits the derived, so while dark
-// `shouldShowModelPicker` is always false — the picker never mounts and the
-// tutorial gate (`!shouldShowModelPicker`) reduces to today's exact
-// `tutorial.tutorialActive && !shouldShowWizard`.
-let modelPickerDismissed = $state(false);
+// Dark guarantee: `BYO_MODELS_ENABLED &&` remains the leading short-circuit
+// conjunct, so while dark `shouldShowModelPicker` is always false and the
+// registry reads never evaluate — the tutorial gate (`!shouldShowModelPicker`)
+// reduces to today's exact `tutorial.tutorialActive && !shouldShowWizard`.
+const MODEL_PICKER_DISMISSED_KEY = "tandem:modelPickerDismissed";
+function loadModelPickerDismissed(): boolean {
+  try {
+    return localStorage.getItem(MODEL_PICKER_DISMISSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+let modelPickerDismissed = $state(loadModelPickerDismissed());
+function dismissModelPicker() {
+  modelPickerDismissed = true;
+  try {
+    localStorage.setItem(MODEL_PICKER_DISMISSED_KEY, "1");
+  } catch {
+    // Storage-disabled (incognito) — a session-scoped dismissal is an acceptable
+    // fallback; the picker still won't re-open within this session.
+  }
+}
 const shouldShowModelPicker = $derived(
-  BYO_MODELS_ENABLED && !shouldShowWizard && tutorial.tutorialActive && !modelPickerDismissed,
+  BYO_MODELS_ENABLED &&
+    resolveModelFirstRunNeeded({
+      wizardShowing: shouldShowWizard,
+      hasConfiguredDefault: modelsStore.defaultModelId !== null,
+      dismissed: modelPickerDismissed,
+      loading: modelsStore.loading,
+    }),
 );
 </script>
 
@@ -2209,7 +2234,7 @@ const shouldShowModelPicker = $derived(
       <!-- Optional post-wizard model step (#1123 M2b, dark until M4). Skip or
            complete dismisses it for the session, revealing the tutorial (gated
            on `!shouldShowModelPicker` below). Never mounts while dark. -->
-      <FirstRunModelPickerModal onComplete={() => (modelPickerDismissed = true)} />
+      <FirstRunModelPickerModal onComplete={dismissModelPicker} />
     {/if}
 
     {#if fileOpenDialogOpen}

--- a/src/client/editor/extensions/annotation.ts
+++ b/src/client/editor/extensions/annotation.ts
@@ -13,6 +13,7 @@ import { sanitizeAnnotation } from "../../../shared/sanitize";
 import type { Annotation } from "../../../shared/types";
 import { agentLabelSource } from "../../hooks/useModels.svelte";
 import { annotationToPmRange } from "../../positions";
+import { agentColor } from "../../utils/agent-color";
 import { resolveAgentLabel } from "../../utils/agentLabel";
 
 export const annotationPluginKey = new PluginKey("tandemAnnotations");
@@ -156,7 +157,10 @@ function buildDecorations(
           // Claude comment → solid underline (distinguishable from user's dashed)
           attrs = {
             class: "tandem-comment tandem-comment--claude",
-            style: "border-bottom: 2px solid var(--tandem-author-claude); padding-bottom: 1px;",
+            // #1123 M4: per-agent underline color. `agentColor` returns the
+            // exact `var(--tandem-author-claude)` token when no agentIdentity is
+            // present, so this string is byte-identical while dark.
+            style: `border-bottom: 2px solid ${agentColor(ann.agentIdentity)}; padding-bottom: 1px;`,
             "data-annotation-id": ann.id,
             "data-annotation-type": ann.type,
             "data-annotation-author": ann.author,

--- a/src/client/panels/AnnotationCardHeader.svelte
+++ b/src/client/panels/AnnotationCardHeader.svelte
@@ -2,6 +2,7 @@
 import type { Snippet } from "svelte";
 import type { Annotation } from "../../shared/types";
 import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
+import { agentColor } from "../utils/agent-color";
 import { formatRelativeTime, getAuthorLabel, getDisplayType } from "./annotation-card-helpers";
 
 interface Props {
@@ -34,11 +35,15 @@ const displayType = $derived(getDisplayType(annotation));
 const authorLabel = $derived(
   getAuthorLabel(annotation.author, agentLabel.family, annotation.agentIdentity),
 );
-// 6px authorship dot before the author label. Only user/claude carry an
-// author color (the two --tandem-author-* tokens); imports show the byline
+// 6px authorship dot before the author label. `user` carries the fixed user
+// token; `claude` carries the per-agent color (#1123 M4) — `agentColor` falls
+// back to the exact --tandem-author-claude token when no agentIdentity is
+// present, so this is byte-identical while dark. Imports show the byline
 // instead, so the dot is omitted for them in the markup below.
 const dotColor = $derived(
-  annotation.author === "claude" ? "var(--tandem-author-claude)" : "var(--tandem-author-user)",
+  annotation.author === "claude"
+    ? agentColor(annotation.agentIdentity)
+    : "var(--tandem-author-user)",
 );
 </script>
 
@@ -88,7 +93,12 @@ const dotColor = $derived(
       <span class="ach-edited">(edited)</span>
     {/if}
     {#if annotation.author !== "import"}
-      <span class="ach-dot" aria-hidden="true" style="background: {dotColor};"></span>
+      <span
+        class="ach-dot"
+        data-testid="annotation-author-dot-{annotation.id}"
+        aria-hidden="true"
+        style="background: {dotColor};"
+      ></span>
     {/if}
     {authorLabel}
     <span class="ach-time" title={new Date(annotation.timestamp).toLocaleString()}>

--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -223,6 +223,7 @@ async function clearChat() {
                real-Claude / dark message (no agentIdentity) keeps the accent
                token unchanged, so this is byte-identical while dark. -->
           <span
+            data-testid="chat-author-{msg.id}"
             style="font-weight: 600; font-size: 11px; color: {msg.author === 'claude'
               ? (msg.agentIdentity ? agentColor(msg.agentIdentity) : 'var(--tandem-accent)')
               : 'var(--tandem-fg-muted)'}; text-transform: uppercase;"

--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -10,6 +10,7 @@ import { generateMessageId } from "../../shared/utils";
 import { scrollFade } from "../actions/scrollFade.svelte.js";
 import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
 import { flatOffsetToPmPos } from "../positions";
+import { agentColor } from "../utils/agent-color";
 import { renderMarkdown } from "./chat-markdown";
 
 const TYPING_DOT_DELAYS = [0, 0.2, 0.4];
@@ -218,9 +219,12 @@ async function clearChat() {
       >
         <!-- Author + doc badge -->
         <div style="display: flex; gap: 6px; align-items: center; margin-bottom: 4px;">
+          <!-- #1123 M4: a local-model chat author gets its per-agent color; a
+               real-Claude / dark message (no agentIdentity) keeps the accent
+               token unchanged, so this is byte-identical while dark. -->
           <span
             style="font-weight: 600; font-size: 11px; color: {msg.author === 'claude'
-              ? 'var(--tandem-accent)'
+              ? (msg.agentIdentity ? agentColor(msg.agentIdentity) : 'var(--tandem-accent)')
               : 'var(--tandem-fg-muted)'}; text-transform: uppercase;"
           >
             {msg.author === "claude"

--- a/src/client/panels/CommentThread.svelte
+++ b/src/client/panels/CommentThread.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { AnnotationReply } from "../../shared/types";
 import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
+import { agentTintColor } from "../utils/agent-color";
 import { formatRelativeTime } from "./annotation-card-helpers";
 
 interface Props {
@@ -17,6 +18,10 @@ const agentLabel = createAgentLabel();
     {#each replies as reply (reply.id)}
       {@const kind =
         reply.author === "claude" ? "claude" : reply.author === "import" ? "import" : "user"}
+      <!-- #1123 M4: per-agent color override, applied ONLY when a local-model
+           reply carries an agentIdentity. Absent (dark / real-Claude) ⇒ no inline
+           style ⇒ the CSS class's --tandem-author-claude renders unchanged. -->
+      {@const agentTint = agentTintColor(reply.agentIdentity)}
       <div class="ct-reply" data-testid="reply-{reply.id}">
         <div class="ct-reply-head">
           <span
@@ -24,9 +29,14 @@ const agentLabel = createAgentLabel();
             class:is-claude={kind === "claude"}
             class:is-import={kind === "import"}
             class:is-user={kind === "user"}
+            style={kind === "claude" && agentTint ? `color: ${agentTint};` : undefined}
           >
             {#if kind === "claude"}
-              <span class="ct-author-dot ct-author-dot--claude" aria-hidden="true"></span>
+              <span
+                class="ct-author-dot ct-author-dot--claude"
+                style={agentTint ? `background: ${agentTint};` : undefined}
+                aria-hidden="true"
+              ></span>
               <!-- #1123 M3: a local-model reply bylines with its specific model
                    name, matching the card + chat surfaces; else the active
                    family label. Dark ⇒ agentIdentity absent ⇒ family label. -->

--- a/src/client/panels/MarginColumn.svelte
+++ b/src/client/panels/MarginColumn.svelte
@@ -269,7 +269,7 @@ $effect(() => subscribeAnnotationActions());
       {@const isActive = ann.id === activeAnnotationId}
       {@const adjTop = adjTopRaw ?? rawTop}
       {@const endY = adjTop + LEADER_BUBBLE_INSET_PX}
-      {@const color = leaderColorForAuthor(ann.author)}
+      {@const color = leaderColorForAuthor(ann.author, ann.agentIdentity)}
       {@const d = bezierLeaderPath({
         startX: editorX,
         startY: rawTop,

--- a/src/client/panels/PeekStrip.svelte
+++ b/src/client/panels/PeekStrip.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Annotation } from "../../shared/types.js";
+import { agentTintColor } from "../utils/agent-color.js";
 
 interface Props {
   side: "left" | "right";
@@ -80,7 +81,15 @@ function dotClass(a: Annotation): string {
       <span class="peek-tick h2"></span>
     {:else}
       {#each annotations as a (a.id)}
-        <span class="peek-dot {dotClass(a)}"></span>
+        {@const cls = dotClass(a)}
+        {@const tint = agentTintColor(a.agentIdentity)}
+        <!-- #1123 M4: per-agent dot color for a plain claude comment carrying an
+             agentIdentity; absent (dark / suggest / highlight) ⇒ no inline style
+             ⇒ the CSS class color renders unchanged. -->
+        <span
+          class="peek-dot {cls}"
+          style={cls === "claude" && tint ? `background: ${tint};` : undefined}
+        ></span>
       {/each}
     {/if}
   </div>

--- a/src/client/panels/PeekStrip.svelte
+++ b/src/client/panels/PeekStrip.svelte
@@ -88,6 +88,7 @@ function dotClass(a: Annotation): string {
              ⇒ the CSS class color renders unchanged. -->
         <span
           class="peek-dot {cls}"
+          data-testid="peek-dot-{a.id}"
           style={cls === "claude" && tint ? `background: ${tint};` : undefined}
         ></span>
       {/each}

--- a/src/client/panels/marginLeaderGeometry.ts
+++ b/src/client/panels/marginLeaderGeometry.ts
@@ -15,7 +15,8 @@
  * both `.svelte` template and vitest.
  */
 
-import type { Annotation } from "../../shared/types.js";
+import type { AgentIdentity, Annotation } from "../../shared/types.js";
+import { agentColor } from "../utils/agent-color.js";
 
 export interface LeaderEndpoints {
   /** SVG-local X at the text-edge endpoint (= dot center X). */
@@ -77,11 +78,20 @@ function assertNever(value: never): never {
  * future fourth `Annotation.author` value breaks the build rather than
  * silently bucketing into the import treatment (which would be the wrong
  * default for whatever the new value would mean).
+ *
+ * `agentIdentity` (#1123 M4) is REQUIRED — not optional — so a call site that
+ * forgets to thread it fails typecheck rather than silently reverting the claude
+ * branch to the generic token. Pass `undefined` for the (dark) no-identity case;
+ * `agentColor(undefined)` returns the exact `var(--tandem-author-claude)` token,
+ * keeping the claude leader byte-identical while dark.
  */
-export function leaderColorForAuthor(author: Annotation["author"]): string {
+export function leaderColorForAuthor(
+  author: Annotation["author"],
+  agentIdentity: AgentIdentity | undefined,
+): string {
   switch (author) {
     case "claude":
-      return "var(--tandem-author-claude)";
+      return agentColor(agentIdentity);
     case "user":
       return "var(--tandem-author-user)";
     case "import":

--- a/src/client/utils/agent-color.ts
+++ b/src/client/utils/agent-color.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-agent authorship color (#1123 M4, ADR-039).
+ *
+ * Maps an annotation/reply/chat record's {@link AgentIdentity} to a CSS color
+ * token, keyed on the closed `provider` enum (NOT the freeform, user-editable
+ * `displayName` — `agentIdentity` is a frozen per-record snapshot, so hashing
+ * the display name would repaint one agent across a rename). Keying on the
+ * bounded enum lets each provider carry a hand-tuned light/dark token in
+ * `index.html`, so theme adaptation is free and the token lint (which flags
+ * only raw hex/rgba literals) is a non-issue.
+ *
+ * DARK-SAFETY: `agentIdentity` is set solely by the flag-gated collaborator
+ * loop, so while `BYO_MODELS_ENABLED` is false no record carries it and every
+ * caller hits the `undefined` branch, which returns the EXACT current
+ * `var(--tandem-author-claude)` literal the decoration surfaces used before M4
+ * — byte-identical output. `anthropic` reuses that same coral (Claude family);
+ * only the `local-*` providers are exercised by the loop today (cloud BYO is
+ * v1.1), but the full map is bounded and cheap.
+ */
+import type { ModelProvider } from "../../shared/models/contract.js";
+import type { AgentIdentity } from "../../shared/types.js";
+
+/** The pre-M4 author color — the byte-identical-dark fallback and the `anthropic`
+ *  (Claude family) mapping both resolve to this exact literal. */
+const CLAUDE = "var(--tandem-author-claude)";
+
+const AGENT_COLOR_VARS: Record<ModelProvider, string> = {
+  anthropic: CLAUDE,
+  openai: "var(--tandem-agent-openai)",
+  gemini: "var(--tandem-agent-gemini)",
+  "local-ollama": "var(--tandem-agent-local-ollama)",
+  "local-llamacpp": "var(--tandem-agent-local-llamacpp)",
+};
+
+/**
+ * The decoration color for an agent-authored record. Returns the exact
+ * `var(--tandem-author-claude)` fallback when `identity` is absent (every
+ * dark-mode record) or names an unknown provider.
+ */
+export function agentColor(identity?: AgentIdentity): string {
+  if (!identity) return CLAUDE;
+  return AGENT_COLOR_VARS[identity.provider] ?? CLAUDE;
+}
+
+/**
+ * The per-agent tint for a class-driven surface (reply byline, peek dot) that
+ * must add NO inline style when no identity is present — returning `undefined`
+ * so the element's CSS class keeps rendering `--tandem-author-claude` unchanged
+ * (byte-identical DOM while dark). Use `agentColor` directly on surfaces that
+ * already emit an inline color unconditionally (card dot, underline, leader).
+ */
+export function agentTintColor(identity?: AgentIdentity): string | undefined {
+  return identity ? agentColor(identity) : undefined;
+}

--- a/src/client/utils/model-chip.ts
+++ b/src/client/utils/model-chip.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure derivation for the titlebar default-model chip (#1123 M4).
+ *
+ * Extracted from `App.svelte` so the loading-gate is unit-testable: inline in a
+ * component `$derived` there is no reachable test, and the whole point of M4's
+ * chip change — that the chip stays hidden while a registry load is in flight,
+ * killing the empty→label pop on a lit boot — can only be proven against a pure
+ * function.
+ */
+
+/** The minimal fields the chip needs from a registry entry. */
+export interface ChipModelEntry {
+  id: string;
+  displayName: string;
+}
+
+export interface DefaultModelChipInput {
+  defaultModelId: string | null;
+  models: readonly ChipModelEntry[];
+  loading: boolean;
+}
+
+/**
+ * The label for the titlebar default-model chip, or `null` when the chip must
+ * be hidden: while a load is in flight (avoids the empty→label pop), when there
+ * is no configured default, or when the default id resolves to no entry.
+ */
+export function resolveDefaultModelChip({
+  defaultModelId,
+  models,
+  loading,
+}: DefaultModelChipInput): string | null {
+  if (loading) return null;
+  if (defaultModelId === null) return null;
+  const entry = models.find((m) => m.id === defaultModelId);
+  return entry ? entry.displayName : null;
+}

--- a/src/client/utils/model-first-run.ts
+++ b/src/client/utils/model-first-run.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure predicate for whether the first-run model picker should show (#1123 M4).
+ *
+ * Extracted from `App.svelte` and — deliberately — takes NO tutorial input. M2b
+ * mounted the picker by borrowing `tutorial.tutorialActive` as its existence
+ * condition, which had two edges: a user with no/completed tutorial never saw
+ * the picker, and a tutorial *replay* re-summoned it. Keying on the model
+ * registry's own state instead (is a default configured yet?) decouples the two
+ * concerns; the absence of a tutorial argument here is the structural proof.
+ *
+ * DARK: the caller leads with `BYO_MODELS_ENABLED &&` so the picker derived
+ * short-circuits (and the registry reads below never evaluate) while dark — the
+ * same convention `resolveDefaultModelChip` uses, so this predicate carries no
+ * redundant build-flag arg of its own.
+ */
+export interface ModelFirstRunInput {
+  /** The integration wizard is showing — it takes first-run precedence. */
+  wizardShowing: boolean;
+  /** The registry has a resolvable default model → setup already done. */
+  hasConfiguredDefault: boolean;
+  /** The user already skipped/completed the picker (persisted across launches). */
+  dismissed: boolean;
+  /** A registry load is in flight — wait rather than flash the picker. */
+  loading: boolean;
+}
+
+export function resolveModelFirstRunNeeded({
+  wizardShowing,
+  hasConfiguredDefault,
+  dismissed,
+  loading,
+}: ModelFirstRunInput): boolean {
+  if (wizardShowing) return false;
+  if (loading) return false;
+  if (hasConfiguredDefault) return false;
+  if (dismissed) return false;
+  return true;
+}

--- a/src/server/local-model/tools.ts
+++ b/src/server/local-model/tools.ts
@@ -147,7 +147,7 @@ export const TOOLS: ToolSchema[] = [
 ];
 
 /** Tools that write to the Y.Doc — gated by the license check. Reads + chat aren't. */
-const MUTATING_TOOLS: ReadonlySet<string> = new Set([
+export const MUTATING_TOOLS: ReadonlySet<string> = new Set([
   "comment_on_quote",
   "propose_replacement",
   "reply_to_annotation",

--- a/tests/client/agent-color.test.ts
+++ b/tests/client/agent-color.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { agentColor } from "../../src/client/utils/agent-color";
+import type { AgentIdentity, ModelProvider } from "../../src/shared/types";
+
+function id(provider: ModelProvider, displayName = "Model"): AgentIdentity {
+  return { provider, displayName };
+}
+
+describe("agentColor (#1123 M4)", () => {
+  it("returns the EXACT current claude token for an absent identity (byte-identical dark)", () => {
+    // This literal is copy-identical to the pre-M4 decoration sites' color, so
+    // any drift (a stray space, an equivalent-but-different token) would break
+    // the byte-identical-while-dark guarantee. Pin it as an exact string.
+    expect(agentColor(undefined)).toBe("var(--tandem-author-claude)");
+  });
+
+  it("maps each provider to its pinned token (guards silent map drift)", () => {
+    // Hardcoded expected vectors, NOT self-comparison — a self-equal assertion
+    // passes even if the whole mapping is rewritten, which would repaint every
+    // existing agent's annotations.
+    expect(agentColor(id("anthropic"))).toBe("var(--tandem-author-claude)");
+    expect(agentColor(id("openai"))).toBe("var(--tandem-agent-openai)");
+    expect(agentColor(id("gemini"))).toBe("var(--tandem-agent-gemini)");
+    expect(agentColor(id("local-ollama"))).toBe("var(--tandem-agent-local-ollama)");
+    expect(agentColor(id("local-llamacpp"))).toBe("var(--tandem-agent-local-llamacpp)");
+  });
+
+  it("colors a non-anthropic agent distinctly from the claude fallback", () => {
+    // The whole point of the wiring tests downstream: a present identity must
+    // NOT collapse to the claude token (that would be indistinguishable from
+    // the dark fallback and hide an unwired call site).
+    expect(agentColor(id("local-ollama"))).not.toBe("var(--tandem-author-claude)");
+  });
+
+  it("is deterministic and independent of displayName (keys on provider only)", () => {
+    expect(agentColor(id("local-ollama", "Qwen 2.5"))).toBe(
+      agentColor(id("local-ollama", "Renamed Later")),
+    );
+  });
+
+  it("emits only var() tokens, never a raw hex/rgba literal (token-lint safe)", () => {
+    for (const provider of [
+      "anthropic",
+      "openai",
+      "gemini",
+      "local-ollama",
+      "local-llamacpp",
+    ] as const) {
+      const color = agentColor(id(provider));
+      expect(color).toMatch(/^var\(--tandem-/);
+      expect(color).not.toMatch(/#[0-9a-fA-F]{3,8}|rgba?\(/);
+    }
+  });
+});

--- a/tests/client/agent-color.test.ts
+++ b/tests/client/agent-color.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { agentColor } from "../../src/client/utils/agent-color";
+import { agentColor, agentTintColor } from "../../src/client/utils/agent-color";
 import type { AgentIdentity, ModelProvider } from "../../src/shared/types";
 
 function id(provider: ModelProvider, displayName = "Model"): AgentIdentity {
@@ -36,6 +36,19 @@ describe("agentColor (#1123 M4)", () => {
     expect(agentColor(id("local-ollama", "Qwen 2.5"))).toBe(
       agentColor(id("local-ollama", "Renamed Later")),
     );
+  });
+
+  // agentTintColor drives the class-driven surfaces (reply byline, peek dot):
+  // it must return `undefined` when no identity is present so NO inline style is
+  // emitted and the CSS class keeps rendering the claude token (byte-identical
+  // DOM while dark) — and the concrete tint otherwise.
+  it("agentTintColor returns undefined for an absent identity (emits no inline style)", () => {
+    expect(agentTintColor(undefined)).toBeUndefined();
+  });
+
+  it("agentTintColor returns the same token as agentColor when identity is present", () => {
+    expect(agentTintColor(id("local-ollama"))).toBe(agentColor(id("local-ollama")));
+    expect(agentTintColor(id("local-ollama"))).toBe("var(--tandem-agent-local-ollama)");
   });
 
   it("emits only var() tokens, never a raw hex/rgba literal (token-lint safe)", () => {

--- a/tests/client/annotation-card-header.test.ts
+++ b/tests/client/annotation-card-header.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+
+import { render } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import AnnotationCardHeader from "../../src/client/panels/AnnotationCardHeader.svelte";
+import type { Annotation } from "../../src/shared/types";
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: "annotation-1",
+    type: "comment",
+    author: "claude",
+    status: "pending",
+    content: "Body",
+    range: { from: 0, to: 1 },
+    timestamp: 0,
+    ...overrides,
+  } as Annotation;
+}
+
+function renderHeader(annotation: Annotation) {
+  return render(AnnotationCardHeader, {
+    props: {
+      annotation,
+      isPending: true,
+      isEditing: false,
+      canEdit: false,
+      badgeBg: "transparent",
+      badgeFg: "inherit",
+      onEnterEdit: () => {},
+    },
+  });
+}
+
+function dotStyle(container: HTMLElement): string {
+  const dot = container.querySelector("[data-testid='annotation-author-dot-annotation-1']");
+  expect(dot).toBeTruthy();
+  return dot?.getAttribute("style") ?? "";
+}
+
+describe("AnnotationCardHeader author dot color (#1123 M4)", () => {
+  it("a claude annotation with NO agentIdentity uses the exact claude token (dark == today)", () => {
+    const { container } = renderHeader(makeAnnotation());
+    expect(dotStyle(container)).toContain("background: var(--tandem-author-claude);");
+  });
+
+  it("a claude annotation WITH agentIdentity uses the per-agent token, not the claude token", () => {
+    const { container } = renderHeader(
+      makeAnnotation({ agentIdentity: { provider: "local-ollama", displayName: "Qwen 2.5" } }),
+    );
+    const style = dotStyle(container);
+    expect(style).toContain("background: var(--tandem-agent-local-ollama);");
+    expect(style).not.toContain("var(--tandem-author-claude)");
+  });
+
+  it("a user annotation is unaffected by identity wiring", () => {
+    const { container } = renderHeader(makeAnnotation({ author: "user" }));
+    expect(dotStyle(container)).toContain("background: var(--tandem-author-user);");
+  });
+});

--- a/tests/client/annotation-decoration.test.ts
+++ b/tests/client/annotation-decoration.test.ts
@@ -577,6 +577,7 @@ describe("AR2: annotation decoration attrs — five visual languages", () => {
       author: string;
       suggestedText?: string;
       color?: string;
+      agentIdentity?: { provider: string; displayName: string };
     },
   ) {
     const id = fields.id ?? "ann-1";
@@ -591,6 +592,7 @@ describe("AR2: annotation decoration attrs — five visual languages", () => {
       range: { from: 1, to: 5 },
       ...(fields.suggestedText !== undefined ? { suggestedText: fields.suggestedText } : {}),
       ...(fields.color !== undefined ? { color: fields.color } : {}),
+      ...(fields.agentIdentity !== undefined ? { agentIdentity: fields.agentIdentity } : {}),
     });
   }
 
@@ -620,6 +622,32 @@ describe("AR2: annotation decoration attrs — five visual languages", () => {
     expect(dec.attrs.class).toBe("tandem-comment tandem-comment--claude");
     expect(dec.attrs.style).toContain("solid");
     expect(dec.attrs["data-annotation-author"]).toBe("claude");
+  });
+
+  // #1123 M4: per-agent underline color. A claude comment with NO agentIdentity
+  // must emit the EXACT pre-M4 style string (byte-identical while dark); one WITH
+  // an agentIdentity swaps in the per-agent token and must not carry the claude one.
+  it("claude comment WITHOUT agentIdentity emits the exact pre-M4 style string", () => {
+    const ydoc = new Y.Doc();
+    addAnnotationEntry(ydoc, { type: "comment", author: "claude" });
+    const [dec] = getDecorations(ydoc);
+    expect(dec.attrs.style).toBe(
+      "border-bottom: 2px solid var(--tandem-author-claude); padding-bottom: 1px;",
+    );
+  });
+
+  it("claude comment WITH agentIdentity uses the per-agent token, not the claude token", () => {
+    const ydoc = new Y.Doc();
+    addAnnotationEntry(ydoc, {
+      type: "comment",
+      author: "claude",
+      agentIdentity: { provider: "local-ollama", displayName: "Qwen 2.5" },
+    });
+    const [dec] = getDecorations(ydoc);
+    expect(dec.attrs.style).toBe(
+      "border-bottom: 2px solid var(--tandem-agent-local-ollama); padding-bottom: 1px;",
+    );
+    expect(dec.attrs.style).not.toContain("var(--tandem-author-claude)");
   });
 
   it("import comment → tandem-comment (not --claude), data-annotation-author=import", () => {

--- a/tests/client/chat-panel.test.ts
+++ b/tests/client/chat-panel.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+
+import { render } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import ChatPanel from "../../src/client/panels/ChatPanel.svelte";
+import { Y_MAP_CHAT } from "../../src/shared/constants";
+import type { ChatMessage } from "../../src/shared/types";
+
+function seedDoc(messages: ChatMessage[]): Y.Doc {
+  const doc = new Y.Doc();
+  const chat = doc.getMap(Y_MAP_CHAT);
+  for (const m of messages) chat.set(m.id, m);
+  return doc;
+}
+
+function renderChat(ctrlYdoc: Y.Doc) {
+  return render(ChatPanel, {
+    props: {
+      ctrlYdoc,
+      editor: null,
+      activeDocId: null,
+      openDocs: [],
+      capturedAnchor: null,
+      onCapturedAnchorChange: () => {},
+    },
+  });
+}
+
+function claudeMsg(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: "m1",
+    author: "claude",
+    text: "hello",
+    timestamp: 1,
+    ...overrides,
+  } as ChatMessage;
+}
+
+function authorStyle(container: HTMLElement, id: string): string {
+  return container.querySelector(`[data-testid='chat-author-${id}']`)?.getAttribute("style") ?? "";
+}
+
+describe("ChatPanel per-agent author color (#1123 M4)", () => {
+  it("a claude message WITH agentIdentity colors the author with the per-agent token", () => {
+    const doc = seedDoc([
+      claudeMsg({ agentIdentity: { provider: "local-ollama", displayName: "Qwen 2.5" } }),
+    ]);
+    const { container } = renderChat(doc);
+    const style = authorStyle(container, "m1");
+    expect(style).toContain("var(--tandem-agent-local-ollama)");
+    // The distinct fallbacks matter: it must NOT collapse to the accent baseline
+    // nor to the annotation coral token.
+    expect(style).not.toContain("var(--tandem-accent)");
+    expect(style).not.toContain("var(--tandem-author-claude)");
+  });
+
+  it("a claude message WITHOUT agentIdentity keeps the accent baseline (byte-identical dark)", () => {
+    // This is the one wiring site whose dark fallback is `--tandem-accent`, NOT
+    // the claude token — a regression that routed it through agentColor's fallback
+    // would silently flip the dark chat-author color from indigo to coral.
+    const doc = seedDoc([claudeMsg()]);
+    const { container } = renderChat(doc);
+    const style = authorStyle(container, "m1");
+    expect(style).toContain("var(--tandem-accent)");
+    expect(style).not.toContain("var(--tandem-author-claude)");
+    expect(style).not.toContain("var(--tandem-agent-");
+  });
+
+  it("a user message uses the muted token, unaffected by identity wiring", () => {
+    const doc = seedDoc([claudeMsg({ id: "u1", author: "user", text: "hi" })]);
+    const { container } = renderChat(doc);
+    expect(authorStyle(container, "u1")).toContain("var(--tandem-fg-muted)");
+  });
+});

--- a/tests/client/marginLeaderGeometry.test.ts
+++ b/tests/client/marginLeaderGeometry.test.ts
@@ -6,9 +6,10 @@ import {
 } from "../../src/client/panels/marginLeaderGeometry";
 
 describe("leaderColorForAuthor", () => {
-  // Equivalence classes cover every value of Annotation["author"]. The
-  // assertNever branch is unreachable under TS; coverage proof is that all
-  // three cases below resolve to distinct CSS variables.
+  // Equivalence classes cover every value of Annotation["author"] with NO
+  // agentIdentity (the dark case). The assertNever branch is unreachable under
+  // TS; coverage proof is that all three cases below resolve to distinct CSS
+  // variables. The claude case pins the exact pre-M4 token (byte-identical dark).
   it.each([
     {
       author: "claude" as const,
@@ -25,8 +26,29 @@ describe("leaderColorForAuthor", () => {
       expected: "var(--tandem-fg-subtle)",
       why: ".docx Word-comment-derived → neutral subtle tone, distinct from Claude",
     },
-  ])("maps $author → $expected ($why)", ({ author, expected }) => {
-    expect(leaderColorForAuthor(author)).toBe(expected);
+  ])("maps $author (no identity) → $expected ($why)", ({ author, expected }) => {
+    expect(leaderColorForAuthor(author, undefined)).toBe(expected);
+  });
+
+  // #1123 M4: a claude leader with an agentIdentity takes the per-agent token.
+  it("claude + agentIdentity → the per-agent token, not the claude token", () => {
+    const color = leaderColorForAuthor("claude", {
+      provider: "local-ollama",
+      displayName: "Qwen 2.5",
+    });
+    expect(color).toBe("var(--tandem-agent-local-ollama)");
+    expect(color).not.toBe("var(--tandem-author-claude)");
+  });
+
+  // Identity is ignored on non-claude leaders — a silent regression here would
+  // leak agent color onto user/import connectors.
+  it.each([
+    { author: "user" as const, expected: "var(--tandem-author-user)" },
+    { author: "import" as const, expected: "var(--tandem-fg-subtle)" },
+  ])("$author ignores agentIdentity → $expected", ({ author, expected }) => {
+    expect(
+      leaderColorForAuthor(author, { provider: "local-ollama", displayName: "Qwen 2.5" }),
+    ).toBe(expected);
   });
 });
 

--- a/tests/client/model-chip.test.ts
+++ b/tests/client/model-chip.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveDefaultModelChip } from "../../src/client/utils/model-chip";
+
+const MODELS = [
+  { id: "m1", displayName: "Qwen 2.5" },
+  { id: "m2", displayName: "Llama 3.1" },
+];
+
+describe("resolveDefaultModelChip (#1123 M4 chip loading-gate)", () => {
+  it("hides the chip while a registry load is in flight (kills the empty→label pop)", () => {
+    // Even with a resolvable default, loading:true must yield null so the chip
+    // never flashes before the async load settles.
+    expect(
+      resolveDefaultModelChip({ defaultModelId: "m1", models: MODELS, loading: true }),
+    ).toBeNull();
+  });
+
+  it("shows the default entry's displayName once loaded", () => {
+    expect(resolveDefaultModelChip({ defaultModelId: "m2", models: MODELS, loading: false })).toBe(
+      "Llama 3.1",
+    );
+  });
+
+  it("hides the chip when there is no configured default", () => {
+    expect(
+      resolveDefaultModelChip({ defaultModelId: null, models: MODELS, loading: false }),
+    ).toBeNull();
+  });
+
+  it("hides the chip when the default id resolves to no entry", () => {
+    expect(
+      resolveDefaultModelChip({ defaultModelId: "gone", models: MODELS, loading: false }),
+    ).toBeNull();
+  });
+
+  it("is null in the dark shape (no models, not loading, no default) — byte-identical", () => {
+    expect(
+      resolveDefaultModelChip({ defaultModelId: null, models: [], loading: false }),
+    ).toBeNull();
+  });
+});

--- a/tests/client/model-first-run.test.ts
+++ b/tests/client/model-first-run.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ModelFirstRunInput,
+  resolveModelFirstRunNeeded,
+} from "../../src/client/utils/model-first-run";
+
+// A configured, past-first-run baseline: nothing should show.
+function base(overrides: Partial<ModelFirstRunInput> = {}): ModelFirstRunInput {
+  return {
+    wizardShowing: false,
+    hasConfiguredDefault: false,
+    dismissed: false,
+    loading: false,
+    ...overrides,
+  };
+}
+
+describe("resolveModelFirstRunNeeded (#1123 M4 first-run decouple)", () => {
+  it("shows on a fresh BYO-on launch with no default configured", () => {
+    expect(resolveModelFirstRunNeeded(base())).toBe(true);
+  });
+
+  // Edge (a): a user with no/completed tutorial still sees the picker. The
+  // predicate's input type has NO tutorial field (the structural decoupling),
+  // so there is no tutorial state that could gate it off — the fresh-launch
+  // case shows `true` with no tutorial involved at all.
+  it("edge (a): shows without any tutorial input in the signal", () => {
+    expect(resolveModelFirstRunNeeded(base())).toBe(true);
+  });
+
+  // Edge (b): a persisted dismissal suppresses the picker on a later launch,
+  // so a tutorial replay (which no longer feeds this signal) can't re-summon it.
+  it("edge (b): a persisted dismissal keeps it hidden", () => {
+    expect(resolveModelFirstRunNeeded(base({ dismissed: true }))).toBe(false);
+  });
+
+  it("hides once a default is configured", () => {
+    expect(resolveModelFirstRunNeeded(base({ hasConfiguredDefault: true }))).toBe(false);
+  });
+
+  it("hides while the integration wizard is showing (precedence)", () => {
+    expect(resolveModelFirstRunNeeded(base({ wizardShowing: true }))).toBe(false);
+  });
+
+  it("hides while the registry is still loading (no flash before settle)", () => {
+    expect(resolveModelFirstRunNeeded(base({ loading: true }))).toBe(false);
+  });
+
+  // The dark gate lives at the call site (`BYO_MODELS_ENABLED && …`), not in this
+  // predicate — matching `resolveDefaultModelChip`. So there is no `byoEnabled`
+  // input to test here; the App.svelte conjunct is what keeps the picker dark.
+});

--- a/tests/client/peek-strip.test.ts
+++ b/tests/client/peek-strip.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+
+import { render } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import PeekStrip from "../../src/client/panels/PeekStrip.svelte";
+import type { Annotation } from "../../src/shared/types";
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: "a1",
+    type: "comment",
+    author: "claude",
+    status: "pending",
+    content: "body",
+    range: { from: 0, to: 1 },
+    timestamp: 0,
+    ...overrides,
+  } as Annotation;
+}
+
+function renderStrip(annotations: Annotation[]) {
+  return render(PeekStrip, {
+    props: {
+      side: "right" as const,
+      onActivate: () => {},
+      collapsed: true,
+      kind: "annotations" as const,
+      annotations,
+    },
+  });
+}
+
+function dotStyle(container: HTMLElement, id: string): string | null {
+  return container.querySelector(`[data-testid='peek-dot-${id}']`)?.getAttribute("style") ?? null;
+}
+
+describe("PeekStrip per-agent dot color (#1123 M4)", () => {
+  it("a claude comment WITH agentIdentity tints the dot with the per-agent token", () => {
+    const { container } = renderStrip([
+      makeAnnotation({ agentIdentity: { provider: "local-ollama", displayName: "Qwen" } }),
+    ]);
+    expect(dotStyle(container, "a1")).toContain("background: var(--tandem-agent-local-ollama);");
+  });
+
+  it("a claude comment WITHOUT agentIdentity adds no inline style (byte-identical dark)", () => {
+    // No inline style ⇒ the `.peek-dot.claude` CSS class's --tandem-author-claude
+    // renders exactly as before M4.
+    const { container } = renderStrip([makeAnnotation()]);
+    expect(dotStyle(container, "a1")).toBeNull();
+  });
+
+  it("a suggestion dot (comment + suggestedText) never takes the agent tint", () => {
+    // dotClass → "suggest" (violet, author-agnostic by design), so even with an
+    // agentIdentity present the per-agent tint must not apply.
+    const { container } = renderStrip([
+      makeAnnotation({
+        suggestedText: "x",
+        agentIdentity: { provider: "local-ollama", displayName: "Qwen" },
+      }),
+    ]);
+    expect(dotStyle(container, "a1")).toBeNull();
+  });
+
+  it("a highlight dot never takes the agent tint", () => {
+    const { container } = renderStrip([makeAnnotation({ type: "highlight", author: "user" })]);
+    expect(dotStyle(container, "a1")).toBeNull();
+  });
+});

--- a/tests/client/reply-thread.test.ts
+++ b/tests/client/reply-thread.test.ts
@@ -91,6 +91,36 @@ describe("ReplyThread — A13 disclosure", () => {
     // The specific model name renders; the generic family fallback ("Assistant"
     // when no model is configured in this test's store) does not.
     expect(container.textContent).toContain("Qwen 2.5");
+    // #1123 M4: the byline is tinted with the per-agent color (inline override).
+    const author = container.querySelector(".ct-author.is-claude");
+    expect(author?.getAttribute("style") ?? "").toContain(
+      "color: var(--tandem-agent-local-ollama);",
+    );
+    const dot = container.querySelector(".ct-author-dot--claude");
+    expect(dot?.getAttribute("style") ?? "").toContain(
+      "background: var(--tandem-agent-local-ollama);",
+    );
+  });
+
+  it("#1123 M4: a claude reply WITHOUT agentIdentity adds no inline color (byte-identical dark)", async () => {
+    const replies = [makeReply({ text: "vanilla claude reply" })];
+    const { container } = render(ReplyThread, {
+      props: {
+        annotation: makeAnnotation(),
+        replies,
+        isPending: false,
+        isEditing: false,
+      },
+    });
+    await fireEvent.click(
+      container.querySelector("[data-testid='reply-toggle-annotation-1']") as Element,
+    );
+    // No agentIdentity ⇒ no inline style attribute at all ⇒ the CSS class's
+    // --tandem-author-claude renders exactly as before M4.
+    const author = container.querySelector(".ct-author.is-claude");
+    expect(author?.getAttribute("style")).toBeNull();
+    const dot = container.querySelector(".ct-author-dot--claude");
+    expect(dot?.getAttribute("style")).toBeNull();
   });
 
   it("pluralises the toggle count", () => {

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -8,6 +8,7 @@ activity-pill
 activity-row-{*}
 activity-tray
 ai-readiness-harness
+annotation-author-dot-{*}
 annotation-card-{*}
 annotation-held-pill-{*}
 annotation-import-byline-{*}

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -37,6 +37,7 @@ bulk-cancel-btn
 bulk-confirm-btn
 bulk-dismiss-btn
 chat-anchor-quote-{*}
+chat-author-{*}
 chat-send-btn
 chat-tab
 claude-typing-indicator-{*}
@@ -264,6 +265,7 @@ palette-input
 palette-item-new-scratchpad
 palette-item-{*}
 panel-edge-collapse-{*}
+peek-dot-{*}
 peek-strip-{*}
 popup-annotate-btn
 popup-annotate-row

--- a/tests/e2e/agent-identity.spec.ts
+++ b/tests/e2e/agent-identity.spec.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { BYO_MODELS_ENABLED } from "../../src/shared/constants";
+import { cleanupAllOpenDocuments, McpTestClient } from "./helpers";
+
+/**
+ * Per-agent identity choreography E2E (#1123 M4).
+ *
+ * SKIP-GUARDED, exactly like `settings-models.spec.ts`: the first-run model
+ * picker and the titlebar default-model chip are gated behind
+ * `BYO_MODELS_ENABLED`, so with the flag off this whole suite is skipped and
+ * auto-enables the moment the flag flips at v1.0 — the flip inherits real
+ * browser coverage of the choreography for free.
+ *
+ * NOT covered here (a documented flip-time deliverable, per the M4 plan): driving
+ * the local-model loop end-to-end against a stub OpenAI-compatible server so a
+ * real model turn produces an agent-authored annotation. That harness does not
+ * exist yet; these tests cover the flag-gated UI choreography, which derives from
+ * client state and needs no model server. The per-agent decoration COLOR + byline
+ * rendering is covered at the unit/component layer (agent-color.test.ts,
+ * annotation-decoration.test.ts, annotation-card-header.test.ts, reply-thread.test.ts,
+ * marginLeaderGeometry.test.ts).
+ */
+
+let mcp: McpTestClient;
+let tmpDir: string;
+
+test.beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tandem-agent-identity-"));
+  fs.writeFileSync(path.join(tmpDir, "sample.md"), "# Sample\n\nA paragraph.\n");
+  mcp = new McpTestClient();
+});
+
+test.afterAll(async () => {
+  await cleanupAllOpenDocuments(mcp).catch(() => {});
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test.beforeEach(async ({ page }) => {
+  // Flag off ⇒ the model picker + chip never render; skip reversibly (re-enables
+  // at the BYO_MODELS_ENABLED flip). See settings-models.spec.ts for the twin.
+  test.skip(!BYO_MODELS_ENABLED, "Agent-identity UI gated off until BYO_MODELS_ENABLED (#1123)");
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://127.0.0.1:5173");
+});
+
+test("first-run picker appears on a fresh boot with no configured model", async ({ page }) => {
+  // Decoupled from the tutorial (#1123 M4): the picker shows purely from registry
+  // state — BYO on, no default configured, not dismissed.
+  await expect(page.locator("[data-testid='first-run-model-modal']")).toBeVisible();
+});
+
+test("skipping the picker persists dismissal across a reload (no re-nag)", async ({ page }) => {
+  await page.locator("[data-testid='first-run-model-modal']").waitFor();
+  await page.locator("[data-testid='first-run-skip']").click();
+  await expect(page.locator("[data-testid='first-run-model-modal']")).toHaveCount(0);
+  // Reload: a persisted dismissal (localStorage) must keep it closed — the M4
+  // fix for the M2b replay re-summon edge.
+  await page.reload();
+  await expect(page.locator("[data-testid='first-run-model-modal']")).toHaveCount(0);
+});

--- a/tests/server/local-model/tools.test.ts
+++ b/tests/server/local-model/tools.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import type * as Y from "yjs";
 import { dispatch, TOOLS } from "../../../src/server/local-model/tools.js";
-import { Y_MAP_ANNOTATION_REPLIES } from "../../../src/shared/constants.js";
+import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_AUTHORSHIP } from "../../../src/shared/constants.js";
 import { MCP_ORIGIN } from "../../../src/shared/origins.js";
 import type { Annotation } from "../../../src/shared/types.js";
 import { getAnnotationsMap, makeMarkdownDoc } from "../../helpers/ydoc-factory.js";
@@ -47,6 +47,41 @@ describe("local-model tool registry (ADR-027 lock)", () => {
     expect(
       TOOLS.some((t) => /^(get|list|read|view|fetch)_?(annotation|comment|note)/i.test(t.name)),
     ).toBe(false);
+  });
+});
+
+// #1123 M4 tripwire. Per-agent AuthorshipRange color was EXCLUDED from M4 on the
+// grounds that the loop writes zero authorship ranges (its edits are proposals,
+// not body text; accepted text is attributed author:"user" client-side). This
+// pins that premise: if a future body-editing tool is added and starts stamping
+// authorship, this breaks and points straight back at the exclusion decision.
+describe("dispatch — writes NO authorship ranges (M4 (d) exclusion tripwire)", () => {
+  it("comment / replacement / reply leave the authorship map empty", () => {
+    doc = makeMarkdownDoc(FIXTURE);
+    dispatch(
+      "comment_on_quote",
+      { quoted_text: "the first phase", comment: "note" },
+      { ydoc: doc },
+    );
+    dispatch(
+      "propose_replacement",
+      { quoted_text: "the first phase", suggested_text: "phase one", rationale: "shorter" },
+      { ydoc: doc },
+    );
+    const created = dispatch(
+      "comment_on_quote",
+      { quoted_text: "We proceeded carefully", comment: "another" },
+      { ydoc: doc },
+    );
+    const annotationId = (created.result as { annotation_id?: string }).annotation_id;
+    if (annotationId) {
+      dispatch(
+        "reply_to_annotation",
+        { annotation_id: annotationId, text: "reply body" },
+        { ydoc: doc },
+      );
+    }
+    expect(doc.getMap(Y_MAP_AUTHORSHIP).size).toBe(0);
   });
 });
 

--- a/tests/server/local-model/tools.test.ts
+++ b/tests/server/local-model/tools.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import type * as Y from "yjs";
-import { dispatch, TOOLS } from "../../../src/server/local-model/tools.js";
+import { dispatch, MUTATING_TOOLS, TOOLS } from "../../../src/server/local-model/tools.js";
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_AUTHORSHIP } from "../../../src/shared/constants.js";
 import { MCP_ORIGIN } from "../../../src/shared/origins.js";
 import type { Annotation } from "../../../src/shared/types.js";
@@ -53,33 +53,37 @@ describe("local-model tool registry (ADR-027 lock)", () => {
 // #1123 M4 tripwire. Per-agent AuthorshipRange color was EXCLUDED from M4 on the
 // grounds that the loop writes zero authorship ranges (its edits are proposals,
 // not body text; accepted text is attributed author:"user" client-side). This
-// pins that premise: if a future body-editing tool is added and starts stamping
-// authorship, this breaks and points straight back at the exclusion decision.
-describe("dispatch — writes NO authorship ranges (M4 (d) exclusion tripwire)", () => {
-  it("comment / replacement / reply leave the authorship map empty", () => {
+// pins that premise by iterating the WHOLE mutating-tool set — so a future
+// body-editing tool that stamps authorship is dispatched here and breaks the
+// assertion, pointing straight back at the exclusion decision.
+describe("dispatch — no mutating tool writes an authorship range (M4 (d) tripwire)", () => {
+  // Best-effort valid args per current mutating tool so each dispatch actually
+  // reaches its write path; an unknown future tool falls back to {} (still
+  // dispatched, so it's at least exercised — tighten its args when it lands).
+  function argsFor(name: string, annotationId: string): Record<string, unknown> {
+    switch (name) {
+      case "comment_on_quote":
+        return { quoted_text: "the first phase", comment: "note" };
+      case "propose_replacement":
+        return { quoted_text: "We proceeded carefully", suggested_text: "x", rationale: "y" };
+      case "reply_to_annotation":
+        return { annotation_id: annotationId, text: "reply body" };
+      default:
+        return {};
+    }
+  }
+
+  it("every tool in MUTATING_TOOLS leaves the authorship map empty", () => {
     doc = makeMarkdownDoc(FIXTURE);
-    dispatch(
+    // Seed one real annotation so reply_to_annotation has a valid target.
+    const seed = dispatch(
       "comment_on_quote",
-      { quoted_text: "the first phase", comment: "note" },
+      { quoted_text: "The team agreed", comment: "seed" },
       { ydoc: doc },
     );
-    dispatch(
-      "propose_replacement",
-      { quoted_text: "the first phase", suggested_text: "phase one", rationale: "shorter" },
-      { ydoc: doc },
-    );
-    const created = dispatch(
-      "comment_on_quote",
-      { quoted_text: "We proceeded carefully", comment: "another" },
-      { ydoc: doc },
-    );
-    const annotationId = (created.result as { annotation_id?: string }).annotation_id;
-    if (annotationId) {
-      dispatch(
-        "reply_to_annotation",
-        { annotation_id: annotationId, text: "reply body" },
-        { ydoc: doc },
-      );
+    const annotationId = (seed.result as { annotation_id?: string }).annotation_id ?? "";
+    for (const name of MUTATING_TOOLS) {
+      dispatch(name, argsFor(name, annotationId), { ydoc: doc });
     }
     expect(doc.getMap(Y_MAP_AUTHORSHIP).size).toBe(0);
   });


### PR DESCRIPTION
## M4 — the final DARK mechanism for the local-model track (#1123, ADR-039)

Stacked on M3 (#1222). **Base: `feat/1123-m3-provider-authorship`.** Merge order: #1220 → #1221 → #1222 → this.

Everything here is **runtime byte-identical while `BYO_MODELS_ENABLED` is false**. Each new branch activates only when a record carries the optional `agentIdentity` snapshot (added in M3), which is set solely by the flag-gated collaborator loop — so while dark, no record carries it and every branch falls through to the exact pre-M4 value. The flag flip is the v1.0 launch call and is **not** in this PR.

### What's in it

- **`agentColor()`** — a per-`provider` (closed 5-enum) → CSS-token helper. Theme-adaptive for free (`--tandem-agent-*` tokens carry light/dark/forced-colors values); rename-stable (keys on the frozen `provider`, not the editable `displayName`); `anthropic` reuses the existing coral so the fallback is byte-identical by construction.
- **Per-agent color on 6 reachable surfaces**, each falling back to `var(--tandem-author-claude)` when no identity: annotation card dot, in-editor comment underline, margin leader (via a now-**required** identity param → a missed call site is a compile error), reply byline, chat author, peek-strip dot.
- **Chip loading-gate** — extracted `resolveDefaultModelChip` hides the titlebar chip while a registry load is in flight, killing the empty→label pop.
- **First-run decouple** — extracted `resolveModelFirstRunNeeded` (takes **no** tutorial input — the structural proof of decoupling); dismissal is now **persisted** so a skip isn't re-nagged. Fixes M2b's two edges (no-tutorial user never saw it; tutorial replay re-summoned it).

### Scope calls (settled by 4 adversarial plan reviews: design / dark-safety / scope / test)

- **EXCLUDED** per-agent AuthorshipRange color — *unreachable, not deferred*: the loop writes zero body text (its edits are proposals; accepted text is attributed `author:"user"` client-side), so it emits no authorship ranges. A tripwire test pins this.
- **DROPPED** the accept/dismiss `provider` payload — two reviewers converged: the collaborator subscription ignores accept/dismiss (wakes only on chat), ADR-039 is single-agent, and a transient event has zero flip-time wire cost. Left as a documented flip-time deliverable, alongside the E2E stub-server loop harness.
- **Also documented as unreachable** (parallel to AuthorshipRange): the Claude focus-paragraph gutter (loop never sets focus presence); `propose_replacement` underlines stay violet by design.

### Tests (guarding the M3 "delete a line, suite stays green" trap)

Lit-path assertions at every wiring site (identity present → **not** the claude token), full-style-string checks on the underline, exact `.toBe` fallback + a pinned token vector for `agentColor`, the two first-run edges as **separate** cases via the extracted pure helpers, and the AuthorshipRange-zero tripwire. The E2E spec is skip-guarded and auto-enables at the flip.

`/simplify` applied: `agentTintColor` helper for the emit-or-omit sites, dropped a dead `byoEnabled` param, hoisted the repeated claude literal.

### Verification

typecheck + svelte-check + biome clean; no new token violations; full unit suite green (5084 passed; testid snapshot regenerated for the new `annotation-author-dot-{id}` testid).

### Deferred docs (intentional)

CLAUDE.md Status + the `annotation-author-dot-{id}` testid-registry line are **not** in this PR — the working tree carries an unrelated uncommitted design-system edit to CLAUDE.md, and Status reflects merged/shipped state anyway. Fold both in at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
