### PR TITLE
feat(diagnostics): add OS/hardware info to Copy Diagnostics, prefill the bug report

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -953,9 +953,17 @@ Read-only, takes **no parameters**, and is **not** license-gated — diagnostics
   "platform": "win32",
   "arch": "x64",
   "nodeVersion": "v22.0.0",
-  "tauriSidecar": true
+  "tauriSidecar": true,
+  "osRelease": "10.0.26100",
+  "osVersion": "Windows 11 Pro",
+  "cpuModel": "AMD Ryzen 7 5800X 8-Core Processor",
+  "cpuCount": 16,
+  "totalMemoryMb": 32768,
+  "freeMemoryMb": 6247
 }
 ```
+
+Everything from `osRelease` down is **optional and best-effort** (`collectHostInfo()` in `src/server/mcp/host-info.ts`): `os.cpus()` returns `[]` on some cgroup-restricted hosts and `os.version()` can throw, so any of these keys may be absent. They are deliberately non-identifying — no hostname, username, home path, network interfaces, locale or timezone — because this payload is what "Copy Diagnostics" puts on the clipboard and what the Report-a-bug link prefills into a public issue.
 
 **Notes:**
 - The two dev-repo-only checks (`node-modules`, `mcp-json`) are filtered out and `ok`/`failures`/`warnings`/`summary` recomputed — they read `process.cwd()` and would fail for every desktop / npm-global install. (`tandem doctor` on the CLI keeps them; there the cwd is meaningful.)
@@ -1021,7 +1029,7 @@ Returns app metadata for the client's About panel and version indicator. All fie
 
 Runs the embedded `tandem doctor` collector and returns the report plus environment metadata. Backs the client's **Settings → About → Copy Diagnostics** button.
 
-**Loopback-only, unconditionally** — non-loopback callers get `403` regardless of auth, because the report embeds absolute paths (which include the username) and PIDs. It never contains token material or document content. The two dev-repo-only checks (`node-modules`, `mcp-json`) are filtered out of the report with `ok`/`failures`/`warnings`/`summary` recomputed — they read `process.cwd()` and would fail for every desktop/npm-global install. Concurrent requests share one in-flight collector run (single-flight).
+**Loopback-only, unconditionally** — non-loopback callers get `403` regardless of auth, because the report embeds absolute paths and PIDs. It never contains token material or document content. Home-directory paths are `~`-redacted before they reach the wire (`redactHomePaths`), since this payload also prefills the Report-a-bug issue body; that narrows what leaks into a public issue but does not change the loopback posture. The two dev-repo-only checks (`node-modules`, `mcp-json`) are filtered out of the report with `ok`/`failures`/`warnings`/`summary` recomputed — they read `process.cwd()` and would fail for every desktop/npm-global install. Concurrent requests share one in-flight collector run (single-flight).
 
 **Response (200):**
 ```json
@@ -1032,9 +1040,17 @@ Runs the embedded `tandem doctor` collector and returns the report plus environm
   "platform": "win32",
   "arch": "x64",
   "nodeVersion": "v22.0.0",
-  "tauriSidecar": true
+  "tauriSidecar": true,
+  "osRelease": "10.0.26100",
+  "osVersion": "Windows 11 Pro",
+  "cpuModel": "AMD Ryzen 7 5800X 8-Core Processor",
+  "cpuCount": 16,
+  "totalMemoryMb": 32768,
+  "freeMemoryMb": 6247
 }
 ```
+
+The `osRelease`/`osVersion`/`cpu*`/`*MemoryMb` fields are optional and best-effort — see the `tandem_diagnostics` section above for why, and for what is deliberately excluded.
 
 **Errors:** `403 FORBIDDEN` (non-loopback caller, or disallowed Host header), `500 diagnostics failed` (collector crash — detail goes to the server log, never the wire)
 

--- a/src/client/components/SettingsModal.svelte
+++ b/src/client/components/SettingsModal.svelte
@@ -242,11 +242,9 @@ let modalEl: HTMLDivElement | undefined = $state();
 let hamburgerEl: HTMLButtonElement | undefined = $state();
 const appInfo = createAppInfo(() => open);
 // Primed from the Report-a-bug link's hover/focus, not from `open` — see the
-// hook's docstring for why the modal opening is the wrong trigger.
-const bugReport = createBugReportUrl();
-$effect(() => {
-  if (!open) bugReport.reset();
-});
+// hook's docstring for why the modal opening is the wrong trigger. The getter
+// is for teardown, which the hook owns.
+const bugReport = createBugReportUrl(() => open);
 let changelogLoading = $state(false);
 let changelogError = $state<string | null>(null);
 let replayLoading = $state(false);

--- a/src/client/components/SettingsModal.svelte
+++ b/src/client/components/SettingsModal.svelte
@@ -720,7 +720,8 @@ async function handleReplayTutorial(): Promise<void> {
              prefetch; if it hasn't landed, this is still the plain issue URL. -->
         <a
           href={bugReport.url}
-          onpointerenter={bugReport.prime}
+          onpointerenter={bugReport.primeOnDwell}
+          onpointerleave={bugReport.cancelDwell}
           onfocus={bugReport.prime}
           target="_blank"
           rel="noreferrer"

--- a/src/client/components/SettingsModal.svelte
+++ b/src/client/components/SettingsModal.svelte
@@ -722,7 +722,8 @@ async function handleReplayTutorial(): Promise<void> {
           href={bugReport.url}
           onpointerenter={bugReport.primeOnDwell}
           onpointerleave={bugReport.cancelDwell}
-          onfocus={bugReport.prime}
+          onfocus={bugReport.primeOnDwell}
+          onblur={bugReport.cancelDwell}
           target="_blank"
           rel="noreferrer"
           data-testid="settings-modal-report-bug-link"

--- a/src/client/components/SettingsModal.svelte
+++ b/src/client/components/SettingsModal.svelte
@@ -83,9 +83,10 @@ export interface SettingsTab {
 
 <script lang="ts">
 import { onMount, untrack } from "svelte";
-import { BYO_MODELS_ENABLED, TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
+import { BYO_MODELS_ENABLED } from "../../shared/constants";
 import { scrollFade } from "../actions/scrollFade.svelte";
 import { createAppInfo } from "../hooks/useAppInfo.svelte";
+import { createBugReportUrl } from "../hooks/useBugReportUrl.svelte";
 import { focusablesWithin, trapTab } from "../utils/focus-trap";
 import { activationKeydown } from "../utils/keyboard-activate";
 import { openServerPath } from "../utils/server-paths";
@@ -240,6 +241,12 @@ let {
 let modalEl: HTMLDivElement | undefined = $state();
 let hamburgerEl: HTMLButtonElement | undefined = $state();
 const appInfo = createAppInfo(() => open);
+// Primed from the Report-a-bug link's hover/focus, not from `open` — see the
+// hook's docstring for why the modal opening is the wrong trigger.
+const bugReport = createBugReportUrl();
+$effect(() => {
+  if (!open) bugReport.reset();
+});
 let changelogLoading = $state(false);
 let changelogError = $state<string | null>(null);
 let replayLoading = $state(false);
@@ -709,8 +716,14 @@ async function handleReplayTutorial(): Promise<void> {
             </div>
           {/if}
         {/if}
+        <!-- Stays an <a>: the href is upgraded in place once diagnostics land,
+             so the click never awaits a fetch (which would lose user activation
+             and get popup-blocked in the browser build). Hover/focus start the
+             prefetch; if it hasn't landed, this is still the plain issue URL. -->
         <a
-          href={TANDEM_ISSUES_NEW_URL}
+          href={bugReport.url}
+          onpointerenter={bugReport.prime}
+          onfocus={bugReport.prime}
           target="_blank"
           rel="noreferrer"
           data-testid="settings-modal-report-bug-link"

--- a/src/client/components/settings-tabs/SettingsAboutTab.svelte
+++ b/src/client/components/settings-tabs/SettingsAboutTab.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-import { API_DIAGNOSTICS } from "../../../shared/api-paths";
 import { isTauriRuntime } from "../../cowork/cowork-helpers";
 import { loadInvoke } from "../../cowork/cowork-invoke";
 import { createAppInfo } from "../../hooks/useAppInfo.svelte";
 import { isCrashReportingEnabled } from "../../sentry";
-import { type DiagnosticsPayload, formatDiagnostics } from "../../utils/diagnostics";
-import { API_BASE } from "../../utils/fileUpload";
+import { formatDiagnostics, summarizeUserAgent } from "../../utils/diagnostics";
+import { fetchDiagnostics } from "../../utils/diagnostics-fetch";
 import { openServerPath } from "../../utils/server-paths";
 import type { SettingsTabContext } from "../SettingsModal.svelte";
 
@@ -24,21 +23,24 @@ async function handleCopyDiagnostics(): Promise<void> {
   diagLoading = true;
   let text: string;
   try {
-    let res: Response;
-    try {
-      res = await fetch(`${API_BASE}${API_DIAGNOSTICS}`);
-    } catch {
-      ctx.notify("error", "Couldn't reach the server — is it running?");
-      return;
-    }
-    if (!res.ok) {
-      // The server WAS reached — an "is it running?" message would misdirect.
-      ctx.notify("error", "Diagnostics failed on the server — try `tandem doctor` in a terminal");
+    // No AbortSignal: this is the explicit-click path and has always been
+    // untimed, with "Collecting…" standing in for progress.
+    const result = await fetchDiagnostics();
+    if (!result.ok) {
+      ctx.notify(
+        "error",
+        result.reason === "unreachable"
+          ? "Couldn't reach the server — is it running?"
+          : // The server WAS reached — an "is it running?" message would misdirect.
+            "Diagnostics failed on the server — try `tandem doctor` in a terminal",
+      );
       return;
     }
     // Format before entering the clipboard try, so a malformed payload isn't
     // misreported as a clipboard-permission problem.
-    text = formatDiagnostics((await res.json()) as DiagnosticsPayload);
+    text = formatDiagnostics(result.payload, {
+      browser: summarizeUserAgent(navigator.userAgent),
+    });
   } catch {
     ctx.notify("error", "Diagnostics failed on the server — try `tandem doctor` in a terminal");
     return;

--- a/src/client/components/settings-tabs/SettingsAboutTab.svelte
+++ b/src/client/components/settings-tabs/SettingsAboutTab.svelte
@@ -23,9 +23,10 @@ async function handleCopyDiagnostics(): Promise<void> {
   diagLoading = true;
   let text: string;
   try {
-    // No AbortSignal: this is the explicit-click path and has always been
-    // untimed, with "Collecting…" standing in for progress.
-    const result = await fetchDiagnostics();
+    // `maxAgeMs: 0` — an explicit click means "the state right now". Serving a
+    // cached report here would hand a user who just fixed something the report
+    // from before the fix.
+    const result = await fetchDiagnostics({ maxAgeMs: 0 });
     if (!result.ok) {
       ctx.notify(
         "error",

--- a/src/client/hooks/useBugReportUrl.svelte.ts
+++ b/src/client/hooks/useBugReportUrl.svelte.ts
@@ -3,26 +3,38 @@ import { buildBugReportUrl, formatDiagnostics, summarizeUserAgent } from "../uti
 import { fetchDiagnostics } from "../utils/diagnostics-fetch";
 
 /**
- * How long the pointer must rest on the link before the collector runs.
+ * How long pointer or focus must rest on the link before the collector runs.
  *
  * `/api/diagnostics` is not an inert read: `runDoctor`'s SSE check opens a real
  * connection to `/api/events`, which registers and immediately drops an
  * `"external"` subscriber — the same count `takeWakeAdvisory` and the Solo
- * forwarding gate read. A mouse merely crossing the sidebar on its way
+ * forwarding gate read. A pointer merely crossing the sidebar on its way
  * somewhere else should not do that, and should not spawn `npm ls -g` either.
- * Resting on the link is intent; passing over it is not. Keyboard focus skips
- * the delay — tabbing to a link is already unambiguous.
+ *
+ * Keyboard focus is gated the same way, and for the same reason: this link is
+ * the last focusable element in the sidebar, with the content pane next in DOM
+ * order inside the modal's focus trap, so *every* keyboard user tabbing from
+ * the sidebar into the content passes focus through it. Focus in transit is no
+ * more a statement of intent than a pointer in transit.
  */
-const POINTER_INTENT_MS = 150;
+const INTENT_DWELL_MS = 150;
+
+/**
+ * How long to wait before a failed prefetch may be retried.
+ *
+ * The latch is released on failure so a later hover can try again — but without
+ * a cooldown, moving the pointer in and out of the link while the endpoint is
+ * failing spawns one full collector run per entry, each with its own `npm ls -g`
+ * subprocess and `/api/events` subscriber registration.
+ */
+const RETRY_COOLDOWN_MS = 10_000;
 
 export interface BugReportUrlState {
   /** Always a usable issue URL — bare until the prefetch lands. */
   readonly url: string;
-  /** Start the prefetch now. Idempotent. For unambiguous intent (focus). */
-  prime(): void;
   /** Arm the prefetch after a short dwell. Idempotent. */
   primeOnDwell(): void;
-  /** Cancel a dwell that has not fired yet (pointer left before it elapsed). */
+  /** Cancel a dwell that has not fired yet (pointer or focus left in transit). */
   cancelDwell(): void;
 }
 
@@ -36,14 +48,15 @@ export interface BugReportUrlState {
  * popup-blocked in the browser build. Failure needs no branch either: the
  * fallback IS the initial value.
  *
- * `prime()` is wired to hover/focus rather than to the modal opening.
+ * Priming is wired to a pointer/focus dwell rather than to the modal opening.
  * `/api/diagnostics` runs the full `tandem doctor` collector — an `npm ls -g`
  * subprocess with a 4s timeout, port probes, a directory scan — which
  * `doctor.ts` notes runs "inside the synchronous Copy-Diagnostics path", i.e.
  * only on an explicit click. Paying that on every Settings open, for the large
  * majority of opens that never touch this link, would be an unforced
- * regression. Hover and focus both precede the click by enough to win the race
- * on a warm path; touch-only interaction fires neither and keeps the bare URL.
+ * regression. A dwell precedes the click by enough to win the race on a warm
+ * path. Touch taps do fire `pointerenter`, but the dwell resolves after the
+ * navigation has already used the bare URL, so touch effectively keeps it.
  *
  * Takes `getOpen` so the hook owns its own teardown, matching `createAppInfo`
  * and the rest of this directory — priming is the caller's business, forgetting
@@ -55,6 +68,7 @@ export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
   // Bumped on close so a report still in flight cannot land afterwards.
   let generation = 0;
   let dwellTimer: ReturnType<typeof setTimeout> | null = null;
+  let retryAllowedAt = 0;
 
   function cancelDwell(): void {
     if (dwellTimer === null) return;
@@ -73,9 +87,21 @@ export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
     url = TANDEM_ISSUES_NEW_URL;
   });
 
+  // Unmount teardown, separate from the close-transition effect above: that one
+  // returns early while the modal is open, so a dwell armed during an open
+  // session would outlive a destroy that never passes through `open === false`.
+  $effect(() => cancelDwell);
+
+  function unlatchAfterFailure(): void {
+    // Released so a later dwell can retry, but not instantly — see
+    // RETRY_COOLDOWN_MS.
+    primed = false;
+    retryAllowedAt = Date.now() + RETRY_COOLDOWN_MS;
+  }
+
   function prime(): void {
     cancelDwell();
-    if (primed) return;
+    if (primed || Date.now() < retryAllowedAt) return;
     primed = true;
     const token = generation;
 
@@ -87,10 +113,10 @@ export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
       .then((result) => {
         if (token !== generation) return;
         if (!result.ok) {
-          // Unlatch so a later hover can retry. The fetch layer deliberately
-          // does not cache failures; latching here would undo that and leave
-          // the prefill dead for the rest of the session after one blip.
-          primed = false;
+          // The fetch layer deliberately does not cache failures; latching here
+          // permanently would undo that and leave the prefill dead for the rest
+          // of the session after one blip.
+          unlatchAfterFailure();
           return;
         }
         url = buildBugReportUrl(
@@ -100,7 +126,7 @@ export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
         );
       })
       .catch((err: unknown) => {
-        if (token === generation) primed = false;
+        if (token === generation) unlatchAfterFailure();
         // No toast: the user asked for an issue form, not a diagnostic report.
         // A banner on every hover of an offline app would be pure noise.
         console.warn("[useBugReportUrl] diagnostics prefetch failed:", err);
@@ -112,14 +138,13 @@ export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
     dwellTimer = setTimeout(() => {
       dwellTimer = null;
       prime();
-    }, POINTER_INTENT_MS);
+    }, INTENT_DWELL_MS);
   }
 
   return {
     get url() {
       return url;
     },
-    prime,
     primeOnDwell,
     cancelDwell,
   };

--- a/src/client/hooks/useBugReportUrl.svelte.ts
+++ b/src/client/hooks/useBugReportUrl.svelte.ts
@@ -1,0 +1,86 @@
+import { TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
+import { buildBugReportUrl, formatDiagnostics, summarizeUserAgent } from "../utils/diagnostics";
+import { fetchDiagnostics } from "../utils/diagnostics-fetch";
+
+/** `runDoctor` does port probes and HTTP self-probes; 3s (useAppInfo's budget) is too tight. */
+const PREFETCH_TIMEOUT_MS = 8000;
+
+export interface BugReportUrlState {
+  /** Always a usable issue URL — bare until the prefetch lands. */
+  readonly url: string;
+  /** Start the prefetch. Idempotent; safe to call on every hover/focus. */
+  prime(): void;
+  /** Abort, and drop any captured diagnostics. */
+  reset(): void;
+}
+
+/**
+ * Backing state for the Settings sidebar's "Report a bug" link.
+ *
+ * The element stays an `<a>` and its `href` is upgraded in place: it starts as
+ * the bare issue URL and is replaced once diagnostics arrive. The click path
+ * therefore never awaits anything, which is the point — a button that had to
+ * `await` a fetch before `window.open` would lose user activation and get
+ * popup-blocked in the browser build. Failure needs no branch either: the
+ * fallback IS the initial value.
+ *
+ * `prime()` is wired to hover/focus rather than to the modal opening.
+ * `/api/diagnostics` runs the full `tandem doctor` collector — an `npm ls -g`
+ * subprocess with a 4s timeout, port probes, a directory scan — which
+ * `doctor.ts` notes runs "inside the synchronous Copy-Diagnostics path", i.e.
+ * only on an explicit click. Paying that on every Settings open, for the large
+ * majority of opens that never touch this link, would be an unforced
+ * regression. Hover and focus both precede the click by enough to win the race
+ * on a warm path; touch-only interaction fires neither and keeps the bare URL.
+ */
+export function createBugReportUrl(): BugReportUrlState {
+  let url = $state(TANDEM_ISSUES_NEW_URL);
+  let primed = false;
+  let controller: AbortController | null = null;
+
+  function prime(): void {
+    if (primed) return;
+    primed = true;
+
+    const ctrl = new AbortController();
+    controller = ctrl;
+    const timeout = setTimeout(() => ctrl.abort(), PREFETCH_TIMEOUT_MS);
+
+    fetchDiagnostics(ctrl.signal)
+      .then((result) => {
+        if (ctrl.signal.aborted || !result.ok) return;
+        url = buildBugReportUrl(
+          formatDiagnostics(result.payload, {
+            browser: summarizeUserAgent(navigator.userAgent),
+          }),
+        );
+      })
+      .catch((err: unknown) => {
+        // No toast: the user asked for an issue form, not a diagnostic report.
+        // A banner on every hover of an offline app would be pure noise.
+        console.warn("[useBugReportUrl] diagnostics prefetch failed:", err);
+      })
+      .finally(() => {
+        clearTimeout(timeout);
+        if (controller === ctrl) controller = null;
+      });
+  }
+
+  function reset(): void {
+    controller?.abort();
+    controller = null;
+    primed = false;
+    // Diagnostics captured during an earlier session of the modal would be
+    // stale by the next open, and stale readings in a bug report are worse
+    // than none.
+    url = TANDEM_ISSUES_NEW_URL;
+  }
+
+  return {
+    get url() {
+      return url;
+    },
+    prime,
+    reset,
+  };
+}

--- a/src/client/hooks/useBugReportUrl.svelte.ts
+++ b/src/client/hooks/useBugReportUrl.svelte.ts
@@ -2,11 +2,28 @@ import { TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
 import { buildBugReportUrl, formatDiagnostics, summarizeUserAgent } from "../utils/diagnostics";
 import { fetchDiagnostics } from "../utils/diagnostics-fetch";
 
+/**
+ * How long the pointer must rest on the link before the collector runs.
+ *
+ * `/api/diagnostics` is not an inert read: `runDoctor`'s SSE check opens a real
+ * connection to `/api/events`, which registers and immediately drops an
+ * `"external"` subscriber — the same count `takeWakeAdvisory` and the Solo
+ * forwarding gate read. A mouse merely crossing the sidebar on its way
+ * somewhere else should not do that, and should not spawn `npm ls -g` either.
+ * Resting on the link is intent; passing over it is not. Keyboard focus skips
+ * the delay — tabbing to a link is already unambiguous.
+ */
+const POINTER_INTENT_MS = 150;
+
 export interface BugReportUrlState {
   /** Always a usable issue URL — bare until the prefetch lands. */
   readonly url: string;
-  /** Start the prefetch. Idempotent; safe to call on every hover/focus. */
+  /** Start the prefetch now. Idempotent. For unambiguous intent (focus). */
   prime(): void;
+  /** Arm the prefetch after a short dwell. Idempotent. */
+  primeOnDwell(): void;
+  /** Cancel a dwell that has not fired yet (pointer left before it elapsed). */
+  cancelDwell(): void;
 }
 
 /**
@@ -37,18 +54,27 @@ export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
   let primed = false;
   // Bumped on close so a report still in flight cannot land afterwards.
   let generation = 0;
+  let dwellTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function cancelDwell(): void {
+    if (dwellTimer === null) return;
+    clearTimeout(dwellTimer);
+    dwellTimer = null;
+  }
 
   $effect(() => {
     if (getOpen()) return;
     // Diagnostics captured during an earlier session of the modal would be
     // stale by the next open, and stale readings in a bug report are worse
     // than none.
+    cancelDwell();
     generation++;
     primed = false;
     url = TANDEM_ISSUES_NEW_URL;
   });
 
   function prime(): void {
+    cancelDwell();
     if (primed) return;
     primed = true;
     const token = generation;
@@ -59,7 +85,14 @@ export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
     // a stale one from being applied.
     void fetchDiagnostics()
       .then((result) => {
-        if (token !== generation || !result.ok) return;
+        if (token !== generation) return;
+        if (!result.ok) {
+          // Unlatch so a later hover can retry. The fetch layer deliberately
+          // does not cache failures; latching here would undo that and leave
+          // the prefill dead for the rest of the session after one blip.
+          primed = false;
+          return;
+        }
         url = buildBugReportUrl(
           formatDiagnostics(result.payload, {
             browser: summarizeUserAgent(navigator.userAgent),
@@ -67,10 +100,19 @@ export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
         );
       })
       .catch((err: unknown) => {
+        if (token === generation) primed = false;
         // No toast: the user asked for an issue form, not a diagnostic report.
         // A banner on every hover of an offline app would be pure noise.
         console.warn("[useBugReportUrl] diagnostics prefetch failed:", err);
       });
+  }
+
+  function primeOnDwell(): void {
+    if (primed || dwellTimer !== null) return;
+    dwellTimer = setTimeout(() => {
+      dwellTimer = null;
+      prime();
+    }, POINTER_INTENT_MS);
   }
 
   return {
@@ -78,5 +120,7 @@ export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
       return url;
     },
     prime,
+    primeOnDwell,
+    cancelDwell,
   };
 }

--- a/src/client/hooks/useBugReportUrl.svelte.ts
+++ b/src/client/hooks/useBugReportUrl.svelte.ts
@@ -2,16 +2,11 @@ import { TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
 import { buildBugReportUrl, formatDiagnostics, summarizeUserAgent } from "../utils/diagnostics";
 import { fetchDiagnostics } from "../utils/diagnostics-fetch";
 
-/** `runDoctor` does port probes and HTTP self-probes; 3s (useAppInfo's budget) is too tight. */
-const PREFETCH_TIMEOUT_MS = 8000;
-
 export interface BugReportUrlState {
   /** Always a usable issue URL — bare until the prefetch lands. */
   readonly url: string;
   /** Start the prefetch. Idempotent; safe to call on every hover/focus. */
   prime(): void;
-  /** Abort, and drop any captured diagnostics. */
-  reset(): void;
 }
 
 /**
@@ -32,23 +27,39 @@ export interface BugReportUrlState {
  * majority of opens that never touch this link, would be an unforced
  * regression. Hover and focus both precede the click by enough to win the race
  * on a warm path; touch-only interaction fires neither and keeps the bare URL.
+ *
+ * Takes `getOpen` so the hook owns its own teardown, matching `createAppInfo`
+ * and the rest of this directory — priming is the caller's business, forgetting
+ * to reset should not be.
  */
-export function createBugReportUrl(): BugReportUrlState {
+export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
   let url = $state(TANDEM_ISSUES_NEW_URL);
   let primed = false;
-  let controller: AbortController | null = null;
+  // Bumped on close so a report still in flight cannot land afterwards.
+  let generation = 0;
+
+  $effect(() => {
+    if (getOpen()) return;
+    // Diagnostics captured during an earlier session of the modal would be
+    // stale by the next open, and stale readings in a bug report are worse
+    // than none.
+    generation++;
+    primed = false;
+    url = TANDEM_ISSUES_NEW_URL;
+  });
 
   function prime(): void {
     if (primed) return;
     primed = true;
+    const token = generation;
 
-    const ctrl = new AbortController();
-    controller = ctrl;
-    const timeout = setTimeout(() => ctrl.abort(), PREFETCH_TIMEOUT_MS);
-
-    fetchDiagnostics(ctrl.signal)
+    // No timeout and no abort: the request is shared (see `diagnostics-fetch`),
+    // so cancelling it could kill a Copy-Diagnostics click's fetch. A late
+    // result is harmless — the link works throughout, and `token` is what stops
+    // a stale one from being applied.
+    void fetchDiagnostics()
       .then((result) => {
-        if (ctrl.signal.aborted || !result.ok) return;
+        if (token !== generation || !result.ok) return;
         url = buildBugReportUrl(
           formatDiagnostics(result.payload, {
             browser: summarizeUserAgent(navigator.userAgent),
@@ -59,21 +70,7 @@ export function createBugReportUrl(): BugReportUrlState {
         // No toast: the user asked for an issue form, not a diagnostic report.
         // A banner on every hover of an offline app would be pure noise.
         console.warn("[useBugReportUrl] diagnostics prefetch failed:", err);
-      })
-      .finally(() => {
-        clearTimeout(timeout);
-        if (controller === ctrl) controller = null;
       });
-  }
-
-  function reset(): void {
-    controller?.abort();
-    controller = null;
-    primed = false;
-    // Diagnostics captured during an earlier session of the modal would be
-    // stale by the next open, and stale readings in a bug report are worse
-    // than none.
-    url = TANDEM_ISSUES_NEW_URL;
   }
 
   return {
@@ -81,6 +78,5 @@ export function createBugReportUrl(): BugReportUrlState {
       return url;
     },
     prime,
-    reset,
   };
 }

--- a/src/client/utils/diagnostics-fetch.ts
+++ b/src/client/utils/diagnostics-fetch.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared `GET /api/diagnostics` fetch for the two consumers that need it: the
+ * About tab's "Copy Diagnostics" button and the Report-a-bug link's prefill.
+ *
+ * Kept separate from `diagnostics.ts` deliberately — that module is pure and
+ * imported by a node-env vitest file; this one touches `fetch`.
+ */
+
+import { API_DIAGNOSTICS } from "../../shared/api-paths";
+import type { DiagnosticsPayload } from "./diagnostics";
+import { API_BASE } from "./fileUpload";
+
+/**
+ * `reason` mirrors the two distinct messages the About tab has always shown.
+ * "unreachable" means the request never landed, so "is the server running?" is
+ * the right prompt; "server" means it landed and failed, where that prompt
+ * would misdirect.
+ */
+export type DiagnosticsFetchResult =
+  | { ok: true; payload: DiagnosticsPayload }
+  | { ok: false; reason: "unreachable" | "server" };
+
+/**
+ * Single shared in-flight request. `runDoctor` behind this route spawns
+ * `npm ls -g`, probes ports, and stats the annotation store, so a hover-prefetch
+ * racing a Copy-Diagnostics click should cost one run, not two. Cleared on
+ * settle rather than cached with a TTL: a later click deserves fresh readings.
+ */
+let inFlight: Promise<DiagnosticsFetchResult> | null = null;
+
+async function run(signal?: AbortSignal): Promise<DiagnosticsFetchResult> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}${API_DIAGNOSTICS}`, { signal });
+  } catch {
+    return { ok: false, reason: "unreachable" };
+  }
+  if (!res.ok) return { ok: false, reason: "server" };
+  try {
+    return { ok: true, payload: (await res.json()) as DiagnosticsPayload };
+  } catch {
+    return { ok: false, reason: "server" };
+  }
+}
+
+/**
+ * Fetch diagnostics, joining any request already in flight.
+ *
+ * Note that `signal` only applies to a request this call actually starts — a
+ * joined caller cannot abort someone else's fetch. That is the intended
+ * behavior: the hook's timeout should stop *waiting*, not cancel the click-path
+ * request it happened to piggyback on.
+ */
+export function fetchDiagnostics(signal?: AbortSignal): Promise<DiagnosticsFetchResult> {
+  inFlight ??= run(signal).finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+/** Test seam — drops any shared in-flight promise. */
+export function _resetDiagnosticsInFlight(): void {
+  inFlight = null;
+}

--- a/src/client/utils/diagnostics-fetch.ts
+++ b/src/client/utils/diagnostics-fetch.ts
@@ -21,17 +21,38 @@ export type DiagnosticsFetchResult =
   | { ok: false; reason: "unreachable" | "server" };
 
 /**
- * Single shared in-flight request. `runDoctor` behind this route spawns
- * `npm ls -g`, probes ports, and stats the annotation store, so a hover-prefetch
- * racing a Copy-Diagnostics click should cost one run, not two. Cleared on
- * settle rather than cached with a TTL: a later click deserves fresh readings.
+ * How long a successful report may be reused.
+ *
+ * Without this, the ordinary sequence — hover the Report-a-bug link (primes,
+ * settles), then click Copy Diagnostics a few seconds later — runs the whole
+ * collector twice, where before the prefetch existed it ran once. In-flight
+ * sharing alone does not help, because those two requests do not overlap. The
+ * staleness is not a real cost: the hook already serves the user a prefetched
+ * report of exactly this age when they click through to the issue form.
+ */
+const CACHE_TTL_MS = 15_000;
+
+/**
+ * Deliberately NO AbortSignal parameter.
+ *
+ * An earlier version took one, and because the promise is shared, whichever
+ * caller *started* the request owned its lifetime: the hover prefetch would
+ * start it, a Copy-Diagnostics click would join it, and then the prefetch's
+ * timeout — or the modal closing — aborted the fetch the click was still
+ * awaiting. `run()` maps AbortError to "unreachable", so the user saw
+ * "Couldn't reach the server — is it running?" for a perfectly healthy server,
+ * and a nearly-complete collector run was thrown away.
+ *
+ * A caller that wants to stop *waiting* can ignore a late result; nobody gets
+ * to cancel work another caller is depending on.
  */
 let inFlight: Promise<DiagnosticsFetchResult> | null = null;
+let cached: { at: number; result: DiagnosticsFetchResult } | null = null;
 
-async function run(signal?: AbortSignal): Promise<DiagnosticsFetchResult> {
+async function run(): Promise<DiagnosticsFetchResult> {
   let res: Response;
   try {
-    res = await fetch(`${API_BASE}${API_DIAGNOSTICS}`, { signal });
+    res = await fetch(`${API_BASE}${API_DIAGNOSTICS}`);
   } catch {
     return { ok: false, reason: "unreachable" };
   }
@@ -44,21 +65,31 @@ async function run(signal?: AbortSignal): Promise<DiagnosticsFetchResult> {
 }
 
 /**
- * Fetch diagnostics, joining any request already in flight.
- *
- * Note that `signal` only applies to a request this call actually starts — a
- * joined caller cannot abort someone else's fetch. That is the intended
- * behavior: the hook's timeout should stop *waiting*, not cancel the click-path
- * request it happened to piggyback on.
+ * Fetch diagnostics, reusing a recent success or joining a request already in
+ * flight. The route runs the full `tandem doctor` collector — an `npm ls -g`
+ * subprocess, port probes, a directory scan — so duplicate runs are the thing
+ * worth avoiding here. (The server single-flights *overlapping* requests too;
+ * this layer additionally covers sequential ones and saves the round-trip.)
  */
-export function fetchDiagnostics(signal?: AbortSignal): Promise<DiagnosticsFetchResult> {
-  inFlight ??= run(signal).finally(() => {
-    inFlight = null;
-  });
+export function fetchDiagnostics(): Promise<DiagnosticsFetchResult> {
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return Promise.resolve(cached.result);
+  }
+  inFlight ??= run()
+    .then((result) => {
+      // Only successes are cached. Pinning a transient failure for 15s would
+      // make a retry look broken.
+      if (result.ok) cached = { at: Date.now(), result };
+      return result;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
   return inFlight;
 }
 
-/** Test seam — drops any shared in-flight promise. */
-export function _resetDiagnosticsInFlight(): void {
+/** Test seam — drops the cached report and any shared in-flight promise. */
+export function _resetDiagnosticsCache(): void {
   inFlight = null;
+  cached = null;
 }

--- a/src/client/utils/diagnostics-fetch.ts
+++ b/src/client/utils/diagnostics-fetch.ts
@@ -71,8 +71,16 @@ async function run(): Promise<DiagnosticsFetchResult> {
  * worth avoiding here. (The server single-flights *overlapping* requests too;
  * this layer additionally covers sequential ones and saves the round-trip.)
  */
-export function fetchDiagnostics(): Promise<DiagnosticsFetchResult> {
-  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+export function fetchDiagnostics(
+  opts: { maxAgeMs?: number } = {},
+): Promise<DiagnosticsFetchResult> {
+  // `maxAgeMs: 0` opts out of the cache. The Copy Diagnostics button uses it:
+  // that click is an explicit "tell me the state now", and a user who fixes a
+  // reported problem and clicks again must not be handed the pre-fix report.
+  // In-flight sharing still applies, so opting out costs a run only when there
+  // isn't one already going.
+  const maxAge = opts.maxAgeMs ?? CACHE_TTL_MS;
+  if (cached && Date.now() - cached.at < maxAge) {
     return Promise.resolve(cached.result);
   }
   inFlight ??= run()

--- a/src/client/utils/diagnostics-fetch.ts
+++ b/src/client/utils/diagnostics-fetch.ts
@@ -46,7 +46,8 @@ const CACHE_TTL_MS = 15_000;
  * A caller that wants to stop *waiting* can ignore a late result; nobody gets
  * to cancel work another caller is depending on.
  */
-let inFlight: Promise<DiagnosticsFetchResult> | null = null;
+/** The single run currently in progress, with when its probes began. */
+let inFlight: { promise: Promise<DiagnosticsFetchResult>; startedAt: number } | null = null;
 let cached: { at: number; result: DiagnosticsFetchResult } | null = null;
 
 async function run(): Promise<DiagnosticsFetchResult> {
@@ -64,36 +65,53 @@ async function run(): Promise<DiagnosticsFetchResult> {
   }
 }
 
+/** Start a run now and register it as the in-flight one. */
+function startRun(): Promise<DiagnosticsFetchResult> {
+  const entry = {
+    startedAt: Date.now(),
+    promise: run()
+      .then((result) => {
+        // Only successes are cached. Pinning a transient failure for the TTL
+        // would make a retry look broken.
+        if (result.ok) cached = { at: Date.now(), result };
+        return result;
+      })
+      .finally(() => {
+        if (inFlight === entry) inFlight = null;
+      }),
+  };
+  inFlight = entry;
+  return entry.promise;
+}
+
 /**
  * Fetch diagnostics, reusing a recent success or joining a request already in
  * flight. The route runs the full `tandem doctor` collector — an `npm ls -g`
  * subprocess, port probes, a directory scan — so duplicate runs are the thing
  * worth avoiding here. (The server single-flights *overlapping* requests too;
  * this layer additionally covers sequential ones and saves the round-trip.)
+ *
+ * `maxAgeMs: 0` opts out of reuse entirely. The Copy Diagnostics button uses
+ * it: that click is an explicit "tell me the state now", and a user who fixes a
+ * reported problem and clicks again must not be handed the pre-fix report.
+ *
+ * Note that opting out has to reject a stale *in-flight* run as well as a stale
+ * cache entry. A hover starts a run at t=0; the user fixes the problem at
+ * t=0.5s and clicks at t=1s. Joining the running one would hand them probes
+ * that predate the fix — the very thing being ruled out. When the running one
+ * is too old for the caller, a fresh run is chained behind it rather than
+ * started alongside it, so two collectors never compete.
  */
 export function fetchDiagnostics(
   opts: { maxAgeMs?: number } = {},
 ): Promise<DiagnosticsFetchResult> {
-  // `maxAgeMs: 0` opts out of the cache. The Copy Diagnostics button uses it:
-  // that click is an explicit "tell me the state now", and a user who fixes a
-  // reported problem and clicks again must not be handed the pre-fix report.
-  // In-flight sharing still applies, so opting out costs a run only when there
-  // isn't one already going.
   const maxAge = opts.maxAgeMs ?? CACHE_TTL_MS;
-  if (cached && Date.now() - cached.at < maxAge) {
-    return Promise.resolve(cached.result);
-  }
-  inFlight ??= run()
-    .then((result) => {
-      // Only successes are cached. Pinning a transient failure for 15s would
-      // make a retry look broken.
-      if (result.ok) cached = { at: Date.now(), result };
-      return result;
-    })
-    .finally(() => {
-      inFlight = null;
-    });
-  return inFlight;
+  const now = Date.now();
+
+  if (cached && now - cached.at < maxAge) return Promise.resolve(cached.result);
+  if (inFlight && now - inFlight.startedAt <= maxAge) return inFlight.promise;
+  if (inFlight) return inFlight.promise.then(() => fetchDiagnostics(opts));
+  return startRun();
 }
 
 /** Test seam — drops the cached report and any shared in-flight promise. */

--- a/src/client/utils/diagnostics.ts
+++ b/src/client/utils/diagnostics.ts
@@ -175,14 +175,26 @@ const TRUNCATION_MARKER =
   "… (truncated — use Copy Diagnostics in Settings → About for the full report)";
 
 /**
- * Tilde fence, not backticks. Doctor `fix` strings embed backticks verbatim
- * (e.g. "run via `npx`"), so a ``` fence is not escape-safe against content we
- * do not control.
+ * Build a fence long enough to contain `text`.
+ *
+ * Tildes rather than backticks because doctor `fix` strings embed backticks
+ * verbatim (e.g. "run via `npx`"). But swapping the character only moves the
+ * problem: report text is not ours either. `checkAnnotationStore` interpolates
+ * raw `store.lock` bytes (doctor.ts:1520), and `stripControlChars` preserves
+ * newlines, so a lock file containing a `~~~` line would close the fence and
+ * let everything after it render as markdown in a public issue.
+ *
+ * CommonMark closes a fence only on a run at least as long as the opener, so
+ * one tilde more than the longest run present is sufficient.
  */
-const FENCE = "~~~";
+function fenceFor(text: string): string {
+  const longest = Math.max(0, ...[...text.matchAll(/~+/g)].map((m) => m[0].length));
+  return "~".repeat(Math.max(3, longest + 1));
+}
 
 function issueUrlFor(text: string): string {
-  const body = `\n\n${BUG_REPORT_BODY_HEADING}\n\n${FENCE}\n${text}\n${FENCE}`;
+  const fence = fenceFor(text);
+  const body = `\n\n${BUG_REPORT_BODY_HEADING}\n\n${fence}\n${text}\n${fence}`;
   return `${TANDEM_ISSUES_NEW_URL}?body=${encodeURIComponent(body)}`;
 }
 

--- a/src/client/utils/diagnostics.ts
+++ b/src/client/utils/diagnostics.ts
@@ -2,29 +2,20 @@
 // client bundle — this is the wire shape of GET /api/diagnostics' `report`.
 import type { DoctorReport, DoctorStatus } from "../../cli/doctor";
 import { TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
+import type { HostInfo } from "../../shared/diagnostics";
 
 /**
  * Wire shape of `GET /api/diagnostics` (see `makeDiagnosticsHandler`).
  *
- * Everything below `tauriSidecar` comes from `collectHostInfo()` and is
- * OPTIONAL — `os.cpus()` legitimately returns `[]` on some hosts, and an older
- * server predates the fields entirely. `formatDiagnostics` therefore drops each
- * one individually rather than printing `undefined`.
+ * Extends `HostInfo` rather than re-declaring its ten fields: the host block is
+ * the server's to define, and a hand-copy here would be the one copy nothing
+ * type-checks. `formatDiagnostics` drops each optional field individually
+ * rather than printing `undefined`.
  */
-export interface DiagnosticsPayload {
+export interface DiagnosticsPayload extends HostInfo {
   report: DoctorReport;
   version: string;
   transport: string;
-  platform: string;
-  arch: string;
-  nodeVersion: string;
-  tauriSidecar: boolean;
-  osRelease?: string;
-  osVersion?: string;
-  cpuModel?: string;
-  cpuCount?: number;
-  totalMemoryMb?: number;
-  freeMemoryMb?: number;
 }
 
 /** Client-side facts the server cannot see. */
@@ -64,6 +55,11 @@ const UA_PATTERNS: ReadonlyArray<readonly [string, RegExp]> = [
   ["HeadlessChrome", /\bHeadlessChrome\/(\d+)/],
   ["Chrome", /\bChrome\/(\d+)/],
   ["Safari", /\bVersion\/(\d+)[.\d]*\s+Safari\//],
+  // Terminal fallback, and it carries the desktop app. macOS WKWebView sends no
+  // `Chrome/`, no `Edg/`, and often no `Version/… Safari/` token, so without
+  // this the Browser line vanishes for exactly the distribution whose engine
+  // version a bug report most needs.
+  ["WebKit", /\bAppleWebKit\/(\d+)/],
 ];
 
 /**
@@ -109,15 +105,14 @@ function hardwareLine(payload: DiagnosticsPayload): string | null {
   else if (model) parts.push(`CPU: ${model}`);
   else if (count) parts.push(`CPU: x${count}`);
 
-  const total = payload.totalMemoryMb;
-  const free = payload.freeMemoryMb;
-  if (total !== undefined && free !== undefined) {
-    parts.push(`RAM: ${formatMemoryMb(total)} total, ${formatMemoryMb(free)} free`);
-  } else if (total !== undefined) {
-    parts.push(`RAM: ${formatMemoryMb(total)} total`);
-  } else if (free !== undefined) {
-    parts.push(`RAM: ${formatMemoryMb(free)} free`);
+  const ram: string[] = [];
+  if (payload.totalMemoryMb !== undefined) {
+    ram.push(`${formatMemoryMb(payload.totalMemoryMb)} total`);
   }
+  if (payload.freeMemoryMb !== undefined) {
+    ram.push(`${formatMemoryMb(payload.freeMemoryMb)} free`);
+  }
+  if (ram.length > 0) parts.push(`RAM: ${ram.join(", ")}`);
 
   return parts.length > 0 ? parts.join(", ") : null;
 }
@@ -215,26 +210,20 @@ export function buildBugReportUrl(diagnostics?: string | null): string {
     // Truncate by whole lines, never mid-string: slicing a JS string can split
     // a surrogate pair, and `encodeURIComponent` throws URIError on a lone
     // surrogate. Line boundaries sidestep that entirely.
+    //
+    // A linear shrink rather than a binary search: reports run 20-40 lines, and
+    // even the pathological 400-line case measures well under a millisecond in
+    // a `.then` continuation off the click path. Not worth the lo/hi/sentinel
+    // bookkeeping.
     const lines = text.split("\n");
-    const candidate = (kept: number): string =>
-      `${lines.slice(0, kept).join("\n")}\n${TRUNCATION_MARKER}`;
-
-    let lo = 1;
-    let hi = lines.length;
-    let best = 0;
-    while (lo <= hi) {
-      const mid = (lo + hi) >> 1;
-      if (issueUrlFor(candidate(mid)).length <= MAX_ISSUE_URL_LENGTH) {
-        best = mid;
-        lo = mid + 1;
-      } else {
-        hi = mid - 1;
-      }
+    for (let kept = lines.length - 1; kept > 0; kept--) {
+      const url = issueUrlFor(`${lines.slice(0, kept).join("\n")}\n${TRUNCATION_MARKER}`);
+      if (url.length <= MAX_ISSUE_URL_LENGTH) return url;
     }
 
     // Not even one line fits — a single pathologically long line. An issue with
     // only a truncation notice is worse than none, so fall back to the bare URL.
-    return best > 0 ? issueUrlFor(candidate(best)) : TANDEM_ISSUES_NEW_URL;
+    return TANDEM_ISSUES_NEW_URL;
   } catch {
     // encodeURIComponent throws URIError on a lone surrogate anywhere in the
     // report. Losing the prefill beats losing the link.

--- a/src/client/utils/diagnostics.ts
+++ b/src/client/utils/diagnostics.ts
@@ -1,8 +1,16 @@
 // Type-only import: erased at compile time, so no CLI/node code reaches the
 // client bundle — this is the wire shape of GET /api/diagnostics' `report`.
 import type { DoctorReport, DoctorStatus } from "../../cli/doctor";
+import { TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
 
-/** Wire shape of `GET /api/diagnostics` (see `makeDiagnosticsHandler`). */
+/**
+ * Wire shape of `GET /api/diagnostics` (see `makeDiagnosticsHandler`).
+ *
+ * Everything below `tauriSidecar` comes from `collectHostInfo()` and is
+ * OPTIONAL — `os.cpus()` legitimately returns `[]` on some hosts, and an older
+ * server predates the fields entirely. `formatDiagnostics` therefore drops each
+ * one individually rather than printing `undefined`.
+ */
 export interface DiagnosticsPayload {
   report: DoctorReport;
   version: string;
@@ -11,6 +19,18 @@ export interface DiagnosticsPayload {
   arch: string;
   nodeVersion: string;
   tauriSidecar: boolean;
+  osRelease?: string;
+  osVersion?: string;
+  cpuModel?: string;
+  cpuCount?: number;
+  totalMemoryMb?: number;
+  freeMemoryMb?: number;
+}
+
+/** Client-side facts the server cannot see. */
+export interface DiagnosticsEnv {
+  /** Short browser/WebView descriptor, e.g. "Chrome 141". Empty to omit. */
+  browser?: string;
 }
 
 const STATUS_TAG: Record<DoctorStatus, string> = {
@@ -30,15 +50,104 @@ function stripControlChars(s: string): string {
 }
 
 /**
- * Format a diagnostics payload as plain text for the clipboard. Pure — the
- * "Copy diagnostics" button is thin glue over this (extract-over-mount).
+ * Ordered because user-agent strings are cumulative liars: Edge's UA contains
+ * "Chrome", Chrome's contains "Safari", and Opera's contains both. First match
+ * wins, so the most specific patterns come first.
  */
-export function formatDiagnostics(payload: DiagnosticsPayload): string {
+const UA_PATTERNS: ReadonlyArray<readonly [string, RegExp]> = [
+  ["Edge", /\bEdg(?:e|A|iOS)?\/(\d+)/],
+  ["Opera", /\bOPR\/(\d+)/],
+  ["Firefox", /\bFirefox\/(\d+)/],
+  // Before Chrome, and matched on its own: "HeadlessChrome" has no word
+  // boundary before "Chrome", so a `\bChrome/` pattern silently misses it and
+  // drops the line entirely.
+  ["HeadlessChrome", /\bHeadlessChrome\/(\d+)/],
+  ["Chrome", /\bChrome\/(\d+)/],
+  ["Safari", /\bVersion\/(\d+)[.\d]*\s+Safari\//],
+];
+
+/**
+ * Reduce a user-agent string to a short "Name Major" descriptor.
+ *
+ * Deliberately a summary rather than the verbatim UA: this line lands in a
+ * public issue body, and the full string is long, noisy, and more identifying
+ * than the browser identity anyone actually needs to triage a report. Returns
+ * "" when nothing matches, which drops the line entirely.
+ */
+export function summarizeUserAgent(ua: string): string {
+  for (const [name, pattern] of UA_PATTERNS) {
+    const major = pattern.exec(ua)?.[1];
+    if (major) return `${name} ${major}`;
+  }
+  return "";
+}
+
+/**
+ * Render a MiB count for humans. Named for its unit rather than `formatBytes`,
+ * which already exists in `cli/doctor.ts` over a different one.
+ */
+export function formatMemoryMb(mb: number): string {
+  return mb < 1024 ? `${mb} MB` : `${(mb / 1024).toFixed(1)} GB`;
+}
+
+/** `OS: Windows 11 Pro (10.0.26100)` — either half may be missing. */
+function osLine(payload: DiagnosticsPayload): string | null {
+  const version = payload.osVersion ? stripControlChars(payload.osVersion).trim() : "";
+  const release = payload.osRelease?.trim() ?? "";
+  if (version && release) return `OS: ${version} (${release})`;
+  if (version || release) return `OS: ${version || release}`;
+  return null;
+}
+
+/** `CPU: Apple M2 Pro x12, RAM: 32.0 GB total, 6.1 GB free` — any part may be missing. */
+function hardwareLine(payload: DiagnosticsPayload): string | null {
+  const parts: string[] = [];
+
+  const model = payload.cpuModel ? stripControlChars(payload.cpuModel).trim() : "";
+  const count = payload.cpuCount;
+  if (model && count) parts.push(`CPU: ${model} x${count}`);
+  else if (model) parts.push(`CPU: ${model}`);
+  else if (count) parts.push(`CPU: x${count}`);
+
+  const total = payload.totalMemoryMb;
+  const free = payload.freeMemoryMb;
+  if (total !== undefined && free !== undefined) {
+    parts.push(`RAM: ${formatMemoryMb(total)} total, ${formatMemoryMb(free)} free`);
+  } else if (total !== undefined) {
+    parts.push(`RAM: ${formatMemoryMb(total)} total`);
+  } else if (free !== undefined) {
+    parts.push(`RAM: ${formatMemoryMb(free)} free`);
+  }
+
+  return parts.length > 0 ? parts.join(", ") : null;
+}
+
+/**
+ * Format a diagnostics payload as plain text for the clipboard. Pure — the
+ * "Copy diagnostics" button is thin glue over this (extract-over-mount), and
+ * `buildBugReportUrl` reuses the same text for the issue body.
+ *
+ * The first two lines are unchanged from before the host fields existed, and a
+ * payload carrying none of them produces byte-identical output to that era.
+ * That degradation is the contract: an older server, or a host where every
+ * `os.*` read failed, must still format cleanly.
+ */
+export function formatDiagnostics(payload: DiagnosticsPayload, env?: DiagnosticsEnv): string {
   const lines: string[] = [
     `Tandem v${payload.version} (${payload.transport}${payload.tauriSidecar ? ", desktop" : ""})`,
     `${payload.platform}/${payload.arch}, Node ${payload.nodeVersion}`,
-    "",
   ];
+
+  const os = osLine(payload);
+  if (os) lines.push(os);
+
+  const hardware = hardwareLine(payload);
+  if (hardware) lines.push(hardware);
+
+  const browser = env?.browser?.trim();
+  if (browser) lines.push(`Browser: ${stripControlChars(browser)}`);
+
+  lines.push("");
 
   for (const res of payload.report.results) {
     lines.push(`${STATUS_TAG[res.status]} ${res.check} — ${stripControlChars(res.message)}`);
@@ -49,4 +158,86 @@ export function formatDiagnostics(payload: DiagnosticsPayload): string {
 
   lines.push("", stripControlChars(payload.report.summary));
   return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Report a bug — prefilled GitHub issue body
+// ---------------------------------------------------------------------------
+
+export const BUG_REPORT_BODY_HEADING = "Diagnostic information:";
+
+/**
+ * Ceiling on the whole issue URL. GitHub rejects request lines past roughly
+ * 8 KB; staying well under that leaves room for the base URL and for whatever
+ * proxy sits in front of it. A dropped issue form is the failure mode being
+ * avoided — it looks like the button is simply broken.
+ */
+export const MAX_ISSUE_URL_LENGTH = 6000;
+
+const TRUNCATION_MARKER =
+  "… (truncated — use Copy Diagnostics in Settings → About for the full report)";
+
+/**
+ * Tilde fence, not backticks. Doctor `fix` strings embed backticks verbatim
+ * (e.g. "run via `npx`"), so a ``` fence is not escape-safe against content we
+ * do not control.
+ */
+const FENCE = "~~~";
+
+function issueUrlFor(text: string): string {
+  const body = `\n\n${BUG_REPORT_BODY_HEADING}\n\n${FENCE}\n${text}\n${FENCE}`;
+  return `${TANDEM_ISSUES_NEW_URL}?body=${encodeURIComponent(body)}`;
+}
+
+/**
+ * Build the "Report a bug" href, prefilling the issue body with the diagnostics
+ * report under a `Diagnostic information:` heading.
+ *
+ * With no diagnostics — not fetched yet, fetch failed, server unreachable —
+ * returns the bare issue URL. That is the whole error strategy: the link always
+ * works, and the prefill is an upgrade rather than a precondition.
+ *
+ * Truncation measures the ENCODED length, which is what the cap is actually
+ * about. The text is newline- and em-dash-dense and both expand (`%0A`,
+ * `%E2%80%94`), so real growth is roughly 2.5–3× — a raw character count would
+ * overshoot the cap by more than double. Lines are dropped from the tail so the
+ * header (version, OS, CPU) survives; those are the highest-value lines and the
+ * check list degrades gracefully.
+ */
+export function buildBugReportUrl(diagnostics?: string | null): string {
+  const text = (diagnostics ?? "").trim();
+  if (!text) return TANDEM_ISSUES_NEW_URL;
+
+  try {
+    const full = issueUrlFor(text);
+    if (full.length <= MAX_ISSUE_URL_LENGTH) return full;
+
+    // Truncate by whole lines, never mid-string: slicing a JS string can split
+    // a surrogate pair, and `encodeURIComponent` throws URIError on a lone
+    // surrogate. Line boundaries sidestep that entirely.
+    const lines = text.split("\n");
+    const candidate = (kept: number): string =>
+      `${lines.slice(0, kept).join("\n")}\n${TRUNCATION_MARKER}`;
+
+    let lo = 1;
+    let hi = lines.length;
+    let best = 0;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (issueUrlFor(candidate(mid)).length <= MAX_ISSUE_URL_LENGTH) {
+        best = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+
+    // Not even one line fits — a single pathologically long line. An issue with
+    // only a truncation notice is worse than none, so fall back to the bare URL.
+    return best > 0 ? issueUrlFor(candidate(best)) : TANDEM_ISSUES_NEW_URL;
+  } catch {
+    // encodeURIComponent throws URIError on a lone surrogate anywhere in the
+    // report. Losing the prefill beats losing the link.
+    return TANDEM_ISSUES_NEW_URL;
+  }
 }

--- a/src/client/utils/diagnostics.ts
+++ b/src/client/utils/diagnostics.ts
@@ -89,7 +89,9 @@ export function formatMemoryMb(mb: number): string {
 /** `OS: Windows 11 Pro (10.0.26100)` — either half may be missing. */
 function osLine(payload: DiagnosticsPayload): string | null {
   const version = payload.osVersion ? stripControlChars(payload.osVersion).trim() : "";
-  const release = payload.osRelease?.trim() ?? "";
+  // `osRelease` needs the same strip as the other two: it is an OS-supplied
+  // string on the same path to a terminal paste and a public issue body.
+  const release = payload.osRelease ? stripControlChars(payload.osRelease).trim() : "";
   if (version && release) return `OS: ${version} (${release})`;
   if (version || release) return `OS: ${version || release}`;
   return null;

--- a/src/server/mcp/diagnostics.ts
+++ b/src/server/mcp/diagnostics.ts
@@ -21,6 +21,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DoctorReport, RunDoctorOptions } from "../../cli/doctor.js";
 import { runDoctor } from "../../cli/doctor.js";
 import { DEFAULT_MCP_PORT, DEFAULT_WS_PORT } from "../../shared/constants.js";
+import { collectHostInfo } from "./host-info.js";
 import { diagnosticsOutputShape } from "./output-schemas.js";
 import { mcpStructured, withErrorBoundary, withStructuredErrors } from "./response.js";
 import { filterDevRepoChecks } from "./routes/diagnostics.js";
@@ -65,15 +66,11 @@ export function registerDiagnosticsTools(server: McpServer, deps: DiagnosticsToo
     withStructuredErrors(
       withErrorBoundary("tandem_diagnostics", async () => {
         const report = filterDevRepoChecks(await collect({ wsPort, mcpPort }));
-        return mcpStructured({
-          ...report,
-          version,
-          transport,
-          platform: process.platform,
-          arch: process.arch,
-          nodeVersion: process.version,
-          tauriSidecar: process.env.TANDEM_TAURI_SIDECAR === "1",
-        });
+        // Note the shape difference from the HTTP route, which nests the report
+        // under `report`: here it is spread flat. The host fields sit at top
+        // level in both. Home-dir paths are NOT redacted here — that is the
+        // route's concern, since only the route feeds a public issue body.
+        return mcpStructured({ ...report, version, transport, ...collectHostInfo() });
       }),
     ),
   );

--- a/src/server/mcp/host-info.ts
+++ b/src/server/mcp/host-info.ts
@@ -49,25 +49,38 @@ function toMb(bytes: number): number {
   return Math.round(bytes / 1024 / 1024);
 }
 
+/** Trim and fold all runs of whitespace — including newlines — to one space. */
+function collapse(s: string | undefined): string {
+  return s?.trim().replace(/\s+/g, " ") ?? "";
+}
+
 /** Collect the host environment fields. Side-effect free; safe to call per request. */
 export function collectHostInfo(): HostInfo {
   // One `os.cpus()` call — it allocates an object per core, and both CPU fields
   // read from the same array.
   const cpus = tryValue(() => os.cpus()) ?? [];
-  const model = cpus[0]?.model?.trim().replace(/\s+/g, " ");
+  const model = collapse(cpus[0]?.model);
+  // Collapse BEFORE truncating: `os.version()` returns a multi-line kernel
+  // banner on some Darwin/Linux builds, and an interior newline survives the
+  // client's `stripControlChars` (which deliberately preserves `\n`), so it
+  // would inject an unlabelled extra line into the clipboard text and the
+  // fenced issue body.
+  //
   // Spread-then-slice truncates on code points, not UTF-16 units. A plain
   // `.slice()` can bisect a surrogate pair, and the lone surrogate that leaves
   // behind makes `encodeURIComponent` throw — which silently drops the entire
   // Report-a-bug prefill. Same hazard `buildBugReportUrl` avoids by cutting on
   // line boundaries.
-  const version = tryValue(() => [...os.version()].slice(0, MAX_OS_VERSION_LENGTH).join(""));
+  const version = tryValue(() =>
+    [...collapse(os.version())].slice(0, MAX_OS_VERSION_LENGTH).join(""),
+  );
 
   return {
     platform: process.platform,
     arch: process.arch,
     nodeVersion: process.version,
     tauriSidecar: process.env.TANDEM_TAURI_SIDECAR === "1",
-    osRelease: tryValue(() => os.release()) || undefined,
+    osRelease: tryValue(() => collapse(os.release())) || undefined,
     osVersion: version || undefined,
     cpuModel: model || undefined,
     cpuCount: cpus.length || undefined,

--- a/src/server/mcp/host-info.ts
+++ b/src/server/mcp/host-info.ts
@@ -55,7 +55,12 @@ export function collectHostInfo(): HostInfo {
   // read from the same array.
   const cpus = tryValue(() => os.cpus()) ?? [];
   const model = cpus[0]?.model?.trim().replace(/\s+/g, " ");
-  const version = tryValue(() => os.version())?.slice(0, MAX_OS_VERSION_LENGTH);
+  // Spread-then-slice truncates on code points, not UTF-16 units. A plain
+  // `.slice()` can bisect a surrogate pair, and the lone surrogate that leaves
+  // behind makes `encodeURIComponent` throw — which silently drops the entire
+  // Report-a-bug prefill. Same hazard `buildBugReportUrl` avoids by cutting on
+  // line boundaries.
+  const version = tryValue(() => [...os.version()].slice(0, MAX_OS_VERSION_LENGTH).join(""));
 
   return {
     platform: process.platform,

--- a/src/server/mcp/host-info.ts
+++ b/src/server/mcp/host-info.ts
@@ -2,9 +2,9 @@
  * Host environment facts shared by the two diagnostics producers: the
  * `GET /api/diagnostics` HTTP route (`routes/diagnostics.ts`) and the
  * `tandem_diagnostics` MCP tool (`diagnostics.ts`). Both used to inline the
- * same four `process.*` reads; collapsing them here means two of the three
- * lockstep files (the third is the zod shape in `output-schemas.ts`) cannot
- * drift apart.
+ * same four `process.*` reads; collapsing them here means the producers cannot
+ * drift apart. The wire type lives in `shared/diagnostics.ts` so the client
+ * formatter shares it too.
  *
  * Privacy: this output reaches a public GitHub issue — Copy Diagnostics puts it
  * on the clipboard, and the Report-a-bug link prefills it into an issue body.
@@ -23,34 +23,19 @@
  * `undefined` rather than failing the whole diagnostics call. `os.cpus()`
  * returns `[]` under some cgroup-restricted containers, which is exactly why
  * the CPU fields are optional rather than defaulted.
+ *
+ * Not memoized. The reads total ~60µs, against a route whose collector spawns
+ * `npm ls -g`, probes two ports and stats a directory — caching them would buy
+ * under 0.01% and cost module state plus a reset seam.
  */
 
 import os from "node:os";
+import type { HostInfo } from "../../shared/diagnostics.js";
+
+export type { HostInfo };
 
 /** Upper bound on `os.version()`. Darwin's kernel banner is ~100 chars. */
 const MAX_OS_VERSION_LENGTH = 120;
-
-export interface HostInfo {
-  platform: string;
-  arch: string;
-  nodeVersion: string;
-  tauriSidecar: boolean;
-  /** `os.release()` — e.g. "10.0.26100", "23.5.0". */
-  osRelease?: string;
-  /** `os.version()` — e.g. "Windows 11 Pro", or a kernel banner. */
-  osVersion?: string;
-  /** First CPU's model string, whitespace-collapsed. */
-  cpuModel?: string;
-  /** Logical CPU count. */
-  cpuCount?: number;
-  /** Total physical memory, MiB. */
-  totalMemoryMb?: number;
-  /** Free physical memory, MiB. */
-  freeMemoryMb?: number;
-}
-
-/** The subset that never changes for the process lifetime. */
-type StaticHostInfo = Omit<HostInfo, "freeMemoryMb">;
 
 function tryValue<T>(read: () => T | undefined): T | undefined {
   try {
@@ -64,11 +49,13 @@ function toMb(bytes: number): number {
   return Math.round(bytes / 1024 / 1024);
 }
 
-function collectStatic(): StaticHostInfo {
+/** Collect the host environment fields. Side-effect free; safe to call per request. */
+export function collectHostInfo(): HostInfo {
+  // One `os.cpus()` call — it allocates an object per core, and both CPU fields
+  // read from the same array.
   const cpus = tryValue(() => os.cpus()) ?? [];
   const model = cpus[0]?.model?.trim().replace(/\s+/g, " ");
   const version = tryValue(() => os.version())?.slice(0, MAX_OS_VERSION_LENGTH);
-  const totalMemoryMb = tryValue(() => toMb(os.totalmem()));
 
   return {
     platform: process.platform,
@@ -79,23 +66,9 @@ function collectStatic(): StaticHostInfo {
     osVersion: version || undefined,
     cpuModel: model || undefined,
     cpuCount: cpus.length || undefined,
-    totalMemoryMb,
+    // No `|| undefined` on the memory fields: 0 MB free is a real, and rather
+    // interesting, reading — unlike a 0 CPU count, which only means "unknown".
+    totalMemoryMb: tryValue(() => toMb(os.totalmem())),
+    freeMemoryMb: tryValue(() => toMb(os.freemem())),
   };
-}
-
-let cachedStatic: StaticHostInfo | null = null;
-
-/**
- * Collect the host environment fields. Static values are memoized (`os.cpus()`
- * is a syscall and this runs on every diagnostics request); free memory is read
- * fresh each call because it is the only field that moves.
- */
-export function collectHostInfo(): HostInfo {
-  cachedStatic ??= collectStatic();
-  return { ...cachedStatic, freeMemoryMb: tryValue(() => toMb(os.freemem())) };
-}
-
-/** Test seam — drops the memoized static block. */
-export function _resetHostInfoCache(): void {
-  cachedStatic = null;
 }

--- a/src/server/mcp/host-info.ts
+++ b/src/server/mcp/host-info.ts
@@ -1,0 +1,101 @@
+/**
+ * Host environment facts shared by the two diagnostics producers: the
+ * `GET /api/diagnostics` HTTP route (`routes/diagnostics.ts`) and the
+ * `tandem_diagnostics` MCP tool (`diagnostics.ts`). Both used to inline the
+ * same four `process.*` reads; collapsing them here means two of the three
+ * lockstep files (the third is the zod shape in `output-schemas.ts`) cannot
+ * drift apart.
+ *
+ * Privacy: this output reaches a public GitHub issue — Copy Diagnostics puts it
+ * on the clipboard, and the Report-a-bug link prefills it into an issue body.
+ * The same constraint `doctor.ts` states for check messages applies here, so
+ * the following are DELIBERATELY absent and must stay absent:
+ *
+ *   os.hostname()          — machine name, frequently the user's own name
+ *   os.userInfo()          — username, uid, shell, homedir
+ *   os.homedir()           — absolute path containing the username
+ *   os.networkInterfaces() — MAC addresses and LAN topology
+ *   process.pid            — no diagnostic value off-machine
+ *   process.env            — tokens
+ *   locale / timeZone      — coarse location; declined deliberately
+ *
+ * Every field is individually guarded: a throw or an empty result yields
+ * `undefined` rather than failing the whole diagnostics call. `os.cpus()`
+ * returns `[]` under some cgroup-restricted containers, which is exactly why
+ * the CPU fields are optional rather than defaulted.
+ */
+
+import os from "node:os";
+
+/** Upper bound on `os.version()`. Darwin's kernel banner is ~100 chars. */
+const MAX_OS_VERSION_LENGTH = 120;
+
+export interface HostInfo {
+  platform: string;
+  arch: string;
+  nodeVersion: string;
+  tauriSidecar: boolean;
+  /** `os.release()` — e.g. "10.0.26100", "23.5.0". */
+  osRelease?: string;
+  /** `os.version()` — e.g. "Windows 11 Pro", or a kernel banner. */
+  osVersion?: string;
+  /** First CPU's model string, whitespace-collapsed. */
+  cpuModel?: string;
+  /** Logical CPU count. */
+  cpuCount?: number;
+  /** Total physical memory, MiB. */
+  totalMemoryMb?: number;
+  /** Free physical memory, MiB. */
+  freeMemoryMb?: number;
+}
+
+/** The subset that never changes for the process lifetime. */
+type StaticHostInfo = Omit<HostInfo, "freeMemoryMb">;
+
+function tryValue<T>(read: () => T | undefined): T | undefined {
+  try {
+    return read();
+  } catch {
+    return undefined;
+  }
+}
+
+function toMb(bytes: number): number {
+  return Math.round(bytes / 1024 / 1024);
+}
+
+function collectStatic(): StaticHostInfo {
+  const cpus = tryValue(() => os.cpus()) ?? [];
+  const model = cpus[0]?.model?.trim().replace(/\s+/g, " ");
+  const version = tryValue(() => os.version())?.slice(0, MAX_OS_VERSION_LENGTH);
+  const totalMemoryMb = tryValue(() => toMb(os.totalmem()));
+
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    nodeVersion: process.version,
+    tauriSidecar: process.env.TANDEM_TAURI_SIDECAR === "1",
+    osRelease: tryValue(() => os.release()) || undefined,
+    osVersion: version || undefined,
+    cpuModel: model || undefined,
+    cpuCount: cpus.length || undefined,
+    totalMemoryMb,
+  };
+}
+
+let cachedStatic: StaticHostInfo | null = null;
+
+/**
+ * Collect the host environment fields. Static values are memoized (`os.cpus()`
+ * is a syscall and this runs on every diagnostics request); free memory is read
+ * fresh each call because it is the only field that moves.
+ */
+export function collectHostInfo(): HostInfo {
+  cachedStatic ??= collectStatic();
+  return { ...cachedStatic, freeMemoryMb: tryValue(() => toMb(os.freemem())) };
+}
+
+/** Test seam — drops the memoized static block. */
+export function _resetHostInfoCache(): void {
+  cachedStatic = null;
+}

--- a/src/server/mcp/output-schemas.ts
+++ b/src/server/mcp/output-schemas.ts
@@ -297,4 +297,14 @@ export const diagnosticsOutputShape = {
   arch: z.string().describe("process.arch"),
   nodeVersion: z.string().describe("process.version"),
   tauriSidecar: z.boolean().describe("True when running as the Tauri desktop sidecar"),
+  // Host facts from `collectHostInfo()` (host-info.ts). Every one is OPTIONAL
+  // by necessity, not politeness: `os.cpus()` returns [] under some
+  // cgroup-restricted containers and `os.version()` can throw, so a required
+  // key here would fail structured-output validation on exactly those hosts.
+  osRelease: z.string().optional().describe("os.release() — e.g. '10.0.26100'"),
+  osVersion: z.string().optional().describe("os.version() — e.g. 'Windows 11 Pro'"),
+  cpuModel: z.string().optional().describe("First CPU's model string"),
+  cpuCount: z.number().optional().describe("Logical CPU count"),
+  totalMemoryMb: z.number().optional().describe("Total physical memory, MiB"),
+  freeMemoryMb: z.number().optional().describe("Free physical memory, MiB"),
 };

--- a/src/server/mcp/routes/diagnostics.ts
+++ b/src/server/mcp/routes/diagnostics.ts
@@ -2,9 +2,10 @@ import os from "node:os";
 import type { Request, Response } from "express";
 import type { DoctorReport, RunDoctorOptions } from "../../../cli/doctor.js";
 import { runDoctor, summarizeDoctorResults } from "../../../cli/doctor.js";
+import type { RedactRoot } from "../../../shared/redact-user-paths.js";
+import { diagnosticsRedactRoots, redactUserPaths } from "../../../shared/redact-user-paths.js";
 import { isLoopback } from "../../auth/middleware.js";
 import { collectHostInfo } from "../host-info.js";
-import { escapeRegex } from "../response.js";
 import type { Handler } from "./_shared.js";
 
 /**
@@ -73,25 +74,30 @@ function scrubDeep(value: unknown, scrub: (s: string) => string): unknown {
 }
 
 /**
- * Replace the user's home directory with `~` everywhere in the report.
+ * Collapse user-identifying paths everywhere in the report.
  *
- * Several checks interpolate absolute app-data paths — `doctor.ts` lines ~1420
- * ("Annotation store dir not yet created (${dir})", a *passing* check on the
- * common first run), ~1434, ~1497 and ~1535 — and `resolveAppDataDir()`
- * resolves those under `C:\Users\<username>\AppData\Local\…` or
- * `/Users/<username>/Library/…`. The username is the leak.
+ * Several checks interpolate the app-data dir — `doctor.ts` ~1420 ("Annotation
+ * store dir not yet created (${dir})", a *passing* check on the common first
+ * run), ~1434, ~1497, ~1535 — and the username is the leak.
  *
  * This mattered less when Copy Diagnostics was the only consumer: a human chose
  * what to paste. The Report-a-bug link prefills a public issue body, which turns
  * that review step into an opt-out, so the redaction happens here instead.
  *
+ * **`$HOME` alone is not enough**, which is why this delegates rather than
+ * doing a one-line prefix swap. `resolveAppDataDir()` (doctor.ts:1386) honours
+ * `TANDEM_APP_DATA_DIR`, `XDG_DATA_HOME` and `LOCALAPPDATA`, any of which can
+ * resolve outside home — a redirected Windows profile, a custom XDG root on
+ * another volume — and those paths still carry the username. Two checks also
+ * interpolate a raw `fs` error (`errMsg` at doctor.ts:1434 and :1541), whose
+ * text embeds an absolute path no prefix list is guaranteed to cover; that is
+ * what `redactUserPaths`' generic second pass is for.
+ *
  * Walks the WHOLE report rather than enumerating `message`/`fix`. The per-check
  * `data` bag is free-form and several checks put the raw directory in it
  * (`annotation-store` carries `data.dir`), so a message-only pass leaves the
  * path on the wire — and enumerating fields means a new string field on
- * `DoctorResult` silently escapes redaction with nothing to fail. Rewriting
- * only the home prefix is safe on any string, so the general walk is both
- * shorter and closed.
+ * `DoctorResult` silently escapes redaction with nothing to fail.
  *
  * Note this is NOT `scrubPathForCaller` (`routes/_shared.ts`): that one is
  * caller-conditional (a loopback caller gets the real path) and reduces to a
@@ -106,27 +112,13 @@ function scrubDeep(value: unknown, scrub: (s: string) => string): unknown {
  * config URLs still make the full report unfit for a LAN caller.
  */
 export function redactHomePaths(report: DoctorReport): DoctorReport {
-  let home: string;
+  let roots: RedactRoot[];
   try {
-    home = os.homedir();
+    roots = diagnosticsRedactRoots(os.homedir(), process.env);
   } catch {
     return report;
   }
-  // Guard against a root/empty homedir, where a blind replace would corrupt
-  // every absolute path in the report. (`length < 2` already covers "/".)
-  if (!home || home.length < 2 || /^[A-Za-z]:[/\\]?$/.test(home)) return report;
-
-  const trimmed = home.replace(/[/\\]+$/, "");
-  const variants = [...new Set([trimmed, trimmed.replace(/\\/g, "/")])];
-  // Windows paths are case-insensitive and the drive letter's case varies by
-  // which API produced the string.
-  const flags = process.platform === "win32" ? "gi" : "g";
-  // The lookahead requires the next character (if any) to be a separator, so a
-  // short home like `/root` cannot swallow the prefix of an unrelated
-  // `/rootfs/...`.
-  const pattern = new RegExp(`(?:${variants.map(escapeRegex).join("|")})(?![^/\\\\])`, flags);
-
-  return scrubDeep(report, (s) => s.replace(pattern, "~")) as DoctorReport;
+  return scrubDeep(report, (s) => redactUserPaths(s, roots)) as DoctorReport;
 }
 
 /**

--- a/src/server/mcp/routes/diagnostics.ts
+++ b/src/server/mcp/routes/diagnostics.ts
@@ -4,6 +4,7 @@ import type { DoctorReport, RunDoctorOptions } from "../../../cli/doctor.js";
 import { runDoctor, summarizeDoctorResults } from "../../../cli/doctor.js";
 import { isLoopback } from "../../auth/middleware.js";
 import { collectHostInfo } from "../host-info.js";
+import { escapeRegex } from "../response.js";
 import type { Handler } from "./_shared.js";
 
 /**
@@ -59,10 +60,6 @@ export function filterDevRepoChecks(report: DoctorReport): DoctorReport {
   };
 }
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 /** Recursively apply `scrub` to every string in a free-form value. */
 function scrubDeep(value: unknown, scrub: (s: string) => string): unknown {
   if (typeof value === "string") return scrub(value);
@@ -88,11 +85,20 @@ function scrubDeep(value: unknown, scrub: (s: string) => string): unknown {
  * what to paste. The Report-a-bug link prefills a public issue body, which turns
  * that review step into an opt-out, so the redaction happens here instead.
  *
- * Scrubs the per-check `data` bag too, not just `message`/`fix`. `data` is
- * free-form and several checks put the raw directory in it (`annotation-store`
- * carries `data.dir`), so a message-only pass leaves the path on the wire — the
- * formatter does not print `data`, but the route's own response is the thing
- * being promised as redacted.
+ * Walks the WHOLE report rather than enumerating `message`/`fix`. The per-check
+ * `data` bag is free-form and several checks put the raw directory in it
+ * (`annotation-store` carries `data.dir`), so a message-only pass leaves the
+ * path on the wire — and enumerating fields means a new string field on
+ * `DoctorResult` silently escapes redaction with nothing to fail. Rewriting
+ * only the home prefix is safe on any string, so the general walk is both
+ * shorter and closed.
+ *
+ * Note this is NOT `scrubPathForCaller` (`routes/_shared.ts`): that one is
+ * caller-conditional (a loopback caller gets the real path) and reduces to a
+ * basename. It would be a no-op here, since this route 403s every non-loopback
+ * caller — and basenaming the report would destroy its diagnostic value. The
+ * adversary is different: not a LAN peer, but the public issue the loopback
+ * user is about to paste into.
  *
  * Applied to the HTTP route ONLY. The `tandem_diagnostics` MCP tool serves an
  * agent that may need to act on the real path, and it does not feed an issue
@@ -107,8 +113,8 @@ export function redactHomePaths(report: DoctorReport): DoctorReport {
     return report;
   }
   // Guard against a root/empty homedir, where a blind replace would corrupt
-  // every absolute path in the report.
-  if (!home || home.length < 2 || home === "/" || /^[A-Za-z]:[/\\]?$/.test(home)) return report;
+  // every absolute path in the report. (`length < 2` already covers "/".)
+  if (!home || home.length < 2 || /^[A-Za-z]:[/\\]?$/.test(home)) return report;
 
   const trimmed = home.replace(/[/\\]+$/, "");
   const variants = [...new Set([trimmed, trimmed.replace(/\\/g, "/")])];
@@ -118,19 +124,9 @@ export function redactHomePaths(report: DoctorReport): DoctorReport {
   // The lookahead requires the next character (if any) to be a separator, so a
   // short home like `/root` cannot swallow the prefix of an unrelated
   // `/rootfs/...`.
-  const pattern = new RegExp(`(?:${variants.map(escapeRegExp).join("|")})(?![^/\\\\])`, flags);
-  const scrub = (s: string): string => s.replace(pattern, "~");
+  const pattern = new RegExp(`(?:${variants.map(escapeRegex).join("|")})(?![^/\\\\])`, flags);
 
-  return {
-    ...report,
-    error: report.error ? scrub(report.error) : report.error,
-    results: report.results.map((res) => ({
-      ...res,
-      message: scrub(res.message),
-      ...(res.fix ? { fix: scrub(res.fix) } : {}),
-      ...(res.data ? { data: scrubDeep(res.data, scrub) as Record<string, unknown> } : {}),
-    })),
-  };
+  return scrubDeep(report, (s) => s.replace(pattern, "~")) as DoctorReport;
 }
 
 /**

--- a/src/server/mcp/routes/diagnostics.ts
+++ b/src/server/mcp/routes/diagnostics.ts
@@ -1,7 +1,9 @@
+import os from "node:os";
 import type { Request, Response } from "express";
 import type { DoctorReport, RunDoctorOptions } from "../../../cli/doctor.js";
 import { runDoctor, summarizeDoctorResults } from "../../../cli/doctor.js";
 import { isLoopback } from "../../auth/middleware.js";
+import { collectHostInfo } from "../host-info.js";
 import type { Handler } from "./_shared.js";
 
 /**
@@ -57,13 +59,89 @@ export function filterDevRepoChecks(report: DoctorReport): DoctorReport {
   };
 }
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Recursively apply `scrub` to every string in a free-form value. */
+function scrubDeep(value: unknown, scrub: (s: string) => string): unknown {
+  if (typeof value === "string") return scrub(value);
+  if (Array.isArray(value)) return value.map((v) => scrubDeep(v, scrub));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, scrubDeep(v, scrub)]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Replace the user's home directory with `~` everywhere in the report.
+ *
+ * Several checks interpolate absolute app-data paths — `doctor.ts` lines ~1420
+ * ("Annotation store dir not yet created (${dir})", a *passing* check on the
+ * common first run), ~1434, ~1497 and ~1535 — and `resolveAppDataDir()`
+ * resolves those under `C:\Users\<username>\AppData\Local\…` or
+ * `/Users/<username>/Library/…`. The username is the leak.
+ *
+ * This mattered less when Copy Diagnostics was the only consumer: a human chose
+ * what to paste. The Report-a-bug link prefills a public issue body, which turns
+ * that review step into an opt-out, so the redaction happens here instead.
+ *
+ * Scrubs the per-check `data` bag too, not just `message`/`fix`. `data` is
+ * free-form and several checks put the raw directory in it (`annotation-store`
+ * carries `data.dir`), so a message-only pass leaves the path on the wire — the
+ * formatter does not print `data`, but the route's own response is the thing
+ * being promised as redacted.
+ *
+ * Applied to the HTTP route ONLY. The `tandem_diagnostics` MCP tool serves an
+ * agent that may need to act on the real path, and it does not feed an issue
+ * form. This does not change the route's loopback posture — PIDs, ports and
+ * config URLs still make the full report unfit for a LAN caller.
+ */
+export function redactHomePaths(report: DoctorReport): DoctorReport {
+  let home: string;
+  try {
+    home = os.homedir();
+  } catch {
+    return report;
+  }
+  // Guard against a root/empty homedir, where a blind replace would corrupt
+  // every absolute path in the report.
+  if (!home || home.length < 2 || home === "/" || /^[A-Za-z]:[/\\]?$/.test(home)) return report;
+
+  const trimmed = home.replace(/[/\\]+$/, "");
+  const variants = [...new Set([trimmed, trimmed.replace(/\\/g, "/")])];
+  // Windows paths are case-insensitive and the drive letter's case varies by
+  // which API produced the string.
+  const flags = process.platform === "win32" ? "gi" : "g";
+  // The lookahead requires the next character (if any) to be a separator, so a
+  // short home like `/root` cannot swallow the prefix of an unrelated
+  // `/rootfs/...`.
+  const pattern = new RegExp(`(?:${variants.map(escapeRegExp).join("|")})(?![^/\\\\])`, flags);
+  const scrub = (s: string): string => s.replace(pattern, "~");
+
+  return {
+    ...report,
+    error: report.error ? scrub(report.error) : report.error,
+    results: report.results.map((res) => ({
+      ...res,
+      message: scrub(res.message),
+      ...(res.fix ? { fix: scrub(res.fix) } : {}),
+      ...(res.data ? { data: scrubDeep(res.data, scrub) as Record<string, unknown> } : {}),
+    })),
+  };
+}
+
 /**
  * GET /api/diagnostics — embedded `tandem doctor` for the client's
  * "Copy diagnostics" button.
  *
- * Loopback-only, unconditionally: the report embeds absolute paths (which
- * include the username) and PIDs — and the unfiltered collector additionally
- * sees MCP config URLs. This is deliberately stricter than /api/info's
+ * Loopback-only, unconditionally: the report embeds absolute paths and PIDs —
+ * and the unfiltered collector additionally sees MCP config URLs. (Home-dir
+ * paths are `~`-redacted by {@link redactHomePaths} before they go on the wire,
+ * because this payload reaches a public issue body; that narrows the leak, it
+ * does not change the posture.) This is deliberately stricter than /api/info's
  * per-field stripping — there is no useful LAN subset of this report. The
  * hand-rolled check predates #1293, which made `assertLoopbackForMutation`
  * unconditional; either would work now, and this one is kept only because a
@@ -92,15 +170,12 @@ export function makeDiagnosticsHandler(deps: DiagnosticsHandlerDeps): Handler {
           inFlight = null;
         });
       }
-      const report = filterDevRepoChecks(await inFlight);
+      const report = redactHomePaths(filterDevRepoChecks(await inFlight));
       res.json({
         report,
         version: deps.version,
         transport: deps.transport,
-        platform: process.platform,
-        arch: process.arch,
-        nodeVersion: process.version,
-        tauriSidecar: process.env.TANDEM_TAURI_SIDECAR === "1",
+        ...collectHostInfo(),
       });
     } catch (err) {
       // Check crashes propagate out of runDoctor (only runDoctorCli converts

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -1,0 +1,42 @@
+/**
+ * Wire types shared by the diagnostics producers and their client.
+ *
+ * Type-only, and deliberately free of `node:os` so the client bundle can import
+ * it: the server fills these in (`src/server/mcp/host-info.ts`), the client
+ * formats them (`src/client/utils/diagnostics.ts`), and the zod shape in
+ * `src/server/mcp/output-schemas.ts` describes them at runtime. Before this
+ * file the interface was hand-copied on both sides, which made the client copy
+ * the one most likely to drift — nothing type-checked it against the server.
+ */
+
+/**
+ * Host environment facts attached to every diagnostics payload.
+ *
+ * Everything below `tauriSidecar` is OPTIONAL by necessity, not politeness:
+ * `os.cpus()` returns `[]` under some cgroup-restricted containers and
+ * `os.version()` can throw, so a required key would fail structured-output
+ * validation on exactly those hosts. The formatter drops each field
+ * individually rather than printing `undefined`.
+ *
+ * Privacy: this reaches a public GitHub issue. See the collector's docstring
+ * for the list of things deliberately absent (hostname, username, home path,
+ * network interfaces, locale, timezone).
+ */
+export interface HostInfo {
+  platform: string;
+  arch: string;
+  nodeVersion: string;
+  tauriSidecar: boolean;
+  /** `os.release()` — e.g. "10.0.26100", "23.5.0". */
+  osRelease?: string;
+  /** `os.version()` — e.g. "Windows 11 Pro", or a kernel banner. */
+  osVersion?: string;
+  /** First CPU's model string, whitespace-collapsed. */
+  cpuModel?: string;
+  /** Logical CPU count. */
+  cpuCount?: number;
+  /** Total physical memory, MiB. */
+  totalMemoryMb?: number;
+  /** Free physical memory, MiB. */
+  freeMemoryMb?: number;
+}

--- a/src/shared/redact-user-paths.ts
+++ b/src/shared/redact-user-paths.ts
@@ -1,0 +1,113 @@
+/**
+ * Collapse user-identifying directory prefixes out of a string.
+ *
+ * The username is the leak: `/Users/bryan/...`, `C:\Users\bryan\...`,
+ * `/home/bryan/...`. Callers that publish text a user did not individually
+ * review — a prefilled public issue body, a crash report — need this.
+ *
+ * Two passes, because neither alone is sufficient:
+ *
+ *  1. **Literal roots.** `$HOME` is the common case, but not the only one:
+ *     Tandem's app-data dir honours `TANDEM_APP_DATA_DIR`, `XDG_DATA_HOME` and
+ *     `LOCALAPPDATA`, any of which can point outside home (redirected Windows
+ *     profiles, a custom XDG root on another volume). A caller passes those in
+ *     as extra roots.
+ *  2. **Generic user segments**, for paths under no root we know — another
+ *     account's directory, or a path that arrived inside a raw `fs` error
+ *     message (`EACCES: permission denied, scandir '/home/bryan/…'`), which no
+ *     prefix list can be relied on to cover.
+ *
+ * Each root match requires a separator or end-of-string after it, so a short
+ * root like `/root` cannot swallow the prefix of an unrelated `/rootfs/...`.
+ */
+
+export interface RedactRoot {
+  /** Absolute path to collapse. Ignored when empty or degenerate. */
+  path: string;
+  /** What to replace it with, e.g. `~` or `<app-data>`. */
+  as: string;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Reject roots so short that replacing them would corrupt unrelated paths. */
+function isUsableRoot(path: string): boolean {
+  return path.length > 1 && path !== "/" && !/^[A-Za-z]:[/\\]?$/.test(path);
+}
+
+function normalize(path: string): string {
+  return path.replace(/[/\\]+$/, "");
+}
+
+/**
+ * Replace `roots` and then any remaining user directory segment.
+ *
+ * A root nested inside another is dropped rather than applied: an app-data dir
+ * that sits inside `$HOME` should read `~/.local/share/tandem`, which is both
+ * safe and more useful than an opaque placeholder.
+ */
+export function redactUserPaths(input: string, roots: RedactRoot[]): string {
+  const seen = new Set<string>();
+  const usable: RedactRoot[] = [];
+
+  for (const root of roots) {
+    if (!root.path) continue;
+    const path = normalize(root.path);
+    if (!isUsableRoot(path) || seen.has(path)) continue;
+    seen.add(path);
+    usable.push({ path, as: root.as });
+  }
+
+  // Drop any root nested inside another: a default-located app-data dir should
+  // render `~/.local/share/tandem`, which is both safe and more useful than an
+  // opaque `<app-data>`. Only the outermost root survives.
+  const outermost = usable.filter(
+    (root) =>
+      !usable.some(
+        (other) =>
+          other !== root &&
+          (root.path.startsWith(`${other.path}/`) || root.path.startsWith(`${other.path}\\`)),
+      ),
+  );
+
+  // Longest first among the survivors, which are now mutually disjoint; this
+  // only matters for deterministic output.
+  outermost.sort((a, b) => b.path.length - a.path.length);
+
+  let out = input;
+  for (const { path, as } of outermost) {
+    const variants = [...new Set([path, path.replace(/\\/g, "/")])];
+    // Windows paths are case-insensitive, and the drive letter's case varies by
+    // which API produced the string.
+    const flags = process.platform === "win32" ? "gi" : "g";
+    const pattern = new RegExp(`(?:${variants.map(escapeRegExp).join("|")})(?![^/\\\\])`, flags);
+    out = out.replace(pattern, as);
+  }
+
+  // Anything still carrying a user directory came from a path we were not told
+  // about — most often the absolute path inside a raw `fs` error message.
+  return out
+    .replace(/(\/Users\/)[^/\\]+/g, "$1[user]")
+    .replace(/(\/home\/)[^/\\]+/g, "$1[user]")
+    .replace(/([A-Za-z]:\\Users\\)[^\\]+/g, "$1[user]");
+}
+
+/**
+ * The roots worth redacting from a Tandem diagnostics report: every source
+ * `resolveAppDataDir()` consults, plus both spellings of the home directory
+ * (`os.homedir()` and `$HOME`/`%USERPROFILE%` can disagree under `sudo` or a
+ * launcher that overrides the environment, and a mismatch would otherwise
+ * defeat the whole pass).
+ */
+export function diagnosticsRedactRoots(homedir: string, env: NodeJS.ProcessEnv): RedactRoot[] {
+  return [
+    { path: homedir, as: "~" },
+    { path: env.HOME ?? "", as: "~" },
+    { path: env.USERPROFILE ?? "", as: "~" },
+    { path: env.TANDEM_APP_DATA_DIR ?? "", as: "<app-data>" },
+    { path: env.XDG_DATA_HOME ?? "", as: "<app-data>" },
+    { path: env.LOCALAPPDATA ?? "", as: "<app-data>" },
+  ];
+}

--- a/tests/client/bug-report-url.test.ts
+++ b/tests/client/bug-report-url.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUG_REPORT_BODY_HEADING,
+  buildBugReportUrl,
+  MAX_ISSUE_URL_LENGTH,
+} from "../../src/client/utils/diagnostics";
+import { TANDEM_ISSUES_NEW_URL } from "../../src/shared/constants";
+
+/**
+ * Unit tests for the Report-a-bug href builder. The link's whole error strategy
+ * is "fall back to the bare issue URL", so most of these assert that a bad
+ * input degrades to a working link rather than throwing or producing a URL
+ * GitHub will reject.
+ */
+
+function bodyOf(url: string): string {
+  const body = new URL(url).searchParams.get("body");
+  expect(body).not.toBeNull();
+  return body as string;
+}
+
+describe("buildBugReportUrl", () => {
+  it.each([
+    [undefined],
+    [null],
+    [""],
+    ["   \n\t  "],
+  ])("returns the bare issue URL for %p", (input) => {
+    expect(buildBugReportUrl(input)).toBe(TANDEM_ISSUES_NEW_URL);
+  });
+
+  it("prefills two blank lines, the heading, then the fenced report", () => {
+    const url = buildBugReportUrl("Tandem v1.2.3 (http)\nwin32/x64");
+    expect(bodyOf(url)).toBe(
+      `\n\n${BUG_REPORT_BODY_HEADING}\n\n~~~\nTandem v1.2.3 (http)\nwin32/x64\n~~~`,
+    );
+  });
+
+  it("starts the body with blank lines so the user has somewhere to type", () => {
+    expect(bodyOf(buildBugReportUrl("x"))).toMatch(/^\n\n\S/);
+  });
+
+  it("fences with tildes, since doctor fix strings contain backticks", () => {
+    // e.g. doctor.ts's "run via `npx`" — a ``` fence would not be escape-safe.
+    const body = bodyOf(buildBugReportUrl("[warn] mcp — run via `npx` instead"));
+    expect(body).toContain("~~~\n[warn] mcp — run via `npx` instead\n~~~");
+    expect(body).not.toContain("```");
+  });
+
+  it("points at the same repo as the bare URL", () => {
+    expect(buildBugReportUrl("x").startsWith(`${TANDEM_ISSUES_NEW_URL}?`)).toBe(true);
+  });
+
+  describe("truncation", () => {
+    // Em dashes encode to 9 chars each and newlines to 3, so this is far longer
+    // encoded than it looks — which is exactly the bug the cap has to survive.
+    const huge = [
+      "Tandem v1.2.3 (http)",
+      "win32/x64, Node v22.0.0",
+      "OS: Windows 11 Pro (10.0.26100)",
+      ...Array.from({ length: 400 }, (_, i) => `[ok]   check-${i} — everything is fine here`),
+    ].join("\n");
+
+    it("keeps the final URL within the cap", () => {
+      const url = buildBugReportUrl(huge);
+      expect(url.length).toBeGreaterThan(0);
+      expect(url.length).toBeLessThanOrEqual(MAX_ISSUE_URL_LENGTH);
+    });
+
+    it("measures the encoded length, not the raw character count", () => {
+      // A raw-length cap would have kept ~6000 chars of source, which encodes to
+      // well over the limit. Assert the retained source is meaningfully shorter.
+      const body = bodyOf(buildBugReportUrl(huge));
+      expect(body.length).toBeLessThan(MAX_ISSUE_URL_LENGTH);
+    });
+
+    it("keeps the header lines and marks the cut", () => {
+      const body = bodyOf(buildBugReportUrl(huge));
+      expect(body).toContain(BUG_REPORT_BODY_HEADING);
+      expect(body).toContain("Tandem v1.2.3 (http)");
+      expect(body).toContain("OS: Windows 11 Pro (10.0.26100)");
+      expect(body).toContain("truncated");
+      expect(body.trimEnd().endsWith("~~~")).toBe(true);
+    });
+
+    it("drops lines from the tail, not the head", () => {
+      const body = bodyOf(buildBugReportUrl(huge));
+      expect(body).toContain("check-0");
+      expect(body).not.toContain("check-399");
+    });
+
+    it("falls back to the bare URL when not even one line fits", () => {
+      expect(buildBugReportUrl("x".repeat(MAX_ISSUE_URL_LENGTH * 2))).toBe(TANDEM_ISSUES_NEW_URL);
+    });
+  });
+
+  it("returns the bare URL rather than throwing on a lone surrogate", () => {
+    // encodeURIComponent throws URIError here. Doctor messages interpolate
+    // OS-supplied strings, so this is reachable, and an uncaught throw inside
+    // the prefetch continuation would kill the feature silently.
+    const url = buildBugReportUrl(`Tandem v1.2.3\nbroken: \uD800`);
+    expect(url).toBe(TANDEM_ISSUES_NEW_URL);
+  });
+
+  it("always produces a parseable URL", () => {
+    for (const input of ["short", "a\nb\nc", "with spaces & ampersands ?=#", "…unicode…"]) {
+      expect(() => new URL(buildBugReportUrl(input))).not.toThrow();
+    }
+  });
+});

--- a/tests/client/bug-report-url.test.ts
+++ b/tests/client/bug-report-url.test.ts
@@ -47,6 +47,26 @@ describe("buildBugReportUrl", () => {
     expect(body).not.toContain("```");
   });
 
+  it("lengthens the fence so report content cannot break out of it", () => {
+    // Not hypothetical: doctor.ts:1520 interpolates raw `store.lock` bytes into
+    // a message, and stripControlChars deliberately preserves newlines. A lock
+    // file containing a `~~~` line would otherwise close the fence early and
+    // let the rest render as markdown in a public issue.
+    const hostile = 'lock has unparseable content: "\n~~~\n<img src=x>"';
+    const body = bodyOf(buildBugReportUrl(hostile));
+    const fence = body.split("\n").find((l) => /^~+$/.test(l)) as string;
+
+    expect(fence.length).toBeGreaterThan(3);
+    // Exactly one opening and one closing fence of that length.
+    expect(body.split("\n").filter((l) => l === fence)).toHaveLength(2);
+    // And the hostile run is strictly shorter, so it cannot close them.
+    expect(body).toContain("~~~\n<img src=x>");
+  });
+
+  it("keeps the default fence when the report contains no tildes", () => {
+    expect(bodyOf(buildBugReportUrl("plain report"))).toContain("~~~\nplain report\n~~~");
+  });
+
   it("points at the same repo as the bare URL", () => {
     expect(buildBugReportUrl("x").startsWith(`${TANDEM_ISSUES_NEW_URL}?`)).toBe(true);
   });

--- a/tests/client/diagnostics-fetch.test.ts
+++ b/tests/client/diagnostics-fetch.test.ts
@@ -59,6 +59,41 @@ describe("fetchDiagnostics", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("does not join an in-flight run that is already too old for the caller", async () => {
+    // The scenario: a hover starts a run, the user fixes the problem while it
+    // is still going, then clicks Copy Diagnostics. Joining would hand them
+    // probes that predate the fix. A fresh run must be chained instead.
+    let releaseFirst: (r: Response) => void = () => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          releaseFirst = resolve;
+        }),
+    );
+
+    const hover = fetchDiagnostics();
+    await vi.advanceTimersByTimeAsync(1_000); // the run is now 1s old
+
+    const click = fetchDiagnostics({ maxAgeMs: 0 });
+    releaseFirst(jsonResponse({ version: "stale" }));
+
+    await expect(hover).resolves.toEqual({ ok: true, payload: { version: "stale" } });
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(click).resolves.toEqual({ ok: true, payload: { version: "1.2.3" } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("still joins an in-flight run that is fresh enough", async () => {
+    const both = Promise.all([
+      fetchDiagnostics({ maxAgeMs: 0 }),
+      fetchDiagnostics({ maxAgeMs: 0 }),
+    ]);
+    await both;
+    // Both asked for maximum freshness, but the second arrives in the same tick
+    // as the first started — no staleness to avoid, so one run serves both.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("refetches once the cache has aged out", async () => {
     await fetchDiagnostics();
     vi.advanceTimersByTime(20_000);

--- a/tests/client/diagnostics-fetch.test.ts
+++ b/tests/client/diagnostics-fetch.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetDiagnosticsCache, fetchDiagnostics } from "../../src/client/utils/diagnostics-fetch";
+
+/**
+ * The point of this module is that `GET /api/diagnostics` is expensive — it
+ * runs the whole `tandem doctor` collector, including an `npm ls -g`
+ * subprocess. These tests pin the two properties that keep it from running
+ * more than it must, and the failure mapping the About tab's error messages
+ * depend on.
+ */
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  _resetDiagnosticsCache();
+  vi.useFakeTimers();
+  fetchMock = vi.fn(async () => jsonResponse({ version: "1.2.3" }));
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  _resetDiagnosticsCache();
+});
+
+describe("fetchDiagnostics", () => {
+  it("returns the parsed payload on success", async () => {
+    const result = await fetchDiagnostics();
+    expect(result).toEqual({ ok: true, payload: { version: "1.2.3" } });
+  });
+
+  it("joins a request already in flight instead of starting a second", async () => {
+    const both = Promise.all([fetchDiagnostics(), fetchDiagnostics()]);
+    await both;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a recent success — the hover-then-click path costs one run", async () => {
+    // This is the regression the TTL exists for: a hover primes the link, then
+    // the user clicks Copy Diagnostics seconds later. The two requests do not
+    // overlap, so in-flight sharing alone would run the collector twice.
+    await fetchDiagnostics();
+    vi.advanceTimersByTime(5_000);
+    await fetchDiagnostics();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches once the cache has aged out", async () => {
+    await fetchDiagnostics();
+    vi.advanceTimersByTime(20_000);
+    await fetchDiagnostics();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache failures — a retry must not look broken for 15s", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("network"));
+    expect(await fetchDiagnostics()).toEqual({ ok: false, reason: "unreachable" });
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ version: "9.9.9" }));
+    expect(await fetchDiagnostics()).toEqual({ ok: true, payload: { version: "9.9.9" } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps a network throw to 'unreachable' and a bad status to 'server'", async () => {
+    // The About tab shows two different messages off this distinction: "is it
+    // running?" misdirects when the server answered.
+    fetchMock.mockRejectedValueOnce(new TypeError("network"));
+    expect(await fetchDiagnostics()).toEqual({ ok: false, reason: "unreachable" });
+
+    _resetDiagnosticsCache();
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false));
+    expect(await fetchDiagnostics()).toEqual({ ok: false, reason: "server" });
+  });
+
+  it("maps unparseable JSON to 'server', not 'unreachable'", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("bad json");
+      },
+    } as unknown as Response);
+    expect(await fetchDiagnostics()).toEqual({ ok: false, reason: "server" });
+  });
+});

--- a/tests/client/diagnostics-fetch.test.ts
+++ b/tests/client/diagnostics-fetch.test.ts
@@ -50,6 +50,15 @@ describe("fetchDiagnostics", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("maxAgeMs: 0 bypasses the cache — the explicit click must see current state", async () => {
+    // A user who reads the report, fixes the problem, and clicks again must not
+    // be handed the pre-fix report.
+    await fetchDiagnostics();
+    vi.advanceTimersByTime(1_000);
+    await fetchDiagnostics({ maxAgeMs: 0 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("refetches once the cache has aged out", async () => {
     await fetchDiagnostics();
     vi.advanceTimersByTime(20_000);

--- a/tests/client/diagnostics-format.test.ts
+++ b/tests/client/diagnostics-format.test.ts
@@ -167,12 +167,17 @@ describe("formatDiagnostics — host information", () => {
     expect(hostLines({ cpuCount: 4 })).toEqual(["CPU: x4"]);
   });
 
-  it("strips control characters from OS and CPU strings", () => {
+  it("strips control characters from every OS-supplied string", () => {
+    // All three come from the host and all three reach a terminal paste and a
+    // public issue body — osRelease is not exempt.
     const lines = hostLines({
       osVersion: "Windows\x1b[31m 11",
+      osRelease: "10.0\x1b]0;spoofed\x07.26100",
       cpuModel: "Fake\x07 CPU",
     });
-    expect(lines).toEqual(["OS: Windows[31m 11", "CPU: Fake CPU"]);
+    expect(lines).toEqual(["OS: Windows[31m 11 (10.0]0;spoofed.26100)", "CPU: Fake CPU"]);
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: asserting their absence
+    expect(lines.join("\n")).not.toMatch(/[\x00-\x08\x0b-\x1f\x7f]/);
   });
 
   it("collapses whitespace-only host strings rather than printing empty labels", () => {

--- a/tests/client/diagnostics-format.test.ts
+++ b/tests/client/diagnostics-format.test.ts
@@ -229,6 +229,26 @@ describe("summarizeUserAgent", () => {
     ).toBe("HeadlessChrome 141");
   });
 
+  it("falls back to WebKit for the macOS desktop WebView", () => {
+    // The Tauri build is the primary distribution, and macOS WKWebView sends no
+    // Chrome/, no Edg/, and often no "Version/… Safari/" token. Without the
+    // AppleWebKit fallback the Browser line vanishes for exactly the users
+    // whose engine version a bug report most needs.
+    expect(
+      summarizeUserAgent(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)",
+      ),
+    ).toBe("WebKit 605");
+  });
+
+  it("still prefers a named browser over the WebKit fallback", () => {
+    expect(
+      summarizeUserAgent(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+      ),
+    ).toBe("Chrome 141");
+  });
+
   it("returns an empty string for an unrecognized agent, which drops the line", () => {
     expect(summarizeUserAgent("")).toBe("");
     expect(summarizeUserAgent("SomeCrawler/1.0")).toBe("");

--- a/tests/client/diagnostics-format.test.ts
+++ b/tests/client/diagnostics-format.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "vitest";
 import type { DiagnosticsPayload } from "../../src/client/utils/diagnostics";
-import { formatDiagnostics } from "../../src/client/utils/diagnostics";
+import {
+  formatDiagnostics,
+  formatMemoryMb,
+  summarizeUserAgent,
+} from "../../src/client/utils/diagnostics";
 
 /**
  * Unit tests for the pure clipboard formatter behind the About tab's
  * "Copy diagnostics" button (extract-over-mount: the button is thin glue,
  * the formatter carries the behavior).
+ *
+ * NOTE: `makePayload()` deliberately carries NONE of the optional host fields
+ * (osRelease, osVersion, cpuModel, cpuCount, memory). Every assertion below
+ * therefore doubles as the graceful-degradation contract: a payload from an
+ * older server, or from a host where the `os.*` reads failed, must format
+ * exactly as it did before those fields existed. Supply the host fields
+ * per-case via `overrides` — never by widening these defaults.
  */
 
 function makePayload(overrides: Partial<DiagnosticsPayload> = {}): DiagnosticsPayload {
@@ -94,5 +105,132 @@ describe("formatDiagnostics", () => {
     expect(text).toContain("fix: delete [2Jit");
     // biome-ignore lint/suspicious/noControlCharactersInRegex: asserting their absence
     expect(text).not.toMatch(/[\x00-\x08\x0b-\x1f\x7f]/);
+  });
+
+  it("emits no host lines when the payload carries none (degradation contract)", () => {
+    // The whole point: an old server sends only the original seven fields.
+    const lines = formatDiagnostics(makePayload()).split("\n");
+    expect(lines[0]).toBe("Tandem v1.2.3 (http)");
+    expect(lines[1]).toBe("win32/x64, Node v22.0.0");
+    // Third line is the blank separator before the check list — nothing between.
+    expect(lines[2]).toBe("");
+  });
+});
+
+describe("formatDiagnostics — host information", () => {
+  const allHostFields: Partial<DiagnosticsPayload> = {
+    osRelease: "10.0.26100",
+    osVersion: "Windows 11 Pro",
+    cpuModel: "AMD Ryzen 7 5800X 8-Core Processor",
+    cpuCount: 16,
+    totalMemoryMb: 32768,
+    freeMemoryMb: 6247,
+  };
+
+  function hostLines(overrides: Partial<DiagnosticsPayload>, browser?: string): string[] {
+    const text = formatDiagnostics(makePayload(overrides), browser ? { browser } : undefined);
+    // Everything between the fixed line 2 and the blank separator.
+    return text.split("\n").slice(2, text.split("\n").indexOf(""));
+  }
+
+  it("renders OS, hardware, and browser lines when everything is present", () => {
+    expect(hostLines(allHostFields, "Chrome 141")).toEqual([
+      "OS: Windows 11 Pro (10.0.26100)",
+      "CPU: AMD Ryzen 7 5800X 8-Core Processor x16, RAM: 32.0 GB total, 6.1 GB free",
+      "Browser: Chrome 141",
+    ]);
+  });
+
+  it("keeps the first two lines untouched when host fields are present", () => {
+    const lines = formatDiagnostics(makePayload(allHostFields)).split("\n");
+    expect(lines[0]).toBe("Tandem v1.2.3 (http)");
+    expect(lines[1]).toBe("win32/x64, Node v22.0.0");
+  });
+
+  it.each([
+    [{ osVersion: "Windows 11 Pro" }, "OS: Windows 11 Pro"],
+    [{ osRelease: "10.0.26100" }, "OS: 10.0.26100"],
+    [{ cpuModel: "Apple M2 Pro" }, "CPU: Apple M2 Pro"],
+    [{ cpuCount: 12 }, "CPU: x12"],
+    [{ totalMemoryMb: 16384 }, "RAM: 16.0 GB total"],
+    [{ freeMemoryMb: 2048 }, "RAM: 2.0 GB free"],
+  ])("renders %o as a single line", (overrides, expected) => {
+    expect(hostLines(overrides)).toEqual([expected]);
+  });
+
+  it("combines CPU and RAM onto one line", () => {
+    expect(hostLines({ cpuCount: 4, totalMemoryMb: 8192 })).toEqual(["CPU: x4, RAM: 8.0 GB total"]);
+  });
+
+  it("omits the browser line when the summary is empty or absent", () => {
+    expect(hostLines({ cpuCount: 4 }, "")).toEqual(["CPU: x4"]);
+    expect(hostLines({ cpuCount: 4 })).toEqual(["CPU: x4"]);
+  });
+
+  it("strips control characters from OS and CPU strings", () => {
+    const lines = hostLines({
+      osVersion: "Windows\x1b[31m 11",
+      cpuModel: "Fake\x07 CPU",
+    });
+    expect(lines).toEqual(["OS: Windows[31m 11", "CPU: Fake CPU"]);
+  });
+
+  it("collapses whitespace-only host strings rather than printing empty labels", () => {
+    expect(hostLines({ osVersion: "   ", cpuModel: "  " })).toEqual([]);
+  });
+});
+
+describe("formatMemoryMb", () => {
+  it.each([
+    [32768, "32.0 GB"],
+    [12288, "12.0 GB"],
+    [6247, "6.1 GB"],
+    [1024, "1.0 GB"],
+    [512, "512 MB"],
+  ])("formats %i MiB as %s", (mb, expected) => {
+    expect(formatMemoryMb(mb)).toBe(expected);
+  });
+});
+
+describe("summarizeUserAgent", () => {
+  it.each([
+    [
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+      "Chrome 141",
+    ],
+    [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15",
+      "Safari 18",
+    ],
+    ["Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0", "Firefox 133"],
+  ])("summarizes %s", (ua, expected) => {
+    expect(summarizeUserAgent(ua)).toBe(expected);
+  });
+
+  it("prefers the specific engine over the ones its UA impersonates", () => {
+    // Edge's UA contains "Chrome", which contains "Safari". Order matters.
+    expect(
+      summarizeUserAgent(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36 Edg/141.0.0.0",
+      ),
+    ).toBe("Edge 141");
+    expect(
+      summarizeUserAgent(
+        "Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 OPR/125.0.0.0",
+      ),
+    ).toBe("Opera 125");
+  });
+
+  it("recognizes HeadlessChrome, which has no word boundary before 'Chrome'", () => {
+    expect(
+      summarizeUserAgent(
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/141.0.0.0 Safari/537.36",
+      ),
+    ).toBe("HeadlessChrome 141");
+  });
+
+  it("returns an empty string for an unrecognized agent, which drops the line", () => {
+    expect(summarizeUserAgent("")).toBe("");
+    expect(summarizeUserAgent("SomeCrawler/1.0")).toBe("");
   });
 });

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -214,7 +214,14 @@ test("settings dialog sections and About panel reflect the redesign closeout", a
   await expect(about).toContainText("sessions");
   await expect(about).toContainText("Token rotated");
   await expect(modal.locator("[data-testid='settings-modal-view-changelog-btn']")).toBeVisible();
-  await expect(page.getByRole("link", { name: "Report a bug" })).toBeVisible();
+  // The href is upgraded in place once the hover-primed diagnostics prefetch
+  // lands. Assert only what holds in BOTH states — a `body=` assertion would
+  // depend on a real `runDoctor` (npm ls -g, port probes) finishing in time and
+  // would flake on a loaded runner. The prefill itself is unit-tested in
+  // tests/client/bug-report-url.test.ts.
+  const reportBug = page.getByRole("link", { name: "Report a bug" });
+  await expect(reportBug).toBeVisible();
+  await expect(reportBug).toHaveAttribute("href", /\/issues\/new/);
 });
 
 test("selection toolbar toggle persists and drives toolbar visibility", async ({ page }) => {

--- a/tests/server/diagnostics-route.test.ts
+++ b/tests/server/diagnostics-route.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { DoctorReport, DoctorResult } from "../../src/cli/doctor.js";
 import {
@@ -85,6 +87,52 @@ describe("GET /api/diagnostics — loopback happy path", () => {
     expect(report.ok).toBe(true);
   });
 
+  it("emits exactly the allowed key set — no hostname, username, or home path", async () => {
+    // This payload reaches a public GitHub issue (Copy Diagnostics puts it on
+    // the clipboard; Report-a-bug prefills it into an issue body), so the key
+    // set is a privacy contract rather than a convenience. Asserting the whole
+    // set — instead of `not.toContain(os.hostname())`, which flakes whenever
+    // CI's hostname is a common substring — is what catches an accidental
+    // `hostname` / `homedir` / `env` field added to `collectHostInfo`.
+    const collect = vi.fn(async () => makeReport([result("node-version", "pass")]));
+    const res = makeMockRes();
+
+    await makeHandler(collect)(makeMockReq("127.0.0.1"), res, () => {});
+
+    expect(Object.keys(res._body as object).sort()).toEqual([
+      "arch",
+      "cpuCount",
+      "cpuModel",
+      "freeMemoryMb",
+      "nodeVersion",
+      "osRelease",
+      "osVersion",
+      "platform",
+      "report",
+      "tauriSidecar",
+      "totalMemoryMb",
+      "transport",
+      "version",
+    ]);
+  });
+
+  it("types the optional host fields when present, without pinning values", async () => {
+    // CI containers legitimately omit cpuModel/cpuCount (`os.cpus()` returns []),
+    // so assert shape rather than content.
+    const res = makeMockRes();
+    await makeHandler(async () => makeReport([]))(makeMockReq("127.0.0.1"), res, () => {});
+    const body = res._body as Record<string, unknown>;
+
+    for (const key of ["osRelease", "osVersion", "cpuModel"]) {
+      if (body[key] !== undefined) expect(typeof body[key]).toBe("string");
+    }
+    for (const key of ["cpuCount", "totalMemoryMb", "freeMemoryMb"]) {
+      if (body[key] !== undefined) expect(typeof body[key]).toBe("number");
+    }
+    // os.version() is bounded so a long kernel banner can't dominate the report.
+    if (typeof body.osVersion === "string") expect(body.osVersion.length).toBeLessThanOrEqual(120);
+  });
+
   it("threads the live ports into the collector", async () => {
     const collect = vi.fn(async () => makeReport([]));
     const handler = makeHandler(collect);
@@ -92,6 +140,85 @@ describe("GET /api/diagnostics — loopback happy path", () => {
     await handler(makeMockReq("::1"), makeMockRes(), () => {});
 
     expect(collect).toHaveBeenCalledExactlyOnceWith({ wsPort: 1234, mcpPort: 5678 });
+  });
+});
+
+describe("GET /api/diagnostics — home-path redaction", () => {
+  it("replaces the home directory with ~ in messages and fixes", async () => {
+    // Several doctor checks interpolate the app-data dir, which sits under the
+    // user's home and therefore carries their username — including on a PASSING
+    // check that fires on the common first run.
+    const home = os.homedir();
+    const dir = path.join(home, "AppData", "Local", "tandem", "annotations");
+    const collect = async () =>
+      makeReport([
+        {
+          check: "annotation-store",
+          status: "warn",
+          message: `Annotation store dir not yet created (${dir})`,
+          fix: `Check permissions on ${dir}`,
+          // The `data` bag is free-form and the real annotation-store check puts
+          // the raw directory in it. A message-only redaction leaves the
+          // username on the wire — this is why the assertion below stringifies
+          // the WHOLE body rather than checking the two obvious fields.
+          data: { dir, docCount: 0, nested: { paths: [dir] } },
+        },
+      ]);
+    const res = makeMockRes();
+
+    await makeHandler(collect)(makeMockReq("127.0.0.1"), res, () => {});
+
+    const wire = JSON.stringify(res._body);
+    expect(wire).not.toContain(home);
+    const [only] = (res._body as { report: DoctorReport }).report.results;
+    expect(only.message).toContain("~");
+    expect(only.fix).toContain("~");
+    // The rest of the path must survive — redaction, not deletion.
+    expect(only.message).toContain("annotations");
+    // Deep scrub reaches nested objects and arrays inside `data`.
+    const data = only.data as { dir: string; nested: { paths: string[] } };
+    expect(data.dir.startsWith("~")).toBe(true);
+    expect(data.nested.paths[0].startsWith("~")).toBe(true);
+  });
+
+  it("scrubs a collector-level error message", async () => {
+    const home = os.homedir();
+    const collect = async () => ({
+      ...makeReport([]),
+      error: `EACCES: permission denied, open '${path.join(home, "secret.json")}'`,
+    });
+    const res = makeMockRes();
+
+    await makeHandler(collect)(makeMockReq("127.0.0.1"), res, () => {});
+
+    const { error } = (res._body as { report: DoctorReport }).report;
+    expect(error).not.toContain(home);
+    expect(error).toContain("~");
+  });
+
+  it("does not swallow an unrelated path that merely starts with the home string", async () => {
+    // With home = "/root", a naive replace turns "/rootfs/x" into "~fs/x".
+    const home = os.homedir();
+    const decoy = `${home}fs/mount/data`;
+    const collect = async () => makeReport([result("ports", "pass", `scanned ${decoy}`)]);
+    const res = makeMockRes();
+
+    await makeHandler(collect)(makeMockReq("127.0.0.1"), res, () => {});
+
+    const [only] = (res._body as { report: DoctorReport }).report.results;
+    expect(only.message).toBe(`scanned ${decoy}`);
+  });
+
+  it("leaves messages without a home path untouched", async () => {
+    const collect = async () =>
+      makeReport([result("ports", "pass", "Hocuspocus :3478 and MCP :3479 are listening")]);
+    const res = makeMockRes();
+
+    await makeHandler(collect)(makeMockReq("127.0.0.1"), res, () => {});
+
+    const [only] = (res._body as { report: DoctorReport }).report.results;
+    expect(only.message).toBe("Hocuspocus :3478 and MCP :3479 are listening");
+    expect(only.fix).toBeUndefined();
   });
 });
 

--- a/tests/server/diagnostics-route.test.ts
+++ b/tests/server/diagnostics-route.test.ts
@@ -197,6 +197,51 @@ describe("GET /api/diagnostics — home-path redaction", () => {
     expect(error).toContain("~");
   });
 
+  it("redacts an app-data dir that resolves OUTSIDE the home directory", async () => {
+    // `resolveAppDataDir()` honours TANDEM_APP_DATA_DIR / XDG_DATA_HOME /
+    // LOCALAPPDATA, any of which can point off-home (redirected Windows
+    // profile, custom XDG root on another volume). A $HOME-only redaction
+    // leaves the username on the wire in exactly that configuration.
+    vi.stubEnv("TANDEM_APP_DATA_DIR", "/srv/exports/bryan/tandem");
+    const dir = "/srv/exports/bryan/tandem/annotations";
+    const { body, report } = await invoke(async () =>
+      makeReport([
+        {
+          check: "annotation-store",
+          status: "pass",
+          message: `Annotation store dir not yet created (${dir}) — first open will create it`,
+          data: { dir },
+        },
+      ]),
+    );
+
+    expect(JSON.stringify(body)).not.toContain("/srv/exports/bryan");
+    const [only] = report.results;
+    expect(only.message).toContain("<app-data>/annotations");
+    vi.unstubAllEnvs();
+  });
+
+  it("redacts a user path that reached the report inside a raw fs error", async () => {
+    // doctor.ts:1434 and :1541 interpolate `errMsg(err)`, whose text embeds an
+    // absolute path no prefix list is guaranteed to cover.
+    const { report } = await invoke(async () =>
+      makeReport([
+        {
+          check: "annotation-store",
+          status: "fail",
+          message:
+            "Annotation store dir unreadable: EACCES: permission denied, scandir '/home/someoneelse/.local/share/tandem'",
+          fix: "Check permissions on /home/someoneelse/.local/share/tandem",
+        },
+      ]),
+    );
+
+    const [only] = report.results;
+    expect(only.message).not.toContain("someoneelse");
+    expect(only.fix).not.toContain("someoneelse");
+    expect(only.message).toContain("/home/[user]/.local/share/tandem");
+  });
+
   it("does not swallow an unrelated path that merely starts with the home string", async () => {
     // With home = "/root", a naive replace turns "/rootfs/x" into "~fs/x".
     const home = os.homedir();

--- a/tests/server/diagnostics-route.test.ts
+++ b/tests/server/diagnostics-route.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DoctorReport, DoctorResult } from "../../src/cli/doctor.js";
 import {
   filterDevRepoChecks,
@@ -150,6 +150,12 @@ describe("GET /api/diagnostics — loopback happy path", () => {
 });
 
 describe("GET /api/diagnostics — home-path redaction", () => {
+  // Failure-safe: an inline unstub at the end of a test does not run when the
+  // test fails, which would leak a fake app-data root into later cases.
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("replaces the home directory with ~ in messages and fixes", async () => {
     // Several doctor checks interpolate the app-data dir, which sits under the
     // user's home and therefore carries their username — including on a PASSING
@@ -218,7 +224,6 @@ describe("GET /api/diagnostics — home-path redaction", () => {
     expect(JSON.stringify(body)).not.toContain("/srv/exports/bryan");
     const [only] = report.results;
     expect(only.message).toContain("<app-data>/annotations");
-    vi.unstubAllEnvs();
   });
 
   it("redacts a user path that reached the report inside a raw fs error", async () => {
@@ -242,12 +247,19 @@ describe("GET /api/diagnostics — home-path redaction", () => {
     expect(only.message).toContain("/home/[user]/.local/share/tandem");
   });
 
-  it("does not swallow an unrelated path that merely starts with the home string", async () => {
-    // With home = "/root", a naive replace turns "/rootfs/x" into "~fs/x".
-    const home = os.homedir();
-    const decoy = `${home}fs/mount/data`;
-    const collect = async () => makeReport([result("ports", "pass", `scanned ${decoy}`)]);
-    const { report } = await invoke(collect);
+  it("does not swallow an unrelated path that merely starts with a redaction root", async () => {
+    // A naive replace turns "/var/lib/tandemfs/..." into "<app-data>fs/...".
+    // The root is stubbed rather than derived from `os.homedir()`: a decoy built
+    // from the real home is environment-dependent — under `/root` it is
+    // `/rootfs/...` (untouched), but under `/home/runner` it is
+    // `/home/runnerfs/...`, which the generic `/home/<x>` pass redacts on
+    // purpose. `tests/shared/redact-user-paths.test.ts` covers the home-root
+    // boundary deterministically.
+    vi.stubEnv("TANDEM_APP_DATA_DIR", "/var/lib/tandem");
+    const decoy = "/var/lib/tandemfs/mount/data";
+    const { report } = await invoke(async () =>
+      makeReport([result("ports", "pass", `scanned ${decoy}`)]),
+    );
 
     const [only] = report.results;
     expect(only.message).toBe(`scanned ${decoy}`);

--- a/tests/server/diagnostics-route.test.ts
+++ b/tests/server/diagnostics-route.test.ts
@@ -66,6 +66,17 @@ function makeHandler(collect: (opts: unknown) => Promise<DoctorReport>) {
   }) as unknown as AnyHandler;
 }
 
+/** Drive a one-shot handler and return what it wrote. */
+async function invoke(
+  collect: (opts: unknown) => Promise<DoctorReport>,
+  remoteAddress = "127.0.0.1",
+): Promise<{ status: number; body: Record<string, unknown>; report: DoctorReport }> {
+  const res = makeMockRes();
+  await makeHandler(collect)(makeMockReq(remoteAddress), res, () => {});
+  const body = (res._body ?? {}) as Record<string, unknown>;
+  return { status: res.statusCode, body, report: body.report as DoctorReport };
+}
+
 describe("GET /api/diagnostics — loopback happy path", () => {
   it("returns 200 with the report and environment fields", async () => {
     const collect = vi.fn(async () => makeReport([result("node-version", "pass")]));
@@ -94,12 +105,9 @@ describe("GET /api/diagnostics — loopback happy path", () => {
     // set — instead of `not.toContain(os.hostname())`, which flakes whenever
     // CI's hostname is a common substring — is what catches an accidental
     // `hostname` / `homedir` / `env` field added to `collectHostInfo`.
-    const collect = vi.fn(async () => makeReport([result("node-version", "pass")]));
-    const res = makeMockRes();
+    const { body } = await invoke(async () => makeReport([result("node-version", "pass")]));
 
-    await makeHandler(collect)(makeMockReq("127.0.0.1"), res, () => {});
-
-    expect(Object.keys(res._body as object).sort()).toEqual([
+    expect(Object.keys(body).sort()).toEqual([
       "arch",
       "cpuCount",
       "cpuModel",
@@ -119,9 +127,7 @@ describe("GET /api/diagnostics — loopback happy path", () => {
   it("types the optional host fields when present, without pinning values", async () => {
     // CI containers legitimately omit cpuModel/cpuCount (`os.cpus()` returns []),
     // so assert shape rather than content.
-    const res = makeMockRes();
-    await makeHandler(async () => makeReport([]))(makeMockReq("127.0.0.1"), res, () => {});
-    const body = res._body as Record<string, unknown>;
+    const { body } = await invoke(async () => makeReport([]));
 
     for (const key of ["osRelease", "osVersion", "cpuModel"]) {
       if (body[key] !== undefined) expect(typeof body[key]).toBe("string");
@@ -164,13 +170,10 @@ describe("GET /api/diagnostics — home-path redaction", () => {
           data: { dir, docCount: 0, nested: { paths: [dir] } },
         },
       ]);
-    const res = makeMockRes();
+    const { body, report } = await invoke(collect);
 
-    await makeHandler(collect)(makeMockReq("127.0.0.1"), res, () => {});
-
-    const wire = JSON.stringify(res._body);
-    expect(wire).not.toContain(home);
-    const [only] = (res._body as { report: DoctorReport }).report.results;
+    expect(JSON.stringify(body)).not.toContain(home);
+    const [only] = report.results;
     expect(only.message).toContain("~");
     expect(only.fix).toContain("~");
     // The rest of the path must survive — redaction, not deletion.
@@ -187,11 +190,9 @@ describe("GET /api/diagnostics — home-path redaction", () => {
       ...makeReport([]),
       error: `EACCES: permission denied, open '${path.join(home, "secret.json")}'`,
     });
-    const res = makeMockRes();
+    const { report } = await invoke(collect);
 
-    await makeHandler(collect)(makeMockReq("127.0.0.1"), res, () => {});
-
-    const { error } = (res._body as { report: DoctorReport }).report;
+    const { error } = report;
     expect(error).not.toContain(home);
     expect(error).toContain("~");
   });
@@ -201,22 +202,18 @@ describe("GET /api/diagnostics — home-path redaction", () => {
     const home = os.homedir();
     const decoy = `${home}fs/mount/data`;
     const collect = async () => makeReport([result("ports", "pass", `scanned ${decoy}`)]);
-    const res = makeMockRes();
+    const { report } = await invoke(collect);
 
-    await makeHandler(collect)(makeMockReq("127.0.0.1"), res, () => {});
-
-    const [only] = (res._body as { report: DoctorReport }).report.results;
+    const [only] = report.results;
     expect(only.message).toBe(`scanned ${decoy}`);
   });
 
   it("leaves messages without a home path untouched", async () => {
-    const collect = async () =>
-      makeReport([result("ports", "pass", "Hocuspocus :3478 and MCP :3479 are listening")]);
-    const res = makeMockRes();
+    const { report } = await invoke(async () =>
+      makeReport([result("ports", "pass", "Hocuspocus :3478 and MCP :3479 are listening")]),
+    );
 
-    await makeHandler(collect)(makeMockReq("127.0.0.1"), res, () => {});
-
-    const [only] = (res._body as { report: DoctorReport }).report.results;
+    const [only] = report.results;
     expect(only.message).toBe("Hocuspocus :3478 and MCP :3479 are listening");
     expect(only.fix).toBeUndefined();
   });

--- a/tests/server/host-info.test.ts
+++ b/tests/server/host-info.test.ts
@@ -1,0 +1,88 @@
+import os from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectHostInfo } from "../../src/server/mcp/host-info.js";
+
+/**
+ * `collectHostInfo` feeds a payload that ends up in a public GitHub issue, so
+ * the two properties under test are: nothing identifying leaks, and no field
+ * can be shaped in a way that breaks the consumer downstream.
+ */
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("collectHostInfo", () => {
+  it("returns the runtime fields unconditionally", () => {
+    const info = collectHostInfo();
+    expect(info.platform).toBe(process.platform);
+    expect(info.arch).toBe(process.arch);
+    expect(info.nodeVersion).toBe(process.version);
+    expect(typeof info.tauriSidecar).toBe("boolean");
+  });
+
+  it("omits the CPU fields rather than defaulting them when os.cpus() is empty", () => {
+    // Real behaviour on some cgroup-restricted containers. The fields are
+    // optional precisely so this host does not fail schema validation.
+    vi.spyOn(os, "cpus").mockReturnValue([]);
+    const info = collectHostInfo();
+    expect(info.cpuModel).toBeUndefined();
+    expect(info.cpuCount).toBeUndefined();
+    expect(info.platform).toBe(process.platform);
+  });
+
+  it("survives a throwing os call instead of failing the whole payload", () => {
+    vi.spyOn(os, "version").mockImplementation(() => {
+      throw new Error("unsupported");
+    });
+    const info = collectHostInfo();
+    expect(info.osVersion).toBeUndefined();
+    expect(info.nodeVersion).toBe(process.version);
+  });
+
+  it("truncates a long os.version() on a code-point boundary", () => {
+    // A plain .slice() here would bisect the surrogate pair straddling index
+    // 120, and the lone surrogate left behind makes encodeURIComponent throw —
+    // which silently drops the entire Report-a-bug prefill.
+    vi.spyOn(os, "version").mockReturnValue(`${"a".repeat(119)}😀${"b".repeat(50)}`);
+    const version = collectHostInfo().osVersion as string;
+
+    expect(version.length).toBeLessThanOrEqual(121);
+    expect(() => encodeURIComponent(version)).not.toThrow();
+    // No unpaired surrogate anywhere in the result.
+    expect(version).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+    );
+  });
+
+  it("keeps a short os.version() intact", () => {
+    vi.spyOn(os, "version").mockReturnValue("Windows 11 Pro");
+    expect(collectHostInfo().osVersion).toBe("Windows 11 Pro");
+  });
+
+  it("reports 0 MB free rather than dropping the field", () => {
+    // Unlike a 0 CPU count (which only means "unknown"), 0 free memory is a
+    // real and rather interesting reading.
+    vi.spyOn(os, "freemem").mockReturnValue(0);
+    expect(collectHostInfo().freeMemoryMb).toBe(0);
+  });
+
+  it("carries nothing identifying", () => {
+    const info = collectHostInfo() as Record<string, unknown>;
+    expect(Object.keys(info).sort()).toEqual([
+      "arch",
+      "cpuCount",
+      "cpuModel",
+      "freeMemoryMb",
+      "nodeVersion",
+      "osRelease",
+      "osVersion",
+      "platform",
+      "tauriSidecar",
+      "totalMemoryMb",
+    ]);
+    const wire = JSON.stringify(info);
+    expect(wire).not.toContain(os.hostname());
+    expect(wire).not.toContain(os.homedir());
+  });
+});

--- a/tests/server/host-info.test.ts
+++ b/tests/server/host-info.test.ts
@@ -68,8 +68,13 @@ describe("collectHostInfo", () => {
   });
 
   it("carries nothing identifying", () => {
-    const info = collectHostInfo() as Record<string, unknown>;
-    expect(Object.keys(info).sort()).toEqual([
+    // The exact key set IS the contract — a `hostname` / `homedir` / `env`
+    // field added to the collector fails here. Deliberately NOT paired with
+    // `not.toContain(os.hostname())`: that assertion flakes whenever CI's
+    // hostname is a short common substring (and `os.homedir()` is `/` on some
+    // images), which is why tests/server/diagnostics-route.test.ts rejects it
+    // too.
+    expect(Object.keys(collectHostInfo()).sort()).toEqual([
       "arch",
       "cpuCount",
       "cpuModel",
@@ -81,8 +86,17 @@ describe("collectHostInfo", () => {
       "tauriSidecar",
       "totalMemoryMb",
     ]);
-    const wire = JSON.stringify(info);
-    expect(wire).not.toContain(os.hostname());
-    expect(wire).not.toContain(os.homedir());
+  });
+
+  it("collapses whitespace so a multi-line kernel banner stays one line", () => {
+    // `stripControlChars` on the client deliberately preserves `\n`, so an
+    // interior newline here would inject an unlabelled extra line into the
+    // clipboard text and the fenced issue body.
+    vi.spyOn(os, "version").mockReturnValue("Darwin Kernel Version 23.5.0:\n  Wed May  1 2024");
+    vi.spyOn(os, "release").mockReturnValue(" 23.5.0\n");
+    const info = collectHostInfo();
+
+    expect(info.osVersion).toBe("Darwin Kernel Version 23.5.0: Wed May 1 2024");
+    expect(info.osRelease).toBe("23.5.0");
   });
 });

--- a/tests/server/mcp-output-schemas.test.ts
+++ b/tests/server/mcp-output-schemas.test.ts
@@ -54,6 +54,7 @@ import {
   searchOutputShape,
   statusOutputShape,
 } from "../../src/server/mcp/output-schemas.js";
+import { makeDiagnosticsHandler } from "../../src/server/mcp/routes/diagnostics.js";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
 import { CTRL_ROOM, Y_MAP_ANNOTATIONS, Y_MAP_CHAT } from "../../src/shared/constants.js";
 import { withInternal } from "../../src/shared/origins.js";
@@ -532,5 +533,66 @@ describe("error envelopes from outputSchema'd tools", () => {
     expect(result.isError).toBe(true);
     const envelope = textEnvelope(result) as { error: boolean; code?: string };
     expect(envelope.code).toBe("NO_DOCUMENT");
+  });
+});
+
+describe("diagnostics payload lockstep (route ↔ MCP tool ↔ zod shape)", () => {
+  /**
+   * The three diagnostics producers must agree on their field set, and the
+   * failure mode is not cosmetic: `response.ts` emits several tool schemas with
+   * `additionalProperties: false`, so a field present in the payload but absent
+   * from `diagnosticsOutputShape` makes a spec-compliant client REJECT the call.
+   *
+   * `output-schemas.ts` states the lockstep requirement in a comment; this is
+   * the test that enforces it.
+   */
+  it("declares every host field the HTTP route puts on the wire", async () => {
+    const handler = makeDiagnosticsHandler({
+      version: "0.0.0-test",
+      transport: "http",
+      wsPort: 1,
+      mcpPort: 2,
+      collect: async () => ({
+        ok: true,
+        crashed: false,
+        failures: 0,
+        warnings: 0,
+        summary: "All checks passed. Tandem is ready.",
+        error: null,
+        results: [],
+      }),
+    }) as unknown as (req: unknown, res: unknown, next: unknown) => Promise<void>;
+
+    let body: Record<string, unknown> = {};
+    const res = {
+      status() {
+        return res;
+      },
+      json(payload: Record<string, unknown>) {
+        body = payload;
+      },
+    };
+    await handler({ socket: { remoteAddress: "127.0.0.1" } }, res, () => {});
+
+    // The route NESTS the doctor report under `report`; the MCP tool spreads it
+    // flat and the zod shape describes that flat form. Compare the host fields
+    // only, which is the part the two payload shapes genuinely share.
+    const doctorReportKeys = [
+      "ok",
+      "crashed",
+      "failures",
+      "warnings",
+      "summary",
+      "error",
+      "results",
+    ];
+    const routeHostKeys = Object.keys(body)
+      .filter((k) => k !== "report")
+      .sort();
+    const shapeHostKeys = Object.keys(diagnosticsOutputShape)
+      .filter((k) => !doctorReportKeys.includes(k))
+      .sort();
+
+    expect(routeHostKeys).toEqual(shapeHostKeys);
   });
 });

--- a/tests/server/mcp-output-schemas.test.ts
+++ b/tests/server/mcp-output-schemas.test.ts
@@ -595,4 +595,37 @@ describe("diagnostics payload lockstep (route ↔ MCP tool ↔ zod shape)", () =
 
     expect(routeHostKeys).toEqual(shapeHostKeys);
   });
+
+  it("emits the same host fields from the MCP tool as the route and the shape", async () => {
+    // Without this half, the describe block's name is a lie: dropping
+    // `...collectHostInfo()` from `mcp/diagnostics.ts` would leave the route and
+    // the zod shape in perfect agreement, the test above green, and
+    // `tandem_diagnostics` silently reporting no OS/CPU/memory at all.
+    const result = (await client.callTool({
+      name: "tandem_diagnostics",
+      arguments: {},
+    })) as ToolResult;
+    const sc = result.structuredContent as Record<string, unknown>;
+
+    const doctorReportKeys = [
+      "ok",
+      "crashed",
+      "failures",
+      "warnings",
+      "summary",
+      "error",
+      "results",
+    ];
+    const toolHostKeys = Object.keys(sc)
+      .filter((k) => !doctorReportKeys.includes(k))
+      .sort();
+    const shapeHostKeys = Object.keys(diagnosticsOutputShape)
+      .filter((k) => !doctorReportKeys.includes(k))
+      .sort();
+
+    expect(toolHostKeys).toEqual(shapeHostKeys);
+    // And the host block is actually populated, not merely declared.
+    expect(sc.platform).toBe(process.platform);
+    expect(sc.arch).toBe(process.arch);
+  });
 });

--- a/tests/shared/redact-user-paths.test.ts
+++ b/tests/shared/redact-user-paths.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { diagnosticsRedactRoots, redactUserPaths } from "../../src/shared/redact-user-paths.js";
+
+/**
+ * This runs over text that is about to be pasted into a public GitHub issue, so
+ * the interesting cases are the ones where a naive prefix swap either misses a
+ * username or corrupts an unrelated path.
+ */
+
+const HOME = { path: "/home/bryan", as: "~" };
+
+describe("redactUserPaths", () => {
+  it("collapses a known root", () => {
+    expect(redactUserPaths("/home/bryan/.local/share/tandem", [HOME])).toBe(
+      "~/.local/share/tandem",
+    );
+  });
+
+  it("does not swallow a path that merely starts with the root string", () => {
+    // The classic: home `/root` vs an unrelated `/rootfs`.
+    expect(redactUserPaths("/rootfs/mount", [{ path: "/root", as: "~" }])).toBe("/rootfs/mount");
+    expect(redactUserPaths("/root/x", [{ path: "/root", as: "~" }])).toBe("~/x");
+  });
+
+  it("redacts an app-data root that lives outside home", () => {
+    const roots = [HOME, { path: "/srv/exports/bryan/tandem", as: "<app-data>" }];
+    expect(redactUserPaths("/srv/exports/bryan/tandem/annotations", roots)).toBe(
+      "<app-data>/annotations",
+    );
+  });
+
+  it("prefers the home-relative form when the app-data root is nested under home", () => {
+    // `~/.local/share/tandem` is both safe and more useful than an opaque
+    // placeholder, so the nested root is skipped.
+    const roots = [HOME, { path: "/home/bryan/.local/share", as: "<app-data>" }];
+    expect(redactUserPaths("/home/bryan/.local/share/tandem", roots)).toBe("~/.local/share/tandem");
+  });
+
+  it("catches a user directory belonging to nobody we were told about", () => {
+    // Reaches the report inside a raw fs error, where no prefix list applies.
+    expect(
+      redactUserPaths(
+        "EACCES: permission denied, scandir '/home/someoneelse/.local/share/tandem'",
+        [HOME],
+      ),
+    ).toBe("EACCES: permission denied, scandir '/home/[user]/.local/share/tandem'");
+  });
+
+  it.each([
+    [
+      "/Users/alice/Library/Application Support/tandem",
+      "/Users/[user]/Library/Application Support/tandem",
+    ],
+    ["C:\\Users\\alice\\AppData\\Local\\tandem", "C:\\Users\\[user]\\AppData\\Local\\tandem"],
+  ])("collapses the generic user segment in %s", (input, expected) => {
+    expect(redactUserPaths(input, [])).toBe(expected);
+  });
+
+  it.each([
+    [""],
+    ["/"],
+    ["C:\\"],
+    ["C:"],
+  ])("ignores the degenerate root %p rather than corrupting every path", (path) => {
+    const input = "/home/bryan/x and C:\\Windows\\y";
+    // Only the generic second pass should apply.
+    expect(redactUserPaths(input, [{ path, as: "~" }])).toBe("/home/[user]/x and C:\\Windows\\y");
+  });
+
+  it("replaces every occurrence, not just the first", () => {
+    expect(redactUserPaths("/home/bryan/a then /home/bryan/b", [HOME])).toBe("~/a then ~/b");
+  });
+
+  it("leaves text with no user paths untouched", () => {
+    const msg = "Hocuspocus :3478 and MCP :3479 are listening";
+    expect(redactUserPaths(msg, [HOME])).toBe(msg);
+  });
+});
+
+describe("diagnosticsRedactRoots", () => {
+  it("covers every source resolveAppDataDir() consults, plus both spellings of home", () => {
+    const roots = diagnosticsRedactRoots("/home/bryan", {
+      HOME: "/home/bryan",
+      USERPROFILE: "C:\\Users\\bryan",
+      TANDEM_APP_DATA_DIR: "/srv/tandem",
+      XDG_DATA_HOME: "/mnt/data",
+      LOCALAPPDATA: "C:\\Data",
+    } as NodeJS.ProcessEnv);
+
+    expect(roots.filter((r) => r.as === "~").map((r) => r.path)).toEqual([
+      "/home/bryan",
+      "/home/bryan",
+      "C:\\Users\\bryan",
+    ]);
+    expect(roots.filter((r) => r.as === "<app-data>").map((r) => r.path)).toEqual([
+      "/srv/tandem",
+      "/mnt/data",
+      "C:\\Data",
+    ]);
+  });
+
+  it("tolerates an environment where none of the overrides are set", () => {
+    const roots = diagnosticsRedactRoots("/home/bryan", {} as NodeJS.ProcessEnv);
+    expect(redactUserPaths("/home/bryan/x", roots)).toBe("~/x");
+  });
+
+  it("still redacts when os.homedir() and $HOME disagree", () => {
+    // Happens under sudo, or a launcher that overrides the environment. A pass
+    // keyed on only one of them would miss paths built from the other.
+    const roots = diagnosticsRedactRoots("/root", { HOME: "/home/bryan" } as NodeJS.ProcessEnv);
+    expect(redactUserPaths("/root/a and /home/bryan/b", roots)).toBe("~/a and ~/b");
+  });
+});


### PR DESCRIPTION
## What and why

**Copy Diagnostics** reported only `platform/arch` and the Node version, so triaging a report meant a round trip to ask for OS version, CPU and memory. **Report a bug** was a bare link to `/issues/new` that prefilled nothing, so the diagnostics a user could have copied almost never reached the issue.

Now the clipboard text carries an OS/hardware/runtime block, and the bug link lands on an issue form whose body is already two blank lines, `Diagnostic information:`, then that same report.

```
Tandem v0.21.0 (http, desktop)
darwin/arm64, Node v22.1.0
OS: Windows 11 Pro (10.0.26100)
CPU: Apple M2 Pro x12, RAM: 32.0 GB total, 6.1 GB free
Browser: Chrome 141
```

Five commits: the feature, a `/simplify` pass, two rounds of correctness-review fixes, and a CI fix. **The review commits are where the interesting bugs are** — they are listed in full below, because several of them are defects the first commit shipped.

## Server

New `collectHostInfo()` (`src/server/mcp/host-info.ts`) supplies `osRelease`, `osVersion`, `cpuModel`, `cpuCount`, `totalMemoryMb`, `freeMemoryMb` to both diagnostics producers, which previously duplicated the same four `process.*` reads.

Every field is **optional** and individually guarded — `os.cpus()` returns `[]` under cgroup-restricted containers, so a required key would fail structured-output validation on exactly those hosts. All three lockstep files move together: `response.ts` emits tool schemas with `additionalProperties: false`, so a field on the wire but absent from `diagnosticsOutputShape` makes a spec-compliant client *reject the call*. A test enforces that and is confirmed to fail when the files drift.

Hostname, username, home path, network interfaces, PID, env, locale and timezone are deliberately excluded, and the module docstring names them so the omission reads as a decision.

## User-path redaction

`formatDiagnostics` prints check messages verbatim, and several doctor checks interpolate the app-data dir — which contains the username — including a **passing** check that fires on the common first run (`doctor.ts:1420`). Manual verification against a live server also showed the raw directory in the free-form `data` bag (`annotation-store` carries `data.dir`).

`redactHomePaths` **walks the whole report** rather than enumerating fields, so a new string field on `DoctorResult` can't silently escape. Redaction itself lives in `src/shared/redact-user-paths.ts` and does **two passes**, because `$HOME` alone is not enough:

1. **Known roots** — both spellings of home (`os.homedir()` and `$HOME`/`%USERPROFILE%` disagree under `sudo`), plus every source `resolveAppDataDir()` consults: `TANDEM_APP_DATA_DIR`, `XDG_DATA_HOME`, `LOCALAPPDATA`. Any of those can resolve *outside* home — a redirected Windows profile, a custom XDG root on another volume — and still carry the username. Each match requires a trailing separator, so `/root` cannot swallow `/rootfs/...`. A root nested inside another is dropped, so a default-located app-data dir still reads `~/.local/share/tandem`.
2. **Generic user segments** (`/Users/<x>`, `/home/<x>`, `C:\Users\<x>`) for paths no root list can cover — notably the absolute path inside a raw `fs` error, which `doctor.ts:1434` and `:1541` interpolate via `errMsg`.

This is deliberately *not* `scrubPathForCaller`: that one is caller-conditional and would be a no-op on a route that 403s every non-loopback caller, and basenaming would destroy the report's diagnostic value. Different adversary — not a LAN peer, but the public issue the loopback user is about to paste into. Applied to the HTTP route only; the MCP tool serves an agent that may need the real path.

## Client

`Report a bug` **stays an `<a>`**; its `href` is upgraded in place once a prefetch resolves. A `<button>` calling `window.open` after an `await` would lose user activation and get popup-blocked in the browser build. The click never awaits anything, and failure needs no branch — the bare URL is the initial value.

Priming is keyed to **a 150ms pointer-or-focus dwell**, not to the modal opening. `/api/diagnostics` runs the full doctor collector — an `npm ls -g` subprocess, port probes, a directory scan — and it is *not* inert: `checkSseEndpoint` opens `/api/events`, registering and dropping an `"external"` subscriber, the same count `takeWakeAdvisory` and the Solo forwarding gate read. Focus is gated the same way as pointer because this link is the **last focusable in the sidebar**, with the content pane next in DOM order inside the focus trap — so every keyboard user tabbing into the content passes focus through it.

The issue body is `\n\n` + `Diagnostic information:` + `\n\n` + the report, with **two deliberate deviations** from a literal reading: the report is **fenced** (GitHub renders the body as Markdown and would otherwise collapse every check line, with `[ok]`/`[warn]` parsed as link syntax), and the fence is tildes **sized to the content** — one longer than the longest run present. Doctor `fix` strings contain backticks verbatim, and `store.lock` content (interpolated raw at `doctor.ts:1520`, newlines preserved) can contain tildes, so neither a fixed ``` nor a fixed `~~~` is escape-safe.

Truncation measures the **encoded** length — newlines expand 3x and em dashes 9x, so a raw character cap would overshoot by more than double — drops whole lines from the tail to keep the header, and falls back to the bare URL on the `URIError` a lone surrogate would raise.

## Bugs found and fixed by the review rounds

Not present in the first commit's own testing — these came out of `/simplify` and two `/code-review` passes:

- **A shared fetch could be aborted out from under another caller.** The in-flight promise adopted whichever caller *started* it: hover starts the fetch, a Copy-Diagnostics click joins it, the modal closes, and the abort kills the fetch the click was awaiting. `AbortError` maps to "unreachable", so the user saw *"Couldn't reach the server — is it running?"* against a healthy server. `fetchDiagnostics` now takes no signal at all.
- **Hover-then-click ran the collector twice** (in-flight sharing only helps when requests overlap). Added a 15s TTL on successes; failures are never cached so a retry can't look broken.
- **…but that cache then staled the explicit click.** Fixed via `maxAgeMs: 0` — which then had to also reject a *stale in-flight run*, since joining one started before the user's fix hands back pre-fix probes.
- **One transient failure killed the prefill for the whole session** (`primed` latched before resolution). Now unlatches, with a 10s cooldown so pointer in/out during an outage doesn't spawn a collector run per entry.
- **The dwell timer could outlive the component** — the reset `$effect` returns early while the modal is open, so a destroy that never passes through `open === false` left it armed.
- **`os.version().slice(0, 120)` could bisect a surrogate pair**, and the lone surrogate makes `encodeURIComponent` throw — silently dropping the entire prefill.
- **`osVersion`/`osRelease` weren't whitespace-collapsed** (asymmetric with `cpuModel`), so a multi-line kernel banner injected an unlabelled extra line into the clipboard text and the fenced body.
- **`osRelease` bypassed `stripControlChars`** while the other two OS-supplied strings got it.
- **`summarizeUserAgent` dropped the Browser line for macOS WKWebView** — no `Chrome/`, no `Edg/`, often no `Version/… Safari/` — i.e. for the desktop build, the primary distribution. Added an `AppleWebKit` fallback.
- **The lockstep test was named "route ↔ MCP tool ↔ zod shape" but never invoked the tool**, so dropping `...collectHostInfo()` from the MCP half would have passed green.

Also from `/simplify`: `HostInfo` moved to `src/shared/diagnostics.ts` (it was declared three times, and the client copy was the one nothing type-checked); a fifth copy of `escapeRegExp` dropped; host-info memoization removed (measured 61µs against a route that spawns a subprocess); truncation binary search replaced with a linear shrink; and `createBugReportUrl` takes a `getOpen` getter so it owns its own teardown, matching every other hook in that directory.

## Verification

- `npm run typecheck`, `biome check`, and the full `vitest` suite (**6442 passed / 23 skipped**) are green; `tests/e2e/settings-and-filters.spec.ts` passes 21/21. The pre-push hook, including `cargo test`, passed on every commit.
- **Verified in a real browser after each round**, which is where several of the bugs above surfaced: a quick pass over the link does not prime, resting on it does, focus-in-transit does not prime while resting focus does, closing the modal resets the href, Copy Diagnostics lands immediately after a prefetch, and the OS line stays a single line. Browser checks are what caught the `data`-bag leak and the `HeadlessChrome` UA miss.
- New tests: `redact-user-paths.test.ts`, `host-info.test.ts`, `bug-report-url.test.ts`, `diagnostics-fetch.test.ts`, plus extensions to the format, route and schema suites. The code-point truncation, stale-in-flight and lockstep tests were each confirmed to fail against the code they guard.
- The suite is run under `HOME=/home/runner` as well as the default — the check that catches tests baking in a local `os.homedir()` shape, which is what the one CI failure on this branch turned out to be.

The existing `makePayload()` fixture is deliberately left without the new fields, so every pre-existing assertion doubles as the graceful-degradation contract: a payload from an older server must format byte-identically to before.

## Notes for review

- The e2e spec asserts only `href` matching `/issues/new`, true in both pre- and post-fetch states. A `body=` assertion there would depend on a real `runDoctor` finishing in time and would flake; the prefill is unit-tested instead.
- `?body=` is silently dropped if the repo ever gains issue *forms* with `blank_issues_enabled: false`. There's no `.github/ISSUE_TEMPLATE/` today, so this works — but it's an undocumented dependency on repo config.
- Touch taps *do* fire `pointerenter`, but the dwell resolves after the navigation has already used the bare URL, so touch effectively keeps it.
- Under Cowork the prefetch fails at the network layer (`API_BASE` is a hardcoded loopback origin) and the link stays bare. Correct behavior; the feature is just invisible there.
- **Not fixed, worth a follow-up:** `src/server/integrations/install-claude-cli.ts:333` has another hand-rolled home redactor (`split(home).join("<home>")`) lacking every guard this one has — including the separator lookahead, so a home of `/root` corrupts `/rootfs/...` there. It could now adopt `redactUserPaths`. Left alone to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaoQA4nbwTEmNaS8KLrg8z