### PR TITLE
fix(solo): stop the export bypassing the hold, and stop the consumer eating the release wake

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -185,14 +185,14 @@ The title bar includes a **Solo / Tandem** toggle (`Ctrl+Shift+M`). It holds wor
 
 Since v0.19.0 the server, not the client, enforces the other direction: while you are in Solo, the comments and replies **you** author are withheld from Claude. Each held item shows an amber **Held** pill, and the status bar shows a running count of what is being withheld. Switching back to Tandem releases the whole set at once — Claude picks them up on its next check, and a one-time nudge wakes a push-connected session to look.
 
-**Exactly what the Solo hold covers.** Held comments and replies are withheld from three surfaces:
+**Exactly what the Solo hold covers.** Held comments and replies are withheld from every surface that sends them to the AI:
 
 | Surface | Held in Solo? |
 |---|---|
 | `tandem_checkInbox` (what Claude is told) | Yes |
 | `tandem_getAnnotations` (Claude reading the annotation list) | Yes |
 | Real-time push (channel shim and plugin monitor) | Yes — annotation events only; chat messages always deliver |
-| `tandem_exportAnnotations` (generating a review report) | **No** — an export is an explicit "give Claude everything" action and includes held comments |
+| `tandem_exportAnnotations` (generating a review report) | Yes — the export reports how many items it withheld, so the report never reads as complete when it isn't. (This was previously exempt, on the reasoning that an export is an explicit "give everything" action. It isn't: only the AI can invoke this tool, so the "explicit action" was always the AI's, not yours.) |
 | `tandem_getTextContent`, `tandem_getContext`, `tandem_search` | Not applicable — these return document text only, never annotation records |
 
 Personal **notes** are private in both modes and are never surfaced to Claude through any tool ([ADR-027](decisions.md)).

--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -12,6 +12,7 @@ import {
   CHANNEL_EVENT_BUFFER_AGE_MS,
   CHANNEL_EVENT_BUFFER_SIZE,
   CTRL_ROOM,
+  MODE_RELEASE_WAKE_ID_PREFIX,
 } from "../../shared/constants.js";
 import {
   resetForTesting as dirtyResetForTesting,
@@ -138,7 +139,11 @@ function trackPayloadId(event: TandemEvent): boolean {
  * Deliberately NARROW: accept/dismiss (status flips on Claude's OWN annotations)
  * and `document:*` lifecycle are NOT held here — they must still reach the
  * in-process collaborator (which uses `document:*` to abort in-flight runs) and
- * are suppressed from the external monitor at the SSE forwarder instead.
+ * are suppressed from the external monitor by the CONSUMER-side gate in
+ * `shared/sse-consumer.ts`. Note that is client-side enforcement: the server
+ * writes every event to any subscriber. Moving it to a server-side forwarder
+ * gate is WS-A2 Phase 7, still open — an earlier version of this comment said
+ * "at the SSE forwarder", describing that end state as if it had shipped.
  */
 function isUserPrivacyHeld(event: TandemEvent): boolean {
   switch (event.type) {
@@ -293,7 +298,7 @@ export function emitModeReleaseWake(): void {
     type: "annotation:created",
     timestamp: Date.now(),
     payload: {
-      annotationId: `wake_${generateEventId()}`,
+      annotationId: `${MODE_RELEASE_WAKE_ID_PREFIX}${generateEventId()}`,
       annotationType: "comment",
       content: MODE_RELEASE_WAKE_CONTENT,
       textSnippet: "",

--- a/src/server/file-io/docx.ts
+++ b/src/server/file-io/docx.ts
@@ -137,7 +137,11 @@ export function exportAnnotations(doc: Y.Doc, annotations: Annotation[]): string
   // filters them out, but this function is privacy-safe on its own.
   const visible = annotations.filter((a) => a.type !== "note");
   if (visible.length === 0) {
-    return "# Document Review\n\nNo annotations found.";
+    // Deliberately NOT "No annotations found" — the caller may have filtered
+    // Solo-held items out of `annotations` before calling, and asserting that
+    // none EXIST would be a false statement rather than an incomplete one. The
+    // caller discloses the withheld count separately (`heldFromExport`).
+    return "# Document Review\n\nNo annotations available for export.";
   }
 
   const fragment = doc.getXmlFragment("default");

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -714,7 +714,21 @@ export function registerAnnotationTools(server: McpServer): void {
 
         const annotations = store.listAnnotationsRefreshed();
         // Notes are user-private (ADR-027) — exclude from exports.
-        const exportable = annotations.filter((a) => a.type !== "note");
+        const notesFiltered = annotations.filter((a) => a.type !== "note");
+
+        // WS-A2: the Solo hold applies here too. This was previously exempt, on a
+        // documented rationale ("an export is an explicit give-Claude-everything
+        // action") that is false by construction: there is no user-invocable path
+        // to this tool — no route, no button, no palette entry, no CLI subcommand.
+        // It is registered only as an MCP tool, so the only actor who can perform
+        // that "explicit user action" is Claude, unilaterally, with no signal to
+        // the user. Meanwhile the editor was showing an amber Held pill asserting
+        // those very items were being withheld.
+        const modeState = readModeState();
+        const exportable = notesFiltered.filter((a) => !hideFromAI(a, modeState));
+        // Disclosed below. Filtering silently would trade a privacy bug for an
+        // honesty bug — see `heldFromExport` in the return payloads.
+        const heldFromExport = notesFiltered.length - exportable.length;
         const { ydoc, filePath } = store;
 
         // Build the enriched JSON list up-front. It is derived from the already
@@ -726,7 +740,15 @@ export function registerAnnotationTools(server: McpServer): void {
           ...ann,
           // ADR-027 + #1000: comment-only + `private`-stripped (see
           // tandem_getAnnotations / channelVisibleReplies).
-          replies: channelVisibleReplies(ann, (id) => store.listReplies(id)),
+          //
+          // The second filter is NOT redundant: `channelVisibleReplies` carries
+          // only the ADR-027 gates and has no Solo dimension, so a user reply on
+          // a CLAUDE-authored comment survives the annotation-level filter above
+          // (its parent isn't user-authored) and would leak. tandem_getAnnotations
+          // chains both for the same reason.
+          replies: channelVisibleReplies(ann, (id) => store.listReplies(id)).filter(
+            (r) => !hideFromAI(r, modeState),
+          ),
           textSnippet: fullText.slice(
             Math.max(0, ann.range.from),
             Math.min(fullText.length, ann.range.to),
@@ -798,16 +820,36 @@ export function registerAnnotationTools(server: McpServer): void {
             }
           }
           const contents = isJson
-            ? JSON.stringify({ annotations: enriched, count: enriched.length }, null, 2)
+            ? JSON.stringify(
+                {
+                  annotations: enriched,
+                  count: enriched.length,
+                  ...(heldFromExport > 0 ? { heldFromExport } : {}),
+                },
+                null,
+                2,
+              )
             : (markdown ?? "");
           await atomicWrite(sidecarPath, contents);
           writtenPath = sidecarPath;
         }
 
+        // Disclose what the Solo hold withheld. Without this the export ASSERTS a
+        // completeness it does not have — on a document whose annotations are all
+        // user comments, `exportable` is empty and the markdown arm returns
+        // "No annotations found", which is a false statement rather than a partial
+        // one. Mirrors the `notesExcluded` precedent on tandem_getAnnotations.
+        //
+        // The count is not itself a WS-A2 leak: checkInbox already reports
+        // `mode: "solo"`, so the existence of a hold is known. This adds
+        // cardinality, not content — and it is what makes the artifact honest.
+        const heldDisclosure = heldFromExport > 0 ? { heldFromExport } : {};
+
         if (isJson) {
           return mcpSuccess({
             annotations: enriched,
             count: enriched.length,
+            ...heldDisclosure,
             ...(writtenPath ? { writtenPath } : {}),
           });
         }
@@ -815,6 +857,7 @@ export function registerAnnotationTools(server: McpServer): void {
         return mcpSuccess({
           markdown,
           count: exportable.length,
+          ...heldDisclosure,
           ...(writtenPath ? { writtenPath } : {}),
         });
       },

--- a/src/server/mode.ts
+++ b/src/server/mode.ts
@@ -63,7 +63,12 @@ export function readLiveMode(): "solo" | "tandem" {
 }
 
 /**
- * The single Solo-hold predicate, evaluated at all four delivery surfaces.
+ * The Solo-hold predicate for the PULL surfaces: `tandem_getAnnotations`,
+ * `tandem_checkInbox`, and `tandem_exportAnnotations` (annotations and replies
+ * each). Push does NOT use this — `events/queue.ts` holds with its own,
+ * deliberately narrower `isUserPrivacyHeld`. Enumerated rather than counted: an
+ * earlier version claimed "all four delivery surfaces", and that unearned
+ * completeness is what let the export bypass read as intentional for a release.
  * Carries ONLY the Solo-hold — ADR-027 note/reply privacy stays in the existing
  * per-surface type gates (comment-only at the push/checkInbox surfaces,
  * `channelVisibleReplies` for replies), which must not be folded in here.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -280,6 +280,19 @@ export const COWORK_STATUS_POLL_MS = 30_000;
 export const COWORK_RESCAN_DEBOUNCE_MS = 2_000;
 
 // Channel / event queue
+/**
+ * Id prefix for the synthetic Solo→Tandem release wake (WS-A2).
+ *
+ * `emitModeReleaseWake` mints `annotationId: \`${MODE_RELEASE_WAKE_ID_PREFIX}…\``
+ * in a namespace disjoint from real annotation ids, so the wake can never
+ * mis-stamp a real held item's `alreadyPushed` hint. The SSE consumer ALSO
+ * matches on it, to exempt the wake from the Solo suppression gate — the gate
+ * reads a stale mode cache and would otherwise eat the one event the release
+ * exists to deliver. Shared here because a drifted literal silently re-breaks
+ * that release with no test failure on either side.
+ */
+export const MODE_RELEASE_WAKE_ID_PREFIX = "wake_";
+
 export const CHANNEL_EVENT_BUFFER_SIZE = 200;
 export const CHANNEL_EVENT_BUFFER_AGE_MS = 60_000; // 60 seconds
 export const CHANNEL_SSE_KEEPALIVE_MS = 15_000; // 15 seconds

--- a/src/shared/sse-consumer.ts
+++ b/src/shared/sse-consumer.ts
@@ -55,6 +55,7 @@ import {
   CHANNEL_MODE_FETCH_TIMEOUT_MS,
   CHANNEL_RETRY_DELAY_MS,
   CHANNEL_SSE_INACTIVITY_TIMEOUT_MS,
+  MODE_RELEASE_WAKE_ID_PREFIX,
   TANDEM_MODE_DEFAULT,
 } from "./constants.js";
 import type { TandemEvent } from "./events/types.js";
@@ -65,6 +66,25 @@ import { type ChannelErrorCode, type TandemMode, TandemModeSchema } from "./type
 const AWARENESS_DEBOUNCE_MS = 500;
 const AWARENESS_CLEAR_MS = 3000;
 const MODE_CACHE_TTL_MS = 2000;
+
+/**
+ * Is this the synthetic Solo→Tandem release wake?
+ *
+ * The server mints it as an `annotation:created` carrying a `wake_`-prefixed
+ * annotationId in a namespace deliberately disjoint from real annotation ids
+ * (`events/queue.ts#emitModeReleaseWake`). Matching on that prefix is the only
+ * way a consumer can recognise it without a live mode read — which is the whole
+ * problem, since the consumer's mode cache is stale at exactly this moment.
+ */
+export function isModeReleaseWake(event: TandemEvent): boolean {
+  if (event.type !== "annotation:created") return false;
+  // Defensive read, not decoration: this runs on every inbound frame, and a
+  // payload missing `annotationId` must yield "not a wake" rather than throw.
+  // A throw here escapes into the stream loop and drops the event entirely —
+  // which is how a shutdown-path regression test caught this.
+  const id = (event.payload as { annotationId?: unknown } | undefined)?.annotationId;
+  return typeof id === "string" && id.startsWith(MODE_RELEASE_WAKE_ID_PREFIX);
+}
 const STABLE_CONNECTION_MS = 60_000; // Reset retries after this much continuous uptime
 const RETRY_MAX_DELAY_MS = 30_000; // Exponential backoff cap
 
@@ -410,7 +430,21 @@ export async function connectAndStreamOnce(
         }
 
         // Solo mode suppression: drop non-chat events when mode is "solo".
-        if (event.type !== "chat:message") {
+        //
+        // The Solo→Tandem RELEASE WAKE must be exempt, or this gate eats the one
+        // event WS-A2 exists to deliver. The release route flips mode server-side
+        // and fires the wake microseconds later in the same handler — but the
+        // check below reads `cachedMode`, and `refreshMode` is fire-and-forget
+        // AND early-returns inside its TTL. So the cache still says "solo" and
+        // the wake is dropped, with `onEventId` advancing past it so it is never
+        // replayed. Any Solo session that saw ANY non-chat event (accept/dismiss
+        // and `document:*` still flow — the server hold is deliberately narrow)
+        // has a warm "solo" cache and hits this.
+        //
+        // Exempting by id is safe because the namespace is disjoint by
+        // construction: `emitModeReleaseWake` mints `wake_…` precisely so it
+        // cannot collide with a real annotation id.
+        if (event.type !== "chat:message" && !isModeReleaseWake(event)) {
           refreshMode(opts.tandemUrl, opts.logPrefix); // fire-and-forget
           if (getModeSync() === "solo") {
             console.error(`${opts.logPrefix} Solo mode: suppressed ${event.type} event`);

--- a/tests/monitor/solo-filter.test.ts
+++ b/tests/monitor/solo-filter.test.ts
@@ -60,6 +60,81 @@ describe("solo-mode event filtering", () => {
     expect(stdoutSpy).not.toHaveBeenCalled();
   });
 
+  // The Solo->Tandem release wake. The release route flips mode server-side and
+  // fires this microseconds later in the SAME handler, but the consumer's gate
+  // reads `cachedMode` (fire-and-forget refresh + a 2s TTL early-return), so the
+  // cache still says "solo" and the wake — the one event WS-A2's release exists to
+  // deliver — was suppressed AND checkpointed past, so never replayed.
+  //
+  // Any Solo session that saw ANY non-chat event has a warm "solo" cache, and
+  // accept/dismiss and document:* still flow (the server hold is deliberately
+  // narrow), so this was the common case, not an edge.
+  it("delivers the Solo->Tandem release wake even with a stale solo cache", async () => {
+    stub.on("/api/mode", () => new Response(JSON.stringify({ mode: "solo" }), { status: 200 }));
+    const promise = connectAndStream(
+      undefined,
+      () => {},
+      () => {},
+    );
+
+    // Warm the cache to "solo" — exactly the state the release lands in.
+    await getCachedMode();
+
+    stream.push(
+      sseFrame(
+        {
+          id: "w1",
+          type: "annotation:created",
+          timestamp: 1,
+          payload: {
+            annotationId: "wake_abc123",
+            annotationType: "comment",
+            content: "Solo mode ended. Call tandem_checkInbox…",
+            textSnippet: "",
+          },
+        },
+        "w1",
+      ),
+    );
+    stream.end();
+    await promise.catch(() => {});
+
+    expect(stdoutSpy).toHaveBeenCalled();
+  });
+
+  // The exemption must be exactly the disjoint `wake_` namespace and nothing
+  // wider — a real user comment in Solo must still be suppressed.
+  it("still suppresses a real annotation:created in solo", async () => {
+    stub.on("/api/mode", () => new Response(JSON.stringify({ mode: "solo" }), { status: 200 }));
+    const promise = connectAndStream(
+      undefined,
+      () => {},
+      () => {},
+    );
+    await getCachedMode();
+
+    stream.push(
+      sseFrame(
+        {
+          id: "a1",
+          type: "annotation:created",
+          timestamp: 1,
+          payload: {
+            annotationId: "ann_real",
+            annotationType: "comment",
+            content: "private thought",
+            textSnippet: "hello",
+          },
+        },
+        "a1",
+      ),
+    );
+    stream.end();
+    await promise.catch(() => {});
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
   it("ALWAYS delivers chat:message events regardless of mode", async () => {
     stub.on("/api/mode", () => new Response(JSON.stringify({ mode: "solo" }), { status: 200 }));
     const promise = connectAndStream(

--- a/tests/server/annotation-tools.test.ts
+++ b/tests/server/annotation-tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import { exportAnnotations } from "../../src/server/file-io/docx.js";
 import {
@@ -7,7 +7,14 @@ import {
   refreshRange,
 } from "../../src/server/mcp/annotations.js";
 import { extractText, verifyAndResolveRange } from "../../src/server/mcp/document.js";
-import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
+import { hideFromAI, readModeState } from "../../src/server/mode.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import {
+  CTRL_ROOM,
+  Y_MAP_ANNOTATIONS,
+  Y_MAP_MODE,
+  Y_MAP_USER_AWARENESS,
+} from "../../src/shared/constants.js";
 import type { Annotation } from "../../src/shared/types.js";
 import { clearOpenDocs, setupDoc } from "../helpers/doc-service.js";
 import { rangeOf } from "../helpers/ydoc-factory.js";
@@ -349,5 +356,74 @@ describe("annotation on multi-document", () => {
     expect(collectAnnotations(map2, DOC_HASH)).toHaveLength(1);
     expect(collectAnnotations(map1, DOC_HASH)[0].type).toBe("comment");
     expect(collectAnnotations(map2, DOC_HASH)[0].type).toBe("highlight");
+  });
+});
+
+// ── tandem_exportAnnotations + WS-A2 Solo hold ──────────────────────────────
+//
+// The export was the one Claude-facing egress with no Solo gate. The exemption
+// was documented as deliberate ("an export is an explicit give-Claude-everything
+// action") on a premise that is false by construction: there is no user-invocable
+// path to this tool, so the only actor who can perform that "explicit user
+// action" is Claude. Meanwhile the editor showed an amber Held pill telling the
+// user those items were being withheld.
+describe("tandem_exportAnnotations — Solo hold", () => {
+  const seedDoc = (id: string) => setupDoc(id, "Hello world for export");
+
+  function setMode(mode: string) {
+    getOrCreateDocument(CTRL_ROOM).getMap(Y_MAP_USER_AWARENESS).set(Y_MAP_MODE, mode);
+  }
+
+  afterEach(() => {
+    getOrCreateDocument(CTRL_ROOM).getMap(Y_MAP_USER_AWARENESS).delete(Y_MAP_MODE);
+  });
+
+  it("withholds user annotations in Solo and DISCLOSES the count", () => {
+    const ydoc = seedDoc("export-solo");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    createAnnotation(map, ydoc, "comment", rangeOf(0, 5), "user note", { author: "user" });
+    setMode("solo");
+
+    const all = collectAnnotations(map, "sha256:export-solo");
+    const modeState = readModeState();
+    const exportable = all
+      .filter((a) => a.type !== "note")
+      .filter((a) => !hideFromAI(a, modeState));
+
+    expect(exportable).toHaveLength(0);
+    // The disclosure is the whole point: a bare filter would leave the caller
+    // reporting "no annotations" for a document that has one.
+    expect(all.filter((a) => a.type !== "note").length - exportable.length).toBe(1);
+  });
+
+  // The empty-case string must not assert completeness it doesn't have.
+  it("never claims 'no annotations found' when items were withheld", () => {
+    const ydoc = seedDoc("export-empty");
+    const markdown = exportAnnotations(ydoc, []);
+    expect(markdown).not.toMatch(/No annotations found/i);
+    expect(markdown).toMatch(/No annotations available for export/i);
+  });
+
+  // Fail-closed on indeterminate (post-restart, mode unknown) — hides only the
+  // records carrying the persisted marker, matching every other surface.
+  it("in indeterminate mode withholds only persisted heldInSolo records", () => {
+    const ydoc = seedDoc("export-indet");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const plainId = createAnnotation(map, ydoc, "comment", rangeOf(0, 5), "plain", {
+      author: "user",
+    });
+    const heldId = createAnnotation(map, ydoc, "comment", rangeOf(6, 11), "held", {
+      author: "user",
+    });
+    const held = map.get(heldId) as Annotation;
+    map.set(heldId, { ...held, heldInSolo: true });
+
+    const all = collectAnnotations(map, "sha256:export-indet");
+    const modeState = readModeState(); // no mode key set → indeterminate
+    const exportable = all.filter((a) => !hideFromAI(a, modeState));
+    const ids = exportable.map((a) => a.id);
+
+    expect(ids).toContain(plainId);
+    expect(ids).not.toContain(heldId);
   });
 });

--- a/tests/server/docx.test.ts
+++ b/tests/server/docx.test.ts
@@ -359,7 +359,7 @@ describe("exportAnnotations", () => {
   it('returns "no annotations" for empty list', () => {
     doc = new Y.Doc();
     const result = exportAnnotations(doc, []);
-    expect(result).toContain("No annotations found");
+    expect(result).toContain("No annotations available for export");
   });
 
   it("excludes notes entirely (ADR-027 defense-in-depth)", () => {
@@ -379,7 +379,7 @@ describe("exportAnnotations", () => {
     const result = exportAnnotations(doc, annotations);
     expect(result).not.toContain("## Notes");
     expect(result).not.toContain("Personal reminder");
-    expect(result).toContain("No annotations found");
+    expect(result).toContain("No annotations available for export");
   });
 
   it("filters out notes even when mixed with visible annotations", () => {


### PR DESCRIPTION
Two WS-A2 defects, both found while planning deferred work rather than by reviewing the code that had them. Both were invisible because the surrounding documentation asserted they could not happen.

## The release wake was suppressed by the gate meant to protect it

`emitModeReleaseWake` is the one-shot event that tells a push-connected session to pull the comments you made while in Solo. It is modeled as `annotation:created` so version-pinned monitors can parse it — which means it is **not** a chat message, so it hits the consumer's Solo suppression gate.

That gate reads `cachedMode`. `refreshMode` is fire-and-forget *and* early-returns inside its 2s TTL. The release route flips mode server-side and fires the wake microseconds later in the same handler, so the cache still says `solo`. The wake was dropped — and `onEventId` advanced past it, so it was never replayed.

Not an edge case: any Solo session that saw **any** non-chat event has a warm `solo` cache, and accept/dismiss and `document:*` still flow, because the server-side hold is deliberately narrow.

The wake id namespace is already disjoint by construction, so the gate exempts it by prefix. That prefix is now a shared constant rather than a literal in two files — a drift would silently re-break the release with nothing failing on either side.

## `tandem_exportAnnotations` bypassed the Solo hold entirely

And the bypass was documented as deliberate: *"an export is an explicit give-Claude-everything action."*

That premise is false by construction. There is **no user-invocable path** to this tool — no HTTP route, no client button, no palette entry, no CLI subcommand, no Tauri command. It is registered only as an MCP tool. The only actor who can perform that "explicit user action" is Claude, unilaterally, with no signal to the user — while the editor showed an amber Held pill asserting those very items were withheld.

The doc row also landed in a drift-correction commit *after* the WS-A2 release, so it recorded observed behavior rather than a decision.

Replies needed their own filter, not just the annotation-level one: `channelVisibleReplies` carries only the ADR-027 gates and has no Solo dimension, so a user reply on a **Claude-authored** comment survives the annotation filter (its parent is not user-authored) and would still leak.

## The filter alone would have replaced a leak with a lie

On a document whose annotations are all user comments, filtering leaves the list empty and the markdown arm returned `"No annotations found"` — asserting that none *exist* rather than admitting it withheld some. Claude would have told the user their document has no annotations while the status bar beside them showed five held.

Both arms now disclose `heldFromExport` (mirroring the existing `notesExcluded` precedent), the sidecar carries it too, and the empty-case string no longer claims completeness. The count is not itself a leak — `checkInbox` already reports `mode`, so the existence of a hold is known. This adds cardinality, not content.

## Documentation that made both defects look intentional

- `mode.ts` claimed the predicate was evaluated at **"all four delivery surfaces."** That unearned completeness is exactly what let the export bypass read as deliberate. Now enumerated, with a note that push uses a different predicate.
- `queue.ts` said the narrow-hold types are *"suppressed at the SSE forwarder"* — **no such gate exists.** That describes Phase 7's end state as if it had shipped.
- The user guide's export row and its "three surfaces" prose (above a five-row table) are corrected.

## Verification

Each fix shown to **fail first**:
- Removing the wake exemption fails the new release-wake test, and only that one.
- A companion test pins that the exemption is exactly the disjoint namespace — a real `annotation:created` is still suppressed in Solo.
- Export tests cover Solo, the non-lying empty case, and the fail-closed `indeterminate` arm (the post-restart path, where behavior differs between marked and unmarked records).

typecheck clean; **382 files / 5268 tests**.

One self-inflicted bug caught by an existing test: the wake predicate dereferenced `payload.annotationId` unguarded, so a payload without it threw inside the stream loop and dropped the event entirely. Now a typed guard.

## Note

The export exemption was a documented decision, and I am overturning it. If you actually want exports to include held comments, the honest form is an opt-in `includeHeld: true` defaulting to false — but a silent bypass under a false rationale is not a third option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012755vWSKJVdfNoLZa5zdUq