### PR TITLE
fix(scratchpad): persist formatting as marks, not as literal HTML tags

### DIFF
--- a/src/client/hooks/useScratchpadPersistence.svelte.ts
+++ b/src/client/hooks/useScratchpadPersistence.svelte.ts
@@ -121,36 +121,126 @@ function purgeLegacyScratchpadKeys(): void {
 const PERSIST_DEBOUNCE_MS = 500;
 
 /**
- * Extract plain text from a Y.XmlFragment ("default" document content). Walks
- * top-level block elements (paragraphs, headings, list items, etc.) and joins
- * their text content with newlines. Inline marks are dropped — recovery is
- * plain text, matching the issue's "unsaved content" scope.
+ * One run of text in a scratchpad block, with whatever inline marks it carries.
+ *
+ * This is Yjs's own delta shape (`Y.XmlText.toDelta()`), kept as-is so no third
+ * format has to be maintained.
+ *
+ * INLINE formatting round-trips; block structure does not. Every block restores
+ * as a `paragraph`, so a heading or a list item comes back as plain text — the
+ * pre-existing scope, unchanged here. And two sibling `Y.XmlText` nodes inside
+ * one block concatenate into a single run, which is also pre-existing (the old
+ * code concatenated the characters the same way). So this is not a general
+ * inverse of the editor's state; it preserves the characters and their marks.
  */
-export function extractFragmentBlocks(fragment: Y.XmlFragment): string[] {
-  const blocks: string[] = [];
-  const collect = (node: Y.XmlElement | Y.XmlText | Y.XmlHook): string => {
-    if (node instanceof Y.XmlText) return node.toString();
-    if (node instanceof Y.XmlElement) {
-      let s = "";
-      for (let i = 0; i < node.length; i++) {
-        s += collect(node.get(i) as Y.XmlElement | Y.XmlText | Y.XmlHook);
+export interface ScratchpadOp {
+  insert: string;
+  attributes?: Record<string, unknown>;
+}
+
+/** A block (paragraph, heading, list item…) as its sequence of formatted runs. */
+export type ScratchpadBlock = ScratchpadOp[];
+
+/**
+ * Extract a Y.XmlFragment's blocks, preserving inline formatting.
+ *
+ * Uses `toDelta()`, NEVER `toString()` (#1489). `Y.XmlText.toString()` renders
+ * marks as HTML TAGS — a bolded run comes back as the literal characters
+ * `<strong>bold</strong>`. Those were persisted verbatim and then restored into
+ * a plain `Y.XmlText`, so crash recovery handed the user their own text with
+ * markup spelled out in it. Same reason `getElementText()` uses `toDelta()` on
+ * the server side.
+ *
+ * Marks are CARRIED rather than stripped, which is a change from the previous
+ * "recovery is plain text" scope. Stripping them would also fix the tags, but
+ * silently unbolding recovered text is its own unexpected change to the user's
+ * content — and this hook exists precisely to not lose their work.
+ */
+export function extractFragmentBlocks(fragment: Y.XmlFragment): ScratchpadBlock[] {
+  const blocks: ScratchpadBlock[] = [];
+  const collect = (node: Y.XmlElement | Y.XmlText | Y.XmlHook, into: ScratchpadBlock): void => {
+    if (node instanceof Y.XmlText) {
+      for (const op of node.toDelta() as ScratchpadOp[]) {
+        // A delta can carry embeds, whose `insert` is an object rather than a
+        // string. Nothing in a scratchpad produces one today; skip rather than
+        // stringify, so a future embed cannot arrive as "[object Object]".
+        if (typeof op.insert !== "string" || op.insert.length === 0) continue;
+        into.push(
+          op.attributes ? { insert: op.insert, attributes: op.attributes } : { insert: op.insert },
+        );
       }
-      return s;
+      return;
     }
-    return "";
+    if (node instanceof Y.XmlElement) {
+      for (let i = 0; i < node.length; i++) {
+        collect(node.get(i) as Y.XmlElement | Y.XmlText | Y.XmlHook, into);
+      }
+    }
   };
   for (let i = 0; i < fragment.length; i++) {
     const child = fragment.get(i);
     if (child instanceof Y.XmlElement || child instanceof Y.XmlText) {
-      blocks.push(collect(child as Y.XmlElement | Y.XmlText));
+      const block: ScratchpadBlock = [];
+      collect(child as Y.XmlElement | Y.XmlText, block);
+      blocks.push(block);
     }
   }
-  while (blocks.length > 0 && blocks[blocks.length - 1] === "") blocks.pop();
+  while (blocks.length > 0 && blockText(blocks[blocks.length - 1]).length === 0) blocks.pop();
   return blocks;
 }
 
+/** The plain characters of a block, marks discarded. */
+export function blockText(block: ScratchpadBlock): string {
+  return block.map((op) => op.insert).join("");
+}
+
+/**
+ * Rebuild a paragraph from a stored block. The inverse of one iteration of
+ * {@link extractFragmentBlocks}, and exported so the tests exercise the code
+ * that actually runs rather than re-implementing it beside it.
+ *
+ * EVERY mark key is passed on EVERY run, `null` where the run does not carry
+ * it. That is not defensive noise — it is the whole correctness of this
+ * function. `Y.XmlText.insert` with `undefined` attributes does not insert
+ * unformatted text; it INHERITS whatever formatting is active at the insertion
+ * point. And `toDelta()` normalizes a mark-off to the absence of a key, so an
+ * unformatted run always extracts as a bare `{insert}`. Take the two together
+ * and a bolded word followed by ordinary typing — the single most common
+ * formatting gesture there is — comes back with the rest of the paragraph
+ * bolded:
+ *
+ *     stored    "plain " + "bold"{strong} + " tail"
+ *     restored  "plain " + "bold tail"{strong}
+ *
+ * Passing an explicit `null` is what turns the mark off. A fresh object per run
+ * also matters: `insert` MUTATES the attributes object it is given, adding the
+ * keys it turned off, so a shared one would accumulate them.
+ */
+export function scratchpadBlockToParagraph(block: ScratchpadBlock): Y.XmlElement {
+  const p = new Y.XmlElement("paragraph");
+  if (block.length === 0) return p;
+
+  const text = new Y.XmlText();
+  p.insert(0, [text]);
+  const markKeys = new Set<string>();
+  for (const op of block) for (const key of Object.keys(op.attributes ?? {})) markKeys.add(key);
+
+  let at = 0;
+  for (const op of block) {
+    const attributes: Record<string, unknown> = {};
+    for (const key of markKeys) attributes[key] = op.attributes?.[key] ?? null;
+    text.insert(at, op.insert, attributes);
+    at += op.insert.length;
+  }
+  return p;
+}
+
+/**
+ * Plain-text view of the fragment, used only for the "is there anything here"
+ * emptiness check. Deliberately marks-free — that question is about characters.
+ */
 export function extractFragmentText(fragment: Y.XmlFragment): string {
-  return extractFragmentBlocks(fragment).join("\n");
+  return extractFragmentBlocks(fragment).map(blockText).join("\n");
 }
 
 /**
@@ -163,7 +253,7 @@ export function extractFragmentText(fragment: Y.XmlFragment): string {
  * recovered scratchpad came back with one paragraph per WRAPPED LINE: crash
  * recovery silently reformatting the thing it exists to preserve.
  */
-export function encodeScratchpadBlocks(blocks: string[]): string {
+export function encodeScratchpadBlocks(blocks: ScratchpadBlock[]): string {
   return JSON.stringify(blocks);
 }
 
@@ -175,18 +265,47 @@ export function encodeScratchpadBlocks(blocks: string[]): string {
  * thing that discards their unsaved text. That form genuinely cannot represent
  * an intra-block newline, so splitting it is the correct reading of it.
  */
-export function decodeScratchpadBlocks(stored: string): string[] {
+export function decodeScratchpadBlocks(stored: string): ScratchpadBlock[] {
+  const plain = (blocks: string[]): ScratchpadBlock[] =>
+    blocks.map((b) => (b.length > 0 ? [{ insert: b }] : []));
+
   if (stored.startsWith("[")) {
     try {
       const parsed: unknown = JSON.parse(stored);
-      if (Array.isArray(parsed) && parsed.every((b) => typeof b === "string")) {
-        return parsed as string[];
+      if (Array.isArray(parsed)) {
+        // Current form: an array of blocks, each an array of delta ops. A block
+        // is an ARRAY where the pre-#1489 form had a STRING, so the two are
+        // structurally distinguishable and no version field is needed.
+        if (parsed.every(isScratchpadBlock)) return parsed as ScratchpadBlock[];
+        // Pre-#1489 form: an array of plain strings.
+        if (parsed.every((b) => typeof b === "string")) return plain(parsed as string[]);
       }
     } catch {
       // Not our JSON after all — read it as legacy text below.
     }
   }
-  return stored.split("\n");
+  return plain(stored.split("\n"));
+}
+
+/**
+ * Is this a block of delta ops? Validates the op SHAPE, not just that it is an
+ * array — an empty array is a valid (empty) block and would otherwise satisfy
+ * both branches above, and anything reaching here came out of `localStorage`,
+ * which the user can edit.
+ */
+function isScratchpadBlock(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (op) =>
+        typeof op === "object" &&
+        op !== null &&
+        typeof (op as ScratchpadOp).insert === "string" &&
+        ((op as ScratchpadOp).attributes === undefined ||
+          (typeof (op as ScratchpadOp).attributes === "object" &&
+            (op as ScratchpadOp).attributes !== null)),
+    )
+  );
 }
 
 interface ScratchpadEntry {
@@ -319,7 +438,7 @@ export function createScratchpadPersistence(
   const persistEntry = (entry: ScratchpadEntry) => {
     const fragment = entry.ydoc.getXmlFragment("default");
     const blocks = extractFragmentBlocks(fragment);
-    const hasContent = blocks.join("").length > 0;
+    const hasContent = blocks.some((b) => blockText(b).length > 0);
     // The warning flag tracks the DOCUMENT, not whether we managed to store it.
     // It is set before the fail-closed return below and outside the empty/
     // non-empty split, because the two questions are independent: "is there
@@ -445,11 +564,11 @@ export function createScratchpadPersistence(
     // Insert restored text as paragraphs into the (empty) fragment. y-prosemirror
     // reconciles this into the editor on mount. Build elements detached then
     // insert in one transaction so the populate path stays atomic.
-    const paragraphs = decodeScratchpadBlocks(stored).map((block) => {
-      const p = new Y.XmlElement("paragraph");
-      if (block.length > 0) p.insert(0, [new Y.XmlText(block)]);
-      return p;
-    });
+    const paragraphs = decodeScratchpadBlocks(stored).map(scratchpadBlockToParagraph);
+    // A stored "[]" decodes to zero blocks. Clearing the fragment and inserting
+    // nothing leaves it empty, which y-prosemirror does not expect — bail
+    // instead, leaving whatever is already there.
+    if (paragraphs.length === 0) return;
     // Privacy invariant: BROWSER_ORIGIN is the only origin NOT in CHANNEL_SKIP
     // (see src/shared/origins.ts and src/server/events/queue.ts). Tagging this
     // restore as `browser` is safe ONLY because there is no channel observer

--- a/tests/client/scratchpad-persistence.test.ts
+++ b/tests/client/scratchpad-persistence.test.ts
@@ -5,6 +5,7 @@ import {
   encodeScratchpadBlocks,
   extractFragmentBlocks,
   extractFragmentText,
+  scratchpadBlockToParagraph,
   scratchpadStorageKey,
 } from "../../src/client/hooks/useScratchpadPersistence.svelte";
 
@@ -86,7 +87,10 @@ describe("the persisted form survives a paragraph that holds its own newline", (
   it("round-trips a soft-wrapped paragraph as ONE block", () => {
     const doc = docWithParagraphs(["first line\nsecond line", "another paragraph"]);
     const blocks = extractFragmentBlocks(doc.getXmlFragment("default"));
-    expect(blocks).toEqual(["first line\nsecond line", "another paragraph"]);
+    expect(blocks).toEqual([
+      [{ insert: "first line\nsecond line" }],
+      [{ insert: "another paragraph" }],
+    ]);
     expect(decodeScratchpadBlocks(encodeScratchpadBlocks(blocks))).toEqual(blocks);
   });
 
@@ -94,15 +98,162 @@ describe("the persisted form survives a paragraph that holds its own newline", (
     // An upgrade must not be the thing that loses a user's unsaved text. The old
     // form cannot represent an intra-block newline, so splitting it is the
     // correct reading of it.
-    expect(decodeScratchpadBlocks("first\nsecond")).toEqual(["first", "second"]);
+    expect(decodeScratchpadBlocks("first\nsecond")).toEqual([
+      [{ insert: "first" }],
+      [{ insert: "second" }],
+    ]);
   });
 
   it("reads a legacy value that merely STARTS with a bracket as legacy text", () => {
-    expect(decodeScratchpadBlocks("[draft] notes\nmore")).toEqual(["[draft] notes", "more"]);
+    expect(decodeScratchpadBlocks("[draft] notes\nmore")).toEqual([
+      [{ insert: "[draft] notes" }],
+      [{ insert: "more" }],
+    ]);
+  });
+
+  it("reads a pre-#1489 JSON string[] value, upgrading it in place", () => {
+    // The form written between #1448 and #1489. A block was a STRING there and
+    // is an ARRAY now, so the two are structurally distinguishable and no
+    // version field is needed — but the old one still has to be readable, or
+    // upgrading discards whatever the user had unsaved at the time.
+    expect(decodeScratchpadBlocks('["first line\\nsecond","other"]')).toEqual([
+      [{ insert: "first line\nsecond" }],
+      [{ insert: "other" }],
+    ]);
+  });
+
+  it("rejects a malformed stored value rather than trusting its shape", () => {
+    // localStorage is user-editable. An array of the wrong thing must not be
+    // read as blocks — it would reach `text.insert(at, op.insert)` as undefined.
+    expect(decodeScratchpadBlocks("[1,2,3]")).toEqual([[{ insert: "[1,2,3]" }]]);
+    expect(decodeScratchpadBlocks('[[{"insert":5}]]')).toEqual([[{ insert: '[[{"insert":5}]]' }]]);
   });
 
   it("keeps extractFragmentText as the plain-text view for the emptiness check", () => {
     const doc = docWithParagraphs(["a", "b"]);
     expect(extractFragmentText(doc.getXmlFragment("default"))).toBe("a\nb");
+  });
+});
+
+describe("#1489: formatting is preserved, never spelled out as HTML tags", () => {
+  /**
+   * A paragraph carrying real inline marks, the way the editor writes one.
+   *
+   * The `{ strong: null }` on " and " is LOAD-BEARING and was the difference
+   * between this suite catching a regression and blessing it. Written as a bare
+   * `t.insert(10, " and ")`, Yjs inherits the active bold, so the fixture had no
+   * unformatted run following a formatted one — the only shape that exposes
+   * mark bleed on restore. The round-trip test below passed for that reason
+   * rather than because restore was correct.
+   */
+  function formattedDoc(): Y.Doc {
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    const p = new Y.XmlElement("paragraph");
+    const t = new Y.XmlText();
+    fragment.insert(0, [p]);
+    p.insert(0, [t]);
+    t.insert(0, "plain ");
+    t.insert(6, "bold", { strong: {} });
+    t.insert(10, " and ", { strong: null });
+    t.insert(15, "italic", { em: {} });
+    return doc;
+  }
+
+  it("does not persist marks as literal tag characters", () => {
+    // The bug, and the assertion that fails on the old code. `toString()` on a
+    // Y.XmlText RENDERS marks as HTML, so this block was persisted as
+    //   "plain <strong>bold and </strong><em>italic</em>"
+    // and restore then wrote those angle brackets into the document as text.
+    const blocks = extractFragmentBlocks(formattedDoc().getXmlFragment("default"));
+    const persisted = encodeScratchpadBlocks(blocks);
+    expect(persisted).not.toContain("<strong>");
+    expect(persisted).not.toContain("<em>");
+    expect(persisted).not.toContain("&lt;");
+  });
+
+  it("carries the marks themselves, so recovery does not silently unformat", () => {
+    // Stripping marks would also stop the tags — and would quietly hand back
+    // unbolded text, which is its own unexpected change to the user's content.
+    const blocks = extractFragmentBlocks(formattedDoc().getXmlFragment("default"));
+    expect(blocks).toEqual([
+      [
+        { insert: "plain " },
+        { insert: "bold", attributes: { strong: {} } },
+        { insert: " and " },
+        { insert: "italic", attributes: { em: {} } },
+      ],
+    ]);
+  });
+
+  /** Persist → restore, through the PRODUCT's builder rather than a copy of it. */
+  function roundTrip(fragment: Y.XmlFragment): Y.XmlFragment {
+    const decoded = decodeScratchpadBlocks(encodeScratchpadBlocks(extractFragmentBlocks(fragment)));
+    const restored = new Y.Doc().getXmlFragment("default");
+    restored.insert(0, decoded.map(scratchpadBlockToParagraph));
+    return restored;
+  }
+
+  it("round-trips formatting through storage and back into a Y.Doc", () => {
+    // Calls `scratchpadBlockToParagraph`, the function `restoreInto` actually
+    // uses. An earlier version re-implemented the restore loop inline here,
+    // which meant a change to the product's restore path could not fail it.
+    const original = extractFragmentBlocks(formattedDoc().getXmlFragment("default"));
+    const back = roundTrip(formattedDoc().getXmlFragment("default"));
+
+    expect(extractFragmentBlocks(back)).toEqual(original);
+    expect(extractFragmentText(back)).toBe("plain bold and italic");
+  });
+
+  it("does NOT bleed a mark onto the run after it", () => {
+    // The regression the first cut of this fix introduced, and the reason the
+    // fixture above turns bold off explicitly.
+    //
+    // `Y.XmlText.insert` with no attributes does not insert unformatted text —
+    // it inherits the formatting active at that position. `toDelta()` normalizes
+    // a mark-off to the ABSENCE of a key, so an unformatted run always extracts
+    // as a bare `{insert}`. Restoring that naively gave:
+    //     "plain " + "bold and italic"{strong}
+    // i.e. bold a word, keep typing, crash — and recovery bolds the rest of your
+    // paragraph. Asserted separately from the round trip because it is a
+    // specific claim about a specific gesture.
+    const back = extractFragmentBlocks(roundTrip(formattedDoc().getXmlFragment("default")));
+    expect(back[0]).toContainEqual({ insert: " and " });
+    expect(back[0].find((op) => op.insert === " and ")?.attributes).toBeUndefined();
+  });
+
+  it("is stable across a SECOND round trip", () => {
+    // Bleed compounds: each restore re-persists what the previous one produced,
+    // so a one-pass assertion can miss a defect that only diverges on pass two.
+    const once = roundTrip(formattedDoc().getXmlFragment("default"));
+    const twice = roundTrip(once);
+    expect(extractFragmentBlocks(twice)).toEqual(extractFragmentBlocks(once));
+  });
+
+  it("survives multi-run astral-plane text", () => {
+    // `at += op.insert.length` assumes Y.js indexes in UTF-16 code units, the
+    // same unit `String.length` counts. A surrogate pair split down the middle
+    // would corrupt the character, not just move it.
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment("default");
+    const p = new Y.XmlElement("paragraph");
+    const t = new Y.XmlText();
+    fragment.insert(0, [p]);
+    p.insert(0, [t]);
+    t.insert(0, "👨‍👩‍👧 ");
+    t.insert(t.length, "𝔘𝔫𝔦", { strong: {} });
+    t.insert(t.length, " café", { strong: null });
+
+    const original = extractFragmentBlocks(fragment);
+    expect(extractFragmentBlocks(roundTrip(fragment))).toEqual(original);
+    expect(extractFragmentText(roundTrip(fragment))).toBe("👨‍👩‍👧 𝔘𝔫𝔦 café");
+  });
+
+  it("the plain-text view still drops marks", () => {
+    // `extractFragmentText` answers "are there any characters here", so it must
+    // stay marks-free — and must not start leaking tags into that answer either.
+    expect(extractFragmentText(formattedDoc().getXmlFragment("default"))).toBe(
+      "plain bold and italic",
+    );
   });
 });


### PR DESCRIPTION
Scratchpad crash recovery handed back the user's own text with HTML markup spelled out in it.

`extractFragmentBlocks` collected each block with `Y.XmlText.toString()`, which **renders inline marks as HTML tags**. Measured:

```
fragment:  "plain " + "bold and "{strong} + "italic"{em}
persisted: ["plain <strong>bold and </strong><em>italic</em>"]
```

`restoreInto` then rebuilt that as a plain `Y.XmlText`, so the angle brackets came back as literal characters in the document. Same class as the server-side rule that `getElementText()` uses `toDelta()`, never `toString()` — this path never got that treatment.

Blocks are now `toDelta()` ops and restore applies them with their marks. Stripping the marks would also stop the tags, but silently unbolding recovered text is its own unexpected change to a user's content, and this hook exists to not lose their work.

**Storage format** goes from `string[]` to `ScratchpadOp[][]`. A block is an array where it used to be a string, so the two are structurally distinguishable with no version field, and both legacy forms (`string[]` JSON, and the pre-#1448 newline-delimited string) still decode. An upgrade must not be the thing that discards someone's unsaved text.

## The regression review caught, and why the suite blessed it

The first cut of this fix introduced a worse bug than the one it fixed.

`Y.XmlText.insert` with no attributes does **not** insert unformatted text — it inherits the formatting active at that position. And `toDelta()` normalizes a mark-off to the *absence* of a key, so an unformatted run always extracts as a bare `{insert}`. Together:

```
stored    "plain " + "bold"{strong} + " tail"
restored  "plain " + "bold tail"{strong}
```

Bold a word, turn bold off, keep typing, crash — and recovery bolds the rest of your paragraph. That is the most common formatting gesture there is, so it was the main path, not a corner. Restore now passes every mark key on every run, `null` where the run doesn't carry it, which is what turns a mark off. A fresh attributes object per run matters too: `insert` mutates the one it's given.

**The suite passed anyway, and that's the part worth keeping.** The fixture wrote `t.insert(10, " and ")` with no attributes — so Yjs inherited the active bold *at construction time*, and the fixture contained no unformatted run following a formatted one, the only shape that exposes the bleed. The round-trip test passed because of the fixture, not because restore was correct. It now builds with an explicit `{ strong: null }`, and with that single change it fails against the bleeding version.

Third time this session that the measuring instrument was the thing hiding the bug — after mocked PM nodes in #1450 and isolated `createNodeFromContent` in #1477. This one is mine end to end: I wrote the fixture that hid my own regression.

## Also from review, each verified before acting

- The restore loop is exported as `scratchpadBlockToParagraph` and the tests call **it**, rather than re-implementing it alongside. Previously a change to the product's restore path could not fail any test.
- A stored `"[]"` decoded to zero blocks and left the fragment empty, which y-prosemirror doesn't expect. Guarded.
- **Two doc claims removed as unsupported.** "Persist and restore are literal inverses" is false — block *type* is discarded (a heading restores as a paragraph) and sibling `Y.XmlText` nodes concatenate, both pre-existing and now stated plainly. And my attach-before-populate comment cited the detached-XmlText gotcha; I could not reproduce it for this shape in yjs 13.6.30. Measured both orders, byte-identical output, so the comment was describing a mechanism that isn't there.

Review also confirmed clean, with hostile inputs run rather than reasoned about: back-compat across all three stored forms including `"["`, `"[]"`, `"[1,2,3]"`, `"[null]"` and a legacy string beginning with a bracket; prototype-pollution shapes in `attributes`; UTF-16 offset arithmetic; and the emptiness-check refactor being exactly equivalent.

## Verification

- 20 tests, up from 11. Round-trip stability across two passes, mark-off transitions, astral-plane multi-run text, malformed localStorage
- Negative-controlled: 3 fail against the bleeding version, 4 against the original `toString()` version
- `npm run typecheck` — 1327 files, 0 errors
- `npm test` — 481 files, 6963 passed
- pre-push hook (biome + vitest + `cargo test`) green

Closes #1489

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnpXPQuW7p25SHTHV9HfMK
