### PR TITLE
docs(status): v0.22.0 shipped, and a trap that has now fired three times

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -7,8 +7,9 @@ disable-model-invocation: true
 # Cut a Tandem Release
 
 Codifies the release sequence used from v0.14.3 onward, and refined by every cut
-through v0.20.1 — including the global-install upgrade step, the two changelog
-gaps, and the duplicate-draft race described below. The version
+through v0.22.0 — including the global-install upgrade step, the two changelog
+gaps, the rebuild-before-retest step, and the duplicate-draft race described
+below. The version
 bump has **SIX surfaces**, none of which bump automatically. Surfaces 1–4 are
 CI-guarded by `tests/plugin/plugin-version-pin.test.ts` (any divergence from
 `package.json` fails CI); surfaces 5–6 are **not guarded** — this skill is what
@@ -115,7 +116,18 @@ prevents them drifting.
      directions — "bundled but we never call it" belongs in the entry, or the
      note implies an exposure that did not exist.
 
-3. Verify the full test suite is green — `plugin-version-pin.test.ts` proves
+3. **Rebuild before you retest.** `APP_VERSION` is a build-time tsup define, so
+   `dist/` still carries the OUTGOING version until `npm run build` runs, and
+   `tests/build/version-baked.test.ts` fails asserting the new string against a
+   stale bundle. It reads as a real regression and is not one. This has now
+   fired at three cuts (v0.19.0→v0.20.0, and again at v0.22.0 despite being
+   recorded in project memory both times), which is why it is a step here rather
+   than a note someone is expected to remember:
+   ```bash
+   npm run build
+   ```
+
+4. Verify the full test suite is green — `plugin-version-pin.test.ts` proves
    surfaces 1–4 agree (it also checks `plugin.json`'s pinned npx specs);
    `tests/plugin-manifest.test.ts` additionally fails if `package.json` and
    `plugin.json` diverge — treat either failure as "you bumped some, not all":
@@ -128,10 +140,10 @@ prevents them drifting.
    terminal. `--run` makes that unconditional; `ci.yml` and `.husky/pre-push`
    both pass it.
 
-4. Ship the bump through the normal flow: branch → PR → CI green → merge →
+5. Ship the bump through the normal flow: branch → PR → CI green → merge →
    verify master CI green on the **merge commit**.
 
-5. Tag the release on the master tip and push the tag:
+6. Tag the release on the master tip and push the tag:
    ```bash
    git tag -a v<version> -m "Tandem v<version>" && git push origin v<version>
    ```
@@ -145,7 +157,7 @@ prevents them drifting.
    tag alone does NOT publish to npm. (`HUSKY=0` on the tag push is fine — the
    commit is already CI-green.)
 
-5b. Populate the GitHub release body from the `## [<version>]` changelog
+6b. Populate the GitHub release body from the `## [<version>]` changelog
    section — `tauri-action` writes only "See the assets to download and install
    Tandem." Extract the section between its heading and the previous version's
    and pass it via `gh release edit v<version> --notes-file <file>`. Do this
@@ -153,7 +165,7 @@ prevents them drifting.
    full notes; v0.17.0 and v0.19.0 shipped with the boilerplate), so it needs
    to be a step rather than a habit.
 
-6. Wait for every matrix build, `release-check`, AND `verify-release-manifest`
+7. Wait for every matrix build, `release-check`, AND `verify-release-manifest`
    to go green, then publish the draft:
    ```bash
    gh release edit v<version> --draft=false --latest
@@ -185,7 +197,7 @@ prevents them drifting.
    developer.apple.com / App Store Connect — re-run the failed jobs after he
    signs.
 
-6b. Upgrade the local global install: `npm install -g tandem-editor@<version>`.
+7b. Upgrade the local global install: `npm install -g tandem-editor@<version>`.
    This is a smoke-checklist §4 step, but it is also a *correctness* step for
    the plugin path and easy to skip because nothing fails loudly without it. A
    stale global `tandem-editor` shadows `npx -y tandem-editor@<pin>`, so the
@@ -195,7 +207,7 @@ prevents them drifting.
    `tandem doctor` also asserts it (`Global tandem-editor@<v> matches this
    build`).
 
-7. Walk `docs/release-smoke-checklist.md`: CI signal first (matrix + macOS
+8. Walk `docs/release-smoke-checklist.md`: CI signal first (matrix + macOS
    launch smoke — **not** `tauri-webdriver.yml`, whose tag trigger was removed
    on 2026-08-08 per #1197, so a release tag no longer produces a run to check;
    review scheduled 2026-11-01 in #1345), then real installers on real
@@ -204,7 +216,7 @@ prevents them drifting.
    doctor`. Record the outcome (platforms covered, anything skipped) on the
    release PR or tracking issue — an unstated skip reads as "verified".
 
-8. Update project memory: the CLAUDE.md **Status** section (what shipped in
+9. Update project memory: the CLAUDE.md **Status** section (what shipped in
    this version) and the project memory SHIPPED entry (per the archive
    rotation discipline).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,9 +201,11 @@ Mechanism, ops, and failure modes: [docs/licensing-explained.md](docs/licensing-
 
 ## Status
 
-**Shipped: v0.21.0** (2026-08-10). Release history is [CHANGELOG.md](CHANGELOG.md); remaining v1.0 work is [docs/roadmap.md](docs/roadmap.md#active--toward-v10). Do not re-narrate either here.
+**Shipped: v0.22.0** (2026-08-12). Release history is [CHANGELOG.md](CHANGELOG.md); remaining v1.0 work is [docs/roadmap.md](docs/roadmap.md#active--toward-v10). Do not re-narrate either here.
 
 Core is complete — 29 active MCP tools, multi-doc tabs, CRDT-anchored annotations, chat, four push paths (self-armed wake, plugin monitor, opt-in channel shim, supervisor stdin), `.md`/`.docx`/`.txt`/`.html`, npm global install, Tauri desktop app.
+
+**First-use arming is now measured, not argued.** v0.22.0 shipped the skill description rewrite (#1391/#1392), the populated MCP `instructions` string (#1397), and the acceptance harness that grades them (#1393). Ten bounded authenticated sessions took natural first-use arming from **3 of 6 to 6 of 6**, both shapes PASS. Two things that live measurement settled and source review had not: the plugin arm reports its skill as `tandem:tandem`, so an exact-match dispatch check scores every plugin session a false decline; and a typed `/tandem` emits **no** `PreToolUse Skill` event at all, so the control arm is invisible without `UserPromptExpansion`. The harness suite is **not run by CI** — `npm test` is vitest and the pre-push hook is biome + vitest + `cargo test`, so `npm run test:acceptance-harness` is the only thing that runs it (#1399, which also carries why wiring it needs a tag-bearing checkout).
 
 **Two systems are merged but runtime-inert. Both must stay that way until their flag flips:**
 


### PR DESCRIPTION
Post-release bookkeeping for v0.22.0, plus one procedural change earned the hard way.

## CLAUDE.md Status

Names v0.22.0, and records what the release **established** rather than only what it changed: first-use arming measured **3 of 6 → 6 of 6** across ten bounded authenticated sessions, both shapes PASS.

Two facts live measurement settled that source review had not, both of which would otherwise have produced false negatives — worth being in project memory because they are properties of the *host*, not of our code:

- the plugin arm reports its skill as **`tandem:tandem`**, so an exact-match dispatch check scores every plugin session a false decline
- a typed `/tandem` emits **no `PreToolUse Skill` event at all**, so the control arm is invisible without `UserPromptExpansion`

It also records that the acceptance harness suite is run by **nothing** in CI (#1399), since a gate nobody runs decays silently.

## The release skill gains a step

`APP_VERSION` is a build-time tsup define, so `dist/` still carries the outgoing version until `npm run build` runs — and `tests/build/version-baked.test.ts` then fails asserting the new string against a stale bundle. It reads as a real regression and is not one.

This fired at **v0.19.0 → v0.20.0**, and again cutting **v0.22.0** — both times with the gotcha already written down in project memory, and both times hit anyway. A trap that survives being recorded twice is not a memory problem. It belongs in the procedure someone is actually reading at the moment it fires, so it is now step 3, immediately before the test step it breaks. Remaining steps renumbered.

The header's "refined by every cut through v0.20.1" was two releases stale — same class of thing, corrected.

## Verification

`tests/docs/` — 42 pass.

Docs and skill only. No product code.