### PR TITLE
fix(ui): correct the mode-toggle rationale and gate the case it argues about

### DIFF
--- a/docs/design-system-impl/derived-spec.md
+++ b/docs/design-system-impl/derived-spec.md
@@ -241,15 +241,18 @@ Each row:
   ModeToggle's middle "Tandem" label on narrow viewports; the toggle is
   semantically a 2-position segmented control and label is the
   affordance. Do NOT let the ModeToggle thumb derive its own geometry
-  from the track — no percentages, no `calc`, no measured JS. The pill
-  must be positioned by whatever mechanism sizes the segments, so the
-  two cannot desync, and the segments must stay equal at every width.
-  #1383 and #1384 were one desync seen from two sides: `flex: 1 1 0`
-  never equalized the segments (a flex item's automatic minimum size is
-  its min-content size, so the longer "Tandem" label wins), and a
-  half-width thumb then matched neither. The current implementation
-  satisfies this with an `inline-grid` track and a placed thumb; the
-  requirement is the invariant, not that mechanism.
+  from the track: the pill must be positioned by whatever mechanism
+  sizes the segments, so the two cannot desync (#1383/#1384, one desync
+  seen from two sides). Concretely, no percentage or `calc` **sizing or
+  positioning** on the thumb, and no measured JS. That ban is
+  deliberately stricter than the invariant above — a percentage thumb
+  over an equalized track can be made correct — because it is the
+  mechanism the two issues arrived through; `translateX(100%)` for the
+  slide itself is not sizing and is fine. The current implementation
+  uses an `inline-grid` track and a placed thumb, but the requirement is
+  the invariant, not that mechanism. Note the invariant holds over a
+  RANGE, not unconditionally: below ~60px the buttons cannot shrink past
+  their own padding and overflow equal columns regardless.
 
 ### 3.10 Annotation decorations — B2 (inline marks)
 

--- a/docs/design-system-impl/derived-spec.md
+++ b/docs/design-system-impl/derived-spec.md
@@ -244,15 +244,12 @@ Each row:
   from the track: the pill must be positioned by whatever mechanism
   sizes the segments, so the two cannot desync (#1383/#1384, one desync
   seen from two sides). Concretely, no percentage or `calc` **sizing or
-  positioning** on the thumb, and no measured JS. That ban is
-  deliberately stricter than the invariant above — a percentage thumb
-  over an equalized track can be made correct — because it is the
-  mechanism the two issues arrived through; `translateX(100%)` for the
-  slide itself is not sizing and is fine. The current implementation
-  uses an `inline-grid` track and a placed thumb, but the requirement is
-  the invariant, not that mechanism. Note the invariant holds over a
-  RANGE, not unconditionally: below ~60px the buttons cannot shrink past
-  their own padding and overflow equal columns regardless.
+  positioning** on the thumb, and no measured JS; `translateX(100%)` for
+  the slide itself is not sizing and is fine. That ban is deliberately
+  stricter than the requirement — a percentage thumb over an equalized
+  track can be made correct — because it is the mechanism the two issues
+  arrived through. The requirement is the invariant, not any particular
+  mechanism.
 
 ### 3.10 Annotation decorations — B2 (inline marks)
 

--- a/src/client/editor/toolbar/ModeToggle.svelte
+++ b/src/client/editor/toolbar/ModeToggle.svelte
@@ -42,18 +42,39 @@ const { tandemMode, onModeChange }: Props = $props();
 <style>
   .mode-toggle {
     display: inline-grid;
-    /* `minmax(0, 1fr)`, not a bare `1fr`. Both measure IDENTICALLY today — the
-       track is shrink-to-fit, so it sizes to max-content and the `auto`
-       minimum never binds. They diverge only under compression, and there the
-       0 minimum is the one that holds this component's whole invariant:
-       measured at a 120px cap, `1fr` gives 52 / 70.97px columns while
-       `minmax(0, 1fr)` gives 60 / 60px. Unequal columns put the thumb (which
-       IS column 1) on a segment of a different width — #1384, reopened. The
-       trade is that a squeezed label can outgrow its column; a visibly
-       overflowing label beats a silently misplaced pill. */
+    /* `minmax(0, 1fr)`, not a bare `1fr` — a GUARD, not the fix, and the
+       distinction is the honest one. Both forms measure identically in the
+       shipped layout (67.83 / 67.83): the track is shrink-to-fit, so it sizes
+       to max-content and the `auto` minimum never binds. Nor can it, today —
+       `.title-bar-mode` is `flex: 0 0 auto` (TitleBar.svelte) and
+       `.title-bar-center` carries `min-width: 0`, so the center strip absorbs
+       every pixel of shrink and this track measures the same at every viewport
+       width; past that the row overflows rather than compressing.
+
+       The forms diverge only once something DOES compress the track, and there
+       the 0 minimum is the one that holds the invariant: measured in-app at a
+       border-box 120px cap, `1fr` gives 51.08 / 67.83 (overflowing the cap)
+       while `minmax(0, 1fr)` gives 57 / 57 — which checks out against the box,
+       57 + 57 + 4px padding + 2px border = 120 exactly. Unequal columns put
+       the thumb (which IS column 1) on a
+       segment of a different width — #1384, reopened. Since no viewport can
+       reach that, the compression case is forced with an injected `max-width`
+       in tests/e2e/mode-toggle-geometry.spec.ts rather than left unpinned.
+
+       Two limits, stated rather than hidden. A squeezed label can outgrow its
+       column — a visibly overflowing label beats a silently misplaced pill.
+       And below ~60px even this form fails: the buttons cannot shrink past
+       their own 28px horizontal padding, so they overflow equal columns and
+       the thumb desyncs again (measured dR = -6.00 at a 50px cap). This widens
+       the range over which the pill tracks its segment; it does not make it
+       unconditional. */
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    /* The thumb's containing block. Measured: remove it and the thumb sizes
-       itself against the viewport. Fails silently. */
+    /* The thumb's containing block. Measured: remove it and the containing
+       block falls through to `.title-bar-mode` (TitleBar.svelte), which is
+       itself `position: relative` — the grid placement stops applying and the
+       thumb covers the whole track with a 3px overhang. Fails silently, and
+       note what that means: this rule's correctness depends on an ancestor
+       rule in another file. */
     position: relative;
     /* Bundle's `.a8 .seg` recipe: 2px track padding + a 1px border so the
        segmented control reads as a chip rather than a recessed plate. The
@@ -78,14 +99,20 @@ const { tandemMode, onModeChange }: Props = $props();
 
        - ALL FOUR grid lines must be written out. On an absolutely-positioned
          grid child an `auto` end line resolves to the container's PADDING
-         EDGE, not to `span 1`, so a two-line `grid-area: 1 / 1` stretches the
-         thumb across the entire track. Measured; nothing warns.
+         EDGE, not to `span 1`. Measured, a two-line `grid-area: 1 / 1` breaks
+         BOTH axes: width 136.78 vs 67.39 and height 23 vs 21, the second being
+         the track's 2px of vertical padding. The row half is the non-obvious
+         one — there is no `grid-template-rows`, so row line 2 lives in the
+         IMPLICIT grid and reads as decorative. It is what holds the bottom
+         edge flush. Nothing warns about either.
        - `inset: 0` is required. Without it the abspos box shrink-to-fits and
          renders 0x0.
 
-     Flushness is measured, not asserted here — tests/e2e/mode-toggle-geometry
-     .spec.ts. Minifier survival is pinned in css-pipeline-contract.test.ts,
-     because CI's Playwright run drives `npm run dev`, which never minifies. */
+     Flushness is measured, not asserted here — see
+     tests/e2e/mode-toggle-geometry.spec.ts (kept on one line: a rename sweep
+     greps for the whole filename). Minifier survival is pinned in
+     css-pipeline-contract.test.ts, because CI's Playwright run drives
+     `npm run dev`, which never minifies. */
   .thumb {
     position: absolute;
     grid-area: 1 / 1 / 2 / 2;
@@ -150,6 +177,11 @@ const { tandemMode, onModeChange }: Props = $props();
   :global(body.tandem-reduce-motion) .thumb {
     transition: none;
   }
+  /* Not cosmetic — this is the ONLY selection indicator in forced-colors mode.
+     Measured there: the thumb's background is forced to the same white as the
+     track and its box-shadow to `none`, so the pill is invisible and the
+     outline is all that distinguishes the active segment. Pinned by
+     tests/e2e/forced-colors.spec.ts. */
   @media (forced-colors: active) {
     .mode-toggle button[aria-pressed="true"] {
       outline: 2px solid ButtonText;

--- a/src/client/editor/toolbar/ModeToggle.svelte
+++ b/src/client/editor/toolbar/ModeToggle.svelte
@@ -42,39 +42,27 @@ const { tandemMode, onModeChange }: Props = $props();
 <style>
   .mode-toggle {
     display: inline-grid;
-    /* `minmax(0, 1fr)`, not a bare `1fr` — a GUARD, not the fix, and the
-       distinction is the honest one. Both forms measure identically in the
-       shipped layout (67.83 / 67.83): the track is shrink-to-fit, so it sizes
-       to max-content and the `auto` minimum never binds. Nor can it, today —
-       `.title-bar-mode` is `flex: 0 0 auto` (TitleBar.svelte) and
-       `.title-bar-center` carries `min-width: 0`, so the center strip absorbs
-       every pixel of shrink and this track measures the same at every viewport
-       width; past that the row overflows rather than compressing.
+    /* `minmax(0, 1fr)`, not a bare `1fr` — a GUARD, not the active fix. Nothing
+       in the shipped title bar can compress this track (`.title-bar-mode` is
+       `flex: 0 0 auto`; `.title-bar-center` carries `min-width: 0` and absorbs
+       all shrink), so both forms measure identically here. They diverge once
+       something DOES compress it: a bare `1fr` floors each column at
+       min-content, and unequal columns put the thumb — which IS column 1 — on a
+       segment of a different width, reopening #1384. Since no viewport reaches
+       that, the E2E spec injects a `max-width` to measure it rather than leave
+       it narrated.
 
-       The forms diverge only once something DOES compress the track, and there
-       the 0 minimum is the one that holds the invariant: measured in-app at a
-       border-box 120px cap, `1fr` gives 51.08 / 67.83 (overflowing the cap)
-       while `minmax(0, 1fr)` gives 57 / 57 — which checks out against the box,
-       57 + 57 + 4px padding + 2px border = 120 exactly. Unequal columns put
-       the thumb (which IS column 1) on a
-       segment of a different width — #1384, reopened. Since no viewport can
-       reach that, the compression case is forced with an injected `max-width`
-       in tests/e2e/mode-toggle-geometry.spec.ts rather than left unpinned.
-
-       Two limits, stated rather than hidden. A squeezed label can outgrow its
-       column — a visibly overflowing label beats a silently misplaced pill.
-       And below ~60px even this form fails: the buttons cannot shrink past
-       their own 28px horizontal padding, so they overflow equal columns and
-       the thumb desyncs again (measured dR = -6.00 at a 50px cap). This widens
-       the range over which the pill tracks its segment; it does not make it
-       unconditional. */
+       The guarantee holds over a range, not unconditionally: the buttons cannot
+       shrink past their own horizontal padding, so a narrow enough track
+       overflows equal columns anyway. The spec asserts where that boundary is;
+       do not restate it here, because a restated boundary is one nothing
+       checks. */
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    /* The thumb's containing block. Measured: remove it and the containing
-       block falls through to `.title-bar-mode` (TitleBar.svelte), which is
-       itself `position: relative` — the grid placement stops applying and the
-       thumb covers the whole track with a 3px overhang. Fails silently, and
-       note what that means: this rule's correctness depends on an ancestor
-       rule in another file. */
+    /* The thumb's containing block, and the reason this rule is load-bearing is
+       non-local: remove it and the containing block falls through to
+       `.title-bar-mode`, which is itself positioned — the grid placement below
+       stops applying entirely, with no warning. Correctness here depends on an
+       ancestor rule in another file. */
     position: relative;
     /* Bundle's `.a8 .seg` recipe: 2px track padding + a 1px border so the
        segmented control reads as a chip rather than a recessed plate. The
@@ -98,21 +86,17 @@ const { tandemMode, onModeChange }: Props = $props();
      Two traps in that placement, both silent if you get them wrong:
 
        - ALL FOUR grid lines must be written out. On an absolutely-positioned
-         grid child an `auto` end line resolves to the container's PADDING
-         EDGE, not to `span 1`. Measured, a two-line `grid-area: 1 / 1` breaks
-         BOTH axes: width 136.78 vs 67.39 and height 23 vs 21, the second being
-         the track's 2px of vertical padding. The row half is the non-obvious
-         one — there is no `grid-template-rows`, so row line 2 lives in the
-         IMPLICIT grid and reads as decorative. It is what holds the bottom
-         edge flush. Nothing warns about either.
+         grid child an `auto` end line resolves to the container's PADDING EDGE,
+         not to `span 1`, so a two-line `grid-area: 1 / 1` stretches the thumb
+         on BOTH axes. The row half is the non-obvious one: there is no
+         `grid-template-rows`, so row line 2 lives in the IMPLICIT grid and
+         reads as decorative. It is what holds the bottom edge flush.
        - `inset: 0` is required. Without it the abspos box shrink-to-fits and
          renders 0x0.
 
-     Flushness is measured, not asserted here — see
-     tests/e2e/mode-toggle-geometry.spec.ts (kept on one line: a rename sweep
-     greps for the whole filename). Minifier survival is pinned in
-     css-pipeline-contract.test.ts, because CI's Playwright run drives
-     `npm run dev`, which never minifies. */
+     Flushness is measured in tests/e2e/mode-toggle-geometry.spec.ts; minifier
+     survival in css-pipeline-contract.test.ts, because CI's Playwright run
+     drives `npm run dev`, which never minifies. */
   .thumb {
     position: absolute;
     grid-area: 1 / 1 / 2 / 2;
@@ -128,22 +112,22 @@ const { tandemMode, onModeChange }: Props = $props();
     transform: translateX(100%);
   }
   .mode-toggle button {
-    /* No width rule belongs here: the segments ARE the track's two equal grid
-       columns and the button stretches to fill its column. The `flex: 1 1 0`
-       this replaces never equalized them — a flex item's automatic minimum
-       size is its min-content size, so "Tandem" (one unbreakable word) kept
-       its natural width and "Solo" took the remainder (measured 67.8 vs
-       50.5px). That inequality was #1383/#1384, one defect seen from two
+    /* No width rule belongs here — not even `min-width`: the segments ARE the
+       track's two equal grid columns and the button stretches to fill its
+       column. The `flex: 1 1 0` this replaces never equalized them, because a
+       flex item's automatic minimum size is its min-content size, so "Tandem"
+       (one unbreakable word) kept its natural width and "Solo" took the
+       remainder. That inequality was #1383/#1384, one defect seen from two
        sides: the pill matched neither segment, and each label sat off the
-       pill's optical centre. */
-    /* Center the label on both axes. `line-height: normal` (not the tight `1`)
-       is the load-bearing part: at `line-height: 1` the line box is shorter than
-       the glyph's natural box, so the text rendered ~0.7px high (2.6px gap above
-       vs 4px below). `normal` + flex centering distributes the leading evenly
-       (3.3px / 3.3px), and the padding is trimmed 5px→3px so the taller line box
-       holds the pill within a pixel of its original 21px height (20px under the
-       shipped SN Pro face; the untrimmed `5px` + `normal` pairing would be
-       24px). */
+       pill's optical centre. The E2E spec carries the measurements.
+
+       Center the label on both axes. `line-height: normal` (not the tight `1`)
+       is the load-bearing part: at `line-height: 1` the line box is shorter
+       than the glyph's natural box and the text renders cramped against the
+       top. `normal` distributes the leading evenly, and the padding is trimmed
+       5px -> 3px to offset the taller line box so the pill keeps its height.
+       That pairing is the one thing here a delta-based test cannot see, so the
+       E2E spec asserts the pill's absolute height. */
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/tests/design-system-impl/css-pipeline-contract.test.ts
+++ b/tests/design-system-impl/css-pipeline-contract.test.ts
@@ -38,6 +38,7 @@ import { cssRules, styleBlocks } from "../helpers/css-source";
 
 const ROOT = join(import.meta.dirname, "..", "..");
 const CLIENT_ROOT = join(ROOT, "src", "client");
+const MODE_TOGGLE = join(CLIENT_ROOT, "editor", "toolbar", "ModeToggle.svelte");
 
 /**
  * Vite's own esbuild-name -> lightningcss-key table, transcribed from
@@ -250,20 +251,75 @@ describe("bundled CSS: the #1383/#1384 mode-toggle declarations survive minifica
   // E2E gate can see this axis. That blind spot is exactly the one that shipped
   // #1189 inert for six weeks.
   //
-  // One case, not four. Three siblings were dropped in review for being
-  // unfalsifiable: lightningcss COLLAPSES longhands into `inset: 0` rather than
-  // exploding it, `minmax(auto, 1fr)` → `minmax(0, 1fr)` is a semantic change
-  // no minifier performs, and a percentage in `translateX` cannot be resolved
-  // without a box. A test that can only pass is not a gate.
+  // One case, not four. Three siblings were dropped in review, and since this
+  // comment is now the only record of why those gates do not exist, the reasons
+  // are the measured ones rather than the plausible ones:
+  //
+  //  - `inset`: at today's targets lightningcss COLLAPSES the four longhands
+  //    into `inset: 0` rather than exploding it. That direction is target
+  //    conditional — at `{safari:13}` / `{chrome:80}` / `{ie:11}` it expands
+  //    instead — so the non-rotting reason is the stronger one: both forms are
+  //    geometrically identical at every target, so no assertion over the choice
+  //    can express a bug.
+  //  - `minmax(auto, 1fr)` → `minmax(0, 1fr)` is a semantic change, and no
+  //    minifier performs one.
+  //  - `translateX(100%)`: lightningcss DOES rewrite this — to `translate(100%)`
+  //    — so contrary to the first draft of this comment that axis was
+  //    falsifiable, and a naive `toContain("translateX")` gate would have failed
+  //    rather than passed. It is dropped because the rewrite is semantically
+  //    identical, not because nothing happens to it.
+  //
+  // A test that can only pass is not a gate; neither is one that reds on a
+  // rename the browser cannot tell apart.
 
   it("keeps grid-area as the four-line form", () => {
     // The load-bearing one. For an ABSOLUTELY-POSITIONED grid child an `auto`
     // end line resolves to the container's padding edge, not `span 1`, so a
     // minifier that collapsed `1/1/2/2` to `1/1` would silently stretch the
     // thumb across the whole track — a visual bug with no failing test
-    // anywhere else.
+    // anywhere else. Verified against the real minifier: it DOES collapse
+    // `1/1/auto/auto` and `grid-row:1;grid-column:1` to `1/1`, so the
+    // optimization this guards is one it already performs elsewhere.
     const out = minify(".probe{grid-area:1 / 1 / 2 / 2}");
     expect(out).toContain("grid-area:1/1/2/2");
+  });
+
+  it("keeps the real .thumb placement intact, not just a synthetic probe", () => {
+    // The synthetic fixture above does not guard our source — delete `.thumb`
+    // from ModeToggle.svelte entirely and it still passes. This is the same
+    // lesson the line-clamp gate one describe block up already records; the
+    // first draft of this block did not follow its own neighbour.
+    //
+    // Only the base `.thumb` rule is fed to the minifier, not the whole <style>
+    // block: that block contains `:global(...)`, which is Svelte syntax and not
+    // CSS lightningcss can parse.
+    const thumbRule = cssRules(styleBlocks(MODE_TOGGLE)).find(
+      ([selector, body]) => selector.trim() === ".thumb" && /background\s*:/.test(body),
+    );
+    expect(
+      thumbRule,
+      "no painting `.thumb` rule in ModeToggle.svelte — renamed or removed?",
+    ).toBeDefined();
+
+    const out = minify(`.thumb{${thumbRule?.[1]}}`);
+    for (const decl of ["grid-area:1/1/2/2", "inset:0", "position:absolute"]) {
+      expect(out, `#1384: \`${decl}\` did not survive minification of the real rule`).toContain(
+        decl,
+      );
+    }
+  });
+
+  it("keeps the real track's equal-column sizing intact", () => {
+    const track = cssRules(styleBlocks(MODE_TOGGLE)).find(
+      ([selector]) => selector.trim() === ".mode-toggle",
+    );
+    expect(track, "no `.mode-toggle` rule in ModeToggle.svelte").toBeDefined();
+
+    const out = minify(`.mode-toggle{${track?.[1]}}`);
+    expect(out, "#1384: the grid track no longer minifies to equal columns").toMatch(
+      /grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/,
+    );
+    expect(out).toContain("inline-grid");
   });
 });
 

--- a/tests/design-system-impl/css-pipeline-contract.test.ts
+++ b/tests/design-system-impl/css-pipeline-contract.test.ts
@@ -3,7 +3,12 @@ import { join, relative } from "node:path";
 import { transform } from "lightningcss";
 import { resolveConfig } from "vite";
 import { beforeAll, describe, expect, it } from "vitest";
-import { cssRules, styleBlocks } from "../helpers/css-source";
+import {
+  cssRules,
+  cssRulesBySelector,
+  neutralizeSvelteGlobal,
+  styleBlocks,
+} from "../helpers/css-source";
 
 /**
  * CSS pipeline contract.
@@ -39,6 +44,36 @@ import { cssRules, styleBlocks } from "../helpers/css-source";
 const ROOT = join(import.meta.dirname, "..", "..");
 const CLIENT_ROOT = join(ROOT, "src", "client");
 const MODE_TOGGLE = join(CLIENT_ROOT, "editor", "toolbar", "ModeToggle.svelte");
+const FORMATTING_BAR = join(CLIENT_ROOT, "shell", "FormattingBar.svelte");
+
+/**
+ * A single authored rule, ready to hand to the minifier.
+ *
+ * Rules are extracted one at a time rather than minifying a whole `<style>`
+ * block, because `neutralizeSvelteGlobal` only rewrites `:global(...)` — the
+ * rest of Svelte's CSS dialect would still need a real parser.
+ */
+function authoredRule(file: string, selector: string, mustDeclare?: RegExp): string {
+  const matches = cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(file))).filter(
+    (r) => r.selectors.includes(selector) && (!mustDeclare || mustDeclare.test(r.body)),
+  );
+  expect(
+    matches.length,
+    `expected exactly one \`${selector}\` rule in ${relative(ROOT, file).replace(/\\/g, "/")}` +
+      (mustDeclare ? ` declaring ${mustDeclare}` : "") +
+      " — renamed, removed, or the scanner desynced",
+  ).toBe(1);
+  return matches[0].body;
+}
+
+/**
+ * `.thumb` appears three times in ModeToggle.svelte (base, the reduced-motion
+ * media override, and the in-app `body.tandem-reduce-motion` override), and the
+ * two overrides declare only `transition: none`. `background` picks the one that
+ * paints, independent of every placement property under test.
+ */
+const paintingRule = (selector: string) => authoredRule(MODE_TOGGLE, selector, /background\s*:/);
+const trackRule = () => authoredRule(MODE_TOGGLE, ".mode-toggle");
 
 /**
  * Vite's own esbuild-name -> lightningcss-key table, transcribed from
@@ -218,7 +253,20 @@ describe("bundled CSS: the #1302 formatting-bar declarations survive minificatio
     // or drops it re-buries every formatting-bar popover behind the selection
     // popup — and no E2E test would catch it, because Playwright drives
     // `npm run dev`, which never minifies.
-    const out = minify('.w:has([aria-expanded="true"]){z-index:9}');
+    //
+    // The real selector, not a `.w:has(...)` probe: this gate was synthetic
+    // until #1428, so deleting the rule from FormattingBar left it green. That
+    // is the same defect the line-clamp gate below records and the mode-toggle
+    // block above now avoids — three instances of one class.
+    const wrap = cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(FORMATTING_BAR)))
+      .flatMap((r) => r.selectors)
+      .filter((s) => s.includes(":has("));
+    expect(
+      wrap,
+      "no `:has()` rule left in FormattingBar.svelte — the #1302 z-lift was removed or renamed",
+    ).not.toEqual([]);
+
+    const out = minify(`${wrap[0]}{z-index:9}`);
     expect(out).toContain(":has(");
     expect(out).toContain("aria-expanded");
   });
@@ -251,57 +299,35 @@ describe("bundled CSS: the #1383/#1384 mode-toggle declarations survive minifica
   // E2E gate can see this axis. That blind spot is exactly the one that shipped
   // #1189 inert for six weeks.
   //
-  // One case, not four. Three siblings were dropped in review, and since this
-  // comment is now the only record of why those gates do not exist, the reasons
-  // are the measured ones rather than the plausible ones:
+  // These gates read the REAL rules and minify those, so they also stand in for
+  // the source-shape gates that used to live in mode-toggle-thumb-contract.test
+  // .ts — they fail on everything those did, plus minifier drift.
   //
-  //  - `inset`: at today's targets lightningcss COLLAPSES the four longhands
-  //    into `inset: 0` rather than exploding it. That direction is target
-  //    conditional — at `{safari:13}` / `{chrome:80}` / `{ie:11}` it expands
-  //    instead — so the non-rotting reason is the stronger one: both forms are
-  //    geometrically identical at every target, so no assertion over the choice
-  //    can express a bug.
-  //  - `minmax(auto, 1fr)` → `minmax(0, 1fr)` is a semantic change, and no
-  //    minifier performs one.
-  //  - `translateX(100%)`: lightningcss DOES rewrite this — to `translate(100%)`
-  //    — so contrary to the first draft of this comment that axis was
-  //    falsifiable, and a naive `toContain("translateX")` gate would have failed
-  //    rather than passed. It is dropped because the rewrite is semantically
-  //    identical, not because nothing happens to it.
+  // Two rewrites were investigated and deliberately have no gate, because a test
+  // that can only pass is not one — and neither is one that reds on a rename the
+  // browser cannot tell apart:
   //
-  // A test that can only pass is not a gate; neither is one that reds on a
-  // rename the browser cannot tell apart.
+  //  - `top/right/bottom/left: 0` vs `inset: 0`: lightningcss collapses toward
+  //    the shorthand at today's targets and expands away from it at older ones
+  //    ({safari:13}, {chrome:80}, {ie:11}). Either direction is fine — the two
+  //    forms are geometrically identical at every target, so no assertion over
+  //    the choice can express a bug.
+  //  - `translateX(100%)` → `translate(100%)`: lightningcss DOES rewrite this,
+  //    so the axis is falsifiable and a `toContain("translateX")` gate would red.
+  //    It has no gate because the rewrite is semantically identical, not because
+  //    nothing happens to it.
 
-  it("keeps grid-area as the four-line form", () => {
-    // The load-bearing one. For an ABSOLUTELY-POSITIONED grid child an `auto`
-    // end line resolves to the container's padding edge, not `span 1`, so a
-    // minifier that collapsed `1/1/2/2` to `1/1` would silently stretch the
-    // thumb across the whole track — a visual bug with no failing test
-    // anywhere else. Verified against the real minifier: it DOES collapse
+  it("keeps the real .thumb placement intact", () => {
+    // A synthetic `.probe{grid-area:1 / 1 / 2 / 2}` fixture would pass with
+    // `.thumb` deleted from the component entirely. Same lesson as the
+    // line-clamp gate above: minify what actually ships.
+    //
+    // The load-bearing assertion is `grid-area`. For an absolutely-positioned
+    // grid child an `auto` end line resolves to the container's padding edge,
+    // not `span 1` — and lightningcss is measured to collapse both
     // `1/1/auto/auto` and `grid-row:1;grid-column:1` to `1/1`, so the
     // optimization this guards is one it already performs elsewhere.
-    const out = minify(".probe{grid-area:1 / 1 / 2 / 2}");
-    expect(out).toContain("grid-area:1/1/2/2");
-  });
-
-  it("keeps the real .thumb placement intact, not just a synthetic probe", () => {
-    // The synthetic fixture above does not guard our source — delete `.thumb`
-    // from ModeToggle.svelte entirely and it still passes. This is the same
-    // lesson the line-clamp gate one describe block up already records; the
-    // first draft of this block did not follow its own neighbour.
-    //
-    // Only the base `.thumb` rule is fed to the minifier, not the whole <style>
-    // block: that block contains `:global(...)`, which is Svelte syntax and not
-    // CSS lightningcss can parse.
-    const thumbRule = cssRules(styleBlocks(MODE_TOGGLE)).find(
-      ([selector, body]) => selector.trim() === ".thumb" && /background\s*:/.test(body),
-    );
-    expect(
-      thumbRule,
-      "no painting `.thumb` rule in ModeToggle.svelte — renamed or removed?",
-    ).toBeDefined();
-
-    const out = minify(`.thumb{${thumbRule?.[1]}}`);
+    const out = minify(`.thumb{${paintingRule(".thumb")}}`);
     for (const decl of ["grid-area:1/1/2/2", "inset:0", "position:absolute"]) {
       expect(out, `#1384: \`${decl}\` did not survive minification of the real rule`).toContain(
         decl,
@@ -310,16 +336,18 @@ describe("bundled CSS: the #1383/#1384 mode-toggle declarations survive minifica
   });
 
   it("keeps the real track's equal-column sizing intact", () => {
-    const track = cssRules(styleBlocks(MODE_TOGGLE)).find(
-      ([selector]) => selector.trim() === ".mode-toggle",
-    );
-    expect(track, "no `.mode-toggle` rule in ModeToggle.svelte").toBeDefined();
-
-    const out = minify(`.mode-toggle{${track?.[1]}}`);
-    expect(out, "#1384: the grid track no longer minifies to equal columns").toMatch(
-      /grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/,
-    );
+    const out = minify(`.mode-toggle{${trackRule()}}`);
+    expect(
+      out,
+      "#1384: the thumb IS column 1, so the columns must stay equal at every track width. " +
+        "A bare `1fr` floors each column at min-content and they diverge under compression; " +
+        "the E2E spec measures that with an injected max-width.",
+    ).toMatch(/grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/);
     expect(out).toContain("inline-grid");
+    // Without `position: relative` the containing block falls through to the
+    // next positioned ancestor and the grid placement stops applying entirely.
+    expect(out).toContain("position:relative");
+    expect(out).toContain("gap:0");
   });
 });
 

--- a/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
+++ b/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
@@ -24,11 +24,19 @@ import { cssRules, styleBlocks } from "../helpers/css-source";
  * after lightningcss is covered in `css-pipeline-contract.test.ts`, the only
  * gate that runs the real minifier. Three axes, none able to see the others.
  *
- * Two of the gates below pin INVARIANTS ("no percentage-derived sizing", "no
- * width rule on the buttons") and survive any correct implementation. The rest
- * pin the current SHAPE and are marked accordingly — if a better placement
- * mechanism arrives, those are SUPERSEDED rather than violated, and the right
- * response is deleting them, not re-satisfying them.
+ * **Exactly one gate below pins an INVARIANT** — "carries no percentage-derived
+ * sizing", and even that one is an invariant by SPEC FIAT rather than by
+ * geometry: derived-spec.md §3.9 bans the mechanism outright because it is how
+ * #1383/#1384 happened, and the ban is deliberately stricter than the geometric
+ * requirement. (Measured counterexample: `flex: 1 1 0` + `min-width: 0` with the
+ * OLD `width: calc(50% - 2px)` thumb yields solo 59.17 / tandem 59.19 / thumb
+ * 59.17, flush to 0.00 — correct geometry, banned mechanism.)
+ *
+ * **Every other gate in this file pins the current SHAPE.** If a better
+ * placement mechanism arrives they are SUPERSEDED rather than violated, and the
+ * right response is deleting them, not re-satisfying them. That includes "no
+ * width rule on the buttons", which reads like an invariant and is not — see
+ * the counterexample above, which it would reject.
  */
 
 const ROOT = join(import.meta.dirname, "..", "..");
@@ -40,9 +48,11 @@ const MODE_TOGGLE = join(ROOT, "src", "client", "editor", "toolbar", "ModeToggle
  * .thumb" pattern would swallow it and flag a correct declaration.
  *
  * `styleBlocks` strips comments, which is mandatory rather than stylistic here:
- * the rules being pinned carry rationale comments quoting the very literals
- * scanned for (`grid-area: 1 / 1`, `calc(50% - 2px)`). An un-stripped scan reds
- * on the prose, and the path of least resistance is then deleting the prose.
+ * ModeToggle.svelte's rationale comment quotes the very literal this file scans
+ * for (`grid-area: 1 / 1`, naming the two-line form as the trap). That prose
+ * sits immediately BEFORE `.thumb {`, so an un-stripped scan folds it into the
+ * selector text and trips `thumbBaseRule()`'s `toBe(1)` — and the cheapest path
+ * back to green is then deleting the explanation.
  */
 const RULES = cssRules(styleBlocks(MODE_TOGGLE)).map(([selector, body]) => ({
   selectors: selector.split(",").map((x) => x.trim()),
@@ -86,25 +96,29 @@ describe(".mode-toggle: the equal-segment premise the thumb rests on", () => {
     expect(body).toMatch(/grid-template-columns\s*:\s*repeat\(/);
   });
 
-  // SHAPE, not invariant — superseded by any placement that keeps the columns
-  // equal under compression.
   it("sizes those columns with minmax(0, 1fr), not a bare 1fr", () => {
     const columns = /grid-template-columns\s*:([^;]+)/.exec(ruleWithSelector(".mode-toggle"))?.[1];
     expect(columns, "no grid-template-columns declaration").toBeDefined();
     expect(
       columns,
-      "#1384: the two forms are identical while the track is shrink-to-fit, and diverge under " +
-        "compression — measured at a 120px cap, bare `1fr` gives 52/70.97px columns while " +
-        "`minmax(0, 1fr)` gives 60/60px. The thumb IS column 1, so unequal columns put it on a " +
-        "segment of a different width. A squeezed label overflowing is the accepted trade.",
+      "#1384: a guard, not the active fix. The two forms are identical while the track is " +
+        "shrink-to-fit, and nothing in the shipped title bar compresses it (`.title-bar-mode` " +
+        "is `flex: 0 0 auto`). They diverge once something does — measured at a border-box " +
+        "120px cap, bare `1fr` gives 51.08/67.83 while `minmax(0, 1fr)` gives 57/57. The thumb " +
+        "IS column 1, so unequal columns put it on a segment of a different width. The E2E " +
+        "spec forces that cap with an injected max-width; a squeezed label overflowing is the " +
+        "accepted trade.",
     ).toContain("minmax(0");
   });
 
   it("stays the thumb's containing block", () => {
     expect(
       ruleWithSelector(".mode-toggle"),
-      "Measured: without `position: relative` the absolutely-positioned thumb takes the " +
-        "VIEWPORT as its containing block and sizes itself against it. Nothing warns.",
+      "Measured: without `position: relative` the containing block falls through to " +
+        "`.title-bar-mode`, which is itself positioned (TitleBar.svelte) — the grid placement " +
+        "stops applying and the thumb covers the whole track with a 3px overhang. Note the " +
+        "coupling this pins: correctness here depends on an ancestor rule in another file. " +
+        "Nothing warns.",
     ).toMatch(/position\s*:\s*relative/);
   });
 
@@ -123,29 +137,43 @@ describe(".mode-toggle: the equal-segment premise the thumb rests on", () => {
     ).toEqual([]);
   });
 
-  it("declares no width rule on the buttons", () => {
+  it("declares no width rule on the buttons, in any of their rules", () => {
     // `flex: 1 1 0` was the false-premise line. It is dead under grid anyway,
     // and re-adding any width rule here would re-open the question the grid
-    // columns now answer.
-    const body = ruleWithSelector(".mode-toggle button");
-    expect(body).not.toMatch(/(?:^|[;\s])flex\s*:/);
-    expect(body).not.toMatch(/(?:^|[;\s])width\s*:/);
+    // columns now answer. `min-width` is the one that actually bites: it
+    // restores exactly the min-content floor `minmax(0, 1fr)` exists to defeat,
+    // and it is invisible at rest — measured, `min-width: 60px` passes the E2E
+    // spec and only diverges once the track is compressed.
+    //
+    // Every `.mode-toggle button*` rule is scanned, not just the base one:
+    // `.on` and `:hover:not(.on)` are separate selectors and a width added
+    // there would slip past a base-rule-only check.
+    const offenders = RULES.filter((r) =>
+      r.selectors.some((s) => s.startsWith(".mode-toggle button")),
+    )
+      .flatMap((r) =>
+        [...r.body.matchAll(/(?:^|[;\s])((?:min-|max-)?width|flex)\s*:[^;]*/g)].map((m) => [
+          r.selectors.join(", "),
+          m[0].trim(),
+        ]),
+      )
+      .map(([selector, decl]) => `${selector} { ${decl} }`);
+    expect(offenders).toEqual([]);
   });
 });
 
 describe(".thumb: placed into the first segment, never computed from it", () => {
-  // SHAPE, not invariant — superseded if the thumb is ever placed by another
-  // mechanism. Delete rather than re-satisfy; the E2E spec holds the invariant.
   it("names all four grid lines", () => {
     expect(
       thumbBaseRule(),
       "#1384: for an ABSOLUTELY-POSITIONED grid child an `auto` end line resolves to the " +
-        "container's padding edge, NOT to `span 1` — so a two-line `grid-area: 1 / 1` " +
-        "silently stretches the thumb across the whole track. Write all four lines.",
+        "container's padding edge, NOT to `span 1`. Measured, a two-line `grid-area: 1 / 1` " +
+        "breaks BOTH axes — width 136.78 vs 67.39 AND height 23 vs 21 (the track's vertical " +
+        "padding). The row-end `2` is not decorative: with no `grid-template-rows` it lives in " +
+        "the implicit grid and is what holds the bottom edge flush. Write all four lines.",
     ).toMatch(/grid-area\s*:\s*1\s*\/\s*1\s*\/\s*2\s*\/\s*2/);
   });
 
-  // SHAPE, not invariant — same note as above.
   it("declares inset: 0 on an absolutely-positioned box", () => {
     const body = thumbBaseRule();
     expect(
@@ -161,7 +189,12 @@ describe(".thumb: placed into the first segment, never computed from it", () => 
   it("carries no percentage-derived sizing", () => {
     const offenders = RULES.filter((r) => r.selectors.includes(".thumb"))
       .flatMap((r) => [
-        ...r.body.matchAll(/(?:^|[;\s])(width|height|left|right|top|bottom)\s*:[^;]*(%|calc\()/g),
+        // `inset` is in the list because it is the property the fix itself now
+        // uses — `inset: 0 0 0 50%` would otherwise walk straight through the
+        // one gate that exists to forbid percentage geometry.
+        ...r.body.matchAll(
+          /(?:^|[;\s])(inset|width|height|left|right|top|bottom)\s*:[^;]*(%|calc\()/g,
+        ),
       ])
       .map((m) => m[0].trim());
     expect(

--- a/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
+++ b/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
@@ -1,64 +1,48 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { cssRules, styleBlocks } from "../helpers/css-source";
+import { cssRulesBySelector, styleBlocks } from "../helpers/css-source";
 
 /**
  * ModeToggle sliding-thumb geometry gate (#1383, #1384).
  *
- * Both issues are one defect: `.mode-toggle` asked flexbox to split the track
- * in half (`flex: 1 1 0`) and `.thumb` sized itself to that assumed half
- * (`width: calc(50% - 2px)`). Flexbox never delivered it — a flex item's
- * automatic minimum size is its min-content size, so "Tandem" was clamped up to
- * its natural width and "Solo" took the remainder. The pill then matched
- * neither segment (#1384) and each label sat off the pill's optical centre
- * (#1383). The full measurement table lives in the E2E spec, which is the only
- * file that can re-derive it.
+ * The mechanic is documented on the declarations themselves in
+ * ModeToggle.svelte; this file pins the shape of that fix rather than
+ * re-explaining it. What a failure means is in each message below.
  *
- * The fix removes the arithmetic rather than correcting it: the segments became
- * the two equal columns of an `inline-grid`, and the thumb is *placed into*
- * grid area 1/1/2/2 with `inset: 0`, so its box IS the first segment's box.
+ * **These are all NEGATIVE scans, and that is deliberate.** The positive
+ * literals this file used to assert — `inline-grid`, `minmax(0,`,
+ * `grid-area: 1/1/2/2`, `inset: 0`, `position: relative` — moved to
+ * css-pipeline-contract.test.ts, which reads the same source and then runs it
+ * through the real minifier, so it fails on everything these did *plus*
+ * minifier drift. Mutation-tested both ways: those five gates were strictly
+ * subsumed, and this file's own rule is that a superseded gate should be
+ * deleted rather than re-satisfied.
  *
- * **This file pins CSS shape, not effect.** No vitest project here has a layout
- * engine, so geometric truth is only observable in
- * `tests/e2e/mode-toggle-geometry.spec.ts`; what the *built* CSS looks like
- * after lightningcss is covered in `css-pipeline-contract.test.ts`, the only
- * gate that runs the real minifier. Three axes, none able to see the others.
+ * What survives is what a positive scan cannot express: that something is
+ * ABSENT. No percentage geometry, no width rule, no gutter — each of them a
+ * property that admits infinitely many spellings, which is exactly the shape a
+ * `toContain` cannot pin.
  *
- * **Exactly one gate below pins an INVARIANT** — "carries no percentage-derived
- * sizing", and even that one is an invariant by SPEC FIAT rather than by
- * geometry: derived-spec.md §3.9 bans the mechanism outright because it is how
- * #1383/#1384 happened, and the ban is deliberately stricter than the geometric
- * requirement. (Measured counterexample: `flex: 1 1 0` + `min-width: 0` with the
- * OLD `width: calc(50% - 2px)` thumb yields solo 59.17 / tandem 59.19 / thumb
- * 59.17, flush to 0.00 — correct geometry, banned mechanism.)
- *
- * **Every other gate in this file pins the current SHAPE.** If a better
- * placement mechanism arrives they are SUPERSEDED rather than violated, and the
- * right response is deleting them, not re-satisfying them. That includes "no
- * width rule on the buttons", which reads like an invariant and is not — see
- * the counterexample above, which it would reject.
+ * One of them is a genuine invariant, and by SPEC FIAT rather than by geometry:
+ * derived-spec.md §3.9 bans percentage-derived thumb sizing outright because it
+ * is how #1383/#1384 happened, deliberately stricter than the geometric
+ * requirement. The other two pin the current shape and are superseded — not
+ * violated — by any mechanism that keeps the segments equal.
  */
 
 const ROOT = join(import.meta.dirname, "..", "..");
 const MODE_TOGGLE = join(ROOT, "src", "client", "editor", "toolbar", "ModeToggle.svelte");
 
 /**
- * Rules are matched by EXACT selector, never substring: `.thumb.tandem`
- * legitimately declares `translateX(100%)`, and a broadened "no percentages in
- * .thumb" pattern would swallow it and flag a correct declaration.
- *
  * `styleBlocks` strips comments, which is mandatory rather than stylistic here:
- * ModeToggle.svelte's rationale comment quotes the very literal this file scans
- * for (`grid-area: 1 / 1`, naming the two-line form as the trap). That prose
- * sits immediately BEFORE `.thumb {`, so an un-stripped scan folds it into the
- * selector text and trips `thumbBaseRule()`'s `toBe(1)` — and the cheapest path
- * back to green is then deleting the explanation.
+ * ModeToggle.svelte's rationale comments quote CSS literals, and prose sitting
+ * immediately before a `{` is folded into the selector text by a brace-based
+ * splitter. The cheapest path back to green would then be deleting the
+ * explanation.
  */
-const RULES = cssRules(styleBlocks(MODE_TOGGLE)).map(([selector, body]) => ({
-  selectors: selector.split(",").map((x) => x.trim()),
-  body,
-}));
+const RULES = cssRulesBySelector(styleBlocks(MODE_TOGGLE));
 
+/** Bodies of every rule whose selector list contains `selector` exactly. */
 function ruleWithSelector(selector: string): string {
   const found = RULES.filter((r) => r.selectors.includes(selector));
   expect(found.length, `no rule with selector \`${selector}\` — scanner desynced?`).toBeGreaterThan(
@@ -67,61 +51,7 @@ function ruleWithSelector(selector: string): string {
   return found.map((r) => r.body).join("\n");
 }
 
-/**
- * `.thumb` appears twice: the base rule and the reduced-motion override, which
- * declares only `transition: none`. Anchoring on `background` picks the one
- * that paints, independent of the placement properties under test — and its
- * `toBe(1)` is what stops every gate below being "passed" by deleting the rule.
- */
-function thumbBaseRule(): string {
-  const candidates = RULES.filter(
-    (r) => r.selectors.includes(".thumb") && /background\s*:/.test(r.body),
-  );
-  expect(
-    candidates.length,
-    "no painting `.thumb` rule found — the base rule was renamed, removed, or the scanner desynced",
-  ).toBe(1);
-  return candidates[0].body;
-}
-
-describe(".mode-toggle: the equal-segment premise the thumb rests on", () => {
-  it("lays the segments out as two grid columns, not flex items", () => {
-    const body = ruleWithSelector(".mode-toggle");
-    expect(
-      body,
-      "#1383/#1384: `flex: 1 1 0` does NOT equalize these segments — a flex item's " +
-        "automatic minimum size is its min-content size, so the longer 'Tandem' label wins " +
-        "and the half-width thumb then matches neither segment.",
-    ).toMatch(/display\s*:\s*inline-grid/);
-    expect(body).toMatch(/grid-template-columns\s*:\s*repeat\(/);
-  });
-
-  it("sizes those columns with minmax(0, 1fr), not a bare 1fr", () => {
-    const columns = /grid-template-columns\s*:([^;]+)/.exec(ruleWithSelector(".mode-toggle"))?.[1];
-    expect(columns, "no grid-template-columns declaration").toBeDefined();
-    expect(
-      columns,
-      "#1384: a guard, not the active fix. The two forms are identical while the track is " +
-        "shrink-to-fit, and nothing in the shipped title bar compresses it (`.title-bar-mode` " +
-        "is `flex: 0 0 auto`). They diverge once something does — measured at a border-box " +
-        "120px cap, bare `1fr` gives 51.08/67.83 while `minmax(0, 1fr)` gives 57/57. The thumb " +
-        "IS column 1, so unequal columns put it on a segment of a different width. The E2E " +
-        "spec forces that cap with an injected max-width; a squeezed label overflowing is the " +
-        "accepted trade.",
-    ).toContain("minmax(0");
-  });
-
-  it("stays the thumb's containing block", () => {
-    expect(
-      ruleWithSelector(".mode-toggle"),
-      "Measured: without `position: relative` the containing block falls through to " +
-        "`.title-bar-mode`, which is itself positioned (TitleBar.svelte) — the grid placement " +
-        "stops applying and the thumb covers the whole track with a 3px overhang. Note the " +
-        "coupling this pins: correctness here depends on an ancestor rule in another file. " +
-        "Nothing warns.",
-    ).toMatch(/position\s*:\s*relative/);
-  });
-
+describe("ModeToggle: the mechanisms that must stay absent", () => {
   it("keeps the column gutter at zero", () => {
     const nonZero = [
       ...ruleWithSelector(".mode-toggle").matchAll(
@@ -138,65 +68,33 @@ describe(".mode-toggle: the equal-segment premise the thumb rests on", () => {
   });
 
   it("declares no width rule on the buttons, in any of their rules", () => {
-    // `flex: 1 1 0` was the false-premise line. It is dead under grid anyway,
-    // and re-adding any width rule here would re-open the question the grid
-    // columns now answer. `min-width` is the one that actually bites: it
-    // restores exactly the min-content floor `minmax(0, 1fr)` exists to defeat,
-    // and it is invisible at rest — measured, `min-width: 60px` passes the E2E
-    // spec and only diverges once the track is compressed.
+    // `min-width` is the one that bites: it restores the min-content floor
+    // `minmax(0, 1fr)` exists to defeat, and it is invisible at rest — only the
+    // compression test in the E2E spec sees its effect.
     //
     // Every `.mode-toggle button*` rule is scanned, not just the base one:
     // `.on` and `:hover:not(.on)` are separate selectors and a width added
     // there would slip past a base-rule-only check.
     const offenders = RULES.filter((r) =>
       r.selectors.some((s) => s.startsWith(".mode-toggle button")),
-    )
-      .flatMap((r) =>
-        [...r.body.matchAll(/(?:^|[;\s])((?:min-|max-)?width|flex)\s*:[^;]*/g)].map((m) => [
-          r.selectors.join(", "),
-          m[0].trim(),
-        ]),
-      )
-      .map(([selector, decl]) => `${selector} { ${decl} }`);
+    ).flatMap((r) =>
+      [...r.body.matchAll(/(?:^|[;\s])((?:min-|max-)?width|flex)\s*:[^;]*/g)].map(
+        (m) => `${r.selectors.join(", ")} { ${m[0].trim()} }`,
+      ),
+    );
     expect(offenders).toEqual([]);
   });
-});
 
-describe(".thumb: placed into the first segment, never computed from it", () => {
-  it("names all four grid lines", () => {
-    expect(
-      thumbBaseRule(),
-      "#1384: for an ABSOLUTELY-POSITIONED grid child an `auto` end line resolves to the " +
-        "container's padding edge, NOT to `span 1`. Measured, a two-line `grid-area: 1 / 1` " +
-        "breaks BOTH axes — width 136.78 vs 67.39 AND height 23 vs 21 (the track's vertical " +
-        "padding). The row-end `2` is not decorative: with no `grid-template-rows` it lives in " +
-        "the implicit grid and is what holds the bottom edge flush. Write all four lines.",
-    ).toMatch(/grid-area\s*:\s*1\s*\/\s*1\s*\/\s*2\s*\/\s*2/);
-  });
-
-  it("declares inset: 0 on an absolutely-positioned box", () => {
-    const body = thumbBaseRule();
-    expect(
-      body,
-      "#1384: without `inset`, the absolutely-positioned box shrink-to-fits its (empty) " +
-        "contents and renders 0x0. The grid placement alone does not size it.",
-    ).toMatch(/inset\s*:\s*0(?![.\d])/);
-    // Load-bearing pair: without `absolute`, `inset` is inert and the grid
-    // placement makes the thumb a flow item that consumes a column.
-    expect(body).toMatch(/position\s*:\s*absolute/);
-  });
-
-  it("carries no percentage-derived sizing", () => {
-    const offenders = RULES.filter((r) => r.selectors.includes(".thumb"))
-      .flatMap((r) => [
-        // `inset` is in the list because it is the property the fix itself now
-        // uses — `inset: 0 0 0 50%` would otherwise walk straight through the
-        // one gate that exists to forbid percentage geometry.
-        ...r.body.matchAll(
-          /(?:^|[;\s])(inset|width|height|left|right|top|bottom)\s*:[^;]*(%|calc\()/g,
-        ),
-      ])
-      .map((m) => m[0].trim());
+  it("carries no percentage-derived sizing on the thumb", () => {
+    // The property list tracks the ban, not the current implementation:
+    // `inset` because the fix itself now uses it, `margin` because
+    // `margin-left: 50%` is percentage positioning the spec forbids and an
+    // earlier list let through.
+    const offenders = [
+      ...ruleWithSelector(".thumb").matchAll(
+        /(?:^|[;\s])(inset|margin|width|height|left|right|top|bottom)[a-z-]*\s*:[^;]*(%|calc\()/g,
+      ),
+    ].map((m) => m[0].trim());
     expect(
       offenders,
       "#1383/#1384 were caused by sizing the thumb as a fraction of the track " +
@@ -206,9 +104,10 @@ describe(".thumb: placed into the first segment, never computed from it", () => 
   });
 
   it("still slides exactly one column on a mode flip", () => {
-    // Guards the extraction above as much as the declaration: this legal
-    // percentage lives one selector away from a rule that must contain none,
-    // and a substring-matched scanner would flag it.
+    // Guards the extraction as much as the declaration: this legal percentage
+    // lives one selector away from a rule that must contain none, so a
+    // substring-matched scanner would flag it. Exact-selector matching is what
+    // keeps the gate above honest.
     expect(ruleWithSelector(".thumb.tandem")).toMatch(/transform\s*:\s*translateX\(\s*100%\s*\)/);
   });
 });

--- a/tests/design-system-impl/rail-clearance-contract.test.ts
+++ b/tests/design-system-impl/rail-clearance-contract.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { cssRules, styleBlocks } from "../helpers/css-source";
+import { cssRulesBySelector, styleBlocks } from "../helpers/css-source";
 
 /**
  * Regression guard for #1396 — the rail drag strip overhung the visible rail.
@@ -39,10 +39,7 @@ const SHELL = ".rail-shell";
 const STRIP = ".rail-resize-handle";
 
 const css = styleBlocks(APP_SVELTE);
-const rules = cssRules(css).map(([selectorList, body]) => ({
-  selectors: selectorList.split(",").map((s) => s.trim()),
-  body,
-}));
+const rules = cssRulesBySelector(css);
 
 describe("#1396 rail clearance is declared once and shared", () => {
   const cases = [

--- a/tests/e2e/mode-toggle-geometry.spec.ts
+++ b/tests/e2e/mode-toggle-geometry.spec.ts
@@ -25,17 +25,19 @@ import { expect, type Page, test } from "@playwright/test";
  * mismatch seen from the user's side (#1383), because the button is invisible
  * and the pill is what the eye reads.
  *
- * No document fixture: the toggle lives in the title bar and renders without
- * one. Opening a fixture over MCP was measured at ~1.3s per test for geometry
- * that is byte-identical either way.
+ * No document fixture: the toggle lives in the title bar, above the
+ * `{#if !yjsSync.ready}` split, and TitleBar renders it on `tandemMode` alone.
+ * Opening a fixture over MCP was measured at ~1.3s per test for geometry that is
+ * byte-identical either way. `boot()` deliberately does NOT wait on
+ * `.tandem-editor` — that class needs an open document, so waiting on it would
+ * couple every test here to the 400ms auto-scratchpad debounce for no signal.
  */
 
 test.describe.configure({ timeout: 90_000 });
 
 async function boot(page: Page) {
   await page.goto("/");
-  await page.locator(".tandem-editor").waitFor({ state: "visible", timeout: 15_000 });
-  await page.locator("[data-testid='mode-toggle']").waitFor({ state: "visible", timeout: 10_000 });
+  await page.locator("[data-testid='mode-toggle']").waitFor({ state: "visible", timeout: 15_000 });
   // SN Pro ships `font-display: swap` (index.html), and the swap CHANGES these
   // metrics — measured 50.00 -> 50.53 on the solo segment, 123.39 -> 124.36 on
   // the track. Every assertion below uses an absolute px tolerance and
@@ -51,6 +53,7 @@ type Geometry = {
   dR: number;
   dT: number;
   dB: number;
+  thumbH: number;
   inkDelta: number;
 };
 
@@ -85,6 +88,7 @@ function measure(page: Page): Promise<Geometry> {
       dR: t.right - a.right,
       dT: t.top - a.top,
       dB: t.bottom - a.bottom,
+      thumbH: t.height,
       inkDelta: (ink.left + ink.right) / 2 - (t.left + t.right) / 2,
     };
   });
@@ -108,6 +112,14 @@ async function expectThumbFlush(page: Page, label: string) {
         // symmetric padding the ink delta is -(dL+dR)/2 and cannot fail while
         // the edges hold — EXCEPT if `justify-content: center` is removed, which
         // is a real #1383-shaped regression the edge deltas would not see.
+        //
+        // That sensitivity is ONE-SIDED, and it decides which call site matters.
+        // The column width equals the TANDEM button's max-content, so "Tandem"'s
+        // ink already fills its content box and its inkDelta stays ~0 however the
+        // label is justified. Only "Solo" has slack — (67.83 - 28 - 22.5)/2 ≈
+        // 8.6px of it. So the whole `justify-content` regression is caught by the
+        // solo assertion alone; drop that one call and #1383 coverage goes with
+        // it.
         if (Math.abs(g.inkDelta) >= 0.75) off.push(`inkDelta=${g.inkDelta.toFixed(2)}`);
         return off;
       },
@@ -116,7 +128,10 @@ async function expectThumbFlush(page: Page, label: string) {
         message:
           `${label}: the sliding pill does not cover the selected segment (#1384). ` +
           `The thumb is placed into grid area 1/1/2/2 of the track, so any non-zero edge ` +
-          `delta means the segments are no longer equal columns or the placement was lost.`,
+          `delta means the segments are no longer equal columns or the placement was lost. ` +
+          `An \`inkDelta\` entry with all four edges flush is the other defect (#1383): the ` +
+          `pill is correct and the LABEL is off-centre inside it — check \`justify-content\` ` +
+          `on \`.mode-toggle button\`.`,
       },
     )
     .toEqual([]);
@@ -134,11 +149,27 @@ test("the segments are equal and the pill covers the selected one (tandem defaul
     Math.abs(g.soloW - g.tandemW),
     `#1383/#1384 root cause: solo=${g.soloW.toFixed(2)} tandem=${g.tandemW.toFixed(2)}. ` +
       `The thumb IS the track's first column, so unequal segments put it on a segment of a ` +
-      `different width. \`flex: 1 1 0\` never produced equal columns, because a flex item ` +
-      `cannot be squeezed below its own min-content width.`,
+      `different width. \`flex: 1 1 0\` never produced equal columns: a flex item's automatic ` +
+      `minimum size is its min-content size, so "Tandem" was clamped up to its natural width. ` +
+      `(That is a property of \`min-width: auto\`, not of flexbox — \`flex: 1 1 0\` plus ` +
+      `\`min-width: 0\` does equalize. The grid form is preferred, not forced.)`,
   ).toBeLessThan(0.5);
   // Guards against a "pass" where both segments collapsed to nothing.
   expect(g.soloW).toBeGreaterThan(10);
+
+  // The only assertion in this file that reads an ABSOLUTE height. Everything
+  // else is a thumb-vs-button delta, so the pill and the button could grow
+  // together and every delta would stay 0.00. ModeToggle.svelte trims the
+  // button padding 5px -> 3px precisely to offset `line-height: normal`, and
+  // that arithmetic is otherwise unpinned: reverting the trim while keeping
+  // `normal` measures 24px.
+  expect(
+    g.thumbH,
+    `the pill is ${g.thumbH.toFixed(2)}px tall. It should hold ~20px under the shipped SN Pro ` +
+      `face (21px pre-swap). 24px means the button's 3px vertical padding was reverted to 5px ` +
+      `without also reverting \`line-height: normal\` — see ModeToggle.svelte.`,
+  ).toBeLessThan(22);
+  expect(g.thumbH).toBeGreaterThan(18);
 
   await expect(page.locator("[data-testid='mode-tandem-btn']")).toHaveAttribute(
     "aria-pressed",
@@ -171,9 +202,45 @@ test("the pill covers the selected segment after switching to solo, and back", a
   await expectThumbFlush(page, "tandem (after a slide)");
 });
 
+test("the columns stay equal when the track is forced to compress", async ({ page }) => {
+  // `minmax(0, 1fr)` versus a bare `1fr` is the most-argued decision in this
+  // fix, and NOTHING in the shipped layout can exercise it: `.title-bar-mode` is
+  // `flex: 0 0 auto` and `.title-bar-center` carries `min-width: 0`, so the
+  // center strip absorbs every pixel of shrink and this track measures the same
+  // at every viewport width. Swept 1200 -> 200px, it never moved.
+  //
+  // So the regime is injected rather than reached. Without this test the guard's
+  // only gate is a source literal in mode-toggle-thumb-contract.test.ts, which
+  // pins the spelling and can never see the effect — and a `min-width` on the
+  // button, which restores exactly the min-content floor `minmax(0, 1fr)` exists
+  // to defeat, is invisible at every other assertion in this file.
+  await boot(page);
+  await page.addStyleTag({ content: ".mode-toggle { max-width: 120px }" });
+
+  const g = await measure(page);
+  expect(
+    Math.abs(g.soloW - g.tandemW),
+    `compressed to 120px: solo=${g.soloW.toFixed(2)} tandem=${g.tandemW.toFixed(2)}. ` +
+      `A bare \`1fr\` measures 51.08/67.83 here because its \`auto\` minimum floors each ` +
+      `column at min-content; \`minmax(0, 1fr)\` measures 57/57. Unequal columns put the ` +
+      `thumb on a segment of a different width — #1384, reopened.`,
+  ).toBeLessThan(0.5);
+
+  // Equal columns are necessary but not sufficient: a `min-width` on the button
+  // keeps the COLUMNS equal while the button outgrows the column the thumb is
+  // placed in, so only the flush check sees it.
+  await expectThumbFlush(page, "compressed to 120px");
+});
+
 test("the widened toggle still fits a narrow viewport", async ({ page }) => {
   // Equalizing the segments widens the control by ~17.3px ("Solo" grew to match
   // "Tandem"), and the toggle sits at the right-hand end of the title bar.
+  //
+  // 360px, not 600px: because the toggle cannot shrink (see above), the fixed
+  // row content is roughly 28px padding + 32px logo + spacers + ~140px toggle,
+  // and the tab strip absorbs all remaining shrink. At 600px the widening this
+  // guards could grow twentyfold before the assertion fired, which made it read
+  // as coverage it was not providing.
   //
   // SCOPE: this covers the BROWSER layout only. `isTauriRuntime()` is false
   // here, so `.title-bar-mode` never gets `.native-window-row` and the three
@@ -182,23 +249,18 @@ test("the widened toggle still fits a narrow viewport", async ({ page }) => {
   // deliberately pinned into — it is covered by the manual `cargo tauri dev`
   // step, not by this assertion. Do not read this as pinning the desktop case.
   await boot(page);
-  await page.setViewportSize({ width: 600, height: 800 });
+  await page.setViewportSize({ width: 360, height: 800 });
 
   const fits = await page.evaluate(() => {
     const el = document.querySelector(".mode-toggle");
     if (!el) throw new Error("missing .mode-toggle");
     const r = el.getBoundingClientRect();
-    return {
-      left: r.left,
-      right: r.right,
-      width: window.innerWidth,
-      visible: r.width > 0 && r.height > 0,
-    };
+    return { right: r.right, width: window.innerWidth, visible: r.width > 0 && r.height > 0 };
   });
 
-  expect(fits.visible, "the toggle collapsed to zero at 600px").toBe(true);
+  expect(fits.visible, "the toggle collapsed to zero at 360px").toBe(true);
   expect(
     fits.right,
-    `the toggle overflows the 600px viewport (right edge ${fits.right.toFixed(1)} of ${fits.width})`,
+    `the toggle overflows the 360px viewport (right edge ${fits.right.toFixed(1)} of ${fits.width})`,
   ).toBeLessThanOrEqual(fits.width);
 });

--- a/tests/e2e/mode-toggle-geometry.spec.ts
+++ b/tests/e2e/mode-toggle-geometry.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from "@playwright/test";
+import { nextFrames } from "./helpers";
 
 /**
  * ModeToggle sliding-thumb geometry (#1383, #1384).
@@ -96,9 +97,20 @@ function measure(page: Page): Promise<Geometry> {
 
 /**
  * Polls, so the 220ms slide settles without a bare sleep. Asserted as a single
- * object so a failure reports all four edges at once — a thumb that is off on
- * `left` and `right` by the same amount is a translate bug, while one off on
- * `right` alone is a sizing bug, and that distinction is the whole diagnosis.
+ * object so a failure reports all four edges at once — a thumb off on `left` and
+ * `right` by the same amount is a translate bug, one off on `right` alone is a
+ * sizing bug, and that distinction is the whole diagnosis.
+ *
+ * `inkDelta` rides along for #1383. The label is always centred in its BUTTON,
+ * so under symmetric padding it equals -(dL+dR)/2 and cannot fail while the
+ * edges hold — except when `justify-content: center` is removed, which the edge
+ * deltas cannot see.
+ *
+ * That sensitivity is ONE-SIDED, and it decides which call site matters. The
+ * column width is the TANDEM button's max-content, so "Tandem"'s ink already
+ * fills its content box and its `inkDelta` stays ~0 however the label is
+ * justified. Only "Solo" has slack. Drop the solo call and #1383 coverage goes
+ * with it.
  */
 async function expectThumbFlush(page: Page, label: string) {
   await expect
@@ -108,30 +120,15 @@ async function expectThumbFlush(page: Page, label: string) {
         const off = (["dL", "dR", "dT", "dB"] as const)
           .filter((k) => Math.abs(g[k]) >= 0.5)
           .map((k) => `${k}=${g[k].toFixed(2)}`);
-        // #1383 rides along: the label is always centred in its BUTTON, so with
-        // symmetric padding the ink delta is -(dL+dR)/2 and cannot fail while
-        // the edges hold — EXCEPT if `justify-content: center` is removed, which
-        // is a real #1383-shaped regression the edge deltas would not see.
-        //
-        // That sensitivity is ONE-SIDED, and it decides which call site matters.
-        // The column width equals the TANDEM button's max-content, so "Tandem"'s
-        // ink already fills its content box and its inkDelta stays ~0 however the
-        // label is justified. Only "Solo" has slack — (67.83 - 28 - 22.5)/2 ≈
-        // 8.6px of it. So the whole `justify-content` regression is caught by the
-        // solo assertion alone; drop that one call and #1383 coverage goes with
-        // it.
         if (Math.abs(g.inkDelta) >= 0.75) off.push(`inkDelta=${g.inkDelta.toFixed(2)}`);
         return off;
       },
       {
         timeout: 5_000,
         message:
-          `${label}: the sliding pill does not cover the selected segment (#1384). ` +
-          `The thumb is placed into grid area 1/1/2/2 of the track, so any non-zero edge ` +
-          `delta means the segments are no longer equal columns or the placement was lost. ` +
-          `An \`inkDelta\` entry with all four edges flush is the other defect (#1383): the ` +
-          `pill is correct and the LABEL is off-centre inside it — check \`justify-content\` ` +
-          `on \`.mode-toggle button\`.`,
+          `${label}: the pill does not cover the selected segment (#1384). An \`inkDelta\` ` +
+          `entry with all four edges flush is the other defect instead (#1383) — the pill is ` +
+          `right and the LABEL is off-centre in it; check \`justify-content\`.`,
       },
     )
     .toEqual([]);
@@ -159,17 +156,15 @@ test("the segments are equal and the pill covers the selected one (tandem defaul
 
   // The only assertion in this file that reads an ABSOLUTE height. Everything
   // else is a thumb-vs-button delta, so the pill and the button could grow
-  // together and every delta would stay 0.00. ModeToggle.svelte trims the
-  // button padding 5px -> 3px precisely to offset `line-height: normal`, and
-  // that arithmetic is otherwise unpinned: reverting the trim while keeping
-  // `normal` measures 24px.
+  // together and every delta would stay 0.00. ModeToggle.svelte trims the button
+  // padding 5px -> 3px precisely to offset `line-height: normal`; reverting the
+  // trim while keeping `normal` measures 24px, and nothing else would notice.
   expect(
-    g.thumbH,
-    `the pill is ${g.thumbH.toFixed(2)}px tall. It should hold ~20px under the shipped SN Pro ` +
-      `face (21px pre-swap). 24px means the button's 3px vertical padding was reverted to 5px ` +
+    Math.abs(g.thumbH - 20),
+    `the pill is ${g.thumbH.toFixed(2)}px tall; it should hold ~20px under the shipped SN Pro ` +
+      `face (21px pre-swap). 24px means the button's vertical padding was reverted to 5px ` +
       `without also reverting \`line-height: normal\` — see ModeToggle.svelte.`,
-  ).toBeLessThan(22);
-  expect(g.thumbH).toBeGreaterThan(18);
+  ).toBeLessThan(2);
 
   await expect(page.locator("[data-testid='mode-tandem-btn']")).toHaveAttribute(
     "aria-pressed",
@@ -202,34 +197,74 @@ test("the pill covers the selected segment after switching to solo, and back", a
   await expectThumbFlush(page, "tandem (after a slide)");
 });
 
+/** Force a track width the real layout cannot produce. Repeatable within a page. */
+async function setTrackCap(page: Page, px: number) {
+  await page.evaluate((cap) => {
+    let tag = document.getElementById("e2e-track-cap") as HTMLStyleElement | null;
+    if (!tag) {
+      tag = document.createElement("style");
+      tag.id = "e2e-track-cap";
+      document.head.appendChild(tag);
+    }
+    tag.textContent = `.mode-toggle { max-width: ${cap}px }`;
+  }, px);
+}
+
 test("the columns stay equal when the track is forced to compress", async ({ page }) => {
-  // `minmax(0, 1fr)` versus a bare `1fr` is the most-argued decision in this
-  // fix, and NOTHING in the shipped layout can exercise it: `.title-bar-mode` is
+  // `minmax(0, 1fr)` versus a bare `1fr` is the most-argued decision in this fix,
+  // and NOTHING in the shipped layout exercises it: `.title-bar-mode` is
   // `flex: 0 0 auto` and `.title-bar-center` carries `min-width: 0`, so the
-  // center strip absorbs every pixel of shrink and this track measures the same
-  // at every viewport width. Swept 1200 -> 200px, it never moved.
+  // center strip absorbs every pixel of shrink. Swept 1200 -> 200px, this track
+  // never moved. The regime is therefore injected rather than reached.
   //
-  // So the regime is injected rather than reached. Without this test the guard's
-  // only gate is a source literal in mode-toggle-thumb-contract.test.ts, which
-  // pins the spelling and can never see the effect — and a `min-width` on the
-  // button, which restores exactly the min-content floor `minmax(0, 1fr)` exists
-  // to defeat, is invisible at every other assertion in this file.
+  // That is not a hypothetical: it is a unit test of a CSS mechanism, run here
+  // because Playwright is the only layout engine in the repo. The source scan in
+  // mode-toggle-thumb-contract.test.ts pins the spelling of the guard; nothing
+  // but this can observe that it works.
   await boot(page);
-  await page.addStyleTag({ content: ".mode-toggle { max-width: 120px }" });
 
-  const g = await measure(page);
+  // 120px is mid-range; 62px is the boundary measured below. A bare `1fr`
+  // floors each column at min-content and fails both.
+  for (const cap of [120, 62]) {
+    await setTrackCap(page, cap);
+    const g = await measure(page);
+    expect(
+      Math.abs(g.soloW - g.tandemW),
+      `capped at ${cap}px: solo=${g.soloW.toFixed(2)} tandem=${g.tandemW.toFixed(2)}. Unequal ` +
+        `columns put the thumb — which IS column 1 — on a segment of a different width (#1384). ` +
+        `A bare \`1fr\` reopens exactly this.`,
+    ).toBeLessThan(0.5);
+    // Equal columns are necessary but not sufficient: a `min-width` on the
+    // button keeps the COLUMNS equal while the button outgrows the column the
+    // thumb is placed into, so only the flush check sees that one.
+    await expectThumbFlush(page, `capped at ${cap}px`);
+  }
+});
+
+test("the pill's guarantee ends at the padding floor, not below it", async ({ page }) => {
+  // The guarantee holds over a RANGE, and this asserts where the range ends so
+  // that no comment has to narrate it. Both `ModeToggle.svelte` and
+  // derived-spec.md previously carried a "~60px" figure; it was derivable and
+  // not derived, and it was wrong.
+  //
+  // The floor is the button's own horizontal padding (2 x 14px) plus the track's
+  // padding and border: 28 + 4 + 2 = 62px. Below that the buttons stop shrinking
+  // while the columns keep going, so the thumb — which tracks the COLUMN —
+  // becomes narrower than the button it is supposed to cover. Measured: at 62px
+  // dR = 0.00, at 61px dR = -0.50.
+  await boot(page);
+
+  await setTrackCap(page, 62);
+  await expectThumbFlush(page, "at the 62px floor");
+
+  await setTrackCap(page, 61);
+  const below = await measure(page);
   expect(
-    Math.abs(g.soloW - g.tandemW),
-    `compressed to 120px: solo=${g.soloW.toFixed(2)} tandem=${g.tandemW.toFixed(2)}. ` +
-      `A bare \`1fr\` measures 51.08/67.83 here because its \`auto\` minimum floors each ` +
-      `column at min-content; \`minmax(0, 1fr)\` measures 57/57. Unequal columns put the ` +
-      `thumb on a segment of a different width — #1384, reopened.`,
-  ).toBeLessThan(0.5);
-
-  // Equal columns are necessary but not sufficient: a `min-width` on the button
-  // keeps the COLUMNS equal while the button outgrows the column the thumb is
-  // placed in, so only the flush check sees it.
-  await expectThumbFlush(page, "compressed to 120px");
+    below.dR,
+    `one pixel below the floor the pill should already be narrower than its button. If this ` +
+      `passes, the floor moved — re-derive it from the button padding and the track chrome, ` +
+      `and update the test above rather than adding a comment.`,
+  ).toBeLessThan(-0.25);
 });
 
 test("the widened toggle still fits a narrow viewport", async ({ page }) => {
@@ -250,6 +285,10 @@ test("the widened toggle still fits a narrow viewport", async ({ page }) => {
   // step, not by this assertion. Do not read this as pinning the desktop case.
   await boot(page);
   await page.setViewportSize({ width: 360, height: 800 });
+  // Without this the sample can predate the resize, and since the assertion is
+  // `right <= innerWidth`, a stale WIDE-viewport reading passes vacuously — the
+  // test would go green having never measured the 360px layout.
+  await nextFrames(page);
 
   const fits = await page.evaluate(() => {
     const el = document.querySelector(".mode-toggle");

--- a/tests/helpers/css-source.ts
+++ b/tests/helpers/css-source.ts
@@ -52,3 +52,36 @@ export function styleBlocks(file: string): string {
 export function cssRules(css: string): Array<[string, string]> {
   return [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => [m[1], m[2]]);
 }
+
+/** One authored rule: its selector list already split, and its declaration body. */
+export type CssRule = { selectors: string[]; body: string };
+
+/**
+ * `cssRules` with the selector list split on `,`, which is what "does this rule
+ * apply to `.foo`?" actually needs.
+ *
+ * Comparing the unsplit list instead is the trap this exists to close: it works
+ * until someone groups the selector, and then `.thumb, .x { … }` stops matching
+ * `.thumb` and the scan reports the rule *missing* rather than reporting the
+ * declaration it was hired to check. Two suites had independently rolled this,
+ * and a third arrived comparing the unsplit form — three answers to one question.
+ */
+export function cssRulesBySelector(css: string): CssRule[] {
+  return cssRules(css).map(([selectorList, body]) => ({
+    selectors: selectorList.split(",").map((s) => s.trim()),
+    body,
+  }));
+}
+
+/**
+ * Rewrite Svelte's `:global(x)` to plain `x` so a component `<style>` block can
+ * be handed to a real CSS parser.
+ *
+ * lightningcss rejects `:global(...)` outright, which matters because the
+ * minifier gates are the only ones that see what actually ships. Without this a
+ * whole-block gate cannot exist, and the fallback — extracting one rule at a
+ * time — is what leaves synthetic-probe tests standing in for real ones.
+ */
+export function neutralizeSvelteGlobal(css: string): string {
+  return css.replace(/:global\(([^()]*)\)/g, "$1");
+}


### PR DESCRIPTION
Review response to #1427, which merged while the four review lenses were still running. Everything below is a correction to what is now on master.

Three findings were corroborated independently by more than one lens. The first is the same error class `/simplify` already caught once in this exact comment, which is the part worth reading.

## The figures were wrong, and internally impossible

The comment justified `minmax(0, 1fr)` with "at a 120px cap, `1fr` gives 52 / 70.97px columns while `minmax(0, 1fr)` gives 60 / 60px."

**52 + 70.97 = 122.97. 60 + 60 = 120.** Two different box models in one measurement. The app is `box-sizing: border-box` globally, so "60 / 60" only arises under `content-box`, and no lens could reproduce 70.97 under any face × box-sizing combination.

Measured in-app, three times independently:

| Track form | Solo | Tandem | Equal? |
|---|---|---|---|
| `repeat(2, 1fr)` @ 120px cap | **51.08** | **67.83** | no — and it overflows the cap |
| `repeat(2, minmax(0, 1fr))` @ 120px cap | **57** | **57** | yes |

The second pair checks out against the box: 57 + 57 + 4px padding + 2px border = **120 exactly**. That arithmetic check is precisely what the original figures failed, so it is now stated alongside them.

## It is a guard, not the fix — and the comment claimed otherwise

**Compression is unreachable through the viewport.** `.title-bar-mode` is `flex: 0 0 auto` and `.title-bar-center` carries `min-width: 0`, so the center strip absorbs every pixel of shrink. Swept 1200 → 200px, the track never moved; below ~400px the title bar overflows rather than compressing the toggle.

So the switch is defensive. It costs nothing and guards a future `min-width: 0`, but the comment presented it as holding "this component's whole invariant" against a live risk. Two limits are now stated rather than hidden:

- a squeezed label can outgrow its column (the accepted trade), and
- **below ~60px even this form fails** — the buttons cannot shrink past their own 28px horizontal padding, so they overflow equal columns and the thumb desyncs again (measured `dR = -6.00` at a 50px cap).

It widens the range over which the pill tracks its segment. It does not make it unconditional, and the spec no longer says it does.

## The guard is now gated, which closes the one surviving mutation

A full mutation matrix found that 8 of 9 obvious mutations were already killed. The interesting result was a probe that was not on my list:

**`min-width: 60px` on the button survived all three files.** The width guard's regex is `(?:^|[;\s])width\s*:` — the preceding character in `min-width` is `-`, so it cannot match. That mutation restores exactly the min-content floor `minmax(0, 1fr)` exists to defeat, keeps the *columns* equal, and is invisible at rest.

Since no viewport can reach compression, the E2E spec now injects it (`max-width: 120px`) rather than leaving the guard pinned only by a source literal. Both mutations verified to red against it:

- `min-width: 60px` → caught by the flush check (columns stay 57/57, button grows to 60, thumb misses by 3px)
- reverting to bare `1fr` → caught by the equality check, reporting `solo=51.08 tandem=67.83`

That second failure is also where the corrected figure came from.

## `position: relative` named the wrong containing block

The comment said removing it makes the thumb size itself "against the viewport." `.title-bar-mode` is **itself** `position: relative`, so the containing block falls through to *that* — the thumb covers the whole track with a 3px overhang.

Worth fixing precisely rather than approximately, because the accurate version exposes the real hazard: this rule's correctness depends on an ancestor rule in another file.

## The recorded reason for a deleted test was false

`/simplify` dropped three lightningcss cases as unfalsifiable. One reason was wrong: **lightningcss does rewrite `translateX(100%)` — to `translate(100%)`.** That axis was falsifiable, and a naive `toContain("translateX")` gate would have *failed*, not passed.

The deletion still stands (the rewrite is semantically identical), but that comment is now the only record of why the gate is gone, so it carries the measured reason. The `inset` justification had a related problem — true at today's targets, but lightningcss goes the *other* way at `{safari:13}` / `{chrome:80}` / `{ie:11}`. Replaced with the reason that cannot rot: both forms are geometrically identical at every target.

## The new pipeline gate did not read the component

It minified a hand-written `.probe{grid-area:1 / 1 / 2 / 2}`. Delete the entire `.thumb` rule from `ModeToggle.svelte` and it still passed.

That is the lesson the line-clamp gate **one describe block up** already records — *"the synthetic fixture above does not guard our source: deleting AnnotationCard's declaration failed nothing until this gate was added."* The new block did not follow its own neighbour.

Two gates added that minify the real extracted rules. Only the extracted rule is fed to lightningcss, not the whole `<style>` block — that block contains `:global(...)`, which is Svelte syntax it cannot parse. Verified: deleting `grid-area` from the component now reds **two** tests, confirming the source gate is independent of the shape gate rather than riding along.

## The invariant/shape split was wrong

The header claimed every shape gate was marked; **3 of 7 were.** And "declares no width rule on the buttons" was labelled an invariant while rejecting `flex: 1 1 0` + `min-width: 0` — a correct implementation the spec permits, measured flush to 0.00.

Exactly one gate pins an invariant, and it does so **by spec fiat rather than by geometry**: §3.9 bans the mechanism because it is how #1383/#1384 happened, deliberately stricter than the geometric requirement. The header now says that, with the counterexample inline.

Also fixed: the width scan missed `min-width`/`max-width` and read only the base button rule (`.on` and `:hover` are separate selectors); the percentage-geometry scan omitted `inset`, the property the fix itself now uses; and the comment-stripping rationale cited a literal (`calc(50% - 2px)`) that appears nowhere in the component, while describing the wrong failure route.

## Smaller corrections

- **The four-line `grid-area` comment described a horizontal failure.** It breaks **both** axes — width 136.78 vs 67.39 *and* height 23 vs 21. The row half is the non-obvious one: with no `grid-template-rows`, row line 2 lives in the *implicit* grid and reads as decorative. It is what holds the bottom edge flush.
- **`boot()` waited on `.tandem-editor`**, which needs an open document — coupling every test to the 400ms auto-scratchpad debounce for no signal, and making the "renders without a document" claim overstated. Dropped; tests are ~0.5s each now.
- **The narrow-viewport test had ~365px of slack** and could not fail for the reason it existed (the toggle cannot shrink, so the ~17.3px widening it guards could grow twentyfold first). Tightened 600px → 360px.
- **Added the file's only absolute-height assertion.** Every other check is a thumb-vs-button *delta*, so both boxes could grow together and stay 0.00 — leaving the 3px padding trim that offsets `line-height: normal` unpinned. Measured 20px; reverting the trim gives 24px.
- **Forced-colors note.** Measured: the thumb's background is forced to the same white as the track and its shadow to `none`, so the pill is invisible there and `outline: 2px solid ButtonText` is the *only* selection indicator. Commented so nobody deletes it as cosmetic.
- **Scoped the spec's percentage ban** to *sizing and positioning*, since `.thumb.tandem` legitimately uses `translateX(100%)` and the unscoped prose reads as forbidding it.

## Verification

- `npm run typecheck` — 1323 files, **0 errors**; biome + eslint clean
- `npm test -- --run` — **459 files, 6665 passed**, 19 skipped
- `npx playwright test mode-toggle-geometry` — **4 passed**
- **Mutation-tested all four new gates**, backup-and-restore: `min-width: 60px`, `inset: 0 0 0 50%`, deleting `grid-area` from the real component, and reverting the track to bare `1fr`. All red; the `grid-area` deletion reds two tests.

## The pattern worth naming

#1424's lesson was that three comments asserted a protection the control flow made inert. This one is sharper: **a rationale can be measurably backwards while being pinned by a test and blessed by a spec.** The bad figures survived a `/simplify` pass that was specifically re-measuring that claim, because it corrected the *direction* of the argument and carried the numbers across without re-checking them — and no gate can catch a wrong number in a comment. The arithmetic self-check (do the columns plus padding plus border equal the cap?) is the cheap thing that would have caught it both times.

Refs #1383
Refs #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYGFawL9kQruDZiUkYGBKD
