### PR TITLE
chore(release): v0.20.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Edit and iterate on documents with any MCP-capable AI. Claude is the default and best-supported client today.",
   "author": {
     "name": "Tandem"
@@ -11,14 +11,14 @@
   "mcpServers": {
     "tandem": {
       "command": "npx",
-      "args": ["-y", "tandem-editor@0.20.0", "mcp-stdio"],
+      "args": ["-y", "tandem-editor@0.20.1", "mcp-stdio"],
       "env": {
         "TANDEM_URL": "http://127.0.0.1:3479"
       }
     },
     "tandem-channel": {
       "command": "npx",
-      "args": ["-y", "tandem-editor@0.20.0", "channel"],
+      "args": ["-y", "tandem-editor@0.20.1", "channel"],
       "env": {
         "TANDEM_URL": "http://127.0.0.1:3479"
       }
@@ -28,7 +28,7 @@
     "monitors": [
       {
         "name": "tandem-events",
-        "command": "npx -y tandem-editor@0.20.0 monitor",
+        "command": "npx -y tandem-editor@0.20.1 monitor",
         "description": "Tandem real-time document events (annotations, chat, selections)"
       }
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1] - 2026-08-05
+
 ### Fixed
 
 - **"Restart Claude Code" no longer fails right after you install or update Tandem (#1282).** The button reported *"cwd must be an absolute path inside the user's home directory"* and restarted nothing. It restarts your AI in the folder of whatever document you have open, and Tandem opens two documents on your behalf — the changelog after an update, and the welcome document on a fresh install — both of which live inside the application itself rather than in your own files. Restarting there isn't allowed, so the request was refused outright. That made the failure specific to the two moments every desktop user passes through, which are exactly the moments someone is most likely to reach for a button labelled "Restart Claude Code". The folder is now treated as a preference rather than a requirement: if it can't be used, Tandem restarts in your configured working directory instead and the notification tells you where it landed. The same thing happened for a document on an external drive, on a network share, or in a folder that had since been deleted, and those are fixed by the same change. The command-palette version still refuses, because "Relaunch Claude in this folder" has no meaning without a usable folder. Present since the launcher shipped, not new in v0.20.0 — the recovery buttons added in that release are what made it easy to hit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-editor",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-editor",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "BUSL-1.1",
       "dependencies": {
         "@hocuspocus/provider": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Edit and iterate on documents with any MCP-capable AI (Claude by default). Real-time push via the channel shim.",
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-desktop"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "base64 0.22.1",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-desktop"
-version = "0.20.0"
+version = "0.20.1"
 description = "Collaborative AI-human document editor"
 authors = ["Bryan Kolb"]
 license = "BUSL-1.1"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "identifier": "com.tandem.editor",
   "build": {
     "frontendDist": "../dist/client",


### PR DESCRIPTION
Patch release for #1282 (fix merged in #1283).

## Why a patch rather than waiting for v0.21.0

The **Restart Claude Code** CTA returned `PATH_REJECTED` and restarted nothing
whenever the active document sat outside the home directory. Both documents
Tandem opens on the user's behalf live inside the app bundle — `CHANGELOG.md`
after an update, `sample/welcome.md` on a fresh install — so that is the
guaranteed state immediately after installing or updating.

Which means the recovery button was broken in precisely the two moments a new
user is most likely to press it, and v0.20.0 shipped this morning. The fix is
client-only, which is the best possible shape for a patch.

## The six surfaces

| # | Surface | Guarded by CI? |
|---|---|---|
| 1 | `package.json` | ✅ `plugin-version-pin.test.ts` |
| 2 | `.claude-plugin/plugin.json` — top-level + **three** npx pins (both `args` arrays and the `monitor` command string) | ✅ |
| 3 | `src-tauri/Cargo.toml` | ✅ |
| 4 | `src-tauri/tauri.conf.json` — drives artifact names and the tauri-action release target | ✅ |
| 5 | `package-lock.json` | ❌ regenerated, never hand-edited |
| 6 | `src-tauri/Cargo.lock` | ❌ relocked via `cargo update -p tandem-desktop` |

## What else ships

Nothing but documentation. Everything on master since the tag is the release
skill's changelog gaps, the `### Security` section v0.20.0 shipped without, and
the roadmap's real-hardware macOS evidence.

Worth noting: the `[0.20.0]` changelog section ships **corrected** here, since
the in-app View Changelog button serves the file rather than the GitHub release
body.

## Verification

- **`dist/` rebuilt first.** It was stale at `0.20.0`, and `version-baked.test.ts`
  greps the built bundle — this was the single red test at the v0.20.0 cut.
  Now baked at `0.20.1`.
- Full suite: **5672 passed**, 399 files, exit 0.
- `npm run typecheck`: clean.
- Straggler grep (`git grep -F 0.20.0` excluding changelog/lockfiles/tests/docs)
  leaves only deliberate prose naming the outgoing version as history — the
  release skill and CLAUDE.md's Status section. Nothing still *pins* it.

## After merge

Tag → draft release → populate notes from the changelog section → publish
(which fires the npm publish) → upgrade the local global install → smoke.

The one thing this release cannot self-verify is whether the button now works on
a real Mac, so the tester who reported it is the natural check once the update
lands.
