### PR TITLE
fix(toolbar): make the heading menu's Escape focus restore actually land (#1313)

### DIFF
--- a/src/client/editor/toolbar/FormattingToolbar.svelte
+++ b/src/client/editor/toolbar/FormattingToolbar.svelte
@@ -85,9 +85,11 @@ $effect(() => {
 // the deferred focus arrived. That frame is not free — a throttled or hidden tab
 // never runs the callback and the restore is simply lost. ProseMirror's own
 // `view.focus()` is synchronous, so focus leaves the menu item BEFORE it
-// unmounts and there is no drop to recover from. It also cannot scroll the
-// document the way the command's selection restoration can, which makes the
-// outside-mousedown branch strictly safer than it was.
+// unmounts and there is no drop to recover from. Nothing is given up: it runs
+// `selectionToDOM()`, so the caret returns to where it was (see Toolbar.svelte's
+// #768 note), and neither call scrolls — both reach the DOM through
+// `focusPreventScroll`. It is also what every other focus restore in
+// src/client/ already uses; this call site was the lone `commands.focus()`.
 function closeHeadingMenu() {
   const ours =
     (!!headingMenuEl && headingMenuEl.contains(document.activeElement)) ||

--- a/src/client/editor/toolbar/FormattingToolbar.svelte
+++ b/src/client/editor/toolbar/FormattingToolbar.svelte
@@ -71,19 +71,30 @@ $effect(() => {
 // falls to <body> when the focused item unmounts. The editor is the right
 // destination: the trigger deliberately keeps focus there on the mouse path.
 //
-// Guarded restore. `editor.commands.focus()` is not a bare `.focus()` — it
-// restores the ProseMirror selection and can scroll the document to it — so an
-// outside mousedown (clickOutside fires on mousedown, before the browser's own
-// focus transfer) must NOT yank focus into the editor when the user was heading
-// somewhere else. Restore only when focus is still inside the menu, or has
-// already fallen to <body> because the focused item unmounted.
+// Guarded restore: an outside mousedown (clickOutside fires on mousedown,
+// before the browser's own focus transfer) must NOT yank focus into the editor
+// when the user was heading somewhere else. Restore only when focus is still
+// inside the menu, or has already fallen to <body> because the focused item
+// unmounted.
+//
+// `view.focus()`, NOT `commands.focus()` (#1313). Tiptap's focus COMMAND
+// schedules the real `view.focus()` inside a requestAnimationFrame
+// (`delayedFocus` — a React workaround), while Svelte unmounts the menu on the
+// microtask flush, which lands first. So the guard passed, the restore was
+// issued, and focus still fell to <body>: the focused item was torn out before
+// the deferred focus arrived. That frame is not free — a throttled or hidden tab
+// never runs the callback and the restore is simply lost. ProseMirror's own
+// `view.focus()` is synchronous, so focus leaves the menu item BEFORE it
+// unmounts and there is no drop to recover from. It also cannot scroll the
+// document the way the command's selection restoration can, which makes the
+// outside-mousedown branch strictly safer than it was.
 function closeHeadingMenu() {
   const ours =
     (!!headingMenuEl && headingMenuEl.contains(document.activeElement)) ||
     document.activeElement === document.body ||
     document.activeElement === null;
   showHeadingMenu = false;
-  if (ours) editor?.commands.focus();
+  if (ours) editor?.view.focus();
 }
 
 function findActiveHeading(ed: TiptapEditor): HeadingLevel | null {

--- a/tests/client/heading-menu-focus-restore.test.ts
+++ b/tests/client/heading-menu-focus-restore.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+
+import { fireEvent, render } from "@testing-library/svelte";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
+import FormattingToolbar from "../../src/client/editor/toolbar/FormattingToolbar.svelte";
+
+/**
+ * #1313 — the heading dropdown's guarded focus restore must actually restore.
+ *
+ * `closeHeadingMenu` exists so focus never strands on `<body>` when the focused
+ * menu item unmounts. It did strand, and the reason is an ORDERING one that is
+ * invisible in the component's own source: `editor.commands.focus()` does not
+ * focus. Tiptap's `focus` command schedules `view.focus()` inside a
+ * `requestAnimationFrame` (see `delayedFocus` in @tiptap/core), while Svelte
+ * removes the menu on the MICROTASK flush — which lands first. So the sequence
+ * was: focused item unmounts → browser drops focus to `<body>` → a whole frame
+ * later the editor is focused. A frame is not nothing: a hidden or throttled
+ * tab never runs the callback at all, and every probe that looks before the
+ * next vsync sees `<body>`.
+ *
+ * The fix is `editor.view.focus()` — ProseMirror's own synchronous focus, which
+ * lands BEFORE the unmount, so the item that unmounts is no longer the focused
+ * one and there is no drop to `<body>` to recover from.
+ *
+ * These assertions therefore deliberately drain only MICROTASKS (which is what
+ * `fireEvent`'s awaited `tick()` does) and never wait for an animation frame.
+ * Waiting a frame would make them pass against the unfixed code.
+ */
+
+const mounted: Array<{ editor: Editor; container: HTMLElement }> = [];
+
+function makeEditor(): Editor {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const editor = new Editor({
+    element: host,
+    extensions: [StarterKit],
+    content: "<p>hello world</p>",
+  });
+  mounted.push({ editor, container: host });
+  return editor;
+}
+
+afterEach(() => {
+  for (const { editor, container } of mounted) {
+    editor.destroy();
+    container.remove();
+  }
+  mounted.length = 0;
+  document.body.innerHTML = "";
+});
+
+/** Open the heading menu the way a keyboard user does: a `detail === 0` click. */
+async function openHeadingMenu(container: HTMLElement) {
+  const trigger = container.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]');
+  expect(trigger, "heading trigger must exist").not.toBeNull();
+  await fireEvent.click(trigger as Element, { detail: 0 });
+  // The focus-in effect (#1303) runs on the flush `fireEvent` already awaited.
+  expect(container.querySelector('[role="menu"]'), "menu must be open").not.toBeNull();
+  expect(
+    (document.activeElement as HTMLElement | null)?.getAttribute("role"),
+    "focus must be on a menu item before we close it",
+  ).toBe("menuitemradio");
+}
+
+describe("heading menu — focus restore on close (#1313)", () => {
+  it("Escape returns focus to the editor without waiting for an animation frame", async () => {
+    const editor = makeEditor();
+    const { container } = render(FormattingToolbar, { props: { editor } });
+    document.body.appendChild(container);
+
+    await openHeadingMenu(container);
+
+    await fireEvent.keyDown(document.activeElement as Element, {
+      key: "Escape",
+      bubbles: true,
+    });
+
+    expect(container.querySelector('[role="menu"]'), "menu must be closed").toBeNull();
+    expect(document.activeElement, "focus must not strand on <body>").not.toBe(document.body);
+    expect(document.activeElement).toBe(editor.view.dom);
+  });
+
+  it("outside mousedown from inside the menu restores the editor on the same flush", async () => {
+    const editor = makeEditor();
+    const { container } = render(FormattingToolbar, { props: { editor } });
+    document.body.appendChild(container);
+
+    await openHeadingMenu(container);
+
+    // `clickOutside` listens for mousedown on `document`. Post-#1303 focus is
+    // inside the menu on the mouse path too, so this takes the same restoring
+    // branch as Escape.
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    await fireEvent.mouseDown(outside);
+
+    expect(container.querySelector('[role="menu"]'), "menu must be closed").toBeNull();
+    expect(document.activeElement, "focus must not strand on <body>").not.toBe(document.body);
+    expect(document.activeElement).toBe(editor.view.dom);
+  });
+
+  it("does not yank focus into the editor when the user has already moved elsewhere", async () => {
+    const editor = makeEditor();
+    const { container } = render(FormattingToolbar, { props: { editor } });
+    document.body.appendChild(container);
+
+    await openHeadingMenu(container);
+
+    // The guard's whole point: `clickOutside` fires on mousedown, and if the
+    // user is on their way somewhere else the restore must stay out of it.
+    // A synchronous editor focus makes this MORE important, not less — it can
+    // no longer be lost to a later frame.
+    const elsewhere = document.createElement("input");
+    document.body.appendChild(elsewhere);
+    elsewhere.focus();
+    expect(document.activeElement).toBe(elsewhere);
+
+    await fireEvent.mouseDown(elsewhere);
+
+    expect(container.querySelector('[role="menu"]'), "menu must be closed").toBeNull();
+    expect(document.activeElement, "restore must not have run").toBe(elsewhere);
+  });
+});

--- a/tests/client/heading-menu-focus-restore.test.ts
+++ b/tests/client/heading-menu-focus-restore.test.ts
@@ -69,7 +69,6 @@ describe("heading menu — focus restore on close (#1313)", () => {
   it("Escape returns focus to the editor without waiting for an animation frame", async () => {
     const editor = makeEditor();
     const { container } = render(FormattingToolbar, { props: { editor } });
-    document.body.appendChild(container);
 
     await openHeadingMenu(container);
 
@@ -86,7 +85,6 @@ describe("heading menu — focus restore on close (#1313)", () => {
   it("outside mousedown from inside the menu restores the editor on the same flush", async () => {
     const editor = makeEditor();
     const { container } = render(FormattingToolbar, { props: { editor } });
-    document.body.appendChild(container);
 
     await openHeadingMenu(container);
 
@@ -105,7 +103,6 @@ describe("heading menu — focus restore on close (#1313)", () => {
   it("does not yank focus into the editor when the user has already moved elsewhere", async () => {
     const editor = makeEditor();
     const { container } = render(FormattingToolbar, { props: { editor } });
-    document.body.appendChild(container);
 
     await openHeadingMenu(container);
 


### PR DESCRIPTION
## Summary

Fixes #1313. The heading dropdown's guarded focus restore ran, passed its guard, and
still left `document.activeElement` on `<body>` after Escape.

`editor.commands.focus()` does not focus synchronously. Tiptap's focus *command*
schedules the real `view.focus()` inside a `requestAnimationFrame` (`delayedFocus` in
`@tiptap/core` — an upstream React workaround). Svelte unmounts the menu on the
microtask flush, which lands first. So the real sequence was: guard passes →
`showHeadingMenu = false` → an rAF is scheduled → microtask: the focused menu item
unmounts → focus falls to `<body>` → *one frame later* the editor is focused.

That frame is not free. A throttled or hidden tab never runs the callback and the
restore is lost outright, and no deterministic probe can observe the restore.

The fix is one expression: `editor?.view.focus()`, ProseMirror's own synchronous
focus. Focus leaves the menu item *before* it unmounts, so there is no drop to
recover from. This also converges the last outlier — every other focus restore in
`src/client/` (`App.svelte`, `CommandPalette`, `OutlinePanel`, `Editor.svelte`,
`context-menu/install.ts`, `chat-insert.ts`) already used `view.focus()`.

Note the issue body proposed the *opposite* ordering (an unmount landing after a
synchronous focus). That hypothesis is wrong, and the comment above
`closeHeadingMenu` now records the measured ordering, since it is invisible in this
file. It also explains the issue's `DecorationsMenu` contrast without a second
defect: `DecorationsMenu.closeMenu` restores with a plain synchronous
`caretBtn?.focus()`.

## Diff

- `src/client/editor/toolbar/FormattingToolbar.svelte` — `commands.focus()` →
  `view.focus()` in `closeHeadingMenu`, plus a rewritten comment block recording the
  ordering and what the two calls do and do not differ on (they differ only in
  timing: both go through `focusPreventScroll` and `selectionToDOM`, so the caret
  still returns to its position and neither scrolls).
- `tests/client/heading-menu-focus-restore.test.ts` — new. Real Tiptap `Editor` +
  the real component in happy-dom. Three cases: Escape restore, outside-mousedown
  restore, and the negative guard (focus already moved elsewhere → no restore). The
  assertions deliberately drain **only microtasks** and never await a frame —
  awaiting one would make them pass against the unfixed code.

## Verification

- Negative control: reverting the one-line source change (test untouched) fails
  2 of 3 — `AssertionError: focus must not strand on <body>`. The third (the guard)
  passes on both sides, correctly, since it does not depend on the fix.
- `npm run typecheck` — `1295 FILES 0 ERRORS 0 WARNINGS`.
- `npx vitest run` over `heading-menu-focus-restore`, `escape-owner`,
  `selection-toolbar`, `toolbar-button-title`, `handlers` — 31 passed.

## Deliberately not done

- The restore *destination* is unchanged. WAI-ARIA APG and `DecorationsMenu` both
  return focus to the trigger, but the editor is this surface's house style
  (`keyboard-a11y.spec.ts`: "command palette returns focus to the editor on Escape")
  and the existing comment states that intent. Changing it is a UX decision, not a
  defect fix.
- `dismissLinkInput` in the same file restores no focus at all on the link popover's
  Escape path — same class of gap, not reported and not measured here.

---

*Wave 2 of the backlog campaign. Fixed by one agent, then independently verified by a second that re-derived each root cause and re-ran the negative controls itself.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKcPLgN9YGgfC1WvPJ2Vq
