### PR TITLE
fix(links): render bare relative hrefs like docs/spec.md (#1377)

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -3048,6 +3048,7 @@ const shouldShowModelPicker = $derived(
         onSlashCommandMenuChange={(open) => (slashCommandMenuOpen = open)}
         onFocusChat={focusChat}
         onComposeAnnotation={requestAnnotationComposer}
+        onNotify={(n) => notifications.push(n)}
       />
     {/snippet}
     <!-- One snippet, two call sites: left wires `marginNotes`, right wires

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -282,15 +282,19 @@ async function openHref(href: string) {
   // Treat anything else with a recognised file extension as a relative path.
   // `resolveRelativeLink` is fail-closed: a non-navigable extension, a pure
   // fragment, or a traversal escaping the current file's root all return null,
-  // and a null routes to this no-op — the correct UX for a link that points
-  // outside the document tree.
+  // and a null means we do not navigate — the correct UX for a link that points
+  // outside the document tree. #1377 widened the RENDER boundary without
+  // widening this one, so an href can now be clickable and still land here; the
+  // warn is what makes that gap visible instead of a dead click.
   if (currentFilePath) {
     const resolvedPath = resolveRelativeLink(href, currentFilePath);
-    if (resolvedPath) {
-      const result = await openServerPath(resolvedPath);
-      if (!result.ok) {
-        console.warn(`[tandem] Could not open linked file "${resolvedPath}": ${result.error}`);
-      }
+    if (!resolvedPath) {
+      console.warn(`[tandem] Link target is not an openable relative path: "${href}"`);
+      return;
+    }
+    const result = await openServerPath(resolvedPath);
+    if (!result.ok) {
+      console.warn(`[tandem] Could not open linked file "${resolvedPath}": ${result.error}`);
     }
   }
 }

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -24,57 +24,16 @@ import { SelectionDecorationExtension } from "./extensions/selection-decoration"
 import { SlashCommandExtension } from "./slash-menu";
 import { applyLink, getInitialLinkHref } from "./toolbar/handlers";
 import LinkEditor from "./toolbar/LinkEditor.svelte";
+// resolveRelativeLink + INTERNAL_LINK_EXTS hoisted to ./utils/relative-link.ts:
+// module-private here, it had zero test coverage, and its fail-closed traversal
+// guards are exactly the kind of thing that has to be tested.
+import { resolveRelativeLink } from "./utils/relative-link";
 import { isSafeExternalHref } from "./utils/url-safety";
 import "./editor.css";
-
-import { SUPPORTED_EXTENSIONS } from "../../shared/constants.js";
-
-/** File extensions that open as new Tandem tabs when clicked as relative links. .docx excluded — not navigable as a link target. */
-const INTERNAL_LINK_EXTS = new Set([...SUPPORTED_EXTENSIONS].filter((e) => e !== ".docx"));
 
 // SAFE_EXTERNAL_PREFIXES + isSafeExternalHref hoisted to ./utils/url-safety.ts
 // so the click-time anchor intercept and the paste-time link sanitizer share
 // one allowlist (any drift would silently widen the XSS trust surface).
-
-/**
- * Resolve a relative href against an absolute file path.
- * Works on both POSIX and Windows paths by detecting the separator.
- * Returns null if the resolved path's extension is not in INTERNAL_LINK_EXTS.
- */
-function resolveRelativeLink(href: string, currentFilePath: string): string | null {
-  // Detect Windows vs POSIX
-  const sep = currentFilePath.includes("\\") ? "\\" : "/";
-
-  // Strip hash fragment for resolution; we don't support in-page anchors cross-file
-  const hashIdx = href.indexOf("#");
-  const hrefPath = hashIdx >= 0 ? href.slice(0, hashIdx) : href;
-  if (!hrefPath) return null; // pure fragment (#section) — not a file link
-
-  // Check extension
-  const extMatch = hrefPath.match(/\.[^./\\]+$/);
-  const ext = extMatch ? extMatch[0].toLowerCase() : "";
-  if (!INTERNAL_LINK_EXTS.has(ext)) return null;
-
-  // Get directory of current file (convert forward slashes in href to platform sep)
-  const dirParts = currentFilePath.split(sep);
-  dirParts.pop(); // remove filename
-
-  // Normalize the href to use the platform separator
-  const hrefNormalized = hrefPath.replace(/\//g, sep);
-  const hrefParts = hrefNormalized.split(sep);
-
-  // Merge directory + relative parts, resolving . and ..
-  const resultParts = [...dirParts];
-  for (const part of hrefParts) {
-    if (part === "..") {
-      if (resultParts.length > 0) resultParts.pop();
-    } else if (part !== ".") {
-      resultParts.push(part);
-    }
-  }
-
-  return resultParts.join(sep);
-}
 
 interface Props {
   ydoc: Y.Doc;
@@ -321,6 +280,10 @@ async function openHref(href: string) {
   }
 
   // Treat anything else with a recognised file extension as a relative path.
+  // `resolveRelativeLink` is fail-closed: a non-navigable extension, a pure
+  // fragment, or a traversal escaping the current file's root all return null,
+  // and a null routes to this no-op — the correct UX for a link that points
+  // outside the document tree.
   if (currentFilePath) {
     const resolvedPath = resolveRelativeLink(href, currentFilePath);
     if (resolvedPath) {

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -6,6 +6,7 @@ import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
 import Typography from "@tiptap/extension-typography";
 import { untrack } from "svelte";
 import * as Y from "yjs";
+import type { TandemNotification } from "../../shared/types.js";
 import { createTandemSettings } from "../hooks/useTandemSettings.svelte";
 import { readStoredName, subscribeToUserName } from "../hooks/useUserName";
 import { openServerPath } from "../utils/server-paths";
@@ -27,7 +28,11 @@ import LinkEditor from "./toolbar/LinkEditor.svelte";
 // resolveRelativeLink + INTERNAL_LINK_EXTS hoisted to ./utils/relative-link.ts:
 // module-private here, it had zero test coverage, and its fail-closed traversal
 // guards are exactly the kind of thing that has to be tested.
-import { resolveRelativeLink } from "./utils/relative-link";
+import {
+  LINKABLE_EXTS_LABEL,
+  resolveRelativeLink,
+  SECURITY_REJECT_REASONS,
+} from "./utils/relative-link";
 import { isSafeExternalHref } from "./utils/url-safety";
 import "./editor.css";
 
@@ -52,6 +57,13 @@ interface Props {
   /** Intent-only callbacks used by the desktop native editor menu. */
   onFocusChat?: () => void;
   onComposeAnnotation?: (kind: "comment" | "note") => void;
+  /**
+   * Surface a link-open failure to the user. Threaded as a prop rather than
+   * calling `createNotifications()` here: that factory is NOT a singleton (it
+   * opens a fresh `EventSource` per call), so a second instantiation would
+   * duplicate the SSE subscription and the tray.
+   */
+  onNotify?: (n: TandemNotification) => void;
 }
 
 const {
@@ -67,6 +79,7 @@ const {
   onSlashCommandMenuChange,
   onFocusChat,
   onComposeAnnotation,
+  onNotify,
 }: Props = $props();
 
 let editor = $state<TiptapEditor | null>(null);
@@ -266,6 +279,18 @@ $effect(() => {
   }
 });
 
+function notifyLinkProblem(message: string, severity: "warning" | "error", dedupKey: string): void {
+  onNotify?.({
+    id: `link-problem-${Date.now()}`,
+    type: "general-error",
+    severity,
+    message,
+    dedupKey,
+    timestamp: Date.now(),
+    errorCode: "LINK_NOT_OPENABLE",
+  });
+}
+
 // Open a link href the same way for both the click intercept and the context
 // menu's "Open Link" item (issue #923): safe external schemes go to the system
 // browser, relative paths open as Tandem tabs, unrecognised schemes are
@@ -280,22 +305,49 @@ async function openHref(href: string) {
   }
 
   // Treat anything else with a recognised file extension as a relative path.
-  // `resolveRelativeLink` is fail-closed: a non-navigable extension, a pure
-  // fragment, or a traversal escaping the current file's root all return null,
-  // and a null means we do not navigate — the correct UX for a link that points
-  // outside the document tree. #1377 widened the RENDER boundary without
-  // widening this one, so an href can now be clickable and still land here; the
-  // warn is what makes that gap visible instead of a dead click.
-  if (currentFilePath) {
-    const resolvedPath = resolveRelativeLink(href, currentFilePath);
-    if (!resolvedPath) {
-      console.warn(`[tandem] Link target is not an openable relative path: "${href}"`);
-      return;
-    }
-    const result = await openServerPath(resolvedPath);
-    if (!result.ok) {
-      console.warn(`[tandem] Could not open linked file "${resolvedPath}": ${result.error}`);
-    }
+  //
+  // #1377 widened the RENDER boundary without widening this one, so an href can
+  // now be clickable — pointer cursor, hover tooltip naming a destination — and
+  // still be refused here. Every refusal therefore has to SAY so. A
+  // `console.warn` alone is not a channel in the primary distribution: the
+  // Tauri release build ships no `devtools` feature, so there is no inspector
+  // the user can open, and `utils/diagnostics.ts` has no console ring buffer,
+  // so it never reaches a bug report either.
+  if (!currentFilePath) {
+    notifyLinkProblem(
+      `Can't follow "${href}" — save this document to disk first so relative links have somewhere to resolve against.`,
+      "warning",
+      `link-no-file:${href}`,
+    );
+    return;
+  }
+
+  const resolved = resolveRelativeLink(href, currentFilePath);
+  if (!resolved.ok) {
+    // A blocked traversal and a mistyped extension are not the same event. The
+    // first is something a hostile or model-authored document put in front of
+    // the user — MCP tools write markdown into these files — and it needs a
+    // durable record, not a line in a console nobody can open.
+    const hostile = SECURITY_REJECT_REASONS.has(resolved.reason);
+    notifyLinkProblem(
+      hostile
+        ? `Blocked a link pointing outside this document's folder: "${href}"`
+        : `Can't open "${href}" — Tandem follows links to ${LINKABLE_EXTS_LABEL} files relative to this document.`,
+      hostile ? "error" : "warning",
+      `link-rejected:${resolved.reason}:${href}`,
+    );
+    console.warn(`[tandem] Link refused (${resolved.reason}): "${href}"`);
+    return;
+  }
+
+  const result = await openServerPath(resolved.path);
+  if (!result.ok) {
+    notifyLinkProblem(
+      `Couldn't open "${resolved.path}": ${result.error}`,
+      "error",
+      `link-open-failed:${resolved.path}`,
+    );
+    console.warn(`[tandem] Could not open linked file "${resolved.path}": ${result.error}`);
   }
 }
 

--- a/src/client/editor/editor-extensions.ts
+++ b/src/client/editor/editor-extensions.ts
@@ -1,7 +1,7 @@
 import { type AnyExtension, mergeAttributes } from "@tiptap/core";
 import Highlight from "@tiptap/extension-highlight";
 import Image from "@tiptap/extension-image";
-import Link from "@tiptap/extension-link";
+import Link, { isAllowedUri as tiptapDefaultIsAllowedUri } from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import Subscript from "@tiptap/extension-subscript";
 import Superscript from "@tiptap/extension-superscript";
@@ -15,19 +15,24 @@ import { FootnoteRefMark } from "./extensions/footnote-ref";
 import { ListItemCheckbox } from "./extensions/list-item-checkbox";
 import { MarkdownHtmlExtension } from "./extensions/markdown-html";
 import { RawMarkdownMark } from "./extensions/raw-markdown";
-import { isSafeExternalHref } from "./utils/url-safety";
+import { isSafeExternalHref, isSchemelessPathHref } from "./utils/url-safety";
 
 // Link mark that surfaces the destination URL on hover via a native `title`
 // tooltip (issue #996). The base `@tiptap/extension-link` renderHTML emits the
 // `href` (plus our configured rel/target) but no title, so links give no hover
 // affordance for where they point. We delegate to the base renderHTML via
-// `this.parent()` — which keeps its `isAllowedUri` security branch (blanking
-// `javascript:`/`data:`/etc. hrefs to "") — and then post-process: mirror the
+// `this.parent()` — which keeps its href-blanking security branch, emitting
+// `href: ""` for any URI its guard refuses — and then post-process: mirror the
 // href into `title` only when the BASE output's href survived (non-empty) and no
 // explicit title already exists (e.g. a .docx-imported title attr wins). Reading
 // the base output rather than the raw HTMLAttributes means a disallowed scheme is
 // never given a title and never resurrected. Pointer-cursor styling lives in
 // editor.css (`.tandem-editor a[href]`).
+//
+// Two halves, deliberately separate: the BLANKING lives here in the base
+// renderHTML, but WHICH hrefs get blanked is decided by the `isAllowedUri`
+// option configured at the `.configure({…})` site below — not by the vendored
+// default. Read that comment before reasoning about what reaches `attrs.href`.
 //
 // It also strips the configured `target="_blank"` from non-external hrefs — see
 // the comment at that branch for why the attribute is a double-open on internal
@@ -113,6 +118,66 @@ export function buildSchemaExtensions(): AnyExtension[] {
     LinkWithHoverTitle.configure({
       openOnClick: false,
       HTMLAttributes: { rel: "noopener noreferrer", target: "_blank" },
+      // #1377: `[spec](docs/spec.md)` — the relative-link form most repos use —
+      // rendered with `href=""` and no hover tooltip. The vendored default
+      // guard blocks `/^[a-zA-Z][a-zA-Z0-9+.-]*[:\/]/`.
+      //
+      // DERIVATION WARNING, because re-deriving it wrong flips the answer: the
+      // vendored pattern is assembled inside a TEMPLATE LITERAL
+      // (`dist/index.js:211-213`), so `\-` collapses to a bare `-` before
+      // `new RegExp` ever sees it and the final class is `[^a-z+.-:]`, in which
+      // `.-:` IS a range (U+002E–U+003A) swallowing `.`, `/`, the digits and
+      // `:`. Written literally with an escaped hyphen it would be a plain set,
+      // and `docs/spec.md` would be ALLOWED — the opposite of production.
+      //
+      // Fix: a strictly-additive union. `ctx.defaultValidate` runs FIRST so
+      // Tiptap's DOMPurify-derived scheme allowlist stays the authority on
+      // schemes, and our predicate can only ever ADD.
+      //
+      // Newly allowed, as a PROPERTY rather than a list (a list was measurably
+      // wrong): every href that contains no URL-hostile character and no
+      // backslash, does not begin `//`, and has either no colon or a `/`, `#`
+      // or `?` before its first colon — that `defaultValidate` rejects.
+      // Illustrations only: `docs/spec.md`, `java/script:alert(1)`,
+      // `example.com/path`. `javascript:`/`data:`/`vbscript:`/`file:`/`blob:`/
+      // `filesystem:` and their whitespace-obfuscated variants stay blocked by
+      // BOTH halves (the default strips whitespace and sees the scheme; our
+      // predicate fails closed on the hostile character).
+      //
+      // NOT claimed: that a newly-allowed href "can only be a relative URL".
+      // That is true of `new URL()` and false of Tandem's actual consumer —
+      // `utils/relative-link.ts` is a segment walk, and it is where the
+      // traversal question is answered.
+      //
+      // This option governs SIX surfaces in `dist/index.js`: parseHTML getAttrs
+      // (:290), renderHTML (:304), setLink (:322), toggleLink (:333), the
+      // linkify markPasteRule (:361) and the autolink validator (:395).
+      // setLink/toggleLink are the Link-editor + context-menu surface, where a
+      // bare nested path silently no-opped before this change. The markPasteRule
+      // reads `isAllowedUri` directly and CANNOT be narrowed by option — pasting
+      // the plain text `example.com/path` now linkifies; accepted deliberately,
+      // since bare `example.com` already linkifies today. Autolink is pinned
+      // below.
+      isAllowedUri: (url, ctx) => ctx.defaultValidate(url) || isSchemelessPathHref(url),
+      // Autolink is held at EXACTLY today's behaviour, and only this option can
+      // do it: the autolink plugin filters on `link.value` — the RAW TYPED TEXT
+      // (`dist/index.js:106`), not the resolved href. Measured with the real
+      // linkifyjs, `find("example.com/path")` yields
+      // `{value: "example.com/path", href: "http://example.com/path"}` while
+      // `defaultValidate("example.com/path")` is false, so widening
+      // `isAllowedUri` alone would make typing `example.com/path ` auto-create a
+      // link — writing markdown link syntax into the user's file on a keystroke,
+      // entirely outside #1377. `shouldAutoLink` is applied AFTER `validate`
+      // (:107), so restoring the vendored default here pins the gate exactly.
+      // What is NOT new: typing `docs/spec.md ` already autolinks `spec.md`
+      // today (linkify tokenizes to the last dotted run); this changes nothing
+      // there.
+      //
+      // The `[]` is the `protocols` argument, and it is correct only because we
+      // never configure `protocols`. If a custom protocol is ever added above,
+      // it must be threaded through here too or autolink will silently ignore
+      // it — an option literal cannot reach `this.options`.
+      shouldAutoLink: (url) => !!tiptapDefaultIsAllowedUri(url, []),
     }),
     // Block-level image node (issue #153). Renders `![alt](url)` markdown
     // (round-tripped through mdast-ydoc) and embedded .docx images (mammoth

--- a/src/client/editor/editor-extensions.ts
+++ b/src/client/editor/editor-extensions.ts
@@ -119,64 +119,42 @@ export function buildSchemaExtensions(): AnyExtension[] {
       openOnClick: false,
       HTMLAttributes: { rel: "noopener noreferrer", target: "_blank" },
       // #1377: `[spec](docs/spec.md)` — the relative-link form most repos use —
-      // rendered with `href=""` and no hover tooltip. The vendored default
-      // guard blocks `/^[a-zA-Z][a-zA-Z0-9+.-]*[:\/]/`.
+      // rendered with `href=""` and no hover tooltip, because Tiptap's default
+      // guard rejects it. (Don't re-derive that guard's regex by reading it:
+      // it is assembled in a template literal, so the escape you see is not the
+      // one `new RegExp` gets, and the naive reading flips the answer. The
+      // behaviour is pinned executably in `tests/client/link-target-internal.test.ts`.)
       //
-      // DERIVATION WARNING, because re-deriving it wrong flips the answer: the
-      // vendored pattern is assembled inside a TEMPLATE LITERAL
-      // (`dist/index.js:211-213`), so `\-` collapses to a bare `-` before
-      // `new RegExp` ever sees it and the final class is `[^a-z+.-:]`, in which
-      // `.-:` IS a range (U+002E–U+003A) swallowing `.`, `/`, the digits and
-      // `:`. Written literally with an escaped hyphen it would be a plain set,
-      // and `docs/spec.md` would be ALLOWED — the opposite of production.
-      //
-      // Fix: a strictly-additive union. `ctx.defaultValidate` runs FIRST so
-      // Tiptap's DOMPurify-derived scheme allowlist stays the authority on
-      // schemes, and our predicate can only ever ADD.
-      //
-      // Newly allowed, as a PROPERTY rather than a list (a list was measurably
-      // wrong): every href that contains no URL-hostile character and no
-      // backslash, does not begin `//`, and has either no colon or a `/`, `#`
-      // or `?` before its first colon — that `defaultValidate` rejects.
-      // Illustrations only: `docs/spec.md`, `java/script:alert(1)`,
-      // `example.com/path`. `javascript:`/`data:`/`vbscript:`/`file:`/`blob:`/
-      // `filesystem:` and their whitespace-obfuscated variants stay blocked by
-      // BOTH halves (the default strips whitespace and sees the scheme; our
-      // predicate fails closed on the hostile character).
+      // The fix is a union, and it is strictly additive because `||` can only
+      // ever widen — not because of which operand runs first. Tiptap's
+      // DOMPurify-derived scheme allowlist therefore stays the authority on
+      // schemes and our predicate only ADDs: hrefs with no URL-hostile
+      // character, no backslash, no leading `//`, and either no colon or a
+      // `/`/`#`/`?` before the first one. `javascript:` and friends stay blocked
+      // by both halves.
       //
       // NOT claimed: that a newly-allowed href "can only be a relative URL".
       // That is true of `new URL()` and false of Tandem's actual consumer —
       // `utils/relative-link.ts` is a segment walk, and it is where the
       // traversal question is answered.
       //
-      // This option governs SIX surfaces in `dist/index.js`: parseHTML getAttrs
-      // (:290), renderHTML (:304), setLink (:322), toggleLink (:333), the
-      // linkify markPasteRule (:361) and the autolink validator (:395).
-      // setLink/toggleLink are the Link-editor + context-menu surface, where a
-      // bare nested path silently no-opped before this change. The markPasteRule
-      // reads `isAllowedUri` directly and CANNOT be narrowed by option — pasting
-      // the plain text `example.com/path` now linkifies; accepted deliberately,
-      // since bare `example.com` already linkifies today. Autolink is pinned
-      // below.
+      // Widening reaches every surface that reads this option, including the
+      // linkify markPasteRule, which cannot be narrowed separately: pasting the
+      // plain text `example.com/path` now linkifies. Accepted deliberately —
+      // bare `example.com` already did.
       isAllowedUri: (url, ctx) => ctx.defaultValidate(url) || isSchemelessPathHref(url),
-      // Autolink is held at EXACTLY today's behaviour, and only this option can
-      // do it: the autolink plugin filters on `link.value` — the RAW TYPED TEXT
-      // (`dist/index.js:106`), not the resolved href. Measured with the real
-      // linkifyjs, `find("example.com/path")` yields
-      // `{value: "example.com/path", href: "http://example.com/path"}` while
-      // `defaultValidate("example.com/path")` is false, so widening
-      // `isAllowedUri` alone would make typing `example.com/path ` auto-create a
-      // link — writing markdown link syntax into the user's file on a keystroke,
-      // entirely outside #1377. `shouldAutoLink` is applied AFTER `validate`
-      // (:107), so restoring the vendored default here pins the gate exactly.
-      // What is NOT new: typing `docs/spec.md ` already autolinks `spec.md`
-      // today (linkify tokenizes to the last dotted run); this changes nothing
-      // there.
+      // Autolink is the one surface held at EXACTLY today's behaviour, and only
+      // this option can do it: the autolink plugin filters on the RAW TYPED
+      // TEXT, not the resolved href, so widening `isAllowedUri` alone would make
+      // typing `example.com/path ` auto-create a link — writing markdown link
+      // syntax into the user's file on a keystroke, entirely outside #1377.
+      // Restoring the vendored default here pins that gate.
       //
       // The `[]` is the `protocols` argument, and it is correct only because we
-      // never configure `protocols`. If a custom protocol is ever added above,
-      // it must be threaded through here too or autolink will silently ignore
-      // it — an option literal cannot reach `this.options`.
+      // never configure `protocols` (asserted in the test file). If a custom
+      // protocol is ever added above, it must be threaded through here too or
+      // autolink will silently ignore it — an option literal cannot reach
+      // `this.options`.
       shouldAutoLink: (url) => !!tiptapDefaultIsAllowedUri(url, []),
     }),
     // Block-level image node (issue #153). Renders `![alt](url)` markdown

--- a/src/client/editor/editor-extensions.ts
+++ b/src/client/editor/editor-extensions.ts
@@ -148,7 +148,13 @@ export function buildSchemaExtensions(): AnyExtension[] {
       // TEXT, not the resolved href, so widening `isAllowedUri` alone would make
       // typing `example.com/path ` auto-create a link — writing markdown link
       // syntax into the user's file on a keystroke, entirely outside #1377.
-      // Restoring the vendored default here pins that gate.
+      //
+      // Substituting the vendored default URI GUARD here pins that gate. Note
+      // it is not the vendored `shouldAutoLink` default (that one is
+      // `url => !!url`): autolink's effective gate is `validate && shouldAutoLink`,
+      // so widened-validate AND default-guard re-composes to exactly the
+      // default. The `!!` is required, not decorative — `isAllowedUri` returns
+      // `RegExpMatchArray | null`, and this option is typed boolean.
       //
       // The `[]` is the `protocols` argument, and it is correct only because we
       // never configure `protocols` (asserted in the test file). If a custom

--- a/src/client/editor/utils/relative-link.ts
+++ b/src/client/editor/utils/relative-link.ts
@@ -1,0 +1,91 @@
+import { SUPPORTED_EXTENSIONS } from "../../../shared/constants.js";
+
+/**
+ * File extensions that open as new Tandem tabs when clicked as relative links.
+ * `.docx` excluded — not navigable as a link target.
+ */
+const INTERNAL_LINK_EXTS = new Set([...SUPPORTED_EXTENSIONS].filter((e) => e !== ".docx"));
+
+/**
+ * Resolve a relative href against an absolute file path.
+ * Works on both POSIX and Windows paths by detecting the separator.
+ * Returns null when the href is not a link we are willing to open — a
+ * non-navigable extension, a pure fragment, or a traversal that escapes the
+ * current file's root.
+ *
+ * **This is NOT a URL parser, and `new URL()` semantics do not transfer to it.**
+ * That distinction is load-bearing: `url-safety.ts`'s `isSchemelessPathHref`
+ * only warrants that a widened href is relative *as far as the WHATWG parser is
+ * concerned*, and it points here precisely because this segment walk answers a
+ * different question.
+ *
+ * **Why the fail-closed guards exist (the bug is invisible from the body).**
+ * With `currentFilePath = C:\Users\blokn\docs\note.md`, the href
+ * `a/../../../../..///evil.com/share/x.md` walks `resultParts` down to empty;
+ * the two empty segments produced by `///` then become two LEADING empties, and
+ * `join("\\")` yields `\\evil.com\share\x.md` — a UNC path, which `openHref`
+ * POSTs to `/api/open`. That is Tandem's named NTLM-hash-leak vector. The
+ * variant WITHOUT the leading `a/` is allowed by Tiptap's default URL guard
+ * today, so these guards close a pre-existing hole as well as one that
+ * widening the guard (#1377) would otherwise open.
+ *
+ * Measured non-regressions (all still resolve):
+ *   - `../docs/spec.md` from `C:\Users\b\docs\note.md` → `C:\Users\b\docs\spec.md`
+ *   - `docs/spec.md` → `C:\Users\b\docs\docs\spec.md`
+ *   - `/\evil.com/x.md` → `C:\Users\b\docs\\\evil.com\x.md`, which
+ *     `path.resolve` collapses to a same-machine path.
+ */
+export function resolveRelativeLink(href: string, currentFilePath: string): string | null {
+  // Detect Windows vs POSIX
+  const sep = currentFilePath.includes("\\") ? "\\" : "/";
+
+  // Strip hash fragment for resolution; we don't support in-page anchors cross-file
+  const hashIdx = href.indexOf("#");
+  const hrefPath = hashIdx >= 0 ? href.slice(0, hashIdx) : href;
+  if (!hrefPath) return null; // pure fragment (#section) — not a file link
+
+  // A protocol-relative (`//host/x`) or UNC-shaped (`\\host\x`) href is an
+  // EXTERNAL navigation, never a path relative to the current file. `openHref`
+  // routes `//` to `isSafeExternalHref` before reaching us, so this changes no
+  // observable behaviour — it keeps the function correct standalone, which the
+  // containment check below cannot do on its own (both forms otherwise append
+  // empty segments to the current directory and pass containment).
+  if (hrefPath.startsWith("//") || hrefPath.startsWith("\\\\")) return null;
+
+  // Check extension
+  const extMatch = hrefPath.match(/\.[^./\\]+$/);
+  const ext = extMatch ? extMatch[0].toLowerCase() : "";
+  if (!INTERNAL_LINK_EXTS.has(ext)) return null;
+
+  // Get directory of current file (convert forward slashes in href to platform sep)
+  const dirParts = currentFilePath.split(sep);
+  dirParts.pop(); // remove filename
+  // No directory to resolve against (a `currentFilePath` with no separator).
+  if (dirParts.length === 0) return null;
+
+  // Normalize the href to use the platform separator
+  const hrefNormalized = hrefPath.replace(/\//g, sep);
+  const hrefParts = hrefNormalized.split(sep);
+
+  // Merge directory + relative parts, resolving . and ..
+  const resultParts = [...dirParts];
+  for (const part of hrefParts) {
+    if (part === "..") {
+      if (resultParts.length > 0) resultParts.pop();
+    } else if (part !== ".") {
+      resultParts.push(part);
+    }
+  }
+
+  // CONTAINMENT: `..` must not escape the current file's root. On Windows
+  // `dirParts[0]` is the drive (`C:`); on POSIX it is the empty string left by
+  // the leading `/`, so the same comparison catches `../../../../etc/passwd`
+  // escaping above `/`.
+  if (resultParts.length === 0 || resultParts[0] !== dirParts[0]) return null;
+
+  // Belt-and-braces UNC reject, independent of the containment check above.
+  const joined = resultParts.join(sep);
+  if (joined.startsWith("\\\\") || joined.startsWith("//")) return null;
+
+  return joined;
+}

--- a/src/client/editor/utils/relative-link.ts
+++ b/src/client/editor/utils/relative-link.ts
@@ -7,6 +7,15 @@ import { rejectUnsafeWindowsPrefix } from "../../../shared/windows-path-safety.j
  */
 const INTERNAL_LINK_EXTS = new Set([...SUPPORTED_EXTENSIONS].filter((e) => e !== ".docx"));
 
+/**
+ * The same set as prose, for error copy. Derived rather than written out so a
+ * change to {@link INTERNAL_LINK_EXTS} cannot leave the user-facing message
+ * naming formats Tandem no longer opens.
+ */
+export const LINKABLE_EXTS_LABEL = [...INTERNAL_LINK_EXTS]
+  .join(", ")
+  .replace(/, ([^,]*)$/, " and $1");
+
 /** Trailing `.ext`, where the extension itself contains no separator. */
 const TRAILING_EXT_RE = /\.[^./\\]+$/;
 
@@ -19,11 +28,41 @@ const TRAILING_EXT_RE = /\.[^./\\]+$/;
 const PATH_SEP_RE = /[/\\]/;
 
 /**
+ * Why a href was refused.
+ *
+ * These are NOT interchangeable, which is the whole reason this is a union
+ * rather than `null`. `escapes-root` and `joined-unc` are things a hostile or
+ * model-authored document put in front of the user — and MCP tools write
+ * markdown into the user's documents, so a crafted link is in-model for this
+ * app. `unsupported-ext` is a typo. A caller that treats them alike leaves a
+ * blocked traversal with the same trace as a mistyped `.pdf`.
+ */
+export type LinkRejectReason =
+  /** Pure `#anchor` (or `?query`) with no path — not a file link. */
+  | "fragment"
+  /** The href itself is UNC- or device-namespace-shaped. */
+  | "unsafe-prefix"
+  /** Not a format Tandem opens in a tab. */
+  | "unsupported-ext"
+  /** `currentFilePath` has no separator, so there is no directory to resolve against. */
+  | "no-directory"
+  /** `..` walked above the current file's root. */
+  | "escapes-root"
+  /** The resolved path is UNC-shaped even though containment passed. */
+  | "joined-unc";
+
+/** Reject reasons that indicate a hostile href rather than a mistake. */
+export const SECURITY_REJECT_REASONS: ReadonlySet<LinkRejectReason> = new Set([
+  "unsafe-prefix",
+  "escapes-root",
+  "joined-unc",
+] satisfies LinkRejectReason[]);
+
+export type LinkResolution = { ok: true; path: string } | { ok: false; reason: LinkRejectReason };
+
+/**
  * Resolve a relative href against an absolute file path.
  * Works on both POSIX and Windows paths by detecting the separator.
- * Returns null when the href is not a link we are willing to open — a
- * non-navigable extension, a pure fragment, or a traversal that escapes the
- * current file's root.
  *
  * **This is NOT a URL parser, and `new URL()` semantics do not transfer to it.**
  * That distinction is load-bearing: `url-safety.ts`'s `isSchemelessPathHref`
@@ -37,38 +76,54 @@ const PATH_SEP_RE = /[/\\]/;
  * the two empty segments produced by `///` then become two LEADING empties, and
  * `join("\\")` yields `\\evil.com\share\x.md` — a UNC path, which `openHref`
  * POSTs to `/api/open`. That is Tandem's named NTLM-hash-leak vector. The
- * variant WITHOUT the leading `a/` is allowed by Tiptap's default URL guard
- * today, so these guards close a pre-existing hole as well as one that
- * widening the guard (#1377) would otherwise open.
+ * example is depth-sensitive on purpose: it carries one more `..` than the path
+ * has directories, so re-running it against a shallower or deeper
+ * `currentFilePath` gives a different answer. The variant WITHOUT the leading
+ * `a/` is allowed by Tiptap's default URL guard today (pinned in
+ * `tests/client/link-target-internal.test.ts`), so these guards close a
+ * pre-existing hole as well as one that widening the guard (#1377) would open.
  *
- * Measured non-regressions (all still resolve):
- *   - `../docs/spec.md` from `C:\Users\b\docs\note.md` → `C:\Users\b\docs\spec.md`
- *   - `docs/spec.md` → `C:\Users\b\docs\docs\spec.md`
- *   - `/\evil.com/x.md` → `C:\Users\b\docs\\\evil.com\x.md`, which
+ * **The two UNC guards are not redundant, and they fail on different platforms.**
+ * For that same href: on Windows containment catches it (`resultParts[0]` is
+ * `""`, not `"C:"`), and on POSIX containment *passes* (both are `""`) so only
+ * the post-join check catches it. Deleting either one leaves a live hole on one
+ * platform; the test suite pins each independently.
+ *
+ * Measured non-regressions (all still resolve), from `C:\Users\blokn\docs\note.md`:
+ *   - `../docs/spec.md` → `C:\Users\blokn\docs\spec.md`
+ *   - `docs/spec.md` → `C:\Users\blokn\docs\docs\spec.md`
+ *   - `/\evil.com/x.md` → `C:\Users\blokn\docs\\\evil.com\x.md`, which
  *     `path.resolve` collapses to a same-machine path.
  */
-export function resolveRelativeLink(href: string, currentFilePath: string): string | null {
-  // Detect Windows vs POSIX
+export function resolveRelativeLink(href: string, currentFilePath: string): LinkResolution {
+  // Detect Windows vs POSIX for the JOIN. The splits below accept either
+  // flavour regardless; only the output separator is platform-shaped.
   const sep = currentFilePath.includes("\\") ? "\\" : "/";
 
-  // Strip hash fragment for resolution; we don't support in-page anchors cross-file
-  const hashIdx = href.indexOf("#");
-  const hrefPath = hashIdx >= 0 ? href.slice(0, hashIdx) : href;
-  if (!hrefPath) return null; // pure fragment (#section) — not a file link
+  // Strip both `#fragment` and `?query` — a browser treats each as structural,
+  // and stripping only `#` made the render and click boundaries disagree:
+  // `isSchemelessPathHref` renders `docs/spec.md?x=1` (it stops at `?` when
+  // looking for a scheme) while `TRAILING_EXT_RE` then saw `.md?x=1`, matched
+  // nothing, and refused it. Cross-file in-page anchors are not supported.
+  const stops = [href.indexOf("#"), href.indexOf("?")].filter((i) => i >= 0);
+  const hrefPath = stops.length ? href.slice(0, Math.min(...stops)) : href;
+  if (!hrefPath) return { ok: false, reason: "fragment" };
 
   // A protocol-relative (`//host/x`), UNC-shaped (`\\host\x`) or
   // device-namespace (`\\?\…`) href is an EXTERNAL navigation, never a path
-  // relative to the current file. `openHref` routes `//` to
-  // `isSafeExternalHref` before reaching us, so this changes no observable
-  // behaviour — it keeps the function correct standalone, which the containment
-  // check below cannot do on its own (both forms otherwise append empty
-  // segments to the current directory and pass containment).
-  if (rejectUnsafeWindowsPrefix(hrefPath) !== null) return null;
+  // relative to the current file.
+  //
+  // Only the `//` case is unobservable in production, because `openHref` routes
+  // it to `isSafeExternalHref` first. The backslash forms DO reach us and this
+  // guard does change their outcome — from a collapsed same-machine path to a
+  // refusal — so it is not inert; don't delete it as dead code.
+  if (rejectUnsafeWindowsPrefix(hrefPath) !== null) {
+    return { ok: false, reason: "unsafe-prefix" };
+  }
 
-  // Check extension
   const extMatch = hrefPath.match(TRAILING_EXT_RE);
   const ext = extMatch ? extMatch[0].toLowerCase() : "";
-  if (!INTERNAL_LINK_EXTS.has(ext)) return null;
+  if (!INTERNAL_LINK_EXTS.has(ext)) return { ok: false, reason: "unsupported-ext" };
 
   // Get directory of current file. Split on either separator so a mixed path
   // (`C:\Users\b\docs/note.md`) does not collapse `docs/note.md` into one
@@ -76,7 +131,7 @@ export function resolveRelativeLink(href: string, currentFilePath: string): stri
   const dirParts = currentFilePath.split(PATH_SEP_RE);
   dirParts.pop(); // remove filename
   // No directory to resolve against (a `currentFilePath` with no separator).
-  if (dirParts.length === 0) return null;
+  if (dirParts.length === 0) return { ok: false, reason: "no-directory" };
 
   const hrefParts = hrefPath.split(PATH_SEP_RE);
 
@@ -94,13 +149,19 @@ export function resolveRelativeLink(href: string, currentFilePath: string): stri
   // `dirParts[0]` is the drive (`C:`); on POSIX it is the empty string left by
   // the leading `/`, so the same comparison catches `../../../../etc/passwd`
   // escaping above `/`.
-  // (An emptied `resultParts` is caught by the same comparison: `dirParts` is
-  // non-empty by the guard above, so `undefined !== dirParts[0]` holds.)
-  if (resultParts[0] !== dirParts[0]) return null;
+  //
+  // `resultParts` cannot be empty here, and the reason is the EXTENSION GATE
+  // above, not the `dirParts` guard: `TRAILING_EXT_RE` requires the final href
+  // segment to contain a dot and no separator, so that segment is never `..`
+  // or `.` and is therefore always pushed. If the gate is ever loosened, an
+  // explicit `resultParts.length === 0` check has to come back — the comparison
+  // below would still refuse (`undefined !== dirParts[0]`), but only by
+  // accident.
+  if (resultParts[0] !== dirParts[0]) return { ok: false, reason: "escapes-root" };
 
-  // Belt-and-braces UNC reject, independent of the containment check above.
+  // Belt-and-braces UNC reject — load-bearing on POSIX, see the header.
   const joined = resultParts.join(sep);
-  if (rejectUnsafeWindowsPrefix(joined) !== null) return null;
+  if (rejectUnsafeWindowsPrefix(joined) !== null) return { ok: false, reason: "joined-unc" };
 
-  return joined;
+  return { ok: true, path: joined };
 }

--- a/src/client/editor/utils/relative-link.ts
+++ b/src/client/editor/utils/relative-link.ts
@@ -1,10 +1,22 @@
 import { SUPPORTED_EXTENSIONS } from "../../../shared/constants.js";
+import { rejectUnsafeWindowsPrefix } from "../../../shared/windows-path-safety.js";
 
 /**
  * File extensions that open as new Tandem tabs when clicked as relative links.
  * `.docx` excluded — not navigable as a link target.
  */
 const INTERNAL_LINK_EXTS = new Set([...SUPPORTED_EXTENSIONS].filter((e) => e !== ".docx"));
+
+/** Trailing `.ext`, where the extension itself contains no separator. */
+const TRAILING_EXT_RE = /\.[^./\\]+$/;
+
+/**
+ * Path separator, either flavour. Both are split on regardless of platform: a
+ * `\` inside an href is the fail-OPEN direction if treated as an ordinary
+ * character, because `a\..\..\..\x.md` would then be one opaque segment that
+ * sails through the `..` walk and the containment check below.
+ */
+const PATH_SEP_RE = /[/\\]/;
 
 /**
  * Resolve a relative href against an absolute file path.
@@ -44,28 +56,29 @@ export function resolveRelativeLink(href: string, currentFilePath: string): stri
   const hrefPath = hashIdx >= 0 ? href.slice(0, hashIdx) : href;
   if (!hrefPath) return null; // pure fragment (#section) — not a file link
 
-  // A protocol-relative (`//host/x`) or UNC-shaped (`\\host\x`) href is an
-  // EXTERNAL navigation, never a path relative to the current file. `openHref`
-  // routes `//` to `isSafeExternalHref` before reaching us, so this changes no
-  // observable behaviour — it keeps the function correct standalone, which the
-  // containment check below cannot do on its own (both forms otherwise append
-  // empty segments to the current directory and pass containment).
-  if (hrefPath.startsWith("//") || hrefPath.startsWith("\\\\")) return null;
+  // A protocol-relative (`//host/x`), UNC-shaped (`\\host\x`) or
+  // device-namespace (`\\?\…`) href is an EXTERNAL navigation, never a path
+  // relative to the current file. `openHref` routes `//` to
+  // `isSafeExternalHref` before reaching us, so this changes no observable
+  // behaviour — it keeps the function correct standalone, which the containment
+  // check below cannot do on its own (both forms otherwise append empty
+  // segments to the current directory and pass containment).
+  if (rejectUnsafeWindowsPrefix(hrefPath) !== null) return null;
 
   // Check extension
-  const extMatch = hrefPath.match(/\.[^./\\]+$/);
+  const extMatch = hrefPath.match(TRAILING_EXT_RE);
   const ext = extMatch ? extMatch[0].toLowerCase() : "";
   if (!INTERNAL_LINK_EXTS.has(ext)) return null;
 
-  // Get directory of current file (convert forward slashes in href to platform sep)
-  const dirParts = currentFilePath.split(sep);
+  // Get directory of current file. Split on either separator so a mixed path
+  // (`C:\Users\b\docs/note.md`) does not collapse `docs/note.md` into one
+  // segment and silently resolve against the wrong directory.
+  const dirParts = currentFilePath.split(PATH_SEP_RE);
   dirParts.pop(); // remove filename
   // No directory to resolve against (a `currentFilePath` with no separator).
   if (dirParts.length === 0) return null;
 
-  // Normalize the href to use the platform separator
-  const hrefNormalized = hrefPath.replace(/\//g, sep);
-  const hrefParts = hrefNormalized.split(sep);
+  const hrefParts = hrefPath.split(PATH_SEP_RE);
 
   // Merge directory + relative parts, resolving . and ..
   const resultParts = [...dirParts];
@@ -81,11 +94,13 @@ export function resolveRelativeLink(href: string, currentFilePath: string): stri
   // `dirParts[0]` is the drive (`C:`); on POSIX it is the empty string left by
   // the leading `/`, so the same comparison catches `../../../../etc/passwd`
   // escaping above `/`.
-  if (resultParts.length === 0 || resultParts[0] !== dirParts[0]) return null;
+  // (An emptied `resultParts` is caught by the same comparison: `dirParts` is
+  // non-empty by the guard above, so `undefined !== dirParts[0]` holds.)
+  if (resultParts[0] !== dirParts[0]) return null;
 
   // Belt-and-braces UNC reject, independent of the containment check above.
   const joined = resultParts.join(sep);
-  if (joined.startsWith("\\\\") || joined.startsWith("//")) return null;
+  if (rejectUnsafeWindowsPrefix(joined) !== null) return null;
 
   return joined;
 }

--- a/src/client/editor/utils/url-safety.ts
+++ b/src/client/editor/utils/url-safety.ts
@@ -40,9 +40,23 @@ export function isSafeExternalHref(href: string): boolean {
  * True when `trimmed` has a URI scheme prefix — a `:` appearing before any of
  * `/`, `#`, or `?` (a colon appearing only after one of those, e.g. inside a
  * filename or query string, is path-like, not a scheme). Shared detection
- * mechanic for `sanitizeHrefForPaste` and `sanitizeImageSrcForPaste`; each
- * keeps its own separate allowlist policy, so a change here can only ever
- * affect what counts as "has a scheme", never which schemes are safe.
+ * mechanic for `sanitizeHrefForPaste`, `sanitizeImageSrcForPaste` and
+ * {@link isSchemelessPathHref}.
+ *
+ * The first two pair this helper with their own separate allowlist
+ * (`SAFE_EXTERNAL_PREFIXES` / `SAFE_IMAGE_PREFIXES`), so for THEM a change here
+ * can only ever affect what counts as "has a scheme", never which schemes are
+ * safe. That warranty does NOT extend to the third consumer:
+ * {@link isSchemelessPathHref} is `!hasSchemePrefix(...)` and nothing else,
+ * with no allowlist of its own, so a change here now also moves the
+ * RENDER-TIME boundary — which hrefs the editor will emit as an `href`
+ * attribute at all.
+ *
+ * Consequence: separator-set changes belong in the CALLER, never here. Adding
+ * `\` to the separator list below to make backslash forms path-like would
+ * silently move `sanitizeHrefForPaste` and `sanitizeImageSrcForPaste` too —
+ * exactly the drift this file's header warns about. {@link isSchemelessPathHref}
+ * handles backslash itself, by rejecting it outright.
  */
 function hasSchemePrefix(trimmed: string): boolean {
   const firstColon = trimmed.indexOf(":");
@@ -50,6 +64,62 @@ function hasSchemePrefix(trimmed: string): boolean {
   const seps = ["/", "#", "?"].map((ch) => trimmed.indexOf(ch)).filter((idx) => idx !== -1);
   const firstPathSep = seps.length ? Math.min(...seps) : Number.POSITIVE_INFINITY;
   return firstPathSep >= firstColon;
+}
+
+/**
+ * Characters that make an href unsafe to reason about as a plain string.
+ *
+ * The leading run mirrors DOMPurify's URL-whitespace set, copied verbatim from
+ * `@tiptap/extension-link/dist/index.js:7` — that module strips these before
+ * matching its scheme regex, and browsers strip a subset of them before
+ * parsing. The trailing `\\` is ours: a backslash is not whitespace, but
+ * browsers map it to `/` inside a URL, so it reinterprets structure just as
+ * badly.
+ */
+const URL_HOSTILE_CHARS = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000\\]/;
+
+/**
+ * True when `raw` is a scheme-less path reference — something the editor may
+ * safely emit as an `href` attribute even though it names no protocol.
+ *
+ * This answers the RENDER-TIME question ("may this href be emitted at all"),
+ * which is a different question from {@link isSafeExternalHref}'s ("may we
+ * hand this to `window.open`") and from {@link sanitizeHrefForPaste}'s ("may
+ * this survive a markdown paste"). It exists so `@tiptap/extension-link`'s
+ * default URL guard can be WIDENED rather than replaced — see the
+ * `isAllowedUri` union in `editor-extensions.ts` (#1377).
+ *
+ * **Fail-closed by design.** Any character a browser strips or reinterprets is
+ * a rejection, never a normalization. That asymmetry IS the safety argument:
+ * rejecting can only ever return `false`, so this predicate can never widen the
+ * union past Tiptap's `defaultValidate`, whereas a normalizer would have to be
+ * *provably identical* to the browser's own stripping to be safe. Worked
+ * counterexamples, all measured:
+ *   - `java<TAB>script:alert(1)` — browsers strip TAB, so this IS `javascript:`.
+ *   - `/\evil.com/x.md` and `\\evil.com\share\x.md` — `new URL(…)` resolves both
+ *     to `http://evil.com/…`, i.e. CROSS-HOST despite looking path-like.
+ *   - `<NUL>//evil.com` — resolves to `http://evil.com/`, and JS `trim()` does
+ *     NOT strip U+0000. That is precisely why there is no `trim()` here.
+ *
+ * **The `//` exclusion is separate and non-obvious.** `hasSchemePrefix("//x")`
+ * is false (no colon before the first `/`), so protocol-relative hrefs would
+ * otherwise be misclassified as paths — they are EXTERNAL navigations.
+ *
+ * **Why this is safe as an allowlist widener:** with hostile characters already
+ * rejected, a `/`, `#` or `?` before the first `:` means WHATWG scheme parsing
+ * (`ALPHA *(ALPHA / DIGIT / "+" / "-" / ".") ":"`) cannot succeed, so the href
+ * is relative *as far as the URL parser is concerned*. That is NOT the same as
+ * "safe for Tandem's own consumer": clicking such a link runs
+ * `resolveRelativeLink` (`./relative-link.ts`), which is a segment walk rather
+ * than a URL parser. The traversal question is answered there, not here.
+ */
+export function isSchemelessPathHref(raw: string | null | undefined): boolean {
+  if (!raw) return false;
+  // Fail closed: no trimming, no normalizing — see the doc comment above.
+  if (URL_HOSTILE_CHARS.test(raw)) return false;
+  // Protocol-relative is an EXTERNAL navigation, not a path.
+  if (raw.startsWith("//")) return false;
+  return !hasSchemePrefix(raw);
 }
 
 /**

--- a/src/client/editor/utils/url-safety.ts
+++ b/src/client/editor/utils/url-safety.ts
@@ -58,12 +58,13 @@ export function isSafeExternalHref(href: string): boolean {
  * exactly the drift this file's header warns about. {@link isSchemelessPathHref}
  * handles backslash itself, by rejecting it outright.
  */
+const SCHEME_STOP_CHARS = /[/#?]/;
+
 function hasSchemePrefix(trimmed: string): boolean {
   const firstColon = trimmed.indexOf(":");
   if (firstColon === -1) return false;
-  const seps = ["/", "#", "?"].map((ch) => trimmed.indexOf(ch)).filter((idx) => idx !== -1);
-  const firstPathSep = seps.length ? Math.min(...seps) : Number.POSITIVE_INFINITY;
-  return firstPathSep >= firstColon;
+  const firstPathSep = trimmed.search(SCHEME_STOP_CHARS);
+  return firstPathSep === -1 || firstPathSep > firstColon;
 }
 
 /**
@@ -75,6 +76,12 @@ function hasSchemePrefix(trimmed: string): boolean {
  * parsing. The trailing `\\` is ours: a backslash is not whitespace, but
  * browsers map it to `/` inside a URL, so it reinterprets structure just as
  * badly.
+ *
+ * Deliberately NOT applied to {@link sanitizeHrefForPaste} or
+ * {@link sanitizeImageSrcForPaste}. Those answer "may this survive a markdown
+ * paste" and already have an allowlist standing between a hostile string and a
+ * navigation; this set exists for the render-time question, which has no
+ * allowlist of its own and so must fail closed.
  */
 const URL_HOSTILE_CHARS = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000\\]/;
 

--- a/src/client/editor/utils/url-safety.ts
+++ b/src/client/editor/utils/url-safety.ts
@@ -78,10 +78,18 @@ function hasSchemePrefix(trimmed: string): boolean {
  * badly.
  *
  * Deliberately NOT applied to {@link sanitizeHrefForPaste} or
- * {@link sanitizeImageSrcForPaste}. Those answer "may this survive a markdown
- * paste" and already have an allowlist standing between a hostile string and a
- * navigation; this set exists for the render-time question, which has no
- * allowlist of its own and so must fail closed.
+ * {@link sanitizeImageSrcForPaste}, and NOT because those are already covered.
+ * Both end in a bare `if (!hasSchemePrefix(trimmed)) return trimmed` — their
+ * allowlists gate only SCHEME-BEARING strings, so for exactly the class this
+ * set exists to catch they are pass-throughs. Measured: both return
+ * `<NUL>//evil.com/x.png` unchanged.
+ *
+ * For links that is covered downstream — `openHref` re-gates every href through
+ * `isSafeExternalHref` or `resolveRelativeLink`'s fail-closed walk. For IMAGES
+ * there is no equivalent gate: a pasted `src` reaches the DOM as written and
+ * the browser resolves it cross-host. That gap is pre-existing and tracked
+ * separately; it is not something this set's absence here creates, but it is
+ * also not something an allowlist prevents.
  */
 const URL_HOSTILE_CHARS = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000\\]/;
 
@@ -103,10 +111,17 @@ const URL_HOSTILE_CHARS = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u
  * *provably identical* to the browser's own stripping to be safe. Worked
  * counterexamples, all measured:
  *   - `java<TAB>script:alert(1)` — browsers strip TAB, so this IS `javascript:`.
- *   - `/\evil.com/x.md` and `\\evil.com\share\x.md` — `new URL(…)` resolves both
- *     to `http://evil.com/…`, i.e. CROSS-HOST despite looking path-like.
  *   - `<NUL>//evil.com` — resolves to `http://evil.com/`, and JS `trim()` does
  *     NOT strip U+0000. That is precisely why there is no `trim()` here.
+ *
+ * **A caution about reading those rows as protections.** The consumer is
+ * `defaultValidate(url) || isSchemelessPathHref(url)`, so a rejection here only
+ * matters when `defaultValidate` also rejects. It does not for `/\evil.com/x.md`
+ * (leading `/` hits its `[^a-z]` alternative), so that href renders regardless
+ * of what this predicate says — the rejection is real but INERT at the union.
+ * `\\evil.com\share\x.md` is the same story. Both resolve cross-host under
+ * `new URL()`; neither is newly reachable because of this file, and neither is
+ * closed by it.
  *
  * **The `//` exclusion is separate and non-obvious.** `hasSchemePrefix("//x")`
  * is false (no colon before the first `/`), so protocol-relative hrefs would

--- a/src/server/annotations/rename-recovery.ts
+++ b/src/server/annotations/rename-recovery.ts
@@ -40,7 +40,7 @@ import type * as Y from "yjs";
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../shared/constants.js";
 import { withInternal } from "../../shared/origins.js";
 import { isUploadPath } from "../../shared/paths.js";
-import { rejectUnsafeWindowsPrefix } from "../file-io/windows-path-safety.js";
+import { rejectUnsafeWindowsPrefix } from "../../shared/windows-path-safety.js";
 import { extractText } from "../mcp/document-model.js";
 import { contentHash, ENVELOPE_FILENAME_RE } from "./doc-hash.js";
 import { type AnnotationDocV1, parseAnnotationDoc, SCHEMA_VERSION } from "./schema.js";

--- a/src/server/integrations/node-binary.ts
+++ b/src/server/integrations/node-binary.ts
@@ -42,7 +42,7 @@
 import { statSync } from "node:fs";
 import { posix as posixPath, resolve, win32 as win32Path } from "node:path";
 import { isValidNodeBinary } from "../../shared/integrations/node-binary-name.js";
-import { rejectUnsafeWindowsPrefix } from "../file-io/windows-path-safety.js";
+import { rejectUnsafeWindowsPrefix } from "../../shared/windows-path-safety.js";
 
 /** The pre-existing behaviour, and the fallback whenever an absolute path
  *  cannot be produced or would not validate. Never emit something the

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -28,11 +28,11 @@ import {
   generateNotificationId,
   generateReplyId,
 } from "../../shared/utils.js";
+import { rejectUnsafeWindowsPrefix } from "../../shared/windows-path-safety.js";
 import { relaySanitizationEvent } from "../annotations/migration-log.js";
 import { nextRev, REPLY_TEXT_MAX } from "../annotations/schema.js";
 import { exportAnnotations } from "../file-io/docx.js";
 import { atomicWrite } from "../file-io/index.js";
-import { rejectUnsafeWindowsPrefix } from "../file-io/windows-path-safety.js";
 import { hideFromAI, readModeState } from "../mode.js";
 import { pushNotification } from "../notifications.js";
 import { anchoredRange } from "../positions.js";

--- a/src/server/mcp/convert.ts
+++ b/src/server/mcp/convert.ts
@@ -1,8 +1,8 @@
 import fs from "fs/promises";
 import path from "path";
+import { rejectUnsafeWindowsPrefix } from "../../shared/windows-path-safety.js";
 import { snapshotBeforeFirstWrite } from "../file-io/doc-backup.js";
 import { atomicWrite } from "../file-io/index.js";
-import { rejectUnsafeWindowsPrefix } from "../file-io/windows-path-safety.js";
 import { resolveAppDataDir } from "../platform.js";
 import { getOrCreateDocument } from "../yjs/provider.js";
 import { extractMarkdown } from "./document-model.js";

--- a/src/server/mcp/document-service.ts
+++ b/src/server/mcp/document-service.ts
@@ -18,6 +18,7 @@ import {
 import { withFileSync, withInternal, withMcp } from "../../shared/origins.js";
 import type { ExternalConflictState, FidelityReport } from "../../shared/types.js";
 import { generateNotificationId } from "../../shared/utils.js";
+import { rejectUnsafeWindowsPrefix } from "../../shared/windows-path-safety.js";
 import { docHash } from "../annotations/doc-hash.js";
 import { closeStore, createStore } from "../annotations/store.js";
 import {
@@ -45,7 +46,6 @@ import {
 } from "../file-io/docx-verify.js";
 import { validateRenameFilename } from "../file-io/filename-safety.js";
 import { atomicWrite, atomicWriteBuffer, getAdapter } from "../file-io/index.js";
-import { rejectUnsafeWindowsPrefix } from "../file-io/windows-path-safety.js";
 import { recordSelfWrite, suppressNextChange, unwatchFile } from "../file-watcher.js";
 import { assertPathSafe } from "../integrations/apply.js";
 import { pushNotification } from "../notifications.js";

--- a/src/server/mcp/docx-apply.ts
+++ b/src/server/mcp/docx-apply.ts
@@ -54,11 +54,18 @@ export async function applyChangesCore(
   const safeDocId = documentId !== undefined ? path.basename(documentId) : undefined;
   const resolvedBackupPath = backupPath !== undefined ? path.resolve(backupPath) : undefined;
 
-  // Reject UNC / device-namespace backup paths (Windows NTLM hash leak). Not
-  // gated on `process.platform`: the check is a pure string test, and a path
-  // arriving at a Linux/macOS server can still reach a Windows client.
-  if (resolvedBackupPath !== undefined) {
-    const unsafe = rejectUnsafeWindowsPrefix(resolvedBackupPath);
+  // Reject UNC / device-namespace backup paths (Windows NTLM hash leak).
+  //
+  // RAW **and** resolved, in that order — checking only the resolved form makes
+  // this inert on POSIX, which is the exact platform an ungated check exists to
+  // cover. `path.resolve` is platform-dependent where this guard is not: on
+  // POSIX it treats `\\server\share\x.docx` as a RELATIVE name and prepends
+  // cwd, and it collapses `//evil/share` to `/evil/share` — either way the
+  // prefix the check looks for is gone before the check runs. Same idiom and
+  // same reason as `integrations/node-binary.ts` and `mcp/file-opener.ts`.
+  if (backupPath !== undefined) {
+    const unsafe =
+      rejectUnsafeWindowsPrefix(backupPath) ?? rejectUnsafeWindowsPrefix(path.resolve(backupPath));
     if (unsafe) throw Object.assign(new Error(unsafe), { code: "INVALID_PATH" });
   }
 

--- a/src/server/mcp/docx-apply.ts
+++ b/src/server/mcp/docx-apply.ts
@@ -7,6 +7,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import fs from "fs/promises";
 import path from "path";
 import { z } from "zod";
+import { rejectUnsafeWindowsPrefix } from "../../shared/windows-path-safety.js";
 import { listDocBackups } from "../file-io/doc-backup.js";
 import {
   type AcceptedSuggestion,
@@ -53,15 +54,12 @@ export async function applyChangesCore(
   const safeDocId = documentId !== undefined ? path.basename(documentId) : undefined;
   const resolvedBackupPath = backupPath !== undefined ? path.resolve(backupPath) : undefined;
 
-  // Reject UNC backup paths (Windows NTLM hash leak)
-  if (
-    resolvedBackupPath !== undefined &&
-    process.platform === "win32" &&
-    (resolvedBackupPath.startsWith("\\\\") || resolvedBackupPath.startsWith("//"))
-  ) {
-    throw Object.assign(new Error("UNC paths are not supported for security reasons."), {
-      code: "INVALID_PATH",
-    });
+  // Reject UNC / device-namespace backup paths (Windows NTLM hash leak). Not
+  // gated on `process.platform`: the check is a pure string test, and a path
+  // arriving at a Linux/macOS server can still reach a Windows client.
+  if (resolvedBackupPath !== undefined) {
+    const unsafe = rejectUnsafeWindowsPrefix(resolvedBackupPath);
+    if (unsafe) throw Object.assign(new Error(unsafe), { code: "INVALID_PATH" });
   }
 
   // 1. Resolve document

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -24,6 +24,7 @@ import { withFileSync, withInternal, withReload } from "../../shared/origins.js"
 import { SCRATCHPAD_PREFIX, UPLOAD_PREFIX } from "../../shared/paths.js";
 import type { Annotation, ExternalConflictState, FidelityReport } from "../../shared/types.js";
 import { generateNotificationId } from "../../shared/utils.js";
+import { rejectUnsafeWindowsPrefix } from "../../shared/windows-path-safety.js";
 import { docHash } from "../annotations/doc-hash.js";
 import { relaySanitizationEvent } from "../annotations/migration-log.js";
 import { recoverRenamedEnvelope } from "../annotations/rename-recovery.js";
@@ -40,7 +41,6 @@ import {
   type LoadIssue,
   type Prepared,
 } from "../file-io/index.js";
-import { rejectUnsafeWindowsPrefix } from "../file-io/windows-path-safety.js";
 import { recordSelfWrite, suppressNextChange, watchFile } from "../file-watcher.js";
 import { pushNotification } from "../notifications.js";
 import { resolveAppDataDir } from "../platform.js";

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -40,6 +40,7 @@ import {
   type LoadIssue,
   type Prepared,
 } from "../file-io/index.js";
+import { rejectUnsafeWindowsPrefix } from "../file-io/windows-path-safety.js";
 import { recordSelfWrite, suppressNextChange, watchFile } from "../file-watcher.js";
 import { pushNotification } from "../notifications.js";
 import { resolveAppDataDir } from "../platform.js";
@@ -658,13 +659,34 @@ export async function restoreDocumentFromBackup(
 
 // --- Extracted helpers for openFileByPath ---
 
+/** Throw INVALID_PATH if `p` carries a UNC / extended-length / device prefix. */
+function assertSafePathPrefix(p: string): void {
+  const reason = rejectUnsafeWindowsPrefix(p);
+  if (reason) throw Object.assign(new Error(reason), { code: "INVALID_PATH" });
+}
+
 /**
  * Resolve a raw file path to its canonical form, validate it (UNC check,
  * extension check, size limit), derive format / readOnly / doc ID.
  * stat is used only for the size check and is not returned.
  */
 async function resolveAndValidatePath(filePath: string): Promise<ResolvedPath> {
+  // ORDER IS THE POINT. `realpathSync` on `\\evil.com\share\x.md` OPENS the SMB
+  // connection — and leaks the NTLM hash — before any post-canonicalization
+  // check could reject it, so the UNC gate has to run first, on the raw input
+  // and on `path.resolve`'s output.
+  //
+  // These pre-checks are deliberately NOT gated on `process.platform ===
+  // "win32"`, matching `windows-path-safety.ts`'s own header and the four
+  // existing ungated call sites (convert.ts, document-service.ts,
+  // rename-recovery.ts, node-binary.ts): the path string can reach code that
+  // runs on Windows via shared state. The helper also covers `\\?\UNC\…`, which
+  // the previous inline two-prefix check did not.
+  assertSafePathPrefix(filePath);
+
   let resolved = path.resolve(filePath);
+  assertSafePathPrefix(resolved);
+
   try {
     resolved = fsSync.realpathSync(resolved);
   } catch (err: unknown) {
@@ -677,11 +699,9 @@ async function resolveAndValidatePath(filePath: string): Promise<ResolvedPath> {
     resolved = path.resolve(filePath);
   }
 
-  if (process.platform === "win32" && (resolved.startsWith("\\\\") || resolved.startsWith("//"))) {
-    throw Object.assign(new Error("UNC paths are not supported for security reasons."), {
-      code: "INVALID_PATH",
-    });
-  }
+  // Defense-in-depth, kept deliberately: a Windows junction can canonicalize to
+  // a UNC target that neither pre-check could see.
+  assertSafePathPrefix(resolved);
 
   const ext = path.extname(resolved).toLowerCase();
   if (!SUPPORTED_EXTENSIONS.has(ext)) {

--- a/src/shared/integrations/node-binary-name.ts
+++ b/src/shared/integrations/node-binary-name.ts
@@ -15,21 +15,7 @@
  */
 
 import { crossBasename } from "../cross-basename.js";
-
-/**
- * Reject UNC paths (both backslash and forward-slash variants) to prevent NTLM
- * hash leaks.
- *
- * Deliberately private, and deliberately weaker than
- * `server/file-io/windows-path-safety.ts#rejectUnsafeWindowsPrefix` — which
- * also covers the `\\?\` and `\\.\` device-namespace forms and is what server
- * callers should use. This copy exists only because this module is in
- * `src/shared/` and must not import from `src/server/`; it is the last line of
- * a basename allowlist, not the security boundary.
- */
-function hasUncPrefix(p: string): boolean {
-  return p.startsWith("\\\\") || p.startsWith("//");
-}
+import { rejectUnsafeWindowsPrefix } from "../windows-path-safety.js";
 
 /** `node-sidecar-<triple>` is the desktop app's bundled Node — accepted so the
  *  Tauri build can point the channel shim at its own runtime. */
@@ -39,6 +25,9 @@ const VALID_NODE_BASENAME_RE = /^node(-sidecar(-[a-z0-9_-]+)?)?(\.exe)?$/;
 export function isValidNodeBinary(nodeBinary: string): boolean {
   if (!nodeBinary) return false;
   if (nodeBinary.includes("..")) return false;
-  if (hasUncPrefix(nodeBinary)) return false;
+  // UNC and device-namespace prefixes leak NTLM hashes on Windows. This is the
+  // last line of a basename allowlist, not the security boundary — but it is
+  // the same rule every other caller uses, so it stays the same code.
+  if (rejectUnsafeWindowsPrefix(nodeBinary) !== null) return false;
   return VALID_NODE_BASENAME_RE.test(crossBasename(nodeBinary));
 }

--- a/src/shared/windows-path-safety.ts
+++ b/src/shared/windows-path-safety.ts
@@ -7,12 +7,26 @@
  *
  * **This is the canonical copy of this rule**, and it lives in `src/shared/`
  * rather than with the server's file IO because client, CLI and server all need
- * it while `src/client/` must not import from `src/server/`. A hand-rolled
- * `startsWith("\\\\")` elsewhere is a weaker duplicate: it misses the
- * device-namespace forms below. Four such copies survive at the time of writing
- * (`cli/win-path-guard.ts`, `server/file-io/docx-export.ts`, its spike twin, and
- * `server/launcher/supervisor.ts`) — see #1417, which also covers the ordering
- * defect where a filesystem call runs *before* the check.
+ * it while `src/client/` must not import from `src/server/`.
+ *
+ * **What this function is worth is one definition and a specific message — NOT
+ * a wider verdict.** Every prefix in the first branch also starts with `\\` or
+ * `//`, so as a boolean this is equivalent to a bare
+ * `startsWith("\\\\") || startsWith("//")` on every input. A test that asserts
+ * only "rejected" therefore does not pin the extended-length branch; assert on
+ * the message. Four hand-rolled copies survive, and their gaps differ — do not
+ * assume they are all "the weak one":
+ *
+ *  - `server/file-io/docx-export.ts` and its spike twin — bare `\\` only, so
+ *    they genuinely miss the forward-slash forms.
+ *  - `server/launcher/supervisor.ts` — names `\\?\` and `\\.\` explicitly; its
+ *    gap is `//`, which `path.isAbsolute` accepts on Windows.
+ *  - `cli/win-path-guard.ts` — handles both flavours of extended UNC and is
+ *    deliberately LOOSER on `\\?\C:\…`, which it allows on purpose before
+ *    applying realpath'd containment. It is not a defect; do not "fix" it.
+ *
+ * See #1417, which also covers the ordering defect where a filesystem call runs
+ * *before* the check — a class this string test cannot detect.
  *
  * Rejected forms (all case-insensitive):
  *  - `\\?\…`        — Windows extended-length prefix. `\\?\UNC\server\share`

--- a/src/shared/windows-path-safety.ts
+++ b/src/shared/windows-path-safety.ts
@@ -5,6 +5,15 @@
  * crafted path to a Linux/macOS server (the path string still reaches code
  * that may eventually run on Windows via shared state).
  *
+ * **This is the canonical copy of this rule**, and it lives in `src/shared/`
+ * rather than with the server's file IO because client, CLI and server all need
+ * it while `src/client/` must not import from `src/server/`. A hand-rolled
+ * `startsWith("\\\\")` elsewhere is a weaker duplicate: it misses the
+ * device-namespace forms below. Four such copies survive at the time of writing
+ * (`cli/win-path-guard.ts`, `server/file-io/docx-export.ts`, its spike twin, and
+ * `server/launcher/supervisor.ts`) — see #1417, which also covers the ordering
+ * defect where a filesystem call runs *before* the check.
+ *
  * Rejected forms (all case-insensitive):
  *  - `\\?\…`        — Windows extended-length prefix. `\\?\UNC\server\share`
  *                     is a documented bypass of plain `\\` UNC rejection

--- a/tests/client/link-target-internal.test.ts
+++ b/tests/client/link-target-internal.test.ts
@@ -190,8 +190,24 @@ describe("the premise of #1377 (Tiptap's default guard)", () => {
     "https://example.com",
     "//example.com/x",
     "#frag",
+    // Load-bearing, and asserted only in a comment until now: this is the
+    // traversal `relative-link.ts` calls a PRE-EXISTING hole. It differs from
+    // the `a/…` variant only in its leading segment, and that is exactly why it
+    // survives — a leading `.` hits the guard's `[^a-z]` alternative, while a
+    // leading letter dies in `[a-z0-9+.-]+` on the following `/`. If this row
+    // ever flips, the "pre-existing" framing is wrong and the claim must move.
+    "../../../../..///evil.com/share/x.md",
   ])("already accepted %j before #1377", (href) => {
     expect(tiptapDefaultIsAllowedUri(href, [])).toBeTruthy();
+  });
+
+  it("returns a match array, not a boolean — which is why `!!` is load-bearing", () => {
+    // `shouldAutoLink` is typed boolean, so `editor-extensions.ts` coerces.
+    // A reader who assumes this returns a boolean will "simplify" the `!!`
+    // away; this makes that a red test rather than a silent type lie. It is
+    // also why the rows above use toBeFalsy/toBeTruthy — `toBe(false)` fails.
+    expect(tiptapDefaultIsAllowedUri("notes.md", [])).toBeInstanceOf(Array);
+    expect(tiptapDefaultIsAllowedUri("docs/spec.md", [])).toBeNull();
   });
 });
 

--- a/tests/client/link-target-internal.test.ts
+++ b/tests/client/link-target-internal.test.ts
@@ -24,6 +24,7 @@
  */
 
 import { Editor } from "@tiptap/core";
+import { isAllowedUri as tiptapDefaultIsAllowedUri } from "@tiptap/extension-link";
 import { afterEach, describe, expect, it } from "vitest";
 import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
 
@@ -112,10 +113,11 @@ describe("link target attribute", () => {
     ["../docs/spec.md", "a parent-relative markdown file"],
     ["./subdir/file.txt", "an explicitly-relative nested path"],
     ["/abs/path.md", "a root-relative path"],
-    // #1377: bare paths whose first separator is `/`. Tiptap's default guard
-    // blanked all of these to `href=""` before our renderHTML post-processing
-    // ran, so they rendered as dead links.
     ["notes.md", "a bare sibling file"],
+    // #1377: bare paths carrying a `/`. Tiptap's default guard blanked these to
+    // `href=""` before our renderHTML post-processing ran, so they rendered as
+    // dead links. (`notes.md` above is NOT one of them — it has no separator,
+    // `defaultValidate` always accepted it, and it is here as a control.)
     ["docs/spec.md", "a bare relative path with a subdirectory"],
     ["a/b.md", "a bare two-segment path"],
     ["subdir/file.md#frag", "a bare nested path with a fragment"],
@@ -163,6 +165,33 @@ describe("link target attribute", () => {
     const anchor = renderLink(href);
     expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer");
     expect(anchor?.getAttribute("title")).toBe(href);
+  });
+});
+
+describe("the premise of #1377 (Tiptap's default guard)", () => {
+  // The whole fix rests on `defaultValidate("docs/spec.md")` being FALSE. That
+  // is genuinely surprising, and reading the vendored regex to confirm it gives
+  // the WRONG answer — the pattern is assembled in a template literal, so the
+  // hyphen escape you see is gone before `new RegExp` runs and `.-:` becomes a
+  // range. So assert it against the real dependency instead of re-deriving it:
+  // if a `@tiptap/extension-link` upgrade widens the default, this row flips
+  // and the union above becomes dead weight worth deleting.
+  it.each([
+    "docs/spec.md",
+    "a/b.md",
+    "Docs/spec.md",
+    "example.com/path",
+  ])("rejects %j, which is why the union exists", (href) => {
+    expect(tiptapDefaultIsAllowedUri(href, [])).toBeFalsy();
+  });
+
+  it.each([
+    "notes.md",
+    "https://example.com",
+    "//example.com/x",
+    "#frag",
+  ])("already accepted %j before #1377", (href) => {
+    expect(tiptapDefaultIsAllowedUri(href, [])).toBeTruthy();
   });
 });
 
@@ -224,5 +253,14 @@ describe("autolink pin (shouldAutoLink)", () => {
     const fn = shouldAutoLink as (url: string) => boolean;
     expect(fn("example.com/path")).toBe(false);
     expect(fn("notes.md")).toBe(true);
+  });
+
+  it("leaves `protocols` unconfigured, which is what makes the pin's `[]` correct", () => {
+    // `shouldAutoLink` passes a literal `[]` for the `protocols` argument
+    // because an option literal cannot reach `this.options`. That is only
+    // faithful while no custom protocol is configured — this converts the
+    // comment saying so into a detector.
+    const editor = mountEditor("<p>x</p>");
+    expect(linkOptions(editor).protocols).toEqual([]);
   });
 });

--- a/tests/client/link-target-internal.test.ts
+++ b/tests/client/link-target-internal.test.ts
@@ -1,14 +1,26 @@
 /**
- * `target="_blank"` is stripped from non-external links (#1343).
+ * The link mark's render-time contract, asserted through the PRODUCTION
+ * `buildSchemaExtensions()` so it cannot drift from a hand-built extension.
  *
- * The reported defect: clicking a link to a local `.md` opened it as a Tandem
- * tab AND popped the system browser. `handleEditorClick` preventDefaults every
- * non-fragment anchor and routes it through `openHref`, but WebView2 treats a
- * `_blank` anchor as a new-window request of its own, and no `on_new_window`
- * handler is registered — so it reaches the OS regardless of preventDefault.
+ * Three things live here:
  *
- * Renders through the production `buildSchemaExtensions()`, so this asserts on
- * the markup the real editor emits rather than on a hand-built extension.
+ * 1. `target="_blank"` is stripped from non-external links (#1343). The
+ *    reported defect: clicking a link to a local `.md` opened it as a Tandem
+ *    tab AND popped the system browser. `handleEditorClick` preventDefaults
+ *    every non-fragment anchor and routes it through `openHref`, but WebView2
+ *    treats a `_blank` anchor as a new-window request of its own, and no
+ *    `on_new_window` handler is registered — so it reaches the OS regardless of
+ *    preventDefault.
+ *
+ * 2. Bare relative hrefs with a subdirectory render live (#1377) — `href` AND
+ *    the hover `title` from #996, which the blanked href also suppressed.
+ *
+ * 3. The render-time SCHEME GUARD itself: the configured `isAllowedUri` union,
+ *    exercised through both rendering entry points, plus the `setLink` command
+ *    surface and the `shouldAutoLink` autolink pin. These are the detectors for
+ *    a `@tiptap/extension-link` upgrade that moves `defaultValidate` in either
+ *    direction, and they deliberately read the CONFIGURED options off the real
+ *    schema rather than re-deriving the union.
  */
 
 import { Editor } from "@tiptap/core";
@@ -17,26 +29,29 @@ import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions
 
 let open: { editor: Editor; container: HTMLDivElement } | null = null;
 
-/**
- * Render a link by applying the `link` MARK, not by parsing an `<a>`.
- *
- * This mirrors how links in a `.md` actually arrive: `mdast-ydoc.ts` builds the
- * mark directly from the mdast `link` node. Going through `content: "<a …>"`
- * instead would route via Tiptap's `parseHTML`, whose `isAllowedUri` drops a
- * bare relative href like `subdir/file.txt` outright — so that path renders no
- * anchor at all and an absence-assertion on `target` would pass vacuously.
- * `renderHTML`, which is what this file tests, runs either way.
- */
-function renderLink(href: string): HTMLAnchorElement | null {
+function mountEditor(content: string): Editor {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const editor = new Editor({
     element: container,
     extensions: buildSchemaExtensions(),
-    content: "<p>link text</p>",
+    content,
   });
   open = { editor, container };
+  return editor;
+}
 
+/**
+ * Render a link by applying the `link` MARK, not by parsing an `<a>`.
+ *
+ * This mirrors how links in a `.md` actually arrive: `mdast-ydoc.ts` builds the
+ * mark directly from the mdast `link` node, so this is the entry point that
+ * matters for a document loaded from disk. Since #1377 the `parseHTML` path
+ * accepts the same set, so it is no longer a strictly narrower surface —
+ * `renderLinkFromHtml` below covers it explicitly.
+ */
+function renderLink(href: string): HTMLAnchorElement | null {
+  const editor = mountEditor("<p>link text</p>");
   const { state, view } = editor;
   const linkType = state.schema.marks.link;
   if (!linkType) throw new Error("the link mark is missing from the production schema");
@@ -44,8 +59,46 @@ function renderLink(href: string): HTMLAnchorElement | null {
   const to = state.doc.content.size - 1;
   view.dispatch(state.tr.addMark(from, to, linkType.create({ href })));
 
-  return container.querySelector("a");
+  return open?.container.querySelector("a") ?? null;
 }
+
+/**
+ * Render a link by PARSING an `<a href=…>`, exercising Tiptap's `parseHTML`
+ * getAttrs guard — a second surface the configured `isAllowedUri` governs and
+ * the mark path structurally bypasses.
+ */
+function renderLinkFromHtml(href: string): { anchor: HTMLAnchorElement | null; html: string } {
+  // Escape only what would break out of the attribute — the href itself must
+  // reach the parser byte-for-byte, since the guard is what's under test.
+  const escaped = href.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;");
+  const editor = mountEditor(`<p><a href="${escaped}">link text</a></p>`);
+  return { anchor: open?.container.querySelector("a") ?? null, html: editor.getHTML() };
+}
+
+/** The `link` extension's CONFIGURED options, read off the production schema. */
+function linkOptions(editor: Editor): Record<string, unknown> {
+  const ext = editor.extensionManager.extensions.find((e) => e.name === "link");
+  if (!ext) throw new Error("the link extension is missing from the production schema");
+  return ext.options as Record<string, unknown>;
+}
+
+/**
+ * Schemes that must never survive to a live `href`. `java\tscript:` is the
+ * tab-obfuscated form — browsers strip TAB before parsing, so `new URL` really
+ * does resolve it to a `javascript:` URL.
+ */
+const DISALLOWED_SCHEME_HREFS = [
+  "javascript:alert(1)",
+  "JavaScript:alert(1)",
+  "data:text/html,<script>alert(1)</script>",
+  "vbscript:msgbox",
+  "file:///etc/passwd",
+  "blob:https://example.com/uuid",
+  "filesystem:http://example.com/temporary/x",
+  "java\tscript:alert(1)",
+  "java script:alert(1)",
+  "\tjavascript:alert(1)",
+];
 
 afterEach(() => {
   open?.editor.destroy();
@@ -54,16 +107,21 @@ afterEach(() => {
 });
 
 describe("link target attribute", () => {
-  // NOTE: a bare relative href with a subdirectory (`subdir/file.md`) is
-  // absent from this list on purpose — Tiptap's own `isAllowedUri` blanks it
-  // to `href=""` before our `renderHTML` post-processing runs, so it renders
-  // as a dead link and an assertion here would be about that bug, not this
-  // one. Filed separately; `./sub/file.md` and `/sub/file.md` are unaffected.
   it.each([
     ["./notes.md", "a sibling markdown file"],
     ["../docs/spec.md", "a parent-relative markdown file"],
     ["./subdir/file.txt", "an explicitly-relative nested path"],
     ["/abs/path.md", "a root-relative path"],
+    // #1377: bare paths whose first separator is `/`. Tiptap's default guard
+    // blanked all of these to `href=""` before our renderHTML post-processing
+    // ran, so they rendered as dead links.
+    ["notes.md", "a bare sibling file"],
+    ["docs/spec.md", "a bare relative path with a subdirectory"],
+    ["a/b.md", "a bare two-segment path"],
+    ["subdir/file.md#frag", "a bare nested path with a fragment"],
+    // The vendored regex carries the `i` flag, so its `[^a-z]` branch does not
+    // rescue an uppercase initial — measured `defaultValidate` = false.
+    ["Docs/spec.md", "a bare nested path with a capital initial"],
   ])("does not set target=_blank on %s (%s)", (href) => {
     const anchor = renderLink(href);
     expect(anchor, "no anchor rendered").toBeTruthy();
@@ -75,6 +133,12 @@ describe("link target attribute", () => {
     "https://example.com/page",
     "http://example.com/page",
     "mailto:someone@example.com",
+    // Pins `isSafeExternalHref`'s protocol-relative entry (`//` is in
+    // SAFE_EXTERNAL_PREFIXES) — explicitly NOT the `isSchemelessPathHref` `//`
+    // carve-out, which is unobservable here: `defaultValidate("//…")` is
+    // already true, so the union short-circuits on its first half. That
+    // carve-out's guard is the reject row in url-safety.test.ts.
+    "//example.com/page",
   ])("keeps target=_blank on the external href %s", (href) => {
     // Deliberate, not incidental: the attribute is redundant while the click
     // intercept works, but if the intercept ever fails to run it degrades to
@@ -84,12 +148,81 @@ describe("link target attribute", () => {
     expect(anchor?.getAttribute("target")).toBe("_blank");
   });
 
-  it("still carries rel and the hover title on an internal link", () => {
-    // Positive control on the same sample: proves the anchor really went
-    // through LinkWithHoverTitle's post-processing rather than failing to
-    // render a link at all, which would satisfy the absence-assertions above.
-    const anchor = renderLink("./notes.md");
+  it.each([
+    "./notes.md",
+    "docs/spec.md",
+  ])("still carries rel and the hover title on the internal link %s", (href) => {
+    // Positive control: proves the anchor really went through
+    // LinkWithHoverTitle's post-processing rather than failing to render a
+    // link at all, which would satisfy the absence-assertions above.
+    //
+    // `docs/spec.md` additionally pins the SECOND symptom of #1377 that the
+    // issue body omits: with `href=""` the `attrs.href.length > 0` gate in
+    // editor-extensions.ts also suppressed the tooltip, so a href-only fix
+    // would pass every other assertion in this file.
+    const anchor = renderLink(href);
     expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer");
-    expect(anchor?.getAttribute("title")).toBe("./notes.md");
+    expect(anchor?.getAttribute("title")).toBe(href);
+  });
+});
+
+describe("render-time scheme guard (the configured isAllowedUri)", () => {
+  it.each(DISALLOWED_SCHEME_HREFS)("blanks %j on the mark path", (href) => {
+    const anchor = renderLink(href);
+    expect(anchor, "no anchor rendered").toBeTruthy();
+    expect(anchor?.getAttribute("href")).toBe("");
+    expect(anchor?.hasAttribute("title")).toBe(false);
+    expect(anchor?.hasAttribute("target")).toBe(false);
+  });
+
+  it.each(DISALLOWED_SCHEME_HREFS)("refuses %j on the parseHTML path", (href) => {
+    const { anchor, html } = renderLinkFromHtml(href);
+    // `getAttrs` returning false drops the mark, so the anchor may not render
+    // at all — the correct assertion is the weaker "no anchor, or an anchor
+    // with an empty href".
+    expect(anchor === null || anchor.getAttribute("href") === "").toBe(true);
+    for (const scheme of ["javascript:", "data:", "vbscript:", "file:", "blob:", "filesystem:"]) {
+      expect(html.toLowerCase()).not.toContain(scheme);
+    }
+  });
+
+  it("accepts a bare nested path on the parseHTML path (#1377)", () => {
+    // Pasted HTML `<a href="docs/spec.md">` had the mark dropped outright —
+    // the same bug wearing a different hat.
+    const { anchor } = renderLinkFromHtml("docs/spec.md");
+    expect(anchor?.getAttribute("href")).toBe("docs/spec.md");
+  });
+});
+
+describe("command surface (setLink / the Link editor + context menu)", () => {
+  // `applyLink` (toolbar/handlers.ts) calls `chain.setLink({href})` from the
+  // LinkEditor and the context menu. `tests/client/handlers.test.ts` cannot
+  // cover this: it drives a stub editor whose `setLink` is a bare spy.
+  it("applies a bare nested path (silently no-opped before #1377)", () => {
+    const editor = mountEditor("<p>link text</p>");
+    editor.commands.selectAll();
+    expect(editor.commands.setLink({ href: "docs/spec.md" })).toBe(true);
+  });
+
+  it("refuses a javascript: href", () => {
+    const editor = mountEditor("<p>link text</p>");
+    editor.commands.selectAll();
+    expect(editor.commands.setLink({ href: "javascript:alert(1)" })).toBe(false);
+  });
+});
+
+describe("autolink pin (shouldAutoLink)", () => {
+  // The autolink plugin filters on the RAW TYPED TEXT, not the resolved href,
+  // so widening `isAllowedUri` alone would turn on domain-with-path
+  // autolinking — writing markdown link syntax into the user's file on a
+  // keystroke. `shouldAutoLink` restores the vendored default exactly. Nothing
+  // else in any suite would notice this regression.
+  it("holds autolink at today's behaviour", () => {
+    const editor = mountEditor("<p>x</p>");
+    const shouldAutoLink = linkOptions(editor).shouldAutoLink;
+    expect(typeof shouldAutoLink).toBe("function");
+    const fn = shouldAutoLink as (url: string) => boolean;
+    expect(fn("example.com/path")).toBe(false);
+    expect(fn("notes.md")).toBe(true);
   });
 });

--- a/tests/client/relative-link.test.ts
+++ b/tests/client/relative-link.test.ts
@@ -6,13 +6,36 @@
  * here and nowhere else: that the #1377 shape (`docs/spec.md`) still resolves,
  * and that a crafted `..` chain cannot walk out to a UNC path and be POSTed to
  * `/api/open`.
+ *
+ * The reject rows assert the REASON, not just "refused". Mutation testing found
+ * the two UNC defenses masking each other — deleting either one alone left the
+ * whole suite green, because the survivor still returned a bare `null`. Reasons
+ * make each guard individually killable.
  */
 
 import { describe, expect, it } from "vitest";
-import { resolveRelativeLink } from "../../src/client/editor/utils/relative-link";
+import {
+  type LinkRejectReason,
+  resolveRelativeLink,
+  SECURITY_REJECT_REASONS,
+} from "../../src/client/editor/utils/relative-link";
 
 const WIN = "C:\\Users\\b\\docs\\note.md";
 const POSIX = "/home/u/docs/note.md";
+
+/** Asserts a resolution succeeded and returns the path, for readable rows. */
+function resolved(href: string, cur: string): string {
+  const r = resolveRelativeLink(href, cur);
+  if (!r.ok) throw new Error(`expected ${href} to resolve, got reject "${r.reason}"`);
+  return r.path;
+}
+
+/** Asserts a resolution was refused and returns the reason. */
+function rejected(href: string, cur: string): LinkRejectReason {
+  const r = resolveRelativeLink(href, cur);
+  if (r.ok) throw new Error(`expected ${href} to be refused, got "${r.path}"`);
+  return r.reason;
+}
 
 describe("resolveRelativeLink — happy paths", () => {
   it.each([
@@ -24,23 +47,48 @@ describe("resolveRelativeLink — happy paths", () => {
     ["../spec.md", "C:\\Users\\b\\spec.md", "/home/u/spec.md"],
     // The fragment is stripped before resolution — no cross-file anchors.
     ["subdir/file.md#frag", "C:\\Users\\b\\docs\\subdir\\file.md", "/home/u/docs/subdir/file.md"],
+    // …and so is a query string. Stripping only `#` made the render and click
+    // boundaries disagree: `isSchemelessPathHref` renders this href, but
+    // `TRAILING_EXT_RE` then saw `.md?x=1` and matched nothing.
+    ["docs/spec.md?x=1", "C:\\Users\\b\\docs\\docs\\spec.md", "/home/u/docs/docs/spec.md"],
+    ["spec.md?a=1#frag", "C:\\Users\\b\\docs\\spec.md", "/home/u/docs/spec.md"],
   ])("resolves %s on both separators", (href, win, posix) => {
-    expect(resolveRelativeLink(href, WIN)).toBe(win);
-    expect(resolveRelativeLink(href, POSIX)).toBe(posix);
+    expect(resolved(href, WIN)).toBe(win);
+    expect(resolved(href, POSIX)).toBe(posix);
   });
 
-  it("returns null for a .docx target (not in INTERNAL_LINK_EXTS)", () => {
-    expect(resolveRelativeLink("report.docx", WIN)).toBeNull();
-    expect(resolveRelativeLink("report.docx", POSIX)).toBeNull();
+  it("resolves against the right directory when currentFilePath has MIXED separators", () => {
+    // Kills the `split(PATH_SEP_RE)` → `split(sep)` mutation on the dirParts
+    // side, which the homogeneous fixtures above cannot: with `split("\\")` the
+    // trailing `docs/note.md` stays one segment, `pop()` removes the whole
+    // thing, and the href silently resolves one directory too high.
+    expect(resolved("spec.md", "C:\\Users\\b\\docs/note.md")).toBe("C:\\Users\\b\\docs\\spec.md");
   });
 
-  it("returns null for a pure fragment", () => {
-    expect(resolveRelativeLink("#section", WIN)).toBeNull();
-    expect(resolveRelativeLink("#section", POSIX)).toBeNull();
+  it("treats a backslash inside an href as a separator, not a filename character", () => {
+    // Fail-CLOSED direction. As one opaque segment, `a\..\..\..\x.md` would sail
+    // through the `..` walk and the containment check untouched.
+    expect(rejected("a\\..\\..\\..\\..\\..\\x.md", WIN)).toBe("escapes-root");
+  });
+});
+
+describe("resolveRelativeLink — refusals carry a reason", () => {
+  it.each([
+    ["report.docx", "unsupported-ext", "a .docx target (not in INTERNAL_LINK_EXTS)"],
+    ["paper.pdf", "unsupported-ext", "a non-Tandem format"],
+    ["docs/", "unsupported-ext", "a directory with no extension"],
+    ["#section", "fragment", "a pure fragment"],
+    ["?x=1", "fragment", "a pure query string"],
+  ])("refuses %s with reason %s (%s)", (href, reason) => {
+    expect(rejected(href, WIN)).toBe(reason);
+    expect(rejected(href, POSIX)).toBe(reason);
   });
 
-  it("returns null when currentFilePath has no directory to resolve against", () => {
-    expect(resolveRelativeLink("notes.md", "note.md")).toBeNull();
+  it("refuses with `no-directory` when currentFilePath has no separator", () => {
+    // Kills deletion of the `dirParts.length === 0` guard: without it, `pop()`
+    // leaves an empty array, `dirParts[0]` is undefined, and the containment
+    // check refuses for the wrong reason.
+    expect(rejected("notes.md", "note.md")).toBe("no-directory");
   });
 });
 
@@ -50,33 +98,62 @@ describe("resolveRelativeLink — traversal is fail-closed", () => {
     // the containment check this returns the UNC string
     // `\\evil.com\share\x.md`, which openHref POSTs to /api/open — Tandem's
     // named NTLM-hash-leak vector.
-    expect(resolveRelativeLink("a/../../../../..///evil.com/share/x.md", WIN)).toBeNull();
+    expect(rejected("a/../../../../..///evil.com/share/x.md", WIN)).toBe("escapes-root");
   });
 
   it("rejects the PRE-EXISTING variant reachable on master", () => {
     // Tiptap's default URL guard ALLOWS this href today (it starts with `.`,
     // not a letter), so this row fails on master — the hole predates #1377.
-    expect(resolveRelativeLink("../../../../..///evil.com/share/x.md", WIN)).toBeNull();
+    expect(rejected("../../../../..///evil.com/share/x.md", WIN)).toBe("escapes-root");
   });
 
-  it("rejects a traversal escaping above the POSIX root", () => {
-    expect(resolveRelativeLink("../../../../../../etc/passwd.md", POSIX)).toBeNull();
+  it("catches the SAME href on POSIX via the joined-UNC guard, not containment", () => {
+    // The two guards are not redundant; they fire on different platforms. Here
+    // containment PASSES (`resultParts[0]` and `dirParts[0]` are both `""`) and
+    // only the post-join check refuses. Deleting it leaves a live POSIX hole
+    // that the Windows rows above would not notice.
+    expect(rejected("a/../../../../..///evil.com/share/x.md", POSIX)).toBe("joined-unc");
+  });
+
+  it("rejects a containment escape that is NOT UNC-shaped", () => {
+    // The converse pin: containment alone must catch this, since the joined
+    // result is an ordinary path the UNC check would wave through.
+    expect(rejected("../../../../../../etc/passwd.md", POSIX)).toBe("escapes-root");
+    expect(rejected("../../../../../../Windows/x.md", WIN)).toBe("escapes-root");
   });
 
   it("rejects a protocol-relative href", () => {
     // Never reaches here in practice — openHref routes `//` to
     // isSafeExternalHref first — but pinned so the function is correct
     // standalone.
-    expect(resolveRelativeLink("//evil.com/x.md", WIN)).toBeNull();
-    expect(resolveRelativeLink("//evil.com/x.md", POSIX)).toBeNull();
+    expect(rejected("//evil.com/x.md", WIN)).toBe("unsafe-prefix");
+    expect(rejected("//evil.com/x.md", POSIX)).toBe("unsafe-prefix");
+  });
+
+  it("rejects device-namespace hrefs, which DO reach here", () => {
+    // Unlike `//`, these are not pre-routed by openHref, so this guard changes
+    // their outcome from a collapsed same-machine path to a refusal.
+    expect(rejected("\\\\?\\C:\\x.md", WIN)).toBe("unsafe-prefix");
+    expect(rejected("\\\\evil.com\\share\\x.md", WIN)).toBe("unsafe-prefix");
   });
 
   it("does NOT over-reject a backslash form that still resolves same-machine", () => {
     // Non-regression: `/\evil.com/x.md` is allowed by Tiptap's guard today and
     // resolves to a same-machine path that `path.resolve` collapses. The
-    // containment check must not turn it into a null.
-    expect(resolveRelativeLink("/\\evil.com/x.md", WIN)).toBe(
-      "C:\\Users\\b\\docs\\\\\\evil.com\\x.md",
-    );
+    // containment check must not turn it into a refusal.
+    expect(resolved("/\\evil.com/x.md", WIN)).toBe("C:\\Users\\b\\docs\\\\\\evil.com\\x.md");
+  });
+});
+
+describe("SECURITY_REJECT_REASONS", () => {
+  it("separates hostile hrefs from mistakes", () => {
+    // `Editor.svelte` escalates this set to an error-severity notification
+    // rather than a warning. A reason added to the union without a decision
+    // here would silently default to the mistake treatment.
+    expect([...SECURITY_REJECT_REASONS].sort()).toEqual([
+      "escapes-root",
+      "joined-unc",
+      "unsafe-prefix",
+    ]);
   });
 });

--- a/tests/client/relative-link.test.ts
+++ b/tests/client/relative-link.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `resolveRelativeLink` — the segment walk behind clicking a relative link.
+ *
+ * Extracted from `Editor.svelte` (where it was module-private and untestable)
+ * so its fail-closed traversal guards can be pinned. Two things are asserted
+ * here and nowhere else: that the #1377 shape (`docs/spec.md`) still resolves,
+ * and that a crafted `..` chain cannot walk out to a UNC path and be POSTed to
+ * `/api/open`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveRelativeLink } from "../../src/client/editor/utils/relative-link";
+
+const WIN = "C:\\Users\\b\\docs\\note.md";
+const POSIX = "/home/u/docs/note.md";
+
+describe("resolveRelativeLink — happy paths", () => {
+  it.each([
+    ["notes.md", "C:\\Users\\b\\docs\\notes.md", "/home/u/docs/notes.md"],
+    // The #1377 shape: a BARE nested path. The whole point of widening the
+    // render-time guard is that this href now reaches a click at all.
+    ["docs/spec.md", "C:\\Users\\b\\docs\\docs\\spec.md", "/home/u/docs/docs/spec.md"],
+    ["./notes.md", "C:\\Users\\b\\docs\\notes.md", "/home/u/docs/notes.md"],
+    ["../spec.md", "C:\\Users\\b\\spec.md", "/home/u/spec.md"],
+    // The fragment is stripped before resolution — no cross-file anchors.
+    ["subdir/file.md#frag", "C:\\Users\\b\\docs\\subdir\\file.md", "/home/u/docs/subdir/file.md"],
+  ])("resolves %s on both separators", (href, win, posix) => {
+    expect(resolveRelativeLink(href, WIN)).toBe(win);
+    expect(resolveRelativeLink(href, POSIX)).toBe(posix);
+  });
+
+  it("returns null for a .docx target (not in INTERNAL_LINK_EXTS)", () => {
+    expect(resolveRelativeLink("report.docx", WIN)).toBeNull();
+    expect(resolveRelativeLink("report.docx", POSIX)).toBeNull();
+  });
+
+  it("returns null for a pure fragment", () => {
+    expect(resolveRelativeLink("#section", WIN)).toBeNull();
+    expect(resolveRelativeLink("#section", POSIX)).toBeNull();
+  });
+
+  it("returns null when currentFilePath has no directory to resolve against", () => {
+    expect(resolveRelativeLink("notes.md", "note.md")).toBeNull();
+  });
+});
+
+describe("resolveRelativeLink — traversal is fail-closed", () => {
+  it("rejects a `..` chain that walks out to a UNC path", () => {
+    // Newly reachable through the widened render-time guard (#1377): without
+    // the containment check this returns the UNC string
+    // `\\evil.com\share\x.md`, which openHref POSTs to /api/open — Tandem's
+    // named NTLM-hash-leak vector.
+    expect(resolveRelativeLink("a/../../../../..///evil.com/share/x.md", WIN)).toBeNull();
+  });
+
+  it("rejects the PRE-EXISTING variant reachable on master", () => {
+    // Tiptap's default URL guard ALLOWS this href today (it starts with `.`,
+    // not a letter), so this row fails on master — the hole predates #1377.
+    expect(resolveRelativeLink("../../../../..///evil.com/share/x.md", WIN)).toBeNull();
+  });
+
+  it("rejects a traversal escaping above the POSIX root", () => {
+    expect(resolveRelativeLink("../../../../../../etc/passwd.md", POSIX)).toBeNull();
+  });
+
+  it("rejects a protocol-relative href", () => {
+    // Never reaches here in practice — openHref routes `//` to
+    // isSafeExternalHref first — but pinned so the function is correct
+    // standalone.
+    expect(resolveRelativeLink("//evil.com/x.md", WIN)).toBeNull();
+    expect(resolveRelativeLink("//evil.com/x.md", POSIX)).toBeNull();
+  });
+
+  it("does NOT over-reject a backslash form that still resolves same-machine", () => {
+    // Non-regression: `/\evil.com/x.md` is allowed by Tiptap's guard today and
+    // resolves to a same-machine path that `path.resolve` collapses. The
+    // containment check must not turn it into a null.
+    expect(resolveRelativeLink("/\\evil.com/x.md", WIN)).toBe(
+      "C:\\Users\\b\\docs\\\\\\evil.com\\x.md",
+    );
+  });
+});

--- a/tests/client/url-safety.test.ts
+++ b/tests/client/url-safety.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
   isSafeExternalHref,
+  isSchemelessPathHref,
   SAFE_EXTERNAL_PREFIXES,
   SAFE_IMAGE_PREFIXES,
   sanitizeHrefForPaste,
   sanitizeImageSrcForPaste,
 } from "../../src/client/editor/utils/url-safety";
+
+/**
+ * Control / exotic-whitespace characters are built rather than written as
+ * literals so the source file stays free of raw control bytes.
+ */
+const ch = (code: number) => String.fromCharCode(code);
+const NUL = ch(0x00);
+const US = ch(0x1f); // U+001F, inside the DOMPurify range
+const MONGOLIAN_VOWEL_SEP = ch(0x180e);
 
 describe("SAFE_EXTERNAL_PREFIXES", () => {
   it("matches the documented allowlist exactly", () => {
@@ -96,6 +106,104 @@ describe("sanitizeHrefForPaste", () => {
 
   it("rejects a bare leading colon", () => {
     expect(sanitizeHrefForPaste(":alert(1)")).toBeNull();
+  });
+
+  it("is unchanged for a backslash-bearing href", () => {
+    // Pins the OTHER consumer of `hasSchemePrefix` against the drift this
+    // file's header warns about: `isSchemelessPathHref` rejects backslash in
+    // the CALLER, so an edit that moved backslash handling into the shared
+    // helper would red two suites rather than one.
+    expect(sanitizeHrefForPaste("a\\b.md")).toBe("a\\b.md");
+  });
+});
+
+describe("isSchemelessPathHref", () => {
+  it.each([
+    "docs/spec.md",
+    "a/b.md",
+    "subdir/file.md#frag",
+    "Docs/spec.md",
+    "notes.md",
+    "./other.md",
+    "../up/file.md",
+    "/abs/path.md",
+    "#section",
+    "docs?x=1",
+    "my%20docs/spec.md",
+    // Looks alarming, is not: the colon FOLLOWS a `/`, so WHATWG scheme
+    // parsing cannot fire. Verified — it resolves to
+    // `http://…/java/script:alert(1)`. Do not "fix" this row.
+    "java/script:alert(1)",
+  ])("accepts the scheme-less path reference %s", (href) => {
+    expect(isSchemelessPathHref(href)).toBe(true);
+  });
+
+  it("accepts a bare domain-with-path", () => {
+    // Accepted deliberately. This is the shape that reaches the linkify
+    // markPasteRule, which cannot be narrowed by option — pasting the plain
+    // text now creates `http://example.com/path`. Justified because bare
+    // `example.com` already linkifies today; NOT reachable via autolink,
+    // which `shouldAutoLink` pins to the vendored default.
+    expect(isSchemelessPathHref("example.com/path")).toBe(true);
+  });
+
+  it("rejects protocol-relative hrefs", () => {
+    // THIS is the assertion guarding the `//` carve-out. Nothing in
+    // link-target-internal.test.ts can: Tiptap's `defaultValidate("//evil.com")`
+    // is already true, so the union short-circuits and the predicate's verdict
+    // is unobservable there.
+    expect(isSchemelessPathHref("//example.com/x")).toBe(false);
+  });
+
+  it.each([
+    "/\\evil.com/x.md",
+    "\\/evil.com/x.md",
+    "\\\\evil.com\\share\\x.md",
+    "a/\\/evil.com/x.md",
+    "a\\b.md",
+  ])("rejects the backslash form %s", (href) => {
+    // The first three resolve CROSS-HOST — `new URL(…)` gives
+    // `http://evil.com/…` — despite looking path-like. The last is benign but
+    // rejected anyway, because the predicate is fail-closed on backslash
+    // rather than normalizing; the union keeps it live via `defaultValidate`.
+    expect(isSchemelessPathHref(href)).toBe(false);
+  });
+
+  it.each([
+    [`${NUL}//evil.com`, "NUL"],
+    [`${US}//evil.com`, "U+001F"],
+    [`${MONGOLIAN_VOWEL_SEP}//evil.com`, "U+180E"],
+    ["\t//evil.com", "TAB"],
+    [`${NUL}a/`, "NUL before a path"],
+    [" a/", "leading space"],
+  ])("rejects the control/exotic-whitespace form (%s)", (href) => {
+    // JS `trim()` does NOT strip U+0000, U+001F or U+180E, while the WHATWG
+    // parser and DOMPurify do — measured, `new URL("<NUL>//evil.com", …)` is
+    // `http://evil.com/`. That mismatch is exactly why this predicate REJECTS
+    // rather than trims.
+    expect(isSchemelessPathHref(href)).toBe(false);
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "JavaScript:alert(1)",
+    "data:text/html,x",
+    "vbscript:msgbox",
+    "file:///etc/passwd",
+    "blob:https://example.com/uuid",
+    "filesystem:http://example.com/temporary/x",
+    "view-source:https://example.com",
+  ])("rejects unsafe scheme %s", (href) => {
+    expect(isSchemelessPathHref(href)).toBe(false);
+  });
+
+  it.each([":alert(1)", "", "   "])("rejects the degenerate input %j", (href) => {
+    expect(isSchemelessPathHref(href)).toBe(false);
+  });
+
+  it("rejects null and undefined", () => {
+    expect(isSchemelessPathHref(null)).toBe(false);
+    expect(isSchemelessPathHref(undefined)).toBe(false);
   });
 });
 

--- a/tests/e2e/fixtures/link-source-nested.md
+++ b/tests/e2e/fixtures/link-source-nested.md
@@ -1,0 +1,5 @@
+# Nested Link Source
+
+This document links into a subdirectory with a bare relative path.
+
+[Open the nested target](subdir/link-target.md)

--- a/tests/e2e/fixtures/link-unopenable.md
+++ b/tests/e2e/fixtures/link-unopenable.md
@@ -1,0 +1,7 @@
+# Unopenable Link
+
+Tandem renders this href live — `defaultValidate("report.docx")` is true, since
+it carries no `/` and no `:` — but `.docx` is not in `INTERNAL_LINK_EXTS`, so
+the click boundary refuses it. That gap is the point of the test.
+
+See [the quarterly report](report.docx) for details.

--- a/tests/e2e/relative-links.spec.ts
+++ b/tests/e2e/relative-links.spec.ts
@@ -159,3 +159,53 @@ test("a disallowed-scheme link renders inert — no live href, no title (#996 se
     cleanupFixtureDir(xssDir);
   }
 });
+
+test("a link that renders live but cannot be opened SAYS so (#1377 render/click gap)", async ({
+  page,
+}) => {
+  // #1377 widened the RENDER boundary without widening the click boundary, so
+  // an href can be live — pointer cursor, tooltip naming a destination — and
+  // still be refused on click. Before this test the refusal was a
+  // `console.warn`, which is not a channel in the primary distribution: the
+  // Tauri release build ships no `devtools` feature, and `diagnostics.ts` has
+  // no console ring buffer, so it reached neither the user nor a bug report.
+  //
+  // `report.docx` is the shape that will actually bite: .docx is first-class
+  // in drag-drop, the file dialog and `tandem_open`, but excluded from
+  // INTERNAL_LINK_EXTS (see #1421).
+  const dir = createFixtureDir("link-unopenable.md");
+  try {
+    await mcp.callTool("tandem_open", { filePath: path.join(dir, "link-unopenable.md") });
+
+    await page.goto("/");
+    const editor = page.locator(".tandem-editor");
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+    await expect(editor).toContainText("Unopenable Link");
+
+    // Precondition: the link really did render live. If this ever fails the
+    // test is passing vacuously — there would be no gap left to report.
+    const link = editor.locator("a", { hasText: "the quarterly report" });
+    await expect(link).toBeVisible({ timeout: 5_000 });
+    await expect(link).toHaveAttribute("href", "report.docx");
+    await expect(link).toHaveAttribute("title", "report.docx");
+
+    await link.click();
+
+    // The refusal reaches the activity tray, which persists to localStorage and
+    // therefore survives into a bug report — unlike a console warn.
+    const pill = page.getByTestId("activity-pill");
+    await expect(pill).toBeVisible({ timeout: 10_000 });
+    await pill.click();
+
+    const tray = page.getByTestId("activity-tray");
+    await expect(tray).toBeVisible({ timeout: 5_000 });
+    await expect(tray).toContainText("report.docx");
+
+    // And it did NOT open a tab.
+    await expect(
+      page.locator("[data-testid^='tab-name-']", { hasText: "report.docx" }),
+    ).toHaveCount(0);
+  } finally {
+    cleanupFixtureDir(dir);
+  }
+});

--- a/tests/e2e/relative-links.spec.ts
+++ b/tests/e2e/relative-links.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import fs from "fs";
 import path from "path";
 import {
   cleanupAllOpenDocuments,
@@ -51,6 +52,60 @@ test("clicking a relative .md link opens the target file as a new tab", async ({
   await expect(sourceTabName).toBeVisible();
 });
 
+test("clicking a bare nested relative .md link opens the target as a new tab (#1377)", async ({
+  page,
+}) => {
+  // Only the SOURCE is a fixture; the nested target is written inline so
+  // `createFixtureDir` (38 call sites across 35 specs) stays untouched.
+  const nestedDir = createFixtureDir("link-source-nested.md");
+  try {
+    fs.mkdirSync(path.join(nestedDir, "subdir"), { recursive: true });
+    // DISTINCT content, not a copy of link-target.md: identical fixture content
+    // across tests is what triggers the rename-recovery envelope collision that
+    // `cleanupFixtureDir`'s own comment warns about.
+    fs.writeFileSync(
+      path.join(nestedDir, "subdir", "link-target.md"),
+      "# Nested Link Target\n\nReached through a bare nested relative link.\n",
+    );
+    // NOTE: `cleanupFixtureDir`'s envelope sweep is NON-recursive, so it would
+    // not clean an envelope for `subdir/link-target.md`. Harmless here because
+    // this test creates no annotations — anyone adding an annotation-creating
+    // nested test must fix the sweep first.
+
+    await mcp.callTool("tandem_open", {
+      filePath: path.join(nestedDir, "link-source-nested.md"),
+    });
+
+    await page.goto("/");
+    const editor = page.locator(".tandem-editor");
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+    await expect(editor).toContainText("Nested Link Source");
+
+    const link = editor.locator("a", { hasText: "Open the nested target" });
+    await expect(link).toBeVisible({ timeout: 5_000 });
+
+    // The regression assertions: both were empty/absent before #1377 — the
+    // base guard blanked the href, and the blanked href also suppressed the
+    // #996 tooltip.
+    await expect(link).toHaveAttribute("href", "subdir/link-target.md");
+    await expect(link).toHaveAttribute("title", "subdir/link-target.md");
+
+    await link.click();
+
+    const targetTabName = page.locator("[data-testid^='tab-name-']", {
+      hasText: "link-target.md",
+    });
+    await expect(targetTabName).toBeVisible({ timeout: 10_000 });
+
+    const sourceTabName = page.locator("[data-testid^='tab-name-']", {
+      hasText: "link-source-nested.md",
+    });
+    await expect(sourceTabName).toBeVisible();
+  } finally {
+    cleanupFixtureDir(nestedDir);
+  }
+});
+
 test("an editor link shows a pointer cursor and a title tooltip with its destination (#996)", async ({
   page,
 }) => {
@@ -77,8 +132,12 @@ test("a disallowed-scheme link renders inert — no live href, no title (#996 se
 }) => {
   // mdast→Y.Doc stores link URLs verbatim (no scheme check), so a .md authored
   // with a javascript: href reaches the editor. The renderHTML override must
-  // delegate to the base extension's isAllowedUri guard (which blanks the href)
-  // and must NOT mirror the disallowed scheme into a title tooltip.
+  // delegate to the base extension's blanking branch, which runs against the
+  // CONFIGURED `isAllowedUri` (`ctx.defaultValidate(url) ||
+  // isSchemelessPathHref(url)`, #1377). A `javascript:` href satisfies neither
+  // half: the scheme fails `defaultValidate`, and its colon precedes any `/`,
+  // `#` or `?`, so `hasSchemePrefix` sees a scheme. The override must also NOT
+  // mirror the disallowed scheme into a title tooltip.
   const xssDir = createFixtureDir("link-xss.md");
   try {
     await mcp.callTool("tandem_open", { filePath: path.join(xssDir, "link-xss.md") });

--- a/tests/server/docx-apply.test.ts
+++ b/tests/server/docx-apply.test.ts
@@ -785,21 +785,23 @@ describe("applyChangesCore — UNC backupPath rejection", () => {
     setActiveDocId(DOC_ID);
   });
 
-  it("rejects a UNC backupPath starting with \\\\", async () => {
-    // Only meaningful on win32; on other platforms path.resolve won't produce
-    // a UNC path, so the check is a no-op — skip on non-Windows.
-    if (process.platform !== "win32") return;
-
-    await expect(
-      applyChangesCore(DOC_ID, "Test Author", "\\\\attacker.com\\share\\backup.docx"),
-    ).rejects.toMatchObject({ code: "INVALID_PATH", message: /UNC paths are not supported/ });
-  });
-
-  it("rejects a UNC backupPath starting with //", async () => {
-    if (process.platform !== "win32") return;
-
-    await expect(
-      applyChangesCore(DOC_ID, "Test Author", "//attacker.com/share/backup.docx"),
-    ).rejects.toMatchObject({ code: "INVALID_PATH", message: /UNC paths are not supported/ });
+  // These used to early-return on non-Windows, which made them assertion-free
+  // no-ops on Ubuntu CI — the only place they actually run. They pass now
+  // because the guard checks the RAW `backupPath` before `path.resolve`;
+  // checking only the resolved form is inert on POSIX, where `path.resolve`
+  // destroys every prefix the check looks for (`//evil/share` → `/evil/share`,
+  // and `\\evil\share` → `<cwd>/\\evil\share`).
+  it.each([
+    ["\\\\attacker.com\\share\\backup.docx", "backslash UNC", /UNC paths are not supported/],
+    ["//attacker.com/share/backup.docx", "forward-slash UNC", /UNC paths are not supported/],
+    // Message, not just verdict: as a boolean this is indistinguishable from
+    // the bare-UNC rows above.
+    ["\\\\?\\UNC\\attacker.com\\share\\b.docx", "extended UNC", /Extended-length/],
+    ["\\\\.\\pipe\\backup.docx", "device namespace", /Extended-length/],
+  ])("rejects a %s backupPath (%s) on every platform", async (badPath, _label, message) => {
+    await expect(applyChangesCore(DOC_ID, "Test Author", badPath)).rejects.toMatchObject({
+      code: "INVALID_PATH",
+      message,
+    });
   });
 });

--- a/tests/server/file-opener-edge-cases.test.ts
+++ b/tests/server/file-opener-edge-cases.test.ts
@@ -1,7 +1,8 @@
+import fsSync from "fs";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   addDoc,
   getOpenDocs,
@@ -367,5 +368,34 @@ describe("handleOpen — readOnly propagation", () => {
     const data = (capturedBody as { data: { readOnly: boolean; alreadyOpen: boolean } }).data;
     expect(data.alreadyOpen).toBe(true);
     expect(data.readOnly).toBe(true);
+  });
+});
+
+describe("openFileByPath — UNC paths are rejected BEFORE canonicalization", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["\\\\evil.com\\share\\x.md", "a bare UNC path"],
+    // The extended-UNC bypass the previous inline two-prefix check did not
+    // cover — `path.resolve` does not normalise `\\?\UNC\…` back to `\\…`.
+    ["\\\\?\\UNC\\evil.com\\share\\x.md", "an extended-UNC path"],
+  ])("rejects %s (%s) without calling realpathSync", async (badPath) => {
+    const spy = vi.spyOn(fsSync, "realpathSync");
+
+    try {
+      await openFileByPath(badPath);
+      expect.unreachable("should have thrown");
+    } catch (err: unknown) {
+      expect((err as NodeJS.ErrnoException).code).toBe("INVALID_PATH");
+    }
+
+    // THE POINT OF THIS TEST. `realpathSync` on a UNC path opens the SMB
+    // connection — and leaks the NTLM hash — so a result-only assertion would
+    // still pass with the check back in its old position after
+    // canonicalization. The pre-check is cross-platform (no `win32` gate,
+    // matching windows-path-safety.ts's own header), so this runs on Linux CI.
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/tests/server/file-opener-edge-cases.test.ts
+++ b/tests/server/file-opener-edge-cases.test.ts
@@ -377,18 +377,28 @@ describe("openFileByPath — UNC paths are rejected BEFORE canonicalization", ()
   });
 
   it.each([
-    ["\\\\evil.com\\share\\x.md", "a bare UNC path"],
-    // The extended-UNC bypass the previous inline two-prefix check did not
-    // cover — `path.resolve` does not normalise `\\?\UNC\…` back to `\\…`.
-    ["\\\\?\\UNC\\evil.com\\share\\x.md", "an extended-UNC path"],
-  ])("rejects %s (%s) without calling realpathSync", async (badPath) => {
-    const spy = vi.spyOn(fsSync, "realpathSync");
+    ["\\\\evil.com\\share\\x.md", "a bare UNC path", /UNC paths/],
+    // Extended UNC. The MESSAGE is the assertion that matters: as a verdict
+    // this is indistinguishable from the bare case (every device-namespace
+    // prefix also starts with `\\`), so asserting only INVALID_PATH would pin
+    // nothing about the extended-length branch.
+    ["\\\\?\\UNC\\evil.com\\share\\x.md", "an extended-UNC path", /Extended-length/],
+  ])("rejects %s (%s) without calling realpathSync", async (badPath, _label, expectedMessage) => {
+    // NOT a pass-through spy. Under a regression the real `realpathSync` runs
+    // against `\\evil.com\share\x.md` — i.e. the test performs the very NTLM
+    // leak it exists to prevent, from the developer's machine, and blocks for
+    // an SMB timeout (measured: 21s) before failing. Throwing turns that into
+    // an instant, local failure.
+    const spy = vi.spyOn(fsSync, "realpathSync").mockImplementation(() => {
+      throw new Error("realpathSync must not be called on an unvalidated path");
+    });
 
     try {
       await openFileByPath(badPath);
       expect.unreachable("should have thrown");
     } catch (err: unknown) {
       expect((err as NodeJS.ErrnoException).code).toBe("INVALID_PATH");
+      expect((err as Error).message).toMatch(expectedMessage);
     }
 
     // THE POINT OF THIS TEST. `realpathSync` on a UNC path opens the SMB

--- a/tests/server/mdast-ydoc.test.ts
+++ b/tests/server/mdast-ydoc.test.ts
@@ -372,6 +372,21 @@ describe("mdastToYDoc — inline marks", () => {
     expect(delta[0].attributes?.link).toEqual({ href: "https://example.com", title: "Example" });
   });
 
+  it("link with a bare nested relative href round-trips verbatim (#1377)", () => {
+    // Closes the issue's explicit open question. The client-side blanking is
+    // RENDER-only: neither mdastToYDoc nor yDocToMdast reads rendered DOM, so
+    // the on-disk href was never at risk.
+    doc = new Y.Doc();
+    loadMarkdown(doc, "[spec](docs/spec.md)\n");
+
+    const paragraph = getFragment(doc).get(0) as Y.XmlElement;
+    const delta = (paragraph.get(0) as Y.XmlText).toDelta();
+    expect(delta[0].insert).toBe("spec");
+    expect(delta[0].attributes?.link).toEqual({ href: "docs/spec.md" });
+
+    expect(saveMarkdown(doc)).toContain("[spec](docs/spec.md)");
+  });
+
   it("overlapping marks: bold-italic", () => {
     const xmlText = loadParagraphWithInline([
       {

--- a/tests/shared/windows-path-safety.test.ts
+++ b/tests/shared/windows-path-safety.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { rejectUnsafeWindowsPrefix } from "../../src/server/file-io/windows-path-safety.js";
+import { rejectUnsafeWindowsPrefix } from "../../src/shared/windows-path-safety.js";
 
 describe("rejectUnsafeWindowsPrefix", () => {
   // Bare UNC.


### PR DESCRIPTION
## The bug

`[spec](docs/spec.md)` — the relative-link form most repos use — rendered as `href=""` with no hover tooltip. `@tiptap/extension-link`'s default URL guard rejects it.

That guard's regex is genuinely surprising, and **reading it gives the wrong answer**: the pattern is assembled inside a template literal, so `\-` collapses to a bare `-` before `new RegExp` ever sees it, and the final character class is `[^a-z+.-:]` — in which `.-:` is a *range* (U+002E–U+003A) swallowing `.`, `/`, the digits and `:`. Written literally with an escaped hyphen it would be a plain set, and `docs/spec.md` would be allowed. So the premise is pinned executably against the real dependency rather than re-derived in a comment:

```ts
expect(tiptapDefaultIsAllowedUri("docs/spec.md", [])).toBeFalsy();
```

If a Tiptap upgrade widens the default, that row flips and this PR's union becomes dead weight worth deleting.

## The fix

A **strictly additive union**, additive because `||` can only widen — not because of which operand runs first:

```ts
isAllowedUri: (url, ctx) => ctx.defaultValidate(url) || isSchemelessPathHref(url),
```

Tiptap's DOMPurify-derived scheme allowlist stays the authority on schemes. `isSchemelessPathHref` (new, in `url-safety.ts`) adds hrefs that have no URL-hostile character, no backslash, no leading `//`, and either no colon or a `/`/`#`/`?` before the first one.

**Fail-closed by design.** Every hostile input is a rejection, never a normalization. That asymmetry is the safety argument: rejecting can only return `false`, so the predicate can never widen past `defaultValidate`, whereas a normalizer would have to be *provably identical* to the browser's own stripping.

An adversarial pass characterized the delta rather than sampling it, which is a stronger result than a list of tried inputs:

> The default rejects exactly one shape: a letter-initial string whose first character outside `[A-Za-z0-9+.-]` is `/` or `:`. The `:` branch is rejected by `isSchemelessPathHref` too. So the union adds precisely `[A-Za-z][A-Za-z0-9+.-]*` followed by `/` and a hostile-char-free, backslash-free remainder. **Every member of that set begins with an ASCII letter.** In WHATWG parsing against a base, a letter-initial input cannot reach relative-slash state, so it can never acquire an authority — cross-origin is structurally unreachable, not merely unobserved.

Confirmed over a 52-case corpus: 11 newly-allowed strings, **0 cross-origin**. Percent-encoded separators (nothing downstream decodes — the server hands the value straight to `path.resolve`), Unicode confusables for `/` and `:` (IDNA never engages without an authority), bidi/format controls outside the hostile set, and `?`/`#` placement games all resolve same-origin.

**What is not claimed:** that a newly-allowed href "can only be a relative URL". That is true of `new URL()` and false of Tandem's actual consumer. `resolveRelativeLink` is a segment walk, and the traversal question is answered there.

### Autolink is pinned, and only one option can do it

The autolink plugin filters on the **raw typed text**, not the resolved href. Measured with the real linkifyjs, `find("example.com/path")` yields `{value: "example.com/path", href: "http://example.com/path"}` while `defaultValidate("example.com/path")` is false — so widening `isAllowedUri` alone would make typing `example.com/path ` auto-create a link, writing markdown link syntax into the user's file on a keystroke, entirely outside #1377.

Substituting the vendored default **URI guard** into `shouldAutoLink` pins that gate: autolink's effective filter is `validate && shouldAutoLink`, so widened-validate AND default-guard re-composes to exactly the default. (Note it is *not* the vendored `shouldAutoLink` default, which is `url => !!url`.)

### Accepted deliberately

The linkify **markPasteRule** reads `isAllowedUri` directly and cannot be narrowed by option, so pasting the plain text `example.com/path` now linkifies. Justified: bare `example.com` already did.

## `resolveRelativeLink` was module-private with zero coverage

It moved to `editor/utils/relative-link.ts` and grew fail-closed traversal guards. The bug those close is invisible from the function body:

With `currentFilePath = C:\Users\blokn\docs\note.md`, the href `a/../../../../..///evil.com/share/x.md` walks the result down to empty; the two empty segments produced by `///` then become two *leading* empties, and `join("\\")` yields `\\evil.com\share\x.md` — a UNC path, which `openHref` POSTs to `/api/open`. That is Tandem's named NTLM-hash-leak vector. **The variant without the leading `a/` is allowed by Tiptap's default guard today** — now asserted executably rather than in prose — so this closes a pre-existing hole as well as one that widening the guard would otherwise open.

**The two UNC guards are not redundant; they fail on different platforms.** For that same href, Windows is caught by containment (`resultParts[0]` is `""`, not `"C:"`) while POSIX containment *passes* (both are `""`) and only the post-join check refuses. Mutation testing found them masking each other — deleting either alone left the suite green — so each now has a test that dies when it alone is removed.

---

## Second commit: the `/simplify` pass

Four review lenses converged on one finding — `relative-link.ts` hand-rolled a UNC predicate the repo already owns a canonical version of. The blocker was **location**: it lived under `src/server/file-io/`, and `src/client/` must not import from `src/server/`. That same constraint is why `src/shared/integrations/node-binary-name.ts` carried a third copy, documented in-tree as *"deliberately weaker"*.

So the helper moves to `src/shared/windows-path-safety.ts` — pure string logic, no server dependency — and four sites route through it: `relative-link.ts` ×2, `node-binary-name.ts` (its private `hasUncPrefix` deleted), and `docx-apply.ts`.

> **Correction to an earlier draft of this description.** I wrote that those copies "missed `\\?\`, `\\.\`, `//?/`, `//./`". That is **false**, and four reviewers said so independently: every device-namespace prefix also starts with `\\` or `//`, so as a *boolean* the canonical helper is equivalent to the two-line check on every input — only the message differs. What the consolidation actually buys is one definition instead of four, plus a message that distinguishes extended-length from bare UNC. The one behavioural change is `docx-apply.ts` losing a `process.platform === "win32"` gate that was wrong for a pure string test. Corollary: a test asserting only "rejected" does not pin the extended-length branch, which is why the `file-opener` and `docx-apply` rows now assert the **message**.

Four weaker copies survive elsewhere, and three places run a filesystem call *before* the guard that would reject the path — on Windows that is the SMB handshake. Sharpest is `uninstall-scrub.ts:179`, where `fs.stat` follows a junction that `assertSafeWorkspacePath`'s very next line would reject. Filed as **#1417** with the inventory and a proposed static-walk detector.

Also from the lenses: mixed-separator paths resolved against the wrong directory; a dead disjunct removed from the containment check; `hasSchemePrefix` no longer allocates per call; the `isAllowedUri` comment block shrank ~60%, with the regex re-derivation and ten `dist/index.js:NNN` citations replaced by executable assertions (those citations rot silently against a `^2.27.2` caret range); and a test row labelled "#1377 fixed this" that measurement showed was never broken.

**Declined:** swapping the `isAllowedUri` operand order for 2.6× (749 → 290 ns/link). ~0.14 ms on a 300-link document, and it costs the security comment its shape.

---

## Third commit: review findings

Five agents. Four independently found the same defect; three refuted a claim I had written.

### Defects

**`docx-apply.ts` checked only the resolved path.** `path.resolve` destroys the prefixes the guard looks for on POSIX (`//evil/share` → `/evil/share`; `\\evil\share` gets cwd prepended), so the ungated check was inert on exactly the platform ungating exists to cover. Now checks raw **and** resolved — the idiom was already written twice in this same PR (`node-binary.ts`, `file-opener.ts`) and this was the one site that didn't adopt it.

**`?` was not stripped, only `#`** — so this PR's own render and click boundaries disagreed. `isSchemelessPathHref` renders `docs/spec.md?x=1`; `TRAILING_EXT_RE` then saw `.md?x=1`, matched nothing, and refused it.

**`console.warn` is not a channel in the primary distribution.** The Tauri release build ships no `devtools` feature, so there is no inspector to open, and `diagnostics.ts` has no console ring buffer, so it never reaches a bug report either. The warn added in commit 2 was therefore not the observability fix it claimed to be. `openHref` now routes through a threaded `onNotify` prop — threaded rather than calling `createNotifications()` in the leaf, which opens a fresh `EventSource` per call and would duplicate the SSE subscription and the tray.

**Six reject reasons, one signal.** `resolveRelativeLink` returned a bare `null` whether the href was a mistyped `.pdf` or a blocked traversal. It now returns a discriminated union, and `SECURITY_REJECT_REASONS` escalates the three hostile reasons to an error-severity notification. MCP tools write markdown into these documents, so a crafted link is in-model for this app.

### Inert claims, all mine, all corrected

- **`windows-path-safety.ts`** called the surviving copies "weaker duplicates". Their gaps actually *differ*, and `cli/win-path-guard.ts` is not one of them — it handles both flavours of extended UNC and is deliberately looser on `\\?\C:\…` before applying realpath'd containment. The header now says so, so nobody "fixes" a correct guard.
- **`url-safety.ts`** justified not applying `URL_HOSTILE_CHARS` to the paste path by saying those already have an allowlist. They don't — both end in a bare `if (!hasSchemePrefix(trimmed)) return trimmed`, a pass-through for exactly the class the set exists to catch. Links are covered downstream by `openHref`; images are not, which is a pre-existing gap now stated rather than papered over.
- **The `/\evil.com/x.md` counterexample is inert at the union.** `defaultValidate` accepts it (leading `/` hits its `[^a-z]` branch), so `||` short-circuits and the href renders regardless of what the predicate says.

### Tests

Every mutation below was applied, run, and reverted:

| Mutation | Killed by |
|---|---|
| joined-UNC guard deleted | the POSIX row, alone (1 test) |
| containment deleted | 4 tests, incl. the non-UNC converse |
| `split(PATH_SEP_RE)` → `split(sep)` on dirParts | the mixed-separator row, alone |
| `dirParts.length === 0` guard deleted | the `no-directory` reason row |

Two test-quality defects also fixed:

- **`docx-apply`'s UNC tests early-returned on non-Windows**, making them assertion-free no-ops on Ubuntu CI — the only place they run.
- **`file-opener-edge-cases` spied on `realpathSync` as a pass-through**, so a regression made the test perform the NTLM leak it exists to prevent, from the developer's machine, blocking ~21 s on an SMB timeout before failing.

## Verification

- `npm run typecheck` — 1322 files, 0 errors
- `npm test -- --run` — **457 files, 6646 passed**, 19 skipped
- `npx playwright test tests/e2e/relative-links.spec.ts` — **4 passed**

Closes #1377
Refs #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYGFawL9kQruDZiUkYGBKD
