### PR TITLE
fix(launcher): fall back when a derived cwd is outside the home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Restart Claude Code" no longer fails right after you install or update Tandem (#1282).** The button reported *"cwd must be an absolute path inside the user's home directory"* and restarted nothing. It restarts your AI in the folder of whatever document you have open, and Tandem opens two documents on your behalf — the changelog after an update, and the welcome document on a fresh install — both of which live inside the application itself rather than in your own files. Restarting there isn't allowed, so the request was refused outright. That made the failure specific to the two moments every desktop user passes through, which are exactly the moments someone is most likely to reach for a button labelled "Restart Claude Code". The folder is now treated as a preference rather than a requirement: if it can't be used, Tandem restarts in your configured working directory instead and the notification tells you where it landed. The same thing happened for a document on an external drive, on a network share, or in a folder that had since been deleted, and those are fixed by the same change. The command-palette version still refuses, because "Relaunch Claude in this folder" has no meaning without a usable folder. Present since the launcher shipped, not new in v0.20.0 — the recovery buttons added in that release are what made it easy to hit.
+
 ## [0.20.0] - 2026-08-05
 
 ### Added

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -19,7 +19,11 @@ import {
   API_SAVE,
   API_SCRATCHPAD,
 } from "../../shared/api-paths.js";
-import { isTransientlyUnavailable, type LauncherStatus } from "../../shared/launcher/contract.js";
+import {
+  isTransientlyUnavailable,
+  LAUNCHER_ERROR_PATH_REJECTED,
+  type LauncherStatus,
+} from "../../shared/launcher/contract.js";
 import { resolveDefaultDirectory } from "../utils/default-directory.js";
 import { API_BASE } from "../utils/fileUpload.js";
 import { addRecentFile, loadRecentFiles, saveRecentFiles } from "../utils/recentFiles.js";
@@ -587,7 +591,12 @@ function deriveCwdFromDocPath(docPath: string | null): string | null {
  * POST to the endpoint, notify on success/failure. Diverges on the
  * preflight (status check, cwd derivation, confirm prompt) — that lives
  * in each caller. The `extraBody` carries action-specific fields (cwd
- * for relaunch; nothing for start-fresh). */
+ * for relaunch; nothing for start-fresh).
+ *
+ * Returns the server's error `code` when it matches `opts.retryOnCode`, having
+ * deliberately NOT notified — that combination means "the caller asked to
+ * handle this failure itself", and a toast here would fire before the caller's
+ * recovery attempt. Every other outcome notifies and returns null. */
 async function postLauncherMutation(
   d: ActionDeps,
   endpoint: string,
@@ -600,14 +609,15 @@ async function postLauncherMutation(
      * response. A malformed body reaches it as `{}`, never as a throw. */
     successMessage: string | ((body: Record<string, unknown>) => string);
   },
-): Promise<void> {
+  opts: { retryOnCode?: string } = {},
+): Promise<string | null> {
   const nonceResult = await fetchLauncherNonce();
   if (!nonceResult.ok) {
     d.notify(
       "error",
       `Failed to acquire launcher nonce: ${nonceResult.kind}${nonceResult.detail ? ` (${nonceResult.detail})` : ""}.`,
     );
-    return;
+    return null;
   }
   const nonce = nonceResult.value;
   try {
@@ -617,9 +627,12 @@ async function postLauncherMutation(
       body: JSON.stringify({ ...extraBody, nonce }),
     });
     if (!res.ok) {
-      const body = (await res.json().catch(() => ({}))) as { message?: string };
+      const body = (await res.json().catch(() => ({}))) as { message?: string; code?: string };
+      if (opts.retryOnCode !== undefined && body.code === opts.retryOnCode) {
+        return body.code;
+      }
       d.notify("error", `${labels.failPrefix}: ${body.message ?? res.statusText}`);
-      return;
+      return null;
     }
     if (typeof labels.successMessage === "string") {
       d.notify("info", labels.successMessage);
@@ -630,6 +643,7 @@ async function postLauncherMutation(
   } catch (err) {
     d.notify("error", `${labels.requestFailPrefix}: ${err instanceof Error ? err.message : err}`);
   }
+  return null;
 }
 
 /** Guards that both palette actions share: in-flight check + availability
@@ -711,20 +725,44 @@ async function relaunchHere(
   }
   // The confirm has to branch with the body: without a cwd there is no folder
   // to name, and naming one anyway would be a promise the request doesn't make.
+  // On the fallback-allowed path the folder is a preference, not a guarantee,
+  // so the prompt says so rather than promising a destination the retry below
+  // may override.
   const prompt = cwd
-    ? `Restart Claude in:\n${cwd}\n\nYour current task may be interrupted.`
+    ? cwdRequired
+      ? `Restart Claude in:\n${cwd}\n\nYour current task may be interrupted.`
+      : `Restart Claude in:\n${cwd}\n\nIf that folder isn't usable, Claude restarts in its configured directory instead.\n\nYour current task may be interrupted.`
     : "Restart Claude in its configured working directory.\n\nYour current task may be interrupted.";
   if (!confirm(prompt)) return;
+  const labels = {
+    failPrefix: "Relaunch failed",
+    requestFailPrefix: "Relaunch request failed",
+    // The server answers with where the respawn actually landed, which is
+    // the only source for that when we didn't send one.
+    successMessage: (body: Record<string, unknown>) =>
+      typeof body?.cwd === "string" ? `Claude restarting in ${body.cwd}.` : "Claude restarting.",
+  };
   launcherInflight = true;
   try {
-    await postLauncherMutation(d, API_LAUNCHER_RELAUNCH, cwd ? { cwd } : {}, {
-      failPrefix: "Relaunch failed",
-      requestFailPrefix: "Relaunch request failed",
-      // The server answers with where the respawn actually landed, which is
-      // the only source for that when we didn't send one.
-      successMessage: (body) =>
-        typeof body?.cwd === "string" ? `Claude restarting in ${body.cwd}.` : "Claude restarting.",
-    });
+    // A derived cwd is a guess: it is `dirname` of whatever tab happens to be
+    // active, and the server home-confines it (`resolveRouteCwd`). Tandem
+    // itself auto-opens CHANGELOG.md after an upgrade and sample/welcome.md on
+    // first run, both from inside the app bundle — so on the two states every
+    // desktop user passes through, the guess is guaranteed to be rejected. A
+    // doc on an external drive, a network share, or in a since-deleted folder
+    // rejects the same way. None of that should sink a recovery action whose
+    // caller already said the cwd is optional, so re-send without it.
+    const rejected =
+      cwd && !cwdRequired
+        ? await postLauncherMutation(d, API_LAUNCHER_RELAUNCH, { cwd }, labels, {
+            retryOnCode: LAUNCHER_ERROR_PATH_REJECTED,
+          })
+        : await postLauncherMutation(d, API_LAUNCHER_RELAUNCH, cwd ? { cwd } : {}, labels);
+    // Fresh nonce, not a replay: the server rotates it on every attempt,
+    // including the rejected one. `postLauncherMutation` acquires its own.
+    if (rejected !== null) {
+      await postLauncherMutation(d, API_LAUNCHER_RELAUNCH, {}, labels);
+    }
   } finally {
     launcherInflight = false;
   }

--- a/tests/client/actions/launcher-commands.test.ts
+++ b/tests/client/actions/launcher-commands.test.ts
@@ -57,9 +57,11 @@ function jsonResponse(status: number, body: unknown): Response {
  * `available` toggles whether the launcher reports as usable; defaults to a
  * running, available launcher so the happy path proceeds to the POST.
  */
-function installFetchStub(opts: { available?: boolean } = {}): ReturnType<typeof vi.fn> {
+function installFetchStub(
+  opts: { available?: boolean; rejectCwd?: boolean } = {},
+): ReturnType<typeof vi.fn> {
   const available = opts.available ?? true;
-  const fetchSpy = vi.fn(async (url: RequestInfo | URL, _init?: RequestInit) => {
+  const fetchSpy = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
     const u = String(url);
     if (u === STATUS_URL) {
       return available
@@ -76,7 +78,21 @@ function installFetchStub(opts: { available?: boolean } = {}): ReturnType<typeof
       return jsonResponse(200, { nonce: TEST_NONCE });
     }
     if (u === RELAUNCH_URL || u === START_FRESH_URL) {
-      return jsonResponse(200, { ok: true });
+      // Mirrors the server: `resolveRouteCwd` home-confines, so ANY cwd this
+      // stub is handed is rejected, while an omitted one is accepted. That is
+      // the real shape of the bug — the rejection is a property of the path,
+      // not of the request being malformed.
+      if (opts.rejectCwd && u === RELAUNCH_URL) {
+        const body = JSON.parse((init?.body as string) ?? "{}") as { cwd?: unknown };
+        if (body.cwd !== undefined) {
+          return jsonResponse(400, {
+            error: "BAD_REQUEST",
+            code: "PATH_REJECTED",
+            message: "cwd must be an absolute path inside the user's home directory",
+          });
+        }
+      }
+      return jsonResponse(200, { ok: true, cwd: "/home/user/configured" });
     }
     throw new Error(`unexpected fetch to ${u}`);
   });
@@ -112,9 +128,17 @@ beforeEach(() => {
     vi.fn(() => true),
   );
   // Active document lives in a real folder so relaunch can derive a cwd.
+  wireDeps("/home/user/project/notes.md");
+});
+
+/** Rewire the dependency bag with a different active-document path. Only that
+ * path varies across these tests, and it is what `deriveCwdFromDocPath` reads
+ * to build the cwd — so it is the one knob worth parameterizing. `null` models
+ * the empty state: no tab, hence no derivable cwd. */
+function wireDeps(activeDocumentPath: string | null): void {
   wireActionDeps({
-    getActiveTabId: () => "doc-1",
-    getActiveDocumentPath: () => "/home/user/project/notes.md",
+    getActiveTabId: () => (activeDocumentPath ? "doc-1" : null),
+    getActiveDocumentPath: () => activeDocumentPath,
     notify,
     openSettings: vi.fn(),
     toggleSoloMode: vi.fn(),
@@ -134,7 +158,7 @@ beforeEach(() => {
     selectBlock: vi.fn(),
     toggleAuthorship: vi.fn(),
   });
-});
+}
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -215,32 +239,6 @@ describe("launcher-start-fresh", () => {
  * safe recovery unreachable while the session-destroying secondary kept working.
  */
 describe("AI-chip relaunch vs. palette relaunch", () => {
-  /** Re-wire deps with a different active-document answer. */
-  function wireWithDocPath(docPath: string | null): void {
-    wireActionDeps({
-      getActiveTabId: () => (docPath ? "doc-1" : null),
-      getActiveDocumentPath: () => docPath,
-      notify,
-      openSettings: vi.fn(),
-      toggleSoloMode: vi.fn(),
-      openFindBar: vi.fn(),
-      openFindBarTabs: vi.fn(),
-      findNext: vi.fn(),
-      findPrev: vi.fn(),
-      closeActiveTab: vi.fn(),
-      openFileDialog: vi.fn(),
-      toggleLeftPanel: vi.fn(),
-      toggleRightPanel: vi.fn(),
-      reopenClosedTab: vi.fn(),
-      annotationNext: vi.fn(),
-      annotationPrev: vi.fn(),
-      annotationAccept: vi.fn(),
-      annotationDismiss: vi.fn(),
-      selectBlock: vi.fn(),
-      toggleAuthorship: vi.fn(),
-    });
-  }
-
   async function drive(fn: () => void, fetchSpy: ReturnType<typeof vi.fn>): Promise<void> {
     fn();
     await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(STATUS_URL));
@@ -251,7 +249,7 @@ describe("AI-chip relaunch vs. palette relaunch", () => {
   it("POSTs with no cwd when no document is open (the empty-state case)", async () => {
     // Against the pre-change code this test fails at the POST assertion: the
     // `if (!cwd)` guard fired and the request was never made at all.
-    wireWithDocPath(null);
+    wireDeps(null);
     const fetchSpy = installFetchStub();
     await drive(relaunchClaudeCode, fetchSpy);
 
@@ -267,7 +265,7 @@ describe("AI-chip relaunch vs. palette relaunch", () => {
     // addressed-AI toast share this entry point and are NOT gated on having a
     // tab — switching them all to the no-cwd form would silently move Claude's
     // project root for every user it already worked for.
-    wireWithDocPath("/home/user/project/notes.md");
+    wireDeps("/home/user/project/notes.md");
     const fetchSpy = installFetchStub();
     await drive(relaunchClaudeCode, fetchSpy);
 
@@ -281,7 +279,7 @@ describe("AI-chip relaunch vs. palette relaunch", () => {
     // "Relaunch Claude in this folder" has no folder to name here, so refusing
     // and saying why is right. This is what keeps the change from reading as
     // "the cwd requirement was dropped everywhere".
-    wireWithDocPath(null);
+    wireDeps(null);
     const fetchSpy = installFetchStub();
     await drive(() => getAction("launcher-relaunch-here").run(), fetchSpy);
 
@@ -299,7 +297,7 @@ describe("AI-chip relaunch vs. palette relaunch", () => {
     // including a "Restart Claude anyway" shown to someone who has just been
     // told to install software they believe they already have. A second click
     // landing on complete silence reads as a broken button.
-    wireWithDocPath(null);
+    wireDeps(null);
     let releaseRelaunch: (() => void) | undefined;
     const fetchSpy = vi.fn(async (url: RequestInfo | URL) => {
       const u = String(url);
@@ -346,7 +344,7 @@ describe("AI-chip relaunch vs. palette relaunch", () => {
   it("names the folder the server reports when it sent none", async () => {
     // The success toast is the only place a user learns where Claude landed
     // after a no-cwd restart; the server echoes it back from live state.
-    wireWithDocPath(null);
+    wireDeps(null);
     const fetchSpy = vi.fn(async (url: RequestInfo | URL) => {
       const u = String(url);
       if (u === STATUS_URL) {
@@ -366,5 +364,92 @@ describe("AI-chip relaunch vs. palette relaunch", () => {
     await drive(relaunchClaudeCode, fetchSpy);
 
     expect(notify).toHaveBeenCalledWith("info", "Claude restarting in /home/user/configured.");
+  });
+});
+
+/**
+ * A derived cwd the server refuses.
+ *
+ * `deriveCwdFromDocPath` is `dirname` of whatever tab is active — a guess, and
+ * the server home-confines it via `resolveRouteCwd`. Tandem itself auto-opens
+ * CHANGELOG.md after an upgrade and sample/welcome.md on first run, both from
+ * inside the app bundle, so on the two states EVERY desktop user passes through
+ * the guess is guaranteed to be rejected. A real macOS tester hit exactly this
+ * on v0.20.0 with CHANGELOG.md open: the 400 landed before any relaunch, so the
+ * recovery button reported failure and did nothing.
+ *
+ * The bug predates v0.20.0 — `cwdRequired: false` only ever forgave a *null*
+ * cwd, never a present-but-rejected one. External drives, network shares and
+ * since-deleted folders reject identically, so this covers a class rather than
+ * the two bundled documents.
+ */
+describe("relaunch with a server-rejected cwd", () => {
+  const BUNDLE_DOC = "/Applications/Tandem.app/Contents/Resources/CHANGELOG.md";
+  const BUNDLE_DIR = "/Applications/Tandem.app/Contents/Resources";
+
+  async function drive(fn: () => void, fetchSpy: ReturnType<typeof vi.fn>): Promise<void> {
+    fn();
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(STATUS_URL));
+    for (let i = 0; i < 6; i++) await new Promise((r) => setTimeout(r, 0));
+  }
+
+  function relaunchPosts(fetchSpy: ReturnType<typeof vi.fn>): Record<string, unknown>[] {
+    return fetchSpy.mock.calls
+      .filter(([url]) => String(url) === RELAUNCH_URL)
+      .map(([, init]) => JSON.parse((init as RequestInit)?.body as string));
+  }
+
+  it("chip path retries without the cwd and succeeds", async () => {
+    wireDeps(BUNDLE_DOC);
+    const fetchSpy = installFetchStub({ rejectCwd: true });
+    await drive(relaunchClaudeCode, fetchSpy);
+
+    const posts = relaunchPosts(fetchSpy);
+    expect(posts, "should have attempted, been rejected, then retried").toHaveLength(2);
+    // First attempt carries the bundle folder — we still PREFER the document's
+    // directory; the retry is a fallback, not a replacement.
+    expect(posts[0]).toEqual({ cwd: BUNDLE_DIR, nonce: TEST_NONCE });
+    // Retry drops cwd entirely rather than substituting a guess of its own.
+    expect(posts[1]).toEqual({ nonce: TEST_NONCE });
+    expect(posts[1].cwd).toBeUndefined();
+  });
+
+  it("chip path reports success, not the rejection, to the user", async () => {
+    // The rejection is an implementation detail of a recovery that worked.
+    // Surfacing it too would be the bug's symptom with extra steps.
+    wireDeps(BUNDLE_DOC);
+    const fetchSpy = installFetchStub({ rejectCwd: true });
+    await drive(relaunchClaudeCode, fetchSpy);
+
+    expect(notify).toHaveBeenCalledWith("info", "Claude restarting in /home/user/configured.");
+    expect(notify).not.toHaveBeenCalledWith("error", expect.stringContaining("Relaunch failed"));
+  });
+
+  it("palette command surfaces the rejection and does NOT retry", async () => {
+    // "Relaunch Claude in this folder" named a folder in its confirm prompt.
+    // Silently restarting somewhere else would make that prompt a lie, and it
+    // is also the security-review ask: the strict path must not inherit the
+    // fallback, or a genuine client bug fails open instead of loud.
+    wireDeps(BUNDLE_DOC);
+    const fetchSpy = installFetchStub({ rejectCwd: true });
+    await drive(() => getAction("launcher-relaunch-here").run(), fetchSpy);
+
+    expect(relaunchPosts(fetchSpy)).toHaveLength(1);
+    expect(notify).toHaveBeenCalledWith(
+      "error",
+      expect.stringContaining("must be an absolute path inside"),
+    );
+  });
+
+  it("a cwd the server accepts is never retried", async () => {
+    // Negative control. Without this, the two tests above would still pass if
+    // the retry fired unconditionally on every relaunch.
+    wireDeps("/home/user/project/notes.md");
+    const fetchSpy = installFetchStub();
+    await drive(relaunchClaudeCode, fetchSpy);
+
+    const posts = relaunchPosts(fetchSpy);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toEqual({ cwd: "/home/user/project", nonce: TEST_NONCE });
   });
 });


### PR DESCRIPTION
Closes #1282.

## The bug

**Restart Claude Code** reported *"cwd must be an absolute path inside the
user's home directory"* and restarted nothing. Reported on macOS against
v0.20.0 by a tester who had just updated, with `CHANGELOG.md` open.

The cwd is `dirname()` of the active document
(`deriveCwdFromDocPath`, `builtin.svelte.ts:577`), and the server home-confines
it (`resolveRouteCwd`, `supervisor.ts:1159`), returning 400 `PATH_REJECTED`
before any relaunch is attempted.

Both documents Tandem opens **on the user's behalf** live inside the app
bundle — `CHANGELOG.md` after an upgrade (`index.ts:594`), `sample/welcome.md`
on a fresh install (`index.ts:618`), both resolved from a `projectRoot` derived
from `import.meta.url` (`index.ts:584`). So the 400 fires in the two states
every desktop user passes through, which are the two states in which someone is
most likely to press a button labelled "Restart Claude Code".

## The actual gap

`cwdRequired: false` forgave a **null** cwd but never a present-but-*rejected*
one. That's why the empty-state case has always worked while having a document
open did not — the two look like the same path and aren't.

## Fix

`postLauncherMutation` takes an optional `retryOnCode`. When the 400 carries
that code it returns the code **without notifying**, so the caller can recover
before any toast fires. `relaunchHere` uses it on the `cwdRequired: false` path
only, then re-sends with no cwd. The retry acquires its own nonce — the server
rotates it on every attempt, including the rejected one.

**No server change.** Home-confinement still runs unconditionally on every
candidate.

## Scope: a class, not two files

All of these produced the identical `PATH_REJECTED` with no fallback, and all
are fixed by the same change:

| Case | Rejected by |
|---|---|
| Bundled `CHANGELOG.md` / `welcome.md` | outside home |
| Document on an external drive | outside home |
| Document in `/tmp` | outside home |
| Document on a UNC network share | `resolveSafeCwd` rejects UNC outright |
| Folder deleted after the doc was opened | `realpathSync` throws |

## What deliberately did not change

- **The palette command still refuses.** Its confirm names a folder; silently
  restarting somewhere else would make that prompt a lie. A test asserts the
  strict path never retries — otherwise a future client bug would fail *open*
  instead of loud.
- **A usable cwd is still preferred.** The retry is a fallback, not a
  replacement; a document in your project still restarts Claude in your project.
- **`POST /working-directory` is untouched.** It shares `validateCwdString` but
  *persists* its value, where discarding a bad path as "unset" is a different
  risk profile entirely.
- The confirm on the fallback path now says the folder is a preference rather
  than promising a destination the retry may override.

## Review

Two agents reviewed the approach before any code was written.

**Security review — neutral.** The fallback is byte-identical to the code path
an *omitted* `cwd` already takes, so nothing reaches a directory it could not
reach before; the attacker's path is discarded, never passed through. It also
raised the `POST /working-directory` containment point and the "strict path must
not inherit the fallback" test, both of which are in this PR.

**Altitude review** rejected my original proposal. I had planned a server-side
body flag; it pointed out `LAUNCHER_ERROR_PATH_REJECTED` is already a shared
contract constant already consumed client-side, making a client-only fix cover
the same class with a smaller blast radius — and leave the 400 visible in logs
rather than swallowing it. It also established the class table above, which my
narrower framing would have missed.

## Verification

- Full suite: **5672 passed**, 399 files, exit 0.
- Changelog round-trip (`markdown-escaping.test.ts`): 37 passed — run
  specifically because the changelog edit came after the suite.
- `npm run typecheck`: clean.
- **Negative control:** the two new chip tests were run against the unfixed
  source by stashing the change. Both fail without it and pass with it. The
  palette test and the no-op control pass either way, which is correct — they
  assert unchanged behavior.

The client suite had only ever mocked `200` responses, so this failure branch
had no coverage at all. The server tested `PATH_REJECTED` with a synthetic path;
the two halves were never tested together.

## Not a v0.20.0 regression

`deriveCwdFromDocPath` and `resolveRouteCwd` are both present at the `v0.19.0`
tag; the derivation dates to the launcher UI in #477 PR 4b. What v0.20.0 changed
(#1268/#1274) is how prominent the recovery CTAs are, which is why it surfaced
now. Slated for a v0.20.1 patch.
