### PR TITLE
fix(ui): align the Solo/Tandem toggle pill with its segment

### DIFF
--- a/docs/design-system-impl/derived-spec.md
+++ b/docs/design-system-impl/derived-spec.md
@@ -240,7 +240,16 @@ Each row:
   Do NOT animate tab insertion — only tab close. Do NOT remove the
   ModeToggle's middle "Tandem" label on narrow viewports; the toggle is
   semantically a 2-position segmented control and label is the
-  affordance.
+  affordance. Do NOT size the ModeToggle thumb as a percentage of the
+  track. The segments must be the two equal `1fr` columns of an
+  `inline-grid` — bare `1fr`, deliberately NOT the house
+  `minmax(0, 1fr)`, because the `auto` minimum is what stops a column
+  being squeezed under its own label — and the thumb must be placed into
+  grid area `1 / 1 / 2 / 2` with `inset: 0`. `flex: 1 1 0` does not
+  equalize the segments (a flex item's automatic minimum size is its
+  min-content size, so the longer "Tandem" label wins) and a half-width
+  thumb then matches neither of them: that is how #1383 and #1384
+  shipped.
 
 ### 3.10 Annotation decorations — B2 (inline marks)
 

--- a/docs/design-system-impl/derived-spec.md
+++ b/docs/design-system-impl/derived-spec.md
@@ -240,16 +240,16 @@ Each row:
   Do NOT animate tab insertion — only tab close. Do NOT remove the
   ModeToggle's middle "Tandem" label on narrow viewports; the toggle is
   semantically a 2-position segmented control and label is the
-  affordance. Do NOT size the ModeToggle thumb as a percentage of the
-  track. The segments must be the two equal `1fr` columns of an
-  `inline-grid` — bare `1fr`, deliberately NOT the house
-  `minmax(0, 1fr)`, because the `auto` minimum is what stops a column
-  being squeezed under its own label — and the thumb must be placed into
-  grid area `1 / 1 / 2 / 2` with `inset: 0`. `flex: 1 1 0` does not
-  equalize the segments (a flex item's automatic minimum size is its
-  min-content size, so the longer "Tandem" label wins) and a half-width
-  thumb then matches neither of them: that is how #1383 and #1384
-  shipped.
+  affordance. Do NOT let the ModeToggle thumb derive its own geometry
+  from the track — no percentages, no `calc`, no measured JS. The pill
+  must be positioned by whatever mechanism sizes the segments, so the
+  two cannot desync, and the segments must stay equal at every width.
+  #1383 and #1384 were one desync seen from two sides: `flex: 1 1 0`
+  never equalized the segments (a flex item's automatic minimum size is
+  its min-content size, so the longer "Tandem" label wins), and a
+  half-width thumb then matched neither. The current implementation
+  satisfies this with an `inline-grid` track and a placed thumb; the
+  requirement is the invariant, not that mechanism.
 
 ### 3.10 Annotation decorations — B2 (inline marks)
 

--- a/src/client/editor/toolbar/ModeToggle.svelte
+++ b/src/client/editor/toolbar/ModeToggle.svelte
@@ -42,49 +42,39 @@ const { tandemMode, onModeChange }: Props = $props();
 <style>
   .mode-toggle {
     display: inline-grid;
-    grid-template-columns: repeat(2, 1fr);
+    /* `minmax(0, 1fr)`, not a bare `1fr`. Both measure IDENTICALLY today — the
+       track is shrink-to-fit, so it sizes to max-content and the `auto`
+       minimum never binds. They diverge only under compression, and there the
+       0 minimum is the one that holds this component's whole invariant:
+       measured at a 120px cap, `1fr` gives 52 / 70.97px columns while
+       `minmax(0, 1fr)` gives 60 / 60px. Unequal columns put the thumb (which
+       IS column 1) on a segment of a different width — #1384, reopened. The
+       trade is that a squeezed label can outgrow its column; a visibly
+       overflowing label beats a silently misplaced pill. */
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    /* The thumb's containing block. Measured: remove it and the thumb sizes
+       itself against the viewport. Fails silently. */
     position: relative;
     /* Bundle's `.a8 .seg` recipe: 2px track padding + a 1px border so the
        segmented control reads as a chip rather than a recessed plate. The
        surface-sunk track is preserved from the prior version because the
-       lighter `surface` active pill needs the contrast in both themes.
-
-       Four details here are load-bearing for #1383/#1384, and each of them
-       fails SILENTLY — no error, no warning, just a misaligned pill:
-
-       (i) The columns are a BARE `1fr`, i.e. `minmax(auto, 1fr)`, and that
-           `auto` minimum IS the fix. Do not normalize it to this codebase's
-           usual `minmax(0, 1fr)` (HelpModal, SettingsModal, SettingsAboutTab,
-           editor-stage): a 0 minimum lets a column be squeezed narrower than
-           its own label, which is the exact condition that made the segments
-           unequal and left the thumb matching neither of them.
-       (ii) `gap` must stay 0. The thumb's slide is exactly one column, so any
-            gutter desyncs `translateX(100%)` from the column pitch.
-       (iii) `position: relative` is the thumb's containing block. Measured:
-             remove it and the thumb sizes itself against the viewport.
-       (iv) `inline-grid` is blockified to `grid` here, because the parent
-            `.title-bar-mode` is an `inline-flex` container. Keep the `inline-`
-            regardless — it is inert in THIS parent, not in general. */
+       lighter `surface` active pill needs the contrast in both themes. */
     padding: 2px;
     background: var(--tandem-surface-sunk);
     border: 1px solid var(--tandem-border);
     border-radius: var(--tandem-r-pill);
     font-size: 11px;
     font-weight: 600;
+    /* Must stay 0: the thumb slides exactly one column, so any gutter desyncs
+       `translateX(100%)` from the column pitch. */
     gap: 0;
   }
   /* A8 (#798): the sliding active pill. Its box IS grid area (1,1) — the first
      segment, to the pixel — so it does no arithmetic of its own and cannot
-     drift from the button underneath it.
+     drift from the button underneath it. Do not reintroduce percentage sizing;
+     derived-spec.md §3.9 forbids it.
 
-     It used to: `width: calc(50% - 2px)` assumed the two segments were exact
-     halves, which `flex: 1 1 0` never delivered (see the button rule below).
-     The pill overhung the selected segment by ~8.6px in both positions, which
-     also left each label ~4.3px off the pill's optical centre — #1384 and
-     #1383 respectively, one defect seen from two sides. Do not reintroduce
-     percentage sizing here; derived-spec.md §3.9 forbids it.
-
-     Two replacements for that arithmetic, both silent if you get them wrong:
+     Two traps in that placement, both silent if you get them wrong:
 
        - ALL FOUR grid lines must be written out. On an absolutely-positioned
          grid child an `auto` end line resolves to the container's PADDING
@@ -93,12 +83,9 @@ const { tandemMode, onModeChange }: Props = $props();
        - `inset: 0` is required. Without it the abspos box shrink-to-fits and
          renders 0x0.
 
-     Verified flush on all four edges under Chromium 145, WebKit 26 (Tandem's
-     Linux WebView engine) and Firefox 146 with the shipped SN Pro webfont;
-     WebKit rounds the translated position by 0.17px, everything else is 0.00.
-     lightningcss keeps the four-line shorthand and `inset: 0` intact — pinned
-     in tests/design-system-impl/css-pipeline-contract.test.ts, because CI's
-     Playwright run drives `npm run dev`, which never minifies. */
+     Flushness is measured, not asserted here — tests/e2e/mode-toggle-geometry
+     .spec.ts. Minifier survival is pinned in css-pipeline-contract.test.ts,
+     because CI's Playwright run drives `npm run dev`, which never minifies. */
   .thumb {
     position: absolute;
     grid-area: 1 / 1 / 2 / 2;
@@ -110,17 +97,18 @@ const { tandemMode, onModeChange }: Props = $props();
     z-index: 0;
     transition: transform 220ms var(--tandem-ease-out);
   }
-  /* Exactly one column — and exact only while the track's `gap` stays 0. */
   .thumb.tandem {
     transform: translateX(100%);
   }
   .mode-toggle button {
     /* No width rule belongs here: the segments ARE the track's two equal grid
        columns and the button stretches to fill its column. The `flex: 1 1 0`
-       this replaces claimed to equalize them and never did — a flex item's
-       automatic minimum size is its min-content size, so "Tandem" (one
-       unbreakable word) kept its natural width and "Solo" took the remainder
-       (measured 67.8px vs 50.5px). That inequality was #1383/#1384. */
+       this replaces never equalized them — a flex item's automatic minimum
+       size is its min-content size, so "Tandem" (one unbreakable word) kept
+       its natural width and "Solo" took the remainder (measured 67.8 vs
+       50.5px). That inequality was #1383/#1384, one defect seen from two
+       sides: the pill matched neither segment, and each label sat off the
+       pill's optical centre. */
     /* Center the label on both axes. `line-height: normal` (not the tight `1`)
        is the load-bearing part: at `line-height: 1` the line box is shorter than
        the glyph's natural box, so the text rendered ~0.7px high (2.6px gap above

--- a/src/client/editor/toolbar/ModeToggle.svelte
+++ b/src/client/editor/toolbar/ModeToggle.svelte
@@ -41,12 +41,30 @@ const { tandemMode, onModeChange }: Props = $props();
 
 <style>
   .mode-toggle {
-    display: inline-flex;
+    display: inline-grid;
+    grid-template-columns: repeat(2, 1fr);
     position: relative;
     /* Bundle's `.a8 .seg` recipe: 2px track padding + a 1px border so the
        segmented control reads as a chip rather than a recessed plate. The
        surface-sunk track is preserved from the prior version because the
-       lighter `surface` active pill needs the contrast in both themes. */
+       lighter `surface` active pill needs the contrast in both themes.
+
+       Four details here are load-bearing for #1383/#1384, and each of them
+       fails SILENTLY — no error, no warning, just a misaligned pill:
+
+       (i) The columns are a BARE `1fr`, i.e. `minmax(auto, 1fr)`, and that
+           `auto` minimum IS the fix. Do not normalize it to this codebase's
+           usual `minmax(0, 1fr)` (HelpModal, SettingsModal, SettingsAboutTab,
+           editor-stage): a 0 minimum lets a column be squeezed narrower than
+           its own label, which is the exact condition that made the segments
+           unequal and left the thumb matching neither of them.
+       (ii) `gap` must stay 0. The thumb's slide is exactly one column, so any
+            gutter desyncs `translateX(100%)` from the column pitch.
+       (iii) `position: relative` is the thumb's containing block. Measured:
+             remove it and the thumb sizes itself against the viewport.
+       (iv) `inline-grid` is blockified to `grid` here, because the parent
+            `.title-bar-mode` is an `inline-flex` container. Keep the `inline-`
+            regardless — it is inert in THIS parent, not in general. */
     padding: 2px;
     background: var(--tandem-surface-sunk);
     border: 1px solid var(--tandem-border);
@@ -55,16 +73,36 @@ const { tandemMode, onModeChange }: Props = $props();
     font-weight: 600;
     gap: 0;
   }
-  /* A8 (#798): the sliding active pill. Half the track's inner width, anchored
-     left; a mode flip slides it by its own width (translateX 100%) to land
-     exactly on the right segment — the `width: calc(50% - 2px)` accounts for
-     the 2px left track padding so the arithmetic is exact. */
+  /* A8 (#798): the sliding active pill. Its box IS grid area (1,1) — the first
+     segment, to the pixel — so it does no arithmetic of its own and cannot
+     drift from the button underneath it.
+
+     It used to: `width: calc(50% - 2px)` assumed the two segments were exact
+     halves, which `flex: 1 1 0` never delivered (see the button rule below).
+     The pill overhung the selected segment by ~8.6px in both positions, which
+     also left each label ~4.3px off the pill's optical centre — #1384 and
+     #1383 respectively, one defect seen from two sides. Do not reintroduce
+     percentage sizing here; derived-spec.md §3.9 forbids it.
+
+     Two replacements for that arithmetic, both silent if you get them wrong:
+
+       - ALL FOUR grid lines must be written out. On an absolutely-positioned
+         grid child an `auto` end line resolves to the container's PADDING
+         EDGE, not to `span 1`, so a two-line `grid-area: 1 / 1` stretches the
+         thumb across the entire track. Measured; nothing warns.
+       - `inset: 0` is required. Without it the abspos box shrink-to-fits and
+         renders 0x0.
+
+     Verified flush on all four edges under Chromium 145, WebKit 26 (Tandem's
+     Linux WebView engine) and Firefox 146 with the shipped SN Pro webfont;
+     WebKit rounds the translated position by 0.17px, everything else is 0.00.
+     lightningcss keeps the four-line shorthand and `inset: 0` intact — pinned
+     in tests/design-system-impl/css-pipeline-contract.test.ts, because CI's
+     Playwright run drives `npm run dev`, which never minifies. */
   .thumb {
     position: absolute;
-    top: 2px;
-    bottom: 2px;
-    left: 2px;
-    width: calc(50% - 2px);
+    grid-area: 1 / 1 / 2 / 2;
+    inset: 0;
     background: var(--tandem-surface);
     border-radius: var(--tandem-r-pill);
     box-shadow: var(--tandem-shadow-1);
@@ -72,19 +110,25 @@ const { tandemMode, onModeChange }: Props = $props();
     z-index: 0;
     transition: transform 220ms var(--tandem-ease-out);
   }
+  /* Exactly one column — and exact only while the track's `gap` stays 0. */
   .thumb.tandem {
     transform: translateX(100%);
   }
   .mode-toggle button {
-    /* Equal-width segments so the half-width thumb lands cleanly on either; the
-       two labels ("Solo"/"Tandem") differ in length, so flex-equalize them. */
-    flex: 1 1 0;
+    /* No width rule belongs here: the segments ARE the track's two equal grid
+       columns and the button stretches to fill its column. The `flex: 1 1 0`
+       this replaces claimed to equalize them and never did — a flex item's
+       automatic minimum size is its min-content size, so "Tandem" (one
+       unbreakable word) kept its natural width and "Solo" took the remainder
+       (measured 67.8px vs 50.5px). That inequality was #1383/#1384. */
     /* Center the label on both axes. `line-height: normal` (not the tight `1`)
        is the load-bearing part: at `line-height: 1` the line box is shorter than
        the glyph's natural box, so the text rendered ~0.7px high (2.6px gap above
        vs 4px below). `normal` + flex centering distributes the leading evenly
        (3.3px / 3.3px), and the padding is trimmed 5px→3px so the taller line box
-       keeps the pill at its original 21px height. */
+       holds the pill within a pixel of its original 21px height (20px under the
+       shipped SN Pro face; the untrimmed `5px` + `normal` pairing would be
+       24px). */
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/tests/design-system-impl/backdrop-filter-guard.test.ts
+++ b/tests/design-system-impl/backdrop-filter-guard.test.ts
@@ -1,7 +1,7 @@
 import { readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
-import { stripCssComments, styleBlocks } from "../helpers/css-source";
+import { cssRules, stripCssComments, styleBlocks } from "../helpers/css-source";
 
 /**
  * backdrop-filter regression gate.
@@ -79,8 +79,8 @@ const RECIPE_SELECTOR = /\.tandem-floating-pill(?![\w-])/;
  * nest this recipe.
  */
 function floatingPillRulesIn(css: string): { selector: string; body: string }[] {
-  return [...stripCssComments(css).matchAll(/([^{}]+)\{([^{}]*)\}/g)]
-    .map((m) => ({ selector: m[1].trim(), body: m[2] }))
+  return cssRules(stripCssComments(css))
+    .map(([selector, body]) => ({ selector: selector.trim(), body }))
     .filter((r) => RECIPE_SELECTOR.test(r.selector));
 }
 

--- a/tests/design-system-impl/css-pipeline-contract.test.ts
+++ b/tests/design-system-impl/css-pipeline-contract.test.ts
@@ -3,7 +3,7 @@ import { join, relative } from "node:path";
 import { transform } from "lightningcss";
 import { resolveConfig } from "vite";
 import { beforeAll, describe, expect, it } from "vitest";
-import { styleBlocks } from "../helpers/css-source";
+import { cssRules, styleBlocks } from "../helpers/css-source";
 
 /**
  * CSS pipeline contract.
@@ -200,10 +200,10 @@ describe("bundled CSS: writing the standard property alone is still the safe adv
     // This exists because the synthetic fixture above does not guard our source: deleting
     // AnnotationCard's declaration failed nothing until this gate was added.
     const missing = bundledCssFiles(CLIENT_ROOT).flatMap((file) =>
-      [...styleBlocks(file).matchAll(/([^{}]+)\{([^{}]*)\}/g)]
-        .filter(([, , body]) => /(^|[;\s])line-clamp\s*:/.test(body))
-        .filter(([, , body]) => !/-webkit-line-clamp\s*:/.test(body))
-        .map(([, selector]) => `${relative(ROOT, file).replace(/\\/g, "/")}: ${selector.trim()}`),
+      cssRules(styleBlocks(file))
+        .filter(([, body]) => /(^|[;\s])line-clamp\s*:/.test(body))
+        .filter(([, body]) => !/-webkit-line-clamp\s*:/.test(body))
+        .map(([selector]) => `${relative(ROOT, file).replace(/\\/g, "/")}: ${selector.trim()}`),
     );
     expect(missing).toEqual([]);
   });
@@ -250,8 +250,11 @@ describe("bundled CSS: the #1383/#1384 mode-toggle declarations survive minifica
   // E2E gate can see this axis. That blind spot is exactly the one that shipped
   // #1189 inert for six weeks.
   //
-  // All four cases were measured green before the change shipped; they are
-  // here so the pipeline question stays visibly answered rather than unasked.
+  // One case, not four. Three siblings were dropped in review for being
+  // unfalsifiable: lightningcss COLLAPSES longhands into `inset: 0` rather than
+  // exploding it, `minmax(auto, 1fr)` → `minmax(0, 1fr)` is a semantic change
+  // no minifier performs, and a percentage in `translateX` cannot be resolved
+  // without a box. A test that can only pass is not a gate.
 
   it("keeps grid-area as the four-line form", () => {
     // The load-bearing one. For an ABSOLUTELY-POSITIONED grid child an `auto`
@@ -261,34 +264,6 @@ describe("bundled CSS: the #1383/#1384 mode-toggle declarations survive minifica
     // anywhere else.
     const out = minify(".probe{grid-area:1 / 1 / 2 / 2}");
     expect(out).toContain("grid-area:1/1/2/2");
-  });
-
-  it("keeps inset: 0 as a placement-neutral shorthand", () => {
-    // Exploding `inset` into a reordered top/right/bottom/left set would be
-    // legal but would put four declarations back where the point of the fix
-    // was to have none.
-    const out = minify(".probe{position:absolute;grid-area:1 / 1 / 2 / 2;inset:0}");
-    expect(out).toMatch(/inset:\s*0|top:\s*0/);
-    expect(out).toContain("grid-area:1/1/2/2");
-  });
-
-  it("does not rewrite repeat(2, 1fr) into a minmax(0, …) form", () => {
-    // Bare `1fr` is `minmax(auto, 1fr)`, and the `auto` minimum is what keeps a
-    // column from being squeezed under its label — the actual root cause of
-    // #1383/#1384. A rewrite to a 0 minimum would reopen both, so this pins the
-    // toolchain half of the rule that `mode-toggle-thumb-contract.test.ts` pins
-    // in source.
-    const out = minify(".probe{display:inline-grid;grid-template-columns:repeat(2, 1fr)}");
-    expect(out).not.toContain("minmax(0");
-    expect(out).toMatch(/repeat\(2,\s*1fr\)|1fr 1fr/);
-  });
-
-  it("preserves the thumb's one-column slide", () => {
-    // lightningcss rewrites `translateX(100%)` to the equivalent
-    // `translate(100%)`. That is semantically identical, so match either —
-    // what must not happen is the percentage being resolved or dropped.
-    const out = minify(".probe{transform:translateX(100%)}");
-    expect(out).toMatch(/translate(?:X)?\(100%\)/);
   });
 });
 
@@ -319,8 +294,7 @@ function handWrittenPairs(): { prop: string; value: string; where: string }[] {
   const found = new Map<string, { prop: string; value: string; where: string }>();
   for (const file of bundledCssFiles(CLIENT_ROOT)) {
     const css = styleBlocks(file);
-    for (const rule of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-      const body = rule[2];
+    for (const [, body] of cssRules(css)) {
       for (const decl of body.matchAll(/-webkit-([a-z-]+)\s*:\s*([^;}]+)/g)) {
         const prop = decl[1];
         if (found.has(prop)) continue;

--- a/tests/design-system-impl/css-pipeline-contract.test.ts
+++ b/tests/design-system-impl/css-pipeline-contract.test.ts
@@ -241,6 +241,57 @@ describe("bundled CSS: the #1302 formatting-bar declarations survive minificatio
   });
 });
 
+describe("bundled CSS: the #1383/#1384 mode-toggle declarations survive minification", () => {
+  // ModeToggle.svelte's thumb no longer computes its own box; it is PLACED into
+  // the track's first grid column (`grid-area: 1 / 1 / 2 / 2` + `inset: 0`) so
+  // that it cannot drift from the segment it selects. Those declarations live in
+  // a component <style> block, so they really do ship through lightningcss —
+  // and CI's Playwright run drives `npm run dev`, which never minifies, so no
+  // E2E gate can see this axis. That blind spot is exactly the one that shipped
+  // #1189 inert for six weeks.
+  //
+  // All four cases were measured green before the change shipped; they are
+  // here so the pipeline question stays visibly answered rather than unasked.
+
+  it("keeps grid-area as the four-line form", () => {
+    // The load-bearing one. For an ABSOLUTELY-POSITIONED grid child an `auto`
+    // end line resolves to the container's padding edge, not `span 1`, so a
+    // minifier that collapsed `1/1/2/2` to `1/1` would silently stretch the
+    // thumb across the whole track — a visual bug with no failing test
+    // anywhere else.
+    const out = minify(".probe{grid-area:1 / 1 / 2 / 2}");
+    expect(out).toContain("grid-area:1/1/2/2");
+  });
+
+  it("keeps inset: 0 as a placement-neutral shorthand", () => {
+    // Exploding `inset` into a reordered top/right/bottom/left set would be
+    // legal but would put four declarations back where the point of the fix
+    // was to have none.
+    const out = minify(".probe{position:absolute;grid-area:1 / 1 / 2 / 2;inset:0}");
+    expect(out).toMatch(/inset:\s*0|top:\s*0/);
+    expect(out).toContain("grid-area:1/1/2/2");
+  });
+
+  it("does not rewrite repeat(2, 1fr) into a minmax(0, …) form", () => {
+    // Bare `1fr` is `minmax(auto, 1fr)`, and the `auto` minimum is what keeps a
+    // column from being squeezed under its label — the actual root cause of
+    // #1383/#1384. A rewrite to a 0 minimum would reopen both, so this pins the
+    // toolchain half of the rule that `mode-toggle-thumb-contract.test.ts` pins
+    // in source.
+    const out = minify(".probe{display:inline-grid;grid-template-columns:repeat(2, 1fr)}");
+    expect(out).not.toContain("minmax(0");
+    expect(out).toMatch(/repeat\(2,\s*1fr\)|1fr 1fr/);
+  });
+
+  it("preserves the thumb's one-column slide", () => {
+    // lightningcss rewrites `translateX(100%)` to the equivalent
+    // `translate(100%)`. That is semantically identical, so match either —
+    // what must not happen is the percentage being resolved or dropped.
+    const out = minify(".probe{transform:translateX(100%)}");
+    expect(out).toMatch(/translate(?:X)?\(100%\)/);
+  });
+});
+
 /** Every `.svelte` `<style>` / `.css` file whose CSS the build routes through lightningcss. */
 function bundledCssFiles(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {

--- a/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
+++ b/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
@@ -1,87 +1,56 @@
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { cssRules, styleBlocks } from "../helpers/css-source";
 
 /**
  * ModeToggle sliding-thumb geometry gate (#1383, #1384).
  *
- * Both issues are one defect. `.mode-toggle` asked flexbox to split the track
+ * Both issues are one defect: `.mode-toggle` asked flexbox to split the track
  * in half (`flex: 1 1 0`) and `.thumb` sized itself to that assumed half
- * (`width: calc(50% - 2px)`). Flexbox never delivered it: a flex item's
- * automatic minimum size is its **min-content** size, and "Tandem" is a single
- * unbreakable word, so its segment was clamped up to its natural width and
- * "Solo" took whatever was left. Measured under the shipped SN Pro face:
+ * (`width: calc(50% - 2px)`). Flexbox never delivered it — a flex item's
+ * automatic minimum size is its min-content size, so "Tandem" was clamped up to
+ * its natural width and "Solo" took the remainder. The pill then matched
+ * neither segment (#1384) and each label sat off the pill's optical centre
+ * (#1383). The full measurement table lives in the E2E spec, which is the only
+ * file that can re-derive it.
  *
- *              before                      after
- *   solo seg   50.53px  }  unequal        67.83px  }  equal
- *   tandem seg 67.83px  }                 67.83px  }
- *   thumb      59.17px                    67.83px
- *   thumb vs active button   dL/dR up to 8.64px    0.00 on all four edges
- *   label ink vs thumb centre     4.32px off       0.00
- *   track                    124.36 x 26px         141.66 x 26px (+17.30 wide)
- *
- * The overhang is #1384 directly. #1383 is the same error seen from the user's
- * side: the label is centred in its *button*, but the button is invisible and
- * the thumb is what the eye reads, so the ink lands half the mismatch off the
- * pill's centre.
- *
- * The fix removes the arithmetic rather than correcting it. The segments became
+ * The fix removes the arithmetic rather than correcting it: the segments became
  * the two equal columns of an `inline-grid`, and the thumb is *placed into*
  * grid area 1/1/2/2 with `inset: 0`, so its box IS the first segment's box.
  *
- * **This file pins CSS shape, not effect.** No vitest project in this repo has
- * a layout engine: the `client` project is happy-dom (vitest.config.ts:29) and
- * this file lands in the `node` project (:44-45) with no DOM at all, where
- * `getBoundingClientRect` cannot answer anything. The geometric truth is only
- * observable in a real browser, which is `tests/e2e/mode-toggle-geometry.spec.ts`.
- * The third axis — what the *built* CSS looks like after lightningcss — is
- * covered in `css-pipeline-contract.test.ts`, the only gate that runs the real
- * minifier.
+ * **This file pins CSS shape, not effect.** No vitest project here has a layout
+ * engine, so geometric truth is only observable in
+ * `tests/e2e/mode-toggle-geometry.spec.ts`; what the *built* CSS looks like
+ * after lightningcss is covered in `css-pipeline-contract.test.ts`, the only
+ * gate that runs the real minifier. Three axes, none able to see the others.
  *
- * A shape gate can red for the right reason and the wrong one. Every failure
- * message below states the invariant, so that a deliberate re-formulation is
- * fixed by updating the pin rather than by routing around it.
- *
- * **Comments are stripped before every grep, and that is mandatory rather than
- * stylistic.** The rules being pinned carry long rationale comments that quote
- * the very literals scanned for here (`grid-area: 1 / 1`, `calc(50% - 2px)`) —
- * the file carried `calc(50% - 2px)` in a comment even before this change. An
- * un-stripped scan reds on the prose, and the path of least resistance under
- * time pressure is deleting the prose. That is exactly how the first attempt at
- * #1383 shipped a comment asserting a property that had never been true, so one
- * test below asserts the prose is still there.
+ * Two of the gates below pin INVARIANTS ("no percentage-derived sizing", "no
+ * width rule on the buttons") and survive any correct implementation. The rest
+ * pin the current SHAPE and are marked accordingly — if a better placement
+ * mechanism arrives, those are SUPERSEDED rather than violated, and the right
+ * response is deleting them, not re-satisfying them.
  */
 
 const ROOT = join(import.meta.dirname, "..", "..");
 const MODE_TOGGLE = join(ROOT, "src", "client", "editor", "toolbar", "ModeToggle.svelte");
 
-/** Strip CSS block comments so commented-out prose can't trip the greps. */
-function stripCssComments(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, "");
-}
-
-function styleBlock(): string {
-  const src = readFileSync(MODE_TOGGLE, "utf-8");
-  return [...src.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]).join("\n");
-}
-
 /**
- * Brace scanner in the shape of `backdrop-filter-guard.test.ts`'s
- * `floatingPillRulesIn`. Rules are matched by EXACT selector, never substring:
- * `.thumb.tandem` legitimately declares `translateX(100%)`, and a broadened
- * "no percentages in .thumb" pattern would swallow it and flag a correct
- * declaration. `@media` wrappers are fine — the inner rule is recovered with
- * its own selector.
+ * Rules are matched by EXACT selector, never substring: `.thumb.tandem`
+ * legitimately declares `translateX(100%)`, and a broadened "no percentages in
+ * .thumb" pattern would swallow it and flag a correct declaration.
+ *
+ * `styleBlocks` strips comments, which is mandatory rather than stylistic here:
+ * the rules being pinned carry rationale comments quoting the very literals
+ * scanned for (`grid-area: 1 / 1`, `calc(50% - 2px)`). An un-stripped scan reds
+ * on the prose, and the path of least resistance is then deleting the prose.
  */
-function rules(): { selector: string; body: string }[] {
-  return [...stripCssComments(styleBlock()).matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => ({
-    selector: m[1].trim(),
-    body: m[2],
-  }));
-}
+const RULES = cssRules(styleBlocks(MODE_TOGGLE)).map(([selector, body]) => ({
+  selectors: selector.split(",").map((x) => x.trim()),
+  body,
+}));
 
 function ruleWithSelector(selector: string): string {
-  const found = rules().filter((r) => r.selector === selector);
+  const found = RULES.filter((r) => r.selectors.includes(selector));
   expect(found.length, `no rule with selector \`${selector}\` — scanner desynced?`).toBeGreaterThan(
     0,
   );
@@ -89,14 +58,14 @@ function ruleWithSelector(selector: string): string {
 }
 
 /**
- * The `.thumb` selector appears twice: the base rule and the reduced-motion
- * override inside `@media (prefers-reduced-motion: reduce)`, which declares
- * only `transition: none`. The base one is the rule that paints — anchoring on
- * `background` keeps this independent of the placement properties under test.
+ * `.thumb` appears twice: the base rule and the reduced-motion override, which
+ * declares only `transition: none`. Anchoring on `background` picks the one
+ * that paints, independent of the placement properties under test — and its
+ * `toBe(1)` is what stops every gate below being "passed" by deleting the rule.
  */
 function thumbBaseRule(): string {
-  const candidates = rules().filter(
-    (r) => r.selector === ".thumb" && /background\s*:/.test(r.body),
+  const candidates = RULES.filter(
+    (r) => r.selectors.includes(".thumb") && /background\s*:/.test(r.body),
   );
   expect(
     candidates.length,
@@ -114,22 +83,21 @@ describe(".mode-toggle: the equal-segment premise the thumb rests on", () => {
         "automatic minimum size is its min-content size, so the longer 'Tandem' label wins " +
         "and the half-width thumb then matches neither segment.",
     ).toMatch(/display\s*:\s*inline-grid/);
-    expect(body).toMatch(/grid-template-columns\s*:\s*repeat\(\s*2\s*,\s*1fr\s*\)/);
+    expect(body).toMatch(/grid-template-columns\s*:\s*repeat\(/);
   });
 
-  it("sizes those columns with a bare 1fr, never minmax(0, …)", () => {
-    // Every other grid in src/client writes `minmax(0, 1fr)` (HelpModal,
-    // SettingsModal, SettingsAboutTab, editor-stage), so normalizing to the
-    // house style is the natural /simplify pass. Here the `auto` minimum that
-    // plain `1fr` carries IS the fix: with a 0 minimum a column can be squeezed
-    // back under its own label and both issues reopen.
+  // SHAPE, not invariant — superseded by any placement that keeps the columns
+  // equal under compression.
+  it("sizes those columns with minmax(0, 1fr), not a bare 1fr", () => {
     const columns = /grid-template-columns\s*:([^;]+)/.exec(ruleWithSelector(".mode-toggle"))?.[1];
     expect(columns, "no grid-template-columns declaration").toBeDefined();
     expect(
       columns,
-      "#1383/#1384: `1fr` here means `minmax(auto, 1fr)`, and the auto minimum is what stops " +
-        "a column being squeezed narrower than its label. Do not normalize to `minmax(0, 1fr)`.",
-    ).not.toContain("minmax(0");
+      "#1384: the two forms are identical while the track is shrink-to-fit, and diverge under " +
+        "compression — measured at a 120px cap, bare `1fr` gives 52/70.97px columns while " +
+        "`minmax(0, 1fr)` gives 60/60px. The thumb IS column 1, so unequal columns put it on a " +
+        "segment of a different width. A squeezed label overflowing is the accepted trade.",
+    ).toContain("minmax(0");
   });
 
   it("stays the thumb's containing block", () => {
@@ -141,9 +109,11 @@ describe(".mode-toggle: the equal-segment premise the thumb rests on", () => {
   });
 
   it("keeps the column gutter at zero", () => {
-    const body = ruleWithSelector(".mode-toggle");
-    expect(body).toMatch(/gap\s*:\s*0(?![.\d])/);
-    const nonZero = [...body.matchAll(/(?:^|[;\s])(?:row-|column-)?gap\s*:\s*([^;]+)/g)]
+    const nonZero = [
+      ...ruleWithSelector(".mode-toggle").matchAll(
+        /(?:^|[;\s])(?:row-|column-)?gap\s*:\s*([^;]+)/g,
+      ),
+    ]
       .map((m) => m[1].trim())
       .filter((v) => !/^0(?:[a-z%]*)?$/.test(v));
     expect(
@@ -164,6 +134,8 @@ describe(".mode-toggle: the equal-segment premise the thumb rests on", () => {
 });
 
 describe(".thumb: placed into the first segment, never computed from it", () => {
+  // SHAPE, not invariant — superseded if the thumb is ever placed by another
+  // mechanism. Delete rather than re-satisfy; the E2E spec holds the invariant.
   it("names all four grid lines", () => {
     expect(
       thumbBaseRule(),
@@ -173,17 +145,21 @@ describe(".thumb: placed into the first segment, never computed from it", () => 
     ).toMatch(/grid-area\s*:\s*1\s*\/\s*1\s*\/\s*2\s*\/\s*2/);
   });
 
-  it("declares inset: 0", () => {
+  // SHAPE, not invariant — same note as above.
+  it("declares inset: 0 on an absolutely-positioned box", () => {
+    const body = thumbBaseRule();
     expect(
-      thumbBaseRule(),
+      body,
       "#1384: without `inset`, the absolutely-positioned box shrink-to-fits its (empty) " +
         "contents and renders 0x0. The grid placement alone does not size it.",
     ).toMatch(/inset\s*:\s*0(?![.\d])/);
+    // Load-bearing pair: without `absolute`, `inset` is inert and the grid
+    // placement makes the thumb a flow item that consumes a column.
+    expect(body).toMatch(/position\s*:\s*absolute/);
   });
 
   it("carries no percentage-derived sizing", () => {
-    const offenders = rules()
-      .filter((r) => r.selector === ".thumb")
+    const offenders = RULES.filter((r) => r.selectors.includes(".thumb"))
       .flatMap((r) => [
         ...r.body.matchAll(/(?:^|[;\s])(width|height|left|right|top|bottom)\s*:[^;]*(%|calc\()/g),
       ])
@@ -201,38 +177,5 @@ describe(".thumb: placed into the first segment, never computed from it", () => 
     // percentage lives one selector away from a rule that must contain none,
     // and a substring-matched scanner would flag it.
     expect(ruleWithSelector(".thumb.tandem")).toMatch(/transform\s*:\s*translateX\(\s*100%\s*\)/);
-  });
-
-  it("still paints the pill it exists to paint", () => {
-    // Guards every gate above from being "passed" by deleting the rule.
-    const body = thumbBaseRule();
-    expect(body).toMatch(/position\s*:\s*absolute/);
-    expect(body).toMatch(/background\s*:/);
-    expect(body).toMatch(/border-radius\s*:/);
-    expect(body).toMatch(/box-shadow\s*:/);
-    expect(body).toMatch(/pointer-events\s*:\s*none/);
-  });
-});
-
-describe("the rationale that keeps this from being reintroduced", () => {
-  it("still explains the padding-edge and inset traps in prose", () => {
-    // The positive half of the comment-stripping rule at the top of this file.
-    // Both traps fail silently and neither is inferable from the declarations,
-    // so the comment is load-bearing documentation, not decoration — and it is
-    // the thing a reader under time pressure deletes to make a grep go green.
-    const comments = [...styleBlock().matchAll(/\/\*([\s\S]*?)\*\//g)]
-      .map((m) => m[1])
-      .join("\n")
-      .replace(/\s+/g, " ")
-      .toLowerCase();
-    expect(comments, "the `.thumb` rationale must name the padding-edge trap").toMatch(
-      /padding edge/,
-    );
-    expect(comments, "the `.thumb` rationale must name the 0x0 shrink-to-fit trap").toMatch(
-      /inset: 0/,
-    );
-    expect(comments, "the `.mode-toggle` rationale must warn off `minmax(0, 1fr)`").toMatch(
-      /minmax\(0, 1fr\)/,
-    );
   });
 });

--- a/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
+++ b/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
@@ -1,0 +1,238 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * ModeToggle sliding-thumb geometry gate (#1383, #1384).
+ *
+ * Both issues are one defect. `.mode-toggle` asked flexbox to split the track
+ * in half (`flex: 1 1 0`) and `.thumb` sized itself to that assumed half
+ * (`width: calc(50% - 2px)`). Flexbox never delivered it: a flex item's
+ * automatic minimum size is its **min-content** size, and "Tandem" is a single
+ * unbreakable word, so its segment was clamped up to its natural width and
+ * "Solo" took whatever was left. Measured under the shipped SN Pro face:
+ *
+ *              before                      after
+ *   solo seg   50.53px  }  unequal        67.83px  }  equal
+ *   tandem seg 67.83px  }                 67.83px  }
+ *   thumb      59.17px                    67.83px
+ *   thumb vs active button   dL/dR up to 8.64px    0.00 on all four edges
+ *   label ink vs thumb centre     4.32px off       0.00
+ *   track                    124.36 x 26px         141.66 x 26px (+17.30 wide)
+ *
+ * The overhang is #1384 directly. #1383 is the same error seen from the user's
+ * side: the label is centred in its *button*, but the button is invisible and
+ * the thumb is what the eye reads, so the ink lands half the mismatch off the
+ * pill's centre.
+ *
+ * The fix removes the arithmetic rather than correcting it. The segments became
+ * the two equal columns of an `inline-grid`, and the thumb is *placed into*
+ * grid area 1/1/2/2 with `inset: 0`, so its box IS the first segment's box.
+ *
+ * **This file pins CSS shape, not effect.** No vitest project in this repo has
+ * a layout engine: the `client` project is happy-dom (vitest.config.ts:29) and
+ * this file lands in the `node` project (:44-45) with no DOM at all, where
+ * `getBoundingClientRect` cannot answer anything. The geometric truth is only
+ * observable in a real browser, which is `tests/e2e/mode-toggle-geometry.spec.ts`.
+ * The third axis — what the *built* CSS looks like after lightningcss — is
+ * covered in `css-pipeline-contract.test.ts`, the only gate that runs the real
+ * minifier.
+ *
+ * A shape gate can red for the right reason and the wrong one. Every failure
+ * message below states the invariant, so that a deliberate re-formulation is
+ * fixed by updating the pin rather than by routing around it.
+ *
+ * **Comments are stripped before every grep, and that is mandatory rather than
+ * stylistic.** The rules being pinned carry long rationale comments that quote
+ * the very literals scanned for here (`grid-area: 1 / 1`, `calc(50% - 2px)`) —
+ * the file carried `calc(50% - 2px)` in a comment even before this change. An
+ * un-stripped scan reds on the prose, and the path of least resistance under
+ * time pressure is deleting the prose. That is exactly how the first attempt at
+ * #1383 shipped a comment asserting a property that had never been true, so one
+ * test below asserts the prose is still there.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const MODE_TOGGLE = join(ROOT, "src", "client", "editor", "toolbar", "ModeToggle.svelte");
+
+/** Strip CSS block comments so commented-out prose can't trip the greps. */
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+function styleBlock(): string {
+  const src = readFileSync(MODE_TOGGLE, "utf-8");
+  return [...src.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]).join("\n");
+}
+
+/**
+ * Brace scanner in the shape of `backdrop-filter-guard.test.ts`'s
+ * `floatingPillRulesIn`. Rules are matched by EXACT selector, never substring:
+ * `.thumb.tandem` legitimately declares `translateX(100%)`, and a broadened
+ * "no percentages in .thumb" pattern would swallow it and flag a correct
+ * declaration. `@media` wrappers are fine — the inner rule is recovered with
+ * its own selector.
+ */
+function rules(): { selector: string; body: string }[] {
+  return [...stripCssComments(styleBlock()).matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => ({
+    selector: m[1].trim(),
+    body: m[2],
+  }));
+}
+
+function ruleWithSelector(selector: string): string {
+  const found = rules().filter((r) => r.selector === selector);
+  expect(found.length, `no rule with selector \`${selector}\` — scanner desynced?`).toBeGreaterThan(
+    0,
+  );
+  return found.map((r) => r.body).join("\n");
+}
+
+/**
+ * The `.thumb` selector appears twice: the base rule and the reduced-motion
+ * override inside `@media (prefers-reduced-motion: reduce)`, which declares
+ * only `transition: none`. The base one is the rule that paints — anchoring on
+ * `background` keeps this independent of the placement properties under test.
+ */
+function thumbBaseRule(): string {
+  const candidates = rules().filter(
+    (r) => r.selector === ".thumb" && /background\s*:/.test(r.body),
+  );
+  expect(
+    candidates.length,
+    "no painting `.thumb` rule found — the base rule was renamed, removed, or the scanner desynced",
+  ).toBe(1);
+  return candidates[0].body;
+}
+
+describe(".mode-toggle: the equal-segment premise the thumb rests on", () => {
+  it("lays the segments out as two grid columns, not flex items", () => {
+    const body = ruleWithSelector(".mode-toggle");
+    expect(
+      body,
+      "#1383/#1384: `flex: 1 1 0` does NOT equalize these segments — a flex item's " +
+        "automatic minimum size is its min-content size, so the longer 'Tandem' label wins " +
+        "and the half-width thumb then matches neither segment.",
+    ).toMatch(/display\s*:\s*inline-grid/);
+    expect(body).toMatch(/grid-template-columns\s*:\s*repeat\(\s*2\s*,\s*1fr\s*\)/);
+  });
+
+  it("sizes those columns with a bare 1fr, never minmax(0, …)", () => {
+    // Every other grid in src/client writes `minmax(0, 1fr)` (HelpModal,
+    // SettingsModal, SettingsAboutTab, editor-stage), so normalizing to the
+    // house style is the natural /simplify pass. Here the `auto` minimum that
+    // plain `1fr` carries IS the fix: with a 0 minimum a column can be squeezed
+    // back under its own label and both issues reopen.
+    const columns = /grid-template-columns\s*:([^;]+)/.exec(ruleWithSelector(".mode-toggle"))?.[1];
+    expect(columns, "no grid-template-columns declaration").toBeDefined();
+    expect(
+      columns,
+      "#1383/#1384: `1fr` here means `minmax(auto, 1fr)`, and the auto minimum is what stops " +
+        "a column being squeezed narrower than its label. Do not normalize to `minmax(0, 1fr)`.",
+    ).not.toContain("minmax(0");
+  });
+
+  it("stays the thumb's containing block", () => {
+    expect(
+      ruleWithSelector(".mode-toggle"),
+      "Measured: without `position: relative` the absolutely-positioned thumb takes the " +
+        "VIEWPORT as its containing block and sizes itself against it. Nothing warns.",
+    ).toMatch(/position\s*:\s*relative/);
+  });
+
+  it("keeps the column gutter at zero", () => {
+    const body = ruleWithSelector(".mode-toggle");
+    expect(body).toMatch(/gap\s*:\s*0(?![.\d])/);
+    const nonZero = [...body.matchAll(/(?:^|[;\s])(?:row-|column-)?gap\s*:\s*([^;]+)/g)]
+      .map((m) => m[1].trim())
+      .filter((v) => !/^0(?:[a-z%]*)?$/.test(v));
+    expect(
+      nonZero,
+      "the thumb slides by exactly one column (`translateX(100%)`); any gutter desyncs " +
+        "that translate from the column pitch and the pill lands short of the segment.",
+    ).toEqual([]);
+  });
+
+  it("declares no width rule on the buttons", () => {
+    // `flex: 1 1 0` was the false-premise line. It is dead under grid anyway,
+    // and re-adding any width rule here would re-open the question the grid
+    // columns now answer.
+    const body = ruleWithSelector(".mode-toggle button");
+    expect(body).not.toMatch(/(?:^|[;\s])flex\s*:/);
+    expect(body).not.toMatch(/(?:^|[;\s])width\s*:/);
+  });
+});
+
+describe(".thumb: placed into the first segment, never computed from it", () => {
+  it("names all four grid lines", () => {
+    expect(
+      thumbBaseRule(),
+      "#1384: for an ABSOLUTELY-POSITIONED grid child an `auto` end line resolves to the " +
+        "container's padding edge, NOT to `span 1` — so a two-line `grid-area: 1 / 1` " +
+        "silently stretches the thumb across the whole track. Write all four lines.",
+    ).toMatch(/grid-area\s*:\s*1\s*\/\s*1\s*\/\s*2\s*\/\s*2/);
+  });
+
+  it("declares inset: 0", () => {
+    expect(
+      thumbBaseRule(),
+      "#1384: without `inset`, the absolutely-positioned box shrink-to-fits its (empty) " +
+        "contents and renders 0x0. The grid placement alone does not size it.",
+    ).toMatch(/inset\s*:\s*0(?![.\d])/);
+  });
+
+  it("carries no percentage-derived sizing", () => {
+    const offenders = rules()
+      .filter((r) => r.selector === ".thumb")
+      .flatMap((r) => [
+        ...r.body.matchAll(/(?:^|[;\s])(width|height|left|right|top|bottom)\s*:[^;]*(%|calc\()/g),
+      ])
+      .map((m) => m[0].trim());
+    expect(
+      offenders,
+      "#1383/#1384 were caused by sizing the thumb as a fraction of the track " +
+        "(`width: calc(50% - 2px)`), which assumed equal halves the layout never produced. " +
+        "The grid area supplies the box; see derived-spec.md §3.9.",
+    ).toEqual([]);
+  });
+
+  it("still slides exactly one column on a mode flip", () => {
+    // Guards the extraction above as much as the declaration: this legal
+    // percentage lives one selector away from a rule that must contain none,
+    // and a substring-matched scanner would flag it.
+    expect(ruleWithSelector(".thumb.tandem")).toMatch(/transform\s*:\s*translateX\(\s*100%\s*\)/);
+  });
+
+  it("still paints the pill it exists to paint", () => {
+    // Guards every gate above from being "passed" by deleting the rule.
+    const body = thumbBaseRule();
+    expect(body).toMatch(/position\s*:\s*absolute/);
+    expect(body).toMatch(/background\s*:/);
+    expect(body).toMatch(/border-radius\s*:/);
+    expect(body).toMatch(/box-shadow\s*:/);
+    expect(body).toMatch(/pointer-events\s*:\s*none/);
+  });
+});
+
+describe("the rationale that keeps this from being reintroduced", () => {
+  it("still explains the padding-edge and inset traps in prose", () => {
+    // The positive half of the comment-stripping rule at the top of this file.
+    // Both traps fail silently and neither is inferable from the declarations,
+    // so the comment is load-bearing documentation, not decoration — and it is
+    // the thing a reader under time pressure deletes to make a grep go green.
+    const comments = [...styleBlock().matchAll(/\/\*([\s\S]*?)\*\//g)]
+      .map((m) => m[1])
+      .join("\n")
+      .replace(/\s+/g, " ")
+      .toLowerCase();
+    expect(comments, "the `.thumb` rationale must name the padding-edge trap").toMatch(
+      /padding edge/,
+    );
+    expect(comments, "the `.thumb` rationale must name the 0x0 shrink-to-fit trap").toMatch(
+      /inset: 0/,
+    );
+    expect(comments, "the `.mode-toggle` rationale must warn off `minmax(0, 1fr)`").toMatch(
+      /minmax\(0, 1fr\)/,
+    );
+  });
+});

--- a/tests/e2e/mode-toggle-geometry.spec.ts
+++ b/tests/e2e/mode-toggle-geometry.spec.ts
@@ -1,0 +1,245 @@
+import { expect, type Page, test } from "@playwright/test";
+import path from "path";
+import {
+  cleanupAllOpenDocuments,
+  cleanupFixtureDir,
+  createFixtureDir,
+  McpTestClient,
+} from "./helpers";
+
+/**
+ * ModeToggle sliding-thumb geometry (#1383, #1384).
+ *
+ * This is the only gate that can see the thing the two issues are actually
+ * about. `mode-toggle-thumb-contract.test.ts` pins the CSS *shape* and
+ * `css-pipeline-contract.test.ts` pins what lightningcss does to it, but
+ * neither can measure a box: no vitest project in this repo has a layout
+ * engine (the client project is happy-dom, and the contract test lands in the
+ * node project with no DOM at all), so `getBoundingClientRect` returns zeros
+ * there. The geometric truth is only observable in a real browser.
+ *
+ * What it is measuring, under the shipped SN Pro face:
+ *
+ *                              before          after
+ *   solo segment               50.53px         67.83px
+ *   tandem segment             67.83px         67.83px   (equal by construction)
+ *   thumb                      59.17px         67.83px
+ *   thumb vs active button     up to 8.64px    0.00 on all four edges
+ *   label ink vs thumb centre  4.32px          0.00
+ *
+ * `flex: 1 1 0` never equalized the segments — a flex item's automatic minimum
+ * size is its min-content size, so "Tandem" (one unbreakable word) kept its
+ * natural width and "Solo" took the remainder. The half-width thumb then
+ * matched neither, which is #1384; the label looking off-centre is that same
+ * mismatch seen from the user's side (#1383), because the button is invisible
+ * and the pill is what the eye reads.
+ *
+ * The segment-equality assertion is kept separate from the edge assertions on
+ * purpose: it is the root cause, so a regression should name itself rather than
+ * only report its symptom.
+ */
+
+test.describe.configure({ timeout: 90_000 });
+
+let mcp: McpTestClient;
+let tmpDir: string;
+
+test.beforeEach(async () => {
+  mcp = new McpTestClient();
+  await mcp.connect();
+  tmpDir = createFixtureDir("sample.md");
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+});
+
+test.afterEach(async () => {
+  await cleanupAllOpenDocuments(mcp);
+  await mcp.close();
+  cleanupFixtureDir(tmpDir);
+});
+
+async function boot(page: Page) {
+  await page.goto("/");
+  await page.locator(".tandem-editor").waitFor({ state: "visible", timeout: 15_000 });
+  await page.locator("[data-testid='mode-toggle']").waitFor({ state: "visible", timeout: 10_000 });
+  // SN Pro ships `font-display: swap` (index.html), and the swap CHANGES these
+  // metrics — measured 50.00 -> 50.53 on the solo segment, 123.39 -> 124.36 on
+  // the track. Every assertion below uses an absolute px tolerance and
+  // `expect.poll` re-evaluates, so a pre-swap sample and a post-swap sample
+  // would be describing two different layouts.
+  await page.evaluate(() => document.fonts.ready);
+}
+
+type Geometry = {
+  soloW: number;
+  tandemW: number;
+  thumbW: number;
+  dL: number;
+  dR: number;
+  dT: number;
+  dB: number;
+  inkDelta: number;
+};
+
+/**
+ * All measurements in one round trip, taken against whichever button is
+ * currently pressed, so the same helper covers `.thumb` and `.thumb.tandem`.
+ */
+function measure(page: Page): Promise<Geometry> {
+  return page.evaluate(() => {
+    const q = <T extends Element>(sel: string): T => {
+      const el = document.querySelector<T>(sel);
+      if (!el) throw new Error(`missing ${sel}`);
+      return el;
+    };
+    const thumb = q<HTMLElement>(".mode-toggle .thumb");
+    const solo = q<HTMLElement>("[data-testid='mode-solo-btn']");
+    const tandem = q<HTMLElement>("[data-testid='mode-tandem-btn']");
+    const active = tandem.getAttribute("aria-pressed") === "true" ? tandem : solo;
+
+    const t = thumb.getBoundingClientRect();
+    const a = active.getBoundingClientRect();
+    // A Range over the button's contents is the label's INK box — the button's
+    // own box is padded and is not what the eye compares against the pill.
+    const range = document.createRange();
+    range.selectNodeContents(active);
+    const ink = range.getBoundingClientRect();
+
+    return {
+      soloW: solo.getBoundingClientRect().width,
+      tandemW: tandem.getBoundingClientRect().width,
+      thumbW: t.width,
+      dL: t.left - a.left,
+      dR: t.right - a.right,
+      dT: t.top - a.top,
+      dB: t.bottom - a.bottom,
+      inkDelta: (ink.left + ink.right) / 2 - (t.left + t.right) / 2,
+    };
+  });
+}
+
+/**
+ * Polls, so the 220ms slide settles without a bare sleep. Asserted as a single
+ * object so a failure reports all four edges at once — a thumb that is off on
+ * `left` and `right` by the same amount is a translate bug, while one off on
+ * `right` alone is a sizing bug, and that distinction is the whole diagnosis.
+ */
+async function expectThumbFlush(page: Page, label: string) {
+  await expect
+    .poll(
+      async () => {
+        const g = await measure(page);
+        return (["dL", "dR", "dT", "dB"] as const)
+          .filter((k) => Math.abs(g[k]) >= 0.5)
+          .map((k) => `${k}=${g[k].toFixed(2)}`);
+      },
+      {
+        timeout: 5_000,
+        message:
+          `${label}: the sliding pill does not cover the selected segment (#1384). ` +
+          `The thumb is placed into grid area 1/1/2/2 of the track, so any non-zero edge ` +
+          `delta means the segments are no longer equal columns or the placement was lost.`,
+      },
+    )
+    .toEqual([]);
+}
+
+test("the two segments are exactly equal", async ({ page }) => {
+  await boot(page);
+  const g = await measure(page);
+  expect(
+    Math.abs(g.soloW - g.tandemW),
+    `#1383/#1384 root cause: solo=${g.soloW.toFixed(2)} tandem=${g.tandemW.toFixed(2)}. ` +
+      `The thumb assumes the segments are the grid's two equal 1fr columns; ` +
+      `\`flex: 1 1 0\` does NOT produce that, because a flex item cannot be squeezed ` +
+      `below its own min-content width.`,
+  ).toBeLessThan(0.5);
+  // Guards against a "pass" where both segments collapsed to nothing.
+  expect(g.soloW).toBeGreaterThan(10);
+});
+
+test("the pill covers the selected segment in tandem mode (the default)", async ({ page }) => {
+  await boot(page);
+  await expect(page.locator("[data-testid='mode-tandem-btn']")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  // Before the fix this failed by ~8.6px on the LEFT: the thumb was a half of
+  // the track, translated by its own width, landing inside the wider segment.
+  await expectThumbFlush(page, "tandem (resting state)");
+});
+
+test("the pill covers the selected segment after switching to solo, and back", async ({ page }) => {
+  await boot(page);
+
+  await page.locator("[data-testid='mode-solo-btn']").click();
+  await expect(page.locator("[data-testid='mode-solo-btn']")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  // Before the fix this failed by ~8.6px on the RIGHT — the untranslated thumb
+  // overhung the narrower "Solo" segment.
+  await expectThumbFlush(page, "solo");
+
+  await page.locator("[data-testid='mode-tandem-btn']").click();
+  await expect(page.locator("[data-testid='mode-tandem-btn']")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  // Re-asserted after an actual slide, so `.thumb.tandem`'s translate is
+  // covered independently of the resting state it happens to share.
+  await expectThumbFlush(page, "tandem (after a slide)");
+});
+
+test("the active label sits centered in the pill, in both modes", async ({ page }) => {
+  await boot(page);
+
+  // #1383 exactly as reported. The label always was centred in its BUTTON; what
+  // the user sees it centred against is the pill, and those were 4.32px apart.
+  for (const mode of ["tandem", "solo"] as const) {
+    if (mode === "solo") await page.locator("[data-testid='mode-solo-btn']").click();
+    await expect(page.locator(`[data-testid='mode-${mode}-btn']`)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect
+      .poll(async () => Math.abs((await measure(page)).inkDelta) < 0.75, {
+        timeout: 5_000,
+        message: `#1383: the ${mode} label's ink is off the pill's centre by more than 0.75px`,
+      })
+      .toBe(true);
+  }
+});
+
+test("the widened toggle still fits a narrow viewport", async ({ page }) => {
+  // Equalizing the segments widens the control by ~17.3px ("Solo" grew to match
+  // "Tandem"), and the toggle sits at the right-hand end of the title bar.
+  //
+  // SCOPE: this covers the BROWSER layout only. `isTauriRuntime()` is false
+  // here, so `.title-bar-mode` never gets `.native-window-row` and the three
+  // native window-control buttons plus `.title-bar-spacer-sm` are not rendered
+  // at all. The desktop row is the TIGHTER case and is the row this control was
+  // deliberately pinned into — it is covered by the manual `cargo tauri dev`
+  // step, not by this assertion. Do not read this as pinning the desktop case.
+  await boot(page);
+  await page.setViewportSize({ width: 600, height: 800 });
+  await page.evaluate(() => document.fonts.ready);
+
+  const fits = await page.evaluate(() => {
+    const el = document.querySelector(".mode-toggle");
+    if (!el) throw new Error("missing .mode-toggle");
+    const r = el.getBoundingClientRect();
+    return {
+      left: r.left,
+      right: r.right,
+      width: window.innerWidth,
+      visible: r.width > 0 && r.height > 0,
+    };
+  });
+
+  expect(fits.visible, "the toggle collapsed to zero at 600px").toBe(true);
+  expect(fits.left).toBeGreaterThanOrEqual(0);
+  expect(
+    fits.right,
+    `the toggle overflows the 600px viewport (right edge ${fits.right.toFixed(1)} of ${fits.width})`,
+  ).toBeLessThanOrEqual(fits.width);
+});

--- a/tests/e2e/mode-toggle-geometry.spec.ts
+++ b/tests/e2e/mode-toggle-geometry.spec.ts
@@ -1,11 +1,4 @@
 import { expect, type Page, test } from "@playwright/test";
-import path from "path";
-import {
-  cleanupAllOpenDocuments,
-  cleanupFixtureDir,
-  createFixtureDir,
-  McpTestClient,
-} from "./helpers";
 
 /**
  * ModeToggle sliding-thumb geometry (#1383, #1384).
@@ -14,11 +7,9 @@ import {
  * about. `mode-toggle-thumb-contract.test.ts` pins the CSS *shape* and
  * `css-pipeline-contract.test.ts` pins what lightningcss does to it, but
  * neither can measure a box: no vitest project in this repo has a layout
- * engine (the client project is happy-dom, and the contract test lands in the
- * node project with no DOM at all), so `getBoundingClientRect` returns zeros
- * there. The geometric truth is only observable in a real browser.
+ * engine, so `getBoundingClientRect` returns zeros there.
  *
- * What it is measuring, under the shipped SN Pro face:
+ * Measured under the shipped SN Pro face:
  *
  *                              before          after
  *   solo segment               50.53px         67.83px
@@ -34,28 +25,12 @@ import {
  * mismatch seen from the user's side (#1383), because the button is invisible
  * and the pill is what the eye reads.
  *
- * The segment-equality assertion is kept separate from the edge assertions on
- * purpose: it is the root cause, so a regression should name itself rather than
- * only report its symptom.
+ * No document fixture: the toggle lives in the title bar and renders without
+ * one. Opening a fixture over MCP was measured at ~1.3s per test for geometry
+ * that is byte-identical either way.
  */
 
 test.describe.configure({ timeout: 90_000 });
-
-let mcp: McpTestClient;
-let tmpDir: string;
-
-test.beforeEach(async () => {
-  mcp = new McpTestClient();
-  await mcp.connect();
-  tmpDir = createFixtureDir("sample.md");
-  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
-});
-
-test.afterEach(async () => {
-  await cleanupAllOpenDocuments(mcp);
-  await mcp.close();
-  cleanupFixtureDir(tmpDir);
-});
 
 async function boot(page: Page) {
   await page.goto("/");
@@ -72,7 +47,6 @@ async function boot(page: Page) {
 type Geometry = {
   soloW: number;
   tandemW: number;
-  thumbW: number;
   dL: number;
   dR: number;
   dT: number;
@@ -107,7 +81,6 @@ function measure(page: Page): Promise<Geometry> {
     return {
       soloW: solo.getBoundingClientRect().width,
       tandemW: tandem.getBoundingClientRect().width,
-      thumbW: t.width,
       dL: t.left - a.left,
       dR: t.right - a.right,
       dT: t.top - a.top,
@@ -128,9 +101,15 @@ async function expectThumbFlush(page: Page, label: string) {
     .poll(
       async () => {
         const g = await measure(page);
-        return (["dL", "dR", "dT", "dB"] as const)
+        const off = (["dL", "dR", "dT", "dB"] as const)
           .filter((k) => Math.abs(g[k]) >= 0.5)
           .map((k) => `${k}=${g[k].toFixed(2)}`);
+        // #1383 rides along: the label is always centred in its BUTTON, so with
+        // symmetric padding the ink delta is -(dL+dR)/2 and cannot fail while
+        // the edges hold — EXCEPT if `justify-content: center` is removed, which
+        // is a real #1383-shaped regression the edge deltas would not see.
+        if (Math.abs(g.inkDelta) >= 0.75) off.push(`inkDelta=${g.inkDelta.toFixed(2)}`);
+        return off;
       },
       {
         timeout: 5_000,
@@ -143,22 +122,24 @@ async function expectThumbFlush(page: Page, label: string) {
     .toEqual([]);
 }
 
-test("the two segments are exactly equal", async ({ page }) => {
+test("the segments are equal and the pill covers the selected one (tandem default)", async ({
+  page,
+}) => {
   await boot(page);
+
+  // The root cause, asserted first so a regression names itself rather than
+  // only reporting its symptom.
   const g = await measure(page);
   expect(
     Math.abs(g.soloW - g.tandemW),
     `#1383/#1384 root cause: solo=${g.soloW.toFixed(2)} tandem=${g.tandemW.toFixed(2)}. ` +
-      `The thumb assumes the segments are the grid's two equal 1fr columns; ` +
-      `\`flex: 1 1 0\` does NOT produce that, because a flex item cannot be squeezed ` +
-      `below its own min-content width.`,
+      `The thumb IS the track's first column, so unequal segments put it on a segment of a ` +
+      `different width. \`flex: 1 1 0\` never produced equal columns, because a flex item ` +
+      `cannot be squeezed below its own min-content width.`,
   ).toBeLessThan(0.5);
   // Guards against a "pass" where both segments collapsed to nothing.
   expect(g.soloW).toBeGreaterThan(10);
-});
 
-test("the pill covers the selected segment in tandem mode (the default)", async ({ page }) => {
-  await boot(page);
   await expect(page.locator("[data-testid='mode-tandem-btn']")).toHaveAttribute(
     "aria-pressed",
     "true",
@@ -190,26 +171,6 @@ test("the pill covers the selected segment after switching to solo, and back", a
   await expectThumbFlush(page, "tandem (after a slide)");
 });
 
-test("the active label sits centered in the pill, in both modes", async ({ page }) => {
-  await boot(page);
-
-  // #1383 exactly as reported. The label always was centred in its BUTTON; what
-  // the user sees it centred against is the pill, and those were 4.32px apart.
-  for (const mode of ["tandem", "solo"] as const) {
-    if (mode === "solo") await page.locator("[data-testid='mode-solo-btn']").click();
-    await expect(page.locator(`[data-testid='mode-${mode}-btn']`)).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    await expect
-      .poll(async () => Math.abs((await measure(page)).inkDelta) < 0.75, {
-        timeout: 5_000,
-        message: `#1383: the ${mode} label's ink is off the pill's centre by more than 0.75px`,
-      })
-      .toBe(true);
-  }
-});
-
 test("the widened toggle still fits a narrow viewport", async ({ page }) => {
   // Equalizing the segments widens the control by ~17.3px ("Solo" grew to match
   // "Tandem"), and the toggle sits at the right-hand end of the title bar.
@@ -222,7 +183,6 @@ test("the widened toggle still fits a narrow viewport", async ({ page }) => {
   // step, not by this assertion. Do not read this as pinning the desktop case.
   await boot(page);
   await page.setViewportSize({ width: 600, height: 800 });
-  await page.evaluate(() => document.fonts.ready);
 
   const fits = await page.evaluate(() => {
     const el = document.querySelector(".mode-toggle");
@@ -237,7 +197,6 @@ test("the widened toggle still fits a narrow viewport", async ({ page }) => {
   });
 
   expect(fits.visible, "the toggle collapsed to zero at 600px").toBe(true);
-  expect(fits.left).toBeGreaterThanOrEqual(0);
   expect(
     fits.right,
     `the toggle overflows the 600px viewport (right edge ${fits.right.toFixed(1)} of ${fits.width})`,


### PR DESCRIPTION
Two reported defects, one cause. The Solo/Tandem toggle's labels looked off-centre (#1383) and its sliding selection pill didn't match the button sizes (#1384).

## Cause

`.mode-toggle` asked flexbox to split the track in half (`flex: 1 1 0`) and `.thumb` sized itself to that assumed half (`width: calc(50% - 2px)`).

**Flexbox never delivered it.** A flex item's automatic minimum size is its **min-content** size, and "Tandem" is a single unbreakable word — so its segment was clamped up to its natural width and "Solo" took whatever was left. Measured under the shipped SN Pro face: **50.53px vs 67.83px.**

The half-width pill then matched neither segment, overhanging by up to 8.64px. That is #1384 directly. #1383 is the same error seen from the user's side: the label *is* centred in its button, but the button is invisible and the pill is what the eye reads, so the ink landed ~4.32px off the pill's centre.

## Fix

The arithmetic is removed rather than corrected. The segments become the two equal columns of an `inline-grid`, and the thumb is **placed into** grid area 1/1/2/2 with `inset: 0` — so its box *is* the first segment's box, to the pixel, and it cannot drift from what it indicates.

```css
.mode-toggle {
  display: inline-grid;
  grid-template-columns: repeat(2, minmax(0, 1fr));
  position: relative;
  gap: 0;
}
.thumb {
  position: absolute;
  grid-area: 1 / 1 / 2 / 2;
  inset: 0;
}
```

Two traps in that placement, both silent:

- **All four grid lines must be written out.** For an absolutely-positioned grid child an `auto` end line resolves to the container's **padding edge**, not `span 1` — so `grid-area: 1 / 1` stretches the thumb across the whole track. Nothing warns.
- **`inset: 0` is required.** Without it the abspos box shrink-to-fits its empty contents and renders 0×0. Grid placement alone does not size it.

## The `/simplify` pass found the rationale was backwards

Worth reading even if you skip the rest, because it changed the code.

The original fix used a bare `1fr` and its comment asserted that the `auto` minimum this carries **"IS the fix"**, warning against normalizing to the codebase's usual `minmax(0, 1fr)`. Two review lenses independently flagged this. I measured it in Chromium against the real nesting rather than trusting either:

| Track form | Width | Solo | Tandem | Equal? |
|---|---|---|---|---|
| `repeat(2, 1fr)` | unconstrained (shipped) | 70.97 | 70.97 | yes |
| `repeat(2, minmax(0, 1fr))` | unconstrained (shipped) | 70.97 | 70.97 | **identical** |
| `repeat(2, 1fr)` | capped at 120px | **52.00** | **70.97** | **no** |
| `repeat(2, minmax(0, 1fr))` | capped at 120px | 60.00 | 60.00 | yes |

Two conclusions, both against the original claim:

1. **In the shipped layout the two forms are byte-identical.** `.mode-toggle` is shrink-to-fit, so the track sizes to max-content and the `auto` minimum never binds. It was inert.
2. **Under compression, bare `1fr` is the form that reopens #1384.** The thumb *is* column 1, so unequal columns place it on a segment of a different width — exactly the bug.

The original inequality came from **flex's** automatic minimum size, not from a 0 minimum; the two were conflated. Switched to `minmax(0, 1fr)`, which holds the invariant at every width. The trade is stated rather than hidden: a squeezed label can outgrow its column, and a visibly overflowing label beats a silently misplaced pill.

The claim was wrong in **four places** — component comment, spec, contract test, and a pipeline test. All four now agree with the measurement, and the contract test asserts the opposite of what it did, with the figures in its failure message.

## Three test axes, none able to see the others

| Axis | File | Why the others can't cover it |
|---|---|---|
| CSS **shape** | `mode-toggle-thumb-contract.test.ts` | Fast, no browser |
| Rendered **geometry** | `tests/e2e/mode-toggle-geometry.spec.ts` | No vitest project here has a layout engine — `getBoundingClientRect` returns zeros |
| **Built** CSS | `css-pipeline-contract.test.ts` | CI's Playwright run drives `npm run dev`, which never minifies |

That third gap is not hypothetical: it is how #1189 shipped inert for six weeks.

**Shape vs invariant is now marked.** Four gates pin the current authoring shape and carry a SUPERSEDED-not-violated note, matching the #1424 precedent — if a better placement mechanism arrives, delete them rather than re-satisfying them. The two that pin genuine invariants ("no percentage-derived sizing", "no width rule on the buttons") carry no such note, because they survive any correct implementation.

## What `/simplify` removed

- **Tests that could not fail.** Three of four new lightningcss cases: lightningcss *collapses* longhands into `inset: 0` rather than exploding it; `minmax(auto, 1fr)` → `minmax(0, 1fr)` is a semantic change no minifier performs; and a percentage in `translateX` can't be resolved without a box. The `grid-area` case stays — a collapse to `1 / 1` is legal and silently stretches an abspos child.
- **A test asserting English substrings** in the CSS comments. It cannot detect a comment that says something *false* — which is exactly what happened here — while taxing every rewording. It would have reddened on this commit, for a comment that was wrong.
- **The E2E spec's MCP document fixture.** No test read the document; the toggle is in the title bar and renders without one. ~1.3s per test.
- **5 tests → 3.** Segment equality never fired independently of the flush assertion, and label-ink centring is an arithmetic consequence of it under symmetric padding — folded into the flush poll, where it now also covers the post-slide state instead of two resting states. **56.2s → 46.2s.**
- **Browser-version stamps** from the component comment ("Chromium 145, WebKit 26, Firefox 146; WebKit rounds by 0.17px"). `playwright.config.ts` declares no projects, so CI runs Chromium only — two of three browsers and all four versions were unenforced one-off readings. Replaced with a pointer to the spec that re-derives them every run.
- Dead: `thumbW` (measured, never read), a second `document.fonts.ready` after a viewport resize, and `fits.left >= 0`.

## Reuse

The new contract test had forked all three primitives from `tests/helpers/css-source.ts` — comment stripping, the `<style>` extractor, and the rule splitter — which landed on master hours earlier in #1424 to end exactly that. Now imports them.

That module's header states the reason: a stale copy of the extractor doesn't fail loudly, it extracts `""`, finds zero offenders and reports **green**. The worst possible property for a file whose only job is to red.

I also adopted `cssRules` in `backdrop-filter-guard.test.ts` and the two remaining sites in `css-pipeline-contract.test.ts`. I extracted it in #1424 and then left them hand-rolling it — the same argument applies to me.

## Spec change

`derived-spec.md` §3.9 was restated at outcome altitude. It was the only anti-pattern in that document naming CSS property values, and it carried the inverted `minmax` rationale in the place readers treat as authoritative. It now reads *"the pill must be positioned by whatever mechanism sizes the segments, so the two cannot desync"* — which survives a redesign and is what the E2E spec actually asserts.

## Verification

- `npm run typecheck` — 1323 files, **0 errors**; `npx eslint` — **0 errors**
- `npm test -- --run` — **459 files, 6663 passed**, 19 skipped
- `npx playwright test mode-toggle-geometry` — **3 passed** (46.2s)
- Mutation-tested the corrected gate: reverting to bare `1fr` fails it, with the measured 52/70.97 vs 60/60 figures in the message

## Not covered here

The E2E narrow-viewport test pins the **browser** layout only. `isTauriRuntime()` is false there, so `.title-bar-mode` never gets `.native-window-row` and the three native window-control buttons aren't rendered. The desktop row is the *tighter* case and the one this control was pinned into — worth a look under `cargo tauri dev`, since equalizing the segments widens the control by ~17.3px.

Closes #1383
Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYGFawL9kQruDZiUkYGBKD
