### PR TITLE
fix(authorship): stop the reap destroying recoverable attribution (#1480)

### DIFF
--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -76,16 +76,17 @@ function readAuthorshipOrigin(transaction: Transaction): AuthorshipRange["author
  * Pinned executably in `authorship-stamp.test.ts` so the fix has a test waiting
  * for it rather than a comment.
  *
- * **AND THE OPPOSITE DIRECTION, which matters more now that entries are
- * anchored.** This scan reads only the frozen `range`, never `relRange`. So a
- * coincidental containment between a deleted span and some entry's stale offsets
- * deletes that entry outright — even when its anchor was live and pointing at
- * text nobody touched. Always possible, but previously it only cost a drifted
- * entry that was already mis-painting; now it discards the very durability the
- * anchor was minted for. Deleting is also less recoverable than mis-painting.
- * The fix is to replace this scan with an anchor-aware liveness sweep rather
- * than to patch it, which is the next piece of #1471 and deliberately not
- * bundled here — it changes what drives the sweep, not just its predicate.
+ * **Both limitations above apply only to UNANCHORED entries now.** An entry
+ * carrying a `relRange` is skipped entirely — see the comment at the skip. The
+ * escape direction stops mattering for those (a collapsed anchor paints
+ * nothing), and the opposite direction — deleting an entry whose anchor was
+ * still live, on a coincidental overlap of stale offsets — stops being possible.
+ *
+ * What remains, and is deliberately NOT fixed here: anchored entries are never
+ * removed, so the map still grows without bound. It always did; the real fix is
+ * coalescing consecutive same-author stamps, which is a separate issue. Trading
+ * unbounded growth for correct undo attribution is the right way round —
+ * growth costs memory, and deleting costs attribution permanently.
  */
 function reapableEntryIds(
   authorshipMap: Y.Map<unknown>,
@@ -96,6 +97,24 @@ function reapableEntryIds(
   authorshipMap.forEach((value, key) => {
     const entry = value as AuthorshipRange;
     if (!entry?.range) return;
+    // ANCHORED ENTRIES ARE GOVERNED BY THEIR ANCHOR, NOT BY THIS SCAN.
+    //
+    // Measured (`authorship-undo-redo.test.ts`): a Yjs anchor resolves BACK
+    // after an undo, because resolution runs through `followRedone`. So an
+    // anchored entry whose text is deleted does not need deleting — it collapses,
+    // the resolver paints nothing for it, and if the user undoes, it resolves
+    // again and paints correctly. Deleting it is not merely unnecessary, it is
+    // destructive: nothing restores a Y.Map entry on undo, so the attribution is
+    // gone permanently. That is the whole of #1480's redo symptom.
+    //
+    // It also closes the false-positive direction. This scan compares FROZEN
+    // offsets, so a coincidental containment could delete an entry whose anchor
+    // was live and pointing at text nobody touched — discarding exactly the
+    // durability the anchor was minted for.
+    //
+    // Unanchored entries still reap. They cannot self-heal (a frozen range is
+    // all they have), so leaving them is the drift this scan exists to limit.
+    if (entry.relRange) return;
     const { from, to } = entry.range;
     if (deletedSpans.some((span) => from >= span.from && to <= span.to)) ids.push(key);
   });

--- a/tests/client/authorship-undo-redo.test.ts
+++ b/tests/client/authorship-undo-redo.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment happy-dom
+
+import { Editor } from "@tiptap/core";
+import Collaboration from "@tiptap/extension-collaboration";
+import { afterEach, describe, expect, it } from "vitest";
+import { yUndoPluginKey } from "y-prosemirror";
+import * as Y from "yjs";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
+import {
+  _resetAuthorshipWarnLatch,
+  AUTHORSHIP_ORIGIN_META,
+  AuthorshipExtension,
+  buildAuthorshipDecorations,
+} from "../../src/client/editor/extensions/authorship";
+import { loadMarkdown } from "../../src/server/file-io/markdown";
+import { Y_MAP_AUTHORSHIP } from "../../src/shared/constants";
+import type { AuthorshipRange } from "../../src/shared/types";
+
+/**
+ * Undo/redo attribution — #1471 gap 2 and #1480.
+ *
+ * WHAT THIS FILE IS FOR. The plan for gap 2 was a stack-item handshake:
+ * stash deleted entries on the Yjs UndoManager's stack item, put them back on
+ * pop, and write the just-died set onto the counterpart item so the operation
+ * self-inverts. That is a substantial mechanism with handlers, teardown
+ * ordering hazards, and a re-entrancy story.
+ *
+ * It may be unnecessary. `createAbsolutePositionFromRelativePosition` resolves
+ * through `followRedone`, which chases an item through its redone incarnations,
+ * and every call site in this repo uses the 2-arg form that passes
+ * `followUndoneDeletions = true`. If a stored anchor therefore resolves BACK
+ * after an undo, then simply not deleting collapsed entries produces the
+ * correct trace on its own: after an accept the covered entries collapse and
+ * (given the resolver fix) paint nothing; after undo they resolve again and
+ * paint; after redo they collapse again. No handshake, no revive list, no
+ * pop-time write.
+ *
+ * These tests are that experiment, kept as the executable record of what it
+ * settled — a measurement that lives only in a commit message gets re-litigated.
+ *
+ * They also carry #1480's scenario end to end. Its stated mechanism — that
+ * ProseMirror's history plugin does not replay `getMeta()` on redo — describes a
+ * plugin the product editor never registers (`StarterKit.configure({ history:
+ * false })`, and `Collaboration` binds Mod-z to the Yjs manager). What is real is
+ * the symptom, and this is where it gets pinned.
+ */
+
+const live: Editor[] = [];
+
+function boundEditor(markdown: string) {
+  const ydoc = new Y.Doc();
+  loadMarkdown(ydoc, markdown);
+  const editor = new Editor({
+    extensions: [
+      ...buildSchemaExtensions(),
+      Collaboration.configure({ document: ydoc }),
+      AuthorshipExtension.configure({ ydoc }),
+    ],
+  });
+  live.push(editor);
+  const entries = () => [...ydoc.getMap(Y_MAP_AUTHORSHIP).values()] as AuthorshipRange[];
+  return { ydoc, editor, entries };
+}
+
+/** The real UndoManager the editor is bound to — not a hand-built one. */
+function undoManager(editor: Editor): Y.UndoManager {
+  const state = yUndoPluginKey.getState(editor.state) as
+    | { undoManager?: Y.UndoManager }
+    | undefined;
+  const manager = state?.undoManager;
+  if (!manager) throw new Error("no UndoManager — the Collaboration binding is not live");
+  return manager;
+}
+
+/** Text each inline authorship decoration covers, keyed by author. */
+function decoratedTextByAuthor(ydoc: Y.Doc, editor: Editor): Record<string, string[]> {
+  const doc = editor.state.doc;
+  const set = buildAuthorshipDecorations(doc, ydoc.getMap(Y_MAP_AUTHORSHIP), ydoc, true);
+  const out: Record<string, string[]> = {};
+  for (const decoration of set.find()) {
+    const author = (decoration as { type?: { attrs?: Record<string, string> } }).type?.attrs?.[
+      "data-tandem-author"
+    ];
+    if (!author) continue;
+    (out[author] ??= []).push(doc.textBetween(decoration.from, decoration.to));
+  }
+  for (const key of Object.keys(out)) out[key].sort();
+  return out;
+}
+
+afterEach(() => {
+  for (const editor of live.splice(0)) editor.destroy();
+  _resetAuthorshipWarnLatch();
+});
+
+describe("the §2.0 gate: does an anchor resolve back after an undo?", () => {
+  it("the editor really is bound to a Yjs UndoManager, not ProseMirror history", () => {
+    // ANTI-VACUUM, and it also settles #1480's premise. If this throws, every
+    // test below is measuring some other editor's undo.
+    const { editor } = boundEditor("alpha bravo\n");
+    expect(undoManager(editor)).toBeInstanceOf(Y.UndoManager);
+  });
+
+  it("a collapsed anchor resolves BACK after undo, and collapses again on redo", () => {
+    // THE MEASUREMENT THE WHOLE OF PART 2 TURNS ON. The intuition is that Yjs
+    // restores content as new items with new clocks, so a pre-undo anchor is
+    // dead afterwards and entries must be re-minted. That intuition is wrong:
+    // resolution runs through `followRedone`, which chases an item through its
+    // redone incarnations.
+    const { ydoc, editor, entries } = boundEditor("alpha bravo charlie\n");
+
+    const at = editor.getText().indexOf("bravo") + 1;
+    editor.view.dispatch(
+      editor.state.tr.insertText("ZZZZ", at).setMeta(AUTHORSHIP_ORIGIN_META, "claude"),
+    );
+    const claude = entries().find((entry) => entry.author === "claude") as AuthorshipRange;
+    expect(claude?.relRange, "the stamp must be anchored for this to mean anything").toBeDefined();
+    expect(decoratedTextByAuthor(ydoc, editor).claude).toEqual(["ZZZZ"]);
+
+    undoManager(editor).undo();
+    expect(
+      decoratedTextByAuthor(ydoc, editor).claude,
+      "after undo the inserted text is gone, so the anchor collapses and paints nothing",
+    ).toBeUndefined();
+
+    undoManager(editor).redo();
+    expect(
+      decoratedTextByAuthor(ydoc, editor).claude,
+      "after redo the SAME stored anchor must find the re-inserted text again",
+    ).toEqual(["ZZZZ"]);
+  });
+
+  it("survives undo and redo twice, without re-minting", () => {
+    // Convergence at depth. A mechanism that works once and drifts on the second
+    // cycle is worse than none, because the drift is invisible.
+    const { ydoc, editor, entries } = boundEditor("alpha bravo charlie\n");
+
+    const at = editor.getText().indexOf("bravo") + 1;
+    editor.view.dispatch(
+      editor.state.tr.insertText("ZZZZ", at).setMeta(AUTHORSHIP_ORIGIN_META, "claude"),
+    );
+    const stored = JSON.stringify(
+      (entries().find((entry) => entry.author === "claude") as AuthorshipRange).relRange,
+    );
+
+    for (let cycle = 0; cycle < 2; cycle++) {
+      undoManager(editor).undo();
+      expect(decoratedTextByAuthor(ydoc, editor).claude, `cycle ${cycle} undo`).toBeUndefined();
+      undoManager(editor).redo();
+      expect(decoratedTextByAuthor(ydoc, editor).claude, `cycle ${cycle} redo`).toEqual(["ZZZZ"]);
+    }
+
+    // And nothing re-minted it along the way — the SAME anchor did all of that.
+    expect(
+      JSON.stringify(
+        (entries().find((entry) => entry.author === "claude") as AuthorshipRange).relRange,
+      ),
+      "the stored anchor must be untouched across four pops",
+    ).toBe(stored);
+  });
+
+  it("#1480: accept then undo then redo attributes the right text at every step", () => {
+    // #1480's scenario end to end, and the highest-value case in this area.
+    // Shipped behaviour was: undo left a stale `claude` entry painting the
+    // user's restored original text AS CLAUDE, and redo attributed the redone
+    // text to nobody.
+    //
+    // Modelled as replace-then-undo-then-redo, which is the accept shape: user
+    // text is removed and Claude text put in its place.
+    const { ydoc, editor, entries } = boundEditor("the user wrote this\n");
+
+    const from = editor.getText().indexOf("user wrote this") + 1;
+    editor.view.dispatch(
+      editor.state.tr
+        .insertText("CLAUDE WROTE THIS INSTEAD", from, from + "user wrote this".length)
+        .setMeta(AUTHORSHIP_ORIGIN_META, "claude"),
+    );
+    expect(entries().some((entry) => entry.author === "claude")).toBe(true);
+    expect(decoratedTextByAuthor(ydoc, editor).claude).toEqual(["CLAUDE WROTE THIS INSTEAD"]);
+
+    undoManager(editor).undo();
+    expect(editor.getText()).toContain("user wrote this");
+    expect(
+      decoratedTextByAuthor(ydoc, editor).claude,
+      "THE #1480 BUG: the restored user text must not be attributed to Claude",
+    ).toBeUndefined();
+
+    undoManager(editor).redo();
+    expect(
+      decoratedTextByAuthor(ydoc, editor).claude,
+      "and the redone text must be attributed to Claude again, not to nobody",
+    ).toEqual(["CLAUDE WROTE THIS INSTEAD"]);
+  });
+
+  it("a whole-paragraph deletion restores its attribution on undo", () => {
+    // The harshest case for the claim, because the anchor's PARENT type is
+    // deleted rather than merely its content — the state that looks most like
+    // "unrecoverable" and would justify the re-mint design if anything did.
+    const { ydoc, editor, entries } = boundEditor("first para\n\nsecond para\n");
+
+    const at = editor.getText().indexOf("second") + 1;
+    editor.view.dispatch(
+      editor.state.tr.insertText("NEW ", at).setMeta(AUTHORSHIP_ORIGIN_META, "claude"),
+    );
+    expect(decoratedTextByAuthor(ydoc, editor).claude).toEqual(["NEW "]);
+    expect(entries().some((entry) => entry.author === "claude")).toBe(true);
+
+    // CLOSE THE STACK ITEM before deleting, and this is load-bearing rather
+    // than hygiene. `Y.UndoManager` merges edits within `captureTimeout`
+    // (500ms) into ONE item, and a test makes both edits in the same
+    // millisecond — so without this the single undo reverts the insertion as
+    // well as the deletion, the text comes back WITHOUT the stamped word, and
+    // the anchor correctly resolves to null. The assertion below then fails
+    // while the code is right: the fixture had quietly merged the two states it
+    // exists to keep apart.
+    undoManager(editor).stopCapturing();
+
+    // Delete the entire second paragraph, node boundaries included.
+    const doc = editor.state.doc;
+    const second = doc.child(1);
+    const start = doc.content.size - second.nodeSize;
+    editor.view.dispatch(editor.state.tr.delete(start, doc.content.size));
+    expect(decoratedTextByAuthor(ydoc, editor).claude).toBeUndefined();
+    // The premise, and the thing this case actually caught: the entry must
+    // still EXIST. It used to be reaped here, and no undo restores a Y.Map
+    // entry — so the attribution was gone permanently, which is the whole of
+    // #1480's redo symptom and had nothing to do with anchors dying.
+    expect(
+      entries().some((entry) => entry.author === "claude"),
+      "the entry must survive the reap",
+    ).toBe(true);
+
+    undoManager(editor).undo();
+    expect(
+      decoratedTextByAuthor(ydoc, editor).claude,
+      "a deleted parent type is recoverable too — followRedone chases it",
+    ).toEqual(["NEW "]);
+  });
+});


### PR DESCRIPTION
Closes #1480. Follows #1510.

The plan put an experiment ahead of building undo/redo attribution support. The
experiment ran, and it **removes the feature rather than shaping it** — the
mechanism turned out to be a one-line change in the opposite place.

## What was going to be built

A stack-item handshake: stash deleted entries on the Yjs UndoManager's stack
item, put them back on pop, and write the just-died set onto the counterpart
item so the operation self-inverts at any stack depth. Handlers, teardown
ordering hazards (the Collaboration extension's `destroy()` runs first and
clears the observer map out from under ours), a re-entrancy story.

## Why none of it is needed

**A stored anchor resolves BACK after an undo.** Resolution runs through
`followRedone`, which chases an item through its redone incarnations, and every
call site in this repo uses the 2-arg form that passes
`followUndoneDeletions = true`. So an entry whose text is undone away collapses,
paints nothing (given #1510's resolver fix), and resolves again on redo.

Measured against a real `Collaboration` binding and the editor's actual
`Y.UndoManager` — not a hand-built one — across content deletion, a deleted
parent type, two full undo/redo cycles, and #1480's own accept→undo→redo
scenario. The stored anchor is asserted byte-identical throughout: nothing
re-mints it, the same anchor does all of that.

## So what was actually broken

**The reap was deleting the entry.** Nothing restores a Y.Map entry on undo, so
the attribution was gone permanently — that is the whole of #1480's redo
symptom. The anchors were never the problem.

This was not obvious from the failing test. The whole-paragraph case initially
failed and looked like proof that a deleted parent type is unrecoverable, which
would have justified the entire re-mint design. A probe showed the entry count
was **0** after the deletion: the anchor had not failed, the entry had been
destroyed.

The fix is one line — anchored entries skip the reap. Their liveness is the
anchor's business, and a collapsed anchor already paints nothing. This also
closes the opposite direction flagged in #1510's review: the scan compares
frozen offsets, so a coincidental containment could delete an entry whose anchor
was live and pointing at text nobody had touched, discarding exactly the
durability the anchor was minted for.

Unanchored entries still reap. They cannot self-heal, so leaving them is the
drift the scan exists to limit.

## On #1480's filed mechanism

It attributes the bug to ProseMirror's history plugin not replaying `getMeta()`
on redo. That plugin is **never registered in the product editor** —
`StarterKit.configure({ history: false })`, and `Collaboration` binds Mod-z to
the Yjs manager. It does exist in `node_modules` and is live in one unrelated
test editor, so "not installed" would be wrong; "not registered here" is right.
The first test in the new file pins that premise by asserting the editor is
bound to a `Y.UndoManager`, so this cannot quietly stop being true.

The symptom was real; the mechanism was not. Both are recorded in the test file
rather than only in this description.

## The tradeoff, stated plainly

Anchored entries are now never removed, so the authorship map still grows
without bound. It always did — the real fix is coalescing consecutive
same-author stamps, which is a separate concern and deliberately not smuggled
in. Growth costs memory; deleting costs attribution permanently. That is the
right way round.

## One fixture note worth reading

The paragraph case needs `stopCapturing()` before the delete. `Y.UndoManager`
merges edits inside `captureTimeout` (500ms) into one stack item, and a test
makes both edits in the same millisecond — so without it a single undo reverts
the *insertion* as well, the text returns without the stamped word, and the
anchor correctly resolves to null. The assertion then fails while the code is
right: the fixture had silently merged the two states it exists to keep apart.
I read that failure as a real limitation first, and said so before diagnosing
it; the comment in the test now carries the explanation.

## Verification

Full suite 7388 passed, exit 0, no unhandled errors. Typecheck clean. The reap
change is mutation-tested: restoring the old behaviour fails with
`the entry must survive the reap: expected false to be true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj99tUgQp3JGru6j9fuHEi
