### PR TITLE
fix(authorship): stop stamping a block separator as authored content

### DIFF
--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -420,6 +420,30 @@ const GUTTER_NODE_TYPES = new Set(["paragraph", "heading"]);
  * fallback count (entries that used to paint stale offsets now decline), so the
  * latch is a precondition for the resolver fix rather than a tidy-up.
  */
+/**
+ * Does an inserted span carry anything a reader would call authored content?
+ *
+ * A block-structure change (Enter, `splitListItem`) inserts a boundary, and the
+ * flat coordinate system charges that boundary one character — so the insertion
+ * branch below mints an entry covering a separator and no text at all.
+ *
+ * `textBetween` alone would be the wrong test: an inline atom renders as no
+ * text, so a hardBreak or an image insertion would stop being attributed. The
+ * atom scan is deliberately conservative — `nodesBetween` visits nodes merely
+ * OVERLAPPING the range, so a false positive keeps a stamp rather than dropping
+ * one, which is the safe direction for an attribution feature.
+ */
+function spanCarriesContent(doc: PmNode, from: PmPos, to: PmPos): boolean {
+  if (doc.textBetween(from, to).length > 0) return true;
+  let atom = false;
+  doc.nodesBetween(from, to, (node) => {
+    if (atom) return false;
+    if (node.isInline && node.isAtom) atom = true;
+    return !atom;
+  });
+  return atom;
+}
+
 const warnedKeys = new Set<string>();
 function warnOnce(key: string, ...args: unknown[]): void {
   if (warnedKeys.has(key)) return;
@@ -857,6 +881,18 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions, Authorshi
             };
             const range = pmSelectionToFlat(pmDoc, pm);
             if (range.to <= range.from) return;
+            // An Enter inserts a block boundary and nothing else, and the flat
+            // system charges that boundary one character — so this branch used
+            // to mint an entry covering a separator and no text.
+            //
+            // Usually coalescing swallowed it, which is why #1512 calls it
+            // harmless. It is not harmless when the split lands at the END of a
+            // block: the separator offset sits between two texts, so
+            // `flatOffsetToRelPos` declines, the entry is stored with frozen
+            // flat offsets and no anchor, and it paints through the flat
+            // fallback — "a confident decoration on the wrong text", on an
+            // authorship-tagged split. Measured via `splitListItem`.
+            if (!spanCarriesContent(pmDoc, pm.from, pm.to)) return;
             // Anchor against the LIVE ydoc, which y-prosemirror has already
             // written: Tiptap's `dispatchTransaction` calls `view.updateState`
             // and emits `transaction` on the very next line, both synchronously,

--- a/tests/client/authorship-coalescing.test.ts
+++ b/tests/client/authorship-coalescing.test.ts
@@ -311,13 +311,12 @@ describe("consecutive same-author stamps coalesce", () => {
     typeChars(editor, "bb", editor.state.doc.content.size - 1);
 
     expect(editor.state.doc.childCount).toBe(2);
-    const texts = decoratedTextByAuthor(ydoc, editor).user ?? [];
-    expect(texts).toContain("aa");
-    expect(texts).toContain("bb");
-    expect(
-      entries().length,
-      "at least the two runs stay separate (plus the split's own separator stamp)",
-    ).toBeGreaterThanOrEqual(2);
+    // Exactly two entries and exactly two runs. The count used to be written as
+    // `>= 2` to leave room for the split's own separator stamp; that stamp is
+    // no longer minted, so the loose bound has nothing left to tolerate — and a
+    // bound that tolerates an unknown extra entry cannot see one appear.
+    expect(decoratedTextByAuthor(ydoc, editor)).toEqual({ user: ["aa", "bb"] });
+    expect(entries().length, "the two runs stay separate").toBe(2);
   });
 
   it("the map does not grow per keystroke over a burst", () => {

--- a/tests/client/authorship-separator-stamp.test.ts
+++ b/tests/client/authorship-separator-stamp.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment happy-dom
+
+import { Editor } from "@tiptap/core";
+import Collaboration from "@tiptap/extension-collaboration";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
+import {
+  _resetAuthorshipWarnLatch,
+  AUTHORSHIP_ORIGIN_META,
+  AuthorshipExtension,
+  buildAuthorshipDecorations,
+} from "../../src/client/editor/extensions/authorship";
+import { loadMarkdown } from "../../src/server/file-io/markdown";
+import { Y_MAP_AUTHORSHIP } from "../../src/shared/constants";
+import type { AuthorshipRange } from "../../src/shared/types";
+
+/**
+ * A block boundary is not authored content — #1512's "adjacent, smaller" half.
+ *
+ * The flat coordinate system charges a block separator one character, so the
+ * insertion branch of `onTransaction` used to mint an entry covering a
+ * separator and no text. #1512 calls that harmless because coalescing usually
+ * swallows it, and usually it does.
+ *
+ * It is not harmless in two shapes, both pinned below: a split whose author
+ * differs from the run it follows has nothing to coalesce into, and a split at
+ * the END of a block mints an offset that sits between two `Y.XmlText`s, so the
+ * anchor DECLINES and the entry paints through the flat fallback — which this
+ * file's own comment calls "a confident decoration on the wrong text".
+ */
+
+const live: Editor[] = [];
+
+function boundEditor(markdown: string) {
+  const ydoc = new Y.Doc();
+  loadMarkdown(ydoc, markdown);
+  const editor = new Editor({
+    extensions: [
+      ...buildSchemaExtensions(),
+      Collaboration.configure({ document: ydoc }),
+      AuthorshipExtension.configure({ ydoc }),
+    ],
+  });
+  live.push(editor);
+  const entries = () => [...ydoc.getMap(Y_MAP_AUTHORSHIP).values()] as AuthorshipRange[];
+  return { ydoc, editor, entries };
+}
+
+function decorationAttr(decoration: unknown, name: string): string | undefined {
+  return (decoration as { type?: { attrs?: Record<string, string> } }).type?.attrs?.[name];
+}
+
+/** Text each inline authorship decoration covers, keyed by author. */
+function decoratedTextByAuthor(ydoc: Y.Doc, editor: Editor): Record<string, string[]> {
+  const doc = editor.state.doc;
+  const set = buildAuthorshipDecorations(doc, ydoc.getMap(Y_MAP_AUTHORSHIP), ydoc, true);
+  const out: Record<string, string[]> = {};
+  for (const decoration of set.find()) {
+    const author = decorationAttr(decoration, "data-tandem-author");
+    if (!author) continue;
+    (out[author] ??= []).push(doc.textBetween(decoration.from, decoration.to));
+  }
+  for (const key of Object.keys(out)) out[key].sort();
+  return out;
+}
+
+/** Seed a user-authored `USERTEXT`, returning its offsets. */
+function seedUserText(editor: Editor) {
+  const end = editor.state.doc.content.size - 1;
+  editor.view.dispatch(editor.state.tr.insertText("USERTEXT", end));
+  const start = editor.state.doc.textContent.indexOf("USERTEXT") + 1;
+  return { start, mid: start + 4, end: start + "USERTEXT".length };
+}
+
+afterEach(() => {
+  for (const editor of live.splice(0)) editor.destroy();
+  _resetAuthorshipWarnLatch();
+  vi.restoreAllMocks();
+});
+
+describe("a block separator is never stamped on its own", () => {
+  it("TEST 0 — the binding is real and ordinary typing is still stamped", () => {
+    // ANTI-VACUUM, and the anti-over-suppression guard in one. If the content
+    // test were inverted, or the binding absent, this fails rather than every
+    // case below quietly passing against an empty map.
+    const { ydoc, editor, entries } = boundEditor("seed\n");
+    expect(ydoc.getXmlFragment("default").length).toBeGreaterThan(0);
+    seedUserText(editor);
+    expect(entries()).toHaveLength(1);
+    expect(entries()[0].relRange, "ordinary typing must still anchor").toBeDefined();
+    expect(decoratedTextByAuthor(ydoc, editor)).toEqual({ user: ["USERTEXT"] });
+  });
+
+  it("a differently-authored split mints no entry for the boundary", () => {
+    // The shape coalescing cannot absorb: the split is tagged `claude`, the run
+    // it lands in is the user's, so before this change the boundary became a
+    // `claude` entry of its own — one covering no text, rendering an empty
+    // decoration between the two blocks.
+    const { ydoc, editor, entries } = boundEditor("seed\n");
+    const { mid } = seedUserText(editor);
+
+    editor.view.dispatch(editor.state.tr.split(mid).setMeta(AUTHORSHIP_ORIGIN_META, "claude"));
+
+    expect(entries().map((entry) => entry.author)).toEqual(["user"]);
+    expect(decoratedTextByAuthor(ydoc, editor)).toEqual({ user: ["USER"] });
+  });
+
+  it("a split at the end of a block mints no unanchored entry, and warns nothing", () => {
+    // The shape that is actively wrong today. The separator offset sits between
+    // two `Y.XmlText`s, so `flatOffsetToRelPos` declines; the entry is stored
+    // with frozen flat offsets and no anchor and paints through the flat
+    // fallback. `warnOnce` firing is the tell, so assert on it directly rather
+    // than only on the entry set.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { editor, entries } = boundEditor("seed\n");
+    const { end } = seedUserText(editor);
+
+    editor.view.dispatch(editor.state.tr.split(end).setMeta(AUTHORSHIP_ORIGIN_META, "claude"));
+
+    expect(entries().filter((entry) => !entry.relRange)).toEqual([]);
+    expect(entries().map((entry) => entry.author)).toEqual(["user"]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("splitListItem is the same story with a different step", () => {
+    // #1512 names Enter and `splitListItem` together, and they are different
+    // steps against different fixtures. The end-of-item case is where the
+    // declined mint was first measured.
+    //
+    // The run ending at the split point is `claude`'s and the split itself is
+    // the user's, so coalescing has nothing to absorb the separator into. That
+    // asymmetry is what makes this case able to fail: with a same-author run it
+    // merges away and the test would pass against either implementation.
+    const { editor, entries } = boundEditor("- alpha\n");
+    const at = editor.state.doc.textContent.indexOf("alpha") + 1;
+    editor.view.dispatch(editor.state.tr.insertText("USER", at + 5));
+    editor.view.dispatch(
+      editor.state.tr.insertText("CL", at + 9).setMeta(AUTHORSHIP_ORIGIN_META, "claude"),
+    );
+    expect(entries()).toHaveLength(2);
+
+    editor.commands.setTextSelection(at + 11);
+    editor.commands.splitListItem("listItem");
+
+    expect(entries().filter((entry) => !entry.relRange)).toEqual([]);
+    expect(
+      entries()
+        .map((entry) => entry.author)
+        .sort(),
+    ).toEqual(["claude", "user"]);
+  });
+
+  it("an inline atom is still stamped, though it renders no text", () => {
+    // The carve-out, and the reason the test is not `textBetween(...) === ""`.
+    // A hardBreak carries no text but is real authored content; suppressing it
+    // would lose attribution for every Shift+Enter and every inserted image.
+    const { editor, entries } = boundEditor("seed\n");
+    const before = entries().length;
+
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+    editor.commands.setHardBreak();
+
+    expect(entries().length, "a hardBreak insertion must still be attributed").toBe(before + 1);
+  });
+
+  it("typing after a split does not join the run across the boundary", () => {
+    // The behaviour change that comes free with the suppression, and the reason
+    // it needs pinning rather than mentioning. `lastStampId` is deliberately
+    // left ALONE by a transaction that stamps nothing, so after this change the
+    // candidate survives a split where the separator stamp used to replace it.
+    // Adjacency is what must reject the merge — a block boundary costs two PM
+    // positions, so the next character is not adjacent to the previous run.
+    const { ydoc, editor, entries } = boundEditor("seed\n");
+    const { mid } = seedUserText(editor);
+
+    editor.view.dispatch(editor.state.tr.split(mid));
+    const tailStart = editor.state.doc.resolve(editor.state.doc.content.size - 1).start();
+    editor.view.dispatch(editor.state.tr.insertText("NEW", tailStart));
+
+    expect(entries().length, "the run must not extend across the block boundary").toBe(2);
+    // `TEXT` — the tail the split carried into the new block — is still
+    // unattributed, which is #1512's main half and is not this change's job.
+    // Recorded rather than hidden: the repair PR inverts this line.
+    expect(decoratedTextByAuthor(ydoc, editor)).toEqual({ user: ["NEW", "USER"] });
+  });
+});

--- a/tests/client/authorship-split.test.ts
+++ b/tests/client/authorship-split.test.ts
@@ -334,11 +334,14 @@ describe("an insertion inside a stamped range splits it", () => {
     expect(editor.state.doc.childCount, "the paragraph really did split").toBe(2);
     // This used to be `["", "USER"]`. The `""` was the second, adjacent thing
     // #1512 records: the split step reports `insertedLen > 0` for the block
-    // separator, so it minted a stamp covering no visible text at all. Stamp
-    // coalescing removed it — the separator stamp is adjacent to the run it
-    // follows and shares its author, so it merges into that entry instead of
-    // becoming an entry of its own. Half of #1512 closed as a side effect,
-    // which is why the expectation moved rather than the code.
+    // separator, so it minted a stamp covering no visible text at all.
+    //
+    // Coalescing hid it HERE and was once credited with closing it. That credit
+    // was wrong in two shapes it cannot reach — a split whose author differs
+    // from the run it follows has nothing to merge into, and a split at the end
+    // of a block mints an offset that declines to anchor and then paints
+    // through the flat fallback. The separator is now suppressed at the source;
+    // `authorship-separator-stamp.test.ts` covers all three shapes.
     expect(
       decoratedTextByAuthor(ydoc, editor).user,
       "the tail moved into the new block and lost its attribution — the limitation",


### PR DESCRIPTION
Second of three PRs from #1512, independent of the first (#1519) and of the repair that follows. Closes the "adjacent, smaller" half of #1512.

## The defect

The flat coordinate system charges a block boundary one character, so an Enter reports `insertedLen > 0` and the insertion branch mints an authorship entry covering a separator and **no text**.

#1512 records this as harmless because coalescing swallows it — the separator is adjacent to the run it follows and shares its author, so it merges into that entry. That is true, and it is why an earlier comment in `authorship-split.test.ts` credited coalescing with closing this half. **The credit was wrong in the two shapes coalescing cannot reach:**

| shape | what happens today |
|---|---|
| The split's author differs from the run it lands in | nothing to merge into — the boundary becomes an entry of its own, rendering an empty decoration between two blocks |
| The split lands at the **end** of a block | the separator offset sits between two `Y.XmlText`s, so `flatOffsetToRelPos` **declines**; the entry is stored with frozen flat offsets and no anchor, and paints through the flat fallback |

The second is the one that matters. The resolver's own comment calls that fallback "a confident decoration on the wrong text", and on an authorship-tagged split it is a live mis-attribution rather than noise. Measured through `splitListItem`.

## Why the test is not `textBetween(...) === ""`

An inline atom renders no text. That test alone would stop attributing every Shift+Enter and every inserted image. So the check is "text, or an inline atom", and the atom scan is deliberately conservative: `nodesBetween` visits nodes merely *overlapping* the range, so a false positive keeps a stamp rather than dropping one — the safe direction for an attribution feature.

## One behaviour change comes free, and is pinned rather than mentioned

`additions.length` goes 1 → 0 on an Enter, and `lastStampId` is deliberately left **alone** by a transaction that stamps nothing (backspace is exactly that, and backspace-then-retype is what makes coalescing worth having). So a coalescing candidate now survives a split where the separator stamp used to replace it.

Adjacency is what refuses the merge — a block boundary costs two ProseMirror positions, so the next character typed in the new block is not adjacent to the previous run. The test drives that rather than arguing it.

## Verification

`npm run typecheck` clean; full `npm test` green (7442 passed, exit 0).

**Mutation-tested:**

| mutation | fails |
|---|---|
| disable the suppression | 4 of the 6 new tests |
| remove the inline-atom carve-out | the hardBreak test |

The `splitListItem` fixture deliberately places a `claude` run at the split point. With a same-author run the separator merges away and the test would pass against either implementation — it was written that way first, and it survived the mutation, which is how the gap was found.

## Two artifacts corrected rather than left to mislead

- `tests/client/authorship-split.test.ts` carried "Half of #1512 closed as a side effect" — the claim this PR disproves and then makes true properly.
- The coalescing suite's cross-block test bounded its entry count with `>= 2` to tolerate the separator stamp. A bound that tolerates an unknown extra entry cannot see one appear; it is now exact, along with the decorated texts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj99tUgQp3JGru6j9fuHEi
