### PR TITLE
docs: correct README drift and remove the tool count from prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Tandem is approaching v1.0 and ships continuous improvements. See [CHANGELOG.md]
 
 ## What Tandem does
 
-Most people use AI on a document by copying a passage into a chat window, asking a question, and pasting the answer back. Tandem closes that loop. The AI sits beside the document you are editing and reads from it directly.
+Most people use AI on a document by copying a passage into a chat window, asking a question, and pasting the answer back. Tandem closes that loop: the AI sits beside the document you are editing and reads from it directly, so there is nothing to copy and nothing to paste back.
 
-When you highlight text, the AI sees the selection as you make it. You can ask it for a rewrite, a summary, a check on tone, or a second opinion. Its suggestions appear as cards next to the document. Accept them, reject them, or reply to ask for something different.
+Ask it for a rewrite, a summary, a check on tone, or a second opinion. Its suggestions arrive as cards next to the document — accept them, reject them, or reply to ask for something different.
 
 Tandem is built to work with Anthropic's Claude out of the box. Other AI tools can also connect. See [the developer section](#the-mcp-integration-policy) below for the details of which clients work and which are tested first.
 
@@ -72,7 +72,7 @@ Tandem is built to work with Anthropic's Claude out of the box. Other AI tools c
   <img src="docs/screenshots/04-toolbar-actions.png" alt="The top of the editor showing several documents open in tabs, the formatting toolbar, a text selection, and the Solo and Tandem mode toggle" width="800">
 </p>
 
-*Several documents open in tabs, with the formatting toolbar above the text. Highlight a passage and the AI sees the selection as you make it. The Solo / Tandem toggle on the right controls whether the AI's annotations appear live or wait until you are ready.*
+*Several documents open in tabs, with the formatting toolbar above the text. Highlight a passage and the AI sees the selection as you make it. The Solo / Tandem toggle on the right decides whether you are working alongside the AI or on your own — see [Privacy and trust](#privacy-and-trust) for what Solo holds back.*
 
 ## Who Tandem is for
 
@@ -93,25 +93,30 @@ Windows 10 version 22H2 or Windows 11. macOS 12 (Monterey) or later. Linux with 
 
 Pick the installer for your platform from the [latest release](https://github.com/bloknayrb/tandem/releases/latest). Windows, macOS, and Linux builds are available.
 
-The desktop app bundles the editor, the server it talks to, and storage for the connection token. Updates land automatically. Double-clicking a `.md`, `.txt`, or `.html` file opens it directly in Tandem.
+The desktop app bundles the editor, the server it talks to, and storage for the connection token. Updates land automatically. Double-clicking a `.md`, `.markdown`, `.txt`, `.html`, or `.docx` file opens it directly in Tandem.
 
 ### What you get
 
 - Multiple documents open in tabs, with `.md`, `.txt`, `.html`, and `.docx` support (Word files are editable; the original is only written when you explicitly save).
 - A scratchpad (`Ctrl+N`) for drafts you do not want to save to disk.
-- A command palette (`Ctrl+Shift+P`) for quick actions.
+- A command palette (`Ctrl+Shift+P`) with fuzzy search, ranked by how well each result matches.
 - Find and replace, including across all open tabs.
 - An outline panel for navigating long documents.
+- Paste that keeps its structure: Markdown tables and images arrive as real tables and images, and a URL pasted over selected text becomes a link.
+- Suggestions shown as word-level diffs, so you can see exactly which words change.
+- Optional smart typography (curly quotes, em dashes) and a spellcheck toggle, in Settings (`Ctrl+,`).
 - Light and dark themes.
 - Keyboard navigation through pending suggestions: `Alt+]` and `Alt+[` to move between them, `Ctrl+Enter` to accept, `Ctrl+Shift+Enter` to reject.
 
 ### Other ways to install
 
-If you use a terminal, you can also install Tandem with `npm install -g tandem-editor` (Node.js 22 or newer required), then run `tandem` — it starts the server and prints a `http://127.0.0.1:3479` URL to open the editor in your browser, where the first-run wizard connects Claude. (For a scripted, non-interactive setup, run `tandem setup --apply` once first.) This is mostly useful if you already have Node.js installed; the desktop app is the recommended experience.
+If you use a terminal, you can also install Tandem with `npm install -g tandem-editor` (Node.js 22.12 or newer required), then run `tandem` — it starts the server and prints a `http://127.0.0.1:3479` URL to open the editor in your browser, where the first-run wizard connects Claude. (For a scripted, non-interactive setup, run `tandem setup --apply` once first.) This is mostly useful if you already have Node.js installed; the desktop app is the recommended experience.
 
 ### Got stuck
 
-See [docs/troubleshooting.md](docs/troubleshooting.md) for common problems and how to resolve them.
+Run the built-in diagnostics first — they check the setup problems that cause most first-launch failures. In the desktop app, that is **Settings → About → Copy Diagnostics**. If you installed from npm, run `tandem doctor` instead. (The desktop app does not install the `tandem` command, so use the button rather than the CLI.)
+
+Then see [docs/troubleshooting.md](docs/troubleshooting.md) for common problems and how to resolve them.
 
 ## How you work with Tandem
 
@@ -128,14 +133,15 @@ See [docs/workflows.md](docs/workflows.md) for examples of how this looks in dai
 - Tandem itself runs on your computer and stores your documents on your disk. We do not operate any servers that hold your files.
 - When you ask the AI to do something, the text you share with it goes to whichever AI service you are using. For example, if you connect Claude, the text goes to Anthropic under their terms. Tandem does not relay or copy your document anywhere else.
 - Tandem includes a private notes feature. Notes you mark as private are stripped from every response the AI sees ([ADR-027](docs/decisions.md)).
-- Tandem does not collect telemetry or analytics by default — no usage data, and **crash reporting is off unless you turn it on**. Crash reporting is strictly opt-in: it activates only when you set the `TANDEM_SENTRY_DSN` environment variable to a [Sentry](https://sentry.io) or self-hosted [GlitchTip](https://glitchtip.com) DSN of your own. With that variable unset (the default), no crash data ever leaves your machine. When enabled, Tandem ships Rust panics, native crash minidumps, JavaScript errors, and unhandled rejections to *your* configured endpoint, scrubbing home-directory paths (to `~`), obvious API keys/bearer tokens, and request/document payloads before anything is sent. Self-hosting GlitchTip keeps the data fully under your control, in keeping with Tandem's local-first posture.
+- **Solo mode holds your work back from the AI.** The Solo / Tandem toggle in the title bar (`Ctrl+Shift+M`) is not just a notification setting: while you are in Solo, the comments and replies *you* write are withheld from what the AI is told and from what it can look up — its inbox, its reads of the annotation list, and the live updates pushed to it. Each held item shows an amber **Held** pill, the status bar keeps a running count, and switching back to Tandem releases the set together. One limit worth knowing: exporting an annotation report is a deliberate "give the AI everything" action and includes held comments. See [the user guide](docs/user-guide.md#solo--tandem-mode) for exactly what the hold does and does not cover.
+- Tandem does not collect telemetry or analytics by default — no usage data, and **crash reporting is off unless you turn it on**. It activates only if you set `TANDEM_SENTRY_DSN` to a [Sentry](https://sentry.io) or self-hosted [GlitchTip](https://glitchtip.com) endpoint of your own; unset (the default), no crash data ever leaves your machine. Sent reports are scrubbed of home-directory paths, API keys, and document payloads — see [docs/security.md](docs/security.md) for the details.
 - When paid licensing arrives at v1.0, running the app will validate a signed license file on your own machine (no network call required); update checks will remain network-only, carry no analytics, and the update service will log only what it needs to authorize the download.
 
 See [docs/security.md](docs/security.md) for the full security model.
 
 ## Where Tandem is headed
 
-Tandem is on the way to a v1.0 release. Today the supported AI integration is Claude (Claude Code / Claude Desktop) over MCP, set up with a one-click in-app wizard. Local models (Ollama, LM Studio) are committed for v1.0 and in active development (#1123) — they'll use the same one-time license as everything else; cloud API-key providers (OpenAI, Gemini) follow in v1.1. Recent releases added Word document write-back (edit a `.docx` and save it back as a real Word file — comments you've sent to your AI are written back as native Word comments) and pre-overwrite backups with in-product restore. Work still in progress covers turnkey setup on macOS and Linux, licensing, and final polish. Tandem is free during the public beta; at v1.0 it moves to a one-time paid license, and beta users are grandfathered with a free license. The full plan lives in [docs/roadmap.md](docs/roadmap.md).
+Tandem is on the way to a v1.0 release. Today the supported AI integration is Claude (Claude Code / Claude Desktop) over MCP, set up with a one-click in-app wizard. Local models (Ollama, LM Studio) are committed for v1.0 and in active development (#1123) — they'll use the same one-time license as everything else; cloud API-key providers (OpenAI, Gemini) follow in v1.1. Word documents round-trip: edit a `.docx` and save it back as a real Word file, with the comments you sent your AI written back as native Word comments — and Tandem snapshots a file before its first write, so you can restore the original from inside the app. Work still in progress covers turnkey setup on macOS and Linux, licensing, and final polish; pricing is covered under [License](#license) below. The full plan lives in [docs/roadmap.md](docs/roadmap.md), and [CHANGELOG.md](CHANGELOG.md) records what landed in each release.
 
 ## Documentation
 
@@ -171,7 +177,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open s
 
 The integration policy is set by [ADR-038](docs/decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration):
 
-> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same 28 tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today.
+> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same MCP tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today.
 >
 > **Integration setup** runs through the integration setup wizard (#477 PR 3). The earlier transitional behavior — Tandem auto-writing its MCP entry to Claude's config files on Tauri startup — was **removed in #477 PR 3c-ii-c**. Every integration (Claude included) is now configured via the wizard, never silently; `tandem setup --apply` is the scriptable non-interactive equivalent.
 
@@ -192,7 +198,7 @@ Client compatibility:
 - **How to enable (Windows desktop app):** open the integration wizard (Settings → AI Assistant, or "Set up" next to Cowork) and click **Enable Cowork**, or toggle it on in Settings → Network. Tandem writes the plugin entry into every detected Cowork workspace and adds a Windows firewall rule so the VM can reach the Tandem server on this computer. That firewall step needs admin once — without it, the VM can't connect.
 - **Why it's automated, not a manual marketplace install:** inside the VM the plugin must point at `host.docker.internal:3479` and carry a per-machine secret auth token. A published marketplace plugin can't carry that token, so Tandem provisions the workspace entries directly. (The published `tandem@tandem-editor` marketplace plugin is for Claude Code running *on the host*, over `127.0.0.1` — see below.)
 - **Verify:** in a Cowork session, ask Claude to open or list your documents — Tandem's tools should appear. If they don't, re-run Enable.
-- **Real-time updates:** live annotation/chat push needs the Tandem desktop app and Claude Code's channel flag (see [Channel push](#channel-push-and-real-time-updates)); the Cowork connection itself is request/response.
+- **Real-time updates:** live annotation/chat push needs the Tandem desktop app plus one of the push transports (see [Channel push](#channel-push-and-real-time-updates)); the Cowork connection itself is request/response.
 - **macOS / Linux:** not yet — tracked in #316 / #317.
 
 For Claude Code on the host, the published plugin can be added from the marketplace instead of the wizard:
@@ -202,11 +208,11 @@ claude plugin marketplace add bloknayrb/tandem
 claude plugin install tandem@tandem-editor
 ```
 
-This activates the MCP tools and the bundled skill. It does **not** auto-enable channel push (that still needs `--dangerously-load-development-channels`, see below).
+This activates the MCP tools, the bundled skill, and — on Claude Code 2.1.212 or newer — a monitor that delivers real-time events with no extra flag. See [Channel push](#channel-push-and-real-time-updates) for how that compares to the channel shim.
 
 ### MCP tools at a glance
 
-28 active tools across five capability areas. Full reference: [docs/mcp-tools.md](docs/mcp-tools.md).
+Tandem's MCP tools span five capability areas. Full reference: [docs/mcp-tools.md](docs/mcp-tools.md).
 
 - **Document.** Open, switch, list, close, and convert documents; read text content and outlines; save back to disk.
 - **Annotation.** Create, resolve, remove, and edit annotations; query the annotation list; export a review report.
@@ -216,7 +222,9 @@ This activates the MCP tools and the bundled skill. It does **not** auto-enable 
 
 ### Channel push and real-time updates
 
-Channel push delivers events (selections, annotation actions, chat messages) to the AI client over Server-Sent Events the moment they happen, so the AI does not have to poll. Two install options:
+Real-time push delivers events (selections, annotation actions, chat messages) to the AI client over Server-Sent Events the moment they happen, so the AI does not have to poll. There are two transports.
+
+**The channel shim** is the default and the one Tandem tests against ([ADR-028](docs/decisions.md)). Sessions the desktop app launches for you already have it. To wire it up yourself:
 
 ```bash
 tandem setup --apply --with-channel-shim                   # persistent setup
@@ -225,7 +233,11 @@ claude --dangerously-load-development-channels server:tandem-channel   # one-off
 
 The `--dangerously-load-development-channels` flag is Claude Code's marker for unstable APIs; it becomes unnecessary when the Channels API stabilizes.
 
-Without channel push, the AI uses `tandem_checkInbox` to pull the same events on demand. You can also ask Claude to poll periodically with `/loop 30s check tandem inbox and respond to any new messages`.
+**The plugin monitor** is the alternative for sessions you start by hand, and it needs no flag. Installing the plugin (above) registers it, and every `claude` you start afterwards wakes on document changes. It requires **Claude Code 2.1.212 or newer** — on older versions the install still succeeds and the monitor simply never runs, with nothing to tell you so, which is why the version matters. Do not enable both: each transport delivers independently, so a session running the plugin *and* the channel flag receives every event twice.
+
+Note that Solo mode suppresses annotation events on both transports by design — chat still comes through. If you are testing push and only chat arrives, check the mode toggle before debugging the transport.
+
+Without either, the AI uses `tandem_checkInbox` to pull the same events on demand. You can also ask Claude to poll periodically with `/loop 30s check tandem inbox and respond to any new messages`.
 
 ### Development setup
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,11 +2,11 @@
 
 ## Integration Compatibility
 
-> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same 28 tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today. See [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration).
+> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same MCP tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today. See [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration).
 
 Four terms — **MCP contract**, **default integration**, **Claude-specific extras**, and **best-effort, not validated** — are used throughout this document with the precise meanings defined in [ADR-038's term glossary](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration) (the single source of truth).
 
-Sections below labeled "Claude-default" describe features in the **Claude-specific extras** column. Generic MCP plumbing (the HTTP server, the SSE stream, the 28 tools) works for any MCP-capable client.
+Sections below labeled "Claude-default" describe features in the **Claude-specific extras** column. Generic MCP plumbing (the HTTP server, the SSE stream, the MCP tools) works for any MCP-capable client.
 
 ## System Context
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -702,15 +702,21 @@ This ADR records the policy that resolves the gap: Tandem is an MCP-first produc
 
 **Decision §1 — canonical policy statement.** Every doc surface that states the policy quotes the following paragraphs verbatim:
 
-> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same 28 tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today.
+> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same MCP tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today.
 >
 > **Integration setup** runs through the integration setup wizard (#477 PR 3). The earlier transitional behavior — Tandem auto-writing its MCP entry to Claude's config files on Tauri startup — was **removed in #477 PR 3c-ii-c**. Every integration (Claude included) is now configured via the wizard, never silently; `tandem setup --apply` is the scriptable non-interactive equivalent.
+
+The canonical paragraph deliberately states **no tool count**. The exact figures live in one
+place — [mcp-tools.md](mcp-tools.md) — with `CLAUDE.md` as the contributor-facing mirror. A
+number embedded in a verbatim-quoted paragraph goes stale on every quoting surface at once,
+which has now happened twice (27→28, then 28→29; see `audit-v3-docs.md` R7). Prose elsewhere
+says "the MCP tools"; only the reference states how many.
 
 Four terms have precise meanings; every doc surface uses them consistently:
 
 | Term | Meaning |
 |---|---|
-| **MCP contract** | The 28 active MCP tools at `http://127.0.0.1:3479` and the SSE event stream at `/api/events`. Available to every MCP client. |
+| **MCP contract** | The active MCP tools at `http://127.0.0.1:3479` and the SSE event stream at `/api/events`. Available to every MCP client. |
 | **Default integration** | Claude. Recommended in all install flows. Documented, tested, and the target of the first-run wizard's one-click setup. |
 | **Claude-specific extras** | Six features built on top of the MCP contract that only work with Claude today: (1) channel push (channel shim + plugin monitor), (2) `--dangerously-load-development-channels` flag wiring, (3) auto-launcher (#477 PR 4), (4) Cowork plugin bridge (`tandem mcp-stdio`), (5) Claude Code skill (`skills/tandem/SKILL.md`), (6) plugin marketplace artifacts (`.claude-plugin/`). |
 | **Best-effort, not validated** | What we say about other MCP clients today. We don't intentionally break them; we don't test them. The MCP HTTP endpoint is the same surface they all use. |

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -12,7 +12,7 @@ The core value: **you point at text, the AI sees it, and you iterate together wi
 
 > **Integration policy ([ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration)):**
 >
-> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same 28 tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today.
+> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same MCP tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today.
 
 ## What Makes It Different
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ The v0.12.0 prep batch (8 parallel units, PRs #634–#641) shipped 2026-05-14. W
 
 ## Integration Policy (ADR-038)
 
-> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same 28 tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today.
+> Tandem's integration contract is **MCP**. The default integration is **Claude** (Claude Code + Claude Desktop) — it's what we recommend, what we test against, and it ships with the channel push, cowork, plugin monitor, and auto-launcher features. Any MCP-capable client can connect to the same MCP HTTP endpoint and use the same MCP tools, but the Claude-specific transports don't apply. Other clients are **best-effort, MCP-contract-compatible, not validated** today.
 >
 > **Integration setup** runs through the integration setup wizard (#477 PR 3). Silent auto-configuration of Claude's MCP config on startup was removed in #477 PR 3c-ii-c; setup is now wizard-driven and explicit.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,7 +2,7 @@
 
 A complete guide to using Tandem — from first launch to advanced workflows.
 
-> **Scope:** Examples use Claude Code as the default AI, per [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration). The editor itself is AI-client-agnostic — any MCP-capable client connecting to `http://127.0.0.1:3479/mcp` gets the same 28 tools. The Claude-specific transports (channel push, cowork, auto-launcher) don't apply to other clients.
+> **Scope:** Examples use Claude Code as the default AI, per [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration). The editor itself is AI-client-agnostic — any MCP-capable client connecting to `http://127.0.0.1:3479/mcp` gets the same MCP tools. The Claude-specific transports (channel push, cowork, auto-launcher) don't apply to other clients.
 
 > **Setting up an AI integration rather than learning the editor?** Skip to [Working with Claude Code](#working-with-claude-code) for the Claude default, or see [README → The MCP integration policy](../README.md#the-mcp-integration-policy) for the generic MCP path.
 
@@ -178,12 +178,26 @@ You can also enable the **margin view** (decorations menu) to see annotation car
 
 ### Solo / Tandem Mode
 
-The title bar includes a **Solo / Tandem** toggle (`Ctrl+Shift+M`) that controls whether Claude's annotations appear as they arrive.
+The title bar includes a **Solo / Tandem** toggle (`Ctrl+Shift+M`). It holds work back in *both* directions — Claude's annotations are held from you, and your own comments are held from Claude.
 
-- **Tandem** (default) — Claude's annotations appear immediately as they arrive.
-- **Solo** — Claude's pending annotations are held back. Resolved annotations (accepted/dismissed) are always visible regardless of mode.
+- **Tandem** (default) — Claude's annotations appear immediately as they arrive, and the comments and replies you write are visible to Claude.
+- **Solo** — Claude's pending annotations are held back from the document. Resolved annotations (accepted/dismissed) are always visible regardless of mode.
 
-Use **Solo** during focused writing to avoid interruption. Switch to **Tandem** when you're ready to see Claude's suggestions — all held annotations appear at once.
+Since v0.19.0 the server, not the client, enforces the other direction: while you are in Solo, the comments and replies **you** author are withheld from Claude. Each held item shows an amber **Held** pill, and the status bar shows a running count of what is being withheld. Switching back to Tandem releases the whole set at once — Claude picks them up on its next check, and a one-time nudge wakes a push-connected session to look.
+
+**Exactly what the Solo hold covers.** Held comments and replies are withheld from three surfaces:
+
+| Surface | Held in Solo? |
+|---|---|
+| `tandem_checkInbox` (what Claude is told) | Yes |
+| `tandem_getAnnotations` (Claude reading the annotation list) | Yes |
+| Real-time push (channel shim and plugin monitor) | Yes — annotation events only; chat messages always deliver |
+| `tandem_exportAnnotations` (generating a review report) | **No** — an export is an explicit "give Claude everything" action and includes held comments |
+| `tandem_getTextContent`, `tandem_getContext`, `tandem_search` | Not applicable — these return document text only, never annotation records |
+
+Personal **notes** are private in both modes and are never surfaced to Claude through any tool ([ADR-027](decisions.md)).
+
+Use **Solo** during focused writing to avoid interruption, or when you want to mark up a draft without Claude reacting to each comment. Switch to **Tandem** when you're ready — all held annotations appear at once, in both directions.
 
 ## Chat
 
@@ -257,7 +271,7 @@ Press `?` to open the in-app shortcuts reference at any time — it always refle
 
 ## Working with Claude Code
 
-Tandem connects to Claude Code through MCP (Model Context Protocol). Claude gets 31 tools (28 active, 3 deprecated stubs) for reading documents, creating annotations, searching text, managing files, and communicating with you.
+Tandem connects to Claude Code through MCP (Model Context Protocol). Claude gets Tandem's full MCP tool surface for reading documents, creating annotations, searching text, managing files, and communicating with you.
 
 ### Connection
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,6 +1,6 @@
 # Workflows
 
-> **Scope:** Real-world usage patterns. Examples use Claude Code as the default AI integration per [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration); patterns generalize to any MCP-capable client speaking the same 28 tools at `http://127.0.0.1:3479/mcp`.
+> **Scope:** Real-world usage patterns. Examples use Claude Code as the default AI integration per [ADR-038](decisions.md#adr-038-mcp-first-integration-policy-claude-as-default-integration); patterns generalize to any MCP-capable client speaking the same MCP tools at `http://127.0.0.1:3479/mcp`.
 
 > **Looking for editor UI help?** See the [User Guide](user-guide.md) for how to use the editor, annotations, chat, and keyboard shortcuts. This document covers Claude Code workflows with MCP tool examples.
 
@@ -36,7 +36,7 @@ Then in Claude, your tandem_* tools will be available.
 
 Bare `tandem setup` (no flags) prints this guidance instead of writing anything — setup is wizard-driven; `--apply` is the explicit opt-in to write config.
 
-The skill teaches Claude how to use Tandem's 31 MCP tools (28 active, 3 deprecated stubs) effectively — workflow patterns, annotation strategy, Solo/Tandem mode respect, and error recovery. It auto-activates when Claude detects `tandem_*` tools.
+The skill teaches Claude how to use Tandem's MCP tools effectively — workflow patterns, annotation strategy, Solo/Tandem mode respect, and error recovery. It auto-activates when Claude detects `tandem_*` tools.
 
 Start Tandem from any directory:
 ```bash

--- a/tests/docs/tool-count-drift.test.ts
+++ b/tests/docs/tool-count-drift.test.ts
@@ -1,0 +1,150 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Tool-count drift guard.
+ *
+ * The active-tool count has now gone stale twice — 27→28 (`docs/audit-v3-docs.md` F5) and
+ * 28→29 — each time across nine or more documentation files, because the number was
+ * embedded in a paragraph that several docs quote verbatim. R7 of that same audit proposed
+ * the structural fix: state the count in ONE reference file and say "the MCP tools"
+ * everywhere else. This test enforces both halves of that.
+ *
+ * Positive half: the counts printed in `docs/mcp-tools.md` (the reference) and `CLAUDE.md`
+ * (the contributor mirror) match what `src/server/mcp/` actually registers.
+ *
+ * Negative half — the load-bearing one: the files that were de-numbered must not silently
+ * reacquire a count. Without it this guard would go green while eight other files drift,
+ * which is worse than no guard because it reads as solved.
+ *
+ * Static source scanning rather than booting a server, matching the rationale in
+ * `tests/server/license-gate-coverage.test.ts`: the regression class is "a doc says a
+ * number that registration no longer supports", and a static read cannot be fooled by a
+ * green run.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, "..", "..");
+const MCP_DIR = join(REPO_ROOT, "src", "server", "mcp");
+
+/** Concatenate every MCP source file so a tool is found regardless of its home. */
+function allMcpSource(): string {
+  const parts: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+        parts.push(readFileSync(full, "utf-8"));
+      }
+    }
+  };
+  walk(MCP_DIR);
+  return parts.join("\n");
+}
+
+const SRC = allMcpSource();
+
+const read = (relative: string): string => readFileSync(join(REPO_ROOT, relative), "utf-8");
+
+/**
+ * Deprecated stubs return an MCP error instead of doing work, so they count toward the
+ * total but not the active figure. Named explicitly (rather than inferred) because
+ * un-stubbing one is a deliberate act that should force a look at this list — the
+ * companion assertion below fails if a name here stops being a stub.
+ */
+const DEPRECATED_STUBS = ["tandem_highlight", "tandem_suggest", "tandem_flag"];
+
+/**
+ * `\s*` so a registration whose name sits on the following line is still matched. A Set
+ * rather than a match count, so a duplicate registration can't inflate the total.
+ */
+function registeredToolNames(): Set<string> {
+  return new Set(
+    [...SRC.matchAll(/server\.(?:tool|registerTool)\(\s*"(tandem_\w+)"/g)].map((m) => m[1]),
+  );
+}
+
+describe("MCP tool count stated in docs", () => {
+  it("every named deprecated stub is registered and still returns DEPRECATED", () => {
+    const registered = registeredToolNames();
+    for (const name of DEPRECATED_STUBS) {
+      expect(registered, `${name} is no longer registered`).toContain(name);
+      // The stub body calls notifyDeprecatedTool with its own name; if it were un-stubbed
+      // that call would go, and the active count below would be wrong by one.
+      expect(SRC, `${name} no longer looks like a deprecated stub`).toContain(
+        `notifyDeprecatedTool("${name}")`,
+      );
+    }
+  });
+
+  it("docs/mcp-tools.md states the counts that source actually registers", () => {
+    const total = registeredToolNames().size;
+    const active = total - DEPRECATED_STUBS.length;
+    expect(read("docs/mcp-tools.md")).toContain(
+      `Tandem exposes ${total} tools via MCP HTTP (${active} active, ${DEPRECATED_STUBS.length} deprecated stubs`,
+    );
+  });
+
+  it("CLAUDE.md mirrors the same counts", () => {
+    const total = registeredToolNames().size;
+    const active = total - DEPRECATED_STUBS.length;
+    const claudeMd = read("CLAUDE.md");
+    expect(claudeMd).toContain(
+      `All ${total} MCP tools (${active} active, ${DEPRECATED_STUBS.length} deprecated stubs)`,
+    );
+    expect(claudeMd).toContain(`${active} active MCP tools`);
+  });
+});
+
+/**
+ * Files deliberately de-numbered so the count lives in one place. `docs/decisions.md` is
+ * excluded: its ADR-019 rationale and ADR-038 Context legitimately record counts that were
+ * true when written, and rewriting history to match today's number is the opposite of what
+ * an ADR is for.
+ */
+const DE_NUMBERED = [
+  "README.md",
+  "docs/architecture.md",
+  "docs/positioning.md",
+  "docs/roadmap.md",
+  "docs/user-guide.md",
+  "docs/workflows.md",
+];
+
+/**
+ * Matches "28 tools", "29 active tools", "31 MCP tools", "28 active MCP tools" — the four
+ * shapes the two historical drifts actually took. Deliberately broad: a false positive
+ * here costs one line of prose, a false negative costs another cross-repo drift.
+ */
+const COUNT_PATTERN = /\b\d+\s+(?:active\s+)?(?:MCP\s+)?tools\b/g;
+
+/**
+ * Occurrences that are not drift, keyed by file. Both are statements about something other
+ * than "how many tools Tandem has today", which is the only claim this guard protects:
+ * a CI assertion threshold, and a roadmap entry recording the count at a past milestone.
+ * Exempting the surrounding phrase rather than the bare number keeps the exemption narrow —
+ * if the sentence changes, the guard speaks up again.
+ */
+const ALLOWED: Record<string, string[]> = {
+  "docs/architecture.md": ["asserts ≥20 tools registered"],
+  "docs/roadmap.md": ["(24 tools total)"],
+};
+
+describe("de-numbered docs do not reacquire a tool count", () => {
+  it.each(DE_NUMBERED)("%s states no tool count", (relative) => {
+    let text = read(relative);
+    for (const phrase of ALLOWED[relative] ?? []) {
+      expect(text, `stale exemption in ${relative}: "${phrase}" no longer appears`).toContain(
+        phrase,
+      );
+      text = text.split(phrase).join("");
+    }
+    const offenders = [...text.matchAll(COUNT_PATTERN)].map((m) => m[0]);
+    expect(
+      offenders,
+      `${relative} states a tool count (${offenders.join(", ")}). The count belongs in ` +
+        `docs/mcp-tools.md only — say "the MCP tools" here. See ADR-038 and audit-v3-docs R7.`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

A thorough accuracy pass over `README.md` — the repo front door *and* the npm package page — which last had a substantial revision around v0.14.0. Five minors have shipped since, and parts of it had drifted from stale into wrong.

Every finding was verified against source on this branch's base, not from memory or docs. Four adversarial reviewers went over the plan before any edit; two of them changed it materially.

## Corrections

| Was | Is |
|---|---|
| Installing the marketplace plugin "does **not** auto-enable channel push" | Since #1201 the manifest ships a monitor that Claude Code 2.1.212+ activates **with no flag** — the README stated the opposite of what ships |
| Double-click opens `.md`, `.txt`, `.html` | `tauri.conf.json` also registers `.markdown` and `.docx` |
| "Node.js 22 or newer" | `engines` requires `>=22.12.0` — 22.0–22.11 satisfied the README and failed the package |
| Solo mode described in a screenshot caption as a display preference | It is a server-enforced hold (#1212); now in **Privacy and trust**, scoped honestly |
| "Recent releases added …" | Described v0.14.0. Rewritten as durable capability so it stops decaying |

The push section now names the **2.1.212** floor explicitly. Below it, both documented install commands succeed and the monitor simply never runs, with no error and no log — the one failure mode a user cannot self-diagnose. It also warns that running the plugin *and* the channel flag delivers every event twice.

The Solo bullet deliberately does **not** claim the AI cannot see your Solo comments. Traced: the hold routes through `hideFromAI` and is enforced at push, `tandem_checkInbox`, and `tandem_getAnnotations` — but `tandem_exportAnnotations` filters only `type !== "note"`, so an export returns held comments in full. `docs/user-guide.md` carried the older one-directional description and gains the full coverage table, since it is where the README sends readers for detail.

## The tool count: removed, not corrected

The README said 28 active tools. Source registers 32, of which 3 are deprecated stubs — 29 active.

The obvious fix is to write 29 in the nine files that say 28. That is exactly what produced this drift twice already (27→28, then 28→29), because the number sits inside a paragraph that five docs quote verbatim. `docs/audit-v3-docs.md` R7 proposed the structural fix after the last occurrence and it was never actioned: state the count in `docs/mcp-tools.md` alone, and say "the MCP tools" everywhere else. Doing that now.

`tests/docs/tool-count-drift.test.ts` enforces both halves — the reference file matches what source actually registers, *and* the de-numbered files do not quietly reacquire a count. The negative half is the load-bearing one; without it the guard would go green while eight other files drift, which reads as solved and is worse than nothing. **Verified red against reintroduced drift in both directions before being accepted as green.**

ADR-038's source text is edited in place rather than given an `Update` block, following the precedent this repo set for the 27→28 correction: the count is incidental description, not decision substance, and the verbatim quotes must stay faithful. A note at the decision point records *why* the paragraph now carries no number, so a future editor does not helpfully add one back.

Historical counts are deliberately untouched — ADR-019's rationale, ADR-038's Context, and old roadmap entries record what was true when written. `tests/e2e/settings-and-filters.spec.ts`'s `toolCount: 31` is a UI fixture that never reads the real count, so it is not a drift site either.

## Cuts

The README grows every revision and has shrunk in none. This one cuts as well as adds: the beta/license claim was stated twice near-verbatim (kept in **License**, referenced from the roadmap paragraph), the crash-reporting paragraph read as a security-doc excerpt rather than a trust signal, and "What Tandem does" restated the intro.

"What you get" gains only what changes what a reader can *do* — Markdown paste, word-level diffs, smart typography and spellcheck. The unified Settings modal and the consolidated AI indicator are consolidations: a first-time reader has no prior version to compare against, so they belong in the changelog, not the landing page.

## Deliberately out of scope

- **Screenshots.** The four embedded PNGs are from 2026-06-18 and show a status bar that no longer exists (Find & Replace redesign, status-pill changes, Settings consolidation, and the design-system resync all postdate them). Re-capturing needs a running app and a human eye — its own PR.
- **The audience question.** `docs/positioning.md` targets writers explicitly *not* developers, yet paragraph two leads with "Claude Code is the default" and the walkthrough says "Start Claude" without saying what that is or how to get it. For the stated audience that is arguably the document's largest unanswered question — but it is a repositioning of the getting-started path, not an accuracy fix, and it is a product call rather than a docs one.
- `docs/roadmap.md`'s void per-feature version pins (v0.16.0 = licensing, v0.17.0 = local models). Real, but roadmap surgery.

## Verification

- `npm run typecheck` — clean (1280 files, 0 errors).
- `npm test` — 5096 passed, 0 test failures. One test *file* fails on a 10s `beforeAll` timeout resolving the Vite config (`css-pipeline-contract`); **confirmed pre-existing** by running it on a clean master checkout, and untouched by this diff.
- The drift guard proven red on reintroduced drift, then green.
- Every link, anchor, and Contents entry re-checked, including the new cross-reference into the user guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W64remM1QrwdU1goyR8dxr