### PR TITLE
docs(status): v0.21.0 shipped; correct the security-gate standing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ Mechanism, ops, and failure modes: [docs/licensing-explained.md](docs/licensing-
 
 ## Status
 
-**Shipped: v0.20.1.** Release history is [CHANGELOG.md](CHANGELOG.md); remaining v1.0 work is [docs/roadmap.md](docs/roadmap.md#active--toward-v10). Do not re-narrate either here.
+**Shipped: v0.21.0** (2026-08-10). Release history is [CHANGELOG.md](CHANGELOG.md); remaining v1.0 work is [docs/roadmap.md](docs/roadmap.md#active--toward-v10). Do not re-narrate either here.
 
 Core is complete — 29 active MCP tools, multi-doc tabs, CRDT-anchored annotations, chat, four push paths (self-armed wake, plugin monitor, opt-in channel shim, supervisor stdin), `.md`/`.docx`/`.txt`/`.html`, npm global install, Tauri desktop app.
 
@@ -210,7 +210,9 @@ Core is complete — 29 active MCP tools, multi-doc tabs, CRDT-anchored annotati
 - **Licensing** (ADR-040, #1116) — `LICENSE_GATE_ENABLED` in `tsup.config.ts`. Section above.
 - **Local-model collaborator** (ADR-039, #1123) — `BYO_MODELS_ENABLED` is a literal `const false` in `src/shared/constants.ts`. The whole M1a→M4 mechanism is merged dark. It also gates UI: the Settings **Models** tab is filtered out entirely while false, so do not document or test it as a visible surface.
 
-**Blocking v1.0:** the cross-platform install matrix and #316 Cowork macOS/Linux (both hardware-gated); the two flag flips; and the v1.0 exit gates. The security gate's RC re-run **failed** on 2026-08-05 — #1291 has since been fixed, leaving #1292 (O(n²) local-model streaming sink), which blocks the BYO-models flip rather than the release. Prior per-feature version pins (v0.16.0 = licensing, v0.17.0 = local models) are void; both ship incrementally dark across minors.
+**Blocking v1.0:** the cross-platform install matrix and #316 Cowork macOS/Linux (both hardware-gated); the two flag flips; and the v1.0 exit gates. Prior per-feature version pins (v0.16.0 = licensing, v0.17.0 = local models) are void; both ship incrementally dark across minors.
+
+**Security gate, as of v0.21.0.** The RC re-run failed on 2026-08-05 with two HIGH. #1291 (CORS opaque-origin grant) and #1293 (inverted loopback gate) are fixed and closed, as is #1294. **#1292 is still OPEN and is the last HIGH** — its code fix shipped in v0.21.0, but it gates on the BYO-models flip rather than on the release, so do not read the v0.21.0 entry as closing it; verify the issue state, not the changelog. **#1295 is also still open**: three of its six LOW findings shipped in v0.21.0 (the scratchpad gate, the restore documentId binding, the reply cap), the other three did not. A batch issue closes when the batch does, so its open state does not tell you which half remains — read the issue.
 
 ## Tandem-Specific Skills
 


### PR DESCRIPTION
Step 8 of the release skill, after publishing v0.21.0.

Two changes to `CLAUDE.md`'s Status section.

**The version line** now reads v0.21.0 (2026-08-10).

**The security-gate paragraph was stale in a way that would have been read as current.** It named #1292 as the last outstanding HIGH, written when #1291 was the only other one open. #1293 and #1294 have since closed too, so the sentence described a state that no longer existed.

The replacement says to read the issues rather than the changelog, because both survivors are cases where the changelog actively misleads:

- **#1292's code fix shipped in v0.21.0, but the issue is still OPEN** — it gates on the BYO-models flag flip rather than on the release. Anyone going from the changelog entry to "so that's closed" would be wrong.
- **#1295 is a six-finding batch, three of which shipped.** A batch issue closes when the batch does, so its open state tells you nothing about which half remains.

## Release state, for the record

Published and marked latest. `tandem-editor@0.21.0` is live on npm. Pre-publish counts were verified rather than assumed: one release for the tag, 17 assets, 11 platform keys including `darwin-aarch64` — the key whose absence at v0.18.0 told every M-series Mac it was up to date until the next release.

Smoke-checklist outcome is recorded as a comment on #1379. Short version: CI and the npm path pass; all three hardware sections are unrun, including the updater, which matters more than usual here because v0.21.0 changes the sidecar bundle and v0.20.1's first-ever real-hardware macOS updater pass is therefore not re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eKcPLgN9YGgfC1WvPJ2Vq