### PR TITLE
feat(launcher): say so when Claude is running in a different folder

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -11,7 +11,9 @@ import { generateNotificationId } from "../shared/utils";
 import { bannerStackHeight } from "./actions/bannerStackHeight.svelte.js";
 import {
   createScratchpad,
+  deriveCwdFromDocPath,
   relaunchClaudeCode,
+  relaunchClaudeHere,
   SCRATCHPAD_EMPTY_STATE_DEBOUNCE_MS,
   saveStore,
   shouldAutoOpenScratchpad,
@@ -65,6 +67,7 @@ import { matchShortcut, type ShortcutContext, type ShortcutId } from "./hooks/us
 import { createChatState } from "./hooks/useChatState.svelte";
 import { createClosedTabStack } from "./hooks/useClosedTabStack.svelte";
 import { createConnectionBanner } from "./hooks/useConnectionBanner.svelte";
+import { createCwdDrift } from "./hooks/useCwdDrift.svelte";
 import { createDensity } from "./hooks/useDensity.svelte";
 import { createDragResize } from "./hooks/useDragResize.svelte";
 import { createRootEditorFont } from "./hooks/useEditorFont.svelte";
@@ -114,6 +117,12 @@ import { pmSelectionToFlat } from "./positions";
 import FormattingBar from "./shell/FormattingBar.svelte";
 import TitleBar from "./shell/TitleBar.svelte";
 import { addressedAiNotice } from "./status/addressed-ai-notice.js";
+import {
+  dismissDrift,
+  driftDismissed,
+  noteDriftSeen,
+  optOutOfDriftNudge,
+} from "./status/cwdDriftDismiss.svelte";
 import StatusBar from "./status/StatusBar.svelte";
 import DocumentTabs from "./tabs/DocumentTabs.svelte";
 import {
@@ -465,6 +474,93 @@ const aiReadiness = createAiReadiness({
   soloMode: () => modeState.tandemMode === "solo",
 });
 
+// #1282 working-folder drift. Fed the SAME derivation the relaunch action uses,
+// so the question asked and the action offered can never be about different
+// folders. `deriveCwdFromDocPath` is the ONLY screen here on purpose — it
+// already rejects `upload://` and every other non-filesystem URI, and this is
+// the one feature whose whole thesis is that the query side owns no predicate
+// of its own. An `isUploadPath` check alongside it would be exactly that: a
+// second copy, free to answer differently after either one is edited.
+const cwdDrift = createCwdDrift(() => {
+  const tab = yjsSync.tabs.find((t) => t.id === yjsSync.activeTabId);
+  return deriveCwdFromDocPath(tab?.filePath ?? null);
+});
+
+/**
+ * The drift the status bar may actually show: the server's verdict minus the
+ * suppression the user asked for. Applied here rather than inside the pill's
+ * pure view so all three layers stay in `cwdDriftDismiss` — split across two
+ * files, "is this dismissed" becomes two questions that can answer differently.
+ */
+const visibleCwdDrift = $derived.by(() => {
+  const d = cwdDrift.drift;
+  if (d === null) return null;
+  return driftDismissed(d.claudeCwd, d.suggestedCwd) ? null : d;
+});
+
+/** All three drift notices share the launcher channel and envelope; only the
+ * severity and the words differ. */
+function pushDriftNotice(severity: "info" | "warning", message: string): void {
+  notifications.push({
+    id: generateNotificationId(),
+    type: "launcher",
+    severity,
+    message,
+    timestamp: Date.now(),
+  });
+}
+
+// One-time explainer, on the first drift this install ever surfaces. An amber
+// chip in the status bar cannot introduce a concept ("Claude Code scopes what it
+// can read to one folder") that the user has never encountered; after the first
+// row it is a reminder and the chip is enough on its own.
+$effect(() => {
+  const d = visibleCwdDrift;
+  if (d === null || !noteDriftSeen()) return;
+  pushDriftNotice(
+    "info",
+    `Claude is running in ${d.claudeCwd}. Claude Code reads a project's CLAUDE.md, ` +
+      ".claude/ settings and git history from the folder it was started in, so it " +
+      "can edit this document without seeing anything around it. The amber folder " +
+      "chip in the status bar offers to move it.",
+  );
+});
+
+function relaunchInDriftFolder(): void {
+  relaunchClaudeHere();
+  refreshAiReadinessAfterLauncherAction();
+}
+
+function dismissDriftNudge(): void {
+  const d = cwdDrift.drift;
+  if (d === null) return;
+  if (!dismissDrift(d.claudeCwd, d.suggestedCwd)) return;
+  // The session backstop just tripped. Going quiet without saying so would
+  // leave "Claude is in the right folder now" and "Tandem stopped mentioning
+  // it" looking identical, which are opposite facts.
+  pushDriftNotice(
+    "info",
+    "I'll stop mentioning Claude's working folder for the rest of this session. " +
+      "“Relaunch Claude in this folder” is still in the command palette.",
+  );
+}
+
+function optOutOfDriftNudgePermanently(): void {
+  // A failed write degrades the promise to what it can actually keep — this
+  // session — and says so, rather than claiming a durable opt-out it hasn't got.
+  if (optOutOfDriftNudge()) {
+    pushDriftNotice(
+      "info",
+      "Working-folder reminders are off. “Relaunch Claude in this folder” is still in the command palette.",
+    );
+    return;
+  }
+  pushDriftNotice(
+    "warning",
+    "Working-folder reminders are off for this session — this browser wouldn't let Tandem save the preference, so they'll be back next launch.",
+  );
+}
+
 // Boot-race guard for the first-run wizard. The hook's boot fetch fires once at
 // construction with no retry; in the desktop app the WebView loads immediately
 // while the sidecar is still spawning (no `visible:false`, sidecar started on a
@@ -505,6 +601,13 @@ function connectAi(): void {
 function refreshAiReadinessAfterLauncherAction(): void {
   setTimeout(() => aiReadiness.refresh(), 2_000);
   setTimeout(() => aiReadiness.refresh(), 5_000);
+  // #1282: the launcher's cwd is not reactive state on this side — it lives
+  // behind a loopback-only status field the drift route reads server-side. So a
+  // relaunch that MOVES Claude changes nothing the drift effect is watching (the
+  // document path is the same document), and the pill would keep naming the
+  // folder Claude just left. Re-probe on the same staggered schedule.
+  setTimeout(() => cwdDrift.refresh(), 2_000);
+  setTimeout(() => cwdDrift.refresh(), 5_000);
 }
 
 /** Restarts the stopped Claude Code process (the "Restart Claude Code" CTA). */
@@ -2628,6 +2731,10 @@ const shouldShowModelPicker = $derived(
       lastSaveOk={saveStore.lastSaveOk}
       {editor}
       {heldCount}
+      cwdDrift={visibleCwdDrift}
+      onRelaunchInFolder={relaunchInDriftFolder}
+      onDismissDrift={dismissDriftNudge}
+      onOptOutDrift={optOutOfDriftNudgePermanently}
     />
 
     <SettingsModal

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -124,6 +124,7 @@ import {
   optOutOfDriftNudge,
 } from "./status/cwdDriftDismiss.svelte";
 import StatusBar from "./status/StatusBar.svelte";
+import { cwdDriftPill } from "./status/status-ai-view";
 import DocumentTabs from "./tabs/DocumentTabs.svelte";
 import {
   tabIdsToCloseLeft,
@@ -477,26 +478,46 @@ const aiReadiness = createAiReadiness({
 // #1282 working-folder drift. Fed the SAME derivation the relaunch action uses,
 // so the question asked and the action offered can never be about different
 // folders. `deriveCwdFromDocPath` is the ONLY screen here on purpose — it
-// already rejects `upload://` and every other non-filesystem URI, and this is
-// the one feature whose whole thesis is that the query side owns no predicate
-// of its own. An `isUploadPath` check alongside it would be exactly that: a
-// second copy, free to answer differently after either one is edited.
-const cwdDrift = createCwdDrift(() => {
-  const tab = yjsSync.tabs.find((t) => t.id === yjsSync.activeTabId);
-  return deriveCwdFromDocPath(tab?.filePath ?? null);
-});
+// rejects `upload://` (and anything else matching `scheme://`), and this is the
+// one feature whose whole thesis is that the query side owns no predicate of its
+// own. An `isUploadPath` check alongside it would be exactly that: a second
+// copy, free to answer differently after either one is edited.
+// Memoized to a STRING, not recomputed from `yjsSync.tabs` inside the hook's
+// effect. `handleDocumentList` reassigns the whole tabs array on every
+// `openDocuments` broadcast, most of which change nothing about the active tab;
+// subscribing the effect to the array would abort the in-flight probe and
+// restart the 1.5s settle timer on each one. `$derived`'s value equality absorbs
+// the no-ops.
+const driftCwd = $derived(
+  deriveCwdFromDocPath(yjsSync.tabs.find((t) => t.id === yjsSync.activeTabId)?.filePath ?? null),
+);
+const cwdDrift = createCwdDrift(() => driftCwd);
 
 /**
- * The drift the status bar may actually show: the server's verdict minus the
- * suppression the user asked for. Applied here rather than inside the pill's
- * pure view so all three layers stay in `cwdDriftDismiss` — split across two
- * files, "is this dismissed" becomes two questions that can answer differently.
+ * The drift the status bar may actually show: the server's verdict, minus the
+ * suppression the user asked for, minus the states where the pill is suppressed
+ * anyway.
+ *
+ * `cwdDriftPill` is called HERE and the result passed down, rather than computed
+ * inside `StatusBar`, because two things need the same answer: the pill, and the
+ * one-time explainer below whose copy points at that pill. Deriving the
+ * explainer from `visibleCwdDrift` instead left its precondition strictly weaker
+ * than the pill's render condition — during the window where `aiChip` is a stale
+ * "restart", the explainer fired, spent the once-per-install token, and directed
+ * the user to an amber chip that `cwdDriftPill` had suppressed. That is
+ * lesson 90's shape exactly, and the irony was that both files' comments argue
+ * the suppression logic must live in one place.
+ *
+ * User-facing suppression (per-pair dismissal, session backstop, opt-out) stays
+ * in `cwdDriftDismiss`; the stale-CTA gate stays in `cwdDriftPill`. Each answers
+ * in one place; this composes them once.
  */
 const visibleCwdDrift = $derived.by(() => {
   const d = cwdDrift.drift;
   if (d === null) return null;
   return driftDismissed(d.claudeCwd, d.suggestedCwd) ? null : d;
 });
+const cwdDriftView = $derived(cwdDriftPill(visibleCwdDrift, aiReadiness.chip));
 
 /** All three drift notices share the launcher channel and envelope; only the
  * severity and the words differ. */
@@ -510,25 +531,30 @@ function pushDriftNotice(severity: "info" | "warning", message: string): void {
   });
 }
 
-// One-time explainer, on the first drift this install ever surfaces. An amber
-// chip in the status bar cannot introduce a concept ("Claude Code scopes what it
-// can read to one folder") that the user has never encountered; after the first
-// row it is a reminder and the chip is enough on its own.
+// One-time explainer, on the first drift this install ever SHOWS. An amber chip
+// in the status bar cannot introduce a concept ("Claude Code scopes what it can
+// read to one folder") that the user has never encountered; after the first row
+// it is a reminder and the chip is enough on its own.
+//
+// Gated on `cwdDriftView`, the same value the pill renders from — the copy ends
+// by pointing at that chip, so firing when the chip is suppressed would spend
+// the once-per-install token on a notice about something not on screen.
 $effect(() => {
-  const d = visibleCwdDrift;
-  if (d === null || !noteDriftSeen()) return;
+  if (cwdDriftView === null || visibleCwdDrift === null || !noteDriftSeen()) return;
   pushDriftNotice(
     "info",
-    `Claude is running in ${d.claudeCwd}. Claude Code reads a project's CLAUDE.md, ` +
-      ".claude/ settings and git history from the folder it was started in, so it " +
-      "can edit this document without seeing anything around it. The amber folder " +
-      "chip in the status bar offers to move it.",
+    `Claude is running in ${visibleCwdDrift.claudeCwd}. Claude Code reads a project's ` +
+      "CLAUDE.md, .claude/ settings and git history from the folder it was started " +
+      "in, so it can edit this document without seeing anything around it. The amber " +
+      "folder chip in the status bar offers to move it.",
   );
 });
 
+/** The pill's action row. `relaunchClaudeHere` re-probes on its own (via the
+ * injected `afterLauncherAction`), so both this and the palette command recover
+ * the same way. */
 function relaunchInDriftFolder(): void {
   relaunchClaudeHere();
-  refreshAiReadinessAfterLauncherAction();
 }
 
 function dismissDriftNudge(): void {
@@ -610,10 +636,11 @@ function refreshAiReadinessAfterLauncherAction(): void {
   setTimeout(() => cwdDrift.refresh(), 5_000);
 }
 
-/** Restarts the stopped Claude Code process (the "Restart Claude Code" CTA). */
+/** Restarts the stopped Claude Code process (the "Restart Claude Code" CTA).
+ * The re-probe is the action's own (`afterLauncherAction`), not this wrapper's —
+ * it used to live here, which is how the palette entry point came to lack it. */
 function restartClaude(): void {
   relaunchClaudeCode();
-  refreshAiReadinessAfterLauncherAction();
 }
 
 /** Drops Claude's saved conversation and restarts fresh (the EmptyState
@@ -622,7 +649,6 @@ function restartClaude(): void {
  *  doc comment on `EmptyState`'s Props. */
 function startFreshClaude(): void {
   startFreshClaudeCode();
-  refreshAiReadinessAfterLauncherAction();
 }
 
 // #1018 loud failures: ChatPanel (chat send) and Toolbar ("Send to Claude"
@@ -1021,6 +1047,7 @@ wireActionDeps({
       timestamp: Date.now(),
     });
   },
+  afterLauncherAction: refreshAiReadinessAfterLauncherAction,
   openSettings: openSettingsModalWithAck,
   toggleSoloMode: () =>
     modeState.setTandemMode(modeState.tandemMode === "solo" ? "tandem" : "solo"),
@@ -2731,7 +2758,7 @@ const shouldShowModelPicker = $derived(
       lastSaveOk={saveStore.lastSaveOk}
       {editor}
       {heldCount}
-      cwdDrift={visibleCwdDrift}
+      {cwdDriftView}
       onRelaunchInFolder={relaunchInDriftFolder}
       onDismissDrift={dismissDriftNudge}
       onOptOutDrift={optOutOfDriftNudgePermanently}

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -55,6 +55,14 @@ interface ActionDeps {
    * the folder Claude had just left, indefinitely, which is precisely what that
    * refresh exists to prevent. Owning it here makes "every launcher action
    * re-probes" true by construction instead of by everyone remembering.
+   *
+   * Fired from the `finally` of `relaunchHere` / `startFreshConversation` — NOT
+   * from the exported wrappers. The wrappers used to call it beside their
+   * `void`-ed invocation, which runs the moment the async function suspends at
+   * its first `await`, i.e. before the blocking `confirm()`. That put the
+   * staggered re-probes ahead of the mutation they were meant to observe, so a
+   * user who read the dialog for a few seconds got two answers describing the
+   * world before the relaunch. Keep it at the mutation.
    */
   afterLauncherAction: () => void;
   /** Open the Settings modal (the single consolidated settings surface). */
@@ -807,6 +815,21 @@ async function relaunchHere(
     }
   } finally {
     launcherInflight = false;
+    // Re-probe from HERE, not from the click. The callers used to fire this
+    // synchronously alongside `void relaunchHere(...)`, which runs the instant
+    // this function suspends at its first `await` — i.e. BEFORE the blocking
+    // `confirm()` above, whose four lines a user may spend ten seconds reading
+    // while the staggered +2s/+5s refresh timers advance on wall clock. Both
+    // would then fire before the POST completed, answer with the pre-relaunch
+    // cwd, and leave the drift pill asserting Claude is in a folder it has
+    // already left — with nothing to re-arm it, since the drift effect keys only
+    // on document path and epoch.
+    //
+    // In `finally` rather than after the POST so a thrown request still
+    // re-probes: a relaunch that failed midway is exactly when the displayed
+    // state is least trustworthy. Placed inside this try, so a cancelled confirm
+    // (which returns before `launcherInflight = true`) still probes nothing.
+    d.afterLauncherAction();
   }
 }
 
@@ -825,7 +848,6 @@ async function relaunchHere(
 export function relaunchClaudeCode(): void {
   guardedRun("launcher-relaunch-here", (d) => {
     void relaunchHere(d, { cwdRequired: false });
-    d.afterLauncherAction();
   });
 }
 
@@ -842,14 +864,12 @@ export function relaunchClaudeCode(): void {
 export function relaunchClaudeHere(): void {
   guardedRun("launcher-relaunch-here", (d) => {
     void relaunchHere(d, { cwdRequired: true });
-    d.afterLauncherAction();
   });
 }
 
 export function startFreshClaudeCode(): void {
   guardedRun("launcher-start-fresh", (d) => {
     void startFreshConversation(d);
-    d.afterLauncherAction();
   });
 }
 
@@ -872,6 +892,9 @@ async function startFreshConversation(d: ActionDeps): Promise<void> {
     );
   } finally {
     launcherInflight = false;
+    // Same reason as `relaunchHere`'s: measured from the mutation, not from a
+    // click that precedes an unbounded modal.
+    d.afterLauncherAction();
   }
 }
 

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -578,7 +578,16 @@ async function fetchLauncherNonce(): Promise<FetchResult<string>> {
   return { ok: true, value: body.nonce };
 }
 
-function deriveCwdFromDocPath(docPath: string | null): string | null {
+/**
+ * The folder a "relaunch here" would target, from a document path.
+ *
+ * Exported so the #1282 drift preview asks about the SAME folder the relaunch
+ * would use. A second dirname implementation on the query side is how you get a
+ * nudge that offers a folder the action then declines to use — the split
+ * between a client derivation and a server check being the defect #1282 itself
+ * was filed for.
+ */
+export function deriveCwdFromDocPath(docPath: string | null): string | null {
   if (!docPath) return null;
   // Reject upload:// and other non-filesystem URIs before they reach the API.
   if (/^[a-z]+:\/\//.test(docPath)) return null;
@@ -799,6 +808,20 @@ async function relaunchHere(
  */
 export function relaunchClaudeCode(): void {
   guardedRun("launcher-relaunch-here", (d) => void relaunchHere(d, { cwdRequired: false }));
+}
+
+/**
+ * Move Claude to the active document's folder — the palette's "Relaunch Claude
+ * in this folder", exported so the #1282 drift nudge runs the *same* code rather
+ * than a second copy of it.
+ *
+ * Distinct from `relaunchClaudeCode` in the one way that matters: this is the
+ * caller that means "here", so it is the caller that persists the folder. The
+ * drift nudge names a specific folder and offers to move Claude into it, which
+ * is that intent exactly — a chip that recovers a crashed Claude is not.
+ */
+export function relaunchClaudeHere(): void {
+  guardedRun("launcher-relaunch-here", (d) => void relaunchHere(d, { cwdRequired: true }));
 }
 
 export function startFreshClaudeCode(): void {
@@ -1170,7 +1193,7 @@ const BUILTINS: Action[] = [
     label: "Relaunch Claude in this folder",
     group: "claude",
     run() {
-      guardedRun("launcher-relaunch-here", (d) => void relaunchHere(d, { cwdRequired: true }));
+      relaunchClaudeHere();
     },
   },
   {

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -24,6 +24,7 @@ import {
   LAUNCHER_ERROR_PATH_REJECTED,
   type LauncherStatus,
 } from "../../shared/launcher/contract.js";
+import { clearDriftNudgeOptOut, driftNudgeOptedOut } from "../status/cwdDriftDismiss.svelte.js";
 import { resolveDefaultDirectory } from "../utils/default-directory.js";
 import { API_BASE } from "../utils/fileUpload.js";
 import { addRecentFile, loadRecentFiles, saveRecentFiles } from "../utils/recentFiles.js";
@@ -41,6 +42,21 @@ interface ActionDeps {
   getActiveDocumentPath: () => string | null;
   /** Push a transient toast notification (info/warning/error). */
   notify: (severity: "info" | "warning" | "error", message: string) => void;
+  /**
+   * Re-poll launcher-derived state after an action that moves or restarts
+   * Claude (#1282).
+   *
+   * Called by every exported launcher action here, rather than left to callers.
+   * It used to be the callers' job and they did not all do it: `App.svelte`
+   * wrapped the status-pill and empty-state paths, while the command palette
+   * invoked the same relaunch directly and never re-probed. The #1282 drift probe
+   * re-arms on the document path and an explicit refresh, neither of which a
+   * relaunch changes — so after a palette relaunch the amber pill went on naming
+   * the folder Claude had just left, indefinitely, which is precisely what that
+   * refresh exists to prevent. Owning it here makes "every launcher action
+   * re-probes" true by construction instead of by everyone remembering.
+   */
+  afterLauncherAction: () => void;
   /** Open the Settings modal (the single consolidated settings surface). */
   openSettings: () => void;
   toggleSoloMode: () => void;
@@ -807,7 +823,10 @@ async function relaunchHere(
  * are not all gated on having a tab, and one of them can only ever run without.
  */
 export function relaunchClaudeCode(): void {
-  guardedRun("launcher-relaunch-here", (d) => void relaunchHere(d, { cwdRequired: false }));
+  guardedRun("launcher-relaunch-here", (d) => {
+    void relaunchHere(d, { cwdRequired: false });
+    d.afterLauncherAction();
+  });
 }
 
 /**
@@ -821,11 +840,17 @@ export function relaunchClaudeCode(): void {
  * is that intent exactly — a chip that recovers a crashed Claude is not.
  */
 export function relaunchClaudeHere(): void {
-  guardedRun("launcher-relaunch-here", (d) => void relaunchHere(d, { cwdRequired: true }));
+  guardedRun("launcher-relaunch-here", (d) => {
+    void relaunchHere(d, { cwdRequired: true });
+    d.afterLauncherAction();
+  });
 }
 
 export function startFreshClaudeCode(): void {
-  guardedRun("launcher-start-fresh", (d) => void startFreshConversation(d));
+  guardedRun("launcher-start-fresh", (d) => {
+    void startFreshConversation(d);
+    d.afterLauncherAction();
+  });
 }
 
 async function startFreshConversation(d: ActionDeps): Promise<void> {
@@ -1201,7 +1226,37 @@ const BUILTINS: Action[] = [
     label: "Start fresh Claude conversation",
     group: "claude",
     run() {
-      guardedRun("launcher-start-fresh", (d) => void startFreshConversation(d));
+      // Delegates rather than calling `startFreshConversation` directly, for the
+      // same reason `launcher-relaunch-here` does: the exported function is where
+      // `afterLauncherAction` lives, and a palette entry that reached past it
+      // would silently be the one launcher action that never re-probes.
+      startFreshClaudeCode();
+    },
+  },
+  {
+    // The only way back from the drift nudge's "Don't show this again" (#1282).
+    // Without it that button is a one-way door whose sole exit is editing
+    // localStorage by hand — and `driftNudgeOptedOut` was written for a Settings
+    // row that does not exist yet. Unconditional in the palette (the registry is
+    // static) and honest when there was nothing to undo.
+    id: "launcher-cwd-nudge-enable",
+    label: "Show working-folder reminders again",
+    group: "claude",
+    run() {
+      guardedRun("launcher-cwd-nudge-enable", (d) => {
+        if (!driftNudgeOptedOut()) {
+          d.notify("info", "Working-folder reminders are already on.");
+          return;
+        }
+        if (clearDriftNudgeOptOut()) {
+          d.notify("info", "Working-folder reminders are back on.");
+          return;
+        }
+        d.notify(
+          "warning",
+          "Working-folder reminders are on for this session — this browser wouldn't let Tandem clear the saved preference, so they'll be off again next launch.",
+        );
+      });
     },
   },
   // Reveal-in-OS-file-manager only makes sense in the desktop app, which can

--- a/src/client/hooks/useCwdDrift.svelte.ts
+++ b/src/client/hooks/useCwdDrift.svelte.ts
@@ -1,0 +1,159 @@
+import { onDestroy } from "svelte";
+
+import { API_LAUNCHER_CWD_PREVIEW } from "../../shared/api-paths.js";
+import type { LauncherCwdPreview } from "../../shared/launcher/contract.js";
+
+/**
+ * Working-directory drift probe (#1282).
+ *
+ * Asks the server, for the currently active document, whether relaunching
+ * Claude "here" would actually move it. Every decision — validity, sameness,
+ * exclusions, labels — is made server-side; this hook holds the answer and the
+ * timing. That division is not incidental: #1282's own post-mortem is that the
+ * client's derivation and the server's rejection were each tested in isolation
+ * and never together, so this side deliberately owns no predicate it could
+ * drift out of sync with.
+ *
+ * Svelte-5 reactive contract (patterned on `useReachabilityCheck`):
+ *   - The `$effect` reads exactly two reactive inputs — `getCwd()` and the
+ *     `epoch` counter — and never reads `drift`, which is write-only from inside
+ *     the effect. `epoch` is `$state` the effect READS but never writes, so
+ *     bumping it from `refresh()` re-arms the probe without self-invalidating.
+ *   - `mounted` is a plain `let`, not `$state`: a flag the effect both reads and
+ *     writes would re-fire it.
+ *   - Supersession and unmount are both handled by the `$effect` cleanup plus an
+ *     `AbortController`, not by an in-flight flag. An in-flight flag would be
+ *     actively wrong here — it drops probes 2..N, so switching quickly between
+ *     three tabs leaves the pill answering for the first one.
+ *   - `state_unsafe_mutation` does not apply. The `$state` writes happen in an
+ *     async continuation, after the synchronous flush has unwound; there is no
+ *     active reaction. Do NOT wrap these in `createCoalescingTick`.
+ *
+ * **Settle delay, not a debounce.** The plan called for a ~250ms debounce plus a
+ * ~1.5s dwell before showing. One timer does both jobs: wait for the input to
+ * hold still, THEN probe, then render the answer immediately. Tab-flicking past
+ * four documents issues zero requests instead of four, and an amber pill can
+ * never flash during a switch because nothing was asked yet.
+ */
+
+export interface CwdDrift {
+  /** Where a relaunch would put Claude (display form, `~`-substituted). */
+  suggestedCwd: string;
+  /** Where Claude is now (display form). */
+  claudeCwd: string;
+  /** Shortest label distinguishing `suggestedCwd` from `claudeCwd`. */
+  label: string;
+  /** The same, for `claudeCwd`. */
+  claudeLabel: string;
+}
+
+export interface CwdDriftState {
+  /** The current drift, or `null` for "nothing to say". */
+  readonly drift: CwdDrift | null;
+  /** Re-probe now — call after any launcher mutation. */
+  refresh: () => void;
+}
+
+/** How long the inputs must hold still before we ask. */
+const DEFAULT_SETTLE_MS = 1_500;
+
+export interface CwdDriftOptions {
+  settleMs?: number;
+  fetchFn?: typeof fetch;
+  baseUrl?: string;
+}
+
+export function createCwdDrift(
+  /** The folder a relaunch would target — the caller's OWN derivation from the
+   * active document, i.e. the exact value the relaunch request will carry, and
+   * already screened for `upload://` scratchpad URIs. Passing the derivation
+   * (not the document path) is what keeps the preview and the action from
+   * disagreeing about which folder is meant. `null` when there is no eligible
+   * document, which clears the nudge. */
+  getCwd: () => string | null,
+  opts: CwdDriftOptions = {},
+): CwdDriftState {
+  const settleMs = opts.settleMs ?? DEFAULT_SETTLE_MS;
+  const baseUrl = opts.baseUrl ?? "";
+  const fetchFn = opts.fetchFn ?? globalThis.fetch.bind(globalThis);
+
+  let drift = $state<CwdDrift | null>(null);
+  let epoch = $state(0);
+
+  // Plain `let` — see the reactive contract above.
+  let mounted = true;
+  onDestroy(() => {
+    mounted = false;
+  });
+
+  $effect(() => {
+    const cwd = getCwd();
+    // Subscribe to refresh requests. Read unconditionally, BEFORE the early
+    // return, or a `refresh()` issued while no document is open would not re-arm
+    // the effect once one is. The launcher's own cwd is not observable from
+    // here — `GET /api/launcher/status` exposes it only to loopback callers and
+    // `useAiReadiness` does not surface it — so a relaunch's effect is picked up
+    // by re-probing, not by keying on the new value. Without this the pill
+    // survives a successful relaunch, naming the folder Claude has just moved
+    // into, because the document path never changed.
+    const startedAt = epoch;
+
+    if (cwd === null) {
+      drift = null;
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      void (async () => {
+        let preview: LauncherCwdPreview;
+        try {
+          const res = await fetchFn(`${baseUrl}${API_LAUNCHER_CWD_PREVIEW}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ cwd }),
+            signal: controller.signal,
+          });
+          if (!res.ok) {
+            // Fail safe to "nothing to say". The alternative — keeping the last
+            // answer — would leave an amber pill asserting a folder relationship
+            // nobody has checked since the server started refusing to answer.
+            if (mounted) drift = null;
+            return;
+          }
+          preview = (await res.json()) as LauncherCwdPreview;
+        } catch {
+          if (mounted) drift = null; // network blip, abort, malformed body
+          return;
+        }
+        // `startedAt !== epoch` is belt to the cleanup's braces: the effect
+        // cleanup aborts this request before a re-run, but an abort that lands
+        // between `res.json()` resolving and this line would otherwise let a
+        // superseded answer write.
+        if (!mounted || controller.signal.aborted || startedAt !== epoch) return;
+        drift = preview.drifted
+          ? {
+              suggestedCwd: preview.suggestedCwd,
+              claudeCwd: preview.claudeCwd,
+              label: preview.label,
+              claudeLabel: preview.claudeLabel,
+            }
+          : null;
+      })();
+    }, settleMs);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  });
+
+  return {
+    get drift() {
+      return drift;
+    },
+    refresh: () => {
+      epoch += 1;
+    },
+  };
+}

--- a/src/client/hooks/useCwdDrift.svelte.ts
+++ b/src/client/hooks/useCwdDrift.svelte.ts
@@ -14,7 +14,10 @@ import type { LauncherCwdPreview } from "../../shared/launcher/contract.js";
  * and never together, so this side deliberately owns no predicate it could
  * drift out of sync with.
  *
- * Svelte-5 reactive contract (patterned on `useReachabilityCheck`):
+ * Svelte-5 reactive contract. The `mounted`-as-plain-`let` and
+ * writes-only-its-own-`$state` rules follow `useReachabilityCheck`; the `epoch`
+ * counter has no precedent there (that hook re-arms off `getActive()`), so don't
+ * go looking for one.
  *   - The `$effect` reads exactly two reactive inputs — `getCwd()` and the
  *     `epoch` counter — and never reads `drift`, which is write-only from inside
  *     the effect. `epoch` is `$state` the effect READS but never writes, so
@@ -25,9 +28,13 @@ import type { LauncherCwdPreview } from "../../shared/launcher/contract.js";
  *     `AbortController`, not by an in-flight flag. An in-flight flag would be
  *     actively wrong here — it drops probes 2..N, so switching quickly between
  *     three tabs leaves the pill answering for the first one.
- *   - `state_unsafe_mutation` does not apply. The `$state` writes happen in an
- *     async continuation, after the synchronous flush has unwound; there is no
- *     active reaction. Do NOT wrap these in `createCoalescingTick`.
+ *   - `state_unsafe_mutation` does not apply to any of the `drift` writes, but
+ *     for two different reasons, and only one of them is "async". The writes
+ *     after a fetch land in a continuation with no active reaction at all. The
+ *     `drift = null` on the no-document path is fully SYNCHRONOUS inside the
+ *     effect body — legal because the guard fires on
+ *     `DERIVED | BLOCK_EFFECT | ASYNC | EAGER_EFFECT` and a plain `$effect`
+ *     carries none of them. Do NOT wrap either in `createCoalescingTick`.
  *
  * **Settle delay, not a debounce.** The plan called for a ~250ms debounce plus a
  * ~1.5s dwell before showing. One timer does both jobs: wait for the input to
@@ -56,6 +63,57 @@ export interface CwdDriftState {
 
 /** How long the inputs must hold still before we ask. */
 const DEFAULT_SETTLE_MS = 1_500;
+
+/**
+ * Accept a `drifted: true` answer only when every field it promises is present.
+ * Returns `null` — "say nothing" — for anything else, which is what the rest of
+ * the feature already does with every other doubt.
+ */
+function completeDrift(preview: LauncherCwdPreview): CwdDrift | null {
+  if (!preview.drifted) return null;
+  const { suggestedCwd, claudeCwd, label, claudeLabel } = preview as Partial<
+    Extract<LauncherCwdPreview, { drifted: true }>
+  >;
+  if (
+    typeof suggestedCwd !== "string" ||
+    typeof claudeCwd !== "string" ||
+    typeof label !== "string" ||
+    typeof claudeLabel !== "string"
+  ) {
+    return null;
+  }
+  return { suggestedCwd, claudeCwd, label, claudeLabel };
+}
+
+/**
+ * One-shot report of a rejected probe.
+ *
+ * Two permanent-rejection states are reachable and neither is otherwise
+ * observable from anywhere: the launcher routes are not registered at all (the
+ * `if (launcher)` branch in `mcp/server.ts` — stdio mode, tests), so the route
+ * 404s forever; and the route is loopback-only, so every LAN/browser client gets
+ * a permanent 403. In both, the pill simply never appears, and "you have no
+ * drift", "this build has no such route" and "you are not on loopback" are
+ * indistinguishable to the user and to whoever they ask.
+ *
+ * `fetchLauncherStatus` in `actions/builtin.svelte.ts` already models exactly
+ * this distinction (`404 → "not-built"`); this is the cheap version of the same
+ * honesty. Module-scoped, so it is one line per page load, not per tab switch.
+ */
+let probeRejectionReported = false;
+function noteProbeRejected(status: number): void {
+  if (probeRejectionReported) return;
+  probeRejectionReported = true;
+  console.warn(
+    `[Tandem] Working-folder drift check unavailable (HTTP ${status}). ` +
+      "The status bar will not report when Claude is running in another folder.",
+  );
+}
+
+/** Test-only reset of the one-shot rejection latch. */
+export function _resetProbeRejectionForTests(): void {
+  probeRejectionReported = false;
+}
 
 export interface CwdDriftOptions {
   settleMs?: number;
@@ -88,14 +146,17 @@ export function createCwdDrift(
 
   $effect(() => {
     const cwd = getCwd();
-    // Subscribe to refresh requests. Read unconditionally, BEFORE the early
-    // return, or a `refresh()` issued while no document is open would not re-arm
-    // the effect once one is. The launcher's own cwd is not observable from
-    // here — `GET /api/launcher/status` exposes it only to loopback callers and
-    // `useAiReadiness` does not surface it — so a relaunch's effect is picked up
-    // by re-probing, not by keying on the new value. Without this the pill
-    // survives a successful relaunch, naming the folder Claude has just moved
-    // into, because the document path never changed.
+    // Subscribe to refresh requests. The launcher's own cwd is not observable
+    // from here — `GET /api/launcher/status` exposes it only to loopback callers
+    // and `useAiReadiness` does not surface it — so a relaunch's effect is picked
+    // up by re-probing, not by keying on the new value. Without this the pill
+    // survives a successful relaunch, naming the folder Claude just moved out of,
+    // because the document path never changed.
+    //
+    // Read before the early return for consistency, not for behaviour: with no
+    // document open the effect's only action is `drift = null`, and the
+    // null→non-null transition re-runs it on the `cwd` dependency regardless. It
+    // is placed here so the subscription does not depend on which branch ran.
     const startedAt = epoch;
 
     if (cwd === null) {
@@ -104,6 +165,19 @@ export function createCwdDrift(
     }
 
     const controller = new AbortController();
+    /**
+     * May this continuation still write? Every exit path asks — including the
+     * failure paths, which is not symmetry for its own sake.
+     *
+     * A real `fetch` REJECTS when its signal aborts, and the effect cleanup
+     * aborts on every re-run. So an abort lands in the `catch` below with
+     * `mounted` still true: guarding the failure paths on `mounted` alone means
+     * every tab switch, and every one of the two `refresh()` calls fired after a
+     * launcher action, blanks the pill for a settle window before it comes back.
+     * The user sees the amber chip flicker twice for an action they cancelled.
+     */
+    const stale = (): boolean => !mounted || controller.signal.aborted || startedAt !== epoch;
+
     const timer = setTimeout(() => {
       void (async () => {
         let preview: LauncherCwdPreview;
@@ -115,30 +189,28 @@ export function createCwdDrift(
             signal: controller.signal,
           });
           if (!res.ok) {
+            noteProbeRejected(res.status);
             // Fail safe to "nothing to say". The alternative — keeping the last
             // answer — would leave an amber pill asserting a folder relationship
             // nobody has checked since the server started refusing to answer.
-            if (mounted) drift = null;
+            if (!stale()) drift = null;
             return;
           }
           preview = (await res.json()) as LauncherCwdPreview;
         } catch {
-          if (mounted) drift = null; // network blip, abort, malformed body
+          if (!stale()) drift = null; // network blip, abort, malformed body
           return;
         }
-        // `startedAt !== epoch` is belt to the cleanup's braces: the effect
-        // cleanup aborts this request before a re-run, but an abort that lands
-        // between `res.json()` resolving and this line would otherwise let a
-        // superseded answer write.
-        if (!mounted || controller.signal.aborted || startedAt !== epoch) return;
-        drift = preview.drifted
-          ? {
-              suggestedCwd: preview.suggestedCwd,
-              claudeCwd: preview.claudeCwd,
-              label: preview.label,
-              claudeLabel: preview.claudeLabel,
-            }
-          : null;
+        if (stale()) return;
+        // Validate before trusting. This is the ONE path in the feature where a
+        // bad answer becomes a confident false statement rather than silence:
+        // a `{ drifted: true }` with missing fields renders "Claude is running in
+        // undefined" AND poisons the dismissal key, so one dismissal of that
+        // nonsense pair suppresses every real drift afterwards. Version skew is
+        // not hypothetical here — the plugin-installed monitor is pinned per
+        // release while the desktop server rides the Tauri updater track, with no
+        // version handshake between them.
+        drift = completeDrift(preview);
       })();
     }, settleMs);
 

--- a/src/client/status/CwdDriftPill.svelte
+++ b/src/client/status/CwdDriftPill.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+import { clickOutside } from "../actions/clickOutside.svelte";
+import { ESCAPE_OWNER_ATTR } from "../utils/escape-owner";
+import { focusMenuEntryPoint, handleMenuArrowKeys } from "../utils/menuKeys";
+import type { CwdDriftPill } from "./status-ai-view";
+
+/**
+ * Status-bar pill for the working-directory drift nudge (#1282).
+ *
+ * The pill is a menu trigger, not a one-click action, for two reasons:
+ *
+ *   - **The dismiss affordance has to be a real control.** A bare inline `×`
+ *     lands at ~10-12px, which fails WCAG 2.2 SC 2.5.8 (24×24 minimum target)
+ *     and would be the only sub-24px control in a status bar where
+ *     `.status-ai-indicator` already carries `min-height: 24px`. Three full-size
+ *     menu rows clear it with room to spare.
+ *   - **The menu is where the explanation fits.** A ten-pixel chip cannot teach
+ *     a concept the user has never met — that Claude Code scopes what it can
+ *     read to one directory — and the menu heading can.
+ *
+ * The menu also *is* the confirmation for opening the relaunch flow, which is
+ * why the action row ends in an ellipsis: the flow itself still confirms, since
+ * it interrupts Claude's current task and rewrites the stored working directory.
+ */
+
+interface Props {
+  pill: CwdDriftPill;
+  /** Open the relaunch-in-this-folder flow (which confirms before acting). */
+  onRelaunch: () => void;
+  /** Hide this (Claude's folder, target folder) pair for the session. */
+  onDismiss: () => void;
+  /** Stop showing the nudge entirely, across restarts. */
+  onOptOut: () => void;
+}
+
+let { pill, onRelaunch, onDismiss, onOptOut }: Props = $props();
+
+let menuOpen = $state(false);
+let triggerBtn = $state<HTMLButtonElement | null>(null);
+let menuEl = $state<HTMLDivElement | null>(null);
+
+$effect(() => {
+  if (menuOpen) focusMenuEntryPoint(menuEl);
+});
+
+// Single close path, guarded exactly as `DecorationsMenu` guards its own:
+// `clickOutside` fires on mousedown, before the browser moves focus, so
+// restoring unconditionally would yank focus away from whatever was clicked.
+function closeMenu(): void {
+  const ours =
+    (!!menuEl && menuEl.contains(document.activeElement)) ||
+    document.activeElement === document.body ||
+    document.activeElement === null;
+  menuOpen = false;
+  if (ours) triggerBtn?.focus();
+}
+
+function handleKey(e: KeyboardEvent): void {
+  if (handleMenuArrowKeys(e)) return;
+  if (e.key === "Escape" && menuOpen) {
+    e.stopPropagation();
+    closeMenu();
+  }
+}
+
+/** Close BEFORE running the handler: `onRelaunch` opens a modal confirm, and a
+ * menu still painted behind it reads as an unrelated stuck overlay. The other
+ * two unmount this component outright, where closing first keeps focus from
+ * stranding on a removed node. */
+function choose(run: () => void): void {
+  closeMenu();
+  run();
+}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="drift-wrap"
+  data-testid="cwd-drift"
+  use:clickOutside={closeMenu}
+  onkeydown={handleKey}
+  {...(menuOpen ? { [ESCAPE_OWNER_ATTR]: "" } : {})}
+>
+  <button
+    bind:this={triggerBtn}
+    type="button"
+    class="drift-pill"
+    data-testid="cwd-drift-pill"
+    aria-haspopup="menu"
+    aria-expanded={menuOpen}
+    title={pill.title}
+    aria-label={pill.ariaLabel}
+    onclick={() => (menuOpen = !menuOpen)}
+  >
+    <span class="drift-ic" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+      </svg>
+    </span>
+    {pill.label}
+  </button>
+
+  {#if menuOpen}
+    <div bind:this={menuEl} class="menu" role="menu" aria-label="Working folder">
+      <div class="menu-head">Working folder</div>
+      <p class="menu-help">{pill.explanation}</p>
+
+      <button
+        type="button"
+        class="mi"
+        data-testid="cwd-drift-relaunch"
+        role="menuitem"
+        onclick={() => choose(onRelaunch)}
+      >
+        {pill.actionLabel}
+      </button>
+      <button
+        type="button"
+        class="mi"
+        data-testid="cwd-drift-dismiss"
+        role="menuitem"
+        onclick={() => choose(onDismiss)}
+      >
+        Not now
+      </button>
+      <div class="menu-div" role="separator"></div>
+      <button
+        type="button"
+        class="mi link"
+        data-testid="cwd-drift-opt-out"
+        role="menuitem"
+        onclick={() => choose(onOptOut)}
+      >
+        Don’t show this again
+      </button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .drift-wrap {
+    position: relative;
+    display: inline-flex;
+  }
+
+  /* The amber warning treatment shared with StatusBar's "Review Only" and
+     "N held" pills — same tokens, same shape, rather than a fourth visual
+     language for "something is off but nothing is broken".
+     The values are restated rather than shared because Svelte scopes styles per
+     component: StatusBar's `.status-warning-pill` rule cannot reach markup
+     rendered here, so wearing that class would style nothing. Keep the two in
+     step — the tokens are the contract, and a change here belongs in
+     StatusBar's copy too. */
+  .drift-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    /* WCAG 2.2 SC 2.5.8 — this is the dismiss/act affordance, so 24px is a
+       floor, not a preference. */
+    min-height: 24px;
+    padding: 1px 8px;
+    font: inherit;
+    font-size: var(--tandem-text-2xs);
+    font-weight: 600;
+    color: var(--tandem-warning-fg-strong);
+    background: var(--tandem-warning-bg);
+    border-radius: var(--tandem-r-pill);
+    border: 1px solid var(--tandem-warning-border);
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .drift-pill:hover {
+    border-color: var(--tandem-warning);
+  }
+  .drift-pill:focus-visible {
+    outline: 2px solid var(--tandem-accent);
+    outline-offset: 1px;
+  }
+  .drift-ic {
+    display: inline-flex;
+    width: 13px;
+    height: 13px;
+  }
+  .drift-ic svg {
+    width: 13px;
+    height: 13px;
+  }
+
+  /* Opens UPWARD — the status bar is the bottom edge of the window, so a
+     `top: 100%` dropdown would render off-screen. */
+  .menu {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    right: 0;
+    min-width: 280px;
+    max-width: 360px;
+    background: var(--tandem-surface);
+    border: 1px solid var(--tandem-border);
+    border-radius: var(--tandem-r-3);
+    box-shadow: var(--tandem-shadow-3);
+    padding: var(--tandem-space-1);
+    z-index: var(--tandem-z-dropdown);
+  }
+  .menu-head {
+    padding: 7px 10px 3px;
+    color: var(--tandem-fg-subtle);
+    font-size: var(--tandem-text-2xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-family: var(--tandem-font-mono);
+  }
+  .menu-help {
+    margin: 0;
+    padding: 0 10px 7px;
+    color: var(--tandem-fg-subtle);
+    font-size: var(--tandem-text-2xs);
+    line-height: 1.45;
+    /* Paths are long and unbreakable at spaces; without this the menu grows a
+       horizontal scrollbar instead of wrapping. */
+    overflow-wrap: anywhere;
+  }
+  .mi {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-height: 24px;
+    padding: 7px 10px;
+    border: none;
+    background: transparent;
+    color: var(--tandem-fg);
+    font: inherit;
+    font-size: 13px;
+    text-align: left;
+    cursor: pointer;
+    border-radius: var(--tandem-r-2);
+    box-sizing: border-box;
+    overflow-wrap: anywhere;
+  }
+  .mi:hover,
+  .mi:focus-visible {
+    background: var(--tandem-surface-sunk);
+    outline: none;
+  }
+  .menu-div {
+    height: 1px;
+    background: var(--tandem-border);
+    margin: 4px 6px;
+  }
+  .mi.link {
+    color: var(--tandem-fg-muted);
+    font-size: 12px;
+  }
+
+  /* Forced-colors: the amber fill is dropped by the OS palette, leaving the pill
+     indistinguishable from plain status text. A border restores the boundary. */
+  @media (forced-colors: active) {
+    .drift-pill {
+      border: 1px solid ButtonText;
+    }
+    .menu {
+      border: 1px solid CanvasText;
+    }
+  }
+</style>

--- a/src/client/status/CwdDriftPill.svelte
+++ b/src/client/status/CwdDriftPill.svelte
@@ -10,10 +10,12 @@ import type { CwdDriftPill } from "./status-ai-view";
  * The pill is a menu trigger, not a one-click action, for two reasons:
  *
  *   - **The dismiss affordance has to be a real control.** A bare inline `×`
- *     lands at ~10-12px, which fails WCAG 2.2 SC 2.5.8 (24×24 minimum target)
- *     and would be the only sub-24px control in a status bar where
- *     `.status-ai-indicator` already carries `min-height: 24px`. Three full-size
- *     menu rows clear it with room to spare.
+ *     lands at ~10-12px, which fails WCAG 2.2 SC 2.5.8 (24×24 minimum target) in
+ *     a status bar where `.status-ai-indicator` already carries
+ *     `min-height: 24px`. Three full-size menu rows clear it with room to spare.
+ *     (The word-count button is also under 24px, but it is inline text that
+ *     plausibly qualifies for SC 2.5.8's inline exception; a standalone glyph
+ *     does not.)
  *   - **The menu is where the explanation fits.** A ten-pixel chip cannot teach
  *     a concept the user has never met — that Claude Code scopes what it can
  *     read to one directory — and the menu heading can.
@@ -38,6 +40,7 @@ let { pill, onRelaunch, onDismiss, onOptOut }: Props = $props();
 let menuOpen = $state(false);
 let triggerBtn = $state<HTMLButtonElement | null>(null);
 let menuEl = $state<HTMLDivElement | null>(null);
+let wrapEl = $state<HTMLDivElement | null>(null);
 
 $effect(() => {
   if (menuOpen) focusMenuEntryPoint(menuEl);
@@ -63,11 +66,30 @@ function handleKey(e: KeyboardEvent): void {
   }
 }
 
-/** Close BEFORE running the handler: `onRelaunch` opens a modal confirm, and a
- * menu still painted behind it reads as an unrelated stuck overlay. The other
- * two unmount this component outright, where closing first keeps focus from
- * stranding on a removed node. */
-function choose(run: () => void): void {
+/**
+ * Run a menu row's handler, having first put focus somewhere that will still
+ * exist afterwards.
+ *
+ * `unmounts` is the whole reason this takes a flag. `DecorationsMenu`, whose
+ * close-guard this component copies, has a trigger that survives every action —
+ * so restoring focus to it is right there and wrong here. Dismiss and
+ * "don't show again" both flip suppression state that nulls the pill's own view,
+ * unmounting this component AND `triggerBtn` with it: focus restored to the
+ * trigger lands on a node removed microseconds later, and a keyboard user is
+ * dumped on `<body>`. Hand focus to the status bar instead, which outlives us.
+ *
+ * `onRelaunch` keeps the trigger: it opens a modal confirm and leaves the pill
+ * mounted, which is the case the copied guard was written for.
+ */
+function choose(run: () => void, { unmounts = false }: { unmounts?: boolean } = {}): void {
+  if (unmounts) {
+    // Read the fallback BEFORE closing — `wrapEl` is still attached here.
+    const fallback = wrapEl?.closest<HTMLElement>("[data-status-focus-root]") ?? null;
+    menuOpen = false;
+    fallback?.focus();
+    run();
+    return;
+  }
   closeMenu();
   run();
 }
@@ -75,6 +97,7 @@ function choose(run: () => void): void {
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
+  bind:this={wrapEl}
   class="drift-wrap"
   data-testid="cwd-drift"
   use:clickOutside={closeMenu}
@@ -119,7 +142,7 @@ function choose(run: () => void): void {
         class="mi"
         data-testid="cwd-drift-dismiss"
         role="menuitem"
-        onclick={() => choose(onDismiss)}
+        onclick={() => choose(onDismiss, { unmounts: true })}
       >
         Not now
       </button>
@@ -129,7 +152,7 @@ function choose(run: () => void): void {
         class="mi link"
         data-testid="cwd-drift-opt-out"
         role="menuitem"
-        onclick={() => choose(onOptOut)}
+        onclick={() => choose(onOptOut, { unmounts: true })}
       >
         Don’t show this again
       </button>

--- a/src/client/status/StatusBar.svelte
+++ b/src/client/status/StatusBar.svelte
@@ -9,10 +9,17 @@ import type {
   PushDelivery,
 } from "../hooks/useAiReadiness.svelte";
 import { AI_CTA } from "../hooks/useAiReadiness.svelte";
+import type { CwdDrift } from "../hooks/useCwdDrift.svelte";
 import type { ConnectionStatus } from "../hooks/yjsSync.svelte";
 import { createCoalescingTick } from "../utils/coalescing-tick";
 import { debounce } from "../utils/debounce";
-import { type AiIndicatorTone, type AiIndicatorView, aiIndicatorView } from "./status-ai-view";
+import CwdDriftPill from "./CwdDriftPill.svelte";
+import {
+  type AiIndicatorTone,
+  type AiIndicatorView,
+  aiIndicatorView,
+  cwdDriftPill,
+} from "./status-ai-view";
 import { getCount, loadMode, modeLabel, nextMode, saveMode } from "./word-count-cycle";
 
 interface Props {
@@ -73,6 +80,20 @@ interface Props {
    * release; only the count is active-doc-local).
    */
   heldCount?: number;
+  /**
+   * #1282: the server's working-folder drift verdict for the active document,
+   * with the user's own suppression (per-pair dismissal / session backstop /
+   * permanent opt-out) ALREADY applied by the caller. `null` means "say
+   * nothing" — this component never re-derives whether a drift is worth
+   * mentioning, it only renders the answer.
+   */
+  cwdDrift?: CwdDrift | null;
+  /** Open the "restart Claude in this folder" flow (which confirms first). */
+  onRelaunchInFolder?: () => void;
+  /** Hide this (Claude's folder, target folder) pair for the session. */
+  onDismissDrift?: () => void;
+  /** Stop showing the drift nudge entirely, across restarts. */
+  onOptOutDrift?: () => void;
 }
 
 let {
@@ -95,6 +116,10 @@ let {
   lastSaveOk = false,
   editor,
   heldCount = 0,
+  cwdDrift = null,
+  onRelaunchInFolder,
+  onDismissDrift,
+  onOptOutDrift,
 }: Props = $props();
 
 /**
@@ -213,6 +238,10 @@ const labelColor = $derived(
 // former "Assistant · idle" segment). The view is a pure mapping — MUST be
 // `$derived` so it recomputes as the reactive props flip connected→solo→down.
 const aiView = $derived(aiIndicatorView(aiState, aiLiveIndicator, soloMode, pushDelivery));
+
+// #1282. A sibling of the AI indicator rather than part of it, and mutually
+// exclusive with the CTA below by construction — see `cwdDriftPill`.
+const driftView = $derived(cwdDriftPill(cwdDrift, aiChip));
 
 /**
  * The AI indicator's actionable content — title, aria-label, and onclick —
@@ -443,6 +472,17 @@ function cycleWordMode() {
       </div>
     {/if}
   {/if}
+  <!-- #1282 working-folder drift. Deliberately NOT nested inside `{#if aiView}`:
+       `aiIndicatorView` returns null for "launcher running, no MCP session yet",
+       which is exactly the auto-launched startup window this nudge exists for. -->
+  {#if driftView}
+    <CwdDriftPill
+      pill={driftView}
+      onRelaunch={() => onRelaunchInFolder?.()}
+      onDismiss={() => onDismissDrift?.()}
+      onOptOut={() => onOptOutDrift?.()}
+    />
+  {/if}
   <!-- #651 "Claude is {verb}…" pill. Gated on a live session (`aiView.canAnimate`)
        as well as an in-flight tool so it can never render "working" while the
        connection indicator shows nothing (an incoherent activity-without-
@@ -534,6 +574,17 @@ function cycleWordMode() {
     background: var(--tandem-warning-bg);
     border-radius: var(--tandem-r-pill);
     border: 1px solid var(--tandem-warning-border);
+  }
+
+  /* Forced-colors drops the amber fill AND the amber border (both resolve to
+     system colors), leaving "Review Only" and "N held" indistinguishable from
+     ordinary status text — they read as pills only by virtue of color. A
+     system-color border restores the boundary. Pre-existing gap, fixed here
+     because `CwdDriftPill` carries the same recipe and needed the same rule. */
+  @media (forced-colors: active) {
+    .status-warning-pill {
+      border: 1px solid CanvasText;
+    }
   }
 
   /* A9 (#798): reduced-motion guard for the connection + claude-presence dots

--- a/src/client/status/StatusBar.svelte
+++ b/src/client/status/StatusBar.svelte
@@ -9,7 +9,6 @@ import type {
   PushDelivery,
 } from "../hooks/useAiReadiness.svelte";
 import { AI_CTA } from "../hooks/useAiReadiness.svelte";
-import type { CwdDrift } from "../hooks/useCwdDrift.svelte";
 import type { ConnectionStatus } from "../hooks/yjsSync.svelte";
 import { createCoalescingTick } from "../utils/coalescing-tick";
 import { debounce } from "../utils/debounce";
@@ -18,7 +17,7 @@ import {
   type AiIndicatorTone,
   type AiIndicatorView,
   aiIndicatorView,
-  cwdDriftPill,
+  type CwdDriftPill as CwdDriftPillView,
 } from "./status-ai-view";
 import { getCount, loadMode, modeLabel, nextMode, saveMode } from "./word-count-cycle";
 
@@ -81,13 +80,16 @@ interface Props {
    */
   heldCount?: number;
   /**
-   * #1282: the server's working-folder drift verdict for the active document,
-   * with the user's own suppression (per-pair dismissal / session backstop /
-   * permanent opt-out) ALREADY applied by the caller. `null` means "say
-   * nothing" — this component never re-derives whether a drift is worth
-   * mentioning, it only renders the answer.
+   * #1282: the fully-resolved working-folder drift pill, or `null` for "say
+   * nothing". Every gate — the server's verdict, the user's suppression, and the
+   * stale-CTA check — is applied by the caller.
+   *
+   * The composed VIEW is passed rather than the raw drift because App needs the
+   * same answer for the one-time explainer, whose copy points at this pill.
+   * Computing it in both places is how the explainer's precondition drifted
+   * weaker than the pill's render condition in the first place.
    */
-  cwdDrift?: CwdDrift | null;
+  cwdDriftView?: CwdDriftPillView | null;
   /** Open the "restart Claude in this folder" flow (which confirms first). */
   onRelaunchInFolder?: () => void;
   /** Hide this (Claude's folder, target folder) pair for the session. */
@@ -116,7 +118,7 @@ let {
   lastSaveOk = false,
   editor,
   heldCount = 0,
-  cwdDrift = null,
+  cwdDriftView = null,
   onRelaunchInFolder,
   onDismissDrift,
   onOptOutDrift,
@@ -239,9 +241,8 @@ const labelColor = $derived(
 // `$derived` so it recomputes as the reactive props flip connected→solo→down.
 const aiView = $derived(aiIndicatorView(aiState, aiLiveIndicator, soloMode, pushDelivery));
 
-// #1282. A sibling of the AI indicator rather than part of it, and mutually
-// exclusive with the CTA below by construction — see `cwdDriftPill`.
-const driftView = $derived(cwdDriftPill(cwdDrift, aiChip));
+// #1282. A sibling of the AI indicator rather than part of it — see
+// `cwdDriftPill` for why, and why it is composed by the caller rather than here.
 
 /**
  * The AI indicator's actionable content — title, aria-label, and onclick —
@@ -356,6 +357,8 @@ function cycleWordMode() {
      labelled already; it needs no landmark of its own. -->
 <div
   class="tandem-floating-pill tandem-status-pill"
+  data-status-focus-root
+  tabindex="-1"
   style="position: fixed; bottom: var(--tandem-space-3, 12px); left: var(--tandem-space-5, 22px); max-width: calc(100% - var(--tandem-space-7, 44px)); display: inline-flex; align-items: center; padding: 6px var(--tandem-space-3); font-family: var(--tandem-font-mono); font-size: var(--tandem-text-xs); color: var(--tandem-fg-muted); user-select: none; gap: var(--tandem-space-3); z-index: var(--tandem-z-sticky); overflow: hidden;"
 >
   <!-- Left: document/sync fields, faint until the pill is hovered/focused.
@@ -475,9 +478,9 @@ function cycleWordMode() {
   <!-- #1282 working-folder drift. Deliberately NOT nested inside `{#if aiView}`:
        `aiIndicatorView` returns null for "launcher running, no MCP session yet",
        which is exactly the auto-launched startup window this nudge exists for. -->
-  {#if driftView}
+  {#if cwdDriftView}
     <CwdDriftPill
-      pill={driftView}
+      pill={cwdDriftView}
       onRelaunch={() => onRelaunchInFolder?.()}
       onDismiss={() => onDismissDrift?.()}
       onOptOut={() => onOptOutDrift?.()}

--- a/src/client/status/cwdDriftDismiss.svelte.ts
+++ b/src/client/status/cwdDriftDismiss.svelte.ts
@@ -22,9 +22,12 @@
  * strictly worse, because Claude is in a folder with a `CLAUDE.md` that has
  * nothing to do with the note.
  *
- * Module scope, not component `$state`: `StatusBar` is inside the layout that
- * re-renders on panel toggles, and "dismissed for this session" has to mean
- * exactly that.
+ * Module scope, not component `$state`, because no single component owns it: the
+ * readers and writers live in `App.svelte` (the `visibleCwdDrift` derivation and
+ * all three menu handlers), while `StatusBar` only receives the already-filtered
+ * result as a prop. `StatusBar` is mounted unconditionally today, so this is not
+ * guarding a live remount — it is keeping "for this session" true of a decision
+ * that spans two files.
  */
 
 /** localStorage key for the permanent opt-out. */
@@ -63,9 +66,11 @@ function loadOptOut(): boolean {
  * Stable key for a (Claude's folder, target folder) pair.
  *
  * Length-prefixed rather than delimiter-joined. Any separator character can in
- * principle occur in a path, and a joined key makes ("~/a", "~/b/c") and
- * ("~/a/b", "~/c") collide — dismissing one would silently suppress the other.
- * A length prefix makes the split unambiguous and reserves no characters.
+ * principle occur in a path, and joining on one makes two different pairs
+ * identical whenever a folder name contains it: joined on "|", both
+ * ("a|b", "c") and ("a", "b|c") become "a|b|c", so dismissing either silently
+ * suppresses the other. A length prefix reserves no character and has no such
+ * case.
  */
 function pairKey(claudeCwd: string, suggestedCwd: string): string {
   return `${claudeCwd.length}:${claudeCwd}${suggestedCwd}`;
@@ -111,9 +116,23 @@ export function optOutOfDriftNudge(): boolean {
   }
 }
 
-/** Whether the user has permanently opted out (for the Settings surface). */
+/** Whether the user has permanently opted out. Read by the palette command that
+ * turns the reminders back on — "don't show this again" must not be a one-way
+ * door whose only exit is editing localStorage by hand. */
 export function driftNudgeOptedOut(): boolean {
   return optedOut;
+}
+
+/** Undo the permanent opt-out. Returns false when the preference could not be
+ * cleared from storage, so the caller can avoid promising it will stick. */
+export function clearDriftNudgeOptOut(): boolean {
+  optedOut = false;
+  try {
+    localStorage.removeItem(OPT_OUT_KEY);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -124,8 +143,15 @@ export function driftNudgeOptedOut(): boolean {
  *
  * A plain `let` guard, deliberately not `$state`: the caller reads this from
  * inside an `$effect` that also writes a notification, and a reactive flag
- * would re-enter that effect. An unreadable/unwritable localStorage degrades to
- * "explain once per session", which is the harmless direction.
+ * would re-enter that effect.
+ *
+ * **When it cannot record the claim, it does not make it.** Returning true on an
+ * unwritable store would look like "degrade to once per session", but the
+ * degradation compounds: the same store cannot persist the opt-out either, so
+ * a storage-disabled browser replays this four-sentence notice on EVERY launch,
+ * forever, including to someone who has explicitly clicked "don't show this
+ * again". The pill and its menu still carry the whole explanation, so declining
+ * to explain costs one notice; the alternative costs one per launch for good.
  */
 let explainerShownThisSession = false;
 export function noteDriftSeen(): boolean {
@@ -135,22 +161,27 @@ export function noteDriftSeen(): boolean {
     if (localStorage.getItem(SEEN_KEY) === "1") return false;
     localStorage.setItem(SEEN_KEY, "1");
   } catch {
-    // Storage unavailable — the session guard above still bounds this to one.
+    return false;
   }
   return true;
 }
 
-/** Test-only reset of module state between cases. */
-export function _resetDriftDismissForTests(): void {
+/** Test-only reset of module state between cases. Clears storage FIRST, then
+ * re-runs `loadOptOut()` exactly as a fresh page load would — so a test can seed
+ * `OPT_OUT_KEY` and prove the opt-out actually survives a restart, which a plain
+ * `optedOut = false` assignment silently skips. */
+export function _resetDriftDismissForTests(opts: { keepStorage?: boolean } = {}): void {
   dismissedPairs = new Set();
   dismissCount = 0;
-  optedOut = false;
   backstopAnnounced = false;
   explainerShownThisSession = false;
-  try {
-    localStorage.removeItem(OPT_OUT_KEY);
-    localStorage.removeItem(SEEN_KEY);
-  } catch {
-    // no-op — the tests that care assert through the exported readers
+  if (!opts.keepStorage) {
+    try {
+      localStorage.removeItem(OPT_OUT_KEY);
+      localStorage.removeItem(SEEN_KEY);
+    } catch {
+      // no-op — the tests that care assert through the exported readers
+    }
   }
+  optedOut = loadOptOut();
 }

--- a/src/client/status/cwdDriftDismiss.svelte.ts
+++ b/src/client/status/cwdDriftDismiss.svelte.ts
@@ -1,0 +1,156 @@
+/**
+ * Suppression state for the working-directory drift nudge (#1282).
+ *
+ * Three layers, because one is not enough and the reason is arithmetic. The
+ * launcher's default working directory is `os.homedir()`, and the drift check
+ * requires the candidate folder to be *inside* home — so out of the box, for a
+ * user who has never set a working directory, EVERY document in every subfolder
+ * drifts. Without suppression this would not be an occasional nudge about an
+ * occasional mistake; it would be a permanent amber pill.
+ *
+ *   1. **Per-pair dismissal** — "not now" for this exact (Claude's folder,
+ *      target folder) combination, for this session.
+ *   2. **Session backstop** — after `SESSION_DISMISS_LIMIT` dismissals the nudge
+ *      stops for the whole session. Aimed at the user who deliberately parks
+ *      Claude in one place and edits everywhere: per-pair dismissal alone hands
+ *      them a fresh pill for every folder they visit, forever.
+ *   3. **Persistent opt-out** — "don't ask again", across restarts.
+ *
+ * Keyed on the PAIR, never the target alone. Dismiss "move to ~/notes" while
+ * Claude sits in home; later move Claude to a project; reopen a note. Keyed on
+ * the target, that is still suppressed — even though the situation is now
+ * strictly worse, because Claude is in a folder with a `CLAUDE.md` that has
+ * nothing to do with the note.
+ *
+ * Module scope, not component `$state`: `StatusBar` is inside the layout that
+ * re-renders on panel toggles, and "dismissed for this session" has to mean
+ * exactly that.
+ */
+
+/** localStorage key for the permanent opt-out. */
+const OPT_OUT_KEY = "tandem:cwd-drift-opt-out";
+/** localStorage key for "the one-time explainer has been shown". */
+const SEEN_KEY = "tandem:cwd-drift-seen";
+
+/** How many "not now" clicks before the nudge gives up for the session. */
+export const SESSION_DISMISS_LIMIT = 3;
+
+/**
+ * Reassigned to a fresh Set on every dismissal, never mutated in place.
+ * `$state(new Set())` is NOT deep-proxied in Svelte 5 — only plain objects and
+ * arrays are — so `.add()` is invisible to reactivity. Mutating would make the
+ * dismiss button look dead and then take effect retroactively at some unrelated
+ * re-render. Same contract as `MarginColumn`'s `pinnedIds`.
+ */
+let dismissedPairs = $state<Set<string>>(new Set());
+let dismissCount = $state(0);
+let optedOut = $state(loadOptOut());
+/** Has the "I'll stop asking" notice been shown this session? */
+let backstopAnnounced = false;
+
+function loadOptOut(): boolean {
+  try {
+    return localStorage.getItem(OPT_OUT_KEY) === "1";
+  } catch {
+    // Incognito / storage-disabled browsers throw on access. An unreadable
+    // preference is not an opt-out — fall back to showing the nudge, which the
+    // session-scoped layers still bound.
+    return false;
+  }
+}
+
+/**
+ * Stable key for a (Claude's folder, target folder) pair.
+ *
+ * Length-prefixed rather than delimiter-joined. Any separator character can in
+ * principle occur in a path, and a joined key makes ("~/a", "~/b/c") and
+ * ("~/a/b", "~/c") collide — dismissing one would silently suppress the other.
+ * A length prefix makes the split unambiguous and reserves no characters.
+ */
+function pairKey(claudeCwd: string, suggestedCwd: string): string {
+  return `${claudeCwd.length}:${claudeCwd}${suggestedCwd}`;
+}
+
+/** Should the nudge for this pair be hidden? */
+export function driftDismissed(claudeCwd: string, suggestedCwd: string): boolean {
+  if (optedOut) return true;
+  if (dismissCount >= SESSION_DISMISS_LIMIT) return true;
+  return dismissedPairs.has(pairKey(claudeCwd, suggestedCwd));
+}
+
+/**
+ * Dismiss this pair for the session.
+ *
+ * Returns `true` when this dismissal is the one that trips the session backstop
+ * and the caller should say so — once. Silently going quiet after the third
+ * dismissal would leave the user with no way to tell "Claude is in the right
+ * folder now" from "Tandem stopped mentioning it", which are opposite facts.
+ */
+export function dismissDrift(claudeCwd: string, suggestedCwd: string): boolean {
+  const next = new Set(dismissedPairs);
+  next.add(pairKey(claudeCwd, suggestedCwd));
+  dismissedPairs = next;
+  dismissCount += 1;
+  if (dismissCount >= SESSION_DISMISS_LIMIT && !backstopAnnounced) {
+    backstopAnnounced = true;
+    return true;
+  }
+  return false;
+}
+
+/** Permanent opt-out ("don't ask again"). A failed write is not silent: the
+ * caller is told, so it can degrade to the session-scoped promise it CAN keep
+ * rather than claiming a durable one it cannot. */
+export function optOutOfDriftNudge(): boolean {
+  optedOut = true;
+  try {
+    localStorage.setItem(OPT_OUT_KEY, "1");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Whether the user has permanently opted out (for the Settings surface). */
+export function driftNudgeOptedOut(): boolean {
+  return optedOut;
+}
+
+/**
+ * Claim the one-time explainer. Returns `true` exactly once per install — the
+ * first time a drift is actually SHOWN, not the first time one is computed, so
+ * a user whose very first drift is suppressed still gets the explanation
+ * whenever one first reaches them.
+ *
+ * A plain `let` guard, deliberately not `$state`: the caller reads this from
+ * inside an `$effect` that also writes a notification, and a reactive flag
+ * would re-enter that effect. An unreadable/unwritable localStorage degrades to
+ * "explain once per session", which is the harmless direction.
+ */
+let explainerShownThisSession = false;
+export function noteDriftSeen(): boolean {
+  if (explainerShownThisSession) return false;
+  explainerShownThisSession = true;
+  try {
+    if (localStorage.getItem(SEEN_KEY) === "1") return false;
+    localStorage.setItem(SEEN_KEY, "1");
+  } catch {
+    // Storage unavailable — the session guard above still bounds this to one.
+  }
+  return true;
+}
+
+/** Test-only reset of module state between cases. */
+export function _resetDriftDismissForTests(): void {
+  dismissedPairs = new Set();
+  dismissCount = 0;
+  optedOut = false;
+  backstopAnnounced = false;
+  explainerShownThisSession = false;
+  try {
+    localStorage.removeItem(OPT_OUT_KEY);
+    localStorage.removeItem(SEEN_KEY);
+  } catch {
+    // no-op — the tests that care assert through the exported readers
+  }
+}

--- a/src/client/status/status-ai-view.ts
+++ b/src/client/status/status-ai-view.ts
@@ -1,8 +1,10 @@
 import type {
+  AiChip,
   AiLiveIndicator,
   AiReadinessState,
   PushDelivery,
 } from "../hooks/useAiReadiness.svelte";
+import type { CwdDrift } from "../hooks/useCwdDrift.svelte";
 
 /**
  * Consolidated AI-status indicator for the status pill (replaces the old
@@ -131,4 +133,65 @@ export function aiIndicatorView(
   if (state === "ready") return null; // launcher running, no session yet
   if (soloMode) return null; // opted out of AI — don't nag
   return NOT_CONNECTED; // unconfigured / stopped, Tandem: honest "not connected"
+}
+
+// --- Working-directory drift qualifier (#1282) -----------------------------
+
+export interface CwdDriftPill {
+  /** Compact status-bar text. */
+  label: string;
+  /** Hover tooltip. */
+  title: string;
+  /** Screen-reader label — carries the full paths, which the pill elides. */
+  ariaLabel: string;
+  /** Menu heading: the explanation the pill has no room for. */
+  explanation: string;
+  /** Label for the act-on-it row. */
+  actionLabel: string;
+}
+
+/**
+ * The working-directory drift pill, or `null` to render nothing.
+ *
+ * **Why this is a sibling of the AI indicator and not folded into it.** The
+ * obvious placement — inside `aiIndicatorView`'s returned view — is dead code
+ * in exactly the state the nudge exists for: `aiIndicatorView` returns `null`
+ * when `state === "ready"` with no live MCP session, which is precisely the
+ * auto-launched desktop startup window where the launcher is running (and so
+ * has a cwd to be wrong about) but no agent has connected yet. Anything nested
+ * inside `{#if aiView}` would never render there.
+ *
+ * **Why two adjacent Claude chips is not the #1268 shape.** That failure was two
+ * CTAs for the same situation, describing it differently and wired to different
+ * handlers. These two cannot coexist by construction: `aiChip` is non-null only
+ * for `unconfigured` / `stopped`, both of which mean the supervised launcher is
+ * not running — and the server reports drift only when it IS. They can overlap
+ * only transiently, when Claude dies between a drift probe and the next
+ * readiness poll, so `aiChip` wins outright. This is a staleness gate, not a
+ * second copy of the server's predicate: it never turns a `false` into a `true`.
+ *
+ * `drift` being non-null already means "the server says nudge"; suppression the
+ * USER asked for (per-pair dismissal, session backstop, permanent opt-out) is
+ * applied by the caller before this point, so it stays in one place —
+ * `cwdDriftDismiss` — rather than half here and half there.
+ */
+export function cwdDriftPill(drift: CwdDrift | null, aiChip: AiChip): CwdDriftPill | null {
+  if (drift === null) return null;
+  if (aiChip !== null) return null;
+  // Names the consequence, not the state. "AI · other folder" reads as a
+  // connection status and leaves the user with no idea what is actually
+  // degraded — the document syncs fine and Claude can still edit it; what it
+  // cannot see is everything AROUND the document.
+  const consequence =
+    `Claude is running in ${drift.claudeCwd}, not ${drift.suggestedCwd}. ` +
+    "It can still read and edit this document, but it can't see that folder's " +
+    "CLAUDE.md, .claude/ settings or git history, and its own file tools can't " +
+    "reach the files beside it.";
+  return {
+    label: `Claude in ${drift.claudeLabel}`,
+    title: consequence,
+    ariaLabel: `Working folder mismatch. ${consequence}`,
+    explanation: consequence,
+    actionLabel: `Restart Claude in ${drift.label}…`,
+  };
 }

--- a/src/client/svelte-harness/CwdDriftHarness.svelte
+++ b/src/client/svelte-harness/CwdDriftHarness.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+import { untrack } from "svelte";
+import {
+  type CwdDriftOptions,
+  type CwdDriftState,
+  createCwdDrift,
+} from "../hooks/useCwdDrift.svelte.js";
+
+/**
+ * Mount host for `createCwdDrift` (#1282). The hook owns an `$effect` and an
+ * `onDestroy`, so it needs a real component context — a bare call from a test
+ * would neither track its inputs nor clean up. Mirrors `ReachabilityCheckHarness`.
+ */
+
+interface Props {
+  onReady: (state: CwdDriftState) => void;
+  cwd?: string | null;
+  opts?: CwdDriftOptions;
+}
+
+let { onReady, cwd = null, opts = {} }: Props = $props();
+
+// Created once at mount; the dep reads the live prop so a test can drive
+// tab switches by re-rendering with a new `cwd`.
+const drift = untrack(() => createCwdDrift(() => cwd, opts));
+
+$effect(() => {
+  onReady(drift);
+});
+</script>
+
+<div
+  data-testid="cwd-drift-harness"
+  data-label={drift.drift?.label ?? ""}
+  data-claude-label={drift.drift?.claudeLabel ?? ""}
+></div>

--- a/src/server/annotations/rename-recovery.ts
+++ b/src/server/annotations/rename-recovery.ts
@@ -168,7 +168,7 @@ export async function recoverRenamedEnvelope(
       // Safety: path is validated above (isAbsolute + resolve + no-UNC).
       let oldStillExists: boolean;
       try {
-        await fs.access(resolvedOldPath); // lgtm[js/path-injection]
+        await fs.access(resolvedOldPath);
         oldStillExists = true;
       } catch {
         oldStillExists = false;

--- a/src/server/launcher/api-routes.ts
+++ b/src/server/launcher/api-routes.ts
@@ -20,9 +20,12 @@
  *   - `POST /cwd-preview` — body `{ cwd }`. Read-only drift verdict (#1282);
  *     loopback-only, no nonce. See `makeCwdPreviewHandler`.
  *
- * The supervisor singleton is bridged via `() => Supervisor | null`. Routes
- * return 503 + `NOT_AVAILABLE` when the getter returns null (stdio mode,
- * disabled-by-env, or no claude-code integration).
+ * The supervisor singleton is bridged via `() => Supervisor | null`. The
+ * MUTATING routes return 503 + `NOT_AVAILABLE` when the getter returns null
+ * (stdio mode, disabled-by-env, or no claude-code integration). The two
+ * read-only ones do not: `GET /status` answers `{ available: false }`, and
+ * `POST /cwd-preview` answers `{ drifted: false }` — for both, "there is no
+ * launcher" is a fact worth reporting rather than an error.
  */
 
 import { randomBytes, timingSafeEqual } from "node:crypto";
@@ -174,6 +177,9 @@ export interface LauncherRoutesDeps {
   relaunchHook?: () => Promise<void>;
   startFreshHook?: () => Promise<void>;
   workingDirHook?: () => Promise<void>;
+  /** Same seam for the preview route: holds a probe in-flight so concurrent
+   * requests exercise the shed path. Fires INSIDE the counted region. */
+  cwdPreviewHook?: () => Promise<void>;
 }
 
 export function registerLauncherRoutes(app: Express, mw: Handler, deps: LauncherRoutesDeps): void {
@@ -665,7 +671,23 @@ function makeCwdPreviewHandler(deps: LauncherRoutesDeps): Handler {
       return;
     }
 
+    // Shed load rather than queue it. This is the only launcher route doing
+    // unbounded filesystem work, and the hazard is the same one the async
+    // resolvers were written for, one level down: `fsp.realpath` keeps the event
+    // loop free but holds a libuv THREADPOOL slot (default 4) for the full SMB
+    // timeout, and it takes no AbortSignal — so an aborted request keeps its
+    // thread. Four concurrent probes against a hung mapped drive would starve
+    // the pool that atomic saves, session writes and the annotation writer share,
+    // and the symptom would be saves hanging with nothing pointing here.
+    // Shedding costs nothing: every failure on this route is already "no drift".
+    if (cwdPreviewInFlight >= MAX_CONCURRENT_CWD_PREVIEWS) {
+      res.json({ drifted: false } satisfies LauncherCwdPreview);
+      return;
+    }
+    cwdPreviewInFlight += 1;
+
     try {
+      if (deps.cwdPreviewHook) await deps.cwdPreviewHook();
       const preview = await previewCwdDrift({
         candidate: pre.cwd,
         claudeCwd: runningCwd(deps.getSupervisor()),
@@ -679,21 +701,46 @@ function makeCwdPreviewHandler(deps: LauncherRoutesDeps): Handler {
       // suppressing the whole feature.
       console.error("[Launcher routes] cwd-preview failed:", err);
       res.json({ drifted: false } satisfies LauncherCwdPreview);
+    } finally {
+      cwdPreviewInFlight -= 1;
     }
   };
 }
 
-/** Where the supervised Claude is running right now, or `null` when nothing is
- * (no supervisor, stopped, or `status()` threw — which it should never do, but a
- * drift verdict is a suggestion, and "no drift" is the safe one). */
+/**
+ * Concurrency cap for the drift preview. Small on purpose: the client issues at
+ * most one probe per settled tab switch, so anything above a couple in flight is
+ * either a burst of very fast switching or a caller that is not the UI.
+ */
+const MAX_CONCURRENT_CWD_PREVIEWS = 3;
+let cwdPreviewInFlight = 0;
+
+/** Test-only reset of the preview concurrency counter. */
+export function _resetCwdPreviewInFlightForTests(): void {
+  if (process.env.VITEST !== "true") {
+    throw new Error("_resetCwdPreviewInFlightForTests is test-only");
+  }
+  cwdPreviewInFlight = 0;
+}
+
+/**
+ * Where the supervised Claude is running right now, or `null` when nothing is.
+ *
+ * Deliberately does NOT catch a throwing `status()`. It is called inside the
+ * handler's `try`, which already answers with the identical `{ drifted: false }`
+ * — and logs. A local catch here would change exactly one thing: it would delete
+ * the only diagnostic this route has, for the failure it is least prepared for.
+ * "Should never throw" is the reason to log it, not the reason to swallow it.
+ *
+ * Contrast `landedCwd`, which lets `status()` throw through to `sendUnexpected`
+ * and a 500. Same call, opposite contracts: there the caller asked to *change*
+ * something and deserves an error; here it asked a question a failed check can
+ * still answer.
+ */
 function runningCwd(sup: Supervisor | null): string | null {
   if (sup === null) return null;
-  try {
-    const st = sup.status();
-    return st.running ? st.cwd : null;
-  } catch {
-    return null;
-  }
+  const st = sup.status();
+  return st.running ? st.cwd : null;
 }
 
 /** Cap on the error detail surfaced over the wire. These routes are loopback +

--- a/src/server/launcher/api-routes.ts
+++ b/src/server/launcher/api-routes.ts
@@ -633,13 +633,19 @@ function makeWorkingDirHandler(deps: LauncherRoutesDeps): Handler {
  * Gates, and why they are these gates:
  *
  *   - **Origin allowlist**, like every other launcher route.
- *   - **A bare loopback check, NOT `assertLoopbackForMutation`.** That helper
- *     only rejects when `TANDEM_ALLOW_UNAUTHENTICATED_LAN=1`, so in the default
- *     configuration it is a no-op — using it here would read as a gate while
- *     enforcing nothing. The response reconstructs the launcher `cwd` that
- *     `makeStatusHandler` deliberately withholds off-loopback, and adds a second
- *     path under the user's home directory, so it needs the unconditional
- *     posture `GET /api/document/raw` and `/api/diagnostics` use (#1121).
+ *   - **A bare loopback check, not `assertLoopbackForMutation`** — and the
+ *     reason is now naming, not strength. When this route was written that
+ *     helper rejected only under `TANDEM_ALLOW_UNAUTHENTICATED_LAN=1`, making it
+ *     a no-op in the default configuration; **#1293 made it unconditional**, so
+ *     the two are behaviourally equivalent today. What remains is that this
+ *     route mutates nothing: it is a read whose response reconstructs the
+ *     launcher `cwd` that `makeStatusHandler` deliberately withholds
+ *     off-loopback, plus a second path under the user's home directory. That
+ *     puts it with `GET /api/document/raw` and `/api/diagnostics` (#1121), which
+ *     use the same bare check for the same reason.
+ *
+ *     If #1320 lands its `/api`-wide loopback invariant, this hand-rolled check
+ *     should fold into it rather than persist as an exception.
  *   - **No nonce.** Nonces exist to stop replayed *destructive* calls. This route
  *     starts nothing, stops nothing and writes nothing; consuming a nonce would
  *     also rotate it out from under a relaunch the user is about to confirm.

--- a/src/server/launcher/api-routes.ts
+++ b/src/server/launcher/api-routes.ts
@@ -1,7 +1,7 @@
 /**
  * HTTP routes for the Claude Code auto-launcher (#477 PR 4b).
  *
- * Five endpoints, all under `/api/launcher/*`:
+ * Seven endpoints, all under `/api/launcher/*`:
  *   - `GET /status` — read-only; loopback returns full struct (with
  *     `sessionId` redacted to "<set>"), non-loopback returns the minimal
  *     `{ available, running }` shape (mirrors `/health`'s redaction pattern).
@@ -16,6 +16,9 @@
  *     Narrow write to the first claude-code integration's
  *     `workingDirectory` field. Bypasses the integrations apply-nonce
  *     rotation that a full-array POST would trigger.
+ *   - `POST /start` — promote a `deferred-autostart` launcher (#1236).
+ *   - `POST /cwd-preview` — body `{ cwd }`. Read-only drift verdict (#1282);
+ *     loopback-only, no nonce. See `makeCwdPreviewHandler`.
  *
  * The supervisor singleton is bridged via `() => Supervisor | null`. Routes
  * return 503 + `NOT_AVAILABLE` when the getter returns null (stdio mode,
@@ -27,6 +30,7 @@ import { randomBytes, timingSafeEqual } from "node:crypto";
 import type { Express, Request, Response } from "express";
 
 import {
+  API_LAUNCHER_CWD_PREVIEW,
   API_LAUNCHER_NONCE,
   API_LAUNCHER_RELAUNCH,
   API_LAUNCHER_START,
@@ -45,6 +49,7 @@ import {
   LAUNCHER_ERROR_NOT_AVAILABLE,
   LAUNCHER_ERROR_PATH_REJECTED,
   LAUNCHER_ERROR_REAPER_NOT_FOUND,
+  type LauncherCwdPreview,
   type LauncherStatus,
   type LauncherUnavailableReason,
   REAPER_NOT_FOUND_MARKER,
@@ -55,6 +60,7 @@ import { assertLoopbackForMutation, assertOriginAllowlisted } from "../integrati
 import type { IntegrationConfig } from "../integrations/schema.js";
 import type { IntegrationsStore } from "../integrations/storage.js";
 import type { Handler } from "../mcp/routes/_shared.js";
+import { previewCwdDrift } from "./cwd-preview.js";
 import { resolveRouteCwd, type Supervisor } from "./supervisor.js";
 
 /**
@@ -153,6 +159,12 @@ export interface LauncherRoutesDeps {
   startSupervisor: () => Promise<void>;
   /** Reads/writes the integrations file. Same store passed to integrations routes. */
   store: IntegrationsStore;
+  /** Directories holding Tandem's own auto-opened documents, excluded from the
+   * drift preview. Injected rather than imported: the paths are resolved in
+   * `mcp/server.ts` (which registers these routes), and passing them keeps the
+   * exclusion list testable without a real install layout. See
+   * `CwdPreviewDeps.bundledDocDirs` for why the exclusion exists at all. */
+  bundledDocDirs?: readonly string[];
   /** Loopback-only side-channel for skill refresh failures. `null` when the
    * last refresh succeeded or the helper is not wired (test mode). */
   getSkillRefreshError?: () => SkillRefreshError | null;
@@ -182,6 +194,9 @@ export function registerLauncherRoutes(app: Express, mw: Handler, deps: Launcher
 
   app.options(API_LAUNCHER_WORKING_DIRECTORY, mw);
   app.post(API_LAUNCHER_WORKING_DIRECTORY, mw, makeWorkingDirHandler(deps));
+
+  app.options(API_LAUNCHER_CWD_PREVIEW, mw);
+  app.post(API_LAUNCHER_CWD_PREVIEW, mw, makeCwdPreviewHandler(deps));
 }
 
 // --- Handlers -------------------------------------------------------------
@@ -299,27 +314,47 @@ function sendInProgress(res: Response, message: string): void {
   });
 }
 
+type CwdPrecheck = { ok: true; cwd: string } | { ok: false; reason: "not-a-string" | "too-long" };
+
+/**
+ * The I/O-free half of the cwd-field predicate: type, then length cap.
+ *
+ * Shared — not restated — by the mutating routes and the read-only preview, and
+ * shared at exactly this seam because the two halves cannot be shared as one.
+ * The mutating routes resolve the path synchronously; the preview runs at
+ * tab-switch frequency and must resolve it asynchronously (`statSync` on a
+ * disconnected mapped drive blocks the event loop). So the fs half necessarily
+ * forks, and the pre-checks must not, or the preview would green-light a
+ * 2000-character dirname that the relaunch it advertises then rejects. A
+ * predicate that answers differently on the query path and the action path is
+ * the defect #1282 was filed for; keeping this function the only home for the
+ * cap means deleting it breaks the relaunch tests, not just the preview's.
+ */
+function precheckCwdField(raw: unknown): CwdPrecheck {
+  if (typeof raw !== "string") return { ok: false, reason: "not-a-string" };
+  if (raw.length > LAUNCHER_CWD_MAX_LENGTH) return { ok: false, reason: "too-long" };
+  return { ok: true, cwd: raw };
+}
+
 /** Validate a string cwd field: type, length cap, and home-confined resolution.
- * `fieldName` parameterizes the error messages — "cwd" for request bodies,
- * "workingDirectory" for the POST /working-directory route. */
+ * The mutating half of the split above — `precheckCwdField` plus the synchronous
+ * fs resolution. `fieldName` parameterizes the error messages — "cwd" for
+ * request bodies, "workingDirectory" for the POST /working-directory route. */
 function validateCwdString(
   raw: unknown,
   res: Response,
   fieldName: "cwd" | "workingDirectory",
 ): string | null {
-  if (typeof raw !== "string") {
-    sendBadRequest(res, LAUNCHER_ERROR_INVALID_BODY, `${fieldName} must be a string`);
+  const pre = precheckCwdField(raw);
+  if (!pre.ok) {
+    const message =
+      pre.reason === "not-a-string"
+        ? `${fieldName} must be a string`
+        : `${fieldName} exceeds ${LAUNCHER_CWD_MAX_LENGTH} chars`;
+    sendBadRequest(res, LAUNCHER_ERROR_INVALID_BODY, message);
     return null;
   }
-  if (raw.length > LAUNCHER_CWD_MAX_LENGTH) {
-    sendBadRequest(
-      res,
-      LAUNCHER_ERROR_INVALID_BODY,
-      `${fieldName} exceeds ${LAUNCHER_CWD_MAX_LENGTH} chars`,
-    );
-    return null;
-  }
-  const resolved = resolveRouteCwd(raw);
+  const resolved = resolveRouteCwd(pre.cwd);
   if (resolved === null) {
     sendBadRequest(
       res,
@@ -584,6 +619,81 @@ function makeWorkingDirHandler(deps: LauncherRoutesDeps): Handler {
       inflight.workingDirectory = false;
     }
   };
+}
+
+/**
+ * `POST /api/launcher/cwd-preview` (#1282) — read-only drift verdict.
+ *
+ * Gates, and why they are these gates:
+ *
+ *   - **Origin allowlist**, like every other launcher route.
+ *   - **A bare loopback check, NOT `assertLoopbackForMutation`.** That helper
+ *     only rejects when `TANDEM_ALLOW_UNAUTHENTICATED_LAN=1`, so in the default
+ *     configuration it is a no-op — using it here would read as a gate while
+ *     enforcing nothing. The response reconstructs the launcher `cwd` that
+ *     `makeStatusHandler` deliberately withholds off-loopback, and adds a second
+ *     path under the user's home directory, so it needs the unconditional
+ *     posture `GET /api/document/raw` and `/api/diagnostics` use (#1121).
+ *   - **No nonce.** Nonces exist to stop replayed *destructive* calls. This route
+ *     starts nothing, stops nothing and writes nothing; consuming a nonce would
+ *     also rotate it out from under a relaunch the user is about to confirm.
+ *
+ * A `503` is impossible here on purpose: "the launcher isn't available" is a
+ * perfectly good answer to "is Claude in the wrong folder", and it is `no`.
+ */
+function makeCwdPreviewHandler(deps: LauncherRoutesDeps): Handler {
+  return async (req: Request, res: Response) => {
+    if (assertOriginAllowlisted(req, res, API_LAUNCHER_CWD_PREVIEW)) return;
+    if (!isLoopback(req.socket.remoteAddress)) {
+      res.status(403).json({ error: "FORBIDDEN", message: "Loopback only." });
+      return;
+    }
+    const body = parseJsonObjectBody(req, res);
+    if (body === null) return;
+    // A non-string `cwd` is a caller bug and gets a 400. Every other rejection —
+    // over-length, outside home, non-existent, UNC — is a legitimate answer to
+    // the question asked, and the answer is "no drift". The client probes this
+    // on every settled tab switch; a document on an external drive is not an
+    // error the user committed.
+    const pre = precheckCwdField(body.cwd);
+    if (!pre.ok) {
+      if (pre.reason === "not-a-string") {
+        sendBadRequest(res, LAUNCHER_ERROR_INVALID_BODY, "cwd must be a string");
+        return;
+      }
+      res.json({ drifted: false } satisfies LauncherCwdPreview);
+      return;
+    }
+
+    try {
+      const preview = await previewCwdDrift({
+        candidate: pre.cwd,
+        claudeCwd: runningCwd(deps.getSupervisor()),
+        bundledDocDirs: deps.bundledDocDirs ?? [],
+      });
+      res.json(preview);
+    } catch (err) {
+      // Deliberately NOT a 500. This endpoint's contract is "should I nudge?",
+      // and a failed check answers that as well as a successful one does. Logged
+      // so a systematically failing probe is discoverable rather than silently
+      // suppressing the whole feature.
+      console.error("[Launcher routes] cwd-preview failed:", err);
+      res.json({ drifted: false } satisfies LauncherCwdPreview);
+    }
+  };
+}
+
+/** Where the supervised Claude is running right now, or `null` when nothing is
+ * (no supervisor, stopped, or `status()` threw — which it should never do, but a
+ * drift verdict is a suggestion, and "no drift" is the safe one). */
+function runningCwd(sup: Supervisor | null): string | null {
+  if (sup === null) return null;
+  try {
+    const st = sup.status();
+    return st.running ? st.cwd : null;
+  } catch {
+    return null;
+  }
 }
 
 /** Cap on the error detail surfaced over the wire. These routes are loopback +

--- a/src/server/launcher/cwd-preview.ts
+++ b/src/server/launcher/cwd-preview.ts
@@ -42,6 +42,22 @@ function segments(p: string): string[] {
 }
 
 /**
+ * The path flavour to render in, chosen by the `platform` seam rather than by
+ * the host.
+ *
+ * Keying on the host would make `platform` a HALF-seam: it would select the
+ * case-fold while `path.sep` and `path.relative` still came from wherever the
+ * test happened to run. Every expectation would then be written with the same
+ * host primitive the implementation uses, so an implementation that hardcoded
+ * "/" would pass on Linux CI — and `tildeAbbreviate`, whose whole job is keeping
+ * a real full name out of screenshots on Windows, could not be exercised with a
+ * Windows-shaped path at all.
+ */
+function flavour(platform: NodeJS.Platform): typeof path.posix {
+  return platform === "win32" ? path.win32 : path.posix;
+}
+
+/**
  * The fewest trailing segments of `target` that distinguish it from `other`.
  *
  * The client cannot compute this, which is the whole reason it is returned over
@@ -50,15 +66,21 @@ function segments(p: string): string[] {
  * where the basenames are identical and only the parent differs. A label that
  * names both folders the same thing is not a smaller label, it is a wrong one.
  *
- * Falls back to an elided suffix when the paths only diverge deeper than
- * `MAX_LABEL_SEGMENTS`, and to the plain last segment when one path is a suffix
- * of the other (nothing distinguishes them at any depth).
+ * When the divergence is deeper than `MAX_LABEL_SEGMENTS` the label elides the
+ * MIDDLE — `alpha…z`, not `…x/y/z`. Eliding the front would drop the only
+ * segment that differs, so both folders would come back named `…/x/y/z`: the
+ * exact "names both folders the same thing" failure this function exists to
+ * avoid, reintroduced by the fallback.
+ *
+ * Falls back to the plain last segment when one path is a trailing sub-path of
+ * the other (nothing distinguishes them at any depth).
  */
 export function distinguishingLabel(
   target: string,
   other: string,
   platform: NodeJS.Platform = process.platform,
 ): string {
+  const sep = flavour(platform).sep;
   const a = segments(target);
   const b = segments(other);
   if (a.length === 0) return target; // filesystem root — nothing to name
@@ -67,8 +89,9 @@ export function distinguishingLabel(
     const aTail = a.slice(-k);
     const bTail = b.slice(-k);
     if (samePath(aTail.join("/"), bTail.join("/"), platform)) continue;
-    if (k <= MAX_LABEL_SEGMENTS) return aTail.join(path.sep);
-    return `…${path.sep}${a.slice(-MAX_LABEL_SEGMENTS).join(path.sep)}`;
+    if (k <= MAX_LABEL_SEGMENTS) return aTail.join(sep);
+    // Keep the diverging segment AND the leaf; elide what's between them.
+    return `${aTail[0]}${sep}…${sep}${a[a.length - 1]}`;
   }
   // One is a trailing sub-path of the other (or they are equal, which the
   // caller has already excluded). Nothing distinguishes them by suffix, so name
@@ -93,10 +116,11 @@ export function tildeAbbreviate(
   home: string,
   platform: NodeJS.Platform = process.platform,
 ): string {
+  const fp = flavour(platform);
   if (samePath(p, home, platform)) return "~";
-  const rel = path.relative(home, p);
-  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return p;
-  return `~${path.sep}${rel}`;
+  const rel = fp.relative(home, p);
+  if (rel === "" || rel.startsWith("..") || fp.isAbsolute(rel)) return p;
+  return `~${fp.sep}${rel}`;
 }
 
 export interface CwdPreviewDeps {
@@ -118,15 +142,48 @@ export interface CwdPreviewDeps {
    * every Windows first run and every upgrade would greet the user by suggesting
    * they restart Claude inside Tandem's install directory.
    *
-   * Matched EXACTLY, not as a prefix. In a development checkout these resolve to
-   * the repository root, and suppressing a whole tree there would silence the
-   * nudge for anyone using Tandem to work on Tandem.
+   * Matched EXACTLY, not as a prefix. In a development checkout `CHANGELOG.md`
+   * resolves to the repository ROOT (`welcome.md` to `<repo>/sample`), and
+   * prefix-matching that root would silence the nudge for anyone using Tandem to
+   * work on Tandem.
    */
   bundledDocDirs: readonly string[];
   /** Test seam, mirroring `resolveRouteCwd`'s. Production leaves it unset. */
   homeOverride?: string;
   /** Test seam so both case-fold branches run on a single-platform CI host. */
   platform?: NodeJS.Platform;
+}
+
+/**
+ * One-shot report of an unresolvable home directory.
+ *
+ * This is the failure that turns the whole feature off for one machine, and it
+ * is the one the route's `catch` cannot see. `resolveRouteCwdAsync` home-confines
+ * by realpath'ing `os.homedir()`; when THAT throws it returns null for every
+ * candidate, so `previewCwdDrift` returns `{ drifted: false }` normally, forever,
+ * having thrown nothing. Reachable via an unmounted roaming profile, a redirected
+ * Windows home on a disconnected share, or `HOME` pointing at a deleted
+ * directory.
+ *
+ * Latched at module scope: the condition is machine-level, not per-candidate, so
+ * one line is the whole signal. Costs one extra `realpath` per process, on a
+ * path that has already failed.
+ */
+let homeFailureReported = false;
+async function noteIfHomeUnresolvable(homeOverride: string | undefined): Promise<void> {
+  if (homeFailureReported) return;
+  const home = homeOverride ?? os.homedir();
+  if ((await resolveSafeCwdAsync(home)) !== null) return;
+  homeFailureReported = true;
+  console.error(
+    `[Launcher] Home directory ${home} does not resolve — the working-folder nudge is ` +
+      "disabled for this session (every candidate folder will be rejected).",
+  );
+}
+
+/** Test-only reset of the one-shot home-failure latch. */
+export function _resetHomeFailureLatchForTests(): void {
+  homeFailureReported = false;
 }
 
 /**
@@ -146,14 +203,20 @@ export async function previewCwdDrift(deps: CwdPreviewDeps): Promise<LauncherCwd
   const suggested = await resolveRouteCwdAsync(deps.candidate, {
     homeOverride: deps.homeOverride,
   });
-  if (suggested === null) return noDrift;
+  if (suggested === null) {
+    await noteIfHomeUnresolvable(deps.homeOverride);
+    return noDrift;
+  }
 
-  // Normalize Claude's side too. `resolveCwd`'s default branch can hand back a
-  // raw, un-realpath'd `os.homedir()`, while the candidate above is always
-  // realpath'd — where home contains a symlink or a junction the two differ as
-  // strings for one directory, which would render a permanent nudge pointing at
-  // the folder Claude is already sitting in. Falling back to the raw value keeps
-  // a since-deleted cwd comparable rather than silently reporting "no drift".
+  // Normalize Claude's side too, so both sides of the comparison are canonical.
+  //
+  // `resolveCwd` already realpaths both its branches — `homeCwd()` is
+  // `resolveSafeCwd(os.homedir()) ?? os.homedir()` — so a merely symlinked home
+  // is NOT the case this guards; realpath is exactly what resolves that. What is
+  // left is `homeCwd()`'s own fallback (home unresolvable at spawn time, raw
+  // string kept) and a cwd that reached the supervisor from a hand-edited
+  // `integrations.json`. Falling back to the raw value keeps a since-deleted cwd
+  // comparable rather than silently reporting "no drift".
   const claude = (await resolveSafeCwdAsync(deps.claudeCwd)) ?? deps.claudeCwd;
 
   if (samePath(suggested, claude, platform)) return noDrift;
@@ -170,11 +233,26 @@ export async function previewCwdDrift(deps: CwdPreviewDeps): Promise<LauncherCwd
   const homeRaw = deps.homeOverride ?? os.homedir();
   const home = (await resolveSafeCwdAsync(homeRaw)) ?? homeRaw;
 
+  const suggestedCwd = tildeAbbreviate(suggested, home, platform);
+  const claudeCwd = tildeAbbreviate(claude, home, platform);
+
+  // Labels come from the ABBREVIATED paths, not the raw ones. Otherwise the
+  // account name lands in the status pill in the default configuration: the
+  // launcher's fallback cwd IS home (`resolveCwd` → `homeCwd()`, taken whenever
+  // no `workingDirectory` is configured), and `distinguishingLabel` of a home
+  // path against a subfolder returns home's basename — so a fresh install with a
+  // document open anywhere renders "Claude in bryan.kolbeck". Abbreviating
+  // first makes that same case read "Claude in ~", and changes nothing else:
+  // paths outside home abbreviate to themselves, and two sibling worktrees still
+  // yield `alpha/src` and `beta/src`.
+  //
+  // This is precisely the harm `tildeAbbreviate` was written for, arriving
+  // through the one field it was not applied to.
   return {
     drifted: true,
-    suggestedCwd: tildeAbbreviate(suggested, home, platform),
-    claudeCwd: tildeAbbreviate(claude, home, platform),
-    label: distinguishingLabel(suggested, claude, platform),
-    claudeLabel: distinguishingLabel(claude, suggested, platform),
+    suggestedCwd,
+    claudeCwd,
+    label: distinguishingLabel(suggestedCwd, claudeCwd, platform),
+    claudeLabel: distinguishingLabel(claudeCwd, suggestedCwd, platform),
   };
 }

--- a/src/server/launcher/cwd-preview.ts
+++ b/src/server/launcher/cwd-preview.ts
@@ -1,0 +1,180 @@
+/**
+ * "Would relaunching here actually move Claude?" — the server half of the
+ * working-directory drift nudge (#1282).
+ *
+ * Claude Code stores conversations per working directory, and a session started
+ * in one folder cannot be resumed from another. So the folder Claude runs in is
+ * not cosmetic: it decides which `CLAUDE.md` and `.claude/` it reads, which git
+ * repository it sees, and which files its own file tools can reach. A user
+ * editing `~/projects/api/README.md` while Claude sits in `~` gets a Claude that
+ * can read the document (Tandem syncs it) and almost nothing else about it.
+ *
+ * This module answers one question and refuses to answer any other: given the
+ * folder a relaunch WOULD target and the folder Claude is in now, are they
+ * different in a way worth mentioning? Every "no" collapses to the same
+ * `{ drifted: false }` — see `LauncherCwdPreview` for why the client must not be
+ * able to tell the no-cases apart.
+ *
+ * Scope boundary, stated rather than implied: a **manually launched** Claude
+ * (#1054) is invisible to the supervisor, which truthfully reports
+ * `running: false`, so `claudeCwd` is null and the answer is always "no drift".
+ * That user is the most drift-prone one there is and gets no signal — correctly,
+ * because the only action this nudge offers would spawn a SECOND agent on the
+ * same documents. A nudge that cannot be acted on safely is worse than silence.
+ */
+
+import os from "node:os";
+import path from "node:path";
+
+import type { LauncherCwdPreview } from "../../shared/launcher/contract.js";
+import { resolveRouteCwdAsync, resolveSafeCwdAsync, samePath } from "./supervisor.js";
+
+/** Cap on how many trailing segments a distinguishing label may carry before it
+ * is elided. Three fits the status pill; beyond that the label stops being a
+ * glance-able name and becomes a path the menu already shows in full. */
+const MAX_LABEL_SEGMENTS = 3;
+
+/** Split a path into non-empty segments, treating both separators as such.
+ * Windows paths reach a Linux CI host as strings, where `path.sep` is "/" —
+ * splitting on the platform separator alone would return one giant segment. */
+function segments(p: string): string[] {
+  return p.split(/[/\\]/).filter((s) => s.length > 0);
+}
+
+/**
+ * The fewest trailing segments of `target` that distinguish it from `other`.
+ *
+ * The client cannot compute this, which is the whole reason it is returned over
+ * the wire: `basename` alone collides on every `src`, `docs`, and `tests` in a
+ * developer's home directory, and — worse — on two worktrees of one repository,
+ * where the basenames are identical and only the parent differs. A label that
+ * names both folders the same thing is not a smaller label, it is a wrong one.
+ *
+ * Falls back to an elided suffix when the paths only diverge deeper than
+ * `MAX_LABEL_SEGMENTS`, and to the plain last segment when one path is a suffix
+ * of the other (nothing distinguishes them at any depth).
+ */
+export function distinguishingLabel(
+  target: string,
+  other: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const a = segments(target);
+  const b = segments(other);
+  if (a.length === 0) return target; // filesystem root — nothing to name
+  const depth = Math.min(a.length, b.length);
+  for (let k = 1; k <= depth; k++) {
+    const aTail = a.slice(-k);
+    const bTail = b.slice(-k);
+    if (samePath(aTail.join("/"), bTail.join("/"), platform)) continue;
+    if (k <= MAX_LABEL_SEGMENTS) return aTail.join(path.sep);
+    return `…${path.sep}${a.slice(-MAX_LABEL_SEGMENTS).join(path.sep)}`;
+  }
+  // One is a trailing sub-path of the other (or they are equal, which the
+  // caller has already excluded). Nothing distinguishes them by suffix, so name
+  // the folder plainly.
+  return a[a.length - 1] as string;
+}
+
+/**
+ * Replace a leading home directory with `~`.
+ *
+ * Two reasons, and the second is not decorative: it shortens the path, and it
+ * keeps the user's account name off screen. These paths land in a status-bar
+ * tooltip and an `aria-label`, which is exactly the surface that ends up in
+ * screenshots, screen recordings, and live demos.
+ *
+ * `~` is a POSIX idiom applied on Windows too — deliberately. The alternative is
+ * rendering `C:\Users\<name>\…` verbatim on the one platform where the account
+ * name is most often a person's real full name.
+ */
+export function tildeAbbreviate(
+  p: string,
+  home: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (samePath(p, home, platform)) return "~";
+  const rel = path.relative(home, p);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return p;
+  return `~${path.sep}${rel}`;
+}
+
+export interface CwdPreviewDeps {
+  /** The folder a relaunch would target, as the client derived it. Unvalidated. */
+  candidate: string;
+  /** Where the supervised Claude is running, or `null` when nothing is running
+   * (stopped, crashed, or manually launched — see the module header). */
+  claudeCwd: string | null;
+  /**
+   * Directories holding Tandem's OWN bundled documents (`sample/welcome.md`,
+   * `CHANGELOG.md`), already canonical.
+   *
+   * Excluded because validity is not desirability. Both open automatically —
+   * `welcome.md` on first run, `CHANGELOG.md` after every upgrade — and on
+   * Windows they live INSIDE the user's home directory: `tauri.conf.json` sets
+   * no NSIS `installMode`, so the installer defaults to `currentUser`, which
+   * puts the app under `%LOCALAPPDATA%`. That makes `dirname(welcome.md)` a
+   * perfectly valid, home-confined, drifting folder — so without this exclusion
+   * every Windows first run and every upgrade would greet the user by suggesting
+   * they restart Claude inside Tandem's install directory.
+   *
+   * Matched EXACTLY, not as a prefix. In a development checkout these resolve to
+   * the repository root, and suppressing a whole tree there would silence the
+   * nudge for anyone using Tandem to work on Tandem.
+   */
+  bundledDocDirs: readonly string[];
+  /** Test seam, mirroring `resolveRouteCwd`'s. Production leaves it unset. */
+  homeOverride?: string;
+  /** Test seam so both case-fold branches run on a single-platform CI host. */
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * Compute the drift verdict. Never throws: every failure is a `drifted: false`,
+ * because a nudge is a suggestion and a suggestion built on a failed check is
+ * worth less than nothing.
+ */
+export async function previewCwdDrift(deps: CwdPreviewDeps): Promise<LauncherCwdPreview> {
+  const platform = deps.platform ?? process.platform;
+  const noDrift: LauncherCwdPreview = { drifted: false };
+
+  if (deps.claudeCwd === null) return noDrift;
+
+  // Home-confined, canonicalized, non-UNC, must exist and be a directory. This
+  // is the SAME predicate the relaunch route applies, which is what keeps the
+  // nudge from offering an action the action itself would reject.
+  const suggested = await resolveRouteCwdAsync(deps.candidate, {
+    homeOverride: deps.homeOverride,
+  });
+  if (suggested === null) return noDrift;
+
+  // Normalize Claude's side too. `resolveCwd`'s default branch can hand back a
+  // raw, un-realpath'd `os.homedir()`, while the candidate above is always
+  // realpath'd — where home contains a symlink or a junction the two differ as
+  // strings for one directory, which would render a permanent nudge pointing at
+  // the folder Claude is already sitting in. Falling back to the raw value keeps
+  // a since-deleted cwd comparable rather than silently reporting "no drift".
+  const claude = (await resolveSafeCwdAsync(deps.claudeCwd)) ?? deps.claudeCwd;
+
+  if (samePath(suggested, claude, platform)) return noDrift;
+  if (deps.bundledDocDirs.some((dir) => samePath(suggested, dir, platform))) return noDrift;
+
+  // Canonicalize home the same way both paths above were, or `tildeAbbreviate`
+  // silently stops matching wherever home contains a symlink. An unresolvable
+  // home falls back to the raw value: a missed `~` is cosmetic.
+  //
+  // No local catch. `resolveSafeCwdAsync` swallows its own failures and returns
+  // null, and the only line here that can throw is `os.homedir()` — which a
+  // catch could not usefully handle anyway, since the fallback would have to
+  // call it again. The route's own try/catch answers that with `drifted: false`.
+  const homeRaw = deps.homeOverride ?? os.homedir();
+  const home = (await resolveSafeCwdAsync(homeRaw)) ?? homeRaw;
+
+  return {
+    drifted: true,
+    suggestedCwd: tildeAbbreviate(suggested, home, platform),
+    claudeCwd: tildeAbbreviate(claude, home, platform),
+    label: distinguishingLabel(suggested, claude, platform),
+    claudeLabel: distinguishingLabel(claude, suggested, platform),
+  };
+}

--- a/src/server/launcher/supervisor.ts
+++ b/src/server/launcher/supervisor.ts
@@ -1470,8 +1470,18 @@ export function resolveSafeCwd(candidate: string): string | null {
     // rejects non-directories, and returns null on any failure. Callers
     // either gate the result further (resolveRouteCwd home-confines) or
     // accept advanced users' explicit integrations.json scope.
-    const real = fs.realpathSync(candidate); // lgtm[js/path-injection]
-    const stat = fs.statSync(real); // lgtm[js/path-injection]
+    //
+    // CodeQL flags these two lines as js/path-injection and is right that the
+    // taint reaches them — the confinement runs after, in resolveRouteCwd, not
+    // before. It is accepted, per alert #82 and the async twin's #162: realpath
+    // + stat + isDirectory on a syntactically pre-screened path is an existence
+    // check, not a read or a write, and the routes that reach here are loopback-
+    // and origin-gated. These lines carried `// lgtm[js/path-injection]` for a
+    // while; that syntax is LGTM's, code scanning does not honour it, and the
+    // alerts fired anyway. A comment that looks like a suppression and is not is
+    // worse than none, so it is gone — the record lives in the dismissals.
+    const real = fs.realpathSync(candidate);
+    const stat = fs.statSync(real);
     if (!stat.isDirectory()) return null;
     return real;
   } catch {
@@ -1497,8 +1507,8 @@ export function resolveSafeCwd(candidate: string): string | null {
 export async function resolveSafeCwdAsync(candidate: string): Promise<string | null> {
   if (rejectedSyntactically(candidate)) return null;
   try {
-    const real = await fsp.realpath(candidate); // lgtm[js/path-injection]
-    const stat = await fsp.stat(real); // lgtm[js/path-injection]
+    const real = await fsp.realpath(candidate);
+    const stat = await fsp.stat(real);
     if (!stat.isDirectory()) return null;
     return real;
   } catch {

--- a/src/server/launcher/supervisor.ts
+++ b/src/server/launcher/supervisor.ts
@@ -25,6 +25,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -390,12 +391,7 @@ export function sessionCwdMatches(
   platform: NodeJS.Platform = process.platform,
 ): boolean {
   if (savedCwd === undefined) return true;
-  // Both sides are realpath'd, but Node's JS `realpathSync` does not
-  // case-normalize on Windows — so this fold is load-bearing, not dead code.
-  if (platform === "win32") {
-    return savedCwd.toLowerCase() === plannedCwd.toLowerCase();
-  }
-  return savedCwd === plannedCwd;
+  return samePath(savedCwd, plannedCwd, platform);
 }
 
 /**
@@ -1468,11 +1464,7 @@ export function createSupervisor(opts: SupervisorOpts): Supervisor {
  * canonical directory on disk. HTTP-driven mutations must use
  * `resolveRouteCwd()` below, which additionally home-confines. */
 export function resolveSafeCwd(candidate: string): string | null {
-  if (typeof candidate !== "string" || !path.isAbsolute(candidate)) return null;
-  if (process.platform === "win32") {
-    if (candidate.startsWith("\\\\?\\") || candidate.startsWith("\\\\.\\")) return null;
-    if (candidate.startsWith("\\\\")) return null; // UNC
-  }
+  if (rejectedSyntactically(candidate)) return null;
   try {
     // This function IS the path validator: it canonicalizes via realpath,
     // rejects non-directories, and returns null on any failure. Callers
@@ -1485,6 +1477,56 @@ export function resolveSafeCwd(candidate: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Async twin of `resolveSafeCwd`, for callers on a hot path.
+ *
+ * `resolveSafeCwd` is `realpathSync` + `statSync`. That is fine for the
+ * spawn path (once per launch) and wrong for anything driven by tab switching:
+ * a document on a disconnected mapped drive blocks the whole event loop for the
+ * SMB timeout. UNC is rejected syntactically before any I/O, but a mapped drive
+ * letter looks entirely ordinary.
+ *
+ * The two are held equivalent by sharing BOTH pure halves — `rejectedSyntactically`
+ * here and `homeConfines` in `resolveRouteCwd` — so only the fs mechanics differ,
+ * plus an equivalence test that runs one case table through both. Two resolvers
+ * that could disagree about which paths are acceptable is the split-predicate
+ * bug this whole area already shipped once.
+ */
+export async function resolveSafeCwdAsync(candidate: string): Promise<string | null> {
+  if (rejectedSyntactically(candidate)) return null;
+  try {
+    const real = await fsp.realpath(candidate); // lgtm[js/path-injection]
+    const stat = await fsp.stat(real); // lgtm[js/path-injection]
+    if (!stat.isDirectory()) return null;
+    return real;
+  } catch {
+    return null;
+  }
+}
+
+/** Pure, I/O-free rejections shared by both resolvers: non-strings, relative
+ * paths, Windows UNC (`\\server\share`) and the `\\?\` / `\\.\` device
+ * namespaces. Checked before any fs call so a hostile path never reaches the
+ * filesystem. */
+function rejectedSyntactically(candidate: string): boolean {
+  if (typeof candidate !== "string" || !path.isAbsolute(candidate)) return true;
+  if (process.platform === "win32") {
+    if (candidate.startsWith("\\\\?\\") || candidate.startsWith("\\\\.\\")) return true;
+    if (candidate.startsWith("\\\\")) return true; // UNC
+  }
+  return false;
+}
+
+/** Is `candidate` (already canonical) inside `homeReal`, or home itself?
+ * Pure — shared by the sync and async home-confining resolvers. */
+function homeConfines(homeReal: string, candidate: string): boolean {
+  const rel = path.relative(homeReal, candidate);
+  // Outside home (`rel` starts with `..`), or a different drive on Windows
+  // (`rel` is absolute), or the empty string (home itself — allowed).
+  if (rel === "") return true;
+  return !(rel.startsWith("..") || path.isAbsolute(rel));
 }
 
 /** HTTP-surface variant of `resolveSafeCwd`. Adds: the canonical path must
@@ -1512,10 +1554,39 @@ export function resolveRouteCwd(
   } catch {
     return null;
   }
-  const rel = path.relative(homeReal, safe);
-  // Outside home (`rel` starts with `..`), or a different drive on Windows
-  // (`rel` is absolute), or the empty string (home itself — allowed).
-  if (rel === "") return safe;
-  if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
-  return safe;
+  return homeConfines(homeReal, safe) ? safe : null;
+}
+
+/** Async twin of `resolveRouteCwd` — see `resolveSafeCwdAsync` for why the
+ * async pair exists and how the two are kept from diverging. */
+export async function resolveRouteCwdAsync(
+  candidate: string,
+  opts: { homeOverride?: string } = {},
+): Promise<string | null> {
+  const safe = await resolveSafeCwdAsync(candidate);
+  if (safe === null) return null;
+  let homeReal: string;
+  try {
+    homeReal = await fsp.realpath(opts.homeOverride ?? os.homedir());
+  } catch {
+    return null;
+  }
+  return homeConfines(homeReal, safe) ? safe : null;
+}
+
+/**
+ * Do two canonical paths name the same directory?
+ *
+ * Extracted from `sessionCwdMatches` so the case-fold rule has exactly one
+ * home. Node's JS `realpathSync` does not case-normalize on Windows, so two
+ * realpath'd strings for one directory can still differ by case — the fold is
+ * load-bearing, not defensive. `platform` is injectable for the same reason it
+ * is on `sessionCwdMatches`: CI runs ubuntu-only.
+ */
+export function samePath(
+  a: string,
+  b: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === "win32" ? a.toLowerCase() === b.toLowerCase() : a === b;
 }

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
@@ -103,6 +103,41 @@ export function findRepoFile(startDir: string, relPath: string): string | undefi
 export function findChangelogPath(startDir: string): string | undefined {
   return findRepoFile(startDir, "CHANGELOG.md");
 }
+/**
+ * Directories holding Tandem's own auto-opened documents, for the #1282 drift
+ * preview's exclusion list. Canonicalized, because the candidate it is compared
+ * against always is — an un-realpath'd entry silently fails to match wherever
+ * the install path involves a junction or a Windows 8.3 short name.
+ *
+ * Warns when it resolves to nothing. Three `undefined`-tolerant seams sit
+ * between `findRepoFile` and the consumer (`string | undefined` constants, an
+ * optional dep, a `?? []` default), and the failure they would let through is
+ * user-visible and specific: `welcome.md` opens on first run and `CHANGELOG.md`
+ * after every upgrade, both from inside the app bundle, which on Windows lives
+ * under `%LOCALAPPDATA%` — i.e. inside home, passing every other check. So a
+ * silently empty list means every desktop user's first run opens with a
+ * suggestion to move Claude into Tandem's install directory.
+ */
+function resolveBundledDocDirs(): string[] {
+  const dirs = [CHANGELOG_PATH, WELCOME_PATH]
+    .filter((p): p is string => p !== undefined)
+    .map((p) => {
+      const dir = dirname(p);
+      try {
+        return realpathSync(dir);
+      } catch {
+        return dir;
+      }
+    });
+  if (dirs.length === 0) {
+    console.error(
+      "[Tandem] Could not locate CHANGELOG.md or sample/welcome.md — the working-folder " +
+        "nudge may suggest restarting Claude inside Tandem's own install directory.",
+    );
+  }
+  return dirs;
+}
+
 const CHANGELOG_PATH: string | undefined = findRepoFile(__dirname, "CHANGELOG.md");
 const WORKFLOWS_PATH: string | undefined = findRepoFile(__dirname, "docs/workflows.md");
 // Exposed via /api/info so the "Replay tutorial" affordance can reopen the
@@ -592,9 +627,7 @@ export async function startMcpServerHttp(
       // preview applies. Without this list the two states every desktop user
       // passes through would each open with a suggestion to move Claude into
       // Tandem's install directory.
-      bundledDocDirs: [CHANGELOG_PATH, WELCOME_PATH]
-        .filter((p): p is string => p !== undefined)
-        .map((p) => dirname(p)),
+      bundledDocDirs: resolveBundledDocDirs(),
     });
   }
 

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -585,6 +585,16 @@ export async function startMcpServerHttp(
       startSupervisor: launcher.startSupervisor,
       store: createIntegrationsStore(resolveAppDataDir()),
       getSkillRefreshError,
+      // Tandem's own auto-opened documents. `welcome.md` opens on first run and
+      // `CHANGELOG.md` after every upgrade, both from inside the app bundle —
+      // which on Windows sits under `%LOCALAPPDATA%`, i.e. INSIDE the user's
+      // home directory, and therefore passes every validity check the drift
+      // preview applies. Without this list the two states every desktop user
+      // passes through would each open with a suggestion to move Claude into
+      // Tandem's install directory.
+      bundledDocDirs: [CHANGELOG_PATH, WELCOME_PATH]
+        .filter((p): p is string => p !== undefined)
+        .map((p) => dirname(p)),
     });
   }
 

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -117,12 +117,35 @@ export function findChangelogPath(startDir: string): string | undefined {
  * under `%LOCALAPPDATA%` — i.e. inside home, passing every other check. So a
  * silently empty list means every desktop user's first run opens with a
  * suggestion to move Claude into Tandem's install directory.
+ *
+ * **Two sample directories, not one, and the second is the one that matters.**
+ * `WELCOME_PATH` comes from `findRepoFile(__dirname, …)`, which lands in the
+ * *resource* dir. But `index.ts` opens `path.join(process.env.TANDEM_DATA_DIR ||
+ * projectRoot, "sample/welcome.md")`, and the Tauri shell always sets
+ * `TANDEM_DATA_DIR` to the app-data dir and copies `sample/*` into it. So on a
+ * packaged desktop first run the document actually open is the app-data copy,
+ * in a directory this list did not contain — and that path is inside home on all
+ * three platforms (`%APPDATA%`, `~/Library/Application Support`, `~/.local/share`),
+ * so it passes the home-confinement check, differs from the launcher's default
+ * `$HOME`, and misses the exact-match exclusion. The result was the amber pill on
+ * every desktop first run, offering to permanently repoint the launcher at
+ * Tandem's own sample folder — the precise failure this exclusion exists to stop.
+ *
+ * Invisible in dev and in every test: `TANDEM_DATA_DIR` is unset there, which
+ * collapses the two directories into one. Derive the app-data sample dir the same
+ * way `index.ts` does rather than restating the join, so the two cannot drift
+ * apart again.
  */
-function resolveBundledDocDirs(): string[] {
-  const dirs = [CHANGELOG_PATH, WELCOME_PATH]
+export function resolveBundledDocDirs(): string[] {
+  const dataDir = process.env.TANDEM_DATA_DIR?.trim();
+  const appDataSample = dataDir ? join(dataDir, "sample") : undefined;
+  const dirs = [
+    CHANGELOG_PATH === undefined ? undefined : dirname(CHANGELOG_PATH),
+    WELCOME_PATH === undefined ? undefined : dirname(WELCOME_PATH),
+    appDataSample,
+  ]
     .filter((p): p is string => p !== undefined)
-    .map((p) => {
-      const dir = dirname(p);
+    .map((dir) => {
       try {
         return realpathSync(dir);
       } catch {

--- a/src/shared/api-paths.ts
+++ b/src/shared/api-paths.ts
@@ -92,3 +92,8 @@ export const API_LAUNCHER_START_FRESH = "/api/launcher/start-fresh";
  * Distinct from `start-fresh`, which restarts an *existing* supervisor. */
 export const API_LAUNCHER_START = "/api/launcher/start";
 export const API_LAUNCHER_WORKING_DIRECTORY = "/api/launcher/working-directory";
+/** Read-only "would relaunching here move Claude?" preview (#1282). POST
+ * because it carries a path in the body, not because it mutates — it does not,
+ * which is also why it takes no nonce. Loopback-only: the answer reconstructs
+ * the launcher `cwd` that `GET /api/launcher/status` withholds off-loopback. */
+export const API_LAUNCHER_CWD_PREVIEW = "/api/launcher/cwd-preview";

--- a/src/shared/launcher/contract.ts
+++ b/src/shared/launcher/contract.ts
@@ -139,6 +139,52 @@ export interface LauncherWorkingDirectoryBody {
   workingDirectory: string | null;
 }
 
+/**
+ * `POST /api/launcher/cwd-preview` body (#1282).
+ *
+ * `cwd` is the folder a relaunch WOULD target — the client's own
+ * `deriveCwdFromDocPath(activeDocumentPath)`, i.e. the exact value the relaunch
+ * request would carry. Sending the derived folder rather than the document path
+ * is deliberate: the preview and the action then share ONE derivation, so they
+ * can never disagree about *which* folder while agreeing about the answer. The
+ * #1282 post-mortem is precisely that the client's derivation and the server's
+ * rejection were each tested alone and never together.
+ */
+export interface LauncherCwdPreviewBody {
+  cwd: string;
+}
+
+/**
+ * `POST /api/launcher/cwd-preview` response (#1282).
+ *
+ * A single collapsed `{ drifted: false }` branch carries every "don't nudge"
+ * case — launcher not running, path unresolvable, outside home, over-length,
+ * same folder, Tandem's own bundled documents. The client must not be able to
+ * tell those apart: each would be a second predicate for it to re-derive, and
+ * the ones that leak (a path exists / does not exist under home) are exactly the
+ * probe an off-loopback caller would want. The route is loopback-only anyway;
+ * this is the belt.
+ *
+ * Every path is display-only and `~`-substituted. The client never needs the
+ * raw path back — it derived the folder in the first place, and the relaunch
+ * action re-derives it the same way.
+ */
+export type LauncherCwdPreview =
+  | { drifted: false }
+  | {
+      drifted: true;
+      /** Where a relaunch would put Claude, `~`-substituted. */
+      suggestedCwd: string;
+      /** Where Claude is now, `~`-substituted. */
+      claudeCwd: string;
+      /** Shortest trailing path segments that distinguish `suggestedCwd` from
+       * `claudeCwd`. The client cannot compute this: `basename` collides on
+       * `src`/`docs` and on two worktrees of one repository. */
+      label: string;
+      /** The same distinguishing suffix for `claudeCwd`. */
+      claudeLabel: string;
+    };
+
 // --- Error codes ----------------------------------------------------------
 
 export const LAUNCHER_ERROR_INVALID_BODY = "INVALID_BODY";

--- a/tests/client/actions/launcher-commands.test.ts
+++ b/tests/client/actions/launcher-commands.test.ts
@@ -33,6 +33,8 @@ import {
   API_LAUNCHER_STATUS,
 } from "../../../src/shared/api-paths.js";
 
+const afterLauncherAction = vi.fn();
+
 const STATUS_URL = `${API_BASE}${API_LAUNCHER_STATUS}`;
 const NONCE_URL = `${API_BASE}${API_LAUNCHER_NONCE}`;
 const RELAUNCH_URL = `${API_BASE}${API_LAUNCHER_RELAUNCH}`;
@@ -140,6 +142,9 @@ function wireDeps(activeDocumentPath: string | null): void {
     getActiveTabId: () => (activeDocumentPath ? "doc-1" : null),
     getActiveDocumentPath: () => activeDocumentPath,
     notify,
+    // #1282: both relaunch entry points must re-probe launcher-derived state.
+    // Captured so `relaunchClaudeHere`'s call can be asserted.
+    afterLauncherAction,
     openSettings: vi.fn(),
     toggleSoloMode: vi.fn(),
     openFindBar: vi.fn(),
@@ -318,6 +323,26 @@ describe("AI-chip relaunch vs. palette relaunch", () => {
     expect(post).toBeDefined();
     const body = JSON.parse(post![1]?.body as string);
     expect(body.cwd).toBe("/home/user/project");
+  });
+
+  it("EVERY launcher action re-probes launcher state", async () => {
+    // This used to be the callers' job and they did not all do it: App wrapped
+    // the status-pill and empty-state paths, while the palette invoked the same
+    // relaunch directly and never re-probed. The #1282 drift probe re-arms on the
+    // document path and an explicit refresh, neither of which a relaunch changes
+    // — so after a palette relaunch the amber pill went on naming the folder
+    // Claude had just left, indefinitely.
+    wireDeps("/home/user/project/notes.md");
+    for (const [label, run] of [
+      ["palette relaunch-here", () => getActionsMap().get("launcher-relaunch-here")?.run()],
+      ["palette start-fresh", () => getActionsMap().get("launcher-start-fresh")?.run()],
+      ["recovery chip", relaunchClaudeCode],
+    ] as const) {
+      afterLauncherAction.mockClear();
+      const fetchSpy = installFetchStub();
+      await drive(run as () => void, fetchSpy);
+      expect(afterLauncherAction, label).toHaveBeenCalled();
+    }
   });
 
   it("the palette command still refuses with no document open", async () => {

--- a/tests/client/derive-cwd-from-doc-path.test.ts
+++ b/tests/client/derive-cwd-from-doc-path.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+
+/**
+ * `deriveCwdFromDocPath` is the single derivation shared by the relaunch action
+ * and the #1282 drift preview — the one place that decides which folder either
+ * of them is talking about. It is pinned here rather than only through its
+ * callers because the drift work deliberately removed the redundant
+ * `isUploadPath` screen that used to sit in front of it in `App.svelte`: a
+ * second copy of a predicate, inside the one feature whose thesis is that the
+ * query side owns no predicate of its own. That is only safe while this
+ * function really does reject non-filesystem URIs.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { deriveCwdFromDocPath } from "../../src/client/actions/builtin.svelte.js";
+
+const WINDOWS_DOC = ["C:", "Users", "u", "projects", "alpha", "README.md"].join("\\");
+const WINDOWS_DIR = ["C:", "Users", "u", "projects", "alpha"].join("\\");
+
+describe("deriveCwdFromDocPath", () => {
+  it("returns the containing folder for a POSIX path", () => {
+    expect(deriveCwdFromDocPath("/home/u/projects/alpha/README.md")).toBe("/home/u/projects/alpha");
+  });
+
+  it("returns the containing folder for a Windows path", () => {
+    expect(deriveCwdFromDocPath(WINDOWS_DOC)).toBe(WINDOWS_DIR);
+  });
+
+  it("rejects upload:// scratchpad URIs", () => {
+    expect(deriveCwdFromDocPath("upload://abc123/notes.md")).toBeNull();
+  });
+
+  it("rejects every other non-filesystem URI scheme", () => {
+    for (const p of ["https://example.com/a.md", "file:///home/u/a.md", "scratchpad://x/y.md"]) {
+      expect(deriveCwdFromDocPath(p), p).toBeNull();
+    }
+  });
+
+  it("returns null with no document open", () => {
+    expect(deriveCwdFromDocPath(null)).toBeNull();
+    expect(deriveCwdFromDocPath("")).toBeNull();
+  });
+
+  it("returns null for a bare filename with no folder", () => {
+    expect(deriveCwdFromDocPath("README.md")).toBeNull();
+  });
+});

--- a/tests/client/status-ai-view.test.ts
+++ b/tests/client/status-ai-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { aiIndicatorView } from "../../src/client/status/status-ai-view.js";
+import { aiIndicatorView, cwdDriftPill } from "../../src/client/status/status-ai-view.js";
 
 /**
  * Spec for the consolidated status-pill AI indicator. Each `it` is one row of
@@ -142,5 +142,73 @@ describe("aiIndicatorView — push delivery", () => {
     const view = aiIndicatorView("ready", "solo-paused", true, "none");
     expect(view?.dataState).toBe("solo-paused");
     expect(view?.title).toContain("Solo mode");
+  });
+});
+
+/**
+ * The working-folder drift qualifier (#1282).
+ *
+ * The two cases worth pinning are structural, not cosmetic: the pill must
+ * survive the state where `aiIndicatorView` renders nothing (or it is dead code
+ * in exactly the situation it exists for), and it must yield to a CTA rather
+ * than sit beside one.
+ */
+describe("cwdDriftPill", () => {
+  const DRIFT = {
+    suggestedCwd: "~/projects/alpha",
+    claudeCwd: "~/notes",
+    label: "alpha",
+    claudeLabel: "notes",
+  };
+
+  it("renders in the state where the AI indicator renders nothing", () => {
+    // `state === "ready"` with no live session is the auto-launched desktop
+    // startup window: the launcher IS running (so it has a folder to be wrong
+    // about) but no agent has connected. `aiIndicatorView` returns null there,
+    // so anything nested inside `{#if aiView}` would never appear — which is why
+    // this is a sibling.
+    expect(aiIndicatorView("ready", null, false)).toBeNull();
+    expect(cwdDriftPill(DRIFT, null)).not.toBeNull();
+  });
+
+  it("renders alongside a connected session", () => {
+    expect(cwdDriftPill(DRIFT, null)?.label).toBe("Claude in notes");
+  });
+
+  it("yields to a CTA rather than sitting next to one", () => {
+    // `aiChip` is non-null only for `unconfigured`/`stopped`, which mean the
+    // supervised launcher is NOT running — and the server reports drift only
+    // when it is. They can overlap only transiently, when Claude dies between a
+    // drift probe and the next readiness poll, and a stale folder note beside a
+    // live "Restart Claude Code" is the two-conflicting-CTAs shape of #1268.
+    for (const chip of ["connect", "setup", "restart"] as const) {
+      expect(cwdDriftPill(DRIFT, chip)).toBeNull();
+    }
+  });
+
+  it("says nothing when there is no drift", () => {
+    expect(cwdDriftPill(null, null)).toBeNull();
+  });
+
+  it("names the consequence rather than a connection state", () => {
+    // "AI · other folder" reads as connectivity and leaves the user with no idea
+    // what is degraded. The document syncs fine and Claude can still edit it;
+    // what it cannot see is everything around the document.
+    const pill = cwdDriftPill(DRIFT, null);
+    expect(pill?.title).toContain("CLAUDE.md");
+    expect(pill?.title).toContain("git history");
+    expect(pill?.title).toContain("read and edit this document");
+  });
+
+  it("carries both full paths in the aria-label, not only the title", () => {
+    // `title` is unreachable by keyboard, touch and assistive tech, so the label
+    // is the only place a screen-reader user learns which folders are meant.
+    const pill = cwdDriftPill(DRIFT, null);
+    expect(pill?.ariaLabel).toContain(DRIFT.claudeCwd);
+    expect(pill?.ariaLabel).toContain(DRIFT.suggestedCwd);
+  });
+
+  it("names the destination folder in the action row", () => {
+    expect(cwdDriftPill(DRIFT, null)?.actionLabel).toBe("Restart Claude in alpha…");
   });
 });

--- a/tests/client/status/CwdDriftPill.svelte.test.ts
+++ b/tests/client/status/CwdDriftPill.svelte.test.ts
@@ -12,11 +12,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import StatusBar from "../../../src/client/status/StatusBar.svelte";
 
-const DRIFT = {
-  suggestedCwd: "~/projects/alpha",
-  claudeCwd: "~/notes",
-  label: "alpha",
-  claudeLabel: "notes",
+const PILL = {
+  label: "Claude in notes",
+  title: "Claude is running in ~/notes, not ~/projects/alpha.",
+  ariaLabel:
+    "Working folder mismatch. Claude is running in ~/notes, not ~/projects/alpha. " +
+    "It can't see that folder's CLAUDE.md.",
+  explanation:
+    "Claude is running in ~/notes, not ~/projects/alpha. It can't see that folder's CLAUDE.md.",
+  actionLabel: "Restart Claude in alpha…",
 };
 
 const baseProps = {
@@ -34,7 +38,7 @@ const baseProps = {
 afterEach(() => cleanup());
 
 function mount(over: Record<string, unknown> = {}) {
-  return render(StatusBar, { props: { ...baseProps, cwdDrift: DRIFT, ...over } });
+  return render(StatusBar, { props: { ...baseProps, cwdDriftView: PILL, ...over } });
 }
 
 describe("drift pill placement", () => {
@@ -53,13 +57,11 @@ describe("drift pill placement", () => {
     expect(getByTestId("cwd-drift-pill")).toBeTruthy();
   });
 
-  it("stays hidden while an AI CTA is showing", () => {
-    const { queryByTestId } = mount({ aiState: "stopped" as const, aiChip: "restart" as const });
-    expect(queryByTestId("cwd-drift-pill")).toBeNull();
-  });
-
-  it("renders nothing when the caller passes no drift", () => {
-    const { queryByTestId } = mount({ cwdDrift: null });
+  it("renders nothing when the caller passes no pill", () => {
+    // The stale-CTA gate now lives in `cwdDriftPill` and is composed by App, so
+    // that suppression is pinned in `status-ai-view.test.ts`. What StatusBar owes
+    // is only that it renders exactly what it is handed.
+    const { queryByTestId } = mount({ cwdDriftView: null });
     expect(queryByTestId("cwd-drift-pill")).toBeNull();
   });
 });
@@ -109,6 +111,38 @@ describe("drift pill affordances", () => {
       expect(queryByTestId(testid), `${testid} left the menu open`).toBeNull();
       cleanup();
     }
+  });
+
+  it("hands focus to the status bar for the rows that unmount it", async () => {
+    // `DecorationsMenu`, whose close-guard this copies, has a trigger that
+    // survives every action. Dismiss and opt-out unmount this component AND its
+    // trigger, so restoring focus there drops a keyboard user on <body>.
+    for (const testid of ["cwd-drift-dismiss", "cwd-drift-opt-out"] as const) {
+      const { getByTestId, container } = mount();
+      await fireEvent.click(getByTestId("cwd-drift-pill"));
+      await fireEvent.click(getByTestId(testid));
+      const statusRoot = container.querySelector("[data-status-focus-root]");
+      expect(statusRoot, testid).not.toBeNull();
+      expect(document.activeElement, `${testid} stranded focus`).toBe(statusRoot);
+      cleanup();
+    }
+  });
+
+  it("keeps focus on the trigger for the row that leaves it mounted", async () => {
+    const { getByTestId } = mount();
+    await fireEvent.click(getByTestId("cwd-drift-pill"));
+    await fireEvent.click(getByTestId("cwd-drift-relaunch"));
+    expect(document.activeElement).toBe(getByTestId("cwd-drift-pill"));
+  });
+
+  it("closes on an outside click", async () => {
+    // `clickOutside` fires on mousedown — the case Escape cannot reach, and the
+    // reason `closeMenu`'s focus guard is conditional at all.
+    const { getByTestId, queryByTestId } = mount();
+    await fireEvent.click(getByTestId("cwd-drift-pill"));
+    expect(queryByTestId("cwd-drift-dismiss")).not.toBeNull();
+    await fireEvent.mouseDown(document.body);
+    expect(queryByTestId("cwd-drift-dismiss")).toBeNull();
   });
 
   it("closes on Escape without running anything", async () => {

--- a/tests/client/status/CwdDriftPill.svelte.test.ts
+++ b/tests/client/status/CwdDriftPill.svelte.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+/**
+ * Rendering + interaction coverage for the drift nudge (#1282), driven through
+ * `StatusBar` rather than the pill in isolation — the placement decisions are
+ * half the design, and the one that matters most (the pill must render in the
+ * state where the AI indicator renders nothing) is only observable from here.
+ */
+
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import StatusBar from "../../../src/client/status/StatusBar.svelte";
+
+const DRIFT = {
+  suggestedCwd: "~/projects/alpha",
+  claudeCwd: "~/notes",
+  label: "alpha",
+  claudeLabel: "notes",
+};
+
+const baseProps = {
+  connected: true,
+  connectionStatus: "connected" as const,
+  reconnectAttempts: 0,
+  disconnectedSince: null,
+  claudeStatus: null,
+  claudeActive: false,
+  aiLiveIndicator: null,
+  aiState: "ready" as const,
+  soloMode: false,
+};
+
+afterEach(() => cleanup());
+
+function mount(over: Record<string, unknown> = {}) {
+  return render(StatusBar, { props: { ...baseProps, cwdDrift: DRIFT, ...over } });
+}
+
+describe("drift pill placement", () => {
+  it("renders in the launcher-running-but-no-session state", () => {
+    // `aiState: "ready"` with `aiLiveIndicator: null` is the auto-launched
+    // desktop startup window, where `aiIndicatorView` returns null. If the pill
+    // were nested inside `{#if aiView}` this query would fail.
+    const { getByTestId, queryByTestId } = mount();
+    expect(queryByTestId("status-ai-indicator")).toBeNull();
+    expect(getByTestId("cwd-drift-pill")).toBeTruthy();
+  });
+
+  it("renders beside a connected AI indicator", () => {
+    const { getByTestId } = mount({ aiLiveIndicator: "connected" as const });
+    expect(getByTestId("status-ai-indicator")).toBeTruthy();
+    expect(getByTestId("cwd-drift-pill")).toBeTruthy();
+  });
+
+  it("stays hidden while an AI CTA is showing", () => {
+    const { queryByTestId } = mount({ aiState: "stopped" as const, aiChip: "restart" as const });
+    expect(queryByTestId("cwd-drift-pill")).toBeNull();
+  });
+
+  it("renders nothing when the caller passes no drift", () => {
+    const { queryByTestId } = mount({ cwdDrift: null });
+    expect(queryByTestId("cwd-drift-pill")).toBeNull();
+  });
+});
+
+describe("drift pill affordances", () => {
+  it("names both folders in its accessible name, not just its tooltip", () => {
+    const { getByTestId } = mount();
+    const pill = getByTestId("cwd-drift-pill");
+    const label = pill.getAttribute("aria-label") ?? "";
+    expect(label).toContain("~/notes");
+    expect(label).toContain("~/projects/alpha");
+  });
+
+  it("is a menu trigger, not a one-click action", () => {
+    // The dismiss affordance has to clear WCAG 2.2 SC 2.5.8 (24×24). A bare
+    // inline × lands around 10px; three full-size menu rows do not.
+    const { getByTestId, queryByTestId } = mount();
+    const pill = getByTestId("cwd-drift-pill");
+    expect(pill.tagName).toBe("BUTTON");
+    expect(pill.getAttribute("aria-haspopup")).toBe("menu");
+    expect(pill.getAttribute("aria-expanded")).toBe("false");
+    expect(queryByTestId("cwd-drift-relaunch")).toBeNull();
+  });
+
+  it("opens three rows and explains itself", async () => {
+    const { getByTestId } = mount();
+    await fireEvent.click(getByTestId("cwd-drift-pill"));
+    expect(getByTestId("cwd-drift-pill").getAttribute("aria-expanded")).toBe("true");
+    expect(getByTestId("cwd-drift-relaunch").textContent).toContain("alpha");
+    expect(getByTestId("cwd-drift-dismiss")).toBeTruthy();
+    expect(getByTestId("cwd-drift-opt-out")).toBeTruthy();
+    // The chip cannot teach the concept; the menu can.
+    expect(getByTestId("cwd-drift").textContent).toContain("CLAUDE.md");
+  });
+
+  it("runs each row's handler exactly once and closes the menu", async () => {
+    for (const [testid, prop] of [
+      ["cwd-drift-relaunch", "onRelaunchInFolder"],
+      ["cwd-drift-dismiss", "onDismissDrift"],
+      ["cwd-drift-opt-out", "onOptOutDrift"],
+    ] as const) {
+      const spy = vi.fn();
+      const { getByTestId, queryByTestId } = mount({ [prop]: spy });
+      await fireEvent.click(getByTestId("cwd-drift-pill"));
+      await fireEvent.click(getByTestId(testid));
+      expect(spy, testid).toHaveBeenCalledOnce();
+      expect(queryByTestId(testid), `${testid} left the menu open`).toBeNull();
+      cleanup();
+    }
+  });
+
+  it("closes on Escape without running anything", async () => {
+    const spy = vi.fn();
+    const { getByTestId, queryByTestId } = mount({ onDismissDrift: spy });
+    await fireEvent.click(getByTestId("cwd-drift-pill"));
+    await fireEvent.keyDown(getByTestId("cwd-drift"), { key: "Escape" });
+    expect(queryByTestId("cwd-drift-dismiss")).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/client/status/cwd-drift-dismiss.test.ts
+++ b/tests/client/status/cwd-drift-dismiss.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment happy-dom
+
+/**
+ * Coverage for the drift-nudge suppression layers (#1282).
+ *
+ * These exist because of an arithmetic fact, not a preference: the launcher's
+ * default working directory is `os.homedir()` and the drift check requires the
+ * candidate to be INSIDE home, so a user who has never configured a working
+ * directory drifts on every document in every subfolder. Without suppression
+ * this feature is a permanent amber pill. So the interesting assertions are the
+ * ones about going quiet, and about the two ways going quiet could be wrong:
+ * suppressing a pair that is not the one dismissed, and going quiet silently.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetDriftDismissForTests,
+  dismissDrift,
+  driftDismissed,
+  driftNudgeOptedOut,
+  noteDriftSeen,
+  optOutOfDriftNudge,
+  SESSION_DISMISS_LIMIT,
+} from "../../../src/client/status/cwdDriftDismiss.svelte.js";
+
+const CLAUDE = "~/notes";
+const TARGET = "~/projects/alpha";
+
+/** Make one localStorage method throw, the way a storage-disabled browser does.
+ * Spies the INSTANCE, not `Storage.prototype` — happy-dom's storage does not
+ * route through that prototype, so a prototype spy installs cleanly and then
+ * intercepts nothing, quietly turning these into vacuous passes. */
+function denyStorage(method: "getItem" | "setItem"): { mockRestore: () => void } {
+  return vi.spyOn(globalThis.localStorage, method).mockImplementation(() => {
+    throw new Error("denied");
+  });
+}
+
+beforeEach(() => {
+  _resetDriftDismissForTests();
+});
+
+describe("per-pair dismissal", () => {
+  it("hides the dismissed pair and nothing else", () => {
+    expect(driftDismissed(CLAUDE, TARGET)).toBe(false);
+    dismissDrift(CLAUDE, TARGET);
+    expect(driftDismissed(CLAUDE, TARGET)).toBe(true);
+    expect(driftDismissed(CLAUDE, "~/projects/beta")).toBe(false);
+  });
+
+  it("keys on the PAIR, so moving Claude re-arms a dismissed target", () => {
+    // Dismiss "move to ~/projects/alpha" while Claude sits in ~/notes; later
+    // move Claude somewhere else and reopen a document in alpha. Keyed on the
+    // target alone that is still suppressed — even though the situation is now
+    // strictly worse, because Claude is in a folder whose CLAUDE.md has nothing
+    // to do with this document.
+    dismissDrift(CLAUDE, TARGET);
+    expect(driftDismissed("~/work/other", TARGET)).toBe(false);
+  });
+
+  it("is reflected immediately, not at some later unrelated render", () => {
+    // `$state(new Set())` is not deep-proxied in Svelte 5, so an implementation
+    // that called `.add()` instead of reassigning would leave the dismiss
+    // button looking dead and then act retroactively. Reading straight back is
+    // the closest a non-component test gets to that; the reassign discipline is
+    // what makes it true inside a component too.
+    dismissDrift(CLAUDE, TARGET);
+    expect(driftDismissed(CLAUDE, TARGET)).toBe(true);
+  });
+
+  it("does not confuse two pairs that would collide under a joined key", () => {
+    // Any delimiter can legally appear in a POSIX folder name, and a joined key
+    // then makes two different pairs identical: joining on "|", both of these
+    // become "~/a|~/b|~/c", so dismissing one silently suppresses the other.
+    // Length-prefixing reserves no character and has no such case.
+    dismissDrift("~/a|~/b", "~/c");
+    expect(driftDismissed("~/a", "~/b|~/c")).toBe(false);
+  });
+});
+
+describe("session backstop", () => {
+  it("goes quiet for every pair once the limit is reached", () => {
+    // The permanent-drift user: parks Claude in one folder, edits everywhere.
+    // Per-pair dismissal alone hands them a fresh pill for every folder, forever.
+    for (let i = 0; i < SESSION_DISMISS_LIMIT; i++) {
+      dismissDrift(CLAUDE, `~/projects/p${i}`);
+    }
+    expect(driftDismissed(CLAUDE, "~/never/seen/before")).toBe(true);
+  });
+
+  it("does not go quiet one dismissal early", () => {
+    for (let i = 0; i < SESSION_DISMISS_LIMIT - 1; i++) {
+      dismissDrift(CLAUDE, `~/projects/p${i}`);
+    }
+    expect(driftDismissed(CLAUDE, "~/never/seen/before")).toBe(false);
+  });
+
+  it("asks the caller to announce the backstop exactly once", () => {
+    // Silently going quiet would make "Claude is in the right folder now" and
+    // "Tandem stopped mentioning it" look identical — opposite facts.
+    const announcements: boolean[] = [];
+    for (let i = 0; i < SESSION_DISMISS_LIMIT + 2; i++) {
+      announcements.push(dismissDrift(CLAUDE, `~/projects/p${i}`));
+    }
+    expect(announcements.filter(Boolean)).toHaveLength(1);
+    expect(announcements[SESSION_DISMISS_LIMIT - 1]).toBe(true);
+  });
+});
+
+describe("permanent opt-out", () => {
+  it("suppresses everything and reports success when storage works", () => {
+    expect(optOutOfDriftNudge()).toBe(true);
+    expect(driftNudgeOptedOut()).toBe(true);
+    expect(driftDismissed(CLAUDE, TARGET)).toBe(true);
+  });
+
+  it("still suppresses for the session when storage throws, and says so", () => {
+    // Incognito / storage-disabled. Returning false is what lets the caller
+    // promise only what it can keep — a session, not forever.
+    const spy = denyStorage("setItem");
+    try {
+      expect(optOutOfDriftNudge()).toBe(false);
+      expect(driftDismissed(CLAUDE, TARGET)).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("treats an unreadable preference as not-opted-out", () => {
+    // Failing the other way would silently disable the feature for anyone whose
+    // browser blocks storage reads. Seed the persisted opt-out FIRST so a
+    // working `getItem` really would answer "opted out" — otherwise this passes
+    // on the default and proves nothing.
+    localStorage.setItem("tandem:cwd-drift-opt-out", "1");
+    const spy = denyStorage("getItem");
+    try {
+      _resetDriftDismissForTests();
+      expect(driftDismissed(CLAUDE, TARGET)).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("one-time explainer", () => {
+  it("claims exactly once", () => {
+    expect(noteDriftSeen()).toBe(true);
+    expect(noteDriftSeen()).toBe(false);
+    expect(noteDriftSeen()).toBe(false);
+  });
+
+  it("stays claimed across a fresh session when storage persists it", () => {
+    expect(noteDriftSeen()).toBe(true);
+    // Simulate a reload: module session state resets, localStorage does not.
+    // `_resetDriftDismissForTests` clears both, so re-set the persisted half.
+    localStorage.setItem("tandem:cwd-drift-seen", "1");
+    expect(noteDriftSeen()).toBe(false);
+  });
+
+  it("degrades to once-per-session when storage is unavailable", () => {
+    const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+    try {
+      expect(noteDriftSeen()).toBe(true);
+      expect(noteDriftSeen()).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/tests/client/status/cwd-drift-dismiss.test.ts
+++ b/tests/client/status/cwd-drift-dismiss.test.ts
@@ -16,6 +16,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   _resetDriftDismissForTests,
+  clearDriftNudgeOptOut,
   dismissDrift,
   driftDismissed,
   driftNudgeOptedOut,
@@ -127,19 +128,38 @@ describe("permanent opt-out", () => {
     }
   });
 
+  it("survives a restart", () => {
+    // Layer 3's entire promise. `_resetDriftDismissForTests({ keepStorage: true })`
+    // re-runs `loadOptOut()` exactly as a page load does — a plain
+    // `optedOut = false` assignment would skip the only code path that reads the
+    // persisted value, leaving "across restarts" asserted nowhere.
+    optOutOfDriftNudge();
+    _resetDriftDismissForTests({ keepStorage: true });
+    expect(driftNudgeOptedOut()).toBe(true);
+    expect(driftDismissed(CLAUDE, TARGET)).toBe(true);
+  });
+
   it("treats an unreadable preference as not-opted-out", () => {
     // Failing the other way would silently disable the feature for anyone whose
-    // browser blocks storage reads. Seed the persisted opt-out FIRST so a
-    // working `getItem` really would answer "opted out" — otherwise this passes
-    // on the default and proves nothing.
-    localStorage.setItem("tandem:cwd-drift-opt-out", "1");
+    // browser blocks storage reads. Seeded first AND read back through the real
+    // `loadOptOut`, so a working `getItem` genuinely would answer "opted out".
+    optOutOfDriftNudge();
     const spy = denyStorage("getItem");
     try {
-      _resetDriftDismissForTests();
-      expect(driftDismissed(CLAUDE, TARGET)).toBe(false);
+      _resetDriftDismissForTests({ keepStorage: true });
+      expect(driftNudgeOptedOut()).toBe(false);
     } finally {
       spy.mockRestore();
     }
+  });
+
+  it("can be turned back on, and the reversal survives a restart", () => {
+    // "Don't show this again" must not be a one-way door whose only exit is
+    // editing localStorage by hand.
+    optOutOfDriftNudge();
+    expect(clearDriftNudgeOptOut()).toBe(true);
+    _resetDriftDismissForTests({ keepStorage: true });
+    expect(driftNudgeOptedOut()).toBe(false);
   });
 });
 
@@ -152,18 +172,31 @@ describe("one-time explainer", () => {
 
   it("stays claimed across a fresh session when storage persists it", () => {
     expect(noteDriftSeen()).toBe(true);
-    // Simulate a reload: module session state resets, localStorage does not.
-    // `_resetDriftDismissForTests` clears both, so re-set the persisted half.
-    localStorage.setItem("tandem:cwd-drift-seen", "1");
+    // A real reload: session state resets, localStorage does not. Resetting the
+    // session flag is the point — without it the second call short-circuits on
+    // that flag and never reads storage at all, so `SEEN_KEY` (the only reason
+    // this is persisted rather than session-scoped) goes untested.
+    _resetDriftDismissForTests({ keepStorage: true });
     expect(noteDriftSeen()).toBe(false);
   });
 
-  it("degrades to once-per-session when storage is unavailable", () => {
-    const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-      throw new Error("denied");
-    });
+  it("does not claim what it cannot record", () => {
+    // Returning true here would look like "degrade to once per session", but the
+    // degradation compounds: the same unwritable store cannot hold the opt-out
+    // either, so a storage-disabled browser would replay this four-sentence
+    // notice every launch, forever — including to someone who clicked "don't
+    // show this again". The pill's menu still carries the whole explanation.
+    const spy = denyStorage("getItem");
     try {
-      expect(noteDriftSeen()).toBe(true);
+      expect(noteDriftSeen()).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("does not claim it when the write fails either", () => {
+    const spy = denyStorage("setItem");
+    try {
       expect(noteDriftSeen()).toBe(false);
     } finally {
       spy.mockRestore();

--- a/tests/client/useCwdDrift.svelte.test.ts
+++ b/tests/client/useCwdDrift.svelte.test.ts
@@ -1,0 +1,288 @@
+// @vitest-environment happy-dom
+
+/**
+ * Coverage for `createCwdDrift` (#1282).
+ *
+ * The hook holds an answer and the timing for asking; every judgement about
+ * WHETHER a folder mismatch is worth mentioning lives server-side. So what is
+ * worth testing here is exactly the timing and the failure behaviour:
+ *
+ *   - the settle delay actually suppresses a probe (a tab-flick must cost zero
+ *     requests, and must never flash a pill mid-switch);
+ *   - a superseded probe cannot write. An in-flight flag — the obvious
+ *     alternative — would be actively wrong: it drops probes 2..N, so switching
+ *     between three documents leaves the pill answering for the first one;
+ *   - every failure clears to "nothing to say" rather than stranding the last
+ *     answer, which would leave an amber pill asserting a relationship nobody
+ *     has checked since the server started refusing to answer.
+ */
+
+import { render } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CwdDriftState } from "../../src/client/hooks/useCwdDrift.svelte.js";
+import CwdDriftHarness from "../../src/client/svelte-harness/CwdDriftHarness.svelte";
+
+const SETTLE = 50;
+
+const DRIFTED = {
+  drifted: true,
+  suggestedCwd: "~/projects/alpha",
+  claudeCwd: "~/notes",
+  label: "alpha",
+  claudeLabel: "notes",
+};
+
+interface Recorder {
+  fetchFn: typeof fetch;
+  bodies: () => string[];
+  calls: () => number;
+}
+
+/** A fetch stub that records each request body and replays a scripted response
+ *  per call (the last entry repeats). A function entry is invoked, so a call can
+ *  throw or resolve late. */
+function recorder(script: Array<unknown | (() => unknown)>): Recorder {
+  const bodies: string[] = [];
+  let i = 0;
+  const fetchFn = (async (_url: string, init?: RequestInit) => {
+    bodies.push(String(init?.body ?? ""));
+    const entry = script[Math.min(i, script.length - 1)];
+    i += 1;
+    const resolved = typeof entry === "function" ? (entry as () => unknown)() : entry;
+    if (resolved instanceof Error) throw resolved;
+    if (resolved instanceof Promise) return (await resolved) as unknown as Response;
+    return resolved as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { fetchFn, bodies: () => bodies, calls: () => i };
+}
+
+function ok(body: unknown): { ok: true; status: number; json: () => Promise<unknown> } {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+function mount(props: { cwd?: string | null; fetchFn?: typeof fetch }): {
+  get(): CwdDriftState;
+  rerender(next: Record<string, unknown>): Promise<void>;
+  unmount(): void;
+} {
+  const holder: { state: CwdDriftState | null } = { state: null };
+  const utils = render(CwdDriftHarness, {
+    props: {
+      onReady: (s: CwdDriftState) => {
+        holder.state = s;
+      },
+      cwd: props.cwd ?? null,
+      opts: { settleMs: SETTLE, fetchFn: props.fetchFn },
+    },
+  });
+  return {
+    get: () => {
+      if (holder.state === null) throw new Error("harness never reported state");
+      return holder.state;
+    },
+    rerender: (next) => utils.rerender(next as never),
+    unmount: () => utils.unmount(),
+  };
+}
+
+/** Advance past the settle delay and let the async continuation land. */
+async function settle(extraTicks = 3): Promise<void> {
+  await vi.advanceTimersByTimeAsync(SETTLE + 1);
+  for (let i = 0; i < extraTicks; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createCwdDrift", () => {
+  it("reports drift after the inputs settle", async () => {
+    const r = recorder([ok(DRIFTED)]);
+    const h = mount({ cwd: "/home/u/projects/alpha", fetchFn: r.fetchFn });
+    await settle();
+    expect(h.get().drift).toEqual({
+      suggestedCwd: "~/projects/alpha",
+      claudeCwd: "~/notes",
+      label: "alpha",
+      claudeLabel: "notes",
+    });
+  });
+
+  it("sends the caller's folder verbatim", async () => {
+    // Not the document path, and not a re-derivation: the value on the wire has
+    // to be the same one the relaunch will carry, or the preview and the action
+    // are answering about different folders.
+    const r = recorder([ok({ drifted: false })]);
+    mount({ cwd: "/home/u/projects/alpha", fetchFn: r.fetchFn });
+    await settle();
+    expect(JSON.parse(r.bodies()[0] as string)).toEqual({ cwd: "/home/u/projects/alpha" });
+  });
+
+  it("asks nothing at all while the input is still moving", async () => {
+    const r = recorder([ok(DRIFTED)]);
+    const h = mount({ cwd: "/home/u/a", fetchFn: r.fetchFn });
+    for (const cwd of ["/home/u/b", "/home/u/c", "/home/u/d"]) {
+      await vi.advanceTimersByTimeAsync(SETTLE / 2);
+      await h.rerender({ cwd });
+    }
+    // Four documents visited; the settle window never elapsed for any of them.
+    expect(r.calls()).toBe(0);
+    expect(h.get().drift).toBeNull();
+  });
+
+  it("answers for the LAST folder, not the first", async () => {
+    // The in-flight-flag design fails exactly here: it would drop the second
+    // probe and leave the pill naming the folder the user has already left.
+    const r = recorder([ok({ ...DRIFTED, label: "first" }), ok({ ...DRIFTED, label: "second" })]);
+    const h = mount({ cwd: "/home/u/first", fetchFn: r.fetchFn });
+    await settle();
+    expect(h.get().drift?.label).toBe("first");
+    await h.rerender({ cwd: "/home/u/second" });
+    await settle();
+    expect(h.get().drift?.label).toBe("second");
+  });
+
+  it("does not let a slow superseded response overwrite a fresher one", async () => {
+    let releaseFirst: ((v: unknown) => void) | null = null;
+    const r = recorder([
+      () =>
+        new Promise((res) => {
+          releaseFirst = res;
+        }),
+      ok({ ...DRIFTED, label: "second" }),
+    ]);
+    const h = mount({ cwd: "/home/u/first", fetchFn: r.fetchFn });
+    await vi.advanceTimersByTimeAsync(SETTLE + 1);
+    await h.rerender({ cwd: "/home/u/second" });
+    await settle();
+    expect(h.get().drift?.label).toBe("second");
+    // The first request only now resolves, with a different answer.
+    releaseFirst?.(ok({ ...DRIFTED, label: "first" }));
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(h.get().drift?.label).toBe("second");
+  });
+
+  it("aborts the in-flight request when the input changes", async () => {
+    const signals: (AbortSignal | undefined)[] = [];
+    const fetchFn = (async (_url: string, init?: RequestInit) => {
+      signals.push(init?.signal ?? undefined);
+      return new Promise(() => {}) as unknown as Response; // never resolves
+    }) as unknown as typeof fetch;
+    const h = mount({ cwd: "/home/u/first", fetchFn });
+    await vi.advanceTimersByTimeAsync(SETTLE + 1);
+    expect(signals[0]?.aborted).toBe(false);
+    await h.rerender({ cwd: "/home/u/second" });
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  it("clears to null when the server says no drift", async () => {
+    const r = recorder([ok(DRIFTED), ok({ drifted: false })]);
+    const h = mount({ cwd: "/home/u/a", fetchFn: r.fetchFn });
+    await settle();
+    expect(h.get().drift).not.toBeNull();
+    await h.rerender({ cwd: "/home/u/b" });
+    await settle();
+    expect(h.get().drift).toBeNull();
+  });
+
+  it("clears to null on a non-OK response", async () => {
+    const r = recorder([
+      ok(DRIFTED),
+      { ok: false, status: 403, json: async () => ({ error: "FORBIDDEN" }) },
+    ]);
+    const h = mount({ cwd: "/home/u/a", fetchFn: r.fetchFn });
+    await settle();
+    expect(h.get().drift).not.toBeNull();
+    await h.rerender({ cwd: "/home/u/b" });
+    await settle();
+    expect(h.get().drift).toBeNull();
+  });
+
+  it("clears to null when the request throws", async () => {
+    const r = recorder([ok(DRIFTED), new Error("offline")]);
+    const h = mount({ cwd: "/home/u/a", fetchFn: r.fetchFn });
+    await settle();
+    expect(h.get().drift).not.toBeNull();
+    await h.rerender({ cwd: "/home/u/b" });
+    await settle();
+    expect(h.get().drift).toBeNull();
+  });
+
+  it("clears to null on a malformed body", async () => {
+    const r = recorder([
+      ok(DRIFTED),
+      {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error("not json");
+        },
+      },
+    ]);
+    const h = mount({ cwd: "/home/u/a", fetchFn: r.fetchFn });
+    await settle();
+    expect(h.get().drift).not.toBeNull();
+    await h.rerender({ cwd: "/home/u/b" });
+    await settle();
+    expect(h.get().drift).toBeNull();
+  });
+
+  it("asks nothing and clears when no eligible document is open", async () => {
+    const r = recorder([ok(DRIFTED)]);
+    const h = mount({ cwd: "/home/u/a", fetchFn: r.fetchFn });
+    await settle();
+    expect(h.get().drift).not.toBeNull();
+    await h.rerender({ cwd: null });
+    await settle();
+    expect(h.get().drift).toBeNull();
+    expect(r.calls()).toBe(1);
+  });
+
+  it("re-probes on refresh() without the document changing", async () => {
+    // The launcher's cwd is not reactive state on this side, so a relaunch that
+    // MOVES Claude changes nothing the effect watches. Without this the pill
+    // survives its own success, naming the folder Claude just left.
+    const r = recorder([ok(DRIFTED), ok({ drifted: false })]);
+    const h = mount({ cwd: "/home/u/a", fetchFn: r.fetchFn });
+    await settle();
+    expect(h.get().drift).not.toBeNull();
+    h.get().refresh();
+    await settle();
+    expect(r.calls()).toBe(2);
+    expect(h.get().drift).toBeNull();
+  });
+
+  it("re-arms after a refresh() issued while nothing was open", async () => {
+    const r = recorder([ok(DRIFTED)]);
+    const h = mount({ cwd: null, fetchFn: r.fetchFn });
+    await settle();
+    h.get().refresh();
+    await settle();
+    expect(r.calls()).toBe(0);
+    await h.rerender({ cwd: "/home/u/a" });
+    await settle();
+    expect(r.calls()).toBe(1);
+  });
+
+  it("writes nothing after unmount", async () => {
+    let release: ((v: unknown) => void) | null = null;
+    const r = recorder([
+      () =>
+        new Promise((res) => {
+          release = res;
+        }),
+    ]);
+    const h = mount({ cwd: "/home/u/a", fetchFn: r.fetchFn });
+    await vi.advanceTimersByTimeAsync(SETTLE + 1);
+    const state = h.get();
+    h.unmount();
+    release?.(ok(DRIFTED));
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(state.drift).toBeNull();
+  });
+});

--- a/tests/client/useCwdDrift.svelte.test.ts
+++ b/tests/client/useCwdDrift.svelte.test.ts
@@ -269,6 +269,85 @@ describe("createCwdDrift", () => {
     expect(r.calls()).toBe(1);
   });
 
+  it("rejects a drifted:true answer with missing fields", async () => {
+    // The one path where a bad answer becomes a confident false statement rather
+    // than silence: undefined fields would render "Claude is running in
+    // undefined" AND poison the dismissal key, so dismissing that nonsense pair
+    // suppresses every real drift afterwards.
+    const r = recorder([ok({ drifted: true, suggestedCwd: "~/a" })]);
+    const h = mount({ cwd: "/home/u/a", fetchFn: r.fetchFn });
+    await settle();
+    expect(h.get().drift).toBeNull();
+  });
+
+  it("rejects a drifted:true answer with non-string fields", async () => {
+    const r = recorder([
+      ok({ drifted: true, suggestedCwd: "~/a", claudeCwd: "~/b", label: 7, claudeLabel: "b" }),
+    ]);
+    const h = mount({ cwd: "/home/u/a", fetchFn: r.fetchFn });
+    await settle();
+    expect(h.get().drift).toBeNull();
+  });
+
+  it("does not blank the pill when a superseding probe aborts the current one", async () => {
+    // A real `fetch` REJECTS on abort, and the effect cleanup aborts on every
+    // re-run — so guarding the failure paths on `mounted` alone blanks the chip
+    // on every tab switch and on both `refresh()` calls fired after a launcher
+    // action. The stub used elsewhere in this file never rejects on abort, which
+    // is exactly why it could not catch this.
+    let call = 0;
+    const abortingFetch = (async (_url: string, init?: RequestInit) => {
+      call += 1;
+      if (call === 1) return ok(DRIFTED) as unknown as Response;
+      // Second and later probes hang until aborted, then reject like the real thing.
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    }) as unknown as typeof fetch;
+
+    const h = mount({ cwd: "/home/u/a", fetchFn: abortingFetch });
+    await settle();
+    expect(h.get().drift, "seed probe should have answered").not.toBeNull();
+
+    // Probe 2 goes in flight...
+    h.get().refresh();
+    await vi.advanceTimersByTimeAsync(SETTLE + 1);
+    // ...and is superseded, which aborts it and drives its rejection.
+    h.get().refresh();
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+
+    expect(h.get().drift, "an aborted probe cleared a live answer").not.toBeNull();
+  });
+
+  it("does not let a slow superseded NON-OK response clear a fresher answer", async () => {
+    // The abort case above drives the `catch`; this drives the `!res.ok` branch,
+    // which an abort never reaches. Same failure either way: a probe the user has
+    // already moved past returns 403 late and blanks the answer on screen.
+    let releaseFirst: ((v: Response) => void) | null = null;
+    let call = 0;
+    const fetchFn = (async () => {
+      call += 1;
+      if (call === 1) {
+        return new Promise<Response>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return ok(DRIFTED) as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const h = mount({ cwd: "/home/u/first", fetchFn });
+    await vi.advanceTimersByTimeAsync(SETTLE + 1);
+    // Supersede it; probe 2 answers with a real drift.
+    await h.rerender({ cwd: "/home/u/second" });
+    await settle();
+    expect(h.get().drift, "second probe should have answered").not.toBeNull();
+
+    // Probe 1 only now resolves — with a rejection the server sent late.
+    releaseFirst?.({ ok: false, status: 403, json: async () => ({}) } as unknown as Response);
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+    expect(h.get().drift, "a superseded non-OK response cleared a live answer").not.toBeNull();
+  });
+
   it("writes nothing after unmount", async () => {
     let release: ((v: unknown) => void) | null = null;
     const r = recorder([

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -95,6 +95,12 @@ cowork-vethernet-cidr
 cowork-workspace-report-{*}-{*}
 cowork-workspace-row-{*}-{*}
 cowork-workspace-table
+cwd-drift
+cwd-drift-dismiss
+cwd-drift-harness
+cwd-drift-opt-out
+cwd-drift-pill
+cwd-drift-relaunch
 decorations-menu
 decorations-menu-caret
 decorations-mute-toggle

--- a/tests/server/bundled-doc-dirs.test.ts
+++ b/tests/server/bundled-doc-dirs.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `resolveBundledDocDirs()` — the #1282 drift-nudge exclusion list.
+ *
+ * These exist because the exclusion's *predicate* was well tested while its
+ * *production input* was not: every case in `cwd-preview.test.ts` injects
+ * `bundledDocDirs` as a fixture, so a list that was correct in dev and wrong in
+ * a packaged build passed everything. That is exactly what happened —
+ * `WELCOME_PATH` resolves under the resource dir, but `index.ts` opens
+ * `<TANDEM_DATA_DIR>/sample/welcome.md`, and only the Tauri shell sets that
+ * variable. Dev and CI leave it unset, which collapses the two directories into
+ * one and hides the gap.
+ *
+ * So the assertion that matters is the coupling one: the directory `index.ts`
+ * would open `welcome.md` from must be in the list. Restating the join here
+ * would only re-test this file's own arithmetic, so the expected value is
+ * derived the same way the production code derives it.
+ */
+
+import { realpathSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveBundledDocDirs } from "../../src/server/mcp/server.js";
+
+/** What `src/server/index.ts` actually opens on a fresh start. */
+function sampleDirIndexWouldOpen(): string {
+  const base = process.env.TANDEM_DATA_DIR?.trim();
+  const dir = base ? join(base, "sample") : undefined;
+  if (dir === undefined) throw new Error("only meaningful with TANDEM_DATA_DIR set");
+  try {
+    return realpathSync(dir);
+  } catch {
+    return dir;
+  }
+}
+
+describe("resolveBundledDocDirs", () => {
+  const original = process.env.TANDEM_DATA_DIR;
+
+  beforeEach(() => {
+    delete process.env.TANDEM_DATA_DIR;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.TANDEM_DATA_DIR;
+    else process.env.TANDEM_DATA_DIR = original;
+  });
+
+  it("includes the app-data sample dir the desktop app actually opens from", () => {
+    // The packaged-desktop shape: the Tauri shell exports TANDEM_DATA_DIR and
+    // copies sample/* into it. Without this entry the amber drift pill fires on
+    // every first run, offering to repoint the launcher at Tandem's own folder.
+    process.env.TANDEM_DATA_DIR = join(process.cwd(), "test-app-data");
+
+    expect(resolveBundledDocDirs()).toContain(sampleDirIndexWouldOpen());
+  });
+
+  it("still lists the bundle's own dirs, so the app-data entry is an addition", () => {
+    // A fix that swapped one directory for the other would leave the npm
+    // distribution (no TANDEM_DATA_DIR, docs beside the code) unprotected.
+    process.env.TANDEM_DATA_DIR = join(process.cwd(), "test-app-data");
+    const withDataDir = resolveBundledDocDirs();
+
+    delete process.env.TANDEM_DATA_DIR;
+    const without = resolveBundledDocDirs();
+
+    expect(without.length).toBeGreaterThan(0);
+    for (const dir of without) expect(withDataDir).toContain(dir);
+    expect(withDataDir.length).toBe(without.length + 1);
+  });
+
+  it("ignores a blank TANDEM_DATA_DIR rather than listing a bare 'sample'", () => {
+    // `join("", "sample")` is the relative string "sample", which would silently
+    // enter the list and could never match a canonicalized absolute candidate.
+    process.env.TANDEM_DATA_DIR = "   ";
+
+    for (const dir of resolveBundledDocDirs()) expect(dir).not.toBe("sample");
+  });
+});

--- a/tests/server/launcher/api-routes.test.ts
+++ b/tests/server/launcher/api-routes.test.ts
@@ -930,3 +930,203 @@ describe("GET /api/launcher/status — reason redaction (#1236)", () => {
     expect(res.body).toEqual({ available: false, reason: "deferred-autostart" });
   });
 });
+
+describe("POST /api/launcher/cwd-preview (#1282)", () => {
+  /**
+   * The gates here are deliberately unlike the mutating routes', and the tests
+   * pin the differences rather than the similarities: no nonce (nothing is
+   * mutated, and consuming one would rotate it out from under the relaunch the
+   * user is about to confirm), an UNCONDITIONAL loopback check rather than
+   * `assertLoopbackForMutation` (which is a no-op outside the
+   * unauthenticated-LAN opt-in), and no 503 (an unavailable launcher is a fine
+   * answer to "is Claude in the wrong folder", and the answer is "no").
+   */
+  let home: string;
+  let projA: string;
+  let projB: string;
+
+  beforeEach(() => {
+    home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "cwd-preview-route-")));
+    projA = path.join(home, "alpha");
+    projB = path.join(home, "beta");
+    fs.mkdirSync(projA);
+    fs.mkdirSync(projB);
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  /** The route resolves against the REAL `os.homedir()` (no seam on the HTTP
+   * surface), so the folders under test must actually live there. */
+  function underRealHome(): { dir: string; other: string; cleanup: () => void } {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.homedir(), ".tandem-cwd-test-")));
+    const dir = path.join(root, "alpha");
+    const other = path.join(root, "beta");
+    fs.mkdirSync(dir);
+    fs.mkdirSync(other);
+    return { dir, other, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+  }
+
+  it("reports drift for a real home-confined folder Claude is not in", async () => {
+    const { dir, other, cleanup } = underRealHome();
+    try {
+      const sup = makeFakeSupervisor({ running: true, cwd: other });
+      const { app } = makeApp(baseDeps(sup));
+      const res = await request(app, "POST", "/api/launcher/cwd-preview", { cwd: dir });
+      expect(res.status).toBe(200);
+      const body = res.body as { drifted: boolean; label?: string };
+      expect(body.drifted).toBe(true);
+      expect(body.label).toBe("alpha");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("rejects a non-loopback caller outright", async () => {
+    // The response reconstructs the launcher `cwd` that GET /status withholds
+    // off-loopback, plus a second path under the user's home directory.
+    const sup = makeFakeSupervisor({ running: true, cwd: projB });
+    const { app } = makeApp(baseDeps(sup), { remoteAddress: "192.168.1.50" });
+    const res = await request(app, "POST", "/api/launcher/cwd-preview", { cwd: projA });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a disallowed origin", async () => {
+    const sup = makeFakeSupervisor({ running: true, cwd: projB });
+    const { app } = makeApp(baseDeps(sup));
+    const res = await request(
+      app,
+      "POST",
+      "/api/launcher/cwd-preview",
+      { cwd: projA },
+      { Origin: "https://evil.example" },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("needs no nonce", async () => {
+    const { dir, other, cleanup } = underRealHome();
+    try {
+      const sup = makeFakeSupervisor({ running: true, cwd: other });
+      const { app } = makeApp(baseDeps(sup));
+      const res = await request(app, "POST", "/api/launcher/cwd-preview", { cwd: dir });
+      expect(res.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("does not consume the relaunch nonce", async () => {
+    // A preview that rotated the nonce would break the very action it advertises:
+    // the user opens the menu, the pill probes again, and their click 403s.
+    const { dir, other, cleanup } = underRealHome();
+    try {
+      const sup = makeFakeSupervisor({ running: true, cwd: other });
+      const { app } = makeApp(baseDeps(sup));
+      const nonceRes = await request(app, "GET", "/api/launcher/nonce");
+      const nonce = (nonceRes.body as { nonce: string }).nonce;
+      await request(app, "POST", "/api/launcher/cwd-preview", { cwd: dir });
+      const relaunch = await request(app, "POST", "/api/launcher/relaunch", { nonce });
+      expect(relaunch.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("400s on a non-string cwd", async () => {
+    const sup = makeFakeSupervisor({ running: true, cwd: projB });
+    const { app } = makeApp(baseDeps(sup));
+    for (const cwd of [undefined, 42, null, { path: "x" }]) {
+      const res = await request(app, "POST", "/api/launcher/cwd-preview", { cwd });
+      expect(res.status, `cwd=${JSON.stringify(cwd)}`).toBe(400);
+    }
+  });
+
+  it("answers 'no drift' rather than 400 for an over-length cwd", async () => {
+    // An over-length path is a legitimate answer to the question asked, not a
+    // caller error — and the length cap runs BEFORE path resolution in the
+    // relaunch route, so answering it any other way here would re-open the
+    // split-predicate gap: a preview that green-lights what the action rejects.
+    const sup = makeFakeSupervisor({ running: true, cwd: projB });
+    const { app } = makeApp(baseDeps(sup));
+    const res = await request(app, "POST", "/api/launcher/cwd-preview", {
+      cwd: `/${"x".repeat(4096)}`,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ drifted: false });
+  });
+
+  // Both of these use a folder that WOULD drift (`underRealHome`), so a pass
+  // proves the launcher-state gate specifically. Handing them a path that is
+  // outside home on some hosts would make them pass for the wrong reason there.
+  it("answers 'no drift' rather than 503 when the launcher is unavailable", async () => {
+    const { dir, cleanup } = underRealHome();
+    try {
+      const { app } = makeApp(baseDeps(null, "stdio-mode"));
+      const res = await request(app, "POST", "/api/launcher/cwd-preview", { cwd: dir });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ drifted: false });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("answers 'no drift' when the launcher is available but stopped", async () => {
+    const { dir, cleanup } = underRealHome();
+    try {
+      const sup = makeFakeSupervisor({ running: false });
+      const { app } = makeApp(baseDeps(sup));
+      const res = await request(app, "POST", "/api/launcher/cwd-preview", { cwd: dir });
+      expect(res.body).toEqual({ drifted: false });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("collapses a path outside home to the same 'no drift' answer", async () => {
+    // Indistinguishable from every other no-case by design: a client that could
+    // tell "outside home" from "same folder" would have a probe for what exists
+    // under the user's home directory.
+    //
+    // The filesystem root, not `os.tmpdir()` — on Windows the temp directory
+    // lives under `%LOCALAPPDATA%\Temp`, i.e. INSIDE home, so a tmpdir-based
+    // "outside home" fixture asserts the opposite of its name there. It did,
+    // until this test failed and said so.
+    const outside = path.parse(os.homedir()).root;
+    const sup = makeFakeSupervisor({ running: true, cwd: projB });
+    const { app } = makeApp(baseDeps(sup));
+    const res = await request(app, "POST", "/api/launcher/cwd-preview", { cwd: outside });
+    expect(res.body).toEqual({ drifted: false });
+  });
+
+  it("honours the bundled-doc exclusion", async () => {
+    const { dir, other, cleanup } = underRealHome();
+    try {
+      const sup = makeFakeSupervisor({ running: true, cwd: other });
+      const { app } = makeApp({ ...baseDeps(sup), bundledDocDirs: [dir] });
+      const res = await request(app, "POST", "/api/launcher/cwd-preview", { cwd: dir });
+      expect(res.body).toEqual({ drifted: false });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("answers 'no drift' rather than 500 when the supervisor's status throws", async () => {
+    const { dir, cleanup } = underRealHome();
+    try {
+      const sup = {
+        ...makeFakeSupervisor({ running: true }),
+        status: () => {
+          throw new Error("boom");
+        },
+      } as unknown as Supervisor;
+      const { app } = makeApp(baseDeps(sup));
+      const res = await request(app, "POST", "/api/launcher/cwd-preview", { cwd: dir });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ drifted: false });
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/tests/server/launcher/api-routes.test.ts
+++ b/tests/server/launcher/api-routes.test.ts
@@ -938,10 +938,15 @@ describe("POST /api/launcher/cwd-preview (#1282)", () => {
    * The gates here are deliberately unlike the mutating routes', and the tests
    * pin the differences rather than the similarities: no nonce (nothing is
    * mutated, and consuming one would rotate it out from under the relaunch the
-   * user is about to confirm), an UNCONDITIONAL loopback check rather than
-   * `assertLoopbackForMutation` (which is a no-op outside the
-   * unauthenticated-LAN opt-in), and no 503 (an unavailable launcher is a fine
+   * user is about to confirm), a bare unconditional loopback check rather than
+   * `assertLoopbackForMutation`, and no 503 (an unavailable launcher is a fine
    * answer to "is Claude in the wrong folder", and the answer is "no").
+   *
+   * On that middle one: the original reason was that the helper *was* a no-op
+   * outside the unauthenticated-LAN opt-in — true until #1293 made it reject
+   * unconditionally. The two are equivalent now, and what remains is that this
+   * route mutates nothing: it is a read with the disclosure posture of
+   * `/api/document/raw`, not a mutation carrying a weakened gate.
    */
   let home: string;
   let projA: string;

--- a/tests/server/launcher/api-routes.test.ts
+++ b/tests/server/launcher/api-routes.test.ts
@@ -14,6 +14,7 @@ import express, { type Express } from "express";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  _resetCwdPreviewInFlightForTests,
   _resetInflightForTests,
   _resetLauncherGateForTests,
   type LauncherRoutesDeps,
@@ -140,6 +141,7 @@ const baseDeps = (
 beforeEach(() => {
   _resetLauncherGateForTests();
   _resetInflightForTests();
+  _resetCwdPreviewInFlightForTests();
 });
 
 afterEach(() => {
@@ -979,6 +981,69 @@ describe("POST /api/launcher/cwd-preview (#1282)", () => {
       expect(body.drifted).toBe(true);
       expect(body.label).toBe("alpha");
     } finally {
+      cleanup();
+    }
+  });
+
+  it("abbreviates against the REAL home directory on the shipping surface", async () => {
+    // The route passes no `homeOverride`, so production always takes the
+    // `os.homedir()` branch — which no unit test observes, because they all
+    // supply the seam. This is the whole privacy claim, asserted on the surface
+    // that actually ships it.
+    const { dir, other, cleanup } = underRealHome();
+    try {
+      const sup = makeFakeSupervisor({ running: true, cwd: other });
+      const { app } = makeApp(baseDeps(sup));
+      const res = await request(app, "POST", "/api/launcher/cwd-preview", { cwd: dir });
+      const body = res.body as { drifted: boolean; suggestedCwd: string; claudeCwd: string };
+      expect(body.drifted).toBe(true);
+      expect(body.suggestedCwd.startsWith("~")).toBe(true);
+      expect(body.claudeCwd.startsWith("~")).toBe(true);
+      expect(body.suggestedCwd).not.toContain(os.homedir());
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("sheds concurrent probes rather than queueing filesystem work", async () => {
+    // `fsp.realpath` frees the event loop but holds a libuv threadpool slot for
+    // the full timeout on a hung mapped drive, and takes no AbortSignal — so
+    // unbounded concurrency here starves the pool that atomic saves and the
+    // annotation writer share, and the symptom is saves hanging with nothing
+    // pointing back at this route. Shedding costs nothing: every failure here is
+    // already "no drift".
+    const { dir, other, cleanup } = underRealHome();
+    let release: (() => void) | null = null;
+    const held = new Promise<void>((r) => {
+      release = r;
+    });
+    let entered = 0;
+    try {
+      const sup = makeFakeSupervisor({ running: true, cwd: other });
+      const { app } = makeApp({
+        ...baseDeps(sup),
+        cwdPreviewHook: async () => {
+          entered += 1;
+          await held;
+        },
+      });
+      const inFlight = Array.from({ length: 8 }, () =>
+        request(app, "POST", "/api/launcher/cwd-preview", { cwd: dir }),
+      );
+      // Give every request time to reach the gate before releasing anything.
+      await new Promise((r) => setTimeout(r, 150));
+      expect(
+        entered,
+        "more probes entered the counted region than the cap allows",
+      ).toBeLessThanOrEqual(3);
+      release?.();
+      const results = await Promise.all(inFlight);
+      for (const r of results) expect(r.status).toBe(200);
+      // The cap releases: a later request still gets a real answer.
+      const after = await request(app, "POST", "/api/launcher/cwd-preview", { cwd: dir });
+      expect((after.body as { drifted: boolean }).drifted).toBe(true);
+    } finally {
+      release?.();
       cleanup();
     }
   });

--- a/tests/server/launcher/cwd-preview.test.ts
+++ b/tests/server/launcher/cwd-preview.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Coverage for the working-directory drift preview (#1282).
+ *
+ * Two halves, tested against a real filesystem rather than mocks:
+ *
+ *   - the pure label helpers, which the CLIENT cannot compute and therefore
+ *     cannot cross-check;
+ *   - the verdict itself, whose entire job is to answer "no" in every case where
+ *     nudging would be wrong. The interesting assertions here are all negatives,
+ *     and each one corresponds to a way this feature could become a permanent
+ *     amber pill nobody can turn off.
+ *
+ * `homeOverride` + `platform` are the two seams that let this run identically on
+ * a Linux CI host and a Windows laptop. Without the platform seam the win32
+ * case-fold — the branch that matters on Tandem's primary desktop platform —
+ * would be exercised nowhere but a maintainer's machine.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  distinguishingLabel,
+  previewCwdDrift,
+  tildeAbbreviate,
+} from "../../../src/server/launcher/cwd-preview.js";
+import {
+  resolveRouteCwd,
+  resolveRouteCwdAsync,
+  resolveSafeCwd,
+  resolveSafeCwdAsync,
+  samePath,
+} from "../../../src/server/launcher/supervisor.js";
+
+let home: string;
+let projA: string;
+let projB: string;
+let sharedSrcA: string;
+let sharedSrcB: string;
+let bundled: string;
+let outside: string;
+
+beforeAll(() => {
+  // `realpath` the root: on macOS `os.tmpdir()` is a symlink to /private/var,
+  // and every path this module returns is realpath'd, so an un-resolved home
+  // would make `tildeAbbreviate` silently stop matching.
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "cwd-preview-")));
+  home = path.join(root, "home");
+  projA = path.join(home, "projects", "alpha");
+  projB = path.join(home, "projects", "beta");
+  sharedSrcA = path.join(projA, "src");
+  sharedSrcB = path.join(projB, "src");
+  bundled = path.join(home, "AppData", "Local", "Tandem", "sample");
+  outside = path.join(root, "elsewhere");
+  for (const d of [sharedSrcA, sharedSrcB, bundled, outside]) {
+    fs.mkdirSync(d, { recursive: true });
+  }
+});
+
+afterAll(() => {
+  fs.rmSync(path.dirname(home), { recursive: true, force: true });
+});
+
+describe("distinguishingLabel", () => {
+  it("stops at the first segment that differs", () => {
+    expect(distinguishingLabel("/home/u/notes", "/home/u/alpha", "linux")).toBe("notes");
+  });
+
+  it("walks up until the paths actually diverge", () => {
+    // The case `basename` gets wrong: two `src` directories in two projects.
+    // A basename label would name both folders "src", which is not a shorter
+    // answer — it is the wrong one.
+    expect(distinguishingLabel("/home/u/alpha/src", "/home/u/beta/src", "linux")).toBe(
+      path.join("alpha", "src"),
+    );
+  });
+
+  it("distinguishes two worktrees of one repository", () => {
+    expect(
+      distinguishingLabel("/home/u/wt/feature/tandem", "/home/u/wt/main/tandem", "linux"),
+    ).toBe(path.join("feature", "tandem"));
+  });
+
+  it("elides once the divergence is deeper than the cap", () => {
+    const a = "/home/u/a/one/two/three/four";
+    const b = "/home/u/b/one/two/three/four";
+    const label = distinguishingLabel(a, b, "linux");
+    expect(label.startsWith("…")).toBe(true);
+    expect(label.endsWith(path.join("two", "three", "four"))).toBe(true);
+  });
+
+  it("falls back to the last segment when one path is a suffix of the other", () => {
+    expect(distinguishingLabel("/home/u/alpha", "/alpha", "linux")).toBe("alpha");
+  });
+
+  it("folds case on win32 and not elsewhere", () => {
+    // Same directory, differently cased. On Windows these must be treated as
+    // equal — so the divergence is found one level up, not at the leaf.
+    expect(distinguishingLabel("C:\\U\\Alpha\\Src", "C:\\U\\beta\\src", "win32")).toBe(
+      path.join("Alpha", "Src"),
+    );
+    expect(distinguishingLabel("/u/alpha/Src", "/u/beta/src", "linux")).toBe("Src");
+  });
+
+  it("splits on both separators regardless of host platform", () => {
+    // A Windows path reaching a Linux CI host: splitting on `path.sep` alone
+    // would yield one enormous segment and a useless label.
+    expect(distinguishingLabel("C:\\u\\alpha", "C:\\u\\beta", "linux")).toBe("alpha");
+  });
+});
+
+describe("tildeAbbreviate", () => {
+  it("replaces the home prefix", () => {
+    expect(tildeAbbreviate("/home/u/projects/alpha", "/home/u", "linux")).toBe(
+      `~${path.sep}${path.join("projects", "alpha")}`,
+    );
+  });
+
+  it("renders home itself as ~ rather than exposing the account name", () => {
+    expect(tildeAbbreviate("/home/rebecca", "/home/rebecca", "linux")).toBe("~");
+  });
+
+  it("leaves a path outside home alone", () => {
+    expect(tildeAbbreviate("/opt/thing", "/home/u", "linux")).toBe("/opt/thing");
+  });
+
+  it("does not treat a sibling with a shared prefix as inside home", () => {
+    // `/home/user2` starts with the string `/home/user` but is not under it.
+    expect(tildeAbbreviate("/home/user2/x", "/home/user", "linux")).toBe("/home/user2/x");
+  });
+});
+
+describe("previewCwdDrift", () => {
+  const base = (over: Partial<Parameters<typeof previewCwdDrift>[0]> = {}) => ({
+    candidate: projA,
+    claudeCwd: projB,
+    bundledDocDirs: [] as readonly string[],
+    homeOverride: home,
+    ...over,
+  });
+
+  it("reports drift between two real, home-confined folders", async () => {
+    const out = await previewCwdDrift(base());
+    expect(out.drifted).toBe(true);
+    if (!out.drifted) return;
+    expect(out.suggestedCwd).toBe(`~${path.sep}${path.join("projects", "alpha")}`);
+    expect(out.claudeCwd).toBe(`~${path.sep}${path.join("projects", "beta")}`);
+    expect(out.label).toBe("alpha");
+    expect(out.claudeLabel).toBe("beta");
+  });
+
+  it("says nothing when the launcher is not running", async () => {
+    // The manually-launched-Claude case (#1054). Silence is correct here: the
+    // only action the nudge offers would spawn a SECOND agent.
+    expect(await previewCwdDrift(base({ claudeCwd: null }))).toEqual({ drifted: false });
+  });
+
+  it("says nothing when Claude is already in the target folder", async () => {
+    expect(await previewCwdDrift(base({ claudeCwd: projA }))).toEqual({ drifted: false });
+  });
+
+  it("says nothing for a folder outside the user's home directory", async () => {
+    expect(await previewCwdDrift(base({ candidate: outside }))).toEqual({ drifted: false });
+  });
+
+  it("says nothing for a relative path", async () => {
+    expect(await previewCwdDrift(base({ candidate: "projects/alpha" }))).toEqual({
+      drifted: false,
+    });
+  });
+
+  it("says nothing for a folder that does not exist", async () => {
+    expect(await previewCwdDrift(base({ candidate: path.join(home, "gone") }))).toEqual({
+      drifted: false,
+    });
+  });
+
+  it("says nothing when the candidate is a file rather than a directory", async () => {
+    const file = path.join(projA, "README.md");
+    fs.writeFileSync(file, "# hi\n");
+    expect(await previewCwdDrift(base({ candidate: file }))).toEqual({ drifted: false });
+  });
+
+  it("says nothing for Tandem's own bundled document folders", async () => {
+    // Without this the two states EVERY desktop user passes through — first run
+    // (welcome.md) and every upgrade (CHANGELOG.md) — would each open with a
+    // suggestion to move Claude inside Tandem's install directory. On Windows
+    // those live under %LOCALAPPDATA%, i.e. inside home, so they pass every
+    // other check here.
+    expect(await previewCwdDrift(base({ candidate: bundled, bundledDocDirs: [bundled] }))).toEqual({
+      drifted: false,
+    });
+    // ...but a DIFFERENT folder is still reported, i.e. the exclusion is exact.
+    // In a development checkout the bundled dir resolves to the repository root;
+    // suppressing that whole tree would silence the nudge for anyone using
+    // Tandem to work on Tandem.
+    const out = await previewCwdDrift(base({ candidate: projA, bundledDocDirs: [bundled] }));
+    expect(out.drifted).toBe(true);
+  });
+
+  it("normalizes Claude's side too, so a symlinked home is not a permanent nudge", async () => {
+    // `resolveCwd`'s default branch can return an un-realpath'd `os.homedir()`
+    // while the candidate is always realpath'd. Where home contains a symlink
+    // the two differ as strings for ONE directory — which would render a
+    // permanent pill pointing at the folder Claude is already sitting in.
+    const link = path.join(home, "alpha-link");
+    try {
+      fs.symlinkSync(projA, link, "junction");
+    } catch {
+      return; // unprivileged Windows without Developer Mode — skip
+    }
+    expect(await previewCwdDrift(base({ candidate: projA, claudeCwd: link }))).toEqual({
+      drifted: false,
+    });
+  });
+
+  it("still compares when Claude's folder has been deleted underneath it", async () => {
+    // A cwd that no longer resolves is a real problem, not a reason to go quiet.
+    const gone = path.join(home, "deleted-under-claude");
+    expect((await previewCwdDrift(base({ claudeCwd: gone }))).drifted).toBe(true);
+  });
+
+  it("folds case only on win32 when comparing an unresolvable folder", async () => {
+    // Case folding only has anything to bite on when a side does NOT resolve:
+    // when it does, `realpath` returns the on-disk casing and both sides already
+    // agree. So this exercises the raw-string fallback. `alpha` differs from
+    // `ALPHA` by case alone; on Windows they name one folder, on POSIX two.
+    const unresolvable = path.join(home, "ghost", "ALPHA");
+    const candidateSibling = path.join(home, "ghost", "alpha");
+    fs.mkdirSync(candidateSibling, { recursive: true });
+    const resolved = fs.realpathSync(candidateSibling);
+    expect(
+      await previewCwdDrift(
+        base({ candidate: resolved, claudeCwd: unresolvable, platform: "win32" }),
+      ),
+    ).toEqual(
+      // On a Windows host `realpath` normalizes `ALPHA` to the real casing and
+      // the fallback never runs, so both platforms agree it is the same folder.
+      { drifted: false },
+    );
+    const posix = await previewCwdDrift(
+      base({ candidate: resolved, claudeCwd: unresolvable, platform: "linux" }),
+    );
+    // On a POSIX host the ghost path really is a different directory.
+    expect(posix.drifted).toBe(process.platform !== "win32");
+  });
+
+  it("labels sibling `src` folders distinguishably", async () => {
+    const out = await previewCwdDrift(base({ candidate: sharedSrcA, claudeCwd: sharedSrcB }));
+    expect(out.drifted).toBe(true);
+    if (!out.drifted) return;
+    expect(out.label).toBe(path.join("alpha", "src"));
+    expect(out.claudeLabel).toBe(path.join("beta", "src"));
+  });
+
+  it("never leaks the raw home path into the response", async () => {
+    const out = await previewCwdDrift(base());
+    expect(out.drifted).toBe(true);
+    if (!out.drifted) return;
+    for (const field of [out.suggestedCwd, out.claudeCwd, out.label, out.claudeLabel]) {
+      expect(field).not.toContain(home);
+    }
+  });
+});
+
+describe("sync/async resolver equivalence", () => {
+  /**
+   * The async resolvers exist because the preview runs at tab-switch frequency
+   * and `statSync` on a disconnected mapped drive blocks the whole event loop.
+   * Two resolvers that could disagree about which paths are acceptable is the
+   * split-predicate defect this feature was filed for, so the pair is pinned
+   * here rather than trusted to stay in step.
+   */
+  it("agrees on every case, safe variant", async () => {
+    const cases = [
+      () => projA,
+      () => path.join(home, "nope"),
+      () => "relative/path",
+      () => "",
+      () => path.join(projA, "README.md"),
+      () => outside,
+      () => "\\\\server\\share",
+      () => "\\\\?\\C:\\Windows",
+    ];
+    for (const mk of cases) {
+      const c = mk();
+      expect(await resolveSafeCwdAsync(c)).toBe(resolveSafeCwd(c));
+    }
+  });
+
+  it("agrees on every case, home-confined variant", async () => {
+    for (const c of [projA, outside, path.join(home, "nope"), home]) {
+      expect(await resolveRouteCwdAsync(c, { homeOverride: home })).toBe(
+        resolveRouteCwd(c, { homeOverride: home }),
+      );
+    }
+  });
+});
+
+describe("samePath", () => {
+  it("folds case on win32 only", () => {
+    expect(samePath("C:\\A", "c:\\a", "win32")).toBe(true);
+    expect(samePath("/A", "/a", "linux")).toBe(false);
+    expect(samePath("/a", "/a", "linux")).toBe(true);
+  });
+
+  it("does not treat a parent as equal to its child", () => {
+    expect(samePath("/home/u", "/home/u/x", "linux")).toBe(false);
+  });
+});

--- a/tests/server/launcher/cwd-preview.test.ts
+++ b/tests/server/launcher/cwd-preview.test.ts
@@ -35,6 +35,10 @@ import {
   samePath,
 } from "../../../src/server/launcher/supervisor.js";
 
+/** Build a Windows-shaped path without writing backslash escapes inline. */
+const BACKSLASH = String.fromCharCode(92);
+const WIN = (parts: string[]): string => parts.join(BACKSLASH);
+
 let home: string;
 let projA: string;
 let projB: string;
@@ -73,23 +77,27 @@ describe("distinguishingLabel", () => {
     // The case `basename` gets wrong: two `src` directories in two projects.
     // A basename label would name both folders "src", which is not a shorter
     // answer — it is the wrong one.
-    expect(distinguishingLabel("/home/u/alpha/src", "/home/u/beta/src", "linux")).toBe(
-      path.join("alpha", "src"),
-    );
+    expect(distinguishingLabel("/home/u/alpha/src", "/home/u/beta/src", "linux")).toBe("alpha/src");
   });
 
   it("distinguishes two worktrees of one repository", () => {
     expect(
       distinguishingLabel("/home/u/wt/feature/tandem", "/home/u/wt/main/tandem", "linux"),
-    ).toBe(path.join("feature", "tandem"));
+    ).toBe("feature/tandem");
   });
 
-  it("elides once the divergence is deeper than the cap", () => {
-    const a = "/home/u/a/one/two/three/four";
-    const b = "/home/u/b/one/two/three/four";
-    const label = distinguishingLabel(a, b, "linux");
-    expect(label.startsWith("…")).toBe(true);
-    expect(label.endsWith(path.join("two", "three", "four"))).toBe(true);
+  it("elides the MIDDLE, keeping the segment that actually differs", () => {
+    // Eliding the front would return the last three segments — which are
+    // identical in both paths by definition, so both folders would come back
+    // named the same thing. That is the exact failure this function exists to
+    // prevent, reintroduced by its own fallback.
+    const a = "/home/u/alpha/one/two/three/four";
+    const b = "/home/u/beta/one/two/three/four";
+    const la = distinguishingLabel(a, b, "linux");
+    const lb = distinguishingLabel(b, a, "linux");
+    expect(la).toBe("alpha/…/four");
+    expect(lb).toBe("beta/…/four");
+    expect(la).not.toBe(lb);
   });
 
   it("falls back to the last segment when one path is a suffix of the other", () => {
@@ -99,24 +107,43 @@ describe("distinguishingLabel", () => {
   it("folds case on win32 and not elsewhere", () => {
     // Same directory, differently cased. On Windows these must be treated as
     // equal — so the divergence is found one level up, not at the leaf.
-    expect(distinguishingLabel("C:\\U\\Alpha\\Src", "C:\\U\\beta\\src", "win32")).toBe(
-      path.join("Alpha", "Src"),
-    );
+    expect(
+      distinguishingLabel(
+        WIN(["C:", "U", "Alpha", "Src"]),
+        WIN(["C:", "U", "beta", "src"]),
+        "win32",
+      ),
+    ).toBe(WIN(["Alpha", "Src"]));
     expect(distinguishingLabel("/u/alpha/Src", "/u/beta/src", "linux")).toBe("Src");
   });
 
   it("splits on both separators regardless of host platform", () => {
     // A Windows path reaching a Linux CI host: splitting on `path.sep` alone
     // would yield one enormous segment and a useless label.
-    expect(distinguishingLabel("C:\\u\\alpha", "C:\\u\\beta", "linux")).toBe("alpha");
+    expect(distinguishingLabel(WIN(["C:", "u", "alpha"]), WIN(["C:", "u", "beta"]), "linux")).toBe(
+      "alpha",
+    );
+  });
+
+  it("joins with the SEAM's separator, not the host's", () => {
+    // Every other expectation in this block is built with `path.join`, i.e. with
+    // the same host primitive the implementation uses — so on a Linux CI host an
+    // implementation that hardcoded "/" would satisfy all of them. These two pin
+    // the separator against the platform argument instead.
+    expect(
+      distinguishingLabel(
+        WIN(["C:", "u", "alpha", "src"]),
+        WIN(["C:", "u", "beta", "src"]),
+        "win32",
+      ),
+    ).toBe(WIN(["alpha", "src"]));
+    expect(distinguishingLabel("/u/alpha/src", "/u/beta/src", "linux")).toBe("alpha/src");
   });
 });
 
 describe("tildeAbbreviate", () => {
   it("replaces the home prefix", () => {
-    expect(tildeAbbreviate("/home/u/projects/alpha", "/home/u", "linux")).toBe(
-      `~${path.sep}${path.join("projects", "alpha")}`,
-    );
+    expect(tildeAbbreviate("/home/u/projects/alpha", "/home/u", "linux")).toBe("~/projects/alpha");
   });
 
   it("renders home itself as ~ rather than exposing the account name", () => {
@@ -130,6 +157,21 @@ describe("tildeAbbreviate", () => {
   it("does not treat a sibling with a shared prefix as inside home", () => {
     // `/home/user2` starts with the string `/home/user` but is not under it.
     expect(tildeAbbreviate("/home/user2/x", "/home/user", "linux")).toBe("/home/user2/x");
+  });
+
+  it("works on Windows-shaped paths, on any host", () => {
+    // This is the function whose stated job is keeping a real full name out of
+    // screenshots on the one platform where the account name usually IS the
+    // person's full name — so it has to be exercised with a Windows path, and a
+    // platform enum alone could not do that while `path.relative` came from the
+    // host.
+    const winHome = WIN(["C:", "Users", "Ada Lovelace"]);
+    expect(tildeAbbreviate(WIN([winHome, "projects"]), winHome, "win32")).toBe(
+      WIN(["~", "projects"]),
+    );
+    expect(tildeAbbreviate(winHome, winHome, "win32")).toBe("~");
+    // Case-insensitively the same directory on Windows.
+    expect(tildeAbbreviate(winHome.toUpperCase(), winHome, "win32")).toBe("~");
   });
 });
 
@@ -263,6 +305,43 @@ describe("previewCwdDrift", () => {
     for (const field of [out.suggestedCwd, out.claudeCwd, out.label, out.claudeLabel]) {
       expect(field).not.toContain(home);
     }
+  });
+
+  it("never leaks the account name when Claude is in home — the DEFAULT case", async () => {
+    // The launcher's fallback cwd IS home (`resolveCwd` → `homeCwd()`, taken
+    // whenever no `workingDirectory` is configured), so this is what a fresh
+    // install with any document open produces. Labels used to be computed from
+    // the RAW paths, and `distinguishingLabel` of a home path against a subfolder
+    // returns home's basename — which on every platform is the account name. The
+    // pill read "Claude in bryan.kolbeck". The full-path assertion above did not
+    // catch it, because only the basename escaped.
+    //
+    // The fixture's home basename is literally "home", so assert on a directory
+    // named like a real account instead.
+    const account = path.join(path.dirname(home), "ada.lovelace");
+    const project = path.join(account, "projects", "api");
+    fs.mkdirSync(project, { recursive: true });
+    const out = await previewCwdDrift({
+      candidate: project,
+      claudeCwd: account,
+      bundledDocDirs: [],
+      homeOverride: account,
+    });
+    expect(out.drifted).toBe(true);
+    if (!out.drifted) return;
+    expect(out.claudeLabel).toBe("~");
+    for (const field of [out.suggestedCwd, out.claudeCwd, out.label, out.claudeLabel]) {
+      expect(field, field).not.toContain("ada.lovelace");
+    }
+  });
+
+  it("keeps sibling folders distinguishable after abbreviation", async () => {
+    // The fix for the leak above rewrites the label inputs, so pin that it did
+    // not flatten the case the labels exist for.
+    const out = await previewCwdDrift(base({ candidate: sharedSrcA, claudeCwd: sharedSrcB }));
+    expect(out.drifted).toBe(true);
+    if (!out.drifted) return;
+    expect(out.label).not.toBe(out.claudeLabel);
   });
 });
 


### PR DESCRIPTION
## What

Claude Code scopes what it can read to the directory it was started in — `CLAUDE.md`, `.claude/`, git history, and everything its own file tools can reach. Tandem lets you open a document from anywhere, so the two routinely disagree, and nothing said so. You get a Claude that edits the document competently and knows nothing about the project around it.

This adds an amber status-bar pill naming the mismatch, with a menu that explains it and offers to move Claude. Part 2 of #1282; Part 1 (#1305) is the prerequisite that made the offer worth making — before it, "restart Claude here" destroyed the conversation and left Claude where it started.

## The server decides; the client renders

Every judgement is server-side (`POST /api/launcher/cwd-preview`): validity, sameness, exclusions, labels. The client sends the folder a relaunch *would* target and holds the answer.

That division is the whole architecture, and #1282's own post-mortem is why — "the client's derivation and the server's rejection were each tested in isolation and never together." So:

- The client sends its **own** `deriveCwdFromDocPath(activeDocumentPath)`, the exact value the relaunch request carries. Preview and action cannot be about different folders.
- The length cap and the path resolution live in **one** `precheckCwdField`, shared with the mutating routes. Deleting it breaks the relaunch tests, not just the preview's — that is the point.
- The response is a single collapsed `{ drifted: false }` for every no-case. A client that could tell "outside home" from "same folder" would have a probe for what exists under the user's home directory.

## The negatives are the feature

Almost every interesting case is a "don't nudge", and each one is a way this becomes a permanent amber pill:

| Case | Why silent |
|---|---|
| Launcher not running | Manually-launched Claude (#1054) is invisible to the supervisor. The only action offered would spawn a **second** agent. |
| Tandem's own bundled docs | `welcome.md` (first run) and `CHANGELOG.md` (every upgrade) live in the app bundle, which on Windows is under `%LOCALAPPDATA%` — **inside** home. Valid, home-confined, drifting. Without this, every Windows first run opens by suggesting Claude move into Tandem's install directory. Matched **exactly**, not by prefix: in a dev checkout that path is the repo root, and suppressing the tree would silence the nudge for anyone using Tandem to work on Tandem. |
| Both sides normalized | Both sides of the comparison are canonicalized, so a string mismatch can never render a permanent pill pointing at the folder Claude is already in. (The original justification here named a symlinked home — the review found that wrong: `resolveCwd` realpaths both its branches, and realpath is exactly what resolves a symlink. What remains is `homeCwd()`'s own fallback when home is unresolvable, and a cwd from a hand-edited `integrations.json`.) |

Issue #1282 says these paths are "outside the user's home directory in both cases." That is wrong for Windows — `tauri.conf.json` sets no NSIS `installMode`, so the installer defaults to `currentUser`.

## Fatigue is the real risk, and it needed three layers

The default working directory is `os.homedir()` and the check requires the candidate to be *inside* home. So for anyone who has never set a working directory, **every document in every subfolder drifts.** This is not an occasional nudge about an occasional mistake; untreated it is a permanent pill.

1. **Per-pair dismissal**, keyed on `(Claude's folder, target folder)` — never the target alone. Dismiss "move to ~/notes" while Claude is in home, later move Claude to a project, reopen the note: keyed on the target that is still suppressed, though the situation is now strictly worse. The key is length-prefixed, not delimiter-joined; any delimiter can legally appear in a POSIX folder name, and `("~/a|~/b", "~/c")` and `("~/a", "~/b|~/c")` would collide.
2. **Session backstop** at 3 dismissals, for the user who parks Claude in one folder and edits everywhere. It **announces itself** — going quiet silently makes "Claude is in the right folder now" and "Tandem stopped mentioning it" look identical.
3. **Permanent opt-out.** The plan deferred this; the arithmetic above says it is not deferrable. A failed `localStorage` write is reported, so the toast promises a session rather than a durability it cannot deliver.

Plus a ~1.5s settle before probing, so tab-flicking never flashes a pill — and never issues a request.

## Placement

A **sibling** of the AI indicator, not part of it. The obvious placement is dead code in exactly the state the nudge exists for: `aiIndicatorView` returns `null` for `ready` + no MCP session — the auto-launched desktop startup window, where the launcher is running (so has a folder to be wrong about) and no agent has connected.

Two adjacent Claude chips is the #1268 shape only if they can coexist, and they cannot: `aiChip` is non-null only for `unconfigured`/`stopped`, both meaning the launcher is not running, and drift is reported only when it is. They overlap only transiently — Claude dying between a drift probe and the next readiness poll — so `aiChip` wins outright. That gate never turns a `false` into a `true`; it is staleness handling, not a second copy of the server's predicate.

The pill is a **menu trigger**, not a one-click action. A bare inline `×` lands ~10px against WCAG 2.2 SC 2.5.8's 24×24 minimum and would be the only sub-24px control in a bar where `.status-ai-indicator` already carries `min-height: 24px`. Three full-size rows clear it, and the menu is the only place with room for the explanation a ten-pixel chip cannot give.

Copy names the consequence, not a connection state: the document still syncs and Claude can still edit it; what is degraded is everything *around* it.

## Also here

- `POST /api/launcher/cwd-preview` gates on the origin allowlist plus a **bare loopback check**, not `assertLoopbackForMutation` — that helper only rejects under `TANDEM_ALLOW_UNAUTHENTICATED_LAN=1`, so in the default configuration it reads as a gate while enforcing nothing. The response reconstructs the launcher `cwd` that `GET /status` withholds off-loopback. Same posture as `/api/document/raw` and `/api/diagnostics`.
- **No nonce**, and a test pins that a preview does not consume the relaunch's — rotating it would 403 the click the pill just advertised.
- **Async path resolvers** (`resolveSafeCwdAsync` / `resolveRouteCwdAsync`). The sync pair is `realpathSync` + `statSync`: fine once per launch, wrong at tab-switch frequency, where a document on a disconnected mapped drive blocks the event loop for the SMB timeout. UNC is rejected before any I/O; a mapped drive letter looks entirely ordinary. Both pure halves are shared with the sync pair and an equivalence test runs one case table through both.
- `samePath` extracted from `sessionCwdMatches` so the Windows case-fold has one home, with the same injectable `platform` seam (CI is ubuntu-only).
- Forced-colors rule added to `.status-warning-pill` — a pre-existing gap affecting `Review Only` and `N held` too, fixed here because the drift pill carries the same recipe.

## Tests

Real filesystems, not mocks. 60+ new cases across the verdict matrix, route gates, label helpers, resolver equivalence, hook timing/abort/fail-safe, the three suppression layers, and pill rendering + menu interaction.

**24 mutations run; all 24 killed.** Two survived the first pass and both were real:

- The over-length test passed with the cap deleted — an over-length path fails to resolve anyway, so it proved nothing. Fixed structurally rather than with a fragile 1024-character-path fixture: the cap now lives in one `precheckCwdField` that the relaunch route also calls, so removing it fails the relaunch's tests.
- The pair-key collision test used `("~/a", "~/b/c")` vs `("~/a/b", "~/c")`, which do **not** collide under a `|` join. The real collision needs a delimiter *inside* a path.

Two other test bugs surfaced by running them rather than reading them: a `Storage.prototype` spy that happy-dom never routes through (installed cleanly, intercepted nothing, and the accompanying assertion passed on the default — vacuous both ways), and an "outside home" fixture built on `os.tmpdir()`, which on Windows is `%LOCALAPPDATA%\Temp` — *inside* home, asserting the opposite of its name.

`npm run typecheck` clean (1299 files). Full suite: 5823 passed, 21 skipped, 0 failed.

## Not done, deliberately

- **No E2E.** The E2E server runs against a wiped `TANDEM_APP_DATA_DIR` with no `claude-code` integration, so the supervisor is null and the route always answers `drifted: false`. An E2E here would either test a stub or need a fixture integration; the App.svelte↔pill wiring seam is genuinely uncovered and I would rather say so than fake it.
- **No Settings toggle** to undo the permanent opt-out. `driftNudgeOptedOut()` is exported for it; clearing the key is currently a devtools operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Review round (commit 2)

Six review passes — correctness, silent failures, test vacuity, Svelte 5, security, comment accuracy. Fourteen findings acted on; the notable ones:

## The pill was rendering the user's account name

Default configuration, not an edge case. The launcher's fallback cwd **is** `$HOME` (`resolveCwd` → `homeCwd()`, taken whenever no `workingDirectory` is configured), and `distinguishingLabel` of a home path against a subfolder returns home's basename — which on every platform is the account name. A fresh install with any document open rendered **"Claude in bryan.kolbeck"** in the status bar, and repeated it in the `title` and `aria-label`.

Labels now derive from the tilde-abbreviated paths, so that case reads "Claude in ~". Nothing else moves: paths outside home abbreviate to themselves, sibling worktrees still yield `alpha/src` and `beta/src`.

The guard test that should have caught it asserted `not.toContain(home)` — the *full* path. Only the basename escaped. Its replacement uses a fixture directory named like a real account.

## The label's own fallback reintroduced the bug it prevents

Past `MAX_LABEL_SEGMENTS`, elision returned the last three segments — which are **identical in both paths by definition**. Both folders came back named `…/x/y/z`. The docstring four lines above says "a label that names both folders the same thing is not a smaller label, it is a wrong one." It now elides the middle and keeps the diverging segment: `alpha/…/four` vs `beta/…/four`.

## `platform` was a half-seam

It selected the case-fold while `path.sep` and `path.relative` still came from the host. Every expectation was written with `path.join` — the same primitive the implementation used — so on Linux CI an implementation that hardcoded `"/"` would have passed all of them, and `tildeAbbreviate` could not be exercised with a Windows path **at all**. That is the function whose entire purpose is keeping a real full name out of screenshots on the one platform where the account name usually *is* the full name.

`platform` now selects the path flavour (`path.win32` / `path.posix`), and the Windows cases run everywhere.

## The explainer pointed at a chip that wasn't there

`cwdDriftPill` suppresses the pill when an AI CTA is showing; the one-time explainer gated only on `visibleCwdDrift`. In the overlap window it fired, **spent the once-per-install token**, and directed the user to an amber chip that had been suppressed — permanently, since the token is persisted.

Lesson 90's shape exactly, and the irony is that both files argue at length that this logic must live in one place. The composed view is now computed once in `App` and passed down; `StatusBar` renders what it is handed.

## Every launcher action re-probes, by construction

The palette invoked the same relaunch directly and never called `refreshAiReadinessAfterLauncherAction` — so after a palette relaunch the pill went on naming the folder Claude had just left, indefinitely, which is precisely what that refresh exists to prevent. The refresh moved into the exported actions, and **the test written for it immediately found a second instance** in the start-fresh palette entry.

## Also fixed

- **The hook validates before trusting.** A `drifted: true` with a missing field rendered "Claude is running in undefined" *and* poisoned the dismissal key, so dismissing that nonsense pair would suppress every real drift afterwards. The one path in the feature where a bad answer became a confident false statement rather than silence.
- **Failure paths use the same supersession guard as the success path.** A real `fetch` **rejects** on abort and the cleanup aborts on every re-run, so guarding on `mounted` alone blanked the pill on every tab switch and on both post-relaunch refreshes.
- **Focus.** Dismiss and opt-out unmount the component *and* its trigger; restoring focus there dropped keyboard users on `<body>`. They now hand focus to the status bar. The relaunch row keeps the trigger — it opens a modal and stays mounted.
- **"Don't show this again" is no longer a one-way door** — a palette command reverses it, and `driftNudgeOptedOut` finally has a consumer.
- **`noteDriftSeen` declines to claim what it cannot record.** Returning true on an unwritable store looked like "degrade to once per session", but the degradation compounds: the same store can't hold the opt-out either, so a storage-disabled browser replayed the four-sentence explainer *every launch, forever* — including to someone who had clicked "don't show this again".
- **Concurrency cap.** `fsp.realpath` frees the event loop but holds a libuv threadpool slot for the full SMB timeout and takes no `AbortSignal`, so concurrent probes against a hung mapped drive would starve the pool that atomic saves and the annotation writer share — surfacing as saves hanging, with nothing pointing here.
- **Three permanent-failure states now log once**: an unresolvable home (which silently disables the feature for a whole machine and, critically, returns *normally* — the route's `catch` never sees it), a rejected probe (404 in a build without launcher routes, 403 off-loopback), and an empty bundled-doc list.
- **`runningCwd`'s inner catch deleted the route's only diagnostic** for the failure it is least prepared for. Removed; the handler's catch already answers identically *and* logs.

## Comment corrections, each verified against source

`resolveCwd` already realpaths both branches (`homeCwd()` is `resolveSafeCwd(os.homedir()) ?? os.homedir()`), so the symlink causal story was wrong — the code is fine, the explanation wasn't. The module-scope justification described a `StatusBar` remount that cannot happen (it renders unconditionally, and doesn't consume the state). Only `CHANGELOG.md` resolves to the repo root; `welcome.md` resolves to `<repo>/sample`. The pair-key collision example did not collide. The word-count button is also sub-24px. And a comment cited a test file that does not exist.

## Tests

**24 mutations, all 24 killed.** Two more vacuous tests replaced — the abort case was written against a stub that never rejects on abort (so it proved nothing about the guard it was named for), and the concurrency cap was asserted by a test that passed with the cap deleted; it now uses the file's existing in-flight hook seam.

Also worth recording: several "anchor not found" mutation misses turned out to be **CRLF line endings in the working copy**, not missing guards. A multi-line anchor silently matches nothing on a CRLF file — a mutation harness that reports that as a skip looks exactly like a guard that isn't there.

`npm run typecheck` clean (1299 files). Full suite: 5845 passed, 21 skipped, 0 failed.
