### PR TITLE
fix(server): refresh managed skill before readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Hand-started Claude Code sessions now try to watch Tandem automatically on first use.** After the first successful read-only `tandem_status`, the bundled skill makes one persistent built-in Monitor attempt using the server-reported wake address; asking Claude to watch is now recovery rather than setup. Existing setup-managed skill copies refresh before Tandem reports ready, including when the launcher is disabled or deferred. A missing standalone skill does not install during generic startup, so plugin-only users do not silently acquire a second integration route. Plugin-only sessions receive the updated instructions when Claude Code refreshes its plugin cache, on a timeline Tandem does not control. If a plugin-backed session starts both its packaged monitor and the built-in watch automatically, wakes remain payload-free and inbox reads de-duplicate; `TaskStop` stops the built-in watch when doubled wakes make the overlap visible.
+
 ## [0.21.0] - 2026-08-10
 
 Most of this release is Tandem telling you the truth about itself.

--- a/src/cli/uninstall-scrub.ts
+++ b/src/cli/uninstall-scrub.ts
@@ -364,8 +364,8 @@ const SKILL_DIR_ALLOWLIST = [/^SKILL\.md$/, /^\.tandem-setup-[0-9a-f-]+\.tmp$/];
  * orphaned `atomicWrite` temps from a crashed install). Anything else means
  * the user put files there; leave the whole dir intact. A dangling skill is
  * harmless to Claude Code but keeps advertising tandem_* tools that no
- * longer exist; if the install survives and runs again, `refreshSkillIfStale`
- * recreates it.
+ * longer exist. A later user-approved `tandem setup` recreates it; generic
+ * server startup deliberately does not cross that install boundary.
  *
  * `homeOverride` is for tests only.
  */

--- a/src/client/actions/builtin.svelte.ts
+++ b/src/client/actions/builtin.svelte.ts
@@ -708,6 +708,16 @@ async function checkLauncherAvailable(d: ActionDeps): Promise<boolean> {
     return false;
   }
   const status = result.value;
+  // Side-channel: surface bundled-skill refresh failures before branching on
+  // launcher availability. Refresh now runs for launcher-disabled and deferred
+  // boots too, so those are precisely the states where a warning can coexist
+  // with `available: false`.
+  if ("skillRefresh" in status && status.skillRefresh) {
+    d.notify(
+      "warning",
+      `Bundled skill refresh failed: ${status.skillRefresh.message}. Run \`tandem setup\` to retry.`,
+    );
+  }
   if (!status.available) {
     // #1236: "not active in this Tandem build" is a lie in the deferred case —
     // the launcher is present and about to start, it just hasn't seen a human
@@ -719,15 +729,6 @@ async function checkLauncherAvailable(d: ActionDeps): Promise<boolean> {
     }
     d.notify("warning", "Claude launcher not active in this Tandem build.");
     return false;
-  }
-  // Side-channel: surface bundled-skill refresh failures to the user. The
-  // server only includes `skillRefresh` on loopback, and the field is
-  // optional on the discriminated-union so absence is the success case.
-  if ("skillRefresh" in status && status.skillRefresh) {
-    d.notify(
-      "warning",
-      `Bundled skill refresh failed: ${status.skillRefresh.message}. Run \`tandem setup\` to retry.`,
-    );
   }
   return true;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -140,11 +140,6 @@ async function startLauncherSupervisor(): Promise<void> {
     launcherSupervisor = createSupervisor({
       integrationsBase: resolveAppDataDir(),
     });
-    // Refresh the bundled skill on-disk if the version stamp moved
-    // forward — existing users pick up skill updates without re-running
-    // `tandem setup`. Best-effort, non-blocking.
-    const { refreshSkillIfStale } = await import("./integrations/apply.js");
-    void refreshSkillIfStale();
     await launcherSupervisor.start();
   } catch (err) {
     launcherUnavailableReason = "spawn-failed";
@@ -573,6 +568,22 @@ async function main() {
   const resolvedLanIP = bindCheck.resolvedLanIP;
 
   if (transportMode === "http") {
+    // Refresh only a standalone skill that Tandem setup already installed.
+    // This is intentionally outside every launcher branch: hand-started
+    // Claude sessions are the population that needs the current instructions,
+    // including TANDEM_DISABLE_LAUNCHER and deferred-autostart boots. Await it
+    // before bind/readiness so a freshly-started session cannot load stale
+    // bytes while the refresh is still racing. The operation records ordinary
+    // read/write failures itself; this catch keeps even an unexpected module
+    // load failure best-effort and non-fatal.
+    await import("./integrations/apply.js")
+      .then(({ refreshExistingSkillIfStale }) => refreshExistingSkillIfStale())
+      .catch((err) =>
+        console.error(
+          `[Tandem] Skill refresh failed (non-fatal): ${err instanceof Error ? err.message : err}`,
+        ),
+      );
+
     // HTTP mode: no startup-order constraint — start both concurrently
     freePort(wsPort);
     freePort(mcpPort);

--- a/src/server/integrations/acl-win.ts
+++ b/src/server/integrations/acl-win.ts
@@ -44,6 +44,12 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+  }
+}
+
 /**
  * Resolve a Windows system binary by absolute path under `%SystemRoot%`.
  * Bypasses `PATH` so a git-bash / MSYS / Cygwin shadow (e.g. their own
@@ -66,16 +72,23 @@ function systemBin(name: string): string {
  * (admin's policy is a real security boundary). The original error is
  * preserved as `cause` on the fallback's failure for log forensics.
  */
-async function runPowerShell(script: string, env: NodeJS.ProcessEnv): Promise<{ stdout: string }> {
+async function runPowerShell(
+  script: string,
+  env: NodeJS.ProcessEnv,
+  signal?: AbortSignal,
+): Promise<{ stdout: string }> {
   const args = ["-NoProfile", "-NonInteractive", "-Command", script];
+  throwIfAborted(signal);
   try {
-    return await execFileAsync("pwsh.exe", args, { env });
+    return await execFileAsync("pwsh.exe", args, { env, signal });
   } catch (err) {
+    if (signal?.aborted) throw signal.reason ?? err;
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== "ENOENT") throw err;
     try {
-      return await execFileAsync("powershell.exe", args, { env });
+      return await execFileAsync("powershell.exe", args, { env, signal });
     } catch (fallbackErr) {
+      if (signal?.aborted) throw signal.reason ?? fallbackErr;
       throw new Error(
         `runPowerShell: both pwsh.exe and powershell.exe failed (pwsh: ${(err as Error).message})`,
         { cause: fallbackErr },
@@ -117,9 +130,13 @@ export function _resetCurrentUserSidForTests(): void {
  * Resolve the SID of the current user via `whoami /user /fo csv /nh`. CSV
  * output is locale-independent and parses cleanly without PowerShell.
  */
-async function getCurrentUserSid(): Promise<string> {
+async function getCurrentUserSid(signal?: AbortSignal): Promise<string> {
   if (cachedCurrentUserSid !== null) return cachedCurrentUserSid;
-  const { stdout } = await execFileAsync(systemBin("whoami.exe"), ["/user", "/fo", "csv", "/nh"]);
+  throwIfAborted(signal);
+  const { stdout } = await execFileAsync(systemBin("whoami.exe"), ["/user", "/fo", "csv", "/nh"], {
+    signal,
+  });
+  throwIfAborted(signal);
   // CSV row format: `"DOMAIN\user","S-1-5-21-..."` — extract the second column.
   const match = stdout.match(/"(S-[\d-]+)"\s*$/m);
   if (!match) {
@@ -158,11 +175,13 @@ async function getCurrentUserSid(): Promise<string> {
  */
 export async function setRestrictiveAcl(
   path: string,
-  opts: { inheritable?: boolean } = {},
+  opts: { inheritable?: boolean; signal?: AbortSignal } = {},
 ): Promise<void> {
   if (process.platform !== "win32") return;
+  const { signal } = opts;
+  throwIfAborted(signal);
 
-  const sid = await getCurrentUserSid();
+  const sid = await getCurrentUserSid(signal);
 
   // icacls processes flags left-to-right in one invocation:
   //   /inheritance:r — remove ALL inherited entries (`:d` would copy them
@@ -176,19 +195,20 @@ export async function setRestrictiveAcl(
   //                    the rights when `inheritable` — see the docblock.
   const rights = opts.inheritable ? "(OI)(CI)F" : "F";
   try {
-    await execFileAsync(systemBin("icacls.exe"), [
-      path,
-      "/inheritance:r",
-      "/grant:r",
-      `*${sid}:${rights}`,
-    ]);
+    await execFileAsync(
+      systemBin("icacls.exe"),
+      [path, "/inheritance:r", "/grant:r", `*${sid}:${rights}`],
+      { signal },
+    );
   } catch (err) {
+    if (signal?.aborted) throw signal.reason ?? err;
     throw new Error(`setRestrictiveAcl: icacls failed on ${path}: ${(err as Error).message}`, {
       cause: err,
     });
   }
 
-  await assertNoBroadAce(path);
+  throwIfAborted(signal);
+  await assertNoBroadAce(path, { signal });
 }
 
 /**
@@ -198,8 +218,13 @@ export async function setRestrictiveAcl(
  *
  * @throws if any broad-principal SDDL shortcut appears in the file's ACL.
  */
-export async function assertNoBroadAce(path: string): Promise<void> {
+export async function assertNoBroadAce(
+  path: string,
+  opts: { signal?: AbortSignal } = {},
+): Promise<void> {
   if (process.platform !== "win32") return;
+  const { signal } = opts;
+  throwIfAborted(signal);
 
   // `-LiteralPath` ensures wildcards in the path are not expanded. The
   // explicit `Import-Module` is defensive — `Get-Acl` lives in
@@ -209,10 +234,15 @@ export async function assertNoBroadAce(path: string): Promise<void> {
   const script =
     "Import-Module Microsoft.PowerShell.Security; (Get-Acl -LiteralPath $env:TANDEM_ACL_PATH).Sddl";
 
-  const { stdout } = await runPowerShell(script, {
-    ...process.env,
-    TANDEM_ACL_PATH: path,
-  });
+  const { stdout } = await runPowerShell(
+    script,
+    {
+      ...process.env,
+      TANDEM_ACL_PATH: path,
+    },
+    signal,
+  );
+  throwIfAborted(signal);
 
   const sddl = stdout.trim();
   for (const fragment of BROAD_SDDL_FRAGMENTS) {

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -46,6 +46,7 @@ import { fileURLToPath } from "node:url";
 import { SKILL_CONTENT } from "../../cli/skill-content.js";
 import { DEFAULT_MCP_PORT } from "../../shared/constants.js";
 import { targetPushSupport } from "../../shared/integrations/contract.js";
+import type { SkillRefreshError } from "../../shared/launcher/contract.js";
 import { resolveAppDataDir } from "../platform.js";
 import { setRestrictiveAcl } from "./acl-win.js";
 import { backupDir, pruneOldBackups, shouldBackup, writeBackup } from "./backup.js";
@@ -520,22 +521,60 @@ export {
  *    operators can diagnose a leaked tempfile or dest from a single log
  *    line rather than chasing a stray `console.error`.
  */
-async function atomicWrite(content: string, dest: string): Promise<void> {
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+  }
+}
+
+async function atomicWrite(
+  content: string,
+  dest: string,
+  opts: {
+    signal?: AbortSignal;
+    /** Refresh-only guard: do not recreate a destination removed mid-operation. */
+    requireExistingDest?: boolean;
+    /** Test-only seam immediately before the refresh commit guard. */
+    beforeCommitForTests?: () => Promise<void>;
+  } = {},
+): Promise<void> {
+  const { signal } = opts;
+  throwIfAborted(signal);
   const tmp = join(dirname(dest), `.tandem-setup-${randomUUID()}.tmp`);
   // mode at create, not chmod-after: on POSIX a plain writeFile lands at
   // 0o666 & ~umask, leaving sibling vendors' tokens world-readable until the
   // tighten below. Windows ignores mode (the ACL step is the protection).
-  await writeFile(tmp, content, { encoding: "utf-8", mode: 0o600 });
+  try {
+    await writeFile(tmp, content, { encoding: "utf-8", mode: 0o600, signal });
+  } catch (writeErr) {
+    await unlinkOrLeak(tmp, writeErr);
+    throw writeErr;
+  }
 
   try {
     if (process.platform === "win32") {
-      await setRestrictiveAcl(tmp);
+      await setRestrictiveAcl(tmp, { signal });
     } else {
+      throwIfAborted(signal);
       await chmod(tmp, 0o600);
     }
+    // The deadline may have fired while the ACL/chmod was in flight. Never
+    // cross the commit boundary after cancellation: the stale destination is
+    // safer than a late replacement racing server readiness.
+    throwIfAborted(signal);
   } catch (tightenErr) {
     await unlinkOrLeak(tmp, tightenErr);
     throw tightenErr;
+  }
+
+  try {
+    if (process.env.VITEST === "true") await opts.beforeCommitForTests?.();
+    throwIfAborted(signal);
+    if (opts.requireExistingDest) await stat(dest);
+    throwIfAborted(signal);
+  } catch (commitGuardErr) {
+    await unlinkOrLeak(tmp, commitGuardErr);
+    throw commitGuardErr;
   }
 
   try {
@@ -570,6 +609,7 @@ async function unlinkOrLeak(path: string, originalErr: unknown): Promise<void> {
   try {
     await unlink(path);
   } catch (cleanupErr) {
+    if ((cleanupErr as NodeJS.ErrnoException).code === "ENOENT") return;
     if (originalErr instanceof Error && originalErr.cause === undefined) {
       (originalErr as { cause?: unknown }).cause = cleanupErr;
     }
@@ -1146,16 +1186,15 @@ function readSkillVersion(skillContent: string): number {
 }
 
 const BUNDLED_SKILL_VERSION = readSkillVersion(SKILL_CONTENT);
+const SKILL_REFRESH_TIMEOUT_MS = 5_000;
 
 /** Module-scoped last-failure record. Cleared on successful refresh; set on
- * read/write failure. Surfaced via `GET /api/launcher/status` (loopback only)
- * so the palette/settings UI can warn the user that the bundled skill is
- * out of date. `null` when last refresh succeeded or was a no-op. */
-let lastSkillRefreshError: { code: "write-failed" | "read-failed"; message: string } | null = null;
-export function getSkillRefreshError(): {
-  code: "write-failed" | "read-failed";
-  message: string;
-} | null {
+ * path, read, write, or deadline failure. Surfaced via
+ * `GET /api/launcher/status` (loopback only) so the palette/settings UI can
+ * warn the user that the bundled skill is out of date. `null` when last
+ * refresh succeeded or was a no-op. */
+let lastSkillRefreshError: SkillRefreshError | null = null;
+export function getSkillRefreshError(): SkillRefreshError | null {
   return lastSkillRefreshError;
 }
 /** Test-only — reset module state between tests. */
@@ -1165,17 +1204,30 @@ export function _resetSkillRefreshErrorForTests(): void {
 }
 
 /**
- * Idempotent skill refresh — called from supervisor startup so existing
- * users (who already ran `tandem setup` once) pick up bundled-skill
- * updates without re-running the wizard.
+ * Idempotently refresh an existing setup-managed skill.
  *
  * Compares the bundled `version:` against the on-disk file. Writes only
- * if bundled > on-disk. Silently no-ops on any error (read failure,
- * write failure, missing parent dir) — this is a best-effort refresh,
- * not a critical path. The wizard-driven `installSkill()` remains the
- * authoritative installer.
+ * if bundled > on-disk. A missing file is an intentional no-op: generic
+ * server startup must not install a standalone copy for plugin-only users.
+ * Failures are recorded for the loopback launcher-status route but never
+ * thrown. A cancellation deadline reaches signal-aware file writes and
+ * Windows ACL subprocesses, and an abort check immediately before rename
+ * prevents those phases from committing after cancellation. Node does not
+ * make every filesystem primitive cancellable, so this is not an absolute
+ * wall-clock bound. The wizard-driven `installSkill()` remains the
+ * authoritative, consent-bearing installer.
  */
-export async function refreshSkillIfStale(opts: { homeOverride?: string } = {}): Promise<void> {
+export async function refreshExistingSkillIfStale(
+  opts: {
+    homeOverride?: string;
+    /** Cancellation deadline for signal-aware phases. Production defaults to five seconds. */
+    timeoutMs?: number;
+    /** Filesystem-boundary test seam; ignored outside Vitest. */
+    _writeSkillForTests?: (content: string, dest: string, signal: AbortSignal) => Promise<void>;
+    /** Test-only seam immediately before the existing-file commit guard. */
+    _beforeSkillCommitForTests?: () => Promise<void>;
+  } = {},
+): Promise<void> {
   if (BUNDLED_SKILL_VERSION === 0) return; // Bundled skill has no version stamp — nothing to compare.
   const home = opts.homeOverride ?? homedir();
   const skillPath = join(home, ".claude", "skills", "tandem", "SKILL.md");
@@ -1183,44 +1235,71 @@ export async function refreshSkillIfStale(opts: { homeOverride?: string } = {}):
     assertPathSafe(skillPath, {
       allowedRoots: opts.homeOverride ? [opts.homeOverride] : undefined,
     });
-  } catch {
-    return;
-  }
-  let onDiskVersion = -1; // -1 = file missing (treat as needing install)
-  let readErr: unknown;
-  try {
-    const fs = await import("node:fs/promises");
-    const current = await fs.readFile(skillPath, "utf8");
-    onDiskVersion = readSkillVersion(current);
   } catch (err) {
-    // ENOENT is expected (first run); any other error is a real read failure.
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") readErr = err;
-  }
-  if (onDiskVersion >= BUNDLED_SKILL_VERSION) {
-    // No-op path — clear any prior failure only if read succeeded.
-    if (readErr === undefined) lastSkillRefreshError = null;
-    else
-      lastSkillRefreshError = {
-        code: "read-failed",
-        message: readErr instanceof Error ? readErr.message : String(readErr),
-      };
+    lastSkillRefreshError = {
+      code: "path-rejected",
+      message: err instanceof Error ? err.message : String(err),
+    };
+    console.error(
+      `[Tandem] Skill refresh rejected unsafe path (non-fatal): ${err instanceof Error ? err.message : err}`,
+    );
     return;
   }
+  const timeoutMs = opts.timeoutMs ?? SKILL_REFRESH_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort(
+      new DOMException(`Skill refresh timed out after ${timeoutMs}ms`, "TimeoutError"),
+    );
+  }, timeoutMs);
+  timeout.unref?.();
+  const { signal } = controller;
+  let stage: "read" | "write" = "read";
   try {
+    const current = await readFile(skillPath, { encoding: "utf8", signal });
+    const onDiskVersion = readSkillVersion(current);
+    if (onDiskVersion >= BUNDLED_SKILL_VERSION) {
+      lastSkillRefreshError = null;
+      return;
+    }
+
+    stage = "write";
     await mkdir(dirname(skillPath), { recursive: true });
-    await atomicWrite(SKILL_CONTENT, skillPath);
+    throwIfAborted(signal);
+    const writeSkill =
+      process.env.VITEST === "true" && opts._writeSkillForTests
+        ? opts._writeSkillForTests
+        : (content: string, dest: string, writeSignal: AbortSignal) =>
+            atomicWrite(content, dest, {
+              signal: writeSignal,
+              requireExistingDest: true,
+              beforeCommitForTests: opts._beforeSkillCommitForTests,
+            });
+    await writeSkill(SKILL_CONTENT, skillPath, signal);
     lastSkillRefreshError = null;
     console.error(
       `[Tandem] Refreshed bundled skill at ${skillPath} (v${onDiskVersion} → v${BUNDLED_SKILL_VERSION}).`,
     );
   } catch (err) {
+    // Generic server startup must never cross the standalone-skill install
+    // boundary. Only the wizard / `tandem setup` may create this file.
+    if (stage === "read" && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      lastSkillRefreshError = null;
+      return;
+    }
+    const timedOut = signal.aborted;
+    const message = timedOut
+      ? `Skill refresh timed out after ${timeoutMs}ms`
+      : err instanceof Error
+        ? err.message
+        : String(err);
     lastSkillRefreshError = {
-      code: "write-failed",
-      message: err instanceof Error ? err.message : String(err),
+      code: timedOut ? "timed-out" : stage === "read" ? "read-failed" : "write-failed",
+      message,
     };
-    console.error(
-      `[Tandem] Skill refresh failed (non-fatal): ${err instanceof Error ? err.message : err}`,
-    );
+    console.error(`[Tandem] Skill refresh failed (non-fatal): ${message}`);
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/src/server/launcher/api-routes.ts
+++ b/src/server/launcher/api-routes.ts
@@ -211,6 +211,7 @@ function makeStatusHandler(deps: LauncherRoutesDeps): Handler {
   return (req: Request, res: Response) => {
     const sup = deps.getSupervisor();
     const loopback = isLoopback(req.socket.remoteAddress);
+    const skillRefresh = loopback ? (deps.getSkillRefreshError?.() ?? null) : undefined;
     if (sup === null) {
       // `reason` is loopback-only. `deferred-autostart` in particular is a live
       // presence oracle — it says "this machine auto-booted at login and the
@@ -218,12 +219,15 @@ function makeStatusHandler(deps: LauncherRoutesDeps): Handler {
       // (rather than filtering that one value) also future-proofs the enum
       // against the next reason that turns out to leak something.
       const body: LauncherStatus = loopback
-        ? { available: false, reason: deps.unavailableReason() }
+        ? {
+            available: false,
+            reason: deps.unavailableReason(),
+            ...(skillRefresh ? { skillRefresh } : {}),
+          }
         : { available: false };
       res.json(body);
       return;
     }
-    const skillRefresh = loopback ? (deps.getSkillRefreshError?.() ?? null) : undefined;
     let raw: ReturnType<Supervisor["status"]>;
     try {
       raw = sup.status();

--- a/src/server/launcher/supervisor.ts
+++ b/src/server/launcher/supervisor.ts
@@ -1532,7 +1532,7 @@ function homeConfines(homeReal: string, candidate: string): boolean {
  * `opts.homeOverride` is a test-only seam: passing an explicit "home" lets
  * cross-platform unit tests stand up a tmpdir, treat it as $HOME, and
  * assert outside-home rejection deterministically on every platform.
- * Mirrors the `refreshSkillIfStale(opts: { homeOverride? })` pattern in
+ * Mirrors the `refreshExistingSkillIfStale(opts: { homeOverride? })` pattern in
  * `src/server/integrations/apply.ts`. Production callers leave it unset
  * and get `os.homedir()`. */
 export function resolveRouteCwd(

--- a/src/shared/launcher/contract.ts
+++ b/src/shared/launcher/contract.ts
@@ -22,7 +22,12 @@
 export type LauncherStatus =
   /** `reason` is loopback-only — see the note on `LauncherUnavailableReason`.
    * Non-loopback callers get the bare `{ available: false }`. */
-  | { available: false; reason?: LauncherUnavailableReason }
+  | {
+      available: false;
+      reason?: LauncherUnavailableReason;
+      /** Loopback-only. Present when the pre-readiness skill refresh failed. */
+      skillRefresh?: SkillRefreshError;
+    }
   | {
       available: true;
       running: false;
@@ -110,7 +115,7 @@ export type LauncherErrorCode =
  * has no other signal that the skill is stale, so `/status` surfaces this
  * for the palette/settings UI to convert into a notification. */
 export interface SkillRefreshError {
-  code: "write-failed" | "read-failed";
+  code: "write-failed" | "read-failed" | "path-rejected" | "timed-out";
   message: string;
 }
 

--- a/tests/client/actions/launcher-commands.test.ts
+++ b/tests/client/actions/launcher-commands.test.ts
@@ -60,7 +60,11 @@ function jsonResponse(status: number, body: unknown): Response {
  * running, available launcher so the happy path proceeds to the POST.
  */
 function installFetchStub(
-  opts: { available?: boolean; rejectCwd?: boolean } = {},
+  opts: {
+    available?: boolean;
+    rejectCwd?: boolean;
+    skillRefresh?: { code: "read-failed" | "write-failed"; message: string };
+  } = {},
 ): ReturnType<typeof vi.fn> {
   const available = opts.available ?? true;
   const fetchSpy = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
@@ -74,7 +78,11 @@ function installFetchStub(
             sessionId: "<set>",
             resuming: false,
           })
-        : jsonResponse(200, { available: false, reason: "stdio-mode" });
+        : jsonResponse(200, {
+            available: false,
+            reason: "stdio-mode",
+            ...(opts.skillRefresh ? { skillRefresh: opts.skillRefresh } : {}),
+          });
     }
     if (u === NONCE_URL) {
       return jsonResponse(200, { nonce: TEST_NONCE });
@@ -246,6 +254,22 @@ describe("launcher-relaunch-here", () => {
     await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(STATUS_URL));
     await new Promise((r) => setTimeout(r, 0));
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === RELAUNCH_URL)).toBe(false);
+  });
+
+  it("warns about a failed skill refresh even when the launcher is unavailable", async () => {
+    const fetchSpy = installFetchStub({
+      available: false,
+      skillRefresh: { code: "write-failed", message: "simulated disk failure" },
+    });
+
+    getAction("launcher-relaunch-here").run();
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(STATUS_URL));
+    await vi.waitFor(() =>
+      expect(notify).toHaveBeenCalledWith(
+        "warning",
+        expect.stringContaining("Bundled skill refresh failed: simulated disk failure"),
+      ),
+    );
   });
 });
 

--- a/tests/docs/wake-availability-claims.test.ts
+++ b/tests/docs/wake-availability-claims.test.ts
@@ -130,4 +130,12 @@ describe("hand-started sessions get the automatic first-use contract", () => {
       expect(text).toMatch(/TaskStop/);
     }
   });
+
+  it("records the combined release behavior and plugin-only timing under Unreleased", () => {
+    const text = readFileSync(join(ROOT, "CHANGELOG.md"), "utf-8");
+    const unreleased = text.slice(text.indexOf("## [Unreleased]"), text.indexOf("## [0.21.0]"));
+    expect(unreleased).toMatch(/automatically/i);
+    expect(unreleased).toMatch(/missing[^.]*skill[^.]*not install/i);
+    expect(unreleased).toMatch(/plugin-only[^.]*Claude Code[^.]*cache/i);
+  });
 });

--- a/tests/server/index.startup-ordering.test.ts
+++ b/tests/server/index.startup-ordering.test.ts
@@ -49,4 +49,53 @@ describe("index.ts startup ordering invariant", () => {
       "maybeOpenStartupFile must be awaited (fire-and-forget would race the bind)",
     ).toMatch(/\bawait\s+maybeOpenStartupFile\b/);
   });
+
+  it("awaits best-effort existing-skill refresh before HTTP readiness in every launcher mode", async () => {
+    const indexPath = path.resolve(fileURLToPath(import.meta.url), "../../../src/server/index.ts");
+    const src = await readFile(indexPath, "utf8");
+
+    const supervisorStart = src.indexOf("async function startLauncherSupervisor()");
+    const supervisorEnd = src.indexOf("// Swallow known Hocuspocus/ws protocol errors");
+    const supervisorBody = src.slice(supervisorStart, supervisorEnd);
+    expect(supervisorBody).not.toContain("refreshSkillIfStale");
+    expect(supervisorBody).not.toContain("refreshExistingSkillIfStale");
+
+    const httpStart = src.indexOf('if (transportMode === "http")');
+    const stdioStart = src.indexOf("} else {\n    // Stdio mode", httpStart);
+    const httpBody = src.slice(httpStart, stdioStart);
+    const refreshIdx = httpBody.indexOf("refreshExistingSkillIfStale");
+    expect(refreshIdx, "HTTP startup must refresh an existing standalone skill").toBeGreaterThan(
+      -1,
+    );
+
+    const bindIdx = httpBody.indexOf("startMcpServerHttp(");
+    expect(bindIdx, "HTTP bind call must exist").toBeGreaterThan(-1);
+    expect(refreshIdx, "skill refresh must finish before Tandem can report ready").toBeLessThan(
+      bindIdx,
+    );
+
+    for (const launcherMarker of [
+      'launcherUnavailableReason === "deferred-autostart"',
+      'launcherUnavailableReason !== "disabled-by-env"',
+      "await startLauncherSupervisor()",
+    ]) {
+      const markerIdx = httpBody.indexOf(launcherMarker);
+      expect(markerIdx, `expected launcher branch marker: ${launcherMarker}`).toBeGreaterThan(-1);
+      expect(
+        refreshIdx,
+        `skill refresh must precede ${launcherMarker} so launcher mode cannot suppress it`,
+      ).toBeLessThan(markerIdx);
+    }
+
+    const refreshThroughBind = httpBody.slice(refreshIdx, bindIdx);
+    expect(httpBody, "skill refresh import must be awaited, not fire-and-forget").toMatch(
+      /\bawait\s+import\("\.\/integrations\/apply\.js"\)[\s\S]*?refreshExistingSkillIfStale\(\)/,
+    );
+    expect(refreshThroughBind, "unexpected refresh failures must be caught before bind").toMatch(
+      /refreshExistingSkillIfStale\(\)\)[\s\S]*?\.catch\(/,
+    );
+    expect(refreshThroughBind, "unexpected refresh failures must stay non-fatal").toContain(
+      "Skill refresh failed (non-fatal)",
+    );
+  });
 });

--- a/tests/server/integrations/acl-win.test.ts
+++ b/tests/server/integrations/acl-win.test.ts
@@ -43,6 +43,17 @@ describe.skipIf(!WIN_ONLY)("acl-win — Windows DACL hardening", () => {
     await expect(assertNoBroadAce(filePath)).resolves.toBeUndefined();
   });
 
+  it("cancels ACL subprocess work when the caller aborts", async () => {
+    const filePath = path.join(tmpDir, "cancelled.json");
+    fs.writeFileSync(filePath, '{"token":"sentinel"}');
+    const controller = new AbortController();
+    controller.abort(new DOMException("refresh deadline", "TimeoutError"));
+
+    await expect(setRestrictiveAcl(filePath, { signal: controller.signal })).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+  });
+
   // Table-driven coverage for every broad-principal SID — a future drop of
   // any entry from BROAD_SDDL_FRAGMENTS would silently weaken the gate.
   const BROAD_CASES: Array<{ name: string; sid: string }> = [

--- a/tests/server/integrations/refresh-skill.test.ts
+++ b/tests/server/integrations/refresh-skill.test.ts
@@ -1,16 +1,16 @@
 /**
- * Direct unit tests for `refreshSkillIfStale()` in
+ * Direct unit tests for `refreshExistingSkillIfStale()` in
  * `src/server/integrations/apply.ts` (#477 PR 4b review fixes).
  *
  * Covers three branches:
- *   - On-disk file missing → bundled gets written.
+ *   - On-disk file missing → no-op (setup is the authoritative installer).
  *   - On-disk version < bundled → bundled overwrites it.
  *   - On-disk version >= bundled → no-op; existing content preserved.
  * Plus failure recording via `getSkillRefreshError()`.
  */
 
 import fs from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -19,7 +19,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   _resetSkillRefreshErrorForTests,
   getSkillRefreshError,
-  refreshSkillIfStale,
+  installSkill,
+  refreshExistingSkillIfStale,
 } from "../../../src/server/integrations/apply.js";
 
 let homeOverride: string;
@@ -43,18 +44,16 @@ function readSkillVersion(content: string): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-describe("refreshSkillIfStale — first-run (no on-disk file)", () => {
-  it("writes the bundled skill when SKILL.md does not exist", async () => {
+describe("refreshExistingSkillIfStale — first-run (no on-disk file)", () => {
+  it("does not install a standalone skill when SKILL.md does not exist", async () => {
     expect(fs.existsSync(skillPath)).toBe(false);
-    await refreshSkillIfStale({ homeOverride });
-    expect(fs.existsSync(skillPath)).toBe(true);
-    const written = await readFile(skillPath, "utf8");
-    expect(readSkillVersion(written)).toBeGreaterThanOrEqual(2);
+    await refreshExistingSkillIfStale({ homeOverride });
+    expect(fs.existsSync(skillPath)).toBe(false);
     expect(getSkillRefreshError()).toBeNull();
   });
 });
 
-describe("refreshSkillIfStale — stale on-disk", () => {
+describe("refreshExistingSkillIfStale — stale on-disk", () => {
   it("overwrites when on-disk version < bundled", async () => {
     await mkdir(path.dirname(skillPath), { recursive: true });
     // Write a v1 stub. The bundled version is v2 (or higher).
@@ -63,7 +62,7 @@ describe("refreshSkillIfStale — stale on-disk", () => {
       "---\nname: tandem\nversion: 1\ndescription: stale\n---\n\nstale body\n",
       "utf8",
     );
-    await refreshSkillIfStale({ homeOverride });
+    await refreshExistingSkillIfStale({ homeOverride });
     const written = await readFile(skillPath, "utf8");
     expect(readSkillVersion(written)).toBeGreaterThanOrEqual(2);
     expect(written).not.toContain("stale body");
@@ -71,55 +70,145 @@ describe("refreshSkillIfStale — stale on-disk", () => {
   });
 });
 
-describe("refreshSkillIfStale — newer-or-equal on-disk", () => {
-  it("preserves on-disk content when version >= bundled", async () => {
+describe("refreshExistingSkillIfStale — newer-or-equal on-disk", () => {
+  it("preserves customized content at the current bundled version", async () => {
+    await installSkill({ homeOverride });
+    const bundled = await readFile(skillPath, "utf8");
+    const customized = `${bundled}\n<!-- user customization -->\n`;
+    await writeFile(skillPath, customized, "utf8");
+
+    await refreshExistingSkillIfStale({ homeOverride });
+
+    expect(await readFile(skillPath, "utf8")).toBe(customized);
+    expect(getSkillRefreshError()).toBeNull();
+  });
+
+  it("preserves on-disk content when version is newer than bundled", async () => {
     await mkdir(path.dirname(skillPath), { recursive: true });
     // Write a v999 stub — guaranteed >= bundled.
     const userCustomized =
       "---\nname: tandem\nversion: 999\ndescription: user-edit\n---\n\nuser custom body\n";
     await writeFile(skillPath, userCustomized, "utf8");
-    await refreshSkillIfStale({ homeOverride });
+    await refreshExistingSkillIfStale({ homeOverride });
     const after = await readFile(skillPath, "utf8");
     expect(after).toBe(userCustomized);
     expect(getSkillRefreshError()).toBeNull();
   });
 });
 
-describe("refreshSkillIfStale — failure recording", () => {
-  it("records read failure when SKILL.md exists but is unreadable", async () => {
-    // POSIX-only: create the file then chmod 000 to force EACCES. On Windows
-    // we can't reliably revoke owner read with the test process's own ACL,
-    // so the test is skipped — chmod is a no-op on Windows.
-    if (process.platform === "win32") return;
-    await mkdir(path.dirname(skillPath), { recursive: true });
-    await writeFile(skillPath, "---\nname: tandem\nversion: 1\n---\n", "utf8");
-    fs.chmodSync(skillPath, 0o000);
+describe("refreshExistingSkillIfStale — failure recording", () => {
+  it("records a path rejection without following a symlinked skill directory", async () => {
+    const outside = await fs.promises.mkdtemp(path.join(os.tmpdir(), "refresh-skill-outside-"));
     try {
-      await refreshSkillIfStale({ homeOverride });
-      const err = getSkillRefreshError();
-      // Either the unreadable read failed (read-failed) OR the subsequent
-      // write succeeded (treats missing as -1). On most POSIX systems the
-      // read fails with EACCES — but if the test runs as root it succeeds.
-      if (err) expect(err.code === "read-failed" || err.code === "write-failed").toBe(true);
+      const realSkillPath = path.join(outside, "skills", "tandem", "SKILL.md");
+      await mkdir(path.dirname(realSkillPath), { recursive: true });
+      const stale = "---\nname: tandem\nversion: 1\n---\n\nstale body\n";
+      await writeFile(realSkillPath, stale, "utf8");
+      await symlink(
+        outside,
+        path.join(homeOverride, ".claude"),
+        process.platform === "win32" ? "junction" : "dir",
+      );
+
+      await refreshExistingSkillIfStale({ homeOverride });
+
+      expect(getSkillRefreshError()).toMatchObject({ code: "path-rejected" });
+      expect(await readFile(realSkillPath, "utf8")).toBe(stale);
     } finally {
-      fs.chmodSync(skillPath, 0o644);
+      await fs.promises.rm(outside, { recursive: true, force: true });
     }
   });
 
-  it("clears lastSkillRefreshError after a successful refresh", async () => {
-    // Seed an error state via the unreadable-file path above (POSIX), then
-    // make the file writable and re-run. The error must clear.
-    if (process.platform === "win32") return;
+  it("records a read failure without trying to replace an unreadable skill", async () => {
+    // A directory at SKILL.md is a deterministic read failure on every
+    // supported platform, unlike chmod-based tests (the Windows owner can
+    // still read mode 000 and CI may run as root on POSIX).
+    await mkdir(skillPath, { recursive: true });
+
+    await refreshExistingSkillIfStale({ homeOverride });
+
+    expect(getSkillRefreshError()?.code).toBe("read-failed");
+    expect((await fs.promises.stat(skillPath)).isDirectory()).toBe(true);
+  });
+
+  it("records a write failure and preserves the stale skill", async () => {
+    await mkdir(path.dirname(skillPath), { recursive: true });
+    const stale = "---\nname: tandem\nversion: 1\n---\n\nstale body\n";
+    await writeFile(skillPath, stale, "utf8");
+
+    await refreshExistingSkillIfStale({
+      homeOverride,
+      _writeSkillForTests: async () => {
+        throw new Error("simulated disk failure");
+      },
+    });
+
+    expect(getSkillRefreshError()).toEqual({
+      code: "write-failed",
+      message: "simulated disk failure",
+    });
+    expect(await readFile(skillPath, "utf8")).toBe(stale);
+  });
+
+  it("does not recreate a skill removed after the stale read but before commit", async () => {
     await mkdir(path.dirname(skillPath), { recursive: true });
     await writeFile(skillPath, "---\nname: tandem\nversion: 1\n---\n", "utf8");
-    fs.chmodSync(skillPath, 0o000);
-    try {
-      await refreshSkillIfStale({ homeOverride });
-    } finally {
-      fs.chmodSync(skillPath, 0o644);
-    }
-    // Second pass: file is readable + stale → write succeeds, error clears.
-    await refreshSkillIfStale({ homeOverride });
+
+    await refreshExistingSkillIfStale({
+      homeOverride,
+      _beforeSkillCommitForTests: async () => {
+        await fs.promises.unlink(skillPath);
+      },
+    });
+
+    expect(fs.existsSync(skillPath)).toBe(false);
+    expect(getSkillRefreshError()).toMatchObject({ code: "write-failed" });
+  });
+
+  it("aborts a hung write at the refresh deadline without a late replacement", async () => {
+    await mkdir(path.dirname(skillPath), { recursive: true });
+    const stale = "---\nname: tandem\nversion: 1\n---\n\nstale body\n";
+    await writeFile(skillPath, stale, "utf8");
+    let writerObservedAbort = false;
+
+    await refreshExistingSkillIfStale({
+      homeOverride,
+      timeoutMs: 20,
+      _writeSkillForTests: async (_content, _dest, signal) => {
+        if (!signal) throw new Error("refresh did not pass an AbortSignal to the writer");
+        await new Promise<void>((_resolve, reject) => {
+          const abort = () => {
+            writerObservedAbort = true;
+            reject(signal.reason ?? new DOMException("aborted", "AbortError"));
+          };
+          if (signal.aborted) abort();
+          else signal.addEventListener("abort", abort, { once: true });
+        });
+      },
+    });
+
+    expect(writerObservedAbort).toBe(true);
+    expect(getSkillRefreshError()).toMatchObject({ code: "timed-out" });
+    expect(await readFile(skillPath, "utf8")).toBe(stale);
+
+    // A Promise.race-only implementation can return at the deadline while its
+    // writer continues and renames later. Give that late branch time to fire.
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(await readFile(skillPath, "utf8")).toBe(stale);
+  });
+
+  it("clears lastSkillRefreshError after a successful refresh", async () => {
+    await mkdir(path.dirname(skillPath), { recursive: true });
+    await writeFile(skillPath, "---\nname: tandem\nversion: 1\n---\n", "utf8");
+    await refreshExistingSkillIfStale({
+      homeOverride,
+      _writeSkillForTests: async () => {
+        throw new Error("simulated disk failure");
+      },
+    });
+    expect(getSkillRefreshError()?.code).toBe("write-failed");
+
+    await refreshExistingSkillIfStale({ homeOverride });
     expect(getSkillRefreshError()).toBeNull();
   });
 });

--- a/tests/server/launcher/api-routes.test.ts
+++ b/tests/server/launcher/api-routes.test.ts
@@ -157,6 +157,25 @@ describe("GET /api/launcher/status", () => {
     expect(res.body).toEqual({ available: false, reason: "stdio-mode" });
   });
 
+  it("surfaces refresh failures to loopback when the supervisor is unavailable", async () => {
+    const deps: LauncherRoutesDeps = {
+      ...baseDeps(null, "disabled-by-env"),
+      getSkillRefreshError: () => ({ code: "write-failed", message: "EACCES" }),
+    };
+
+    const { app: loopbackApp } = makeApp(deps);
+    const loopback = await request(loopbackApp, "GET", "/api/launcher/status");
+    expect(loopback.body).toEqual({
+      available: false,
+      reason: "disabled-by-env",
+      skillRefresh: { code: "write-failed", message: "EACCES" },
+    });
+
+    const { app: lanApp } = makeApp(deps, { remoteAddress: "192.168.1.50" });
+    const lan = await request(lanApp, "GET", "/api/launcher/status");
+    expect(lan.body).toEqual({ available: false });
+  });
+
   it("returns full status payload to loopback callers when running", async () => {
     const sup = makeFakeSupervisor({ running: true, cwd: "/home/test" });
     const { app } = makeApp(baseDeps(sup));

--- a/tests/server/launcher/supervisor.test.ts
+++ b/tests/server/launcher/supervisor.test.ts
@@ -310,7 +310,7 @@ describe("resolveRouteCwd — homeOverride seam (cross-platform determinism, #80
   /** Treat a tmpdir as "$HOME" so the home-confinement check is exercised
    * deterministically on every platform — no dependency on whether the
    * process's real $HOME happens to encompass `os.tmpdir()` (Windows CI
-   * sometimes does, POSIX never does). Mirrors the `refreshSkillIfStale`
+   * sometimes does, POSIX never does). Mirrors the `refreshExistingSkillIfStale`
    * homeOverride pattern in `src/server/integrations/apply.ts`. */
   let fakeHome: string;
   let outside: string;


### PR DESCRIPTION
## Summary

- refresh an existing setup-managed Tandem skill before HTTP readiness, outside launcher normal/disabled/deferred gates
- never install a missing skill during generic startup, and preserve equal, newer, customized, or concurrently removed copies
- bound signal-aware refresh work, prevent late atomic replacement, and surface refresh failures even when the launcher is unavailable
- record the combined PR1 + PR2 release behavior under Unreleased

## Stack

This PR is stacked on #1391 so reviewers see only refresh lifecycle changes. After #1391 merges, retarget this PR to master. PR1 and PR2 must release together.

## Validation

- repository pre-push gate: full Vitest and Rust suites passed
- focused refresh, ACL, startup-ordering, launcher API/client, documentation, and supervisor suites
- npm run typecheck
- targeted ESLint and git diff --check

## Release gate

Draft until the separate authenticated ten-session ConPTY evidence PR completes successfully.

Refs #1389
Refs #1390