### PR TITLE
refactor(positions): extract Y.Doc position leaves to src/shared

### DIFF
--- a/src/server/mcp/document-model.ts
+++ b/src/server/mcp/document-model.ts
@@ -1,11 +1,21 @@
 import path from "path";
 import * as Y from "yjs";
+import { FLAT_SEPARATOR, headingPrefix } from "../../shared/offsets.js";
 import {
-  FLAT_SEPARATOR,
-  headingPrefix,
-  headingPrefixLength as sharedHeadingPrefixLength,
-} from "../../shared/offsets.js";
+  findXmlTextAtOffset,
+  getElementTextLength,
+  getHeadingPrefixLength,
+  isHardBreakElement,
+} from "../../shared/positions/ydoc.js";
 import { saveMarkdown } from "../file-io/markdown.js";
+
+// These four moved to `src/shared/positions/ydoc.ts` so the client can reach
+// them without pulling this module's `node:path` and `saveMarkdown` imports —
+// and with them the whole remark pipeline — into the browser bundle. Re-exported
+// from here because ~20 call sites and a dozen test files import them from this
+// path, and a refactor that forces test edits cannot demonstrate it was
+// behaviour-preserving.
+export { findXmlTextAtOffset, getElementTextLength, getHeadingPrefixLength, isHardBreakElement };
 
 /**
  * Detect file format from extension.
@@ -116,17 +126,6 @@ export function populateYDoc(doc: Y.Doc, text: string): void {
 
     fragment.insert(fragment.length, [element]);
   }
-}
-
-/**
- * True when a node is a sibling `hardBreak` inline-leaf element — the only inline
- * leaf a textblock holds. It occupies exactly 1 flat char and REPLACES the
- * between-block separator (matches the client, which counts every hardBreak as 1;
- * `src/client/positions.ts`). Container children (list items, table cells) instead
- * get a FLAT_SEPARATOR between siblings.
- */
-export function isHardBreakElement(node: unknown): boolean {
-  return node instanceof Y.XmlElement && node.nodeName === "hardBreak";
 }
 
 /**
@@ -260,90 +259,6 @@ function collectElementFlat(element: Y.XmlElement, acc: FlatAcc): void {
 }
 
 /**
- * Compute the flat text length of a Y.XmlElement without building the string.
- * Uses the same one-character separator invariant as getElementText().
- */
-export function getElementTextLength(element: Y.XmlElement): number {
-  let len = 0;
-  let hasPriorContent = false;
-  for (let i = 0; i < element.length; i++) {
-    const child = element.get(i);
-    if (child instanceof Y.XmlText) {
-      len += child.length;
-      hasPriorContent = true;
-    } else if (child instanceof Y.XmlElement) {
-      if (isHardBreakElement(child)) {
-        len += 1; // inline-leaf: exactly 1, replaces the separator (see getElementText)
-      } else {
-        if (hasPriorContent) len += 1;
-        len += getElementTextLength(child);
-      }
-      hasPriorContent = true;
-    }
-  }
-  return len;
-}
-
-/**
- * Find the Y.XmlText that contains a given flat text offset within a Y.XmlElement.
- * Returns the XmlText and the offset within it, or null if the offset falls on a
- * separator character or cannot be resolved.
- */
-export function findXmlTextAtOffset(
-  element: Y.XmlElement,
-  textOffset: number,
-): { xmlText: Y.XmlText; offsetInXmlText: number } | null {
-  let accumulated = 0;
-  let hasPriorContent = false;
-  for (let i = 0; i < element.length; i++) {
-    const child = element.get(i);
-    if (child instanceof Y.XmlText) {
-      const len = child.length;
-      if (accumulated + len > textOffset) {
-        return { xmlText: child, offsetInXmlText: textOffset - accumulated };
-      }
-      accumulated += len;
-      hasPriorContent = true;
-    } else if (child instanceof Y.XmlElement) {
-      if (isHardBreakElement(child)) {
-        // Inline-leaf break: 1 flat char, unaddressable like a separator. An offset
-        // landing ON it returns null so the caller's assoc fallback re-anchors.
-        if (textOffset === accumulated) return null;
-        accumulated += 1;
-        hasPriorContent = true;
-      } else {
-        if (hasPriorContent) {
-          if (textOffset === accumulated) {
-            // Offset lands ON the separator — return null (between-element gap)
-            return null;
-          }
-          accumulated += 1;
-        }
-        const childTextLen = getElementTextLength(child);
-        if (accumulated + childTextLen > textOffset) {
-          return findXmlTextAtOffset(child, textOffset - accumulated);
-        }
-        accumulated += childTextLen;
-        hasPriorContent = true;
-      }
-    }
-  }
-  // Handle end-of-element: offset equals total length
-  if (textOffset === accumulated) {
-    // Walk backwards to find the last XmlText
-    for (let i = element.length - 1; i >= 0; i--) {
-      const child = element.get(i);
-      if (child instanceof Y.XmlText) {
-        return { xmlText: child, offsetInXmlText: child.length };
-      } else if (child instanceof Y.XmlElement) {
-        return findXmlTextAtOffset(child, getElementTextLength(child));
-      }
-    }
-  }
-  return null;
-}
-
-/**
  * Collect all Y.XmlText nodes in a Y.XmlElement with their flat offsets from the
  * element's start. Uses the same one-character separator invariant as getElementText().
  */
@@ -429,18 +344,6 @@ export function extractTextWithBreaks(doc: Y.Doc): { text: string; breaks: FlatB
  */
 export function extractMarkdown(doc: Y.Doc): string {
   return saveMarkdown(doc).trimEnd();
-}
-
-/**
- * Get the heading prefix length for a Y.XmlElement.
- * Delegates to shared headingPrefixLength for the actual math.
- */
-export function getHeadingPrefixLength(node: Y.XmlElement): number {
-  if (node.nodeName === "heading") {
-    const level = Number(node.getAttribute("level") ?? 1);
-    return sharedHeadingPrefixLength(level);
-  }
-  return 0;
 }
 
 // -- Range staleness detection ------------------------------------------------

--- a/src/server/positions.ts
+++ b/src/server/positions.ts
@@ -21,122 +21,35 @@ import { withMcp } from "../shared/origins.js";
 import type {
   AnchoredRangeResult,
   DocumentRange,
-  ElementPosition,
   FlatOffset,
   RangeValidation,
   RefreshResult,
   RelativeRange,
   SerializedRelPos,
 } from "../shared/positions/index.js";
-import { toFlatOffset, toSerializedRelPos } from "../shared/positions/index.js";
-import type { Annotation } from "../shared/types.js";
+import { toFlatOffset } from "../shared/positions/index.js";
 import {
-  collectXmlTexts,
-  extractText,
-  findXmlTextAtOffset,
+  anchorFlatRange,
+  flatOffsetToRelPos,
   getElementTextLength,
   getHeadingPrefixLength,
-} from "./mcp/document-model.js";
+  resolveToElement,
+} from "../shared/positions/ydoc.js";
+import type { Annotation } from "../shared/types.js";
+import { collectXmlTexts, extractText } from "./mcp/document-model.js";
+
+// Moved to `src/shared/positions/ydoc.ts` — see that file's header for why the
+// move is a leaf extraction rather than a file move. Re-exported so existing
+// importers of `server/positions` keep working untouched.
+export { anchorFlatRange, flatOffsetToRelPos, resolveToElement };
 
 // ---------------------------------------------------------------------------
 // Low-level: element resolution
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve a flat character offset to a Y.Doc element position.
- * Needed by tandem_edit for cross-element deletion logic.
- */
-export function resolveToElement(
-  fragment: Y.XmlFragment,
-  charOffset: FlatOffset,
-): ElementPosition | null {
-  let accumulated = 0;
-
-  for (let i = 0; i < fragment.length; i++) {
-    const node = fragment.get(i);
-    if (!(node instanceof Y.XmlElement)) continue;
-
-    const prefixLen = getHeadingPrefixLength(node);
-    const textLen = getElementTextLength(node);
-    const fullLen = prefixLen + textLen;
-
-    if (accumulated + fullLen > charOffset) {
-      const offsetInFull = charOffset - accumulated;
-      const clampedFromPrefix = offsetInFull < prefixLen && prefixLen > 0;
-      const textOffset = Math.max(0, offsetInFull - prefixLen);
-      return { elementIndex: i, textOffset, clampedFromPrefix };
-    }
-
-    accumulated += fullLen;
-
-    if (i < fragment.length - 1) {
-      accumulated += 1; // \n separator
-      if (accumulated > charOffset) {
-        return { elementIndex: i, textOffset: textLen, clampedFromPrefix: false };
-      }
-    }
-  }
-
-  if (fragment.length > 0) {
-    const lastNode = fragment.get(fragment.length - 1);
-    if (lastNode instanceof Y.XmlElement) {
-      return {
-        elementIndex: fragment.length - 1,
-        textOffset: getElementTextLength(lastNode),
-        clampedFromPrefix: false,
-      };
-    }
-  }
-
-  return null;
-}
-
 // ---------------------------------------------------------------------------
 // Low-level: RelativePosition conversion
 // ---------------------------------------------------------------------------
-
-/**
- * Convert a flat text offset to a JSON-serialized Yjs RelativePosition.
- * Returns null if the offset falls in a heading prefix or can't be resolved.
- *
- * Sole mint of `SerializedRelPos` — no other code path constructs the wire
- * shape. Readers (`relPosToFlatOffset` here + `relRangeToPmPositions` in
- * `src/client/positions.ts`) must tolerate `Y.createRelativePositionFromJSON`
- * throwing on stale items after `reloadFromDisk` replaces the Y.Doc content;
- * see `docs/lessons-learned.md` "Dead CRDT RelativePositions Must Be Stripped,
- * Not Preserved" for why the throw is expected rather than a bug.
- */
-export function flatOffsetToRelPos(
-  doc: Y.Doc,
-  offset: FlatOffset,
-  assoc: 0 | -1,
-): SerializedRelPos | null {
-  const fragment = doc.getXmlFragment("default");
-  const resolved = resolveToElement(fragment, offset);
-  if (!resolved || resolved.clampedFromPrefix) return null;
-
-  const node = fragment.get(resolved.elementIndex);
-  if (!(node instanceof Y.XmlElement)) return null;
-
-  let found = findXmlTextAtOffset(node, resolved.textOffset);
-  // If the offset lands exactly on an intra-element separator (between nested block children),
-  // fall back based on assoc: -1 (stick left) → try offset-1; 0 (stick right) → try offset+1.
-  if (!found && assoc === -1 && resolved.textOffset > 0) {
-    found = findXmlTextAtOffset(node, resolved.textOffset - 1);
-    if (found) {
-      // Advance offsetInXmlText to end of this XmlText to stick to the left boundary
-      found = { xmlText: found.xmlText, offsetInXmlText: found.xmlText.length };
-    }
-  } else if (!found && assoc === 0) {
-    const nodeLen = getElementTextLength(node);
-    if (resolved.textOffset + 1 <= nodeLen) {
-      found = findXmlTextAtOffset(node, resolved.textOffset + 1);
-    }
-  }
-  if (!found) return null;
-  const rpos = Y.createRelativePositionFromTypeIndex(found.xmlText, found.offsetInXmlText, assoc);
-  return toSerializedRelPos(Y.relativePositionToJSON(rpos));
-}
 
 /**
  * Resolve a JSON-serialized Yjs RelativePosition back to a flat text offset.

--- a/src/shared/positions/ydoc.ts
+++ b/src/shared/positions/ydoc.ts
@@ -1,0 +1,284 @@
+/**
+ * Y.Doc position primitives shared by the server and the client.
+ *
+ * FIRST RUNTIME Y.DOC LOGIC IN `src/shared/`. Everything else here is types or
+ * pure string math, so this file establishes a precedent and needs its boundary
+ * stated rather than assumed.
+ *
+ * THREE-IMPORT CEILING — `yjs`, `./types.js`, `../offsets.js`, and nothing else,
+ * ever. That ceiling is the only thing keeping `node:path` and the remark
+ * pipeline out of the browser bundle. These six functions have a pure-Yjs
+ * dependency closure, but four of them used to live in
+ * `src/server/mcp/document-model.ts`, a 700-line module that imports `node:path`
+ * and `saveMarkdown` at module level. Neither import is in the closure, but a
+ * client bundle cannot reach past them — which is why this is a leaf extraction
+ * rather than the file move it looks like.
+ * `tests/shared/ydoc-import-ceiling.test.ts` enforces the ceiling, because
+ * `biome.json` disables the linter entirely and there is no `no-restricted-imports`
+ * rule to lean on. A ceiling kept by convention is not kept.
+ *
+ * The server keeps everything needing more than that: `relPosToFlatOffset`,
+ * `collectXmlTexts`, `extractText`, `validateRange`, `anchoredRange`,
+ * `refreshRange`, and every mutation helper. The client needs neither Y-to-flat
+ * (it goes Y-to-PM via `relRangeToPmPositions`) nor any mutation.
+ *
+ * NOT re-exported from `./index.js`, deliberately: that barrel is `yjs`-free
+ * today and imported for types by both sides, so routing runtime Y logic through
+ * it would make every consumer pull `yjs` in invisibly.
+ */
+
+import * as Y from "yjs";
+import { headingPrefixLength as sharedHeadingPrefixLength } from "../offsets.js";
+import type { ElementPosition, FlatOffset, RelativeRange, SerializedRelPos } from "./types.js";
+import { toSerializedRelPos } from "./types.js";
+
+/**
+ * True when a node is a sibling `hardBreak` inline-leaf element — the only inline
+ * leaf a textblock holds. It occupies exactly 1 flat char and REPLACES the
+ * between-block separator (matches the client, which counts every hardBreak as 1;
+ * `src/client/positions.ts`). Container children (list items, table cells) instead
+ * get a FLAT_SEPARATOR between siblings.
+ */
+export function isHardBreakElement(node: unknown): boolean {
+  return node instanceof Y.XmlElement && node.nodeName === "hardBreak";
+}
+
+/**
+ * Compute the flat text length of a Y.XmlElement without building the string.
+ * Uses the same one-character separator invariant as getElementText().
+ */
+export function getElementTextLength(element: Y.XmlElement): number {
+  let len = 0;
+  let hasPriorContent = false;
+  for (let i = 0; i < element.length; i++) {
+    const child = element.get(i);
+    if (child instanceof Y.XmlText) {
+      len += child.length;
+      hasPriorContent = true;
+    } else if (child instanceof Y.XmlElement) {
+      if (isHardBreakElement(child)) {
+        len += 1; // inline-leaf: exactly 1, replaces the separator (see getElementText)
+      } else {
+        if (hasPriorContent) len += 1;
+        len += getElementTextLength(child);
+      }
+      hasPriorContent = true;
+    }
+  }
+  return len;
+}
+
+/**
+ * Find the Y.XmlText that contains a given flat text offset within a Y.XmlElement.
+ * Returns the XmlText and the offset within it, or null if the offset falls on a
+ * separator character or cannot be resolved.
+ */
+export function findXmlTextAtOffset(
+  element: Y.XmlElement,
+  textOffset: number,
+): { xmlText: Y.XmlText; offsetInXmlText: number } | null {
+  let accumulated = 0;
+  let hasPriorContent = false;
+  for (let i = 0; i < element.length; i++) {
+    const child = element.get(i);
+    if (child instanceof Y.XmlText) {
+      const len = child.length;
+      if (accumulated + len > textOffset) {
+        return { xmlText: child, offsetInXmlText: textOffset - accumulated };
+      }
+      accumulated += len;
+      hasPriorContent = true;
+    } else if (child instanceof Y.XmlElement) {
+      if (isHardBreakElement(child)) {
+        // Inline-leaf break: 1 flat char, unaddressable like a separator. An offset
+        // landing ON it returns null so the caller's assoc fallback re-anchors.
+        if (textOffset === accumulated) return null;
+        accumulated += 1;
+        hasPriorContent = true;
+      } else {
+        if (hasPriorContent) {
+          if (textOffset === accumulated) {
+            // Offset lands ON the separator — return null (between-element gap)
+            return null;
+          }
+          accumulated += 1;
+        }
+        const childTextLen = getElementTextLength(child);
+        if (accumulated + childTextLen > textOffset) {
+          return findXmlTextAtOffset(child, textOffset - accumulated);
+        }
+        accumulated += childTextLen;
+        hasPriorContent = true;
+      }
+    }
+  }
+  // Handle end-of-element: offset equals total length
+  if (textOffset === accumulated) {
+    // Walk backwards to find the last XmlText
+    for (let i = element.length - 1; i >= 0; i--) {
+      const child = element.get(i);
+      if (child instanceof Y.XmlText) {
+        return { xmlText: child, offsetInXmlText: child.length };
+      } else if (child instanceof Y.XmlElement) {
+        return findXmlTextAtOffset(child, getElementTextLength(child));
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Get the heading prefix length for a Y.XmlElement.
+ * Delegates to shared headingPrefixLength for the actual math.
+ */
+export function getHeadingPrefixLength(node: Y.XmlElement): number {
+  if (node.nodeName === "heading") {
+    const level = Number(node.getAttribute("level") ?? 1);
+    return sharedHeadingPrefixLength(level);
+  }
+  return 0;
+}
+
+/**
+ * Resolve a flat character offset to a Y.Doc element position.
+ * Needed by tandem_edit for cross-element deletion logic.
+ */
+export function resolveToElement(
+  fragment: Y.XmlFragment,
+  charOffset: FlatOffset,
+): ElementPosition | null {
+  let accumulated = 0;
+
+  for (let i = 0; i < fragment.length; i++) {
+    const node = fragment.get(i);
+    if (!(node instanceof Y.XmlElement)) continue;
+
+    const prefixLen = getHeadingPrefixLength(node);
+    const textLen = getElementTextLength(node);
+    const fullLen = prefixLen + textLen;
+
+    if (accumulated + fullLen > charOffset) {
+      const offsetInFull = charOffset - accumulated;
+      const clampedFromPrefix = offsetInFull < prefixLen && prefixLen > 0;
+      const textOffset = Math.max(0, offsetInFull - prefixLen);
+      return { elementIndex: i, textOffset, clampedFromPrefix };
+    }
+
+    accumulated += fullLen;
+
+    if (i < fragment.length - 1) {
+      accumulated += 1; // \n separator
+      if (accumulated > charOffset) {
+        return { elementIndex: i, textOffset: textLen, clampedFromPrefix: false };
+      }
+    }
+  }
+
+  if (fragment.length > 0) {
+    const lastNode = fragment.get(fragment.length - 1);
+    if (lastNode instanceof Y.XmlElement) {
+      return {
+        elementIndex: fragment.length - 1,
+        textOffset: getElementTextLength(lastNode),
+        clampedFromPrefix: false,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Convert a flat text offset to a JSON-serialized Yjs RelativePosition.
+ * Returns null if the offset falls in a heading prefix or can't be resolved.
+ *
+ * Sole mint of `SerializedRelPos` — no other code path constructs the wire
+ * shape. Readers (`relPosToFlatOffset` here + `relRangeToPmPositions` in
+ * `src/client/positions.ts`) must tolerate `Y.createRelativePositionFromJSON`
+ * throwing on stale items after `reloadFromDisk` replaces the Y.Doc content;
+ * see `docs/lessons-learned.md` "Dead CRDT RelativePositions Must Be Stripped,
+ * Not Preserved" for why the throw is expected rather than a bug.
+ */
+export function flatOffsetToRelPos(
+  doc: Y.Doc,
+  offset: FlatOffset,
+  assoc: 0 | -1,
+): SerializedRelPos | null {
+  const fragment = doc.getXmlFragment("default");
+  const resolved = resolveToElement(fragment, offset);
+  if (!resolved || resolved.clampedFromPrefix) return null;
+
+  const node = fragment.get(resolved.elementIndex);
+  if (!(node instanceof Y.XmlElement)) return null;
+
+  let found = findXmlTextAtOffset(node, resolved.textOffset);
+  // If the offset lands exactly on an intra-element separator (between nested block children),
+  // fall back based on assoc: -1 (stick left) → try offset-1; 0 (stick right) → try offset+1.
+  if (!found && assoc === -1 && resolved.textOffset > 0) {
+    found = findXmlTextAtOffset(node, resolved.textOffset - 1);
+    if (found) {
+      // Advance offsetInXmlText to end of this XmlText to stick to the left boundary
+      found = { xmlText: found.xmlText, offsetInXmlText: found.xmlText.length };
+    }
+  } else if (!found && assoc === 0) {
+    const nodeLen = getElementTextLength(node);
+    if (resolved.textOffset + 1 <= nodeLen) {
+      found = findXmlTextAtOffset(node, resolved.textOffset + 1);
+    }
+  }
+  if (!found) return null;
+  const rpos = Y.createRelativePositionFromTypeIndex(found.xmlText, found.offsetInXmlText, assoc);
+  return toSerializedRelPos(Y.relativePositionToJSON(rpos));
+}
+
+// ---------------------------------------------------------------------------
+// Range minting
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint both endpoints of a CRDT-anchored range from flat offsets.
+ *
+ * `from` sticks right (assoc 0) so text inserted at the start stays outside;
+ * `to` sticks left (assoc -1) so text appended at the end stays outside.
+ *
+ * INTENDED to become the sole assembler of a `RelativeRange` — it is not one
+ * yet, and saying so plainly matters more than the aspiration. The three
+ * existing sites (`anchoredRange` and both `refreshRange` re-assembly branches
+ * in `src/server/positions.ts`) still spell the pair out by hand; collapsing
+ * them is deliberately a separate change, because it touches the riskiest
+ * server path and because `anchoredRange` cannot be collapsed mechanically: it
+ * re-resolves both endpoints on failure and logs only when NEITHER was clamped
+ * by a heading prefix, distinguishing "should have anchored and didn't" from
+ * "correctly declined". A helper that just returns null erases that, so porting
+ * the diagnostic is a precondition, not a detail. Verified consistent: all three
+ * sites do use this same assoc pair today.
+ *
+ * The first consumer is the client-side mint in #1471.
+ *
+ * All-or-nothing, and that is a real constraint rather than tidiness: the two
+ * assocs refuse to mint in DIFFERENT places around an empty block — assoc 0 on
+ * the leading separator, assoc -1 on the trailing one, each retrying into the
+ * void. A range touching either offset therefore has to degrade as a whole; a
+ * caller must never end up holding one anchored endpoint and one raw offset.
+ * `tests/client/flat-offset-correspondence.test.ts` pins both refusal sets.
+ *
+ * Never throws — a null return means the caller falls back to flat offsets.
+ * The catch is defensive rather than load-bearing: `flatOffsetToRelPos` returns
+ * null for every failure it currently has, and the throw-prone Yjs call
+ * (`createRelativePositionFromJSON`, which is documented as throwing on stale
+ * items after `reloadFromDisk`) is on the READ path, not this one. Kept because
+ * a keystroke handler must not be the place that discovers otherwise.
+ */
+export function anchorFlatRange(
+  doc: Y.Doc,
+  from: FlatOffset,
+  to: FlatOffset,
+): RelativeRange | null {
+  try {
+    const fromRel = flatOffsetToRelPos(doc, from, 0);
+    const toRel = flatOffsetToRelPos(doc, to, -1);
+    return fromRel && toRel ? { fromRel, toRel } : null;
+  } catch {
+    return null;
+  }
+}

--- a/tests/shared/anchor-flat-range.test.ts
+++ b/tests/shared/anchor-flat-range.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `anchorFlatRange` — the range mint the client side of #1471 will call.
+ *
+ * It ships one branch ahead of its first consumer, so it would otherwise be
+ * untested dead code arriving with a confident JSDoc. These tests exist so the
+ * contract that comment describes is actually pinned before anything is built
+ * on it — particularly the all-or-nothing rule, which is not an aesthetic
+ * choice: the two assocs refuse to mint in DIFFERENT places, so a helper that
+ * returned one anchored endpoint and one raw offset would hand the caller a
+ * range whose halves disagree about which document they describe.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { loadMarkdown } from "../../src/server/file-io/markdown";
+import { extractText } from "../../src/server/mcp/document-model";
+import { toFlatOffset } from "../../src/shared/positions/types";
+import { anchorFlatRange, flatOffsetToRelPos } from "../../src/shared/positions/ydoc";
+
+function docFor(markdown: string) {
+  const ydoc = new Y.Doc();
+  loadMarkdown(ydoc, markdown);
+  return ydoc;
+}
+
+describe("anchorFlatRange", () => {
+  it("mints both endpoints for an ordinary range", () => {
+    const ydoc = docFor("alpha bravo\n");
+    const range = anchorFlatRange(ydoc, toFlatOffset(0), toFlatOffset(5));
+    expect(range).not.toBeNull();
+    expect(range?.fromRel).toBeDefined();
+    expect(range?.toRel).toBeDefined();
+  });
+
+  it("uses assoc 0 for from and assoc -1 for to", () => {
+    // The assoc pair IS the contract — it decides whether text typed at either
+    // boundary joins the range. Compared against the primitive directly rather
+    // than trusted, so a swapped pair fails here instead of surfacing later as
+    // an annotation that quietly grows when the user types next to it.
+    const ydoc = docFor("alpha bravo\n");
+    const range = anchorFlatRange(ydoc, toFlatOffset(2), toFlatOffset(7));
+    expect(range?.fromRel).toEqual(flatOffsetToRelPos(ydoc, toFlatOffset(2), 0));
+    expect(range?.toRel).toEqual(flatOffsetToRelPos(ydoc, toFlatOffset(7), -1));
+    // And NOT the other way round, which a symmetric-looking helper could be.
+    expect(range?.fromRel).not.toEqual(flatOffsetToRelPos(ydoc, toFlatOffset(2), -1));
+  });
+
+  it("returns null when only the from endpoint refuses", () => {
+    // Offset 0 is inside the `# ` prefix, which exists only in the server's
+    // rendering and has no Y.XmlText behind it.
+    const ydoc = docFor("# Title\n\nbody\n");
+    expect(anchorFlatRange(ydoc, toFlatOffset(0), toFlatOffset(6))).toBeNull();
+    // Guard against the test passing for the wrong reason: the `to` endpoint on
+    // its own must be perfectly mintable, so the null above is the
+    // all-or-nothing rule and not a doc-wide failure.
+    expect(flatOffsetToRelPos(ydoc, toFlatOffset(6), -1)).not.toBeNull();
+  });
+
+  it("returns null when only the to endpoint refuses", () => {
+    // The mirror case, which a from-only guard would let through. Empty blocks
+    // are where the two assocs disagree: assoc -1 refuses on the separator
+    // AFTER the empty element, assoc 0 on the one before it.
+    const ydoc = docFor("- one\n-\n- three\n");
+    const flat = extractText(ydoc);
+    const refusesLeft = [...flat].findIndex(
+      (_, i) => flatOffsetToRelPos(ydoc, toFlatOffset(i), -1) === null,
+    );
+    expect(refusesLeft, "fixture must contain an offset assoc -1 refuses").toBeGreaterThan(0);
+    expect(flatOffsetToRelPos(ydoc, toFlatOffset(0), 0)).not.toBeNull();
+    expect(anchorFlatRange(ydoc, toFlatOffset(0), toFlatOffset(refusesLeft))).toBeNull();
+  });
+
+  it("does not throw on a wildly out-of-range offset", () => {
+    const ydoc = docFor("short\n");
+    expect(() => anchorFlatRange(ydoc, toFlatOffset(0), toFlatOffset(9999))).not.toThrow();
+  });
+
+  it("does not throw on an empty document", () => {
+    const ydoc = new Y.Doc();
+    expect(() => anchorFlatRange(ydoc, toFlatOffset(0), toFlatOffset(1))).not.toThrow();
+    expect(anchorFlatRange(ydoc, toFlatOffset(0), toFlatOffset(1))).toBeNull();
+  });
+});

--- a/tests/shared/ydoc-import-ceiling.test.ts
+++ b/tests/shared/ydoc-import-ceiling.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `src/shared/positions/ydoc.ts` is the first runtime Y.Doc logic in
+ * `src/shared/`, and its whole reason for existing is that the client cannot
+ * import `src/server/mcp/document-model.ts` — that module pulls `node:path` and
+ * `saveMarkdown`, and with it the remark/unified pipeline, at module level.
+ *
+ * The three-import ceiling is what keeps that true. It CANNOT be held by
+ * convention: `biome.json` disables the linter entirely, there is no
+ * `no-restricted-imports` rule and no dependency-cruiser, so a stray import
+ * would land with nothing to object. A comment asking people not to is not a
+ * mechanism — this test is.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const MODULE = path.join(ROOT, "src/shared/positions/ydoc.ts");
+
+/** Every module specifier the file imports, in source order. */
+function importsOf(file: string): string[] {
+  const source = readFileSync(file, "utf-8");
+  return [...source.matchAll(/^\s*import\s[^;]*?from\s+["']([^"']+)["']/gm)].map((m) => m[1]);
+}
+
+describe("shared/positions/ydoc import ceiling", () => {
+  it("imports exactly yjs, ./types.js and ../offsets.js", () => {
+    // Asserted as an exact set, not a denylist of forbidden modules. A denylist
+    // only catches the imports someone thought to forbid; the danger here is a
+    // NEW transitive edge nobody has named yet, and `node:path` was never the
+    // point — reaching anything in `src/server` is.
+    expect([...new Set(importsOf(MODULE))].sort()).toEqual(["../offsets.js", "./types.js", "yjs"]);
+  });
+
+  it("reaches nothing under src/server, by any spelling", () => {
+    // Belt and braces over the exact-set assertion above, and the one that
+    // states the actual invariant in words a reader can check against intent.
+    const offenders = importsOf(MODULE).filter((s) => /server/.test(s));
+    expect(offenders).toEqual([]);
+  });
+
+  it("reaches nothing outside src/shared transitively either", () => {
+    // The direct ceiling is necessary but NOT sufficient, and the gap is easy to
+    // miss: if `../offsets.js` grew a `node:path` or `src/server` import
+    // tomorrow, every assertion above would still pass while the browser bundle
+    // quietly regained the dependency this extraction removed. The invariant is
+    // about the CLOSURE, so the test has to walk it.
+    const seen = new Set<string>();
+    const escapes: string[] = [];
+
+    const visit = (file: string) => {
+      if (seen.has(file)) return;
+      seen.add(file);
+      for (const spec of importsOf(file)) {
+        if (!spec.startsWith(".")) continue; // bare specifiers are packages
+        const resolved = path.resolve(path.dirname(file), spec.replace(/\.js$/, ".ts"));
+        const rel = path.relative(ROOT, resolved).replace(/\\/g, "/");
+        if (!rel.startsWith("src/shared/")) {
+          escapes.push(`${path.relative(ROOT, file).replace(/\\/g, "/")} -> ${rel}`);
+          continue;
+        }
+        visit(resolved);
+      }
+    };
+    visit(MODULE);
+
+    expect(escapes, "relative imports escaping src/shared").toEqual([]);
+    // Positive anchor: an empty `escapes` is also what a walk that visited
+    // nothing produces.
+    expect(seen.size).toBeGreaterThanOrEqual(3);
+  });
+
+  it("is not re-exported through the yjs-free barrel", () => {
+    // `shared/positions/index.ts` is imported for types by both halves of the
+    // app. Routing this module through it would make every one of those
+    // consumers pull `yjs` in invisibly — the leak this extraction exists to
+    // prevent, reintroduced one convenience re-export later.
+    const barrel = readFileSync(path.join(ROOT, "src/shared/positions/index.ts"), "utf-8");
+    expect(barrel).not.toContain("ydoc");
+  });
+});


### PR DESCRIPTION
Branch C of the #1471 authorship plan. Prepares the ground for the client-side
anchor mint; independent of #1504 and #1508.

## Why this isn't the file move it looks like

#1471 describes this step as mechanical. It isn't. `flatOffsetToRelPos` is
server-*located* and its dependency closure is pure Yjs — but four of its leaves
live inside `src/server/mcp/document-model.ts`, a 700-line module that imports
`node:path` and `saveMarkdown` (dragging the whole remark/unified pipeline) at
module level. Neither import is in the closure, but **a client bundle cannot
reach past them**, there are no client→server imports today, and `vite.config.ts`
defines no `@server` alias. `src/shared/` is the only sanctioned meeting point,
and `src/shared/positions/` is types-only today with no `yjs` import at all.

So this establishes a new architectural boundary, and the boundary needs
defending rather than describing.

## The gate

**Full suite green with ZERO test-file edits.** A refactor that forces test
changes cannot demonstrate it was behaviour-preserving. Met: 7374 passed, exit
0, and the only test-tree change is two new files. The six function bodies moved
verbatim.

## The ceiling is a test, not a comment

Three imports — `yjs`, `./types.js`, `../offsets.js` — and nothing else, ever.
That ceiling is the only thing keeping `node:path` out of the browser bundle,
and it **cannot be held by convention**: `biome.json` disables the linter
entirely, and there is no `no-restricted-imports` rule or dependency-cruiser, so
a stray import would land with nothing to object.

`tests/shared/ydoc-import-ceiling.test.ts` walks the **transitive closure**, not
just direct imports. The direct ceiling is necessary and not sufficient: if
`offsets.ts` grew a `src/server` import tomorrow, every direct assertion would
still pass while the bundle quietly regained the dependency this extraction
exists to remove. Mutation-tested — adding exactly that import reddens the
transitive test and only that test.

The module is deliberately **not** re-exported through
`shared/positions/index.ts`, which is `yjs`-free and imported for types by both
sides; routing runtime Y logic through it would make every consumer pull `yjs`
in invisibly. Also pinned.

## `anchorFlatRange`, and a claim I walked back

The new helper mints both endpoints with the canonical assoc pair. Its
all-or-nothing contract is not tidiness: the two assocs refuse to mint in
*different* places around an empty block (measured in #1504), so a partially
anchored range would have halves describing different documents.

Review caught that my JSDoc called it "the sole assembler of a `RelativeRange`"
as though it already were. It isn't — this diff adds the helper without
refactoring the three existing sites, so as shipped it is unreferenced until
branch D. The comment now says that plainly.

Collapsing those three sites stays deliberately separate. Two of them
(`refreshRange`'s branches) would swap in mechanically, but `anchoredRange`
re-resolves both endpoints on failure and logs only when *neither* was clamped
by a heading prefix — distinguishing "should have anchored and didn't" from
"correctly declined". A helper that just returns null erases that distinction,
so porting the diagnostic is a precondition, not a detail.

Because the helper ships ahead of its consumer, it gets its own tests rather
than arriving as untested code with a confident comment —
including both mirror-image failure cases, since a from-only guard would let the
to-side through.

## Verification

Typecheck, `svelte-check --fail-on-warnings`, biome, `audit:origins`,
`audit:ymap-keys` all clean. Reviewed by `crdt-reviewer`, which diffed each
moved body against `master` (verbatim), checked the shims for dropped exports
and import cycles (none), and confirmed `yjs` module identity is safe —
`package.json` pins one version and `vite.config.ts` dedupes it.

**One thing I can't fully account for:** an early full-suite run on this branch
reported 1 failure among 7391, and I discarded that log before identifying the
test. Four subsequent full runs are green at exit 0. The most likely explanation
is that the run began immediately after I reverted a deliberate mutation to
`offsets.ts` during mutation-testing, so it may have raced a stale transform —
but I can't confirm it, and "flake" is not a conclusion I can support without
knowing which test it was. Flagging rather than burying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj99tUgQp3JGru6j9fuHEi
