### PR TITLE
docs(release): close the two changelog gaps the v0.20.0 cut exposed

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -87,6 +87,24 @@ prevents them drifting.
    `changelog` skill sets `disable-model-invocation: true`, which makes it
    user-invocable only.
 
+   **Ask for it again AFTER the cut, over `v<prev>..v<new>`.** At v0.20.0 that
+   post-release run found a whole missing category that two dedicated review
+   agents had not: no `### Security` section, despite the release pinning
+   `@hono/node-server` past GHSA-frvp-7c67-39w9 in code that ships. A reviewer
+   pointed at the entries can only grade the entries that exist; nothing asks
+   which category is *absent*. Concretely, before calling the section done:
+   - Walk the merged-PR list (`git log v<prev>..HEAD --merges`), not only the
+     commit subjects — a fix can land with no issue number anywhere in its
+     subject and be invisible to a `#\d+` scan.
+   - Check every dependency bump against the repo's real Dependabot alert list
+     (`gh api repos/<owner>/<repo>/dependabot/alerts`). A bump next to a
+     security bump is not itself a security fix, and an automated update can
+     widen a peer range without moving the resolved version off the affected
+     one.
+   - When recording a security fix, state reachability honestly in both
+     directions — "bundled but we never call it" belongs in the entry, or the
+     note implies an exposure that did not exist.
+
 3. Verify the full test suite is green — `plugin-version-pin.test.ts` proves
    surfaces 1–4 agree (it also checks `plugin.json`'s pinned npx specs);
    `tests/plugin-manifest.test.ts` additionally fails if `package.json` and
@@ -116,6 +134,14 @@ prevents them drifting.
    GitHub Release (`releaseDraft: true`) with artifacts + `latest.json`. The
    tag alone does NOT publish to npm. (`HUSKY=0` on the tag push is fine — the
    commit is already CI-green.)
+
+5b. Populate the GitHub release body from the `## [<version>]` changelog
+   section — `tauri-action` writes only "See the assets to download and install
+   Tandem." Extract the section between its heading and the previous version's
+   and pass it via `gh release edit v<version> --notes-file <file>`. Do this
+   before publishing where possible. Inconsistent historically (v0.18.0 had
+   full notes; v0.17.0 and v0.19.0 shipped with the boilerplate), so it needs
+   to be a step rather than a habit.
 
 6. Wait for every matrix build and `release-check` to go green, then publish
    the draft:


### PR DESCRIPTION
Follow-up to #1278. Both gaps were found by running `/changelog` as a **post-release** cross-check — after two dedicated review agents (accuracy vs. the diff, voice/honesty) had already passed the section.

## 1. Ask for `/changelog` after the cut, not only before

v0.20.0 shipped with no `### Security` section despite pinning `@hono/node-server` past GHSA-frvp-7c67-39w9 in code that ships (`hono` appears 31× in `dist/server/index.js`).

The structural reason is worth writing down: **a reviewer pointed at the entries can only grade the entries that exist.** Nothing in that framing asks which category is *absent*. So the step now carries three concrete checks:

- Walk the merged-PR list (`git log v<prev>..HEAD --merges`), not only commit subjects — a fix can land with no issue number anywhere in its subject and be invisible to a `#\d+` scan. That is exactly how the Cowork report-link fix (#1241) was nearly missed too.
- Check dependency bumps against the repo's real Dependabot alert list. An automated update can widen a peer range without moving the resolved version off the affected one — which is precisely what happened here. And a bump sitting next to a security bump is not itself a security fix: `brace-expansion` 5.0.7 → 5.0.8 clears nothing, since every known advisory is patched at ≤ 5.0.6.
- State reachability in both directions. "Bundled but we never call it" belongs in the entry, or the note implies an exposure that never existed.

## 2. Populate the GitHub release body

`tauri-action` writes only `See the assets to download and install Tandem.` — so a published release page can carry no notes at all, which is how v0.20.0 went out. Historically inconsistent (v0.18.0 had full notes; v0.17.0 and v0.19.0 did not), so it becomes step 5b rather than something remembered. v0.20.0's body has since been populated from the corrected changelog.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zvt9RXMCoNJbuA2Nj7i2R