### PR TITLE
fix(toolbar): un-clip formatting-bar popovers via an overflow axis split (#1302)

### DIFF
--- a/src/client/editor/toolbar/FormattingToolbar.svelte
+++ b/src/client/editor/toolbar/FormattingToolbar.svelte
@@ -3,8 +3,9 @@ import type { Editor as TiptapEditor } from "@tiptap/core";
 import { yUndoPluginKey } from "y-prosemirror";
 import { clickOutside } from "../../actions/clickOutside.svelte";
 import { createCoalescingTick } from "../../utils/coalescing-tick";
+import { ESCAPE_OWNER_ATTR } from "../../utils/escape-owner";
 import { focusMenuEntryPoint, handleMenuArrowKeys } from "../../utils/menuKeys";
-import { applyLink, getInitialLinkHref, withPreventDefault } from "./handlers.js";
+import { applyLink, getInitialLinkHref, onKeyActivate, withPreventDefault } from "./handlers.js";
 import LinkEditor from "./LinkEditor.svelte";
 import ToolbarButton from "./ToolbarButton.svelte";
 
@@ -185,16 +186,6 @@ const handleCodeBlock = $derived(
   withPreventDefault(() => editor?.chain().focus().toggleCodeBlock().run()),
 );
 
-// Keyboard activation: Enter/Space on a focused button fires `click` with
-// detail === 0. The mouse path uses `mousedown` so the editor selection
-// survives. Pair onMouseDown (mouse) with onClick={onKeyActivate(...)}
-// (keyboard, filtered on detail===0) so both routes work without double-firing.
-function onKeyActivate(handler: (e: MouseEvent) => void) {
-  return (e: MouseEvent) => {
-    if (e.detail === 0) handler(e);
-  };
-}
-
 function handleHeadingToggle(level: HeadingLevel) {
   return (e: MouseEvent) => {
     e.preventDefault();
@@ -295,9 +286,13 @@ function dismissLinkInput() {
     />
 
     <!-- Link (A8: stays in the inline-marks group, right after Code). -->
+    <!-- Claims Escape while open so Toolbar's capture-phase window listener
+         yields to this handler instead of dismissing the selection popup out
+         from under it (escape-owner.ts). -->
     <div
       use:clickOutside={dismissLinkInput}
       style="position: relative;"
+      {...(showLinkInput ? { [ESCAPE_OWNER_ATTR]: "" } : {})}
       onkeydown={(e) => {
         if (e.key === "Escape") dismissLinkInput();
       }}
@@ -335,9 +330,11 @@ function dismissLinkInput() {
     <div style="width: 1px; height: 16px; background: var(--tandem-border); margin: 0 2px;"></div>
 
     <!-- Heading dropdown (A8: leads the block group). -->
+    <!-- Claims Escape while open — see the link wrapper above. -->
     <div
       use:clickOutside={closeHeadingMenu}
       style="position: relative;"
+      {...(showHeadingMenu ? { [ESCAPE_OWNER_ATTR]: "" } : {})}
       onkeydown={(e) => {
         if (e.key === "Escape") closeHeadingMenu();
       }}

--- a/src/client/editor/toolbar/HighlightColorPicker.svelte
+++ b/src/client/editor/toolbar/HighlightColorPicker.svelte
@@ -2,6 +2,8 @@
 import { HIGHLIGHT_COLOR_VARS } from "../../../shared/constants";
 import type { HighlightColor } from "../../../shared/types";
 import { onOutsideEvent } from "../../utils/dismiss-outside";
+import { ESCAPE_OWNER_ATTR } from "../../utils/escape-owner";
+import { onKeyActivate } from "./handlers.js";
 import ToolbarButton from "./ToolbarButton.svelte";
 
 const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> = [
@@ -21,6 +23,7 @@ const { disabled = false, onHighlight }: Props = $props();
 let highlightColor = $state<HighlightColor>("yellow");
 let showColorPicker = $state(false);
 let colorPickerEl = $state<HTMLDivElement | null>(null);
+let toggleEl = $state<HTMLButtonElement | null>(null);
 
 $effect(() => {
   if (!showColorPicker) return;
@@ -45,32 +48,52 @@ function handleColorPickerToggle(e: MouseEvent) {
 }
 
 /**
- * Keyboard activation. Enter/Space on a focused button fires `click` with
- * `detail === 0`; the mouse path deliberately uses `mousedown` so the editor
- * selection survives the toolbar interaction. Pairing them is the house pattern
- * (`onKeyActivate` in FormattingToolbar) and both routes must exist here, not
- * least because this control now publishes `aria-expanded` — without a keyboard
- * path that state could never change for a keyboard user, which is a promise
- * the markup cannot keep.
+ * Focus returns to the trigger on every DELIBERATE dismissal. This PR is what
+ * makes the menu keyboard-reachable, and the `{#if}` unmounts the focused
+ * button, so without this `activeElement` falls to `<body>` and the next Tab
+ * restarts from the top of the document. Matches `DecorationsMenu.closeMenu()`.
+ *
+ * The outside-mousedown path deliberately does NOT call this: yanking focus
+ * back to the toolbar when the user clicked elsewhere would be wrong.
  */
-function handleColorPickerKeyActivate(e: MouseEvent) {
-  if (e.detail === 0) handleColorPickerToggle(e);
+function closePicker() {
+  showColorPicker = false;
+  toggleEl?.focus();
 }
 
 function handleColorSelect(color: HighlightColor) {
   highlightColor = color;
-  showColorPicker = false;
+  closePicker();
 }
 </script>
 
-<!-- Escape dismisses, matching the heading menu and link editor in the same bar
-     (both wrap their trigger + popover in an Escape keydown handler). Without
-     it this was the only popover in the formatting bar a keyboard user could
-     open but not close. -->
+<!-- This PR makes the picker keyboard-OPENABLE (the trigger previously had only
+     `onmousedown`), so it also has to be keyboard-dismissable. Two non-obvious
+     pieces make that work:
+       - Escape only reaches this bubble-phase handler because the selection
+         popup's capture-phase `window` listener yields to a subtree carrying
+         ESCAPE_OWNER_ATTR (see utils/escape-owner.ts and Toolbar.svelte). The
+         heading menu, link editor and decorations menu claim it the same way.
+       - `focusout` is the dismissal for the keyboard path that Escape cannot
+         cover: the picker is otherwise only closed by an outside *mousedown*,
+         so a keyboard user who Tabs past it would leave it mounted — and a
+         mounted popover pins the whole bar at --tandem-z-toast via
+         FormattingBar's `:has([aria-expanded="true"])` rule. -->
 <div
   class="highlight-picker-wrap"
+  {...(showColorPicker ? { [ESCAPE_OWNER_ATTR]: "" } : {})}
   onkeydown={(e) => {
-    if (e.key === "Escape") showColorPicker = false;
+    if (e.key !== "Escape" || !showColorPicker) return;
+    e.stopPropagation();
+    closePicker();
+  }}
+  onfocusout={(e) => {
+    if (!showColorPicker) return;
+    // A `null` relatedTarget (window blur, focus dropped to <body>) is
+    // deliberately ignored — only a focus move to a real element OUTSIDE the
+    // wrap counts as leaving the popover.
+    const next = e.relatedTarget;
+    if (next instanceof Node && !e.currentTarget.contains(next)) showColorPicker = false;
   }}
   role="presentation"
 >
@@ -80,17 +103,25 @@ function handleColorSelect(color: HighlightColor) {
     {disabled}
     disabledTitle="Select text first"
     onMouseDown={handleHighlight}
+    onClick={onKeyActivate(handleHighlight)}
   />
+  <!-- `aria-expanded` is dropped while disabled: a selection can collapse while
+       the menu is open, and publishing aria-expanded="true" on a disabled button
+       keeps FormattingBar's `:has([aria-expanded="true"])` rule matching, which
+       pins the whole bar at --tandem-z-toast. Dropping the attribute closes that
+       without adding a dismissal path a transient selection blip could trip. -->
   <button
+    bind:this={toggleEl}
     type="button"
     class="highlight-swatch-toggle"
     data-testid="toolbar-highlight-color-toggle"
     {disabled}
     aria-haspopup="menu"
-    aria-expanded={showColorPicker}
+    aria-expanded={disabled ? undefined : showColorPicker}
     onmousedown={handleColorPickerToggle}
-    onclick={handleColorPickerKeyActivate}
+    onclick={onKeyActivate(handleColorPickerToggle)}
     title="Choose highlight color"
+    aria-label="Choose highlight color"
   >
     <span
       class="highlight-swatch-preview"
@@ -108,45 +139,50 @@ function handleColorSelect(color: HighlightColor) {
       role="menu"
       aria-label="Highlight color"
     >
-      {#each HIGHLIGHT_COLOR_OPTIONS as { value, label } (value)}
-        <button
-          type="button"
-          role="menuitemradio"
-          aria-checked={value === highlightColor}
-          data-testid={`toolbar-highlight-color-${value}`}
-          title={label}
-          aria-label={label}
-          onclick={() => handleColorSelect(value)}
-          class="highlight-picker-swatch"
-          class:is-selected={value === highlightColor}
-        >
-          <span
-            class="highlight-picker-swatch-inner"
-            style="background: {HIGHLIGHT_COLOR_VARS[value]};"
-          ></span>
-          <svg
-            class="highlight-picker-swatch-check"
-            width="10"
-            height="10"
-            viewBox="0 0 20 20"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
+      <!-- The radio set gets its own group so set-size/position-in-set are
+           computed over the four colours alone; the close command is a sibling,
+           not a fifth "colour". -->
+      <div role="group" aria-label="Highlight color" class="highlight-picker-swatches">
+        {#each HIGHLIGHT_COLOR_OPTIONS as { value, label } (value)}
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={value === highlightColor}
+            data-testid={`toolbar-highlight-color-${value}`}
+            title={label}
+            aria-label={label}
+            onclick={() => handleColorSelect(value)}
+            class="highlight-picker-swatch"
+            class:is-selected={value === highlightColor}
           >
-            <path d="M5 11l3 3 7-9" />
-          </svg>
-        </button>
-      {/each}
+            <span
+              class="highlight-picker-swatch-inner"
+              style="background: {HIGHLIGHT_COLOR_VARS[value]};"
+            ></span>
+            <svg
+              class="highlight-picker-swatch-check"
+              width="10"
+              height="10"
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 11l3 3 7-9" />
+            </svg>
+          </button>
+        {/each}
+      </div>
       <button
         type="button"
         role="menuitem"
         data-testid="color-picker-close"
         title="Close"
         aria-label="Close color picker"
-        onclick={() => (showColorPicker = false)}
+        onclick={closePicker}
         class="highlight-picker-close"
       >
         ✕
@@ -181,7 +217,13 @@ function handleColorSelect(color: HighlightColor) {
   .highlight-swatch-toggle:disabled {
     cursor: not-allowed;
   }
-  .highlight-swatch-toggle:focus-visible {
+  /* One ring for every focusable control this component owns. The popover's
+     items only became keyboard-reachable in #1304, so their omission from this
+     list was newly load-bearing — a UA default ring lands on a 20px saturated
+     fill and, on the selected swatch, competes with `.is-selected`'s own ring. */
+  .highlight-swatch-toggle:focus-visible,
+  .highlight-picker-swatch:focus-visible,
+  .highlight-picker-close:focus-visible {
     outline: 2px solid var(--tandem-accent);
     outline-offset: 1px;
   }
@@ -196,14 +238,13 @@ function handleColorSelect(color: HighlightColor) {
      consumer today (FormattingBar), and this alignment is chosen for that host's
      geometry — a second mount site is a reason to re-check it, not to copy it.
      There, this control is the last item in the clipped track and its wrap ends
-     flush with the track's right edge, so a `left: 0` popover overhung the
-     horizontal clip and lost its rightmost controls specifically: the pink
-     swatch and the close button were unclickable while yellow/green/blue were
-     fine. Opening leftward keeps the whole popover inside the clipped box, and
-     wins in the truncated case too (the wrap is what gets pushed past the edge,
-     so a right-aligned popover keeps more of itself visible, not less). The
-     horizontal clip is deliberate — it is what truncates the toolbar on narrow
-     windows; only the vertical axis was widened to `visible`. */
+     flush with the track's right edge, so a `left: 0` popover overhangs the
+     horizontal clip and loses its rightmost controls. Opening leftward keeps the
+     whole popover inside the clipped box, and wins in the truncated case too
+     (the wrap is what gets pushed past the edge, so a right-aligned popover
+     keeps more of itself visible, not less). The horizontal clip is deliberate —
+     it is what truncates the toolbar on narrow windows; only the vertical axis
+     was widened to `visible`. */
   .highlight-picker-popover {
     position: absolute;
     top: 100%;
@@ -238,6 +279,13 @@ function handleColorSelect(color: HighlightColor) {
   .highlight-picker-popover::after {
     bottom: calc(100% - 1px);
     border-bottom-color: var(--tandem-surface);
+  }
+  /* Layout-neutral: reproduces the popover's own flex row so wrapping the radio
+     set in a group for AT changes nothing visually. */
+  .highlight-picker-swatches {
+    display: flex;
+    align-items: center;
+    gap: 4px;
   }
   .highlight-picker-swatch {
     position: relative;

--- a/src/client/editor/toolbar/HighlightColorPicker.svelte
+++ b/src/client/editor/toolbar/HighlightColorPicker.svelte
@@ -44,13 +44,36 @@ function handleColorPickerToggle(e: MouseEvent) {
   showColorPicker = !showColorPicker;
 }
 
+/**
+ * Keyboard activation. Enter/Space on a focused button fires `click` with
+ * `detail === 0`; the mouse path deliberately uses `mousedown` so the editor
+ * selection survives the toolbar interaction. Pairing them is the house pattern
+ * (`onKeyActivate` in FormattingToolbar) and both routes must exist here, not
+ * least because this control now publishes `aria-expanded` — without a keyboard
+ * path that state could never change for a keyboard user, which is a promise
+ * the markup cannot keep.
+ */
+function handleColorPickerKeyActivate(e: MouseEvent) {
+  if (e.detail === 0) handleColorPickerToggle(e);
+}
+
 function handleColorSelect(color: HighlightColor) {
   highlightColor = color;
   showColorPicker = false;
 }
 </script>
 
-<div class="highlight-picker-wrap">
+<!-- Escape dismisses, matching the heading menu and link editor in the same bar
+     (both wrap their trigger + popover in an Escape keydown handler). Without
+     it this was the only popover in the formatting bar a keyboard user could
+     open but not close. -->
+<div
+  class="highlight-picker-wrap"
+  onkeydown={(e) => {
+    if (e.key === "Escape") showColorPicker = false;
+  }}
+  role="presentation"
+>
   <ToolbarButton
     label="Highlight"
     testId="toolbar-highlight-btn"
@@ -66,6 +89,7 @@ function handleColorSelect(color: HighlightColor) {
     aria-haspopup="menu"
     aria-expanded={showColorPicker}
     onmousedown={handleColorPickerToggle}
+    onclick={handleColorPickerKeyActivate}
     title="Choose highlight color"
   >
     <span
@@ -74,13 +98,21 @@ function handleColorSelect(color: HighlightColor) {
     ></span>
   </button>
   {#if showColorPicker}
+    <!-- The trigger advertises `aria-haspopup="menu"`, so this has to actually
+         be one. Single-select level picker → `menuitemradio` + `aria-checked`,
+         mirroring the heading dropdown in FormattingToolbar, which has the
+         identical shape. -->
     <div
       bind:this={colorPickerEl}
       class="highlight-picker-popover"
+      role="menu"
+      aria-label="Highlight color"
     >
       {#each HIGHLIGHT_COLOR_OPTIONS as { value, label } (value)}
         <button
           type="button"
+          role="menuitemradio"
+          aria-checked={value === highlightColor}
           data-testid={`toolbar-highlight-color-${value}`}
           title={label}
           aria-label={label}
@@ -110,6 +142,7 @@ function handleColorSelect(color: HighlightColor) {
       {/each}
       <button
         type="button"
+        role="menuitem"
         data-testid="color-picker-close"
         title="Close"
         aria-label="Close color picker"
@@ -159,14 +192,18 @@ function handleColorSelect(color: HighlightColor) {
     border-radius: var(--tandem-r-1);
     border: 1px solid var(--tandem-border);
   }
-  /* Right-aligned, so it unfurls leftward into the track (#1302). This control
-     is the last item in the formatting bar's clipped track and its wrap ends
+  /* Right-aligned, so it unfurls leftward into the track (#1302). Single
+     consumer today (FormattingBar), and this alignment is chosen for that host's
+     geometry — a second mount site is a reason to re-check it, not to copy it.
+     There, this control is the last item in the clipped track and its wrap ends
      flush with the track's right edge, so a `left: 0` popover overhung the
-     horizontal clip by ~61px and took the pink swatch and the close button with
-     it — unclickable. Opening leftward keeps the whole popover inside the
-     clipped box. The horizontal clip is deliberate (it is what truncates the
-     toolbar on narrow windows); only the vertical axis was widened to `visible`
-     to let popovers escape downward. */
+     horizontal clip and lost its rightmost controls specifically: the pink
+     swatch and the close button were unclickable while yellow/green/blue were
+     fine. Opening leftward keeps the whole popover inside the clipped box, and
+     wins in the truncated case too (the wrap is what gets pushed past the edge,
+     so a right-aligned popover keeps more of itself visible, not less). The
+     horizontal clip is deliberate — it is what truncates the toolbar on narrow
+     windows; only the vertical axis was widened to `visible`. */
   .highlight-picker-popover {
     position: absolute;
     top: 100%;

--- a/src/client/editor/toolbar/HighlightColorPicker.svelte
+++ b/src/client/editor/toolbar/HighlightColorPicker.svelte
@@ -14,24 +14,13 @@ const HIGHLIGHT_COLOR_OPTIONS: Array<{ value: HighlightColor; label: string }> =
 interface Props {
   disabled?: boolean;
   onHighlight: (color: HighlightColor) => void;
-  /**
-   * Fired whenever the color sub-menu opens or closes. The host (FormattingBar)
-   * uses this to lift its fixed wrapper's stacking context above the selection
-   * popup while the sub-menu is open — otherwise the open sub-menu, trapped in
-   * the bar's lower stacking context, renders behind the selection pill (#1024).
-   */
-  onOpenChange?: (open: boolean) => void;
 }
 
-const { disabled = false, onHighlight, onOpenChange }: Props = $props();
+const { disabled = false, onHighlight }: Props = $props();
 
 let highlightColor = $state<HighlightColor>("yellow");
 let showColorPicker = $state(false);
 let colorPickerEl = $state<HTMLDivElement | null>(null);
-
-$effect(() => {
-  onOpenChange?.(showColorPicker);
-});
 
 $effect(() => {
   if (!showColorPicker) return;
@@ -74,6 +63,8 @@ function handleColorSelect(color: HighlightColor) {
     class="highlight-swatch-toggle"
     data-testid="toolbar-highlight-color-toggle"
     {disabled}
+    aria-haspopup="menu"
+    aria-expanded={showColorPicker}
     onmousedown={handleColorPickerToggle}
     title="Choose highlight color"
   >
@@ -168,10 +159,18 @@ function handleColorSelect(color: HighlightColor) {
     border-radius: var(--tandem-r-1);
     border: 1px solid var(--tandem-border);
   }
+  /* Right-aligned, so it unfurls leftward into the track (#1302). This control
+     is the last item in the formatting bar's clipped track and its wrap ends
+     flush with the track's right edge, so a `left: 0` popover overhung the
+     horizontal clip by ~61px and took the pink swatch and the close button with
+     it — unclickable. Opening leftward keeps the whole popover inside the
+     clipped box. The horizontal clip is deliberate (it is what truncates the
+     toolbar on narrow windows); only the vertical axis was widened to `visible`
+     to let popovers escape downward. */
   .highlight-picker-popover {
     position: absolute;
     top: 100%;
-    left: 0;
+    right: 0;
     margin-top: 8px;
     background: var(--tandem-surface);
     border: 1px solid var(--tandem-border);
@@ -190,7 +189,9 @@ function handleColorSelect(color: HighlightColor) {
   .highlight-picker-popover::after {
     content: "";
     position: absolute;
-    left: 12px;
+    /* Mirrors the popover's right alignment above so the caret still points at
+       the swatch toggle, which is the rightmost control in the wrap. */
+    right: 12px;
     border: 5px solid transparent;
   }
   .highlight-picker-popover::before {

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -18,6 +18,7 @@ import { ENTER_POPUP_MS, motionOff, popupEnter, registerFlySource } from "../../
 import { pmPosToFlatOffset } from "../../positions";
 import DecorationsMenu from "../../shell/DecorationsMenu.svelte";
 import { onOutsideEvent } from "../../utils/dismiss-outside";
+import { escapeIsClaimed } from "../../utils/escape-owner";
 import {
   type AnnotationComposerIntent,
   defaultAnnotationIntent,
@@ -600,6 +601,12 @@ $effect(() => {
   // here would let Escape both close the popup AND clear the active annotation.
   function handleKeyDown(e: KeyboardEvent) {
     if (e.key !== "Escape") return;
+    // Yield to a nested popover that has claimed Escape (see escape-owner.ts).
+    // This listener is capture-phase at `window`, so without this it preempts
+    // the formatting bar's own dismissals: a keyboard user with the colour
+    // picker open got the POPUP dismissed on the first Escape and had to press
+    // it twice (#1302 review).
+    if (escapeIsClaimed(e.target)) return;
     e.preventDefault();
     e.stopPropagation();
     dismissPopup();

--- a/src/client/editor/toolbar/handlers.ts
+++ b/src/client/editor/toolbar/handlers.ts
@@ -17,6 +17,24 @@ export function withPreventDefault(command: () => void): (e: MouseEvent) => void
   };
 }
 
+/**
+ * Keyboard half of the toolbar handler pair. Enter/Space on a focused button
+ * fires `click` with `detail === 0`; the mouse path binds `mousedown` +
+ * `preventDefault()` (see `withPreventDefault`) so the editor selection
+ * survives. Pair `onMouseDown={h}` with `onClick={onKeyActivate(h)}` so both
+ * routes work without double-firing.
+ *
+ * The opposite case to `utils/keyboard-activate.ts`, which exists for NON-native
+ * interactive elements: a native `<button>` already synthesises the click, and
+ * the `detail === 0` filter is what stops that synthesised click re-running the
+ * mousedown handler.
+ */
+export function onKeyActivate(handler: (e: MouseEvent) => void): (e: MouseEvent) => void {
+  return (e: MouseEvent) => {
+    if (e.detail === 0) handler(e);
+  };
+}
+
 /** Current link's `href` attribute, or `""` if the cursor isn't on a link. */
 export function getInitialLinkHref(editor: TiptapEditor): string {
   const href = editor.getAttributes("link").href;

--- a/src/client/shell/DecorationsMenu.svelte
+++ b/src/client/shell/DecorationsMenu.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { clickOutside } from "../actions/clickOutside.svelte";
+import { ESCAPE_OWNER_ATTR } from "../utils/escape-owner";
 import { focusMenuEntryPoint, handleMenuArrowKeys } from "../utils/menuKeys";
 
 interface Props {
@@ -97,6 +98,7 @@ function chooseSettings() {
   class:open={menuOpen}
   data-testid="decorations-menu"
   data-tauri-drag-region="false"
+  {...(menuOpen ? { [ESCAPE_OWNER_ATTR]: "" } : {})}
   use:clickOutside={closeMenu}
   onkeydown={handleKey}
 >

--- a/src/client/shell/FormattingBar.svelte
+++ b/src/client/shell/FormattingBar.svelte
@@ -119,6 +119,7 @@ function handleHighlight(color: HighlightColor) {
      drag-region might otherwise capture them. -->
 <div
   class="tandem-fmtbar-wrap"
+  data-testid="formatting-bar-wrap"
   style="position: fixed; top: var(--tandem-fmtbar-top, 52px); left: 0; right: 0; display: flex; justify-content: center; pointer-events: none;"
 >
   <div
@@ -136,16 +137,29 @@ function handleHighlight(color: HighlightColor) {
          they were clipped out of existence: the trigger fired and
          `aria-expanded` flipped, but the menu painted below the clip edge and
          `elementFromPoint` at a menu item resolved to the editor underneath.
-         `clip` rather than `hidden` because only `clip` may pair with
-         `visible`: per CSS Overflow 3, a `visible` paired with `hidden` computes
-         to `auto`, which would make this a scroll container and clip vertically
-         anyway, whereas `visible` paired with `clip` is preserved as specified.
-         Horizontal truncation is byte-for-byte what `hidden` gave us (verified:
-         same track width, no wrapping, buttons past the edge unhittable).
-         Creating no scroll container is a second win — a focused control inside
-         a scrollable track can be scrolled into view, displacing the whole row.
-         Requires Chrome 90 / Safari 16 / Firefox 81; the project already
-         targets safari16.4. -->
+         `clip` rather than `hidden` because a `visible` paired with `hidden`
+         computes to `auto` (CSS Overflow 3), which would make this a scroll
+         container and clip vertically anyway, whereas `visible` paired with
+         `clip` is preserved as specified. That rule is symmetric, and it is the
+         tripwire here: setting EITHER axis to a scrollable value silently
+         computes the other's `visible` to `auto` and its `clip` to `hidden`, so
+         changing `overflow-y` alone re-clips the popovers with no diff on the
+         `clip` line.
+
+         Horizontal truncation behaves identically to `hidden` for this box
+         (verified: same track width, no wrapping, buttons past the edge
+         unhittable). The one behavioural difference is a real trade, not a pure
+         win: `clip` creates no scroll container, so a truncated control that
+         receives keyboard focus can no longer be scrolled into view. Measured:
+         with `hidden`, focusing a clipped button scrolled the track (scrollLeft
+         171) and made it hittable; with `clip` it stays invisible and
+         unhittable. That only bites where the track actually truncates — at
+         viewport widths <= 640px — which the desktop app cannot reach
+         (tauri.conf.json minWidth is 800), so it is confined to the browser
+         distribution at narrow widths. Accepted because the alternative is
+         keeping three popovers unusable for everyone; revisit if the bar ever
+         gains a genuinely narrow target. Requires Chrome 90 / Safari 16 /
+         Firefox 81; the project already targets safari16.4. -->
     <div
       style="display: flex; align-items: center; gap: 1px; overflow-x: clip; overflow-y: visible; min-width: 0;"
     >
@@ -181,7 +195,7 @@ function handleHighlight(color: HighlightColor) {
       </button>
     {/if}
     {#if onHide}
-      <!-- Outside the overflow:hidden track so it never truncates. Hiding the
+      <!-- Outside the clipped track so it never truncates. Hiding the
            bar leaves formatting reachable via the always-full selection popup;
            restore via the command palette or Appearance settings. -->
       <div class="fmtbar-divider"></div>
@@ -208,21 +222,30 @@ function handleHighlight(color: HighlightColor) {
      context, so it would paint behind the selection pill. Lift the whole
      wrapper while any popover inside it is open.
 
-     Keyed on `aria-expanded` rather than on per-popover props (#1302). Every
-     trigger in here already publishes that state for assistive tech — the
-     heading menu, link editor, highlight sub-menu and Decorations menu — so the
-     rule covers all four by construction. The previous version was wired to the
-     highlight sub-menu alone and silently did not cover the other three; an
-     enumerated list of popovers is exactly the thing that goes stale when the
-     fifth one is added. Must live here rather than in the inline style
-     attribute, which would outrank it. */
+     Keyed on `aria-expanded` rather than on per-popover props (#1302). All four
+     popovers the bar owns publish that state for assistive tech — heading menu
+     and link editor (via ToolbarButton), Decorations menu, and the highlight
+     sub-menu, whose attribute was added in #1302 precisely so this rule covers
+     it too. The previous version was an inline ternary wired to the highlight
+     sub-menu alone and silently did not cover the other three; an enumerated
+     list of popovers is exactly the thing that goes stale when the fifth one is
+     added. Must live here rather than in the inline style attribute, which
+     would outrank it regardless of specificity. */
   .tandem-fmtbar-wrap {
     z-index: var(--tandem-z-sticky);
   }
   /* `:global()` inside `:has()` because the expanded state is set at runtime on
      descendants owned by child components; Svelte's CSS pruner cannot prove the
      match and would drop this rule as unused, which `svelte-check
-     --fail-on-warnings` turns into a build failure. */
+     --fail-on-warnings` turns into a build failure.
+
+     Support note, because the overflow comment above states a floor and this is
+     the HIGHER one: `:has()` needs Chrome 105 / Safari 15.4 / Firefox 121, and
+     that Firefox floor sits above the declared `firefox114` cssTarget.
+     Acceptable because the shipped surfaces are WebView2 and WKWebView and the
+     browser distribution is deprecated (#477 PR 2) — and because a non-matching
+     `:has()` degrades to the un-lifted z-index (dropdown paints behind the
+     selection pill) rather than to a broken bar. */
   .tandem-fmtbar-wrap:has(:global([aria-expanded="true"])) {
     z-index: var(--tandem-z-toast);
   }

--- a/src/client/shell/FormattingBar.svelte
+++ b/src/client/shell/FormattingBar.svelte
@@ -161,6 +161,7 @@ function handleHighlight(color: HighlightColor) {
          gains a genuinely narrow target. Requires Chrome 90 / Safari 16 /
          Firefox 81; the project already targets safari16.4. -->
     <div
+      data-testid="formatting-bar-track"
       style="display: flex; align-items: center; gap: 1px; overflow-x: clip; overflow-y: visible; min-width: 0;"
     >
       <FormattingToolbar {editor} />

--- a/src/client/shell/FormattingBar.svelte
+++ b/src/client/shell/FormattingBar.svelte
@@ -88,13 +88,6 @@ const canHighlight = $derived.by(() => {
   return !editor.state.selection.empty;
 });
 
-// #1024: the bar is a fixed wrapper that creates its own stacking context at
-// --tandem-z-sticky (below the selection popup at --tandem-z-modal). A dropdown
-// opened from the bar is trapped in that context, so it renders BEHIND the
-// selection pill. While the highlight color sub-menu is open, lift the wrapper
-// above the selection popup so the sub-menu paints fully clear of the pill.
-let highlightPickerOpen = $state(false);
-
 function handleHighlight(color: HighlightColor) {
   if (!editor || !ydoc || editor.isDestroyed) return;
   const { state } = editor;
@@ -126,26 +119,39 @@ function handleHighlight(color: HighlightColor) {
      drag-region might otherwise capture them. -->
 <div
   class="tandem-fmtbar-wrap"
-  style="position: fixed; top: var(--tandem-fmtbar-top, 52px); left: 0; right: 0; display: flex; justify-content: center; pointer-events: none; z-index: {highlightPickerOpen ? 'var(--tandem-z-toast)' : 'var(--tandem-z-sticky)'};"
+  style="position: fixed; top: var(--tandem-fmtbar-top, 52px); left: 0; right: 0; display: flex; justify-content: center; pointer-events: none;"
 >
   <div
     data-testid="formatting-bar"
     class="tandem-floating-pill"
     style="display: inline-flex; align-items: center; padding: var(--tandem-space-1); user-select: none; pointer-events: auto; -webkit-app-region: no-drag; max-width: calc(100% - var(--tandem-space-6));"
   >
-    <!-- The format controls live in an overflow:hidden track so a narrow
-         window truncates buttons rather than wrapping. The Decorations split
-         button is intentionally OUTSIDE that track: it must never truncate,
-         and its dropdown (which drops below the pill) would otherwise be
-         clipped by the track's overflow:hidden. -->
-    <div style="display: flex; align-items: center; gap: 1px; overflow: hidden; min-width: 0;">
+    <!-- The format controls live in a clipped track so a narrow window
+         truncates buttons rather than wrapping. The Decorations split button is
+         intentionally OUTSIDE that track: it must never truncate.
+
+         The axis split is load-bearing (#1302). This was `overflow: hidden`,
+         which clips BOTH axes — and the heading menu, highlight color picker
+         and link editor are `position: absolute` popovers inside this track, so
+         they were clipped out of existence: the trigger fired and
+         `aria-expanded` flipped, but the menu painted below the clip edge and
+         `elementFromPoint` at a menu item resolved to the editor underneath.
+         `clip` rather than `hidden` because only `clip` may pair with
+         `visible`: per CSS Overflow 3, a `visible` paired with `hidden` computes
+         to `auto`, which would make this a scroll container and clip vertically
+         anyway, whereas `visible` paired with `clip` is preserved as specified.
+         Horizontal truncation is byte-for-byte what `hidden` gave us (verified:
+         same track width, no wrapping, buttons past the edge unhittable).
+         Creating no scroll container is a second win — a focused control inside
+         a scrollable track can be scrolled into view, displacing the whole row.
+         Requires Chrome 90 / Safari 16 / Firefox 81; the project already
+         targets safari16.4. -->
+    <div
+      style="display: flex; align-items: center; gap: 1px; overflow-x: clip; overflow-y: visible; min-width: 0;"
+    >
       <FormattingToolbar {editor} />
       <div class="fmtbar-divider"></div>
-      <HighlightColorPicker
-        disabled={!canHighlight}
-        onHighlight={handleHighlight}
-        onOpenChange={(open) => (highlightPickerOpen = open)}
-      />
+      <HighlightColorPicker disabled={!canHighlight} onHighlight={handleHighlight} />
     </div>
     {#if onUpdateDecorations}
       <div class="fmtbar-divider"></div>
@@ -196,6 +202,30 @@ function handleHighlight(color: HighlightColor) {
 </div>
 
 <style>
+  /* #1024/#1036: the bar is a fixed wrapper that creates its own stacking
+     context at --tandem-z-sticky, BELOW the selection popup at
+     --tandem-z-modal. A dropdown opened from the bar is trapped in that
+     context, so it would paint behind the selection pill. Lift the whole
+     wrapper while any popover inside it is open.
+
+     Keyed on `aria-expanded` rather than on per-popover props (#1302). Every
+     trigger in here already publishes that state for assistive tech — the
+     heading menu, link editor, highlight sub-menu and Decorations menu — so the
+     rule covers all four by construction. The previous version was wired to the
+     highlight sub-menu alone and silently did not cover the other three; an
+     enumerated list of popovers is exactly the thing that goes stale when the
+     fifth one is added. Must live here rather than in the inline style
+     attribute, which would outrank it. */
+  .tandem-fmtbar-wrap {
+    z-index: var(--tandem-z-sticky);
+  }
+  /* `:global()` inside `:has()` because the expanded state is set at runtime on
+     descendants owned by child components; Svelte's CSS pruner cannot prove the
+     match and would drop this rule as unused, which `svelte-check
+     --fail-on-warnings` turns into a build failure. */
+  .tandem-fmtbar-wrap:has(:global([aria-expanded="true"])) {
+    z-index: var(--tandem-z-toast);
+  }
   .fmtbar-divider {
     width: 1px;
     height: 16px;

--- a/src/client/utils/escape-owner.ts
+++ b/src/client/utils/escape-owner.ts
@@ -1,0 +1,36 @@
+/**
+ * Escape ownership for nested popovers.
+ *
+ * `Toolbar.svelte`'s selection popup registers its Escape handler at `window`
+ * in the CAPTURE phase and calls `stopPropagation()`, so it preempts every
+ * handler inside the document — including a popover's own dismissal. Capture
+ * order is fixed (window is the first target in the propagation path), so a
+ * nested popover cannot win by registering capture too, and registration order
+ * is not a contract either. The nested popover therefore MARKS its subtree with
+ * `ESCAPE_OWNER_ATTR` while it is open, and the window-level handler yields when
+ * the Escape originated inside that subtree.
+ *
+ * Scoped to the event's origin on purpose: a popover only claims Escape while
+ * focus is actually inside it. A mouse-opened popover leaves focus in the editor
+ * (its trigger calls `preventDefault()` on mousedown), and there Escape still
+ * dismisses the selection popup first — the behaviour that ships today, and the
+ * behaviour `tests/e2e/formatting-bar-popovers.spec.ts` relies on when it
+ * dismisses a mouse-opened heading menu by clicking away.
+ *
+ * Claimants today are the four popovers the persistent formatting bar owns: the
+ * highlight colour picker (`HighlightColorPicker.svelte`), the link editor and
+ * heading menu (`FormattingToolbar.svelte`) and the decorations menu
+ * (`DecorationsMenu.svelte`). They are marked as a set deliberately — an
+ * enumerated subset is exactly the thing that goes stale, and all four carry the
+ * same wrapper-scoped Escape handler that the capture listener swallows. Any new
+ * popover that owns Escape should set the attribute while open.
+ */
+export const ESCAPE_OWNER_ATTR = "data-tandem-escape-owner";
+
+/**
+ * True when `target` sits inside a subtree that has claimed Escape. Non-Element
+ * targets (`window`, `document`, `null`) never claim.
+ */
+export function escapeIsClaimed(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest(`[${ESCAPE_OWNER_ATTR}]`) !== null;
+}

--- a/tests/client/escape-owner.test.ts
+++ b/tests/client/escape-owner.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+
+/**
+ * `escapeIsClaimed` is the predicate that lets a nested popover keep its own
+ * Escape while `Toolbar.svelte`'s capture-phase `window` listener is armed.
+ * Its whole contract is "did this event originate inside a marked subtree",
+ * so the edge cases worth pinning are the non-Element targets (the listener
+ * really does see `window` and `document` as targets) and the sibling subtree.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { ESCAPE_OWNER_ATTR, escapeIsClaimed } from "../../src/client/utils/escape-owner";
+
+function build(): { owner: HTMLElement; child: HTMLElement; sibling: HTMLElement } {
+  document.body.innerHTML = `
+    <div id="owner" ${ESCAPE_OWNER_ATTR}><button id="child">x</button></div>
+    <div id="sibling"><button id="other">y</button></div>
+  `;
+  return {
+    owner: document.getElementById("owner") as HTMLElement,
+    child: document.getElementById("child") as HTMLElement,
+    sibling: document.getElementById("other") as HTMLElement,
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("escapeIsClaimed", () => {
+  it("claims the marked element itself", () => {
+    expect(escapeIsClaimed(build().owner)).toBe(true);
+  });
+
+  it("claims a descendant of the marked element", () => {
+    expect(escapeIsClaimed(build().child)).toBe(true);
+  });
+
+  it("does not claim a sibling subtree", () => {
+    expect(escapeIsClaimed(build().sibling)).toBe(false);
+  });
+
+  it("does not claim once the marker is removed (the closed state)", () => {
+    const { owner, child } = build();
+    owner.removeAttribute(ESCAPE_OWNER_ATTR);
+    expect(escapeIsClaimed(child)).toBe(false);
+  });
+
+  it("does not claim non-Element targets", () => {
+    build();
+    expect(escapeIsClaimed(null)).toBe(false);
+    expect(escapeIsClaimed(window)).toBe(false);
+    expect(escapeIsClaimed(document)).toBe(false);
+  });
+});

--- a/tests/client/highlight-color-picker-keyboard.test.ts
+++ b/tests/client/highlight-color-picker-keyboard.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment happy-dom
+
+/**
+ * Mounted keyboard/focus regression net for HighlightColorPicker.
+ *
+ * #1304 is what makes this menu keyboard-operable at all (before it, the
+ * trigger had only `onmousedown`, so Enter/Space did nothing). Everything
+ * asserted here is a property that arrived with that: the `detail === 0`
+ * activation route, focus restored to the trigger on every deliberate
+ * dismissal, focus-out dismissal, and the Escape hand-off with the selection
+ * popup's capture-phase `window` listener.
+ *
+ * A mounted unit test rather than an E2E addition on purpose: the E2E spec's
+ * own header documents that headless ProseMirror loses the selection around
+ * synthesised clicks, which is exactly what puts this flow out of reach there.
+ * happy-dom models focus, `relatedTarget` and event-phase ordering faithfully
+ * enough for all of it.
+ */
+
+import { fireEvent } from "@testing-library/dom";
+import { cleanup, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import HighlightColorPicker from "../../src/client/editor/toolbar/HighlightColorPicker.svelte";
+import { escapeIsClaimed } from "../../src/client/utils/escape-owner";
+
+afterEach(() => cleanup());
+
+function mount(props: Partial<{ disabled: boolean; onHighlight: (c: string) => void }> = {}) {
+  const onHighlight = vi.fn();
+  const result = render(HighlightColorPicker, {
+    props: { disabled: false, onHighlight, ...props },
+  });
+  const toggle = document.querySelector(
+    "[data-testid='toolbar-highlight-color-toggle']",
+  ) as HTMLButtonElement;
+  return { ...result, onHighlight, toggle };
+}
+
+/** Enter/Space on a focused native button — a click with `detail === 0`. */
+const keyClick = (el: Element) => fireEvent.click(el, { detail: 0 });
+/** A real pointer click — `detail === 1`; the mouse path owns this via mousedown. */
+const mouseClick = (el: Element) => fireEvent.click(el, { detail: 1 });
+
+const popover = () => document.querySelector(".highlight-picker-popover");
+
+describe("HighlightColorPicker keyboard operation", () => {
+  it("Enter/Space on the trigger opens the menu; a mouse click does not toggle it back", async () => {
+    const { toggle } = mount();
+    expect(popover()).toBeNull();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    await keyClick(toggle);
+    expect(popover()).not.toBeNull();
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    // The mouse route runs off `mousedown`; if `click` also fired the toggle the
+    // menu would close again the instant the button was released.
+    await mouseClick(toggle);
+    expect(popover()).not.toBeNull();
+  });
+
+  it("selecting a swatch closes the menu and returns focus to the trigger", async () => {
+    const { toggle } = mount();
+    await keyClick(toggle);
+
+    const pink = document.querySelector(
+      "[data-testid='toolbar-highlight-color-pink']",
+    ) as HTMLButtonElement;
+    pink.focus();
+    await keyClick(pink);
+
+    expect(popover()).toBeNull();
+    // Without the focus restore the focused button is unmounted and
+    // activeElement falls to <body>, so the next Tab restarts from the top of
+    // the document.
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it("the close button closes the menu and returns focus to the trigger", async () => {
+    const { toggle } = mount();
+    await keyClick(toggle);
+
+    const close = document.querySelector("[data-testid='color-picker-close']") as HTMLButtonElement;
+    close.focus();
+    await keyClick(close);
+
+    expect(popover()).toBeNull();
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it("Escape closes the picker and is NOT consumed by the selection popup's capture listener", async () => {
+    const { toggle } = mount();
+    await keyClick(toggle);
+
+    // Replica of Toolbar.svelte's selection-popup handler (capture phase at
+    // `window`, stopPropagation on Escape) — including its yield. Without the
+    // yield the picker's own bubble-phase handler never runs and the user's
+    // first Escape dismisses the POPUP instead of the menu they just opened.
+    let popupDismissed = false;
+    const onWindowKey = (e: Event) => {
+      const ke = e as KeyboardEvent;
+      if (ke.key !== "Escape") return;
+      if (escapeIsClaimed(ke.target)) return;
+      ke.stopPropagation();
+      popupDismissed = true;
+    };
+    window.addEventListener("keydown", onWindowKey, { capture: true });
+    try {
+      const yellow = document.querySelector(
+        "[data-testid='toolbar-highlight-color-yellow']",
+      ) as HTMLButtonElement;
+      yellow.focus();
+      await fireEvent.keyDown(yellow, { key: "Escape", bubbles: true });
+
+      expect(popupDismissed).toBe(false);
+      expect(popover()).toBeNull();
+      expect(document.activeElement).toBe(toggle);
+
+      // Control: with the picker closed the wrap no longer claims Escape, so the
+      // popup handler runs exactly as it does today.
+      await fireEvent.keyDown(document.body, { key: "Escape", bubbles: true });
+      expect(popupDismissed).toBe(true);
+    } finally {
+      window.removeEventListener("keydown", onWindowKey, { capture: true });
+    }
+  });
+
+  it("focus leaving the wrap closes the menu; focus moving within it does not", async () => {
+    const { toggle } = mount();
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+
+    await keyClick(toggle);
+    const wrap = document.querySelector(".highlight-picker-wrap") as HTMLElement;
+    const yellow = document.querySelector(
+      "[data-testid='toolbar-highlight-color-yellow']",
+    ) as HTMLButtonElement;
+
+    await fireEvent.focusOut(wrap, { relatedTarget: yellow });
+    expect(popover(), "focus moving inside the wrap must not dismiss").not.toBeNull();
+
+    await fireEvent.focusOut(wrap, { relatedTarget: outside });
+    // A keyboard user Tabbing past the popover has no other dismissal: Escape
+    // needs focus inside, and the outside-mousedown guard never fires.
+    expect(popover()).toBeNull();
+
+    outside.remove();
+  });
+
+  it("the Highlight button itself is keyboard-activatable", async () => {
+    const { onHighlight } = mount();
+    const highlight = document.querySelector(
+      "[data-testid='toolbar-highlight-btn']",
+    ) as HTMLButtonElement;
+
+    await mouseClick(highlight);
+    expect(onHighlight, "mouse route runs off mousedown, not click").not.toHaveBeenCalled();
+
+    await keyClick(highlight);
+    expect(onHighlight).toHaveBeenCalledWith("yellow");
+  });
+
+  it("a disabled trigger publishes no aria-expanded, so the bar's z-lift cannot stick", async () => {
+    const { toggle, rerender } = mount();
+    await keyClick(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    // A selection collapse disables the control without closing the menu.
+    // FormattingBar lifts the whole bar to --tandem-z-toast while any descendant
+    // reports aria-expanded="true"; a disabled button must not hold that open.
+    await rerender({ disabled: true, onHighlight: vi.fn() });
+    expect(toggle.hasAttribute("aria-expanded")).toBe(false);
+  });
+});

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -173,6 +173,7 @@ font-by-extension-{*}-{*}
 formatbar-hide-btn
 formatbar-source-toggle
 formatting-bar
+formatting-bar-wrap
 harness-acknowledge
 harness-banner-dismiss
 harness-banner-version

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -173,6 +173,7 @@ font-by-extension-{*}-{*}
 formatbar-hide-btn
 formatbar-source-toggle
 formatting-bar
+formatting-bar-track
 formatting-bar-wrap
 harness-acknowledge
 harness-banner-dismiss

--- a/tests/design-system-impl/css-pipeline-contract.test.ts
+++ b/tests/design-system-impl/css-pipeline-contract.test.ts
@@ -208,6 +208,38 @@ describe("bundled CSS: writing the standard property alone is still the safe adv
   });
 });
 
+describe("bundled CSS: the #1302 formatting-bar declarations survive minification", () => {
+  it("preserves the :has() z-lift selector", () => {
+    // FormattingBar.svelte's wrap lift keys on `:has([aria-expanded="true"])`,
+    // and that rule DOES live in a component <style> block, so it really does
+    // ship through lightningcss. A future Vite/lightningcss bump that rewrites
+    // or drops it re-buries every formatting-bar popover behind the selection
+    // popup — and no E2E test would catch it, because Playwright drives
+    // `npm run dev`, which never minifies.
+    const out = minify('.w:has([aria-expanded="true"]){z-index:9}');
+    expect(out).toContain(":has(");
+    expect(out).toContain("aria-expanded");
+  });
+
+  it("keeps overflow-x: clip / overflow-y: visible as a clip+visible pair", () => {
+    // Forward-looking cover, stated plainly: today these two declarations live
+    // in FormattingBar's inline `style=` attribute and therefore never reach
+    // lightningcss at all. This exists so that moving them into the <style>
+    // block — the tidy-up CLAUDE.md's two-pipeline guidance invites — does not
+    // have to re-litigate the axis split.
+    //
+    // The invariant is the axis split, not the syntax: folding the two longhands
+    // into the shorthand is benign and either form passes. Folding EITHER axis
+    // to `hidden`/`auto` is not — a scrollable value on one axis silently
+    // computes the other's `visible` to `auto` (CSS Overflow 3), which re-clips
+    // the popovers.
+    const out = minify(".p{overflow-x:clip;overflow-y:visible}");
+    expect(out).toMatch(/overflow:\s*clip visible|overflow-x:\s*clip/);
+    expect(out).not.toContain("hidden");
+    expect(out).not.toContain("auto");
+  });
+});
+
 /** Every `.svelte` `<style>` / `.css` file whose CSS the build routes through lightningcss. */
 function bundledCssFiles(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {

--- a/tests/e2e/formatting-bar-popovers.spec.ts
+++ b/tests/e2e/formatting-bar-popovers.spec.ts
@@ -49,7 +49,31 @@ async function openFixture(page: import("@playwright/test").Page) {
   await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
   await page.goto("/");
   await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+  // Wait for CONTENT, not just the mount. `.tandem-editor` is the ProseMirror
+  // contenteditable and it mounts before the Y.Doc syncs over Hocuspocus, so
+  // `locator("p").first()` can otherwise resolve to an empty placeholder — the
+  // selection then covers nothing, `canHighlight` stays false, and the
+  // selection-gated controls never enable. Every other spec in this suite waits
+  // on text for the same reason.
+  await expect(page.locator(".tandem-editor")).toContainText("first paragraph", {
+    timeout: 10_000,
+  });
   await expect(page.locator("[data-testid='formatting-bar']")).toBeVisible({ timeout: 10_000 });
+}
+
+/** Computed z-index of the bar's fixed wrapper — the element the lift applies to. */
+async function wrapZIndex(page: import("@playwright/test").Page): Promise<string> {
+  return page
+    .locator("[data-testid='formatting-bar-wrap']")
+    .evaluate((el) => getComputedStyle(el).zIndex);
+}
+
+/** Resolve a design token to its numeric value so assertions never hardcode one. */
+async function tokenValue(page: import("@playwright/test").Page, name: string): Promise<string> {
+  return page.evaluate(
+    (n) => getComputedStyle(document.documentElement).getPropertyValue(n).trim(),
+    name,
+  );
 }
 
 test("heading dropdown in the persistent bar is visible and clickable", async ({ page }) => {
@@ -89,16 +113,6 @@ test("heading dropdown in the persistent bar is visible and clickable", async ({
   });
   expect(inViewport).toBe(true);
 
-  // The bar must outrank the selection popup while a popover is open, or the
-  // menu paints behind it (#1024/#1036). The lift keys on `aria-expanded`, so
-  // it covers every popover in the bar rather than an enumerated list.
-  const lifted = await page.locator(".tandem-fmtbar-wrap").evaluate((el) => {
-    const z = getComputedStyle(el).zIndex;
-    const popupZ = getComputedStyle(document.documentElement).getPropertyValue("--tandem-z-modal");
-    return Number(z) > Number(popupZ.trim());
-  });
-  expect(lifted).toBe(true);
-
   // Clicking it applies the format — the end-to-end proof.
   await item.click();
   await expect(editor.locator("h2", { hasText: "first paragraph" })).toBeVisible({
@@ -112,7 +126,11 @@ test("highlight color picker in the persistent bar is visible and clickable", as
   const bar = page.locator("[data-testid='formatting-bar']");
   const editor = page.locator(".tandem-editor");
 
-  // The color toggle is disabled without a selection (canHighlight).
+  // The click is a prerequisite, not decoration: ProseMirror's DOMObserver
+  // ignores `selectionchange` unless the view owns focus, so without it
+  // `editor.state.selection` stays empty and the selection-gated controls never
+  // enable. Same pairing as accessibility.spec.ts and six other specs.
+  await editor.click();
   await editor.locator("p").first().selectText();
 
   const toggle = bar.locator("[data-testid='toolbar-highlight-color-toggle']");
@@ -150,10 +168,11 @@ test("highlight color picker in the persistent bar is visible and clickable", as
   }
 
   // Deliberately NOT asserting that a highlight gets applied here.
-  // toolbar-redesign.spec.ts documents that clicking the color toggle makes
-  // ProseMirror clear the text selection before the swatch panel renders, which
-  // puts the apply-a-color flow out of reach in headless CI regardless of
-  // `preventDefault`. That limitation is orthogonal to #1302: this bug is about
+  // toolbar-redesign.spec.ts documents the same ROOT CAUSE surfacing one step
+  // later — headless ProseMirror loses the selection around a synthesised click,
+  // which there costs the follow-up swatch click and here would cost the
+  // trigger's own mousedown. Either way the apply-a-color flow is out of reach
+  // in headless CI. That limitation is orthogonal to #1302: this bug is about
   // the popover's geometry, and the assertions above test exactly that. The
   // recolor behaviour itself is covered by tests/client/highlight-toggle.test.ts.
 });
@@ -164,20 +183,22 @@ test("link editor in the persistent bar is not clipped by the format track", asy
   const bar = page.locator("[data-testid='formatting-bar']");
   const editor = page.locator(".tandem-editor");
 
+  await editor.click();
   await editor.locator("p").first().selectText();
-  // Dispatched for the same reason as the color toggle above: the Link control
-  // is disabled without a selection, and headless loses the selection during
-  // Playwright's click synthesis.
-  await bar.getByRole("button", { name: "Link", exact: true }).dispatchEvent("mousedown");
+  // Dispatched for the same reason as the color toggle above. Precedent:
+  // accessibility.spec.ts drives this exact button the same way.
+  await bar
+    .getByRole("button", { name: "Link", exact: true })
+    .dispatchEvent("mousedown", { bubbles: true, cancelable: true });
 
   const input = bar.locator("[data-testid='toolbar-link-input']");
   await expect(input).toBeVisible();
 
-  // The dialog must own every one of its own corners. Hit-testing (rather than
-  // comparing rects against clipping ancestors) is what stays correct after the
-  // fix: a `position: fixed` popover legitimately extends past an ancestor's
-  // overflow box without being clipped by it, so a rect comparison would report
-  // a false failure while a hit test reports the truth the user experiences.
+  // The dialog must own every one of its own corners. Hit-testing beats
+  // comparing rects against clipping ancestors because a rect comparison would
+  // have to re-derive which ancestors actually clip this element — the very
+  // logic under test — whereas a hit test reports what the user experiences and
+  // stays correct however the fix is implemented.
   const ownsItsCorners = await input.evaluate((el) => {
     const dialog = el.closest("[role='dialog']") as HTMLElement | null;
     if (!dialog) return false;
@@ -199,4 +220,77 @@ test("link editor in the persistent bar is not clipped by the format track", asy
   // Escape must still dismiss it (the wrapper keydown handler).
   await page.keyboard.press("Escape");
   await expect(input).toBeHidden();
+});
+
+test("bar lifts above the selection popup only while a popover is open", async ({ page }) => {
+  await openFixture(page);
+
+  const bar = page.locator("[data-testid='formatting-bar']");
+  const editor = page.locator(".tandem-editor");
+
+  // Asserted as a PAIR. A rule that lifted unconditionally would satisfy a
+  // lift-only check while leaving the bar floating over unrelated chrome, so the
+  // closed state is as load-bearing as the open one.
+  const sticky = await tokenValue(page, "--tandem-z-sticky");
+  const toast = await tokenValue(page, "--tandem-z-toast");
+  const modal = await tokenValue(page, "--tandem-z-modal");
+  expect(Number(toast)).toBeGreaterThan(Number(modal));
+
+  await editor.locator("p").first().click();
+  expect(await wrapZIndex(page), "closed: bar must not outrank the popup").toBe(sticky);
+
+  await bar.getByRole("button", { name: "Heading", exact: true }).click();
+  await expect(page.getByRole("menu", { name: "Heading level" })).toBeVisible();
+  expect(await wrapZIndex(page), "heading menu open: bar must lift").toBe(toast);
+
+  // Dismissed by clicking away, not Escape. The trigger's mousedown calls
+  // preventDefault so the editor keeps focus and the ProseMirror selection
+  // survives — which also means the wrapper's Escape keydown never fires for a
+  // mouse-opened menu. clickOutside is the dismissal path that actually applies
+  // here, and releasing the lift on close is the half being asserted.
+  await editor.locator("p").first().click();
+  await expect(page.getByRole("menu", { name: "Heading level" })).toBeHidden();
+  expect(await wrapZIndex(page), "closed again: lift must release").toBe(sticky);
+
+  // The refactor's whole claim is that the lift keys on `aria-expanded` and so
+  // covers every popover the bar owns, not an enumerated list. Prove it on a
+  // second, independently-implemented one (Decorations lives OUTSIDE the clipped
+  // track, so it exercises a different DOM path to the same rule).
+  await bar.locator("[data-testid='decorations-menu-caret']").click();
+  await expect(page.locator("[data-testid='decorations-menu']")).toBeVisible();
+  expect(await wrapZIndex(page), "decorations menu open: bar must lift").toBe(toast);
+});
+
+test("format track truncates rather than wrapping, and never scrolls", async ({ page }) => {
+  await openFixture(page);
+
+  // The changed declaration is `overflow-x: clip` in place of `overflow: hidden`.
+  // Truncation is the property `hidden` was there for, so it needs its own net —
+  // every other test here would stay green if the bar started wrapping into two
+  // rows or grew a scrollbar. `scrollLeft` is the one observable that actually
+  // distinguishes `clip` from `hidden`: both truncate, only `hidden` scrolls.
+  const track = page.locator("[data-testid='formatting-bar'] > div").first();
+  const singleRowHeight = await track.evaluate((el) => el.getBoundingClientRect().height);
+
+  await page.setViewportSize({ width: 640, height: 800 });
+  await expect(page.locator("[data-testid='formatting-bar']")).toBeVisible();
+
+  const narrow = await track.evaluate((el) => {
+    const before = el.scrollLeft;
+    el.scrollLeft = 9999;
+    const scrolled = el.scrollLeft;
+    el.scrollLeft = before;
+    return {
+      truncated: el.scrollWidth > el.clientWidth + 1,
+      scrollable: scrolled > 0,
+      height: el.getBoundingClientRect().height,
+    };
+  });
+
+  expect(narrow.truncated, "track should overflow its box at 640px").toBe(true);
+  expect(narrow.scrollable, "clip must not create a scroll container").toBe(false);
+  expect(narrow.height, "track must truncate, not wrap to a second row").toBeCloseTo(
+    singleRowHeight,
+    0,
+  );
 });

--- a/tests/e2e/formatting-bar-popovers.spec.ts
+++ b/tests/e2e/formatting-bar-popovers.spec.ts
@@ -76,6 +76,46 @@ async function tokenValue(page: import("@playwright/test").Page, name: string): 
   );
 }
 
+/**
+ * Does this element actually receive clicks at its own centre? The load-bearing
+ * assertion for #1302: a clipped element still reports a non-empty box, so
+ * `toBeVisible()` passes on a popover the user can neither see nor click.
+ */
+async function ownsItsPixels(locator: import("@playwright/test").Locator): Promise<boolean> {
+  return locator.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+    return !!hit && el.contains(hit);
+  });
+}
+
+/**
+ * The same property at all four corners of the passed element's owning dialog —
+ * for wide popovers where only an edge is clipped and a centre hit test passes.
+ * The dialog is resolved with `closest()` from the passed element rather than
+ * located independently: `LinkEditor` has three mount sites on one page (the
+ * persistent bar, the selection popup, the editor's context menu), so a bare
+ * `[role='dialog']` locator would be ambiguous.
+ */
+async function ownsItsCorners(locator: import("@playwright/test").Locator): Promise<boolean> {
+  return locator.evaluate((el) => {
+    const dialog = el.closest("[role='dialog']") as HTMLElement | null;
+    if (!dialog) return false;
+    const d = dialog.getBoundingClientRect();
+    const inset = 4;
+    const corners: Array<[number, number]> = [
+      [d.left + inset, d.top + inset],
+      [d.right - inset, d.top + inset],
+      [d.left + inset, d.bottom - inset],
+      [d.right - inset, d.bottom - inset],
+    ];
+    return corners.every(([x, y]) => {
+      const hit = document.elementFromPoint(x, y);
+      return !!hit && dialog.contains(hit);
+    });
+  });
+}
+
 test("heading dropdown in the persistent bar is visible and clickable", async ({ page }) => {
   await openFixture(page);
 
@@ -97,12 +137,7 @@ test("heading dropdown in the persistent bar is visible and clickable", async ({
 
   // The regression assertion: the menu item must actually own its own pixels.
   // Before the fix this resolved to the editor's scroll container.
-  const ownsItsPixels = await item.evaluate((el) => {
-    const r = el.getBoundingClientRect();
-    const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
-    return !!hit && el.contains(hit);
-  });
-  expect(ownsItsPixels).toBe(true);
+  expect(await ownsItsPixels(item)).toBe(true);
 
   // And the menu must sit inside the viewport, not off the bottom/right edge.
   const inViewport = await menu.evaluate((el) => {
@@ -159,12 +194,7 @@ test("highlight color picker in the persistent bar is visible and clickable", as
   ]) {
     const control = page.locator(`[data-testid='${id}']`);
     await expect(control).toBeVisible();
-    const ownsItsPixels = await control.evaluate((el) => {
-      const r = el.getBoundingClientRect();
-      const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
-      return !!hit && el.contains(hit);
-    });
-    expect(ownsItsPixels, `${id} is not clickable`).toBe(true);
+    expect(await ownsItsPixels(control), `${id} is not clickable`).toBe(true);
   }
 
   // Deliberately NOT asserting that a highlight gets applied here.
@@ -199,23 +229,7 @@ test("link editor in the persistent bar is not clipped by the format track", asy
   // have to re-derive which ancestors actually clip this element — the very
   // logic under test — whereas a hit test reports what the user experiences and
   // stays correct however the fix is implemented.
-  const ownsItsCorners = await input.evaluate((el) => {
-    const dialog = el.closest("[role='dialog']") as HTMLElement | null;
-    if (!dialog) return false;
-    const d = dialog.getBoundingClientRect();
-    const inset = 4;
-    const corners: Array<[number, number]> = [
-      [d.left + inset, d.top + inset],
-      [d.right - inset, d.top + inset],
-      [d.left + inset, d.bottom - inset],
-      [d.right - inset, d.bottom - inset],
-    ];
-    return corners.every(([x, y]) => {
-      const hit = document.elementFromPoint(x, y);
-      return !!hit && dialog.contains(hit);
-    });
-  });
-  expect(ownsItsCorners).toBe(true);
+  expect(await ownsItsCorners(input)).toBe(true);
 
   // Escape must still dismiss it (the wrapper keydown handler).
   await page.keyboard.press("Escape");
@@ -269,7 +283,7 @@ test("format track truncates rather than wrapping, and never scrolls", async ({ 
   // every other test here would stay green if the bar started wrapping into two
   // rows or grew a scrollbar. `scrollLeft` is the one observable that actually
   // distinguishes `clip` from `hidden`: both truncate, only `hidden` scrolls.
-  const track = page.locator("[data-testid='formatting-bar'] > div").first();
+  const track = page.locator("[data-testid='formatting-bar-track']");
   const singleRowHeight = await track.evaluate((el) => el.getBoundingClientRect().height);
 
   await page.setViewportSize({ width: 640, height: 800 });

--- a/tests/e2e/formatting-bar-popovers.spec.ts
+++ b/tests/e2e/formatting-bar-popovers.spec.ts
@@ -1,0 +1,202 @@
+import { expect, test } from "@playwright/test";
+import path from "path";
+import {
+  cleanupAllOpenDocuments,
+  cleanupFixtureDir,
+  createFixtureDir,
+  McpTestClient,
+} from "./helpers";
+
+/**
+ * Regression net for #1302 — popovers owned by the PERSISTENT formatting bar
+ * (`data-testid="formatting-bar"`) were rendered inside an `overflow: hidden`
+ * track (`FormattingBar.svelte`), which clipped them out of existence: the
+ * trigger fired and `aria-expanded` flipped, but the menu painted below the
+ * track's clip edge and `elementFromPoint` at a menu item resolved to the
+ * editor underneath, so clicks moved the caret instead of applying the format.
+ *
+ * Why this file exists at all: the only pre-existing coverage of the heading
+ * dropdown (`toolbar-redesign.spec.ts`) drives the SELECTION POPUP variant,
+ * whose ancestors drop their clip (`Toolbar.svelte`) — so it passed throughout.
+ * These tests deliberately scope every locator to the persistent bar.
+ *
+ * The hit-test assertions are the load-bearing ones, and they are written to
+ * outlive the implementation. A visibility check alone would NOT have caught
+ * the original bug: an element clipped by an ancestor's overflow still reports
+ * a non-empty box, so `toBeVisible` passes on a popover the user cannot see or
+ * click. Asserting that a hit test at the element's own coordinates resolves
+ * back to that element is the property that actually matters, and it holds
+ * regardless of whether the fix is a CSS axis split or JS repositioning.
+ */
+
+let mcp: McpTestClient;
+let tmpDir: string;
+
+test.beforeEach(async () => {
+  mcp = new McpTestClient();
+  await mcp.connect();
+  tmpDir = createFixtureDir("sample.md");
+});
+
+test.afterEach(async () => {
+  await cleanupAllOpenDocuments(mcp);
+  await mcp.close();
+  cleanupFixtureDir(tmpDir);
+});
+
+/** Open the fixture and wait for the editor + persistent bar to be live. */
+async function openFixture(page: import("@playwright/test").Page) {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("[data-testid='formatting-bar']")).toBeVisible({ timeout: 10_000 });
+}
+
+test("heading dropdown in the persistent bar is visible and clickable", async ({ page }) => {
+  await openFixture(page);
+
+  const bar = page.locator("[data-testid='formatting-bar']");
+  const editor = page.locator(".tandem-editor");
+
+  // Put the caret in the first paragraph so toggleHeading has a target.
+  await editor.locator("p").first().click();
+
+  // The trigger renders a serif "H" glyph but carries the accessible name
+  // "Heading" (see FormattingToolbar) — match the name, not the glyph.
+  await bar.getByRole("button", { name: "Heading", exact: true }).click();
+
+  const menu = page.getByRole("menu", { name: "Heading level" });
+  await expect(menu).toBeVisible();
+
+  const item = menu.getByRole("menuitemradio", { name: "Heading 2" });
+  await expect(item).toBeVisible();
+
+  // The regression assertion: the menu item must actually own its own pixels.
+  // Before the fix this resolved to the editor's scroll container.
+  const ownsItsPixels = await item.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+    return !!hit && el.contains(hit);
+  });
+  expect(ownsItsPixels).toBe(true);
+
+  // And the menu must sit inside the viewport, not off the bottom/right edge.
+  const inViewport = await menu.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    return (
+      r.top >= 0 && r.left >= 0 && r.bottom <= window.innerHeight && r.right <= window.innerWidth
+    );
+  });
+  expect(inViewport).toBe(true);
+
+  // The bar must outrank the selection popup while a popover is open, or the
+  // menu paints behind it (#1024/#1036). The lift keys on `aria-expanded`, so
+  // it covers every popover in the bar rather than an enumerated list.
+  const lifted = await page.locator(".tandem-fmtbar-wrap").evaluate((el) => {
+    const z = getComputedStyle(el).zIndex;
+    const popupZ = getComputedStyle(document.documentElement).getPropertyValue("--tandem-z-modal");
+    return Number(z) > Number(popupZ.trim());
+  });
+  expect(lifted).toBe(true);
+
+  // Clicking it applies the format — the end-to-end proof.
+  await item.click();
+  await expect(editor.locator("h2", { hasText: "first paragraph" })).toBeVisible({
+    timeout: 3_000,
+  });
+});
+
+test("highlight color picker in the persistent bar is visible and clickable", async ({ page }) => {
+  await openFixture(page);
+
+  const bar = page.locator("[data-testid='formatting-bar']");
+  const editor = page.locator(".tandem-editor");
+
+  // The color toggle is disabled without a selection (canHighlight).
+  await editor.locator("p").first().selectText();
+
+  const toggle = bar.locator("[data-testid='toolbar-highlight-color-toggle']");
+  await expect(toggle).toBeEnabled();
+
+  // Dispatched rather than `.click()`. This control is `disabled` without a
+  // selection, and in headless ProseMirror drops the selection between
+  // Playwright's actionability check and its synthesised click — a disabled
+  // button then fires no mousedown at all, so the panel never opens. That is
+  // the same limitation toolbar-redesign.spec.ts documents for this flow. A
+  // dispatched mousedown reproduces the user's gesture without the focus
+  // round-trip that loses the selection, and it exercises the real handler.
+  await toggle.dispatchEvent("mousedown");
+
+  // Assert EVERY swatch plus the close button, not just one. This popover sits
+  // flush against the track's right edge, so a left-aligned popover overhangs
+  // the horizontal clip and loses its rightmost controls specifically — pink
+  // and close were unclickable while yellow/green/blue were fine. A single
+  // swatch check would have passed straight through that.
+  for (const id of [
+    "toolbar-highlight-color-yellow",
+    "toolbar-highlight-color-green",
+    "toolbar-highlight-color-blue",
+    "toolbar-highlight-color-pink",
+    "color-picker-close",
+  ]) {
+    const control = page.locator(`[data-testid='${id}']`);
+    await expect(control).toBeVisible();
+    const ownsItsPixels = await control.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+      return !!hit && el.contains(hit);
+    });
+    expect(ownsItsPixels, `${id} is not clickable`).toBe(true);
+  }
+
+  // Deliberately NOT asserting that a highlight gets applied here.
+  // toolbar-redesign.spec.ts documents that clicking the color toggle makes
+  // ProseMirror clear the text selection before the swatch panel renders, which
+  // puts the apply-a-color flow out of reach in headless CI regardless of
+  // `preventDefault`. That limitation is orthogonal to #1302: this bug is about
+  // the popover's geometry, and the assertions above test exactly that. The
+  // recolor behaviour itself is covered by tests/client/highlight-toggle.test.ts.
+});
+
+test("link editor in the persistent bar is not clipped by the format track", async ({ page }) => {
+  await openFixture(page);
+
+  const bar = page.locator("[data-testid='formatting-bar']");
+  const editor = page.locator(".tandem-editor");
+
+  await editor.locator("p").first().selectText();
+  // Dispatched for the same reason as the color toggle above: the Link control
+  // is disabled without a selection, and headless loses the selection during
+  // Playwright's click synthesis.
+  await bar.getByRole("button", { name: "Link", exact: true }).dispatchEvent("mousedown");
+
+  const input = bar.locator("[data-testid='toolbar-link-input']");
+  await expect(input).toBeVisible();
+
+  // The dialog must own every one of its own corners. Hit-testing (rather than
+  // comparing rects against clipping ancestors) is what stays correct after the
+  // fix: a `position: fixed` popover legitimately extends past an ancestor's
+  // overflow box without being clipped by it, so a rect comparison would report
+  // a false failure while a hit test reports the truth the user experiences.
+  const ownsItsCorners = await input.evaluate((el) => {
+    const dialog = el.closest("[role='dialog']") as HTMLElement | null;
+    if (!dialog) return false;
+    const d = dialog.getBoundingClientRect();
+    const inset = 4;
+    const corners: Array<[number, number]> = [
+      [d.left + inset, d.top + inset],
+      [d.right - inset, d.top + inset],
+      [d.left + inset, d.bottom - inset],
+      [d.right - inset, d.bottom - inset],
+    ];
+    return corners.every(([x, y]) => {
+      const hit = document.elementFromPoint(x, y);
+      return !!hit && dialog.contains(hit);
+    });
+  });
+  expect(ownsItsCorners).toBe(true);
+
+  // Escape must still dismiss it (the wrapper keydown handler).
+  await page.keyboard.press("Escape");
+  await expect(input).toBeHidden();
+});


### PR DESCRIPTION
Fixes #1302.

## The bug

Clicking the heading (`H▾`) button in the persistent formatting bar did nothing. The button was never at fault — it fires, and `aria-expanded` flips to `true`. Its menu is a `position: absolute` popover inside the bar's control track, which was `overflow: hidden` so a narrow window truncates buttons rather than wrapping them. That clips **both** axes, so the menu painted entirely below the clip edge:

| | value |
|---|---|
| track box | top `57`, bottom `83.75` |
| heading menu box | top `87.75`, bottom `170.75` |
| `elementFromPoint` at a menu item | `DIV.editor-scroll` — not the menu |

Clicks aimed at "Heading 2" reached the editor and moved the caret.

Two siblings shared the root cause: the **highlight color picker** was equally unreachable (popover `91.4`–`129.4`, `reachable: false`), and the **link editor** was being sliced.

The codebase already documented this hazard twice — `FormattingBar.svelte` explains that the Decorations button sits *outside* the track precisely so its dropdown isn't clipped, and `Toolbar.svelte` drops the selection popup's clip because otherwise "the menu items are cut off and the editor underneath intercepts their clicks." These three popovers never got either escape.

## The fix

`overflow-x: clip; overflow-y: visible` on the track.

The axis split is the whole fix. `clip` rather than `hidden` because **only `clip` may pair with `visible`** — per CSS Overflow 3, a `visible` paired with `hidden` computes to `auto`, which would make the track a scroll container and clip vertically anyway. That distinction is why the obvious `overflow-x: hidden` version of this idea doesn't work.

Verified rather than assumed:
- Horizontal truncation is unchanged — same track width, no wrapping, buttons past the edge remain unhittable, measured side-by-side against `overflow: hidden`.
- Survives lightningcss at every target (`overflow: clip visible`), so the two-CSS-pipeline asymmetry doesn't bite.
- Creating no scroll container is a second win: a focused control inside a scrollable track can be scrolled into view, displacing the whole row.

Support floor is Chrome 90 / Safari 16 / Firefox 81; the project already targets `safari16.4`.

## Two consequences handled

**The color picker sits flush against the track's right edge.** A `left: 0` popover overhung the horizontal clip by ~61px, leaving the pink swatch and close button unclickable (yellow/green/blue were fine — which is exactly the kind of thing a single-swatch test sails past). It now opens leftward with the caret mirrored.

**Un-clipped popovers become subject to the #1024/#1036 stacking problem.** The wrapper's z-lift previously keyed on a prop wired to the highlight sub-menu *alone*; the heading menu and link editor would have painted under the selection popup. It now keys on `:has([aria-expanded="true"])`, covering all four popovers the bar owns by construction rather than by enumeration. That deletes the `onOpenChange` prop and its state, and adds the missing `aria-expanded` on the swatch toggle (an a11y gap regardless).

## Tests

New `tests/e2e/formatting-bar-popovers.spec.ts`, scoped to the persistent bar — which had **no** popover coverage. The existing heading-dropdown test drives the selection-popup variant, whose ancestors drop their clip, so it passed throughout this bug's life.

The assertions **hit-test rather than check visibility**, deliberately: an element clipped by an ancestor's overflow still reports a non-empty box, so `toBeVisible` passes on a popover the user can neither see nor click. Asserting that a hit test at the element's own coordinates resolves back to that element is the property that actually matters, and it holds regardless of how the fix is implemented.

Confirmed **red** with the old `overflow: hidden` restored and **green** after — all three tests.

## Verification

- `npm run typecheck` clean
- `npm test` — 5672 passed
- `npm run test:e2e` — 258 passed. One failure (`scratchpad.spec.ts:141`) is pre-existing: it fails identically with these changes stashed.
- Manual verification in a real browser: all three popovers correctly positioned, every control hit-testable, z-lift engaging and releasing.

## Note on the road not taken

The first implementation of this was a ~450-line viewport-anchored positioning subsystem (a pure geometry module, a Svelte action with a frame loop, three call-site wirings, unit tests). It worked, but adversarial review pointed out it was a large permanently-owned mechanism built to route around a one-character-too-strong `overflow` value. `clip` was tested, held up, and replaced all of it. The E2E spec is the surviving artifact from that work, and it is implementation-agnostic by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYdfLJBmVcojd8hiHqt3qX
