### PR TITLE
perf(chat): stream ctrl-room chat through a Y.Text sidecar instead of re-setting the row

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,6 +214,8 @@ Chat is **session-scoped**, stored on the `__tandem_ctrl__` Y.Doc (not per-docum
 
 `Y.Map('chat')` on the `__tandem_ctrl__` Y.Doc holds all chat messages keyed by message ID. Each message has `id`, `author` (user/claude), `text`, `timestamp`, and optionally `documentId` and `replyTo`.
 
+**Streaming sidecar (#1340):** while a Claude reply is being token-streamed, its full text-so-far lives in one `Y.Text` per message in `Y.Map('chatStream')` (`Y_MAP_CHAT_STREAM`), keyed by message id — `updateClaudeChatMessage` diff-splices O(delta) appends into it instead of re-`set`ting the whole message value per flush (which was O(n²) on the wire). While the sidecar entry exists it is authoritative over the row's `text` (the client composes in `useChatState.refresh`); `finalizeClaudeChatMessage` folds the text back into the plain chat row and deletes the entry. Durable snapshots never carry a live sidecar entry: `persistCtrlSnapshot` folds on the snapshot clone, and `restoreCtrlDoc` sweeps (fold-or-delete) anything a restored snapshot carried. Both folds drop an entry that is not a non-empty `Y.Text` with a live chat row rather than writing it over the row. Nothing structural forces the terminal `finalize` call, so `foldChatStream` — the one path that enumerates live entries regardless of producer activity — reconciles the `chat-stream-staleness.ts` ledger on every persist and restore and warns once (stderr) for an entry still live after 10 minutes.
+
 ### User → Claude
 
 ```
@@ -577,6 +579,7 @@ Each Y.Map has observers attached by different subsystems. Understanding who own
 | `awareness` | Client Svelte hook | `yjsSync.svelte.ts` → `setupTabObservers()` | Drive "Claude -- typing" status indicator |
 | `userAwareness` | Server event queue | `events/observers/awareness.ts`, via `observers/factory.ts` | Buffer selection for chat messages |
 | `chat` (CTRL_ROOM) | Server event queue | `events/observers/ctrl-chat.ts`, attached via `attachCtrlObservers()` | Emit `chat:message` |
+| `chatStream` (CTRL_ROOM) | Client Svelte hook | `useChatState.svelte.ts` `$effect` — **deep** observe (`observeDeep`), since nested `Y.Text` edits don't fire a plain `observe` | Live-compose in-flight streamed reply text (#1340). **No server-side observer** — server write-only. |
 | `documentMeta` (CTRL_ROOM) | Server event queue | `events/observers/ctrl-meta.ts`, via `attachCtrlObservers()` | Emit `document:opened` / `closed` / `switched` (the latter from `activeDocumentId`) |
 | `annotationReplies` | Server event queue | `events/observers/replies.ts`, via `observers/factory.ts` | Emit reply events |
 | `documentMeta` (CTRL_ROOM) | Client Svelte hook | `yjsSync.svelte.ts` → `handleDocumentListRef` | Sync tab list from server broadcasts (CTRL_ROOM) |
@@ -874,6 +877,7 @@ Detailed file-level listing for navigating the codebase. For architectural conte
 - `events/` -- Channel event infrastructure: `types.ts` (TandemEvent definitions), `queue.ts` (Y.Map observers + circular buffer + subscriber-gated payload tracking), `sse.ts` (SSE endpoint handler), `push-liveness.ts` (consumer heartbeat counters — diagnostics only, never Claude's presence), `observers/` (per-map event derivation), `file-sync-registry.ts` (durable-annotation file-watcher binding), `wake-socket.ts` (the self-armed `ws://…/api/wake` transport — ADR-049), `delivery-state.ts` (per-item surfaced/pushed bookkeeping)
 - `yjs/` -- Y.Doc management, the authoritative document state
 - `mode.ts` -- Solo/Tandem authority (CTRL_ROOM `Y_MAP_MODE`), read by `shouldForwardExternally`
+- `chat-stream-staleness.ts` -- Abandoned-`chatStream`-entry tripwire (#1340): the ledger + warn-once sweep shared by `mcp/awareness.ts` (seeds) and `session/manager.ts`'s `foldChatStream` (checks). A leaf module with no project imports — `session/manager.ts` cannot import `mcp/awareness.ts` without a cycle
 - `startup-file.ts` -- `maybeOpenStartupFile()`; consumes `TANDEM_OPEN_FILE` before HTTP bind
 - `bind-check.ts` -- Bind-host policy: `TANDEM_BIND_HOST`, `TANDEM_LAN_IP`, wildcard handling, the token-provisioned refusal
 - `documents/` -- Per-document state helpers

--- a/src/client/hooks/useChatState.svelte.ts
+++ b/src/client/hooks/useChatState.svelte.ts
@@ -6,6 +6,7 @@ import {
   Y_MAP_CHAT_DOCUMENT_NAMES,
   Y_MAP_CHAT_SEEN,
   Y_MAP_CHAT_SEEN_INITIALIZED,
+  Y_MAP_CHAT_STREAM,
 } from "../../shared/constants";
 import { withBrowser } from "../../shared/origins";
 import type { CapturedAnchor, ChatMessage } from "../../shared/types";
@@ -49,7 +50,17 @@ export function createChatState(options: {
 
   function refresh(doc: Y.Doc): void {
     const next: ChatMessage[] = [];
-    doc.getMap(Y_MAP_CHAT).forEach((value) => next.push(value as ChatMessage));
+    // #1340: while a message streams, its full text-so-far lives in the
+    // chatStream sidecar Y.Text and the chat row's `text` is deliberately
+    // stale — compose here so every downstream consumer (ChatPanel, export,
+    // insert, unread accounting) sees the live text without knowing about
+    // the sidecar. instanceof guards against malformed foreign values.
+    const streamMap = doc.getMap(Y_MAP_CHAT_STREAM);
+    doc.getMap(Y_MAP_CHAT).forEach((value) => {
+      const msg = value as ChatMessage;
+      const live = streamMap.get(msg.id);
+      next.push(live instanceof Y.Text ? { ...msg, text: live.toString() } : msg);
+    });
     next.sort((a, b) => a.timestamp - b.timestamp || a.id.localeCompare(b.id));
     messages = next;
     const seen = doc.getMap(Y_MAP_CHAT_SEEN);
@@ -117,15 +128,23 @@ export function createChatState(options: {
     const chat = doc.getMap(Y_MAP_CHAT);
     const seen = doc.getMap(Y_MAP_CHAT_SEEN);
     const names = doc.getMap(Y_MAP_CHAT_DOCUMENT_NAMES);
+    const stream = doc.getMap(Y_MAP_CHAT_STREAM);
     const observer = () => refresh(doc);
     chat.observe(observer);
     seen.observe(observer);
     names.observe(observer);
+    // DEEP observe, deliberately: a plain `observe` fires only on key
+    // add/delete, not on edits inside a nested Y.Text — the live streaming
+    // bubble would freeze at its first flush (#1340). Resolved inside this
+    // $effect keyed on getCtrlYdoc(), so generation-gate provider rebuilds
+    // re-attach exactly like the three observers above.
+    stream.observeDeep(observer);
     observer();
     return () => {
       chat.unobserve(observer);
       seen.unobserve(observer);
       names.unobserve(observer);
+      stream.unobserveDeep(observer);
     };
   });
 

--- a/src/server/chat-stream-staleness.ts
+++ b/src/server/chat-stream-staleness.ts
@@ -1,0 +1,86 @@
+/**
+ * Staleness tripwire for the `chatStream` sidecar (#1340).
+ *
+ * A sidecar entry should live for exactly one stream — seconds to minutes. An
+ * entry older than {@link STREAM_SIDECAR_WARN_MS} means a producer started
+ * streaming and never called `finalizeClaudeChatMessage`: its chat row stays
+ * frozen at the last flush in durable state, and its `Y.Text` is never
+ * collected from the live doc (the snapshot fold only cleans CLONES).
+ *
+ * The detector deliberately does NOT sit on the write path. The failure it
+ * names — a producer that crashes, hangs, or is torn down without finalizing —
+ * emits no further `updateClaudeChatMessage` calls, so a check inside that
+ * function could only ever fire for a producer that is STILL streaming after
+ * ten minutes, which is not the leak. `foldChatStream` (session/manager.ts)
+ * enumerates every live entry on every persist and every restore, regardless
+ * of producer activity, so the sweep calls {@link reconcileStreamSidecars}
+ * from there.
+ *
+ * This is a leaf module with no project imports on purpose: `session/manager.ts`
+ * cannot import `mcp/awareness.ts` (awareness → mcp/document → session/manager
+ * is an import cycle), so the ledger both sides need lives on its own.
+ */
+
+/** Age at which a live sidecar entry is reported as abandoned. */
+export const STREAM_SIDECAR_WARN_MS = 10 * 60 * 1000;
+
+/** id → epoch ms at which the sidecar entry was first observed. */
+const streamStartedAt = new Map<string, number>();
+/** ids already warned about — the warning is once per id, not per sweep. */
+const streamWarnedIds = new Set<string>();
+
+/** Record that `id` has an in-flight sidecar entry. First observation wins. */
+export function noteStreamSidecar(id: string, now = Date.now()): void {
+  if (!streamStartedAt.has(id)) streamStartedAt.set(id, now);
+}
+
+/** Retire `id`'s ledger entry — its sidecar is gone (finalized or cleared). */
+export function clearStreamStaleness(id: string): void {
+  streamStartedAt.delete(id);
+  streamWarnedIds.delete(id);
+}
+
+/**
+ * Reconcile the ledger against the sidecar entries a sweep actually found, and
+ * warn once for any that has been live past the threshold.
+ *
+ * Reconciliation is what bounds the ledger: an abandoned entry's `startedAt`
+ * would otherwise be retained forever alongside the `Y.Text` it describes, and
+ * an entry deleted by a path that does not call {@link clearStreamStaleness}
+ * (`clearCtrlChatDurably`'s live-doc pass) would leak a ledger row.
+ *
+ * `console.error` is deliberate and always on: it is stderr NATIVELY, so
+ * Critical Rule 3 (stdout is reserved for the MCP wire) is satisfied without
+ * the `index.ts` redirect, and the server has no reusable DEV-only gate. Once
+ * per id keeps it from becoming noise.
+ */
+export function reconcileStreamSidecars(liveIds: Iterable<string>, now = Date.now()): void {
+  const seen = new Set<string>();
+  for (const id of liveIds) {
+    seen.add(id);
+    const started = streamStartedAt.get(id);
+    if (started === undefined) {
+      // First sight of an entry this process never started — e.g. one carried
+      // in by a snapshot from a build that persisted live entries. Start its
+      // clock here rather than warning on an age we cannot know.
+      streamStartedAt.set(id, now);
+      continue;
+    }
+    if (now - started <= STREAM_SIDECAR_WARN_MS || streamWarnedIds.has(id)) continue;
+    streamWarnedIds.add(id);
+    console.error(
+      `[Tandem] chatStream entry ${id} has been live for over ` +
+        `${STREAM_SIDECAR_WARN_MS / 60000} minutes — a streaming producer never called ` +
+        `finalizeClaudeChatMessage(). The durable chat row for this message is stale.`,
+    );
+  }
+  for (const id of Array.from(streamStartedAt.keys())) {
+    if (!seen.has(id)) clearStreamStaleness(id);
+  }
+}
+
+/** Test-only: drop all ledger state so suites cannot leak into one another. */
+export function resetStreamStalenessForTests(): void {
+  streamStartedAt.clear();
+  streamWarnedIds.clear();
+}

--- a/src/server/local-model/collaborator.ts
+++ b/src/server/local-model/collaborator.ts
@@ -28,7 +28,11 @@ import type { AgentIdentity } from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
 import { getActiveDocId, requireDocument } from "../documents/registry.js";
 import { type SubscriberKind, subscribe, unsubscribe } from "../events/queue.js";
-import { appendClaudeChatMessage, updateClaudeChatMessage } from "../mcp/awareness.js";
+import {
+  appendClaudeChatMessage,
+  finalizeClaudeChatMessage,
+  updateClaudeChatMessage,
+} from "../mcp/awareness.js";
 import { extractText } from "../mcp/document.js";
 import { readLiveMode } from "../mode.js";
 import { pushNotification } from "../notifications.js";
@@ -45,15 +49,16 @@ const STREAM_FLUSH_CHARS = 80;
 /**
  * Ceiling on a single streamed reply (#1292).
  *
- * Every flush re-`set`s the ENTIRE message value into the ctrl-room Y.Map, which
- * Hocuspocus then broadcasts to every connected client — so a stream of length n
- * costs O(n²) in Yjs encoding and WebSocket bytes. The only other ceiling is the
- * per-response raw-byte cap, which is sized for a whole JSON response rather than
- * a chat bubble; a local model in a repetition loop (a routine failure mode for
- * quantized small models) reaches it with no attacker involved.
- *
- * 64 KiB is generous for a chat bubble. This cap is load-bearing beyond the
- * quadratic blowup: it also bounds what lands in the persisted session file.
+ * Since #1340 each flush is a diff-splice into the `chatStream` sidecar
+ * `Y.Text` — O(delta) on the wire — so the old O(n²) broadcast rationale is
+ * gone. The cap is still load-bearing three ways: it bounds the per-flush CPU
+ * (`updateClaudeChatMessage` reads the current text and scans a prefix, O(n)
+ * per flush), it bounds what the finalize fold writes into the durable chat
+ * row and hence the persisted session file, and it bounds the chat bubble a
+ * user gets shown. A local model in a repetition loop (a routine failure mode
+ * for quantized small models) reaches it with no attacker involved; the only
+ * other ceiling is the per-response raw-byte cap, sized for a whole JSON
+ * response rather than a chat bubble. 64 KiB is generous for a chat bubble.
  */
 const MAX_STREAMED_CHARS = 64 * 1024;
 
@@ -267,7 +272,19 @@ export function createLocalModelCollaborator(deps: CollaboratorDeps = DEFAULT_DE
         }
       },
       flushFinal: () => write(),
-      dispose: () => cancelTimer(),
+      // Runs in executeRun's `finally` on EVERY exit (clean/budget/timeout/
+      // error after their flushFinal; abort/supersede; throw), and `run()`
+      // awaits the previous slot's promise before starting the next executeRun
+      // — so the finalize fold always lands before any successor stream and
+      // never interleaves with one. Finalize is deliberately NOT ownership-
+      // gated: it appends no content, only folds already-committed CRDT state,
+      // and `isOwner()` is already false for a superseded/aborted run — gating
+      // it would strand the truncation marker (#1292) and every superseded
+      // stream's sidecar entry as a permanent leak (#1340).
+      dispose: () => {
+        cancelTimer();
+        if (liveId !== null) finalizeClaudeChatMessage(liveId);
+      },
     };
   }
 

--- a/src/server/mcp/awareness.ts
+++ b/src/server/mcp/awareness.ts
@@ -1,13 +1,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as Y from "yjs";
 import { z } from "zod";
 import {
   CTRL_ROOM,
   Y_MAP_ACTIVITY,
   Y_MAP_CHAT,
+  Y_MAP_CHAT_STREAM,
   Y_MAP_SELECTION,
   Y_MAP_USER_AWARENESS,
 } from "../../shared/constants.js";
-import { withMcp } from "../../shared/origins.js";
+import { withInternal, withMcp } from "../../shared/origins.js";
 import type {
   AgentIdentity,
   Annotation,
@@ -17,6 +19,7 @@ import type {
 } from "../../shared/types.js";
 import { generateMessageId } from "../../shared/utils.js";
 import { isStoreReadOnly } from "../annotations/store.js";
+import { clearStreamStaleness, noteStreamSidecar } from "../chat-stream-staleness.js";
 import { recordInboxPoll, resolveDeliveryRound } from "../events/delivery-state.js";
 import { getAnnotationEditedChannelKey, wasEmittedViaChannel } from "../events/queue.js";
 import { hideFromAI, type ModeState, readModeState, reportedMode } from "../mode.js";
@@ -103,8 +106,10 @@ export function appendClaudeChatMessage(
     ...(opts.documentId ? { documentId: opts.documentId } : {}),
     ...(opts.replyTo ? { replyTo: opts.replyTo } : {}),
     // #1123 M3: agent byline (local-model collaborator only). `tandem_reply`
-    // omits it ⇒ real-Claude chat is byte-identical. updateClaudeChatMessage's
-    // `{...existing, text}` re-set carries it through every streamed delta.
+    // omits it ⇒ real-Claude chat is byte-identical. The byline lives on the
+    // chat row, which streaming leaves untouched (#1340 — deltas go to the
+    // chatStream sidecar), and finalizeClaudeChatMessage's `{...existing}`
+    // fold carries it into the final re-set.
     ...(opts.agentIdentity ? { agentIdentity: opts.agentIdentity } : {}),
     read: true,
   };
@@ -113,22 +118,129 @@ export function appendClaudeChatMessage(
 }
 
 /**
- * Update the text of an existing Claude-authored chat message, for the
- * local-model collaborator's token streaming (#1123 M1.2). Re-`set`s a FRESH
- * object so the value read from the map is never mutated in place; ONLY `text`
- * changes — `id`, `author`, `timestamp` (deliberately NOT re-stamped: ChatPanel
- * sorts by timestamp, so a bump would re-sort the live bubble on every flush),
- * `read`, `documentId`, `replyTo` carry verbatim. No-op when the id is absent
- * (doc closed / message GC'd). The re-`set` is an `update` action, which the
- * ctrl-chat observer additionally drops at its `action !== "add"` gate — so a
- * streamed delta self-wakes even less than the initial append.
+ * Stream the text of an existing Claude-authored chat message, for the
+ * local-model collaborator's token streaming (#1123 M1.2, #1340). `text` is
+ * always the FULL text so far; the write is the minimal diff-splice into a
+ * per-message `Y.Text` in the `chatStream` sidecar map — pure append in the
+ * common case — so a stream of final length L costs O(L) update bytes on the
+ * wire instead of the old whole-value re-`set`'s O(L²). (Per-flush CPU is
+ * still O(current length) — `toString()` + the prefix scan — bounded by the
+ * producer's cap; the linearity claim is a WIRE claim.)
+ *
+ * While the sidecar entry exists it is AUTHORITATIVE over the chat row's
+ * `text` — the row is deliberately stale mid-stream and readers compose (see
+ * `Y_MAP_CHAT_STREAM` in shared/constants.ts). Callers MUST end the stream
+ * with {@link finalizeClaudeChatMessage}, which folds the text back into the
+ * row; the chat row itself is untouched here, so `id`, `author`, `timestamp`
+ * (deliberately never re-stamped: ChatPanel sorts by timestamp), `read`,
+ * `documentId`, `replyTo` and `agentIdentity` ride through streaming verbatim.
+ *
+ * No-op when the chat row is absent (doc closed / message GC'd / chat cleared
+ * mid-stream) — and in that case any orphan sidecar entry is deleted, so a
+ * `DELETE /api/chat` racing an in-flight stream converges instead of leaving
+ * an erased message's `Y.Text` behind.
+ *
+ * The splice point is clamped to a code-point boundary: `Y.Text` splices at a
+ * UTF-16 offset inside a surrogate pair make Yjs substitute U+FFFD on both
+ * sides of the split — permanently. Never remove the clamp.
  */
 export function updateClaudeChatMessage(id: string, text: string): void {
   const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
   const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
+  const streamMap = ctrlDoc.getMap(Y_MAP_CHAT_STREAM);
   const existing = chatMap.get(id) as ChatMessage | undefined;
-  if (!existing) return;
-  withMcp(ctrlDoc, () => chatMap.set(id, { ...existing, text }));
+  if (!existing) {
+    if (streamMap.has(id)) {
+      // Convergence cleanup after `DELETE /api/chat` raced a flush, not a
+      // Claude-authored chat write — `withInternal`'s documented
+      // "cleanup-after-failure" case (Critical Rule 2: the helper IS the
+      // contract, and `audit:origins` reads it as a census of intent).
+      withInternal(ctrlDoc, () => streamMap.delete(id));
+      clearStreamStaleness(id);
+    }
+    return;
+  }
+
+  const entry = streamMap.get(id);
+  const yText = entry instanceof Y.Text ? entry : null;
+  const current = yText ? yText.toString() : "";
+  // Covers both "unchanged text" and "no sidecar yet + empty text": no ops,
+  // no empty broadcast, and never an empty-but-authoritative sidecar entry.
+  if (current === text) return;
+  // No sidecar and the row already holds exactly this text (a flushFinal
+  // re-sending what the minting append committed): minting a sidecar just to
+  // fold it back would cost two O(L) writes for nothing.
+  if (!yText && text === existing.text) return;
+
+  // Seed only. The age CHECK runs from `foldChatStream`'s sweep, which
+  // enumerates live entries regardless of producer activity — the abandoned
+  // producer this tripwire exists for stops calling this function entirely.
+  noteStreamSidecar(id);
+
+  withMcp(ctrlDoc, () => {
+    let target = yText;
+    if (!target) {
+      target = new Y.Text();
+      // Attach BEFORE populate: a detached Y.Text reverses segment order
+      // (docs/gotchas.md, Y.js section). `set` integrates it in this txn.
+      streamMap.set(id, target);
+    }
+    // Longest common prefix of the flushed text vs the new full text.
+    let p = 0;
+    const max = Math.min(current.length, text.length);
+    while (p < max && current.charCodeAt(p) === text.charCodeAt(p)) p++;
+    // Never split a surrogate pair: if the prefix ends on a high surrogate,
+    // back off. A LOOP, not a single step — malformed input can carry a run of
+    // consecutive unpaired high surrogates, and backing off exactly one unit
+    // still lands the splice on a high surrogate ("\uD83D\uD83Dx" against a
+    // "\uD83D…" prefix). The condition stays a bare `p > 0`: adding
+    // `p < text.length` corrupts the `p === text.length` pure-shrink case.
+    // (current[0..p-1] === text[0..p-1] and p <= min(length), so
+    // charCodeAt(p-1) is in-bounds on both strings.)
+    while (p > 0) {
+      const c = text.charCodeAt(p - 1);
+      if (c >= 0xd800 && c <= 0xdbff) p--;
+      else break;
+    }
+    if (current.length > p) target.delete(p, current.length - p);
+    if (text.length > p) target.insert(p, text.slice(p));
+  });
+}
+
+/**
+ * End a streamed chat message (#1340): fold the sidecar `Y.Text` back into the
+ * plain chat row (`{...existing, text}` — one `update`-action re-`set`, which
+ * the ctrl-chat observer drops at both the `mcp` origin gate and the
+ * `action !== "add"` gate) and delete the sidecar entry. Idempotent — no-op
+ * when no sidecar entry exists. If the chat row was deleted mid-stream (chat
+ * cleared), the sidecar entry is deleted WITHOUT re-creating the row: the user
+ * erased that message, and finalize must not resurrect it.
+ *
+ * Deliberately NOT ownership-gated by callers: it appends no new content, only
+ * folds already-committed CRDT state, so even a superseded/aborted stream must
+ * finalize or its sidecar entry (and its authority over the row) leaks.
+ */
+export function finalizeClaudeChatMessage(id: string): void {
+  const ctrlDoc = getOrCreateDocument(CTRL_ROOM);
+  const chatMap = ctrlDoc.getMap(Y_MAP_CHAT);
+  const streamMap = ctrlDoc.getMap(Y_MAP_CHAT_STREAM);
+  const entry = streamMap.get(id);
+  // Unconditional: the sidecar entry may already be gone (clearCtrlChatDurably
+  // deletes live entries directly), but the staleness ledger is module state
+  // only this function retires.
+  clearStreamStaleness(id);
+  if (entry === undefined) return;
+  withMcp(ctrlDoc, () => {
+    const existing = chatMap.get(id) as ChatMessage | undefined;
+    // `length > 0`: an EMPTY sidecar `Y.Text` is malformed state, not a
+    // streamed empty reply (the update path returns before minting one). Folding
+    // it would blank a chat row that holds real text; falling through to the
+    // unconditional delete drops the sidecar and keeps the row.
+    if (existing && entry instanceof Y.Text && entry.length > 0) {
+      chatMap.set(id, { ...existing, text: entry.toString() });
+    }
+    streamMap.delete(id);
+  });
 }
 
 export function registerAwarenessTools(server: McpServer): void {

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -7,6 +7,7 @@ import {
   SESSION_MAX_AGE,
   Y_MAP_CHAT,
   Y_MAP_CHAT_DOCUMENT_NAMES,
+  Y_MAP_CHAT_STREAM,
 } from "../../shared/constants.js";
 import { withInternal } from "../../shared/origins.js";
 import { isUploadPath } from "../../shared/paths.js";
@@ -15,6 +16,7 @@ import { rejectUnsafeWindowsPrefix } from "../../shared/windows-path-safety.js";
 import { docHash, ENVELOPE_FILENAME_RE } from "../annotations/doc-hash.js";
 import { parseAnnotationDoc } from "../annotations/schema.js";
 import { createStore, getAnnotationsDir, isStoreReadOnly } from "../annotations/store.js";
+import { reconcileStreamSidecars } from "../chat-stream-staleness.js";
 import { atomicWrite } from "../file-io/index.js";
 import { SESSION_DIR } from "../platform.js";
 
@@ -238,6 +240,49 @@ function cloneYDoc(doc: Y.Doc): Y.Doc {
   return clone;
 }
 
+/**
+ * Fold any in-flight `chatStream` sidecar entries into their chat rows and
+ * delete them (#1340) — the durability half of the sidecar invariant: durable
+ * CTRL state never carries a LIVE `chatStream` entry.
+ *
+ * TOTAL by construction, because this runs on every persist and every restore
+ * for all users while the only streaming producer ships dark: an entry folds
+ * only when it is a real `Y.Text` AND its chat row still exists; everything
+ * else — an entry whose row the user erased mid-stream (a fold there would
+ * durably resurrect a message the user just deleted), or a malformed value
+ * from a future/buggy build — is deleted without folding.
+ *
+ * Runs on snapshot CLONES in the persist path (never mutates live user-visible
+ * state) and on the freshly-restored doc in `restoreCtrlDoc` (a snapshot
+ * written by a newer or buggy build may carry live entries; without the sweep
+ * an orphan `Y.Text` would stay authoritative over its chat row with no
+ * collector until the next persist).
+ *
+ * It is also the ONLY path that sees an ABANDONED entry — a producer that
+ * crashed or hung without finalizing emits no further writes — so the sidecar
+ * staleness tripwire is reconciled from here, with the ids as found, before
+ * anything is folded or deleted.
+ */
+function foldChatStream(doc: Y.Doc): void {
+  const streamMap = doc.getMap(Y_MAP_CHAT_STREAM);
+  reconcileStreamSidecars(streamMap.keys());
+  if (streamMap.size === 0) return;
+  const chatMap = doc.getMap(Y_MAP_CHAT);
+  withInternal(doc, () => {
+    for (const [id, value] of Array.from(streamMap.entries())) {
+      const existing = chatMap.get(id) as Record<string, unknown> | undefined;
+      // `length > 0`: an EMPTY `Y.Text` is malformed state, not a streamed
+      // empty reply — folding it would blank a chat row holding real text,
+      // which is the opposite of what this defensive sweep is for. It falls
+      // through to the unconditional delete: drop the sidecar, keep the row.
+      if (existing && value instanceof Y.Text && value.length > 0) {
+        chatMap.set(id, { ...existing, text: value.toString() });
+      }
+      streamMap.delete(id);
+    }
+  });
+}
+
 function pruneCtrlDocumentNames(doc: Y.Doc): void {
   const referencedDocumentIds = new Set<string>();
   doc.getMap(Y_MAP_CHAT).forEach((value) => {
@@ -262,6 +307,12 @@ async function persistCtrlSnapshot(doc: Y.Doc): Promise<void> {
     await fs.mkdir(SESSION_DIR, { recursive: true });
     sessionDirReady = true;
   }
+
+  // Fold in-flight streamed text into the chat rows BEFORE pruning/encoding,
+  // so a crash mid-stream durably keeps the last-flushed text and the file
+  // never contains a live chatStream entry (#1340). Snapshot-only, like the
+  // prunes below — the live doc's sidecar is finalized by its producer.
+  foldChatStream(doc);
 
   // Prune the snapshot, never the live CTRL doc. User-visible deletions must not
   // happen until the corresponding atomic write has succeeded.
@@ -313,12 +364,29 @@ export async function clearCtrlChatDurably(doc: Y.Doc): Promise<number> {
   return enqueueCtrlSnapshot(async () => {
     const snapshot = cloneYDoc(doc);
     const snapshotChat = snapshot.getMap(Y_MAP_CHAT);
+    const snapshotStream = snapshot.getMap(Y_MAP_CHAT_STREAM);
     withInternal(snapshot, () => {
-      for (const id of capturedIds) snapshotChat.delete(id);
+      for (const id of capturedIds) {
+        snapshotChat.delete(id);
+        // Belt-and-braces (#1340). `foldChatStream` already cannot resurrect
+        // the row — it re-`set`s only when `existing && value instanceof Y.Text`
+        // and `snapshotChat.delete(id)` above ran first, in this same
+        // transaction — so this delete is REDUNDANT with that `existing &&`
+        // guard. Kept so the clone never carries an entry for an erased id even
+        // if the guard is ever loosened; it is hygiene, not a data-loss gate.
+        if (snapshotStream.has(id)) snapshotStream.delete(id);
+      }
     });
     await persistCtrlSnapshot(snapshot);
+    const liveStream = doc.getMap(Y_MAP_CHAT_STREAM);
     withInternal(doc, () => {
-      for (const id of capturedIds) liveChat.delete(id);
+      for (const id of capturedIds) {
+        liveChat.delete(id);
+        // A clear racing an in-flight stream must not leave an orphan Y.Text;
+        // updateClaudeChatMessage's !existing guard then keeps later flushes
+        // no-ops (and deletes any entry a mid-race flush recreated).
+        if (liveStream.has(id)) liveStream.delete(id);
+      }
       // Recompute from the current live map so messages that arrived while
       // the snapshot persisted retain their filename metadata. This also
       // clears legacy orphan metadata when chat was already empty.
@@ -353,10 +421,15 @@ export async function loadCtrlSession(): Promise<string | null> {
   }
 }
 
-/** Restore a CTRL_ROOM Y.Doc from base64 state */
+/** Restore a CTRL_ROOM Y.Doc from base64 state. Sweeps any live `chatStream`
+ *  entries the snapshot carried (fold-or-delete) — the write side keeps them
+ *  out of durable files, but a blind `applyUpdate` of a foreign/future
+ *  snapshot must not import an orphan sidecar entry that stays authoritative
+ *  over its chat row with no collector (#1340). */
 export function restoreCtrlDoc(doc: Y.Doc, base64State: string): void {
   const state = Buffer.from(base64State, "base64");
   Y.applyUpdate(doc, new Uint8Array(state));
+  foldChatStream(doc);
 }
 
 /**

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -256,6 +256,30 @@ export const Y_MAP_CHAT_SEEN = "chatSeen";
 export const Y_MAP_CHAT_SEEN_INITIALIZED = "initialized";
 /** Path-free document-id → filename history used by durable chat exports. */
 export const Y_MAP_CHAT_DOCUMENT_NAMES = "chatDocumentNames";
+/**
+ * CTRL_ROOM streaming sidecar for in-flight Claude chat replies (#1340): one
+ * `Y.Text` per streamed message, keyed by message id (the same entity-id
+ * keying as `Y_MAP_CHAT` itself). Exists so token streaming costs O(delta) on
+ * the wire instead of re-`set`ting the whole `ChatMessage` per flush (O(n²)).
+ * Invariants every producer and reader inherits:
+ *  - While an entry exists it is AUTHORITATIVE over `ChatMessage.text` for the
+ *    same id — the chat row is deliberately stale mid-stream, and readers
+ *    compose (`useChatState.refresh` overlays `yText.toString()`).
+ *  - Process-transient: `finalizeClaudeChatMessage` folds the text into the
+ *    chat row and deletes the entry. Durable snapshots never carry a LIVE
+ *    entry — `persistCtrlSnapshot` folds outbound, `restoreCtrlDoc` sweeps
+ *    inbound. (Deleted-entry tombstones remain in the encoded state, as with
+ *    any Y.Map delete — the invariant is "no live entries", not byte-absence.)
+ *  - Never empty. The update path returns before minting a sidecar for empty
+ *    text, so an empty `Y.Text` here is malformed state from some other build:
+ *    both folds DROP it instead of blanking the chat row it shadows.
+ *  - Splice on code-point boundaries ONLY. `Y.Text.delete`/`insert` at a UTF-16
+ *    offset inside a surrogate pair makes Yjs substitute U+FFFD on BOTH sides
+ *    of the item split (`ContentString.splice`) — permanent CRDT corruption,
+ *    not a render glitch. Clamp the split point like `updateClaudeChatMessage`
+ *    does before writing.
+ */
+export const Y_MAP_CHAT_STREAM = "chatStream";
 export const Y_MAP_DOCUMENT_META = "documentMeta";
 export const Y_MAP_ANNOTATION_REPLIES = "annotationReplies";
 export const Y_MAP_SAVED_AT_VERSION = "savedAtVersion";

--- a/tests/client/chat-state.test.ts
+++ b/tests/client/chat-state.test.ts
@@ -8,6 +8,7 @@ import {
   Y_MAP_CHAT_DOCUMENT_NAMES,
   Y_MAP_CHAT_SEEN,
   Y_MAP_CHAT_SEEN_INITIALIZED,
+  Y_MAP_CHAT_STREAM,
 } from "../../src/shared/constants";
 import type { ChatMessage } from "../../src/shared/types";
 import ChatStateHarness from "./fixtures/ChatStateHarness.svelte";
@@ -140,6 +141,77 @@ describe("App-owned chat unread state", () => {
     });
     await waitFor(() => {
       expect(afterRestart.getByTestId("document-names").textContent).toContain("Closed notes.md");
+    });
+  });
+});
+
+describe("streamed message composition (#1340)", () => {
+  afterEach(() => cleanup());
+
+  it("overlays the chatStream sidecar text over a stale chat row, and leaves rows without a sidecar verbatim", async () => {
+    const doc = new Y.Doc();
+    doc.getMap(Y_MAP_CHAT_SEEN).set(Y_MAP_CHAT_SEEN_INITIALIZED, true);
+    doc.getMap(Y_MAP_CHAT).set("plain", claude("plain", 1));
+    doc.getMap(Y_MAP_CHAT).set("streamed", { ...claude("streamed", 2), text: "first flush" });
+    const yText = new Y.Text();
+    doc.transact(() => {
+      doc.getMap(Y_MAP_CHAT_STREAM).set("streamed", yText); // attach before populate
+      yText.insert(0, "first flush plus the streamed tail");
+    });
+
+    const view = render(ChatStateHarness, { props: { doc, synced: true, visible: false } });
+    await waitFor(() => {
+      const texts = JSON.parse(view.getByTestId("message-texts").textContent ?? "[]");
+      // The sidecar is authoritative while it exists; the stale row text must
+      // NOT be shown. The un-streamed message passes through verbatim.
+      expect(texts).toEqual(["plain", "first flush plus the streamed tail"]);
+    });
+  });
+
+  it("re-renders on a nested Y.Text edit — a plain observe would freeze the live bubble", async () => {
+    const doc = new Y.Doc();
+    doc.getMap(Y_MAP_CHAT_SEEN).set(Y_MAP_CHAT_SEEN_INITIALIZED, true);
+    doc.getMap(Y_MAP_CHAT).set("live", { ...claude("live", 1), text: "start" });
+    const yText = new Y.Text();
+    doc.transact(() => {
+      doc.getMap(Y_MAP_CHAT_STREAM).set("live", yText);
+      yText.insert(0, "start");
+    });
+    const view = render(ChatStateHarness, { props: { doc, synced: true, visible: false } });
+    await waitFor(() => {
+      expect(view.getByTestId("message-texts").textContent).toContain("start");
+    });
+
+    // An APPEND inside the existing Y.Text: no chatStream KEY changes, so a
+    // shallow map observe fires nothing — only observeDeep sees it (#1340).
+    yText.insert(yText.length, " and more tokens");
+    await waitFor(() => {
+      expect(view.getByTestId("message-texts").textContent).toContain("start and more tokens");
+    });
+  });
+
+  it("falls back to the row text after finalize (sidecar deleted, row folded)", async () => {
+    const doc = new Y.Doc();
+    doc.getMap(Y_MAP_CHAT_SEEN).set(Y_MAP_CHAT_SEEN_INITIALIZED, true);
+    doc.getMap(Y_MAP_CHAT).set("done", { ...claude("done", 1), text: "partial" });
+    const yText = new Y.Text();
+    doc.transact(() => {
+      doc.getMap(Y_MAP_CHAT_STREAM).set("done", yText);
+      yText.insert(0, "partial + streamed");
+    });
+    const view = render(ChatStateHarness, { props: { doc, synced: true, visible: false } });
+    await waitFor(() => {
+      expect(view.getByTestId("message-texts").textContent).toContain("partial + streamed");
+    });
+
+    // The server-side fold: row re-set with the final text, sidecar deleted.
+    doc.transact(() => {
+      doc.getMap(Y_MAP_CHAT).set("done", { ...claude("done", 1), text: "partial + streamed" });
+      doc.getMap(Y_MAP_CHAT_STREAM).delete("done");
+    });
+    await waitFor(() => {
+      const texts = JSON.parse(view.getByTestId("message-texts").textContent ?? "[]");
+      expect(texts).toEqual(["partial + streamed"]);
     });
   });
 });

--- a/tests/client/fixtures/ChatStateHarness.svelte
+++ b/tests/client/fixtures/ChatStateHarness.svelte
@@ -26,4 +26,5 @@ const state = createChatState({
 
 <output data-testid="unread">{state.unreadCount}</output>
 <output data-testid="message-count">{state.messages.length}</output>
+<output data-testid="message-texts">{JSON.stringify(state.messages.map((m) => m.text))}</output>
 <output data-testid="document-names">{JSON.stringify(Array.from(state.documentFileNames))}</output>

--- a/tests/server/chat-durable-clear.test.ts
+++ b/tests/server/chat-durable-clear.test.ts
@@ -1,7 +1,11 @@
 import fs from "fs/promises";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
-import { Y_MAP_CHAT, Y_MAP_CHAT_DOCUMENT_NAMES } from "../../src/shared/constants";
+import {
+  Y_MAP_CHAT,
+  Y_MAP_CHAT_DOCUMENT_NAMES,
+  Y_MAP_CHAT_STREAM,
+} from "../../src/shared/constants";
 
 const controls = vi.hoisted(() => ({
   failWrite: false,
@@ -40,6 +44,11 @@ vi.mock("../../src/server/file-io/index.js", async () => {
   };
 });
 
+import {
+  noteStreamSidecar,
+  resetStreamStalenessForTests,
+  STREAM_SIDECAR_WARN_MS,
+} from "../../src/server/chat-stream-staleness";
 import {
   clearCtrlChatDurably,
   loadCtrlSession,
@@ -124,5 +133,159 @@ describe("durable chat clear", () => {
     const restored = new Y.Doc();
     restoreCtrlDoc(restored, (await loadCtrlSession())!);
     expect(restored.getMap(Y_MAP_CHAT_DOCUMENT_NAMES).get("closed")).toBe("Closed.md");
+  });
+});
+
+describe("chatStream sidecar durability (#1340)", () => {
+  beforeAll(() => fs.mkdir(controls.sessionDir, { recursive: true }));
+  afterAll(() => fs.rm(controls.sessionDir, { recursive: true, force: true }));
+
+  /** Decode the written session file RAW (no restore-time sweep) — asserts on
+   *  the bytes that actually hit disk, not on what restoreCtrlDoc repairs. */
+  async function decodeWrittenSnapshot(): Promise<Y.Doc> {
+    const raw = new Y.Doc();
+    Y.applyUpdate(raw, new Uint8Array(Buffer.from((await loadCtrlSession())!, "base64")));
+    return raw;
+  }
+
+  function seedStreamingDoc(id: string, rowText: string, streamedText: string): Y.Doc {
+    const doc = new Y.Doc();
+    doc.getMap(Y_MAP_CHAT).set(id, {
+      id,
+      author: "claude",
+      text: rowText,
+      timestamp: 10,
+      read: true,
+    });
+    const yText = new Y.Text();
+    doc.transact(() => {
+      doc.getMap(Y_MAP_CHAT_STREAM).set(id, yText); // attach before populate
+      yText.insert(0, streamedText);
+    });
+    return doc;
+  }
+
+  it("saveCtrlSession mid-stream folds the sidecar into the durable row and never mutates the live doc", async () => {
+    const doc = seedStreamingDoc("live-msg", "first flush", "first flush plus streamed tail");
+    await saveCtrlSession(doc);
+
+    const raw = await decodeWrittenSnapshot();
+    // Crash-mid-stream guarantee: the last-flushed text survives durably…
+    expect((raw.getMap(Y_MAP_CHAT).get("live-msg") as { text: string }).text).toBe(
+      "first flush plus streamed tail",
+    );
+    // …and the durable file carries no LIVE sidecar entry.
+    expect(raw.getMap(Y_MAP_CHAT_STREAM).size).toBe(0);
+
+    // The fold ran on the snapshot CLONE only — the live doc still streams.
+    expect((doc.getMap(Y_MAP_CHAT).get("live-msg") as { text: string }).text).toBe("first flush");
+    expect(doc.getMap(Y_MAP_CHAT_STREAM).size).toBe(1);
+  });
+
+  it("clearing chat mid-stream does not let the snapshot fold resurrect the erased message", async () => {
+    const doc = seedStreamingDoc("erased", "first flush", "first flush plus streamed tail");
+    expect(await clearCtrlChatDurably(doc)).toBe(1);
+
+    // The written snapshot: the erased id is gone from BOTH maps. What these
+    // assertions actually pin is `foldChatStream`'s `existing &&` guard — the
+    // row is deleted before the fold runs, so the fold must not re-`set` it
+    // from the in-flight Y.Text and resurrect a message the user just erased.
+    // (They do NOT pin `clearCtrlChatDurably`'s snapshot-side sidecar delete,
+    // which is redundant with that guard: commenting it out leaves this suite
+    // green. The LIVE-side sidecar delete is pinned below, by the last
+    // assertion in this test.)
+    const raw = await decodeWrittenSnapshot();
+    expect(raw.getMap(Y_MAP_CHAT).size).toBe(0);
+    expect(raw.getMap(Y_MAP_CHAT_STREAM).size).toBe(0);
+
+    // The live doc: row and orphan sidecar entry both removed.
+    expect(doc.getMap(Y_MAP_CHAT).size).toBe(0);
+    expect(doc.getMap(Y_MAP_CHAT_STREAM).size).toBe(0);
+  });
+
+  it("restoreCtrlDoc sweeps live sidecar entries a snapshot carried: folds real ones, deletes malformed ones", async () => {
+    // A snapshot from a future/buggy build that persisted live entries — the
+    // write side can't prevent this file existing, so restore must repair it.
+    const foreign = seedStreamingDoc("carried", "stale row", "stale row plus streamed tail");
+    foreign.getMap(Y_MAP_CHAT_STREAM).set("orphan-no-row", "not-a-ytext");
+    const base64 = Buffer.from(Y.encodeStateAsUpdate(foreign)).toString("base64");
+
+    const restored = new Y.Doc();
+    restoreCtrlDoc(restored, base64);
+    // The Y.Text with a live row folded; the malformed value deleted outright.
+    expect((restored.getMap(Y_MAP_CHAT).get("carried") as { text: string }).text).toBe(
+      "stale row plus streamed tail",
+    );
+    expect(restored.getMap(Y_MAP_CHAT_STREAM).size).toBe(0);
+    // The sweep never invents a chat row for an entry without one.
+    expect(restored.getMap(Y_MAP_CHAT).has("orphan-no-row")).toBe(false);
+  });
+
+  it("an EMPTY sidecar Y.Text is dropped, never folded over the live row's text", async () => {
+    // Not reachable from today's producer (`write()` no-ops on an empty
+    // buffer), but the sweep's whole job is malformed input from some other
+    // build — and an empty `Y.Text` is malformed. Folding it would blank a
+    // chat row that holds real user-visible text.
+    const foreign = new Y.Doc();
+    foreign.getMap(Y_MAP_CHAT).set("m1", {
+      id: "m1",
+      author: "claude",
+      text: "a real answer the user can read",
+      timestamp: 10,
+      read: true,
+    });
+    foreign.transact(() => {
+      foreign.getMap(Y_MAP_CHAT_STREAM).set("m1", new Y.Text()); // attached, never populated
+    });
+    const base64 = Buffer.from(Y.encodeStateAsUpdate(foreign)).toString("base64");
+
+    const restored = new Y.Doc();
+    restoreCtrlDoc(restored, base64);
+    expect((restored.getMap(Y_MAP_CHAT).get("m1") as { text: string }).text).toBe(
+      "a real answer the user can read",
+    );
+    expect(restored.getMap(Y_MAP_CHAT_STREAM).size).toBe(0);
+  });
+
+  it("an abandoned sidecar entry is reported by the snapshot sweep, once per id", async () => {
+    // The leak this tripwire exists for is a producer that crashed, hung or was
+    // torn down without finalizing — it emits NO further writes, so nothing on
+    // the write path can ever notice. The sweep enumerates live entries on
+    // every persist regardless of producer activity, which is why it lives
+    // there.
+    resetStreamStalenessForTests();
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      const doc = seedStreamingDoc("abandoned", "first flush", "first flush plus tail");
+      noteStreamSidecar("abandoned", Date.now() - STREAM_SIDECAR_WARN_MS - 1_000);
+
+      await saveCtrlSession(doc);
+      const warnings = () =>
+        errors.mock.calls.filter((call) => String(call[0]).includes("chatStream entry abandoned"));
+      expect(warnings()).toHaveLength(1);
+
+      // Warn-once: a second persist with the entry still live stays silent.
+      await saveCtrlSession(doc);
+      expect(warnings()).toHaveLength(1);
+    } finally {
+      errors.mockRestore();
+      resetStreamStalenessForTests();
+    }
+  });
+
+  it("a sidecar entry within its lifetime is not reported", async () => {
+    resetStreamStalenessForTests();
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      const doc = seedStreamingDoc("in-flight", "first flush", "first flush plus tail");
+      noteStreamSidecar("in-flight", Date.now() - 1_000);
+      await saveCtrlSession(doc);
+      expect(
+        errors.mock.calls.filter((call) => String(call[0]).includes("chatStream entry in-flight")),
+      ).toHaveLength(0);
+    } finally {
+      errors.mockRestore();
+      resetStreamStalenessForTests();
+    }
   });
 });

--- a/tests/server/chat-stream.test.ts
+++ b/tests/server/chat-stream.test.ts
@@ -1,0 +1,267 @@
+/**
+ * #1340 — ctrl-room chat streaming primitives.
+ *
+ * The write-volume assertions are BYTE-shaped, never wall-clock: update-payload
+ * bytes counted via `doc.on("update")` are deterministic on a loaded or idle
+ * machine (this box runs many concurrent suites). They pin the mechanism the
+ * fix installs — O(delta) diff-splices into the `chatStream` sidecar `Y.Text` —
+ * against the old whole-value re-`set`, which cost O(L²) bytes for a stream of
+ * final length L.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import {
+  appendClaudeChatMessage,
+  finalizeClaudeChatMessage,
+  updateClaudeChatMessage,
+} from "../../src/server/mcp/awareness.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { CTRL_ROOM, Y_MAP_CHAT, Y_MAP_CHAT_STREAM } from "../../src/shared/constants.js";
+import { withInternal } from "../../src/shared/origins.js";
+import type { ChatMessage } from "../../src/shared/types.js";
+
+const FLUSH_STEP = 80; // mirrors STREAM_FLUSH_CHARS in collaborator.ts
+
+function ctrl() {
+  return getOrCreateDocument(CTRL_ROOM);
+}
+function chatMap() {
+  return ctrl().getMap(Y_MAP_CHAT);
+}
+function streamMap() {
+  return ctrl().getMap(Y_MAP_CHAT_STREAM);
+}
+function streamText(id: string): string | null {
+  const entry = streamMap().get(id);
+  return entry instanceof Y.Text ? entry.toString() : null;
+}
+
+/** Drive the real primitives end to end and count ctrl-doc update bytes. */
+function measureStreamBytes(finalLength: number, docId: string): number {
+  const doc = ctrl();
+  let bytes = 0;
+  const onUpdate = (update: Uint8Array) => {
+    bytes += update.byteLength;
+  };
+  doc.on("update", onUpdate);
+  try {
+    const full = "x".repeat(finalLength);
+    const id = appendClaudeChatMessage(full.slice(0, FLUSH_STEP), { documentId: docId });
+    for (let n = FLUSH_STEP * 2; n < finalLength; n += FLUSH_STEP) {
+      updateClaudeChatMessage(id, full.slice(0, n));
+    }
+    updateClaudeChatMessage(id, full);
+    finalizeClaudeChatMessage(id);
+  } finally {
+    doc.off("update", onUpdate);
+  }
+  return bytes;
+}
+
+beforeEach(() => {
+  const doc = ctrl();
+  withInternal(doc, () => {
+    doc.getMap(Y_MAP_CHAT).clear();
+    doc.getMap(Y_MAP_CHAT_STREAM).clear();
+  });
+});
+
+describe("streamed chat write volume is linear (#1340)", () => {
+  it("a full streamed lifecycle costs O(L) update bytes, not O(L²)", () => {
+    const L = 16_384;
+    const bytes = measureStreamBytes(L, "doc-linearity");
+    // Master (whole-value re-set per flush) measures ~104×L (~1.7 MB) here;
+    // the sidecar fix measures ~2.3×L (~37 KB). 12×L gives 5× headroom against
+    // encoding drift while sitting 8× below the quadratic. RED on master.
+    expect(bytes).toBeGreaterThan(L); // sanity: the content did get transmitted
+    expect(bytes).toBeLessThanOrEqual(12 * L);
+  });
+
+  it("doubling the stream length ~doubles the bytes (pins the curve, not a point)", () => {
+    const L = 16_384;
+    const b1 = measureStreamBytes(L, "doc-curve-1");
+    const b2 = measureStreamBytes(2 * L, "doc-curve-2");
+    // Linear ⇒ ratio ≈ 2; quadratic ⇒ ratio ≈ 4. 3 separates them and catches
+    // a half-revert that reintroduces any per-flush whole-value chatMap.set.
+    expect(b2 / b1).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("streaming semantics — sidecar authority and fold", () => {
+  it("mid-stream: the chat row is deliberately stale; the sidecar holds the full text", () => {
+    const id = appendClaudeChatMessage("first flush", { documentId: "d1" });
+    updateClaudeChatMessage(id, "first flush and more");
+    // The row is untouched between append and finalize — the sidecar is
+    // authoritative while it exists (readers compose).
+    expect((chatMap().get(id) as ChatMessage).text).toBe("first flush");
+    expect(streamText(id)).toBe("first flush and more");
+  });
+
+  it("finalize folds the full text into the row, preserves every field verbatim, deletes the sidecar, and is idempotent", () => {
+    const id = appendClaudeChatMessage("partial", {
+      documentId: "d2",
+      replyTo: "u9",
+      agentIdentity: { provider: "local-ollama", displayName: "Qwen 2.5" },
+    });
+    const before = chatMap().get(id) as ChatMessage;
+    updateClaudeChatMessage(id, "partial + more");
+    updateClaudeChatMessage(id, "partial + more + done");
+    finalizeClaudeChatMessage(id);
+
+    const after = chatMap().get(id) as ChatMessage;
+    expect(after.text).toBe("partial + more + done");
+    expect(after.id).toBe(before.id);
+    expect(after.author).toBe("claude");
+    expect(after.timestamp).toBe(before.timestamp); // NOT re-stamped (sort stability)
+    expect(after.read).toBe(before.read);
+    expect(after.documentId).toBe("d2");
+    expect(after.replyTo).toBe("u9");
+    expect(after.agentIdentity).toEqual({ provider: "local-ollama", displayName: "Qwen 2.5" });
+    expect(streamMap().has(id)).toBe(false);
+
+    expect(() => finalizeClaudeChatMessage(id)).not.toThrow(); // idempotent
+    expect((chatMap().get(id) as ChatMessage).text).toBe("partial + more + done");
+  });
+
+  it("turn-reset replace: a shorter, different text replaces the streamed preamble exactly", () => {
+    const id = appendClaudeChatMessage("Let me look at the document. ", { documentId: "d3" });
+    updateClaudeChatMessage(id, "Let me look at the document. It seems that");
+    // onTurnEnd({hadToolCalls:true}) resets the buffer; the next turn streams a
+    // different, shorter answer — common prefix 0 → delete-all + insert.
+    updateClaudeChatMessage(id, "Done.");
+    expect(streamText(id)).toBe("Done.");
+    finalizeClaudeChatMessage(id);
+    expect((chatMap().get(id) as ChatMessage).text).toBe("Done.");
+  });
+
+  it("truncation-marker append: extending the last flushed buffer is committed exactly", () => {
+    const body = "y".repeat(200);
+    const marker = "\n\n_[Reply truncated — the model exceeded the streaming limit.]_";
+    const id = appendClaudeChatMessage(body.slice(0, 80), { documentId: "d4" });
+    updateClaudeChatMessage(id, body);
+    updateClaudeChatMessage(id, body + marker); // pure extension, like the #1292 cap path
+    finalizeClaudeChatMessage(id);
+    expect((chatMap().get(id) as ChatMessage).text).toBe(body + marker);
+  });
+
+  it("equal text is a no-op that broadcasts nothing", () => {
+    const id = appendClaudeChatMessage("stable", { documentId: "d5" });
+    updateClaudeChatMessage(id, "stable text so far");
+    let updates = 0;
+    const onUpdate = () => {
+      updates += 1;
+    };
+    ctrl().on("update", onUpdate);
+    try {
+      updateClaudeChatMessage(id, "stable text so far");
+    } finally {
+      ctrl().off("update", onUpdate);
+    }
+    expect(updates).toBe(0);
+    expect(streamText(id)).toBe("stable text so far");
+  });
+
+  it("empty text never mints a sidecar entry that would shadow the row (pins the equal-text guard)", () => {
+    // The load-bearing case for `if (current === text) return`. Without it a
+    // flush of "" before any sidecar exists mints an EMPTY Y.Text, which is
+    // AUTHORITATIVE over the row — every reader then composes an empty bubble
+    // for a message that has text.
+    const id = appendClaudeChatMessage("a real answer", { documentId: "d10" });
+    updateClaudeChatMessage(id, "");
+    expect(streamMap().has(id)).toBe(false);
+    expect((chatMap().get(id) as ChatMessage).text).toBe("a real answer");
+  });
+
+  it("finalize drops an EMPTY sidecar Y.Text instead of blanking the row", () => {
+    // Malformed state from some other build (today's update path returns
+    // before minting one). Folding it would destroy the row's real text.
+    const id = appendClaudeChatMessage("a real answer", { documentId: "d11" });
+    withInternal(ctrl(), () => streamMap().set(id, new Y.Text()));
+    finalizeClaudeChatMessage(id);
+    expect((chatMap().get(id) as ChatMessage).text).toBe("a real answer");
+    expect(streamMap().has(id)).toBe(false);
+  });
+
+  it("update on an unknown id is a no-op that creates no sidecar entry", () => {
+    updateClaudeChatMessage("never-appended", "x");
+    expect(chatMap().has("never-appended")).toBe(false);
+    expect(streamMap().has("never-appended")).toBe(false);
+  });
+
+  it("a flush racing a chat clear deletes the orphan sidecar entry and never resurrects the row", () => {
+    const id = appendClaudeChatMessage("will be erased", { documentId: "d6" });
+    updateClaudeChatMessage(id, "will be erased plus streamed tail");
+    // The chat row goes away mid-stream (the clear's live deletion), but a
+    // sidecar entry survived — e.g. a flush recreated it between the clear's
+    // snapshot capture and its live-doc deletion pass.
+    withInternal(ctrl(), () => chatMap().delete(id));
+    expect(streamMap().has(id)).toBe(true);
+    // The next in-flight flush lands after the clear: it must not recreate
+    // anything, and must delete the orphan sidecar entry so the erased
+    // message cannot be resurrected by any later fold.
+    updateClaudeChatMessage(id, "will be erased plus streamed tail plus more");
+    expect(chatMap().has(id)).toBe(false);
+    expect(streamMap().has(id)).toBe(false);
+  });
+
+  it("finalize after the chat row was deleted mid-stream drops the sidecar without resurrecting the row", () => {
+    const id = appendClaudeChatMessage("erase me", { documentId: "d7" });
+    updateClaudeChatMessage(id, "erase me and my stream");
+    withInternal(ctrl(), () => chatMap().delete(id)); // row gone, sidecar still live
+    expect(streamMap().has(id)).toBe(true);
+    finalizeClaudeChatMessage(id);
+    expect(chatMap().has(id)).toBe(false); // the erased message stays erased
+    expect(streamMap().has(id)).toBe(false);
+  });
+});
+
+describe("surrogate-pair safety (BLOCKER — Yjs substitutes U+FFFD on a mid-pair split)", () => {
+  it("a replace whose common prefix ends inside a surrogate pair never corrupts the text", () => {
+    // 🙂 (U+1F642, UTF-16 <D83D DE42>) and 🙃 (U+1F643, <D83D DE43>)
+    // share the high surrogate 0xD83D, so the naive UTF-16 common prefix is 1
+    // — a splice at offset 1 makes Yjs's ContentString.splice write U+FFFD on
+    // BOTH sides of the split,
+    // permanently, and insert a lone low surrogate. The clamp must back the
+    // prefix off to the code-point boundary (p=0 here).
+    const id = appendClaudeChatMessage("🙂", { documentId: "d8" });
+    updateClaudeChatMessage(id, "🙂x"); // seed the sidecar with the astral text
+    expect(streamText(id)).toBe("🙂x");
+    updateClaudeChatMessage(id, "🙃y");
+    expect(streamText(id)).toBe("🙃y");
+    expect(streamText(id)).not.toContain("�");
+    finalizeClaudeChatMessage(id);
+    const row = chatMap().get(id) as ChatMessage;
+    expect(row.text).toBe("🙃y");
+    expect(row.text).not.toContain("�");
+  });
+
+  it("a RUN of consecutive unpaired high surrogates backs the split all the way off", () => {
+    // Yjs substitutes U+FFFD whenever the character before a ContentString
+    // split is a high surrogate — paired or not. So backing the prefix off by
+    // exactly ONE unit is not enough: here the prefix is 2, one step lands it
+    // on another lone high surrogate, and the splice yields "\uFFFD\uD83Dx".
+    // The clamp must LOOP until the split point is off high surrogates.
+    const id = appendClaudeChatMessage("seed", { documentId: "d12" });
+    updateClaudeChatMessage(id, "\uD83D🙃"); // lone high surrogate, then a real pair
+    expect(streamText(id)).toBe("\uD83D🙃");
+    updateClaudeChatMessage(id, "\uD83D\uD83Dx"); // common prefix 2, both units high
+    expect(streamText(id)).toBe("\uD83D\uD83Dx");
+    expect(streamText(id)).not.toContain("\uFFFD");
+    finalizeClaudeChatMessage(id);
+    expect((chatMap().get(id) as ChatMessage).text).toBe("\uD83D\uD83Dx");
+  });
+
+  it("the turn-reset shape from the collaborator (emoji preamble → different emoji answer) round-trips exactly", () => {
+    const id = appendClaudeChatMessage("🙂 checking", { documentId: "d9" });
+    updateClaudeChatMessage(id, "🙂 checking the doc"); // populate the sidecar
+    updateClaudeChatMessage(id, "🙃 done"); // shrink+replace across a shared high surrogate
+    // Asserted BEFORE any further update: a later replace whose common prefix
+    // is 0 would silently repair the corruption and mask a missing clamp.
+    expect(streamText(id)).toBe("🙃 done");
+    updateClaudeChatMessage(id, "🙃 done 🎉"); // then a pure append of another astral char
+    expect(streamText(id)).toBe("🙃 done 🎉");
+    expect(streamText(id)).not.toContain("�");
+    finalizeClaudeChatMessage(id);
+    expect((chatMap().get(id) as ChatMessage).text).toBe("🙃 done 🎉");
+  });
+});

--- a/tests/server/local-model/collaborator.test.ts
+++ b/tests/server/local-model/collaborator.test.ts
@@ -22,6 +22,7 @@ import type { LocalModelConfig } from "../../../src/server/local-model/config.js
 import type { LoopResult } from "../../../src/server/local-model/index.js";
 import {
   appendClaudeChatMessage,
+  finalizeClaudeChatMessage,
   updateClaudeChatMessage,
 } from "../../../src/server/mcp/awareness.js";
 import { populateYDoc } from "../../../src/server/mcp/document.js";
@@ -33,6 +34,7 @@ import { getOrCreateDocument } from "../../../src/server/yjs/provider.js";
 import {
   CTRL_ROOM,
   Y_MAP_CHAT,
+  Y_MAP_CHAT_STREAM,
   Y_MAP_MODE,
   Y_MAP_USER_AWARENESS,
 } from "../../../src/shared/constants.js";
@@ -141,6 +143,10 @@ function chatMap() {
   return getOrCreateDocument(CTRL_ROOM).getMap(Y_MAP_CHAT);
 }
 
+function streamMap() {
+  return getOrCreateDocument(CTRL_ROOM).getMap(Y_MAP_CHAT_STREAM);
+}
+
 function chatMessages(): ChatMessage[] {
   return [...chatMap().values()] as ChatMessage[];
 }
@@ -165,6 +171,7 @@ beforeEach(() => {
   const ctrl = getOrCreateDocument(CTRL_ROOM);
   withInternal(ctrl, () => {
     ctrl.getMap(Y_MAP_CHAT).clear();
+    ctrl.getMap(Y_MAP_CHAT_STREAM).clear();
     ctrl.getMap(Y_MAP_USER_AWARENESS).delete(Y_MAP_MODE);
   });
 });
@@ -791,15 +798,20 @@ describe("classifyFailure — bucketing + redaction", () => {
 });
 
 describe("chat write helpers — self-wake safety (load-bearing)", () => {
-  it("append + update produce ZERO chat:message events; a user write produces one", async () => {
+  it("append + update + finalize produce ZERO chat:message events; a user write produces one", async () => {
     attachCtrlObservers();
     const events: TandemEvent[] = [];
     const sub = (e: TandemEvent) => events.push(e);
     subscribe(sub, "external");
     try {
-      // Claude/local writes — both must be invisible to the channel.
+      // Claude/local writes — all three must be invisible to the channel.
+      // Updates land in the chatStream sidecar (no observer, mcp origin
+      // anyway); the finalize fold is an `update`-action re-set on the chat
+      // map, dropped at BOTH the shouldSkipChannel(mcp) gate and the
+      // `action !== "add"` gate (#1340 — pins the origin arithmetic).
       const id = appendClaudeChatMessage("streamed reply", { documentId: "d1" });
       updateClaudeChatMessage(id, "streamed reply (more)");
+      finalizeClaudeChatMessage(id);
 
       // Control: a user (browser-origin) write DOES fire one chat:message.
       const ctrl = getOrCreateDocument(CTRL_ROOM);
@@ -823,11 +835,19 @@ describe("chat write helpers — self-wake safety (load-bearing)", () => {
   });
 });
 
-describe("updateClaudeChatMessage — shape preservation", () => {
-  it("changes only text, freezing id/author/timestamp/read/documentId/replyTo", () => {
+describe("update + finalize — shape preservation across the streamed lifecycle", () => {
+  it("finalize folds the text; id/author/timestamp/read/documentId/replyTo ride through verbatim", () => {
     const id = appendClaudeChatMessage("first", { documentId: "d2", replyTo: "u9" });
     const before = chatMap().get(id) as ChatMessage;
     updateClaudeChatMessage(id, "second");
+    // #1340 NEW INVARIANT, asserted deliberately: mid-stream the chat row is
+    // STALE (untouched since append) and the chatStream sidecar is the
+    // authority — readers compose. A `chatMap.set` per update would be the
+    // O(n²) revert this test's sibling byte-guard also catches.
+    expect((chatMap().get(id) as ChatMessage).text).toBe("first");
+    expect(streamMap().has(id)).toBe(true);
+
+    finalizeClaudeChatMessage(id);
     const after = chatMap().get(id) as ChatMessage;
     expect(after.text).toBe("second");
     expect(after.id).toBe(before.id);
@@ -836,19 +856,25 @@ describe("updateClaudeChatMessage — shape preservation", () => {
     expect(after.read).toBe(before.read);
     expect(after.documentId).toBe("d2");
     expect(after.replyTo).toBe("u9");
+    expect(streamMap().has(id)).toBe(false);
   });
 
-  it("is a no-op when the message id is absent", () => {
+  it("is a no-op when the message id is absent (no chat row, no sidecar entry)", () => {
     expect(() => updateClaudeChatMessage("does-not-exist", "x")).not.toThrow();
     expect(chatMap().has("does-not-exist")).toBe(false);
+    expect(streamMap().has("does-not-exist")).toBe(false);
   });
 
-  it("#1123 M3: stamps agentIdentity on append and preserves it across a streamed update", () => {
+  it("#1123 M3: stamps agentIdentity on append and carries it through stream + fold", () => {
     const identity = { provider: "local-ollama" as const, displayName: "Qwen 2.5" };
     const id = appendClaudeChatMessage("partial", { documentId: "d3", agentIdentity: identity });
     expect((chatMap().get(id) as ChatMessage).agentIdentity).toEqual(identity);
-    // The `{...existing, text}` re-set must carry the byline through every delta.
+    // Streaming leaves the row untouched, so the byline survives every delta
+    // by construction; the fold's `{...existing}` must then carry it into the
+    // final re-set.
     updateClaudeChatMessage(id, "partial + more");
+    expect((chatMap().get(id) as ChatMessage).agentIdentity).toEqual(identity);
+    finalizeClaudeChatMessage(id);
     const after = chatMap().get(id) as ChatMessage;
     expect(after.text).toBe("partial + more");
     expect(after.agentIdentity).toEqual(identity);
@@ -1035,5 +1061,162 @@ describe("collaborator — streamed reply is bounded (#1292)", () => {
     expect(seen).toBeDefined();
     expect(seen).toBeLessThan(16 * 1024 * 1024);
     expect(seen).toBeGreaterThanOrEqual(CAP);
+  });
+});
+
+describe("collaborator — streamed lifecycle ends with an empty sidecar (#1340)", () => {
+  // dispose() runs in executeRun's finally on EVERY exit, and its finalize
+  // fold is deliberately not ownership-gated — a leaked chatStream entry would
+  // stay authoritative over the row forever (and leak a Y.Text). Each terminal
+  // path must leave the sidecar map empty and the row holding the final text.
+
+  it("clean multi-flush run: sidecar empty, row holds the full reply", async () => {
+    setupDoc("doc-fin-clean", "Body");
+    const reply = "w".repeat(300); // > STREAM_FLUSH_CHARS → real mid-stream flushes
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          opts.onContentDelta?.(reply.slice(0, 150));
+          await new Promise((r) => setTimeout(r, 0)); // let the deferred flush land
+          opts.onContentDelta?.(reply.slice(150));
+          opts.onTurnEnd?.({ hadToolCalls: false });
+          return cleanResult(reply);
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("go", { documentId: "doc-fin-clean" }));
+    await drain(collab);
+
+    expect(streamMap().size).toBe(0);
+    const msgs = chatMessages();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].text).toBe(reply);
+  });
+
+  it("error-with-partial run: partial folded into the row, sidecar empty", async () => {
+    setupDoc("doc-fin-err", "Body");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const partial = "p".repeat(120);
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          opts.onContentDelta?.(partial); // > 80 → flush lands mid-stream
+          await new Promise((r) => setTimeout(r, 0));
+          return errorResult("local model response exceeded 4194304-byte cap");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("go", { documentId: "doc-fin-err" }));
+    await drain(collab);
+
+    expect(streamMap().size).toBe(0);
+    expect(chatMessages()[0].text).toBe(partial);
+    errorSpy.mockRestore();
+  });
+
+  it("truncation-cap run (#1292): marker folded into the row, sidecar empty", async () => {
+    setupDoc("doc-fin-cap", "Body");
+    const CAP = 64 * 1024;
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          for (let sent = 0; sent < CAP * 2; sent += 16 * 1024) {
+            opts.onContentDelta?.("x".repeat(16 * 1024));
+          }
+          await new Promise((r) => setTimeout(r, 0)); // let the cap commit+abort run
+          opts.onTurnEnd?.({ hadToolCalls: false });
+          return cleanResult("unused");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("go", { documentId: "doc-fin-cap" }));
+    await drain(collab);
+
+    expect(streamMap().size).toBe(0);
+    expect(chatMessages()[0].text).toContain("Reply truncated");
+  });
+
+  it("superseded run: its last flushed partial is folded, sidecar empty, B's reply intact", async () => {
+    setupDoc("doc-fin-super", "Body");
+    const partialA = "a".repeat(120);
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          if (opts.task === "A") {
+            opts.onContentDelta?.(partialA);
+            await new Promise((r) => setTimeout(r, 0)); // flush lands → bubble minted
+            await new Promise<void>((res) =>
+              opts.signal?.addEventListener("abort", () => res(), { once: true }),
+            );
+            return cleanResult("unused");
+          }
+          opts.onContentDelta?.("reply B is long enough to flush".repeat(4));
+          await new Promise((r) => setTimeout(r, 0));
+          opts.onTurnEnd?.({ hadToolCalls: false });
+          return cleanResult("reply B");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("A", { documentId: "doc-fin-super", messageId: "a" }));
+    await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0)); // A's flush mints its bubble
+    collab.onEvent(chatEvent("B", { documentId: "doc-fin-super", messageId: "b" }));
+    await drain(collab);
+
+    // A kept its last flushed partial (today's observable abort behaviour),
+    // folded into the durable row; nothing left in the sidecar for either run.
+    expect(streamMap().size).toBe(0);
+    const texts = chatMessages().map((m) => m.text);
+    expect(texts).toContain(partialA);
+    expect(texts).toContain("reply B is long enough to flush".repeat(4));
+  });
+});
+
+describe("collaborator — streamed write volume at the caller level (#1340)", () => {
+  it("a whole streamed run costs O(L) ctrl update bytes", async () => {
+    // Byte-shaped, never wall-clock (this box runs under heavy load). Guards a
+    // revert of the sidecar primitive as seen THROUGH the collaborator's real
+    // flush machinery: master's whole-value re-set measures ~104×L here; the
+    // sidecar fix ~2.3×L. It does NOT constrain STREAM_FLUSH_CHARS — with the
+    // linear primitive, flush fineness only adds per-transaction overhead.
+    setupDoc("doc-bytes", "Body");
+    const L = 16_384;
+    const STEP = 80;
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          for (let sent = 0; sent < L; sent += STEP) {
+            opts.onContentDelta?.("x".repeat(Math.min(STEP, L - sent)));
+            // Yield a macrotask so each ≥80-char flush actually lands — the
+            // sink only ever writes from deferred timers.
+            await new Promise((r) => setTimeout(r, 0));
+          }
+          opts.onTurnEnd?.({ hadToolCalls: false });
+          return cleanResult("x".repeat(L));
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+
+    const ctrl = getOrCreateDocument(CTRL_ROOM);
+    let bytes = 0;
+    const onUpdate = (u: Uint8Array) => {
+      bytes += u.byteLength;
+    };
+    ctrl.on("update", onUpdate);
+    try {
+      collab.onEvent(chatEvent("go", { documentId: "doc-bytes" }));
+      await drain(collab);
+    } finally {
+      ctrl.off("update", onUpdate);
+    }
+
+    expect(chatMessages()[0].text).toBe("x".repeat(L)); // the run really streamed L chars
+    expect(bytes).toBeGreaterThan(L); // sanity: content was transmitted
+    expect(bytes).toBeLessThanOrEqual(12 * L); // RED on master (~104×L)
   });
 });


### PR DESCRIPTION
Closes #1340.

## Root cause

`updateClaudeChatMessage` committed each streamed flush as a whole-value `Y.Map.set` of the entire `ChatMessage`, and its only caller (`local-model/collaborator.ts`) passes the **full accumulated text** on every flush:

```ts
withMcp(ctrlDoc, () => chatMap.set(id, { ...existing, text }));   // full re-set
```

A `Y.Map` value can only be replaced wholesale, so "append 80 chars" was encoded as "retransmit everything so far". A reply of final length `L` flushed every ~80 chars performed `N ≈ L/80` sets of sizes 80, 160, …, L — `Σ ≈ L²/160` bytes broadcast to every connected client. This is a property of the **carrier**, not the flush policy: the 120 ms flush timer alone makes a slow token stream quadratic in duration regardless of `STREAM_FLUSH_CHARS`, and finer streaming is strictly worse, which is the wrong incentive for a streaming primitive.

Measured on this checkout, driving the real primitives and counting `doc.on("update")` payload bytes:

| final length L | flushes | update bytes | amplification |
|---|---|---|---|
| 2,000 | 25 | 27,921 | 14.0× |
| 16,384 | 205 | 1,705,195 | 104.1× |
| 65,536 (`MAX_STREAMED_CHARS`) | 820 | 26,994,562 | 411.9× |

`L×8 → bytes ×64`, matching the issue's numbers within encoding noise.

## The fix

A CTRL_ROOM **streaming sidecar**: `Y.Map('chatStream')` (`Y_MAP_CHAT_STREAM`) holds one `Y.Text` per *in-flight* streamed message, keyed by message id.

- `updateClaudeChatMessage(id, fullTextSoFar)` keeps its signature but now **diff-splices** the minimal delta into that `Y.Text` (a pure append in the common case; a delete+insert for the turn-reset shape). O(delta) on the wire.
- New `finalizeClaudeChatMessage(id)` folds the final text back into the plain chat row (`{...existing, text}` — `id`/`author`/`timestamp`/`read`/`documentId`/`replyTo`/`agentIdentity` ride through verbatim; `timestamp` is deliberately never re-stamped) and deletes the sidecar entry. Called from the collaborator sink's `dispose()`, which runs in `executeRun`'s `finally` on every exit path.
- **The durable/at-rest shape is unchanged** — a plain `ChatMessage` in `Y.Map('chat')`. `persistCtrlSnapshot` folds on the snapshot **clone** (so the live doc keeps streaming and a crash mid-stream durably keeps the last-flushed text, exactly as today), and `restoreCtrlDoc` sweeps anything a foreign snapshot carried.
- While a sidecar entry exists it is **authoritative** over the row's `text`; the client hook composes the two. The `$effect` uses `observeDeep`, because a plain `observe` on the map fires only for key add/delete and the live bubble would freeze.

Measured after: a flat **2.2–2.3×** at every L — 36,834 bytes at L=16,384 (46× less), 148,053 at the 64 KiB cap (182× less). The linearity claim is a **wire** claim; per-flush CPU is still O(current length) for the `toString()` + prefix scan, bounded by the producer's cap.

Rejected alternatives (detail in the branch's `PLAN.md`): capping chat history (does not touch the mechanism, and trades user data for a bug it cannot fix); adaptive/geometric flush throttling (the 120 ms timer stays quadratic in duration, and it fixes only this caller); making the chat-map value a nested `Y.Map`+`Y.Text` (breaks the plain-`ChatMessage` read contract at every reader and changes the on-disk format).

## Hardening from review

The plan was reviewed adversarially before implementation, and the implementation was reviewed independently by a CRDT reviewer and a durability reviewer (both **ship-after-fixes**, seven minor findings, no blockers). What those reviews changed:

- **The staleness tripwire moved off the write path.** The leak it exists for — a producer that crashes, hangs or is torn down without finalizing — emits no further `updateClaudeChatMessage` calls, so a check inside that function could only ever fire for a producer *still* streaming after ten minutes. `foldChatStream` enumerates every live entry on every persist and every restore regardless of producer activity, so the ledger is reconciled from there. The ledger lives in a new leaf module `src/server/chat-stream-staleness.ts` with no project imports: `session/manager.ts` cannot import `mcp/awareness.ts` (awareness → mcp/document → session/manager is a cycle). Reconciliation also bounds the ledger, which previously leaked an entry per abandoned stream.
- **Both folds now require a NON-EMPTY `Y.Text`.** A snapshot carrying an empty sidecar entry alongside a real chat row folded the empty text over the row and destroyed user chat text. Not reachable from today's producer (`write()` no-ops on an empty buffer), so this was a hardening gap in a defensive path rather than a live bug — but "drop malformed input" is exactly what that sweep is for.
- **The surrogate clamp is a loop, not a single step.** Yjs's `ContentString.splice` substitutes U+FFFD on *both* sides of a split whenever the preceding code unit is a high surrogate, paired or not. Backing off exactly one unit still lands on a high surrogate for a run of consecutive unpaired highs (`current = "\uD83D🙃"`, `text = "\uD83D\uD83Dx"` yielded `"�\uD83Dx"`). The condition stays a bare `p > 0` — adding `p < text.length` corrupts the `p === text.length` pure-shrink case.
- **Origin helper corrected** (Critical Rule 2): the orphan-sidecar delete on the `!existing` early return is `withInternal`, not `withMcp`. It is convergence cleanup after `DELETE /api/chat` raced a flush, not a Claude-authored chat write. No live behaviour change (on CTRL_ROOM both are in `CHANNEL_SKIP`), but the helper choice is the contract and `audit:origins` reads it as a census of intent.

### One claim corrected

An earlier report described `clearCtrlChatDurably`'s **snapshot-side** `snapshotStream.delete(id)` as a data-loss guard. It is not. `foldChatStream` re-`set`s only when `existing && value instanceof Y.Text`, and `snapshotChat.delete(id)` has already run for every captured id in the same `withInternal` transaction — so the fold cannot resurrect an erased message without it, and commenting the line out leaves the suite green. It is kept as belt-and-braces, and both its comment and the test's comment now say so. The **live-side** delete is the load-bearing one (orphan-`Y.Text` hygiene), and it *is* pinned by an assertion.

## Tests

New `tests/server/chat-stream.test.ts` (13 cases) plus extensions to `tests/server/chat-durable-clear.test.ts`, `tests/server/local-model/collaborator.test.ts`, `tests/client/chat-state.test.ts`. All perf assertions are **byte- or count-shaped**, never wall-clock, so they are deterministic on a loaded machine.

What they catch, with the reversion that turns each red:

| Test | Red when |
|---|---|
| `a full streamed lifecycle costs O(L) update bytes, not O(L²)` (`≤ 12×L` at L=16,384) | the sidecar is reverted to per-flush whole-value `chatMap.set` (master measures ~104×L) |
| `doubling the stream length ~doubles the bytes` (ratio ≤ 3) | any half-revert that reintroduces a per-flush whole-value set — pins the *curve*, not a point |
| collaborator-level write-volume guard across a whole streamed run | the primitive is reverted, or the flush policy is changed in a way that restores amplification |
| `empty text never mints a sidecar entry that would shadow the row` | `if (current === text) return;` removed → `expected true to be false` (an empty `Y.Text` is minted and is authoritative over a row that has text) |
| `finalize drops an EMPTY sidecar Y.Text instead of blanking the row` | `&& entry.length > 0` removed → `expected '' to be 'a real answer'` |
| `an EMPTY sidecar Y.Text is dropped, never folded over the live row's text` (restore path) | `&& value.length > 0` removed → `expected '' to be 'a real answer the user can read'` |
| `a RUN of consecutive unpaired high surrogates backs the split all the way off` | the clamp `while` reverted to `if` → `expected '�\uD83Dx' to be '\uD83D\uD83Dx'` |
| `an abandoned sidecar entry is reported by the snapshot sweep, once per id` | `reconcileStreamSidecars(streamMap.keys())` removed from `foldChatStream` → `expected [] to have a length of 1` |
| `a sidecar entry within its lifetime is not reported` | the age threshold removed from the sweep → `expected [Array(1)] to have a length of +0` (false-positive guard) |

Also covered: mid-stream row staleness and sidecar authority; field-verbatim fold + idempotent finalize; turn-reset replace and truncation-marker append round-trips; update on an unknown id; a flush racing a chat clear (orphan deleted, row never resurrected); finalize after the row was deleted mid-stream; the existing surrogate-pair cases; **zero** `chat:message` channel events across append → N updates → finalize (the origin/action arithmetic is unchanged from master); every collaborator terminal path (clean, error-with-partial, `#1292` truncation cap, superseded/abort) leaving an empty sidecar map; and the client hook composing sidecar text and refreshing on a nested `Y.Text` insert (would fail if `observeDeep` regressed to `observe`).

## Gates

| Gate | Result |
|---|---|
| `npm run typecheck` (tsc server + tsc client + `svelte-check --fail-on-warnings`) | pass — 1337 files, 0 errors, 0 warnings |
| `npx biome check src/ tests/` | pass — 1091 files checked |
| `npm test` (full vitest) | pass — **515 files passed, 2 skipped; 7510 tests passed, 24 skipped** |
| `npm run audit:ymap-keys` (Critical Rule 1) | `clean` |
| `npm run audit:origins` (Critical Rule 2) | `clean (77 tagged sites across 496 files)` |
| pre-commit (lint-staged: eslint, biome, semantic-token scan, EOL normalize) | pass |
| pre-push (biome + full vitest + `cargo test`) | pass, including the full Rust suite |

## Unverified / notes

- **No Playwright run.** No E2E spec exercises chat streaming — the only producer (`local-model/`) ships dark behind `BYO_MODELS_ENABLED = false` — and the client-side change is read-side composition in a hook, covered by unit tests. The E2E harness also refuses to start while another server holds :3479, which is the case on this box.
- **No live streaming was exercised end to end against a real model**, for the same dark-flag reason. The collaborator tests drive a fake `runTurn` emitting real delta sequences.
- `Y_MAP_CHAT_STREAM` is a new Y.Map key, so downgrading to a build without this change would leave a mid-stream reply's row showing only its last flush — no data loss (the durable file never carries a live entry), but worth knowing.
- The `data-testid` snapshot was deliberately **not** regenerated: the new testid lives in `tests/client/fixtures/`, and `testid-coverage.test.ts` scans `src/client/` only.
- Adjacent, not fixed here: the client `refresh()` still re-reads and re-sorts the whole chat map on every observer fire — O(history) per flush. That is client-local CPU, linear per fire, and out of scope for this issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_018DdaCvomDgPsumrDAmNH13)_