### PR TITLE
docs(roadmap): record macOS in-app updater pass on real hardware

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -569,20 +569,31 @@ The wave-structure table (top of "Active — Toward v1.0") owns wave numbering a
 - Ubuntu 22.04 LTS (.AppImage + .deb)
 - Fedora 39 (.rpm)
 
-*Partial evidence as of v0.20.0 (2026-08-05):* one real-hardware macOS pass —
-browser-downloaded `.dmg` (so quarantine was set), installed and launched with
-**no Gatekeeper dialog at all**. That is the first hardware confirmation the
-notarization ticket is honored in the wild, and the residual #428 was closed
-with. It does **not** tick a row above: the machine was a MacBook Air of
-unrecorded OS version and architecture, so neither the "macOS 14 (Intel + Apple
-Silicon)" nor the "macOS 26.1 M1" row is satisfied. It de-risks them rather
-than closing them. Linux `.deb`/`.rpm` install-and-load is separately automated
-per tag (containers, `linux-package-smoke.sh`); everything else here is still
-unobserved.
+*Partial evidence as of v0.20.0 (2026-08-05).* Two independent real-hardware
+macOS observations — the first this project has had. Treat them as separate
+data points, not one machine's story; nothing establishes they were the same
+Mac.
+
+1. **Gatekeeper.** A browser-downloaded `.dmg` (so `com.apple.quarantine` was
+   set and Gatekeeper genuinely engaged) installed and launched with **no
+   dialog at all**. First hardware confirmation that the notarization ticket is
+   honored in the wild, and the residual #428 was closed with.
+2. **Updater, `v0.19.0 → v0.20.0`.** The in-app path, not a reinstall:
+   titlebar update dot → install → restart → and a document opened and edited
+   afterward. That last clause is the load-bearing one — the sidecar is killed
+   and respawned across `app.restart()`, and a dead one still shows the new
+   version in About while the editor sits inert.
+
+Neither ticks a row above. Both machines' OS versions and CPU architectures
+went unrecorded, so neither "macOS 14 (Intel + Apple Silicon)" nor "macOS 26.1
+M1" is satisfied; this de-risks those rows rather than closing them. Linux
+`.deb`/`.rpm` install-and-load is separately automated per tag (containers,
+`linux-package-smoke.sh`). Everything else here — all of Windows, macOS file
+associations, orphaned-sidecar-after-quit, the AppImage — is still unobserved.
 
 **Functional gates:**
 - Claude Code CLI: loopback-exempt, zero-config, tools work unchanged
-- Tauri update flow: download → install → restart verified on all three platforms; sidecar restart succeeds; no data loss
+- Tauri update flow: download → install → restart verified on all three platforms; sidecar restart succeeds; no data loss — **macOS observed 2026-08-05** (`v0.19.0 → v0.20.0`, in-app update dot, document editable after restart, so the sidecar respawn held); Windows and Linux still unobserved
 - Tutorial: completes end-to-end on `sample/welcome.md`; tutorial annotation anchors hold (anchor-drift regression test)
 - Dark/light toggle: works in both desktop and browser
 - ~~Multi-provider models registry (D4): user can add/remove/edit Anthropic + #477 local + at least one third-party provider~~ **Replaced per D4 amendment (2026-06-11):** first-run wizard one-click Claude Code connect works on all three platforms (detect → connect → `/mcp` shows Tandem tools); **cloud** BYO-models surfaces remain hidden until v1.1 (local surfaces re-enable in v0.17.0 per #1123 M4); **and** the keychain secrets layer (shipped v0.13.0, still holding live v0.13.x user keys) passes a store→read round-trip against the real OS keychain (Windows Credential Manager + macOS Keychain) on the smoke-checklist machines — CI cannot cover this (no libsecret/keychain in runners), and the struck criterion was previously the only release-time check that touched it


### PR DESCRIPTION
## What

Two edits to `docs/roadmap.md`: the v1.0 install-matrix evidence note now
records the macOS **in-app updater** pass alongside the Gatekeeper one, and the
"Tauri update flow" functional gate is annotated with what has actually been
observed on which platform.

## Why

The updater was the highest-risk unobserved row in the whole smoke checklist —
every existing install takes that path, and CI cannot reach any of it. The
Ed25519 signature check against a real `latest.json`, `kill_sidecar()` before
`app.restart()`, and the port-release poll only run against a genuinely
previously-installed app.

Confirmed 2026-08-05 for `v0.19.0 → v0.20.0`: titlebar update dot → install →
restart → **document opened and edited afterward**.

## The detail that makes it a pass

The post-restart edit is load-bearing, not a nicety. The sidecar is killed and
respawned across `app.restart()`; one that fails to come back still leaves the
new version showing in About while the editor sits inert. Editing a document is
what proves the respawn actually held. A record that stopped at "About shows
0.20.0" would be a version-number sighting, not a verified update.

## What this deliberately does not claim

- **No install-matrix row is ticked.** Neither observation captured an OS
  version or CPU architecture, so neither "macOS 14 (Intel + Apple Silicon)"
  nor "macOS 26.1 M1" is satisfied. The note says so explicitly — this de-risks
  those rows rather than closing them.
- **Two data points, not one machine's story.** The Gatekeeper observation was
  Bryan's own; the updater result was reported to him. Nothing establishes they
  were the same Mac, so the note keeps them separate rather than assembling a
  tidier narrative than the evidence supports.
- **Windows and Linux updater flows remain unobserved.** The functional-gate
  line names macOS specifically rather than softening to "verified".

## Also updated (outside this diff)

The v0.20.0 smoke record on #1276, as a second amendment comment — so the
original "unverified", Amendment 1, and this all stay readable in sequence
instead of the earlier claims being quietly overwritten.
