### PR TITLE
fix(cowork,wizard): surface every push route in the wizard, and make live regions announceable

### DIFF
--- a/docs/design-system-impl/testid-manifest.md
+++ b/docs/design-system-impl/testid-manifest.md
@@ -257,10 +257,13 @@ shipped and were removed:
   This sub-view has no confirm step — its footer button fires the real enable —
   so the probe runs on entry to the view, and the retry button *replaces*
   `cowork-enable-confirm-btn` while blocked rather than sitting beside it.
-- Plugin install (#1390): `integration-wizard-plugin{,-commands,-copy}` in the
-  push-mode block. Tandem cannot run these commands — registering a marketplace
-  is Claude Code's own trust boundary — so `-commands` holds the text and
-  `-copy` is the only affordance. Shown in BOTH channel-registered branches.
+- Plugin install (#1390): `integration-wizard-plugin{,-commands,-copy,-copy-status}`
+  in the push-mode block. Tandem shows these commands rather than running them
+  (the reason is on `CLAUDE_PLUGIN_INSTALL_COMMANDS`), so `-commands` holds the
+  text and `-copy` is the only affordance. `-copy-status` is the button's
+  outcome, in its own live region rather than in the button label — a changed
+  accessible name on an unfocused button announces nothing. Shown in BOTH
+  channel-registered branches.
 
 ### Cowork modals & settings
 - `cowork-onboarding-{step,confirm,error,enable-btn,enable-confirm-btn,enable-cancel-btn,skip-btn,learn-more-btn,learn-more-link}`
@@ -274,7 +277,10 @@ shipped and were removed:
   The `role="status"` wrapper, mounted for the life of the confirm (the wizard's
   for the life of the sub-view) so a hint arriving later is announced rather than
   inserted silently with its region. The `-blocked` testids sit INSIDE it, which
-  is why they still come and go; the wrapper never does.
+  is why they still come and go; the wrapper never does. The wizard's carries
+  `display: contents` — its parent is a gapped flex column, so an empty box
+  there would be a permanent gap; the other two parents are plain blocks.
+  Thirteen more live regions app-wide still have the pre-#1376 shape (#1431).
 - `cowork-admin-declined-{backdrop,modal,confirm-disable,error,status-error,disable-btn,disable-confirm-btn,disable-cancel-btn,retry-btn,learn-more-link}`
 - `cowork-settings{,-loading,-unsupported,-undetected,-error}`,
   `cowork-toggle`, `cowork-toggle-checkbox`, `cowork-inline-toast`, `cowork-explainer`,

--- a/docs/design-system-impl/testid-manifest.md
+++ b/docs/design-system-impl/testid-manifest.md
@@ -262,8 +262,9 @@ shipped and were removed:
   (the reason is on `CLAUDE_PLUGIN_INSTALL_COMMANDS`), so `-commands` holds the
   text and `-copy` is the only affordance. `-copy-status` is the button's
   outcome, in its own live region rather than in the button label — a changed
-  accessible name on an unfocused button announces nothing. Shown in BOTH
-  channel-registered branches.
+  accessible name on an unfocused button announces nothing. Rendered once from
+  a snippet ABOVE the registered/unregistered split rather than twice inside it
+  — both branches carry it because neither one can omit it.
 
 ### Cowork modals & settings
 - `cowork-onboarding-{step,confirm,error,enable-btn,enable-confirm-btn,enable-cancel-btn,skip-btn,learn-more-btn,learn-more-link}`

--- a/docs/design-system-impl/testid-manifest.md
+++ b/docs/design-system-impl/testid-manifest.md
@@ -257,6 +257,10 @@ shipped and were removed:
   This sub-view has no confirm step — its footer button fires the real enable —
   so the probe runs on entry to the view, and the retry button *replaces*
   `cowork-enable-confirm-btn` while blocked rather than sitting beside it.
+- Plugin install (#1390): `integration-wizard-plugin{,-commands,-copy}` in the
+  push-mode block. Tandem cannot run these commands — registering a marketplace
+  is Claude Code's own trust boundary — so `-commands` holds the text and
+  `-copy` is the only affordance. Shown in BOTH channel-registered branches.
 
 ### Cowork modals & settings
 - `cowork-onboarding-{step,confirm,error,enable-btn,enable-confirm-btn,enable-cancel-btn,skip-btn,learn-more-btn,learn-more-link}`
@@ -265,6 +269,12 @@ shipped and were removed:
   `cowork-preflight-{blocked,retry-btn}`. The retry button **replaces** the
   enable-confirm button while detection is known-failing, so a spec asserting
   `*-enable-confirm-btn` visible must first establish the probe did not block.
+- Pre-flight live regions (#1376): `cowork-preflight-live`,
+  `cowork-onboarding-preflight-live` and `integration-wizard-cowork-preflight-live`.
+  The `role="status"` wrapper, mounted for the life of the confirm (the wizard's
+  for the life of the sub-view) so a hint arriving later is announced rather than
+  inserted silently with its region. The `-blocked` testids sit INSIDE it, which
+  is why they still come and go; the wrapper never does.
 - `cowork-admin-declined-{backdrop,modal,confirm-disable,error,status-error,disable-btn,disable-confirm-btn,disable-cancel-btn,retry-btn,learn-more-link}`
 - `cowork-settings{,-loading,-unsupported,-undetected,-error}`,
   `cowork-toggle`, `cowork-toggle-checkbox`, `cowork-inline-toast`, `cowork-explainer`,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -220,7 +220,7 @@ async function writeTargets(targets: DetectedTarget[], opts: SetupOptions): Prom
  * starts are woken over the supervisor's stdin instead, so they need nothing
  * from this report. See `src/shared/launcher/contract.ts`.
  */
-function printPushStatus(shimRegisteredFor: string[]): void {
+export function printPushStatus(shimRegisteredFor: string[]): void {
   const pluginManifest = join(PACKAGE_ROOT, ".claude-plugin", "plugin.json");
   // `--plugin-dir` DOES activate the monitor. The previous copy here said it
   // did not, citing a 2026-08-06 null on 2.1.223; that null was the print-mode

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -14,6 +14,7 @@ import {
   type TargetKind,
   validateChannelShimPrereq,
 } from "../server/integrations/apply.js";
+import { CLAUDE_PLUGIN_INSTALL_COMMANDS } from "../shared/constants.js";
 
 /**
  * Parse repeatable `--target=<kind>` CLI args into valid target kinds plus the
@@ -279,8 +280,8 @@ function printPushStatus(shimRegisteredFor: string[]): void {
       "  `claude` from a terminal), and it shares the built-in Monitor tool's\n" +
       "  per-account gate — so it cannot stand in when that gate is off.\n" +
       "  Use one or the other — both active in one session deliver every event twice:\n\n" +
-      "    claude plugin marketplace add bloknayrb/tandem\n" +
-      "    claude plugin install tandem@tandem-editor\n\n" +
+      CLAUDE_PLUGIN_INSTALL_COMMANDS.map((cmd) => `    ${cmd}\n`).join("") +
+      "\n" +
       devInstructions,
   );
 }

--- a/src/client/components/CoworkOnboardingStep.svelte
+++ b/src/client/components/CoworkOnboardingStep.svelte
@@ -102,13 +102,23 @@ function handleSkip(): void {
         can connect back — admin is required once. To check it worked afterward, ask Claude in a
         Cowork session to open or list your documents.
       </div>
-      {#if probe.preflight?.status === "blocked"}
-        <!-- Say what stopped us and offer a retry, rather than an Enable button
-             whose failure we have already observed. -->
-        <div class="cos-preflight" data-testid="cowork-onboarding-preflight-blocked" role="status">
-          {probe.preflight.hint}
-        </div>
-      {/if}
+      <!-- #1376: mounted with the confirm, contents swap inside it. A live
+           region created together with its text is generally not announced, so
+           `role="status"` on the banner itself did nothing for the one user it
+           was written for. Both children can show at once — see CoworkSettings
+           for why a retry has `probing` and `blocked` set together. -->
+      <div role="status" data-testid="cowork-onboarding-preflight-live">
+        {#if probe.preflight?.status === "blocked"}
+          <!-- Say what stopped us and offer a retry, rather than an Enable button
+               whose failure we have already observed. -->
+          <div class="cos-preflight" data-testid="cowork-onboarding-preflight-blocked">
+            {probe.preflight.hint}
+          </div>
+        {/if}
+        {#if probe.probing}
+          <div class="cos-preflight cos-preflight-checking">Checking your network…</div>
+        {/if}
+      </div>
       <div class="cos-actions">
         {#if probe.preflight?.status === "blocked"}
           <button
@@ -228,6 +238,11 @@ function handleSkip(): void {
     border-radius: var(--tandem-r-2);
     padding: 6px 8px;
     margin-bottom: 8px;
+  }
+  .cos-preflight-checking {
+    color: var(--tandem-fg-muted);
+    background: var(--tandem-surface-sunk);
+    border-color: var(--tandem-border);
   }
   .cos-confirm-heading {
     font-weight: 600;

--- a/src/client/components/CoworkOnboardingStep.svelte
+++ b/src/client/components/CoworkOnboardingStep.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 import { TANDEM_REPO_URL } from "../../shared/constants";
-import { formatCoworkError, writeCoworkOnboardingSkipped } from "../cowork/cowork-helpers";
+import {
+  COWORK_PREFLIGHT_CHECKING,
+  formatCoworkError,
+  writeCoworkOnboardingSkipped,
+} from "../cowork/cowork-helpers";
 import { coworkToggleIntegration, type InvokeFn, loadInvoke } from "../cowork/cowork-invoke";
 import { createSubnetPreflight } from "../hooks/useCoworkPreflight.svelte";
 import type { CoworkStatus } from "../types";
@@ -102,11 +106,9 @@ function handleSkip(): void {
         can connect back — admin is required once. To check it worked afterward, ask Claude in a
         Cowork session to open or list your documents.
       </div>
-      <!-- #1376: mounted with the confirm, contents swap inside it. A live
-           region created together with its text is generally not announced, so
-           `role="status"` on the banner itself did nothing for the one user it
-           was written for. Both children can show at once — see CoworkSettings
-           for why a retry has `probing` and `blocked` set together. -->
+      <!-- #1376: mounted-before-populated, and the two children are additive.
+           `useCoworkPreflight.svelte.ts` explains both and is the one place
+           that should. -->
       <div role="status" data-testid="cowork-onboarding-preflight-live">
         {#if probe.preflight?.status === "blocked"}
           <!-- Say what stopped us and offer a retry, rather than an Enable button
@@ -116,7 +118,7 @@ function handleSkip(): void {
           </div>
         {/if}
         {#if probe.probing}
-          <div class="cos-preflight cos-preflight-checking">Checking your network…</div>
+          <div class="cos-checking">{COWORK_PREFLIGHT_CHECKING}</div>
         {/if}
       </div>
       <div class="cos-actions">
@@ -239,10 +241,10 @@ function handleSkip(): void {
     padding: 6px 8px;
     margin-bottom: 8px;
   }
-  .cos-preflight-checking {
+  .cos-checking {
+    font-size: 12px;
     color: var(--tandem-fg-muted);
-    background: var(--tandem-surface-sunk);
-    border-color: var(--tandem-border);
+    margin-bottom: 8px;
   }
   .cos-confirm-heading {
     font-weight: 600;

--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -106,11 +106,24 @@ async function withInvoke(
 }
 
 async function handleToggleOn(): Promise<void> {
+  // Same hazard `handleToggleOff` guards against, mirrored: `refetch()` can
+  // swallow its own failure into `coworkState.error` and return without
+  // storing a fresh status, so after a successful enable whose refetch failed,
+  // `status.enabled` is still stale at `false`. Closing the confirm
+  // unconditionally would drop the only `true` term left in `enableBoxChecked`
+  // and visibly UNCHECK the box over an integration that is now actually on --
+  // the more security-relevant direction, since it under-reports an active
+  // integration rather than over-reporting one. Leaving `confirming` set keeps
+  // the box checked (still accurate) until a later successful refetch -- the
+  // 30s poll, or a retry -- closes it for real. If the toggle itself threw,
+  // `readBack` stays at its initial `true`, so the confirm still closes and
+  // `enableBoxChecked` correctly falls back to the unchanged, accurate status.
+  let readBack = true;
   await withInvoke(async (invoke) => {
     await coworkToggleIntegration(invoke, true);
-    await refetch();
-    closeEnableConfirm();
+    readBack = await refetch();
   }, "Failed to enable Cowork");
+  if (readBack) closeEnableConfirm();
 }
 
 /**

--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -177,14 +177,23 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
       class:is-busy={busy}
       data-testid="cowork-toggle"
     >
+      <!-- `|| confirming` so Cancel un-checks the box again: `s.enabled` never
+           changed on the way in, so binding to it alone left a checked box
+           sitting over a disabled integration until the next status refetch. -->
       <input
         class="cs-accent-cbx"
         data-testid="cowork-toggle-checkbox"
         type="checkbox"
-        checked={s.enabled}
+        checked={s.enabled || confirming === "enable"}
         disabled={busy}
         onchange={(e) => {
           if ((e.target as HTMLInputElement).checked) openEnableConfirm();
+          // Unchecking while the confirm is open is a cancel, not a disable.
+          // It used to fall through to `handleToggleOff`, which fired a real
+          // `coworkToggleIntegration(invoke, false)` for a state transition
+          // that had never happened — and left the confirm open behind it,
+          // Enable button and all.
+          else if (confirming === "enable") closeEnableConfirm();
           else void handleToggleOff();
         }}
       />
@@ -238,13 +247,28 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
           Cowork can reach your open documents. This adds a Windows firewall rule so the Cowork VM
           can connect back — admin is required once.
         </div>
-        {#if probe.preflight?.status === "blocked"}
-          <!-- #1298: we already watched detection fail, so offer a retry rather
-               than an Enable button whose outcome we know. -->
-          <div class="cs-preflight" data-testid="cowork-preflight-blocked" role="status">
-            {probe.preflight.hint}
-          </div>
-        {/if}
+        <!-- #1376: the live region is mounted for the life of the confirm and
+             only its contents swap. Carried on the banner itself, `role=status`
+             announced nothing — a region inserted with its text already present
+             is generally not read out, so a screen-reader user asked Tandem to
+             check the network, watched it fail, and heard no reason.
+
+             Both children are shown rather than one `{#if}/{:else if}`: `run()`
+             keeps the previous result on purpose, so a retry has `probing` and
+             `blocked` set together, and swapping would unmount a testid the
+             wizard/settings suites read mid-probe. -->
+        <div role="status" data-testid="cowork-preflight-live">
+          {#if probe.preflight?.status === "blocked"}
+            <!-- #1298: we already watched detection fail, so offer a retry rather
+                 than an Enable button whose outcome we know. -->
+            <div class="cs-preflight" data-testid="cowork-preflight-blocked">
+              {probe.preflight.hint}
+            </div>
+          {/if}
+          {#if probe.probing}
+            <div class="cs-preflight-checking">Checking your network…</div>
+          {/if}
+        </div>
         <div class="cs-actions">
           {#if probe.preflight?.status === "blocked"}
             <button
@@ -421,13 +445,18 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
      paragraph of the confirm blurb. It already inherits the warning tokens from
      `.cs-warning-banner`, so a border is what separates it — matching
      `.cos-preflight` in CoworkOnboardingStep, which renders the same hint. */
-  .cs-preflight {
+  .cs-preflight,
+  .cs-preflight-checking {
     font-size: 12px;
     line-height: 1.5;
     border: 1px solid var(--tandem-warning-border);
     border-radius: var(--tandem-r-2);
     padding: 6px 8px;
     margin-bottom: 8px;
+  }
+  .cs-preflight-checking {
+    border-color: var(--tandem-border);
+    color: var(--tandem-fg-muted);
   }
   .cs-link {
     color: var(--tandem-accent);

--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -112,11 +112,30 @@ async function handleToggleOn(): Promise<void> {
   }, "Failed to enable Cowork");
 }
 
-async function handleToggleOff(): Promise<void> {
+/**
+ * Re-assert a one-way `checked=` checkbox against the model.
+ *
+ * Svelte caches the last value it wrote and skips the DOM write when the
+ * expression re-computes to that same value — but the user's click has already
+ * moved the DOM without telling it. So every transition that leaves the
+ * expression unchanged desyncs the control from its own label, and nothing
+ * re-runs to heal it. Measured before this existed: decline the UAC prompt on
+ * disable and the toggle reads off, the line directly under it reads
+ * "Integration enabled: yes", and clicking the toggle again opens the ENABLE
+ * confirm — `handleToggleOff` is unreachable until the component remounts.
+ */
+function resyncCheckbox(box: HTMLInputElement, modelValue: boolean): void {
+  box.checked = modelValue;
+}
+
+async function handleToggleOff(box: HTMLInputElement): Promise<void> {
   await withInvoke(async (invoke) => {
     await coworkToggleIntegration(invoke, false);
     await refetch();
   }, "Failed to disable Cowork");
+  // Unconditional, not just on the failure path: a disable whose refetch does
+  // not reflect the write leaves the same desync with no toast at all.
+  resyncCheckbox(box, coworkState.status?.enabled ?? false);
 }
 
 function handleRescan(): void {
@@ -128,11 +147,15 @@ function handleRescan(): void {
   });
 }
 
-async function handleToggleLanIp(enabled: boolean): Promise<void> {
+async function handleToggleLanIp(enabled: boolean, box: HTMLInputElement): Promise<void> {
   await withInvoke(async (invoke) => {
     await coworkSetLanIpOverride(invoke, enabled);
     await refetch();
   }, "Failed to update LAN-IP override");
+  // Same hazard as the Enable toggle, without a confirm banner to mask it:
+  // `checked={s.useLanIpOverride}` cannot re-run when the write fails, so the
+  // box would sit where the user put it over a setting that never moved.
+  resyncCheckbox(box, coworkState.status?.useLanIpOverride ?? false);
 }
 
 function workspaceRowStyle(ws: WorkspaceStatus): string {
@@ -180,7 +203,9 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
     >
       <!-- `|| confirming` so Cancel un-checks the box again: `s.enabled` never
            changed on the way in, so binding to it alone left a checked box
-           sitting over a disabled integration until the next status refetch. -->
+           sitting over a disabled integration until the next status refetch.
+           That covers the enable half; `resyncCheckbox` covers the disable
+           half, which this expression cannot reach. -->
       <input
         class="cs-accent-cbx"
         data-testid="cowork-toggle-checkbox"
@@ -188,14 +213,26 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
         checked={s.enabled || confirming === "enable"}
         disabled={busy}
         onchange={(e) => {
-          if ((e.target as HTMLInputElement).checked) openEnableConfirm();
+          const box = e.currentTarget as HTMLInputElement;
+          if (box.checked) {
+            // Already on: there is no enable to confirm. Snap the box back
+            // rather than offering a UAC prompt and a firewall write for the
+            // state the user is already in. This is the only way out of a
+            // desync left by a disable that failed.
+            if (s.enabled) resyncCheckbox(box, true);
+            else openEnableConfirm();
+            return;
+          }
           // Unchecking while the confirm is open is a cancel, not a disable.
           // It used to fall through to `handleToggleOff`, which fired a real
           // `coworkToggleIntegration(invoke, false)` for a state transition
           // that had never happened — and left the confirm open behind it,
           // Enable button and all.
-          else if (confirming === "enable") closeEnableConfirm();
-          else void handleToggleOff();
+          if (confirming === "enable") closeEnableConfirm();
+          // …but cancelling is ALL it does unless the integration is genuinely
+          // on, which is reachable: the 30s status poll can report an enable
+          // that happened on another surface while this confirm sat open.
+          if (s.enabled) void handleToggleOff(box);
         }}
       />
       <span>Enable Cowork integration</span>
@@ -317,7 +354,10 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
             type="checkbox"
             checked={s.useLanIpOverride}
             disabled={busy}
-            onchange={(e) => void handleToggleLanIp((e.target as HTMLInputElement).checked)}
+            onchange={(e) => {
+              const box = e.currentTarget as HTMLInputElement;
+              void handleToggleLanIp(box.checked, box);
+            }}
           />
           <span>Use LAN IP instead of host.docker.internal</span>
         </label>

--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -7,6 +7,7 @@ import {
 } from "../../shared/constants";
 import {
   aggregateWorkspaceStatus,
+  COWORK_PREFLIGHT_CHECKING,
   coworkReachability,
   coworkReachabilityCopy,
   coworkSettingsVariant,
@@ -247,16 +248,9 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
           Cowork can reach your open documents. This adds a Windows firewall rule so the Cowork VM
           can connect back — admin is required once.
         </div>
-        <!-- #1376: the live region is mounted for the life of the confirm and
-             only its contents swap. Carried on the banner itself, `role=status`
-             announced nothing — a region inserted with its text already present
-             is generally not read out, so a screen-reader user asked Tandem to
-             check the network, watched it fail, and heard no reason.
-
-             Both children are shown rather than one `{#if}/{:else if}`: `run()`
-             keeps the previous result on purpose, so a retry has `probing` and
-             `blocked` set together, and swapping would unmount a testid the
-             wizard/settings suites read mid-probe. -->
+        <!-- #1376: mounted-before-populated, and the two children are additive.
+             `useCoworkPreflight.svelte.ts` explains both and is the one place
+             that should. -->
         <div role="status" data-testid="cowork-preflight-live">
           {#if probe.preflight?.status === "blocked"}
             <!-- #1298: we already watched detection fail, so offer a retry rather
@@ -266,7 +260,7 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
             </div>
           {/if}
           {#if probe.probing}
-            <div class="cs-preflight-checking">Checking your network…</div>
+            <div class="cs-help-text">{COWORK_PREFLIGHT_CHECKING}</div>
           {/if}
         </div>
         <div class="cs-actions">
@@ -445,18 +439,13 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
      paragraph of the confirm blurb. It already inherits the warning tokens from
      `.cs-warning-banner`, so a border is what separates it — matching
      `.cos-preflight` in CoworkOnboardingStep, which renders the same hint. */
-  .cs-preflight,
-  .cs-preflight-checking {
+  .cs-preflight {
     font-size: 12px;
     line-height: 1.5;
     border: 1px solid var(--tandem-warning-border);
     border-radius: var(--tandem-r-2);
     padding: 6px 8px;
     margin-bottom: 8px;
-  }
-  .cs-preflight-checking {
-    border-color: var(--tandem-border);
-    color: var(--tandem-fg-muted);
   }
   .cs-link {
     color: var(--tandem-accent);

--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -113,39 +113,66 @@ async function handleToggleOn(): Promise<void> {
   }, "Failed to enable Cowork");
 }
 
+/**
+ * The Enable checkbox's rendered state, in ONE place.
+ *
+ * `resyncCheckbox` writes `box.checked` directly and does not update the cache
+ * Svelte's `set_checked` keeps, so a resync to a value the `checked=` expression
+ * disagrees with LATCHES: the next re-computation back to the cached value is
+ * skipped and the box can no longer be moved. Passing the same expression to
+ * both makes that structurally impossible instead of incidentally true.
+ */
+const enableBoxChecked = $derived(
+  (coworkState.status?.enabled ?? false) || confirming === "enable",
+);
+
 async function handleToggleOff(box: HTMLInputElement): Promise<void> {
+  // Gate the resync on the READ-BACK, not on the write. `refetch()` swallows
+  // its own failure into `coworkState.error`, so after a successful toggle
+  // whose refetch failed, `status` still says `enabled: true` — and resyncing
+  // from it would visibly re-check the box over an integration that is now off.
+  // Three cases, and only the middle one is safe to paint from:
+  //   toggle threw            -> status unchanged AND accurate  -> resync
+  //   toggle ok, refetch ok   -> status fresh                   -> resync
+  //   toggle ok, refetch fail -> status stale and WRONG         -> leave the
+  //     box where the user put it, which is what the write we know landed did.
+  // Not the same thing as #1437, which is an HONEST refetch reporting a partial
+  // commit — there `status` is fresh and must be believed.
+  let readBack = true;
   await withInvoke(async (invoke) => {
     await coworkToggleIntegration(invoke, false);
-    await refetch();
+    readBack = await refetch();
   }, "Failed to disable Cowork");
-  // Unconditional, not just on the failure path: a disable whose refetch does
-  // not reflect the write leaves the same desync with no toast at all.
-  resyncCheckbox(box, coworkState.status?.enabled ?? false);
+  if (readBack) resyncCheckbox(box, enableBoxChecked);
 }
 
 /**
  * The Enable checkbox's only handler — and three of its four cases are not an
  * enable.
  *
- * Checking a box that is already on snaps it back rather than offering a UAC
- * prompt and a firewall write for the state the user is in; that is also the
- * only exit from a desync left by a disable that failed. Unchecking while the
- * confirm is open is a cancel, not a disable — it used to fall through to
- * `handleToggleOff` and fire a real `coworkToggleIntegration(invoke, false)`
- * for a transition that had never happened, leaving the confirm standing behind
- * it. The two unchecked-branch conditions are independent rather than
- * either/or: the 30s status poll can report an enable from another surface
- * while this confirm sits open.
+ * Checking a box that already shows off while the integration is ON is the user
+ * correcting the display, not asking for an enable — so that branch suppresses
+ * the confirm and lets the click stand rather than firing a UAC prompt and a
+ * firewall write for the state the user is already in. (It needs no
+ * `resyncCheckbox`: the browser's own toggle is what heals it, and an
+ * assignment there would write `true` over `true`.)
+ *
+ * Unchecking while the confirm is open is a cancel, not a disable — it used to
+ * fall through to `handleToggleOff` and fire a real
+ * `coworkToggleIntegration(invoke, false)` for a transition that had never
+ * happened, leaving the confirm standing behind it. The two unchecked-branch
+ * conditions are independent rather than either/or: the 30s status poll can
+ * report an enable from another surface while this confirm sits open, so
+ * cancelling a pending enable and disabling a live one are separate
+ * obligations that can both be due.
  */
 function handleToggleChange(box: HTMLInputElement): void {
   const enabled = coworkState.status?.enabled ?? false;
   if (box.checked) {
-    if (enabled) resyncCheckbox(box, true);
-    else openEnableConfirm();
+    if (!enabled) openEnableConfirm();
     return;
   }
   if (confirming === "enable") closeEnableConfirm();
-  // Independently: cancelling a pending enable does not disable anything.
   if (enabled) void handleToggleOff(box);
 }
 
@@ -160,12 +187,14 @@ function handleRescan(): void {
 
 async function handleToggleLanIp(box: HTMLInputElement): Promise<void> {
   const enabled = box.checked;
+  let readBack = true;
   await withInvoke(async (invoke) => {
     await coworkSetLanIpOverride(invoke, enabled);
-    await refetch();
+    readBack = await refetch();
   }, "Failed to update LAN-IP override");
-  // Same hazard as the Enable toggle, and with no confirm banner to mask it.
-  resyncCheckbox(box, coworkState.status?.useLanIpOverride ?? false);
+  // Same hazard as the Enable toggle, same read-back gate — and with no confirm
+  // banner to mask it, the snap-back is this row's entire signal.
+  if (readBack) resyncCheckbox(box, coworkState.status?.useLanIpOverride ?? false);
 }
 
 function workspaceRowStyle(ws: WorkspaceStatus): string {
@@ -211,16 +240,21 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
       class:is-busy={busy}
       data-testid="cowork-toggle"
     >
-      <!-- `|| confirming` so Cancel un-checks the box again: `s.enabled` never
-           changed on the way in, so binding to it alone left a checked box
-           sitting over a disabled integration until the next status refetch.
-           That covers the enable half; `resyncCheckbox` covers the disable
-           half, which this expression cannot reach. -->
+      <!-- `enableBoxChecked`, not a second copy of the expression: the resync
+           in `handleToggleOff` must pass the SAME value this renders, or the two
+           writers latch against each other. The `|| confirming` term is what
+           makes Cancel un-check the box again — `s.enabled` never changed on the
+           way in, so binding to it alone left a checked box sitting over a
+           disabled integration until the next status refetch. What this
+           expression cannot do is repair the disable half, and not because it
+           computes the wrong value: it computes the right one and `set_checked`
+           skips the write because its cache already holds it. See
+           `utils/checkbox-sync.ts`. -->
       <input
         class="cs-accent-cbx"
         data-testid="cowork-toggle-checkbox"
         type="checkbox"
-        checked={s.enabled || confirming === "enable"}
+        checked={enableBoxChecked}
         disabled={busy}
         onchange={(e) => handleToggleChange(e.currentTarget)}
       />
@@ -394,9 +428,15 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
     </div>
   {/if}
 
-  {#if coworkState.error && !coworkState.status}
+  <!-- Not gated on `!coworkState.status`. That gate made this dead for every
+       failure after the first load — which is every failure a user of the
+       toggle can cause, since the toggle only exists once a status has loaded.
+       `refetch()` reports its failure by setting `error` and returning false
+       rather than throwing, so without this a re-read that fails leaves the
+       whole surface showing stale values with nothing to say so. -->
+  {#if coworkState.error}
     <div class="cs-error-banner" data-testid="cowork-settings-error" role="alert">
-      Failed to load Cowork status: {coworkState.error}
+      {coworkState.status ? "Couldn't refresh Cowork status" : "Failed to load Cowork status"}: {coworkState.error}
     </div>
   {/if}
 

--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -139,6 +139,15 @@ const enableBoxChecked = $derived(
   (coworkState.status?.enabled ?? false) || confirming === "enable",
 );
 
+/**
+ * The LAN-IP override checkbox's rendered state, in ONE place — same
+ * `resyncCheckbox` latch hazard as {@link enableBoxChecked}, and the same fix:
+ * the resync call and the `checked=` binding must read the identical
+ * expression, not two copies that happen to agree today only because
+ * `useLanIpOverride` is a non-optional `boolean`.
+ */
+const lanIpOverrideChecked = $derived(coworkState.status?.useLanIpOverride ?? false);
+
 async function handleToggleOff(box: HTMLInputElement): Promise<void> {
   // Gate the resync on the READ-BACK, not on the write. `refetch()` swallows
   // its own failure into `coworkState.error`, so after a successful toggle
@@ -207,7 +216,7 @@ async function handleToggleLanIp(box: HTMLInputElement): Promise<void> {
   }, "Failed to update LAN-IP override");
   // Same hazard as the Enable toggle, same read-back gate — and with no confirm
   // banner to mask it, the snap-back is this row's entire signal.
-  if (readBack) resyncCheckbox(box, coworkState.status?.useLanIpOverride ?? false);
+  if (readBack) resyncCheckbox(box, lanIpOverrideChecked);
 }
 
 function workspaceRowStyle(ws: WorkspaceStatus): string {
@@ -388,7 +397,7 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
             class="cs-accent-cbx"
             data-testid="cowork-lan-ip-override-checkbox"
             type="checkbox"
-            checked={s.useLanIpOverride}
+            checked={lanIpOverrideChecked}
             disabled={busy}
             onchange={(e) => void handleToggleLanIp(e.currentTarget)}
           />

--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -28,6 +28,7 @@ import {
 import { createSubnetPreflight } from "../hooks/useCoworkPreflight.svelte";
 import { createCoworkStatus } from "../hooks/useCoworkStatus.svelte";
 import type { WorkspaceFileStatus, WorkspaceStatus } from "../types";
+import { resyncCheckbox } from "../utils/checkbox-sync";
 
 const STATUS_TOKENS: Record<StatusTokenFamily, { bg: string; fg: string; border: string }> = {
   success: {
@@ -112,22 +113,6 @@ async function handleToggleOn(): Promise<void> {
   }, "Failed to enable Cowork");
 }
 
-/**
- * Re-assert a one-way `checked=` checkbox against the model.
- *
- * Svelte caches the last value it wrote and skips the DOM write when the
- * expression re-computes to that same value — but the user's click has already
- * moved the DOM without telling it. So every transition that leaves the
- * expression unchanged desyncs the control from its own label, and nothing
- * re-runs to heal it. Measured before this existed: decline the UAC prompt on
- * disable and the toggle reads off, the line directly under it reads
- * "Integration enabled: yes", and clicking the toggle again opens the ENABLE
- * confirm — `handleToggleOff` is unreachable until the component remounts.
- */
-function resyncCheckbox(box: HTMLInputElement, modelValue: boolean): void {
-  box.checked = modelValue;
-}
-
 async function handleToggleOff(box: HTMLInputElement): Promise<void> {
   await withInvoke(async (invoke) => {
     await coworkToggleIntegration(invoke, false);
@@ -136,6 +121,32 @@ async function handleToggleOff(box: HTMLInputElement): Promise<void> {
   // Unconditional, not just on the failure path: a disable whose refetch does
   // not reflect the write leaves the same desync with no toast at all.
   resyncCheckbox(box, coworkState.status?.enabled ?? false);
+}
+
+/**
+ * The Enable checkbox's only handler — and three of its four cases are not an
+ * enable.
+ *
+ * Checking a box that is already on snaps it back rather than offering a UAC
+ * prompt and a firewall write for the state the user is in; that is also the
+ * only exit from a desync left by a disable that failed. Unchecking while the
+ * confirm is open is a cancel, not a disable — it used to fall through to
+ * `handleToggleOff` and fire a real `coworkToggleIntegration(invoke, false)`
+ * for a transition that had never happened, leaving the confirm standing behind
+ * it. The two unchecked-branch conditions are independent rather than
+ * either/or: the 30s status poll can report an enable from another surface
+ * while this confirm sits open.
+ */
+function handleToggleChange(box: HTMLInputElement): void {
+  const enabled = coworkState.status?.enabled ?? false;
+  if (box.checked) {
+    if (enabled) resyncCheckbox(box, true);
+    else openEnableConfirm();
+    return;
+  }
+  if (confirming === "enable") closeEnableConfirm();
+  // Independently: cancelling a pending enable does not disable anything.
+  if (enabled) void handleToggleOff(box);
 }
 
 function handleRescan(): void {
@@ -147,14 +158,13 @@ function handleRescan(): void {
   });
 }
 
-async function handleToggleLanIp(enabled: boolean, box: HTMLInputElement): Promise<void> {
+async function handleToggleLanIp(box: HTMLInputElement): Promise<void> {
+  const enabled = box.checked;
   await withInvoke(async (invoke) => {
     await coworkSetLanIpOverride(invoke, enabled);
     await refetch();
   }, "Failed to update LAN-IP override");
-  // Same hazard as the Enable toggle, without a confirm banner to mask it:
-  // `checked={s.useLanIpOverride}` cannot re-run when the write fails, so the
-  // box would sit where the user put it over a setting that never moved.
+  // Same hazard as the Enable toggle, and with no confirm banner to mask it.
   resyncCheckbox(box, coworkState.status?.useLanIpOverride ?? false);
 }
 
@@ -212,28 +222,7 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
         type="checkbox"
         checked={s.enabled || confirming === "enable"}
         disabled={busy}
-        onchange={(e) => {
-          const box = e.currentTarget as HTMLInputElement;
-          if (box.checked) {
-            // Already on: there is no enable to confirm. Snap the box back
-            // rather than offering a UAC prompt and a firewall write for the
-            // state the user is already in. This is the only way out of a
-            // desync left by a disable that failed.
-            if (s.enabled) resyncCheckbox(box, true);
-            else openEnableConfirm();
-            return;
-          }
-          // Unchecking while the confirm is open is a cancel, not a disable.
-          // It used to fall through to `handleToggleOff`, which fired a real
-          // `coworkToggleIntegration(invoke, false)` for a state transition
-          // that had never happened — and left the confirm open behind it,
-          // Enable button and all.
-          if (confirming === "enable") closeEnableConfirm();
-          // …but cancelling is ALL it does unless the integration is genuinely
-          // on, which is reachable: the 30s status poll can report an enable
-          // that happened on another surface while this confirm sat open.
-          if (s.enabled) void handleToggleOff(box);
-        }}
+        onchange={(e) => handleToggleChange(e.currentTarget)}
       />
       <span>Enable Cowork integration</span>
     </label>
@@ -354,10 +343,7 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
             type="checkbox"
             checked={s.useLanIpOverride}
             disabled={busy}
-            onchange={(e) => {
-              const box = e.currentTarget as HTMLInputElement;
-              void handleToggleLanIp(box.checked, box);
-            }}
+            onchange={(e) => void handleToggleLanIp(e.currentTarget)}
           />
           <span>Use LAN IP instead of host.docker.internal</span>
         </label>

--- a/src/client/components/IntegrationWizardModal.svelte
+++ b/src/client/components/IntegrationWizardModal.svelte
@@ -25,7 +25,7 @@
  * --tandem-z-above-titlebar, r-5 + shadow-3) and a Tab focus trap re-queried
  * per keypress (the Advanced <details> changes the focusable set while open).
  */
-import { untrack } from "svelte";
+import { tick, untrack } from "svelte";
 import {
   BYO_MODELS_ENABLED,
   CLAUDE_PLUGIN_INSTALL_COMMANDS,
@@ -164,13 +164,23 @@ const PLUGIN_INSTALL_TEXT = CLAUDE_PLUGIN_INSTALL_COMMANDS.join("\n");
 let pluginCopyResult = $state("");
 
 async function copyPluginCommands(): Promise<void> {
+  // Clear and flush before writing the outcome. A second click with the same
+  // outcome would otherwise re-assign an identical string: Svelte skips the
+  // text update, the region's contents never change, and a live region that
+  // does not change announces nothing. The user clicks the retry the failure
+  // message asks for and hears silence.
+  pluginCopyResult = "";
+  await tick();
   try {
     await navigator.clipboard.writeText(PLUGIN_INSTALL_TEXT);
     pluginCopyResult = "Copied";
-  } catch {
-    // No rethrow and no console noise: the message says everything actionable,
-    // and the commands stay on screen to be selected by hand. The WebView
-    // denies clipboard access in more situations than it grants it.
+  } catch (err) {
+    // Not rethrown: the message says everything actionable and the commands
+    // stay on screen to be selected by hand. Logged anyway — a denied
+    // permission, a WebView with no `navigator.clipboard`, and a security
+    // policy rejection are three different bugs with three different fixes,
+    // and after this catch nobody can tell which one a user hit.
+    console.warn("[wizard] clipboard write failed:", err);
     pluginCopyResult = "Couldn't copy — select the commands above";
   }
 }
@@ -212,6 +222,12 @@ $effect(() => {
 function openCoworkView(): void {
   coworkError = null;
   coworkBusy = false;
+  // The push-routes block unmounts with the main view, so a surviving result
+  // would remount CREATED WITH its content on the way back — a live region
+  // that is never announced, which is the defect #1376 exists to fix,
+  // reintroduced inside the fix. `leaveCoworkView` documents the same
+  // discipline for `coworkProbe`.
+  pluginCopyResult = "";
   view = "cowork";
   void coworkProbe.run();
 }
@@ -302,6 +318,9 @@ function close(): void {
 function retryDetection(): void {
   wizard.reset();
   secretInputs = {};
+  // Same reason as `openCoworkView`: `wizard.reset()` re-renders through the
+  // detecting state, so the status must not survive into the remount.
+  pluginCopyResult = "";
   void wizard.begin();
   void cliStatus.refetch();
   // The Cowork poller only refreshes every 30s — "Check again" must reflect a
@@ -703,12 +722,24 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
                  surfaces, this wrapper's parent (`.iw-step`) is a flex column
                  with a `gap`, and a gap applies between items regardless of
                  their size — so an always-mounted empty wrapper would sit there
-                 as a permanent `--tandem-space-4` of dead air. `:empty` and
-                 `display: none` are both wrong here: Svelte leaves comment
-                 anchors inside an `{#if}` so the wrapper is never `:empty`, and
-                 `display: none` takes a live region back OUT of the
-                 accessibility tree, restoring the exact bug at the exact
-                 moment content arrives. -->
+                 as a permanent `--tandem-space-4` of dead air.
+
+                 `:empty` and `display: none` are both wrong here. `:empty`
+                 because the two `{#if}` blocks compile to two `<!>` anchors on
+                 separate source lines, and the WHITESPACE between them is a
+                 text node — `:empty` ignores comments but not that, so the
+                 wrapper never matches. (Joining the source lines would fix the
+                 selector and is not worth the fragility.) `display: none`
+                 because it takes a live region back OUT of the accessibility
+                 tree, restoring the exact bug at the exact moment content
+                 arrives.
+
+                 `display: contents` has its own history of dropping elements
+                 from the a11y tree; Chromium has exposed them since 89 and
+                 this sub-view is WebView2-only (gated on `isTauriRuntime()`
+                 and an `osSupported` Cowork status), so the WebKit path never
+                 renders it. Re-check before reusing this on a surface macOS
+                 can reach. -->
             <div
               class="iw-preflight-live"
               role="status"
@@ -1025,9 +1056,12 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
                     The channel shim is registered here, and it is the one route that needs
                     neither of those. Registration alone does not switch it on, though: start the
                     session with
-                    <code class="iw-code-inline">
-                      claude --dangerously-load-development-channels server:tandem-channel
-                    </code>.
+                    <!-- One source line on purpose: `.iw-code-inline` sets no
+                         `white-space`, so a wrap here collapses to a space
+                         INSIDE the chip and the command can break mid-flag
+                         where a user will copy a fragment of it. -->
+                    <!-- prettier-ignore -->
+                    <code class="iw-code-inline">claude --dangerously-load-development-channels server:tandem-channel</code>.
                   </p>
                 {:else}
                   <p>
@@ -1728,19 +1762,16 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
     margin-top: 1px;
   }
 
-  /* Push-vs-polling readout (WS-B). A config-truth line, not a live claim:
-     "configured" (success-tinted) vs "polling" (neutral/muted). */
+  /* Push-routes readout. ONE treatment for both arms since #1389: the old
+     green/grey split tinted "configured" vs "polling", which read as
+     configured-vs-degraded, and the unregistered arm is neither — it now leads
+     with two push routes that need no shim at all. */
   .iw-push-mode {
     margin-top: var(--tandem-space-2);
     padding: var(--tandem-space-2) var(--tandem-space-3);
     border-radius: var(--tandem-r-3);
     font-size: var(--tandem-text-xs);
     line-height: 1.5;
-  }
-  /* One treatment for both arms since #1389. The green/grey split read as
-     "configured" vs "degraded", and the unregistered arm is neither — it now
-     leads with two push routes that need no shim at all. */
-  .iw-push-mode {
     background: var(--tandem-surface-muted);
     color: var(--tandem-fg-muted);
   }

--- a/src/client/components/IntegrationWizardModal.svelte
+++ b/src/client/components/IntegrationWizardModal.svelte
@@ -33,6 +33,7 @@ import {
 } from "../../shared/constants.js";
 import type { ApplyItemResult, ExistingMcpInstall } from "../../shared/integrations/contract.js";
 import {
+  COWORK_PREFLIGHT_CHECKING,
   coworkSettingsVariant,
   formatCoworkError,
   isTauriRuntime,
@@ -154,27 +155,23 @@ let coworkBusy = $state(false);
 let coworkError = $state<string | null>(null);
 const coworkProbe = createSubnetPreflight();
 
-// #1390: the plugin install commands, and the state of the button that copies
-// them. The label is the only feedback — deliberately, because the alternative
-// is a transient banner in a modal that already stacks four of them, and a
-// label change on a persistent node is the shape screen readers announce.
+// #1390: the plugin install commands, plus the outcome of the button that
+// copies them. The outcome lives beside the button in its own live region
+// rather than in the button's label — a changed accessible name on a button
+// nobody is focused on is announced by nothing, which is the same mistake
+// #1376 exists to fix.
 const PLUGIN_INSTALL_TEXT = CLAUDE_PLUGIN_INSTALL_COMMANDS.join("\n");
-let pluginCopyState = $state<"idle" | "copied" | "failed">("idle");
-const pluginCopyLabel = $derived(
-  { idle: "Copy", copied: "Copied", failed: "Copy failed — select the text above" }[
-    pluginCopyState
-  ],
-);
+let pluginCopyResult = $state("");
 
 async function copyPluginCommands(): Promise<void> {
   try {
     await navigator.clipboard.writeText(PLUGIN_INSTALL_TEXT);
-    pluginCopyState = "copied";
+    pluginCopyResult = "Copied";
   } catch {
-    // No rethrow and no console noise: the failure is fully described by the
-    // label, and the commands stay on screen to be selected by hand. The
-    // WebView denies clipboard access in more situations than it grants it.
-    pluginCopyState = "failed";
+    // No rethrow and no console noise: the message says everything actionable,
+    // and the commands stay on screen to be selected by hand. The WebView
+    // denies clipboard access in more situations than it grants it.
+    pluginCopyResult = "Couldn't copy — select the commands above";
   }
 }
 
@@ -540,9 +537,10 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
 {/snippet}
 
 <!-- The two push routes that need no flag, in the order `doctor.ts` and
-     `README.md` recommend them. Shared by both halves of the push-mode block
-     because they are true either way: registering the channel shim does not
-     take the built-in watch away, and #1389 was the copy that implied it did.
+     `README.md` recommend them. Rendered ONCE, above the registered/unregistered
+     `{#if}` rather than inside either arm — which is the fix for #1389, whose
+     defect was the registered arm implying that registering the shim takes the
+     built-in watch away. It does not.
 
      Deliberately avoids "every session" in any form. The plugin genuinely does
      apply to every session once installed, but it arms on skill dispatch rather
@@ -563,11 +561,17 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
     Claude uses Tandem's skill, so ask for Tandem by name rather than expecting it to be listening
     beforehand, and launch <code class="iw-code-inline">claude</code> from a terminal so it can
     find Node. It reads the same per-account gate as the built-in Monitor, so it cannot cover for
-    that gate being off — but it does not need Git Bash.
+    that gate being off — but it does not need Git Bash. It also needs Claude Code 2.1.212 or
+    newer: on anything older the install succeeds and the monitor simply never runs, with nothing
+    to tell you so.
   </p>
-  <!-- #1390: registering a marketplace is Claude Code's own trust boundary, so
-       these can only be shown, never run for the user. Before this they were
-       printed by `tandem setup` alone, which a desktop-app user never runs. -->
+  <!-- #1390: shown rather than run. Not because Tandem *cannot* — `apply.ts`
+       already writes `~/.claude.json` and the skill, and `cowork_installer.rs`
+       already writes a plugin registry — but because the personal-Claude-Code
+       registry schema is reverse-engineered rather than supported, and enabling
+       a plugin installs hooks that run in the user's own sessions. See
+       `CLAUDE_PLUGIN_INSTALL_COMMANDS`. Before this they were printed by
+       `tandem setup` alone, which a desktop-app user never runs. -->
   <div class="iw-plugin-install" data-testid="integration-wizard-plugin">
     <pre class="iw-plugin-commands" data-testid="integration-wizard-plugin-commands">{PLUGIN_INSTALL_TEXT}</pre>
     <button
@@ -576,9 +580,12 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
       data-testid="integration-wizard-plugin-copy"
       onclick={() => void copyPluginCommands()}
     >
-      {pluginCopyLabel}
+      Copy
     </button>
   </div>
+  <p class="iw-hint-text" role="status" data-testid="integration-wizard-plugin-copy-status">
+    {pluginCopyResult}
+  </p>
 {/snippet}
 
 {#if open}
@@ -688,19 +695,25 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
                 </div>
               </details>
             {/if}
-            <!-- #1376: `role="status"` used to sit on the banner itself, which
-                 is created together with its text — a live region generally has
-                 to be in the accessibility tree BEFORE its contents change for
-                 the change to be announced, so the sentence explaining a failed
-                 detection was silent for the users who most needed it. The
-                 region is now mounted for the life of the sub-view and only its
-                 contents swap.
+            <!-- #1376: mounted-before-populated, and the two children are
+                 additive. `useCoworkPreflight.svelte.ts` explains both and is
+                 the one place that should.
 
-                 Not styled `:empty { display: none }` as #1376 sketched: Svelte
-                 leaves comment anchors inside an `{#if}`, so the wrapper is
-                 never `:empty`. It carries no box of its own instead, which
-                 costs nothing when both children are absent. -->
-            <div role="status" data-testid="integration-wizard-cowork-preflight-live">
+                 `display: contents` rather than a box: unlike the other two
+                 surfaces, this wrapper's parent (`.iw-step`) is a flex column
+                 with a `gap`, and a gap applies between items regardless of
+                 their size — so an always-mounted empty wrapper would sit there
+                 as a permanent `--tandem-space-4` of dead air. `:empty` and
+                 `display: none` are both wrong here: Svelte leaves comment
+                 anchors inside an `{#if}` so the wrapper is never `:empty`, and
+                 `display: none` takes a live region back OUT of the
+                 accessibility tree, restoring the exact bug at the exact
+                 moment content arrives. -->
+            <div
+              class="iw-preflight-live"
+              role="status"
+              data-testid="integration-wizard-cowork-preflight-live"
+            >
               {#if coworkProbe.preflight?.status === "blocked"}
                 <!-- #1298: detection already failed once here; say why rather
                      than leaving an Enable button that repeats it. -->
@@ -712,13 +725,8 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
                   <span>{coworkProbe.preflight.hint}</span>
                 </div>
               {/if}
-              <!-- Additive rather than an `{:else if}` on `probing`: `run()`
-                   deliberately keeps the previous result, so a retry has both
-                   flags set at once, and swapping the hint out would remove the
-                   testid three tests assert on mid-probe. Appending changes the
-                   region's contents either way, which is what gets announced. -->
               {#if coworkProbe.probing}
-                <p class="iw-hint-text">Checking your network…</p>
+                <p class="iw-hint-text">{COWORK_PREFLIGHT_CHECKING}</p>
               {/if}
             </div>
             {#if coworkError}
@@ -1002,9 +1010,9 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
             </div>
             {#if wizard.channelRegistered !== null && whatsNext !== "stdio-only"}
               <div
-                class="iw-push-mode iw-push-mode-{wizard.channelRegistered ? 'push' : 'polling'}"
+                class="iw-push-mode"
                 data-testid="integration-wizard-push-mode"
-                data-push-mode={wizard.channelRegistered ? "push" : "polling"}
+                data-push-mode={wizard.channelRegistered ? "shim" : "no-shim"}
               >
                 <p>
                   Sessions Tandem starts for you are woken directly and need nothing further. A
@@ -1729,11 +1737,10 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
     font-size: var(--tandem-text-xs);
     line-height: 1.5;
   }
-  .iw-push-mode-push {
-    background: var(--tandem-success-bg);
-    color: var(--tandem-success-fg-strong);
-  }
-  .iw-push-mode-polling {
+  /* One treatment for both arms since #1389. The green/grey split read as
+     "configured" vs "degraded", and the unregistered arm is neither — it now
+     leads with two push routes that need no shim at all. */
+  .iw-push-mode {
     background: var(--tandem-surface-muted);
     color: var(--tandem-fg-muted);
   }
@@ -1768,6 +1775,11 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
   }
   .iw-plugin-copy-btn {
     flex: 0 0 auto;
+  }
+  /* See the markup comment: the parent is a gapped flex column, so a box here
+     would cost a gap whenever the region is empty — which is most of the time. */
+  .iw-preflight-live {
+    display: contents;
   }
 
   /* --- More integrations --- */

--- a/src/client/components/IntegrationWizardModal.svelte
+++ b/src/client/components/IntegrationWizardModal.svelte
@@ -26,7 +26,11 @@
  * per keypress (the Advanced <details> changes the focusable set while open).
  */
 import { untrack } from "svelte";
-import { BYO_MODELS_ENABLED, DEFAULT_MCP_PORT } from "../../shared/constants.js";
+import {
+  BYO_MODELS_ENABLED,
+  CLAUDE_PLUGIN_INSTALL_COMMANDS,
+  DEFAULT_MCP_PORT,
+} from "../../shared/constants.js";
 import type { ApplyItemResult, ExistingMcpInstall } from "../../shared/integrations/contract.js";
 import {
   coworkSettingsVariant,
@@ -149,6 +153,30 @@ let view = $state<"main" | "cowork">("main");
 let coworkBusy = $state(false);
 let coworkError = $state<string | null>(null);
 const coworkProbe = createSubnetPreflight();
+
+// #1390: the plugin install commands, and the state of the button that copies
+// them. The label is the only feedback — deliberately, because the alternative
+// is a transient banner in a modal that already stacks four of them, and a
+// label change on a persistent node is the shape screen readers announce.
+const PLUGIN_INSTALL_TEXT = CLAUDE_PLUGIN_INSTALL_COMMANDS.join("\n");
+let pluginCopyState = $state<"idle" | "copied" | "failed">("idle");
+const pluginCopyLabel = $derived(
+  { idle: "Copy", copied: "Copied", failed: "Copy failed — select the text above" }[
+    pluginCopyState
+  ],
+);
+
+async function copyPluginCommands(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(PLUGIN_INSTALL_TEXT);
+    pluginCopyState = "copied";
+  } catch {
+    // No rethrow and no console noise: the failure is fully described by the
+    // label, and the commands stay on screen to be selected by hand. The
+    // WebView denies clipboard access in more situations than it grants it.
+    pluginCopyState = "failed";
+  }
+}
 
 let dialogEl: HTMLElement | null = $state(null);
 let prevFocus: Element | null = null;
@@ -511,6 +539,48 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
   {/if}
 {/snippet}
 
+<!-- The two push routes that need no flag, in the order `doctor.ts` and
+     `README.md` recommend them. Shared by both halves of the push-mode block
+     because they are true either way: registering the channel shim does not
+     take the built-in watch away, and #1389 was the copy that implied it did.
+
+     Deliberately avoids "every session" in any form. The plugin genuinely does
+     apply to every session once installed, but it arms on skill dispatch rather
+     than at session start, and `tests/docs/monitor-arming-claims.test.ts` scores
+     that claim per LINE — a sentence that reads honestly here is one wrap away
+     from an unqualified promise. Saying when it starts and leaving the scope
+     implied is both shorter and not the thing that keeps breaking. -->
+{#snippet pushRoutes()}
+  <p>
+    <strong>The built-in Monitor watch</strong> installs nothing and needs no flag: on first
+    Tandem use, Tandem's bundled skill reads the wake address from Claude's first
+    <code class="iw-code-inline">tandem_status</code> and starts it for that session. It needs a
+    Claude Code that offers a built-in Monitor tool — that is granted per account rather than per
+    version, so upgrading will not add it, and on Windows it also needs Git Bash.
+  </p>
+  <p>
+    <strong>The Tandem plugin</strong> needs no flag either. It starts watching the first time
+    Claude uses Tandem's skill, so ask for Tandem by name rather than expecting it to be listening
+    beforehand, and launch <code class="iw-code-inline">claude</code> from a terminal so it can
+    find Node. It reads the same per-account gate as the built-in Monitor, so it cannot cover for
+    that gate being off — but it does not need Git Bash.
+  </p>
+  <!-- #1390: registering a marketplace is Claude Code's own trust boundary, so
+       these can only be shown, never run for the user. Before this they were
+       printed by `tandem setup` alone, which a desktop-app user never runs. -->
+  <div class="iw-plugin-install" data-testid="integration-wizard-plugin">
+    <pre class="iw-plugin-commands" data-testid="integration-wizard-plugin-commands">{PLUGIN_INSTALL_TEXT}</pre>
+    <button
+      type="button"
+      class="iw-btn iw-btn-secondary iw-plugin-copy-btn"
+      data-testid="integration-wizard-plugin-copy"
+      onclick={() => void copyPluginCommands()}
+    >
+      {pluginCopyLabel}
+    </button>
+  </div>
+{/snippet}
+
 {#if open}
   <div
     role="presentation"
@@ -618,18 +688,39 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
                 </div>
               </details>
             {/if}
-            {#if coworkProbe.preflight?.status === "blocked"}
-              <!-- #1298: detection already failed once here; say why rather
-                   than leaving an Enable button that repeats it. -->
-              <div
-                class="iw-banner-warning"
-                role="status"
-                data-testid="integration-wizard-cowork-preflight-blocked"
-              >
-                {@render warningIcon()}
-                <span>{coworkProbe.preflight.hint}</span>
-              </div>
-            {/if}
+            <!-- #1376: `role="status"` used to sit on the banner itself, which
+                 is created together with its text — a live region generally has
+                 to be in the accessibility tree BEFORE its contents change for
+                 the change to be announced, so the sentence explaining a failed
+                 detection was silent for the users who most needed it. The
+                 region is now mounted for the life of the sub-view and only its
+                 contents swap.
+
+                 Not styled `:empty { display: none }` as #1376 sketched: Svelte
+                 leaves comment anchors inside an `{#if}`, so the wrapper is
+                 never `:empty`. It carries no box of its own instead, which
+                 costs nothing when both children are absent. -->
+            <div role="status" data-testid="integration-wizard-cowork-preflight-live">
+              {#if coworkProbe.preflight?.status === "blocked"}
+                <!-- #1298: detection already failed once here; say why rather
+                     than leaving an Enable button that repeats it. -->
+                <div
+                  class="iw-banner-warning"
+                  data-testid="integration-wizard-cowork-preflight-blocked"
+                >
+                  {@render warningIcon()}
+                  <span>{coworkProbe.preflight.hint}</span>
+                </div>
+              {/if}
+              <!-- Additive rather than an `{:else if}` on `probing`: `run()`
+                   deliberately keeps the previous result, so a retry has both
+                   flags set at once, and swapping the hint out would remove the
+                   testid three tests assert on mid-probe. Appending changes the
+                   region's contents either way, which is what gets announced. -->
+              {#if coworkProbe.probing}
+                <p class="iw-hint-text">Checking your network…</p>
+              {/if}
+            </div>
             {#if coworkError}
               <div
                 class="iw-banner-warning"
@@ -915,34 +1006,28 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
                 data-testid="integration-wizard-push-mode"
                 data-push-mode={wizard.channelRegistered ? "push" : "polling"}
               >
-                {#if wizard.channelRegistered}
-                  The channel shim is registered. Sessions Tandem starts for you are woken directly
-                  and need nothing further. For a session you start yourself, the simplest route is
-                  still to ask Claude to arm a watch on Tandem's wake stream — nothing to install,
-                  no flag — where Claude Code offers a Monitor tool. If Claude says it has none,
-                  that is what the shim is for: start it with the
-                  <code class="iw-code-inline">--dangerously-load-development-channels</code> flag,
-                  since registration alone does not switch the channel on. Either way, Claude also
-                  sees your comments and messages when it next checks its inbox. Use one, not both.
-                {:else}
+                <p>
                   Sessions Tandem starts for you are woken directly and need nothing further. A
-                  session you start yourself will see your comments and messages when it next
-                  checks its inbox — to have it react as they happen, the simplest route is to ask
-                  Claude to arm a watch on Tandem's wake stream, which needs nothing installed.
-                  That one depends on Claude Code offering a Monitor tool, which not every one
-                  does; if Claude says it has none, come back here and register the channel shim,
-                  which does not need it. Installing the Tandem plugin covers any session where you
-                  ask for Tandem by name — it starts watching the first time Claude uses the Tandem
-                  skill, not the moment the session opens — as long as you launch
-                  <code class="iw-code-inline">claude</code> from a terminal so it can find Node.
-                  Use one, not both.
-                {/if}
-                <p class="iw-hint-text">
-                  To install the plugin, run these in a terminal:
-                  <code class="iw-code-inline">claude plugin marketplace add bloknayrb/tandem</code>
-                  then
-                  <code class="iw-code-inline">claude plugin install tandem@tandem-editor</code>.
+                  session you start yourself sees your comments and messages when it next checks
+                  its inbox; to have it react as they happen, use one of these — not several.
                 </p>
+                {@render pushRoutes()}
+                {#if wizard.channelRegistered}
+                  <p>
+                    The channel shim is registered here, and it is the one route that needs
+                    neither of those. Registration alone does not switch it on, though: start the
+                    session with
+                    <code class="iw-code-inline">
+                      claude --dangerously-load-development-channels server:tandem-channel
+                    </code>.
+                  </p>
+                {:else}
+                  <p>
+                    If Claude reports no Monitor tool at all, come back here and register the
+                    channel shim — it is the one route that depends on neither gate, at the cost
+                    of a flag on every session you start.
+                  </p>
+                {/if}
               </div>
             {/if}
           </section>
@@ -1651,6 +1736,38 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
   .iw-push-mode-polling {
     background: var(--tandem-surface-muted);
     color: var(--tandem-fg-muted);
+  }
+  /* The block is now several paragraphs rather than one sentence; scoped so it
+     cannot reach the `<p>`s in the Cowork sub-view. */
+  .iw-push-mode p {
+    margin: 0 0 var(--tandem-space-2);
+  }
+  .iw-push-mode p:last-child {
+    margin-bottom: 0;
+  }
+  .iw-plugin-install {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--tandem-space-2);
+    margin-bottom: var(--tandem-space-2);
+  }
+  .iw-plugin-commands {
+    /* `min-width: 0` because a flex item's automatic minimum size is
+       min-content, and these are two unbreakable command lines — without it the
+       <pre> refuses to shrink and pushes the button out of the dialog. */
+    flex: 1 1 auto;
+    min-width: 0;
+    margin: 0;
+    padding: var(--tandem-space-2);
+    font-family: var(--tandem-font-mono);
+    font-size: var(--tandem-text-xs);
+    line-height: 1.6;
+    background: var(--tandem-surface-sunk);
+    border-radius: var(--tandem-r-2);
+    overflow-x: auto;
+  }
+  .iw-plugin-copy-btn {
+    flex: 0 0 auto;
   }
 
   /* --- More integrations --- */

--- a/src/client/components/IntegrationWizardModal.svelte
+++ b/src/client/components/IntegrationWizardModal.svelte
@@ -168,11 +168,17 @@ const PLUGIN_INSTALL_TEXT = CLAUDE_PLUGIN_INSTALL_COMMANDS.join("\n");
  * MUST be `""` whenever the push-routes block is about to (re)mount — a live
  * region created already holding its text is announced by nothing, which is
  * #1376's defect reintroduced inside the fix for it. Unlike `coworkProbe`,
- * there is no single choke point to hang that on: this block's mount condition
- * is compound and partly `$derived` (`step === "done"` AND `view === "main"`
- * AND `channelRegistered !== null && whatsNext !== "stdio-only"`, where
- * `whatsNext` follows a live reachability poll). So the reset is explicit at
- * each transition, and `copyToken` is what makes that safe.
+ * there is no single choke point to hang that on, so the reset is explicit at
+ * each transition that can remount the block — `openCoworkView` and
+ * `retryDetection` — and `copyToken` is what makes that safe.
+ *
+ * `close()` deliberately does not reset, and that is the one leg of this
+ * invariant the component does not own: it holds only because `App.svelte`
+ * renders the modal under `{#if shouldShowWizard}`, so closing DESTROYS this
+ * state rather than hiding it. The component is otherwise written for a
+ * persistent `open` prop, and under that shape a close/reopen would remount the
+ * block still holding "Copied". If the parent ever stops unmounting, this needs
+ * a third reset site.
  */
 let pluginCopyResult = $state("");
 
@@ -189,9 +195,11 @@ let copyToken = 0;
 async function copyPluginCommands(): Promise<void> {
   const mine = ++copyToken;
   let result: string;
-  // `writeText` FIRST, with no await before it. Some engines gate the
-  // clipboard on transient user activation, which an awaited microtask can
-  // outlive — so the clear-and-flush below happens after the write, not before.
+  // `writeText` FIRST, with no await before it. WebKit invalidates the
+  // user-gesture token across an `await`, so a clipboard write placed after one
+  // can be rejected for want of transient activation — hence the clear-and-flush
+  // below happens after the write, not before. (Not testable here: happy-dom
+  // models no activation state, so this is pinned by the comment, deliberately.)
   try {
     await navigator.clipboard.writeText(PLUGIN_INSTALL_TEXT);
     result = "Copied";
@@ -204,9 +212,11 @@ async function copyPluginCommands(): Promise<void> {
     console.warn("[wizard] clipboard write failed:", err);
     result = "Couldn't copy — select the commands above";
   }
-  // Early out so a superseded copy does not blank a region it no longer owns.
-  // The guard AFTER the flush is the load-bearing one — it is what stops the
-  // stale "Copied" from landing — and the tests pin the pair.
+  // THIS is the load-bearing guard: `writeText` spans real tasks, so a user can
+  // click the Cowork row while it is pending, and without this the superseded
+  // continuation both blanks a region it no longer owns and lands a stale
+  // "Copied" in it. Pinned by "drops a copy result that lands after the user has
+  // left for the sub-view".
   if (mine !== copyToken) return;
   // Clear and flush before the outcome: a second click with the SAME outcome
   // would otherwise re-assign an identical string, mutate no text node, and
@@ -214,6 +224,12 @@ async function copyPluginCommands(): Promise<void> {
   // for and hears silence.
   pluginCopyResult = "";
   await tick();
+  // Defensive, and unreachable today: every `copyToken` mutator is an `onclick`,
+  // a click is a task, and the gap above is a microtask — so nothing can
+  // supersede across it. Kept because it costs one line and Svelte's async mode
+  // would make `tick()` span a task, at which point it becomes the load-bearing
+  // one. Deliberately NOT tested: reaching it needs a synthetic click dispatched
+  // inside a microtask flush, which pins an interleaving no user can produce.
   if (mine !== copyToken) return;
   pluginCopyResult = result;
 }
@@ -349,8 +365,9 @@ function close(): void {
 function retryDetection(): void {
   wizard.reset();
   secretInputs = {};
-  // Same reason as `openCoworkView` — `wizard.reset()` re-renders through the
-  // detecting state, so the block remounts.
+  // Same reason as `openCoworkView`: `wizard.reset()` sets `step = "connect"`,
+  // and the push-routes block gates on `step === "done"` — so leaving "done" is
+  // what unmounts it, not the `detecting` flag `reset()` also clears.
   copyToken++;
   pluginCopyResult = "";
   void wizard.begin();
@@ -616,13 +633,9 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
     newer: on anything older the install succeeds and the monitor simply never runs, with nothing
     to tell you so.
   </p>
-  <!-- #1390: shown rather than run. Not because Tandem *cannot* — `apply.ts`
-       already writes `~/.claude.json` and the skill, and `cowork_installer.rs`
-       already writes a plugin registry — but because the personal-Claude-Code
-       registry schema is reverse-engineered rather than supported, and enabling
-       a plugin installs hooks that run in the user's own sessions. See
-       `CLAUDE_PLUGIN_INSTALL_COMMANDS`. Before this they were printed by
-       `tandem setup` alone, which a desktop-app user never runs. -->
+  <!-- #1390: shown rather than run — see `CLAUDE_PLUGIN_INSTALL_COMMANDS` for
+       why. Before this they were printed by `tandem setup` alone, which a
+       desktop-app user never runs. -->
   <div class="iw-plugin-install" data-testid="integration-wizard-plugin">
     <pre class="iw-plugin-commands" data-testid="integration-wizard-plugin-commands">{PLUGIN_INSTALL_TEXT}</pre>
     <button
@@ -1088,12 +1101,9 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
                     The channel shim is registered here, and it is the one route that needs
                     neither of those. Registration alone does not switch it on, though: start the
                     session with
-                    <!-- One source line on purpose: `.iw-code-inline` sets no
-                         `white-space`, so a wrap here collapses to a space
-                         INSIDE the chip and the command can break mid-flag
-                         where a user will copy a fragment of it. -->
-                    <!-- prettier-ignore -->
-                    <code class="iw-code-inline">claude --dangerously-load-development-channels server:tandem-channel</code>.
+                    <code class="iw-code-inline"
+                      >claude --dangerously-load-development-channels server:tandem-channel</code
+                    >.
                   </p>
                 {:else}
                   <p>

--- a/src/client/components/IntegrationWizardModal.svelte
+++ b/src/client/components/IntegrationWizardModal.svelte
@@ -161,19 +161,40 @@ const coworkProbe = createSubnetPreflight();
 // nobody is focused on is announced by nothing, which is the same mistake
 // #1376 exists to fix.
 const PLUGIN_INSTALL_TEXT = CLAUDE_PLUGIN_INSTALL_COMMANDS.join("\n");
+
+/**
+ * Outcome of the Copy button, announced from its own live region.
+ *
+ * MUST be `""` whenever the push-routes block is about to (re)mount — a live
+ * region created already holding its text is announced by nothing, which is
+ * #1376's defect reintroduced inside the fix for it. Unlike `coworkProbe`,
+ * there is no single choke point to hang that on: this block's mount condition
+ * is compound and partly `$derived` (`step === "done"` AND `view === "main"`
+ * AND `channelRegistered !== null && whatsNext !== "stdio-only"`, where
+ * `whatsNext` follows a live reachability poll). So the reset is explicit at
+ * each transition, and `copyToken` is what makes that safe.
+ */
 let pluginCopyResult = $state("");
 
+/**
+ * Monotonic ticket, same device as `createSubnetPreflight`'s. The clear is
+ * synchronous and the write is two awaits later, so without it a clear cannot
+ * dominate an in-flight copy: click Copy, click the Cowork row before the
+ * clipboard settles, and the continuation writes "Copied" into an unmounted
+ * region that then remounts holding it — the exact thing the clear exists to
+ * prevent, caused by the clear's own async gap.
+ */
+let copyToken = 0;
+
 async function copyPluginCommands(): Promise<void> {
-  // Clear and flush before writing the outcome. A second click with the same
-  // outcome would otherwise re-assign an identical string: Svelte skips the
-  // text update, the region's contents never change, and a live region that
-  // does not change announces nothing. The user clicks the retry the failure
-  // message asks for and hears silence.
-  pluginCopyResult = "";
-  await tick();
+  const mine = ++copyToken;
+  let result: string;
+  // `writeText` FIRST, with no await before it. Some engines gate the
+  // clipboard on transient user activation, which an awaited microtask can
+  // outlive — so the clear-and-flush below happens after the write, not before.
   try {
     await navigator.clipboard.writeText(PLUGIN_INSTALL_TEXT);
-    pluginCopyResult = "Copied";
+    result = "Copied";
   } catch (err) {
     // Not rethrown: the message says everything actionable and the commands
     // stay on screen to be selected by hand. Logged anyway — a denied
@@ -181,8 +202,20 @@ async function copyPluginCommands(): Promise<void> {
     // policy rejection are three different bugs with three different fixes,
     // and after this catch nobody can tell which one a user hit.
     console.warn("[wizard] clipboard write failed:", err);
-    pluginCopyResult = "Couldn't copy — select the commands above";
+    result = "Couldn't copy — select the commands above";
   }
+  // Early out so a superseded copy does not blank a region it no longer owns.
+  // The guard AFTER the flush is the load-bearing one — it is what stops the
+  // stale "Copied" from landing — and the tests pin the pair.
+  if (mine !== copyToken) return;
+  // Clear and flush before the outcome: a second click with the SAME outcome
+  // would otherwise re-assign an identical string, mutate no text node, and
+  // announce nothing — so the user clicks the retry the failure message asks
+  // for and hears silence.
+  pluginCopyResult = "";
+  await tick();
+  if (mine !== copyToken) return;
+  pluginCopyResult = result;
 }
 
 let dialogEl: HTMLElement | null = $state(null);
@@ -222,11 +255,9 @@ $effect(() => {
 function openCoworkView(): void {
   coworkError = null;
   coworkBusy = false;
-  // The push-routes block unmounts with the main view, so a surviving result
-  // would remount CREATED WITH its content on the way back — a live region
-  // that is never announced, which is the defect #1376 exists to fix,
-  // reintroduced inside the fix. `leaveCoworkView` documents the same
-  // discipline for `coworkProbe`.
+  // Remount incoming — see the declaration. Bumping the token is what stops an
+  // in-flight copy from writing its result after this clear.
+  copyToken++;
   pluginCopyResult = "";
   view = "cowork";
   void coworkProbe.run();
@@ -318,8 +349,9 @@ function close(): void {
 function retryDetection(): void {
   wizard.reset();
   secretInputs = {};
-  // Same reason as `openCoworkView`: `wizard.reset()` re-renders through the
-  // detecting state, so the status must not survive into the remount.
+  // Same reason as `openCoworkView` — `wizard.reset()` re-renders through the
+  // detecting state, so the block remounts.
+  copyToken++;
   pluginCopyResult = "";
   void wizard.begin();
   void cliStatus.refetch();

--- a/src/client/components/IntegrationWizardModal.svelte
+++ b/src/client/components/IntegrationWizardModal.svelte
@@ -294,15 +294,23 @@ function leaveCoworkView(): void {
  *  footer, never sub-view mount. On success (or UAC-declined, which the Rust
  *  side leaves fail-closed with enabled:false) we refetch and return to MAIN
  *  so the Cowork row reflects the committed outcome; a thrown firewall error
- *  (incl. adminDeclined) shows inline and keeps the user on the sub-view. */
+ *  (incl. adminDeclined) shows inline and keeps the user on the sub-view.
+ *
+ *  Same hazard as `CoworkSettings.svelte`'s `handleToggleOn`: `refetch()` can
+ *  swallow its own failure and return without storing a fresh status. Leaving
+ *  the sub-view on a failed read-back would paint `coworkRowDetail` from the
+ *  stale pre-enable status on MAIN — "Let a teammate's Claude join…" over an
+ *  integration that is actually now connected. Gate the return on the
+ *  read-back succeeding; a failed one leaves the user on the sub-view, whose
+ *  own copy is accurate, until a retry or the next poll catches up. */
 async function enableCowork(): Promise<void> {
   coworkBusy = true;
   coworkError = null;
   try {
     const invoke: InvokeFn = await loadInvoke();
     await coworkToggleIntegration(invoke, true);
-    await coworkStatus.refetch();
-    leaveCoworkView();
+    const readBack = await coworkStatus.refetch();
+    if (readBack) leaveCoworkView();
   } catch (err) {
     const raw = err instanceof Error ? err.message : String(err);
     coworkError = formatCoworkError(raw);

--- a/src/client/components/NetworkSettings.svelte
+++ b/src/client/components/NetworkSettings.svelte
@@ -3,6 +3,7 @@ import { isTauriRuntime } from "../cowork/cowork-helpers.js";
 import { createAppInfo } from "../hooks/useAppInfo.svelte.js";
 import { createAutostart } from "../hooks/useAutostart.svelte.js";
 import type { SidecarRetryStrategy } from "../hooks/useTandemSettings.svelte.js";
+import { resyncCheckbox } from "../utils/checkbox-sync.js";
 import { disabledControlStyle } from "../utils/colors.js";
 import CollapsibleSection from "./CollapsibleSection.svelte";
 import type { SettingsTabContext } from "./SettingsModal.svelte";
@@ -26,6 +27,21 @@ const autostart = createAutostart(() => open && isTauri);
 const autostartStatus = $derived(autostart.status);
 const autostartBlocked = $derived(autostartStatus !== null && !autostartStatus.trayAvailable);
 const autostartDisabled = $derived(autostartBlocked || autostart.loading);
+
+/**
+ * `resyncCheckbox` because `checked={autostartStatus.enabled}` cannot repair
+ * itself — see that helper for the mechanism. Two paths leave `enabled`
+ * unchanged here and both are routine rather than exceptional: `toggle()`'s
+ * `catch` sets `error` without touching `status`, and a `readback-mismatch`
+ * (the OS virtualized the write away) reports the value it already had. Either
+ * way the expression re-computes to what Svelte last wrote, the DOM write is
+ * skipped, and the box sits where the USER put it over a setting that never
+ * moved — with only an error line below to contradict it.
+ */
+async function toggleAutostart(box: HTMLInputElement): Promise<void> {
+  await autostart.toggle(box.checked);
+  resyncCheckbox(box, autostart.status?.enabled ?? false);
+}
 
 let restartError = $state<string | null>(null);
 let restarting = $state(false);
@@ -143,7 +159,7 @@ const tokenRotatedAt = $derived(appInfo.info?.tokenRotatedAt);
         data-testid="network-autostart-toggle"
         checked={autostartStatus.enabled}
         disabled={autostartDisabled}
-        onchange={(e) => void autostart.toggle(e.currentTarget.checked)}
+        onchange={(e) => void toggleAutostart(e.currentTarget)}
         style="accent-color: var(--tandem-accent); margin-top: 2px; flex-shrink: 0; {disabledControlStyle(
           autostartDisabled,
         )}"

--- a/src/client/components/NetworkSettings.svelte
+++ b/src/client/components/NetworkSettings.svelte
@@ -30,13 +30,22 @@ const autostartDisabled = $derived(autostartBlocked || autostart.loading);
 
 /**
  * `resyncCheckbox` because `checked={autostartStatus.enabled}` cannot repair
- * itself — see that helper for the mechanism. Two paths leave `enabled`
- * unchanged here and both are routine rather than exceptional: `toggle()`'s
- * `catch` sets `error` without touching `status`, and a `readback-mismatch`
- * (the OS virtualized the write away) reports the value it already had. Either
- * way the expression re-computes to what Svelte last wrote, the DOM write is
- * skipped, and the box sits where the USER put it over a setting that never
- * moved — with only an error line below to contradict it.
+ * itself — see that helper for the mechanism.
+ *
+ * Unconditional, and NOT keyed on an error code, because several paths leave
+ * `enabled` unchanged and they do not share a signal: `toggle()`'s `catch` sets
+ * `error` without touching `status`; a `readback-mismatch` (the OS virtualized
+ * the write away) reports the value it already had; and a failed
+ * `manager.enable()`/`disable()` still reads back and returns the old value
+ * with an `io-error`/`plugin-error` code *without* rejecting, so the `catch`
+ * never sees it (`src-tauri/src/autostart.rs`, the write-error branch). In
+ * every one of them the expression re-computes to what Svelte last wrote, the
+ * DOM write is skipped, and the box sits where the USER put it over a setting
+ * that never moved — with only an error line below to contradict it.
+ *
+ * Unlike the Cowork toggles, this needs no read-back gate: the status it
+ * resyncs from is the one THIS call returned, not a separately-fetched value
+ * whose fetch can fail unobserved.
  */
 async function toggleAutostart(box: HTMLInputElement): Promise<void> {
   await autostart.toggle(box.checked);

--- a/src/client/cowork/cowork-helpers.ts
+++ b/src/client/cowork/cowork-helpers.ts
@@ -18,9 +18,12 @@ import type {
  *
  * Shared because all three Enable surfaces announce the same probe, and a
  * screen-reader user who moves between Settings, onboarding and the wizard
- * should not hear three descriptions of one operation. Kept beside the other
- * Cowork copy helpers rather than in each component, which is how the three
- * `-checking` styles had already drifted apart within a single commit.
+ * should not hear three descriptions of one operation.
+ *
+ * The STRING is what is shared, and only that — the three surfaces still style
+ * it three ways (`.cs-help-text`, `.cos-checking`, `.iw-hint-text`), because
+ * each sits in a differently-tinted container. Sharing the text is what a
+ * screen reader hears; sharing the CSS would be a visual regression.
  */
 export const COWORK_PREFLIGHT_CHECKING = "Checking your network…";
 

--- a/src/client/cowork/cowork-helpers.ts
+++ b/src/client/cowork/cowork-helpers.ts
@@ -14,6 +14,17 @@ import type {
 } from "../types";
 
 /**
+ * In-flight text for the subnet pre-flight's live region (#1376).
+ *
+ * Shared because all three Enable surfaces announce the same probe, and a
+ * screen-reader user who moves between Settings, onboarding and the wizard
+ * should not hear three descriptions of one operation. Kept beside the other
+ * Cowork copy helpers rather than in each component, which is how the three
+ * `-checking` styles had already drifted apart within a single commit.
+ */
+export const COWORK_PREFLIGHT_CHECKING = "Checking your network…";
+
+/**
  * High-level branch the Settings UI renders. Collapses the `osSupported` /
  * `coworkDetected` / `uacDeclined` / normal states into a single label.
  */

--- a/src/client/hooks/useAutostart.svelte.ts
+++ b/src/client/hooks/useAutostart.svelte.ts
@@ -74,8 +74,15 @@ export function createAutostart(getActive: () => boolean): AutostartState {
     error = null;
     try {
       // The result carries the OS's read-back value, not `next` — so a write
-      // that was virtualized away or blocked leaves the toggle where it was
-      // and reports `readback-mismatch` instead of lying.
+      // that was virtualized away or blocked reports `readback-mismatch`
+      // instead of lying about the STATUS.
+      //
+      // It does not, on its own, put the checkbox back: `status.enabled` is
+      // unchanged, so the one-way `checked=` expression re-computes to the
+      // value Svelte last wrote and the DOM write is skipped, leaving the box
+      // where the user clicked. `NetworkSettings.svelte` calls `resyncCheckbox`
+      // after this for that reason. (An earlier version of this comment claimed
+      // the toggle stayed put by itself. It does not.)
       applyResult(await autostartSetEnabled(await loadInvoke(), next));
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);

--- a/src/client/hooks/useCoworkPreflight.svelte.ts
+++ b/src/client/hooks/useCoworkPreflight.svelte.ts
@@ -45,12 +45,10 @@ export interface SubnetPreflightState {
  *     user asked Tandem to check the network, detection failed, and the
  *     sentence saying why was silent.
  *
- *     Mounting the region early is only half of it, and the missing half is
- *     easy to reintroduce: the in-flight line is the FIRST text to arrive, so
- *     if `probing` flips in the same tick that mounts the region, the region
- *     is once again inserted with content and rule 1 buys nothing. `run()`
- *     therefore defers it one flush. Every caller is free to keep flipping its
- *     mount condition and calling `run()` together; the hook absorbs it.
+ *     Mounting the region early is only half of it: the in-flight line is the
+ *     FIRST text to arrive, so `run()` defers `probing` one flush (see the
+ *     comment on it). Callers may keep flipping their mount condition and
+ *     calling `run()` in one tick; the hook absorbs it.
  *  2. The blocked hint and the in-flight line are ADDITIVE, not an
  *     `{#if}/{:else if}`. `run()` deliberately keeps the previous result (see
  *     the comment on `run` below), so a retry has `probing` and `blocked` set
@@ -84,14 +82,11 @@ export function createSubnetPreflight(): SubnetPreflightState {
     // The cost is that every path which closes a surface MUST call `reset()`,
     // or a stale hint paints on reopen. All three do; the tests pin it.
 
-    // Rule 1 above is why `probing` is set a flush late rather than here.
-    // All three callers flip their mount condition (`confirming`, `view`) and
-    // call `run()` in the same tick, so setting it synchronously would insert
-    // the region and its first line in ONE mutation — the pattern that is not
-    // announced. Waiting one flush lets the region reach the accessibility
-    // tree empty, so "Checking…" arrives as a change to a region already in
-    // it. The ticket is taken above, synchronously, so a `reset()` landing
-    // inside this gap still wins.
+    // Rule 1's deferral. All three callers flip their mount condition
+    // (`confirming`, `view`) and call `run()` in one tick, so setting `probing`
+    // synchronously would insert the region and its first line in ONE mutation
+    // — the pattern that is not announced. The ticket is taken above,
+    // synchronously, so a `reset()` landing inside this gap still wins.
     await tick();
     // Consequence worth knowing: a probe superseded during this gap never
     // issues at all, so two `run()`s in one tick cost ONE PowerShell

--- a/src/client/hooks/useCoworkPreflight.svelte.ts
+++ b/src/client/hooks/useCoworkPreflight.svelte.ts
@@ -1,3 +1,4 @@
+import { tick } from "svelte";
 import {
   coworkPreflightSubnet,
   loadInvoke,
@@ -43,11 +44,20 @@ export interface SubnetPreflightState {
  *     its text is commonly not read out at all. That is the whole defect: a
  *     user asked Tandem to check the network, detection failed, and the
  *     sentence saying why was silent.
+ *
+ *     Mounting the region early is only half of it, and the missing half is
+ *     easy to reintroduce: the in-flight line is the FIRST text to arrive, so
+ *     if `probing` flips in the same tick that mounts the region, the region
+ *     is once again inserted with content and rule 1 buys nothing. `run()`
+ *     therefore defers it one flush. Every caller is free to keep flipping its
+ *     mount condition and calling `run()` together; the hook absorbs it.
  *  2. The blocked hint and the in-flight line are ADDITIVE, not an
  *     `{#if}/{:else if}`. `run()` deliberately keeps the previous result (see
  *     the comment on `run` below), so a retry has `probing` and `blocked` set
- *     at once — and swapping would unmount the `-blocked` testid that three
- *     suites read mid-probe.
+ *     at once — and swapping would unmount the `-blocked` testid that
+ *     `cowork-settings-mounted.test.ts` reads mid-probe. It is also the right
+ *     a11y shape: `role="status"` implies `aria-atomic="false"`, so only the
+ *     added subtree is announced and the retry does not re-read the hint.
  */
 export function createSubnetPreflight(): SubnetPreflightState {
   let preflight = $state<SubnetPreflight | null>(null);
@@ -73,6 +83,22 @@ export function createSubnetPreflight(): SubnetPreflightState {
     //
     // The cost is that every path which closes a surface MUST call `reset()`,
     // or a stale hint paints on reopen. All three do; the tests pin it.
+
+    // Rule 1 above is why `probing` is set a flush late rather than here.
+    // All three callers flip their mount condition (`confirming`, `view`) and
+    // call `run()` in the same tick, so setting it synchronously would insert
+    // the region and its first line in ONE mutation — the pattern that is not
+    // announced. Waiting one flush lets the region reach the accessibility
+    // tree empty, so "Checking…" arrives as a change to a region already in
+    // it. The ticket is taken above, synchronously, so a `reset()` landing
+    // inside this gap still wins.
+    await tick();
+    // Consequence worth knowing: a probe superseded during this gap never
+    // issues at all, so two `run()`s in one tick cost ONE PowerShell
+    // round-trip. That is the desirable reading of a double-clicked retry
+    // button, and `cowork-preflight-hook.test.ts` pins both halves — this one,
+    // and that a probe superseded AFTER issuing still cannot write.
+    if (mine !== token) return;
     probing = true;
     try {
       const invoke = await loadInvoke();

--- a/src/client/hooks/useCoworkPreflight.svelte.ts
+++ b/src/client/hooks/useCoworkPreflight.svelte.ts
@@ -31,6 +31,23 @@ export interface SubnetPreflightState {
  *
  * Callers must keep the returned object intact. Destructuring
  * `preflight`/`probing` invokes the getters once and freezes the values.
+ *
+ * **How the three surfaces must render this (#1376).** All of them announce the
+ * result to a screen reader, and all of them got it wrong the same way, so the
+ * rule lives here rather than three times over:
+ *
+ *  1. The `role="status"` region must be mounted BEFORE any text lands in it —
+ *     for the life of the confirm, or of the wizard's sub-view. An ARIA live
+ *     region generally has to be in the accessibility tree before its contents
+ *     change for the change to be announced; a region inserted together with
+ *     its text is commonly not read out at all. That is the whole defect: a
+ *     user asked Tandem to check the network, detection failed, and the
+ *     sentence saying why was silent.
+ *  2. The blocked hint and the in-flight line are ADDITIVE, not an
+ *     `{#if}/{:else if}`. `run()` deliberately keeps the previous result (see
+ *     the comment on `run` below), so a retry has `probing` and `blocked` set
+ *     at once — and swapping would unmount the `-blocked` testid that three
+ *     suites read mid-probe.
  */
 export function createSubnetPreflight(): SubnetPreflightState {
   let preflight = $state<SubnetPreflight | null>(null);

--- a/src/client/hooks/useCoworkPreflight.svelte.ts
+++ b/src/client/hooks/useCoworkPreflight.svelte.ts
@@ -52,10 +52,12 @@ export interface SubnetPreflightState {
  *  2. The blocked hint and the in-flight line are ADDITIVE, not an
  *     `{#if}/{:else if}`. `run()` deliberately keeps the previous result (see
  *     the comment on `run` below), so a retry has `probing` and `blocked` set
- *     at once — and swapping would unmount the `-blocked` testid that
- *     `cowork-settings-mounted.test.ts` reads mid-probe. It is also the right
- *     a11y shape: `role="status"` implies `aria-atomic="false"`, so only the
- *     added subtree is announced and the retry does not re-read the hint.
+ *     at once — and swapping would unmount the blocked hint that all three
+ *     mounted suites read mid-probe (`cowork-settings-mounted.test.ts`,
+ *     `cowork-onboarding-step-mounted.test.ts`,
+ *     `integration-wizard-cowork.test.ts`), each via the live region's
+ *     `textContent` and the retry button node rather than the `-blocked`
+ *     testid itself.
  */
 export function createSubnetPreflight(): SubnetPreflightState {
   let preflight = $state<SubnetPreflight | null>(null);
@@ -82,28 +84,39 @@ export function createSubnetPreflight(): SubnetPreflightState {
     // The cost is that every path which closes a surface MUST call `reset()`,
     // or a stale hint paints on reopen. All three do; the tests pin it.
 
-    // Rule 1's deferral. All three callers flip their mount condition
-    // (`confirming`, `view`) and call `run()` in one tick, so setting `probing`
-    // synchronously would insert the region and its first line in ONE mutation
-    // — the pattern that is not announced. The ticket is taken above,
-    // synchronously, so a `reset()` landing inside this gap still wins.
-    await tick();
-    // Consequence worth knowing: a probe superseded during this gap never
-    // issues at all, so two `run()`s in one tick cost ONE PowerShell
-    // round-trip. That is the desirable reading of a double-clicked retry
-    // button, and `cowork-preflight-hook.test.ts` pins both halves — this one,
-    // and that a probe superseded AFTER issuing still cannot write.
-    if (mine !== token) return;
-    probing = true;
     try {
+      // Rule 1's deferral. The three ENTRY points (`CoworkSettings`,
+      // `CoworkOnboardingStep`, `IntegrationWizardModal`) flip their mount
+      // condition (`confirming`, `view`) and call `run()` in one tick, so
+      // setting `probing` synchronously would insert the region and its first
+      // line in ONE mutation — the pattern that is not announced. The three
+      // retry buttons mount nothing and flip nothing; for them this is a pure
+      // one-flush delay. The ticket is taken above, synchronously, so a
+      // `reset()` landing inside this gap still wins.
+      //
+      // Inside the `try` on purpose: `tick()` is `await Promise.resolve()` then
+      // `flushSync()`, and `flushSync` runs every pending effect in the app
+      // synchronously — an unrelated component's `$effect` can throw through it.
+      // Every caller is `void run()` with no `.catch()`, so outside the `try`
+      // that would surface as an unhandled rejection AND leave the probe
+      // silently un-issued.
+      await tick();
+      // Consequence worth knowing: a probe superseded during this gap never
+      // issues at all, so two `run()`s in one tick cost ONE PowerShell
+      // round-trip. That is the desirable reading of a double-clicked retry
+      // button, and `cowork-preflight-hook.test.ts` pins both halves — this one,
+      // and that a probe superseded AFTER issuing still cannot write.
+      if (mine !== token) return;
+      probing = true;
       const invoke = await loadInvoke();
       const result = await coworkPreflightSubnet(invoke);
       if (mine !== token) return;
       preflight = result;
     } catch (err) {
       if (mine !== token) return;
-      // Reaching here means the bridge didn't load, or `coworkPreflightSubnet`
-      // threw rather than resolving — several distinct causes that all say
+      // Reaching here means the bridge didn't load, `coworkPreflightSubnet`
+      // threw rather than resolving, or an unrelated `$effect` threw through
+      // the `tick()` flush above — several distinct causes that all say
       // nothing about whether enabling would work, so fall through to the
       // unguarded button. Log it: `unknown` is never rendered, so without this
       // a genuine client fault is invisible on both sides of the bridge.

--- a/src/client/hooks/useCoworkStatus.svelte.ts
+++ b/src/client/hooks/useCoworkStatus.svelte.ts
@@ -12,7 +12,19 @@ export interface CoworkStatusState {
   readonly status: CoworkStatus | null;
   readonly loading: boolean;
   readonly error: string | null;
-  refetch: () => Promise<void>;
+  /**
+   * Re-read the OS status. Resolves `true` only when a fresh status was
+   * actually stored.
+   *
+   * The boolean matters because this swallows its own failure into `error`
+   * rather than rejecting — so a caller that only `await`s it cannot tell a
+   * refreshed `status` from a stale one, and `error` is not a usable substitute
+   * (a caller would have to compare it before and after). Anything that reads
+   * `status` to decide what to PAINT after a write must gate on this, or it
+   * will paint the pre-write value as though it were the outcome.
+   * `useFirstRunNeeded`'s `refetch` returns a boolean for the same reason.
+   */
+  refetch: () => Promise<boolean>;
 }
 
 /**
@@ -43,20 +55,23 @@ export function createCoworkStatus(getActive: () => boolean): CoworkStatusState 
     }
   });
 
-  const refetch = async (): Promise<void> => {
+  const refetch = async (): Promise<boolean> => {
     if (tauriMissing) {
       if (mounted) loading = false;
-      return;
+      return false;
     }
     const invoke = invokeRef;
-    if (!invoke) return;
+    if (!invoke) return false;
     try {
       const next = await coworkGetStatus(invoke);
-      if (!mounted) return;
+      // An unmounted component stored nothing, so this is `false` for the same
+      // reason a throw is: `status` does not reflect the read.
+      if (!mounted) return false;
       status = next;
       error = null;
+      return true;
     } catch (err) {
-      if (!mounted) return;
+      if (!mounted) return false;
       const msg = err instanceof Error ? err.message : String(err);
       if (msg === TAURI_NOT_AVAILABLE) {
         tauriMissing = true;
@@ -65,9 +80,10 @@ export function createCoworkStatus(getActive: () => boolean): CoworkStatusState 
           intervalId = null;
         }
         loading = false;
-        return;
+        return false;
       }
       error = msg;
+      return false;
     } finally {
       if (mounted) loading = false;
     }

--- a/src/client/utils/checkbox-sync.ts
+++ b/src/client/utils/checkbox-sync.ts
@@ -1,0 +1,32 @@
+/**
+ * Re-assert a one-way `checked=` checkbox against the model that owns it.
+ *
+ * **The trap.** Svelte compiles `checked={expr}` to a `set_checked` call that
+ * caches the last value it wrote and returns *before touching the DOM* when the
+ * new value compares equal. A user click mutates `input.checked` without
+ * updating that cache. So any transition that leaves `expr` re-computing to its
+ * pre-click value never writes, and the control keeps the state the click gave
+ * it — over a model that never moved. Nothing re-runs to heal it, because the
+ * whole condition is that the dependency did *not* change.
+ *
+ * It bites exactly where the click drives an **async, failable** write: the
+ * failure path is the one that leaves the model untouched. Measured instance:
+ * decline the UAC prompt on Cowork disable and the toggle reads off, the line
+ * directly beneath it reads "Integration enabled: yes", and the next click —
+ * seeing an unchecked box — opens the *Enable* confirm. The disable becomes
+ * unreachable without a remount.
+ *
+ * **Why this is a function and not an action.** The correct moment to re-assert
+ * is "after the async write and its refetch have resolved", which only the
+ * caller knows. A `use:` action driven by `$effect` re-runs on dependency
+ * change, and the defect is precisely that no dependency changed.
+ *
+ * **Why not `bind:checked`.** 21 of the 22 checkboxes in `src/client/` are
+ * one-way; two-way binding is the outlier here, and switching a control to it
+ * changes who owns the value. Re-asserting is the smaller, local fix.
+ *
+ * Call it at the end of every async handler that can leave the model unchanged.
+ */
+export function resyncCheckbox(box: HTMLInputElement, modelValue: boolean): void {
+  box.checked = modelValue;
+}

--- a/src/client/utils/checkbox-sync.ts
+++ b/src/client/utils/checkbox-sync.ts
@@ -16,16 +16,23 @@
  * seeing an unchecked box — opens the *Enable* confirm. The disable becomes
  * unreachable without a remount.
  *
- * **Why this is a function and not an action.** The correct moment to re-assert
- * is "after the async write and its refetch have resolved", which only the
- * caller knows. A `use:` action driven by `$effect` re-runs on dependency
- * change, and the defect is precisely that no dependency changed.
- *
  * **Why not `bind:checked`.** 21 of the 22 checkboxes in `src/client/` are
  * one-way; two-way binding is the outlier here, and switching a control to it
  * changes who owns the value. Re-asserting is the smaller, local fix.
  *
- * Call it at the end of every async handler that can leave the model unchanged.
+ * **`modelValue` MUST be the `checked=` expression itself, not the model field
+ * it happens to read today.** This writes `box.checked` without updating
+ * `set_checked`'s cache, so a value that disagrees with the expression does not
+ * merely look wrong for a frame — it latches. The DOM holds one value, the
+ * cache holds the other, and the next re-computation back to the cached value
+ * is skipped, leaving a control the user cannot move. Where the expression is
+ * more than a bare field, hoist it into one `$derived` and pass that (see
+ * `enableBoxChecked` in `CoworkSettings.svelte`).
+ *
+ * Call it at the end of every async handler that can leave the model unchanged
+ * — and only when the model is known to be CURRENT. Re-asserting from a value
+ * whose refresh silently failed paints a stale state as though it were the
+ * outcome, which is worse than not re-asserting at all.
  */
 export function resyncCheckbox(box: HTMLInputElement, modelValue: boolean): void {
   box.checked = modelValue;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -18,11 +18,18 @@ export const TANDEM_ISSUES_NEW_URL = `${TANDEM_REPO_URL}/issues/new`;
 /**
  * The two commands that install Tandem's Claude Code plugin, in order.
  *
- * Tandem shows these rather than running them, and that is a choice rather
- * than a limitation — `POST /api/integrations/install-claude-code` already
- * shells out to install the Claude CLI itself, so the capability plainly
- * exists. Registering a marketplace adds a trusted source to the user's own
- * Claude Code; that consent should be typed by the user, in the user's shell.
+ * THE canonical rationale for showing rather than running them; other surfaces
+ * point here rather than restating it.
+ *
+ * It is a choice, not a limitation — `POST /api/integrations/install-claude-code`
+ * already shells out to install the Claude CLI, `apply.ts` already writes
+ * `~/.claude.json` and the skill, and `cowork_installer.rs` already writes a
+ * plugin registry. The capability plainly exists. Two things make this the one
+ * we decline to automate: the personal-Claude-Code registry schema is
+ * reverse-engineered rather than supported, so a write we get wrong breaks a
+ * tool that is not ours; and enabling a plugin installs hooks that run in the
+ * user's own sessions. Registering a marketplace adds a trusted source, and
+ * that consent should be typed by the user, in the user's shell.
  *
  * Being display-only is what made them easy to leave in exactly one place:
  * `tandem setup` printed them and the desktop wizard did not, so on the primary

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -15,6 +15,25 @@ export const TRIAL_DAYS = 14;
 export const TANDEM_REPO_URL = "https://github.com/bloknayrb/tandem";
 export const TANDEM_ISSUES_NEW_URL = `${TANDEM_REPO_URL}/issues/new`;
 
+/**
+ * The two commands that install Tandem's Claude Code plugin, in order.
+ *
+ * Tandem cannot run these for the user from any surface: registering a
+ * marketplace is Claude Code's own trust boundary, so showing the commands is
+ * the whole of what either surface can do. That made them easy to leave in only
+ * one place — `tandem setup` printed them and the desktop wizard did not, so on
+ * the primary distribution channel a whole push route was undiscoverable
+ * (#1390). Shared so the CLI and the wizard cannot say different things.
+ *
+ * The identities here are the manifest's: plugin `tandem` from marketplace
+ * `tandem-editor`, sourced from `bloknayrb/tandem`. `tests/plugin-manifest.test.ts`
+ * pins this array against `.claude-plugin/*.json` rather than trusting the match.
+ */
+export const CLAUDE_PLUGIN_INSTALL_COMMANDS = [
+  "claude plugin marketplace add bloknayrb/tandem",
+  "claude plugin install tandem@tandem-editor",
+] as const;
+
 /** Tandem's website. The public face — distinct from the source repo. */
 export const TANDEM_SITE_URL = "https://tandem.ink";
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -18,12 +18,16 @@ export const TANDEM_ISSUES_NEW_URL = `${TANDEM_REPO_URL}/issues/new`;
 /**
  * The two commands that install Tandem's Claude Code plugin, in order.
  *
- * Tandem cannot run these for the user from any surface: registering a
- * marketplace is Claude Code's own trust boundary, so showing the commands is
- * the whole of what either surface can do. That made them easy to leave in only
- * one place — `tandem setup` printed them and the desktop wizard did not, so on
- * the primary distribution channel a whole push route was undiscoverable
- * (#1390). Shared so the CLI and the wizard cannot say different things.
+ * Tandem shows these rather than running them, and that is a choice rather
+ * than a limitation — `POST /api/integrations/install-claude-code` already
+ * shells out to install the Claude CLI itself, so the capability plainly
+ * exists. Registering a marketplace adds a trusted source to the user's own
+ * Claude Code; that consent should be typed by the user, in the user's shell.
+ *
+ * Being display-only is what made them easy to leave in exactly one place:
+ * `tandem setup` printed them and the desktop wizard did not, so on the primary
+ * distribution channel a whole push route was undiscoverable (#1390). Shared so
+ * the CLI and the wizard cannot say different things.
  *
  * The identities here are the manifest's: plugin `tandem` from marketplace
  * `tandem-editor`, sourced from `bloknayrb/tandem`. `tests/plugin-manifest.test.ts`

--- a/tests/cli/setup-push-status.test.ts
+++ b/tests/cli/setup-push-status.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `tandem setup`'s push-notification report, rendered (#1390).
+ *
+ * `tests/plugin-manifest.test.ts` pins the CONTENTS of
+ * `CLAUDE_PLUGIN_INSTALL_COMMANDS` against the manifests. Nothing pinned the
+ * RENDER — and the render is the whole of #1390, whose defect was precisely
+ * that a surface failed to show these commands. A dropped indent, a lost
+ * newline, or a `.join("")` that stopped producing one line per command prints
+ * silently-wrong setup instructions, and `tandem setup` is the only surface
+ * that ever printed them before the wizard did.
+ *
+ * Asserted on stderr, not stdout: Critical Rule 3 reserves stdout for the MCP
+ * wire, and `console.error` is what the whole CLI report already uses.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { printPushStatus } from "../../src/cli/setup";
+import { CLAUDE_PLUGIN_INSTALL_COMMANDS } from "../../src/shared/constants";
+
+function capture(shimRegisteredFor: string[]): string {
+  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+  printPushStatus(shimRegisteredFor);
+  return spy.mock.calls.map((args) => args.join(" ")).join("\n");
+}
+
+describe("printPushStatus — plugin install commands (#1390)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  for (const registeredFor of [[], ["claude-code"]]) {
+    const branch = registeredFor.length > 0 ? "shim registered" : "no shim";
+
+    it(`prints every install command on its own indented line — ${branch}`, () => {
+      const out = capture(registeredFor);
+      for (const cmd of CLAUDE_PLUGIN_INSTALL_COMMANDS) {
+        // The indent is part of the contract: these sit in a block the user
+        // reads as a copyable pair, not as prose.
+        expect(out).toContain(`    ${cmd}\n`);
+      }
+    });
+
+    it(`keeps the commands in manifest order — ${branch}`, () => {
+      // `marketplace add` before `plugin install`: the second fails outright if
+      // the first has not run, so a reorder is a broken instruction rather than
+      // a cosmetic one.
+      const out = capture(registeredFor);
+      const positions = CLAUDE_PLUGIN_INSTALL_COMMANDS.map((cmd) => out.indexOf(cmd));
+      expect(positions.every((p) => p >= 0)).toBe(true);
+      expect([...positions]).toEqual([...positions].sort((a, b) => a - b));
+    });
+  }
+
+  it("names the version floor beside the commands", () => {
+    // Below 2.1.212 the install succeeds and the monitor never runs, with
+    // nothing to say so. The wizard carries the same floor; this is the CLI's
+    // half of that claim.
+    expect(capture([])).toContain("2.1.212");
+  });
+});

--- a/tests/client/cowork-admin-declined-modal-keyboard.test.ts
+++ b/tests/client/cowork-admin-declined-modal-keyboard.test.ts
@@ -21,24 +21,18 @@ import { cleanup, render, screen } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CoworkAdminDeclinedModal from "../../src/client/components/CoworkAdminDeclinedModal.svelte";
 import { _resetAdminDismissForTests } from "../../src/client/cowork/coworkAdminDismiss.svelte";
+import { coworkStatusFixture } from "../helpers/cowork-status-fixture";
 
 // uacDeclined status so the modal renders. Everything else in the component
 // (cowork-invoke, dismiss module) stays real — no button is ever clicked, so
 // loadInvoke's Tauri-unavailable rejection is never hit.
 vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
   createCoworkStatus: () => ({
-    status: {
-      osSupported: true,
-      coworkDetected: true,
+    status: coworkStatusFixture({
       enabled: true,
-      vethernetCidr: "172.30.16.0/28",
-      lanIpFallback: null,
-      useLanIpOverride: false,
-      workspaces: [],
       uacDeclined: true,
       uacDeclinedAt: "2026-07-14T00:00:00Z",
-      workspacesLastScannedAt: null,
-    },
+    }),
     loading: false,
     error: null,
     refetch: vi.fn(async () => {}),

--- a/tests/client/cowork-onboarding-step-mounted.test.ts
+++ b/tests/client/cowork-onboarding-step-mounted.test.ts
@@ -15,18 +15,16 @@
  * this file gives the other surface the same guard.
  */
 
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
+import { coworkStatusFixture } from "../helpers/cowork-fixtures.svelte";
 
 const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
 const fakeInvoke = vi.fn();
 
-type Preflight =
-  | { status: "ok"; cidr: string }
-  | { status: "blocked"; hint: string }
-  | { status: "unknown" };
-const preflightSubnet = vi.fn(async (): Promise<Preflight> => ({ status: "unknown" }));
+const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unknown" }));
 
 vi.mock("../../src/client/cowork/cowork-invoke", () => ({
   TAURI_NOT_AVAILABLE: "Tauri runtime not available",
@@ -36,19 +34,10 @@ vi.mock("../../src/client/cowork/cowork-invoke", () => ({
 }));
 
 import CoworkOnboardingStep from "../../src/client/components/CoworkOnboardingStep.svelte";
-import type { CoworkStatus } from "../../src/client/types";
 
-const STATUS: CoworkStatus = {
-  osSupported: true,
-  coworkDetected: true,
-  enabled: false,
-  vethernetCidr: "172.30.16.0/28",
-  lanIpFallback: null,
-  useLanIpOverride: false,
-  workspaces: [],
-  uacDeclined: false,
-  uacDeclinedAt: null,
-};
+// A prop, not a hook: this component takes its status from the parent, so the
+// plain fixture is enough — nothing here observes it changing.
+const STATUS = coworkStatusFixture();
 
 function q(container: HTMLElement, testid: string): HTMLElement | null {
   return container.querySelector(`[data-testid='${testid}']`);
@@ -109,11 +98,14 @@ describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {
     await openConfirm(container);
 
     (q(container, "cowork-onboarding-enable-confirm-btn") as HTMLButtonElement).click();
-    for (let i = 0; i < 6; i++) await tick();
+    // `waitFor`, not a tick count: the advance is several promise hops past the
+    // click, and a hand-counted number is a constant nobody can re-derive.
+    await waitFor(() => {
+      expect(onAdvance).toHaveBeenCalledTimes(1);
+    });
 
     expect(toggleIntegration).toHaveBeenCalledTimes(1);
     expect(toggleIntegration).toHaveBeenCalledWith(fakeInvoke, true);
-    expect(onAdvance).toHaveBeenCalledTimes(1);
   });
 
   it("Cancel clears the blocked hint, so a re-open does not paint a stale one", async () => {
@@ -147,7 +139,9 @@ describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {
     await openConfirm(container);
 
     (q(container, "cowork-onboarding-enable-confirm-btn") as HTMLButtonElement).click();
-    for (let i = 0; i < 6; i++) await tick();
+    await waitFor(() => {
+      expect(q(container, "cowork-onboarding-error")).toBeTruthy();
+    });
 
     expect(onAdvance).not.toHaveBeenCalled();
     expect(q(container, "cowork-onboarding-error")?.textContent).toContain(

--- a/tests/client/cowork-onboarding-step-mounted.test.ts
+++ b/tests/client/cowork-onboarding-step-mounted.test.ts
@@ -15,9 +15,9 @@
  * this file gives the other surface the same guard.
  */
 
-import { render, waitFor } from "@testing-library/svelte";
+import { cleanup, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { COWORK_PREFLIGHT_CHECKING } from "../../src/client/cowork/cowork-helpers";
 import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
 import { coworkStatusFixture } from "../helpers/cowork-status-fixture";
@@ -85,6 +85,12 @@ beforeEach(() => {
   fakeInvoke.mockClear();
   preflightSubnet.mockClear();
   preflightSubnet.mockResolvedValue({ status: "unknown" });
+});
+
+afterEach(() => {
+  // Explicit: without `globals: true` Testing Library never registers its own
+  // `afterEach`, so mounts would otherwise accumulate across this file.
+  cleanup();
 });
 
 describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {

--- a/tests/client/cowork-onboarding-step-mounted.test.ts
+++ b/tests/client/cowork-onboarding-step-mounted.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+
+/**
+ * CoworkOnboardingStep, actually rendered (#1375).
+ *
+ * Like its Settings sibling, this component had no mounted coverage at all —
+ * `tests/client/cowork-onboarding.test.ts` exercises `cowork-helpers` and never
+ * renders anything. The property that most needed a test is the one a passing
+ * suite would not have noticed losing: the step probes on CONFIRM, not on mount,
+ * and moving the probe to `onMount` passes every other test in the repo.
+ *
+ * That ordering is a deliberate cost decision with a comment explaining it — the
+ * step mounts for every user with Cowork detected-but-off, including everyone
+ * who will hit Skip. The wizard suite pins the analogous property for itself;
+ * this file gives the other surface the same guard.
+ */
+
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
+const fakeInvoke = vi.fn();
+
+type Preflight =
+  | { status: "ok"; cidr: string }
+  | { status: "blocked"; hint: string }
+  | { status: "unknown" };
+const preflightSubnet = vi.fn(async (): Promise<Preflight> => ({ status: "unknown" }));
+
+vi.mock("../../src/client/cowork/cowork-invoke", () => ({
+  TAURI_NOT_AVAILABLE: "Tauri runtime not available",
+  loadInvoke: vi.fn(async () => fakeInvoke),
+  coworkToggleIntegration: (...args: unknown[]) => toggleIntegration(...args),
+  coworkPreflightSubnet: () => preflightSubnet(),
+}));
+
+import CoworkOnboardingStep from "../../src/client/components/CoworkOnboardingStep.svelte";
+import type { CoworkStatus } from "../../src/client/types";
+
+const STATUS: CoworkStatus = {
+  osSupported: true,
+  coworkDetected: true,
+  enabled: false,
+  vethernetCidr: "172.30.16.0/28",
+  lanIpFallback: null,
+  useLanIpOverride: false,
+  workspaces: [],
+  uacDeclined: false,
+  uacDeclinedAt: null,
+};
+
+function q(container: HTMLElement, testid: string): HTMLElement | null {
+  return container.querySelector(`[data-testid='${testid}']`);
+}
+
+function mount() {
+  const onAdvance = vi.fn();
+  const { container } = render(CoworkOnboardingStep, {
+    props: { status: STATUS, onAdvance },
+  });
+  return { container, onAdvance };
+}
+
+/** Click Enable, opening the confirm and starting the probe. */
+async function openConfirm(container: HTMLElement): Promise<void> {
+  (q(container, "cowork-onboarding-enable-btn") as HTMLButtonElement).click();
+  await tick();
+}
+
+describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {
+  beforeEach(() => {
+    toggleIntegration.mockClear();
+    fakeInvoke.mockClear();
+    preflightSubnet.mockClear();
+    preflightSubnet.mockResolvedValue({ status: "unknown" });
+  });
+
+  it("does not probe on mount — the step renders for everyone who will Skip", async () => {
+    const { container } = mount();
+    await tick();
+
+    expect(q(container, "cowork-onboarding-step")).toBeTruthy();
+    expect(preflightSubnet).not.toHaveBeenCalled();
+    expect(toggleIntegration).not.toHaveBeenCalled();
+  });
+
+  it("Skip advances without probing or enabling", async () => {
+    const { container, onAdvance } = mount();
+    (q(container, "cowork-onboarding-skip-btn") as HTMLButtonElement).click();
+    await tick();
+
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+    expect(preflightSubnet).not.toHaveBeenCalled();
+    expect(toggleIntegration).not.toHaveBeenCalled();
+  });
+
+  it("Enable opens the confirm and probes, without enabling", async () => {
+    const { container } = mount();
+    await openConfirm(container);
+
+    expect(q(container, "cowork-onboarding-confirm")).toBeTruthy();
+    expect(preflightSubnet).toHaveBeenCalledTimes(1);
+    expect(toggleIntegration).not.toHaveBeenCalled();
+  });
+
+  it("the confirm's Enable is the sole trigger, and it advances", async () => {
+    const { container, onAdvance } = mount();
+    await openConfirm(container);
+
+    (q(container, "cowork-onboarding-enable-confirm-btn") as HTMLButtonElement).click();
+    for (let i = 0; i < 6; i++) await tick();
+
+    expect(toggleIntegration).toHaveBeenCalledTimes(1);
+    expect(toggleIntegration).toHaveBeenCalledWith(fakeInvoke, true);
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+  });
+
+  it("Cancel clears the blocked hint, so a re-open does not paint a stale one", async () => {
+    // Asserted through the DOM because `reset()` has no observable handle:
+    // blocked hint, Cancel, re-open against a probe that never settles, and the
+    // hint must already be gone. The second probe proves the re-open is real.
+    preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
+    const { container } = mount();
+    await openConfirm(container);
+    await tick();
+
+    expect(q(container, "cowork-onboarding-preflight-blocked")?.textContent).toContain(
+      "no adapter",
+    );
+
+    (q(container, "cowork-onboarding-enable-cancel-btn") as HTMLButtonElement).click();
+    await tick();
+    expect(q(container, "cowork-onboarding-confirm")).toBeNull();
+
+    preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
+    await openConfirm(container);
+
+    expect(q(container, "cowork-onboarding-confirm")).toBeTruthy();
+    expect(q(container, "cowork-onboarding-preflight-blocked")).toBeNull();
+    expect(preflightSubnet).toHaveBeenCalledTimes(2);
+  });
+
+  it("a failed enable keeps the confirm open and says why", async () => {
+    toggleIntegration.mockRejectedValueOnce(new Error("firewall write refused"));
+    const { container, onAdvance } = mount();
+    await openConfirm(container);
+
+    (q(container, "cowork-onboarding-enable-confirm-btn") as HTMLButtonElement).click();
+    for (let i = 0; i < 6; i++) await tick();
+
+    expect(onAdvance).not.toHaveBeenCalled();
+    expect(q(container, "cowork-onboarding-error")?.textContent).toContain(
+      "firewall write refused",
+    );
+    expect(q(container, "cowork-onboarding-confirm")).toBeTruthy();
+  });
+});
+
+describe("CoworkOnboardingStep — pre-flight live region (#1376)", () => {
+  beforeEach(() => {
+    preflightSubnet.mockClear();
+    preflightSubnet.mockResolvedValue({ status: "unknown" });
+    toggleIntegration.mockClear();
+  });
+
+  it("mounts the region empty, before the text that has to be announced", async () => {
+    preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
+    const { container } = mount();
+    await openConfirm(container);
+
+    const region = q(container, "cowork-onboarding-preflight-live");
+    expect(region).toBeTruthy();
+    expect(region?.getAttribute("role")).toBe("status");
+    expect(q(container, "cowork-onboarding-preflight-blocked")).toBeNull();
+  });
+
+  it("keeps the same region node across probing → blocked", async () => {
+    preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
+    const { container } = mount();
+    await openConfirm(container);
+    const before = q(container, "cowork-onboarding-preflight-live");
+    await tick();
+    await tick();
+
+    const after = q(container, "cowork-onboarding-preflight-live");
+    expect(after).toBe(before);
+    expect(after?.textContent).toContain("no adapter");
+  });
+});

--- a/tests/client/cowork-onboarding-step-mounted.test.ts
+++ b/tests/client/cowork-onboarding-step-mounted.test.ts
@@ -20,15 +20,19 @@ import { tick } from "svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { COWORK_PREFLIGHT_CHECKING } from "../../src/client/cowork/cowork-helpers";
 import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
-import { coworkStatusFixture } from "../helpers/cowork-fixtures.svelte";
+import { coworkStatusFixture } from "../helpers/cowork-status-fixture";
 
 const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
 const fakeInvoke = vi.fn();
 
 const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unknown" }));
 
-vi.mock("../../src/client/cowork/cowork-invoke", () => ({
-  TAURI_NOT_AVAILABLE: "Tauri runtime not available",
+// Spread `importOriginal` rather than re-declaring the module: `cowork-invoke`
+// exports nine symbols and each suite's mock used to name a different subset,
+// so a component reaching for an un-named one failed as `undefined is not a
+// function` — a component-shaped error, discovered one file at a time.
+vi.mock("../../src/client/cowork/cowork-invoke", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/cowork/cowork-invoke")>()),
   loadInvoke: vi.fn(async () => fakeInvoke),
   coworkToggleIntegration: (...args: unknown[]) => toggleIntegration(...args),
   coworkPreflightSubnet: () => preflightSubnet(),
@@ -66,9 +70,11 @@ async function openConfirm(container: HTMLElement): Promise<void> {
  * the tick that opened the confirm.
  */
 async function probeCount(n: number): Promise<void> {
-  await waitFor(() => {
-    expect(preflightSubnet).toHaveBeenCalledTimes(n);
-  });
+  // `interval: 5` because the predicate is a mock call count: it emits no DOM
+  // mutation, so `waitFor`'s MutationObserver can never wake it and it falls
+  // through to the poll timer. At the 50ms default that is one full interval
+  // per call, measured at ~479ms across these suites.
+  await waitFor(() => expect(preflightSubnet).toHaveBeenCalledTimes(n), { interval: 5 });
 }
 
 // File scope so both describes get it — a per-describe reset is isolation by

--- a/tests/client/cowork-onboarding-step-mounted.test.ts
+++ b/tests/client/cowork-onboarding-step-mounted.test.ts
@@ -18,6 +18,7 @@
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { COWORK_PREFLIGHT_CHECKING } from "../../src/client/cowork/cowork-helpers";
 import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
 import { coworkStatusFixture } from "../helpers/cowork-fixtures.svelte";
 
@@ -57,14 +58,30 @@ async function openConfirm(container: HTMLElement): Promise<void> {
   await tick();
 }
 
-describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {
-  beforeEach(() => {
-    toggleIntegration.mockClear();
-    fakeInvoke.mockClear();
-    preflightSubnet.mockClear();
-    preflightSubnet.mockResolvedValue({ status: "unknown" });
+/**
+ * Wait for the Nth probe to have been issued.
+ *
+ * `run()` defers `probing` one flush (#1376 rule 1 — the region must reach the
+ * a11y tree before its first line), so the probe is not in flight by the end of
+ * the tick that opened the confirm.
+ */
+async function probeCount(n: number): Promise<void> {
+  await waitFor(() => {
+    expect(preflightSubnet).toHaveBeenCalledTimes(n);
   });
+}
 
+// File scope so both describes get it — a per-describe reset is isolation by
+// test ordering, which the next added test silently breaks.
+beforeEach(() => {
+  toggleIntegration.mockClear();
+  toggleIntegration.mockImplementation(async () => ({ ok: true as const }));
+  fakeInvoke.mockClear();
+  preflightSubnet.mockClear();
+  preflightSubnet.mockResolvedValue({ status: "unknown" });
+});
+
+describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {
   it("does not probe on mount — the step renders for everyone who will Skip", async () => {
     const { container } = mount();
     await tick();
@@ -89,7 +106,7 @@ describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {
     await openConfirm(container);
 
     expect(q(container, "cowork-onboarding-confirm")).toBeTruthy();
-    expect(preflightSubnet).toHaveBeenCalledTimes(1);
+    await probeCount(1);
     expect(toggleIntegration).not.toHaveBeenCalled();
   });
 
@@ -106,6 +123,41 @@ describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {
 
     expect(toggleIntegration).toHaveBeenCalledTimes(1);
     expect(toggleIntegration).toHaveBeenCalledWith(fakeInvoke, true);
+    // The success path must close the confirm too — deleting `closeConfirm()`
+    // and leaving `onAdvance()` used to pass every test in this file. The step
+    // can be returned to, so a confirm left open comes back with it.
+    expect(q(container, "cowork-onboarding-confirm")).toBeNull();
+  });
+
+  it("a successful enable supersedes the probe still in flight", async () => {
+    // The success path's own `reset()`. It cannot be proved the way Cancel's is
+    // — a blocked hint REPLACES the confirm's Enable button with a retry, so
+    // there is no state where a hint is on screen and Enable is clickable.
+    // What is reachable is the race: enable while the probe is still running,
+    // then let it answer `blocked` afterwards. Without `reset()`'s ticket bump
+    // that late result paints a firewall hint over a step the user has left.
+    let release: ((v: SubnetPreflight) => void) | undefined;
+    preflightSubnet.mockImplementationOnce(
+      () =>
+        new Promise<SubnetPreflight>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const { container, onAdvance } = mount();
+    await openConfirm(container);
+    await probeCount(1);
+
+    (q(container, "cowork-onboarding-enable-confirm-btn") as HTMLButtonElement).click();
+    await waitFor(() => {
+      expect(onAdvance).toHaveBeenCalledTimes(1);
+    });
+
+    release?.({ status: "blocked", hint: "no adapter" });
+    await tick();
+    await tick();
+
+    expect(q(container, "cowork-onboarding-preflight-blocked")).toBeNull();
+    expect(q(container, "cowork-onboarding-confirm")).toBeNull();
   });
 
   it("Cancel clears the blocked hint, so a re-open does not paint a stale one", async () => {
@@ -115,11 +167,11 @@ describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {
     preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
     const { container } = mount();
     await openConfirm(container);
-    await tick();
-
-    expect(q(container, "cowork-onboarding-preflight-blocked")?.textContent).toContain(
-      "no adapter",
-    );
+    await waitFor(() => {
+      expect(q(container, "cowork-onboarding-preflight-blocked")?.textContent ?? "").toContain(
+        "no adapter",
+      );
+    });
 
     (q(container, "cowork-onboarding-enable-cancel-btn") as HTMLButtonElement).click();
     await tick();
@@ -127,10 +179,10 @@ describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {
 
     preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
     await openConfirm(container);
+    await probeCount(2);
 
     expect(q(container, "cowork-onboarding-confirm")).toBeTruthy();
     expect(q(container, "cowork-onboarding-preflight-blocked")).toBeNull();
-    expect(preflightSubnet).toHaveBeenCalledTimes(2);
   });
 
   it("a failed enable keeps the confirm open and says why", async () => {
@@ -152,12 +204,6 @@ describe("CoworkOnboardingStep — confirm wiring (#1375)", () => {
 });
 
 describe("CoworkOnboardingStep — pre-flight live region (#1376)", () => {
-  beforeEach(() => {
-    preflightSubnet.mockClear();
-    preflightSubnet.mockResolvedValue({ status: "unknown" });
-    toggleIntegration.mockClear();
-  });
-
   it("mounts the region empty, before the text that has to be announced", async () => {
     preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
     const { container } = mount();
@@ -166,7 +212,26 @@ describe("CoworkOnboardingStep — pre-flight live region (#1376)", () => {
     const region = q(container, "cowork-onboarding-preflight-live");
     expect(region).toBeTruthy();
     expect(region?.getAttribute("role")).toBe("status");
+    // Empty is the half that matters and the half nothing asserted: the
+    // in-flight line is the FIRST text to arrive here, so a region that mounts
+    // already holding it is announced by nothing.
+    expect(region?.textContent?.trim()).toBe("");
     expect(q(container, "cowork-onboarding-preflight-blocked")).toBeNull();
+  });
+
+  it("announces the in-flight line into the region it already mounted", async () => {
+    // The `{#if probe.probing}` child on this surface was covered by nothing —
+    // deleting it outright left the file green. It is also the one line that
+    // proves the region fills rather than being replaced.
+    preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
+    const { container } = mount();
+    await openConfirm(container);
+    const region = q(container, "cowork-onboarding-preflight-live");
+
+    await waitFor(() => {
+      expect(region?.textContent ?? "").toContain(COWORK_PREFLIGHT_CHECKING);
+    });
+    expect(q(container, "cowork-onboarding-preflight-live")).toBe(region);
   });
 
   it("keeps the same region node across probing → blocked", async () => {
@@ -174,11 +239,38 @@ describe("CoworkOnboardingStep — pre-flight live region (#1376)", () => {
     const { container } = mount();
     await openConfirm(container);
     const before = q(container, "cowork-onboarding-preflight-live");
-    await tick();
-    await tick();
+    expect(before).toBeTruthy();
 
-    const after = q(container, "cowork-onboarding-preflight-live");
-    expect(after).toBe(before);
-    expect(after?.textContent).toContain("no adapter");
+    await waitFor(() => {
+      expect(q(container, "cowork-onboarding-preflight-live")?.textContent ?? "").toContain(
+        "no adapter",
+      );
+    });
+    expect(q(container, "cowork-onboarding-preflight-live")).toBe(before);
+  });
+
+  it("keeps the hint mounted while re-checking it", async () => {
+    // Additive, not `{:else if}` — pinned on Settings but not here, so swapping
+    // this surface's second `{#if}` was a silent change. The hint the retry is
+    // re-checking must not vanish under the pointer that clicked retry.
+    preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
+    const { container } = mount();
+    await openConfirm(container);
+    await waitFor(() => {
+      expect(q(container, "cowork-onboarding-preflight-retry-btn")).toBeTruthy();
+    });
+
+    preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
+    (q(container, "cowork-onboarding-preflight-retry-btn") as HTMLButtonElement).click();
+    await probeCount(2);
+
+    await waitFor(() => {
+      expect(q(container, "cowork-onboarding-preflight-live")?.textContent ?? "").toContain(
+        COWORK_PREFLIGHT_CHECKING,
+      );
+    });
+    expect(q(container, "cowork-onboarding-preflight-live")?.textContent ?? "").toContain(
+      "no adapter",
+    );
   });
 });

--- a/tests/client/cowork-preflight-hook.test.ts
+++ b/tests/client/cowork-preflight-hook.test.ts
@@ -6,7 +6,7 @@
  * the entire suite still passed. The mechanism the hook's longest comment
  * defends was pinned by nothing.
  *
- * Must live in `tests/client/`: `vite.config.ts` registers the svelte plugin on
+ * Must live in `tests/client/`: `vitest.config.ts` registers the svelte plugin on
  * that project only, so a `.svelte.ts` import from anywhere else is never
  * compiled and fails with `$state is not defined`.
  */
@@ -38,8 +38,20 @@ const OK = { status: "ok", cidr: "172.20.0.0/20" } as const;
 const BLOCKED = { status: "blocked", hint: "stale hint" } as const;
 
 /**
+ * `run()` has issued its probe and flipped `probing`.
+ *
+ * The leading `tick()` is #1376's deferral: `run()` no longer sets `probing`
+ * synchronously, because the live region has to reach the accessibility tree
+ * before the in-flight line lands in it.
+ */
+async function probeStarted(): Promise<void> {
+  await tick();
+  await Promise.resolve();
+}
+
+/**
  * Drain enough microtasks for every in-flight `run()` to get past its
- * `await tick()` and its `await loadInvoke()`, and actually attach to its probe
+ * `await tick()` and its `await loadInvoke()` and actually ATTACH to its probe
  * promise.
  *
  * Without this the tests below are vacuous: resolving a deferred before its
@@ -47,20 +59,14 @@ const BLOCKED = { status: "blocked", hint: "stale hint" } as const;
  * RESOLVE order, so the newest probe wins by accident and the assertions pass
  * with the staleness guard deleted. Verified by mutation — that is exactly how
  * the first draft of this file behaved.
- *
- * The leading `tick()` is #1376's deferral: `run()` no longer sets `probing`
- * synchronously, because the live region has to reach the accessibility tree
- * before the in-flight line lands in it.
  */
 async function settleAttachments(): Promise<void> {
-  await tick();
-  for (let i = 0; i < 4; i++) await Promise.resolve();
-}
-
-/** `run()` has issued its probe and flipped `probing` — one flush after the call. */
-async function probeStarted(): Promise<void> {
-  await tick();
-  await Promise.resolve();
+  await probeStarted();
+  // Over-drained deliberately. The deferreds are unresolved here, so extra
+  // drains cost nothing — while too FEW fails toward GREEN, which is the mode
+  // described above. Composed from `probeStarted` so the deferral is encoded
+  // once rather than in two helpers that must agree.
+  for (let i = 0; i < 12; i++) await Promise.resolve();
 }
 
 describe("createSubnetPreflight", () => {

--- a/tests/client/cowork-preflight-hook.test.ts
+++ b/tests/client/cowork-preflight-hook.test.ts
@@ -10,6 +10,7 @@
  * that project only, so a `.svelte.ts` import from anywhere else is never
  * compiled and fails with `$state is not defined`.
  */
+import { tick } from "svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const preflightSubnet = vi.fn();
@@ -38,16 +39,28 @@ const BLOCKED = { status: "blocked", hint: "stale hint" } as const;
 
 /**
  * Drain enough microtasks for every in-flight `run()` to get past its
- * `await loadInvoke()` and actually attach to its probe promise.
+ * `await tick()` and its `await loadInvoke()`, and actually attach to its probe
+ * promise.
  *
  * Without this the tests below are vacuous: resolving a deferred before its
  * `await` is attached makes the continuations queue in ATTACH order rather than
  * RESOLVE order, so the newest probe wins by accident and the assertions pass
  * with the staleness guard deleted. Verified by mutation — that is exactly how
  * the first draft of this file behaved.
+ *
+ * The leading `tick()` is #1376's deferral: `run()` no longer sets `probing`
+ * synchronously, because the live region has to reach the accessibility tree
+ * before the in-flight line lands in it.
  */
 async function settleAttachments(): Promise<void> {
+  await tick();
   for (let i = 0; i < 4; i++) await Promise.resolve();
+}
+
+/** `run()` has issued its probe and flipped `probing` — one flush after the call. */
+async function probeStarted(): Promise<void> {
+  await tick();
+  await Promise.resolve();
 }
 
 describe("createSubnetPreflight", () => {
@@ -62,6 +75,11 @@ describe("createSubnetPreflight", () => {
 
     const probe = createSubnetPreflight();
     const a = probe.run();
+    // `a` must reach its probe before `b` starts. Since #1376 `run()` waits a
+    // flush before doing anything, so two `run()`s in one tick leave the first
+    // superseded BEFORE it issues — it returns without calling the bridge at
+    // all, and this test would then be pinning the wrong thing entirely.
+    await probeStarted();
     const b = probe.run();
     await settleAttachments();
 
@@ -70,6 +88,23 @@ describe("createSubnetPreflight", () => {
     first.resolve(BLOCKED);
     await Promise.all([a, b]);
 
+    expect(preflightSubnet).toHaveBeenCalledTimes(2);
+    expect(probe.preflight).toEqual(OK);
+    expect(probe.probing).toBe(false);
+  });
+
+  it("never issues a probe that was superseded before it started", async () => {
+    // The other half of the same deferral: two `run()`s in one tick cost ONE
+    // PowerShell round-trip, not two. A user double-clicking the retry button
+    // is the common case.
+    preflightSubnet.mockResolvedValue(OK);
+
+    const probe = createSubnetPreflight();
+    const a = probe.run();
+    const b = probe.run();
+    await Promise.all([a, b]);
+
+    expect(preflightSubnet).toHaveBeenCalledTimes(1);
     expect(probe.preflight).toEqual(OK);
     expect(probe.probing).toBe(false);
   });
@@ -81,6 +116,7 @@ describe("createSubnetPreflight", () => {
 
     const probe = createSubnetPreflight();
     const a = probe.run();
+    await probeStarted(); // both must genuinely issue — see the test above
     const b = probe.run();
     await settleAttachments();
 
@@ -100,6 +136,7 @@ describe("createSubnetPreflight", () => {
 
     const probe = createSubnetPreflight();
     const run = probe.run();
+    await probeStarted();
     expect(probe.probing).toBe(true);
 
     probe.reset();
@@ -128,6 +165,10 @@ describe("createSubnetPreflight", () => {
     // button on `blocked`, so clearing it here unmounts the button the user is
     // clicking and mounts Enable in its place.
     const retry = probe.run();
+    // `preflight` must survive the gap BEFORE `probing` flips too — that gap is
+    // new, and it is exactly when the user's pointer is on the retry button.
+    expect(probe.preflight).toEqual(BLOCKED);
+    await probeStarted();
     expect(probe.probing).toBe(true);
     expect(probe.preflight).toEqual(BLOCKED);
 

--- a/tests/client/cowork-settings-mounted.test.ts
+++ b/tests/client/cowork-settings-mounted.test.ts
@@ -1,0 +1,242 @@
+// @vitest-environment happy-dom
+
+/**
+ * CoworkSettings, actually rendered (#1375).
+ *
+ * `tests/client/cowork-settings.test.ts` is a pure-function suite over
+ * `cowork-helpers`; the file name hid the fact that the component itself had
+ * never been mounted by anything. So four of the testids #1366 added existed
+ * only in the snapshot, and the wiring around them — the checkbox handler, the
+ * confirm reset, the enable path's own close — was covered by nothing.
+ *
+ * What this pins is the wiring, not the helpers. Each `it` below names a path
+ * that a passing suite reached zero times before this file existed.
+ *
+ * `useCoworkStatus` MUST be mocked: `CoworkSettings` calls
+ * `createCoworkStatus(() => true)` unconditionally at mount, and that hook holds
+ * an `$effect` and a real invoke — an unmocked mount hits the network.
+ */
+
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
+const fakeInvoke = vi.fn();
+
+type Preflight =
+  | { status: "ok"; cidr: string }
+  | { status: "blocked"; hint: string }
+  | { status: "unknown" };
+const preflightSubnet = vi.fn(async (): Promise<Preflight> => ({ status: "unknown" }));
+
+vi.mock("../../src/client/cowork/cowork-invoke", () => ({
+  TAURI_NOT_AVAILABLE: "Tauri runtime not available",
+  loadInvoke: vi.fn(async () => fakeInvoke),
+  coworkToggleIntegration: (...args: unknown[]) => toggleIntegration(...args),
+  coworkPreflightSubnet: () => preflightSubnet(),
+  coworkRescan: vi.fn(async () => {}),
+  coworkSetLanIpOverride: vi.fn(async () => {}),
+}));
+
+const refetch = vi.fn(async () => {});
+
+vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
+  createCoworkStatus: () => ({
+    status: {
+      osSupported: true,
+      coworkDetected: true,
+      enabled: false,
+      vethernetCidr: "172.30.16.0/28",
+      lanIpFallback: null,
+      useLanIpOverride: false,
+      workspaces: [],
+      uacDeclined: false,
+      uacDeclinedAt: null,
+    },
+    loading: false,
+    error: null,
+    refetch,
+  }),
+}));
+
+import CoworkSettings from "../../src/client/components/CoworkSettings.svelte";
+
+function q(container: HTMLElement, testid: string): HTMLElement | null {
+  return container.querySelector(`[data-testid='${testid}']`);
+}
+
+/** Tick the checkbox and dispatch the `change` the handler listens for. */
+async function setChecked(box: HTMLInputElement, checked: boolean): Promise<void> {
+  box.checked = checked;
+  box.dispatchEvent(new Event("change", { bubbles: true }));
+  await tick();
+}
+
+function mount() {
+  const { container } = render(CoworkSettings);
+  const checkbox = q(container, "cowork-toggle-checkbox") as HTMLInputElement;
+  return { container, checkbox };
+}
+
+describe("CoworkSettings — enable confirm wiring (#1375)", () => {
+  beforeEach(() => {
+    toggleIntegration.mockClear();
+    fakeInvoke.mockClear();
+    refetch.mockClear();
+    preflightSubnet.mockClear();
+    preflightSubnet.mockResolvedValue({ status: "unknown" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the toggle without enabling or probing anything", async () => {
+    const { container, checkbox } = mount();
+    await tick();
+
+    expect(q(container, "cowork-settings")).toBeTruthy();
+    expect(checkbox).toBeTruthy();
+    expect(checkbox.checked).toBe(false);
+    expect(q(container, "cowork-enable-confirm")).toBeNull();
+    expect(toggleIntegration).not.toHaveBeenCalled();
+    // The probe costs a real PowerShell round-trip; it belongs to the confirm,
+    // not to the mount of a settings tab the user may only be scrolling past.
+    expect(preflightSubnet).not.toHaveBeenCalled();
+  });
+
+  it("checking the box opens the confirm and probes, without enabling", async () => {
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+
+    expect(q(container, "cowork-enable-confirm")).toBeTruthy();
+    expect(preflightSubnet).toHaveBeenCalledTimes(1);
+    expect(toggleIntegration).not.toHaveBeenCalled();
+  });
+
+  it("un-checking while the confirm is open cancels instead of disabling", async () => {
+    // The defect: the handler's `else` branch fired a real
+    // `coworkToggleIntegration(invoke, false)` for a transition that had never
+    // happened, and left the confirm — Enable button and all — standing behind
+    // it. Nothing was enabled, so nothing was there to disable.
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    await setChecked(checkbox, false);
+
+    expect(toggleIntegration).not.toHaveBeenCalled();
+    expect(q(container, "cowork-enable-confirm")).toBeNull();
+  });
+
+  it("re-checking after a cancel starts a second probe", async () => {
+    // The raced path #1375 singles out: two overlapping probes on the surface
+    // where a user can toggle faster than PowerShell answers. `reset()` bumps
+    // the ticket, so only the newest may write — which is invisible unless a
+    // test actually issues the second one.
+    const { checkbox } = mount();
+    await setChecked(checkbox, true);
+    await setChecked(checkbox, false);
+    await setChecked(checkbox, true);
+
+    expect(preflightSubnet).toHaveBeenCalledTimes(2);
+    expect(toggleIntegration).not.toHaveBeenCalled();
+  });
+
+  it("Enable fires the toggle and closes the confirm", async () => {
+    // `closeEnableConfirm()` on SUCCESS is the reset #1366 made load-bearing:
+    // `run()` no longer clears `preflight`, so a path that leaves the confirm
+    // without resetting leaves a stale hint waiting for the next open.
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+
+    (q(container, "cowork-enable-confirm-btn") as HTMLButtonElement).click();
+    // `withInvoke` awaits `loadInvoke` → the toggle → `refetch` before it
+    // closes, so the close is four promise hops downstream of the click.
+    for (let i = 0; i < 6; i++) await tick();
+
+    expect(toggleIntegration).toHaveBeenCalledTimes(1);
+    expect(toggleIntegration).toHaveBeenCalledWith(fakeInvoke, true);
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(q(container, "cowork-enable-confirm")).toBeNull();
+  });
+
+  it("Cancel clears the blocked hint, so a re-open does not paint a stale one", async () => {
+    // `reset()` has no observable handle — `probe` is component-local. So this
+    // asserts through the DOM instead: blocked hint, Cancel, re-open with a
+    // probe that never settles, and the hint must already be gone. Written as
+    // "assert reset() was called" it would need a spy that cannot exist.
+    preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    await tick();
+
+    expect(q(container, "cowork-preflight-blocked")?.textContent).toContain("no adapter");
+
+    (q(container, "cowork-enable-cancel-btn") as HTMLButtonElement).click();
+    await tick();
+
+    preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
+    await setChecked(checkbox, true);
+
+    expect(q(container, "cowork-enable-confirm")).toBeTruthy();
+    expect(q(container, "cowork-preflight-blocked")).toBeNull();
+    expect(preflightSubnet).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("CoworkSettings — pre-flight live region (#1376)", () => {
+  beforeEach(() => {
+    preflightSubnet.mockClear();
+    preflightSubnet.mockResolvedValue({ status: "unknown" });
+    toggleIntegration.mockClear();
+  });
+
+  it("mounts the region empty, before the text that has to be announced", async () => {
+    // The whole of #1376: a live region inserted together with its content is
+    // generally not announced. Region first and empty, content second.
+    preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+
+    const region = q(container, "cowork-preflight-live");
+    expect(region).toBeTruthy();
+    expect(region?.getAttribute("role")).toBe("status");
+    expect(q(container, "cowork-preflight-blocked")).toBeNull();
+  });
+
+  it("keeps the same region node across probing → blocked", async () => {
+    // Same NODE, not merely a region in both states: a wrapper that unmounts
+    // and remounts is the original bug wearing a testid.
+    preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    const before = q(container, "cowork-preflight-live");
+    await tick();
+    await tick();
+
+    const after = q(container, "cowork-preflight-live");
+    expect(after).toBe(before);
+    expect(after?.textContent).toContain("no adapter");
+  });
+
+  it("announces the re-probe without dropping the hint it is re-checking", async () => {
+    // `run()` deliberately keeps the previous result, so a retry has `probing`
+    // and `blocked` set at once. Appending rather than swapping is what lets
+    // the region change (so it is announced) while `-blocked` stays mounted for
+    // the three suites that read it mid-probe.
+    preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    await tick();
+    await tick();
+
+    preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
+    (q(container, "cowork-preflight-retry-btn") as HTMLButtonElement).click();
+    await tick();
+    await tick();
+
+    const region = q(container, "cowork-preflight-live");
+    expect(region?.textContent).toContain("no adapter");
+    expect(region?.textContent).toMatch(/Checking/);
+  });
+});

--- a/tests/client/cowork-settings-mounted.test.ts
+++ b/tests/client/cowork-settings-mounted.test.ts
@@ -20,6 +20,7 @@
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { COWORK_PREFLIGHT_CHECKING } from "../../src/client/cowork/cowork-helpers";
 import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
 import { coworkStatusCell } from "../helpers/cowork-fixtures.svelte";
 
@@ -28,13 +29,15 @@ const fakeInvoke = vi.fn();
 
 const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unknown" }));
 
-vi.mock("../../src/client/cowork/cowork-invoke", () => ({
-  TAURI_NOT_AVAILABLE: "Tauri runtime not available",
+// Spread `importOriginal` rather than re-declaring the module: `cowork-invoke`
+// exports nine symbols and each suite's mock used to name a different subset,
+// so a component reaching for an un-named one failed as `undefined is not a
+// function` — a component-shaped error, discovered one file at a time.
+vi.mock("../../src/client/cowork/cowork-invoke", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/cowork/cowork-invoke")>()),
   loadInvoke: vi.fn(async () => fakeInvoke),
   coworkToggleIntegration: (...args: unknown[]) => toggleIntegration(...args),
   coworkPreflightSubnet: () => preflightSubnet(),
-  coworkRescan: vi.fn(async () => {}),
-  coworkSetLanIpOverride: vi.fn(async () => {}),
 }));
 
 // A REACTIVE status cell, not a frozen literal: `enabled` is what the surface
@@ -83,9 +86,11 @@ async function setChecked(box: HTMLInputElement, checked: boolean): Promise<void
  * offset as a constant; this stays true if the chain gains or loses a hop.
  */
 async function probeCount(n: number): Promise<void> {
-  await waitFor(() => {
-    expect(preflightSubnet).toHaveBeenCalledTimes(n);
-  });
+  // `interval: 5` because the predicate is a mock call count: it emits no DOM
+  // mutation, so `waitFor`'s MutationObserver can never wake it and it falls
+  // through to the poll timer. At the 50ms default that is one full interval
+  // per call, measured at ~479ms across these suites.
+  await waitFor(() => expect(preflightSubnet).toHaveBeenCalledTimes(n), { interval: 5 });
 }
 
 function mount() {
@@ -184,9 +189,9 @@ describe("CoworkSettings — enable confirm wiring (#1375)", () => {
     expect(checkbox.checked).toBe(true);
 
     await setChecked(checkbox, false);
-    await waitFor(() => {
-      expect(checkbox.checked).toBe(true);
-    });
+    // `interval: 5`: a `checked` property assignment emits no mutation record,
+    // so the observer never fires and this polls to the full default otherwise.
+    await waitFor(() => expect(checkbox.checked).toBe(true), { interval: 5 });
 
     // Still on, still says so, and no confirm was opened by the failure.
     expect(q(container, "cowork-settings")?.textContent).toContain("Integration enabled: yes");
@@ -314,7 +319,7 @@ describe("CoworkSettings — pre-flight live region (#1376)", () => {
     // …and the same node then fills, rather than being replaced by one that
     // arrives already populated.
     await waitFor(() => {
-      expect(region?.textContent ?? "").toMatch(/Checking/);
+      expect(region?.textContent ?? "").toContain(COWORK_PREFLIGHT_CHECKING);
     });
     expect(q(container, "cowork-preflight-live")).toBe(region);
   });
@@ -353,7 +358,9 @@ describe("CoworkSettings — pre-flight live region (#1376)", () => {
     await probeCount(2);
 
     await waitFor(() => {
-      expect(q(container, "cowork-preflight-live")?.textContent ?? "").toMatch(/Checking/);
+      expect(q(container, "cowork-preflight-live")?.textContent ?? "").toContain(
+        COWORK_PREFLIGHT_CHECKING,
+      );
     });
     expect(q(container, "cowork-preflight-live")?.textContent ?? "").toContain("no adapter");
   });

--- a/tests/client/cowork-settings-mounted.test.ts
+++ b/tests/client/cowork-settings-mounted.test.ts
@@ -74,27 +74,47 @@ async function setChecked(box: HTMLInputElement, checked: boolean): Promise<void
   await tick();
 }
 
+/**
+ * Wait for the Nth probe to have been issued.
+ *
+ * `run()` defers `probing` one flush (#1376 rule 1 — the region has to reach
+ * the a11y tree before its first line), so the probe is never in flight by the
+ * end of the tick that opened the confirm. Counted ticks would encode that
+ * offset as a constant; this stays true if the chain gains or loses a hop.
+ */
+async function probeCount(n: number): Promise<void> {
+  await waitFor(() => {
+    expect(preflightSubnet).toHaveBeenCalledTimes(n);
+  });
+}
+
 function mount() {
   const { container } = render(CoworkSettings);
   const checkbox = q(container, "cowork-toggle-checkbox") as HTMLInputElement;
   return { container, checkbox };
 }
 
+// FILE scope, not per-describe: `coworkStatusCell` is module state and
+// `enableSucceeds()` installs a `refetch` that mutates it to `enabled: true`.
+// Scoped to one describe, a sibling describe inherits whatever the previous
+// one left — isolation by test ordering, which the next added test silently
+// breaks.
+beforeEach(() => {
+  coworkStatusCell.reset();
+  toggleIntegration.mockClear();
+  toggleIntegration.mockImplementation(async () => ({ ok: true as const }));
+  fakeInvoke.mockClear();
+  refetch.mockReset();
+  refetch.mockImplementation(async () => {});
+  preflightSubnet.mockClear();
+  preflightSubnet.mockResolvedValue({ status: "unknown" });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe("CoworkSettings — enable confirm wiring (#1375)", () => {
-  beforeEach(() => {
-    coworkStatusCell.reset();
-    toggleIntegration.mockClear();
-    fakeInvoke.mockClear();
-    refetch.mockReset();
-    refetch.mockImplementation(async () => {});
-    preflightSubnet.mockClear();
-    preflightSubnet.mockResolvedValue({ status: "unknown" });
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it("renders the toggle without enabling or probing anything", async () => {
     const { container, checkbox } = mount();
     await tick();
@@ -114,7 +134,7 @@ describe("CoworkSettings — enable confirm wiring (#1375)", () => {
     await setChecked(checkbox, true);
 
     expect(q(container, "cowork-enable-confirm")).toBeTruthy();
-    expect(preflightSubnet).toHaveBeenCalledTimes(1);
+    await probeCount(1);
     expect(toggleIntegration).not.toHaveBeenCalled();
   });
 
@@ -131,17 +151,96 @@ describe("CoworkSettings — enable confirm wiring (#1375)", () => {
     expect(q(container, "cowork-enable-confirm")).toBeNull();
   });
 
-  it("re-checking after a cancel starts a second probe", async () => {
-    // The raced path #1375 singles out: two overlapping probes on the surface
-    // where a user can toggle faster than PowerShell answers. `reset()` bumps
-    // the ticket, so only the newest may write — which is invisible unless a
-    // test actually issues the second one.
-    const { checkbox } = mount();
+  it("the Cancel button un-checks the box, not just the banner", async () => {
+    // The `|| confirming === "enable"` half of the `checked=` expression, which
+    // was previously pinned by nothing: dropping it (or the whole attribute)
+    // left every test here green, because `setChecked` writes `box.checked` by
+    // hand and the suite never observed Svelte writing it. Driving Cancel from
+    // the BUTTON is what makes the DOM write observable — Svelte skips the
+    // write whenever the expression re-computes to its cached value, so with
+    // `checked={s.enabled}` alone the box stays visually checked over a
+    // disabled integration until the next status refetch.
+    const { container, checkbox } = mount();
     await setChecked(checkbox, true);
+    expect(q(container, "cowork-enable-confirm")).toBeTruthy();
+
+    (q(container, "cowork-enable-cancel-btn") as HTMLButtonElement).click();
+    await tick();
+
+    expect(checkbox.checked).toBe(false);
+    expect(toggleIntegration).not.toHaveBeenCalled();
+  });
+
+  it("a failed disable puts the box back, so the retry is reachable", async () => {
+    // Measured trap this closes: `checked=` is one-way and Svelte caches the
+    // last value it wrote, so a disable that throws left the box unchecked over
+    // `enabled: true` with the line beneath it reading "yes" — and the next
+    // click, seeing an unchecked box, opened the ENABLE confirm. There was no
+    // gesture that reached `handleToggleOff` again short of a remount.
+    coworkStatusCell.patch({ enabled: true });
+    toggleIntegration.mockRejectedValueOnce(new Error("UAC declined"));
+    const { container, checkbox } = mount();
+    await tick();
+    expect(checkbox.checked).toBe(true);
+
     await setChecked(checkbox, false);
+    await waitFor(() => {
+      expect(checkbox.checked).toBe(true);
+    });
+
+    // Still on, still says so, and no confirm was opened by the failure.
+    expect(q(container, "cowork-settings")?.textContent).toContain("Integration enabled: yes");
+    expect(q(container, "cowork-enable-confirm")).toBeNull();
+    expect(toggleIntegration).toHaveBeenCalledWith(fakeInvoke, false);
+  });
+
+  it("checking an already-enabled box re-asserts it instead of offering Enable", async () => {
+    // The other exit from that desync. Clicking a box whose model is already
+    // `true` must not open a confirm whose Enable button fires a UAC prompt and
+    // a firewall write for the state the user is in.
+    coworkStatusCell.patch({ enabled: true });
+    const { container, checkbox } = mount();
+    await tick();
+
     await setChecked(checkbox, true);
 
-    expect(preflightSubnet).toHaveBeenCalledTimes(2);
+    expect(checkbox.checked).toBe(true);
+    expect(q(container, "cowork-enable-confirm")).toBeNull();
+    expect(preflightSubnet).not.toHaveBeenCalled();
+    expect(toggleIntegration).not.toHaveBeenCalled();
+  });
+
+  it("re-checking after a cancel starts a second probe", async () => {
+    // The raced path #1375 singles out: two OVERLAPPING probes on the surface
+    // where a user can toggle faster than PowerShell answers. `reset()` bumps
+    // the ticket, so only the newest may write.
+    //
+    // The first probe must never settle, or this degenerates into two
+    // sequential probes and exercises no supersession at all — the default mock
+    // resolves immediately, so probe 1 would already be done before probe 2
+    // started.
+    let releaseFirst: ((v: SubnetPreflight) => void) | undefined;
+    preflightSubnet.mockImplementationOnce(
+      () =>
+        new Promise<SubnetPreflight>((resolve) => {
+          releaseFirst = resolve;
+        }),
+    );
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    await probeCount(1);
+
+    await setChecked(checkbox, false);
+    await setChecked(checkbox, true);
+    await probeCount(2);
+
+    // Probe 1 lands late, after its ticket was superseded twice. Its result
+    // must not paint: the user is looking at the second probe's surface.
+    releaseFirst?.({ status: "blocked", hint: "stale adapter" });
+    await waitFor(() => {
+      expect(q(container, "cowork-enable-confirm")).toBeTruthy();
+    });
+    expect(q(container, "cowork-preflight-blocked")).toBeNull();
     expect(toggleIntegration).not.toHaveBeenCalled();
   });
 
@@ -178,32 +277,30 @@ describe("CoworkSettings — enable confirm wiring (#1375)", () => {
     preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
     const { container, checkbox } = mount();
     await setChecked(checkbox, true);
-    await tick();
-
-    expect(q(container, "cowork-preflight-blocked")?.textContent).toContain("no adapter");
+    await waitFor(() => {
+      expect(q(container, "cowork-preflight-blocked")?.textContent ?? "").toContain("no adapter");
+    });
 
     (q(container, "cowork-enable-cancel-btn") as HTMLButtonElement).click();
     await tick();
 
     preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
     await setChecked(checkbox, true);
+    await probeCount(2);
 
     expect(q(container, "cowork-enable-confirm")).toBeTruthy();
     expect(q(container, "cowork-preflight-blocked")).toBeNull();
-    expect(preflightSubnet).toHaveBeenCalledTimes(2);
   });
 });
 
 describe("CoworkSettings — pre-flight live region (#1376)", () => {
-  beforeEach(() => {
-    preflightSubnet.mockClear();
-    preflightSubnet.mockResolvedValue({ status: "unknown" });
-    toggleIntegration.mockClear();
-  });
-
   it("mounts the region empty, before the text that has to be announced", async () => {
     // The whole of #1376: a live region inserted together with its content is
-    // generally not announced. Region first and empty, content second.
+    // generally not announced. Region first and EMPTY, content second — and
+    // the emptiness is the half that was asserted by nothing. The in-flight
+    // line is the first text to arrive, so a `probing` that flips in the tick
+    // that mounts the region puts this right back; `run()` defers it one flush
+    // for exactly this reason.
     preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
     const { container, checkbox } = mount();
     await setChecked(checkbox, true);
@@ -211,40 +308,53 @@ describe("CoworkSettings — pre-flight live region (#1376)", () => {
     const region = q(container, "cowork-preflight-live");
     expect(region).toBeTruthy();
     expect(region?.getAttribute("role")).toBe("status");
+    expect(region?.textContent?.trim()).toBe("");
     expect(q(container, "cowork-preflight-blocked")).toBeNull();
+
+    // …and the same node then fills, rather than being replaced by one that
+    // arrives already populated.
+    await waitFor(() => {
+      expect(region?.textContent ?? "").toMatch(/Checking/);
+    });
+    expect(q(container, "cowork-preflight-live")).toBe(region);
   });
 
   it("keeps the same region node across probing → blocked", async () => {
     preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
     const { container, checkbox } = mount();
     await setChecked(checkbox, true);
+    // Captured BEFORE the hint arrives — that is what makes the identity
+    // assertion real. A wrapper living inside `{#if blocked}` gives `before ===
+    // null` here and fails, which is the shape #1376 is about.
     const before = q(container, "cowork-preflight-live");
-    await tick();
-    await tick();
+    expect(before).toBeTruthy();
 
-    const after = q(container, "cowork-preflight-live");
-    expect(after).toBe(before);
-    expect(after?.textContent).toContain("no adapter");
+    await waitFor(() => {
+      expect(q(container, "cowork-preflight-live")?.textContent ?? "").toContain("no adapter");
+    });
+    expect(q(container, "cowork-preflight-live")).toBe(before);
   });
 
   it("announces the re-probe without dropping the hint it is re-checking", async () => {
     // `run()` deliberately keeps the previous result, so a retry has `probing`
     // and `blocked` set at once. Appending rather than swapping is what lets
-    // the region change (so it is announced) while `-blocked` stays mounted for
-    // the three suites that read it mid-probe.
+    // the region change (so it is announced) while `-blocked` stays mounted —
+    // swapping to `{:else if}` would unmount the hint the retry is re-checking,
+    // under a pointer that is on the retry button.
     preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
     const { container, checkbox } = mount();
     await setChecked(checkbox, true);
-    await tick();
-    await tick();
+    await waitFor(() => {
+      expect(q(container, "cowork-preflight-retry-btn")).toBeTruthy();
+    });
 
     preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
     (q(container, "cowork-preflight-retry-btn") as HTMLButtonElement).click();
-    await tick();
-    await tick();
+    await probeCount(2);
 
-    const region = q(container, "cowork-preflight-live");
-    expect(region?.textContent).toContain("no adapter");
-    expect(region?.textContent).toMatch(/Checking/);
+    await waitFor(() => {
+      expect(q(container, "cowork-preflight-live")?.textContent ?? "").toMatch(/Checking/);
+    });
+    expect(q(container, "cowork-preflight-live")?.textContent ?? "").toContain("no adapter");
   });
 });

--- a/tests/client/cowork-settings-mounted.test.ts
+++ b/tests/client/cowork-settings-mounted.test.ts
@@ -419,6 +419,34 @@ describe("CoworkSettings — enable confirm wiring (#1375)", () => {
     expect(checkbox.checked).toBe(true);
   });
 
+  it("an enable whose read-back fails leaves the box checked and the confirm open", async () => {
+    // The mirror of "a disable whose read-back fails leaves the box off and
+    // says why", in the more security-relevant direction: the write landed
+    // (Cowork IS enabled), only the re-read did not, so `status.enabled` is
+    // still stale at `false`. Closing the confirm unconditionally would drop
+    // the only `true` term left in `enableBoxChecked` and visibly UNCHECK a
+    // box over an integration that is actually on. Leaving the confirm open
+    // is the accurate reflection: nothing here is confidently wrong.
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+
+    readBackFails();
+    (q(container, "cowork-enable-confirm-btn") as HTMLButtonElement).click();
+    // Both edges, as in the disable read-back-fail test above: waiting only on
+    // `disabled === false` risks reading before the click's async chain even
+    // starts, which would pass this test no matter what the handler does.
+    await waitFor(() => expect(checkbox.disabled).toBe(true), { interval: 5 });
+    await waitFor(() => expect(checkbox.disabled).toBe(false), { interval: 5 });
+
+    expect(toggleIntegration).toHaveBeenCalledWith(fakeInvoke, true);
+    expect(refetch).toHaveBeenCalledTimes(1);
+    // Confirm still open: closing it is exactly what a fresh read-back gates.
+    expect(q(container, "cowork-enable-confirm")).not.toBeNull();
+    // Box still checked via `confirming === "enable"`, not via `status.enabled`
+    // (which a frozen `enabled: false` fixture would leave stale) — accurate.
+    expect(checkbox.checked).toBe(true);
+  });
+
   it("Cancel clears the blocked hint, so a re-open does not paint a stale one", async () => {
     // `reset()` has no observable handle — `probe` is component-local. So this
     // asserts through the DOM instead: blocked hint, Cancel, re-open with a

--- a/tests/client/cowork-settings-mounted.test.ts
+++ b/tests/client/cowork-settings-mounted.test.ts
@@ -17,17 +17,18 @@
  * an `$effect` and a real invoke — an unmocked mount hits the network.
  */
 
-import { render, waitFor } from "@testing-library/svelte";
+import { cleanup, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { COWORK_PREFLIGHT_CHECKING } from "../../src/client/cowork/cowork-helpers";
 import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
-import { coworkStatusCell } from "../helpers/cowork-fixtures.svelte";
+import { coworkErrorCell, coworkStatusCell } from "../helpers/cowork-fixtures.svelte";
 
 const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
 const fakeInvoke = vi.fn();
 
 const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unknown" }));
+const setLanIpOverride = vi.fn(async () => {});
 
 // Spread `importOriginal` rather than re-declaring the module: `cowork-invoke`
 // exports nine symbols and each suite's mock used to name a different subset,
@@ -38,19 +39,50 @@ vi.mock("../../src/client/cowork/cowork-invoke", async (importOriginal) => ({
   loadInvoke: vi.fn(async () => fakeInvoke),
   coworkToggleIntegration: (...args: unknown[]) => toggleIntegration(...args),
   coworkPreflightSubnet: () => preflightSubnet(),
+  coworkSetLanIpOverride: (...args: unknown[]) => setLanIpOverride(...args),
 }));
 
-// A REACTIVE status cell, not a frozen literal: `enabled` is what the surface
-// renders, and a status the component cannot observe changing makes the
-// post-enable checkbox untestable. See the helper for why a plain `let` is
-// worse than useless here.
-const refetch = vi.fn(async () => {});
+/**
+ * The re-read that follows every write.
+ *
+ * Resolves `true` — "a fresh status was stored". The real `refetch` reports its
+ * failure that way rather than throwing, and the handlers gate their resync on
+ * it, so a mock resolving `undefined` would silently send every test in this
+ * file down the read-back-failed branch and skip the very resync they exist to
+ * pin. It would still be green, which is why it is worth saying out loud.
+ *
+ * It mutates `coworkStatusCell` — a REACTIVE cell, not a frozen literal —
+ * because `enabled` is what the surface renders, and a status the component
+ * cannot observe changing makes the post-write checkbox untestable. See the
+ * helper for why a plain `let` is worse than useless here.
+ */
+const refetch = vi.fn(async () => true);
 
 /** What the Rust side does on success: the toggle commits, the refetch reports it. */
 function enableSucceeds(): void {
   refetch.mockImplementation(async () => {
     coworkStatusCell.patch({ enabled: true });
+    return true;
   });
+}
+
+/** The disable mirror of `enableSucceeds`. */
+function disableSucceeds(): void {
+  refetch.mockImplementation(async () => {
+    coworkStatusCell.patch({ enabled: false });
+    return true;
+  });
+}
+
+/**
+ * The write commits, but the read-back after it does not land.
+ *
+ * `refetch` swallows that into `coworkState.error` and resolves `false` rather
+ * than throwing, so `status` keeps its PRE-write value while every other signal
+ * says the operation succeeded.
+ */
+function readBackFails(): void {
+  refetch.mockImplementation(async () => false);
 }
 
 vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
@@ -59,7 +91,9 @@ vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
       return coworkStatusCell.value;
     },
     loading: false,
-    error: null,
+    get error() {
+      return coworkErrorCell.value;
+    },
     refetch,
   }),
 }));
@@ -109,13 +143,20 @@ beforeEach(() => {
   toggleIntegration.mockClear();
   toggleIntegration.mockImplementation(async () => ({ ok: true as const }));
   fakeInvoke.mockClear();
+  coworkErrorCell.reset();
   refetch.mockReset();
-  refetch.mockImplementation(async () => {});
+  refetch.mockImplementation(async () => true);
+  setLanIpOverride.mockClear();
+  setLanIpOverride.mockImplementation(async () => {});
   preflightSubnet.mockClear();
   preflightSubnet.mockResolvedValue({ status: "unknown" });
 });
 
 afterEach(() => {
+  // Explicit: without `globals: true` Testing Library never registers its own
+  // `afterEach`, so mounts would accumulate across this file — the other half
+  // of the isolation argument the file-scoped `beforeEach` above makes.
+  cleanup();
   vi.unstubAllGlobals();
 });
 
@@ -197,6 +238,110 @@ describe("CoworkSettings — enable confirm wiring (#1375)", () => {
     expect(q(container, "cowork-settings")?.textContent).toContain("Integration enabled: yes");
     expect(q(container, "cowork-enable-confirm")).toBeNull();
     expect(toggleIntegration).toHaveBeenCalledWith(fakeInvoke, false);
+  });
+
+  it("a disable that succeeds leaves the box off", async () => {
+    // The mirror of the test above, and the one that makes the resync's ARGUMENT
+    // matter rather than just its presence: with only the failure path covered,
+    // `enabled` never moves, so `resyncCheckbox(box, true)` as a hard-coded
+    // constant is indistinguishable from reading the model — and a constant
+    // `true` would leave the box checked over an integration that just turned
+    // off, which is precisely the defect `checkbox-sync.ts` exists to fix.
+    coworkStatusCell.patch({ enabled: true });
+    disableSucceeds();
+    const { container, checkbox } = mount();
+    await tick();
+    expect(checkbox.checked).toBe(true);
+
+    await setChecked(checkbox, false);
+
+    // Wait on the MODEL's readout, not the box: `resyncCheckbox` writes
+    // `checked` imperatively before Svelte's flush, so gating on the box alone
+    // would let this proceed while the surface still said "yes".
+    await waitFor(
+      () =>
+        expect(q(container, "cowork-settings")?.textContent).toContain("Integration enabled: no"),
+      { interval: 5 },
+    );
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it("a disable whose read-back fails leaves the box off and says why", async () => {
+    // The write landed; only the re-read did not. `status` therefore still says
+    // `enabled: true`, and resyncing from it would visibly RE-CHECK the box over
+    // an integration that is now off — the resync making the UI more wrong than
+    // no resync at all. So the resync is gated on the read-back, and the failure
+    // gets a banner instead of the silence it used to get.
+    coworkStatusCell.patch({ enabled: true });
+    readBackFails();
+    const { checkbox } = mount();
+    await tick();
+    expect(checkbox.checked).toBe(true);
+
+    await setChecked(checkbox, false);
+    // `disabled={busy}` is the handler's own end-marker, and waiting on it is
+    // what makes this test non-vacuous: waiting on `toggleIntegration` instead
+    // resolves while `refetch` and the resync are still pending, so the
+    // assertion below would read the user's click position and pass no matter
+    // what the handler went on to do. Both edges, so a missed flush cannot make
+    // the second wait return immediately.
+    await waitFor(() => expect(checkbox.disabled).toBe(true), { interval: 5 });
+    await waitFor(() => expect(checkbox.disabled).toBe(false), { interval: 5 });
+
+    expect(toggleIntegration).toHaveBeenCalledWith(fakeInvoke, false);
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it("surfaces a re-read failure that happens after the first load", async () => {
+    // The banner used to be gated on `!coworkState.status`, which is false for
+    // every failure a user of the toggle can cause — the toggle only exists once
+    // a status has loaded. So the one error state reachable from this surface
+    // was the one the banner could not show.
+    coworkStatusCell.patch({ enabled: true });
+    refetch.mockImplementation(async () => {
+      coworkErrorCell.set("bridge unavailable");
+      return false;
+    });
+    const { container, checkbox } = mount();
+    await tick();
+
+    await setChecked(checkbox, false);
+
+    const banner = await waitFor(
+      () => {
+        const el = q(container, "cowork-settings-error");
+        expect(el).toBeTruthy();
+        return el as HTMLElement;
+      },
+      { interval: 5 },
+    );
+    expect(banner.textContent).toContain("bridge unavailable");
+    // Phrased for a refresh, not a cold load — the status on screen is real,
+    // just stale.
+    expect(banner.textContent).toContain("refresh");
+  });
+
+  it("the LAN-IP override row resyncs its own box", async () => {
+    // This row is behind `{#if s.lanIpFallback !== null}` and every fixture
+    // leaves that null, so `handleToggleLanIp` had never executed under a mount
+    // at all — deleting its resync left the whole suite green. It carries the
+    // same hazard as the Enable toggle with none of the cover: no confirm
+    // banner, no "enabled: yes/no" line, so the box IS the readout.
+    coworkStatusCell.patch({ lanIpFallback: "192.168.1.100", useLanIpOverride: false });
+    const { container } = mount();
+    await tick();
+
+    const lanBox = q(container, "cowork-lan-ip-override-checkbox") as HTMLInputElement;
+    expect(lanBox).toBeTruthy();
+    expect(lanBox.checked).toBe(false);
+
+    // The write fails, so `useLanIpOverride` stays false and the expression
+    // re-computes to the value Svelte last wrote — the skipped-write trap.
+    setLanIpOverride.mockRejectedValueOnce(new Error("bridge gone"));
+    lanBox.checked = true;
+    lanBox.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await waitFor(() => expect(lanBox.checked).toBe(false), { interval: 5 });
   });
 
   it("checking an already-enabled box re-asserts it instead of offering Enable", async () => {

--- a/tests/client/cowork-settings-mounted.test.ts
+++ b/tests/client/cowork-settings-mounted.test.ts
@@ -17,18 +17,16 @@
  * an `$effect` and a real invoke — an unmocked mount hits the network.
  */
 
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
+import { coworkStatusCell } from "../helpers/cowork-fixtures.svelte";
 
 const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
 const fakeInvoke = vi.fn();
 
-type Preflight =
-  | { status: "ok"; cidr: string }
-  | { status: "blocked"; hint: string }
-  | { status: "unknown" };
-const preflightSubnet = vi.fn(async (): Promise<Preflight> => ({ status: "unknown" }));
+const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unknown" }));
 
 vi.mock("../../src/client/cowork/cowork-invoke", () => ({
   TAURI_NOT_AVAILABLE: "Tauri runtime not available",
@@ -39,20 +37,23 @@ vi.mock("../../src/client/cowork/cowork-invoke", () => ({
   coworkSetLanIpOverride: vi.fn(async () => {}),
 }));
 
+// A REACTIVE status cell, not a frozen literal: `enabled` is what the surface
+// renders, and a status the component cannot observe changing makes the
+// post-enable checkbox untestable. See the helper for why a plain `let` is
+// worse than useless here.
 const refetch = vi.fn(async () => {});
+
+/** What the Rust side does on success: the toggle commits, the refetch reports it. */
+function enableSucceeds(): void {
+  refetch.mockImplementation(async () => {
+    coworkStatusCell.patch({ enabled: true });
+  });
+}
 
 vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
   createCoworkStatus: () => ({
-    status: {
-      osSupported: true,
-      coworkDetected: true,
-      enabled: false,
-      vethernetCidr: "172.30.16.0/28",
-      lanIpFallback: null,
-      useLanIpOverride: false,
-      workspaces: [],
-      uacDeclined: false,
-      uacDeclinedAt: null,
+    get status() {
+      return coworkStatusCell.value;
     },
     loading: false,
     error: null,
@@ -81,9 +82,11 @@ function mount() {
 
 describe("CoworkSettings — enable confirm wiring (#1375)", () => {
   beforeEach(() => {
+    coworkStatusCell.reset();
     toggleIntegration.mockClear();
     fakeInvoke.mockClear();
-    refetch.mockClear();
+    refetch.mockReset();
+    refetch.mockImplementation(async () => {});
     preflightSubnet.mockClear();
     preflightSubnet.mockResolvedValue({ status: "unknown" });
   });
@@ -142,22 +145,29 @@ describe("CoworkSettings — enable confirm wiring (#1375)", () => {
     expect(toggleIntegration).not.toHaveBeenCalled();
   });
 
-  it("Enable fires the toggle and closes the confirm", async () => {
+  it("Enable fires the toggle, closes the confirm, and leaves the box checked", async () => {
     // `closeEnableConfirm()` on SUCCESS is the reset #1366 made load-bearing:
     // `run()` no longer clears `preflight`, so a path that leaves the confirm
     // without resetting leaves a stale hint waiting for the next open.
     const { container, checkbox } = mount();
     await setChecked(checkbox, true);
 
+    enableSucceeds();
     (q(container, "cowork-enable-confirm-btn") as HTMLButtonElement).click();
-    // `withInvoke` awaits `loadInvoke` → the toggle → `refetch` before it
-    // closes, so the close is four promise hops downstream of the click.
-    for (let i = 0; i < 6; i++) await tick();
+    // `waitFor`, not a tick count: `withInvoke` awaits `loadInvoke` → the toggle
+    // → `refetch`, and a hand-counted number of flushes is a constant nobody
+    // can re-derive when the chain gains a hop.
+    await waitFor(() => {
+      expect(q(container, "cowork-enable-confirm")).toBeNull();
+    });
 
     expect(toggleIntegration).toHaveBeenCalledTimes(1);
     expect(toggleIntegration).toHaveBeenCalledWith(fakeInvoke, true);
     expect(refetch).toHaveBeenCalledTimes(1);
-    expect(q(container, "cowork-enable-confirm")).toBeNull();
+    // The box must still read checked, now because the integration IS enabled
+    // rather than because a confirm is open. With a frozen `enabled: false`
+    // fixture it would silently un-check here and nothing would notice.
+    expect(checkbox.checked).toBe(true);
   });
 
   it("Cancel clears the blocked hint, so a re-open does not paint a stale one", async () => {
@@ -205,8 +215,6 @@ describe("CoworkSettings — pre-flight live region (#1376)", () => {
   });
 
   it("keeps the same region node across probing → blocked", async () => {
-    // Same NODE, not merely a region in both states: a wrapper that unmounts
-    // and remounts is the original bug wearing a testid.
     preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
     const { container, checkbox } = mount();
     await setChecked(checkbox, true);

--- a/tests/client/integration-wizard-cowork.test.ts
+++ b/tests/client/integration-wizard-cowork.test.ts
@@ -68,7 +68,12 @@ vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
     status: coworkStatusFixture(),
     loading: false,
     error: null,
-    refetch: vi.fn(async () => {}),
+    // The real hook resolves `true`/`false` (a fresh status was/wasn't
+    // stored) and `enableCowork`/`handleToggleOn` gate a UI transition on it —
+    // stubbing `undefined` here would make every enable in this file look
+    // like a failed read-back to that gate, whether or not that's this file's
+    // intent to test.
+    refetch: vi.fn(async () => true),
   }),
 }));
 

--- a/tests/client/integration-wizard-cowork.test.ts
+++ b/tests/client/integration-wizard-cowork.test.ts
@@ -22,9 +22,10 @@
  * view + "More integrations" section render without a real /api round-trip.
  */
 
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
 
 const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
 const fakeInvoke = vi.fn();
@@ -38,11 +39,10 @@ vi.mock("../../src/client/cowork/cowork-helpers", async (importOriginal) => {
 
 // #1298: the sub-view pre-flights subnet detection on entry. Default to
 // `unknown` (the probe couldn't run) — the state that must leave Enable alone.
-type Preflight =
-  | { status: "ok"; cidr: string }
-  | { status: "blocked"; hint: string }
-  | { status: "unknown" };
-const preflightSubnet = vi.fn(async (): Promise<Preflight> => ({ status: "unknown" }));
+// The real type, not a transcription: a hand-copied union goes stale silently,
+// and `tests/` is typechecked by nothing (`tsconfig.json` includes only `src`),
+// so the copy would not even fail to compile.
+const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unknown" }));
 
 vi.mock("../../src/client/cowork/cowork-invoke", () => ({
   TAURI_NOT_AVAILABLE: "Tauri runtime not available",
@@ -188,6 +188,13 @@ describe("integration wizard — Cowork sub-view gating", () => {
 
   async function openCoworkSubView(container: HTMLElement): Promise<void> {
     (q(container, "integration-wizard-cowork-setup") as HTMLButtonElement).click();
+    // Wait for the probe to be ISSUED rather than counting ticks: `run()`
+    // defers `probing` one flush so the live region reaches the accessibility
+    // tree empty first (#1376), which puts the call an unknowable number of
+    // hops from the click.
+    await waitFor(() => {
+      expect(preflightSubnet).toHaveBeenCalled();
+    });
     await tick();
     await tick(); // let the pre-flight promise settle
   }
@@ -234,19 +241,20 @@ describe("integration wizard — Cowork sub-view gating", () => {
 
     // The user starts a Cowork session, then retries.
     preflightSubnet.mockResolvedValue({ status: "ok", cidr: "172.20.0.0/20" });
+    await waitFor(() => {
+      expect(q(container, "integration-wizard-cowork-preflight-retry-btn")).toBeTruthy();
+    });
     (q(container, "integration-wizard-cowork-preflight-retry-btn") as HTMLButtonElement).click();
-    // Four ticks, not two: the blocked banner now survives until the re-probe
-    // SETTLES rather than vanishing synchronously on click (see the test below
-    // for why). Two ticks lands mid-probe, where the banner is still correctly
-    // on screen.
-    await tick();
-    await tick();
-    await tick();
-    await tick();
+    // `waitFor` on the settled outcome, not a tick count: the blocked banner
+    // survives until the re-probe SETTLES rather than vanishing synchronously
+    // on click (see the test below for why), so any fixed number of ticks is
+    // either mid-probe or an over-count nobody can re-derive.
+    await waitFor(() => {
+      expect(q(container, "cowork-enable-confirm-btn")).toBeTruthy();
+    });
 
     expect(preflightSubnet).toHaveBeenCalledTimes(2);
     expect(q(container, "integration-wizard-cowork-preflight-blocked")).toBeNull();
-    expect(q(container, "cowork-enable-confirm-btn")).toBeTruthy();
   });
 
   it("keeps the retry button in place while it re-probes, rather than swapping in Enable", async () => {
@@ -271,9 +279,14 @@ describe("integration wizard — Cowork sub-view gating", () => {
     // `beforeEach` uses `mockClear`, which does NOT clear implementations, so a
     // hanging default would wedge every later test in this file.
     preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
+    await waitFor(() => {
+      expect(q(container, "integration-wizard-cowork-preflight-retry-btn")).toBeTruthy();
+    });
     const retryBtn = q(container, "integration-wizard-cowork-preflight-retry-btn");
     (retryBtn as HTMLButtonElement).click();
-    await tick();
+    await waitFor(() => {
+      expect(preflightSubnet).toHaveBeenCalledTimes(2);
+    });
     await tick();
 
     const stillThere = q(container, "integration-wizard-cowork-preflight-retry-btn");
@@ -305,7 +318,16 @@ describe("integration wizard — Cowork sub-view gating", () => {
     const region = q(container, "integration-wizard-cowork-preflight-live");
     expect(region).toBeTruthy();
     expect(region?.getAttribute("role")).toBe("status");
+    // EMPTY, which nothing asserted before: the in-flight line is the first
+    // text to arrive, so a `probing` flipped in the tick that mounts the region
+    // reintroduces the whole defect. `run()` defers it one flush for this.
+    expect(region?.textContent?.trim()).toBe("");
     expect(q(container, "integration-wizard-cowork-preflight-blocked")).toBeNull();
+
+    await waitFor(() => {
+      expect(region?.textContent ?? "").toMatch(/Checking/);
+    });
+    expect(q(container, "integration-wizard-cowork-preflight-live")).toBe(region);
   });
 
   it("keeps the same region node when the hint arrives", async () => {
@@ -320,12 +342,14 @@ describe("integration wizard — Cowork sub-view gating", () => {
     (q(container, "integration-wizard-cowork-setup") as HTMLButtonElement).click();
     await tick();
     const before = q(container, "integration-wizard-cowork-preflight-live");
-    await tick();
-    await tick();
+    expect(before).toBeTruthy();
 
-    const after = q(container, "integration-wizard-cowork-preflight-live");
-    expect(after).toBe(before);
-    expect(after?.textContent).toContain("no adapter");
+    await waitFor(() => {
+      expect(q(container, "integration-wizard-cowork-preflight-live")?.textContent ?? "").toContain(
+        "no adapter",
+      );
+    });
+    expect(q(container, "integration-wizard-cowork-preflight-live")).toBe(before);
   });
 
   it("leaves Enable available when the probe itself cannot run", async () => {

--- a/tests/client/integration-wizard-cowork.test.ts
+++ b/tests/client/integration-wizard-cowork.test.ts
@@ -25,7 +25,9 @@
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { COWORK_PREFLIGHT_CHECKING } from "../../src/client/cowork/cowork-helpers";
 import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
+import { coworkStatusFixture } from "../helpers/cowork-status-fixture";
 
 const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
 const fakeInvoke = vi.fn();
@@ -44,28 +46,26 @@ vi.mock("../../src/client/cowork/cowork-helpers", async (importOriginal) => {
 // so the copy would not even fail to compile.
 const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unknown" }));
 
-vi.mock("../../src/client/cowork/cowork-invoke", () => ({
-  TAURI_NOT_AVAILABLE: "Tauri runtime not available",
+// Spread `importOriginal` rather than re-declaring the module: `cowork-invoke`
+// exports nine symbols and each suite's mock used to name a different subset,
+// so a component reaching for an un-named one failed as `undefined is not a
+// function` — a component-shaped error, discovered one file at a time.
+vi.mock("../../src/client/cowork/cowork-invoke", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/cowork/cowork-invoke")>()),
   loadInvoke: vi.fn(async () => fakeInvoke),
   coworkToggleIntegration: (...args: unknown[]) => toggleIntegration(...args),
   coworkPreflightSubnet: () => preflightSubnet(),
 }));
 
 // A "normal" (Windows + detected) status with Cowork OFF, so the "Set up"
-// button renders and enable is a meaningful action.
+// button renders and enable is a meaningful action. The shared fixture, not a
+// literal: its sibling `integration-wizard-push-support.test.ts` mounts the
+// SAME component through the SAME mock, and a hand-written literal here omits
+// the optional fields the sidecar always sends — so the two suites would render
+// different `undetectedDetail` arms for reasons neither file states.
 vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
   createCoworkStatus: () => ({
-    status: {
-      osSupported: true,
-      coworkDetected: true,
-      enabled: false,
-      vethernetCidr: "172.30.16.0/28",
-      lanIpFallback: null,
-      useLanIpOverride: false,
-      workspaces: [],
-      uacDeclined: false,
-      uacDeclinedAt: null,
-    },
+    status: coworkStatusFixture(),
     loading: false,
     error: null,
     refetch: vi.fn(async () => {}),
@@ -192,11 +192,14 @@ describe("integration wizard — Cowork sub-view gating", () => {
     // defers `probing` one flush so the live region reaches the accessibility
     // tree empty first (#1376), which puts the call an unknowable number of
     // hops from the click.
-    await waitFor(() => {
-      expect(preflightSubnet).toHaveBeenCalled();
-    });
+    // `interval: 5` — a mock call count wakes no MutationObserver.
+    await waitFor(() => expect(preflightSubnet).toHaveBeenCalled(), { interval: 5 });
+    // Two flushes to let an ALREADY-RESOLVED mock's continuations run. Not a
+    // chain length — the `waitFor` above owns that — so this stays correct if
+    // `run()` gains a hop. A caller waiting on a specific settled state should
+    // still use its own `waitFor`; the ones below do.
     await tick();
-    await tick(); // let the pre-flight promise settle
+    await tick();
   }
 
   it("pre-flights subnet detection when entering the sub-view", async () => {
@@ -224,8 +227,11 @@ describe("integration wizard — Cowork sub-view gating", () => {
     await tick();
     await openCoworkSubView(container);
 
-    const banner = q(container, "integration-wizard-cowork-preflight-blocked");
-    expect(banner?.textContent).toContain("didn't find a Hyper-V virtual network adapter");
+    await waitFor(() => {
+      expect(
+        q(container, "integration-wizard-cowork-preflight-blocked")?.textContent ?? "",
+      ).toContain("didn't find a Hyper-V virtual network adapter");
+    });
     expect(q(container, "integration-wizard-cowork-preflight-retry-btn")).toBeTruthy();
     // The whole point: no button offering an action we've watched fail.
     expect(q(container, "cowork-enable-confirm-btn")).toBeNull();
@@ -284,9 +290,7 @@ describe("integration wizard — Cowork sub-view gating", () => {
     });
     const retryBtn = q(container, "integration-wizard-cowork-preflight-retry-btn");
     (retryBtn as HTMLButtonElement).click();
-    await waitFor(() => {
-      expect(preflightSubnet).toHaveBeenCalledTimes(2);
-    });
+    await waitFor(() => expect(preflightSubnet).toHaveBeenCalledTimes(2), { interval: 5 });
     await tick();
 
     const stillThere = q(container, "integration-wizard-cowork-preflight-retry-btn");
@@ -325,7 +329,7 @@ describe("integration wizard — Cowork sub-view gating", () => {
     expect(q(container, "integration-wizard-cowork-preflight-blocked")).toBeNull();
 
     await waitFor(() => {
-      expect(region?.textContent ?? "").toMatch(/Checking/);
+      expect(region?.textContent ?? "").toContain(COWORK_PREFLIGHT_CHECKING);
     });
     expect(q(container, "integration-wizard-cowork-preflight-live")).toBe(region);
   });

--- a/tests/client/integration-wizard-cowork.test.ts
+++ b/tests/client/integration-wizard-cowork.test.ts
@@ -286,6 +286,48 @@ describe("integration wizard — Cowork sub-view gating", () => {
     ).toBeNull();
   });
 
+  // -------------------------------------------------------------------------
+  // #1376 — the live region. `role="status"` sat on the blocked banner, which
+  // is created together with its text; a region inserted with its content is
+  // generally not announced, so the sentence explaining a failed detection was
+  // silent for exactly the users #1298 wrote it for.
+  // -------------------------------------------------------------------------
+
+  it("mounts the pre-flight region empty on entry, before any hint exists", async () => {
+    preflightSubnet.mockImplementationOnce(() => new Promise(() => {}));
+    const { container } = render(IntegrationWizardModal, {
+      props: { open: true, onClose: vi.fn() },
+    });
+    await tick();
+    (q(container, "integration-wizard-cowork-setup") as HTMLButtonElement).click();
+    await tick();
+
+    const region = q(container, "integration-wizard-cowork-preflight-live");
+    expect(region).toBeTruthy();
+    expect(region?.getAttribute("role")).toBe("status");
+    expect(q(container, "integration-wizard-cowork-preflight-blocked")).toBeNull();
+  });
+
+  it("keeps the same region node when the hint arrives", async () => {
+    // Same NODE, not merely a region present in both states: a wrapper that
+    // unmounts and remounts with its content is the original bug wearing a
+    // testid.
+    preflightSubnet.mockResolvedValue({ status: "blocked", hint: "no adapter" });
+    const { container } = render(IntegrationWizardModal, {
+      props: { open: true, onClose: vi.fn() },
+    });
+    await tick();
+    (q(container, "integration-wizard-cowork-setup") as HTMLButtonElement).click();
+    await tick();
+    const before = q(container, "integration-wizard-cowork-preflight-live");
+    await tick();
+    await tick();
+
+    const after = q(container, "integration-wizard-cowork-preflight-live");
+    expect(after).toBe(before);
+    expect(after?.textContent).toContain("no adapter");
+  });
+
   it("leaves Enable available when the probe itself cannot run", async () => {
     // A broken probe says nothing about whether enabling would work. Blocking
     // here would strand a user whose enable would have succeeded — a worse

--- a/tests/client/integration-wizard-push-support.test.ts
+++ b/tests/client/integration-wizard-push-support.test.ts
@@ -19,12 +19,13 @@
  * is the render, and a real probe would fetch `/health`.
  */
 
-import { cleanup, render } from "@testing-library/svelte";
+import { cleanup, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CLAUDE_PLUGIN_INSTALL_COMMANDS } from "../../src/shared/constants.js";
 import type { ApplyItemResult } from "../../src/shared/integrations/contract.js";
+import { coworkStatusFixture } from "../helpers/cowork-status-fixture";
 
 // Mutable stubs the mocked hooks return; each test sets them BEFORE render.
 const wizardStub: {
@@ -87,13 +88,33 @@ vi.mock("../../src/client/hooks/useClaudeCliStatus.svelte", () => ({
   }),
 }));
 
+// Mutable, defaulting to `null` (no Cowork row) so the push-mode assertions
+// below see the layout they were written against. One test flips it to reach
+// the Cowork sub-view, which is the only way to unmount and remount the
+// push-routes block.
+const coworkStub: { status: unknown } = { status: null };
+
 vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
   createCoworkStatus: () => ({
-    status: null,
+    get status() {
+      return coworkStub.status;
+    },
     loading: false,
     error: null,
     refetch: vi.fn(async () => {}),
   }),
+}));
+
+vi.mock("../../src/client/cowork/cowork-helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/client/cowork/cowork-helpers")>();
+  return { ...actual, isTauriRuntime: () => coworkStub.status !== null };
+});
+
+vi.mock("../../src/client/cowork/cowork-invoke", () => ({
+  TAURI_NOT_AVAILABLE: "Tauri runtime not available",
+  loadInvoke: vi.fn(async () => vi.fn()),
+  coworkToggleIntegration: vi.fn(async () => ({ ok: true })),
+  coworkPreflightSubnet: vi.fn(async () => ({ status: "unknown" })),
 }));
 
 import IntegrationWizardModal from "../../src/client/components/IntegrationWizardModal.svelte";
@@ -217,9 +238,10 @@ describe("IntegrationWizardModal — per-target push support (#1299)", () => {
  *
  * #1390: the two plugin install commands existed only as `tandem setup` console
  * output, which a desktop-app user never sees — and the desktop app is the
- * primary distribution channel. Tandem cannot run them either way (registering
- * a marketplace is Claude Code's own trust boundary), so showing them IS the
- * fix, and showing them in both branches is the part that keeps regressing.
+ * primary distribution channel. Tandem shows them rather than running them (the
+ * reason is on `CLAUDE_PLUGIN_INSTALL_COMMANDS`), so putting them where a
+ * desktop user can see them IS the fix — and reaching both branches is the part
+ * that keeps regressing.
  */
 describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
   afterEach(() => {
@@ -227,7 +249,14 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     wizardStub.picked = [];
     wizardStub.applyResults = [];
     wizardStub.channelRegistered = null;
+    coworkStub.status = null;
     vi.clearAllMocks();
+    // Here rather than at the end of each clipboard test: `navigator` is a
+    // global and the stub replaces it wholesale (no `userAgent`, no
+    // `platform`). Unstubbing in the test body means one real assertion failure
+    // leaves every later test in the worker running against the stripped
+    // object, turning a single red into a cascade.
+    vi.unstubAllGlobals();
   });
 
   function mountPushMode(channelRegistered: boolean) {
@@ -257,12 +286,26 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
       expect(q(container, "integration-wizard-plugin-copy")).toBeTruthy();
     });
 
+    it(`labels the branch it rendered when the ${branch}`, async () => {
+      // `data-push-mode` had no reader at all after #1389 renamed its values
+      // from push/polling to shim/no-shim — dead metadata with a silently
+      // changed contract. Asserted rather than deleted: it is the only handle
+      // on WHICH arm rendered, and both arms now share one visual treatment.
+      const { container } = mountPushMode(registered);
+      await tick();
+      expect(q(container, "integration-wizard-push-mode")?.getAttribute("data-push-mode")).toBe(
+        registered ? "shim" : "no-shim",
+      );
+    });
+
     it(`names the plugin's version floor when the ${branch}`, async () => {
       // `docs/cli.md` records the failure mode this prevents: below 2.1.212 the
       // install succeeds and the monitor never runs, with nothing to say so. A
       // wizard that recommends the plugin without the floor sends a desktop
-      // user to a silent no-op — and neither doc-contract test covers this
-      // file's prose, so the assertion has to live here.
+      // user to a silent no-op. `tests/docs/monitor-arming-claims.test.ts` does
+      // read this file (it is in that suite's CARRIERS), but only to ban
+      // unconditional-arming phrasings — nothing there asserts the floor is
+      // PRESENT, so that assertion has to live here.
       const { container } = mountPushMode(registered);
       await tick();
       expect(q(container, "integration-wizard-push-mode")?.textContent ?? "").toContain("2.1.212");
@@ -287,7 +330,14 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     // named the flag alone, which is a command that silently does nothing.
     const { container } = mountPushMode(true);
     await tick();
-    const text = q(container, "integration-wizard-push-mode")?.textContent ?? "";
+    // Whitespace-normalised: the command lives in an inline `<code>` whose
+    // source line-breaks would land in `textContent` verbatim. Without this the
+    // test goes red on a re-wrap that changes no behaviour, and the natural
+    // "fix" for that is to delete the assertion.
+    const text = (q(container, "integration-wizard-push-mode")?.textContent ?? "").replace(
+      /\s+/g,
+      " ",
+    );
     expect(text).toContain("--dangerously-load-development-channels server:tandem-channel");
   });
 
@@ -301,17 +351,26 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     expect(text).toMatch(/neither gate|no Monitor tool/i);
   });
 
+  /** Click Copy and wait for the live region to settle on `expected`. */
+  async function clickCopy(container: HTMLElement, expected: RegExp): Promise<void> {
+    (q(container, "integration-wizard-plugin-copy") as HTMLButtonElement).click();
+    // `waitFor`, not a tick count: the handler clears the status, awaits a
+    // flush, then awaits `writeText` — a hand-counted number of hops is a
+    // constant nobody can re-derive when the chain changes.
+    await waitFor(() => {
+      expect(q(container, "integration-wizard-plugin-copy-status")?.textContent ?? "").toMatch(
+        expected,
+      );
+    });
+  }
+
   it("copies both commands as one pasteable block", async () => {
     const writeText = vi.fn(async () => {});
     vi.stubGlobal("navigator", { clipboard: { writeText } });
     const { container } = mountPushMode(false);
     await tick();
 
-    (q(container, "integration-wizard-plugin-copy") as HTMLButtonElement).click();
-    // Two ticks: the label is written after an awaited `writeText`, so it lands
-    // a microtask after the click's own flush.
-    await tick();
-    await tick();
+    await clickCopy(container, /Copied/);
 
     expect(writeText).toHaveBeenCalledWith(CLAUDE_PLUGIN_INSTALL_COMMANDS.join("\n"));
     // The outcome is announced from a live region beside the button, not from
@@ -320,7 +379,29 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     const status = q(container, "integration-wizard-plugin-copy-status");
     expect(status?.getAttribute("role")).toBe("status");
     expect(status?.textContent?.trim()).toBe("Copied");
-    vi.unstubAllGlobals();
+  });
+
+  it("empties the status between copies, so a repeat click is announced too", async () => {
+    // A live region that does not CHANGE announces nothing. Re-assigning the
+    // same string mutates no text node, so without the clear the second click
+    // is silent — indistinguishable from an unwired button for exactly the
+    // user this region exists for.
+    vi.stubGlobal("navigator", { clipboard: { writeText: vi.fn(async () => {}) } });
+    const { container } = mountPushMode(false);
+    await tick();
+
+    await clickCopy(container, /Copied/);
+
+    const status = q(container, "integration-wizard-plugin-copy-status") as HTMLElement;
+    (q(container, "integration-wizard-plugin-copy") as HTMLButtonElement).click();
+    // Same node throughout — the region must never be replaced, only refilled.
+    await waitFor(() => {
+      expect(status.textContent?.trim()).toBe("");
+    });
+    await waitFor(() => {
+      expect(status.textContent?.trim()).toBe("Copied");
+    });
+    expect(q(container, "integration-wizard-plugin-copy-status")).toBe(status);
   });
 
   it("says so on the button when the clipboard refuses", async () => {
@@ -336,17 +417,45 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     const { container } = mountPushMode(false);
     await tick();
 
-    (q(container, "integration-wizard-plugin-copy") as HTMLButtonElement).click();
-    await tick();
-    await tick();
+    await clickCopy(container, /Couldn't copy/i);
 
-    expect(q(container, "integration-wizard-plugin-copy-status")?.textContent ?? "").toMatch(
-      /Couldn't copy/i,
-    );
     // The commands stay on screen to be selected by hand.
     expect(q(container, "integration-wizard-plugin-commands")?.textContent ?? "").toContain(
       CLAUDE_PLUGIN_INSTALL_COMMANDS[0],
     );
-    vi.unstubAllGlobals();
+  });
+
+  it("does not carry a copy status back from the Cowork sub-view", async () => {
+    // The push-routes block unmounts with the main view. A surviving status
+    // remounts CREATED WITH its content, which is a live region announced by
+    // nothing — #1376's defect, reintroduced inside the fix for it.
+    coworkStub.status = coworkStatusFixture();
+    vi.stubGlobal("navigator", { clipboard: { writeText: vi.fn(async () => {}) } });
+    const { container } = mountPushMode(false);
+    await tick();
+
+    await clickCopy(container, /Copied/);
+
+    (q(container, "integration-wizard-cowork-setup") as HTMLButtonElement).click();
+    await tick();
+    expect(q(container, "integration-wizard-plugin-copy-status")).toBeNull();
+
+    (q(container, "integration-wizard-cowork-back") as HTMLButtonElement).click();
+    await waitFor(() => {
+      expect(q(container, "integration-wizard-plugin-copy-status")).toBeTruthy();
+    });
+    expect(q(container, "integration-wizard-plugin-copy-status")?.textContent?.trim()).toBe("");
+  });
+
+  it("survives a WebView with no clipboard API at all", async () => {
+    // Not the same path as a rejecting `writeText`: this throws a TypeError on
+    // the property access itself. The `try` covers it only because the access
+    // is inside the block — moving it out to a `const` above would reintroduce
+    // an unhandled rejection with the same visible symptom.
+    vi.stubGlobal("navigator", {});
+    const { container } = mountPushMode(false);
+    await tick();
+
+    await clickCopy(container, /Couldn't copy/i);
   });
 });

--- a/tests/client/integration-wizard-push-support.test.ts
+++ b/tests/client/integration-wizard-push-support.test.ts
@@ -110,8 +110,10 @@ vi.mock("../../src/client/cowork/cowork-helpers", async (importOriginal) => {
   return { ...actual, isTauriRuntime: () => coworkStub.status !== null };
 });
 
-vi.mock("../../src/client/cowork/cowork-invoke", () => ({
-  TAURI_NOT_AVAILABLE: "Tauri runtime not available",
+// Spread, not re-declare — see `cowork-settings-mounted.test.ts` for the
+// subset-drift this avoids.
+vi.mock("../../src/client/cowork/cowork-invoke", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/cowork/cowork-invoke")>()),
   loadInvoke: vi.fn(async () => vi.fn()),
   coworkToggleIntegration: vi.fn(async () => ({ ok: true })),
   coworkPreflightSubnet: vi.fn(async () => ({ status: "unknown" })),
@@ -439,6 +441,44 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     (q(container, "integration-wizard-cowork-setup") as HTMLButtonElement).click();
     await tick();
     expect(q(container, "integration-wizard-plugin-copy-status")).toBeNull();
+
+    (q(container, "integration-wizard-cowork-back") as HTMLButtonElement).click();
+    await waitFor(() => {
+      expect(q(container, "integration-wizard-plugin-copy-status")).toBeTruthy();
+    });
+    expect(q(container, "integration-wizard-plugin-copy-status")?.textContent?.trim()).toBe("");
+  });
+
+  it("drops a copy result that lands after the user has left for the sub-view", async () => {
+    // The clear is synchronous and the write is two awaits later, so a clear
+    // alone cannot dominate an in-flight copy. Click Copy, click the Cowork row
+    // before the clipboard settles, and without the token the continuation
+    // writes "Copied" into an unmounted region — which then remounts holding
+    // it, which is the very thing the clear exists to prevent.
+    coworkStub.status = coworkStatusFixture();
+    let release: (() => void) | undefined;
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              release = resolve;
+            }),
+        ),
+      },
+    });
+    const { container } = mountPushMode(false);
+    await tick();
+
+    (q(container, "integration-wizard-plugin-copy") as HTMLButtonElement).click();
+    await tick();
+    (q(container, "integration-wizard-cowork-setup") as HTMLButtonElement).click();
+    await tick();
+
+    // The clipboard answers only now, with the block unmounted.
+    release?.();
+    await tick();
+    await tick();
 
     (q(container, "integration-wizard-cowork-back") as HTMLButtonElement).click();
     await waitFor(() => {

--- a/tests/client/integration-wizard-push-support.test.ts
+++ b/tests/client/integration-wizard-push-support.test.ts
@@ -257,6 +257,17 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
       expect(q(container, "integration-wizard-plugin-copy")).toBeTruthy();
     });
 
+    it(`names the plugin's version floor when the ${branch}`, async () => {
+      // `docs/cli.md` records the failure mode this prevents: below 2.1.212 the
+      // install succeeds and the monitor never runs, with nothing to say so. A
+      // wizard that recommends the plugin without the floor sends a desktop
+      // user to a silent no-op — and neither doc-contract test covers this
+      // file's prose, so the assertion has to live here.
+      const { container } = mountPushMode(registered);
+      await tick();
+      expect(q(container, "integration-wizard-push-mode")?.textContent ?? "").toContain("2.1.212");
+    });
+
     it(`does not tell the user to ask Claude to watch when the ${branch}`, async () => {
       // The watch is automatic on first Tandem use as of the ADR-049 amendment;
       // asking is a recovery step. `tests/docs/wake-availability-claims.test.ts`
@@ -303,7 +314,12 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     await tick();
 
     expect(writeText).toHaveBeenCalledWith(CLAUDE_PLUGIN_INSTALL_COMMANDS.join("\n"));
-    expect(q(container, "integration-wizard-plugin-copy")?.textContent?.trim()).toBe("Copied");
+    // The outcome is announced from a live region beside the button, not from
+    // the button's own label — a changed accessible name on a button nobody is
+    // focused on is announced by nothing.
+    const status = q(container, "integration-wizard-plugin-copy-status");
+    expect(status?.getAttribute("role")).toBe("status");
+    expect(status?.textContent?.trim()).toBe("Copied");
     vi.unstubAllGlobals();
   });
 
@@ -324,8 +340,8 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     await tick();
     await tick();
 
-    expect(q(container, "integration-wizard-plugin-copy")?.textContent ?? "").toMatch(
-      /Copy failed/i,
+    expect(q(container, "integration-wizard-plugin-copy-status")?.textContent ?? "").toMatch(
+      /Couldn't copy/i,
     );
     // The commands stay on screen to be selected by hand.
     expect(q(container, "integration-wizard-plugin-commands")?.textContent ?? "").toContain(

--- a/tests/client/integration-wizard-push-support.test.ts
+++ b/tests/client/integration-wizard-push-support.test.ts
@@ -23,6 +23,7 @@ import { cleanup, render } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { CLAUDE_PLUGIN_INSTALL_COMMANDS } from "../../src/shared/constants.js";
 import type { ApplyItemResult } from "../../src/shared/integrations/contract.js";
 
 // Mutable stubs the mocked hooks return; each test sets them BEFORE render.
@@ -181,6 +182,17 @@ describe("IntegrationWizardModal — per-target push support (#1299)", () => {
     expect(q(container, "integration-wizard-push-support-claude-code-1")).toBeNull();
   });
 
+  it("keeps the push-mode block off a stdio-only selection entirely", async () => {
+    // Guards the `whatsNext !== "stdio-only"` half of the gate: with only
+    // Claude Desktop picked, the per-row line is the whole story and a block of
+    // Claude Code push routes would be advice the user cannot act on.
+    wizardStub.channelRegistered = false;
+    const { container } = mountDone([pickedDesktop()], [applied("claude-desktop-1")]);
+    await tick();
+    expect(q(container, "integration-wizard-push-mode")).toBeNull();
+    expect(q(container, "integration-wizard-plugin")).toBeNull();
+  });
+
   it("says nothing on a row that did not apply", async () => {
     // An error row is about the write failing; leading with a delivery caveat
     // would bury the actionable problem under one the user cannot act on yet.
@@ -190,5 +202,135 @@ describe("IntegrationWizardModal — per-target push support (#1299)", () => {
     );
     await tick();
     expect(q(container, "integration-wizard-push-support-claude-desktop-1")).toBeNull();
+  });
+});
+
+/**
+ * The push-mode block's copy (#1389, #1390).
+ *
+ * #1389: the block has two branches keyed on whether the channel shim is
+ * registered, and the registered one used to drop the built-in Monitor watch
+ * entirely — reading as if the `--dangerously-load-development-channels` flag
+ * were the only route a hand-started session had. Registering the shim does not
+ * take the watch away, so the user who followed the wizard's own advice was the
+ * one who lost the free option.
+ *
+ * #1390: the two plugin install commands existed only as `tandem setup` console
+ * output, which a desktop-app user never sees — and the desktop app is the
+ * primary distribution channel. Tandem cannot run them either way (registering
+ * a marketplace is Claude Code's own trust boundary), so showing them IS the
+ * fix, and showing them in both branches is the part that keeps regressing.
+ */
+describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
+  afterEach(() => {
+    cleanup();
+    wizardStub.picked = [];
+    wizardStub.applyResults = [];
+    wizardStub.channelRegistered = null;
+    vi.clearAllMocks();
+  });
+
+  function mountPushMode(channelRegistered: boolean) {
+    wizardStub.channelRegistered = channelRegistered;
+    return mountDone([pickedCode()], [applied("claude-code-1")]);
+  }
+
+  for (const registered of [true, false]) {
+    const branch = registered ? "channel registered" : "channel not registered";
+
+    it(`names the built-in Monitor watch when the ${branch}`, async () => {
+      const { container } = mountPushMode(registered);
+      await tick();
+      const text = q(container, "integration-wizard-push-mode")?.textContent ?? "";
+      expect(text).toMatch(/built-in Monitor/i);
+      // The precondition, not just the option: it is granted per account, so a
+      // user told to use it without being told it may not be there reads a
+      // missing tool as Tandem being broken.
+      expect(text).toMatch(/per account/i);
+    });
+
+    it(`offers the plugin install commands when the ${branch}`, async () => {
+      const { container } = mountPushMode(registered);
+      await tick();
+      const commands = q(container, "integration-wizard-plugin-commands")?.textContent ?? "";
+      for (const cmd of CLAUDE_PLUGIN_INSTALL_COMMANDS) expect(commands).toContain(cmd);
+      expect(q(container, "integration-wizard-plugin-copy")).toBeTruthy();
+    });
+
+    it(`does not tell the user to ask Claude to watch when the ${branch}`, async () => {
+      // The watch is automatic on first Tandem use as of the ADR-049 amendment;
+      // asking is a recovery step. `tests/docs/wake-availability-claims.test.ts`
+      // bans this wording on README and the user guide — this wizard carries the
+      // same claim and was written before the correction.
+      const { container } = mountPushMode(registered);
+      await tick();
+      expect(q(container, "integration-wizard-push-mode")?.textContent ?? "").not.toMatch(
+        /ask Claude to watch/i,
+      );
+    });
+  }
+
+  it("keeps the flag as the registered branch's own instruction, with its argument", async () => {
+    // A bare `--dangerously-load-development-channels` does not enable the
+    // Tandem channel; it needs `server:tandem-channel` after it. The old copy
+    // named the flag alone, which is a command that silently does nothing.
+    const { container } = mountPushMode(true);
+    await tick();
+    const text = q(container, "integration-wizard-push-mode")?.textContent ?? "";
+    expect(text).toContain("--dangerously-load-development-channels server:tandem-channel");
+  });
+
+  it("points an unregistered user back here for the gate-independent route", async () => {
+    const { container } = mountPushMode(false);
+    await tick();
+    const text = q(container, "integration-wizard-push-mode")?.textContent ?? "";
+    expect(text).toMatch(/channel shim/i);
+    // Not merely mentioned — offered as the answer to both Monitor gates being
+    // shut, which is the only thing that makes it worth a flag on every session.
+    expect(text).toMatch(/neither gate|no Monitor tool/i);
+  });
+
+  it("copies both commands as one pasteable block", async () => {
+    const writeText = vi.fn(async () => {});
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const { container } = mountPushMode(false);
+    await tick();
+
+    (q(container, "integration-wizard-plugin-copy") as HTMLButtonElement).click();
+    // Two ticks: the label is written after an awaited `writeText`, so it lands
+    // a microtask after the click's own flush.
+    await tick();
+    await tick();
+
+    expect(writeText).toHaveBeenCalledWith(CLAUDE_PLUGIN_INSTALL_COMMANDS.join("\n"));
+    expect(q(container, "integration-wizard-plugin-copy")?.textContent?.trim()).toBe("Copied");
+    vi.unstubAllGlobals();
+  });
+
+  it("says so on the button when the clipboard refuses", async () => {
+    // The WebView denies clipboard access in more situations than it grants it,
+    // and a silent no-op button is indistinguishable from a copy that worked.
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn(async () => {
+          throw new Error("denied");
+        }),
+      },
+    });
+    const { container } = mountPushMode(false);
+    await tick();
+
+    (q(container, "integration-wizard-plugin-copy") as HTMLButtonElement).click();
+    await tick();
+    await tick();
+
+    expect(q(container, "integration-wizard-plugin-copy")?.textContent ?? "").toMatch(
+      /Copy failed/i,
+    );
+    // The commands stay on screen to be selected by hand.
+    expect(q(container, "integration-wizard-plugin-commands")?.textContent ?? "").toContain(
+      CLAUDE_PLUGIN_INSTALL_COMMANDS[0],
+    );
+    vi.unstubAllGlobals();
   });
 });

--- a/tests/client/integration-wizard-push-support.test.ts
+++ b/tests/client/integration-wizard-push-support.test.ts
@@ -416,6 +416,7 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
         }),
       },
     });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { container } = mountPushMode(false);
     await tick();
 
@@ -425,6 +426,11 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     expect(q(container, "integration-wizard-plugin-commands")?.textContent ?? "").toContain(
       CLAUDE_PLUGIN_INSTALL_COMMANDS[0],
     );
+    // The user-facing string is the same for every clipboard failure, so the log
+    // is the only thing that separates a denied permission from a missing API
+    // from a CSP rejection. Without this the catch could stop logging and
+    // nothing would notice.
+    expect(warn).toHaveBeenCalledWith("[wizard] clipboard write failed:", expect.any(Error));
   });
 
   it("does not carry a copy status back from the Cowork sub-view", async () => {
@@ -481,6 +487,36 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     await tick();
 
     (q(container, "integration-wizard-cowork-back") as HTMLButtonElement).click();
+    await waitFor(() => {
+      expect(q(container, "integration-wizard-plugin-copy-status")).toBeTruthy();
+    });
+    expect(q(container, "integration-wizard-plugin-copy-status")?.textContent?.trim()).toBe("");
+  });
+
+  it("does not carry a copy status through a retry either", async () => {
+    // `retryDetection` resets the status for the same reason `openCoworkView`
+    // does — `wizard.reset()` takes `step` out of "done", which is what the
+    // push-routes block gates on, so the block unmounts and would remount
+    // holding "Copied". Its comment claimed parity with `openCoworkView`; the
+    // tests did not, and deleting both lines here left the suite green.
+    vi.stubGlobal("navigator", { clipboard: { writeText: vi.fn(async () => {}) } });
+    wizardStub.channelRegistered = false;
+    // One error alongside the applied target, so the done step offers "Try
+    // again" while the push-routes block is still on screen.
+    const { container } = mountDone(
+      [pickedCode(), pickedDesktop()],
+      [applied("claude-code-1"), { id: "claude-desktop-1", status: "error", error: "nope" }],
+    );
+    await tick();
+
+    await clickCopy(container, /Copied/);
+
+    (q(container, "integration-wizard-done-retry") as HTMLButtonElement).click();
+    await tick();
+
+    // Back to "done" the way the wizard gets there, and the region must be
+    // empty rather than remounting with its old text.
+    wizardStub.step = "done";
     await waitFor(() => {
       expect(q(container, "integration-wizard-plugin-copy-status")).toBeTruthy();
     });

--- a/tests/client/network-settings-autostart.test.ts
+++ b/tests/client/network-settings-autostart.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+
+/**
+ * The start-at-login checkbox, actually rendered.
+ *
+ * `useAutostart.svelte.test.ts` covers the hook — that a virtualized or blocked
+ * write leaves `status.enabled` where it was and reports why. What it cannot
+ * cover is the consequence at the DOM: `checked={autostartStatus.enabled}` is
+ * one-way, and Svelte skips the write whenever the expression re-computes to
+ * the value it last wrote. So the honest status the hook works hard to produce
+ * is exactly the case where the CONTROL lies — the box keeps the position the
+ * user's click gave it, over a setting that never moved, with only an error
+ * line beneath it to disagree.
+ *
+ * This is the same defect measured on Cowork's two toggles (#1375); the third
+ * instance lived here and was found by reviewing that fix. See
+ * `src/client/utils/checkbox-sync.ts`.
+ */
+
+import { render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TandemSettings } from "../../src/client/hooks/useTandemSettings.svelte";
+import type { AutostartStatus } from "../../src/client/tauri/autostart-invoke";
+
+/** What the OS reports. Mutated per-test; the mocked hook reads it live. */
+let osStatus: AutostartStatus = { enabled: false, trayAvailable: true, error: null };
+let toggleError: string | null = null;
+
+const toggle = vi.fn(async (_next: boolean) => {
+  // The shape that matters: a write the OS refused or virtualized away leaves
+  // `status` untouched. `next` is deliberately ignored.
+});
+
+vi.mock("../../src/client/hooks/useAutostart.svelte.js", () => ({
+  createAutostart: () => ({
+    get status() {
+      return osStatus;
+    },
+    get error() {
+      return toggleError;
+    },
+    loading: false,
+    toggle,
+  }),
+}));
+
+vi.mock("../../src/client/cowork/cowork-helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/cowork/cowork-helpers")>()),
+  isTauriRuntime: () => true,
+}));
+
+vi.mock("../../src/client/hooks/useAppInfo.svelte.js", () => ({
+  createAppInfo: () => ({ info: null, loading: false, error: null }),
+}));
+
+import NetworkSettings from "../../src/client/components/NetworkSettings.svelte";
+
+function mount() {
+  const { container } = render(NetworkSettings, {
+    props: {
+      open: true,
+      settings: {
+        degradedBannerDelayMs: 30000,
+        sidecarRetryStrategy: "exponential",
+      } as TandemSettings,
+      onUpdate: vi.fn(),
+      connected: true,
+      reconnectAttempts: 0,
+      readOnly: false,
+      notify: vi.fn(),
+    },
+  });
+  const box = container.querySelector<HTMLInputElement>(
+    "[data-testid='network-autostart-toggle']",
+  ) as HTMLInputElement;
+  return { container, box };
+}
+
+async function clickToggle(box: HTMLInputElement, checked: boolean): Promise<void> {
+  box.checked = checked;
+  box.dispatchEvent(new Event("change", { bubbles: true }));
+  await tick();
+}
+
+describe("NetworkSettings — start-at-login toggle", () => {
+  beforeEach(() => {
+    osStatus = { enabled: false, trayAvailable: true, error: null };
+    toggleError = null;
+    toggle.mockClear();
+  });
+
+  it("puts the box back when the OS did not take the write", async () => {
+    const { box } = mount();
+    await tick();
+    expect(box.checked).toBe(false);
+
+    await clickToggle(box, true);
+
+    expect(toggle).toHaveBeenCalledWith(true);
+    // `osStatus.enabled` never moved, so the expression re-computes to `false`
+    // — the value Svelte last wrote — and the DOM write is skipped. Without an
+    // explicit resync the box stays checked over a login item that does not
+    // exist.
+    await waitFor(() => expect(box.checked).toBe(false), { interval: 5 });
+  });
+
+  it("leaves the box on when the OS confirms the write", async () => {
+    const { box } = mount();
+    await tick();
+
+    toggle.mockImplementationOnce(async () => {
+      osStatus = { ...osStatus, enabled: true };
+    });
+    await clickToggle(box, true);
+
+    await waitFor(() => expect(box.checked).toBe(true), { interval: 5 });
+  });
+
+  it("puts the box back when un-checking fails too", async () => {
+    // The disable half, which on Cowork was the one that produced an
+    // unrecoverable control.
+    osStatus = { enabled: true, trayAvailable: true, error: null };
+    const { box } = mount();
+    await tick();
+    expect(box.checked).toBe(true);
+
+    await clickToggle(box, false);
+
+    expect(toggle).toHaveBeenCalledWith(false);
+    await waitFor(() => expect(box.checked).toBe(true), { interval: 5 });
+  });
+});

--- a/tests/client/network-settings-autostart.test.ts
+++ b/tests/client/network-settings-autostart.test.ts
@@ -15,28 +15,33 @@
  * This is the same defect measured on Cowork's two toggles (#1375); the third
  * instance lived here and was found by reviewing that fix. See
  * `src/client/utils/checkbox-sync.ts`.
+ *
+ * The status lives in a `$state` cell rather than a module `let` — the first
+ * version of this file used a `let` and it made a test pass that could not
+ * fail. See `../helpers/autostart-status-cell.svelte`.
  */
 
-import { render, waitFor } from "@testing-library/svelte";
+import { cleanup, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TandemSettings } from "../../src/client/hooks/useTandemSettings.svelte";
-import type { AutostartStatus } from "../../src/client/tauri/autostart-invoke";
+import { autostartStatusCell } from "../helpers/autostart-status-cell.svelte";
 
-/** What the OS reports. Mutated per-test; the mocked hook reads it live. */
-let osStatus: AutostartStatus = { enabled: false, trayAvailable: true, error: null };
 let toggleError: string | null = null;
 
-const toggle = vi.fn(async (_next: boolean) => {
-  // The shape that matters: a write the OS refused or virtualized away leaves
-  // `status` untouched. `next` is deliberately ignored.
-});
+/**
+ * The OS write. Default: it fails to commit — the write is refused or
+ * virtualized away, so `status` is left exactly as it was. That is the shape
+ * `resyncCheckbox` exists for, and making it the default keeps each test's
+ * setup to the ONE thing it varies.
+ */
+const toggle = vi.fn(async (_next: boolean) => {});
 
 vi.mock("../../src/client/hooks/useAutostart.svelte.js", () => ({
   createAutostart: () => ({
     get status() {
-      return osStatus;
+      return autostartStatusCell.value;
     },
     get error() {
       return toggleError;
@@ -78,17 +83,44 @@ function mount() {
   return { container, box };
 }
 
+/** Move the box the way a user does: mutate `.checked`, then fire `change`. */
 async function clickToggle(box: HTMLInputElement, checked: boolean): Promise<void> {
   box.checked = checked;
   box.dispatchEvent(new Event("change", { bubbles: true }));
   await tick();
 }
 
+// FILE scope. `autostartStatusCell` is module state, and without an explicit
+// `cleanup()` Testing Library's auto-cleanup never registers here (it hooks
+// `afterEach` only under `globals: true`, which this project does not set), so
+// mounts would otherwise accumulate across the file.
+beforeEach(() => {
+  autostartStatusCell.reset();
+  toggleError = null;
+  toggle.mockReset();
+  toggle.mockImplementation(async () => {});
+});
+
+afterEach(() => {
+  cleanup();
+});
+
 describe("NetworkSettings — start-at-login toggle", () => {
-  beforeEach(() => {
-    osStatus = { enabled: false, trayAvailable: true, error: null };
-    toggleError = null;
-    toggle.mockClear();
+  it("follows the OS when the status changes with no click at all", async () => {
+    // The binding must be live. Every other test here reads `box.checked` after
+    // a click, and a click sets `.checked` by itself — so if the mocked status
+    // were inert (a plain module `let`, which is what this file used to do)
+    // those assertions would pass with the production resync deleted. This is
+    // the one test that can only pass if Svelte's own write is running, and it
+    // is the reason the others mean anything. The real hook does exactly this
+    // on a Settings reopen.
+    const { box } = mount();
+    await tick();
+    expect(box.checked).toBe(false);
+
+    autostartStatusCell.patch({ enabled: true });
+
+    await waitFor(() => expect(box.checked).toBe(true), { interval: 5 });
   });
 
   it("puts the box back when the OS did not take the write", async () => {
@@ -99,29 +131,17 @@ describe("NetworkSettings — start-at-login toggle", () => {
     await clickToggle(box, true);
 
     expect(toggle).toHaveBeenCalledWith(true);
-    // `osStatus.enabled` never moved, so the expression re-computes to `false`
-    // — the value Svelte last wrote — and the DOM write is skipped. Without an
+    // `enabled` never moved, so the expression re-computes to `false` — the
+    // value Svelte last wrote — and the DOM write is skipped. Without an
     // explicit resync the box stays checked over a login item that does not
     // exist.
     await waitFor(() => expect(box.checked).toBe(false), { interval: 5 });
   });
 
-  it("leaves the box on when the OS confirms the write", async () => {
-    const { box } = mount();
-    await tick();
-
-    toggle.mockImplementationOnce(async () => {
-      osStatus = { ...osStatus, enabled: true };
-    });
-    await clickToggle(box, true);
-
-    await waitFor(() => expect(box.checked).toBe(true), { interval: 5 });
-  });
-
   it("puts the box back when un-checking fails too", async () => {
     // The disable half, which on Cowork was the one that produced an
     // unrecoverable control.
-    osStatus = { enabled: true, trayAvailable: true, error: null };
+    autostartStatusCell.patch({ enabled: true });
     const { box } = mount();
     await tick();
     expect(box.checked).toBe(true);
@@ -130,5 +150,38 @@ describe("NetworkSettings — start-at-login toggle", () => {
 
     expect(toggle).toHaveBeenCalledWith(false);
     await waitFor(() => expect(box.checked).toBe(true), { interval: 5 });
+  });
+
+  it("leaves the box on when the OS confirms the write", async () => {
+    const { box } = mount();
+    await tick();
+
+    // Deferred rather than resolving inline: with a mock that settles in the
+    // same microtask, dropping the `await` in `toggleAutostart` still passes.
+    // The gap is what makes the resync's ORDERING observable.
+    let release!: () => void;
+    const committed = new Promise<void>((r) => {
+      release = r;
+    });
+    toggle.mockImplementationOnce(async () => {
+      await committed;
+      autostartStatusCell.patch({ enabled: true });
+    });
+
+    await clickToggle(box, true);
+    // Ordering, not timing: while the write is still in flight the resync must
+    // not have run. Drop the `await` in `toggleAutostart` and it runs here
+    // instead, reading the PRE-write status and snapping the box back to
+    // `false` under the user before the commit lands. The deferred promise is
+    // what makes that deterministic rather than a race.
+    expect(box.checked).toBe(true);
+
+    release();
+
+    await waitFor(() => expect(box.checked).toBe(true), { interval: 5 });
+    // And it stays on: the resync must not read the pre-write status and undo
+    // a commit that succeeded.
+    await tick();
+    expect(box.checked).toBe(true);
   });
 });

--- a/tests/client/settings-claude-code-tab-cowork.test.ts
+++ b/tests/client/settings-claude-code-tab-cowork.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+
+/**
+ * The Settings → AI Assistant tab actually reaching CoworkSettings (#1375).
+ *
+ * `tests/client/SettingsClaudeCodeTab.test.ts` mounts this parent already, but
+ * under happy-dom `isTauriRuntime()` is false, so the lazy
+ * `{#await import("../CoworkSettings.svelte")}` branch never ran and the whole
+ * Cowork surface was one un-taken `{#if}` away from every test in the repo.
+ * The sibling mount suites cover the child in isolation; this file covers the
+ * seam — that the desktop build renders it here at all, and that the browser
+ * build still does not.
+ *
+ * Separate from `SettingsClaudeCodeTab.test.ts` on purpose: `isTauriRuntime` is
+ * mocked at module scope, which that file's #1022 assertions must not inherit.
+ */
+
+import { render, waitFor } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TandemSettings } from "../../src/client/hooks/useTandemSettings.svelte";
+
+let tauri = true;
+
+vi.mock("../../src/client/cowork/cowork-helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/client/cowork/cowork-helpers")>();
+  return { ...actual, isTauriRuntime: () => tauri };
+});
+
+// CoworkSettings calls `createCoworkStatus(() => true)` at mount, which holds an
+// `$effect` and a real invoke — unmocked, arriving here hits the network.
+vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
+  createCoworkStatus: () => ({
+    status: {
+      osSupported: true,
+      coworkDetected: true,
+      enabled: false,
+      vethernetCidr: null,
+      lanIpFallback: null,
+      useLanIpOverride: false,
+      workspaces: [],
+      uacDeclined: false,
+      uacDeclinedAt: null,
+    },
+    loading: false,
+    error: null,
+    refetch: vi.fn(async () => {}),
+  }),
+}));
+
+vi.mock("../../src/client/cowork/cowork-invoke", () => ({
+  TAURI_NOT_AVAILABLE: "Tauri runtime not available",
+  loadInvoke: vi.fn(async () => vi.fn()),
+  coworkToggleIntegration: vi.fn(async () => ({ ok: true })),
+  coworkPreflightSubnet: vi.fn(async () => ({ status: "unknown" })),
+  coworkRescan: vi.fn(async () => {}),
+  coworkSetLanIpOverride: vi.fn(async () => {}),
+}));
+
+import SettingsClaudeCodeTab from "../../src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte";
+
+function makeProps() {
+  return {
+    open: true,
+    settings: {
+      selectionDwellMs: 1000,
+      selectionToolbar: true,
+      marginView: false,
+    } as TandemSettings,
+    onUpdate: vi.fn(),
+    connected: true,
+    reconnectAttempts: 0,
+    readOnly: false,
+    notify: vi.fn(),
+  };
+}
+
+const byTestId = (container: HTMLElement, id: string) =>
+  container.querySelector<HTMLElement>(`[data-testid='${id}']`);
+
+describe("SettingsClaudeCodeTab — Cowork section (#1375)", () => {
+  afterEach(() => {
+    tauri = true;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders CoworkSettings in the desktop app", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ integrations: [] }) }),
+    );
+    const { container } = render(SettingsClaudeCodeTab, { props: makeProps() });
+
+    // `waitFor`, not ticks: the branch is a dynamic `import()`, so the child
+    // arrives a module-load later than any number of Svelte flushes.
+    await waitFor(() => {
+      expect(byTestId(container, "cowork-settings")).toBeTruthy();
+    });
+    expect(byTestId(container, "cowork-toggle-checkbox")).toBeTruthy();
+  });
+
+  it("renders nothing Cowork-shaped in the browser build", async () => {
+    // The negative half matters as much: Cowork's enable path is Windows- and
+    // Tauri-only, and `tests/e2e/integration-wizard.spec.ts` asserts count 0 in
+    // a real browser. This pins the gate that makes that true.
+    tauri = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ integrations: [] }) }),
+    );
+    const { container } = render(SettingsClaudeCodeTab, { props: makeProps() });
+
+    await waitFor(() => {
+      expect(byTestId(container, "settings-modal-open-integration-wizard")).toBeTruthy();
+    });
+    expect(byTestId(container, "cowork-settings")).toBeNull();
+    expect(byTestId(container, "settings-modal-cowork-suspense-fallback")).toBeNull();
+  });
+});

--- a/tests/client/settings-claude-code-tab-cowork.test.ts
+++ b/tests/client/settings-claude-code-tab-cowork.test.ts
@@ -18,6 +18,7 @@
 import { render, waitFor } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TandemSettings } from "../../src/client/hooks/useTandemSettings.svelte";
+import { coworkStatusFixture } from "../helpers/cowork-fixtures.svelte";
 
 let tauri = true;
 
@@ -30,17 +31,7 @@ vi.mock("../../src/client/cowork/cowork-helpers", async (importOriginal) => {
 // `$effect` and a real invoke — unmocked, arriving here hits the network.
 vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
   createCoworkStatus: () => ({
-    status: {
-      osSupported: true,
-      coworkDetected: true,
-      enabled: false,
-      vethernetCidr: null,
-      lanIpFallback: null,
-      useLanIpOverride: false,
-      workspaces: [],
-      uacDeclined: false,
-      uacDeclinedAt: null,
-    },
+    status: coworkStatusFixture({ vethernetCidr: null }),
     loading: false,
     error: null,
     refetch: vi.fn(async () => {}),

--- a/tests/client/settings-claude-code-tab-cowork.test.ts
+++ b/tests/client/settings-claude-code-tab-cowork.test.ts
@@ -18,7 +18,7 @@
 import { render, waitFor } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TandemSettings } from "../../src/client/hooks/useTandemSettings.svelte";
-import { coworkStatusFixture } from "../helpers/cowork-fixtures.svelte";
+import { coworkStatusFixture } from "../helpers/cowork-status-fixture";
 
 let tauri = true;
 
@@ -38,13 +38,12 @@ vi.mock("../../src/client/hooks/useCoworkStatus.svelte", () => ({
   }),
 }));
 
-vi.mock("../../src/client/cowork/cowork-invoke", () => ({
-  TAURI_NOT_AVAILABLE: "Tauri runtime not available",
+// Spread, not re-declare — see `cowork-settings-mounted.test.ts`.
+vi.mock("../../src/client/cowork/cowork-invoke", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/cowork/cowork-invoke")>()),
   loadInvoke: vi.fn(async () => vi.fn()),
   coworkToggleIntegration: vi.fn(async () => ({ ok: true })),
   coworkPreflightSubnet: vi.fn(async () => ({ status: "unknown" })),
-  coworkRescan: vi.fn(async () => {}),
-  coworkSetLanIpOverride: vi.fn(async () => {}),
 }));
 
 import SettingsClaudeCodeTab from "../../src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte";

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -81,10 +81,12 @@ cowork-onboarding-error
 cowork-onboarding-learn-more-btn
 cowork-onboarding-learn-more-link
 cowork-onboarding-preflight-blocked
+cowork-onboarding-preflight-live
 cowork-onboarding-preflight-retry-btn
 cowork-onboarding-skip-btn
 cowork-onboarding-step
 cowork-preflight-blocked
+cowork-preflight-live
 cowork-preflight-retry-btn
 cowork-reachability
 cowork-rescan-btn
@@ -208,6 +210,7 @@ integration-wizard-cowork-back
 integration-wizard-cowork-error
 integration-wizard-cowork-explainer
 integration-wizard-cowork-preflight-blocked
+integration-wizard-cowork-preflight-live
 integration-wizard-cowork-preflight-retry-btn
 integration-wizard-cowork-setup
 integration-wizard-cowork-step
@@ -222,6 +225,9 @@ integration-wizard-keychain-fallback
 integration-wizard-models-setup
 integration-wizard-more
 integration-wizard-pick-{*}
+integration-wizard-plugin
+integration-wizard-plugin-commands
+integration-wizard-plugin-copy
 integration-wizard-push-mode
 integration-wizard-push-support-{*}
 integration-wizard-reachability-{*}

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -228,6 +228,7 @@ integration-wizard-pick-{*}
 integration-wizard-plugin
 integration-wizard-plugin-commands
 integration-wizard-plugin-copy
+integration-wizard-plugin-copy-status
 integration-wizard-push-mode
 integration-wizard-push-support-{*}
 integration-wizard-reachability-{*}

--- a/tests/helpers/autostart-status-cell.svelte.ts
+++ b/tests/helpers/autostart-status-cell.svelte.ts
@@ -1,0 +1,33 @@
+import type { AutostartStatus } from "../../src/client/tauri/autostart-invoke";
+
+/**
+ * A reactive stand-in for `createAutostart`'s `status`.
+ *
+ * Same reason as [`coworkStatusCell`](./cowork-fixtures.svelte.ts), and the
+ * first version of `network-settings-autostart.test.ts` made the mistake that
+ * helper warns about: a plain module `let` behind a getter creates no reactive
+ * dependency, so `$derived(autostart.status)` in `NetworkSettings.svelte` never
+ * invalidates and Svelte's `set_checked` never runs at all.
+ *
+ * That direction of falseness is the dangerous one. It does not weaken an
+ * assertion, it makes a broken component PASS: with the binding inert, a test
+ * asserting `box.checked === true` after clicking the box to `true` is
+ * satisfied by the click alone, and deleting the production `resyncCheckbox`
+ * call leaves it green. Measured — that is exactly what happened here.
+ *
+ * One cell per module, reset in a FILE-level `beforeEach`.
+ */
+let current = $state<AutostartStatus>({ enabled: false, trayAvailable: true, error: null });
+
+export const autostartStatusCell = {
+  get value(): AutostartStatus {
+    return current;
+  },
+  /** Commit a change the way the OS read-back does: set it, then report it. */
+  patch(overrides: Partial<AutostartStatus>): void {
+    current = { ...current, ...overrides };
+  },
+  reset(): void {
+    current = { enabled: false, trayAvailable: true, error: null };
+  },
+};

--- a/tests/helpers/cowork-fixtures.svelte.ts
+++ b/tests/helpers/cowork-fixtures.svelte.ts
@@ -35,3 +35,26 @@ export const coworkStatusCell = {
     current = coworkStatusFixture();
   },
 };
+
+/**
+ * `createCoworkStatus`'s `error`, and reactive for the same reason as the
+ * status above.
+ *
+ * `refetch` sets this instead of throwing, so the surface's error banner is the
+ * only thing that can report a failed re-read. A frozen `let` here makes that
+ * banner untestable in the direction that matters — it can never appear, so a
+ * test asserting it does will fail against correct code.
+ */
+let currentError = $state<string | null>(null);
+
+export const coworkErrorCell = {
+  get value(): string | null {
+    return currentError;
+  },
+  set(next: string | null): void {
+    currentError = next;
+  },
+  reset(): void {
+    currentError = null;
+  },
+};

--- a/tests/helpers/cowork-fixtures.svelte.ts
+++ b/tests/helpers/cowork-fixtures.svelte.ts
@@ -1,29 +1,10 @@
 import type { CoworkStatus } from "../../src/client/types";
+import { coworkStatusFixture } from "./cowork-status-fixture";
 
-/**
- * A `CoworkStatus` in the state the Enable surfaces actually render: Windows,
- * Cowork detected, integration OFF. That is the only combination under which
- * the toggle, the confirm and the pre-flight all exist, so every mounted Cowork
- * suite needs it and they had each written their own nine-field literal.
- *
- * `CoworkStatus` carries optional fields (`claudeDesktopDetected`,
- * `workspacesBlocked`), so a hand-written literal that omits them typechecks
- * and then quietly stops representing the shape when a required field lands.
- */
-export function coworkStatusFixture(overrides: Partial<CoworkStatus> = {}): CoworkStatus {
-  return {
-    osSupported: true,
-    coworkDetected: true,
-    enabled: false,
-    vethernetCidr: "172.30.16.0/28",
-    lanIpFallback: null,
-    useLanIpOverride: false,
-    workspaces: [],
-    uacDeclined: false,
-    uacDeclinedAt: null,
-    ...overrides,
-  };
-}
+// Re-exported so a client suite needs one import, not two. The factory itself
+// lives in a plain `.ts` — see that file for why a `.svelte.ts` cannot be
+// imported from the `node` vitest project.
+export { coworkStatusFixture };
 
 /**
  * A reactive stand-in for `createCoworkStatus`'s `status`.
@@ -36,8 +17,10 @@ export function coworkStatusFixture(overrides: Partial<CoworkStatus> = {}): Cowo
  * `enabled: false` — so a correct component fails the assertion. Measured;
  * that is exactly what the first version of this helper did.
  *
- * One cell per module, reset in `beforeEach`. The surfaces under test mount one
- * `CoworkSettings` at a time, so there is nothing to key it by.
+ * One cell per module, reset in a FILE-level `beforeEach`. Per-describe is not
+ * enough: `enableSucceeds()`-style helpers mutate this cell, so a sibling
+ * describe inherits whatever the previous one left and its isolation becomes a
+ * property of test ordering.
  */
 let current = $state(coworkStatusFixture());
 

--- a/tests/helpers/cowork-fixtures.svelte.ts
+++ b/tests/helpers/cowork-fixtures.svelte.ts
@@ -1,0 +1,55 @@
+import type { CoworkStatus } from "../../src/client/types";
+
+/**
+ * A `CoworkStatus` in the state the Enable surfaces actually render: Windows,
+ * Cowork detected, integration OFF. That is the only combination under which
+ * the toggle, the confirm and the pre-flight all exist, so every mounted Cowork
+ * suite needs it and they had each written their own nine-field literal.
+ *
+ * `CoworkStatus` carries optional fields (`claudeDesktopDetected`,
+ * `workspacesBlocked`), so a hand-written literal that omits them typechecks
+ * and then quietly stops representing the shape when a required field lands.
+ */
+export function coworkStatusFixture(overrides: Partial<CoworkStatus> = {}): CoworkStatus {
+  return {
+    osSupported: true,
+    coworkDetected: true,
+    enabled: false,
+    vethernetCidr: "172.30.16.0/28",
+    lanIpFallback: null,
+    useLanIpOverride: false,
+    workspaces: [],
+    uacDeclined: false,
+    uacDeclinedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * A reactive stand-in for `createCoworkStatus`'s `status`.
+ *
+ * `.svelte.ts` and `$state` rather than a plain module `let`, because the real
+ * hook's status IS reactive and a frozen one produces a FALSE result, not
+ * merely a weak one: with a plain variable, flipping `enabled` in a `refetch`
+ * mock never re-renders, `{@const s = coworkState.status}` keeps the stale
+ * object, and the toggle's `checked` expression then evaluates against
+ * `enabled: false` — so a correct component fails the assertion. Measured;
+ * that is exactly what the first version of this helper did.
+ *
+ * One cell per module, reset in `beforeEach`. The surfaces under test mount one
+ * `CoworkSettings` at a time, so there is nothing to key it by.
+ */
+let current = $state(coworkStatusFixture());
+
+export const coworkStatusCell = {
+  get value(): CoworkStatus {
+    return current;
+  },
+  /** Commit a change the way the Rust side does: toggle, then report it. */
+  patch(overrides: Partial<CoworkStatus>): void {
+    current = { ...current, ...overrides };
+  },
+  reset(): void {
+    current = coworkStatusFixture();
+  },
+};

--- a/tests/helpers/cowork-fixtures.svelte.ts
+++ b/tests/helpers/cowork-fixtures.svelte.ts
@@ -1,10 +1,9 @@
 import type { CoworkStatus } from "../../src/client/types";
 import { coworkStatusFixture } from "./cowork-status-fixture";
 
-// Re-exported so a client suite needs one import, not two. The factory itself
-// lives in a plain `.ts` — see that file for why a `.svelte.ts` cannot be
-// imported from the `node` vitest project.
-export { coworkStatusFixture };
+// Deliberately NOT re-exported: `coworkStatusFixture` has one home, and a
+// second door here would defeat the split that put it in a plain `.ts`. Import
+// it from `./cowork-status-fixture` directly.
 
 /**
  * A reactive stand-in for `createCoworkStatus`'s `status`.

--- a/tests/helpers/cowork-status-fixture.ts
+++ b/tests/helpers/cowork-status-fixture.ts
@@ -7,14 +7,19 @@ import type { CoworkStatus } from "../../src/client/types";
  * suite needs it and they had each written their own nine-field literal.
  *
  * Deliberately a plain `.ts`, split from the reactive cell in
- * `cowork-fixtures.svelte.ts`. `vitest.config.ts` gives the svelte plugin to
- * the `client` project only, so a `.svelte.ts` import from anywhere else in
- * `tests/` fails with `rune_outside_svelte` — in a test that never touches
- * reactivity. Every consumer today is in `tests/client/` and would be fine
- * either way; this is cheap insurance for the first contract or server test
- * that wants a `CoworkStatus`, not a constraint anything currently hits. The
- * alternative — giving the `node` project the svelte plugin — changes the
- * transform pipeline for every server and CLI test to buy the same thing.
+ * `cowork-fixtures.svelte.ts`. Measured, not assumed: importing a `.svelte.ts`
+ * from a `tests/` file outside `tests/client/` fails with `ReferenceError:
+ * $state is not defined` — in a test that never touches reactivity. Note
+ * `vitest.config.ts` DOES declare the svelte plugin at the root as well as on
+ * the `client` project; the root declaration simply does not reach the `node`
+ * project's transform, which is why the split is about where a file lives
+ * rather than about the config growing a plugin.
+ *
+ * Every consumer today is in `tests/client/` and would be fine either way; this
+ * is cheap insurance for the first contract or server test that wants a
+ * `CoworkStatus`, not a constraint anything currently hits. The alternative —
+ * giving the `node` project the svelte plugin — changes the transform pipeline
+ * for every server and CLI test to buy the same thing.
  *
  * Import it from HERE, not through the `.svelte.ts`. One symbol, one path.
  *

--- a/tests/helpers/cowork-status-fixture.ts
+++ b/tests/helpers/cowork-status-fixture.ts
@@ -7,11 +7,16 @@ import type { CoworkStatus } from "../../src/client/types";
  * suite needs it and they had each written their own nine-field literal.
  *
  * Deliberately a plain `.ts`, split from the reactive cell in
- * `cowork-fixtures.svelte.ts`: `vitest.config.ts` gives the svelte plugin to
- * the `client` project only, so anything under `tests/` outside `tests/client/`
- * that imported a `.svelte.ts` would fail at import with `rune_outside_svelte`
- * — in a test that never touches reactivity. This factory is the half a
- * contract or server test would plausibly want.
+ * `cowork-fixtures.svelte.ts`. `vitest.config.ts` gives the svelte plugin to
+ * the `client` project only, so a `.svelte.ts` import from anywhere else in
+ * `tests/` fails with `rune_outside_svelte` — in a test that never touches
+ * reactivity. Every consumer today is in `tests/client/` and would be fine
+ * either way; this is cheap insurance for the first contract or server test
+ * that wants a `CoworkStatus`, not a constraint anything currently hits. The
+ * alternative — giving the `node` project the svelte plugin — changes the
+ * transform pipeline for every server and CLI test to buy the same thing.
+ *
+ * Import it from HERE, not through the `.svelte.ts`. One symbol, one path.
  *
  * The optional fields are set rather than omitted. Omitting them sends every
  * mounted suite down the `undefined` branch of `undetectedDetail` /

--- a/tests/helpers/cowork-status-fixture.ts
+++ b/tests/helpers/cowork-status-fixture.ts
@@ -1,0 +1,43 @@
+import type { CoworkStatus } from "../../src/client/types";
+
+/**
+ * A `CoworkStatus` in the state the Enable surfaces actually render: Windows,
+ * Cowork detected, integration OFF. That is the only combination under which
+ * the toggle, the confirm and the pre-flight all exist, so every mounted Cowork
+ * suite needs it and they had each written their own nine-field literal.
+ *
+ * Deliberately a plain `.ts`, split from the reactive cell in
+ * `cowork-fixtures.svelte.ts`: `vitest.config.ts` gives the svelte plugin to
+ * the `client` project only, so anything under `tests/` outside `tests/client/`
+ * that imported a `.svelte.ts` would fail at import with `rune_outside_svelte`
+ * — in a test that never touches reactivity. This factory is the half a
+ * contract or server test would plausibly want.
+ *
+ * The optional fields are set rather than omitted. Omitting them sends every
+ * mounted suite down the `undefined` branch of `undetectedDetail` /
+ * `coworkSettingsVariant` at once, so the `blocked` and `noWorkspacesYet` arms
+ * are reached by no test — and centralising the omission makes that uniform
+ * instead of merely likely. Note this file cannot catch shape DRIFT: no
+ * tsconfig covers `tests/` (`tsconfig.json` includes only `src`) and vitest
+ * transpiles without checking, so a new required field lands as `undefined`
+ * here with nothing to complain. The win is one place to fix, not a guarantee.
+ */
+export function coworkStatusFixture(overrides: Partial<CoworkStatus> = {}): CoworkStatus {
+  return {
+    osSupported: true,
+    coworkDetected: true,
+    enabled: false,
+    vethernetCidr: "172.30.16.0/28",
+    lanIpFallback: null,
+    useLanIpOverride: false,
+    workspaces: [],
+    uacDeclined: false,
+    uacDeclinedAt: null,
+    claudeDesktopDetected: true,
+    // A COUNT, not a flag — `workspacesBlocked?: number`. Zero is "scanned,
+    // none blocked", which is what an empty `workspaces` list means here.
+    workspacesBlocked: 0,
+    workspacesLastScannedAt: null,
+    ...overrides,
+  };
+}

--- a/tests/plugin-manifest.test.ts
+++ b/tests/plugin-manifest.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { CLAUDE_PLUGIN_INSTALL_COMMANDS } from "../src/shared/constants.js";
 
 // Guards against the published Claude Code plugin manifest drifting out of
 // sync with the npm package — historically `plugin.json` was left at 0.8.0
@@ -66,6 +67,21 @@ describe("published Claude Code plugin manifest", () => {
     const tandem = plugins.find((p) => p.name === "tandem");
     expect(tandem).toBeDefined();
     expect(tandem?.source).toEqual({ source: "github", repo: "bloknayrb/tandem" });
+  });
+
+  it("the shared install commands spell the identities the manifests declare", () => {
+    // #1390: `tandem setup` and the desktop wizard both print these, and Tandem
+    // cannot run either one for the user — registering a marketplace is Claude
+    // Code's own trust boundary. A wrong slug is therefore a dead end the user
+    // has to debug, not an error Tandem can catch at runtime. Derived from the
+    // manifests rather than transcribed, so renaming the plugin fails here
+    // instead of shipping two surfaces that confidently say the old name.
+    const plugins = marketplace.plugins as Array<{ name: string; source?: { repo?: string } }>;
+    const repo = plugins.find((p) => p.name === plugin.name)?.source?.repo;
+    expect(CLAUDE_PLUGIN_INSTALL_COMMANDS).toEqual([
+      `claude plugin marketplace add ${repo}`,
+      `claude plugin install ${plugin.name}@${marketplace.name}`,
+    ]);
   });
 
   it("the experimental monitor runs via the pinned npx subcommand", () => {

--- a/tests/plugin-manifest.test.ts
+++ b/tests/plugin-manifest.test.ts
@@ -70,12 +70,13 @@ describe("published Claude Code plugin manifest", () => {
   });
 
   it("the shared install commands spell the identities the manifests declare", () => {
-    // #1390: `tandem setup` and the desktop wizard both print these, and Tandem
-    // cannot run either one for the user — registering a marketplace is Claude
-    // Code's own trust boundary. A wrong slug is therefore a dead end the user
-    // has to debug, not an error Tandem can catch at runtime. Derived from the
-    // manifests rather than transcribed, so renaming the plugin fails here
-    // instead of shipping two surfaces that confidently say the old name.
+    // #1390: `tandem setup` and the desktop wizard both print these for the
+    // user to run (see `CLAUDE_PLUGIN_INSTALL_COMMANDS` for why Tandem shows
+    // them rather than running them). Nothing executes them here, so a wrong
+    // slug is a dead end the user has to debug rather than an error Tandem can
+    // catch at runtime. Derived from the manifests rather than transcribed, so
+    // renaming the plugin fails here instead of shipping two surfaces that
+    // confidently say the old name.
     const plugins = marketplace.plugins as Array<{ name: string; source?: { repo?: string } }>;
     const repo = plugins.find((p) => p.name === plugin.name)?.source?.repo;
     expect(CLAUDE_PLUGIN_INSTALL_COMMANDS).toEqual([


### PR DESCRIPTION
Four issues that all live on the same three surfaces — the desktop first-run
wizard and the two Cowork panels — so they ship as one cluster.

Closes #1389
Closes #1390
Closes #1376
Closes #1375

## #1389 — the registered-channel copy omitted the Monitor tool

`printPushStatus` and the wizard both described the channel shim as the way to
get pushed events, which has not been true since #1354: the plugin monitor and
the self-armed `ws` watch on `/api/wake` are both flagless, and ADR-049's
amendment makes the wake watch the first recommendation. Copy now names every
route and — per CLAUDE.md — says "where Claude Code offers a Monitor tool"
rather than promising one, and names the channel shim as the fallback.

`src/cli/setup.ts`'s `printPushStatus` went from private to exported so the
rendering itself is testable; `tests/cli/setup-push-status.test.ts` pins the
indent, the manifest order and the version floor.

## #1390 — the wizard never told users how to install the plugin

New push-mode section in `IntegrationWizardModal.svelte` with the two commands
to register the marketplace and install the plugin, plus a copy button.

The commands are **shown, not run**. That is a choice, not a limitation —
`POST /api/integrations/install-claude-code` already shells out to install the
Claude CLI, `apply.ts` already writes `~/.claude.json`, and
`cowork_installer.rs` already writes a plugin registry. Two things make this the
one we decline to automate: the personal-Claude-Code registry schema is
reverse-engineered rather than supported, and enabling a plugin installs hooks
that run in the user's own sessions. `src/shared/constants.ts` is the single
home for that rationale; the wizard points at it rather than restating it.

## #1376 — live regions were created with their content

An ARIA live region has to be in the accessibility tree **before** its contents
change, or nothing is announced. Mounting the region early is only half of it:
the in-flight line is the FIRST text to arrive, so a `probing` that flips in the
same tick that mounts the region inserts the region *with* content and the
announcement is lost again.

`createSubnetPreflight.run()` therefore takes its staleness ticket
synchronously, then `await tick()` before setting `probing = true`. The ticket
is taken first so a `reset()` landing inside the gap still wins.

One deliberate consequence: a probe superseded *during* that gap never issues at
all, so two `run()`s in one tick cost ONE PowerShell round-trip rather than two.
That is the desirable reading of a double-clicked retry button, and
`cowork-preflight-hook.test.ts` pins both halves — that one, and that a probe
superseded *after* issuing still cannot write.

The same class of bug was in the wizard's clipboard status: `pluginCopyResult`
was never cleared, so a repeat copy announced nothing. It is now cleared, flushed
and re-set, behind a `copyToken` guard so a superseded copy cannot land a stale
"Copied" on a region it no longer owns. `writeText` runs first with no `await`
before it — some engines gate the clipboard on transient user activation, which
an awaited microtask can outlive.

## #1375 — the two Cowork components were never mounted by any test

Two new mounted suites (`cowork-settings-mounted.test.ts`,
`cowork-onboarding-step-mounted.test.ts`) plus additions to
`settings-claude-code-tab-cowork.test.ts`, reaching the lazy parent
`settings-tabs/SettingsClaudeCodeTab.svelte`.

Mounting them immediately found a real defect, which is the point. Svelte's
`set_checked` caches the last value it wrote and returns early when unchanged
(`svelte/src/internal/client/dom/elements/attributes.js`). A user click mutates
`input.checked` without updating that cache, so any transition where the
expression re-computes to its **pre-click** value never writes — and the control
desyncs permanently. It bites wherever the click drives an async, failable
write: decline the UAC prompt and the Cowork toggle stays on over a feature that
is off, with only an error line to disagree.

`src/client/utils/checkbox-sync.ts` holds the fix and the mechanism.

## Bundled: a third instance of that bug

Two independent review agents converged on `NetworkSettings.svelte`, so it is
fixed here rather than filed. The start-at-login toggle has two routine paths
that leave `status.enabled` unchanged — `toggle()`'s `catch` sets `error`
without touching status, and a `readback-mismatch` (the OS virtualized the write
away) reports the value it already had. Both left the box where the user put it.
`tests/client/network-settings-autostart.test.ts` pins it; mutating the resync
call away fails two of its three tests.

Measured census: 22 `<input type="checkbox">` in `src/client/`, 21 one-way and
exactly one `bind:checked`. So one-way is the house style and this is the shape
of the hazard, not an outlier.

## What the third review round changed

A five-agent panel over the review-response commits found eight defects, and
three of them were in my *fixes* rather than in the original work. The one that
mattered:

**The resync I added was consuming a stale read.** `refetch()` swallows its
failure into `coworkState.error` and returns normally, and that error rendered
only behind `!coworkState.status` — false for every failure a toggle user can
cause, since the toggle only exists once a status has loaded. So after a
successful disable whose read-back failed, `status` still said `enabled: true`
and the resync *visibly re-checked* the box over an integration that was now
off. Before the resync existed the box stayed unchecked and accidentally matched
disk. The fix had made that path worse.

The discriminator is the **read-back**, not the write — a toggle that threw
leaves `status` unchanged but accurate; a refetch that succeeded is fresh and
must be believed even when it disagrees (that is #1437); only "wrote but could
not re-read" is stale. `refetch()` now reports whether it stored a fresh status,
which is what `useFirstRunNeeded` already does for the same reason.

Also worth naming, because they were my errors: a `<!-- prettier-ignore -->`
whose justification was fabricated (compiling both forms with the repo's own
Svelte produces byte-identical output, and this repo has no Prettier); an
`aria-atomic` claim that was inverted; and a comment asserting the tests pinned
a guard pair when measurement showed neither guard was individually pinned.

## Filed rather than fixed

- **#1436** — rendering `coworkPreflightSubnet`'s `unknown` as a failure. It is
  also the routine non-Windows/no-Tauri outcome (`cowork-invoke.ts:107-134`), so
  a failure message would fire on the ordinary path.
- **#1437** — an *honest* non-committing refetch reverting the UI silently. A
  product copy decision, and distinct from the stale-read bug fixed here.
- **#1438** — `cowork_toggle_integration` encodes degraded success (leftover
  firewall rule, partial multi-workspace install) in its `Ok` string, and the
  client discards it. Wants a structured return from Rust.
- **#1439** — client `console.warn` is unreadable in a release desktop build
  (`devtools` is mutually exclusive with `tauri-plugin-log`, and there is no
  client log buffer). Cross-cutting; wants its own PR.
- The app-wide `aria-live` sweep #1376 suggests reaches `SidePanel.svelte`,
  which is C10's file. Out of scope here by design.

## Verification

- `npm run typecheck` — 1324 files, 0 errors, 0 warnings
- `npm test -- --run` — 464 files, 6731 passed, 19 skipped
- `npx biome check src/ tests/` and `eslint` — clean
- `npm run test:e2e -- integration-wizard` — 8 passed
- Mutation-tested across three rounds. Every fix in the final round was
  confirmed by mutating it away and watching a **named** test fail — including
  two cases where the first version of my own test turned out to be vacuous and
  had to be rewritten before it would bite.

Three review panels: six agents on the implementation, five on the delta, plus
`/simplify`. The `/simplify` round moved `resyncCheckbox` out of one component
and cut `waitFor`'s default interval, taking the touched suites from 887ms to
633ms.

No `CHANGELOG.md` entry — this wave writes the changelog once at integration
from the diffs (#1406).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYGFawL9kQruDZiUkYGBKD
