### PR TITLE
fix(docx): guard tandem_applyChanges' overwrite like every other write path

### DIFF
--- a/src/server/mcp/docx-apply.ts
+++ b/src/server/mcp/docx-apply.ts
@@ -12,7 +12,6 @@ import {
   Y_MAP_EXTERNAL_CONFLICT,
   Y_MAP_SAVED_AT_VERSION,
 } from "../../shared/constants.js";
-import { withInternal } from "../../shared/origins.js";
 import { rejectUnsafeWindowsPrefix } from "../../shared/windows-path-safety.js";
 import { listDocBackups, snapshotBeforeFirstWrite } from "../file-io/doc-backup.js";
 import {
@@ -195,9 +194,34 @@ export async function applyChangesCore(
   // being protected is the file's content at read time. Same 1-second tolerance
   // and the same `Y_MAP_SAVED_AT_VERSION` baseline as `saveDocumentToDisk` —
   // fs.watch debounce plus an atomic rename cause minor drift.
+  //
+  // The stat is wrapped the way `saveDocumentToDisk` wraps its own. A `.docx`
+  // held open by Word raises EPERM/EBUSY on Windows and a deleted or moved file
+  // raises ENOENT — both ordinary states, and both would otherwise leave here as
+  // an unhandled fs error: an MCP protocol failure on one side, and a 500 logged
+  // as "[Tandem] Unhandled API error" with a stack on the other, reporting an
+  // expected condition as a Tandem crash in the one artefact (Copy Diagnostics)
+  // a user would send us about it.
+  //
+  // Anything that is not ENOENT is re-thrown with its ORIGINAL errno code rather
+  // than a code of our own, because EBUSY / EPERM / EACCES already map to
+  // accurate labels (FILE_LOCKED, PERMISSION_DENIED) in `routes/_shared.ts`. A
+  // new code would land on `default: INTERNAL` and say less.
   const meta = ydoc.getMap(Y_MAP_DOCUMENT_META);
   const lastSavedAt = meta.get(Y_MAP_SAVED_AT_VERSION) as number | undefined;
-  const stat = await fs.stat(filePath);
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(filePath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw Object.assign(new Error("The source file no longer exists."), {
+        code: "SOURCE_MISSING",
+      });
+    }
+    console.error("[docx-apply] Unexpected stat error for %s:", filePath, err);
+    throw Object.assign(new Error("Cannot verify the file's state."), { code });
+  }
   if (lastSavedAt && stat.mtimeMs > lastSavedAt + 1000) {
     throw Object.assign(
       new Error("The file was modified outside Tandem. Reload it before applying changes."),
@@ -251,18 +275,24 @@ export async function applyChangesCore(
   });
 
   // 8. Write modified .docx
+  //
+  // `Y_MAP_SAVED_AT_VERSION` is deliberately NOT re-baselined here, unlike every
+  // other write path. An earlier revision of this PR did re-baseline it, on the
+  // reasoning that a path's own write should not read as an external change —
+  // which is true everywhere else and wrong here.
+  //
+  // What went on disk is tracked-changes markup (`w:ins` / `w:del`). The
+  // in-memory Y.Doc still holds the PRE-apply body and cannot represent
+  // revisions at all: mammoth silently accepts every insertion and discards
+  // every deletion on import, which is why `docx-lost-features.ts` exists. So
+  // between this write and the watcher's reload, the Y.Doc is genuinely STALE
+  // relative to the file, and an explicit Ctrl+S in that window would export it
+  // over the revisions that were just written.
+  //
+  // The stale baseline is what makes `saveDocumentToDisk`'s
+  // `stat.mtimeMs > lastSavedAt + 1000` fire and refuse that save. The refusal
+  // is correct. The reload re-baselines when it lands.
   await atomicWriteBuffer(filePath, result.buffer);
-
-  // Re-baseline so the write we just made does not read as an EXTERNAL change
-  // to the next save or to the guard added above. The watcher's reload
-  // re-baselines too, but it is async and deliberately un-fingerprinted for
-  // this path (the reload re-imports tracked-changes markup, which is a
-  // semantic change, not an identical-bytes echo), so an explicit save landing
-  // in that window would otherwise be refused as FILE_MODIFIED.
-  const writtenStat = await fs.stat(filePath).catch(() => undefined);
-  withInternal(ydoc, () => {
-    meta.set(Y_MAP_SAVED_AT_VERSION, writtenStat?.mtimeMs ?? Date.now());
-  });
 
   // 9. Build result
   const output: ApplyChangesResult = {
@@ -311,6 +341,18 @@ export function registerApplyTools(server: McpServer): void {
         if (e.code === "UNSUPPORTED_FORMAT") return mcpError("FORMAT_ERROR", e.message);
         if (e.code === "INVALID_PATH") return mcpError("FORMAT_ERROR", e.message);
         if (e.code === "BACKUP_FAILED") return mcpError("BACKUP_FAILED", e.message);
+        // The write guards (#1448 W1). Every one of these is an expected policy
+        // refusal, so it has to come back as a structured error the AI can read
+        // and act on. Rethrowing would surface "the file changed on disk" as an
+        // unhandled MCP protocol failure.
+        if (e.code === "READ_ONLY") return mcpError("READ_ONLY", e.message);
+        if (e.code === "EXTERNAL_CONFLICT") return mcpError("EXTERNAL_CONFLICT", e.message);
+        if (e.code === "FILE_MODIFIED") return mcpError("FILE_MODIFIED", e.message);
+        if (e.code === "SOURCE_MISSING") return mcpError("SOURCE_MISSING", e.message);
+        // A locked or unreadable source keeps its own errno rather than a code of
+        // ours, so it is matched by code here too — same reasoning as the stat guard.
+        if (e.code === "EBUSY" || e.code === "EPERM" || e.code === "EACCES")
+          return mcpError("FILE_LOCKED", e.message);
         throw err;
       }
     }),

--- a/src/server/mcp/docx-apply.ts
+++ b/src/server/mcp/docx-apply.ts
@@ -7,8 +7,14 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import fs from "fs/promises";
 import path from "path";
 import { z } from "zod";
+import {
+  Y_MAP_DOCUMENT_META,
+  Y_MAP_EXTERNAL_CONFLICT,
+  Y_MAP_SAVED_AT_VERSION,
+} from "../../shared/constants.js";
+import { withInternal } from "../../shared/origins.js";
 import { rejectUnsafeWindowsPrefix } from "../../shared/windows-path-safety.js";
-import { listDocBackups } from "../file-io/doc-backup.js";
+import { listDocBackups, snapshotBeforeFirstWrite } from "../file-io/doc-backup.js";
 import {
   type AcceptedSuggestion,
   applyTrackedChanges,
@@ -16,6 +22,7 @@ import {
 } from "../file-io/index.js";
 import { resolveAppDataDir } from "../platform.js";
 import { relPosToFlatOffset } from "../positions.js";
+import { narrowConflict } from "../session/manager.js";
 import { extractText } from "./document-model.js";
 import { getCurrentDoc, requireDocument } from "./document-service.js";
 import { YDocStore } from "./document-store.js";
@@ -92,6 +99,31 @@ export async function applyChangesCore(
     });
   }
 
+  // Read-only is the user's stated intent and dominates everything below. This
+  // is the only write path in the codebase that used to ignore it: the View
+  // Changelog button and every `POST /api/open {readOnly:true}` produce a doc
+  // that refuses `saveDocumentToDisk` and, until now, accepted an overwrite from
+  // `tandem_applyChanges`.
+  if (docState.readOnly) {
+    throw Object.assign(new Error("Cannot apply changes to a read-only document."), {
+      code: "READ_ONLY",
+    });
+  }
+
+  // An unresolved keep-vs-reload choice blocks this the same way it blocks
+  // Ctrl+S and tandem_save (#1238). `diskChanged` is the discriminator, not the
+  // flag's presence: an "unsaved-restore" over an unchanged disk is unambiguous
+  // intent and stays permitted, mirroring `saveDocumentToDisk` exactly. Claude
+  // has no surface that would even tell it a conflict is pending, so applying
+  // over one is never a resolution.
+  const conflict = narrowConflict(ydoc.getMap(Y_MAP_DOCUMENT_META).get(Y_MAP_EXTERNAL_CONFLICT));
+  if (conflict?.diskChanged) {
+    throw Object.assign(
+      new Error("The file changed on disk. Resolve the conflict before applying changes."),
+      { code: "EXTERNAL_CONFLICT" },
+    );
+  }
+
   // 3. Collect accepted suggestions.
   // `listAnnotations()` sanitizes legacy shapes through the same migration-log
   // relay (keyed on docHash(filePath)) the inline loop used, and skips
@@ -155,7 +187,24 @@ export async function applyChangesCore(
     throw Object.assign(new Error("No accepted suggestions to apply."), { code: "NO_SUGGESTIONS" });
   }
 
-  // 4. Get ydocFlatText and read the original file
+  // 4. Get ydocFlatText and read the original file.
+  //
+  // The mtime guard runs HERE, immediately before the read whose bytes are
+  // rewritten, not up with the other preconditions: the suggestion collection
+  // above is synchronous but `applyTrackedChanges` below is not, and the value
+  // being protected is the file's content at read time. Same 1-second tolerance
+  // and the same `Y_MAP_SAVED_AT_VERSION` baseline as `saveDocumentToDisk` —
+  // fs.watch debounce plus an atomic rename cause minor drift.
+  const meta = ydoc.getMap(Y_MAP_DOCUMENT_META);
+  const lastSavedAt = meta.get(Y_MAP_SAVED_AT_VERSION) as number | undefined;
+  const stat = await fs.stat(filePath);
+  if (lastSavedAt && stat.mtimeMs > lastSavedAt + 1000) {
+    throw Object.assign(
+      new Error("The file was modified outside Tandem. Reload it before applying changes."),
+      { code: "FILE_MODIFIED" },
+    );
+  }
+
   const ydocFlatText = extractText(ydoc);
   const buffer = await fs.readFile(filePath);
 
@@ -185,10 +234,37 @@ export async function applyChangesCore(
     });
   }
 
-  // 7. Write modified .docx
+  // 7. Pre-overwrite snapshot of the on-disk original, then write.
+  //
+  // The `.backup.docx` sidecar above is NOT a substitute, and it was this
+  // path's only net. It lands wherever the CALLER says — next to the user's
+  // document by default, or at any `backupPath` an MCP client supplies — so
+  // it is easy to delete, move or lose, and it is not swept or capped.
+  // `snapshotBeforeFirstWrite` is the same once-per-path-per-run
+  // mechanism every other write path calls, stored in app data, size-capped and
+  // swept — and it is format-agnostic, so a `.docx` restores byte-identical.
+  // Never throws: a snapshot failure must not block the write, since the
+  // in-memory edits are the newer data.
+  await snapshotBeforeFirstWrite(filePath, {
+    appDataDir: resolveAppDataDir(),
+    documentId: docState.id,
+  });
+
+  // 8. Write modified .docx
   await atomicWriteBuffer(filePath, result.buffer);
 
-  // 8. Build result
+  // Re-baseline so the write we just made does not read as an EXTERNAL change
+  // to the next save or to the guard added above. The watcher's reload
+  // re-baselines too, but it is async and deliberately un-fingerprinted for
+  // this path (the reload re-imports tracked-changes markup, which is a
+  // semantic change, not an identical-bytes echo), so an explicit save landing
+  // in that window would otherwise be refused as FILE_MODIFIED.
+  const writtenStat = await fs.stat(filePath).catch(() => undefined);
+  withInternal(ydoc, () => {
+    meta.set(Y_MAP_SAVED_AT_VERSION, writtenStat?.mtimeMs ?? Date.now());
+  });
+
+  // 9. Build result
   const output: ApplyChangesResult = {
     applied: result.applied,
     rejected: result.rejected,

--- a/src/server/mcp/routes/_shared.ts
+++ b/src/server/mcp/routes/_shared.ts
@@ -94,6 +94,11 @@ export function errorCodeToHttpStatus(code: string | undefined): number {
     case "FILE_NOT_FOUND":
     case "NO_DOCUMENT":
     case "NOT_FOUND":
+    // `SOURCE_MISSING` and `FILE_MODIFIED` are `saveDocumentToDisk`'s skip codes
+    // (see `saveSkippedMessage`), which docx-apply reuses rather than minting a
+    // parallel vocabulary for the same two conditions. They reach sendApiError
+    // only from there — a skipped save returns 200 with a `skipCode`.
+    case "SOURCE_MISSING":
       return 404;
     case "INVALID_PATH":
     case "UNSUPPORTED_FORMAT":
@@ -111,6 +116,7 @@ export function errorCodeToHttpStatus(code: string | undefined): number {
     case "RENAME_IN_PROGRESS":
     case "RELOAD_IN_PROGRESS":
     case "EXTERNAL_CONFLICT":
+    case "FILE_MODIFIED":
       return 409;
     // DOCX_TOO_LARGE (#1310) is the decompressed-size sibling of FILE_TOO_LARGE's compressed cap.
     // Without this case it falls through to 500, which makes sendApiError log
@@ -138,6 +144,7 @@ export function errorCodeToLabel(code: string): string {
     case "FILE_NOT_FOUND":
     case "NO_DOCUMENT":
     case "NOT_FOUND":
+    case "SOURCE_MISSING":
       return "NOT_FOUND";
     case "INVALID_PATH":
       return "INVALID_PATH";
@@ -159,7 +166,13 @@ export function errorCodeToLabel(code: string): string {
       return "READ_ONLY";
     case "RELOAD_IN_PROGRESS":
       return "RELOAD_IN_PROGRESS";
+    // `FILE_MODIFIED` folds onto EXTERNAL_CONFLICT for the same reason
+    // DOCX_TOO_LARGE folds onto FILE_TOO_LARGE below: they are one condition
+    // ("the file changed under us") reported by two code paths, `saveSkippedMessage`
+    // already gives them identical user-facing copy, and a novel label would be an
+    // unrecognized string to every existing client.
     case "EXTERNAL_CONFLICT":
+    case "FILE_MODIFIED":
       return "EXTERNAL_CONFLICT";
     // Deliberately the SAME label as the compressed-size cap rather than a new one: both are
     // "this file is too big to open", the distinction between them is in `message`, and a novel

--- a/tests/server/docx-apply.test.ts
+++ b/tests/server/docx-apply.test.ts
@@ -932,11 +932,35 @@ describe("applyChangesCore — write guards", () => {
     await expect(applyChangesCore(DOC_ID)).resolves.toMatchObject({ applied: 1 });
   });
 
-  it("re-baselines savedAtVersion so its own write does not read as external", async () => {
-    await applyChangesCore(DOC_ID);
+  it("leaves savedAtVersion STALE so a save before the reload is refused", async () => {
+    // The inverse of every other write path, and deliberate. What lands on disk is
+    // tracked-changes markup the Y.Doc cannot represent — mammoth drops revisions on
+    // import — so until the watcher's reload the Y.Doc is genuinely older than the
+    // file, and an explicit Ctrl+S in that window would export it over the revisions
+    // just written. The stale baseline is what makes saveDocumentToDisk refuse.
+    const baseline = Date.now() - 60_000;
     const meta = getOrCreateDocument(DOC_ID).getMap(Y_MAP_DOCUMENT_META);
+    meta.set(Y_MAP_SAVED_AT_VERSION, baseline);
+    // Not a drift refusal: touch the file back to the baseline first, so the apply
+    // itself is what moves mtime past it.
+    await fsp.utimes(docPath, new Date(baseline), new Date(baseline));
+
+    await expect(applyChangesCore(DOC_ID)).resolves.toMatchObject({ applied: 1 });
+
+    expect(meta.get(Y_MAP_SAVED_AT_VERSION)).toBe(baseline);
     const stat = await fsp.stat(docPath);
-    expect(meta.get(Y_MAP_SAVED_AT_VERSION)).toBe(stat.mtimeMs);
+    expect(stat.mtimeMs).toBeGreaterThan(baseline + 1000);
+  });
+
+  it("reports a source file deleted mid-apply as SOURCE_MISSING, not an fs crash", async () => {
+    // An ordinary state (the user moved or deleted the file), so it has to come back
+    // as a structured refusal. Unguarded it leaves as a raw ENOENT: an unhandled MCP
+    // protocol failure on one side and a 500 logged as "Unhandled API error" with a
+    // stack on the other — a Tandem crash report for something Tandem did not do.
+    getOrCreateDocument(DOC_ID).getMap(Y_MAP_DOCUMENT_META).set(Y_MAP_SAVED_AT_VERSION, Date.now());
+    await fsp.rm(docPath);
+
+    await expect(applyChangesCore(DOC_ID)).rejects.toMatchObject({ code: "SOURCE_MISSING" });
   });
 
   it("takes a pre-overwrite snapshot, not just the sidecar backup", async () => {

--- a/tests/server/docx-apply.test.ts
+++ b/tests/server/docx-apply.test.ts
@@ -1,7 +1,11 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import render from "dom-serializer";
 import JSZip from "jszip";
 import { beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
+import { listDocBackups } from "../../src/server/file-io/doc-backup.js";
 import {
   applySingleSuggestion,
   applyTrackedChanges,
@@ -16,7 +20,14 @@ import {
   setActiveDocId,
 } from "../../src/server/mcp/document-service.js";
 import { applyChangesCore } from "../../src/server/mcp/docx-apply.js";
+import { resolveAppDataDir } from "../../src/server/platform.js";
 import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import {
+  Y_MAP_ANNOTATIONS,
+  Y_MAP_DOCUMENT_META,
+  Y_MAP_EXTERNAL_CONFLICT,
+  Y_MAP_SAVED_AT_VERSION,
+} from "../../src/shared/constants.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -803,5 +814,136 @@ describe("applyChangesCore — UNC backupPath rejection", () => {
       code: "INVALID_PATH",
       message,
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyChangesCore — write guards (#1448 W1)
+// ---------------------------------------------------------------------------
+
+describe("applyChangesCore — write guards", () => {
+  // A fresh id per test: `getOrCreateDocument` is a module-level registry, so a
+  // shared id accumulates a paragraph per `beforeEach` and every case after the
+  // first fails on a flat-text mismatch instead of on the guard under test.
+  let counter = 0;
+  let DOC_ID: string;
+  let docPath: string;
+
+  beforeEach(async () => {
+    for (const id of [...getOpenDocs().keys()]) removeDoc(id);
+    setActiveDocId(null);
+
+    counter += 1;
+    DOC_ID = `guard-test-doc-${counter}`;
+    docPath = path.join(
+      await fsp.mkdtemp(path.join(os.tmpdir(), "tandem-apply-guard-")),
+      "doc.docx",
+    );
+    await fsp.writeFile(
+      docPath,
+      await createTestDocx(wrapBody("<w:p><w:r><w:t>Hello world</w:t></w:r></w:p>")),
+    );
+
+    const doc = getOrCreateDocument(DOC_ID);
+    doc.getXmlFragment("default").insert(0, [makeYParagraph("Hello world")]);
+    // One accepted suggestion, so the guards below are the ONLY thing that can
+    // stop the write. Without it every case would fail on NO_SUGGESTIONS and
+    // pass for the wrong reason.
+    doc.getMap(Y_MAP_ANNOTATIONS).set("a1", {
+      id: "a1",
+      type: "comment",
+      author: "claude",
+      status: "accepted",
+      range: { from: 0, to: 5 },
+      text: "swap it",
+      suggestedText: "Howdy",
+      textSnapshot: "Hello",
+      createdAt: Date.now(),
+    });
+
+    addDoc(DOC_ID, {
+      id: DOC_ID,
+      filePath: docPath,
+      format: "docx",
+      readOnly: false,
+      source: "file",
+    });
+    setActiveDocId(DOC_ID);
+  });
+
+  /** The on-disk bytes, so a guard can be shown to have left the file alone. */
+  const onDisk = () => fsp.readFile(docPath);
+
+  it("refuses a read-only document and leaves the file untouched", async () => {
+    const before = await onDisk();
+    addDoc(DOC_ID, {
+      id: DOC_ID,
+      filePath: docPath,
+      format: "docx",
+      readOnly: true,
+      source: "file",
+    });
+
+    await expect(applyChangesCore(DOC_ID)).rejects.toMatchObject({ code: "READ_ONLY" });
+    expect(await onDisk()).toEqual(before);
+  });
+
+  it("refuses while an external-edit conflict is pending", async () => {
+    const before = await onDisk();
+    getOrCreateDocument(DOC_ID).getMap(Y_MAP_DOCUMENT_META).set(Y_MAP_EXTERNAL_CONFLICT, {
+      kind: "external-edit",
+      diskChanged: true,
+      detectedAt: Date.now(),
+    });
+
+    await expect(applyChangesCore(DOC_ID)).rejects.toMatchObject({ code: "EXTERNAL_CONFLICT" });
+    expect(await onDisk()).toEqual(before);
+  });
+
+  it("allows an unsaved-restore conflict over an UNCHANGED disk", async () => {
+    // Mirrors saveDocumentToDisk exactly: `diskChanged` is the discriminator,
+    // not the flag's presence. A blanket block here would refuse every apply
+    // after an ordinary restart-with-unsaved-edits.
+    getOrCreateDocument(DOC_ID).getMap(Y_MAP_DOCUMENT_META).set(Y_MAP_EXTERNAL_CONFLICT, {
+      kind: "unsaved-restore",
+      diskChanged: false,
+      detectedAt: Date.now(),
+    });
+
+    await expect(applyChangesCore(DOC_ID)).resolves.toMatchObject({ applied: 1 });
+  });
+
+  it("refuses when the file was modified outside Tandem since our last write", async () => {
+    const before = await onDisk();
+    getOrCreateDocument(DOC_ID)
+      .getMap(Y_MAP_DOCUMENT_META)
+      .set(Y_MAP_SAVED_AT_VERSION, Date.now() - 60_000);
+    await fsp.utimes(docPath, new Date(), new Date());
+
+    await expect(applyChangesCore(DOC_ID)).rejects.toMatchObject({ code: "FILE_MODIFIED" });
+    expect(await onDisk()).toEqual(before);
+  });
+
+  it("does not refuse on mtime drift within the tolerance", async () => {
+    // Positive control for the guard above: without this, a guard that always
+    // threw would satisfy the FILE_MODIFIED test.
+    getOrCreateDocument(DOC_ID).getMap(Y_MAP_DOCUMENT_META).set(Y_MAP_SAVED_AT_VERSION, Date.now());
+
+    await expect(applyChangesCore(DOC_ID)).resolves.toMatchObject({ applied: 1 });
+  });
+
+  it("re-baselines savedAtVersion so its own write does not read as external", async () => {
+    await applyChangesCore(DOC_ID);
+    const meta = getOrCreateDocument(DOC_ID).getMap(Y_MAP_DOCUMENT_META);
+    const stat = await fsp.stat(docPath);
+    expect(meta.get(Y_MAP_SAVED_AT_VERSION)).toBe(stat.mtimeMs);
+  });
+
+  it("takes a pre-overwrite snapshot, not just the sidecar backup", async () => {
+    // The `.backup.docx` sidecar lands wherever the CALLER says. The snapshot is
+    // the swept, capped, app-data copy every other write path takes.
+    await applyChangesCore(DOC_ID);
+    const backups = await listDocBackups(docPath, resolveAppDataDir());
+    expect(backups.length).toBe(1);
   });
 });


### PR DESCRIPTION
Fifth of five in #1448, and the only one that branches off `master` — it shares no file and no test with the markdown-fidelity chain, so it can merge in any order.

`applyChangesCore` did `atomicWriteBuffer` on the user's `.docx` with **no read-only check, no pending-conflict check, no mtime check, and no `snapshotBeforeFirstWrite`** — the four things every other write path in the codebase honours. Its only net was the `.backup.docx` sidecar, which lands wherever the *caller* says and is neither swept nor size-capped.

## What each guard covers

**Read-only** is the case that reads worst. The View Changelog button and every `POST /api/open {readOnly:true}` produce a document that refuses `saveDocumentToDisk` outright — and accepted an overwrite from here.

**Pending external conflict.** Mirrors `saveDocumentToDisk` exactly: `diskChanged` is the discriminator, not the flag's presence. An `"external-edit"` blocks; an `"unsaved-restore"` over an unchanged disk stays permitted, because that is unambiguous intent. A blanket block would refuse every apply after an ordinary restart-with-unsaved-edits — there is a test for that direction, because getting it wrong is silent and annoying rather than loud.

Claude has no surface that would even tell it a conflict is pending, so applying over one is never a resolution.

**External mtime.** Same 1-second tolerance and same `Y_MAP_SAVED_AT_VERSION` baseline as `saveDocumentToDisk`. It sits immediately before the `readFile` whose bytes get rewritten, not up with the other preconditions — the value being protected is the file's content *at read time*, and `applyTrackedChanges` between them is async.

`Y_MAP_SAVED_AT_VERSION` is re-baselined after the write, so this path's own output cannot read as an external change to the next save. The watcher's reload re-baselines too, but it is async and this write is deliberately un-fingerprinted (the reload re-imports tracked-changes markup, which is a semantic change, not an identical-bytes echo — see CLAUDE.md), so an explicit save landing in that window would otherwise be refused as `FILE_MODIFIED`.

**Pre-overwrite snapshot.** The same once-per-path-per-run mechanism every other write path calls: stored in app data, size-capped, swept. Format-agnostic raw byte copy, so a `.docx` restores byte-identical and `tandem_restoreBackup` already exposes it. Never throws — a snapshot failure must not block the write, since the in-memory edits are the newer data.

## Tests

Seven new cases in `tests/server/docx-apply.test.ts`. Each refusal case also asserts the **on-disk bytes are unchanged**, not just that a code came back, and the two "allowed" cases are positive controls: a guard that always threw would satisfy the refusal tests alone.

Each test gets a fresh document id — `getOrCreateDocument` is a module-level registry, so a shared id accumulates a paragraph per `beforeEach` and every case after the first fails on a flat-text mismatch instead of on the guard under test.

## Verification

- `npm run typecheck` clean; `npx vitest run tests/server/` green apart from `refresh-skill`.
- The pre-push hook (biome + full vitest + `cargo test`) passed on the third attempt. The two earlier attempts failed on `useTauriFileDrop` (4 × `Test timed out in 5000ms`) and then `refresh-skill` (a 20 ms write deadline) — both wall-clock-bound, both on a branch containing **zero** client code and one server file, and the runs took 316–350 s against a ~200 s baseline. Load, not this diff.
- `npm run test:e2e` not run — :3478/:3479 are held by a running `tandem-desktop.exe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnpXPQuW7p25SHTHV9HfMK


---

## Review round (xhigh) — 3 findings, all applied

**The `savedAtVersion` re-baseline was wrong and is removed.** Every other write path re-stamps it after writing, on the reasoning that a path's own write should not read as an external change. That is true everywhere else and false here: what lands on disk is tracked-changes markup (`w:ins`/`w:del`) the in-memory Y.Doc cannot represent at all — mammoth accepts every insertion and discards every deletion on import — so between this write and the watcher's reload the Y.Doc is genuinely *older* than the file, and an explicit Ctrl+S in that window would export it over the revisions just written. The `FILE_MODIFIED` refusal a stale baseline produces is correct. The test asserting the re-baseline now asserts the opposite, with the reasoning attached.

**The `fs.stat` is guarded.** A `.docx` held open by Word raises EPERM/EBUSY on Windows and a deleted file raises ENOENT — ordinary states that left here as raw fs errors: an unhandled MCP protocol failure on one side, and a 500 logged as `[Tandem] Unhandled API error` with a stack on the other, reporting a condition Tandem did not cause as a Tandem crash in the one artefact (Copy Diagnostics) a user would send us about it. ENOENT becomes `SOURCE_MISSING`; anything else keeps its original errno, because EBUSY/EPERM/EACCES already map to accurate labels and a code of our own would land on `default: INTERNAL` and say less.

**The refusals now have HTTP mappings.** `FILE_MODIFIED` and `SOURCE_MISSING` reach `sendApiError` only from this path — a skipped *save* returns 200 with a `skipCode` — so both fell to 500/INTERNAL. Mapped to 409 and 404, folded onto the existing `EXTERNAL_CONFLICT` and `NOT_FOUND` labels rather than minting new ones: `saveSkippedMessage` already gives these codes identical user-facing copy, and a novel label is an unrecognized string to every existing client. Same precedent as `DOCX_TOO_LARGE` → `FILE_TOO_LARGE`.

One half of one finding was **wrong and is not fixed**: it claimed an unmapped code leaks the absolute path into the API body. It does not — `sendApiError` substitutes `GENERIC_ERROR_MESSAGE` for every non-loopback caller regardless of label.
