### PR TITLE
fix(files): accept .markdown, fix the User Guide link, stop long paths overflowing (#1306, #1270, #1269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Without the flag nothing breaks and nothing is lost: your messages and comments 
 
 ### What you get
 
-- Multiple documents open in tabs, with `.md`, `.txt`, `.html`, and `.docx` support (Word files are editable; the original is only written when you explicitly save).
+- Multiple documents open in tabs, with `.md`, `.markdown`, `.txt`, `.html`, and `.docx` support (Word files are editable; the original is only written when you explicitly save).
 - A scratchpad (`Ctrl+N`) for drafts you do not want to save to disk.
 - A command palette (`Ctrl+Shift+P`) with fuzzy search, ranked by how well each result matches.
 - Find and replace, including across all open tabs.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Windows 10 version 22H2 or Windows 11. macOS 12 (Monterey) or later. Linux with 
 
 Pick the installer for your platform from the [latest release](https://github.com/bloknayrb/tandem/releases/latest). Windows, macOS, and Linux builds are available.
 
-The desktop app bundles the editor, the server it talks to, and storage for the connection token. Updates land automatically. Double-clicking a `.md`, `.txt`, `.html`, or `.docx` file opens it directly in Tandem.
+The desktop app bundles the editor, the server it talks to, and storage for the connection token. Updates land automatically. Double-clicking a `.md`, `.markdown`, `.txt`, `.html`, or `.docx` file opens it directly in Tandem.
 
 ### Connect your AI
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,7 +245,7 @@ On server startup, `listSessionFilePaths()` scans the session directory and `res
 
 ### OS File-Association Open
 
-When the Tauri desktop app is launched via the OS file-association handler (double-clicking a `.md` / `.txt` / `.html` / `.docx` file in Finder, Explorer, or a Linux file manager), the file path reaches the editor via three platform-specific routes:
+When the Tauri desktop app is launched via the OS file-association handler (double-clicking a `.md` / `.markdown` / `.txt` / `.html` / `.docx` file in Finder, Explorer, or a Linux file manager), the file path reaches the editor via three platform-specific routes:
 
 ```
 Cold start, Windows / Linux:

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -117,7 +117,7 @@ tandem_open({ filePath: "C:\\Users\\bkolb\\Documents\\progress-report-feb.md" })
 ```
 
 **Notes:**
-- Supported formats: `.md`, `.txt`, `.html`, `.docx`. All open editable; `.docx` is written back only on an explicit save (auto-save skips it).
+- Supported formats: `.md`, `.markdown`, `.txt`, `.html`, `.htm`, `.docx`. All open editable; `.docx` is written back only on an explicit save (auto-save skips it). `.markdown` and `.htm` are aliases — `detectFormat` folds them into `md` and `html`, and the file keeps its own extension on save.
 - Editor opens automatically in the Tauri WebView (desktop) or at `http://127.0.0.1:5173` (development) on the first call.
 - Opening a file that's already open switches to its tab (returns `alreadyOpen: true`).
 - **Auto-reload:** Open documents are automatically reloaded when the file changes on disk (e.g., Claude's Edit tool, `git pull`). Annotations are preserved. A toast notification appears in the editor.

--- a/sample/welcome.md
+++ b/sample/welcome.md
@@ -4,7 +4,7 @@ Tandem lets you work on documents with an AI — by default Claude, but any MCP-
 
 ## Getting Started
 
-> Follow the tutorial in the bottom-left corner to learn the basics. You can dismiss it at any time. For a full walkthrough of all features, see the [User Guide](../docs/user-guide.md).
+> Follow the tutorial in the bottom-left corner to learn the basics. You can dismiss it at any time. For a full walkthrough of all features, see the [User Guide](https://github.com/bloknayrb/tandem/blob/master/docs/user-guide.md) (opens in your browser).
 
 Open Claude Code from any directory — your Tandem tools are already configured. Both you and your AI can see and edit this document at the same time. Your AI's cursor appears as a soft blue highlight on the paragraph being read, and a typing indicator shows when it's writing.
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -95,9 +95,18 @@ const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(8 * 60 * 60);
 const COWORK_HEAL_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
 /// File extensions Tandem can open via OS file association. Keep aligned with
-/// `SUPPORTED_EXTENSIONS` in `src/server/mcp/file-opener.ts` — server-side is
-/// the authority; this list is defense-in-depth to reject obviously-wrong argv
-/// before issuing an HTTP request.
+/// `SUPPORTED_EXTENSIONS` in `src/shared/constants.ts` (re-exported through
+/// `src/server/mcp/file-opener.ts`) — server-side is the authority; this list is
+/// defense-in-depth to reject obviously-wrong argv before issuing an HTTP
+/// request.
+///
+/// "Keep aligned" was the whole instruction and it still drifted (#1306):
+/// `markdown` sat in this list and in `tauri.conf.json` while the server
+/// rejected it, and the failure is silent — `maybeOpenStartupFile` swallows the
+/// open error and falls through to `welcome.md`. The alignment is now pinned by
+/// `tests/build/file-association-alignment.test.ts`, which parses this literal
+/// out of the source, so renaming or reshaping the constant fails that test
+/// rather than silently stopping the check.
 pub(crate) const SUPPORTED_FILE_ASSOC_EXTS: &[&str] =
     &["md", "markdown", "txt", "html", "docx"];
 

--- a/src/client/components/ActivityTray.svelte
+++ b/src/client/components/ActivityTray.svelte
@@ -698,9 +698,24 @@ onDestroy(() => {
     line-height: 1.4;
     color: var(--tandem-fg);
   }
+  /* `min-width: 0` lets this flex item shrink below its min-content width, but on
+     its own that only permits the SHRINK — it grants the text no place to break.
+     Activity messages routinely end in a filesystem path
+     ("Claude restarting in C:\Users\…\com.tandem.editor\sample"), which is one
+     unbroken word: no space, and `\` is not a break opportunity. So the line
+     rendered at its full min-content width and spilled out of the row, where the
+     shell's `overflow: clip` sheared it mid-character (#1269).
+
+     `anywhere` rather than `break-word` because the two differ exactly where it
+     matters here: `anywhere` also shrinks the min-content contribution, so the
+     row can never demand more width than the 340px shell has, while `break-word`
+     leaves the intrinsic size at the unbroken word and only relocates the
+     overflow. Standard property alone — lightningcss owns any prefixing (see the
+     two-pipeline rule in CLAUDE.md). */
   .toast-row .msg {
     font-weight: 500;
     min-width: 0;
+    overflow-wrap: anywhere;
   }
   .toast-row .action {
     margin-top: 6px;

--- a/src/client/components/ToastContainer.svelte
+++ b/src/client/components/ToastContainer.svelte
@@ -169,8 +169,15 @@ let { toasts, onDismiss }: Props = $props();
     color: var(--tandem-fg);
     padding-top: 2px;
   }
+  /* Same defect as the tray row it feeds (#1269), and the same fix — a toast and
+     its activity row render the identical `message` string, so a path that
+     overflows one overflows the other. `min-width: 0` permits the shrink but
+     supplies no break opportunity, and a Windows path is a single unbroken word.
+     Here the card does not clip, so the text ran out past the rounded border
+     instead of being sheared. See the fuller note in ActivityTray.svelte. */
   .toast-card .msg {
     min-width: 0;
+    overflow-wrap: anywhere;
   }
   /* Inline action button (#1018) — e.g. "Connect AI" on a no-AI-connected
      toast. Compact, accent-tinted, doesn't compete with the message. */

--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -14,6 +14,11 @@ export function detectFormat(filePath: string): string {
   const ext = path.extname(filePath).toLowerCase();
   switch (ext) {
     case ".md":
+    // `.markdown` is the long-form spelling, registered as an OS file
+    // association alongside `.md`. It MUST fold to "md" here — the default
+    // branch below is the plaintext fallback, which would render the syntax
+    // literally and save back through `extractText` (#1306).
+    case ".markdown":
       return "md";
     case ".txt":
       return "txt";

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -66,8 +66,25 @@ export const TANDEM_SUPPORT_EMAIL = "support@tandem.ink";
  */
 export const BYO_MODELS_ENABLED = false;
 
-/** File extensions the server accepts for opening. */
-export const SUPPORTED_EXTENSIONS = new Set([".md", ".txt", ".html", ".htm", ".docx"]);
+/**
+ * File extensions the server accepts for opening.
+ *
+ * This set is the authority, and `src-tauri/tauri.conf.json`'s
+ * `bundle.fileAssociations` is a PROMISE made against it: once an extension is
+ * registered there, the OS offers Tandem as a handler and a double-click
+ * launches the app with that path. An extension registered but missing here
+ * fails silently — `maybeOpenStartupFile` swallows the open error by design and
+ * falls through to `welcome.md`, so the user gets Tandem showing the wrong
+ * document with no visible error (#1306). `tests/build/file-association-alignment.test.ts`
+ * pins the two lists together.
+ *
+ * `.markdown` and `.htm` are aliases, not distinct formats — `detectFormat`
+ * folds them into `md` and `html`. Adding an alias here without adding it to
+ * `detectFormat` is worse than omitting it: the file would open, route to the
+ * PLAINTEXT adapter, render its syntax literally, and then auto-save back
+ * through `extractText` instead of `saveMarkdown`, rewriting the user's file.
+ */
+export const SUPPORTED_EXTENSIONS = new Set([".md", ".markdown", ".txt", ".html", ".htm", ".docx"]);
 
 /**
  * Inline marks the `.docx` import path (`docx-html.ts#htmlToYDoc`) can emit onto

--- a/tests/build/file-association-alignment.test.ts
+++ b/tests/build/file-association-alignment.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Alignment pin for the three lists that decide whether a double-clicked file
+ * actually opens (#1306).
+ *
+ * A file association is a promise made by the OS on Tandem's behalf: once
+ * `tauri.conf.json` registers an extension, Explorer/Finder offer Tandem as a
+ * handler and a double-click launches it. Three independent lists then have to
+ * agree, or the app launches and refuses the very file it was launched for:
+ *
+ *   1. `bundle.fileAssociations[].ext` in `src-tauri/tauri.conf.json` — what the
+ *      OS is told Tandem handles.
+ *   2. `SUPPORTED_FILE_ASSOC_EXTS` in `src-tauri/src/lib.rs` — the shell's
+ *      defense-in-depth argv filter, before it exports `TANDEM_OPEN_FILE`.
+ *   3. `SUPPORTED_EXTENSIONS` in `src/shared/constants.ts` — the server, which
+ *      is the authority; `resolveAndValidatePath` throws UNSUPPORTED_FORMAT.
+ *
+ * The failure this pins is silent by construction. `maybeOpenStartupFile`
+ * deliberately swallows an open failure (a broken `TANDEM_OPEN_FILE` must not
+ * abort startup) and falls through to the `welcome.md` fallback — so the user
+ * sees Tandem open with the wrong document and no error, and only stderr says
+ * why. Nothing else in the tree compares these lists, so drift ships.
+ *
+ * Direction matters: registered-but-unsupported is the bug. The reverse
+ * (`.htm` is server-supported but deliberately not OS-registered, since
+ * `.html` alone is the association) is a legitimate product choice and is NOT
+ * asserted here.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { SUPPORTED_EXTENSIONS } from "../../src/shared/constants.js";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+function registeredAssociationExts(): string[] {
+  const raw = readFileSync(path.join(repoRoot, "src-tauri/tauri.conf.json"), "utf-8");
+  const conf = JSON.parse(raw) as {
+    bundle?: { fileAssociations?: Array<{ ext?: string[] }> };
+  };
+  const assoc = conf.bundle?.fileAssociations ?? [];
+  expect(assoc.length).toBeGreaterThan(0); // positive control: we really parsed it
+  return [...new Set(assoc.flatMap((a) => a.ext ?? []))].map((e) => e.toLowerCase());
+}
+
+function rustAssocExts(): string[] {
+  const src = readFileSync(path.join(repoRoot, "src-tauri/src/lib.rs"), "utf-8");
+  const m = src.match(/SUPPORTED_FILE_ASSOC_EXTS:\s*&\[&str\]\s*=\s*&\[([^\]]*)\]/);
+  expect(m, "SUPPORTED_FILE_ASSOC_EXTS literal not found in lib.rs").toBeTruthy();
+  return [...(m as RegExpMatchArray)[1].matchAll(/"([^"]+)"/g)].map((x) => x[1].toLowerCase());
+}
+
+describe("OS file associations align with the server's accepted extensions", () => {
+  it("every extension tauri.conf.json registers is accepted by the server", () => {
+    const registered = registeredAssociationExts();
+    const unsupported = registered.filter((ext) => !SUPPORTED_EXTENSIONS.has(`.${ext}`));
+    expect(unsupported).toEqual([]);
+  });
+
+  it("every extension tauri.conf.json registers passes the Rust argv filter", () => {
+    const registered = registeredAssociationExts();
+    const rust = new Set(rustAssocExts());
+    const rejected = registered.filter((ext) => !rust.has(ext));
+    expect(rejected).toEqual([]);
+  });
+
+  it("the Rust argv filter never admits an extension the server will reject", () => {
+    const overpermissive = rustAssocExts().filter((ext) => !SUPPORTED_EXTENSIONS.has(`.${ext}`));
+    expect(overpermissive).toEqual([]);
+  });
+});

--- a/tests/design-system-impl/activity-message-wrapping.test.ts
+++ b/tests/design-system-impl/activity-message-wrapping.test.ts
@@ -1,0 +1,205 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { transform } from "lightningcss";
+import { resolveConfig } from "vite";
+import { beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Activity messages must have somewhere to break (#1269).
+ *
+ * The two surfaces that render a `TandemNotification.message` — the transient
+ * `ToastContainer` card and the `ActivityTray` row it feeds — both put the text
+ * in a flex item carrying `min-width: 0`. That permits the item to shrink below
+ * its min-content width, and it is easy to read as "so it will never overflow".
+ * It is not: shrinking is permitted, but the text still needs a BREAK
+ * OPPORTUNITY, and several of the app's own messages end in a filesystem path
+ * ("Claude restarting in C:\Users\…\com.tandem.editor\sample") which is one
+ * unbroken word — no space, and `\` is not a break opportunity either.
+ *
+ * So the line rendered at full min-content width and left its box. The two
+ * surfaces then failed differently, which is why the issue carries two
+ * screenshots: the tray shell has `overflow: clip`, so the path was sheared
+ * mid-character; the toast card does not clip, so the path simply ran out past
+ * the rounded border.
+ *
+ * WHAT THIS TEST CAN AND CANNOT DO. No layout engine is available here —
+ * happy-dom and jsdom do not lay out text, so the visual outcome is not
+ * assertable in a unit test and is covered by the manual browser gate. What is
+ * assertable, and what this pins, is that the declaration granting the break
+ * opportunity is present in BOTH surfaces AND survives the real build. That
+ * second half is not ceremony: component `<style>` blocks go through
+ * lightningcss (see `css-pipeline-contract.test.ts`), which rewrites and drops
+ * declarations it considers redundant for the configured `cssTarget`, so a
+ * property that is correct in source is not automatically a property that ships.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+
+/** Both components that render a notification `message` string. */
+const SURFACES = [
+  {
+    file: "src/client/components/ActivityTray.svelte",
+    selector: ".toast-row .msg",
+  },
+  {
+    file: "src/client/components/ToastContainer.svelte",
+    selector: ".toast-card .msg",
+  },
+] as const;
+
+/**
+ * Values that let a line break INSIDE an otherwise unbreakable word. `normal`
+ * and `break-spaces` are excluded deliberately — neither breaks a long path.
+ */
+const BREAKING_VALUES = ["anywhere", "break-word"];
+
+const VITE_TARGET_MAP: Record<string, string | false> = {
+  chrome: "chrome",
+  edge: "edge",
+  firefox: "firefox",
+  hermes: false,
+  ie: "ie",
+  ios: "ios_saf",
+  node: false,
+  opera: "opera",
+  rhino: false,
+  safari: "safari",
+};
+
+/** Mirrors Vite's `convertTargets` (transcribed in css-pipeline-contract.test.ts). */
+function convertTargets(cssTarget: string | string[]): Record<string, number> {
+  const targets: Record<string, number> = {};
+  for (const entry of [cssTarget].flat()) {
+    const index = entry.search(/\d/);
+    if (index < 0) throw new Error(`unparseable cssTarget entry: ${entry}`);
+    const browser = VITE_TARGET_MAP[entry.slice(0, index)];
+    if (browser === false) continue;
+    if (!browser) throw new Error(`cssTarget entry not in Vite's map: ${entry}`);
+    const [major, minor = 0] = entry
+      .slice(index)
+      .split(".")
+      .map((v) => parseInt(v, 10));
+    const version = (major << 16) | (minor << 8);
+    if (!targets[browser] || version < targets[browser]) targets[browser] = version;
+  }
+  return targets;
+}
+
+let targets: Record<string, number>;
+
+beforeAll(async () => {
+  const config = await resolveConfig({ root: ROOT }, "build");
+  expect(config.configFile, "resolveConfig must actually find vite.config.ts").toBeDefined();
+  targets = convertTargets(config.build.cssTarget);
+});
+
+/** The component's `<style>` block, which is what the bundler compiles. */
+function styleBlock(file: string): string {
+  const source = readFileSync(join(ROOT, file), "utf-8");
+  const m = source.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+  expect(m, `${file} has no <style> block`).toBeTruthy();
+  return (m as RegExpMatchArray)[1];
+}
+
+/**
+ * Strip Svelte's `:global` syntax, which lightningcss does not parse — the real
+ * pipeline never sees it either, because the Svelte compiler resolves scoping
+ * before handing CSS to the bundler. Both forms are in use here:
+ * `:global(sel)` inline (ActivityTray) and a bare `:global { … }` wrapper around
+ * an `@keyframes` (ToastContainer, which lightningcss rejects outright as an
+ * unknown at-rule rather than warning).
+ */
+function stripSvelteGlobal(css: string): string {
+  const inlineStripped = css.replace(/:global\(([^)]*)\)/g, "$1");
+  let out = "";
+  let i = 0;
+  while (true) {
+    const at = inlineStripped.indexOf(":global", i);
+    if (at === -1) {
+      out += inlineStripped.slice(i);
+      return out;
+    }
+    const open = inlineStripped.indexOf("{", at);
+    if (open === -1) {
+      out += inlineStripped.slice(i);
+      return out;
+    }
+    out += inlineStripped.slice(i, at);
+    // Splice out the wrapper braces, keeping the block's contents in place.
+    let depth = 0;
+    let j = open;
+    for (; j < inlineStripped.length; j++) {
+      if (inlineStripped[j] === "{") depth++;
+      else if (inlineStripped[j] === "}" && --depth === 0) break;
+    }
+    out += inlineStripped.slice(open + 1, j);
+    i = j + 1;
+  }
+}
+
+/** Minify exactly the way the real build's `minifyCSS` would. */
+function minify(css: string, filename: string): string {
+  const { code, warnings } = transform({
+    // lightningcss keys its parser off the extension; a `.svelte` name makes it
+    // reject `@keyframes`. The real build hands it plain CSS.
+    filename: `${filename.replace(/[^a-z0-9]/gi, "-")}.css`,
+    code: Buffer.from(stripSvelteGlobal(css)),
+    minify: true,
+    targets,
+  });
+  expect(warnings, `lightningcss warned while compiling ${filename}`).toEqual([]);
+  return code.toString();
+}
+
+/**
+ * The declaration block declared for `selector`, or null.
+ *
+ * The trailing boundary is load-bearing: `.toast-row .msg` is a prefix of
+ * `.toast-row .msg-row`, which sits a few lines above it in the same file and
+ * has no `overflow-wrap`. A prefix match reads that neighbour's body and
+ * reports the property missing while it is right there.
+ */
+function ruleBody(css: string, selector: string): string | null {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+");
+  const m = css.match(new RegExp(`(?:^|[};])[^{}]*${escaped}\\s*(?:,[^{}]*)?\\{([^}]*)\\}`));
+  return m ? m[1] : null;
+}
+
+describe("notification messages can break inside a long path (#1269)", () => {
+  it.each(SURFACES)("$selector declares a breaking overflow-wrap in source", ({
+    file,
+    selector,
+  }) => {
+    const css = styleBlock(file);
+    const body = ruleBody(css, selector);
+    expect(body, `${selector} rule not found in ${file}`).not.toBeNull();
+    const value = (body as string).match(/overflow-wrap\s*:\s*([a-z-]+)/)?.[1];
+    expect(
+      value,
+      `${selector} in ${file} has no overflow-wrap — a path with no space in it ` +
+        `will render at full min-content width and leave the box`,
+    ).toBeDefined();
+    expect(BREAKING_VALUES).toContain(value);
+  });
+
+  it.each(SURFACES)("$selector keeps it through lightningcss", ({ file, selector }) => {
+    const compiled = minify(styleBlock(file), file);
+    const body = ruleBody(compiled, selector);
+    expect(body, `${selector} rule vanished from the compiled CSS of ${file}`).not.toBeNull();
+    const value = (body as string).match(/overflow-wrap\s*:\s*([a-z-]+)/)?.[1];
+    expect(
+      value,
+      `${selector} lost its overflow-wrap during minification of ${file} — ` +
+        `correct in source is not the same as shipped`,
+    ).toBeDefined();
+    expect(BREAKING_VALUES).toContain(value);
+  });
+
+  it("the extractor really reads these files (positive control)", () => {
+    // Every assertion above would pass vacuously on an empty read. Pin something
+    // that has been in both files since long before this change.
+    for (const { file } of SURFACES) {
+      expect(styleBlock(file)).toContain("--tandem-");
+    }
+  });
+});

--- a/tests/docs/welcome-links.test.ts
+++ b/tests/docs/welcome-links.test.ts
@@ -28,6 +28,18 @@ import { isSafeExternalHref } from "../../src/client/editor/utils/url-safety.js"
  * `docs/` resolves for a developer running from source and for nobody else.
  * That is exactly how `[User Guide](../docs/user-guide.md)` shipped broken.
  *
+ * WHY THE FIX IS AN EXTERNAL URL AND NOT A BUNDLED FILE. Bundling was
+ * available — `docs/workflows.md` is already a Tauri resource and package.json
+ * `files` is one more line — so "it could not ship" is NOT the reason, and a
+ * future reader should not re-derive that. The reason is the readOnly flag:
+ * `Editor.svelte#openHref` calls `openServerPath(resolvedPath)` with no
+ * options, so a bundled guide would open as an EDITABLE tab on a file inside
+ * the installed app's resources directory, and the 60s autosave would then
+ * round-trip it through `remark-stringify`. That is the hazard `CHANGELOG.md`
+ * is opened `readOnly: true` to avoid (lesson #69 / #605). Making a bundled
+ * guide safe would mean teaching the link intercept to open some targets
+ * read-only — a real feature, not a link fix. Hence the URL.
+ *
  * This test reads both shipping manifests from their real sources rather than
  * restating them — a restated manifest is what would drift.
  */

--- a/tests/docs/welcome-links.test.ts
+++ b/tests/docs/welcome-links.test.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isSafeExternalHref } from "../../src/client/editor/utils/url-safety.js";
+
+/**
+ * `sample/welcome.md` is the ONE document every new user reads, and it is the
+ * only shipped document whose links are authored by us rather than by the user
+ * (#1270). Its links therefore have to survive PACKAGING, which is where they
+ * rot — and rot invisibly.
+ *
+ * The editor's anchor intercept (`Editor.svelte#openHref`) splits every click
+ * two ways:
+ *
+ *   - allowlisted external scheme → `window.open` → the system browser. Works
+ *     in every distribution; nothing has to be bundled.
+ *   - anything else → resolved relative to the OPEN FILE's path and handed to
+ *     `POST /api/open`. This only works when the target is actually next to
+ *     `welcome.md` in the shipped tree.
+ *
+ * The second branch fails SILENTLY: `openHref` logs a `console.warn` and
+ * returns. The click already had `preventDefault()` called on it, so the user
+ * gets no navigation, no toast, no error — a link that does nothing at all.
+ *
+ * And the shipped tree is much smaller than the checkout. The desktop bundle
+ * carries `sample/` plus exactly one docs file (`docs/workflows.md`); the npm
+ * package's `files` list carries no `docs/` at all. So a relative link into
+ * `docs/` resolves for a developer running from source and for nobody else.
+ * That is exactly how `[User Guide](../docs/user-guide.md)` shipped broken.
+ *
+ * This test reads both shipping manifests from their real sources rather than
+ * restating them — a restated manifest is what would drift.
+ */
+
+const repoRoot = path.resolve(__dirname, "../..");
+const WELCOME_REL = "sample/welcome.md";
+
+/** `[text](href)` links, excluding image links (`![alt](src)`). */
+function markdownLinks(md: string): Array<{ text: string; href: string }> {
+  return [...md.matchAll(/(!?)\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g)]
+    .filter((m) => m[1] !== "!")
+    .map((m) => ({ text: m[2], href: m[3] }));
+}
+
+/** Repo-relative paths the Tauri bundle copies into the app resources dir. */
+function tauriResourcePaths(): string[] {
+  const conf = JSON.parse(
+    readFileSync(path.join(repoRoot, "src-tauri/tauri.conf.json"), "utf-8"),
+  ) as { bundle?: { resources?: Record<string, string> } };
+  const resources = conf.bundle?.resources ?? {};
+  const keys = Object.keys(resources);
+  expect(keys.length).toBeGreaterThan(0); // we really parsed it
+  // Keys are relative to `src-tauri/`, so "../docs/workflows.md" → "docs/workflows.md".
+  return keys.map((k) => k.replace(/^\.\.\//, "").replace(/\\/g, "/"));
+}
+
+/** Entries of package.json `files` — what `npm pack` puts in the tarball. */
+function npmPackagedPaths(): string[] {
+  const pkg = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf-8")) as {
+    files?: string[];
+  };
+  const files = pkg.files ?? [];
+  expect(files.length).toBeGreaterThan(0);
+  return files.map((f) => f.replace(/\\/g, "/"));
+}
+
+/** True when `target` (repo-relative) is inside one of `manifest`'s entries. */
+function shipsWith(manifest: string[], target: string): boolean {
+  return manifest.some((entry) => {
+    const normalized = entry.replace(/\/$/, "");
+    return target === normalized || target.startsWith(`${normalized}/`);
+  });
+}
+
+describe("sample/welcome.md links survive packaging (#1270)", () => {
+  const welcome = readFileSync(path.join(repoRoot, WELCOME_REL), "utf-8");
+  const links = markdownLinks(welcome);
+
+  it("has links to check at all", () => {
+    // Positive control: if the extraction regex silently stopped matching,
+    // every assertion below would pass vacuously.
+    expect(links.length).toBeGreaterThan(0);
+  });
+
+  it.each(links)("$text → $href is reachable from a shipped build", ({ href }) => {
+    if (href.startsWith("#")) return; // in-page fragment; never navigates out
+
+    if (isSafeExternalHref(href)) {
+      // Hands off to the system browser — nothing has to be bundled.
+      return;
+    }
+
+    // Relative link: resolved against welcome.md's own directory and opened as
+    // a Tandem tab, so the target must exist AND ship in BOTH distributions.
+    const target = path
+      .normalize(path.join(path.dirname(WELCOME_REL), href.split("#")[0]))
+      .replace(/\\/g, "/");
+
+    expect(existsSync(path.join(repoRoot, target)), `${target} does not exist in the repo`).toBe(
+      true,
+    );
+    expect(
+      shipsWith(tauriResourcePaths(), target),
+      `${target} is not in tauri.conf.json bundle.resources — the desktop app cannot open it`,
+    ).toBe(true);
+    expect(
+      shipsWith(npmPackagedPaths(), target),
+      `${target} is not in package.json "files" — the npm distribution cannot open it`,
+    ).toBe(true);
+  });
+});

--- a/tests/fixtures/welcome-snapshot.md
+++ b/tests/fixtures/welcome-snapshot.md
@@ -4,7 +4,7 @@ Tandem lets you work on documents with an AI — by default Claude, but any MCP-
 
 ## Getting Started
 
-> Follow the tutorial in the bottom-left corner to learn the basics. You can dismiss it at any time. For a full walkthrough of all features, see the [User Guide](../docs/user-guide.md).
+> Follow the tutorial in the bottom-left corner to learn the basics. You can dismiss it at any time. For a full walkthrough of all features, see the [User Guide](https://github.com/bloknayrb/tandem/blob/master/docs/user-guide.md) (opens in your browser).
 
 Open Claude Code from any directory — your Tandem tools are already configured. Both you and your AI can see and edit this document at the same time. Your AI's cursor appears as a soft blue highlight on the paragraph being read, and a typing indicator shows when it's writing.
 

--- a/tests/server/markdown-extension-alias.test.ts
+++ b/tests/server/markdown-extension-alias.test.ts
@@ -1,0 +1,55 @@
+/**
+ * `.markdown` is the long-form spelling of `.md` and Tandem registers it as an
+ * OS file association (#1306). Passing the extension allowlist is necessary but
+ * not sufficient: an alias that reaches the server and then routes to the
+ * PLAINTEXT adapter would open a markdown file with its syntax rendered as
+ * literal text, and — worse — save it back through `extractText` rather than
+ * `saveMarkdown`, rewriting the user's file. So the alias has to be pinned at
+ * three points, not one.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { getAdapter } from "../../src/server/file-io/index.js";
+import { detectFormat } from "../../src/server/mcp/document-model.js";
+import { AUTO_SAVE_FORMATS, SUPPORTED_EXTENSIONS } from "../../src/shared/constants.js";
+
+describe(".markdown is a first-class alias for .md", () => {
+  it("passes the server's open-time extension allowlist", () => {
+    expect(SUPPORTED_EXTENSIONS.has(".markdown")).toBe(true);
+  });
+
+  it("detects as the md format, not the txt fallback", () => {
+    expect(detectFormat("/tmp/notes.markdown")).toBe("md");
+    expect(detectFormat("C:\\Users\\me\\Notes.MARKDOWN")).toBe("md");
+    // Control: an unrelated extension still lands on the plaintext fallback,
+    // so the assertion above is about `.markdown` and not about the default.
+    expect(detectFormat("/tmp/notes.rtf")).toBe("txt");
+  });
+
+  it("routes to the markdown adapter, which round-trips syntax as structure", async () => {
+    const format = detectFormat("/tmp/notes.markdown");
+    const adapter = getAdapter(format);
+    const doc = new Y.Doc();
+    try {
+      const prepared = await adapter.parse("# Heading\n\nBody text.\n");
+      expect(prepared.format).toBe("md");
+      adapter.apply(doc, prepared);
+      // The markdown adapter builds a heading node; the plaintext adapter would
+      // have produced a paragraph whose text still carries the literal "# ".
+      const fragment = doc.getXmlFragment("default");
+      const first = fragment.get(0) as Y.XmlElement;
+      expect(first.nodeName).toBe("heading");
+      expect(adapter.save?.(doc)).toContain("# Heading");
+    } finally {
+      doc.destroy();
+    }
+  });
+
+  it("is auto-saved in place, so a .markdown file keeps its extension", () => {
+    // Auto-save is format-keyed, and the write target is the doc's own
+    // filePath — so "md" here is what makes an edited .markdown file persist
+    // to `notes.markdown` rather than being silently skipped or renamed.
+    expect(AUTO_SAVE_FORMATS.has(detectFormat("/tmp/notes.markdown"))).toBe(true);
+  });
+});

--- a/tests/server/markdown-extension-alias.test.ts
+++ b/tests/server/markdown-extension-alias.test.ts
@@ -50,6 +50,12 @@ describe(".markdown is a first-class alias for .md", () => {
     // Auto-save is format-keyed, and the write target is the doc's own
     // filePath — so "md" here is what makes an edited .markdown file persist
     // to `notes.markdown` rather than being silently skipped or renamed.
-    expect(AUTO_SAVE_FORMATS.has(detectFormat("/tmp/notes.markdown"))).toBe(true);
+    const format = detectFormat("/tmp/notes.markdown");
+    // Pin the format first. `AUTO_SAVE_FORMATS` contains "txt" as well as "md",
+    // so the membership check ALONE passes under the exact defect this file
+    // exists to catch (the alias falling through to the plaintext fallback) —
+    // it is an assertion that cannot fail, and cannot be evidence on its own.
+    expect(format).toBe("md");
+    expect(AUTO_SAVE_FORMATS.has(format)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Three small, unrelated user-facing defects, one commit each plus a verification pass.

Closes #1306, closes #1270, closes #1269.

## `.markdown` was registered with the OS and rejected by the server (#1306)

`tauri.conf.json` registers `.markdown` as a file association and the Rust argv
filter admits it, but `SUPPORTED_EXTENSIONS` did not — so the OS offered Tandem
as a handler for a format the server refused. The failure is silent by
construction: `maybeOpenStartupFile` deliberately swallows an open error so a bad
`TANDEM_OPEN_FILE` can't abort startup, then falls through to `welcome.md`. The
user double-clicks their file and gets the welcome document, with the reason only
on stderr.

`detectFormat` had to change with it. The allowlist alone would let the file open
and route to the **plaintext** adapter — markdown syntax rendered literally, and
auto-save writing back through `extractText` instead of `saveMarkdown`, rewriting
the user's file. Everything downstream (adapter registry, `AUTO_SAVE_FORMATS`,
source view, restore, backups) is format-keyed and the path is never rewritten,
so folding the alias to `"md"` is sufficient and the file keeps its extension.

Deliberately unchanged: Save-As still normalises a `.markdown` pick to `.md`.
That is an explicit format choice rather than the in-place save, and it matches
how `.htm` has always behaved.

`tests/build/file-association-alignment.test.ts` pins all three lists against
each other by parsing them from their real sources — a restated list is what
drifted here. `lib.rs`'s doc-comment now points at the constant's actual home and
names that test, so "keep aligned" is checkable rather than aspirational.

## The User Guide link in welcome.md went nowhere (#1270)

The link was `../docs/user-guide.md`, which resolves only in a source checkout:
the desktop bundle carries `sample/` plus exactly one docs file
(`docs/workflows.md`), and `package.json` `files` carries no `docs/` at all.

The anchor intercept makes that invisible — it `preventDefault`s every
non-fragment click, routes the relative href through `/api/open`, and on failure
logs a `console.warn` and returns. No navigation, no toast: in the first document
a new user ever opens, a link that does nothing.

Note the issue reports the link "opens the target in a new browser tab". That is
not reproducible and could not be — `openOnClick` is false on the Link mark, the
intercept preventDefaults, and `isSafeExternalHref` (the only route to
`window.open`) rejects a relative path. Same underlying defect, same fix, but the
reported symptom should not be read back as a description of the old behaviour.

The link now points at the canonical copy on GitHub, labelled "(opens in your
browser)". Bundling the guide was genuinely available — `docs/workflows.md` is
already a Tauri resource and `files` is one more line — and is rejected for a
different reason: a relative link goes through `openServerPath` with no
`readOnly` flag, so a bundled guide would open as an **editable** tab on a file
inside the installed app's resources directory, and the 60s autosave would
round-trip it through `remark-stringify`. That is the hazard `CHANGELOG.md` is
opened read-only to avoid (lesson #69 / #605). Making bundling safe would mean
teaching the link intercept to open some targets read-only — a feature, not a
link fix.

`tests/docs/welcome-links.test.ts` reads both shipping manifests from their real
sources and checks every welcome.md link against them; the defect class is "a
link that only works before packaging", which no per-link assertion would catch.

## Activity and toast text ran out of its box (#1269)

`min-width: 0` on the message span reads like overflow protection and is not: it
permits the flex item to shrink below min-content, and grants the text no break
opportunity. Several of the app's own messages end in a filesystem path
(`Claude restarting in C:\Users\…\sample`) — one unbroken word, and `\` is not a
break opportunity — so the line rendered at full min-content width and left its
box.

Both surfaces that render a notification message have it, which is why the issue
carries two screenshots of the same string: the tray shell has `overflow: clip`
so the path was sheared mid-character; the toast card does not clip so it ran out
past the rounded border. `overflow-wrap: anywhere` on both — `anywhere` rather
than `break-word` because only `anywhere` also shrinks the min-content
contribution, so the row can never demand more width than its shell has.

The visual outcome is not unit-testable (no layout engine), so the test pins the
two things that are: the declaration exists on both surfaces, and it survives the
real minifier — correct in source is not correct as shipped, which is how #1189
got out.

## Verification pass

The last commit is an adversarial re-verification of the three above. It found:

- three more artifacts still carrying the pre-#1306 format list (README's feature
  list, `architecture.md`'s file-association section, `mcp-tools.md`'s
  `tandem_open` notes; the last also never listed `.htm`);
- a factually wrong rationale in the #1270 commit message — it claims bundling
  would have broken npm, which is false. The correct reason (the missing
  `readOnly` flag, above) is now recorded in the test's doc-comment so nobody
  "fixes" the link back to a bundled relative path;
- an assertion that could not fail: the `.markdown` auto-save test checked only
  `AUTO_SAVE_FORMATS` membership, and `"txt"` is in that set, so it passed under
  the precise defect the file exists to catch.

Each source change was negative-controlled by reverting it and confirming the new
test fails with the expected message.

## Testing

- `npm run typecheck` — clean
- `npm run check:tokens` — no new warnings
- The four new test files plus every existing test touching `SUPPORTED_EXTENSIONS`,
  `detectFormat`, `welcome.md`, the testid manifest and the CSS pipeline contract:
  151 passing
- No E2E run
- `cargo test` not run: the only Rust change is a doc comment

### Manual gate still owed

1. Double-click a `.markdown` file → opens as markdown; after an edit and the 60s
   autosave the file is still `.markdown` and still valid markdown.
2. Click **User Guide** in `welcome.md` — **in the desktop app specifically**, not
   only the browser build. `window.open` is the client's only external-open route
   and there is no Tauri opener plugin or `NewWindowRequested` handler, so desktop
   behaviour here is unverified. Confirm the system browser opens.
3. Trigger `Relaunch Claude` from a deeply nested folder: the path wraps inside
   the toast card and inside the 340px tray row, in both themes, at a narrow
   window.

---

*Wave 2 of the backlog campaign. Fixed by one agent, then independently verified by a second that re-derived each root cause and re-ran the negative controls itself.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKcPLgN9YGgfC1WvPJ2Vq
