### PR TITLE
docs(sample): anchor the timeline claims in the welcome doc's demo paragraph

### DIFF
--- a/sample/welcome.md
+++ b/sample/welcome.md
@@ -47,6 +47,6 @@ Want to connect your AI? Open Settings → AI Assistant and use the setup wizard
 
 ## Sample Content
 
-The project launched in early 2025 with three core goals: simplify onboarding and reduce support tickets by 40% in Q2, then ship a self-service dashboard by Q3. The team hit both Q2 goals a month early, but the dashboard slipped to Q4 after an unexpected API redesign in May.
+The project launched in early 2025 with three core goals: simplify onboarding, reduce support tickets by 40% in Q2, and ship a self-service dashboard by Q3. The team hit both Q2 goals a month early, but the dashboard slipped to Q4 after an unexpected API redesign in May.
 
 > Once your AI connects, try asking it to help you improve this text — you'll see highlights and suggestions appear in the side panel.

--- a/sample/welcome.md
+++ b/sample/welcome.md
@@ -47,6 +47,6 @@ Want to connect your AI? Open Settings → AI Assistant and use the setup wizard
 
 ## Sample Content
 
-The project launched in early 2025 with three core goals: simplify onboarding, reduce support tickets by 40%, and ship a self-service dashboard by Q3. The team completed the first two milestones ahead of schedule, but the dashboard timeline slipped due to an unexpected API redesign in May.
+The project launched in early 2025 with three core goals: simplify onboarding and reduce support tickets by 40% in Q2, then ship a self-service dashboard by Q3. The team hit both Q2 goals a month early, but the dashboard slipped to Q4 after an unexpected API redesign in May.
 
 > Once your AI connects, try asking it to help you improve this text — you'll see highlights and suggestions appear in the side panel.

--- a/scripts/take-screenshots.mjs
+++ b/scripts/take-screenshots.mjs
@@ -246,13 +246,17 @@ async function main() {
     }
 
     // Comment on the timeline slip mention
-    const flagText = "the dashboard timeline slipped due to an unexpected API redesign in May";
+    // Anchored on an exact substring of sample/welcome.md. `findRange` returns
+    // null when the prose changes, and the `if` below then drops the annotation
+    // silently -- the screenshot just comes out missing a comment. If you edit
+    // that sentence, edit this string with it.
+    const flagText = "the dashboard slipped to Q4 after an unexpected API redesign in May";
     const flRange = findRange(flagText);
     if (flRange) {
       await mcp.addAnnotation("tandem_comment", {
         from: flRange.from,
         to: flRange.to,
-        text: "This needs a mitigation plan or updated timeline before sharing externally.",
+        text: "A new date without a recovery plan still reads as a slip. Say what changed before sharing externally.",
         textSnapshot: flagText,
       });
       console.log("   + comment added (was flag)");

--- a/tests/fixtures/welcome-snapshot.md
+++ b/tests/fixtures/welcome-snapshot.md
@@ -47,6 +47,6 @@ Want to connect your AI? Open Settings → AI Assistant and use the setup wizard
 
 ## Sample Content
 
-The project launched in early 2025 with three core goals: simplify onboarding and reduce support tickets by 40% in Q2, then ship a self-service dashboard by Q3. The team hit both Q2 goals a month early, but the dashboard slipped to Q4 after an unexpected API redesign in May.
+The project launched in early 2025 with three core goals: simplify onboarding, reduce support tickets by 40% in Q2, and ship a self-service dashboard by Q3. The team hit both Q2 goals a month early, but the dashboard slipped to Q4 after an unexpected API redesign in May.
 
 > Once your AI connects, try asking it to help you improve this text — you'll see highlights and suggestions appear in the side panel.

--- a/tests/fixtures/welcome-snapshot.md
+++ b/tests/fixtures/welcome-snapshot.md
@@ -47,6 +47,6 @@ Want to connect your AI? Open Settings → AI Assistant and use the setup wizard
 
 ## Sample Content
 
-The project launched in early 2025 with three core goals: simplify onboarding, reduce support tickets by 40%, and ship a self-service dashboard by Q3. The team completed the first two milestones ahead of schedule, but the dashboard timeline slipped due to an unexpected API redesign in May.
+The project launched in early 2025 with three core goals: simplify onboarding and reduce support tickets by 40% in Q2, then ship a self-service dashboard by Q3. The team hit both Q2 goals a month early, but the dashboard slipped to Q4 after an unexpected API redesign in May.
 
 > Once your AI connects, try asking it to help you improve this text — you'll see highlights and suggestions appear in the side panel.

--- a/tests/scripts/screenshot-anchors.test.ts
+++ b/tests/scripts/screenshot-anchors.test.ts
@@ -1,0 +1,44 @@
+/**
+ * `scripts/take-screenshots.mjs` anchors its demo annotations on exact
+ * substrings of `sample/welcome.md`. When that prose is edited, `findRange`
+ * returns null and the script's `if (range)` guard drops the annotation
+ * SILENTLY — the screenshot just comes out missing a comment, with no error and
+ * no failed step. Nobody notices until a README image looks wrong.
+ *
+ * So this test does what a human reviewer of a prose edit will not reliably do:
+ * check that every anchor still exists in the file it points at.
+ *
+ * It is not a substitute for looking at the screenshots. It only proves the
+ * annotations will attach — not that they land somewhere that reads well.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = join(__dirname, "../..");
+
+const welcome = readFileSync(join(repoRoot, "sample/welcome.md"), "utf8");
+const script = readFileSync(join(repoRoot, "scripts/take-screenshots.mjs"), "utf8");
+
+/**
+ * Anchors are declared as `const <something>Text = "..."`. Long enough to
+ * exclude incidental short string constants; the count guard below catches the
+ * case where a rename makes this stop matching.
+ */
+const anchors = [...script.matchAll(/const \w*Text\s*=\s*"([^"]{20,})"/g)].map((m) => m[1]);
+
+describe("take-screenshots.mjs anchors resolve against sample/welcome.md", () => {
+  it("finds the anchor declarations at all (guards the regex itself)", () => {
+    // Without this, a rename to the `const ...Text` convention would empty the
+    // list and every assertion below would vacuously pass — the same
+    // silent-disarm this file exists to prevent.
+    expect(anchors.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it.each(anchors)("anchor is present: %s", (anchor) => {
+    expect(welcome).toContain(anchor);
+  });
+});


### PR DESCRIPTION
The Sample Content paragraph in `sample/welcome.md` states a timeline whose numbers don't anchor to anything.

**Before:**
> The project launched in early 2025 with three core goals: simplify onboarding, reduce support tickets by 40%, and ship a self-service dashboard by Q3. The team completed the first two milestones ahead of schedule, but the dashboard timeline slipped due to an unexpected API redesign in May.

Two specific problems. "Ahead of schedule" refers to a schedule the paragraph never gives — only the third goal had a date. And "the dashboard timeline slipped" names no new date, which is the least informative form of the sentence the paragraph exists to deliver.

**After:**
> The project launched in early 2025 with three core goals: simplify onboarding and reduce support tickets by 40% in Q2, then ship a self-service dashboard by Q3. The team hit both Q2 goals a month early, but the dashboard slipped to Q4 after an unexpected API redesign in May.

## Why this is a tightening and not a rewrite

This paragraph sits directly above the line inviting a new user to ask their AI to improve it. Some of the vagueness is load-bearing — a crisp paragraph gives a new user nothing to practice on. So `early 2025` still has no month, the 40% still has no baseline, `May` still has no year, and the API redesign is still just "unexpected." What's fixed is the two that read as sloppy rather than as an invitation.

## The part that would have broken quietly

`scripts/take-screenshots.mjs` anchors its demo annotations on exact substrings of this prose, and one of them was the sentence I changed. `findRange` returns null when the text moves, and the caller's `if (range)` guard then drops the annotation **silently** — the README screenshot just comes out missing a comment, with no error and no failed step.

So this PR also:

- updates that anchor, and comments it so the coupling is visible from the script side;
- rewords the flag comment, which told the reader to add "an updated timeline" — odd advice now that there is one;
- adds `tests/scripts/screenshot-anchors.test.ts`, asserting every anchor still resolves against `sample/welcome.md`.

The new test has a count guard (`>= 4`) so that renaming the `const ...Text` convention can't silently empty the anchor list and make every assertion vacuously pass — the same silent-disarm the test exists to prevent. It only proves the annotations will attach, not that they land somewhere that reads well; the screenshots still need eyes.

## Verification

- `tests/server/tutorial-annotations.test.ts` green — that's the guard which fails if `tests/fixtures/welcome-snapshot.md` drifts from the live file, and it also re-runs the real tutorial injection against the live doc to confirm every anchor still resolves.
- New anchor test **negative-controlled**: editing the prose (`slipped to Q4` → `slipped to Q4 or later`) fails it on exactly the changed anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAuNuaCrP7UrxSrpK3kqzE
