### PR TITLE
fix(authorship): pin #1481's mirror-free assumption, and guard it at runtime

### DIFF
--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -696,6 +696,44 @@ export function _resetAuthorshipWarnLatch(): void {
 }
 
 /**
+ * Index of the first map in `mapping` that has a mirror partner, or `null` when
+ * none has one. The runtime half of #1481's mirror-free assumption — see the
+ * survey at the reap's `toBefore` construction for what that assumption is.
+ *
+ * `getMirror` rather than the `mirror` array itself: the array is `@internal`
+ * and declared only as a constructor parameter in the published typings, so
+ * reading it back needs a cast — and a cast is what would turn a later rename
+ * of the field into a silent `undefined` here. The accessor is public.
+ *
+ * Exported for the test, which is the only caller that can hand this a mapping
+ * WITH a mirror. Nothing in this stack produces one, so a test driving a real
+ * editor can only ever observe the `null` answer, and would pass just as well
+ * against a function that returned `null` unconditionally.
+ */
+export function firstMirroredMapIndex(mapping: Mapping): number | null {
+  for (let i = 0; i < mapping.maps.length; i++) {
+    if (mapping.getMirror(i) !== undefined) return i;
+  }
+  return null;
+}
+
+/**
+ * DEV-only companion to the above. Call sites guard with `import.meta.env.DEV`
+ * so this is dead code in a production build, and `warnOnce` holds it to one
+ * line per session rather than one per transaction.
+ */
+function warnOnMirroredMapping(mapping: Mapping): void {
+  const index = firstMirroredMapIndex(mapping);
+  if (index === null) return;
+  warnOnce(
+    "mapping-mirror",
+    `[authorship] Transaction mapping carries a mirror (map ${index} <-> ${mapping.getMirror(index)}). ` +
+      "The reap's before-frame mapping drops it, which #1481 established was safe only because " +
+      "nothing in this stack sets one. Re-open #1481 rather than silencing this.",
+  );
+}
+
+/**
  * Resolve an AuthorshipRange to ProseMirror positions.
  *
  * THE FALLBACK ORDERING IS THE WHOLE POINT, and it used to be wrong. An entry
@@ -1163,30 +1201,64 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions, Authorshi
             // Neither matters today, because nothing in this stack has a mirror
             // to lose. `Transform.addStep` is the only writer to a
             // transaction's mapping and calls `appendMap(step.getMap())` with
-            // no `mirrors` argument, so EVERY editor command — list wrap,
-            // `liftListItem`, `sinkListItem`, blockquote, heading toggle —
-            // appends mirror-free. Measured over all of those plus history
-            // undo: `mapping.mirror` is `undefined` in every case, and the
-            // before-frame span this recovers is exact.
+            // no `mirrors` argument, so every editor command appends
+            // mirror-free by construction. The structural five — list wrap,
+            // `liftListItem`, `sinkListItem`, blockquote, heading toggle — are
+            // each driven through a real editor in
+            // `tests/client/authorship-stamp.test.ts`, which reads each
+            // dispatched mapping back through `getMirror`. Those five are the
+            // evidence for this paragraph — do not restate it as a measurement
+            // without them, since a claim no test reproduces is exactly what
+            // rots here.
+            //
+            // UNDO IS NOT ON THAT LIST, and its absence is not an omission.
+            // There is no prosemirror-history plugin in this editor to undo
+            // through — `editor-extensions.ts` builds
+            // `StarterKit.configure({ history: false })` because Yjs owns
+            // undo — and the Yjs UndoManager's replay arrives as a transaction
+            // y-prosemirror tags with `ySyncPluginKey`, which returns at the
+            // guard near the top of this handler and never reaches this line.
+            // (`tests/client/authorship-undo-redo.test.ts` drives that path.)
             //
             // The two packages that do pass `mirrors` never reach a dispatched
             // transaction's mapping. `prosemirror-history` mirrors only its own
             // local `remap` (in `popEvent`, `remapping` and `compress`) and
-            // dispatches through `transform.maybeStep` → `addStep`.
+            // dispatches through `transform.maybeStep` → `addStep` — and, per
+            // the paragraph above, is not registered here at all.
             // `prosemirror-collab`'s `rebaseSteps` is the one real producer,
             // and it is INSTALLED but unimported — it ships as a dependency of
             // `@tiptap/pm`, so it is one import away, not one `npm install`
             // away. Tandem syncs through y-prosemirror, which never constructs
             // a `Mapping` at all.
             //
-            // So adding a collab plugin is the single change that would
-            // invalidate this, and it would do so silently. The static import
-            // walk in `tests/client/authorship-stamp.test.ts` is what catches
-            // that; the two reap tests beside it pin the behaviour this
-            // recovers. Note the asymmetry with `toFinal` above, which DOES
-            // carry a mirror through (`Mapping.slice` preserves it): that
-            // difference is invisible only for as long as the field stays
-            // empty, which is what those tests are for.
+            // WHAT WOULD INVALIDATE THIS, AND WHAT WATCHES FOR IT. Two guards,
+            // because neither covers the other's route:
+            //
+            //  - The static import walk in
+            //    `tests/client/authorship-stamp.test.ts` asserts that nothing
+            //    under `src/` imports either collab specifier. It is a CI gate,
+            //    and it catches the obvious route: someone adds a collab plugin
+            //    here. It is also the NARROWER guard, because it matches a
+            //    literal specifier. A collab plugin arriving transitively — a
+            //    third-party Tiptap collaboration extension, a Hocuspocus
+            //    ProseMirror adapter; `@tiptap/pm/collab` is itself only a
+            //    re-export wrapper, so one more wrapper layer is the
+            //    ecosystem's ordinary idiom — or a specifier assembled by
+            //    concatenation, leaves zero matches under `src/` while
+            //    `transaction.mapping.mirror` becomes populated, and the walk
+            //    stays green forever.
+            //  - The DEV-only `warnOnce` on the next line is
+            //    route-independent: it reads the mapping actually in hand, so
+            //    it speaks however the mirror arrived. It is the weaker guard
+            //    in the other direction — it only speaks when someone runs this
+            //    path in a dev build — which is why both are here rather than
+            //    either alone.
+            //
+            // Note the asymmetry with `toFinal` above, which DOES carry a
+            // mirror through (`Mapping.slice` preserves it): that difference is
+            // invisible only for as long as the field stays empty, which is
+            // what the two guards are for.
+            if (import.meta.env.DEV) warnOnMirroredMapping(transaction.mapping);
             toBefore ??= new Mapping(transaction.mapping.maps.slice(0, i)).invert();
             const span = pmSelectionToFlat(beforeDoc, {
               from: toPmPos(toBefore.map(oldStart, 1)),

--- a/src/client/editor/extensions/authorship.ts
+++ b/src/client/editor/extensions/authorship.ts
@@ -1143,6 +1143,50 @@ export const AuthorshipExtension = Extension.create<AuthorshipOptions, Authorshi
             // EVERY step, not of none — which silently collapsed every reap
             // range to zero width and made the reap a no-op that nothing threw
             // over.
+            //
+            // THE `mirror` ARRAY GOES WITH IT, DELIBERATELY (#1481). The fix
+            // suggested there — `new Mapping(maps, mirror?.filter(...))` — is
+            // wrong twice over, quite apart from being unreachable.
+            //
+            // 1. `mirror` is a FLAT ARRAY OF PAIRS read by parity:
+            //    `this.mirror[i + (i % 2 ? -1 : 1)]` (prosemirror-transform,
+            //    `getMirror`). Filtering it element-wise desynchronises every
+            //    pair after the first drop — keep index n, drop its partner m,
+            //    and `getMirror` starts answering with a neighbouring pair's
+            //    map index. That is a confidently WRONG answer, not a missing
+            //    one, which is worse than the approximation it set out to fix.
+            // 2. `mirror` is `@internal`. The published typings declare it as a
+            //    constructor parameter only, never as a property, so reading it
+            //    back needs a cast — and a cast is exactly what turns a later
+            //    rename of the field into a silent `undefined` here.
+            //
+            // Neither matters today, because nothing in this stack has a mirror
+            // to lose. `Transform.addStep` is the only writer to a
+            // transaction's mapping and calls `appendMap(step.getMap())` with
+            // no `mirrors` argument, so EVERY editor command — list wrap,
+            // `liftListItem`, `sinkListItem`, blockquote, heading toggle —
+            // appends mirror-free. Measured over all of those plus history
+            // undo: `mapping.mirror` is `undefined` in every case, and the
+            // before-frame span this recovers is exact.
+            //
+            // The two packages that do pass `mirrors` never reach a dispatched
+            // transaction's mapping. `prosemirror-history` mirrors only its own
+            // local `remap` (in `popEvent`, `remapping` and `compress`) and
+            // dispatches through `transform.maybeStep` → `addStep`.
+            // `prosemirror-collab`'s `rebaseSteps` is the one real producer,
+            // and it is INSTALLED but unimported — it ships as a dependency of
+            // `@tiptap/pm`, so it is one import away, not one `npm install`
+            // away. Tandem syncs through y-prosemirror, which never constructs
+            // a `Mapping` at all.
+            //
+            // So adding a collab plugin is the single change that would
+            // invalidate this, and it would do so silently. The static import
+            // walk in `tests/client/authorship-stamp.test.ts` is what catches
+            // that; the two reap tests beside it pin the behaviour this
+            // recovers. Note the asymmetry with `toFinal` above, which DOES
+            // carry a mirror through (`Mapping.slice` preserves it): that
+            // difference is invisible only for as long as the field stays
+            // empty, which is what those tests are for.
             toBefore ??= new Mapping(transaction.mapping.maps.slice(0, i)).invert();
             const span = pmSelectionToFlat(beforeDoc, {
               from: toPmPos(toBefore.map(oldStart, 1)),

--- a/tests/client/authorship-stamp.test.ts
+++ b/tests/client/authorship-stamp.test.ts
@@ -5,14 +5,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Editor, Extension } from "@tiptap/core";
 import type { Transaction } from "@tiptap/pm/state";
-import { findWrapping } from "@tiptap/pm/transform";
+import { findWrapping, Mapping, StepMap } from "@tiptap/pm/transform";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ySyncPluginKey } from "y-prosemirror";
 import * as Y from "yjs";
 import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
 import {
+  _resetAuthorshipWarnLatch,
   AUTHORSHIP_ORIGIN_META,
   AuthorshipExtension,
+  firstMirroredMapIndex,
 } from "../../src/client/editor/extensions/authorship";
 import { insertChatMarkdown } from "../../src/client/panels/chat-insert";
 import { applySuggestion } from "../../src/client/panels/useAnnotationReview.svelte";
@@ -242,9 +244,11 @@ describe("authorship stamp path", () => {
      * a replace-around. It does not, because nothing in this stack ever sets
      * a mirror; the long comment at that line records the survey.
      *
-     * WHAT THESE TESTS ARE FOR, PRECISELY. They do not test mirror handling —
+     * WHAT THE FIRST TWO ARE FOR, PRECISELY. They do not test mirror handling —
      * they cannot, because no transaction here carries a mirror, so a wrong
-     * filter of `undefined` is still `undefined` and would stay green. Their
+     * filter of `undefined` is still `undefined` and would stay green. (The
+     * DEV-guard cases at the bottom of this block do exercise a mirror, by
+     * fabricating one no editor in this repo can produce.) Their
      * value is that they are the first tests to drive `toBefore` with `i > 0`
      * THROUGH A STRUCTURAL STEP and then assert a REAP outcome. The multi-step
      * test above reaches `i = 1` but asserts only on insertion spans, and
@@ -311,6 +315,49 @@ describe("authorship stamp path", () => {
       expect(entries().map((e) => e.id)).not.toContain(stamped[0].id);
     });
 
+    /**
+     * A throwaway editor plus a transaction recorder, torn down whichever way
+     * `run` exits. Separate from the suite's shared `editor` because these
+     * cases need their own starting content (a list to lift out of, a second
+     * item to sink) and must not leave the shared one restructured.
+     */
+    function withProbe<T>(content: string, run: (editor: Editor, seen: Transaction[]) => T): T {
+      const seen: Transaction[] = [];
+      const probeYdoc = new Y.Doc();
+      const probeEditor = new Editor({
+        extensions: [
+          ...buildSchemaExtensions(),
+          AuthorshipExtension.configure({ ydoc: probeYdoc }),
+          Extension.create({
+            name: "mirrorProbe",
+            onTransaction({ transaction }) {
+              seen.push(transaction);
+            },
+          }),
+        ],
+        content,
+      });
+      try {
+        return run(probeEditor, seen);
+      } finally {
+        probeEditor.destroy();
+        probeYdoc.destroy();
+      }
+    }
+
+    /** Position inside `text`, so a case does not hard-code a PM offset. */
+    function posInText(editor: Editor, text: string): number {
+      let found = -1;
+      editor.state.doc.descendants((node, pos) => {
+        if (found >= 0) return false;
+        const at = node.isText ? (node.text ?? "").indexOf(text) : -1;
+        if (at >= 0) found = pos + at + 1;
+        return true;
+      });
+      expect(found, `premise: the probe document must contain "${text}"`).toBeGreaterThan(0);
+      return found;
+    }
+
     it("observes no mirror on the transaction the reap maps through", () => {
       // The runtime half of the assumption. It asserts POSITIVELY before it
       // asserts an absence: an assertion of the form "the field is undefined"
@@ -325,22 +372,7 @@ describe("authorship stamp path", () => {
       // This is the runtime half only. It cannot see a collab plugin added to
       // `src/client/editor/`, because this editor will never configure one;
       // the static walk at the bottom of this file is what covers that.
-      const seen: Transaction[] = [];
-      const probeYdoc = new Y.Doc();
-      const probeEditor = new Editor({
-        extensions: [
-          ...buildSchemaExtensions(),
-          AuthorshipExtension.configure({ ydoc: probeYdoc }),
-          Extension.create({
-            name: "mirrorProbe",
-            onTransaction({ transaction }) {
-              seen.push(transaction);
-            },
-          }),
-        ],
-        content: "<p>hello world</p>",
-      });
-      try {
+      withProbe("<p>hello world</p>", (probeEditor, seen) => {
         probeEditor.commands.insertContentAt(6, "brave ");
         seen.length = 0;
 
@@ -357,10 +389,171 @@ describe("authorship stamp path", () => {
         for (let i = 0; i < observed.mapping.maps.length; i++) {
           expect(observed.mapping.getMirror(i)).toBeUndefined();
         }
-      } finally {
-        probeEditor.destroy();
-        probeYdoc.destroy();
-      }
+      });
+    });
+
+    /**
+     * Every structural command the source comment names, driven for real. The
+     * comment asserts they all append mirror-free; a claim about five commands
+     * backed by a probe that drives one is a pin whose evidence lives where the
+     * reader cannot look, and this is an editor the file already builds, so the
+     * loop is cheaper than the prose it replaces.
+     *
+     * Note what is NOT here: history undo. There is no prosemirror-history
+     * plugin in this editor to undo through (`StarterKit.configure({ history:
+     * false })`), and Yjs undo arrives tagged with `ySyncPluginKey`, which the
+     * handler skips before it ever builds a mapping — see
+     * `authorship-undo-redo.test.ts`. A case for it here would assert against a
+     * plugin the product does not register.
+     */
+    const STRUCTURAL_COMMANDS: {
+      name: string;
+      content: string;
+      drive: (editor: Editor) => boolean;
+    }[] = [
+      {
+        name: "list wrap",
+        content: "<p>hello world</p>",
+        drive: (e) => e.commands.toggleBulletList(),
+      },
+      {
+        name: "liftListItem",
+        content: "<ul><li><p>hello world</p></li></ul>",
+        drive: (e) =>
+          e.chain().setTextSelection(posInText(e, "hello")).liftListItem("listItem").run(),
+      },
+      {
+        name: "sinkListItem",
+        content: "<ul><li><p>first</p></li><li><p>second</p></li></ul>",
+        drive: (e) =>
+          e.chain().setTextSelection(posInText(e, "second")).sinkListItem("listItem").run(),
+      },
+      {
+        name: "blockquote toggle",
+        content: "<p>hello world</p>",
+        drive: (e) => e.commands.toggleBlockquote(),
+      },
+      {
+        name: "heading toggle",
+        content: "<p>hello world</p>",
+        drive: (e) => e.commands.toggleHeading({ level: 2 }),
+      },
+    ];
+
+    it.each(STRUCTURAL_COMMANDS)("appends mirror-free through $name", ({ content, drive }) => {
+      withProbe(content, (probeEditor, seen) => {
+        seen.length = 0;
+        expect(drive(probeEditor), "premise: the command must have applied").toBe(true);
+
+        const changing = seen.filter((candidate) => candidate.docChanged);
+        // Zero-of-zero guard, twice over: a command that silently no-opped, or
+        // a doc-changing transaction with no step maps, would satisfy the
+        // mirror assertion vacuously.
+        expect(changing.length, "premise: the command must have changed the doc").toBeGreaterThan(
+          0,
+        );
+        for (const observed of changing) {
+          expect(observed.mapping.maps.length).toBeGreaterThan(0);
+          for (let i = 0; i < observed.mapping.maps.length; i++) {
+            expect(observed.mapping.getMirror(i), `map ${i} carried a mirror`).toBeUndefined();
+          }
+          expect(firstMirroredMapIndex(observed.mapping)).toBeNull();
+        }
+      });
+    });
+
+    describe("the DEV-only runtime guard", () => {
+      // The detector is route-independent where the static walk is not: it
+      // reads the mapping in hand, so it fires whether collab was imported
+      // directly, pulled in transitively by some future Tiptap extension, or
+      // named through a specifier the walk's regex cannot see.
+      beforeEach(() => {
+        _resetAuthorshipWarnLatch();
+      });
+      afterEach(() => {
+        _resetAuthorshipWarnLatch();
+      });
+
+      /** The mirror warning specifically — this editor emits others. */
+      const mirrorWarnings = (warn: { mock: { calls: unknown[][] } }): string[] =>
+        warn.mock.calls.map((call) => String(call[0])).filter((line) => line.includes("mirror"));
+
+      it("stays silent on the mirror-free transactions the reap actually sees", () => {
+        // The false-positive direction, and the only thing that catches a
+        // detector that answers "mirrored" unconditionally — every other test
+        // in this file would stay green through that mutation.
+        //
+        // Filtered rather than `not.toHaveBeenCalled()`: this editor has no
+        // Collaboration binding, so every stamp fails to anchor and warns
+        // (#1471). Asserting on the whole console would couple this case to
+        // that unrelated line.
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+          editor.commands.insertContentAt(6, "brave ");
+          const tr = editor.state.tr;
+          wrapInBulletList(tr, 6, editor.schema);
+          tr.delete(tr.mapping.map(6, 1), tr.mapping.map(12, -1));
+          editor.view.dispatch(tr);
+
+          expect(mirrorWarnings(warn)).toEqual([]);
+        } finally {
+          warn.mockRestore();
+        }
+      });
+
+      it("warns once when the mapping does carry a mirror", () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+          editor.commands.insertContentAt(6, "brave ");
+          const stamped = entries();
+          expect(stamped).toHaveLength(1);
+
+          const tr = editor.state.tr;
+          tr.delete(6, 12);
+          // Fabricate what only `prosemirror-collab`'s `rebaseSteps` produces
+          // in the wild. The appended map is EMPTY, so it contributes no ranges
+          // and the reap behaves exactly as it would without it — the mirror is
+          // the single observable difference, which is what makes the pair of
+          // assertions below separable.
+          tr.mapping.appendMap(new StepMap([]), 0);
+          expect(tr.mapping.getMirror(1), "premise: the fabricated pair must be mirrored").toBe(0);
+          editor.view.dispatch(tr);
+
+          // The reap still ran…
+          expect(entries().map((e) => e.id)).not.toContain(stamped[0].id);
+          // …and it said so, naming the issue rather than the symptom.
+          expect(mirrorWarnings(warn)).toHaveLength(1);
+          expect(mirrorWarnings(warn)[0]).toContain("#1481");
+
+          // ONCE, not once per transaction. A mirror that survives is a
+          // standing condition, so an unlatched warning would fire on every
+          // deleting keystroke for the rest of the session and get muted
+          // wholesale — which is how the signal would be lost.
+          editor.commands.insertContentAt(6, "bold ");
+          const second = editor.state.tr;
+          second.delete(6, 11);
+          second.mapping.appendMap(new StepMap([]), 0);
+          editor.view.dispatch(second);
+          expect(mirrorWarnings(warn)).toHaveLength(1);
+        } finally {
+          warn.mockRestore();
+        }
+      });
+
+      it("reports the first mirrored index, not merely that one exists", () => {
+        // Direct, because no editor in this repo can produce a mapping with a
+        // mirror at a non-zero index — and an index-returning detector that
+        // always answered 0 would be indistinguishable through the handler.
+        const plain = new StepMap([]);
+        const mirrorless = new Mapping([plain, plain, plain]);
+        expect(firstMirroredMapIndex(mirrorless)).toBeNull();
+
+        const mirrored = new Mapping([plain]);
+        mirrored.appendMap(plain);
+        mirrored.appendMap(plain, 1);
+        expect(mirrored.getMirror(2), "premise: maps 1 and 2 must be a mirrored pair").toBe(1);
+        expect(firstMirroredMapIndex(mirrored)).toBe(1);
+      });
     });
   });
 
@@ -435,10 +628,24 @@ describe("authorship stamp path", () => {
  * that would invalidate the reasoning at `authorship.ts` silently, and no
  * runtime test in this file could see it, because the editors here will never
  * configure a collab plugin.
+ *
+ * WHAT IT DOES NOT COVER, so nobody reads it as the whole guard: it matches a
+ * literal specifier under `src/`. A collab plugin pulled in transitively by
+ * some future third-party Tiptap extension, or named through a specifier built
+ * by concatenation, populates `transaction.mapping.mirror` while leaving this
+ * walk green. That route belongs to the DEV-only `firstMirroredMapIndex` guard
+ * wired at the reap; this one is the half that fails in CI.
  */
 describe("the mirror-free assumption's static half (#1481)", () => {
   const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../src");
-  const COLLAB = /["'](?:prosemirror-collab|@tiptap\/pm\/collab)["']/;
+  // Anchored on an import CONTEXT, not on the bare specifier. Matching any
+  // quoted occurrence fails closed, so it was never dangerous — but the source
+  // comment this pairs with names both packages in prose, and the repair for a
+  // spurious red is to LOOSEN the pattern, which is the one direction that
+  // makes it miss a real import. Covering `from "x"`, `import "x"`,
+  // `import("x")` and `require("x")` keeps prose out of it without widening.
+  const COLLAB =
+    /\b(?:from|import|require)\s*\(?\s*["'](?:prosemirror-collab|@tiptap\/pm\/collab)["']/;
   const SCANNED = new Set([".ts", ".tsx", ".js", ".mjs", ".svelte"]);
 
   function walk(dir: string): string[] {

--- a/tests/client/authorship-stamp.test.ts
+++ b/tests/client/authorship-stamp.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment happy-dom
 
-import { Editor } from "@tiptap/core";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Editor, Extension } from "@tiptap/core";
+import type { Transaction } from "@tiptap/pm/state";
+import { findWrapping } from "@tiptap/pm/transform";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ySyncPluginKey } from "y-prosemirror";
 import * as Y from "yjs";
@@ -228,6 +233,137 @@ describe("authorship stamp path", () => {
     });
   });
 
+  describe("a structural step and a deletion in the SAME transaction (#1481)", () => {
+    /**
+     * #1481 asked whether the reap's before-frame mapping —
+     * `new Mapping(transaction.mapping.maps.slice(0, i)).invert()` — loses
+     * accuracy by dropping `transaction.mapping`'s `mirror` array, since
+     * ProseMirror uses mirrored step pairs for exact position recovery across
+     * a replace-around. It does not, because nothing in this stack ever sets
+     * a mirror; the long comment at that line records the survey.
+     *
+     * WHAT THESE TESTS ARE FOR, PRECISELY. They do not test mirror handling —
+     * they cannot, because no transaction here carries a mirror, so a wrong
+     * filter of `undefined` is still `undefined` and would stay green. Their
+     * value is that they are the first tests to drive `toBefore` with `i > 0`
+     * THROUGH A STRUCTURAL STEP and then assert a REAP outcome. The multi-step
+     * test above reaches `i = 1` but asserts only on insertion spans, and
+     * "does not reap on a formatting change that deletes no text" dispatches
+     * its wrap and its delete as separate transactions, so neither one covers
+     * this path. Verified by mutation: swapping the construction for the
+     * known-broken `transaction.mapping.slice(0, i).invert()` idiom reds the
+     * wrap-first case below — alongside the two single-step reap tests above,
+     * which that idiom already broke. So the mutation proves PATH COVERAGE
+     * (the deletion's `old*` positions really do travel back through the
+     * structural step), not mirror coverage. The delete-first case survives
+     * that mutation, which is exactly why it is written down: it is the shape
+     * a bounds bug leaves working.
+     */
+    function wrapInBulletList(tr: Transaction, pos: number, schema: Editor["schema"]) {
+      const $pos = tr.doc.resolve(pos);
+      const range = $pos.blockRange($pos);
+      expect(range, "premise: the paragraph must form a block range").not.toBeNull();
+      const wrapping = range && findWrapping(range, schema.nodes.bulletList);
+      expect(wrapping, "premise: the block range must be wrappable in a bullet list").toBeTruthy();
+      if (range && wrapping) tr.wrap(range, wrapping);
+    }
+
+    it("reaps an entry deleted by a transaction that also wraps the block in a list", () => {
+      editor.commands.insertContentAt(6, "brave ");
+      const stamped = entries();
+      expect(stamped).toHaveLength(1);
+      // THE PREMISE, asserted rather than assumed. `reapableEntryIds` returns
+      // early for any entry carrying a `relRange` (#1480), so against a
+      // Collaboration-bound editor this test would pass without the reap
+      // running at all. This editor has no binding, so the mint declines and
+      // the entry is unanchored — the only kind the scan looks at.
+      expect(stamped[0].relRange).toBeUndefined();
+
+      const tr = editor.state.tr;
+      // Wrap FIRST, so the deletion is step 1 and its `old*` positions have to
+      // travel back through the ReplaceAroundStep to reach the before frame.
+      // That is the `i > 0` case; getting it wrong shifts the recovered span
+      // off the stamped text and the containment check silently misses.
+      wrapInBulletList(tr, 6, editor.schema);
+      tr.delete(tr.mapping.map(6, 1), tr.mapping.map(12, -1));
+      expect(tr.mapping.maps.length, "premise: two steps, structural then text").toBe(2);
+      editor.view.dispatch(tr);
+
+      expect(editor.state.doc.textBetween(0, editor.state.doc.content.size)).not.toContain("brave");
+      expect(entries().map((e) => e.id)).not.toContain(stamped[0].id);
+    });
+
+    it("reaps it with the deletion first too — the step order must not matter", () => {
+      editor.commands.insertContentAt(6, "brave ");
+      const stamped = entries();
+      expect(stamped).toHaveLength(1);
+      expect(stamped[0].relRange).toBeUndefined();
+
+      const tr = editor.state.tr;
+      tr.delete(6, 12);
+      // Now `i = 0` for the deletion, so `toBefore` is the inverse of NOTHING.
+      // Pinned as the other half of the pair: it is the case that a bounds bug
+      // in the slice would leave working, which is how such a bug hides.
+      wrapInBulletList(tr, 3, editor.schema);
+      expect(tr.mapping.maps.length).toBe(2);
+      editor.view.dispatch(tr);
+
+      expect(entries().map((e) => e.id)).not.toContain(stamped[0].id);
+    });
+
+    it("observes no mirror on the transaction the reap maps through", () => {
+      // The runtime half of the assumption. It asserts POSITIVELY before it
+      // asserts an absence: an assertion of the form "the field is undefined"
+      // also passes when the capture never fired, when the transaction was not
+      // the one meant, and — since `mirror` is `@internal` and absent from the
+      // published typings — when a dependency bump renames the field out from
+      // under a cast. So: the probe must have seen THIS transaction object, it
+      // must have changed the doc, it must carry the two step maps, and only
+      // then is the mirror read — through `getMirror`, which IS public and
+      // would fail loudly rather than read `undefined` if it were removed.
+      //
+      // This is the runtime half only. It cannot see a collab plugin added to
+      // `src/client/editor/`, because this editor will never configure one;
+      // the static walk at the bottom of this file is what covers that.
+      const seen: Transaction[] = [];
+      const probeYdoc = new Y.Doc();
+      const probeEditor = new Editor({
+        extensions: [
+          ...buildSchemaExtensions(),
+          AuthorshipExtension.configure({ ydoc: probeYdoc }),
+          Extension.create({
+            name: "mirrorProbe",
+            onTransaction({ transaction }) {
+              seen.push(transaction);
+            },
+          }),
+        ],
+        content: "<p>hello world</p>",
+      });
+      try {
+        probeEditor.commands.insertContentAt(6, "brave ");
+        seen.length = 0;
+
+        const tr = probeEditor.state.tr;
+        wrapInBulletList(tr, 6, probeEditor.schema);
+        tr.delete(tr.mapping.map(6, 1), tr.mapping.map(12, -1));
+        probeEditor.view.dispatch(tr);
+
+        const observed = seen.find((candidate) => candidate === tr);
+        expect(observed, "the probe must have observed the dispatched transaction").toBeDefined();
+        if (!observed) return;
+        expect(observed.docChanged).toBe(true);
+        expect(observed.mapping.maps.length).toBeGreaterThanOrEqual(2);
+        for (let i = 0; i < observed.mapping.maps.length; i++) {
+          expect(observed.mapping.getMirror(i)).toBeUndefined();
+        }
+      } finally {
+        probeEditor.destroy();
+        probeYdoc.destroy();
+      }
+    });
+  });
+
   it("applySuggestion attributes an accepted suggestion to Claude", () => {
     // The real function, not a reconstruction of its shape. `applySuggestion`
     // is exported solely for this: the hook's own suite drives it through a
@@ -284,5 +420,52 @@ describe("authorship stamp path", () => {
     // becomes a silent no-op instead of a bug report.
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+/**
+ * The static half of #1481's assumption, and the only half that can catch the
+ * trigger the source comment actually names.
+ *
+ * The reap's before-frame mapping is built without a `mirror` array, which is
+ * safe because no transaction in this stack carries one. `prosemirror-collab`'s
+ * `rebaseSteps` is the sole producer in the whole dependency tree — and it is
+ * INSTALLED, not absent: it ships as a dependency of `@tiptap/pm` and is one
+ * `@tiptap/pm/collab` import away. Importing it is therefore a one-line change
+ * that would invalidate the reasoning at `authorship.ts` silently, and no
+ * runtime test in this file could see it, because the editors here will never
+ * configure a collab plugin.
+ */
+describe("the mirror-free assumption's static half (#1481)", () => {
+  const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../src");
+  const COLLAB = /["'](?:prosemirror-collab|@tiptap\/pm\/collab)["']/;
+  const SCANNED = new Set([".ts", ".tsx", ".js", ".mjs", ".svelte"]);
+
+  function walk(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...walk(full));
+      else if (SCANNED.has(path.extname(entry.name))) out.push(full);
+    }
+    return out;
+  }
+
+  it("no file under src/ imports prosemirror-collab", () => {
+    const files = walk(SRC);
+    // The zero-of-zero guard. A walk that silently stopped scanning reports
+    // exactly the same "no offenders" as a clean tree — this repo has shipped
+    // that shape before (see `tests/scripts/audit-origins.test.ts`).
+    expect(files.length).toBeGreaterThan(300);
+
+    const offenders = files
+      .filter((file) => COLLAB.test(readFileSync(file, "utf-8")))
+      .map((file) => path.relative(SRC, file));
+    // If this fails, the mirror survey in `authorship.ts`'s reap comment no
+    // longer holds: a collab plugin rebases steps through `setMirror`, so
+    // `transaction.mapping.mirror` becomes populated and dropping it when
+    // building `toBefore` starts costing exact position recovery. Re-open
+    // #1481 rather than deleting this test.
+    expect(offenders).toEqual([]);
   });
 });


### PR DESCRIPTION
## The report was not a bug; the missing guard was

#1481 asked whether the authorship reap's before-frame mapping loses accuracy by dropping the `mirror` array:

```ts
toBefore ??= new Mapping(transaction.mapping.maps.slice(0, i)).invert();
```

It does not. **The mapping construction is unchanged and still correct.** What the first round of this PR shipped was evidence; what the review round added is the guard that keeps that evidence true — so the branch is no longer comment-only, and the earlier "no runtime change" framing has been retired.

## Root cause

### The mechanism the issue describes is real — in prosemirror

With a hand-mirrored delete/re-insert pair, mapping a position back through the inverse genuinely differs. Measured:

| position | without mirror (assoc 1 / -1) | with mirror |
|---|---|---|
| 5 | 9 / 5 | 5 / 5 |
| 6 | 9 / 5 | 6 / 6 |
| 9 | 9 / 5 | 9 / 9 |

So the issue's reasoning about consequence is sound *given* a mirror.

### Its trigger cannot occur in Tandem

`mirror` is only ever populated through `Mapping.setMirror`. `Transform.addStep` is the sole writer to a transaction's mapping and calls `appendMap(step.getMap())` with **no** `mirrors` argument, so every editor command appends mirror-free by construction. The only mirror-passing sites in the whole dependency tree are `prosemirror-collab`'s `rebaseSteps` and three in `prosemirror-history` (`popEvent`, `remapping`, `compress`) — and all three history sites target a **local** `remap`, while the dispatched transform goes through `transform.maybeStep` → `addStep`. y-prosemirror never imports `prosemirror-transform` at all, so it constructs no `Mapping`.

### The suggested fix is not neutral

`new Mapping(maps, mirror?.filter(...))` is wrong **if it were ever reached**, because `mirror` is a flat array of **pairs** read by parity:

```js
getMirror(n) { ... return this.mirror[i + (i % 2 ? -1 : 1)] }
```

Filtering it element-wise drops one half of a pair and desynchronises the parity of everything after it, so `getMirror` starts answering with a *neighbouring pair's* map index — a confidently wrong answer in place of the approximation it set out to remove. It also would not compile in `src/` without a cast: `mirror` is `@internal` and absent from the published typings, while `getMirror` **is** public.

### What was actually missing

`toFinal` is built with `Mapping.slice`, which carries `mirror` through; `toBefore` is built from a plain array slice, which does not. That asymmetry is behaviourally invisible only for as long as the field is `undefined` here — an invariant living in a third-party package and recorded nowhere in this repo.

## What this PR contains

**`src/client/editor/extensions/authorship.ts`**

- A comment at the construction: the parity hazard, the typings fact, the producer survey, and what would invalidate it.
- `firstMirroredMapIndex(mapping)` plus a DEV-only `warnOnce` at the construction site — see the first review finding below. Guarded by `import.meta.env.DEV` (the `installUntaggedWriteWarning` idiom), so it is dead code in a production build, and latched through this file's existing `warnOnce`, so a standing condition costs one line per session rather than one per keystroke.

**`tests/client/authorship-stamp.test.ts`** — 14 → 18 → **26** tests, on the unbound editor there (`reapableEntryIds` returns early for any anchored entry, so a Collaboration-bound editor would pass without the reap running at all — asserted as an explicit premise):

1. **wrap-first reap** — one transaction that wraps the block in a bullet list *and* deletes the stamped span, deletion as step 1.
2. **delete-first reap** — same, order reversed.
3. **runtime mirror probe** — asserts *positively* (the handler saw this exact transaction object, it changed the doc, it carries two step maps) **before** reading `getMirror(i)`, through the public accessor rather than `toBeUndefined()` on a cast to an `@internal` field.
4. **five structural commands**, each driven through a real editor — list wrap, `liftListItem`, `sinkListItem`, blockquote, heading toggle.
5. **three DEV-guard cases** — silence on a mirror-free transaction, one warning on a fabricated mirrored pair, and the first-index answer.
6. **static import walk** — no file under `src/` imports `prosemirror-collab` or `@tiptap/pm/collab`, with a `files.length > 300` zero-of-zero guard.

### What the first two catch, stated precisely

They do **not** test mirror handling and cannot: no *real* transaction here carries a mirror, so a mis-filtered `undefined` is still `undefined` and would stay green. Their value is that they are the first tests to drive `toBefore` with `i > 0` **through a structural step** and then assert a **reap** outcome — the existing multi-step test reaches `i = 1` but asserts only on insertion spans, and "does not reap on a formatting change" dispatches its wrap and its delete as *separate* transactions. Swapping the construction for the known-broken `transaction.mapping.slice(0, i).invert()` idiom reds the wrap-first test; **the delete-first case survives that mutation, which is exactly why it is written down: it is the shape a bounds bug leaves working.**

## Review round — three findings, all applied

### 1. The static walk was oversold, so there is now a runtime guard beside it

The comment claimed that "adding a collab plugin is the single change that would invalidate this" and that the import walk catches it. The walk matches a **literal specifier string** under `src/`. `@tiptap/pm/collab` is itself only a re-export wrapper around `prosemirror-collab`, which is proof that one more wrapper layer is the ecosystem's ordinary idiom — so a collab plugin arriving transitively (a third-party Tiptap collaboration extension, a Hocuspocus ProseMirror adapter), or a specifier assembled by concatenation, leaves **zero** matches under `src/` while `transaction.mapping.mirror` becomes populated, and the walk stays green forever.

Softening the sentence would have left the hole open, so the DEV-only `warnOnce` closes it instead: it reads the mapping actually in hand, so it speaks however the mirror arrived. The two guards are complementary rather than redundant — the walk fails in CI and never at runtime; the warning speaks at runtime and only in a dev build.

### 2. An unreproducible "measured" claim, with a misleading half

The comment said *"Measured over all of those plus history undo: `mapping.mirror` is `undefined` in every case"*, while the shipped probe drove exactly one command shape. All five structural commands are now driven for real and their dispatched mappings read back through `getMirror`; the prose became a loop.

The undo half is **deleted rather than tested**, because it described a plugin the product does not register: `editor-extensions.ts` builds `StarterKit.configure({ history: false })`, and undo is the Yjs UndoManager behind `yUndoPlugin`, whose replay y-prosemirror tags with `ySyncPluginKey` — which returns at the guard near the top of this handler and never reaches the mapping at all. The comment now says that instead.

### 3. The collab regex matched any quoted context

It matched the specifier inside a comment or docstring too. That fails *closed*, so it was never dangerous — the hazard is the repair, since the obvious response to a spurious red is to loosen the pattern, which is the one direction that makes it miss a real import. It is now anchored on an import context (`from` / `import` / `require` before the quote), which still matches bare, dynamic, re-export and `require` forms, while a comment naming the package no longer trips it.

## Mutation results

Every mutation restored to a byte-identical tree afterwards (`sha256sum -c`).

| Mutation | Result |
|---|---|
| `import { collab } from "@tiptap/pm/collab"` at `authorship.ts:1` | walk reds — `expected [ Array(1) ] to deeply equal []` |
| the same specifier in a straight-quoted **comment** | stays green (the old pattern reddened here — that is the finding) |
| `firstMirroredMapIndex` → `null` always | warn case reds — `expected [] to have a length of 1` |
| `firstMirroredMapIndex` → `0` always | silence case + all five command cases red — `expected [ Array(1) ] to deeply equal []`, `expected +0 to be null` |
| `firstMirroredMapIndex` scans backwards | index case reds — `expected 2 to be 1` |
| DEV call site deleted | warn case reds |
| `warnOnce` → bare `console.warn` | latch assertion reds — `expected [ …(2) ] to have a length of 1 but got 2` |
| sink case given a single-item list | premise reds — `premise: the command must have applied: expected false to be true` |
| `transaction.mapping.slice(0, i).invert()` | three reap tests red, as before |

## Gates

| Gate | Result |
|---|---|
| `npx vitest run tests/client/authorship-stamp.test.ts --maxWorkers=2` | **26 passed** (18 before this round) |
| all nine `tests/client/authorship-*.test.ts` | 111 passed |
| `npm run typecheck` | 0 errors, 0 warnings, 1337 files |
| `npx biome check` on both touched files | clean |
| pre-push hook (biome + full vitest + `cargo test`) | green |

**Playwright deliberately not run.** The runtime addition is DEV-only and warning-only, with no rendered surface, so the browser suite can return no signal on it; starting the E2E harness is flagged rather than skipped silently. `check:tokens`, `audit:ymap-keys` and `audit:origins` do not apply — no tokens, Y.Map keys or Y.Doc writes touched.

Closes #1481