### PR TITLE
fix(positions): resolve flat offsets at a block boundary inside the block

### DIFF
--- a/src/client/positions.ts
+++ b/src/client/positions.ts
@@ -71,15 +71,54 @@ function resolveWithinNode(node: PmNode, textOffset: number, pmStart: number): P
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
     const childStart = pmOffset + 1;
-    if (i > 0) accumulated += 1;
     const childLen = pmNodeFlatTextLength(child);
     if (accumulated + childLen > textOffset) {
       return resolveWithinNode(child, textOffset - accumulated, childStart);
     }
     accumulated += childLen;
     pmOffset += child.nodeSize;
+
+    if (i < node.childCount - 1) {
+      // The FLAT_SEPARATOR between two block children. An offset that lands ON
+      // it means "the end of this child" — and it MUST be resolved here (#1485).
+      //
+      // Charging the separator at the top of the next iteration instead, which
+      // is what this loop used to do, makes the next child's test pass with a
+      // NEGATIVE `textOffset - accumulated`, so the recursion resolves inside
+      // the WRONG child and returns a position one past the previous child's
+      // close token. For a table that put `to` inside the next CELL, and the
+      // accept's deleteRange then ate it: a suggestion on the first cell of a
+      // row silently deleted the second.
+      accumulated += 1;
+      if (accumulated > textOffset) {
+        // Recurse rather than `childStart + child.content.size`: for a container
+        // child (a cell, a list item) that sum lands between the inner block's
+        // close token and the container's, which is not a text position.
+        return resolveWithinNode(child, childLen, childStart);
+      }
+    }
   }
-  return toPmPos(pmStart + node.content.size);
+
+  // Past the end of every child — clamp to the end of the LAST one. The old
+  // `pmStart + node.content.size` is the container's own inner boundary, which
+  // is a text position only when the container's last child is inline. For a
+  // table cell wrapping a paragraph it sits BETWEEN the paragraph's close token
+  // and the cell's, and a range ending there spans a structural boundary.
+  //
+  // Recursion terminates because each step descends exactly one level in a
+  // finite tree, and this branch is reached with `textOffset` already equal to
+  // the node's full flat length, so no child's test can fire and re-enter here.
+  // It does NOT always bottom out in a textblock — a container whose last child
+  // is a LEAF (a `horizontalRule`) or which is empty ends the descent early,
+  // and the `+1` below assumes an open token a leaf does not have. Both return
+  // the same value the old code did, so those shapes are unimproved rather than
+  // broken; say so rather than claiming an invariant this does not establish.
+  if (node.childCount > 0) {
+    const last = node.child(node.childCount - 1);
+    const lastStart = pmStart + node.content.size - last.nodeSize + 1;
+    return resolveWithinNode(last, pmNodeFlatTextLength(last), lastStart);
+  }
+  return toPmPos(pmStart);
 }
 
 /**
@@ -116,11 +155,34 @@ export function flatOffsetToPmPos(doc: PmNode, flatOffset: FlatOffset): PmPos {
     if (i < nodeCount - 1) {
       accumulated += 1; // \n separator
       if (accumulated > flatOffset) {
-        return toPmPos(childStart + child.content.size);
+        // End of this block. Recurse rather than `childStart + content.size`:
+        // that sum is only a text position when the child is a TEXTBLOCK. For a
+        // container (a table, a list, a blockquote) it lands between the last
+        // inner block's close token and the container's own, which resolves to
+        // a structural position and makes the surrounding deleteRange take the
+        // node boundary with it. Same defect as #1485, one level up.
+        return resolveWithinNode(child, textLen, childStart);
       }
     }
   }
 
+  // Past the end of the document — the end of the LAST block, by the same
+  // reasoning as `resolveWithinNode`'s fallthrough. `doc.content.size` is the
+  // position AFTER the last block closes, whose parent is the doc node, and it
+  // is reached for `flatOffset === flat.length` in EVERY document shape, not
+  // just container-ending ones. `tr.delete` survives it (ProseMirror re-fits the
+  // slice) but an insert does not: `insertContentAt(doc.content.size, …)`
+  // appends a new sibling paragraph AFTER the last block, so a suggestion whose
+  // range ends at the end of the document grew a stray paragraph instead of
+  // extending the last one.
+  if (doc.childCount > 0) {
+    const last = doc.child(doc.childCount - 1);
+    return resolveWithinNode(
+      last,
+      pmNodeFlatTextLength(last),
+      doc.content.size - last.nodeSize + 1,
+    );
+  }
   return toPmPos(doc.content.size);
 }
 

--- a/tests/client/awareness-decoration.test.ts
+++ b/tests/client/awareness-decoration.test.ts
@@ -184,8 +184,11 @@ describe("buildAwarenessDecorations", () => {
     // Flat text is "Hi" (length 2), doc.content.size = 4, offset 999 exceeds both
     buildAwarenessDecorations(doc as any, makeAwareness({ focusOffset: 999 }));
     expect(capturedWidgets).toHaveLength(1);
-    // flatOffsetToPmPos falls through to doc.content.size = 4
-    expect(capturedWidgets[0].pos).toBe(doc.content.size);
+    // Clamps to the end of the last block's TEXT (3), not to `doc.content.size`
+    // (4). Changed by #1485: `content.size` is the position after the paragraph
+    // closes, whose parent is the doc node — a remote cursor rendered there sits
+    // outside every textblock. 3 is where the caret actually belongs.
+    expect(capturedWidgets[0].pos).toBe(3);
   });
 
   it("adds idle class when active is false", () => {

--- a/tests/client/coordinate-conversion.test.ts
+++ b/tests/client/coordinate-conversion.test.ts
@@ -96,7 +96,12 @@ describe("flatOffsetToPmPos", () => {
     expect(flatOffsetToPmPos(doc as any, 0)).toBe(1);
     expect(flatOffsetToPmPos(doc as any, 2)).toBe(3);
     expect(flatOffsetToPmPos(doc as any, 4)).toBe(5);
-    expect(flatOffsetToPmPos(doc as any, 5)).toBe(doc.content.size); // past end → content.size
+    // End of the text, NOT `doc.content.size` (7). Changed by #1485: 7 is the
+    // position after the paragraph's close token, whose parent is the doc node,
+    // so an insert there appends a stray sibling paragraph instead of extending
+    // this one. This assertion pinned that defect — note it is a MOCK doc, the
+    // same instrument that let #1450 through.
+    expect(flatOffsetToPmPos(doc as any, 5)).toBe(6);
   });
 
   it('H1 heading — prefix "# " (length 2) clamps to text start', () => {

--- a/tests/client/flat-offset-container-boundary.test.ts
+++ b/tests/client/flat-offset-container-boundary.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Flat offsets at a container's internal block boundary (#1485).
+ *
+ * `resolveWithinNode` charged the FLAT_SEPARATOR between two block children at
+ * the TOP of the next iteration. So an offset landing exactly on that separator
+ * — the end of child N — failed child N's `>` test, then passed child N+1's with
+ * a NEGATIVE remaining offset, and the recursion resolved inside the wrong
+ * child. The returned position sat one past child N's close token.
+ *
+ * Through the accept path that is destructive, not merely off-by-one: the range
+ * spans a structural boundary, so `deleteRange` takes the boundary with it. A
+ * suggestion on the first cell of a table row DELETED the second cell; a
+ * suggestion on the first item of a list ate into the second item.
+ *
+ * The same shape existed one level up in `flatOffsetToPmPos`, whose boundary
+ * return was `childStart + child.content.size`. That is a text position only
+ * when the child is a TEXTBLOCK — for a container it lands between the last
+ * inner block's close token and the container's own.
+ *
+ * SCOPE. This is the FLAT fallback path. #1450/#1459 fixed the same class of
+ * drift in the CRDT (`relRange`) path, and an annotation carrying a live
+ * `relRange` never reaches this code — which is exactly why it survived: the
+ * common case is resolved by the other branch.
+ */
+
+import { EditorState } from "@tiptap/pm/state";
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { flatOffsetToPmPos, pmPosToFlatOffset } from "../../src/client/positions";
+import { loadMarkdown } from "../../src/server/file-io/markdown";
+import { extractText } from "../../src/server/mcp/document-model";
+import type { FlatOffset } from "../../src/shared/positions/types";
+import { toPmPos } from "../../src/shared/positions/types";
+import { productionSchema, yDocToPmNode } from "./editor-roundtrip-harness.js";
+
+type PMNode = ReturnType<typeof yDocToPmNode>;
+
+function docPair(markdown: string) {
+  const ydoc = new Y.Doc();
+  loadMarkdown(ydoc, markdown);
+  return { ydoc, pmDoc: yDocToPmNode(ydoc, productionSchema()) };
+}
+
+/** Structural render — a node boundary must be visible, not flattened to text. */
+function structure(node: PMNode): string {
+  const parts: string[] = [];
+  node.forEach((child) => {
+    if (child.isText) parts.push(JSON.stringify(child.text));
+    else if (child.isTextblock || child.childCount > 0)
+      parts.push(`${child.type.name}(${structure(child)})`);
+    else parts.push(`<${child.type.name}>`);
+  });
+  return parts.join("+");
+}
+
+const TABLE = "| a | b |\n|---|---|\n| cell | two |\n";
+const LIST = "- one\n- two\n";
+
+/**
+ * The corpus both property tests run over.
+ *
+ * Deliberately wider than the shapes the bug was reported against. #1485 was
+ * filed as a table bug; the list case only surfaced because the property ran
+ * over a shape nobody suspected, and the end-of-document case only surfaced
+ * because a later shape ended in something other than a paragraph. The cost of
+ * an extra entry here is a few milliseconds.
+ *
+ * Shapes chosen to reach specific branches:
+ *  - `blockquote, two paragraphs` / `table cell, two paragraphs` — the only
+ *    ones that exercise a MULTI-CHILD container's fallthrough, which is what
+ *    the fix's own comment is written about.
+ *  - `heading` — the boundary branch passes a prefix-EXCLUDED length.
+ *  - `hard breaks` — one flat char, zero text-node chars.
+ *  - `horizontal rule` / `empty list item` — where the descent stops before
+ *    reaching a textblock; pinned so a future change notices if that moves.
+ */
+const SHAPES: Record<string, string> = {
+  table: TABLE,
+  list: LIST,
+  "list then paragraph": "- one\n- two\n\nafter\n",
+  blockquote: "> quoted\n\npara\n",
+  "two paragraphs": "alpha\n\nbravo\n",
+  "nested list": "- one\n  - inner\n- two\n",
+  "blockquote, two paragraphs": "> one\n>\n> two\n\nafter\n",
+  heading: "# Title\n\nbody\n",
+  "heading last": "body\n\n### Deep\n",
+  "code block": "para\n\n```\ncode\nmore\n```\n",
+  "hard breaks": "alpha\\\nbravo\\\ncharlie\n",
+  "ends with a container": "intro\n\n- one\n- two\n",
+  "ends with a table": "intro\n\n| a | b |\n|---|---|\n| c | d |\n",
+  "single paragraph": "only\n",
+  "empty list item": "- one\n-\n\nafter\n",
+  "horizontal rule": "a\n\n---\n\nb\n",
+};
+
+/**
+ * Offsets that do NOT resolve inside a textblock, with the reason, pinned as an
+ * exact set.
+ *
+ * All three are PRE-EXISTING and unchanged by #1485 — I checked each against
+ * the old code. They are listed rather than excluded from the corpus because an
+ * exception that is silently skipped is an exception nobody re-examines: if a
+ * later change fixes one, or introduces a fourth, this set fails and says so.
+ *
+ * - `empty list item` — a `listItem` with no children at all. There is no
+ *   textblock inside it to land in, so no better answer exists. Round-trips
+ *   correctly.
+ * - `horizontal rule` — an `hr` contributes zero flat characters but sits
+ *   between two block separators, so one flat offset belongs to it and has no
+ *   text position anywhere. Resolving it to the end of the previous block or
+ *   the start of the next is a judgment call that belongs with the flat-text
+ *   convention, not with this fix.
+ */
+const KNOWN_NON_TEXTBLOCK: Record<string, number[]> = {
+  "empty list item": [4],
+  "horizontal rule": [2],
+};
+
+/**
+ * Offsets where `flat -> pm -> flat` is not the identity, pinned the same way.
+ *
+ * Also pre-existing. A heading's `"# "` prefix occupies flat offsets with no
+ * ProseMirror counterpart — `flatOffsetToPmPos` clamps them to the start of the
+ * heading's text, so they all map to the same position and come back as the
+ * first post-prefix offset. The `horizontal rule` entry is the same zero-width
+ * block as above.
+ */
+const KNOWN_NON_ROUNDTRIP: Record<string, number[]> = {
+  heading: [0, 1],
+  // "body\n### Deep" — the "### " prefix sits at flat offsets 5-8.
+  "heading last": [5, 6, 7, 8],
+  "horizontal rule": [2],
+};
+
+describe("#1485: an offset on a container's internal block boundary", () => {
+  it("resolves to the END of the block it belongs to, not into the next one", () => {
+    // The direct assertion. In the table above the flat text is
+    // "a\nb\ncell\ntwo"; offset 8 is the end of "cell". Before the fix this
+    // returned a position inside the SECOND cell.
+    //
+    // Keep this ALONGSIDE the round-trip property below rather than trusting
+    // that property alone. A third defect in the same function returned the
+    // cell's own inner boundary — between the paragraph's close token and the
+    // cell's — and `pmPosToFlatOffset` maps that back to 8, so the round trip
+    // was perfectly green while the position was still structural. Only naming
+    // the expected parent node caught it.
+    const { pmDoc } = docPair(TABLE);
+    const at = flatOffsetToPmPos(pmDoc, 8 as FlatOffset);
+
+    // Resolving there must land inside the first cell's paragraph, at its end.
+    const $at = pmDoc.resolve(at);
+    expect($at.parent.type.name, "parent node").toBe("paragraph");
+    expect($at.parent.textContent, "which paragraph").toBe("cell");
+    expect($at.parentOffset, "at the end of it").toBe(4);
+  });
+
+  it("resolves to a TEXTBLOCK for every offset in every shape", () => {
+    // The invariant the whole fix establishes, and the one assertion the
+    // round-trip property below is structurally incapable of making.
+    //
+    // `flat -> pm -> flat` is the identity even for a structural position, so
+    // the round trip is GREEN over the entire family of bugs this file is
+    // about. Measured: with the fix reverted, the blockquote shape below
+    // round-trips perfectly while resolving offset 6 to the blockquote's own
+    // inner end. This loop is what catches that, and it is what caught the
+    // end-of-document case (`doc.content.size`, parent = the doc node) that
+    // survived the first two rounds of this fix in EVERY shape, container or
+    // not.
+    for (const [name, markdown] of Object.entries(SHAPES)) {
+      const { ydoc, pmDoc } = docPair(markdown);
+      const flat = extractText(ydoc);
+      const structural: number[] = [];
+      for (let i = 0; i <= flat.length; i++) {
+        const pos = flatOffsetToPmPos(pmDoc, i as FlatOffset);
+        if (!pmDoc.resolve(pos).parent.isTextblock) structural.push(i);
+      }
+      // Asserted as an exact SET, not as "none": the two documented exceptions
+      // have no textblock answer to give, and pinning them means a fourth one
+      // appearing is a failure rather than a silently widened skip list.
+      expect(structural, `${name}: offsets not inside a textblock`).toEqual(
+        KNOWN_NON_TEXTBLOCK[name] ?? [],
+      );
+    }
+  });
+
+  it("every flat offset survives a round trip, for each container shape", () => {
+    // The general property, and the one that caught the list case: a boundary
+    // offset that resolved into the wrong child came back as a DIFFERENT flat
+    // offset. Checking only the shapes we thought were affected would have
+    // missed lists entirely — the issue was filed as a table bug.
+    //
+    // Kept DESPITE being weaker than the invariant above: it is the assertion
+    // that catches a wrong-child resolution, which the textblock check cannot
+    // see (the wrong child is still a textblock).
+    for (const [name, markdown] of Object.entries(SHAPES)) {
+      const { ydoc, pmDoc } = docPair(markdown);
+      const flat = extractText(ydoc);
+      const drifted: number[] = [];
+      for (let i = 0; i <= flat.length; i++) {
+        const pm = flatOffsetToPmPos(pmDoc, i as FlatOffset);
+        if (pmPosToFlatOffset(pmDoc, pm) !== i) drifted.push(i);
+      }
+      expect(drifted, `${name}: offsets that do not round-trip`).toEqual(
+        KNOWN_NON_ROUNDTRIP[name] ?? [],
+      );
+    }
+  });
+});
+
+describe("#1485: replacing the resolved range does not eat a sibling", () => {
+  /**
+   * Delete a flat-resolved range and insert over it. Asserted STRUCTURALLY: a
+   * text-level assertion cannot see a cell or list item disappearing, which is
+   * the entire damage here.
+   *
+   * NOT a replay of the accept path, and the difference matters: `applySuggestion`
+   * uses Tiptap's `deleteRange` + `insertContentAt`, and those two diverge from
+   * `tr.delete` + `tr.insertText` precisely AT structural positions — an
+   * `insertContentAt` at `doc.content.size` appends a stray sibling paragraph
+   * where `insertText` quietly lands in the last block. So this models the range
+   * arithmetic, not the accept. The end-to-end behaviour of the accept path is
+   * pinned against a live editor in `suggestion-literal-insert.test.ts`.
+   */
+  function replace(markdown: string, from: number, to: number, text: string): string {
+    const { pmDoc } = docPair(markdown);
+    const pmFrom = flatOffsetToPmPos(pmDoc, from as FlatOffset);
+    const pmTo = flatOffsetToPmPos(pmDoc, to as FlatOffset);
+    const state = EditorState.create({ doc: pmDoc });
+    const tr = state.tr.delete(pmFrom, pmTo);
+    tr.insertText(text, toPmPos(pmFrom));
+    return structure(state.apply(tr).doc);
+  }
+
+  it("a suggestion on the first table cell leaves the second cell alone", () => {
+    // Before the fix the row came back with ONE cell holding two paragraphs —
+    // the second cell was gone and unrecoverable.
+    const after = replace(TABLE, 4, 8, "REPLACED");
+    expect(after).toContain('paragraph("REPLACED")');
+    expect(after, "the second cell must survive").toContain('paragraph("two")');
+    expect(after.match(/tableCell/g)?.length, "cell count").toBe(2);
+  });
+
+  it("a suggestion on the first list item leaves the second item alone", () => {
+    // Filed as a table bug; the round-trip property above surfaced this one.
+    const after = replace(LIST, 0, 3, "REPLACED");
+    expect(after).toContain('paragraph("REPLACED")');
+    expect(after, "the second item must survive").toContain('paragraph("two")');
+    expect(after.match(/listItem/g)?.length, "item count").toBe(2);
+  });
+
+  it("a range ending at the END OF THE DOCUMENT stays inside the last block", () => {
+    // `flatOffsetToPmPos(doc, flat.length)` returned `doc.content.size` — the
+    // position after the last block CLOSES — in every shape, container or not.
+    // `tr.delete` survives that (ProseMirror re-fits the slice) but an insert
+    // does not: the accept path's `insertContentAt` appends a stray sibling
+    // paragraph instead of extending the last block.
+    const { ydoc, pmDoc } = docPair("intro\n\n- one\n- two\n");
+    const flat = extractText(ydoc);
+    const end = flatOffsetToPmPos(pmDoc, flat.length as FlatOffset);
+    const $end = pmDoc.resolve(end);
+    expect($end.parent.type.name).toBe("paragraph");
+    expect($end.parent.textContent).toBe("two");
+    expect($end.parentOffset, "at the end of the last block's text").toBe(3);
+  });
+});
+
+describe("#1485: the fallthrough's descent", () => {
+  it("terminates on a deeply nested container", () => {
+    // The fix made the fallthrough recursive. It descends one level per step in
+    // a finite tree, so it cannot loop — but "cannot loop" is a claim, and this
+    // is what makes it a checked one. Fails as a stack overflow, not a wrong
+    // value, so an assertion on the result would not be the point.
+    const deep = `${"> ".repeat(200)}x\n\nafter\n`;
+    const { ydoc, pmDoc } = docPair(deep);
+    const flat = extractText(ydoc);
+    for (let i = 0; i <= flat.length; i++) {
+      expect(() => flatOffsetToPmPos(pmDoc, i as FlatOffset)).not.toThrow();
+    }
+  });
+
+  it("lands in the right block for a MULTI-CHILD container", () => {
+    // The shape the fix's own comment is written about — a container whose
+    // fallthrough has more than one child to choose between. Every other test
+    // here uses single-child cells and items, which reach the fallthrough
+    // trivially. Markdown can express this one as a blockquote holding two
+    // paragraphs; a table cell holding two cannot be written in markdown at all.
+    const { ydoc, pmDoc } = docPair("> one\n>\n> two\n\nafter\n");
+    const flat = extractText(ydoc);
+    // Flat text is "one\n\ntwo\nafter"; offset 8 is the end of "two", the last
+    // block INSIDE the blockquote — the fallthrough's multi-child case.
+    const endOfQuote = flat.indexOf("two") + 3;
+    const $at = pmDoc.resolve(flatOffsetToPmPos(pmDoc, endOfQuote as FlatOffset));
+    expect($at.parent.type.name).toBe("paragraph");
+    expect($at.parent.textContent).toBe("two");
+    expect($at.parentOffset).toBe(3);
+  });
+});


### PR DESCRIPTION
**Accepting a suggestion on a table cell deleted the neighbouring cell.** Not an off-by-one — the resolved range spanned a structural boundary, so `deleteRange` took the boundary with it and the row came back with one cell holding two paragraphs. Unrecoverable.

```
before: row[ cell("cell"), cell("two") ]
after : row[ cell( p("REPLACED"), p("two") ) ]
```

## Cause

`resolveWithinNode` charged the `FLAT_SEPARATOR` between two block children at the **top of the next loop iteration**. An offset landing exactly on that separator — the end of child N — failed child N's strict `>` test, then passed child N+1's with a **negative** remaining offset. The recursion resolved inside the wrong child and returned a position one past child N's close token.

**It was never only tables.** The new property test runs over shapes nobody suspected, and lists have it too: a suggestion on the first bullet ate into the second.

## Three sites, same defect at different levels

1. **`resolveWithinNode`'s loop** — separator moved to the end of the iteration, mirroring the structure `flatOffsetToPmPos` already had.
2. **Both boundary returns** — `childStart + child.content.size` → a recursive descent. That sum is a text position only when the child is a **textblock**; for a container it lands between the last inner block's close token and the container's own.
3. **Both fallthroughs.** The doc-level one means `flatOffsetToPmPos(doc, flat.length)` no longer returns `doc.content.size` — which it did in **every** document shape, container or not. `tr.delete` survives that; an insert does not, since `insertContentAt(doc.content.size, …)` appends a stray sibling paragraph instead of extending the last block. This also affects the four callers with no CRDT alternative (authorship decorations, ChatPanel, OutlinePanel, awareness).

Site 3's doc-level half came from adversarial review. Sites 2 and 3 came from the test asserting the resolved position's **parent node**, not just that it round-trips.

## The round-trip property is blind to this whole family

`flat → pm → flat` is the identity **even for a structural position**, so it stays green while the position is wrong. Measured with the fix reverted:

- the `blockquote` shape round-trips perfectly while resolving offset 6 to the blockquote's own inner end — that leg of the property test was entirely vacuous;
- `list then paragraph` catches offset 3 but not offset 7, the container→sibling boundary;
- the end-of-document case is invisible in **every** shape.

So the file asserts both: a `parent.isTextblock` invariant *and* the round trip. Neither subsumes the other — the invariant can't see a wrong-child resolution (the wrong child is still a textblock), and the round trip can't see a structural position.

## Known exceptions are pinned, not skipped

Three offsets don't resolve into a textblock, all pre-existing and verified against the old code: an empty `listItem` has no textblock to land in; an `hr` contributes zero flat characters but sits between two separators, so one offset belongs to it and has no text position anywhere; a heading's `"# "` prefix occupies offsets with no ProseMirror counterpart. They're asserted as an **exact set** with reasons, so a fourth one appearing is a failure rather than a silently widened skip list.

## Two existing assertions were pinning the bug

Updated as deliberate decisions:

- `coordinate-conversion.test.ts` expected `doc.content.size` past the end — on a **mock doc**, the same instrument that let #1450 through.
- `awareness-decoration.test.ts` rendered a clamped remote cursor at `content.size`, outside every textblock.

## Scope

This is the **flat fallback** path. #1450/#1459 fixed the same class in the CRDT (`relRange`) path, and an annotation carrying a live `relRange` never reaches this code — which is exactly why it survived. Verified: a real annotation on a table resolves via `method: "rel"`.

Separately noted and **not** fixed here: a genuinely cross-cell range still merges cells on accept, identically on both paths. That belongs to the accept path refusing such a range, not to coordinate conversion.

## Verification

- New suite: 8 tests, including a `parent.isTextblock` invariant over 16 shapes, a termination test at 200 nesting levels, and the multi-child-container fallthrough
- Negative-controlled: reverting the loop fix fails 5, reverting the doc-end fix fails 2 — while the round-trip test stays green, which is the point
- `npm run typecheck` — 1327 files, 0 errors
- `npm test` — 482 files, 6962 passed
- pre-push hook (biome + vitest + `cargo test`) green

Closes #1485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnpXPQuW7p25SHTHV9HfMK
