### PR TITLE
docs(perf): refute #1288's mechanism with measurements, and make the harness runnable twice

### DIFF
--- a/docs/perf-gate-results.md
+++ b/docs/perf-gate-results.md
@@ -240,6 +240,15 @@ card stack — is refuted twice, on independent evidence:
    The crowding pass has no motion input at all, so a flag that only disables
    transitions cannot change its cost. It changes this one by a factor of four.
 
+   Note the limit of this experiment. `reduceMotion` is a GLOBAL kill switch: it
+   zeroes every transition in `cardMotion.ts`, the `cardFlyToMargin` entrance on
+   the margin bubble, the annotation ping, and every
+   `@media (prefers-reduced-motion)` rule via the `tandem-reduce-motion` body
+   class. That makes it conclusive against `resolveCrowding` — which it cannot
+   reach — and conclusive that the remaining cost is motion. It does NOT
+   apportion that cost among individual transitions. `AnnotationCard`'s
+   `lifecycleMotion` prop is the narrower knob and was not used.
+
 ### What the accept measurement actually spends
 
 The button is not blocked, starved, or overlaid. An in-page sampler run across
@@ -251,9 +260,11 @@ Clicking after that idle costs **203ms**, against 460–534ms for the same click
 issued immediately after the create. The difference is not contention; it is the
 app still finishing its entrance.
 
-Both halves land on the card's own lifecycle motion
+Both halves are motion, and the card's own lifecycle transitions
 (`src/client/panels/cardMotion.ts`, wired at `SidePanel.svelte`'s
-`lifecycleMotion={true}`):
+`lifecycleMotion={true}`) are the leading candidate for each. Read the two
+bullets below as candidates, not as findings — the durations fit, but only the
+click half fits cleanly:
 
 - **`cardEnter` (A4, `ENTER_MS = 260`)** runs on the freshly created card. It
   animates `height: 0 → h` under `overflow: clip`, plus a `translateY`, so for
@@ -262,17 +273,31 @@ Both halves land on the card's own lifecycle motion
   that entrance. This also explains run 1's `click({ force: true })` probe
   dispatching instantly and the accept then never taking effect: a forced click
   computes its point from a box that is still moving.
-- **`cardExit` (A1, `EXIT_MS = 260`)** runs on accept. Svelte keeps an outroing
-  block's content mounted for the duration, so the accept control — whose
-  disappearance is the spec's definition of "reflected" — stays in the DOM for
-  the whole outro. Motion off drops the settle from 147–419ms to **6ms**.
+- **`cardExit` (A1, `EXIT_MS = 260`)** runs on accept. Motion off drops the
+  settle from 147–419ms to **6ms**, so the settle is motion — but the specific
+  attribution to `cardExit` is NOT established, and one of the three recorded
+  samples contradicts it. The proposed mechanism is that Svelte keeps an
+  outroing block's content mounted for the duration, so the accept control —
+  whose disappearance is the spec's definition of "reflected" — survives the
+  whole outro. That mechanism has a floor of `EXIT_MS = 260ms`, and sample B
+  settled in **147ms**. A 260ms outro cannot produce a 147ms settle, so either
+  the rail control is leaving before the outro finishes (the margin bubble
+  carries no `out:` transition at all and drops its control on the status flip,
+  and `toHaveCount` counts both surfaces) or the outro is not what is being
+  waited on. Do not build on this bullet: it needs a `lifecycleMotion`-only
+  toggle and a DOM-level observation of when each of the two controls actually
+  unmounts. The click half is on firmer ground — 460–534ms minus the measured
+  ~170–200ms floor lands on `ENTER_MS = 260` — but it is the same class of
+  arithmetic-fit argument and deserves the same direct check.
 
 What remains after both is ~170–200ms of fixed cost present even against a fully
 settled page: selector resolution, scroll-into-view and actionability
 round-trips over CDP. That is the floor this harness can measure, not app cost.
 
-**This is therefore a scoping question, not an optimization target.** Roughly
-520ms of a 500ms budget is deliberate #798 motion, and no human experiences it
+**This is therefore a scoping question, not an optimization target.** The
+`reduceMotion` delta puts ~510–710ms of the total in deliberate #798 motion —
+that figure comes straight from the measurement and does not depend on which
+transitions above turn out to be the ones — and no human experiences it
 as an eight-second wait — they experience a card that animates in over a quarter
 of a second. There are three ways out and none of them should be chosen by
 whoever is holding the profiler: measure the annotation's status flip rather
@@ -295,6 +320,14 @@ Two things are worth saying and nothing more:
   followed a build. Machine contention is not ruled out.
 - The Linux container verification below measured 33ms on the same code. Either
   the platforms genuinely differ here, or one of the two environments is noise.
+- These numbers are already **stale against the scroll path they measure**.
+  Master gained ~950 lines of scroll-path code after `13b0300` — the proximity-
+  faded scroll pill and its controller (`src/client/editor/scroll-pill*`,
+  merged in #1323 on 2026-08-07), plus a wheel-handling fix and keyboard
+  scrolling for read-only documents. Condition 3 is "worst frame gap during a
+  scripted top-to-bottom scroll". Re-measure on current master BEFORE profiling;
+  a mechanism derived from the numbers above would be derived from code that no
+  longer runs the scroll.
 
 Nobody should read a cause into these numbers yet. They need their own profile,
 on a quiet machine, before an issue describes a mechanism.

--- a/docs/perf-gate-results.md
+++ b/docs/perf-gate-results.md
@@ -183,15 +183,121 @@ checklist; it would characterise Chromium on a Mac.
 
 ---
 
-## Run 2 — pending
+## Run 2 — 2026-08-07 — Windows 11 workstation
 
-The harness changed materially (see "Harness configuration" above), so run 1's
-numbers are not a baseline and there is currently **no valid recorded run**.
-The v1.0 performance gate therefore remains **open**.
+| | |
+|---|---|
+| Commit | `13b0300` (master), measured from a worktree |
+| Machine | Windows 11 Pro 26200, developer workstation — the same one run 1 used |
+| Build | production (`vite build` + `tsup`), served via `vite preview` |
+| Fixture seed | `20260805` — 22,608 words, ~50.2 pages, 38 sections |
+| Annotation load | 50 pending comments: 49 seeded + 1 measured, all 50 verified anchored |
+| Margin pipeline | **mounted** (`marginView` forced on, column asserted ≥240px / `full`) |
 
-Re-recording requires the same Windows 11 workstation run 1 used — comparing a
-new machine against a superseded run would confound two changes at once. Until
-that run exists, this document records a harness, not a result.
+Three clean samples. No row is an average; each column is one run.
+
+| Condition | Threshold | A | B | C | Verdict |
+|---|---|---|---|---|---|
+| open-to-interactive | < 3000ms | 1325ms | 1634ms | 1017ms | PASS |
+| annotation create | < 500ms | 145ms | 130ms | 39ms | PASS |
+| annotation accept — *click-dispatch* | — | 460ms | 534ms | 485ms | — |
+| annotation accept — *post-click settle* | — | 419ms | 147ms | 396ms | — |
+| annotation accept — **total** | < 500ms | **879ms** | **681ms** | **881ms** | **FAIL** |
+| worst frame gap during full scroll | < 100ms | **2483ms** | **2550ms** | **317ms** | **FAIL** |
+
+Condition 1 and the create half of condition 2 pass with room. The accept half
+of condition 2 and condition 3 fail. Read each failure with the section it gets
+below — they are unrelated, and only one of them is understood.
+
+### #1288 does not reproduce, and its proposed mechanism is refuted
+
+Run 1 recorded `click-dispatch 7851ms`, and #1288 was filed on that number. On
+this harness, on the same workstation, the same measurement is **460–534ms in
+every sample taken** — including one at a fifth of the annotation load. Run 1's
+instrument no longer exists, and two of its four defects bear directly on this
+figure: the margin pipeline never mounted, and the app-data wipe landed under an
+already-restored server, so the load the 7851ms was measured against is not a
+number anyone knows. Nothing in `src/client/` between the two runs plausibly
+moves an eight-second wait. The honest reading is that 8s was an artifact of the
+superseded harness, not a regression that has since been fixed.
+
+The issue's suspected area — `marginPressure.resolveCrowding` and the margin
+card stack — is refuted twice, on independent evidence:
+
+1. **It does not scale with annotation count.** The issue asked for exactly this
+   check. Measured in one browser session so machine state is held constant: at
+   5 pending annotations the accept splits `click-dispatch 511ms / settle 394ms`,
+   statistically the same as the 49-annotation reading beside it. A cost that is
+   flat from 5 to 49 is not the cost of simulating a card stack.
+2. **It vanishes under `reduceMotion`, which `resolveCrowding` never reads.**
+   Same spec, same load, one settings key changed:
+
+   | | click-dispatch | settle | total |
+   |---|---|---|---|
+   | shipped default | 460–534ms | 147–419ms | 681–881ms — FAIL |
+   | `reduceMotion: true` | **169ms** | **6ms** | **175ms** — PASS |
+
+   The crowding pass has no motion input at all, so a flag that only disables
+   transitions cannot change its cost. It changes this one by a factor of four.
+
+### What the accept measurement actually spends
+
+The button is not blocked, starved, or overlaid. An in-page sampler run across
+the click window — rAF gaps, `getBoundingClientRect` per frame,
+`elementFromPoint` at the button's centre, mutation counts, long tasks — found
+the page essentially at rest: **0 long tasks** and 3 DOM mutations over a 12s
+idle window, worst rAF gap 17–33ms, the button's box moving twice by 1px.
+Clicking after that idle costs **203ms**, against 460–534ms for the same click
+issued immediately after the create. The difference is not contention; it is the
+app still finishing its entrance.
+
+Both halves land on the card's own lifecycle motion
+(`src/client/panels/cardMotion.ts`, wired at `SidePanel.svelte`'s
+`lifecycleMotion={true}`):
+
+- **`cardEnter` (A4, `ENTER_MS = 260`)** runs on the freshly created card. It
+  animates `height: 0 → h` under `overflow: clip`, plus a `translateY`, so for
+  260ms the accept control inside it is neither stably positioned nor painted
+  where a hit-test would find it. Playwright's actionability wait is measuring
+  that entrance. This also explains run 1's `click({ force: true })` probe
+  dispatching instantly and the accept then never taking effect: a forced click
+  computes its point from a box that is still moving.
+- **`cardExit` (A1, `EXIT_MS = 260`)** runs on accept. Svelte keeps an outroing
+  block's content mounted for the duration, so the accept control — whose
+  disappearance is the spec's definition of "reflected" — stays in the DOM for
+  the whole outro. Motion off drops the settle from 147–419ms to **6ms**.
+
+What remains after both is ~170–200ms of fixed cost present even against a fully
+settled page: selector resolution, scroll-into-view and actionability
+round-trips over CDP. That is the floor this harness can measure, not app cost.
+
+**This is therefore a scoping question, not an optimization target.** Roughly
+520ms of a 500ms budget is deliberate #798 motion, and no human experiences it
+as an eight-second wait — they experience a card that animates in over a quarter
+of a second. There are three ways out and none of them should be chosen by
+whoever is holding the profiler: measure the annotation's status flip rather
+than the control's disappearance (drops the outro, keeps the intro honest);
+state the threshold as covering motion and raise it; or decide the motion on
+this path costs more than it is worth. The first two are gate-wording changes
+and belong to the roadmap; the third is a design decision.
+
+### Condition 3 fails on Windows and is NOT characterised
+
+Worst frame gap during the scripted scroll: **2483 / 2550 / 317ms** across the
+three samples, with a further 66.6ms and 250.0ms from two instrumented runs. The
+worst long task in each run tracks the worst gap almost exactly (2470 / 2535 /
+305ms), so this is main-thread script — not compositor, not raster.
+
+Two things are worth saying and nothing more:
+
+- It is **not stable**. The spread is a factor of 38 across five runs on one
+  machine, and the two worst readings came from the two runs that immediately
+  followed a build. Machine contention is not ruled out.
+- The Linux container verification below measured 33ms on the same code. Either
+  the platforms genuinely differ here, or one of the two environments is noise.
+
+Nobody should read a cause into these numbers yet. They need their own profile,
+on a quiet machine, before an issue describes a mechanism.
 
 ### Harness verification — 2026-08-06, Linux container — NOT a recorded run
 

--- a/tests/perf/perf-server.mjs
+++ b/tests/perf/perf-server.mjs
@@ -34,8 +34,32 @@
 // Usage: node tests/perf/perf-server.mjs <server-entry> [args...]
 // The remaining argv is run under this same Node binary.
 import { spawn } from "node:child_process";
-import { rmSync } from "node:fs";
+import { readdirSync, rmSync } from "node:fs";
 import path from "node:path";
+
+/**
+ * Paths under `root` whose contents cannot be listed — the descendants that
+ * make a recursive delete fail. Diagnostic only, so its own errors are the
+ * answer rather than a problem: a directory that throws on `readdirSync` IS the
+ * thing being looked for.
+ */
+function findUnreadable(root) {
+  const stuck = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      stuck.push(dir);
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) walk(path.join(dir, entry.name));
+    }
+  };
+  walk(root);
+  return stuck;
+}
 
 /** The one directory this script is ever allowed to delete. Must match
  *  `PERF_APP_DATA_DIR` in tests/perf/playwright.config.ts. */
@@ -53,7 +77,55 @@ if (!resolved || path.basename(resolved) !== PERF_APP_DATA_BASENAME) {
   );
   process.exit(1);
 }
-rmSync(resolved, { recursive: true, force: true });
+// ## Why the wipe is retried, and why it also reports the offending child
+//
+// Observed 2026-08-07, Windows 11: after a normal `perf:gate` run, the next
+// four consecutive runs all died here and the gate became un-runnable for
+// roughly ten minutes:
+//
+//   Error: EPERM, Permission denied: \\?\...\Temp\tandem-perf-data
+//   Error: Process from config.webServer was not able to start. Exit code: 1
+//
+// Both of those messages name the app-data ROOT, and neither names the wipe as
+// the failing step — so from the operator's seat the harness has simply stopped
+// working. It had not. The actual blocker was ONE child:
+// `doc-backups/<docHash>/`, left un-traversable and un-deletable by whatever
+// still held it (an `icacls` on it listed no ACEs at all and `dir` reported its
+// contents as not found — the shape of a Windows delete-pending entry). It
+// cleared on its own later, and a plain `rmdir` then removed it instantly.
+//
+// So there are two separate failures to fix, and only the first is a wait:
+//
+//  1. RETRY covers the short window. `force: true` only suppresses ENOENT, so
+//     it does nothing here. 20 x 250ms bounds the wait at ~5s, well inside the
+//     120s webServer timeout, and costs nothing on first-try success.
+//
+//  2. When the retries are NOT enough — and in the observed case they were
+//     not, by two orders of magnitude — the operator must at least be told
+//     which path is stuck, because that is the whole difference between "wait
+//     and re-run" and "the perf gate is broken". Node reports the root it was
+//     asked to delete, not the descendant that refused, so the walk below
+//     recovers the real offender. Deliberately still FATAL: booting the server
+//     over a surviving `sessions/` dir would silently restore the previous
+//     run's tabs and annotation envelopes and measure a load nobody chose,
+//     which is the exact defect this file exists to prevent (run 1, see
+//     docs/perf-gate-results.md). A wrong number is worse than no number.
+try {
+  rmSync(resolved, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+} catch (err) {
+  console.error(
+    `[perf-server] could not wipe app-data at ${resolved}\n` +
+      `[perf-server] ${err?.code ?? "error"}: ${err?.message ?? err}`,
+  );
+  for (const stuck of findUnreadable(resolved)) {
+    console.error(`[perf-server]   still held: ${stuck}`);
+  }
+  console.error(
+    `[perf-server] On Windows this is usually a delete-pending directory left by the\n` +
+      `[perf-server] previous run; it clears on its own. Wait, or remove the path above by hand.`,
+  );
+  process.exit(1);
+}
 console.error(`[perf-server] wiped app-data at ${resolved} before server start`);
 
 const child = spawn(process.execPath, process.argv.slice(2), { stdio: "inherit" });

--- a/tests/perf/perf-server.mjs
+++ b/tests/perf/perf-server.mjs
@@ -38,10 +38,44 @@ import { readdirSync, rmSync } from "node:fs";
 import path from "node:path";
 
 /**
+ * Block the thread for `ms` without a dependency or an async hop. The wipe has
+ * to finish before `spawn` below, so the retry loop cannot be a promise.
+ */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Recursive delete with a retry loop we own.
+ *
+ * `rmSync`'s own `maxRetries` / `retryDelay` were tried here first and are
+ * INERT for this failure. Measured on Node v24.14.1 / Windows 11, against two
+ * separately constructed holds — an un-traversable directory (`readdirSync`
+ * throws EPERM) and a file held open exclusively by another process — both
+ * `{recursive, force}` and `{recursive, force, maxRetries: 20, retryDelay:
+ * 250}` returned the same EPERM in 0–1ms. Node's retry only covers some of the
+ * syscalls a recursive delete makes, and not the ones that fail here. So a
+ * comment claiming a bounded wait, sitting above options that produce none, is
+ * worse than no retry at all: the operator is told the harness already waited.
+ */
+function wipeWithRetry(target, attempts, delayMs) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      rmSync(target, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      if (attempt >= attempts) throw err;
+      sleepSync(delayMs);
+    }
+  }
+}
+
+/**
  * Paths under `root` whose contents cannot be listed — the descendants that
  * make a recursive delete fail. Diagnostic only, so its own errors are the
  * answer rather than a problem: a directory that throws on `readdirSync` IS the
- * thing being looked for.
+ * thing being looked for. Does NOT see a listable-but-undeletable file; the
+ * caller reports an empty result rather than printing nothing.
  */
 function findUnreadable(root) {
   const stuck = [];
@@ -97,32 +131,42 @@ if (!resolved || path.basename(resolved) !== PERF_APP_DATA_BASENAME) {
 // So there are two separate failures to fix, and only the first is a wait:
 //
 //  1. RETRY covers the short window. `force: true` only suppresses ENOENT, so
-//     it does nothing here. 20 x 250ms bounds the wait at ~5s, well inside the
-//     120s webServer timeout, and costs nothing on first-try success.
+//     it does nothing here, and neither does `rmSync`'s own `maxRetries` — see
+//     `wipeWithRetry` above, which is why the loop is hand-rolled. 20 x 250ms
+//     bounds the wait at ~5s, well inside the 120s webServer timeout, and costs
+//     nothing on first-try success.
 //
 //  2. When the retries are NOT enough — and in the observed case they were
 //     not, by two orders of magnitude — the operator must at least be told
 //     which path is stuck, because that is the whole difference between "wait
 //     and re-run" and "the perf gate is broken". Node reports the root it was
 //     asked to delete, not the descendant that refused, so the walk below
-//     recovers the real offender. Deliberately still FATAL: booting the server
+//     recovers the offender WHEN it is un-listable, which is the observed
+//     shape. It does not catch a plain held-open file (a locked `sessions/*.json`
+//     lists fine and still refuses to unlink), so the walk finding nothing is
+//     itself reported rather than left as silence. Deliberately still FATAL: booting the server
 //     over a surviving `sessions/` dir would silently restore the previous
 //     run's tabs and annotation envelopes and measure a load nobody chose,
 //     which is the exact defect this file exists to prevent (run 1, see
 //     docs/perf-gate-results.md). A wrong number is worse than no number.
 try {
-  rmSync(resolved, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+  wipeWithRetry(resolved, 20, 250);
 } catch (err) {
   console.error(
     `[perf-server] could not wipe app-data at ${resolved}\n` +
       `[perf-server] ${err?.code ?? "error"}: ${err?.message ?? err}`,
   );
-  for (const stuck of findUnreadable(resolved)) {
+  const stuckPaths = findUnreadable(resolved);
+  for (const stuck of stuckPaths) {
     console.error(`[perf-server]   still held: ${stuck}`);
   }
   console.error(
-    `[perf-server] On Windows this is usually a delete-pending directory left by the\n` +
-      `[perf-server] previous run; it clears on its own. Wait, or remove the path above by hand.`,
+    stuckPaths.length > 0
+      ? `[perf-server] On Windows this is usually a delete-pending directory left by the\n` +
+          `[perf-server] previous run; it clears on its own. Wait, or remove the path above by hand.`
+      : `[perf-server]   no un-listable descendant — the blocker lists fine but refuses to\n` +
+          `[perf-server]   unlink, most likely a file still held open by a surviving process.\n` +
+          `[perf-server] Look for a stray node/chromium from the previous run before re-running.`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
## What this is

A recorded run of the v1.0 performance gate, and the harness fixes that
recording it required. **No product code changes.** The accept-latency
optimization this branch was opened for is deliberately not here — the defect
it was opened for does not reproduce.

## #1288 does not reproduce, and its mechanism is refuted

Run 1 recorded `click-dispatch 7851ms` and #1288 was filed on it. Three clean
samples on the same Windows 11 workstation: **460 / 534 / 485ms**, including one
at a fifth of the annotation load. Run 1 is marked SUPERSEDED with four harness
defects, two of which bear on this number (the margin pipeline never mounted;
the app-data wipe landed under an already-restored server).

The suspected `marginPressure.resolveCrowding` mechanism is refuted twice
independently: the cost is **flat from 5 to 49 annotations**, and it collapses
4x under `reduceMotion`, which `resolveCrowding` reads no input from.

Recommended issue action: close #1288 as not-reproducing with a refuted
mechanism, and re-file the surviving question as "the accept round-trip spends
most of its budget in card lifecycle motion — decide whether the gate or the
motion changes."

## What the diff contains

**`docs/perf-gate-results.md`** — run 2 recorded in full. Conditions 1 and
2-create PASS. 2-accept (681–881ms vs a 500ms budget) and 3 (worst frame gap
2483/2550/317ms vs 100ms) FAIL, and the doc is explicit that they are unrelated
and that only one is understood. Two limits are stated rather than papered over:
the `cardExit` attribution for the settle half is a candidate contradicted by
one of the three samples (a 260ms outro cannot produce a 147ms settle), and
condition 3's numbers predate ~950 lines of scroll-path code merged in #1323 —
re-measure before profiling.

**`tests/perf/perf-server.mjs`** — the app-data wipe could not run twice in a
row. Four consecutive runs died on an `EPERM` naming the app-data *root* while
the real blocker was one `doc-backups/<hash>/` child in Windows delete-pending
state, so the failure read as "the perf gate is broken". Now: a walk that names
the stuck descendant, an explicit branch for the case the walk cannot see (a
listable file still held open), and a retry that actually waits.

That last one matters more than it looks. The first pass used `rmSync`'s
`maxRetries` / `retryDelay`, which are **inert** for this failure — measured on
Node v24.14.1 against both an un-traversable directory and an exclusively held
file, they returned the same EPERM in 0–1ms. The harness died in 259ms under a
comment promising a 5s wait. The loop is hand-rolled now; same budget, observed
at 4955ms.

The wipe stays FATAL on failure. Booting over a surviving `sessions/` dir
silently restores the previous run's tabs and annotations and measures a load
nobody chose — run 1's defect #2. A wrong number is worse than no number.

## Verification

Four controls, each run against the committed harness: un-listable child
(names the offender, ~5s), held-open file (names the class, since the walk
cannot see it), access restored (wipes, spawns, exit 0), wrong basename
(refuses). No `src/` changes, so no Critical Rule surface is touched.

---

*Wave 4 of the backlog campaign: investigate-before-fixing. Diagnosed by one agent, then independently verified by a second that re-derived the root cause and re-ran the controls itself.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKcPLgN9YGgfC1WvPJ2Vq
