### PR TITLE
feat(client): solution-centric error UI and circuit-breaker recovery for launcher

### DIFF
--- a/docs/design-system-impl/testid-manifest.md
+++ b/docs/design-system-impl/testid-manifest.md
@@ -253,6 +253,7 @@ shipped and were removed:
 
 ### Empty states (3.11 D5)
 - `empty-state-open-file` (state A primary), `empty-state-retry` + `empty-state-open-settings` (state C)
+- State A AI-readiness CTA (#1268, keyed 1:1 off the `useAiReadiness` `chip` value — never re-derive from `lastError` in the view): `empty-state-connect-ai` (`aiChip: "connect"`), `empty-state-setup-claude` (`aiChip: "setup"` — the branch that actually fires for an uninstalled Claude CLI, re-keyed off `lastError === "circuit-open"`), `empty-state-restart-claude` (`aiChip: "restart"` primary), `empty-state-start-fresh` (`aiChip: "restart"` secondary — irreversible, never the default handler)
 
 ### Licensing gate (#1116, ships dark)
 - `license-trial-banner`, `license-trial-days` (trial countdown banner)

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -493,20 +493,30 @@ function connectAi(): void {
   window.dispatchEvent(new CustomEvent("tandem:open-integration-wizard"));
 }
 
-/** Restarts the stopped Claude Code process (the "Restart Claude Code" CTA),
- *  then re-polls launcher status so the chip clears once it's back up. Two
- *  staggered refreshes cover a slow cold start (MCP init / skill refresh) so
- *  the chip doesn't look stuck waiting for the next 8s background poll. */
-function restartClaude(): void {
-  relaunchClaudeCode();
+/** Re-polls launcher status twice after kicking off a launcher mutation, so
+ *  the chip clears once Claude is back up instead of looking stuck until the
+ *  next 8s background poll. The two staggered refreshes cover a slow cold
+ *  start (MCP init / skill refresh). Shared by `restartClaude` and
+ *  `startFreshClaude` — they differ only in which launcher action they kick
+ *  off, not in how they wait for it. */
+function refreshAiReadinessAfterLauncherAction(): void {
   setTimeout(() => aiReadiness.refresh(), 2_000);
   setTimeout(() => aiReadiness.refresh(), 5_000);
 }
 
+/** Restarts the stopped Claude Code process (the "Restart Claude Code" CTA). */
+function restartClaude(): void {
+  relaunchClaudeCode();
+  refreshAiReadinessAfterLauncherAction();
+}
+
+/** Drops Claude's saved conversation and restarts fresh (the EmptyState
+ *  "Start a fresh conversation" secondary CTA) — irreversible, so it must
+ *  never be an ambient CTA's default handler. See the `onStartFreshClaude`
+ *  doc comment on `EmptyState`'s Props. */
 function startFreshClaude(): void {
   startFreshClaudeCode();
-  setTimeout(() => aiReadiness.refresh(), 2_000);
-  setTimeout(() => aiReadiness.refresh(), 5_000);
+  refreshAiReadinessAfterLauncherAction();
 }
 
 // #1018 loud failures: ChatPanel (chat send) and Toolbar ("Send to Claude"
@@ -2443,10 +2453,8 @@ const shouldShowModelPicker = $derived(
       aiLiveIndicator={aiReadiness.liveIndicator}
       aiState={aiReadiness.state}
       aiChip={aiReadiness.chip}
-      lastError={aiReadiness.lastError}
       onConnectAi={connectAi}
       onRestartClaude={restartClaude}
-      onStartFreshClaude={startFreshClaude}
       soloMode={modeState.tandemMode === "solo"}
       claudeWorkingTool={yjsSync.claudeWorking?.tool ?? null}
       readOnly={isReadOnly}
@@ -2888,7 +2896,6 @@ const shouldShowModelPicker = $derived(
             <EmptyState
               connected={yjsSync.connected}
               aiChip={aiReadiness.chip}
-              lastError={aiReadiness.lastError}
               onOpenFile={() => (fileOpenDialogOpen = true)}
               onRetry={() => yjsSync.reconnect()}
               onOpenSettings={openSettingsModalWithAck}

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -14,6 +14,7 @@ import {
   SCRATCHPAD_EMPTY_STATE_DEBOUNCE_MS,
   saveStore,
   shouldAutoOpenScratchpad,
+  startFreshClaudeCode,
   triggerSave,
   triggerSaveAs,
   wireActionDeps,
@@ -498,6 +499,12 @@ function connectAi(): void {
  *  the chip doesn't look stuck waiting for the next 8s background poll. */
 function restartClaude(): void {
   relaunchClaudeCode();
+  setTimeout(() => aiReadiness.refresh(), 2_000);
+  setTimeout(() => aiReadiness.refresh(), 5_000);
+}
+
+function startFreshClaude(): void {
+  startFreshClaudeCode();
   setTimeout(() => aiReadiness.refresh(), 2_000);
   setTimeout(() => aiReadiness.refresh(), 5_000);
 }
@@ -2436,8 +2443,10 @@ const shouldShowModelPicker = $derived(
       aiLiveIndicator={aiReadiness.liveIndicator}
       aiState={aiReadiness.state}
       aiChip={aiReadiness.chip}
+      lastError={aiReadiness.lastError}
       onConnectAi={connectAi}
       onRestartClaude={restartClaude}
+      onStartFreshClaude={startFreshClaude}
       soloMode={modeState.tandemMode === "solo"}
       claudeWorkingTool={yjsSync.claudeWorking?.tool ?? null}
       readOnly={isReadOnly}
@@ -2879,11 +2888,13 @@ const shouldShowModelPicker = $derived(
             <EmptyState
               connected={yjsSync.connected}
               aiChip={aiReadiness.chip}
+              lastError={aiReadiness.lastError}
               onOpenFile={() => (fileOpenDialogOpen = true)}
               onRetry={() => yjsSync.reconnect()}
               onOpenSettings={openSettingsModalWithAck}
               onConnectAi={connectAi}
               onRestartClaude={restartClaude}
+              onStartFreshClaude={startFreshClaude}
             />
           {/if}
         </div>

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -51,7 +51,7 @@ import FindReplaceBar from "./editor/find-replace/FindReplaceBar.svelte";
 import SourceView from "./editor/SourceView.svelte";
 import Toolbar from "./editor/toolbar/Toolbar.svelte";
 import { createAccentHue } from "./hooks/useAccentHue.svelte";
-import { createAiReadiness } from "./hooks/useAiReadiness.svelte";
+import { AI_CTA, createAiReadiness } from "./hooks/useAiReadiness.svelte";
 import {
   nextAnnotationId,
   prevAnnotationId,
@@ -549,8 +549,12 @@ $effect(() => {
         timestamp: Date.now(),
       },
       {
-        label: chip === "connect" ? "Connect AI" : "Restart Claude Code",
-        onClick: chip === "connect" ? connectAi : restartClaude,
+        // Driven by the shared exhaustive map, not a binary ternary: `chip`
+        // has three non-null members, and a `=== "connect"` test sent `setup`
+        // (Claude CLI not installed) down the restart branch — offering to
+        // restart a binary that isn't there.
+        label: AI_CTA[chip].label,
+        onClick: AI_CTA[chip].action === "restart" ? restartClaude : connectAi,
       },
     );
   };

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -703,6 +703,10 @@ export function relaunchClaudeCode(): void {
   guardedRun("launcher-relaunch-here", (d) => void relaunchHere(d));
 }
 
+export function startFreshClaudeCode(): void {
+  guardedRun("launcher-start-fresh", (d) => void startFreshConversation(d));
+}
+
 async function startFreshConversation(d: ActionDeps): Promise<void> {
   if (!(await checkLauncherAvailable(d))) return;
   if (!confirm("Drop Claude's saved conversation and restart fresh. This cannot be undone.")) {

--- a/src/client/components/EmptyState.svelte
+++ b/src/client/components/EmptyState.svelte
@@ -1,36 +1,49 @@
 <script lang="ts">
 import { DISCONNECT_DEBOUNCE_MS } from "../../shared/constants";
-import type { LauncherErrorCode } from "../../shared/launcher/contract";
 import type { AiChip } from "../hooks/useAiReadiness.svelte";
 
 interface Props {
   connected: boolean;
   /**
-   * AI-readiness CTA (#1018/#1022). `"connect"` → AI isn't set up;
-   * `"restart"` → configured but stopped; `null` → ready / booting / Solo
-   * (no CTA, falls back to the product-positioning line). Replaces the old
-   * `claudeActive`-gated line, which keyed on a flapping presence signal.
+   * AI-readiness CTA (#1018/#1022). This is the ONLY signal the branches
+   * below switch on — `useAiReadiness` already folds `lastError` into this
+   * value (see its `AiChip` doc comment), so this component must not
+   * re-derive its own `lastError`-keyed decision. That duplication is what
+   * let this component's CTA drift out of sync with StatusBar's (#1268).
+   *   `"connect"` → never configured.
+   *   `"setup"`   → configured but stopped with the CLI apparently missing.
+   *   `"restart"` → configured but stopped for any other reason.
+   *   `null`      → ready / booting / Solo (no CTA, falls back to the
+   *                 product-positioning line).
+   * Replaces the old `claudeActive`-gated line, which keyed on a flapping
+   * presence signal.
    */
   aiChip?: AiChip;
-  lastError?: LauncherErrorCode;
   /** State A primary — opens the file-open dialog. */
   onOpenFile: () => void;
   /** State C primary — retries the sync-server connection. */
   onRetry: () => void;
   /** State C ghost link — opens the settings modal. */
   onOpenSettings: () => void;
-  /** Opens AI setup (Claude Code wizard) — the `"connect"` CTA. */
+  /** Opens AI setup (Claude Code wizard) — the `"connect"` and `"setup"` CTAs. */
   onConnectAi?: () => void;
-  /** Restarts the stopped Claude Code process — the `"restart"` CTA. */
+  /** Restarts the stopped Claude Code process — the `"restart"` CTA primary. */
   onRestartClaude?: () => void;
-  /** Restarts the stopped Claude Code process with a fresh session (clears circuit breaker). */
+  /**
+   * Drops Claude's saved conversation and restarts fresh — irreversible (its
+   * own confirm dialog says so). NOT a circuit-breaker clear: a plain restart
+   * (`onRestartClaude`) already clears the breaker on its own. The only
+   * actual difference is that this one discards the conversation, so it's
+   * offered as an explicit, clearly-labeled secondary action — never the
+   * primary/default handler for an ambient CTA (a button a user might click
+   * expecting a safe retry must never destroy their session; see #1268).
+   */
   onStartFreshClaude?: () => void;
 }
 
 let {
   connected,
   aiChip = null,
-  lastError,
   onOpenFile,
   onRetry,
   onOpenSettings,
@@ -126,44 +139,49 @@ $effect(() => {
           Connect AI
         </button>
       </div>
+    {:else if connected && aiChip === "setup"}
+      <!-- Re-keyed off `lastError === "circuit-open"` — see the `AiChip` doc
+           comment in useAiReadiness. This is the branch that actually fires
+           when the Claude CLI isn't installed (the old `binary-not-found` key
+           here rendered for nobody: an uninstalled CLI surfaces as an ordinary
+           reaper exit code, not a Node spawn ENOENT). -->
+      <p class="empty-sub empty-sub-secondary">Let's get Claude set up on your computer.</p>
+      <div class="empty-actions">
+        <button
+          class="empty-cta"
+          data-testid="empty-state-setup-claude"
+          data-ai-chip="setup"
+          onclick={onConnectAi}
+        >
+          Set up Claude Code
+        </button>
+      </div>
     {:else if connected && aiChip === "restart"}
-      {#if lastError === "binary-not-found"}
-        <p class="empty-sub empty-sub-secondary">Let's get Claude set up on your computer.</p>
-        <div class="empty-actions">
-          <button
-            class="empty-cta"
-            data-testid="empty-state-connect-ai"
-            data-ai-chip="connect"
-            onclick={onConnectAi}
-          >
-            Set up Claude Code
-          </button>
-        </div>
-      {:else if lastError === "circuit-open"}
-        <p class="empty-sub empty-sub-secondary">Tandem is having trouble connecting to Claude.</p>
-        <div class="empty-actions">
-          <button
-            class="empty-cta"
-            data-testid="empty-state-connect-ai"
-            data-ai-chip="restart"
-            onclick={onStartFreshClaude ?? onRestartClaude}
-          >
-            Try Again
-          </button>
-        </div>
-      {:else}
-        <p class="empty-sub empty-sub-secondary">Claude Code has stopped.</p>
-        <div class="empty-actions">
-          <button
-            class="empty-cta"
-            data-testid="empty-state-connect-ai"
-            data-ai-chip="restart"
-            onclick={onRestartClaude}
-          >
-            Restart Claude Code
-          </button>
-        </div>
-      {/if}
+      <p class="empty-sub empty-sub-secondary">Claude Code has stopped.</p>
+      <div class="empty-actions">
+        <button
+          class="empty-cta"
+          data-testid="empty-state-restart-claude"
+          data-ai-chip="restart"
+          onclick={onRestartClaude}
+        >
+          Restart Claude Code
+        </button>
+        <!-- Secondary, explicitly-labeled, and never the default action: the
+             underlying flow is irreversible (drops the saved conversation),
+             so it must not hide behind a button a user could click expecting
+             a safe retry (#1268). The primary Restart button above stays
+             available regardless of what the user does with this one's own
+             confirm dialog — cancelling it is never a dead end. -->
+        <button
+          class="empty-link"
+          data-testid="empty-state-start-fresh"
+          data-ai-chip="restart"
+          onclick={onStartFreshClaude}
+        >
+          Start a fresh conversation
+        </button>
+      </div>
     {:else if connected}
       <!-- Preserved from production: carries product positioning, not in the bundle. -->
       <p class="empty-sub empty-sub-secondary">

--- a/src/client/components/EmptyState.svelte
+++ b/src/client/components/EmptyState.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { DISCONNECT_DEBOUNCE_MS } from "../../shared/constants";
+import type { LauncherErrorCode } from "../../shared/launcher/contract";
 import type { AiChip } from "../hooks/useAiReadiness.svelte";
 
 interface Props {
@@ -11,6 +12,7 @@ interface Props {
    * `claudeActive`-gated line, which keyed on a flapping presence signal.
    */
   aiChip?: AiChip;
+  lastError?: LauncherErrorCode;
   /** State A primary — opens the file-open dialog. */
   onOpenFile: () => void;
   /** State C primary — retries the sync-server connection. */
@@ -21,16 +23,20 @@ interface Props {
   onConnectAi?: () => void;
   /** Restarts the stopped Claude Code process — the `"restart"` CTA. */
   onRestartClaude?: () => void;
+  /** Restarts the stopped Claude Code process with a fresh session (clears circuit breaker). */
+  onStartFreshClaude?: () => void;
 }
 
 let {
   connected,
   aiChip = null,
+  lastError,
   onOpenFile,
   onRetry,
   onOpenSettings,
   onConnectAi,
   onRestartClaude,
+  onStartFreshClaude,
 }: Props = $props();
 
 let showDisconnected = $state(false);
@@ -121,17 +127,43 @@ $effect(() => {
         </button>
       </div>
     {:else if connected && aiChip === "restart"}
-      <p class="empty-sub empty-sub-secondary">Claude Code has stopped.</p>
-      <div class="empty-actions">
-        <button
-          class="empty-cta"
-          data-testid="empty-state-connect-ai"
-          data-ai-chip="restart"
-          onclick={onRestartClaude}
-        >
-          Restart Claude Code
-        </button>
-      </div>
+      {#if lastError === "binary-not-found"}
+        <p class="empty-sub empty-sub-secondary">Let's get Claude set up on your computer.</p>
+        <div class="empty-actions">
+          <button
+            class="empty-cta"
+            data-testid="empty-state-connect-ai"
+            data-ai-chip="connect"
+            onclick={onConnectAi}
+          >
+            Set up Claude Code
+          </button>
+        </div>
+      {:else if lastError === "circuit-open"}
+        <p class="empty-sub empty-sub-secondary">Tandem is having trouble connecting to Claude.</p>
+        <div class="empty-actions">
+          <button
+            class="empty-cta"
+            data-testid="empty-state-connect-ai"
+            data-ai-chip="restart"
+            onclick={onStartFreshClaude ?? onRestartClaude}
+          >
+            Try Again
+          </button>
+        </div>
+      {:else}
+        <p class="empty-sub empty-sub-secondary">Claude Code has stopped.</p>
+        <div class="empty-actions">
+          <button
+            class="empty-cta"
+            data-testid="empty-state-connect-ai"
+            data-ai-chip="restart"
+            onclick={onRestartClaude}
+          >
+            Restart Claude Code
+          </button>
+        </div>
+      {/if}
     {:else if connected}
       <!-- Preserved from production: carries product positioning, not in the bundle. -->
       <p class="empty-sub empty-sub-secondary">

--- a/src/client/hooks/useAiReadiness.svelte.ts
+++ b/src/client/hooks/useAiReadiness.svelte.ts
@@ -103,6 +103,55 @@ export type AiReadinessState = "booting" | "unconfigured" | "stopped" | "ready";
 export type AiChip = "connect" | "setup" | "restart" | null;
 
 /**
+ * Everything a surface needs to render an `AiChip`'s call to action: its copy
+ * and, crucially, WHICH action it performs.
+ *
+ * A `Record` keyed on the union rather than a ternary at each call site, and
+ * the `action` discriminant is the whole point. `AiChip` grew from two members
+ * to three, and every widening silently left binary `chip === "connect" ? a : b`
+ * ternaries behind — they keep compiling, and the new member just falls down
+ * the wrong branch. That is not hypothetical: it shipped. The "no AI connected"
+ * toast in `App.svelte` offered `setup` users "Restart Claude Code" wired to
+ * `restartClaude()`, re-triggering the doomed spawn loop that tripped the
+ * circuit breaker in the first place — the exact opposite of the intended
+ * "install the CLI".
+ *
+ * With this map a fourth member is a type error at every consumer instead.
+ */
+export const AI_CTA: Record<
+  Exclude<AiChip, null>,
+  {
+    /** Short button/CTA text. */
+    label: string;
+    /** `title` attribute — the hover explanation. */
+    title: string;
+    ariaLabel: string;
+    /** Which handler this CTA must invoke. `setup` resolves to `connect`: the
+     * install flow IS the integration wizard, only with different copy. */
+    action: "connect" | "restart";
+  }
+> = {
+  connect: {
+    label: "Connect AI",
+    title: "AI isn't set up — connect Claude Code",
+    ariaLabel: "AI isn't set up. Connect Claude Code.",
+    action: "connect",
+  },
+  setup: {
+    label: "Set up Claude Code",
+    title: "Claude Code needs to be installed",
+    ariaLabel: "Claude Code needs to be installed. Set up Claude Code.",
+    action: "connect",
+  },
+  restart: {
+    label: "Restart Claude Code",
+    title: "Claude Code stopped — restart it",
+    ariaLabel: "Claude Code has stopped. Restart Claude Code.",
+    action: "restart",
+  },
+};
+
+/**
  * The affirmative "an agent is connected" indicator, or `null` when there's
  * nothing positive to assert (no session, or still booting). Distinct from
  * `chip` (which is the *negative*-state CTA): `chip` and `liveIndicator` are

--- a/src/client/hooks/useAiReadiness.svelte.ts
+++ b/src/client/hooks/useAiReadiness.svelte.ts
@@ -57,7 +57,11 @@
  */
 import { onDestroy } from "svelte";
 import { API_HEALTH, API_LAUNCHER_STATUS } from "../../shared/api-paths.js";
-import { isTransientlyUnavailable, type LauncherStatus } from "../../shared/launcher/contract.js";
+import {
+  isTransientlyUnavailable,
+  type LauncherErrorCode,
+  type LauncherStatus,
+} from "../../shared/launcher/contract.js";
 import { API_BASE } from "../utils/fileUpload.js";
 
 /** Loopback `/health` response. `hasSession` is omitted for non-loopback
@@ -93,6 +97,8 @@ export interface AiReadiness {
   readonly state: AiReadinessState;
   /** The CTA to surface, with Solo-mode suppression already applied. */
   readonly chip: AiChip;
+  /** Last scrubbed error code from supervisor when state is stopped. */
+  readonly lastError?: LauncherErrorCode;
   /**
    * The affirmative connected indicator, keyed on the authoritative MCP-session
    * signal (`hasSession`) — NOT on `state`, which also reaches `ready` from the
@@ -267,6 +273,14 @@ export function createAiReadiness(deps: {
     return null;
   });
 
+  const lastError = $derived.by((): LauncherErrorCode | undefined => {
+    if (status === null) return undefined;
+    if ("running" in status && status.running === false && "lastError" in status) {
+      return status.lastError;
+    }
+    return undefined;
+  });
+
   // The affirmative indicator keys on `mcpSessionActive` (an open MCP transport,
   // proven by a real `initialize` round-trip) — the honest subset of `ready`.
   // `state === "ready"` also fires from the launcher `running: true` branch with
@@ -285,6 +299,9 @@ export function createAiReadiness(deps: {
     },
     get chip() {
       return chip;
+    },
+    get lastError() {
+      return lastError;
     },
     get liveIndicator() {
       return liveIndicator;

--- a/src/client/hooks/useAiReadiness.svelte.ts
+++ b/src/client/hooks/useAiReadiness.svelte.ts
@@ -74,8 +74,33 @@ interface HealthResponse {
 
 export type AiReadinessState = "booting" | "unconfigured" | "stopped" | "ready";
 
-/** What the titlebar/empty-state CTA should offer, or `null` to show nothing. */
-export type AiChip = "connect" | "restart" | null;
+/**
+ * What the titlebar/empty-state CTA should offer, or `null` to show nothing.
+ * This is the SINGLE source of truth for which CTA a `stopped` state gets —
+ * views must switch on this value alone, never re-derive their own decision
+ * from `lastError` (that duplication is exactly how the titlebar and empty
+ * state CTAs drifted out of sync; see #1268).
+ *   - `connect` — never configured (`state === "unconfigured"`). Opens the
+ *     integration wizard.
+ *   - `setup`   — configured but stopped with the circuit breaker tripped
+ *     (`lastError === "circuit-open"`). This — NOT `binary-not-found` — is
+ *     the branch that actually fires when the Claude Code CLI isn't
+ *     installed: the supervisor spawns the bundled reaper (which always
+ *     exists), and the reaper's own exec of the (missing) `claude` binary
+ *     fails internally and exits with code 127 — an ordinary process exit,
+ *     not a Node `ENOENT` on the reaper spawn itself. That routes through
+ *     `scheduleRestart`, which retries and eventually trips the breaker
+ *     (`circuit-open`), never through the `child.on("error")` handler that
+ *     sets `binary-not-found`. `binary-not-found` is reserved for the
+ *     genuinely rare case where the *reaper* binary is missing/unrunnable —
+ *     a broken Tandem install, not a missing Claude CLI — and gets no
+ *     special CTA (falls into `restart`, since retrying the reaper spawn is
+ *     the only available action). Opens the integration wizard, same as
+ *     `connect`, but with install-specific copy.
+ *   - `restart` — configured but stopped for any other reason (including the
+ *     rare `binary-not-found`). Plain restart.
+ */
+export type AiChip = "connect" | "setup" | "restart" | null;
 
 /**
  * The affirmative "an agent is connected" indicator, or `null` when there's
@@ -266,20 +291,29 @@ export function createAiReadiness(deps: {
     return status.running === true ? "ready" : "stopped";
   });
 
-  const chip = $derived.by((): AiChip => {
-    if (deps.soloMode()) return null;
-    if (state === "unconfigured") return "connect";
-    if (state === "stopped") return "restart";
-    return null;
-  });
+  // `status` is a discriminated union on `available` (and, once available,
+  // `running`) — narrow on those tags rather than probing shape with `in`
+  // checks, which only happen to work because the `available: false` arm
+  // lacks a `running` field.
+  const lastError = $derived<LauncherErrorCode | undefined>(
+    status !== null && status.available && !status.running ? status.lastError : undefined,
+  );
 
-  const lastError = $derived.by((): LauncherErrorCode | undefined => {
-    if (status === null) return undefined;
-    if ("running" in status && status.running === false && "lastError" in status) {
-      return status.lastError;
-    }
-    return undefined;
-  });
+  // `chip` is the ONE place the `lastError` → CTA decision is made (see the
+  // `AiChip` doc comment for why `circuit-open`, not `binary-not-found`, is
+  // the branch that means "go install Claude Code"). Views must render off
+  // this value alone, not re-derive their own copy of this ternary.
+  const chip = $derived<AiChip>(
+    deps.soloMode()
+      ? null
+      : state === "unconfigured"
+        ? "connect"
+        : state === "stopped"
+          ? lastError === "circuit-open"
+            ? "setup"
+            : "restart"
+          : null,
+  );
 
   // The affirmative indicator keys on `mcpSessionActive` (an open MCP transport,
   // proven by a real `initialize` round-trip) — the honest subset of `ready`.
@@ -288,10 +322,9 @@ export function createAiReadiness(deps: {
   // connected. When no session is open there is nothing affirmative to say
   // (`null`); Solo-with-no-session is still `null` — "AI won't see your edits"
   // only makes sense once an AI is actually connected.
-  const liveIndicator = $derived.by((): AiLiveIndicator => {
-    if (!mcpSessionActive) return null;
-    return deps.soloMode() ? "solo-paused" : "connected";
-  });
+  const liveIndicator = $derived<AiLiveIndicator>(
+    !mcpSessionActive ? null : deps.soloMode() ? "solo-paused" : "connected",
+  );
 
   return {
     get state() {

--- a/src/client/status/StatusBar.svelte
+++ b/src/client/status/StatusBar.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { Editor as TiptapEditor } from "@tiptap/core";
 import { onDestroy, untrack } from "svelte";
-import type { LauncherErrorCode } from "../../shared/launcher/contract";
 import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
 import type { AiChip, AiLiveIndicator, AiReadinessState } from "../hooks/useAiReadiness.svelte";
 import type { ConnectionStatus } from "../hooks/yjsSync.svelte";
@@ -27,12 +26,15 @@ interface Props {
    *  (render nothing) from genuinely-down (`unconfigured`/`stopped` → "AI not
    *  connected"). A boolean can't carry that; see `aiIndicatorView`. */
   aiState: AiReadinessState;
-  /** When present, the AI status indicator becomes the Connect/Restart control. */
+  /**
+   * When present, the AI status indicator becomes the Connect/Setup/Restart
+   * control. This is the ONLY signal the CTA lookup below switches on — the
+   * hook (`useAiReadiness`) already folded `lastError` into this value, so
+   * this component must not re-derive its own copy of that decision (#1268).
+   */
   aiChip?: AiChip;
-  lastError?: LauncherErrorCode;
   onConnectAi?: () => void;
   onRestartClaude?: () => void;
-  onStartFreshClaude?: () => void;
   /** Solo mode — suppresses the "AI not connected" nag when no AI is connected. */
   soloMode: boolean;
   /**
@@ -74,10 +76,8 @@ let {
   aiLiveIndicator,
   aiState,
   aiChip = null,
-  lastError,
   onConnectAi,
   onRestartClaude,
-  onStartFreshClaude,
   soloMode,
   claudeWorkingTool = null,
   readOnly,
@@ -203,6 +203,46 @@ const labelColor = $derived(
 // former "Assistant · idle" segment). The view is a pure mapping — MUST be
 // `$derived` so it recomputes as the reactive props flip connected→solo→down.
 const aiView = $derived(aiIndicatorView(aiState, aiLiveIndicator, soloMode));
+
+/**
+ * The AI indicator's actionable content — title, aria-label, and onclick —
+ * keyed together off `aiChip` as ONE lookup. Previously these were three
+ * separate parallel ternary chains (one each for title/aria-label/onclick);
+ * the onclick chain silently lost its `binary-not-found` branch, so the
+ * button announced "Set up Claude Code" but clicking it restarted Claude
+ * instead (#1268). A single lookup makes that class of bug structurally
+ * impossible — a new `aiChip` value with no entry here is a type error, not
+ * a silently-inherited fallthrough.
+ *
+ * Copy is static (module scope is fine); the handler depends on the
+ * `onConnectAi`/`onRestartClaude` props, so it's resolved inside `aiCta`
+ * below — a plain top-level object would freeze stale closures over the
+ * props' initial values.
+ */
+const AI_CTA_COPY: Record<Exclude<AiChip, null>, { title: string; ariaLabel: string }> = {
+  connect: {
+    title: "AI isn't set up — connect Claude Code",
+    ariaLabel: "AI isn't set up. Connect Claude Code.",
+  },
+  // See the `AiChip` doc comment in useAiReadiness — `setup` is the branch
+  // that actually fires when the Claude CLI isn't installed.
+  setup: {
+    title: "Claude Code needs to be installed",
+    ariaLabel: "Claude Code needs to be installed. Set up Claude Code.",
+  },
+  restart: {
+    title: "Claude Code stopped — restart it",
+    ariaLabel: "Claude Code has stopped. Restart Claude Code.",
+  },
+};
+const aiCta = $derived(
+  aiChip
+    ? {
+        ...AI_CTA_COPY[aiChip],
+        onclick: aiChip === "restart" ? onRestartClaude : onConnectAi,
+      }
+    : null,
+);
 
 // Activity latch (D3): `claudeActive` flaps to false every few seconds while
 // Claude idles between tool calls. Animating the now-full-opacity dot straight
@@ -374,32 +414,16 @@ function cycleWordMode() {
       </span>
   {/snippet}
   {#if aiView}
-    {#if aiChip}
+    {#if aiCta}
       <button
         type="button"
         class="status-ai-indicator actionable"
         data-testid="status-ai-indicator"
         data-ai-state={aiView.dataState}
         data-ai-action={aiChip}
-        title={aiChip === "connect"
-          ? "AI isn't set up — connect Claude Code"
-          : lastError === "binary-not-found"
-          ? "Claude Code needs to be installed"
-          : lastError === "circuit-open"
-          ? "Tandem can't connect to Claude — try again"
-          : "Claude Code stopped — restart it"}
-        aria-label={aiChip === "connect"
-          ? "AI isn't set up. Connect Claude Code."
-          : lastError === "binary-not-found"
-          ? "Claude Code needs to be installed. Set up Claude Code."
-          : lastError === "circuit-open"
-          ? "Tandem is having trouble connecting to Claude. Try again."
-          : "Claude Code has stopped. Restart Claude Code."}
-        onclick={aiChip === "connect"
-          ? onConnectAi
-          : lastError === "circuit-open"
-          ? (onStartFreshClaude ?? onRestartClaude)
-          : onRestartClaude}
+        title={aiCta.title}
+        aria-label={aiCta.ariaLabel}
+        onclick={aiCta.onclick}
       >
         {@render aiIndicatorContent(aiView)}
       </button>

--- a/src/client/status/StatusBar.svelte
+++ b/src/client/status/StatusBar.svelte
@@ -3,6 +3,7 @@ import type { Editor as TiptapEditor } from "@tiptap/core";
 import { onDestroy, untrack } from "svelte";
 import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
 import type { AiChip, AiLiveIndicator, AiReadinessState } from "../hooks/useAiReadiness.svelte";
+import { AI_CTA } from "../hooks/useAiReadiness.svelte";
 import type { ConnectionStatus } from "../hooks/yjsSync.svelte";
 import { createCoalescingTick } from "../utils/coalescing-tick";
 import { debounce } from "../utils/debounce";
@@ -214,32 +215,18 @@ const aiView = $derived(aiIndicatorView(aiState, aiLiveIndicator, soloMode));
  * impossible — a new `aiChip` value with no entry here is a type error, not
  * a silently-inherited fallthrough.
  *
- * Copy is static (module scope is fine); the handler depends on the
- * `onConnectAi`/`onRestartClaude` props, so it's resolved inside `aiCta`
- * below — a plain top-level object would freeze stale closures over the
- * props' initial values.
+ * Copy and the handler *choice* live in `AI_CTA` (useAiReadiness), shared with
+ * App.svelte's "no AI connected" toast — that toast had the same bug against
+ * the same union, so the fix belongs in one place. The handler *values* are
+ * props, so they're bound inside `aiCta` here: a plain top-level object would
+ * freeze stale closures over the props' initial values.
  */
-const AI_CTA_COPY: Record<Exclude<AiChip, null>, { title: string; ariaLabel: string }> = {
-  connect: {
-    title: "AI isn't set up — connect Claude Code",
-    ariaLabel: "AI isn't set up. Connect Claude Code.",
-  },
-  // See the `AiChip` doc comment in useAiReadiness — `setup` is the branch
-  // that actually fires when the Claude CLI isn't installed.
-  setup: {
-    title: "Claude Code needs to be installed",
-    ariaLabel: "Claude Code needs to be installed. Set up Claude Code.",
-  },
-  restart: {
-    title: "Claude Code stopped — restart it",
-    ariaLabel: "Claude Code has stopped. Restart Claude Code.",
-  },
-};
 const aiCta = $derived(
   aiChip
     ? {
-        ...AI_CTA_COPY[aiChip],
-        onclick: aiChip === "restart" ? onRestartClaude : onConnectAi,
+        title: AI_CTA[aiChip].title,
+        ariaLabel: AI_CTA[aiChip].ariaLabel,
+        onclick: AI_CTA[aiChip].action === "restart" ? onRestartClaude : onConnectAi,
       }
     : null,
 );

--- a/src/client/status/StatusBar.svelte
+++ b/src/client/status/StatusBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Editor as TiptapEditor } from "@tiptap/core";
 import { onDestroy, untrack } from "svelte";
+import type { LauncherErrorCode } from "../../shared/launcher/contract";
 import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
 import type { AiChip, AiLiveIndicator, AiReadinessState } from "../hooks/useAiReadiness.svelte";
 import type { ConnectionStatus } from "../hooks/yjsSync.svelte";
@@ -28,8 +29,10 @@ interface Props {
   aiState: AiReadinessState;
   /** When present, the AI status indicator becomes the Connect/Restart control. */
   aiChip?: AiChip;
+  lastError?: LauncherErrorCode;
   onConnectAi?: () => void;
   onRestartClaude?: () => void;
+  onStartFreshClaude?: () => void;
   /** Solo mode — suppresses the "AI not connected" nag when no AI is connected. */
   soloMode: boolean;
   /**
@@ -71,8 +74,10 @@ let {
   aiLiveIndicator,
   aiState,
   aiChip = null,
+  lastError,
   onConnectAi,
   onRestartClaude,
+  onStartFreshClaude,
   soloMode,
   claudeWorkingTool = null,
   readOnly,
@@ -378,11 +383,23 @@ function cycleWordMode() {
         data-ai-action={aiChip}
         title={aiChip === "connect"
           ? "AI isn't set up — connect Claude Code"
+          : lastError === "binary-not-found"
+          ? "Claude Code needs to be installed"
+          : lastError === "circuit-open"
+          ? "Tandem can't connect to Claude — try again"
           : "Claude Code stopped — restart it"}
         aria-label={aiChip === "connect"
           ? "AI isn't set up. Connect Claude Code."
+          : lastError === "binary-not-found"
+          ? "Claude Code needs to be installed. Set up Claude Code."
+          : lastError === "circuit-open"
+          ? "Tandem is having trouble connecting to Claude. Try again."
           : "Claude Code has stopped. Restart Claude Code."}
-        onclick={aiChip === "connect" ? onConnectAi : onRestartClaude}
+        onclick={aiChip === "connect"
+          ? onConnectAi
+          : lastError === "circuit-open"
+          ? (onStartFreshClaude ?? onRestartClaude)
+          : onRestartClaude}
       >
         {@render aiIndicatorContent(aiView)}
       </button>

--- a/tests/client/EmptyState.test.ts
+++ b/tests/client/EmptyState.test.ts
@@ -15,6 +15,7 @@ function makeProps(overrides: Record<string, unknown> = {}) {
     onOpenSettings: vi.fn(),
     onConnectAi: vi.fn(),
     onRestartClaude: vi.fn(),
+    onStartFreshClaude: vi.fn(),
     ...overrides,
   };
 }
@@ -34,27 +35,43 @@ describe("EmptyState", () => {
     vi.useRealTimers();
   });
 
+  // Every non-null aiChip branch renders exactly one of these — checking all
+  // three per case (not just the one expected to be present) is the positive
+  // control: it proves an "absent" testid is absent because that branch
+  // genuinely didn't render, not because the whole card failed to mount.
+  const AI_CTA_TESTIDS = [
+    "empty-state-connect-ai",
+    "empty-state-setup-claude",
+    "empty-state-restart-claude",
+  ] as const;
+
   describe("state A — no document open", () => {
     it.each([
       {
         why: "aiChip null (ready/booting/solo) → state A + product-positioning line, no CTA",
         aiChip: null,
         expectSecondary: true,
-        expectCta: false,
+        expectedTestId: null,
       },
       {
         why: "aiChip 'connect' → Connect AI CTA, no positioning line",
         aiChip: "connect",
         expectSecondary: false,
-        expectCta: true,
+        expectedTestId: "empty-state-connect-ai",
       },
       {
-        why: "aiChip 'restart' → Restart CTA, no positioning line",
+        why: "aiChip 'setup' (re-keyed off lastError === circuit-open, #1268) → Set up Claude Code CTA, no positioning line",
+        aiChip: "setup",
+        expectSecondary: false,
+        expectedTestId: "empty-state-setup-claude",
+      },
+      {
+        why: "aiChip 'restart' → Restart Claude Code CTA, no positioning line",
         aiChip: "restart",
         expectSecondary: false,
-        expectCta: true,
+        expectedTestId: "empty-state-restart-claude",
       },
-    ])("$why", ({ aiChip, expectSecondary, expectCta }) => {
+    ])("$why", ({ aiChip, expectSecondary, expectedTestId }) => {
       const { container } = render(EmptyState, {
         props: makeProps({ connected: true, aiChip }),
       });
@@ -68,7 +85,14 @@ describe("EmptyState", () => {
       const hasSecondary =
         container.textContent?.includes("Tandem works alongside Claude") ?? false;
       expect(hasSecondary).toBe(expectSecondary);
-      expect(byTestId(container, "empty-state-connect-ai") !== null).toBe(expectCta);
+
+      // Exactly the expected branch's testid is present — every other AI-CTA
+      // testid must be absent, distinguishing the three reachable branches
+      // from each other (not just "some CTA rendered").
+      for (const testid of AI_CTA_TESTIDS) {
+        const present = byTestId(container, testid) !== null;
+        expect(present).toBe(testid === expectedTestId);
+      }
     });
 
     it("Open file… fires onOpenFile", async () => {
@@ -90,16 +114,110 @@ describe("EmptyState", () => {
       await tick();
 
       expect(props.onConnectAi).toHaveBeenCalledOnce();
+      expect(props.onRestartClaude).not.toHaveBeenCalled();
     });
 
-    it("Restart CTA fires onRestartClaude", async () => {
-      const props = makeProps({ connected: true, aiChip: "restart" });
+    it("aiChip 'connect' carries an honest data-ai-chip attribute", () => {
+      const { container } = render(EmptyState, {
+        props: makeProps({ connected: true, aiChip: "connect" }),
+      });
+      expect(byTestId(container, "empty-state-connect-ai")?.getAttribute("data-ai-chip")).toBe(
+        "connect",
+      );
+    });
+
+    // #1268 defect 2a: the install CTA was keyed on `lastError ===
+    // "binary-not-found"`, which never actually fires for an uninstalled
+    // Claude CLI (that surfaces as an ordinary reaper exit code, routed to
+    // `circuit-open` — see the `AiChip` doc comment in useAiReadiness). The
+    // hook now folds that into `aiChip === "setup"`; EmptyState must render
+    // the install CTA off that value alone.
+    it("Set up Claude Code CTA (aiChip 'setup') fires onConnectAi, not onRestartClaude", async () => {
+      const props = makeProps({ connected: true, aiChip: "setup" });
       const { container } = render(EmptyState, { props });
 
-      byTestId(container, "empty-state-connect-ai")?.click();
+      const btn = byTestId(container, "empty-state-setup-claude");
+      expect(btn?.textContent?.trim()).toBe("Set up Claude Code");
+      expect(btn?.getAttribute("data-ai-chip")).toBe("setup");
+
+      btn?.click();
       await tick();
 
-      expect(props.onRestartClaude).toHaveBeenCalledOnce();
+      expect(props.onConnectAi).toHaveBeenCalledOnce();
+      expect(props.onRestartClaude).not.toHaveBeenCalled();
+      expect(props.onStartFreshClaude).not.toHaveBeenCalled();
+    });
+
+    describe("aiChip 'restart' — primary Restart + secondary Start Fresh", () => {
+      function renderRestart(overrides: Record<string, unknown> = {}) {
+        const props = makeProps({ connected: true, aiChip: "restart", ...overrides });
+        const result = render(EmptyState, { props });
+        return { ...result, props };
+      }
+
+      it("both actions render with distinct testids and an honest data-ai-chip", () => {
+        const { container } = renderRestart();
+
+        const primary = byTestId(container, "empty-state-restart-claude");
+        const secondary = byTestId(container, "empty-state-start-fresh");
+        expect(primary).toBeTruthy();
+        expect(secondary).toBeTruthy();
+        expect(primary).not.toBe(secondary);
+        expect(primary?.getAttribute("data-ai-chip")).toBe("restart");
+        expect(secondary?.getAttribute("data-ai-chip")).toBe("restart");
+      });
+
+      // #1268 defect 2b: this button used to be labelled "Try Again" while
+      // invoking the session-destroying start-fresh flow. The primary CTA
+      // must now be non-destructive — positive control: it still does the
+      // (safe) thing its label promises.
+      it("primary Restart Claude Code CTA calls onRestartClaude, never onStartFreshClaude", async () => {
+        const { container, props } = renderRestart();
+
+        const btn = byTestId(container, "empty-state-restart-claude");
+        expect(btn?.textContent?.trim()).toBe("Restart Claude Code");
+
+        btn?.click();
+        await tick();
+
+        expect(props.onRestartClaude).toHaveBeenCalledOnce();
+        expect(props.onStartFreshClaude).not.toHaveBeenCalled();
+      });
+
+      it("secondary Start Fresh CTA calls onStartFreshClaude, never onRestartClaude", async () => {
+        const { container, props } = renderRestart();
+
+        const btn = byTestId(container, "empty-state-start-fresh");
+        expect(btn?.textContent?.trim()).toBe("Start a fresh conversation");
+
+        btn?.click();
+        await tick();
+
+        expect(props.onStartFreshClaude).toHaveBeenCalledOnce();
+        expect(props.onRestartClaude).not.toHaveBeenCalled();
+      });
+
+      // #1268 defect 2b: "cancelling that confirm leaves the user with no
+      // exit from the empty state." The destructive confirm lives inside the
+      // wired `onStartFreshClaude` handler (out of this component's scope —
+      // a cancel there is a no-op prop call, same as any click), so the
+      // structural guarantee EmptyState owns is that the primary, safe
+      // Restart button is never removed or disabled as a side effect of the
+      // secondary action being present or clicked. Positive control: the
+      // primary button still fires its own handler afterwards.
+      it("the primary Restart button stays a working exit after the secondary CTA is clicked", async () => {
+        const { container, props } = renderRestart();
+
+        byTestId(container, "empty-state-start-fresh")?.click();
+        await tick();
+        expect(props.onStartFreshClaude).toHaveBeenCalledOnce();
+
+        const primary = byTestId(container, "empty-state-restart-claude");
+        expect(primary).toBeTruthy();
+        primary?.click();
+        await tick();
+        expect(props.onRestartClaude).toHaveBeenCalledOnce();
+      });
     });
   });
 

--- a/tests/client/StatusBar.svelte.test.ts
+++ b/tests/client/StatusBar.svelte.test.ts
@@ -52,6 +52,37 @@ describe("StatusBar AI action indicator", () => {
     expect(onRestartClaude).toHaveBeenCalledOnce();
   });
 
+  // #1268 defect 1: the "setup" chip (re-keyed off `lastError ===
+  // "circuit-open"` in the hook — see useAiReadiness's `AiChip` doc comment)
+  // used to announce "Set up Claude Code" via title/aria-label while the
+  // separate onclick ternary had silently lost that branch and fell through
+  // to onRestartClaude. Assert the announced label AND the invoked handler
+  // agree, with a positive control proving onRestartClaude is reachable at
+  // all (so a bug that made onclick always resolve to undefined wouldn't
+  // pass by both assertions vacuously succeeding).
+  it("renders Setup with a state-specific accessible name whose handler matches", async () => {
+    const onConnectAi = vi.fn();
+    const onRestartClaude = vi.fn();
+    const { getByTestId } = render(StatusBar, {
+      props: {
+        ...baseProps,
+        aiState: "stopped",
+        aiChip: "setup",
+        onConnectAi,
+        onRestartClaude,
+      },
+    });
+
+    const indicator = getByTestId("status-ai-indicator");
+    expect(indicator.getAttribute("aria-label")).toBe(
+      "Claude Code needs to be installed. Set up Claude Code.",
+    );
+    expect(indicator.getAttribute("data-ai-action")).toBe("setup");
+    await fireEvent.click(indicator);
+    expect(onConnectAi).toHaveBeenCalledOnce();
+    expect(onRestartClaude).not.toHaveBeenCalled();
+  });
+
   it("keeps a connected, non-actionable status as a labelled image", () => {
     const { getByTestId } = render(StatusBar, {
       props: { ...baseProps, aiLiveIndicator: "connected", aiState: "ready" },

--- a/tests/client/useAiReadiness.svelte.test.ts
+++ b/tests/client/useAiReadiness.svelte.test.ts
@@ -26,7 +26,8 @@
 import { render } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AiReadiness } from "../../src/client/hooks/useAiReadiness.svelte";
+import type { AiChip, AiReadiness } from "../../src/client/hooks/useAiReadiness.svelte";
+import { AI_CTA } from "../../src/client/hooks/useAiReadiness.svelte";
 import AiReadinessHarness from "../../src/client/svelte-harness/AiReadinessHarness.svelte";
 import { API_LAUNCHER_STATUS } from "../../src/shared/api-paths.js";
 
@@ -453,5 +454,42 @@ describe("createAiReadiness", () => {
       await settle();
       expect(h.get().liveIndicator).toBeNull();
     });
+  });
+});
+
+/**
+ * `AI_CTA` is the shared chip→call-to-action map consumed by StatusBar's
+ * indicator button and App's "no AI connected" toast. It exists because both
+ * surfaces independently reduced a THREE-member union with a binary
+ * `chip === "connect" ? … : …` ternary, and `setup` — the branch that fires
+ * when the Claude CLI isn't installed — fell through to the restart handler in
+ * both. Restarting is exactly the doomed spawn loop the circuit breaker tripped
+ * to stop, so the wrong branch is actively harmful, not merely mislabelled.
+ */
+describe("AI_CTA", () => {
+  const CHIPS: Exclude<AiChip, null>[] = ["connect", "setup", "restart"];
+
+  it("covers every non-null chip with non-empty copy", () => {
+    // Guards against a future union member landing with no entry: the type
+    // catches it at compile time, this catches a `{} as any` escape hatch.
+    expect(Object.keys(AI_CTA).sort()).toEqual([...CHIPS].sort());
+    for (const chip of CHIPS) {
+      expect(AI_CTA[chip].label).toBeTruthy();
+      expect(AI_CTA[chip].title).toBeTruthy();
+      expect(AI_CTA[chip].ariaLabel).toBeTruthy();
+    }
+  });
+
+  it("routes 'setup' to the connect flow, not restart", () => {
+    expect(AI_CTA.setup.action).toBe("connect");
+    expect(AI_CTA.setup.label).toBe("Set up Claude Code");
+  });
+
+  // Positive control for the assertion above — `restart` proves the `action`
+  // field can actually take the other value, so "not restart" is a real result
+  // rather than an artefact of a map that only ever says "connect".
+  it("routes 'connect' and 'restart' to their own flows", () => {
+    expect(AI_CTA.connect.action).toBe("connect");
+    expect(AI_CTA.restart.action).toBe("restart");
   });
 });

--- a/tests/client/useAiReadiness.svelte.test.ts
+++ b/tests/client/useAiReadiness.svelte.test.ts
@@ -117,6 +117,38 @@ describe("createAiReadiness", () => {
     await settle();
     expect(h.get().state).toBe("stopped");
     expect(h.get().chip).toBe("restart");
+    expect(h.get().lastError).toBeUndefined();
+  });
+
+  // #1268: `chip` is the single source of truth for the CTA views render —
+  // it must fold `lastError === "circuit-open"` into `"setup"` itself,
+  // rather than leaving each view to re-derive that from `lastError`
+  // (which is how StatusBar and EmptyState drifted out of sync). This is
+  // also the actual live path for an uninstalled Claude CLI — see the
+  // `AiChip` doc comment.
+  it("shows the setup chip (not restart) when the launcher's lastError is circuit-open", async () => {
+    globalThis.fetch = routedFetch({
+      launcher: mkResponse({ available: true, running: false, lastError: "circuit-open" }),
+      health: mkResponse({ status: "ok", hasSession: false }),
+    });
+    const h = mount();
+    await settle();
+    expect(h.get().state).toBe("stopped");
+    expect(h.get().lastError).toBe("circuit-open");
+    expect(h.get().chip).toBe("setup");
+  });
+
+  it("still shows the restart chip for other lastError values, e.g. binary-not-found", async () => {
+    // binary-not-found is the reaper-missing case, not a missing Claude CLI
+    // (see the AiChip doc comment) — it gets no special CTA.
+    globalThis.fetch = routedFetch({
+      launcher: mkResponse({ available: true, running: false, lastError: "binary-not-found" }),
+      health: mkResponse({ status: "ok", hasSession: false }),
+    });
+    const h = mount();
+    await settle();
+    expect(h.get().lastError).toBe("binary-not-found");
+    expect(h.get().chip).toBe("restart");
   });
 
   it("#1054: an active MCP session promotes a stopped launcher to ready (no restart chip)", async () => {

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -121,7 +121,10 @@ editor-stage
 empty-state-connect-ai
 empty-state-open-file
 empty-state-open-settings
+empty-state-restart-claude
 empty-state-retry
+empty-state-setup-claude
+empty-state-start-fresh
 error-boundary-recover-btn
 error-boundary-reload-btn
 external-conflict-banner


### PR DESCRIPTION
## Problem

When the Claude Code launcher failed, users saw generic error messages with no guidance on what to do — especially painful for non-technical users who didn't know whether to retry, reinstall, or give up.

## Changes

- **`src/client/actions/builtin.svelte.ts`**: Added `startFreshClaudeCode` action that clears the circuit breaker via `POST /api/launcher/start-fresh`
- **`src/client/App.svelte`**: Wired `startFreshClaudeCode` and `lastError` props through to child components
- **`src/client/components/EmptyState.svelte`**:
  - Shows "Set up Claude Code" CTA on first-time / never-launched state
  - Shows "Try Again" on transient errors
  - Shows actionable setup instructions when Claude Code is not found
- **`src/client/status/StatusBar.svelte`**: Mirrors the same solution-centric logic in the status bar

## UX Rationale

Non-technical users need to know *what to do*, not just *what went wrong*. The new UI distinguishes between:
- **Never launched**: Guide to setup
- **Transient error**: Offer retry with circuit-breaker reset
- **Missing binary**: Direct to installation docs

Closes #1266

## Testing

- Manual: verified all three error states render correctly with correct CTA labels
