### PR TITLE
docs(changelog): add the Internal section v0.21.0 was missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,18 @@ This release closes the findings from the v1.0 security review. **None was reach
 - **A network-path check was being made against the wrong string.** When Tandem writes the location of a helper program into your Claude configuration, it refuses paths that point at a network share, because Windows can be induced to hand over credentials when it reaches one. The check ran after a normalization step that, on macOS and Linux, removes the very prefix it looks for — so a path that should have been refused could be written. It now checks the path as given. This required a non-default setup that supplies its own path, and was found by a test rather than in the wild.
 - **Absolute file paths no longer appear in responses sent to other machines on your network (#1294).** Tandem already stripped the directory part of file paths before sending them to a caller that isn't your own machine, so a network client saw a file's name and not where it lives. Several responses had been missed — the integrations list, some success and error messages, and one internal error that included the layout of Tandem's data directory. All of them now go through the same stripping. A caller on your own machine sees exactly what it did before.
 
+### Internal
+
+- **The v1.0 performance gate exists now, and its first finding was that one of our own bug reports was wrong.** There is a fixture generator, a harness, and two recorded runs. Pointed at the complaint that accepting an annotation took about eight seconds under a heavy load, it separated the time spent getting the click to land from the time spent acting on it — 7851 ms against 379 ms — so the problem is that the button is hard to hit, not that accepting is slow. The report's stated mechanism does not survive the measurement, and the issue has been re-scoped to what the numbers actually say.
+
+- **The accessibility audit went from two surfaces to fifteen.** Settings, the command palette, find and replace, the margin view, chat, the tray, menus and the tutorial were all previously unaudited. Three structural problems had to be fixed first, and one of them was itself hiding a defect: an exclusion added years earlier to skip a faded element was still suppressing three unrelated controls that had since moved out from under it.
+
+- **Forced-colors support was being tested by a switch that does nothing.** Tandem carries sixteen blocks of styling for Windows High Contrast, and the test harness meant to exercise them used a Playwright option measured to be inert on the current Chromium. Those blocks had therefore never once executed under test. They are now driven through the browser's own protocol instead, and they work.
+
+- **The documentation was reconciled against what actually ships.** A sweep across the README, the architecture and security documents, the tool reference and the bundled skill corrected claims that had drifted — most consequentially that `.docx` files open read-only, which has been false since v0.14.0 and was being told to every AI that read the skill. Two documentation claims about a security gate are now pinned by a test, because the same stale claim survived a manual correction sweep twice.
+
+- **Bring-your-own-model support and the licensing gate both remain switched off.** Both received real fixes this release — bounded streaming, a run clock, a rebuilt request URL, and an issuance path that now fails closed on a missing support address. None of it is reachable: both are literal off switches in the source, and the model settings tab is filtered out of the interface entirely while its flag is false.
+
 ## [0.20.1] - 2026-08-05
 
 ### Fixed


### PR DESCRIPTION
Adds the `### Internal` section v0.21.0 was about to ship without. **This must land before the `v0.21.0` tag** — the tag is not yet pushed, so there is still a window.

## How it was found

The `/changelog` skill asks *which category is absent*, which is a structurally different question from *are the written entries correct*. Two adversarial passes over this draft asked the second question well — between them they caught a byte-cap misread off a test parameter, a wrong issue citation carried in the commit history, an issue number already claimed by v0.20.1, a `nanoid` CVE riding a Dependabot bump, and a contradiction between the Security section's own opener and its own bullet.

None of them asked the first question, because a reviewer pointed at a list of entries can only grade the entries in front of it.

v0.19.0 and v0.20.0 both carry an `### Internal` section. v0.21.0 had none — in a release containing the entire v1.0 performance gate, the accessibility audit's expansion from two surfaces to fifteen, and a documentation sweep across the README, architecture, security and tool-reference docs.

This is the same failure shape v0.20.0 actually shipped with, where the absent category was `### Security`.

## What went in

Five entries, each written from the diff:

- **The performance gate**, including that its first finding refuted one of our own bug reports. Pointed at #1288's "accepting an annotation takes ~8s", it split 7851 ms of getting the click to land from 379 ms of actually accepting — so the defect is hit-testability, not accept speed. The issue's stated mechanism does not survive the measurement.
- **The accessibility audit's expansion**, and that one of the three structural problems fixed first was itself concealing a defect: an exclusion written for a faded element was still suppressing three unrelated controls that had since moved out from under it.
- **Forced-colors styling had never once executed under test** — sixteen blocks of it, exercised by a Playwright option measured to be inert on the current Chromium. Now driven through the browser protocol instead.
- **The documentation reconciliation**, most consequentially the claim that `.docx` opens read-only, false since v0.14.0 and being told to every AI that read the bundled skill.
- **Both dark systems remain dark**, stated explicitly, because both received real fixes this release and neither is reachable. Saying so is the difference between a note and an implied capability.

## Considered and deliberately not added

`### Removed`. The dev-channels flag change is Tandem no longer *passing* a flag that did nothing, not a capability withdrawn from users — `git diff v0.20.1..HEAD --diff-filter=D -- src/` is empty, and no setting or file type was dropped. `### Changed` is where it belongs, and it is already there.

## Testing

`tests/server/file-io/markdown-escaping.test.ts` green — 37 passed. That is the byte-identical golden test, and it is what catches tight-vs-loose list drift between sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKcPLgN9YGgfC1WvPJ2Vq
