### PR TITLE
test(fidelity): harnesses that can see a first-pass document mutation

### DIFF
--- a/tests/client/attribute-parity.test.ts
+++ b/tests/client/attribute-parity.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Server-written Y attributes must be declared on the client node (#1448).
+ *
+ * The server sets attributes on Y.XmlElements (`mdast-ydoc.ts`); the client
+ * turns those elements into ProseMirror nodes via `schema.node()`, which drops
+ * any attribute the node spec does not declare; y-prosemirror then prunes the
+ * dropped key back out of the Y.Doc ("remove all keys that are no longer in
+ * pAttrs"). So an attribute the client forgot to declare is not merely ignored
+ * — it is deleted from the document, permanently, on the first edit.
+ *
+ * That is how `table.align` was lost: `|:--|:-:|--:|` came back `|---|---|---|`
+ * with nothing in any log. Nothing else in the suite can see this class, and it
+ * is silent by construction, so the check has to be structural.
+ *
+ * The server side is derived from real documents rather than a hand-kept list,
+ * because a hand-kept list is exactly what would drift.
+ */
+
+import { describe, expect, it } from "vitest";
+import { productionSchema, yAttributes } from "./editor-roundtrip-harness.js";
+
+/**
+ * One document per attribute-bearing construct. Deliberately inline rather than
+ * read from `tests/fixtures/`: this test's job is to notice when the server
+ * starts writing an attribute the client does not declare, and a shared fixture
+ * someone else edits for an unrelated reason is a weak place to anchor that.
+ */
+const SOURCES = [
+  "# H1\n\n### H3\n",
+  "| L | C | R |\n| :- | :-: | -: |\n| 1 | 2 | 3 |\n",
+  "3. three\n4. four\n",
+  "```ts\nconst x = 1;\n```\n",
+  "- [ ] todo\n- [x] done\n",
+  "![alt](img.png 'title')\n",
+  '<div class="raw">block</div>\n',
+  "[ref]: https://example.com\n\nSee [ref].\n",
+  "Text[^1]\n\n[^1]: A footnote.\n",
+];
+
+/** Every (nodeName, attribute) pair the server actually writes. */
+function serverWrittenAttributes(): Map<string, Set<string>> {
+  const written = new Map<string, Set<string>>();
+  for (const source of SOURCES) {
+    for (const [nodeName, attrs] of yAttributes(source)) {
+      const set = written.get(nodeName) ?? new Set<string>();
+      for (const key of Object.keys(attrs)) set.add(key);
+      written.set(nodeName, set);
+    }
+  }
+  return written;
+}
+
+describe("Y attribute parity between server and client schema", () => {
+  it("every attribute the server writes is declared on the client node", () => {
+    const schema = productionSchema();
+    const dropped: string[] = [];
+
+    for (const [nodeName, attrs] of serverWrittenAttributes()) {
+      const type = schema.nodes[nodeName];
+      if (!type) {
+        dropped.push(`${nodeName}: node is absent from the client schema entirely`);
+        continue;
+      }
+      const declared = new Set(Object.keys(type.spec.attrs ?? {}));
+      for (const attr of attrs) {
+        if (!declared.has(attr)) dropped.push(`${nodeName}.${attr}`);
+      }
+    }
+
+    // V4 is open: `table.align` is the one casualty today. When PR 3 declares
+    // it, this list empties and the assertion below becomes the permanent gate.
+    expect(dropped).toEqual(["table.align"]);
+  });
+
+  it.fails("no server-written attribute is discarded by the client schema", () => {
+    const schema = productionSchema();
+    const dropped: string[] = [];
+    for (const [nodeName, attrs] of serverWrittenAttributes()) {
+      const declared = new Set(Object.keys(schema.nodes[nodeName]?.spec.attrs ?? {}));
+      for (const attr of attrs) if (!declared.has(attr)) dropped.push(`${nodeName}.${attr}`);
+    }
+    expect(dropped).toEqual([]);
+  });
+
+  it("the attributes that do survive are still surviving", () => {
+    // A regression guard with teeth: these are the nine that work today, so a
+    // change that breaks one fails here rather than silently eating data.
+    const schema = productionSchema();
+    const expected: Record<string, string[]> = {
+      heading: ["level"],
+      orderedList: ["start"],
+      listItem: ["checked"],
+      codeBlock: ["language"],
+      paragraph: ["markdownHtml", "markdownRaw"],
+      image: ["src", "alt", "title"],
+    };
+    for (const [nodeName, attrs] of Object.entries(expected)) {
+      const declared = Object.keys(schema.nodes[nodeName]?.spec.attrs ?? {});
+      for (const attr of attrs) {
+        expect(declared, `${nodeName}.${attr} must stay declared`).toContain(attr);
+      }
+    }
+  });
+});

--- a/tests/client/editor-roundtrip-harness.ts
+++ b/tests/client/editor-roundtrip-harness.ts
@@ -170,7 +170,11 @@ export function editorRoundTrip(
   let reparsed = attached;
   if (edit) {
     reparsed = reparseThroughDom(attached, schema, docSpanning);
-    updateYFragment(doc, fragment, reparsed, { mapping: new Map() } as never);
+    // BindingMetadata requires both maps: `mapping` for node identity reuse and `isOMark`
+    // for overlapping-mark hashing. y-prosemirror's marksToAttributes() calls
+    // map.setIfUndefined(meta.isOMark, ...) unconditionally for any marked text run, so an
+    // omitted isOMark throws the moment a fixture contains an inline mark (bold/italic/code/link).
+    updateYFragment(doc, fragment, reparsed, { mapping: new Map(), isOMark: new Map() } as never);
   }
 
   const output = saveMarkdown(doc);

--- a/tests/client/editor-roundtrip-harness.ts
+++ b/tests/client/editor-roundtrip-harness.ts
@@ -1,0 +1,197 @@
+/**
+ * Editor round-trip harness (#1448).
+ *
+ * Every markdown suite we had asserted *idempotency* (`pass2 === pass1`), which
+ * a first-pass mutation trivially satisfies — and all of them run server-side,
+ * where `loadMarkdown → saveMarkdown` is already clean. That combination is why
+ * the soft-wrap → hard-break defect shipped: the damage is done by the editor,
+ * on the way back out of the DOM, and no test could see it.
+ *
+ * This drives the path those suites cannot:
+ *
+ *   markdown → Y.Doc → ProseMirror → DOM → re-parse → Y.Doc → markdown
+ *
+ * and asserts byte-identity on the FIRST pass.
+ *
+ * ## Why this reproduces production rather than approximating it
+ *
+ * The re-parse is what `prosemirror-view`'s `readDOMChange` → `parseBetween`
+ * does after the browser reports a DOM mutation. Two details there are
+ * load-bearing, and getting either wrong makes the harness pass while the
+ * product is broken:
+ *
+ * 1. **The whitespace mode.** `parseBetween` passes
+ *    `preserveWhitespace: $from.parent.type.whitespace == "pre" ? "full" : true`
+ *    (`prosemirror-view/dist/index.js:4974`). Plain `true` — not `"full"` — is
+ *    the mode that reaches `prosemirror-model`'s `linebreakReplacement` branch,
+ *    which splits text on `/\r?\n|\r/` and inserts a `hardBreak` between the
+ *    pieces. `"full"` keeps the newline as text; `false` collapses it to a space.
+ *
+ * 2. **`ruleFromNode`.** For any DOM node backed by a node view desc,
+ *    `NodeViewDesc.parseRule` supplies `{ node, attrs }` and adds
+ *    `preserveWhitespace: "full"` *only* when that node type's whitespace is
+ *    `"pre"` (`prosemirror-view/dist/index.js:1336-1338`). We emulate it rather
+ *    than omitting it, because it decides two separate questions: whether a
+ *    block escapes the newline split, and whether its attributes survive a
+ *    re-read even when the node spec's `parseHTML` would discard them.
+ *
+ * `docSpanning: true` models the case that actually damaged `README.md` — a
+ * childList mutation whose target is the doc node, which re-parses every block
+ * in one pass with `$from.parent` being the doc (whitespace `"normal"`), so no
+ * block gets `"full"` from `parseBetween` itself.
+ */
+
+import { getSchema } from "@tiptap/core";
+import {
+  DOMSerializer,
+  DOMParser as PMDOMParser,
+  Node as PMNode,
+  type Schema,
+} from "prosemirror-model";
+import {
+  prosemirrorToYXmlFragment,
+  updateYFragment,
+  yXmlFragmentToProsemirrorJSON,
+} from "y-prosemirror";
+import * as Y from "yjs";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions.js";
+import { loadMarkdown, saveMarkdown } from "../../src/server/file-io/markdown.js";
+
+/** The production editor schema, built from the same extension list the app uses. */
+export function productionSchema(): Schema {
+  return getSchema(buildSchemaExtensions());
+}
+
+/**
+ * Build the schema with `overrides` applied to named node specs.
+ *
+ * Exists because the obvious way to override a StarterKit-provided node is a
+ * silent no-op: `paragraph` has no entry of its own in `buildSchemaExtensions()`
+ * (it comes from `starterKit`), so filtering the extension list by
+ * `e.name === "paragraph"` matches nothing and the "modified" schema is
+ * byte-identical to the stock one. Patching the assembled spec cannot miss.
+ */
+export function schemaWith(overrides: Record<string, Record<string, unknown>>): Schema {
+  const base = productionSchema();
+  let nodes = base.spec.nodes;
+  for (const [name, patch] of Object.entries(overrides)) {
+    const spec = nodes.get(name);
+    if (!spec) throw new Error(`schemaWith: no such node in the production schema: ${name}`);
+    nodes = nodes.update(name, { ...spec, ...patch });
+  }
+  return new (base.constructor as typeof import("prosemirror-model").Schema)({
+    nodes,
+    marks: base.spec.marks,
+  });
+}
+
+/** Y.Doc → ProseMirror, the way y-prosemirror's sync plugin builds the initial doc. */
+export function yDocToPmNode(doc: Y.Doc, schema: Schema): PMNode {
+  return PMNode.fromJSON(schema, yXmlFragmentToProsemirrorJSON(doc.getXmlFragment("default")));
+}
+
+/**
+ * Serialize a PM node to DOM and read it back the way `readDOMChange` does.
+ *
+ * `docSpanning` selects which node `$from.parent` resolves to: the doc node (a
+ * mutation targeting the whole document) or the single block being edited.
+ */
+export function reparseThroughDom(node: PMNode, schema: Schema, docSpanning: boolean): PMNode {
+  const serializer = DOMSerializer.fromSchema(schema);
+  const holder = document.createElement("div");
+
+  // Serialize block by block so each top-level element can be mapped back to the
+  // exact node that produced it. That mapping is what a node view desc gives
+  // prosemirror-view for free; reconstructing it by tag name would guess.
+  const nodeForElement = new Map<Node, PMNode>();
+  node.forEach((child) => {
+    const dom = serializer.serializeNode(child, { document });
+    nodeForElement.set(dom, child);
+    holder.appendChild(dom);
+  });
+
+  // Emulate prosemirror-view's `ruleFromNode`: a desc-backed element re-parses
+  // through its own node's rule, carrying current attrs and — only for a "pre"
+  // node type — `preserveWhitespace: "full"`.
+  const ruleFromNode = (dom: Node) => {
+    const child = nodeForElement.get(dom);
+    if (!child) return null;
+    const rule: Record<string, unknown> = { node: child.type.name, attrs: child.attrs };
+    if (child.type.whitespace === "pre") rule.preserveWhitespace = "full";
+    return rule;
+  };
+
+  const parentWhitespace = docSpanning
+    ? schema.nodes.doc.whitespace
+    : node.child(0).type.whitespace;
+  return PMDOMParser.fromSchema(schema).parse(holder, {
+    preserveWhitespace: parentWhitespace === "pre" ? "full" : true,
+    ruleFromNode: ruleFromNode as never,
+  });
+}
+
+export interface RoundTripResult {
+  /** Markdown after a full load → attach → DOM re-read → save cycle. */
+  output: string;
+  /** Markdown after load → save with no editor involvement (the server-only path). */
+  serverOnly: string;
+  /** The PM doc as the editor first sees it, before any DOM round trip. */
+  attached: PMNode;
+  /** The PM doc after the DOM re-read — the shape that gets written back to Y. */
+  reparsed: PMNode;
+}
+
+/**
+ * Run markdown through the full editor cycle.
+ *
+ * Set `edit: false` to model open-and-close: the editor attaches, nothing is
+ * mutated, and nothing should be written back. That is the negative control —
+ * it must stay byte-clean even while the edit path is broken, and if it ever
+ * fails the defect is somewhere other than the DOM re-read.
+ */
+export function editorRoundTrip(
+  markdown: string,
+  opts: { schema?: Schema; docSpanning?: boolean; edit?: boolean } = {},
+): RoundTripResult {
+  const schema = opts.schema ?? productionSchema();
+  const docSpanning = opts.docSpanning ?? true;
+  const edit = opts.edit ?? true;
+
+  const serverDoc = new Y.Doc();
+  loadMarkdown(serverDoc, markdown);
+  const serverOnly = saveMarkdown(serverDoc);
+  serverDoc.destroy();
+
+  const doc = new Y.Doc();
+  loadMarkdown(doc, markdown);
+  const fragment = doc.getXmlFragment("default");
+  const attached = yDocToPmNode(doc, schema);
+
+  let reparsed = attached;
+  if (edit) {
+    reparsed = reparseThroughDom(attached, schema, docSpanning);
+    updateYFragment(doc, fragment, reparsed, { mapping: new Map() } as never);
+  }
+
+  const output = saveMarkdown(doc);
+  doc.destroy();
+  return { output, serverOnly, attached, reparsed };
+}
+
+/** Collect every attribute present on the Y.Doc's block elements, keyed by node name. */
+export function yAttributes(markdown: string): Map<string, Record<string, unknown>> {
+  const doc = new Y.Doc();
+  loadMarkdown(doc, markdown);
+  const found = new Map<string, Record<string, unknown>>();
+  const visit = (el: Y.XmlElement | Y.XmlText | Y.XmlHook) => {
+    if (!(el instanceof Y.XmlElement)) return;
+    const attrs = el.getAttributes() as Record<string, unknown>;
+    if (Object.keys(attrs).length > 0 && !found.has(el.nodeName)) found.set(el.nodeName, attrs);
+    el.toArray().forEach(visit);
+  };
+  doc.getXmlFragment("default").toArray().forEach(visit);
+  doc.destroy();
+  return found;
+}
+
+export { prosemirrorToYXmlFragment };

--- a/tests/client/editor-roundtrip.test.ts
+++ b/tests/client/editor-roundtrip.test.ts
@@ -71,6 +71,19 @@ describe("editor round-trip: soft wraps (V3)", () => {
   });
 });
 
+describe("editor round-trip: inline marks", () => {
+  // updateYFragment's BindingMetadata needs both `mapping` and `isOMark` --
+  // y-prosemirror's marksToAttributes() calls map.setIfUndefined(meta.isOMark, ...)
+  // unconditionally for every marked text run, so an omitted isOMark throws the
+  // moment a fixture contains a mark. None of the other suites in this file touch
+  // marked text, so this is the only thing that exercises that argument at all.
+  const MARKED = "Some **bold** and *italic* and `code` text.\n";
+
+  it("an edit through a marked paragraph does not throw", () => {
+    expect(() => editorRoundTrip(MARKED)).not.toThrow();
+  });
+});
+
 describe("editor round-trip: table column alignment (V4)", () => {
   const ALIGNED = "| L | C | R |\n| :- | :-: | -: |\n| 1 | 2 | 3 |\n";
 

--- a/tests/client/editor-roundtrip.test.ts
+++ b/tests/client/editor-roundtrip.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Editor round-trip fidelity (#1448).
+ *
+ * These are the assertions no existing suite could make: byte-identity on the
+ * FIRST pass, through the editor rather than around it. See
+ * `editor-roundtrip-harness.ts` for why the DOM re-read has to be modelled
+ * exactly.
+ *
+ * Several cases below document defects that are still open. They are written as
+ * the behaviour we want and marked `.fails`, so the suite goes green the moment
+ * the fix lands and cannot be forgotten — rather than encoding the bug as if it
+ * were the spec.
+ */
+
+import { describe, expect, it } from "vitest";
+import { editorRoundTrip, productionSchema, schemaWith } from "./editor-roundtrip-harness.js";
+
+const SOFT_WRAPPED =
+  "At work I kept asking Claude to draft a report for me. I had it write into\na scratch file in my vault, and it updated the instant Claude touched it.\n";
+
+describe("editor round-trip: the negative control", () => {
+  it("attaching the editor and touching nothing does not change the document", () => {
+    const { output } = editorRoundTrip(SOFT_WRAPPED, { edit: false });
+    expect(output).toBe(SOFT_WRAPPED);
+  });
+
+  it("the server-only path was never the problem", () => {
+    // Pinning this makes the diagnosis un-forgettable: if someone "fixes"
+    // soft wraps in the serializer, this stays green and the real defect
+    // (the DOM re-read) survives untouched.
+    const { serverOnly } = editorRoundTrip(SOFT_WRAPPED);
+    expect(serverOnly).toBe(SOFT_WRAPPED);
+  });
+});
+
+describe("editor round-trip: soft wraps (V3)", () => {
+  it.fails("a soft-wrapped paragraph survives an edit", () => {
+    const { output } = editorRoundTrip(SOFT_WRAPPED);
+    expect(output).toBe(SOFT_WRAPPED);
+  });
+
+  it("today a soft wrap becomes a hard break, and this is the defect", () => {
+    const { output } = editorRoundTrip(SOFT_WRAPPED);
+    expect(output).toContain("write into\\\n");
+  });
+
+  it("declaring paragraph whitespace:'pre' fixes it", () => {
+    const schema = schemaWith({ paragraph: { whitespace: "pre" } });
+    // Guard against the silent no-op: a filtered-extension override would
+    // match nothing and this test would "pass" against the stock schema.
+    expect(schema.nodes.paragraph.spec.whitespace).toBe("pre");
+
+    const { output } = editorRoundTrip(SOFT_WRAPPED, { schema });
+    expect(output).toBe(SOFT_WRAPPED);
+  });
+
+  it("an explicit hard break still survives whitespace:'pre'", () => {
+    const withBreak = "first line\\\nsecond line\n";
+    const schema = schemaWith({ paragraph: { whitespace: "pre" } });
+    const { output } = editorRoundTrip(withBreak, { schema });
+    expect(output).toBe(withBreak);
+  });
+
+  it("the doc-spanning re-parse is what damages untouched paragraphs", () => {
+    // A childList mutation targeting the doc node re-parses every block in one
+    // pass, which is why one edit backslashed every wrapped line of README.md.
+    const twoParas = `${SOFT_WRAPPED}\nA second paragraph, also\nwrapped across lines.\n`;
+    const { output } = editorRoundTrip(twoParas, { docSpanning: true });
+    const damaged = output.split("\n").filter((l) => l.endsWith("\\")).length;
+    expect(damaged).toBeGreaterThan(1);
+  });
+});
+
+describe("editor round-trip: table column alignment (V4)", () => {
+  const ALIGNED = "| L | C | R |\n| :- | :-: | -: |\n| 1 | 2 | 3 |\n";
+
+  it("the Tiptap table node declares no attributes, so align cannot survive", () => {
+    // The loss happens at `schema.node()` when the PM doc is built from the
+    // Y.Doc — before the DOM is involved at all. This assertion is the root
+    // cause; the round-trip below is the symptom.
+    expect(Object.keys(productionSchema().nodes.table.spec.attrs ?? {})).not.toContain("align");
+  });
+
+  it.fails("an aligned table survives an edit", () => {
+    const { output } = editorRoundTrip(ALIGNED);
+    expect(output).toContain(":-:");
+  });
+
+  it("today alignment is silently dropped, permanently", () => {
+    const { output, attached } = editorRoundTrip(ALIGNED);
+    expect(attached.child(0).attrs.align).toBeUndefined();
+    expect(output).not.toContain(":-:");
+  });
+});
+
+describe("editor round-trip: multi-line verbatim blocks (V6)", () => {
+  const RAW_HTML = '<div class="x">\n  <span>one</span>\n  <span>two</span>\n</div>\n\nAfter.\n';
+
+  it("round-trips cleanly with no editor in the loop", () => {
+    const { serverOnly } = editorRoundTrip(RAW_HTML);
+    expect(serverOnly).toBe(RAW_HTML);
+  });
+
+  it.fails("a multi-line raw HTML block survives an edit", () => {
+    const { output } = editorRoundTrip(RAW_HTML);
+    expect(output).toBe(RAW_HTML);
+  });
+});

--- a/tests/fixtures/roundtrip/frontmatter.md
+++ b/tests/fixtures/roundtrip/frontmatter.md
@@ -1,0 +1,8 @@
+---
+title: A Note
+tags: [reference, markdown]
+created: 2026-08-14
+---
+
+An Obsidian-style note. The block above is YAML frontmatter: metadata, not
+content. Losing it loses the note's tags, aliases and dates.

--- a/tests/fixtures/roundtrip/inline-code-fence.md
+++ b/tests/fixtures/roundtrip/inline-code-fence.md
@@ -1,0 +1,8 @@
+A code span whose content contains a backtick run needs a fence longer than any
+run inside it. The serializer escapes the inner backticks instead of lengthening
+the fence, so the span ends early and the words on either side get glued
+together.
+
+Control, and this one is clean: `console.error(\` followed by prose.
+
+The case that breaks: `x ?? ``y``` and text after it.

--- a/tests/fixtures/roundtrip/loose-list.md
+++ b/tests/fixtures/roundtrip/loose-list.md
@@ -1,0 +1,8 @@
+A loose list: the blank lines between items are semantic, because they make the
+renderer wrap each item's text in a paragraph.
+
+- first item
+
+- second item
+
+- third item

--- a/tests/fixtures/roundtrip/nested-marks.md
+++ b/tests/fixtures/roundtrip/nested-marks.md
@@ -1,0 +1,2 @@
+A mark nested inside another mark, which is where delimiter reconstruction goes
+wrong: the **local slice's** mechanism, and ~~a **struck** phrase~~ too.

--- a/tests/fixtures/roundtrip/raw-blocks.md
+++ b/tests/fixtures/roundtrip/raw-blocks.md
@@ -1,0 +1,12 @@
+Constructs Tandem keeps as verbatim source rather than modelling.
+
+<div class="callout">
+  <span>line one</span>
+  <span>line two</span>
+</div>
+
+A reference link to [the spec][spec], and a footnote[^why].
+
+[spec]: https://spec.commonmark.org
+
+[^why]: Because the mdast node carries no `.value`.

--- a/tests/fixtures/roundtrip/soft-wrap.md
+++ b/tests/fixtures/roundtrip/soft-wrap.md
@@ -1,0 +1,6 @@
+A paragraph whose lines are soft-wrapped by the author rather than by the
+renderer. The newlines carry no meaning to a markdown renderer, but they are
+the author's formatting and a save must not rewrite them into hard breaks.
+
+A second paragraph, also wrapped, so a doc-spanning re-parse has more than one
+block to damage.

--- a/tests/fixtures/roundtrip/table-aligned.md
+++ b/tests/fixtures/roundtrip/table-aligned.md
@@ -1,0 +1,5 @@
+Column alignment is semantic: it changes how the table renders.
+
+| Left | Center | Right |
+| :- | :-: | -: |
+| 1 | 2 | 3 |

--- a/tests/fixtures/roundtrip/table-compact.md
+++ b/tests/fixtures/roundtrip/table-compact.md
@@ -1,0 +1,7 @@
+The delimiter style people actually write, and the one this repo uses in 266 of
+its 294 delimiter rows.
+
+| Column | What it does |
+|---|---|
+| one | a short cell |
+| two | a considerably longer cell that sets the column width |

--- a/tests/fixtures/roundtrip/tight-list.md
+++ b/tests/fixtures/roundtrip/tight-list.md
@@ -1,0 +1,10 @@
+A tight list, as a control: this one already round-trips, so if it ever starts
+failing the cause is a regression rather than a known gap.
+
+- first item
+- second item
+  - nested item
+- third item
+
+1. ordered one
+2. ordered two

--- a/tests/server/file-io/roundtrip-corpus.test.ts
+++ b/tests/server/file-io/roundtrip-corpus.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Curated round-trip corpus (#1448).
+ *
+ * One fixture per construct, asserting byte-identity on the FIRST pass. That
+ * distinction is the whole point: the existing fidelity suites assert
+ * idempotency (`pass2 === pass1`), which every defect in #1448 satisfies — each
+ * one mangles the document once and is then a stable fixed point.
+ *
+ * Fixtures with a known defect are registered here with the defect they are
+ * blocked on, and asserted to STILL be broken. That is deliberate: when a fix
+ * lands, this test fails and forces the registration to be removed, so the
+ * corpus cannot quietly accumulate an allowlist. A fixture that is neither
+ * clean nor registered is a new regression.
+ *
+ * Line endings are synthesized rather than committed — `.gitattributes` pins
+ * `*.md text eol=lf`, so a CRLF fixture checked into git arrives as LF and the
+ * test would silently pass on the wrong input.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { loadMarkdown, saveMarkdown } from "../../../src/server/file-io/markdown.js";
+
+const CORPUS_DIR = fileURLToPath(new URL("../../fixtures/roundtrip/", import.meta.url));
+
+/**
+ * `blockedOn` names the open defect from #1448. Absent means the fixture must
+ * round-trip byte-identically today.
+ */
+const CORPUS: Record<string, { blockedOn?: string; why?: string }> = {
+  "soft-wrap.md": {},
+  "tight-list.md": {},
+  "raw-blocks.md": {},
+  "frontmatter.md": { blockedOn: "V1", why: "no remark-frontmatter; the fences parse as setext" },
+  "loose-list.md": { blockedOn: "V2", why: "spread is hardcoded false in yDocToMdast" },
+  "table-aligned.md": { blockedOn: "V-table-padding", why: "tablePipeAlign defaults to true" },
+  "table-compact.md": { blockedOn: "V-table-padding", why: "tablePipeAlign defaults to true" },
+  "nested-marks.md": { blockedOn: "V5", why: "deltaToPhrasingContent rebuilds nested marks wrong" },
+  "inline-code-fence.md": {
+    blockedOn: "V7",
+    why: "code-span fence length is not recomputed from the content's backtick runs",
+  },
+};
+
+function roundTrip(input: string): string {
+  const doc = new Y.Doc();
+  try {
+    loadMarkdown(doc, input);
+    return saveMarkdown(doc);
+  } finally {
+    doc.destroy();
+  }
+}
+
+const read = (name: string) => readFileSync(`${CORPUS_DIR}${name}`, "utf-8");
+
+describe("round-trip corpus", () => {
+  it("every fixture on disk is registered", () => {
+    const onDisk = readdirSync(CORPUS_DIR)
+      .filter((f) => f.endsWith(".md"))
+      .sort();
+    expect(onDisk).toEqual(Object.keys(CORPUS).sort());
+  });
+
+  const clean = Object.entries(CORPUS).filter(([, v]) => !v.blockedOn);
+  it.each(clean)("%s round-trips byte-identically", (name) => {
+    expect(roundTrip(read(name))).toBe(read(name));
+  });
+
+  const blocked = Object.entries(CORPUS).filter(([, v]) => v.blockedOn);
+  it.each(blocked)("%s is still blocked on %o", (name, meta) => {
+    // Asserting the defect is still present. When it is fixed this fails, which
+    // is the signal to delete the registration — not to widen it.
+    expect(
+      roundTrip(read(name)),
+      `${name} now round-trips cleanly. Remove its ${meta.blockedOn} registration from CORPUS.`,
+    ).not.toBe(read(name));
+  });
+});
+
+describe("round-trip corpus: line endings (W2)", () => {
+  const LF = "# Title\n\nA paragraph soft-wrapped\nacross two lines.\n\n- a\n- b\n";
+  const CRLF = LF.replace(/\n/g, "\r\n");
+
+  it("an LF document keeps LF endings", () => {
+    expect(roundTrip(LF)).toBe(LF);
+  });
+
+  it.fails("a CRLF document keeps CRLF endings", () => {
+    expect(roundTrip(CRLF)).toBe(CRLF);
+  });
+
+  it("today a CRLF document comes back with MIXED endings, which is worse than either", () => {
+    const out = roundTrip(CRLF);
+    expect(out).toContain("\r\n"); // the intra-paragraph soft wrap keeps its \r
+    expect(out).toMatch(/[^\r]\n/); // block separators have lost theirs
+  });
+});

--- a/tests/server/file-io/roundtrip-repo-metric.test.ts
+++ b/tests/server/file-io/roundtrip-repo-metric.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Repo-wide round-trip metric (#1448).
+ *
+ * The curated corpus in `roundtrip-corpus.test.ts` is the gate. This is the
+ * breadth check that runs the same round trip over every tracked `.md` file in
+ * the repository — a large, free, real-world corpus that no one had to write.
+ *
+ * It deliberately does NOT snapshot the list of failing filenames. That list
+ * changes with every docs PR, so it would churn constantly, and a snapshot
+ * people regenerate reflexively stops being a signal. Instead it classifies
+ * each *render-affecting* difference by the kind of mdast change it causes and
+ * asserts the set of KINDS, which is stable under ordinary prose edits and
+ * fails by name the moment a construct starts breaking in a new way.
+ *
+ * The byte-level count is reported, not asserted: most of it is formatting
+ * canonicalization that renders identically (marker style, table padding), and
+ * pinning it would be pinning a number nobody should be optimizing.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { beforeAll, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { loadMarkdown, mdParser, saveMarkdown } from "../../../src/server/file-io/markdown.js";
+
+/**
+ * Kinds of render-affecting change we already know about, each tied to a defect
+ * in #1448. Anything outside this set is a new defect.
+ */
+const KNOWN_KINDS = new Set([
+  "list.spread", // V2 — loose lists forced tight
+  "listItem.spread", // V2
+  "inline-marks", // V5 — nested mark reconstruction
+  "inline-code-fence", // V7 — code-span fence length not recomputed
+  "table-cells", // trailing empty cells made explicit; renders identically in GFM
+  "listItem-child-count", // a table nested in a list item; see #1448
+]);
+
+/** mdast phrasing types — a difference in any of these is an inline defect. */
+const PHRASING = new Set([
+  "text",
+  "emphasis",
+  "strong",
+  "delete",
+  "inlineCode",
+  "link",
+  "image",
+  "html",
+  "break",
+  "footnoteReference",
+  "linkReference",
+  "imageReference",
+]);
+
+/** Block types whose children are phrasing content. */
+const PHRASING_PARENTS = new Set(["paragraph", "heading", "tableCell"]);
+
+const sameNode = (a: unknown, b: unknown) => JSON.stringify(strip(a)) === JSON.stringify(strip(b));
+
+interface Finding {
+  file: string;
+  kind: string;
+}
+
+const byteDifferent: string[] = [];
+const renderDifferent: Finding[] = [];
+let scanned = 0;
+
+/** Structural comparison: `position` is source offsets, not meaning. */
+function strip(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(strip);
+  if (node && typeof node === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(node as object).sort()) {
+      if (key === "position") continue;
+      out[key] = strip((node as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return node;
+}
+
+/** Name the first structural difference, coarsely enough to stay stable. */
+function classify(before: unknown, after: unknown): string {
+  const a = before as { type?: string; children?: unknown[]; spread?: boolean };
+  const b = after as { type?: string; children?: unknown[]; spread?: boolean };
+
+  // Inline defects manifest as a dozen different node-level symptoms (a `strong`
+  // gaining children, a `text` value shifting, a `delete` becoming a `strong`).
+  // They are all one family, so collapse them — otherwise the known-kind set
+  // churns on prose edits and stops meaning anything.
+  const inline = PHRASING.has(a?.type ?? "") || PHRASING.has(b?.type ?? "");
+  if (inline) {
+    return a?.type === "inlineCode" || b?.type === "inlineCode"
+      ? "inline-code-fence"
+      : "inline-marks";
+  }
+
+  if (a?.type !== b?.type) return "inline-marks";
+  if (a?.type === "list" && a.spread !== b.spread) return "list.spread";
+  if (a?.type === "listItem" && a.spread !== b.spread) return "listItem.spread";
+
+  const ca = a?.children ?? [];
+  const cb = b?.children ?? [];
+  if (ca.length !== cb.length) {
+    if (a?.type === "tableRow" || a?.type === "table") return "table-cells";
+    // A block whose children are phrasing. A changed child count means marks or
+    // code spans split/merged, which is an inline defect rather than a
+    // structural change to the block. Name it from the divergent TAIL — the
+    // nodes past the common prefix — because a mis-fenced code span shows up as
+    // two `text` nodes disagreeing with an extra `inlineCode` after them, and
+    // reading only the first divergent pair would blame marks for V7.
+    if (PHRASING_PARENTS.has(a?.type ?? "")) {
+      let i = 0;
+      while (i < ca.length && i < cb.length && sameNode(ca[i], cb[i])) i++;
+      const tail = [...ca.slice(i), ...cb.slice(i)] as { type?: string }[];
+      return tail.some((n) => n?.type === "inlineCode") ? "inline-code-fence" : "inline-marks";
+    }
+    return `${a?.type ?? "root"}-child-count`;
+  }
+  for (let i = 0; i < ca.length; i++) {
+    if (JSON.stringify(strip(ca[i])) === JSON.stringify(strip(cb[i]))) continue;
+    return classify(ca[i], cb[i]);
+  }
+  return `${a?.type ?? "root"}-scalar`;
+}
+
+// Hoisted out of the per-test budget: this walks the whole repo once. Doing it
+// inside each `it` blew the 15s timeout on a comparable docs-scanning suite
+// and surfaced as an unrelated-looking assertion failure (#1434).
+beforeAll(() => {
+  const files = execFileSync("git", ["ls-files", "--", "*.md"], { encoding: "utf-8" })
+    .split("\n")
+    .filter(Boolean);
+
+  for (const file of files) {
+    let source: string;
+    try {
+      source = readFileSync(file, "utf-8");
+    } catch {
+      continue; // listed but absent (submodule, sparse checkout)
+    }
+    scanned++;
+
+    const doc = new Y.Doc();
+    let output: string;
+    try {
+      loadMarkdown(doc, source);
+      output = saveMarkdown(doc);
+    } catch {
+      renderDifferent.push({ file, kind: "threw" });
+      continue;
+    } finally {
+      doc.destroy();
+    }
+
+    if (output === source || output === `${source}\n` || `${output}\n` === source) continue;
+    byteDifferent.push(file);
+
+    const before = strip(mdParser.parse(source));
+    const after = strip(mdParser.parse(output));
+    if (JSON.stringify(before) === JSON.stringify(after)) continue;
+    renderDifferent.push({ file, kind: classify(before, after) });
+  }
+}, 120_000);
+
+describe("repo-wide round-trip metric", () => {
+  it("scans a corpus worth scanning", () => {
+    // A positive anchor. Without it, a broken `git ls-files` yields zero files,
+    // every "count of bad things is zero" assertion below passes, and the suite
+    // reports perfect health on an empty scan.
+    expect(scanned).toBeGreaterThan(100);
+  });
+
+  it("every render-affecting difference is a known kind", () => {
+    const unknown = renderDifferent.filter((f) => !KNOWN_KINDS.has(f.kind));
+    expect(unknown).toEqual([]);
+  });
+
+  it("reports the current state", () => {
+    const byKind = new Map<string, number>();
+    for (const { kind } of renderDifferent) byKind.set(kind, (byKind.get(kind) ?? 0) + 1);
+    const summary = [...byKind].sort((a, b) => b[1] - a[1]).map(([k, n]) => `${k}=${n}`);
+    console.log(
+      `round-trip: ${scanned} scanned, ${byteDifferent.length} differ in bytes, ` +
+        `${renderDifferent.length} differ in rendering [${summary.join(" ")}]`,
+    );
+    // Not an assertion on the numbers — see the file header.
+    expect(byteDifferent.length).toBeLessThanOrEqual(scanned);
+  });
+});


### PR DESCRIPTION
Tests only. No product code changes, no behaviour change.

PR 1 of the #1448 document-fidelity work. Nothing else in that plan can be validated without these, and they are also the reason the defects went unnoticed for so long.

## Why these are new rather than an extension of the existing suites

Every existing fidelity suite asserts **idempotency** — `pass2 === pass1`. Each defect in #1448 satisfies that: it mangles the document exactly once and is then a stable fixed point. So the suites were green and the documents were wrong. These four assert **byte-identity on the first pass** instead.

## What is here

**`tests/client/editor-roundtrip-harness.ts` + `editor-roundtrip.test.ts`** — drives the real production schema (`getSchema(buildSchemaExtensions())`) through Y.Doc → ProseMirror → DOM → re-parse → `updateYFragment` → `saveMarkdown`.

- Exercises the **doc-spanning** re-parse, where `parseBetween` passes plain `true` rather than `"full"`. That is the path a real edit takes and the reason one edit rewrites every paragraph.
- Emulates `ruleFromNode` faithfully rather than omitting it, so the "does a node view desc rescue the attributes" question is settled by the harness instead of assumed. It does not, for paragraphs, today.
- Asserts **attribute survival**, not just text shape — the only thing that catches `table.align` being dropped.
- Includes a negative control: attach-and-close damages nothing. The damage needs an edit.
- Pins the **fix** as well as the bug: declaring `whitespace: "pre"` on `paragraph` makes a soft-wrapped file round-trip losslessly. That assertion carries an explicit `schema.nodes.paragraph.spec.whitespace === "pre"` guard, because the natural way to write the override (`.map(e => e.name === "paragraph" …)`) silently matches nothing — `paragraph` comes from `starterKit` — and a no-op override otherwise passes as a fix.

**`tests/server/file-io/roundtrip-corpus.test.ts` + `tests/fixtures/roundtrip/*.md`** — one fixture per construct. Fixtures with a known defect are registered with the defect they are blocked on and asserted to be **still broken**, so landing a fix fails this test and forces the registration to be deleted. An allowlist cannot accumulate quietly. A fixture that is neither clean nor registered is a new regression.

CRLF cases are synthesized in code rather than committed — `.gitattributes` pins `*.md text eol=lf`, so a CRLF fixture in git arrives as LF and would silently pass on the wrong input.

**`tests/server/file-io/roundtrip-repo-metric.test.ts`** — the same round trip over every tracked `.md` file.

It deliberately does **not** snapshot the list of failing filenames. That list changes with every docs PR, so it would churn constantly, blame prose authors for serializer defects, and become a snapshot people regenerate reflexively. It classifies each render-affecting difference by **kind** and asserts the kind set, which is stable under ordinary prose edits and fails by name the moment a construct starts breaking in a new way. It carries a positive anchor (`scanned > 100`) so a broken `git ls-files` cannot pass as a clean scan.

Current state:

```
236 scanned, 196 differ in bytes, 72 differ in rendering
[list.spread=49 inline-marks=11 listItem.spread=4 inline-code-fence=3 table-cells=3 listItem-child-count=2]
```

**`tests/client/attribute-parity.test.ts`** — every attribute the server writes vs. every attribute the client declares. Derives the server side from inline markdown sources rather than a shared fixture, so it cannot agree with the code under test by construction. `table.align` is the only casualty today, and that is what it asserts.

## It already found a defect

**V7**, which neither the investigation nor three review agents identified from source: a code span containing a backtick run is re-emitted with its inner backticks escaped instead of a longer fence, so the span ends early and glues adjacent words together.

```
`x ?? ``y```   ->   `x ?? `\`y`\`\`
```

Three files in this repo, including `docs/design-system-impl/testid-manifest.md`. Fixture registered, fix scheduled with the other inline work.

## Verification

- `npm run typecheck` — clean.
- `npm test` — 6693 passed, 5 expected fail (the `it.fails` pins), 21 skipped.
- Pre-push hook ran in full, including `cargo test`.

One unrelated intermittent seen once and not reproduced: `tests/server/integrations/refresh-skill.test.ts` "aborts a hung write at the refresh deadline" — a 20ms deadline test. Ran the negative control (full suite with these four excluded: green) and the full suite again with them included (green), so it is not attributable to this PR, but it is load-sensitive and worth a look separately.

Refs #1448