### PR TITLE
docs(readme): document both entry points; fix a test racing the production deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ One thing you need, though: an AI client running on your own computer, plus the 
 - You're reviewing what someone else wrote (a thesis chapter, a contract, a spec) and you want a faster pass.
 - The AI wrote a draft and you have to decide what to keep.
 
-I built Tandem for one person working on their own documents. Those three are examples rather than a boundary; the workflow is the same whatever you're writing. The interface is English-only for now.
+I built Tandem for one person working on their own documents. Those three are examples rather than a boundary, and the kind of document doesn't change how any of it works: a contract behaves the same as an essay. The interface is English-only for now.
 
 ## Install
 
@@ -83,11 +83,17 @@ Without any of them nothing breaks and nothing is lost: your messages and commen
 
 ## How you work with Tandem
 
-1. Open a document in Tandem.
-2. Start your AI client, which is Claude Code in the default setup. Once you've been through [Install](#install), Tandem and Claude find each other on their own; you don't reconnect them each time.
-3. Type a question in the chat panel, or highlight text in the document to point the AI at a passage. It sees what you highlight as you highlight it.
-4. The AI's suggestions show up as cards beside the document. You decide what to accept.
-5. Save when you're finished.
+Tandem has to be running, and once you've been through [Install](#install) it and your AI client find each other on their own, so you don't reconnect them each time. From there it works in both directions, and which one you pick changes how you start rather than what you do next.
+
+**Starting in Tandem.** Open a document and the AI can already see it. There's nothing to attach and no session to paste into. If Claude isn't running yet, the desktop app can start it for you.
+
+**Starting in Claude.** Ask it to open the file in Tandem ("pull up the draft in Tandem") and the document appears in a tab with the AI already on it. This is the direction I use most.
+
+Either way, the rest is the same:
+
+1. Type a question in the chat panel, or highlight text in the document to point the AI at a passage. It sees what you highlight as you highlight it.
+2. The AI's suggestions show up as cards beside the document. You decide what to accept.
+3. Save when you're finished.
 
 [docs/workflows.md](docs/workflows.md) has examples of what this looks like day to day.
 

--- a/tests/server/integrations/refresh-skill.test.ts
+++ b/tests/server/integrations/refresh-skill.test.ts
@@ -26,6 +26,35 @@ import {
 let homeOverride: string;
 let skillPath: string;
 
+/**
+ * Every test below except the deadline one is about overwrite / no-op /
+ * error-recording semantics, not about the deadline. Left on the production
+ * default (`SKILL_REFRESH_TIMEOUT_MS`, 5s) they inherit a wall-clock race they
+ * never meant to enter: under a loaded 460-file parallel run this worker can be
+ * descheduled for seconds, the timer fires by wall clock while the real
+ * `readFile`/`mkdir`/`atomicWrite` are still queued, and a refresh that would
+ * have succeeded is recorded as `{ code: "timed-out" }` instead.
+ *
+ * That is not hypothetical: it took down three different tests in this file
+ * across three consecutive pre-push runs, each failing on a different
+ * assertion, while CI stayed green on the same commit. A budget this far above
+ * the default cannot be reached by scheduling noise, and no test here asserts
+ * anything about how long a refresh takes -- the one that does owns the
+ * deadline explicitly and overrides this via the spread below.
+ */
+const GENEROUS_TIMEOUT_MS = 60_000;
+
+type RefreshOpts = Parameters<typeof refreshExistingSkillIfStale>[0];
+
+/** Calls the real function with a deadline that scheduling noise cannot trip. */
+function refresh(opts: RefreshOpts = {}): Promise<void> {
+  return refreshExistingSkillIfStale({
+    homeOverride,
+    timeoutMs: GENEROUS_TIMEOUT_MS,
+    ...opts,
+  });
+}
+
 beforeEach(async () => {
   homeOverride = await fs.promises.mkdtemp(path.join(os.tmpdir(), "refresh-skill-test-"));
   skillPath = path.join(homeOverride, ".claude", "skills", "tandem", "SKILL.md");
@@ -47,7 +76,7 @@ function readSkillVersion(content: string): number {
 describe("refreshExistingSkillIfStale — first-run (no on-disk file)", () => {
   it("does not install a standalone skill when SKILL.md does not exist", async () => {
     expect(fs.existsSync(skillPath)).toBe(false);
-    await refreshExistingSkillIfStale({ homeOverride });
+    await refresh();
     expect(fs.existsSync(skillPath)).toBe(false);
     expect(getSkillRefreshError()).toBeNull();
   });
@@ -62,7 +91,7 @@ describe("refreshExistingSkillIfStale — stale on-disk", () => {
       "---\nname: tandem\nversion: 1\ndescription: stale\n---\n\nstale body\n",
       "utf8",
     );
-    await refreshExistingSkillIfStale({ homeOverride });
+    await refresh();
     const written = await readFile(skillPath, "utf8");
     expect(readSkillVersion(written)).toBeGreaterThanOrEqual(2);
     expect(written).not.toContain("stale body");
@@ -77,7 +106,7 @@ describe("refreshExistingSkillIfStale — newer-or-equal on-disk", () => {
     const customized = `${bundled}\n<!-- user customization -->\n`;
     await writeFile(skillPath, customized, "utf8");
 
-    await refreshExistingSkillIfStale({ homeOverride });
+    await refresh();
 
     expect(await readFile(skillPath, "utf8")).toBe(customized);
     expect(getSkillRefreshError()).toBeNull();
@@ -89,7 +118,7 @@ describe("refreshExistingSkillIfStale — newer-or-equal on-disk", () => {
     const userCustomized =
       "---\nname: tandem\nversion: 999\ndescription: user-edit\n---\n\nuser custom body\n";
     await writeFile(skillPath, userCustomized, "utf8");
-    await refreshExistingSkillIfStale({ homeOverride });
+    await refresh();
     const after = await readFile(skillPath, "utf8");
     expect(after).toBe(userCustomized);
     expect(getSkillRefreshError()).toBeNull();
@@ -110,7 +139,7 @@ describe("refreshExistingSkillIfStale — failure recording", () => {
         process.platform === "win32" ? "junction" : "dir",
       );
 
-      await refreshExistingSkillIfStale({ homeOverride });
+      await refresh();
 
       expect(getSkillRefreshError()).toMatchObject({ code: "path-rejected" });
       expect(await readFile(realSkillPath, "utf8")).toBe(stale);
@@ -125,7 +154,7 @@ describe("refreshExistingSkillIfStale — failure recording", () => {
     // still read mode 000 and CI may run as root on POSIX).
     await mkdir(skillPath, { recursive: true });
 
-    await refreshExistingSkillIfStale({ homeOverride });
+    await refresh();
 
     expect(getSkillRefreshError()?.code).toBe("read-failed");
     expect((await fs.promises.stat(skillPath)).isDirectory()).toBe(true);
@@ -136,8 +165,7 @@ describe("refreshExistingSkillIfStale — failure recording", () => {
     const stale = "---\nname: tandem\nversion: 1\n---\n\nstale body\n";
     await writeFile(skillPath, stale, "utf8");
 
-    await refreshExistingSkillIfStale({
-      homeOverride,
+    await refresh({
       _writeSkillForTests: async () => {
         throw new Error("simulated disk failure");
       },
@@ -154,8 +182,7 @@ describe("refreshExistingSkillIfStale — failure recording", () => {
     await mkdir(path.dirname(skillPath), { recursive: true });
     await writeFile(skillPath, "---\nname: tandem\nversion: 1\n---\n", "utf8");
 
-    await refreshExistingSkillIfStale({
-      homeOverride,
+    await refresh({
       _beforeSkillCommitForTests: async () => {
         await fs.promises.unlink(skillPath);
       },
@@ -171,8 +198,7 @@ describe("refreshExistingSkillIfStale — failure recording", () => {
     await writeFile(skillPath, stale, "utf8");
     let writerObservedAbort = false;
 
-    await refreshExistingSkillIfStale({
-      homeOverride,
+    await refresh({
       // The deadline clock starts at function entry, but `readFile` and
       // `mkdir` both run before the writer is reached. At 20ms this test
       // failed intermittently under a full-suite run: the abort landed in
@@ -209,15 +235,14 @@ describe("refreshExistingSkillIfStale — failure recording", () => {
   it("clears lastSkillRefreshError after a successful refresh", async () => {
     await mkdir(path.dirname(skillPath), { recursive: true });
     await writeFile(skillPath, "---\nname: tandem\nversion: 1\n---\n", "utf8");
-    await refreshExistingSkillIfStale({
-      homeOverride,
+    await refresh({
       _writeSkillForTests: async () => {
         throw new Error("simulated disk failure");
       },
     });
     expect(getSkillRefreshError()?.code).toBe("write-failed");
 
-    await refreshExistingSkillIfStale({ homeOverride });
+    await refresh();
     expect(getSkillRefreshError()).toBeNull();
   });
 });


### PR DESCRIPTION
Follow-up to #1440, which merged while this was in flight.

## The README documented only one way in

Bryan flagged "the workflow is the same whatever you're writing" as untrue, and the problem was larger than the sentence. I meant it narrowly (the three bullets above it are document types, and a contract doesn't behave differently from an essay), but it sat directly above **How you work with Tandem**, which described exactly one entry point: open a document in Tandem, then start your AI.

The Claude-first path appeared nowhere in the README outside the origin story, even though it's the direction he uses most. A reader who starts from Claude Code got no instructions at all.

Both directions are now described, along with a precondition neither had: **Tandem has to be running**. That was verified rather than assumed:

- The stdio bridge (`src/cli/mcp-stdio.ts`) is a proxy. It runs `probeTandemServer` and, on failure, synthesizes a `-32000` instead of forwarding. It explicitly does not start anything ("Intentional: no reconnection logic").
- The entry Claude Code gets is `{ type: "http", url }` (`apply.ts:419`) with no subprocess at all, so there is nothing to run a preflight.

Neither can bring the server up, so the precondition is real and belongs in the copy.

The flagged sentence is also narrowed to the claim it was actually making.

## #1463, filed from this

The precondition is a genuine product gap, and the asymmetry is the interesting part: **the failure is worst on the path we recommend.** Claude Desktop gets the bridge and a readable "Tandem server not running. Start the Tauri app or run `tandem start`." Claude Code gets direct HTTP, so with Tandem down the `tandem_*` tools are simply absent from the session — no failing tool call, no message, and the likely outcome is Claude editing the file directly, which looks like success. The session can't self-heal either; connection state is fixed at session start and needs `/mcp`.

Filed as #1463 with the options rather than a decision, since routing Claude Code through the bridge would trade away ADR-045's direct-HTTP path.

## A test that was racing the production deadline

Three different tests in `tests/server/integrations/refresh-skill.test.ts` failed across three consecutive pre-push runs, each on a different assertion, while CI stayed green on the same commit. One root cause: every call inherited the production default `SKILL_REFRESH_TIMEOUT_MS` (5s). Under a loaded 460-file parallel run the worker is descheduled for seconds, the wall-clock timer fires while the real `readFile`/`mkdir`/`atomicWrite` are still queued, and a refresh that would have succeeded is recorded as `{ code: "timed-out" }`.

That is how `expected 1 to be greater than or equal to 2` and `expected { code: 'timed-out' } to be null` are the same bug: the refresh never wrote, so the file stayed stale and the error stuck.

None of those tests is about the deadline — they cover overwrite, no-op and error-recording semantics — so they now route through a helper supplying a budget scheduling noise cannot reach. The one test that *is* about the deadline keeps its own value and overrides via the spread. This is the sibling of the fix already in #1440, which handled the same defect in that test's explicit 20ms budget.

## Verification, and one thing to know

- `tests/docs/` + `skill-instruction-contract` — 59 passing. These are what pin the README's prose (Monitor preconditions, the shim fallback, the plugin's skill-dispatch trigger, `TaskStop`, and the guard forbidding a tool count).
- Full vitest after the refresh-skill fix — **459 files, 6689 tests, 0 failures.**
- `tsc --noEmit` clean.

**This was pushed with `HUSKY=0`, with Bryan's explicit authorization, so CI is the gate here.** The local pre-push suite failed five consecutive times and every single failure was a wall-clock assertion in unrelated code — a 2s ReDoS budget in `markdown-escaping.test.ts`, 5s test timeouts and a 10s hook timeout in the Tauri client tests — each passing in isolation, on a box pegged at 100% across 8 cores with six Claude sessions and a dev server competing. Capping vitest workers took it from three failures to one, which isolates load as the cause; it does not make the local run trustworthy. CI is not contended and is the honest signal for this branch.

Also fixed along the way, in the shared checkout rather than in this diff: `d4ea79a` made `postcss` a direct dependency and `node_modules` had never been installed since, so five `tests/design-system-impl/*` suites were failing to **load** with `Cannot find package 'postcss'`. `npm install` resolves it. Anyone else on this machine would have hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AV8D7q23vxqG87Q9iLuc1p
