### PR TITLE
docs(readme): compact the docs table, the last of the #1448 damage in-tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,18 +159,18 @@ Tandem is close to v1.0, and I keep shipping. [CHANGELOG.md](CHANGELOG.md) recor
 
 **Something not working?** Run the built-in diagnostics first, since they check the setup problems behind most first-launch failures. In the desktop app: **Settings → About → Copy Diagnostics**. On an npm install: `tandem doctor`. (The desktop app doesn't install the `tandem` command, so use the button rather than the CLI.) Then see [docs/troubleshooting.md](docs/troubleshooting.md).
 
-|                                                                                                                                                                          |                                                                        |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| [User guide](docs/user-guide.md)                                                                                                                                         | a longer walkthrough of the editor                                     |
-| [Workflows](docs/workflows.md)                                                                                                                                           | daily usage patterns                                                   |
-| [Troubleshooting](docs/troubleshooting.md)                                                                                                                               | when something goes wrong                                              |
-| [Data locations](docs/data-locations.md)                                                                                                                                 | where Tandem stores data, and clean uninstall                          |
-| [Integrations](docs/integrations.md)                                                                                                                                     | which AI clients connect, and how                                      |
-| [Security](docs/security.md)                                                                                                                                             | the full security model                                                |
-| [Licensing](docs/licensing-explained.md)                                                                                                                                 | how licensing works at v1.0, plain English first                       |
-| [Configuration](docs/configuration.md) · [CLI](docs/cli.md)                                                                                                              | advanced setup and command reference                                   |
+| | |
+| - | - |
+| [User guide](docs/user-guide.md) | a longer walkthrough of the editor |
+| [Workflows](docs/workflows.md) | daily usage patterns |
+| [Troubleshooting](docs/troubleshooting.md) | when something goes wrong |
+| [Data locations](docs/data-locations.md) | where Tandem stores data, and clean uninstall |
+| [Integrations](docs/integrations.md) | which AI clients connect, and how |
+| [Security](docs/security.md) | the full security model |
+| [Licensing](docs/licensing-explained.md) | how licensing works at v1.0, plain English first |
+| [Configuration](docs/configuration.md) · [CLI](docs/cli.md) | advanced setup and command reference |
 | [Positioning](docs/positioning.md) · [Decisions](docs/decisions.md) · [Roadmap](docs/roadmap.md) · [Architecture](docs/architecture.md) · [MCP tools](docs/mcp-tools.md) | why Tandem exists, ADRs, what's next, diagrams, the MCP tool reference |
-| [CHANGELOG](CHANGELOG.md)                                                                                                                                                | release notes                                                          |
+| [CHANGELOG](CHANGELOG.md) | release notes |
 
 ## License
 


### PR DESCRIPTION
The docs table in `README.md` was width-padded to 245 columns by the bug #1448 was filed
about — a Tandem save reflowing every cell to the widest value in its column. It is the one
piece of that damage that landed in git history and stayed there. With the five fidelity PRs
merged, this cleans it up.

**The delimiter row is `| - | - |`, not `| --- | --- |`, and that is deliberate.** With
`tablePipeAlign: false` now shipped, the single dash is what the serializer emits, so this
makes `README.md` a **byte-identical fixed point** through `loadMarkdown → saveMarkdown` —
verified directly, `identical: true`. Writing the conventional `---` would cost one line of
diff noise on the next save in Tandem for no reader-visible difference; GFM treats the two
identically.

Before this, editing one word of the README in Tandem reflowed all 12 table rows. Now it
produces a one-line diff.

Refs #1448
