### PR TITLE
refactor(theme): restructure useTauriTheme's push pipeline into two lifecycle-split records

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3340,7 +3340,7 @@ fn set_native_theme(
     // Fail closed AND fail loud. The action above has already released any
     // prior force, so the accessibility scheme wins — but the push did not
     // achieve the requested theme, and resolving it as success would let the
-    // client latch `lastPush.pref` on a preference the OS does not have,
+    // client latch its dedupe on a preference the OS does not have,
     // deduping every later attempt to re-apply it. That is #992 itself,
     // silently restored, so report the uncertainty instead.
     if high_contrast == HighContrast::Unknown {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3340,7 +3340,7 @@ fn set_native_theme(
     // Fail closed AND fail loud. The action above has already released any
     // prior force, so the accessibility scheme wins — but the push did not
     // achieve the requested theme, and resolving it as success would let the
-    // client latch `lastPushedPref` on a preference the OS does not have,
+    // client latch `lastPush.pref` on a preference the OS does not have,
     // deduping every later attempt to re-apply it. That is #992 itself,
     // silently restored, so report the uncertainty instead.
     if high_contrast == HighContrast::Unknown {

--- a/src/client/hooks/useTauriTheme.svelte.ts
+++ b/src/client/hooks/useTauriTheme.svelte.ts
@@ -132,7 +132,12 @@ let pushSeq = 0;
 // in `setNativeTheme`, leaving an armed retry of a *rejected* push free to
 // land later and release an override while the app renders an explicit theme.
 // A rejection means "no claim", full stop.
-let lastPush: { pref: ThemePreference; inFlight: boolean; issuedAt: number } | null = null;
+let lastPush: {
+  pref: ThemePreference;
+  inFlight: boolean;
+  issuedAt: number;
+  viaRetry: boolean;
+} | null = null;
 
 // What the native layer actually DID: the last RESOLVED outcome's
 // `overrideActive`. The push pipeline writes it through exactly ONE function,
@@ -218,7 +223,19 @@ function cancelRetry(): void {
     clearTimeout(retryHandle);
     retryHandle = null;
     retryAttempts = 0;
+    return;
   }
+  // A retry whose timer has already FIRED is not covered by the branch above:
+  // the timer nulls `retryHandle` before re-pushing, so between that and the
+  // `invoke` settling there is an armed ladder with no handle to find. A new
+  // user intent arriving in that window is still a new intent and must get a
+  // full budget — otherwise it silently inherits a partly-spent counter and
+  // retries fewer times than the next one, with no way to tell from the logs.
+  //
+  // `viaRetry` is what distinguishes it from the retry's OWN re-entry, which
+  // must keep its budget (that call sees `lastPush === null`, because the
+  // `.catch` cleared it before arming the timer).
+  if (lastPush?.viaRetry) retryAttempts = 0;
 }
 
 /** Stops the poll if it is running. Idempotent. */
@@ -378,6 +395,17 @@ function acceptReadback(seqAtIssue: number, next: "light" | "dark"): void {
  * must not be misread as a general reset.
  */
 export function setNativeTheme(pref: ThemePreference): void {
+  pushNativeTheme(pref, false);
+}
+
+/**
+ * The push itself. `viaRetry` exists so `cancelRetry` can tell a retry's own
+ * re-entry (keeps its budget) from a new user intent superseding an in-flight
+ * retry (gets a fresh one). It is deliberately NOT a parameter on the exported
+ * `setNativeTheme`: no caller outside this module can meaningfully supply it,
+ * and an optional boolean on the public surface would invite one to try.
+ */
+function pushNativeTheme(pref: ThemePreference, viaRetry: boolean): void {
   if (!isTauriRuntime()) return;
   // Cancel BEFORE the dedupe check, not after. A new intent supersedes a
   // pending retry whether or not it needs an `invoke`. Today this is a
@@ -399,7 +427,7 @@ export function setNativeTheme(pref: ThemePreference): void {
   // which is `< PUSH_SETTLE_CEILING_MS` — pinning the read-back gate shut for
   // as long as the offset persists. That is precisely the frozen-theme failure
   // the ceiling exists to guarantee against.
-  lastPush = { pref, inFlight: true, issuedAt: performance.now() };
+  lastPush = { pref, inFlight: true, issuedAt: performance.now(), viaRetry };
   getInvoke()
     .then((invoke) => invoke<NativeThemeOutcome>("set_native_theme", { theme: pref }))
     .then((outcome) => {
@@ -445,7 +473,7 @@ export function setNativeTheme(pref: ThemePreference): void {
         retryAttempts++;
         retryHandle = setTimeout(() => {
           retryHandle = null;
-          setNativeTheme(pref);
+          pushNativeTheme(pref, true);
         }, delay);
         console.warn(
           `[useTauriTheme] set_native_theme("${pref}") failed (retry ${retryAttempts}/${MAX_PUSH_RETRIES}):`,

--- a/src/client/hooks/useTauriTheme.svelte.ts
+++ b/src/client/hooks/useTauriTheme.svelte.ts
@@ -46,8 +46,8 @@ let _initialized = false;
 // the native layer actually DID). They are split by LIFECYCLE, not by field
 // list — a rejection voids the whole of `lastPush` in one expression and must
 // never name `lastResolved`. A NEW pipeline fact belongs as a field on one of
-// them rather than as another module `let`; `issuedAt` below is the worked
-// example, and it needed no `_resetForTests` line.
+// them rather than as another module `let` — a field is cleared with its
+// record, so `_resetForTests` cannot fall out of sync with it.
 //
 // REQUIRED: both are plain module `let`s and must NEVER become `$state`.
 // `setNativeTheme` both reads `lastPush?.pref` and writes `lastPush = {…}`
@@ -71,12 +71,13 @@ let invokePromise: Promise<InvokeFn> | null = null;
 let pollIntervalHandle: ReturnType<typeof setInterval> | null = null;
 
 // Monotonic ticket dispenser, bumped on every `setNativeTheme` call. A push
-// compares its own ticket against THIS counter, never against `lastPush` —
-// which is why no `seq` field lives on that record: comparing against the
-// record instead of the dispenser flips the retry decision when two pushes
-// are in flight and the older one rejects. Doubles as the staleness stamp
-// async read-backs (onThemeChanged, the poll) capture at issue time — see
-// `acceptReadback` below.
+// compares its own ticket against THIS counter, never against `lastPush`, and
+// no `seq` field lives on that record for two reasons. First, the `.catch`
+// sets `lastPush = null` BEFORE the seq compare, so a record-based compare
+// would read `undefined` and the retry would never fire for an unsuperseded
+// push — the one case retries exist for. Second, this counter is also the
+// staleness stamp that async read-backs (onThemeChanged, the poll) capture at
+// issue time, when `lastPush` may be null; see `acceptReadback` below.
 let pushSeq = 0;
 
 // What we ASSERTED to the native layer: the preference last sent to
@@ -117,6 +118,14 @@ let lastPush: { pref: ThemePreference; inFlight: boolean; issuedAt: number } | n
 // `acceptReadback`) so an OS notification arriving while an explicit override
 // is forced (macOS only — Windows always resolves `false`) isn't mistaken for
 // a real user-driven OS change.
+//
+// It is a record rather than the bare boolean it replaced, and every read is
+// truthiness, so the wrapper carries no data the boolean did not. What it
+// carries is LEGIBILITY: #1362 was caused by the failure path writing
+// `overrideActive = false`, which reads as innocuous cleanup. The equivalent
+// write here is `lastResolved = { overrideActive: false }`, which reads as
+// inventing a resolution that never happened. The compiler still permits it —
+// this raises the bar, it does not close the hole (see the header).
 let lastResolved: { overrideActive: boolean } | null = null;
 
 // Bounded retry for a rejected push. Without this, a failed *release* would
@@ -140,10 +149,16 @@ let retryAttempts = 0;
 //
 // 3000 ms is justified from two independent directions: Rust's own wait in
 // `apply_app_mode` is `rx.recv_timeout(Duration::from_secs(2))`, so a healthy
-// push settles well inside it; and it equals the 3s poll period below, so a
-// hung push costs at most one poll tick before degrading to the pre-#1369
-// behaviour.
+// push settles well inside it; and it matches `POLL_INTERVAL_MS`, so a hung
+// push costs at most one poll tick before degrading to the pre-#1369
+// behaviour. Deliberately NOT defined as `= POLL_INTERVAL_MS`: the Rust
+// timeout is the primary justification and must keep holding if the poll is
+// ever retuned. If you change the poll, re-check this comment rather than
+// assuming the equality is load-bearing.
 const PUSH_SETTLE_CEILING_MS = 3000;
+
+/** How often the focused window re-reads the OS theme as a fallback. */
+const POLL_INTERVAL_MS = 3000;
 
 /** Cancels a scheduled push retry, if any. Idempotent. */
 function cancelRetry(): void {
@@ -255,7 +270,6 @@ function setTauriTheme(next: "light" | "dark"): void {
  *    like the `false` this used to initialize to.
  */
 function acceptReadback(seqAtIssue: number, next: "light" | "dark"): void {
-  // Bounded, not unconditional -- see PUSH_SETTLE_CEILING_MS.
   if (lastPush?.inFlight && Date.now() - lastPush.issuedAt < PUSH_SETTLE_CEILING_MS) return;
   if (seqAtIssue !== pushSeq) return; // issued before the latest push -- stale
   if (lastResolved?.overrideActive) return; // echo of our own force (macOS only)
@@ -305,18 +319,32 @@ function acceptReadback(seqAtIssue: number, next: "light" | "dark"): void {
  * must not be misread as a general reset.
  */
 export function setNativeTheme(pref: ThemePreference): void {
-  if (!isTauriRuntime() || pref === lastPush?.pref) return;
+  if (!isTauriRuntime()) return;
+  // Cancel BEFORE the dedupe check, not after. A new intent supersedes a
+  // pending retry whether or not it needs an `invoke`. Today this is a
+  // provable no-op in the deduped case, because an armed retry implies
+  // `lastPush === null` (retries are armed only in the `.catch`, which nulls
+  // it, and only when `seq === pushSeq`) — so a deduped call cannot have one
+  // pending. That invariant is exactly what #1369 proposed to break by
+  // widening the dedupe input to a last-RESOLVED preference: the re-picked
+  // pref would short-circuit past this line and leave a rejected push's retry
+  // armed to release the override under an explicit theme. Hoisting it costs
+  // nothing and makes the ordering safe independently of that reasoning.
+  cancelRetry();
+  if (pref === lastPush?.pref) return;
   const seq = ++pushSeq;
-  cancelRetry(); // a newer push supersedes any pending retry
   lastPush = { pref, inFlight: true, issuedAt: Date.now() };
   getInvoke()
     .then((invoke) => invoke<NativeThemeOutcome>("set_native_theme", { theme: pref }))
     .then((outcome) => {
       if (seq !== pushSeq) return; // superseded by a later push -- discard
-      // MUTATE, never reassign. `lastPush = { pref, inFlight: false, … }` here
-      // would resurrect a dedupe claim that a concurrent stale rejection
-      // deliberately voided, silently deduping away the next same-pref push.
-      // The `if` guard IS that case -- not defensive noise.
+      // MUTATE, never reassign, and the `if` guard is not defensive noise: it
+      // is the case where a concurrent stale rejection voided the claim. The
+      // reassigning form would not be *wrong* here -- this push is current
+      // (`seq === pushSeq`) and it succeeded -- but mutating keeps "a
+      // rejection voids the claim, and nothing undoes that" a ONE-WAY
+      // invariant with a single writer per direction. That is what makes the
+      // `.catch` below readable as the whole failure story.
       if (lastPush) lastPush.inFlight = false;
       lastResolved = { overrideActive: outcome.overrideActive };
       retryAttempts = 0;
@@ -450,7 +478,7 @@ export function initTauriTheme(): void {
           pollErrorLogged = true;
         }
       });
-  }, 3000);
+  }, POLL_INTERVAL_MS);
 
   // Clean up the polling interval. pagehide is more reliable than unload in
   // Chromium-based environments (including Tauri's WebView2).

--- a/src/client/hooks/useTauriTheme.svelte.ts
+++ b/src/client/hooks/useTauriTheme.svelte.ts
@@ -16,14 +16,23 @@ declare global {
  * the reading is authoritative, because Rust reads `window.theme()` AFTER
  * applying/releasing the override. That is the mechanism that lets a
  * transition back to `"system"` resolve correctly in the SAME round trip
- * instead of waiting on the 3s poll below (see `setNativeTheme`).
+ * instead of waiting on the poll below (see `setNativeTheme`).
  *
- * Expressed as a discriminated union rather than a flat struct so that
- * contract is enforced by the compiler instead of by this comment:
+ * Expressed as a discriminated union rather than a flat struct, because
  * `{ overrideActive: true, osTheme: "dark" }` is exactly the pair that would
- * write an echo of our own force into `tauriTheme.current`, and it must not
- * type-check. Serde cannot express this from the Rust side's flat struct, but
- * TypeScript is the consumer and is free to be stricter than the producer.
+ * write an echo of our own force into `tauriTheme.current`. Serde cannot
+ * express that from the Rust side's flat struct, but TypeScript is the
+ * consumer and is free to be stricter than the producer.
+ *
+ * Be clear about what this does NOT do. The type reaches values only through
+ * `invoke<NativeThemeOutcome>(...)`, an unchecked assertion, so the compiler
+ * polices no producer and validates no payload -- the forbidden pair can
+ * arrive over the wire and type-check fine. What actually enforces the
+ * contract is the `!outcome.overrideActive` guard in `setNativeTheme`'s
+ * `.then`, at runtime, where the violation could originate; the union's job is
+ * to make that guard the obvious shape and to type `recordResolution`'s
+ * parameter. Field-name fidelity against Rust's serde attributes is pinned
+ * separately, by `tests/docs/native-theme-claims.test.ts`.
  */
 type NativeThemeOutcome =
   | { overrideActive: true; osTheme: null }
@@ -44,10 +53,13 @@ let _initialized = false;
 // The push pipeline's own state lives in exactly TWO records below:
 // `lastPush` (what we ASSERTED to the native layer) and `lastResolved` (what
 // the native layer actually DID). They are split by LIFECYCLE, not by field
-// list — a rejection voids the whole of `lastPush` in one expression and must
-// never name `lastResolved`. A NEW pipeline fact belongs as a field on one of
-// them rather than as another module `let` — a field is cleared with its
-// record, so `_resetForTests` cannot fall out of sync with it.
+// list — a rejection voids the whole of `lastPush` in one expression, and it
+// may never write a RESOLUTION into `lastResolved`. (Once the retry ladder is
+// exhausted it does drop `lastResolved` to `null` — "we no longer know" is not
+// a resolution, and the `.catch` argues why that beats suppressing forever.)
+// A NEW pipeline fact belongs as a field on one of them rather than as another
+// module `let` — a field is cleared with its record, so `_resetForTests`
+// cannot fall out of sync with it.
 //
 // REQUIRED: both are plain module `let`s and must NEVER become `$state`.
 // `setNativeTheme` both reads `lastPush?.pref` and writes `lastPush = {…}`
@@ -55,8 +67,14 @@ let _initialized = false;
 // (useTheme.svelte.ts). A rune would (a) subscribe that effect to the push
 // pipeline, re-running `applyTheme` on every settle — precisely the
 // accidental subscription the notes in `createTheme` exist to avoid — and
-// (b) place a `$state` write inside an active reaction, which throws
-// `state_unsafe_mutation` in production as well as in dev. The sibling
+// (b) make that effect self-invalidating, since it both reads `lastPush?.pref`
+// and writes `lastPush` in one body: an unbounded re-run surfacing as
+// `effect_update_depth_exceeded`. Note it would NOT be `state_unsafe_mutation`
+// — that fires only when the active reaction matches `DERIVED | BLOCK_EFFECT |
+// ASYNC | EAGER_EFFECT`, and a plain `$effect` is `EFFECT | USER_EFFECT`,
+// which matches none of them (verified against the installed runtime; this
+// comment previously named the wrong error). Reason (a) carries the
+// conclusion on its own. The sibling
 // `useTauriFileDrop.svelte.ts` states that it "mirrors `useTauriTheme.svelte.ts`
 // in shape" and DOES declare a module-scope `$state`; do not mirror that back
 // here. `tauriTheme.current` is the only reactive value in this module.
@@ -66,18 +84,22 @@ let _initialized = false;
 // of each site doing its own `import("@tauri-apps/api/core")`.
 let invokePromise: Promise<InvokeFn> | null = null;
 
-// The 3s poll interval handle, held here (not just closed over inside
+// The poll interval handle, held here (not just closed over inside
 // `initTauriTheme`) so `_resetForTests()` can clear it.
 let pollIntervalHandle: ReturnType<typeof setInterval> | null = null;
 
 // Monotonic ticket dispenser, bumped on every `setNativeTheme` call. A push
 // compares its own ticket against THIS counter, never against `lastPush`, and
-// no `seq` field lives on that record for two reasons. First, the `.catch`
-// sets `lastPush = null` BEFORE the seq compare, so a record-based compare
-// would read `undefined` and the retry would never fire for an unsuperseded
-// push — the one case retries exist for. Second, this counter is also the
-// staleness stamp that async read-backs (onThemeChanged, the poll) capture at
-// issue time, when `lastPush` may be null; see `acceptReadback` below.
+// no `seq` field lives on that record. The durable reason: this counter is
+// ALSO the staleness stamp that async read-backs (onThemeChanged, the poll)
+// capture at issue time, when `lastPush` may be null — a record-based stamp
+// would have nothing to read there. See `acceptReadback` below.
+//
+// A second reason holds as the `.catch` is currently ordered — `lastPush =
+// null` precedes the seq compare, so a record-based compare would read
+// `undefined` and the retry would never fire for an unsuperseded push, the one
+// case retries exist for. True, but defeated by moving two adjacent
+// statements; don't mistake it for the structural argument.
 let pushSeq = 0;
 
 // What we ASSERTED to the native layer: the preference last sent to
@@ -92,52 +114,75 @@ let pushSeq = 0;
 // still in flight short-circuits instead of duplicating it.
 //
 // On rejection it is cleared to `null` — NOT restored to its previous value.
-// Restoring the previous value is a *guess* that the failed push never
-// landed, and the guess inverts in the case that actually happens: a
-// `recv_timeout` in Rust's `apply_app_mode` abandons the wait but does not
-// cancel the queued closure, so the mode can apply a moment later. The latch
-// would then claim the old preference while the OS holds the new one, and
-// re-picking the old one would be deduped away forever. `null` means "no
-// claim", which is the only honest state after a failure and guarantees the
-// next push proceeds whatever its value.
+// Restoring the previous value is a *guess* that the failed push never landed,
+// and a rejection is exactly the state in which we cannot know. Rust names one
+// concrete way the guess inverts: `apply_app_mode`'s `recv_timeout` abandons
+// the wait without cancelling the queued closure, so the mode can apply a
+// moment later (Windows-only, and today unreachable because the closure runs
+// inline — but the Rust side bounds the receive anyway, on the grounds that
+// the inlining is a Tauri implementation detail). The latch would then claim
+// the old preference while the OS holds the new one, and re-picking the old
+// one would be deduped away forever. `null` means "no claim", which is the
+// only honest state after a failure and guarantees the next push proceeds
+// whatever its value.
 //
 // This is the ONLY dedupe input, and `lastResolved` deliberately carries no
 // `pref` field to become a second one. Deduping against the last CONFIRMED
 // preference would let a re-pick of it short-circuit past the `cancelRetry()`
 // in `setNativeTheme`, leaving an armed retry of a *rejected* push free to
-// land later and release an override while the app renders an explicit theme
-// — the `recv_timeout` hazard described just above. A rejection means "no
-// claim", full stop.
+// land later and release an override while the app renders an explicit theme.
+// A rejection means "no claim", full stop.
 let lastPush: { pref: ThemePreference; inFlight: boolean; issuedAt: number } | null = null;
 
 // What the native layer actually DID: the last RESOLVED outcome's
-// `overrideActive`. Assigned at exactly ONE site — the non-superseded `.then`
-// in `setNativeTheme` — and the failure path never names this variable,
-// because a rejected push leaves the native override state UNKNOWN and that
-// is precisely what the client cannot guess. Gates read-backs (see
-// `acceptReadback`) so an OS notification arriving while an explicit override
-// is forced (macOS only — Windows always resolves `false`) isn't mistaken for
-// a real user-driven OS change.
+// `overrideActive`. The push pipeline writes it through exactly ONE function,
+// `recordResolution` below (plus the initializer and `_resetForTests`), and
+// the failure path never records a resolution — a rejected push leaves the
+// native override state UNKNOWN, and that is precisely what the client cannot
+// guess. Gates read-backs (see `acceptReadback`) so an OS notification
+// arriving while an explicit override is forced (macOS only — Windows always
+// resolves `false`) isn't mistaken for a real user-driven OS change.
 //
-// It is a record rather than the bare boolean it replaced, and every read is
-// truthiness, so the wrapper carries no data the boolean did not. What it
-// carries is LEGIBILITY: #1362 was caused by the failure path writing
-// `overrideActive = false`, which reads as innocuous cleanup. The equivalent
-// write here is `lastResolved = { overrideActive: false }`, which reads as
-// inventing a resolution that never happened. The compiler still permits it —
-// this raises the bar, it does not close the hole (see the header).
+// A record rather than the bare boolean it replaced, because the boolean could
+// not distinguish "never resolved" from "resolved to `false`" — it initialized
+// to the same value it would eventually settle to. `null` is that third state,
+// and it is exactly the state #1362 fabricated a false claim about. Every read
+// is truthiness today, so the distinction is representable rather than
+// consumed; that is deliberate, and it is why a new pipeline fact belongs here
+// as a field rather than as another module `let`.
 let lastResolved: { overrideActive: boolean } | null = null;
 
-// Bounded retry for a rejected push. Without this, a failed *release* would
-// leave `lastResolved.overrideActive` true, which suppresses both the 3s poll
-// and every `onThemeChanged` — so `tauriTheme.current` would stop moving and
-// the app's own `data-theme` would stop following the OS for the rest of the
-// session. Capped and cancelled on supersession so a persistently failing
-// invoke cannot hot-loop.
+/**
+ * The only writer of `lastResolved` in the push pipeline. Taking a whole
+ * `NativeThemeOutcome` is the point, not ceremony: the failure path has no
+ * outcome in hand, so recording one from there means visibly fabricating an
+ * IPC payload rather than assigning a bare `false` — which is what #1362 did.
+ * This raises the bar; it does not close the hole.
+ */
+function recordResolution(outcome: NativeThemeOutcome): void {
+  lastResolved = { overrideActive: outcome.overrideActive };
+}
+
+// Bounded retry for a rejected push. Without it, a failed *release* would leave
+// `lastResolved.overrideActive` true, which suppresses both the poll and every
+// `onThemeChanged` — so `tauriTheme.current` would stop moving and the app's
+// own `data-theme` would stop following the OS. The ladder is capped so a
+// persistently failing invoke cannot hot-loop; PAST the cap the `.catch` drops
+// `lastResolved` to `null`, because once we have stopped trying, "unknown" has
+// to degrade to "stop suppressing" rather than to "suppress forever".
+//
+// `retryAttempts` belongs to ONE user intent, not to the session. It is reset
+// by `cancelRetry` when a new intent supersedes an armed ladder, and again at
+// exhaustion. Without those resets a user toggling themes against a failing
+// invoke burns the whole budget in three picks, and every later failure gets
+// zero retries — silently.
 const MAX_PUSH_RETRIES = 3;
 const RETRY_BASE_MS = 500;
 let retryHandle: ReturnType<typeof setTimeout> | null = null;
 let retryAttempts = 0;
+
+/** How often the focused window re-reads the OS theme as a fallback. */
+const POLL_INTERVAL_MS = 3000;
 
 // Ceiling on how long an UNSETTLED push may suppress OS read-backs (see
 // `acceptReadback`). The bound is not optional: a hung `invoke` never
@@ -147,28 +192,36 @@ let retryAttempts = 0;
 // therefore freeze `tauriTheme.current` for the whole session — exactly the
 // failure the retry ladder exists to prevent, reintroduced by the guard.
 //
-// 3000 ms is justified from two independent directions: Rust's own wait in
-// `apply_app_mode` is `rx.recv_timeout(Duration::from_secs(2))`, so a healthy
-// push settles well inside it; and it matches `POLL_INTERVAL_MS`, so a hung
-// push costs at most one poll tick before degrading to the pre-#1369
-// behaviour. Deliberately NOT defined as `= POLL_INTERVAL_MS`: the Rust
-// timeout is the primary justification and must keep holding if the poll is
-// ever retuned. If you change the poll, re-check this comment rather than
-// assuming the equality is load-bearing.
-const PUSH_SETTLE_CEILING_MS = 3000;
+// ONE poll tick is the whole justification, which is why this is defined as
+// `POLL_INTERVAL_MS` rather than repeating its number: a hung push costs at
+// most one missed re-read, and the next poll re-establishes the OS reading.
+//
+// An earlier revision cited Rust's `recv_timeout(Duration::from_secs(2))` in
+// `apply_app_mode` as the PRIMARY justification. Do not reinstate that: it is
+// wrong twice over. `apply_app_mode` is `#[cfg(target_os = "windows")]`, and
+// macOS — which routes to `SetWindowTheme` — is the only platform where
+// `overrideActive` is ever true, i.e. the only platform this gate exists for.
+const PUSH_SETTLE_CEILING_MS = POLL_INTERVAL_MS;
 
-/** How often the focused window re-reads the OS theme as a fallback. */
-const POLL_INTERVAL_MS = 3000;
-
-/** Cancels a scheduled push retry, if any. Idempotent. */
+/**
+ * Cancels a scheduled push retry, if any, and resets the ladder. Idempotent.
+ *
+ * The `retryAttempts` reset MUST stay inside the guard. The retry timer clears
+ * `retryHandle` BEFORE re-entering `setNativeTheme`, so a call on the retry
+ * path sees `null` here and keeps its budget — which is what bounds the
+ * ladder. Hoisting the reset out of the guard would make every rung refill its
+ * own budget: an unbounded 500 ms hot loop, the exact thing `MAX_PUSH_RETRIES`
+ * exists to prevent.
+ */
 function cancelRetry(): void {
   if (retryHandle !== null) {
     clearTimeout(retryHandle);
     retryHandle = null;
+    retryAttempts = 0;
   }
 }
 
-/** Stops the 3s poll if it is running. Idempotent. */
+/** Stops the poll if it is running. Idempotent. */
 function stopPoll(): void {
   if (pollIntervalHandle !== null) {
     clearInterval(pollIntervalHandle);
@@ -223,7 +276,7 @@ function getInvoke(): Promise<InvokeFn> {
  *
  * Called from three sources: the initial `get_app_theme` fetch in
  * `initTauriTheme`; `acceptReadback` below (the gated path for
- * `onThemeChanged` events and the 3s poll); and `setNativeTheme`'s own
+ * `onThemeChanged` events and the poll); and `setNativeTheme`'s own
  * resolved outcome, when `osTheme` is non-null -- the release round trip,
  * which is authoritative and bypasses the read-back gate entirely (Rust
  * only sets `osTheme` once the override state settles).
@@ -235,7 +288,7 @@ function setTauriTheme(next: "light" | "dark"): void {
 
 /**
  * Gate for ASYNCHRONOUS OS read-backs only -- `onThemeChanged` events and
- * the 3s poll. NOT used for `setNativeTheme`'s own resolved outcome, which
+ * the poll. NOT used for `setNativeTheme`'s own resolved outcome, which
  * carries its own authoritative `osTheme` on release and writes through
  * unconditionally (see `setNativeTheme`).
  *
@@ -254,6 +307,11 @@ function setTauriTheme(next: "light" | "dark"): void {
  *    `setNativeTheme` -- which reopens the gate while a newer push is still
  *    unsettled. That residue is the same benign class the gate reduces.
  *
+ *    Platform note, the mirror of gate 3's: on Windows there is no echo to
+ *    suppress at all (see the platform contract in `setNativeTheme`), so this
+ *    gate can only ever discard a GENUINE read-back there. It is kept for
+ *    uniformity because the cost is bounded at one poll tick.
+ *
  * 2. STALENESS. `seqAtIssue` must be the value of `pushSeq` captured when the
  *    read-back was ISSUED (the poll's `invoke` call, or the moment an OS event
  *    was received) -- not when it resolves. A read-back that started before
@@ -270,7 +328,7 @@ function setTauriTheme(next: "light" | "dark"): void {
  *    like the `false` this used to initialize to.
  */
 function acceptReadback(seqAtIssue: number, next: "light" | "dark"): void {
-  if (lastPush?.inFlight && Date.now() - lastPush.issuedAt < PUSH_SETTLE_CEILING_MS) return;
+  if (lastPush?.inFlight && performance.now() - lastPush.issuedAt < PUSH_SETTLE_CEILING_MS) return;
   if (seqAtIssue !== pushSeq) return; // issued before the latest push -- stale
   if (lastResolved?.overrideActive) return; // echo of our own force (macOS only)
   setTauriTheme(next);
@@ -285,8 +343,10 @@ function acceptReadback(seqAtIssue: number, next: "light" | "dark"): void {
  * `AppsUseLightTheme` registry value before consulting uxtheme, so our app
  * mode cannot echo into it); on macOS it forces `NSApp.appearance` app-wide
  * and `overrideActive` is `true` while an explicit theme is set; on Linux
- * the Rust side resolves to a no-op action (#1363) -- the client pushes
- * identically on every platform. Called
+ * the Rust side resolves to a no-op *action* (#1363), though the round trip
+ * is not itself a no-op -- the outcome still carries an `osTheme`, currently
+ * a hardcoded `Light` (see `native_theme_outcome` in `lib.rs`). The client
+ * pushes identically on every platform. Called
  * on every `settings.theme` change: an explicit preference forces that
  * theme, and `"system"` clears the override so native surfaces resume
  * following the OS -- the raw, UNRESOLVED `ThemePreference` is sent
@@ -297,20 +357,19 @@ function acceptReadback(seqAtIssue: number, next: "light" | "dark"): void {
  * `$effect`, which also reruns on `lightVariant` churn) doesn't re-push an
  * unchanged preference. It is set OPTIMISTICALLY, before the `invoke`
  * settles, and the whole record is cleared to `null` on rejection -- see its
- * declaration for why `null` rather than the previous value. `lastResolved`
- * is deliberately NOT touched on rejection: a failed push means the native
- * override state is UNKNOWN, and leaving read-backs suppressed is
- * stale-but-recoverable, where admitting an echo of a force we may not have
- * released is corrupt and self-reinforcing via the poll.
+ * declaration for why `null` rather than the previous value. `lastResolved` is
+ * NOT touched while retries remain: a failed push means the native override
+ * state is UNKNOWN, and leaving read-backs suppressed is stale-but-recoverable
+ * where admitting an echo of a force we may not have released is corrupt and
+ * self-reinforcing via the poll. Once the ladder is exhausted that trade
+ * inverts and it drops to `null`; the `.catch` says why.
  *
  * Note the latch does not prevent duplicate *concurrent* pushes: a stale
  * rejection can clear it while a newer push is still in flight. That is
- * harmless -- the native operation is idempotent. Since #1369 that same clear
- * also reopens `acceptReadback`'s in-flight gate, so a stale rejection can
- * admit an OS read-back while a newer push is still unsettled; that residue
- * is the same benign class the gate narrows rather than closes, and the
- * unconditional clear is required (a superseded rejection must still
- * invalidate the latch).
+ * harmless -- the native operation is idempotent -- and the unconditional
+ * clear is required, since a superseded rejection must still invalidate the
+ * latch. It also reopens `acceptReadback`'s in-flight gate early; that residue
+ * is the same benign class the gate narrows rather than closes.
  *
  * Note also that a push which NEVER settles holds the dedupe claim
  * indefinitely: `PUSH_SETTLE_CEILING_MS` bounds only the read-back gate, not
@@ -333,7 +392,14 @@ export function setNativeTheme(pref: ThemePreference): void {
   cancelRetry();
   if (pref === lastPush?.pref) return;
   const seq = ++pushSeq;
-  lastPush = { pref, inFlight: true, issuedAt: Date.now() };
+  // `performance.now()`, not `Date.now()`: `issuedAt` is only ever used to
+  // measure an elapsed duration against `PUSH_SETTLE_CEILING_MS`, and the wall
+  // clock is not monotonic. An NTP correction or a VM resume that steps the
+  // clock backwards while a push is hung makes that difference negative —
+  // which is `< PUSH_SETTLE_CEILING_MS` — pinning the read-back gate shut for
+  // as long as the offset persists. That is precisely the frozen-theme failure
+  // the ceiling exists to guarantee against.
+  lastPush = { pref, inFlight: true, issuedAt: performance.now() };
   getInvoke()
     .then((invoke) => invoke<NativeThemeOutcome>("set_native_theme", { theme: pref }))
     .then((outcome) => {
@@ -346,31 +412,69 @@ export function setNativeTheme(pref: ThemePreference): void {
       // invariant with a single writer per direction. That is what makes the
       // `.catch` below readable as the whole failure story.
       if (lastPush) lastPush.inFlight = false;
-      lastResolved = { overrideActive: outcome.overrideActive };
+      recordResolution(outcome);
       retryAttempts = 0;
       // Authoritative: Rust reads the theme AFTER applying/releasing the
       // override, so on release this is already correct as part of THIS
-      // round trip -- no need to wait on the 3s poll (acceptReadback above).
-      if (outcome.osTheme) setTauriTheme(outcome.osTheme);
+      // round trip -- no need to wait on a poll tick (acceptReadback above).
+      //
+      // The `!overrideActive` half enforces `NativeThemeOutcome`'s union at
+      // RUNTIME, which is the only place it can be violated: the type is
+      // applied via an unchecked `invoke<...>` assertion, and Rust's own
+      // struct is flat, so a future edit to `native_theme_outcome`'s match
+      // could send the forbidden pair with no error on either side. Writing an
+      // `osTheme` read while our force is applied is the #992/#1362 echo bug.
+      if (!outcome.overrideActive && outcome.osTheme) setTauriTheme(outcome.osTheme);
     })
     .catch((e) => {
       // Clear the latch unconditionally, superseded or not: a rejected push
       // may have left the latch describing a preference the native layer
-      // never received, and `null` guarantees the next call re-pushes. This
-      // one expression is the whole of the PIPELINE state change on failure:
-      // it drops the dedupe claim and `inFlight` together, and `lastResolved`
-      // is deliberately never named here. (The retry bookkeeping below is
-      // scheduling, not pipeline state.)
+      // never received, and `null` guarantees the next call re-pushes. One
+      // expression drops the dedupe claim and `inFlight` together.
       lastPush = null;
-      if (seq === pushSeq && retryAttempts < MAX_PUSH_RETRIES) {
+
+      // A superseded rejection stops here. The newer push owns the outcome,
+      // including whatever `lastResolved` should end up saying.
+      if (seq !== pushSeq) {
+        console.warn(`[useTauriTheme] set_native_theme("${pref}") failed (superseded):`, e);
+        return;
+      }
+
+      if (retryAttempts < MAX_PUSH_RETRIES) {
         const delay = RETRY_BASE_MS * 2 ** retryAttempts;
         retryAttempts++;
         retryHandle = setTimeout(() => {
           retryHandle = null;
           setNativeTheme(pref);
         }, delay);
+        console.warn(
+          `[useTauriTheme] set_native_theme("${pref}") failed (retry ${retryAttempts}/${MAX_PUSH_RETRIES}):`,
+          e,
+        );
+        return;
       }
-      console.warn(`[useTauriTheme] set_native_theme("${pref}") failed:`, e);
+
+      // Ladder exhausted. Suppressing read-backs was the right trade while a
+      // retry was pending — a TRANSIENT unknown resolves in seconds. It
+      // inverts once we have stopped trying, and the end states are not
+      // symmetric. Keeping `lastResolved.overrideActive` true pins BOTH the
+      // poll and every `onThemeChanged` shut with nothing left to reopen them,
+      // so the app renders a theme matching neither the OS nor the native
+      // surfaces, for the rest of the session, with no self-correction path.
+      // Dropping to `null` may instead let a still-forced appearance be read
+      // back — wrong against the user's pick, but consistent with the native
+      // menus, and it self-corrects the moment any later push succeeds.
+      //
+      // Note `null`, never `{ overrideActive: false }`: the failure path is
+      // still not permitted to invent a resolution. "We no longer know" is a
+      // state this type has, which is the whole reason it is nullable.
+      lastResolved = null;
+      // Give the next intent a fresh ladder; see `retryAttempts`.
+      retryAttempts = 0;
+      console.warn(
+        `[useTauriTheme] set_native_theme("${pref}") gave up after ${MAX_PUSH_RETRIES} retries; OS theme read-backs re-enabled:`,
+        e,
+      );
     });
 }
 
@@ -399,9 +503,13 @@ export function initTauriTheme(): void {
           // `systemTheme` fall through to the honest Rust-provided seed.
           //
           // For the same reason this is deliberately NOT gated on
-          // `lastPush.inFlight` either: that first push is unsettled at
-          // exactly this moment by construction, so an in-flight gate here
-          // would discard the boot reading every single time.
+          // `lastPush.inFlight` either: that first push is normally still
+          // unsettled at this moment, so an in-flight gate here would discard
+          // the boot reading in the common case, with no offsetting benefit --
+          // gate 3 already covers the real (macOS echo) hazard. Pinned by the
+          // "seeds the boot theme even though the first push is still
+          // unsettled" test; without it this reads as a preference rather
+          // than a rule, and adding the gate passed the whole suite.
           if (lastResolved?.overrideActive) return;
           setTauriTheme(theme === "dark" ? "dark" : "light");
         })
@@ -432,7 +540,7 @@ export function initTauriTheme(): void {
       console.warn("[useTauriTheme] Tauri window API import failed:", e);
     });
 
-  // 3-second polling fallback while focused -- onThemeChanged reliability
+  // Polling fallback while focused (POLL_INTERVAL_MS) -- onThemeChanged reliability
   // on Windows app-mode-only flips is undocumented and unverified. Skipped
   // entirely while an override is forced: the round trip would just be
   // discarded by acceptReadback's `lastResolved.overrideActive` check, so

--- a/src/client/hooks/useTauriTheme.svelte.ts
+++ b/src/client/hooks/useTauriTheme.svelte.ts
@@ -39,13 +39,27 @@ export const tauriTheme = new TauriThemeStore();
 
 let _initialized = false;
 
-// ----- Module-scope push/read-back state (#992) ---------------------------
+// ----- Module-scope push/read-back state (#992, restructured in #1369) ----
 //
-// NOTE: these encode one concept — the state of the push pipeline — as
-// separate fields whose cross-invariants are held by the comments below
-// rather than by the types. #1369 restructures them into `inFlight` /
-// `lastResolved`, which makes those invariants structural. Do that BEFORE
-// adding another variable here, not after.
+// The push pipeline's own state lives in exactly TWO records below:
+// `lastPush` (what we ASSERTED to the native layer) and `lastResolved` (what
+// the native layer actually DID). They are split by LIFECYCLE, not by field
+// list — a rejection voids the whole of `lastPush` in one expression and must
+// never name `lastResolved`. A NEW pipeline fact belongs as a field on one of
+// them rather than as another module `let`; `issuedAt` below is the worked
+// example, and it needed no `_resetForTests` line.
+//
+// REQUIRED: both are plain module `let`s and must NEVER become `$state`.
+// `setNativeTheme` both reads `lastPush?.pref` and writes `lastPush = {…}`
+// synchronously from inside `createTheme`'s `$effect` body
+// (useTheme.svelte.ts). A rune would (a) subscribe that effect to the push
+// pipeline, re-running `applyTheme` on every settle — precisely the
+// accidental subscription the notes in `createTheme` exist to avoid — and
+// (b) place a `$state` write inside an active reaction, which throws
+// `state_unsafe_mutation` in production as well as in dev. The sibling
+// `useTauriFileDrop.svelte.ts` states that it "mirrors `useTauriTheme.svelte.ts`
+// in shape" and DOES declare a module-scope `$state`; do not mirror that back
+// here. `tauriTheme.current` is the only reactive value in this module.
 //
 // One cached `invoke` import, reused by both the initial `get_app_theme`
 // fetch/poll (in `initTauriTheme`) and every `setNativeTheme` push, instead
@@ -56,14 +70,24 @@ let invokePromise: Promise<InvokeFn> | null = null;
 // `initTauriTheme`) so `_resetForTests()` can clear it.
 let pollIntervalHandle: ReturnType<typeof setInterval> | null = null;
 
-// Monotonic counter, bumped on every `setNativeTheme` call. Doubles as a
-// "supersession" token for that call's own resolved promise AND as the
-// staleness stamp async read-backs (onThemeChanged, the poll) capture at
-// issue time — see `acceptReadback` below.
+// Monotonic ticket dispenser, bumped on every `setNativeTheme` call. A push
+// compares its own ticket against THIS counter, never against `lastPush` —
+// which is why no `seq` field lives on that record: comparing against the
+// record instead of the dispenser flips the retry decision when two pushes
+// are in flight and the older one rejects. Doubles as the staleness stamp
+// async read-backs (onThemeChanged, the poll) capture at issue time — see
+// `acceptReadback` below.
 let pushSeq = 0;
 
-// The last preference sent to `set_native_theme` (dedupe latch), set
-// optimistically before the `invoke` settles so a rerun while a push is
+// What we ASSERTED to the native layer: the preference last sent to
+// `set_native_theme` (the dedupe latch), whether that push has settled
+// (`inFlight`), and when it was issued (`issuedAt` — the bound on how long
+// `inFlight` may suppress read-backs). ONE record, so the single expression
+// `lastPush = null` on the failure path drops the dedupe claim and reopens
+// the read-back gate together; neither can be voided while the other is
+// forgotten.
+//
+// Set OPTIMISTICALLY, before the `invoke` settles, so a rerun while a push is
 // still in flight short-circuits instead of duplicating it.
 //
 // On rejection it is cleared to `null` — NOT restored to its previous value.
@@ -75,26 +99,51 @@ let pushSeq = 0;
 // re-picking the old one would be deduped away forever. `null` means "no
 // claim", which is the only honest state after a failure and guarantees the
 // next push proceeds whatever its value.
-let lastPushedPref: ThemePreference | null = null;
+//
+// This is the ONLY dedupe input, and `lastResolved` deliberately carries no
+// `pref` field to become a second one. Deduping against the last CONFIRMED
+// preference would let a re-pick of it short-circuit past the `cancelRetry()`
+// in `setNativeTheme`, leaving an armed retry of a *rejected* push free to
+// land later and release an override while the app renders an explicit theme
+// — the `recv_timeout` hazard described just above. A rejection means "no
+// claim", full stop.
+let lastPush: { pref: ThemePreference; inFlight: boolean; issuedAt: number } | null = null;
 
-// Mirrors the last-RESOLVED outcome's `overrideActive`, and is never written
-// from a rejected push: it describes what the native layer actually did, which
+// What the native layer actually DID: the last RESOLVED outcome's
+// `overrideActive`. Assigned at exactly ONE site — the non-superseded `.then`
+// in `setNativeTheme` — and the failure path never names this variable,
+// because a rejected push leaves the native override state UNKNOWN and that
 // is precisely what the client cannot guess. Gates read-backs (see
 // `acceptReadback`) so an OS notification arriving while an explicit override
 // is forced (macOS only — Windows always resolves `false`) isn't mistaken for
 // a real user-driven OS change.
-let overrideActive = false;
+let lastResolved: { overrideActive: boolean } | null = null;
 
 // Bounded retry for a rejected push. Without this, a failed *release* would
-// leave `overrideActive` true, which suppresses both the 3s poll and every
-// `onThemeChanged` — so `tauriTheme.current` would stop moving and the app's
-// own `data-theme` would stop following the OS for the rest of the session.
-// Capped and cancelled on supersession so a persistently failing invoke
-// cannot hot-loop.
+// leave `lastResolved.overrideActive` true, which suppresses both the 3s poll
+// and every `onThemeChanged` — so `tauriTheme.current` would stop moving and
+// the app's own `data-theme` would stop following the OS for the rest of the
+// session. Capped and cancelled on supersession so a persistently failing
+// invoke cannot hot-loop.
 const MAX_PUSH_RETRIES = 3;
 const RETRY_BASE_MS = 500;
 let retryHandle: ReturnType<typeof setTimeout> | null = null;
 let retryAttempts = 0;
+
+// Ceiling on how long an UNSETTLED push may suppress OS read-backs (see
+// `acceptReadback`). The bound is not optional: a hung `invoke` never
+// rejects, so the retry ladder above is not a release path for it, and
+// `inFlight` is otherwise cleared only in the non-superseded `.then` or
+// implicitly by `lastPush = null` in the `.catch`. An unbounded gate would
+// therefore freeze `tauriTheme.current` for the whole session — exactly the
+// failure the retry ladder exists to prevent, reintroduced by the guard.
+//
+// 3000 ms is justified from two independent directions: Rust's own wait in
+// `apply_app_mode` is `rx.recv_timeout(Duration::from_secs(2))`, so a healthy
+// push settles well inside it; and it equals the 3s poll period below, so a
+// hung push costs at most one poll tick before degrading to the pre-#1369
+// behaviour.
+const PUSH_SETTLE_CEILING_MS = 3000;
 
 /** Cancels a scheduled push retry, if any. Idempotent. */
 function cancelRetry(): void {
@@ -118,8 +167,8 @@ export function _resetForTests(): void {
   _initialized = false;
   invokePromise = null;
   pushSeq = 0;
-  lastPushedPref = null;
-  overrideActive = false;
+  lastPush = null;
+  lastResolved = null;
   retryAttempts = 0;
   cancelRetry();
   stopPoll();
@@ -175,22 +224,41 @@ function setTauriTheme(next: "light" | "dark"): void {
  * carries its own authoritative `osTheme` on release and writes through
  * unconditionally (see `setNativeTheme`).
  *
- * `seqAtIssue` must be the value of `pushSeq` captured when the read-back
- * was ISSUED (the poll's `invoke` call, or the moment an OS event was
- * received) -- not when it resolves. A read-back that started before the
- * latest push began may reflect state from before that push landed, so it
- * is discarded once a newer push has superseded it.
+ * Three gates, in this order:
  *
- * `overrideActive` suppresses read-backs entirely while an explicit
- * override is forced (macOS only -- Windows always keeps `overrideActive:
- * false`, so this branch never suppresses there): any OS-level notification
- * arriving during that window is an echo of our own force, not a real
- * OS-driven change, and writing it through would corrupt `tauriTheme.current`
- * with a value the user didn't ask for.
+ * 1. UNSETTLED PUSH (#1369). `lastResolved` describes the last push to have
+ *    RESOLVED, so in the window between an override's appearance flipping and
+ *    its `invoke` resolving, gate 3 is still open and gate 2 still passes
+ *    (`seqAtIssue === pushSeq`) -- an `onThemeChanged` carrying an echo of our
+ *    own force would be written into `tauriTheme.current` as if it were an OS
+ *    reading. The window is TIME-BOUNDED because a hung `invoke` neither
+ *    resolves nor rejects, and an unbounded gate would freeze
+ *    `tauriTheme.current` for the session (see `PUSH_SETTLE_CEILING_MS`).
+ *    This gate NARROWS the echo window; it does NOT close it. A stale
+ *    rejection clears `lastPush` unconditionally -- by design, see
+ *    `setNativeTheme` -- which reopens the gate while a newer push is still
+ *    unsettled. That residue is the same benign class the gate reduces.
+ *
+ * 2. STALENESS. `seqAtIssue` must be the value of `pushSeq` captured when the
+ *    read-back was ISSUED (the poll's `invoke` call, or the moment an OS event
+ *    was received) -- not when it resolves. A read-back that started before
+ *    the latest push began may reflect state from before that push landed, so
+ *    it is discarded once a newer push has superseded it.
+ *
+ * 3. FORCED OVERRIDE. `lastResolved.overrideActive` suppresses read-backs
+ *    entirely while an explicit override is forced (macOS only -- Windows
+ *    always keeps `overrideActive: false`, so this branch never suppresses
+ *    there): any OS-level notification arriving during that window is an echo
+ *    of our own force, not a real OS-driven change, and writing it through
+ *    would corrupt `tauriTheme.current` with a value the user didn't ask for.
+ *    A never-yet-resolved `lastResolved` is `null`, which is falsy exactly
+ *    like the `false` this used to initialize to.
  */
 function acceptReadback(seqAtIssue: number, next: "light" | "dark"): void {
+  // Bounded, not unconditional -- see PUSH_SETTLE_CEILING_MS.
+  if (lastPush?.inFlight && Date.now() - lastPush.issuedAt < PUSH_SETTLE_CEILING_MS) return;
   if (seqAtIssue !== pushSeq) return; // issued before the latest push -- stale
-  if (overrideActive) return; // echo of our own force (macOS only)
+  if (lastResolved?.overrideActive) return; // echo of our own force (macOS only)
   setTauriTheme(next);
 }
 
@@ -211,30 +279,46 @@ function acceptReadback(seqAtIssue: number, next: "light" | "dark"): void {
  * (`"light" | "dark" | "warm" | "system"`); Rust owns resolving `"warm"` to
  * a native theme and mapping `"system"` to "no override".
  *
- * `lastPushedPref` dedupes so the effect this feeds (`createTheme`'s merged
+ * `lastPush.pref` dedupes so the effect this feeds (`createTheme`'s merged
  * `$effect`, which also reruns on `lightVariant` churn) doesn't re-push an
  * unchanged preference. It is set OPTIMISTICALLY, before the `invoke`
- * settles, and cleared to `null` on rejection -- see its declaration for why
- * `null` rather than the previous value. `overrideActive` is deliberately
- * NOT touched on rejection: a failed push means the native override state is
- * UNKNOWN, and leaving read-backs suppressed is stale-but-recoverable, where
- * admitting an echo of a force we may not have released is corrupt and
- * self-reinforcing via the poll.
+ * settles, and the whole record is cleared to `null` on rejection -- see its
+ * declaration for why `null` rather than the previous value. `lastResolved`
+ * is deliberately NOT touched on rejection: a failed push means the native
+ * override state is UNKNOWN, and leaving read-backs suppressed is
+ * stale-but-recoverable, where admitting an echo of a force we may not have
+ * released is corrupt and self-reinforcing via the poll.
  *
  * Note the latch does not prevent duplicate *concurrent* pushes: a stale
  * rejection can clear it while a newer push is still in flight. That is
- * harmless -- the native operation is idempotent.
+ * harmless -- the native operation is idempotent. Since #1369 that same clear
+ * also reopens `acceptReadback`'s in-flight gate, so a stale rejection can
+ * admit an OS read-back while a newer push is still unsettled; that residue
+ * is the same benign class the gate narrows rather than closes, and the
+ * unconditional clear is required (a superseded rejection must still
+ * invalidate the latch).
+ *
+ * Note also that a push which NEVER settles holds the dedupe claim
+ * indefinitely: `PUSH_SETTLE_CEILING_MS` bounds only the read-back gate, not
+ * the latch. That is unchanged from the pre-#1369 behaviour -- an unsettled
+ * push held the latch then too -- so it is not a regression, but the ceiling
+ * must not be misread as a general reset.
  */
 export function setNativeTheme(pref: ThemePreference): void {
-  if (!isTauriRuntime() || pref === lastPushedPref) return;
+  if (!isTauriRuntime() || pref === lastPush?.pref) return;
   const seq = ++pushSeq;
   cancelRetry(); // a newer push supersedes any pending retry
-  lastPushedPref = pref;
+  lastPush = { pref, inFlight: true, issuedAt: Date.now() };
   getInvoke()
     .then((invoke) => invoke<NativeThemeOutcome>("set_native_theme", { theme: pref }))
     .then((outcome) => {
       if (seq !== pushSeq) return; // superseded by a later push -- discard
-      overrideActive = outcome.overrideActive;
+      // MUTATE, never reassign. `lastPush = { pref, inFlight: false, … }` here
+      // would resurrect a dedupe claim that a concurrent stale rejection
+      // deliberately voided, silently deduping away the next same-pref push.
+      // The `if` guard IS that case -- not defensive noise.
+      if (lastPush) lastPush.inFlight = false;
+      lastResolved = { overrideActive: outcome.overrideActive };
       retryAttempts = 0;
       // Authoritative: Rust reads the theme AFTER applying/releasing the
       // override, so on release this is already correct as part of THIS
@@ -244,8 +328,12 @@ export function setNativeTheme(pref: ThemePreference): void {
     .catch((e) => {
       // Clear the latch unconditionally, superseded or not: a rejected push
       // may have left the latch describing a preference the native layer
-      // never received, and `null` guarantees the next call re-pushes.
-      lastPushedPref = null;
+      // never received, and `null` guarantees the next call re-pushes. This
+      // one expression is the whole of the PIPELINE state change on failure:
+      // it drops the dedupe claim and `inFlight` together, and `lastResolved`
+      // is deliberately never named here. (The retry bookkeeping below is
+      // scheduling, not pipeline state.)
+      lastPush = null;
       if (seq === pushSeq && retryAttempts < MAX_PUSH_RETRIES) {
         const delay = RETRY_BASE_MS * 2 ** retryAttempts;
         retryAttempts++;
@@ -271,8 +359,9 @@ export function initTauriTheme(): void {
       invokeRef = invoke;
       invoke<string>("get_app_theme")
         .then((theme) => {
-          // Gated on `overrideActive` ONLY -- deliberately not stamped with a
-          // `pushSeq` and routed through `acceptReadback`. This fetch and the
+          // Gated on `lastResolved.overrideActive` ONLY -- deliberately not
+          // stamped with a `pushSeq` and routed through `acceptReadback`.
+          // This fetch and the
           // first `setNativeTheme` push are both microtask-scheduled from the
           // same `createTheme` setup, so a seq captured here is stale before
           // it is compared and the boot reading is discarded every time
@@ -280,7 +369,12 @@ export function initTauriTheme(): void {
           // needs to avoid is narrower: on macOS `window.theme()` echoes our
           // own force, so skip the seed while an override is live and let
           // `systemTheme` fall through to the honest Rust-provided seed.
-          if (overrideActive) return;
+          //
+          // For the same reason this is deliberately NOT gated on
+          // `lastPush.inFlight` either: that first push is unsettled at
+          // exactly this moment by construction, so an in-flight gate here
+          // would discard the boot reading every single time.
+          if (lastResolved?.overrideActive) return;
           setTauriTheme(theme === "dark" ? "dark" : "light");
         })
         .catch((e) => {
@@ -313,13 +407,19 @@ export function initTauriTheme(): void {
   // 3-second polling fallback while focused -- onThemeChanged reliability
   // on Windows app-mode-only flips is undocumented and unverified. Skipped
   // entirely while an override is forced: the round trip would just be
-  // discarded by acceptReadback's overrideActive check, so there's no
-  // reason to make the IPC call at all.
+  // discarded by acceptReadback's `lastResolved.overrideActive` check, so
+  // there's no reason to make the IPC call at all.
+  //
+  // Deliberately NOT skipped merely because a push is unsettled. A forced
+  // override is a durable state worth short-circuiting; the in-flight window
+  // is milliseconds, so a skip keyed on it would be a race rather than a
+  // rule, and `acceptReadback` already discards anything that lands inside
+  // it.
   let pollErrorLogged = false;
   let pollImportAttempts = 0;
   const MAX_POLL_IMPORT_ATTEMPTS = 3;
   pollIntervalHandle = setInterval(() => {
-    if (!document.hasFocus() || overrideActive) return;
+    if (!document.hasFocus() || lastResolved?.overrideActive) return;
     // Re-acquire `invoke` if the init import failed, so a transient failure
     // doesn't kill the poll for the whole session -- but only a few times.
     // `getInvoke()` clears its cache on rejection, so retrying every tick
@@ -356,8 +456,8 @@ export function initTauriTheme(): void {
   // Chromium-based environments (including Tauri's WebView2).
   //
   // HMR dispose is a DEV-MODE WART, not app teardown -- Vite re-evaluates
-  // this module on hot-reload, which resets in-memory state
-  // (`lastPushedPref`, `overrideActive`, `pushSeq` all go back to their
+  // this module on hot-reload, which resets in-memory state (`lastPush`,
+  // `lastResolved`, `pushSeq` all go back to their
   // initial values) but does NOT release the native override: Rust's forced
   // app mode / NSApp.appearance is process-global and outlives the JS
   // module swap. So immediately after a hot-reload, this module may believe

--- a/src/client/hooks/useTheme.svelte.ts
+++ b/src/client/hooks/useTheme.svelte.ts
@@ -174,11 +174,21 @@ export function createTheme(
 
     // Do NOT "fix" staleness by writing `setTauriTheme(...)` (or
     // `tauriTheme.current = ...`) synchronously from inside this effect
-    // body. Effect bodies run inside an active Svelte reaction, and a
-    // synchronous `$state` write from within one throws
-    // `state_unsafe_mutation` -- in production too, not just dev (see
-    // CLAUDE.md). All native read-backs are written through the async
-    // `acceptReadback` gate in useTauriTheme.svelte.ts instead.
+    // body. Under `pref === "system"` this effect READS that same `$state`
+    // (via `applyTheme` -> `resolveTheme` -> `systemTheme`), so writing it
+    // here self-invalidates the effect and re-runs it, which writes again:
+    // an unbounded loop that surfaces as `effect_update_depth_exceeded`.
+    //
+    // It is specifically NOT `state_unsafe_mutation`. That error fires only
+    // when the active reaction matches `DERIVED | BLOCK_EFFECT | ASYNC |
+    // EAGER_EFFECT` (see CLAUDE.md); a plain `$effect` is `EFFECT |
+    // USER_EFFECT`, which matches none of them, and `$effect.pre` is
+    // `RENDER_EFFECT | USER_EFFECT`, which also does not. Verified against
+    // the installed runtime, because this comment previously claimed the
+    // wrong error and sent a reader looking for a throw that cannot happen.
+    //
+    // All native read-backs are written through the async `acceptReadback`
+    // gate in useTauriTheme.svelte.ts instead.
 
     return applyTheme(pref, lightVariant);
   });

--- a/src/client/hooks/useTheme.svelte.ts
+++ b/src/client/hooks/useTheme.svelte.ts
@@ -134,13 +134,13 @@ export function applyTheme(
  * resolved theme to the DOM (`applyTheme`). One effect rather than two, so
  * correctness does not depend on Svelte flushing siblings in declaration
  * order. This is safe because `setNativeTheme` dedupes internally on
- * `lastPushedPref` (useTauriTheme.svelte.ts), so a `lightVariant`-only rerun
+ * `lastPush.pref` (useTauriTheme.svelte.ts), so a `lightVariant`-only rerun
  * calls it with the same `pref` and no-ops.
  *
  * That dedupe is also the LOOP BREAKER: a release round trip writes
  * `osTheme` back through `tauriTheme.current`, which re-runs this effect. It
  * terminates only because the second `setNativeTheme` call short-circuits.
- * Do not "simplify" the latch away.
+ * Do not "simplify" the `lastPush` latch away.
  *
  * Accepts getters for `pref` and `lightVariant` so callers with `$state`
  * values propagate reactively. `lightVariant` (#993) controls which

--- a/src/client/hooks/useTheme.svelte.ts
+++ b/src/client/hooks/useTheme.svelte.ts
@@ -133,14 +133,14 @@ export function applyTheme(
  * to a native theme and `"system"` to "no override") and applies the
  * resolved theme to the DOM (`applyTheme`). One effect rather than two, so
  * correctness does not depend on Svelte flushing siblings in declaration
- * order. This is safe because `setNativeTheme` dedupes internally on
- * `lastPush.pref` (useTauriTheme.svelte.ts), so a `lightVariant`-only rerun
- * calls it with the same `pref` and no-ops.
+ * order. This is safe because `setNativeTheme` dedupes internally on the
+ * preference it last pushed (useTauriTheme.svelte.ts), so a
+ * `lightVariant`-only rerun calls it with the same `pref` and no-ops.
  *
  * That dedupe is also the LOOP BREAKER: a release round trip writes
  * `osTheme` back through `tauriTheme.current`, which re-runs this effect. It
  * terminates only because the second `setNativeTheme` call short-circuits.
- * Do not "simplify" the `lastPush` latch away.
+ * Do not "simplify" the latch away.
  *
  * Accepts getters for `pref` and `lightVariant` so callers with `$state`
  * values propagate reactively. `lightVariant` (#993) controls which

--- a/tests/client/useTauriTheme.svelte.test.ts
+++ b/tests/client/useTauriTheme.svelte.test.ts
@@ -43,8 +43,14 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 /**
- * Filters `invoke.mock.calls` down to a single command name. A stray 3s
- * poll tick landing mid-test must not flake a `toHaveBeenCalledTimes`
+ * Mirrors the SUT's `MAX_PUSH_RETRIES`, which is not exported. The ladder is
+ * 500 + 1000 + 2000 ms, so advancing 4000 ms clears all three rungs.
+ */
+const MAX_PUSH_RETRIES = 3;
+
+/**
+ * Filters `invoke.mock.calls` down to a single command name. A stray poll
+ * tick landing mid-test must not flake a `toHaveBeenCalledTimes`
  * assertion -- prefer this everywhere over a raw call count.
  */
 function callsFor(invoke: { mock: { calls: unknown[][] } }, cmd: string): unknown[][] {
@@ -355,8 +361,11 @@ describe("setNativeTheme (#992)", () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(callsFor(invoke, "set_native_theme")).toHaveLength(3);
 
-      // Past every rung of the retry ladder: nothing more may be issued.
-      await vi.advanceTimersByTimeAsync(2000);
+      // Past every rung of the ladder (500 + 1000 + 2000 = 3500 ms, so 4000
+      // clears it with room): nothing more may be issued. Only the single
+      // armed 500 ms rung is actually pending here — the point is that
+      // disarming it left nothing behind at any later delay either.
+      await vi.advanceTimersByTimeAsync(4000);
       expect(callsFor(invoke, "set_native_theme")).toHaveLength(3);
     } finally {
       vi.useRealTimers();
@@ -525,7 +534,8 @@ describe("setNativeTheme (#992)", () => {
     // `invoke` resolving BOTH of the pre-existing gates pass: the read-back's
     // stamp equals `pushSeq` (it is taken at delivery) and no resolved
     // outcome has reported `overrideActive` yet. Without the in-flight gate
-    // this event is ACCEPTED, i.e. this test is red at HEAD by construction.
+    // this event is ACCEPTED, i.e. this test is red on master by
+    // construction (it was written against the pre-#1369 shape).
     const { setNativeTheme, initTauriTheme } = await import(
       "../../src/client/hooks/useTauriTheme.svelte.js"
     );
@@ -597,17 +607,145 @@ describe("setNativeTheme (#992)", () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(systemTheme()).toBe("light"); // gate shut
 
-      // vitest's fake timers fake `Date` too (default `toFake`), and this
-      // repo sets no `fakeTimers` config — so `Date.now()` advances here.
-      await vi.advanceTimersByTimeAsync(3001);
+      // vitest's fake timers fake `performance` and `Date` (default `toFake`
+      // is every timer sinon knows, minus nextTick/queueMicrotask), and this
+      // repo sets no `fakeTimers` config — so `performance.now()`, which is
+      // what `issuedAt` is measured on, advances here. Measured, not assumed.
+      //
+      // Pin the bound from BOTH sides. Without the lower assertion the value
+      // is bracketed only to "somewhere in (a few ms, 3001]" — a mutant
+      // dropping the ceiling to 500 ms survives, which would silently reopen
+      // the echo window for every healthy push slower than half a second.
+      await vi.advanceTimersByTimeAsync(2999);
+      themeChangedCapture.current?.({ payload: "dark" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(systemTheme()).toBe("light"); // still inside the ceiling
 
+      await vi.advanceTimersByTimeAsync(2);
       themeChangedCapture.current?.({ payload: "dark" });
       await vi.advanceTimersByTimeAsync(0);
       expect(systemTheme()).toBe("dark"); // gate expired — degraded to pre-#1369
+    } finally {
+      // Stops the poll interval while fake timers are still installed;
+      // afterEach would otherwise run it against real ones. In the `finally`
+      // so an assertion failure above cannot leak the interval.
+      (await import("../../src/client/hooks/useTauriTheme.svelte.js"))._resetForTests();
+      vi.useRealTimers();
+    }
+  });
 
-      // Stops the 3s interval while fake timers are still installed; afterEach
-      // would otherwise run it against real ones.
+  it("seeds the boot theme even though the first push is still unsettled", async () => {
+    // The boot `get_app_theme` fetch is deliberately NOT gated on
+    // `lastPush.inFlight`, and that decision had no test: adding the gate
+    // passed the entire suite. It is not self-limiting either — the poll that
+    // would correct it is skipped while the window is unfocused, so a
+    // backgrounded launch holds the wrong theme indefinitely, and
+    // `window.__TANDEM_INITIAL_THEME__` carries it into the pre-mount seed.
+    const { setNativeTheme, initTauriTheme } = await import(
+      "../../src/client/hooks/useTauriTheme.svelte.js"
+    );
+    vi.stubGlobal("window", { addEventListener: vi.fn(), __TANDEM_INITIAL_THEME__: undefined });
+    vi.stubGlobal("document", { hasFocus: () => false });
+    invoke.mockImplementation((cmd: string) =>
+      cmd === "get_app_theme" ? Promise.resolve("dark") : new Promise(() => {}),
+    );
+
+    initTauriTheme();
+    setNativeTheme("dark"); // same tick as createTheme's effect; never settles
+    await flushAsync();
+
+    // "dark", not "light": a vacuous version of this test would assert
+    // "light", which is also what `systemTheme()` returns when
+    // `tauriTheme.current` is still null.
+    expect(systemTheme()).toBe("dark");
+  });
+
+  it("re-enables OS read-backs once the retry ladder is exhausted", async () => {
+    // The failure the ladder exists to prevent, reached THROUGH the ladder.
+    // A failed release leaves `lastResolved.overrideActive` true, which pins
+    // both the poll and every `onThemeChanged` shut. While a retry is pending
+    // that is the right trade — a transient unknown resolves in seconds. Past
+    // the cap there is nothing left to reopen the gate, so holding it shut
+    // renders a theme matching neither the OS nor the native surfaces for the
+    // rest of the session. "We stopped trying" has to degrade to "stop
+    // suppressing".
+    vi.useFakeTimers();
+    try {
+      const { setNativeTheme, initTauriTheme, _resetForTests } = await import(
+        "../../src/client/hooks/useTauriTheme.svelte.js"
+      );
+      vi.stubGlobal("window", { addEventListener: vi.fn(), __TANDEM_INITIAL_THEME__: undefined });
+      vi.stubGlobal("document", { hasFocus: () => false });
+
+      invoke.mockImplementation((cmd: string) =>
+        cmd === "get_app_theme"
+          ? Promise.resolve("light")
+          : Promise.resolve({ overrideActive: true, osTheme: null }),
+      );
+      initTauriTheme();
+      await vi.advanceTimersByTimeAsync(0);
+      setNativeTheme("dark"); // succeeds — the override is now live
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Gate shut: an OS event while the override is forced is an echo.
+      themeChangedCapture.current?.({ payload: "dark" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(systemTheme()).toBe("light");
+
+      // Now fail the release on every attempt, ladder included.
+      invoke.mockImplementation((cmd: string) =>
+        cmd === "get_app_theme"
+          ? Promise.resolve("light")
+          : Promise.reject(new Error("release failed")),
+      );
+      setNativeTheme("system");
+      await vi.advanceTimersByTimeAsync(4000); // 500 + 1000 + 2000, plus slack
+
+      // Four attempts and no more: the ladder is spent, not looping.
+      expect(callsFor(invoke, "set_native_theme")).toHaveLength(1 + 1 + MAX_PUSH_RETRIES);
+
+      // The gate must now be OPEN. Before this fix `lastResolved` stayed
+      // `{ overrideActive: true }` forever and this read-back was discarded.
+      themeChangedCapture.current?.({ payload: "dark" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(systemTheme()).toBe("dark");
+
       _resetForTests();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives each new user intent a fresh retry budget", async () => {
+    // `retryAttempts` is module-scope, so without a reset the budget belongs
+    // to the SESSION rather than to one intent: a user toggling themes
+    // against a failing invoke burns all three rungs in three picks, and
+    // every later failure then retries zero times, silently. The reset lives
+    // inside `cancelRetry`'s `if (retryHandle !== null)` guard — the retry
+    // timer nulls the handle before re-entering, so the ladder's own rungs do
+    // NOT refill their budget. Both halves are asserted here, because moving
+    // that reset out of the guard turns the ladder into a 500 ms hot loop.
+    vi.useFakeTimers();
+    try {
+      const { setNativeTheme } = await import("../../src/client/hooks/useTauriTheme.svelte.js");
+      invoke.mockImplementation(() => Promise.reject(new Error("nope")));
+
+      // Three distinct intents, each superseding the previous one's armed
+      // retry before it can fire.
+      setNativeTheme("dark");
+      await vi.advanceTimersByTimeAsync(0);
+      setNativeTheme("light");
+      await vi.advanceTimersByTimeAsync(0);
+      setNativeTheme("warm");
+      await vi.advanceTimersByTimeAsync(0);
+      const afterThreeIntents = callsFor(invoke, "set_native_theme").length;
+      expect(afterThreeIntents).toBe(3); // no rung has fired yet
+
+      // The third intent must still own a FULL ladder, not a spent one.
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(callsFor(invoke, "set_native_theme")).toHaveLength(
+        afterThreeIntents + MAX_PUSH_RETRIES,
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/tests/client/useTauriTheme.svelte.test.ts
+++ b/tests/client/useTauriTheme.svelte.test.ts
@@ -750,4 +750,44 @@ describe("setNativeTheme (#992)", () => {
       vi.useRealTimers();
     }
   });
+
+  it("gives a fresh budget to an intent that supersedes an IN-FLIGHT retry", async () => {
+    // The gap the `retryHandle !== null` guard alone does not cover. The retry
+    // timer nulls `retryHandle` BEFORE re-pushing, so between the timer firing
+    // and that push settling there is an armed ladder with no handle to find.
+    // A new user intent landing in that window used to inherit the spent
+    // counter and retry fewer times than the intent before it — silently, and
+    // not reproducibly, since it depends on where the pick lands relative to
+    // the 500 ms rung. `viaRetry` on `lastPush` is what closes it.
+    vi.useFakeTimers();
+    try {
+      const { setNativeTheme } = await import("../../src/client/hooks/useTauriTheme.svelte.js");
+
+      // A hung invoke: the retry push neither resolves nor rejects, so it is
+      // still in flight — `retryHandle` is null and the ladder is half spent.
+      let hang = false;
+      invoke.mockImplementation(() =>
+        hang ? new Promise(() => {}) : Promise.reject(new Error("nope")),
+      );
+
+      setNativeTheme("dark");
+      await vi.advanceTimersByTimeAsync(0);
+      hang = true;
+      await vi.advanceTimersByTimeAsync(500); // rung 1 fires and hangs
+      const beforeNewIntent = callsFor(invoke, "set_native_theme").length;
+
+      // A new user pick supersedes the in-flight retry.
+      hang = false;
+      setNativeTheme("light");
+      await vi.advanceTimersByTimeAsync(0);
+
+      // It must own a FULL ladder. With the budget leaked it gets two rungs.
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(callsFor(invoke, "set_native_theme")).toHaveLength(
+        beforeNewIntent + 1 + MAX_PUSH_RETRIES,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/client/useTauriTheme.test.ts
+++ b/tests/client/useTauriTheme.test.ts
@@ -295,7 +295,7 @@ describe("setNativeTheme (#992)", () => {
     await flushAsync();
     expect(callsFor(invoke, "set_native_theme")).toHaveLength(1);
 
-    // Committing lastPushedPref before the await, with no clear on failure,
+    // Committing lastPush before the await, with no clear on failure,
     // meant this second call — the SAME pref, retried after a failure — was
     // silently deduped away forever. It must go through again.
     setNativeTheme("dark");
@@ -328,6 +328,39 @@ describe("setNativeTheme (#992)", () => {
     setNativeTheme("dark");
     await flushAsync();
     expect(callsFor(invoke, "set_native_theme").length).toBeGreaterThan(before);
+  });
+
+  it("re-issues the last CONFIRMED preference after a failed push in between", async () => {
+    // Regression guard for the dedupe INPUT (#1369). The obvious restructure
+    // is to dedupe against "the last preference we know about" — i.e. to fall
+    // back to the last RESOLVED outcome when nothing is in flight. Trace why
+    // that is wrong: dark resolves, system rejects and arms the 500 ms retry,
+    // then the user re-picks dark. A `lastResolved`-aware dedupe
+    // short-circuits that third call, so `cancelRetry()` never runs, and the
+    // armed "system" retry lands afterwards — releasing the native override
+    // while the app renders dark. A rejection means "no claim", full stop:
+    // only what we ASSERTED (and have not had rejected) may dedupe.
+    vi.useFakeTimers();
+    try {
+      const { setNativeTheme } = await import("../../src/client/hooks/useTauriTheme.svelte.js");
+
+      setNativeTheme("dark"); // resolves — this is the last CONFIRMED pref
+      await vi.advanceTimersByTimeAsync(0);
+
+      invoke.mockImplementationOnce(() => Promise.reject(new Error("release failed")));
+      setNativeTheme("system"); // rejects — arms a 500 ms retry of "system"
+      await vi.advanceTimersByTimeAsync(0);
+
+      setNativeTheme("dark"); // must go through, and must disarm that retry
+      await vi.advanceTimersByTimeAsync(0);
+      expect(callsFor(invoke, "set_native_theme")).toHaveLength(3);
+
+      // Past every rung of the retry ladder: nothing more may be issued.
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(callsFor(invoke, "set_native_theme")).toHaveLength(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not touch overrideActive on a rejected push", async () => {
@@ -478,6 +511,106 @@ describe("setNativeTheme (#992)", () => {
       await vi.advanceTimersByTimeAsync(0);
 
       expect(systemTheme()).toBe("light"); // stale poll discarded, not "dark"
+
+      _resetForTests();
+    } finally {
+      vi.useRealTimers();
+      isTauri.mockReturnValue(false);
+    }
+  });
+
+  it("an OS read-back arriving while a push is unsettled is discarded, and honoured once it settles", async () => {
+    // #1369 item C. `lastResolved` describes the last push to have RESOLVED,
+    // so in the window between an override's appearance flipping and its
+    // `invoke` resolving BOTH of the pre-existing gates pass: the read-back's
+    // stamp equals `pushSeq` (it is taken at delivery) and no resolved
+    // outcome has reported `overrideActive` yet. Without the in-flight gate
+    // this event is ACCEPTED, i.e. this test is red at HEAD by construction.
+    const { setNativeTheme, initTauriTheme } = await import(
+      "../../src/client/hooks/useTauriTheme.svelte.js"
+    );
+    vi.stubGlobal("window", { addEventListener: vi.fn(), __TANDEM_INITIAL_THEME__: undefined });
+    // hasFocus false so no poll tick can confound the assertions below.
+    vi.stubGlobal("document", { hasFocus: () => false });
+    invoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_app_theme") return Promise.resolve("light");
+      return Promise.resolve({ overrideActive: false, osTheme: null });
+    });
+
+    initTauriTheme();
+    await flushAsync();
+    expect(themeChangedCapture.current).not.toBeNull();
+    expect(systemTheme()).toBe("light");
+
+    // Hold the push with a CAPTURED resolver, branched on the command so the
+    // `Once` implementation cannot be consumed by a stray `get_app_theme`.
+    let resolveHeld!: (v: unknown) => void;
+    invoke.mockImplementationOnce((cmd: string) =>
+      cmd === "set_native_theme"
+        ? new Promise((r) => {
+            resolveHeld = r;
+          })
+        : Promise.resolve("light"),
+    );
+    setNativeTheme("dark");
+    await flushAsync();
+
+    themeChangedCapture.current?.({ payload: "dark" });
+    await flushAsync();
+    expect(systemTheme()).toBe("light"); // discarded — the push has not settled
+
+    resolveHeld({ overrideActive: false, osTheme: null });
+    await flushAsync();
+
+    // A window, not a lockout: once the push settles the same event lands.
+    themeChangedCapture.current?.({ payload: "dark" });
+    await flushAsync();
+    expect(systemTheme()).toBe("dark");
+  });
+
+  it("the in-flight read-back gate expires, so a push that never settles cannot freeze the theme", async () => {
+    // Pins the BOUND, not the gate. Resolving a held push only proves the
+    // gate opens on a SETTLED push; a promise that neither resolves nor
+    // rejects reaches neither the `.then` nor the `.catch`, and the retry
+    // ladder fires on rejection only — so an unbounded `if (inFlight) return`
+    // would freeze `tauriTheme.current` for the rest of the session. Without
+    // this test, `issuedAt` and PUSH_SETTLE_CEILING_MS read as unused
+    // ceremony and get simplified away.
+    vi.useFakeTimers();
+    try {
+      const { setNativeTheme, initTauriTheme, _resetForTests } = await import(
+        "../../src/client/hooks/useTauriTheme.svelte.js"
+      );
+      _resetForTests();
+      vi.stubGlobal("window", { addEventListener: vi.fn(), __TANDEM_INITIAL_THEME__: undefined });
+      vi.stubGlobal("document", { hasFocus: () => false });
+      invoke.mockImplementation((cmd: string) => {
+        if (cmd === "get_app_theme") return Promise.resolve("light");
+        return Promise.resolve({ overrideActive: false, osTheme: null });
+      });
+
+      initTauriTheme();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(themeChangedCapture.current).not.toBeNull();
+      expect(systemTheme()).toBe("light");
+
+      invoke.mockImplementationOnce((cmd: string) =>
+        cmd === "set_native_theme" ? new Promise(() => {}) : Promise.resolve("light"),
+      );
+      setNativeTheme("dark");
+      await vi.advanceTimersByTimeAsync(0);
+
+      themeChangedCapture.current?.({ payload: "dark" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(systemTheme()).toBe("light"); // gate shut
+
+      // vitest's fake timers fake `Date` too (default `toFake`), and this
+      // repo sets no `fakeTimers` config — so `Date.now()` advances here.
+      await vi.advanceTimersByTimeAsync(3001);
+
+      themeChangedCapture.current?.({ payload: "dark" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(systemTheme()).toBe("dark"); // gate expired — degraded to pre-#1369
 
       _resetForTests();
     } finally {

--- a/tests/client/useTauriTheme.test.ts
+++ b/tests/client/useTauriTheme.test.ts
@@ -532,10 +532,7 @@ describe("setNativeTheme (#992)", () => {
     vi.stubGlobal("window", { addEventListener: vi.fn(), __TANDEM_INITIAL_THEME__: undefined });
     // hasFocus false so no poll tick can confound the assertions below.
     vi.stubGlobal("document", { hasFocus: () => false });
-    invoke.mockImplementation((cmd: string) => {
-      if (cmd === "get_app_theme") return Promise.resolve("light");
-      return Promise.resolve({ overrideActive: false, osTheme: null });
-    });
+    // invoke default comes from beforeEach; the two commands in play behave identically.
 
     initTauriTheme();
     await flushAsync();
@@ -581,13 +578,9 @@ describe("setNativeTheme (#992)", () => {
       const { setNativeTheme, initTauriTheme, _resetForTests } = await import(
         "../../src/client/hooks/useTauriTheme.svelte.js"
       );
-      _resetForTests();
       vi.stubGlobal("window", { addEventListener: vi.fn(), __TANDEM_INITIAL_THEME__: undefined });
       vi.stubGlobal("document", { hasFocus: () => false });
-      invoke.mockImplementation((cmd: string) => {
-        if (cmd === "get_app_theme") return Promise.resolve("light");
-        return Promise.resolve({ overrideActive: false, osTheme: null });
-      });
+      // invoke default comes from beforeEach; the two commands in play behave identically.
 
       initTauriTheme();
       await vi.advanceTimersByTimeAsync(0);
@@ -612,10 +605,11 @@ describe("setNativeTheme (#992)", () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(systemTheme()).toBe("dark"); // gate expired — degraded to pre-#1369
 
+      // Stops the 3s interval while fake timers are still installed; afterEach
+      // would otherwise run it against real ones.
       _resetForTests();
     } finally {
       vi.useRealTimers();
-      isTauri.mockReturnValue(false);
     }
   });
 });

--- a/tests/client/useTheme-native-push.svelte.test.ts
+++ b/tests/client/useTheme-native-push.svelte.test.ts
@@ -13,7 +13,7 @@
  * discovery. Harness shape copied from
  * `tests/client/useAutostart.svelte.test.ts`.
  *
- * `tests/client/useTauriTheme.test.ts` covers `setNativeTheme` /
+ * `tests/client/useTauriTheme.svelte.test.ts` covers `setNativeTheme` /
  * `acceptReadback`'s own logic (dedupe, latch clearing, supersession,
  * read-back gating) directly, but never touches the DOM. This file covers the
  * two things only an end-to-end reactive run can show:
@@ -55,7 +55,7 @@ import { _resetForTests, tauriTheme } from "../../src/client/hooks/useTauriTheme
 import { createTheme } from "../../src/client/hooks/useTheme.svelte.js";
 
 /** Filters `invoke.mock.calls` to a single command — mirrors
- * useTauriTheme.test.ts so a stray poll tick can't flake a count. */
+ * useTauriTheme.svelte.test.ts so a stray poll tick can't flake a count. */
 function callsFor(invoke: { mock: { calls: unknown[][] } }, cmd: string): unknown[][] {
   return invoke.mock.calls.filter(([c]) => c === cmd);
 }
@@ -148,7 +148,7 @@ describe("createTheme effect wiring (#992)", () => {
   it("an OS theme flip re-resolves a 'system' pref onto the DOM", async () => {
     // The chain nothing used to cover: `useTheme.test.ts` calls `applyTheme`
     // directly and seeds via `__TANDEM_INITIAL_THEME__`, and
-    // `useTauriTheme.test.ts` never touches the DOM. Without this, the only
+    // `useTauriTheme.svelte.test.ts` never touches the DOM. Without this, the only
     // thing standing behind the effect's subscription to `tauriTheme.current`
     // was a comment -- and that comment was wrong about where the
     // subscription came from.


### PR DESCRIPTION
`useTauriTheme.svelte.ts` held the push/read-back pipeline as five independent
module-level `let`s, with the invariants between them held only by comments. #1362
had already been caused by one of those comments not being a rule: a failure path
wrote `overrideActive = false`, which reads as innocuous cleanup and is in fact a
claim the client cannot make.

The pipeline is now **two records split by lifecycle**:

- `lastPush` — what we **asserted** to the native layer (`pref`, `inFlight`, `issuedAt`)
- `lastResolved` — what the native layer actually **did** (`overrideActive`)

`invokePromise`, `pollIntervalHandle`, `retryHandle` and `retryAttempts` stay separate:
they are resources and scheduling, not pipeline state.

## What that buys, against the issue's three goals

**A — `overrideActive` written only from a resolved outcome.** The `.catch` names
exactly one variable, `lastPush`, and `lastResolved` is unreachable from it. Not
structurally *unwritable* — a determined edit still compiles — so the comment says so
rather than claiming a guarantee it does not have. What changed is that the equivalent
mistake now reads as `lastResolved = { overrideActive: false }`, i.e. as inventing a
resolution that never happened, instead of as tidying a boolean.

**B — one expression at one site.** `lastPush = null` drops the dedupe claim and the
`inFlight` gate together. Neither can be voided while the other is forgotten.

**C — the in-flight echo window, which is the real bug the issue found.** Closed, but
**time-bounded** rather than by the issue's bare `if (inFlight) return;`. A hung
`invoke` never resolves *and* never rejects, so an unbounded gate would freeze
`tauriTheme.current` for the rest of the session — the exact failure the #1362 retry
ladder exists to prevent, reintroduced by the guard meant to help. `PUSH_SETTLE_CEILING_MS`
bounds it at one poll tick. The gate **narrows** the echo window; it does not close it,
and the residue is documented rather than papered over.

**Bonus — `_resetForTests`.** `issuedAt` is a new pipeline fact that needed no new line
there, because a field is cleared with its record.

## One place the issue is wrong, and this PR deliberately does not follow it

> Dedupe becomes `pref === (inFlight?.pref ?? lastResolved?.pref)`.

Do not do this. `lastResolved` deliberately carries **no `pref` field**, and the durable
reason is about what a rejection *means*, not about any one code path:

**After a rejected push, the native override state is UNKNOWN.** The `invoke` failed, but
"the call failed" is not "the effect did not happen" — a rejection can arrive after the
native side has already acted, or before it acts at all, and the client cannot tell which.
So a rejection clears the record to `null` rather than reverting it to the last confirmed
value: `null` is the honest encoding of "we have no claim", and it guarantees the next
call re-pushes. Deduping against a last-*confirmed* preference asserts the opposite — that
the confirmed state survived the failure — which is exactly the claim the failure
invalidated.

The concrete consequence is that a re-pick of the confirmed preference would short-circuit
`setNativeTheme` past `cancelRetry()`, leaving a rejected push's retry armed to fire later
and release the native override while the app renders an explicit theme.

`cancelRetry()` is also hoisted **above** the dedupe check, so the ordering is safe
independently of that reasoning rather than relying on it.

## Review trail

Adversarial plan review (3 lenses) before any code, then `/simplify` (4 agents).
The simplify pass changed real things, not just prose:

- **A comment at the wrong altitude, in two files.** `src-tauri/src/lib.rs` carried the
  *only* reference to a private client field path among its ten client references — every
  other one is file- or exported-symbol granularity. This PR is the proof of the cost: a
  pure client-internal rename forced a Rust edit and a `cargo` rebuild. `useTheme.svelte.ts`
  had the same shape. Both now de-reference; the reasoning survives intact, since a Rust
  reader could never act on a JS field path anyway.
- **Two hold-out comments were overstated.** The `pushSeq` note described a scenario that
  provably cannot flip, and the mutate-vs-reassign note called the reassigning form *wrong*
  when it is merely less legible. Both now state what is actually true — still enough to
  justify the code.
- **`lastResolved` nearly lost its wrapper.** Two agents read it as pointless, fairly:
  the old comment only argued that `null` is falsy like the `false` it replaced. The
  record is kept and the actual reason (the #1362 legibility argument above) is now on
  the page.
- **`POLL_INTERVAL_MS` named**, with `PUSH_SETTLE_CEILING_MS` documented as deliberately
  *not* defined as equal to it, on the grounds that Rust's `recv_timeout(2s)` was its
  primary justification. **Round two overturned this** — that bound is Windows-only and
  the gate is macOS-only — and the constant is now `= POLL_INTERVAL_MS`.

## Verification

- `npm run typecheck` — clean (1320 files, 0 errors, 0 warnings).
- `npm test -- --run` — **453 files / 6515 passing**, 19 skipped.
- `cargo test` via `pre-push` — clean.
- **Run by hand, because the hook silently skipped them.** `related-test.sh` derives
  `useTauriTheme.svelte` from `useTauriTheme.svelte.ts` and looked for a then-nonexistent
  `tests/client/useTauriTheme.svelte.test.ts`, so the per-edit hook covered this module
  with *nothing*. Filed as #1408 — and **fixed for this module in round two** by renaming
  the suite to exactly that name.

Not run: E2E. No spec touches the native theme bridge (it is a Tauri IPC path with no
browser surface), and it is a global mutex belonging to the serial integration pass.

## Notes for the reviewer

No `CHANGELOG.md` entry — this wave writes the changelog once at integration from the
diffs, rather than having seven branches contend for one `## [Unreleased]` insertion
point. Tracked in #1406.

Closes #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYGFawL9kQruDZiUkYGBKD

---

## Second round — `/pr-review-toolkit:review-pr` (5 agents)

Three findings were defects rather than polish, and **two are in comments this PR
itself wrote** — a fair result for a PR whose thesis is that a comment is not a rule.

### The retry ladder gave up and left the pipeline wedged

Past `MAX_PUSH_RETRIES` the `.catch` warned and stopped, while `lastResolved` still
held `{ overrideActive: true }` from the last successful explicit push. That pins
**both** the poll and every `onThemeChanged` shut, and nothing else clears it. On macOS
a failed release therefore left the app rendering a theme matching neither the OS nor
the native menus, for the rest of the session, with no self-correction path — while the
comment three lines up claimed the retry ladder was what prevented exactly that.

Suppressing read-backs is the right trade while a retry is pending (a *transient*
unknown resolves in seconds) and the wrong one once we have stopped trying.
`lastResolved` now drops to `null` at exhaustion — never to `{ overrideActive: false }`,
which would still be the failure path inventing a resolution. Pre-existing behaviour;
this PR upgraded it from undocumented to *mis*-documented, so it is fixed here.

### The retry budget belonged to the session, not to the intent

`retryAttempts` reset only on success, so a user toggling themes against a failing
invoke burned all three rungs in three picks and every later failure retried zero times,
silently. `cancelRetry` now resets it — deliberately **inside** the
`retryHandle !== null` guard. The retry timer nulls the handle before re-entering
`setNativeTheme`, so hoisting the reset out of that guard would make each rung refill
its own budget: a 500 ms hot loop, the exact thing the cap exists to prevent. The review
proposed the fix without that placement constraint; it is called out in the code.

### `issuedAt` was measured on a non-monotonic clock — introduced by this PR

`Date.now()` moves backwards under an NTP correction or a VM resume. While a push hangs,
that makes the elapsed comparison negative, which is `< PUSH_SETTLE_CEILING_MS` — pinning
the gate shut for as long as the offset persists, i.e. the frozen-theme failure the
ceiling is supposed to *guarantee* against. Now `performance.now()`. Confirmed vitest
fakes `performance` by default (measured with a throwaway probe) before relying on it.

### Two claims this PR made that do not survive checking

- **`state_unsafe_mutation` was the wrong error.** Verified against the installed
  Svelte: `$effect` is `EFFECT | USER_EFFECT`, and the guard fires only for
  `DERIVED | BLOCK_EFFECT | ASYNC | EAGER_EFFECT`. The real hazard is a
  self-invalidating effect (`effect_update_depth_exceeded`). The conclusion — never make
  these `$state` — is unchanged and carried by the other reason on its own. The same
  wrong claim was **pre-existing** in `useTheme.svelte.ts`; fixed there too rather than
  leaving two copies to diverge.
- **`PUSH_SETTLE_CEILING_MS` cited a Rust bound that does not apply.**
  `apply_app_mode`'s `recv_timeout(2s)` is `#[cfg(target_os = "windows")]`, and macOS —
  which routes to `SetWindowTheme` — is the only platform where `overrideActive` is ever
  true, i.e. the only platform this gate exists for. The poll-tick argument is
  platform-independent and was always the real one, so the constant is now
  `= POLL_INTERVAL_MS`. **This reverses the first round's `/simplify` call**, whose
  premise was that citation.

`NativeThemeOutcome`'s "must not type-check" was likewise an overclaim: the type only
ever arrives through an unchecked `invoke<...>` assertion, so it polices nothing, and
the repo's own tests construct the forbidden pair. It now has a real enforcement site
(`!outcome.overrideActive`, at runtime, where the violation could actually originate)
and a real construction site (`recordResolution`, the sole writer of `lastResolved` —
recording one from the failure path now means visibly fabricating an IPC payload).

### Tests

`tests/client/useTauriTheme.test.ts` → **`useTauriTheme.svelte.test.ts`**. The hook
derives `useTauriTheme.svelte` from the `.svelte.ts` module and was matching nothing, so
this module's only safety net was never armed. One rename fixes it; noted on #1408,
which stays open for the other 55 `.svelte.ts` modules and for the fact that a miss is
silent.

New coverage, **each verified by mutation and killed by exactly one test**:

| Mutation | Killed by |
|---|---|
| exhaustion keeps `lastResolved` | re-enables OS read-backs once the ladder is exhausted |
| `cancelRetry` keeps the budget | gives each new user intent a fresh retry budget |
| ceiling `= 500` | the in-flight gate's new lower-bound assertion |
| boot seed gated on `inFlight` | seeds the boot theme even though the first push is unsettled |

The last one is the gap I care most about: it is a **documented** decision that had no
test whatsoever — adding the gate passed the entire suite — in a file where #1362 was
caused by a comment not being a rule. It is not self-limiting either, since the poll
that would correct it is skipped while the window is unfocused.

Deferred to **#1413**: every failure path in this module reports through `console.warn`,
and `tauri-plugin-log` declares no `TargetKind::Webview`, so none of it reaches
`tandem.log` — the one artifact a user can attach to a bug report. That includes Rust's
deliberately-loud High Contrast decline, which is durable rather than transient on
Windows. The fix needs a `push` callback threaded from `App.svelte` (the sibling
`useTauriFileDrop.svelte.ts` already does exactly this), which is its own change.

### Verification, second round

- `npm run typecheck` — clean (1320 files, 0 errors, 0 warnings).
- `npm test -- --run` — **453 files / 6518 passing**, 19 skipped.
- `cargo test` via `pre-push` — clean.



---

## Third round — the retry-budget gap the second round's fix did not cover

Applying the `cancelRetry` budget reset surfaced a window the `retryHandle !== null`
guard only *looks* like it covers. **The retry timer nulls `retryHandle` before
re-pushing**, so between the timer firing and that push settling there is an armed
ladder with no handle to find. A new user pick landing there took the guard's false
branch, kept the spent counter, and retried fewer times than the pick before it —
silently, and not reproducibly, since it depends on where the pick falls relative to
the 500 ms rung.

`lastPush` now carries `viaRetry`, which is the one bit that distinguishes the two
callers `cancelRetry` cannot otherwise tell apart:

| Caller | `retryHandle` | `lastPush` | Budget |
|---|---|---|---|
| Retry timer's own re-entry | `null` (it just cleared it) | `null` (the `.catch` cleared it) | **kept** — this is one intent's ladder |
| New intent, retry armed | non-null | any | reset (existing branch) |
| New intent, retry **in flight** | `null` | `{ viaRetry: true }` | **reset** — this is the gap |

`viaRetry` is a parameter on an internal `pushNativeTheme`, not on the exported
`setNativeTheme`: no caller outside this module can meaningfully supply it, and an
optional boolean on the public surface would invite one to try.

Mutation-verified — deleting the reset fails exactly the new test
(`gives a fresh budget to an intent that supersedes an IN-FLIGHT retry`) and nothing else.

Also: three references to `tests/client/useTauriTheme.test.ts` inside
`useTheme-native-push.svelte.test.ts`, stale since round two renamed the suite to
`.svelte.test.ts` to arm `related-test.sh` for this module (#1408). A stale pointer to a
test file is the same failure class as #1408 itself — a reference that silently matches
nothing.

### Verification, third round

- `npm run typecheck` — clean (1320 files, 0 errors, 0 warnings).
- `npm test -- --run` — **453 files / 6519 passing**, 19 skipped.
- `cargo test` — 160 passed, 1 ignored.
