### PR TITLE
fix(ui): drop the redundant rail titles, and repair what was leaning on them

### DIFF
--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -211,6 +211,13 @@ async function clearChat() {
   actionError = null;
   try {
     await onClear();
+    // Clearing empties `messages`, which closes the header gate and destroys
+    // the button the user just pressed. Without this, focus falls to <body>:
+    // the next Tab restarts at the top of the document, and the rail shell's
+    // `onfocusout` sees a null `relatedTarget` (App.svelte) — so a
+    // hover-revealed rail either collapses mid-task or latches open. The
+    // composer is both inside the shell and the natural next action.
+    internalInputEl?.focus();
   } catch (err) {
     actionError = err instanceof Error ? err.message : "Chat history could not be cleared.";
   } finally {
@@ -235,52 +242,47 @@ async function exportChat() {
   data-testid="chat-panel"
   style="width: 100%; display: flex; flex-direction: column; background: var(--tandem-surface-muted); flex: 1; min-height: 0;"
 >
-  <!-- Header. #1382: no "Chat" title — the rail's tab pill above already says
-       so. With the word gone the row has nothing to show on an empty chat (the
-       unread pill and Export/Clear are all content-gated), so the row is gated
-       too rather than rendering as a bordered, padded empty strip under the
-       tabs. It reappears whenever content returns, and `clearChat` can take it
-       away again, so this is a recurring transition rather than a one-time one.
+  <!-- Header. #1382: no "Chat" title — the rail tab above already says so. With
+       the word gone the row has nothing left to show on an empty chat, so it is
+       gated rather than rendering as a bordered, padded empty strip.
 
-       `font-weight: 600` stays even though the text it was written for is gone:
-       `.chat-header-action` is `font: inherit`, overriding only `font-size`, so
-       the weight here is what renders Export/Clear and the unread count at 600.
-       Dropping it silently demotes all three to 400. `--tandem-text-md` was
-       genuinely inert (that same rule sets its own `font-size`) and is gone. -->
-  {#if unreadCount > 0 || messages.length > 0}
+       `font-weight: 600` stays even though the text it was written for is gone.
+       Export/Clear are `.chat-header-action`, which is `font: inherit`
+       overriding only `font-size`; the unread pill sets no weight of its own.
+       All three inherit 600 from here, so dropping it demotes all three to 400.
+       `--tandem-text-md` really was inert — nothing in the row consumes it. -->
+  {#if messages.length > 0}
     <div
-      style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border); font-weight: 600; display: flex; align-items: center;"
+      style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border); font-weight: 600; display: flex; align-items: center; justify-content: flex-end; gap: var(--tandem-space-2);"
     >
-      <div
-        style="display: flex; align-items: center; gap: var(--tandem-space-2); margin-left: auto;"
+      {#if unreadCount > 0}
+        <!-- The count was legible as "Chat 3" by adjacency; alone it is a bare
+             number, so it needs the label the word used to supply. Matches how
+             the collapsed-rail badge names the same count (App.svelte). -->
+        <span
+          aria-label="{unreadCount} unread message{unreadCount === 1 ? '' : 's'}"
+          style="background: var(--tandem-accent); color: var(--tandem-accent-fg); border-radius: var(--tandem-r-pill); padding: 2px 8px; font-size: var(--tandem-text-xs);"
+        >
+          {unreadCount}
+        </span>
+      {/if}
+      <button
+        onclick={exportChat}
+        disabled={exporting}
+        title="Export complete chat to a scratchpad"
+        class="chat-header-action"
       >
-        {#if unreadCount > 0}
-          <span
-            style="background: var(--tandem-accent); color: var(--tandem-accent-fg); border-radius: var(--tandem-r-pill); padding: 2px 8px; font-size: var(--tandem-text-xs);"
-          >
-            {unreadCount}
-          </span>
-        {/if}
-        {#if messages.length > 0}
-          <button
-            onclick={exportChat}
-            disabled={exporting}
-            title="Export complete chat to a scratchpad"
-            class="chat-header-action"
-          >
-            {exporting ? "Exporting…" : "Export"}
-          </button>
-          <button
-            onclick={clearChat}
-            disabled={clearing}
-            title="Clear chat history"
-            data-testid="clear-chat-btn"
-            class="chat-header-action"
-          >
-            {clearing ? "Clearing…" : "Clear"}
-          </button>
-        {/if}
-      </div>
+        {exporting ? "Exporting…" : "Export"}
+      </button>
+      <button
+        onclick={clearChat}
+        disabled={clearing}
+        title="Clear chat history"
+        data-testid="clear-chat-btn"
+        class="chat-header-action"
+      >
+        {clearing ? "Clearing…" : "Clear"}
+      </button>
     </div>
   {/if}
 

--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -235,40 +235,59 @@ async function exportChat() {
   data-testid="chat-panel"
   style="width: 100%; display: flex; flex-direction: column; background: var(--tandem-surface-muted); flex: 1; min-height: 0;"
 >
-  <!-- Header -->
-  <div
-    style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border); font-weight: 600; font-size: var(--tandem-text-md); display: flex; justify-content: space-between; align-items: center;"
-  >
-    Chat
-    <div style="display: flex; align-items: center; gap: var(--tandem-space-2);">
-      {#if unreadCount > 0}
-        <span
-          style="background: var(--tandem-accent); color: var(--tandem-accent-fg); border-radius: var(--tandem-r-pill); padding: 2px 8px; font-size: var(--tandem-text-xs);"
-        >
-          {unreadCount}
-        </span>
-      {/if}
-      {#if messages.length > 0}
-        <button
-          onclick={exportChat}
-          disabled={exporting}
-          title="Export complete chat to a scratchpad"
-          class="chat-header-action"
-        >
-          {exporting ? "Exporting…" : "Export"}
-        </button>
-        <button
-          onclick={clearChat}
-          disabled={clearing}
-          title="Clear chat history"
-          data-testid="clear-chat-btn"
-          class="chat-header-action"
-        >
-          {clearing ? "Clearing…" : "Clear"}
-        </button>
-      {/if}
+  <!-- Header. #1382: no "Chat" title — the rail's tab pill above already says
+       so. Removing the word leaves the row with nothing to show on a fresh
+       chat (both the unread pill and Export/Clear are content-gated), so the
+       row is gated too rather than rendering as a bordered, padded empty strip
+       under the tabs — which is itself the redundant chrome this issue is
+       about, and is the exact frame the issue screenshots.
+
+       The trade is a one-time appearance when the first message lands instead
+       of a permanent empty strip. That jump is masked: it coincides with the
+       message list going from empty-state to content, so it is not a shift the
+       user sees happen to stable content.
+
+       Typography (`font-weight: 600`, `--tandem-text-md`) dropped with the
+       text — `.chat-header-action` sets its own, so it styled nothing. -->
+  {#if unreadCount > 0 || messages.length > 0}
+    <div
+      style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border); display: flex; align-items: center;"
+    >
+      <!-- `margin-left: auto` rather than `justify-content: space-between`:
+           with the title gone this is the only flex item, and space-between
+           puts a lone item at flex-start. -->
+      <div
+        style="display: flex; align-items: center; gap: var(--tandem-space-2); margin-left: auto;"
+      >
+        {#if unreadCount > 0}
+          <span
+            style="background: var(--tandem-accent); color: var(--tandem-accent-fg); border-radius: var(--tandem-r-pill); padding: 2px 8px; font-size: var(--tandem-text-xs);"
+          >
+            {unreadCount}
+          </span>
+        {/if}
+        {#if messages.length > 0}
+          <button
+            onclick={exportChat}
+            disabled={exporting}
+            title="Export complete chat to a scratchpad"
+            class="chat-header-action"
+          >
+            {exporting ? "Exporting…" : "Export"}
+          </button>
+          <button
+            onclick={clearChat}
+            disabled={clearing}
+            title="Clear chat history"
+            data-testid="clear-chat-btn"
+            class="chat-header-action"
+          >
+            {clearing ? "Clearing…" : "Clear"}
+          </button>
+        {/if}
+      </div>
     </div>
-  </div>
+  {/if}
 
   <!-- Messages -->
   <div

--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -236,26 +236,21 @@ async function exportChat() {
   style="width: 100%; display: flex; flex-direction: column; background: var(--tandem-surface-muted); flex: 1; min-height: 0;"
 >
   <!-- Header. #1382: no "Chat" title — the rail's tab pill above already says
-       so. Removing the word leaves the row with nothing to show on a fresh
-       chat (both the unread pill and Export/Clear are content-gated), so the
-       row is gated too rather than rendering as a bordered, padded empty strip
-       under the tabs — which is itself the redundant chrome this issue is
-       about, and is the exact frame the issue screenshots.
+       so. With the word gone the row has nothing to show on an empty chat (the
+       unread pill and Export/Clear are all content-gated), so the row is gated
+       too rather than rendering as a bordered, padded empty strip under the
+       tabs. It reappears whenever content returns, and `clearChat` can take it
+       away again, so this is a recurring transition rather than a one-time one.
 
-       The trade is a one-time appearance when the first message lands instead
-       of a permanent empty strip. That jump is masked: it coincides with the
-       message list going from empty-state to content, so it is not a shift the
-       user sees happen to stable content.
-
-       Typography (`font-weight: 600`, `--tandem-text-md`) dropped with the
-       text — `.chat-header-action` sets its own, so it styled nothing. -->
+       `font-weight: 600` stays even though the text it was written for is gone:
+       `.chat-header-action` is `font: inherit`, overriding only `font-size`, so
+       the weight here is what renders Export/Clear and the unread count at 600.
+       Dropping it silently demotes all three to 400. `--tandem-text-md` was
+       genuinely inert (that same rule sets its own `font-size`) and is gone. -->
   {#if unreadCount > 0 || messages.length > 0}
     <div
-      style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border); display: flex; align-items: center;"
+      style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border); font-weight: 600; display: flex; align-items: center;"
     >
-      <!-- `margin-left: auto` rather than `justify-content: space-between`:
-           with the title gone this is the only flex item, and space-between
-           puts a lone item at flex-start. -->
       <div
         style="display: flex; align-items: center; gap: var(--tandem-space-2); margin-left: auto;"
       >

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -584,17 +584,31 @@ function handleRailBackgroundClick(e: MouseEvent) {
 
   <!-- Header -->
   <div style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border);">
-    <div style="display: flex; justify-content: space-between; align-items: center;">
-      <h3 style="font-size: 13px; font-weight: 600; margin: 0;">
-        Annotations
-        {#if filteredData.allPending.length > 0}
-          <span
-            style="margin-left: 8px; padding: 1px 6px; font-size: var(--tandem-text-xs); background: var(--tandem-accent); color: var(--tandem-accent-fg); border-radius: var(--tandem-r-pill);"
-          >
-            {filteredData.allPending.length}
-          </span>
-        {/if}
-      </h3>
+    <!-- #1382: no "Annotations" title — the rail's tab pill directly above
+         already says which tab you are on. The COUNT stays, and that is not
+         cosmetic: both rail-tab badges are gated on their tab being inactive
+         (`pendingAnnotationBadge` returns 0 on the active tab), so while you
+         are looking at this panel the pill below is the only pending count on
+         screen. It also counts something the tab badge does not — the badge
+         filters on `isPendingReviewTarget`, which excludes user-authored
+         annotations, so a user who highlights three phrases sees 3 here and
+         would have seen 0 from the badge.
+
+         `aria-hidden` because the visually-hidden live region below already
+         announces "N pending annotations"; without it the count is spoken
+         twice. No heading element: an <h3> holding only the pill is an
+         `empty-heading` axe violation in the (default) zero-pending state, and
+         `accessibility.spec.ts` builds its scan with no `.withTags()`, so
+         best-practice rules are live. -->
+    <div style="display: flex; align-items: center;">
+      {#if filteredData.allPending.length > 0}
+        <span
+          aria-hidden="true"
+          style="padding: 1px 6px; font-size: var(--tandem-text-xs); background: var(--tandem-accent); color: var(--tandem-accent-fg); border-radius: var(--tandem-r-pill);"
+        >
+          {filteredData.allPending.length}
+        </span>
+      {/if}
       <span
         aria-live="polite"
         style="position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0);"
@@ -603,7 +617,14 @@ function handleRailBackgroundClick(e: MouseEvent) {
           ? "s"
           : ""}
       </span>
-      <div style="display: flex; align-items: center; gap: var(--tandem-space-2);">
+      <!-- `margin-left: auto`, NOT the row's old `justify-content:
+           space-between`. With the title gone the pill is conditional, so the
+           row alternates between one and two flex items — and `space-between`
+           puts a lone item at flex-start, which made these controls jump ~180px
+           left and back every time the pending count crossed 0/1. -->
+      <div
+        style="display: flex; align-items: center; gap: var(--tandem-space-2); margin-left: auto;"
+      >
         <button
           data-testid="annotation-sort-toggle"
           onclick={toggleSortMode}

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -584,12 +584,18 @@ function handleRailBackgroundClick(e: MouseEvent) {
 
   <!-- Header -->
   <div style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border);">
-    <!-- #1382: no "Annotations" title — the tab pill directly above says it.
+    <!-- #1382: no "Annotations" title — the rail tab directly above says it,
+         and the region is named independently (`role="complementary"
+         aria-label="Annotations and chat"` in App.svelte), so deleting the
+         heading leaves nothing unnamed.
+
          The count is NOT redundant with the tab badge and must stay: that badge
-         hides on the active tab and counts a narrower set (see #1382).
-         `aria-hidden` because the live region below already speaks it, and no
-         heading element because an <h3> holding only a pill trips axe's
-         `empty-heading` in the zero-pending state. -->
+         hides on the active tab, and it counts a strict subset (see #1382).
+         `aria-hidden` because the live region below already speaks it. No
+         heading element either — an <h3> whose only child is an `aria-hidden`
+         pill has no accessible text in ANY state, so it would trip axe's
+         `empty-heading` (live: see the disabled-rules list in
+         tests/e2e/accessibility.spec.ts). -->
     <div style="display: flex; align-items: center;">
       {#if filteredData.allPending.length > 0}
         <span
@@ -608,11 +614,12 @@ function handleRailBackgroundClick(e: MouseEvent) {
           : ""}
       </span>
       <!-- `margin-left: auto`, not the row's old `justify-content:
-           space-between`: the pill is conditional, so the row alternates
-           between one and two flex items, and `space-between` puts a lone item
-           at flex-start — measured as these controls jumping ~180px left and
-           back each time the pending count crossed 0/1. ChatPanel's header row
-           is the same shape for the same reason. -->
+           space-between`. The leading item is now conditional, so
+           `space-between` can't be trusted to hold these right: with the pill
+           absent it parked the lone controls div at flex-start, and they
+           snapped to the left edge and back each time the pending count
+           crossed 0/1. (The `aria-live` span above is `position: absolute`, so
+           it is out of flow and not a flex item at all.) -->
       <div
         style="display: flex; align-items: center; gap: var(--tandem-space-2); margin-left: auto;"
       >

--- a/src/client/panels/SidePanel.svelte
+++ b/src/client/panels/SidePanel.svelte
@@ -584,22 +584,12 @@ function handleRailBackgroundClick(e: MouseEvent) {
 
   <!-- Header -->
   <div style="padding: var(--tandem-space-3) var(--tandem-space-4); border-bottom: 1px solid var(--tandem-border);">
-    <!-- #1382: no "Annotations" title — the rail's tab pill directly above
-         already says which tab you are on. The COUNT stays, and that is not
-         cosmetic: both rail-tab badges are gated on their tab being inactive
-         (`pendingAnnotationBadge` returns 0 on the active tab), so while you
-         are looking at this panel the pill below is the only pending count on
-         screen. It also counts something the tab badge does not — the badge
-         filters on `isPendingReviewTarget`, which excludes user-authored
-         annotations, so a user who highlights three phrases sees 3 here and
-         would have seen 0 from the badge.
-
-         `aria-hidden` because the visually-hidden live region below already
-         announces "N pending annotations"; without it the count is spoken
-         twice. No heading element: an <h3> holding only the pill is an
-         `empty-heading` axe violation in the (default) zero-pending state, and
-         `accessibility.spec.ts` builds its scan with no `.withTags()`, so
-         best-practice rules are live. -->
+    <!-- #1382: no "Annotations" title — the tab pill directly above says it.
+         The count is NOT redundant with the tab badge and must stay: that badge
+         hides on the active tab and counts a narrower set (see #1382).
+         `aria-hidden` because the live region below already speaks it, and no
+         heading element because an <h3> holding only a pill trips axe's
+         `empty-heading` in the zero-pending state. -->
     <div style="display: flex; align-items: center;">
       {#if filteredData.allPending.length > 0}
         <span
@@ -617,11 +607,12 @@ function handleRailBackgroundClick(e: MouseEvent) {
           ? "s"
           : ""}
       </span>
-      <!-- `margin-left: auto`, NOT the row's old `justify-content:
-           space-between`. With the title gone the pill is conditional, so the
-           row alternates between one and two flex items — and `space-between`
-           puts a lone item at flex-start, which made these controls jump ~180px
-           left and back every time the pending count crossed 0/1. -->
+      <!-- `margin-left: auto`, not the row's old `justify-content:
+           space-between`: the pill is conditional, so the row alternates
+           between one and two flex items, and `space-between` puts a lone item
+           at flex-start — measured as these controls jumping ~180px left and
+           back each time the pending count crossed 0/1. ChatPanel's header row
+           is the same shape for the same reason. -->
       <div
         style="display: flex; align-items: center; gap: var(--tandem-space-2); margin-left: auto;"
       >


### PR DESCRIPTION
#1382 is one line of prose and two screenshots: *"Explanatory headers are not
needed when the top of the rail already indicates whether the user is on the
annotations tab or the chat tab."*

The redundancy is the **word**, not the header row. Both rows also host controls
redundant with nothing — sort, filter, export, clear-chat, the pending count and
its live region. So this deletes two strings and keeps everything else, which
turned out to be the whole difficulty: removing the words broke two things that
had been leaning on them.

Closes #1382

## What the header rows were actually holding

`SidePanel.svelte`'s `<h3>Annotations</h3>` had the **pending-count pill nested
inside it**, and both rail-tab badges in `App.svelte` are gated on their tab
being *inactive*. So while you are looking at the annotations panel its own tab
badge is hidden, and that nested pill is the only pending count on screen. The
obvious reading of "remove redundant UI" — delete the header — silently removes
the count from the one view where it is the sole indicator.

The two counts are not the same number either. The tab badge filters on
`isPendingReviewTarget` (`src/shared/types.ts:239-246`), which excludes
user-authored annotations; the pill counts `allPending`, with no author test.
Both read the same base array, so the badge set is a strict subset — highlight
three phrases yourself and the pill says 3 where the badge says 0.

So the pill is hoisted out of the deleted `<h3>` rather than removed with it, as
a standalone `aria-hidden` span — `aria-hidden` because the visually-hidden
`aria-live` sibling right below already announces "N pending annotations"
(unconditionally mounted, per #1376), and without it the count is spoken twice.

**No heading element replaces the `<h3>`.** An `<h3>` whose only child is an
`aria-hidden` pill has no accessible text in any state, so it trips
`empty-heading` — and `tests/e2e/accessibility.spec.ts` builds its AxeBuilder
with no `.withTags()`, so best-practice rules are live and that would have failed
CI. What actually makes the deletion safe is that the rail carries
`role="complementary" aria-label="Annotations and chat"` (`App.svelte:2592-2595`);
the region was never named by the heading.

## The chat header is now gated, which is a judgment call

Remove the word `Chat` and the row has nothing left to show on a fresh chat —
the unread pill and Export/Clear are all content-gated. The choice was a
bordered, padded empty strip under the tabs (which is itself the redundant
chrome this issue is about, and is the exact frame the issue screenshots) or
gating the row.

I gated it rather than blocking on you, because the alternative — a `min-height`
holding an always-visible empty strip — preserves the thing the issue objects to.
The cost is a transition when the first message lands, and it is **recurring**,
not one-time: `clearChat()` empties the list and takes the row away again. That
jump coincides with the message list going from empty-state to content, so it is
not a shift the user sees happen to stable content. **Say if you would rather
have the reserved strip** — it is a two-line change in the other direction.

## Two defects the gate and the deletion introduced

Both found by review, neither by any test.

**Focus fell to `<body>` on clear.** `clear-chat-btn` is the button the user just
pressed, and a successful clear empties `messages`, closes the new gate and
destroys it. The next Tab restarted at the top of the document. Worse, the rail
shell's `onfocusout` (`App.svelte:1455-1462`) treats a null `relatedTarget` as
"focus left the shell", so a hover-revealed rail either collapsed out from under
you mid-task or latched open and stopped retreating on mouse-leave. This is new:
before the gate the header row survived a clear, which kept focus inside the
shell. `clearChat` now redirects focus to the composer — inside the shell, and
the natural next action.

**The unread pill lost its meaning with the word.** It read as "Chat 3" by
adjacency; deleting the adjacency left a bare number with no label and no live
region, so a browse-mode reader got a naked "3" as the first thing in the panel.
It now carries an `aria-label`, matching how `App.svelte` already names the same
count on the collapsed-rail badge. SidePanel got the `aria-hidden` + live-region
treatment in this branch; ChatPanel had received neither half.

## A layout bug the deletion created, found by measurement

Both rows used `justify-content: space-between`, correct while the title was a
permanent first flex item. With it gone, SidePanel's row alternates between one
and two in-flow children as the count crosses 0/1 — and `space-between` parks a
*lone* item at flex-start, so the sort and filter controls snapped to the left
edge and back, oscillating with the count. (The `aria-live` span in that row is
`position: absolute`, so it is out of flow and not a flex item; the alternation
really is one-and-two.) `margin-left: auto` is stable regardless of how many
siblings render.

## The regression that nearly shipped inside the cleanup

ChatPanel's header carried `font-weight: 600` and `--tandem-text-md`. I removed
both with the text, calling them dead style. `--tandem-text-md` was.
`font-weight: 600` was not: Export/Clear are `.chat-header-action`, which is
`font: inherit` overriding only `font-size`, and the unread pill sets no weight
of its own — so all three inherit 600 from this row. Dropping it silently
demoted all three to 400. No error, no failing test. Restored, with the
mechanism recorded at the declaration.

## Simplifications review found

`unreadCount` is `$derived` as a filter over `messages` (`useChatState.svelte.ts:43-47`)
and `App.svelte:2653-2654` passes both props from the same `chatState`, so
`unreadCount > 0` strictly implies `messages.length > 0`. The gate
`unreadCount > 0 || messages.length > 0` was therefore exactly
`messages.length > 0`. Simplifying it also collapses the inner duplicate of the
same condition — taking `clear-chat-btn` back to one gate rather than the two
nested ones my first commit gave it — and with the pill inside the actions
group, the redundant nested flex wrapper goes too.

## Testids

`annotation-sort-toggle`, `filter-bar-toggle` and `clear-chat-btn` all survive
verbatim (Critical Rule 7). None added, none removed, so
`__snapshots__/testid-set.snap.txt` is byte-unchanged — this branch does not
touch the snapshot file C4's unmerged PR owns.

## Tests: none added, deliberately

Every constructible assertion fails the bar. Empty chat → no `clear-chat-btn`
passes on master (the inner gate already did that). Messages present → button
present also passes on master. `unreadCount: 3, messages: []` is the only state
that distinguishes the old outer gate, and the wiring provably cannot produce it.
The one true characterization — "no bordered strip on an empty chat" — needs
either a forbidden new testid or a `querySelector` pinning an inline style
string. A test that cannot fail is theatre; I would rather ship none and say so.

Nothing existing breaks: there is no `getByRole("heading")` anywhere in `tests/`,
no text locator on either removed string, and no spec references the Export
button, `clear-chat-btn`, or the header row.

**One accepted coverage narrowing.** `accessibility.spec.ts`'s `"chat panel"`
surface boots with no messages, so the header subtree no longer exists there and
that surface audits slightly less. I checked what was actually lost: Export/Clear
were gated on `messages.length > 0` before this branch too, so they were never
audited in that surface — what disappeared is an empty bordered row and a word
that no longer exists. Seeding a message would *add* coverage that never existed,
which is worth doing, but it changes a spec I cannot run locally and a chat send
can raise the push-delivery notice, dragging a new component into the scan.
Deliberately not done blind here.

## Verification

- `npm run typecheck` — 1323 files, 0 errors, 0 warnings
- `npm test -- --run` — 459 files, 6669 passed, 19 skipped, on the rebased base
- `npm run check:tokens` — only pre-existing warnings, none in these two files
- Pre-commit ran biome + the token scan on both files

**E2E did not run locally.** Your Tandem desktop app is running and its sidecar
holds `:3478`, so the harness browser reaches that server instead of the test
one; I did not kill your editor to get a number. CI runs `npm run test:e2e`, and
`accessibility.spec.ts` is the spec that matters here — its `"annotation card"`
surface provably opens the rail, so the axe scan covers the heading deletion
directly.

## Rebased off C7

This branch was cut from `fix/c7-composer-restyle` and carried its three commits.
Since the two touch entirely disjoint files, I rebased onto `origin/master` so
this is independent — #1449 and this can merge in either order.

## README screenshots are now stale

`annotation-list-scroll-container` and `chat-panel` are both on their component's
**root**, so `03-side-panel.png` and `02-chat-sidebar.png` are element shots that
include the header rows this PR changes; `01-editor-overview.png` and
`05-review-mode.png` are full-page and show the rail too. Regenerating needs
`scripts/take-screenshots.mjs`, which needs the same ports as E2E — blocked by
the same conflict. Worth a run when the desktop app is closed.

## Review

`/simplify` (2 lenses) then `/pr-review-toolkit:review-pr` (4 lenses), on top of
a 3-lens adversarial panel on the plan before any code.

What review changed: the two defects above; the `font-weight` regression; the
flex collapse (found by rendering both states rather than reading the CSS); the
`empty-heading` violation that killed the "keep an empty `<h3>`" option; the dead
disjunct, which three lenses found independently; and roughly half the comment
volume — including three claims in my own comments that were false or
half-right. The worst was a flat assertion that ChatPanel's header row "is the
same shape for the same reason" as SidePanel's. It is not: its row has one
unconditional child and never alternates, so the hazard I claimed it shared
cannot occur there.

Recorded as *no action*: the header-row style string recurs inline at six sites
with no shared class anywhere in `src/client`, so per-component inline is the
house style; the accent count pill is correctly distinct from `.rail-tab-badge`
(accent vs error are different semantics); `OutlinePanel`'s "Outline" label must
stay, because the left rail has no tab picker above it post-Wave-I; and
`{#if}`-gating bordered chrome matches `CommentThread.svelte:16`.

One pre-existing thing worth knowing, out of scope here: the premise "the tab
above says which panel you're on" is true visually but not programmatically —
`App.svelte:2624-2648` renders the rail tabs as plain `<button>`s with a CSS
`on` class, no `role="tab"`, no `aria-selected`, no `aria-current`. Unchanged by
this branch, but it means the removed labels were never being replaced by an
accessible tab state. Happy to file it.

No `CHANGELOG.md` entry — this wave writes the changelog once at integration
from the diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYGFawL9kQruDZiUkYGBKD
