### PR TITLE
fix(markdown): stop destroying frontmatter, stop dropping table alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **YAML and TOML frontmatter is no longer destroyed when you save (#1457).** A block of `---` at the top of a note was being read as a horizontal rule followed by a heading, so saving turned it into exactly that. For an Obsidian vault this quietly stopped every note's tags, aliases and dates from being metadata at all — queries and filters that relied on them returned nothing, while the note still looked about right. Frontmatter is now kept exactly as written, and shown as a metadata block above the note rather than as body text.
+- **Table column alignment survives editing (#1448).** A table written as `|:--|:-:|--:|` lost its alignment the first time you edited the document, and permanently — reopening the file could not recover it, because it was no longer on disk.
 - **Editing a document no longer adds line breaks to paragraphs you did not touch (#1448).** If a file wrapped its paragraphs across several lines — the normal way of writing markdown in a text editor — then editing a single word anywhere in it added a `\` to the end of every wrapped line in the whole document. That backslash is a real markdown instruction, so afterwards GitHub and every other viewer broke those paragraphs at the original author's wrap column no matter how wide the window was. Opening a file to read it was never affected; it took an edit.
 - **Multi-line blocks Tandem stores verbatim — raw HTML, footnote definitions, link definitions — no longer get collapsed onto one line (#1458).** Their line breaks were dropped silently on save, with no warning and no fallback.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "mammoth": "^1.8.0",
         "markdown-it": "^14.2.0",
         "prosemirror-markdown": "^1.13.4",
+        "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
@@ -5189,6 +5190,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fd-package-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
@@ -5299,6 +5313,14 @@
       "version": "3.4.2",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
     },
     "node_modules/formatly": {
       "version": "0.3.0",
@@ -6685,6 +6707,36 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-gfm": {
       "version": "3.1.0",
       "license": "MIT",
@@ -6910,6 +6962,22 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -8245,6 +8313,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "mammoth": "^1.8.0",
     "markdown-it": "^14.2.0",
     "prosemirror-markdown": "^1.13.4",
+    "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",

--- a/src/client/editor/editor-extensions.ts
+++ b/src/client/editor/editor-extensions.ts
@@ -162,6 +162,41 @@ const LinkWithHoverTitle = Link.extend({
  */
 const SoftWrapParagraph = Paragraph.extend({ whitespace: "pre" });
 
+/**
+ * Table that carries GFM column alignment (#1448).
+ *
+ * `@tiptap/extension-table` declares no attributes at all, so the `align` array
+ * the server writes on the table element was discarded by `computeAttrs` the
+ * moment the ProseMirror doc was built from the Y.Doc — before the DOM was
+ * involved — and `updateYFragment` then pruned it from the Y.Doc on the next
+ * write. `|:--|:-:|--:|` became `|---|---|---|` on the user's first edit, and
+ * permanently: reopening the file cannot recover what is no longer on disk.
+ *
+ * Stored the way the server stores it: a JSON array at the TABLE level, not
+ * per-cell — that mirrors mdast's own shape and avoids per-cell plumbing.
+ *
+ * **Deliberately NOT `parseHTML: () => null`.** The `markdownRaw` /
+ * `markdownHtml` attributes next door use that pattern so pasted HTML can never
+ * forge a verbatim-passthrough block, which would let arbitrary pasted text
+ * serialize as un-escaped markdown source. Alignment carries no such risk, and
+ * copying the pattern here would re-break the thing being fixed: the attribute
+ * would reset to null on the next DOM re-read. It must survive a DOM round trip,
+ * so it renders to `data-align` and parses back from it.
+ */
+const TableWithAlignment = Table.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      align: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute("data-align"),
+        renderHTML: (attrs: Record<string, unknown>) =>
+          attrs.align ? { "data-align": String(attrs.align) } : {},
+      },
+    };
+  },
+});
+
 export function buildSchemaExtensions(): AnyExtension[] {
   return [
     // `listItem:false` disables StarterKit's stock ListItem so our
@@ -238,7 +273,7 @@ export function buildSchemaExtensions(): AnyExtension[] {
     Placeholder.configure({
       placeholder: "Start typing…",
     }),
-    Table.configure({ resizable: true }),
+    TableWithAlignment.configure({ resizable: true }),
     TableRow,
     TableCell,
     TableHeader,

--- a/src/client/editor/editor.css
+++ b/src/client/editor/editor.css
@@ -119,6 +119,19 @@
 .hide-raw-md .tandem-editor [data-markdown-raw] {
   display: none;
 }
+/* YAML/TOML frontmatter (#1457) rides the same raw-passthrough carrier, but it
+   is the one raw construct that is never part of the document's text — it is
+   metadata about the note. Given its own box so it reads as a header block
+   rather than as a dimmed first paragraph, which is what an Obsidian user
+   expects to see above their note. It still obeys the "Show raw markdown"
+   toggle above via the [data-markdown-raw] rule, and the source is always in
+   the Y.Doc either way, so nothing here can affect the saved file. */
+.tandem-editor [data-markdown-frontmatter] {
+  border-left: 2px solid var(--tandem-border);
+  padding: var(--tandem-space-2) var(--tandem-space-3);
+  background: var(--tandem-surface-sunk);
+  white-space: pre-wrap;
+}
 /* Inline/embedded images (issue #153): markdown `![alt](url)` + .docx images.
    Constrain to the content width so large embedded images don't overflow. */
 .tandem-editor img {

--- a/src/client/editor/extensions/markdown-html.ts
+++ b/src/client/editor/extensions/markdown-html.ts
@@ -11,8 +11,19 @@ import { Extension } from "@tiptap/core";
  *   #981 / ADR-042. Unlike `markdownHtml` it emits `data-markdown-raw` so the
  *   editor.css visibility toggle (`.hide-raw-md [data-markdown-raw]`) has a DOM
  *   hook.
+ * - `markdownFrontmatter`: narrows `markdownRaw` to YAML/TOML frontmatter
+ *   (#1457) so it can be styled as a metadata block rather than body prose.
+ *   Purely presentational — serialization goes through the same path either way.
  *
- * Both use `parseHTML: () => null` so the attribute is NEVER reconstructed from
+ * All three must be DECLARED here even though nothing in the editor sets them.
+ * An attribute the client schema does not declare is discarded by
+ * `computeAttrs` when the PM doc is built from the Y.Doc, and `updateYFragment`
+ * then prunes it from the Y.Doc on the next write — so the server's attribute
+ * silently disappears on the user's first edit. That is the mechanism that
+ * destroyed table alignment (#1448), and it happens before the DOM is involved
+ * at all, so no `parseHTML` choice can protect against it.
+ *
+ * They use `parseHTML: () => null` so the attribute is NEVER reconstructed from
  * pasted/loaded HTML — it is a server-Y.Doc-only attribute. Re-deriving it from
  * the DOM would let pasted content masquerade as raw passthrough and serialize
  * back as un-escaped source, corrupting the document.
@@ -34,6 +45,12 @@ export const MarkdownHtmlExtension = Extension.create({
             default: null,
             parseHTML: () => null,
             renderHTML: (attrs) => (attrs.markdownRaw ? { "data-markdown-raw": "" } : {}),
+          },
+          markdownFrontmatter: {
+            default: null,
+            parseHTML: () => null,
+            renderHTML: (attrs) =>
+              attrs.markdownFrontmatter ? { "data-markdown-frontmatter": "" } : {},
           },
         },
       },

--- a/src/server/file-io/markdown.ts
+++ b/src/server/file-io/markdown.ts
@@ -1,4 +1,5 @@
 import type { PhrasingContent, Root, RootContent } from "mdast";
+import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
@@ -40,8 +41,26 @@ function normalizeLabel(s: string): string {
  */
 const HOST_AFTER_AT = /^[A-Za-z0-9._-]*\.[A-Za-z0-9_-]*[A-Za-z]/;
 
+/**
+ * Frontmatter flavours to recognize. Both halves of the pipeline must be given
+ * the SAME list — a flavour the parser knows and the stringifier does not comes
+ * back out as an unhandled node.
+ *
+ * Without this, CommonMark rules apply to a frontmatter block and destroy it:
+ * the opening `---` is a thematic break and the closing `---` is a setext
+ * underline for the line above, so `---\ntitle: X\n---` saves back as
+ * `---\n\ntitle: X\n---------` and is no longer frontmatter at all. For an
+ * Obsidian vault that silently voids every note's tags, aliases and dates
+ * (#1457).
+ */
+const FRONTMATTER_FLAVOURS: ["yaml", "toml"] = ["yaml", "toml"];
+
 /** Markdown parser shared by production and tests. */
-export const mdParser = unified().use(remarkParse).use(remarkGfm).freeze();
+export const mdParser = unified()
+  .use(remarkParse)
+  .use(remarkFrontmatter, FRONTMATTER_FLAVOURS)
+  .use(remarkGfm)
+  .freeze();
 
 const stringifyOptions = {
   bullet: "-",
@@ -77,6 +96,7 @@ let activeRefDefs = new Set<string>();
  * time, so the same frozen processor serves every tree.
  */
 const mdStringifier = unified()
+  .use(remarkFrontmatter, FRONTMATTER_FLAVOURS)
   .use(remarkGfm)
   .use(remarkStringify, {
     ...stringifyOptions,

--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -13,6 +13,17 @@ const MARKDOWN_HTML_ATTR = "markdownHtml";
  */
 const MARKDOWN_RAW_ATTR = "markdownRaw";
 /**
+ * Marks a `markdownRaw` paragraph that is specifically YAML/TOML frontmatter
+ * (#1457), so the client can present it as a metadata block rather than prose.
+ *
+ * Presentation only — it does NOT affect serialization, which goes through the
+ * same `html`-node path as any other raw block. It exists because frontmatter
+ * is the one raw construct that is never part of the document's text: showing
+ * it as an editable paragraph in the body would put `---` and `title:` at the
+ * top of every Obsidian note.
+ */
+const FRONTMATTER_ATTR = "markdownFrontmatter";
+/**
  * Delta-attribute key for an inline run holding verbatim markdown source
  * (footnoteReference, linkReference, imageReference, inline image, inline html).
  * MUST byte-match the Tiptap `rawMarkdown` Mark name. Listed in ALL_MARKS so
@@ -94,6 +105,21 @@ function blockToYxml(
   node: RootContent,
   deferred: Array<{ xmlText: Y.XmlText; nodes?: PhrasingContent[]; plainText?: string }>,
 ): Y.XmlElement[] {
+  // Frontmatter (#1457), handled before the switch. It must NOT fall through to
+  // the `default:` branch: a yaml/toml node HAS a `.value`, so that branch would
+  // match and store only the body, dropping the `---` fences — which is exactly
+  // what makes it frontmatter. `serializeMdastBlock` re-emits the fences because
+  // `remarkFrontmatter` is registered on the stringifier too.
+  //
+  // Checked here rather than as switch cases because `toml` is not in mdast's
+  // node union: @types/mdast declares `yaml` natively, and `toml` only arrives
+  // via a module augmentation in `mdast-util-frontmatter` that TypeScript elides
+  // from a type-only import. Widening the switch subject to `string` would cost
+  // narrowing on every other case.
+  if (node.type === "yaml" || (node.type as string) === "toml") {
+    return [rawBlockParagraph(serializeMdastBlock(node), deferred, { frontmatter: true })];
+  }
+
   switch (node.type) {
     case "heading": {
       const el = new Y.XmlElement("heading");
@@ -260,9 +286,14 @@ function blockToYxml(
 function rawBlockParagraph(
   source: string,
   deferred: Array<{ xmlText: Y.XmlText; nodes?: PhrasingContent[]; plainText?: string }>,
+  opts: { frontmatter?: boolean } = {},
 ): Y.XmlElement {
   const el = new Y.XmlElement("paragraph");
   el.setAttribute(MARKDOWN_RAW_ATTR, true as any);
+  // Frontmatter rides the same carrier but is tagged so the client can style it
+  // as a metadata block rather than prose. Serialization is identical either
+  // way — the attribute is presentation only.
+  if (opts.frontmatter) el.setAttribute(FRONTMATTER_ATTR, true as any);
   const text = new Y.XmlText();
   el.insert(0, [text]);
   deferred.push({ xmlText: text, plainText: source });

--- a/tests/client/attribute-parity.test.ts
+++ b/tests/client/attribute-parity.test.ts
@@ -35,6 +35,7 @@ const SOURCES = [
   '<div class="raw">block</div>\n',
   "[ref]: https://example.com\n\nSee [ref].\n",
   "Text[^1]\n\n[^1]: A footnote.\n",
+  "---\ntitle: A Note\ntags: [x]\n---\n\nBody.\n",
 ];
 
 /** Every (nodeName, attribute) pair the server actually writes. */
@@ -51,7 +52,12 @@ function serverWrittenAttributes(): Map<string, Set<string>> {
 }
 
 describe("Y attribute parity between server and client schema", () => {
-  it("every attribute the server writes is declared on the client node", () => {
+  it("no server-written attribute is discarded by the client schema", () => {
+    // The permanent gate. An attribute the client schema does not declare is
+    // dropped by `computeAttrs` when the PM doc is built from the Y.Doc, and
+    // `updateYFragment` then prunes it from the Y.Doc — so the data is gone from
+    // disk on the user's first edit, silently and irrecoverably. That is what
+    // happened to `table.align`.
     const schema = productionSchema();
     const dropped: string[] = [];
 
@@ -67,19 +73,21 @@ describe("Y attribute parity between server and client schema", () => {
       }
     }
 
-    // V4 is open: `table.align` is the one casualty today. When PR 3 declares
-    // it, this list empties and the assertion below becomes the permanent gate.
-    expect(dropped).toEqual(["table.align"]);
+    expect(dropped).toEqual([]);
   });
 
-  it.fails("no server-written attribute is discarded by the client schema", () => {
-    const schema = productionSchema();
-    const dropped: string[] = [];
-    for (const [nodeName, attrs] of serverWrittenAttributes()) {
-      const declared = new Set(Object.keys(schema.nodes[nodeName]?.spec.attrs ?? {}));
-      for (const attr of attrs) if (!declared.has(attr)) dropped.push(`${nodeName}.${attr}`);
-    }
-    expect(dropped).toEqual([]);
+  it("actually derives attributes, rather than passing on an empty set", () => {
+    // The positive anchor. Without it, a change that made
+    // `serverWrittenAttributes()` return nothing would satisfy the "zero
+    // dropped" assertion above and report perfect health on an empty scan.
+    const written = serverWrittenAttributes();
+    expect(written.size).toBeGreaterThan(4);
+    // Spread each Set — `.flat()` does not flatten a Set, so a plain
+    // `[...written.values()].flat()` silently yields an array OF Sets and the
+    // `toContain` below can never match.
+    const all = [...written.values()].flatMap((set) => [...set]);
+    expect(all).toContain("align");
+    expect(all).toContain("markdownFrontmatter");
   });
 
   it("the attributes that do survive are still surviving", () => {
@@ -91,8 +99,9 @@ describe("Y attribute parity between server and client schema", () => {
       orderedList: ["start"],
       listItem: ["checked"],
       codeBlock: ["language"],
-      paragraph: ["markdownHtml", "markdownRaw"],
+      paragraph: ["markdownHtml", "markdownRaw", "markdownFrontmatter"],
       image: ["src", "alt", "title"],
+      table: ["align"],
     };
     for (const [nodeName, attrs] of Object.entries(expected)) {
       const declared = Object.keys(schema.nodes[nodeName]?.spec.attrs ?? {});

--- a/tests/client/editor-roundtrip.test.ts
+++ b/tests/client/editor-roundtrip.test.ts
@@ -78,21 +78,33 @@ describe("editor round-trip: soft wraps (V3)", () => {
 describe("editor round-trip: table column alignment (V4)", () => {
   const ALIGNED = "| L | C | R |\n| :- | :-: | -: |\n| 1 | 2 | 3 |\n";
 
-  it("the Tiptap table node declares no attributes, so align cannot survive", () => {
-    // The loss happens at `schema.node()` when the PM doc is built from the
-    // Y.Doc — before the DOM is involved at all. This assertion is the root
-    // cause; the round-trip below is the symptom.
-    expect(Object.keys(productionSchema().nodes.table.spec.attrs ?? {})).not.toContain("align");
+  it("the Tiptap table node declares align, which is what lets it survive", () => {
+    // The root-cause assertion. The loss happened at `schema.node()` when the
+    // PM doc is built from the Y.Doc — before the DOM is involved at all — so
+    // no parseHTML/renderHTML choice could have rescued it. Only declaring the
+    // attribute does.
+    expect(Object.keys(productionSchema().nodes.table.spec.attrs ?? {})).toContain("align");
   });
 
-  it.fails("an aligned table survives an edit", () => {
+  it("an aligned table survives an edit", () => {
     const { output } = editorRoundTrip(ALIGNED);
     expect(output).toContain(":-:");
   });
 
-  it("today alignment is silently dropped, permanently", () => {
+  it("the alignment reaches the PM doc and comes back unchanged", () => {
     const { output, attached } = editorRoundTrip(ALIGNED);
-    expect(attached.child(0).attrs.align).toBeUndefined();
+    expect(attached.child(0).attrs.align).toBe('["left","center","right"]');
+    // The delimiter row is what carries alignment, and it is byte-identical.
+    // The body rows are still width-padded — that is the `tablePipeAlign`
+    // canonicalization, a separate (invisible-tier) item, not alignment loss.
+    expect(output.split("\n")[1]).toBe("| :- | :-: | -: |");
+  });
+
+  it("a stock table node still drops it", () => {
+    // Negative control. If this goes green the harness has stopped exercising
+    // the attribute path and the assertions above prove nothing.
+    const stock = schemaWith({ table: { attrs: {} } });
+    const { output } = editorRoundTrip(ALIGNED, { schema: stock });
     expect(output).not.toContain(":-:");
   });
 });

--- a/tests/server/file-io/frontmatter.test.ts
+++ b/tests/server/file-io/frontmatter.test.ts
@@ -1,0 +1,126 @@
+/**
+ * YAML/TOML frontmatter round-trip (#1457).
+ *
+ * Before `remark-frontmatter` was wired in, CommonMark rules applied to a
+ * frontmatter block and destroyed it: the opening `---` is a thematic break and
+ * the closing `---` a setext underline for the line above. The block survived
+ * as text but stopped being frontmatter, which for an Obsidian vault means every
+ * note's tags, aliases and dates stop existing as metadata while the note still
+ * looks roughly right.
+ *
+ * The regression these tests exist to catch is subtler than "frontmatter
+ * broke": it is the block silently ceasing to be *frontmatter* while its bytes
+ * still round-trip, or the two halves of the pipeline being configured with
+ * different flavour lists.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { loadMarkdown, mdParser, saveMarkdown } from "../../../src/server/file-io/markdown.js";
+
+function roundTrip(input: string): string {
+  const doc = new Y.Doc();
+  try {
+    loadMarkdown(doc, input);
+    return saveMarkdown(doc);
+  } finally {
+    doc.destroy();
+  }
+}
+
+const YAML = "---\ntitle: My Note\ntags: [a, b]\n---\n\nBody text.\n";
+
+describe("frontmatter survives a round trip", () => {
+  it("a YAML block comes back byte-identical", () => {
+    expect(roundTrip(YAML)).toBe(YAML);
+  });
+
+  it("and is still parsed AS frontmatter, not as prose that looks like it", () => {
+    // The assertion that matters. Byte-identity alone would also hold for a
+    // block that had degenerated into a thematic break plus a setext heading,
+    // since that shape is a stable fixed point once reached.
+    const tree = mdParser.parse(roundTrip(YAML));
+    expect(tree.children[0]).toMatchObject({ type: "yaml" });
+    expect(tree.children[0]).not.toMatchObject({ type: "thematicBreak" });
+  });
+
+  it("the old failure mode is gone", () => {
+    const out = roundTrip(YAML);
+    expect(out).not.toContain("------");
+    expect(out).not.toMatch(/^---\n\n/);
+  });
+
+  it("a TOML block round-trips too", () => {
+    // The stringifier must be given the same flavour list as the parser. If
+    // only the parser knew `toml`, this would parse and then fail to serialize.
+    const toml = '+++\ntitle = "My Note"\n+++\n\nBody text.\n';
+    expect(roundTrip(toml)).toBe(toml);
+    expect(mdParser.parse(roundTrip(toml)).children[0]).toMatchObject({ type: "toml" });
+  });
+
+  it("an empty frontmatter block survives", () => {
+    const empty = "---\n---\n\nBody.\n";
+    expect(roundTrip(empty)).toBe(empty);
+  });
+
+  it("frontmatter containing a line of dashes is not confused for the fence", () => {
+    const tricky = "---\ntitle: A\nrule: ---\n---\n\nBody.\n";
+    expect(roundTrip(tricky)).toBe(tricky);
+  });
+
+  it("survives a second pass unchanged", () => {
+    expect(roundTrip(roundTrip(YAML))).toBe(YAML);
+  });
+});
+
+describe("a `---` that is NOT frontmatter still behaves as a thematic break", () => {
+  it("mid-document dashes stay a thematic break", () => {
+    // Frontmatter is position-sensitive: only a block at the very start counts.
+    // If the plugin were misconfigured to match anywhere, this document's rule
+    // would be silently swallowed into a metadata block.
+    const withRule = "Intro paragraph.\n\n---\n\nAfter the rule.\n";
+    const tree = mdParser.parse(roundTrip(withRule));
+    expect(tree.children.some((n) => n.type === "thematicBreak")).toBe(true);
+    expect(tree.children.some((n) => n.type === "yaml")).toBe(false);
+  });
+});
+
+describe("frontmatter is carried as a raw block, not as prose", () => {
+  it("is stored with both the raw and frontmatter markers", () => {
+    // `markdownRaw` is what makes it serialize verbatim; the frontmatter marker
+    // is what lets the client present it as metadata instead of body text.
+    // Losing the first corrupts the file; losing the second only looks wrong.
+    const doc = new Y.Doc();
+    loadMarkdown(doc, YAML);
+    const first = doc.getXmlFragment("default").get(0) as Y.XmlElement;
+
+    expect(first.nodeName).toBe("paragraph");
+    expect(first.getAttribute("markdownRaw")).toBeTruthy();
+    expect(first.getAttribute("markdownFrontmatter")).toBeTruthy();
+    doc.destroy();
+  });
+
+  it("keeps its fences in the stored source", () => {
+    // The `default:` branch of the mdast->Y mapping would match a yaml node
+    // (it has a `.value`) and store the body WITHOUT the fences. That reads as
+    // working — the text is all there — and silently stops it being frontmatter.
+    const doc = new Y.Doc();
+    loadMarkdown(doc, YAML);
+    const first = doc.getXmlFragment("default").get(0) as Y.XmlElement;
+    const stored = first.toString();
+
+    expect(stored).toContain("---");
+    expect(stored).toContain("title: My Note");
+    doc.destroy();
+  });
+
+  it("an ordinary raw block does NOT get the frontmatter marker", () => {
+    const doc = new Y.Doc();
+    loadMarkdown(doc, "[spec]: https://example.com\n");
+    const first = doc.getXmlFragment("default").get(0) as Y.XmlElement;
+
+    expect(first.getAttribute("markdownRaw")).toBeTruthy();
+    expect(first.getAttribute("markdownFrontmatter")).toBeFalsy();
+    doc.destroy();
+  });
+});

--- a/tests/server/file-io/roundtrip-corpus.test.ts
+++ b/tests/server/file-io/roundtrip-corpus.test.ts
@@ -33,7 +33,7 @@ const CORPUS: Record<string, { blockedOn?: string; why?: string }> = {
   "soft-wrap.md": {},
   "tight-list.md": {},
   "raw-blocks.md": {},
-  "frontmatter.md": { blockedOn: "V1", why: "no remark-frontmatter; the fences parse as setext" },
+  "frontmatter.md": {},
   "loose-list.md": { blockedOn: "V2", why: "spread is hardcoded false in yDocToMdast" },
   "table-aligned.md": { blockedOn: "V-table-padding", why: "tablePipeAlign defaults to true" },
   "table-compact.md": { blockedOn: "V-table-padding", why: "tablePipeAlign defaults to true" },


### PR DESCRIPTION
**Stacked on #1461** (base is `fix/document-fidelity-whitespace`). Retarget as the stack merges.

PR 3 of the #1448 document-fidelity work. Fixes #1457.

## Frontmatter (#1457) — the most serious defect in the set

There was no `remark-frontmatter` in the pipeline, so CommonMark rules applied to a frontmatter block: the opening `---` is a thematic break, the closing `---` a setext underline for the line above. Saving wrote that misreading back to disk.

```
in : "---\ntitle: My Note\ntags: [a, b]\n---\n\nBody\n"
out: "---\n\ntitle: My Note\ntags: [a, b]\n------------\n\nBody\n"
```

**19 of 19 tracked files with frontmatter in this repo.** For an Obsidian vault — the use case the README leads with — this does not degrade the metadata, it stops it *being* metadata. Every query, filter and backlink that depends on tags or aliases silently returns nothing, while the note still looks about right.

It had no issue of its own until this work; a repo-wide search turned up nothing.

### Two things worth calling out in the fix

**It is handled before the `switch`, not as a case in it.** A `yaml`/`toml` node HAS a `.value`, so the `default:` branch would have matched it and stored only the *body* — dropping the `---` fences, which is precisely what makes it frontmatter. That reads as working: all the text is there. (Secondary reason: `toml` is not in mdast'"'"'s node union — `@types/mdast` declares `yaml` natively and `toml` arrives via a module augmentation that TypeScript elides from a type-only import. Widening the switch subject to `string` would cost narrowing on every other case.)

**Both halves of the pipeline get the same flavour list.** A flavour the parser knows and the stringifier does not comes back out as an unhandled node, so the TOML test is not redundant with the YAML one.

### The visibility decision

Frontmatter rides the existing `markdownRaw` carrier but is tagged with its own attribute, and styled as a metadata block above the note rather than as a dimmed first paragraph of body prose. Serialization is identical either way — the attribute is presentation only, so this can be changed later without touching the file format.

I took the smaller option deliberately: the destruction is the harm worth fixing now, and a dedicated non-rendering node type is a much larger change that can be made on top of this without redoing it. **Flagging it as a real choice rather than burying it** — if you want frontmatter hidden entirely, or surfaced as a properties panel, that is a follow-up rather than a rework.

## Table alignment (#1448)

`@tiptap/extension-table` declares no attributes, so the `align` array the server writes was discarded by `computeAttrs` when the PM doc is built from the Y.Doc — **before the DOM is involved at all** — and `updateYFragment` then pruned it from the Y.Doc on the next write. `|:--|:-:|--:|` became `|---|---|---|` on the user'"'"'s first edit, permanently: reopening cannot recover what is no longer on disk.

Deliberately **not** `parseHTML: () => null`. The `markdownRaw`/`markdownHtml` attributes next door use that pattern so pasted HTML cannot forge a verbatim-passthrough block (which would let arbitrary pasted text serialize as un-escaped markdown source). Alignment carries no such risk, and copying the pattern would re-break the thing being fixed — the attribute would reset to `null` on the next DOM re-read.

**Known limitation, stated plainly:** alignment is now *preserved* but still not *rendered* in the editor — there is no `text-align` on table cells. The data survives a round trip; it is not yet visibly editable. Per-column styling has to be driven from a table-level JSON array, which is #995'"'"'s territory.

## Test changes

Both the corpus and the attribute-parity suite are designed to fail when a defect is fixed, and both did — that is what forced the registrations out rather than letting an allowlist linger:

- `frontmatter.md` loses its `blockedOn` registration and becomes a plain byte-identity fixture.
- The attribute-parity test loses its `it.fails` and becomes the permanent gate, plus a **positive anchor** so a change that made it derive zero attributes could not pass as "nothing dropped". Its own assertion had a bug I hit while doing this: `.flat()` does not flatten a `Set`, so the array-of-Sets it built could never have matched.
- New `frontmatter.test.ts` asserts more than byte-identity. Byte-identity alone would also hold for a block that had already degenerated into a thematic break plus a setext heading, since that shape is a stable fixed point once reached — so it also asserts the block still **parses as** `yaml`, that a mid-document `---` is still a thematic break, and that the stored source keeps its fences.

## Verification

- `npm run typecheck` clean.
- `npm test` — 6741 passed, 1 expected fail (the CRLF pin, which is PR 4), 0 failed.
- Repo metric: 245 scanned, 195 byte-different, 75 render-different, all in known kinds.
- **E2E not run** — it kills whatever holds :3478/:3479, currently the running Tandem desktop app.
- The frontmatter block'"'"'s appearance in the editor has not been looked at in a browser, for the same reason. The CSS uses existing tokens (I checked the three I first reached for did not exist — `--tandem-border-subtle`, `--tandem-bg-subtle`, `--tandem-radius-sm` are not defined anywhere, and would have rendered as nothing).

Refs #1448