### PR TITLE
fix(ci): grant verify-release-manifest write scope so it can read drafts

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -755,7 +755,21 @@ jobs:
   # mistake is free to fix.
   verify-release-manifest:
     permissions:
-      contents: read
+      # `write`, not `read`, and NOT because this job writes anything -- it is
+      # purely an assertion. A DRAFT release is invisible to a read-scoped
+      # token: both `listReleaseAssets` and `getReleaseAsset` 403 with
+      # "Resource not accessible by integration". `contents` is the only scope
+      # covering releases and it has no read-only-plus-drafts level, so `write`
+      # is the whole menu.
+      #
+      # Drafts are awkward in TWO independent ways, and it is worth not
+      # conflating them: this one is token-visibility, while `create-release`
+      # above works around a *resolution* problem (`getReleaseByTag` 404s
+      # because the API will not resolve a tag to an unpublished release, at
+      # any permission level). Fixing one does not fix the other -- which is
+      # how this gate 403'd on the very first release it guarded (v0.20.1),
+      # while the manifest it was checking was in fact perfect.
+      contents: write
     needs: [create-release, build-tauri]
     if: needs.build-tauri.result == 'success'
     runs-on: ubuntu-latest
@@ -788,7 +802,20 @@ jobs:
               owner, repo, asset_id: manifest.id,
               headers: { accept: 'application/octet-stream' },
             });
-            const json = JSON.parse(Buffer.from(res.data).toString('utf8'));
+            // octokit picks its body parser from the RESPONSE content-type, not
+            // from the `accept` we sent -- and that content-type is whatever was
+            // recorded at upload time. tauri-action currently stores every asset
+            // as application/zip, so this lands as bytes; but nothing in this
+            // repo controls that, and an upload that tagged latest.json as
+            // application/json would arrive pre-parsed and make `Buffer.from`
+            // throw ERR_INVALID_ARG_TYPE -- a crash in the gate, on a release
+            // that may well be fine. Accept both shapes.
+            const raw = res.data;
+            const json =
+              typeof raw === 'string' ? JSON.parse(raw)
+              : raw instanceof ArrayBuffer || ArrayBuffer.isView(raw)
+                ? JSON.parse(Buffer.from(raw).toString('utf8'))
+                : raw;
             const keys = Object.keys(json.platforms ?? {});
             core.info(`platform keys (${keys.length}): ${keys.join(', ')}`);
 


### PR DESCRIPTION
## What

`verify-release-manifest` — the gate added in #1285 to make the split-release class of bug structurally impossible — could not run. It failed with HTTP 403 on the first release it guarded.

```
data: { message: 'Resource not accessible by integration', status: '403' }
url: '.../releases/365677926/assets?per_page=100'
```

The job declared `permissions: contents: read`. A read-scoped `GITHUB_TOKEN` cannot see a **draft** release's assets at all, and the gate exists precisely to inspect a draft before a human publishes it. `contents` is the only scope covering releases and has no read-only-plus-drafts level, so `write` is the entire menu.

## Why this slipped through

Drafts are awkward in two independent ways, and I treated them as one.

| | Failure | Cause | Workaround |
|---|---|---|---|
| `create-release` | `getReleaseByTag` **404** | The API will not resolve a tag to an unpublished release — at any permission level | use `listReleases` |
| `verify-release-manifest` | `listReleaseAssets` **403** | Draft assets are invisible to a read-scoped token | `contents: write` |

Both jobs landed in the same commit. Solving the first taught me nothing about the second, and I wrote the second as if it had. The comment now spells out that these are separate so the next person debugging a draft-related failure here doesn't inherit the same conflation.

## Blast radius of the elevation

Deliberately checked rather than assumed, since this grants repo-wide `contents: write` to a job that only asserts:

- The workflow triggers on `push: tags: v*` only — no `pull_request`/`pull_request_target`/`workflow_run`. It never runs against fork content; reaching this job already requires push access.
- The one `${{ }}`-into-script interpolation is `needs.create-release.outputs.release_id`, a GitHub-minted integer, not user-suppliable text.
- `latest.json` comes from this same run's build artifacts and is only compared as strings — never `eval`'d or shelled out.

## Second fix: the decode had never executed

Review flagged that `Buffer.from(res.data)` was unverified, and it was right that nothing had exercised it — the 403 happened one call earlier.

octokit picks its body parser from the **response** content-type, not the `accept` header we send, and that content-type is whatever was recorded at upload time. Checked against the real release: tauri-action stores every asset as `application/zip`, including `latest.json`, so the `arrayBuffer` path is live and the existing line would have worked. But nothing in this repo controls that; an upload tagging the manifest `application/json` would arrive pre-parsed and throw `ERR_INVALID_ARG_TYPE` — the gate crashing on a release that may well be fine, which is the same failure mode in a different costume. Now accepts object, string, or bytes.

## Not done, deliberately

Review suggested SHA-pinning `actions/github-script`. Skipped: 8 of 9 actions in this file use moving tags, `azure/login` is pinned for a specific reason (it holds the Windows signing credentials), and `.github/dependabot.yml` has an empty `package-ecosystem` placeholder — so `github-actions` updates aren't automated and pins would rot unmaintained. Pinning two of nine looks like a policy that isn't one. Worth doing as its own change if the repo adopts the posture properly.

## Verification

- v0.20.1's manifest verified by hand with an authenticated token, which is how the release shipped despite the red gate: **11/11 platform keys, 17 assets, 1 release for the tag, every URL resolving to an attached asset, every signature present.**
- Workflow re-parsed with `yaml` after editing; job block, `permissions`, `needs` and `if` all resolve.
- The gate itself is unexercised until the next tag build — it cannot be tested without a draft release. Stating that plainly rather than implying this is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zvt9RXMCoNJbuA2Nj7i2R
