### PR TITLE
fix(authorship): give client stamps a CRDT anchor (#1471 gap 1)

### DIFF
--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -8,6 +8,7 @@ import * as Y from "yjs";
 import { AUTHORSHIP_TOGGLE_KEY, Y_MAP_AUTHORSHIP } from "../../../shared/constants";
 import { withBrowser } from "../../../shared/origins";
 import { toPmPos } from "../../../shared/positions/types";
+import { anchorFlatRange } from "../../../shared/positions/ydoc";
 import type { AuthorshipRange } from "../../../shared/types";
 import { isAuthorshipAuthor } from "../../../shared/types";
 import { generateAuthorshipId } from "../../../shared/utils";
@@ -74,6 +75,17 @@ function readAuthorshipOrigin(transaction: Transaction): AuthorshipRange["author
  * text, and escapes the reap. One unrelated keystroke above the span is enough.
  * Pinned executably in `authorship-stamp.test.ts` so the fix has a test waiting
  * for it rather than a comment.
+ *
+ * **AND THE OPPOSITE DIRECTION, which matters more now that entries are
+ * anchored.** This scan reads only the frozen `range`, never `relRange`. So a
+ * coincidental containment between a deleted span and some entry's stale offsets
+ * deletes that entry outright — even when its anchor was live and pointing at
+ * text nobody touched. Always possible, but previously it only cost a drifted
+ * entry that was already mis-painting; now it discards the very durability the
+ * anchor was minted for. Deleting is also less recoverable than mis-painting.
+ * The fix is to replace this scan with an anchor-aware liveness sweep rather
+ * than to patch it, which is the next piece of #1471 and deliberately not
+ * bundled here — it changes what drives the sweep, not just its predicate.
  */
 function reapableEntryIds(
   authorshipMap: Y.Map<unknown>,
@@ -93,8 +105,57 @@ function reapableEntryIds(
 const GUTTER_NODE_TYPES = new Set(["paragraph", "heading"]);
 
 /**
+ * Warn once per key per session.
+ *
+ * Both call sites below sit on hot paths — one runs per fallback entry per
+ * decoration rebuild, the other inside a keystroke handler. An unlatched
+ * `console.warn` there is not a diagnostic, it is a way of making the console
+ * useless and getting the warning deleted. This change also INCREASES the
+ * fallback count (entries that used to paint stale offsets now decline), so the
+ * latch is a precondition for the resolver fix rather than a tidy-up.
+ */
+const warnedKeys = new Set<string>();
+function warnOnce(key: string, ...args: unknown[]): void {
+  if (warnedKeys.has(key)) return;
+  warnedKeys.add(key);
+  console.warn(...args);
+}
+
+/** Test seam — the latch is module state and would leak between test cases. */
+export function _resetAuthorshipWarnLatch(): void {
+  warnedKeys.clear();
+}
+
+/**
  * Resolve an AuthorshipRange to ProseMirror positions.
- * Prefers relRange (CRDT-anchored) with flat-offset fallback.
+ *
+ * THE FALLBACK ORDERING IS THE WHOLE POINT, and it used to be wrong. An entry
+ * that HAS a `relRange` never falls back to flat offsets — if its anchor
+ * resolves collapsed or dead, the entry has no live text and the answer is
+ * `null`, not "try the frozen numbers instead".
+ *
+ * Previously the anchored result was accepted only when `from < to`, so a
+ * COLLAPSED anchor — the normal state of an entry whose text was deleted or
+ * replaced — fell straight through to `entry.range`. That is the orphan-paint
+ * symptom itself, and it is worse than it sounds: `flatOffsetToPmPos` CLAMPS
+ * rather than failing (`client/positions.ts`, which returns the end of the last
+ * block for any out-of-range offset), so a stale flat range never degrades to
+ * "no decoration". It degrades to a confident decoration on the wrong text —
+ * precisely what the authorship overlay exists to prevent (#1388).
+ *
+ * The flat branch is correct only for an entry that never had an anchor at all:
+ * a legacy in-session stamp, a server entry with `fullyAnchored: false`, or a
+ * mint that declined (heading prefix, empty block, no Collaboration binding).
+ *
+ * DO NOT MIRROR THIS INTO `annotationToPmRange` — it would break annotations,
+ * and the asymmetry is deliberate. That function accepts `from <= to`, so a
+ * collapsed annotation anchor returns as `method: "rel"` and never reaches its
+ * flat branch; the flat branch fires only on null-or-inverted, which is the
+ * lazy re-attachment recovery path CLAUDE.md warns about breaking. Annotations
+ * survive the shape because the SERVER refreshes their flat range on every read.
+ * Authorship has no `refreshRange` analogue, so nothing ever repairs a stale
+ * flat offset here — which is exactly why the same shape is safe there and
+ * unsafe here.
  */
 function resolveAuthorshipRange(
   entry: AuthorshipRange,
@@ -103,10 +164,10 @@ function resolveAuthorshipRange(
 ): { from: number; to: number } | null {
   if (entry.relRange) {
     const resolved = relRangeToPmPositions(ydoc, pmDoc, entry.relRange);
-    if (resolved && resolved.from < resolved.to) return resolved;
+    return resolved && resolved.from < resolved.to ? resolved : null;
   }
   if (entry.range) {
-    console.warn("[authorship] Falling back to flat offsets for range", entry.id);
+    warnOnce("flat-fallback", "[authorship] Falling back to flat offsets for range", entry.id);
     const from = flatOffsetToPmPos(pmDoc, entry.range.from);
     const to = flatOffsetToPmPos(pmDoc, entry.range.to);
     if (from < to) return { from, to };
@@ -429,10 +490,45 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions>({
               to: toPmPos(toFinal.map(newEnd, -1)),
             });
             if (range.to <= range.from) return;
+            // Anchor against the LIVE ydoc, which y-prosemirror has already
+            // written: Tiptap's `dispatchTransaction` calls `view.updateState`
+            // and emits `transaction` on the very next line, both synchronously,
+            // and the sync plugin's `update()` writes to Y inside that — no
+            // debounce, no microtask. So the Y.Doc is current when we stamp.
+            //
+            // Anchored from `range` — the FINAL-frame offsets out of
+            // `toFinal.map(...)` — and never from raw `newStart`/`newEnd`. Y
+            // holds only the transaction's final state, never a per-step
+            // intermediate, so anchoring the raw positions would mint a
+            // confidently wrong anchor on any multi-step transaction. That is
+            // the same failure `toFinal` was added to prevent on the flat side.
+            //
+            // Declining is safe and expected: no Collaboration extension, an
+            // offset inside a heading prefix, or either endpoint adjacent to an
+            // empty block. The entry then behaves exactly as it does today.
+            //
+            // UNSTATED INVARIANT, now stated: no `appendTransaction` plugin may
+            // insert or delete TEXT. `EditorState.apply` folds appended steps
+            // into the state handed to `updateState`, and y-prosemirror writes
+            // from `view.state.doc` — but the transaction Tiptap emits is the
+            // ROOT one, so `transaction.doc` does not include them. A text-moving
+            // append would therefore put `range` and the Y.Doc in different
+            // frames. This binds the flat `range` exactly as much as the anchor,
+            // so it is a property of the whole handler rather than of the mint.
+            // True today: `@tiptap/extension-link` is the only extension in the
+            // stack defining `appendTransaction` and it only adds/removes marks.
+            const relRange = anchorFlatRange(ydoc, range.from, range.to) ?? undefined;
+            if (!relRange) {
+              warnOnce(
+                "mint-declined",
+                "[authorship] Could not anchor a stamp; it will drift as before (#1471)",
+              );
+            }
             additions.push({
               id: generateAuthorshipId(author),
               author,
               range,
+              ...(relRange ? { relRange } : {}),
               timestamp: Date.now(),
             });
           } catch (err) {

--- a/tests/client/authorship-anchor.test.ts
+++ b/tests/client/authorship-anchor.test.ts
@@ -1,0 +1,252 @@
+// @vitest-environment happy-dom
+
+import { Editor } from "@tiptap/core";
+import Collaboration from "@tiptap/extension-collaboration";
+import { afterEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
+import {
+  _resetAuthorshipWarnLatch,
+  AUTHORSHIP_ORIGIN_META,
+  AuthorshipExtension,
+  buildAuthorshipDecorations,
+} from "../../src/client/editor/extensions/authorship";
+import { flatOffsetToPmPos, relRangeToPmPositions } from "../../src/client/positions";
+import { loadMarkdown } from "../../src/server/file-io/markdown";
+import { Y_MAP_AUTHORSHIP } from "../../src/shared/constants";
+import type { AuthorshipRange } from "../../src/shared/types";
+
+/**
+ * Client authorship stamps carry a CRDT anchor (#1471 gap 1).
+ *
+ * WHY THIS FILE EXISTS SEPARATELY FROM `authorship-stamp.test.ts`. That file
+ * builds its Editor with no `Collaboration` extension, so
+ * `ydoc.getXmlFragment("default")` is EMPTY and a mint there can only ever
+ * decline. Every test in it would still pass with this change reverted, proving
+ * nothing — the `a-mock-cannot-see-a-correspondence-bug` shape. A real
+ * y-prosemirror binding is the prerequisite for testing any of this, not a
+ * nicety.
+ *
+ * That is also why the "KNOWN LIMITATION (#1471)" case over there could not be
+ * inverted where it stood: with no binding, the limitation it pins is still
+ * genuinely true there. It is re-homed here against a bound editor, and the
+ * original is retitled as the graceful-degradation contract — which this change
+ * needs pinned anyway and would otherwise not have.
+ */
+
+const live: Editor[] = [];
+
+/**
+ * Seed Y FIRST, then bind. Sidesteps y-prosemirror's `initialContentChanged`
+ * latch rather than betting on it, and is the shape
+ * `structural-snapshot-undo.test.ts` already uses.
+ */
+function boundEditor(markdown: string) {
+  const ydoc = new Y.Doc();
+  loadMarkdown(ydoc, markdown);
+  const editor = new Editor({
+    extensions: [
+      ...buildSchemaExtensions(),
+      Collaboration.configure({ document: ydoc }),
+      AuthorshipExtension.configure({ ydoc }),
+    ],
+  });
+  live.push(editor);
+  const entries = () => [...ydoc.getMap(Y_MAP_AUTHORSHIP).values()] as AuthorshipRange[];
+  return { ydoc, editor, entries };
+}
+
+/**
+ * The text each INLINE AUTHORSHIP DECORATION actually covers, per author.
+ *
+ * Goes through `buildAuthorshipDecorations` — the real render path — rather than
+ * re-deriving positions from `relRangeToPmPositions` here. An earlier draft of
+ * this file did the latter and it was worthless: reverting the resolver fix in
+ * production left all five tests green, because the test was asserting against
+ * its own copy of the logic under test. That is the shape
+ * `a-mock-cannot-see-a-correspondence-bug` names, reproduced exactly.
+ *
+ * Keyed by author because that is what the decoration carries
+ * (`data-tandem-author`); entry ids are not in the spec.
+ */
+function decoratedTextByAuthor(ydoc: Y.Doc, editor: Editor): Record<string, string[]> {
+  const doc = editor.state.doc;
+  const set = buildAuthorshipDecorations(doc, ydoc.getMap(Y_MAP_AUTHORSHIP), ydoc, true);
+  const out: Record<string, string[]> = {};
+  for (const decoration of set.find()) {
+    const author = (decoration as { type?: { attrs?: Record<string, string> } }).type?.attrs?.[
+      "data-tandem-author"
+    ];
+    // The gutter pass adds node decorations too; only inline spans carry it.
+    if (!author) continue;
+    (out[author] ??= []).push(doc.textBetween(decoration.from, decoration.to));
+  }
+  for (const key of Object.keys(out)) out[key].sort();
+  return out;
+}
+
+/** The anchor's own resolution, for asserting the MINT rather than the render. */
+function anchoredText(ydoc: Y.Doc, editor: Editor, entry: AuthorshipRange): string | null {
+  if (!entry.relRange) return null;
+  const at = relRangeToPmPositions(ydoc, editor.state.doc, entry.relRange);
+  return at && at.from < at.to ? editor.state.doc.textBetween(at.from, at.to) : null;
+}
+
+afterEach(() => {
+  // Destroying every editor matters more than it looks: an undestroyed Tiptap
+  // Editor's DOMObserver timer fires after happy-dom tears the document down,
+  // which surfaces as "everything passed, exit 1" with no failing test named.
+  for (const editor of live.splice(0)) editor.destroy();
+  _resetAuthorshipWarnLatch();
+});
+
+describe("client stamps are CRDT-anchored", () => {
+  it("TEST 0 — the binding is real and the mint works", () => {
+    // ANTI-VACUUM GUARD, and the most important test in the file. Without it a
+    // regression in the harness silently turns every test below into a green
+    // test of the degraded path — precisely the state the pre-existing suite
+    // was already in, which is why it proved nothing for months.
+    const { ydoc, editor, entries } = boundEditor("hello world\n");
+
+    expect(ydoc.getXmlFragment("default").length, "Y fragment must be populated").toBeGreaterThan(
+      0,
+    );
+
+    editor.view.dispatch(editor.state.tr.insertText("X", 1));
+    expect(entries()).toHaveLength(1);
+    expect(entries()[0].relRange, "a stamp on a bound editor must mint an anchor").toBeDefined();
+  });
+
+  it("keeps a stamp on its own text after an edit earlier in the document", () => {
+    // RE-HOMED from `authorship-stamp.test.ts`. One unrelated keystroke ABOVE a
+    // stamped span used to move its text out from under its recorded flat
+    // offsets, permanently and silently.
+    //
+    // Asserted by resolved TEXT rather than by literal offsets: this change
+    // deliberately does not rewrite the stored flat `range`, so an offset
+    // assertion would pin the stale numbers and pass for the wrong reason. What
+    // must be true is that the anchor still names the same characters.
+    const { ydoc, editor, entries } = boundEditor("alpha bravo charlie\n");
+
+    const at = editor.getText().indexOf("bravo") + 1;
+    editor.view.dispatch(
+      editor.state.tr.insertText("BOLDLY ", at).setMeta(AUTHORSHIP_ORIGIN_META, "claude"),
+    );
+    const claude = entries().find((entry) => entry.author === "claude");
+    expect(claude?.relRange, "the claude stamp must be anchored").toBeDefined();
+    expect(anchoredText(ydoc, editor, claude as AuthorshipRange)).toBe("BOLDLY ");
+
+    // The unrelated keystroke, well before the stamped span.
+    editor.view.dispatch(editor.state.tr.insertText("X", 1));
+
+    expect(
+      anchoredText(ydoc, editor, claude as AuthorshipRange),
+      "anchor must survive an earlier edit",
+    ).toBe("BOLDLY ");
+    // And the RENDER must agree, which is the part the user sees.
+    expect(decoratedTextByAuthor(ydoc, editor).claude).toEqual(["BOLDLY "]);
+  });
+
+  it("paints nothing when a DRIFTED entry loses its text, instead of painting elsewhere", () => {
+    // THE RESOLVER FIX, and getting this scenario right took two attempts.
+    //
+    // A simple delete-what-you-stamped is NOT a test of it: that deletion is
+    // exactly what the existing reap catches, so no entry survives for either
+    // version of the resolver to get wrong, and the test passes identically with
+    // the fix reverted. The fix only matters for an entry the reap MISSES.
+    //
+    // Which is the #1471 entry itself. Drift the stored flat offsets first with
+    // an unrelated edit above; the reap then compares a current-frame deleted
+    // span against stale offsets, containment fails, and the entry survives with
+    // a collapsed anchor and a stale flat range. Before the fix, that range
+    // resolved through `flatOffsetToPmPos` — which CLAMPS rather than failing —
+    // and painted confidently on whatever text now sat at those numbers. That is
+    // #1388's render reached from the other side.
+    const { ydoc, editor, entries } = boundEditor("alpha bravo charlie delta\n");
+
+    const at = editor.getText().indexOf("bravo") + 1;
+    editor.view.dispatch(
+      editor.state.tr.insertText("ZZZZ", at).setMeta(AUTHORSHIP_ORIGIN_META, "claude"),
+    );
+    const claude = entries().find((entry) => entry.author === "claude") as AuthorshipRange;
+    expect(decoratedTextByAuthor(ydoc, editor).claude).toEqual(["ZZZZ"]);
+    const storedRange = { ...claude.range };
+
+    // Drift: an unrelated insertion ABOVE the stamp, so the stored offsets no
+    // longer describe where the text is.
+    editor.view.dispatch(editor.state.tr.insertText("XX", 1));
+
+    // Now delete the stamped text. The reap misses it, by construction.
+    const from = editor.getText().indexOf("ZZZZ") + 1;
+    editor.view.dispatch(editor.state.tr.delete(from, from + 4));
+    const survivor = entries().find((entry) => entry.id === claude.id);
+    expect(survivor, "the drifted entry must survive the reap — that is the premise").toBeDefined();
+    expect(survivor?.range, "and still carry its stale offsets").toEqual(storedRange);
+
+    // The stale offsets must still name real, non-empty text, or the assertion
+    // below would pass for the boring reason rather than the intended one.
+    const doc = editor.state.doc;
+    expect(
+      doc.textBetween(
+        flatOffsetToPmPos(doc, storedRange.from),
+        flatOffsetToPmPos(doc, storedRange.to),
+      ),
+      "the stale range must resolve to SOMETHING for this test to mean anything",
+    ).not.toBe("");
+
+    expect(
+      decoratedTextByAuthor(ydoc, editor).claude,
+      "a collapsed anchor must paint nothing, never fall back to stale offsets",
+    ).toBeUndefined();
+  });
+
+  it("still stamps, unanchored, when there is no Collaboration binding", () => {
+    // THE DEGRADATION CONTRACT. Declining to anchor must never cost the stamp
+    // itself: an unanchored entry behaves exactly as every entry did before this
+    // change — worse than anchored, but not broken.
+    const ydoc = new Y.Doc();
+    const editor = new Editor({
+      extensions: [...buildSchemaExtensions(), AuthorshipExtension.configure({ ydoc })],
+      content: "<p>hello world</p>",
+    });
+    live.push(editor);
+
+    editor.view.dispatch(editor.state.tr.insertText("X", 1));
+    const entries = [...ydoc.getMap(Y_MAP_AUTHORSHIP).values()] as AuthorshipRange[];
+    expect(entries).toHaveLength(1);
+    expect(entries[0].relRange, "no fragment to anchor into").toBeUndefined();
+    expect(entries[0].range, "but the flat stamp must still happen").toBeDefined();
+  });
+
+  it("anchors against the final frame, not a per-step intermediate", () => {
+    // A multi-step transaction applied in reverse document order — the
+    // find-replace-all shape. Y holds only the transaction's FINAL state, never
+    // a per-step intermediate, so anchoring raw step positions would mint a
+    // confidently wrong anchor on every step but the last.
+    const { ydoc, editor, entries } = boundEditor("one TARGET two TARGET three\n");
+
+    const text = editor.getText();
+    const second = text.lastIndexOf("TARGET") + 1;
+    const first = text.indexOf("TARGET") + 1;
+    const tr = editor.state.tr;
+    // Pure insertions, LATER POSITION FIRST — the order find-replace-all
+    // applies its matches in. Deliberately not replacements: a replacement that
+    // shrinks the text has `insertedLen <= 0` and is never stamped at all, so a
+    // fixture built that way asserts nothing while looking like it does.
+    //
+    // Step 0 lands at `second`; step 1 then inserts BEFORE it and shifts it. So
+    // step 0's own `newStart` no longer addresses `transaction.doc` by the time
+    // the handler reads it, which is exactly the case `toFinal` exists for and
+    // the case a raw-position anchor would get confidently wrong.
+    tr.insertText("AAA", second);
+    tr.insertText("BBB", first);
+    editor.view.dispatch(tr.setMeta(AUTHORSHIP_ORIGIN_META, "claude"));
+
+    const anchored = entries().filter((entry) => entry.relRange);
+    expect(anchored.length, "both replacements must anchor").toBe(2);
+    expect(
+      anchored.map((entry) => anchoredText(ydoc, editor, entry)).sort(),
+      "each anchor must name its own replacement",
+    ).toEqual(["AAA", "BBB"]);
+  });
+});

--- a/tests/client/authorship-stamp.test.ts
+++ b/tests/client/authorship-stamp.test.ts
@@ -182,17 +182,22 @@ describe("authorship stamp path", () => {
       expect(entries().map((e) => e.id)).not.toContain(claudeEntry.id);
     });
 
-    it("KNOWN LIMITATION (#1471): a drifted entry escapes the reap", () => {
-      // Not a wish — measured. Stored client ranges are frozen flat offsets
-      // that nothing remaps, so one unrelated keystroke ABOVE a stamped span
-      // is enough to move its text out from under its recorded range. The reap
-      // then compares a current-frame deleted span against a stale entry, the
-      // containment test fails, and the stale \"user\" range survives underneath
-      // the new \"claude\" one — #1388's render, reached from the other side.
+    it("without a Collaboration binding, a drifted entry still escapes the reap", () => {
+      // THE GRACEFUL-DEGRADATION CONTRACT, and it did not change when #1471
+      // landed. This editor has no `Collaboration` extension, so
+      // `ydoc.getXmlFragment("default")` is empty, the anchor mint declines, and
+      // the entry keeps exactly the frozen-flat-offset behaviour described
+      // below: one unrelated keystroke ABOVE a stamped span moves its text out
+      // from under its recorded range, the reap compares a current-frame deleted
+      // span against a stale entry, containment fails, and the entry survives.
       //
-      // Pinned deliberately, so the durable-relRange fix has a red test to
-      // turn green rather than a comment to notice. When #1471 lands, the
-      // second assertion inverts.
+      // It was titled "KNOWN LIMITATION (#1471)" and expected to invert when the
+      // fix landed. It cannot invert HERE — with no binding there is nothing to
+      // anchor into, so the limitation remains real in this context. The
+      // inverted case lives in `authorship-anchor.test.ts` against a genuinely
+      // bound editor; what is pinned here is that declining to anchor still
+      // costs nothing beyond the drift, which this change needs asserted
+      // somewhere and would otherwise not have.
       editor.commands.insertContentAt(6, "brave ");
       editor.view.dispatch(editor.state.tr.insertText("X", 1));
 


### PR DESCRIPTION
Branch D1 of the #1471 plan, on top of #1509. This is the complete user-visible
fix for gap 1; the observer-driven sweep (map growth, gap 3) follows in D2.

## The defect

Client authorship stamps carried a flat `range` and nothing else, while the
server's carry a CRDT-anchored `relRange` alongside. So a client entry had only
frozen offsets that nothing remaps:

1. every edit earlier in the document slid the highlight off its text; and
2. the reap #1388 shipped was defeated — it compares a current-frame deleted
   span against stale stored offsets, containment fails, and a stale `"user"`
   entry survives sitting on top of the new `"claude"` one. Both get painted.

## Two changes, and the second matters more

**The mint** anchors against the live Y.Doc, which y-prosemirror has already
written: Tiptap's `dispatchTransaction` calls `view.updateState` and emits
`transaction` on the very next line, both synchronously, and the sync plugin
writes to Y inside that — no debounce, no microtask. Verified against
`@tiptap/core`, `prosemirror-view` and `y-prosemirror` sources rather than
assumed, since if the Y write landed *after* the event, every anchor would be
minted against a stale document and this would be worse than the bug.

Anchored from the **final-frame** offsets, never from raw step positions. Y
holds only the transaction's final state, so raw positions would mint a
confidently wrong anchor on any multi-step transaction — the same failure
`toFinal` was added to prevent on the flat side.

**The resolver fix** is the higher-value half. `resolveAuthorshipRange` accepted
the anchored result only when `from < to`, so a *collapsed* anchor — the normal
state of an entry whose text was deleted — fell straight through to the frozen
offsets. That is the orphan-paint symptom itself, and worse than it sounds:
`flatOffsetToPmPos` **clamps rather than failing**, so a stale range never
degraded to "no decoration". It degraded to a confident decoration on the wrong
text, which is exactly what the overlay exists to prevent.

## The test for that took three attempts, and two of them were green frauds

Worth reading, because both failure modes look like passing tests:

1. **Re-implemented the resolver in the test file.** Mutating production changed
   nothing the test observed — it was asserting against its own copy of the logic
   under test. Reverting the fix left all five tests green.
2. **Routed through `buildAuthorshipDecorations`, but deleted exactly the
   stamped text.** Still green when reverted, for a subtler reason: that deletion
   is precisely what the existing reap catches, so no entry survives for either
   version of the resolver to get wrong.

The fix only matters for an entry the reap **misses** — which is the drifted
#1471 entry itself. The test now drifts the offsets first, asserts the entry
survived the reap (the premise), asserts the stale range still names non-empty
text (so it cannot pass for the boring reason), and only then checks the render.
Reverted, it fails with `expected [ 'a br' ] to be undefined` — the stale entry
painting four characters it does not own. That is #1388's render reached from
the other side, demonstrated rather than described.

Both other claims are mutation-tested too: anchoring from raw step positions
kills the multi-step test.

## Test re-homing

`authorship-stamp.test.ts`'s `KNOWN LIMITATION (#1471)` case **could not invert
where it stood**, contrary to the issue's expectation. That editor has no
`Collaboration` extension, so `ydoc.getXmlFragment("default")` is empty, the
mint declines, and the limitation it pins is still genuinely true there. It is
re-homed to a bound editor in the new file, and the original retitled as the
graceful-degradation contract — which this change needs pinned anyway and would
otherwise not have.

The new file leads with an anti-vacuum guard asserting the fragment is populated
and a trivial insert produces a defined `relRange`. Without it, a regression in
the harness silently turns every test below into a green test of the degraded
path — which is the state the pre-existing suite was already in.

## Two invariants documented rather than changed

Both surfaced in review, both real, neither a defect in this diff:

- **No `appendTransaction` plugin may move text.** `EditorState.apply` folds
  appended steps into the state y-prosemirror writes from, but the transaction
  Tiptap emits is the root one — so a text-moving append would put `range` and
  the Y.Doc in different frames. This binds the flat range exactly as much as
  the anchor, so it is a property of the whole handler. True today:
  `@tiptap/extension-link` is the only extension defining `appendTransaction`
  and it only adds and removes marks.
- **The reap still keys off frozen offsets**, so a coincidental containment can
  delete an entry whose anchor was live and correct. Always possible, but now
  more consequential: it discards the durability the anchor was minted for, and
  deleting is less recoverable than mis-painting. Replacing that scan with an
  anchor-aware sweep is D2, deliberately not bundled — it changes what *drives*
  the sweep, not just its predicate.

## Verification

Full suite 7383 passed, exit 0, no unhandled errors. Typecheck, `svelte-check
--fail-on-warnings` and biome clean. Reviewed by `crdt-reviewer`, which
confirmed the Y-currency claim against the vendored sources, verified no server
path stores a `relRange` while intending the flat range to stay authoritative
(so the stricter fallback breaks nothing existing), and surfaced both caveats
above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj99tUgQp3JGru6j9fuHEi
