### PR TITLE
fix(server): correct wrong auth-ordering comment in server.ts

### DIFF
--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -589,16 +589,32 @@ export async function startMcpServerHttp(
   // to loopback.
 
   // Auth middleware for /mcp and /api/* — mounted BEFORE the per-route DNS-rebinding
-  // check (lanAwareApiMiddleware for /api/*, the SDK's own hostHeaderValidation inside
-  // mcpApp for /mcp — see the comment at mcpApp's construction above) and, for /api,
-  // BEFORE enforceLoopbackMutation too. A request that fails both checks gets 401 from
-  // auth, not 403 from the Host check. Loopback is always exempt (Claude Code
-  // zero-config), so this ordering has no security effect either way — the Host check
-  // still runs unconditionally for a loopback-bypassing caller, just after auth instead
-  // of before.
+  // check and, for /api, BEFORE enforceLoopbackMutation too. Express dispatches
+  // middleware in registration order and every one of those checks is attached later in
+  // this same function, so a request that fails auth AND a Host check is answered 401 by
+  // auth, never 403 by the Host check.
+  //
+  // There are TWO Host checks in front of /api/*, not one. `app.use(mcpApp)` below mounts
+  // the SDK sub-app at the ROOT with no path prefix, and createMcpExpressApp installs its
+  // hostHeaderValidation as a bare app.use INSIDE that sub-app — so every request that
+  // reaches that line, /api/* included, passes through the SDK's Host check, and it is
+  // registered before registerApiRoutes attaches lanAwareApiMiddleware per route. The
+  // real /api chain is therefore:
+  //     authMiddleware -> enforceLoopbackMutation -> mcpApp's express.json +
+  //     hostHeaderValidation -> the route's lanAwareApiMiddleware -> handler
+  // The SDK check fires first and answers with a JSON-RPC body ("Invalid Host: evil.com");
+  // lanAwareApiMiddleware narrows it further per route, rejecting hosts the SDK's list
+  // admits (e.g. "localhost:PORT" and "[::1]:PORT") with {"error":"FORBIDDEN"}. Reading a
+  // 403 on /api without checking the body will attribute it to the wrong middleware.
+  //
+  // Loopback is always exempt from auth (Claude Code zero-config), so this ordering has no
+  // security effect either way — both Host checks still run unconditionally for a
+  // loopback-bypassing caller, just after auth instead of before.
   // /health and /.well-known/* never reach authMiddleware at all: they're registered
-  // directly on `app`, outside both the /api and /mcp prefixes this middleware is
-  // mounted on.
+  // directly on `app`, outside both the /api and /mcp prefixes this middleware is mounted
+  // on. They are also registered ABOVE `app.use(mcpApp)`, so they never reach the SDK Host
+  // check either — /health carries its own lanAwareApiMiddleware, the metadata routes are
+  // deliberately unguarded (they must be reachable before auth is established).
   // Note: all channel routes use /api/channel-* paths (covered by /api below).
   app.use("/mcp", authMiddleware);
   app.use("/api", authMiddleware);

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -588,9 +588,17 @@ export async function startMcpServerHttp(
   // follow-up; do not re-add a payment-processor endpoint to a server that binds
   // to loopback.
 
-  // Auth middleware for /mcp and /api/* — AFTER apiMiddleware (DNS-rebinding)
-  // but BEFORE route handlers. Loopback is always exempt (Claude Code zero-config).
-  // /health and /.well-known/* are intentionally omitted — they're public/diagnostic.
+  // Auth middleware for /mcp and /api/* — mounted BEFORE the per-route DNS-rebinding
+  // check (lanAwareApiMiddleware for /api/*, the SDK's own hostHeaderValidation inside
+  // mcpApp for /mcp — see the comment at mcpApp's construction above) and, for /api,
+  // BEFORE enforceLoopbackMutation too. A request that fails both checks gets 401 from
+  // auth, not 403 from the Host check. Loopback is always exempt (Claude Code
+  // zero-config), so this ordering has no security effect either way — the Host check
+  // still runs unconditionally for a loopback-bypassing caller, just after auth instead
+  // of before.
+  // /health and /.well-known/* never reach authMiddleware at all: they're registered
+  // directly on `app`, outside both the /api and /mcp prefixes this middleware is
+  // mounted on.
   // Note: all channel routes use /api/channel-* paths (covered by /api below).
   app.use("/mcp", authMiddleware);
   app.use("/api", authMiddleware);

--- a/tests/server/server-security-invariants.test.ts
+++ b/tests/server/server-security-invariants.test.ts
@@ -13,7 +13,9 @@
  * so the Express routing and middleware are tested exactly as deployed.
  */
 
+import { readFileSync } from "node:fs";
 import type { Server } from "node:http";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isLoopback } from "../../src/server/auth/middleware.js";
 import { startMcpServerHttp } from "../../src/server/mcp/server.js";
@@ -255,5 +257,153 @@ describe("Invariant 7 — /health non-loopback branch omits hasSession (unit)", 
       body.hasSession = currentTransport !== null;
     }
     expect("hasSession" in body).toBe(false);
+  });
+});
+
+// ── #1488 item 2: auth-ordering comment matches the real registration order ──
+//
+// The block comment sitting directly above `app.use("/mcp", authMiddleware)` /
+// `app.use("/api", authMiddleware)` used to assert authMiddleware ran "AFTER
+// apiMiddleware (DNS-rebinding)" — the opposite of the real order: auth is
+// mounted first here, and the per-route DNS-rebinding check (lanAwareApiMiddleware
+// for /api, the SDK's hostHeaderValidation for /mcp) is attached later, inside
+// registrars called further down this same function.
+//
+// (a) below is a source-text guard against the exact wrong phrase reappearing —
+// weak alone, since a differently-worded wrong claim would sail through it
+// uncaught. (b) is the behavioral counterpart: it exercises the real running
+// Express app and goes red if the registration order itself ever regresses,
+// independent of whatever the comment says.
+
+describe('#1488 item 2 — comment above app.use("/mcp", authMiddleware) matches reality', () => {
+  const serverSrc = readFileSync(
+    fileURLToPath(new URL("../../src/server/mcp/server.ts", import.meta.url)),
+    "utf-8",
+  );
+
+  it("(a) does not claim auth runs AFTER apiMiddleware", () => {
+    const marker = 'app.use("/mcp", authMiddleware);';
+    const idx = serverSrc.indexOf(marker);
+    expect(idx, 'app.use("/mcp", authMiddleware) not found in server.ts').toBeGreaterThan(-1);
+    // The comment block sits directly above the app.use call; 800 chars comfortably
+    // covers it without reaching into unrelated code further up the file.
+    const preceding = serverSrc.slice(Math.max(0, idx - 800), idx);
+    expect(preceding).not.toMatch(/AFTER\s+apiMiddleware/i);
+  });
+});
+
+// (b) Behavioral order test — the app itself, not its comments.
+//
+// isLoopback() (src/server/auth/middleware.ts) does an exact-string compare
+// against "127.0.0.1", so binding the *client's* outbound socket to 127.0.0.2 via
+// Node's `localAddress` option produces a request whose `req.socket.remoteAddress`
+// is "127.0.0.2" server-side — genuinely non-loopback to authMiddleware — while
+// the connection never leaves the machine. That lets one request trip two
+// different checks for two different reasons: authMiddleware rejects it with 401
+// (no/bad Authorization), and the Host-header DNS-rebinding check would reject it
+// with 403 (Host: evil.com is in neither allowlist). Whichever check runs first
+// determines the status code actually observed, so this is a live assertion about
+// registration order, not source text.
+//
+// IMPORTANT — this trick depends on isLoopback() matching "127.0.0.1" by exact
+// string, not by CIDR range (see src/server/auth/middleware.ts). If isLoopback()
+// is ever widened to treat the whole 127.0.0.0/8 block as loopback, 127.0.0.2
+// becomes loopback too: authMiddleware will bypass it, and cases 1 and 3 below
+// will reach the Host check instead of being rejected by auth — they will fail
+// LOUDLY with 403 instead of the expected 401. That failure is NOT an
+// auth-ordering regression; it means the loopback definition moved, and this test
+// needs a different non-loopback source address. Do not "fix" it by reordering
+// middleware.
+describe("#1488 item 2 — auth runs before the DNS-rebinding Host check (behavioral)", () => {
+  const AUTH_TOKEN = "test-token-1488-auth-ordering";
+  let orderPort: number;
+  let orderHttpServer: Server;
+
+  beforeEach(async () => {
+    orderPort = await allocPort();
+    // Both a known token (so we can construct a request auth actually accepts)
+    // and a resolvedLanIP (so the /mcp SDK host check is active, matching the
+    // "Fix 1 regression" block above) are required to exercise both prefixes.
+    orderHttpServer = await startMcpServerHttp(orderPort, "127.0.0.1", AUTH_TOKEN, "192.168.1.50");
+  });
+
+  afterEach(() => {
+    return new Promise<void>((resolve, reject) => {
+      orderHttpServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  function rawRequest(
+    path: string,
+    opts: { method?: string; hostHeader: string; authorization?: string; body?: string },
+  ): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const bodyBuf = opts.body !== undefined ? Buffer.from(opts.body, "utf8") : undefined;
+      const headers: Record<string, string | number> = { Host: opts.hostHeader };
+      if (opts.authorization !== undefined) headers.Authorization = opts.authorization;
+      if (bodyBuf !== undefined) {
+        headers["Content-Type"] = "application/json";
+        headers["Content-Length"] = bodyBuf.length;
+      }
+      const req = httpRequest(
+        {
+          host: "127.0.0.1",
+          port: orderPort,
+          path,
+          method: opts.method ?? "GET",
+          // Binds the client's outbound socket to a non-loopback address while
+          // still connecting to the server on 127.0.0.1 — see the block comment
+          // above for why this makes authMiddleware treat the request as
+          // genuinely non-loopback without any real network traffic leaving the
+          // machine.
+          localAddress: "127.0.0.2",
+          headers,
+        },
+        (res) => {
+          let data = "";
+          res.on("data", (chunk: Buffer) => {
+            data += chunk.toString();
+          });
+          res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
+        },
+      );
+      req.on("error", reject);
+      if (bodyBuf !== undefined) req.write(bodyBuf);
+      req.end();
+    });
+  }
+
+  it("1) GET /api/info, non-loopback + bad Host + no Authorization -> 401 (auth runs first)", async () => {
+    const { status } = await rawRequest("/api/info", { hostHeader: "evil.com" });
+    expect(status).toBe(401);
+  });
+
+  it("2) control: same request WITH valid Authorization -> 403 (Host check is reachable and fires once auth passes)", async () => {
+    const { status } = await rawRequest("/api/info", {
+      hostHeader: "evil.com",
+      authorization: `Bearer ${AUTH_TOKEN}`,
+    });
+    expect(status).toBe(403);
+  });
+
+  it("3) POST /mcp, non-loopback + bad Host + no Authorization -> 401 (auth runs first)", async () => {
+    const payload = JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 });
+    const { status } = await rawRequest("/mcp", {
+      method: "POST",
+      hostHeader: "evil.com",
+      body: payload,
+    });
+    expect(status).toBe(401);
+  });
+
+  it("4) control: same request WITH valid Authorization -> 403 (SDK host check still fires after auth passes)", async () => {
+    const payload = JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 });
+    const { status } = await rawRequest("/mcp", {
+      method: "POST",
+      hostHeader: "evil.com",
+      authorization: `Bearer ${AUTH_TOKEN}`,
+      body: payload,
+    });
+    expect(status).toBe(403);
   });
 });

--- a/tests/server/server-security-invariants.test.ts
+++ b/tests/server/server-security-invariants.test.ts
@@ -140,8 +140,16 @@ describe("Invariant 7 — /health includes hasSession for loopback callers", () 
 // ── Fix 1 regression: /mcp DNS-rebinding protection with allowedHosts ────────
 //
 // When startMcpServerHttp is called with resolvedLanIP set (non-loopback bind),
-// createMcpExpressApp receives allowedHosts and activates hostHeaderValidation.
-// A request to /mcp with Host: evil.com must be rejected 403.
+// createMcpExpressApp receives allowedHosts and hostHeaderValidation validates
+// against that list. A request to /mcp with Host: evil.com must be rejected 403.
+//
+// resolvedLanIP does NOT switch the check on and off — it only swaps which allowlist
+// is used. With allowedHosts undefined, createMcpExpressApp falls through to
+// localhostHostValidation() whenever the bind host is 127.0.0.1 / localhost / ::1
+// (node_modules/@modelcontextprotocol/sdk/dist/cjs/server/express.js), which is
+// Tandem's default bind — so the SDK Host check is active in the default
+// configuration too. Probed: no resolvedLanIP, POST /mcp with Host: evil.com still
+// returns 403 {"error":{"code":-32000,"message":"Invalid Host: evil.com"}}.
 //
 // Node.js fetch() silently overrides the Host header with the connection target,
 // so we use http.request() with explicit headers to properly spoof the Host header.
@@ -281,14 +289,54 @@ describe('#1488 item 2 — comment above app.use("/mcp", authMiddleware) matches
     "utf-8",
   );
 
+  const MARKER = 'app.use("/mcp", authMiddleware);';
+
+  /**
+   * Returns the contiguous run of `//` lines immediately above `marker`'s line.
+   *
+   * Anchor to the block, never to a byte budget. The first version of this guard
+   * sliced a fixed `idx - 800`, and the block is 887 chars from its first character
+   * to the marker — so the window opened mid-block and left the comment's FIRST line,
+   * the exact line the wrong "AFTER apiMiddleware" claim lived on, outside the
+   * assertion. The guard was green while the comment still made the wrong claim.
+   * A byte budget silently decouples from the comment the moment anyone lengthens it;
+   * walking the block cannot.
+   */
+  function commentBlockAbove(src: string, marker: string): string {
+    const idx = src.indexOf(marker);
+    expect(idx, `${marker} not found in server.ts`).toBeGreaterThan(-1);
+    const before = src.slice(0, idx).split("\n");
+    // The final element is the marker line's own leading indentation, not a full line.
+    let i = before.length - 2;
+    while (i >= 0 && /^\s*\/\//.test(before[i] as string)) i--;
+    // Strip the `//` markers and flatten to a single space-separated line, so every
+    // assertion below is line-wrap tolerant. Matching the raw text would make each
+    // regex hostage to where a formatter happened to break the sentence — and would
+    // let a wrong claim evade the negative assertion just by wrapping across two lines.
+    return before
+      .slice(i + 1)
+      .map((line) => line.replace(/^\s*\/\/ ?/, ""))
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
   it("(a) does not claim auth runs AFTER apiMiddleware", () => {
-    const marker = 'app.use("/mcp", authMiddleware);';
-    const idx = serverSrc.indexOf(marker);
-    expect(idx, 'app.use("/mcp", authMiddleware) not found in server.ts').toBeGreaterThan(-1);
-    // The comment block sits directly above the app.use call; 800 chars comfortably
-    // covers it without reaching into unrelated code further up the file.
-    const preceding = serverSrc.slice(Math.max(0, idx - 800), idx);
-    expect(preceding).not.toMatch(/AFTER\s+apiMiddleware/i);
+    expect(commentBlockAbove(serverSrc, MARKER)).not.toMatch(/AFTER\s+apiMiddleware/i);
+  });
+
+  it("(a2) positive control: the block actually states the order and the mcpApp mount", () => {
+    // (a) alone is an absence assertion, and absence satisfies it: deleting the whole
+    // comment block left (a) green because the license-webhook NOTE above simply moved
+    // into view. Pinning a phrase that must be PRESENT makes deletion fail too, so the
+    // pair covers both reintroduction (a) and removal/rewording (a2).
+    const block = commentBlockAbove(serverSrc, MARKER);
+    expect(block).toMatch(/mounted BEFORE the per-route DNS-rebinding/);
+    // The block must also keep saying WHY /api sees the SDK Host check first: mcpApp is
+    // mounted at the root with no path prefix, so its hostHeaderValidation is in front of
+    // /api/* as well, ahead of the route's own lanAwareApiMiddleware. An earlier revision
+    // attributed the /api 403 to lanAwareApiMiddleware alone, which is measurably wrong.
+    expect(block).toMatch(/mounts the SDK sub-app at the ROOT/);
   });
 });
 
@@ -300,10 +348,11 @@ describe('#1488 item 2 — comment above app.use("/mcp", authMiddleware) matches
 // is "127.0.0.2" server-side — genuinely non-loopback to authMiddleware — while
 // the connection never leaves the machine. That lets one request trip two
 // different checks for two different reasons: authMiddleware rejects it with 401
-// (no/bad Authorization), and the Host-header DNS-rebinding check would reject it
-// with 403 (Host: evil.com is in neither allowlist). Whichever check runs first
-// determines the status code actually observed, so this is a live assertion about
-// registration order, not source text.
+// (no/bad Authorization), and a Host-header DNS-rebinding check would reject the same
+// request with 403 (each case below picks a Host that the check it targets refuses —
+// see the note above cases 1-4 for which Host selects which middleware). Whichever
+// check runs first determines the status code actually observed, so this is a live
+// assertion about registration order, not source text.
 //
 // IMPORTANT — this trick depends on isLoopback() matching "127.0.0.1" by exact
 // string, not by CIDR range (see src/server/auth/middleware.ts). If isLoopback()
@@ -314,96 +363,137 @@ describe('#1488 item 2 — comment above app.use("/mcp", authMiddleware) matches
 // auth-ordering regression; it means the loopback definition moved, and this test
 // needs a different non-loopback source address. Do not "fix" it by reordering
 // middleware.
-describe("#1488 item 2 — auth runs before the DNS-rebinding Host check (behavioral)", () => {
-  const AUTH_TOKEN = "test-token-1488-auth-ordering";
-  let orderPort: number;
-  let orderHttpServer: Server;
+//
+// PLATFORM — Linux only, hence the skipIf. `localAddress` is a bind() of the client's
+// outbound socket, and bind() requires the address to be ASSIGNED to an interface; it is
+// not a routing question. Linux's `lo` claims all of 127.0.0.0/8, so 127.0.0.2 is bindable
+// out of the box. macOS `lo0` carries only 127.0.0.1 unless someone runs `ifconfig lo0
+// alias 127.0.0.2`, and Windows behaves likewise — there bind() returns EADDRNOTAVAIL, the
+// `req.on("error", reject)` path fires, and all four cases fail for a reason that has
+// nothing to do with auth ordering. CI would never surface it (only ci.yml's `check` job
+// runs vitest, on ubuntu-latest), but the pre-push hook runs the full vitest suite
+// locally, so a macOS or Windows contributor would be blocked at push by a red suite they
+// did not break. Skipping is the lesser evil, and the skip reason is spelled out in the
+// describe name so it reads as a deliberate platform gap rather than a silent hole. The
+// source-text guard (a)/(a2) above is NOT skipped and still runs everywhere.
+describe.skipIf(process.platform !== "linux")(
+  "#1488 item 2 — auth runs before the DNS-rebinding Host check (behavioral; Linux only — needs a bindable 127.0.0.2 source address)",
+  () => {
+    const AUTH_TOKEN = "test-token-1488-auth-ordering";
+    let orderPort: number;
+    let orderHttpServer: Server;
 
-  beforeEach(async () => {
-    orderPort = await allocPort();
-    // Both a known token (so we can construct a request auth actually accepts)
-    // and a resolvedLanIP (so the /mcp SDK host check is active, matching the
-    // "Fix 1 regression" block above) are required to exercise both prefixes.
-    orderHttpServer = await startMcpServerHttp(orderPort, "127.0.0.1", AUTH_TOKEN, "192.168.1.50");
-  });
-
-  afterEach(() => {
-    return new Promise<void>((resolve, reject) => {
-      orderHttpServer.close((err) => (err ? reject(err) : resolve()));
-    });
-  });
-
-  function rawRequest(
-    path: string,
-    opts: { method?: string; hostHeader: string; authorization?: string; body?: string },
-  ): Promise<{ status: number; body: string }> {
-    return new Promise((resolve, reject) => {
-      const bodyBuf = opts.body !== undefined ? Buffer.from(opts.body, "utf8") : undefined;
-      const headers: Record<string, string | number> = { Host: opts.hostHeader };
-      if (opts.authorization !== undefined) headers.Authorization = opts.authorization;
-      if (bodyBuf !== undefined) {
-        headers["Content-Type"] = "application/json";
-        headers["Content-Length"] = bodyBuf.length;
-      }
-      const req = httpRequest(
-        {
-          host: "127.0.0.1",
-          port: orderPort,
-          path,
-          method: opts.method ?? "GET",
-          // Binds the client's outbound socket to a non-loopback address while
-          // still connecting to the server on 127.0.0.1 — see the block comment
-          // above for why this makes authMiddleware treat the request as
-          // genuinely non-loopback without any real network traffic leaving the
-          // machine.
-          localAddress: "127.0.0.2",
-          headers,
-        },
-        (res) => {
-          let data = "";
-          res.on("data", (chunk: Buffer) => {
-            data += chunk.toString();
-          });
-          res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
-        },
+    beforeEach(async () => {
+      orderPort = await allocPort();
+      // Both a known token (so we can construct a request auth actually accepts)
+      // and a resolvedLanIP (so the /mcp SDK host check is active, matching the
+      // "Fix 1 regression" block above) are required to exercise both prefixes.
+      orderHttpServer = await startMcpServerHttp(
+        orderPort,
+        "127.0.0.1",
+        AUTH_TOKEN,
+        "192.168.1.50",
       );
-      req.on("error", reject);
-      if (bodyBuf !== undefined) req.write(bodyBuf);
-      req.end();
     });
-  }
 
-  it("1) GET /api/info, non-loopback + bad Host + no Authorization -> 401 (auth runs first)", async () => {
-    const { status } = await rawRequest("/api/info", { hostHeader: "evil.com" });
-    expect(status).toBe(401);
-  });
-
-  it("2) control: same request WITH valid Authorization -> 403 (Host check is reachable and fires once auth passes)", async () => {
-    const { status } = await rawRequest("/api/info", {
-      hostHeader: "evil.com",
-      authorization: `Bearer ${AUTH_TOKEN}`,
+    afterEach(() => {
+      return new Promise<void>((resolve, reject) => {
+        orderHttpServer.close((err) => (err ? reject(err) : resolve()));
+      });
     });
-    expect(status).toBe(403);
-  });
 
-  it("3) POST /mcp, non-loopback + bad Host + no Authorization -> 401 (auth runs first)", async () => {
-    const payload = JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 });
-    const { status } = await rawRequest("/mcp", {
-      method: "POST",
-      hostHeader: "evil.com",
-      body: payload,
-    });
-    expect(status).toBe(401);
-  });
+    function rawRequest(
+      path: string,
+      opts: { method?: string; hostHeader: string; authorization?: string; body?: string },
+    ): Promise<{ status: number; body: string }> {
+      return new Promise((resolve, reject) => {
+        const bodyBuf = opts.body !== undefined ? Buffer.from(opts.body, "utf8") : undefined;
+        const headers: Record<string, string | number> = { Host: opts.hostHeader };
+        if (opts.authorization !== undefined) headers.Authorization = opts.authorization;
+        if (bodyBuf !== undefined) {
+          headers["Content-Type"] = "application/json";
+          headers["Content-Length"] = bodyBuf.length;
+        }
+        const req = httpRequest(
+          {
+            host: "127.0.0.1",
+            port: orderPort,
+            path,
+            method: opts.method ?? "GET",
+            // Binds the client's outbound socket to a non-loopback address while
+            // still connecting to the server on 127.0.0.1 — see the block comment
+            // above for why this makes authMiddleware treat the request as
+            // genuinely non-loopback without any real network traffic leaving the
+            // machine.
+            localAddress: "127.0.0.2",
+            headers,
+          },
+          (res) => {
+            let data = "";
+            res.on("data", (chunk: Buffer) => {
+              data += chunk.toString();
+            });
+            res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
+          },
+        );
+        req.on("error", reject);
+        if (bodyBuf !== undefined) req.write(bodyBuf);
+        req.end();
+      });
+    }
 
-  it("4) control: same request WITH valid Authorization -> 403 (SDK host check still fires after auth passes)", async () => {
-    const payload = JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 });
-    const { status } = await rawRequest("/mcp", {
-      method: "POST",
-      hostHeader: "evil.com",
-      authorization: `Bearer ${AUTH_TOKEN}`,
-      body: payload,
+    // Cases 1+2 target the PER-ROUTE /api check (lanAwareApiMiddleware); cases 3+4 target
+    // the SDK's hostHeaderValidation on /mcp. Picking the Host header is what separates
+    // them, and getting it wrong makes the two "controls" assert the same middleware twice:
+    // `app.use(mcpApp)` mounts the SDK sub-app at the ROOT, so "evil.com" on /api/info is
+    // answered by the SDK, not by lanAwareApiMiddleware — with `evil.com` here, deleting
+    // lanAwareApiMiddleware from the /api/info route entirely left this suite fully green.
+    // "localhost:PORT" is the discriminator: the SDK's allowlist admits it, isHostAllowed
+    // rejects it. The body assertions are the second half of the fix — they name which
+    // middleware actually answered, so a future mix-up cannot hide behind a bare 403.
+    const API_BAD_HOST = () => `localhost:${orderPort}`;
+
+    it("1) GET /api/info, non-loopback + bad Host + no Authorization -> 401 (auth runs first)", async () => {
+      const { status } = await rawRequest("/api/info", { hostHeader: API_BAD_HOST() });
+      expect(status).toBe(401);
     });
-    expect(status).toBe(403);
-  });
-});
+
+    it("2) control: same request WITH valid Authorization -> 403 from lanAwareApiMiddleware (the per-route /api Host check is reachable)", async () => {
+      const { status, body } = await rawRequest("/api/info", {
+        hostHeader: API_BAD_HOST(),
+        authorization: `Bearer ${AUTH_TOKEN}`,
+      });
+      expect(status).toBe(403);
+      // lanAwareApiMiddleware's shape, NOT the SDK's JSON-RPC error body. If the route ever
+      // loses its lanAwareApiMiddleware, "localhost:PORT" sails past the SDK check and this
+      // becomes a 200 from the handler.
+      expect(JSON.parse(body)).toMatchObject({ error: "FORBIDDEN" });
+    });
+
+    it("3) POST /mcp, non-loopback + bad Host + no Authorization -> 401 (auth runs first)", async () => {
+      const payload = JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 });
+      const { status } = await rawRequest("/mcp", {
+        method: "POST",
+        hostHeader: "evil.com",
+        body: payload,
+      });
+      expect(status).toBe(401);
+    });
+
+    it("4) control: same request WITH valid Authorization -> 403 from the SDK hostHeaderValidation (a different middleware than case 2)", async () => {
+      const payload = JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 });
+      const { status, body } = await rawRequest("/mcp", {
+        method: "POST",
+        hostHeader: "evil.com",
+        authorization: `Bearer ${AUTH_TOKEN}`,
+        body: payload,
+      });
+      expect(status).toBe(403);
+      // The SDK's JSON-RPC error shape, NOT lanAwareApiMiddleware's {error:"FORBIDDEN"}.
+      expect(JSON.parse(body)).toMatchObject({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Invalid Host: evil.com" },
+      });
+    });
+  },
+);


### PR DESCRIPTION
## Root cause

The block comment directly above `app.use("/mcp", authMiddleware)` / `app.use("/api", authMiddleware)` in `src/server/mcp/server.ts` claimed:

> Auth middleware for /mcp and /api/* — AFTER apiMiddleware (DNS-rebinding) but BEFORE route handlers.

This is backwards. `authMiddleware` is mounted at lines 595-596 (pre-fix numbering); every per-route DNS-rebinding check is attached later in the same function, inside registrars (`registerApiRoutes`, `registerChannelRoutes`, `registerIntegrationsRoutes`, `registerLauncherRoutes`, `registerModelsRoutes`) that are all called after those two `app.use` lines, plus `app.use(mcpApp)` itself is mounted after them. Since Express dispatches middleware in registration order, auth genuinely runs first for both prefixes.

A second, correct comment 120 lines earlier — right where `authMiddleware` is constructed — already says the opposite ("Runs before per-route apiMiddleware"). The two comments in the same file contradicted each other about the same ordering. Nothing in the code was ever wrong; only the prose describing it.

Item 1 of #1488 (the `/.well-known/oauth-protected-resource/mcp` presence oracle) is a deliberate security-posture tradeoff for the repo owner and is **explicitly out of scope for this PR** — no routes or middleware touched, no behavior changed there.

## The fix

Reworded the comment to state the true order for all four route classes:

- **`/api/*`**: `authMiddleware` → `enforceLoopbackMutation` (method-gated: GET/HEAD/OPTIONS pass through unconditionally) → **`mcpApp`'s `express.json` + `hostHeaderValidation`** → the route's own `lanAwareApiMiddleware` → the handler.
- **`/mcp`**: `authMiddleware` → the SDK's own `hostHeaderValidation` inside `mcpApp` → the route handler. This matches, and does not contradict, the existing correct comment at `mcpApp`'s construction site.
- **`/health`**: never reaches `authMiddleware` at all — it's registered directly on `app` via `app.get(API_HEALTH, lanAwareApiMiddleware, ...)`, outside both the `/api` and `/mcp` mount prefixes. That's a structural fact, not an ordering one. It is also registered *above* `app.use(mcpApp)`, so it never reaches the SDK Host check either; `lanAwareApiMiddleware` is its only Host guard. Probed: `GET /health` with `Host: evil.com` returns `{"error":"FORBIDDEN","message":"Host not allowed."}`.
- **`/.well-known/*`**: same story as `/health` — registered directly on `app`, above `app.use(mcpApp)`, outside both prefixes. Unlike `/health`, these routes carry no `lanAwareApiMiddleware` and no `enforceLoopbackMutation` either, and no Host check reaches them: probed, `Host: evil.com` returns 200. That's item 1 of #1488, untouched here.

**There are two Host checks in front of `/api/*`, not one.** `app.use(mcpApp)` mounts the SDK sub-app at the **root** with no path prefix, and `createMcpExpressApp` installs its `hostHeaderValidation` as a bare `app.use(...)` *inside* that sub-app (`@modelcontextprotocol/sdk/dist/cjs/server/express.js`, lines 35-44). So every request that reaches that line — `/api/*` included — passes through the SDK's Host check, and it is registered *before* `registerApiRoutes` attaches `lanAwareApiMiddleware` per route. The SDK check fires first; `lanAwareApiMiddleware` narrows it further per route. Measured on a real server (client bound to `127.0.0.2`, valid Bearer):

| request | status | body | answered by |
|---|---|---|---|
| `GET /api/info`, `Host: evil.com` | 403 | `{"jsonrpc":"2.0","error":{"code":-32000,"message":"Invalid Host: evil.com"},"id":null}` | SDK `hostHeaderValidation` |
| `GET /api/info`, `Host: localhost:PORT` | 403 | `{"error":"FORBIDDEN","message":"Host not allowed."}` | `lanAwareApiMiddleware` |
| `GET /api/info`, `Host: [::1]:PORT` | 403 | `{"error":"FORBIDDEN","message":"Host not allowed."}` | `lanAwareApiMiddleware` |

Reading a bare 403 on `/api` without checking the body attributes it to the wrong middleware — which is exactly what the first revision of this PR's comment and its `/api` "control" test both did.

The comment also states plainly that this ordering has no security effect: loopback is always exempt from auth, so a loopback-bypassing caller still hits both Host checks unconditionally, just after auth instead of before. A request that fails auth **and** a Host check gets 401 (auth), not 403.

## Tests — `tests/server/server-security-invariants.test.ts`

**(a) Textual regression guard + (a2) positive control.** Reads `server.ts` and extracts the contiguous run of `//` lines immediately above `app.use("/mcp", authMiddleware)`, flattened to a single space-separated line so no assertion is hostage to where a formatter broke a sentence. (a) asserts the block never matches `/AFTER\s+apiMiddleware/i`; (a2) asserts it *does* still state the real order and the `mcpApp` root mount, so deletion and rewording fail as well as reintroduction.

The window is anchored to the comment block, **not to a byte budget**. The first revision sliced a fixed `serverSrc.slice(idx - 800, idx)` and asserted in its own comment that "800 chars comfortably covers it" — the block is **887 characters** from its first character to the marker, so the window opened mid-block and left the comment's first line, the exact line the wrong claim lived on, outside the assertion. A byte budget silently decouples from the comment the moment anyone lengthens it; walking the block cannot.

**(b) Behavioral order test against the real running app.** Node's `http.request({ localAddress: "127.0.0.2", ... })` lets the test client bind its own outbound socket to a non-loopback address while still connecting to the server on 127.0.0.1 — no real network traffic leaves the machine. `isLoopback()` (`src/server/auth/middleware.ts`) does an exact-string compare against `"127.0.0.1"`, so `127.0.0.2` reads as genuinely non-loopback to `authMiddleware`. That lets one request trip two different checks for two different reasons, and whichever runs first determines the observed status code.

Four cases, and the **Host header is what selects which middleware answers** — the two controls target deliberately different ones:

1. `GET /api/info`, `Host: localhost:PORT`, no `Authorization` → 401 (auth runs first).
2. Control: same request with valid `Authorization` → 403 **from `lanAwareApiMiddleware`**, asserted on the body (`{"error":"FORBIDDEN"}`). `localhost:PORT` is the discriminator: the SDK's allowlist admits it, `isHostAllowed` rejects it.
3. `POST /mcp`, `Host: evil.com`, no `Authorization` → 401 (auth runs first).
4. Control: same request with valid `Authorization` → 403 **from the SDK's `hostHeaderValidation`**, asserted on the JSON-RPC body (`code: -32000`, `Invalid Host: evil.com`).

Both controls assert the response body, so a future mix-up cannot hide behind a bare 403.

An inline comment documents the semantic coupling: the non-loopback trick depends on `isLoopback()` matching `"127.0.0.1"` by exact string. If `isLoopback()` is ever widened to the whole `127.0.0.0/8` block, cases 1 and 3 will start failing **loudly** with 403 instead of 401 — a loopback-definition change, not an auth-ordering regression, needing a different source address rather than a middleware reorder.

**Platform gate.** The behavioral describe is `describe.skipIf(process.platform !== "linux")`. `localAddress` is a `bind()` of the client's outbound socket, and `bind()` requires the address to be **assigned to an interface** — routing is not the constraint. Linux's `lo` claims all of `127.0.0.0/8`, so `127.0.0.2` is bindable out of the box; macOS `lo0` carries only `127.0.0.1` unless someone runs `ifconfig lo0 alias 127.0.0.2`, and Windows behaves likewise, so `bind()` returns `EADDRNOTAVAIL` and all four cases fail via the `req.on("error", reject)` path for a reason unrelated to auth ordering. CI would not surface it (only `ci.yml`'s `check` job runs vitest, on `ubuntu-latest`), but **the pre-push hook runs the full vitest suite locally**, so a macOS or Windows contributor would otherwise be blocked at push by a red suite they did not break. The skip reason is spelled out in the describe name, so it reads as a deliberate platform gap rather than a silent hole. The source-text guards (a)/(a2) are not skipped and run everywhere.

## Mutation testing

Every assertion here was broken on purpose, watched go red, and restored byte-identical (`md5sum -c` against pre-mutation hashes).

| mutation | before the review fixes | after |
|---|---|---|
| Reintroduce `AFTER apiMiddleware` on the comment's **first line** | **16/16 green** — the guard did not cover that line | (a) `expected 'Auth middleware for /mcp and /api/* —…' not to match /AFTER\s+apiMiddleware/i`; (a2) `expected … to match /mounted BEFORE the per-route DNS-rebi…/` — **2 failed \| 15 passed** |
| Delete the entire auth-ordering comment block | **16/16 green** — the license-webhook NOTE above simply moved into the 800-char window and satisfied the negative assertion | (a2) `expected '' to match /mounted BEFORE the per-route DNS-rebi…/` — **1 failed \| 16 passed** |
| Drop `mw` from `app.get(API_INFO, mw, makeInfoHandler(...))`, leaving that route with **no** DNS-rebinding middleware at all | **16/16 green** — case 2's 403 came from the SDK middleware, not the per-route check | case 2 `expected 200 to be 403` — **1 failed \| 16 passed** |
| Move both `app.use(…, authMiddleware)` lines below `app.use(mcpApp)` and `registerApiRoutes(…)` (the ordering regression this PR exists to pin) | cases 1 and 3 `expected 403 to be 401` | **still red** — cases 1 and 3 `expected 403 to be 401`, plus (a2) `expected '' to match …` since the comment no longer sits above the marker — **3 failed \| 14 passed** |

The behavioral pin survived the Host-header change: the ordering regression is still caught.

## Gates run

- `npx vitest run tests/server/server-security-invariants.test.ts --maxWorkers=2` — **17/17 passed** (16 baseline + the new (a2) positive control).
- `npx vitest run tests/server/stateless-transport-sdk.test.ts tests/server/api-loopback-invariant.test.ts tests/docs/loopback-gate-claims.test.ts` — 15/15 passed (the other suites that read `server.ts` as source text, plus the loopback-claims doc pin).
- `npx tsc -p tsconfig.json --noEmit` and `npx tsc --noEmit -p tsconfig.server.json` — clean.
- `npx biome check src/server/mcp/server.ts tests/server/server-security-invariants.test.ts` — clean.
- Pre-push hook (biome + full vitest + `cargo test`) via the push-lock wrapper — passed clean, `git push exit=0`.

## Verification

Push verified by the push-lock wrapper reading the remote ref back, not inferred from the push command's exit code:

```
[push-lock] VERIFIED: remote fix/1488-auth-ordering-comment is now b9523b7fd03f
```

## Unverified / out of scope

- Item 1 of #1488 (the `.well-known` presence oracle) — deliberately untouched, belongs to the repo owner.
- The `localAddress: "127.0.0.2"` trick is confirmed on Linux only. macOS and Windows are **not** verified and are expected to fail `bind()` with `EADDRNOTAVAIL`, which is why the behavioral describe is skipped there rather than left to go red at push time.

Refs #1488