### PR TITLE
fix(docx): refuse over-expanding archives before any reader sees them (#1310)

### DIFF
--- a/src/server/file-io/docx-apply.ts
+++ b/src/server/file-io/docx-apply.ts
@@ -8,6 +8,7 @@ import type { ChildNode } from "domhandler";
 import { Element, Text } from "domhandler";
 import { parseDocument } from "htmlparser2";
 import JSZip from "jszip";
+import { assertDocxWithinSizeLimits } from "./docx-size-gate.js";
 import {
   findAllByName,
   getAttr,
@@ -485,6 +486,12 @@ export async function applyTrackedChanges(
   suggestions: AcceptedSuggestion[],
   options: ApplyOptions,
 ): Promise<ApplyOutput> {
+  // #1310: this path re-reads the SAME on-disk file the document was opened from
+  // (`mcp/docx-apply.ts` → `fs.readFile`), so it carries the identical untrusted input as import and
+  // needs the identical ceiling. The `tandem_applyChanges` license gate is a monetization control
+  // that currently ships dark; it authenticates nothing about the bytes.
+  await assertDocxWithinSizeLimits(docxBuffer);
+
   const zip = await JSZip.loadAsync(docxBuffer);
   const documentXml = await zip.file("word/document.xml")?.async("text");
   if (!documentXml) {

--- a/src/server/file-io/docx-size-gate.ts
+++ b/src/server/file-io/docx-size-gate.ts
@@ -1,0 +1,234 @@
+import JSZip from "jszip";
+
+/**
+ * Decompressed-size ceiling for untrusted `.docx` archives (#1310).
+ *
+ * ## Why this is a gate on the buffer, not a check inside each reader
+ *
+ * `docxAdapter.parse` hands one untrusted buffer to four readers concurrently, and the FIRST of them
+ * is mammoth — which vendors its own JSZip (`mammoth/lib/zipfile.js`) and does its own unguarded
+ * `.async("uint8array")`. Mammoth exposes no size option and runs its own zip load, so nothing
+ * applied to *this* codebase's `.async("text")` call sites can reach it. It also reads more parts
+ * than Tandem's own readers combined, following OPC relationships rather than fixed literal paths.
+ *
+ * The first attempt at this fix did exactly that — gated our four call sites — and would have
+ * shipped green while leaving the largest reader completely unguarded. That is why the check lives
+ * here, ahead of everyone: a reader that never receives a hostile buffer needs no guard of its own,
+ * including readers added later.
+ *
+ * ## Why both a declared-size check and a streaming one
+ *
+ * `uncompressedSize` is read raw off the ZIP central directory (`jszip/lib/zipEntry.js`) with no
+ * cross-check against actual bytes or CRC, so a crafted archive can declare anything. Declared size
+ * alone is defeated by a one-field edit — which is exactly the weakness the sibling header/footer
+ * guard in `docx-lost-features.ts` documents about itself.
+ *
+ * So the declared pass is a free early-out for the honest case, and the streaming pass is the actual
+ * guarantee. Measured on this repo's jszip: 64 MiB of compressible XML packs to 65,451 bytes
+ * (1025:1 — ordinary, not exotic), and aborting a `nodeStream()` past a 1 MiB cap stops at 1,064,960
+ * bytes in 57 ms. The overshoot is one 16 KiB `DataWorker` chunk, because `pause()` propagates back
+ * up the worker chain and genuinely halts inflation rather than merely discarding output.
+ *
+ * ## Why a total across all entries, not an allowlist of known parts
+ *
+ * Mammoth resolves what to read through relationships, and a hostile package can point a
+ * relationship at any archive member. "The parts mammoth reads" is therefore not a static set, and
+ * an allowlist keyed to conventional names (`document.xml`, `styles.xml`, …) is the same shape of
+ * mistake as guarding only our own call sites: correct against the sample in front of you, blind to
+ * the next one.
+ */
+
+/**
+ * Per-entry ceiling. A `word/document.xml` at this size is an enormous document — the largest real
+ * fixture in this repo is 11.7 KB.
+ */
+export const MAX_DOCX_PART_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Ceiling on the sum across every entry.
+ *
+ * Sized against `docx-verify.ts`'s `MAX_VERIFY_BYTES` (25 MiB), which is the largest *compressed*
+ * buffer Tandem will re-import to verify its own export: a `.docx` that big is mostly already-
+ * compressed images at ~1:1, with XML a small fraction, so a legitimate worst case decompresses to
+ * tens of MiB rather than hundreds. Peak memory is bounded at roughly this times three concurrent
+ * main-part readers times two for UTF-16, i.e. ~384 MB.
+ *
+ * NO IN-REPO EVIDENCE SETS THIS NUMBER. Every `.docx` fixture here is KB-scale, so nothing available
+ * measures a realistically large legitimate document. It is a judgement call with headroom, pinned
+ * by tests so that changing it is a decision rather than a drift.
+ */
+export const MAX_DOCX_TOTAL_BYTES = 64 * 1024 * 1024;
+
+export interface DocxSizeLimits {
+  maxPartBytes?: number;
+  maxTotalBytes?: number;
+}
+
+export class DocxTooLargeError extends Error {
+  readonly code = "DOCX_TOO_LARGE";
+  constructor(
+    message: string,
+    readonly entryCount: number,
+  ) {
+    super(message);
+    this.name = "DocxTooLargeError";
+  }
+}
+
+/**
+ * Best-effort declared uncompressed size.
+ *
+ * `_data` is a JSZip internal with no compatibility guarantee. If it moves, every entry looks
+ * size-less and the early-out silently stops existing — and a dead guard is indistinguishable from a
+ * working one on benign input. Say so once. The streaming pass below still holds, which is the whole
+ * reason it is not optional.
+ *
+ * The tag is caller-supplied because every module in this directory labels its own diagnostics, and
+ * Copy Diagnostics is read by humans trying to work out which component failed.
+ */
+let warnedMissingSizeField = false;
+export function declaredSize(file: unknown, tag: string): number | undefined {
+  const size = (file as { _data?: { uncompressedSize?: unknown } })?._data?.uncompressedSize;
+  if (typeof size === "number") return size;
+  if (file && !warnedMissingSizeField) {
+    warnedMissingSizeField = true;
+    console.error(
+      `[${tag}] JSZip no longer exposes _data.uncompressedSize; the declared-size ` +
+        "early-out is inactive (the streaming ceiling still applies)",
+    );
+  }
+  return undefined;
+}
+
+/** Test seam: the warn-once latch is module state and would otherwise leak between tests. */
+export function _resetSizeFieldWarningForTests(): void {
+  warnedMissingSizeField = false;
+}
+
+/**
+ * Count an entry's real decompressed bytes, abandoning the stream once it passes `limit`.
+ *
+ * Returns the bytes seen, which is `> limit` exactly when the entry is oversized. We deliberately do
+ * not decode to a string: this counts bytes to decide admission, and building the string is the very
+ * allocation being guarded against.
+ */
+function measureEntry(file: JSZip.JSZipObject, limit: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let seen = 0;
+    let settled = false;
+    // JSZip types this as a bare `ReadableStream`, but it returns its own
+    // `NodejsStreamOutputAdapter`, which extends `stream.Readable` and does implement `destroy()`.
+    // The cast is to the runtime truth, and it is load-bearing: `destroy()` is what propagates
+    // `pause()` back through the worker chain and actually stops inflation. Without it this measures
+    // a bomb by decompressing all of it, which is the thing being prevented.
+    const stream = file.nodeStream("nodebuffer") as NodeJS.ReadableStream & { destroy(): void };
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+    stream.on("data", (chunk: Buffer) => {
+      seen += chunk.length;
+      if (seen > limit) {
+        // Destroying propagates pause() back through the worker chain, so inflation stops here
+        // rather than running to completion with the output thrown away.
+        stream.destroy();
+        finish(() => resolve(seen));
+      }
+    });
+    stream.on("end", () => finish(() => resolve(seen)));
+    stream.on("close", () => finish(() => resolve(seen)));
+    stream.on("error", (err: Error) => finish(() => reject(err)));
+    // NOTE on JSZip's own size check: it throws "Bug : uncompressed data size mismatch" when the
+    // inflated length disagrees with the declared one — but measured, that fires only AFTER the
+    // entry is fully inflated (67,108,864 bytes in 165 ms for a 64 MiB bomb). It is a post-hoc
+    // integrity assertion, not a ceiling: by the time it throws, the allocation this module exists
+    // to prevent has already happened. So it is not a substitute for the cap above, and an archive
+    // that trips it is malformed rather than merely large — `assertDocxWithinSizeLimits` classifies
+    // it accordingly instead of surfacing a message with the word "Bug" in it.
+  });
+}
+
+/**
+ * Throw unless every entry, and their sum, decompress within the limits.
+ *
+ * Call this before the buffer reaches any reader. Corrupt or non-ZIP input is NOT this function's
+ * problem — it resolves quietly and lets the real parser produce the honest error, because a size
+ * gate reporting "too large" for a truncated file would send the reader somewhere useless.
+ */
+export async function assertDocxWithinSizeLimits(
+  buffer: Buffer,
+  limits: DocxSizeLimits = {},
+): Promise<void> {
+  const maxPart = limits.maxPartBytes ?? MAX_DOCX_PART_BYTES;
+  const maxTotal = limits.maxTotalBytes ?? MAX_DOCX_TOTAL_BYTES;
+
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(buffer);
+  } catch {
+    return; // Not our error to report.
+  }
+
+  const entries: JSZip.JSZipObject[] = [];
+  zip.forEach((_path, file) => {
+    if (!file.dir) entries.push(file);
+  });
+
+  // Pass 1 — declared sizes. Free, and rejects an honest bomb without inflating a byte. A liar
+  // survives this and is caught below; that is the division of labour, not a gap.
+  let declaredTotal = 0;
+  for (const entry of entries) {
+    const declared = declaredSize(entry, "docx-size-gate");
+    if (declared === undefined) continue;
+    if (declared > maxPart) {
+      throw new DocxTooLargeError(
+        `A part of this .docx declares ${mib(declared)} uncompressed, over the ${mib(maxPart)} limit.`,
+        entries.length,
+      );
+    }
+    declaredTotal += declared;
+    if (declaredTotal > maxTotal) {
+      throw new DocxTooLargeError(
+        `This .docx declares more than ${mib(maxTotal)} of uncompressed content.`,
+        entries.length,
+      );
+    }
+  }
+
+  // Pass 2 — actual bytes. Sequential on purpose: the point is to bound peak memory, and measuring
+  // every entry at once would reintroduce the concurrency this exists to survive.
+  let actualTotal = 0;
+  for (const entry of entries) {
+    const remaining = Math.min(maxPart, maxTotal - actualTotal);
+    let seen: number;
+    try {
+      seen = await measureEntry(entry, remaining);
+    } catch (err) {
+      // An entry that completes under the cap and still fails to inflate is malformed — most often
+      // JSZip's declared-vs-actual mismatch. Refuse it here rather than letting a reader meet it
+      // later: the readers downstream are more forgiving than they look (htmlparser2 parses garbage
+      // into a text node without throwing), so passing a known-inconsistent archive through means
+      // importing whatever partial nonsense it yields.
+      throw new DocxTooLargeError(
+        `This .docx could not be read: ${err instanceof Error ? err.message : String(err)}`,
+        entries.length,
+      );
+    }
+    if (seen > remaining) {
+      throw new DocxTooLargeError(
+        seen > maxPart
+          ? `A part of this .docx expands past the ${mib(maxPart)} per-part limit.`
+          : `This .docx expands past the ${mib(maxTotal)} total limit.`,
+        entries.length,
+      );
+    }
+    actualTotal += seen;
+  }
+}
+
+function mib(bytes: number): string {
+  return `${Math.round(bytes / (1024 * 1024))} MiB`;
+}
+
+export const _internals = { measureEntry };

--- a/src/server/file-io/index.ts
+++ b/src/server/file-io/index.ts
@@ -27,6 +27,7 @@ import {
   scanFailureLines,
   structuralLossLines,
 } from "./docx-lost-features.js";
+import { assertDocxWithinSizeLimits } from "./docx-size-gate.js";
 import { loadMarkdown, saveMarkdown } from "./markdown.js";
 import type { FormatAdapter, LoadIssue, Prepared } from "./types.js";
 
@@ -100,6 +101,20 @@ const plaintextAdapter: FormatAdapter = {
 const docxAdapter: FormatAdapter = {
   async parse(content, options): Promise<Prepared> {
     const buffer = content as Buffer;
+
+    // #1310: refuse an over-expanding archive BEFORE any reader sees the buffer.
+    //
+    // This has to sit ahead of the fan-out rather than inside the readers, because the first entry
+    // below is mammoth, which loads its own zip and reads more parts than the other three combined.
+    // Nothing added to our own `.async("text")` call sites can reach it. Throwing here also means a
+    // reader added later inherits the guard instead of having to remember it.
+    //
+    // Deliberately a throw rather than a `LoadIssue`: every issue kind below describes a document
+    // that DID import with something lost, and the fidelity-report banner reads them that way.
+    // "We refused to open this" is not a fidelity loss, and dressing it as one would render a
+    // banner about a document that isn't on screen.
+    await assertDocxWithinSizeLimits(buffer);
+
     const issues: LoadIssue[] = [];
     let commentsFailed = false;
     const [loaded, comments, notes, lost] = await Promise.all([

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -32,6 +32,7 @@ import { loadAndMerge } from "../annotations/sync.js";
 import { isDirty, markClean, markDirty, registerDirtyObserver } from "../documents/dirty.js";
 import { attachObservers, clearFileSyncContext, setFileSyncContext } from "../events/queue.js";
 import { docBackupSnapshotPath, snapshotBeforeFirstWrite } from "../file-io/doc-backup.js";
+import { assertDocxWithinSizeLimits } from "../file-io/docx-size-gate.js";
 import {
   atomicWrite,
   atomicWriteBuffer,
@@ -589,6 +590,19 @@ export async function restoreDocumentFromBackup(
   // is itself reversible (first overwrite per path per run; never throws — a
   // skip or snapshot failure must not block the restore).
   await snapshotBeforeFirstWrite(existing.filePath, { appDataDir, documentId: id });
+
+  // #1310: validate BEFORE the write, not during the reload below.
+  //
+  // The ordering is the whole point. `reloadFromDisk` is where `adapter.parse` — and therefore the
+  // size gate — would otherwise run, and that is AFTER `atomicWriteBuffer` has already committed
+  // these bytes to disk. A refusal at that point would leave the rejected archive on disk, the
+  // Y.Doc still holding pre-restore content, and the `savedAtVersion` baseline below never updated
+  // — the exact split this function's own comments describe as making the autosave
+  // external-modification guard misfire. Snapshots can predate this gate, so restoring an old
+  // hostile file reaches that ordering by an ordinary route, not a contrived one.
+  if (isDocx) {
+    await assertDocxWithinSizeLimits(content as Buffer);
+  }
 
   suppressNextChange(existing.filePath);
   if (isDocx) {

--- a/src/server/mcp/routes/_shared.ts
+++ b/src/server/mcp/routes/_shared.ts
@@ -48,7 +48,12 @@ export function errorCodeToHttpStatus(code: string | undefined): number {
     case "RELOAD_IN_PROGRESS":
     case "EXTERNAL_CONFLICT":
       return 409;
+    // DOCX_TOO_LARGE (#1310) is the decompressed-size sibling of FILE_TOO_LARGE's compressed cap.
+    // Without this case it falls through to 500, which makes sendApiError log
+    // "[Tandem] Unhandled API error:" with a stack — reporting a policy refusal of hostile input as
+    // a Tandem crash, in the one artefact (Copy Diagnostics) a user would send us about it.
     case "FILE_TOO_LARGE":
+    case "DOCX_TOO_LARGE":
       return 413;
     case "EBUSY":
     case "EPERM":
@@ -92,7 +97,12 @@ function errorCodeToLabel(code: string): string {
       return "RELOAD_IN_PROGRESS";
     case "EXTERNAL_CONFLICT":
       return "EXTERNAL_CONFLICT";
+    // Deliberately the SAME label as the compressed-size cap rather than a new one: both are
+    // "this file is too big to open", the distinction between them is in `message`, and a novel
+    // label would be an unrecognized string to every existing client while changing nothing a
+    // caller can act on differently.
     case "FILE_TOO_LARGE":
+    case "DOCX_TOO_LARGE":
       return "FILE_TOO_LARGE";
     case "EBUSY":
     case "EPERM":

--- a/tests/server/api-middleware.test.ts
+++ b/tests/server/api-middleware.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from "vitest";
+import type { Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { DocxTooLargeError } from "../../src/server/file-io/docx-size-gate.js";
 import {
   createApiMiddleware,
   errorCodeToHttpStatus,
   isHostAllowed,
   isLocalhostOrigin,
 } from "../../src/server/mcp/api-routes.js";
+import { sendApiError } from "../../src/server/mcp/routes/_shared.js";
 import { jsonrpcId } from "../../src/server/mcp/server.js";
 
 describe("isHostAllowed (DNS rebinding protection)", () => {
@@ -279,5 +282,68 @@ describe("createApiMiddleware — CORS headers (#1291)", () => {
     const { headers, status } = run({ origin: "null" }, "OPTIONS");
     expect(status).toBe(204);
     expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendApiError — the DOCX_TOO_LARGE mapping (#1310)
+// ---------------------------------------------------------------------------
+
+describe("sendApiError with a decompressed-size refusal", () => {
+  function capture(err: unknown) {
+    let status = 0;
+    let body: unknown;
+    const res = {
+      status(code: number) {
+        status = code;
+        return this;
+      },
+      json(payload: unknown) {
+        body = payload;
+        return this;
+      },
+    } as unknown as Response;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      sendApiError(res, err);
+      // Snapshot the calls BEFORE restoring: `mockRestore` clears the recorded calls, so asserting
+      // on the spy afterwards asserts on an emptied array and passes no matter what was logged.
+      return {
+        status,
+        body: body as { error: string; message: string },
+        errors: errorSpy.mock.calls.map((c) => String(c[0])),
+        warns: warnSpy.mock.calls.map((c) => String(c[0])),
+      };
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  }
+
+  it("answers 413, not 500, for an over-expanding .docx", () => {
+    // The gate refuses hostile INPUT. Reported as 500 it is indistinguishable from a Tandem fault,
+    // and no caller can tell a policy refusal from a server bug.
+    const { status, body } = capture(
+      new DocxTooLargeError("A part of this .docx expands past…", 3),
+    );
+    expect(status).toBe(413);
+    expect(body.error).toBe("FILE_TOO_LARGE");
+    expect(body.message).toContain("expands past");
+  });
+
+  it("does not log it as an unhandled server error", () => {
+    // `[Tandem] Unhandled API error:` plus a stack is what Copy Diagnostics shows the user, and it
+    // is what a 5xx status triggers. Refusing a bomb is not a crash.
+    const { errors, warns } = capture(new DocxTooLargeError("too big", 1));
+    expect(errors).toEqual([]);
+    // Positive control on the same sample: the refusal IS logged, just at the level a rejected
+    // request warrants. Without this, an assertion that nothing was logged as unhandled would also
+    // pass if `sendApiError` had stopped logging entirely.
+    expect(warns).toEqual([expect.stringContaining("API error (413)")]);
+  });
+
+  it("still maps the code through the exported status mapper", () => {
+    expect(errorCodeToHttpStatus("DOCX_TOO_LARGE")).toBe(413);
   });
 });

--- a/tests/server/docx-size-gate-call-sites.test.ts
+++ b/tests/server/docx-size-gate-call-sites.test.ts
@@ -1,0 +1,140 @@
+/**
+ * #1310 — the decompressed-size gate is WIRED, at each of its three call sites.
+ *
+ * `docx-size-gate.test.ts` proves the gate works when you call it. It cannot prove anybody does.
+ * Every one of those tests passes with all three `await assertDocxWithinSizeLimits(...)` lines
+ * deleted — including the one in `file-io/index.ts`, which is the entire point of the fix, since it
+ * is what stands between mammoth's vendored JSZip and a hostile buffer. A `/simplify` pass that
+ * removes a single line would restore the OOM with the module, its docs and its regression guards
+ * all still present and all still green.
+ *
+ * So these tests drive the real entry points and assert refusal. Each one goes red if — and only
+ * if — its own call site's line is deleted.
+ *
+ * The bomb is sized against the SHIPPED ceilings rather than injected limits, because the call
+ * sites deliberately do not thread `DocxSizeLimits` (there is no per-caller policy). That is
+ * affordable: an honest over-declaration is refused by the declared-size pass without inflating a
+ * byte, so the cost here is building the archive, not reading it.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock factories are hoisted above module-level code, so they build their own paths inline.
+vi.mock("../../src/server/platform", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/server/platform")>();
+  const osMod = await import("os");
+  const pathMod = await import("path");
+  const cryptoMod = await import("crypto");
+  const appDataDir = pathMod.join(
+    osMod.tmpdir(),
+    `tandem-test-gate-sites-${cryptoMod.randomUUID()}`,
+  );
+  process.env.TANDEM_APP_DATA_DIR = appDataDir;
+  return { ...original, SESSION_DIR: pathMod.join(appDataDir, "sessions") };
+});
+
+vi.mock("../../src/server/file-watcher", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/server/file-watcher")>()),
+  watchFile: vi.fn(),
+  suppressNextChange: vi.fn(),
+}));
+
+vi.mock("../../src/server/notifications.js", () => ({ pushNotification: vi.fn() }));
+
+vi.mock("../../src/server/integrations/acl-win.js", () => ({
+  setRestrictiveAcl: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { Document, Packer, Paragraph, TextRun } from "docx";
+import JSZip from "jszip";
+import { docHash } from "../../src/server/annotations/doc-hash.js";
+import { docBackupsRoot } from "../../src/server/file-io/doc-backup.js";
+import { applyTrackedChanges } from "../../src/server/file-io/docx-apply.js";
+import { DocxTooLargeError, MAX_DOCX_PART_BYTES } from "../../src/server/file-io/docx-size-gate.js";
+import { getAdapter } from "../../src/server/file-io/index.js";
+import { getOpenDocs, removeDoc, setActiveDocId } from "../../src/server/mcp/document-service.js";
+import { openFileByPath, restoreDocumentFromBackup } from "../../src/server/mcp/file-opener.js";
+import { resolveAppDataDir } from "../../src/server/platform.js";
+
+/**
+ * An archive whose media part declares (honestly) more than the per-part ceiling.
+ *
+ * Two shape choices are deliberate, both about keeping the NEGATIVE control cheap and legible —
+ * a control that OOM-kills the test worker proves the point but reports it as an unrelated crash.
+ *
+ * 1. The payload is a media part, not `word/document.xml`, so no ungated reader pushes 40 MiB
+ *    through htmlparser2 to reach its error.
+ * 2. `word/document.xml` is OMITTED entirely, so with the gate removed `applyTrackedChanges` throws
+ *    "Missing word/document.xml" at its first read instead of reaching `zip.generateAsync`, which
+ *    re-emits every entry — measured, that path exhausts a 4 GB heap and hard-kills the worker.
+ *    That crash IS #1310, but as a regression signal a typed rejection is worth more.
+ */
+let bomb: Buffer;
+beforeAll(async () => {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", "<Types/>");
+  zip.file("word/media/blob.bin", Buffer.alloc(MAX_DOCX_PART_BYTES + 8 * 1024 * 1024, 0x41));
+  bomb = (await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" })) as Buffer;
+  // Sanity: the thing sails through every COMPRESSED-size check in the codebase, which is the
+  // premise of #1310. MAX_FILE_SIZE is 50 MB.
+  expect(bomb.length).toBeLessThan(1024 * 1024);
+}, 60_000);
+
+let tmpDir: string;
+beforeEach(async () => {
+  for (const id of [...getOpenDocs().keys()]) removeDoc(id);
+  setActiveDocId(null);
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tandem-gate-sites-"));
+});
+
+describe("call site 1 — docxAdapter.parse", () => {
+  it("refuses the archive before any reader receives the buffer", async () => {
+    // This is the line that guards mammoth. Nothing added to Tandem's own `.async` call sites can
+    // reach mammoth's vendored JSZip, so if this call site is dropped there is no second chance.
+    await expect(getAdapter("docx").parse(bomb)).rejects.toBeInstanceOf(DocxTooLargeError);
+  });
+});
+
+describe("call site 2 — applyTrackedChanges", () => {
+  it("refuses the archive before loading it", async () => {
+    // Re-reads the same untrusted on-disk file the document was opened from, so it carries the
+    // identical input; its license gate authenticates nothing about the bytes.
+    await expect(
+      applyTrackedChanges(bomb, [], { author: "Test", ydocFlatText: "" }),
+    ).rejects.toBeInstanceOf(DocxTooLargeError);
+  });
+});
+
+describe("call site 3 — restoreDocumentFromBackup", () => {
+  it("refuses the snapshot BEFORE committing it to disk", async () => {
+    // The ordering is the finding, not just the refusal. `reloadFromDisk` would run the gate too —
+    // via call site 1 — but only after `atomicWriteBuffer` has already put the rejected archive on
+    // disk, and it degrades to a toast rather than a throw. So a gate here that merely refused
+    // "eventually" is indistinguishable from no gate here at all: the assertion that separates them
+    // is that the ORIGINAL bytes survive on disk.
+    const filePath = path.join(tmpDir, "thesis.docx");
+    const good = (await Packer.toBuffer(
+      new Document({
+        sections: [{ children: [new Paragraph({ children: [new TextRun("ok")] })] }],
+      }),
+    )) as Buffer;
+    await fs.writeFile(filePath, good);
+    const opened = await openFileByPath(filePath);
+
+    // A snapshot predating the gate is an ordinary route to hostile bytes, so plant one directly
+    // (the shape `docBackupSnapshotPath` accepts).
+    const subdir = path.join(docBackupsRoot(resolveAppDataDir()), docHash(filePath));
+    await fs.mkdir(subdir, { recursive: true });
+    const name = "thesis-20260101-100000-aaaaaaaa.docx";
+    await fs.writeFile(path.join(subdir, name), bomb);
+    await fs.writeFile(path.join(subdir, "source.txt"), `${filePath}\n`);
+
+    await expect(restoreDocumentFromBackup(opened.documentId, name)).rejects.toBeInstanceOf(
+      DocxTooLargeError,
+    );
+    expect((await fs.readFile(filePath)).equals(good)).toBe(true);
+  });
+});

--- a/tests/server/docx-size-gate.test.ts
+++ b/tests/server/docx-size-gate.test.ts
@@ -1,0 +1,213 @@
+import JSZip from "jszip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetSizeFieldWarningForTests,
+  assertDocxWithinSizeLimits,
+  DocxTooLargeError,
+  declaredSize,
+  MAX_DOCX_PART_BYTES,
+  MAX_DOCX_TOTAL_BYTES,
+} from "../../src/server/file-io/docx-size-gate.js";
+import { rawDocx } from "../helpers/docx-corpus.js";
+
+/**
+ * #1310 — the decompressed-size ceiling.
+ *
+ * Two tests here exist specifically to fail the two designs this fix went through before landing.
+ * They are marked in place, because without them a future simplification can quietly restore either
+ * mistake and every other test in this file will still pass.
+ */
+
+/** An archive whose named entry inflates to `size` bytes but compresses to almost nothing. */
+async function bombDocx(entry: string, size: number): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", "<Types/>");
+  zip.file(entry, Buffer.alloc(size, 0x41));
+  return (await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" })) as Buffer;
+}
+
+/**
+ * Overwrite the uncompressed-size field in every central-directory record.
+ *
+ * Central-directory file header (PKWARE APPNOTE 4.3.12): signature `PK\x01\x02` = 0x02014b50, with
+ * the uncompressed size a 4-byte little-endian value at offset 24. JSZip builds its entry list from
+ * these records and deliberately ignores the local header's copy, so this is the field it reads —
+ * and nothing validates it against the deflate stream.
+ */
+function patchCentralDirectoryUncompressedSize(
+  buf: Buffer,
+  entryName: string,
+  lie: number,
+): Buffer {
+  const out = Buffer.from(buf);
+  const target = Buffer.from(entryName, "utf8");
+  let patched = 0;
+  for (let i = 0; i + 46 <= out.length; i++) {
+    if (out.readUInt32LE(i) !== 0x02014b50) continue;
+    // Patch ONLY the named entry. Rewriting every record also breaks the tiny parts (a 9-byte
+    // [Content_Types].xml suddenly claiming 128), which makes the archive fail for a reason that has
+    // nothing to do with the bomb — the first draft of this helper did exactly that and the test
+    // passed for the wrong reason.
+    const nameLen = out.readUInt16LE(i + 28);
+    if (out.subarray(i + 46, i + 46 + nameLen).equals(target)) {
+      out.writeUInt32LE(lie, i + 24);
+      patched++;
+    }
+  }
+  if (patched !== 1) throw new Error(`expected 1 central-directory record, patched ${patched}`);
+  return out;
+}
+
+afterEach(() => {
+  _resetSizeFieldWarningForTests();
+  vi.restoreAllMocks();
+});
+
+describe("docx size gate", () => {
+  it("admits an ordinary document untouched", async () => {
+    const buf = await rawDocx({ body: "<w:p><w:r><w:t>hello</w:t></w:r></w:p>" });
+    await expect(assertDocxWithinSizeLimits(buf)).resolves.toBeUndefined();
+  });
+
+  it("refuses a part that expands past the per-part ceiling", async () => {
+    const buf = await bombDocx("word/document.xml", 4 * 1024 * 1024);
+    await expect(
+      assertDocxWithinSizeLimits(buf, {
+        maxPartBytes: 1024 * 1024,
+        maxTotalBytes: 8 * 1024 * 1024,
+      }),
+    ).rejects.toBeInstanceOf(DocxTooLargeError);
+  });
+
+  it("refuses on the SUM across entries, not just any single one", async () => {
+    // Each part is comfortably under the per-part ceiling; together they are not. A per-part-only
+    // guard passes this, which is why the total exists — mammoth resolves what to read through
+    // relationships, so a hostile package can spread the payload across parts it chooses.
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", "<Types/>");
+    for (const name of ["word/document.xml", "word/styles.xml", "word/numbering.xml"]) {
+      zip.file(name, Buffer.alloc(600 * 1024, 0x41));
+    }
+    const buf = (await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" })) as Buffer;
+
+    await expect(
+      assertDocxWithinSizeLimits(buf, {
+        maxPartBytes: 1024 * 1024,
+        maxTotalBytes: 1024 * 1024,
+      }),
+    ).rejects.toBeInstanceOf(DocxTooLargeError);
+  });
+
+  /**
+   * REGRESSION GUARD — kills the declared-size-only design.
+   *
+   * The first attempt gated on `_data.uncompressedSize`, which JSZip reads raw off the ZIP central
+   * directory with no cross-check against the actual stream. An archive can simply lie about it.
+   *
+   * The lie has to be written into the BUFFER's bytes, not into a loaded JSZip object: the gate
+   * calls `loadAsync` itself, so tampering with an in-memory instance proves nothing — the gate
+   * would re-read the honest value and this test would pass against the very design it exists to
+   * kill. (It did, in its first draft.) So patch the central-directory record and assert the lie
+   * survives a reload, which is the positive control.
+   */
+  it("refuses an archive that LIES about its declared size", async () => {
+    const buf = await bombDocx("word/document.xml", 4 * 1024 * 1024);
+    const tampered = patchCentralDirectoryUncompressedSize(buf, "word/document.xml", 128);
+
+    // Positive control: the gate's own view of the declared size must actually be the lie. Without
+    // this, a failure to patch would look like the streaming pass succeeding.
+    const reloaded = await JSZip.loadAsync(tampered);
+    expect(declaredSize(reloaded.file("word/document.xml"), "test")).toBe(128);
+
+    // 128 declared sails under any declared-size check. Only the streaming pass is left.
+    const err = await assertDocxWithinSizeLimits(tampered, {
+      maxPartBytes: 1024 * 1024,
+      maxTotalBytes: 1024 * 1024,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DocxTooLargeError);
+
+    // And it must be the CAP that refused, not JSZip's own declared-vs-actual assertion. Both now
+    // surface as DocxTooLargeError, so without this the test would still pass if the early abort
+    // stopped working and the entry inflated fully before anything complained — which is precisely
+    // the failure this guard is about.
+    expect(err.message).toMatch(/expands past/);
+    expect(err.message).not.toMatch(/could not be read/);
+  });
+
+  it("bounds the work it does — a 64 MiB bomb is refused without inflating 64 MiB", async () => {
+    // The point of streaming is that `destroy()` propagates pause() back through JSZip's worker
+    // chain and actually stops inflation. If it ever silently degrades to "decompress everything,
+    // then check the length", this stays correct but stops being a defence. Time is the only
+    // available proxy for that, so the bound is deliberately loose enough not to flake.
+    const buf = await bombDocx("word/document.xml", 64 * 1024 * 1024);
+    expect(buf.length).toBeLessThan(1024 * 1024); // ~1000:1, an ordinary deflate ratio
+
+    const started = Date.now();
+    await expect(
+      assertDocxWithinSizeLimits(buf, { maxPartBytes: 1024 * 1024, maxTotalBytes: 1024 * 1024 }),
+    ).rejects.toBeInstanceOf(DocxTooLargeError);
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  it("stays silent on corrupt or non-ZIP input, leaving the real parser to report it", async () => {
+    // A size gate answering "too large" for a truncated file sends the reader somewhere useless.
+    await expect(assertDocxWithinSizeLimits(Buffer.from("not a zip"))).resolves.toBeUndefined();
+  });
+
+  it("says so once when JSZip stops exposing the declared-size field", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A dead guard and a working guard are indistinguishable on benign input, so the disappearance
+    // has to announce itself rather than degrade in silence.
+    expect(declaredSize({ _data: {} }, "docx-size-gate")).toBeUndefined();
+    expect(declaredSize({ _data: {} }, "docx-size-gate")).toBeUndefined();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toContain("[docx-size-gate]");
+  });
+
+  it("tags the warning with the CALLER, not this module", async () => {
+    // Every module in file-io/ labels its own diagnostics, and Copy Diagnostics is read by humans
+    // working out which component failed. A hardcoded tag would misattribute every caller.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    declaredSize({ _data: {} }, "docx-apply");
+    expect(spy.mock.calls[0][0]).toContain("[docx-apply]");
+  });
+
+  it("ships ceilings that are ordered and non-trivial", async () => {
+    // Pinned so that changing them is a decision rather than a drift. No in-repo evidence sets
+    // these numbers — every .docx fixture here is KB-scale — so the test guards the shape, not the
+    // magnitude: a per-part ceiling above the total would make the total unreachable.
+    expect(MAX_DOCX_PART_BYTES).toBeLessThanOrEqual(MAX_DOCX_TOTAL_BYTES);
+    expect(MAX_DOCX_PART_BYTES).toBeGreaterThan(1024 * 1024);
+  });
+});
+
+describe("the assumption the gate rests on", () => {
+  /**
+   * REGRESSION GUARD — kills the design silently, with no other test failing.
+   *
+   * The gate and mammoth open the SAME buffer through SEPARATE JSZip instances. That is only safe
+   * because both parses are identical, which holds because JSZip builds its file list from the
+   * central directory and distrusts local headers — and because exactly one jszip exists in the
+   * tree. If mammoth ever denests its own copy at a different version with different
+   * ZIP64/duplicate-name handling, the two reads stop being guaranteed to agree and the gate can be
+   * made to see something mammoth does not.
+   *
+   * That is a lockfile fact, not a design property. Nothing else in this suite would notice.
+   */
+  it("resolves exactly one jszip for both Tandem and mammoth", async () => {
+    const ours = await import("jszip/package.json", { with: { type: "json" } });
+    const theirs = await import("mammoth/node_modules/jszip/package.json", {
+      with: { type: "json" },
+    }).then(
+      (m) => m.default.version as string,
+      () => undefined, // no nested copy — this is the state we want
+    );
+
+    expect(
+      theirs,
+      "mammoth has denested its own jszip; the size gate and mammoth may no longer parse the " +
+        "archive identically. Re-verify the gate before relaxing this test.",
+    ).toBeUndefined();
+    expect(ours.default.version).toMatch(/^3\./);
+  });
+});

--- a/tests/server/docx-size-gate.test.ts
+++ b/tests/server/docx-size-gate.test.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import JSZip from "jszip";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -195,19 +197,24 @@ describe("the assumption the gate rests on", () => {
    * That is a lockfile fact, not a design property. Nothing else in this suite would notice.
    */
   it("resolves exactly one jszip for both Tandem and mammoth", async () => {
-    const ours = await import("jszip/package.json", { with: { type: "json" } });
-    const theirs = await import("mammoth/node_modules/jszip/package.json", {
-      with: { type: "json" },
-    }).then(
-      (m) => m.default.version as string,
-      () => undefined, // no nested copy — this is the state we want
+    // Asked of the FILESYSTEM, not the module resolver. The first draft did
+    // `import("mammoth/node_modules/jszip/package.json").then(v => v, () => undefined)`, which
+    // resolves only because mammoth's package.json happens to have no `exports` field today. Add
+    // one — the near-universal direction of travel — and the specifier becomes
+    // ERR_PACKAGE_PATH_NOT_EXPORTED, the rejection handler swallows it, and the assertion passes
+    // while reporting a lockfile fact that no longer holds. A guard whose failure mode is
+    // indistinguishable from success is not a guard. `existsSync` cannot be talked out of an answer.
+    const nested = fileURLToPath(
+      new URL("../../node_modules/mammoth/node_modules/jszip", import.meta.url),
     );
 
     expect(
-      theirs,
+      existsSync(nested),
       "mammoth has denested its own jszip; the size gate and mammoth may no longer parse the " +
         "archive identically. Re-verify the gate before relaxing this test.",
-    ).toBeUndefined();
+    ).toBe(false);
+
+    const ours = await import("jszip/package.json", { with: { type: "json" } });
     expect(ours.default.version).toMatch(/^3\./);
   });
 });


### PR DESCRIPTION
Closes #1310.

A `.docx` whose `word/document.xml` honestly declares ~400 MiB and compresses to ~400 KiB passes every check we have. `MAX_FILE_SIZE` (50 MB) and the 70 MB `largeBody` limit both measure **compressed** input, so the payload is 0.8% of the cap. Import then inflates it concurrently, the sidecar OOM-dies, and it takes unsaved edits in **every open tab** with it — `autoSaveAllToDisk` runs on graceful shutdown, not on an OOM kill. No auth required: drag-drop, `tandem_open` and OS file-association all reach the same fan-out.

Measured on this repo's own jszip: 64 MiB of XML packs to **65,451 bytes, 1025:1**. That is ordinary DEFLATE, not a crafted curiosity.

## Where the gate goes, and why not where the issue suggests

The issue proposes gating the four `.async("text")` call sites in `file-io/`. **I built that first and it does not work.** `loadDocxWithWarnings` is mammoth — the *first* entry in the very `Promise.all` the issue quotes. It declares its own `jszip`, does its own `loadAsync` + `.async("uint8array")` with no size bound and no option to add one, and reads more parts than our three readers combined. Nothing added to our call sites reaches it. That version would have shipped green and left the OOM intact.

So the gate runs on the **buffer**, before any reader receives it. A reader that never sees a hostile archive needs no guard of its own — including one added later.

It also can't be an allowlist of "the parts mammoth reads": mammoth resolves parts through OPC *relationships*, and a hostile package can point a relationship at any member. Hence a cap on the total across every entry.

This isn't imposed on the module against its wishes. `docx-lost-features.ts:385-389` says it itself: *"a general ratio/entry cap for the whole docx read path is tracked separately; this only refuses to ADD a new multiplier."* This is that deferred work.

## Two passes, because either alone is wrong

- **Declared size** is free and stops the honest bomb without inflating a byte — but JSZip reads `uncompressedSize` raw off the central directory, so a one-field edit defeats it.
- **Streaming** is the actual ceiling. `destroy()` propagates `pause()` back through JSZip's worker chain and genuinely halts inflation: measured at **1,064,960 bytes against a 1 MiB cap** — one 16 KiB chunk of overshoot.

Worth recording, because it contradicts a plausible assumption: JSZip *does* assert declared-vs-actual, but only **after** inflating the entry — 67,108,864 bytes before it threw. It is a post-hoc integrity check, not a ceiling. By the time it fires, the allocation this exists to prevent has already happened.

## Three call sites

Saying "one gate, one place" is how the second draft went wrong, so they're named explicitly:

1. `docxAdapter.parse` — ahead of the fan-out.
2. `applyTrackedChanges` — re-reads the *same hostile file from disk* via `mcp/docx-apply.ts`. Its `tandem_applyChanges` license gate is a monetization control shipping dark; it authenticates nothing about the bytes.
3. `restoreDocumentFromBackup` — **before `atomicWriteBuffer`**, not during the reload it triggers. Gating at parse time would commit the rejected bytes to disk first, leaving the Y.Doc on pre-restore content and `savedAtVersion` never updated — the split that function's own comments describe as making the autosave external-modification guard misfire. Snapshots predate this gate, so an old hostile file reaches that ordering by an ordinary route.

`reloadFromDisk` is verified graceful already: it parses before touching the Y.Doc, so a refusal leaves a stale doc plus a toast, with no corruption.

## The ceilings are a judgement call — please push back

32 MiB per part, 64 MiB total. **No in-repo evidence sets these numbers.** Every `.docx` fixture here is KB-scale; the largest `document.xml` is 11.7 KB. They're reasoned from `docx-verify.ts`'s `MAX_VERIFY_BYTES` (25 MiB *compressed*, the largest export we re-import to verify our own output), on the basis that a `.docx` that big is mostly already-compressed images with XML a small fraction.

The risk band is an export **under** 25 MiB compressed whose parts inflate past the cap — that would make Tandem fail verification of its own output. Pinned by tests so changing them is a decision rather than a drift.

## Tests

10 new, plus 87 existing `.docx` tests and the full server suite (185 files, 3095 tests) green.

Two exist specifically to kill designs this went through, and are labelled as such in place:

- **An archive that lies in its central-directory bytes.** The lie has to be patched into the buffer, not a loaded JSZip object — the gate calls `loadAsync` itself, so tampering with an in-memory instance proves nothing and the test would pass against the exact design it rules out. It did, in its first draft. It now carries a positive control that the lie survives a reload, and asserts *the cap* refused it rather than JSZip's post-hoc check, since both now surface the same error type.
- **A pin that one `jszip` resolves for both us and mammoth.** The gate and mammoth parse the same buffer through separate instances; that's only safe while they cannot disagree, which holds because JSZip builds its list from the central directory and distrusts local headers. That is a **lockfile fact, not a design property** — if mammoth ever denests its own copy, this design silently stops applying and nothing else in the suite would notice.

## Corrections owed to the issue body

- `docx-footnotes.ts:64` is **not** a `document.xml` read — it reads `footnotes.xml`/`endnotes.xml`.
- `docx-comments.ts` usually never reaches `document.xml`; it early-returns when a file has no Word comments.
- So the concurrent main-part multiplier is **3 worst case, 2 typical**, not 4 — which matters, because that number is what sizes the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKcPLgN9YGgfC1WvPJ2Vq


---

## Additions after review (2026-08-07)

Nothing in the body above turned out to be false — this PR was the only one in the queue where every claim survived checking. Three additions.

### The gate was not pinned to its call sites

This is the finding that mattered. The suite tested `assertDocxWithinSizeLimits` directly and never drove a real entry point, so **deleting the single line that is the entire point of the PR** — the one at `file-io/index.ts:116` guarding mammoth's vendored JSZip — left the full suite green. That is precisely the failure mode the body describes the *first draft* as having had, still present in the tests that were supposed to prevent it.

`5f37016` adds one integration test per call site, driving `docxAdapter.parse`, `applyTrackedChanges` and `restoreDocumentFromBackup`. Each deletion now reds exactly its own test:

```
######## removed gate from src/server/file-io/index.ts ########
  × refuses the archive before any reader receives the buffer
######## removed gate from src/server/file-io/docx-apply.ts ########
  × refuses the archive before loading it
######## removed gate from src/server/mcp/file-opener.ts ########
  × refuses the snapshot BEFORE committing it to disk
```

The third failure is the interesting one: ungated, `restoreDocumentFromBackup` does not throw at all — the reload degrades to a toast — and **commits the bomb to disk**. So that test asserts on the on-disk bytes, which is the only thing that distinguishes the two orderings.

### A refused .docx was reported as a Tandem crash

`DOCX_TOO_LARGE` was unmapped in `errorCodeToHttpStatus`, so a refusal fell through to `500 INTERNAL` and printed `[Tandem] Unhandled API error:` with a stack — which is what a user sees in Copy Diagnostics when they report the problem. A policy refusal, presented as our bug. `38d5353` maps it to **413** alongside the existing `FILE_TOO_LARGE`, covering the whole `sendApiError` route family (`open`, `backups`, `apply-changes`, `convert`, `upload`) at one site.

The label deliberately stays `FILE_TOO_LARGE` rather than becoming a new one: the distinction lives in `message`, and a novel label would be unrecognised by every existing client and actionable by none.

### The jszip pin could pass while false

`0eba2ba`. The "exactly one jszip" assertion resolved through a dynamic `import()`, whose rejection was swallowed by a `() => undefined` handler. `mammoth@1.12.0` has no `exports` field today, so it works — but a future mammoth adding one (the near-universal direction of travel) would make the specifier throw `ERR_PACKAGE_PATH_NOT_EXPORTED`, get swallowed, and the test would report "no nested copy — this is the state we want" **even if mammoth had denested jszip in that same upgrade**. It now asks the filesystem, and fails loudly.

Verified against a planted `node_modules/mammoth/node_modules/jszip`: the new form fails, the old form passes.

### Two things the negative controls caught in my own test code

Worth recording, because both would have shipped as tests that prove nothing:

- The first 413 test asserted on spies **after** `mockRestore()`, which clears recorded calls — it passed against unmapped code. It now snapshots `mock.calls` before restoring, and pairs the absence-assertion with a positive control on the same sample.
- The first bomb fixture included `word/document.xml`. Ungated, `applyTrackedChanges` then reached `zip.generateAsync`, which re-emits every entry — **exhausting a 4 GB heap and hard-killing the vitest worker in 141 seconds**. That crash *is* #1310, faithfully reproduced, but it reports as an unrelated worker death rather than as a failed assertion. The fixture omits `word/document.xml` so the negative control produces a typed rejection you can read. Reason is recorded in the file.
