### PR TITLE
fix(editor): copy-out double spacing and internal links opening twice

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -20,7 +20,15 @@ git describe --tags --abbrev=0
 git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
 ```
 
-3. Group commits into Keep a Changelog categories based on conventional commit prefixes:
+3. **Read the diff of each change, not its subject line.** `git show <sha> -- <path>` for
+   anything you are about to describe. The commit prefix tells you where an entry goes; only
+   the diff tells you what it says. v0.20.0 shipped five defective entries composed from PR
+   titles — the worst promised a detection capability that did not exist. Where a change
+   landed across several commits (a fix, then its review corrections), describe the **final**
+   state: `git log --oneline v<prev>..HEAD -- <path>` shows whether what you just read was
+   later amended, and `git show v<prev>:<file>` settles "is this actually new?"
+
+4. Group into Keep a Changelog categories based on conventional commit prefixes:
    - `feat(...)` → **Added** (new features) or **Changed** (enhancements to existing)
    - `fix(...)` → **Fixed**
    - `refactor(...)` → **Changed**
@@ -30,12 +38,23 @@ git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
    - `perf(...)` → **Performance**
    - Security-related commits → **Security**
 
-4. Format as a `## [Unreleased]` section. Each entry should be:
+5. **Open the version with a plain-language summary, before any `###` subsection.** Two or
+   three sentences for someone who does not know the codebase, the issue numbers, or our
+   vocabulary, answering "what is different for me now?" Name the one or two changes most
+   people will notice, and say plainly if the release is mostly internal. No issue numbers,
+   no file paths, no subsystem names in the summary — those belong in the entries below it.
+
+6. **Order entries within each section by user impact, most impactful first.** Not by issue
+   number, not by merge order, not by subsystem. Ask which bullet a user would be sorriest to
+   miss and put it at the top. A reader who stops after the first bullet of each section
+   should still have the release's substance.
+
+7. Format as a `## [Unreleased]` section. Each entry should be:
    - Bold summary with PR number: `- **Description** (#N)`
    - Group related commits into a single entry where appropriate
    - Use imperative mood ("Add", "Fix", "Remove" — not "Added", "Fixes")
 
-5. Output the formatted block for the user to review and paste into `CHANGELOG.md`.
+8. Output the formatted block for the user to review and paste into `CHANGELOG.md`.
 
 ## Important
 
@@ -43,6 +62,12 @@ git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
 - Check the existing CHANGELOG.md format to match style (indentation, heading levels, PR references)
 - If there's already an `[Unreleased]` section, show what to append, not a replacement
 - Omit empty categories (don't show "### Security" if there are no security commits)
+- **List spacing is load-bearing.** `CHANGELOG.md` has a byte-identical `serializeMdast`
+  round-trip golden test (`tests/server/file-io/markdown-escaping.test.ts`). `### Fixed` uses
+  tight lists (no blank line between bullets) while `### Added`/`### Changed` use loose ones;
+  mixing them fails the test. Run that test after editing, not at the end.
+- **The in-app View Changelog surface renders this file**, so an HTML comment is invisible
+  there. Caveats and hedges go in the prose or they reach nobody.
 
 ## Releasing
 

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -269,8 +269,8 @@ $effect(() => {
 // -- A5: spellcheck toggling without recreating the editor ------------------
 // `setOptions({ editorProps })` replaces `editorProps` wholesale (not a
 // shallow merge), so `makeEditorProps` always rebuilds the full object
-// (attributes + clipboardTextParser + handlePaste), not just the spellcheck
-// bit. No last-value guard needed here (unlike `_lastReadOnly` above):
+// (attributes + clipboardTextParser + clipboardTextSerializer + handlePaste),
+// not just the spellcheck bit. No last-value guard needed here (unlike `_lastReadOnly` above):
 // `spellcheckOn` is a memoized `$derived` of a primitive, so this effect only
 // re-fires on a real toggle — or on editor recreation, where the one
 // same-value `setOptions` call is harmless (the new editor was already

--- a/src/client/editor/editor-extensions.ts
+++ b/src/client/editor/editor-extensions.ts
@@ -15,6 +15,7 @@ import { FootnoteRefMark } from "./extensions/footnote-ref";
 import { ListItemCheckbox } from "./extensions/list-item-checkbox";
 import { MarkdownHtmlExtension } from "./extensions/markdown-html";
 import { RawMarkdownMark } from "./extensions/raw-markdown";
+import { isSafeExternalHref } from "./utils/url-safety";
 
 // Link mark that surfaces the destination URL on hover via a native `title`
 // tooltip (issue #996). The base `@tiptap/extension-link` renderHTML emits the
@@ -27,6 +28,10 @@ import { RawMarkdownMark } from "./extensions/raw-markdown";
 // the base output rather than the raw HTMLAttributes means a disallowed scheme is
 // never given a title and never resurrected. Pointer-cursor styling lives in
 // editor.css (`.tandem-editor a[href]`).
+//
+// It also strips the configured `target="_blank"` from non-external hrefs — see
+// the comment at that branch for why the attribute is a double-open on internal
+// links but a safety net on external ones.
 const LinkWithHoverTitle = Link.extend({
   renderHTML(props) {
     const out = this.parent?.(props) ?? [
@@ -35,11 +40,28 @@ const LinkWithHoverTitle = Link.extend({
       0,
     ];
     if (Array.isArray(out) && out.length >= 2 && out[1] && typeof out[1] === "object") {
-      const attrs = out[1] as Record<string, unknown>;
+      const attrs = { ...(out[1] as Record<string, unknown>) };
       const href = attrs.href;
       if (typeof href === "string" && href.length > 0 && attrs.title == null) {
-        (out as unknown[])[1] = { ...attrs, title: href };
+        attrs.title = href;
       }
+      // Drop `target="_blank"` on anything that is not a safe external URL
+      // (#1343). Clicking a relative link to a local `.md` opened it as a
+      // Tandem tab AND popped the system browser: `handleEditorClick`
+      // preventDefaults and routes the click through `openHref`, but WebView2
+      // treats a `_blank` anchor as a new-window request in its own right, and
+      // no `on_new_window` handler is registered, so it falls through to the OS.
+      //
+      // Kept for external hrefs deliberately, even though `openHref` already
+      // calls `window.open` itself and the attribute is redundant on the happy
+      // path: if the intercept ever fails to run, `_blank` degrades to "opens a
+      // new tab" instead of navigating the editor frame away and taking the
+      // session with it. Internal links have no such consolation — their
+      // fallback is the double-open being fixed here.
+      if (typeof href === "string" && !isSafeExternalHref(href)) {
+        delete attrs.target;
+      }
+      (out as unknown[])[1] = attrs;
     }
     return out;
   },

--- a/src/client/editor/editor-props.ts
+++ b/src/client/editor/editor-props.ts
@@ -13,8 +13,8 @@ import { isSafeExternalHref } from "./utils/url-safety";
 // Full `editorProps` factory (A5). Tiptap's `editor.setOptions({ editorProps
 // })` replaces `editorProps` wholesale — it is NOT a shallow merge — so
 // toggling spellcheck without recreating the editor requires re-supplying
-// every existing prop (attributes, clipboardTextParser, handlePaste) plus
-// the new `spellcheck` attribute, not just the changed piece.
+// every existing prop (attributes, clipboardTextParser, clipboardTextSerializer,
+// handlePaste) plus the new `spellcheck` attribute, not just the changed piece.
 export function makeEditorProps(spellcheckOnValue: boolean): EditorProps {
   return {
     attributes: {
@@ -44,6 +44,27 @@ export function makeEditorProps(spellcheckOnValue: boolean): EditorProps {
       // diverge.
       return buildPlainTextSlice(text, view.state.schema, $context.marks());
     },
+    // Copy out with single newlines between blocks (#1365). ProseMirror's
+    // default serializer is `textBetween(…, "\n\n")`, which puts a blank line
+    // between EVERY block — including consecutive list items — so a bulleted
+    // list pasted anywhere plain arrives double-spaced, and prose arrives with
+    // a blank line after every paragraph.
+    //
+    // Only the `text/plain` flavor is affected. ProseMirror writes `text/html`
+    // on every copy too, and rich targets (Word, Google Docs, Outlook) read
+    // that instead — so real paragraph structure survives there regardless of
+    // what we do here. A single `\n` is what those apps themselves put on
+    // `text/plain`. The tradeoff is deliberate: pasting into a markdown file,
+    // which needs a blank line to separate paragraphs, now merges them.
+    //
+    // The `leafText` arm fixes a second, independent default. `hardBreak` is
+    // an inline leaf carrying no text and no `leafText` spec, so `textBetween`
+    // contributes nothing for it and "a<br>b" copied as "ab" — a silently
+    // lost line break, unrelated to the separator above.
+    clipboardTextSerializer: (slice) =>
+      slice.content.textBetween(0, slice.content.size, "\n", (leaf) =>
+        leaf.type.name === "hardBreak" ? "\n" : "",
+      ),
     // Paste URL over a non-empty selection → link the selected text instead
     // of replacing it. Direct `editorProps` handlers run BEFORE both
     // `clipboardTextParser` above and Link's own `pasteHandler` plugin, so

--- a/tests/client/clipboard-copy-text.test.ts
+++ b/tests/client/clipboard-copy-text.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Copy-out plain-text serialization (#1365).
+ *
+ * The reported defect: copying from Tandem and pasting into another app "adds
+ * double line breaks which kind of ruin formatting in the target
+ * applications". ProseMirror's default `clipboardTextSerializer` is
+ * `textBetween(…, "\n\n")`, which inserts a blank line between EVERY block —
+ * consecutive list items included.
+ *
+ * These drive the REAL production serializer out of `makeEditorProps` against
+ * the REAL production schema from `buildSchemaExtensions()`, the same pattern
+ * as `link-paste.test.ts`. Asserting on a hand-written `textBetween` call
+ * would test this file's arithmetic rather than the editor's behaviour.
+ */
+
+import { Editor } from "@tiptap/core";
+import { TextSelection } from "@tiptap/pm/state";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
+import { makeEditorProps } from "../../src/client/editor/editor-props";
+
+let open: { editor: Editor; container: HTMLDivElement } | null = null;
+
+function makeEditor(content: string): Editor {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const editor = new Editor({
+    element: container,
+    extensions: buildSchemaExtensions(),
+    content,
+    editorProps: makeEditorProps(true),
+  });
+  open = { editor, container };
+  return editor;
+}
+
+afterEach(() => {
+  open?.editor.destroy();
+  open?.container.remove();
+  open = null;
+});
+
+/**
+ * Serialize the whole document the way a Ctrl+C would.
+ *
+ * Goes through `view.someProp("clipboardTextSerializer", …)` — the exact
+ * lookup `prosemirror-view`'s `serializeForClipboard` performs — so a prop
+ * that failed to reach `editorProps` shows up as a miss here rather than
+ * being papered over by calling the factory's function directly.
+ */
+function copyAll(editor: Editor): string {
+  const { doc, tr } = editor.state;
+  editor.view.dispatch(tr.setSelection(TextSelection.create(doc, 0, doc.content.size)));
+  const slice = editor.state.selection.content();
+  const serializer = editor.view.someProp("clipboardTextSerializer");
+  expect(serializer, "clipboardTextSerializer never reached editorProps").toBeTypeOf("function");
+  return (serializer as (s: typeof slice, v: unknown) => string)(slice, editor.view);
+}
+
+describe("copying to the clipboard as plain text", () => {
+  it("separates list items with one newline, not a blank line", () => {
+    const editor = makeEditor(
+      "<ul><li><p>one</p></li><li><p>two</p></li><li><p>three</p></li></ul>",
+    );
+    expect(copyAll(editor)).toBe("one\ntwo\nthree");
+  });
+
+  it("separates paragraphs with one newline", () => {
+    const editor = makeEditor("<p>first</p><p>second</p>");
+    expect(copyAll(editor)).toBe("first\nsecond");
+  });
+
+  it("does not double-space a heading followed by its paragraph", () => {
+    const editor = makeEditor("<h2>Title</h2><p>Body text.</p>");
+    expect(copyAll(editor)).toBe("Title\nBody text.");
+  });
+
+  it("keeps a hard break as a line break instead of dropping it", () => {
+    // Independent of the separator: hardBreak is an inline leaf with no text
+    // and no `leafText` spec, so ProseMirror's default contributes NOTHING for
+    // it and "a<br>b" copied as "ab".
+    const editor = makeEditor("<p>alpha<br>beta</p>");
+    expect(copyAll(editor)).toBe("alpha\nbeta");
+  });
+
+  it("still emits no blank lines for a mixed document", () => {
+    // The end-to-end shape of the complaint. The assertion that matters is the
+    // absence of "\n\n" anywhere; the exact text is pinned alongside it so
+    // this cannot pass by serializing to something empty or truncated.
+    const editor = makeEditor(
+      "<p>Intro.</p><ul><li><p>one</p></li><li><p>two</p></li></ul><p>Outro.</p>",
+    );
+    const copied = copyAll(editor);
+    expect(copied).not.toContain("\n\n");
+    expect(copied).toBe("Intro.\none\ntwo\nOutro.");
+  });
+});

--- a/tests/client/link-target-internal.test.ts
+++ b/tests/client/link-target-internal.test.ts
@@ -1,0 +1,95 @@
+/**
+ * `target="_blank"` is stripped from non-external links (#1343).
+ *
+ * The reported defect: clicking a link to a local `.md` opened it as a Tandem
+ * tab AND popped the system browser. `handleEditorClick` preventDefaults every
+ * non-fragment anchor and routes it through `openHref`, but WebView2 treats a
+ * `_blank` anchor as a new-window request of its own, and no `on_new_window`
+ * handler is registered — so it reaches the OS regardless of preventDefault.
+ *
+ * Renders through the production `buildSchemaExtensions()`, so this asserts on
+ * the markup the real editor emits rather than on a hand-built extension.
+ */
+
+import { Editor } from "@tiptap/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
+
+let open: { editor: Editor; container: HTMLDivElement } | null = null;
+
+/**
+ * Render a link by applying the `link` MARK, not by parsing an `<a>`.
+ *
+ * This mirrors how links in a `.md` actually arrive: `mdast-ydoc.ts` builds the
+ * mark directly from the mdast `link` node. Going through `content: "<a …>"`
+ * instead would route via Tiptap's `parseHTML`, whose `isAllowedUri` drops a
+ * bare relative href like `subdir/file.txt` outright — so that path renders no
+ * anchor at all and an absence-assertion on `target` would pass vacuously.
+ * `renderHTML`, which is what this file tests, runs either way.
+ */
+function renderLink(href: string): HTMLAnchorElement | null {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const editor = new Editor({
+    element: container,
+    extensions: buildSchemaExtensions(),
+    content: "<p>link text</p>",
+  });
+  open = { editor, container };
+
+  const { state, view } = editor;
+  const linkType = state.schema.marks.link;
+  if (!linkType) throw new Error("the link mark is missing from the production schema");
+  const from = 1;
+  const to = state.doc.content.size - 1;
+  view.dispatch(state.tr.addMark(from, to, linkType.create({ href })));
+
+  return container.querySelector("a");
+}
+
+afterEach(() => {
+  open?.editor.destroy();
+  open?.container.remove();
+  open = null;
+});
+
+describe("link target attribute", () => {
+  // NOTE: a bare relative href with a subdirectory (`subdir/file.md`) is
+  // absent from this list on purpose — Tiptap's own `isAllowedUri` blanks it
+  // to `href=""` before our `renderHTML` post-processing runs, so it renders
+  // as a dead link and an assertion here would be about that bug, not this
+  // one. Filed separately; `./sub/file.md` and `/sub/file.md` are unaffected.
+  it.each([
+    ["./notes.md", "a sibling markdown file"],
+    ["../docs/spec.md", "a parent-relative markdown file"],
+    ["./subdir/file.txt", "an explicitly-relative nested path"],
+    ["/abs/path.md", "a root-relative path"],
+  ])("does not set target=_blank on %s (%s)", (href) => {
+    const anchor = renderLink(href);
+    expect(anchor, "no anchor rendered").toBeTruthy();
+    expect(anchor?.getAttribute("href")).toBe(href);
+    expect(anchor?.hasAttribute("target")).toBe(false);
+  });
+
+  it.each([
+    "https://example.com/page",
+    "http://example.com/page",
+    "mailto:someone@example.com",
+  ])("keeps target=_blank on the external href %s", (href) => {
+    // Deliberate, not incidental: the attribute is redundant while the click
+    // intercept works, but if the intercept ever fails to run it degrades to
+    // "opens a new tab" rather than navigating the editor frame away and
+    // taking the session with it.
+    const anchor = renderLink(href);
+    expect(anchor?.getAttribute("target")).toBe("_blank");
+  });
+
+  it("still carries rel and the hover title on an internal link", () => {
+    // Positive control on the same sample: proves the anchor really went
+    // through LinkWithHoverTitle's post-processing rather than failing to
+    // render a link at all, which would satisfy the absence-assertions above.
+    const anchor = renderLink("./notes.md");
+    expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(anchor?.getAttribute("title")).toBe("./notes.md");
+  });
+});

--- a/tests/docs/loopback-gate-claims.test.ts
+++ b/tests/docs/loopback-gate-claims.test.ts
@@ -100,12 +100,35 @@ function scannedFiles(): string[] {
   return [...docs, ...code].filter((p) => !p.endsWith("loopback-gate-claims.test.ts"));
 }
 
+/**
+ * Read every scanned file ONCE, shared across the tests below.
+ *
+ * This scan walks ~1500 `.ts` files with synchronous I/O, and each test used to
+ * repeat the whole walk. Under the full suite — where vitest is already
+ * saturating the disk with its own transforms — that pushed a single test past
+ * vitest's 15s default and failed the run on timing alone, on Windows, while
+ * passing in isolation and on CI. A test whose verdict depends on how busy the
+ * machine is reports nothing useful about the claim it exists to check.
+ *
+ * Memoized at module scope rather than in a `beforeAll` so the cost lands once
+ * per file, not once per suite.
+ */
+let cachedCorpus: Array<{ rel: string; lines: string[] }> | null = null;
+function corpus(): Array<{ rel: string; lines: string[] }> {
+  if (!cachedCorpus) {
+    cachedCorpus = scannedFiles().map((rel) => ({
+      rel,
+      lines: readFileSync(join(REPO_ROOT, rel), "utf-8").split("\n"),
+    }));
+  }
+  return cachedCorpus;
+}
+
 describe("loopback-gate documentation claims (#1293 / #1322)", () => {
   it("nothing live describes the gate as inert without tensing that as history", () => {
     const offenders: string[] = [];
 
-    for (const rel of scannedFiles()) {
-      const lines = readFileSync(join(REPO_ROOT, rel), "utf-8").split("\n");
+    for (const { rel, lines } of corpus()) {
       lines.forEach((line, i) => {
         if (!/assertLoopbackForMutation/.test(line)) return;
         const claimsInert =

--- a/tests/docs/loopback-gate-claims.test.ts
+++ b/tests/docs/loopback-gate-claims.test.ts
@@ -85,6 +85,19 @@ function ungatedMutatingRouteModules(): string[] {
 const PATH_TAKING = ["convert", "open", "save", "upload"];
 
 /**
+ * Budget for the corpus walk, well above vitest's 15s default.
+ *
+ * Measured: ~5s for this file alone, ~22-25s inside the full suite on Windows,
+ * where vitest's own transforms are already saturating the disk. The default
+ * turned that gap into a red run that reproduced on master and passed on CI —
+ * a timing verdict wearing the costume of a security-invariant failure, which
+ * is the most expensive kind of false alarm to debug. Generous on purpose: this
+ * number exists to stop the machine's load deciding the outcome, so it should
+ * only ever fail if the walk is genuinely broken.
+ */
+const CORPUS_TIMEOUT_MS = 90_000;
+
+/**
  * Source and test comments are scanned too, not just prose docs: #1293's own
  * report counted ~10 *comments* making this claim, and the last carrier the
  * manual sweep turned up was a header comment in `tests/server/`.
@@ -111,7 +124,9 @@ function scannedFiles(): string[] {
  * machine is reports nothing useful about the claim it exists to check.
  *
  * Memoized at module scope rather than in a `beforeAll` so the cost lands once
- * per file, not once per suite.
+ * per file, not once per suite. Memoizing alone is not sufficient — whichever
+ * test runs first still pays the full walk, which is why the test consuming it
+ * also carries {@link CORPUS_TIMEOUT_MS}.
  */
 let cachedCorpus: Array<{ rel: string; lines: string[] }> | null = null;
 function corpus(): Array<{ rel: string; lines: string[] }> {
@@ -125,28 +140,33 @@ function corpus(): Array<{ rel: string; lines: string[] }> {
 }
 
 describe("loopback-gate documentation claims (#1293 / #1322)", () => {
-  it("nothing live describes the gate as inert without tensing that as history", () => {
-    const offenders: string[] = [];
+  it(
+    "nothing live describes the gate as inert without tensing that as history",
+    () => {
+      const offenders: string[] = [];
 
-    for (const { rel, lines } of corpus()) {
-      lines.forEach((line, i) => {
-        if (!/assertLoopbackForMutation/.test(line)) return;
-        const claimsInert =
-          /no-op|only rejects when|would not fire|is inert|dead code|does not (?:fire|gate)/i.test(
-            line,
-          );
-        // A historical note is fine, but naming #1293 is not enough on its own:
-        // the roadmap entry that survived the first sweep described the gate in
-        // the PRESENT tense on a line that opened with the issue number. The
-        // past-tense marker is what distinguishes "this was true once" from
-        // "this is true", so both are required.
-        const dated = /#1293/.test(line) && /\bwas\b|\bwere\b|\buntil\b|\bbefore\b|~~/i.test(line);
-        if (claimsInert && !dated) offenders.push(`${rel}:${i + 1}`);
-      });
-    }
+      for (const { rel, lines } of corpus()) {
+        lines.forEach((line, i) => {
+          if (!/assertLoopbackForMutation/.test(line)) return;
+          const claimsInert =
+            /no-op|only rejects when|would not fire|is inert|dead code|does not (?:fire|gate)/i.test(
+              line,
+            );
+          // A historical note is fine, but naming #1293 is not enough on its own:
+          // the roadmap entry that survived the first sweep described the gate in
+          // the PRESENT tense on a line that opened with the issue number. The
+          // past-tense marker is what distinguishes "this was true once" from
+          // "this is true", so both are required.
+          const dated =
+            /#1293/.test(line) && /\bwas\b|\bwere\b|\buntil\b|\bbefore\b|~~/i.test(line);
+          if (claimsInert && !dated) offenders.push(`${rel}:${i + 1}`);
+        });
+      }
 
-    expect(offenders).toEqual([]);
-  });
+      expect(offenders).toEqual([]);
+    },
+    CORPUS_TIMEOUT_MS,
+  );
 
   it("the ungated mutating set derived from source is exactly what the docs enumerate", () => {
     const derived = ungatedMutatingRouteModules();


### PR DESCRIPTION
Two editor papercuts reported against v0.20.1, both in the "copy or click and the app does the wrong thing quietly" class, plus a test-infrastructure fix the branch needed in order to push.

Closes #1365
Closes #1343

## Copying out no longer double-spaces everything (#1365)

Copy a bulleted list out of Tandem and paste it anywhere plain — Slack, a terminal, a chat box — and every item arrived separated by a blank line. So did every paragraph. The reporter's words: it "kind of ruins formatting in the target applications."

The cause is a ProseMirror default. `clipboardTextSerializer` falls back to `textBetween(…, "\n\n")`, which puts a blank line between *every* block, list items included. `editor-props.ts` now supplies its own serializer with a single `\n`.

Two things worth knowing about the scope:

- **Rich targets are unaffected.** ProseMirror writes `text/html` on every copy too, and Word, Google Docs and Outlook read that instead. This changes the `text/plain` flavor only — which is also where those same apps put a single `\n`.
- **The tradeoff is deliberate.** Pasting into a markdown file, where a blank line is what separates paragraphs, now merges them. That is the cost of matching what every other editor puts on the clipboard, and it goes the right way for the overwhelmingly more common target.

The same change fixes a second, independent default that was hiding underneath it: `hardBreak` is an inline leaf with no text and no `leafText` spec, so `textBetween` contributed *nothing* for it and `a<br>b` copied as `ab`. A silently swallowed line break, unrelated to the separator.

## An internal link no longer opens twice (#1343)

Clicking a relative link to a local `.md` opened it as a Tandem tab **and** popped the system browser.

`handleEditorClick` preventDefaults every non-fragment anchor and routes it through `openHref`, so the interception was working. But the Link extension is configured with `target="_blank"`, and WebView2 treats a `_blank` anchor as a new-window request in its own right — no `on_new_window` handler is registered, so it reaches the OS regardless of what preventDefault did.

`LinkWithHoverTitle.renderHTML` now drops `target` from anything that isn't a safe external URL.

External links keep it on purpose. `openHref` calls `window.open` itself, so the attribute is redundant on the happy path — but if the intercept ever fails to run, `_blank` degrades to "opens a new tab" rather than navigating the editor frame away and taking the session with it. Internal links have no equivalent consolation; their fallback was the double-open being fixed here.

While testing this I found a **separate pre-existing bug**: a bare relative href with a subdirectory component and no leading `./` or `/` (`subdir/file.md`) is blanked to `href=""` by Tiptap's own `isAllowedUri` before our post-processing runs, so it renders as a dead link. Filed as #1377; that case is excluded from the test here with a comment saying why, since asserting on it would be testing the other bug.

## The docs test's timeout (no issue)

`tests/docs/loopback-gate-claims.test.ts` was failing the full suite on this branch — and, once checked, on master too. Not an assertion failure: a 15s timeout. The test walks ~1500 `.ts` files with synchronous I/O, three times over, while vitest saturates the same disk with its own transforms. ~5s in isolation, ~22-25s inside the full run, Windows only, green on CI.

Two changes: memoize the corpus so the walk happens once per file instead of once per test, and give the test that pays for it a 90s budget. A security-invariant test whose verdict depends on how busy the machine is teaches its reader to discount it, which is the opposite of the job.

## Testing

- `npm run typecheck` — clean (1315 files)
- `npm test -- --run` — **6360 passed, 19 skipped, 0 failed**
- 13 new tests (5 clipboard, 8 link target), all driving production factories — `makeEditorProps` and `buildSchemaExtensions` — rather than hand-built stand-ins

Both new suites were mutation-checked rather than assumed:

- Reverting the separator to `"\n\n"` fails 4 of 5 clipboard tests; the hardBreak test correctly still passes, since it tests the independent `leafText` arm.
- The link tests apply the link **mark** directly rather than parsing `<a>` markup, because the parse path drops bare relative hrefs before rendering — an absence-assertion on `target` would have passed vacuously against an anchor that never rendered. A positive control on the same sample asserts `rel` and `title` survive, proving the anchor really went through the post-processing.

Not manually tested in the desktop app: the WebView2 double-open needs a Tauri build, and the assertion available here is on the emitted markup, which is where the fix lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKcPLgN9YGgfC1WvPJ2Vq
