### PR TITLE
fix(ui): align the rail resize strip with the rail it belongs to

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,10 +261,7 @@
            deliberately tucked under it — which is why any offset expressed as
            "52px + something" is wrong for clearing in-flow chrome below the
            titlebar. Rails use rail-top-clearance as margin-top inside the
-           editor row, so they track the editor content automatically — and so
-           does the rail drag strip (`.rail-resize-handle` in App.svelte), which
-           shares that margin with `.rail-shell` from a single rule so the two
-           flex siblings start on the same line (#1396). */
+           editor row, so they track the editor content automatically. */
         /* Bottom edge of the in-flow top-of-shell banner stack (server-restart
            strip, updater, connection, license) in viewport coordinates,
            measured at runtime by the `bannerStackHeight` action in App.svelte
@@ -304,14 +301,8 @@
         /* Bottom inset that any "hugs-content" rail (outline) reserves
            below itself so the floating status pill (W5) renders into
            clear space. Sum of pill chrome (status-clearance) + a comfy
-           24px margin.
-
-           Two consumers, both in App.svelte's orbit: PanelSlot's outline
-           `padding-bottom` (PanelSlot.svelte), and the shared
-           `.rail-shell, .rail-resize-handle` margin-bottom rule in App.svelte
-           that keeps a rail and its drag strip ending on the same line (#1396).
-           Note the value rides --tandem-space-5, so it computes to 52/60/68px
-           across compact/cozy/spacious — never hardcode it at a call site. */
+           24px margin. The value rides --tandem-space-5, so it is
+           density-dependent — never hardcode it at a call site. */
         --tandem-status-clearance-total: calc(var(--tandem-status-clearance) + var(--tandem-space-5, 24px));
         /* Light-mode floating-pill stack (matches v7 calm-v7.css). Warm/dark
            override --c7-pill-shadow inside their own theme blocks. */

--- a/index.html
+++ b/index.html
@@ -261,7 +261,10 @@
            deliberately tucked under it — which is why any offset expressed as
            "52px + something" is wrong for clearing in-flow chrome below the
            titlebar. Rails use rail-top-clearance as margin-top inside the
-           editor row, so they track the editor content automatically. */
+           editor row, so they track the editor content automatically — and so
+           does the rail drag strip (`.rail-resize-handle` in App.svelte), which
+           shares that margin with `.rail-shell` from a single rule so the two
+           flex siblings start on the same line (#1396). */
         /* Bottom edge of the in-flow top-of-shell banner stack (server-restart
            strip, updater, connection, license) in viewport coordinates,
            measured at runtime by the `bannerStackHeight` action in App.svelte
@@ -301,7 +304,14 @@
         /* Bottom inset that any "hugs-content" rail (outline) reserves
            below itself so the floating status pill (W5) renders into
            clear space. Sum of pill chrome (status-clearance) + a comfy
-           24px margin. Consumed by PanelSlot's outline branch in W6. */
+           24px margin.
+
+           Two consumers, both in App.svelte's orbit: PanelSlot's outline
+           `padding-bottom` (PanelSlot.svelte), and the shared
+           `.rail-shell, .rail-resize-handle` margin-bottom rule in App.svelte
+           that keeps a rail and its drag strip ending on the same line (#1396).
+           Note the value rides --tandem-space-5, so it computes to 52/60/68px
+           across compact/cozy/spacious — never hardcode it at a call site. */
         --tandem-status-clearance-total: calc(var(--tandem-status-clearance) + var(--tandem-space-5, 24px));
         /* Light-mode floating-pill stack (matches v7 calm-v7.css). Warm/dark
            override --c7-pill-shadow inside their own theme blocks. */

--- a/index.html
+++ b/index.html
@@ -298,11 +298,12 @@
         --tandem-fmtbar-top: max(52px, var(--tandem-banner-stack-bottom, 0px));
         --tandem-rail-top-clearance: 52px;
         --tandem-status-clearance: 36px;
-        /* Bottom inset that any "hugs-content" rail (outline) reserves
-           below itself so the floating status pill (W5) renders into
-           clear space. Sum of pill chrome (status-clearance) + a comfy
-           24px margin. The value rides --tandem-space-5, so it is
-           density-dependent — never hardcode it at a call site. */
+        /* Bottom inset reserved by anything in the editor row that must clear
+           the floating status pill (W5). Sum of pill chrome (status-clearance)
+           + a comfy 24px margin. The value rides --tandem-space-5, so it is
+           density-dependent — never restate it at a call site. The literal
+           `var()` fallbacks consumers carry are a degraded cozy-only floor for
+           the token-undefined case, not a copy of the value. */
         --tandem-status-clearance-total: calc(var(--tandem-status-clearance) + var(--tandem-space-5, 24px));
         /* Light-mode floating-pill stack (matches v7 calm-v7.css). Warm/dark
            override --c7-pill-shadow inside their own theme blocks. */

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -2892,6 +2892,7 @@ const shouldShowModelPicker = $derived(
 {#snippet resizeHandle(side: "left" | "right", onmousedown: (e: MouseEvent) => void, testId?: string, widthPx?: number)}
   <div
     data-testid={testId ?? `${side}-panel-resize-handle`}
+    class="rail-resize-handle"
     role="slider"
     aria-orientation="horizontal"
     aria-label={side === "left" ? "Resize left panel" : "Resize right panel"}
@@ -2921,13 +2922,6 @@ const shouldShowModelPicker = $derived(
     }}
     onkeyup={() => {
       // Width is already persisted inside handleResizeStep on each keyboard step.
-    }}
-    style="width: 4px; cursor: col-resize; background: transparent; flex-shrink: 0; transition: background 0.15s; position: relative; z-index: var(--tandem-z-base);"
-    onmouseenter={(e) => {
-      (e.currentTarget as HTMLDivElement).style.background = "var(--tandem-border-strong)";
-    }}
-    onmouseleave={(e) => {
-      (e.currentTarget as HTMLDivElement).style.background = "transparent";
     }}
   ></div>
 {/snippet}
@@ -3264,6 +3258,25 @@ const shouldShowModelPicker = $derived(
     flex-shrink: 0;
   }
 
+  /* #1396: the editor row's vertical clearance, declared ONCE for the rail
+     shell AND for the drag strip that sits beside it. Both are flex items of
+     the same `align-items: stretch` row, and under `stretch` an item's margins
+     inset its stretched cross size — so while only the shell carried these two
+     margins, the 4px strip stretched the FULL row height and its hover tint
+     painted 52px above and 52-68px below the rail it resizes.
+
+     One rule, two consumers, deliberately: the bottom inset is
+     density-dependent (`--tandem-status-clearance-total` rides
+     `--tandem-space-5`, so 52/60/68px across compact/cozy/spacious), so a
+     hardcoded copy on the strip would desync at two densities out of three,
+     and any second declaration desyncs the moment either token moves. A third
+     consumer may join this selector list; it must never get its own copy.
+     Pinned by tests/design-system-impl/rail-clearance-contract.test.ts. */
+  .rail-shell,
+  .rail-resize-handle {
+    margin-top: var(--tandem-rail-top-clearance, 0);
+    margin-bottom: var(--tandem-status-clearance-total, 60px);
+  }
   /* Always-mounted dual-layer rail. The shell owns width + chrome (bg, inner
      radius, side shadow) + the hover-grow; its two children (`.rail-full` via
      the data-testid divs in markup, and `.rail-peek` via PeekStrip) are
@@ -3271,13 +3284,11 @@ const shouldShowModelPicker = $derived(
      is set inline (`width: <dragWidth>px`); the collapsed width + hover-grow
      live here so the CSS `:hover` rule can win (an inline width would not be
      overridable). overflow:hidden clips the 28px peek button to a 14px sliver
-     at rest. */
+     at rest. Its vertical extent comes from the shared rule above, not here. */
   .rail-shell {
     position: relative;
     flex-shrink: 0;
     overflow: hidden;
-    margin-top: var(--tandem-rail-top-clearance, 0);
-    margin-bottom: var(--tandem-status-clearance-total, 60px);
     background: var(--tandem-surface-muted);
     /* #798: ease the open/close width + the side shadow. The collapse-side
        display:none of `.rail-full` is deferred by the `.animating` flag (JS)
@@ -3286,17 +3297,55 @@ const shouldShowModelPicker = $derived(
       width 360ms cubic-bezier(0.22, 1, 0.36, 1),
       box-shadow 280ms cubic-bezier(0.22, 1, 0.36, 1);
   }
+  /* The drag strip between a rail and the editor. Everything here used to be an
+     inline `style` attribute plus two inline JS handlers for the hover tint;
+     both moved into the stylesheet for #1396, because the clearance the strip
+     was missing has to come from the shared rule above and a clearance copied
+     into a string literal is precisely the desync that rule exists to prevent.
+     So: vertical extent from the shared rule, horizontal box + chrome here.
+
+     Declared BEFORE the reduce-motion blocks on purpose — the media-query rule
+     below beats this one by source order alone (see its comment), so moving
+     this rule after it would silently unguard the colour crossfade.
+
+     `:focus-visible` also paints a background because this element and
+     `.rail-shell-right` are both z-index 1 with the rail LATER in DOM, so the
+     outward half of a 2px outline on the right-hand strip can be over-painted;
+     the accent fill is unconditionally visible and unconditionally distinct
+     from the border-strong hover tint on a 4px transparent strip. */
+  .rail-resize-handle {
+    position: relative;
+    z-index: var(--tandem-z-base);
+    flex-shrink: 0;
+    width: 4px;
+    background: transparent;
+    cursor: col-resize;
+    transition: background 0.15s;
+  }
+  .rail-resize-handle:hover {
+    background: var(--tandem-border-strong);
+  }
+  .rail-resize-handle:focus-visible {
+    background: var(--tandem-accent);
+    outline: 2px solid var(--tandem-accent);
+    outline-offset: 1px;
+  }
   /* Reduce motion: snap (the JS path likewise skips the `animating` flag so
      `.rail-full` drops to display:none synchronously). The :global body class
      mirrors the OS query but also honours the in-app reduceMotion setting; the
      media-query rule wins by SOURCE ORDER (equal specificity to the base), the
-     body-class rule by added specificity — both override the base transition. */
+     body-class rule by added specificity — both override the base transition.
+     The drag strip's colour crossfade is guarded here too (#1396): it shipped
+     unguarded only because an inline style was structurally unreachable by
+     these rules, not because it was meant to ignore the setting. */
   @media (prefers-reduced-motion: reduce) {
-    .rail-shell {
+    .rail-shell,
+    .rail-resize-handle {
       transition: none;
     }
   }
-  :global(body.tandem-reduce-motion) .rail-shell {
+  :global(body.tandem-reduce-motion) .rail-shell,
+  :global(body.tandem-reduce-motion) .rail-resize-handle {
     transition: none;
   }
   /* z-index lifts the pinned rail above the editor column. Both rails are

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -2916,12 +2916,10 @@ const shouldShowModelPicker = $derived(
       if (delta !== null) {
         e.preventDefault();
         e.stopPropagation();
+        // No keyup counterpart: handleResizeStep persists the width on each step.
         if (side === "left") dragResizeLeft.handleResizeStep(delta);
         else dragResizeRight.handleResizeStep(delta);
       }
-    }}
-    onkeyup={() => {
-      // Width is already persisted inside handleResizeStep on each keyboard step.
     }}
   ></div>
 {/snippet}
@@ -3266,11 +3264,10 @@ const shouldShowModelPicker = $derived(
      painted 52px above and 52-68px below the rail it resizes.
 
      One rule, two consumers, deliberately: the bottom inset is
-     density-dependent (`--tandem-status-clearance-total` rides
-     `--tandem-space-5`, so 52/60/68px across compact/cozy/spacious), so a
-     hardcoded copy on the strip would desync at two densities out of three,
-     and any second declaration desyncs the moment either token moves. A third
-     consumer may join this selector list; it must never get its own copy.
+     density-dependent, so a hardcoded copy on the strip would desync at two
+     densities out of three, and any second declaration desyncs the moment
+     either token moves. A third consumer may join this selector list; it must
+     never get its own copy.
      Pinned by tests/design-system-impl/rail-clearance-contract.test.ts. */
   .rail-shell,
   .rail-resize-handle {
@@ -3303,16 +3300,15 @@ const shouldShowModelPicker = $derived(
      was missing has to come from the shared rule above and a clearance copied
      into a string literal is precisely the desync that rule exists to prevent.
      So: vertical extent from the shared rule, horizontal box + chrome here.
+     Declared BEFORE the reduce-motion blocks on purpose (see their comment).
 
-     Declared BEFORE the reduce-motion blocks on purpose — the media-query rule
-     below beats this one by source order alone (see its comment), so moving
-     this rule after it would silently unguard the colour crossfade.
-
-     `:focus-visible` also paints a background because this element and
-     `.rail-shell-right` are both z-index 1 with the rail LATER in DOM, so the
-     outward half of a 2px outline on the right-hand strip can be over-painted;
-     the accent fill is unconditionally visible and unconditionally distinct
-     from the border-strong hover tint on a 4px transparent strip. */
+     On a 4px strip the `:focus-visible` FILL is the focus indicator and the
+     outline is the redundant half, not the other way round: a 2px inset outline
+     on a 4px element degenerates to a fill anyway, and the outward half of an
+     outset one can be over-painted on the right — that strip precedes
+     `.rail-shell-right` in DOM at the same z-index, so the rail's opaque
+     background and side shadow win. The accent fill is unconditionally visible
+     and distinct from the border-strong hover tint. */
   .rail-resize-handle {
     position: relative;
     z-index: var(--tandem-z-base);

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -3258,10 +3258,12 @@ const shouldShowModelPicker = $derived(
 
   /* #1396: the editor row's vertical clearance, declared ONCE for the rail
      shell AND for the drag strip that sits beside it. Both are flex items of
-     the same `align-items: stretch` row, and under `stretch` an item's margins
-     inset its stretched cross size — so while only the shell carried these two
-     margins, the 4px strip stretched the FULL row height and its hover tint
-     painted 52px above and 52-68px below the rail it resizes.
+     the same row, which declares no `align-items` and so stretches them (the
+     initial `normal` resolves to stretch — don't go looking for the keyword,
+     and note that adding one explicitly would change this rule's premise).
+     Under stretch an item's margins inset its stretched cross size, so while
+     only the shell carried these two margins, the 4px strip stretched the FULL
+     row height and its hover tint painted well past the rail at both ends.
 
      One rule, two consumers, deliberately: the bottom inset is
      density-dependent, so a hardcoded copy on the strip would desync at two
@@ -3352,7 +3354,11 @@ const shouldShowModelPicker = $derived(
      is the pinned/collapsed baseline, shared by both rails. */
   .rail-shell-left,
   .rail-shell-right {
-    z-index: 1;
+    /* Same token as .rail-resize-handle, deliberately: the strip's
+       :focus-visible comment reasons from the two being EQUAL (so DOM order
+       decides the paint). A literal here would make that a coincidence between
+       two values authored 80 lines apart. */
+    z-index: var(--tandem-z-base);
   }
   .rail-shell-left {
     border-radius: 0 var(--tandem-rail-inner-radius, 14px) var(--tandem-rail-inner-radius, 14px) 0;

--- a/src/client/components/PanelSlot.svelte
+++ b/src/client/components/PanelSlot.svelte
@@ -49,7 +49,7 @@ let { kind, visible, ...rest }: Props = $props();
 const wrapStyle = $derived(
   visible !== undefined
     ? `display: ${visible ? "flex" : "none"}; flex-direction: column; flex: 1; min-height: 0;${
-        kind === "outline" ? " padding-bottom: var(--tandem-status-clearance-total, 88px);" : ""
+        kind === "outline" ? " padding-bottom: var(--tandem-status-clearance-total, 60px);" : ""
       }`
     : undefined,
 );

--- a/tests/design-system-impl/backdrop-filter-guard.test.ts
+++ b/tests/design-system-impl/backdrop-filter-guard.test.ts
@@ -1,6 +1,7 @@
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
+import { stripCssComments, styleBlocks } from "../helpers/css-source";
 
 /**
  * backdrop-filter regression gate.
@@ -52,24 +53,6 @@ import { describe, expect, it } from "vitest";
 const ROOT = join(import.meta.dirname, "..", "..");
 const INDEX_HTML = join(ROOT, "index.html");
 const CLIENT_ROOT = join(ROOT, "src", "client");
-
-/** Strip CSS block comments so commented-out prose can't trip the greps. */
-function stripCssComments(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, "");
-}
-
-/**
- * Only `<style>` blocks go through the minifier. An inline `style="..."`
- * attribute is emitted verbatim, so it is exempt (CommandPalette's palette
- * scrim legitimately blurs a translucent backdrop that way).
- */
-function styleBlocks(file: string): string {
-  const src = readFileSync(file, "utf-8");
-  if (file.endsWith(".css")) return stripCssComments(src);
-  return stripCssComments(
-    [...src.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]).join("\n"),
-  );
-}
 
 /**
  * Matches a selector that targets the recipe class itself.

--- a/tests/design-system-impl/css-pipeline-contract.test.ts
+++ b/tests/design-system-impl/css-pipeline-contract.test.ts
@@ -1,8 +1,9 @@
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { transform } from "lightningcss";
 import { resolveConfig } from "vite";
 import { beforeAll, describe, expect, it } from "vitest";
+import { styleBlocks } from "../helpers/css-source";
 
 /**
  * CSS pipeline contract.
@@ -248,18 +249,6 @@ function bundledCssFiles(dir: string, out: string[] = []): string[] {
     else if (full.endsWith(".svelte") || full.endsWith(".css")) out.push(full);
   }
   return out;
-}
-
-function stripCssComments(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, "");
-}
-
-function styleBlocks(file: string): string {
-  const src = readFileSync(file, "utf-8");
-  if (file.endsWith(".css")) return stripCssComments(src);
-  return stripCssComments(
-    [...src.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]).join("\n"),
-  );
 }
 
 /**

--- a/tests/design-system-impl/rail-clearance-contract.test.ts
+++ b/tests/design-system-impl/rail-clearance-contract.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for #1396 — the rail drag strip overhung the visible rail.
+ *
+ * The strip (`{#snippet resizeHandle}` in App.svelte) is a flex SIBLING of
+ * `.rail-shell` inside the editor row, which has no `align-items` and therefore
+ * stretches every child. Under `stretch`, an item's margins inset its stretched
+ * cross size — so while only the shell carried `--tandem-rail-top-clearance` /
+ * `--tandem-status-clearance-total`, the strip stretched the full row height and
+ * its hover tint painted 52px above and 52-68px below the rail it resizes.
+ *
+ * The fix is a SHARED declaration, not a copied one, and that is what this file
+ * pins. The bottom inset rides `--tandem-space-5`, so it computes to 52/60/68px
+ * across compact/cozy/spacious — a second declaration (even a correct-looking
+ * one) desyncs the two siblings the moment either token moves. Hence:
+ *
+ *  - exactly ONE declaration site per token (not one *mention*: counting token
+ *    names would forbid the explanatory comments this fix is required to carry,
+ *    and index.html:280 shows in-repo how naturally a comment names a token);
+ *  - and each declaration's rule must list BOTH classes, so "shared" is proven
+ *    rather than asserted. Counting declarations rather than selectors also
+ *    leaves room for a legitimate third consumer joining the same rule.
+ *
+ * Comment spans are stripped BEFORE any analysis. Without that, the selector
+ * walk-back would sweep up the comment block sitting between `.banner-stack`'s
+ * closing brace and the rule under test — so prose could satisfy the check while
+ * the bug was reintroduced. `maskComments` in scripts/check-semantic-tokens.ts
+ * does the same job but is not exported; widening that script's public API for
+ * one test is not worth it, and inside a `<style>` block `/* … *\/` is the only
+ * comment form, so the local four-line strip is sufficient.
+ *
+ * The rendered geometry (computed margins + box edges matching the shell's) is
+ * covered by tests/e2e/rail-resize-handle.spec.ts. This file is the source-level
+ * half: it fails in `npm test`, with no browser, if the shape that caused #1396
+ * — geometry inlined onto the element — comes back.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const APP_SVELTE = join(ROOT, "src", "client", "App.svelte");
+
+const SHARED_SELECTORS = [".rail-shell", ".rail-resize-handle"] as const;
+
+const src = readFileSync(APP_SVELTE, "utf-8");
+
+/** Strip CSS block comments so commented-out prose can't satisfy or trip a grep. */
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/** The component's `<style>` blocks, comments removed. */
+function styleBlock(): string {
+  const blocks = [...src.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]);
+  if (blocks.length === 0) throw new Error("App.svelte has no <style> block");
+  return stripCssComments(blocks.join("\n"));
+}
+
+/**
+ * The selector list of the rule containing `index`, as trimmed entries.
+ *
+ * Brace scanner, not a CSS parser: the opening brace of the enclosing rule is
+ * the last `{` before the declaration, and the selector runs back to whichever
+ * comes later — the previous rule's `}` or an enclosing at-rule's `{`.
+ */
+function enclosingSelectors(css: string, index: number): string[] {
+  const open = css.lastIndexOf("{", index);
+  expect(open, "declaration should sit inside a rule").toBeGreaterThan(-1);
+  const start = Math.max(css.lastIndexOf("}", open), css.lastIndexOf("{", open - 1)) + 1;
+  return css
+    .slice(start, open)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function matchIndices(css: string, re: RegExp): number[] {
+  return [...css.matchAll(re)].map((m) => m.index as number);
+}
+
+describe("#1396 rail clearance is declared once and shared", () => {
+  const css = styleBlock();
+
+  const cases: Array<{ token: string; re: RegExp }> = [
+    { token: "--tandem-rail-top-clearance", re: /margin-top:\s*var\(--tandem-rail-top-clearance/g },
+    {
+      token: "--tandem-status-clearance-total",
+      re: /margin-bottom:\s*var\(--tandem-status-clearance-total/g,
+    },
+  ];
+
+  for (const { token, re } of cases) {
+    it(`declares ${token} exactly once in App.svelte's stylesheet`, () => {
+      expect(matchIndices(css, re)).toHaveLength(1);
+    });
+
+    it(`shares the ${token} declaration between the rail shell and the drag strip`, () => {
+      const [index] = matchIndices(css, re);
+      expect(index, `no declaration of ${token} found`).toBeDefined();
+      const selectors = enclosingSelectors(css, index);
+      for (const selector of SHARED_SELECTORS) {
+        // Exact entry, not `includes`: a partial or prose match must not pass.
+        expect(selectors).toContain(selector);
+      }
+    });
+  }
+});
+
+describe("#1396 the drag strip carries no inline geometry", () => {
+  const start = src.indexOf("{#snippet resizeHandle");
+  const end = src.indexOf("{/snippet}", start);
+  const snippet = src.slice(start, end);
+
+  it("locates the resizeHandle snippet", () => {
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+  });
+
+  it("styles the handle through a class, not an inline style attribute", () => {
+    expect(snippet).toContain('class="rail-resize-handle"');
+    // An inline `style` is exactly where the missing margins would end up as a
+    // second, silently desyncing copy of the clearance policy.
+    expect(snippet).not.toContain("style=");
+  });
+
+  it("paints the hover tint in CSS, not from inline JS handlers", () => {
+    expect(snippet).not.toContain("onmouseenter");
+    expect(snippet).not.toContain("onmouseleave");
+  });
+});

--- a/tests/design-system-impl/rail-clearance-contract.test.ts
+++ b/tests/design-system-impl/rail-clearance-contract.test.ts
@@ -1,123 +1,74 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { styleBlocks } from "../helpers/css-source";
 
 /**
  * Regression guard for #1396 — the rail drag strip overhung the visible rail.
  *
- * The strip (`{#snippet resizeHandle}` in App.svelte) is a flex SIBLING of
- * `.rail-shell` inside the editor row, which has no `align-items` and therefore
- * stretches every child. Under `stretch`, an item's margins inset its stretched
- * cross size — so while only the shell carried `--tandem-rail-top-clearance` /
- * `--tandem-status-clearance-total`, the strip stretched the full row height and
- * its hover tint painted 52px above and 52-68px below the rail it resizes.
+ * The mechanic (flex `stretch` + margins) is documented on the shared
+ * `.rail-shell, .rail-resize-handle` rule in App.svelte; this file pins the
+ * shape of that fix rather than re-explaining it.
  *
- * The fix is a SHARED declaration, not a copied one, and that is what this file
- * pins. The bottom inset rides `--tandem-space-5`, so it computes to 52/60/68px
- * across compact/cozy/spacious — a second declaration (even a correct-looking
- * one) desyncs the two siblings the moment either token moves. Hence:
+ * What it pins, and why each half matters:
  *
- *  - exactly ONE declaration site per token (not one *mention*: counting token
- *    names would forbid the explanatory comments this fix is required to carry,
- *    and index.html:280 shows in-repo how naturally a comment names a token);
- *  - and each declaration's rule must list BOTH classes, so "shared" is proven
- *    rather than asserted. Counting declarations rather than selectors also
- *    leaves room for a legitimate third consumer joining the same rule.
+ *  - The clearance is declared ONCE per token, in a rule listing BOTH classes,
+ *    so "shared" is proven rather than asserted. Counting *declarations* rather
+ *    than token mentions leaves the explanatory comments alone and leaves room
+ *    for a legitimate third consumer joining the same rule.
+ *  - The strip carries no inline geometry. This is the more valuable half: an
+ *    inline `style` attribute is structurally unreachable by any stylesheet
+ *    rule, which is why the strip could not be covered by its neighbour's
+ *    clearance policy and why its colour crossfade sat unguarded by both
+ *    reduce-motion rules. One cause, two bugs.
  *
- * Comment spans are stripped BEFORE any analysis. Without that, the selector
- * walk-back would sweep up the comment block sitting between `.banner-stack`'s
- * closing brace and the rule under test — so prose could satisfy the check while
- * the bug was reintroduced. `maskComments` in scripts/check-semantic-tokens.ts
- * does the same job but is not exported; widening that script's public API for
- * one test is not worth it, and inside a `<style>` block `/* … *\/` is the only
- * comment form, so the local four-line strip is sufficient.
- *
- * The rendered geometry (computed margins + box edges matching the shell's) is
- * covered by tests/e2e/rail-resize-handle.spec.ts. This file is the source-level
- * half: it fails in `npm test`, with no browser, if the shape that caused #1396
- * — geometry inlined onto the element — comes back.
+ * The rendered geometry lives in tests/e2e/rail-resize-handle.spec.ts, and that
+ * spec states the actual invariant ("the strip's edges coincide with its
+ * rail's") in a structure-independent way. This file is the fast source-level
+ * half: it fails in `npm test`, with no browser.
  */
 
 const ROOT = join(import.meta.dirname, "..", "..");
 const APP_SVELTE = join(ROOT, "src", "client", "App.svelte");
 
-const SHARED_SELECTORS = [".rail-shell", ".rail-resize-handle"] as const;
-
-const src = readFileSync(APP_SVELTE, "utf-8");
-
-/** Strip CSS block comments so commented-out prose can't satisfy or trip a grep. */
-function stripCssComments(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, "");
-}
-
-/** The component's `<style>` blocks, comments removed. */
-function styleBlock(): string {
-  const blocks = [...src.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]);
-  if (blocks.length === 0) throw new Error("App.svelte has no <style> block");
-  return stripCssComments(blocks.join("\n"));
-}
-
-/**
- * The selector list of the rule containing `index`, as trimmed entries.
- *
- * Brace scanner, not a CSS parser: the opening brace of the enclosing rule is
- * the last `{` before the declaration, and the selector runs back to whichever
- * comes later — the previous rule's `}` or an enclosing at-rule's `{`.
- */
-function enclosingSelectors(css: string, index: number): string[] {
-  const open = css.lastIndexOf("{", index);
-  expect(open, "declaration should sit inside a rule").toBeGreaterThan(-1);
-  const start = Math.max(css.lastIndexOf("}", open), css.lastIndexOf("{", open - 1)) + 1;
-  return css
-    .slice(start, open)
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
-function matchIndices(css: string, re: RegExp): number[] {
-  return [...css.matchAll(re)].map((m) => m.index as number);
-}
+const SHARED_SELECTORS = [".rail-shell", ".rail-resize-handle"];
 
 describe("#1396 rail clearance is declared once and shared", () => {
-  const css = styleBlock();
+  // Flat rule scan. `[^{}]*` bodies naturally skip an at-rule wrapper and match
+  // the inner rule, so a declaration moved inside `@media` is still found.
+  const rules = [...styleBlocks(APP_SVELTE).matchAll(/([^{}]+)\{([^{}]*)\}/g)];
 
-  const cases: Array<{ token: string; re: RegExp }> = [
-    { token: "--tandem-rail-top-clearance", re: /margin-top:\s*var\(--tandem-rail-top-clearance/g },
+  const cases = [
+    { token: "--tandem-rail-top-clearance", re: /margin-top:\s*var\(--tandem-rail-top-clearance/ },
     {
       token: "--tandem-status-clearance-total",
-      re: /margin-bottom:\s*var\(--tandem-status-clearance-total/g,
+      re: /margin-bottom:\s*var\(--tandem-status-clearance-total/,
     },
   ];
 
   for (const { token, re } of cases) {
-    it(`declares ${token} exactly once in App.svelte's stylesheet`, () => {
-      expect(matchIndices(css, re)).toHaveLength(1);
-    });
+    // If a structural fix ever moves this clearance onto a wrapper element,
+    // this assertion is SUPERSEDED, not violated — delete the block rather than
+    // re-satisfying it. The geometry invariant lives in the E2E spec.
+    it(`declares ${token} once in App.svelte, shared by the shell and the strip`, () => {
+      const declaring = rules.filter((r) => re.test(r[2]));
+      expect(declaring).toHaveLength(1);
 
-    it(`shares the ${token} declaration between the rail shell and the drag strip`, () => {
-      const [index] = matchIndices(css, re);
-      expect(index, `no declaration of ${token} found`).toBeDefined();
-      const selectors = enclosingSelectors(css, index);
-      for (const selector of SHARED_SELECTORS) {
-        // Exact entry, not `includes`: a partial or prose match must not pass.
-        expect(selectors).toContain(selector);
-      }
+      const selectors = declaring[0][1].split(",").map((s) => s.trim());
+      // Exact entries, not `includes`: a partial or prose match must not pass.
+      expect(selectors).toEqual(expect.arrayContaining(SHARED_SELECTORS));
     });
   }
 });
 
 describe("#1396 the drag strip carries no inline geometry", () => {
+  const src = readFileSync(APP_SVELTE, "utf-8");
   const start = src.indexOf("{#snippet resizeHandle");
   const end = src.indexOf("{/snippet}", start);
   const snippet = src.slice(start, end);
 
-  it("locates the resizeHandle snippet", () => {
-    expect(start).toBeGreaterThan(-1);
-    expect(end).toBeGreaterThan(start);
-  });
-
   it("styles the handle through a class, not an inline style attribute", () => {
+    expect(start).toBeGreaterThan(-1);
     expect(snippet).toContain('class="rail-resize-handle"');
     // An inline `style` is exactly where the missing margins would end up as a
     // second, silently desyncing copy of the clearance policy.

--- a/tests/design-system-impl/rail-clearance-contract.test.ts
+++ b/tests/design-system-impl/rail-clearance-contract.test.ts
@@ -1,26 +1,30 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { styleBlocks } from "../helpers/css-source";
+import { cssRules, styleBlocks } from "../helpers/css-source";
 
 /**
  * Regression guard for #1396 — the rail drag strip overhung the visible rail.
  *
- * The mechanic (flex `stretch` + margins) is documented on the shared
- * `.rail-shell, .rail-resize-handle` rule in App.svelte; this file pins the
- * shape of that fix rather than re-explaining it.
+ * The mechanic (the editor row sets no `align-items`, so it stretches its
+ * children, and under stretch an item's margins inset its stretched cross size)
+ * is documented on the shared `.rail-shell, .rail-resize-handle` rule in
+ * App.svelte; this file pins the shape of that fix rather than re-explaining it.
  *
  * What it pins, and why each half matters:
  *
  *  - The clearance is declared ONCE per token, in a rule listing BOTH classes,
- *    so "shared" is proven rather than asserted. Counting *declarations* rather
- *    than token mentions leaves the explanatory comments alone and leaves room
- *    for a legitimate third consumer joining the same rule.
+ *    and the strip gets no margin of its own anywhere else — including as a
+ *    hardcoded literal, which is the copy a `var()`-shaped check would miss and
+ *    the one a human is most likely to write.
  *  - The strip carries no inline geometry. This is the more valuable half: an
  *    inline `style` attribute is structurally unreachable by any stylesheet
  *    rule, which is why the strip could not be covered by its neighbour's
  *    clearance policy and why its colour crossfade sat unguarded by both
  *    reduce-motion rules. One cause, two bugs.
+ *  - The hover tint and focus ring EXIST. Both are stylesheet rules that were
+ *    ported from (or added alongside) inline JS handlers, and asserting only the
+ *    handlers' absence would let the port be deleted with both suites green.
  *
  * The rendered geometry lives in tests/e2e/rail-resize-handle.spec.ts, and that
  * spec states the actual invariant ("the strip's edges coincide with its
@@ -31,13 +35,16 @@ import { styleBlocks } from "../helpers/css-source";
 const ROOT = join(import.meta.dirname, "..", "..");
 const APP_SVELTE = join(ROOT, "src", "client", "App.svelte");
 
-const SHARED_SELECTORS = [".rail-shell", ".rail-resize-handle"];
+const SHELL = ".rail-shell";
+const STRIP = ".rail-resize-handle";
+
+const css = styleBlocks(APP_SVELTE);
+const rules = cssRules(css).map(([selectorList, body]) => ({
+  selectors: selectorList.split(",").map((s) => s.trim()),
+  body,
+}));
 
 describe("#1396 rail clearance is declared once and shared", () => {
-  // Flat rule scan. `[^{}]*` bodies naturally skip an at-rule wrapper and match
-  // the inner rule, so a declaration moved inside `@media` is still found.
-  const rules = [...styleBlocks(APP_SVELTE).matchAll(/([^{}]+)\{([^{}]*)\}/g)];
-
   const cases = [
     { token: "--tandem-rail-top-clearance", re: /margin-top:\s*var\(--tandem-rail-top-clearance/ },
     {
@@ -51,24 +58,44 @@ describe("#1396 rail clearance is declared once and shared", () => {
     // this assertion is SUPERSEDED, not violated — delete the block rather than
     // re-satisfying it. The geometry invariant lives in the E2E spec.
     it(`declares ${token} once in App.svelte, shared by the shell and the strip`, () => {
-      const declaring = rules.filter((r) => re.test(r[2]));
+      const declaring = rules.filter((r) => re.test(r.body));
       expect(declaring).toHaveLength(1);
-
-      const selectors = declaring[0][1].split(",").map((s) => s.trim());
       // Exact entries, not `includes`: a partial or prose match must not pass.
-      expect(selectors).toEqual(expect.arrayContaining(SHARED_SELECTORS));
+      expect(declaring[0].selectors).toEqual(expect.arrayContaining([SHELL, STRIP]));
     });
   }
+
+  // The above counts `var()` declarations, so a hardcoded copy — `margin-bottom:
+  // 60px` on the strip alone — slips past it AND past the E2E spec, which runs
+  // at the cozy density where the token also resolves to 60. It would overhang
+  // by 8px at compact and spacious: the original bug, at two densities of three.
+  it("gives the strip no vertical margin outside the shared rule", () => {
+    const offenders = rules.filter(
+      (r) =>
+        r.selectors.some((s) => s.startsWith(STRIP)) &&
+        !r.selectors.includes(SHELL) &&
+        /margin(-top|-bottom)?:/.test(r.body),
+    );
+    expect(offenders.map((o) => o.selectors.join(", "))).toEqual([]);
+  });
 });
 
-describe("#1396 the drag strip carries no inline geometry", () => {
+describe("#1396 the strip's chrome lives in the stylesheet", () => {
   const src = readFileSync(APP_SVELTE, "utf-8");
   const start = src.indexOf("{#snippet resizeHandle");
   const end = src.indexOf("{/snippet}", start);
-  const snippet = src.slice(start, end);
+
+  // Guarded in its own test AND asserted before every slice-dependent one: a
+  // missing anchor yields start === -1, and `slice(-1, …)` returns "" — on which
+  // every `not.toContain` passes vacuously.
+  it("locates the resizeHandle snippet", () => {
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+  });
 
   it("styles the handle through a class, not an inline style attribute", () => {
     expect(start).toBeGreaterThan(-1);
+    const snippet = src.slice(start, end);
     expect(snippet).toContain('class="rail-resize-handle"');
     // An inline `style` is exactly where the missing margins would end up as a
     // second, silently desyncing copy of the clearance policy.
@@ -76,7 +103,22 @@ describe("#1396 the drag strip carries no inline geometry", () => {
   });
 
   it("paints the hover tint in CSS, not from inline JS handlers", () => {
+    expect(start).toBeGreaterThan(-1);
+    const snippet = src.slice(start, end);
     expect(snippet).not.toContain("onmouseenter");
     expect(snippet).not.toContain("onmouseleave");
+
+    // …and the CSS the handlers were replaced by actually exists. Without this,
+    // deleting the rule leaves a 4px transparent strip with no affordance and
+    // every suite green.
+    const hover = rules.find((r) => r.selectors.includes(`${STRIP}:hover`));
+    expect(hover?.body).toMatch(/background:/);
+  });
+
+  // Not a port — the strip previously relied on the UA ring. Pinned because it
+  // is keyboard-operable (role="slider", tabindex="0", arrow/Home/End handlers).
+  it("gives the keyboard-operable strip a focus indicator", () => {
+    const focus = rules.find((r) => r.selectors.includes(`${STRIP}:focus-visible`));
+    expect(focus?.body).toMatch(/background:/);
   });
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -212,14 +212,17 @@ export type RailSide = "left" | "right";
 
 /**
  * A rail's resize-handle testid — the presence of which is how every spec
- * detects rail visibility, since the shells carry no testid of their own.
+ * detects rail visibility. The shells' own testids (`rail-float-left` /
+ * `rail-float-right`) cannot serve: they are conditional on the floating state,
+ * so their absence does not mean the rail is closed.
  *
  * The right entry is NOT `right-panel-resize-handle`: App.svelte overrides the
  * snippet's default at the call site. That asymmetry is a documented blind spot
  * of the testid extractor (docs/design-system-impl/testid-manifest.md) — the
  * snapshot only ever sees the template form, so a rename of the call-site
  * literal slips past testid-coverage.test.ts and breaks specs at runtime with
- * nothing catching it at source level. Hence one copy, here.
+ * nothing catching it at source level. Hence one copy, here — reference it
+ * rather than re-typing either literal.
  */
 export const RAIL_HANDLE_TESTID: Record<RailSide, string> = {
   left: "left-panel-resize-handle",
@@ -245,7 +248,8 @@ export async function setRailVisible(
   visible: boolean,
 ): Promise<Locator> {
   const handle = page.locator(`[data-testid='${RAIL_HANDLE_TESTID[side]}']`);
-  if ((await handle.count()) > 0 !== visible) {
+  const alreadyVisible = (await handle.count()) > 0;
+  if (alreadyVisible !== visible) {
     await page.keyboard.press(RAIL_TOGGLE_KEY[side]);
   }
   await expect(handle).toHaveCount(visible ? 1 : 0, { timeout: 3_000 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,6 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -206,6 +206,50 @@ export async function nextFrames(page: Page, n = 3): Promise<void> {
 export async function openSettingsViaBrandMenu(page: Page): Promise<void> {
   await page.locator("[data-testid='titlebar-brand-menu']").click();
   await page.locator("[data-testid='brand-menu-settings']").click();
+}
+
+export type RailSide = "left" | "right";
+
+/**
+ * A rail's resize-handle testid — the presence of which is how every spec
+ * detects rail visibility, since the shells carry no testid of their own.
+ *
+ * The right entry is NOT `right-panel-resize-handle`: App.svelte overrides the
+ * snippet's default at the call site. That asymmetry is a documented blind spot
+ * of the testid extractor (docs/design-system-impl/testid-manifest.md) — the
+ * snapshot only ever sees the template form, so a rename of the call-site
+ * literal slips past testid-coverage.test.ts and breaks specs at runtime with
+ * nothing catching it at source level. Hence one copy, here.
+ */
+export const RAIL_HANDLE_TESTID: Record<RailSide, string> = {
+  left: "left-panel-resize-handle",
+  right: "panel-resize-handle",
+};
+
+const RAIL_TOGGLE_KEY: Record<RailSide, string> = {
+  left: "Alt+Shift+ArrowLeft",
+  right: "Alt+Shift+ArrowRight",
+};
+
+/**
+ * Put a rail into the requested visibility state and return its handle locator.
+ *
+ * Toggles only when needed, so a spec never has to assume the product defaults
+ * (`leftPanelVisible: false` / `rightPanelVisible: true` today) — if one flips,
+ * the count assertion here reports it rather than a later assertion measuring a
+ * phantom. Wave M removed the titlebar toggle buttons; keyboard drives it.
+ */
+export async function setRailVisible(
+  page: Page,
+  side: RailSide,
+  visible: boolean,
+): Promise<Locator> {
+  const handle = page.locator(`[data-testid='${RAIL_HANDLE_TESTID[side]}']`);
+  if ((await handle.count()) > 0 !== visible) {
+    await page.keyboard.press(RAIL_TOGGLE_KEY[side]);
+  }
+  await expect(handle).toHaveCount(visible ? 1 : 0, { timeout: 3_000 });
+  return handle;
 }
 
 /** Success-payload shape for `tandem_status` consumed by `cleanupAllOpenDocuments`. */

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -5,6 +5,7 @@ import {
   cleanupFixtureDir,
   createFixtureDir,
   McpTestClient,
+  RAIL_HANDLE_TESTID,
   switchToAnnotationsTab,
 } from "./helpers";
 
@@ -250,7 +251,7 @@ test("Alt+Shift+Left toggles the left panel", async ({ page }) => {
   await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
 
   // Capture initial left-panel visibility via the resize-handle testid.
-  const leftHandle = page.locator("[data-testid='left-panel-resize-handle']");
+  const leftHandle = page.locator(`[data-testid='${RAIL_HANDLE_TESTID.left}']`);
   const initial = await leftHandle.count();
 
   await page.keyboard.press("Alt+Shift+ArrowLeft");
@@ -282,7 +283,7 @@ test("Alt+Shift+Right toggles the right panel", async ({ page }) => {
   await page.goto("http://127.0.0.1:5173");
   await expect(page.locator("[data-testid^='tab-name-']", { hasText: "sample.md" })).toBeVisible();
 
-  const rightHandle = page.locator("[data-testid='panel-resize-handle']");
+  const rightHandle = page.locator(`[data-testid='${RAIL_HANDLE_TESTID.right}']`);
   const initial = await rightHandle.count();
 
   await page.keyboard.press("Alt+Shift+ArrowRight");

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -10,6 +10,7 @@ import {
   nextFrames,
   openAnnotatePopup,
   openSettingsViaBrandMenu,
+  RAIL_HANDLE_TESTID,
   setRailVisible,
 } from "./helpers";
 
@@ -660,8 +661,8 @@ test("opening a rail keeps both margin columns (#892 decoupling)", async ({ page
   await seedNoteViaPopup(page, "left-side note");
   const leftCol = page.locator("[data-testid='margin-column-left']");
   const rightCol = page.locator("[data-testid='margin-column-right']");
-  const leftHandle = page.locator("[data-testid='left-panel-resize-handle']");
-  const rightHandle = page.locator("[data-testid='panel-resize-handle']");
+  const leftHandle = page.locator(`[data-testid='${RAIL_HANDLE_TESTID.left}']`);
+  const rightHandle = page.locator(`[data-testid='${RAIL_HANDLE_TESTID.right}']`);
   await expect(leftCol).toHaveCount(1);
   await expect(rightCol).toHaveCount(1);
 
@@ -855,7 +856,7 @@ test("Stage A: tracks reserve only while margins render, rail-independent", asyn
   // Open the LEFT rail (outline) → the right track is UNCHANGED (#892
   // decoupling); the left stays 0 (still no note — not because the rail opened).
   await page.keyboard.press("Alt+Shift+ArrowLeft");
-  await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(1, {
+  await expect(page.locator(`[data-testid='${RAIL_HANDLE_TESTID.left}']`)).toHaveCount(1, {
     timeout: 3_000,
   });
   expect((await marginTracks(page)).right).not.toBe("0px");

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -10,6 +10,7 @@ import {
   nextFrames,
   openAnnotatePopup,
   openSettingsViaBrandMenu,
+  setRailVisible,
 } from "./helpers";
 
 /**
@@ -67,18 +68,8 @@ async function openSettingsAndGotoCowork(page: import("@playwright/test").Page):
  * removed the titlebar panel-toggle buttons; keyboard shortcuts drive it.
  */
 async function closeBothRails(page: import("@playwright/test").Page): Promise<void> {
-  if ((await page.locator("[data-testid='left-panel-resize-handle']").count()) > 0) {
-    await page.keyboard.press("Alt+Shift+ArrowLeft");
-    await expect(page.locator("[data-testid='left-panel-resize-handle']")).toHaveCount(0, {
-      timeout: 3_000,
-    });
-  }
-  if ((await page.locator("[data-testid='panel-resize-handle']").count()) > 0) {
-    await page.keyboard.press("Alt+Shift+ArrowRight");
-    await expect(page.locator("[data-testid='panel-resize-handle']")).toHaveCount(0, {
-      timeout: 3_000,
-    });
-  }
+  await setRailVisible(page, "left", false);
+  await setRailVisible(page, "right", false);
 }
 
 async function setMarginView(

--- a/tests/e2e/rail-resize-handle.spec.ts
+++ b/tests/e2e/rail-resize-handle.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "@playwright/test";
+import path from "path";
+import {
+  cleanupAllOpenDocuments,
+  cleanupFixtureDir,
+  createFixtureDir,
+  McpTestClient,
+} from "./helpers";
+
+/**
+ * #1396 — the drag strip must not overhang the visible rail.
+ *
+ * The strip is a flex sibling of `.rail-shell` in the editor row, which has no
+ * `align-items` and therefore stretches every child. Under `stretch` an item's
+ * margins inset its stretched cross size, so while only the shell carried the
+ * titlebar / status-pill clearances the strip stretched the full column and its
+ * hover tint ran past the rail at both ends.
+ *
+ * The source-level guard (one shared declaration rather than two copies) lives
+ * in tests/design-system-impl/rail-clearance-contract.test.ts. This spec is the
+ * rendered-geometry half: it measures the real boxes in a real browser, which is
+ * what would actually have caught the bug.
+ */
+
+let mcp: McpTestClient;
+let tmpDir: string;
+
+/** The floor below is deliberately density-agnostic — see `expectAligned`. */
+const MIN_INSET_PX = 40;
+
+type Side = "left" | "right";
+
+const HANDLE_TESTID: Record<Side, string> = {
+  // The right handle's testid is overridden at the call site in App.svelte.
+  left: "left-panel-resize-handle",
+  right: "panel-resize-handle",
+};
+
+const SHELL_SELECTOR: Record<Side, string> = {
+  left: ".rail-shell-left",
+  right: ".rail-shell-right",
+};
+
+const TOGGLE_KEY: Record<Side, string> = {
+  left: "Alt+Shift+ArrowLeft",
+  right: "Alt+Shift+ArrowRight",
+};
+
+/**
+ * Make the side's rail visible so its handle renders, whatever the defaults are.
+ *
+ * Expected defaults today: `leftPanelVisible: false` / `rightPanelVisible: true`
+ * (src/client/hooks/useTandemSettings.ts), `defaultMode: "tandem"` (same file,
+ * mirroring TANDEM_MODE_DEFAULT in src/shared/constants.ts) and
+ * `soloRailHidden: true` (same file — only bites in solo mode). If any of those
+ * flip, this helper still gets the rail open and the `toHaveCount(1)` below is
+ * what reports the surprise, instead of a later assertion measuring a phantom.
+ */
+async function openRail(page: import("@playwright/test").Page, side: Side) {
+  const handle = page.locator(`[data-testid='${HANDLE_TESTID[side]}']`);
+  if ((await handle.count()) === 0) {
+    await page.keyboard.press(TOGGLE_KEY[side]);
+  }
+  await expect(handle).toHaveCount(1, { timeout: 3_000 });
+  return handle;
+}
+
+async function expectAligned(page: import("@playwright/test").Page, side: Side) {
+  const handle = await openRail(page, side);
+  const shell = page.locator(SHELL_SELECTOR[side]);
+  await expect(shell).toHaveCount(1);
+
+  // (a) The clearance is literally the same computed value on both siblings.
+  const margins = await page.evaluate(
+    ([handleSel, shellSel]) => {
+      const h = document.querySelector(handleSel) as HTMLElement;
+      const s = document.querySelector(shellSel) as HTMLElement;
+      const hs = getComputedStyle(h);
+      const ss = getComputedStyle(s);
+      return {
+        handleTop: hs.marginTop,
+        handleBottom: hs.marginBottom,
+        shellTop: ss.marginTop,
+        shellBottom: ss.marginBottom,
+      };
+    },
+    [`[data-testid='${HANDLE_TESTID[side]}']`, SHELL_SELECTOR[side]],
+  );
+  expect(margins.handleTop).toBe(margins.shellTop);
+  expect(margins.handleBottom).toBe(margins.shellBottom);
+
+  // (b) …and the rendered boxes start and end on the same lines. Polled: the
+  // shell carries a 360ms width transition, so a rail just toggled open is
+  // still settling.
+  await expect
+    .poll(
+      async () => {
+        const hb = await handle.boundingBox();
+        const sb = await shell.boundingBox();
+        if (!hb || !sb) return null;
+        return {
+          top: Math.abs(hb.y - sb.y) <= 1,
+          bottom: Math.abs(hb.y + hb.height - (sb.y + sb.height)) <= 1,
+        };
+      },
+      { timeout: 5_000 },
+    )
+    .toEqual({ top: true, bottom: true });
+
+  // (c) A real inset on the HANDLE, so deleting the shared rule reds this even
+  // if the shell lost its clearance in lockstep. No parent hop (undeclared DOM
+  // structure) and no per-density number: the top inset is a fixed 52px, but the
+  // bottom rides --tandem-space-5 and so is 52/60/68px across
+  // compact/cozy/spacious — any exact figure would be wrong at two densities.
+  expect(parseFloat(margins.handleTop)).toBeGreaterThanOrEqual(MIN_INSET_PX);
+  expect(parseFloat(margins.handleBottom)).toBeGreaterThanOrEqual(MIN_INSET_PX);
+}
+
+test.beforeEach(async ({ page }) => {
+  mcp = new McpTestClient();
+  await mcp.connect();
+  tmpDir = createFixtureDir("sample.md");
+  // The E2E server sets TANDEM_NO_SAMPLE=1 against a per-run-wiped app-data dir,
+  // so nothing is open at boot — open a fixture, then wait for the editor, which
+  // also proves we are past App.svelte's `{#if !yjsSync.ready}` branch (the
+  // editor row, and therefore both rails, do not exist inside it).
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("http://127.0.0.1:5173");
+  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
+});
+
+test.afterEach(async () => {
+  await cleanupAllOpenDocuments(mcp);
+  await mcp.close();
+  cleanupFixtureDir(tmpDir);
+});
+
+test("left rail: the drag strip spans exactly the visible rail", async ({ page }) => {
+  await expectAligned(page, "left");
+});
+
+test("right rail: the drag strip spans exactly the visible rail", async ({ page }) => {
+  await expectAligned(page, "right");
+});

--- a/tests/e2e/rail-resize-handle.spec.ts
+++ b/tests/e2e/rail-resize-handle.spec.ts
@@ -5,21 +5,22 @@ import {
   cleanupFixtureDir,
   createFixtureDir,
   McpTestClient,
+  RAIL_HANDLE_TESTID,
+  type RailSide,
+  setRailVisible,
 } from "./helpers";
 
 /**
  * #1396 — the drag strip must not overhang the visible rail.
  *
- * The strip is a flex sibling of `.rail-shell` in the editor row, which has no
- * `align-items` and therefore stretches every child. Under `stretch` an item's
- * margins inset its stretched cross size, so while only the shell carried the
- * titlebar / status-pill clearances the strip stretched the full column and its
- * hover tint ran past the rail at both ends.
+ * The mechanic (flex `stretch` + margins) is documented on the shared
+ * `.rail-shell, .rail-resize-handle` rule in App.svelte. The source-level guard
+ * on the *shape* of that fix lives in
+ * tests/design-system-impl/rail-clearance-contract.test.ts.
  *
- * The source-level guard (one shared declaration rather than two copies) lives
- * in tests/design-system-impl/rail-clearance-contract.test.ts. This spec is the
- * rendered-geometry half: it measures the real boxes in a real browser, which is
- * what would actually have caught the bug.
+ * This spec states the invariant itself — the strip's edges coincide with its
+ * rail's — by measuring real boxes in a real browser, which is what would
+ * actually have caught the bug and what stays true under any correct structure.
  */
 
 let mcp: McpTestClient;
@@ -28,92 +29,61 @@ let tmpDir: string;
 /** The floor below is deliberately density-agnostic — see `expectAligned`. */
 const MIN_INSET_PX = 40;
 
-type Side = "left" | "right";
-
-const HANDLE_TESTID: Record<Side, string> = {
-  // The right handle's testid is overridden at the call site in App.svelte.
-  left: "left-panel-resize-handle",
-  right: "panel-resize-handle",
-};
-
-const SHELL_SELECTOR: Record<Side, string> = {
+const SHELL_SELECTOR: Record<RailSide, string> = {
   left: ".rail-shell-left",
   right: ".rail-shell-right",
 };
 
-const TOGGLE_KEY: Record<Side, string> = {
-  left: "Alt+Shift+ArrowLeft",
-  right: "Alt+Shift+ArrowRight",
+type Measured = {
+  topAligned: boolean;
+  bottomAligned: boolean;
+  marginTop: number;
+  marginBottom: number;
 };
 
-/**
- * Make the side's rail visible so its handle renders, whatever the defaults are.
- *
- * Expected defaults today: `leftPanelVisible: false` / `rightPanelVisible: true`
- * (src/client/hooks/useTandemSettings.ts), `defaultMode: "tandem"` (same file,
- * mirroring TANDEM_MODE_DEFAULT in src/shared/constants.ts) and
- * `soloRailHidden: true` (same file — only bites in solo mode). If any of those
- * flip, this helper still gets the rail open and the `toHaveCount(1)` below is
- * what reports the surprise, instead of a later assertion measuring a phantom.
- */
-async function openRail(page: import("@playwright/test").Page, side: Side) {
-  const handle = page.locator(`[data-testid='${HANDLE_TESTID[side]}']`);
-  if ((await handle.count()) === 0) {
-    await page.keyboard.press(TOGGLE_KEY[side]);
-  }
-  await expect(handle).toHaveCount(1, { timeout: 3_000 });
-  return handle;
-}
+async function expectAligned(page: import("@playwright/test").Page, side: RailSide) {
+  await setRailVisible(page, side, true);
+  const selectors: [string, string] = [
+    `[data-testid='${RAIL_HANDLE_TESTID[side]}']`,
+    SHELL_SELECTOR[side],
+  ];
 
-async function expectAligned(page: import("@playwright/test").Page, side: Side) {
-  const handle = await openRail(page, side);
-  const shell = page.locator(SHELL_SELECTOR[side]);
-  await expect(shell).toHaveCount(1);
+  let last: Measured | null = null;
 
-  // (a) The clearance is literally the same computed value on both siblings.
-  const margins = await page.evaluate(
-    ([handleSel, shellSel]) => {
-      const h = document.querySelector(handleSel) as HTMLElement;
-      const s = document.querySelector(shellSel) as HTMLElement;
-      const hs = getComputedStyle(h);
-      const ss = getComputedStyle(s);
-      return {
-        handleTop: hs.marginTop,
-        handleBottom: hs.marginBottom,
-        shellTop: ss.marginTop,
-        shellBottom: ss.marginBottom,
-      };
-    },
-    [`[data-testid='${HANDLE_TESTID[side]}']`, SHELL_SELECTOR[side]],
-  );
-  expect(margins.handleTop).toBe(margins.shellTop);
-  expect(margins.handleBottom).toBe(margins.shellBottom);
-
-  // (b) …and the rendered boxes start and end on the same lines. Polled: the
-  // shell carries a 360ms width transition, so a rail just toggled open is
-  // still settling.
+  // One round-trip per attempt, and polled: the shell carries a 360ms width
+  // transition, so a rail just toggled open is still settling.
   await expect
     .poll(
       async () => {
-        const hb = await handle.boundingBox();
-        const sb = await shell.boundingBox();
-        if (!hb || !sb) return null;
-        return {
-          top: Math.abs(hb.y - sb.y) <= 1,
-          bottom: Math.abs(hb.y + hb.height - (sb.y + sb.height)) <= 1,
-        };
+        last = await page.evaluate(([handleSel, shellSel]) => {
+          const h = document.querySelector(handleSel);
+          const s = document.querySelector(shellSel);
+          if (!h || !s) return null;
+          const hb = h.getBoundingClientRect();
+          const sb = s.getBoundingClientRect();
+          const hs = getComputedStyle(h);
+          return {
+            topAligned: Math.abs(hb.top - sb.top) <= 1,
+            bottomAligned: Math.abs(hb.bottom - sb.bottom) <= 1,
+            marginTop: parseFloat(hs.marginTop),
+            marginBottom: parseFloat(hs.marginBottom),
+          };
+        }, selectors);
+        return last && { topAligned: last.topAligned, bottomAligned: last.bottomAligned };
       },
       { timeout: 5_000 },
     )
-    .toEqual({ top: true, bottom: true });
+    .toEqual({ topAligned: true, bottomAligned: true });
 
-  // (c) A real inset on the HANDLE, so deleting the shared rule reds this even
-  // if the shell lost its clearance in lockstep. No parent hop (undeclared DOM
-  // structure) and no per-density number: the top inset is a fixed 52px, but the
-  // bottom rides --tandem-space-5 and so is 52/60/68px across
-  // compact/cozy/spacious — any exact figure would be wrong at two densities.
-  expect(parseFloat(margins.handleTop)).toBeGreaterThanOrEqual(MIN_INSET_PX);
-  expect(parseFloat(margins.handleBottom)).toBeGreaterThanOrEqual(MIN_INSET_PX);
+  // A real inset on the HANDLE. Alignment alone still passes if the shared rule
+  // is deleted outright and BOTH siblings drop to zero — a plausible refactor,
+  // and the only regression this catches that alignment doesn't. No parent hop
+  // (undeclared DOM structure) and no per-density number: the top inset is a
+  // fixed 52px, but the bottom rides --tandem-space-5 and so is 52/60/68px
+  // across compact/cozy/spacious — any exact figure would be wrong at two.
+  expect(last).not.toBeNull();
+  expect((last as unknown as Measured).marginTop).toBeGreaterThanOrEqual(MIN_INSET_PX);
+  expect((last as unknown as Measured).marginBottom).toBeGreaterThanOrEqual(MIN_INSET_PX);
 }
 
 test.beforeEach(async ({ page }) => {

--- a/tests/e2e/rail-resize-handle.spec.ts
+++ b/tests/e2e/rail-resize-handle.spec.ts
@@ -20,7 +20,10 @@ import {
  *
  * This spec states the invariant itself — the strip's edges coincide with its
  * rail's — by measuring real boxes in a real browser, which is what would
- * actually have caught the bug and what stays true under any correct structure.
+ * actually have caught the bug. The alignment half stays true under any correct
+ * structure; the inset floor below reads margins off the handle itself, so a
+ * structural fix that moved the clearance to a wrapper would SUPERSEDE it, the
+ * same way it supersedes the source-level contract test.
  */
 
 let mcp: McpTestClient;
@@ -34,12 +37,7 @@ const SHELL_SELECTOR: Record<RailSide, string> = {
   right: ".rail-shell-right",
 };
 
-type Measured = {
-  topAligned: boolean;
-  bottomAligned: boolean;
-  marginTop: number;
-  marginBottom: number;
-};
+type Margins = { marginTop: number; marginBottom: number };
 
 async function expectAligned(page: import("@playwright/test").Page, side: RailSide) {
   await setRailVisible(page, side, true);
@@ -48,14 +46,13 @@ async function expectAligned(page: import("@playwright/test").Page, side: RailSi
     SHELL_SELECTOR[side],
   ];
 
-  let last: Measured | null = null;
-
-  // One round-trip per attempt, and polled: the shell carries a 360ms width
-  // transition, so a rail just toggled open is still settling.
+  // Polled because the rail was just toggled open by a keypress and mount plus
+  // layout has to settle. (Not the shell's 360ms width transition — that
+  // animates width and box-shadow, neither of which moves the measured axis.)
   await expect
     .poll(
       async () => {
-        last = await page.evaluate(([handleSel, shellSel]) => {
+        const m = await page.evaluate(([handleSel, shellSel]) => {
           const h = document.querySelector(handleSel);
           const s = document.querySelector(shellSel);
           if (!h || !s) return null;
@@ -69,21 +66,32 @@ async function expectAligned(page: import("@playwright/test").Page, side: RailSi
             marginBottom: parseFloat(hs.marginBottom),
           };
         }, selectors);
-        return last && { topAligned: last.topAligned, bottomAligned: last.bottomAligned };
+        return m && { topAligned: m.topAligned, bottomAligned: m.bottomAligned };
       },
       { timeout: 5_000 },
     )
     .toEqual({ topAligned: true, bottomAligned: true });
 
   // A real inset on the HANDLE. Alignment alone still passes if the shared rule
-  // is deleted outright and BOTH siblings drop to zero — a plausible refactor,
-  // and the only regression this catches that alignment doesn't. No parent hop
-  // (undeclared DOM structure) and no per-density number: the top inset is a
-  // fixed 52px, but the bottom rides --tandem-space-5 and so is 52/60/68px
-  // across compact/cozy/spacious — any exact figure would be wrong at two.
-  expect(last).not.toBeNull();
-  expect((last as unknown as Measured).marginTop).toBeGreaterThanOrEqual(MIN_INSET_PX);
-  expect((last as unknown as Measured).marginBottom).toBeGreaterThanOrEqual(MIN_INSET_PX);
+  // is deleted outright and BOTH siblings drop to zero — the motivating
+  // regression this catches that alignment doesn't (it also catches either token
+  // being retuned below the floor). No parent hop (undeclared DOM structure) and
+  // no per-density number: the top inset is a fixed 52px, but the bottom rides
+  // --tandem-space-5 and so is 52/60/68px across compact/cozy/spacious — any
+  // exact figure would be wrong at two of the three.
+  //
+  // Re-measured rather than captured from the poll: one extra round-trip total,
+  // and it keeps the value type-checked instead of cast out of a closure.
+  const settled: Margins | null = await page.evaluate(([handleSel]) => {
+    const h = document.querySelector(handleSel);
+    if (!h) return null;
+    const hs = getComputedStyle(h);
+    return { marginTop: parseFloat(hs.marginTop), marginBottom: parseFloat(hs.marginBottom) };
+  }, selectors);
+
+  expect(settled).not.toBeNull();
+  expect(settled?.marginTop).toBeGreaterThanOrEqual(MIN_INSET_PX);
+  expect(settled?.marginBottom).toBeGreaterThanOrEqual(MIN_INSET_PX);
 }
 
 test.beforeEach(async ({ page }) => {

--- a/tests/helpers/css-source.ts
+++ b/tests/helpers/css-source.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Source-level CSS extraction shared by the `tests/design-system-impl/` suites.
+ *
+ * These suites assert properties of CSS *as authored* — which rules exist, which
+ * hand-write a vendor prefix, which declare a token — so they read the source
+ * rather than a rendered page. That means every one of them needs the same two
+ * primitives, and before this module three files had rolled their own.
+ *
+ * The extractor is a regex, not a parser, and that is the reason to have exactly
+ * one of it: Svelte's `<style>` syntax can grow (a `lang=` attribute, `module`,
+ * nesting), and when it does, a stale copy does not fail loudly — it extracts an
+ * empty string, finds zero offenders and reports **green**. That failure mode is
+ * documented in-repo: css-pipeline-contract.test.ts records a scan whose first
+ * prototype returned 0 pairs while 12 existed and looked passing. One copy is a
+ * bug to fix; four copies is a bug plus three silent false negatives.
+ */
+
+/** Strip CSS block comments so commented-out prose can't satisfy or trip a grep. */
+export function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/**
+ * A file's authored CSS, comments removed.
+ *
+ * `.css` files are returned whole. For `.svelte` / `.html` only `<style>` blocks
+ * are returned — an inline `style="…"` attribute is emitted verbatim by the
+ * bundler and is therefore not the same artifact (CommandPalette's palette scrim
+ * legitimately blurs a translucent backdrop that way).
+ */
+export function styleBlocks(file: string): string {
+  const src = readFileSync(file, "utf-8");
+  if (file.endsWith(".css")) return stripCssComments(src);
+  return stripCssComments(
+    [...src.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]).join("\n"),
+  );
+}

--- a/tests/helpers/css-source.ts
+++ b/tests/helpers/css-source.ts
@@ -5,16 +5,20 @@ import { readFileSync } from "node:fs";
  *
  * These suites assert properties of CSS *as authored* — which rules exist, which
  * hand-write a vendor prefix, which declare a token — so they read the source
- * rather than a rendered page. That means every one of them needs the same two
- * primitives, and before this module three files had rolled their own.
+ * rather than a rendered page. Two files had rolled their own byte-identical
+ * copies of the first two helpers below, and the rule splitter was triplicated.
  *
- * The extractor is a regex, not a parser, and that is the reason to have exactly
- * one of it: Svelte's `<style>` syntax can grow (a `lang=` attribute, `module`,
+ * These are regexes, not a parser, and that is the reason to have exactly one of
+ * each: Svelte's `<style>` syntax can grow (a `lang=` attribute, `module`,
  * nesting), and when it does, a stale copy does not fail loudly — it extracts an
  * empty string, finds zero offenders and reports **green**. That failure mode is
  * documented in-repo: css-pipeline-contract.test.ts records a scan whose first
  * prototype returned 0 pairs while 12 existed and looked passing. One copy is a
- * bug to fix; four copies is a bug plus three silent false negatives.
+ * bug to fix; N copies is a bug plus N-1 silent false negatives.
+ *
+ * Deliberately NOT migrated: `styleBlock` in activity-message-wrapping.test.ts.
+ * It is a different primitive — singular, non-global, no comment stripping —
+ * that asserts a block's presence rather than scanning its contents.
  */
 
 /** Strip CSS block comments so commented-out prose can't satisfy or trip a grep. */
@@ -36,4 +40,15 @@ export function styleBlocks(file: string): string {
   return stripCssComments(
     [...src.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]).join("\n"),
   );
+}
+
+/**
+ * Flat `[selectorList, declarationBlock]` pairs.
+ *
+ * Because a body may not contain braces, an at-rule wrapper never matches as a
+ * whole — the scan steps past it and matches the rules *inside*, so a
+ * declaration hidden in `@media` is still found rather than skipped.
+ */
+export function cssRules(css: string): Array<[string, string]> {
+  return [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => [m[1], m[2]]);
 }


### PR DESCRIPTION
The rail drag strip overhung the rail it resizes: its hover tint painted ~52px above and 52–68px below the visible rail, at both ends of the column.

## Cause

The strip (`{#snippet resizeHandle}`) is a flex **sibling** of `.rail-shell` in the editor row. That row sets no `align-items`, so it defaults to `stretch` — and under `stretch` an item's margins inset its *stretched cross size*. Only `.rail-shell` carried the two clearance margins, so the 4px strip stretched the full row height.

The deeper cause, and the reason no reviewer caught it: the strip's entire geometry lived in an inline `style=` attribute plus two inline JS hover handlers. An inline attribute is **structurally unreachable by any stylesheet rule** — no rule could have included the strip, so its absence from the clearance rule was invisible.

Evidence that this is the real cause rather than a nicer framing: moving the strip into the stylesheet **incidentally fixed a second, unrelated bug**. Its colour crossfade had been silently unguarded by *both* reduce-motion rules for as long as it was inline. Two bugs, one structural cause.

## Fix

One shared declaration, plus the strip's chrome moved into the stylesheet:

```css
.rail-shell,
.rail-resize-handle {
  margin-top: var(--tandem-rail-top-clearance, 0);
  margin-bottom: var(--tandem-status-clearance-total, 60px);
}
```

Shared rather than copied deliberately: the bottom inset rides `--tandem-space-5`, so it is 52/60/68px across compact/cozy/spacious. A hardcoded copy on the strip would be wrong at two densities out of three.

**Two behaviour additions beyond the geometry fix, called out because "moved inline styles into the stylesheet" doesn't cover them:**

1. A `:focus-visible` indicator, which the strip never had (it is keyboard-operable — `role="slider"`, `tabindex="0"`, arrow/Home/End handlers).
2. The reduce-motion guard now reaches the strip's crossfade. See "Resolved disagreement" below — the claim I originally made there was too strong, and review corrected it.

## Why not fix it at the row instead

The obvious deeper fix — put the clearance on the flex container so children inherit it structurally and a new sibling *cannot* forget — is wrong for this row, and the row's own geometry says so.

The editor column is **deliberately full-bleed**. `.editor-scroll` takes `padding: max(--tandem-space-7, 52px)` *internally*, precisely so document content scrolls **under** the floating titlebar and status pill (the calm-v7 floating-chrome effect; the `--tandem-rail-top-clearance` comment in `index.html` states this outright). Row padding would move `.editor-scroll`'s border-box from y=56 to y=108, double-count the top clearance, shorten the scroll viewport, and destroy the scroll-under at both ends.

`align-items` other than `stretch` is a harder non-starter: `.rail-shell` has no height of its own at all — `stretch` is its only height source.

A `.rail-band` wrapper around each shell+handle pair *would* work and *would* be forgetting-proof. Rejected on population grounds: the row's child set is closed by design (`rail | handle | editor | handle | rail`; the cross-rail tab picker was deleted in Wave I and `leftRailTabs`/`rightRailTabs` migrated out). Against a closed child set, enumeration in one selector is the cheaper correct answer than a DOM level added to a row that already carries a scroll-pop workaround and an offset-parent invariant.

## Tests

**Source-level** — `tests/design-system-impl/rail-clearance-contract.test.ts`. Fails in `npm test` with no browser if the shape that caused #1396 comes back. Mutation-tested rather than trusted:

| Mutation | Result |
|---|---|
| Strip dropped from the shared rule | **2 tests fail**, readable selector diff |
| Declaration *copied* onto the strip instead of shared | **2 tests fail** |
| Hardcoded literal `margin-bottom: 60px` on the strip | **1 test fails** — added in commit 3, see below |
| `:hover` rule deleted | **1 test fails** — added in commit 3 |

It also names its own obsolescence: if a structural fix later moves the clearance to a wrapper, the assertion is **superseded**, not violated — delete the block rather than re-satisfying it. Without that, its failure message would read as "you broke the #1396 fix" to someone who had in fact improved on it.

**Rendered geometry** — `tests/e2e/rail-resize-handle.spec.ts` measures real boxes in a real browser. Its alignment half states the invariant structure-independently (the strip's edges coincide with its rail's), so it survives any correct implementation. Its inset floor does not: that reads margins off the handle itself, so a wrapper refactor would supersede it — the header now says so, matching the contract test's own note.

The floor is `>= 40px` rather than an exact figure, deliberately: the top inset is a fixed 52px but the bottom is density-dependent, so any exact number would be wrong at two densities out of three. It earns its place as the motivating catch for the shared rule being deleted **outright** with both siblings dropping to zero in lockstep — which box-alignment alone would pass.

## `/simplify` pass (second commit)

Four cleanup lenses. Net **−120 lines** of prose and machinery, plus two extractions. Highlights:

- **`tests/helpers/css-source.ts`** — `stripCssComments` / `styleBlocks` were byte-identical in `backdrop-filter-guard.test.ts` and `css-pipeline-contract.test.ts`, and this branch was adding a third copy. The extractor is a regex, not a parser: when Svelte's `<style>` syntax grows, a stale copy doesn't fail loudly — it extracts `""`, finds zero offenders and reports **green**. `css-pipeline-contract.test.ts` already records exactly that failure (a scan whose first prototype returned 0 pairs while 12 existed).
- **`setRailVisible()` + `RAIL_HANDLE_TESTID`** in `tests/e2e/helpers.ts`, replacing this spec's copy *and* `margin-view.spec.ts`'s `closeBothRails`. The right handle's testid is `panel-resize-handle`, **not** `right-panel-resize-handle` — an `App.svelte` call-site override that the testid extractor structurally cannot see (documented blind spot in the manifest), so a rename would have broken three specs at runtime with nothing catching it at source level.
- The contract test's brace-scanner + `matchIndices` + split assertions collapse to a flat rule scan: ~21 lines to ~7, same strictness, and the `expect()` buried inside a helper goes away.
- Dropped the E2E "computed margins are equal on both siblings" assertion. Mutation table showed it never fires alone — every regression it catches, box-alignment also catches.
- Deleted an empty `onkeyup` handler whose entire body was a comment.

### Resolved disagreement: the reduce-motion guard stays

Two lenses reached opposite verdicts on the same hunk, so I checked rather than picked. One argued it was a policy change smuggled into a refactor, citing unguarded colour transitions elsewhere in `App.svelte`. The precedent for guarding is real:

| Element | Transitions | Reduce-motion guarded today? |
|---|---|---|
| `.acb-btn` (ApplyChangesButton) | `background`, `color` — nothing else | **yes**, both rules |
| `.itc-card` (IntegrationTargetCard) | `border-color`, `background` — nothing else | **yes**, both rules |

**But PR review sharpened this and I was over-claiming.** "House convention" is too strong: the counterexamples are genuinely unguarded, there is no blanket fallback covering them, and one is worse than a colour fade — `.panel-edge-collapse::before` transitions `height`, which is actual motion, on `:hover`. The honest claim is narrower: **this addition is consistent with the neighbouring `.rail-shell` rule it joins, and with two component precedents.** The real state of the policy is "guarded if someone remembered", which is filed as #1425 — that is the gap this PR walked past, not one it created.

## PR review pass (third commit)

Four review agents — code, tests, comments, Svelte. The Svelte review came back clean, having compiled a repro against the repo's own Svelte to confirm the scope hash reaches snippet-rendered elements rather than assuming it. The other three found real problems, including two in my own comments.

### A coverage hole that survived *both* new test files

```css
.rail-resize-handle { margin-bottom: 60px; }   /* added after the shared rule */
```

Green everywhere. The contract test matched on `margin-bottom:\s*var\(--tandem-status-clearance-total`, which a **literal** does not match — still one declaration, still both selectors. And E2E runs at cozy density, where the token *also* resolves to 60, so alignment and the floor both pass. At compact (52) and spacious (68) the strip overhangs by 8px: the original bug, at two densities out of three.

This is the more likely human error than the `var()` copy I had mutation-tested — and this PR itself edits a hardcoded `88` → `60` in a neighbouring file. Now asserted: no rule listing `.rail-resize-handle` without `.rail-shell` may declare a vertical margin at all.

### Ported behaviour was pinned in only one direction

Both suites asserted the **absence** of `onmouseenter`/`onmouseleave`, and nothing asserted the `:hover` rule that replaced them. Deleting it leaves a 4px transparent strip with no affordance and every suite green. Same for the new `:focus-visible`. Both now pinned.

### Two of my comments were false

- **`helpers.ts`: "the shells carry no testid of their own."** They carry `rail-float-left` / `rail-float-right`, both in the frozen snapshot. The real reason they can't probe visibility is that those testids are conditional on the *floating* state — a different fact, and the one that actually justifies the spec reaching for CSS classes.
- **`css-source.ts`: "three files had rolled their own."** Two had the identical pair; a third has a *different* variant that I deliberately did not migrate. The header implied no duplicates remained while leaving one in place — self-undermining in a comment whose whole argument is that stale copies fail green.

### A dedup that didn't dedup

`RAIL_HANDLE_TESTID`'s docstring said "hence one copy, here" while **five** literal occurrences remained across `keyboard-shortcuts.spec.ts` and `margin-view.spec.ts`. A rename would still have broken four specs at runtime. All five now reference the constant.

### Smaller corrections

- `cssRules()` extracted — the rule-splitting regex was triplicated, and by the module's own argument it's the *more* dangerous primitive (a stale copy returns zero rules, reports green).
- The snippet-scan tests could pass **vacuously**: a renamed anchor gives `start === -1`, and `slice(-1, …)` returns `""`, on which every `not.toContain` passes. Guarded in each slice-dependent test.
- Dropped a dead `expect(last).not.toBeNull()` (unreachable — the poll throws first) and an `as unknown as` double cast, by re-measuring with a `const`.
- `align-items: stretch` was cited as if **declared**. It appears nowhere in the repo — the behaviour is the initial `normal`. Reworded, and it now warns that adding one explicitly would change the rule's premise.
- The poll comment blamed the shell's 360ms width transition; that animates `width` and `box-shadow`, neither of which moves the measured axis. The real reason is mount/layout settling after the keypress.
- `.rail-shell-left/right` now take `z-index: var(--tandem-z-base)` instead of a literal `1`. The `:focus-visible` comment reasons from the strip and shell being **equal** so DOM order decides the paint — with a literal that was a coincidence between two values authored 80 lines apart, and retuning a token named "base" would have silently falsified the explanation while the behaviour survived.
- `index.html`: dropped the `(outline)` parenthetical (the surviving half of the consumer enumeration, already wrong for two of three consumers) and reworded "never hardcode it at a call site", which read as violated on sight since all three consumers carry a literal `var()` fallback.

## Also fixed while in the file

`PanelSlot.svelte`'s `--tandem-status-clearance-total` fallback said `88px` where `App.svelte` says `60px`. The real computed value is 60px (36 + 24). No runtime effect — the token is always defined in `:root` — but one of the two was documentation that lied.

## One thing I did not change

`.rail-shell` takes `margin-bottom: var(--tandem-status-clearance-total)`, and `PanelSlot`'s outline branch takes `padding-bottom` from the **same token** on a wrapper *inside* that shell. That double application is plausibly intentional (it gives a scrolling outline room to scroll its last item clear of the pill), but it isn't recorded anywhere. Flagging rather than "fixing" it — it predates this branch and changing it is a visual decision, not a cleanup.

## Verification

- `npm run typecheck` — 1323 files, **0 errors**
- `npm test -- --run` — **458 files, 6653 passed**, 19 skipped
- `npx playwright test rail-resize-handle margin-view keyboard-shortcuts` — **60 passed**
- `npx playwright test rail-motion accessibility forced-colors` — **52 passed**
- `npx eslint tests/` — **0 errors**
- Four mutations killed (see the table above), each restored by file copy rather than `git checkout`

Two flakes observed across runs, both in `openAnnotatePopup` and both unrelated to rails — one cleared **3/3** on a targeted `--repeat-each=3` re-run. Worth watching, not caused here.

Worth noting: `tsconfig` includes only `src/`, so `npm run typecheck` does **not** cover `tests/`. The husky hook caught two unused imports that typecheck had waved straight through — which is also why the double cast the review flagged was buying nothing in CI.

Closes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYGFawL9kQruDZiUkYGBKD
