### PR TITLE
fix(tests): close the gate holes that let a banned declaration ship green

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "husky": "^9.1.7",
         "knip": "^5.66.0",
         "lint-staged": "^16.4.0",
+        "postcss": "^8.5.23",
         "svelte": "^5.46.4",
         "svelte-check": "^4.0.0",
         "tsup": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "husky": "^9.1.7",
     "knip": "^5.66.0",
     "lint-staged": "^16.4.0",
+    "postcss": "^8.5.23",
     "svelte": "^5.46.4",
     "svelte-check": "^4.0.0",
     "tsup": "^8.5.1",

--- a/src/client/editor/toolbar/ModeToggle.svelte
+++ b/src/client/editor/toolbar/ModeToggle.svelte
@@ -24,6 +24,7 @@ const { tandemMode, onModeChange }: Props = $props();
        sits correctly on mount with no slide; only a mode change animates it. -->
   <span class="thumb" class:tandem={tandemMode === "tandem"} aria-hidden="true"></span>
   <button
+    type="button"
     data-testid="mode-solo-btn"
     class={tandemMode === "solo" ? "on" : ""}
     title="Write undisturbed — your AI pauses and won't see your comments or edits until you switch back to Tandem"
@@ -31,6 +32,7 @@ const { tandemMode, onModeChange }: Props = $props();
     onclick={() => onModeChange("solo")}
   >Solo</button>
   <button
+    type="button"
     data-testid="mode-tandem-btn"
     class={tandemMode === "tandem" ? "on" : ""}
     title="Full collaboration — your AI sees your selections, comments, and edits as you make them"
@@ -124,10 +126,11 @@ const { tandemMode, onModeChange }: Props = $props();
        Center the label on both axes. `line-height: normal` (not the tight `1`)
        is the load-bearing part: at `line-height: 1` the line box is shorter
        than the glyph's natural box and the text renders cramped against the
-       top. `normal` distributes the leading evenly, and the padding is trimmed
-       5px -> 3px to offset the taller line box so the pill keeps its height.
-       That pairing is the one thing here a delta-based test cannot see, so the
-       E2E spec asserts the pill's absolute height. */
+       top. `normal` distributes the leading evenly, and the vertical padding
+       below is trimmed to offset the taller line box so the pill keeps its
+       height. Change one without the other and the pill's height moves while
+       every thumb-vs-button delta stays 0.00 — which is why the E2E spec
+       asserts the pill's absolute height, the only such assertion it makes. */
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/tests/design-system-impl/backdrop-filter-guard.test.ts
+++ b/tests/design-system-impl/backdrop-filter-guard.test.ts
@@ -1,7 +1,6 @@
-import { readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
-import { cssRules, stripCssComments, styleBlocks } from "../helpers/css-source";
+import { bundledCssFiles, cssRules, stripCssComments, styleBlocks } from "../helpers/css-source";
 
 /**
  * backdrop-filter regression gate.
@@ -82,21 +81,6 @@ function floatingPillRulesIn(css: string): { selector: string; body: string }[] 
   return cssRules(stripCssComments(css))
     .map(([selector, body]) => ({ selector: selector.trim(), body }))
     .filter((r) => RECIPE_SELECTOR.test(r.selector));
-}
-
-/**
- * Every file whose CSS Vite routes through lightningcss. Deliberately excludes
- * `index.html`: its inline `<style>` is emitted verbatim, so it is NOT a bundled
- * source and the collapse cannot reach it. The two obey different rules — see
- * `allRecipeSources` and the `-webkit-` gate below.
- */
-function bundledCssFiles(dir: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) bundledCssFiles(full, out);
-    else if (full.endsWith(".svelte") || full.endsWith(".css")) out.push(full);
-  }
-  return out;
 }
 
 /**

--- a/tests/design-system-impl/css-pipeline-contract.test.ts
+++ b/tests/design-system-impl/css-pipeline-contract.test.ts
@@ -1,9 +1,9 @@
-import { readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { transform } from "lightningcss";
 import { resolveConfig } from "vite";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
+  bundledCssFiles,
   cssRules,
   cssRulesBySelector,
   neutralizeSvelteGlobal,
@@ -54,14 +54,8 @@ const FORMATTING_BAR = join(CLIENT_ROOT, "shell", "FormattingBar.svelte");
  * rest of Svelte's CSS dialect would still need a real parser.
  */
 function authoredRule(file: string, selector: string, mustDeclare?: RegExp): string {
-  // Stripped of `g`/`y` deliberately: `test()` on a sticky or global regex
-  // advances `lastIndex`, so reusing one inside a `.filter` would skip every
-  // other candidate and the count below would be wrong in a way that reads like
-  // a missing rule. No caller passes one today; this makes it impossible to.
-  const declares =
-    mustDeclare && new RegExp(mustDeclare.source, mustDeclare.flags.replace(/[gy]/g, ""));
   const matches = cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(file))).filter(
-    (r) => r.selectors.includes(selector) && (!declares || declares.test(r.body)),
+    (r) => r.selectors.includes(selector) && (!mustDeclare || mustDeclare.test(r.body)),
   );
   expect(
     matches.length,
@@ -172,56 +166,6 @@ function minify(css: string): string {
 
 const declares = (css: string, prop: string) => new RegExp(`[;{]\\s*${prop}\\s*:`).test(css);
 
-describe("the shared CSS extractor can still read what this repo authors", () => {
-  // Every gate in this file and in mode-toggle-thumb-contract.test.ts is built on
-  // `tests/helpers/css-source.ts`, which is regexes rather than a parser. Its own
-  // docstring names the hazard — Svelte's CSS dialect can grow, and a splitter
-  // that cannot represent the new form does not fail, it returns fewer rules and
-  // reports green. Two live instances were found by review rather than by any
-  // test: CSS nesting silently drops the parent rule's declarations, and a
-  // `:global()` holding parentheses is left unrewritten.
-  //
-  // Both now throw, which is only useful if something runs them over the real
-  // corpus. That is this: the assertion is not about any one rule, it is that the
-  // extractor still understands the whole surface the other gates trust it on. It
-  // fails the day someone adopts a form the helpers cannot represent, which is
-  // the day those gates would otherwise start passing vacuously.
-  const files = bundledCssFiles(CLIENT_ROOT);
-
-  it("enumerates a plausible corpus", () => {
-    // Guards the sweep below from passing on an empty list.
-    expect(files.length).toBeGreaterThan(50);
-  });
-
-  it("extracts every bundled file without losing structure", () => {
-    const broken: string[] = [];
-    for (const file of files) {
-      const where = relative(ROOT, file).replace(/\\/g, "/");
-      let rules: ReturnType<typeof cssRulesBySelector>;
-      try {
-        rules = cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(file)));
-      } catch (err) {
-        broken.push(`${where}: ${(err as Error).message}`);
-        continue;
-      }
-      for (const rule of rules) {
-        // A brace or an empty string in a selector means the splitter lost its
-        // place; a brace in a body means a nested block was swallowed whole.
-        if (rule.selectors.some((s) => s === "" || s.includes("{"))) {
-          broken.push(`${where}: unparseable selector ${JSON.stringify(rule.selectors)}`);
-        }
-        if (rule.body.includes("}")) {
-          broken.push(`${where}: rule body contains a closing brace`);
-        }
-        if (rule.selectors.some((s) => s.includes(":global("))) {
-          broken.push(`${where}: unrewritten :global( in ${JSON.stringify(rule.selectors)}`);
-        }
-      }
-    }
-    expect(broken).toEqual([]);
-  });
-});
-
 describe("the Vite CSS target our authoring rule depends on", () => {
   it("reads Tandem's real Vite config", () => {
     // Guards the beforeAll assertion above from being silently skipped.
@@ -316,32 +260,26 @@ describe("bundled CSS: the #1302 formatting-bar declarations survive minificatio
     // popup — and no E2E test would catch it, because Playwright drives
     // `npm run dev`, which never minifies.
     //
-    // The real selector AND the real body, not a `.w:has(...){z-index:9}` probe:
-    // this gate was synthetic until #1428, so deleting the rule from
-    // FormattingBar left it green. That is the same defect the line-clamp gate
-    // below records and the mode-toggle block above now avoids — three
-    // instances of one class.
-    //
-    // #1428 fixed only half of it, which is why this reads the way it does.
-    // Scraping the selector but hand-writing the declaration still asserts
-    // nothing about what ships, and taking `wrap[0]` off an at-least-one guard
-    // reintroduced the original hole from the other side: with a second
-    // `:has([aria-expanded])` rule present, deleting THIS one still passed.
-    // Identify the rule by the property that makes it the z-lift, and require
-    // exactly one.
-    const lifts = cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(FORMATTING_BAR))).flatMap(
-      (rule) =>
-        rule.selectors
-          .filter((s) => s.includes(":has(") && s.includes("aria-expanded"))
-          .map((selector) => ({ selector, body: rule.body })),
+    // The real rule, both halves, not a `.w:has(...){z-index:9}` probe. Two
+    // mutations, both of which passed a previous spelling of this gate:
+    // deleting the rule outright (it was fully synthetic), and deleting it
+    // while any other `:has([aria-expanded])` rule remained (the selector was
+    // scraped, but taken as `wrap[0]` off an at-least-one guard). Identifying
+    // it by the property that makes it the z-lift, and requiring exactly one,
+    // closes both.
+    const isLift = (s: string) => s.includes(":has(") && s.includes("aria-expanded");
+    const lifts = cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(FORMATTING_BAR))).filter(
+      (rule) => rule.selectors.some(isLift),
     );
     expect(
-      lifts.map((l) => l.selector),
+      lifts.map((r) => r.selectors.join(", ")),
       "expected exactly one `:has([aria-expanded])` rule in FormattingBar.svelte — " +
         "the #1302 z-lift was removed, renamed, or joined by a lookalike",
     ).toHaveLength(1);
 
-    const out = minify(`${lifts[0].selector}{${lifts[0].body}}`);
+    // Grouped as authored: counting RULES rather than selectors means a legal
+    // `.a:has(…), .b:has(…)` grouping is one rule, not a false red.
+    const out = minify(`${lifts[0].selectors.join(", ")}{${lifts[0].body}}`);
     expect(out).toContain(":has(");
     expect(out).toContain("aria-expanded");
     // The lift itself, not just its selector: a surviving `:has()` that no
@@ -433,16 +371,6 @@ describe("bundled CSS: the #1383/#1384 mode-toggle declarations survive minifica
     expect(out).toContain("gap:0");
   });
 });
-
-/** Every `.svelte` `<style>` / `.css` file whose CSS the build routes through lightningcss. */
-function bundledCssFiles(dir: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) bundledCssFiles(full, out);
-    else if (full.endsWith(".svelte") || full.endsWith(".css")) out.push(full);
-  }
-  return out;
-}
 
 /**
  * Every rule body in bundled CSS that hand-writes both `-webkit-X` and `X`.

--- a/tests/design-system-impl/css-pipeline-contract.test.ts
+++ b/tests/design-system-impl/css-pipeline-contract.test.ts
@@ -54,8 +54,14 @@ const FORMATTING_BAR = join(CLIENT_ROOT, "shell", "FormattingBar.svelte");
  * rest of Svelte's CSS dialect would still need a real parser.
  */
 function authoredRule(file: string, selector: string, mustDeclare?: RegExp): string {
+  // Stripped of `g`/`y` deliberately: `test()` on a sticky or global regex
+  // advances `lastIndex`, so reusing one inside a `.filter` would skip every
+  // other candidate and the count below would be wrong in a way that reads like
+  // a missing rule. No caller passes one today; this makes it impossible to.
+  const declares =
+    mustDeclare && new RegExp(mustDeclare.source, mustDeclare.flags.replace(/[gy]/g, ""));
   const matches = cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(file))).filter(
-    (r) => r.selectors.includes(selector) && (!mustDeclare || mustDeclare.test(r.body)),
+    (r) => r.selectors.includes(selector) && (!declares || declares.test(r.body)),
   );
   expect(
     matches.length,
@@ -67,10 +73,16 @@ function authoredRule(file: string, selector: string, mustDeclare?: RegExp): str
 }
 
 /**
- * `.thumb` appears three times in ModeToggle.svelte (base, the reduced-motion
- * media override, and the in-app `body.tandem-reduce-motion` override), and the
- * two overrides declare only `transition: none`. `background` picks the one that
- * paints, independent of every placement property under test.
+ * Two rules in ModeToggle.svelte carry the exact selector `.thumb` — the base
+ * rule and the reduced-motion media override — and the override declares only
+ * `transition: none`. `background` picks the one that paints, independent of
+ * every placement property under test.
+ *
+ * The in-app `:global(body.tandem-reduce-motion) .thumb` override is a third
+ * `.thumb` rule in the file but not a third *candidate*: it is a descendant
+ * selector, and the filter matches selectors exactly. Worth stating, because a
+ * reader debugging a count failure would otherwise hunt for a rule that was
+ * never in the running.
  */
 const paintingRule = (selector: string) => authoredRule(MODE_TOGGLE, selector, /background\s*:/);
 const trackRule = () => authoredRule(MODE_TOGGLE, ".mode-toggle");
@@ -159,6 +171,56 @@ function minify(css: string): string {
 }
 
 const declares = (css: string, prop: string) => new RegExp(`[;{]\\s*${prop}\\s*:`).test(css);
+
+describe("the shared CSS extractor can still read what this repo authors", () => {
+  // Every gate in this file and in mode-toggle-thumb-contract.test.ts is built on
+  // `tests/helpers/css-source.ts`, which is regexes rather than a parser. Its own
+  // docstring names the hazard — Svelte's CSS dialect can grow, and a splitter
+  // that cannot represent the new form does not fail, it returns fewer rules and
+  // reports green. Two live instances were found by review rather than by any
+  // test: CSS nesting silently drops the parent rule's declarations, and a
+  // `:global()` holding parentheses is left unrewritten.
+  //
+  // Both now throw, which is only useful if something runs them over the real
+  // corpus. That is this: the assertion is not about any one rule, it is that the
+  // extractor still understands the whole surface the other gates trust it on. It
+  // fails the day someone adopts a form the helpers cannot represent, which is
+  // the day those gates would otherwise start passing vacuously.
+  const files = bundledCssFiles(CLIENT_ROOT);
+
+  it("enumerates a plausible corpus", () => {
+    // Guards the sweep below from passing on an empty list.
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it("extracts every bundled file without losing structure", () => {
+    const broken: string[] = [];
+    for (const file of files) {
+      const where = relative(ROOT, file).replace(/\\/g, "/");
+      let rules: ReturnType<typeof cssRulesBySelector>;
+      try {
+        rules = cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(file)));
+      } catch (err) {
+        broken.push(`${where}: ${(err as Error).message}`);
+        continue;
+      }
+      for (const rule of rules) {
+        // A brace or an empty string in a selector means the splitter lost its
+        // place; a brace in a body means a nested block was swallowed whole.
+        if (rule.selectors.some((s) => s === "" || s.includes("{"))) {
+          broken.push(`${where}: unparseable selector ${JSON.stringify(rule.selectors)}`);
+        }
+        if (rule.body.includes("}")) {
+          broken.push(`${where}: rule body contains a closing brace`);
+        }
+        if (rule.selectors.some((s) => s.includes(":global("))) {
+          broken.push(`${where}: unrewritten :global( in ${JSON.stringify(rule.selectors)}`);
+        }
+      }
+    }
+    expect(broken).toEqual([]);
+  });
+});
 
 describe("the Vite CSS target our authoring rule depends on", () => {
   it("reads Tandem's real Vite config", () => {
@@ -254,21 +316,37 @@ describe("bundled CSS: the #1302 formatting-bar declarations survive minificatio
     // popup — and no E2E test would catch it, because Playwright drives
     // `npm run dev`, which never minifies.
     //
-    // The real selector, not a `.w:has(...)` probe: this gate was synthetic
-    // until #1428, so deleting the rule from FormattingBar left it green. That
-    // is the same defect the line-clamp gate below records and the mode-toggle
-    // block above now avoids — three instances of one class.
-    const wrap = cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(FORMATTING_BAR)))
-      .flatMap((r) => r.selectors)
-      .filter((s) => s.includes(":has("));
+    // The real selector AND the real body, not a `.w:has(...){z-index:9}` probe:
+    // this gate was synthetic until #1428, so deleting the rule from
+    // FormattingBar left it green. That is the same defect the line-clamp gate
+    // below records and the mode-toggle block above now avoids — three
+    // instances of one class.
+    //
+    // #1428 fixed only half of it, which is why this reads the way it does.
+    // Scraping the selector but hand-writing the declaration still asserts
+    // nothing about what ships, and taking `wrap[0]` off an at-least-one guard
+    // reintroduced the original hole from the other side: with a second
+    // `:has([aria-expanded])` rule present, deleting THIS one still passed.
+    // Identify the rule by the property that makes it the z-lift, and require
+    // exactly one.
+    const lifts = cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(FORMATTING_BAR))).flatMap(
+      (rule) =>
+        rule.selectors
+          .filter((s) => s.includes(":has(") && s.includes("aria-expanded"))
+          .map((selector) => ({ selector, body: rule.body })),
+    );
     expect(
-      wrap,
-      "no `:has()` rule left in FormattingBar.svelte — the #1302 z-lift was removed or renamed",
-    ).not.toEqual([]);
+      lifts.map((l) => l.selector),
+      "expected exactly one `:has([aria-expanded])` rule in FormattingBar.svelte — " +
+        "the #1302 z-lift was removed, renamed, or joined by a lookalike",
+    ).toHaveLength(1);
 
-    const out = minify(`${wrap[0]}{z-index:9}`);
+    const out = minify(`${lifts[0].selector}{${lifts[0].body}}`);
     expect(out).toContain(":has(");
     expect(out).toContain("aria-expanded");
+    // The lift itself, not just its selector: a surviving `:has()` that no
+    // longer raises anything is the bug wearing the gate's own shape.
+    expect(out).toContain("z-index");
   });
 
   it("keeps overflow-x: clip / overflow-y: visible as a clip+visible pair", () => {
@@ -301,7 +379,12 @@ describe("bundled CSS: the #1383/#1384 mode-toggle declarations survive minifica
   //
   // These gates read the REAL rules and minify those, so they also stand in for
   // the source-shape gates that used to live in mode-toggle-thumb-contract.test
-  // .ts — they fail on everything those did, plus minifier drift.
+  // .ts, adding minifier drift to what those caught. Not a strict superset,
+  // and the exception is the first bullet below: a rewrite to the `inset`
+  // longhands failed the old source regex and passes here, because the minifier
+  // collapses it back. Deliberate — the two spellings are the same box — but
+  // the two statements have to agree, and "fails on everything those did" did
+  // not agree with the bullet six lines under it.
   //
   // Two rewrites were investigated and deliberately have no gate, because a test
   // that can only pass is not one — and neither is one that reds on a rename the

--- a/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
+++ b/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
@@ -89,11 +89,16 @@ describe("ModeToggle: the mechanisms that must stay absent", () => {
     // "remove the unused expression" cleanup cannot quietly reopen the hole.
     assertRuleExists(".mode-toggle button");
 
+    // `fullSelectors`, not `selectors`: a `.mode-toggle { button { … } }` CSS
+    // nesting rewrite gives the inner rule a bare local selector (`"button"`),
+    // which never carries the `.mode-toggle` prefix a `startsWith` scan needs —
+    // `fullSelectors` resolves it against the ancestor chain first. Reintroduces
+    // the exact hole `assertRuleExists` above already guards against by name.
     const offenders = RULES.filter((r) =>
-      r.selectors.some((s) => s.startsWith(".mode-toggle button")),
+      r.fullSelectors.some((s) => s.startsWith(".mode-toggle button")),
     ).flatMap((r) =>
       [...r.body.matchAll(/(?:^|[;\s])((?:min-|max-)?width|flex)\s*:[^;]*/g)].map(
-        (m) => `${r.selectors.join(", ")} { ${m[0].trim()} }`,
+        (m) => `${r.fullSelectors.join(", ")} { ${m[0].trim()} }`,
       ),
     );
     expect(offenders).toEqual([]);

--- a/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
+++ b/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
@@ -9,22 +9,15 @@ import { cssRulesBySelector, styleBlocks } from "../helpers/css-source";
  * ModeToggle.svelte; this file pins the shape of that fix rather than
  * re-explaining it. What a failure means is in each message below.
  *
- * **These are all NEGATIVE scans, and that is deliberate.** The positive
- * literals this file used to assert — `inline-grid`, `minmax(0,`,
- * `grid-area: 1/1/2/2`, `inset: 0`, `position: relative` — moved to
- * css-pipeline-contract.test.ts, which reads the same source and then runs it
- * through the real minifier, so it adds minifier drift to what those caught.
- * Mutation-tested both ways, with one measured exception in the other
- * direction: rewriting `inset: 0` to the four longhands failed the old source
- * regex, and passes the new gate because the minifier collapses it back. That
- * is a false red removed rather than coverage lost — the two spellings are the
- * same box — but "everything the old gates caught" would be the wrong claim,
- * and it is the sort of claim that stops anyone from checking.
- *
- * What survives is what a positive scan cannot express: that something is
- * ABSENT. No percentage geometry, no width rule, no gutter — each of them a
- * property that admits infinitely many spellings, which is exactly the shape a
- * `toContain` cannot pin.
+ * **Mostly NEGATIVE scans, and that is deliberate.** The positive literals this
+ * file used to assert — `inline-grid`, `minmax(0,`, `grid-area: 1/1/2/2`,
+ * `inset: 0`, `position: relative` — moved to css-pipeline-contract.test.ts,
+ * which reads the same source and then runs it through the real minifier. What
+ * stayed is what a positive scan cannot express: that something is ABSENT. No
+ * percentage geometry, no width rule, no gutter — each a property admitting
+ * infinitely many spellings, which is exactly the shape a `toContain` cannot
+ * pin. (The translate check at the end is positive, and belongs here because it
+ * guards the extraction as much as the declaration; see its comment.)
  *
  * One of them is a genuine invariant, and by SPEC FIAT rather than by geometry:
  * derived-spec.md §3.9 bans percentage-derived thumb sizing outright because it
@@ -52,6 +45,11 @@ function ruleWithSelector(selector: string): string {
     0,
   );
   return found.map((r) => r.body).join("\n");
+}
+
+/** The same existence assertion, for a scan that needs the proof but not the body. */
+function assertRuleExists(selector: string): void {
+  ruleWithSelector(selector);
 }
 
 describe("ModeToggle: the mechanisms that must stay absent", () => {
@@ -85,9 +83,11 @@ describe("ModeToggle: the mechanisms that must stay absent", () => {
     // same elements and fails `startsWith`, so the filter yields zero rules and
     // `offenders` is `[]` by construction. Mutation-proved: that rename carrying
     // `min-width: 60px`, the exact bug this gate exists to catch, passed the
-    // whole suite. (Folding a child rule into the base one via CSS nesting would
-    // also empty the scan; `cssRules` throws on that, so it is guarded upstream.)
-    ruleWithSelector(".mode-toggle button");
+    // whole suite.
+    //
+    // `ruleWithSelector` is called for its assertion, not its value. Named so a
+    // "remove the unused expression" cleanup cannot quietly reopen the hole.
+    assertRuleExists(".mode-toggle button");
 
     const offenders = RULES.filter((r) =>
       r.selectors.some((s) => s.startsWith(".mode-toggle button")),
@@ -100,30 +100,27 @@ describe("ModeToggle: the mechanisms that must stay absent", () => {
   });
 
   it("carries no percentage-derived sizing on the thumb", () => {
-    // The property list tracks the ban, not the current implementation:
-    // `inset` because the fix itself now uses it, `margin` because
-    // `margin-left: 50%` is percentage positioning the spec forbids and an
-    // earlier list let through.
+    // A ban on VALUES, not an enumeration of properties, because §3.9 states it
+    // that way — "no percentage or `calc` sizing or positioning on the thumb" —
+    // and because every enumeration of this has been short. The last one listed
+    // ten properties and still let `transform: translateX(50%)` through, which
+    // is percentage positioning AND half of the literal #1383/#1384 mechanism
+    // (`width: calc(50% - 2px)` plus a translate). `padding` and the individual
+    // `translate` property were missing too.
     //
-    // The `(?:min-|max-)?` prefix and the logical sizes are load-bearing, not
-    // completeness theatre. `[a-z-]*` only extends a property to the RIGHT
-    // (`margin` → `margin-left`), while the `(?:^|[;\s])` anchor requires the
-    // character before the match to be a separator — so `min-width` cannot match
-    // via `width`, whose preceding character is `-`. Mutation-proved: before the
-    // prefix was added, `max-width: 50%` on the thumb passed all 73 tests. The
-    // sibling scan above already spelled `(?:min-|max-)?width`, so this was one
-    // scan of two carrying knowledge the file already had.
-    const offenders = [
-      ...ruleWithSelector(".thumb").matchAll(
-        /(?:^|[;\s])((?:min-|max-)?(?:width|height|block-size|inline-size)|inset|margin|left|right|top|bottom)[a-z-]*\s*:[^;]*(%|calc\()/g,
-      ),
-    ].map((m) => m[0].trim());
+    // This costs nothing to hold: the shipped `.thumb` rule declares position,
+    // grid-area, inset, background, border-radius, box-shadow, pointer-events,
+    // z-index and transition, and the reduced-motion override declares
+    // `transition: none` — not one `%` or `calc(` between them. The legal
+    // `translateX(100%)` lives in `.thumb.tandem`, a different rule that
+    // exact-selector matching never hands to this scan, and which the test
+    // below pins positively.
     expect(
-      offenders,
+      ruleWithSelector(".thumb"),
       "#1383/#1384 were caused by sizing the thumb as a fraction of the track " +
         "(`width: calc(50% - 2px)`), which assumed equal halves the layout never produced. " +
         "The grid area supplies the box; see derived-spec.md §3.9.",
-    ).toEqual([]);
+    ).not.toMatch(/%|calc\(/);
   });
 
   it("still slides exactly one column on a mode flip", () => {

--- a/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
+++ b/tests/design-system-impl/mode-toggle-thumb-contract.test.ts
@@ -13,10 +13,13 @@ import { cssRulesBySelector, styleBlocks } from "../helpers/css-source";
  * literals this file used to assert — `inline-grid`, `minmax(0,`,
  * `grid-area: 1/1/2/2`, `inset: 0`, `position: relative` — moved to
  * css-pipeline-contract.test.ts, which reads the same source and then runs it
- * through the real minifier, so it fails on everything these did *plus*
- * minifier drift. Mutation-tested both ways: those five gates were strictly
- * subsumed, and this file's own rule is that a superseded gate should be
- * deleted rather than re-satisfied.
+ * through the real minifier, so it adds minifier drift to what those caught.
+ * Mutation-tested both ways, with one measured exception in the other
+ * direction: rewriting `inset: 0` to the four longhands failed the old source
+ * regex, and passes the new gate because the minifier collapses it back. That
+ * is a false red removed rather than coverage lost — the two spellings are the
+ * same box — but "everything the old gates caught" would be the wrong claim,
+ * and it is the sort of claim that stops anyone from checking.
  *
  * What survives is what a positive scan cannot express: that something is
  * ABSENT. No percentage geometry, no width rule, no gutter — each of them a
@@ -75,6 +78,17 @@ describe("ModeToggle: the mechanisms that must stay absent", () => {
     // Every `.mode-toggle button*` rule is scanned, not just the base one:
     // `.on` and `:hover:not(.on)` are separate selectors and a width added
     // there would slip past a base-rule-only check.
+    //
+    // Anchor on the exact base selector first, because a negative scan proves
+    // nothing without evidence it scanned something — and this one is defeated
+    // by a rename that changes no behaviour. `.mode-toggle > button` selects the
+    // same elements and fails `startsWith`, so the filter yields zero rules and
+    // `offenders` is `[]` by construction. Mutation-proved: that rename carrying
+    // `min-width: 60px`, the exact bug this gate exists to catch, passed the
+    // whole suite. (Folding a child rule into the base one via CSS nesting would
+    // also empty the scan; `cssRules` throws on that, so it is guarded upstream.)
+    ruleWithSelector(".mode-toggle button");
+
     const offenders = RULES.filter((r) =>
       r.selectors.some((s) => s.startsWith(".mode-toggle button")),
     ).flatMap((r) =>
@@ -90,9 +104,18 @@ describe("ModeToggle: the mechanisms that must stay absent", () => {
     // `inset` because the fix itself now uses it, `margin` because
     // `margin-left: 50%` is percentage positioning the spec forbids and an
     // earlier list let through.
+    //
+    // The `(?:min-|max-)?` prefix and the logical sizes are load-bearing, not
+    // completeness theatre. `[a-z-]*` only extends a property to the RIGHT
+    // (`margin` → `margin-left`), while the `(?:^|[;\s])` anchor requires the
+    // character before the match to be a separator — so `min-width` cannot match
+    // via `width`, whose preceding character is `-`. Mutation-proved: before the
+    // prefix was added, `max-width: 50%` on the thumb passed all 73 tests. The
+    // sibling scan above already spelled `(?:min-|max-)?width`, so this was one
+    // scan of two carrying knowledge the file already had.
     const offenders = [
       ...ruleWithSelector(".thumb").matchAll(
-        /(?:^|[;\s])(inset|margin|width|height|left|right|top|bottom)[a-z-]*\s*:[^;]*(%|calc\()/g,
+        /(?:^|[;\s])((?:min-|max-)?(?:width|height|block-size|inline-size)|inset|margin|left|right|top|bottom)[a-z-]*\s*:[^;]*(%|calc\()/g,
       ),
     ].map((m) => m[0].trim());
     expect(

--- a/tests/e2e/mode-toggle-geometry.spec.ts
+++ b/tests/e2e/mode-toggle-geometry.spec.ts
@@ -40,10 +40,16 @@ async function boot(page: Page) {
   await page.goto("/");
   await page.locator("[data-testid='mode-toggle']").waitFor({ state: "visible", timeout: 15_000 });
   // SN Pro ships `font-display: swap` (index.html), and the swap CHANGES these
-  // metrics — measured 50.00 -> 50.53 on the solo segment, 123.39 -> 124.36 on
-  // the track. Every assertion below uses an absolute px tolerance and
+  // metrics: the segments are sized from label text, so every width here moves
+  // when the face does. Every assertion below uses an absolute px tolerance and
   // `expect.poll` re-evaluates, so a pre-swap sample and a post-swap sample
   // would be describing two different layouts.
+  //
+  // (The figures that used to sit here were the PRE-FIX widths, left behind
+  // when the fix changed them, and the same file described the same track three
+  // times with one of the three 17px out. Deleted rather than re-measured: the
+  // point is that the swap moves them, which nothing here can assert and no
+  // number makes truer.)
   await page.evaluate(() => document.fonts.ready);
 }
 
@@ -156,14 +162,15 @@ test("the segments are equal and the pill covers the selected one (tandem defaul
 
   // The only assertion in this file that reads an ABSOLUTE height. Everything
   // else is a thumb-vs-button delta, so the pill and the button could grow
-  // together and every delta would stay 0.00. ModeToggle.svelte trims the button
-  // padding 5px -> 3px precisely to offset `line-height: normal`; reverting the
-  // trim while keeping `normal` measures 24px, and nothing else would notice.
+  // together and every delta would stay 0.00. ModeToggle.svelte's button padding
+  // and its `line-height: normal` are a matched pair — the padding is trimmed to
+  // offset the taller line box — and changing one without the other moves this
+  // height while disturbing no delta in the file.
   expect(
     Math.abs(g.thumbH - 20),
     `the pill is ${g.thumbH.toFixed(2)}px tall; it should hold ~20px under the shipped SN Pro ` +
-      `face (21px pre-swap). 24px means the button's vertical padding was reverted to 5px ` +
-      `without also reverting \`line-height: normal\` — see ModeToggle.svelte.`,
+      `face. If this drifted, the button's vertical padding and \`line-height\` were changed ` +
+      `independently of each other — see ModeToggle.svelte.`,
   ).toBeLessThan(2);
 
   await expect(page.locator("[data-testid='mode-tandem-btn']")).toHaveAttribute(
@@ -197,6 +204,43 @@ test("the pill covers the selected segment after switching to solo, and back", a
   await expectThumbFlush(page, "tandem (after a slide)");
 });
 
+/**
+ * The narrowest track that still holds the pill's guarantee, DERIVED from the
+ * shipped CSS rather than transcribed from it.
+ *
+ * Deriving it is the point. This boundary has been stated as a literal three
+ * times — "~60px" twice in prose, then a worked sum that added to 34 while
+ * claiming 62 — and each time the figure was admissible under whatever rule was
+ * in force and wrong anyway. A comment cannot be made to add up; this can.
+ *
+ * `box-sizing: border-box` is global (index.html), so `max-width` clamps the
+ * BORDER box: the track's own padding and border sit inside the cap, and each
+ * button floors at its own horizontal padding because its content box cannot go
+ * below zero. Two buttons, because both columns must fit — the missing half of
+ * the sum this replaces.
+ */
+async function paddingFloor(page: Page): Promise<number> {
+  const floor = await page.evaluate(() => {
+    const track = document.querySelector<HTMLElement>(".mode-toggle");
+    if (!track) throw new Error("missing .mode-toggle");
+    const buttons = [...track.querySelectorAll<HTMLElement>("button")];
+    if (buttons.length !== 2) throw new Error(`expected 2 segments, found ${buttons.length}`);
+    const px = (v: string) => Number.parseFloat(v) || 0;
+    const sides = (el: Element) => {
+      const s = getComputedStyle(el);
+      return (
+        px(s.paddingLeft) + px(s.paddingRight) + px(s.borderLeftWidth) + px(s.borderRightWidth)
+      );
+    };
+    return sides(track) + buttons.reduce((sum, b) => sum + sides(b), 0);
+  });
+  // A zeroed or absurd floor would make both assertions below meaningless
+  // rather than failing: capping at 0 collapses everything flush.
+  expect(floor, "derived padding floor is implausible — did the query desync?").toBeGreaterThan(20);
+  expect(floor).toBeLessThan(300);
+  return floor;
+}
+
 /** Force a track width the real layout cannot produce. Repeatable within a page. */
 async function setTrackCap(page: Page, px: number) {
   await page.evaluate((cap) => {
@@ -213,9 +257,9 @@ async function setTrackCap(page: Page, px: number) {
 test("the columns stay equal when the track is forced to compress", async ({ page }) => {
   // `minmax(0, 1fr)` versus a bare `1fr` is the most-argued decision in this fix,
   // and NOTHING in the shipped layout exercises it: `.title-bar-mode` is
-  // `flex: 0 0 auto` and `.title-bar-center` carries `min-width: 0`, so the
-  // center strip absorbs every pixel of shrink. Swept 1200 -> 200px, this track
-  // never moved. The regime is therefore injected rather than reached.
+  // `flex: 0 0 auto`, so it overflows rather than compresses at any viewport,
+  // and `.title-bar-center` carries `min-width: 0` and takes the shrink instead.
+  // The regime is therefore injected rather than reached.
   //
   // That is not a hypothetical: it is a unit test of a CSS mechanism, run here
   // because Playwright is the only layout engine in the repo. The source scan in
@@ -223,9 +267,9 @@ test("the columns stay equal when the track is forced to compress", async ({ pag
   // but this can observe that it works.
   await boot(page);
 
-  // 120px is mid-range; 62px is the boundary measured below. A bare `1fr`
-  // floors each column at min-content and fails both.
-  for (const cap of [120, 62]) {
+  // Mid-range, then the floor itself — the two ends of the range the guarantee
+  // covers. A bare `1fr` floors each column at min-content and fails both.
+  for (const cap of [120, await paddingFloor(page)]) {
     await setTrackCap(page, cap);
     const g = await measure(page);
     expect(
@@ -247,35 +291,43 @@ test("the pill's guarantee ends at the padding floor, not below it", async ({ pa
   // derived-spec.md previously carried a "~60px" figure; it was derivable and
   // not derived, and it was wrong.
   //
-  // The floor is the button's own horizontal padding (2 x 14px) plus the track's
-  // padding and border: 28 + 4 + 2 = 62px. Below that the buttons stop shrinking
-  // while the columns keep going, so the thumb — which tracks the COLUMN —
-  // becomes narrower than the button it is supposed to cover. Measured: at 62px
-  // dR = 0.00, at 61px dR = -0.50.
+  // Below the floor the buttons stop shrinking while the columns keep going, so
+  // the thumb — which tracks the COLUMN — becomes narrower than the button it is
+  // supposed to cover. `paddingFloor()` computes where that starts, so a padding
+  // change moves this test with it instead of silently invalidating it.
   await boot(page);
 
-  await setTrackCap(page, 62);
-  await expectThumbFlush(page, "at the 62px floor");
+  const floor = await paddingFloor(page);
 
-  await setTrackCap(page, 61);
+  await setTrackCap(page, floor);
+  await expectThumbFlush(page, `at the ${floor}px floor`);
+
+  await setTrackCap(page, floor - 1);
   const below = await measure(page);
+  // Bounded on BOTH sides, because `< -0.25` alone is satisfied by any breakage
+  // at all — remove `inset: 0` and the thumb renders 0x0 for a dR near -55,
+  // which would read as this test passing. One pixel off the floor splits across
+  // two columns, so the intended desync is half a pixel and nothing else is.
   expect(
     below.dR,
-    `one pixel below the floor the pill should already be narrower than its button. If this ` +
-      `passes, the floor moved — re-derive it from the button padding and the track chrome, ` +
-      `and update the test above rather than adding a comment.`,
+    `one pixel below the floor the pill should be exactly half a pixel narrower than its ` +
+      `button (got ${below.dR.toFixed(2)}). Too small: the floor moved, and since it is now ` +
+      `derived that means the box model changed, not the padding. Too large: the thumb is ` +
+      `mis-sized for a reason that has nothing to do with the floor.`,
   ).toBeLessThan(-0.25);
+  expect(below.dR).toBeGreaterThan(-1);
 });
 
 test("the widened toggle still fits a narrow viewport", async ({ page }) => {
-  // Equalizing the segments widens the control by ~17.3px ("Solo" grew to match
-  // "Tandem"), and the toggle sits at the right-hand end of the title bar.
+  // Equalizing the segments widened the control ("Solo" grew to match "Tandem"),
+  // and the toggle sits at the right-hand end of the title bar.
   //
-  // 360px, not 600px: because the toggle cannot shrink (see above), the fixed
-  // row content is roughly 28px padding + 32px logo + spacers + ~140px toggle,
-  // and the tab strip absorbs all remaining shrink. At 600px the widening this
-  // guards could grow twentyfold before the assertion fired, which made it read
-  // as coverage it was not providing.
+  // 360px, not 600px: the toggle cannot shrink (see above) and neither can the
+  // brand cluster or the row padding, so the tab strip absorbs all remaining
+  // shrink. Those fixed costs leave enough slack at 600px that the widening this
+  // guards could grow many times over before the assertion fired, which made it
+  // read as coverage it was not providing. 360px is the narrowest viewport worth
+  // supporting, so it is the honest place to ask the question.
   //
   // SCOPE: this covers the BROWSER layout only. `isTauriRuntime()` is false
   // here, so `.title-bar-mode` never gets `.native-window-row` and the three

--- a/tests/e2e/mode-toggle-geometry.spec.ts
+++ b/tests/e2e/mode-toggle-geometry.spec.ts
@@ -44,12 +44,6 @@ async function boot(page: Page) {
   // when the face does. Every assertion below uses an absolute px tolerance and
   // `expect.poll` re-evaluates, so a pre-swap sample and a post-swap sample
   // would be describing two different layouts.
-  //
-  // (The figures that used to sit here were the PRE-FIX widths, left behind
-  // when the fix changed them, and the same file described the same track three
-  // times with one of the three 17px out. Deleted rather than re-measured: the
-  // point is that the swap moves them, which nothing here can assert and no
-  // number makes truer.)
   await page.evaluate(() => document.fonts.ready);
 }
 
@@ -234,10 +228,12 @@ async function paddingFloor(page: Page): Promise<number> {
     };
     return sides(track) + buttons.reduce((sum, b) => sum + sides(b), 0);
   });
-  // A zeroed or absurd floor would make both assertions below meaningless
-  // rather than failing: capping at 0 collapses everything flush.
+  // A zeroed floor would make both assertions below meaningless rather than
+  // failing: capping at ~0 collapses everything flush. An over-large one needs
+  // no guard — it produces no effective cap, `dR` stays 0, and the boundary
+  // test's own "too small" assertion fails with a better diagnosis than a
+  // transcribed ceiling could give.
   expect(floor, "derived padding floor is implausible — did the query desync?").toBeGreaterThan(20);
-  expect(floor).toBeLessThan(300);
   return floor;
 }
 
@@ -308,14 +304,18 @@ test("the pill's guarantee ends at the padding floor, not below it", async ({ pa
   // at all — remove `inset: 0` and the thumb renders 0x0 for a dR near -55,
   // which would read as this test passing. One pixel off the floor splits across
   // two columns, so the intended desync is half a pixel and nothing else is.
-  expect(
-    below.dR,
-    `one pixel below the floor the pill should be exactly half a pixel narrower than its ` +
-      `button (got ${below.dR.toFixed(2)}). Too small: the floor moved, and since it is now ` +
-      `derived that means the box model changed, not the padding. Too large: the thumb is ` +
-      `mis-sized for a reason that has nothing to do with the floor.`,
-  ).toBeLessThan(-0.25);
-  expect(below.dR).toBeGreaterThan(-1);
+  //
+  // The upper bound is -0.25 rather than -0.5 only to leave rounding room; the
+  // lower is -0.75, which keeps the band narrower than the half-pixel claim is
+  // wide. A wider band would let a sub-pixel error in the derivation satisfy
+  // both this and `expectThumbFlush`'s |d| < 0.5 at the same time.
+  const why =
+    `one pixel below the floor the pill should be about half a pixel narrower than its ` +
+    `button (got ${below.dR.toFixed(2)}). Too small: the floor moved, and since it is now ` +
+    `derived that means the box model changed, not the padding. Too large: the thumb is ` +
+    `mis-sized for a reason that has nothing to do with the floor.`;
+  expect(below.dR, why).toBeLessThan(-0.25);
+  expect(below.dR, why).toBeGreaterThan(-0.75);
 });
 
 test("the widened toggle still fits a narrow viewport", async ({ page }) => {

--- a/tests/helpers/css-source.test.ts
+++ b/tests/helpers/css-source.test.ts
@@ -1,0 +1,161 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  bundledCssFiles,
+  cssRulesBySelector,
+  neutralizeSvelteGlobal,
+  styleBlocks,
+} from "./css-source";
+
+/**
+ * The extractor that every `tests/design-system-impl/` gate is built on.
+ *
+ * This file exists because two real defects in `css-source.ts` were found by
+ * code review rather than by any test, and both had the same shape: the helper
+ * mishandled a LEGAL input and returned a smaller, confident answer instead of
+ * failing. A scan built on it then finds no offenders and reports green. Every
+ * gate downstream inherits that, so a hole here is not one wrong test, it is
+ * every test quietly asserting less than it says.
+ *
+ * Two complementary halves, and the split is deliberate:
+ *
+ *  - **Fixtures** pin the shapes that are hard, rare, or not in the repo yet —
+ *    exactly the ones a corpus sweep cannot see, because the corpus does not
+ *    contain them. This is the pattern backdrop-filter-guard.test.ts already
+ *    uses for its recipe matcher, with the same rationale: negative controls
+ *    written from the same mental model as the matcher cannot find its blind
+ *    spots, so pin the tricky shapes directly.
+ *  - **The corpus sweep** pins that the extractor still understands what this
+ *    repo actually authors today. It fails the day someone adopts a form the
+ *    helper cannot represent — which is the day the other gates would otherwise
+ *    start passing vacuously.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const CLIENT_ROOT = join(ROOT, "src", "client");
+
+const rules = (css: string) => cssRulesBySelector(css);
+/** Declarations of the one rule whose selector list contains `selector` exactly. */
+const declsOf = (css: string, selector: string) =>
+  rules(css)
+    .filter((r) => r.selectors.includes(selector))
+    .map((r) => r.body);
+
+describe("cssRulesBySelector: shapes that must not lose declarations", () => {
+  // THE regression. A brace-splitting regex cannot represent nesting: the
+  // parent rule does not match as a whole either, so its declarations are
+  // swallowed into the child's captured selector and the parent vanishes.
+  // Measured on the old implementation, this returned [["span","color:red"]] —
+  // `.thumb`'s banned `width: 50%` simply gone, with every scan green.
+  it("keeps a parent's declarations when a bare selector is nested inside it", () => {
+    expect(declsOf(".thumb{span{color:red}width:50%}", ".thumb")).toEqual(["width: 50%"]);
+  });
+
+  // The `&` form. A guard keyed on `&` appearing in a captured selector caught
+  // this one and missed the bare form above, which is why detection was
+  // replaced by a parse rather than made stricter.
+  it("keeps a parent's declarations when an & rule is nested inside it", () => {
+    const css = ".mode-toggle button{padding:3px 14px;min-width:60px;&:hover{color:blue}}";
+    expect(declsOf(css, ".mode-toggle button")).toEqual(["padding: 3px 14px; min-width: 60px"]);
+  });
+
+  it("reaches rules wrapped in an at-rule", () => {
+    const css = '@media (forced-colors: active){ .x[aria-pressed="true"]{outline:2px solid X} }';
+    expect(declsOf(css, '.x[aria-pressed="true"]')).toEqual(["outline: 2px solid X"]);
+  });
+
+  it("drops commented-out CSS rather than reporting it as a rule", () => {
+    expect(rules("/* .fake { width: 50% } */ .real{gap:0}").map((r) => r.selectors)).toEqual([
+      [".real"],
+    ]);
+  });
+
+  // Losslessness, which is the reason for postcss over lightningcss: two gates
+  // ask "is this prefix HAND-WRITTEN in the source?", and a normalizing parser
+  // has already rewritten the answer by the time they ask.
+  it("preserves a hand-written vendor prefix exactly as authored", () => {
+    expect(declsOf(".c{-webkit-line-clamp:2;line-clamp:2}", ".c")).toEqual([
+      "-webkit-line-clamp: 2; line-clamp: 2",
+    ]);
+  });
+});
+
+describe("cssRulesBySelector: selector lists split the way CSS splits them", () => {
+  it("splits a grouped selector", () => {
+    expect(rules(".a, .b { color: red }")[0].selectors).toEqual([".a", ".b"]);
+  });
+
+  // `String.split(",")` turns this into `[":is(.a", ".b)"]` — two selectors
+  // that match nothing. `:has()` is already in use in FormattingBar.svelte and
+  // is consumed by a gate, so this is one authored comma away from mattering.
+  it("does NOT split a comma inside a functional pseudo-class", () => {
+    expect(rules(".x:is(.a, .b) { color: red }")[0].selectors).toEqual([".x:is(.a, .b)"]);
+  });
+});
+
+describe("neutralizeSvelteGlobal", () => {
+  it("rewrites the plain form", () => {
+    expect(neutralizeSvelteGlobal(":global(body.x) .thumb{a:b}")).toBe("body.x .thumb{a:b}");
+  });
+
+  // Live in App.svelte and ReplyThread.svelte. The original `[^()]*` regex
+  // could not match these at all and left `:global(` in the output.
+  it("rewrites a form holding nested parentheses", () => {
+    expect(neutralizeSvelteGlobal(":global(body:not(.x)) .rail{a:b}")).toBe(
+      "body:not(.x) .rail{a:b}",
+    );
+    expect(neutralizeSvelteGlobal('.w:has(:global([aria-expanded="true"])){a:b}')).toBe(
+      '.w:has([aria-expanded="true"]){a:b}',
+    );
+  });
+
+  // Flattening a list in place is silent and WRONG: `.a, .b .thumb` is two
+  // selectors meaning something else, so a gate asking whether a `.thumb` rule
+  // exists gets a confident "no".
+  it("throws on a top-level selector list rather than flattening it", () => {
+    expect(() => neutralizeSvelteGlobal(":global(.a, .b) .thumb{a:b}")).toThrow(
+      /holds a selector list/,
+    );
+  });
+
+  // The other side of that: a nested comma is ONE selector and flattens
+  // safely. Throwing here would be a false positive, and App.svelte's
+  // `:global(body:not(…))` is one added class from this shape.
+  it("does not throw on a comma nested inside a functional pseudo-class", () => {
+    expect(neutralizeSvelteGlobal(":global(:is(.a, .b)) .thumb{a:b}")).toBe(
+      ":is(.a, .b) .thumb{a:b}",
+    );
+  });
+});
+
+describe("the extractor still reads what this repo authors", () => {
+  const files = bundledCssFiles(CLIENT_ROOT);
+
+  it("extracts a plausible number of rules from the real corpus", () => {
+    // Counting FILES would not do: 45 of them legitimately have no `<style>`
+    // block at all, so an empty extraction is already normal and a file count
+    // survives total extractor failure untouched. Rules are the thing that
+    // would go to zero, and every downstream scan is a filter over them.
+    expect(files.length, "corpus walk found nothing — did the tree move?").toBeGreaterThan(50);
+
+    const total = files.reduce(
+      (sum, file) => sum + cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(file))).length,
+      0,
+    );
+    expect(total, "extractor returned almost nothing — every gate is now vacuous").toBeGreaterThan(
+      500,
+    );
+  });
+
+  it("parses every bundled file without throwing", () => {
+    const broken = files.flatMap((file) => {
+      try {
+        cssRulesBySelector(neutralizeSvelteGlobal(styleBlocks(file)));
+        return [];
+      } catch (err) {
+        return [`${file.replace(/\\/g, "/").split("/src/client/")[1]}: ${(err as Error).message}`];
+      }
+    });
+    expect(broken).toEqual([]);
+  });
+});

--- a/tests/helpers/css-source.test.ts
+++ b/tests/helpers/css-source.test.ts
@@ -80,6 +80,50 @@ describe("cssRulesBySelector: shapes that must not lose declarations", () => {
   });
 });
 
+describe("cssRulesBySelector: fullSelectors resolves nesting against ancestors", () => {
+  // THE bypass: `selectors` on a nested rule is only its own local text
+  // (`"button"`), which never carries `.mode-toggle`'s prefix — a
+  // `startsWith(".mode-toggle button")` scan built on `selectors` reports zero
+  // offenders no matter what the nested rule declares. Reproduced against
+  // mode-toggle-thumb-contract.test.ts's real gate before fullSelectors existed.
+  it("resolves a bare nested selector against its ancestor", () => {
+    const css = ".mode-toggle{button{min-width:60px}}";
+    expect(rules(css).find((r) => r.selectors[0] === "button")?.fullSelectors).toEqual([
+      ".mode-toggle button",
+    ]);
+  });
+
+  it("substitutes & with the ancestor rather than prefixing it", () => {
+    const css = ".mode-toggle button{&:hover{color:blue}}";
+    expect(rules(css).find((r) => r.selectors[0] === "&:hover")?.fullSelectors).toEqual([
+      ".mode-toggle button:hover",
+    ]);
+  });
+
+  it("cross-multiplies grouped selectors at both levels", () => {
+    const css = ".a, .b { .c, .d { color: red } }";
+    expect(rules(css).find((r) => r.selectors[0] === ".c")?.fullSelectors).toEqual([
+      ".a .c",
+      ".a .d",
+      ".b .c",
+      ".b .d",
+    ]);
+  });
+
+  it("does not resolve past an at-rule boundary, but still resolves within it", () => {
+    const css = ".mode-toggle{@media (forced-colors: active){button{min-width:60px}}}";
+    expect(rules(css).find((r) => r.selectors[0] === "button")?.fullSelectors).toEqual([
+      ".mode-toggle button",
+    ]);
+  });
+
+  // A top-level (non-nested) rule's fullSelectors equals its selectors —
+  // resolution is a no-op when there is no rule ancestor to resolve against.
+  it("leaves an unnested rule's fullSelectors equal to its selectors", () => {
+    expect(rules(".thumb{width:50%}")[0].fullSelectors).toEqual([".thumb"]);
+  });
+});
+
 describe("cssRulesBySelector: selector lists split the way CSS splits them", () => {
   it("splits a grouped selector", () => {
     expect(rules(".a, .b { color: red }")[0].selectors).toEqual([".a", ".b"]);

--- a/tests/helpers/css-source.ts
+++ b/tests/helpers/css-source.ts
@@ -48,9 +48,31 @@ export function styleBlocks(file: string): string {
  * Because a body may not contain braces, an at-rule wrapper never matches as a
  * whole — the scan steps past it and matches the rules *inside*, so a
  * declaration hidden in `@media` is still found rather than skipped.
+ *
+ * That same property makes CSS nesting unrepresentable, and unrepresentable in
+ * the one direction that fails green: a nested rule's parent does not match as a
+ * whole either, so the parent's own declarations are swallowed into the child's
+ * captured *selector* and the parent vanishes from the list. A negative scan
+ * ("no rule declares a width") then finds nothing and passes while the banned
+ * declaration ships. Svelte 5 accepts nesting and lightningcss compiles it, so
+ * this is one refactor away, not hypothetical — hence the guard rather than a
+ * comment. `&` cannot appear in a flat selector and `;` cannot appear in any
+ * selector this repo writes, so both are nesting tells.
  */
 export function cssRules(css: string): Array<[string, string]> {
-  return [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => [m[1], m[2]]);
+  const rules = [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(
+    (m) => [m[1], m[2]] as [string, string],
+  );
+  for (const [selector] of rules) {
+    if (selector.includes("&") || selector.includes(";")) {
+      throw new Error(
+        `css-source: CSS nesting detected near ${JSON.stringify(selector.trim().slice(0, 60))}. ` +
+          `The flat splitter drops the parent rule's declarations, so every scan built on it ` +
+          `would pass while missing them. Upgrade this helper to a real parser before nesting here.`,
+      );
+    }
+  }
+  return rules;
 }
 
 /** One authored rule: its selector list already split, and its declaration body. */
@@ -77,11 +99,54 @@ export function cssRulesBySelector(css: string): CssRule[] {
  * Rewrite Svelte's `:global(x)` to plain `x` so a component `<style>` block can
  * be handed to a real CSS parser.
  *
- * lightningcss rejects `:global(...)` outright, which matters because the
- * minifier gates are the only ones that see what actually ships. Without this a
- * whole-block gate cannot exist, and the fallback — extracting one rule at a
- * time — is what leaves synthetic-probe tests standing in for real ones.
+ * lightningcss does not *reject* `:global(...)` — measured, it passes the
+ * selector through unchanged and emits a `SelectorError` warning. The gates hold
+ * because `minify()` asserts the warning list is empty, which is a different
+ * mechanism than refusal and permits a different set of safe uses. Without this
+ * rewrite a whole-block gate cannot exist, and the fallback — extracting one
+ * rule at a time — is what leaves synthetic-probe tests standing in for real
+ * ones.
+ *
+ * Both failure modes below throw, because the alternative is worse than a crash.
+ * A `:global()` this cannot rewrite is left verbatim and merely warns, but one
+ * it rewrites *wrongly* is silent: `:global(.a, .b) .thumb` flattens to
+ * `.a, .b .thumb`, which splits into two selectors that mean something else
+ * entirely, and a gate asking "does a rule for `.thumb` exist?" gets a confident
+ * "no". Distributing the list correctly (`.a .thumb, .b .thumb`) is the real
+ * fix; nothing in the repo needs it yet, and a throw is honest until something
+ * does.
+ *
+ * Known limitation, deliberately not handled: Svelte's `:global { … }` *block*
+ * form (live in ToastContainer, ChatPanel, StatusBar). `cssRules` steps past the
+ * wrapper and emits the inner rules as though they were scoped, so no
+ * declaration is lost and every current gate is unaffected — but a future gate
+ * asking "is this rule global?" would get a wrong answer with no signal.
  */
 export function neutralizeSvelteGlobal(css: string): string {
-  return css.replace(/:global\(([^()]*)\)/g, "$1");
+  const TOKEN = ":global(";
+  let out = "";
+  let cursor = 0;
+  for (;;) {
+    const start = css.indexOf(TOKEN, cursor);
+    if (start === -1) return out + css.slice(cursor);
+    out += css.slice(cursor, start);
+    let depth = 1;
+    let i = start + TOKEN.length;
+    for (; i < css.length && depth > 0; i++) {
+      if (css[i] === "(") depth++;
+      else if (css[i] === ")") depth--;
+    }
+    if (depth !== 0) {
+      throw new Error(`css-source: unbalanced \`:global(\` starting at index ${start}.`);
+    }
+    const inner = css.slice(start + TOKEN.length, i - 1);
+    if (inner.includes(",")) {
+      throw new Error(
+        `css-source: \`:global(${inner})\` holds a selector list. Flattening it in place ` +
+          `changes what it matches; distribute the list across the descendant part instead.`,
+      );
+    }
+    out += inner;
+    cursor = i;
+  }
 }

--- a/tests/helpers/css-source.ts
+++ b/tests/helpers/css-source.ts
@@ -1,4 +1,6 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import postcss from "postcss";
 
 /**
  * Source-level CSS extraction shared by the `tests/design-system-impl/` suites.
@@ -7,19 +9,52 @@ import { readFileSync } from "node:fs";
  * hand-write a vendor prefix, which declare a token — so they read the source
  * rather than a rendered page. Two files had rolled their own byte-identical
  * copies of the first two helpers below, and the rule splitter was triplicated.
+ * One copy is a bug to fix; N copies is a bug plus N-1 silent false negatives.
  *
- * These are regexes, not a parser, and that is the reason to have exactly one of
- * each: Svelte's `<style>` syntax can grow (a `lang=` attribute, `module`,
- * nesting), and when it does, a stale copy does not fail loudly — it extracts an
- * empty string, finds zero offenders and reports **green**. That failure mode is
- * documented in-repo: css-pipeline-contract.test.ts records a scan whose first
- * prototype returned 0 pairs while 12 existed and looked passing. One copy is a
- * bug to fix; N copies is a bug plus N-1 silent false negatives.
+ * **Rule extraction is a real parse (postcss), not a brace regex**, and the
+ * reason is that the regex form failed silently in the one direction that
+ * matters. A brace splitter cannot represent CSS nesting: a nested rule's
+ * PARENT does not match as a whole either, so the parent's declarations are
+ * swallowed and the parent vanishes from the list. Measured:
+ *
+ *     ".thumb{span{color:red}width:50%}"  ->  [["span", "color:red"]]
+ *
+ * `.thumb`'s banned `width: 50%` is simply gone, and every negative scan built
+ * on the splitter reports green. Svelte 5 accepts nesting and lightningcss
+ * compiles it, so this is one tidy-up away rather than hypothetical. A guard
+ * was tried first and is why the parse is here: keying on `&`/`;` appearing in
+ * a captured selector catches `&`-nesting and misses the bare-selector form
+ * above entirely, which is a tell rather than a detector.
+ *
+ * postcss specifically, over lightningcss (also a dependency): it is LOSSLESS.
+ * `handWrittenPairs` and the `-webkit-line-clamp` gate ask "is this prefix
+ * hand-written in the source?", which a normalizing parser cannot answer
+ * because it has already rewritten the answer. postcss round-trips authored
+ * text, so `d.prop` is what the developer typed. It also leaves `:global(...)`
+ * alone as opaque selector text, and parses Svelte's `:global { … }` block form
+ * rather than rejecting it.
  *
  * Deliberately NOT migrated: `styleBlock` in activity-message-wrapping.test.ts.
  * It is a different primitive — singular, non-global, no comment stripping —
  * that asserts a block's presence rather than scanning its contents.
  */
+
+/**
+ * Every file whose CSS Vite routes through lightningcss. Deliberately excludes
+ * `index.html`: its inline `<style>` is emitted verbatim, so it is NOT a bundled
+ * source and the collapse cannot reach it. The two obey different rules.
+ *
+ * `withFileTypes` rather than a `statSync` per entry — measured 1.8ms against
+ * 13.2ms over this corpus, and there are four call sites.
+ */
+export function bundledCssFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) bundledCssFiles(full, out);
+    else if (full.endsWith(".svelte") || full.endsWith(".css")) out.push(full);
+  }
+  return out;
+}
 
 /** Strip CSS block comments so commented-out prose can't satisfy or trip a grep. */
 export function stripCssComments(css: string): string {
@@ -42,57 +77,48 @@ export function styleBlocks(file: string): string {
   );
 }
 
-/**
- * Flat `[selectorList, declarationBlock]` pairs.
- *
- * Because a body may not contain braces, an at-rule wrapper never matches as a
- * whole — the scan steps past it and matches the rules *inside*, so a
- * declaration hidden in `@media` is still found rather than skipped.
- *
- * That same property makes CSS nesting unrepresentable, and unrepresentable in
- * the one direction that fails green: a nested rule's parent does not match as a
- * whole either, so the parent's own declarations are swallowed into the child's
- * captured *selector* and the parent vanishes from the list. A negative scan
- * ("no rule declares a width") then finds nothing and passes while the banned
- * declaration ships. Svelte 5 accepts nesting and lightningcss compiles it, so
- * this is one refactor away, not hypothetical — hence the guard rather than a
- * comment. `&` cannot appear in a flat selector and `;` cannot appear in any
- * selector this repo writes, so both are nesting tells.
- */
-export function cssRules(css: string): Array<[string, string]> {
-  const rules = [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(
-    (m) => [m[1], m[2]] as [string, string],
-  );
-  for (const [selector] of rules) {
-    if (selector.includes("&") || selector.includes(";")) {
-      throw new Error(
-        `css-source: CSS nesting detected near ${JSON.stringify(selector.trim().slice(0, 60))}. ` +
-          `The flat splitter drops the parent rule's declarations, so every scan built on it ` +
-          `would pass while missing them. Upgrade this helper to a real parser before nesting here.`,
-      );
-    }
-  }
-  return rules;
-}
-
 /** One authored rule: its selector list already split, and its declaration body. */
 export type CssRule = { selectors: string[]; body: string };
 
 /**
- * `cssRules` with the selector list split on `,`, which is what "does this rule
- * apply to `.foo`?" actually needs.
+ * Every style rule in `css`, at any nesting depth and inside any at-rule.
  *
- * Comparing the unsplit list instead is the trap this exists to close: it works
- * until someone groups the selector, and then `.thumb, .x { … }` stops matching
- * `.thumb` and the scan reports the rule *missing* rather than reporting the
- * declaration it was hired to check. Two suites had independently rolled this,
- * and a third arrived comparing the unsplit form — three answers to one question.
+ * `selectors` comes from postcss, which splits a grouped selector list the way
+ * CSS does rather than the way `String.split(",")` does — so `:is(.a, .b)`
+ * stays one selector instead of becoming two nonsense ones. Comparing the
+ * UNSPLIT list is the older trap this closes: `.thumb, .x { … }` stops matching
+ * `.thumb`, and the scan reports the rule *missing* rather than reporting the
+ * declaration it was hired to check.
+ *
+ * `body` is re-serialized from the declaration nodes as `prop: value` pairs, so
+ * it holds exactly what was authored (postcss does not normalize) minus
+ * comments and whitespace noise. Scans regex it, and every one of them anchors
+ * on `(?:^|[;\s])`, which the `; ` join satisfies.
+ *
+ * Nested children are returned as their OWN rules, carrying their authored
+ * relative selector (`&:hover`, or a bare `span`). No scan in the repo needs
+ * them resolved against the parent, and resolving would mean re-implementing
+ * the nesting cascade; what matters is that the parent keeps its declarations,
+ * which is precisely what the brace splitter got wrong.
  */
 export function cssRulesBySelector(css: string): CssRule[] {
-  return cssRules(css).map(([selectorList, body]) => ({
-    selectors: selectorList.split(",").map((s) => s.trim()),
-    body,
-  }));
+  const out: CssRule[] = [];
+  postcss.parse(css).walkRules((rule) => {
+    const body = rule.nodes
+      .filter((node) => node.type === "decl")
+      .map((decl) => `${decl.prop}: ${decl.value}${decl.important ? " !important" : ""}`)
+      .join("; ");
+    out.push({ selectors: rule.selectors.map((s) => s.trim()), body });
+  });
+  return out;
+}
+
+/**
+ * `cssRulesBySelector` as flat `[selectorList, declarationBlock]` pairs, for
+ * callers that only scan bodies and never ask which selector they belong to.
+ */
+export function cssRules(css: string): Array<[string, string]> {
+  return cssRulesBySelector(css).map((rule) => [rule.selectors.join(", "), rule.body]);
 }
 
 /**
@@ -107,20 +133,24 @@ export function cssRulesBySelector(css: string): CssRule[] {
  * rule at a time — is what leaves synthetic-probe tests standing in for real
  * ones.
  *
- * Both failure modes below throw, because the alternative is worse than a crash.
- * A `:global()` this cannot rewrite is left verbatim and merely warns, but one
- * it rewrites *wrongly* is silent: `:global(.a, .b) .thumb` flattens to
- * `.a, .b .thumb`, which splits into two selectors that mean something else
- * entirely, and a gate asking "does a rule for `.thumb` exist?" gets a confident
- * "no". Distributing the list correctly (`.a .thumb, .b .thumb`) is the real
- * fix; nothing in the repo needs it yet, and a throw is honest until something
- * does.
+ * Throws rather than mis-rewrites, because flattening a selector LIST in place
+ * is silent and wrong: `:global(.a, .b) .thumb` becomes `.a, .b .thumb`, two
+ * selectors meaning something else entirely, and a gate asking "does a rule for
+ * `.thumb` exist?" gets a confident "no". Distributing it (`.a .thumb, .b
+ * .thumb`) is the real fix; nothing needs it yet, and a throw is honest until
+ * something does.
+ *
+ * Only a TOP-LEVEL comma is a list. A comma nested inside a functional
+ * pseudo-class — `:global(:is(.a, .b))`, `:global(.x:not(.a, .b))` — is one
+ * selector and flattens safely, so throwing on it would be a false positive
+ * that reds three test files. `App.svelte` already carries
+ * `:global(body:not(…))`, one added class away from that shape.
  *
  * Known limitation, deliberately not handled: Svelte's `:global { … }` *block*
- * form (live in ToastContainer, ChatPanel, StatusBar). `cssRules` steps past the
- * wrapper and emits the inner rules as though they were scoped, so no
- * declaration is lost and every current gate is unaffected — but a future gate
- * asking "is this rule global?" would get a wrong answer with no signal.
+ * form (live in ToastContainer, ChatPanel, StatusBar). postcss parses it as an
+ * ordinary rule with children, so no declaration is lost and every current gate
+ * is unaffected — but a gate asking "is this rule global?" would get a wrong
+ * answer with no signal.
  */
 export function neutralizeSvelteGlobal(css: string): string {
   const TOKEN = ":global(";
@@ -131,16 +161,18 @@ export function neutralizeSvelteGlobal(css: string): string {
     if (start === -1) return out + css.slice(cursor);
     out += css.slice(cursor, start);
     let depth = 1;
+    let topLevelComma = false;
     let i = start + TOKEN.length;
     for (; i < css.length && depth > 0; i++) {
       if (css[i] === "(") depth++;
       else if (css[i] === ")") depth--;
+      else if (css[i] === "," && depth === 1) topLevelComma = true;
     }
     if (depth !== 0) {
       throw new Error(`css-source: unbalanced \`:global(\` starting at index ${start}.`);
     }
     const inner = css.slice(start + TOKEN.length, i - 1);
-    if (inner.includes(",")) {
+    if (topLevelComma) {
       throw new Error(
         `css-source: \`:global(${inner})\` holds a selector list. Flattening it in place ` +
           `changes what it matches; distribute the list across the descendant part instead.`,

--- a/tests/helpers/css-source.ts
+++ b/tests/helpers/css-source.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import postcss from "postcss";
+import postcss, { type Rule } from "postcss";
 
 /**
  * Source-level CSS extraction shared by the `tests/design-system-impl/` suites.
@@ -77,8 +77,40 @@ export function styleBlocks(file: string): string {
   );
 }
 
-/** One authored rule: its selector list already split, and its declaration body. */
-export type CssRule = { selectors: string[]; body: string };
+/**
+ * One authored rule: its selector list already split, its declaration body,
+ * and its selector list resolved against every ancestor rule.
+ */
+export type CssRule = { selectors: string[]; fullSelectors: string[]; body: string };
+
+/**
+ * Resolve `rule`'s selectors against its ancestor rule chain, cross-multiplied
+ * the way CSS nesting actually cascades (`&` substitutes the ancestor list;
+ * its absence implies a descendant combinator). At-rules (`@media`, etc.) are
+ * transparent to this walk — skipped over rather than stopped at — because
+ * they constrain *when* a rule applies, not *what* it matches: `.a { @media
+ * (…) { button { … } } }`'s `button` still resolves to `.a button`. The walk
+ * stops only at Root, where there is no further ancestor to resolve against.
+ */
+function resolveSelectors(rule: Rule, cache: WeakMap<Rule, string[]>): string[] {
+  const cached = cache.get(rule);
+  if (cached) return cached;
+  const own = rule.selectors.map((s) => s.trim());
+  let ancestor = rule.parent;
+  while (ancestor && ancestor.type === "atrule") ancestor = ancestor.parent;
+  const full =
+    ancestor && ancestor.type === "rule"
+      ? resolveSelectors(ancestor as Rule, cache).flatMap((parentSelector) =>
+          own.map((child) =>
+            child.includes("&")
+              ? child.split("&").join(parentSelector)
+              : `${parentSelector} ${child}`,
+          ),
+        )
+      : own;
+  cache.set(rule, full);
+  return full;
+}
 
 /**
  * Every style rule in `css`, at any nesting depth and inside any at-rule.
@@ -96,19 +128,29 @@ export type CssRule = { selectors: string[]; body: string };
  * on `(?:^|[;\s])`, which the `; ` join satisfies.
  *
  * Nested children are returned as their OWN rules, carrying their authored
- * relative selector (`&:hover`, or a bare `span`). No scan in the repo needs
- * them resolved against the parent, and resolving would mean re-implementing
- * the nesting cascade; what matters is that the parent keeps its declarations,
- * which is precisely what the brace splitter got wrong.
+ * relative selector in `selectors` (`&:hover`, or a bare `span`) — that field
+ * is unchanged, so existing scans built on it keep their exact prior meaning.
+ * `fullSelectors` is the same rule's selectors resolved against every ancestor
+ * (`.mode-toggle { button { … } }`'s inner rule gets `[".mode-toggle button"]`
+ * here, not `["button"]`). A `startsWith`/prefix scan for a compound selector
+ * MUST use `fullSelectors`, not `selectors` — a nested rule's bare local
+ * selector will never carry its ancestor's prefix, which is exactly how a CSS
+ * nesting rewrite defeated `mode-toggle-thumb-contract.test.ts`'s width-rule
+ * gate (mutation-proved) before this field existed.
  */
 export function cssRulesBySelector(css: string): CssRule[] {
   const out: CssRule[] = [];
+  const cache = new WeakMap<Rule, string[]>();
   postcss.parse(css).walkRules((rule) => {
     const body = rule.nodes
       .filter((node) => node.type === "decl")
       .map((decl) => `${decl.prop}: ${decl.value}${decl.important ? " !important" : ""}`)
       .join("; ");
-    out.push({ selectors: rule.selectors.map((s) => s.trim()), body });
+    out.push({
+      selectors: rule.selectors.map((s) => s.trim()),
+      fullSelectors: resolveSelectors(rule, cache),
+      body,
+    });
   });
   return out;
 }


### PR DESCRIPTION
Follow-up to #1428. Four review lenses on that merged PR found it had made one gate **strictly worse** and left three more defeatable — then a `/simplify` round on the fix found the fix itself was at the wrong depth. Both rounds are here.

Every claim below is mutation-proved, not reasoned.

## What was shipping green

| Mutation | Before | After |
|---|---|---|
| `.mode-toggle > button` rename **+** `min-width: 60px` | 🟢 the bug | 🔴 |
| `max-width: 50%` on `.thumb` | 🟢 the bug | 🔴 |
| fold `:hover` into the base rule (`&` nesting) + `min-width` | 🟢 the bug | 🔴 |
| fold a **bare selector** in + `min-width` | 🟢 the bug | 🔴 |
| `transform: translateX(50%)` on `.thumb` | 🟢 the bug | 🔴 |
| delete the `:has()` z-lift **behind a lookalike** | 🟢 the bug | 🔴 |
| keep the `:has()` selector, drop its `z-index` | 🟢 | 🔴 |
| `:global(.a, .b)` | silently mis-split | throws |

## The regression #1428 introduced

Broadening the button width-ban from the base rule to every `.mode-toggle button*` rule was right, but it dropped the existence guard `ruleWithSelector` carried. `.mode-toggle > button` selects the same elements and fails `startsWith`, so `offenders` was `[]` by construction — the rename carrying `min-width: 60px`, the exact bug the gate exists to catch, passed the whole suite.

## Why this parses CSS now

The first round added a nesting guard keyed on `&`/`;` in a captured selector. Review probed it:

```
".thumb{span{color:red}width:50%}"  ->  [["span", "color:red"]]
```

`.thumb` is gone, `width: 50%` with it, and no `&` or `;` appears. A tell, not a detector.

**postcss** is already a version-pinned transitive dependency (8.5.26, via Vite) — now declared, one line in the lockfile. Measured against every shape: both nesting forms keep the parent's declarations, grouped selectors split the way CSS splits them, **`:is(.a, .b)` is not split** (fixing a `String.split(",")` bug older than either round), at-rules, `:global()` plain/nested/inside-`:has()`, and Svelte's `:global { … }` block form.

postcss rather than lightningcss, which is also on hand, because it is **lossless**: two gates ask "is this prefix *hand-written* in the source?", and a normalizing parser has rewritten the answer before they ask.

## The percentage ban is now a ban on values

The enumeration listed ten properties and still let `transform: translateX(50%)` through — percentage positioning, and half of the literal #1383/#1384 mechanism. `not.toMatch(/%|calc\(/)` is how §3.9 actually states it, is complete, is shorter, and needs no exception: the shipped `.thumb` declares no `%` or `calc(` at all.

## The 62px floor is derived, not transcribed

The comment read `28 + 4 + 2 = 62`, which is 34 — it counted one button when the floor needs both. Third wrong spelling of one boundary, and the test's own failure message told the next maintainer to re-derive from it. `paddingFloor()` now reads the computed padding and border, so the test moves when the CSS does. It is self-proving: a wrong derivation fails the flush assertion at that cap immediately.

## Also fixed

- `neutralizeSvelteGlobal` threw on **any** comma, including one nested in a functional pseudo-class where flattening is safe. `App.svelte` already carries `:global(body:not(…))` — one added class from reddening three files.
- The corpus sweep's structural checks were unreachable by construction, and it counted **files** — 45 of 103 legitimately have no `<style>` block, so it could not detect total extractor failure, the one mode the helper's docstring names. Moved to `tests/helpers/css-source.test.ts` beside the code it guards, with fixtures for shapes the corpus doesn't contain and a rule-count floor for the corpus.
- `bundledCssFiles` was duplicated byte-for-byte in two files and #1428 added a third caller. Shared; `withFileTypes` (13.2ms → 1.8ms, four call sites).
- `type="button"` on both segments, matching every other TitleBar button.

## Verification

biome clean · eslint 0 errors · typecheck 1323 files / 0 errors · vitest **460 files, 6672 passed** · playwright **11 passed** · knip reports no new unused dependency.

Refs #1383, #1384, #1302