### PR TITLE
fix(client): route client warnings into the diagnostics report (#1439)

### DIFF
--- a/src/client/components/IntegrationWizardModal.svelte
+++ b/src/client/components/IntegrationWizardModal.svelte
@@ -60,6 +60,7 @@ import {
   type ReachabilityTarget,
 } from "../hooks/useReachabilityCheck.svelte.js";
 import { resyncCheckbox } from "../utils/checkbox-sync.js";
+import { logClientWarning } from "../utils/client-log.js";
 import IntegrationTargetCard from "./IntegrationTargetCard.svelte";
 import {
   computeDoneHeaderState,
@@ -278,7 +279,11 @@ async function copyPluginCommands(): Promise<void> {
     // permission, a WebView with no `navigator.clipboard`, and a security
     // policy rejection are three different bugs with three different fixes,
     // and after this catch nobody can tell which one a user hit.
-    console.warn("[wizard] clipboard write failed:", err);
+    // Via `logClientWarning` rather than `console.warn` so the distinguishing
+    // error name survives into a bug report: the release desktop build ships no
+    // devtools, so the console alone is a sink with no reader (#1439). The
+    // console line itself is unchanged.
+    logClientWarning("wizard", "clipboard write failed", err);
     result = "Couldn't copy — select the commands above";
   }
   // THIS is the load-bearing guard: `writeText` spans real tasks, so a user can

--- a/src/client/components/settings-tabs/SettingsAboutTab.svelte
+++ b/src/client/components/settings-tabs/SettingsAboutTab.svelte
@@ -3,6 +3,7 @@ import { isTauriRuntime } from "../../cowork/cowork-helpers";
 import { loadInvoke } from "../../cowork/cowork-invoke";
 import { createAppInfo } from "../../hooks/useAppInfo.svelte";
 import { isCrashReportingEnabled } from "../../sentry";
+import { readClientLog } from "../../utils/client-log";
 import { formatDiagnostics, summarizeUserAgent } from "../../utils/diagnostics";
 import { fetchDiagnostics } from "../../utils/diagnostics-fetch";
 import { openServerPath } from "../../utils/server-paths";
@@ -41,6 +42,9 @@ async function handleCopyDiagnostics(): Promise<void> {
     // misreported as a clipboard-permission problem.
     text = formatDiagnostics(result.payload, {
       browser: summarizeUserAgent(navigator.userAgent),
+      // Client-side warnings the server cannot see (#1439). Read, not drained:
+      // the Report-a-bug link is a second consumer of the same buffer.
+      clientLog: readClientLog(),
     });
   } catch {
     ctx.notify("error", "Diagnostics failed on the server — try `tandem doctor` in a terminal");

--- a/src/client/editor/Editor.svelte
+++ b/src/client/editor/Editor.svelte
@@ -330,8 +330,9 @@ async function openHref(href: string) {
   // still be refused here. Every refusal therefore has to SAY so. A
   // `console.warn` alone is not a channel in the primary distribution: the
   // Tauri release build ships no `devtools` feature, so there is no inspector
-  // the user can open, and `utils/diagnostics.ts` has no console ring buffer,
-  // so it never reaches a bug report either.
+  // the user can open. (Since #1439 `utils/client-log.ts` does carry warnings
+  // into the diagnostics report — but this refusal is one the user needs to see
+  // NOW, not one a maintainer reads afterwards, so the notice stays.)
   if (!currentFilePath) {
     notifyLinkProblem(
       `Can't follow "${href}" — save this document to disk first so relative links have somewhere to resolve against.`,

--- a/src/client/hooks/useBugReportUrl.svelte.ts
+++ b/src/client/hooks/useBugReportUrl.svelte.ts
@@ -1,4 +1,5 @@
 import { TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
+import { readClientLog } from "../utils/client-log";
 import { buildBugReportUrl, formatDiagnostics, summarizeUserAgent } from "../utils/diagnostics";
 import { fetchDiagnostics } from "../utils/diagnostics-fetch";
 
@@ -122,6 +123,10 @@ export function createBugReportUrl(getOpen: () => boolean): BugReportUrlState {
         url = buildBugReportUrl(
           formatDiagnostics(result.payload, {
             browser: summarizeUserAgent(navigator.userAgent),
+            // Client-side warnings the server cannot see (#1439). The section is
+            // rendered above the check list and budgeted, because this URL is
+            // the surface that truncates.
+            clientLog: readClientLog(),
           }),
         );
       })

--- a/src/client/hooks/useCoworkPreflight.svelte.ts
+++ b/src/client/hooks/useCoworkPreflight.svelte.ts
@@ -4,6 +4,7 @@ import {
   loadInvoke,
   type SubnetPreflight,
 } from "../cowork/cowork-invoke.js";
+import { logClientError } from "../utils/client-log.js";
 
 export interface SubnetPreflightState {
   readonly preflight: SubnetPreflight | null;
@@ -120,7 +121,11 @@ export function createSubnetPreflight(): SubnetPreflightState {
       // nothing about whether enabling would work, so fall through to the
       // unguarded button. Log it: `unknown` is never rendered, so without this
       // a genuine client fault is invisible on both sides of the bridge.
-      console.error("[cowork] subnet pre-flight threw:", err);
+      // Via `logClientError`, so it also reaches a bug report — the release
+      // desktop build has no devtools console to read (#1439). Note Tauri
+      // `invoke` rejects with the Rust error's `Display` STRING, not an `Error`,
+      // which is why `describeCause` keeps a string branch at all.
+      logClientError("cowork", "subnet pre-flight threw", err);
       preflight = { status: "unknown" };
     } finally {
       if (mine === token) probing = false;

--- a/src/client/sentry.ts
+++ b/src/client/sentry.ts
@@ -38,42 +38,13 @@
  */
 
 import type * as SentryBrowser from "@sentry/browser";
+import { redactPaths, redactSecrets, scrubText } from "../shared/scrub-text";
 
 let sentry: typeof SentryBrowser | null = null;
 
 /** True inside the Tauri WebView (where the IPC transport is available). */
 function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
-}
-
-/**
- * Crude redaction of anything that looks like a long opaque secret (API keys,
- * bearer tokens) embedded in a string. Anthropic keys start `sk-ant-`; we also
- * catch generic `sk-…` and long base64-ish runs. Conservative: false positives
- * only cost a `[redacted]` in a crash report, never correctness.
- */
-function redactSecrets(input: string): string {
-  return input
-    .replace(/sk-ant-[A-Za-z0-9_-]{8,}/g, "sk-ant-[redacted]")
-    .replace(/sk-[A-Za-z0-9_-]{16,}/g, "sk-[redacted]")
-    .replace(/\bBearer\s+[A-Za-z0-9._~+/-]{12,}=*/gi, "Bearer [redacted]");
-}
-
-/**
- * Replace absolute home-dir prefixes with `~`. The WebView can't read `$HOME`,
- * but file paths surfaced in error messages typically embed a recognizable
- * `/Users/<name>/`, `/home/<name>/`, or `C:\Users\<name>\` segment. Collapse
- * the user segment so a crash report can't fingerprint the OS account.
- */
-function redactPaths(input: string): string {
-  return input
-    .replace(/(\/Users\/)[^/\\]+/g, "$1[user]")
-    .replace(/(\/home\/)[^/\\]+/g, "$1[user]")
-    .replace(/([A-Za-z]:\\Users\\)[^\\]+/g, "$1[user]");
-}
-
-function scrub(input: string): string {
-  return redactPaths(redactSecrets(input));
 }
 
 /**
@@ -108,21 +79,21 @@ export async function initCrashReporting(): Promise<void> {
       // transport — a harmless no-op, matching the opt-in posture.
       sendDefaultPii: false,
       beforeSend: (event) => {
-        if (event.message) event.message = scrub(event.message);
+        if (event.message) event.message = scrubText(event.message);
         for (const exception of event.exception?.values ?? []) {
-          if (exception.value) exception.value = scrub(exception.value);
+          if (exception.value) exception.value = scrubText(exception.value);
         }
         // Drop request bodies / query strings — these can carry doc content.
         if (event.request) {
           event.request.data = undefined;
-          if (event.request.url) event.request.url = scrub(event.request.url);
+          if (event.request.url) event.request.url = scrubText(event.request.url);
         }
         return event;
       },
       beforeBreadcrumb: (breadcrumb) => {
         // `console`/`fetch`/`xhr` breadcrumbs can capture document text or auth
         // headers. Scrub their messages and drop their data payloads.
-        if (breadcrumb.message) breadcrumb.message = scrub(breadcrumb.message);
+        if (breadcrumb.message) breadcrumb.message = scrubText(breadcrumb.message);
         if (breadcrumb.category === "fetch" || breadcrumb.category === "xhr") {
           breadcrumb.data = undefined;
         }
@@ -171,5 +142,10 @@ export function reportError(error: unknown, context?: Record<string, unknown>): 
   }
 }
 
-/** Exposed for unit tests — the scrubbing is the privacy-load-bearing part. */
-export const __test = { scrub, redactSecrets, redactPaths };
+/**
+ * Exposed for unit tests — the scrubbing is the privacy-load-bearing part.
+ * The implementations moved to `shared/scrub-text.ts` when the client log
+ * (#1439) became a second consumer; `scrub` stays named here so the existing
+ * tests keep their entry point.
+ */
+export const __test = { scrub: scrubText, redactSecrets, redactPaths };

--- a/src/client/sentry.ts
+++ b/src/client/sentry.ts
@@ -145,7 +145,8 @@ export function reportError(error: unknown, context?: Record<string, unknown>): 
 /**
  * Exposed for unit tests — the scrubbing is the privacy-load-bearing part.
  * The implementations moved to `shared/scrub-text.ts` when the client log
- * (#1439) became a second consumer; `scrub` stays named here so the existing
- * tests keep their entry point.
+ * (#1439) became a third consumer alongside this file and `server/sentry.ts`,
+ * which until then held byte-identical copies; `scrub` stays named here so the
+ * existing tests keep their entry point.
  */
 export const __test = { scrub: scrubText, redactSecrets, redactPaths };

--- a/src/client/utils/client-log.ts
+++ b/src/client/utils/client-log.ts
@@ -60,6 +60,27 @@ const CAPACITY = 20;
  */
 const MAX_DETAIL_CHARS = 160;
 
+/**
+ * Ceiling on the RAW cause, applied before any pass reads it.
+ *
+ * `MAX_DETAIL_CHARS` bounds what is *stored*, not what is *processed*:
+ * `describeCause` deliberately scrubs the full cause and only then clamps, so
+ * without this the cost of a `catch` is a function of the raw input, on the UI
+ * thread. Two passes are super-linear in ways a regex change alone does not
+ * remove — `collapseLines`' leading `\s*` backtracks across a whitespace run
+ * (128k spaces: 18.2s), and the URL-credential rule's two `[^/\s@]+` runs
+ * either side of a literal `:` have O(n²) ways to split a colon run
+ * (`"https://" + "a:".repeat(50000)`: 33s, before AND after the `\w{1,16}` fix).
+ * Capping the input is what actually bounds both: at 1024 they are 1.2ms and
+ * 3.2ms.
+ *
+ * 1024 rather than `MAX_DETAIL_CHARS` because the pre-clamp string is also what
+ * `fingerprint` keys on, and coalescing on 160 characters is precisely the bug
+ * `fingerprint` exists to avoid. 6.4x the display cap keeps that discrimination
+ * while making the excess unreachable by `detail`.
+ */
+const MAX_CAUSE_CHARS = 1024;
+
 export interface ClientLogEntry {
   /** Seconds since the bundle loaded, one decimal. The LAST occurrence. */
   readonly at: number;
@@ -99,6 +120,19 @@ function elapsedSeconds(): number {
 }
 
 /**
+ * Bound the raw cause before any pass reads it. See `MAX_CAUSE_CHARS`.
+ *
+ * A plain slice: this runs BEFORE scrubbing, so it may leave a half-matched
+ * credential at the cut — which is harmless because the cut sits far beyond
+ * `MAX_DETAIL_CHARS`, so that tail reaches only `fingerprint`, which stores a
+ * hash and no text. `clamp` is what guards the surrogate boundary on the string
+ * that is actually kept.
+ */
+function cap(input: string): string {
+  return input.length > MAX_CAUSE_CHARS ? input.slice(0, MAX_CAUSE_CHARS) : input;
+}
+
+/**
  * Collapse newlines before anything else measures or renders this string.
  *
  * `stripControlChars` in `diagnostics.ts` deliberately does NOT strip `\x0a`
@@ -129,9 +163,17 @@ function collapseLines(input: string): string {
  *    slice rather than before it.
  */
 function clamp(input: string): string {
-  const paired = input.replace(
-    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
-    "",
+  // Ordered alternation rather than a lookahead/lookbehind pair: the first
+  // branch consumes a well-formed pair whole, so a low surrogate that follows a
+  // high one can never be reached by the second branch and only genuinely
+  // unpaired ones are dropped. Written this way because a lookbehind would be
+  // the FIRST one in the browser bundle — esbuild cannot downlevel it, so it
+  // would raise the WKWebView floor from 15.4 to 16.4, and a lookbehind is an
+  // early SyntaxError in JSC, which blanks the whole bundle rather than
+  // degrading one function. Verified byte-identical to the lookbehind form over
+  // 399,592 inputs (exhaustive over high/low/BMP symbols to length 6).
+  const paired = input.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDFFF]/g, (m) =>
+    m.length === 2 ? m : "",
   );
   if (paired.length <= MAX_DETAIL_CHARS) return paired;
   return `${paired.slice(0, MAX_DETAIL_CHARS).replace(/[\uD800-\uDBFF]$/, "")}…`;
@@ -178,13 +220,18 @@ function isErrorLike(value: object): value is { name: string; message: string } 
  *
  * Returns the scrubbed string UNCLAMPED — `record` clamps for display and
  * fingerprints the full string for coalescing, which are different jobs.
+ * "Unclamped" means un-clamped to `MAX_DETAIL_CHARS`; the raw cause is still cut
+ * to `MAX_CAUSE_CHARS` FIRST, so neither `collapseLines` nor `scrubText` ever
+ * sees an unbounded string. The cut cannot reach `detail`: it sits 6.4x beyond
+ * the display cap, and scrubbing only ever replaces a credential with a
+ * placeholder, so nothing past it can be pulled into the visible window.
  */
 function describeCause(cause: unknown): string {
   if (cause === undefined || cause === null) return "";
-  if (typeof cause === "string") return scrubText(collapseLines(cause));
+  if (typeof cause === "string") return scrubText(collapseLines(cap(cause)));
   if (typeof cause === "object") {
     if (isErrorLike(cause)) {
-      return scrubText(collapseLines(`${cause.name}: ${cause.message}`));
+      return scrubText(collapseLines(cap(`${cause.name}: ${cause.message}`)));
     }
     // Deliberately the TYPE and nothing else: a rejected `{ path, body }`
     // contributes the word "Object", never its contents.
@@ -225,24 +272,48 @@ function record(level: "warn" | "error", scope: string, event: string, cause: un
 }
 
 /**
+ * Never let telemetry throw into the app's error path — `src/client/sentry.ts`'s
+ * own stated norm, and this module is the declared intake for the ~150 other
+ * `console.warn` sites, so it will meet causes today's two never produce.
+ *
+ * `describeCause` reads `cause.name`, and a getter that throws would otherwise
+ * abort the CALLER's `catch` block, so the user-facing recovery line after the
+ * warn never runs. That is also why the console call is emitted first: the
+ * console line is the one part of this that was there before the ring buffer
+ * existed, and it must not become conditional on the buffer succeeding.
+ */
+function recordSafely(level: "warn" | "error", scope: string, event: string, cause: unknown): void {
+  try {
+    record(level, scope, event, cause);
+  } catch {
+    // Deliberately silent. A `console.warn` here would recurse straight back
+    // into a mocked console in tests and add nothing a developer can act on.
+  }
+}
+
+/**
  * Record a client-side warning and log it to the console exactly as before.
  *
  * `scope` and `event` must be **string literals**; `cause` is the thrown value.
  * The console call is byte-identical to a hand-written
  * ``console.warn(`[scope] event:`, err)`` and passes the RAW cause, so a
  * developer with an inspector open keeps the full object and its stack.
+ *
+ * It is also emitted FIRST and the buffer write is caught, so replacing a bare
+ * `console.warn` with this call cannot change what the caller's `catch` block
+ * does — see `recordSafely`.
  */
 export function logClientWarning(scope: string, event: string, cause?: unknown): void {
-  record("warn", scope, event, cause);
   if (cause === undefined) console.warn(`[${scope}] ${event}`);
   else console.warn(`[${scope}] ${event}:`, cause);
+  recordSafely("warn", scope, event, cause);
 }
 
 /** As `logClientWarning`, for failures that warrant `console.error`. */
 export function logClientError(scope: string, event: string, cause?: unknown): void {
-  record("error", scope, event, cause);
   if (cause === undefined) console.error(`[${scope}] ${event}`);
   else console.error(`[${scope}] ${event}:`, cause);
+  recordSafely("error", scope, event, cause);
 }
 
 /**

--- a/src/client/utils/client-log.ts
+++ b/src/client/utils/client-log.ts
@@ -1,0 +1,266 @@
+/**
+ * A small bounded ring buffer for client-side diagnostics (#1439).
+ *
+ * ## Why this exists
+ *
+ * The desktop app is the primary distribution and its release build ships no
+ * `devtools` feature (`src-tauri/Cargo.toml`; the feature is mutually exclusive
+ * with `tauri-plugin-log`), so there is no inspector to open. `tauri-plugin-log`
+ * captures Rust `log::*`, not WebView `console.*`. A `console.warn` that
+ * distinguishes three different bugs behind one generic user-facing string is
+ * therefore written to a sink nobody can read, and the bug report says only
+ * "the copy button didn't work".
+ *
+ * Entries recorded here are drained by `formatDiagnostics`, so they reach the
+ * clipboard via Copy Diagnostics and the prefilled body via Report a bug.
+ *
+ * ## The API is the privacy control
+ *
+ * The diagnostics report is pasted into a **public GitHub issue**, and
+ * `buildBugReportUrl` prefills it — which turns the user's review step into an
+ * opt-out. So:
+ *
+ * 1. **Nothing is captured automatically.** No `console` monkey-patch: every
+ *    entry comes from an explicit call someone wrote and reviewed.
+ * 2. **There is no free-text parameter.** `scope` and `event` are static string
+ *    literals — there is nothing to interpolate a document title into. That is
+ *    enforced by `tests/client/client-log-callsites.test.ts`, not by types,
+ *    because TypeScript cannot express "literal only".
+ * 3. **The cause is classified, not traversed.** `describeCause` reads `name`
+ *    and `message` and NOTHING else: no `.stack`, no `.cause`, no `String(err)`,
+ *    no `JSON.stringify`, no recursion into fields. This is a rule, not an
+ *    accident — the obvious "make detail more useful" follow-up is
+ *    `err.cause?.message`, and a stack is almost entirely absolute file paths.
+ * 4. **Scrubbed on the way in**, so the buffer never holds unscrubbed text for
+ *    some other reader (a Sentry breadcrumb, a heap dump) to find, and capped,
+ *    which bounds how much of anything that slipped through can travel.
+ *
+ * ## What this does NOT protect against
+ *
+ * `redactPaths` collapses the username segment only, so
+ * `~/Documents/board-minutes.md` still names the document. A `string` cause is
+ * captured verbatim (scrubbed and capped) — kept deliberately, because Tauri
+ * `invoke` rejects with the Rust error's `Display` string rather than an
+ * `Error`, and dropping that branch would blind the Cowork pre-flight call site
+ * to every failure it has. In short: layers 1–3 constrain what we *ask* to be
+ * logged; they cannot vouch for the content of a string handed to us.
+ */
+
+import { scrubText } from "../../shared/scrub-text";
+
+/** Entries kept. Small on purpose — this is evidence, not a log file. */
+const CAPACITY = 20;
+
+/**
+ * Ceiling on a single entry's `detail`.
+ *
+ * A privacy control as much as a size one: it bounds how much of any string
+ * that slipped past the scrubbers — a paragraph of document text inside a
+ * server error message, say — can ride along into a public issue.
+ */
+const MAX_DETAIL_CHARS = 160;
+
+export interface ClientLogEntry {
+  /** Seconds since the bundle loaded, one decimal. The LAST occurrence. */
+  readonly at: number;
+  /**
+   * When this entry was FIRST recorded. Rendered alongside `count`, because
+   * `at` alone cannot distinguish three failures 300ms apart from three spread
+   * over a quarter of an hour, and those are different bugs.
+   */
+  readonly firstAt: number;
+  readonly level: "warn" | "error";
+  /** Static subsystem tag, e.g. `"wizard"`. */
+  readonly scope: string;
+  /** Static event description, e.g. `"clipboard write failed"`. */
+  readonly event: string;
+  /** Scrubbed, single-line, capped classification of the cause. `""` if none. */
+  readonly detail: string;
+  /** Occurrences collapsed into this entry. */
+  readonly count: number;
+}
+
+/**
+ * The coalescing key rides on the stored entry but never leaves this module —
+ * `readClientLog` strips it. It is an implementation detail of deduplication,
+ * not something the diagnostics report should render or a caller should read.
+ */
+interface StoredEntry extends ClientLogEntry {
+  readonly key: string;
+}
+
+const buffer: StoredEntry[] = [];
+
+const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
+
+function elapsedSeconds(): number {
+  const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+  return Math.round((now - startedAt) / 100) / 10;
+}
+
+/**
+ * Collapse newlines before anything else measures or renders this string.
+ *
+ * `stripControlChars` in `diagnostics.ts` deliberately does NOT strip `\x0a`
+ * (report text legitimately contains newlines — that is why `fenceFor` exists),
+ * and multi-line `Error.message`s are routine for Tauri `invoke` failures and
+ * JSON parse errors. Left alone, one entry would render as several lines: it
+ * breaks the section's size accounting, and a message could inject a convincing
+ * `[ok]   some-check — …` line into a public issue body.
+ */
+function collapseLines(input: string): string {
+  return input.replace(/\s*[\r\n]+\s*/g, " ").trim();
+}
+
+/**
+ * Drop unpaired surrogates, then truncate to `MAX_DETAIL_CHARS`.
+ *
+ * `encodeURIComponent` throws `URIError` on a lone surrogate, and
+ * `buildBugReportUrl` answers a throw by returning the BARE issue URL — the
+ * entire diagnostics prefill silently gone, on the exact surface #1439 exists
+ * to fix. Two ways one arrives, and both have to be closed:
+ *
+ *  - **already in the input.** A `String.fromCharCode(0xd800)` inside a message
+ *    reaches us intact: every scrub pattern is ASCII and every `[^…]+` run
+ *    consumes whole pairs, so nothing upstream can remove — or manufacture —
+ *    one. Hence the unconditional pass, not just a cut-site fix-up.
+ *  - **created by the cut**, when the slice lands between a high and low
+ *    surrogate. That is why the trailing-high-surrogate strip runs after the
+ *    slice rather than before it.
+ */
+function clamp(input: string): string {
+  const paired = input.replace(
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+    "",
+  );
+  if (paired.length <= MAX_DETAIL_CHARS) return paired;
+  return `${paired.slice(0, MAX_DETAIL_CHARS).replace(/[\uD800-\uDBFF]$/, "")}…`;
+}
+
+/**
+ * A collision-resistant stand-in for the FULL scrubbed cause, used as the
+ * coalescing key.
+ *
+ * Coalescing on the clamped `detail` would merge two genuinely different
+ * failures that happen to agree on their first 160 characters and report them
+ * as one that recurred — a `(x2)` asserting a repeat that never happened, which
+ * is worse than two lines. Keying on the pre-clamp string fixes that; keying on
+ * a FINGERPRINT of it fixes it without storing the extra text, which matters
+ * because everything in this buffer is a candidate for a public issue body.
+ * Length plus a 32-bit FNV-1a hash: no text, and a collision needs both to
+ * agree.
+ */
+function fingerprint(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${input.length}:${(hash >>> 0).toString(36)}`;
+}
+
+function isErrorLike(value: object): value is { name: string; message: string } {
+  const candidate = value as { name?: unknown; message?: unknown };
+  return typeof candidate.name === "string" && typeof candidate.message === "string";
+}
+
+/**
+ * Reduce an unknown thrown value to a short classification.
+ *
+ * `name` is the diagnostic payload, not a formality: `NotAllowedError` vs
+ * `TypeError` vs `SecurityError` is precisely what separates a denied clipboard
+ * permission from a WebView with no `navigator.clipboard` from a policy
+ * rejection — the three bugs #1439 opens with.
+ *
+ * READS `name` AND `message` ONLY. Not `.stack`, not `.cause`, not fields, not
+ * `String(value)`. See the privacy note at the top of this file before
+ * "improving" this.
+ *
+ * Returns the scrubbed string UNCLAMPED — `record` clamps for display and
+ * fingerprints the full string for coalescing, which are different jobs.
+ */
+function describeCause(cause: unknown): string {
+  if (cause === undefined || cause === null) return "";
+  if (typeof cause === "string") return scrubText(collapseLines(cause));
+  if (typeof cause === "object") {
+    if (isErrorLike(cause)) {
+      return scrubText(collapseLines(`${cause.name}: ${cause.message}`));
+    }
+    // Deliberately the TYPE and nothing else: a rejected `{ path, body }`
+    // contributes the word "Object", never its contents.
+    const ctorName = (cause as { constructor?: { name?: unknown } }).constructor?.name;
+    return typeof ctorName === "string" && ctorName ? ctorName : "object";
+  }
+  return typeof cause;
+}
+
+function record(level: "warn" | "error", scope: string, event: string, cause: unknown): void {
+  const described = describeCause(cause);
+  const detail = clamp(described);
+  const key = fingerprint(described);
+  const at = elapsedSeconds();
+
+  // Coalesce against ANY matching entry, not just the newest one. Two failures
+  // alternating (A, B, A, B …) would otherwise consume all 20 slots with two
+  // distinct facts and flush every other scope out — and alternation is the
+  // expected shape here, since the Cowork pre-flight is retry-driven and its
+  // catch covers several distinct causes. Matching anywhere makes CAPACITY a
+  // count of distinct facts.
+  const index = buffer.findIndex(
+    (entry) =>
+      entry.level === level && entry.scope === scope && entry.event === event && entry.key === key,
+  );
+  if (index !== -1) {
+    const [existing] = buffer.splice(index, 1);
+    // Replaced, never mutated in place: `readClientLog` hands entries to callers
+    // that hold them across an await, and `at` moves to the newest occurrence so
+    // newest-first rendering does not show a stale time at the top. `firstAt`
+    // stays put — the pair is what makes a repeat count legible.
+    buffer.push({ ...existing, at, count: existing.count + 1 });
+    return;
+  }
+
+  buffer.push({ at, firstAt: at, level, scope, event, detail, count: 1, key });
+  if (buffer.length > CAPACITY) buffer.shift();
+}
+
+/**
+ * Record a client-side warning and log it to the console exactly as before.
+ *
+ * `scope` and `event` must be **string literals**; `cause` is the thrown value.
+ * The console call is byte-identical to a hand-written
+ * ``console.warn(`[scope] event:`, err)`` and passes the RAW cause, so a
+ * developer with an inspector open keeps the full object and its stack.
+ */
+export function logClientWarning(scope: string, event: string, cause?: unknown): void {
+  record("warn", scope, event, cause);
+  if (cause === undefined) console.warn(`[${scope}] ${event}`);
+  else console.warn(`[${scope}] ${event}:`, cause);
+}
+
+/** As `logClientWarning`, for failures that warrant `console.error`. */
+export function logClientError(scope: string, event: string, cause?: unknown): void {
+  record("error", scope, event, cause);
+  if (cause === undefined) console.error(`[${scope}] ${event}`);
+  else console.error(`[${scope}] ${event}:`, cause);
+}
+
+/**
+ * Snapshot the buffer, oldest first. Non-destructive despite the "drain"
+ * framing: Copy Diagnostics and Report-a-bug are two consumers of one buffer,
+ * and clearing on either would empty it for the other.
+ *
+ * Entries are copied individually — coalescing replaces entries and callers
+ * hold this array across an await, so a shallow copy could let the `(x3)` a
+ * user sees drift from what was rendered.
+ */
+export function readClientLog(): readonly ClientLogEntry[] {
+  // Destructured rather than spread-then-delete so the internal coalescing key
+  // cannot reach a diagnostics report by omission.
+  return buffer.map(({ key: _key, ...entry }) => entry);
+}
+
+/** Test seam — empties the buffer. (Precedent: `_resetDiagnosticsCache`.) */
+export function _resetClientLog(): void {
+  buffer.length = 0;
+}

--- a/src/client/utils/diagnostics.ts
+++ b/src/client/utils/diagnostics.ts
@@ -3,6 +3,7 @@
 import type { DoctorReport, DoctorStatus } from "../../cli/doctor";
 import { TANDEM_ISSUES_NEW_URL } from "../../shared/constants";
 import type { HostInfo } from "../../shared/diagnostics";
+import type { ClientLogEntry } from "./client-log";
 
 /**
  * Wire shape of `GET /api/diagnostics` (see `makeDiagnosticsHandler`).
@@ -22,7 +23,30 @@ export interface DiagnosticsPayload extends HostInfo {
 export interface DiagnosticsEnv {
   /** Short browser/WebView descriptor, e.g. "Chrome 141". Empty to omit. */
   browser?: string;
+  /**
+   * Recent client-side warnings (`utils/client-log.ts`), oldest first. Omitted
+   * or empty renders nothing at all — see `formatDiagnostics`.
+   */
+  clientLog?: readonly ClientLogEntry[];
 }
+
+/**
+ * Ceilings on the client-log section, overridable per call.
+ *
+ * Not cosmetic. `buildBugReportUrl` drops whole lines from the TAIL to fit
+ * `MAX_ISSUE_URL_LENGTH`, and the section sits above the check list (see
+ * `formatDiagnostics`), so an unbudgeted section evicts the doctor report line
+ * by line before it loses a single log entry. Measured: roughly 3,700 raw chars
+ * survive the cap, and an unbounded 20-entry section is 1,800–4,100 of them.
+ */
+export interface DiagnosticsFormatOptions {
+  maxClientLogLines?: number;
+  maxClientLogChars?: number;
+}
+
+export const MAX_CLIENT_LOG_LINES = 6;
+export const MAX_CLIENT_LOG_CHARS = 800;
+export const CLIENT_LOG_HEADING = "Recent client warnings (newest first):";
 
 const STATUS_TAG: Record<DoctorStatus, string> = {
   pass: "[ok]  ",
@@ -120,6 +144,58 @@ function hardwareLine(payload: DiagnosticsPayload): string | null {
 }
 
 /**
+ * Render the client-log section, newest first, within a fixed budget.
+ *
+ * **Newest first is load-bearing.** `buildBugReportUrl` truncates from the tail,
+ * so oldest-first would drop precisely the entries nearest the bug the user is
+ * reporting. Same reason the section sits above the check list rather than
+ * after it: appended at the end it would be the first thing cut, and the fix
+ * would work for Copy Diagnostics while silently not working for Report a bug —
+ * the surface #1439 is actually about.
+ *
+ * The trade that buys, stated once: under the cap the report keeps client text
+ * scrubbed with no known roots over doctor text scrubbed server-side with real
+ * ones. That is the right priority for a bug report — the client evidence is
+ * the proximate cause — but it is a trade, which is why the budget exists.
+ *
+ * Returns `[]` for an empty log, so a report with no warnings is byte-identical
+ * to one produced before this section existed.
+ */
+function renderClientLog(
+  entries: readonly ClientLogEntry[],
+  opts?: DiagnosticsFormatOptions,
+): string[] {
+  if (entries.length === 0) return [];
+
+  const maxLines = opts?.maxClientLogLines ?? MAX_CLIENT_LOG_LINES;
+  const maxChars = opts?.maxClientLogChars ?? MAX_CLIENT_LOG_CHARS;
+
+  const body: string[] = [];
+  let used = 0;
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (body.length >= maxLines) break;
+    const detail = entry.detail ? ` — ${entry.detail}` : "";
+    // `first` only when it says something: `at` is the newest occurrence, so a
+    // bare `(x3)` cannot distinguish a 300ms burst from three failures spread
+    // across a quarter of an hour.
+    const repeats =
+      entry.count > 1 ? ` (x${entry.count}, first +${entry.firstAt.toFixed(1)}s)` : "";
+    const line = stripControlChars(
+      `[${entry.level}] +${entry.at.toFixed(1)}s ${entry.scope}: ${entry.event}${detail}${repeats}`,
+    );
+    // Always emit at least one entry: a single pathological line is still worth
+    // more than a heading with nothing under it.
+    if (body.length > 0 && used + line.length > maxChars) break;
+    body.push(line);
+    used += line.length + 1;
+  }
+
+  if (body.length < entries.length) body.push(`(showing ${body.length} of ${entries.length})`);
+  return [CLIENT_LOG_HEADING, ...body];
+}
+
+/**
  * Format a diagnostics payload as plain text for the clipboard. Pure — the
  * "Copy diagnostics" button is thin glue over this (extract-over-mount), and
  * `buildBugReportUrl` reuses the same text for the issue body.
@@ -129,7 +205,11 @@ function hardwareLine(payload: DiagnosticsPayload): string | null {
  * That degradation is the contract: an older server, or a host where every
  * `os.*` read failed, must still format cleanly.
  */
-export function formatDiagnostics(payload: DiagnosticsPayload, env?: DiagnosticsEnv): string {
+export function formatDiagnostics(
+  payload: DiagnosticsPayload,
+  env?: DiagnosticsEnv,
+  opts?: DiagnosticsFormatOptions,
+): string {
   const lines: string[] = [
     `Tandem v${payload.version} (${payload.transport}${payload.tauriSidecar ? ", desktop" : ""})`,
     `${payload.platform}/${payload.arch}, Node ${payload.nodeVersion}`,
@@ -145,6 +225,12 @@ export function formatDiagnostics(payload: DiagnosticsPayload, env?: Diagnostics
   if (browser) lines.push(`Browser: ${stripControlChars(browser)}`);
 
   lines.push("");
+
+  // Between the existing host-block separator and its own trailing blank, so
+  // the host block still ends at the FIRST blank line — `diagnostics-format`'s
+  // `hostLines()` helper slices to exactly that and asserts with `toEqual`.
+  const clientLog = renderClientLog(env?.clientLog ?? [], opts);
+  if (clientLog.length > 0) lines.push(...clientLog, "");
 
   for (const res of payload.report.results) {
     lines.push(`${STATUS_TAG[res.status]} ${res.check} — ${stripControlChars(res.message)}`);

--- a/src/server/sentry.ts
+++ b/src/server/sentry.ts
@@ -22,6 +22,7 @@
  * the fatal-error path — never document content or annotation bodies.
  */
 
+import { redactPaths, redactSecrets } from "../shared/scrub-text.js";
 import { APP_VERSION } from "./mcp/server.js";
 
 const SENTRY_DSN_ENV = "TANDEM_SENTRY_DSN";
@@ -31,13 +32,6 @@ const SENTRY_DSN_ENV = "TANDEM_SENTRY_DSN";
 type SentryNode = typeof import("@sentry/node");
 let sentry: SentryNode | null = null;
 
-function redactSecrets(input: string): string {
-  return input
-    .replace(/sk-ant-[A-Za-z0-9_-]{8,}/g, "sk-ant-[redacted]")
-    .replace(/sk-[A-Za-z0-9_-]{16,}/g, "sk-[redacted]")
-    .replace(/\bBearer\s+[A-Za-z0-9._~+/-]{12,}=*/gi, "Bearer [redacted]");
-}
-
 function redactHome(input: string): string {
   const home = process.env.HOME || process.env.USERPROFILE;
   let out = input;
@@ -46,14 +40,29 @@ function redactHome(input: string): string {
   if (home && home.length > 1) {
     out = out.split(home).join("~");
   }
-  // Also collapse user segments not under $HOME (e.g. another account's path).
-  return out
-    .replace(/(\/Users\/)[^/\\]+/g, "$1[user]")
-    .replace(/(\/home\/)[^/\\]+/g, "$1[user]")
-    .replace(/([A-Za-z]:\\Users\\)[^\\]+/g, "$1[user]");
+  // Then the shared generic pass, for user segments not under $HOME — another
+  // account's path, or the absolute path inside a raw `fs` error. Shared rather
+  // than a local copy of the same three regexes: the local copy had already
+  // drifted (it was case-SENSITIVE on `\Users\`, so a lowercase Windows path
+  // leaked the account name here after the shared module was fixed), and the
+  // `$HOME` swap above is case-sensitive too, so it does not cover for that.
+  // Only the literal-root swap is genuinely server-only — the sidecar can read
+  // the environment and the WebView cannot.
+  return redactPaths(out);
 }
 
-/** Exposed for unit tests — scrubbing is the privacy-load-bearing part. */
+/**
+ * Exposed for unit tests — scrubbing is the privacy-load-bearing part.
+ *
+ * The secrets half is `shared/scrub-text.ts`, shared with the WebView reporter
+ * and the client log. It used to be a private copy here carrying only the
+ * original three patterns, which meant the sidecar — the half most likely to
+ * hold a credential, since MCP server configs carry `env`/`headers` full of API
+ * keys (`GET /api/integrations/existing` exists because of that) — was the LEAST
+ * redacted of the three. The path half is shared too; `redactHome` stays local
+ * only for its `$HOME` literal swap, which genuinely is server-only because the
+ * sidecar can read the environment and the WebView cannot.
+ */
 export function scrub(input: string): string {
   return redactHome(redactSecrets(input));
 }

--- a/src/server/sentry.ts
+++ b/src/server/sentry.ts
@@ -42,9 +42,10 @@ function redactHome(input: string): string {
   }
   // Then the shared generic pass, for user segments not under $HOME — another
   // account's path, or the absolute path inside a raw `fs` error. Shared rather
-  // than a local copy of the same three regexes: the local copy had already
-  // drifted (it was case-SENSITIVE on `\Users\`, so a lowercase Windows path
-  // leaked the account name here after the shared module was fixed), and the
+  // than the local copy of the same three regexes this used to hold: that copy
+  // and `src/client/sentry.ts`'s were byte-identical and both case-SENSITIVE on
+  // `\Users\`, so a lowercase Windows path leaked the account name from BOTH.
+  // This PR adds the `/i` to the shared rule and adopts it in both places; the
   // `$HOME` swap above is case-sensitive too, so it does not cover for that.
   // Only the literal-root swap is genuinely server-only — the sidecar can read
   // the environment and the WebView cannot.
@@ -55,13 +56,18 @@ function redactHome(input: string): string {
  * Exposed for unit tests — scrubbing is the privacy-load-bearing part.
  *
  * The secrets half is `shared/scrub-text.ts`, shared with the WebView reporter
- * and the client log. It used to be a private copy here carrying only the
- * original three patterns, which meant the sidecar — the half most likely to
- * hold a credential, since MCP server configs carry `env`/`headers` full of API
- * keys (`GET /api/integrations/existing` exists because of that) — was the LEAST
- * redacted of the three. The path half is shared too; `redactHome` stays local
- * only for its `$HOME` literal swap, which genuinely is server-only because the
- * sidecar can read the environment and the WebView cannot.
+ * and the client log. There were TWO copies before this PR, here and in
+ * `src/client/sentry.ts`, and they had NOT drifted: both carried the same three
+ * patterns (`sk-ant-`, `sk-`, `Bearer`) byte for byte. So the widening — GitHub,
+ * Slack and Stripe tokens, `Basic`, JWTs, `scheme://user:pass@`, credential
+ * query params — is new in this PR, not one copy catching up with another; it
+ * lands in both halves at once precisely because there is now only one to
+ * widen. It matters most here: the sidecar is the half most likely to hold a
+ * credential, since MCP server configs carry `env`/`headers` full of API keys
+ * (`GET /api/integrations/existing` exists because of that). The path half is
+ * shared too; `redactHome` stays local only for its `$HOME` literal swap, which
+ * genuinely is server-only because the sidecar can read the environment and the
+ * WebView cannot.
  */
 export function scrub(input: string): string {
   return redactHome(redactSecrets(input));

--- a/src/shared/scrub-text.ts
+++ b/src/shared/scrub-text.ts
@@ -2,9 +2,11 @@
  * Scrubbing for free-form text that leaves the process — a crash report, or a
  * report body a user is about to paste into a public GitHub issue.
  *
- * Both halves started life in `src/client/sentry.ts` and moved here when a
- * second consumer appeared (`client/utils/client-log.ts`, #1439). Two copies of
- * a privacy control is how a hardening pass ends up fixing only one of them.
+ * Both halves lived as byte-identical copies in `src/client/sentry.ts` and
+ * `src/server/sentry.ts`, and moved here when a third consumer appeared
+ * (`client/utils/client-log.ts`, #1439). They had not drifted — but two copies
+ * of a privacy control is how a hardening pass ends up fixing only one of them,
+ * and the widening below is exactly such a pass.
  *
  * ## Scope, stated plainly
  *
@@ -76,7 +78,19 @@ export function redactSecrets(input: string): string {
       // `Authorization: Basic` rule without this one is the trap: a reader
       // checking "is basic auth handled?" gets yes from the header form and no
       // from the reachable one.
-      .replace(/(\w+:\/\/)[^/\s@]+:[^/\s@]+@/g, "$1[redacted]@")
+      //
+      // `\w{1,16}`, not `\w+`: an unbounded leading quantifier denies the engine
+      // a prescan, so every position inside a run of word characters becomes a
+      // start candidate that scans to end-of-string — quadratic, and this
+      // function runs synchronously on the UI thread inside a `catch`. A plain
+      // 100k-char run of `x` with no credential in it took 10.2s; bounding the
+      // scheme run takes it to 7.9ms. The bound cannot change the OUTPUT: a
+      // longer word-character run simply matches its last 16 characters
+      // instead, and the earlier ones are copied through verbatim either way.
+      // Verified byte-identical against `\w+` over 422,794 inputs (exhaustive
+      // over a 28-token alphabet to depth 3, plus randomized and targeted
+      // long-scheme cases).
+      .replace(/(\w{1,16}:\/\/)[^/\s@]+:[^/\s@]+@/g, "$1[redacted]@")
       // Credential-bearing query parameters. Already an assumed input shape:
       // `sentry.ts` runs this same function over `event.request.url`.
       .replace(

--- a/src/shared/scrub-text.ts
+++ b/src/shared/scrub-text.ts
@@ -1,0 +1,114 @@
+/**
+ * Scrubbing for free-form text that leaves the process — a crash report, or a
+ * report body a user is about to paste into a public GitHub issue.
+ *
+ * Both halves started life in `src/client/sentry.ts` and moved here when a
+ * second consumer appeared (`client/utils/client-log.ts`, #1439). Two copies of
+ * a privacy control is how a hardening pass ends up fixing only one of them.
+ *
+ * ## Scope, stated plainly
+ *
+ * `redactPaths` collapses the **username segment only**: `/Users/alice/Docs/
+ * board-minutes.md` becomes `/Users/[user]/Docs/board-minutes.md`. Filenames and
+ * directories survive, and in a document editor those are often the sensitive
+ * part. This is deliberately **narrower than the server-side pass** in
+ * `shared/redact-user-paths.ts`, which is handed real roots (`$HOME`,
+ * `$USERPROFILE`, `TANDEM_APP_DATA_DIR`, `XDG_DATA_HOME`, `LOCALAPPDATA`) and so
+ * also catches `/root/…`, redirected Windows profiles (`D:\Profiles\<user>`),
+ * UNC shares and app-data dirs outside home. (Fedora Silverblue's
+ * `/var/home/<user>` IS covered here — the patterns are unanchored — so the gap
+ * is narrower than "only $HOME-shaped paths"; `tests/shared/scrub-text.test.ts`
+ * pins both the coverage and the gap.) A caller with access to those roots should use
+ * that module instead; this one exists for callers that have none — the WebView
+ * cannot read the environment.
+ *
+ * `redactSecrets` is an ENUMERATION, not a classifier: it matches the credential
+ * shapes this codebase plausibly produces, and everything else passes through.
+ * Known gaps — AWS (`AKIA…`), Google (`AIza…`), npm (`npm_…`), bare
+ * `x-api-key:` and `Cookie:` header values, `?refresh_token=`/`?auth=` query
+ * names, and a token living in a URL PATH segment — are pinned by a "documented gap" test
+ * in `tests/shared/scrub-text.test.ts`. Pinned rather than merely unmentioned:
+ * an unlisted gap reads as coverage to the next reader, and the enumerated list
+ * above is exactly the thing that invites that misreading.
+ *
+ * ## Purity
+ *
+ * No `process`, no `os`, no Node builtins, no imports at all: this module is
+ * bundled into the browser client, where `process` is not defined (`vite.config.ts`
+ * declares no `define` for it) and touching it would be a runtime ReferenceError.
+ */
+
+/**
+ * Redact anything that looks like a credential.
+ *
+ * Conservative by construction: a false positive costs a `[redacted]` in a bug
+ * report, a false negative puts a live token in a public issue. The list grew
+ * with the input distribution — Sentry only ever fed this `Error` objects, while
+ * the client log feeds it Tauri IPC rejection strings and (after the #1439
+ * follow-up) arbitrary server-supplied messages.
+ */
+export function redactSecrets(input: string): string {
+  return (
+    input
+      // Anthropic keys first: the generic `sk-` rule below would otherwise
+      // swallow the `sk-ant-` prefix that identifies which vendor leaked.
+      .replace(/sk-ant-[A-Za-z0-9_-]{8,}/g, "sk-ant-[redacted]")
+      .replace(/sk-[A-Za-z0-9_-]{16,}/g, "sk-[redacted]")
+      .replace(/\bBearer\s+[A-Za-z0-9._~+/-]{12,}=*/gi, "Bearer [redacted]")
+      .replace(/\bBasic\s+[A-Za-z0-9+/]{8,}={0,2}/gi, "Basic [redacted]")
+      // GitHub's token family. Worth naming explicitly because the destination
+      // of this text IS a GitHub issue: a leaked `ghp_` there is live, public,
+      // and scoped to the account filing the report.
+      .replace(/\bgh([pousr])_[A-Za-z0-9]{16,}/g, "gh$1_[redacted]")
+      .replace(/\bgithub_pat_[A-Za-z0-9_]{20,}/g, "github_pat_[redacted]")
+      // Slack and Stripe. These two are here rather than in the documented-gap
+      // list below because GitHub's own push protection recognises both shapes
+      // as live credentials — it blocked a commit carrying them as test
+      // fixtures — which is the strongest available evidence that they read as
+      // real and belong in a scrubber whose output lands in a GitHub issue.
+      .replace(/\bxox([abeprs])-[A-Za-z0-9-]{10,}/g, "xox$1-[redacted]")
+      .replace(/\b(sk|pk|rk)_(live|test)_[A-Za-z0-9]{10,}/g, "$1_$2_[redacted]")
+      // JWTs: three base64url segments. The header always starts `eyJ` because
+      // every JWT header begins `{"`.
+      .replace(/\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]+/g, "[redacted-jwt]")
+      // `scheme://user:pass@host` — the shape that actually reaches this
+      // function, since `sentry.ts` runs it over `event.request.url`. An
+      // `Authorization: Basic` rule without this one is the trap: a reader
+      // checking "is basic auth handled?" gets yes from the header form and no
+      // from the reachable one.
+      .replace(/(\w+:\/\/)[^/\s@]+:[^/\s@]+@/g, "$1[redacted]@")
+      // Credential-bearing query parameters. Already an assumed input shape:
+      // `sentry.ts` runs this same function over `event.request.url`.
+      .replace(
+        /([?&](?:token|key|access_token|api_key|apikey|secret|password|sig|signature)=)[^&\s"'`]+/gi,
+        "$1[redacted]",
+      )
+  );
+}
+
+/**
+ * Replace absolute home-dir prefixes with a placeholder user segment.
+ *
+ * The WebView can't read `$HOME`, but file paths surfaced in error messages
+ * typically embed a recognizable `/Users/<name>/`, `/home/<name>/`, or
+ * `C:\Users\<name>\` segment. Collapse the user segment so a report can't
+ * fingerprint the OS account.
+ */
+export function redactPaths(input: string): string {
+  return (
+    input
+      .replace(/(\/Users\/)[^/\\]+/g, "$1[user]")
+      .replace(/(\/home\/)[^/\\]+/g, "$1[user]")
+      // `i` on THIS rule only. Windows paths are case-insensitive, so
+      // `c:\users\bob` and `C:\USERS\bob` name the same directory and leak the
+      // same account name; the two POSIX rules above are on case-SENSITIVE
+      // filesystems where `/Users` and `/users` are genuinely different
+      // directories, and an `i` there would collapse an unrelated one.
+      .replace(/([A-Za-z]:\\users\\)[^\\]+/gi, "$1[user]")
+  );
+}
+
+/** Secrets then paths — the order the Sentry scrubber has always used. */
+export function scrubText(input: string): string {
+  return redactPaths(redactSecrets(input));
+}

--- a/tests/client/bug-report-url.test.ts
+++ b/tests/client/bug-report-url.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
+import type { ClientLogEntry } from "../../src/client/utils/client-log";
+import type { DiagnosticsPayload } from "../../src/client/utils/diagnostics";
 import {
   BUG_REPORT_BODY_HEADING,
   buildBugReportUrl,
+  formatDiagnostics,
   MAX_ISSUE_URL_LENGTH,
 } from "../../src/client/utils/diagnostics";
 import { TANDEM_ISSUES_NEW_URL } from "../../src/shared/constants";
@@ -126,5 +129,124 @@ describe("buildBugReportUrl", () => {
     for (const input of ["short", "a\nb\nc", "with spaces & ampersands ?=#", "…unicode…"]) {
       expect(() => new URL(buildBugReportUrl(input))).not.toThrow();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composition with `formatDiagnostics` — placement of the client-log section
+// ---------------------------------------------------------------------------
+
+/**
+ * These tests deliberately compose the REAL formatter rather than hand-building
+ * a report string. `buildBugReportUrl` takes an opaque string and is unchanged
+ * by #1439, so a hand-built input can only restate the truncation test above:
+ * it passes identically whether the client-log section is rendered above the
+ * check list or appended after it. Only the round-trip discriminates the two,
+ * and the placement is the thing worth pinning — appended at the tail, the
+ * section is the first thing truncation drops, so the fix would work for Copy
+ * Diagnostics and silently not work for Report a bug.
+ */
+function bigPayload(checkCount: number): DiagnosticsPayload {
+  return {
+    report: {
+      ok: true,
+      crashed: false,
+      failures: 0,
+      warnings: 0,
+      summary: "All checks passed. Tandem is ready.",
+      error: null,
+      results: Array.from({ length: checkCount }, (_, i) => ({
+        check: `check-${i}`,
+        status: "pass" as const,
+        message: `probe ${i} completed and everything looked entirely normal here`,
+      })),
+    },
+    version: "1.2.3",
+    transport: "http",
+    platform: "darwin",
+    arch: "arm64",
+    nodeVersion: "v22.0.0",
+    tauriSidecar: true,
+  };
+}
+
+function logEntries(): ClientLogEntry[] {
+  return [
+    {
+      at: 1,
+      firstAt: 1,
+      level: "warn",
+      scope: "wizard",
+      event: "e0",
+      detail: "OLDEST_MARKER",
+      count: 1,
+    },
+    ...Array.from({ length: 4 }, (_, i) => ({
+      at: 2 + i,
+      firstAt: 2 + i,
+      level: "warn" as const,
+      scope: "wizard",
+      event: `e${i + 1}`,
+      detail: `FILLER_MARKER_${i}`,
+      count: 1,
+    })),
+    {
+      at: 9,
+      firstAt: 8,
+      level: "error",
+      scope: "cowork",
+      event: "e5",
+      detail: "NEWEST_MARKER",
+      count: 2,
+    },
+  ];
+}
+
+describe("buildBugReportUrl composed with formatDiagnostics", () => {
+  it("keeps the newest client warning and drops check lines when over the cap", () => {
+    const text = formatDiagnostics(bigPayload(60), { clientLog: logEntries() });
+    // Precondition: the report really is too big, or this proves nothing.
+    // The encoded body alone already exceeds the cap, so the full URL must.
+    expect(encodeURIComponent(text).length).toBeGreaterThan(MAX_ISSUE_URL_LENGTH);
+
+    const url = buildBugReportUrl(text);
+    const body = bodyOf(url);
+
+    expect(url.length).toBeLessThanOrEqual(MAX_ISSUE_URL_LENGTH);
+    // (a) the highest-value header survives, as it always has
+    expect(body).toContain("Tandem v1.2.3 (http, desktop)");
+    // (b) the newest warning survives — this is what head placement buys
+    expect(body).toContain("NEWEST_MARKER");
+    // (c) the tail of the check list is what got dropped instead
+    expect(body).not.toContain("check-59");
+    expect(body).toContain("truncated");
+  });
+
+  it("still carries a usable check list when the buffer is full", () => {
+    // The complement: the budget in `formatDiagnostics` is what stops the
+    // section from evicting the entire doctor report ahead of itself.
+    const clientLog = Array.from({ length: 20 }, (_, i) => ({
+      at: i,
+      firstAt: i,
+      level: "warn" as const,
+      scope: "wizard",
+      event: `event-${i}`,
+      detail: "D".repeat(160),
+      count: 1,
+    }));
+    const body = bodyOf(buildBugReportUrl(formatDiagnostics(bigPayload(60), { clientLog })));
+
+    expect(body).toContain("check-0");
+    expect(body).toContain("check-5");
+    // The char budget binds before the line budget at this detail length —
+    // either way the section announces what it withheld.
+    expect(body).toMatch(/\(showing [1-6] of 20\)/);
+  });
+
+  it("leaves the URL unchanged when the client log is empty", () => {
+    const payload = bigPayload(3);
+    expect(buildBugReportUrl(formatDiagnostics(payload, { clientLog: [] }))).toBe(
+      buildBugReportUrl(formatDiagnostics(payload)),
+    );
   });
 });

--- a/tests/client/client-log-callsites.test.ts
+++ b/tests/client/client-log-callsites.test.ts
@@ -12,10 +12,20 @@ import { describe, expect, it } from "vitest";
  * title, a file path, or user input into. TypeScript cannot express
  * "literal only", so it is pinned here.
  *
- * This matters most for the follow-up that migrates the other ~150
+ * This matters most for the follow-up that migrates the other ~147
  * `console.warn`/`console.error` sites: several of them today do exactly what
  * this forbids (`Editor.svelte` interpolates `resolved.path` into a template
  * literal), and a mechanical sweep would carry that straight into an issue body.
+ *
+ * ## What this scan does NOT establish
+ *
+ * It constrains the SHAPE of what a call site may pass, never the CONTENT. A
+ * bare identifier is still a value someone chose, and `describeCause`'s string
+ * branch captures a `string` cause verbatim — scrubbed and capped, but
+ * `redactPaths` collapses the username segment only, so a path cause still names
+ * the document. So this makes the follow-up sweep MECHANICAL, not SAFE: it
+ * catches the interpolation shapes and leaves a human to judge the values. It
+ * is a lower bound on review, not a substitute for it.
  *
  * ## Why the shape of this test is what it is
  *
@@ -56,13 +66,22 @@ const LOOSE = /\blogClient(?:Warning|Error)\s*\(/g;
 
 /**
  * A COMPLIANT call. `\s*` throughout (not `.`), so a biome-wrapped multi-line
- * call still matches; the third argument may only be a bare identifier or a
- * member expression, which rejects a string literal, a template literal, a
- * concatenation and a call such as `String(err)` — argument three is where
- * untrusted text would actually enter.
+ * call still matches; the third argument may only be a BARE IDENTIFIER, which
+ * rejects a string literal, a template literal, a concatenation, a call such as
+ * `String(err)` — and a member expression. Argument three is where untrusted
+ * text would actually enter.
+ *
+ * Member expressions used to be allowed, and that made this scan pass exactly
+ * the shape the module doc above cites as the reason the sweep is unsafe:
+ * `logClientWarning("editor", "link refused", resolved.path)` scanned clean
+ * while landing a document filename in a public issue body. A bare identifier is
+ * not a guarantee — see "What this scan does NOT establish" — but reaching INTO
+ * an object for a field is the one shape that is nearly always a deliberate
+ * detail grab, so it is worth failing. Both current call sites pass a bare
+ * `err`; a compliant biome-wrapped call still matches.
  */
 const STRICT =
-  /\blogClient(?:Warning|Error)\s*\(\s*"[^"\\]*"\s*,\s*"[^"\\]*"\s*(?:,\s*[A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*)*\s*)?,?\s*\)/g;
+  /\blogClient(?:Warning|Error)\s*\(\s*"[^"\\]*"\s*,\s*"[^"\\]*"\s*(?:,\s*[A-Za-z_$][\w$]*\s*)?,?\s*\)/g;
 
 const files = walk(CLIENT_ROOT).filter((f) => f !== MODULE);
 

--- a/tests/client/client-log-callsites.test.ts
+++ b/tests/client/client-log-callsites.test.ts
@@ -1,0 +1,116 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The call-site contract for the client log (#1439).
+ *
+ * `logClientWarning`/`logClientError` feed a report a user pastes into a public
+ * GitHub issue, and `buildBugReportUrl` prefills that body — so the user's
+ * review step is an opt-out. The privacy control is the API's shape: `scope` and
+ * `event` are STATIC LITERALS, so there is nothing to interpolate a document
+ * title, a file path, or user input into. TypeScript cannot express
+ * "literal only", so it is pinned here.
+ *
+ * This matters most for the follow-up that migrates the other ~150
+ * `console.warn`/`console.error` sites: several of them today do exactly what
+ * this forbids (`Editor.svelte` interpolates `resolved.path` into a template
+ * literal), and a mechanical sweep would carry that straight into an issue body.
+ *
+ * ## Why the shape of this test is what it is
+ *
+ * A plain "find the calls and check them" scan fails GREEN, which is the
+ * `audit:origins` failure mode CLAUDE.md Critical Rule 2 records. Four ways it
+ * can silently pass, and the answer to each:
+ *
+ *  1. `biome.json` sets `lineWidth: 100`, so a deeply-indented call wraps across
+ *     lines. A pattern that cannot parse it simply matches nothing and the
+ *     iteration body never runs → the COUNT INVARIANT below (loose occurrences
+ *     must EQUAL strict matches) turns "cannot parse" into a failure.
+ *  2. `import { logClientWarning as warn }` defeats a callee-name key — plausible,
+ *     since `annotation-actions.ts` already binds a local `warn`. → alias check.
+ *  3. A one-line forwarding wrapper elsewhere means no scanned file ever contains
+ *     a violating literal. → re-export check.
+ *  4. Renaming the recorders would leave this asserting nothing. → floor.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const SRC = join(ROOT, "src");
+const CLIENT_ROOT = join(SRC, "client");
+const MODULE = join(CLIENT_ROOT, "utils", "client-log.ts");
+// `.svelte` is not optional: one of the two call sites lives in
+// `IntegrationWizardModal.svelte`. (Precedent: `testid-coverage.test.ts`.)
+const EXT = [".ts", ".svelte"];
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (EXT.some((e) => full.endsWith(e)) && !full.endsWith(".d.ts")) out.push(full);
+  }
+  return out;
+}
+
+/** Any mention of a recorder call, however it is formatted. */
+const LOOSE = /\blogClient(?:Warning|Error)\s*\(/g;
+
+/**
+ * A COMPLIANT call. `\s*` throughout (not `.`), so a biome-wrapped multi-line
+ * call still matches; the third argument may only be a bare identifier or a
+ * member expression, which rejects a string literal, a template literal, a
+ * concatenation and a call such as `String(err)` — argument three is where
+ * untrusted text would actually enter.
+ */
+const STRICT =
+  /\blogClient(?:Warning|Error)\s*\(\s*"[^"\\]*"\s*,\s*"[^"\\]*"\s*(?:,\s*[A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*)*\s*)?,?\s*\)/g;
+
+const files = walk(CLIENT_ROOT).filter((f) => f !== MODULE);
+
+function countOf(text: string, pattern: RegExp): number {
+  return text.match(new RegExp(pattern.source, "g"))?.length ?? 0;
+}
+
+describe("client-log call sites", () => {
+  const callSites = files
+    .map((file) => ({ file, text: readFileSync(file, "utf8") }))
+    // Never `LOOSE.test(text)`: a /g regex carries `lastIndex` between calls.
+    .filter(({ text }) => countOf(text, LOOSE) > 0);
+
+  it("finds the call sites at all", () => {
+    // A floor, so a rename or a deletion cannot leave this suite asserting
+    // nothing at all while still reporting green.
+    const total = callSites.reduce((n, { text }) => n + countOf(text, LOOSE), 0);
+    expect(total).toBeGreaterThanOrEqual(2);
+  });
+
+  it("passes only string literals for scope and event, and no literal cause", () => {
+    const offenders = callSites
+      .filter(({ text }) => countOf(text, LOOSE) !== countOf(text, STRICT))
+      .map(({ file }) => relative(ROOT, file));
+    // A call this cannot parse counts as a violation, never as a skip: an
+    // unparseable call site and a compliant one must not look the same.
+    expect(offenders).toEqual([]);
+  });
+
+  it("imports the recorders under their own names", () => {
+    const aliased: string[] = [];
+    for (const { file, text } of callSites) {
+      for (const match of text.matchAll(/import\s*\{([^}]*)\}\s*from\s*"[^"]*client-log[^"]*"/g)) {
+        if (/\bas\b/.test(match[1])) aliased.push(relative(ROOT, file));
+      }
+    }
+    expect(aliased).toEqual([]);
+  });
+
+  it("is not re-exported, so no wrapper can hide a call site from this scan", () => {
+    const reexports = walk(SRC)
+      .filter(
+        (file) =>
+          /export\s*(?:type\s*)?\{[^}]*logClient(?:Warning|Error)[^}]*\}/.test(
+            readFileSync(file, "utf8"),
+          ) || /export\s*\*\s*from\s*"[^"]*client-log/.test(readFileSync(file, "utf8")),
+      )
+      .map((file) => relative(ROOT, file));
+    expect(reexports).toEqual([]);
+  });
+});

--- a/tests/client/client-log.test.ts
+++ b/tests/client/client-log.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetClientLog,
+  logClientError,
+  logClientWarning,
+  readClientLog,
+} from "../../src/client/utils/client-log";
+
+/**
+ * The ring buffer behind #1439. Most of what is asserted here is the PRIVACY
+ * contract, not the data structure: entries land in a report a user pastes into
+ * a public GitHub issue, and `buildBugReportUrl` prefills that body, so the
+ * user's review step is an opt-out rather than a gate.
+ */
+
+function quiet() {
+  return {
+    warn: vi.spyOn(console, "warn").mockImplementation(() => {}),
+    error: vi.spyOn(console, "error").mockImplementation(() => {}),
+  };
+}
+
+beforeEach(() => {
+  _resetClientLog();
+  vi.restoreAllMocks();
+});
+
+describe("ring buffer", () => {
+  it("keeps the newest CAPACITY entries and drops the oldest", () => {
+    quiet();
+    for (let i = 0; i < 25; i++) logClientWarning("scope", `event ${i}`);
+    const log = readClientLog();
+    expect(log).toHaveLength(20);
+    expect(log[0].event).toBe("event 5");
+    expect(log[19].event).toBe("event 24");
+  });
+
+  it("coalesces a repeat that is NOT the newest entry", () => {
+    // The alternating case (A,B,A,B…) is the one a newest-only comparison
+    // misses, and it is the expected shape: the Cowork pre-flight is
+    // retry-driven and its catch covers several distinct causes. Without
+    // whole-buffer coalescing this fills 20 slots with 2 facts.
+    quiet();
+    for (let i = 0; i < 3; i++) {
+      logClientWarning("a", "first");
+      logClientError("b", "second");
+    }
+    const log = readClientLog();
+    expect(log).toHaveLength(2);
+    expect(log.map((e) => [e.scope, e.count])).toEqual([
+      ["a", 3],
+      ["b", 3],
+    ]);
+    // Most recently seen sorts last, so newest-first rendering leads with it.
+    expect(log[1].scope).toBe("b");
+  });
+
+  it("keeps two long causes distinct when they differ past the display cap", () => {
+    // Coalescing on the CLAMPED detail merges these and renders `(x2)` —
+    // actively asserting a repeat that never happened, which is worse than two
+    // lines. The key is a fingerprint of the full scrubbed cause.
+    quiet();
+    const prefix = "z".repeat(200);
+    logClientWarning("cowork", "probe failed", new Error(`${prefix} FIRST`));
+    logClientWarning("cowork", "probe failed", new Error(`${prefix} SECOND`));
+    const log = readClientLog();
+    expect(log).toHaveLength(2);
+    expect(log.map((e) => e.count)).toEqual([1, 1]);
+    // Both render identically — the point is that they are two events, not one
+    // that recurred.
+    expect(log[0].detail).toBe(log[1].detail);
+  });
+
+  it("tracks first and last occurrence separately", () => {
+    // `at` alone cannot tell a 300ms burst from three failures a quarter of an
+    // hour apart, and those are different bugs.
+    quiet();
+    logClientWarning("a", "e");
+    logClientWarning("a", "e");
+    const [entry] = readClientLog();
+    expect(entry.count).toBe(2);
+    expect(entry.firstAt).toBeLessThanOrEqual(entry.at);
+  });
+
+  it("does not leak the internal coalescing key to callers", () => {
+    quiet();
+    logClientWarning("a", "e", new Error("boom"));
+    expect(Object.keys(readClientLog()[0]).sort()).toEqual([
+      "at",
+      "count",
+      "detail",
+      "event",
+      "firstAt",
+      "level",
+      "scope",
+    ]);
+  });
+
+  it("keeps entries distinct when only the detail differs", () => {
+    quiet();
+    logClientWarning("wizard", "clipboard write failed", new Error("denied"));
+    logClientWarning("wizard", "clipboard write failed", new TypeError("no clipboard"));
+    expect(readClientLog().map((e) => e.detail)).toEqual([
+      "Error: denied",
+      "TypeError: no clipboard",
+    ]);
+  });
+
+  it("hands out copies, not the live entries coalescing mutates", () => {
+    // `useBugReportUrl` holds this array across an await; a shallow copy would
+    // let the `(x3)` a user sees drift from what was rendered.
+    quiet();
+    logClientWarning("a", "e");
+    const snapshot = readClientLog();
+    logClientWarning("a", "e");
+    expect(snapshot[0].count).toBe(1);
+    expect(readClientLog()[0].count).toBe(2);
+  });
+
+  it("_resetClientLog empties it", () => {
+    quiet();
+    logClientWarning("a", "e");
+    _resetClientLog();
+    expect(readClientLog()).toEqual([]);
+  });
+});
+
+describe("console fidelity", () => {
+  it("logs exactly what the hand-written call logged, with the RAW cause", () => {
+    // `integration-wizard-push-support.test.ts` asserts this exact shape; a
+    // developer with an inspector open must keep the object and its stack.
+    const { warn, error } = quiet();
+    const err = new Error("denied");
+    logClientWarning("wizard", "clipboard write failed", err);
+    expect(warn).toHaveBeenCalledWith("[wizard] clipboard write failed:", err);
+    logClientError("cowork", "subnet pre-flight threw", err);
+    expect(error).toHaveBeenCalledWith("[cowork] subnet pre-flight threw:", err);
+  });
+
+  it("omits the colon when there is no cause", () => {
+    const { warn } = quiet();
+    logClientWarning("wizard", "nothing to copy");
+    expect(warn).toHaveBeenCalledWith("[wizard] nothing to copy");
+  });
+});
+
+describe("describeCause — privacy contract", () => {
+  it("records the error name, which is the whole diagnostic point", () => {
+    // NotAllowedError vs TypeError vs SecurityError is what separates the three
+    // clipboard bugs #1439 opens with.
+    quiet();
+    const denied = new DOMException("Write permission denied", "NotAllowedError");
+    logClientWarning("wizard", "clipboard write failed", denied);
+    expect(readClientLog()[0].detail).toBe("NotAllowedError: Write permission denied");
+  });
+
+  it("captures a string cause — the Tauri invoke shape — scrubbed and capped", () => {
+    // `invoke` rejects with the Rust error's Display string, not an Error, so
+    // this branch is the ONLY thing that carries a Cowork pre-flight failure.
+    quiet();
+    // The path goes at the FRONT: with it past the 160-char cut this assertion
+    // passes with the scrubbing deleted entirely, and reads as if it covers it.
+    const rejection = `subnet probe failed at /home/bryan/tandem: ${"x".repeat(1000)}`;
+    logClientError("cowork", "subnet pre-flight threw", rejection);
+    const { detail } = readClientLog()[0];
+    expect(detail).toContain("/home/[user]/tandem");
+    expect(detail).not.toContain("bryan");
+    expect(detail.length).toBeLessThanOrEqual(161);
+    expect(detail.endsWith("…")).toBe(true);
+  });
+
+  it("caps a long Error message but keeps the name", () => {
+    quiet();
+    logClientWarning("scope", "event", new RangeError("y".repeat(1000)));
+    const { detail } = readClientLog()[0];
+    expect(detail.startsWith("RangeError: y")).toBe(true);
+    expect(detail.length).toBeLessThanOrEqual(161);
+  });
+
+  it("drops a lone surrogate that was already in the message", () => {
+    // Not a theoretical shape: `encodeURIComponent` throws URIError on one, and
+    // `buildBugReportUrl` answers a throw by returning the BARE issue URL — the
+    // whole prefill gone, on the surface this feature exists to fix. Nothing
+    // upstream can remove one (every scrub pattern is ASCII), so the buffer is
+    // where it has to be handled.
+    quiet();
+    logClientWarning("scope", "event", `boom ${String.fromCharCode(0xd800)} tail`);
+    const { detail } = readClientLog()[0];
+    expect(detail).toBe("boom  tail");
+    expect(() => encodeURIComponent(detail)).not.toThrow();
+
+    // A trailing low surrogate is the same hazard from the other end.
+    logClientWarning("scope", "other", `tail ${String.fromCharCode(0xdc00)}`);
+    expect(() => encodeURIComponent(readClientLog()[1].detail)).not.toThrow();
+  });
+
+  it("keeps well-formed pairs intact", () => {
+    quiet();
+    logClientWarning("scope", "event", "ok 🙂 done");
+    expect(readClientLog()[0].detail).toBe("ok 🙂 done");
+  });
+
+  it("never truncates into a lone surrogate", () => {
+    // `encodeURIComponent` throws URIError on one, and `buildBugReportUrl`
+    // answers a throw by dropping the entire prefill.
+    quiet();
+    logClientWarning("scope", "event", "🙂".repeat(200));
+    const { detail } = readClientLog()[0];
+    expect(() => encodeURIComponent(detail)).not.toThrow();
+    expect(/[\uD800-\uDBFF]$/.test(detail.slice(0, -1))).toBe(false);
+  });
+
+  it("scrubs user paths and secrets on the way IN", () => {
+    // On the way in, so the buffer never holds unscrubbed text for some other
+    // reader (a Sentry breadcrumb, a heap dump) to pick up.
+    quiet();
+    logClientWarning(
+      "scope",
+      "event",
+      new Error("ENOENT /Users/alice/x.md and ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
+    );
+    const { detail } = readClientLog()[0];
+    expect(detail).toContain("/Users/[user]/x.md");
+    expect(detail).toContain("ghp_[redacted]");
+    expect(detail).not.toContain("alice");
+  });
+
+  it("never reads .stack or .cause", () => {
+    // A stated rule, not an emergent one: the obvious "make detail more useful"
+    // follow-up is `err.cause?.message`, and a stack is almost entirely
+    // absolute file paths.
+    quiet();
+    const inner = new Error("INNER_MARKER_/Users/alice/private.md");
+    const outer = new Error("outer failed", { cause: inner });
+    outer.stack = "Error: outer failed\n    at boom (/Users/alice/app/main.js:1:1)";
+    logClientWarning("scope", "event", outer);
+    const serialized = JSON.stringify(readClientLog()[0]);
+    expect(serialized).not.toContain("INNER_MARKER");
+    expect(serialized).not.toContain("alice");
+    expect(serialized).not.toContain(" at ");
+    expect(readClientLog()[0].detail).toBe("Error: outer failed");
+  });
+
+  it("records only the TYPE of a non-error object, never its fields", () => {
+    quiet();
+    class RejectedPayload {
+      secretPath = "/Users/alice/x";
+      body = "the whole document";
+    }
+    logClientWarning("scope", "event", new RejectedPayload());
+    const { detail } = readClientLog()[0];
+    expect(detail).toBe("RejectedPayload");
+    logClientWarning("scope", "other", { secretPath: "/Users/alice/x", body: "doc" });
+    expect(readClientLog()[1].detail).toBe("Object");
+    expect(JSON.stringify(readClientLog())).not.toContain("secretPath");
+  });
+
+  it("survives a null-prototype object", () => {
+    quiet();
+    logClientWarning("scope", "event", Object.assign(Object.create(null), { a: 1 }));
+    expect(readClientLog()[0].detail).toBe("object");
+  });
+
+  it("records nothing for an absent cause", () => {
+    quiet();
+    logClientWarning("scope", "event");
+    expect(readClientLog()[0].detail).toBe("");
+  });
+
+  it("collapses newlines so one entry cannot forge report structure", () => {
+    // `stripControlChars` deliberately preserves \n (that is why `fenceFor`
+    // exists), and multi-line messages are routine for Tauri and JSON errors.
+    // Left alone, a message can inject a convincing `[ok]` check line into a
+    // public issue body.
+    quiet();
+    logClientWarning("scope", "event", new Error("boom\n[ok]   fake-check — nothing to see"));
+    const { detail } = readClientLog()[0];
+    // Interior runs are left alone — only the newline (and whitespace
+    // adjacent to it) collapses. One line is what matters.
+    expect(detail).toBe("Error: boom [ok]   fake-check — nothing to see");
+    expect(detail).not.toContain("\n");
+  });
+});

--- a/tests/client/client-log.test.ts
+++ b/tests/client/client-log.test.ts
@@ -203,11 +203,85 @@ describe("describeCause — privacy contract", () => {
   it("never truncates into a lone surrogate", () => {
     // `encodeURIComponent` throws URIError on one, and `buildBugReportUrl`
     // answers a throw by dropping the entire prefill.
+    //
+    // The leading `"x"` is the whole point of the fixture and must not be
+    // "tidied" away. Every emoji is two UTF-16 units, so a bare
+    // `"🙂".repeat(200)` puts a LOW surrogate at index 159 and the 160-char cut
+    // lands neatly BETWEEN pairs — deleting the cut-site strip in `clamp` left
+    // this test green, which is how it shipped asserting nothing. One BMP
+    // character of offset puts a HIGH surrogate at index 159 so the cut splits a
+    // pair, which is the case the strip exists for.
+    quiet();
+    logClientWarning("scope", "event", `x${"🙂".repeat(200)}`);
+    const { detail } = readClientLog()[0];
+    expect(() => encodeURIComponent(detail)).not.toThrow();
+    expect(/[\uD800-\uDBFF]$/.test(detail.slice(0, -1))).toBe(false);
+    // Pin the geometry itself, so a later change to `MAX_DETAIL_CHARS` cannot
+    // silently move the cut back between pairs and re-vacuate the assertion.
+    expect(`x${"🙂".repeat(200)}`.charCodeAt(159)).toBeGreaterThanOrEqual(0xd800);
+    expect(`x${"🙂".repeat(200)}`.charCodeAt(159)).toBeLessThanOrEqual(0xdbff);
+  });
+
+  it("still handles a cut that falls between surrogate pairs", () => {
+    // The even case the fixture above used to be. Kept: the two differ in which
+    // branch of `clamp` does the work, and only the odd one exercises the strip.
     quiet();
     logClientWarning("scope", "event", "🙂".repeat(200));
     const { detail } = readClientLog()[0];
     expect(() => encodeURIComponent(detail)).not.toThrow();
-    expect(/[\uD800-\uDBFF]$/.test(detail.slice(0, -1))).toBe(false);
+    expect(detail.endsWith("…")).toBe(true);
+  });
+
+  it("bounds the RAW cause before scrubbing, not just the stored detail", () => {
+    // The ReDoS half of the fix, pinned by SHAPE rather than by a clock.
+    //
+    // `describeCause` scrubs the full cause and only then clamps, so cost was a
+    // function of raw input on the UI thread inside a `catch`. Two passes are
+    // super-linear on their own — `collapseLines`' leading `\s*` over a
+    // whitespace run, and the URL rule's two runs either side of a `:` over a
+    // colon run (`"https://" + "a:".repeat(50000)` took 33s) — and no regex
+    // rewrite removes the second one. The cap is what bounds them.
+    //
+    // Observable consequence, with no timing involved: two causes that agree for
+    // the first `MAX_CAUSE_CHARS` are indistinguishable to `fingerprint`, so
+    // they COALESCE. Delete the `cap(...)` call and they become two entries.
+    quiet();
+    const shared = "z".repeat(2000);
+    logClientWarning("scope", "event", `${shared}AAA`);
+    logClientWarning("scope", "event", `${shared}BBB`);
+    const entries = readClientLog();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].count).toBe(2);
+    // And the converse, so the test cannot pass by coalescing everything: a
+    // difference INSIDE the cap still separates them.
+    _resetClientLog();
+    logClientWarning("scope", "event", `A${shared}`);
+    logClientWarning("scope", "event", `B${shared}`);
+    expect(readClientLog()).toHaveLength(2);
+  });
+
+  it("never lets a throwing cause escape into the caller's catch block", () => {
+    // `src/client/sentry.ts`'s stated norm — never let telemetry throw into the
+    // app's error path — applied here, because this module is the declared
+    // intake for the other ~150 `console.warn` sites. `describeCause` reads
+    // `cause.name`, so a throwing getter would abort the CALLER's `catch` and
+    // the user-facing recovery line after the warn would never run.
+    const { warn } = quiet();
+    const hostile = {
+      get name(): string {
+        throw new Error("boom");
+      },
+      message: "x",
+    };
+    expect(() => logClientWarning("scope", "event", hostile)).not.toThrow();
+    // The console line is the part that predates the ring buffer, so it must be
+    // emitted whether or not the buffer write survives. Asserted by IDENTITY,
+    // not `toHaveBeenCalledWith`: a deep-equality check would itself read the
+    // throwing getter and fail the test from the assertion rather than the code.
+    expect(warn.mock.calls).toHaveLength(1);
+    expect(warn.mock.calls[0][0]).toBe("[scope] event:");
+    expect(warn.mock.calls[0][1]).toBe(hostile);
+    expect(readClientLog()).toHaveLength(0);
   });
 
   it("scrubs user paths and secrets on the way IN", () => {

--- a/tests/client/cowork-preflight-hook.test.ts
+++ b/tests/client/cowork-preflight-hook.test.ts
@@ -12,6 +12,7 @@
  */
 import { tick } from "svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetClientLog, readClientLog } from "../../src/client/utils/client-log";
 
 const preflightSubnet = vi.fn();
 
@@ -192,5 +193,37 @@ describe("createSubnetPreflight", () => {
 
     expect(probe.preflight).toEqual({ status: "unknown" });
     expect(probe.probing).toBe(false);
+  });
+
+  it("records the failure where a bug report can reach it (#1439)", async () => {
+    // `unknown` is never rendered, and the release desktop build ships no
+    // devtools, so before #1439 the cause of a pre-flight failure was
+    // unrecoverable from a user's bug report.
+    _resetClientLog();
+    preflightSubnet.mockRejectedValueOnce(new Error("bridge gone"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSubnetPreflight().run();
+
+    expect(readClientLog()).toEqual([
+      expect.objectContaining({
+        level: "error",
+        scope: "cowork",
+        event: "subnet pre-flight threw",
+        detail: "Error: bridge gone",
+      }),
+    ]);
+  });
+
+  it("records a STRING rejection, which is the real Tauri shape", async () => {
+    // `invoke` rejects with the Rust error's Display string, not an Error, so
+    // the string branch of `describeCause` is the only thing that carries this.
+    _resetClientLog();
+    preflightSubnet.mockRejectedValueOnce("subnet probe failed: no such command");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSubnetPreflight().run();
+
+    expect(readClientLog()[0].detail).toBe("subnet probe failed: no such command");
   });
 });

--- a/tests/client/diagnostics-format.test.ts
+++ b/tests/client/diagnostics-format.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
+import type { ClientLogEntry } from "../../src/client/utils/client-log";
 import type { DiagnosticsPayload } from "../../src/client/utils/diagnostics";
 import {
+  CLIENT_LOG_HEADING,
   formatDiagnostics,
   formatMemoryMb,
+  MAX_CLIENT_LOG_CHARS,
+  MAX_CLIENT_LOG_LINES,
   summarizeUserAgent,
 } from "../../src/client/utils/diagnostics";
 
@@ -257,5 +261,123 @@ describe("summarizeUserAgent", () => {
   it("returns an empty string for an unrecognized agent, which drops the line", () => {
     expect(summarizeUserAgent("")).toBe("");
     expect(summarizeUserAgent("SomeCrawler/1.0")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client-log section (#1439)
+// ---------------------------------------------------------------------------
+
+function entry(overrides: Partial<ClientLogEntry> = {}): ClientLogEntry {
+  return {
+    at: 1.5,
+    firstAt: 1.5,
+    level: "warn",
+    scope: "wizard",
+    event: "clipboard write failed",
+    detail: "NotAllowedError: Write permission denied",
+    count: 1,
+    ...overrides,
+  };
+}
+
+describe("formatDiagnostics — client log", () => {
+  it("renders nothing at all when there is no client log", () => {
+    // The degradation contract: a report with no client warnings is
+    // byte-identical to one produced before this section existed.
+    const baseline = formatDiagnostics(makePayload());
+    expect(formatDiagnostics(makePayload(), {})).toBe(baseline);
+    expect(formatDiagnostics(makePayload(), { clientLog: [] })).toBe(baseline);
+    expect(baseline).not.toContain("Recent client warnings");
+  });
+
+  it("sits between the host block and the checks, with its own separator", () => {
+    // `hostLines()` above slices to the FIRST blank line and asserts with
+    // toEqual, so the host block must still end there.
+    const payload = makePayload();
+    payload.report.results = [{ check: "ports", status: "pass", message: "3478/3479 free" }];
+    const lines = formatDiagnostics(payload, {
+      browser: "Chrome 141",
+      clientLog: [entry()],
+    }).split("\n");
+
+    expect(lines[2]).toBe("Browser: Chrome 141");
+    expect(lines[3]).toBe("");
+    expect(lines[4]).toBe(CLIENT_LOG_HEADING);
+    expect(lines[5]).toBe(
+      "[warn] +1.5s wizard: clipboard write failed — NotAllowedError: Write permission denied",
+    );
+    expect(lines[6]).toBe("");
+    expect(lines[7]).toBe("[ok]   ports — 3478/3479 free");
+  });
+
+  it("renders newest first, so tail truncation drops the oldest", () => {
+    const text = formatDiagnostics(makePayload(), {
+      clientLog: [
+        entry({ event: "oldest", at: 1 }),
+        entry({ event: "middle", at: 2 }),
+        entry({ event: "newest", at: 3, firstAt: 0.4, level: "error", count: 3 }),
+      ],
+    });
+    const rendered = text
+      .split("\n")
+      .filter((l) => l.startsWith("[warn] +") || l.startsWith("[error] +"));
+    expect(rendered[0]).toContain("newest");
+    // The first-seen stamp rides with the count: `at` is the newest occurrence,
+    // so `(x3)` alone cannot say whether they were a burst or spread out.
+    expect(rendered[0]).toContain("(x3, first +0.4s)");
+    expect(rendered[0].startsWith("[error]")).toBe(true);
+    expect(rendered[2]).toContain("oldest");
+  });
+
+  it("omits the detail separator when there is no cause", () => {
+    const text = formatDiagnostics(makePayload(), { clientLog: [entry({ detail: "" })] });
+    expect(text).toContain("[warn] +1.5s wizard: clipboard write failed\n");
+  });
+
+  it("budgets the section so a full buffer cannot evict the doctor report", () => {
+    // Truncation drops from the tail and this section sits above the checks, so
+    // an unbudgeted section eats the entire check list before losing one entry.
+    const clientLog = Array.from({ length: 19 }, (_, i) =>
+      entry({ event: `event ${i}`, at: i, detail: "D".repeat(160) }),
+    );
+    const lines = formatDiagnostics(makePayload(), { clientLog }).split("\n");
+    const section = lines.slice(lines.indexOf(CLIENT_LOG_HEADING) + 1, lines.indexOf("", 4));
+    const body = section.filter((l) => !l.startsWith("(showing"));
+
+    expect(body.length).toBeLessThanOrEqual(MAX_CLIENT_LOG_LINES);
+    expect(body.join("\n").length).toBeLessThanOrEqual(MAX_CLIENT_LOG_CHARS);
+    expect(section.at(-1)).toBe(`(showing ${body.length} of 19)`);
+    // Newest survive the budget; the oldest are the ones withheld.
+    expect(body[0]).toContain("event 18");
+    expect(lines.join("\n")).not.toContain("event 0 ");
+  });
+
+  it("honours per-call budget overrides", () => {
+    const clientLog = [entry({ event: "a" }), entry({ event: "b" }), entry({ event: "c" })];
+    const text = formatDiagnostics(makePayload(), { clientLog }, { maxClientLogLines: 1 });
+    expect(text).toContain("(showing 1 of 3)");
+    expect(text).not.toContain(": a ");
+  });
+
+  it("emits at least one entry even when a single line blows the char budget", () => {
+    const text = formatDiagnostics(
+      makePayload(),
+      { clientLog: [entry({ detail: "D".repeat(160) })] },
+      { maxClientLogChars: 10 },
+    );
+    expect(text).toContain("[warn] +1.5s wizard: clipboard write failed — DDD");
+  });
+
+  it("strips control characters from a rendered entry", () => {
+    // Defense in depth: `detail` is already scrubbed on the way into the ring
+    // buffer, but every other line of this report goes through the same strip
+    // that the check lines do.
+    const esc = String.fromCharCode(27);
+    const text = formatDiagnostics(makePayload(), {
+      clientLog: [entry({ detail: `Error: ${esc}[31mred${esc}[0m` })],
+    });
+    expect(text).toContain("Error: [31mred[0m");
+    expect(text).not.toContain(esc);
   });
 });

--- a/tests/client/integration-wizard-push-support.test.ts
+++ b/tests/client/integration-wizard-push-support.test.ts
@@ -22,6 +22,7 @@
 import { cleanup, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { _resetClientLog, readClientLog } from "../../src/client/utils/client-log";
 
 import { CLAUDE_PLUGIN_INSTALL_COMMANDS } from "../../src/shared/constants.js";
 import type { ApplyItemResult } from "../../src/shared/integrations/contract.js";
@@ -417,6 +418,7 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
       },
     });
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    _resetClientLog();
     const { container } = mountPushMode(false);
     await tick();
 
@@ -431,6 +433,18 @@ describe("IntegrationWizardModal — push-mode copy (#1389, #1390)", () => {
     // from a CSP rejection. Without this the catch could stop logging and
     // nothing would notice.
     expect(warn).toHaveBeenCalledWith("[wizard] clipboard write failed:", expect.any(Error));
+    // …and since #1439 it also lands in the client log, which the diagnostics
+    // report drains — the console alone is a sink with no reader in a release
+    // desktop build. The error NAME is the payload: it is what separates a
+    // denied permission from a missing API from a policy rejection.
+    expect(readClientLog()).toEqual([
+      expect.objectContaining({
+        level: "warn",
+        scope: "wizard",
+        event: "clipboard write failed",
+        detail: "Error: denied",
+      }),
+    ]);
   });
 
   it("does not carry a copy status back from the Cowork sub-view", async () => {

--- a/tests/server/sentry-scrub.test.ts
+++ b/tests/server/sentry-scrub.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { scrub } from "../../src/server/sentry.js";
+import { redactPaths } from "../../src/shared/scrub-text.js";
 
 /**
  * The scrubber is the privacy-load-bearing surface of #921. These tests lock in
@@ -54,6 +55,55 @@ describe("server sentry scrub", () => {
     expect(scrub("Authorization: Bearer abcdef0123456789ghij")).toBe(
       "Authorization: Bearer [redacted]",
     );
+  });
+
+  it("redacts the wider credential set the sidecar can actually hold (#1439)", () => {
+    // The sidecar is the half most likely to be holding one of these: MCP
+    // server configs carry `env`/`headers` full of API keys — `GET
+    // /api/integrations/existing` exists precisely because of that — so an
+    // error quoting one used to reach Sentry unredacted. It shares
+    // `shared/scrub-text.ts` with the WebView reporter now; before that it had
+    // a private copy carrying only the three patterns above, which made the
+    // most exposed of the three surfaces the least redacted.
+    delete process.env.HOME;
+    expect(scrub("token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")).toBe("token ghp_[redacted]");
+    expect(scrub("github_pat_11ABCDEFG0abcdefghij_KLMNOPQRSTUVWXYZ0123456789")).toBe(
+      "github_pat_[redacted]",
+    );
+    expect(scrub("Authorization: Basic YWxpY2U6aHVudGVyMg==")).toBe(
+      "Authorization: Basic [redacted]",
+    );
+    expect(
+      scrub(
+        "failed: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+      ),
+    ).toBe("failed: [redacted-jwt]");
+    expect(scrub("GET /api/events?token=abc123def&x=1 failed")).toBe(
+      "GET /api/events?token=[redacted]&x=1 failed",
+    );
+    expect(scrub("connect https://alice:hunter2@internal.example.com/doc")).toBe(
+      "connect https://[redacted]@internal.example.com/doc",
+    );
+  });
+
+  it("agrees with the shared path scrubber on Windows case (#1439)", () => {
+    // The server half kept its own copy of the three path regexes and drifted:
+    // the shared one was fixed to be case-insensitive on `\Users\` (Windows
+    // paths are), this one was not, so a lowercase path leaked the OS account
+    // name from the sidecar into a public issue. `redactHome` composes the
+    // shared pass now, and this pins the two together — a second copy is how
+    // one of them gets fixed and the other does not.
+    delete process.env.HOME;
+    for (const input of [
+      String.raw`c:\users\bob\notes.md`,
+      String.raw`C:\Users\bob\notes.md`,
+      String.raw`C:\USERS\bob\notes.md`,
+      "/Users/bob/notes.md",
+      "/home/bob/notes.md",
+    ]) {
+      expect(scrub(input)).toBe(redactPaths(input));
+      expect(scrub(input)).not.toContain("bob");
+    }
   });
 
   it("leaves benign strings untouched", () => {

--- a/tests/shared/scrub-text.test.ts
+++ b/tests/shared/scrub-text.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { redactPaths, redactSecrets, scrubText } from "../../src/shared/scrub-text.js";
 
@@ -165,5 +166,49 @@ describe("scrubText", () => {
     expect(scrubText("/Users/dan/.env had sk-ant-api03-SECRETSECRET12")).toBe(
       "/Users/[user]/.env had sk-ant-[redacted]",
     );
+  });
+});
+
+/**
+ * The URL-credential rule opened `(\w+:\/\/)`, an unbounded quantifier with no
+ * literal for the engine to prescan on, so every position inside a run of word
+ * characters became a start candidate that scanned to end-of-string: 10.2s on a
+ * plain 100k-char run of `x` with no credential in it at all. It is bounded to
+ * `\w{1,16}` now.
+ *
+ * Both tests below are deliberately SHAPE-shaped, not wall-clock-shaped. This
+ * repo already has "completes in linear time" gates that fail under load, and a
+ * timing assertion here would join them; what actually needs pinning is that the
+ * bound did not cost any redaction, plus the bound itself.
+ */
+describe("the URL-credential rule's bound", () => {
+  it("still redacts the degenerate scheme shapes a tighter rule would drop", () => {
+    // These are not valid RFC 3986 schemes — a scheme must start with a letter —
+    // but `\w+` matched them, so refusing them now would be redaction LOST, and
+    // the consolidation's whole claim is that none was. The obvious tightening
+    // (`[A-Za-z][A-Za-z0-9+.-]{0,15}`) fails every line here.
+    expect(scrubText("0://user:pass@host")).toBe("0://[redacted]@host");
+    expect(scrubText("__://user:pass@host")).toBe("__://[redacted]@host");
+    expect(scrubText(":8080://user:pass@host")).toBe(":8080://[redacted]@host");
+    expect(scrubText("?tok=1://user:pass@host")).toBe("?tok=1://[redacted]@host");
+  });
+
+  it("is unaffected by a scheme run longer than the bound", () => {
+    // The bound cannot change the OUTPUT, only where the match starts: a longer
+    // word-character run matches its last 16 characters and the earlier ones are
+    // copied through verbatim. This is the property that let the fix be applied
+    // without re-deriving what the rule redacts.
+    const scheme = "w".repeat(40);
+    expect(scrubText(`${scheme}://user:pass@host`)).toBe(`${scheme}://[redacted]@host`);
+  });
+
+  it("keeps the bound in the source — a source scan, because behaviour cannot see it", () => {
+    // Behaviour is identical either way (that is the point of the two tests
+    // above), so nothing else in this file goes red if the bound is reverted.
+    // Precedent for asserting on source text: `client-log-callsites.test.ts`,
+    // `loopback-gate-claims.test.ts`.
+    const source = readFileSync(new URL("../../src/shared/scrub-text.ts", import.meta.url), "utf8");
+    expect(source).toContain(String.raw`(\w{1,16}:\/\/)`);
+    expect(source).not.toContain(String.raw`(\w+:\/\/)`);
   });
 });

--- a/tests/shared/scrub-text.test.ts
+++ b/tests/shared/scrub-text.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { redactPaths, redactSecrets, scrubText } from "../../src/shared/scrub-text.js";
+
+/**
+ * These scrubbers were sized for Sentry, which only ever fed them `Error`
+ * objects this codebase constructed. #1439 promotes them: the client log feeds
+ * them Tauri IPC rejection strings and server-supplied messages, and the
+ * destination is a public GitHub issue. The added patterns are the ones that
+ * distribution makes plausible.
+ */
+/**
+ * Fixtures for real-looking credentials are ASSEMBLED at runtime rather than
+ * written as literals.
+ *
+ * GitHub's push protection scans the file text and blocks a commit that carries
+ * a contiguous `xoxb-…` or `sk_live_…` string, fabricated or not — it rejected
+ * an earlier revision of this very file. Splitting the prefix from the body
+ * keeps the test honest without shipping something a scanner reads as live.
+ */
+function fake(...parts: string[]): string {
+  return parts.join("");
+}
+
+describe("redactSecrets", () => {
+  it.each([
+    ["key sk-ant-api03-ABCdef123_xyz here", "key sk-ant-[redacted] here"],
+    ["Bearer abcdefghijkl0123456789", "Bearer [redacted]"],
+    ["Authorization: Basic YWxpY2U6aHVudGVyMg==", "Authorization: Basic [redacted]"],
+    // The destination IS GitHub — a leaked ghp_ in an issue body is live.
+    ["token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", "token ghp_[redacted]"],
+    ["gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123", "gho_[redacted]"],
+    ["github_pat_11ABCDEFG0abcdefghij_KLMNOPQRSTUVWXYZ0123456789", "github_pat_[redacted]"],
+    [
+      "failed: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+      "failed: [redacted-jwt]",
+    ],
+    ["GET /api/events?token=abc123def&x=1 failed", "GET /api/events?token=[redacted]&x=1 failed"],
+    ["https://h/x?api_key=sekrit", "https://h/x?api_key=[redacted]"],
+    // The reachable shape of basic auth: `sentry.ts` runs this function over
+    // `event.request.url`, so a header-only rule would pin coverage that the
+    // real input never exercises.
+    [
+      "fetch failed: https://alice:hunter2@internal.example.com/doc",
+      "fetch failed: https://[redacted]@internal.example.com/doc",
+    ],
+    ["ws://user:pw@127.0.0.1:3478/ws", "ws://[redacted]@127.0.0.1:3478/ws"],
+    // RFC 7235 auth schemes are case-insensitive, and `Bearer` was already `/gi`.
+    // The replacement normalizes the scheme's case, exactly as the older
+    // `Bearer` rule always has.
+    ["authorization: basic YWxpY2U6aHVudGVyMg==", "authorization: Basic [redacted]"],
+  ])("redacts %s", (input, expected) => {
+    expect(redactSecrets(input)).toBe(expected);
+  });
+
+  it("redacts the two shapes GitHub's own scanner treats as live credentials", () => {
+    // Slack and Stripe started out on the documented-gap list below. Push
+    // protection blocked the commit that carried them as fixtures, which is a
+    // better argument for redacting them than anything I could reason out.
+    expect(redactSecrets(fake("xoxb", "-2482048272-2482048272-abcdefghijklmnopqrst"))).toBe(
+      "xoxb-[redacted]",
+    );
+    expect(redactSecrets(fake("xoxp", "-1111111111-2222222222-abcdefghijkl"))).toBe(
+      "xoxp-[redacted]",
+    );
+    expect(redactSecrets(fake("sk", "_live_", "51ABCdefGHIjklMNOpqrSTUvwx"))).toBe(
+      "sk_live_[redacted]",
+    );
+    expect(redactSecrets(fake("pk", "_test_", "51ABCdefGHIjklMNOpqrSTUvwx"))).toBe(
+      "pk_test_[redacted]",
+    );
+  });
+
+  it("keeps the vendor prefix so a leak report names the right vendor", () => {
+    // The generic `sk-` rule would otherwise swallow `sk-ant-`.
+    expect(redactSecrets("sk-ant-api03-SECRETSECRET12")).toBe("sk-ant-[redacted]");
+    expect(redactSecrets("sk-proj-ABCDEFGHIJKLMNOPQRSTUV")).toBe("sk-[redacted]");
+  });
+
+  it("leaves these shapes untouched — the documented gap", () => {
+    // `redactSecrets` is an ENUMERATION, not a classifier. Pinned rather than
+    // merely unmentioned: an unlisted gap reads as coverage to the next reader,
+    // and the list of vendors it DOES match is exactly what invites that
+    // misreading. Anything on this list that later gains a rule should move up
+    // into the redaction cases above, deliberately.
+    const gaps = [
+      fake("AKIA", "IOSFODNN7EXAMPLE"),
+      fake("ASIA", "1234567890ABCDEF"),
+      fake("AIza", "SyD-abc1234567890abcdefghijklmnopqrs"),
+      fake("npm", "_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
+      "x-api-key: 0123456789abcdef0123456789abcdef",
+      "Cookie: session=abc; auth_token=def",
+      // `_token` is not `?token`, and `auth` is not on the parameter list.
+      "https://h/x?refresh_token=abcdefghijklmnop",
+      "https://h/x?auth=abcdefghijklmnop",
+      // A token living in a PATH segment is indistinguishable from a doc id.
+      "https://h/share/AbCdEf0123456789AbCdEf0123456789/doc.md",
+    ];
+    for (const gap of gaps) expect(redactSecrets(gap)).toBe(gap);
+  });
+
+  it("leaves ordinary error text alone", () => {
+    // False positives cost a `[redacted]` in a report; these are the strings
+    // that must survive for the report to be worth anything.
+    const benign = "TypeError: cannot read property foo of undefined";
+    expect(redactSecrets(benign)).toBe(benign);
+    expect(redactSecrets("NotAllowedError: Write permission denied")).toBe(
+      "NotAllowedError: Write permission denied",
+    );
+    // Short query values that are not credential-named stay put.
+    expect(redactSecrets("GET /api/events?documentId=abc123")).toBe(
+      "GET /api/events?documentId=abc123",
+    );
+  });
+});
+
+describe("redactPaths", () => {
+  it.each([
+    ["/Users/alice/Documents/x.md", "/Users/[user]/Documents/x.md"],
+    ["/home/bob/notes", "/home/[user]/notes"],
+    [String.raw`C:\Users\carol\AppData`, String.raw`C:\Users\[user]\AppData`],
+  ])("collapses the user segment in %s", (input, expected) => {
+    expect(redactPaths(input)).toBe(expected);
+  });
+
+  it("collapses the Windows user segment in either case", () => {
+    // Windows paths are case-insensitive, so the lowercase spelling is the same
+    // directory and leaks the same account name into a public issue.
+    expect(redactPaths(String.raw`c:\users\bob\x.md`)).toBe(String.raw`c:\users\[user]\x.md`);
+    expect(redactPaths(String.raw`C:\USERS\bob\x.md`)).toBe(String.raw`C:\USERS\[user]\x.md`);
+    // The POSIX rules stay case-sensitive: `/users` is a different directory
+    // from `/Users` on a case-sensitive filesystem.
+    expect(redactPaths("/users/bob/x.md")).toBe("/users/bob/x.md");
+  });
+
+  it("collapses the username only — the filename survives, by design", () => {
+    // Documented limitation, asserted so nobody reads this as stronger than it
+    // is: in a document editor the filename is often the sensitive half.
+    expect(redactPaths("/Users/alice/Documents/Q3-layoffs-plan.md")).toBe(
+      "/Users/[user]/Documents/Q3-layoffs-plan.md",
+    );
+  });
+
+  it("catches a /home segment anywhere, not just at the start", () => {
+    // Fedora Silverblue's `/var/home/<user>` is covered for free because the
+    // pattern is unanchored. Pinned because the module's own doc claims it.
+    expect(redactPaths("/var/home/dave/notes")).toBe("/var/home/[user]/notes");
+    expect(redactPaths("EACCES: scandir '/home/dave/x'")).toBe("EACCES: scandir '/home/[user]/x'");
+  });
+
+  it("leaves paths under no known user root untouched — the documented gap", () => {
+    // What the server-side pass catches with real roots and this one cannot.
+    // Asserted so the limitation is visible rather than assumed.
+    expect(redactPaths("/root/notes")).toBe("/root/notes");
+    expect(redactPaths(String.raw`D:\Profiles\alice\tandem`)).toBe(
+      String.raw`D:\Profiles\alice\tandem`,
+    );
+    expect(redactPaths(String.raw`\\fileserver\share\alice\x.md`)).toBe(
+      String.raw`\\fileserver\share\alice\x.md`,
+    );
+  });
+});
+
+describe("scrubText", () => {
+  it("handles path + secret in one string", () => {
+    expect(scrubText("/Users/dan/.env had sk-ant-api03-SECRETSECRET12")).toBe(
+      "/Users/[user]/.env had sk-ant-[redacted]",
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

`src/client/` had exactly one diagnostic egress that survives packaging — `GET /api/diagnostics` → `formatDiagnostics` → clipboard / prefilled issue body — and it was fed **solely** by the server's `tandem doctor` collector, with client-side facts limited to a single `browser` field.

So every client-side classification went to `console`, which in the primary distribution has no reader: the Tauri release build ships no `devtools` feature (`src-tauri/Cargo.toml:104`), which is mutually exclusive with `tauri-plugin-log` (`docs/gotchas.md:20`), and that plugin captures Rust `log::*`, not WebView `console.*`. A comment at `src/client/editor/Editor.svelte:333` asserted the absence outright: "`utils/diagnostics.ts` has no console ring buffer, so it never reaches a bug report either."

Net effect: a denied clipboard permission, a WebView with no `navigator.clipboard`, and a policy rejection are three different bugs behind one identical user-facing string, and the `console.warn` that separated them was unreachable in a shipped build.

## The fix

**`src/client/utils/client-log.ts` (new)** — a 20-slot non-reactive ring buffer that `formatDiagnostics` drains, plus the two call sites the issue names (`IntegrationWizardModal.svelte`, `useCoworkPreflight.svelte.ts`). The console line is byte-identical to before, still receives the **raw** cause, and is emitted *first* with the buffer write caught, so replacing a bare `console.warn` with this call cannot change what the caller's `catch` block does. The buffer is a plain module array, never `$state` — recorders run from `catch` blocks inside effects, where a `$state` write throws `state_unsafe_mutation` in production.

**Privacy, since this text lands in a public issue body.** `buildBugReportUrl` prefills that body, which turns the user's review step into an opt-out, so the API itself is the control:

1. Nothing is captured automatically — no global `console` patch, so every entry was chosen by whoever wrote the call site.
2. No free-text parameter: `(scope, event, cause)` with static literals, so there is nothing to interpolate a document title into. Enforced by `tests/client/client-log-callsites.test.ts`, since TypeScript cannot express "literal only".
3. `describeCause` reads `name` and `message` **only** — never `.stack`, `.cause`, fields, or `String(value)`. Stated as a rule and pinned by a test, because the obvious follow-up is `err.cause?.message`.
4. Bounded to 1024 chars *before* anything reads it, then scrubbed on the way in, newline-collapsed (a multi-line message could otherwise forge an `[ok] some-check` line into the issue body), unpaired surrogates dropped (`encodeURIComponent` throws `URIError` on one and `buildBugReportUrl` answers a throw by dropping the *entire* prefill), and capped at 160 chars for display.

The gaps that remain are stated in the module doc and pinned by tests rather than left unmentioned — the path scrub collapses the **username segment only**, so `~/Documents/board-minutes.md` still names the document, and a `string` cause is captured verbatim (kept deliberately: Tauri `invoke` rejects with the Rust error's `Display` string, so dropping that branch would blind the Cowork pre-flight site to every failure it has). An unlisted gap reads as coverage to the next reader.

**Placement is load-bearing.** `buildBugReportUrl` drops whole lines from the **tail** under a 6000-char encoded cap, so the section sits *above* the check list and renders newest-first; otherwise the fix would work for Copy Diagnostics and silently not work for Report a bug, which is the surface the issue is about. It carries a 6-line / 800-char budget so a full buffer cannot evict the doctor report in the other direction.

**Both scrubbers were duplicated; this PR consolidates and widens them.** `src/shared/scrub-text.ts` (new) now owns the secret and path passes, previously held as **two copies** — `src/client/sentry.ts` and `src/server/sentry.ts`. To be precise about what changed, since an earlier draft of this description got it wrong: at the merge base those two copies were **byte-identical and had not drifted**. Both carried the same three patterns (`sk-ant-`, `sk-`, `Bearer`), and both Windows path rules were case-**sensitive**. So the `/i` flag and the seven added credential rules — `ghp_`/`github_pat_`, `Basic`, JWTs, Slack, Stripe, `scheme://user:pass@host`, credential query params — are **introduced by this PR**, not one copy catching up with another. They land in both halves at once precisely because there is now only one thing to widen. That matters most for the sidecar, the half most likely to hold a credential: MCP server configs carry `env`/`headers` full of API keys, which is why `GET /api/integrations/existing` scrubs them. `redactHome` keeps only its `$HOME` literal swap, which genuinely is server-only.

Sample output:

```
Tandem v0.23.0 (http, desktop)
darwin/arm64, Node v22.0.0
Browser: WebKit 605

Recent client warnings (newest first):
[warn] +12.3s wizard: clipboard write failed — NotAllowedError: Write permission denied (x3, first +0.9s)
[error] +2.1s cowork: subnet pre-flight threw — invoke failed: no such command

[ok]   ports — 3478/3479 free

All checks passed. Tandem is ready.
```

## Security review findings, applied

A security review returned SHIP-AFTER-FIXES: 2 MAJOR, 4 MINOR, 1 INFO. All are addressed in `6e657db7`. It also confirmed the consolidation loses no redaction (a 200,017-input differential harness across six `$HOME` values, `clientLoss=0 serverLoss=0`), so nothing about its design changed.

### F1 (MAJOR) — a quadratic regex on an unbounded UI-thread path

The URL-credential rule opened `(\w+:\/\/)`: an unbounded quantifier with no literal for the engine to prescan on, so every position inside a run of word characters became a start candidate that scanned to end-of-string. Measured per rule on a plain run of `x` with **no credential present at all** — every other rule is flat, this one quadrupled per doubling: 16k → 260ms, 64k → 3.9s, 100k → **10.2s**. This PR created the exposure: `describeCause` scrubs the *full, uncapped* cause and only then clamps to 160, so cost is a function of raw input, not of `MAX_DETAIL_CHARS`, and it runs synchronously on the UI thread inside a `catch`.

Two changes, and **both** are needed:

- **`\w{1,16}` instead of `\w+`.** 100k plain run: 10.2s → 7.9ms. The bound cannot change the *output*, only where a match starts — a longer word-character run simply matches its last 16 characters and the earlier ones are copied through verbatim — which is what let this be applied without re-deriving what the rule redacts. Verified byte-identical against `\w+` over 422,794 inputs (exhaustive over a 28-token alphabet to depth 3, plus randomized and targeted long-scheme cases).
- **A `MAX_CAUSE_CHARS = 1024` cut in `describeCause`, before any pass reads the cause.** The regex bound alone does **not** close this. Two passes stay super-linear whatever the scheme rule looks like: `collapseLines`' leading `\s*` backtracking across a whitespace run (128k spaces: 18.2s), and the URL rule's two `[^/\s@]+` runs either side of a literal `:`, which have O(n²) ways to split a colon run — `"https://" + "a:".repeat(50000)` measured 33s *both before and after* the `\w{1,16}` change. Capping the input is what actually bounds them, to 1.2ms and 3.2ms. The cut sits 6.4× beyond the display cap, so nothing past it can reach `detail`; it reaches only `fingerprint`, which stores a length and a hash and no text.

One deviation from the review's suggested patch, worth flagging. The proposed replacement was `([A-Za-z][A-Za-z0-9+.-]{0,15}:\/\/)`. That is *not* byte-identical: it **loses redaction** on four degenerate shapes that `\w+` caught — `0://user:pass@host`, `__://user:pass@host`, `:8080://user:pass@host`, `?tok=1://user:pass@host`. None is a valid RFC 3986 scheme, but "no redaction lost" is this PR's own standard, so `\w{1,16}` was used instead: a one-token change, provably identical, and equally linear. Those four shapes are now pinned by test.

### F2 (MAJOR) — a test that asserted nothing, and a claim that said otherwise

`tests/client/client-log.test.ts` "never truncates into a lone surrogate" used `"🙂".repeat(200)`. Every emoji is two UTF-16 units, so `MAX_DETAIL_CHARS = 160` is an exact multiple of the pair width: index 159 is a *low* surrogate and the cut always fell **between** pairs. Deleting the cut-site strip at `client-log.ts` left the file **22/22 green**. An earlier draft of this description claimed "Each was verified load-bearing by mutation"; that was **false for this one**, and the claim is corrected below.

Fixed by shifting the fixture one BMP character — `` `x${"🙂".repeat(200)}` `` — which puts a *high* surrogate at index 159 so the cut splits a pair. Re-running the same mutation now fails with `AssertionError: expected [Function] to not throw an error but 'URIError: URI malformed' was thrown`. The even case is kept as its own test (the two exercise different branches of `clamp`), and the geometry itself is asserted so a later change to `MAX_DETAIL_CHARS` cannot silently move the cut back between pairs.

### F3 (MINOR) — a comment inventing a history the merge base refutes

`src/server/sentry.ts` claimed its copy "had already drifted" and was "the LEAST redacted of the three". At `0df1c991` the two `redactSecrets` bodies are byte-identical, both Windows path rules are byte-identical and both case-sensitive, and `src/shared/scrub-text.ts` does not exist. Two copies, not three; no drift. The outcome claimed — the sidecar is better redacted now — is real; the premise was invented, and a comment like that gets read as history. Rewritten in `server/sentry.ts`, `client/sentry.ts` and `shared/scrub-text.ts`, and in this description above.

### F4 (MINOR) — telemetry could throw into the app's error path

`record()` ran before the console call and unguarded, and `describeCause` → `isErrorLike` does `typeof candidate.name` with no `try`. A cause with a throwing getter therefore aborted the **caller's** `catch` block: console calls 0, buffer entries 0, and the user-facing recovery line after the warn never ran. That inverts this module's own stated guarantee and contradicts `src/client/sentry.ts`'s norm ("Never let telemetry throw into the app's error path"). Not reachable from today's two sites, but this module is the declared intake for ~147 more. Console line first, then `recordSafely`, which catches.

### F6 (MINOR) — the call-site scanner's comment overclaimed

`STRICT` allowed any member expression as argument three, so `logClientWarning("editor", "link refused", resolved.path)` **passed the scan** — the exact shape this description cites (`Editor.svelte` interpolating `resolved.path`) as the reason the follow-up sweep is unsafe. Argument three is now restricted to a **bare identifier**: the probe fails, both current call sites still pass, and a biome-wrapped compliant call still matches. The test's module doc now also says plainly what it does *not* establish — it constrains the **shape** of what a call site may pass, never the **content**, so it makes the sweep *mechanical*, not *safe*. It is a lower bound on review, not a substitute for it.

### F7 (INFO) — resolved rather than escalated

`clamp` shipped what would have been the **first regex lookbehind in the browser bundle**, raising the WKWebView floor from Safari 15.4 (already implied by existing `.at()` usage) to **16.4** / macOS 13+. esbuild cannot downlevel it, and a lookbehind is an *early* SyntaxError in JSC — it would blank the entire bundle rather than degrade one function. There is no explicit `build.target` and no `minimumSystemVersion` in `src-tauri/`.

This was flagged for a human decision, but it turned out not to need one: ordered alternation expresses the identical rule with no lookbehind and no cost. `/[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDFFF]/g` with a callback consumes a well-formed pair in the *first* branch, so a low surrogate following a high can never be reached by the second, and only genuinely unpaired ones are dropped. Verified byte-identical to the lookbehind form over 399,592 inputs (exhaustive over high/low/BMP symbols to length 6), and `npx vite build` confirms nothing matching `(?<` survives anywhere into `dist/client/assets/`. **The macOS 12 floor is preserved and there is nothing to decide.**

## Tests, and what each catches

| Test | Catches |
|---|---|
| `tests/client/client-log.test.ts` (new) | Ring capacity; **whole-buffer** coalescing (`A,B,A,B` alternation would otherwise fill 20 slots with 2 facts); coalescing keyed on a fingerprint of the *full* cause, so two failures agreeing on their first 160 chars are not reported as one that recurred; scrubbing; the 160-char leak bound; the **raw-cause cap**, pinned by coalescing rather than by a clock; a **throwing `name` getter not escaping** into the caller's catch; **stack and `.cause` never captured**; object causes reduced to their type; newline injection; unpaired surrogates on **both** the between-pairs and the split-pair cut. |
| `tests/client/client-log-callsites.test.ts` (new) | The literal-only contract, hardened against four ways a source scan fails *green*: a per-file **count invariant** (a biome-wrapped call the strict pattern cannot parse fails rather than being skipped), an alias ban, a re-export ban, arg 3 constrained to a **bare identifier**, a `>= 2` floor, and `.svelte` in the walk. This makes the follow-up sweep of the other ~147 sites **mechanical**; the doc is explicit that it does not make it *safe*, since no source scan can vouch for the content of an identifier's value. |
| `tests/client/bug-report-url.test.ts` | Composes the **real** `formatDiagnostics` into `buildBugReportUrl`: over the cap, the newest warning survives and the tail of the check list is dropped; with a full buffer the check list is still usable. Only the round-trip discriminates head placement from tail placement. |
| `tests/client/diagnostics-format.test.ts` | Section omitted entirely when empty (byte-identical degradation); placement between the host block's separator and a second blank, so `hostLines()` still ends at the first blank; newest-first; the size budget and `(showing N of M)`; control-char stripping. |
| `tests/shared/scrub-text.test.ts` (new) | The widened secret set, Windows path case-insensitivity, an explicit **"documented gap"** block enumerating what is *not* matched — AWS/Google/npm keys, `x-api-key`, `Cookie`, `?refresh_token=`, `?auth=` and path-segment tokens — and the **URL rule's bound**: the four degenerate scheme shapes a tighter rule would drop, invariance to a scheme run longer than the bound, and a source scan for `\w{1,16}` (behaviour is identical either way, so nothing else can see a revert). |
| `tests/server/sentry-scrub.test.ts` | The sidecar now redacts the wider credential set, and its path scrubber **agrees** with the shared one on all three Windows spellings plus both POSIX forms. |
| `tests/client/integration-wizard-push-support.test.ts`, `tests/client/cowork-preflight-hook.test.ts` | Both named call sites record, including the string-rejection shape Tauri actually produces. The pre-existing `expect(warn).toHaveBeenCalledWith("[wizard] clipboard write failed:", expect.any(Error))` assertion is untouched and still passes — it is the regression guard on console fidelity. |

New assertions are deliberately **shape-shaped, not wall-clock-shaped**: this repo already carries "completes in linear time" gates that fail under load, and a timing assertion on the ReDoS fix would have joined them. The cap is pinned by an observable consequence with no clock in it — two causes agreeing for the first 1024 characters must coalesce into one entry, and two differing *inside* the cap must not.

**Mutation results.** Each new or changed assertion was verified load-bearing by deleting the thing it guards — with the F2 correction above being the one that was previously claimed and not true:

| Mutation | Result |
|---|---|
| Delete the cut-site surrogate strip in `clamp` | **red** — `URIError: URI malformed` (was **green, 22/22**, before F2) |
| Remove the `cap(...)` call in `describeCause` | **red** — the two long causes stop coalescing |
| Unguard the buffer write in `recordSafely` | **red** — the throwing getter escapes |
| Revert `\w{1,16}` to `\w+` | **red** — source scan |
| Substitute the review's proposed `[A-Za-z]…{0,15}` regex | **red** — redaction lost on all four degenerate shapes |
| Re-allow member expressions as arg 3, with an `err.message` probe at a real call site | **red** with the tightened pattern; **green** with the old one, which is the finding |

The pre-existing mutations still hold: the composition test against a tail-appended variant (2 failures, restored to 20 passing); the call-site scan probed with a biome-wrapped template-literal call, an aliased import and a re-export (each fails its own assertion) and with a compliant wrapped call (passes); the shared-scrubber tests with the server import reverted to a private copy and with the URL rule deleted (both red, then restored). Stashing only the two call-site edits turns 3 assertions red while the console assertion stays green.

## Gates

| Gate | Result |
|---|---|
| Pre-push hook (biome + full vitest + `cargo test`) | **Clean** — ran on the review-fix push; `git push` exit 0 and remote verified at `6e657db7b059` |
| `npm test` (full vitest, quiet box) | **517 files / 7552 tests passed**, 2 files + 24 tests skipped |
| `npx biome check src/ tests/` | Clean (1094 files) |
| `npm run typecheck` | `1339 FILES 0 ERRORS 0 WARNINGS` |
| Scoped vitest over the 8 affected files | 157 tests, all pass |
| `npx playwright test settings-and-filters.spec.ts integration-wizard.spec.ts` | 28 passed, 1 flaky (`selection toolbar toggle`, a known flake area) |
| `npx vite build` | Succeeds; bundle carries no `process.platform` and no Node polyfill markers (confirming `shared/scrub-text.ts` stays pure) and **no `(?<` anywhere in `dist/client/assets/`** (F7) |

An earlier full-suite run on a heavily contended box (several agents' suites concurrently, load ~65) showed 7 failures in 5 files, all wall-clock gates (`Test timed out in 15000ms`, "completes in linear time", "bounds the work it does"). Those were environmental: the failing set **shifts between runs** — that run hit `mcp-stdio`, `monitor`, `docx-size-gate`, `markdown-escaping` and `roundtrip-repo-metric`, while an independent concurrent run hit `plaintext-newline-invariant`, `authorship-block-structure`, `markdown-escaping` ×2 and `docx-size-gate` — five of six also fail on clean master (`0df1c991`, zero local modifications) at load 49, none of the ten files imports `client-log`, `scrub-text`, `diagnostics` or `sentry`, and re-running them with these changes stashed reproduced the failures. The runs above, on a quiet box, are green. That flakiness is also why the new ReDoS assertions avoid the clock entirely.

One note on the Slack and Stripe rules: those two started on the documented-gap list, and GitHub's push protection rejected the commit that carried them as test fixtures. A scanner treating them as live credentials is a better argument for redacting them than anything I could reason out, so they moved into the covered set — and the fixtures are now assembled at runtime rather than written as literals, since the file itself must not carry a string a scanner reads as a secret.

## Scope and what is left

The issue scopes migrating every `console.warn` in `src/client/` as a separate PR; this builds the mechanism plus the two named call sites, and `client-log-callsites.test.ts` is the guard that makes that sweep mechanical. **147 `console.warn`/`console.error` call sites across 56 files remain** (counted at HEAD, excluding `client-log.ts`'s own; an earlier draft said 155/58, which was the merge-base *line* count and included doc-comment mentions and the two sites this PR migrated). Several of them — such as `Editor.svelte:369` interpolating `resolved.path` into a template literal — do exactly what the new API forbids, which is why the sweep needs its own review rather than a mechanical find-and-replace.

Not verified: real Tauri desktop behaviour (no devtools, WebKit clipboard denial) is not reachable in this environment — the string-cause branch is covered by unit test against the documented `invoke` rejection shape, not against a live bridge. No `src-tauri/` change, so `cargo test` was only exercised by the pre-push hook.

Closes #1439

---
_Generated by [Claude Code](https://claude.ai/code/session_018DdaCvomDgPsumrDAmNH13)_