### PR TITLE
fix(local-model): bound the streamed reply, the request URL, and the run clock

### DIFF
--- a/src/server/local-model/collaborator.ts
+++ b/src/server/local-model/collaborator.ts
@@ -315,6 +315,20 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
             documentId: req.docName,
             timestamp: Date.now(),
           });
+        } else if (exit === "timeout") {
+          // Deliberately its own branch, not folded into the budget message
+          // above (#1295 L6). A wall-clock exit happens with turns to spare, so
+          // "reached its step limit" would be false and would send the user to
+          // raise maxTurns for what is really a slow or stalling endpoint.
+          sink.flushFinal();
+          pushNotification({
+            id: generateMessageId(),
+            type: "general-error",
+            severity: "warning",
+            message: "The local model stopped before finishing (it ran out of time).",
+            documentId: req.docName,
+            timestamp: Date.now(),
+          });
         } else if (exit === "error") {
           console.error(
             `[local-model] run error (exit=${exit}): ${result.metrics.errorMessage ?? "unknown"}`,

--- a/src/server/local-model/collaborator.ts
+++ b/src/server/local-model/collaborator.ts
@@ -41,6 +41,35 @@ const INLINE_CHAR_LIMIT = 8000;
 /** Coalesce streamed deltas: flush at most this often OR every FLUSH_CHARS chars. */
 const STREAM_FLUSH_MS = 120;
 const STREAM_FLUSH_CHARS = 80;
+
+/**
+ * Ceiling on a single streamed reply (#1292).
+ *
+ * Every flush re-`set`s the ENTIRE message value into the ctrl-room Y.Map, which
+ * Hocuspocus then broadcasts to every connected client — so a stream of length n
+ * costs O(n²) in Yjs encoding and WebSocket bytes. The only other ceiling is the
+ * per-response raw-byte cap, which is sized for a whole JSON response rather than
+ * a chat bubble; a local model in a repetition loop (a routine failure mode for
+ * quantized small models) reaches it with no attacker involved.
+ *
+ * 64 KiB is generous for a chat bubble. This cap is load-bearing beyond the
+ * quadratic blowup: it also bounds what lands in the persisted session file.
+ */
+const MAX_STREAMED_CHARS = 64 * 1024;
+
+/** Appended once when {@link MAX_STREAMED_CHARS} is hit, so the cut is visible. */
+const TRUNCATION_MARKER = "\n\n_[Reply truncated — the model exceeded the streaming limit.]_";
+
+/**
+ * Wire-level twin of {@link MAX_STREAMED_CHARS} (#1292).
+ *
+ * Deliberately looser than the char cap: a streaming response carries SSE
+ * framing and JSON envelope overhead around the content, and tool-call turns
+ * spend bytes on arguments that never reach the sink at all. 1 MiB leaves room
+ * for that while staying four orders of magnitude below the client's 16 MB
+ * default, which exists for whole-JSON reads rather than chat.
+ */
+const MAX_STREAMED_RESPONSE_BYTES = 1024 * 1024;
 /** Truncate selectedText before embedding in the model prompt. A large selection
  *  can't inflate token usage unboundedly; 500 chars captures any reasonable
  *  user-selected excerpt (a paragraph or two). */
@@ -128,6 +157,9 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
     let buffer = "";
     let charsSinceFlush = 0;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    // Latch, not a counter: the marker is appended exactly once, and every
+    // subsequent delta is dropped rather than re-triggering the cap branch.
+    let truncated = false;
 
     const isOwner = () =>
       current?.token === ctx.token &&
@@ -161,8 +193,36 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
 
     return {
       push: (delta: string) => {
+        // Post-cap deltas are dropped outright: the marker is already committed
+        // and the run is aborting, so appending would only grow a buffer nobody
+        // will write.
+        if (truncated) return;
+
         buffer += delta;
         charsSinceFlush += delta.length;
+
+        if (buffer.length >= MAX_STREAMED_CHARS) {
+          // #1292. ORDER IS LOAD-BEARING — do not reorder these two calls.
+          // `write()` returns early on `!isOwner()`, and `isOwner()` includes
+          // `!ctx.abort.signal.aborted`, so aborting FIRST would permanently
+          // disable the only write path: the marker would never reach the
+          // Y.Map, and the user would see a silently truncated reply. The
+          // terminal path in `executeRun` cannot rescue it either — its
+          // `stillOwner()` carries the same abort clause.
+          //
+          // Both calls ride ONE deferred task so the ordering is guaranteed
+          // while preserving this file's nested-txn invariant (see the header:
+          // the sink flushes only from a timer, never on a delta stack).
+          truncated = true;
+          buffer = buffer.slice(0, MAX_STREAMED_CHARS) + TRUNCATION_MARKER;
+          cancelTimer();
+          timer = setTimeout(() => {
+            write();
+            ctx.abort.abort();
+          }, 0);
+          return;
+        }
+
         // Deferred always — a flush must never run on the onContentDelta stack.
         if (charsSinceFlush >= STREAM_FLUSH_CHARS) {
           cancelTimer();
@@ -172,6 +232,10 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
         }
       },
       onTurnEnd: (info: { hadToolCalls: boolean }) => {
+        // Once truncated, the buffer holds the committed-or-committing marker.
+        // Dropping it here would cancel the pending cap flush and wipe the
+        // marker, which is the one write the user needs to see (#1292).
+        if (truncated) return;
         if (info.hadToolCalls) {
           // The turn's content was preamble/scaffolding — drop it so the next
           // turn's content replaces it (no "" write → no empty-bubble flip).
@@ -219,6 +283,12 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
         config,
         task,
         includeFullText,
+        // #1292: the client default is 16 MB, sized for a whole JSON response.
+        // A chat reply is bounded by MAX_STREAMED_CHARS on the sink side; this
+        // is the wire-level twin, so a hostile or looping endpoint cannot make
+        // us buffer 16 MB before the sink ever sees it. Both are needed — the
+        // sink cap bounds the Y.Map write, this bounds the raw read.
+        maxResponseBytes: MAX_STREAMED_RESPONSE_BYTES,
         signal: abort.signal,
         onContentDelta: sink.push,
         onTurnEnd: sink.onTurnEnd,

--- a/src/server/local-model/collaborator.ts
+++ b/src/server/local-model/collaborator.ts
@@ -78,9 +78,14 @@ const TRUNCATION_MARKER = "\n\n_[Reply truncated — the model exceeded the stre
  * v1 stream needs to deliver 64 KiB of content, restoring the intended order:
  * the sink cap is the primary bound (it is what shows the user a marker), this
  * is the backstop. Still four times below the client's 16 MB default, which
- * exists for whole-JSON reads rather than chat — and when a sink is attached the
- * sink's cap-abort kills the stream first anyway, so the raised ceiling is not a
- * raised memory exposure.
+ * exists for whole-JSON reads rather than chat.
+ *
+ * What the raise actually costs is `readStream`'s line buffer, and the sink
+ * cannot help there: the case that cap was added for is a newline-less flood,
+ * where no frame ever completes, so no delta is ever emitted and the sink's
+ * cap-abort can never fire. This constant is the only bound on that buffer.
+ * 4 MiB of transient decode buffer against a loopback endpoint is the price of
+ * making the sink's marker reachable at all.
  *
  * It cannot be ordered for EVERY stream: a degenerate one-char-token stream runs
  * ~260 B per content char and still trips this cap first. That path exits

--- a/src/server/local-model/collaborator.ts
+++ b/src/server/local-model/collaborator.ts
@@ -63,13 +63,30 @@ const TRUNCATION_MARKER = "\n\n_[Reply truncated — the model exceeded the stre
 /**
  * Wire-level twin of {@link MAX_STREAMED_CHARS} (#1292).
  *
- * Deliberately looser than the char cap: a streaming response carries SSE
- * framing and JSON envelope overhead around the content, and tool-call turns
- * spend bytes on arguments that never reach the sink at all. 1 MiB leaves room
- * for that while staying four orders of magnitude below the client's 16 MB
- * default, which exists for whole-JSON reads rather than chat.
+ * The two caps must be compared in CONTENT chars, not in bytes, and doing that
+ * inverts the naive reading: per-frame framing overhead means a streamed byte
+ * budget buys far fewer content chars than its size suggests. Measured against
+ * realistic frames carrying a 5-char token:
+ *
+ *   v1 SSE (id, object, created, model, system_fingerprint, choices[0].delta,
+ *   logprobs, finish_reason)  ~264 B/frame  ->  ~53 B per content char
+ *   Ollama-native NDJSON      ~132 B/frame  ->  ~26 B per content char
+ *
+ * At 1 MiB that admitted only ~20k (v1) / ~40k (native) content chars — both
+ * BELOW the 64 KiB sink cap, so the wire cap always tripped first and the sink's
+ * truncation marker was unreachable in production. 4 MiB clears the ~3.3 MiB a
+ * v1 stream needs to deliver 64 KiB of content, restoring the intended order:
+ * the sink cap is the primary bound (it is what shows the user a marker), this
+ * is the backstop. Still four times below the client's 16 MB default, which
+ * exists for whole-JSON reads rather than chat — and when a sink is attached the
+ * sink's cap-abort kills the stream first anyway, so the raised ceiling is not a
+ * raised memory exposure.
+ *
+ * It cannot be ordered for EVERY stream: a degenerate one-char-token stream runs
+ * ~260 B per content char and still trips this cap first. That path exits
+ * `error`, which is why `executeRun`'s error branch also flushes the sink.
  */
-const MAX_STREAMED_RESPONSE_BYTES = 1024 * 1024;
+const MAX_STREAMED_RESPONSE_BYTES = 4 * 1024 * 1024;
 /** Truncate selectedText before embedding in the model prompt. A large selection
  *  can't inflate token usage unboundedly; 500 chars captures any reasonable
  *  user-selected excerpt (a paragraph or two). */
@@ -330,6 +347,15 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
             timestamp: Date.now(),
           });
         } else if (exit === "error") {
+          // Commit what did arrive before the fault (#1292). The runaway case
+          // this cap exists for — a quantized model in a repetition loop —
+          // trips the WIRE cap inside readStream, which throws, so the run
+          // lands here rather than on the sink's own truncation path. Without
+          // this flush the user is left with a bubble frozen at the last 80-char
+          // flush boundary and only a generic notification to explain it.
+          // no-ops on an empty buffer, so a fault before any content still
+          // mints nothing.
+          sink.flushFinal();
           console.error(
             `[local-model] run error (exit=${exit}): ${result.metrics.errorMessage ?? "unknown"}`,
           );

--- a/src/server/local-model/config.ts
+++ b/src/server/local-model/config.ts
@@ -7,9 +7,16 @@
  * gated decision). This mirrors the hardened `LoopbackUrl` precedent in
  * `integrations/schema.ts`, extended (D2, Bryan 2026-06-19) to also accept
  * `localhost` and `[::1]` for Ollama/LM-Studio UX — by STRING match against an
- * explicit set, never DNS resolution. Not resolving is the anti-rebinding
- * property: a poisoned `localhost`→public-IP can't widen the allowlist because
- * we compare the literal hostname the URL parser produced, not a resolved IP.
+ * explicit set, never DNS resolution.
+ *
+ * What actually protects the two IP literals is that there is nothing to
+ * resolve. Declining to resolve is NOT itself the anti-rebinding property
+ * (#1295 L4): comparing a literal name and then letting `fetch` resolve that
+ * same name is validate-by-name-then-connect-by-name, which is the shape that
+ * rebinds. `localhost` was the one entry exposed to it. The client closes that
+ * gap by substituting `127.0.0.1` for a validated `localhost` before issuing
+ * the request (see `baseUrl` in `ollama-client.ts`), so the checked value and
+ * the connected value are the same address.
  */
 
 import type { AgentIdentity } from "../../shared/types.js";

--- a/src/server/local-model/index.ts
+++ b/src/server/local-model/index.ts
@@ -34,6 +34,8 @@ export interface RunTurnOpts {
   maxToolCalls?: number;
   temperature?: number;
   timeoutMs?: number;
+  /** Raw response-byte ceiling per model call (#1292). See `RunLoopOpts`. */
+  maxResponseBytes?: number;
   signal?: AbortSignal;
   isLicenseRestricted?: () => boolean;
   /** Per assistant content delta, for token streaming (#1123 M1.2). */
@@ -56,6 +58,7 @@ export async function runLocalModelTurn(opts: RunTurnOpts): Promise<LoopResult> 
     maxToolCalls: opts.maxToolCalls,
     temperature: opts.temperature,
     timeoutMs: opts.timeoutMs,
+    maxResponseBytes: opts.maxResponseBytes,
     signal: opts.signal,
     isLicenseRestricted: opts.isLicenseRestricted,
     onContentDelta: opts.onContentDelta,

--- a/src/server/local-model/loop.ts
+++ b/src/server/local-model/loop.ts
@@ -71,6 +71,10 @@ export interface RunLoopOpts {
   maxToolCalls?: number;
   temperature?: number;
   timeoutMs?: number;
+  /** Raw response-byte ceiling per `chat()` call. Omitted → the client's
+   *  `DEFAULT_MAX_RESPONSE_BYTES`, which is sized for a whole JSON response
+   *  rather than a chat bubble (#1292). */
+  maxResponseBytes?: number;
   signal?: AbortSignal;
   isLicenseRestricted?: () => boolean;
   /** When set, every turn streams and this fires per assistant content delta
@@ -122,6 +126,7 @@ export async function runLoop(opts: RunLoopOpts): Promise<LoopResult> {
         tools,
         temperature: opts.temperature,
         timeoutMs: opts.timeoutMs,
+        maxResponseBytes: opts.maxResponseBytes,
         signal,
         onContentDelta: opts.onContentDelta,
       });

--- a/src/server/local-model/loop.ts
+++ b/src/server/local-model/loop.ts
@@ -39,6 +39,10 @@ export interface LoopMetrics {
    * its step limit" — true for a turn-budget exit, a lie for a wall-clock one,
    * and it points them at raising `maxTurns` for what is actually a stalling
    * endpoint. It would also contradict `turns`, which stays below the budget.
+   *
+   * `timeout` covers BOTH wall-clock expiries: the run-budget clamp and a plain
+   * per-turn `timeoutMs`. Neither is caller-initiated, and `aborted` is silent
+   * by design, so bucketing either one there tells the user nothing at all.
    */
   exit: "clean" | "max_turns" | "max_tool_calls" | "timeout" | "aborted" | "error";
   errorMessage?: string;
@@ -70,8 +74,13 @@ export interface LoopResult {
  * Aggregate wall-clock ceiling for one run (#1295 L6).
  *
  * Five minutes: comfortably above a slow-but-working local model answering a
- * multi-turn task, and far below the ~36 minutes a stalling endpoint could hold
- * by dribbling a byte before each of 12 per-turn timeouts.
+ * multi-turn task, and far below the ~36 minutes (12 turns x 180 s) a slow
+ * endpoint could hold by answering each turn just inside its per-turn timeout.
+ *
+ * Note the shape carefully: a turn that actually HITS `timeoutMs` throws and
+ * ends the whole run at the first timeout, so the long hold is built from turns
+ * that COMPLETE late, not from turns that time out. `timeoutMs` cannot bound it
+ * because it only ever bounds one turn.
  */
 const DEFAULT_RUN_DEADLINE_MS = 5 * 60_000;
 
@@ -160,9 +169,11 @@ export async function runLoop(opts: RunLoopOpts): Promise<LoopResult> {
         metrics.exit = "aborted";
         break;
       }
-      // #1295 L6: `timeoutMs` bounds a single turn, so 12 turns of a stalling
-      // endpoint that dribbles one byte before each timeout holds a run for
-      // ~36 minutes. This is the aggregate ceiling.
+      // #1295 L6: `timeoutMs` bounds a single turn, so 12 turns that each
+      // complete just inside it hold a run for ~36 minutes. This is the
+      // aggregate ceiling. It fires only for a run whose LAST turn returned at
+      // or after the deadline — a turn still in flight is cut by the clamp
+      // below and classified in the catch instead.
       if (Date.now() - started >= runDeadlineMs) {
         metrics.exit = "timeout";
         break;
@@ -277,9 +288,31 @@ export async function runLoop(opts: RunLoopOpts): Promise<LoopResult> {
       metrics.exit = "max_turns";
     }
   } catch (err) {
-    // An abort surfaces as a fetch AbortError — classify it as "aborted", not "error".
-    if (signal?.aborted || (err instanceof Error && err.name === "AbortError")) {
+    // An abort surfaces as a fetch AbortError, but TWO different things abort a
+    // turn and they mean opposite things to the user (#1295 L6 follow-up):
+    //
+    //  - the CALLER's signal (supersede / doc close / doc switch / shutdown, and
+    //    the streaming sink's own cap-abort). Deliberately silent — the user
+    //    caused it and already has the partial reply on screen.
+    //  - `postLoopback`'s internal timeout controller, which is the ONLY other
+    //    abort source in the client. That is a wall-clock expiry: either the
+    //    per-turn `timeoutMs` or the clamp to what remained of the run budget
+    //    (`turnTimeoutMs`). Both must reach the user.
+    //
+    // The clamp is why the top-of-loop deadline check is not enough on its own:
+    // it hands `chat()` a timeout that expires exactly AT the deadline, so the
+    // in-flight turn always aborts before the loop can come back around and see
+    // `Date.now() - started >= runDeadlineMs`. Classifying every AbortError as
+    // "aborted" therefore made the "timeout" exit — and the collaborator's
+    // "it ran out of time" notification — unreachable, leaving a run that stalls
+    // out with no message at all.
+    //
+    // `signal?.aborted` is checked FIRST so a caller abort that races a timeout
+    // stays silent.
+    if (signal?.aborted) {
       metrics.exit = "aborted";
+    } else if (err instanceof Error && err.name === "AbortError") {
+      metrics.exit = "timeout";
     } else {
       metrics.exit = "error";
       metrics.errorMessage = err instanceof Error ? err.message : String(err);

--- a/src/server/local-model/loop.ts
+++ b/src/server/local-model/loop.ts
@@ -33,7 +33,14 @@ export interface LoopMetrics {
   replyFailures: number;
   blockedByLicense: number;
   wallMs: number;
-  exit: "clean" | "max_turns" | "max_tool_calls" | "aborted" | "error";
+  /**
+   * `timeout` is deliberately NOT folded into `max_turns` (#1295 L6). The
+   * collaborator branches on `max_turns` to tell the user the model "reached
+   * its step limit" — true for a turn-budget exit, a lie for a wall-clock one,
+   * and it points them at raising `maxTurns` for what is actually a stalling
+   * endpoint. It would also contradict `turns`, which stays below the budget.
+   */
+  exit: "clean" | "max_turns" | "max_tool_calls" | "timeout" | "aborted" | "error";
   errorMessage?: string;
 }
 
@@ -59,6 +66,35 @@ export interface LoopResult {
   messages: ChatMessage[];
 }
 
+/**
+ * Aggregate wall-clock ceiling for one run (#1295 L6).
+ *
+ * Five minutes: comfortably above a slow-but-working local model answering a
+ * multi-turn task, and far below the ~36 minutes a stalling endpoint could hold
+ * by dribbling a byte before each of 12 per-turn timeouts.
+ */
+const DEFAULT_RUN_DEADLINE_MS = 5 * 60_000;
+
+/** Mirrors `DEFAULT_TIMEOUT_MS` in the client — only used to compute the clamp
+ *  below, so the client stays the single authority on the value it applies. */
+const CLIENT_DEFAULT_TIMEOUT_MS = 180_000;
+
+/**
+ * Per-turn timeout, clamped to whatever remains of the run deadline (#1295 L6).
+ * Never returns 0 or negative: the loop's top-of-iteration deadline check is
+ * what stops the run, and handing `chat()` a non-positive timeout would abort
+ * instantly and surface as a confusing transport error instead.
+ */
+function turnTimeoutMs(
+  configured: number | undefined,
+  started: number,
+  deadlineMs: number,
+): number {
+  const perTurn = configured ?? CLIENT_DEFAULT_TIMEOUT_MS;
+  const remaining = deadlineMs - (Date.now() - started);
+  return Math.max(1, Math.min(perTurn, remaining));
+}
+
 export interface RunLoopOpts {
   ydoc: Y.Doc;
   config: LocalModelConfig;
@@ -75,6 +111,10 @@ export interface RunLoopOpts {
    *  `DEFAULT_MAX_RESPONSE_BYTES`, which is sized for a whole JSON response
    *  rather than a chat bubble (#1292). */
   maxResponseBytes?: number;
+  /** Aggregate wall-clock ceiling for the whole run (#1295 L6). Defaults to
+   *  {@link DEFAULT_RUN_DEADLINE_MS}. `timeoutMs` bounds one turn; this bounds
+   *  all of them together. */
+  runDeadlineMs?: number;
   signal?: AbortSignal;
   isLicenseRestricted?: () => boolean;
   /** When set, every turn streams and this fires per assistant content delta
@@ -91,6 +131,7 @@ export async function runLoop(opts: RunLoopOpts): Promise<LoopResult> {
   const { ydoc, config, tools, systemPrompt, userPrompt, signal } = opts;
   const maxTurns = opts.maxTurns ?? 12;
   const maxToolCalls = opts.maxToolCalls ?? 20;
+  const runDeadlineMs = opts.runDeadlineMs ?? DEFAULT_RUN_DEADLINE_MS;
 
   const messages: ChatMessage[] = [
     { role: "system", content: systemPrompt },
@@ -119,13 +160,24 @@ export async function runLoop(opts: RunLoopOpts): Promise<LoopResult> {
         metrics.exit = "aborted";
         break;
       }
+      // #1295 L6: `timeoutMs` bounds a single turn, so 12 turns of a stalling
+      // endpoint that dribbles one byte before each timeout holds a run for
+      // ~36 minutes. This is the aggregate ceiling.
+      if (Date.now() - started >= runDeadlineMs) {
+        metrics.exit = "timeout";
+        break;
+      }
       metrics.turns += 1;
       const res = await chat({
         config,
         messages,
         tools,
         temperature: opts.temperature,
-        timeoutMs: opts.timeoutMs,
+        // Clamp the per-turn timeout to what is left of the run budget, so the
+        // deadline can't be overshot by a whole turn. Checking only at the top
+        // of the loop would let a turn that starts one millisecond inside the
+        // budget run the full `timeoutMs` past it.
+        timeoutMs: turnTimeoutMs(opts.timeoutMs, started, runDeadlineMs),
         maxResponseBytes: opts.maxResponseBytes,
         signal,
         onContentDelta: opts.onContentDelta,

--- a/src/server/local-model/ollama-client.ts
+++ b/src/server/local-model/ollama-client.ts
@@ -257,9 +257,27 @@ function buildNativeBody(
   };
 }
 
-/** Trim trailing slashes so `${base}/v1/...` doesn't double up. */
-function baseUrl(endpoint: string): string {
-  return endpoint.replace(/\/+$/, "");
+/**
+ * Build the request base from the VALIDATED URL, never the raw endpoint string.
+ *
+ * #1295 L5: trimming trailing slashes off the raw string leaves any query or
+ * fragment attached, so `http://127.0.0.1:11434#f` became
+ * `http://127.0.0.1:11434#f/v1/chat/completions`, which `fetch` re-parses as
+ * path `/`. Not an SSRF — the authority is fixed before any `?` or `#`, so it
+ * still connects to loopback — but the request silently goes to the wrong path
+ * and fails in the generic "non-JSON response" bucket. Reassembling from
+ * `origin` + `pathname` drops both components structurally.
+ *
+ * #1295 L4: `localhost` passes validation by literal string match, and `fetch`
+ * would then resolve it independently — validate-by-name-then-connect-by-name
+ * is precisely the shape that rebinds. Substituting the address here makes the
+ * checked value and the connected value the same thing, so the loopback
+ * guarantee rests on an address rather than on RFC 6761 goodwill.
+ */
+function baseUrl(validated: URL): string {
+  const url = new URL(validated);
+  if (url.hostname.toLowerCase() === "localhost") url.hostname = "127.0.0.1";
+  return url.origin + url.pathname.replace(/\/+$/, "");
 }
 
 // ---------------------------------------------------------------------------
@@ -498,7 +516,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
   const validated = validateEndpoint(config.endpoint);
   if (!validated.ok) throw new Error(`invalid local-model endpoint (${validated.code})`);
 
-  const base = baseUrl(config.endpoint);
+  const base = baseUrl(validated.url);
   const started = Date.now();
   const transport: LocalModelTransport = config.transport;
 

--- a/tests/server/local-model/collaborator.test.ts
+++ b/tests/server/local-model/collaborator.test.ts
@@ -652,9 +652,43 @@ describe("collaborator — failure + robustness", () => {
     collab.__setConfigForTests(CONFIG);
     collab.onEvent(chatEvent("go", { documentId: "doc-err" }));
     await drain(collab);
-    // No chat reply on error; the raw error stays on stderr only.
+    // Nothing was streamed, so the error branch's flush has nothing to commit
+    // and mints no empty bubble; the raw error stays on stderr only.
     expect(chatMessages()).toHaveLength(0);
     expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("commits the streamed partial when the run exits 'error' (#1292)", async () => {
+    // The runaway case this PR exists for — a quantized model in a repetition
+    // loop — trips the WIRE cap inside readStream, which throws, so the run
+    // lands on the `error` branch and NOT on the sink's own truncation path.
+    // That branch used to notify without flushing, so everything received since
+    // the last 80-char flush boundary was dropped and the bubble stayed frozen
+    // mid-sentence.
+    setupDoc("doc-err-partial", "Body");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          // Under STREAM_FLUSH_CHARS (80), so nothing has been committed yet:
+          // this content exists ONLY in the sink buffer when the fault lands.
+          opts.onContentDelta?.("The answer is ");
+          return errorResult("local model response exceeded 1048576-byte cap");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("go", { documentId: "doc-err-partial" }));
+    await drain(collab);
+
+    const msgs = chatMessages();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].text).toBe("The answer is ");
+    // The notification is still required — the partial alone doesn't say why.
+    const notes = getBuffer().filter((n) => n.documentId === "doc-err-partial");
+    expect(notes).toHaveLength(1);
+    expect(notes[0].message).toMatch(/too large/);
     errorSpy.mockRestore();
   });
 

--- a/tests/server/local-model/collaborator.test.ts
+++ b/tests/server/local-model/collaborator.test.ts
@@ -674,7 +674,7 @@ describe("collaborator — failure + robustness", () => {
           // Under STREAM_FLUSH_CHARS (80), so nothing has been committed yet:
           // this content exists ONLY in the sink buffer when the fault lands.
           opts.onContentDelta?.("The answer is ");
-          return errorResult("local model response exceeded 1048576-byte cap");
+          return errorResult("local model response exceeded 4194304-byte cap");
         },
       }),
     );

--- a/tests/server/local-model/collaborator.test.ts
+++ b/tests/server/local-model/collaborator.test.ts
@@ -852,3 +852,154 @@ describe("dark audit — engine reachability", () => {
     expect(offenders).toEqual([]);
   });
 });
+
+describe("collaborator — streamed reply is bounded (#1292)", () => {
+  // Mirrors MAX_STREAMED_CHARS in collaborator.ts. Kept as a literal rather than
+  // exported: these tests assert the OBSERVABLE contract (a bounded, marked
+  // message in the Y.Map), so importing the constant would let a bad cap change
+  // move the test with it.
+  const CAP = 64 * 1024;
+
+  /** Push `total` chars in realistic ~16 KiB chunks, like undici delivers them. */
+  function pushChunks(opts: { onContentDelta?: (d: string) => void }, total: number) {
+    const CHUNK = 16 * 1024;
+    for (let sent = 0; sent < total; sent += CHUNK) {
+      opts.onContentDelta?.("x".repeat(Math.min(CHUNK, total - sent)));
+    }
+  }
+
+  it("caps a runaway stream and persists the truncation marker to the Y.Map", async () => {
+    setupDoc("doc-runaway", "Body");
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          // A repetition-looping model: 4x the cap, no tool calls, never stops.
+          pushChunks(opts, CAP * 4);
+          // Yield so the cap's deferred commit+abort actually runs mid-stream.
+          // This is what makes the test discriminating: once aborted, the
+          // terminal `flushFinal()` in executeRun is skipped (its `stillOwner()`
+          // carries the abort clause), so the ONLY thing that can have written
+          // the marker is the cap's own commit. Without this yield the clean
+          // exit's flushFinal commits the buffer for us and the assertion below
+          // passes even when the abort happens first — verified by inverting the
+          // ordering, where this test stayed green and only the abort test caught it.
+          await new Promise((r) => setTimeout(r, 0));
+          opts.onTurnEnd?.({ hadToolCalls: false });
+          return cleanResult("unused");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("go", { documentId: "doc-runaway" }));
+    await drain(collab);
+
+    const msgs = chatMessages();
+    expect(msgs).toHaveLength(1);
+
+    // THE load-bearing assertion, and the reason this reads the Y.Map rather
+    // than the sink. `write()` bails on `!isOwner()`, which includes
+    // `!abort.signal.aborted` — so an implementation that aborts BEFORE
+    // committing the marker leaves the bubble frozen at the last 80-char flush
+    // boundary and the user never learns the reply was cut. A sink-level
+    // assertion, or one that only checks `abort` was called, passes against
+    // exactly that bug.
+    expect(msgs[0].text).toContain("Reply truncated");
+
+    // Bounded: the cap plus one marker, not 4x the cap.
+    expect(msgs[0].text.length).toBeLessThan(CAP + 500);
+    expect(msgs[0].text.length).toBeGreaterThan(CAP - 500);
+  });
+
+  it("appends the truncation marker exactly once across many post-cap deltas", async () => {
+    setupDoc("doc-marker-once", "Body");
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          pushChunks(opts, CAP * 8); // many chunks land after the latch trips
+          await new Promise((r) => setTimeout(r, 0)); // let the cap commit+abort run
+          opts.onTurnEnd?.({ hadToolCalls: false });
+          return cleanResult("unused");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("go", { documentId: "doc-marker-once" }));
+    await drain(collab);
+
+    const text = chatMessages()[0].text;
+    expect(text.split("Reply truncated")).toHaveLength(2); // one occurrence
+  });
+
+  it("aborts the run once capped, so the endpoint stops being read", async () => {
+    setupDoc("doc-abort", "Body");
+    let signalAfterCap: boolean | undefined;
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          pushChunks(opts, CAP * 2);
+          // The cap commits + aborts on a deferred task; yield so it runs.
+          await new Promise((r) => setTimeout(r, 0));
+          signalAfterCap = opts.signal?.aborted;
+          opts.onTurnEnd?.({ hadToolCalls: false });
+          return cleanResult("unused");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("go", { documentId: "doc-abort" }));
+    await drain(collab);
+
+    expect(signalAfterCap).toBe(true);
+    // Positive control on the same sample: the abort must not have cost us the
+    // marker. Asserting the abort alone is satisfied by the broken ordering.
+    expect(chatMessages()[0].text).toContain("Reply truncated");
+  });
+
+  it("keeps the marker when a tool-call turn ends after the cap trips", async () => {
+    setupDoc("doc-marker-toolcall", "Body");
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          pushChunks(opts, CAP * 2);
+          // `onTurnEnd({hadToolCalls:true})` normally cancels the pending flush
+          // and clears the buffer to drop preamble — which would wipe the
+          // not-yet-committed marker. The truncation latch must win.
+          opts.onTurnEnd?.({ hadToolCalls: true });
+          return cleanResult("unused");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("go", { documentId: "doc-marker-toolcall" }));
+    await drain(collab);
+
+    const msgs = chatMessages();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].text).toContain("Reply truncated");
+  });
+
+  it("passes an explicit chat-sized response-byte ceiling, not the 16 MB client default", async () => {
+    setupDoc("doc-bytecap", "Body");
+    let seen: number | undefined;
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          seen = opts.maxResponseBytes;
+          opts.onContentDelta?.("hi");
+          opts.onTurnEnd?.({ hadToolCalls: false });
+          return cleanResult("hi");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("go", { documentId: "doc-bytecap" }));
+    await drain(collab);
+
+    // Assert on the VALUE reaching runTurn. Asserting only "no error" would pass
+    // while the option silently defaulted to DEFAULT_MAX_RESPONSE_BYTES (16 MB),
+    // which is the bug — the field being threaded but never set.
+    expect(seen).toBeDefined();
+    expect(seen).toBeLessThan(16 * 1024 * 1024);
+    expect(seen).toBeGreaterThanOrEqual(CAP);
+  });
+});

--- a/tests/server/local-model/loop.test.ts
+++ b/tests/server/local-model/loop.test.ts
@@ -272,7 +272,6 @@ describe("runLoop — aggregate wall-clock deadline (#1295 L6)", () => {
     const r = await runLoop(base({ runDeadlineMs: 50, timeoutMs: 600_000, maxTurns: 99 }));
 
     expect(r.metrics.exit).toBe("timeout");
-    expect(r.metrics.exit).not.toBe("aborted");
     expect(r.metrics.errorMessage).toBeUndefined();
   });
 

--- a/tests/server/local-model/loop.test.ts
+++ b/tests/server/local-model/loop.test.ts
@@ -179,3 +179,61 @@ describe("runLoop — abort", () => {
     expect(r.metrics.errorMessage).toMatch(/connection refused/);
   });
 });
+
+describe("runLoop — aggregate wall-clock deadline (#1295 L6)", () => {
+  it("stops on the run deadline with its own exit reason, not max_turns", async () => {
+    stubFetch(() => v1ToolCall("get_outline")); // never terminates on its own
+    const r = await runLoop(base({ runDeadlineMs: 1, maxTurns: 99, maxToolCalls: 99 }));
+
+    // The distinction is the whole point of the fix. The collaborator branches
+    // on `max_turns` to tell the user the model "reached its step limit" — a
+    // lie for a wall-clock exit, and it sends them to raise maxTurns for what
+    // is really a stalling endpoint.
+    expect(r.metrics.exit).toBe("timeout");
+    expect(r.metrics.exit).not.toBe("max_turns");
+
+    // And it must be self-consistent: a timeout exit reports turns BELOW the
+    // budget, which is exactly why reusing "max_turns" would corrupt the metric.
+    expect(r.metrics.turns).toBeLessThan(99);
+  });
+
+  it("does not fire when the run finishes inside the budget", async () => {
+    // Positive control on the same sample: without this, the assertion above
+    // would also pass against an implementation that always exits "timeout".
+    stubFetch(() => v1Text("done"));
+    const r = await runLoop(base({ runDeadlineMs: 60_000 }));
+    expect(r.metrics.exit).toBe("clean");
+    expect(r.finalContent).toBe("done");
+  });
+
+  it("clamps the per-turn timeout to the remaining budget", async () => {
+    // A deadline checked only at the top of the loop lets a turn that starts one
+    // millisecond inside the budget run the full per-turn timeout past it.
+    // The stub must HONOUR the abort signal. A stub that merely sleeps and then
+    // resolves is testing itself, not the clamp — the first draft of this test
+    // did exactly that and passed against an unclamped timeout.
+    let abortedAfterMs: number | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            const t0 = Date.now();
+            const signal = init.signal as AbortSignal | undefined;
+            signal?.addEventListener("abort", () => {
+              abortedAfterMs = Date.now() - t0;
+              reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+            });
+            // Never resolves on its own: only the timeout can end this turn.
+          }),
+      ),
+    );
+
+    await runLoop(base({ runDeadlineMs: 50, timeoutMs: 600_000, maxTurns: 1 }));
+
+    // Unclamped, the turn would have been governed by the 600s per-turn timeout
+    // and this test would hang rather than abort in tens of milliseconds.
+    expect(abortedAfterMs).toBeDefined();
+    expect(abortedAfterMs).toBeLessThan(5_000);
+  });
+});

--- a/tests/server/local-model/loop.test.ts
+++ b/tests/server/local-model/loop.test.ts
@@ -155,14 +155,18 @@ describe("runLoop — abort", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("classifies a thrown AbortError as 'aborted', not 'error'", async () => {
+  it("classifies a CALLER-initiated AbortError as 'aborted', not 'error'", async () => {
+    // The caller's signal is what makes this "aborted" rather than "timeout":
+    // the user superseded / closed / switched, so the exit is silent by design.
+    const controller = new AbortController();
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
+        controller.abort();
         throw Object.assign(new Error("The operation was aborted"), { name: "AbortError" });
       }),
     );
-    const r = await runLoop(base());
+    const r = await runLoop(base({ signal: controller.signal }));
     expect(r.metrics.exit).toBe("aborted");
     expect(r.metrics.errorMessage).toBeUndefined();
   });
@@ -235,5 +239,66 @@ describe("runLoop — aggregate wall-clock deadline (#1295 L6)", () => {
     // and this test would hang rather than abort in tens of milliseconds.
     expect(abortedAfterMs).toBeDefined();
     expect(abortedAfterMs).toBeLessThan(5_000);
+  });
+
+  it("reports 'timeout' when the budget expires DURING a turn, not 'aborted'", async () => {
+    // The clamp above is exactly what made the `timeout` exit unreachable: it
+    // hands chat() a timeout expiring AT the deadline, so the in-flight turn
+    // always aborts before the loop can come back around to its top-of-loop
+    // deadline check. Every wall-clock expiry therefore arrived as an
+    // AbortError — and `aborted` is deliberately SILENT in the collaborator, so
+    // a run that stalled out told the user nothing at all.
+    //
+    // Note what the sibling test above does NOT do: it asserts only that the
+    // abort fired promptly, never what `exit` became. The 'timeout' assertion
+    // in the first test of this block reaches its branch only because
+    // runDeadlineMs:1 lets a synchronously-resolving stub complete a turn past
+    // the deadline — no endpoint takes real time there. This is the case a real
+    // stalling endpoint produces.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            const signal = init.signal as AbortSignal | undefined;
+            signal?.addEventListener("abort", () =>
+              reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+            );
+            // Never resolves: only the clamped per-turn timeout can end this.
+          }),
+      ),
+    );
+
+    const r = await runLoop(base({ runDeadlineMs: 50, timeoutMs: 600_000, maxTurns: 99 }));
+
+    expect(r.metrics.exit).toBe("timeout");
+    expect(r.metrics.exit).not.toBe("aborted");
+    expect(r.metrics.errorMessage).toBeUndefined();
+  });
+
+  it("a plain per-turn timeout is also 'timeout' (no caller abort involved)", async () => {
+    // Same silent-failure class, reached without the run budget: with the
+    // shipped defaults the FIRST turn is not clamped (300 s budget > 180 s
+    // per-turn), so a stalling endpoint hits `timeoutMs` and ends the whole run
+    // there. Bucketing that as `aborted` would leave the primary stalling case
+    // silent even with the budget-expiry fix in place.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            const signal = init.signal as AbortSignal | undefined;
+            signal?.addEventListener("abort", () =>
+              reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+            );
+          }),
+      ),
+    );
+
+    // timeoutMs well below the remaining budget → the clamp is NOT the binding
+    // constraint, so this exercises the per-turn timer specifically.
+    const r = await runLoop(base({ runDeadlineMs: 600_000, timeoutMs: 30, maxTurns: 99 }));
+
+    expect(r.metrics.exit).toBe("timeout");
   });
 });

--- a/tests/server/local-model/ollama-client.test.ts
+++ b/tests/server/local-model/ollama-client.test.ts
@@ -370,3 +370,60 @@ describe("ollama-client — streaming (#1123 M1.2)", () => {
     ).rejects.toThrow();
   });
 });
+
+describe("ollama-client — endpoint is rebuilt from the validated URL (#1295 L4/L5)", () => {
+  const ok = () => new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }));
+
+  it("drops a fragment instead of welding it in front of the API path", async () => {
+    const fetchMock = stubFetch(ok);
+    await chat({
+      config: { ...V1, endpoint: "http://127.0.0.1:11434#frag" },
+      messages: [{ role: "user", content: "hi" }],
+      tools: [],
+    });
+    // Trimming trailing slashes off the RAW string left the fragment attached,
+    // producing `...:11434#frag/v1/chat/completions`, which fetch re-parses as
+    // path `/` — a silent wrong-path request surfacing as "non-JSON response".
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:11434/v1/chat/completions",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("drops a query string the same way", async () => {
+    const fetchMock = stubFetch(ok);
+    await chat({
+      config: { ...V1, endpoint: "http://127.0.0.1:11434/?k=v" },
+      messages: [{ role: "user", content: "hi" }],
+      tools: [],
+    });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.1:11434/v1/chat/completions");
+  });
+
+  it("connects to 127.0.0.1 for a validated `localhost`, so check and connect agree", async () => {
+    const fetchMock = stubFetch(ok);
+    await chat({
+      config: { ...V1, endpoint: "http://localhost:11434" },
+      messages: [{ role: "user", content: "hi" }],
+      tools: [],
+    });
+    // The literal-name match accepted `localhost`, but fetch would have resolved
+    // it independently — validate-by-name-then-connect-by-name is the rebinding
+    // shape. The dialed URL must carry the address, not the name.
+    const dialed = fetchMock.mock.calls[0]?.[0] as string;
+    expect(dialed).toBe("http://127.0.0.1:11434/v1/chat/completions");
+    expect(dialed).not.toContain("localhost");
+  });
+
+  it("still preserves a legitimate base path", async () => {
+    // Positive control: the fix rebuilds the URL, so prove it does not also
+    // discard a path the user deliberately configured (a reverse-proxied Ollama).
+    const fetchMock = stubFetch(ok);
+    await chat({
+      config: { ...V1, endpoint: "http://127.0.0.1:11434/ollama/" },
+      messages: [{ role: "user", content: "hi" }],
+      tools: [],
+    });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.1:11434/ollama/v1/chat/completions");
+  });
+});


### PR DESCRIPTION
Refs #1292, and #1295 items L4, L5, L6.

Wave 1 of the v1.0 RC security-gate batch, grouped by file locality rather than by issue: all four findings live in `src/server/local-model/`, and two of them share `loop.ts`. Splitting them by issue would have put a collision across two PRs.

## All of this is dark, and nothing here was exercised

`BYO_MODELS_ENABLED` is a literal `const false` and `startLocalModelCollaborator()` early-returns before `wire()`, so no subscriber is registered and no fetch is issued. **Passing tests are the only evidence in this PR.** There is no dogfooding path and no E2E; I am not claiming these fixes were observed working against a real model. They block the flag flip, not the current release.

## #1292 — the streamed reply had no ceiling

Every flush re-`set`s the *entire* message value into the ctrl-room Y.Map, which Hocuspocus broadcasts to every connected client. A stream of length *n* therefore costs O(n²) in Yjs encoding and WebSocket bytes. The only other ceiling was a 16 MB raw-byte cap sized for a whole JSON response, so a quantized model in a repetition loop — a routine failure mode, no attacker required — reaches it and the user's own editor is the victim.

Both halves landed, because either alone is insufficient: the sink cap (64 KiB) bounds the Y.Map write *and* what reaches the persisted session file; the explicit `maxResponseBytes` (1 MiB) bounds the raw read before the sink ever sees it.

### The ordering is the fix, not a detail

The issue says "stop appending, write a truncation marker once, `ctx.abort.abort()`". Done in that order it does not work. `write()` returns early on `!isOwner()`, and `isOwner()` includes `!ctx.abort.signal.aborted` — so aborting first permanently disables the only write path, the marker never reaches the Y.Map, and the user gets a silently truncated reply. `executeRun`'s terminal `flushFinal()` can't rescue it either; its `stillOwner()` carries the same clause.

Both calls now ride one deferred task, which guarantees the order while preserving this file's nested-txn invariant (the sink flushes only from a timer, never on a delta stack).

A related race the issue doesn't mention: `onTurnEnd({hadToolCalls: true})` cancels the pending flush and clears the buffer to drop preamble, which would have wiped the not-yet-committed marker. The truncation latch now wins.

## #1295 L4 + L5 — one line carried both

`baseUrl` trimmed trailing slashes off the raw endpoint and never used the validated URL, so `http://127.0.0.1:11434#f` became `...#f/v1/chat/completions`, which `fetch` re-parses as path `/`. Not an SSRF — the authority is fixed before any `?` or `#` — just a silently wrong path failing in the generic "non-JSON response" bucket.

The same place fixes L4's rationale. The docstring claimed that declining to resolve *is* the anti-rebinding property. It isn't: comparing a literal name and then letting `fetch` resolve that same name is validate-by-name-then-connect-by-name, which is the shape that rebinds. The two IP literals are safe because there is nothing to resolve; `localhost` was the entry exposed to it. Substituting the address makes the comment true rather than merely reworded.

## #1295 L6 — and why the suggested exit reason was wrong

`maxTurns` caps iterations, `timeoutMs` caps one turn, nothing capped the run: an endpoint dribbling a byte before each of 12 per-turn timeouts holds a collaborator ~36 minutes.

The issue proposes exiting `"max_turns"`. **That produces a false statement to the user.** `collaborator.ts` branches on it to say the model "reached its step limit" — untrue for a wall-clock exit, and it sends them to raise `maxTurns` for what is really a stalling endpoint, while `metrics.turns` sits below budget and contradicts it. A `"timeout"` exit with its own message keeps the string and the metric honest.

The per-turn timeout is clamped to the remaining budget rather than accepting overshoot, since a top-of-loop check lets a turn starting one millisecond inside the budget run the full timeout past it.

## Tests, and two that were wrong first

Every assertion here was confirmed to fail against the unfixed code. Two needed rewriting because they passed for the wrong reason:

- **The cap tests read the persisted Y.Map, not the sink.** A sink-level assertion — or one that merely checks `abort` was called — passes against the exact ordering bug this PR exists to prevent. My first draft of the headline test still passed when I inverted the ordering, because a clean exit's `flushFinal` committed the buffer for it; it now yields mid-stream so the cap's own commit is the only thing that can have written the marker. Inverted, all three marker tests now fail.
- **The clamp test stubbed `fetch` to sleep and resolve**, which tested the stub rather than the clamp and passed unclamped. It now honours the abort signal; without the clamp it hangs to the test timeout.

Full local gate green: typecheck (1295 files, 0 errors), `audit:origins` clean, `npm test -- --run` 5752 passed / 0 failed.

GitHub Actions is in a major outage, so CI has not run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKcPLgN9YGgfC1WvPJ2Vq


---

## Corrections after review (2026-08-07)

Everything here is still behind `BYO_MODELS_ENABLED` (a literal `const false`), so none of it ships today. Fixed now because a wrong exit path is cheap to fix while dark and expensive at the flip.

### The `timeout` exit was unreachable — the feature the body describes did not exist

The body says "a `timeout` exit with its own message keeps the string and the metric honest." At PR head it did not, because the exit could never be produced.

`loop.ts` clamps the per-turn timeout to the remaining run budget, so wall-clock expiry surfaces as an `AbortError`, and the catch mapped **every** `AbortError` to `"aborted"` — which `collaborator.ts` treats as deliberately silent. So `collaborator.ts`'s "it ran out of time" branch was dead code, and a run that exhausted its budget told the user nothing at all.

`dd6693f` distinguishes the two abort sources. The ordering is load-bearing rather than stylistic: `postLoopback` builds `AbortSignal.any([opts.signal, timeoutCtrl.signal])`, and the sink's own cap path aborts the *caller* controller. Testing `AbortError` first would have turned every sink truncation into a spurious "it ran out of time" notification stacked on top of the truncation marker. The check reads `signal?.aborted` first for that reason.

As of `dd6693f` the body's claim is true. It was not true when written.

### The two caps were the wrong way round

The body describes `MAX_STREAMED_RESPONSE_BYTES` as "deliberately looser" than the character cap. At 1 MiB it was **tighter** in practice: per-frame SSE/JSON overhead runs 20–40× for token-per-frame streaming, so the wire cap tripped first and the 64 KiB character cap — the one with the graceful truncation marker — never got the chance to. The constant is now **4 MiB**; any text quoting 1 MiB is stale.

`b172225` also fixes the `exit === "error"` branch, which never called `flushFinal()` and so dropped buffered text on the error path.

### The "~36 minutes" worked example has the wrong mechanism

The body describes "an endpoint dribbling a byte before each of 12 per-turn timeouts holds a collaborator ~36 minutes". A turn that hits its per-turn timeout throws and ends the **whole run at the first timeout**. The 36-minute number is right; the mechanism is twelve turns that each complete *just inside* the per-turn timeout, never one that trips it twelve times. The same conflation appeared in two source comments in `loop.ts`; both corrected in `dd6693f`.

### One defect found beyond the review

`5258591` — the sink could not bound a flood containing no newlines. Found while writing the negative control for the cap ordering, not by the review.

### On the test stubs

The abort tests use a fetch stub that *honours* the abort signal and never resolves on its own. A stub that merely sleeps would be testing itself — which is the trap the pre-existing clamp test already documents in a comment, and the reason it was worth re-reading before writing new ones.
