### PR TITLE
chore(release): v0.22.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Edit and iterate on documents with any MCP-capable AI. Claude is the default and best-supported client today.",
   "author": {
     "name": "Tandem"
@@ -11,14 +11,14 @@
   "mcpServers": {
     "tandem": {
       "command": "npx",
-      "args": ["-y", "tandem-editor@0.21.0", "mcp-stdio"],
+      "args": ["-y", "tandem-editor@0.22.0", "mcp-stdio"],
       "env": {
         "TANDEM_URL": "http://127.0.0.1:3479"
       }
     },
     "tandem-channel": {
       "command": "npx",
-      "args": ["-y", "tandem-editor@0.21.0", "channel"],
+      "args": ["-y", "tandem-editor@0.22.0", "channel"],
       "env": {
         "TANDEM_URL": "http://127.0.0.1:3479"
       }
@@ -28,13 +28,13 @@
     "monitors": [
       {
         "name": "tandem-events",
-        "command": "npx -y tandem-editor@0.21.0 monitor",
+        "command": "npx -y tandem-editor@0.22.0 monitor",
         "description": "Tandem real-time document events (annotations, chat, selections)",
         "when": "on-skill-invoke:tandem:tandem"
       },
       {
         "name": "tandem-events-user-skill",
-        "command": "npx -y tandem-editor@0.21.0 monitor",
+        "command": "npx -y tandem-editor@0.22.0 monitor",
         "description": "Tandem real-time document events (annotations, chat, selections)",
         "when": "on-skill-invoke:tandem"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-08-11
+
+This release is about your AI noticing that you said something.
+
+Tandem has always been able to tell your AI that you commented on a paragraph or sent a chat message, but for sessions you started yourself, something had to be listening first — and nothing arranged that for you. A session you opened by typing `claude` would sit there while your comments piled up unread. Now it sets that up itself, on its own, the first time it touches Tandem, and Tandem says how at the moment the connection opens rather than hoping the subject comes up later. Measured across ten isolated sessions, the number that arranged it went from three in six to six in six.
+
+The rest is a smaller thing that will save you a round trip: bug reports now arrive with the details we would otherwise have to ask you for, and the Report a bug link fills them in.
+
 ### Changed
 
 - **Hand-started Claude Code sessions now try to watch Tandem automatically on first use.** After the first successful read-only `tandem_status`, the bundled skill makes one persistent built-in Monitor attempt using the server-reported wake address; asking Claude to watch is now recovery rather than setup. Existing setup-managed skill copies refresh before Tandem reports ready, including when the launcher is disabled or deferred. A missing standalone skill does not install during generic startup, so plugin-only users do not silently acquire a second integration route. Plugin-only sessions receive the updated instructions when Claude Code refreshes its plugin cache, on a timeline Tandem does not control. If a plugin-backed session starts both its packaged monitor and the built-in watch automatically, wakes remain payload-free and inbox reads de-duplicate; `TaskStop` stops the built-in watch when doubled wakes make the overlap visible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-editor",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-editor",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@hocuspocus/provider": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Edit and iterate on documents with any MCP-capable AI (Claude by default). Real-time push via the channel shim.",
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-desktop"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "base64 0.22.1",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-desktop"
-version = "0.21.0"
+version = "0.22.0"
 description = "Collaborative AI-human document editor"
 authors = ["Bryan Kolb"]
 license = "BUSL-1.1"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "identifier": "com.tandem.editor",
   "build": {
     "frontendDist": "../dist/client",


### PR DESCRIPTION
Cuts **v0.22.0**. Six version surfaces, the dated changelog section, and its summary.

## Why a minor and not `0.21.1`

#1394 adds host and hardware facts to Copy Diagnostics, prefills the bug report, and brings a new `src/shared/redact-user-paths.ts`. That is a feature, and this file's header commits the project to semver, so it moves the minor. The rest of the release is corrective.

## The six surfaces

| Surface | How |
|---|---|
| `package.json` | edited |
| `.claude-plugin/plugin.json` | **five** pins — top-level `version`, the npx spec in each of two `mcpServers`, and one per `experimental.monitors` entry |
| `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` | edited |
| `package-lock.json` | `npm install --package-lock-only` |
| `src-tauri/Cargo.lock` | `cargo update -p tandem-desktop` (no `--precise` — silently ignored for a local package) |

Both monitor pins live inside a `command` string where the `args`-array walker cannot see them. I counted them in the file rather than trusting the documented number, which has been stale before.

## Catch-all grep: three hits, no stragglers

`git grep -F 0.21.0` with the documented exclusions leaves three, and reading them matters more than counting them:

- two are `CLAUDE.md` prose naming v0.21.0 as history. The **Status** line is updated after publish, per the skill's ordering, so it is not false in the meantime.
- `SEEDED_SKILL_TAG = "v0.21.0"` in the acceptance harness genuinely *pins* the old version — deliberately. It is the last release whose bundled skill lacked the auto-arm instruction, which is what stops the refresh proof from being vacuous. Bumping it would leave the harness comparing the candidate against itself.

## `npm audit`: one high, and it does not ship

`postcss` GHSA-r28c-9q8g-f849 (CVSS 7.5), transitive under **vite**, absent from both dependency lists. The path traversal needs attacker-controlled CSS carrying a crafted `sourceMappingURL`; Tandem compiles its own CSS from this repo. Build tooling only, not reachable in the published product. **No dependency moved in this release**, so there is no `### Security` section to write — a changelog records changes. Tracked separately in #1402 with the vite-bump caveats.

## Verification

- `npm run typecheck` — clean
- `npm test -- --run` — **6482 passed** across 453 files, 19 skipped. Includes `plugin-version-pin.test.ts` and `plugin-manifest.test.ts`, which are what prove surfaces 1–4 agree.
- The first run failed `tests/build/version-baked.test.ts` against a **stale `dist/`**. `APP_VERSION` is a build-time tsup define, so the bundle has to be rebuilt after a bump rather than merely retested — worth knowing for the next cut.

Publishing the resulting draft release is what fires `publish.yml` → `npm publish --provenance`. The smoke checklist's real-hardware sections stay unrunnable on this setup and will be recorded as skipped rather than left implied.