### PR TITLE
fix(desktop): widen Windows update-restart port timeouts, diagnose failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Updating on Windows no longer strands you at "Server failed to start".** After an auto-update the app restarts and its server has to reclaim ports 3478/3479 from the copy that was just shut down — and Windows does not always hand them back immediately. Three separate steps gave up after five seconds, which is exactly the wrong budget for the one moment a machine is guaranteed to be busy: fresh files on disk, antivirus scanning them, the installer still settling. All three now wait up to fifteen, and the shell's own health deadline moved to thirty so it cannot kill a server that is legitimately waiting. Nothing waits longer on a healthy machine — these are polling loops that finish the moment the port frees.
+
+- **When the server genuinely cannot start, the error now says why and offers to fix it.** The old dialog suggested checking "that port 3479 is not in use" and left you to run `netstat` and `taskkill` yourself. On Windows it now names what is holding the port — the program and its process ID — or tells you the port is still tied up by a connection from the previous run and simply needs a moment. Either way there is a **Retry Server Start** button, and it says plainly what it will do: end the named program, or just try again. The retry keeps the file you opened from Explorer, which the old flow would have quietly replaced with the welcome document.
+
+- **Freeing a busy port no longer risks killing the wrong program.** The Windows port-reclaim step matched `netstat` output with a pattern loose enough to hit a process on port 34790 while looking for 3479, and to pick a process ID from a line it had not matched. It now parses the table properly, ignores listeners on interfaces that cannot conflict with Tandem, and handles non-English Windows, where the "LISTENING" label it depended on does not exist.
+
 ## [0.22.0] - 2026-08-11
 
 This release is about your AI noticing that you said something.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -751,9 +751,9 @@ On launch, the Rust core:
 1. Copies `sample/` files to the writable app-data dir (first run only — skips if destination exists)
 2. In **debug builds only** (`cfg!(debug_assertions)`), checks whether a server is already healthy (`GET /health`) and skips spawn if so — supports the `cargo tauri dev` + `npm run dev:standalone` workflow. Release builds always spawn their own sidecar (the early-return was gated after a stale `tsx watch` dev session was found answering `/health` for the installed app, producing a silent "Disconnected" state with mismatched auth/session). `freePort()` in the sidecar handles any port conflict on bind.
 3. Spawns `node-sidecar` (bundled Node.js binary named with target triple) with `dist/server/index.js` as the entry point and `TANDEM_DATA_DIR` set to the platform app-data dir
-4. Polls `GET http://127.0.0.1:3479/health` every 200ms with a 15s timeout
+4. Polls `GET http://127.0.0.1:3479/health` every 200ms with a 30s timeout (`HEALTH_TIMEOUT`). It is 30s rather than 15s because it times a wait that happens *inside* the sidecar: `waitForPort` in `src/server/platform.ts` polls up to 15s for the TCP port to release before the server can bind and answer. Lowering either without the other resurrects the post-update failure described under "Install flow" below.
 5. On crash, retries up to `MAX_RESTARTS = 3` times with exponential backoff (1s, 2s, 4s)
-6. On all retries exhausted: shows an error dialog and exits
+6. On all retries exhausted: shows a "Server Error" dialog offering a one-shot **Retry Server Start** (all platforms) that re-runs `start_sidecar` — the respawned sidecar's own `freePort()` is what does any killing. On **Windows only**, the dialog first says *what* is holding the port, via `describe_port_holder` (read-only `netstat -ano` + `tasklist`, resolved out of `%SystemRoot%\System32`). It distinguishes two populations, because they need different sentences: a **live listener** (nameable, and the retry will terminate it) and a **lingering TIME_WAIT connection** left by the previous run (no process to kill, PID 0, no LISTENING row — the retry works only because the state expires). Declining leaves the app running with no sidecar; Settings → Network → Restart server is the remaining recovery.
 7. On clean exit (`RunEvent::Exit`): kills the sidecar process to avoid orphan processes
 
 The sidecar child handle is stored in `SidecarState` (a `Mutex<Option<CommandChild>>`) in Tauri managed state. Stdout/stderr from the sidecar are forwarded to the Tauri log system for diagnostics.
@@ -796,11 +796,14 @@ Update available dialog (Ok/Cancel)
     → User confirms
     → download_and_install()
     → kill_sidecar() — releases ports :3478/:3479
-    → Poll /health until server stops responding (5s deadline)
+    → Poll /health until server stops responding (POST_KILL_PORT_RELEASE_SECS = 15s)
+      + on Windows, concurrently poll until the sidecar exe unlocks (15s)
     → app.restart() — Tauri launches the new version
 ```
 
 The sidecar kill before restart is required to prevent a port conflict when the new process starts up.
+
+Both deadlines were 5s until 2026-08-12, when a beta user's v0.21.1 → v0.22.0 update failed against this class of assumption. Note what each actually observes: the first polls `/health`, so it detects "the old server is gone", not "the OS released the port" — a socket in TIME_WAIT is invisible to it. The second polls a real file write-lock. Both are polling loops that return the moment the resource frees, so the wider ceiling costs a healthy machine nothing. The TIME_WAIT half of the problem is handled on the other side of the restart, by `waitForPort` in `src/server/platform.ts` (also widened to 15s).
 
 ### Origin Handling
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -231,9 +231,11 @@ The orphaned Hocuspocus `Document`'s close handlers become no-ops when they look
 
 **Problem:** The server startup used a fixed `setTimeout(300)` between `freePort()` and `Hocuspocus.listen()`. On Windows, port release after `taskkill` is not instant — the OS may hold the port in TIME_WAIT for several seconds. The fixed sleep was sometimes too short (causing EADDRINUSE) and always wasteful when the port was already free.
 
-**Solution:** Replace the fixed sleep with `waitForPort()` in `platform.ts`, which polls every 100ms (up to 5s default) by attempting a TCP `connect()` and checking for `ECONNREFUSED` (port free) vs success (port still held). Hocuspocus `.listen()` is also wrapped with EADDRINUSE detection for a clear error message.
+**Solution:** Replace the fixed sleep with `waitForPort()` in `platform.ts`, which polls every 200ms (15s default) by attempting a `listen()` on the port and treating `EADDRINUSE` as "still held". Hocuspocus `.listen()` is also wrapped with EADDRINUSE detection for a clear error message.
 
 **Impact:** Eliminates a class of flaky startup failures on Windows, especially after unclean shutdowns. The polling approach adapts to actual OS port release timing instead of guessing.
+
+**Follow-up (2026-08-12): the ceiling was still a guess.** The polling fix shipped with a 5s default, which is itself a Windows timing assumption — and a beta user hit it on the v0.21.1 → v0.22.0 auto-update, where the machine is at its slowest (fresh files, antivirus scanning them, installer settling) and TIME_WAIT genuinely exceeded 5s. The result was the non-actionable "Server failed to start after 3 restart attempts" dialog. Two lessons: **(a)** replacing a fixed sleep with polling fixes the *shape* of the bug but not the *magnitude* — the ceiling still has to be sized for the worst realistic case, not the common one; **(b)** the ceiling was one of *three* ~5s assumptions on that path (two more in `perform_install`), and a timeout that a caller times from outside the process is coupled to that caller's own deadline — raising `waitForPort` without raising Tauri's `HEALTH_TIMEOUT` would have made the failure *more* likely, not less.
 
 ## 25. Atomic Undo for Accepted Suggestions
 

--- a/docs/plans/2026-08-12-windows-update-restart-port-timeouts.md
+++ b/docs/plans/2026-08-12-windows-update-restart-port-timeouts.md
@@ -1,0 +1,289 @@
+# Windows update-restart port timeouts + self-service port diagnostic
+
+**Date:** 2026-08-12
+**Status:** revised after three adversarial plan reviews (security, correctness,
+Tauri/UX). Findings folded in are marked **[rev]**.
+
+**Trigger:** Beta user (Eddie) updated v0.21.1 → v0.22.0 on Windows 11. After the
+post-install `app.restart()`, the app showed:
+
+> Server unavailable — Tandem can't reach its sync server.
+> Server Error: Tandem's server failed to start. Error: Server failed to start
+> after 3 restart attempts. Try restarting the application. If the problem
+> persists, check that port 3479 is not in use by another process.
+
+Recovery required running `netstat -ano | findstr :3479` + `taskkill` by hand
+(the recipe in `docs/troubleshooting.md` §"Port already in use").
+
+**Scope:** two independent, additive mitigations. NOT in scope: the ADR-043
+pending-update boot marker (#1118), the update download/install flow itself, the
+WebView "Server unavailable" empty state, or consolidating the eight hardcoded
+`3479`s in `lib.rs`.
+
+---
+
+## References (verified on this branch; ✓ = re-verified by a reviewer)
+
+| Ref | Location | What it is |
+|---|---|---|
+| R1 ✓ | `src-tauri/src/lib.rs:86` | `HEALTH_TIMEOUT = 15s` — per-attempt `/health` wait |
+| R2 ✓ | `src-tauri/src/lib.rs:93` | `MAX_RESTARTS = 3` |
+| R3 ✓ | `src-tauri/src/lib.rs:2179`, loop at `2233-2366` | `start_sidecar` |
+| R4 ✓ | `src-tauri/src/lib.rs:2368-2370` | the `"Server failed to start after {MAX_RESTARTS} restart attempts"` error |
+| R5 ✓ | `src-tauri/src/lib.rs:2413-2422` | `wait_for_port_release(client, deadline_secs)` |
+| R6 ✓ | `src-tauri/src/lib.rs:2447-2477` | `wait_for_sidecar_unlock(deadline_secs)` (Windows-only) |
+| R7 ✓ | `src-tauri/src/lib.rs:4443, 4444, 4458` | `perform_install`'s three `5`-second literals |
+| R8 ✓ | `src-tauri/src/lib.rs:1226-1247` | setup()'s "Server Error" dialog — **the dialog Eddie saw** |
+| R9 ✓ | `src-tauri/src/lib.rs:1577-1625` | `restart_sidecar` + `RESTART_IN_PROGRESS` |
+| R10 ✓ | `src/server/platform.ts:45` | `waitForPort(port, timeoutMs = 5000)` |
+| R11 ✓ | `src/server/platform.ts:88-122` | `freePortWindows` — netstat+taskkill, PID validated `/^\d+$/` |
+| R12 ✓ | `src/server/index.ts:588-594`, `740-745` | the two `freePort`→`waitForPort` sites; failure is **logged and ignored** |
+| R13 ✓ | `tests/server/platform.test.ts:75-133` | `waitForPort` tests |
+| R14 ✓ | `docs/lessons-learned.md:234` | the prior fixed-sleep→polling fix; says "every 100ms (up to 5s default)" — **both numbers wrong** |
+| R15 ✓ | `docs/troubleshooting.md:112` | manual recipe; says the server "logs … and exits" (R12: it proceeds) |
+| R16 **[rev]** | `src/server/index.ts:305-345` (HTTP branch; `acquireStoreLock` in `src/server/annotations/store.ts:158`) | store-lock acquisition retries up to **30s** *before* R12 runs |
+| R17 **[rev]** | `docs/architecture.md:754, 755, 799` + `docs/roadmap.md:353` | four more stale citations of the numbers Part 1 changes |
+| R18 **[rev]** | `src-tauri/src/lib.rs:1159-1166` | `tauri-plugin-log` registers `TargetKind::Webview` at `LevelFilter::Warn` — `log::error!` **does** reach the WebView |
+| R19 **[rev]** | `src/client/components/EmptyState.svelte:94-101` | the WebView's own "Server unavailable" + **Retry** button, shown after 3s |
+| R20 **[rev]** | `src/client/components/NetworkSettings.svelte:39` | `invoke("restart_sidecar")` — the app's real recovery path |
+
+---
+
+## Part 1 — Widen the three ~5s ceilings
+
+### Problem
+
+Three 5s ceilings sit in the update→restart path, all Windows timing
+assumptions. Windows holds a killed listener's port in TIME_WAIT for seconds,
+and the moment we are most likely to exceed 5s is immediately after an update —
+new files on disk, antivirus scanning them, installer still settling.
+
+- R7a `wait_for_port_release(&client, 5)` → install proceeds with the old sidecar possibly alive.
+- R7b `wait_for_sidecar_unlock(5)` → NSIS may fail to overwrite `node-sidecar.exe`.
+- R10 `waitForPort(port, 5000)` → the fresh sidecar stops waiting, binds anyway
+  (R12 swallows the error), gets EADDRINUSE, dies. Tauri retries, exhausts
+  `MAX_RESTARTS`, shows R8.
+
+### Fix
+
+1. **`src/server/platform.ts` (R10)** — default `timeoutMs` 5000 → **15000**, with
+   a comment naming post-update TIME_WAIT on Windows as the reason.
+2. **`src-tauri/src/lib.rs` (R7)** — replace the three `5` literals with named consts:
+   `POST_KILL_PORT_RELEASE_SECS: u64 = 15` and (Windows-only)
+   `SIDECAR_UNLOCK_DEADLINE_SECS: u64 = 15`. The two warning strings hardcode
+   `"after 5s"` — they must interpolate the const or the next bump makes the log lie.
+3. **`HEALTH_TIMEOUT` (R1) 15s → 30s. Not optional.** The sidecar's own
+   `waitForPort` runs *inside* the window `wait_for_health` is timing. Today
+   5s(port) + startup < 15s(health) holds. Raising the port wait to 15s without
+   raising the health timeout kills a sidecar that legitimately waited 15s — i.e.
+   mitigation 1 alone would make Eddie's bug *more* likely. Verified by two
+   reviewers as a real coupling.
+
+   **[rev] Honest margin.** 30s covers 15s of port wait plus normal startup. It
+   does **not** cover R16: `acquireStoreLock` retries for up to 30s on its own,
+   *before* the port wait, when a genuinely live competing process holds
+   `store.lock`. That case (a stray `tandem start`, a second app-data dir) can
+   exhaust 30s by itself. We are not widening for it — it is a different failure
+   with its own deadline and its own error — but the code comment on
+   `HEALTH_TIMEOUT` must say so rather than implying 30s is universal margin.
+
+### Deliberately unchanged
+
+- **`MAX_RESTARTS` (R2) stays 3.** **[rev] corrected arithmetic:** backoff is
+  `2u64.pow(attempt-1)` = 1+2+4 = **7s**, not 14s. Worst case to the dialog goes
+  15·4+7+3 ≈ **67s** → 30·4+7+3 ≈ **127s** (the +3 is the three
+  `wait_for_port_release(client, 1)` calls on the failed attempts). That is the
+  accepted cost; the alternative is failing a machine that would have succeeded,
+  which is the reported bug. Part 2 is what makes the longer wait tolerable.
+- **Backoff**, and `wait_for_port_release(client, 1)` in R3's error arm — the
+  backoff sleep right after it is the real buffer.
+- **The healthy path.** All four are polling loops that return on first success.
+  A wider ceiling costs zero milliseconds when the port is free.
+
+### **[rev]** Other affected populations (verified, no action needed)
+
+- **Stdio mode is unaffected.** R12's second site sits in a *non-awaited* async
+  IIFE; `startMcpServerStdio()` is awaited outside it, so a 15s default cannot
+  delay MCP init.
+- **npm-global `tandem start` shares the HTTP branch.** A browser user with a
+  foreign holder on 3478/3479 now waits 15s instead of 5s before auto-open.
+  Acceptable; named here so it isn't a surprise.
+- **CI is not coupled.** Playwright `webServer` 120s, `ci.yml` backend probe 30s,
+  `dev-standalone.mjs` 60s all exceed the new ceilings, and they invoke
+  `dist/server/index.js` directly, bypassing `HEALTH_TIMEOUT`.
+
+### Tests / docs
+
+- R13: add one test pinning the **default**, under `vi.useFakeTimers()` so it
+  costs no wall clock — hold the port, call `waitForPort(port)` with no timeout,
+  advance to 14 900 ms and assert still pending, advance past 15 000 ms and
+  assert it rejects with `after 15000ms`.
+- Rust: no existing test asserts any of these constants (independently confirmed
+  by two reviewers). Add a const-invariant test asserting
+  `HEALTH_TIMEOUT.as_secs() >= 30` with a comment naming the cross-language
+  coupling to `src/server/platform.ts`.
+- **[rev] Five doc citations, not two:** R14 (fix *both* "5s" and "100ms" — the
+  poll is 200ms), R15, `docs/architecture.md:754` (15s), `:799` (5s deadline),
+  `:755` ("shows an error dialog and exits" — now has a Retry button),
+  `docs/roadmap.md:353` (15s).
+
+---
+
+## Part 2 — Make the terminal failure self-service
+
+### 2a — Concrete diagnostic
+
+New in `src-tauri/src/lib.rs`:
+
+```rust
+const MCP_PORT: u16 = 3479;   // keep in sync with the URL constants above
+const WS_PORT:  u16 = 3478;   // Hocuspocus
+
+fn parse_netstat_listening_pid(output: &str, port: u16) -> Option<u32>;
+fn parse_tasklist_image_name(output: &str) -> Option<String>;
+fn describe_port_holder(ports: &[u16]) -> Option<String>;  // "3479 by node.exe (PID 12345)"
+```
+
+**[rev] Both ports, not just 3479.** The sidecar binds 3478 *and* 3479 and
+`freePort`s both (R12). A conflict on 3478 produces an identical
+`wait_for_health` failure, and a 3479-only probe would return `None` for half
+the affected population — degrading to exactly the generic text this exists to
+replace.
+
+Security discipline (mirrors R11 and the `reveal_command_args` tests):
+
+- **No `cmd /c`, no pipe to `findstr`.** Filtering happens in
+  `parse_netstat_listening_pid`. Strictly less surface than R11, which is
+  shell-mediated.
+- The only interpolated value is a `u32` from `str::parse::<u32>()` — it cannot
+  carry a metacharacter by construction (a stronger guarantee than R11's regex).
+- **[rev] Anchor both binaries to `%SystemRoot%\System32\`** rather than relying
+  on PATH order. `firewall.rs:3-4` documents bare-name invocation as house style,
+  but both binaries are guaranteed at a fixed path, so anchoring is free. Fall
+  back to the bare name only if `SystemRoot` is unset.
+- `CREATE_NO_WINDOW` (0x08000000) via `CommandExt::creation_flags` — a GUI app
+  must not flash a console.
+- **[rev] `spawn_blocking`.** `Command::output()` is synchronous and the caller
+  is async; the file already uses `spawn_blocking` at `lib.rs:1272`.
+- **[rev] PID-reuse TOCTOU.** Between `netstat` and `tasklist` the PID can be
+  recycled, and `docs/troubleshooting.md` teaches users to `taskkill` what we
+  name. Mitigation: re-run the netstat lookup after `tasklist` and only report
+  if the same PID still holds the port, and word it **"appears to be held by"**
+  rather than as an assertion.
+- Exact port matching: split the local-address column on the **last** `:` so
+  `[::1]:3479` matches and `:34790` does not.
+- Every failure path returns `None`. A diagnostic must never break startup.
+
+**[rev] Where it is called — this is the change that removes the privacy
+question entirely.** The original plan folded the holder string into
+`start_sidecar`'s `Err`. That is wrong: R18 shows `tauri-plugin-log` registers
+`TargetKind::Webview`, so the `log::error!` in `restart_sidecar` (R9) *does*
+cross into the WebView — the existing "never user-visible" comment at
+`lib.rs:1610-1612` is already stale. So instead:
+
+> `start_sidecar` returns its error unchanged. `show_server_error_dialog` — the
+> setup()-only surface — computes the holder description and composes the
+> message.
+
+`restart_sidecar`'s path is untouched, and no new string crosses any boundary.
+Fix the stale comment at 1610-1612 in the same pass (small, and we are in the file).
+
+### 2b — Retry action
+
+Extract R8 into `fn show_server_error_dialog(app: &AppHandle, error: &str,
+holder: Option<String>, cold_start_file: Option<PathBuf>, allow_retry: bool)`.
+
+**[rev] There is no existing precedent for this dialog shape** — `grep
+OkCancelCustom src-tauri/src/lib.rs` returns nothing, and
+`show_update_available_dialog` uses plain `OkCancel` + `blocking_show()`. This
+is the first custom-label task dialog Tandem ships. Verified against the
+vendored `tauri-plugin-dialog` 2.7.0 source:
+
+- `MessageDialogButtons::OkCancelCustom(String, String)` — **takes `String`**;
+  the `&str` form in the crate's own doc example does not compile (E0308).
+- `show<F: FnOnce(bool) + Send + 'static>` — `true` = first (OK) label.
+  **Esc and the title-bar X both map to `false`**, i.e. Close.
+- Custom labels do render on Windows: the plugin pins `rfd` with
+  `common-controls-v6`, selecting the `TaskDialogIndirect` backend.
+- Non-blocking `.show(cb)` is correct here (`blocking_show()` from the async
+  task is what `lib.rs:4202-4206` warns deadlocks). Correction to the earlier
+  rationale: the plugin runs its wait on a fresh `std::thread` either way, so
+  the win is not "avoids parking a Tokio worker" but "does not park *this*
+  task's worker".
+- **[rev] `.parent(&window)`** with the `log::warn!` fallback, matching the three
+  other dialog helpers. A parentless modal that lands behind the (already
+  visible — `lib.rs:1135-1137` shows the window first) main window is a real
+  usability failure now that the dialog carries an action.
+- **[rev] Label the button "Retry Server Start", not "Retry".** R19 puts a
+  *different* Retry on screen 3s into the failure (it only re-dials the
+  Hocuspocus WS, so it is inert here). Two identically-labelled Retry buttons
+  with different meanings is worse than a longer label.
+
+On `true`, the callback spawns a task that:
+
+1. **[rev] Takes `RESTART_IN_PROGRESS` *inside* the spawned task** and releases
+   it on both arms. Taking it outside would strand it forever if the callback
+   never runs — `run_on_main_thread`'s error is discarded in the plugin
+   (`desktop.rs:219`), and a panic in the plugin's thread unwinds silently.
+2. **[rev] Passes `cold_start_file` through, not `None`.** `restart_sidecar`
+   passes `None` because setup() already opened the file — on *this* path setup()
+   **failed**, so nothing was opened. Without this, a user who double-clicked a
+   `.md`, hit the conflict, and clicked Retry silently lands on `welcome.md`.
+3. Does **not** call `clear_startup_rejection` — the buffered rejection is from
+   this same launch and is still valid.
+4. **[rev] Runs `check_for_update(&handle, false)` on success**, which setup()'s
+   failure path `return`ed before. Otherwise a recovered session has no startup
+   update check for 8h.
+5. On failure, re-shows the dialog with `allow_retry: false`.
+
+**Why "retry" and not a Rust-side kill:** `start_sidecar` spawns the sidecar,
+whose first act is `freePort()` (R11) — the kill already happens, in reviewed
+code that is its single owner. A `taskkill` in the Tauri shell would add a second
+kill implementation *and* a second PID-reuse TOCTOU with a destructive outcome
+(kill the wrong process) instead of a cosmetic one. This runs literally the same
+kill-and-retry `start_sidecar` logic the brief asks for.
+
+**[rev] The dead end must name the real exit.** R20 shows Settings → Network →
+Restart server is the app's actual recovery path. The `allow_retry: false`
+dialog says so, instead of implying the app is finished.
+
+### **[rev]** Accepted limitations (stated, not fixed)
+
+- While the retry holds `RESTART_IN_PROGRESS`, R20's Settings restart is a
+  **silent** no-op (R9's contended branch is a bare `log::warn!` + `return`).
+  Giving it a user-visible signal needs a new client toast contract — out of
+  scope here; recorded so it is a known gap, not a discovery.
+- `perform_install` (`lib.rs:4417`) does not take the gate either, so a retry can
+  race an update install. Pre-existing; `app.restart()` tears everything down.
+- Worst case is now two ~127s waits and two modals before the honest dead end.
+
+### Tests
+
+Pure-function Rust unit tests, no process spawn (same shape as
+`reveal_command_tests`), using real captured output from this machine:
+
+- `parse_netstat_listening_pid`: IPv4 LISTENING match; IPv6 `[::]:3479` match;
+  `:34790` not matched; `ESTABLISHED` on the same port not matched; empty → `None`.
+- `parse_tasklist_image_name`: real CSV row; the literal
+  `INFO: No tasks are running which match the specified criteria.` (which
+  `tasklist` prints on **exit 0** for a missing PID) → `None`; garbage → `None`.
+
+---
+
+## Verification
+
+1. `npm run typecheck`
+2. `npm test`
+3. `cd src-tauri && cargo test` (prereqs confirmed present: both sidecar stubs in
+   `src-tauri/binaries/`, all four `dist/` dirs; `cargo test --no-run` already
+   passes on this machine).
+4. **Not verifiable here:** the real Windows update→restart flow needs a signed
+   release, an installed v0.21.1, and a published version to update to. The
+   report must say so rather than claiming the user-visible bug is fixed.
+
+## Files touched
+
+- `src/server/platform.ts`, `tests/server/platform.test.ts`
+- `src-tauri/src/lib.rs`
+- `docs/lessons-learned.md`, `docs/troubleshooting.md`, `docs/architecture.md`,
+  `docs/roadmap.md`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -350,7 +350,7 @@ Production WebView uses `tauri://localhost` origin. Server CORS and DNS-rebindin
 
 ### Step 3: Sidecar lifecycle hardening — DONE
 
-Health polling (200ms interval, 15s timeout), exponential backoff restart (up to 3 attempts), early-exit if sidecar dies before healthy, error dialog on exhausted retries. `kill_sidecar()` on `RunEvent::Exit` prevents orphan processes.
+Health polling (200ms interval, 30s timeout), exponential backoff restart (up to 3 attempts), early-exit if sidecar dies before healthy, error dialog on exhausted retries — the dialog names the port holder and offers a one-shot retry on Windows. `kill_sidecar()` on `RunEvent::Exit` prevents orphan processes.
 
 ### Step 4: MCP auto-setup — SUPERSEDED (removed in #477 PR 3c-ii-c)
 

--- a/docs/spikes/updater-rollback-healthpoll-audit.md
+++ b/docs/spikes/updater-rollback-healthpoll-audit.md
@@ -17,8 +17,8 @@
 
 ```
 kill_sidecar(app)                         // free the sidecar exe + port before install
-  → wait_for_port_release(client, 5)      // poll /health until it stops responding
-  → wait_for_sidecar_unlock(5)            // Windows-only, joined via tokio::join!; polls file write-lock
+  → wait_for_port_release(client, POST_KILL_PORT_RELEASE_SECS)  // poll /health until it stops responding
+  → wait_for_sidecar_unlock(SIDECAR_UNLOCK_DEADLINE_SECS)       // Windows-only, joined via tokio::join!; polls file write-lock
   → update.download_and_install(...)      // tauri-plugin-updater; minisign-verified, NSIS on Windows
   → on Ok:  app.restart()                 // divergent — see §3
   → on Err: show_update_error_dialog(...) // threads pre-install warnings into the message

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,7 +109,14 @@ tandem
 
 All three need to match — `TANDEM_URL` is what the channel shim and MCP clients connect to.
 
-If bind still fails after the timeout, the server logs `port {port} still not available after {timeoutMs}ms` and exits. Identify the holding process with `lsof -i :3479` (macOS/Linux) or `netstat -ano | findstr :3479` (Windows).
+If the port is still held after the wait (15s), the server logs `Port {port} still not available after {timeoutMs}ms` and tries to bind anyway — so the visible symptom is usually an `EADDRINUSE` a moment later, not the wait message. Identify the holding process with `lsof -i :3479` (macOS/Linux) or `netstat -ano | findstr :3479` (Windows).
+
+**In the desktop app** you should not have to run that by hand. When the server fails to start, the "Server Error" dialog offers **Retry Server Start**, and on Windows it first tells you what is going on:
+
+- *"Port 3479 appears to be held by …"* — another program owns the port. Retrying ends that process and starts the server again.
+- *"Port 3479 is still tied up by a connection from a previous run"* — nothing to kill; Windows has not finished releasing the port. Retrying usually succeeds once it does.
+
+If you close that dialog, Settings → Network → **Restart server** does the same thing.
 
 ## I sent a chat message (or left a comment) and nothing happened
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,6 +132,7 @@ const SIDECAR_UNLOCK_DEADLINE_SECS: u64 = 15;
 /// timeout elsewhere — it only bounds a best-effort diagnostic on the
 /// terminal failure dialog, so a wedged lookup fails toward "less detail",
 /// never toward blocking the dialog itself.
+#[cfg(target_os = "windows")]
 const PORT_HOLDER_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_RESTARTS: u32 = 3;
 /// The two TCP ports the sidecar binds. Used by the port-holder diagnostic on
@@ -1281,14 +1282,23 @@ pub fn run() {
                 // and orphaning a child. That is the exact failure the gate was
                 // added for; only this call site was outside it.
                 // CAS rather than a bare store, and release only what we took:
-                // a blind store would clear a gate held by someone else.
-                let gate_held = RESTART_IN_PROGRESS
+                // a blind store would clear a gate held by someone else. And if
+                // the gate is already held — some other path won the race before
+                // we got here — we must NOT run start_sidecar anyway: doing so
+                // is the exact concurrent-spawn failure this gate exists to
+                // prevent, just from the other direction. Skip, like
+                // `restart_sidecar` itself does on a gate miss.
+                if RESTART_IN_PROGRESS
                     .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                    .is_ok();
-                let start_result = start_sidecar(&handle, &client, cold_start_file.as_deref()).await;
-                if gate_held {
-                    RESTART_IN_PROGRESS.store(false, Ordering::Release);
+                    .is_err()
+                {
+                    log::warn!(
+                        "initial start_sidecar found RESTART_IN_PROGRESS already held — skipping to avoid a concurrent spawn"
+                    );
+                    return;
                 }
+                let start_result = start_sidecar(&handle, &client, cold_start_file.as_deref()).await;
+                RESTART_IN_PROGRESS.store(false, Ordering::Release);
 
                 if let Err(e) = start_result {
                     log::error!("Sidecar failed: {e}");
@@ -1723,31 +1733,6 @@ async fn port_holder_for_dialog() -> Option<PortHolder> {
     }
 }
 
-/// The terminal "your server didn't start" dialog, with a one-shot retry.
-///
-/// This is the dialog a user hits after a Windows auto-update when the old
-/// sidecar's port hasn't released yet. Two things it does that the previous
-/// version did not:
-///
-/// 1. **Names the holder.** `holder` comes from `describe_port_holder`, so the
-///    message says "Port 3479 appears to be held by node.exe (PID 12345)"
-///    instead of asking the user to run `netstat` themselves.
-/// 2. **Offers a retry** (`allow_retry`), which re-runs `start_sidecar` — whose
-///    freshly spawned sidecar calls `freePort()` on both ports as its first act.
-///    The kill therefore stays in `src/server/platform.ts`, its single owner; a
-///    second `taskkill` implementation here would duplicate that logic AND add a
-///    PID-reuse race whose bad outcome is killing the wrong process.
-///
-/// `allow_retry: false` on the second showing — an unbounded retry loop at ~2
-/// minutes a cycle is worse than an honest dead end, and the dead end names the
-/// real remaining exit (Settings → Network → Restart server).
-///
-/// Non-blocking `.show(cb)` deliberately: `blocking_show()` from inside a
-/// `tauri::async_runtime::spawn` task parks this task's worker (see
-/// `show_update_available_dialog`'s doc comment), and the callback form is what
-/// lets the retry spawn async work. Note the callback's `bool` is `true` only
-/// for the first (OK) label — Esc and the title-bar X both arrive as `false`,
-/// i.e. as Close.
 /// Parent a dialog builder to the main window if it exists, else warn and
 /// leave it parentless. Shared by every `show_*_dialog` function below —
 /// `fn_name` names the caller in the log line so a parentless dialog is
@@ -1766,6 +1751,35 @@ fn attach_main_window_or_warn<R: tauri::Runtime>(
     }
 }
 
+/// The terminal "your server didn't start" dialog, with a one-shot retry.
+///
+/// This is the dialog a user hits after a Windows auto-update when the old
+/// sidecar's port hasn't released yet. Two things it does that the previous
+/// version did not:
+///
+/// 1. **Names the holder.** `holder` comes from `describe_port_holder`, so the
+///    message says "Port 3479 appears to be held by node.exe (PID 12345)"
+///    instead of asking the user to run `netstat` themselves.
+/// 2. **Offers a retry** (`allow_retry`), which re-runs `start_sidecar` — whose
+///    freshly spawned sidecar calls `freePort()` on both ports as its first act.
+///    The kill therefore stays in `src/server/platform.ts`, its single owner; a
+///    second `taskkill` implementation here would duplicate that logic AND add a
+///    PID-reuse race whose bad outcome is killing the wrong process. Note this
+///    dialog only appears after `start_sidecar` already ran that same
+///    `freePort()` up to MAX_RESTARTS+1 times without success — the retry's
+///    real new leverage is elapsed time, not a fresh kill mechanism, so the
+///    message text says "try to end", not "will end".
+///
+/// `allow_retry: false` on the second showing — an unbounded retry loop at ~2
+/// minutes a cycle is worse than an honest dead end, and the dead end names the
+/// real remaining exit (Settings → Network → Restart server).
+///
+/// Non-blocking `.show(cb)` deliberately: `blocking_show()` from inside a
+/// `tauri::async_runtime::spawn` task parks this task's worker (see
+/// `show_update_available_dialog`'s doc comment), and the callback form is what
+/// lets the retry spawn async work. Note the callback's `bool` is `true` only
+/// for the first (OK) label — Esc and the title-bar X both arrive as `false`,
+/// i.e. as Close.
 fn show_server_error_dialog(
     app: &tauri::AppHandle,
     error: &str,
@@ -1784,15 +1798,21 @@ fn show_server_error_dialog(
     }
     if allow_retry {
         // Say what the retry will actually DO. When we have identified a live
-        // process, retrying terminates it — "free the port" does not read as
-        // "end node.exe, discarding its unsaved state" to a non-technical user,
-        // and the likeliest collision in this codebase's own workflow is a dev
-        // server the user cares about. When the port is merely in TIME_WAIT
-        // there is nothing to kill and the retry works only because time
-        // passed; promising to "free the port" there would be a lie.
+        // process, retrying attempts to terminate it — "free the port" does
+        // not read as "end node.exe, discarding its unsaved state" to a
+        // non-technical user, and the likeliest collision in this codebase's
+        // own workflow is a dev server the user cares about. "Attempts" rather
+        // than a flat promise: by the time this dialog shows, `start_sidecar`
+        // has already run `freePort()` against this same holder up to
+        // MAX_RESTARTS+1 times without success, so a holder that survived all
+        // of those (elevated/protected, or something that respawns) may well
+        // survive one more — don't claim certainty the mechanism hasn't earned.
+        // When the port is merely in TIME_WAIT there is nothing to kill and
+        // the retry works only because time passed; promising to "free the
+        // port" there would be a lie.
         match holder.as_ref().and_then(|h| h.killable_process.as_deref()) {
             Some(proc) => message.push_str(&format!(
-                "\n\nRetry Server Start will end {proc} and start Tandem's server again. \
+                "\n\nRetry Server Start will try to end {proc} and start Tandem's server again. \
                  This can take up to two minutes."
             )),
             None => message.push_str(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1791,7 +1791,7 @@ fn show_server_error_dialog(
 
     let mut message = format!("Tandem's server failed to start.\n\nError: {error}\n\n");
     match &holder {
-        Some(h) => message.push_str(&h.message),
+        Some(h) => message.push_str(&h.message()),
         None => message.push_str(&format!(
             "Ports {WS_PORT} and {MCP_PORT} must be free for Tandem's server to start."
         )),
@@ -1810,7 +1810,7 @@ fn show_server_error_dialog(
         // When the port is merely in TIME_WAIT there is nothing to kill and
         // the retry works only because time passed; promising to "free the
         // port" there would be a lie.
-        match holder.as_ref().and_then(|h| h.killable_process.as_deref()) {
+        match holder.as_ref().and_then(|h| h.killable_process()) {
             Some(proc) => message.push_str(&format!(
                 "\n\nRetry Server Start will try to end {proc} and start Tandem's server again. \
                  This can take up to two minutes."
@@ -2843,17 +2843,60 @@ fn run_system32_tool(exe: &str, args: &[&str]) -> Option<String> {
 }
 
 /// What is holding one of the sidecar's ports, and whether the retry can do
-/// anything about it.
+/// anything about it. An enum rather than a `{ message, killable_process }`
+/// struct deliberately: those two fields were only ever kept in sync by both
+/// return sites of `describe_port_holder` being written carefully by hand —
+/// nothing stopped a future construction site from naming a process in
+/// `message` while leaving `killable_process` `None`, which is exactly the
+/// kind of contradictory-dialog bug this type exists to prevent. With the
+/// population as the only source of truth, `message()` and
+/// `killable_process()` below derive both user-facing strings from the same
+/// value, so that drift is unrepresentable rather than merely avoided.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
-pub(crate) struct PortHolder {
+pub(crate) enum PortHolder {
+    /// A live process we can name and that a retry would terminate.
+    Listener { port: u16, pid: u32, name: Option<String> },
+    /// Windows TIME_WAIT: the old sidecar is gone, so there is no owning
+    /// process, but the OS hasn't released the port yet. Nothing to kill;
+    /// the retry works only because time passed.
+    Lingering { port: u16 },
+}
+
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+impl PortHolder {
     /// User-facing sentence, already hedged. Never logged or emitted — it goes
     /// straight into the native dialog.
-    pub message: String,
-    /// A live process we can name and that a retry would terminate. None for
-    /// the TIME_WAIT case, where there is no process to kill and the retry
-    /// succeeds only because time passed.
-    pub killable_process: Option<String>,
+    fn message(&self) -> String {
+        match self {
+            PortHolder::Listener { port, pid, name } => {
+                format!("Port {port} appears to be held by {}.", describe_process(*pid, name.as_deref()))
+            }
+            PortHolder::Lingering { port } => format!(
+                "Port {port} is still tied up by a connection from a previous run \
+                 (Windows releases these after a short delay). No other program is using it."
+            ),
+        }
+    }
+
+    /// A description of the process a retry would terminate, or `None` for
+    /// the `Lingering` case where there is nothing to kill.
+    fn killable_process(&self) -> Option<String> {
+        match self {
+            PortHolder::Listener { pid, name, .. } => Some(describe_process(*pid, name.as_deref())),
+            PortHolder::Lingering { .. } => None,
+        }
+    }
+}
+
+/// Shared by `PortHolder::message` and `PortHolder::killable_process` so the
+/// two can't describe the same process differently.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn describe_process(pid: u32, name: Option<&str>) -> String {
+    match name {
+        Some(n) => format!("{n} (PID {pid})"),
+        None => format!("PID {pid}"),
+    }
 }
 
 /// Describe what is holding one of `ports`.
@@ -2885,13 +2928,7 @@ fn describe_port_holder(ports: &[u16]) -> Option<PortHolder> {
     let Some(first) = parse_netstat_listening_pid(&netstat, ports) else {
         // No listener — check for the TIME_WAIT population before giving up.
         let port = parse_netstat_lingering_port(&netstat, ports)?;
-        return Some(PortHolder {
-            message: format!(
-                "Port {port} is still tied up by a connection from a previous run \
-                 (Windows releases these after a short delay). No other program is using it."
-            ),
-            killable_process: None,
-        });
+        return Some(PortHolder::Lingering { port });
     };
     let (port, pid) = first;
 
@@ -2909,14 +2946,7 @@ fn describe_port_holder(ports: &[u16]) -> Option<PortHolder> {
         return None;
     }
 
-    let described = match &name {
-        Some(n) => format!("{n} (PID {pid})"),
-        None => format!("PID {pid}"),
-    };
-    Some(PortHolder {
-        message: format!("Port {port} appears to be held by {described}."),
-        killable_process: Some(described),
-    })
+    Some(PortHolder::Listener { port, pid, name })
 }
 
 /// Non-Windows: no diagnostic. The failures this serves are Windows-specific
@@ -5311,7 +5341,7 @@ Active Connections
         let port = listener.local_addr().expect("local_addr").port();
 
         let holder = describe_port_holder(&[port]).expect("a held port must be described");
-        let described = holder.message;
+        let described = holder.message();
 
         assert!(
             described.contains(&format!("Port {port}")),
@@ -5328,10 +5358,14 @@ Active Connections
             described.to_ascii_lowercase().contains(".exe"),
             "should resolve the image name via tasklist, not fall back to PID-only: {described}"
         );
-        // A live listener is killable, so the dialog is allowed to promise the
-        // retry will end it. The TIME_WAIT branch must NOT set this.
+        // A live listener is killable, so the dialog is allowed to say the
+        // retry will try to end it. The TIME_WAIT branch must report None here.
         assert!(
-            holder.killable_process.is_some(),
+            matches!(holder, PortHolder::Listener { .. }),
+            "a live listener must be reported as the Listener variant"
+        );
+        assert!(
+            holder.killable_process().is_some(),
             "a live listener must be reported as killable"
         );
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,14 +83,63 @@ const LICENSE_STATUS_URL: &str = "http://127.0.0.1:3479/api/license/status";
 /// expanded by tauri-plugin-updater at check time.
 const LICENSE_UPDATE_ENDPOINT: &str = "";
 const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(200);
-const HEALTH_TIMEOUT: Duration = Duration::from_secs(15);
+/// How long each `start_sidecar` attempt waits for `/health` before declaring
+/// the sidecar dead.
+///
+/// This times a wait that HAPPENS INSIDE the sidecar: `waitForPort` in
+/// `src/server/platform.ts` polls for the TCP port to release (15s default)
+/// before Hocuspocus/MCP can bind and answer `/health`. So this constant must
+/// stay comfortably above that one — at 15s each, a sidecar that legitimately
+/// waited out a slow Windows TIME_WAIT release would be killed by its own
+/// shell, which is the post-update failure this pairing exists to prevent.
+///
+/// It is NOT universal margin. The store-lock acquisition in
+/// `src/server/index.ts` retries for up to a further 30s when a genuinely live
+/// process holds `store.lock` (a stray `tandem start`, a second app-data dir).
+/// That case is a different failure with its own deadline and its own error
+/// message; we deliberately do not size this constant for it.
+const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
 const HTTP_CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
 /// How long to wait for the sidecar to exit after POST /api/shutdown before
 /// hard-killing it. The Node shutdown's disk flush is 5s-bounded
 /// (src/server/index.ts), so 6s covers the flush plus the session save in the
 /// common case while keeping the restart button responsive (#1088).
 const GRACEFUL_SHUTDOWN_DEADLINE_SECS: u64 = 6;
+/// How long `perform_install` waits for the killed sidecar to stop answering
+/// `/health` before starting the update download/install anyway.
+///
+/// Note what this actually observes: `wait_for_port_release` polls the HTTP
+/// endpoint, so it detects "the server is gone", NOT "the OS has released the
+/// TCP port" — a socket in TIME_WAIT is invisible to it. The rename would be
+/// `wait_for_server_gone`; the name is kept for churn reasons but do not read a
+/// port-state guarantee into it.
+///
+/// 15s rather than 5s because the machine is at its slowest exactly here —
+/// mid-update, with antivirus scanning freshly written files — and a kill that
+/// takes longer than the deadline means we start overwriting files while the
+/// old process may still be alive. The polling loop returns the instant the
+/// server stops answering, so a wider ceiling costs a healthy machine nothing.
+const POST_KILL_PORT_RELEASE_SECS: u64 = 15;
+/// How long `perform_install` waits for Windows to release the sidecar exe's
+/// file handle so the NSIS installer can overwrite it. Same reasoning, same
+/// budget as POST_KILL_PORT_RELEASE_SECS — TerminateProcess returns before the
+/// OS drops the handle.
+#[cfg(target_os = "windows")]
+const SIDECAR_UNLOCK_DEADLINE_SECS: u64 = 15;
+/// How long `port_holder_for_dialog` waits for `describe_port_holder`'s
+/// `netstat`/`tasklist` calls before giving up and showing the generic
+/// message. Unlike the deadlines above, this isn't coupled to another
+/// timeout elsewhere — it only bounds a best-effort diagnostic on the
+/// terminal failure dialog, so a wedged lookup fails toward "less detail",
+/// never toward blocking the dialog itself.
+const PORT_HOLDER_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_RESTARTS: u32 = 3;
+/// The two TCP ports the sidecar binds. Used by the port-holder diagnostic on
+/// the exhausted-restarts path; keep in sync with the URL constants above and
+/// with DEFAULT_WS_PORT / DEFAULT_MCP_PORT in src/shared/constants.ts. Pinned
+/// against the URL constants by `port_constants_match_urls`.
+const WS_PORT: u16 = 3478;
+const MCP_PORT: u16 = 3479;
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(8 * 60 * 60);
 
 /// Cadence of the Cowork self-heal pass (see `cowork_heal_pass`): installs
@@ -1223,19 +1272,30 @@ pub fn run() {
                     log::warn!("Sample file copy failed (non-fatal): {e}");
                 }
 
-                if let Err(e) = start_sidecar(&handle, &client, cold_start_file.as_deref()).await {
+                // Hold RESTART_IN_PROGRESS across the initial spawn. The window
+                // mounts while this is still looping — and that loop is now up
+                // to ~2 minutes (HEALTH_TIMEOUT 30s x 4 attempts) — so Settings
+                // → Network → Restart server is clickable the whole time. Without
+                // the gate, `restart_sidecar` would find it free and run a second
+                // start_sidecar concurrently, racing this one over SidecarState
+                // and orphaning a child. That is the exact failure the gate was
+                // added for; only this call site was outside it.
+                // CAS rather than a bare store, and release only what we took:
+                // a blind store would clear a gate held by someone else.
+                let gate_held = RESTART_IN_PROGRESS
+                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok();
+                let start_result = start_sidecar(&handle, &client, cold_start_file.as_deref()).await;
+                if gate_held {
+                    RESTART_IN_PROGRESS.store(false, Ordering::Release);
+                }
+
+                if let Err(e) = start_result {
                     log::error!("Sidecar failed: {e}");
-                    use tauri_plugin_dialog::DialogExt;
-                    handle
-                        .dialog()
-                        .message(format!(
-                            "Tandem's server failed to start.\n\n\
-                             Error: {e}\n\n\
-                             Try restarting the application. If the problem persists, \
-                             check that port 3479 is not in use by another process."
-                        ))
-                        .title("Server Error")
-                        .show(|_| {});
+                    // Ask the OS what is actually holding the port instead of
+                    // telling the user to go find out.
+                    let holder = port_holder_for_dialog().await;
+                    show_server_error_dialog(&handle, &e, holder, cold_start_file, true);
                     return;
                 }
 
@@ -1606,10 +1666,17 @@ fn restart_sidecar(app: tauri::AppHandle) {
         // Restart never re-injects the cold-start file: the original `setup()`
         // invocation already opened it and registered it in `openDocuments`.
         if let Err(e) = start_sidecar(&handle, &client, None).await {
-            // Detailed error stays in the log sink only — never user-visible.
             // The emitted event carries a stable code, no error detail, so the
-            // WebView can surface a generic toast without leaking paths, env
-            // vars, errno text, or the auth token.
+            // WebView's toast can never leak paths, env vars, errno text, or
+            // the auth token.
+            //
+            // NB: "the detail stays in the log sink" is not the same as "the
+            // detail is not user-visible" — `tauri-plugin-log` registers
+            // `TargetKind::Webview` at LevelFilter::Warn in release, so this
+            // `log::error!` is forwarded to the WebView as a `log://log` event
+            // (nothing in src/client currently listens). The emit below is what
+            // carries the contract; the log line is not a second, quieter
+            // channel. Keep sensitive detail out of both.
             log::error!("[restart_sidecar] failed to restart sidecar: {e}");
             eprintln!("[restart_sidecar] failed to restart sidecar: {e}");
             if let Err(emit_err) =
@@ -1622,6 +1689,199 @@ fn restart_sidecar(app: tauri::AppHandle) {
         // leave the button usable for another attempt.
         RESTART_IN_PROGRESS.store(false, Ordering::Release);
     });
+}
+
+/// Look up the port holder for the error dialog, off the reactor and bounded.
+///
+/// Two guards, both load-bearing on Windows: `spawn_blocking` because
+/// `describe_port_holder` runs external processes synchronously, and a
+/// timeout because it runs them with no deadline of their own. A wedged
+/// `netstat` (huge connection table, a misbehaving NDIS/LSP filter) must not
+/// stop the user from getting a dialog at all — a generic message beats
+/// silence on the one path whose entire job is to tell the user something
+/// went wrong. On other platforms `describe_port_holder` is a pure `None`
+/// stub, so the async/timeout machinery would only add ceremony around a
+/// function that can't block or panic.
+#[cfg(not(target_os = "windows"))]
+async fn port_holder_for_dialog() -> Option<PortHolder> {
+    describe_port_holder(&[WS_PORT, MCP_PORT])
+}
+
+#[cfg(target_os = "windows")]
+async fn port_holder_for_dialog() -> Option<PortHolder> {
+    let lookup = tauri::async_runtime::spawn_blocking(|| describe_port_holder(&[WS_PORT, MCP_PORT]));
+    match tokio::time::timeout(PORT_HOLDER_LOOKUP_TIMEOUT, lookup).await {
+        Ok(Ok(holder)) => holder,
+        Ok(Err(e)) => {
+            log::debug!("Port-holder lookup panicked: {e}");
+            None
+        }
+        Err(_) => {
+            log::warn!("Port-holder lookup timed out — showing the generic message");
+            None
+        }
+    }
+}
+
+/// The terminal "your server didn't start" dialog, with a one-shot retry.
+///
+/// This is the dialog a user hits after a Windows auto-update when the old
+/// sidecar's port hasn't released yet. Two things it does that the previous
+/// version did not:
+///
+/// 1. **Names the holder.** `holder` comes from `describe_port_holder`, so the
+///    message says "Port 3479 appears to be held by node.exe (PID 12345)"
+///    instead of asking the user to run `netstat` themselves.
+/// 2. **Offers a retry** (`allow_retry`), which re-runs `start_sidecar` — whose
+///    freshly spawned sidecar calls `freePort()` on both ports as its first act.
+///    The kill therefore stays in `src/server/platform.ts`, its single owner; a
+///    second `taskkill` implementation here would duplicate that logic AND add a
+///    PID-reuse race whose bad outcome is killing the wrong process.
+///
+/// `allow_retry: false` on the second showing — an unbounded retry loop at ~2
+/// minutes a cycle is worse than an honest dead end, and the dead end names the
+/// real remaining exit (Settings → Network → Restart server).
+///
+/// Non-blocking `.show(cb)` deliberately: `blocking_show()` from inside a
+/// `tauri::async_runtime::spawn` task parks this task's worker (see
+/// `show_update_available_dialog`'s doc comment), and the callback form is what
+/// lets the retry spawn async work. Note the callback's `bool` is `true` only
+/// for the first (OK) label — Esc and the title-bar X both arrive as `false`,
+/// i.e. as Close.
+/// Parent a dialog builder to the main window if it exists, else warn and
+/// leave it parentless. Shared by every `show_*_dialog` function below —
+/// `fn_name` names the caller in the log line so a parentless dialog is
+/// traceable to which one fired.
+fn attach_main_window_or_warn<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    builder: tauri_plugin_dialog::MessageDialogBuilder<R>,
+    fn_name: &str,
+) -> tauri_plugin_dialog::MessageDialogBuilder<R> {
+    match app.get_webview_window(MAIN_WINDOW_LABEL) {
+        Some(window) => builder.parent(&window),
+        None => {
+            log::warn!("{fn_name}: main window not found — dialog will appear parentless");
+            builder
+        }
+    }
+}
+
+fn show_server_error_dialog(
+    app: &tauri::AppHandle,
+    error: &str,
+    holder: Option<PortHolder>,
+    cold_start_file: Option<std::path::PathBuf>,
+    allow_retry: bool,
+) {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+
+    let mut message = format!("Tandem's server failed to start.\n\nError: {error}\n\n");
+    match &holder {
+        Some(h) => message.push_str(&h.message),
+        None => message.push_str(&format!(
+            "Ports {WS_PORT} and {MCP_PORT} must be free for Tandem's server to start."
+        )),
+    }
+    if allow_retry {
+        // Say what the retry will actually DO. When we have identified a live
+        // process, retrying terminates it — "free the port" does not read as
+        // "end node.exe, discarding its unsaved state" to a non-technical user,
+        // and the likeliest collision in this codebase's own workflow is a dev
+        // server the user cares about. When the port is merely in TIME_WAIT
+        // there is nothing to kill and the retry works only because time
+        // passed; promising to "free the port" there would be a lie.
+        match holder.as_ref().and_then(|h| h.killable_process.as_deref()) {
+            Some(proc) => message.push_str(&format!(
+                "\n\nRetry Server Start will end {proc} and start Tandem's server again. \
+                 This can take up to two minutes."
+            )),
+            None => message.push_str(
+                "\n\nRetry Server Start will try again, which usually succeeds once Windows \
+                 has released the port. This can take up to two minutes.",
+            ),
+        }
+    } else {
+        message.push_str(
+            "\n\nClose this dialog, then use Settings \u{2192} Network \u{2192} Restart server \
+             to try again.",
+        );
+    }
+
+    let mut builder = app
+        .dialog()
+        .message(message)
+        .title("Server Error")
+        .kind(MessageDialogKind::Error);
+    builder = attach_main_window_or_warn(app, builder, "show_server_error_dialog");
+
+    if !allow_retry {
+        builder.show(|_| {});
+        return;
+    }
+
+    // "Retry Server Start", not "Retry": the WebView shows its own Retry button
+    // in the "Server unavailable" empty state ~3s into this failure, and that
+    // one only re-dials the Hocuspocus WebSocket. Two same-labelled buttons
+    // meaning different things is worse than a longer label.
+    let handle = app.clone();
+    builder
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Retry Server Start".to_string(),
+            "Close".to_string(),
+        ))
+        .show(move |retry| {
+            if !retry {
+                return;
+            }
+            tauri::async_runtime::spawn(async move {
+                // Take the gate INSIDE the task, not around the `.show()` call:
+                // the plugin discards `run_on_main_thread` errors and its dialog
+                // thread can unwind, so a callback is not guaranteed to run. A
+                // gate acquired outside would then be stranded for the process
+                // lifetime, permanently disabling `restart_sidecar`.
+                if RESTART_IN_PROGRESS
+                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .is_err()
+                {
+                    // Do not just log: the modal is already dismissed, so a
+                    // bare return means the user's explicit click produced
+                    // nothing at all on screen. (Reachable when they hit
+                    // Settings → Network → Restart server first.)
+                    log::warn!("Server-start retry ignored — a restart is already in flight");
+                    show_server_error_dialog(
+                        &handle,
+                        "A server restart is already in progress",
+                        None,
+                        cold_start_file,
+                        false,
+                    );
+                    return;
+                }
+                let client = handle.state::<reqwest::Client>().inner().clone();
+                // Pass the cold-start file through, unlike `restart_sidecar`,
+                // which passes None because setup() already opened it. Here
+                // setup() FAILED, so nothing was opened — dropping it would
+                // silently land a user who double-clicked a .md on welcome.md.
+                let result = start_sidecar(&handle, &client, cold_start_file.as_deref()).await;
+                // Release before anything user-facing, so Settings → Restart
+                // server is usable again while the second dialog is on screen.
+                RESTART_IN_PROGRESS.store(false, Ordering::Release);
+
+                match result {
+                    Ok(()) => {
+                        log::info!("Server-start retry succeeded");
+                        // setup()'s failure path returned before this; without
+                        // it a recovered session gets no update check for 8h.
+                        check_for_update(&handle, false).await;
+                    }
+                    Err(e) => {
+                        log::error!("Server-start retry failed: {e}");
+                        let holder = port_holder_for_dialog().await;
+                        show_server_error_dialog(&handle, &e, holder, cold_start_file, false);
+                    }
+                }
+            });
+        });
 }
 
 /// Build the `(program, args)` tuple that reveals `path` in the host OS file
@@ -2419,6 +2679,232 @@ async fn wait_for_port_release(client: &reqwest::Client, deadline_secs: u64) -> 
         tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
     }
     false
+}
+
+/// One parsed `netstat -ano` TCP row, reduced to the fields that decide whether
+/// it contends with our bind.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+struct NetstatRow {
+    local_port: u16,
+    /// True when the row is a listening socket. Windows LOCALIZES the State
+    /// column, so this is not just a string compare: a foreign address of
+    /// `0.0.0.0:0` / `[::]:0` is the structural signature of a listener and no
+    /// connected state produces it.
+    listening: bool,
+    pid: u32,
+}
+
+/// Parse one `netstat -ano` line, keeping only rows that could block a bind on
+/// our loopback address.
+///
+/// Two subtleties, both regression-tested:
+/// - The port is taken from the LAST `:` of the local-address column, not by
+///   substring match — a substring match also hits `:34790` and the `[::]` prefix.
+/// - A listener on a specific non-loopback interface (WSL/Hyper-V vEthernet,
+///   Docker, a VPN adapter) does NOT prevent a `127.0.0.1` bind, so naming it
+///   would blame an innocent process for a failure it did not cause.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn parse_netstat_row(line: &str) -> Option<NetstatRow> {
+    // Proto | Local Address | Foreign Address | State | PID
+    let cols: Vec<&str> = line.split_whitespace().collect();
+    if cols.len() < 5 || !cols[0].eq_ignore_ascii_case("TCP") {
+        return None;
+    }
+    let (local_addr, local_port_str) = cols[1].rsplit_once(':')?;
+    if !matches!(local_addr, "127.0.0.1" | "0.0.0.0" | "[::]" | "[::1]") {
+        return None;
+    }
+    let local_port = local_port_str.parse::<u16>().ok()?;
+    let foreign_port = cols[2].rsplit_once(':').and_then(|(_, p)| p.parse::<u16>().ok());
+    // The PID is parsed as u32, which is what makes it safe to interpolate into
+    // the tasklist filter later: a u32's Display output is `[0-9]+` by
+    // construction, so no metacharacter can survive. This is the typed
+    // equivalent of the `/^\d+$/` guard in src/server/platform.ts.
+    let pid = cols[4].parse::<u32>().ok()?;
+    Some(NetstatRow {
+        local_port,
+        listening: cols[3].eq_ignore_ascii_case("LISTENING") || foreign_port == Some(0),
+        pid,
+    })
+}
+
+/// Shared scan behind `parse_netstat_listening_pid` and
+/// `parse_netstat_lingering_port` below: find the first row matching one of
+/// `ports` whose `listening` flag equals `listening`. The two callers differ
+/// only in which flag value they want and what they extract from the match.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn find_netstat_row(output: &str, ports: &[u16], listening: bool) -> Option<NetstatRow> {
+    output.lines().find_map(|line| {
+        let row = parse_netstat_row(line)?;
+        (row.listening == listening && ports.contains(&row.local_port)).then_some(row)
+    })
+}
+
+/// Parse `netstat -ano` output for a process LISTENING on one of `ports`.
+/// Returns the first `(port, pid)` match in output order.
+///
+/// Kept out of the `cfg(windows)` block so its tests run on every CI platform;
+/// the allow keeps a non-Windows release build warning-free.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn parse_netstat_listening_pid(output: &str, ports: &[u16]) -> Option<(u16, u32)> {
+    find_netstat_row(output, ports, true).map(|row| (row.local_port, row.pid))
+}
+
+/// Find a port held by a lingering CONNECTION rather than by a live listener —
+/// the Windows TIME_WAIT case.
+///
+/// This is the failure that motivated the whole change and it is invisible to
+/// the function above: a killed listener leaves no LISTENING row, but its
+/// accepted connections sit in TIME_WAIT (owner PID 0) and Windows still
+/// refuses a fresh bind on that port. Without this pass the dialog falls back
+/// to generic text in exactly the headline scenario.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn parse_netstat_lingering_port(output: &str, ports: &[u16]) -> Option<u16> {
+    find_netstat_row(output, ports, false).map(|row| row.local_port)
+}
+
+/// Parse the image name out of `tasklist /NH /FO CSV` output.
+///
+/// Returns None for the `INFO: No tasks are running which match…` line that
+/// tasklist prints — on exit code 0 — when the PID no longer exists.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn parse_tasklist_image_name(output: &str) -> Option<String> {
+    for line in output.lines() {
+        let line = line.trim();
+        // CSV rows are quoted: `"node.exe","12345","Console","1","50,000 K"`.
+        // Anything not starting with a quote is a header, an INFO line, or an
+        // ERROR line — never a row.
+        let Some(rest) = line.strip_prefix('"') else {
+            continue;
+        };
+        let Some((name, _)) = rest.split_once('"') else {
+            continue;
+        };
+        if !name.is_empty() {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+/// Run a Windows system binary and capture stdout, or None on any failure.
+///
+/// Anchored to `%SystemRoot%\System32\` rather than resolved through PATH:
+/// `Command::new("netstat")` searches the application directory (and, absent
+/// `NoDefaultCurrentDirectoryInExePath`, the cwd) ahead of System32, and both
+/// binaries are guaranteed at the fixed path. CREATE_NO_WINDOW keeps a
+/// GUI-subsystem app from flashing a console window.
+///
+/// Fails CLOSED when `SystemRoot` is unset, empty, or non-UTF-8: falling back to
+/// the bare name would do exactly the unanchored PATH lookup this exists to
+/// avoid, and `SystemRoot` is a per-process env var that an unelevated launcher
+/// can set before starting an elevated app. Every caller degrades to generic
+/// text on None, so a skipped diagnostic costs nothing. (`freePortWindows` in
+/// src/server/platform.ts makes the opposite call, deliberately — its lookup is
+/// load-bearing for startup rather than cosmetic.)
+#[cfg(target_os = "windows")]
+fn run_system32_tool(exe: &str, args: &[&str]) -> Option<String> {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    let root = std::env::var("SystemRoot").ok()?;
+    if root.trim().is_empty() {
+        return None;
+    }
+    let program = format!("{root}\\System32\\{exe}");
+    let output = std::process::Command::new(program)
+        .args(args)
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .ok()?;
+    // netstat/tasklist both report "nothing matched" on exit 0, so a non-zero
+    // status is a genuine tool failure and the parsers handle the empty case.
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// What is holding one of the sidecar's ports, and whether the retry can do
+/// anything about it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) struct PortHolder {
+    /// User-facing sentence, already hedged. Never logged or emitted — it goes
+    /// straight into the native dialog.
+    pub message: String,
+    /// A live process we can name and that a retry would terminate. None for
+    /// the TIME_WAIT case, where there is no process to kill and the retry
+    /// succeeds only because time passed.
+    pub killable_process: Option<String>,
+}
+
+/// Describe what is holding one of `ports`.
+///
+/// Two populations, and the second one is the headline case:
+///
+/// 1. **A live listener** — a stale sidecar, a `npm run dev:server`, an
+///    unrelated app. Nameable, and `freePort()` will terminate it on retry.
+/// 2. **A lingering connection (Windows TIME_WAIT)** — the update case. The old
+///    sidecar is gone, so there is no LISTENING row and no owning process, but
+///    Windows still refuses the bind. Nothing to kill; the retry works because
+///    the state expires. Reporting this honestly is the difference between "we
+///    don't know" and "wait a moment and try again".
+///
+/// Best-effort and read-only: every failure returns None and the caller falls
+/// back to generic text. Blocking (up to three `Command::output()` calls) — async
+/// callers must wrap it in `spawn_blocking` AND bound it with a timeout, since a
+/// wedged netstat would otherwise delay the error dialog indefinitely.
+///
+/// The wording is deliberately hedged. Between the netstat lookup and the
+/// tasklist lookup the PID can be recycled, and `docs/troubleshooting.md` tells
+/// users to `taskkill` what we name here — so we re-verify that the same PID
+/// still holds the same port before reporting, and still say "appears to be"
+/// rather than asserting it.
+#[cfg(target_os = "windows")]
+fn describe_port_holder(ports: &[u16]) -> Option<PortHolder> {
+    let netstat = run_system32_tool("netstat.exe", &["-ano"])?;
+
+    let Some(first) = parse_netstat_listening_pid(&netstat, ports) else {
+        // No listener — check for the TIME_WAIT population before giving up.
+        let port = parse_netstat_lingering_port(&netstat, ports)?;
+        return Some(PortHolder {
+            message: format!(
+                "Port {port} is still tied up by a connection from a previous run \
+                 (Windows releases these after a short delay). No other program is using it."
+            ),
+            killable_process: None,
+        });
+    };
+    let (port, pid) = first;
+
+    let name = run_system32_tool(
+        "tasklist.exe",
+        &["/FI", &format!("PID eq {pid}"), "/NH", "/FO", "CSV"],
+    )
+    .and_then(|out| parse_tasklist_image_name(&out));
+
+    // Re-verify: if the holder changed while we were looking it up, anything we
+    // print is about a process that no longer owns the port.
+    let second = parse_netstat_listening_pid(&run_system32_tool("netstat.exe", &["-ano"])?, ports);
+    if second != Some(first) {
+        log::debug!("Port holder changed during lookup — not reporting");
+        return None;
+    }
+
+    let described = match &name {
+        Some(n) => format!("{n} (PID {pid})"),
+        None => format!("PID {pid}"),
+    };
+    Some(PortHolder {
+        message: format!("Port {port} appears to be held by {described}."),
+        killable_process: Some(described),
+    })
+}
+
+/// Non-Windows: no diagnostic. The failures this serves are Windows-specific
+/// (a stale listener surviving an update, or TIME_WAIT after the restart), and
+/// the dialog degrades to its generic text when this returns None.
+#[cfg(not(target_os = "windows"))]
+fn describe_port_holder(_ports: &[u16]) -> Option<PortHolder> {
+    None
 }
 
 /// Resolve the sidecar executable path (alongside the main binary).
@@ -4216,11 +4702,7 @@ fn show_update_available_dialog(app: &tauri::AppHandle, version: &str) -> bool {
         .title("Update Available")
         .kind(MessageDialogKind::Info)
         .buttons(MessageDialogButtons::OkCancel);
-    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
-        builder = builder.parent(&window);
-    } else {
-        log::warn!("show_update_available_dialog: main window not found — dialog will appear parentless");
-    }
+    builder = attach_main_window_or_warn(app, builder, "show_update_available_dialog");
     builder.blocking_show()
 }
 
@@ -4236,11 +4718,7 @@ fn show_up_to_date_dialog(app: &tauri::AppHandle) {
         ))
         .title("No Updates Available")
         .kind(MessageDialogKind::Info);
-    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
-        builder = builder.parent(&window);
-    } else {
-        log::warn!("show_up_to_date_dialog: main window not found — dialog will appear parentless");
-    }
+    builder = attach_main_window_or_warn(app, builder, "show_up_to_date_dialog");
     builder.show(|_| {});
 }
 
@@ -4257,11 +4735,7 @@ fn show_update_error_dialog(app: &tauri::AppHandle, error: &str) {
         ))
         .title("Update Error")
         .kind(MessageDialogKind::Error);
-    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
-        builder = builder.parent(&window);
-    } else {
-        log::warn!("show_update_error_dialog: main window not found — dialog will appear parentless");
-    }
+    builder = attach_main_window_or_warn(app, builder, "show_update_error_dialog");
     builder.show(|_| {});
 }
 
@@ -4411,6 +4885,18 @@ async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Log + record the "sidecar didn't release the port in time" warning shared
+/// by `perform_install`'s Windows and non-Windows branches. Interpolates the
+/// const rather than hardcoding the duration: this string reaches the failure
+/// dialog, and a hardcoded duration would silently go stale on the next bump.
+fn warn_port_still_responding(warnings: &mut Vec<String>) {
+    let msg = format!(
+        "Sidecar still responding after {POST_KILL_PORT_RELEASE_SECS}s kill deadline -- proceeding with install anyway"
+    );
+    log::warn!("{msg}");
+    warnings.push(msg);
+}
+
 /// Shared install flow: kill sidecar, await port + file-lock release, then
 /// download+install via the Tauri updater plugin. On success the application
 /// is restarted; on failure a native dialog surfaces the error.
@@ -4440,25 +4926,23 @@ async fn perform_install(
     #[cfg(target_os = "windows")]
     {
         let (port_ok, file_ok) = tokio::join!(
-            wait_for_port_release(&client, 5),
-            wait_for_sidecar_unlock(5),
+            wait_for_port_release(&client, POST_KILL_PORT_RELEASE_SECS),
+            wait_for_sidecar_unlock(SIDECAR_UNLOCK_DEADLINE_SECS),
         );
         if !port_ok {
-            let msg = "Sidecar still responding after 5s kill deadline -- proceeding with install anyway";
-            log::warn!("{msg}");
-            pre_install_warnings.push(msg.to_string());
+            warn_port_still_responding(&mut pre_install_warnings);
         }
         if !file_ok {
-            let msg = "Sidecar exe still locked after 5s -- installer may prompt for retry";
+            let msg = format!(
+                "Sidecar exe still locked after {SIDECAR_UNLOCK_DEADLINE_SECS}s -- installer may prompt for retry"
+            );
             log::warn!("{msg}");
-            pre_install_warnings.push(msg.to_string());
+            pre_install_warnings.push(msg);
         }
     }
     #[cfg(not(target_os = "windows"))]
-    if !wait_for_port_release(&client, 5).await {
-        let msg = "Sidecar still responding after 5s kill deadline -- proceeding with install anyway";
-        log::warn!("{msg}");
-        pre_install_warnings.push(msg.to_string());
+    if !wait_for_port_release(&client, POST_KILL_PORT_RELEASE_SECS).await {
+        warn_port_still_responding(&mut pre_install_warnings);
     }
 
     match update.download_and_install(
@@ -4633,11 +5117,45 @@ mod pending_opens_tests {
 mod url_constants_tests {
     use super::*;
 
+    // The port constants used by the port-holder diagnostic must agree with the
+    // URL literals — they are two spellings of the same fact, and a diagnostic
+    // probing the wrong port silently degrades to "no holder found".
+    #[test]
+    fn port_constants_match_urls() {
+        assert!(
+            HEALTH_URL.contains(&format!(":{MCP_PORT}/")),
+            "MCP_PORT ({MCP_PORT}) must match HEALTH_URL ({HEALTH_URL})"
+        );
+        assert_eq!(WS_PORT + 1, MCP_PORT, "WS/MCP ports are adjacent by convention");
+    }
+
+    // HEALTH_TIMEOUT times a wait that happens INSIDE the sidecar: waitForPort
+    // in src/server/platform.ts polls up to 15s for the TCP port to release
+    // before the server can bind and answer /health. If this drops back to 15s
+    // the shell kills sidecars that were legitimately waiting — the post-update
+    // "Server failed to start after 3 restart attempts" failure.
+    //
+    // This can only pin ITS half of the coupling; Rust cannot read the TS
+    // default. The other half is pinned by "defaults to a 15s ceiling" in
+    // tests/server/platform.test.ts. Raising waitForPort's default without
+    // raising this constant leaves BOTH tests green and reopens the bug —
+    // the two must move together.
+    #[test]
+    fn health_timeout_exceeds_sidecar_port_wait() {
+        assert!(
+            HEALTH_TIMEOUT.as_secs() >= 30,
+            "HEALTH_TIMEOUT ({}s) must stay well above waitForPort's 15s default \
+             in src/server/platform.ts",
+            HEALTH_TIMEOUT.as_secs()
+        );
+    }
+
     // Regression guard for #477 PR 2 + #637 + #686. The server's isHostAllowed
     // gate (api-routes.ts) rejects bare `localhost` Host headers; if these
     // constants drift back to `http://localhost:…`, the supervisor's
-    // health-poll 403's for 15s and `npm run dev:tauri` reports
-    // "Server failed to start after 3 restart attempts".
+    // health-poll 403's for the whole HEALTH_TIMEOUT window and
+    // `npm run dev:tauri` reports "Server failed to start after 3 restart
+    // attempts".
     #[test]
     fn supervisor_urls_use_loopback_ip_not_localhost() {
         for (name, url) in [
@@ -4651,6 +5169,170 @@ mod url_constants_tests {
                 "{name} must use 127.0.0.1 (got {url}) — see #477 PR 2"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod port_holder_tests {
+    use super::*;
+
+    // Verbatim `netstat -ano` output shape (captured on Windows 11), trimmed to
+    // the rows that matter. Fixture realism is the point: a hand-written table
+    // would not have caught the `[::]:` prefix, which is why the parser splits
+    // on the LAST colon rather than matching a substring.
+    const NETSTAT: &str = "
+Active Connections
+
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       1520
+  TCP    127.0.0.1:3479         0.0.0.0:0              LISTENING       12345
+  TCP    [::]:445               [::]:0                 LISTENING       4
+";
+
+    #[test]
+    fn finds_the_ipv4_listener_on_a_requested_port() {
+        assert_eq!(parse_netstat_listening_pid(NETSTAT, &[3478, 3479]), Some((3479, 12345)));
+    }
+
+    #[test]
+    fn finds_an_ipv6_listener() {
+        let out = "  TCP    [::]:3479              [::]:0                 LISTENING       777\n";
+        assert_eq!(parse_netstat_listening_pid(out, &[3479]), Some((3479, 777)));
+        // The bracketed address contains colons of its own — a substring match
+        // on ":3479" would work here but break on the negative cases below.
+        assert_eq!(parse_netstat_listening_pid(out, &[3478]), None);
+    }
+
+    #[test]
+    fn does_not_match_a_longer_port_with_the_same_prefix() {
+        let out = "  TCP    127.0.0.1:34790        0.0.0.0:0              LISTENING       999\n";
+        assert_eq!(parse_netstat_listening_pid(out, &[3479]), None);
+    }
+
+    #[test]
+    fn ignores_non_listening_rows() {
+        // An ESTABLISHED row on the same port is a client connection, not the
+        // process holding the port against a fresh bind.
+        let out = "  TCP    127.0.0.1:3479         127.0.0.1:5500         ESTABLISHED     42\n";
+        assert_eq!(parse_netstat_listening_pid(out, &[3479]), None);
+    }
+
+    #[test]
+    fn ignores_listeners_on_non_contending_interfaces() {
+        // A WSL/Hyper-V/Docker adapter listening on its own address does not
+        // prevent a 127.0.0.1 bind, so it is not the cause of our failure —
+        // naming it would blame an innocent process, and the retry would kill it.
+        let out = "  TCP    172.28.16.1:3479       0.0.0.0:0              LISTENING       777\n";
+        assert_eq!(parse_netstat_listening_pid(out, &[3479]), None);
+    }
+
+    #[test]
+    fn treats_a_wildcard_foreign_port_as_listening() {
+        // Windows LOCALIZES the State column, so a non-English host never says
+        // "LISTENING". A foreign address of *:0 is the structural signature of
+        // a listening socket and no connected state produces it.
+        let out = "  TCP    127.0.0.1:3479         0.0.0.0:0              ABIERTO         31\n";
+        assert_eq!(parse_netstat_listening_pid(out, &[3479]), Some((3479, 31)));
+    }
+
+    #[test]
+    fn finds_a_lingering_connection_when_there_is_no_listener() {
+        // THE headline case: the old sidecar is gone (no LISTENING row) but its
+        // connections sit in TIME_WAIT with owner PID 0, and Windows still
+        // refuses the bind. Without this pass the dialog falls back to generic
+        // text in exactly the scenario the feature was built for.
+        let out = "  TCP    127.0.0.1:3479         127.0.0.1:52000        TIME_WAIT       0\n";
+        assert_eq!(parse_netstat_listening_pid(out, &[3479]), None);
+        assert_eq!(parse_netstat_lingering_port(out, &[3479]), Some(3479));
+    }
+
+    #[test]
+    fn a_live_listener_is_not_reported_as_lingering() {
+        assert_eq!(parse_netstat_lingering_port(NETSTAT, &[3479]), None);
+    }
+
+    #[test]
+    fn returns_none_for_empty_or_garbage_output() {
+        assert_eq!(parse_netstat_listening_pid("", &[3479]), None);
+        assert_eq!(parse_netstat_listening_pid("not a table at all", &[3479]), None);
+        assert_eq!(parse_netstat_lingering_port("", &[3479]), None);
+        // Header row: rejected on the Proto column (it is not "TCP").
+        assert_eq!(
+            parse_netstat_listening_pid("  Proto  Local Address  Foreign Address  State  PID", &[3479]),
+            None
+        );
+    }
+
+    #[test]
+    fn reads_the_image_name_from_a_tasklist_csv_row() {
+        // Verbatim `tasklist /FI "PID eq 4" /NH /FO CSV` output.
+        let out = "\"System\",\"4\",\"Services\",\"0\",\"5,060 K\"\n";
+        assert_eq!(parse_tasklist_image_name(out), Some("System".to_string()));
+    }
+
+    #[test]
+    fn returns_none_when_no_task_matches() {
+        // tasklist prints this on EXIT CODE 0 for a PID that no longer exists,
+        // so exit status cannot be used to detect the miss.
+        let out = "INFO: No tasks are running which match the specified criteria.\n";
+        assert_eq!(parse_tasklist_image_name(out), None);
+    }
+
+    // The parser tests above pin the pure logic against captured fixtures; this
+    // one exercises the real pipeline — System32 resolution, CREATE_NO_WINDOW,
+    // the live output format, and the re-verification pass — by holding a port
+    // ourselves and asking who has it. Without it, a wrong argument vector or a
+    // netstat output-format drift would pass every other test in this module.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn describes_a_port_this_test_process_is_holding() {
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().expect("local_addr").port();
+
+        let holder = describe_port_holder(&[port]).expect("a held port must be described");
+        let described = holder.message;
+
+        assert!(
+            described.contains(&format!("Port {port}")),
+            "should name the port it was asked about: {described}"
+        );
+        assert!(
+            described.contains(&format!("PID {}", std::process::id())),
+            "should name this test process (pid {}): {described}",
+            std::process::id()
+        );
+        // Without this the tasklist half could fail entirely and the test would
+        // still pass on the PID-only fallback format.
+        assert!(
+            described.to_ascii_lowercase().contains(".exe"),
+            "should resolve the image name via tasklist, not fall back to PID-only: {described}"
+        );
+        // A live listener is killable, so the dialog is allowed to promise the
+        // retry will end it. The TIME_WAIT branch must NOT set this.
+        assert!(
+            holder.killable_process.is_some(),
+            "a live listener must be reported as killable"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn describes_nothing_when_the_port_is_free() {
+        let port = {
+            let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+            probe.local_addr().expect("local_addr").port()
+        }; // dropped — port released
+        assert_eq!(describe_port_holder(&[port]), None);
+    }
+
+    #[test]
+    fn returns_none_for_empty_or_malformed_output() {
+        assert_eq!(parse_tasklist_image_name(""), None);
+        assert_eq!(parse_tasklist_image_name("garbage without quotes"), None);
+        assert_eq!(parse_tasklist_image_name("\"\",\"4\""), None);
+        // Unterminated quote — never a real row.
+        assert_eq!(parse_tasklist_image_name("\"node.exe"), None);
     }
 }
 

--- a/src/server/integrations/acl-win.ts
+++ b/src/server/integrations/acl-win.ts
@@ -39,8 +39,8 @@
  */
 
 import { execFile } from "node:child_process";
-import { join } from "node:path";
 import { promisify } from "node:util";
+import { systemBin } from "../platform.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -48,16 +48,6 @@ function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
     throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
   }
-}
-
-/**
- * Resolve a Windows system binary by absolute path under `%SystemRoot%`.
- * Bypasses `PATH` so a git-bash / MSYS / Cygwin shadow (e.g. their own
- * `whoami` that doesn't understand Windows flags) can't intercept us.
- * `icacls` and `whoami` both live in `System32`.
- */
-export function systemBin(name: string): string {
-  return join(process.env.SystemRoot ?? "C:\\Windows", "System32", name);
 }
 
 /**

--- a/src/server/integrations/acl-win.ts
+++ b/src/server/integrations/acl-win.ts
@@ -56,7 +56,7 @@ function throwIfAborted(signal?: AbortSignal): void {
  * `whoami` that doesn't understand Windows flags) can't intercept us.
  * `icacls` and `whoami` both live in `System32`.
  */
-function systemBin(name: string): string {
+export function systemBin(name: string): string {
   return join(process.env.SystemRoot ?? "C:\\Windows", "System32", name);
 }
 

--- a/src/server/platform.ts
+++ b/src/server/platform.ts
@@ -2,7 +2,6 @@ import { execFileSync, execSync } from "child_process";
 import envPaths from "env-paths";
 import net from "net";
 import path from "path";
-import { systemBin } from "./integrations/acl-win.js";
 
 /**
  * Resolve the Tandem app-data root directory. `TANDEM_APP_DATA_DIR` overrides
@@ -12,6 +11,18 @@ export function resolveAppDataDir(): string {
   const envOverride = process.env.TANDEM_APP_DATA_DIR;
   if (envOverride && envOverride.length > 0) return envOverride;
   return envPaths("tandem", { suffix: "" }).data;
+}
+
+/**
+ * Resolve a Windows system binary by absolute path under `%SystemRoot%`.
+ * Bypasses `PATH` so a git-bash / MSYS / Cygwin shadow (e.g. their own
+ * `whoami` that doesn't understand Windows flags) can't intercept us.
+ * Lives here rather than in a feature module (e.g. `integrations/acl-win.ts`,
+ * a former home) because this file is a leaf utility imported broadly across
+ * `src/server` — a feature module importing a leaf is fine, the reverse isn't.
+ */
+export function systemBin(name: string): string {
+  return path.join(process.env.SystemRoot ?? "C:\\Windows", "System32", name);
 }
 
 const APP_DATA_DIR = resolveAppDataDir();

--- a/src/server/platform.ts
+++ b/src/server/platform.ts
@@ -2,6 +2,7 @@ import { execFileSync, execSync } from "child_process";
 import envPaths from "env-paths";
 import net from "net";
 import path from "path";
+import { systemBin } from "./integrations/acl-win.js";
 
 /**
  * Resolve the Tandem app-data root directory. `TANDEM_APP_DATA_DIR` overrides
@@ -41,8 +42,23 @@ export function freePort(port: number): void {
  * Poll until a TCP port is available for binding.
  * Replaces the fixed 300ms sleep after freePort() — the OS may need
  * longer to release a killed process's socket (especially on Windows).
+ *
+ * The 15s default is a Windows post-update figure, not a guess. Windows can
+ * hold a killed listener's port in TIME_WAIT for several seconds, and the
+ * moment that is most likely is immediately after an auto-update restart —
+ * fresh files on disk, antivirus scanning them, the installer still settling.
+ * The previous 5s ceiling was reported failing there: the sidecar gave up
+ * waiting, bound anyway (callers log and proceed), took EADDRINUSE, and died,
+ * which the Tauri shell surfaces as "Server failed to start after 3 restart
+ * attempts".
+ *
+ * Widening costs nothing on a healthy machine — this polls and returns as soon
+ * as the port is free. But it IS coupled to HEALTH_TIMEOUT in
+ * `src-tauri/src/lib.rs`, which times this wait from outside the process:
+ * that constant must stay comfortably above this one or the shell kills a
+ * sidecar that was legitimately waiting.
  */
-export async function waitForPort(port: number, timeoutMs = 5000): Promise<void> {
+export async function waitForPort(port: number, timeoutMs = 15000): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     if (await tryBind(port)) return;
@@ -85,15 +101,67 @@ export function parseSsPid(output: string): number | null {
   return match ? parseInt(match[1], 10) : null;
 }
 
+/**
+ * Parse `netstat -ano` output for the PIDs of processes LISTENING on `port` in
+ * a way that would contend with our own `127.0.0.1` bind.
+ *
+ * This replaced `netstat -ano | findstr ":${port}.*LISTENING"`, which was wrong
+ * in three ways that all end in killing the wrong process:
+ *
+ * 1. `findstr` takes a REGEX matched anywhere in the line, so `:3479.*LISTENING`
+ *    also matched `127.0.0.1:34790  …  LISTENING` — a different service.
+ * 2. The result was `.split(/\s+/).at(-1)` over the whole multi-line blob, so
+ *    with several matching rows only the LAST row's PID was taken, which need
+ *    not be the row that matched the port.
+ * 3. A listener bound to a specific non-loopback interface (WSL/Hyper-V vEthernet,
+ *    Docker, a VPN adapter) does not block a `127.0.0.1` bind, but matched anyway.
+ *
+ * The column-aware parse fixes all three, and deliberately mirrors
+ * `parse_netstat_listening_pid` in `src-tauri/src/lib.rs` — the Tauri shell
+ * NAMES the holder in its error dialog and this function KILLS it, so the two
+ * must agree on which row is the holder or the dialog blames one process while
+ * the retry terminates another.
+ *
+ * Locale note: the State column is localized by Windows, so a row also counts as
+ * listening when its Foreign Address port is 0 (`0.0.0.0:0` / `[::]:0`) — the
+ * structural signature of a listening socket, which no connected state produces.
+ */
+export function parseNetstatListeningPids(output: string, port: number): number[] {
+  const pids: number[] = [];
+  for (const line of output.split("\n")) {
+    const cols = line.trim().split(/\s+/);
+    // Proto | Local Address | Foreign Address | State | PID
+    if (cols.length < 5 || cols[0].toUpperCase() !== "TCP") continue;
+
+    const localPort = cols[1].slice(cols[1].lastIndexOf(":") + 1);
+    if (localPort !== String(port)) continue;
+
+    // Only addresses that actually contend with a 127.0.0.1 bind.
+    const localAddr = cols[1].slice(0, cols[1].lastIndexOf(":"));
+    if (!["127.0.0.1", "0.0.0.0", "[::]", "[::1]"].includes(localAddr)) continue;
+
+    const foreignPort = cols[2].slice(cols[2].lastIndexOf(":") + 1);
+    const listening = cols[3].toUpperCase() === "LISTENING" || foreignPort === "0";
+    if (!listening) continue;
+
+    // Integer parse is the injection guard (the old `/^\d+$/` in typed form):
+    // only a value that round-trips as a non-negative integer is passed to
+    // taskkill, and it is passed as a discrete argv element, never a shell string.
+    const pid = Number(cols[4]);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    if (!pids.includes(pid)) pids.push(pid);
+  }
+  return pids;
+}
+
 function freePortWindows(port: number): void {
-  const out = execSync(`netstat -ano | findstr ":${port}.*LISTENING"`, {
+  const out = execFileSync(systemBin("netstat.exe"), ["-ano"], {
     encoding: "utf-8",
     stdio: ["pipe", "pipe", "ignore"],
   });
-  const pid = out.trim().split(/\s+/).at(-1);
-  if (pid && /^\d+$/.test(pid)) {
+  for (const pid of parseNetstatListeningPids(out, port)) {
     try {
-      const killOut = execFileSync("taskkill", ["/PID", pid, "/F"], {
+      const killOut = execFileSync(systemBin("taskkill.exe"), ["/PID", String(pid), "/F"], {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
       });

--- a/tests/server/platform.test.ts
+++ b/tests/server/platform.test.ts
@@ -1,9 +1,10 @@
 import net from "net";
 import path from "path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   freePort,
   parseLsofPids,
+  parseNetstatListeningPids,
   parseSsPid,
   resolveAppDataDir,
   SESSION_DIR,
@@ -72,6 +73,80 @@ LISTEN 0      128    127.0.0.1:3478       0.0.0.0:*     users:(("node",pid=12345
     });
   });
 
+  // These pin the process-selection half of freePort() on Windows. The old
+  // implementation piped netstat through `findstr ":${port}.*LISTENING"` — a
+  // regex matched anywhere in the line — and then took the last whitespace
+  // token of the whole blob, so it could kill a process that merely had a
+  // similar-looking port. Since the Tauri shell now NAMES the holder in its
+  // error dialog while this function KILLS it, the two must select the same row.
+  describe("parseNetstatListeningPids", () => {
+    // Verbatim `netstat -ano` shape captured on Windows 11.
+    const NETSTAT = [
+      "",
+      "Active Connections",
+      "",
+      "  Proto  Local Address          Foreign Address        State           PID",
+      "  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       1520",
+      "  TCP    127.0.0.1:3479         0.0.0.0:0              LISTENING       12345",
+      "  TCP    [::]:445               [::]:0                 LISTENING       4",
+      "",
+    ].join("\n");
+
+    it("finds the PID listening on the requested port", () => {
+      expect(parseNetstatListeningPids(NETSTAT, 3479)).toEqual([12345]);
+    });
+
+    it("does not match a longer port sharing the prefix", () => {
+      // The regression the old findstr regex had: ":3479.*LISTENING" matched
+      // this row, so freePort killed an unrelated service.
+      const out = "  TCP    127.0.0.1:34790        0.0.0.0:0              LISTENING       999\n";
+      expect(parseNetstatListeningPids(out, 3479)).toEqual([]);
+    });
+
+    it("ignores connected rows on the same port", () => {
+      const out = "  TCP    127.0.0.1:3479         127.0.0.1:5500         ESTABLISHED     42\n";
+      expect(parseNetstatListeningPids(out, 3479)).toEqual([]);
+    });
+
+    it("ignores listeners on interfaces that don't contend with a loopback bind", () => {
+      // A WSL/Hyper-V/Docker adapter listening on its own address does not
+      // prevent Tandem binding 127.0.0.1 — killing it would be pure collateral.
+      const out = "  TCP    172.28.16.1:3479       0.0.0.0:0              LISTENING       777\n";
+      expect(parseNetstatListeningPids(out, 3479)).toEqual([]);
+    });
+
+    it("returns every distinct holder, not just the last row", () => {
+      // The old `.at(-1)` over the whole blob returned one PID — and not
+      // necessarily one from a matching row.
+      const out = [
+        "  TCP    127.0.0.1:3479         0.0.0.0:0              LISTENING       111",
+        "  TCP    [::]:3479              [::]:0                 LISTENING       222",
+        "  TCP    [::]:445               [::]:0                 LISTENING       4",
+      ].join("\n");
+      expect(parseNetstatListeningPids(out, 3479)).toEqual([111, 222]);
+    });
+
+    it("treats a wildcard foreign port as listening (localized Windows)", () => {
+      // netstat localizes the State column, so "LISTENING" is absent on a
+      // non-English host. A foreign address of *:0 is the structural signature.
+      const out = "  TCP    127.0.0.1:3479         0.0.0.0:0              ABIERTO         31\n";
+      expect(parseNetstatListeningPids(out, 3479)).toEqual([31]);
+    });
+
+    it("returns nothing for empty, header-only, or garbage output", () => {
+      expect(parseNetstatListeningPids("", 3479)).toEqual([]);
+      expect(parseNetstatListeningPids("no table here", 3479)).toEqual([]);
+      expect(
+        parseNetstatListeningPids("  Proto  Local Address  Foreign Address  State  PID", 3479),
+      ).toEqual([]);
+    });
+
+    it("rejects a non-numeric PID column", () => {
+      const out = "  TCP    127.0.0.1:3479         0.0.0.0:0              LISTENING       n/a\n";
+      expect(parseNetstatListeningPids(out, 3479)).toEqual([]);
+    });
+  });
+
   describe("waitForPort", () => {
     let holdServer: net.Server | null = null;
 
@@ -117,6 +192,36 @@ LISTEN 0      128    127.0.0.1:3478       0.0.0.0:*     users:(("node",pid=12345
       const elapsed = Date.now() - start;
       expect(elapsed).toBeGreaterThanOrEqual(200);
       expect(elapsed).toBeLessThan(3000);
+    });
+
+    // Pins the DEFAULT timeout (no explicit argument). Uses fake timers so the
+    // 15s ceiling costs no wall clock. The default is coupled to HEALTH_TIMEOUT
+    // in src-tauri/src/lib.rs — the Tauri shell times this wait from outside the
+    // process, so lowering one without the other resurrects the post-update
+    // "Server failed to start after 3 restart attempts" failure.
+    it("defaults to a 15s ceiling", async () => {
+      holdServer = net.createServer();
+      await new Promise<void>((resolve) => holdServer!.listen(0, "127.0.0.1", resolve));
+      const port = (holdServer.address() as net.AddressInfo).port;
+
+      vi.useFakeTimers();
+      try {
+        let settled: "pending" | "rejected" = "pending";
+        const pending = waitForPort(port).catch((err: Error) => {
+          settled = "rejected";
+          return err;
+        });
+
+        await vi.advanceTimersByTimeAsync(14_900);
+        expect(settled).toBe("pending");
+
+        await vi.advanceTimersByTimeAsync(400);
+        const err = await pending;
+        expect(settled).toBe("rejected");
+        expect((err as Error).message).toBe(`Port ${port} still not available after 15000ms`);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("throws when port stays occupied past timeout", async () => {

--- a/tests/server/platform.test.ts
+++ b/tests/server/platform.test.ts
@@ -108,6 +108,17 @@ LISTEN 0      128    127.0.0.1:3478       0.0.0.0:*     users:(("node",pid=12345
       expect(parseNetstatListeningPids(out, 3479)).toEqual([]);
     });
 
+    it("does not treat a TIME_WAIT row as a listener (headline case: killed sidecar's lingering connection)", () => {
+      // Mirrors `finds_a_lingering_connection_when_there_is_no_listener` in
+      // src-tauri/src/lib.rs — same row, same claim: the old sidecar is gone
+      // (no LISTENING row) but its connections sit in TIME_WAIT with owner PID
+      // 0, and freePortWindows must not try to taskkill PID 0. The Rust and TS
+      // parsers must agree here or the dialog names one thing and the kill
+      // targets another.
+      const out = "  TCP    127.0.0.1:3479         127.0.0.1:52000        TIME_WAIT       0\n";
+      expect(parseNetstatListeningPids(out, 3479)).toEqual([]);
+    });
+
     it("ignores listeners on interfaces that don't contend with a loopback bind", () => {
       // A WSL/Hyper-V/Docker adapter listening on its own address does not
       // prevent Tandem binding 127.0.0.1 — killing it would be pure collateral.


### PR DESCRIPTION
## Summary

A beta user (real, live report) hit "Server failed to start after 3 restart attempts" immediately after a Windows auto-update from v0.21.1 to v0.22.0. Root cause: the fresh sidecar has to reclaim ports 3478/3479 from the copy that was just killed, and three separate timeouts in that path (`wait_for_port_release`, `wait_for_sidecar_unlock` in `perform_install`, and `waitForPort` in the freshly-restarted sidecar) all gave up after ~5s — exactly the wrong budget for the one moment a machine is guaranteed to be slow (antivirus scanning fresh files, the installer still settling, general post-update load).

- **Widened timeouts.** All three ~5s ceilings → 15s. `HEALTH_TIMEOUT` (the Rust-side deadline that wraps the sidecar's own `waitForPort`) moves 15s → 30s so it can't kill a sidecar that's legitimately still waiting — the two are now pinned to each other by tests on both sides, with a comment on each pointing at the other. These are polling loops that return the instant the resource frees, so a healthy machine pays nothing.
- **Self-service failure.** When retries still exhaust, the dialog now identifies what's holding the port (Windows: parses `netstat`/`tasklist`, including the TIME_WAIT-but-PID-0 case that a listener-only probe misses) and offers a one-shot **Retry Server Start** that re-runs the same `start_sidecar` path, rather than sending the user to a terminal to run `netstat`/`taskkill` by hand.
- **Fixed a real bug found while building the diagnostic.** The existing `freePortWindows` netstat matching (`netstat -ano | findstr ":${port}.*LISTENING"`) was loose enough to match `:34790` while hunting for `:3479`, and took the last PID in a multi-line blob rather than the PID from the matched row — i.e. it could kill the wrong process. Replaced with a column-aware parser (mirrored in Rust for the read-only diagnostic and TS for the actual kill), verified live against a decoy process on a neighboring port.

## Process

Plan drafted and adversarially reviewed before implementation (`docs/plans/2026-08-12-windows-update-restart-port-timeouts.md`) — review caught the `HEALTH_TIMEOUT` coupling, the TIME_WAIT/PID-0 gap in the original diagnostic design, and a stale privacy claim about where the port-holder string was logged. `/simplify` ran afterward across reuse/simplification/efficiency/altitude; findings applied: a `system32()` duplicate of an existing `acl-win.ts` helper, a copy-pasted "attach main window or warn" block (now the 4th instance → extracted), two duplicated code paths in the Rust netstat parsing and `perform_install` warning construction, and a magic-number timeout promoted to a named constant.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 6491 passed, 0 failed
- [x] `cargo test` (src-tauri) — 176+23 passed, 0 warnings
- [x] `cargo check` — clean after the simplify-pass refactor
- [x] `biome check src/ tests/` — clean
- [x] Live-verified on this Windows 11 box: `describe_port_holder` correctly names a port this process holds (including image name via `tasklist`), and `freePortWindows`'s new parser reclaims the right PID while leaving a decoy on a neighboring port alone
- [ ] **Needs Bryan's hardware**: the actual update→restart flow end-to-end (requires a signed release + a real v0.21.1→next-version update to reproduce the original failure) and the new custom-button "Server Error" dialog's rendering (`OkCancelCustom` is the first custom-label task dialog in this codebase)

Two accepted, documented gaps (in the plan doc): Settings → Restart server silently no-ops while a Retry Server Start is already in flight; worst-case time-to-dialog on total failure rises from ~67s to ~127s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5TQnz5CtadvuWzV88uAqa