### PR TITLE
docs(toolbar): record why the dwell teardown clears timers and nothing else

### DIFF
--- a/src/client/editor/toolbar/Toolbar.svelte
+++ b/src/client/editor/toolbar/Toolbar.svelte
@@ -436,6 +436,25 @@ $effect(() => {
     pendingAffordanceFrame = 0;
     // A28: cancel pending dwell/entrance timers so they can't write $state into
     // an unmounted component (or clear `entering` into a later popup's entrance).
+    //
+    // The two bare `clearTimeout`s are NOT an oversight, and must not be
+    // "tidied" into the `clearDwell()` that wraps them. `clearDwell()` also
+    // resets `dwellSatisfied`, and this effect DEPENDS on `dwellSatisfied`:
+    // the `onSelectionUpdate()` call below runs synchronously during the
+    // effect, reaching the re-arm guard in `updateSelectionAffordance` that
+    // reads it. So the dwell timer firing — whose whole job is
+    // `dwellSatisfied = true` — invalidates this effect and re-runs it, and a
+    // teardown that reset the flag would set it straight back to false. The
+    // popup could then never appear at all: measured at 24 of 28 failures in
+    // `toolbar-redesign.spec.ts`.
+    //
+    // What the asymmetry costs is small and, as far as anyone has managed to
+    // reproduce, unreachable: the non-reactive `lastDwellFrom`/`lastDwellTo`
+    // survive into the next editor, so a replacement that mounted with the
+    // *same* non-collapsed range would fail that guard and never arm. Every
+    // real path self-heals first — a new editor mounts collapsed, and the
+    // `!next` branch of `updateSelectionAffordance` calls `clearDwell()` — which
+    // is why a tab switch mid-popup behaves correctly.
     clearTimeout(dwellTimer);
     clearTimeout(enteringTimer);
     cleanup();


### PR DESCRIPTION
I reported a latent bug in `Toolbar.svelte`'s editor-effect teardown while diagnosing the E2E selection flake (#1522). This PR is the result of trying to fix it. **The finding was wrong**, and what ships is the comment that stops the next person making the same mistake.

## What I thought was wrong

The teardown clears the two timers directly:

```js
clearTimeout(dwellTimer);
clearTimeout(enteringTimer);
```

where every other cleanup path in the file calls `clearDwell()`, which clears the same two timers *and* resets `dwellSatisfied`, `entering`, `lastDwellFrom`/`lastDwellTo`, the latched anchors and `pointerUpSinceDwellArm`. Leaving those set looked like it would leave the re-arm guard poisoned across an editor swap.

## Why that is not a fix

`clearDwell()` resets `dwellSatisfied` — and **this effect depends on `dwellSatisfied`.** Its body ends with a synchronous `onSelectionUpdate()`, which reaches the re-arm guard in `updateSelectionAffordance`:

```js
if (!dwellSatisfied && !pointerSelecting && (from !== lastDwellFrom || to !== lastDwellTo)) {
```

Reading it there makes it a dependency. So the dwell timer firing — whose entire job is `dwellSatisfied = true` — invalidates the effect and re-runs it, and a teardown that reset the flag sets it straight back to false before the popup can render.

Not a subtle degradation. **24 of the 28 tests in `toolbar-redesign.spec.ts` fail**, the popup never appearing at all.

## What the asymmetry actually costs

Real, but as far as I can reproduce, unreachable. `lastDwellFrom`/`lastDwellTo` are plain `let`s rather than `$state`, so they do survive into the next editor, and a replacement that mounted with the *same* non-collapsed range would fail the guard and never arm.

Every real path self-heals before that matters: a replacement editor mounts with a collapsed selection, so the `!next` branch of `updateSelectionAffordance` calls `clearDwell()` on the first update. I checked the one path that looked most likely to defeat that — `Toolbar` is rendered outside every `{#key activeTab.id}` block in `App.svelte`, so it survives tab switches while its `editor` prop swaps underneath it. Driving a tab switch with the popup open: the popup clears correctly, and both documents arm normally afterwards.

Fixing the narrow case in isolation would mean resetting only the two non-reactive range fields. That is possible, but it buys a scenario nobody can produce and adds a second partial-reset path next to the full one — more surface for exactly this confusion, not less.

## So: a comment

The bare `clearTimeout`s look like a tidy-up waiting to happen. They are load-bearing, and the failure they cause is total. That is worth 19 lines at the site, including the measured cost of getting it wrong and the honest account of what the asymmetry leaves behind.

## Verification

- Comment only — no behaviour change
- `npm run typecheck` — 1337 files, 0 errors, 0 warnings
- `toolbar-redesign.spec.ts` — 28 passed, `--retries=0`
- pre-push (biome + full vitest + `cargo test`) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wh6tAyoSs6EeobDLUUVTJM
