### PR TITLE
fix(ci): create the release draft once, and verify the manifest before publish

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -27,10 +27,14 @@ prevents them drifting.
    npx spec via `env!("CARGO_PKG_VERSION")`; stale = ships a build pinning the
    WRONG published npm version)
 4. `src-tauri/tauri.conf.json` — `version` (drives desktop artifact names
-   `Tandem_<version>_x64.dmg`, … AND the tauri-action `__VERSION__` that
-   names/targets the GitHub release; stale = installers uploaded onto the
-   PREVIOUS release — this bit v0.15.0, clobbering v0.14.3's published
-   artifacts before the guard was added)
+   `Tandem_<version>_x64.dmg`, …). It used to also *target* the GitHub release
+   through the tauri-action `__VERSION__` substitution, which is how a stale
+   value uploaded v0.15.0's build onto the PREVIOUS release and clobbered
+   v0.14.3's published artifacts. That mechanism is gone: `tauri-release.yml`
+   targets the pushed git tag, and its `create-release` job fails the build
+   before anything is signed when the tag and this file disagree. Still bump
+   it — a stale value now ships mis-*named* installers instead of mis-placed
+   ones.
 5. `package-lock.json` — regenerate, never hand-edit:
    ```bash
    npm install --package-lock-only
@@ -143,11 +147,31 @@ prevents them drifting.
    full notes; v0.17.0 and v0.19.0 shipped with the boilerplate), so it needs
    to be a step rather than a habit.
 
-6. Wait for every matrix build and `release-check` to go green, then publish
-   the draft:
+6. Wait for every matrix build, `release-check`, AND `verify-release-manifest`
+   to go green, then publish the draft:
    ```bash
    gh release edit v<version> --draft=false --latest
    ```
+
+   **A green matrix is not a complete release.** Until v0.20.1 every matrix leg
+   independently found-or-created the draft, so four jobs starting in the same
+   second could race and split the artifacts across TWO drafts sharing one tag,
+   each with a partial `latest.json`. v0.18.0 shipped that way — 8 assets and 5
+   platform keys, no `darwin-aarch64`, no linux, while a 10-asset sibling draft
+   sat orphaned and unpublished. Nothing was red. A missing platform key is
+   indistinguishable from "no update available", so every M-series Mac was told
+   it was up to date until the next release.
+
+   `create-release` + `verify-release-manifest` now make that structural, but
+   the cheap manual confirmation is worth keeping — the counts are the tell:
+   ```bash
+   gh api repos/bloknayrb/tandem/releases --jq \
+     '[.[]|select(.tag_name=="v<version>")]|length'   # must be 1, never 2
+   gh release view v<version> --json assets --jq '.assets|length'  # 17
+   ```
+   17 assets and 11 platform keys is the healthy shape (`latest.json`, 4
+   installers + 4 `.sig`, 2 `.app.tar.gz` + 2 `.sig`, 2 dmg, deb/rpm/AppImage
+   + sigs).
    Publishing is the npm trigger: `.github/workflows/publish.yml` fires on
    `release: [published]` and runs `npm publish --provenance`. If macOS
    notarization 403s on "agreement missing/expired," that is an Apple

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -5,8 +5,121 @@ on:
     tags:
       - "v*"
 
+# The create-release job below removes the race BETWEEN matrix legs. This
+# removes it between whole workflow RUNS: a double push, a webhook redelivery,
+# or an operator re-running while a prior run is mid-flight would otherwise give
+# two `create-release` jobs that each see zero existing releases and each create
+# one -- the same duplicate-release bug, one level up.
+# `cancel-in-progress: false` deliberately: a release build is signed and
+# notarized, and cancelling one halfway leaves a partially-populated draft,
+# which is the state we are trying to make impossible.
+concurrency:
+  group: tauri-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  # Create the draft release EXACTLY ONCE, before any build starts.
+  #
+  # Without this job, every matrix leg called tauri-action with `tagName` and
+  # `releaseDraft: true` and each one independently found-or-created the draft.
+  # Four legs starting within the same second race, and when two of them win the
+  # create, the artifacts split across two draft releases that share a tag --
+  # each with its own partial `latest.json`.
+  #
+  # That is not hypothetical. v0.18.0 SHIPPED that way: its published release
+  # carries 8 assets and a 5-key `latest.json` with no `darwin-aarch64` and no
+  # linux keys, while a 10-asset sibling draft holding the Apple Silicon and
+  # Linux artifacts was left orphaned and never published. Every M-series Mac
+  # checking for an update in that window was told it was up to date, because a
+  # missing platform key is indistinguishable from "no update available".
+  # v0.19.0 and v0.20.0 came out complete by luck, not by construction -- the
+  # create simply didn't race those times. v0.20.1 hit it again.
+  #
+  # Passing a single `releaseId` to every leg removes the create from the
+  # matrix entirely.
+  #
+  # It does NOT make concurrent uploads provably safe, and this comment used to
+  # claim it did on the grounds that v0.19.0/v0.20.0 came out complete -- which
+  # is the same luck-for-construction mistake described above, made about our
+  # own fix. tauri-action's `upload-version-json` does an unguarded
+  # read-modify-write on the `latest.json` asset (list assets, GET, merge this
+  # leg's keys locally, delete, re-upload) with no ETag or compare-and-swap, so
+  # two legs whose GET-to-PUT windows overlap can still drop a platform key.
+  # That is why `verify-release-manifest` below asserts the finished manifest
+  # rather than trusting the merge -- the same "check the artifact you actually
+  # shipped" philosophy as the Linux install smoke and the notarization staple
+  # check.
+  create-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create.outputs.release_id }}
+    steps:
+      - uses: actions/checkout@v6
+
+      # The pushed tag now names the release (previously tauri-action derived it
+      # from tauri.conf.json via `v__VERSION__`). That is the more correct
+      # source -- artifacts land on the tag a human actually pushed -- but it
+      # makes a tag/manifest mismatch silent, where before it produced a
+      # visibly wrong-tagged release. `plugin-version-pin.test.ts` proves the
+      # four in-repo surfaces agree with each other; nothing proved they agree
+      # with the TAG. Assert it here, before spending a signed 4-platform build
+      # on a version that would ship mis-named installers.
+      - name: Tag must match tauri.conf.json version
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          CONF=$(node -p "require('./src-tauri/tauri.conf.json').version")
+          echo "tag=$TAG  tauri.conf.json=$CONF"
+          if [ "$TAG" != "v$CONF" ]; then
+            echo "::error::tag $TAG does not match tauri.conf.json version $CONF — bump all six surfaces before tagging"
+            exit 1
+          fi
+
+      - uses: actions/github-script@v8
+        id: create
+        with:
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            // listReleases, NOT getReleaseByTag: the REST API does not resolve a
+            // tag to a DRAFT release, so getReleaseByTag 404s on the very thing
+            // we need to find and would re-create a duplicate on any re-run.
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const existing = releases.filter((r) => r.tag_name === tag);
+            if (existing.length > 1) {
+              // Refuse rather than pick one: publishing either would ship a
+              // partial manifest, which is the exact failure this job exists to
+              // prevent. Delete the extras and re-run.
+              throw new Error(
+                `${existing.length} releases already exist for ${tag} (ids: ${existing
+                  .map((r) => r.id)
+                  .join(', ')}). Delete all but one and re-run.`,
+              );
+            }
+            if (existing.length === 1) {
+              core.info(`Reusing existing release ${existing[0].id} for ${tag}`);
+              core.setOutput('release_id', existing[0].id);
+              return;
+            }
+            const { data } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: `Tandem ${tag}`,
+              body: 'See the assets to download and install Tandem.',
+              draft: true,
+              prerelease: false,
+            });
+            core.info(`Created draft release ${data.id} for ${tag}`);
+            core.setOutput('release_id', data.id);
+
   build-tauri:
+    needs: create-release
     permissions:
       contents: write
       # OIDC token write for azure/login@v2 (Windows signing).
@@ -234,11 +347,17 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
         with:
-          tagName: v__VERSION__
-          releaseName: "Tandem v__VERSION__"
-          releaseBody: "See the assets to download and install Tandem."
-          releaseDraft: true
-          prerelease: false
+          # `releaseId` makes tauri-action upload into an existing release
+          # instead of finding-or-creating one, which is what removes the race
+          # (see the create-release job). tagName/releaseName/releaseBody/
+          # releaseDraft are deliberately gone: with releaseId set they are
+          # ignored, and leaving them would imply this step still decides where
+          # the artifacts land. The create-release job owns that now.
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          # `prerelease` is dropped for the same reason as the four above -- it
+          # is only read on the create path. `updaterJsonPreferNsis` stays: it
+          # feeds uploadVersionJSON's signature-priority choice, which still
+          # runs in releaseId mode.
           updaterJsonPreferNsis: true
           args: ${{ matrix.args }}
 
@@ -621,3 +740,76 @@ jobs:
         run: |
           echo "::error::Some platform builds failed. Check the matrix jobs before publishing the release."
           exit 1
+
+  # Assert the thing the updater actually reads.
+  #
+  # Four green build jobs do not prove a complete release: the artifacts land
+  # via concurrent read-modify-write into one `latest.json`, and a lost update
+  # there removes a platform silently. A missing key is indistinguishable from
+  # "no update available" to `tauri-plugin-updater`, so the failure mode is an
+  # entire platform being told it is up to date, forever, with nothing red
+  # anywhere. v0.18.0 shipped exactly that for Apple Silicon and Linux behind a
+  # fully green matrix.
+  #
+  # This runs before a human publishes the draft, which is the last moment the
+  # mistake is free to fix.
+  verify-release-manifest:
+    permissions:
+      contents: read
+    needs: [create-release, build-tauri]
+    if: needs.build-tauri.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const EXPECTED = [
+              'darwin-aarch64', 'darwin-aarch64-app',
+              'darwin-x86_64', 'darwin-x86_64-app',
+              'linux-x86_64', 'linux-x86_64-appimage',
+              'linux-x86_64-deb', 'linux-x86_64-rpm',
+              'windows-x86_64', 'windows-x86_64-nsis', 'windows-x86_64-msi',
+            ];
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const release_id = Number('${{ needs.create-release.outputs.release_id }}');
+
+            const assets = await github.paginate(github.rest.repos.listReleaseAssets, {
+              owner, repo, release_id, per_page: 100,
+            });
+            const names = new Set(assets.map((a) => a.name));
+            core.info(`release ${release_id} has ${assets.length} assets`);
+
+            const manifest = assets.find((a) => a.name === 'latest.json');
+            if (!manifest) {
+              throw new Error(`latest.json is not attached to release ${release_id}`);
+            }
+            const res = await github.rest.repos.getReleaseAsset({
+              owner, repo, asset_id: manifest.id,
+              headers: { accept: 'application/octet-stream' },
+            });
+            const json = JSON.parse(Buffer.from(res.data).toString('utf8'));
+            const keys = Object.keys(json.platforms ?? {});
+            core.info(`platform keys (${keys.length}): ${keys.join(', ')}`);
+
+            const missing = EXPECTED.filter((k) => !keys.includes(k));
+            if (missing.length) {
+              throw new Error(
+                `latest.json is missing ${missing.length} platform key(s): ${missing.join(', ')}. ` +
+                `A missing key silently tells that platform it is up to date. Do NOT publish.`,
+              );
+            }
+
+            // Every URL must point at a file actually attached to THIS release.
+            // Catches the split-release case, where a manifest looks complete
+            // but half its artifacts live on a sibling draft.
+            const dangling = [];
+            for (const [key, p] of Object.entries(json.platforms)) {
+              const file = decodeURIComponent(String(p.url).split('/').pop() ?? '');
+              if (!names.has(file)) dangling.push(`${key} -> ${file}`);
+              if (!p.signature) dangling.push(`${key} -> missing signature`);
+            }
+            if (dangling.length) {
+              throw new Error(`latest.json references assets not on this release:\n${dangling.join('\n')}`);
+            }
+            core.info('manifest OK: all platform keys present, every URL resolves to an attached asset');

--- a/tests/plugin/plugin-version-pin.test.ts
+++ b/tests/plugin/plugin-version-pin.test.ts
@@ -11,12 +11,16 @@
  *   - `src-tauri/Cargo.toml` — the Cowork installer pins via `env!("CARGO_PKG_VERSION")`,
  *     which is only correct while the Rust crate version equals the npm version.
  *   - `src-tauri/tauri.conf.json` — drives the desktop bundle artifact names
- *     (`Tandem_<version>_x64.dmg`, …) AND the tauri-action `__VERSION__` that
- *     names/targets the GitHub release. A stale value here builds correctly-coded
- *     installers under the WRONG version and uploads them onto the PREVIOUS
- *     release (observed on v0.15.0: 0.14.3-named artifacts clobbered the
- *     published v0.14.3 release). This surface has no CARGO_PKG_VERSION-style
- *     derivation, so it silently rots.
+ *     (`Tandem_<version>_x64.dmg`, …). A stale value here builds
+ *     correctly-coded installers under the WRONG version. It used to also
+ *     mis-*target* the release, via the tauri-action `__VERSION__`
+ *     substitution — that is how v0.15.0's 0.14.3-named artifacts clobbered
+ *     the published v0.14.3 release. `tauri-release.yml` no longer works that
+ *     way: the release is targeted by the pushed git tag, and its
+ *     `create-release` job fails the build outright when the tag and this file
+ *     disagree. So the wrong-release failure mode is gone; the wrong-*name*
+ *     one is what this assertion still guards, and this surface has no
+ *     CARGO_PKG_VERSION-style derivation, so it silently rots.
  *
  * This test fails CI the moment any of them diverges from package.json.
  * (`src/server/integrations/apply.ts` build-injects the version from package.json
@@ -81,8 +85,10 @@ describe("plugin/version pin drift guard", () => {
   });
 
   it("src-tauri/tauri.conf.json version matches package.json", () => {
-    // Drives desktop artifact names and the tauri-action release __VERSION__.
-    // A stale value ships mis-versioned installers onto the wrong release.
+    // Drives desktop artifact names. A stale value ships mis-versioned
+    // installers; the release it lands ON is now the pushed git tag, and
+    // tauri-release.yml's create-release job refuses to build when the two
+    // disagree.
     expect(tauriConf.version).toBe(expected);
   });
 


### PR DESCRIPTION
Blocks the v0.20.1 publish. Found while cutting it.

## What happened

Every matrix leg called `tauri-action` with `tagName` + `releaseDraft: true` and
**no `releaseId`**, so each of the four independently found-or-created the
draft. Four jobs starting in the same second race. When two win the create, the
artifacts split across two draft releases sharing one tag, each with its own
partial `latest.json`.

Right now, for `v0.20.1`:

| Release id | Assets |
|---|---|
| 365649360 | 10 — aarch64 dmg + app.tar.gz, AppImage, deb, rpm, sigs |
| 365649312 | 8 — x64 dmg + app.tar.gz, msi, nsis, sigs |

## It already shipped once

```
id=356407572  draft=true   tag=v0.18.0  assets=10   <- orphaned, never published
id=356407563  draft=false  tag=v0.18.0  assets=8    <- what users got
```

v0.18.0's published `latest.json` has **5** platform keys. v0.19.0 and v0.20.0
have **11**. Missing: `darwin-aarch64`, `darwin-aarch64-app`, and all four
`linux-*` keys.

A missing platform key is indistinguishable from "no update available" to
`tauri-plugin-updater`. So every M-series Mac was silently told it was up to
date, and Linux had no packages at all, for the two days until v0.19.0. Nothing
was red — the matrix was fully green.

**v0.19.0 and v0.20.0 were luck, not correctness.** The create simply did not
race those times.

## Changes

**1. `create-release` job — one draft, made once.**
Runs before the matrix and passes a single `releaseId` to every leg. Verified
against tauri-action's source (`src/index.ts`): the find-or-create path is
gated on `if (tagName && !releaseId)`, so dropping `tagName` makes it
structurally unreachable. `tagName`/`releaseName`/`releaseBody`/`releaseDraft`/
`prerelease` are all dead in this mode and removed; `updaterJsonPreferNsis`
stays because it still feeds `uploadVersionJSON`.

It matches with `listReleases`, not `getReleaseByTag` — the REST API will not
resolve a tag to a **draft**, so the naive find-or-create would 404 and
duplicate on every re-run. (tauri-action's own `create-release.ts` carries the
identical workaround for the same reason.) Two releases for one tag throws and
names the ids rather than guessing, because guessing means publishing a partial
manifest.

**2. `verify-release-manifest` job — check what the updater actually reads.**
`releaseId` narrows the race without closing it: `uploadVersionJSON` does an
unguarded read-modify-write on `latest.json` (list, GET, merge locally, delete,
re-upload) with no ETag or CAS, so two legs whose GET-to-PUT windows overlap can
still drop a key. This asserts all 11 platform keys are present and that every
URL resolves to an asset attached to *this* release — which also catches the
split-release case, where a manifest looks complete but half its artifacts live
on a sibling draft. Same philosophy as the Linux install smoke and the
notarization staple check: verify the artifact, not the exit code.

**3. Workflow-level `concurrency` group**, so two runs for one tag cannot race
`create-release` the way two legs used to. `cancel-in-progress: false` — these
builds are signed and notarized, and cancelling one halfway leaves exactly the
partial draft we are trying to make impossible.

**Plus a tag guard.** Targeting by pushed git tag is more correct than the old
`__VERSION__` substitution, but it makes a tag/version mismatch *silent* where
it used to produce a visibly wrong-tagged release. `plugin-version-pin.test.ts`
proves the four in-repo surfaces agree with each other; nothing proved they
agree with the **tag**. The guard fails before anything is signed.

## Review

An agent reviewed this against tauri-action's upstream source rather than its
docs, and found three things I had wrong or missing — all fixed here:

- My comment claimed concurrent uploads were "proven correct" by v0.19.0 and
  v0.20.0. That is the same luck-for-construction mistake this PR criticizes,
  made about my own fix. Hence job 2.
- No `concurrency:` guard, leaving the same race one level up. Hence job 3.
- `prerelease: false` left inert beside three siblings removed for being inert.

It also confirmed the parts I was least sure of: `releaseId` is a real input
with the claimed semantics, the drafts-need-`listReleases` claim is accurate,
`github-script@v8` is valid, the tag guard's `GITHUB_REF_NAME` and `node -p`
work on `ubuntu-latest` without `setup-node`, and re-running failed legs reuses
the existing `release_id` rather than duplicating.

## Docs

The release skill and `plugin-version-pin.test.ts` both narrated the
`__VERSION__` targeting mechanism this deletes. Updated — including the v0.15.0
story, which was *caused* by that mechanism and can no longer happen the same
way. The skill's publish step now waits on `verify-release-manifest` and records
the 17-assets / 11-keys shape as the healthy baseline.

## Verification

`wrkflw validate` passes; YAML parses; `tests/plugin/` 5 passed. The workflow
itself can only be exercised by a tag push, which is what happens next: after
this merges I delete both v0.20.1 drafts and the orphaned v0.18.0 one, delete
and re-push the tag, and confirm a single release with 17 assets and 11 platform
keys before publishing.
