### PR TITLE
fix(scratchpad): scope crash recovery to the installation, not the origin

### DIFF
--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -151,7 +151,10 @@ onDestroy(() => yjsSync.destroy());
 
 // #864: persist unsaved scratchpad content for recovery + warn before losing
 // it. Logic lives in the hook to keep App.svelte minimal.
-const scratchpadPersistence = createScratchpadPersistence(() => yjsSync.tabs);
+const scratchpadPersistence = createScratchpadPersistence(
+  () => yjsSync.tabs,
+  () => yjsSync.installId,
+);
 onDestroy(() => scratchpadPersistence.destroy());
 
 // #1116: license gate (ADR-040). Polls /api/license/status; on any

--- a/src/client/hooks/useScratchpadPersistence.svelte.ts
+++ b/src/client/hooks/useScratchpadPersistence.svelte.ts
@@ -6,10 +6,10 @@
  * close warning, so content is lost on app close / tab close. This hook:
  *
  *  1. Observes each open scratchpad tab's Y.Doc `update` event and persists its
- *     plain-text content to localStorage (debounced) keyed by the scratchpad
- *     UUID — NOT by docHash. All scratchpads collapse to one docHash, so keying
- *     by hash would let concurrent scratchpads overwrite each other's recovery
- *     content.
+ *     plain-text content to localStorage (debounced) keyed by install id plus
+ *     the scratchpad UUID — NOT by docHash. All scratchpads collapse to one
+ *     docHash, so keying by hash would let concurrent scratchpads overwrite each
+ *     other's recovery content; the install segment is #1387.
  *  2. Restores the most-recently-persisted unsaved scratchpad content into a
  *     freshly-opened scratchpad (each Ctrl+N mints a new UUID, so recovery
  *     targets the latest persisted text rather than an exact UUID match).
@@ -30,13 +30,71 @@ import { isScratchpadPath, scratchpadUuidFromPath } from "../../shared/paths.js"
 import type { OpenTab } from "../types.js";
 import { type Debounced, debounce } from "../utils/debounce.js";
 
-/** localStorage key for a scratchpad's persisted text, keyed by UUID. */
-export function scratchpadStorageKey(uuid: string): string {
-  return `tandem:scratchpad:${uuid}`;
+/**
+ * localStorage key for a scratchpad's persisted text.
+ *
+ * Keyed by INSTALL as well as UUID (#1387). Every Tandem server on a machine
+ * shares one browser origin, so a key carrying only the UUID is visible to all
+ * of them — and since a fresh scratchpad has no key of its own, the
+ * latest-pointer fallback below would restore one server's content into
+ * another's document. Scoping by install makes that lookup miss, which is the
+ * whole fix; see `utils/install-id.ts` for why the server's session-store path
+ * is the right discriminator and `generationId` is not.
+ */
+export function scratchpadStorageKey(installId: string, uuid: string): string {
+  return `tandem:scratchpad:${installId}:${uuid}`;
 }
 
-/** Pointer to the UUID of the most recently persisted unsaved scratchpad. */
-const SCRATCHPAD_LATEST_KEY = "tandem:scratchpad:latest";
+/**
+ * Pointer to the UUID of the most recently persisted unsaved scratchpad, per
+ * install. Must be install-scoped for the same reason as the content key — a
+ * global pointer would send every install to the same content.
+ *
+ * The `tandem:scratchpad:` prefix is load-bearing beyond tidiness: the E2E
+ * cleanups clear recovery by prefix match, so keeping it means that clearing
+ * still reaches both key kinds, for every install.
+ */
+function scratchpadLatestKey(installId: string): string {
+  return `tandem:scratchpad:${installId}:latest`;
+}
+
+/**
+ * Delete the pre-#1387 unscoped keys (`tandem:scratchpad:<uuid>` and
+ * `tandem:scratchpad:latest`) once, without reading them.
+ *
+ * Nothing addresses those keys any more, so left alone they sit in the user's
+ * browser forever holding document text — and it is precisely the text that
+ * crossed installs, so "forever" is the wrong retention for it.
+ *
+ * Deliberately a purge and not a migration. Adopting a legacy value would have
+ * to guess which install wrote it, and the whole class of gated read-throughs
+ * was rejected on the plan: the gating condition is not client-detectable, so
+ * every variant fails open on a foreign install's content. The cost is one
+ * release's worth of unsaved scratchpad text for someone upgrading mid-edit —
+ * already the accepted cost of not reading these at all. This only makes the
+ * loss immediate instead of leaving the content behind to be lost silently.
+ *
+ * The discriminator is segment count: a scoped key is
+ * `tandem:scratchpad:<install>:<uuid|latest>` (four segments) and neither an
+ * install id nor a UUID contains a colon, so exactly three segments means
+ * legacy.
+ */
+function purgeLegacyScratchpadKeys(): void {
+  try {
+    const doomed: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key === null) continue;
+      if (!key.startsWith("tandem:scratchpad:")) continue;
+      if (key.split(":").length === 3) doomed.push(key);
+    }
+    // Collected first: removing during the walk reindexes localStorage under
+    // the loop and would skip every other match.
+    for (const key of doomed) localStorage.removeItem(key);
+  } catch {
+    // ignore — storage-disabled browsers (CLAUDE.md gotcha)
+  }
+}
 
 const PERSIST_DEBOUNCE_MS = 500;
 
@@ -162,8 +220,17 @@ function removeStorage(key: string): void {
  *
  * @param getTabs Reactive accessor for the current open tabs. The hook diffs
  *   this on every change to attach/detach Y.Doc observers per scratchpad.
+ * @param getInstallId Accessor for the connected server's install id, or `null`
+ *   before `/api/info` has answered. Injected rather than read from module
+ *   state so the cross-install behaviour is testable without a live connection.
+ *   **Persistence and restore are both suppressed while this is `null`** —
+ *   fail closed. A fail-open default here would restore under whatever key
+ *   happened to be reachable, which is the #1387 bug with extra steps.
  */
-export function createScratchpadPersistence(getTabs: () => OpenTab[]): ScratchpadPersistence {
+export function createScratchpadPersistence(
+  getTabs: () => OpenTab[],
+  getInstallId: () => string | null,
+): ScratchpadPersistence {
   // Tracked scratchpad rooms keyed by UUID. Non-reactive — observers drive
   // persistence directly; the unsaved-content map below carries reactive state.
   const entries = new Map<string, ScratchpadEntry>();
@@ -173,21 +240,26 @@ export function createScratchpadPersistence(getTabs: () => OpenTab[]): Scratchpa
 
   const anyUnsaved = () => Object.values(unsaved).some(Boolean);
 
+  purgeLegacyScratchpadKeys();
+
   const persistEntry = (entry: ScratchpadEntry) => {
+    const installId = getInstallId();
+    if (installId === null) return; // fail closed — see getInstallId
+    const latestKey = scratchpadLatestKey(installId);
     const fragment = entry.ydoc.getXmlFragment("default");
     const blocks = extractFragmentBlocks(fragment);
-    const key = scratchpadStorageKey(entry.uuid);
+    const key = scratchpadStorageKey(installId, entry.uuid);
     if (blocks.join("").length === 0) {
       // Empty scratchpad — clear any stale recovery so we don't warn on close.
       removeStorage(key);
-      if (readStorage(SCRATCHPAD_LATEST_KEY) === entry.uuid) {
-        removeStorage(SCRATCHPAD_LATEST_KEY);
+      if (readStorage(latestKey) === entry.uuid) {
+        removeStorage(latestKey);
       }
       unsaved[entry.uuid] = false;
       return;
     }
     writeStorage(key, encodeScratchpadBlocks(blocks));
-    writeStorage(SCRATCHPAD_LATEST_KEY, entry.uuid);
+    writeStorage(latestKey, entry.uuid);
     unsaved[entry.uuid] = true;
   };
 
@@ -228,6 +300,9 @@ export function createScratchpadPersistence(getTabs: () => OpenTab[]): Scratchpa
   };
 
   const restoreInto = (entry: ScratchpadEntry) => {
+    const installId = getInstallId();
+    if (installId === null) return; // fail closed — see getInstallId
+
     const fragment = entry.ydoc.getXmlFragment("default");
     // Only restore into a genuinely empty scratchpad (provider has synced, so
     // a non-empty fragment means real server content we must not clobber).
@@ -245,11 +320,11 @@ export function createScratchpadPersistence(getTabs: () => OpenTab[]): Scratchpa
     // invoking `restoreInto`, so at this point `entries.size === 1` means
     // "this is the only open scratchpad" regardless of caller timing.
     let sourceUuid = entry.uuid;
-    let stored = readStorage(scratchpadStorageKey(sourceUuid));
+    let stored = readStorage(scratchpadStorageKey(installId, sourceUuid));
     if (stored === null && entries.size === 1) {
-      const latest = readStorage(SCRATCHPAD_LATEST_KEY);
+      const latest = readStorage(scratchpadLatestKey(installId));
       if (latest && latest !== entry.uuid) {
-        stored = readStorage(scratchpadStorageKey(latest));
+        stored = readStorage(scratchpadStorageKey(installId, latest));
         sourceUuid = latest;
       }
     }
@@ -280,9 +355,9 @@ export function createScratchpadPersistence(getTabs: () => OpenTab[]): Scratchpa
 
     // Re-point latest at THIS scratchpad's UUID and persist under it so the
     // recovered content survives a subsequent reload of this room.
-    writeStorage(scratchpadStorageKey(entry.uuid), stored);
-    writeStorage(SCRATCHPAD_LATEST_KEY, entry.uuid);
-    if (sourceUuid !== entry.uuid) removeStorage(scratchpadStorageKey(sourceUuid));
+    writeStorage(scratchpadStorageKey(installId, entry.uuid), stored);
+    writeStorage(scratchpadLatestKey(installId), entry.uuid);
+    if (sourceUuid !== entry.uuid) removeStorage(scratchpadStorageKey(installId, sourceUuid));
     unsaved[entry.uuid] = true;
   };
 
@@ -300,8 +375,16 @@ export function createScratchpadPersistence(getTabs: () => OpenTab[]): Scratchpa
   };
 
   const clearUnsaved = (uuid: string) => {
-    removeStorage(scratchpadStorageKey(uuid));
-    if (readStorage(SCRATCHPAD_LATEST_KEY) === uuid) removeStorage(SCRATCHPAD_LATEST_KEY);
+    // Unlike persist/restore this does NOT fail closed on a null install id:
+    // the reactive flag must still clear so a confirmed close stops warning.
+    // Only the storage removal is skipped, and it is re-reachable — the next
+    // persist under a known install id rewrites the key.
+    const installId = getInstallId();
+    if (installId !== null) {
+      removeStorage(scratchpadStorageKey(installId, uuid));
+      const latestKey = scratchpadLatestKey(installId);
+      if (readStorage(latestKey) === uuid) removeStorage(latestKey);
+    }
     // Drop any pending debounced write so it can't re-persist after discard.
     entries.get(uuid)?.persist.cancel();
     unsaved[uuid] = false;

--- a/src/client/hooks/useScratchpadPersistence.svelte.ts
+++ b/src/client/hooks/useScratchpadPersistence.svelte.ts
@@ -33,9 +33,10 @@ import { type Debounced, debounce } from "../utils/debounce.js";
 /**
  * localStorage key for a scratchpad's persisted text.
  *
- * Keyed by INSTALL as well as UUID (#1387). Every Tandem server on a machine
- * shares one browser origin, so a key carrying only the UUID is visible to all
- * of them — and since a fresh scratchpad has no key of its own, the
+ * Keyed by INSTALL as well as UUID (#1387). Successive Tandem servers are
+ * reached at the same host:port, which is one `localStorage` bucket, so a key
+ * carrying only the UUID is readable by all of them in turn — and since a
+ * fresh scratchpad has no key of its own, the
  * latest-pointer fallback below would restore one server's content into
  * another's document. Scoping by install makes that lookup miss, which is the
  * whole fix; see `utils/install-id.ts` for why the server's session-store path
@@ -60,7 +61,7 @@ function scratchpadLatestKey(installId: string): string {
 
 /**
  * Delete the pre-#1387 unscoped keys (`tandem:scratchpad:<uuid>` and
- * `tandem:scratchpad:latest`) once, without reading them.
+ * `tandem:scratchpad:latest`) on hook creation, without reading them.
  *
  * Nothing addresses those keys any more, so left alone they sit in the user's
  * browser forever holding document text — and it is precisely the text that
@@ -76,8 +77,21 @@ function scratchpadLatestKey(installId: string): string {
  *
  * The discriminator is segment count: a scoped key is
  * `tandem:scratchpad:<install>:<uuid|latest>` (four segments) and neither an
- * install id nor a UUID contains a colon, so exactly three segments means
- * legacy.
+ * install id (8 hex chars) nor a `randomUUID()` contains a colon, so exactly
+ * three segments means legacy. The `tandem:scratchpad:` prefix check is the
+ * other half of the guard and is load-bearing: `tandem:headingCollapse:<docId>`
+ * is a real neighbour with the same segment count, and sweeping it would wipe
+ * every user's heading-collapse state on every start.
+ *
+ * Scoped keys belonging to an install this browser no longer talks to are
+ * deliberately NOT swept. Two installs alternate legitimately on one machine —
+ * the desktop sidecar and a dev server take turns on the same port — so
+ * "not the current install" does not mean "dead", and deleting on that basis
+ * would destroy a real draft. Growth is bounded in practice because the paths
+ * that vary are fixed, not per-run (`playwright.config.ts` pins
+ * `/tmp/tandem-e2e-data`, design baselines pin their own); a user accumulates
+ * one or two ids for life, and a new one is minted only by something as rare as
+ * an app-data root move.
  */
 function purgeLegacyScratchpadKeys(): void {
   try {
@@ -92,7 +106,9 @@ function purgeLegacyScratchpadKeys(): void {
     // the loop and would skip every other match.
     for (const key of doomed) localStorage.removeItem(key);
   } catch {
-    // ignore — storage-disabled browsers (CLAUDE.md gotcha)
+    // Ignore — storage-disabled browsers (CLAUDE.md gotcha). A SecurityError
+    // mid-loop leaves a PARTIAL purge rather than none; harmless, since this
+    // runs again on the next hook creation and nothing writes these keys.
   }
 }
 
@@ -223,9 +239,23 @@ function removeStorage(key: string): void {
  * @param getInstallId Accessor for the connected server's install id, or `null`
  *   before `/api/info` has answered. Injected rather than read from module
  *   state so the cross-install behaviour is testable without a live connection.
- *   **Persistence and restore are both suppressed while this is `null`** —
- *   fail closed. A fail-open default here would restore under whatever key
- *   happened to be reachable, which is the #1387 bug with extra steps.
+ *   **Storage is suppressed while this is `null`** — fail closed. A fail-open
+ *   default would restore under whatever key happened to be reachable, which is
+ *   the #1387 bug with extra steps.
+ *
+ *   Scoped deliberately to *storage*: the unsaved-content warning still fires
+ *   (see `persistEntry`), and `clearUnsaved` still clears its flag. Widening the
+ *   guard to those would trade a content leak for silent content loss.
+ *
+ *   Note the two suppressed paths recover differently. Persist retries on the
+ *   next debounced update, so a null window costs nothing once the id lands.
+ *   **Restore does not retry** — it runs once per attach (directly, or from a
+ *   one-shot `synced` listener), so a null read forfeits recovery for that tab's
+ *   whole lifetime. That asymmetry is tolerable only because the branch is
+ *   unreachable in production: `yjsSync` builds no provider until
+ *   `fetchServerIdentity` resolves, and that same response carries both the
+ *   generation id and `storagePath` (they share one `if (loopback)` block in
+ *   `server/mcp/routes/info.ts`). Split those two fields and this comes alive.
  */
 export function createScratchpadPersistence(
   getTabs: () => OpenTab[],
@@ -243,24 +273,35 @@ export function createScratchpadPersistence(
   purgeLegacyScratchpadKeys();
 
   const persistEntry = (entry: ScratchpadEntry) => {
-    const installId = getInstallId();
-    if (installId === null) return; // fail closed — see getInstallId
-    const latestKey = scratchpadLatestKey(installId);
     const fragment = entry.ydoc.getXmlFragment("default");
     const blocks = extractFragmentBlocks(fragment);
+    const hasContent = blocks.join("").length > 0;
+    // The warning flag tracks the DOCUMENT, not whether we managed to store it.
+    // It is set before the fail-closed return below and outside the empty/
+    // non-empty split, because the two questions are independent: "is there
+    // unsaved text here" is answered by the fragment alone. Deriving it from a
+    // successful write instead would mean content we could not persist closes
+    // with no prompt at all — the case where the warning matters MOST, since
+    // the recovery net is exactly what is missing. (The pre-existing storage
+    // wrappers swallow QuotaExceededError for the same reason: on a failed
+    // write the flag stays true and the user is warned.)
+    unsaved[entry.uuid] = hasContent;
+
+    const installId = getInstallId();
+    if (installId === null) return; // fail closed on STORAGE only — see getInstallId
+    const latestKey = scratchpadLatestKey(installId);
     const key = scratchpadStorageKey(installId, entry.uuid);
-    if (blocks.join("").length === 0) {
-      // Empty scratchpad — clear any stale recovery so we don't warn on close.
+    if (!hasContent) {
+      // Empty scratchpad — clear any stale recovery so a later open doesn't
+      // resurrect text the user deleted.
       removeStorage(key);
       if (readStorage(latestKey) === entry.uuid) {
         removeStorage(latestKey);
       }
-      unsaved[entry.uuid] = false;
       return;
     }
     writeStorage(key, encodeScratchpadBlocks(blocks));
     writeStorage(latestKey, entry.uuid);
-    unsaved[entry.uuid] = true;
   };
 
   const attach = (uuid: string, ydoc: Y.Doc, provider: HocuspocusProvider) => {
@@ -301,7 +342,17 @@ export function createScratchpadPersistence(
 
   const restoreInto = (entry: ScratchpadEntry) => {
     const installId = getInstallId();
-    if (installId === null) return; // fail closed — see getInstallId
+    if (installId === null) {
+      // Fail closed — see getInstallId. Warn rather than return silently: this
+      // is one-shot, so the user simply sees an empty scratchpad and cannot
+      // distinguish "nothing to recover" from "recovery was skipped", and a
+      // developer chasing it has no artifact but an unread localStorage key.
+      // Same reasoning as `buildDecorations`' CRDT-fallback warning.
+      console.warn(
+        "[Tandem] Scratchpad recovery skipped: install id unknown (/api/info reported no storagePath). This does not retry for this scratchpad.",
+      );
+      return;
+    }
 
     const fragment = entry.ydoc.getXmlFragment("default");
     // Only restore into a genuinely empty scratchpad (provider has synced, so
@@ -377,8 +428,17 @@ export function createScratchpadPersistence(
   const clearUnsaved = (uuid: string) => {
     // Unlike persist/restore this does NOT fail closed on a null install id:
     // the reactive flag must still clear so a confirmed close stops warning.
-    // Only the storage removal is skipped, and it is re-reachable — the next
-    // persist under a known install id rewrites the key.
+    // Guarding it too would latch `unsaved[uuid]` true forever — the confirm
+    // dialog would re-fire on every close attempt and `beforeunload` would warn
+    // permanently, since detach() runs right after and nothing recomputes it.
+    //
+    // The storage removal IS skipped, and there is NO retry to recover it: the
+    // sole caller is the confirmed-close path, after which detach() drops the
+    // entry and each new scratchpad mints a fresh UUID. A skipped removal
+    // therefore leaves both the content key and the `latest` pointer behind,
+    // and the fallback below can restore the very text the user confirmed
+    // discarding. Acceptable only because the null branch is unreachable in
+    // production (see getInstallId) — not because it self-heals.
     const installId = getInstallId();
     if (installId !== null) {
       removeStorage(scratchpadStorageKey(installId, uuid));

--- a/src/client/hooks/useScratchpadPersistence.svelte.ts
+++ b/src/client/hooks/useScratchpadPersistence.svelte.ts
@@ -366,6 +366,22 @@ export function createScratchpadPersistence(
     ydoc.on("update", entry.updateHandler);
     entries.set(uuid, entry);
 
+    // Prime the lock HERE, synchronously, rather than leaving it to whichever
+    // of restoreInto/persistEntry/detach's flush happens to call
+    // resolveInstallId first. attach() always runs while the live id still
+    // genuinely corresponds to this entry's own room — a rebuild's install-id
+    // flip and its teardownAllTabs() (which destroys this entry) happen
+    // together inside one synchronous `rebuild()` call, so they can never
+    // straddle a still-live entry the way a LATER first-lock could. Without
+    // this, an entry whose provider hasn't synced yet defers restoreInto (and
+    // so its lock attempt) behind the one-shot `synced` listener; if a
+    // rebuild's detach-triggered flush fires first, THAT becomes the entry's
+    // first resolution and locks onto the NEW server's id instead of the one
+    // this room was actually opened against. A no-op when the id isn't known
+    // yet (resolveInstallId leaves it unlocked, matching the documented
+    // null-retry behavior on `getInstallId` above).
+    resolveInstallId(entry);
+
     // Restore must wait until the provider has synced the room's authoritative
     // state — restoring before sync races the incoming server content and the
     // CRDT merge would DUPLICATE it (server content + our injected paragraphs).

--- a/src/client/hooks/useScratchpadPersistence.svelte.ts
+++ b/src/client/hooks/useScratchpadPersistence.svelte.ts
@@ -54,9 +54,15 @@ export function scratchpadStorageKey(installId: string, uuid: string): string {
  * The `tandem:scratchpad:` prefix is load-bearing beyond tidiness: the E2E
  * cleanups clear recovery by prefix match, so keeping it means that clearing
  * still reaches both key kinds, for every install.
+ *
+ * Delegates to `scratchpadStorageKey` rather than repeating its template —
+ * `"latest"` can never collide with a real scratchpad UUID, and hand-writing
+ * the same prefix twice would let a future format change (e.g. a version
+ * segment) update one and not the other, desyncing the content key from its
+ * own pointer.
  */
 function scratchpadLatestKey(installId: string): string {
-  return `tandem:scratchpad:${installId}:latest`;
+  return scratchpadStorageKey(installId, "latest");
 }
 
 /**
@@ -191,6 +197,11 @@ interface ScratchpadEntry {
   /** One-shot `synced` listener used to defer restore until after initial sync. */
   syncedHandler: (() => void) | null;
   persist: Debounced<[]>;
+  /**
+   * The install id this entry's content belongs to, locked in the first time
+   * `resolveInstallId` observes a non-null value — see that function for why.
+   */
+  lockedInstallId: string | null;
 }
 
 export interface ScratchpadPersistence {
@@ -272,6 +283,39 @@ export function createScratchpadPersistence(
 
   purgeLegacyScratchpadKeys();
 
+  /**
+   * Resolve the install id an entry's storage writes belong to, and lock it
+   * onto the entry the first time it's non-null.
+   *
+   * Locking (not a live re-read every call) closes a leak the live-read design
+   * left open: `getInstallId()` reflects the CURRENTLY connected server, but a
+   * generation-rebuild swaps that value BEFORE tearing tabs down — the
+   * scheduler's `fetchGenerationId` (aliased to `fetchServerIdentity`, which
+   * updates the module-level install id) resolves first, then `rebuild()`
+   * calls `teardownAllTabs()`. `detach()` flushes each entry's pending
+   * debounced write as part of that teardown, so an unflushed keystroke typed
+   * in the moment before a same-port server swap (dev server replaced by the
+   * E2E server `npm run test:e2e` boots on :3478/:3479, for instance) would
+   * otherwise be persisted under the NEW server's install id — content
+   * misattributed to a foreign installation, the same leak class #1387 exists
+   * to close, reopened through the teardown path instead of the initial-open
+   * one.
+   *
+   * Once locked, a later live change is deliberately ignored: the only way the
+   * connected install id changes during an entry's life IS that rebuild path,
+   * which destroys every entry shortly after via the tabs-diff effect, so a
+   * locked entry never legitimately needs to follow it. Locking still starts
+   * as null and keeps re-reading live until a value lands — that's what lets
+   * persistence recover once `/api/info` answers after a tab attached before
+   * it did (documented on `getInstallId` above).
+   */
+  const resolveInstallId = (entry: ScratchpadEntry): string | null => {
+    if (entry.lockedInstallId !== null) return entry.lockedInstallId;
+    const id = getInstallId();
+    if (id !== null) entry.lockedInstallId = id;
+    return id;
+  };
+
   const persistEntry = (entry: ScratchpadEntry) => {
     const fragment = entry.ydoc.getXmlFragment("default");
     const blocks = extractFragmentBlocks(fragment);
@@ -287,7 +331,7 @@ export function createScratchpadPersistence(
     // write the flag stays true and the user is warned.)
     unsaved[entry.uuid] = hasContent;
 
-    const installId = getInstallId();
+    const installId = resolveInstallId(entry);
     if (installId === null) return; // fail closed on STORAGE only — see getInstallId
     const latestKey = scratchpadLatestKey(installId);
     const key = scratchpadStorageKey(installId, entry.uuid);
@@ -313,6 +357,7 @@ export function createScratchpadPersistence(
       updateHandler: () => {},
       syncedHandler: null,
       persist: debounce(() => {}, PERSIST_DEBOUNCE_MS),
+      lockedInstallId: null,
     };
     entry.persist = debounce(() => persistEntry(entry), PERSIST_DEBOUNCE_MS);
     // Observe the Y.Doc `update` event (NOT a content-reading $effect, which
@@ -341,7 +386,7 @@ export function createScratchpadPersistence(
   };
 
   const restoreInto = (entry: ScratchpadEntry) => {
-    const installId = getInstallId();
+    const installId = resolveInstallId(entry);
     if (installId === null) {
       // Fail closed — see getInstallId. Warn rather than return silently: this
       // is one-shot, so the user simply sees an empty scratchpad and cannot
@@ -439,14 +484,21 @@ export function createScratchpadPersistence(
     // and the fallback below can restore the very text the user confirmed
     // discarding. Acceptable only because the null branch is unreachable in
     // production (see getInstallId) — not because it self-heals.
-    const installId = getInstallId();
+    //
+    // Prefers the entry's locked id (see resolveInstallId) over a live read:
+    // content was persisted under whichever id was locked when it was written,
+    // and a live read could have already moved on to a different server's id
+    // in the same rebuild-teardown window `resolveInstallId` guards against —
+    // targeting the wrong key here would leave the real content key behind.
+    const entry = entries.get(uuid);
+    const installId = entry?.lockedInstallId ?? getInstallId();
     if (installId !== null) {
       removeStorage(scratchpadStorageKey(installId, uuid));
       const latestKey = scratchpadLatestKey(installId);
       if (readStorage(latestKey) === uuid) removeStorage(latestKey);
     }
     // Drop any pending debounced write so it can't re-persist after discard.
-    entries.get(uuid)?.persist.cancel();
+    entry?.persist.cancel();
     unsaved[uuid] = false;
   };
 

--- a/src/client/hooks/yjsSync.svelte.ts
+++ b/src/client/hooks/yjsSync.svelte.ts
@@ -191,8 +191,8 @@ export function createYjsSync(opts?: {
    * See `installIdFromStoragePath` for what this is and why it is derived the
    * way it is. Two things true only here: unlike `generationId` it is NOT an
    * auth token and never travels to the server, and it is a plain `let` rather
-   * than `$state` because its only consumer reads it inside a callback at
-   * attach time, never in a template.
+   * than `$state` because its consumer reads it from callbacks (debounced
+   * persist, restore-on-attach, clear-on-close), never in a template.
    */
   let installId: string | null = null;
   // Last activation epoch applied from the server. Lets handleDocumentList tell a
@@ -296,16 +296,37 @@ export function createYjsSync(opts?: {
       });
       // A non-ok response returns before the assignment below, so a transient
       // blip preserves the previous install id rather than disabling recovery.
+      // The poll loop already surfaces unreachability as a "disconnected"
+      // banner, so there is nothing to add here.
       if (!res.ok) return null;
       const body = (await res.json()) as AppInfoData;
-      // `storagePath` is loopback-only, so a response without it leaves the id
-      // null — and every consumer of `installId` fails closed on that.
-      installId =
+      // Note the asymmetry with the line above, which is deliberate but reads
+      // backwards at first: an unreachable server KEEPS the old id, while a
+      // successful response that has stopped reporting `storagePath` REPLACES
+      // it with null. `storagePath` is loopback-only, so for a client that
+      // always calls 127.0.0.1 its disappearance means something is genuinely
+      // wrong — and unlike a blip it is invisible, since a 200 raises no
+      // banner. Hence the warning: this silently disables scratchpad recovery,
+      // and restore never retries.
+      const nextInstallId =
         typeof body.storagePath === "string" && body.storagePath.length > 0
           ? installIdFromStoragePath(body.storagePath)
           : null;
+      if (nextInstallId === null && installId !== null) {
+        console.warn(
+          `[Tandem] ${API_INFO} stopped reporting storagePath — scratchpad crash recovery is now disabled.`,
+        );
+      }
+      installId = nextInstallId;
       return body.generationId ?? null;
-    } catch {
+    } catch (err) {
+      // A SyntaxError here means the server answered with something that is not
+      // JSON — a broken server, not an unreachable one, and the banner cannot
+      // tell the two apart. Everything else (abort/timeout, network) is the
+      // routine case the banner already covers.
+      if ((err as Error | undefined)?.name === "SyntaxError") {
+        console.warn(`[Tandem] ${API_INFO} returned a non-JSON body`, err);
+      }
       return null;
     }
   };

--- a/src/client/hooks/yjsSync.svelte.ts
+++ b/src/client/hooks/yjsSync.svelte.ts
@@ -21,7 +21,8 @@ import {
 } from "../../shared/constants";
 import { sanitizeAnnotation } from "../../shared/sanitize";
 import type { Annotation, ClaudeAwareness } from "../../shared/types";
-import type { DocListEntry, OpenTab } from "../types";
+import type { AppInfoData, DocListEntry, OpenTab } from "../types";
+import { installIdFromStoragePath } from "../utils/install-id.js";
 import { createRebuildScheduler } from "./rebuild-scheduler.js";
 import { resolveActiveTabId } from "./tab-reconcile.js";
 import type { SidecarRetryStrategy } from "./useTandemSettings";
@@ -83,6 +84,8 @@ export interface YjsSyncState {
   readonly connectionStatus: ConnectionStatus;
   readonly reconnectAttempts: number;
   readonly disconnectedSince: number | null;
+  /** Identifies the connected INSTALLATION (not the run); null until `/api/info` answers. */
+  readonly installId: string | null;
   readonly annotations: Annotation[];
   readonly claudeStatus: string | null;
   readonly claudeActive: boolean;
@@ -136,7 +139,7 @@ export function createYjsSync(opts?: {
    * built providers / the next rebuild — in-flight sockets are not re-wired.
    * Lazy by design: the getter may close over state initialized AFTER this
    * factory is called (e.g. App.svelte builds settings below createYjsSync), and
-   * it is only ever invoked after `await fetchGenerationId()`, so the closed-over
+   * it is only ever invoked after `await fetchServerIdentity()`, so the closed-over
    * binding is live by call time.
    */
   getRetryStrategy?: () => SidecarRetryStrategy;
@@ -184,6 +187,14 @@ export function createYjsSync(opts?: {
    * state can merge back.
    */
   let generationId: string | null = null;
+  /**
+   * See `installIdFromStoragePath` for what this is and why it is derived the
+   * way it is. Two things true only here: unlike `generationId` it is NOT an
+   * auth token and never travels to the server, and it is a plain `let` rather
+   * than `$state` because its only consumer reads it inside a callback at
+   * attach time, never in a template.
+   */
+  let installId: string | null = null;
   // Last activation epoch applied from the server. Lets handleDocumentList tell a
   // genuine (re)activation (epoch advanced) from a stale re-broadcast of an
   // unchanged active id (epoch same), so the latter never clobbers a local tab
@@ -261,16 +272,38 @@ export function createYjsSync(opts?: {
   // ---------- Generation fetch + full-rebuild plumbing (stale-tab resync) ----------
   const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-  /** Fetch the current server generation id, or null if unreachable/absent.
-   *  Timeboxed: a half-open server (accepts TCP, never responds) must not
-   *  hang the connect/rebuild poll loops forever. */
-  const fetchGenerationId = async (): Promise<string | null> => {
+  /**
+   * Fetch the server's identity: returns the generation id (or null if
+   * unreachable/absent) and, as a side effect, refreshes `installId` from the
+   * SAME response — named for that rather than for the return value, because a
+   * caller who reads this as a pure probe and memoizes it would silently freeze
+   * the install id.
+   *
+   * One response for both is deliberate: two fetches could straddle a server
+   * swap and pair one server's generation with another's identity.
+   *
+   * Timeboxed: a half-open server (accepts TCP, never responds) must not hang
+   * the connect/rebuild poll loops forever.
+   *
+   * Deliberately does NOT reuse `fetchAppInfo` (`useAppInfo.ts`), which caches
+   * at module scope: the rebuild path exists precisely to observe a CHANGED
+   * generation, so a cached body would defeat stale-tab resync entirely.
+   */
+  const fetchServerIdentity = async (): Promise<string | null> => {
     try {
       const res = await fetch(`http://127.0.0.1:${DEFAULT_MCP_PORT}${API_INFO}`, {
         signal: AbortSignal.timeout(5000),
       });
+      // A non-ok response returns before the assignment below, so a transient
+      // blip preserves the previous install id rather than disabling recovery.
       if (!res.ok) return null;
-      const body = (await res.json()) as { generationId?: string | null };
+      const body = (await res.json()) as AppInfoData;
+      // `storagePath` is loopback-only, so a response without it leaves the id
+      // null — and every consumer of `installId` fails closed on that.
+      installId =
+        typeof body.storagePath === "string" && body.storagePath.length > 0
+          ? installIdFromStoragePath(body.storagePath)
+          : null;
       return body.generationId ?? null;
     } catch {
       return null;
@@ -315,7 +348,7 @@ export function createYjsSync(opts?: {
    */
   const scheduleRebuild = createRebuildScheduler({
     isDestroyed: () => destroyed,
-    fetchGenerationId,
+    fetchGenerationId: fetchServerIdentity,
     getPinnedGeneration: () => generationId,
     onGenerationUnchanged: () => {
       // Near-unreachable (/api/info and the gate disagreeing). Nothing to
@@ -603,7 +636,7 @@ export function createYjsSync(opts?: {
   // poll keeps running and bootstraps the moment the server answers.
   void (async () => {
     while (!destroyed) {
-      const gen = await fetchGenerationId();
+      const gen = await fetchServerIdentity();
       if (destroyed) return;
       if (gen) {
         startBootstrap(gen);
@@ -746,6 +779,10 @@ export function createYjsSync(opts?: {
   return {
     get tabs() {
       return tabsState;
+    },
+    /** See `installId` above — null until `/api/info` answers. */
+    get installId() {
+      return installId;
     },
     get activeTabId() {
       return activeTabIdState;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -130,9 +130,16 @@ export interface AppInfoData {
   /**
    * Loopback-only: identifies this server RUN. New on every boot — every
    * Hocuspocus provider pins it as its auth token so a Y.Doc that predates a
-   * restart is rejected before it can merge back. Null in stdio mode.
+   * restart is rejected before it can merge back. Undefined for non-loopback
+   * callers; stdio mode serves no `/api/info` at all, so the field is not
+   * "null in stdio" — it is unreachable there.
+   *
+   * Emitted in the SAME `if (loopback)` block as `storagePath`, and scratchpad
+   * recovery depends on that: the client only derives its install id once a
+   * generation id has bootstrapped it. `tests/server/info-route.test.ts` pins
+   * the two together.
    */
-  generationId?: string | null;
+  generationId?: string;
   /** Loopback-only: mtime of the auth token file in ms, or null if not yet created. */
   tokenRotatedAt?: number | null;
   /** Absolute path to CHANGELOG.md on the server host. Undefined if not found at startup. */

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -127,6 +127,12 @@ export interface AppInfoData {
   bindPort?: number;
   /** Loopback-only: absolute path to session storage directory. */
   storagePath?: string;
+  /**
+   * Loopback-only: identifies this server RUN. New on every boot — every
+   * Hocuspocus provider pins it as its auth token so a Y.Doc that predates a
+   * restart is rejected before it can merge back. Null in stdio mode.
+   */
+  generationId?: string | null;
   /** Loopback-only: mtime of the auth token file in ms, or null if not yet created. */
   tokenRotatedAt?: number | null;
   /** Absolute path to CHANGELOG.md on the server host. Undefined if not found at startup. */

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -138,8 +138,13 @@ export interface AppInfoData {
    * recovery depends on that: the client only derives its install id once a
    * generation id has bootstrapped it. `tests/server/info-route.test.ts` pins
    * the two together.
+   *
+   * `null`, not just absent, for a loopback caller: `info.ts` sets it to
+   * `deps.getGenerationId?.() ?? null` unconditionally inside the loopback
+   * branch, so a loopback response with no generation yet assigned still
+   * includes the field as `null` rather than omitting it.
    */
-  generationId?: string;
+  generationId?: string | null;
   /** Loopback-only: mtime of the auth token file in ms, or null if not yet created. */
   tokenRotatedAt?: number | null;
   /** Absolute path to CHANGELOG.md on the server host. Undefined if not found at startup. */

--- a/src/client/utils/install-id.ts
+++ b/src/client/utils/install-id.ts
@@ -1,0 +1,69 @@
+/**
+ * A stable, per-installation identifier for the connected server.
+ *
+ * Every Tandem server on a machine shares one browser origin
+ * (`127.0.0.1:5173` / `:3479`), so `localStorage` written while talking to one
+ * server is visible to every other. That is how #1387 leaks: scratchpad
+ * recovery keys were global to the origin, so a scratchpad opened on ANY server
+ * would restore content persisted while talking to a DIFFERENT one.
+ *
+ * The discriminator has to be stable across restarts — recovery exists to
+ * survive them — which rules out `generationId`, new on every boot. The
+ * server's session-store path (`storagePath` on `/api/info`) is one-to-one with
+ * its app-data root: stable per installation, and distinct for any server that
+ * sets `TANDEM_APP_DATA_DIR` (E2E, perf, design baselines, screenshots). It is
+ * already exposed, so this needs no new durable server state.
+ *
+ * Deliberately NOT derived from the auth token: `shared/auth/token-file.ts`
+ * resolves via `envPaths("tandem").data` directly and ignores
+ * `TANDEM_APP_DATA_DIR`, so a test server and the real server share one token
+ * file — it would collide in precisely the case this exists to separate.
+ *
+ * Client-side, not `shared/`, because the derivation exists only to let a
+ * browser tell two servers apart; nothing on the server needs it. If the server
+ * ever publishes an `installId` of its own, this module goes away rather than
+ * moving — the normalisation below exists only because the client is guessing
+ * how a path it did not produce is spelled.
+ */
+
+/**
+ * FNV-1a, 32-bit, hex. **Not a security boundary**: a collision degrades to the
+ * pre-#1387 behaviour (a cross-install restore), so this only needs to separate
+ * a handful of paths on one machine, not resist an adversary. A non-crypto hash
+ * also keeps this synchronous — `crypto.subtle` is async and would push a
+ * promise into the persistence hook's attach path for no benefit.
+ */
+function fnv1a32(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    // `Math.imul` rather than `*`: the 32-bit FNV prime overflows a float64
+    // mantissa, so plain multiplication silently loses low bits.
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+/**
+ * Derive the install id from a server's `storagePath`.
+ *
+ * Normalises separators, trailing separator and case first, because the same
+ * directory reaches us spelled differently depending on who resolved it:
+ * Windows APIs return backslashes and a drive letter whose case is not
+ * guaranteed, while a path that has been through `env-paths` or an env var may
+ * arrive with forward slashes. Two spellings of one directory MUST produce one
+ * id, or a restart would look like a different installation and silently drop
+ * recovery.
+ *
+ * The lowercase is unconditional, which differs from `doc-hash.ts`'s rule for
+ * the same problem (it lowercases only on Windows, because POSIX paths are
+ * case-sensitive). The cost here is that two POSIX directories differing only
+ * in case share an id — a collision, which by the note above degrades to
+ * pre-#1387 behaviour rather than breaking anything. Worth it to avoid
+ * threading a platform flag into the browser for a case that needs two
+ * same-named-but-differently-cased Tandem installs to matter.
+ */
+export function installIdFromStoragePath(storagePath: string): string {
+  const normalized = storagePath.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+  return fnv1a32(normalized);
+}

--- a/src/client/utils/install-id.ts
+++ b/src/client/utils/install-id.ts
@@ -1,21 +1,32 @@
 /**
  * A stable, per-installation identifier for the connected server.
  *
- * Every Tandem server on a machine shares one browser origin
- * (`127.0.0.1:5173` / `:3479`), so `localStorage` written while talking to one
- * server is visible to every other. That is how #1387 leaks: scratchpad
- * recovery keys were global to the origin, so a scratchpad opened on ANY server
- * would restore content persisted while talking to a DIFFERENT one.
+ * Successive Tandem servers are reached at the SAME host:port — an E2E server,
+ * a dev server and the real one take turns on `127.0.0.1:5173` / `:3479` — and
+ * one host:port is one `localStorage` bucket. So state written while talking to
+ * one server is read back while talking to the next. That is how #1387 leaks:
+ * scratchpad recovery keys were global to the bucket, so a scratchpad opened on
+ * ANY server would restore content persisted while talking to a DIFFERENT one.
+ * (Not a claim that `:5173` and `:3479` share storage — they are two origins
+ * with two buckets. The Tauri WebView is a third, `http://tauri.localhost`, and
+ * was never exposed to this.)
  *
  * The discriminator has to be stable across restarts — recovery exists to
  * survive them — which rules out `generationId`, new on every boot. The
  * server's session-store path (`storagePath` on `/api/info`) is one-to-one with
  * its app-data root: stable per installation, and distinct for any server that
- * sets `TANDEM_APP_DATA_DIR` (E2E, perf, design baselines, screenshots). It is
- * already exposed, so this needs no new durable server state.
+ * sets `TANDEM_APP_DATA_DIR` — verified for E2E, perf and design baselines.
+ * (Screenshots do NOT set their own: that config spreads the root Playwright
+ * `webServer` verbatim, so it shares E2E's dir and id.) It is already exposed,
+ * so this needs no new durable server state.
+ *
+ * Separation is by app-data root, not by binary: an npm-global install and the
+ * desktop app both resolve the default root, so they share one id. That is the
+ * intended reading — same user, same data — but it does mean "install" here is
+ * shorthand for "app-data root".
  *
  * Deliberately NOT derived from the auth token: `shared/auth/token-file.ts`
- * resolves via `envPaths("tandem").data` directly and ignores
+ * resolves via `envPaths("tandem", { suffix: "" }).data` directly and ignores
  * `TANDEM_APP_DATA_DIR`, so a test server and the real server share one token
  * file — it would collide in precisely the case this exists to separate.
  *
@@ -37,8 +48,10 @@ function fnv1a32(input: string): string {
   let hash = 0x811c9dc5;
   for (let i = 0; i < input.length; i++) {
     hash ^= input.charCodeAt(i);
-    // `Math.imul` rather than `*`: the 32-bit FNV prime overflows a float64
-    // mantissa, so plain multiplication silently loses low bits.
+    // `Math.imul` rather than `*`: the PRODUCT of a 32-bit accumulator and the
+    // FNV prime reaches ~2^56, past float64's 53-bit mantissa, so plain
+    // multiplication silently loses low bits. (The prime itself, 16777619, is
+    // exactly representable — it is the product that overflows.)
     hash = Math.imul(hash, 0x01000193) >>> 0;
   }
   return hash.toString(16).padStart(8, "0");
@@ -47,13 +60,18 @@ function fnv1a32(input: string): string {
 /**
  * Derive the install id from a server's `storagePath`.
  *
- * Normalises separators, trailing separator and case first, because the same
- * directory reaches us spelled differently depending on who resolved it:
- * Windows APIs return backslashes and a drive letter whose case is not
- * guaranteed, while a path that has been through `env-paths` or an env var may
- * arrive with forward slashes. Two spellings of one directory MUST produce one
- * id, or a restart would look like a different installation and silently drop
- * recovery.
+ * Normalises separators, trailing separator and case first. Two spellings of
+ * one directory MUST produce one id, or a restart would look like a different
+ * installation and silently drop recovery.
+ *
+ * Only ONE of those three actually varies today. `storagePath` has a single
+ * producer — `path.join(resolveAppDataDir(), "sessions")` — and `path.join`
+ * already normalises separators to the platform's and strips a trailing one,
+ * even when its input used the other kind. What survives it is casing: the
+ * drive letter and `AppData` reach us however the env var or OS API spelled
+ * them. The separator and trailing-slash handling is therefore defence in
+ * depth, kept because the client is consuming a string it did not produce and
+ * cannot re-derive.
  *
  * The lowercase is unconditional, which differs from `doc-hash.ts`'s rule for
  * the same problem (it lowercases only on Windows, because POSIX paths are

--- a/tests/client/install-id.test.ts
+++ b/tests/client/install-id.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { installIdFromStoragePath } from "../../src/client/utils/install-id";
+
+/**
+ * #1387 — the discriminator that keeps two Tandem servers on one machine from
+ * reading each other's browser-local state. See the module docblock for why the
+ * server's session-store path is the thing being hashed, and `generationId` is
+ * not.
+ */
+
+describe("installIdFromStoragePath", () => {
+  it("gives one id to one directory however its path is spelled", () => {
+    // A restart must never look like a different installation, or recovery
+    // silently stops working. The same directory reaches us spelled differently
+    // depending on who resolved it — Windows APIs return backslashes and an
+    // unpredictable drive-letter case.
+    const a = installIdFromStoragePath("C:\\Users\\x\\AppData\\Local\\tandem\\Data\\sessions");
+    const b = installIdFromStoragePath("c:/users/x/appdata/local/tandem/data/sessions");
+    const c = installIdFromStoragePath("C:\\Users\\x\\AppData\\Local\\tandem\\Data\\sessions\\");
+    expect(a).toBe(b);
+    expect(a).toBe(c);
+  });
+
+  it("separates the real store from an isolated test store", () => {
+    // The case that matters: E2E, perf, design-baselines and screenshots each
+    // set their own TANDEM_APP_DATA_DIR.
+    expect(installIdFromStoragePath("C:/Users/x/AppData/Local/tandem/Data/sessions")).not.toBe(
+      installIdFromStoragePath("C:/tmp/tandem-e2e-data/sessions"),
+    );
+  });
+
+  it("returns a stable, filesystem-safe token", () => {
+    const id = installIdFromStoragePath("/home/x/.local/share/tandem/sessions");
+    expect(id).toMatch(/^[0-9a-f]{8}$/);
+    expect(installIdFromStoragePath("/home/x/.local/share/tandem/sessions")).toBe(id);
+  });
+});

--- a/tests/client/install-id.test.ts
+++ b/tests/client/install-id.test.ts
@@ -21,17 +21,35 @@ describe("installIdFromStoragePath", () => {
     expect(a).toBe(c);
   });
 
+  it("pins the exact hash, so a silent re-key of every user is impossible", () => {
+    // Golden vectors, and they earn their keep: swapping `Math.imul` for plain
+    // `*` — which loses low bits once the product passes 2^53 — leaves every
+    // other assertion in this file passing (sampled paths stay distinct, output
+    // is still 8 hex chars, still deterministic). Any drift in the hash OR the
+    // normalisation re-keys every existing user, and their orphaned 4-segment
+    // keys are exactly what the legacy purge (3-segment only) will never
+    // collect. Regenerate these only with a deliberate migration.
+    expect(installIdFromStoragePath("/home/x/.local/share/tandem/sessions")).toBe("53640ea4");
+    expect(installIdFromStoragePath("C:\\Users\\x\\AppData\\Local\\tandem\\Data\\sessions")).toBe(
+      "de3381f5",
+    );
+  });
+
   it("separates the real store from an isolated test store", () => {
-    // The case that matters: E2E, perf, design-baselines and screenshots each
-    // set their own TANDEM_APP_DATA_DIR.
+    // The case that matters: E2E, perf and design baselines each set their own
+    // TANDEM_APP_DATA_DIR. (Screenshots do not — that config spreads the root
+    // Playwright webServer, so it shares E2E's dir and id.)
     expect(installIdFromStoragePath("C:/Users/x/AppData/Local/tandem/Data/sessions")).not.toBe(
       installIdFromStoragePath("C:/tmp/tandem-e2e-data/sessions"),
     );
   });
 
-  it("returns a stable, filesystem-safe token", () => {
+  it("returns a filesystem- and key-safe token", () => {
+    // The shape matters independently of the value above: the legacy purge
+    // discriminates on colon count, so an id containing a colon would make a
+    // scoped key look like a legacy one and get swept on every start.
     const id = installIdFromStoragePath("/home/x/.local/share/tandem/sessions");
     expect(id).toMatch(/^[0-9a-f]{8}$/);
-    expect(installIdFromStoragePath("/home/x/.local/share/tandem/sessions")).toBe(id);
+    expect(id).not.toContain(":");
   });
 });

--- a/tests/client/scratchpad-install-scope.test.ts
+++ b/tests/client/scratchpad-install-scope.test.ts
@@ -1,0 +1,194 @@
+import type { HocuspocusProvider } from "@hocuspocus/provider";
+import { flushSync } from "svelte";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import {
+  createScratchpadPersistence,
+  scratchpadStorageKey,
+} from "../../src/client/hooks/useScratchpadPersistence.svelte";
+import type { OpenTab } from "../../src/client/types";
+
+/**
+ * #1387 — scratchpad recovery must not cross installations.
+ *
+ * Every Tandem server on a machine shares one browser origin, so `localStorage`
+ * written while talking to one server is visible to all of them. Recovery keys
+ * carried only a UUID, and a *fresh* scratchpad has no key of its own — so the
+ * latest-pointer fallback would hand it whatever the last server persisted.
+ * In practice that meant a real document's content being written into a
+ * scratchpad on a test server, and the test's typing persisted back under the
+ * real profile.
+ *
+ * This is the regression that turns the fix on. `restoreInto` had no unit
+ * coverage at all before it — `tests/client/scratchpad-persistence.test.ts`
+ * only exercises the pure exports — so the behaviour these tests pin was
+ * previously asserted nowhere.
+ */
+
+const INSTALL_A = "aaaa1111";
+const INSTALL_B = "bbbb2222";
+const UUID_OLD = "11111111-1111-4111-8111-111111111111";
+const UUID_NEW = "22222222-2222-4222-8222-222222222222";
+
+/** Minimal stand-in: the hook only ever touches `synced`, `on` and `off`. */
+function fakeProvider(): HocuspocusProvider {
+  return {
+    synced: true,
+    on: () => {},
+    off: () => {},
+  } as unknown as HocuspocusProvider;
+}
+
+function scratchpadTab(uuid: string, ydoc: Y.Doc): OpenTab {
+  return {
+    id: `doc-${uuid}`,
+    filePath: `upload://scratchpad/${uuid}/Scratchpad.md`,
+    fileName: "Scratchpad.md",
+    format: "markdown",
+    readOnly: false,
+    source: "upload",
+    ydoc,
+    provider: fakeProvider(),
+  };
+}
+
+function textOf(ydoc: Y.Doc): string {
+  return ydoc.getXmlFragment("default").toString();
+}
+
+/**
+ * Seed recovery data as if a previous session on `installId` had persisted it.
+ * Mirrors `persistEntry`'s two writes — content key plus latest pointer.
+ *
+ * Deliberately builds the keys as LITERALS rather than calling
+ * `scratchpadStorageKey`. Seeding through the function under test makes the
+ * seed move with it: a mutation that drops the install segment changes both
+ * the write and the read, and every assertion here still passes. That mutant
+ * genuinely survived until this helper stopped sharing the implementation.
+ */
+function contentKey(installId: string, uuid: string): string {
+  return `tandem:scratchpad:${installId}:${uuid}`;
+}
+
+function latestKey(installId: string): string {
+  return `tandem:scratchpad:${installId}:latest`;
+}
+
+function seedRecovery(installId: string, uuid: string, text: string): void {
+  localStorage.setItem(contentKey(installId, uuid), JSON.stringify([text]));
+  localStorage.setItem(latestKey(installId), uuid);
+}
+
+let stop: (() => void) | null = null;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  stop?.();
+  stop = null;
+  localStorage.clear();
+});
+
+/** Attach the hook to a single scratchpad tab and let its diff effect run. */
+function attachTo(ydoc: Y.Doc, uuid: string, installId: string | null) {
+  const tabs = [scratchpadTab(uuid, ydoc)];
+  const persistence = createScratchpadPersistence(
+    () => tabs,
+    () => installId,
+  );
+  stop = persistence.destroy;
+  flushSync();
+  return persistence;
+}
+
+describe("scratchpad recovery is scoped to the installation", () => {
+  it("agrees with the implementation on the key layout", () => {
+    // The seed helpers above build keys by hand so they cannot move with a
+    // mutation. That independence is only safe if they match the real layout,
+    // which is what this pins — otherwise every test below would seed data the
+    // hook never reads and pass for the wrong reason.
+    expect(contentKey(INSTALL_A, UUID_OLD)).toBe(scratchpadStorageKey(INSTALL_A, UUID_OLD));
+  });
+
+  it("restores content persisted by the SAME installation", () => {
+    // The feature this fix must not break: reopening a scratchpad on your own
+    // server still recovers what you were writing.
+    seedRecovery(INSTALL_A, UUID_OLD, "my unsaved draft");
+    const ydoc = new Y.Doc();
+    attachTo(ydoc, UUID_NEW, INSTALL_A);
+
+    expect(textOf(ydoc)).toContain("my unsaved draft");
+  });
+
+  it("does NOT restore content persisted by a DIFFERENT installation", () => {
+    // The leak. A scratchpad opened on a server that never persisted anything
+    // must come up empty, even though the browser holds recovery data for a
+    // different server at the same origin.
+    seedRecovery(INSTALL_A, UUID_OLD, "a real document's contents");
+    const ydoc = new Y.Doc();
+    attachTo(ydoc, UUID_NEW, INSTALL_B);
+
+    expect(textOf(ydoc)).toBe("");
+  });
+
+  it("does NOT restore while the install id is unknown", () => {
+    // Fail closed. Before `/api/info` answers there is no key that can be
+    // scoped correctly, and guessing one is the bug with extra steps.
+    seedRecovery(INSTALL_A, UUID_OLD, "a real document's contents");
+    const ydoc = new Y.Doc();
+    attachTo(ydoc, UUID_NEW, null);
+
+    expect(textOf(ydoc)).toBe("");
+  });
+
+  it("refuses outright rather than falling back to a placeholder namespace", () => {
+    // The previous test cannot tell "refuse" from "substitute some other
+    // string", because either way the INSTALL_A data is missed. A `?? "unknown"`
+    // in place of the guard passed it — and that is a real leak, just a narrow
+    // one: every client whose install id is unknown would then share one
+    // namespace, so content persisted during the pre-`/api/info` window on any
+    // server restores on any other. Seeding that exact namespace is what makes
+    // the distinction observable.
+    localStorage.setItem(contentKey("unknown", UUID_OLD), JSON.stringify(["placeholder ns"]));
+    localStorage.setItem(latestKey("unknown"), UUID_OLD);
+    const ydoc = new Y.Doc();
+    attachTo(ydoc, UUID_NEW, null);
+
+    expect(textOf(ydoc)).toBe("");
+  });
+
+  it("purges the pre-fix unscoped keys instead of leaving them addressable by nobody", () => {
+    // After the fix nothing reads `tandem:scratchpad:<uuid>`, so left alone it
+    // holds document text in the browser forever — and it is exactly the text
+    // that crossed installs. Deletion is not a new loss: declining to read
+    // these already gave it up.
+    localStorage.setItem("tandem:scratchpad:legacy-uuid", JSON.stringify(["old draft"]));
+    localStorage.setItem("tandem:scratchpad:latest", "legacy-uuid");
+    seedRecovery(INSTALL_A, UUID_OLD, "still mine");
+
+    attachTo(new Y.Doc(), UUID_NEW, INSTALL_A);
+
+    expect(localStorage.getItem("tandem:scratchpad:legacy-uuid")).toBeNull();
+    expect(localStorage.getItem("tandem:scratchpad:latest")).toBeNull();
+    // The purge is shape-based, so a scoped key must survive it — a sweep that
+    // ate those would delete live recovery on every boot.
+    expect(localStorage.getItem(latestKey(INSTALL_A))).not.toBeNull();
+  });
+
+  it("keeps a foreign installation's recovery data intact", () => {
+    // Declining to restore must not also destroy the other installation's
+    // recovery: the restore path rewrites the latest pointer and deletes the
+    // source key, so a partial application of the fix could silently discard
+    // the user's real draft instead of merely ignoring it.
+    seedRecovery(INSTALL_A, UUID_OLD, "a real document's contents");
+    const ydoc = new Y.Doc();
+    attachTo(ydoc, UUID_NEW, INSTALL_B);
+
+    expect(localStorage.getItem(contentKey(INSTALL_A, UUID_OLD))).toContain(
+      "a real document's contents",
+    );
+    expect(localStorage.getItem(latestKey(INSTALL_A))).toBe(UUID_OLD);
+  });
+});

--- a/tests/client/scratchpad-install-scope.test.ts
+++ b/tests/client/scratchpad-install-scope.test.ts
@@ -177,6 +177,21 @@ describe("scratchpad recovery is scoped to the installation", () => {
     expect(localStorage.getItem(latestKey(INSTALL_A))).not.toBeNull();
   });
 
+  it("leaves same-shaped keys belonging to other features alone", () => {
+    // The purge matches on segment count, so the `tandem:scratchpad:` prefix
+    // check is the only thing standing between it and a real neighbour:
+    // `tandem:headingCollapse:<docId>` is also three segments under `tandem:`.
+    // Widen or drop that check and every user silently loses heading-collapse
+    // state on every app start.
+    localStorage.setItem("tandem:headingCollapse:doc123", '{"h1":true}');
+    localStorage.setItem("tandem:showAuthorship", "true");
+
+    attachTo(new Y.Doc(), UUID_NEW, INSTALL_A);
+
+    expect(localStorage.getItem("tandem:headingCollapse:doc123")).toBe('{"h1":true}');
+    expect(localStorage.getItem("tandem:showAuthorship")).toBe("true");
+  });
+
   it("keeps a foreign installation's recovery data intact", () => {
     // Declining to restore must not also destroy the other installation's
     // recovery: the restore path rewrites the latest pointer and deletes the

--- a/tests/client/scratchpad-persist-guards.test.ts
+++ b/tests/client/scratchpad-persist-guards.test.ts
@@ -1,0 +1,246 @@
+import type { HocuspocusProvider } from "@hocuspocus/provider";
+import { flushSync } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+import { createScratchpadPersistence } from "../../src/client/hooks/useScratchpadPersistence.svelte";
+import type { OpenTab } from "../../src/client/types";
+
+/**
+ * The write side of scratchpad recovery, plus the guards around it (#1387).
+ *
+ * `scratchpad-install-scope.test.ts` covers restore. Everything here is the
+ * direction it cannot see: what `persistEntry` writes, what `clearUnsaved`
+ * removes, and — most importantly — what the fail-closed install-id guard is
+ * allowed to suppress. The guard protects STORAGE. A review found it had been
+ * written to suppress the unsaved-content warning too, which turns a content
+ * leak into silent content loss; these tests exist so that cannot come back.
+ *
+ * Persist is debounced, so every test drives it with fake timers.
+ */
+
+const INSTALL_A = "aaaa1111";
+const UUID = "11111111-1111-4111-8111-111111111111";
+const PERSIST_MS = 500;
+
+function contentKey(installId: string, uuid: string): string {
+  return `tandem:scratchpad:${installId}:${uuid}`;
+}
+
+function latestKey(installId: string): string {
+  return `tandem:scratchpad:${installId}:latest`;
+}
+
+/**
+ * Provider stand-in whose `synced` state is controllable. `emitSynced()` fires
+ * the one-shot listener `attach` registers when a tab is not yet synced — the
+ * branch every existing test skips by passing `synced: true`.
+ */
+function fakeProvider(synced: boolean) {
+  const handlers = new Set<() => void>();
+  const provider = {
+    synced,
+    on: (event: string, fn: () => void) => {
+      if (event === "synced") handlers.add(fn);
+    },
+    off: (event: string, fn: () => void) => {
+      if (event === "synced") handlers.delete(fn);
+    },
+  };
+  return {
+    provider: provider as unknown as HocuspocusProvider,
+    emitSynced: () => {
+      for (const fn of [...handlers]) fn();
+    },
+  };
+}
+
+function scratchpadTab(uuid: string, ydoc: Y.Doc, provider: HocuspocusProvider): OpenTab {
+  return {
+    id: `doc-${uuid}`,
+    filePath: `upload://scratchpad/${uuid}/Scratchpad.md`,
+    fileName: "Scratchpad.md",
+    format: "markdown",
+    readOnly: false,
+    source: "upload",
+    ydoc,
+    provider,
+  };
+}
+
+/** Type a paragraph into a scratchpad's Y.Doc, as the editor would. */
+function type(ydoc: Y.Doc, text: string): void {
+  const fragment = ydoc.getXmlFragment("default");
+  const p = new Y.XmlElement("paragraph");
+  p.insert(0, [new Y.XmlText(text)]);
+  ydoc.transact(() => {
+    fragment.insert(fragment.length, [p]);
+  });
+}
+
+/** Remove everything from a scratchpad, as select-all + delete would. */
+function clearDoc(ydoc: Y.Doc): void {
+  const fragment = ydoc.getXmlFragment("default");
+  ydoc.transact(() => {
+    fragment.delete(0, fragment.length);
+  });
+}
+
+let stop: (() => void) | null = null;
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  stop?.();
+  stop = null;
+  vi.useRealTimers();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Attach the hook to one scratchpad tab. The install id is read through a
+ * mutable box so a test can flip it null → known the way `/api/info` does.
+ */
+function harness(opts: { installId: string | null; synced?: boolean }) {
+  const box = { id: opts.installId };
+  const ydoc = new Y.Doc();
+  const { provider, emitSynced } = fakeProvider(opts.synced ?? true);
+  const tabs = [scratchpadTab(UUID, ydoc, provider)];
+  const persistence = createScratchpadPersistence(
+    () => tabs,
+    () => box.id,
+  );
+  stop = persistence.destroy;
+  flushSync();
+  return { ydoc, persistence, box, emitSynced };
+}
+
+describe("persistEntry", () => {
+  it("writes the content key and the latest pointer under the install", () => {
+    const { ydoc } = harness({ installId: INSTALL_A });
+    type(ydoc, "draft text");
+    vi.advanceTimersByTime(PERSIST_MS);
+
+    expect(localStorage.getItem(contentKey(INSTALL_A, UUID))).toContain("draft text");
+    expect(localStorage.getItem(latestKey(INSTALL_A))).toBe(UUID);
+  });
+
+  it("writes NOTHING while the install id is unknown", () => {
+    // The write half of fail-closed. The restore-side tests cannot see this:
+    // a `?? "unknown"` applied only here still passes them, while pooling every
+    // install's document text into one shared key — the #1387 shape, waiting
+    // for anyone to relax the read guard.
+    const { ydoc } = harness({ installId: null });
+    type(ydoc, "draft text");
+    vi.advanceTimersByTime(PERSIST_MS);
+
+    const keys = Object.keys(localStorage).filter((k) => k.startsWith("tandem:scratchpad:"));
+    expect(keys).toEqual([]);
+  });
+
+  it("STILL warns about unsaved content when the install id is unknown", () => {
+    // The regression this file exists for. The fail-closed guard governs
+    // storage only: content we could not persist is content the user is more
+    // likely to lose, so suppressing the warning there is exactly backwards —
+    // the tab would close with no prompt and no recovery net.
+    const { ydoc, persistence } = harness({ installId: null });
+    type(ydoc, "draft text");
+    vi.advanceTimersByTime(PERSIST_MS);
+
+    expect(persistence.hasUnsavedContent(UUID)).toBe(true);
+  });
+
+  it("clears the content key and the pointer when the scratchpad is emptied", () => {
+    // Otherwise the next fresh scratchpad restores text the user deleted on
+    // purpose, and the close warning fires over a visibly empty pad.
+    const { ydoc, persistence } = harness({ installId: INSTALL_A });
+    type(ydoc, "draft text");
+    vi.advanceTimersByTime(PERSIST_MS);
+    clearDoc(ydoc);
+    vi.advanceTimersByTime(PERSIST_MS);
+
+    expect(localStorage.getItem(contentKey(INSTALL_A, UUID))).toBeNull();
+    expect(localStorage.getItem(latestKey(INSTALL_A))).toBeNull();
+    expect(persistence.hasUnsavedContent(UUID)).toBe(false);
+  });
+});
+
+describe("clearUnsaved", () => {
+  it("removes both keys so a discarded draft cannot come back", () => {
+    const { ydoc, persistence } = harness({ installId: INSTALL_A });
+    type(ydoc, "about to be discarded");
+    vi.advanceTimersByTime(PERSIST_MS);
+
+    persistence.clearUnsaved(UUID);
+
+    expect(localStorage.getItem(contentKey(INSTALL_A, UUID))).toBeNull();
+    expect(localStorage.getItem(latestKey(INSTALL_A))).toBeNull();
+    expect(persistence.hasUnsavedContent(UUID)).toBe(false);
+  });
+
+  it("clears the flag even when the install id is unknown", () => {
+    // Deliberately NOT fail-closed, and the asymmetry is load-bearing: adding
+    // the storage guard here "for consistency" latches the flag true forever,
+    // because detach() runs immediately after and nothing recomputes it. The
+    // close dialog would then re-fire on every attempt and `beforeunload` would
+    // warn permanently.
+    const { ydoc, persistence } = harness({ installId: null });
+    type(ydoc, "about to be discarded");
+    vi.advanceTimersByTime(PERSIST_MS);
+    expect(persistence.hasUnsavedContent(UUID)).toBe(true);
+
+    persistence.clearUnsaved(UUID);
+
+    expect(persistence.hasUnsavedContent(UUID)).toBe(false);
+  });
+});
+
+describe("restore deferred until the provider syncs", () => {
+  it("recovers a draft for a tab that attaches before sync", () => {
+    // The one-shot `synced` path. Every other test passes `synced: true` and
+    // skips it entirely — so hoisting the `getInstallId()` read up into
+    // attach(), an obvious "read it once" cleanup, would kill recovery for
+    // real tabs (which attach unsynced) without failing anything.
+    localStorage.setItem(contentKey(INSTALL_A, UUID), JSON.stringify(["recovered draft"]));
+    localStorage.setItem(latestKey(INSTALL_A), UUID);
+
+    const { ydoc, emitSynced } = harness({ installId: INSTALL_A, synced: false });
+    expect(ydoc.getXmlFragment("default").toString()).toBe("");
+
+    emitSynced();
+
+    expect(ydoc.getXmlFragment("default").toString()).toContain("recovered draft");
+  });
+
+  it("reads the install id at sync time, not at attach time", () => {
+    // `/api/info` answers asynchronously, so a tab can attach while the id is
+    // still null. Recovery must survive that — which it does only because
+    // restoreInto re-reads the accessor when `synced` fires.
+    localStorage.setItem(contentKey(INSTALL_A, UUID), JSON.stringify(["recovered draft"]));
+    localStorage.setItem(latestKey(INSTALL_A), UUID);
+
+    const { ydoc, box, emitSynced } = harness({ installId: null, synced: false });
+    box.id = INSTALL_A;
+    emitSynced();
+
+    expect(ydoc.getXmlFragment("default").toString()).toContain("recovered draft");
+  });
+
+  it("warns rather than failing silently when the id never arrives", () => {
+    // Restore is one-shot, so this is terminal for the tab: the user sees an
+    // empty scratchpad and cannot tell it from "nothing to recover". The warning
+    // is the only artifact anyone debugging it would have.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    localStorage.setItem(contentKey(INSTALL_A, UUID), JSON.stringify(["recovered draft"]));
+    localStorage.setItem(latestKey(INSTALL_A), UUID);
+
+    const { ydoc, emitSynced } = harness({ installId: null, synced: false });
+    emitSynced();
+
+    expect(ydoc.getXmlFragment("default").toString()).toBe("");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Scratchpad recovery skipped"));
+  });
+});

--- a/tests/client/scratchpad-persist-guards.test.ts
+++ b/tests/client/scratchpad-persist-guards.test.ts
@@ -244,3 +244,60 @@ describe("restore deferred until the provider syncs", () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("Scratchpad recovery skipped"));
   });
 });
+
+const INSTALL_B = "bbbb2222";
+
+describe("install id locks to the entry, surviving a later live change", () => {
+  // A generation-rebuild (server swapped behind the same host:port — e.g.
+  // `npm run test:e2e` killing and replacing a dev server on :3478/:3479)
+  // updates the live install id BEFORE tearing tabs down, and `detach()`
+  // flushes each entry's pending debounced write as part of that teardown.
+  // Reading `getInstallId()` live at flush time would persist content typed
+  // under the OLD server under the NEW server's key — the #1387 leak,
+  // reopened through the teardown path instead of the initial-open one these
+  // tests can't otherwise see. These tests flip the live id directly (the
+  // same shape a rebuild produces) without needing to drive the reactive
+  // tabs-diff effect that would normally trigger it.
+
+  it("persistEntry keeps writing under the id locked when the entry first resolved it", () => {
+    const { ydoc, box } = harness({ installId: INSTALL_A }); // locks to A via restoreInto at attach
+    type(ydoc, "typed while still on A");
+    box.id = INSTALL_B; // the live id moves on before the debounce fires
+    vi.advanceTimersByTime(PERSIST_MS);
+
+    expect(localStorage.getItem(contentKey(INSTALL_A, UUID))).toContain("typed while still on A");
+    expect(localStorage.getItem(latestKey(INSTALL_A))).toBe(UUID);
+    expect(localStorage.getItem(contentKey(INSTALL_B, UUID))).toBeNull();
+    expect(localStorage.getItem(latestKey(INSTALL_B))).toBeNull();
+  });
+
+  it("clearUnsaved removes the locked install's key, not the live-changed one", () => {
+    const { ydoc, persistence, box } = harness({ installId: INSTALL_A });
+    type(ydoc, "about to be discarded");
+    vi.advanceTimersByTime(PERSIST_MS);
+    box.id = INSTALL_B; // live id moves on before the confirmed-close callback runs
+
+    persistence.clearUnsaved(UUID);
+
+    expect(localStorage.getItem(contentKey(INSTALL_A, UUID))).toBeNull();
+    expect(localStorage.getItem(latestKey(INSTALL_A))).toBeNull();
+  });
+
+  it("still locks to whichever id is live on first resolution when attach starts unsynced", () => {
+    // Attach defers restoreInto (and so the lock) to the synced listener when
+    // the provider hasn't synced yet — this pins that the lock is taken at
+    // THAT point, not at attach(), and survives a live change afterward.
+    const { ydoc, box, emitSynced } = harness({ installId: INSTALL_A, synced: false });
+    box.id = INSTALL_B; // flips before synced fires
+    emitSynced(); // resolveInstallId locks to whatever is live now: B
+
+    type(ydoc, "typed after sync, locked to B");
+    box.id = INSTALL_A; // live id moves on again — must not un-stick the lock
+    vi.advanceTimersByTime(PERSIST_MS);
+
+    expect(localStorage.getItem(contentKey(INSTALL_B, UUID))).toContain(
+      "typed after sync, locked to B",
+    );
+    expect(localStorage.getItem(contentKey(INSTALL_A, UUID))).toBeNull();
+  });
+});

--- a/tests/client/scratchpad-persist-guards.test.ts
+++ b/tests/client/scratchpad-persist-guards.test.ts
@@ -283,21 +283,44 @@ describe("install id locks to the entry, surviving a later live change", () => {
     expect(localStorage.getItem(latestKey(INSTALL_A))).toBeNull();
   });
 
-  it("still locks to whichever id is live on first resolution when attach starts unsynced", () => {
-    // Attach defers restoreInto (and so the lock) to the synced listener when
-    // the provider hasn't synced yet — this pins that the lock is taken at
-    // THAT point, not at attach(), and survives a live change afterward.
+  it("locks at attach() itself, not deferred to the synced listener", () => {
+    // A first pass at this fix locked lazily, in whichever of restoreInto /
+    // persistEntry / detach's flush happened to call resolveInstallId first.
+    // For a tab that attaches unsynced, that let a live id change BEFORE the
+    // synced listener ever fires decide the lock — this pins that attach()
+    // grabs the live id immediately instead, so a later change (here, before
+    // sync even completes) cannot touch it.
     const { ydoc, box, emitSynced } = harness({ installId: INSTALL_A, synced: false });
-    box.id = INSTALL_B; // flips before synced fires
-    emitSynced(); // resolveInstallId locks to whatever is live now: B
+    box.id = INSTALL_B; // flips before synced fires — must NOT become the lock
+    emitSynced();
 
-    type(ydoc, "typed after sync, locked to B");
-    box.id = INSTALL_A; // live id moves on again — must not un-stick the lock
+    type(ydoc, "typed after sync, still locked to A");
     vi.advanceTimersByTime(PERSIST_MS);
 
-    expect(localStorage.getItem(contentKey(INSTALL_B, UUID))).toContain(
-      "typed after sync, locked to B",
+    expect(localStorage.getItem(contentKey(INSTALL_A, UUID))).toContain(
+      "typed after sync, still locked to A",
     );
-    expect(localStorage.getItem(contentKey(INSTALL_A, UUID))).toBeNull();
+    expect(localStorage.getItem(contentKey(INSTALL_B, UUID))).toBeNull();
+  });
+
+  it("survives a rebuild that completes before the entry ever synced", () => {
+    // The gap a review found in the first pass: an entry whose provider never
+    // syncs before a rebuild tears it down defers restoreInto — and so its
+    // lock attempt — behind the one-shot `synced` listener that never fires.
+    // If the entry's first-ever resolveInstallId call were the detach flush
+    // itself (post-rebuild, live id already the NEW server's), content typed
+    // under the OLD server would lock onto — and persist under — the new
+    // one. Locking eagerly in attach() closes this: the entry captures A the
+    // moment it opens, before sync, before typing, before any rebuild could
+    // occur.
+    const { ydoc, box, persistence } = harness({ installId: INSTALL_A, synced: false });
+    type(ydoc, "typed before this room ever synced");
+    box.id = INSTALL_B; // rebuild's fetchServerIdentity() resolves the new id...
+    persistence.destroy(); // ...then teardownAllTabs() detaches and flushes — never synced
+
+    expect(localStorage.getItem(contentKey(INSTALL_A, UUID))).toContain(
+      "typed before this room ever synced",
+    );
+    expect(localStorage.getItem(contentKey(INSTALL_B, UUID))).toBeNull();
   });
 });

--- a/tests/client/scratchpad-persistence.test.ts
+++ b/tests/client/scratchpad-persistence.test.ts
@@ -23,8 +23,26 @@ function docWithParagraphs(lines: string[]): Y.Doc {
 
 describe("scratchpadStorageKey", () => {
   it("namespaces by uuid so distinct scratchpads never collide", () => {
-    expect(scratchpadStorageKey("uuid-a")).toBe("tandem:scratchpad:uuid-a");
-    expect(scratchpadStorageKey("uuid-a")).not.toBe(scratchpadStorageKey("uuid-b"));
+    expect(scratchpadStorageKey("inst1", "uuid-a")).toBe("tandem:scratchpad:inst1:uuid-a");
+    expect(scratchpadStorageKey("inst1", "uuid-a")).not.toBe(
+      scratchpadStorageKey("inst1", "uuid-b"),
+    );
+  });
+
+  it("namespaces by install so two servers never read each other's recovery (#1387)", () => {
+    // The whole fix in one assertion. Every Tandem server on a machine shares
+    // one browser origin, so without this segment a scratchpad opened on any
+    // server can restore content persisted while talking to another one.
+    expect(scratchpadStorageKey("inst1", "uuid-a")).not.toBe(
+      scratchpadStorageKey("inst2", "uuid-a"),
+    );
+  });
+
+  it("keeps the `tandem:scratchpad:` prefix that the E2E cleanup matches on", () => {
+    // The E2E cleanups clear recovery with a prefix match. If the install
+    // segment were prepended instead of inserted, that cleanup would silently
+    // stop matching and the suite would leak state between tests.
+    expect(scratchpadStorageKey("inst1", "uuid-a").startsWith("tandem:scratchpad:")).toBe(true);
   });
 });
 

--- a/tests/server/info-route.test.ts
+++ b/tests/server/info-route.test.ts
@@ -242,6 +242,30 @@ describe("GET /api/info — non-loopback branch (unit)", () => {
     expect("tokenRotatedAt" in body).toBe(false);
     expect("generationId" in body).toBe(false);
   });
+
+  it("gates storagePath and generationId TOGETHER, for both caller kinds", async () => {
+    // A client-side invariant enforced here because only this file can see it.
+    // The browser derives its scratchpad install id from `storagePath` (#1387),
+    // but only reaches that code once `generationId` has bootstrapped it. They
+    // share one `if (loopback)` block today, which is what makes the client's
+    // fail-closed branch unreachable in production.
+    //
+    // Split them and the failure is silent and total: scratchpad crash recovery
+    // stops (restore is one-shot and never retries) AND the unsaved-content
+    // warning goes with it, with no error and no other failing test. The
+    // assertions above pin each field independently, which cannot catch that.
+    const handler = makeInfoHandler(BASE_DEPS);
+    for (const peer of ["127.0.0.1", "192.168.1.50"]) {
+      const res = makeMockRes();
+      await (handler as (req: unknown, res: unknown, next: unknown) => Promise<void>)(
+        makeMockReq(peer),
+        res,
+        () => {},
+      );
+      const b = res._body as Record<string, unknown>;
+      expect("storagePath" in b, `mismatched gating for peer ${peer}`).toBe("generationId" in b);
+    }
+  });
 });
 
 describe("GET /api/info — generationId field (unit)", () => {


### PR DESCRIPTION
Refs #1387.

Every Tandem server on a machine shares one browser origin, so `localStorage` written while talking to one server is visible to all of them. Scratchpad recovery keys carried only a UUID — and a *fresh* scratchpad has no key of its own, so `restoreInto`'s latest-pointer fallback handed it whatever the **last server on that origin** had persisted.

That is #1387, and it runs in both directions from the one mechanism, which is why it read as two bugs:

- A real document's contents restored into a scratchpad on a **test** server.
- The test's own typing persisted straight back under the **real** profile — `ydoc.on("update")` fires on remote applies too.

## What the leak needed

A carrier, and one exists: a tab left open at `http://127.0.0.1:5173/` re-attaches to **anything** that binds `ws://127.0.0.1:3478`. Measured against a hand-started server with a freshly wiped, isolated app-data dir and no browser of mine running:

```
[Hocuspocus] Rejected stale-generation connection to __tandem_ctrl__ (client token "b150fc76…")
[onAuthenticate] Connection rejected: stale server generation
```

**The generation gate is not defeated and is not the bug.** It fires, `scheduleRebuild` destroys every provider and Y.Doc, and `Editor.svelte:113` re-creates the editor on `(ydoc, provider)` identity change, so no editor content survives. The leak is downstream of all of it, in a `localStorage` lookup that has no idea which server it is talking to.

## The fix

Keys become `tandem:scratchpad:<install>:<uuid>`, with a per-install latest-pointer.

**The identity already exists and is already exposed.** `GET /api/info` returns `storagePath` in the same loopback block as `generationId` (`info.ts:114-120` → `server.ts:665` → `SESSION_DIR`, which honours `TANDEM_APP_DATA_DIR`). Hashed client-side. **No new durable server state, no new field, no new route.**

`generationId` cannot do this job: it changes on **every** restart, and surviving a restart is the entire point of recovery.

Two properties this rests on, both verified rather than assumed:

| Must be | Why | Verified |
|---|---|---|
| **Stable** across restarts and runtimes | else recovery silently stops working | Tauri passes `TANDEM_DATA_DIR`, **not** `TANDEM_APP_DATA_DIR` (`src-tauri/src/lib.rs:2775-2776`), so the desktop app and `npm run dev:server` yield the same `storagePath` |
| **Distinct** per installation | else the fix does nothing | E2E, perf, design-baselines and screenshots each set their own dir |

**Not** derived from the auth token: `shared/auth/token-file.ts:7` calls `envPaths("tandem").data` directly and ignores `TANDEM_APP_DATA_DIR`, so a test server and the real server share one token file — it would collide in exactly the case this separates.

Everything **fails closed** on an unknown install id: no restore, no persist. `clearUnsaved` is the one deliberate exception — the reactive flag still clears so a confirmed close stops warning, and only the storage removal is skipped, which the next persist re-reaches.

**No legacy read-through.** Every gated variant considered had a hole: the condition is not client-detectable, races the server's own boot writes, and fails open on a foreign install's *second* boot. The cost is one release's worth of unsaved scratchpad text for a user upgrading mid-edit; the content class is already documented as ephemeral, annotations an explicit "accepted loss". A bounded stated loss over an unbounded silent one.

## Mutation testing found two dead tests before they shipped

| Mutant | First run | After |
|---|---|---|
| Drop the install segment from the content key | **SURVIVED** | killed, 2 tests |
| Unscope the latest-pointer | killed | killed |
| `?? "unknown"` in place of the fail-closed guard | **SURVIVED** | killed |

The first survived because the seeding helper called `scratchpadStorageKey` itself — the seed moved with the mutation and both sides stayed consistent. The helpers now build keys as **literals**, with one test pinning that they still agree with the implementation (without it the suite would seed data the hook never reads and pass for the wrong reason).

The third survived because "refuse" and "substitute a placeholder namespace" are indistinguishable if you only ever seed the *other* install. The distinction is real — a shared `unknown` namespace leaks among every client in the pre-`/api/info` window — so there is now a test that seeds exactly that namespace.

`restoreInto` had **zero** unit coverage before this; the existing suite only exercised pure exports.

Mutation-tested again after the review fixes: restoring the pre-review ordering in `persistEntry` (guard first, flag only on a successful write) fails 2 tests; relaxing the purge's `=== 3` to `>= 3`, which would eat live scoped keys on every boot, fails 3.

## What review caught, and it was the real bug

The panel found a defect the fix itself introduced, and it is worse than the leak in one respect: it loses content rather than misplacing it.

`persistEntry` returned on a null install id **before** setting `unsaved[uuid]`, and `restoreInto` — the only other writer — sits behind the same guard. So with no install id the flag stayed false, `hasUnsavedContent` returned false, and **both** the tab-close confirm and the `beforeunload` prompt went silent. Pre-fix, `persistEntry` always ran and the warning was unconditional; I had widened the guard from persistence to the whole #864 warning apparatus, and my own `@param` claimed it covered "persistence and restore."

The correct reading is the opposite of what I wrote: content we could not persist is content the user is **more** likely to lose, so it argues *for* warning. The flag now tracks the document; only storage fails closed.

Two silent paths became observable, both one-way doors:

- `restoreInto` is one-shot, so a null read forfeits recovery for that tab's whole lifetime. It now warns — otherwise the user sees an empty scratchpad and cannot tell it from "nothing to recover," and a developer has no artifact but an unread key.
- `fetchServerIdentity` had a backwards asymmetry: an unreachable server **keeps** the old id, while a 200 that has stopped reporting `storagePath` **replaces** it with null. The second is the alarming one and the invisible one, since a 200 raises no banner.

Coverage was one-directional — every test drove `attach → restoreInto` with a constant id and `synced: true`. Added: the write side (including that `?? "unknown"` on the *write* half alone passed every prior test while pooling every install's text into one key), the empty-content branch, `clearUnsaved` in both directions, and the deferred-`synced` path that real tabs actually take.

Two catches worth naming:

- **A live mutant in the hash.** Swapping `Math.imul` for plain `*` passed all three install-id tests. Any drift there silently re-keys every user, and the orphaned 4-segment keys are exactly what the 3-segment purge can never collect. Now pinned with golden vectors.
- **`tandem:headingCollapse:<docId>` is a real neighbour** with the same three-segment shape. The `tandem:scratchpad:` prefix check is the only thing between the purge and every user's heading-collapse state. Now asserted.

One finding I rejected on measurement: a reviewer rated orphaned namespaces "important" on the premise that E2E/perf/screenshot runs each set a *fresh temp* app-data dir, making growth unbounded. They don't — `playwright.config.ts:18` pins `/tmp/tandem-e2e-data` and design baselines pin their own. A user accumulates one or two ids for life. A TTL would need a storage-format change and would delete genuinely-live recovery from someone who left unsaved text for a few weeks; purging foreign ids is forbidden by a test here on purpose, since a desktop sidecar and a dev server alternate legitimately. Documented the bound instead of hiding it.

Eight docblock claims were wrong and are corrected — including that two Tandem ports share one localStorage bucket (they are two origins with two buckets; the mechanism is successive servers at the **same** host:port), and that `clearUnsaved`'s skipped removal is "re-reachable via the next persist" (there is no next persist — the sole caller runs as the tab closes, so the key would survive and the next scratchpad would restore the text the user just confirmed discarding).

Also pins the coupling all of this rests on: `storagePath` and `generationId` share one `if (loopback)` block in `info.ts`, which is what makes the client's fail-closed branch unreachable in production. The existing tests assert each field's gating independently and structurally cannot catch a split.

## Verification

- `npm run typecheck` — clean, 1327 files, 0 errors, 0 warnings
- `npm test -- --run` — **481 files, 6950 passed**, 19 skipped
- `npx biome check src/ tests/` — clean

**One check is outstanding and needs the orphan tab closed first.** `tests/e2e/scratchpad.spec.ts` cannot be trusted while that tab is open: it is running the previously-loaded client bundle, so it will inject its content into any scratchpad on any server regardless of this fix. Note the plan's own framing — that E2E run is a **non-regression check, not evidence**, because the suite never crosses an install boundary and so structurally cannot demonstrate what is being fixed.

## Deliberately not in this PR

- **The connection-layer gate.** An earlier revision refused to adopt a replaced server outright. Dropped for two reasons: it can only ever see a tab that *survived* a swap, while a freshly opened tab goes down the initial poll loop (`yjsSync.svelte.ts:604-618`) with nothing to compare — and its own prescribed recovery, "reload", does not clear `localStorage`, which is the carrier. It would have told the user to perform the leak. Still the right defence in depth; it needs its own UI surface (the `serverRestarted` strip self-erases after 5s and carries no `data-testid`, so an assertable banner pulls in a snapshot regeneration under Critical Rule 7).
- **#1482** — client Y.Doc writes bypass origin tagging; both enforcement paths are structurally blind to `src/client`.
- **#1483** — `reuseExistingServer: !CI` makes a local E2E run *adopt* a running server. Note this path leaves `storagePath` identical, so the fix here does **not** cover it — genuinely different bugs.
- **The mode/dwell broadcast** (`useTandemModeBroadcast.svelte.ts:96-120`) pushes localStorage-sourced state into whatever ctrl room it is attached to. Same family, different carrier.

No `CHANGELOG.md` entry: this wave writes the changelog once at integration from the diffs (precedent `a62f4dee`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UGCvUhrQt1aruANfWTAQ2
