### PR TITLE
fix(ui): restyle the annotation composer, and rebuild the focus indicator un-boxing would have destroyed

### DIFF
--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -256,8 +256,12 @@ const annotationTextTrimmed = $derived(annotationText.trim());
 const primaryAnnotationIntent = $derived(defaultAnnotationIntent(annotationIntent));
 
 // #1385's eyebrow. The mock labelled it `DRAFT`, which names a state this
-// component does not have: `annotationText` is plain component-local $state,
-// destroyed on all four exit paths, and `AnnotationStatus` has no draft member.
+// component does not have: `annotationText` is plain component-local $state
+// with no persistence behind it, and `AnnotationStatus` is
+// pending/accepted/dismissed only. (It is not even uniformly discarded — the
+// click-away path at the `showPopup` effect deliberately KEEPS the text while
+// the textarea has focus, for recovery. So "draft" would overstate durability
+// in one direction and understate it in the other.)
 // Labelling the AUDIENCE instead is honest and more useful — it is the only
 // *resting* surface stating ADR-027's primary axis (private vs outbound), which
 // is otherwise inferable only from the placeholder or from which button carries
@@ -781,10 +785,13 @@ function submitAsComment() {
     // Gated on `id` alone, not `id && rect`: a missing rect costs the fly
     // animation, not the write, and must not suppress the notice.
     //
-    // Not reachable today (the popup requires a non-empty selection, so
-    // `capturedRange` can't be collapsed here); it becomes reachable once
-    // anything can collapse mid-compose, which the proposed in-card highlight
-    // swatches would (#1445).
+    // All three of `createAnnotation`'s undefined returns are unreachable from
+    // here today: no-editor/no-ydoc is gated by `canAnnotate` upstream of
+    // `showPopup`, empty content by this function's own early return, and a
+    // collapsed range by the fact that the only two collapse sites live in the
+    // format block, which is `inert` while the composer is open. The third is
+    // the one that stops being true once anything can collapse mid-compose —
+    // which the proposed in-card highlight swatches would (#1445).
     window.dispatchEvent(new CustomEvent("tandem:addressed-ai", { detail: { via: "comment" } }));
   }
   dismissPopup();
@@ -1007,7 +1014,9 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
           aria-label="Annotation text"
           bind:value={annotationText}
           onkeydown={handleTextareaKeyDown}
-          placeholder={annotationIntent === "note" ? "Write a private note..." : "Write an instruction for AI..."}
+          placeholder={primaryAnnotationIntent === "note"
+            ? "Write a private note..."
+            : "Write an instruction for AI..."}
           rows={1}
           class="composer-input"
         ></textarea>
@@ -1214,6 +1223,12 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
     letter-spacing: 0.06em;
     text-transform: uppercase;
     color: var(--tandem-fg-subtle);
+    /* Load-bearing for SELECTION_POPUP_HEIGHT_RESERVE, not cosmetic. The
+       eyebrow cannot wrap today only because `min-width: 260px` happens to
+       exceed the longest label — an incidental guarantee sitting on the thin
+       end of that constant's headroom. `nowrap` makes the one-row assumption
+       structural. */
+    white-space: nowrap;
   }
   /* The leading dot follows the same authorship keying the card headers use
      (derived-spec's "cobalt dot · You" / "coral dot · Claude"): cobalt while the
@@ -1221,7 +1236,7 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
   .composer-eyebrow-dot {
     width: 6px;
     height: 6px;
-    border-radius: var(--tandem-r-circle, 50%);
+    border-radius: var(--tandem-r-circle);
     background: var(--tandem-author-claude);
     flex-shrink: 0;
   }
@@ -1240,10 +1255,11 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
        border is kept at 1px `transparent` rather than removed so the
        forced-colors rule below can paint a resting boundary without shifting
        layout by a pixel; with no boundary at all, a borderless textarea is
-       indistinguishable from static text in HCM. The global token remap
-       (index.html) cannot reach this one — `transparent` is a keyword, not a
-       token — which is the same reason StatusBar's `.status-warning-pill`
-       carries its own block. */
+       indistinguishable from static text in HCM. The global token remap in
+       index.html cannot reach this one, because `transparent` is a keyword
+       rather than a token — and forced-colors deliberately exempts
+       `transparent`, so the explicit override below is what does the work.
+       Same shape as ToastContainer's `.toast-card`. */
     border: 1px solid transparent;
     background: none;
     color: var(--tandem-fg);
@@ -1261,24 +1277,24 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
      10%-alpha box-shadow alone is far under SC 1.4.11's 3:1, so the outline is
      now opaque and does the whole job.
      `--tandem-accent`, not the author-claude family the old border used. A8
-     keys the annotation *chrome* to coral, and on a border that is what the old
-     rule read as; on an `outline` it would read as a focus ring, and every
-     other focus ring in the app is accent — including `.composer-btn` a few
-     rules below, so coral here would put two hues in one component. Accent is
-     also the only correct choice in HCM: it maps to `Highlight`, the system
-     focus color, where `--tandem-author-claude-border` maps to `ButtonText`.
-     The dropped box-shadow used `--tandem-claude-focus-bg`, which despite the
-     name is Claude's *attention* decoration (the awareness gutter rail in
-     `editor/extensions/awareness.ts`), not a keyboard-focus token.
+     keys the annotation *chrome* to coral, which is what the old rule read as
+     on a border; on an `outline` it reads as a focus ring instead, and the
+     sibling `.composer-btn:focus-visible` a few rules below is accent — so
+     coral here would put two focus hues in one component. Accent is also the
+     better choice in HCM, mapping to `Highlight` (the system focus color)
+     where `--tandem-author-claude-border` maps to `ButtonText`. The dropped
+     box-shadow used `--tandem-claude-focus-bg`, which despite the name is
+     Claude's *presence* tint (paragraph background in `awareness.ts`, the
+     typing pill, the working pill), not a keyboard-focus token.
 
      Deliberately `:focus`, not `:focus-visible`: UAs always match
      :focus-visible on text-entry fields, so switching buys nothing and would
      stake the only focus indicator on that heuristic — and this field is also
-     focused programmatically (the rAF in openRequestedComposer). */
+     focused programmatically (the rAF in openRequestedComposer /
+     openAnnotateMode). */
   .composer-input:focus {
     outline: 2px solid var(--tandem-accent);
     outline-offset: 2px;
-    box-shadow: none;
   }
   @media (forced-colors: active) {
     .composer-input {
@@ -1320,6 +1336,10 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
     background: transparent;
     color: var(--tandem-fg-muted);
     font-weight: 500;
+    /* Content-sized now that `flex: 1` is gone, so the row's width is the sum
+       of two labels. Fits today with room to spare, but `nowrap` keeps a long
+       agent family name from wrapping text out of the fixed 28px height. */
+    white-space: nowrap;
     height: 28px;
     padding: 0 var(--tandem-space-3);
     border-radius: var(--tandem-r-3);
@@ -1342,7 +1362,13 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
     outline: 2px solid var(--tandem-accent);
     outline-offset: 1px;
   }
-  .composer-btn:hover:not(:disabled) {
+  /* `:not(.is-primary)` is required, not decorative. `:not(:disabled)` weighs
+     as a pseudo-class, so a bare `.composer-btn:hover:not(:disabled)` scores
+     (0,3,0) and outranks `.composer-btn-send.is-primary` at (0,2,0) — hovering
+     the primary button would drop its authorship colour for `--tandem-fg`,
+     which is what the pre-#1385 selectors did too and is why the hover comment
+     below could claim a contrast pairing that never actually rendered. */
+  .composer-btn:not(.is-primary):hover:not(:disabled) {
     background: var(--tandem-surface-sunk);
     color: var(--tandem-fg);
   }

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -255,6 +255,21 @@ const showPopup = $derived(
 const annotationTextTrimmed = $derived(annotationText.trim());
 const primaryAnnotationIntent = $derived(defaultAnnotationIntent(annotationIntent));
 
+// #1385's eyebrow. The mock labelled it `DRAFT`, which names a state this
+// component does not have: `annotationText` is plain component-local $state,
+// destroyed on all four exit paths, and `AnnotationStatus` has no draft member.
+// Labelling the AUDIENCE instead is both honest and the more useful of the two
+// — it is the only *resting* surface that states ADR-027's primary axis
+// (private vs outbound). Today that is otherwise inferable only from the
+// placeholder or from which button carries `.is-primary`.
+//
+// $derived, not a plain const: a component-scope const would freeze at mount
+// and keep saying "private" after a native-menu open flipped the intent.
+// `aria-hidden` in the template — see the markup comment for why.
+const composerAudience = $derived(
+  primaryAnnotationIntent === "note" ? "Private note" : `To ${agentLabel.family}`,
+);
+
 // Plain `let` — see SelectionToolbarPositionArgs.previousPlacement docstring.
 // This is read+written from a Tiptap event listener, NOT from inside a
 // Svelte $effect, so it does not need to be reactive and must not be
@@ -754,12 +769,33 @@ function submitAsComment() {
   // the popover, so the rect must be read first.
   const rect = toolbarEl?.getBoundingClientRect();
   const id = createAnnotation("comment", annotationTextTrimmed);
-  if (id && rect) registerFlySource(id, rect);
-  // #1018: a comment is outbound (Claude reads it). If no AI is connected, App
-  // shows a "saved, will be seen when AI connects" notice. ONLY comments —
-  // notes/highlights are user-private (ADR-027) and never sent to AI, so a
-  // "no AI connected" notice on those would be misleading. Post-write only.
-  window.dispatchEvent(new CustomEvent("tandem:addressed-ai", { detail: { via: "comment" } }));
+  if (id) {
+    if (rect) registerFlySource(id, rect);
+    // #1018: a comment is outbound (Claude reads it). If no AI is connected, App
+    // shows a "saved, will be seen when AI connects" notice. ONLY comments —
+    // notes/highlights are user-private (ADR-027) and never sent to AI, so a
+    // "no AI connected" notice on those would be misleading.
+    //
+    // "Post-write only" means exactly that, and until #1385 the dispatch sat
+    // OUTSIDE the guard: a create that returned undefined (`createAnnotation`
+    // bails on a collapsed range) still told the user their comment was saved
+    // and would reach Claude when nothing had been written to the Y.Map. That
+    // broke a contract documented on the CONSUMER side — App.svelte's #1018
+    // block states both dispatchers fire "AFTER persisting" — so the defect was
+    // invisible from either file alone.
+    //
+    // Gated on `id` alone rather than on `id && rect`: the rect is the
+    // fly-animation's input, so a missing one is a cosmetic loss, not a failed
+    // write, and must not suppress the notice.
+    //
+    // Not reachable through today's UI — the popup requires a non-empty
+    // selection, so `capturedRange` is never collapsed here. It becomes
+    // reachable the moment anything can collapse the range mid-compose, which
+    // is exactly what putting the highlight swatches in this card would do
+    // (handleHighlight collapses the PM selection for #768). Hence: fixed now,
+    // while the reason is written down.
+    window.dispatchEvent(new CustomEvent("tandem:addressed-ai", { detail: { via: "comment" } }));
+  }
   dismissPopup();
 }
 
@@ -961,6 +997,19 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
       <!-- Annotate popover. Alt+Enter is always private; Ctrl/Cmd+Enter follows
            the requested menu intent (ordinary opens default to outbound). -->
       <div class="composer-card">
+        <!-- #1385 eyebrow. `aria-hidden` deliberately: it duplicates what the
+             textarea's placeholder already says ("Write a private note…" /
+             "Write an instruction for AI…"), and an announced eyebrow would put
+             a bare audience word ahead of the field's own label on every AT
+             traversal. It carries no data-testid on purpose — the coverage
+             snapshot is a SET over all of src/client/, so *adding* one rewrites
+             a file another branch currently owns. -->
+        <div class="composer-eyebrow" aria-hidden="true">
+          <span
+            class="composer-eyebrow-dot"
+            class:is-private={primaryAnnotationIntent === "note"}
+          ></span>{composerAudience}
+        </div>
         <textarea
           bind:this={textareaEl}
           data-testid="popup-annotation-input"
@@ -1163,6 +1212,32 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
     min-width: 260px;
     max-width: 360px;
   }
+  /* #1385: the eyebrow names the audience, not a draft state. Sized off
+     --tandem-text-2xs with tracking so it reads as a label rather than as the
+     first line of the user's own text. */
+  .composer-eyebrow {
+    display: flex;
+    align-items: center;
+    gap: var(--tandem-space-2);
+    font-size: var(--tandem-text-2xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--tandem-fg-subtle);
+  }
+  /* The leading dot follows the same authorship keying the card headers use
+     (derived-spec's "cobalt dot · You" / "coral dot · Claude"): cobalt while the
+     composer is private, coral once it is addressed to the agent. */
+  .composer-eyebrow-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--tandem-author-claude);
+    flex: none;
+  }
+  .composer-eyebrow-dot.is-private {
+    background: var(--tandem-author-user);
+  }
   .composer-input {
     width: 100%;
     box-sizing: border-box;
@@ -1171,37 +1246,72 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
     max-height: 120px;
     overflow-y: auto;
     resize: none;
-    border: 1px solid var(--tandem-border);
-    border-radius: var(--tandem-r-3);
-    background: var(--tandem-surface);
+    /* #1385: un-boxed — the draft reads as content, not as a form field. The
+       border is kept at 1px `transparent` rather than removed so the
+       forced-colors rule below can paint a resting boundary without shifting
+       layout by a pixel; with no boundary at all, a borderless textarea is
+       indistinguishable from static text in HCM. Precedent for the pattern:
+       ModeToggle.svelte's forced-colors block. */
+    border: 1px solid transparent;
+    background: none;
     color: var(--tandem-fg);
-    font-size: var(--tandem-text-sm);
+    font-size: var(--tandem-text-base);
+    line-height: 1.45;
     font-family: inherit;
-    padding: var(--tandem-space-1) var(--tandem-space-2);
+    padding: var(--tandem-space-1) 0;
   }
   .composer-input::placeholder {
     color: var(--tandem-fg-subtle);
   }
   /* Coral-keyed focus treatment (A8: chrome keyed to the annotation action).
-     The default outline is replaced by a visible composite indicator: the
-     border swaps to the 3:1 coral border-grade plus a soft 10%-alpha tint
-     ring. Previously the textarea had `outline: none` with no replacement.
-     The outline is transparent rather than `none` so Windows forced-colors
-     mode (which strips box-shadows and forces border colors) still paints a
-     visible system-color focus ring. */
+     Until #1385 this was a composite of three layers, and only two of them were
+     ever visible in normal mode: a *transparent* outline (the forced-colors
+     path), a border-color swap, and a 10%-alpha tint ring. Un-boxing the field
+     removed the border, which was the load-bearing half — a 10%-alpha
+     box-shadow alone is far under SC 1.4.11's 3:1 for a non-text indicator.
+     So the outline is now opaque and does both jobs: forced-colors still
+     overrides its color to a system color exactly as it did when transparent,
+     and normal mode gets a real ring. --tandem-author-claude-border is the
+     grade audited for this (≥3:1 against both the tint and the card surface,
+     documented at its definition in index.html).
+
+     Deliberately still `:focus`, not `:focus-visible`. The two are equivalent
+     here — UAs always match :focus-visible on text-entry fields, mouse focus
+     included — so switching would buy nothing and stake the only focus
+     indicator on that UA heuristic holding. The composer is also focused
+     programmatically (the rAF in openRequestedComposer), which is exactly the
+     case where the heuristic is worth not relying on. */
   .composer-input:focus {
-    outline: 2px solid transparent;
-    outline-offset: 1px;
-    border-color: var(--tandem-author-claude-border);
-    box-shadow: 0 0 0 2px var(--tandem-claude-focus-bg);
+    outline: 2px solid var(--tandem-author-claude-border);
+    outline-offset: 2px;
+    box-shadow: none;
   }
+  @media (forced-colors: active) {
+    .composer-input {
+      border-color: ButtonText;
+    }
+  }
+  /* #1385: the action row is separated by a full-bleed hairline rather than by
+     whitespace alone. Negative horizontal margins cancel .composer-card's
+     padding so the rule spans the card edge-to-edge; the padding-top restores
+     the gap the flex `gap` used to supply above the border. That rule is also
+     what gives the un-boxed textarea a visible bottom edge to scroll against
+     once its content passes max-height. */
   .composer-actions {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
+    align-items: center;
     gap: var(--tandem-space-2);
+    margin: 0 calc(-1 * var(--tandem-space-2));
+    padding: var(--tandem-space-2) var(--tandem-space-2) 0;
+    border-top: 1px solid var(--tandem-border);
   }
   .composer-btn {
-    flex: 1;
+    /* Deliberately NOT `flex: 1`. Equal-width twins are what made the two
+       submits read as equal weight; letting each size to its own content is
+       where most of #1385's hierarchy comes from, and unlike a filled-accent
+       pill it contradicts no recorded decision (#1006's "tinted, not shouting"
+       stands, and the composer's Send keeps the author-claude family). */
     height: 28px;
     padding: 0 var(--tandem-space-3);
     border-radius: var(--tandem-r-3);
@@ -1224,9 +1334,17 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
     outline: 2px solid var(--tandem-accent);
     outline-offset: 1px;
   }
+  /* #1385: the SECONDARY button is a borderless ghost — whichever one that is.
+     Keying the ghost to `:not(.is-primary)` rather than to Note specifically is
+     what keeps the hierarchy intent-responsive: openRequestedComposer("note")
+     (the desktop native menu) makes Note primary, and a fixed Send-dominant
+     treatment would show an outbound CTA to a user who explicitly chose Private
+     Note while their Ctrl+Enter submits privately. The border is `transparent`
+     rather than absent so both buttons keep identical box metrics and the row
+     does not reflow when the intent flips. */
   .composer-btn-note,
   .composer-btn-send {
-    border: 1px solid var(--tandem-border);
+    border: 1px solid transparent;
     background: transparent;
     color: var(--tandem-fg-muted);
     font-weight: 500;

--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -258,14 +258,10 @@ const primaryAnnotationIntent = $derived(defaultAnnotationIntent(annotationInten
 // #1385's eyebrow. The mock labelled it `DRAFT`, which names a state this
 // component does not have: `annotationText` is plain component-local $state,
 // destroyed on all four exit paths, and `AnnotationStatus` has no draft member.
-// Labelling the AUDIENCE instead is both honest and the more useful of the two
-// — it is the only *resting* surface that states ADR-027's primary axis
-// (private vs outbound). Today that is otherwise inferable only from the
-// placeholder or from which button carries `.is-primary`.
-//
-// $derived, not a plain const: a component-scope const would freeze at mount
-// and keep saying "private" after a native-menu open flipped the intent.
-// `aria-hidden` in the template — see the markup comment for why.
+// Labelling the AUDIENCE instead is honest and more useful — it is the only
+// *resting* surface stating ADR-027's primary axis (private vs outbound), which
+// is otherwise inferable only from the placeholder or from which button carries
+// `.is-primary`.
 const composerAudience = $derived(
   primaryAnnotationIntent === "note" ? "Private note" : `To ${agentLabel.family}`,
 );
@@ -776,24 +772,19 @@ function submitAsComment() {
     // notes/highlights are user-private (ADR-027) and never sent to AI, so a
     // "no AI connected" notice on those would be misleading.
     //
-    // "Post-write only" means exactly that, and until #1385 the dispatch sat
-    // OUTSIDE the guard: a create that returned undefined (`createAnnotation`
-    // bails on a collapsed range) still told the user their comment was saved
-    // and would reach Claude when nothing had been written to the Y.Map. That
-    // broke a contract documented on the CONSUMER side — App.svelte's #1018
-    // block states both dispatchers fire "AFTER persisting" — so the defect was
-    // invisible from either file alone.
+    // Until #1385 this dispatch sat OUTSIDE the guard, so a create that
+    // returned undefined still told the user their comment was saved and would
+    // reach Claude. That broke a contract documented on the CONSUMER side —
+    // App.svelte's #1018 block states both dispatchers fire "AFTER persisting"
+    // — so the defect was invisible from either file alone.
     //
-    // Gated on `id` alone rather than on `id && rect`: the rect is the
-    // fly-animation's input, so a missing one is a cosmetic loss, not a failed
-    // write, and must not suppress the notice.
+    // Gated on `id` alone, not `id && rect`: a missing rect costs the fly
+    // animation, not the write, and must not suppress the notice.
     //
-    // Not reachable through today's UI — the popup requires a non-empty
-    // selection, so `capturedRange` is never collapsed here. It becomes
-    // reachable the moment anything can collapse the range mid-compose, which
-    // is exactly what putting the highlight swatches in this card would do
-    // (handleHighlight collapses the PM selection for #768). Hence: fixed now,
-    // while the reason is written down.
+    // Not reachable today (the popup requires a non-empty selection, so
+    // `capturedRange` can't be collapsed here); it becomes reachable once
+    // anything can collapse mid-compose, which the proposed in-card highlight
+    // swatches would (#1445).
     window.dispatchEvent(new CustomEvent("tandem:addressed-ai", { detail: { via: "comment" } }));
   }
   dismissPopup();
@@ -1212,9 +1203,8 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
     min-width: 260px;
     max-width: 360px;
   }
-  /* #1385: the eyebrow names the audience, not a draft state. Sized off
-     --tandem-text-2xs with tracking so it reads as a label rather than as the
-     first line of the user's own text. */
+  /* Sized off --tandem-text-2xs with tracking so the eyebrow reads as a label
+     rather than as the first line of the user's own text. */
   .composer-eyebrow {
     display: flex;
     align-items: center;
@@ -1231,9 +1221,9 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
   .composer-eyebrow-dot {
     width: 6px;
     height: 6px;
-    border-radius: 50%;
+    border-radius: var(--tandem-r-circle, 50%);
     background: var(--tandem-author-claude);
-    flex: none;
+    flex-shrink: 0;
   }
   .composer-eyebrow-dot.is-private {
     background: var(--tandem-author-user);
@@ -1250,8 +1240,10 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
        border is kept at 1px `transparent` rather than removed so the
        forced-colors rule below can paint a resting boundary without shifting
        layout by a pixel; with no boundary at all, a borderless textarea is
-       indistinguishable from static text in HCM. Precedent for the pattern:
-       ModeToggle.svelte's forced-colors block. */
+       indistinguishable from static text in HCM. The global token remap
+       (index.html) cannot reach this one — `transparent` is a keyword, not a
+       token — which is the same reason StatusBar's `.status-warning-pill`
+       carries its own block. */
     border: 1px solid transparent;
     background: none;
     color: var(--tandem-fg);
@@ -1263,26 +1255,28 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
   .composer-input::placeholder {
     color: var(--tandem-fg-subtle);
   }
-  /* Coral-keyed focus treatment (A8: chrome keyed to the annotation action).
-     Until #1385 this was a composite of three layers, and only two of them were
-     ever visible in normal mode: a *transparent* outline (the forced-colors
-     path), a border-color swap, and a 10%-alpha tint ring. Un-boxing the field
-     removed the border, which was the load-bearing half — a 10%-alpha
-     box-shadow alone is far under SC 1.4.11's 3:1 for a non-text indicator.
-     So the outline is now opaque and does both jobs: forced-colors still
-     overrides its color to a system color exactly as it did when transparent,
-     and normal mode gets a real ring. --tandem-author-claude-border is the
-     grade audited for this (≥3:1 against both the tint and the card surface,
-     documented at its definition in index.html).
+  /* Until #1385 this was a three-layer composite — a *transparent* outline, a
+     border-color swap, and a 10%-alpha ring — of which the border was the only
+     part carrying normal-mode weight. Un-boxing the field removed it, and a
+     10%-alpha box-shadow alone is far under SC 1.4.11's 3:1, so the outline is
+     now opaque and does the whole job.
+     `--tandem-accent`, not the author-claude family the old border used. A8
+     keys the annotation *chrome* to coral, and on a border that is what the old
+     rule read as; on an `outline` it would read as a focus ring, and every
+     other focus ring in the app is accent — including `.composer-btn` a few
+     rules below, so coral here would put two hues in one component. Accent is
+     also the only correct choice in HCM: it maps to `Highlight`, the system
+     focus color, where `--tandem-author-claude-border` maps to `ButtonText`.
+     The dropped box-shadow used `--tandem-claude-focus-bg`, which despite the
+     name is Claude's *attention* decoration (the awareness gutter rail in
+     `editor/extensions/awareness.ts`), not a keyboard-focus token.
 
-     Deliberately still `:focus`, not `:focus-visible`. The two are equivalent
-     here — UAs always match :focus-visible on text-entry fields, mouse focus
-     included — so switching would buy nothing and stake the only focus
-     indicator on that UA heuristic holding. The composer is also focused
-     programmatically (the rAF in openRequestedComposer), which is exactly the
-     case where the heuristic is worth not relying on. */
+     Deliberately `:focus`, not `:focus-visible`: UAs always match
+     :focus-visible on text-entry fields, so switching buys nothing and would
+     stake the only focus indicator on that heuristic — and this field is also
+     focused programmatically (the rAF in openRequestedComposer). */
   .composer-input:focus {
-    outline: 2px solid var(--tandem-author-claude-border);
+    outline: 2px solid var(--tandem-accent);
     outline-offset: 2px;
     box-shadow: none;
   }
@@ -1291,12 +1285,19 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
       border-color: ButtonText;
     }
   }
-  /* #1385: the action row is separated by a full-bleed hairline rather than by
-     whitespace alone. Negative horizontal margins cancel .composer-card's
-     padding so the rule spans the card edge-to-edge; the padding-top restores
-     the gap the flex `gap` used to supply above the border. That rule is also
-     what gives the un-boxed textarea a visible bottom edge to scroll against
-     once its content passes max-height. */
+  /* #1385: a full-bleed hairline separates the action row instead of whitespace
+     alone, and doubles as the bottom edge the un-boxed textarea scrolls against
+     once its content passes max-height. Negative horizontal margins cancel
+     .composer-card's padding so the rule reaches the card edges; the flex `gap`
+     still supplies the space ABOVE the border, and `padding-top` adds the
+     matching space below it.
+
+     The codebase's other edge-to-edge dividers (ChatPanel, CommandPalette,
+     FindReplaceBar) avoid this cancellation by keeping horizontal padding on
+     the sections rather than the container. That is the tidier shape, but here
+     it would push .composer-input's box out to the card edges, and its focus
+     outline sits at `outline-offset: 2px` — which `.morph-block`'s
+     `overflow: clip` would then cut. Left as-is deliberately. */
   .composer-actions {
     display: flex;
     justify-content: flex-end;
@@ -1306,12 +1307,19 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
     padding: var(--tandem-space-2) var(--tandem-space-2) 0;
     border-top: 1px solid var(--tandem-border);
   }
+  /* #1385: no `flex: 1` (equal-width twins read as equal weight — sizing each
+     to its content is where most of the new hierarchy comes from, and unlike a
+     filled-accent pill it contradicts no recorded decision), and the ghost
+     treatment is the BASE rule here rather than a Note-specific one. That is
+     what keeps the hierarchy intent-responsive: openRequestedComposer("note")
+     makes Note primary, and the `.is-primary` variants below win on
+     specificity, so whichever button is secondary is the ghost. `transparent`
+     borders rather than none, so the row does not reflow when intent flips. */
   .composer-btn {
-    /* Deliberately NOT `flex: 1`. Equal-width twins are what made the two
-       submits read as equal weight; letting each size to its own content is
-       where most of #1385's hierarchy comes from, and unlike a filled-accent
-       pill it contradicts no recorded decision (#1006's "tinted, not shouting"
-       stands, and the composer's Send keeps the author-claude family). */
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--tandem-fg-muted);
+    font-weight: 500;
     height: 28px;
     padding: 0 var(--tandem-space-3);
     border-radius: var(--tandem-r-3);
@@ -1334,23 +1342,7 @@ function handleTextareaKeyDown(e: KeyboardEvent) {
     outline: 2px solid var(--tandem-accent);
     outline-offset: 1px;
   }
-  /* #1385: the SECONDARY button is a borderless ghost — whichever one that is.
-     Keying the ghost to `:not(.is-primary)` rather than to Note specifically is
-     what keeps the hierarchy intent-responsive: openRequestedComposer("note")
-     (the desktop native menu) makes Note primary, and a fixed Send-dominant
-     treatment would show an outbound CTA to a user who explicitly chose Private
-     Note while their Ctrl+Enter submits privately. The border is `transparent`
-     rather than absent so both buttons keep identical box metrics and the row
-     does not reflow when the intent flips. */
-  .composer-btn-note,
-  .composer-btn-send {
-    border: 1px solid transparent;
-    background: transparent;
-    color: var(--tandem-fg-muted);
-    font-weight: 500;
-  }
-  .composer-btn-note:hover:not(:disabled),
-  .composer-btn-send:hover:not(:disabled) {
+  .composer-btn:hover:not(:disabled) {
     background: var(--tandem-surface-sunk);
     color: var(--tandem-fg);
   }

--- a/src/client/editor/toolbar/selection-toolbar.ts
+++ b/src/client/editor/toolbar/selection-toolbar.ts
@@ -21,15 +21,31 @@ export const SELECTION_TOOLBAR_FLIP_HYSTERESIS = 4;
 // mid-morph and the height-independent edge-anchor (`bottom` for above) always
 // clears MIN_TOP as the popup grows.
 //
-// Must stay a genuine over-estimate, and this is the half that bites: `above`
-// is bottom-anchored and so immune, but `below` is TOP-anchored, so an
-// under-estimate clips the bottom of the card off-screen. #1385 broke that
-// silently — the eyebrow row, the action row's divider + padding, and a taller
-// type ramp took the fully-scrolled composer to a measured 205px (cozy) / 225px
-// (spacious) including the shell's 2px border, against a reserve of 200. It was
-// invisible because the reserve is a hand-maintained number with nothing
-// asserting it against the rendered card. Measure the real max before trusting
-// this again; density scales it, so `spacious` is the case to measure.
+// Must stay a genuine over-estimate. An under-estimate bites hardest on
+// `below`, which is TOP-anchored, so the bottom of the card is clipped
+// off-screen; `above` is bottom-anchored and immune to that, though not to the
+// constant generally — `fitsAbove` consumes it too, so an under-estimate also
+// lets an above-placed popup's top edge render past MIN_TOP into the chrome.
+//
+// #1385 broke the `below` half silently: the eyebrow row and the action row's
+// divider + padding took the fully-scrolled composer to a measured 205px (cozy)
+// / 225px (spacious) including the shell's 2px border, against a reserve of
+// 200. (The larger type ramp is NOT a contributor — `.composer-input` is
+// `box-sizing: border-box` under a hard `max-height`, so a taller line box
+// changes how fast the field reaches the cap, not the cap. Both densities
+// reconcile to the same 14px eyebrow row without it.) It was invisible because
+// the reserve is a hand-maintained number with nothing asserting it against the
+// rendered card. Measure the real max before trusting this again; density
+// scales it — only `--tandem-space-*` is density-dependent, not the type ramp —
+// so `spacious` is the case to measure.
+//
+// The cost of raising it, stated so it is not mistaken for a new bug: the
+// neither-fits fallback pins `below` at `maxTop`, which moves UP as this grows.
+// Below a viewport height of roughly 548px there is now a band where the popup
+// is pinned above the cursor and can overlap the selection it annotates. Not
+// reachable in the desktop app (`minHeight: 600` in tauri.conf.json), reachable
+// in a short browser window. Accepted deliberately: overlapping a selection is
+// recoverable, clipping the submit buttons off-screen is not.
 export const SELECTION_POPUP_HEIGHT_RESERVE = 240;
 
 export type SelectionToolbarPlacement = "above" | "below";

--- a/src/client/editor/toolbar/selection-toolbar.ts
+++ b/src/client/editor/toolbar/selection-toolbar.ts
@@ -13,14 +13,24 @@ export const SELECTION_TOOLBAR_FLIP_HYSTERESIS = 4;
 // Conservative height used by the A26 morph (#798) to DECIDE placement, so the
 // above/below choice is stable across the format↔annotate morph. Since the A8
 // two-pill restructure the format state is two stacked capsules + a 5px gap
-// (~95–105px); the annotate composer (textarea max-height 120px + buttons)
-// remains the taller, binding case. Only `rect.width` feeds positioning — height
-// reaches the placement math ONLY as this constant — so a taller format state
-// can't move the anchor. Passing this constant rather than the live animating
-// `toolbarHeight` means a placement re-decision can't flip mid-morph and the
-// height-independent edge-anchor (`bottom` for above) always clears MIN_TOP as
-// the popup grows. A deliberate over-estimate that clears every state.
-export const SELECTION_POPUP_HEIGHT_RESERVE = 200;
+// (~95–105px); the annotate composer (eyebrow + textarea max-height 120px +
+// divider + buttons) remains the taller, binding case. Only `rect.width` feeds
+// positioning — height reaches the placement math ONLY as this constant — so a
+// taller format state can't move the anchor. Passing this constant rather than
+// the live animating `toolbarHeight` means a placement re-decision can't flip
+// mid-morph and the height-independent edge-anchor (`bottom` for above) always
+// clears MIN_TOP as the popup grows.
+//
+// Must stay a genuine over-estimate, and this is the half that bites: `above`
+// is bottom-anchored and so immune, but `below` is TOP-anchored, so an
+// under-estimate clips the bottom of the card off-screen. #1385 broke that
+// silently — the eyebrow row, the action row's divider + padding, and a taller
+// type ramp took the fully-scrolled composer to a measured 205px (cozy) / 225px
+// (spacious) including the shell's 2px border, against a reserve of 200. It was
+// invisible because the reserve is a hand-maintained number with nothing
+// asserting it against the rendered card. Measure the real max before trusting
+// this again; density scales it, so `spacious` is the case to measure.
+export const SELECTION_POPUP_HEIGHT_RESERVE = 240;
 
 export type SelectionToolbarPlacement = "above" | "below";
 

--- a/tests/e2e/toolbar-redesign.spec.ts
+++ b/tests/e2e/toolbar-redesign.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 import path from "path";
+import { SELECTION_POPUP_HEIGHT_RESERVE } from "../../src/client/editor/toolbar/selection-toolbar";
+import { TANDEM_SETTINGS_KEY } from "../../src/shared/constants";
 import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
@@ -133,6 +135,68 @@ test("floating selection toolbar stays within a short viewport", async ({ page }
   expect(viewport).not.toBeNull();
   expect(box!.y).toBeGreaterThanOrEqual(48);
   expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
+});
+
+/**
+ * #1385 regression net for SELECTION_POPUP_HEIGHT_RESERVE.
+ *
+ * That constant is the ONLY way height reaches the placement math — the live
+ * measurement path feeds `rect.width` alone. So it is a numeric contract
+ * between `selection-toolbar.ts` and a card whose real height is entirely CSS,
+ * and until this test nothing tied the two together. #1385 broke it silently by
+ * adding an eyebrow row and a divider: the composer grew past the reserve, and
+ * because `below` is top-anchored, `fitsBelow` kept admitting a placement whose
+ * bottom is off-screen. Nothing failed; the submit buttons just left the
+ * viewport.
+ *
+ * Asserting the HEIGHT rather than viewport slack is deliberate. On the
+ * neither-fits branch the pin is `viewportHeight - RESERVE - EDGE_GAP`, so
+ * overflow reduces to `realHeight > RESERVE + EDGE_GAP` — independent of
+ * viewport size, which makes this a stable bound instead of a geometry puzzle.
+ * It also covers the `above` half, where an under-estimate overruns MIN_TOP
+ * into the fixed chrome rather than clipping.
+ *
+ * Seeded `spacious` because only `--tandem-space-*` is density-scoped, so
+ * spacious is the binding case. The assertion discriminates at cozy too, but
+ * seeding keeps it honest about which case it guards.
+ */
+test("the annotate composer never exceeds its placement reserve", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+
+  await page.addInitScript(
+    ([key, density]) => {
+      const raw = window.localStorage.getItem(key);
+      const parsed = raw ? JSON.parse(raw) : {};
+      window.localStorage.setItem(key, JSON.stringify({ ...parsed, density }));
+    },
+    [TANDEM_SETTINGS_KEY, "spacious"] as const,
+  );
+
+  await page.goto("/");
+  const editor = page.locator(".tiptap");
+  await expect(editor).toBeVisible({ timeout: 10_000 });
+  await expect(editor.locator("p").first()).toContainText("first paragraph", {
+    timeout: 10_000,
+  });
+  await expect(page.locator("html")).toHaveAttribute("data-density", "spacious", {
+    timeout: 5_000,
+  });
+
+  await editor.click();
+  await editor.locator("p").first().selectText();
+  await openAnnotatePopup(page);
+
+  // Overfill so `field-sizing: content` pins the textarea at its max-height —
+  // the worst case the reserve has to cover. Fewer lines would measure a card
+  // that has not finished growing and pass against a too-small reserve.
+  const input = page.locator("[data-testid='popup-annotation-input']");
+  await input.fill(Array.from({ length: 15 }, (_, i) => `line ${i + 1}`).join("\n"));
+  await expect(page.locator("[data-testid='popup-comment-submit']")).toBeVisible();
+
+  const toolbar = page.getByRole("toolbar", { name: "Selection tools" });
+  const composerBox = await toolbar.boundingBox();
+  expect(composerBox).not.toBeNull();
+  expect(composerBox!.height).toBeLessThanOrEqual(SELECTION_POPUP_HEIGHT_RESERVE);
 });
 
 test("floating selection toolbar exposes first-pass formatting actions", async ({ page }) => {


### PR DESCRIPTION
#1385 is two screenshots and no prose, so the first job was deciding what the
mock actually asks for and what it merely draws. Three of its five elements
ship here. The other three turned out to be decisions rather than styling, and
are filed with the mechanism that blocks each.

Refs #1385 — the remainder is #1444, #1445 and #1446. Close it if you agree
those three cover it.

## What ships

- **An audience eyebrow.** The mock says `● DRAFT`; nothing in this component
  has a draft state (`annotationText` is component-local `$state`,
  `AnnotationStatus` is pending/accepted/dismissed). Naming the **audience**
  instead is honest and more useful — it is the only resting surface stating
  ADR-027's private-vs-outbound axis, which today is inferable only from the
  placeholder or from which button is tinted. `aria-hidden`, because it
  duplicates what the placeholder already announces, and it carries no testid.
- **Un-boxed draft text** with a rebuilt focus indicator (below).
- **A full-bleed hairline divider**, which doubles as the bottom edge the
  now-borderless textarea scrolls against.
- **An asymmetric action row.** `flex: 1` is gone, so the buttons size to their
  content, and the ghost treatment is the base rule — whichever button is
  *secondary* is the ghost. That last part is the point: `openRequestedComposer("note")`
  makes Note primary, and a fixed Send-dominant row would show an outbound CTA
  to someone who explicitly chose Private Note while their Ctrl+Enter submits
  privately.

Strings, keybinding chips, testids and Send's colour family are all unchanged.
Two of those were nearly dropped before review caught that they are recorded
decisions: `conflicts-resolved.md:100` requires both buttons to render their key
hint, and `Note to self` is ADR-027's audience signal — "Note" alone drops the
only word on that button meaning *private*.

## The focus indicator, which un-boxing would have quietly destroyed

`.composer-input:focus` was a three-layer composite — a transparent outline, a
border-color swap, and a 10%-alpha ring — and only the border carried
normal-mode weight. Removing the box would have left focus as a 10%-alpha
box-shadow, far under SC 1.4.11's 3:1. It is now a single opaque outline, plus a
`forced-colors` resting border so a borderless field is still distinguishable
from static text in HCM.

Two things review corrected here. The ring is **`--tandem-accent`**, not the
author-claude family the old border used: on a border, coral read as A8 chrome
keying; on an outline it reads as a focus ring, and the sibling
`.composer-btn:focus-visible` is accent — coral would have put two focus hues in
one component. Accent is also the right HCM mapping (`Highlight`, the system
focus colour, vs `ButtonText`). And the dropped box-shadow used
`--tandem-claude-focus-bg`, which despite its name is Claude's *presence* tint,
not a keyboard-focus token.

A side effect worth naming: the old rule's premise was wrong. Forced-colors
exempts `transparent`, so `outline: 2px solid transparent` never painted — **the
composer had no focus indicator at all in HCM until this PR.**

## The regression that nearly shipped

`/simplify`'s efficiency lens rendered the old and new cards in Chromium instead
of estimating, and found the composer had grown past
`SELECTION_POPUP_HEIGHT_RESERVE`: 205px (cozy) / 225px (spacious) including the
shell border, against a reserve of 200 whose own docblock called itself "a
deliberate over-estimate that clears every state". `above` is bottom-anchored
and immune, but `below` is **top-anchored**, so `fitsBelow` kept admitting a
placement whose bottom — the submit buttons — is off-screen. Nothing failed.

Raised to 240. Two things are recorded rather than left implicit:

- **The cost.** The neither-fits pin moves up with the reserve, so below a
  ~548px viewport the popup can overlap the selection it annotates. Unreachable
  in the desktop app (`minHeight: 600`), reachable in a short browser window.
  Accepted deliberately — overlapping a selection is recoverable, clipping the
  submit buttons off-screen is not.
- **The type ramp is not a contributor**, despite sounding like one. The
  textarea is `box-sizing: border-box` under a hard `max-height`, so a taller
  line box changes how fast the cap is reached, not the cap. Both densities
  reconcile to the same 14px eyebrow row without it. That claim was in my first
  draft of the docblock and would have produced a wrong answer at the next
  recalculation.

## Bundled: a false "sent to Claude" notice

`submitAsComment` dispatched `tandem:addressed-ai` outside its write guard, so a
create returning `undefined` still told the user the comment was saved and would
reach Claude. It broke a contract documented on the **consumer** side —
`App.svelte`'s #1018 block states both dispatchers fire "AFTER persisting" —
which is why neither file showed the defect alone.

Not reachable today, and the PR does not claim otherwise: all three of
`createAnnotation`'s `undefined` returns are gated upstream while the composer is
mounted. It becomes reachable the moment anything can collapse the range
mid-compose, which is exactly what #1445 would do.

## Tests

One test, and it exists because the review talked me out of my own reasoning. I
had justified shipping none partly on "it's overwhelmingly CSS" — which is the
reasoning that produced the bug. The reserve is a numeric contract against a
card whose height is entirely CSS, and my new docblock complained that nothing
asserts it against the rendered card while shipping another number nothing
asserts.

`tests/e2e/toolbar-redesign.spec.ts` now seeds `spacious`, overfills the
textarea to its max-height, and bounds the popup's measured height by the
imported constant. It **fails on revert** (225 ≤ 200 is false), needs no new
testid, and covers the `above` half too: on the neither-fits pin, overflow
reduces to `realHeight > RESERVE + EDGE_GAP`, independent of viewport.

The `submitAsComment` guard stays untested on purpose — every test constructible
on that path passes with the fix reverted, which would be theatre.

## Deferred, with the mechanism that blocks each

- **#1444 — the solid blue Send pill.** The strongest finding of the review, and
  not what I first thought. Two "Send to Claude" affordances already ship and
  disagree: the annotation card is cobalt (`AnnotationCardActions.svelte:184-192`,
  specified at `derived-spec.md:301`), the composer is coral (#1006, which
  argued it semantically). The mock's *solid* fill is the card's **hover** state,
  so adopting it literally would swap which surface is out of step. That is
  "which surface is wrong", and it is yours to answer — so the hierarchy ships
  structurally instead, which contradicts nothing and needs no override entry.
- **#1445 — swatches in the card.** Not a restyle and not "two annotations from
  one gesture": `handleHighlight` nulls `capturedRange` and collapses the PM
  selection (deliberately, for #768), which unmounts the popup. One highlight,
  **zero** comments, draft lost. Duplicating rather than moving them is invisible
  to the testid gate (it snapshots a `Set`) and breaks Playwright on strict mode.
- **#1446 — the tail.** Clipped by `overflow: clip` on both morph blocks and
  again by `popupEnter` during the entrance; and the popup is cursor-anchored
  with a viewport clamp, so in the default `below` placement a bottom tail points
  away from the anchor and, when clamped, at nothing.

## Verification

- `npm run typecheck` — 1323 files, 0 errors, 0 warnings
- `npm test -- --run` — full suite green (one failure en route was a stale
  `dist/` from the 0.22.1 bump, not this branch; green after `build:server`)
- `npm run check:tokens`, `biome`, `eslint` — clean
- `tests/design-system-impl/` — 73 passed, including the testid snapshot
  confirming zero selectors added or removed
- Pre-push ran the full vitest suite plus `cargo test`

**E2E is comparative only, and the new test has not executed locally.** 13
failures appeared, so I ran the same specs on clean `master` and got the
identical 13 — the cause is that the Tandem desktop app is running and its
sidecar holds `:3478`, so the test browser reaches that server instead of the
harness one ("Nothing open yet" in every failure snapshot). CI is green on
master, confirming it is local. I did not kill your running editor to get a
cleaner number. CI runs `npm run test:e2e`, so the new assertion gets its first
real execution there — if it lands materially above 225, the reserve is still
wrong and the test is saying so.

## Review

`/simplify` (4 lenses) then `/pr-review-toolkit:review-pr` (4 lenses), plus a
3-lens adversarial panel on the plan before any code. Findings that changed the
work: the height regression, the focus-ring family, the primary-hover
specificity bug, the missing test, and three factual claims in my own comments
that were false — two of them in the two densest comment blocks, which is the
expected failure mode when prose reaches for a sweeping claim.

No `CHANGELOG.md` entry — this wave writes the changelog once at integration
from the diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYGFawL9kQruDZiUkYGBKD
