### PR TITLE
fix(editor): render GFM table column alignment in the editor

### DIFF
--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -173,10 +173,13 @@ $effect(() => {
       FindReplaceExtension,
       SelectionDecorationExtension,
       // A4: opt-in smart typography (smart quotes/dashes/ellipsis as you
-      // type). Input-rules-only — no new nodes/marks — so it stays out of
-      // buildSchemaExtensions() and is appended here like the other
-      // runtime-param extensions. Default off; conditionally included based
-      // on the tracked `smartTypographyOn` above.
+      // type). Default off; conditionally included based on the tracked
+      // `smartTypographyOn` above — and that CONDITIONAL INCLUSION is why it
+      // is assembled here rather than in buildSchemaExtensions(), which takes
+      // no params and cannot see a setting. Adding no nodes or marks is not by
+      // itself the test: TableColumnAlignExtension (#995) adds neither and does
+      // live in that builder, deliberately, so the client tests exercise its
+      // real registration.
       ...(smartTypographyOn ? [Typography] : []),
       // #1460: a plaintext document cannot store a newline inside a textblock,
       // so Shift+Enter has to split the block instead of inserting a hardBreak.

--- a/src/client/editor/editor-extensions.ts
+++ b/src/client/editor/editor-extensions.ts
@@ -17,6 +17,7 @@ import { ListItemCheckbox } from "./extensions/list-item-checkbox";
 import { ListSpreadExtension } from "./extensions/list-spread";
 import { MarkdownHtmlExtension } from "./extensions/markdown-html";
 import { RawMarkdownMark } from "./extensions/raw-markdown";
+import { TableColumnAlignExtension } from "./extensions/table-column-align";
 import { isSafeExternalHref, isSchemelessPathHref } from "./utils/url-safety";
 
 // Link mark that surfaces the destination URL on hover via a native `title`
@@ -279,6 +280,22 @@ export function buildSchemaExtensions(): AnyExtension[] {
     TableRow,
     TableCell,
     TableHeader,
+    // Renders the `align` array above as `text-align` on each cell (#995).
+    // Decoration-only — it adds no node, mark or attribute — so it contributes
+    // nothing to `getSchema()`. It lives in this builder anyway, deliberately:
+    // this is what the client tests build editors from, so registering here is
+    // what makes "the extension is actually wired into production" a thing the
+    // unit suite can fail on. Appending it in Editor.svelte instead would let
+    // every test pass with the feature unwired.
+    //
+    // Being here places it BEFORE annotation/authorship/heading-collapse in
+    // decoration order (see Editor.svelte, #650). Inert today: no other
+    // Decoration.node in src/client emits `text-align`. Note prosemirror-view
+    // concatenates `class` AND `style` alike — the reason to keep this a `class`
+    // is that concatenated styles apply via `cssText +=`, so two decorations
+    // setting `text-align` would resolve by registration order. See the
+    // extension's header comment.
+    TableColumnAlignExtension,
     MarkdownHtmlExtension,
     // Inline mark for verbatim markdown source (footnote/reference refs, inline
     // image/html). Name must match the server `rawMarkdown` delta key so it

--- a/src/client/editor/editor.css
+++ b/src/client/editor/editor.css
@@ -158,6 +158,31 @@
 .tandem-editor th {
   background: var(--tandem-surface-muted);
   font-weight: 600;
+  /* Deliberate visual change (#995). The UA stylesheet centres `th`, and nothing
+     here overrode it, so every header cell was centred. Once GFM column
+     alignment renders (see below), leaving that in place would make
+     `| :- | --- | -: |` show header 0 left, header 1 CENTRED and header 2 right
+     — the centred one being the column with no alignment declared at all. A row
+     whose only centred column is the unaligned one reads as broken. Left matches
+     the body cells, and matches how GitHub and every reset-using GFM renderer
+     display an unaligned header. */
+  text-align: left;
+}
+/* GFM column alignment (#995). Applied per cell by
+   `extensions/table-column-align.ts`, which resolves each cell's column through
+   prosemirror-tables' TableMap — the table-level `align` array cannot be
+   expressed as a selector, because a column's cells are not siblings and
+   colspan/rowspan break `:nth-child`. Specificity (0,2,0) clears the
+   `.tandem-editor td` / `.tandem-editor th` rules above; `text-align` inherits
+   into the cell's child paragraph, so no descendant rule is needed. */
+.tandem-editor .tandem-cell-align-left {
+  text-align: left;
+}
+.tandem-editor .tandem-cell-align-center {
+  text-align: center;
+}
+.tandem-editor .tandem-cell-align-right {
+  text-align: right;
 }
 .tandem-editor blockquote {
   border-left: 2px solid var(--tandem-border-strong);

--- a/src/client/editor/extensions/table-column-align.ts
+++ b/src/client/editor/extensions/table-column-align.ts
@@ -1,0 +1,250 @@
+import { Extension } from "@tiptap/core";
+import type { Node as PMNode } from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { TableMap } from "@tiptap/pm/tables";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+/**
+ * Render GFM column alignment on table cells (#995).
+ *
+ * #1462 made the alignment *survive*: the server writes mdast's per-column
+ * `align` array as a JSON string on the table element (`mdast-ydoc.ts:231`) and
+ * `TableWithAlignment` declares the attribute so `computeAttrs` stops discarding
+ * it. Nothing rendered it — `editor.css` had no `text-align` at all — so a
+ * document's alignment was invisible even though the data was intact.
+ *
+ * ## Why decorations, and not any of the obvious cheaper things
+ *
+ * Alignment is stored ONCE, on the table, indexed by column. `text-align` has to
+ * be applied per CELL. Nothing bridges those shapes declaratively:
+ *
+ * - **CSS cannot.** A column's cells are not siblings — they are one cell from
+ *   each row — so the only reach is `:nth-child`, which counts child index, and
+ *   `colspan`/`rowspan` desynchronise child index from column index.
+ * - **`<colgroup>`/`<col>` cannot.** Only `border`, `background`, `width` and
+ *   `visibility` apply to a `col` element (CSS 2.1 §17.3); `text-align` on `col`
+ *   is ignored by every browser. This is a live trap here because Tiptap's
+ *   `TableView` ALREADY renders a colgroup for column resizing, so the wrong fix
+ *   looks available and silently does nothing.
+ * - **A per-cell attribute cannot** without writing to the document: it invents a
+ *   cell attribute the server neither writes nor reads (the class of bug
+ *   `tests/client/attribute-parity.test.ts` exists to police), and it makes a
+ *   purely visual concern undoable and dirties the doc on open.
+ *
+ * So the column index is computed at view time and applied as a node decoration.
+ * This is the first per-cell table decoration in the codebase.
+ *
+ * ## The cell → column mapping is `TableMap`'s, never ours
+ *
+ * `TableMap` is prosemirror-tables' own authority — the same structure
+ * `addColumnBefore`, `deleteColumn`, `mergeCells` and `splitCell` operate on. It
+ * expands `colspan`/`rowspan` into a dense `width × height` grid of cell
+ * positions, so a cell that spans down from row 1 still occupies its column in
+ * row 2 and every later cell in that row keeps its true column index.
+ *
+ * The naive alternative — `row.child(i)` is column `i` — is wrong for exactly
+ * the tables the #923 context menu produces, and wrong SILENTLY: a single
+ * `rowspan` shifts a whole table's alignment one column. `tests/client/
+ * table-column-align.test.ts` pins both the rowspan and colspan cases.
+ *
+ * Structural edits cannot leave this stale because the set is rebuilt from
+ * scratch on every `docChanged` rather than mapped forward. `TableMap.get` is
+ * memoised per node instance, so an untouched table costs a WeakMap hit, and a
+ * structural edit replaces the node and invalidates the cache for us.
+ *
+ * A merged cell spanning two differently-aligned columns takes its LEFTMOST
+ * column's alignment. That is the only thing a single `text-align` allows, and it
+ * matches how the cell is serialized back to GFM.
+ *
+ * ## Two independent guards, and neither covers the other's case
+ *
+ * 1. **`relPos === 0` is a sentinel, not a position.** `computeMap` pre-fills the
+ *    grid with `0` (`prosemirror-tables/dist/index.js:121`) and LEAVES those
+ *    zeros for a short row, recording `{type:"missing"}` in `map.problems`. Zero
+ *    is never a real cell offset — `pos` is incremented before the first cell of
+ *    every row — but `table.nodeAt(0)` returns the first `tableRow`, NOT null. So
+ *    a bare existence check passes, and `Decoration.node` spanning a `<tr>`
+ *    exactly is *legal* (`NodeType.valid()` only requires the range to span a
+ *    non-text node exactly) and is accepted with no warning. `text-align` on a
+ *    `<tr>` then inherits into every cell in that row without its own class, so
+ *    one ragged row can centre an entire header. Ragged tables are reachable:
+ *    `mdast-ydoc.ts:233-250` does not pad short rows, and `fixTables` runs from
+ *    `tableEditing()`'s `appendTransaction`, which `EditorState.create` never
+ *    calls. Hence the explicit skip AND the `tableRole` check below — existence
+ *    alone is not the question, role is.
+ * 2. **`align.length !== map.width` bails out entirely.** The `align` array is
+ *    NOT maintained by the column commands: `addColumnBefore` on a 3-column table
+ *    leaves 3 entries against 4 columns, so every column from the insertion point
+ *    would render one column's alignment too far left and the last would lose it.
+ *    Re-indexing the array is deferred to #1535 (it needs command wrappers and a
+ *    document write), and #1535 is why this guard exists rather than being
+ *    defensive noise: without the re-index the column commands silently rewrite
+ *    the user's file, and this guard is what stops the editor from confidently
+ *    displaying the corrupted result. Until then, showing nothing
+ *    is right: it is exactly the pre-#995 behaviour for that table, whereas
+ *    showing a confident wrong answer has no user recourse while the alignment UI
+ *    is unbuilt.
+ *
+ * These do not subsume each other. For a ragged table the width guard passes
+ * (`width === align.length`) and only the sentinel skip protects; for a
+ * column-inserted table the sentinel never appears and only the width guard does.
+ *
+ * ## Registration and ordering
+ *
+ * Registered in `buildSchemaExtensions()` despite adding no schema, because that
+ * builder is what the client tests build editors from — placing it in
+ * `Editor.svelte` instead would let the whole suite pass with the extension
+ * unwired in production. `getSchema()` resolves nodes and marks only and never
+ * calls `addProseMirrorPlugins`, so the schema is byte-identical.
+ *
+ * That puts this plugin BEFORE annotation/authorship/heading-collapse in
+ * decoration order (see `Editor.svelte`, #650), which is inert here — but for a
+ * narrower reason than "class merges and style does not".
+ *
+ * `computeOuterDeco` (`prosemirror-view/dist/index.js:1663`) concatenates BOTH
+ * `class` and `style`; neither replaces the other. The difference is what
+ * concatenation MEANS. Two class tokens coexist and CSS specificity decides.
+ * Two `style` strings are joined and applied via `dom.style.cssText +=`, so two
+ * decorations setting `text-align` resolve LAST-DECLARATION-WINS — i.e.
+ * registration order would silently pick the winner. So: do not convert this to
+ * an inline `style`.
+ *
+ * Today no other `Decoration.node` in `src/client` (`annotationPing`,
+ * `awareness`, `heading-collapse`, `authorship`) emits `text-align` at all —
+ * they emit `class` or `data-*` — so there is nothing for this to race with.
+ */
+
+const CLASS_PREFIX = "tandem-cell-align-";
+
+/** The only values that may reach a DOM class name. See `usableAlignment`. */
+const ALIGNMENTS: ReadonlySet<string> = new Set(["left", "center", "right"]);
+
+/**
+ * Parse the table-level `align` attribute.
+ *
+ * The attribute is ALWAYS a JSON string in production: the server writes
+ * `JSON.stringify(align)` and `TableWithAlignment.renderHTML` emits
+ * `String(attrs.align)`, so an array would come back from a DOM re-read
+ * comma-joined (`"left,center"`) rather than as JSON. There is deliberately no
+ * already-parsed-array branch — it is unreachable outside a hand-built fixture,
+ * which would then pass while exercising a shape production never produces.
+ *
+ * Tolerant of garbage on purpose: the JSON comes off disk, and a malformed
+ * attribute must not take the editor down on open. Mirrors the server's own
+ * posture at `mdast-ydoc.ts:626-634`.
+ */
+function parseColumnAlign(raw: unknown): unknown[] {
+  if (typeof raw !== "string" || raw.length === 0) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Allowlist a single column's value.
+ *
+ * Not defensive noise: the value is interpolated into a DOM `class`, and it comes
+ * from a file that may have been authored by someone else. Without the
+ * allowlist, a crafted `.md` injects arbitrary class tokens onto editor DOM.
+ * `null` — GFM's "no alignment for this column" — falls through here too.
+ */
+function usableAlignment(value: unknown): string | null {
+  return typeof value === "string" && ALIGNMENTS.has(value) ? value : null;
+}
+
+/** Append one table's cell decorations. `pos` is the table node's own position. */
+function collectTableDecorations(table: PMNode, pos: number, out: Decoration[]): void {
+  const align = parseColumnAlign(table.attrs.align);
+  // Cheap exit for the overwhelmingly common case — an unaligned table, which is
+  // every table Tandem's own `/table` command creates. Costs one JSON.parse and
+  // never builds a TableMap.
+  if (!align.some((value) => usableAlignment(value) !== null)) return;
+
+  const map = TableMap.get(table);
+  // Guard 2. See the header comment: bail rather than render a confident wrong
+  // answer for a table whose column count has drifted from its align array.
+  if (align.length !== map.width) return;
+
+  // `map.map` holds cell positions relative to the table's CONTENT start, so the
+  // absolute position of a cell is `pos + 1 + relPos` — the same convention
+  // `fixTable` uses.
+  const start = pos + 1;
+  const seen = new Set<number>();
+
+  for (let i = 0; i < map.map.length; i++) {
+    const relPos = map.map[i];
+    // Guard 1. A zero is computeMap's unfilled-slot sentinel, not a position.
+    if (relPos === 0) continue;
+    // A colspan/rowspan cell occupies several slots; the FIRST is its top-left,
+    // which is why `i % map.width` is its leftmost column.
+    if (seen.has(relPos)) continue;
+    seen.add(relPos);
+
+    const cell = table.nodeAt(relPos);
+    const role = cell?.type.spec.tableRole;
+    if (!cell || (role !== "cell" && role !== "header_cell")) continue;
+
+    const value = usableAlignment(align[i % map.width]);
+    if (value === null) continue;
+
+    out.push(
+      Decoration.node(start + relPos, start + relPos + cell.nodeSize, {
+        class: `${CLASS_PREFIX}${value}`,
+      }),
+    );
+  }
+}
+
+/** Rebuild the whole decoration set from a document. */
+function buildTableAlignDecorations(doc: PMNode): DecorationSet {
+  const decorations: Decoration[] = [];
+
+  doc.descendants((node, pos) => {
+    // Returning false stops descent into THIS node only — siblings are still
+    // visited — so returning false at the textblock is exactly what keeps the
+    // walk off inline content. `nodesBetween` does not descend when the callback
+    // returns false, and without this cut every text node in the document would
+    // be visited on every keystroke. Do not delete it.
+    if (node.isTextblock) return false;
+    if (node.type.spec.tableRole !== "table") return true;
+    collectTableDecorations(node, pos, decorations);
+    // A nested table is schema-legal (`tableCell` is `content: 'block+'` and
+    // `table` is in group `block`, so pasted HTML can produce one) but is
+    // unreachable from GFM and is not serialized back to markdown, so it has no
+    // alignment to render. Deliberately undecorated, not assumed impossible.
+    return false;
+  });
+
+  if (decorations.length === 0) return DecorationSet.empty;
+  return DecorationSet.create(doc, decorations);
+}
+
+export const tableColumnAlignPluginKey = new PluginKey<DecorationSet>("tandemTableColumnAlign");
+
+export const TableColumnAlignExtension = Extension.create({
+  name: "tandemTableColumnAlign",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<DecorationSet>({
+        key: tableColumnAlignPluginKey,
+        state: {
+          init: (_config, state) => buildTableAlignDecorations(state.doc),
+          // Rebuilt rather than mapped forward: an `align` change arrives as a
+          // step that sets the attribute, and a structural edit invalidates every
+          // column index in the table anyway. `NodeType.eq` compares attrs by
+          // value, so an identical rebuilt decoration does not redraw.
+          apply: (tr, previous) => (tr.docChanged ? buildTableAlignDecorations(tr.doc) : previous),
+        },
+        props: {
+          decorations(state) {
+            return tableColumnAlignPluginKey.getState(state) ?? DecorationSet.empty;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/src/client/editor/extensions/table-column-align.ts
+++ b/src/client/editor/extensions/table-column-align.ts
@@ -8,7 +8,7 @@ import { Decoration, DecorationSet } from "@tiptap/pm/view";
  * Render GFM column alignment on table cells (#995).
  *
  * #1462 made the alignment *survive*: the server writes mdast's per-column
- * `align` array as a JSON string on the table element (`mdast-ydoc.ts:231`) and
+ * `align` array as a JSON string on the table element (`mdast-ydoc.ts:232`) and
  * `TableWithAlignment` declares the attribute so `computeAttrs` stops discarding
  * it. Nothing rendered it — `editor.css` had no `text-align` at all — so a
  * document's alignment was invisible even though the data was intact.
@@ -58,20 +58,31 @@ import { Decoration, DecorationSet } from "@tiptap/pm/view";
  *
  * ## Two independent guards, and neither covers the other's case
  *
- * 1. **`relPos === 0` is a sentinel, not a position.** `computeMap` pre-fills the
- *    grid with `0` (`prosemirror-tables/dist/index.js:121`) and LEAVES those
- *    zeros for a short row, recording `{type:"missing"}` in `map.problems`. Zero
- *    is never a real cell offset — `pos` is incremented before the first cell of
- *    every row — but `table.nodeAt(0)` returns the first `tableRow`, NOT null. So
- *    a bare existence check passes, and `Decoration.node` spanning a `<tr>`
- *    exactly is *legal* (`NodeType.valid()` only requires the range to span a
- *    non-text node exactly) and is accepted with no warning. `text-align` on a
- *    `<tr>` then inherits into every cell in that row without its own class, so
- *    one ragged row can centre an entire header. Ragged tables are reachable:
- *    `mdast-ydoc.ts:233-250` does not pad short rows, and `fixTables` runs from
- *    `tableEditing()`'s `appendTransaction`, which `EditorState.create` never
- *    calls. Hence the explicit skip AND the `tableRole` check below — existence
- *    alone is not the question, role is.
+ * 1. **The cell guard tests ROLE, not existence, because of a sentinel.**
+ *    `computeMap` pre-fills the grid with `0`
+ *    (`prosemirror-tables/dist/index.js:124`) and LEAVES those zeros for a short
+ *    row, recording `{type:"missing"}` in `map.problems`. Zero is never a real
+ *    cell offset — `pos` is incremented at `index.js:127`, before the first cell
+ *    of every row — but `table.nodeAt(0)` returns the first `tableRow`, NOT
+ *    null. So a bare existence check passes, and `Decoration.node` spanning a
+ *    `<tr>` exactly is *legal* (`NodeType.valid()` only requires the range to
+ *    span a non-text node exactly) and is accepted with no warning. `text-align`
+ *    on a `<tr>` then inherits into every cell in that row without its own
+ *    class, so one ragged row can centre an entire header. Ragged tables are
+ *    reachable: `mdast-ydoc.ts:233-250` does not pad short rows, and `fixTables`
+ *    runs from `tableEditing()`'s `appendTransaction`, which
+ *    `EditorState.create` never calls.
+ *
+ *    An earlier revision also carried an explicit `if (relPos === 0) continue;`
+ *    ahead of this check and described the two as independent. They are not:
+ *    every sentinel resolves to a `tableRow`, so the role check already refuses
+ *    it, and deleting the skip left the whole suite green. The skip is gone and
+ *    the role check is the single cover — which is also the more durable of the
+ *    two, since it states the invariant the code actually needs ("only decorate
+ *    a cell") in schema terms, whereas `=== 0` hard-codes a private upstream
+ *    detail that would silently stop matching if `computeMap` ever pre-filled
+ *    with something other than zero. T8 pins it: weakening this line to a bare
+ *    `!cell` fails that test.
  * 2. **`align.length !== map.width` bails out entirely.** The `align` array is
  *    NOT maintained by the column commands: `addColumnBefore` on a 3-column table
  *    leaves 3 entries against 4 columns, so every column from the insertion point
@@ -176,13 +187,14 @@ function collectTableDecorations(table: PMNode, pos: number, out: Decoration[]):
 
   for (let i = 0; i < map.map.length; i++) {
     const relPos = map.map[i];
-    // Guard 1. A zero is computeMap's unfilled-slot sentinel, not a position.
-    if (relPos === 0) continue;
     // A colspan/rowspan cell occupies several slots; the FIRST is its top-left,
     // which is why `i % map.width` is its leftmost column.
     if (seen.has(relPos)) continue;
     seen.add(relPos);
 
+    // Guard 1. Role, not existence — see the sentinel note in the header. An
+    // unfilled slot holds `0`, and `table.nodeAt(0)` returns the first
+    // tableRow rather than null, so `!cell` alone would let a <tr> through.
     const cell = table.nodeAt(relPos);
     const role = cell?.type.spec.tableRole;
     if (!cell || (role !== "cell" && role !== "header_cell")) continue;

--- a/tests/client/table-column-align.test.ts
+++ b/tests/client/table-column-align.test.ts
@@ -302,7 +302,7 @@ describe("T7 — the decoration cannot leak into the document", () => {
 });
 
 describe("T8 — a ragged table must not decorate its rows", () => {
-  it("skips TableMap's unfilled-slot sentinel", () => {
+  it("refuses to decorate a row a TableMap sentinel resolves to", () => {
     // `computeMap` pre-fills its grid with 0 and leaves those zeros for a short
     // row. Zero is never a real cell offset, but `table.nodeAt(0)` returns the
     // first tableRow rather than null, and a node decoration spanning a <tr>
@@ -314,7 +314,16 @@ describe("T8 — a ragged table must not decorate its rows", () => {
     // never calls.
     //
     // Note the width guard does NOT cover this — width is 3 and align has 3
-    // entries — so this is the only test that holds the sentinel skip.
+    // entries — so this is the only test that holds the cell guard's ROLE
+    // check. Weakening that line to a bare `!cell` fails here and nowhere else.
+    //
+    // The <tr> loop below is the robust half of this test, not the
+    // `cellAlignments` expectation: the short row is row 1, so its sentinel
+    // slots land on align[1] ("center"), which is non-null and therefore
+    // emits. A ragged fixture whose MISSING columns happened to be null-aligned
+    // would leave `value === null` and let the mutant pass, so the centre and
+    // right columns here are load-bearing for what this can see. Keep them
+    // non-null if you edit the fixture.
     const editor = mount({
       content: fromMarkdown("| a | b | c |\n| :- | :-: | -: |\n| 1 |\n| 2 | 3 | 4 |\n"),
     });

--- a/tests/client/table-column-align.test.ts
+++ b/tests/client/table-column-align.test.ts
@@ -1,0 +1,335 @@
+/**
+ * GFM column alignment must reach the editor's cells (#995).
+ *
+ * #1462 stopped `table.align` being destroyed; nothing rendered it, so a
+ * document's alignment was invisible. `extensions/table-column-align.ts` maps
+ * each cell to its column through prosemirror-tables' `TableMap` and decorates
+ * it. Every test here builds its editor from `buildSchemaExtensions()`, so a
+ * plugin that works but is not registered in production fails this file rather
+ * than passing it.
+ *
+ * The mapping is the part that fails silently: `row.child(i) → column i` is
+ * correct for a rectangular table and wrong for every table the #923 context
+ * menu can produce. T3/T4 are the tests that separate the two implementations.
+ */
+
+import { Editor } from "@tiptap/core";
+import Collaboration from "@tiptap/extension-collaboration";
+import { DOMParser as PMDOMParser } from "@tiptap/pm/model";
+import { CellSelection } from "@tiptap/pm/tables";
+import { afterEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
+import { loadMarkdown, saveMarkdown } from "../../src/server/file-io/markdown";
+import { productionSchema, yDocToPmNode } from "./editor-roundtrip-harness";
+
+const ALIGNED_MD = "| L | C | R |\n| :- | :-: | -: |\n| 1 | 2 | 3 |\n";
+
+const mounted: Array<{ editor: Editor; container: HTMLDivElement }> = [];
+
+afterEach(() => {
+  for (const { editor, container } of mounted.splice(0)) {
+    editor.destroy();
+    container.remove();
+  }
+});
+
+/** A real mounted editor — decorations only exist once there is an EditorView. */
+function mount(opts: { content?: unknown; ydoc?: Y.Doc } = {}): Editor {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const editor = new Editor({
+    element: container,
+    extensions: opts.ydoc
+      ? [...buildSchemaExtensions(), Collaboration.configure({ document: opts.ydoc })]
+      : buildSchemaExtensions(),
+    ...(opts.content === undefined ? {} : { content: opts.content }),
+  });
+  mounted.push({ editor, container });
+  return editor;
+}
+
+/**
+ * Markdown → Y.Doc → ProseMirror JSON, through the REAL server loader.
+ *
+ * Preferred over hand-written HTML wherever the fixture allows it: it proves the
+ * whole chain (mdast `align` → Y attribute → PM attribute → decoration) rather
+ * than the last link of it. `attrs.align` arrives as the JSON STRING the server
+ * wrote — the only shape production ever produces.
+ */
+function fromMarkdown(markdown: string): unknown {
+  const ydoc = new Y.Doc();
+  loadMarkdown(ydoc, markdown);
+  const node = yDocToPmNode(ydoc, productionSchema());
+  ydoc.destroy();
+  return node.toJSON();
+}
+
+/** The alignment class on an element, or null. */
+function alignOf(el: Element): string | null {
+  for (const token of Array.from(el.classList)) {
+    if (token.startsWith("tandem-cell-align-")) return token.slice("tandem-cell-align-".length);
+  }
+  return null;
+}
+
+/** Alignment of every cell, in document order, tagged with its element name. */
+function cellAlignments(editor: Editor): string[] {
+  return Array.from(editor.view.dom.querySelectorAll("th, td")).map(
+    (cell) => `${cell.tagName.toLowerCase()}:${alignOf(cell) ?? "-"}`,
+  );
+}
+
+/** Document positions of every cell node, in document order. */
+function cellPositions(editor: Editor): number[] {
+  const positions: number[] = [];
+  editor.state.doc.descendants((node, pos) => {
+    const role = node.type.spec.tableRole;
+    if (role === "cell" || role === "header_cell") positions.push(pos);
+    return true;
+  });
+  return positions;
+}
+
+describe("T1 — alignment declared in the file reaches the cells", () => {
+  it("renders left/center/right on header AND body cells", () => {
+    const editor = mount({ content: fromMarkdown(ALIGNED_MD) });
+
+    // Header cells included deliberately: GFM alignment governs the whole
+    // column, and a body-rows-only implementation passes without this half.
+    expect(cellAlignments(editor)).toEqual([
+      "th:left",
+      "th:center",
+      "th:right",
+      "td:left",
+      "td:center",
+      "td:right",
+    ]);
+  });
+
+  it("reads the JSON-string shape the server actually writes", () => {
+    // Pins the assumption the parser is built on. `renderHTML` is
+    // `String(attrs.align)`, so an array would come back comma-joined from a DOM
+    // re-read, never as JSON — there is no already-parsed-array branch to test.
+    const editor = mount({ content: fromMarkdown(ALIGNED_MD) });
+    expect(editor.state.doc.child(0).attrs.align).toBe('["left","center","right"]');
+  });
+});
+
+describe("T2 — an unaligned table is left alone", () => {
+  it("decorates nothing when every column is null", () => {
+    // The negative control. A decorate-everything or default-to-left
+    // implementation passes T1 and fails here. This is also every table Tandem's
+    // own `/table` command creates.
+    const editor = mount({ content: fromMarkdown("| a | b |\n| --- | --- |\n| 1 | 2 |\n") });
+
+    expect(editor.state.doc.child(0).attrs.align).toBe("[null,null]");
+    expect(cellAlignments(editor)).toEqual(["th:-", "th:-", "td:-", "td:-"]);
+  });
+});
+
+describe("T3 — colspan does not shift the mapping", () => {
+  it("gives the cell after a colspan its true column", () => {
+    const editor = mount({
+      content:
+        `<table data-align='["left","center","right"]'><tbody>` +
+        '<tr><td colspan="2">A</td><td>B</td></tr>' +
+        "<tr><td>C</td><td>D</td><td>E</td></tr>" +
+        "</tbody></table>",
+    });
+
+    // A spans columns 0-1 and takes its LEFTMOST column's alignment; B is column
+    // 2, not column 1. `row.child(i) → column i` gives B "center" and fails.
+    expect(cellAlignments(editor)).toEqual([
+      "td:left",
+      "td:right",
+      "td:left",
+      "td:center",
+      "td:right",
+    ]);
+  });
+});
+
+describe("T4 — rowspan does not shift the mapping", () => {
+  it("gives a row under a rowspan its true columns", () => {
+    const editor = mount({
+      content:
+        `<table data-align='["left","center","right"]'><tbody>` +
+        '<tr><td rowspan="2">A</td><td>B</td><td>C</td></tr>' +
+        "<tr><td>D</td><td>E</td></tr>" +
+        "</tbody></table>",
+    });
+
+    // THE load-bearing case. Row 2 contains no spanning cell of its own, yet its
+    // children are columns 1 and 2 because A occupies column 0 from above. The
+    // map is [p0,p1,p2, p0,p3,p4]. A naive child-index mapping gives D/E
+    // "left"/"center" — shifting a whole table's alignment one column, silently.
+    expect(cellAlignments(editor)).toEqual([
+      "td:left",
+      "td:center",
+      "td:right",
+      "td:center",
+      "td:right",
+    ]);
+  });
+});
+
+describe("T5 — structural edits from the #923 context menu", () => {
+  // All six table ops funnel through `editor.commands.*`
+  // (`context-menu/dispatch.ts:103-124`), so driving the commands drives the
+  // menu.
+
+  it("stops decorating once a column op desynchronises align from the columns", () => {
+    const editor = mount({ content: fromMarkdown(ALIGNED_MD) });
+    expect(cellAlignments(editor)).toContain("th:center");
+
+    editor.commands.setTextSelection(cellPositions(editor)[1] + 2);
+    expect(editor.commands.addColumnBefore()).toBe(true);
+
+    // The `align` array is NOT maintained by the column commands — it still has
+    // 3 entries against 4 columns. Rendering it anyway would put every column
+    // from the insertion point one place wrong and silently drop the last one,
+    // with no recourse for the user while the alignment UI is unbuilt. The width
+    // guard bails instead, which is exactly the pre-#995 behaviour for this
+    // table. Re-indexing the array is tracked as #1535; when that lands, this
+    // expectation changes to the corrected alignment.
+    expect(editor.state.doc.child(0).attrs.align).toBe('["left","center","right"]');
+    expect(cellAlignments(editor).every((entry) => entry.endsWith(":-"))).toBe(true);
+  });
+
+  it("stops decorating after a column delete too", () => {
+    const editor = mount({ content: fromMarkdown(ALIGNED_MD) });
+
+    editor.commands.setTextSelection(cellPositions(editor)[1] + 2);
+    expect(editor.commands.deleteColumn()).toBe(true);
+
+    expect(cellAlignments(editor).every((entry) => entry.endsWith(":-"))).toBe(true);
+  });
+
+  it("recomputes — not maps forward — across a merge that keeps the column count", () => {
+    const editor = mount({ content: fromMarkdown(ALIGNED_MD) });
+
+    // Merge the first two BODY cells. Column count is unchanged, so the width
+    // guard stays open and the decorations must survive, recomputed against the
+    // new structure: the merged cell takes its leftmost column's alignment.
+    const cells = cellPositions(editor);
+    const selection = CellSelection.create(editor.state.doc, cells[3], cells[4]);
+    editor.view.dispatch(editor.state.tr.setSelection(selection));
+    expect(editor.commands.mergeCells()).toBe(true);
+
+    expect(cellAlignments(editor)).toEqual([
+      "th:left",
+      "th:center",
+      "th:right",
+      "td:left",
+      "td:right",
+    ]);
+    // An implementation that mapped an old DecorationSet forward instead of
+    // rebuilding keeps a stale decoration on the vanished cell and fails above.
+  });
+});
+
+describe("T6 — values off the disk are not trusted", () => {
+  it("ignores non-alignment values and never emits them as class tokens", () => {
+    const editor = mount({
+      content:
+        `<table data-align='["left","not-an-align","x y z","center"]'><tbody>` +
+        "<tr><td>A</td><td>B</td><td>C</td><td>D</td></tr>" +
+        "</tbody></table>",
+    });
+
+    // Four columns, four entries, so the width guard is open and the allowlist is
+    // what is under test. Without it, `x y z` injects three arbitrary class
+    // tokens onto editor DOM from a file that may not be the user's own.
+    expect(cellAlignments(editor)).toEqual(["td:left", "td:-", "td:-", "td:center"]);
+    expect(editor.view.dom.innerHTML).not.toContain("not-an-align");
+    expect(editor.view.dom.innerHTML).not.toContain("x y z");
+  });
+
+  it("survives an unparseable attribute instead of throwing on open", () => {
+    const editor = mount({
+      content:
+        `<table data-align='{"nope'><tbody>` + "<tr><td>A</td><td>B</td></tr>" + "</tbody></table>",
+    });
+
+    expect(cellAlignments(editor)).toEqual(["td:-", "td:-"]);
+  });
+});
+
+describe("T7 — the decoration cannot leak into the document", () => {
+  // The #1448 hazard, and the only invariant this change sits near: node
+  // decorations add a `class` to the live <td>, and `readDOMChange` re-parses
+  // that DOM. Asserted against a real decorated view, because the
+  // `editorRoundTrip` harness never constructs an EditorView and therefore
+  // cannot see a decoration at all.
+
+  it("re-parsing the live decorated DOM gains no cell attribute", () => {
+    const editor = mount({ content: fromMarkdown(ALIGNED_MD) });
+    // Guard against asserting on an undecorated view by accident.
+    expect(editor.view.dom.innerHTML).toContain("tandem-cell-align-center");
+
+    const reparsed = PMDOMParser.fromSchema(editor.state.schema).parse(editor.view.dom);
+
+    let cells = 0;
+    reparsed.descendants((node) => {
+      const role = node.type.spec.tableRole;
+      if (role !== "cell" && role !== "header_cell") return true;
+      cells++;
+      expect(Object.keys(node.attrs).sort()).toEqual(["colspan", "colwidth", "rowspan"]);
+      return true;
+    });
+    expect(cells).toBe(6);
+  });
+
+  it("an edit through a decorated table writes clean markdown back to the Y.Doc", () => {
+    // The path that actually reaches disk: real Collaboration sync, real edit,
+    // real `saveMarkdown`.
+    const ydoc = new Y.Doc();
+    loadMarkdown(ydoc, ALIGNED_MD);
+    const editor = mount({ ydoc });
+    expect(editor.view.dom.innerHTML).toContain("tandem-cell-align-right");
+
+    editor.commands.setTextSelection(cellPositions(editor)[3] + 2);
+    editor.commands.insertContent("X");
+
+    const saved = saveMarkdown(ydoc);
+    expect(saved).not.toContain("class");
+    expect(saved).not.toContain("tandem-cell-align");
+    // Alignment itself still round-trips through an edit made while decorated.
+    expect(saved.split("\n")[1]).toBe("| :- | :-: | -: |");
+    ydoc.destroy();
+  });
+});
+
+describe("T8 — a ragged table must not decorate its rows", () => {
+  it("skips TableMap's unfilled-slot sentinel", () => {
+    // `computeMap` pre-fills its grid with 0 and leaves those zeros for a short
+    // row. Zero is never a real cell offset, but `table.nodeAt(0)` returns the
+    // first tableRow rather than null, and a node decoration spanning a <tr>
+    // exactly is LEGAL — so an existence-only guard silently decorates the row,
+    // and `text-align` on a <tr> inherits into every undecorated cell in it.
+    //
+    // Reachable: `mdast-ydoc.ts` does not pad short rows, and `fixTables` runs
+    // from `tableEditing()`'s appendTransaction, which `EditorState.create`
+    // never calls.
+    //
+    // Note the width guard does NOT cover this — width is 3 and align has 3
+    // entries — so this is the only test that holds the sentinel skip.
+    const editor = mount({
+      content: fromMarkdown("| a | b | c |\n| :- | :-: | -: |\n| 1 |\n| 2 | 3 | 4 |\n"),
+    });
+
+    for (const row of Array.from(editor.view.dom.querySelectorAll("tr"))) {
+      expect(alignOf(row), `<tr> must never carry an alignment class: ${row.outerHTML}`).toBeNull();
+    }
+    expect(cellAlignments(editor)).toEqual([
+      "th:left",
+      "th:center",
+      "th:right",
+      "td:left",
+      "td:left",
+      "td:center",
+      "td:right",
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #995. Refs #1462 (the preservation half this depends on), #1535 (the deferred remainder).

Scope is the re-scope Bryan set on the issue thread: **render what the file already says.** No control to *set* alignment — that stays unbuilt until real use asks for it. Nothing in `context-menu/types.ts`, `dispatch.ts` or `src-tauri/src/lib.rs`, so this does not collide with #1361 over the `dispatch.ts` exhaustiveness guard.

## Root cause

#1462 made `table.align` survive the Y.Doc round trip. Nothing ever rendered it: `editor.css` contained no `text-align` at all, and the `data-align` attribute `TableWithAlignment` emits had **no consumer anywhere in `src/`** — three grep hits, all inside the extension that produces it. A document declaring `| :- | :-: | -: |` loaded, saved and reopened correctly while displaying every column flush left.

The gap is a shape mismatch. Alignment is stored **once, on the table**, indexed by column; `text-align` has to be applied **per cell**. Nothing bridges that declaratively:

- **CSS cannot.** A column's cells are not siblings — they are one cell from each row — so the only reach is `:nth-child`, which counts child index, and `colspan`/`rowspan` desynchronise child index from column index.
- **`<colgroup>`/`<col>` cannot.** `text-align` is not among the properties that apply to a `col` element (CSS 2.1 §17.3). This one is a live trap: Tiptap's `TableView` already renders a colgroup for column resizing, so the wrong fix looks available and silently does nothing.

## The fix

A decoration-only extension, `src/client/editor/extensions/table-column-align.ts` — the first per-cell table decoration in the codebase. It resolves each cell's column at view time and applies a class. **It writes nothing**: no `doc.transact`, no `Y.Map` write, no ProseMirror transaction. Critical Rule 2 is untouched by construction rather than by care.

The mapping is prosemirror-tables' own `TableMap`, never a hand-rolled child index. `TableMap` expands `colspan`/`rowspan` into a dense grid, so a cell spanning down from row 1 still occupies its column in row 2 and every later cell in that row keeps its true column index. The set is rebuilt on `docChanged` rather than mapped forward, so the six #923 context-menu operations cannot leave it stale.

**Two guards, and neither subsumes the other** — this was the sharpest review finding:

1. **`relPos === 0` is `computeMap`'s unfilled-slot sentinel, not a position.** It is left in the grid for a short row. Zero is never a real cell offset (`pos` is incremented past the row's opening token before the first cell of every row), but `table.nodeAt(0)` returns the **first `tableRow`**, not null — so an existence-only check passes, and a node decoration spanning a `<tr>` exactly is *legal*. `text-align` on a `<tr>` then inherits into every undecorated cell in that row, so one ragged row silently centres a whole header. Ragged tables are reachable: `mdast-ydoc.ts` does not pad short rows, and `fixTables` runs from `tableEditing()`'s `appendTransaction`, which `EditorState.create` never calls.
2. **`align.length !== map.width` bails out entirely.** The column commands do not maintain the `align` array, so after an insert or delete it describes a different table. Showing nothing is exactly the pre-#995 behaviour for that table, whereas showing a confident wrong answer has no user recourse while the alignment UI is unbuilt.

For a ragged table the width guard *passes* (width 3, align length 3) and only the sentinel skip protects; for a column-inserted table the sentinel never appears and only the width guard does. Both are load-bearing, independently.

## Deliberate visual change, stated rather than discovered

**Header cells now default to `text-align: left`.** The UA stylesheet centres `th` and `editor.css` never overrode it, so every header cell in Tandem was centred. Left alone, a table declaring alignment on some columns but not others would render its **unaligned** header centred between an aligned neighbour on each side — the one column with nothing declared being the one that looks deliberately centred. Left matches the body cells and matches how GitHub and every reset-using GFM renderer display an unaligned header. This changes the appearance of existing unaligned tables and wants an eye in the manual pass.

## What is deferred, and why the guard exists — #1535

The column commands rewrite the user's file. With the cursor in column 1 of `| L | C | R |` / `| :- | :-: | -: |`, `addColumnBefore` leaves the 3-entry array against 4 columns: the new empty column acquires `center`, the original centre becomes `right`, and the original right column loses its alignment — **on disk**. `deleteColumn` is symmetric. That is pre-existing and invisible today; it becomes visible the moment alignment renders. Re-indexing the array needs command wrappers plus a document write, which is the "editing alignment" half this PR deliberately does not open, so it is tracked as **#1535** and the width guard is what stops the editor from confidently displaying the corrupted result in the meantime. Both the guard and the test that pins it cite #1535 in-line, so the deferral has a tracked home rather than living only in this description.

## Decoration ordering

Registering in `buildSchemaExtensions()` places this plugin *before* annotation/authorship/heading-collapse (#650). That is inert, and for a narrower reason than the usual framing: `computeOuterDeco` (`prosemirror-view/dist/index.js:1663`) concatenates **both** `class` and `style` — neither replaces the other. The difference is what concatenation means. Class tokens coexist and specificity decides; concatenated styles are applied via `dom.style.cssText +=`, so two decorations setting `text-align` would resolve last-declaration-wins, i.e. registration order would silently pick the winner. An inventory of every `Decoration.node` in `src/client` (`annotationPing`, `awareness`, `heading-collapse`, `authorship`) shows all of them emit `class` or `data-*` and **none emits `text-align`**, so there is nothing to race with. Keeping this a `class` rather than an inline `style` is what keeps it that way, and the comment says so.

Registration lives in `buildSchemaExtensions()` despite adding no schema, because that builder is what the client tests build editors from — in `Editor.svelte` the whole suite would pass with the feature unwired in production. `getSchema()` resolves nodes and marks only and never calls `addProseMirrorPlugins`, so the schema is byte-identical. `Editor.svelte`'s comment claiming "no new nodes/marks ⇒ stays out of `buildSchemaExtensions()`" would have become false, so it is corrected to name conditional inclusion as Typography's real discriminator.

## Tests — `tests/client/table-column-align.test.ts`, 13 tests

Every test builds its editor from `buildSchemaExtensions()`, so a plugin that works but is not registered fails the file. Fixtures run through the real server loader (`loadMarkdown` → `yDocToPmNode`) wherever the shape allows, so T1 exercises mdast `align` → Y attribute → PM attribute → decoration → DOM rather than the last link only.

| Test | What it catches |
|---|---|
| T1 | The bug, end to end, on header **and** body cells |
| T2 | Negative control — an unaligned table is decorated nowhere |
| T3 | `colspan` does not shift the mapping |
| T4 | `rowspan` does not shift the mapping — a row with no spanning cell of its own whose children are still columns 1 and 2 |
| T5 | The #923 command path: column ops stop decoration (pins the width guard); a merge keeps it and recomputes |
| T6 | Values off disk are allowlisted — no junk class token, no throw on malformed JSON |
| T7 | The decoration class cannot enter `node.attrs` (live re-parse) or reach disk (Collaboration + `saveMarkdown`) |
| T8 | The ragged-table sentinel |

**The tests were proved load-bearing by building each wrong implementation and running it**, not by stashing once:

| Counterfactual | Result |
|---|---|
| Extension unregistered | 9 of 13 fail; the 4 survivors are the pure absence-assertions |
| Bare `!cell` guard (no sentinel skip) | **T8 alone fails**, with `<tr class="tandem-cell-align-center">` in the assertion — the mechanism visible in the failure |
| Naive `row.child(i) → column i` | T3, T4, T5-merge fail |
| Width guard removed | Both T5 column-op tests fail |

The old T7 was replaced during review because it was **inert**: `editorRoundTrip()` never constructs an `EditorView` and builds its schema with `getSchema()`, so no decoration exists in the DOM it re-parses — it passed identically with and without this change, and duplicated the existing V4 block at `editor-roundtrip.test.ts:91-123`. The replacement asserts against a real decorated view.

## Gates

| Gate | Result |
|---|---|
| `npx biome check src/ tests/` | clean, 1091 files |
| `npm run typecheck` | exit 0 — `1340 FILES 0 ERRORS 0 WARNINGS` |
| `npm run check:tokens` | exit 0; 12 warnings, all pre-existing `border-radius`, count identical with `editor.css` stashed |
| `npx playwright test tests/e2e/slash-command-menu.spec.ts` | **9 passed (55.6s)** — harness did not refuse, ports were free |
| `npx vitest --run --maxWorkers=2` (full) | 7487 passed, **4 failed**, 27 skipped — twice, identical counts |
| `tests/client/table-column-align.test.ts` | 13 passed |
| pre-push hook (biome + vitest + `cargo test`) | passed — the push was rejected otherwise; `cargo test` lines visible in the log, the vitest summary was not captured in the output I have |

**The 4 full-suite failures are not from this change.** They are `roundtrip-repo-metric`, `useTauriFileDrop`, `docx-size-gate` and `markdown-escaping` — every one a wall-clock budget or timeout assertion, on a box shared with ~25 agent worktrees (measured load average 54, 56 concurrent vitest processes). Re-running exactly those files **with** the change and **on a clean tree** gave byte-identical failures both ways. Independently: five of six wall-clock-budgeted files fail on **clean master (`0df1c991`, zero local modifications) at load 49**, and at top priority with a single worker the `markdown-escaping` ReDoS guard still reports **2038ms against a 2000ms budget on clean master** — roughly 2% headroom on this hardware irrespective of load.

## Unverified

- **No visual confirmation of the `th` `text-align: left` change.** It is CSS-only; the assertions are happy-dom class checks, and nobody has looked at it in a browser. It needs an eye in the manual pass.
- No clean full-suite run was ever observed on this machine, so "the 4 failures are load-induced" rests on the clean-master comparison above rather than on a green run.

---
_Generated by [Claude Code](https://claude.ai/code/session_018DdaCvomDgPsumrDAmNH13)_