### PR TITLE
chore(deps): clear the last 2 dependabot alerts (postcss)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7797,6 +7797,35 @@
         "node": ">=18"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
       "dev": true,
@@ -9446,35 +9475,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vite/node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
       "esbuild": "^0.28.1"
     },
     "ws": "^8.21.0",
-    "@hono/node-server": "^2.0.12"
+    "@hono/node-server": "^2.0.12",
+    "postcss": "^8.5.23"
   },
   "dependencies": {
     "@hocuspocus/provider": "3.4.4",


### PR DESCRIPTION
Clears the last two open Dependabot alerts. With #1419 merged, this takes the repo to **0 open advisories**.

| Advisory | Severity | Fix |
|---|---|---|
| GHSA-r28c-9q8g-f849 — path traversal in previous-source-map auto-loading (`sourceMappingURL`) → arbitrary `.map` disclosure | HIGH | 8.5.18 |
| GHSA-fxqj-rqcc-2cmp — incomplete fix of the same; reads arbitrary `.map` files when `from` is unset | MODERATE | 8.5.23 |

`npm audit`: **found 0 vulnerabilities.**

## Why an override, when npm's own remediation doesn't work

postcss arrives **nested** under vite — `vite/node_modules/postcss@8.5.15` — rather than hoisted. With no top-level entry, `npm update postcss` and `npm audit fix` both target the *hoisted* position, create a redundant copy there, and never rewrite vite's nested one. Verified against throwaway lockfile copies rather than assumed:

| Command | Result |
|---|---|
| `npm update postcss` | Adds hoisted 8.5.26, leaves nested 8.5.15. **Still 1 high.** |
| `npm audit fix --package-lock-only` | Identical no-op. |
| `overrides.postcss` + `npm install` | Nested entry collapses. **0 vulnerabilities.** |

`vite@8.0.16` declares `postcss: ^8.5.15`, so semver permits a plain lockfile refresh — npm simply will not perform one. The repo already uses this pattern for `tsup`, `ws` and `@hono/node-server`.

Lockfile diff is **58 lines touching only the two postcss entries**: hoisted 8.5.26 added, `vite/node_modules/postcss@8.5.15` removed. Nothing else moves.

## Practical risk was near-zero — this is hygiene

Worth stating plainly, since it explains why this cluster was scheduled last rather than rushed:

1. **Vite always passes `from: source`**, and GHSA-fxqj-rqcc-2cmp explicitly requires `from` to be **unset**. Its stated precondition is not met.
2. **Input is first-party.** Only `src/client/**` and vendored dependency CSS reach postcss. Tandem's untrusted inputs — `.md`, `.docx`, `.html`, uploads — never touch the CSS pipeline.
3. **Dev-only, build-time only.** The lockfile marks postcss `"dev": true`; it never ships in `dist/`, the npm package, or the Tauri bundle.
4. **The disclosure sink is closed.** `build.sourcemap` is unset in `vite.config.ts` and vite passes `annotation: false`, so there is no emitted sourcemap for a leaked `.map` to land in.

## The `css-pipeline-contract` fear was misplaced

CLAUDE.md flags that `tests/design-system-impl/css-pipeline-contract.test.ts` hand-transcribes vite's internal target table, and that fragility is why #1402 was scheduled last and alone. It doesn't apply here.

That suite imports `transform` from **lightningcss** and `resolveConfig` from **vite**. postcss appears nowhere in it — and `grep -ri postcss` across the entire repo, excluding the lockfile, returns **no matches at all**: no `postcss.config.js`, no `css.postcss` key, no import in `src/`. Every assertion routes through `lightningcss.transform()` directly, bypassing vite's plugin pipeline. The hand-transcribed map is a *vite* coupling, not a postcss one.

Where postcss actually sits: vite's default `css.transformer` runs it over component `<style>` blocks and `src/client/**/*.css` during `vite build`, for URL rewriting and `@import`/`@charset` handling. lightningcss then does minification only. `index.html`'s inline `<style>` never sees postcss at all.

## It also corrects a pre-existing node_modules drift

This is the larger part of the *"114 added, 33 removed, 14 changed"* install output, and almost none of it is postcss — it is npm reconciling a drifted tree back to the **already-committed** lockfile:

- **eslint was 9.39.5 on disk** against **10.8.1** in both `package.json` and the lockfile (`npm ls` flagged it `invalid`).
- `eslint-plugin-react-hooks@5.2.0` was installed and **extraneous** — in neither file.

That is a correction, not a regression, but `npm run lint` runs at `ci.yml:87`, so it was verified separately under the corrected version rather than bundled into the postcss claim: **0 errors** across `src/`, `tests/` and `scripts/`. The 231 warnings are pre-existing `no-explicit-any` in tests, unchanged. (A local `npm run lint` also reports 1 error in `.remember/tmp/last-ndc.ts`, a gitignored scratch file that does not exist in a CI checkout.)

## Verification

- `npm run typecheck` — 1323 files, **0 errors**
- `npm test -- --run` — **457 files, 6646 passed**, 19 skipped
- `npm run build` — **succeeds.** This is the meaningful one: postcss runs during `vite build`, so a break here would be loud.
- `npx vitest run tests/design-system-impl/` — 6 files, **60 tests**
- `npx playwright test tests/e2e/token-contrast.spec.ts tests/e2e/forced-colors.spec.ts` — **9 passed**
- `npm ls postcss` — single hoisted 8.5.26, deduped, no nested entry

## npm quirk worth knowing

`npm install` left the lockfile byte-stable after the `--package-lock-only` pass — the 58-line diff is the whole change, and re-running produced nothing further.

Closes #1402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYGFawL9kQruDZiUkYGBKD
