### PR TITLE
fix(cowork): route the schema-drift Report link to the real support inbox

### DIFF
--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 import { onDestroy } from "svelte";
-import { COWORK_RESCAN_DEBOUNCE_MS, TANDEM_REPO_URL } from "../../shared/constants";
+import {
+  COWORK_RESCAN_DEBOUNCE_MS,
+  TANDEM_REPO_URL,
+  TANDEM_SUPPORT_EMAIL,
+} from "../../shared/constants";
 import {
   aggregateWorkspaceStatus,
   coworkReachability,
@@ -290,7 +294,7 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
                 <a
                   class="cs-report-link"
                   data-testid={`cowork-workspace-report-${ws.workspaceId}-${ws.vmId}`}
-                  href="mailto:maintainers@tandem.invalid?subject=Cowork%20schema%20drift"
+                  href={`mailto:${TANDEM_SUPPORT_EMAIL}?subject=Cowork%20schema%20drift`}
                 >
                   Report
                 </a>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -44,6 +44,12 @@ export const TANDEM_PURCHASE_URL = TANDEM_SITE_URL;
  * to buyers at their most frustrated moment, and `docs/security.md` also routes
  * *security reports* here — an address that bounces is worse than the GitHub
  * tracker it replaces.
+ *
+ * Three consumers now, not just licensing: the license surfaces, `docs/security.md`,
+ * and `CoworkSettings.svelte`'s schema-drift **Report** link. The name says
+ * SUPPORT, not LICENSING, and this is a general support address — but keep this
+ * list complete, because "who writes to this mailbox" is what decides whether it
+ * can ever be repointed at a licensing-only inbox.
  */
 export const TANDEM_SUPPORT_EMAIL = "support@tandem.ink";
 


### PR DESCRIPTION
## What

`CoworkSettings.svelte`'s "Report" link — shown when a Cowork workspace is in `schemaDrift` — pointed at `mailto:maintainers@tandem.invalid`. `.invalid` is an RFC 2606 reserved TLD, so every report a user sent from that button bounced.

It's now `TANDEM_SUPPORT_EMAIL` (`support@tandem.ink`), referenced from `src/shared/constants.ts` rather than re-hardcoded, so the surface moves with the constant the way the licensing surfaces already do.

## Why this is the only change

The original ask was to replace `bloknayrb@gmail.com` with `support@`/`bryan@` addresses. That literal string isn't anywhere in the tree, and #1236 had already wired `support@tandem.ink` through `package.json` (`author`/`homepage`/`bugs.email`), `docs/security.md`, `src/shared/constants.ts`, and the issuance Worker's `reply_to`. `grandfather-list.ts` and its `bryan@tandem.chat` entry were removed entirely along with the legacy loopback webhook.

After rebasing onto current `master`, `git grep -in "tandem\.invalid\|tandem\.chat"` had exactly one hit — this line. So the PR is one line of substance instead of six files of churn.

`RESEND_FROM = "REPLACE_WITH_VERIFIED_SENDER"` in `infra/license-issuance-worker/wrangler.toml` is deliberately left alone: master's comment makes clear the sender must be a Resend-verified domain, with `support@` already serving as `reply_to`. Filling it in is an ops step, not a code change.

## Verification

- `npm run typecheck` — 1284 files, 0 errors, 0 warnings
- `npx vitest run tests/client tests/design-system-impl` — 1862 passed (covers the `cowork-workspace-report-*` testid snapshot)
- `git grep -in "tandem\.invalid\|tandem\.chat"` — zero hits

Not manually exercised: the link only renders for a workspace in `schemaDrift`, which needs a real Cowork install to reproduce. Verified by reading the rendered `href`, not by clicking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)