### PR TITLE
fix(annotations): insert an accepted suggestion literally, not as HTML

### DIFF
--- a/src/client/editor/utils/literal-content.ts
+++ b/src/client/editor/utils/literal-content.ts
@@ -1,0 +1,78 @@
+// Literal text → ProseMirror inline content (#1477).
+//
+// `insertContentAt(pos, someString)` does NOT insert that string. Tiptap routes
+// a string through `createNodeFromContent`, which wraps it in `<body>` and runs
+// `DOMParser` — so the argument is parsed as HTML. Measured through a LIVE
+// editor, which is the only instrument that answers this correctly (see below):
+//
+//     "use <div> for layout"  -> "use " + a PARAGRAPH node (the block splits)
+//     "<b>bold</b> text"      -> text carrying a bold mark
+//     "one\ntwo"              -> one text node holding a LITERAL newline
+//
+// Both failure modes are live in the suggestion-accept path. A suggestion that
+// merely MENTIONS a tag rewrote the document structure. And `suggestedText` /
+// `textSnapshot` render every hard break as "\n" (the `getElementText()`
+// convention), while a literal newline inside a paragraph is how this editor
+// represents a SOFT wrap — so accepting over a break-bearing paragraph
+// downgraded every hard break to a soft one, silently.
+//
+// Passing JSON content instead takes `createNodeFromContent`'s `Fragment.fromJSON`
+// branch, which never parses.
+//
+// MEASUREMENT NOTE: calling `createNodeFromContent` in ISOLATION reports a
+// collapsed space and decoded entities. Neither happens on the shipping path,
+// whose paragraph carries `whitespace: "pre"` (#1461) — those readings put two
+// wrong claims in #1477's original body. Measure through the Editor.
+
+import type { JSONContent } from "@tiptap/core";
+
+/** Matches a line ending in any of the three conventions. */
+const LINE_ENDING = /\r\n|[\r\n]/;
+
+/**
+ * Build inline content that inserts `text` verbatim.
+ *
+ * `asCodeText` selects how a newline is represented, and the distinction is
+ * real rather than defensive: `codeBlock` declares `code: true` and its content
+ * expression does NOT admit `hardBreak`, so emitting break nodes there builds
+ * schema-invalid content. Inside a code block a newline is genuinely a newline
+ * and survives as one; everywhere else the editor models it as a `hardBreak`,
+ * which is what the markdown serializer reads back as a hard break.
+ *
+ * `marks` must be the marks spanning the range being replaced, and passing them
+ * is NOT optional polish — see `MARKS` below.
+ *
+ * Returns an EMPTY array for empty text. Callers must skip the insert in that
+ * case — `insertContentAt` with `[]` logs a Tiptap warning and inserts an empty
+ * fragment rather than being a clean no-op.
+ *
+ * MARKS. `insertContentAt` branches on `isOnlyTextContent`: a single unmarked
+ * text node goes through `tr.insertText`, which inherits `$from.marksAcross($to)`
+ * for free, while anything else goes through `tr.replaceWith`, which does not.
+ * Since a newline is exactly what pushes this function from the first shape to
+ * the second, leaving marks off would make the SAME suggestion keep its bold on
+ * one line and lose it on two — a silent formatting change that reaches disk.
+ * Stamping them explicitly makes both branches agree.
+ */
+export function literalInlineContent(
+  text: string,
+  asCodeText = false,
+  marks: JSONContent["marks"] = undefined,
+): JSONContent[] {
+  if (text.length === 0) return [];
+  const textNode = (value: string): JSONContent =>
+    marks?.length ? { type: "text", text: value, marks } : { type: "text", text: value };
+
+  if (asCodeText) return [textNode(text)];
+
+  const content: JSONContent[] = [];
+  const segments = text.split(LINE_ENDING);
+  for (const [i, segment] of segments.entries()) {
+    // The break goes BETWEEN segments, so a leading/trailing newline still
+    // produces its break even though the segment beside it is empty.
+    if (i > 0) content.push({ type: "hardBreak" });
+    // A zero-length text node is invalid in ProseMirror.
+    if (segment.length > 0) content.push(textNode(segment));
+  }
+  return content;
+}

--- a/src/client/panels/useAnnotationReview.svelte.ts
+++ b/src/client/panels/useAnnotationReview.svelte.ts
@@ -1,4 +1,4 @@
-import type { Editor as TiptapEditor } from "@tiptap/core";
+import type { JSONContent, Editor as TiptapEditor } from "@tiptap/core";
 import { onDestroy } from "svelte";
 import * as Y from "yjs";
 import { Y_MAP_ANNOTATIONS } from "../../shared/constants";
@@ -7,7 +7,74 @@ import { sanitizeAnnotation } from "../../shared/sanitize";
 import type { Annotation } from "../../shared/types";
 import { isPendingReviewTarget } from "../../shared/types";
 import { AUTHORSHIP_ORIGIN_META } from "../editor/extensions/authorship";
+import { literalInlineContent } from "../editor/utils/literal-content";
 import { annotationToPmRange } from "../positions";
+
+/**
+ * Is this position inside a node that stores newlines literally?
+ *
+ * `codeBlock` declares `code: true` and does not admit `hardBreak` in its
+ * content expression, so the two contexts need different representations of the
+ * same newline. See `literalInlineContent`.
+ */
+function isCodeContext(editor: TiptapEditor, pos: number): boolean {
+  try {
+    // Not named `$pos` despite the ProseMirror convention: this is a
+    // `.svelte.ts` module and the Svelte compiler reserves the `$` prefix.
+    const resolvedPos = editor.state.doc.resolve(pos);
+    // Depth 0 — parent is the DOC rather than a textblock — is reachable: it is
+    // where `flatOffsetToPmPos` clamps an over-long flat offset, at
+    // `doc.content.size`. `doc.spec.code` is undefined there so this answers
+    // "prose", and that is CORRECT rather than a gap: `insertContentAt` at the
+    // document end appends a NEW PARAGRAPH, so the receiving node is a paragraph
+    // even when the last block is a code block. Reading the preceding node
+    // instead looks more careful and is wrong — it puts a literal newline, i.e.
+    // a soft wrap, into that paragraph. Measured, not reasoned.
+    return resolvedPos.parent.type.spec.code === true;
+  } catch {
+    // A position that will not resolve is about to fail the surrounding
+    // transaction anyway; prose is the safe assumption.
+    return false;
+  }
+}
+
+/**
+ * The flat text a PM range covers, in the SERVER's flat-text projection.
+ *
+ * Both separators are load-bearing, and they are the same argument made twice.
+ * `suggestedText` and `textSnapshot` come from `extractText()`, which spells a
+ * hard break "\n" (`leafText`) AND joins blocks with "\n" (`blockSeparator`).
+ * Drop the first and every multi-line suggestion looks edited-since-accept;
+ * drop the second and a range that has DRIFTED across a block boundary can
+ * concatenate to exactly the snapshot, passing a guard that exists to stop
+ * precisely that — after which undo deletes across the boundary and merges two
+ * blocks.
+ */
+export function rangeText(editor: TiptapEditor, from: number, to: number): string {
+  return editor.state.doc.textBetween(from, to, "\n", "\n");
+}
+
+/**
+ * The marks spanning a range, as JSON, for `literalInlineContent` to stamp.
+ *
+ * `marksAcross` returns null when the endpoints disagree, which is the right
+ * answer: a replacement straddling a bold boundary should not pick a side.
+ */
+function marksAcrossRange(
+  editor: TiptapEditor,
+  from: number,
+  to: number,
+): JSONContent["marks"] | undefined {
+  try {
+    const { doc } = editor.state;
+    return doc
+      .resolve(from)
+      .marksAcross(doc.resolve(to))
+      ?.map((m) => m.toJSON());
+  } catch {
+    return undefined;
+  }
+}
 
 /** Browser DevTools breadcrumb — only forensic trail client-side when sanitize coerces. */
 const devSanitizeWarn = (event: SanitizationEvent): void => {
@@ -38,19 +105,29 @@ export function applySuggestion(
   }
 
   try {
-    return (
-      editor
-        .chain()
-        .focus()
-        // Claude wrote this text; without the tag `Authorship.onTransaction`
-        // stamps it as the user's, which is #1388. The tag must live INSIDE the
-        // chain — a chain batches every step into one transaction, and a
-        // separate dispatch would tag a different one.
-        .setMeta(AUTHORSHIP_ORIGIN_META, "claude")
-        .deleteRange({ from: resolved.from, to: resolved.to })
-        .insertContentAt(resolved.from, newText)
-        .run()
+    // Inline JSON, never the raw string: `insertContentAt` HTML-parses a string
+    // argument, which downgraded every hard break to a soft wrap and let markup
+    // in a suggestion restructure the document (#1477).
+    const content = literalInlineContent(
+      newText,
+      isCodeContext(editor, resolved.from),
+      marksAcrossRange(editor, resolved.from, resolved.to),
     );
+    let chain = editor
+      .chain()
+      .focus()
+      // Claude wrote this text; without the tag `Authorship.onTransaction`
+      // stamps it as the user's, which is #1388. The tag must live INSIDE the
+      // chain — a chain batches every step into one transaction, and a
+      // separate dispatch would tag a different one.
+      .setMeta(AUTHORSHIP_ORIGIN_META, "claude")
+      .deleteRange({ from: resolved.from, to: resolved.to });
+    // An empty suggestion is a deletion. Inserting `[]` would not be a clean
+    // no-op — `createNodeFromContent` gates its array branch on a non-empty
+    // length, so `[]` falls through to `schema.nodeFromJSON([])`, throws, and is
+    // caught into an empty fragment plus a `[tiptap warn]: Invalid content.`
+    if (content.length > 0) chain = chain.insertContentAt(resolved.from, content);
+    return chain.run();
   } catch (err) {
     console.error("[SidePanel] Editor mutation failed for suggestion", ann.id, err);
     return false;
@@ -199,7 +276,7 @@ export function useAnnotationReview({
             scheduleRemoval(id);
             return false;
           }
-          const currentText = editor.state.doc.textBetween(resolved.from, resolved.to);
+          const currentText = rangeText(editor, resolved.from, resolved.to);
           if (currentText !== newText) {
             console.warn(`[undo] Text changed since accept for annotation ${id}, skipping`);
             scheduleRemoval(id);
@@ -213,12 +290,24 @@ export function useAnnotationReview({
           // entry the accept reaped, which needs the durable/`relRange` work in
           // #1471 — until then the common case is right and the rare one is
           // #1388's inversion in miniature. Tracked there, not silently left.
-          editor
-            .chain()
-            .focus()
-            .deleteRange({ from: resolved.from, to: resolved.to })
-            .insertContentAt(resolved.from, oldText)
-            .run();
+          // Same literal-content treatment as accept (#1477): restoring through
+          // a raw string put back a literal newline where the snapshot recorded
+          // a hard break as "\n", so undo could not restore what accept took
+          // away even when the range was right.
+          //
+          // KNOWN LIMIT (#1486): `textSnapshot` uses ONE "\n" for both a hard
+          // break and a block boundary, so undoing an accept that spanned two
+          // blocks restores a single block with a hard break rather than the two
+          // blocks that were there. The string cannot distinguish them; the fix
+          // is a structural snapshot, not a smarter parse of this one.
+          const restored = literalInlineContent(
+            oldText,
+            isCodeContext(editor, resolved.from),
+            marksAcrossRange(editor, resolved.from, resolved.to),
+          );
+          let chain = editor.chain().focus().deleteRange({ from: resolved.from, to: resolved.to });
+          if (restored.length > 0) chain = chain.insertContentAt(resolved.from, restored);
+          chain.run();
         }
       } catch (err) {
         console.warn(`[undo] Failed to revert text for annotation ${id}:`, err);

--- a/tests/client/suggestion-hardbreak-range.test.ts
+++ b/tests/client/suggestion-hardbreak-range.test.ts
@@ -22,13 +22,11 @@
  *
  * SCOPE. These assert the RANGE and what a plain-text replacement over it
  * produces. They deliberately do NOT assert what the shipping accept path
- * inserts: `insertContentAt` HTML-parses its string argument and collapses
- * newlines, which is a separate defect (#1477) with its own corruption modes,
- * pinned in its own describe block below. Conflating the two would let a fix
- * for one hide a regression in the other.
+ * inserts: `insertContentAt` HTML-parses its string argument, a separate defect
+ * (#1477) covered by `suggestion-literal-insert.test.ts` against a live editor.
+ * Conflating the two would let a fix for one hide a regression in the other.
  */
 
-import { createNodeFromContent } from "@tiptap/core";
 import { EditorState } from "@tiptap/pm/state";
 import { describe, expect, it } from "vitest";
 import * as Y from "yjs";
@@ -218,47 +216,18 @@ describe("#1450: replacing the resolved range", () => {
   });
 });
 
-describe("#1477: what the SHIPPING insert path does (known defect, pinned)", () => {
-  /**
-   * `applySuggestion` passes `suggestedText` to `insertContentAt`, which
-   * HTML-parses the string rather than inserting it literally. That is a
-   * separate bug from #1450 and is tracked as #1477.
-   *
-   * These assert the CURRENT broken behaviour on purpose, following the same
-   * convention as `roundtrip-corpus.test.ts`: when #1477 is fixed these fail,
-   * which is the signal to update them — rather than the defect quietly
-   * surviving because nothing described it.
-   */
-  const build = (input: string) =>
-    createNodeFromContent(input, productionSchema(), { preserveWhitespace: "full" });
-
-  const asJson = (input: string) => JSON.stringify(build(input).toJSON());
-
-  it("collapses a newline to a space instead of making a hard break", () => {
-    // The realistic case: textSnapshot renders every hard break as "\n", so a
-    // suggestion over a break-bearing paragraph normally contains newlines.
-    expect(asJson("one\ntwo")).toBe('[{"type":"text","text":"one two"}]');
-    // Not a preserveWhitespace problem — the other setting collapses too.
-    const loose = createNodeFromContent("one\ntwo", productionSchema(), {
-      preserveWhitespace: true,
-    });
-    expect(JSON.stringify(loose.toJSON())).toBe('[{"type":"text","text":"one two"}]');
-  });
-
-  it("parses markup in the suggestion instead of inserting it literally", () => {
-    // A suggestion that merely MENTIONS a tag splits the paragraph in two.
-    expect(asJson("use <div> for layout")).toContain('"type":"paragraph"');
-    // ...and inline tags become real marks.
-    expect(asJson("<b>bold</b> text")).toContain('"marks":[{"type":"bold"}]');
-    // ...and entities are decoded.
-    expect(asJson("AT&amp;T")).toContain('"text":"AT&T"');
-  });
-
-  it("leaves ordinary prose alone (the reason this went unnoticed)", () => {
-    expect(asJson("plain replacement")).toBe('[{"type":"text","text":"plain replacement"}]');
-    expect(asJson("a < b && c > d")).toBe('[{"type":"text","text":"a < b && c > d"}]');
-  });
-});
+// The insert half of the same action (#1477) is covered by
+// `suggestion-literal-insert.test.ts`, against a LIVE Tiptap editor.
+//
+// This file previously pinned that defect here using `createNodeFromContent`
+// directly. That was the wrong instrument and two of its assertions were simply
+// false of the shipping path: in isolation the helper collapses "one\ntwo" to
+// "one two" and decodes "&amp;", but a real editor — whose paragraph carries
+// `whitespace: "pre"` (#1461) — does neither. Worse, those assertions would have
+// stayed green after #1477 was fixed, so the known-defect convention they
+// claimed to follow could never have fired. Removed rather than corrected in
+// place: a probe that cannot observe the product does not become trustworthy by
+// having its expected values patched.
 
 describe("#1450: the schema assumption the fix rests on", () => {
   it("hardBreak is the only inline non-text node in the production schema", () => {

--- a/tests/client/suggestion-literal-insert.test.ts
+++ b/tests/client/suggestion-literal-insert.test.ts
@@ -1,0 +1,333 @@
+// @vitest-environment happy-dom
+
+/**
+ * Accepting a suggestion inserts `suggestedText` LITERALLY (#1477).
+ *
+ * `insertContentAt(pos, someString)` does not insert that string — Tiptap wraps
+ * it in `<body>` and runs `DOMParser`, so the argument is parsed as HTML. Two
+ * corruptions followed, both through the primary review action and both silent:
+ *
+ *   - a suggestion that merely MENTIONED markup was parsed as markup: `<div>`
+ *     SPLIT THE PARAGRAPH IN TWO and `<b>` became a real bold mark;
+ *   - every newline arrived as a literal "\n" inside a text node rather than a
+ *     `hardBreak`. `suggestedText` spells a hard break "\n" (the
+ *     `getElementText()` convention), and a literal newline in a paragraph is
+ *     how this editor represents a SOFT WRAP — so accepting a suggestion over a
+ *     multi-line paragraph silently downgraded every hard break to a soft one,
+ *     which renders differently.
+ *
+ * MEASUREMENT NOTE, because it cost a wrong issue body: probing this with
+ * `createNodeFromContent` in isolation gives DIFFERENT answers than the
+ * shipping path — a collapsed space, and decoded entities. Neither happens
+ * through a real editor, whose paragraph carries `whitespace: "pre"` (#1461).
+ * Entities are NOT decoded here. Measure through the Editor or not at all.
+ *
+ * These drive a LIVE Tiptap editor through the exported `applySuggestion`,
+ * because the defect lives in what Tiptap does with the argument. The hook's
+ * own suite mocks the editor wholesale and cannot see it — the same reason
+ * #1388 shipped past it.
+ */
+
+import { render } from "@testing-library/svelte";
+import { Editor } from "@tiptap/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
+import { literalInlineContent } from "../../src/client/editor/utils/literal-content";
+import {
+  applySuggestion,
+  rangeText,
+  useAnnotationReview,
+} from "../../src/client/panels/useAnnotationReview.svelte";
+import UseAnnotationReviewHarness from "../../src/client/svelte-harness/UseAnnotationReviewHarness.svelte";
+import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants";
+import type { Annotation } from "../../src/shared/types";
+
+function suggestion(from: number, to: number, suggestedText: string): Annotation {
+  return {
+    id: "a1",
+    type: "comment",
+    author: "claude",
+    status: "pending",
+    text: "why",
+    suggestedText,
+    createdAt: 0,
+    range: { from, to },
+  } as Annotation;
+}
+
+/** Inline shape of the first block, with hardBreak distinguishable from text. */
+function inlineShape(editor: Editor): string {
+  const doc = editor.getJSON();
+  const blocks = doc.content ?? [];
+  return blocks
+    .map(
+      (b) =>
+        `${b.type}(${(b.content ?? [])
+          .map((c) =>
+            c.type === "text"
+              ? `${JSON.stringify(c.text)}${c.marks?.length ? `^${c.marks.map((m) => m.type).join(",")}` : ""}`
+              : `<${c.type}>`,
+          )
+          .join("+")})`,
+    )
+    .join(" ");
+}
+
+describe("#1477: accepting inserts the suggestion literally", () => {
+  let ydoc: Y.Doc;
+  let editor: Editor;
+
+  beforeEach(() => {
+    ydoc = new Y.Doc();
+    editor = new Editor({
+      extensions: buildSchemaExtensions(),
+      content: "<p>hello world</p>",
+    });
+  });
+  afterEach(() => {
+    editor.destroy();
+    ydoc.destroy();
+  });
+
+  it("a plain replacement still works (positive control)", () => {
+    // Without this, every assertion below could be passing because the accept
+    // silently did nothing at all.
+    expect(applySuggestion(suggestion(0, 11, "goodbye world"), editor, ydoc)).toBe(true);
+    expect(inlineShape(editor)).toBe('paragraph("goodbye world")');
+  });
+
+  it("a newline becomes a hard break, not a literal newline", () => {
+    // Before the fix: paragraph("one\ntwo") — one text node holding a literal
+    // newline, which this editor treats as a SOFT wrap and the serializer
+    // writes back without the trailing backslash. The break is gone from the
+    // file even though the characters survive.
+    applySuggestion(suggestion(0, 11, "one\ntwo"), editor, ydoc);
+    expect(inlineShape(editor)).toBe('paragraph("one"+<hardBreak>+"two")');
+  });
+
+  it("several newlines each become their own break", () => {
+    applySuggestion(suggestion(0, 11, "a\nb\nc"), editor, ydoc);
+    expect(inlineShape(editor)).toBe('paragraph("a"+<hardBreak>+"b"+<hardBreak>+"c")');
+  });
+
+  it("markup in the suggestion is text, not markup", () => {
+    // Before the fix this split the paragraph in two.
+    applySuggestion(suggestion(0, 11, "use <div> for layout"), editor, ydoc);
+    expect(inlineShape(editor)).toBe('paragraph("use <div> for layout")');
+  });
+
+  it("an inline tag does not become a mark", () => {
+    // Before the fix: text carrying a real bold mark.
+    applySuggestion(suggestion(0, 11, "<b>bold</b> text"), editor, ydoc);
+    expect(inlineShape(editor)).toBe('paragraph("<b>bold</b> text")');
+  });
+
+  it("an HTML entity survives — as it already did (regression guard, not a fix)", () => {
+    // Deliberately labelled: this passes BEFORE the fix too. An isolated
+    // `createNodeFromContent` probe decodes this to "AT&T", which is what put a
+    // wrong claim in #1477's original body; the shipping path never did. Kept
+    // as a guard so the new JSON path cannot start decoding, but it is not
+    // evidence for the fix and must not be read as such.
+    applySuggestion(suggestion(0, 11, "AT&amp;T"), editor, ydoc);
+    expect(inlineShape(editor)).toBe('paragraph("AT&amp;T")');
+  });
+
+  it("an empty suggestion deletes the range without inserting anything", () => {
+    // `insertContentAt` with an empty array returns null and logs a Tiptap
+    // warning, so the insert has to be skipped rather than passed through.
+    expect(applySuggestion(suggestion(0, 11, ""), editor, ydoc)).toBe(true);
+    expect(inlineShape(editor)).toBe("paragraph()");
+  });
+
+  it("the accepted text reads back as the suggestion the guard compares against", () => {
+    // Undo re-reads the range and bails if it does not match `suggestedText`.
+    // That comparison is only well-founded if accept and the guard agree on how
+    // a hard break projects — so this pins the two halves together.
+    //
+    // Calls the PRODUCT's `rangeText`, not an inline `textBetween`. An earlier
+    // version of this test inlined it and therefore asserted a property of
+    // ProseMirror: revert the guard to a bare `textBetween` and it stayed green.
+    const text = "alpha\nbravo\ncharlie";
+    applySuggestion(suggestion(0, 11, text), editor, ydoc);
+    expect(rangeText(editor, 0, editor.state.doc.content.size)).toBe(text);
+  });
+
+  it("keeps the surrounding marks whether or not the suggestion has a newline", () => {
+    // `insertContentAt` branches on `isOnlyTextContent`: one unmarked text node
+    // goes through `tr.insertText`, which inherits marks across the range, and
+    // anything else through `tr.replaceWith`, which does not. A newline is
+    // exactly what moves this content from the first shape to the second — so
+    // without an explicit mark stamp the SAME suggestion kept its bold on one
+    // line and silently lost it on two, all the way to disk.
+    const bold = () =>
+      new Editor({ extensions: buildSchemaExtensions(), content: "<p><strong>aXXXb</strong></p>" });
+
+    const one = bold();
+    applySuggestion(suggestion(1, 4, "Y"), one, ydoc);
+    expect(one.getHTML(), "single line").toBe("<p><strong>aYb</strong></p>");
+    one.destroy();
+
+    const two = bold();
+    applySuggestion(suggestion(1, 4, "Y\nZ"), two, ydoc);
+    expect(two.getHTML(), "with a newline").toBe(
+      "<p><strong>aY</strong><br><strong>Zb</strong></p>",
+    );
+    two.destroy();
+  });
+});
+
+describe("#1477: code blocks store a newline as a newline", () => {
+  let ydoc: Y.Doc;
+  let editor: Editor;
+
+  beforeEach(() => {
+    ydoc = new Y.Doc();
+    editor = new Editor({
+      extensions: buildSchemaExtensions(),
+      content: "<pre><code>old</code></pre>",
+    });
+  });
+  afterEach(() => {
+    editor.destroy();
+    ydoc.destroy();
+  });
+
+  it("inserts literal newlines rather than schema-invalid break nodes", () => {
+    // `codeBlock` declares `code: true` and its content expression does not
+    // admit `hardBreak`, so emitting breaks here would build invalid content.
+    // A newline in a code block is genuinely a newline.
+    applySuggestion(suggestion(0, 3, "line1\nline2"), editor, ydoc);
+    expect(inlineShape(editor)).toBe('codeBlock("line1\\nline2")');
+  });
+});
+
+describe("#1477: undoing an accept restores the breaks it recorded", () => {
+  /**
+   * Undo is the half the accept-only tests above cannot reach, and the diff
+   * changed it in three independent ways (the staleness guard's projection, the
+   * literal restore, and the empty-content skip). It needs the real hook, so
+   * this mounts it through the Svelte harness the way the hook's own suite does.
+   */
+  function mountReview(params: Parameters<typeof useAnnotationReview>[0]) {
+    let api: ReturnType<typeof useAnnotationReview> | undefined;
+    render(UseAnnotationReviewHarness, {
+      props: { params, onReady: (returned) => (api = returned) },
+    });
+    if (!api) throw new Error("useAnnotationReview did not report ready");
+    return api;
+  }
+
+  function setup(html: string, ann: Annotation) {
+    const ydoc = new Y.Doc();
+    ydoc.getMap(Y_MAP_ANNOTATIONS).set(ann.id, ann);
+    const editor = new Editor({ extensions: buildSchemaExtensions(), content: html });
+    const review = mountReview({
+      getYdoc: () => ydoc,
+      getEditor: () => editor,
+      getAnnotations: () => [ann],
+      onActiveAnnotationChange: () => {},
+      getScrollBehavior: () => "auto",
+    });
+    return { ydoc, editor, review };
+  }
+
+  it("puts back a multi-line snapshot as hard breaks, not a soft wrap", () => {
+    // The round trip that matters: accept replaced a break-bearing paragraph,
+    // undo has to restore one. Through a raw string the restore produced a
+    // literal newline — a soft wrap — so the `\` never came back to the file
+    // even though the characters did.
+    const ann = {
+      id: "u1",
+      type: "comment",
+      author: "claude",
+      status: "accepted",
+      text: "why",
+      suggestedText: "one\ntwo",
+      textSnapshot: "alpha\nbravo",
+      createdAt: 0,
+      range: { from: 0, to: 7 },
+    } as Annotation;
+    const { editor, review } = setup("<p>one<br>two</p>", ann);
+
+    expect(review.undoResolveAnnotation("u1")).toBe(true);
+    expect(inlineShape(editor)).toBe('paragraph("alpha"+<hardBreak>+"bravo")');
+  });
+
+  it("declines when the text changed since accept", () => {
+    // The guard's whole job. Pinned because `rangeText`'s separators are what
+    // make the comparison well-founded — a projection mismatch would make this
+    // decline on EVERY multi-line accept instead of only edited ones.
+    const ann = {
+      id: "u2",
+      type: "comment",
+      author: "claude",
+      status: "accepted",
+      text: "why",
+      suggestedText: "one\ntwo",
+      textSnapshot: "alpha\nbravo",
+      createdAt: 0,
+      range: { from: 0, to: 7 },
+    } as Annotation;
+    const { editor, review } = setup("<p>edited since</p>", ann);
+
+    expect(review.undoResolveAnnotation("u2")).toBe(false);
+    expect(inlineShape(editor)).toBe('paragraph("edited since")');
+  });
+
+  it("an empty snapshot deletes the accepted text without inserting", () => {
+    const ann = {
+      id: "u3",
+      type: "comment",
+      author: "claude",
+      status: "accepted",
+      text: "why",
+      suggestedText: "one",
+      textSnapshot: "",
+      createdAt: 0,
+      range: { from: 0, to: 3 },
+    } as Annotation;
+    const { editor, review } = setup("<p>one</p>", ann);
+
+    expect(review.undoResolveAnnotation("u3")).toBe(true);
+    expect(inlineShape(editor)).toBe("paragraph()");
+  });
+});
+
+describe("literalInlineContent", () => {
+  it("splits on every line-ending convention", () => {
+    for (const nl of ["\n", "\r\n", "\r"]) {
+      expect(literalInlineContent(`a${nl}b`), nl).toEqual([
+        { type: "text", text: "a" },
+        { type: "hardBreak" },
+        { type: "text", text: "b" },
+      ]);
+    }
+  });
+
+  it("keeps a leading or trailing newline as a break with no empty text node", () => {
+    // A zero-length text node is invalid in ProseMirror, so the break has to
+    // survive without one beside it.
+    expect(literalInlineContent("\nb")).toEqual([
+      { type: "hardBreak" },
+      { type: "text", text: "b" },
+    ]);
+    expect(literalInlineContent("a\n")).toEqual([
+      { type: "text", text: "a" },
+      { type: "hardBreak" },
+    ]);
+  });
+
+  it("turns a run of newlines into that many breaks", () => {
+    expect(literalInlineContent("\n\n")).toEqual([{ type: "hardBreak" }, { type: "hardBreak" }]);
+  });
+
+  it("returns an empty array for empty text", () => {
+    expect(literalInlineContent("")).toEqual([]);
+    expect(literalInlineContent("", true)).toEqual([]);
+  });
+
+  it("leaves newlines alone in code mode", () => {
+    expect(literalInlineContent("a\nb", true)).toEqual([{ type: "text", text: "a\nb" }]);
+  });
+});


### PR DESCRIPTION
Accepting a suggestion inserted `suggestedText` as **HTML**, not as text. `insertContentAt(pos, someString)` routes a string through `createNodeFromContent`, which wraps it in `<body>` and runs `DOMParser`. Two silent corruptions followed, both through the primary review action:

- **Markup in a suggestion was applied as markup.** `<div>` split the paragraph in two; `<b>` became a real bold mark. A suggestion that merely *mentions* a tag restructured the document.
- **Every newline arrived as a literal `\n`** in a text node rather than a `hardBreak`. `suggestedText` spells a hard break `\n` (the `getElementText()` convention), and a literal newline in a paragraph is how this editor represents a **soft wrap** — so accepting over a multi-line paragraph downgraded every hard break to a soft one. The characters survive; the `\` does not, and the file changes.

Both are fixed by passing inline JSON, which takes `createNodeFromContent`'s `Fragment.fromJSON` branch and never parses. `literalInlineContent` splits on line endings and interleaves `hardBreak` nodes — except inside a code block, where `code: true` and a content expression that does not admit `hardBreak` mean a newline is genuinely a newline. Undo gets the same treatment.

## What adversarial review changed

Two further defects in my first cut, both reproduced against a live editor before fixing and both now pinned by tests that fail without the fix:

**Marks were lost on multi-line suggestions only.** `insertContentAt` branches on `isOnlyTextContent`: a single unmarked text node goes through `tr.insertText`, which inherits `marksAcross` for free; anything else goes through `tr.replaceWith`, which does not. A newline is exactly what moves this content from the first shape to the second, so the same suggestion kept its bold on one line and silently lost it on two, all the way to disk:

```
<p><strong>aXXXb</strong></p>, replace "XXX"
  with "Y"    → <strong>aYb</strong>                     (bold kept)
  with "Y\nZ" → <strong>a</strong>Y<br>Z<strong>b</strong>   (bold LOST)
```

**The undo staleness guard used the wrong projection.** It compared with no block separator, while `textSnapshot` comes from `extractText()`, which joins blocks with `\n`. A range that had drifted across a block boundary could concatenate to exactly the snapshot and pass a guard whose entire job is to stop that — after which undo deletes across the boundary and merges two blocks.

**One review finding was measured and rejected.** At `doc.content.size` the resolved parent is the doc node rather than a textblock, which looks like a hole for a document ending in a code block. It isn't: `insertContentAt` at the document end appends a **new paragraph**, so the receiving node is a paragraph and "prose" is the right answer. Reading the preceding node instead looks more careful and would put a soft wrap where a break belongs. The reasoning is recorded at the site, because the wrong version is the one that looks correct.

## Measurement correction

#1477's original body claimed newlines collapse to spaces and entities are decoded. **Neither is true of the shipping path.** Both readings came from probing `createNodeFromContent` in isolation, outside the live editor whose paragraph carries `whitespace: "pre"` (#1461). A [correction comment](https://github.com/bloknayrb/tandem/issues/1477#issuecomment-5305342024) is on the issue.

The knock-on: `tests/client/suggestion-hardbreak-range.test.ts` (merged in #1478) pinned this defect with that same wrong instrument. Those assertions were doubly bad — they asserted behaviour the product does not have, **and** they would have stayed green after this fix, so the known-defect convention they claimed to follow could never have fired. They are **removed** rather than corrected in place: a probe that cannot observe the product does not become trustworthy by having its expected values patched.

The reusable part, since it is the second time in this series: being right that someone else's numbers were wrong is not the same as being right. I replaced a reviewer's wrong measurements with my own equally-wrong ones. Measure through the surface the user actually reaches, or say plainly that you didn't.

## Tests

`tests/client/suggestion-literal-insert.test.ts` drives a **real `Editor`** through the real `applySuggestion`, and the undo cases drive the **real hook** through the Svelte harness — undo was previously untested, and this diff changed it in three independent ways.

Negative-controlled: reverting the mark stamp fails 1 test, reverting the guard projection fails 2. The entity test is explicitly labelled a regression guard that passes before the fix too, so it is not read as evidence.

## Filed separately

Both surfaced by this review, neither caused by this change:

- **#1485** — accepting a suggestion on a table cell **deletes the neighbouring cell**. `flatOffsetToPmPos` overshoots `to` into the next cell; same family as #1450 but in the flat fallback rather than the CRDT path. Data loss with no recovery.
- **#1486** — `textSnapshot` cannot represent a block boundary (one `\n` means both that and a hard break), and is truncated at 200 chars with `...` appended, which undo then writes into the document verbatim.

The first is documented as a KNOWN LIMIT at the undo site.

## Verification

- `npm run typecheck` — 1327 files, 0 errors, 0 warnings
- `npm test` — 479 files, 6941 passed, 19 skipped
- biome clean; pre-push hook (biome + vitest + `cargo test`) green

Closes #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnpXPQuW7p25SHTHV9HfMK
