### PR TITLE
fix(licensing): fail issuance closed on an unset or placeholder SUPPORT_EMAIL (#1289)

### DIFF
--- a/docs/licensing-operations.md
+++ b/docs/licensing-operations.md
@@ -326,9 +326,13 @@ tracker, where they will paste a key carrying their own name and email), and
 
 `SUPPORT_EMAIL` is **required and enforced**: the Worker rejects every request
 with 503 and `stage: "config-support-email"` while the value is unset, still the
-`REPLACE_WITH_…` placeholder, or not address-shaped. That is deliberate — the
-alternative was emitting a license email with no support address at all, or with
-the placeholder printed in it, to a customer who has already paid. A 503 makes
+`REPLACE_WITH_…` placeholder, not address-shaped, or longer than 70 characters.
+That is deliberate — the alternative was emitting a license email with no support
+address at all, or with the placeholder printed in it, to a customer who has
+already paid. The length bound is not cosmetic: the address prints on its own
+line beneath the base64 key, and a line over 72 characters invites an MTA to
+re-encode the body as quoted-printable, whose soft line break truncates that key.
+A `Name <addr>` display name is allowed but counts toward the 70. A 503 makes
 Polar re-deliver, so the event is fulfilled unchanged once the var is fixed.
 Note that the check is per-request, not a deploy-time gate: nothing alerts on
 it, so a fix is only prompted by Polar's delivery log (§5b).

--- a/docs/licensing-operations.md
+++ b/docs/licensing-operations.md
@@ -324,6 +324,15 @@ it a buyer whose activation fails has no inbound channel but the public issue
 tracker, where they will paste a key carrying their own name and email), and
 `ALERT_WEBHOOK_URL` / `ALERT_EMAIL` (§5c).
 
+`SUPPORT_EMAIL` is **required and enforced**: the Worker rejects every request
+with 503 and `stage: "config-support-email"` while the value is unset, still the
+`REPLACE_WITH_…` placeholder, or not address-shaped. That is deliberate — the
+alternative was emitting a license email with no support address at all, or with
+the placeholder printed in it, to a customer who has already paid. A 503 makes
+Polar re-deliver, so the event is fulfilled unchanged once the var is fixed.
+Note that the check is per-request, not a deploy-time gate: nothing alerts on
+it, so a fix is only prompted by Polar's delivery log (§5b).
+
 Point the Polar webhook endpoint (subscribed to `order.paid` + `order.refunded`)
 at the deployed URL. Deploy a **separate sandbox instance** (the sandbox Polar
 secret, its own namespaces) to test end-to-end — the sandbox needs no Polar KYC,
@@ -522,6 +531,8 @@ Then walk §5a steps 2–4 with that order number.
       cheap way to buy off the webhook-auto-disable risk in §5b, and it is
       non-negotiable while `stage: "email"` returns a retryable 500.
 - [ ] `SUPPORT_EMAIL` set, the mailbox actually exists, and someone reads it.
+      The Worker enforces the first clause (503 on unset/placeholder/malformed);
+      the mailbox existing and being read is still only this checklist line.
 - [ ] `ALERT_WEBHOOK_URL` set (see §5c — without it you cannot be alerted about
       the email failures that disable the endpoint).
 - [ ] A sandbox purchase completed end-to-end: email → activate →

--- a/infra/license-issuance-worker/src/worker.ts
+++ b/infra/license-issuance-worker/src/worker.ts
@@ -693,12 +693,13 @@ export function licenseAttachment(blob: string): { content: string; filename: st
   return { content: btoa(blob), filename: "tandem.license" };
 }
 
-/** What is wrong with `SUPPORT_EMAIL`, or `null` if nothing is. All three fail
+/** What is wrong with `SUPPORT_EMAIL`, or `null` if nothing is. All of them fail
  *  the Worker closed; they are named separately because the operator-visible
  *  symptom differs (an unset value silently omits the support block from a paid
  *  customer's email, a placeholder prints `REPLACE_WITH_SUPPORT_INBOX` to them
- *  instead). */
-export type SupportEmailProblem = "unset" | "placeholder" | "malformed";
+ *  instead, a too-long one is a perfectly good address that would truncate the
+ *  license key it is sent with). */
+export type SupportEmailProblem = "unset" | "placeholder" | "malformed" | "too-long";
 
 /** Placeholder shapes that actually occur here, not an invented list: the
  *  deploy template ships `SUPPORT_EMAIL = "REPLACE_WITH_SUPPORT_INBOX"`, and the
@@ -708,15 +709,26 @@ export type SupportEmailProblem = "unset" | "placeholder" | "malformed";
  *  smuggle one past. */
 const SUPPORT_EMAIL_PLACEHOLDER = /replace_with|yourdomain/i;
 
+/** Longest value that still renders inside the body's line ceiling: the address
+ *  gets its own line under a two-space indent, and `wrapBlob`'s 72 is the width
+ *  below which no line invites an MTA to re-encode. Bounding it here is what
+ *  giving it its own line was reaching for — that only caps the *sentence*, and
+ *  a 70+ character value (the display-name form permitted below is exactly the
+ *  long shape) pushes the rendered line back over 72, at which point QP's soft
+ *  break silently truncates the base64 license key printed above it. A valid
+ *  address is worth refusing when sending it is what breaks activation. */
+const MAX_SUPPORT_EMAIL_LEN = 70;
+
 /**
  * Validate the operator-configured support inbox.
  *
  * Deliberately NOT an RFC 5322 parser. It rejects the shapes a misconfiguration
  * actually produces — unset, whitespace, a leftover placeholder, a value with no
- * `@`, an empty local or domain part, embedded whitespace, a dotless domain —
- * and accepts everything else. The proof that the mailbox exists and is read is
- * the runbook's end-to-end send test; a stricter regex here would only add ways
- * to fail a valid address closed, which for this Worker means refusing sales.
+ * `@`, an empty local or domain part, embedded whitespace, a dotless domain, one
+ * too long to wrap — and accepts everything else. The proof that the mailbox
+ * exists and is read is the runbook's end-to-end send test; a stricter regex
+ * here would only add ways to fail a valid address closed, which for this Worker
+ * means refusing sales.
  *
  * A `Name <addr@example.com>` wrapper is accepted because `RESEND_FROM`'s
  * documented example uses exactly that form, so an operator copying its shape
@@ -729,6 +741,7 @@ export function supportEmailProblem(raw: string | undefined | null): SupportEmai
   const wrapped = /^[^<>]*<([^<>]*)>$/.exec(value);
   const address = (wrapped ? wrapped[1] : value).trim();
   if (!/^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/.test(address)) return "malformed";
+  if (value.length > MAX_SUPPORT_EMAIL_LEN) return "too-long";
   return null;
 }
 

--- a/infra/license-issuance-worker/src/worker.ts
+++ b/infra/license-issuance-worker/src/worker.ts
@@ -112,8 +112,19 @@ export type ResultKind =
 /** Non-PII failure stage attached to error logs. Cloudflare's log stream is
  * operator-only (not attacker-visible), so tagging the failing stage — and the
  * upstream HTTP status for email — costs no security and makes a launch-day
- * Resend misconfiguration debuggable. */
-export type FailStage = "config" | "email" | "blob-size" | "ledger" | "unexpected";
+ * Resend misconfiguration debuggable.
+ *
+ * `config` is the signing key; `config-support-email` is SUPPORT_EMAIL. They
+ * are separate values on purpose — both fail closed with an identical 503, so
+ * the stage is the only thing that tells an operator whether to re-put a secret
+ * or edit a `[vars]` line. */
+export type FailStage =
+  | "config"
+  | "config-support-email"
+  | "email"
+  | "blob-size"
+  | "ledger"
+  | "unexpected";
 
 interface Failure {
   stage: FailStage;
@@ -605,8 +616,10 @@ interface WorkerEnv {
   RESEND_API_KEY?: string;
   RESEND_FROM?: string;
   /** Monitored inbox used as the license email's `reply_to` and named in its
-   *  body. Keep in sync with TANDEM_SUPPORT_EMAIL in src/shared/constants.ts. */
-  SUPPORT_EMAIL?: string;
+   *  body. Keep in sync with TANDEM_SUPPORT_EMAIL in src/shared/constants.ts.
+   *  REQUIRED: validated at the top of every request (see `supportEmailProblem`)
+   *  and a bad value fails the Worker closed rather than emailing a buyer. */
+  SUPPORT_EMAIL: string;
   TANDEM_ISSUANCE_ENV?: string; // "sandbox" | "production" (default production)
   LICENSE_KV: KvNamespace; // SAME namespace the update Worker reads
   LEDGER_KV: KvNamespace; // issuance-owned; holds PII
@@ -680,6 +693,45 @@ export function licenseAttachment(blob: string): { content: string; filename: st
   return { content: btoa(blob), filename: "tandem.license" };
 }
 
+/** What is wrong with `SUPPORT_EMAIL`, or `null` if nothing is. All three fail
+ *  the Worker closed; they are named separately because the operator-visible
+ *  symptom differs (an unset value silently omits the support block from a paid
+ *  customer's email, a placeholder prints `REPLACE_WITH_SUPPORT_INBOX` to them
+ *  instead). */
+export type SupportEmailProblem = "unset" | "placeholder" | "malformed";
+
+/** Placeholder shapes that actually occur here, not an invented list: the
+ *  deploy template ships `SUPPORT_EMAIL = "REPLACE_WITH_SUPPORT_INBOX"`, and the
+ *  comment three lines above it offers `noreply@yourdomain.com` as the
+ *  RESEND_FROM example — the two strings an operator can plausibly leave behind
+ *  or half-edit. Matched against the raw value, so a display-name wrapper can't
+ *  smuggle one past. */
+const SUPPORT_EMAIL_PLACEHOLDER = /replace_with|yourdomain/i;
+
+/**
+ * Validate the operator-configured support inbox.
+ *
+ * Deliberately NOT an RFC 5322 parser. It rejects the shapes a misconfiguration
+ * actually produces — unset, whitespace, a leftover placeholder, a value with no
+ * `@`, an empty local or domain part, embedded whitespace, a dotless domain —
+ * and accepts everything else. The proof that the mailbox exists and is read is
+ * the runbook's end-to-end send test; a stricter regex here would only add ways
+ * to fail a valid address closed, which for this Worker means refusing sales.
+ *
+ * A `Name <addr@example.com>` wrapper is accepted because `RESEND_FROM`'s
+ * documented example uses exactly that form, so an operator copying its shape
+ * across is a likely and legitimate configuration — not a defect to 503 on.
+ */
+export function supportEmailProblem(raw: string | undefined | null): SupportEmailProblem | null {
+  const value = (raw ?? "").trim();
+  if (value === "") return "unset";
+  if (SUPPORT_EMAIL_PLACEHOLDER.test(value)) return "placeholder";
+  const wrapped = /^[^<>]*<([^<>]*)>$/.exec(value);
+  const address = (wrapped ? wrapped[1] : value).trim();
+  if (!/^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/.test(address)) return "malformed";
+  return null;
+}
+
 async function sendViaResend(env: WorkerEnv, to: string, name: string, blob: string) {
   // Not configured counts as a delivery failure so the event stays retryable
   // (the handler's 500 path logs it) rather than silently dropping a paid
@@ -698,8 +750,10 @@ async function sendViaResend(env: WorkerEnv, to: string, name: string, blob: str
         // A buyer whose activation fails needs somewhere to write that isn't the
         // public issue tracker — the natural instinct is to paste the key, and
         // the key carries their own name and email. `RESEND_FROM` is a noreply
-        // address, so without this there is no inbound channel at all.
-        ...(env.SUPPORT_EMAIL ? { reply_to: env.SUPPORT_EMAIL } : {}),
+        // address, so without this there is no inbound channel at all. It used
+        // to be conditional, which made a missing var invisible; the fetch
+        // handler now validates it up front, so it is unconditional here.
+        reply_to: env.SUPPORT_EMAIL,
         subject: "Your Tandem license",
         text: licenseEmailText(name, blob, env.SUPPORT_EMAIL),
         attachments: [licenseAttachment(blob)],
@@ -724,7 +778,7 @@ async function sendViaResend(env: WorkerEnv, to: string, name: string, blob: str
  * silently truncates a base64 license key. `name` is the unavoidable exception
  * (it is the customer's actual name); everything we author is ASCII.
  */
-export function licenseEmailText(name: string, blob: string, supportEmail?: string): string {
+export function licenseEmailText(name: string, blob: string, supportEmail: string): string {
   return [
     `Hi ${name},`,
     "",
@@ -746,17 +800,13 @@ export function licenseEmailText(name: string, blob: string, supportEmail?: stri
     "",
     "Please don't post the key publicly - it contains your name and email",
     "address.",
-    ...(supportEmail
-      ? [
-          "",
-          "If activation gives you any trouble, just reply here, or write to:",
-          // Its own line: the address is operator-configured and interpolating
-          // it mid-sentence made this line's length unbounded (85 chars with a
-          // short address, and the whole point of the 72 ceiling is that no
-          // line invites an MTA to re-encode).
-          `  ${supportEmail}`,
-        ]
-      : []),
+    "",
+    "If activation gives you any trouble, just reply here, or write to:",
+    // Its own line: the address is operator-configured and interpolating it
+    // mid-sentence made this line's length unbounded (85 chars with a short
+    // address, and the whole point of the 72 ceiling is that no line invites an
+    // MTA to re-encode).
+    `  ${supportEmail}`,
     "",
     "-- The Tandem team",
   ].join("\n");
@@ -910,6 +960,31 @@ export default {
       }
     }
     const { signBytes } = signerCache;
+
+    // Same fail-closed treatment as the signing key, and for the same reason: a
+    // bad SUPPORT_EMAIL is not detectable from a successful-looking response.
+    //
+    // WHY HERE and not at the point of use in `sendViaResend`: by the time the
+    // email is composed the license has already been minted, the entitlement
+    // written to LICENSE_KV and the order recorded in the ledger. A point-of-use
+    // refusal would leave an issued-but-undeliverable license behind and a 500
+    // retry loop that can never succeed, and it would only fire for buyers —
+    // i.e. after a bad deploy has already cost a sale. Checking before any
+    // webhook processing means nothing durable is written, Polar simply
+    // re-delivers, and the untouched event is fulfilled once the var is fixed.
+    //
+    // The three problem kinds share one stage: they name the same `[vars]` line
+    // and the operator reads the value to tell them apart. What the stage must
+    // distinguish is this from the signing key's `config` — different fix.
+    if (supportEmailProblem(env.SUPPORT_EMAIL) !== null) {
+      log({
+        result: "error",
+        ts: Math.floor(Date.now() / 1000),
+        stage: "config-support-email",
+      });
+      return jsonResponse(503);
+    }
+
     const grandfatherSet = grandfatherSetOf(env.GRANDFATHER_EMAILS ?? "");
 
     return handleIssuance(request, {

--- a/infra/license-issuance-worker/wrangler.toml
+++ b/infra/license-issuance-worker/wrangler.toml
@@ -24,6 +24,10 @@ RESEND_FROM = "REPLACE_WITH_VERIFIED_SENDER"
 # TANDEM_SUPPORT_EMAIL in src/shared/constants.ts. Without it a buyer whose
 # activation fails has no inbound channel except the public issue tracker —
 # where they will paste a key carrying their own name and email.
+# REQUIRED. The Worker validates this on every request and returns 503
+# (`stage: "config-support-email"`) while it is unset, still this placeholder,
+# or not address-shaped — deploying it unedited stops issuance rather than
+# emailing the placeholder to someone who just paid.
 SUPPORT_EMAIL = "REPLACE_WITH_SUPPORT_INBOX"
 # Operator alerting. `dropped` results and email-delivery failures are the two
 # outcomes that lose sales silently.

--- a/tests/server/license-issuance-worker.test.ts
+++ b/tests/server/license-issuance-worker.test.ts
@@ -16,6 +16,7 @@ import issuanceWorker, {
   type IssuanceDeps,
   type KvNamespace,
   LICENSE_VERSION,
+  licenseEmailText,
   supportEmailProblem,
 } from "../../infra/license-issuance-worker/src/worker.js";
 import {
@@ -1230,6 +1231,30 @@ describe("default fetch wiring (env → deps)", () => {
     expect(supportEmailProblem("support@tandem.ink")).toBeNull();
     expect(supportEmailProblem("  support@tandem.ink  ")).toBeNull();
     expect(supportEmailProblem("Tandem Support <support@tandem.ink>")).toBeNull();
+  });
+
+  it("rejects an address too long to render inside the body's 72-column ceiling", () => {
+    // Not a style rule. The address prints on its own line under a two-space
+    // indent, directly beneath the wrapped base64 key. Push that line past 72
+    // and an MTA re-encodes the body as quoted-printable, whose soft line break
+    // truncates the key — the buyer's activation then fails with a valid
+    // support address in the mail that broke it. The guard is the only thing
+    // standing between `[vars]` and that line, so the bound belongs here.
+    const longButValid =
+      "Tandem Support (include your order id) <support@tandem-collab.example.com>";
+    expect(longButValid.length).toBeGreaterThan(72 - 2);
+    expect(supportEmailProblem(longButValid)).toBe("too-long");
+
+    // Positive control on the same sample: the longest ACCEPTED value must
+    // actually fit. Asserting only the rejection would pass with the ceiling
+    // set to any number at all.
+    const atCeiling = `${"a".repeat(70 - "@tandem.ink".length)}@tandem.ink`;
+    expect(atCeiling).toHaveLength(72 - 2);
+    expect(supportEmailProblem(atCeiling)).toBeNull();
+    for (const line of licenseEmailText("Ada", "QUJD", atCeiling).split("\n")) {
+      expect(line.length).toBeLessThanOrEqual(72);
+    }
+    expect(supportEmailProblem(`a${atCeiling}`)).toBe("too-long");
   });
 
   it("unconfigured Resend → retryable 500, not a silent drop", async () => {

--- a/tests/server/license-issuance-worker.test.ts
+++ b/tests/server/license-issuance-worker.test.ts
@@ -16,6 +16,7 @@ import issuanceWorker, {
   type IssuanceDeps,
   type KvNamespace,
   LICENSE_VERSION,
+  supportEmailProblem,
 } from "../../infra/license-issuance-worker/src/worker.js";
 import {
   handleUpdateRequest,
@@ -936,6 +937,7 @@ describe("default fetch wiring (env → deps)", () => {
       TANDEM_PRIVATE_KEY: pem,
       RESEND_API_KEY: "re_test",
       RESEND_FROM: "Tandem <noreply@example.com>",
+      SUPPORT_EMAIL: "support@tandem.test",
       LICENSE_KV: makeKv(),
       LEDGER_KV: makeKv(),
       ...overrides,
@@ -1127,6 +1129,107 @@ describe("default fetch wiring (env → deps)", () => {
       good as never,
     );
     expect(res2.status).toBe(200);
+  });
+
+  // --- SUPPORT_EMAIL fail-closed guard (#1289) ------------------------------
+  // Two silent failures used to be reachable from `[vars]` alone: an unset
+  // value dropped the support block from the email AND the `reply_to` header,
+  // so a buyer whose activation failed replied into a noreply; and the shipped
+  // placeholder went out on the wire and printed in the body of a mail sent to
+  // someone who had just paid.
+
+  it("a placeholder SUPPORT_EMAIL → 503 before anything is minted or emailed", async () => {
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    // The literal value shipped in infra/license-issuance-worker/wrangler.toml.
+    const env = makeEnv({ SUPPORT_EMAIL: "REPLACE_WITH_SUPPORT_INBOX" });
+    const res = await issuanceWorker.fetch(
+      makeRequest(paidBody("ord_se"), { id: "evt_se", ts: nowTs() }),
+      env as never,
+    );
+    expect(res.status).toBe(503);
+    // Fails BEFORE any durable write, so Polar's re-delivery fulfils the event
+    // unchanged once the var is fixed — no orphan license, no half-written order.
+    expect(env.LEDGER_KV.map.size).toBe(0);
+    expect(env.LICENSE_KV.map.size).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("an unset SUPPORT_EMAIL → 503, not a license email with no reply channel", async () => {
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const env = makeEnv({ SUPPORT_EMAIL: undefined });
+    const res = await issuanceWorker.fetch(
+      makeRequest(paidBody("ord_se2"), { id: "evt_se2", ts: nowTs() }),
+      env as never,
+    );
+    expect(res.status).toBe(503);
+    expect(env.LEDGER_KV.map.size).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("the guard's stage is distinguishable from the signing key's", async () => {
+    // Both fail closed with an identical 503, so the log stage is the only
+    // thing telling an operator whether to re-put a secret or edit a [vars]
+    // line. Collapsing them into `config` would make the 503 undiagnosable.
+    const logs: unknown[] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((line: string) => {
+      logs.push(JSON.parse(line));
+    });
+    try {
+      await issuanceWorker.fetch(
+        makeRequest(paidBody("ord_se3"), { id: "evt_se3", ts: nowTs() }),
+        makeEnv({ SUPPORT_EMAIL: "  " }) as never,
+      );
+      await issuanceWorker.fetch(
+        makeRequest(paidBody("ord_se4"), { id: "evt_se4", ts: nowTs() }),
+        makeEnv({ TANDEM_PRIVATE_KEY: "garbage-not-a-pem" }) as never,
+      );
+    } finally {
+      spy.mockRestore();
+    }
+    expect(logs.map((e) => (e as { stage?: string }).stage)).toEqual([
+      "config-support-email",
+      "config",
+    ]);
+  });
+
+  it("a configured SUPPORT_EMAIL reaches both reply_to and the email body", async () => {
+    const fetchMock = vi.fn(async () => new Response('{"id":"em_2"}', { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const env = makeEnv();
+    await issuanceWorker.fetch(
+      makeRequest(paidBody("ord_se5"), { id: "evt_se5", ts: nowTs() }),
+      env as never,
+    );
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const sent = JSON.parse(init.body as string);
+    expect(sent.reply_to).toBe("support@tandem.test");
+    expect(sent.text as string).toContain("support@tandem.test");
+  });
+
+  it("supportEmailProblem names the misconfiguration it found", () => {
+    // Placeholder cases are the strings this repo actually ships (wrangler.toml
+    // line 27, and the `noreply@yourdomain.com` RESEND_FROM example above it) —
+    // not an invented list.
+    expect(supportEmailProblem(undefined)).toBe("unset");
+    expect(supportEmailProblem("")).toBe("unset");
+    expect(supportEmailProblem("   \t ")).toBe("unset");
+    expect(supportEmailProblem("REPLACE_WITH_SUPPORT_INBOX")).toBe("placeholder");
+    expect(supportEmailProblem("replace_with_support_inbox")).toBe("placeholder");
+    // A placeholder that IS address-shaped — the case a bare `@` check misses.
+    expect(supportEmailProblem("support@yourdomain.com")).toBe("placeholder");
+    expect(supportEmailProblem("Support <REPLACE_WITH_SUPPORT_INBOX>")).toBe("placeholder");
+    expect(supportEmailProblem("support")).toBe("malformed");
+    expect(supportEmailProblem("@tandem.ink")).toBe("malformed");
+    expect(supportEmailProblem("support@")).toBe("malformed");
+    expect(supportEmailProblem("support@tandem")).toBe("malformed"); // dotless domain
+    expect(supportEmailProblem("sup port@tandem.ink")).toBe("malformed");
+    // Valid, including the display-name form RESEND_FROM's own example uses —
+    // an operator copying that shape across must not take issuance down.
+    expect(supportEmailProblem("support@tandem.ink")).toBeNull();
+    expect(supportEmailProblem("  support@tandem.ink  ")).toBeNull();
+    expect(supportEmailProblem("Tandem Support <support@tandem.ink>")).toBeNull();
   });
 
   it("unconfigured Resend → retryable 500, not a silent drop", async () => {


### PR DESCRIPTION
> ## Issuance Worker fails closed on a bad `SUPPORT_EMAIL`
>
> Closes #1289.
>
> `SUPPORT_EMAIL` was `?: string` and both consumers branched on truthiness, so "missing" was a supported state rather than an error. Unset meant a paid customer's license email carried no `reply_to` **and** no support address in the body, with `RESEND_FROM` being a noreply — a buyer whose activation fails replies into a void. Left at the shipped `REPLACE_WITH_SUPPORT_INBOX`, that literal went on the wire as `reply_to` and printed in the body. Both returned a clean 200 and logged `{"result":"issued"}`. The runbook's checklist line was the only control.
>
> **`infra/license-issuance-worker/src/worker.ts`**
> - New exported pure `supportEmailProblem(raw) → "unset" | "placeholder" | "malformed" | "too-long" | null`.
> - Guard at the top of `fetch`, right after the signing-key import, returning 503 with a new `FailStage` member `"config-support-email"`.
> - `SUPPORT_EMAIL` is required in `WorkerEnv`; `reply_to` and the body block are unconditional.
>
> **Why boot-of-request, not point-of-use.** By the time the email is composed the license is minted, the entitlement is in `LICENSE_KV` and the order is in the ledger — a refusal there strands an issued-but-undeliverable license behind a 500 retry loop that can never succeed, and only fires *for a buyer*, i.e. after a bad deploy has already cost a sale. Failing before signature verification writes nothing durable, so Polar's re-delivery fulfils the untouched event once the var is fixed. Same trade the signing-key import makes three lines above.
>
> **Why a separate stage.** Both config failures return an identical 503, so the stage is the only thing telling an operator whether to re-put a secret or edit a `[vars]` line. The problem *kinds* share one stage — they name the same var, and its value distinguishes them.
>
> **The placeholder set is grepped, not invented:** `/replace_with|yourdomain/i` covers `REPLACE_WITH_SUPPORT_INBOX` (wrangler.toml:31) and the `noreply@yourdomain.com` `RESEND_FROM` example above it. The second matters — it is address-shaped, so the issue's suggested "must contain `@`" bar misses it. `Name <addr@dom.tld>` is accepted, because `RESEND_FROM`'s documented example uses that shape and 503-ing a valid address is an outage, not a safeguard.
>
> **Length bound.** The address prints on its own line under a two-space indent, beneath the wrapped base64 key. A value over 70 characters pushes that line past `wrapBlob`'s 72 — the width chosen so nothing invites an MTA to re-encode the body as quoted-printable, whose soft break silently truncates the key. The permitted display-name form is exactly the long shape, so the widest accepted value was also the one most likely to break activation for every buyer. Verified before fixing: the guard returned `null` for a 74-character value that rendered a 76-character line. The test pairs the rejection with a positive control at the ceiling, so it pins the wrap invariant rather than the number 70.
>
> **Known gap, recorded not closed.** Config-stage failures are not alertable: `isAlertable` fires only on `dropped` or `stage === "email"`. So this converts "customer gets a bad email" into "every webhook 503s and nothing wakes the operator". Left deliberately — the pre-existing signing-key guard has the identical property; the check runs *before* signature verification, so alerting it would give an unauthenticated caller a way to trigger outbound webhook/Resend sends; and `alertBody` assumes exactly two arms. Documented in `docs/licensing-operations.md` §5b, worth its own issue.
>
> `wrangler.toml` keeps its `REPLACE_WITH_SUPPORT_INBOX` placeholder — it is an owner-deployed template, and that placeholder is now the thing the Worker refuses.
>
> **Verification:** 60 tests in `tests/server/license-issuance-worker.test.ts`, `npm run typecheck` clean (1295 files, 0 errors), biome clean. Negative controls run for both the guard and the length bound; each removal reds exactly the tests that assert it. Nothing here is on the `LICENSE_GATE_ENABLED` path — `infra/` Workers deploy separately and are not inputs to `tsup.config.ts`; no `src/` bytes changed.

Branch `fix/issuance-worker-support-email` in `C:\Users\blokn\GitHub\tandem-w2-issuance-worker`, 3 commits, **not pushed, no PR opened**. E2E not run.

---

*Wave 2 of the backlog campaign. Fixed by one agent, then independently verified by a second that re-derived each root cause and re-ran the negative controls itself.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKcPLgN9YGgfC1WvPJ2Vq
