### PR TITLE
feat(solo): enforce the Solo hold server-side for external consumers (WS-A2 Ph7)

### DIFF
--- a/src/server/events/queue.ts
+++ b/src/server/events/queue.ts
@@ -140,6 +140,38 @@ function trackPayloadId(event: TandemEvent): boolean {
  * in-process collaborator (which uses `document:*` to abort in-flight runs) and
  * are suppressed from the external monitor at the SSE forwarder instead.
  */
+/**
+ * WS-A2 Phase 7: may this event go to an EXTERNAL consumer right now?
+ *
+ * `isUserPrivacyHeld` above drops the user's own annotation/reply CONTENT before
+ * it is ever buffered. This predicate covers what that one deliberately does not:
+ * accept/dismiss status flips, Claude-authored replies, and `document:*`
+ * lifecycle. Those carry no content the AI cannot already pull on demand (Solo
+ * does not gate document reads), but they carry TIMING — they tell an idle
+ * session "the user is doing things right now, go look", which is precisely what
+ * Solo promises not to do.
+ *
+ * Until now this was enforced only in the CONSUMER (`shared/sse-consumer.ts`),
+ * i.e. client-side, with a 2s stale mode cache that fails open on cold start —
+ * so any process that opens `/api/events` (a loopback `curl`, a third-party
+ * bridge, a version-pinned monitor) received the full stream in Solo. The server
+ * vouched for nothing.
+ *
+ * Deliberately NOT applied before `buffer.push`: keeping the buffer's contents
+ * unchanged means `replaySince`'s unknown-id fallback (which returns the ENTIRE
+ * buffer, on a client-controlled header) cannot hand out anything it could not
+ * hand out before. The gate is applied at the two delivery points instead.
+ *
+ * Read LIVE, per delivery — never stamped at push time. The Solo→Tandem release
+ * flips mode and then emits the wake, so a stamped value would swallow it.
+ */
+function shouldForwardExternally(event: TandemEvent): boolean {
+  // Chat is the always-delivered channel in both directions, and it is also the
+  // in-process collaborator's wake trigger. Never gate it.
+  if (event.type === "chat:message") return true;
+  return readModeState() !== "solo";
+}
+
 function isUserPrivacyHeld(event: TandemEvent): boolean {
   switch (event.type) {
     case "annotation:created":
@@ -203,13 +235,34 @@ function pushEvent(event: TandemEvent): void {
     if (evicted && trackedEvents.delete(evicted)) untrackPayloadId(evicted);
   }
 
+  // Bound ONCE and reused, rather than re-read per subscriber: `pushEvent` is
+  // synchronous so two reads cannot currently disagree, but binding it is the
+  // difference between correct and correct-by-accident.
+  const forwardExternally = shouldForwardExternally(event);
+
   for (const cb of subscribers) {
+    // In-process subscribers (the local-model collaborator) are NOT gated: they
+    // rely on `document:closed` / `document:switched` to abort in-flight runs,
+    // and they never leave this machine. Only external consumers are held.
+    if (!forwardExternally && externalSubscribers.has(cb)) continue;
     try {
       cb(event);
     } catch (err) {
       console.error("[EventQueue] Subscriber threw during event dispatch:", err);
     }
   }
+}
+
+/**
+ * Test-only seam onto `pushEvent`.
+ *
+ * Most queue tests drive real Y.Map observers, which is the right default. But
+ * `document:*` events are pushed directly by the document service rather than
+ * derived from an observer, so the Solo forwarder gate cannot be exercised for
+ * them any other way.
+ */
+export function _pushEventForTests(event: TandemEvent): void {
+  pushEvent(event);
 }
 
 // --- Public API ---
@@ -246,11 +299,22 @@ export function unsubscribe(cb: EventCallback): void {
   externalSubscribers.delete(cb);
 }
 
-/** Replay buffered events since a given event ID (for SSE reconnection). */
+/**
+ * Replay buffered events since a given event ID (for SSE reconnection).
+ *
+ * The Solo filter here is MANDATORY, not symmetry with the fan-out gate. This is
+ * the higher-risk branch: when `lastEventId` is not found the fallback returns
+ * the ENTIRE buffer, and `lastEventId` comes from a client-controlled
+ * `Last-Event-ID` header. Without the filter, any consumer reconnecting with a
+ * stale or fabricated id would receive the whole Solo span in one shot.
+ *
+ * Only `sse.ts` calls this, and it is the external delivery path, so filtering
+ * inside the function is complete.
+ */
 export function replaySince(lastEventId: string): TandemEvent[] {
   const idx = buffer.findIndex((e) => e.id === lastEventId);
-  if (idx === -1) return [...buffer]; // ID not found — replay everything
-  return buffer.slice(idx + 1);
+  const slice = idx === -1 ? [...buffer] : buffer.slice(idx + 1);
+  return slice.filter((e) => shouldForwardExternally(e));
 }
 
 /**

--- a/src/server/local-model/collaborator.ts
+++ b/src/server/local-model/collaborator.ts
@@ -27,7 +27,7 @@ import type { ChatMessagePayload, TandemEvent } from "../../shared/events/types.
 import type { AgentIdentity } from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
 import { getActiveDocId, requireDocument } from "../documents/registry.js";
-import { subscribe, unsubscribe } from "../events/queue.js";
+import { type SubscriberKind, subscribe, unsubscribe } from "../events/queue.js";
 import { appendClaudeChatMessage, updateClaudeChatMessage } from "../mcp/awareness.js";
 import { extractText } from "../mcp/document.js";
 import { readLiveMode } from "../mode.js";
@@ -51,7 +51,7 @@ const SELECTION_TEXT_CAP = 500;
 export interface CollaboratorDeps {
   runTurn: (opts: RunTurnOpts) => Promise<LoopResult>;
   resolveConfig: () => LocalModelConfig | null;
-  subscribe: (cb: (e: TandemEvent) => void) => void;
+  subscribe: (cb: (e: TandemEvent) => void, kind?: SubscriberKind) => void;
   unsubscribe: (cb: (e: TandemEvent) => void) => void;
 }
 
@@ -345,14 +345,15 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
       );
     }
     subscriberCb = onEvent;
-    // BEFORE FLIPPING BYO_MODELS_ENABLED: this subscription lands in the same
-    // fan-out Set that `pushEvent` reads to decide whether an event was "handed
-    // to a consumer" (events/queue.ts). Once this is live, `subscribers.size >= 1`
-    // permanently even with no external channel shim or monitor attached, so every
-    // user comment would be stamped `alreadyPushed: true` on the strength of an
-    // in-process subscriber — restoring the false signal #1242 removed. The gate
-    // there needs to count EXTERNAL subscribers only; give `subscribe` a kind.
-    deps.subscribe(subscriberCb);
+    // "internal" is passed EXPLICITLY, not left to the default. Two correctness
+    // properties now hang on this subscriber not being external:
+    //   1. `alreadyPushed` — an in-process listener must not make the server
+    //      claim an event was handed to a consumer (#1242).
+    //   2. The WS-A2 Solo forwarder gate — external consumers are held in Solo,
+    //      but this loop needs `document:closed` / `document:switched` to abort
+    //      in-flight runs, so it must keep receiving them.
+    // Relying on a silent default is a poor place to hang a privacy gate.
+    deps.subscribe(subscriberCb, "internal");
   }
 
   function start(): void {

--- a/tests/server/event-queue.test.ts
+++ b/tests/server/event-queue.test.ts
@@ -2,21 +2,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import type { AnnotationDocV1 } from "../../src/server/annotations/schema.js";
 import {
+  _pushEventForTests,
   attachCtrlObservers,
   attachObservers,
   detachObservers,
+  emitModeReleaseWake,
   getAnnotationEditedChannelKey,
   getBufferedSelection,
   reattachObservers,
   replaySince,
   resetForTesting,
+  type SubscriberKind,
   subscribe,
   unsubscribe,
   wasEmittedViaChannel,
 } from "../../src/server/events/queue.js";
 import type { TandemEvent } from "../../src/server/events/types.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import {
   CHANNEL_EVENT_BUFFER_SIZE,
+  CTRL_ROOM,
   SELECTION_DWELL_DEFAULT_MS,
   Y_MAP_ANNOTATION_REPLIES,
   Y_MAP_ANNOTATIONS,
@@ -32,14 +37,19 @@ afterEach(() => {
 
 // --- Helper to collect events from the subscriber ---
 
-function collectEvents(): { events: TandemEvent[]; cleanup: () => void } {
+function collectEvents(kind: SubscriberKind = "external"): {
+  events: TandemEvent[];
+  cleanup: () => void;
+} {
   const events: TandemEvent[] = [];
   const cb = (event: TandemEvent) => {
     events.push(event);
   };
-  // "external" — these stand in for a channel shim / plugin monitor, which is
-  // what `wasEmittedViaChannel` and the doctor's push check are asking about.
-  subscribe(cb, "external");
+  // Default "external" — these stand in for a channel shim / plugin monitor,
+  // which is what `wasEmittedViaChannel` and the doctor's push check ask about.
+  // Pass "internal" to model the in-process collaborator, which the Solo
+  // forwarder gate deliberately does not hold.
+  subscribe(cb, kind);
   return { events, cleanup: () => unsubscribe(cb) };
 }
 
@@ -1475,6 +1485,12 @@ describe("WS-A2 Solo privacy hold (pushEvent)", () => {
     cleanup();
   });
 
+  // The server's PRE-BUFFER hold stays narrow: accept/dismiss is still buffered
+  // and still reaches in-process subscribers in Solo (the local-model
+  // collaborator needs it). What changed in Phase 7 is that EXTERNAL forwarding
+  // of it is now gated server-side rather than in the consumer — so this test
+  // subscribes as "internal" to assert the narrowness it was written for.
+  // External behaviour is covered in "Solo forwarder gate".
   it("does NOT hold accept/dismiss of a Claude annotation in Solo (narrow scope)", () => {
     setMode("solo");
     // Seed a Claude annotation via MCP (no event), then the user accepts it.
@@ -1492,16 +1508,126 @@ describe("WS-A2 Solo privacy hold (pushEvent)", () => {
       },
       MCP_ORIGIN,
     );
-    const { events, cleanup } = collectEvents();
+    const { events, cleanup } = collectEvents("internal");
 
-    // User accepts (browser-origin status flip) — must still fan out even in Solo,
-    // because accept/dismiss are suppressed from the external monitor downstream,
-    // not held here.
+    // User accepts (browser-origin status flip) — must still be buffered and
+    // delivered in-process even in Solo. It is withheld from EXTERNAL consumers
+    // by the forwarder gate, not dropped here.
     const ann = map.get("claude_ann") as Record<string, unknown>;
     map.set("claude_ann", { ...ann, status: "accepted" });
 
     expect(events).toHaveLength(1);
     expect(events[0].type).toBe("annotation:accepted");
     cleanup();
+  });
+});
+
+// ── WS-A2 Phase 7: server-side Solo gate for EXTERNAL consumers ─────────────
+//
+// `isUserPrivacyHeld` drops the user's own annotation/reply content before it is
+// buffered. This gate covers what that deliberately does not — accept/dismiss,
+// Claude-authored replies, and document:* lifecycle. Those carry no content the
+// AI can't already pull (Solo doesn't gate document reads) but they carry
+// TIMING: they wake an idle session, which is exactly what Solo promises not to
+// do. Enforcement used to live only in the consumer, so any process that opened
+// /api/events got the full stream in Solo.
+describe("Solo forwarder gate (external consumers)", () => {
+  function setMode(mode: string | null) {
+    const map = getOrCreateDocument(CTRL_ROOM).getMap(Y_MAP_USER_AWARENESS);
+    if (mode === null) map.delete(Y_MAP_MODE);
+    else map.set(Y_MAP_MODE, mode);
+  }
+  afterEach(() => setMode(null));
+
+  function docEvent(id: string): TandemEvent {
+    return {
+      id,
+      type: "document:opened",
+      timestamp: Date.now(),
+      documentId: "d1",
+      payload: { fileName: "secret-plan.md", format: "md" },
+    } as TandemEvent;
+  }
+
+  it("withholds document lifecycle from an external consumer in Solo", () => {
+    setMode("solo");
+    const external: TandemEvent[] = [];
+    const cb = (e: TandemEvent) => external.push(e);
+    subscribe(cb, "external");
+    _pushEventForTests(docEvent("ev-ext-solo"));
+    unsubscribe(cb);
+
+    expect(external).toHaveLength(0);
+  });
+
+  // The in-process collaborator aborts in-flight runs on document:closed /
+  // switched. Gating it would silently strand those runs — so the gate is
+  // external-only, and this pins that.
+  it("still delivers to in-process subscribers in Solo", () => {
+    setMode("solo");
+    const internal: TandemEvent[] = [];
+    const cb = (e: TandemEvent) => internal.push(e);
+    subscribe(cb, "internal");
+    _pushEventForTests(docEvent("ev-int-solo"));
+    unsubscribe(cb);
+
+    expect(internal).toHaveLength(1);
+  });
+
+  it("delivers to external consumers again in Tandem", () => {
+    setMode("tandem");
+    const external: TandemEvent[] = [];
+    const cb = (e: TandemEvent) => external.push(e);
+    subscribe(cb, "external");
+    _pushEventForTests(docEvent("ev-ext-tandem"));
+    unsubscribe(cb);
+
+    expect(external).toHaveLength(1);
+  });
+
+  // The gate reads mode LIVE per delivery, never stamped at push time. The
+  // release route flips mode and THEN emits the wake in the same handler, so a
+  // stamped value would swallow the one event the release exists to deliver.
+  it("forwards the Solo→Tandem release wake to external consumers", () => {
+    setMode("tandem"); // the route has already flipped by the time the wake fires
+    const external: TandemEvent[] = [];
+    const cb = (e: TandemEvent) => external.push(e);
+    subscribe(cb, "external");
+    emitModeReleaseWake();
+    unsubscribe(cb);
+
+    expect(external).toHaveLength(1);
+    expect(external[0].type).toBe("annotation:created");
+  });
+
+  // replaySince is the HIGHER-risk branch: the unknown-id fallback returns the
+  // entire buffer, driven by a client-controlled Last-Event-ID header.
+  it("filters the replay path too, including the unknown-id fallback", () => {
+    setMode("tandem");
+    const cb = () => {};
+    subscribe(cb, "external");
+    _pushEventForTests(docEvent("ev-replay-1"));
+    unsubscribe(cb);
+
+    expect(replaySince("no-such-id").some((e) => e.id === "ev-replay-1")).toBe(true);
+
+    setMode("solo");
+    expect(replaySince("no-such-id").some((e) => e.id === "ev-replay-1")).toBe(false);
+  });
+
+  it("never gates chat, in either mode", () => {
+    setMode("solo");
+    const external: TandemEvent[] = [];
+    const cb = (e: TandemEvent) => external.push(e);
+    subscribe(cb, "external");
+    _pushEventForTests({
+      id: "ev-chat-solo",
+      type: "chat:message",
+      timestamp: Date.now(),
+      payload: { messageId: "m1", text: "hi", replyTo: null, anchor: null },
+    } as TandemEvent);
+    unsubscribe(cb);
+
+    expect(external).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Solo suppression for accept/dismiss, Claude-authored replies, and `document:*` lifecycle lived **only in the consumer** (`shared/sse-consumer.ts`). That is client trust: `/api/events` writes every event to anything that connects, so a loopback `curl`, a third-party bridge, or a version-pinned monitor received the full stream in Solo. The consumer gate also reads a 2s stale mode cache and fails open on cold start.

## What actually leaks

**Timing, not content.** Solo does not gate document reads, so the snippets and filenames in these events carry nothing the AI cannot pull on demand. But the wake itself is what Solo promises not to do — they tell an idle session *"the user is doing things right now, go look."*

Worth being precise about, because it sets the severity: this is an enforcement-architecture fix, not a confidentiality hole.

## The placement is the load-bearing decision

`shouldForwardExternally` is applied at the two delivery points and **not** before `buffer.push`.

Moving the drop earlier was the obvious refactor and would have been wrong: it puts Solo-held content **into the replay buffer**, and `replaySince` returns the *entire* buffer whenever `Last-Event-ID` is not found — on a client-controlled header. Keeping the existing pre-buffer hold for user content means the buffer is unchanged, so the unknown-id fallback cannot hand out anything it could not hand out before.

Filtering `replaySince` is therefore **mandatory, not symmetry** with the fan-out gate. It is the higher-risk branch.

## Two more traps

**Mode is read live per delivery, never stamped at push time.** The release route flips mode and *then* emits the wake in the same handler, so a stamped value would swallow the one event the release exists to deliver. Bound once per push and reused, so correctness does not depend on `pushEvent` staying synchronous.

**In-process subscribers are deliberately not gated.** The local-model collaborator aborts in-flight runs on `document:closed`/`switched`; a blanket gate would strand them silently. That subscriber now passes `"internal"` **explicitly** rather than relying on the default — two correctness properties hang on it (this gate and `alreadyPushed`), and a silent default is a poor place to hang a privacy gate.

## Sequencing

The consumer-side gate is **retained on purpose**. A double gate is harmless; removing it first would open the gap on every already-installed server. Retire it once a server carrying this gate is what users actually run.

## One test changed meaning rather than breaking

*"does NOT hold accept/dismiss in Solo (narrow scope)"* was written about the **pre-buffer** hold, which is still narrow — the event is still buffered and still reaches in-process subscribers. It now observes as `"internal"` to assert the narrowness it was written for, with external behaviour covered by the new suite.

## Verification

Removed the gate and watched the withhold and replay-fallback tests fail. Also pinned: the release wake still reaches external consumers, chat is never gated in either mode, and in-process delivery is unaffected in Solo.

typecheck clean; **382 files / 5269 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012755vWSKJVdfNoLZa5zdUq