### PR TITLE
docs: tell new users how to connect an AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Tandem is a document editor that lets you and an AI work on the same file together. You highlight a passage. The AI sees what you highlighted and can ask about it, comment on it, or propose changes that appear as cards beside your document. You decide what to keep.
 
-One thing to know up front: the AI side requires an MCP-capable AI client — [Claude Code](https://claude.com/claude-code) is the default — and the subscription behind it (for Claude, a paid Anthropic plan). Without one connected, Tandem is a capable local document editor and nothing more.
+One thing to know up front: the AI side needs an AI client running on your own computer, plus the subscription behind it. [Claude Code](https://claude.com/claude-code) is the default, and a Claude Pro or Max subscription includes it. Clients connect over [MCP](https://modelcontextprotocol.io) — an open standard for letting an AI reach tools and files — so others can be used too. [Connect your AI](#connect-your-ai) below covers the setup, which is a wizard rather than a config file. Without a client connected, Tandem is a capable local document editor and nothing more.
 
 Tandem is approaching v1.0 and ships continuous improvements. See [CHANGELOG.md](CHANGELOG.md) for what is in the latest release.
 
@@ -76,9 +76,9 @@ Tandem is built to work with Anthropic's Claude out of the box. Other AI tools c
 
 ## Who Tandem is for
 
-- If you draft long-form writing and want a second reader for tone and structure.
-- If you review documents — an essay, a thesis chapter, a report, or a contract — and want a faster pass.
-- When a colleague hands you a document to mark up.
+- If you draft long-form writing — an essay, a report, a proposal, a design doc — and want a second reader for tone and structure.
+- If you review what someone else wrote — a thesis chapter, a contract, a spec, an RFC — and want a faster pass.
+- When a colleague hands you a document to mark up, or a design lands in your queue for sign-off.
 - When the AI wrote a draft and you need to decide what to keep.
 
 Tandem is built for individuals working on their own documents. The example document types above are just that — examples; the workflow is the same whatever you are writing or reviewing. The interface is English-only for now.
@@ -94,6 +94,18 @@ Windows 10 version 22H2 or Windows 11. macOS 12 (Monterey) or later. Linux with 
 Pick the installer for your platform from the [latest release](https://github.com/bloknayrb/tandem/releases/latest). Windows, macOS, and Linux builds are available.
 
 The desktop app bundles the editor, the server it talks to, and storage for the connection token. Updates land automatically. Double-clicking a `.md`, `.markdown`, `.txt`, `.html`, or `.docx` file opens it directly in Tandem.
+
+### Connect your AI
+
+Installing Tandem gives you the editor. The AI half needs one more thing: an AI client running on your machine, and the subscription behind it.
+
+The default — and the one Tandem is tested against — is [Claude Code](https://claude.com/claude-code), Anthropic's Claude that runs on your own computer rather than in a browser tab. **A Claude Pro or Max subscription includes it**, so if you already pay for Claude you are most likely already covered; pay-as-you-go API billing works too. See [Anthropic's pricing](https://claude.com/pricing) for what each plan costs.
+
+One thing worth knowing before you start: **the Claude you use at claude.ai in a browser cannot connect to Tandem.** A web page has no way to reach a document sitting on your disk. So a subscription is necessary but not sufficient — you also need Claude Code, or Claude Desktop, installed locally.
+
+You do not have to configure any of this by hand. Tandem opens a setup wizard the first time you run it: if Claude Code is not installed, the wizard can install it for you in one click on Windows, macOS, and Linux, and it then writes the connection settings itself. You can reopen it any time from **Settings → AI Assistant**.
+
+Prefer a different AI? Any MCP-capable client can connect to the same endpoint — see the [compatibility table](#the-mcp-integration-policy) for what is supported and what is untested, and [Cowork](#cowork) for connecting Claude Desktop on Windows.
 
 ### What you get
 
@@ -121,7 +133,7 @@ Then see [docs/troubleshooting.md](docs/troubleshooting.md) for common problems 
 ## How you work with Tandem
 
 1. Open a document in Tandem.
-2. Start Claude. Tandem and Claude connect automatically once you have run setup once.
+2. Start your AI client — Claude Code, in the default setup. Once you have been through [Connect your AI](#connect-your-ai), Tandem and Claude find each other automatically; you do not reconnect them each time.
 3. Type a question in the chat panel, or highlight text in the document to focus the AI on a passage. The AI sees what you highlight as you highlight it.
 4. The AI's suggestions appear as cards beside the document. You decide what to accept.
 5. Save when you are finished.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -366,7 +366,7 @@ Make sure Claude Code is running and connected. Check `tandem_status` from Claud
 
 If using channels, the server must be running before Claude Code starts. If you restarted the server, restart Claude Code or run `/mcp`. Channel timeout messages such as `/api/events timed out after 10000ms`, `SSE inactivity timeout`, or `/api/channel-reply timed out after 5000ms` mean the server accepted a connection but stopped responding; restart Tandem and reconnect Claude.
 
-For server-side and MCP troubleshooting, see the [README](../README.md#troubleshooting).
+For server-side and MCP troubleshooting, see [troubleshooting.md](troubleshooting.md).
 
 ### Desktop app: server won't start
 


### PR DESCRIPTION
Follows #1226. That PR fixed what the README got *wrong*; this one fixes what it never said.

## The defect

The README's third paragraph says the AI side needs a client and a subscription. `## Getting started` then runs System requirements → Download → What you get → Other ways to install → Got stuck — **no step for connecting an AI at all**. A reader who follows it exactly ends up with what line 18 itself calls "a capable local document editor and nothing more," and hits `## How you work with Tandem` step 2, *"Start Claude. Tandem and Claude connect automatically once you have run setup once"* — a forward reference to a setup the document never described.

The wizard *is* mentioned five times in the file, but none of them is inside the section a new user is following: line 113 is a subordinate clause in the npm path (which the same sentence calls the non-recommended route), line 144 is under `## Where Tandem is headed` where the neighbouring sentences are future-tense, and the rest are in the developer section.

## What changed

**A new `### Connect your AI` step**, between "Download the desktop app" and "What you get" — before the feature list, so a reader scanning top-down hits it before concluding they're done. It answers the two questions a first-time reader actually stops on, **neither of which was answered anywhere in this repository**:

- *Does the Claude subscription I already pay for cover this?* — I grepped `docs/` for subscription/plan/claude.ai; nothing addresses it. Silence reads as the bad answer.
- *Why doesn't the claude.ai tab I have open work?* — that fact existed only in the compatibility table under `## For developers and contributors`, i.e. behind the header that tells a writer to stop reading. The reader most likely to assume "I'm covered" was given nothing to correct them.

It also surfaces the one-click Claude Code installer (all three platforms), which the README had never mentioned.

**Three smaller repairs.** MCP glossed where it first appears rather than only at its definition 88 lines later inside the developer section; walkthrough step 2 names what it's asking you to start; audience examples broadened to design docs, specs and RFCs alongside essays and contracts — interleaved into one list rather than appended as a second, since two lists would assert the audiences are distinct.

**One adjacent dead link**, found while editing: `docs/user-guide.md` pointed at `README.md#troubleshooting`, an anchor that has never existed. Now points at `troubleshooting.md`.

## Deliberately not done

- **No dollar figures.** Pricing is Anthropic's and would rot here — exactly the drift class #1226 spent a PR eliminating. The section states the shape and links to their pricing page.
- **No `docs/positioning.md` edit.** ADR-040 §1 already names the audience as "individuals (writers, editors, researchers, developers)", so this is consistent with it. But positioning.md's three enumerated bullets don't say "developer", so this knowingly leaves a small residual framing inconsistency in a strategy doc with its own review cadence.
- **Screenshots** still stale from 2026-06-18 (own PR, needs a running app).

## Review

Plan went through four adversarial reviewers before implementation. They caught two false claims in my own plan — that the wizard was "mentioned exactly once in the whole file" (it's five), and that #1226 touched three of the four regions this edits (it touched one; `git diff origin/master...HEAD` confirms line 18 and step 2 were untouched). Both were assertions I made without grepping. They also found the cost/subscription gap above, which my plan had missed entirely.

## Verification

- Anchors `#connect-your-ai`, `#the-mcp-integration-policy`, `#cowork` all resolve; the only inbound cross-file README anchor (`user-guide.md:7`) still resolves.
- `## Contents` lists `h2`s plus the developer section's `h3`s only — Getting started's `h3`s are absent, so the new one correctly needs no entry.
- `tests/docs/tool-count-drift.test.ts` 9/9, `tests/plugin*` 10/10 (the latter asserts a heading whose text is exactly `Cowork`, which three Svelte components link to at runtime).
- Capability claims traced to source: install platforms `install-claude-cli.ts:357-359`; first-run gate `api-routes.ts:388-390`; **Settings → AI Assistant** still current at `SettingsModal.svelte:149-154`.
- `npm run typecheck` clean. `npm test`: **5096 passed, 0 test failures.** One test *file* fails on a 10s `beforeAll` timeout resolving the Vite config (`css-pipeline-contract.test.ts`) — pre-existing and machine-local, identical on clean master, confirmed during #1226.

**One claim I could not verify from this repo:** "A Claude Pro or Max subscription includes it." It's Anthropic's commercial fact, not Tandem's, and it's the single most useful sentence in the section — worth an eye before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W64remM1QrwdU1goyR8dxr