### PR TITLE
docs(roadmap): record first real-hardware macOS Gatekeeper pass

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -569,6 +569,17 @@ The wave-structure table (top of "Active — Toward v1.0") owns wave numbering a
 - Ubuntu 22.04 LTS (.AppImage + .deb)
 - Fedora 39 (.rpm)
 
+*Partial evidence as of v0.20.0 (2026-08-05):* one real-hardware macOS pass —
+browser-downloaded `.dmg` (so quarantine was set), installed and launched with
+**no Gatekeeper dialog at all**. That is the first hardware confirmation the
+notarization ticket is honored in the wild, and the residual #428 was closed
+with. It does **not** tick a row above: the machine was a MacBook Air of
+unrecorded OS version and architecture, so neither the "macOS 14 (Intel + Apple
+Silicon)" nor the "macOS 26.1 M1" row is satisfied. It de-risks them rather
+than closing them. Linux `.deb`/`.rpm` install-and-load is separately automated
+per tag (containers, `linux-package-smoke.sh`); everything else here is still
+unobserved.
+
 **Functional gates:**
 - Claude Code CLI: loopback-exempt, zero-config, tools work unchanged
 - Tauri update flow: download → install → restart verified on all three platforms; sidecar restart succeeds; no data loss


### PR DESCRIPTION
## What

One paragraph under the v1.0.0 install-matrix criteria in `docs/roadmap.md`,
recording the first real-hardware macOS verification this project has had.

## Why

Bryan installed and ran v0.20.0 on a Mac on 2026-08-05. Two smoke-checklist
rows that had been recorded as hardware-gated and unverified are now observed:
the `.dmg` came from a **browser** download (so `com.apple.quarantine` was set
and Gatekeeper genuinely engaged), and the app launched with **no dialog at
all** — not "unidentified developer", not "damaged", no right-click to Open.

The download method is the load-bearing detail. A `curl`-ed or locally built
`.dmg` carries no quarantine attribute, Gatekeeper never engages, and a clean
launch would prove nothing.

Wave 5 and the install matrix both read as though no macOS hardware evidence
exists. That understates what is known and overstates how much Wave 5 has to
discover from scratch, so it belongs in the roadmap rather than only in the
release record.

## What this deliberately does not claim

It does not tick a matrix row. The OS version and architecture were not
captured and the machine is no longer to hand, so neither "macOS 14 (Intel +
Apple Silicon)" nor "macOS 26.1 M1" is satisfied — the note says so explicitly.
It de-risks those rows; it does not close them.

The updater row is also untouched and called out as such in the release record:
this was an *install*, not an *update*, so `v0.19.0 → v0.20.0` remains
unexercised on every platform.

## Also updated (outside this diff)

- The v0.20.0 smoke record on #1276 — amended with a follow-up comment rather
  than an edit, so the original claim and its correction both stay readable.
- Project memory, which carried the same "hardware-gated, still unverified"
  line.
