### PR TITLE
chore(lint): drop eslint-plugin-react-hooks, dead since the Svelte migration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,4 @@
 import tseslint from "typescript-eslint";
-import reactHooks from "eslint-plugin-react-hooks";
 
 export default tseslint.config(
   // tests/tauri-driver is a standalone sub-package with its own WebdriverIO
@@ -24,13 +23,6 @@ export default tseslint.config(
   },
 
   ...tseslint.configs.recommended,
-
-  // React hooks rules for client code only
-  {
-    files: ["src/client/**/*.{ts,tsx}"],
-    plugins: { "react-hooks": reactHooks },
-    rules: { ...reactHooks.configs.recommended.rules },
-  },
 
   // `.cjs` is CommonJS by extension, so `require()` is the only import form
   // available there — the ESM-oriented rule cannot be satisfied, only disabled.

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
         "@types/update-notifier": "^6.0.8",
         "cross-env": "^10.1.0",
         "eslint": "^9.39.4",
-        "eslint-plugin-react-hooks": "^5.2.0",
         "happy-dom": "^20.9.0",
         "husky": "^9.1.7",
         "knip": "^5.66.0",
@@ -5059,17 +5058,6 @@
         "jiti": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
     "@types/update-notifier": "^6.0.8",
     "cross-env": "^10.1.0",
     "eslint": "^9.39.4",
-    "eslint-plugin-react-hooks": "^5.2.0",
     "happy-dom": "^20.9.0",
     "husky": "^9.1.7",
     "knip": "^5.66.0",


### PR DESCRIPTION
Unblocks the dependabot security bumps in #1272.

## Why it's blocked

#1272 bumps eslint to `^10.8.0` and `npm ci` fails with `ERESOLVE`: `eslint-plugin-react-hooks@5.2.0` declares a peer range that stops at eslint 9. Every other check on that PR passes; this one step is the whole failure.

## Why removing it is the fix rather than a workaround

v0.10.0 completed the React → Svelte 5 migration — all 39 `.tsx` files replaced, `react` / `react-dom` / `@tiptap/react` removed. This plugin and its `eslint.config.js` block were left behind. The block targets `src/client/**/*.{ts,tsx}` and applies `react-hooks/recommended`, and the repo now contains:

- 0 files matching `src/**/*.tsx`
- 0 imports from `react` anywhere in `src/`

So the rules have nothing to describe. The block isn't merely inert, either — its peer range is what pins eslint below 10 for the whole project.

## Verification

- `npm run lint` runs clean with the block removed (locally it reports pre-existing problems from gitignored `.remember/tmp` and `probe/svelte-spike/dist`, which a fresh CI checkout never sees — the same divergence the config's own ignore-list comment documents).
- `npm install --save-dev eslint@^10.8.0 --dry-run` resolves with no `ERESOLVE` once the plugin is gone. That is the direct test of the claim: with it present, the same command is what #1272's CI fails on.

After this merges, #1272 needs a rebase to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zvt9RXMCoNJbuA2Nj7i2R
