### PR TITLE
fix(annotations): count hard breaks when resolving a CRDT range to PM

### DIFF
--- a/src/client/positions.ts
+++ b/src/client/positions.ts
@@ -209,6 +209,30 @@ function findXmlTextInParallel(
           return toPmPos(pmStart + Math.min(charAccum + absPos.index, textblockFlatLength(pmNode)));
         }
         charAccum += child.length;
+      } else {
+        // A `hardBreak`, which lives as a SIBLING Y.XmlElement rather than
+        // inside a Y.XmlText (#1450, #1459). It contributes nothing to the
+        // concatenated-XmlText projection this loop walks, but occupies one
+        // ProseMirror position — so skipping it under-counted by one per
+        // preceding break and resolved every endpoint that many positions
+        // early. `applySuggestion` deletes [from, to) and inserts at `from`,
+        // so that silently corrupted documents: a short `to` left the tail of
+        // the original behind, a short `from` ate text ahead of the range.
+        if (!(child instanceof Y.XmlElement) || child.nodeName !== "hardBreak") {
+          // Unreachable today — `hardBreak` is the only inline leaf in the
+          // schema (pinned by a test) and neither importer puts anything else
+          // in a textblock. Worth a runtime warn rather than a silent guess:
+          // `textblockFlatLength` above counts ONLY hardBreak, and the server's
+          // `directChildSpans` charges a nested element separator + its inner
+          // length, so a third shape would put three conventions in play and
+          // this is the one that would fail without saying anything.
+          console.warn(
+            `[positions] unexpected non-text child in textblock: ${
+              child instanceof Y.XmlElement ? child.nodeName : typeof child
+            }; counting it as one position`,
+          );
+        }
+        charAccum += 1;
       }
     }
     return null;

--- a/tests/client/suggestion-hardbreak-range.test.ts
+++ b/tests/client/suggestion-hardbreak-range.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Annotation ranges across hard breaks (#1450, #1459).
+ *
+ * The user-visible symptom was document corruption through the primary review
+ * action: `applySuggestion` does `deleteRange({from, to})` then inserts at
+ * `from`, so a `to` that lands short leaves the tail of the original behind and
+ * the accepted text is pasted in front of it —
+ *
+ *     I had to go find it myself.self.
+ *
+ * `self.` being the last 5 characters of a paragraph that held exactly 5 hard
+ * breaks. Cause: `findXmlTextInParallel` advanced its accumulator only for
+ * `Y.XmlText` children, and a hard break is a SIBLING `Y.XmlElement` that
+ * occupies one ProseMirror position. Both endpoints drifted, so a mid-paragraph
+ * accept also ate text ahead of the range.
+ *
+ * These tests build a REAL Y.Doc through `loadMarkdown` and a REAL ProseMirror
+ * node through the production schema. That matters more than usual: the bug IS
+ * the correspondence between the two representations, so the existing
+ * mock-PM-node coordinate tests structurally cannot see it — a mock written
+ * from the same misunderstanding as the code agrees with the code.
+ *
+ * SCOPE. These assert the RANGE and what a plain-text replacement over it
+ * produces. They deliberately do NOT assert what the shipping accept path
+ * inserts: `insertContentAt` HTML-parses its string argument and collapses
+ * newlines, which is a separate defect (#1477) with its own corruption modes,
+ * pinned in its own describe block below. Conflating the two would let a fix
+ * for one hide a regression in the other.
+ */
+
+import { createNodeFromContent } from "@tiptap/core";
+import { EditorState } from "@tiptap/pm/state";
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { annotationToPmRange } from "../../src/client/positions";
+import { loadMarkdown } from "../../src/server/file-io/markdown";
+import { anchoredRange } from "../../src/server/positions";
+import type { Annotation } from "../../src/shared/types";
+import { productionSchema, yDocToPmNode } from "./editor-roundtrip-harness.js";
+
+type PMNode = ReturnType<typeof yDocToPmNode>;
+
+/** Build the Y.Doc + PM node pair the client actually holds for a document. */
+function docPair(markdown: string) {
+  const ydoc = new Y.Doc();
+  loadMarkdown(ydoc, markdown);
+  return { ydoc, pmDoc: yDocToPmNode(ydoc, productionSchema()) };
+}
+
+/** An annotation anchored the way the server anchors one, over [from, to). */
+function anchor(ydoc: Y.Doc, from: number, to: number): Annotation {
+  const range = anchoredRange(ydoc, from, to);
+  if (!range) throw new Error(`anchoredRange returned null for ${from}..${to}`);
+  return {
+    id: "a1",
+    type: "comment",
+    author: "claude",
+    status: "pending",
+    text: "suggestion",
+    suggestedText: "REPLACED",
+    createdAt: 0,
+    ...range,
+  } as Annotation;
+}
+
+/**
+ * Render a node's content structurally, so a `hardBreak` is DISTINGUISHABLE
+ * from a literal newline character.
+ *
+ * `textBetween(..., "\n", "\n")` — the obvious choice — renders both as "\n"
+ * and therefore cannot see the one distinction this whole file is about. A test
+ * using it passes just as happily when every hard break has been flattened into
+ * a newline, which is a real thing the accept path does.
+ */
+function structure(node: PMNode): string {
+  const parts: string[] = [];
+  node.forEach((child) => {
+    if (child.isText) {
+      parts.push(JSON.stringify(child.text));
+    } else if (child.isTextblock || child.childCount > 0) {
+      parts.push(`${child.type.name}(${structure(child)})`);
+    } else {
+      parts.push(`<${child.type.name}>`);
+    }
+  });
+  return parts.join("+");
+}
+
+/** Resolve, asserting the CRDT path ran — see the note in the first test. */
+function resolveRel(ann: Annotation, pmDoc: PMNode, ydoc: Y.Doc) {
+  const r = annotationToPmRange(ann, pmDoc, ydoc);
+  expect(r, "range did not resolve at all").not.toBeNull();
+  // Without this, every assertion below is satisfiable by the flat fallback —
+  // which never had the bug. Deleting the entire relRange branch would leave
+  // the suite green, and the tests would be covering the wrong code.
+  expect(r!.method, "resolved via the flat fallback, not the CRDT path").toBe("rel");
+  return r!;
+}
+
+/** What the range covers, structurally. */
+function covered(pmDoc: PMNode, from: number, to: number): string {
+  return structure(pmDoc.slice(from, to).content as unknown as PMNode);
+}
+
+// A paragraph with hard breaks, written the way markdown spells them.
+const THREE_BREAKS = "alpha\\\nbravo\\\ncharlie\\\ndelta\n";
+const PLAIN = "alpha bravo charlie delta\n";
+// Flat text of THREE_BREAKS' paragraph — one flat char per break, matching the
+// server's getElementText() convention.
+const THREE_FLAT = "alpha\nbravo\ncharlie\ndelta";
+
+describe("#1450: a suggestion over a paragraph with hard breaks", () => {
+  it("the break-free case works today (positive control)", () => {
+    // Without this, a green suite below could mean the harness never resolved
+    // anything at all.
+    const { ydoc, pmDoc } = docPair(PLAIN);
+    const text = "alpha bravo charlie delta";
+    const r = resolveRel(anchor(ydoc, 0, text.length), pmDoc, ydoc);
+    expect(covered(pmDoc, r.from, r.to)).toBe(JSON.stringify(text));
+  });
+
+  it("covers the WHOLE paragraph, hard breaks included, leaving no tail", () => {
+    const { ydoc, pmDoc } = docPair(THREE_BREAKS);
+    const r = resolveRel(anchor(ydoc, 0, THREE_FLAT.length), pmDoc, ydoc);
+
+    // Before the fix this stopped after "de" — short by 3, the number of hard
+    // breaks — so accepting left "lta" behind. Asserted structurally so a
+    // hardBreak cannot masquerade as a newline character.
+    expect(covered(pmDoc, r.from, r.to)).toBe(
+      '"alpha"+<hardBreak>+"bravo"+<hardBreak>+"charlie"+<hardBreak>+"delta"',
+    );
+  });
+
+  it("the drift was one position per break, not a constant", () => {
+    // Checking more than one count is what distinguishes a per-embed drift from
+    // an off-by-one; the issue's evidence rested on exactly that.
+    for (const breaks of [1, 2, 5]) {
+      const words = Array.from({ length: breaks + 1 }, (_, i) => `w${i}`);
+      const { ydoc, pmDoc } = docPair(`${words.join("\\\n")}\n`);
+      const flat = words.join("\n");
+      const r = resolveRel(anchor(ydoc, 0, flat.length), pmDoc, ydoc);
+
+      const expected = words.map((w) => JSON.stringify(w)).join("+<hardBreak>+");
+      expect(covered(pmDoc, r.from, r.to), `${breaks} hard breaks`).toBe(expected);
+    }
+  });
+
+  it("a range STARTING after a hard break is not shifted either", () => {
+    // The `from` endpoint drifts by the same mechanism, and a wrong `from`
+    // corrupts differently: before the fix this returned "o\ncharl" — shifted
+    // back two at BOTH ends — so the accept ate text ahead of the range as well
+    // as leaving some behind.
+    const { ydoc, pmDoc } = docPair(THREE_BREAKS);
+    const from = THREE_FLAT.indexOf("charlie");
+    const r = resolveRel(anchor(ydoc, from, from + "charlie".length), pmDoc, ydoc);
+    expect(covered(pmDoc, r.from, r.to)).toBe('"charlie"');
+  });
+});
+
+describe("#1450: nested blocks take a different code path", () => {
+  // A break inside a list item or blockquote reaches findXmlTextInParallel's
+  // RECURSIVE branch rather than the textblock branch that was fixed. The
+  // accumulator is per-textblock, so the fix should hold — but that is a claim
+  // about a different branch, and it deserves its own case.
+  it("a hard break inside a list item resolves correctly", () => {
+    const { ydoc, pmDoc } = docPair("- alpha\\\n  bravo\n- second\n");
+    const r = resolveRel(anchor(ydoc, 0, "alpha\nbravo".length), pmDoc, ydoc);
+    expect(covered(pmDoc, r.from, r.to)).toContain('"alpha"+<hardBreak>+"bravo"');
+  });
+
+  it("a hard break inside a blockquote resolves correctly", () => {
+    const { ydoc, pmDoc } = docPair("> alpha\\\n> bravo\n");
+    const r = resolveRel(anchor(ydoc, 0, "alpha\nbravo".length), pmDoc, ydoc);
+    expect(covered(pmDoc, r.from, r.to)).toContain('"alpha"+<hardBreak>+"bravo"');
+  });
+});
+
+describe("#1450: replacing the resolved range", () => {
+  /**
+   * Replay the DELETE half of `applySuggestion` and a plain-text insertion.
+   *
+   * Honest about what this models: `.deleteRange()` does map to `tr.delete`,
+   * but `.insertContentAt()` does NOT simply map to `tr.insertText` — it
+   * HTML-parses the string first. So this asserts what a correct replacement
+   * over a correct range produces, which is what #1450 is about, and the final
+   * describe block covers the insertion defect separately.
+   */
+  function replaceRange(markdown: string, flatFrom: number, flatTo: number, text: string): string {
+    const { ydoc, pmDoc } = docPair(markdown);
+    const r = resolveRel(anchor(ydoc, flatFrom, flatTo), pmDoc, ydoc);
+    const state = EditorState.create({ doc: pmDoc });
+    const tr = state.tr.delete(r.from, r.to);
+    tr.insertText(text, r.from);
+    return structure(state.apply(tr).doc);
+  }
+
+  it("replacing a whole break-bearing paragraph leaves NO residue", () => {
+    expect(replaceRange(THREE_BREAKS, 0, THREE_FLAT.length, "REPLACED")).toBe(
+      'paragraph("REPLACED")',
+    );
+  });
+
+  it("the issue's own five-break shape comes back clean", () => {
+    const words = ["one", "two", "three", "four", "five", "six"];
+    const flat = words.join("\n");
+    expect(replaceRange(`${words.join("\\\n")}\n`, 0, flat.length, "CLEAN")).toBe(
+      'paragraph("CLEAN")',
+    );
+  });
+
+  it("a mid-paragraph replacement keeps the surrounding breaks intact", () => {
+    const from = THREE_FLAT.indexOf("charlie");
+    // Structural, so this would fail if the surrounding hard breaks had been
+    // flattened to newline characters — which a text-level assertion misses.
+    expect(replaceRange(THREE_BREAKS, from, from + 7, "CHARLIE")).toBe(
+      'paragraph("alpha"+<hardBreak>+"bravo"+<hardBreak>+"CHARLIE"+<hardBreak>+"delta")',
+    );
+  });
+});
+
+describe("#1477: what the SHIPPING insert path does (known defect, pinned)", () => {
+  /**
+   * `applySuggestion` passes `suggestedText` to `insertContentAt`, which
+   * HTML-parses the string rather than inserting it literally. That is a
+   * separate bug from #1450 and is tracked as #1477.
+   *
+   * These assert the CURRENT broken behaviour on purpose, following the same
+   * convention as `roundtrip-corpus.test.ts`: when #1477 is fixed these fail,
+   * which is the signal to update them — rather than the defect quietly
+   * surviving because nothing described it.
+   */
+  const build = (input: string) =>
+    createNodeFromContent(input, productionSchema(), { preserveWhitespace: "full" });
+
+  const asJson = (input: string) => JSON.stringify(build(input).toJSON());
+
+  it("collapses a newline to a space instead of making a hard break", () => {
+    // The realistic case: textSnapshot renders every hard break as "\n", so a
+    // suggestion over a break-bearing paragraph normally contains newlines.
+    expect(asJson("one\ntwo")).toBe('[{"type":"text","text":"one two"}]');
+    // Not a preserveWhitespace problem — the other setting collapses too.
+    const loose = createNodeFromContent("one\ntwo", productionSchema(), {
+      preserveWhitespace: true,
+    });
+    expect(JSON.stringify(loose.toJSON())).toBe('[{"type":"text","text":"one two"}]');
+  });
+
+  it("parses markup in the suggestion instead of inserting it literally", () => {
+    // A suggestion that merely MENTIONS a tag splits the paragraph in two.
+    expect(asJson("use <div> for layout")).toContain('"type":"paragraph"');
+    // ...and inline tags become real marks.
+    expect(asJson("<b>bold</b> text")).toContain('"marks":[{"type":"bold"}]');
+    // ...and entities are decoded.
+    expect(asJson("AT&amp;T")).toContain('"text":"AT&T"');
+  });
+
+  it("leaves ordinary prose alone (the reason this went unnoticed)", () => {
+    expect(asJson("plain replacement")).toBe('[{"type":"text","text":"plain replacement"}]');
+    expect(asJson("a < b && c > d")).toBe('[{"type":"text","text":"a < b && c > d"}]');
+  });
+});
+
+describe("#1450: the schema assumption the fix rests on", () => {
+  it("hardBreak is the only inline non-text node in the production schema", () => {
+    // The fix counts every non-text inline child as one position, which is
+    // right for any inline leaf. `textblockFlatLength` counts ONLY hardBreak
+    // and the server charges a separator plus nested length for a non-leaf, so
+    // a second shape would put three conventions in play. The runtime warn in
+    // `findXmlTextInParallel` is the other half of this guard.
+    const schema = productionSchema();
+    const inlineLeaves = Object.values(schema.nodes)
+      .filter((t) => t.isInline && !t.isText)
+      .map((t) => t.name)
+      .sort();
+    expect(inlineLeaves).toEqual(["hardBreak"]);
+  });
+});


### PR DESCRIPTION
Closes #1450, closes #1459 — **one defect, two reports**. #1459 named the function; #1450 was its user-visible consequence.

## The bug

`findXmlTextInParallel` (`src/client/positions.ts`) converts a Yjs `RelativePosition` back to a ProseMirror position by walking a textblock's Y children, and advanced its accumulator **only** for `Y.XmlText` children. A hard break is a *sibling* `Y.XmlElement` — it contributes no characters to that projection but occupies exactly one PM position. Every annotation endpoint in a paragraph with breaks therefore resolved one position early per preceding break.

`applySuggestion` deletes `[from, to)` then inserts at `from`, so this corrupted documents through the primary review action, with no error and no toast:

```
I had to go find it myself.self.
```

**The reproduction found more than the issue reported: both endpoints drift, not just `to`.** A range over `charlie` in a three-break paragraph resolved as `o\ncharl` — shifted back two at *both* ends. So a mid-paragraph accept also *eats* text ahead of the range, it does not merely leave some behind.

#1450 guessed at `toString()` vs `toDelta()`. The real mechanism is adjacent but different — the sibling-element walk — which is why that lead didn't close it.

## The fix

One line, plus a runtime warn for any non-`hardBreak` element. That guard is not defensive padding: the server's `directChildSpans` charges a *separator plus nested length* for such a shape, so a third element type would put three conventions in play, and this reader is the one that would fail silently. A test pins `hardBreak` as the only inline leaf in the schema.

## Tests

Real `Y.Doc` via `loadMarkdown`, real PM node via the production schema. **The existing coordinate tests mock the PM node, which is exactly why they couldn't see this** — a mock written from the same misunderstanding as the code agrees with the code.

Two deliberate choices:

- **Assertions are structural, not `textBetween()`.** That projection renders a `hardBreak` and a literal newline identically, so a text-level assertion passes just as happily against a document whose breaks have been flattened — which is a real thing that happens (see below).
- **Every resolve asserts `method === "rel"`.** Without it, the assertions are satisfiable by the flat fallback, which never had the bug; deleting the entire CRDT branch would have left the suite green.

Coverage includes the recursive branch (a break inside a list item and a blockquote), which is different code from the textblock branch that was fixed.

**Negative control, run explicitly:** reverting the increment to `0` fails 8 of 13, while the positive control, the rel-path check and the schema check stay green — so the controls are insensitive to the fix, as controls should be.

`npm test` 471/471 files via the pre-push hook, `cargo test` green, typecheck clean (1325 files, 0 errors).

## Found by review, filed not fixed: #1477

The *insert* half of the same action is independently broken. `insertContentAt` HTML-parses its string argument and collapses newlines. Measured against the production schema:

| `suggestedText` | inserted |
|---|---|
| `one\ntwo` | `"one two"` — newline becomes a **space** |
| `use <div> for layout` | text + a **paragraph node**, splitting the block |
| `<b>bold</b> text` | text with a **bold mark** |
| `AT&amp;T` | `AT&T` |

Undo restores `textSnapshot` through the same call, so it cannot restore hard breaks even with a correct range. Tracked as #1477 and **pinned by tests in this PR** asserting the current broken behaviour, following `roundtrip-corpus.test.ts`'s known-defect convention — when #1477 is fixed those tests fail, which is the signal to update them.

Kept out of this PR deliberately: it is a different fix in different code, and bundling it would let either change hide a regression in the other.

## Review notes

Two adversarial reviews ran before this was committed, and they **disagreed** on whether a break-aligned `from` now resolves correctly. Settling it: the endpoint is snapped forward by the *server's* `assoc: 0` fallback, which deliberately refuses to anchor on a break — so the CRDT path is self-consistent with the server, and the flat fallback is the one that differs. That divergence is pre-existing and was previously *masked* by this very bug (the under-count happened to cancel it). It is out of scope here and worth its own issue.

One reviewer's specific measurements for the insert path were wrong; the numbers above are re-derived independently and the corrected ones are what I filed.
