### PR TITLE
chore(deps): clear 2 of 5 dependabot alerts in the tauri-driver harness

### DIFF
--- a/tests/tauri-driver/README.md
+++ b/tests/tauri-driver/README.md
@@ -133,3 +133,35 @@ xvfb-run npm test
 - `specs/prevent-default.e2e.ts` — the reload-interception assertions.
 - `package.json` / `tsconfig.json` — standalone toolchain (kept out of the root
   install so the WebdriverIO dependency tree is opt-in).
+
+## Dependency advisories
+
+**`serialize-javascript` is pinned via `overrides`, and that is not tidiness.**
+It arrives at `@wdio/mocha-framework` → `mocha` → `serialize-javascript`, and
+**every** published `mocha` (through 11.8.0) declares `^6.0.2` — which cannot
+reach the 7.0.5 that patches GHSA-5c6j-r48x-rmvq (RCE) and GHSA-qj8w-gfj5-8c6v
+(CPU-exhaustion DoS). Only the unreleased `mocha@12` RC widens it to `^7`, and
+`@wdio/mocha-framework` pins `mocha@^10.3.0` regardless. So there is no version
+bump that fixes this and `npm audit fix` is a no-op; the `overrides` entry is the
+only route short of `--force`, which downgrades the harness to
+`@wdio/mocha-framework@7`. v7 is API-compatible with mocha's single call site
+(`BufferedWorkerPool.serializeOptions`, `{unsafe, ignoreFunction}`) and drops the
+`randombytes` dependency. Remove the override once `@wdio/mocha-framework` ships
+a `mocha` that carries `serialize-javascript@^7`.
+
+**`extract-zip` is knowingly accepted, not overlooked.** GHSA-jmr9-qjv8-65gv
+(symlink path traversal on extract) has **no patched release** — 2.0.1 is the
+last publish, from 2020. It enters at `@wdio/cli` → `@wdio/utils` →
+`@puppeteer/browsers@2` → `extract-zip`, and is used only by
+`@puppeteer/browsers`' `unpackArchive`, i.e. unpacking a browser/driver archive
+that WebdriverIO downloaded itself. **This harness never takes that path**: it
+sets `host`/`port` to the `tauri-driver` proxy on 127.0.0.1:4444, so
+`@wdio/utils`' `startWebDriver` short-circuits on `definesRemoteDriver()`
+("Connecting to existing driver at …") and never imports the `./node.js` module
+where `@puppeteer/browsers` lives. Nothing here extracts an archive at all,
+attacker-influenced or otherwise, and `tests/` is excluded from the published
+npm package. `@puppeteer/browsers@3` did drop `extract-zip` (native
+`unzip`/`tar.exe`/PowerShell plus an optional `yauzl` path), but `@wdio/utils`
+still pins `^2.2.0`, and forcing the major across it would be an unverifiable
+override on a code path this harness provably never runs. Revisit alongside
+#1345 — if that review retires this workflow, the dependency leaves with it.

--- a/tests/tauri-driver/package-lock.json
+++ b/tests/tauri-driver/package-lock.json
@@ -5208,16 +5208,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react-is-18": {
       "name": "react-is",
       "version": "18.3.1",
@@ -5626,13 +5616,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {

--- a/tests/tauri-driver/package.json
+++ b/tests/tauri-driver/package.json
@@ -16,5 +16,8 @@
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "webdriverio": "^9.4.0"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
   }
 }


### PR DESCRIPTION
Clears two of the five open Dependabot alerts. Both live in `tests/tauri-driver/` — a standalone, `"private": true` WebdriverIO harness with its own `package.json` and lockfile, isolated from the repo root.

| Advisory | Severity | Status |
|---|---|---|
| GHSA-5c6j-r48x-rmvq — `serialize-javascript` RCE via `RegExp.flags` / `Date.prototype.toISOString` | HIGH | **Fixed** |
| GHSA-qj8w-gfj5-8c6v — `serialize-javascript` CPU-exhaustion DoS | MODERATE | **Fixed** |
| GHSA-jmr9-qjv8-65gv — `extract-zip` symlink path traversal | HIGH | **Accepted** — see below |

## Why an override, when npm's own tooling says otherwise

`serialize-javascript` is transitive at depth 3: `@wdio/mocha-framework` → `mocha@10.8.2` → `serialize-javascript`. Every cleaner route was tried and measured, not assumed:

- **`npm audit fix`** resolves nothing and churns 509 unrelated lockfile lines.
- **`npm audit fix --force`** proposes `@wdio/mocha-framework@7.7.3` / `@wdio/cli@8.14.6` — a **two-major downgrade of the whole harness**.
- **Bumping the parent does not exist.** Every published `mocha` through 11.8.0 declares `serialize-javascript: ^6.0.2` — all 20 releases of the 11.x line checked individually. Only the unreleased `mocha@12.0.0-rc.6` widens it to `^7.0.2`, and `@wdio/mocha-framework@9.30.1` pins `mocha@^10.3.0` anyway, so the RC is unreachable without a second, larger override.

So the `overrides` entry is the only route that isn't a downgrade. It resolves to **7.1.0**.

**Compatibility verified by running it, not by reading changelogs.** Mocha's sole call site is `BufferedWorkerPool.serializeOptions` with `{unsafe: true, ignoreFunction: true}`; v7 keeps the same CJS `module.exports = function serialize(obj, options)` and honours both options. Round-tripped against the installed package:

```
serialize-javascript version: 7.1.0
serializeOptions -> {"ui":"bdd","timeout":60000,"spec":["./specs/**/*.e2e.ts"],"reporter":"spec"}
ignoreFunction honored (fn absent): true
unsafe:true passthrough: {"a":"<b>"}
```

One thing to know: **v7 adds `engines: {node: ">=20.0.0"}`.** CI is node 22, so this is fine, but it is a new floor.

`npm audit` goes from `14 vulnerabilities (1 moderate, 13 high)` to `12 high` — and the remaining 12 are **one** advisory plus its 11-package transitive fan-out.

## Why `extract-zip` is accepted rather than patched

2.0.1 is the latest release. There is no fix and none coming.

**It is also unreachable here, verified at runtime rather than by reading.** `extract-zip` is called from exactly one place — `@puppeteer/browsers`' `unpackArchive` — which unpacks a browser or driver archive that WebdriverIO downloaded *for itself*. This harness never manages a driver: `wdio.conf.ts` points at an already-running `tauri-driver` proxy on `127.0.0.1:4444`, so `@wdio/utils`' `startWebDriver` short-circuits on `definesRemoteDriver(options)` and returns **before** dynamically importing the module where the `@puppeteer/browsers` import lives.

A real run confirms it:

```
[0-0] INFO @wdio/utils: Connecting to existing driver at http://localhost:4444/
```

with **zero** occurrences of `download`, `puppeteer`, `Setting up`, or `browserName` in the full log. Nothing in this harness extracts an archive at all — not an attacker-influenced one, not a pinned one. The `msedgedriver.exe` it does use comes from `PATH`, unpacked by the CI workflow's own PowerShell step.

Blast radius is correspondingly small: `tests/` is not in the root `package.json` `files` array, so nothing here ships. The only CI wiring is `.github/workflows/tauri-webdriver.yml`, which has been **`workflow_dispatch`-only since 2026-08-08** (#1197). The root `test:tauri-driver` script is called by nothing — not `npm test`, not `test:e2e`, not `pre-push`.

**The fix that exists is worse than the advisory.** `@puppeteer/browsers@3.x` drops `extract-zip` entirely (its whole dependency set is `{yargs, modern-tar}`), and all seven symbols `@wdio/utils` imports still exist in 3.2.0. But reaching it needs a second override forcing a *major* across `@wdio/utils`' `^2.2.0` pin; v3 is ESM-only where v2 shipped CJS; engines rise to `node >= 22.12.0`; and while the export *names* survived, the *signatures* can only be exercised by the download path this harness provably never runs. An untestable override against an unreachable advisory, on a currently-disabled workflow, buys a green audit number and adds a real way for the harness to break.

**Rationale is recorded in `tests/tauri-driver/README.md`**, because a JSON `overrides` block cannot carry a comment and an unexplained one is exactly what a later cleanup deletes. It points at **#1345** — the workflow's existing dated 2026-11-01 review gate, which already permits only restore / replace / retire — rather than opening a competing gate, per the #1308 convention. If that workflow retires, `extract-zip` leaves the repo with it.

**Recommended follow-up:** dismiss the `extract-zip` Dependabot alert as *"vulnerable code is not actually used"*. Left open it becomes standing noise that trains the next reader to skim the list — which is the failure mode that lets a real alert through.

## Verification

```
$ npm ls serialize-javascript extract-zip
+-- @wdio/cli@9.28.0
| `-- @wdio/utils@9.28.0
|   `-- @puppeteer/browsers@2.13.2
|     `-- extract-zip@2.0.1
`-- @wdio/mocha-framework@9.28.0
  `-- mocha@10.8.2
    `-- serialize-javascript@7.1.0
```

`npm ls` and `npm ls --all` both exit 0 (remaining `UNMET` lines are optional deps, all pre-existing). `npm ci` succeeds, installs 7.1.0, and leaves the lockfile byte-identical.

**Not claimed: that the specs pass.** Running them needs `tauri-driver` (`cargo install tauri-driver --locked`) plus a matching `msedgedriver.exe`, neither installed on this machine. The harness was run anyway and fails at exactly that prerequisite and nothing else — wdio launched, forked a worker, loaded `@wdio/mocha-framework`, compiled and collected `specs/prevent-default.e2e.ts`, and reached session creation before erroring on the missing binary. That exercises the changed code path (mocha's worker serialization) without asserting on the specs themselves.

One pre-existing, unrelated `tsc` error remains: `wdio.conf.ts(152,3): TS2353: 'host' does not exist in type 'Config'` — a `@wdio/types` mismatch on an unchanged package; that file is deliberately outside `npm run typecheck`.

## npm quirk worth flagging

npm 11 did **not** write an `overrides` key into the lockfile root. `npm ci` still installs 7.1.0 because lockfileVersion 3 pins the resolved version explicitly, and CI uses `npm install` (which reads `package.json` directly) — so both paths are covered, but npm won't cross-validate the two. A future hand-edit of the override would not be caught by `npm ci`.

Refs #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYGFawL9kQruDZiUkYGBKD
