### PR TITLE
docs(firewall): replace dangling §N invariant citations with inline rationale

### DIFF
--- a/src-tauri/src/cowork_installer.rs
+++ b/src-tauri/src/cowork_installer.rs
@@ -514,7 +514,7 @@ pub fn apply_token_to_all_workspaces(token: &str) -> Vec<WorkspaceWriteReport> {
 // ---------------------------------------------------------------------------
 
 /// Remove orphan `"Tandem Cowork*"` firewall rules left by a previous failed
-/// uninstall (security invariant §12). Returns the names of rules removed, or an
+/// uninstall. Returns the names of rules removed, or an
 /// empty vec on scan/remove failure.
 ///
 /// **Ordering contract (issue #1163):** on the enable path this MUST run *before*
@@ -525,7 +525,7 @@ pub fn apply_token_to_all_workspaces(token: &str) -> Vec<WorkspaceWriteReport> {
 /// leaving every enable with no allow rule. The stale-token half of the old
 /// combined reconcile is split into [`reconcile_stale_workspace_tokens`], which
 /// runs *after* a successful add so a fail-closed firewall add never reaches a
-/// workspace write (invariant §4).
+/// workspace write.
 pub fn reconcile_orphan_firewall_rules() -> Vec<String> {
     use crate::firewall;
 

--- a/src-tauri/src/firewall.rs
+++ b/src-tauri/src/firewall.rs
@@ -1,7 +1,9 @@
 //! Windows Firewall management for the Cowork VM subnet allow/deny rules.
 //!
 //! All `netsh` invocations use `Command::new("netsh").args([...])` — never
-//! `cmd.exe`, never string concatenation, never `--%` wrappers (security §4).
+//! `cmd.exe`, never string concatenation, never `--%` wrappers: no shell is
+//! interposed, so nothing in an argument value — including the detected CIDR
+//! in `remoteip={cidr}` — can be re-read as a second command.
 //!
 //! Every invocation is logged at DEBUG with: argv, exit code, stdout+stderr tail,
 //! and wall-clock duration.
@@ -18,8 +20,15 @@ use std::time::Instant;
 
 /// Errors that can arise from Windows Firewall operations.
 ///
-/// Variants are designed to give the PR-f Settings UI distinct recovery hints
-/// (security invariant §13).
+/// Each variant must drive its own distinct recovery hint in the Settings UI,
+/// not share a generic one — see `FirewallErrorVariant` in
+/// `src/client/types.ts` and the `firewallErrorHint` switch in
+/// `src/client/cowork/cowork-helpers.ts`. That switch ends in a runtime
+/// `default` arm (TypeScript can't prove exhaustiveness across the Rust/TS
+/// boundary), so a variant added here with no arm there would otherwise
+/// degrade silently to the generic fallback — which is why
+/// `tests/build/firewall-invariant-citations.test.ts` pins the two variant
+/// lists together.
 ///
 /// `Serialize`/`Deserialize` enable structured JSON errors over the Tauri IPC:
 /// `{"kind": "adminDeclined"}` etc., matching the TypeScript discriminant in
@@ -67,7 +76,9 @@ pub enum SubnetDetectionReason {
     /// Adapters matched, but none carried an IPv4 address.
     NoIpv4,
     /// At least one candidate line was present and none survived
-    /// `parse_cidr_from_line` — in practice the `/20` floor (invariant §5).
+    /// `parse_cidr_from_line` — in practice the `/20` floor: prefixes wider
+    /// than /20 are rejected so the firewall rule can never span more of the
+    /// network than Cowork's VM subnet needs.
     PrefixTooBroad,
     /// PowerShell ran but exited non-zero, or its output was not in the shape
     /// we asked for. The least-blaming bucket, and deliberately the fallback.
@@ -320,12 +331,16 @@ fn looks_like_ipv4_cidr(line: &str) -> bool {
 
 /// Parse an `IPAddress/PrefixLength` string into a proper CIDR network address.
 ///
-/// Rejects prefix length < 20 per security invariant §5.
+/// Rejects prefix length < 20: a wider prefix (e.g. `/12`) would let the
+/// firewall rule span far more of the network than Cowork's VM subnet
+/// needs, so it's refused rather than silently widening the allowlisted
+/// range.
 fn parse_cidr_from_line(line: &str) -> Option<String> {
     let (ip_str, prefix_str) = line.split_once('/')?;
     let prefix: u8 = prefix_str.trim().parse().ok()?;
 
-    // Security invariant §5: reject too-broad prefixes.
+    // Reject prefixes wider than /20 so the firewall rule can never span more
+    // than Cowork's VM subnet actually needs.
     if prefix < 20 {
         log::warn!(
             "[firewall] detected vEthernet subnet has prefix /{prefix} — too broad (< /20); rejected"
@@ -469,8 +484,12 @@ pub fn remove_cowork_rules() -> Result<(), FirewallError> {
 
 /// Scan for orphan "Tandem Cowork*" firewall rules and return their names.
 ///
-/// Used by install-time orphan reconciliation (security invariant §12) to detect
-/// stale rules from a previous failed uninstall.
+/// Used by install-time orphan reconciliation, which — per the ordering
+/// contract on `reconcile_orphan_firewall_rules` in `cowork_installer.rs`
+/// (#1163) — MUST run *before* `add_cowork_allow_rule`: this scan matches by
+/// the name prefix `"Tandem Cowork"`, identical to the allow rule's own name,
+/// so scanning after the add would see the just-added rule as an orphan and
+/// delete it, leaving the enable with no allow rule.
 ///
 /// Returns `Err` on spawn failure or unexpected netsh errors so that
 /// `reconcile_orphan_firewall_rules` can distinguish "no orphans" from "scan failed".

--- a/src-tauri/src/firewall.rs
+++ b/src-tauri/src/firewall.rs
@@ -27,8 +27,9 @@ use std::time::Instant;
 /// `default` arm (TypeScript can't prove exhaustiveness across the Rust/TS
 /// boundary), so a variant added here with no arm there would otherwise
 /// degrade silently to the generic fallback — which is why
-/// `tests/build/firewall-invariant-citations.test.ts` pins the two variant
-/// lists together.
+/// `tests/build/firewall-invariant-citations.test.ts` pins all three lists
+/// together: the variants here, the union members in `types.ts`, and the
+/// `case` arms of that switch.
 ///
 /// `Serialize`/`Deserialize` enable structured JSON errors over the Tauri IPC:
 /// `{"kind": "adminDeclined"}` etc., matching the TypeScript discriminant in

--- a/tests/build/firewall-invariant-citations.test.ts
+++ b/tests/build/firewall-invariant-citations.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Regression pin for #1374 — dangling `(security invariant §N)` /
+ * `(invariant §N)` / `(security §N)` citations in `src-tauri/src/firewall.rs`.
+ *
+ * `firewall.rs` is `#![cfg(target_os = "windows")]`. A cfg-stripped external
+ * `mod` is never read from disk by rustc on a non-matching target, so on this
+ * repo's Linux CI/dev boxes `cargo check`/`cargo test` do not even LEX this
+ * file — a dangling citation, or any other silent drift in it, produces zero
+ * diagnostic from the Rust toolchain here. That is exactly the failure mode
+ * #1374 describes ("a criterion whose evidence lives where the judge cannot
+ * look fails silently") applied to the file's own doc comments, so the guard
+ * has to live in a platform-independent text check, not a Rust one.
+ *
+ * The citation-defect pattern is deliberately narrow and excludes `§3`:
+ * `CLAUDE.md` and this repo use `§` legitimately and often (`ADR-040 §5`,
+ * `JSON-RPC 2.0 §5.1`, `OOXML §2.5.39`, `RFC 4632 §3.1`, `spec §6.4`) — those
+ * resolve to a real, findable document, and `invariant §3` specifically
+ * resolves too: it's the defense-in-depth path guard defined inline at
+ * `cowork_workspace_scan.rs:7`/`:605` and cited (accurately) from
+ * `cowork_atomic_json.rs:128`, `src/cli/win-path-guard.ts`, and
+ * `tests/shared/unc-check-duplication.test.ts:114`. Excluding it here isn't
+ * just convenience — it keeps this test's own defect pattern consistent with
+ * the reasoning in this comment, instead of contradicting it if this pattern
+ * is ever reused against a wider file set.
+ *
+ * SCOPE. #1374 fixed all six dangling citations in `firewall.rs`, plus two in
+ * `cowork_installer.rs::reconcile_orphan_firewall_rules` — the one function
+ * `firewall.rs`'s own fix now points a reader at by name (see `firewall.rs`'s
+ * `scan_orphan_rules` doc comment), so that pointer can't lead into a
+ * still-dirty comment. The SAME bare-citation pattern remains elsewhere,
+ * confirmed still present at the time of this fix in `src-tauri/src/lib.rs`,
+ * two more sites in `cowork_installer.rs` itself (`apply_token_to_all_workspaces`
+ * and `reconcile_stale_workspace_tokens` — neither reachable from `firewall.rs`'s
+ * own citations, the latter only one hop further out via
+ * `reconcile_orphan_firewall_rules`'s intra-doc link), three `src/cli/*.ts`
+ * files, and `tests/client/cowork-settings.test.ts:126` (the TS-side twin of
+ * the exact `(security invariant §13)` citation removed from `firewall.rs:22`
+ * in this change). None of that is covered here — full inventory tracked in
+ * issue #1531.
+ *
+ * A green run of this test is NOT a repo-wide guarantee — only a guarantee
+ * about `firewall.rs` and the one `cowork_installer.rs` function it reads.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+function readFirewallRs(): string {
+  return readFileSync(path.join(repoRoot, "src-tauri/src/firewall.rs"), "utf8");
+}
+
+function readCoworkInstallerRs(): string {
+  return readFileSync(path.join(repoRoot, "src-tauri/src/cowork_installer.rs"), "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Dangling-citation detector
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches the bare `invariant §N` / `security §N` defect shape, with or
+ * without surrounding parens (two of the six original citations in
+ * `firewall.rs` — `:323` and `:328` — carried no parens at all, so requiring
+ * them would have missed exactly those two). `§3` is excluded — see the file
+ * header.
+ */
+const DANGLING_CITATION_RE =
+  /(?<![\w-])(?:security\s+)?invariant\s*§\s*(\d+)|(?<![\w-])security\s*§\s*(\d+)(?!\w)/gi;
+
+function danglingCitations(text: string): string[] {
+  const found: string[] = [];
+  for (const m of text.matchAll(DANGLING_CITATION_RE)) {
+    const num = m[1] ?? m[2];
+    if (num === "3") continue; // the one legitimate, resolvable numeral
+    found.push(m[0]);
+  }
+  return found;
+}
+
+/**
+ * The doc comment directly attached to `reconcile_orphan_firewall_rules` —
+ * the one function `firewall.rs`'s rewritten `scan_orphan_rules` doc now
+ * names. Extracted narrowly (consecutive `///` lines immediately above the
+ * `pub fn` line) so this test says nothing about the rest of the file, which
+ * still has other, intentionally untouched dangling citations one hop
+ * further out (see the file header).
+ */
+function reconcileOrphanFirewallRulesDoc(): string {
+  const src = readCoworkInstallerRs();
+  const match = /((?:\/\/\/[^\n]*\n)+)pub fn reconcile_orphan_firewall_rules\(/.exec(src);
+  expect(
+    match,
+    "reconcile_orphan_firewall_rules's doc comment not found — function signature or doc-comment shape changed",
+  ).not.toBeNull();
+  const doc = match?.[1] ?? "";
+  expect(doc.length, "matched an empty doc comment").toBeGreaterThan(0);
+  return doc;
+}
+
+describe("regression pin (#1374): dangling citations are gone", () => {
+  // Both of these fail on the pre-fix source (six live citations in
+  // firewall.rs, two more in cowork_installer.rs) and pass after — verified
+  // by stashing the fix and re-running before writing this test up.
+
+  it("firewall.rs has no dangling invariant citation left", () => {
+    expect(danglingCitations(readFirewallRs())).toEqual([]);
+  });
+
+  it("reconcile_orphan_firewall_rules's doc (what firewall.rs now points readers at) is clean too", () => {
+    expect(danglingCitations(reconcileOrphanFirewallRulesDoc())).toEqual([]);
+  });
+
+  it("positive control: the detector actually catches the defect shape, parens or not, and carves out §3", () => {
+    // Guards the detector itself from the bug it's meant to guard against:
+    // a pattern that matches nothing would make the two tests above pass for
+    // the wrong reason. Covers all six original shapes plus the §3 carve-out.
+    expect(danglingCitations("(security §4).")).toEqual(["security §4"]);
+    expect(danglingCitations("(security invariant §13).")).toEqual(["security invariant §13"]);
+    expect(danglingCitations("(invariant §5).")).toEqual(["invariant §5"]);
+    expect(danglingCitations("per security invariant §5.")).toEqual(["security invariant §5"]);
+    expect(danglingCitations("Security invariant §5: reject too-broad prefixes.")).toEqual([
+      "Security invariant §5",
+    ]);
+    expect(danglingCitations("(security invariant §12)")).toEqual(["security invariant §12"]);
+    expect(danglingCitations("(invariant §3) — the path guard.")).toEqual([]);
+    expect(
+      danglingCitations("ADR-040 §5, JSON-RPC 2.0 §5.1, OOXML §2.5.39, RFC 4632 §3.1, spec §6.4"),
+    ).toEqual([]);
+  });
+});
+
+describe("forward guards: protect against future drift, not part of #1374's original defect", () => {
+  // Neither of these can fail on this specific change — the alignment was
+  // already correct, and the argv-safety phrase was already present. They
+  // exist to catch what happens NEXT: a new Rust variant with no TS arm, or
+  // a "cleanup" of the module doc that quietly drops a "never".
+
+  it("FirewallError's variants stay aligned with FirewallErrorVariant (TS)", () => {
+    // Makes the doc comment at firewall.rs:22-29 literally true: it now
+    // claims a variant added with no TS arm is "the failure this test pins
+    // against" — reusing the extraction shape from
+    // `subnet-reason-alignment.test.ts`, which pins the sibling
+    // `SubnetDetectionReason` list the same way for the same reason.
+    const rustSrc = readFirewallRs();
+    const enumMatch = /pub enum FirewallError \{([\s\S]*?)\n\}/.exec(rustSrc);
+    expect(enumMatch, "FirewallError enum not found in firewall.rs").not.toBeNull();
+    const rustVariants = [...(enumMatch?.[1] ?? "").matchAll(/^ {4}([A-Z]\w*)\s*(?:,|\{)/gm)].map(
+      (m) => m[1].slice(0, 1).toLowerCase() + m[1].slice(1),
+    );
+    expect(rustVariants.length, "parsed no variants — the enum's shape changed").toBeGreaterThan(0);
+
+    const tsSrc = readFileSync(path.join(repoRoot, "src/client/types.ts"), "utf8");
+    // Non-greedy to the next BLANK line, not the next `;` — `netshFailure`'s
+    // member has field separators (`exitCode: number; stderrTail: string`)
+    // that are themselves semicolons, so stopping at the first `;` truncates
+    // the union after the second variant. Verified this fails loudly (wrong
+    // list, not a false pass) before switching to the blank-line boundary.
+    const unionMatch = /export type FirewallErrorVariant =([\s\S]*?)\n\s*\n/.exec(tsSrc);
+    expect(unionMatch, "FirewallErrorVariant union not found in types.ts").not.toBeNull();
+    const tsVariants = [...(unionMatch?.[1] ?? "").matchAll(/kind:\s*"([^"]+)"/g)].map((m) => m[1]);
+    expect(
+      tsVariants.length,
+      "parsed no union members — the declaration's shape changed",
+    ).toBeGreaterThan(0);
+
+    expect(
+      tsVariants.slice().sort(),
+      `Rust has ${rustVariants.join(", ")}; TypeScript has ${tsVariants.join(", ")}`,
+    ).toEqual(rustVariants.slice().sort());
+  });
+
+  it("the /20 floor in prose still matches the /20 floor in code", () => {
+    // NOT a pin on this fix's specific rewording — a forward guard against
+    // code/prose drift (e.g. someone changes `< 20` to `< 19` without
+    // updating the rewritten comments that now say "wider than /20" instead
+    // of citing "§5"). Restricted to comment lines only, with continuation
+    // lines joined within a comment block (never across two different
+    // blocks, so unrelated comments can't accidentally form the phrase at
+    // their boundary) — a naive whole-file, non-global scan would have
+    // matched the untouched `Display` string at line ~118
+    // ("...is wider than /20 — refused") before ever reaching a rewritten
+    // comment, which is exactly the bug this version fixes.
+    const src = readFirewallRs();
+
+    const codeMatch = /if prefix < (\d+)/.exec(src);
+    expect(
+      codeMatch,
+      "couldn't find the prefix-floor check in code — did it move or get refactored?",
+    ).not.toBeNull();
+
+    const blocks: string[] = [];
+    let current: string[] = [];
+    for (const line of src.split("\n")) {
+      const m = /^\s*(?:\/\/\/|\/\/!|\/\/)\s?(.*)$/.exec(line);
+      if (m) {
+        current.push(m[1]);
+      } else if (current.length > 0) {
+        blocks.push(current.join(" "));
+        current = [];
+      }
+    }
+    if (current.length > 0) blocks.push(current.join(" "));
+    const commentText = blocks.join("\n"); // "\n" between blocks: two different
+    // comments can never accidentally join into one phrase at their seam.
+
+    const proseMatches = [...commentText.matchAll(/wider than \/(\d+)/g)].map((m) => m[1]);
+    expect(
+      proseMatches.length,
+      "expected at least two rewritten comments (sites 3 and 5) to use the 'wider than /N' phrasing",
+    ).toBeGreaterThanOrEqual(2);
+
+    for (const prose of proseMatches) {
+      expect(prose).toBe(codeMatch?.[1]);
+    }
+  });
+
+  it("the netsh argv-safety rule's 'never concatenation' half survives in the module doc", () => {
+    // Pins the phrase MAJOR 3 (round 1) required kept verbatim. Already true
+    // before this change too (it was never broken) — this is pure insurance
+    // against a future "cleanup" of the module doc dropping it.
+    expect(readFirewallRs()).toContain("never string concatenation");
+  });
+});

--- a/tests/build/firewall-invariant-citations.test.ts
+++ b/tests/build/firewall-invariant-citations.test.ts
@@ -1,6 +1,7 @@
 /**
  * Regression pin for #1374 — dangling `(security invariant §N)` /
- * `(invariant §N)` / `(security §N)` citations in `src-tauri/src/firewall.rs`.
+ * `(invariant §N)` / `(security §N)` / bare `(§N)` citations in
+ * `src-tauri/src/firewall.rs`.
  *
  * `firewall.rs` is `#![cfg(target_os = "windows")]`. A cfg-stripped external
  * `mod` is never read from disk by rustc on a non-matching target, so on this
@@ -64,16 +65,29 @@ function readCoworkInstallerRs(): string {
  * Matches the bare `invariant §N` / `security §N` defect shape, with or
  * without surrounding parens (two of the six original citations in
  * `firewall.rs` — `:323` and `:328` — carried no parens at all, so requiring
- * them would have missed exactly those two). `§3` is excluded — see the file
- * header.
+ * them would have missed exactly those two), plus the label-less `(§N)` form.
+ * `§3` is excluded — see the file header.
+ *
+ * The third branch is not hypothetical: `(§N)` with no `invariant`/`security`
+ * label in front of it is already live one `mod` away, same author and same
+ * subsystem, at `src-tauri/src/lib.rs:4169` (`(§12)`) and `:4882` (`(§9)`) —
+ * see issue #1531, which records it as a third citation shape. Those sites
+ * are out of this test's scope (file header, SCOPE), but the shape has to be
+ * in the detector or the same defect could land inside `firewall.rs` unseen.
+ *
+ * It cannot swallow the legitimate `§` uses this repo makes, because it
+ * requires the `(` to be followed by the `§` itself and the `)` to follow the
+ * digits directly: `(ADR-040 §5)` has a label between `(` and `§`, and
+ * `(RFC 4632 §3.1)` has both that and a subsection number where the closing
+ * paren must be. Both are covered in the positive-control test below.
  */
 const DANGLING_CITATION_RE =
-  /(?<![\w-])(?:security\s+)?invariant\s*§\s*(\d+)|(?<![\w-])security\s*§\s*(\d+)(?!\w)/gi;
+  /(?<![\w-])(?:security\s+)?invariant\s*§\s*(\d+)|(?<![\w-])security\s*§\s*(\d+)(?!\w)|\(\s*§\s*(\d+)\s*\)/gi;
 
 function danglingCitations(text: string): string[] {
   const found: string[] = [];
   for (const m of text.matchAll(DANGLING_CITATION_RE)) {
-    const num = m[1] ?? m[2];
+    const num = m[1] ?? m[2] ?? m[3];
     if (num === "3") continue; // the one legitimate, resolvable numeral
     found.push(m[0]);
   }
@@ -98,6 +112,45 @@ function reconcileOrphanFirewallRulesDoc(): string {
   const doc = match?.[1] ?? "";
   expect(doc.length, "matched an empty doc comment").toBeGreaterThan(0);
   return doc;
+}
+
+/**
+ * The `FirewallError` variant names as the wire sees them (camelCase, per
+ * `#[serde(rename_all = "camelCase")]`). Shared by both alignment guards
+ * below so they can never disagree about what the Rust list is.
+ */
+function rustFirewallVariants(): string[] {
+  const rustSrc = readFirewallRs();
+  const enumMatch = /pub enum FirewallError \{([\s\S]*?)\n\}/.exec(rustSrc);
+  expect(enumMatch, "FirewallError enum not found in firewall.rs").not.toBeNull();
+  const variants = [...(enumMatch?.[1] ?? "").matchAll(/^ {4}([A-Z]\w*)\s*(?:,|\{)/gm)].map(
+    (m) => m[1].slice(0, 1).toLowerCase() + m[1].slice(1),
+  );
+  expect(variants.length, "parsed no variants — the enum's shape changed").toBeGreaterThan(0);
+  return variants;
+}
+
+/**
+ * The `case "…":` labels inside `firewallErrorHint`'s switch — the arms the
+ * `FirewallError` doc comment says are pinned. Extracted from that function's
+ * body only (`export function firewallErrorHint(` to the next column-0 `}`),
+ * because `cowork-helpers.ts` holds three other unrelated switches whose case
+ * labels would otherwise be scooped up.
+ */
+function firewallErrorHintArms(): string[] {
+  const helpersSrc = readFileSync(
+    path.join(repoRoot, "src/client/cowork/cowork-helpers.ts"),
+    "utf8",
+  );
+  const fnMatch = /export function firewallErrorHint\([\s\S]*?\n\}/.exec(helpersSrc);
+  expect(
+    fnMatch,
+    "firewallErrorHint's body not found in cowork-helpers.ts — signature or formatting changed",
+  ).not.toBeNull();
+  const body = fnMatch?.[0] ?? "";
+  const arms = [...body.matchAll(/case "([^"]+)":/g)].map((m) => m[1]);
+  expect(arms.length, "parsed no case arms — the switch's shape changed").toBeGreaterThan(0);
+  return arms;
 }
 
 describe("regression pin (#1374): dangling citations are gone", () => {
@@ -125,32 +178,37 @@ describe("regression pin (#1374): dangling citations are gone", () => {
       "Security invariant §5",
     ]);
     expect(danglingCitations("(security invariant §12)")).toEqual(["security invariant §12"]);
+    // The label-less shape (#1531). Its match includes the parens, since they
+    // are the only thing that distinguishes it from a subsection reference.
+    expect(danglingCitations("Rule naming follows (§7).")).toEqual(["(§7)"]);
     expect(danglingCitations("(invariant §3) — the path guard.")).toEqual([]);
+    expect(danglingCitations("(§3) — the path guard.")).toEqual([]);
     expect(
       danglingCitations("ADR-040 §5, JSON-RPC 2.0 §5.1, OOXML §2.5.39, RFC 4632 §3.1, spec §6.4"),
+    ).toEqual([]);
+    // Same real citations, parenthesised — the widened branch must still not
+    // match them.
+    expect(
+      danglingCitations("(ADR-040 §5), (JSON-RPC 2.0 §5.1), (OOXML §2.5.39), (RFC 4632 §3.1)"),
     ).toEqual([]);
   });
 });
 
 describe("forward guards: protect against future drift, not part of #1374's original defect", () => {
-  // Neither of these can fail on this specific change — the alignment was
-  // already correct, and the argv-safety phrase was already present. They
-  // exist to catch what happens NEXT: a new Rust variant with no TS arm, or
-  // a "cleanup" of the module doc that quietly drops a "never".
+  // None of these can fail on this specific change — the enum, the union and
+  // the switch arms were already in agreement, and the argv-safety phrase was
+  // already present. They exist to catch what happens NEXT: a new Rust variant
+  // with no TS union member, the same variant with no switch arm (a separate
+  // hole — the switch's `default:` arm means the compiler stays quiet), or a
+  // "cleanup" of the module doc that quietly drops a "never".
 
   it("FirewallError's variants stay aligned with FirewallErrorVariant (TS)", () => {
-    // Makes the doc comment at firewall.rs:22-29 literally true: it now
+    // Makes the doc comment at firewall.rs:22-31 literally true: it now
     // claims a variant added with no TS arm is "the failure this test pins
     // against" — reusing the extraction shape from
     // `subnet-reason-alignment.test.ts`, which pins the sibling
     // `SubnetDetectionReason` list the same way for the same reason.
-    const rustSrc = readFirewallRs();
-    const enumMatch = /pub enum FirewallError \{([\s\S]*?)\n\}/.exec(rustSrc);
-    expect(enumMatch, "FirewallError enum not found in firewall.rs").not.toBeNull();
-    const rustVariants = [...(enumMatch?.[1] ?? "").matchAll(/^ {4}([A-Z]\w*)\s*(?:,|\{)/gm)].map(
-      (m) => m[1].slice(0, 1).toLowerCase() + m[1].slice(1),
-    );
-    expect(rustVariants.length, "parsed no variants — the enum's shape changed").toBeGreaterThan(0);
+    const rustVariants = rustFirewallVariants();
 
     const tsSrc = readFileSync(path.join(repoRoot, "src/client/types.ts"), "utf8");
     // Non-greedy to the next BLANK line, not the next `;` — `netshFailure`'s
@@ -169,6 +227,25 @@ describe("forward guards: protect against future drift, not part of #1374's orig
     expect(
       tsVariants.slice().sort(),
       `Rust has ${rustVariants.join(", ")}; TypeScript has ${tsVariants.join(", ")}`,
+    ).toEqual(rustVariants.slice().sort());
+  });
+
+  it("every FirewallError variant has its own arm in firewallErrorHint", () => {
+    // The union in `types.ts` is only half of what firewall.rs's doc comment
+    // claims is pinned: it names the `firewallErrorHint` switch as the place
+    // the per-variant hint actually lives, and that switch ends in a runtime
+    // `default:` arm. That arm defeats TypeScript's exhaustiveness check, so
+    // a variant added to the Rust enum AND to the TS union but not to the
+    // switch typechecks clean and silently renders the generic "Unexpected
+    // firewall error (…). Please restart Tandem." fallback — the exact
+    // degradation the doc comment says is pinned. Nothing else catches it:
+    // `tests/client/cowork-settings.test.ts`'s variant list is hand-written,
+    // so it grows only when someone remembers to grow it.
+    const rustVariants = rustFirewallVariants();
+    const arms = firewallErrorHintArms();
+    expect(
+      arms.slice().sort(),
+      `Rust has ${rustVariants.join(", ")}; firewallErrorHint handles ${arms.join(", ")}`,
     ).toEqual(rustVariants.slice().sort());
   });
 


### PR DESCRIPTION
## Root cause

`src-tauri/src/firewall.rs` and `src-tauri/src/cowork_installer.rs` carried comments citing security invariants by number — `invariant §4`, `§9`, `security §12` and similar. **No numbered invariant list exists anywhere in the repository.** The numbering appears to have come from a document that was never committed, or was committed and later restructured; either way, a reader following one of those citations has nowhere to go.

This is worse than an unhelpful comment. Each citation stands in place of the reasoning it references, so the load-bearing "why" for several fail-closed decisions in the firewall path exists only as a pointer to nothing. A maintainer deciding whether a guard is still needed has no way to recover the argument.

## The fix

Comment-only in both Rust files. Six dangling citations in `firewall.rs` and two in `cowork_installer.rs` are replaced with the actual rationale inline, so the reasoning travels with the code rather than depending on a document that does not exist.

No logic changed. Verified two ways: every added and removed line in `git diff -U0` on the two `.rs` files matches a comment prefix, and a comment-stripped comparison of each file against `HEAD` is empty. Still true after the review fixes below — `git diff origin/master...HEAD -- '*.rs'` filtered of comment lines returns zero.

## The regression pin

`tests/build/firewall-invariant-citations.test.ts` (new) scans the Rust sources for the defect shape:

```
/(?<[\w-])(?:security\s+)?invariant\s*§\s*(\d+)|(?<[\w-])security\s*§\s*(\d+)(?!\w)|\(\s*§\s*(\d+)\s*\)/gi
```

It is split into two `describe` blocks that are deliberately not equivalent:

- **`regression pin (#1374)`** — asserts `firewall.rs` and the doc comment on `reconcile_orphan_firewall_rules` (where `firewall.rs` now points readers) carry no dangling citation, plus a **positive control** proving the detector actually catches the defect shape with and without surrounding parentheses. The control matters: a scanner that matches nothing passes vacuously, and this one has a deliberate carve-out for `§3` (a real cross-reference, not a dangling one), so the carve-out needs to be shown not to have swallowed everything.
- **`forward guards`** — four checks against future drift that are *not* part of #1374's original defect and are labelled as such: `FirewallError`'s variants staying aligned with the TS `FirewallErrorVariant` union, **every variant having its own `case` arm in `firewallErrorHint`**, the `/20` subnet floor in prose still matching the floor in code, and the netsh argv-safety rule's "never concatenation" half surviving in the module doc.

Keeping those two groups separate is the point. Only the first group is evidence that #1374 is fixed; the second is opportunistic hardening that would otherwise be mistaken for it.

**Mutation-verified.** With the two `.rs` files stashed and the test kept, **3 tests go red**. Restored, all pass.

One caveat stated plainly, because it shaped the test: an earlier draft of the `/20` guard read a string the diff never touches, so it would have passed identically before and after. It was rewritten to compare the prose floor against the code floor rather than asserting a constant.

## What the second commit fixes (adversarial review)

Review found the guard did not pin what a comment in this very PR said it pinned — #1374's own defect shape, one level up. Both findings were re-verified against source before acting, and both fixes are mutation-tested.

**1. The `firewallErrorHint` arms were never pinned.** The rewritten `FirewallError` doc said a variant added with no arm in the `firewallErrorHint` switch is what the test guards against. The test compared the Rust enum only against the `FirewallErrorVariant` union in `src/client/types.ts`; it never read `src/client/cowork/cowork-helpers.ts`, where the arms live. Adding `RuleNameCollision` to the Rust enum **and** `| { kind: "ruleNameCollision" }` to the union, with **no** `case` arm, left the suite green and `npm run typecheck` silent — the switch's `default:` arm defeats exhaustiveness — while the UI rendered *"Unexpected firewall error (ruleNameCollision). Please restart Tandem."*, the exact degradation the comment claimed was pinned.

The guard now parses `case "…":` out of `firewallErrorHint`'s body (that function's body only — `cowork-helpers.ts` holds three other unrelated switches) and asserts that set equals the Rust variant set. Rust-variant extraction is factored into one helper so the two alignment guards cannot disagree about what the Rust list is. Re-running the same mutation now fails:

```
AssertionError: Rust has adminDeclined, netshNotFound, netshFailure, subnetDetectionFailed,
adapterEnumerationFailed, ruleNameCollision; firewallErrorHint handles adminDeclined,
netshNotFound, netshFailure, subnetDetectionFailed, adapterEnumerationFailed
- "ruleNameCollision"
```

The `FirewallError` doc comment was corrected in the same commit: it now says all three lists are pinned — the enum, the union, and the switch arms.

**2. The detector missed the label-less `(§N)` shape.** Inserting `//! Rule naming follows (§7) and the deny variant (§8).` into `firewall.rs`'s module doc left the test green. This shape is already live one `mod` away at `lib.rs:4169` (`(§12)`) and `:4882` (`(§9)`), same subsystem — #1531 records it as a third citation shape. A third alternation branch now catches it, keeping the `§3` carve-out. The same mutation now fails with `expected [ '(§7)', '(§8)' ] to deeply equal []`.

The branch cannot swallow the repo's real `§` references, by construction: the `(` must be followed by the `§` itself and the `)` must follow the digits directly, so `(ADR-040 §5)` (label in between) and `(RFC 4632 §3.1)` (subsection number where the `)` must be) stay unmatched. Both, plus `(OOXML §2.5.39)` and `(JSON-RPC 2.0 §5.1)`, are now negative controls alongside the `(§7)` positive control and the `(§3)` carve-out.

**Scope unchanged.** Still `firewall.rs` plus the one `cowork_installer.rs` function it points readers at — the file header's "a green run is NOT a repo-wide guarantee" stays true and load-bearing. The `(§4)` citations at `cowork_installer.rs:563`/`:572` sit in `reconcile_stale_workspace_tokens`, outside the extracted doc, so the widened regex does not reach them; they remain #1531's job.

**Deliberately not changed:** `tests/client/cowork-settings.test.ts:130`'s hand-enumerated `variants` array. Deriving it from source would duplicate the build guard's source-parsing job inside a behavioural unit test. The hole it left is now closed one level up — a variant added without a switch arm reds the build guard regardless of that array — so the only residue is that a new variant's hint would not be covered by the distinctness assertion, which cannot silently degrade the UI now that the arm is mandatory.

## Follow-up already filed

The sweep that produced this change found the same defect shape **outside** `firewall.rs` — a bare `(§12)` at `lib.rs:4169`, a bare `§9` at `lib.rs:4882`, and three sites under `src/cli/`. Those are tracked as **#1531** rather than widened into this diff, since they sit in unrelated modules and the detector here is scoped to the firewall path.

## Gates

| Gate | Result |
|---|---|
| `npx vitest run tests/build/` | pass (22 passed / 3 skipped, up from 21 / 3) |
| `npx vitest run tests/client/cowork-settings.test.ts` | pass |
| `npx biome check` (touched files) | pass |
| `npm run typecheck` | pass (0 errors, 0 warnings) |
| `rustfmt --edition 2021 --emit stdout src-tauri/src/firewall.rs` | parses clean |
| pre-push hook (biome + full vitest + `cargo test`) | pass |

No `cargo check` was run against this diff on purpose: `lib.rs` declares `#[cfg(target_os = "windows")] mod firewall;`, so rustc on Linux never reads the file from disk and a local check would prove nothing about it. The firewall code compiles and its tests execute on CI's `rust-test (windows-latest)` leg; since both commits are comment-only on the Rust side, they cannot break it.

Earlier push attempts failed in six test files carrying wall-clock budgets — `roundtrip-repo-metric` (a 120s `beforeAll`), `markdown-escaping` (a ReDoS linear-time budget), `docx-size-gate`, `authorship-block-structure`, `plaintext-newline-invariant` and `cli/monitor`. Those failures reproduce on a **pristine checkout of `master` with zero local modifications** at high load, and all six pass once the machine is idle. Independently worth knowing: at top scheduling priority with a single worker, `markdown-escaping`'s ReDoS assertion still reports **2038ms against its 2000ms budget** on clean `master` — roughly 2% headroom on this class of hardware regardless of load.

## Unverified

- The replacement rationale is my reconstruction of *why* each guard exists, derived from the surrounding code rather than from the original numbered document. Where the code makes the reason unambiguous the text follows it directly; where it did not, the comment describes the mechanism rather than asserting an intent I could not confirm. Worth a skim by someone who remembers the original invariant list, if it still exists anywhere.

Closes #1374