### PR TITLE
docs(status): v0.22.1 shipped, plus the flake that cost a release push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,9 @@ Mechanism, ops, and failure modes: [docs/licensing-explained.md](docs/licensing-
 
 ## Status
 
-**Shipped: v0.22.0** (2026-08-12). Release history is [CHANGELOG.md](CHANGELOG.md); remaining v1.0 work is [docs/roadmap.md](docs/roadmap.md#active--toward-v10). Do not re-narrate either here.
+**Shipped: v0.22.1** (2026-08-13). Release history is [CHANGELOG.md](CHANGELOG.md); remaining v1.0 work is [docs/roadmap.md](docs/roadmap.md#active--toward-v10). Do not re-narrate either here.
+
+**The v0.22.1 smoke run is the first with §1 executed end to end**, results on PR #1430. Two things it settled that no prior cut had: the Windows updater was tested against a **real v0.22.0 baseline** (install 0.22.1 → verify → reinstall 0.22.0 from its own release → publish → update), which costs one extra install and forfeits nothing — do this again rather than arguing the upgrade path from the diff; and the signed installer was **opened and inspected**, which is the only check covering `dist/stdio-bridge/` (new in v0.22.1, and its absence degrades silently to bare `npx` behind a `log::warn!` — the exact bug the release fixes). Two facts worth carrying: **an upgrade does not repair an already-broken Claude Desktop entry** — the boot sweep repairs stale *absolute* paths and deliberately skips bare `npx`, since Tandem emits that as a considered fallback, so those users must re-run `tandem setup --apply`; and the Windows matrix leg **failed on the first attempt inside Azure Trusted Signing**, which is a re-run, not a burned tag — the discriminator is whether the *same commit* passes on retry.
 
 Core is complete — 29 active MCP tools, multi-doc tabs, CRDT-anchored annotations, chat, four push paths (self-armed wake, plugin monitor, opt-in channel shim, supervisor stdin), `.md`/`.docx`/`.txt`/`.html`, npm global install, Tauri desktop app.
 

--- a/tests/docs/stateless-transport-claims.test.ts
+++ b/tests/docs/stateless-transport-claims.test.ts
@@ -98,6 +98,24 @@ function corpus(): Array<{ rel: string; lines: string[] }> {
   });
 }
 
+/**
+ * Walked ONCE at module load, not per test — the same idiom as
+ * `tool-count-drift.test.ts`'s `const SRC = allMcpSource()`.
+ *
+ * Two tests below need this, and computing it inside each of them put a
+ * recursive walk of `docs/**` plus every `.ts` under `src/` and `tests/`, and a
+ * `readFileSync` of every survivor, inside a 15s per-test budget — twice. Under
+ * the parallel pool on a loaded machine both tests then failed together with
+ * `Test timed out in 15000ms`, while passing in isolation and in CI (#1434).
+ * That reads as a real doc regression and names nothing that changed.
+ *
+ * Module evaluation is not subject to `testTimeout`, so hoisting removes the
+ * walk from the budget entirely rather than just halving it. `vitest.config.ts`
+ * already records the sibling case, where `applyConfig`'s icacls/pwsh spawns
+ * push apply-heavy tests past the default under the same contention.
+ */
+const CORPUS = corpus();
+
 /** The refuted assertion, in the wordings it has taken or plausibly could. */
 const BROKEN_PHRASING =
   /crash(es|ed|ing)?\b|does ?n.t work|is unusable|cannot be used|never works?\b|is broken|fails? (after|on|with|once)|hangs?\b|(is )?(not supported|unsupported)|blows? up|errors? out|panics?\b/i;
@@ -200,7 +218,7 @@ const MUST_NOT_FLAG = [
 
 describe("stateless-transport documentation claims (#1332 / #1253)", () => {
   it("nothing asserts that stateless mode crashes without marking it as overturned", () => {
-    const offenders = corpus().flatMap(({ rel, lines }) =>
+    const offenders = CORPUS.flatMap(({ rel, lines }) =>
       offendersIn(lines).map((n) => `${rel}:${n}`),
     );
     expect(offenders).toEqual([]);
@@ -223,7 +241,7 @@ describe("stateless-transport documentation claims (#1332 / #1253)", () => {
     // matcher, but only this exercises the walk that feeds it. Every sibling
     // guard carries an equivalent; `wake-availability-claims.test.ts` is the
     // closest in idiom.
-    const scanned = corpus().map(({ rel }) => rel);
+    const scanned = CORPUS.map(({ rel }) => rel);
     expect(scanned).toContain("docs/decisions.md");
     expect(scanned).toContain("docs/lessons-learned.md");
     expect(scanned).toContain("docs/spikes/stateless-transport-probe.md");


### PR DESCRIPTION
Post-release housekeeping for v0.22.1, plus a real fix for the doc-contract flake found while cutting it.

## CLAUDE.md Status

Moves to v0.22.1 and records the two things this cut learned that are **procedure, not history**, so the next release does not re-derive them:

- **The updater was tested against a real v0.22.0 baseline**, not argued from the diff. The apparent conflict — installing the new build destroys the only baseline, but the update dot needs a published `latest.json` — is not real, because the previous installer is still on its own release. Install new → verify → reinstall previous → publish → update. One extra install, nothing forfeited.
- **The signed installer was opened and inspected.** That is the *only* check covering `dist/stdio-bridge/`, new in v0.22.1, whose absence degrades silently to bare `npx` behind a `log::warn!` — i.e. it would have shipped the exact bug the release fixes, past every automated gate.

Plus two facts that would otherwise be rediscovered the hard way: an upgrade does **not** repair an already-broken Claude Desktop entry (the boot sweep repairs stale *absolute* paths and deliberately skips bare `npx`, which Tandem itself emits as a considered fallback), and a Windows leg failing inside Azure Trusted Signing is a **re-run, not a burned tag** — the discriminator being whether the same commit passes on retry, which it did.

## The flake fix — closes #1434

Both tests in `stateless-transport-claims.test.ts` that call `corpus()` failed together three times during this release, passed in isolation every time, and passed in CI. I finally captured the error on the pre-push hook: **`Test timed out in 15000ms`** — not an assertion.

`corpus()` walks `docs/**` plus every `.ts` under `src/` and `tests/` and `readFileSync`s every survivor, and it ran inside each test's 15s budget, twice.

The failure mode is worse than slow. It reports as **two doc-contract tests failing**, which reads as a real documentation regression, and it names nothing that changed. It cost a release push to diagnose, and on a busier machine it would fail CI for a reason no one could reproduce.

Hoisting to `const CORPUS = corpus()` removes the walk from the budget entirely rather than halving it, because module evaluation is not subject to `testTimeout`. This is the same idiom the sibling guard already uses (`tool-count-drift.test.ts`'s `const SRC = allMcpSource()`).

Measured: `tests 23.86s` → `tests 25ms`, with the cost moving to import.

**Detection verified by negative control, not by the suite going green** — a perf change that makes a guard pass is precisely how a guard gets hollowed out. Injecting `Stateless mode crashes the SDK.` into a `docs/` file fails the guard, naming that file and line; removing it restores green.

## Verification

- Full pre-push gate green with no bypass: biome, 6669 vitest tests, `cargo test`.
- `npx vitest run tests/docs/` green; `npm run check:links` — 283 links across 271 files, all resolve.

Closes #1434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AV8D7q23vxqG87Q9iLuc1p
