### PR TITLE
chore: ignore piwapp MCP credential artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,18 @@ docs/design-system-impl/preview/baselines/baselines.html
 # generator, so the artifact itself is noise in the history. The GENERATOR is tracked;
 # this output is not. See docs/roadmap.md §"Performance gate".
 tests/perf/.generated/
+
+# WhatsApp MCP (piwapp) session artifacts. These are LIVE CREDENTIALS -- the JSON
+# holds noise_key, signed_identity_key, signed_pre_key and adv_secret_key, and the
+# sibling .keys file is the encrypted keystore. The server writes them into
+# whatever directory it was started from, which for an MCP server configured at
+# user level is the repo you happen to be working in. Untracked-but-committable is
+# the dangerous state: one `git add -A` publishes a working WhatsApp session.
+# Ignored rather than deleted -- removing them unpairs the device.
+piwapp_auth.json
+piwapp_auth.json.keys
+piwapp_qr.png
+
+# Python bytecode from the spike harnesses under scripts/spikes/.
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary

`piwapp_auth.json` holds **live WhatsApp key material** — `noise_key`, `signed_identity_key`, `signed_pre_key`, `adv_secret_key`, `pairing_ephemeral_key_pair` — and `piwapp_auth.json.keys` is the sibling keystore (~9KB). The piwapp MCP server writes them into whatever directory it was started from, which for a user-level server configuration is whichever repo happens to be open.

They were **untracked but not ignored**, which is the dangerous state: one `git add -A` publishes a working WhatsApp session. Also ignores `__pycache__/` from the `scripts/spikes/` harnesses, committable for the same reason.

## Verified

- `git log --all -- <each file>` returns empty: **none has ever been committed on any branch**, so this is prevention, not remediation. No history rewrite needed.
- `git check-ignore` confirms all four paths are ignored after the change.

## Deliberately not deleted

Removing the auth files unpairs the device, so that is the user's call, not this PR's. Ignoring them is the part that is unambiguously safe.

Found incidentally while checking the working tree before opening #1397.