### PR TITLE
fix(authorship): count only content positions in the block gutter

### DIFF
--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -556,8 +556,18 @@ export function buildAuthorshipDecorations(
     let userChars = 0;
     let claudeChars = 0;
 
-    const countTo = Math.min(blockTo, authorAt.length);
-    for (let at = blockFrom; at < countTo; at++) {
+    // Content positions only. `blockFrom` is the block's own open token and
+    // `blockTo - 1` its close token — neither is a character anybody authored,
+    // and a within-block entry can never mark them, since its endpoints are
+    // content positions. An entry SPANNING the boundary does mark both, so each
+    // block adjacent to it used to gain one phantom authored character. That is
+    // enough to flip `dominant` in a near-tied block: measured on a tail block
+    // where the user really owns one character and Claude owns two, the bar
+    // came out `user`. Cross-block entries already arrive today from a
+    // multi-block paste, and #1512's repair will make them the ordinary shape
+    // of a run that crossed an Enter.
+    const countTo = Math.min(blockTo - 1, authorAt.length);
+    for (let at = blockFrom + 1; at < countTo; at++) {
       const code = authorAt[at];
       if (code === AUTHOR_NONE) continue;
       if (code === AUTHOR_USER) userChars++;

--- a/tests/client/authorship-gutter.test.ts
+++ b/tests/client/authorship-gutter.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+
+import { Editor } from "@tiptap/core";
+import Collaboration from "@tiptap/extension-collaboration";
+import { afterEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
+import {
+  AuthorshipExtension,
+  buildAuthorshipDecorations,
+} from "../../src/client/editor/extensions/authorship";
+import { loadMarkdown } from "../../src/server/file-io/markdown";
+import { Y_MAP_AUTHORSHIP } from "../../src/shared/constants";
+import { anchorFlatRange } from "../../src/shared/positions/ydoc";
+import type { AuthorshipRange } from "../../src/shared/types";
+
+/**
+ * The block gutter counts CONTENT positions, not block tokens.
+ *
+ * `authorAt` is filled over ProseMirror positions, and the per-block count used
+ * to run `[blockFrom, blockTo)` — which includes the block's own open and close
+ * tokens. A within-block entry can never mark those, so the bug was invisible
+ * for years: an entry's endpoints are content positions by construction. An
+ * entry SPANNING a block boundary marks both, and each adjacent block then
+ * gained one phantom authored character.
+ *
+ * One character decides a near-tied block, because `dominant` is
+ * `userChars >= claudeChars`. Cross-block entries already arrive from a
+ * multi-block paste today, and #1512's repair will make them the ordinary shape
+ * of a typing run that crossed an Enter — which is why this is a prerequisite
+ * for that work rather than a tidy-up.
+ *
+ * Assertions go through `buildAuthorshipDecorations` against a real
+ * `Collaboration` binding. The sibling `authorship-decoration.test.ts` mocks
+ * ProseMirror wholesale, and a mock of the position system cannot see a
+ * position bug — it would encode the same off-by-one the code has.
+ */
+
+const live: Editor[] = [];
+
+afterEach(() => {
+  for (const editor of live.splice(0)) editor.destroy();
+});
+
+/** Two paragraphs: `seedUSER` then `TEXT`. */
+function twoBlocks() {
+  const ydoc = new Y.Doc();
+  loadMarkdown(ydoc, "seedUSER\n\nTEXT\n");
+  const editor = new Editor({
+    extensions: [
+      ...buildSchemaExtensions(),
+      Collaboration.configure({ document: ydoc }),
+      AuthorshipExtension.configure({ ydoc }),
+    ],
+  });
+  live.push(editor);
+  return { ydoc, editor };
+}
+
+function decorationAttr(decoration: unknown, name: string): string | undefined {
+  return (decoration as { type?: { attrs?: Record<string, string> } }).type?.attrs?.[name];
+}
+
+/** `pos:author` per block gutter decoration, in document order. */
+function gutter(ydoc: Y.Doc, editor: Editor): string[] {
+  const doc = editor.state.doc;
+  const set = buildAuthorshipDecorations(doc, ydoc.getMap(Y_MAP_AUTHORSHIP), ydoc, true);
+  const blocks: { from: number; author: string }[] = [];
+  for (const decoration of set.find()) {
+    const author = decorationAttr(decoration, "data-tandem-author-block");
+    if (author) blocks.push({ from: decoration.from, author });
+  }
+  return blocks.sort((a, b) => a.from - b.from).map((b) => `${b.from}:${b.author}`);
+}
+
+/** Place an anchored entry over a flat range. Returns false if the mint declined. */
+function put(
+  ydoc: Y.Doc,
+  id: string,
+  author: AuthorshipRange["author"],
+  from: number,
+  to: number,
+): boolean {
+  const relRange = anchorFlatRange(ydoc, from, to);
+  ydoc.getMap(Y_MAP_AUTHORSHIP).set(id, {
+    id,
+    author,
+    range: { from, to },
+    ...(relRange ? { relRange } : {}),
+    timestamp: 1,
+  } satisfies AuthorshipRange);
+  return relRange !== null;
+}
+
+describe("the block gutter counts content positions only", () => {
+  it("TEST 0 — the binding is real and hand-placed entries anchor", () => {
+    // ANTI-VACUUM. Without a Collaboration binding the fragment is empty, every
+    // mint declines, entries fall back to frozen flat offsets, and every
+    // assertion below would be testing the degraded path.
+    const { ydoc, editor } = twoBlocks();
+    expect(ydoc.getXmlFragment("default").length).toBeGreaterThan(0);
+    expect(put(ydoc, "u1", "user", 4, 8), "the fixture's entries must be anchored").toBe(true);
+    expect(gutter(ydoc, editor)).toEqual(["0:user"]);
+  });
+
+  it("a cross-block entry does not win a block it barely touches", () => {
+    // THE BUG. Flat offsets: `seedUSER` is 0..8, the separator is 8, `TEXT` is
+    // 9..13. In the second block the user really owns one character (`T` at 9)
+    // and Claude owns two (`EX` at 10..12), so the bar must read `claude`.
+    //
+    // The counts have to STRADDLE the tipping point or the mutation survives:
+    // `dominant` is `userChars >= claudeChars`, so 1 vs 2 reads `claude` and the
+    // single phantom character makes it 2 vs 2, which reads `user`.
+    const { ydoc, editor } = twoBlocks();
+    put(ydoc, "u1", "user", 4, 10);
+    put(ydoc, "c1", "claude", 10, 12);
+
+    expect(gutter(ydoc, editor)).toEqual(["0:user", "10:claude"]);
+  });
+
+  it("the same coverage split into per-block entries reads the same", () => {
+    // The control for the test above: two entries covering exactly the same
+    // characters, with no entry crossing the boundary and therefore no phantom.
+    // Before the fix these two fixtures disagreed, which is the whole defect —
+    // the gutter depended on how the coverage happened to be stored.
+    const { ydoc, editor } = twoBlocks();
+    put(ydoc, "u1", "user", 4, 8);
+    put(ydoc, "u1#1", "user", 9, 10);
+    put(ydoc, "c1", "claude", 10, 12);
+
+    expect(gutter(ydoc, editor)).toEqual(["0:user", "10:claude"]);
+  });
+
+  it("a character at either end of a block is still counted", () => {
+    // The bounds moved, so this pins that they did not move too far. The first
+    // content character sits at `blockFrom + 1` and the last at `blockTo - 2`;
+    // an entry covering only one of them must still carry its block.
+    const { ydoc, editor } = twoBlocks();
+    put(ydoc, "c1", "claude", 0, 1); // `s`, the first character of block 1
+    put(ydoc, "c2", "claude", 12, 13); // `T`, the last character of block 2
+
+    expect(gutter(ydoc, editor)).toEqual(["0:claude", "10:claude"]);
+  });
+
+  it("a within-block tie still breaks to the user", () => {
+    // Unchanged behaviour, and the reason the fix is bounds-only rather than a
+    // change to `dominant`. Both blocks are untouched by any boundary.
+    const { ydoc, editor } = twoBlocks();
+    put(ydoc, "u1", "user", 9, 11);
+    put(ydoc, "c1", "claude", 11, 13);
+
+    expect(gutter(ydoc, editor)).toEqual(["10:user"]);
+  });
+});


### PR DESCRIPTION
First of three PRs coming out of #1512. This one stands entirely on its own and is a **precondition** for the other two rather than a tidy-up — see the last section.

## The defect

`buildAuthorshipDecorations` fills `authorAt` over ProseMirror positions, then counts each block's authored characters over `[blockFrom, blockTo)`. Those bounds include the block's own open and close tokens, which are not characters anybody authored.

It has been invisible for as long as it has existed, because a **within-block** entry cannot mark those positions — an entry's endpoints are content positions by construction. An entry **spanning a block boundary** marks both, so each block adjacent to the boundary gains one phantom authored character.

One character is enough, because `dominant` is `userChars >= claudeChars`. Measured on a tail block where the user really owns one character and Claude owns two:

```
one cross-block user entry     -> gutter reads "user"     <- the phantom decides it
the same coverage, two entries -> gutter reads "claude"
after this change              -> both read "claude"
```

The bug underneath the symptom is that the gutter's answer depended on **how the coverage happened to be stored**, not on what the coverage was.

## Not hypothetical, and about to become ordinary

A multi-block paste stamps one cross-block entry today, so this is reachable now. It is about to become the normal shape: #1512's repair re-anchors a run that crossed an Enter as a single entry spanning the split, so every repaired split would otherwise ship a phantom character on both adjacent blocks. That is why this lands first, separately, and why it is a precondition — the repair is not safe to merge on top of a consumer that miscounts the shape it produces.

## Verification

`npm run typecheck` clean, full `npm test` green (7450 passed, exit 0), and every existing authorship test passes unchanged — which is also why the change needs its own test rather than riding on the suite.

**Mutation-tested, both bounds pinned by a different test:**

| mutation | fails |
|---|---|
| restore the old lower bound (`blockFrom`) | the cross-block near-tie case |
| restore the old upper bound (`blockTo`) | the cross-block near-tie case |
| tighten the upper bound one further (`blockTo - 2`) | the first-and-last-character case |

The near-tie fixture straddles the tipping point deliberately: at 1 vs 2 the phantom makes it 2 vs 2, and a tie reads `user`. A fixture that did not straddle would leave the mutation alive — the same trap the coalescing tests already carry a comment about.

## Why a new test file rather than `authorship-decoration.test.ts`

That file mocks ProseMirror and the position system wholesale. A mock of the position system cannot see a position bug: it would encode the same off-by-one the code has. These assertions run through `buildAuthorshipDecorations` against a real `Collaboration` binding, with an anti-vacuum TEST 0 asserting the fragment is non-empty and the hand-placed entries actually anchored — without it, a binding regression would silently turn every case below into a green test of the unanchored fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj99tUgQp3JGru6j9fuHEi
