### PR TITLE
fix(ui): stop the formatting bar from covering banner notifications

### DIFF
--- a/docs/design-system-impl/testid-manifest.md
+++ b/docs/design-system-impl/testid-manifest.md
@@ -146,6 +146,10 @@ more lines in `__snapshots__/testid-set.snap.txt`.
   gaps)
 
 ### Banners
+- `banner-stack` — the measured wrapper around the four top-of-shell banners
+  (server-restart strip, updater, connection, license). Its bottom edge is
+  published as `--tandem-banner-stack-bottom` so the fixed formatting-bar pill
+  clears it; the selector is the hook the geometry E2E uses to inject a probe.
 - `connection-banner`, `connection-banner-retry`
 - `updater-banner`, `updater-banner-{install,dismiss,visible}`
 - `review-only-banner`, `review-only-dismiss`,

--- a/index.html
+++ b/index.html
@@ -242,16 +242,60 @@
         --tandem-z-above-titlebar: 100000;
         /* v7 floating chrome clearance/position vars — consumed by W2-W6
            rails, fmtbar, status pill. W4a maximalist lifted DocumentTabs
-           into the floating TitleBar (44px tall, no in-flow tabs row), so
-           these drop to 52px per the calm-v7.css target. The fmtbar pill is
-           fixed-positioned at top: 52px, height 36px → bottom at viewport
-           y=88. Editor-scroll lives below the titlebar in the flex column,
-           so its top edge is at viewport y=44; an editor padding-top of at
-           least 52px (max(--tandem-space-7, 52px)) lands content at y≥96,
-           clearing the fmtbar with ≥8px breathing. Rails use
-           rail-top-clearance as margin-top inside the editor row → rail top
-           also at y=96, in line with the editor content. */
-        --tandem-fmtbar-top: 52px;
+           into the floating TitleBar (no in-flow tabs row), so these drop to
+           52px per the calm-v7.css target.
+
+           MEASURED geometry (2026-08-07, default density, 1280px wide). The
+           figures here were previously wrong — the comment claimed a 44px
+           TitleBar, and that stale number is exactly what made the first
+           attempt at the banner-overlap fix land 4px short. Re-measure rather
+           than re-deriving if you change any of this:
+
+             TitleBar          y=0..56    (56px tall, NOT 44)
+             banner stack      y=56..56+H (in flow, H=0 when none showing)
+             fmtbar pill       y=52..88.75 at rest (~36.75px tall)
+             editor-scroll     top edge y=56; padding-top max(space-7, 52px)
+                               → content at y=108
+
+           Note the pill rests 4px ABOVE the titlebar's bottom edge, i.e. it is
+           deliberately tucked under it — which is why any offset expressed as
+           "52px + something" is wrong for clearing in-flow chrome below the
+           titlebar. Rails use rail-top-clearance as margin-top inside the
+           editor row, so they track the editor content automatically. */
+        /* Bottom edge of the in-flow top-of-shell banner stack (server-restart
+           strip, updater, connection, license) in viewport coordinates,
+           measured at runtime by the `bannerStackHeight` action in App.svelte
+           and written as an inline style on <html>. **0px means "no banners
+           showing"**, which the max() below maps back to the resting 52px.
+
+           Why the bottom edge and not the stack's height: a height offset makes
+           the consumer responsible for knowing where the stack STARTS, i.e. for
+           hardcoding the TitleBar height — the very number that was wrong.
+           `max(52px, bottom)` needs no such constant and self-corrects if the
+           TitleBar is ever resized.
+
+           ONLY --tandem-fmtbar-top consumes this, and that asymmetry is the
+           whole contract. The banner stack pushes the editor row down in normal
+           flow, so .editor-scroll's padding-top, the ScrollPill track,
+           FindReplaceBar and --tandem-rail-top-clearance are already expressed
+           in a frame that moved with it. The fmtbar is `position: fixed` — it is
+           the one surface that escaped the flow, so it is the one surface that
+           re-applies the offset by hand. Doing it anywhere else double-counts.
+
+           Three rules for anyone extending this:
+           1. Never feed --tandem-banner-stack-bottom into a property that SIZES
+              a ResizeObserver-observed box (.editor-scroll, the margin layer,
+              the tab scroller, the chat composer — 7 observer sites in
+              src/client). That closes a measure→resize→measure loop, which the
+              action's rounding and last-value guards do NOT suppress: they
+              suppress redundant writes, not a genuine oscillation.
+           2. The measured wrapper must never take padding, border, margin or
+              gap, or the bar's offset diverges from the flow it is tracking.
+           3. This token's computed string is now "max(52px, 0px)", not "52px" —
+              custom-property substitution is not math-resolved, so a
+              getComputedStyle() assertion on it must not expect a bare length. */
+        --tandem-banner-stack-bottom: 0px;
+        --tandem-fmtbar-top: max(52px, var(--tandem-banner-stack-bottom, 0px));
         --tandem-rail-top-clearance: 52px;
         --tandem-status-clearance: 36px;
         /* Bottom inset that any "hugs-content" rail (outline) reserves

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -8,6 +8,7 @@ import { toPmPos } from "../shared/positions/types";
 import type { Annotation, CapturedAnchor, ChatMessage, TandemNotification } from "../shared/types";
 import { isPendingReviewTarget } from "../shared/types";
 import { generateNotificationId } from "../shared/utils";
+import { bannerStackHeight } from "./actions/bannerStackHeight.svelte.js";
 import {
   createScratchpad,
   relaunchClaudeCode,
@@ -2317,33 +2318,48 @@ const shouldShowModelPicker = $derived(
       Connecting...
     </div>
   {:else}
-    {#if yjsSync.serverRestarted}
-      <div
-        style="padding: var(--tandem-space-2) var(--tandem-space-4); background: var(--tandem-warning-bg); border-bottom: 1px solid var(--tandem-warning-border); font-size: 13px; color: var(--tandem-warning-fg-strong); text-align: center;"
-      >
-        Server restarted — refreshing documents
-      </div>
-    {/if}
+    <!-- Top-of-shell banner stack. Wrapped so its total height can be measured
+         in ONE ResizeObserver and published as --tandem-banner-stack-bottom,
+         which index.html folds into --tandem-fmtbar-top so the fixed
+         formatting-bar pill sits below the banners instead of on top of their
+         message text. See the geometry contract in index.html for why only the
+         fmtbar re-applies that offset, and why it tracks the stack's bottom
+         edge rather than its height.
 
-    {#if isTauriRuntime() && updaterBanner.showBanner && updaterBanner.availableVersion}
-      <UpdaterBanner
-        version={updaterBanner.availableVersion}
-        installing={updaterBanner.installing}
-        onInstall={() => { updaterBanner.install(); }}
-        onDismiss={updaterBanner.dismiss}
-      />
-    {/if}
+         One wrapper rather than four observers because LicenseBanner self-gates
+         internally — App cannot tell from state alone whether it has a box, so
+         the wrapper's measured height is the only ground truth. Any future
+         top-of-shell banner belongs INSIDE this element; a sibling added after
+         it is invisible to the measurement and silently re-opens the overlap. -->
+    <div class="banner-stack" data-testid="banner-stack" use:bannerStackHeight>
+      {#if yjsSync.serverRestarted}
+        <div
+          style="padding: var(--tandem-space-2) var(--tandem-space-4); background: var(--tandem-warning-bg); border-bottom: 1px solid var(--tandem-warning-border); font-size: 13px; color: var(--tandem-warning-fg-strong); text-align: center;"
+        >
+          Server restarted — refreshing documents
+        </div>
+      {/if}
 
-    {#if connectionBanner.showBanner}
-      <ConnectionBanner
-        onDismiss={connectionBanner.dismiss}
-        onRetry={() => { yjsSync.reconnect(); }}
-      />
-    {/if}
+      {#if isTauriRuntime() && updaterBanner.showBanner && updaterBanner.availableVersion}
+        <UpdaterBanner
+          version={updaterBanner.availableVersion}
+          installing={updaterBanner.installing}
+          onInstall={() => { updaterBanner.install(); }}
+          onDismiss={updaterBanner.dismiss}
+        />
+      {/if}
 
-    <!-- #1116: trial countdown. Self-gates (renders only during an active trial;
-         silent when the gate is dark or a license is active). -->
-    <LicenseBanner />
+      {#if connectionBanner.showBanner}
+        <ConnectionBanner
+          onDismiss={connectionBanner.dismiss}
+          onRetry={() => { yjsSync.reconnect(); }}
+        />
+      {/if}
+
+      <!-- #1116: trial countdown. Self-gates (renders only during an active trial;
+           silent when the gate is dark or a license is active). -->
+      <LicenseBanner />
+    </div>
 
     <Toolbar
       {editor}
@@ -3124,6 +3140,27 @@ const shouldShowModelPicker = $derived(
 {/snippet}
 
 <style>
+  /* Measured wrapper for the top-of-shell banners (see markup above).
+
+     `flex-shrink: 0` is DEFENSIVE, and the reason is narrower than it looks:
+     wrapping does not by itself make the stack shrinkable, because a column
+     flex item with `overflow: visible` gets `min-height: auto`, whose
+     content-based minimum is its full min-content height — the same floor each
+     banner already had as a direct child. It earns its place as the guard for
+     the one case that WOULD shrink: adding `overflow: hidden` here drops that
+     automatic minimum to 0, at which point the wrapper compresses while its
+     block children overflow, getBoundingClientRect() under-reports the height,
+     and the pill lands back on the banner text.
+
+     So: no `overflow: hidden` (it also clips the banners' slide-in, which
+     translates from -100% over the titlebar, and their box-shadow), and no
+     `display: contents` (it erases the box entirely — ResizeObserver skips
+     box-less elements and getBoundingClientRect returns zeros). No padding,
+     border, margin or gap either, per rule 2 of the index.html contract. */
+  .banner-stack {
+    flex-shrink: 0;
+  }
+
   /* Always-mounted dual-layer rail. The shell owns width + chrome (bg, inner
      radius, side shadow) + the hover-grow; its two children (`.rail-full` via
      the data-testid divs in markup, and `.rail-peek` via PeekStrip) are

--- a/src/client/actions/bannerStackHeight.svelte.ts
+++ b/src/client/actions/bannerStackHeight.svelte.ts
@@ -1,0 +1,92 @@
+/**
+ * Publishes the top-of-shell banner stack's bottom edge as
+ * `--tandem-banner-stack-bottom` on <html>, so `--tandem-fmtbar-top`
+ * (index.html) can push the fixed formatting-bar pill below whatever banners
+ * are showing. 0px means "no banners", which the consumer maps to its resting
+ * offset.
+ *
+ * Usage: `<div class="banner-stack" use:bannerStackHeight>…banners…</div>`
+ *
+ * Imperative rather than `$state`: nothing in Svelte reads this value, only CSS
+ * does, so a reactive round-trip would buy nothing. That also moots the
+ * reaction-safety question entirely. (The narrow claim is still worth stating:
+ * ResizeObserver notifications are delivered from the rendering steps, never
+ * nested inside a Svelte reaction, so `state_unsafe_mutation` does not apply —
+ * cf. useMarginPositions/DocumentTabs, which do write $state from an RO. The
+ * BROAD claim "an RO write is always safe" is false: editor-stage.svelte.ts
+ * records RO chatter tripping `effect_update_depth_exceeded`, which is why the
+ * last-value guard below is not optional.)
+ */
+
+const PROP = "--tandem-banner-stack-bottom";
+
+export function bannerStackHeight(node: HTMLElement) {
+  const root = document.documentElement;
+  let last = -1;
+
+  function publish(): void {
+    // ResizeObserver can fire one callback after disconnect; a detached read
+    // returns 0 and would park the pill at its resting offset.
+    if (!node.isConnected) return;
+
+    // Publish the stack's BOTTOM EDGE in viewport coordinates, not its height.
+    //
+    // Height was the obvious choice and it is subtly wrong: it forces the
+    // consumer to know where the stack *starts*, i.e. to hardcode the TitleBar
+    // height. The old geometry-contract comment in index.html put that at 44px;
+    // the real rendered value is 56px, so a `calc(52px + height)` offset landed
+    // 4px short and the pill still clipped the bottom of every banner. The
+    // bottom edge encodes "where the stack ends" directly and stays correct if
+    // the TitleBar is ever resized.
+    //
+    // `getBoundingClientRect()` is the border box (unlike RO's default
+    // content-box `contentRect`, which would drop the 1px border-bottom each
+    // banner carries). Rounded because a fractional devicePixelRatio (125%/150%
+    // Windows scaling, browser zoom) otherwise redelivers sub-pixel noise
+    // forever. Viewport-relative is safe here: the root column is `height:
+    // 100vh` and the stack sits above the only scroll container, so it never
+    // moves under scroll.
+    const rect = node.getBoundingClientRect();
+    // 0 is the "no banners showing" signal, which the consumer's `max()` maps
+    // back to the resting 52px. Reporting the real bottom of an empty stack
+    // would move the pill whenever the TitleBar height changed.
+    const bottom = rect.height > 0 ? Math.round(rect.bottom) : 0;
+    if (bottom === last) return;
+    last = bottom;
+
+    // MUST carry the unit. A custom property accepts any token stream, so a
+    // bare `96` is stored happily and only fails one level down as
+    // `max(52px, 96)` — invalid at computed-value time, which makes `top`
+    // compute to `auto` and drops the fixed pill to its static position. The
+    // `var(--tandem-fmtbar-top, 52px)` fallback at the consumer never fires,
+    // because the token itself is well-formed.
+    root.style.setProperty(PROP, `${bottom}px`);
+  }
+
+  // Eager first measurement, BEFORE the observer is constructed: RO's first
+  // delivery is asynchronous (post-layout), so without this the first painted
+  // frame uses H=0 and the pill lands on the banner for a frame. Visible on the
+  // server-down path, where yjsSync sets ready=true and
+  // connectionStatus="disconnected" in the same synchronous block.
+  publish();
+
+  // Guard construction the way scrollFade does — a missing ResizeObserver
+  // degrades to the eager measurement above rather than throwing on mount.
+  let observer: ResizeObserver | null = null;
+  try {
+    observer = new ResizeObserver(publish);
+    observer.observe(node);
+  } catch (err) {
+    console.warn("[tandem:bannerStackHeight] ResizeObserver init failed", err);
+  }
+
+  return {
+    destroy(): void {
+      observer?.disconnect();
+      // Falls back to the `:root` 0px declared in index.html, which the
+      // consumer's max() reads as the resting 52px — which is why this is a
+      // second variable rather than an overwrite of --tandem-fmtbar-top.
+      root.style.removeProperty(PROP);
+    },
+  };
+}

--- a/src/client/shell/FormattingBar.svelte
+++ b/src/client/shell/FormattingBar.svelte
@@ -110,7 +110,35 @@ function handleHighlight(color: HighlightColor) {
      pill centered horizontally over the document area at
      top: var(--tandem-fmtbar-top). Anchored via `position: fixed` (not
      absolute) so it stays viewport-aligned across containing-block changes
-     in W4. Drag-region is intentionally NOT set on the wrap: the TitleBar
+     in W4.
+
+     That `fixed` is also why this bar carries a correction nothing else needs.
+     The top-of-shell banners (server-restart strip, updater, connection,
+     license) sit in NORMAL FLOW between the TitleBar and the editor row, so
+     they displace everything below them — but not this pill, which left the
+     flow. It used to paint straight over their message text and CTAs. The fix
+     lives in the token, not here: --tandem-fmtbar-top is
+     `max(52px, var(--tandem-banner-stack-bottom))`, and App.svelte measures the
+     stack's bottom edge into that variable (0 when no banner is showing).
+
+     It is the stack's BOTTOM, not its height, precisely because this pill rests
+     at y=52 while the TitleBar is 56px tall — the pill tucks 4px UNDER the
+     titlebar, so "52 + banner height" lands 4px short and still clips the
+     banner. Anchoring to the bottom edge needs no titlebar constant at all.
+
+     Read the contract in index.html before touching any of the other clearance
+     vars — re-applying this offset to .editor-scroll, the ScrollPill or
+     --tandem-rail-top-clearance double-counts, because those frames already
+     moved with the banners.
+
+     Deliberately NO `transition` on `top`. Only .tandem-banner animates (a
+     180ms slide-in); the server-restart strip and LicenseBanner paint at full
+     height instantly, so a transition would manufacture a window where the pill
+     slides ACROSS an already-painted banner — re-creating the bug for two of the
+     four cases. The banner keyframes animate transform/opacity only, so the
+     border box is final at frame 0 and the measurement never races them.
+
+     Drag-region is intentionally NOT set on the wrap: the TitleBar
      already provides the window drag-region above it, and combining
      -webkit-app-region: drag with pointer-events: none is unreliable in
      WebView2 (Tauri-on-Windows) — clicks land on the editor underneath

--- a/tests/client/banner-stack-height.test.ts
+++ b/tests/client/banner-stack-height.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bannerStackHeight } from "../../src/client/actions/bannerStackHeight.svelte.js";
+
+const PROP = "--tandem-banner-stack-bottom";
+
+interface ROCallback {
+  (entries: ResizeObserverEntry[], observer: ResizeObserver): void;
+}
+
+class MockResizeObserver {
+  static instances: MockResizeObserver[] = [];
+  callback: ROCallback;
+  observed: Element[] = [];
+  disconnected = false;
+  constructor(cb: ROCallback) {
+    this.callback = cb;
+    MockResizeObserver.instances.push(this);
+  }
+  observe(el: Element): void {
+    this.observed.push(el);
+  }
+  disconnect(): void {
+    this.disconnected = true;
+  }
+  unobserve(): void {}
+  trigger(): void {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+/**
+ * happy-dom has no layout engine, so `getBoundingClientRect()` returns all
+ * zeros. Stubbing it is what keeps these assertions from passing vacuously —
+ * without it every measurement is 0, the last-value guard suppresses everything
+ * after the first write, and a broken implementation would look identical to a
+ * correct one.
+ */
+const STACK_TOP = 56; // real rendered TitleBar height — see index.html contract
+
+function mountWithHeight(height: number) {
+  const node = document.createElement("div");
+  document.body.appendChild(node);
+  let current = height;
+  // Model the real layout: the stack sits directly below the TitleBar, so its
+  // bottom is STACK_TOP + height. The action publishes that bottom edge.
+  node.getBoundingClientRect = () =>
+    ({ height: current, top: STACK_TOP, bottom: STACK_TOP + current }) as DOMRect;
+  return {
+    node,
+    setHeight(h: number) {
+      current = h;
+    },
+  };
+}
+
+function publishedValue(): string {
+  return document.documentElement.style.getPropertyValue(PROP);
+}
+
+function latestObserver(): MockResizeObserver {
+  return MockResizeObserver.instances[MockResizeObserver.instances.length - 1];
+}
+
+beforeEach(() => {
+  MockResizeObserver.instances = [];
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+});
+
+afterEach(() => {
+  document.documentElement.style.removeProperty(PROP);
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("bannerStackHeight", () => {
+  it("publishes the bottom edge eagerly, before the observer ever fires", () => {
+    const { node } = mountWithHeight(40);
+    bannerStackHeight(node);
+    // Not `latestObserver().trigger()` first — the point is that the very first
+    // painted frame already has the right value, since RO's first delivery is
+    // asynchronous and would otherwise leave the pill on the banner for a frame.
+    expect(publishedValue()).toBe("96px"); // 56 titlebar + 40 stack
+  });
+
+  it("always writes a px unit, never a bare number", () => {
+    const { node } = mountWithHeight(37);
+    bannerStackHeight(node);
+    // Load-bearing: a bare `37` is a VALID custom property, so the failure would
+    // surface a level down as `max(52px, 93)` — invalid at computed-value
+    // time, collapsing the fixed pill to its static position.
+    expect(publishedValue()).toBe("93px");
+    expect(publishedValue()).toMatch(/^\d+px$/);
+  });
+
+  it("rounds fractional edges so sub-pixel DPR noise cannot churn", () => {
+    const { node } = mountWithHeight(40.6640625);
+    bannerStackHeight(node);
+    expect(publishedValue()).toBe("97px"); // round(56 + 40.6640625)
+  });
+
+  it("does not rewrite the property when the rounded edge is unchanged", () => {
+    const { node, setHeight } = mountWithHeight(40);
+    bannerStackHeight(node);
+
+    const setProperty = vi.spyOn(document.documentElement.style, "setProperty");
+
+    // Same value, and a fractional wobble that rounds to the same integer:
+    // both must be suppressed by the last-value guard.
+    latestObserver().trigger();
+    setHeight(40.4);
+    latestObserver().trigger();
+    expect(setProperty).not.toHaveBeenCalled();
+
+    setHeight(72);
+    latestObserver().trigger();
+    expect(setProperty).toHaveBeenCalledWith(PROP, "128px");
+  });
+
+  it("reports 0 for an empty stack, then tracks its bottom edge", () => {
+    const { node, setHeight } = mountWithHeight(0);
+    bannerStackHeight(node);
+    expect(publishedValue()).toBe("0px");
+
+    setHeight(76);
+    latestObserver().trigger();
+    expect(publishedValue()).toBe("132px");
+
+    // The resting reset runs through the observer, not destroy() — the wrapper
+    // stays mounted and simply becomes empty when the last banner unmounts.
+    setHeight(0);
+    latestObserver().trigger();
+    expect(publishedValue()).toBe("0px");
+  });
+
+  it("ignores a callback delivered after the node detaches", () => {
+    const { node, setHeight } = mountWithHeight(40);
+    bannerStackHeight(node);
+
+    node.remove();
+    setHeight(999);
+    latestObserver().trigger();
+
+    // A detached read returns 0 and would park the pill at its resting offset.
+    expect(publishedValue()).toBe("96px");
+  });
+
+  it("removes the property and disconnects on destroy", () => {
+    const { node } = mountWithHeight(40);
+    const handle = bannerStackHeight(node);
+    expect(publishedValue()).toBe("96px");
+
+    handle.destroy();
+
+    expect(latestObserver().disconnected).toBe(true);
+    // Removed, not zeroed: it falls back to the `:root` 0px from index.html.
+    expect(publishedValue()).toBe("");
+  });
+
+  it("still publishes an edge when ResizeObserver is unavailable", () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor() {
+          throw new Error("no ResizeObserver");
+        }
+      },
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { node } = mountWithHeight(40);
+
+    // Must not throw on mount, and the eager measurement must survive — which
+    // only holds because it runs BEFORE the observer is constructed.
+    expect(() => bannerStackHeight(node)).not.toThrow();
+    expect(publishedValue()).toBe("96px");
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -27,6 +27,7 @@ appearance-system-light-warm
 appearance-uniform-tab-width
 apply-changes-btn
 archive-btn-{*}
+banner-stack
 batch-promote-bar
 batch-promote-clear
 batch-promote-confirm

--- a/tests/e2e/formatting-bar-popovers.spec.ts
+++ b/tests/e2e/formatting-bar-popovers.spec.ts
@@ -364,3 +364,69 @@ test("Escape on a mouse-opened popup menu closes the menu first, the popup secon
   await page.keyboard.press("Escape");
   await expect(popup, "second Escape dismisses the popup").toBeHidden();
 });
+
+/**
+ * Geometry net: the fixed formatting-bar pill must never paint over the
+ * top-of-shell banner stack.
+ *
+ * The bar is `position: fixed; top: var(--tandem-fmtbar-top)` while the four
+ * banners (server-restart strip, updater, connection, license) sit in NORMAL
+ * FLOW between the TitleBar and the editor row. Because both are horizontally
+ * centred, the pill used to land squarely on the banner's message text and CTA.
+ * The fix measures the stack's bottom edge into `--tandem-banner-stack-bottom`,
+ * which the token folds in as `max(52px, bottom)`.
+ *
+ * Why a probe element rather than a real banner: every one of the four is
+ * unreachable from a stock E2E run (license dark, updater Tauri-gated,
+ * connection needs a forced disconnect plus a >=5s floor, serverRestarted
+ * false), so H is always 0 here and a "real banner" test would assert nothing.
+ * Injecting into `banner-stack` exercises the actual mechanism — the
+ * ResizeObserver, the token composition and the pill's response — in one frame.
+ */
+test("formatting bar clears the top-of-shell banner stack", async ({ page }) => {
+  await openFixture(page);
+
+  const bar = page.locator("[data-testid='formatting-bar']");
+  const stack = page.locator("[data-testid='banner-stack']");
+  await expect(stack).toHaveCount(1);
+
+  // Resting state: no banners, so the stack reports 0 and the pill sits at the
+  // bare 52px baseline.
+  expect(await tokenValue(page, "--tandem-banner-stack-bottom")).toBe("0px");
+  const restingTop = (await bar.boundingBox())!.y;
+
+  // Inject a probe of a known height and let the observer publish it.
+  const PROBE = 40;
+  await page.evaluate((h) => {
+    const el = document.createElement("div");
+    el.id = "banner-probe";
+    el.style.height = `${h}px`;
+    el.style.background = "red";
+    document.querySelector("[data-testid='banner-stack']")!.appendChild(el);
+  }, PROBE);
+
+  await expect
+    .poll(() => tokenValue(page, "--tandem-banner-stack-bottom"), { timeout: 5_000 })
+    .not.toBe("0px");
+
+  // The load-bearing assertion: the pill is strictly below the banner box, not
+  // merely "moved". A box-vs-box comparison is what the user actually sees.
+  const probeBox = (await page.locator("#banner-probe").boundingBox())!;
+  const barBox = (await bar.boundingBox())!;
+  expect(
+    barBox.y,
+    "formatting bar must sit below the banner stack, not over it",
+  ).toBeGreaterThanOrEqual(probeBox.y + probeBox.height);
+  // Deliberately NOT `restingTop + PROBE`: the pill rests tucked 4px under the
+  // 56px TitleBar, so a height-based offset lands short of the banner's bottom.
+  // The contract is "flush with the stack's bottom edge", nothing else.
+  expect(Math.round(barBox.y)).toBe(Math.round(probeBox.y + probeBox.height));
+
+  // And it returns when the banner goes away — the reset path is as much a part
+  // of the contract as the offset, and it runs through the observer, not destroy().
+  await page.evaluate(() => document.getElementById("banner-probe")!.remove());
+  await expect
+    .poll(() => tokenValue(page, "--tandem-banner-stack-bottom"), { timeout: 5_000 })
+    .toBe("0px");
+  expect(Math.round((await bar.boundingBox())!.y)).toBe(Math.round(restingTop));
+});


### PR DESCRIPTION
## The bug

The floating format bar is `position: fixed; top: var(--tandem-fmtbar-top)` — a **static** token with exactly one consumer. The four top-of-shell banners (server-restart strip, `UpdaterBanner`, `ConnectionBanner`, `LicenseBanner`) render in **normal flow** under the TitleBar. Both are horizontally centred and banner backgrounds are opaque, so the pill painted squarely over their message text and CTAs. The bar had no idea banners existed.

## The fix

Wrap the banners in a measured element and publish its **bottom edge** as `--tandem-banner-stack-bottom`; the token folds it in as `max(52px, bottom)`. `0px` means "no banners" and maps back to the resting 52px, so geometry is byte-identical when nothing is showing.

### Why the bottom edge, not the height

This is the load-bearing decision. A height offset forces the consumer to know where the stack *starts* — i.e. to hardcode the TitleBar height — and **the geometry contract in `index.html` had that number wrong**. It claimed a 44px TitleBar; the real rendered value is **56px**. The pill rests at y=52, tucked 4px *under* the titlebar, so `52px + height` lands 4px short and still clips every banner.

The first cut of this fix did exactly that, and the new E2E caught it. The contract comment is now corrected to measured figures with a "re-measure, don't re-derive" warning.

### Only the fixed bar re-applies the offset

`.editor-scroll`'s padding, the ScrollPill track, `FindReplaceBar` and `--tandem-rail-top-clearance` all sit in frames the banners **already** displaced — re-applying the offset there would double-count and push content down twice. That asymmetry is written into the contract, along with a rule against feeding the variable into any `ResizeObserver`-observed box (7 such sites exist; that would close a measure→resize→measure loop the rounding guards can't suppress).

### No transition on `top`

Deliberately omitted. Only `.tandem-banner` animates; the restart strip and `LicenseBanner` paint at full height instantly, so a transition would *manufacture* a window where the pill slides across an already-painted banner — re-creating the bug for two of the four cases.

## How this was explored

Four parallel design agents, then three adversarial review rounds on the plan:

| Approach | Outcome |
|---|---|
| **Dynamic offset** | **Shipped** |
| Re-layer banners above the bar | Rejected — `LicenseBanner` has no dismiss control and renders for the whole trial, so every trial user would get a permanently occluded formatting bar |
| Fold the bar into normal flow | Viable, but can't preserve pixel parity in both bar-visible and bar-hidden states — a design call, not a bug fix |
| Relocate messages to toast/status surfaces | ~3 days, needs an ADR and deliberate `data-testid` removals against Critical Rule 7 |

Review also corrected several claims in my own plan: a `flex-shrink` rationale that was reasoned wrongly (the declaration is still worth keeping, but as a guard against a future `overflow: hidden`, not because wrapping newly enables shrinking), a bad E2E lever, and the density arithmetic.

## Tests

- **Unit** (`tests/client/banner-stack-height.test.ts`) — px-unit serialization, rounding, last-value guard, detached reads, RO-unavailable fallback. Verified by mutation testing: dropping the `px` unit, removing the eager measurement, or removing either guard each fail the suite.
- **E2E** (extends `formatting-bar-popovers.spec.ts`) — injects a probe into the stack and asserts the pill sits flush with its bottom edge, then returns to 52px. Confirmed a genuine net: reverting the token to its static value fails it (bar at 52, needs ≥96).
- Full suite green: **5975 unit**, **338 E2E**, `svelte-check` 0 errors/0 warnings.

The `px`-unit assertion is worth more than it looks: a bare number is a *valid* custom property, so the failure surfaces a level down as an invalid `max()`, which computes `top` to `auto` and drops the fixed pill to its static position — worse than the original bug.

## Not fixed here

`ExternalConflictBanner` is `sticky; top: 0` inside `.editor-scroll`, whose scroll-fade mask creates a stacking context on any scrolling document — trapping it under the pill regardless of z-index, with `top: 0` resolving to ≈y=46. Pre-existing and independent, but it will look like a regression from this work, so flagging it explicitly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hv7RqiCFXmKjjEejuYSywF)_