### PR TITLE
fix(authorship): stop stamping Claude's text as the user's

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -2062,7 +2062,7 @@ async function exportChatToScratchpad(): Promise<void> {
 function insertChatMessage(message: ChatMessage): boolean {
   const targetEditor = editor;
   if (!chatCanInsert || !targetEditor) return false;
-  insertChatMarkdown(targetEditor, message.text);
+  insertChatMarkdown(targetEditor, message.text, message.author);
   return true;
 }
 

--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -1,15 +1,94 @@
 import { Extension } from "@tiptap/core";
 import type { Node as PmNode } from "@tiptap/pm/model";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Plugin, PluginKey, type Transaction } from "@tiptap/pm/state";
+import { Mapping } from "@tiptap/pm/transform";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import { ySyncPluginKey } from "y-prosemirror";
 import * as Y from "yjs";
 import { AUTHORSHIP_TOGGLE_KEY, Y_MAP_AUTHORSHIP } from "../../../shared/constants";
+import { withBrowser } from "../../../shared/origins";
 import { toPmPos } from "../../../shared/positions/types";
 import type { AuthorshipRange } from "../../../shared/types";
+import { isAuthorshipAuthor } from "../../../shared/types";
 import { generateAuthorshipId } from "../../../shared/utils";
-import { flatOffsetToPmPos, pmPosToFlatOffset, relRangeToPmPositions } from "../../positions";
+import { flatOffsetToPmPos, pmSelectionToFlat, relRangeToPmPositions } from "../../positions";
 
 export const authorshipPluginKey = new PluginKey("tandemAuthorship");
+
+/**
+ * Transaction meta naming who authored the content a transaction inserts.
+ *
+ * Set it on any dispatch that puts Claude's words into the document —
+ * accepting a suggestion, inserting a Claude chat message — or the insertion
+ * is attributed to the user, which is worse than leaving it unattributed
+ * (#1388).
+ *
+ * A `PluginKey` rather than a bare string, matching every other meta key in
+ * the codebase, and deliberately NOT `authorshipPluginKey`: `onTransaction`
+ * early-returns on that one, because it marks the plugin's own rebuild/toggle
+ * transactions. Overloading it would make the stamp path skip the very
+ * transactions it exists to label.
+ */
+export const AUTHORSHIP_ORIGIN_META = new PluginKey("tandemAuthorshipOrigin");
+
+/**
+ * Read {@link AUTHORSHIP_ORIGIN_META}, narrowed to the two authors the schema
+ * allows.
+ *
+ * `getMeta` is typed `any`, and this value reaches a Y.Map that
+ * `buildAuthorshipDecorations` switches on — an unvalidated read would put an
+ * off-schema author into a CRDT the decoration builder then switches on. An
+ * unrecognised value falls back to `"user"` rather than throwing: the caller
+ * is a keystroke handler, and refusing to attribute is a smaller failure than
+ * refusing to record the edit. Note the read path makes the opposite call —
+ * `buildAuthorshipDecorations` DROPS an off-schema entry rather than coercing
+ * it — which is right for each side: coercing on read would paint a lie.
+ */
+function readAuthorshipOrigin(transaction: Transaction): AuthorshipRange["author"] {
+  const origin: unknown = transaction.getMeta(AUTHORSHIP_ORIGIN_META);
+  return isAuthorshipAuthor(origin) ? origin : "user";
+}
+
+/**
+ * Ids of authorship entries lying entirely inside one of `deletedSpans`.
+ *
+ * Without this, accepting a suggestion leaves the replaced text's `"user"`
+ * entry sitting at flat offsets the new `"claude"` text now occupies, and the
+ * decoration builder paints both — which is the same wrong-author render #1388
+ * is about, arrived at from the other side.
+ *
+ * **One pass over the map for the whole transaction, not one per deleted
+ * span.** The map grows by one entry per doc-changing transaction and is never
+ * compacted, so it reaches five figures in an afternoon's typing; a per-span
+ * scan would multiply that by the match count on a replace-all. Duplicate ids
+ * across spans are harmless — `Y.Map.delete` of an absent key is a no-op.
+ *
+ * **Fully contained only.** A partially overlapping entry needs its stored
+ * range rewritten, not dropped, and rewriting it correctly means giving client
+ * stamps a `relRange` they do not have today (#1471). Half a remap would turn
+ * a drifted entry into a confidently wrong one.
+ *
+ * **Known limitation, measured, same root cause (#1471).** Stored client
+ * ranges are frozen flat offsets that nothing remaps, so an entry that has
+ * drifted since it was written no longer lies inside the span that deletes its
+ * text, and escapes the reap. One unrelated keystroke above the span is enough.
+ * Pinned executably in `authorship-stamp.test.ts` so the fix has a test waiting
+ * for it rather than a comment.
+ */
+function reapableEntryIds(
+  authorshipMap: Y.Map<unknown>,
+  deletedSpans: readonly { from: number; to: number }[],
+): string[] {
+  if (deletedSpans.length === 0 || authorshipMap.size === 0) return [];
+  const ids: string[] = [];
+  authorshipMap.forEach((value, key) => {
+    const entry = value as AuthorshipRange;
+    if (!entry?.range) return;
+    const { from, to } = entry.range;
+    if (deletedSpans.some((span) => from >= span.from && to <= span.to)) ids.push(key);
+  });
+  return ids;
+}
 
 const GUTTER_NODE_TYPES = new Set(["paragraph", "heading"]);
 
@@ -50,13 +129,12 @@ export function buildAuthorshipDecorations(
   const maxPos = doc.content.size;
 
   // Single pass: build inline spans and collect resolved ranges for the block gutter pass.
-  type ResolvedEntry = { author: "user" | "claude"; from: number; to: number };
+  type ResolvedEntry = { author: AuthorshipRange["author"]; from: number; to: number };
   const resolvedRanges: ResolvedEntry[] = [];
 
   authorshipMap.forEach((value) => {
     const entry = value as AuthorshipRange;
-    if (!entry.author || !entry.range) return;
-    if (entry.author !== "user" && entry.author !== "claude") return;
+    if (!isAuthorshipAuthor(entry.author) || !entry.range) return;
 
     const r = resolveAuthorshipRange(entry, doc, ydoc);
     if (!r) return;
@@ -71,7 +149,7 @@ export function buildAuthorshipDecorations(
       console.warn("[authorship] Decoration RangeError for entry", entry.id, err);
     }
 
-    resolvedRanges.push({ author: entry.author as "user" | "claude", from, to });
+    resolvedRanges.push({ author: entry.author, from, to });
   });
 
   // Per-block dominant-author gutter decoration — descendants() visits nested blocks too
@@ -134,8 +212,10 @@ interface AuthorshipOptions {
  * as ProseMirror inline decorations. Uses the Y.Map overlay strategy (not inline
  * marks) to avoid CRDT size overhead -- see tests/crdt/authorship-marks-size.test.ts.
  *
- * User attribution: onTransaction detects local (non-y-sync) text insertions
- * and records them as author="user" in the authorship Y.Map.
+ * Attribution: onTransaction records local (non-y-sync) text insertions in the
+ * authorship Y.Map, against `"user"` unless the dispatch tagged itself with
+ * {@link AUTHORSHIP_ORIGIN_META}, and drops entries whose text the same
+ * transaction deleted.
  */
 export const AuthorshipExtension = Extension.create<AuthorshipOptions>({
   name: "tandemAuthorship",
@@ -224,6 +304,17 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions>({
         view(editorView) {
           // Observe Y.Map changes and trigger decoration rebuild
           const observer = () => {
+            // `buildAuthorshipDecorations` short-circuits to an empty set while
+            // the overlay is hidden, so a rebuild dispatched now is a whole
+            // ProseMirror transaction for a discarded result. Nothing is lost
+            // by skipping: the `toggle` branch rebuilds from scratch when the
+            // overlay comes back on. This matters because the reap made map
+            // writes fire on DELETIONS too — backspacing over your own recent
+            // text hits this on nearly every keypress.
+            const current = authorshipPluginKey.getState(editorView.state) as
+              | AuthorshipPluginState
+              | undefined;
+            if (!current?.visible) return;
             const tr = editorView.state.tr.setMeta(authorshipPluginKey, { type: "rebuild" });
             editorView.dispatch(tr);
           };
@@ -246,46 +337,127 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions>({
   },
 
   /**
-   * User attribution via onTransaction: detect local text insertions
-   * (not y-sync remotes) and record them as author="user".
+   * Attribution via onTransaction: record local text insertions (not y-sync
+   * remotes) against an author, and drop the entries the same transaction
+   * deleted out from under.
+   *
+   * The author is `"user"` unless the dispatcher set
+   * {@link AUTHORSHIP_ORIGIN_META}. That default is deliberate and must stay:
+   * find-replace, drag-drop and context-menu paste are genuine user authorship
+   * with no obvious place to hang an explicit tag, and an opt-in default would
+   * silently leave them unattributed instead of correctly attributed. It is
+   * the *insertions Claude owns* that carry the tag — see #1388, which was
+   * filed because accepting a Claude suggestion rendered the words as the
+   * user's own.
    */
   onTransaction({ transaction }) {
     const ydoc = this.options.ydoc;
     if (!ydoc) return;
 
-    // Skip remote syncs -- y-sync$ meta is set by the collaboration extension
-    if (transaction.getMeta("y-sync$")) return;
+    // Skip remote syncs — y-prosemirror tags its own applies with this key.
+    if (transaction.getMeta(ySyncPluginKey)) return;
     // Skip our own rebuild/toggle transactions
     if (transaction.getMeta(authorshipPluginKey)) return;
     // Skip if doc didn't change
     if (!transaction.docChanged) return;
 
+    const author = readAuthorshipOrigin(transaction);
     const authorshipMap = ydoc.getMap(Y_MAP_AUTHORSHIP);
     const pmDoc = transaction.doc;
+    const beforeDoc = transaction.before;
 
-    transaction.steps.forEach((step) => {
-      const stepMap = step.getMap();
+    const additions: AuthorshipRange[] = [];
+    /** Deleted spans as flat offsets in the whole-transaction BEFORE frame. */
+    const deletedSpans: { from: number; to: number }[] = [];
+
+    // `mapping.maps`, not `steps`. They are pushed in lockstep by
+    // `Transform.addStep` so they align today, but `i` is what `mapping.slice`
+    // is keyed on — and `src/client/editor/slash-menu/extension.ts` already
+    // carries that warning about this exact idiom. Iterating one and indexing
+    // the other is how the two copies would drift apart.
+    transaction.mapping.maps.forEach((stepMap, i) => {
+      // Step i's `new*` positions address the doc as it stood immediately
+      // after step i, NOT `transaction.doc`. Reading them against the final
+      // doc silently mis-attributes any multi-step transaction whose later
+      // steps shift earlier ones — find-and-replace-all applies its matches in
+      // reverse document order, so every step but the last is affected.
+      // `slice` shares the maps array and just sets bounds, so this is free.
+      const toFinal = transaction.mapping.slice(i + 1);
+      // The mirror image, built lazily because most transactions delete
+      // nothing: step i's `old*` positions address the doc BEFORE step i,
+      // while stored entries are in whole-transaction before-frame coordinates.
+      let toBefore: Mapping | null = null;
+
       stepMap.forEach((oldStart, oldEnd, newStart, newEnd) => {
         const insertedLen = newEnd - newStart - (oldEnd - oldStart);
+
+        if (oldEnd > oldStart) {
+          try {
+            // Built from a real `maps` slice rather than `mapping.slice(0, i)`,
+            // because `Mapping.invert()` does NOT honour a slice's bounds: it
+            // calls `appendMappingInverted`, which walks the whole `maps` array
+            // and ignores `from`/`to` (prosemirror-transform, `invert` → line
+            // 282). `mapping.slice(0, 0).invert()` is therefore the inverse of
+            // EVERY step, not of none — which silently collapsed every reap
+            // range to zero width and made the reap a no-op that nothing threw
+            // over.
+            toBefore ??= new Mapping(transaction.mapping.maps.slice(0, i)).invert();
+            const span = pmSelectionToFlat(beforeDoc, {
+              from: toPmPos(toBefore.map(oldStart, 1)),
+              to: toPmPos(toBefore.map(oldEnd, -1)),
+            });
+            // Node-boundary steps (heading toggle, list wrap) report a deleted
+            // range that carries no TEXT, so it collapses to zero flat width.
+            // Correctness does not need this guard — a zero-width span contains
+            // no entry, since a zero-width entry is never stored. It is an
+            // early-out: dropping the span leaves `deletedSpans` empty, which
+            // skips the whole map scan. Formatting keystrokes are common enough
+            // to be worth not charging them an O(entries) walk. Verified by
+            // mutation: removing this line fails no test, which is the point.
+            if (span.to > span.from) deletedSpans.push(span);
+          } catch (err) {
+            console.warn("[authorship] Position conversion failed reaping a deleted span", err);
+          }
+        }
+
+        // Its own try/catch: a reap that cannot resolve its span must not also
+        // cost the transaction its attribution. These are independent failures.
         if (insertedLen > 0) {
           try {
-            const flatFrom = pmPosToFlatOffset(pmDoc, toPmPos(newStart));
-            const flatTo = pmPosToFlatOffset(pmDoc, toPmPos(newEnd));
-            if (flatTo <= flatFrom) return;
-
-            const rangeId = generateAuthorshipId("user");
-            const entry: AuthorshipRange = {
-              id: rangeId,
-              author: "user",
-              range: { from: flatFrom, to: flatTo },
+            const range = pmSelectionToFlat(pmDoc, {
+              from: toPmPos(toFinal.map(newStart, 1)),
+              to: toPmPos(toFinal.map(newEnd, -1)),
+            });
+            if (range.to <= range.from) return;
+            additions.push({
+              id: generateAuthorshipId(author),
+              author,
+              range,
               timestamp: Date.now(),
-            };
-            authorshipMap.set(rangeId, entry);
+            });
           } catch (err) {
-            console.warn("[authorship] Position conversion failed during user attribution", err);
+            console.warn("[authorship] Position conversion failed stamping an insertion", err);
           }
         }
       });
+    });
+
+    const removals = reapableEntryIds(authorshipMap, deletedSpans);
+    if (additions.length === 0 && removals.length === 0) return;
+    // One transaction for both halves, and removals first: the reap compares
+    // BEFORE-frame offsets, while an addition's range is in final-frame
+    // offsets, so an addition visible to the scan could be deleted by a
+    // coincidental containment across the two frames. Collecting first makes
+    // that structurally impossible rather than ordering-dependent.
+    //
+    // Critical Rule 2: every Y.Doc write is origin-tagged. `browser` is right
+    // for all of them — this handler only ever runs for a local dispatch, the
+    // remote and self-originated cases having returned above. No observer
+    // filters on Y_MAP_AUTHORSHIP today, so the tag buys identity rather than
+    // behaviour; that is the point of the universal rule.
+    withBrowser(ydoc, () => {
+      for (const id of removals) authorshipMap.delete(id);
+      for (const entry of additions) authorshipMap.set(entry.id, entry);
     });
   },
 });

--- a/src/client/editor/slash-menu/extension.ts
+++ b/src/client/editor/slash-menu/extension.ts
@@ -1,5 +1,6 @@
 import { Extension, type Editor as TiptapEditor } from "@tiptap/core";
 import { type EditorState, Plugin, PluginKey, type Transaction } from "@tiptap/pm/state";
+import { ySyncPluginKey } from "y-prosemirror";
 import {
   filterSlashCommands,
   findSlashCommandMatch,
@@ -45,13 +46,17 @@ function activeKey(active: ActiveSlashCommand): string {
  * Used to gate slash-menu *opening* (#998): a bare caret move/click that merely
  * lands after a pre-existing "/" must NOT re-open the menu -- only typing the
  * "/" (or query chars while already open) may. Mirrors the local-vs-remote
- * discrimination in `authorship.ts` (`y-sync$` meta marks remote/MCP syncs).
+ * discrimination in `authorship.ts` — y-prosemirror tags remote/MCP syncs with
+ * `ySyncPluginKey`, which is the same thing the literal `"y-sync$"` used to
+ * name here (a `PluginKey` stringifies to `name + "$"`). The imported key is
+ * the one both sites now use; the literal was only correct for as long as
+ * y-prosemirror's remained the FIRST `PluginKey("y-sync")` constructed.
  */
 function isTypedInsertionAtCaret(tr: Transaction): boolean {
   // Selection-only transactions (click, arrow keys) never open the menu.
   if (!tr.docChanged) return false;
   // Remote collaborative / MCP-driven syncs are not local typing.
-  if (tr.getMeta("y-sync$")) return false;
+  if (tr.getMeta(ySyncPluginKey)) return false;
   // Clipboard paste / drag-drop are explicit UI events, not typing.
   const uiEvent = tr.getMeta("uiEvent");
   if (uiEvent === "paste" || uiEvent === "drop" || tr.getMeta("paste")) return false;

--- a/src/client/panels/chat-insert.ts
+++ b/src/client/panels/chat-insert.ts
@@ -1,8 +1,22 @@
 import type { Editor } from "@tiptap/core";
+import type { AuthorshipRange } from "../../shared/types";
+import { AUTHORSHIP_ORIGIN_META } from "../editor/extensions/authorship";
 import { markdownToSlice } from "../editor/utils/markdown-paste";
 
-/** Insert one chat body through the sanitized paste parser in one history transaction. */
-export function insertChatMarkdown(editor: Editor, markdown: string): void {
+/**
+ * Insert one chat body through the sanitized paste parser in one history
+ * transaction, attributed to whoever wrote the message.
+ *
+ * `author` is threaded from the message rather than hardcoded to `"claude"`:
+ * the Insert affordance in `ChatPanel.svelte` is rendered for every message,
+ * the user's own included, so a hardcoded value would fix #1388's inversion by
+ * introducing its mirror image.
+ */
+export function insertChatMarkdown(
+  editor: Editor,
+  markdown: string,
+  author: AuthorshipRange["author"],
+): void {
   const slice = markdownToSlice(markdown, editor.schema);
   let transaction = editor.state.tr;
   if (slice) {
@@ -15,7 +29,11 @@ export function insertChatMarkdown(editor: Editor, markdown: string): void {
       editor.state.selection.to,
     );
   }
-  transaction.setMeta("addToHistory", true).scrollIntoView();
+  // Both branches reassign `transaction` above, so one setMeta covers each.
+  transaction
+    .setMeta("addToHistory", true)
+    .setMeta(AUTHORSHIP_ORIGIN_META, author)
+    .scrollIntoView();
   editor.view.dispatch(transaction);
   editor.view.focus();
 }

--- a/src/client/panels/useAnnotationReview.svelte.ts
+++ b/src/client/panels/useAnnotationReview.svelte.ts
@@ -6,6 +6,7 @@ import type { SanitizationEvent } from "../../shared/sanitize";
 import { sanitizeAnnotation } from "../../shared/sanitize";
 import type { Annotation } from "../../shared/types";
 import { isPendingReviewTarget } from "../../shared/types";
+import { AUTHORSHIP_ORIGIN_META } from "../editor/extensions/authorship";
 import { annotationToPmRange } from "../positions";
 
 /** Browser DevTools breadcrumb — only forensic trail client-side when sanitize coerces. */
@@ -13,8 +14,20 @@ const devSanitizeWarn = (event: SanitizationEvent): void => {
   console.warn("[sanitize]", event);
 };
 
-/** Apply an annotation's replacement text in the editor */
-function applySuggestion(ann: Annotation, editor: TiptapEditor, ydoc: Y.Doc | null): boolean {
+/**
+ * Apply an annotation's replacement text in the editor.
+ *
+ * Exported for tests only. The hook's own suite drives it through a fully
+ * mocked editor, which cannot observe the transaction — and a mutation that
+ * deletes the authorship tag below passes every assertion there. The real
+ * behaviour is pinned in `tests/client/authorship-stamp.test.ts` against a
+ * live Tiptap editor.
+ */
+export function applySuggestion(
+  ann: Annotation,
+  editor: TiptapEditor,
+  ydoc: Y.Doc | null,
+): boolean {
   if (ann.suggestedText === undefined) return false;
 
   const newText = ann.suggestedText;
@@ -25,17 +38,23 @@ function applySuggestion(ann: Annotation, editor: TiptapEditor, ydoc: Y.Doc | nu
   }
 
   try {
-    editor
-      .chain()
-      .focus()
-      .deleteRange({ from: resolved.from, to: resolved.to })
-      .insertContentAt(resolved.from, newText)
-      .run();
+    return (
+      editor
+        .chain()
+        .focus()
+        // Claude wrote this text; without the tag `Authorship.onTransaction`
+        // stamps it as the user's, which is #1388. The tag must live INSIDE the
+        // chain — a chain batches every step into one transaction, and a
+        // separate dispatch would tag a different one.
+        .setMeta(AUTHORSHIP_ORIGIN_META, "claude")
+        .deleteRange({ from: resolved.from, to: resolved.to })
+        .insertContentAt(resolved.from, newText)
+        .run()
+    );
   } catch (err) {
     console.error("[SidePanel] Editor mutation failed for suggestion", ann.id, err);
     return false;
   }
-  return true;
 }
 
 export interface UseAnnotationReviewParams {
@@ -186,6 +205,14 @@ export function useAnnotationReview({
             scheduleRemoval(id);
             return false;
           }
+          // Deliberately NOT tagged with AUTHORSHIP_ORIGIN_META, so this falls
+          // to the `"user"` default. `textSnapshot` is the document's PRIOR
+          // content, whose author this site does not know: usually the user,
+          // but Claude if an earlier `tandem_edit` wrote it and then suggested
+          // a revision on top. The correct answer is to restore the authorship
+          // entry the accept reaped, which needs the durable/`relRange` work in
+          // #1471 — until then the common case is right and the rare one is
+          // #1388's inversion in miniature. Tracked there, not silently left.
           editor
             .chain()
             .focus()

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -591,8 +591,12 @@ export function registerDocumentTools(server: McpServer): void {
           // This runs in a separate transaction because anchoredRange() reads the
           // Y.Doc state *after* the edit to compute RelativePositions for the new
           // text. Combining it into the edit transaction would anchor against
-          // pre-edit state. The race window is acceptable for v1 — authorship is
-          // decorative (highlight overlay), not semantic.
+          // pre-edit state.
+          //
+          // The split opens no race: `anchoredRange` is synchronous and nothing
+          // between the two `withMcp` calls awaits, so Node cannot interleave a
+          // remote Y update into the gap. Adding an `await` in this span would
+          // create one.
           if (newText.length > 0) {
             const newFrom = from;
             const newTo = toFlatOffset(newFrom + newText.length);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -246,6 +246,22 @@ export function isPendingReviewTarget(a: Annotation): boolean {
 }
 
 /**
+ * Narrow an untrusted value to the two-member authorship author union.
+ *
+ * Distinct from `Annotation.author`, which has a third member (`"import"`,
+ * for .docx Word comments). Attribution has no import case: an imported
+ * comment is a note ABOUT text, never a claim to have written it.
+ *
+ * Exists because the union's membership was being re-spelled at four sites —
+ * the client stamp's meta read, the decoration builder's validity check (plus
+ * the `as` cast that check failed to narrow away), and
+ * `generateAuthorshipId`'s parameter.
+ */
+export function isAuthorshipAuthor(value: unknown): value is AuthorshipRange["author"] {
+  return value === "user" || value === "claude";
+}
+
+/**
  * Authorship tracking range stored in Y.Map('authorship').
  * Uses the same flat-offset coordinate system as annotations.
  * RelativePositions anchor the range to survive concurrent edits.

--- a/tests/client/authorship-stamp.test.ts
+++ b/tests/client/authorship-stamp.test.ts
@@ -1,0 +1,283 @@
+// @vitest-environment happy-dom
+
+import { Editor } from "@tiptap/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ySyncPluginKey } from "y-prosemirror";
+import * as Y from "yjs";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
+import {
+  AUTHORSHIP_ORIGIN_META,
+  AuthorshipExtension,
+} from "../../src/client/editor/extensions/authorship";
+import { insertChatMarkdown } from "../../src/client/panels/chat-insert";
+import { applySuggestion } from "../../src/client/panels/useAnnotationReview.svelte";
+import { Y_MAP_AUTHORSHIP } from "../../src/shared/constants";
+import type { Annotation, AuthorshipRange } from "../../src/shared/types";
+
+/**
+ * Flipped by the one test that needs the flat-offset conversion to fail.
+ * Mocking `pmSelectionToFlat` is the only honest way in: breaking ProseMirror's
+ * own `resolve` takes the transaction down before `onTransaction` ever runs, so
+ * it proves nothing about the handler's catch.
+ */
+let failConversion = false;
+
+vi.mock("../../src/client/positions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/client/positions")>();
+  return {
+    ...actual,
+    pmSelectionToFlat: (...args: Parameters<typeof actual.pmSelectionToFlat>) => {
+      if (failConversion) throw new Error("synthetic conversion failure");
+      return actual.pmSelectionToFlat(...args);
+    },
+  };
+});
+
+/**
+ * The stamp path — `Authorship.onTransaction`, which decides WHO an insertion
+ * is attributed to. It had no tests at all, which is how #1388 shipped:
+ * `author: "user"` was hardcoded, so accepting a Claude suggestion or
+ * inserting a Claude chat message rendered the words as the user's own.
+ *
+ * Distinct from `authorship-decoration.test.ts`, which mocks ProseMirror
+ * wholesale and tests only how stored entries are PAINTED. Nothing there could
+ * have caught a wrong author, because a wrong author paints perfectly.
+ */
+describe("authorship stamp path", () => {
+  let ydoc: Y.Doc;
+  let editor: Editor;
+
+  const entries = (): AuthorshipRange[] =>
+    [...ydoc.getMap(Y_MAP_AUTHORSHIP).values()] as AuthorshipRange[];
+
+  beforeEach(() => {
+    ydoc = new Y.Doc();
+    editor = new Editor({
+      extensions: [...buildSchemaExtensions(), AuthorshipExtension.configure({ ydoc })],
+      content: "<p>hello world</p>",
+    });
+  });
+  afterEach(() => {
+    // Reset here, not at the end of the test that sets it: if that test throws
+    // mid-way the flag leaks `true` into every case below and reds the suite
+    // for a reason unrelated to any of them.
+    failConversion = false;
+    editor.destroy();
+    ydoc.destroy();
+  });
+
+  it("attributes an untagged local edit to the user", () => {
+    // Pins the DEFAULT, which is the half a fix for #1388 could quietly
+    // invert. Without this, stamping everything "claude" would leave every
+    // other test in this file green.
+    editor.commands.insertContentAt(6, "brave ");
+
+    expect(entries()).toHaveLength(1);
+    expect(entries()[0].author).toBe("user");
+    expect(entries()[0].id.startsWith("user")).toBe(true);
+  });
+
+  it("attributes a tagged edit to Claude, id and field together", () => {
+    const tr = editor.state.tr.insertText("XYZ", 6).setMeta(AUTHORSHIP_ORIGIN_META, "claude");
+    editor.view.dispatch(tr);
+
+    expect(entries()).toHaveLength(1);
+    expect(entries()[0].author).toBe("claude");
+    // The id encodes the author. A pair that disagrees is a debugging trap:
+    // whichever one the reader happens to check tells them a different story.
+    expect(entries()[0].id.startsWith("claude")).toBe(true);
+  });
+
+  it("falls back to the user for an off-schema origin rather than writing it through", () => {
+    // `getMeta` is untyped, and this value lands in a Y.Map that outlives the
+    // session and that the decoration builder switches on.
+    const tr = editor.state.tr.insertText("XYZ", 6).setMeta(AUTHORSHIP_ORIGIN_META, "gpt-9");
+    editor.view.dispatch(tr);
+
+    expect(entries()[0].author).toBe("user");
+  });
+
+  it("records nothing for a remote y-sync transaction", () => {
+    const tr = editor.state.tr
+      .insertText("XYZ", 6)
+      .setMeta(ySyncPluginKey, { isChangeOrigin: true });
+    editor.view.dispatch(tr);
+
+    // A remote edit is somebody else's authorship, already carried in their
+    // own Y.Map entry. Stamping it here would double-attribute it, locally as
+    // "user". The new meta read must not disturb this skip.
+    expect(entries()).toHaveLength(0);
+  });
+
+  it("attributes each step of a multi-step transaction to the text it actually inserted", () => {
+    // Find-and-replace-all applies its matches in REVERSE document order, so
+    // every step but the last is shifted by the ones that follow it. Reading
+    // step positions against `transaction.doc` (the final doc) puts the marks
+    // on the wrong characters — invisible in a single-step transaction, which
+    // is every other test here.
+    editor.commands.setContent("<p>aaa bbb aaa</p>");
+    ydoc.getMap(Y_MAP_AUTHORSHIP).clear();
+
+    const tr = editor.state.tr;
+    // Later match first, exactly as replace-all does it.
+    tr.insertText("ZZZZZZ", 9, 12);
+    tr.insertText("ZZZZZZ", 1, 4);
+    editor.view.dispatch(tr);
+
+    const text = editor.state.doc.textBetween(0, editor.state.doc.content.size);
+    expect(text).toBe("ZZZZZZ bbb ZZZZZZ");
+    const spans = entries()
+      .map((e) => e.range)
+      .sort((a, b) => a.from - b.from);
+    expect(spans).toHaveLength(2);
+    // Both spans must land on the Zs. The first replacement's recorded range
+    // is the one the un-remapped read gets wrong: it stays at 8–14 while its
+    // text has moved to 11–17.
+    for (const span of spans) {
+      expect(text.slice(span.from, span.to)).toBe("ZZZZZZ");
+    }
+  });
+
+  describe("reaping entries the same transaction deleted", () => {
+    it("drops an entry whose text is entirely replaced", () => {
+      editor.commands.insertContentAt(6, "brave ");
+      const original = entries();
+      expect(original).toHaveLength(1);
+
+      // Replace exactly the stamped span with Claude's text — the accept-a-
+      // suggestion shape. Leaving the old entry behind would put a "user"
+      // range on top of the new "claude" one, and the decoration builder
+      // paints both.
+      const tr = editor.state.tr
+        .insertText("BOLDLY ", 6, 12)
+        .setMeta(AUTHORSHIP_ORIGIN_META, "claude");
+      editor.view.dispatch(tr);
+
+      const after = entries();
+      expect(after.map((e) => e.id)).not.toContain(original[0].id);
+      expect(after).toHaveLength(1);
+      expect(after[0].author).toBe("claude");
+    });
+
+    it("keeps an entry the deletion only partially overlaps", () => {
+      editor.commands.insertContentAt(6, "brave ");
+      const original = entries()[0];
+
+      // Half of the stamped span. Dropping it would erase attribution for the
+      // surviving half; rewriting its range needs a relRange client stamps do
+      // not carry yet (#1471). Keeping the (now drifted) entry is deliberate.
+      editor.view.dispatch(editor.state.tr.delete(6, 9));
+
+      expect(entries().map((e) => e.id)).toContain(original.id);
+    });
+
+    it("reaps a claude entry too — the reap keys on the span, never the author", () => {
+      const tr = editor.state.tr.insertText("XYZ", 6).setMeta(AUTHORSHIP_ORIGIN_META, "claude");
+      editor.view.dispatch(tr);
+      const claudeEntry = entries()[0];
+      expect(claudeEntry.author).toBe("claude");
+
+      editor.view.dispatch(editor.state.tr.delete(6, 9));
+
+      expect(entries().map((e) => e.id)).not.toContain(claudeEntry.id);
+    });
+
+    it("KNOWN LIMITATION (#1471): a drifted entry escapes the reap", () => {
+      // Not a wish — measured. Stored client ranges are frozen flat offsets
+      // that nothing remaps, so one unrelated keystroke ABOVE a stamped span
+      // is enough to move its text out from under its recorded range. The reap
+      // then compares a current-frame deleted span against a stale entry, the
+      // containment test fails, and the stale \"user\" range survives underneath
+      // the new \"claude\" one — #1388's render, reached from the other side.
+      //
+      // Pinned deliberately, so the durable-relRange fix has a red test to
+      // turn green rather than a comment to notice. When #1471 lands, the
+      // second assertion inverts.
+      editor.commands.insertContentAt(6, "brave ");
+      editor.view.dispatch(editor.state.tr.insertText("X", 1));
+
+      const at = editor.getText().indexOf("brave ") + 1;
+      editor.view.dispatch(
+        editor.state.tr.insertText("BOLDLY ", at, at + 6).setMeta(AUTHORSHIP_ORIGIN_META, "claude"),
+      );
+
+      expect(entries().some((e) => e.author === "claude")).toBe(true);
+      expect(entries().some((e) => e.range.from === 5 && e.range.to === 11)).toBe(true);
+    });
+
+    it("does not reap on a formatting change that deletes no text", () => {
+      // A heading toggle or list wrap emits a step whose map reports a deleted
+      // NODE-boundary range, which is exactly the shape that would make a reap
+      // eat a whole block's attribution. It does not, because those ranges
+      // carry no text and collapse to zero flat width. Pinned here because the
+      // reasoning is a property of ReplaceAroundStep's step map, not of our
+      // code — a prosemirror-transform change could take it away silently.
+      editor.commands.insertContentAt(6, "brave ");
+      const before = entries().map((e) => e.id);
+
+      editor.commands.setTextSelection(3);
+      editor.commands.toggleHeading({ level: 2 });
+      editor.commands.toggleBulletList();
+
+      expect(entries().map((e) => e.id)).toEqual(expect.arrayContaining(before));
+    });
+  });
+
+  it("applySuggestion attributes an accepted suggestion to Claude", () => {
+    // The real function, not a reconstruction of its shape. `applySuggestion`
+    // is exported solely for this: the hook's own suite drives it through a
+    // fully mocked editor that cannot observe a transaction, and a mutation
+    // deleting its `.setMeta()` step passes every assertion over there.
+    //
+    // This also pins the mechanism the whole approach rests on — a Tiptap
+    // chain batches its steps into ONE transaction, so a `.setMeta()` step
+    // tags the insertion three steps later. Asserted on the resulting entry,
+    // never on a `dispatch` call count: `.focus()` adds a second,
+    // non-doc-changing dispatch, so a count would fail for a reason that has
+    // nothing to do with attribution.
+    const ann = {
+      id: "ann_stamp_001",
+      author: "claude",
+      type: "comment",
+      status: "pending",
+      // Flat offsets: "world" in "hello world".
+      range: { from: 6, to: 11 },
+      text: "reword this",
+      suggestedText: "planet",
+      timestamp: Date.now(),
+    } as unknown as Annotation;
+
+    expect(applySuggestion(ann, editor, ydoc)).toBe(true);
+    expect(editor.getText()).toBe("hello planet");
+    expect(entries()).toHaveLength(1);
+    expect(entries()[0].author).toBe("claude");
+  });
+
+  // Both rows are load-bearing and neither subsumes the other: the "claude"
+  // row catches a lost tag, the "user" row catches a hardcoded one. The Insert
+  // affordance is rendered for EVERY chat message, the user's included
+  // (`ChatPanel.svelte` has no author guard), so hardcoding "claude" inside
+  // `insertChatMarkdown` would have replaced #1388 with its mirror image.
+  it.each(["claude", "user"] as const)("attributes a %s chat message to %s", (author) => {
+    insertChatMarkdown(editor, "**a message**", author);
+    expect(entries().length).toBeGreaterThan(0);
+    expect(entries().every((e) => e.author === author)).toBe(true);
+  });
+
+  it("writes no entry when position conversion throws", () => {
+    // The handler swallows conversion failures so a keystroke is never lost.
+    // That must mean "no entry", not "an entry with garbage coordinates" — a
+    // bad range would be painted somewhere, and a range painted on the wrong
+    // text is the defect this whole file is about.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    failConversion = true;
+
+    editor.commands.insertContentAt(6, "brave ");
+
+    expect(entries()).toHaveLength(0);
+    // …and it said so. A swallow that logs nothing is how a coordinate bug
+    // becomes a silent no-op instead of a bug report.
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/tests/client/chat-insert.test.ts
+++ b/tests/client/chat-insert.test.ts
@@ -3,6 +3,7 @@
 import { Editor } from "@tiptap/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
+import { AUTHORSHIP_ORIGIN_META } from "../../src/client/editor/extensions/authorship";
 import { insertChatMarkdown } from "../../src/client/panels/chat-insert";
 
 describe("chat insertion", () => {
@@ -15,9 +16,12 @@ describe("chat insertion", () => {
   it("replaces the selection through one undoable sanitized transaction", () => {
     editor.commands.setTextSelection({ from: 7, to: 12 });
     const dispatch = vi.spyOn(editor.view, "dispatch");
-    insertChatMarkdown(editor, "**safe** [link](javascript:evil)");
+    insertChatMarkdown(editor, "**safe** [link](javascript:evil)", "claude");
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch.mock.calls[0][0].getMeta("addToHistory")).toBe(true);
+    // Attribution rides the same transaction as the content, so an insertion
+    // can never be committed under the wrong author by a partial dispatch.
+    expect(dispatch.mock.calls[0][0].getMeta(AUTHORSHIP_ORIGIN_META)).toBe("claude");
     expect(editor.getText()).toContain("hello safe [link](javascript:evil)");
     expect(JSON.stringify(editor.getJSON())).not.toContain('"href":"javascript:');
   });

--- a/tests/e2e/authorship-attribution.spec.ts
+++ b/tests/e2e/authorship-attribution.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import path from "path";
-import { AUTHORSHIP_TOGGLE_KEY } from "../../src/shared/constants";
+import { AUTHORSHIP_TOGGLE_KEY, TANDEM_SETTINGS_KEY } from "../../src/shared/constants";
 import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
@@ -22,8 +22,15 @@ import {
  * cannot reach, which is that the entry actually reaches the DOM as a
  * decoration on the inserted text.
  *
- * The overlay is off by default, so each test arms it in `localStorage` BEFORE
- * the app boots — the plugin reads the key once during `init`, not reactively.
+ * Arming the overlay takes TWO writes, not one. The plugin reads
+ * `AUTHORSHIP_TOGGLE_KEY` once during `init` (not reactively), so it has to be
+ * set before the app boots — but writing only that key is inert: settings-store
+ * creation calls `mirrorDecorationKeys(loaded)`, which unconditionally
+ * re-derives the key from the settings blob (`showAuthorship && !muted`) before
+ * the editor is constructed. So seed the blob as well. Both defaults happen to
+ * be favourable today; `showAuthorship` has already been flipped once (#442),
+ * and if it flips again these tests would fail on a bare visibility timeout
+ * while the setup read as though it had prevented exactly that.
  */
 
 let mcp: McpTestClient;
@@ -39,9 +46,16 @@ test.beforeEach(async ({ page }) => {
   mcp = new McpTestClient();
   await mcp.connect();
   tmpDir = createFixtureDir("sample.md");
-  await page.addInitScript((key) => {
-    window.localStorage.setItem(key, "true");
-  }, AUTHORSHIP_TOGGLE_KEY);
+  await page.addInitScript(
+    (keys) => {
+      window.localStorage.setItem(
+        keys.settings,
+        JSON.stringify({ showAuthorship: true, decorationsMuted: false }),
+      );
+      window.localStorage.setItem(keys.toggle, "true");
+    },
+    { settings: TANDEM_SETTINGS_KEY, toggle: AUTHORSHIP_TOGGLE_KEY },
+  );
 });
 
 test.afterEach(async () => {
@@ -73,8 +87,10 @@ test("accepting a suggestion attributes the replacement to Claude", async ({ pag
 
   await switchToAnnotationsTab(page);
   const acceptBtn = page.locator("[data-testid^='accept-btn-']");
-  await expect(acceptBtn.first()).toBeVisible({ timeout: 10_000 });
-  await acceptBtn.first().click();
+  // Pin the cardinality: `accept-btn-` is a prefix match, so `.first()` would
+  // silently pick an arbitrary card the day a second annotation exists.
+  await expect(acceptBtn).toHaveCount(1, { timeout: 10_000 });
+  await acceptBtn.click();
 
   await expect(editor).toContainText("Rewritten Heading", { timeout: 10_000 });
 
@@ -82,9 +98,21 @@ test("accepting a suggestion attributes the replacement to Claude", async ({ pag
   await expect(claudeSpan.first()).toBeVisible({ timeout: 10_000 });
   await expect(claudeSpan.first()).toContainText("Rewritten Heading");
 
-  // The inversion this fixes would have produced a `"user"` decoration over
-  // the same text, so assert on the whole set rather than only on presence.
-  expect(await decoratedAuthors(page)).toEqual(["claude"]);
+  // Now type as the user, so the document holds BOTH authors at once — the
+  // state #1388 was actually reported in, and the only one that can tell this
+  // fix apart from an over-correction that stamps everything `"claude"`.
+  //
+  // Order is load-bearing: type AFTER the accept. Typing first would make the
+  // accept shift the user entry's frozen flat range, and the assertion would
+  // land in the #1471 drift that `authorship-stamp.test.ts` already pins as a
+  // known limitation. Assert on attribute values only, never on span text, for
+  // the same reason.
+  await editor.locator("p").last().click();
+  await page.keyboard.type(" and the user typed this");
+
+  const authors = await decoratedAuthors(page);
+  expect(authors).toContain("claude");
+  expect(authors).toContain("user");
 });
 
 test("inserting a Claude chat message attributes it to Claude", async ({ page }) => {
@@ -96,13 +124,25 @@ test("inserting a Claude chat message attributes it to Claude", async ({ page })
   await expect(editor).toContainText(TITLE_TEXT, { timeout: 10_000 });
 
   await page.locator("[data-testid='chat-tab']").click();
+  // Chat lives in the ctrl doc and is server-lifetime — `cleanupAllOpenDocuments`
+  // closes documents, nothing clears chat — so pin the count rather than taking
+  // `.first()`. If another spec ever posts chat text before this one runs, an
+  // unpinned locator would insert THAT string and fail below as though
+  // attribution were broken.
   const insertBtn = page.getByRole("button", { name: "Insert into open document" });
-  await expect(insertBtn.first()).toBeEnabled({ timeout: 10_000 });
-  await insertBtn.first().click();
+  await expect(insertBtn).toHaveCount(1, { timeout: 10_000 });
+  await expect(insertBtn).toBeEnabled({ timeout: 10_000 });
+  await insertBtn.click();
 
   const claudeSpan = page.locator(".tandem-editor [data-tandem-author='claude']");
   await expect(claudeSpan.first()).toBeVisible({ timeout: 10_000 });
   await expect(claudeSpan.first()).toContainText("Inserted by Claude");
 
-  expect(await decoratedAuthors(page)).toEqual(["claude"]);
+  // Nothing here is user-authored, so no `"user"` decoration may exist. Not an
+  // exact-set assertion: `Decoration.inline` emits one span per text node, so a
+  // fixture that ever splits across nodes would red for a rendering-chunk
+  // reason rather than an attribution one.
+  const authors = await decoratedAuthors(page);
+  expect(authors).toContain("claude");
+  expect(authors).not.toContain("user");
 });

--- a/tests/e2e/authorship-attribution.spec.ts
+++ b/tests/e2e/authorship-attribution.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+import path from "path";
+import { AUTHORSHIP_TOGGLE_KEY } from "../../src/shared/constants";
+import {
+  cleanupAllOpenDocuments,
+  cleanupFixtureDir,
+  createFixtureDir,
+  McpTestClient,
+  switchToAnnotationsTab,
+} from "./helpers";
+
+/**
+ * #1388 — the two client paths that insert Claude's text must attribute it to
+ * Claude, not to the user.
+ *
+ * `Authorship.onTransaction` stamps every local doc-changing transaction, and
+ * before this fix it hardcoded `author: "user"`. Accepting a suggestion and
+ * inserting a chat message both dispatch exactly such a transaction, so
+ * Claude's own words rendered in the user's colour — the precise failure the
+ * overlay exists to prevent. `tests/client/authorship-stamp.test.ts` pins the
+ * stamp against a live Tiptap editor; this spec covers the half that unit test
+ * cannot reach, which is that the entry actually reaches the DOM as a
+ * decoration on the inserted text.
+ *
+ * The overlay is off by default, so each test arms it in `localStorage` BEFORE
+ * the app boots — the plugin reads the key once during `init`, not reactively.
+ */
+
+let mcp: McpTestClient;
+let tmpDir: string;
+
+// "# Test Document" in flat text: "# " is the heading prefix (2 chars), so
+// "Test Document" spans offsets 2–15.
+const TITLE_FROM = 2;
+const TITLE_TO = 15;
+const TITLE_TEXT = "Test Document";
+
+test.beforeEach(async ({ page }) => {
+  mcp = new McpTestClient();
+  await mcp.connect();
+  tmpDir = createFixtureDir("sample.md");
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(key, "true");
+  }, AUTHORSHIP_TOGGLE_KEY);
+});
+
+test.afterEach(async () => {
+  await cleanupAllOpenDocuments(mcp);
+  await mcp.close();
+  cleanupFixtureDir(tmpDir);
+});
+
+/** Authors of every inline authorship decoration currently in the editor. */
+async function decoratedAuthors(page: import("@playwright/test").Page): Promise<string[]> {
+  return page
+    .locator(".tandem-editor [data-tandem-author]")
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-tandem-author") ?? ""));
+}
+
+test("accepting a suggestion attributes the replacement to Claude", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: "Punchier title",
+    textSnapshot: TITLE_TEXT,
+    suggestedText: "Rewritten Heading",
+  });
+
+  await page.goto("/");
+  const editor = page.locator(".tandem-editor");
+  await expect(editor).toContainText(TITLE_TEXT, { timeout: 10_000 });
+
+  await switchToAnnotationsTab(page);
+  const acceptBtn = page.locator("[data-testid^='accept-btn-']");
+  await expect(acceptBtn.first()).toBeVisible({ timeout: 10_000 });
+  await acceptBtn.first().click();
+
+  await expect(editor).toContainText("Rewritten Heading", { timeout: 10_000 });
+
+  const claudeSpan = page.locator(".tandem-editor [data-tandem-author='claude']");
+  await expect(claudeSpan.first()).toBeVisible({ timeout: 10_000 });
+  await expect(claudeSpan.first()).toContainText("Rewritten Heading");
+
+  // The inversion this fixes would have produced a `"user"` decoration over
+  // the same text, so assert on the whole set rather than only on presence.
+  expect(await decoratedAuthors(page)).toEqual(["claude"]);
+});
+
+test("inserting a Claude chat message attributes it to Claude", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_reply", { text: "Inserted by Claude" });
+
+  await page.goto("/");
+  const editor = page.locator(".tandem-editor");
+  await expect(editor).toContainText(TITLE_TEXT, { timeout: 10_000 });
+
+  await page.locator("[data-testid='chat-tab']").click();
+  const insertBtn = page.getByRole("button", { name: "Insert into open document" });
+  await expect(insertBtn.first()).toBeEnabled({ timeout: 10_000 });
+  await insertBtn.first().click();
+
+  const claudeSpan = page.locator(".tandem-editor [data-tandem-author='claude']");
+  await expect(claudeSpan.first()).toBeVisible({ timeout: 10_000 });
+  await expect(claudeSpan.first()).toContainText("Inserted by Claude");
+
+  expect(await decoratedAuthors(page)).toEqual(["claude"]);
+});


### PR DESCRIPTION
Closes #1388.

Per-character authorship already ships and is default-on. #1388 reads as "build attribution"; the defect underneath it is an **inversion**.

`Authorship.onTransaction` hardcoded `author: "user"` for every local, doc-changing, non-y-sync transaction — and two of the most-travelled ways Claude's text enters a document dispatch exactly such a transaction: accepting a suggestion, and inserting a chat message. Text with no attribution is merely unlabeled; text labeled with the *wrong* author is the exact failure the overlay exists to prevent. Server-side MCP edits were already correct, so this is client-only.

## The fix

A transaction meta, `AUTHORSHIP_ORIGIN_META`, read by `onTransaction` and defaulting to `"user"`.

**The default stays, deliberately.** Find-replace, drag-drop and context-menu paste are genuine user authorship with no obvious place to hang a tag; an opt-in default would leave them *unattributed* instead of *correctly attributed*, and every future insertion site would inherit no label rather than the right one. It is the insertions Claude owns that carry the tag — and that obligation is bounded, not open-ended. An exhaustive grep of `src/client` for content-inserting dispatches (`insertContentAt`, `insertContent(`, `replaceSelection`, `insertText`, `setContent`) returns **five**, and the split is clean:

| Site | Origin | Tagged |
|---|---|---|
| `editor/context-menu/dispatch.ts:87` | user paste | n/a — user |
| `editor/extensions/find-replace.ts:266,292` | user replace | n/a — user |
| `panels/chat-insert.ts` | threaded from the message | yes |
| `panels/useAnnotationReview.svelte.ts:32` (accept) | Claude | yes |
| `panels/useAnnotationReview.svelte.ts:193` (undo) | prior content, author unknown | **no** — see below |

**The chat author is threaded, not hardcoded.** `ChatPanel.svelte` renders the Insert affordance for **every** message, the user's own included, with no author guard. Hardcoding `"claude"` in `insertChatMarkdown` would have replaced the inversion with its mirror image. Both entry points — the button and the `tandem:insert-chat-message` native-menu listener — route through `App.svelte`'s `insertChatMessage`, which has `message.author`. The parameter is required rather than optional, which is the forcing function for the next caller.

## Three defects the fix uncovered

**Step positions were read against the wrong doc.** A step's `new*` positions address the doc immediately *after that step*, not `transaction.doc`. Find-and-replace-all applies its matches in reverse document order, so every step but the last was being recorded at offsets its text had already left. Now mapped forward through `mapping.slice(i + 1)`.

**Deleted text left its authorship behind.** `Y_MAP_AUTHORSHIP` had no `.delete` anywhere, so accepting a suggestion left the replaced text's `"user"` entry sitting at the flat offsets the new `"claude"` text now occupies — and the decoration builder paints both. That is #1388's render reached from the other side. Entries lying fully inside a deleted span are now reaped, in the same Y transaction as the stamp.

**`Mapping.invert()` ignores a slice's bounds.** `appendMappingInverted` walks the whole `maps` array regardless of `from`/`to`, so `mapping.slice(0, 0).invert()` is the inverse of *every* step rather than of none. That collapsed every reap range to zero width and made the reap a silent no-op: it threw nothing, logged nothing, and failed no test until one existed for it. Built from a real `maps` slice instead.

## Also in the diff

- **`withBrowser` on the map write** (Critical Rule 2). The bare `.set` was invisible to both enforcement paths — `audit-origins.ts` walks `src/server` only and `check-raw-transact.sh` matches `.transact(`.
- **`ySyncPluginKey` instead of the `"y-sync$"` literal**, completed at the slash-menu's copy — whose docstring advertised the literal as the shared convention, and which would have become the stale pointer otherwise. The literal is only correct while y-prosemirror's is the first `PluginKey("y-sync")` constructed.
- **`applySuggestion` returns the chain's own result** instead of an unconditional `true`, so a falsey chain now reverts the annotation to pending and fires `onApplyFailed`. Behaviour change; Tiptap's `focus` returns `true` on every branch, so it is low-risk, but it is real.
- **An `isAuthorshipAuthor` guard** in `shared/types.ts`. The two-member union's membership was re-spelled at four sites, including an `as` cast the validity check next to it failed to narrow away.
- **The observer no longer dispatches a rebuild while the overlay is hidden.** The reap made map writes fire on deletions too, and a rebuild dispatched while hidden is a full ProseMirror transaction for a result `buildAuthorshipDecorations` immediately discards. Measured at 5.6 ms per rebuild for a 500-paragraph doc with 1000 entries.

## Deliberately not done — #1471, filed with a red test waiting

Client stamps carry no `relRange`, so their flat offsets drift, and that drift **defeats the reap**: the containment test compares a current-frame span against a stale entry. Measured — one unrelated keystroke above a stamped span is enough for the stale `"user"` entry to survive underneath the new `"claude"` one:

```
1. type "brave "                     -> user entry {5,11}, slices "brave "
2. type one char at doc start        -> entry still {5,11}, text now at 6..12
3. claude-tagged replace of "brave " -> deleted span {7,13}; containment fails
   stale "user" entry survived the reap? TRUE
```

That is pinned as a `KNOWN LIMITATION (#1471)` test which inverts when the fix lands, rather than as a comment nobody will notice. #1471 also carries: Yjs undo/redo bypassing this handler entirely (verified — y-prosemirror tags the Y-to-PM apply with `ySyncPluginKey` even when the origin is a `Y.UndoManager`); `undoResolveAnnotation` restoring prior content whose author this site cannot know; partial-overlap entries left drifted; attribution being session-ephemeral; and the origin-audit blind spot above.

One correction worth stating, because I had it wrong in the plan: the deferral is **not** because the coordinate systems are incompatible. `flatOffsetToRelPos` is pure Yjs in our own convention and moving it to `shared/` is mechanical. The real blocker is an ordering question — whether y-prosemirror has pushed the PM change into the Y.XmlFragment by the time `onTransaction` fires — which has to be answered empirically before any anchor is minted, because a confidently-wrong anchor is worse than the drift.

## Verification

- `npm run typecheck` — clean (1325 files, 0 errors, 0 warnings), rebased onto current master
- `npm test -- --run` — 471 files, 6832 passed, 19 skipped
- `npx biome check src/ tests/` — clean
- **Eight mutants confirmed killed**: hardcoding the author back to `"user"`; dropping the position remap; disabling the reap; widening containment to partial overlap; reverting the `Mapping.invert()` workaround; removing the slash-menu y-sync guard; deleting `applySuggestion`'s tag; passing an off-schema origin value. A ninth — removing the zero-width span guard — **SURVIVED**, and rather than adding a test to force it, that guard's comment now says what it actually is: an efficiency early-out that keeps formatting keystrokes from paying for a map scan, not the correctness barrier an earlier draft of the comment claimed.
- `applySuggestion` is exported for one test. The hook's own suite drives it through a fully mocked editor which cannot observe a transaction, and the mutant that deletes its tag passes every assertion there.

**Verified live, not by inspection.** `tests/e2e/authorship-attribution.spec.ts` (new) drives both Claude insertion paths through a real browser against a real server: accept a suggestion, insert a Claude chat message. Each asserts the inserted text carries `data-tandem-author="claude"` **and** that the full decoration set is exactly `["claude"]` — a presence-only check would have passed on the bug itself, since the inversion painted a `"user"` span over the same text. Both fail against the hardcoded-`"user"` mutant, on the first attempt and on the retry.

`tests/e2e/authorship-gutter.spec.ts` also passes on this branch.

No `CHANGELOG.md` entry: this wave writes the changelog once at integration from the diffs (precedent `a62f4dee`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UGCvUhrQt1aruANfWTAQ2
