### PR TITLE
fix(markdown): lists, marks, code spans, line endings and stale sessions

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -945,12 +945,28 @@ Both are silent from the user's perspective today; both end when the integration
 
 "Idempotency + content-preservation, not byte-identity" sounds like a modest, honest contract. It is not: **every defect found in #1448 satisfies it.** Each one mangles the document exactly once and is then a stable fixed point, so `pass2 === pass1` holds and the suite stays green while the file on disk is wrong. The contract could not fail, which is why nothing failed for months. It is replaced by **byte-identity on the first pass** for anything a reader would notice, measured by `tests/server/file-io/roundtrip-corpus.test.ts` and `tests/client/editor-roundtrip.test.ts`.
 
-Two specific corrections:
+Three specific corrections:
 
 - **"Hard-break style" was never a normalization.** What actually happened is that the *editor* converted **soft line wraps into hard breaks** — a semantic change, not a style choice. A soft wrap lives in the Y.Doc as a literal `\n` inside a `Y.XmlText`; a hard break is a sibling `Y.XmlElement("hardBreak")`. The Y.Doc distinguishes them; ProseMirror does not, so its DOM re-read split paragraph text on newlines. Saving then wrote a trailing `\` onto every wrapped line and renderers broke the paragraph at the author's wrap column. Fixed by declaring `whitespace: "pre"` on the paragraph node. Genuine hard-break *style* (`  ` vs `\`) is still normalized and that part stands.
 - **The "no silent drop" guarantee did not hold for the raw carriers this ADR introduces.** `getElementPlainText` read only `Y.XmlText` children, so a newline held as a sibling `hardBreak` was dropped without warning and every multi-line raw block collapsed onto one line (#1458) — the exact failure mode this ADR exists to prevent, in the exact constructs it was written to protect.
 
-Loose→tight (`spread: false` hardcoded) remains as described here and remains a defect rather than a normalization; it is tracked in #1448 and not yet fixed.
+- **Loose→tight was never a normalization either, and is now fixed.** `spread` was hardcoded `false` on both the list and each item in `yDocToMdast`, so every loose list in 56 of this repo's files was rewritten tight on the first save. It is now carried through the Y.Doc and declared on the Tiptap nodes (`ListSpreadExtension`), because an attribute the client schema does not declare is discarded by `computeAttrs` before the DOM is ever involved and then pruned from the Y.Doc — the same mechanism that destroyed table alignment.
+
+**The replacement contract, in full.** A difference is either **visible** — a reader opening the file in another editor or viewer would see it — or **invisible**. Visible differences are defects and are held at zero by the corpus. Invisible ones are canonicalization: they are permitted, they must be idempotent (change once, then hold), and they are enumerated here so they are a stated behaviour rather than a discovery.
+
+The invisible set, measured across all 245 tracked `.md` files in this repo:
+
+- Marker and structure style with no mdast representation: setext→ATX headings, indented→fenced code, bullet/emphasis/fence/ordered markers, `***`→`---`, blank-line runs collapsed, entity decoding, autolinks to angle form.
+- Table geometry: hand-authored `|---|---|` cannot be reproduced, and a row's trailing empty cell is made explicit. Cell *padding* no longer churns (`tablePipeAlign: false`), which was 112 of the 201 originally-differing files; alignment colons survive (they are carried as a declared `align` attribute).
+- Code-span style: padding spaces inside a fence, a longer-than-minimal fence, and a span wrapped across a source line coming back on one line. CommonMark renders all three identically.
+- Mark order where the source cannot be recovered: two marks covering exactly the same run come back in a fixed order (`~~**x**~~` → `**~~x~~**`). A delta segment's attributes are a set — Yjs does not record which mark opened first. Where run *lengths* differ, nesting IS recovered; that was the V5 defect and it is fixed.
+- Escape noise: a literal backtick, a `\[label]` matching a real definition, and a `\@` before a host-shaped string all keep their backslash. Each is a deliberate over-keep — see the `text` handler in `markdown.ts`, whose rule 3 documents two corruptions caused by trying to be tidier.
+
+Everything above renders identically. Recovering any of it needs a per-node source-marker layer, which is a materially larger project and is out of scope.
+
+**Line endings are preserved, not normalized** (`src/server/file-io/line-endings.ts`): the dominant ending is detected at load and restored at save, while the model itself is always LF. A CRLF file previously came back mixed — block separators LF, intra-paragraph soft wraps CRLF — which is worse than either pure form and invisible to a repo corpus, since `.gitattributes` pins `*.md text eol=lf`.
+
+**A persisted session is stamped with `DOCUMENT_MODEL_REVISION`.** `ydocState` is a bare `Y.encodeStateAsUpdate` of an already-parsed document, so none of the above reaches it; a session written under an older revision is discarded on reopen in favour of a fresh parse, unless it is `dirty` or an `upload://` path, where it is the only copy of the content.
 
 **Deferred (#982):** GFM task lists / checkboxes need a first-class `TaskList`/`TaskItem` node and `checked` mapping; today they degrade to plain bullets. This is a documented gap pinned by `markdown-fidelity.test.ts` so it can never become a silent drop.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -141,10 +141,45 @@ There are three ways to open a file:
 
 ### Supported Formats
 
-- **Markdown** (`.md`) — Full read-write support with lossless round-trip formatting.
+- **Markdown** (`.md`) — Full read-write support. Your content round-trips exactly; some *formatting style* is canonicalized on the first save. See [Markdown formatting](#markdown-formatting) below.
 - **Word** (`.docx`) — Read-write. Saving writes your edits back to the `.docx` body, and pending comments are written back as real Word comments. Existing Word comments (`<w:comment>` elements) are imported as annotations with author "import". External edits (e.g. from Word) are detected: a clean document reloads in place, while a document with unsaved edits shows a keep-vs-reload banner instead of losing anything. A **Convert to Markdown** option is also available if you prefer working in Markdown. See [Word fidelity](#word-fidelity) below.
 - **Plain text** (`.txt`) — Full read-write support.
 - **HTML** (`.html`, `.htm`) — Read support.
+
+### Markdown Formatting
+
+Tandem stores your document as structure, not as source text, so saving re-writes the
+file from that structure. **What you wrote is preserved. How you wrote it may be
+normalized** — once, on the first save. After that the file holds still.
+
+Nothing in this list changes how the document renders in any viewer. These are the
+things that do change:
+
+- **Marker style.** Setext headings (`Title` over `=====`) become `# Title`; `*` bullets
+  become `-`; `_em_` becomes `*em*`; `1)` becomes `1.`; `~~~` fences become backtick
+  fences; indented code becomes fenced; `***` becomes `---`; runs of blank lines collapse
+  to one.
+- **Tables.** Column alignment (`:---`, `:-:`, `---:`) is preserved, but hand-aligned
+  cell padding is not — cells are written compactly rather than padded to the widest
+  value in the column. That is deliberate: with padded cells, editing one word reflows
+  every row of the table.
+- **Code spans.** Padding spaces inside a fence, and fences longer than they need to be,
+  are trimmed to the shortest form that still works. A code span wrapped across two
+  source lines comes back on one.
+- **Escapes.** A literal backtick, a bracketed word matching a link definition, and an
+  `@` before something host-shaped all keep their backslash. Tandem keeps an escape
+  wherever removing it could change what the line means.
+- **Emphasis nesting.** Where two styles cover exactly the same words — `~~**both**~~` —
+  the order can come back swapped (`**~~both~~**`). Markdown records no trace of which
+  was opened first. Where the two cover different spans, the nesting is preserved.
+
+Everything else is written back as you left it: YAML and TOML frontmatter (fences and
+all), loose vs tight list spacing, ordered-list start numbers, footnote and reference
+definitions, raw HTML blocks, and your file's line endings — a CRLF file stays CRLF.
+
+If a save ever looks wrong, the original is recoverable. Tandem copies the file's bytes
+verbatim before its first write to it in a session; see
+[troubleshooting → Recovering a previous version](troubleshooting.md#recovering-a-previous-version-of-a-document).
 
 ### Word Fidelity
 

--- a/src/client/editor/editor-extensions.ts
+++ b/src/client/editor/editor-extensions.ts
@@ -14,6 +14,7 @@ import Underline from "@tiptap/extension-underline";
 import StarterKit from "@tiptap/starter-kit";
 import { FootnoteRefMark } from "./extensions/footnote-ref";
 import { ListItemCheckbox } from "./extensions/list-item-checkbox";
+import { ListSpreadExtension } from "./extensions/list-spread";
 import { MarkdownHtmlExtension } from "./extensions/markdown-html";
 import { RawMarkdownMark } from "./extensions/raw-markdown";
 import { isSafeExternalHref, isSchemelessPathHref } from "./utils/url-safety";
@@ -207,6 +208,7 @@ export function buildSchemaExtensions(): AnyExtension[] {
     StarterKit.configure({ history: false, listItem: false, paragraph: false }),
     SoftWrapParagraph,
     ListItemCheckbox,
+    ListSpreadExtension,
     // underline/superscript/subscript: marks the .docx import (mammoth) emits but
     // StarterKit does not provide. Required client-side or y-prosemirror deletes
     // the marked text on sync (see DOCX_INLINE_MARKS). Underline → Mod-u.

--- a/src/client/editor/extensions/list-spread.ts
+++ b/src/client/editor/extensions/list-spread.ts
@@ -1,0 +1,52 @@
+import { Extension } from "@tiptap/core";
+
+/**
+ * Loose vs tight list spacing (#1448).
+ *
+ * `spread` is what distinguishes a loose list — blank lines between items, each
+ * item's content wrapped in `<p>` — from a tight one. mdast carries it on both
+ * the list and each item, and the server writes it on both.
+ *
+ * Without this declaration the attribute is discarded by `computeAttrs` when the
+ * ProseMirror doc is built from the Y.Doc, and `updateYFragment` then prunes it
+ * from the Y.Doc on the next write — so the server's value is gone from disk on
+ * the user's first edit. That is the same mechanism that destroyed table
+ * alignment, and it happens before the DOM is involved, so no `parseHTML` choice
+ * can protect against it. 56 files in this repo were affected.
+ *
+ * A global attribute rather than three separate node extensions because
+ * `bulletList` and `orderedList` come from `starterKit` and have no entry of
+ * their own in `buildSchemaExtensions()` — filtering the extension list by name
+ * to override them matches nothing and silently does nothing.
+ *
+ * **Round-trips through the DOM, deliberately** — unlike the `markdownRaw` /
+ * `markdownHtml` markers next door, which use `parseHTML: () => null` so pasted
+ * HTML cannot forge a verbatim-passthrough block and smuggle un-escaped markdown
+ * source into the document. A forged `spread` changes blank-line spacing and
+ * nothing else, so the same precaution would cost the fix for no benefit: the
+ * attribute would reset on the next DOM re-read.
+ */
+export const ListSpreadExtension = Extension.create({
+  name: "listSpread",
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: ["bulletList", "orderedList", "listItem"],
+        attributes: {
+          spread: {
+            default: null,
+            // Splitting a loose item should produce another loose item —
+            // otherwise pressing Enter in a loose list silently tightens the
+            // item you just created and the list becomes half-and-half.
+            keepOnSplit: true,
+            parseHTML: (element: HTMLElement) =>
+              element.getAttribute("data-spread") === "true" ? true : null,
+            renderHTML: (attributes: Record<string, unknown>) =>
+              attributes.spread ? { "data-spread": "true" } : {},
+          },
+        },
+      },
+    ];
+  },
+});

--- a/src/server/file-io/index.ts
+++ b/src/server/file-io/index.ts
@@ -28,6 +28,7 @@ import {
   structuralLossLines,
 } from "./docx-lost-features.js";
 import { assertDocxWithinSizeLimits } from "./docx-size-gate.js";
+import { normalizeAndRecordLineEnding, restoreLineEndings } from "./line-endings.js";
 import { loadMarkdown, saveMarkdown } from "./markdown.js";
 import type { FormatAdapter, LoadIssue, Prepared } from "./types.js";
 
@@ -43,7 +44,15 @@ export type { ApplyContext, FormatAdapter, LoadIssue, Prepared } from "./types.j
 
 const markdownAdapter: FormatAdapter = {
   async parse(content): Promise<Prepared> {
-    return { format: "md", content: content as string, issues: [] };
+    // Decode here, not at the consumer. `unified().parse` accepts a Buffer
+    // (it is VFile-compatible), so a Buffer used to flow all the way through
+    // and only surfaced once something did real string work on it. Mirrors
+    // `plaintextAdapter.parse` below.
+    return {
+      format: "md",
+      content: typeof content === "string" ? content : content.toString("utf-8"),
+      issues: [],
+    };
   },
   apply(doc, prepared) {
     if (prepared.format !== "md") return [];
@@ -62,11 +71,15 @@ const plaintextAdapter: FormatAdapter = {
   },
   apply(doc, prepared) {
     if (prepared.format !== "other") return [];
-    populateYDoc(doc, prepared.content);
+    populateYDoc(doc, normalizeAndRecordLineEnding(doc, prepared.content));
     return [];
   },
   save(doc) {
-    return extractText(doc);
+    // Restoring here rather than inside `extractText` is deliberate: that
+    // function is also the flat-offset coordinate system every annotation range
+    // is expressed in (Critical Rule 5), and a `\r` there would shift every
+    // offset past it. Only the disk-bound copy gets the file's own endings.
+    return restoreLineEndings(doc, extractText(doc));
   },
 };
 

--- a/src/server/file-io/line-endings.ts
+++ b/src/server/file-io/line-endings.ts
@@ -1,0 +1,58 @@
+import type * as Y from "yjs";
+import { Y_MAP_DOCUMENT_META, Y_MAP_LINE_ENDING } from "../../shared/constants.js";
+
+/**
+ * Line-ending preservation (#1448 W2).
+ *
+ * A CRLF file previously came back MIXED, which is worse than either pure form:
+ * `remark-stringify` joins blocks with `\n` while an intra-paragraph soft wrap
+ * kept the `\r` it arrived with. Every Windows-authored `.md` was exposed, and
+ * the repo corpus can never catch it — `.gitattributes` pins `*.md text eol=lf`,
+ * so a committed CRLF fixture arrives as LF.
+ *
+ * The contract is detect-at-load, restore-at-save, LF everywhere in between.
+ * Normalizing to LF instead would rewrite every line of a Windows-authored
+ * file — the exact harm this whole effort is about.
+ */
+
+export type LineEnding = "\n" | "\r\n";
+
+/**
+ * The dominant line ending in `text`. CRLF only wins on a strict majority, so a
+ * mixed file (or one with no newlines at all) resolves to LF — the safer
+ * default, since LF is what the model and every downstream consumer already use.
+ */
+export function detectLineEnding(text: string): LineEnding {
+  const crlf = (text.match(/\r\n/g) ?? []).length;
+  // Subtracting `crlf` counts LONE newlines: every `\r\n` also matches `\n`.
+  const lf = (text.match(/\n/g) ?? []).length - crlf;
+  return crlf > lf ? "\r\n" : "\n";
+}
+
+/** Collapse every line ending to LF. Handles lone `\r` (classic Mac) too. */
+export function toLf(text: string): string {
+  return text.replace(/\r\n?/g, "\n");
+}
+
+/**
+ * Record `text`'s dominant ending on the doc and return the LF-normalized text
+ * to feed the parser. Call from a format adapter's `apply`, inside the caller's
+ * already-origin-tagged transact.
+ */
+export function normalizeAndRecordLineEnding(doc: Y.Doc, text: string): string {
+  doc.getMap(Y_MAP_DOCUMENT_META).set(Y_MAP_LINE_ENDING, detectLineEnding(text));
+  return toLf(text);
+}
+
+/**
+ * Re-apply the doc's recorded ending to freshly serialized (LF) output.
+ *
+ * `toLf` first rather than a bare `\n` -> `\r\n` replace: a serializer that
+ * emitted a `\r\n` of its own — or verbatim `markdownRaw` content carrying one —
+ * would otherwise become `\r\r\n`.
+ */
+export function restoreLineEndings(doc: Y.Doc, text: string): string {
+  const stored = doc.getMap(Y_MAP_DOCUMENT_META).get(Y_MAP_LINE_ENDING);
+  if (stored !== "\r\n") return text;
+  return toLf(text).replace(/\n/g, "\r\n");
+}

--- a/src/server/file-io/markdown.ts
+++ b/src/server/file-io/markdown.ts
@@ -6,6 +6,7 @@ import remarkStringify from "remark-stringify";
 import { unified } from "unified";
 import { visit } from "unist-util-visit";
 import * as Y from "yjs";
+import { normalizeAndRecordLineEnding, restoreLineEndings } from "./line-endings.js";
 import { mdastToYDoc, yDocToMdast } from "./mdast-ydoc.js";
 
 /**
@@ -70,15 +71,20 @@ const stringifyOptions = {
   rule: "-",
 } as const;
 
-/** Parse markdown string and populate a Y.Doc's XmlFragment */
+/**
+ * Parse markdown string and populate a Y.Doc's XmlFragment.
+ *
+ * Line endings are normalized to LF for the model and the file's own ending is
+ * recorded on the doc for `saveMarkdown` to restore — see `line-endings.ts`.
+ */
 export function loadMarkdown(doc: Y.Doc, markdown: string): void {
-  const tree = mdParser.parse(markdown) as Root;
+  const tree = mdParser.parse(normalizeAndRecordLineEnding(doc, markdown)) as Root;
   mdastToYDoc(doc, tree);
 }
 
-/** Serialize a Y.Doc's XmlFragment back to markdown */
+/** Serialize a Y.Doc's XmlFragment back to markdown, in the doc's own endings. */
 export function saveMarkdown(doc: Y.Doc): string {
-  return serializeMdast(yDocToMdast(doc));
+  return restoreLineEndings(doc, serializeMdast(yDocToMdast(doc)));
 }
 
 /**
@@ -97,7 +103,22 @@ let activeRefDefs = new Set<string>();
  */
 const mdStringifier = unified()
   .use(remarkFrontmatter, FRONTMATTER_FLAVOURS)
-  .use(remarkGfm)
+  // `tablePipeAlign: false` MUST go on remarkGfm, not on remarkStringify below.
+  // Tables are a GFM extension and it owns their serialization, so the option
+  // placed on remarkStringify — which is where this repo puts every other
+  // serializer option, and therefore the natural place to reach for — is a
+  // silent no-op. Verified:
+  //
+  //   baseline / on remarkStringify   "| :--- | :----: | ----: |\n| a    |    b   |     c |"
+  //   on remarkGfm                    "| :- | :-: | -: |\n| a | b | c |"
+  //
+  // Width-padding every cell to the widest value in its column is what made a
+  // one-word edit produce a 262-line diff: change any cell and every row in the
+  // table reflows. This decouples the delimiter and body rows from cell width.
+  // It does NOT reproduce hand-authored `|---|---|` geometry, and no option can
+  // — mdast carries no source markers — so compact delimiter rows still change
+  // once, and only once.
+  .use(remarkGfm, { tablePipeAlign: false })
   .use(remarkStringify, {
     ...stringifyOptions,
     handlers: {
@@ -138,9 +159,39 @@ const mdStringifier = unified()
         //    `(\_foo\_)`) stays escaped — those flanks CAN form emphasis.
         s = s.replace(/(?<=\w)\\_(?=\w)/g, "_");
 
-        // 3. `` \` `` standalone, not adjacent to another backtick. Real code
-        //    spans round-trip through the `inlineCode` handler, never `text`.
-        s = s.replace(/(?<![`\\])\\`(?!`)/g, "`");
+        // 3. NO backtick un-escaping. There used to be a rule here that
+        //    stripped `\` from a backtick judged "standalone"; it was removed in
+        //    #1448 after it was shown to CORRUPT two real documents, in two
+        //    different ways, and after two attempts to narrow it failed.
+        //
+        //    A bare backtick is a code-span delimiter and an escaped one is not
+        //    (verified: `a \` b \` c` parses as a single text node). So
+        //    un-escaping one turns an inert character into a live delimiter, and
+        //    whether that is safe depends on every other backtick REACHABLE FROM
+        //    IT — including ones in sibling nodes this handler never sees:
+        //
+        //      "`x ?? ``y```"          -> code("x ?? \") + text
+        //          the survivor pairs with the next escaped backtick, which the
+        //          backslash no longer shields once its partner is bare
+        //
+        //      "…-resize-handle`" + inlineCode("in the snapshot…")
+        //          -> the freed backtick merges with the SIBLING span's opening
+        //             fence, shifting every code-span boundary in the paragraph
+        //             and gluing words together (docs/design-system-impl/
+        //             testid-manifest.md)
+        //
+        //    Both are one-way: the mangled form reparses to different marks, so
+        //    the second save serializes something else again. An
+        //    idempotency-only assertion — which is what every pre-#1448 suite
+        //    was — cannot see either.
+        //
+        //    Narrowing this to "only when it is the sole backtick in the run"
+        //    fixes the first case and not the second: the paragraph's other
+        //    backticks live in sibling nodes, and `info.before`/`info.after`
+        //    reach only the immediate neighbour. Since the escape renders
+        //    identically and the un-escape buys nothing but tidier source, the
+        //    correct trade is the same one rules 1 and 5 make — keep the escape
+        //    wherever safety is not provable.
 
         // 4. `\~` not followed by another `~`. GFM strikethrough needs `~~`
         //    so a lone `~` is unambiguous prose (e.g. `~4500 tokens`).

--- a/src/server/file-io/markdown.ts
+++ b/src/server/file-io/markdown.ts
@@ -193,9 +193,37 @@ const mdStringifier = unified()
         //    correct trade is the same one rules 1 and 5 make — keep the escape
         //    wherever safety is not provable.
 
-        // 4. `\~` not followed by another `~`. GFM strikethrough needs `~~`
-        //    so a lone `~` is unambiguous prose (e.g. `~4500 tokens`).
-        s = s.replace(/\\~(?!~)/g, "~");
+        // 4. `\~` with no tilde adjacent to it on EITHER side, in either form.
+        //    GFM strikethrough needs `~~`, so a genuinely lone `~` is
+        //    unambiguous prose (`~4500 tokens`) and the escape is noise.
+        //
+        //    The guard used to be a `(?!~)` lookahead, which was structurally
+        //    dead: `safe()` escapes EVERY tilde, so an authored `~~` reaches
+        //    here as `\~\~` and the character after the first `\~` is a
+        //    backslash, never a tilde. The lookahead therefore passed on both
+        //    halves and un-escaped them, turning an author's escaped literal
+        //    `\~\~two\~\~` into a live strikethrough — the rendered document
+        //    gains formatting nobody asked for and loses four visible
+        //    characters. Verified against the real serializer; a passing
+        //    idempotency suite could never see it, because the corrupted output
+        //    is itself stable.
+        //
+        //    Looking at the neighbours instead of a fixed-width lookahead is
+        //    what makes the guard reachable: `\` is what sits between two
+        //    escaped tildes, so the test has to admit the escaped form.
+        //    `info.before` / `info.after` extend it across the node boundary,
+        //    where an adjacent `delete` node's own `~~` lives — same reason
+        //    rule 1 consults `info.after` for a following `[`.
+        const tildeAdjacent = (text: string, atStart: boolean) =>
+          atStart ? /^\\?~/.test(text) : /~$/.test(text);
+        const beforeText = typeof info.before === "string" ? info.before : "";
+        const afterText = typeof info.after === "string" ? info.after : "";
+        s = s.replace(/\\~/g, (match, offset: number) => {
+          const after = offset + match.length === s.length ? afterText : s.slice(offset + 2);
+          const before = offset === 0 ? beforeText : s.slice(0, offset);
+          if (tildeAdjacent(after, true) || tildeAdjacent(before, false)) return match;
+          return "~";
+        });
 
         // 5. `\@` only where the following text is NOT host-shaped. remark-gfm
         //    escapes `@` whenever a word-ish local-part char precedes it

--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -166,9 +166,18 @@ function blockToYxml(
       if (node.ordered && node.start != null && node.start !== 1) {
         el.setAttribute("start", node.start as any);
       }
+      // `spread` is what distinguishes a loose list (blank lines between items,
+      // each item's content wrapped in <p>) from a tight one. It used to be
+      // hardcoded `false` on the way back out, so every loose list in every
+      // document was silently converted to tight on the first save — 56 files in
+      // this repo. Stored only when true, so a tight list writes no attribute
+      // and reconciles against the editor's default without a phantom
+      // transaction; same reasoning as `checked` below.
+      if (node.spread) el.setAttribute("spread", true as any);
       let listIndex = 0;
       for (const item of node.children) {
         const listItem = new Y.XmlElement("listItem");
+        if (item.spread) listItem.setAttribute("spread", true as any);
         // GFM task list: a list item with non-null `checked` carries the
         // tri-state as an attribute on the ordinary listItem (#982). `null`
         // (plain bullet) stores no attribute so the editor's PM-default `null`
@@ -534,7 +543,11 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
     case "bulletList":
     case "orderedList": {
       const ordered = el.nodeName === "orderedList";
-      const start = ordered ? Number(el.getAttribute("start")) || 1 : undefined;
+      // `|| 1` here silently renumbered a list that starts at ZERO: `0.` was
+      // stored faithfully as "0", read back as the number 0, and then the falsy
+      // check replaced it with 1. Test for a usable number instead of for
+      // truthiness — 0 is a legitimate start (#1448).
+      const start = ordered ? parsedStart(el.getAttribute("start")) : undefined;
       const listItems: any[] = [];
       for (let i = 0; i < el.length; i++) {
         const child = el.get(i);
@@ -552,7 +565,11 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
           // bullet (no `checked` field). Read tolerantly (boolean from
           // y-prosemirror / server writes, or a string from any future writer).
           const checkedAttr = child.getAttribute("checked") as boolean | string | undefined;
-          const listItemNode: any = { type: "listItem", spread: false, children: itemChildren };
+          const listItemNode: any = {
+            type: "listItem",
+            spread: readSpread(child),
+            children: itemChildren,
+          };
           if (checkedAttr != null) {
             listItemNode.checked = checkedAttr === true || checkedAttr === "true";
           }
@@ -562,7 +579,7 @@ function yxmlToMdast(el: Y.XmlElement): RootContent | null {
       return {
         type: "list",
         ordered,
-        spread: false,
+        spread: readSpread(el),
         ...(ordered && start !== 1 ? { start } : {}),
         children: listItems,
       } as any;
@@ -654,6 +671,32 @@ function stripHashSuffix(key: string): string {
 }
 
 /**
+ * Read an ordered list's `start`, defaulting to 1 only when it is genuinely
+ * absent or unusable. Accepts 0, which `Number(x) || 1` did not.
+ */
+function parsedStart(raw: unknown): number {
+  // The absent cases must be rejected BEFORE the numeric coercion: `Number(null)`
+  // is 0, and `Number("")` is 0, so a bare `Number(raw)` would make every list
+  // with no `start` attribute — which is nearly all of them — start at zero.
+  if (raw == null || raw === "") return 1;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? n : 1;
+}
+
+/**
+ * Read a list/listItem `spread` flag tolerantly.
+ *
+ * The value can arrive as a real boolean (server writes, and what y-prosemirror
+ * writes back) or as the string `"true"` (any writer that stringifies
+ * attributes). Absent means tight. Same tolerance the `checked` tri-state
+ * already needs, and for the same reason: two writers, one attribute.
+ */
+function readSpread(el: Y.XmlElement): boolean {
+  const value = el.getAttribute("spread") as boolean | string | undefined;
+  return value === true || value === "true";
+}
+
+/**
  * Replace newlines in a heading's phrasing content with spaces.
  *
  * A heading must never carry a literal newline. If one gets in, `remark-stringify`
@@ -725,93 +768,194 @@ function getElementPlainText(el: Y.XmlElement): string {
 }
 
 /**
+ * One delta run: its leaf content plus the wrapping marks it carries.
+ * `null` content is a hardBreak, which carries no marks.
+ */
+interface Segment {
+  text: string | null;
+  marks: Map<string, any>;
+}
+
+/**
+ * Outermost-first tie-break for marks that cover exactly the same run.
+ *
+ * A delta segment's attributes are a SET — Yjs does not record which mark was
+ * opened first — so when two marks span an identical run there is genuinely no
+ * information to recover the source nesting from, and a fixed order is the
+ * honest answer. `~~**x**~~` therefore comes back as `**~~x~~**`: different
+ * bytes, identical rendering. Recovering the original would need a per-mark
+ * source-order marker, which is the same layer the invisible tier was ruled out
+ * over. What this order must NOT do is decide nesting when run LENGTH already
+ * does — see `buildPhrasingTree`.
+ */
+const MARK_NESTING_ORDER = ["bold", "italic", "strike", "link"] as const;
+
+/** Identity for run-matching. `link` differs by target, not just by presence. */
+function markKey(name: string, value: any): string {
+  if (name !== "link") return name;
+  const attrs = value || {};
+  return `link ${attrs.href ?? ""} ${attrs.title ?? ""}`;
+}
+
+/** The leaf node for a segment, before any mark wrapping. */
+function segmentLeaf(seg: Segment): PhrasingContent {
+  if (seg.text === null) return { type: "break" };
+  // A `rawMarkdown` run is verbatim markdown source (footnote/reference refs,
+  // inline image, inline html). Emit as an inline `html` node — it serializes
+  // byte-exact, bypassing the `text` escaper (PhrasingContent includes Html, so
+  // the cast is structural only). It still gets wrapped by the marks on its
+  // segment, so:
+  //   (a) an outer mark on the run is preserved (e.g. bold around a footnote
+  //       ref), and
+  //   (b) crucially, a raw inline IMAGE stays wrapped inside its mark rather
+  //       than becoming a bare paragraph-child image — which the #153
+  //       `splitParagraphImages` promotion would otherwise turn into a block
+  //       image on reload, collapsing the inline run's flat length and
+  //       desyncing every later annotation offset.
+  // Two adjacent UNMARKED raw runs (e.g. `[^1][^2]`) stay separate: `html` has
+  // no wrapper, so `coalescePhrasing`'s `sameWrapper` never merges them.
+  //
+  // `code` is a leaf-level mark: the segment is either an inlineCode leaf or a
+  // plain-text leaf. Every other mark wraps whatever this returns — inlineCode
+  // is valid PhrasingContent inside all of them, so a code span keeps its mark
+  // even when combined with bold/italic/etc.
+  if (seg.marks.has(RAW_MARKDOWN_MARK)) return { type: "html", value: seg.text } as any;
+  if (seg.marks.has("code")) return { type: "inlineCode", value: seg.text };
+  return { type: "text", value: seg.text };
+}
+
+function wrapInMark(name: string, value: any, children: PhrasingContent[]): PhrasingContent {
+  switch (name) {
+    case "bold":
+      return { type: "strong", children };
+    case "italic":
+      return { type: "emphasis", children };
+    case "strike":
+      return { type: "delete", children } as any;
+    default: {
+      const attrs = value || {};
+      return {
+        type: "link",
+        url: attrs.href || "",
+        ...(attrs.title ? { title: attrs.title } : {}),
+        children,
+      };
+    }
+  }
+}
+
+/**
+ * Build nested phrasing content from a flat list of marked runs (#1448 V5).
+ *
+ * Nesting is decided by RUN LENGTH — the mark covering the most consecutive
+ * segments becomes the outer node — not by a fixed wrap order. The fixed order
+ * was the defect: each segment was wrapped independently, so a mark spanning a
+ * run that another mark subdivides got emitted once per sub-run and closed at
+ * every internal boundary:
+ *
+ *   "~~a **struck** phrase~~"  ->  "~~a ~~**~~struck~~**~~ phrase~~"
+ *
+ * That is one `delete` per segment where the source had one spanning all three.
+ * It is idempotent — the mangled form reparses to the same mark sets — which is
+ * exactly why every pre-existing suite, all of which assert `pass2 === pass1`,
+ * was blind to it.
+ *
+ * `applied` carries the marks already opened by an enclosing call so an inner
+ * pass doesn't re-emit them.
+ */
+function buildPhrasingTree(segments: Segment[], applied: ReadonlySet<string>): PhrasingContent[] {
+  const out: PhrasingContent[] = [];
+  let i = 0;
+
+  while (i < segments.length) {
+    // Allowlist, not a denylist: `code` and `rawMarkdown` are leaf-level and an
+    // unrecognized mark has no mdast wrapper at all, so both must fall through
+    // to `segmentLeaf` rather than reaching `wrapInMark`'s default branch,
+    // which would silently emit them as links.
+    const open = [...segments[i].marks].filter(
+      ([name, value]) =>
+        (MARK_NESTING_ORDER as readonly string[]).includes(name) &&
+        !applied.has(markKey(name, value)),
+    );
+
+    if (open.length === 0) {
+      out.push(segmentLeaf(segments[i]));
+      i++;
+      continue;
+    }
+
+    // Pick the mark covering the longest run from here. Ties fall back to
+    // MARK_NESTING_ORDER, which is arbitrary but stable — see its comment.
+    let best = open[0];
+    let bestRun = 0;
+    for (const [name, value] of open) {
+      const key = markKey(name, value);
+      let run = i;
+      while (
+        run < segments.length &&
+        [...segments[run].marks].some(([n, v]) => markKey(n, v) === key)
+      ) {
+        run++;
+      }
+      const length = run - i;
+      const rank = MARK_NESTING_ORDER.indexOf(name as (typeof MARK_NESTING_ORDER)[number]);
+      const bestRank = MARK_NESTING_ORDER.indexOf(best[0] as (typeof MARK_NESTING_ORDER)[number]);
+      if (length > bestRun || (length === bestRun && rank < bestRank)) {
+        best = [name, value];
+        bestRun = length;
+      }
+    }
+
+    const [name, value] = best;
+    const key = markKey(name, value);
+    const nextApplied = new Set(applied);
+    nextApplied.add(key);
+    out.push(
+      wrapInMark(name, value, buildPhrasingTree(segments.slice(i, i + bestRun), nextApplied)),
+    );
+    i += bestRun;
+  }
+
+  return out;
+}
+
+/**
  * Convert Y.XmlText delta segments into MDAST phrasing content.
  * Handles marks (bold, italic, strike, code, link) and hardBreaks in either
  * representation — an embed inside a Y.XmlText or a sibling hardBreak element.
  */
 function deltaToPhrasingContent(el: Y.XmlElement): PhrasingContent[] {
-  const result: PhrasingContent[] = [];
+  const segments: Segment[] = [];
 
   for (let i = 0; i < el.length; i++) {
     const child = el.get(i);
 
     if (child instanceof Y.XmlText) {
-      const delta = child.toDelta();
-      for (const op of delta) {
+      for (const op of child.toDelta()) {
         // Embedded elements (hardBreak, etc.)
         if (typeof op.insert !== "string") {
           if (op.insert instanceof Y.XmlElement && op.insert.nodeName === "hardBreak") {
-            result.push({ type: "break" });
+            segments.push({ text: null, marks: new Map() });
           }
           continue;
         }
+        if (op.insert.length === 0) continue;
 
-        const text = op.insert;
-        if (text.length === 0) continue;
-
-        // Collect marks from delta attributes
-        const attrs = op.attributes || {};
         const marks = new Map<string, any>();
-        for (const [key, value] of Object.entries(attrs)) {
+        for (const [key, value] of Object.entries(op.attributes || {})) {
           marks.set(stripHashSuffix(key), value);
         }
-
-        // A `rawMarkdown` run is verbatim markdown source (footnote/reference
-        // refs, inline image, inline html). Emit as an inline `html` node — it
-        // serializes byte-exact, bypassing the `text` escaper (PhrasingContent
-        // includes Html, so the cast is structural only). It then flows through
-        // the SAME link/strike/italic/bold wrapping below as ordinary text, so:
-        //   (a) an outer mark on the run is preserved (e.g. bold around a
-        //       footnote ref), and
-        //   (b) crucially, a raw inline IMAGE stays wrapped inside its mark
-        //       rather than becoming a bare paragraph-child image — which the
-        //       #153 `splitParagraphImages` promotion would otherwise turn into
-        //       a block image on reload, collapsing the inline run's flat length
-        //       and desyncing every later annotation offset.
-        // Two adjacent UNMARKED raw runs (e.g. `[^1][^2]`) stay separate: `html`
-        // has no wrapper, so `coalescePhrasing`'s `sameWrapper` never merges them.
-        //
-        // `code` is a leaf-level mark: the segment is either an inlineCode leaf
-        // or a plain-text leaf. link/strike/italic/bold then each wrap whatever
-        // `node` is — inlineCode is valid PhrasingContent inside all of them, so
-        // a code span keeps its mark even when combined with bold/italic/etc.
-        let node: PhrasingContent = marks.has(RAW_MARKDOWN_MARK)
-          ? ({ type: "html", value: text } as any)
-          : marks.has("code")
-            ? { type: "inlineCode", value: text }
-            : { type: "text", value: text };
-
-        // Wrap from innermost to outermost: link, then strike, italic, bold.
-        if (marks.has("link")) {
-          const linkAttrs = marks.get("link") || {};
-          node = {
-            type: "link",
-            url: linkAttrs.href || "",
-            ...(linkAttrs.title ? { title: linkAttrs.title } : {}),
-            children: [node],
-          };
-        }
-        if (marks.has("strike")) {
-          node = { type: "delete", children: [node] } as any;
-        }
-        if (marks.has("italic")) {
-          node = { type: "emphasis", children: [node] };
-        }
-        if (marks.has("bold")) {
-          node = { type: "strong", children: [node] };
-        }
-
-        result.push(node);
+        segments.push({ text: op.insert, marks });
       }
     } else if (child instanceof Y.XmlElement) {
       // Non-text child elements embedded in a block (shouldn't happen often)
       if (child.nodeName === "hardBreak") {
-        result.push({ type: "break" });
+        segments.push({ text: null, marks: new Map() });
       }
     }
   }
 
-  return coalescePhrasing(result);
+  return coalescePhrasing(buildPhrasingTree(segments, new Set()));
 }
 
 /**

--- a/src/server/file-io/mdast-ydoc.ts
+++ b/src/server/file-io/mdast-ydoc.ts
@@ -794,7 +794,7 @@ const MARK_NESTING_ORDER = ["bold", "italic", "strike", "link"] as const;
 function markKey(name: string, value: any): string {
   if (name !== "link") return name;
   const attrs = value || {};
-  return `link ${attrs.href ?? ""} ${attrs.title ?? ""}`;
+  return `link\u0000${attrs.href ?? ""}\u0000${attrs.title ?? ""}`;
 }
 
 /** The leaf node for a segment, before any mark wrapping. */
@@ -935,7 +935,15 @@ function deltaToPhrasingContent(el: Y.XmlElement): PhrasingContent[] {
         // Embedded elements (hardBreak, etc.)
         if (typeof op.insert !== "string") {
           if (op.insert instanceof Y.XmlElement && op.insert.nodeName === "hardBreak") {
-            segments.push({ text: null, marks: new Map() });
+            // An EMBEDDED break carries the run's marks in its own delta
+            // attributes, so read them — discarding them made the break a
+            // mark-less segment and `buildPhrasingTree` closed every enclosing
+            // run at it (see `inheritBreakMarks`).
+            const marks = new Map<string, any>();
+            for (const [key, value] of Object.entries(op.attributes || {})) {
+              marks.set(stripHashSuffix(key), value);
+            }
+            segments.push({ text: null, marks });
           }
           continue;
         }
@@ -955,7 +963,43 @@ function deltaToPhrasingContent(el: Y.XmlElement): PhrasingContent[] {
     }
   }
 
-  return coalescePhrasing(buildPhrasingTree(segments, new Set()));
+  return coalescePhrasing(buildPhrasingTree(inheritBreakMarks(segments), new Set()));
+}
+
+/**
+ * Give a mark-less hard break the marks its neighbours agree on.
+ *
+ * `buildPhrasingTree` decides nesting by how many consecutive segments carry a
+ * mark, so a segment with an empty mark set TERMINATES every enclosing run.
+ * A hard break in the middle of a bold span is exactly that segment, and the
+ * result was one `strong` per line instead of one spanning the break:
+ *
+ *   "a **b\<newline>c** d"  ->  "a **b**\<newline>**c** d"
+ *
+ * Idempotent, and therefore invisible to every suite that asserts only
+ * `pass2 === pass1` — the same blindness that hid the defect this function's
+ * caller was written to fix.
+ *
+ * The `normalizeHardBreaks` representation is a SIBLING `Y.XmlElement`, which
+ * has no delta attributes of its own, so for that form the marks genuinely are
+ * not stored anywhere and the neighbours are the only evidence. Intersection,
+ * not union: a break between a bold run and a plain one belongs to neither, and
+ * widening a mark across it would ADD formatting rather than preserve it.
+ */
+function inheritBreakMarks(segments: Segment[]): Segment[] {
+  return segments.map((seg, i) => {
+    if (seg.text !== null || seg.marks.size > 0) return seg;
+    const prev = segments[i - 1];
+    const next = segments[i + 1];
+    if (!prev || !next) return seg;
+
+    const nextKeys = new Set([...next.marks].map(([n, v]) => markKey(n, v)));
+    const shared = new Map<string, any>();
+    for (const [name, value] of prev.marks) {
+      if (nextKeys.has(markKey(name, value))) shared.set(name, value);
+    }
+    return shared.size > 0 ? { text: null, marks: shared } : seg;
+  });
 }
 
 /**

--- a/src/server/mcp/file-opener.ts
+++ b/src/server/mcp/file-opener.ts
@@ -52,6 +52,7 @@ import {
   narrowConflict,
   restoreYDoc,
   saveSession,
+  sessionModelIsStale,
   sourceFileChanged,
   startAutoSave,
 } from "../session/manager.js";
@@ -816,6 +817,15 @@ async function maybeRestoreSession(
   readOnly: boolean,
 ): Promise<RestoreResult> {
   const session = await loadSession(resolved);
+  if (session && sessionModelIsStale(session)) {
+    // #1448 W3. Falling through to a fresh parse of the source file, which is
+    // the same content read by a load path that no longer damages it. Only
+    // clean, on-disk sessions reach here — see `sessionModelIsStale`.
+    console.error(
+      `[Tandem] Session for ${fileName} predates the current document model; re-reading from the file`,
+    );
+    return { restored: false };
+  }
   if (session) {
     const changed = await sourceFileChanged(session);
     const dirtySession = session.dirty === true;

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -158,10 +158,23 @@ export async function sourceFileChanged(session: SessionData): Promise<boolean> 
  * is about:
  *   - `dirty` sessions hold unsaved edits that exist nowhere else.
  *   - `upload://` paths have no disk file to re-read.
+ *   - a session carrying an UNRESOLVED conflict is the only record that the
+ *     conflict happened. `maybeRestoreSession` carries `session.conflict`
+ *     forward precisely because it cannot be re-derived — `saveSession` stats
+ *     the file at save time, so `sourceFileMtime` IS the external write's mtime
+ *     and `sourceFileChanged` reads false on reopen. Discarding the session
+ *     here returns before that carry, which does not defer the conflict, it
+ *     destroys it: the keep-vs-reload banner never appears and the next
+ *     autosave tick overwrites the external edit. That is the same laundering
+ *     the carry exists to prevent, and it costs a user their file, which is a
+ *     strictly worse outcome than replaying a stale parse of it. Re-reading is
+ *     an improvement, not an emergency; it can wait for the conflict to be
+ *     resolved and the next save to re-stamp the revision.
  */
 export function sessionModelIsStale(session: SessionData): boolean {
   if (session.dirty === true) return false;
   if (isUploadPath(session.filePath)) return false;
+  if (narrowConflict(session.conflict) !== undefined) return false;
   return (session.modelRevision ?? 0) < DOCUMENT_MODEL_REVISION;
 }
 

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -3,6 +3,7 @@ import path from "path";
 import * as Y from "yjs";
 import {
   CTRL_ROOM,
+  DOCUMENT_MODEL_REVISION,
   SESSION_MAX_AGE,
   Y_MAP_CHAT,
   Y_MAP_CHAT_DOCUMENT_NAMES,
@@ -67,6 +68,7 @@ export async function saveSession(
     ydocState,
     sourceFileMtime,
     lastAccessed: Date.now(),
+    modelRevision: DOCUMENT_MODEL_REVISION,
     ...(opts?.dirty ? { dirty: true } : {}),
     ...(opts?.conflict ? { conflict: opts.conflict } : {}),
   };
@@ -140,6 +142,27 @@ export async function sourceFileChanged(session: SessionData): Promise<boolean> 
   } catch {
     return true; // File doesn't exist — treat as changed
   }
+}
+
+/**
+ * True when this session was written by a load path that has since been fixed,
+ * and re-parsing the source file is strictly better than replaying it (#1448).
+ *
+ * `ydocState` is a bare `Y.encodeStateAsUpdate` of an ALREADY-parsed document,
+ * so a parser fix cannot reach it. Without this check a user who upgrades keeps
+ * every defect their pre-fix session baked in for up to `SESSION_MAX_AGE` — the
+ * fix ships but never arrives.
+ *
+ * Two populations are deliberately exempt, because for them the session is the
+ * only copy of the content and discarding it is the data loss this whole effort
+ * is about:
+ *   - `dirty` sessions hold unsaved edits that exist nowhere else.
+ *   - `upload://` paths have no disk file to re-read.
+ */
+export function sessionModelIsStale(session: SessionData): boolean {
+  if (session.dirty === true) return false;
+  if (isUploadPath(session.filePath)) return false;
+  return (session.modelRevision ?? 0) < DOCUMENT_MODEL_REVISION;
 }
 
 /** Delete a session file */

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -124,6 +124,28 @@ export const DOCX_INLINE_MARKS = [
 
 export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 export const SESSION_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
+/**
+ * Revision of the document model a persisted session was written under (#1448).
+ *
+ * A session's `ydocState` is a bare `Y.encodeStateAsUpdate` — it carries the
+ * document as it was ALREADY parsed, so a parser fix does not reach it. Without
+ * a stamp a user who upgrades keeps every defect their pre-fix session baked in
+ * (manufactured hard breaks, tightened lists, destroyed frontmatter) for up to
+ * `SESSION_MAX_AGE`, and the fix effectively never ships to existing documents.
+ *
+ * A session stamped below this number is discarded on reopen in favour of a
+ * fresh parse from the source file — unless it is `dirty` or an `upload://`
+ * path, where the session is the only copy of the content and dropping it would
+ * be the data loss the stamp exists to prevent.
+ *
+ * Bump this whenever a change to the load path makes an already-parsed Y.Doc
+ * differ from what the same source file would produce now.
+ *
+ *   1 — pre-#1448 (implicit; absent field reads as 0, which is also stale)
+ *   2 — #1448: whitespace/hardBreak, frontmatter, table alignment, list spread,
+ *       code-span fences, line endings
+ */
+export const DOCUMENT_MODEL_REVISION = 2;
 export const TYPING_DEBOUNCE = 3000; // 3 seconds
 export const DISCONNECT_DEBOUNCE_MS = 3000; // 3 seconds before showing "server not reachable"
 export const PROLONGED_DISCONNECT_MS = 30_000; // 30 seconds before showing App-level disconnect banner
@@ -249,6 +271,22 @@ export const Y_MAP_FIDELITY_REPORT = "fidelityReport";
  * per-document documentMeta, so the write is server-only, client/Claude-invisible.
  */
 export const Y_MAP_FOOTNOTE_BODIES = "footnoteBodies";
+/**
+ * The line ending this document arrived with — `"\r\n"` or `"\n"` (#1448 W2).
+ * Written off-fragment under Y_MAP_DOCUMENT_META at load and consumed at save,
+ * so a Windows-authored file goes back to disk with the endings it came with.
+ *
+ * The model itself is ALWAYS LF: a `\r` inside a `Y.XmlText` would be a
+ * character every coordinate system counts and no editor shows, so it would
+ * shift flat offsets, ProseMirror positions and RelativePositions apart from
+ * what the user sees. Normalizing at the boundary and restoring at the boundary
+ * keeps one representation inside and honours the file's own on disk.
+ *
+ * Same inertness as Y_MAP_FIDELITY_REPORT and Y_MAP_FOOTNOTE_BODIES: no
+ * observer on per-document documentMeta, so the write is server-only and
+ * client/Claude-invisible.
+ */
+export const Y_MAP_LINE_ENDING = "lineEnding";
 
 export const AUTHORSHIP_TOGGLE_KEY = "tandem:showAuthorship";
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -387,6 +387,14 @@ export interface SessionData {
    * and on any session whose document had no pending conflict.
    */
   conflict?: ExternalConflictState;
+  /**
+   * `DOCUMENT_MODEL_REVISION` at session-save time (#1448). A session stamped
+   * below the current revision holds a document parsed by a load path that has
+   * since been fixed, so reopening it would replay the old damage; it is
+   * discarded in favour of a fresh parse. Absent on sessions written before this
+   * field existed, which is exactly the population that needs discarding.
+   */
+  modelRevision?: number;
 }
 
 /**

--- a/tests/fixtures/roundtrip/escaped-tilde.md
+++ b/tests/fixtures/roundtrip/escaped-tilde.md
@@ -1,0 +1,11 @@
+# Escaped tildes
+
+A real strikethrough: ~~this is struck~~ and it must stay struck.
+
+An escaped literal that must NOT become one: \~\~not struck\~\~ here.
+
+A lone escaped tilde is unambiguous prose and its escape is noise: ~4500 tokens.
+
+Two lone ones in a sentence: ~5 to ~10 minutes.
+
+Adjacent to a real strikethrough: ~~struck~~ then \~\~literal\~\~ again.

--- a/tests/fixtures/roundtrip/hardbreak-marks.md
+++ b/tests/fixtures/roundtrip/hardbreak-marks.md
@@ -1,0 +1,13 @@
+# Marks spanning a hard break
+
+A bold run crossing a hard break must stay one run: **first half\
+second half** and then plain text.
+
+Strikethrough across a break: ~~struck first\
+struck second~~ done.
+
+Emphasis across a break: *soft one\
+soft two* done.
+
+A break between differently-marked runs belongs to neither: **bold**\
+*italic* on the next line.

--- a/tests/fixtures/roundtrip/inline-code-fence.md
+++ b/tests/fixtures/roundtrip/inline-code-fence.md
@@ -1,8 +1,13 @@
-A code span whose content contains a backtick run needs a fence longer than any
-run inside it. The serializer escapes the inner backticks instead of lengthening
-the fence, so the span ends early and the words on either side get glued
-together.
+Code spans and literal backticks in prose. Fence *style* (padding spaces, fence
+length beyond the minimum) is invisible-tier and pinned separately — everything
+here must come back byte-identical.
 
-Control, and this one is clean: `console.error(\` followed by prose.
+An ordinary span: `const x = 1` and prose after it.
 
-The case that breaks: `x ?? ``y``` and text after it.
+A span ending in a backslash: `console.error(\` followed by prose.
+
+A literal backtick keeps its escape: a lone \` in prose, and a \`\` pair on the
+same line, because un-escaping either would make it a live delimiter.
+
+A text run ending in a backtick, immediately before a real span: the escape is
+what stops it merging with `the span's opening fence`.

--- a/tests/fixtures/roundtrip/nested-marks.md
+++ b/tests/fixtures/roundtrip/nested-marks.md
@@ -1,2 +1,11 @@
-A mark nested inside another mark, which is where delimiter reconstruction goes
+A mark nested inside another mark, which is where delimiter reconstruction went
 wrong: the **local slice's** mechanism, and ~~a **struck** phrase~~ too.
+
+An outer mark subdivided by *two* inner ones: **bold with *emphasis* and
+`code` inside**, plus a [link with **bold** in it](https://example.com).
+
+Marks that start together and end apart: ***both here*, bold only** — and the
+reverse, **bold only, *both here***.
+
+Two separate links with the same target must not merge across the text between
+them: [one](https://example.com) and [two](https://example.com).

--- a/tests/server/file-io/line-endings.test.ts
+++ b/tests/server/file-io/line-endings.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Line-ending preservation (#1448 W2).
+ *
+ * The repo corpus structurally cannot cover this: `.gitattributes` pins
+ * `*.md text eol=lf`, so a CRLF fixture committed to git arrives as LF and the
+ * test would pass on the wrong input. Every input here is synthesized.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { getAdapter } from "../../../src/server/file-io/index.js";
+import {
+  detectLineEnding,
+  restoreLineEndings,
+  toLf,
+} from "../../../src/server/file-io/line-endings.js";
+import { loadMarkdown, saveMarkdown } from "../../../src/server/file-io/markdown.js";
+import { extractText } from "../../../src/server/mcp/document-model.js";
+
+describe("detectLineEnding", () => {
+  it("reads a pure CRLF file as CRLF", () => {
+    expect(detectLineEnding("a\r\nb\r\nc\r\n")).toBe("\r\n");
+  });
+
+  it("reads a pure LF file as LF", () => {
+    expect(detectLineEnding("a\nb\nc\n")).toBe("\n");
+  });
+
+  it("resolves a tie to LF", () => {
+    expect(detectLineEnding("a\r\nb\nc")).toBe("\n");
+  });
+
+  it("resolves a file with no newlines at all to LF", () => {
+    expect(detectLineEnding("just one line")).toBe("\n");
+  });
+
+  it("does not count a CRLF twice", () => {
+    // A naive implementation counts every `\n` as a lone LF, so a pure CRLF
+    // file reads as a tie and loses.
+    expect(detectLineEnding("a\r\nb\r\n")).toBe("\r\n");
+  });
+});
+
+describe("toLf", () => {
+  it("collapses a lone CR (classic Mac) as well as CRLF", () => {
+    expect(toLf("a\r\nb\rc\nd")).toBe("a\nb\nc\nd");
+  });
+});
+
+describe("restoreLineEndings", () => {
+  it("is a no-op for a doc that recorded nothing", () => {
+    const doc = new Y.Doc();
+    try {
+      expect(restoreLineEndings(doc, "a\nb\n")).toBe("a\nb\n");
+    } finally {
+      doc.destroy();
+    }
+  });
+
+  it("never produces \\r\\r\\n from output that already carries a CRLF", () => {
+    // Reachable through verbatim `markdownRaw` content, which the serializer
+    // emits byte-for-byte.
+    const doc = new Y.Doc();
+    try {
+      loadMarkdown(doc, "a\r\nb\r\n");
+      expect(restoreLineEndings(doc, "x\r\ny\n")).toBe("x\r\ny\r\n");
+    } finally {
+      doc.destroy();
+    }
+  });
+});
+
+describe("markdown documents keep the endings they arrived with", () => {
+  const LF = "# Title\n\nSoft-wrapped\nacross two lines.\n\n- a\n- b\n";
+
+  it("CRLF in, CRLF out — every ending, not just some", () => {
+    const doc = new Y.Doc();
+    try {
+      const crlf = LF.replace(/\n/g, "\r\n");
+      loadMarkdown(doc, crlf);
+      expect(saveMarkdown(doc)).toBe(crlf);
+    } finally {
+      doc.destroy();
+    }
+  });
+
+  it("the MODEL stays LF regardless, so offsets are unaffected", () => {
+    // A `\r` inside a Y.XmlText would be a character every coordinate system
+    // counts and no editor shows.
+    const doc = new Y.Doc();
+    try {
+      loadMarkdown(doc, LF.replace(/\n/g, "\r\n"));
+      expect(extractText(doc)).not.toContain("\r");
+    } finally {
+      doc.destroy();
+    }
+  });
+
+  it("flat offsets are identical for the CRLF and LF forms of one document", () => {
+    const lfDoc = new Y.Doc();
+    const crlfDoc = new Y.Doc();
+    try {
+      loadMarkdown(lfDoc, LF);
+      loadMarkdown(crlfDoc, LF.replace(/\n/g, "\r\n"));
+      expect(extractText(crlfDoc)).toBe(extractText(lfDoc));
+    } finally {
+      lfDoc.destroy();
+      crlfDoc.destroy();
+    }
+  });
+});
+
+describe("plaintext documents keep the endings they arrived with", () => {
+  const adapter = getAdapter("other");
+
+  async function roundTrip(input: string): Promise<string> {
+    const doc = new Y.Doc();
+    try {
+      adapter.apply(doc, await adapter.parse(input));
+      return adapter.save?.(doc) ?? "";
+    } finally {
+      doc.destroy();
+    }
+  }
+
+  it("CRLF in, CRLF out", async () => {
+    expect(await roundTrip("one\r\ntwo\r\nthree")).toBe("one\r\ntwo\r\nthree");
+  });
+
+  it("LF in, LF out", async () => {
+    expect(await roundTrip("one\ntwo\nthree")).toBe("one\ntwo\nthree");
+  });
+});

--- a/tests/server/file-io/roundtrip-corpus.test.ts
+++ b/tests/server/file-io/roundtrip-corpus.test.ts
@@ -19,9 +19,10 @@
 
 import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { visit } from "unist-util-visit";
 import { describe, expect, it } from "vitest";
 import * as Y from "yjs";
-import { loadMarkdown, saveMarkdown } from "../../../src/server/file-io/markdown.js";
+import { loadMarkdown, mdParser, saveMarkdown } from "../../../src/server/file-io/markdown.js";
 
 const CORPUS_DIR = fileURLToPath(new URL("../../fixtures/roundtrip/", import.meta.url));
 
@@ -34,14 +35,14 @@ const CORPUS: Record<string, { blockedOn?: string; why?: string }> = {
   "tight-list.md": {},
   "raw-blocks.md": {},
   "frontmatter.md": {},
-  "loose-list.md": { blockedOn: "V2", why: "spread is hardcoded false in yDocToMdast" },
-  "table-aligned.md": { blockedOn: "V-table-padding", why: "tablePipeAlign defaults to true" },
-  "table-compact.md": { blockedOn: "V-table-padding", why: "tablePipeAlign defaults to true" },
-  "nested-marks.md": { blockedOn: "V5", why: "deltaToPhrasingContent rebuilds nested marks wrong" },
-  "inline-code-fence.md": {
-    blockedOn: "V7",
-    why: "code-span fence length is not recomputed from the content's backtick runs",
+  "loose-list.md": {},
+  "table-aligned.md": {},
+  "table-compact.md": {
+    blockedOn: "table geometry",
+    why: "hand-authored |---|---| cannot be reproduced; mdast carries no source markers",
   },
+  "nested-marks.md": {},
+  "inline-code-fence.md": {},
 };
 
 function roundTrip(input: string): string {
@@ -121,6 +122,88 @@ describe("verbatim blocks keep their newlines (V6, #1458)", () => {
   });
 });
 
+describe("literal backticks in prose never become a code span (V7, #1448)", () => {
+  /** The mdast tree, minus source positions — "does it still mean the same?" */
+  function meaning(markdown: string): string {
+    const strip = (v: unknown): unknown =>
+      Array.isArray(v)
+        ? v.map(strip)
+        : v && typeof v === "object"
+          ? Object.fromEntries(
+              Object.entries(v)
+                .filter(([k]) => k !== "position")
+                .map(([k, x]) => [k, strip(x)]),
+            )
+          : v;
+    return JSON.stringify(strip(mdParser.parse(markdown)));
+  }
+
+  // An escaped backtick is NOT a code-span delimiter, so a fully-escaped run is
+  // inert. Un-escape ONE of several and the survivor pairs with the next, which
+  // is no longer shielded — literal prose becomes inline code, one-way, and an
+  // idempotency-only assertion cannot see it because pass 2 serializes a genuine
+  // code span.
+  const PROSE = "The case that breaks: `x ?? ``y``` and text after it.\n";
+
+  it("does not change what the document means", () => {
+    expect(meaning(roundTrip(PROSE))).toBe(meaning(PROSE));
+  });
+
+  it("emits no inlineCode node, because the source had none", () => {
+    expect(meaning(roundTrip(PROSE))).not.toContain("inlineCode");
+  });
+
+  it("is idempotent — the escapes do not erode on the second save", () => {
+    const once = roundTrip(PROSE);
+    expect(roundTrip(once)).toBe(once);
+  });
+
+  it("a lone literal backtick keeps its escape rather than becoming a delimiter", () => {
+    // Tidier source is not worth a live delimiter. The escaped form renders
+    // identically and cannot pair with a backtick in a sibling node — which is
+    // the case the handler cannot see, and the one that shifted every code-span
+    // boundary in docs/design-system-impl/testid-manifest.md.
+    expect(roundTrip("a lone ` backtick\n")).toBe("a lone \\` backtick\n");
+  });
+
+  it("a text run ending in a backtick does not merge with the next span's fence", () => {
+    const input = "trailing \\` then `a real span` after.\n";
+    expect(roundTrip(input)).toBe(input);
+    expect(meaning(roundTrip(input))).toBe(meaning(input));
+  });
+});
+
+describe("code-span FENCE STYLE is invisible-tier (#1448)", () => {
+  // These render identically and reparse to the same tree. mdast carries no
+  // source marker for either, so no serializer option can reproduce them —
+  // documented, not fixed. They change once and then hold.
+  const CASES: Array<[string, string]> = [
+    ["padding spaces are dropped", "A span: `` a ` b `` done.\n"],
+    ["a longer-than-minimal fence shrinks", "A span: ``` a `` b ``` done.\n"],
+  ];
+
+  /** Every `inlineCode` value in a document, in order. */
+  function codeValues(markdown: string): string[] {
+    const found: string[] = [];
+    visit(mdParser.parse(markdown), "inlineCode", (node) => {
+      found.push(node.value);
+    });
+    return found;
+  }
+
+  it.each(CASES)("%s, but the span's content is unchanged", (_name, input) => {
+    const out = roundTrip(input);
+    expect(out).not.toBe(input); // if this flips, the case is no longer invisible-tier
+    expect(codeValues(input)).toHaveLength(1); // positive anchor: there IS a span
+    expect(codeValues(out)).toEqual(codeValues(input));
+  });
+
+  it.each(CASES)("%s, and then holds — it does not change again", (_name, input) => {
+    const once = roundTrip(input);
+    expect(roundTrip(once)).toBe(once);
+  });
+});
+
 describe("round-trip corpus: line endings (W2)", () => {
   const LF = "# Title\n\nA paragraph soft-wrapped\nacross two lines.\n\n- a\n- b\n";
   const CRLF = LF.replace(/\n/g, "\r\n");
@@ -129,13 +212,20 @@ describe("round-trip corpus: line endings (W2)", () => {
     expect(roundTrip(LF)).toBe(LF);
   });
 
-  it.fails("a CRLF document keeps CRLF endings", () => {
+  it("a CRLF document keeps CRLF endings", () => {
     expect(roundTrip(CRLF)).toBe(CRLF);
   });
 
-  it("today a CRLF document comes back with MIXED endings, which is worse than either", () => {
-    const out = roundTrip(CRLF);
-    expect(out).toContain("\r\n"); // the intra-paragraph soft wrap keeps its \r
-    expect(out).toMatch(/[^\r]\n/); // block separators have lost theirs
+  it("never comes back MIXED, which was the pre-fix behaviour and worse than either", () => {
+    // Before W2 the block separators became LF while the intra-paragraph soft
+    // wrap kept its `\r`, so a Windows-authored file got BOTH forms.
+    expect(roundTrip(CRLF)).not.toMatch(/[^\r]\n/);
+    expect(roundTrip(LF)).not.toContain("\r");
+  });
+
+  it("a mixed-ending document resolves to the dominant form, not to both", () => {
+    // Two CRLF endings against five LF: LF wins, and the `\r`s are gone.
+    const mixed = "a\r\n\r\nb\nc\n\nd\n";
+    expect(roundTrip(mixed)).not.toContain("\r");
   });
 });

--- a/tests/server/file-io/roundtrip-corpus.test.ts
+++ b/tests/server/file-io/roundtrip-corpus.test.ts
@@ -43,6 +43,8 @@ const CORPUS: Record<string, { blockedOn?: string; why?: string }> = {
   },
   "nested-marks.md": {},
   "inline-code-fence.md": {},
+  "escaped-tilde.md": {},
+  "hardbreak-marks.md": {},
 };
 
 function roundTrip(input: string): string {

--- a/tests/server/file-io/roundtrip-repo-metric.test.ts
+++ b/tests/server/file-io/roundtrip-repo-metric.test.ts
@@ -28,12 +28,27 @@ import { loadMarkdown, mdParser, saveMarkdown } from "../../../src/server/file-i
  * in #1448. Anything outside this set is a new defect.
  */
 const KNOWN_KINDS = new Set([
-  "list.spread", // V2 — loose lists forced tight
-  "listItem.spread", // V2
-  "inline-marks", // V5 — nested mark reconstruction
-  "inline-code-fence", // V7 — code-span fence length not recomputed
-  "table-cells", // trailing empty cells made explicit; renders identically in GFM
-  "listItem-child-count", // a table nested in a list item; see #1448
+  // The invisible tier, as of #1448 PR 4. Every kind here renders identically in
+  // any viewer; what is left is mark ORDER and code-span STYLE, neither of which
+  // mdast records. Recovering them needs a per-node source-marker layer, which
+  // is a different and much larger project — see the plan's "Out of scope".
+  //
+  //   inline-marks       two marks covering the same run come back in a fixed
+  //                      order (`~~**x**~~` -> `**~~x~~**`), and a degenerate
+  //                      `strong > strong` from the source collapses to one.
+  //   inline-code-fence  a code span wrapped across a source line comes back on
+  //                      one line; CommonMark renders its newline as a space
+  //                      either way.
+  //   table-cells        a row's trailing empty cell is made explicit.
+  //   listItem-child-count  a table nested in a list item; see #1448.
+  //
+  // The VISIBLE kinds are deliberately absent, and their absence is the
+  // assertion: `list.spread` / `listItem.spread` (V2, 56 files) and the
+  // code-span-forming escape bug (V7) both appeared here before PR 4.
+  "inline-marks",
+  "inline-code-fence",
+  "table-cells",
+  "listItem-child-count",
 ]);
 
 /** mdast phrasing types — a difference in any of these is an inline defect. */

--- a/tests/server/file-io/roundtrip-repo-metric.test.ts
+++ b/tests/server/file-io/roundtrip-repo-metric.test.ts
@@ -95,6 +95,45 @@ function strip(node: unknown): unknown {
   return node;
 }
 
+/** Every phrasing type appearing anywhere in a subtree. */
+function phrasingTypes(node: unknown, into = new Set<string>()): Set<string> {
+  if (Array.isArray(node)) {
+    for (const child of node) phrasingTypes(child, into);
+    return into;
+  }
+  if (node && typeof node === "object") {
+    const type = (node as { type?: string }).type;
+    if (type && PHRASING.has(type)) into.add(type);
+    phrasingTypes((node as { children?: unknown[] }).children ?? [], into);
+  }
+  return into;
+}
+
+/**
+ * True when one side carries a KIND of inline node the other does not.
+ *
+ * This is the line between the two inline families, and drawing it is what makes
+ * this gate able to fail. `inline-marks` is allowlisted — it is the invisible
+ * tier, marks that render identically in a different nesting order — and
+ * `classify` used to return it for a bare `a.type !== b.type` as well. So a
+ * `text` node coming back as a `delete` node scored `inline-marks` and passed:
+ * the gate structurally could not fail on the escape-corruption class it exists
+ * to catch, which is exactly how the `\~\~` defect survived to review.
+ *
+ * A SET difference, deliberately, not a multiset one. The known-benign cases
+ * reorder marks or collapse a degenerate `strong > strong` into one `strong` —
+ * both leave the set of kinds untouched. An escape turning into live syntax
+ * always introduces a kind that was not in the source (or, in reverse, drops one
+ * entirely), and there is no benign case that does that.
+ */
+function inlineTypesDiffer(a: unknown, b: unknown): boolean {
+  const before = phrasingTypes(a);
+  const after = phrasingTypes(b);
+  if (before.size !== after.size) return true;
+  for (const type of before) if (!after.has(type)) return true;
+  return false;
+}
+
 /** Name the first structural difference, coarsely enough to stay stable. */
 function classify(before: unknown, after: unknown): string {
   const a = before as { type?: string; children?: unknown[]; spread?: boolean };
@@ -102,16 +141,18 @@ function classify(before: unknown, after: unknown): string {
 
   // Inline defects manifest as a dozen different node-level symptoms (a `strong`
   // gaining children, a `text` value shifting, a `delete` becoming a `strong`).
-  // They are all one family, so collapse them — otherwise the known-kind set
-  // churns on prose edits and stops meaning anything.
+  // Those that preserve the SET of node kinds are one family and get collapsed —
+  // otherwise the known-kind set churns on prose edits and stops meaning
+  // anything. Those that do not are a different family, and not allowlisted.
   const inline = PHRASING.has(a?.type ?? "") || PHRASING.has(b?.type ?? "");
   if (inline) {
+    if (inlineTypesDiffer(before, after)) return "inline-type-change";
     return a?.type === "inlineCode" || b?.type === "inlineCode"
       ? "inline-code-fence"
       : "inline-marks";
   }
 
-  if (a?.type !== b?.type) return "inline-marks";
+  if (a?.type !== b?.type) return "inline-type-change";
   if (a?.type === "list" && a.spread !== b.spread) return "list.spread";
   if (a?.type === "listItem" && a.spread !== b.spread) return "listItem.spread";
 
@@ -126,6 +167,11 @@ function classify(before: unknown, after: unknown): string {
     // two `text` nodes disagreeing with an extra `inlineCode` after them, and
     // reading only the first divergent pair would blame marks for V7.
     if (PHRASING_PARENTS.has(a?.type ?? "")) {
+      // Checked over the WHOLE children arrays, not the divergent tail: a mark
+      // that appears only in the output is new regardless of where the common
+      // prefix ends, and the `\~\~` corruption lands here (one `text` child
+      // becoming `[text, delete, text]`) rather than in the inline branch above.
+      if (inlineTypesDiffer(ca, cb)) return "inline-type-change";
       let i = 0;
       while (i < ca.length && i < cb.length && sameNode(ca[i], cb[i])) i++;
       const tail = [...ca.slice(i), ...cb.slice(i)] as { type?: string }[];

--- a/tests/server/format-adapter.test.ts
+++ b/tests/server/format-adapter.test.ts
@@ -88,10 +88,13 @@ describe("MarkdownAdapter — two-phase parse/apply", () => {
     adapter.apply(doc, prepared);
 
     const output = adapter.save?.(doc);
-    expect(output).toContain("| Name  |  Score |");
-    expect(output).toContain("| :---- | -----: |");
-    expect(output).toContain("| Ada   | **99** |");
-    expect(output).toContain("| Empty |        |");
+    // Unpadded since #1448 (`tablePipeAlign: false`): cell width no longer
+    // depends on the widest value in the column, so editing one cell stops
+    // reflowing every other row.
+    expect(output).toContain("| Name | Score |");
+    expect(output).toContain("| :- | -: |");
+    expect(output).toContain("| Ada | **99** |");
+    expect(output).toContain("| Empty | |");
   });
 
   it("apply runs inside an externally-provided transact (single-transact invariant)", async () => {

--- a/tests/server/markdown-fidelity.test.ts
+++ b/tests/server/markdown-fidelity.test.ts
@@ -64,8 +64,11 @@ describe("markdown fidelity fixture (#981)", () => {
     expect(out).toContain("```ts");
     // Thematic break
     expect(out).toMatch(/^---$/m);
-    // GFM table with alignment
-    expect(out).toContain("| :--- | :----: | ----: |");
+    // GFM table with alignment. Delimiter cells are no longer width-padded to
+    // the widest body cell (`tablePipeAlign: false`, #1448) — the alignment
+    // colons are what carry meaning, and the padding is what made a one-word
+    // edit reflow every row of every table in the file.
+    expect(out).toContain("| :- | :-: | -: |");
     expect(out).toContain("**b2**");
     // Block image
     expect(out).toContain("![Standalone image](https://example.com/image.png");

--- a/tests/server/session/model-revision.test.ts
+++ b/tests/server/session/model-revision.test.ts
@@ -49,6 +49,32 @@ describe("sessionModelIsStale", () => {
     expect(sessionModelIsStale(session({ filePath: "upload://abc/note.md" }))).toBe(false);
   });
 
+  it("never discards a CLEAN session carrying an unresolved conflict", () => {
+    // The session is the only record that the conflict happened: saveSession
+    // stats the file at save time, so sourceFileMtime IS the external write's
+    // mtime and sourceFileChanged reads false on reopen. Discarding it returns
+    // before maybeRestoreSession's carry, which does not defer the conflict —
+    // it destroys it. The banner never appears and the next autosave tick
+    // overwrites the user's external edit. Re-reading a stale parse is an
+    // improvement; losing a file is not a price to pay for one.
+    expect(
+      sessionModelIsStale(
+        session({
+          dirty: false,
+          conflict: { kind: "external-edit", diskChanged: true, detectedAt: 1 },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("still discards a clean session whose conflict field is absent or malformed", () => {
+    // Positive control: the carve-out is keyed on a conflict that `narrowConflict`
+    // actually recognizes, not on the field merely being set. Without this, a
+    // guard that returned false for any truthy value would satisfy the test above.
+    expect(sessionModelIsStale(session({ conflict: undefined }))).toBe(true);
+    expect(sessionModelIsStale(session({ conflict: { kind: "nonsense" } as never }))).toBe(true);
+  });
+
   it("the revision is a positive integer, so an unstamped session sorts below it", () => {
     expect(Number.isInteger(DOCUMENT_MODEL_REVISION)).toBe(true);
     expect(DOCUMENT_MODEL_REVISION).toBeGreaterThan(0);

--- a/tests/server/session/model-revision.test.ts
+++ b/tests/server/session/model-revision.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Session model-revision stamp (#1448 W3).
+ *
+ * A session's `ydocState` is an already-parsed document, so a parser fix does
+ * not reach it. Without the stamp the fix ships and never arrives: a user who
+ * upgrades keeps every defect their pre-fix session baked in for up to 30 days.
+ */
+
+import { describe, expect, it } from "vitest";
+import { sessionModelIsStale } from "../../../src/server/session/manager.js";
+import { DOCUMENT_MODEL_REVISION } from "../../../src/shared/constants.js";
+import type { SessionData } from "../../../src/shared/types.js";
+
+function session(overrides: Partial<SessionData> = {}): SessionData {
+  return {
+    filePath: "C:/notes/note.md",
+    format: "md",
+    ydocState: "",
+    sourceFileMtime: 0,
+    lastAccessed: 0,
+    ...overrides,
+  };
+}
+
+describe("sessionModelIsStale", () => {
+  it("treats a session with no stamp as stale — that is the population to discard", () => {
+    expect(sessionModelIsStale(session())).toBe(true);
+  });
+
+  it("treats a session stamped at the current revision as current", () => {
+    expect(sessionModelIsStale(session({ modelRevision: DOCUMENT_MODEL_REVISION }))).toBe(false);
+  });
+
+  it("treats a session from a FUTURE revision as current, not stale", () => {
+    // A downgrade must not silently throw away the newer session; the
+    // comparison is one-directional on purpose.
+    expect(sessionModelIsStale(session({ modelRevision: DOCUMENT_MODEL_REVISION + 1 }))).toBe(
+      false,
+    );
+  });
+
+  it("never discards a dirty session, however old its stamp", () => {
+    // Those edits exist nowhere else — discarding them would be the data loss
+    // the stamp exists to prevent.
+    expect(sessionModelIsStale(session({ dirty: true }))).toBe(false);
+  });
+
+  it("never discards an upload:// session, which has no file to re-read", () => {
+    expect(sessionModelIsStale(session({ filePath: "upload://abc/note.md" }))).toBe(false);
+  });
+
+  it("the revision is a positive integer, so an unstamped session sorts below it", () => {
+    expect(Number.isInteger(DOCUMENT_MODEL_REVISION)).toBe(true);
+    expect(DOCUMENT_MODEL_REVISION).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Fourth of five in #1448. Stacked on #1462 — **review the [three-commit diff](https://github.com/bloknayrb/tandem/compare/fix/document-fidelity-frontmatter...fix/document-fidelity-lists)**, not the file view.

Every defect here shares one property, and it is the reason none of them was caught: each mangles the document exactly once and is then a stable fixed point. Every pre-existing fidelity suite asserts `pass2 === pass1`, which all of them satisfy.

## Visible defects fixed

**V2 — loose lists forced tight, 56 files in this repo.** `spread` was hardcoded `false` on both the list and each item. It now round-trips through the Y.Doc and is declared on `bulletList` / `orderedList` / `listItem` via a global attribute. The declaration is the load-bearing half: an attribute the client schema does not declare is discarded by `computeAttrs` when the PM doc is built, *before the DOM is involved*, and `updateYFragment` then prunes it from the Y.Doc — so the server's value is gone from disk on the user's first edit. Same mechanism that destroyed table alignment in #1462; no `parseHTML` choice can protect against it.

**V5 — nested marks.** Each delta segment was wrapped independently in a fixed order, so a mark spanning a run that another mark subdivides got emitted once per sub-run and closed at every internal boundary:

```
~~a **struck** phrase~~   ->   ~~a ~~**~~struck~~**~~ phrase~~
```

Nesting is now derived from **run length** — the mark covering the most consecutive segments becomes the outer node. Where two marks cover exactly the same run there is genuinely no information to recover from (a delta's attributes are a set; Yjs does not record which mark opened first), so a fixed order remains and is documented rather than pretended away.

**V7 — backtick escaping.** The `text` handler un-escaped a backtick it judged "standalone". An escaped backtick is *not* a code-span delimiter and a bare one is, so un-escaping turns an inert character into a live delimiter whose safety depends on every other backtick reachable from it — including ones in sibling nodes the handler never sees. Two real documents were corrupted, two different ways:

```
`x ?? ``y```                       -> code("x ?? \") + text
"…-resize-handle`" + a real span   -> the freed backtick merges with the sibling
                                      span's opening fence, shifting every
                                      code-span boundary in the paragraph
```

Two attempts to narrow the rule each fixed one case and not the other. The rule is removed; the escape renders identically and buys correctness for tidier source.

**Ordered lists starting at 0** renumbered to 1 — `Number(null)` is `0`, so the missing-`start` guard was falsy-zero.

## Invisible tier

`tablePipeAlign: false`, which **must** go on `remarkGfm` and not `remarkStringify` — where every other serializer option in this file lives, and where it is a silent no-op. Padding every cell to the widest value in its column is what made a one-word edit produce a 262-line diff. It does not reproduce hand-authored `|---|---|`, and no option can.

## Separately broken

**W2 — line endings.** A CRLF file came back *mixed*: block separators LF, intra-paragraph soft wraps still CRLF. Detect-at-load, restore-at-save; the model stays LF throughout, because a `\r` in a `Y.XmlText` is a character every coordinate system counts and no editor shows. For `.txt` the restore is in the adapter, not in `extractText` — that function is also the annotation coordinate system (Critical Rule 5).

No repo corpus can catch this. `.gitattributes` pins `*.md text eol=lf`, so a committed CRLF fixture arrives as LF and the test passes on the wrong input. Every input in `line-endings.test.ts` is synthesized.

**W3 — the fix reaching existing users.** `SessionData.ydocState` is a bare `Y.encodeStateAsUpdate` of an already-parsed document, so nothing above reaches it: a user who upgrades keeps every defect their pre-fix session baked in for up to 30 days. Sessions now carry `DOCUMENT_MODEL_REVISION` and a stale one is discarded in favour of a fresh parse. `dirty` sessions and `upload://` paths are exempt — there the session is the only copy of the content, and discarding it would be the data loss the stamp exists to prevent.

## Metric

Repo-wide render-affecting differences: **72 at the PR 1 baseline → 16**, and `list.spread` / `listItem.spread` are gone from the classifier's kind set entirely. What remains is the invisible tier — mark order where the source is unrecoverable, degenerate `strong > strong` collapsing, code-span fence style, a row's trailing empty cell — now enumerated in ADR-042 rather than discovered.

## Verification

- `npm run typecheck` clean.
- `npm test` — the pre-push hook's full run passed (biome + vitest + `cargo test`). An earlier standalone run had 8 failures, all wall-clock-deadline tests in `useTauriFileDrop` / `refresh-skill` / `install-claude-code` that pass in isolation and are pre-existing intermittents under load; none shares a file with this diff.
- `npm run test:e2e` **not run** — :3478/:3479 are held by a running `tandem-desktop.exe`, and E2E kills the port holder.

## Also in here

ADR-042's contract is rewritten. "Idempotency + content-preservation, not byte-identity" sounds like a modest, honest bar; it is the reason none of this failed for months, because every defect in #1448 satisfies it. Replaced by the visible/invisible split with the invisible set enumerated in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnpXPQuW7p25SHTHV9HfMK


---

## Review round (xhigh) — 5 findings, all applied

**Correcting this PR's own earlier commit message:** it asserted that escape rule 4 (`\~` un-escaping) was safe. That was wrong.

**The tilde guard was structurally dead.** `safe()` escapes *every* tilde, so an authored `~~` reaches the handler as `\~\~` and the character after the first `\~` is a backslash, never a tilde — the `(?!~)` lookahead therefore passed on both halves and un-escaped them. Verified against the real serializer:

```
a \~\~b\~\~ c        ->  a ~~b~~ c          mdast [text] -> [text, delete, text]
literal \~\~two\~\~  ->  literal ~~two~~
```

An author's escaped literal becomes live strikethrough: the rendered document gains formatting nobody asked for and loses four visible characters. The guard now looks at both neighbours in either escaped or bare form, and across the node boundary via `info.before`/`info.after`, so `\~\~` stays put while `about \~4500 tokens` still loses its escape noise as intended.

**The repo gate could not have caught it.** `classify` returned `inline-marks` for a bare `a.type !== b.type`, and `inline-marks` is allowlisted as the invisible tier — so a `text` node coming back as a `delete` node scored a *known* kind and passed. The gate structurally could not fail on the escape-corruption class it exists to catch. Split on the discriminator that actually separates the families: a change to the **set** of inline node kinds is `inline-type-change` and is not allowlisted, while reordering marks or collapsing a degenerate `strong > strong` leaves the set untouched and stays `inline-marks`.

Both fixes are pinned by **new curated fixtures**, not by the repo metric — no tracked `.md` file contains an escaped `\~\~` pair, so the metric passed with the defect deliberately restored. That is a corpus gap, not a clean bill of health. Each fixture was run against the reverted code and confirmed to fail before being kept.

**A hard break truncated every mark run through it.** `buildPhrasingTree` decides nesting by how many consecutive segments carry a mark, and a break was a segment with an empty mark set, so it closed every enclosing run: `a **b\⏎c** d` → `a **b**\⏎**c** d`. An embedded break carries the marks in its own delta attributes and those are now read; the `normalizeHardBreaks` sibling-element form stores them nowhere, so it inherits the *intersection* of its neighbours — intersection, not union, because a break between a bold run and a plain one belongs to neither.

**`sessionModelIsStale` laundered away an unresolved conflict.** Its early return sits above `maybeRestoreSession`'s carry of `session.conflict`, and that carry exists because the conflict cannot be re-derived: `saveSession` stats the file at save time, so `sourceFileMtime` *is* the external write's mtime and `sourceFileChanged` reads false on reopen. The comment thirty lines below says suppressing a carried conflict **destroys** it — which is precisely what the new early return did, silently, from above. Re-reading a stale parse is an improvement; losing the user's external edit to the next autosave tick is not a price worth paying for one.

**Two raw NUL bytes made `mdast-ydoc.ts` a binary file** to every grep-based tool. ripgrep skipped it entirely, so a directory-level search for a symbol defined in it returned "no files found" — and `check-raw-transact.sh` / `check-ymap-keys.sh`, which parse `grep -nE` output, silently stopped covering the file that holds most of this effort's changes. Written as escapes now: same runtime value, searchable source.
