### PR TITLE
test(e2e): pin the batch-promote confirm row to the rail it lives in

### DIFF
--- a/tests/e2e/batch-promote-width.spec.ts
+++ b/tests/e2e/batch-promote-width.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+import path from "path";
+import { PANEL_MIN_WIDTH } from "../../src/client/panel-layout";
+import { PANEL_WIDTH_KEY } from "../../src/shared/constants";
+import {
+  cleanupAllOpenDocuments,
+  cleanupFixtureDir,
+  createFixtureDir,
+  McpTestClient,
+  switchToAnnotationsTab,
+} from "./helpers";
+
+/**
+ * The batch-promote confirm row must fit the rail it lives in (#1444).
+ *
+ * This exists because the confirm gate shipped without anyone measuring it, and
+ * the failure is silent in every way that matters. `BatchPromoteBar` is
+ * `position: sticky; top: 0` — but not `left: 0` — inside a scroll container
+ * that sets `overflow-y: auto`, which makes `overflow-x` compute to `auto` too.
+ * So a row too wide for the rail does not clip visibly or throw: it slides the
+ * commit button out past the right edge, reachable only by scrolling a bar that
+ * is pinned to the top and looks complete. Nothing in the DOM is wrong, no
+ * assertion elsewhere fails, and axe has nothing to say about it.
+ *
+ * Measured on the version that introduced the gate: at the rail's 200px minimum
+ * the confirm row ran 105-141px past the edge at every density and the commit
+ * button itself sat 17-41px outside it; at the 300px default it still overran
+ * by 5-41px. The fix swaps the whole row (dropping the count and Clear, as
+ * BulkActions does) and lets the sentence wrap instead of shove.
+ *
+ * The assertions are deliberately about geometry rather than a pixel budget —
+ * a height limit would fail the moment the copy or the density scale changed,
+ * while "the button the user must press is inside the panel" stays true for any
+ * future layout that is not broken.
+ */
+
+test.setTimeout(90_000);
+
+let mcp: McpTestClient;
+let tmpDir: string;
+
+const DOCX_FIXTURE = "reviewer-comments.docx";
+
+test.beforeEach(async () => {
+  mcp = new McpTestClient();
+  await mcp.connect();
+  tmpDir = createFixtureDir(DOCX_FIXTURE);
+});
+
+test.afterEach(async () => {
+  await cleanupAllOpenDocuments(mcp);
+  await mcp.close();
+  cleanupFixtureDir(tmpDir);
+});
+
+// Spacious is the worst case (largest gaps and padding), and the minimum rail
+// width is the tightest surface a user can actually produce by dragging.
+for (const density of ["cozy", "spacious"]) {
+  test(`confirm row fits the minimum-width rail (${density})`, async ({ page }) => {
+    await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, DOCX_FIXTURE) });
+    await page.addInitScript(([key, width]) => localStorage.setItem(key as string, String(width)), [
+      PANEL_WIDTH_KEY,
+      PANEL_MIN_WIDTH,
+    ] as [string, number]);
+    await page.goto("/");
+    await page.evaluate((d) => document.documentElement.setAttribute("data-density", d), density);
+    await switchToAnnotationsTab(page);
+
+    const checkboxes = page.locator("[data-testid^='annotation-select-checkbox-']");
+    await expect(checkboxes).toHaveCount(2, { timeout: 25_000 });
+    for (let i = 0; i < 2; i++) await checkboxes.nth(i).check();
+
+    await expect(page.locator("[data-testid='batch-promote-bar']")).toBeVisible();
+    await page.locator("[data-testid='batch-promote-confirm']").click();
+    const commit = page.locator("[data-testid='batch-promote-commit']");
+    await expect(commit).toBeVisible();
+
+    const geometry = await commit.evaluate((btn) => {
+      const bar = btn.closest("[data-testid='batch-promote-bar']") as HTMLElement;
+      const scroller = bar.parentElement as HTMLElement;
+      const b = btn.getBoundingClientRect();
+      const s = scroller.getBoundingClientRect();
+      return {
+        barWidth: Math.round(bar.getBoundingClientRect().width),
+        railWidth: scroller.clientWidth,
+        commitOverhang: Math.round(b.right - s.right),
+      };
+    });
+
+    expect(
+      geometry.barWidth,
+      "the confirm row is wider than the rail — it will overflow horizontally",
+    ).toBeLessThanOrEqual(geometry.railWidth);
+    expect(
+      geometry.commitOverhang,
+      "the commit button sits past the rail's right edge, behind a horizontal scroll",
+    ).toBeLessThanOrEqual(0);
+  });
+}


### PR DESCRIPTION
Follow-up to #1515, which merged before this could ride along.

#1515's review found that the new batch-promote confirm row did not fit the rail it lives in. That was fixed in `b1ee0ea2` (in the merge), but **nothing pins it**, and the failure mode is the kind that comes back silently.

## Why a test rather than a comment

`BatchPromoteBar` is `position: sticky; top: 0` — **not** `left: 0` — inside a scroll container that sets `overflow-y: auto`, which makes `overflow-x` compute to `auto` as well. A row too wide for the rail therefore does not clip, wrap or throw. It slides the commit button out past the right edge, where it is reachable only by scrolling a bar that is pinned to the top and looks complete.

The DOM is correct. No other assertion notices. axe has nothing to say about it. The gate exists to stop an irreversible bulk attribution rewrite, and its confirm button was off-panel at the default rail width — that is the whole hazard in one sentence.

## Measured, in the running app

At the rail's **200px minimum**, on the component as it stood at `0aa0a553`:

| density | row overran rail by | commit button past the edge |
|---|---|---|
| compact | 105px | **17px** |
| cozy | 117px | **23px** |
| spacious | 141px | **41px** |

At the **300px default** it still overran by 5 / 17 / 41px. After the fix: fits at every density and both widths, commit button 24–48px inside the edge.

(These supersede the figures in `b1ee0ea2`'s commit message, which came from a token harness rather than the app. Same conclusion, different numbers — the harness overstated the height and understated the overflow.)

## Shape of the assertions

Geometry, not a pixel budget. A height limit would fail the moment the copy or the density scale changed; "the button the user must press is inside the panel" stays true for any future layout that is not broken.

Two densities, both at `PANEL_MIN_WIDTH` — spacious is the worst case, cozy is the default, and the minimum rail width is the tightest surface a user can actually produce by dragging.

## Negative control

Both cases **fail** against `0aa0a553` with `the commit button sits past the rail's right edge, behind a horizontal scroll`, and pass after. So they measure the fix rather than something that was true either way — the same discipline `forced-colors.spec.ts` documents for its own assertions.

## Verification

- `npm run test:e2e` — full suite, `--retries=0`: **360 passed**, 11 skipped, 0 failed
- New spec + `batch-promote.spec.ts` in isolation: 3 passed
- No new `data-testid` selectors, so no snapshot change (Critical Rule 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wh6tAyoSs6EeobDLUUVTJM
