### PR TITLE
fix(honesty): stop claiming connectivity, and repair the repairs

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -30,7 +30,11 @@ import { createConnection } from "node:net";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { parseLockfile } from "../server/annotations/lockfile.js";
-import { isRecordedPathGone, probeNodeBinary } from "../server/integrations/node-binary.js";
+import {
+  isRecordedPathAbsolute,
+  isRecordedPathGone,
+  probeNodeBinary,
+} from "../server/integrations/node-binary.js";
 import { DEFAULT_MCP_PORT, DEFAULT_WS_PORT } from "../shared/constants.js";
 import type { ClaudeCliPresence } from "../shared/integrations/contract.js";
 import { detectClaudeCli, isBareNameLaunchable } from "../shared/integrations/detect-claude-cli.js";
@@ -617,7 +621,11 @@ function checkMcpJson(r: Recorder): void {
   const channel = servers["tandem-channel"];
   if (!channel) {
     r.warn(
-      ".mcp.json has no tandem-channel entry — push here depends on the plugin monitor instead (see the push-path line below)",
+      // No cross-reference to "the push-path line below": `evaluatePushPath`
+      // runs only from `checkHealth`, which `runDoctor` reaches only when :3479
+      // is up and answering — and someone debugging a dead push path is often
+      // running doctor with Tandem stopped, where that line never prints.
+      ".mcp.json has no tandem-channel entry — push here depends on the plugin monitor instead",
     );
   } else {
     const cmd = channel.command;
@@ -688,7 +696,9 @@ function checkUserMcpConfig(r: Recorder): void {
   }
   if (!servers["tandem-channel"]) {
     r.warn(
-      "tandem-channel not registered in ~/.claude.json — push depends on the plugin monitor instead (see the push-path line below)",
+      // See the sibling note in `checkMcpJson`: the push-path line is gated on
+      // a running server, so it cannot be cited unconditionally.
+      "tandem-channel not registered in ~/.claude.json — push depends on the plugin monitor instead",
       "Run: tandem setup --apply",
     );
   } else {
@@ -704,7 +714,15 @@ function checkUserMcpConfig(r: Recorder): void {
       r,
       servers["tandem-channel"],
       "~/.claude.json",
-      "Restart Tandem (it repairs this at startup), or run: tandem setup --apply",
+      // Lead with the remedy that always works. The boot repair is real but
+      // conditional in two ways doctor cannot see and the user cannot act on:
+      // `refreshChannelNodeBinary` deliberately declines when the only
+      // replacement it could offer is the bare name, and the whole sweep is
+      // skipped while another instance holds the annotation-store lock. Under
+      // either, "restart Tandem" is a loop with no exit — the shape of false
+      // promise this check exists to replace.
+      "Run: tandem setup --apply (Tandem also attempts this at startup, but skips it when it " +
+        "has no valid Node path to substitute, or when another instance holds the store lock)",
     );
   }
 }
@@ -734,19 +752,36 @@ function reportChannelCommand(r: Recorder, entry: unknown, label: string, fix: s
   if (entry === null || typeof entry !== "object") return;
   const command = (entry as { command?: unknown }).command;
   if (typeof command !== "string" || command === "") return;
+  // Cheap gate first, and it must come BEFORE the probe: a bare `npx` or `node`
+  // would otherwise be `stat`ed against whatever cwd doctor was invoked from,
+  // for an answer both branches then discard, and a relative path would be
+  // resolved against a working directory that is not the spawning client's.
+  if (!isRecordedPathAbsolute(command)) return;
+
+  // ONE `stat`, reused below. `isRecordedPathGone` takes an injectable probe
+  // precisely so the result can be handed back to it — calling it bare would
+  // stat the same path a second time (expensive on an unreachable share, and
+  // this runs inside `/api/diagnostics`, a request path) and open a window
+  // where the two reads disagree and the branch taken is decided by a value
+  // already superseded.
+  //
   // Three-state on purpose: `false` means definitely gone, `null` means the
   // probe could not run. The server declines to rewrite on `null` — but a path
   // it cannot read is still a dead push path, and staying silent about it would
   // leave the user with no output from any surface.
   const probed = probeNodeBinary(command);
-  if (probed === null && /[/\\]/.test(command)) {
+  if (probed === null) {
     r.warn(
-      `${label} tandem-channel Node path could not be checked (permission denied, broken link, or unreachable share): ${command}`,
+      // NOT "broken link". A dangling symlink resolves to ENOENT, which
+      // `probeNodeBinary` reports as `false` (definitely gone) — it lands in
+      // the branch below, never here. `null` is the narrower set that actually
+      // throws: permission denied, a symlink LOOP, an unreachable share.
+      `${label} tandem-channel Node path could not be checked (permission denied, symlink loop, or unreachable share): ${command}`,
       "Verify the path is readable — Tandem deliberately will not rewrite it on an unreadable probe.",
     );
     return;
   }
-  if (!isRecordedPathGone(command)) return;
+  if (!isRecordedPathGone(command, () => probed)) return;
   r.warn(`${label} tandem-channel points at a Node binary that no longer exists: ${command}`, fix);
 }
 
@@ -849,20 +884,32 @@ export function evaluateTandemPlugin(input: TandemPluginInput): EvalOutcome[] {
   // `false` is a real and common value — a plugin the user deliberately
   // disabled — so test the VALUE, not just key presence. A truthiness check
   // would report a disabled plugin as installed.
-  const installed = Object.entries(input.enabledPlugins).some(
+  // Keep the KEY, not just the fact. Detection matches any marketplace
+  // (`tandem@<whatever>`) on purpose — `docs/spikes/plugin-delivery.md`
+  // recommends a local marketplace for the no-git path — so a hardcoded
+  // `tandem@tandem-editor` in the remedy hands those users a command that
+  // errors. The uninstall string has to name the plugin we actually found.
+  const installedKey = Object.entries(input.enabledPlugins).find(
     ([key, value]) => key.startsWith("tandem@") && value === true,
-  );
-  if (!installed) return [];
+  )?.[0];
+  if (installedKey === undefined) return [];
 
   const out: EvalOutcome[] = [
     {
-      status: "warn",
+      // `pass`, not `warn`. We have no evidence the monitor failed — the check
+      // sees a registry file, not an exit code, and on a host with Node on
+      // PATH it starts fine. Warning unconditionally would mean a permanently
+      // unclean report for doing exactly what `printPushStatus` recommends, and
+      // a warning that cannot be cleared teaches users to ignore the section.
+      // The mechanism and its remedy are still worth stating, so they stay in
+      // `fix`, phrased as the conditional it is.
+      status: "pass",
       message: "The Tandem plugin is installed — its monitor and MCP servers all run via `npx`",
       fix:
         'If you see `Monitor "Tandem real-time document events…" script failed (exit 127)`, ' +
         "Claude Code was started without Node on its PATH — it spawns monitors through a " +
         "non-login shell, so a GUI launch never reads your shell profile. Start Claude from " +
-        "a terminal, or uninstall with `claude plugin uninstall tandem@tandem-editor`.",
+        `a terminal, or uninstall with \`claude plugin uninstall ${installedKey}\`.`,
     },
   ];
 
@@ -875,7 +922,7 @@ export function evaluateTandemPlugin(input: TandemPluginInput): EvalOutcome[] {
         "Both the Tandem plugin and a tandem MCP entry in ~/.claude.json are present — the tandem_* tools will appear twice",
       fix:
         "Plugin MCP servers load alongside your own, under a plugin_ prefix. Keep one: " +
-        "`claude plugin uninstall tandem@tandem-editor` leaves the Tandem-managed config in place.",
+        `\`claude plugin uninstall ${installedKey}\` leaves the Tandem-managed config in place.`,
     });
   }
   return out;

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -565,14 +565,15 @@ $effect(() => {
     // initialize landed after the last poll would otherwise get a false "no AI
     // is connected" notice (#1083) — and refreshes the push signal in the same
     // round trip.
-    const sessionLive = await aiReadiness.probeSession();
+    const probe = await aiReadiness.probeSession();
     const notice = addressedAiNotice({
       // Re-read across the await, don't reuse the pre-probe capture: a user who
       // switches to Solo while the probe is in flight would otherwise still get
       // a notice. Every input here is re-read for the same reason.
       soloMode: isSoloNow(),
       serverUnreachable: aiReadiness.serverUnreachable,
-      sessionLive,
+      probeAnswered: probe.answered,
+      sessionLive: probe.sessionLive,
       chip: aiReadiness.chip,
       pushDelivery: aiReadiness.pushDelivery,
     });

--- a/src/client/hooks/useAiReadiness.svelte.ts
+++ b/src/client/hooks/useAiReadiness.svelte.ts
@@ -332,12 +332,21 @@ export interface AiReadiness {
    * live. Callers about to alarm on `chip !== null` should confirm with this
    * probe first.
    *
-   * Returns `true` only when a fresh `/health` read confirms an open MCP
-   * transport. On fetch failure or a redacted body (no `hasSession` field) it
-   * returns the last-known polled value — mirroring the poll's "keep prior
-   * value on a blip" fail-safe in both directions.
+   * `sessionLive` is `true` only when a fresh `/health` read confirms an open
+   * MCP transport. On fetch failure or a redacted body (no `hasSession` field)
+   * it falls back to the last-known polled value — mirroring the poll's "keep
+   * prior value on a blip" fail-safe in both directions.
+   *
+   * `answered` reports whether THIS read reached our server, and it is separate
+   * from `sessionLive` because the fallback above silently launders a stale
+   * `true` into what reads like a fresh confirmation. That is the same collapse
+   * `HealthRead` exists to prevent, one layer up: a caller that only sees the
+   * boolean cannot tell "a live session, just confirmed" from "no idea, here is
+   * what we thought 8 seconds ago". Callers making an AFFIRMATIVE connectivity
+   * claim must check it; `serverUnreachable` is no substitute, because probe
+   * reads deliberately do not accrue strikes and so cannot set it.
    */
-  probeSession: () => Promise<boolean>;
+  probeSession: () => Promise<{ answered: boolean; sessionLive: boolean }>;
 }
 
 const POLL_MS = 8_000;
@@ -400,7 +409,18 @@ export function createAiReadiness(deps: {
    *
    * So it now clears to `null` after the same two consecutive dead reads, which
    * lands on "booting" — "we do not know" — rather than on a fabricated
-   * launcher state. Note the asymmetry with `/health`: a non-OK or unparseable
+   * launcher state.
+   *
+   * "Two reads" is not "~16s" here, and the difference is deliberate rather than
+   * overlooked. `refreshAiReadinessAfterLauncherAction` fires two extra polls at
+   * 2s and 5s after a restart action, so a dead API demotes in seconds on that
+   * path. There is no `fromPoll` equivalent because there is nothing to exempt —
+   * every launcher read IS a poll, one per generation, and a burst issued
+   * precisely to observe a state change should be allowed to observe it. The
+   * outcome is "booting" during a restart the user just asked for, which is
+   * both accurate and unalarming.
+   *
+   * Note the asymmetry with `/health`: a non-OK or unparseable
    * response is NOT a strike here, because unlike `makeHealthHandler` the
    * launcher route genuinely can fail (`requireSupervisor` 503s while the
    * launcher is deferred), so on THIS route those really are the server
@@ -511,9 +531,13 @@ export function createAiReadiness(deps: {
    *  most recently issued read — last-issued-wins, so a slow older response
    *  can never clobber a fresher one (e.g. a poll that sampled "no session"
    *  just before the agent's initialize, resolving after the probe that saw
-   *  it). A dropped write is recovered by the next interval poll. Returns the
-   *  fetched value either way so callers can act on their own read. */
-  async function readHasSession(fromPoll: boolean): Promise<boolean | null> {
+   *  it). A dropped write is recovered by the next interval poll. Returns both
+   *  the fetched value and whether the read answered at all, so callers can act
+   *  on their own read WITHOUT having to treat "no session" and "no answer" as
+   *  the same thing — `hasSession: null` alone cannot tell them apart. */
+  async function readHasSession(
+    fromPoll: boolean,
+  ): Promise<{ answered: boolean; hasSession: boolean | null }> {
     const mine = ++healthSeq;
     const fresh = await fetchHealth();
 
@@ -551,8 +575,11 @@ export function createAiReadiness(deps: {
       console.warn(`[aiReadiness] /health did not answer: ${fresh.why}`);
     }
 
-    const value = fresh.answered ? fresh.hasSession : null;
-    if (mine !== healthSeq || destroyed) return value;
+    const out = {
+      answered: fresh.answered,
+      hasSession: fresh.answered ? fresh.hasSession : null,
+    };
+    if (mine !== healthSeq || destroyed) return out;
 
     if (fresh.answered) {
       serverUnreachable = false;
@@ -570,16 +597,17 @@ export function createAiReadiness(deps: {
       // confident lie for another.
       pushAttached = null;
     }
-    return value;
+    return out;
   }
 
   /** See `AiReadiness.probeSession`. Issues a fresh `/health` read (which also
    *  folds into polled state, clearing the titlebar chip immediately instead
    *  of waiting out the poll interval) and answers with the freshest data it
-   *  has — falling back to the last-known polled value when the read fails. */
-  async function probeSession(): Promise<boolean> {
+   *  has — falling back to the last-known polled value when the read fails, and
+   *  saying which of the two happened. */
+  async function probeSession(): Promise<{ answered: boolean; sessionLive: boolean }> {
     const fresh = await readHasSession(false);
-    return fresh ?? mcpSessionActive;
+    return { answered: fresh.answered, sessionLive: fresh.hasSession ?? mcpSessionActive };
   }
 
   function poll(): void {

--- a/src/client/status/addressed-ai-notice.ts
+++ b/src/client/status/addressed-ai-notice.ts
@@ -39,7 +39,10 @@ import type { AiChip, PushDelivery } from "../hooks/useAiReadiness.svelte";
  *   3. A live session decides which of the remaining branches applies. Without
  *      one, only the agent-absence notice can be correct; with one, only the
  *      delivery notice can be.
- *   4. `no-push` fires ONLY on a confirmed zero. `routes/health.ts:43-45` is
+ *   5. An affirmative claim needs a read that answered. `sessionLive` launders
+ *      a stale value into a fresh-looking `true` when the probe fails, and
+ *      `no-push` is the only branch that asserts connectivity off it.
+ *   6. `no-push` fires ONLY on a confirmed zero. `routes/health.ts:43-45` is
  *      explicit that `subscribers: 0` is a sound negative while any positive
  *      count includes an attached-but-inert shim — so `true` and `null` (field
  *      absent, redacted, or not yet read) must both stay silent. Guessing here
@@ -59,6 +62,14 @@ export function addressedAiNotice(input: {
    * so a blip cannot raise an alarm about data loss.
    */
   serverUnreachable: boolean;
+  /**
+   * Did the probe's `/health` read reach our server at all?
+   *
+   * Separate from `sessionLive` because that value falls back to the last
+   * polled result when the read fails, so a stale `true` is indistinguishable
+   * from a fresh one at this boundary. Only rule 5 consults it — see there.
+   */
+  probeAnswered: boolean;
   /** Fresh `/health` confirmation that an MCP transport is open. */
   sessionLive: boolean;
   /** Re-read after the probe — readiness may have settled while it was in flight. */
@@ -84,6 +95,33 @@ export function addressedAiNotice(input: {
     return input.chip === null ? null : { kind: "no-agent", chip: input.chip };
   }
 
-  // Rule 4 — attached, but is anything delivering?
+  // Rule 5 — `no-push` is the ONLY branch here that makes an affirmative
+  // connectivity claim ("Claude is connected but isn't being notified"). It is
+  // therefore the only one that must not be built on a stale `sessionLive`.
+  //
+  // The gap this closes: a hand-launched session never takes the caller's fast
+  // path, so every send probes. If the server has just died, that probe fails,
+  // `probeSession` falls back to the last polled `true`, and probe reads do not
+  // accrue strikes — so `serverUnreachable` is still false and rule 2 above
+  // cannot catch it. The user was told Claude was connected on the strength of
+  // a read that had failed a millisecond earlier, for a message written into a
+  // local Y.Doc with nowhere to sync.
+  //
+  // Silence, not `offline`: one failed read is not evidence the server is gone
+  // (that is exactly what the strike floor exists to establish), and the HTTP
+  // API going quiet does not imply the Hocuspocus socket did — so "it wasn't
+  // delivered" would be its own false claim. We genuinely do not know, and the
+  // residual cost is bounded and visible: if the server really is gone, the
+  // next two polls set `serverUnreachable` within ~16s and the pill stops
+  // claiming a session. No notice fires retroactively for THIS message, which
+  // is a real gap, not a fixed one.
+  //
+  // Rules 3-4 are deliberately NOT gated on this. Their evidence is `chip`,
+  // derived from the launcher route, which has its own independent floor — an
+  // unrelated route blipping is no reason to suppress a notice that route
+  // supports.
+  if (!input.probeAnswered) return null;
+
+  // Rule 6 — attached, but is anything delivering?
   return input.pushDelivery === "none" ? { kind: "no-push" } : null;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -689,8 +689,16 @@ async function main() {
     // would reach the unhandledRejection handler, which `process.exit(1)`s on
     // anything it does not recognise. Best-effort config repair must never be
     // able to take down the server.
+    // AWAITED, not fire-and-forget. `void` would defeat both guarantees above:
+    // the dynamic import defers to a microtask and the sweep itself yields
+    // before its first `stat`, so control would return here and the launcher
+    // would spawn Claude Code against the config we are mid-repair of — which
+    // is both halves of the failure at once (the session reads the stale entry,
+    // AND our rename lands inside Claude Code's own startup write window). The
+    // cost is bounded: a handful of `stat`s over detected config files, after
+    // the server is already listening.
     if (!isStoreReadOnly()) {
-      void import("./integrations/apply.js")
+      await import("./integrations/apply.js")
         .then(({ refreshAllChannelNodeBinaries }) => refreshAllChannelNodeBinaries())
         .catch((err) =>
           console.error(

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -887,7 +887,9 @@ export type RefreshNodeBinaryResult =
   /** The recorded binary is gone and we have no better value to put there —
    *  see the `BARE_NODE` refusal in `refreshChannelNodeBinary`. */
   | { status: "skipped"; reason: "no-valid-replacement" }
-  | { status: "rewritten"; from: string; to: string; scriptRefreshed: boolean };
+  /** `from`/`to` are null when only the SCRIPT path needed repair — the two are
+   *  checked independently, so either can move without the other. */
+  | { status: "rewritten"; from: string | null; to: string | null; scriptRefreshed: boolean };
 
 /**
  * Repair a `tandem-channel` entry whose recorded Node path has gone stale.
@@ -927,23 +929,19 @@ export async function refreshChannelNodeBinary(
   const command = record.command;
   if (typeof command !== "string") return { status: "no-op" };
 
-  if (!isRecordedPathGone(command, deps.probe)) return { status: "no-op" };
-
-  const next = resolveBinary();
-  if (next === command) return { status: "no-op" };
-  // Refuse to "repair" a dead absolute path into the bare name. That is not a
-  // fix — `node-binary.ts` documents the bare name as the thing that failed in
-  // the field — and it is actively worse for diagnosis: `isRecordedPathGone`
-  // exempts bare names, so `tandem doctor` would go permanently quiet about an
-  // entry that is still broken. Leaving the dead path in place keeps it visible.
-  if (next === BARE_NODE) return { status: "skipped", reason: "no-valid-replacement" };
-
-  // The script path goes stale in LOCKSTEP with the binary. `args[0]` is
-  // `CHANNEL_DIST`, derived from `PACKAGE_ROOT`/`__dirname`, so every cause
-  // listed above — App Translocation's per-launch UUID, an AppImage's per-run
-  // mount, a Tauri update — invalidates both at once. Repairing only `command`
-  // yields a working Node that dies on `Cannot find module`, and doctor (which
-  // inspects `command` alone) would call that healthy.
+  // The script path is checked INDEPENDENTLY of the binary, and first.
+  //
+  // This block used to sit after an early `return` on a healthy `command`, so
+  // it could only ever run when the binary was ALSO stale. The docblock
+  // justified that by asserting the two go stale in lockstep — but nothing
+  // enforces it and their roots are different: `command` is `process.execPath`,
+  // `args[0]` is `CHANNEL_DIST`, derived from `PACKAGE_ROOT`/`__dirname`. A
+  // global npm reinstall to a new prefix, or a rebuilt `dist/` under a
+  // relocated package root, moves the script while Node stays exactly where it
+  // was. The entry then spawns a working Node that dies on `Cannot find
+  // module`, and `tandem doctor` — which inspects `command` alone — calls it
+  // healthy. (Tauri updates and App Translocation really do move both; that
+  // case was never the problem.)
   let scriptRefreshed = false;
   const args = record.args;
   if (Array.isArray(args) && typeof args[0] === "string" && args[0] !== channelScript) {
@@ -953,9 +951,33 @@ export async function refreshChannelNodeBinary(
     }
   }
 
-  record.command = next;
+  let commandRewrite: { from: string; to: string } | null = null;
+  let noValidReplacement = false;
+  if (isRecordedPathGone(command, deps.probe)) {
+    const next = resolveBinary();
+    // Refuse to "repair" a dead absolute path into the bare name. That is not a
+    // fix — `node-binary.ts` documents the bare name as the thing that failed in
+    // the field — and it is actively worse for diagnosis: `isRecordedPathGone`
+    // exempts bare names, so `tandem doctor` would go permanently quiet about an
+    // entry that is still broken. Leaving the dead path in place keeps it visible.
+    if (next === BARE_NODE) noValidReplacement = true;
+    else if (next !== command) commandRewrite = { from: command, to: next };
+  }
+
+  if (commandRewrite === null && !scriptRefreshed) {
+    return noValidReplacement
+      ? { status: "skipped", reason: "no-valid-replacement" }
+      : { status: "no-op" };
+  }
+
+  if (commandRewrite !== null) record.command = commandRewrite.to;
   await atomicWrite(JSON.stringify(opened.root, null, 2) + "\n", configPath);
-  return { status: "rewritten", from: command, to: next, scriptRefreshed };
+  return {
+    status: "rewritten",
+    from: commandRewrite?.from ?? null,
+    to: commandRewrite?.to ?? null,
+    scriptRefreshed,
+  };
 }
 
 /**
@@ -995,10 +1017,15 @@ export async function refreshAllChannelNodeBinaries(
     try {
       const result = await refreshChannelNodeBinary(target.configPath);
       if (result.status === "rewritten") {
-        console.error(
-          `[Tandem] Repaired stale channel entry in ${target.label} (${result.from} → ${result.to}` +
-            `${result.scriptRefreshed ? ", channel script path also refreshed" : ""}).`,
-        );
+        // Name what actually moved. The binary and the script are repaired
+        // independently, so `from`/`to` are null on a script-only fix — logging
+        // them unconditionally would print "null → null" for a real repair.
+        const what =
+          result.from === null
+            ? "channel script path refreshed"
+            : `${result.from} → ${result.to}` +
+              (result.scriptRefreshed ? ", channel script path also refreshed" : "");
+        console.error(`[Tandem] Repaired stale channel entry in ${target.label} (${what}).`);
       } else if (result.status === "skipped") {
         // Every refusal was previously silent. `malformed-json` in particular
         // deserves to be loud: `~/.claude.json` is the whole MCP registry, so

--- a/src/server/integrations/node-binary.ts
+++ b/src/server/integrations/node-binary.ts
@@ -40,7 +40,7 @@
  * counterpart that can, gated by `isRecordedPathGone` below.
  */
 import { statSync } from "node:fs";
-import { resolve } from "node:path";
+import { posix as posixPath, resolve, win32 as win32Path } from "node:path";
 import { isValidNodeBinary } from "../../shared/integrations/node-binary-name.js";
 import { rejectUnsafeWindowsPrefix } from "../file-io/windows-path-safety.js";
 
@@ -67,6 +67,32 @@ const WIN_EXTENDED_DRIVE_RE = /^\\\\\?\\([A-Za-z]:)/;
  * default.
  */
 export function resolveNodeBinary(candidate: string = process.execPath): string {
+  // Memoized for the DEFAULT candidate only. `process.execPath` cannot change
+  // mid-process (this module already relies on that), while the callers loop:
+  // `buildMcpEntries` resolves once per entry, and `writeTargets` /
+  // `applyConfigWithToken` / `refreshAllChannelNodeBinaries` each loop over
+  // every detected target. Without this, a host whose execPath fails
+  // validation — a Debian `nodejs` basename, a home directory containing `..` —
+  // prints `fallBackToBareNode`'s four-line warning once per target per
+  // operation, and again on every boot sweep. One cause deserves one warning.
+  //
+  // An explicit candidate always recomputes: it is the test seam, and tests
+  // assert on that warning firing per call.
+  const isDefault = candidate === process.execPath;
+  if (isDefault && defaultResolution !== undefined) return defaultResolution;
+  const resolved = resolveNodeBinaryUncached(candidate);
+  if (isDefault) defaultResolution = resolved;
+  return resolved;
+}
+
+let defaultResolution: string | undefined;
+
+/** Test seam: drop the memoized default so a suite can vary `process.execPath`. */
+export function _resetNodeBinaryCacheForTests(): void {
+  defaultResolution = undefined;
+}
+
+function resolveNodeBinaryUncached(candidate: string): string {
   if (!candidate) return BARE_NODE;
   // Strip the extended-length DRIVE prefix first: `process.execPath` can
   // legitimately return `\\?\C:\…` on Windows, and the check below rejects
@@ -139,18 +165,44 @@ export function probeNodeBinary(path: string): boolean | null {
  * `true` means the recorded value is an absolute path that definitely no longer
  * resolves to a file — the staleness case above — and should be rewritten.
  *
- * Two cases deliberately report NOT stale:
+ * Three cases deliberately report NOT stale:
  *   - A bare name. Whether it resolves is the client's lookup to perform at
  *     spawn time, not ours to second-guess, and rewriting it would undo a
  *     deliberate fallback.
+ *   - A RELATIVE path. It resolves against the spawning client's working
+ *     directory, which is not ours — so probing it here answers a different
+ *     question than the one that matters. This used to test only "contains a
+ *     separator", which let `./node_modules/.bin/node` (idiomatic in a
+ *     project-scoped `.mcp.json`) be `stat`ed against whatever cwd the caller
+ *     happened to have: `tandem doctor` runs wherever it was invoked, and
+ *     `/api/diagnostics` runs in the server's cwd. A valid entry would be
+ *     reported gone and, on the server side, rewritten.
  *   - An unreadable path (`probe` → `null`). Never rewrite a user's config on
  *     the strength of a probe that could not run.
+ *
+ * Absoluteness is tested against BOTH path flavours, not the host's. The value
+ * comes out of a config file, and CI reads Windows-shaped fixtures on Linux —
+ * `path.isAbsolute` alone would call `C:\...\node.exe` relative there.
  */
 export function isRecordedPathGone(
   command: string,
   probe: (p: string) => boolean | null = probeNodeBinary,
 ): boolean {
-  if (!command) return false;
-  if (!/[/\\]/.test(command)) return false; // bare name
+  if (!isRecordedPathAbsolute(command)) return false;
   return probe(command) === false;
+}
+
+/**
+ * Is this recorded command a path we are entitled to probe?
+ *
+ * Exported so callers can answer the cheap half — "is a `stat` even meaningful
+ * here" — WITHOUT performing one, and without restating the rule. `tandem
+ * doctor` needs exactly that: it wants the probe's three-state result for its
+ * own reporting, so it cannot just call `isRecordedPathGone` and re-derive.
+ * Sharing this predicate is what keeps the diagnosis and the repair from
+ * drifting apart.
+ */
+export function isRecordedPathAbsolute(command: string): boolean {
+  if (!command) return false;
+  return win32Path.isAbsolute(command) || posixPath.isAbsolute(command);
 }

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -1345,13 +1345,18 @@ describe("evaluateTandemPlugin", () => {
     ).toEqual([]);
   });
 
-  it("warns about the npx dependency when the plugin is enabled", () => {
+  it("notes the npx dependency when the plugin is enabled, without warning", () => {
     const out = evaluateTandemPlugin({
       enabledPlugins: { "tandem@tandem-editor": true },
       wizardTandemEntry: false,
     });
     expect(out).toHaveLength(1);
-    expect(out[0].status).toBe("warn");
+    // `pass`, not `warn`. Registry presence is not evidence the monitor failed
+    // — with Node on PATH it starts fine — and `printPushStatus` actively
+    // recommends installing this plugin. A permanent warning for following our
+    // own advice is a report the user can never clean, so the mechanism lives
+    // in `fix` while the status stays honest about what we observed.
+    expect(out[0].status).toBe("pass");
     expect(out[0].message).toContain("npx");
     expect(out[0].fix).toContain("exit 127");
     // Names the actual mechanism, not just the symptom.
@@ -1382,5 +1387,21 @@ describe("evaluateTandemPlugin", () => {
       wizardTandemEntry: false,
     });
     expect(out).toHaveLength(1);
+  });
+
+  it("names the marketplace it actually found in the uninstall command", () => {
+    // Detection is marketplace-agnostic but the remedy used to hardcode
+    // `tandem@tandem-editor`, so a user who registered a local marketplace —
+    // the no-git path `docs/spikes/plugin-delivery.md` recommends — was handed
+    // a command that errors. Both outcomes carry an uninstall string.
+    const out = evaluateTandemPlugin({
+      enabledPlugins: { "tandem@some-local-marketplace": true },
+      wizardTandemEntry: true,
+    });
+    expect(out).toHaveLength(2);
+    for (const outcome of out) {
+      expect(outcome.fix).toContain("claude plugin uninstall tandem@some-local-marketplace");
+      expect(outcome.fix).not.toContain("tandem@tandem-editor");
+    }
   });
 });

--- a/tests/client/addressed-ai-notice.test.ts
+++ b/tests/client/addressed-ai-notice.test.ts
@@ -19,6 +19,10 @@ import { addressedAiNotice } from "../../src/client/status/addressed-ai-notice.j
 const base = {
   soloMode: false,
   serverUnreachable: false,
+  // The healthy default: the probe reached our server. Cases that exercise the
+  // unanswered path set it explicitly, so every other test keeps reading as a
+  // statement about the branch it names.
+  probeAnswered: true,
   sessionLive: false,
   // `AiChip` already includes `null`; annotating honestly (rather than `as
   // never`) keeps a future widening of that union a type error here.
@@ -143,6 +147,60 @@ describe("addressedAiNotice", () => {
           pushDelivery: "none",
         }),
       ).toEqual({ kind: "no-push" });
+    });
+  });
+
+  describe("an unanswered probe", () => {
+    // The gap: a hand-launched session never takes the caller's fast path, so
+    // every send probes. If the server has just died that probe fails,
+    // `probeSession` falls back to the last polled `true`, and probe reads
+    // deliberately do not accrue strikes — so `serverUnreachable` is still
+    // false and the offline branch cannot catch it. Before this rule the user
+    // was told "Claude is connected but isn't being notified" on the strength
+    // of a read that had failed a millisecond earlier.
+    it("suppresses no-push, because that is the branch asserting connectivity", () => {
+      const inputs = {
+        ...base,
+        sessionLive: true, // stale — the fallback, not a confirmation
+        chip: null,
+        pushDelivery: "none" as PushDelivery,
+      };
+      // The control: with the same inputs and an answered probe, it fires.
+      expect(addressedAiNotice(inputs)).toEqual({ kind: "no-push" });
+      expect(addressedAiNotice({ ...inputs, probeAnswered: false })).toBeNull();
+    });
+
+    it("does NOT suppress no-agent — that branch rests on the launcher route", () => {
+      // `chip` comes from `/api/launcher/status`, which carries its own
+      // independent strike floor. An unrelated route blipping is no reason to
+      // withhold a notice this one supports, and the copy it produces ("saved
+      // while no AI was connected") stays true regardless.
+      expect(
+        addressedAiNotice({
+          ...base,
+          probeAnswered: false,
+          sessionLive: false,
+          chip: "restart",
+          pushDelivery: "unknown",
+        }),
+      ).toEqual({ kind: "no-agent", chip: "restart" });
+    });
+
+    it("does NOT suppress offline — a met strike floor outranks a single read", () => {
+      // `serverUnreachable` is only set after a full run of dead POLLS, which
+      // is strictly stronger evidence than the one failed probe that got us
+      // here. Ordering this gate above rule 2 would discard the stronger signal
+      // for the weaker one.
+      expect(
+        addressedAiNotice({
+          ...base,
+          probeAnswered: false,
+          serverUnreachable: true,
+          sessionLive: true,
+          chip: null,
+          pushDelivery: "none",
+        }),
+      ).toEqual({ kind: "offline" });
     });
   });
 

--- a/tests/client/useAiReadiness.svelte.test.ts
+++ b/tests/client/useAiReadiness.svelte.test.ts
@@ -491,7 +491,7 @@ describe("createAiReadiness", () => {
     // `false` is what selects the "saved while no AI was connected" notice over
     // the delivery-delay one. That routing is the user-visible payoff of the
     // whole demotion, and it is the only assertion here that reaches it.
-    await expect(h.get().probeSession()).resolves.toBe(false);
+    await expect(h.get().probeSession()).resolves.toEqual({ answered: false, sessionLive: false });
   });
 
   it("drops the connected indicator when the server dies under a running launcher", async () => {
@@ -652,7 +652,7 @@ describe("createAiReadiness", () => {
     expect(h.get().state).toBe("unconfigured");
     expect(h.get().chip).toBe("connect");
 
-    await expect(h.get().probeSession()).resolves.toBe(true);
+    await expect(h.get().probeSession()).resolves.toEqual({ answered: true, sessionLive: true });
     await tick();
     // The fresh read also folds into polled state — chip clears immediately.
     expect(h.get().state).toBe("ready");
@@ -668,7 +668,7 @@ describe("createAiReadiness", () => {
     await settle();
     expect(h.get().chip).toBe("restart");
 
-    await expect(h.get().probeSession()).resolves.toBe(false);
+    await expect(h.get().probeSession()).resolves.toEqual({ answered: true, sessionLive: false });
     await tick();
     expect(h.get().chip).toBe("restart");
   });
@@ -693,8 +693,16 @@ describe("createAiReadiness", () => {
     await settle();
     expect(h.get().state).toBe("ready");
 
-    await expect(h.get().probeSession()).resolves.toBe(true);
+    // `sessionLive: true` is the FALLBACK, not a confirmation — and `answered:
+    // false` is the only thing that says so. This pair is the whole reason the
+    // return type is a record: a caller seeing the boolean alone cannot tell a
+    // just-confirmed session from an 8-second-old guess, which is how a dead
+    // server got a "Claude is connected" toast. `addressed-ai-notice.test.ts`
+    // pins the consuming half.
+    await expect(h.get().probeSession()).resolves.toEqual({ answered: false, sessionLive: true });
     expect(h.get().state).toBe("ready");
+    // And the fallback must not have been laundered into polled state either.
+    expect(h.get().serverUnreachable).toBe(false); // one blip is not a dead server
   });
 
   it("probeSession treats a redacted body (no hasSession) as unknown and keeps last-known false", async () => {
@@ -715,7 +723,7 @@ describe("createAiReadiness", () => {
     await settle();
     expect(h.get().chip).toBe("restart");
 
-    await expect(h.get().probeSession()).resolves.toBe(false);
+    await expect(h.get().probeSession()).resolves.toEqual({ answered: true, sessionLive: false });
     await tick();
     expect(h.get().chip).toBe("restart");
   });
@@ -744,7 +752,7 @@ describe("createAiReadiness", () => {
     await settle(); // launcher settled; health read 1 still in flight
     expect(h.get().state).toBe("stopped");
 
-    await expect(h.get().probeSession()).resolves.toBe(true);
+    await expect(h.get().probeSession()).resolves.toEqual({ answered: true, sessionLive: true });
     await tick();
     expect(h.get().state).toBe("ready");
 
@@ -785,7 +793,7 @@ describe("createAiReadiness", () => {
     await settle();
 
     // Probe read 3 is issued last and answers: a live session, freshest word.
-    await expect(h.get().probeSession()).resolves.toBe(true);
+    await expect(h.get().probeSession()).resolves.toEqual({ answered: true, sessionLive: true });
     await tick();
     expect(h.get().state).toBe("ready");
 

--- a/tests/server/integrations/node-binary.test.ts
+++ b/tests/server/integrations/node-binary.test.ts
@@ -1,7 +1,8 @@
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  _resetNodeBinaryCacheForTests,
   BARE_NODE,
   isRecordedPathGone,
   probeNodeBinary,
@@ -74,6 +75,40 @@ describe("resolveNodeBinary", () => {
     // same rule, and a fix that only handled backslashes would look correct.
     expect(resolveNodeBinary("//server/share/node.exe")).toBe(BARE_NODE);
   });
+
+  it("resolves the default candidate once, and warns once", () => {
+    // One cause deserves one warning. `buildMcpEntries` resolves per entry and
+    // three separate callers loop over every detected target, so an unmemoized
+    // resolution printed the four-line fallback warning once per target per
+    // operation — twice for `tandem setup --apply` on a box with Claude Code
+    // plus Desktop, and again on every boot sweep. The value is process-
+    // constant, so the repetition carried no information.
+    const original = process.execPath;
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A Python basename fails `isValidNodeBinary`, which is what routes this
+    // through `fallBackToBareNode` — the only branch that logs.
+    Object.defineProperty(process, "execPath", { value: "/usr/bin/python", configurable: true });
+    _resetNodeBinaryCacheForTests();
+    try {
+      expect(resolveNodeBinary()).toBe(BARE_NODE);
+      expect(resolveNodeBinary()).toBe(BARE_NODE);
+      expect(resolveNodeBinary()).toBe(BARE_NODE);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // An explicit candidate is the test seam and always recomputes — the
+      // memo must not swallow a warning a caller asked for by name.
+      expect(resolveNodeBinary("/usr/bin/ruby")).toBe(BARE_NODE);
+      expect(resolveNodeBinary("/usr/bin/ruby")).toBe(BARE_NODE);
+      expect(spy).toHaveBeenCalledTimes(3);
+    } finally {
+      Object.defineProperty(process, "execPath", { value: original, configurable: true });
+      // Mandatory, not tidiness: the memo is keyed on "was this the default",
+      // so leaving it set would serve `/usr/bin/python`'s BARE_NODE to every
+      // later caller asking about the real execPath.
+      _resetNodeBinaryCacheForTests();
+      spy.mockRestore();
+    }
+  });
 });
 
 /**
@@ -103,6 +138,22 @@ describe("isRecordedPathGone", () => {
 
   it("recognises a Windows path as absolute", () => {
     expect(isRecordedPathGone("C:\\Program Files\\nodejs\\node.exe", missing)).toBe(true);
+    // Both flavours, on whichever host runs the suite. The value comes out of a
+    // config file, not from this process, and CI reads Windows-shaped fixtures
+    // on Linux — `path.isAbsolute` alone would call the above relative there.
+    expect(isRecordedPathGone("\\\\server\\share\\node.exe", missing)).toBe(true);
+    expect(isRecordedPathGone("/usr/local/bin/node", missing)).toBe(true);
+  });
+
+  it("never flags a RELATIVE path, however many separators it has", () => {
+    // The guard used to be "contains a separator", which resolves these against
+    // whatever cwd the caller happens to have — `tandem doctor` runs wherever
+    // it was invoked, `/api/diagnostics` runs in the server's cwd — while the
+    // path is really relative to the SPAWNING CLIENT's directory. A valid
+    // project-local entry would be reported gone and, server-side, rewritten.
+    expect(isRecordedPathGone("./node_modules/.bin/node", missing)).toBe(false);
+    expect(isRecordedPathGone("bin/node", missing)).toBe(false);
+    expect(isRecordedPathGone("..\\node\\node.exe", missing)).toBe(false);
   });
 
   it("treats an empty command as nothing to do", () => {

--- a/tests/server/integrations/refresh-channel-node.test.ts
+++ b/tests/server/integrations/refresh-channel-node.test.ts
@@ -197,6 +197,37 @@ describe("refreshChannelNodeBinary", () => {
     expect(read().mcpServers["tandem-channel"].args).toEqual([configPath]);
   });
 
+  it("repairs a stale script path even when the Node binary is fine", async () => {
+    // This was unreachable: the script block sat behind an early return on a
+    // healthy `command`, justified by a docblock claiming the two go stale in
+    // lockstep. They don't — `command` is `process.execPath`, `args[0]` derives
+    // from `PACKAGE_ROOT`. A global npm reinstall to a new prefix, or a `dist/`
+    // rebuilt under a relocated root, moves the script and leaves Node exactly
+    // where it was. The entry then spawns a working Node that dies on `Cannot
+    // find module`, and doctor — which inspects `command` alone — calls it
+    // healthy.
+    write({
+      mcpServers: {
+        "tandem-channel": { command: GOOD, args: ["/gone/dist/channel/index.js"] },
+      },
+    });
+    const result = await refreshChannelNodeBinary(configPath, {
+      probe: (p) => p !== "/gone/dist/channel/index.js",
+      resolveBinary: () => GOOD,
+      channelScript: configPath,
+    });
+    // `from`/`to` are null: nothing about the BINARY changed, and reporting the
+    // unchanged command as a rewrite would misname what was repaired.
+    expect(result).toEqual({
+      status: "rewritten",
+      from: null,
+      to: null,
+      scriptRefreshed: true,
+    });
+    expect(read().mcpServers["tandem-channel"].args).toEqual([configPath]);
+    expect(read().mcpServers["tandem-channel"].command).toBe(GOOD);
+  });
+
   it("leaves a script path that still resolves alone", async () => {
     write({
       mcpServers: {


### PR DESCRIPTION
Follow-ups from `/code-review xhigh` over #1316 + #1324, which merged while the review was running — so these land as one PR against master rather than on those branches.

Thirteen findings survived verification. **Two are dropped, and it's worth saying why:**

- An E2E helper was predicted to close the right rail instead of switching tabs, failing both new tests on a clean profile. **Refuted by observation** — CI runs the full Playwright suite and reports `259 passed` on the exact commit under review.
- The `/api/integrations/existing` absolute-path disclosure was **fixed independently by #1318**, whose `scrubExistingInstalls` basenames `command`/`args` for non-loopback callers. The comment at the scrub site already says so.

## The sharp one

`probeSession` collapsed *"a live session, just confirmed"* and *"no idea, here's what we thought 8 seconds ago"* into one boolean — the same collapse `HealthRead` exists to prevent, one layer up.

A hand-launched session never takes the caller's fast path, so **every send probes**. With the server just dead, that probe fails, the fallback returns the last polled `true`, and probe reads deliberately don't accrue strikes — so `serverUnreachable` is still false and the `offline` branch added in #1324 can't catch it. The user was told *"Claude is connected but isn't being notified"* on the strength of a read that had failed a millisecond earlier, for a message written into a local Y.Doc with nowhere to sync.

`probeSession` now reports `answered` alongside the value, and `no-push` — the only branch that asserts connectivity — requires it.

**Silence rather than `offline`**, deliberately: one failed read is not evidence the server is gone (that's what the strike floor is for), and the HTTP API going quiet doesn't imply the Hocuspocus socket did, so *"it wasn't delivered"* would be its own false claim. The residual gap — no retroactive notice for that one message — is stated in the code, not papered over.

Rules 3–4 are **not** gated on it. Their evidence is `chip`, from the launcher route, which has its own independent floor; an unrelated route blipping is no reason to suppress a notice that route supports.

## Repairs that couldn't repair

| | |
|---|---|
| **Boot sweep `void`ed** | The channel-entry repair was fired immediately before the launcher spawns, so both guarantees its own comment asserted were false: the dynamic import defers to a microtask and the sweep yields before its first `stat`. The session Tandem just launched read the **stale** entry — while doctor says restarting repairs it — and our `atomicWrite` (a rename, not a compare-and-swap) landed inside Claude Code's own startup write window. |
| **Script path unreachable** | It sat behind an early return on a healthy `command`, justified by a "they go stale in lockstep" claim nothing enforces. The roots are independent (`process.execPath` vs `PACKAGE_ROOT`), so an npm prefix change moves the script and leaves Node exactly where it was — the entry then spawns a working Node that dies on `Cannot find module`, and doctor, inspecting `command` alone, calls it healthy. |
| **Relative paths judged as absolute** | `isRecordedPathGone` documented "absolute" and tested "contains a separator", so `./node_modules/.bin/node` was resolved against the caller's cwd — doctor's invocation directory, or the server's under `/api/diagnostics`. A valid project-local entry could be declared gone and, server-side, rewritten. |

## doctor honesty

- **"Restart Tandem (it repairs this at startup)"** promised a repair that provably doesn't run when there's no valid Node path to substitute (the deliberate `BARE_NODE` refusal) or while another instance holds the store lock — the #1268 shape this check exists to replace.
- Two warnings cited **"the push-path line below"**, which only prints when the server is up — often not the case for someone debugging a dead push path.
- The unreadable-probe warning offered **"broken link"**, a cause that cannot produce it: a dangling symlink is ENOENT, which `probeNodeBinary` reports as `false`.
- The plugin check **warned unconditionally** for doing exactly what `printPushStatus` recommends, with no way to reach a clean report → now `pass`, mechanism retained in `fix`. Its remedy also hardcoded `tandem@tandem-editor` while detection matches any marketplace, handing a local-marketplace user a command that errors.
- `reportChannelCommand` stat'd the same path twice, and stat'd bare names it was about to discard.
- `resolveNodeBinary` recomputed a process-constant value once per target per operation, re-printing its four-line warning each time.

## Verification

`npm run typecheck` clean (1303 files). `npm test` **5969 passed | 19 skipped**.

**Seven mutations, all caught** — gate removed / mis-ordered above `serverUnreachable` / above the `sessionLive` branch; `probeSession` always claiming it answered; script repair re-gated behind the binary; absoluteness back to a separator test; the hardcoded marketplace.

One of those only got caught after I found **my own harness** counting a module that failed to load as a clean run — a malformed regex in the mutation produced "no tests", which my parser read as zero failures. That's lesson 93 firing inside the tool written to check for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYdfLJBmVcojd8hiHqt3qX
