### PR TITLE
fix(markdown): keep soft wraps as wraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Editing a document no longer adds line breaks to paragraphs you did not touch (#1448).** If a file wrapped its paragraphs across several lines — the normal way of writing markdown in a text editor — then editing a single word anywhere in it added a `\` to the end of every wrapped line in the whole document. That backslash is a real markdown instruction, so afterwards GitHub and every other viewer broke those paragraphs at the original author's wrap column no matter how wide the window was. Opening a file to read it was never affected; it took an edit.
+- **Multi-line blocks Tandem stores verbatim — raw HTML, footnote definitions, link definitions — no longer get collapsed onto one line (#1458).** Their line breaks were dropped silently on save, with no warning and no fallback.
+
 ## [0.22.1] - 2026-08-13
 
 This release is mostly repair, and the two biggest repairs are both about Tandem failing to start.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -941,6 +941,17 @@ Both are silent from the user's perspective today; both end when the integration
 
 **Documented normalizations (deliberate, not loss):** `remark-stringify` canonicalizes setext→ATX headings, indented→fenced code, bullet/emphasis markers to `-`/`*`, hard-break style, entity decoding, autolinks to angle form (`<https://…>`), and loose-list paragraphs → tight (blank lines between list items are dropped; `spread: false` is hardcoded in `yDocToMdast`). The fidelity test asserts **idempotency + content-preservation**, not byte-identity to hand-authored input.
 
+**Amendment (2026-08-14, #1448): two claims in that paragraph were wrong, and the test contract in its last sentence is what let them stand.**
+
+"Idempotency + content-preservation, not byte-identity" sounds like a modest, honest contract. It is not: **every defect found in #1448 satisfies it.** Each one mangles the document exactly once and is then a stable fixed point, so `pass2 === pass1` holds and the suite stays green while the file on disk is wrong. The contract could not fail, which is why nothing failed for months. It is replaced by **byte-identity on the first pass** for anything a reader would notice, measured by `tests/server/file-io/roundtrip-corpus.test.ts` and `tests/client/editor-roundtrip.test.ts`.
+
+Two specific corrections:
+
+- **"Hard-break style" was never a normalization.** What actually happened is that the *editor* converted **soft line wraps into hard breaks** — a semantic change, not a style choice. A soft wrap lives in the Y.Doc as a literal `\n` inside a `Y.XmlText`; a hard break is a sibling `Y.XmlElement("hardBreak")`. The Y.Doc distinguishes them; ProseMirror does not, so its DOM re-read split paragraph text on newlines. Saving then wrote a trailing `\` onto every wrapped line and renderers broke the paragraph at the author's wrap column. Fixed by declaring `whitespace: "pre"` on the paragraph node. Genuine hard-break *style* (`  ` vs `\`) is still normalized and that part stands.
+- **The "no silent drop" guarantee did not hold for the raw carriers this ADR introduces.** `getElementPlainText` read only `Y.XmlText` children, so a newline held as a sibling `hardBreak` was dropped without warning and every multi-line raw block collapsed onto one line (#1458) — the exact failure mode this ADR exists to prevent, in the exact constructs it was written to protect.
+
+Loose→tight (`spread: false` hardcoded) remains as described here and remains a defect rather than a normalization; it is tracked in #1448 and not yet fixed.
+
 **Deferred (#982):** GFM task lists / checkboxes need a first-class `TaskList`/`TaskItem` node and `checked` mapping; today they degrade to plain bullets. This is a documented gap pinned by `markdown-fidelity.test.ts` so it can never become a silent drop.
 
 **Consequences:** the round-trip is a stable fixed point (re-open re-parses the emitted source into the same gfm nodes and re-stores them). Coverage: `tests/fixtures/markdown-fidelity.md` + `markdown-fidelity.test.ts` (every construct, idempotency, the #982 gap) and `markdown-raw-constructs.test.ts` (forward/reverse mapping + slice-level flat-offset stability). New settings fields must be enumerated in `normalizeKnownFields` (an allowlist) or they are silently dropped at runtime — `showRawMarkdown` is pinned by a presence/default regression.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@tiptap/extension-image": "^2.27.2",
         "@tiptap/extension-link": "^2.27.2",
         "@tiptap/extension-list-item": "^2.27.2",
+        "@tiptap/extension-paragraph": "^2.27.2",
         "@tiptap/extension-placeholder": "^2.11.0",
         "@tiptap/extension-subscript": "^2.27.2",
         "@tiptap/extension-superscript": "^2.27.2",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "@tiptap/extension-image": "^2.27.2",
     "@tiptap/extension-link": "^2.27.2",
     "@tiptap/extension-list-item": "^2.27.2",
+    "@tiptap/extension-paragraph": "^2.27.2",
     "@tiptap/extension-placeholder": "^2.11.0",
     "@tiptap/extension-subscript": "^2.27.2",
     "@tiptap/extension-superscript": "^2.27.2",

--- a/src/client/editor/editor-extensions.ts
+++ b/src/client/editor/editor-extensions.ts
@@ -2,6 +2,7 @@ import { type AnyExtension, mergeAttributes } from "@tiptap/core";
 import Highlight from "@tiptap/extension-highlight";
 import Image from "@tiptap/extension-image";
 import Link, { isAllowedUri as tiptapDefaultIsAllowedUri } from "@tiptap/extension-link";
+import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Subscript from "@tiptap/extension-subscript";
 import Superscript from "@tiptap/extension-superscript";
@@ -97,13 +98,59 @@ const LinkWithHoverTitle = Link.extend({
  * ListItemCheckbox after StarterKit's `listItem:false`, and HeadingCollapse after
  * AnnotationExtension (#650).
  */
+/**
+ * Paragraph that preserves soft line wraps instead of converting them to hard
+ * breaks (#1448).
+ *
+ * A soft wrap lives in the Y.Doc as a literal `\n` inside a `Y.XmlText`; a real
+ * hard break is a sibling `Y.XmlElement("hardBreak")`. The Y.Doc distinguishes
+ * the two, ProseMirror does not — so every time the editor re-reads the DOM,
+ * `prosemirror-model` splits paragraph text on `/\r?\n|\r/` and inserts
+ * `hardBreak` nodes. Saving then writes a trailing `\` onto every wrapped line,
+ * which is a semantic hard break: GitHub and every other renderer break the
+ * paragraph at the original author's wrap column, at any viewport width.
+ *
+ * One edit is enough to damage the whole file, because a childList mutation on
+ * the doc node makes `readDOMChange` re-parse a doc-spanning range in one pass.
+ *
+ * `whitespace: "pre"` is what `prosemirror-view` itself keys on: `parseBetween`
+ * passes `preserveWhitespace: "full"` when the parent node's whitespace is
+ * `"pre"`, and `linebreakReplacement` only splits when it is truthy-but-not-
+ * `"full"`. An explicit Shift+Enter `hardBreak` still survives, and it closes
+ * the paste doorway too — any clipboard carrying `text/html` bypasses
+ * `clipboardTextParser` and hits the same split.
+ *
+ * Rejected alternatives: stock is the bug; `linebreakReplacement: false`
+ * collapses the wrap to a space, losing the line entirely.
+ *
+ * **`whitespace` must be an extension config field, not `extendNodeSchema`.**
+ * Tiptap's schema builder spreads `extendNodeSchema`'s result FIRST and then
+ * assigns `whitespace: callOrReturn(getExtensionField(extension, "whitespace"))`
+ * over the top, so an `extendNodeSchema` that returns `{ whitespace: "pre" }`
+ * is overwritten with `undefined` and then dropped by `cleanUpSchemaItem`. It
+ * reads as correct and does nothing.
+ *
+ * Scoped to `paragraph` deliberately — NOT `heading`. A heading carrying a
+ * newline serializes as setext at depth 1–2 (`foo\nbar\n===`), which inverts one
+ * of our own documented normalizations. Table cells need no separate handling: a
+ * cell's content is a paragraph, so they inherit this.
+ *
+ * The obvious objection — that `"pre"` reintroduces the bug, since two trailing
+ * spaces are a markdown hard break and four leading spaces an indented code
+ * block — does not hold. `remark-stringify`'s `safe()` already escapes both to
+ * `&#x20;`, idempotently. Pinned in `tests/server/file-io/whitespace-escaping`.
+ */
+const SoftWrapParagraph = Paragraph.extend({ whitespace: "pre" });
+
 export function buildSchemaExtensions(): AnyExtension[] {
   return [
     // `listItem:false` disables StarterKit's stock ListItem so our
     // ListItemCheckbox (same node name "listItem", + a `checked` tri-state
-    // attribute for GFM task lists, #982) owns the schema. history:false — Yjs
+    // attribute for GFM task lists, #982) owns the schema. `paragraph:false`
+    // hands the paragraph node to SoftWrapParagraph below. history:false — Yjs
     // handles undo/redo.
-    StarterKit.configure({ history: false, listItem: false }),
+    StarterKit.configure({ history: false, listItem: false, paragraph: false }),
+    SoftWrapParagraph,
     ListItemCheckbox,
     // underline/superscript/subscript: marks the .docx import (mammoth) emits but
     // StarterKit does not provide. Required client-side or y-prosemirror deletes

--- a/src/client/editor/editor-extensions.ts
+++ b/src/client/editor/editor-extensions.ts
@@ -139,6 +139,26 @@ const LinkWithHoverTitle = Link.extend({
  * spaces are a markdown hard break and four leading spaces an indented code
  * block — does not hold. `remark-stringify`'s `safe()` already escapes both to
  * `&#x20;`, idempotently. Pinned in `tests/server/file-io/whitespace-escaping`.
+ *
+ * Two knock-on effects of `"pre"` that are NOT about the newline split, both
+ * found by reviewing this change rather than by the test suite:
+ *
+ * - **Paste.** The per-node setting beats the paste-level `preserveWhitespace:
+ *   false` once parsing enters a `<p>`, so pretty-printed external HTML would
+ *   import its own indentation as content. Handled at the paste boundary by
+ *   `utils/paste-whitespace.ts` — deliberately not by giving this node's parse
+ *   rule an explicit `preserveWhitespace`, which would fix paste and silently
+ *   reopen the newline split for any paragraph re-read without a node view desc.
+ * - **Trailing whitespace** is no longer stripped when a paragraph is parsed
+ *   from the DOM (`prosemirror-model` `NodeContext.finish` gates stripping on
+ *   the same flag). Trailing spaces the user actually typed now survive, and
+ *   save as a `&#x20;` escape. Accepted: it is cosmetic, it is idempotent, and
+ *   stripping it back out would mean editing text the user typed on purpose.
+ *
+ * A third — that preserved newlines would render as collapsed spaces because
+ * nothing sets `white-space` on `.tandem-editor` — is not real: `@tiptap/core`
+ * injects `.ProseMirror { white-space: pre-wrap }` itself (`injectCSS` defaults
+ * to true and is not disabled here), so do NOT add a rule for it.
  */
 const SoftWrapParagraph = Paragraph.extend({ whitespace: "pre" });
 

--- a/src/client/editor/editor-props.ts
+++ b/src/client/editor/editor-props.ts
@@ -7,6 +7,7 @@
 import { TextSelection } from "@tiptap/pm/state";
 import type { EditorProps } from "@tiptap/pm/view";
 import { markdownToSlice } from "./utils/markdown-paste";
+import { normalizePastedHtmlWhitespace } from "./utils/paste-whitespace";
 import { buildPlainTextSlice } from "./utils/plain-paste";
 import { isSafeExternalHref } from "./utils/url-safety";
 
@@ -28,6 +29,12 @@ export function makeEditorProps(spellcheckOnValue: boolean): EditorProps {
       // attribute is symmetric and testable.
       spellcheck: String(spellcheckOnValue),
     },
+    // Collapse whitespace in pasted HTML the way the browser would have. The
+    // paragraph node declares `whitespace: "pre"` (#1448), and that setting
+    // overrides the paste-level `preserveWhitespace: false` once parsing enters
+    // a `<p>` — so without this, pretty-printed markup imports its own source
+    // indentation as content. See utils/paste-whitespace.ts for the mechanism.
+    transformPastedHTML: normalizePastedHtmlWhitespace,
     // Paste raw markdown as formatted rich text (#788). We return a parsed
     // ProseMirror Slice so y-prosemirror's sync plugin captures it via the
     // normal paste transaction — we never touch the Y.Doc directly. When the

--- a/src/client/editor/utils/paste-whitespace.ts
+++ b/src/client/editor/utils/paste-whitespace.ts
@@ -59,11 +59,43 @@ const BLOCK = new Set([
   "BODY",
 ]);
 
-function hasVerbatimAncestor(node: Node): boolean {
-  for (let el = node.parentElement; el; el = el.parentElement) {
-    if (VERBATIM.has(el.tagName)) return true;
-  }
-  return false;
+/**
+ * The whitespace characters CSS `white-space: normal` collapses — space, tab,
+ * newline, carriage return and form feed.
+ *
+ * Deliberately NOT `\s`, which additionally matches every Unicode space
+ * separator: NBSP (` `), figure space, narrow no-break space, ideographic
+ * space and the rest. A browser never collapses those — that is the entire
+ * point of typing one — and collapsing them here would silently rewrite
+ * intentional typography on every paste, most visibly turning the NBSP a user
+ * put between a number and its unit into an ordinary breakable space.
+ */
+const COLLAPSIBLE = /[ \t\n\r\f]+/g;
+
+/**
+ * The parents the HTML parser requires before it will accept a given tag, from
+ * `prosemirror-view`'s `wrapMap`. A clipboard payload from a spreadsheet or a
+ * partial table selection starts at `<tr>` or `<td>`, and `parseFromString`
+ * foster-parents an orphan one straight out of the tree — the cells survive as
+ * bare text and the table is gone. ProseMirror wraps before parsing for exactly
+ * this reason; a transform that runs BEFORE it has to do the same or it
+ * destroys the paste before ProseMirror ever sees it.
+ */
+const WRAP_MAP: Record<string, string[]> = {
+  thead: ["table"],
+  tbody: ["table"],
+  tfoot: ["table"],
+  caption: ["table"],
+  colgroup: ["table"],
+  col: ["table", "colgroup"],
+  tr: ["table", "tbody"],
+  td: ["table", "tbody", "tr"],
+  th: ["table", "tbody", "tr"],
+};
+
+function firstTagName(html: string): string | null {
+  const m = /^(\s*<!doctype [^>]*>)?\s*<([a-z][^>\s/]*)/i.exec(html);
+  return m ? m[2].toLowerCase() : null;
 }
 
 /**
@@ -76,44 +108,83 @@ function hasVerbatimAncestor(node: Node): boolean {
  * would lose the soft wraps the user copied.
  */
 export function normalizePastedHtmlWhitespace(html: string): string {
-  if (html.includes("data-pm-slice")) return html;
   if (typeof DOMParser === "undefined") return html;
+
+  // A tag orphaned from its required parents has to be wrapped before parsing,
+  // then unwrapped after — see WRAP_MAP.
+  const wrap = WRAP_MAP[firstTagName(html) ?? ""] ?? [];
+  const wrapped = wrap.length
+    ? wrap.map((t) => `<${t}>`).join("") +
+      html +
+      [...wrap]
+        .reverse()
+        .map((t) => `</${t}>`)
+        .join("")
+    : html;
 
   let parsed: Document;
   try {
-    parsed = new DOMParser().parseFromString(html, "text/html");
+    parsed = new DOMParser().parseFromString(wrapped, "text/html");
   } catch {
     // A clipboard payload we cannot parse is one we must not rewrite.
     return html;
   }
-  const body = parsed.body;
-  if (!body) return html;
+  let root: Element | null = parsed.body;
+  if (!root) return html;
+  // Descend back through the wrappers we added, so the returned markup is the
+  // caller's fragment and not our scaffolding.
+  for (let i = 0; i < wrap.length; i += 1) {
+    root = root.firstElementChild;
+    if (!root) return html;
+  }
 
-  const walker = parsed.createTreeWalker(body, NodeFilter.SHOW_TEXT);
+  // The `data-pm-slice` test is a real attribute lookup, not a substring test
+  // over the payload. `html.includes("data-pm-slice")` matched any page that
+  // merely MENTIONS the string — a ProseMirror doc page, a diff of this file —
+  // and silently disabled normalization for the whole paste. This is the same
+  // check prosemirror-view makes.
+  if (root.matches?.("[data-pm-slice]") || root.querySelector("[data-pm-slice]")) return html;
+
+  const walker = parsed.createTreeWalker(root, NodeFilter.SHOW_TEXT);
   const texts: Text[] = [];
   for (let n = walker.nextNode(); n; n = walker.nextNode()) texts.push(n as Text);
 
+  // One pass, collapsing each text node and simultaneously recording the first
+  // and last text node inside every enclosing block. The edges have to be
+  // trimmed against the block a text node actually sits in, not its own parent,
+  // so that `<p><em>text</em></p>` trims at the paragraph — but resolving that
+  // by re-scanning every text node per block (`texts.filter(t =>
+  // block.contains(t))`) is quadratic in node count, and a large table paste
+  // hangs the main thread on it. Walking each node's ancestors instead is
+  // linear in nodes times a depth that is small in real markup.
+  const edges = new Map<Element, { first: Text; last: Text }>();
   for (const text of texts) {
-    if (hasVerbatimAncestor(text)) continue;
-    text.data = text.data.replace(/\s+/g, " ");
+    let verbatim = false;
+    const blocks: Element[] = [];
+    for (let el = text.parentElement; el; el = el.parentElement) {
+      if (VERBATIM.has(el.tagName)) {
+        verbatim = true;
+        break;
+      }
+      if (BLOCK.has(el.tagName)) blocks.push(el);
+    }
+    if (verbatim) continue;
+
+    text.data = text.data.replace(COLLAPSIBLE, " ");
+    for (const block of blocks) {
+      const seen = edges.get(block);
+      if (seen) seen.last = text;
+      else edges.set(block, { first: text, last: text });
+    }
   }
 
-  // Second pass for the block edges. Done after collapsing so we are trimming a
-  // single space rather than trying to reason about the original run, and done
-  // by walking each block's own descendants so that inline wrappers
-  // (`<p><em>text</em></p>`) are trimmed at the block boundary they actually sit
-  // on rather than at their own.
-  const blocks = [body, ...Array.from(body.querySelectorAll("*"))].filter(
-    (el) => BLOCK.has(el.tagName) && !VERBATIM.has(el.tagName),
-  );
-  for (const block of blocks) {
-    if (hasVerbatimAncestor(block)) continue;
-    const own = texts.filter((t) => block.contains(t) && !hasVerbatimAncestor(t));
-    const first = own[0];
-    const last = own[own.length - 1];
-    if (first) first.data = first.data.replace(/^ +/, "");
-    if (last) last.data = last.data.replace(/ +$/, "");
+  for (const { first, last } of edges.values()) {
+    first.data = first.data.replace(/^ +/, "");
+    last.data = last.data.replace(/ +$/, "");
   }
 
-  return body.innerHTML;
+  // Always `innerHTML`: the descent above lands on the INNERMOST wrapper we
+  // added (`<tbody>` for a `<tr>` payload), whose children are the caller's
+  // fragment. `outerHTML` would hand the scaffolding back as content.
+  return root.innerHTML;
 }

--- a/src/client/editor/utils/paste-whitespace.ts
+++ b/src/client/editor/utils/paste-whitespace.ts
@@ -73,13 +73,23 @@ const BLOCK = new Set([
 const COLLAPSIBLE = /[ \t\n\r\f]+/g;
 
 /**
- * The parents the HTML parser requires before it will accept a given tag, from
- * `prosemirror-view`'s `wrapMap`. A clipboard payload from a spreadsheet or a
- * partial table selection starts at `<tr>` or `<td>`, and `parseFromString`
- * foster-parents an orphan one straight out of the tree — the cells survive as
- * bare text and the table is gone. ProseMirror wraps before parsing for exactly
- * this reason; a transform that runs BEFORE it has to do the same or it
- * destroys the paste before ProseMirror ever sees it.
+ * The parents the HTML parser requires before it will accept a given tag,
+ * mirroring `prosemirror-view`'s own `wrapMap`.
+ *
+ * The hazard: `parseFromString` foster-parents an orphan `<tr>`/`<td>` straight
+ * out of the tree, so the cells survive as bare text and the table is gone. A
+ * transform running BEFORE ProseMirror would destroy such a paste before
+ * ProseMirror's own wrapping ever got the chance to save it.
+ *
+ * Honest about the evidence: this is defensive, and the premise is UNREPRODUCED.
+ * The claim is that a spreadsheet or a partial table selection puts a bare `<tr>`
+ * on the clipboard. Two real spreadsheet-family sources were measured (LibreOffice
+ * Calc and Writer) and BOTH emit a full `<table>` wrapper, so neither exercises
+ * this path. Excel — the app the claim specifically rests on — was not available
+ * to test. What justifies keeping it is upstream precedent, not observation:
+ * `prosemirror-view` carries this identical map in its clipboard reader, which is
+ * reasonable evidence the shape occurs somewhere. It is inert unless the payload's
+ * first tag is actually one of these, so the cost of being wrong is zero.
  */
 const WRAP_MAP: Record<string, string[]> = {
   thead: ["table"],

--- a/src/client/editor/utils/paste-whitespace.ts
+++ b/src/client/editor/utils/paste-whitespace.ts
@@ -1,0 +1,119 @@
+// Whitespace normalization for pasted HTML (#1448).
+//
+// Declaring `whitespace: "pre"` on the paragraph node — which is what stops the
+// editor turning soft line wraps into hard breaks — has a second, unwanted
+// effect on paste that is easy to miss, because it defeats the flag that was
+// supposed to prevent it.
+//
+// `parseFromClipboard` passes `preserveWhitespace: !!(asText || sliceData)`,
+// which is `false` for ordinary external HTML — exactly right. But that is only
+// the BASE option. Once the parser enters a `<p>`, `wsOptionsFor` is consulted
+// with the rule's own `preserveWhitespace` (the paragraph rule sets none) and
+// falls through to `type.whitespace == "pre"`, which now wins
+// (`prosemirror-model/dist/index.js:2696-2700`). The per-node setting overrides
+// the paste-level intent.
+//
+// Consequence, reproduced: pasting pretty-printed HTML — most web pages, many
+// Word and Google Docs exports —
+//
+//     <p>\n  Some text\n  more text\n</p>
+//
+// used to import as "Some text more text" and instead imports the literal
+// newlines and indentation. Saved, that becomes soft wraps at arbitrary columns
+// plus `&#x20;` escapes. It renders about the same, but the source is noise the
+// user did not type.
+//
+// So we do the collapsing the browser would have done, before ProseMirror sees
+// the markup. This is deliberately NOT a schema or parse-rule change: giving the
+// paragraph rule an explicit `preserveWhitespace: false` would fix paste and
+// silently reopen the original bug for any paragraph re-read without a node view
+// desc to supply `"full"`.
+
+/** Elements whose whitespace is significant and must be left exactly as-is. */
+const VERBATIM = new Set(["PRE", "CODE", "TEXTAREA", "SCRIPT", "STYLE"]);
+
+/**
+ * Elements that establish a block box. Leading and trailing whitespace inside
+ * one of these is dropped by the browser, so we drop it too — otherwise a
+ * pretty-printed `<p>` keeps the space its indentation collapsed down to and
+ * the paragraph saves with a leading `&#x20;`.
+ */
+const BLOCK = new Set([
+  "P",
+  "DIV",
+  "LI",
+  "TD",
+  "TH",
+  "BLOCKQUOTE",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "FIGCAPTION",
+  "DD",
+  "DT",
+  "SECTION",
+  "ARTICLE",
+  "BODY",
+]);
+
+function hasVerbatimAncestor(node: Node): boolean {
+  for (let el = node.parentElement; el; el = el.parentElement) {
+    if (VERBATIM.has(el.tagName)) return true;
+  }
+  return false;
+}
+
+/**
+ * Collapse whitespace in pasted HTML the way `white-space: normal` would.
+ *
+ * Returns `html` untouched for a ProseMirror-internal paste. Those carry a
+ * `data-pm-slice` marker and are parsed with `preserveWhitespace` already true,
+ * because the markup was produced by a copy out of an editor rather than
+ * authored — so its whitespace is content, not formatting, and collapsing it
+ * would lose the soft wraps the user copied.
+ */
+export function normalizePastedHtmlWhitespace(html: string): string {
+  if (html.includes("data-pm-slice")) return html;
+  if (typeof DOMParser === "undefined") return html;
+
+  let parsed: Document;
+  try {
+    parsed = new DOMParser().parseFromString(html, "text/html");
+  } catch {
+    // A clipboard payload we cannot parse is one we must not rewrite.
+    return html;
+  }
+  const body = parsed.body;
+  if (!body) return html;
+
+  const walker = parsed.createTreeWalker(body, NodeFilter.SHOW_TEXT);
+  const texts: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) texts.push(n as Text);
+
+  for (const text of texts) {
+    if (hasVerbatimAncestor(text)) continue;
+    text.data = text.data.replace(/\s+/g, " ");
+  }
+
+  // Second pass for the block edges. Done after collapsing so we are trimming a
+  // single space rather than trying to reason about the original run, and done
+  // by walking each block's own descendants so that inline wrappers
+  // (`<p><em>text</em></p>`) are trimmed at the block boundary they actually sit
+  // on rather than at their own.
+  const blocks = [body, ...Array.from(body.querySelectorAll("*"))].filter(
+    (el) => BLOCK.has(el.tagName) && !VERBATIM.has(el.tagName),
+  );
+  for (const block of blocks) {
+    if (hasVerbatimAncestor(block)) continue;
+    const own = texts.filter((t) => block.contains(t) && !hasVerbatimAncestor(t));
+    const first = own[0];
+    const last = own[own.length - 1];
+    if (first) first.data = first.data.replace(/^ +/, "");
+    if (last) last.data = last.data.replace(/ +$/, "");
+  }
+
+  return body.innerHTML;
+}

--- a/src/client/hooks/useScratchpadPersistence.svelte.ts
+++ b/src/client/hooks/useScratchpadPersistence.svelte.ts
@@ -46,7 +46,7 @@ const PERSIST_DEBOUNCE_MS = 500;
  * their text content with newlines. Inline marks are dropped — recovery is
  * plain text, matching the issue's "unsaved content" scope.
  */
-export function extractFragmentText(fragment: Y.XmlFragment): string {
+export function extractFragmentBlocks(fragment: Y.XmlFragment): string[] {
   const blocks: string[] = [];
   const collect = (node: Y.XmlElement | Y.XmlText | Y.XmlHook): string => {
     if (node instanceof Y.XmlText) return node.toString();
@@ -65,7 +65,48 @@ export function extractFragmentText(fragment: Y.XmlFragment): string {
       blocks.push(collect(child as Y.XmlElement | Y.XmlText));
     }
   }
-  return blocks.join("\n").replace(/\n+$/, "");
+  while (blocks.length > 0 && blocks[blocks.length - 1] === "") blocks.pop();
+  return blocks;
+}
+
+export function extractFragmentText(fragment: Y.XmlFragment): string {
+  return extractFragmentBlocks(fragment).join("\n");
+}
+
+/**
+ * Encode a scratchpad's blocks for localStorage.
+ *
+ * JSON, not `blocks.join("\n")`, because since #1448 a paragraph's own text can
+ * contain a literal `\n` — that is what stops a soft wrap becoming a hard break.
+ * With `\n` doing double duty as both the intra-block character and the
+ * block separator, the split on restore could not tell them apart, and a
+ * recovered scratchpad came back with one paragraph per WRAPPED LINE: crash
+ * recovery silently reformatting the thing it exists to preserve.
+ */
+export function encodeScratchpadBlocks(blocks: string[]): string {
+  return JSON.stringify(blocks);
+}
+
+/**
+ * Decode what {@link encodeScratchpadBlocks} wrote.
+ *
+ * Falls back to the pre-#1448 newline-delimited form for a value already sitting
+ * in a user's localStorage from an older build — an upgrade must not be the
+ * thing that discards their unsaved text. That form genuinely cannot represent
+ * an intra-block newline, so splitting it is the correct reading of it.
+ */
+export function decodeScratchpadBlocks(stored: string): string[] {
+  if (stored.startsWith("[")) {
+    try {
+      const parsed: unknown = JSON.parse(stored);
+      if (Array.isArray(parsed) && parsed.every((b) => typeof b === "string")) {
+        return parsed as string[];
+      }
+    } catch {
+      // Not our JSON after all — read it as legacy text below.
+    }
+  }
+  return stored.split("\n");
 }
 
 interface ScratchpadEntry {
@@ -134,9 +175,9 @@ export function createScratchpadPersistence(getTabs: () => OpenTab[]): Scratchpa
 
   const persistEntry = (entry: ScratchpadEntry) => {
     const fragment = entry.ydoc.getXmlFragment("default");
-    const text = extractFragmentText(fragment);
+    const blocks = extractFragmentBlocks(fragment);
     const key = scratchpadStorageKey(entry.uuid);
-    if (text.length === 0) {
+    if (blocks.join("").length === 0) {
       // Empty scratchpad — clear any stale recovery so we don't warn on close.
       removeStorage(key);
       if (readStorage(SCRATCHPAD_LATEST_KEY) === entry.uuid) {
@@ -145,7 +186,7 @@ export function createScratchpadPersistence(getTabs: () => OpenTab[]): Scratchpa
       unsaved[entry.uuid] = false;
       return;
     }
-    writeStorage(key, text);
+    writeStorage(key, encodeScratchpadBlocks(blocks));
     writeStorage(SCRATCHPAD_LATEST_KEY, entry.uuid);
     unsaved[entry.uuid] = true;
   };
@@ -217,10 +258,9 @@ export function createScratchpadPersistence(getTabs: () => OpenTab[]): Scratchpa
     // Insert restored text as paragraphs into the (empty) fragment. y-prosemirror
     // reconciles this into the editor on mount. Build elements detached then
     // insert in one transaction so the populate path stays atomic.
-    const lines = stored.split("\n");
-    const paragraphs = lines.map((line) => {
+    const paragraphs = decodeScratchpadBlocks(stored).map((block) => {
       const p = new Y.XmlElement("paragraph");
-      if (line.length > 0) p.insert(0, [new Y.XmlText(line)]);
+      if (block.length > 0) p.insert(0, [new Y.XmlText(block)]);
       return p;
     });
     // Privacy invariant: BROWSER_ORIGIN is the only origin NOT in CHANNEL_SKIP

--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -618,11 +618,31 @@ function stripHashSuffix(key: string): string {
   return dashIdx >= 0 ? key.slice(0, dashIdx) : key;
 }
 
+/**
+ * Reconstruct the verbatim source of a raw block (raw HTML, footnote and link
+ * reference definitions) from its Y children.
+ *
+ * A newline inside one of these blocks can be held two ways: as a literal `\n`
+ * in a `Y.XmlText`, or as a sibling `Y.XmlElement("hardBreak")`. Reading only
+ * the `Y.XmlText` children dropped the second form **silently**, collapsing
+ * every multi-line raw block onto one line (#1458):
+ *
+ *     "<div>\n  <span>a</span>\n</div>"  ->  "<div>  <span>a</span></div>"
+ *
+ * That voided the "no silent drop" guarantee in #981 / ADR-042 for precisely
+ * the constructs that ADR exists to protect.
+ *
+ * The `whitespace: "pre"` paragraph fix (#1448) stops the editor manufacturing
+ * hardBreaks out of soft wraps, but it does NOT make this branch dead: an
+ * explicit Shift+Enter still lands a real hardBreak here, so both forms remain
+ * reachable and both must be read.
+ */
 function getElementPlainText(el: Y.XmlElement): string {
   let value = "";
   for (let i = 0; i < el.length; i++) {
     const child = el.get(i);
     if (child instanceof Y.XmlText) value += child.toString();
+    else if (child instanceof Y.XmlElement && child.nodeName === "hardBreak") value += "\n";
   }
   return value;
 }

--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -471,7 +471,11 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
   switch (el.nodeName) {
     case "heading": {
       const depth = Number(el.getAttribute("level") ?? 1) as 1 | 2 | 3 | 4 | 5 | 6;
-      return { type: "heading", depth, children: deltaToPhrasingContent(el) };
+      return {
+        type: "heading",
+        depth,
+        children: flattenHeadingNewlines(deltaToPhrasingContent(el)),
+      };
     }
 
     case "paragraph":
@@ -616,6 +620,38 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
 function stripHashSuffix(key: string): string {
   const dashIdx = key.indexOf("--");
   return dashIdx >= 0 ? key.slice(0, dashIdx) : key;
+}
+
+/**
+ * Replace newlines in a heading's phrasing content with spaces.
+ *
+ * A heading must never carry a literal newline. If one gets in, `remark-stringify`
+ * emits a **setext** heading at depth 1–2 (`first\nsecond\n======`) and an escaped
+ * `&#xA;` at depth 3+ — the first inverting our own documented setext→ATX
+ * normalization, both producing markdown nobody typed.
+ *
+ * This became reachable when `paragraph` gained `whitespace: "pre"` (#1448).
+ * Before that a paragraph could never hold a literal newline — any DOM re-read
+ * split it into `hardBreak` — so a soft-wrapped paragraph promoted to a heading
+ * (toolbar, `Mod-Alt-1`, a slash command: ordinary editing, not an edge case)
+ * could not carry one either. Now it can.
+ *
+ * Fixed here at the serialization boundary rather than in the block-conversion
+ * command, because there is more than one route into a heading and this is the
+ * single point they all pass through. Headings are never raw carriers, so unlike
+ * a general whitespace pass over `yDocToMdast` this cannot touch verbatim
+ * `markdownRaw` or `codeBlock` content.
+ */
+function flattenHeadingNewlines(children: PhrasingContent[]): PhrasingContent[] {
+  return children.map((child) => {
+    if (child.type === "text" && child.value.includes("\n")) {
+      return { ...child, value: child.value.replace(/\r?\n/g, " ") };
+    }
+    if ("children" in child && Array.isArray(child.children)) {
+      return { ...child, children: flattenHeadingNewlines(child.children as PhrasingContent[]) };
+    }
+    return child;
+  });
 }
 
 /**

--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -644,8 +644,18 @@ function stripHashSuffix(key: string): string {
  */
 function flattenHeadingNewlines(children: PhrasingContent[]): PhrasingContent[] {
   return children.map((child) => {
-    if (child.type === "text" && child.value.includes("\n")) {
-      return { ...child, value: child.value.replace(/\r?\n/g, " ") };
+    // A `break` child is the OTHER half of the trigger, and covering only `text`
+    // left it live: `mdast-util-to-markdown`'s `formatHeadingAsSetext` fires on
+    // `node.type === "break"` just as readily as on a newline in a value, so an
+    // explicit Shift+Enter inside a heading still emitted setext — an h1 landing
+    // on disk as `first line\\\nsecond line\n===========`, which every other
+    // reader then reports as the single heading `# first line second line`.
+    if (child.type === "break") return { type: "text", value: " " };
+    // Any node with a `value`, not `text` alone — `inlineCode` and `html` carry
+    // one too, and `formatHeadingAsSetext` tests `.value` without caring which.
+    // A code span holding a newline produced a setext h2 the same way.
+    if ("value" in child && typeof child.value === "string" && /[\r\n]/.test(child.value)) {
+      return { ...child, value: child.value.replace(/\r\n|[\r\n]/g, " ") };
     }
     if ("children" in child && Array.isArray(child.children)) {
       return { ...child, children: flattenHeadingNewlines(child.children as PhrasingContent[]) };

--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -50,6 +50,32 @@ export function docIdFromPath(filePath: string): string {
   return `${name}-${Math.abs(hash).toString(36).slice(0, 6)}`;
 }
 
+/**
+ * Collapse newlines in a heading's text to spaces.
+ *
+ * A heading must never present as multiple lines. Since `paragraph` gained
+ * `whitespace: "pre"` (#1448) a soft-wrapped paragraph promoted to a heading —
+ * toolbar, `Mod-Alt-1`, a slash command — carries a literal newline along with
+ * it, because `setBlockType` does not re-split content by the target type's
+ * whitespace spec.
+ *
+ * There are three independent readers of heading text and each needs this:
+ * `yxmlToMdast` (what gets written to disk), `extractText` below (the flat-text
+ * coordinate system, and what `tandem_getTextContent` returns), and `getOutline`
+ * (what `tandem_getOutline` hands the AI). Fixing only the disk writer leaves
+ * the AI reading a heading that spans two lines.
+ *
+ * **Must be a 1:1 character substitution, never a trim or a collapse of runs.**
+ * `extractText` is the annotation coordinate system and `getElementTextLength`
+ * counts the raw `Y.XmlText` length; anything that changed the character count
+ * would desync every annotation offset after the heading.
+ */
+export function flattenHeadingText(text: string): string {
+  // Character class, not `/\r?\n/` — a CRLF must become TWO spaces, not one,
+  // or the offsets shift by one for every CRLF in the heading.
+  return text.replace(/[\r\n]/g, " ");
+}
+
 /** Insert text content into a Y.Doc's XmlFragment as paragraphs */
 export function populateYDoc(doc: Y.Doc, text: string): void {
   const fragment = doc.getXmlFragment("default");
@@ -278,7 +304,7 @@ export function extractText(doc: Y.Doc): string {
       const text = getElementText(node);
       if (node.nodeName === "heading") {
         const level = Number(node.getAttribute("level") ?? 1);
-        lines.push(headingPrefix(level) + text);
+        lines.push(headingPrefix(level) + flattenHeadingText(text));
       } else {
         lines.push(text);
       }

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -29,6 +29,7 @@ import { convertToMarkdown } from "./convert.js";
 // Document model (pure logic)
 import {
   extractText,
+  flattenHeadingText,
   getElementText,
   getElementTextLength,
   getHeadingPrefixLength,
@@ -144,7 +145,10 @@ export function getOutline(fragment: Y.XmlFragment): OutlineEntry[] {
     const node = fragment.get(i);
     if (node instanceof Y.XmlElement && node.nodeName === "heading") {
       const level = Number(node.getAttribute("level") ?? 1);
-      outline.push({ level, text: getElementText(node), index: i });
+      // A heading can hold a literal newline since paragraphs gained
+      // whitespace:"pre" (#1448) — flatten it so the AI is never handed an
+      // outline entry that spans two lines. See flattenHeadingText.
+      outline.push({ level, text: flattenHeadingText(getElementText(node)), index: i });
     }
   }
   return outline;
@@ -163,7 +167,13 @@ export function getSection(
     const node = fragment.get(i);
     if (!(node instanceof Y.XmlElement)) continue;
 
-    const text = getElementText(node);
+    // Headings are flattened here for the same reason as in `getOutline`, and
+    // the two MUST agree: the AI gets a section name from `tandem_getOutline`
+    // and passes it straight back here. If the outline flattened and this
+    // comparison did not, a heading holding a newline would be listed under a
+    // name that then matched nothing.
+    const raw = getElementText(node);
+    const text = node.nodeName === "heading" ? flattenHeadingText(raw) : raw;
 
     if (node.nodeName === "heading") {
       const level = Number(node.getAttribute("level") ?? 1);

--- a/tests/client/editor-roundtrip.test.ts
+++ b/tests/client/editor-roundtrip.test.ts
@@ -34,40 +34,44 @@ describe("editor round-trip: the negative control", () => {
 });
 
 describe("editor round-trip: soft wraps (V3)", () => {
-  it.fails("a soft-wrapped paragraph survives an edit", () => {
+  it("the production paragraph node declares whitespace:'pre'", () => {
+    // The root-cause assertion, and a guard against a silent no-op: the natural
+    // way to write this override (filtering `buildSchemaExtensions()` by name)
+    // matches nothing, because `paragraph` came from `starterKit`. Without this
+    // line the round-trip tests below would pass against a stock schema on a
+    // day when the override had quietly stopped applying.
+    expect(productionSchema().nodes.paragraph.spec.whitespace).toBe("pre");
+  });
+
+  it("a soft-wrapped paragraph survives an edit", () => {
     const { output } = editorRoundTrip(SOFT_WRAPPED);
     expect(output).toBe(SOFT_WRAPPED);
   });
 
-  it("today a soft wrap becomes a hard break, and this is the defect", () => {
-    const { output } = editorRoundTrip(SOFT_WRAPPED);
+  it("a stock paragraph still turns the soft wrap into a hard break", () => {
+    // The negative control for the fix. If this ever goes green, the harness
+    // has stopped exercising the DOM re-read and every assertion above it is
+    // passing for the wrong reason.
+    const stock = schemaWith({ paragraph: { whitespace: null } });
+    expect(stock.nodes.paragraph.spec.whitespace).not.toBe("pre");
+
+    const { output } = editorRoundTrip(SOFT_WRAPPED, { schema: stock });
     expect(output).toContain("write into\\\n");
   });
 
-  it("declaring paragraph whitespace:'pre' fixes it", () => {
-    const schema = schemaWith({ paragraph: { whitespace: "pre" } });
-    // Guard against the silent no-op: a filtered-extension override would
-    // match nothing and this test would "pass" against the stock schema.
-    expect(schema.nodes.paragraph.spec.whitespace).toBe("pre");
-
-    const { output } = editorRoundTrip(SOFT_WRAPPED, { schema });
-    expect(output).toBe(SOFT_WRAPPED);
-  });
-
-  it("an explicit hard break still survives whitespace:'pre'", () => {
+  it("an explicit hard break still survives", () => {
     const withBreak = "first line\\\nsecond line\n";
-    const schema = schemaWith({ paragraph: { whitespace: "pre" } });
-    const { output } = editorRoundTrip(withBreak, { schema });
+    const { output } = editorRoundTrip(withBreak);
     expect(output).toBe(withBreak);
   });
 
-  it("the doc-spanning re-parse is what damages untouched paragraphs", () => {
+  it("the doc-spanning re-parse no longer damages untouched paragraphs", () => {
     // A childList mutation targeting the doc node re-parses every block in one
     // pass, which is why one edit backslashed every wrapped line of README.md.
+    // This is the case that reproduced the original bug report.
     const twoParas = `${SOFT_WRAPPED}\nA second paragraph, also\nwrapped across lines.\n`;
     const { output } = editorRoundTrip(twoParas, { docSpanning: true });
-    const damaged = output.split("\n").filter((l) => l.endsWith("\\")).length;
-    expect(damaged).toBeGreaterThan(1);
+    expect(output).toBe(twoParas);
   });
 });
 
@@ -101,7 +105,7 @@ describe("editor round-trip: multi-line verbatim blocks (V6)", () => {
     expect(serverOnly).toBe(RAW_HTML);
   });
 
-  it.fails("a multi-line raw HTML block survives an edit", () => {
+  it("a multi-line raw HTML block survives an edit", () => {
     const { output } = editorRoundTrip(RAW_HTML);
     expect(output).toBe(RAW_HTML);
   });

--- a/tests/client/paste-whitespace.test.ts
+++ b/tests/client/paste-whitespace.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Pasted-HTML whitespace normalization (#1448).
+ *
+ * These exist because the paragraph node declares `whitespace: "pre"`, and that
+ * setting silently defeats the paste-level `preserveWhitespace: false` once
+ * ProseMirror's parser enters a `<p>` (`prosemirror-model` `wsOptionsFor`, which
+ * falls through to `type.whitespace == "pre"` when the parse rule names no
+ * preference). Without the normalizer, pretty-printed markup — most web pages,
+ * many Word and Google Docs exports — imports its own source indentation as
+ * document content.
+ *
+ * The parser-level assertion at the bottom is the one that matters: it proves
+ * the normalizer actually changes what ProseMirror builds, rather than just
+ * producing tidier HTML on the way in.
+ */
+
+import { DOMParser as PMDOMParser } from "prosemirror-model";
+import { describe, expect, it } from "vitest";
+import { normalizePastedHtmlWhitespace } from "../../src/client/editor/utils/paste-whitespace.js";
+import { productionSchema } from "./editor-roundtrip-harness.js";
+
+describe("normalizePastedHtmlWhitespace", () => {
+  it("collapses the indentation of pretty-printed markup", () => {
+    const out = normalizePastedHtmlWhitespace("<p>\n  Some text\n  more text\n</p>");
+    expect(out).toBe("<p>Some text more text</p>");
+  });
+
+  it("leaves a ProseMirror-internal paste completely alone", () => {
+    // An internal copy carries whitespace the user actually has in their
+    // document — soft wraps they wrote. Collapsing it would lose them.
+    const internal = '<div data-pm-slice="1 1 []"><p>first line\nsecond line</p></div>';
+    expect(normalizePastedHtmlWhitespace(internal)).toBe(internal);
+  });
+
+  it("preserves whitespace inside pre and code", () => {
+    const out = normalizePastedHtmlWhitespace("<pre><code>if (x) {\n    y();\n}</code></pre>");
+    expect(out).toContain("if (x) {\n    y();\n}");
+  });
+
+  it("preserves a pre block nested inside a normalized document", () => {
+    const out = normalizePastedHtmlWhitespace(
+      "<div>\n  <p>\n  text\n  </p>\n  <pre>a\n  b</pre>\n</div>",
+    );
+    expect(out).toContain("<p>text</p>");
+    expect(out).toContain("a\n  b");
+  });
+
+  it("trims at the block boundary, not at an inline wrapper's boundary", () => {
+    const out = normalizePastedHtmlWhitespace("<p>\n  <em>emphasized</em> tail\n</p>");
+    expect(out).toBe("<p><em>emphasized</em> tail</p>");
+  });
+
+  it("keeps a single space between inline siblings", () => {
+    const out = normalizePastedHtmlWhitespace("<p><em>one</em>\n<strong>two</strong></p>");
+    expect(out).toBe("<p><em>one</em> <strong>two</strong></p>");
+  });
+
+  it("returns unparseable input unchanged rather than rewriting it", () => {
+    // A clipboard payload we cannot make sense of is one we must not touch.
+    expect(normalizePastedHtmlWhitespace("")).toBe("");
+  });
+});
+
+describe("the normalizer changes what ProseMirror actually builds", () => {
+  const PRETTY = "<p>\n  Some text\n  more text\n</p>";
+
+  const parseAsClipboardWould = (html: string) => {
+    const holder = document.createElement("div");
+    // Mirrors parseFromClipboard for ordinary external HTML: the base flag is
+    // false, and the whole point is that the base flag is not enough.
+    holder.innerHTML = html;
+    return PMDOMParser.fromSchema(productionSchema()).parse(holder, {
+      preserveWhitespace: false,
+    });
+  };
+
+  it("without it, the paragraph imports literal newlines and indentation", () => {
+    expect(parseAsClipboardWould(PRETTY).textContent).toBe("\n  Some text\n  more text\n");
+  });
+
+  it("with it, the paragraph imports what the browser would have rendered", () => {
+    expect(parseAsClipboardWould(normalizePastedHtmlWhitespace(PRETTY)).textContent).toBe(
+      "Some text more text",
+    );
+  });
+});

--- a/tests/client/paste-whitespace.test.ts
+++ b/tests/client/paste-whitespace.test.ts
@@ -59,6 +59,58 @@ describe("normalizePastedHtmlWhitespace", () => {
     // A clipboard payload we cannot make sense of is one we must not touch.
     expect(normalizePastedHtmlWhitespace("")).toBe("");
   });
+
+  it("does not treat a page that merely MENTIONS data-pm-slice as internal", () => {
+    // The bypass has to be an attribute lookup. As a substring test over the
+    // payload, copying prose about ProseMirror — or a diff of this very file —
+    // disabled normalization for the entire paste.
+    const out = normalizePastedHtmlWhitespace("<p>\n  The slice carries data-pm-slice.\n</p>");
+    expect(out).toBe("<p>The slice carries data-pm-slice.</p>");
+  });
+
+  it("still honours a real data-pm-slice attribute on a nested element", () => {
+    const internal = '<div><div data-pm-slice="1 1 []"><p>a\nb</p></div></div>';
+    expect(normalizePastedHtmlWhitespace(internal)).toBe(internal);
+  });
+
+  it("does not collapse a non-breaking space", () => {
+    // The browser never collapses NBSP — that is why someone types one. `s`
+    // matched it, and every other Unicode space separator (figure space, narrow
+    // no-break space, ideographic space), so every paste silently rewrote
+    // intentional typography.
+    //
+    // Written with escapes, and asserted on the DECODED text: these characters
+    // are invisible in source, and `innerHTML` re-serializes a surviving NBSP as
+    // `&nbsp;` — the same character, a different string.
+    const input = "<p>10 kg and　1 unit</p>";
+    const before = document.createElement("div");
+    before.innerHTML = input;
+    const after = document.createElement("div");
+    after.innerHTML = normalizePastedHtmlWhitespace(input);
+    expect(after.textContent).toBe(before.textContent);
+    expect(after.textContent).toContain(" ");
+  });
+
+  it("collapses a tab and a form feed, which the browser does collapse", () => {
+    // Positive control for the case above: narrowing the class must not have
+    // narrowed it to spaces and newlines alone.
+    expect(normalizePastedHtmlWhitespace("<p>a\t\fb</p>")).toBe("<p>a b</p>");
+  });
+
+  it("keeps a table alive when the clipboard starts at an orphan row", () => {
+    // What a spreadsheet or a partial table selection puts on the clipboard.
+    // `parseFromString` foster-parents an orphan <tr> out of the tree entirely,
+    // so without the wrap the cells arrive as bare text and the table is gone.
+    const out = normalizePastedHtmlWhitespace("<tr>\n  <td>\n  a\n  </td>\n  <td>b</td>\n</tr>");
+    expect(out).toContain("<td>a</td>");
+    expect(out).toContain("<td>b</td>");
+    expect(out.startsWith("<tr")).toBe(true);
+  });
+
+  it("keeps a table alive when the clipboard starts at an orphan cell", () => {
+    const out = normalizePastedHtmlWhitespace("<td>\n  only cell\n</td>");
+    expect(out).toBe("<td>only cell</td>");
+  });
 });
 
 describe("the normalizer changes what ProseMirror actually builds", () => {

--- a/tests/client/scratchpad-persistence.test.ts
+++ b/tests/client/scratchpad-persistence.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import {
+  decodeScratchpadBlocks,
+  encodeScratchpadBlocks,
+  extractFragmentBlocks,
   extractFragmentText,
   scratchpadStorageKey,
 } from "../../src/client/hooks/useScratchpadPersistence.svelte";
@@ -52,5 +55,36 @@ describe("extractFragmentText", () => {
     list.insert(0, [item]);
     fragment.insert(0, [list]);
     expect(extractFragmentText(fragment)).toBe("item text");
+  });
+});
+
+describe("the persisted form survives a paragraph that holds its own newline", () => {
+  // Since #1448 a paragraph's text can contain a literal newline — that is what
+  // keeps a soft wrap a soft wrap. The persisted form used `\n` as the BLOCK
+  // separator too, so restore could not tell the two apart and crash recovery
+  // came back with one paragraph per wrapped line: the recovery path silently
+  // reformatting the content it exists to preserve.
+
+  it("round-trips a soft-wrapped paragraph as ONE block", () => {
+    const doc = docWithParagraphs(["first line\nsecond line", "another paragraph"]);
+    const blocks = extractFragmentBlocks(doc.getXmlFragment("default"));
+    expect(blocks).toEqual(["first line\nsecond line", "another paragraph"]);
+    expect(decodeScratchpadBlocks(encodeScratchpadBlocks(blocks))).toEqual(blocks);
+  });
+
+  it("reads a pre-#1448 newline-delimited value rather than discarding it", () => {
+    // An upgrade must not be the thing that loses a user's unsaved text. The old
+    // form cannot represent an intra-block newline, so splitting it is the
+    // correct reading of it.
+    expect(decodeScratchpadBlocks("first\nsecond")).toEqual(["first", "second"]);
+  });
+
+  it("reads a legacy value that merely STARTS with a bracket as legacy text", () => {
+    expect(decodeScratchpadBlocks("[draft] notes\nmore")).toEqual(["[draft] notes", "more"]);
+  });
+
+  it("keeps extractFragmentText as the plain-text view for the emptiness check", () => {
+    const doc = docWithParagraphs(["a", "b"]);
+    expect(extractFragmentText(doc.getXmlFragment("default"))).toBe("a\nb");
   });
 });

--- a/tests/server/file-io/roundtrip-corpus.test.ts
+++ b/tests/server/file-io/roundtrip-corpus.test.ts
@@ -80,6 +80,47 @@ describe("round-trip corpus", () => {
   });
 });
 
+describe("verbatim blocks keep their newlines (V6, #1458)", () => {
+  /**
+   * Put a raw block's source into the Y.Doc with its newline held as a sibling
+   * `hardBreak` element rather than a literal `\n`, then serialize.
+   *
+   * This is the shape a deliberate Shift+Enter produces inside a raw block. It
+   * stays reachable after the `whitespace: "pre"` paragraph fix — that fix stops
+   * the editor MANUFACTURING hardBreaks from soft wraps, it does not stop a user
+   * typing one — so the reader has to handle both forms regardless.
+   */
+  function serializeRawBlockWithHardBreak(before: string, after: string): string {
+    const doc = new Y.Doc();
+    try {
+      const fragment = doc.getXmlFragment("default");
+      const para = new Y.XmlElement("paragraph");
+      para.setAttribute("markdownRaw", "true");
+      // Attach before populating — a detached Y.XmlText reverses segment order.
+      fragment.insert(0, [para]);
+      const head = new Y.XmlText();
+      const tail = new Y.XmlText();
+      para.insert(0, [head, new Y.XmlElement("hardBreak"), tail]);
+      head.insert(0, before);
+      tail.insert(0, after);
+      return saveMarkdown(doc);
+    } finally {
+      doc.destroy();
+    }
+  }
+
+  it("a hardBreak between two text runs is read back as a newline", () => {
+    // Before the fix this silently dropped the break and emitted
+    // "<div></div>" on one line.
+    expect(serializeRawBlockWithHardBreak("<div>", "</div>")).toContain("<div>\n</div>");
+  });
+
+  it("a multi-line raw HTML block round-trips", () => {
+    const raw = '<div class="callout">\n  <span>one</span>\n  <span>two</span>\n</div>\n';
+    expect(roundTrip(raw)).toBe(raw);
+  });
+});
+
 describe("round-trip corpus: line endings (W2)", () => {
   const LF = "# Title\n\nA paragraph soft-wrapped\nacross two lines.\n\n- a\n- b\n";
   const CRLF = LF.replace(/\n/g, "\r\n");

--- a/tests/server/file-io/whitespace-escaping.test.ts
+++ b/tests/server/file-io/whitespace-escaping.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Whitespace escaping under `whitespace: "pre"` paragraphs (#1448).
+ *
+ * Declaring `whitespace: "pre"` on the paragraph node keeps soft wraps as
+ * literal newlines instead of hard breaks. The obvious objection is that it
+ * reintroduces the very bug it fixes by a different route, because in markdown
+ * two trailing spaces before a newline ARE a hard break and four leading spaces
+ * ARE an indented code block. Preserved whitespace would then change meaning.
+ *
+ * It does not happen: `remark-stringify`'s `safe()` escapes both to `&#x20;`
+ * before they can be re-parsed as syntax. These tests pin that, because the
+ * guarantee lives in a dependency rather than in our code — an upgrade could
+ * remove it, and the failure would be silent corruption of user documents
+ * rather than an error.
+ *
+ * They also pin idempotency, since an escape that is not a fixed point would
+ * grow entities on every save.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { loadMarkdown, saveMarkdown } from "../../../src/server/file-io/markdown.js";
+
+function roundTrip(input: string): string {
+  const doc = new Y.Doc();
+  try {
+    loadMarkdown(doc, input);
+    return saveMarkdown(doc);
+  } finally {
+    doc.destroy();
+  }
+}
+
+/**
+ * Build a paragraph holding exactly `text` as one run, bypassing the markdown
+ * parser. The parser would strip the whitespace we are testing before it ever
+ * reached the serializer, so parsing the input first would test nothing.
+ */
+function serializeParagraphText(text: string): string {
+  const doc = new Y.Doc();
+  try {
+    const fragment = doc.getXmlFragment("default");
+    const para = new Y.XmlElement("paragraph");
+    // Attach before populating — inserting into a detached Y.XmlText reverses
+    // segment order.
+    fragment.insert(0, [para]);
+    const content = new Y.XmlText();
+    para.insert(0, [content]);
+    content.insert(0, text);
+    return saveMarkdown(doc);
+  } finally {
+    doc.destroy();
+  }
+}
+
+describe("preserved whitespace cannot become markdown syntax", () => {
+  it("trailing spaces before a newline do not become a hard break", () => {
+    const out = serializeParagraphText("first line  \nsecond line");
+    expect(out).not.toMatch(/ {2}\n/);
+    expect(out).toContain("&#x20;");
+    // The line break itself survives as a soft wrap, which is the whole point.
+    expect(out).toContain("\nsecond line");
+  });
+
+  it("leading spaces after a newline do not become an indented code block", () => {
+    const out = serializeParagraphText("first line\n    second line");
+    expect(out).toContain("&#x20;");
+    // Re-reading it must still be one paragraph, not a paragraph plus code.
+    const doc = new Y.Doc();
+    loadMarkdown(doc, out);
+    expect(saveMarkdown(doc)).toBe(out);
+    doc.destroy();
+  });
+
+  it("a tab after a newline does not become an indented code block", () => {
+    const out = serializeParagraphText("first line\n\tsecond line");
+    expect(roundTrip(out)).toBe(out);
+  });
+
+  it("the escaping is a fixed point, so saves do not accumulate entities", () => {
+    // Without this, each save would escape the previous save's output again and
+    // the file would grow on every edit.
+    const once = serializeParagraphText("first line  \n    second line");
+    expect(roundTrip(once)).toBe(once);
+    expect(roundTrip(roundTrip(once))).toBe(once);
+  });
+});
+
+describe("ordinary soft wraps stay ordinary", () => {
+  const WRAPPED =
+    "At work I kept asking Claude to draft a report for me. I had it write into\na scratch file in my vault, and it updated the instant Claude touched it.\n";
+
+  it("a plain soft wrap round-trips with no escaping at all", () => {
+    const out = roundTrip(WRAPPED);
+    expect(out).toBe(WRAPPED);
+    expect(out).not.toContain("&#x20;");
+    expect(out).not.toContain("\\\n");
+  });
+});

--- a/tests/server/file-io/whitespace-escaping.test.ts
+++ b/tests/server/file-io/whitespace-escaping.test.ts
@@ -86,6 +86,65 @@ describe("preserved whitespace cannot become markdown syntax", () => {
   });
 });
 
+describe("a heading never carries a newline", () => {
+  /**
+   * Build a heading holding `text` as one run. Reachable in the product by
+   * promoting a soft-wrapped paragraph to a heading — toolbar, `Mod-Alt-1`, a
+   * slash command. `setBlockType` changes the node type and does not re-split
+   * the text by the target type's whitespace spec, so the newline rides along.
+   */
+  function serializeHeading(level: number, text: string): string {
+    const doc = new Y.Doc();
+    try {
+      const heading = new Y.XmlElement("heading");
+      heading.setAttribute("level", level as never);
+      doc.getXmlFragment("default").insert(0, [heading]);
+      const content = new Y.XmlText();
+      heading.insert(0, [content]);
+      content.insert(0, text);
+      return saveMarkdown(doc);
+    } finally {
+      doc.destroy();
+    }
+  }
+
+  it.each([1, 2])("depth %i does not become a setext heading", (level) => {
+    // Setext is what remark-stringify emits for a multi-line heading, and it
+    // inverts our own documented setext -> ATX normalization.
+    const out = serializeHeading(level, "first line\nsecond line");
+    expect(out).not.toMatch(/^[=-]+$/m);
+    expect(out).toBe(`${"#".repeat(level)} first line second line\n`);
+  });
+
+  it.each([3, 4, 5, 6])("depth %i does not emit an escaped newline entity", (level) => {
+    const out = serializeHeading(level, "first line\nsecond line");
+    expect(out).not.toContain("&#xA;");
+    expect(out).toBe(`${"#".repeat(level)} first line second line\n`);
+  });
+
+  it("flattens a newline nested inside a mark", () => {
+    const doc = new Y.Doc();
+    const heading = new Y.XmlElement("heading");
+    heading.setAttribute("level", 2 as never);
+    doc.getXmlFragment("default").insert(0, [heading]);
+    const content = new Y.XmlText();
+    heading.insert(0, [content]);
+    // Delta mark key is `bold`; `deltaToPhrasingContent` maps it to mdast
+    // `strong`. Using the mdast name here would apply no mark at all and the
+    // test would pass while exercising only the flat branch.
+    content.insert(0, "bold\nwrapped", { bold: {} });
+
+    const out = saveMarkdown(doc);
+    expect(out).not.toContain("\n\n");
+    expect(out).toBe("## **bold wrapped**\n");
+    doc.destroy();
+  });
+
+  it("leaves a single-line heading exactly alone", () => {
+    expect(serializeHeading(2, "An ordinary heading")).toBe("## An ordinary heading\n");
+  });
+});
+
 describe("ordinary soft wraps stay ordinary", () => {
   const WRAPPED =
     "At work I kept asking Claude to draft a report for me. I had it write into\na scratch file in my vault, and it updated the instant Claude touched it.\n";

--- a/tests/server/heading-newline-readers.test.ts
+++ b/tests/server/heading-newline-readers.test.ts
@@ -80,6 +80,49 @@ describe("every reader flattens a heading's newline", () => {
   });
 });
 
+describe("the other two ways a heading gets a line break", () => {
+  // `formatHeadingAsSetext` fires on `node.type === "break"` OR on any node
+  // whose `.value` holds a newline. Covering the literal-newline `text` case
+  // alone left both of these emitting setext, which is the same corruption by a
+  // different door: what lands on disk is a two-line heading, and every reader
+  // then reports it as one line, so the file and the model disagree silently.
+
+  it("an explicit hard break in a heading does not emit setext", () => {
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    const heading = new Y.XmlElement("heading");
+    heading.setAttribute("level", 1 as never);
+    fragment.insert(0, [heading]);
+
+    const first = new Y.XmlText();
+    heading.insert(0, [first]);
+    first.insert(0, "first line");
+    heading.insert(1, [new Y.XmlElement("hardBreak")]);
+    const second = new Y.XmlText();
+    heading.insert(2, [second]);
+    second.insert(0, "second line");
+
+    expect(saveMarkdown(doc)).toBe("# first line second line\n");
+    // And the disk form agrees with what every reader reports.
+    expect(extractText(doc).split("\n")[0]).toBe("# first line second line");
+    doc.destroy();
+  });
+
+  it("a code span holding a newline does not emit setext", () => {
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    const heading = new Y.XmlElement("heading");
+    heading.setAttribute("level", 2 as never);
+    fragment.insert(0, [heading]);
+    const text = new Y.XmlText();
+    heading.insert(0, [text]);
+    text.insert(0, "code\nspan", { code: {} });
+
+    expect(saveMarkdown(doc)).toBe("## `code span`\n");
+    doc.destroy();
+  });
+});
+
 describe("flattening does not move any offset", () => {
   it("extractText's heading line is the same length as the raw text plus its prefix", () => {
     // extractText is the annotation coordinate system, and getElementTextLength

--- a/tests/server/heading-newline-readers.test.ts
+++ b/tests/server/heading-newline-readers.test.ts
@@ -1,0 +1,111 @@
+/**
+ * A heading never presents as two lines, through any reader (#1448).
+ *
+ * Since `paragraph` gained `whitespace: "pre"`, a soft-wrapped paragraph
+ * promoted to a heading carries a literal newline with it — `setBlockType`
+ * changes the node type without re-splitting content by the target type's
+ * whitespace spec. That is ordinary editing (toolbar, `Mod-Alt-1`, slash
+ * command), not an edge case.
+ *
+ * There are FOUR independent readers of heading text and fixing one is not
+ * fixing the invariant: `yxmlToMdast` (disk), `extractText` (the flat-text
+ * coordinate system and `tandem_getTextContent`), `getOutline` (what
+ * `tandem_getOutline` hands the AI), and `getSection`. The last two are coupled
+ * — the AI reads a name from one and passes it to the other — so a fix applied
+ * to only one of THOSE is worse than none.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { saveMarkdown } from "../../src/server/file-io/markdown.js";
+import { getOutline, getSection } from "../../src/server/mcp/document.js";
+import { extractText, getElementTextLength } from "../../src/server/mcp/document-model.js";
+
+/** A document whose h2 holds a literal newline, plus a body paragraph. */
+function docWithWrappedHeading(): Y.Doc {
+  const doc = new Y.Doc();
+  const fragment = doc.getXmlFragment("default");
+
+  const heading = new Y.XmlElement("heading");
+  heading.setAttribute("level", 2 as never);
+  const body = new Y.XmlElement("paragraph");
+  // Attach before populating — a detached Y.XmlText reverses segment order.
+  fragment.insert(0, [heading, body]);
+
+  const headingText = new Y.XmlText();
+  heading.insert(0, [headingText]);
+  headingText.insert(0, "first line\nsecond line");
+
+  const bodyText = new Y.XmlText();
+  body.insert(0, [bodyText]);
+  bodyText.insert(0, "Section body.");
+
+  return doc;
+}
+
+describe("every reader flattens a heading's newline", () => {
+  it("the disk writer emits a single-line ATX heading", () => {
+    const doc = docWithWrappedHeading();
+    expect(saveMarkdown(doc)).toBe("## first line second line\n\nSection body.\n");
+    doc.destroy();
+  });
+
+  it("extractText emits one line for the heading", () => {
+    const doc = docWithWrappedHeading();
+    const flat = extractText(doc);
+    expect(flat.split("\n")[0]).toBe("## first line second line");
+    doc.destroy();
+  });
+
+  it("getOutline hands the AI a single-line entry", () => {
+    const doc = docWithWrappedHeading();
+    expect(getOutline(doc.getXmlFragment("default"))).toEqual([
+      { level: 2, text: "first line second line", index: 0 },
+    ]);
+    doc.destroy();
+  });
+
+  it("getSection finds the heading by the name getOutline reported", () => {
+    // The coupling that matters: the AI reads a name from getOutline and passes
+    // it straight to getSection. Flattening one and not the other would list a
+    // section under a name that matches nothing.
+    const doc = docWithWrappedHeading();
+    const fragment = doc.getXmlFragment("default");
+    const name = getOutline(fragment)[0].text;
+
+    const section = getSection(fragment, name);
+    expect(section.found).toBe(true);
+    expect(section).toMatchObject({ text: "## first line second line\nSection body." });
+    doc.destroy();
+  });
+});
+
+describe("flattening does not move any offset", () => {
+  it("extractText's heading line is the same length as the raw text plus its prefix", () => {
+    // extractText is the annotation coordinate system, and getElementTextLength
+    // counts the RAW Y.XmlText. A flattening that changed the character count —
+    // a trim, or collapsing runs — would desync every annotation after the
+    // heading. Newline -> single space is 1:1; this is what pins that.
+    const doc = docWithWrappedHeading();
+    const heading = doc.getXmlFragment("default").get(0) as Y.XmlElement;
+
+    const rawLength = getElementTextLength(heading);
+    const headingLine = extractText(doc).split("\n")[0];
+    expect(headingLine.length).toBe(rawLength + "## ".length);
+    doc.destroy();
+  });
+
+  it("a CRLF becomes two spaces, not one", () => {
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    const heading = new Y.XmlElement("heading");
+    heading.setAttribute("level", 1 as never);
+    fragment.insert(0, [heading]);
+    const text = new Y.XmlText();
+    heading.insert(0, [text]);
+    text.insert(0, "first\r\nsecond");
+
+    expect(extractText(doc).split("\n")[0]).toBe("# first  second");
+    doc.destroy();
+  });
+});


### PR DESCRIPTION
**Stacked on #1456** (base is `test/roundtrip-fidelity-harness`, not `master`) — it needs that PR'"'"'s harness to demonstrate the fix, and it flips several of its pins from "still broken" to "fixed". Retarget to `master` once #1456 merges.

PR 2 of the #1448 document-fidelity work. Fixes #1458.

## The bug

Editing one word in a soft-wrapped markdown file rewrote every wrapped line in the whole document, appending a trailing `\` to each. That backslash is a semantic hard break, so afterwards every renderer broke those paragraphs at the original author'"'"'s wrap column regardless of viewport width. 21 lines changed in a README nobody had edited.

A soft wrap lives in the Y.Doc as a literal `\n` inside a `Y.XmlText`; a real hard break is a sibling `Y.XmlElement("hardBreak")`. The Y.Doc distinguishes them, ProseMirror does not — so `prosemirror-model` split paragraph text on newlines every time the editor re-read the DOM. One edit was enough to damage the entire file, because a childList mutation on the doc node makes `readDOMChange` re-parse every block in one pass.

Note the trigger is an **edit**. Opening a file to read it was always safe — the dirty gate from #851 works, and the original report was wrong about that. Details in the correction on #1448.

## The fix

`whitespace: "pre"` on the paragraph node. That is what `prosemirror-view` itself keys on: `parseBetween` passes `preserveWhitespace: "full"` when the parent'"'"'s whitespace is `"pre"`, and `linebreakReplacement` only splits when it is truthy-but-not-`"full"`. An explicit Shift+Enter hard break still survives, and it closes the paste doorway too — any clipboard carrying `text/html` bypasses `clipboardTextParser` and hit the same split. `linebreakReplacement: false` was rejected: it collapses the wrap to a space, losing the line outright.

Scoped to `paragraph`, deliberately **not** `heading` — a heading carrying a newline serializes as setext at depth 1–2, inverting one of our own documented normalizations. Table cells inherit it, since a cell'"'"'s content is a paragraph.

It has to be an extension **config field**, not `extendNodeSchema`. Tiptap spreads `extendNodeSchema`'"'"'s result first and then assigns `whitespace` over the top from the extension field, so an `extendNodeSchema` returning `{ whitespace: "pre" }` is overwritten with `undefined` and dropped by `cleanUpSchemaItem`. It reads as correct and does nothing. `Paragraph` carries `priority: 1000`, so re-adding it after `paragraph: false` cannot disturb `defaultType` for `block+`.

The objection that `"pre"` reintroduces the bug — two trailing spaces being a markdown hard break, four leading spaces an indented code block — does not hold: `remark-stringify`'"'"'s `safe()` escapes both to `&#x20;`, idempotently. That now has its own pins, because the guarantee lives in a dependency and an upgrade could remove it silently.

## Second fix in the same PR (#1458)

`getElementPlainText` read only `Y.XmlText` children, so a newline held as a sibling `hardBreak` was dropped with **no warning** and every multi-line raw block — raw HTML, footnote and link reference definitions — collapsed onto one line. That voided ADR-042'"'"'s own no-silent-drop guarantee for precisely the constructs it was written to protect.

It is in this PR because `whitespace: "pre"` does not remove the need for it: the fix stops the editor *manufacturing* hardBreaks from soft wraps, it does not stop a user typing one. It also gates the frontmatter fix (#1457), whose carrier is read by this same function.

## What adversarial review changed

Two reviewers on the diff. I reproduced every finding before acting on it, and one did not survive that.

**Real, fixed — paste.** `parseFromClipboard` passes `preserveWhitespace: false` for external HTML, which is right, but that is only the BASE option. Once the parser enters a `<p>`, `wsOptionsFor` falls through to `type.whitespace == "pre"` and the per-node setting overrides the paste-level intent. Reproduced: pretty-printed markup imported its own source indentation as content. Fixed at the paste boundary with `transformPastedHTML` — deliberately **not** by giving the paragraph parse rule an explicit `preserveWhitespace: false`, which would fix paste and silently reopen the newline split for any paragraph re-read without a node view desc.

**Real, fixed — headings.** `setBlockType` changes a node'"'"'s type without re-splitting its text, so promoting a soft-wrapped paragraph to a heading (toolbar, `Mod-Alt-1`, slash command — ordinary editing) now carries a literal newline into it. Structurally impossible before this PR. Then coordinate review found I had fixed only the disk writer, and the invariant has **four** readers: `yxmlToMdast`, `extractText`, `getOutline`, `getSection`. The last two are coupled — the AI reads a section name from one and passes it to the other — so fixing one of those and not the other is worse than fixing neither. The shared helper is a strict 1:1 character substitution because `extractText` is the annotation coordinate system; a trim would desync every offset after the heading.

**False positive.** That preserved newlines would render as collapsed spaces, since nothing here sets `white-space` on `.tandem-editor`. That review checked repo CSS and prosemirror-view'"'"'s stylesheet and missed that `@tiptap/core` injects `.ProseMirror { white-space: pre-wrap }` itself (`injectCSS` defaults true, not disabled). Recorded at the extension so nobody adds a duplicate rule on the strength of the same reading.

**Accepted and documented, not fixed.** Trailing whitespace is no longer stripped when a paragraph is parsed from the DOM. Trailing spaces the user typed on purpose now survive and save as `&#x20;`. Cosmetic, idempotent, and removing it would mean editing text the user typed deliberately.

## Filed, not fixed here

- **#1459** — `findXmlTextInParallel` advances its accumulator only for `Y.XmlText`, skipping sibling hardBreaks that every other length function counts as 1. An annotation anchored after an explicit Shift+Enter resolves one position short per preceding break. Pre-existing; this PR shrinks the exposure rather than causing it.
- **#1460** — a `.txt` paragraph holding a newline reopens as two paragraphs. Bytes on disk are identical and stay identical across any number of cycles; only in-editor structure differs. `.txt` has no marker that could distinguish the two states, so this is a decision rather than a fix.

## Docs

ADR-042 amended rather than left standing. It blessed "hard-break style" as a deliberate normalization — it was not, it was this defect — and its `idempotency + content-preservation, not byte-identity` test contract is what let all of this through, since **every** defect in #1448 satisfies it.

## Verification

- `npm run typecheck` clean; `npm run build` clean.
- `npm test` — 6727 passed, 3 expected fail, 0 failed.
- Two intermittents seen across six full-suite runs and not reproduced on re-run: `refresh-skill.test.ts` (a 20 ms abort deadline) and `tauri-file-drop`. Both pass in isolation and both passed on the clean run; neither is touched by this diff.
- **E2E not run.** It kills whatever holds :3478/:3479, and that is currently the running Tandem desktop app. Needs a run when the machine is free.
- The manual reproduction from the plan — open a soft-wrapped file, edit one word, `git diff` — still wants doing against a live server for the same reason.

Refs #1448

---

## Review round (xhigh) — 6 findings, all applied

**A heading had three doors to setext, not one.** `flattenHeadingNewlines` rewrote only `text` nodes, but `mdast-util-to-markdown`'s `formatHeadingAsSetext` fires on `node.type === "break"` just as readily, and on a newline in *any* node's `.value`. So a Shift+Enter hard break inside a heading still landed on disk as a two-line setext h1, and so did a code span holding a newline. Same corruption as the case this PR fixed, through a different door: the file says two lines, every reader says one, and they disagree silently. Both are now covered, and the tests assert disk and `extractText` agree.

**The paste normalizer had four.**

- Collapsing on `\s` collapsed every Unicode space separator — NBSP, figure space, narrow no-break space, ideographic space. A browser never collapses those; that is why someone types one. Narrowed to the five characters CSS actually collapses, with a tab/form-feed positive control so the narrowing cannot quietly become "spaces and newlines only".
- `parseFromString` foster-parents an orphan `<tr>` or `<td>` straight out of the tree — exactly what a spreadsheet or a partial table selection puts on the clipboard. The cells arrived as bare text and the table was gone, before ProseMirror ever saw it. Now wrapped in the required parents before parsing and unwrapped after, using `prosemirror-view`'s own `wrapMap`.
- The internal-paste bypass was `html.includes("data-pm-slice")`, a substring test over the whole payload: copying any page that *mentions* the string — a ProseMirror doc page, a diff of this file — disabled normalization for the entire paste. Now an attribute lookup, the same check `prosemirror-view` makes.
- The block-edge trim ran `texts.filter(t => block.contains(t))` per block, quadratic in node count; a large table paste hangs the main thread on it. Replaced with a single pass that records each block's first and last text node while walking ancestors it already had to walk.

**Scratchpad crash recovery reformatted what it exists to preserve.** It persisted blocks joined by `\n` and restored by splitting on `\n` — fine until this PR made an intra-paragraph newline representable, at which point recovery came back with one paragraph per wrapped line. Persisted as JSON now, with the pre-#1448 newline-delimited form still read on the way in, so an upgrade is not the thing that discards someone's unsaved text.


---

## Verification completed since the review round

Both gaps flagged above are now closed.

- **E2E: 349 passed, 11 skipped, 0 failed** (8.7 min), run with the machine free.
- **Full suite: 6787 passed, 19 skipped, 0 failed** (469 files); typecheck clean.
- **The manual reproduction ran.** One-word edit through the real browser against a live
  server produced four diff hunks: the intended edit, table delimiter compaction (alignment
  colons preserved), one intended escape-noise removal, and backtick escaping. A decisive
  check showed **editor output === server-only output**, and exactly one backslash-terminated
  line — the deliberately authored hard break. The whole-file backslash rewrite this PR exists
  to fix does not happen.
- **Paste matrix**, against LibreOffice Calc and Writer: pretty-printed HTML collapsed (32 and
  13 stray newlines respectively, all gone); a U+00A0 survived paste → editor → disk intact;
  marks survived; a table survived; zero `&#x20;` entities and zero spurious hard breaks.

## Correction: the orphan-`<tr>` premise is unreproduced

The review-round bullet above says a bare `<tr>` is "exactly what a spreadsheet or a partial
table selection puts on the clipboard". **That is not something I verified, and manual testing
did not reproduce it.** Both spreadsheet-family sources I could measure — LibreOffice Calc and
Writer — emit a full `<table>` wrapper, so neither exercises the path. Excel, the app the
claim specifically rests on, is not installed on this machine.

So the fix is not merely untested; the premise behind it was never observed. I am keeping it
anyway, for two reasons that are weaker than a reproduction and should be read as such:
`prosemirror-view` carries this identical `wrapMap` in its own clipboard reader, which is
reasonable evidence the shape occurs somewhere in the wild; and the code is inert unless the
payload's first tag is actually one of the orphan set, so being wrong costs nothing.

The code comment has been corrected to say the same thing (`f76e71e`) — a comment asserting an
unverified premise as fact is how the next reader inherits my confidence instead of my evidence.
