### PR TITLE
fix(theme): re-release the forced app mode when High Contrast is toggled mid-session

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3702,8 +3702,10 @@ fn native_theme_action(pref: &str, high_contrast: bool, host: NativeHost) -> Nat
         NativeHost::Windows => {
             // Do not force an app mode while High Contrast is active — that
             // would fight the accessibility setting the user turned on.
-            // Mid-session toggling is not re-released by this guard; that is
-            // #1364, a separate, narrower gap.
+            // `high_contrast` is sampled once per call, by design; the client
+            // re-pushes the unchanged preference on a `(forced-colors: active)`
+            // change (#1364), which is what makes a mid-session toggle release
+            // (or re-apply) the app mode without a theme change.
             if high_contrast {
                 return NativeThemeAction::SetAppMode(AppMode::AllowDark);
             }

--- a/src-tauri/src/win_app_mode.rs
+++ b/src-tauri/src/win_app_mode.rs
@@ -267,8 +267,11 @@ pub fn set_preferred_app_mode(mode: crate::AppMode) -> AppModeOutcome {
 /// True when Windows' High Contrast accessibility mode is currently active.
 /// `native_theme_action` (`lib.rs`) uses this to refuse forcing an app mode
 /// while it's on, so an explicit theme choice never fights the user's
-/// accessibility setting. Mid-session High Contrast toggling does not
-/// re-release an already-forced app mode — that is #1364, not this guard.
+/// accessibility setting. This remains a PER-CALL sample by design — nothing
+/// here subscribes to `WM_SETTINGCHANGE`. Mid-session toggling is handled on
+/// the client instead (#1364): `useTauriTheme.svelte.ts` watches
+/// `(forced-colors: active)` and re-pushes the unchanged preference, which
+/// re-enters this probe and releases (or re-applies) the app mode.
 ///
 /// `uiParam` MUST be `size_of::<HIGHCONTRASTW>()` — `SystemParametersInfoW`
 /// returns FALSE (not an error, just silently declines) for a mismatched

--- a/src/client/hooks/useTauriTheme.svelte.ts
+++ b/src/client/hooks/useTauriTheme.svelte.ts
@@ -130,6 +130,29 @@ function releasePageHideListener(): void {
   pagehideHandler = null;
 }
 
+// The `(forced-colors: active)` subscription's release closure (#1364). A
+// SUBSCRIPTION HANDLE, like `unlistenTheme` and `pagehideHandler` above — not a
+// push-pipeline fact, so the "belongs as a field on lastPush/lastResolved" rule does
+// not apply to it. Plain `let`, never `$state`, per the REQUIRED note above.
+//
+// A release CLOSURE rather than the bare handler, because `removeEventListener` needs
+// the MediaQueryList *and* the handler, and happy-dom (like some real engines) returns a
+// NEW MediaQueryList object per `matchMedia()` call — so re-deriving the list at teardown
+// would remove nothing. One closure captures exactly the pair this generation registered,
+// which is the property the `pagehideHandler` note above is really asking for.
+let unlistenForcedColors: (() => void) | null = null;
+
+/** Release the forced-colors subscription, if one was ever registered. */
+function releaseForcedColorsListener(): void {
+  if (!unlistenForcedColors) return;
+  try {
+    unlistenForcedColors();
+  } catch (e) {
+    console.warn("[useTauriTheme] forced-colors unlisten failed:", e);
+  }
+  unlistenForcedColors = null;
+}
+
 // Monotonic ticket dispenser, bumped on every `setNativeTheme` call. A push
 // compares its own ticket against THIS counter, never against `lastPush`, and
 // no `seq` field lives on that record. The durable reason: this counter is
@@ -301,6 +324,7 @@ export function _resetForTests(): void {
   stopPoll();
   releaseThemeListener();
   releasePageHideListener();
+  releaseForcedColorsListener();
   // Must be cleared, even though the sibling `useTauriFileDrop._resetForTests` omits the
   // equivalent line: there the omission is inert because HMR never runs under vitest, but
   // any test here that drives the dispose path would otherwise leave this latched and
@@ -453,8 +477,21 @@ export function setNativeTheme(pref: ThemePreference): void {
  * retry (gets a fresh one). It is deliberately NOT a parameter on the exported
  * `setNativeTheme`: no caller outside this module can meaningfully supply it,
  * and an optional boolean on the public surface would invite one to try.
+ *
+ * `bypassDedupe` (#1364) is the same kind of parameter, for the forced-colors
+ * listener, whose whole point is to re-issue an UNCHANGED preference. It skips the
+ * READ of the dedupe latch for exactly one call and CLEARS NOTHING — which is the
+ * distinction that keeps it race-free. `lastPush` is not nulled first: the call
+ * falls straight through to the ordinary `lastPush = {…}` assignment below, so
+ * the record is never transiently `null`, `inFlight` is never transiently dropped
+ * (which would reopen `acceptReadback`'s in-flight gate), and no window exists in
+ * which the module holds no dedupe claim and `createTheme`'s effect could double-push.
+ * Ordering against a concurrent push is governed entirely by the existing
+ * `++pushSeq` ticket and the `seq !== pushSeq` supersede checks: the forced push is
+ * simply the newest intent. `lastResolved` is untouched — `recordResolution` stays
+ * its only pipeline writer.
  */
-function pushNativeTheme(pref: ThemePreference, viaRetry: boolean): void {
+function pushNativeTheme(pref: ThemePreference, viaRetry: boolean, bypassDedupe = false): void {
   if (!isTauriRuntime()) return;
   // Cancel BEFORE the dedupe check, not after. A new intent supersedes a
   // pending retry whether or not it needs an `invoke`. Today this is a
@@ -467,7 +504,7 @@ function pushNativeTheme(pref: ThemePreference, viaRetry: boolean): void {
   // armed to release the override under an explicit theme. Hoisting it costs
   // nothing and makes the ordering safe independently of that reasoning.
   cancelRetry();
-  if (pref === lastPush?.pref) return;
+  if (!bypassDedupe && pref === lastPush?.pref) return;
   const seq = ++pushSeq;
   // `performance.now()`, not `Date.now()`: `issuedAt` is only ever used to
   // measure an elapsed duration against `PUSH_SETTLE_CEILING_MS`, and the wall
@@ -685,6 +722,69 @@ export function initTauriTheme(): void {
       });
   }, POLL_INTERVAL_MS);
 
+  // Re-push on an OS High Contrast change (#1364).
+  //
+  // The Windows guard that declines to force an app mode while High Contrast is on
+  // (`native_theme_action` in lib.rs) samples `SPI_GETHIGHCONTRAST` ONCE, at push time,
+  // and nothing on either side subscribes to changes. So turning High Contrast on while
+  // an explicit theme was already forced left the forced app mode in place until the
+  // user's next theme change: the preference has not changed, so `createTheme`'s effect
+  // does not re-run, and the dedupe latch would refuse the push even if it did. Turning
+  // it back off is the mirror image — the release stands while an explicit theme is
+  // selected. One listener covers both, because it is LEVEL-INDEPENDENT: it never reads
+  // `event.matches` and re-pushes on any change, leaving Rust to decide what the new
+  // state means. There is deliberately no `matches` branch to keep in sync.
+  //
+  // Fail-open by construction: this listener's only job is to say "ask again". Every
+  // decision stays in `native_theme_action`, off the real `SPI_GETHIGHCONTRAST` probe —
+  // `forced-colors` is a CSS-level proxy and is trusted for nothing more than a nudge.
+  // A spurious fire costs one idempotent IPC; a missed fire costs nothing worse than the
+  // pre-#1364 behaviour. That asymmetry is why the proxy is acceptable HERE and would not
+  // be if the client were deciding.
+  //
+  // Registered on every platform rather than behind a host check: `forced-colors` is
+  // effectively the Windows High Contrast signal in Chromium, so off Windows this fires
+  // essentially never, and an idempotent extra push is cheaper than importing platform
+  // detection into this module.
+  //
+  // The `try`/`catch` is for hosts where `matchMedia` throws or is missing (old WebViews;
+  // see the "matchMedia throws" case in useTheme.svelte.ts's browser path) — NOT for test
+  // stubs, which carry the member instead. It WARNS rather than failing silently: a host
+  // without `matchMedia` loses this fix entirely, and a silent feature-detect would make
+  // that indistinguishable from working.
+  try {
+    const forcedColors = window.matchMedia("(forced-colors: active)");
+    const onForcedColorsChange = (): void => {
+      // `lastPush.pref` is this module's only record of the preference, and it is
+      // `null` whenever there is no claim: before the first push, across an armed
+      // retry (which re-pushes and re-samples High Contrast on its own), after an
+      // exhausted ladder, and after a superseded rejection cleared it. Pushing
+      // `undefined` would be worse than waiting for the next real theme change.
+      const pref = lastPush?.pref;
+      if (pref === undefined) return;
+      // Knowingly relaxes `retryAttempts`' "one user intent" rule (see its
+      // declaration) in ONE reachable case: a retry that has FIRED but not settled
+      // leaves `lastPush.viaRetry` true, so `cancelRetry()` below refills its budget
+      // for what is an OS event rather than a user intent. Accepted rather than
+      // flagged — the rule exists to stop a budget being DRAINED across picks, this
+      // refills it, and the cost is bounded at MAX_PUSH_RETRIES + 1 invokes per
+      // physical toggle. An ARMED (not yet fired) retry cannot reach here at all: it
+      // implies `lastPush === null`, so the guard above returns first.
+      pushNativeTheme(pref, false, true);
+    };
+    forcedColors.addEventListener("change", onForcedColorsChange);
+    unlistenForcedColors = () => forcedColors.removeEventListener("change", onForcedColorsChange);
+  } catch (e) {
+    // No issue number in the STRING: `check-semantic-tokens` masks comments but scans
+    // live code, and a `#` followed by 3-8 hex digits on a line whose text looks
+    // CSS-ish ("forced-colors") is read as a raw hex colour. The reference lives in
+    // the comment above instead.
+    console.warn(
+      "[useTauriTheme] forced-colors subscribe failed; High Contrast re-push disabled:",
+      e,
+    );
+  }
+
   // Clean up the polling interval. pagehide is more reliable than unload in
   // Chromium-based environments (including Tauri's WebView2).
   //
@@ -708,6 +808,7 @@ export function initTauriTheme(): void {
     cancelRetry();
     releaseThemeListener();
     releasePageHideListener();
+    releaseForcedColorsListener();
   };
   // `event.persisted` means the page is going into the bfcache and can be restored with
   // this module instance intact. Tearing down there would be worse than the leak this

--- a/tests/client/useTauriTheme.svelte.test.ts
+++ b/tests/client/useTauriTheme.svelte.test.ts
@@ -68,6 +68,39 @@ function callsFor(invoke: { mock: { calls: unknown[][] } }, cmd: string): unknow
   return invoke.mock.calls.filter(([c]) => c === cmd);
 }
 
+/**
+ * The `matchMedia` member every `vi.stubGlobal("window", …)` below SHOULD carry — not
+ * one any assertion needs. `initTauriTheme` queries `(forced-colors: active)` (#1364)
+ * as unconditionally as it calls `window.addEventListener("pagehide", …)`; without the
+ * member the query throws into the source's `try`/`catch`, so those ten tests would
+ * exercise the DEGRADED (matchMedia-unavailable) branch while asserting things about the
+ * push pipeline. Carrying it puts them on the production path instead.
+ *
+ * Measured, so nobody treats ten edits to shared setup as mandatory: with all ten
+ * `matchMedia: inertMatchMedia` lines stripped and the #1364 source fix in place, the
+ * file still passes 37/37. This is a fidelity improvement, not a requirement. (The source
+ * also warns on that branch; vitest surfaced no console output for this file in either
+ * run, so treat the warn as unobserved here rather than as measured.)
+ *
+ * Inert on purpose: these stubs belong to tests about the push pipeline, not about the
+ * forced-colors listener, which has its own describe — with its own live fake — at the
+ * bottom of this file. Note the inertness is exactly what makes note 1 down there true:
+ * this function ignores its query argument, so it can stand in for `matchMedia` without
+ * ever standing in for the fake.
+ *
+ * The source could have feature-detected `matchMedia` instead, and an earlier draft of
+ * #1364 did. That was rejected: the guard would have been shaped by these stubs rather
+ * than by any real host, and it would silently disable the whole fix on a host that
+ * genuinely lacks `matchMedia`. Extending the stubs is the repo's precedent.
+ */
+function inertMatchMedia(): {
+  matches: boolean;
+  addEventListener: () => void;
+  removeEventListener: () => void;
+} {
+  return { matches: false, addEventListener: () => {}, removeEventListener: () => {} };
+}
+
 /** Drain the microtask queue so a dynamic-import + invoke chain settles. */
 async function flushAsync(): Promise<void> {
   await new Promise((r) => setTimeout(r, 0));
@@ -165,6 +198,7 @@ describe("useTauriTheme", () => {
     vi.stubGlobal("window", {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
+      matchMedia: inertMatchMedia,
       __TANDEM_INITIAL_THEME__: undefined,
     });
 
@@ -198,6 +232,7 @@ describe("useTauriTheme", () => {
       __TANDEM_INITIAL_THEME__: "light" as "light" | "dark",
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
+      matchMedia: inertMatchMedia,
       hasFocus: () => true,
     });
 
@@ -232,7 +267,11 @@ describe("useTauriTheme", () => {
       );
       _resetForTests();
       vi.stubGlobal("document", { hasFocus: () => true });
-      vi.stubGlobal("window", { addEventListener: vi.fn(), removeEventListener: vi.fn() });
+      vi.stubGlobal("window", {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        matchMedia: inertMatchMedia,
+      });
 
       initTauriTheme();
       await vi.advanceTimersByTimeAsync(0); // let the initial get_app_theme settle
@@ -399,6 +438,7 @@ describe("setNativeTheme (#992)", () => {
     vi.stubGlobal("window", {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
+      matchMedia: inertMatchMedia,
       __TANDEM_INITIAL_THEME__: undefined,
     });
     invoke.mockImplementation((cmd: string) => {
@@ -456,6 +496,7 @@ describe("setNativeTheme (#992)", () => {
     vi.stubGlobal("window", {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
+      matchMedia: inertMatchMedia,
       __TANDEM_INITIAL_THEME__: undefined,
     });
     invoke.mockImplementation((cmd: string) => {
@@ -507,6 +548,7 @@ describe("setNativeTheme (#992)", () => {
       vi.stubGlobal("window", {
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
+        matchMedia: inertMatchMedia,
         __TANDEM_INITIAL_THEME__: undefined,
       });
 
@@ -567,6 +609,7 @@ describe("setNativeTheme (#992)", () => {
     vi.stubGlobal("window", {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
+      matchMedia: inertMatchMedia,
       __TANDEM_INITIAL_THEME__: undefined,
     });
     // hasFocus false so no poll tick can confound the assertions below.
@@ -620,6 +663,7 @@ describe("setNativeTheme (#992)", () => {
       vi.stubGlobal("window", {
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
+        matchMedia: inertMatchMedia,
         __TANDEM_INITIAL_THEME__: undefined,
       });
       vi.stubGlobal("document", { hasFocus: () => false });
@@ -680,6 +724,7 @@ describe("setNativeTheme (#992)", () => {
     vi.stubGlobal("window", {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
+      matchMedia: inertMatchMedia,
       __TANDEM_INITIAL_THEME__: undefined,
     });
     vi.stubGlobal("document", { hasFocus: () => false });
@@ -714,6 +759,7 @@ describe("setNativeTheme (#992)", () => {
       vi.stubGlobal("window", {
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
+        matchMedia: inertMatchMedia,
         __TANDEM_INITIAL_THEME__: undefined,
       });
       vi.stubGlobal("document", { hasFocus: () => false });
@@ -1004,5 +1050,271 @@ describe("setNativeTheme (#992)", () => {
       removeSpy.mockRestore();
       _resetForTests();
     });
+  });
+});
+
+/**
+ * #1364 — an OS High Contrast toggle must re-issue the CURRENT preference.
+ *
+ * The Windows guard that declines to force an app mode while High Contrast is on
+ * (`native_theme_action`, lib.rs) samples `SPI_GETHIGHCONTRAST` once per push, and
+ * nothing subscribes to changes. Since the preference has not changed, `createTheme`'s
+ * effect does not re-run and the dedupe latch would refuse the push if it did — so the
+ * forced app mode stayed in place until the user's next theme change.
+ *
+ * PLACEMENT AND HARNESS ARE LOAD-BEARING, in this order:
+ *
+ *  1. This describe sits LAST in the file, and its `beforeEach` starts with
+ *     `vi.unstubAllGlobals()`. `describe("setNativeTheme (#992)")`'s own `beforeEach`
+ *     never unstubs, so without this the last `vi.stubGlobal("window", …)` above — the
+ *     one in "does not accumulate pagehide listeners" — is still in force. Its
+ *     `matchMedia` is `inertMatchMedia`, which IGNORES its query argument and returns a
+ *     throwaway MediaQueryList, so the SUT registers its listener on an object
+ *     `fc.fire()` can never reach. Re-measured against this file as it ships, with only
+ *     the `beforeEach` unstub commented out: `typeof window.matchMedia === "function"`,
+ *     `window.matchMedia === inertMatchMedia`, the fake's listener count is 0, and
+ *     1 of the 6 tests fails — the FIRST one only, because this describe's own
+ *     `afterEach` unstubs and tests 2-6 then run against the real happy-dom window.
+ *     That masking is itself the argument for keeping the `beforeEach` unstub rather
+ *     than leaning on the `afterEach`: relying on it would make the harness depend on
+ *     execution order, and a `.only` or a reordering would silently break test 1 alone.
+ *     (An earlier version of this note recorded `typeof window.matchMedia ===
+ *     "undefined"` and "every test below would fail". That was measured honestly and
+ *     then falsified by this very diff, which added `matchMedia` to those ten stubs —
+ *     re-measure a comment after the diff stops changing, not when you first write it.)
+ *
+ *  2. `installForcedColorsFake` hands back the SAME MediaQueryList object for every
+ *     `(forced-colors: active)` query, and `fire()` invokes the handlers CAPTURED from
+ *     that object's `addEventListener`. happy-dom returns a NEW MediaQueryList per
+ *     `matchMedia()` call, so dispatching on a freshly obtained one reaches nothing and
+ *     would silently no-op. The test must own the object the SUT received.
+ *
+ *  3. `afterEach` calls `_resetForTests()` UNCONDITIONALLY rather than each test ending
+ *     with it: a failing test would skip a trailing call and leak a live 3s poll (real
+ *     `document.hasFocus()` is true once globals are unstubbed) plus a live listener into
+ *     whatever runs next. The test at the top of this file exists to catch exactly that.
+ *
+ * WHICH TESTS ARE LOAD-BEARING (measured against master, not asserted):
+ *   - "re-pushes the current preference", "re-pushes on every forced-colors change" and
+ *     the listener-lifecycle test are RED before the fix, on the assertion that matters.
+ *   - The two GUARD tests below also go red on master, but only on their PRECONDITION —
+ *     the re-push they need to follow up never happens. Their own distinguishing
+ *     assertions are vacuous there, so read them as shape guards, not as regression
+ *     coverage.
+ *   - "does not push when no preference has ever been pushed" passes on master and is a
+ *     pure guard.
+ */
+describe("forced-colors re-push (#1364)", () => {
+  let invoke: ReturnType<typeof vi.fn>;
+
+  /** The fake `(forced-colors: active)` MediaQueryList — see note 2 above. */
+  function installForcedColorsFake(): {
+    fire: () => void;
+    listenerCount: () => number;
+    addCalls: () => number;
+    removeCalls: () => number;
+  } {
+    const listeners = new Set<() => void>();
+    let addCalls = 0;
+    let removeCalls = 0;
+    const realMatchMedia =
+      typeof window.matchMedia === "function" ? window.matchMedia.bind(window) : null;
+    const mql = {
+      matches: false,
+      media: "(forced-colors: active)",
+      addEventListener: (type: string, cb: () => void) => {
+        if (type !== "change") return;
+        listeners.add(cb);
+        addCalls++;
+      },
+      removeEventListener: (type: string, cb: () => void) => {
+        if (type === "change" && listeners.delete(cb)) removeCalls++;
+      },
+    };
+    vi.stubGlobal("matchMedia", (query: string) =>
+      query.includes("forced-colors") ? mql : (realMatchMedia?.(query) ?? inertMatchMedia()),
+    );
+    return {
+      // Copy before iterating: a handler is free to re-register during dispatch.
+      fire: () => {
+        for (const cb of [...listeners]) cb();
+      },
+      listenerCount: () => listeners.size,
+      addCalls: () => addCalls,
+      removeCalls: () => removeCalls,
+    };
+  }
+
+  beforeEach(async () => {
+    vi.unstubAllGlobals(); // FIRST — see note 1 above
+    const core = await import("@tauri-apps/api/core");
+    invoke = vi.mocked(core.invoke) as any;
+    invoke.mockReset();
+    invoke.mockImplementation((cmd: string) => {
+      if (cmd === "set_native_theme")
+        return Promise.resolve({ overrideActive: false, osTheme: null });
+      return Promise.resolve("light");
+    });
+    isTauri.mockReturnValue(true);
+    const { _resetForTests } = await import("../../src/client/hooks/useTauriTheme.svelte.js");
+    _resetForTests();
+    themeChangedCapture.current = null;
+  });
+
+  afterEach(async () => {
+    const { _resetForTests } = await import("../../src/client/hooks/useTauriTheme.svelte.js");
+    _resetForTests(); // unconditional — see note 3 above
+    isTauri.mockReturnValue(false);
+    vi.unstubAllGlobals();
+  });
+
+  // RED BEFORE THE FIX. Nothing in the module touched `matchMedia` at all, so this
+  // asserted 1 against 0.
+  it("re-pushes the current preference when forced-colors changes, bypassing the dedupe latch", async () => {
+    const fc = installForcedColorsFake();
+    const { initTauriTheme, setNativeTheme, _resetForTests } = await import(
+      "../../src/client/hooks/useTauriTheme.svelte.js"
+    );
+    _resetForTests();
+    initTauriTheme();
+    setNativeTheme("dark");
+    await flushAsync();
+    expect(callsFor(invoke, "set_native_theme")).toHaveLength(1);
+
+    fc.fire();
+    await flushAsync();
+
+    // The SAME preference goes out again — that is the whole point: on Windows,
+    // `native_theme_action` re-samples High Contrast and maps "dark" to AllowDark
+    // (release) while it is on, and back to ForceDark once it is off.
+    expect(callsFor(invoke, "set_native_theme")).toEqual([
+      ["set_native_theme", { theme: "dark" }],
+      ["set_native_theme", { theme: "dark" }],
+    ]);
+  });
+
+  // RED BEFORE THE FIX, but only as "the test above with a second event" — it cannot
+  // distinguish a correct implementation from one that re-pushes on an unrelated media
+  // change. What it pins is that the handler is LEVEL-INDEPENDENT: it never reads
+  // `event.matches`, so one code path covers High-Contrast-on and High-Contrast-off, and
+  // there is deliberately no `matches` branch in the source to drift out of sync.
+  it("re-pushes on every forced-colors change, not just the first (no `matches` branch)", async () => {
+    const fc = installForcedColorsFake();
+    const { initTauriTheme, setNativeTheme, _resetForTests } = await import(
+      "../../src/client/hooks/useTauriTheme.svelte.js"
+    );
+    _resetForTests();
+    initTauriTheme();
+    setNativeTheme("dark");
+    await flushAsync();
+
+    fc.fire(); // High Contrast on  -> Rust releases the force
+    await flushAsync();
+    fc.fire(); // High Contrast off -> Rust re-applies it
+    await flushAsync();
+
+    expect(callsFor(invoke, "set_native_theme")).toHaveLength(3);
+  });
+
+  // GUARD. Measured on master it fails, but only on its PRECONDITION (the re-push it
+  // needs to follow up never happens); its own distinguishing assertion — the final
+  // `toHaveLength(2)` — is vacuous there. It pins the SHAPE of the
+  // fix: the bypass skips the READ of the dedupe latch for one call and clears nothing,
+  // so the latch still holds afterwards. An implementation written as
+  // `lastPush = null; setNativeTheme(pref)` fails here, and that shape also reopens
+  // `acceptReadback`'s in-flight gate and lets `createTheme`'s effect double-push.
+  it("GUARD: the bypass does not clear the latch — a later identical push still dedupes", async () => {
+    const fc = installForcedColorsFake();
+    const { initTauriTheme, setNativeTheme, _resetForTests } = await import(
+      "../../src/client/hooks/useTauriTheme.svelte.js"
+    );
+    _resetForTests();
+    initTauriTheme();
+    setNativeTheme("dark");
+    await flushAsync();
+    fc.fire();
+    await flushAsync();
+    expect(callsFor(invoke, "set_native_theme")).toHaveLength(2);
+
+    setNativeTheme("dark"); // the effect's ordinary re-run — must still no-op
+    await flushAsync();
+
+    expect(callsFor(invoke, "set_native_theme")).toHaveLength(2);
+  });
+
+  // GUARD (vacuous on master). `lastPush` is this module's only record of the
+  // preference, and it is null whenever there is no claim. Pushing `undefined` would be
+  // worse than waiting for the next real theme change.
+  it("GUARD: does not push when no preference has ever been pushed", async () => {
+    const fc = installForcedColorsFake();
+    const { initTauriTheme, _resetForTests } = await import(
+      "../../src/client/hooks/useTauriTheme.svelte.js"
+    );
+    _resetForTests();
+    initTauriTheme();
+    await flushAsync();
+
+    fc.fire();
+    await flushAsync();
+
+    expect(callsFor(invoke, "set_native_theme")).toHaveLength(0);
+  });
+
+  // GUARD. Like the latch guard above, it fails on master on its PRECONDITION only (no
+  // forced push happens there to reject); its own final assertion is vacuous. Pins the
+  // accepted limitation: a forced re-push that REJECTS clears `lastPush` (the failure path's
+  // unconditional `lastPush = null`), after which the module holds no claim and a further
+  // toggle must no-op rather than guess. Reachable in production: `set_native_theme`
+  // returns Err whenever the High Contrast probe yields `Unknown`, so on such a machine
+  // every toggle lands here.
+  it("GUARD: after a rejected forced re-push, a further change no-ops (no claim to re-assert)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const fc = installForcedColorsFake();
+      const { initTauriTheme, setNativeTheme, _resetForTests } = await import(
+        "../../src/client/hooks/useTauriTheme.svelte.js"
+      );
+      _resetForTests();
+      initTauriTheme();
+      setNativeTheme("dark");
+      await flushAsync();
+
+      invoke.mockImplementationOnce(() => Promise.reject(new Error("ipc failed")));
+      fc.fire();
+      await flushAsync();
+      expect(callsFor(invoke, "set_native_theme")).toHaveLength(2);
+
+      fc.fire();
+      await flushAsync();
+
+      expect(callsFor(invoke, "set_native_theme")).toHaveLength(2);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // RED BEFORE THE FIX (the `toBe(1)` sees 0). The leak class #1413's landed half closed
+  // for `onThemeChanged` and the `pagehide` handler, one function further down: a
+  // listener that is registered but never released is structurally unobservable, which is
+  // how the earlier leaks went unnoticed.
+  it("releases the forced-colors listener on teardown, and does not accumulate", async () => {
+    const fc = installForcedColorsFake();
+    const { initTauriTheme, _resetForTests } = await import(
+      "../../src/client/hooks/useTauriTheme.svelte.js"
+    );
+    _resetForTests();
+
+    initTauriTheme();
+    expect(fc.listenerCount()).toBe(1);
+    _resetForTests();
+    expect(fc.listenerCount()).toBe(0);
+
+    for (let i = 0; i < 3; i++) {
+      initTauriTheme();
+      _resetForTests();
+    }
+    expect(fc.addCalls()).toBe(4); // one per initTauriTheme()
+    expect(fc.removeCalls()).toBe(4); // every registered generation released
+    expect(fc.listenerCount()).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #1364.

## Root cause

Windows' `set_native_theme` declines to force a process-wide uxtheme app mode while High Contrast is active, so the accessibility scheme wins — but that guard samples `SPI_GETHIGHCONTRAST` **once per push**, inside the command handler, and nothing on either side of the IPC subscribes to changes (`grep -rn "WM_SETTINGCHANGE\|WM_THEMECHANGED" src-tauri/` → no hits).

The deeper cause is on the client. The push pipeline dedupes on `lastPush.pref`, but the native outcome is a function of **two** inputs — the preference **and** the OS High Contrast state. The latch therefore keys on a strict subset of the decision's inputs, so a change in the unobserved one produces no push at all: the preference has not changed, `createTheme`'s effect does not re-run, and the latch would refuse the push even if it did. Nothing else self-corrects — the 3s poll and `onThemeChanged` only *read*, and the retry ladder only re-issues *failed* pushes.

The gap is symmetric, which the issue does not say: turning High Contrast **off** mid-session was equally uncorrected, leaving the app mode released while an explicit theme was selected.

## The fix

Client-side, per the issue's own sketch. `initTauriTheme` subscribes to `(forced-colors: active)` and, on any change, re-issues the **current** preference with the dedupe latch bypassed.

No Rust logic changes: `native_theme_action` already maps an explicit preference to `AppMode::AllowDark` (the release target) while High Contrast is on, and back to `ForceDark`/`ForceLight` once it is off — so one listener covers both directions, and `set_preferred_app_mode`'s `FlushMenuThemes` call means the change reaches already-drawn chrome.

The handler is deliberately **level-independent**: it never reads `event.matches`, so there is no `matches` branch to drift out of sync. Every decision stays in Rust, off the real `SPI_GETHIGHCONTRAST` probe. `forced-colors` is a CSS-level proxy trusted for nothing but "ask again" — fail-open by construction: a spurious fire costs one idempotent IPC, a missed fire costs nothing worse than the previous behaviour.

**The bypass clears no state**, which is what keeps it race-free. `bypassDedupe` skips the *read* of `lastPush?.pref` for exactly one call and falls straight through to the ordinary `lastPush = {…}` assignment:

- `lastPush` is never transiently `null`, and `inFlight` is never transiently dropped (which would reopen `acceptReadback`'s in-flight gate).
- No window exists in which the module holds no dedupe claim and `createTheme`'s effect could double-push — so the documented loop breaker is strengthened, not weakened.
- Ordering against a concurrent push is the existing `++pushSeq` ticket plus the `seq !== pushSeq` supersede checks. The loser is discarded in `.then`, so no stale `lastPush` is ever written.
- `lastResolved` is untouched; `recordResolution` stays its only pipeline writer.

One **accepted and documented** relaxation: a retry that has *fired* but not settled has its budget refilled by the existing `cancelRetry()`. That is bounded at `MAX_PUSH_RETRIES + 1 = 4` invokes per physical toggle, and it refills rather than drains — the opposite of the hazard the `retryAttempts` comment guards against. An *armed* (not yet fired) retry cannot reach the handler at all, since it implies `lastPush === null`.

The listener's release closure lives at module scope and is released from **both** `teardown()` and `_resetForTests()` — a closure rather than a bare handler, because `removeEventListener` needs the MediaQueryList too and engines hand back a new one per `matchMedia()` call.

Also updated: two Rust comments that asserted this gap was unfixed and cited the issue. Both are comment-only; no logic changed.

## Tests

Six new tests in a `describe` placed **last** in `tests/client/useTauriTheme.svelte.test.ts`, with `vi.unstubAllGlobals()` first in its `beforeEach`. That unstub is load-bearing and was measured, not assumed: without it, the `window` stub leaked from an earlier describe is still in force, its `matchMedia` is the inert helper that ignores its query argument, and the SUT registers on a throwaway MediaQueryList the test can never dispatch to (measured: `typeof window.matchMedia === "function"`, fake listener count 0, and 1 of the 6 tests red — the first only, because this describe's own `afterEach` unstubs and masks the rest).

| Test | Before the fix |
|---|---|
| re-pushes the current preference on a `change` | **red** — the regression test |
| re-pushes on every `change`, not just the first | **red** — pins level-independence |
| releases the listener on teardown; no accumulation | **red** — the listener-leak class |
| GUARD: the bypass does not clear the latch | red on its *precondition* only; its own assertion is vacuous on master |
| GUARD: after a rejected forced re-push, a further change no-ops | red on its *precondition* only |
| GUARD: no push when no preference has ever been pushed | passes on master |

Measured with the fix stashed and the tests kept: **5 of 6 fail, 1 passes**. Three fail on the assertion that matters; two fail only because the re-push they follow up does not exist. The test bodies say which is which, since this table does not travel with the file.

Ten existing `vi.stubGlobal("window", …)` sites gained a `matchMedia` member so they exercise the production path instead of the source's degraded catch branch. Measured as behaviour-neutral: with all ten stripped, the file still passes 37/37. It is a fidelity improvement, not a requirement, and the helper's doc comment says so.

## Gates

| Gate | Result |
|---|---|
| `npx biome check src/ tests/` | pass — 1089 files, no fixes |
| `npm run typecheck` | pass — `1337 FILES 0 ERRORS 0 WARNINGS`, exit 0 |
| `npx vitest --run tests/client/useTauriTheme.svelte.test.ts` | pass — 37/37 |
| `useTheme.test.ts` + `useTheme-native-push.svelte.test.ts` + `native-theme-claims.test.ts` | pass — 40/40 |
| `cargo test --manifest-path src-tauri/Cargo.toml` | pass, exit 0 |
| `npx playwright test tests/e2e/forced-colors.spec.ts` | pass — 7 tests |
| `npx vitest --run` (full) | run twice; failures were **different both times** and all in wall-clock-budgeted tests. Verified not mine: the same seven files, with this change **stashed**, fail identically on clean master under the same load. The pre-push hook re-ran the suite on a quiet box |
| `tsx scripts/check-semantic-tokens.ts` | pass (0 errors). It initially flagged the issue reference inside a runtime string — comments are masked, live code is not, and `#` followed by 3–8 hex digits on a line containing "forced-colors" reads as a raw hex colour. The reference now lives in the comment, not the warn message |

`cargo test` caveat: `lib.rs` declares `#[cfg(target_os = "windows")] mod win_app_mode;`, so the local Linux leg never parses `win_app_mode.rs`. One of the two comment edits is only compiled on CI's `windows-latest` leg.

## Unverified — both halves, stated plainly

- **Native half.** That Windows actually re-releases the uxtheme app mode on the re-push. Needs Windows hardware with High Contrast, and the `#[tauri::command]` body is unreachable from `cargo test` (its own doc comment records this). `native_theme_action`'s exhaustive matrix proves Rust *releases when asked*; the join with "the client asks" is argued, not measured.
- **Client half, equally load-bearing.** That WebView2 fires a `(forced-colors: active)` `change` event for a mid-session Windows contrast switch at all, and that Chromium's forced-colors state tracks `SPI_GETHIGHCONTRAST` closely enough that the re-push lands on the transition. The whole fix hinges on this.

## Coordination with concurrent work

- **#1439** (same wave) sweeps client `console.warn` calls into a structured diagnostic recorder. This PR adds exactly one new `console.warn`; if #1439 lands first, that call should adopt its recorder rather than stay a bare warn.
- **#1368** adds an `applied` discriminant to `NativeThemeOutcome` (including a `DeclinedHighContrast` variant), rewrites the client's mirrored union, and threads a callback into `initTauriTheme` — the same function this PR inserts into. Whichever of the two lands second rebases onto the other's shape; this diff was kept narrow (one module `let`, one release fn, one defaulted parameter, one `if` condition, one registration block, one line each in `teardown()` and `_resetForTests()`) so that rebase is mechanical.

## CHANGELOG

Deliberately **not** edited. The 0.21.0 entry for #992 says turning High Contrast on while a theme is already forced "is the one case that doesn't settle on its own until you next change themes" — which remains true *of 0.21.0*, and that file has never carried inline corrections. As of this change it settles on its own, in both directions, without waiting for a theme change; that sentence is here for `.claude/skills/changelog` to lift into the next release's entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_018DdaCvomDgPsumrDAmNH13)_