### PR TITLE
fix(doc-backup): stop the backup root's own ACL bricking its subdirs, and say something useful when a snapshot fails (#1299)

### DIFF
--- a/src/server/file-io/doc-backup.ts
+++ b/src/server/file-io/doc-backup.ts
@@ -346,11 +346,23 @@ export async function snapshotBeforeFirstWrite(
     // content (prose, not tokens), so unlike integrations/backup.ts an ACL
     // failure keeps the backup — an existing backup beats no backup. The ACL
     // spawns icacls/whoami, so apply it once per run, not once per path.
+    //
+    // `inheritable` is load-bearing, not cosmetic. The ACL lands on the ROOT
+    // while the snapshot is written to a per-path SUBDIR that the `mkdir`
+    // below may have just created. A non-inheritable grant plus
+    // `/inheritance:r` strips that subdir's DACL to EMPTY, and every write
+    // into it then fails EPERM — permanently, because nothing ever re-ACLs a
+    // subdir and the once-per-run `aclEnsured` latch stops the root ACL from
+    // being retried either (#1299). It bit the first path snapshotted per
+    // install, which on a fresh install is always the auto-opened
+    // `welcome.md`. The inheritable grant also REPAIRS subdirs already
+    // poisoned by the old behaviour — re-running icacls propagates the new
+    // inheritable ACE down to them.
     await fs.mkdir(subdir, { recursive: true, mode: 0o700 });
     if (process.platform === "win32" && !aclEnsured) {
       aclEnsured = true;
       try {
-        await setRestrictiveAcl(root);
+        await setRestrictiveAcl(root, { inheritable: true });
       } catch (aclErr) {
         console.error("[DocBackup] Restrictive ACL on backup root failed (continuing):", aclErr);
       }

--- a/src/server/file-io/doc-backup.ts
+++ b/src/server/file-io/doc-backup.ts
@@ -255,6 +255,40 @@ export function docBackupSnapshotPath(
   return path.join(docBackupsRoot(appDataDir), docHash(filePath), name);
 }
 
+/**
+ * Human cause clause for a snapshot failure, keyed on errno. Deliberately
+ * NOT the raw `err.message`: Node's fs errors serialize as
+ * `EPERM: operation not permitted, open 'C:\\Users\\<name>\\AppData\\...'`,
+ * which is stack-trace-shaped in a toast, leaks the user's account name and
+ * an internal implementation path they have no reason to see, and tells them
+ * nothing they can act on (#1299).
+ *
+ * Unmapped codes contribute no clause rather than a guess — the errno still
+ * travels on the notification's `errorCode`, and the full error object is on
+ * stderr for diagnostics.
+ */
+export function describeSnapshotFailure(err: unknown): string {
+  switch ((err as NodeJS.ErrnoException | undefined)?.code) {
+    case "EPERM":
+    case "EACCES":
+      return "Tandem does not have permission to write to its backup folder — antivirus or folder-permission software may be blocking it.";
+    case "ENOSPC":
+      return "There is no free disk space for the backup.";
+    case "EROFS":
+      return "The backup location is read-only.";
+    case "EBUSY":
+    case "ETXTBSY":
+      return "The document is locked by another program.";
+    case "EMFILE":
+    case "ENFILE":
+      return "Too many files are open on this system.";
+    case "ENAMETOOLONG":
+      return "The backup file path is too long for this filesystem.";
+    default:
+      return "";
+  }
+}
+
 export type SnapshotOutcome =
   | "written"
   | "skipped-already-this-run"
@@ -409,17 +443,25 @@ export async function snapshotBeforeFirstWrite(
     // Gate stays unset — the next save retries. The console line fires on
     // every retry; the user-facing notification only once per path until a
     // snapshot succeeds (a 60s autosave would otherwise re-toast each minute).
-    const msg = err instanceof Error ? err.message : String(err);
     console.error("[DocBackup] Snapshot failed for %s (save proceeds):", filePath, err);
     if (!failureNotifiedPaths.has(pathKey)) {
       failureNotifiedPaths.add(pathKey);
+      // Worth telling the user about even though the save itself is fine: a
+      // silently-absent safety net is worse than a noisy one, because the
+      // whole point of snapshots is that you find out you needed one later.
+      // But the sentence must not claim the save succeeded — this runs
+      // BEFORE the write, which can still fail and raise its own toast.
+      const cause = describeSnapshotFailure(err);
       pushNotification({
         id: generateNotificationId(),
         type: "general-error",
         severity: "warning",
-        message: `Could not back up ${path.basename(filePath)} before saving: ${msg}`,
+        message:
+          `Couldn't store a backup copy of "${path.basename(filePath)}". ` +
+          `Saving is unaffected.${cause ? ` ${cause}` : ""}`,
         documentId: opts.documentId,
         dedupKey: `doc-backup:${pathKey}`,
+        errorCode: (err as NodeJS.ErrnoException | undefined)?.code,
         timestamp: Date.now(),
       });
     }

--- a/src/server/file-io/doc-backup.ts
+++ b/src/server/file-io/doc-backup.ts
@@ -136,6 +136,34 @@ export function snapshotFilename(filePath: string, now: Date = new Date()): stri
   return `${stem}-${formatTimestamp(now)}-${uuid8}${safeExt ? `.${safeExt}` : ""}`;
 }
 
+/**
+ * Create the doc-backups root and apply its restrictive Windows DACL, at most
+ * once per server run.
+ *
+ * Best-effort by design: snapshots hold user document content (prose, not
+ * tokens), so unlike `integrations/backup.ts` an ACL failure keeps the backup
+ * — an existing backup beats no backup. `setRestrictiveAcl` spawns
+ * icacls/whoami, hence the once-per-run latch rather than once-per-path.
+ *
+ * `inheritable` is load-bearing, not cosmetic: the ACL lands on the ROOT while
+ * snapshots are written into per-path SUBDIRs, and the default grant strips
+ * those subdirs to an EMPTY, deny-everyone DACL (#1299 — full mechanism in
+ * `setRestrictiveAcl`'s docblock). It bit the first path snapshotted per
+ * install, which on a fresh install is always the auto-opened `welcome.md`.
+ * The inheritable grant also REPAIRS subdirs already poisoned by the old
+ * behaviour — re-running icacls propagates the new ACE down to them.
+ */
+async function ensureBackupRootHardened(root: string): Promise<void> {
+  await fs.mkdir(root, { recursive: true, mode: 0o700 });
+  if (process.platform !== "win32" || aclEnsured) return;
+  aclEnsured = true;
+  try {
+    await setRestrictiveAcl(root, { inheritable: true });
+  } catch (aclErr) {
+    console.error("[DocBackup] Restrictive ACL on backup root failed (continuing):", aclErr);
+  }
+}
+
 /** List snapshot filenames in a per-path subdir, newest first. */
 async function listSnapshots(dir: string): Promise<string[]> {
   let entries: string[];
@@ -338,6 +366,15 @@ export async function snapshotBeforeFirstWrite(
     const root = docBackupsRoot(opts.appDataDir);
     const subdir = path.join(root, pathKey);
 
+    // Position is load-bearing: harden BEFORE anything READS the tree, not
+    // merely before the write. A poisoned subdir's empty DACL denies `readdir`
+    // (`EPERM … scandir`) exactly as it denies `open`, so with hardening any
+    // later than this `listSnapshots` below rethrows and the repair is never
+    // reached — leaving the one document the bug always claims permanently
+    // broken. This line is what makes the inheritable grant an actual repair
+    // rather than a fix for fresh installs only.
+    await ensureBackupRootHardened(root);
+
     // Byte-identical skip: nothing changed on disk since the newest snapshot
     // (typical across restarts with no external edits). ENOENT mid-read (e.g.
     // a peer instance pruning concurrently) means "no prior snapshot" —
@@ -376,31 +413,10 @@ export async function snapshotBeforeFirstWrite(
       return "skipped-size-cap";
     }
 
-    // 0o700/0o600 + best-effort Windows ACL: snapshots hold user document
-    // content (prose, not tokens), so unlike integrations/backup.ts an ACL
-    // failure keeps the backup — an existing backup beats no backup. The ACL
-    // spawns icacls/whoami, so apply it once per run, not once per path.
-    //
-    // `inheritable` is load-bearing, not cosmetic. The ACL lands on the ROOT
-    // while the snapshot is written to a per-path SUBDIR that the `mkdir`
-    // below may have just created. A non-inheritable grant plus
-    // `/inheritance:r` strips that subdir's DACL to EMPTY, and every write
-    // into it then fails EPERM — permanently, because nothing ever re-ACLs a
-    // subdir and the once-per-run `aclEnsured` latch stops the root ACL from
-    // being retried either (#1299). It bit the first path snapshotted per
-    // install, which on a fresh install is always the auto-opened
-    // `welcome.md`. The inheritable grant also REPAIRS subdirs already
-    // poisoned by the old behaviour — re-running icacls propagates the new
-    // inheritable ACE down to them.
+    // 0o700 mode on the per-path subdir. Windows ignores it; the root's
+    // inheritable DACL (see `ensureBackupRootHardened`) is what covers this
+    // directory there, and it is already in force by the time we get here.
     await fs.mkdir(subdir, { recursive: true, mode: 0o700 });
-    if (process.platform === "win32" && !aclEnsured) {
-      aclEnsured = true;
-      try {
-        await setRestrictiveAcl(root, { inheritable: true });
-      } catch (aclErr) {
-        console.error("[DocBackup] Restrictive ACL on backup root failed (continuing):", aclErr);
-      }
-    }
 
     // `wx` exclusive-create: a pre-planted symlink or colliding name fails the
     // open instead of following it. UUID suffix makes the path unpredictable.

--- a/src/server/integrations/acl-win.ts
+++ b/src/server/integrations/acl-win.ts
@@ -25,6 +25,9 @@
  *   `:r` on both flags, inherited ACEs from the parent dir survive and
  *   `/grant` adds the user as an additional principal instead of
  *   replacing the ACL.
+ * - On a DIRECTORY that already has children, the default
+ *   (non-inheritable) grant is destructive — pass `{ inheritable: true }`.
+ *   See `setRestrictiveAcl`'s docblock for the mechanism.
  * - The tempfile self-verify (`assertNoBroadAce` at the end of
  *   `setRestrictiveAcl`) is load-bearing — icacls is documented to exit
  *   0 on partial failure (silent no-op). The SDDL re-read is the only
@@ -135,9 +138,28 @@ async function getCurrentUserSid(): Promise<string> {
  * documented to exit 0 even when "Failed processing N files" — the SDDL
  * read is the only trustworthy signal that the DACL is actually correct.
  *
+ * `inheritable` adds the `(OI)(CI)` object/container-inherit flags to the
+ * grant, and is REQUIRED when `path` is a directory whose children already
+ * exist. The default (flagless) grant applies to the directory object
+ * alone, and combined with `/inheritance:r` it is actively destructive:
+ * breaking inheritance on the parent makes Windows recompute the inherited
+ * ACEs of every existing child, and a non-inheritable parent ACE
+ * contributes none. A child that had only inherited ACEs — i.e. any
+ * directory Node's `mkdir` just created — is left with an **empty DACL**,
+ * which denies everyone including its owner. Writing into it then fails
+ * `EPERM`, permanently, because nothing re-ACLs the child (#1299). Newly
+ * created children are unaffected either way: with no inheritable ACE to
+ * inherit they fall back to the process token's default DACL.
+ *
+ * Files take no children, so token-file callers correctly leave this off —
+ * `(OI)(CI)` on a leaf is meaningless.
+ *
  * @throws if any step (SID resolve, icacls, verify) fails.
  */
-export async function setRestrictiveAcl(path: string): Promise<void> {
+export async function setRestrictiveAcl(
+  path: string,
+  opts: { inheritable?: boolean } = {},
+): Promise<void> {
   if (process.platform !== "win32") return;
 
   const sid = await getCurrentUserSid();
@@ -150,9 +172,16 @@ export async function setRestrictiveAcl(path: string): Promise<void> {
   //                    accumulate over repeated runs).
   //   *<SID>:F       — grant Full Control by SID. The `*` prefix tells
   //                    icacls to interpret the principal as a raw SID
-  //                    rather than a name to look up.
+  //                    rather than a name to look up. `(OI)(CI)` prefixes
+  //                    the rights when `inheritable` — see the docblock.
+  const rights = opts.inheritable ? "(OI)(CI)F" : "F";
   try {
-    await execFileAsync(systemBin("icacls.exe"), [path, "/inheritance:r", "/grant:r", `*${sid}:F`]);
+    await execFileAsync(systemBin("icacls.exe"), [
+      path,
+      "/inheritance:r",
+      "/grant:r",
+      `*${sid}:${rights}`,
+    ]);
   } catch (err) {
     throw new Error(`setRestrictiveAcl: icacls failed on ${path}: ${(err as Error).message}`, {
       cause: err,

--- a/tests/server/file-io/doc-backup-acl-repair.test.ts
+++ b/tests/server/file-io/doc-backup-acl-repair.test.ts
@@ -1,0 +1,92 @@
+/**
+ * #1299 — the doc-backup ACL bug, exercised END TO END with real `icacls`.
+ *
+ * Deliberately a separate file from `doc-backup.test.ts`, which mocks
+ * `acl-win.js` at module scope and therefore cannot observe any of this. The
+ * unit suite proves the toast; `acl-win.test.ts` proves the icacls primitive.
+ * Neither proves the thing that actually matters to the reporter: that a
+ * machine ALREADY poisoned by the old non-inheritable grant recovers by
+ * running the fixed build, with nothing to delete by hand.
+ *
+ * That gap was real. The inheritable grant alone did not repair such a
+ * machine: an empty DACL denies `readdir` (`EPERM … scandir`) just as it
+ * denies `open`, so `listSnapshots` threw before the ACL was ever applied.
+ * The repair only works because root hardening now precedes every READ of the
+ * tree, not just the write.
+ */
+
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { docHash } from "../../../src/server/annotations/doc-hash.js";
+import {
+  _resetDocBackupGateForTests,
+  docBackupsRoot,
+  snapshotBeforeFirstWrite,
+} from "../../../src/server/file-io/doc-backup.js";
+
+vi.mock("../../../src/server/notifications.js", () => ({ pushNotification: vi.fn() }));
+
+const WIN_ONLY = process.platform === "win32";
+const execFileAsync = promisify(execFile);
+const systemBin = (name: string) =>
+  path.join(process.env.SystemRoot ?? "C:\\Windows", "System32", name);
+
+/** Current user's SID — the principal the production ACL grants to. */
+async function currentUserSid(): Promise<string> {
+  const { stdout } = await execFileAsync(systemBin("whoami.exe"), ["/user", "/fo", "csv", "/nh"]);
+  return stdout.split(",")[1].replace(/"/g, "").trim();
+}
+
+describe.skipIf(!WIN_ONLY)("doc-backup — recovery from a pre-#1299 poisoned install", () => {
+  let tmpDir: string;
+  let appDataDir: string;
+  let docPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tandem-docbackup-acl-"));
+    appDataDir = path.join(tmpDir, "app-data");
+    docPath = path.join(tmpDir, "welcome.md");
+    fs.writeFileSync(docPath, "# original bytes\n");
+    _resetDocBackupGateForTests();
+  });
+
+  afterEach(async () => {
+    // The subdir may still be un-listable if an assertion failed mid-test, and
+    // an empty DACL defeats rm. Re-grant inheritably before cleaning up.
+    const root = docBackupsRoot(appDataDir);
+    if (fs.existsSync(root)) {
+      const sid = await currentUserSid();
+      await execFileAsync(systemBin("icacls.exe"), [root, "/grant", `*${sid}:(OI)(CI)F`]).catch(
+        () => {},
+      );
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("snapshots successfully on an install whose subdir the old grant already bricked", async () => {
+    const root = docBackupsRoot(appDataDir);
+    const subdir = path.join(root, docHash(docPath));
+    fs.mkdirSync(subdir, { recursive: true });
+
+    // Reproduce the pre-fix state verbatim: the OLD non-inheritable grant on
+    // the root, applied while the per-path subdir already exists.
+    const sid = await currentUserSid();
+    await execFileAsync(systemBin("icacls.exe"), [root, "/inheritance:r", "/grant:r", `*${sid}:F`]);
+
+    // Positive control that the poison took — without this the test would
+    // pass just as well against a healthy tree and prove nothing.
+    expect(() => fs.readdirSync(subdir)).toThrow(/EPERM/);
+
+    const outcome = await snapshotBeforeFirstWrite(docPath, { appDataDir, documentId: "d1" });
+
+    expect(outcome).toBe("written");
+    const written = fs.readdirSync(subdir).filter((n) => n.startsWith("welcome-"));
+    expect(written).toHaveLength(1);
+    expect(fs.readFileSync(path.join(subdir, written[0]), "utf8")).toBe("# original bytes\n");
+  });
+});

--- a/tests/server/file-io/doc-backup.test.ts
+++ b/tests/server/file-io/doc-backup.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   _resetDocBackupGateForTests,
+  describeSnapshotFailure,
   docBackupsRoot,
   MAX_DOC_BACKUPS,
   sanitizeBackupStem,
@@ -161,10 +162,19 @@ describe("doc-backup", () => {
       const first = await snapshotBeforeFirstWrite(docPath, { appDataDir, documentId: "doc-1" });
       expect(first).toBe("failed");
       expect(pushNotificationMock).toHaveBeenCalledTimes(1);
-      expect(pushNotificationMock.mock.calls[0][0]).toMatchObject({
-        documentId: "doc-1",
-        severity: "warning",
-      });
+      const notification = pushNotificationMock.mock.calls[0][0];
+      expect(notification).toMatchObject({ documentId: "doc-1", severity: "warning" });
+
+      // #1299: the toast is a user-facing surface, so it names the document by
+      // BASENAME and carries nothing else from the error. Node fs errors
+      // serialize as `EPERM: operation not permitted, open '<abs path>'` —
+      // pasting that in put a stack-trace-shaped string and the user's home
+      // directory on screen. The errno survives as structured data instead.
+      expect(notification.message).toContain("thesis.md");
+      expect(notification.message).not.toMatch(/\bE[A-Z]{2,}\b/);
+      expect(notification.message).not.toContain(appDataDir);
+      expect(notification.message).not.toContain(root);
+      expect(notification.errorCode).toMatch(/^E[A-Z]+$/);
 
       // A second failure on the same path retries but does NOT re-notify —
       // the 60s autosave loop would otherwise toast every minute.
@@ -189,6 +199,35 @@ describe("doc-backup", () => {
 
       expect(outcome).toBe("written");
       expect(allSnapshots()[0].content).toBe("the victim's irreplaceable notes\n");
+    });
+  });
+
+  describe("describeSnapshotFailure", () => {
+    it.each([
+      { code: "EPERM", match: /permission/i, why: "the #1299 report's own errno" },
+      { code: "EACCES", match: /permission/i, why: "POSIX twin of EPERM" },
+      { code: "ENOSPC", match: /disk space/i, why: "actionable: free space" },
+      { code: "EROFS", match: /read-only/i, why: "actionable: wrong volume" },
+      { code: "EBUSY", match: /locked by another program/i, why: "actionable: close it" },
+    ])("maps $code to an actionable clause ($why)", ({ code, match }) => {
+      expect(describeSnapshotFailure(Object.assign(new Error("boom"), { code }))).toMatch(match);
+    });
+
+    it("contributes no clause for an unmapped or non-errno failure", () => {
+      // A guessed cause is worse than none — the errno still rides on the
+      // notification's `errorCode` and the full error is on stderr.
+      expect(describeSnapshotFailure(new Error("something odd"))).toBe("");
+      expect(describeSnapshotFailure(undefined)).toBe("");
+    });
+
+    it("never returns the raw error message", () => {
+      const err = Object.assign(
+        new Error("EPERM: operation not permitted, open 'C:\\Users\\Akapl\\AppData\\Local\\x.md'"),
+        { code: "EPERM" },
+      );
+      const described = describeSnapshotFailure(err);
+      expect(described).not.toContain("EPERM");
+      expect(described).not.toContain("C:\\Users");
     });
   });
 

--- a/tests/server/integrations/acl-win.test.ts
+++ b/tests/server/integrations/acl-win.test.ts
@@ -60,6 +60,33 @@ describe.skipIf(!WIN_ONLY)("acl-win — Windows DACL hardening", () => {
     });
   }
 
+  // #1299: doc-backup ACLs a ROOT directory whose per-path subdirs already
+  // exist. This walks the full lifecycle the bug produced — poison, observe
+  // EPERM, repair — with real icacls, because the doc-backup unit suite mocks
+  // this module and therefore cannot see any of it. The repair phase is also
+  // what makes the tree deletable again in afterEach.
+  it("grant on a directory: non-inheritable strips an existing child's DACL, inheritable repairs it", async () => {
+    const root = path.join(tmpDir, "doc-backups");
+    const child = path.join(root, "abc123hash");
+    const snapshot = path.join(child, "welcome-20260805-160342-45f01c92.md");
+    fs.mkdirSync(child, { recursive: true });
+    // Baseline: a plain inherited-ACE child is writable.
+    fs.writeFileSync(snapshot, "original bytes");
+    fs.rmSync(snapshot);
+
+    // Poison: the default grant applies to `root` alone, so breaking
+    // inheritance leaves `child` with an EMPTY DACL — deny-all, owner included.
+    await setRestrictiveAcl(root);
+    expect(() => fs.writeFileSync(snapshot, "original bytes", { flag: "wx" })).toThrow(/EPERM/);
+
+    // Repair: an inheritable grant propagates down to the existing child.
+    await setRestrictiveAcl(root, { inheritable: true });
+    expect(() => fs.writeFileSync(snapshot, "original bytes", { flag: "wx" })).not.toThrow();
+    expect(fs.readFileSync(snapshot, "utf8")).toBe("original bytes");
+    // Hardening is not traded away for the fix.
+    await expect(assertNoBroadAce(root)).resolves.toBeUndefined();
+  });
+
   it("setRestrictiveAcl throws when icacls cannot act on the path", async () => {
     // Non-existent path → icacls exits non-zero. setRestrictiveAcl must
     // wrap the error with the path in the message for forensics.


### PR DESCRIPTION
## Summary

Fixes #1299. The reported mechanism is refuted: this was not antivirus or a
locked user file. Tandem inflicted the `EPERM` on itself, on its own folder
under AppData, and the unreadable toast was the second defect rather than the
first.

## Root cause

`snapshotBeforeFirstWrite` runs `mkdir(subdir)` -> `setRestrictiveAcl(root)` ->
`writeFile(subdir/snap.md)`. `setRestrictiveAcl` ran
`icacls <root> /inheritance:r /grant:r *<SID>:F` -- a **non-inheritable** grant.
Correct on a leaf file; destructive on a directory. Breaking inheritance makes
Windows recompute every existing child's inherited ACEs, and a parent ACE
without `(OI)(CI)` contributes none -- so the per-path subdir created moments
earlier, which had *only* inherited ACEs, is left with an **empty DACL** that
denies everyone including its owner. The write two lines later fails `EPERM`.

Three things this explains that "locked file / antivirus" does not: the error
path is Tandem's own AppData folder, not the user's document; it is always
`welcome.md` (only a subdir existing *before* the root was hardened gets
stripped, so the victim is the first path snapshotted per install); and it never
self-heals, because nothing re-ACLs a subdir and the once-per-run `aclEnsured`
latch stops the root ACL being reapplied.

## Changes

1. **`acl-win.ts`** -- opt-in `{ inheritable: true }` adding `(OI)(CI)`. Default
   unchanged, so token-file callers keep the correct leaf behaviour. The other
   directory callers (`storage.ts`, `apply.ts`, `install-claude-cli.ts`) are
   deliberately untouched and were measured, not assumed: their children are
   files created *after* the first ACL, so they hold explicit token-default ACEs
   that survive inheritance recomputation. `doc-backup` is uniquely affected
   because its child is a subdir whose ACEs were purely inherited.

2. **`doc-backup.ts` -- the grant, and its position.** Passing `inheritable`
   fixes fresh installs. It does **not** on its own recover a machine already
   poisoned by the old grant, which is the state the reporter is in: an empty
   DACL denies `readdir` (`EPERM ... scandir`) exactly as it denies `open`, and
   `listSnapshots(subdir)` ran ahead of the ACL call and rethrows anything
   non-`ENOENT`. The function threw before the repair was ever reached and
   returned `"failed"` forever. Root hardening is now extracted to
   `ensureBackupRootHardened` and called before **any read** of the tree, which
   is what makes the inheritable grant an actual repair. Poisoned installs
   recover by running this build; nothing to delete by hand.

3. **The toast.** Was `Could not back up thesis.md before saving: EPERM:
   operation not permitted, open 'C:\Users\<name>\AppData\...'` -- stack-trace
   shaped, leaking the account name and an internal path, and unactionable. Now:
   `Couldn't store a backup copy of "welcome.md". Saving is unaffected. Tandem
   does not have permission to write to its backup folder — antivirus or
   folder-permission software may be blocking it.` The errno maps to a short
   cause clause (permissions / disk full / read-only / locked); unmapped codes
   contribute none rather than a guess; the code moves to the notification's
   existing `errorCode` field and stderr keeps the full error. The wording
   deliberately does not claim the save succeeded -- this runs *before* the
   write, which can still fail and raise its own toast.

The warn-once gate was already correct and is untouched: `failureNotifiedPaths`
is separate from `snapshottedPaths` precisely so a failure still retries.

## Tests

- `acl-win.test.ts` -- real `icacls`, walks poison -> `EPERM` -> repair, and
  asserts `assertNoBroadAce` still holds so hardening is not traded for the fix.
- `doc-backup-acl-repair.test.ts` (new) -- drives the real
  `snapshotBeforeFirstWrite` against a tree poisoned with real `icacls`, with a
  positive control asserting the poison took. Separate file because the existing
  `doc-backup` suite mocks `acl-win` at module scope and structurally cannot see
  any of this. This is the test that catches the recovery gap; without the
  hoist it fails `expected 'failed' to be 'written'`.
- `doc-backup.test.ts` -- the toast names the document by basename and carries
  no errno, no absolute path, no appDataDir; `errorCode` carries the errno.

## Not fixed here

- `storage.ts:265`'s docblock states a mechanism that was not the one running
  ("the file inherits the dir's restricted DACL at create-time"). Nothing was
  inherited; those copies got the token default DACL. Not a broad-principal
  leak, so `assertNoBroadAce` passes and nothing is exposed -- but the comment
  is wrong and deserves its own change.
- `document-service.ts:555,856,1384` interpolate raw `err.message` into save /
  save-as / rename toasts, same defect class. Different UX judgement (a *failed*
  save is a case where raw detail is more defensible than a *succeeded* one), so
  it warrants its own decision rather than being swept in here.
- The reporter's other complaint (Claude connected but not interactive) is
  unrelated and untouched.
```

**Not pushed, no PR opened.** Branch `fix/doc-backup-eperm-toast` in `C:/Users/blokn/GitHub/tandem-w4-eperm-backup` is 4 commits ahead of `origin/master`; working tree clean.

---

*Wave 4 of the backlog campaign: investigate-before-fixing. Diagnosed by one agent, then independently verified by a second that re-derived the root cause and re-ran the controls itself.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKcPLgN9YGgfC1WvPJ2Vq
