### PR TITLE
ci(webdriver): un-stale the Edge driver pin table and give it a tracked guard

### DIFF
--- a/.github/workflows/tauri-webdriver.yml
+++ b/.github/workflows/tauri-webdriver.yml
@@ -169,11 +169,19 @@ jobs:
           # about October 2026 - up to that review, not past it. If #1345
           # resolves to "restore", the restore work needs a fresh dated gate for
           # this table, because #1345 closes and the table outlives it.
+          # A row must NOT equal today's LATEST_RELEASE_<major>. Add-Candidate
+          # deduplicates, so a pin equal to the pointer is dropped and the net is
+          # present-but-degenerate: in exactly the #1197 failure (the pointer
+          # names a build whose zip is missing) it contributes no candidate at
+          # all. Verified 2026-08-20: LATEST_RELEASE_151 = 151.0.4129.93 and
+          # LATEST_RELEASE_152 = 152.0.4191.35, so both rows below sit BELOW
+          # their pointer, and below the 16-patch walk-back window under it.
+          # Each was fetched and confirmed to contain msedgedriver.exe.
           $pinned = @{
             '149' = '149.0.4022.98'
             '150' = '150.0.4078.83'
-            '151' = '151.0.4129.93'
-            '152' = '152.0.4191.35'
+            '151' = '151.0.4129.50'
+            '152' = '152.0.4191.10'
           }
           # Say a missing row out loud (a ::warning:: annotation, visible on the
           # run page) instead of letting a green-until-it-isn't run hide it.
@@ -265,16 +273,20 @@ jobs:
 
           # Green-but-rescued is the other half of "fail loudly" (#1197). If the
           # hand-pinned row is what won, EVERY live candidate missed - the exact
-          # runtime version, the LATEST_RELEASE_<major> pointer and all 32
-          # walk-back builds - which is #1197's original CDN failure recurring,
-          # survived only because the net happened to still be current. A run
-          # that rendered as an ordinary green would hide exactly that, and the
-          # net is the one candidate guaranteed to expire.
+          # runtime version, the LATEST_RELEASE_<major> pointer and every
+          # walk-back build tried - which is #1197's original CDN failure
+          # recurring, survived only because the net happened to still be
+          # current. A run that rendered as an ordinary green would hide exactly
+          # that, and the net is the one candidate guaranteed to expire.
+          #
+          # The count is interpolated, never hard-coded: the list is 34 builds
+          # only when both live sources resolve and neither collides with the
+          # walk-back. A LATEST_RELEASE_<major> fetch that throws leaves 18.
           if ($driverVersion -eq $pinned[$major] -and $driverVersion -ne $pv -and $driverVersion -ne $latest) {
             Write-Host ("::warning::Only the hand-pinned Edge WebDriver ($driverVersion) resolved for " +
-              "WebView2 major ${major} - every live candidate missed, so msedgedriver.microsoft.com " +
-              "or its LATEST_RELEASE_${major} pointer is broken again (#1197). This run is green " +
-              "only because the last-resort pin is still current.")
+              "WebView2 major ${major} - all $($candidates.Count) candidates tried missed, so " +
+              "msedgedriver.microsoft.com or its LATEST_RELEASE_${major} pointer is broken again " +
+              "(#1197). This run is green only because the last-resort pin is still current.")
           }
 
           # Defense in depth: a mislabelled blob must not become a silently

--- a/.github/workflows/tauri-webdriver.yml
+++ b/.github/workflows/tauri-webdriver.yml
@@ -146,12 +146,37 @@ jobs:
           Write-Host "WebView2 Runtime: $pv (major $major)"
 
           # Known-good driver builds keyed by WebView2 major. Only consulted once
-          # every live candidate has missed; keep in sync as majors roll.
-          $pinned = @{ '149' = '149.0.4022.98'; '150' = '150.0.4078.83' }
-          # This table rots silently: when the runners roll to a major with no
-          # row, Add-Candidate gets $null and the last-resort net just vanishes.
-          # Say so out loud (an ::warning:: annotation, visible on the run page)
-          # instead of letting a green-until-it-isn't run hide it.
+          # every live candidate has missed. Each row was verified downloadable
+          # (HTTP 200, and the zip really contains msedgedriver.exe) when added.
+          #
+          # HOW THIS ROTS, measured rather than assumed (2026-08-20). It is NOT
+          # that the CDN drops old blobs: 149.0.4022.98 still serves today, and
+          # #1197's original failure was a LATEST_RELEASE_ pointer naming a build
+          # that was never published at all. The rot is a NEW MAJOR WITH NO ROW:
+          # `$pinned[$major]` on a missing key is $null and Add-Candidate returns
+          # immediately, so the last-resort net simply is not there. Worse, a
+          # MIS-KEYED row ('152' = '151.0...') is dropped by Add-Candidate's
+          # in-major filter with no error AND without tripping the ContainsKey
+          # warning below, because the key IS present. Both shapes are pinned by
+          # tests/scripts/tauri-webdriver-pin.test.ts, which is the only thing
+          # that reads this table on an ordinary PR - this job is dispatch-only,
+          # so the annotations below reach nobody until someone runs it.
+          #
+          # REVIEW HOME: #1345, dated 2026-11-01, which already lists "the
+          # current pinned driver table in the workflow versus what Microsoft
+          # ships at review time" among the evidence it weighs. Edge ships stable
+          # majors roughly every 4 weeks, so these rows cover the runners to
+          # about October 2026 - up to that review, not past it. If #1345
+          # resolves to "restore", the restore work needs a fresh dated gate for
+          # this table, because #1345 closes and the table outlives it.
+          $pinned = @{
+            '149' = '149.0.4022.98'
+            '150' = '150.0.4078.83'
+            '151' = '151.0.4129.93'
+            '152' = '152.0.4191.35'
+          }
+          # Say a missing row out loud (a ::warning:: annotation, visible on the
+          # run page) instead of letting a green-until-it-isn't run hide it.
           if (-not $pinned.ContainsKey($major)) {
             Write-Host ("::warning::No hand-pinned Edge WebDriver for WebView2 major " + $major +
               " - the last-resort fallback is gone. Add a row to `$pinned in .github/workflows/tauri-webdriver.yml.")
@@ -237,6 +262,20 @@ jobs:
           }
           $how = if ($driverVersion -eq $pv) { 'exact runtime match' } else { 'in-major fallback' }
           Write-Host "Edge WebDriver: $driverVersion ($how; runtime $pv)"
+
+          # Green-but-rescued is the other half of "fail loudly" (#1197). If the
+          # hand-pinned row is what won, EVERY live candidate missed - the exact
+          # runtime version, the LATEST_RELEASE_<major> pointer and all 32
+          # walk-back builds - which is #1197's original CDN failure recurring,
+          # survived only because the net happened to still be current. A run
+          # that rendered as an ordinary green would hide exactly that, and the
+          # net is the one candidate guaranteed to expire.
+          if ($driverVersion -eq $pinned[$major] -and $driverVersion -ne $pv -and $driverVersion -ne $latest) {
+            Write-Host ("::warning::Only the hand-pinned Edge WebDriver ($driverVersion) resolved for " +
+              "WebView2 major ${major} - every live candidate missed, so msedgedriver.microsoft.com " +
+              "or its LATEST_RELEASE_${major} pointer is broken again (#1197). This run is green " +
+              "only because the last-resort pin is still current.")
+          }
 
           # Defense in depth: a mislabelled blob must not become a silently
           # browser-matched driver, which is the connect-hang failure mode.

--- a/.github/workflows/tauri-webdriver.yml
+++ b/.github/workflows/tauri-webdriver.yml
@@ -150,9 +150,10 @@ jobs:
           # (HTTP 200, and the zip really contains msedgedriver.exe) when added.
           #
           # HOW THIS ROTS, measured rather than assumed (2026-08-20). It is NOT
-          # that the CDN drops old blobs: 149.0.4022.98 still serves today, and
-          # #1197's original failure was a LATEST_RELEASE_ pointer naming a build
-          # that was never published at all. The rot is a NEW MAJOR WITH NO ROW:
+          # that the CDN drops old blobs: the oldest row below, 149.0.4022.69,
+          # was built 2026-06-12 and still downloads today, and #1197's original
+          # failure was a LATEST_RELEASE_ pointer naming a build that was never
+          # published at all. The rot is a NEW MAJOR WITH NO ROW:
           # `$pinned[$major]` on a missing key is $null and Add-Candidate returns
           # immediately, so the last-resort net simply is not there. Worse, a
           # MIS-KEYED row ('152' = '151.0...') is dropped by Add-Candidate's
@@ -173,12 +174,26 @@ jobs:
           # deduplicates, so a pin equal to the pointer is dropped and the net is
           # present-but-degenerate: in exactly the #1197 failure (the pointer
           # names a build whose zip is missing) it contributes no candidate at
-          # all. Verified 2026-08-20: LATEST_RELEASE_151 = 151.0.4129.93 and
-          # LATEST_RELEASE_152 = 152.0.4191.35, so both rows below sit BELOW
-          # their pointer, and below the 16-patch walk-back window under it.
-          # Each was fetched and confirmed to contain msedgedriver.exe.
+          # all. The same argument extends 16 further: a row inside the walk-back
+          # window BELOW the pointer is deduplicated by the walk-back for the
+          # identical reason, so every row must sit more than 16 patches under
+          # its pointer, not merely differ from it.
+          #
+          # The pointers are recorded here, one line per row, because that is
+          # what makes the rule checkable at all without a network call:
+          # tests/scripts/tauri-webdriver-pin.test.ts parses these lines and
+          # fails if a row has no pointer recorded, equals it, or sits within the
+          # walk-back window under it. Re-fetch and rewrite them when you touch
+          # the table - a row added without its pointer line fails that test.
+          # Verified 2026-08-20, each pointer fetched from
+          # msedgedriver.microsoft.com/LATEST_RELEASE_<major> and each row's
+          # edgedriver_win64.zip downloaded (HTTP 200, contains msedgedriver.exe):
+          #   LATEST_RELEASE_149 = 149.0.4022.98
+          #   LATEST_RELEASE_150 = 150.0.4078.132
+          #   LATEST_RELEASE_151 = 151.0.4129.93
+          #   LATEST_RELEASE_152 = 152.0.4191.35
           $pinned = @{
-            '149' = '149.0.4022.98'
+            '149' = '149.0.4022.69'
             '150' = '150.0.4078.83'
             '151' = '151.0.4129.50'
             '152' = '152.0.4191.10'
@@ -279,7 +294,7 @@ jobs:
           # current. A run that rendered as an ordinary green would hide exactly
           # that, and the net is the one candidate guaranteed to expire.
           #
-          # The count is interpolated, never hard-coded: the list is 34 builds
+          # The count is interpolated, never hard-coded: the list is 35 builds
           # only when both live sources resolve and neither collides with the
           # walk-back. A LATEST_RELEASE_<major> fetch that throws leaves 18.
           if ($driverVersion -eq $pinned[$major] -and $driverVersion -ne $pv -and $driverVersion -ne $latest) {

--- a/tests/scripts/tauri-webdriver-pin.test.ts
+++ b/tests/scripts/tauri-webdriver-pin.test.ts
@@ -96,9 +96,18 @@ const run = driverStepRun();
  * The block form `<# … #>` is not optional. With only the whole-line `#` filter,
  * wrapping the last-resort net in a block comment disabled it while the suite
  * stayed fully green — the exact "grep-shaped test asserting a string while
- * claiming a semantic property" failure this file exists to avoid. Blank the
- * span rather than deleting it so line-relative reading of `runCode` still
- * lines up with the workflow.
+ * claiming a semantic property" failure this file exists to avoid. The span is
+ * blanked rather than deleted so that character offsets in the rest of its own
+ * line are unshifted — `at()` compares offsets, and a block comment opened and
+ * closed mid-line would otherwise drag the code after it leftwards. (Nothing
+ * here reads `runCode` by line NUMBER; the whole-line filter below deletes
+ * lines outright, so `runCode` is much shorter than `run`.)
+ *
+ * `<#` and `#>` are also counted for balance in a test below: the non-greedy
+ * match simply does not fire on an UNTERMINATED `<#`, so the disabled code
+ * survives into `runCode` and every `toContain` stays green. What no
+ * string-shaped test can catch is `if ($false) { … }` around the same code —
+ * that is acknowledged, not solved, here.
  */
 const runCode = run
   .replace(/<#[\s\S]*?#>/g, (m) => m.replace(/[^\n]/g, " "))
@@ -111,6 +120,18 @@ function at(needle: string): number {
   const i = runCode.indexOf(needle);
   if (i < 0) throw new Error(`${WORKFLOW}: the driver step no longer contains \`${needle}\``);
   return i;
+}
+
+/**
+ * The walk-back's `-le <n>` loop bound, read out of the script rather than
+ * duplicated as a literal here. Two assertions below depend on it — the prose
+ * candidate counts and how far a pinned row must sit under its pointer — and a
+ * second hard-coded 16 in this file would just be a third place to drift.
+ */
+function walkBackBound(): number {
+  const m = runCode.match(/-le (\d+) -and/);
+  if (!m?.[1]) throw new Error(`${WORKFLOW}: cannot find the walk-back's '-le <n> -and' bound`);
+  return Number(m[1]);
 }
 
 /** Throws rather than returning `[]`: an empty table must fail, not pass quietly. */
@@ -147,8 +168,44 @@ describe("tauri-webdriver.yml — Edge WebDriver candidate chain (#1197)", () =>
     // runtime match — the silent degradation this chain exists to prevent.
     // Measured: with three order-blind `toContain` calls, that hoist left the
     // suite 9/9 green.
+    //
+    // All FOUR positions are pinned, not three. With only the outer two, moving
+    // the whole walk-back `foreach` block BELOW `Add-Candidate $pinned[$major]`
+    // left the suite 10/10 green — and that reordering makes the stale hand-pin
+    // outrank every live near-miss build, which is the same degradation one step
+    // further down the chain.
     expect(at("Add-Candidate $pv")).toBeLessThan(at("Add-Candidate $latest"));
-    expect(at("Add-Candidate $latest")).toBeLessThan(at("Add-Candidate $pinned[$major]"));
+    expect(at("Add-Candidate $latest")).toBeLessThan(at("foreach ($seed in @($latest, $pv))"));
+    expect(at("foreach ($seed in @($latest, $pv))")).toBeLessThan(
+      at("Add-Candidate $pinned[$major]"),
+    );
+  });
+
+  it("cannot be blinded by an unterminated PowerShell block comment", () => {
+    // `runCode`'s block-comment stripper is `<#[\s\S]*?#>`, which is non-greedy
+    // and therefore does not fire at all on an unterminated `<#`. Measured: a
+    // bare `<# disabled` inserted above `Add-Candidate $pinned[$major]` — which
+    // comments out the whole rest of the script in real pwsh — left the suite
+    // 10/10 green, because the text still reached every `toContain`. Balance is
+    // the cheap invariant that catches it, and it is also a genuine syntax error
+    // in the workflow, so there is no legitimate reason for it to be unbalanced.
+    const opens = (run.match(/<#/g) ?? []).length;
+    const closes = (run.match(/#>/g) ?? []).length;
+    expect(opens).toBe(closes);
+  });
+
+  it("keeps the candidate-count prose derived from the walk-back bound", () => {
+    // Both `::warning::`-adjacent comments quote a maximum list length, and the
+    // review that produced this test found one saying 34 while the other said 35
+    // (the real max is 1 `$pv` + 1 `$latest` + 16 + 16 + 1 pin). A hard-coded
+    // number in prose next to a `-le N` loop bound is drift waiting to happen,
+    // so derive it: change the bound and this fails until the prose follows.
+    const walkBack = walkBackBound();
+    const max = 2 * walkBack + 3; // $pv + $latest + two walk-backs + the pin
+    const noPointer = walkBack + 2; // $pv + its walk-back + the pin
+    expect(run).toContain(`with up to ${max} candidates`);
+    expect(run).toContain(`the list is ${max} builds`);
+    expect(run).toContain(`leaves ${noPointer}`);
   });
 
   it("still warns when the runners reach a major with no pinned row", () => {
@@ -201,7 +258,61 @@ describe("tauri-webdriver.yml — the $pinned last-resort table", () => {
     // whose zip is missing — the net contributes no candidate at all. Both new
     // rows were byte-identical to their pointer when first written.
     expect(run).toContain("must NOT equal today's LATEST_RELEASE_<major>");
-    expect(run).toMatch(/Verified 2026-\d\d-\d\d/);
+    // Not /2026-\d\d-\d\d/, which accepts "Verified 2026-99-99" — a date that
+    // reads as maintained and cannot be a real fetch.
+    expect(run).toMatch(/Verified \d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])/);
+  });
+
+  it("records a live pointer for EVERY row, and every row sits clear of it", () => {
+    // The prose above pins that the RULE stays written down. This pins that the
+    // rule was actually FOLLOWED — possible offline only because the comment now
+    // records the pointers as tracked text, so the fetch is a one-time cost paid
+    // by whoever edits the table rather than a network call on every PR run.
+    //
+    // (a) is the assertion that would have caught the bug this test was added
+    // for: '149' was pinned to a build byte-identical to its own pointer while
+    // the comment verified only 151 and 152, so the degenerate row was invisible.
+    const recorded = new Map(
+      [...run.matchAll(/LATEST_RELEASE_(\d+)\s*=\s*(\d+\.\d+\.\d+\.\d+)/g)].map(
+        (m) => [m[1], m[2]] as [string, string],
+      ),
+    );
+
+    for (const [major, pin] of rows) {
+      const pointer = recorded.get(major);
+
+      // (a) recorded at all — an unverified row is not a verified one.
+      expect(
+        pointer,
+        `${WORKFLOW}: '$pinned' has a row for major ${major} but the comment records no ` +
+          `"LATEST_RELEASE_${major} = <version>" line. Fetch the pointer and record it.`,
+      ).toBeDefined();
+      if (!pointer) continue;
+
+      // (b) differs from the pointer — Add-Candidate deduplicates an equal row
+      // away, leaving the net present-but-degenerate.
+      expect(
+        pin,
+        `${WORKFLOW}: pinned row '${major}' equals its recorded LATEST_RELEASE_${major}, so ` +
+          `Add-Candidate deduplicates it away and the last-resort net is degenerate.`,
+      ).not.toBe(pointer);
+
+      // (c) further below the pointer than the walk-back reaches — that loop
+      // emits pointer-1 .. pointer-N, and deduplicates a row landing in there
+      // for exactly the same reason as (b). Only comparable on the same version
+      // line; a row on a different build line cannot collide with that walk-back.
+      const pinParts = pin.split(".");
+      const ptrParts = pointer.split(".");
+      if (pinParts.slice(0, 3).join(".") !== ptrParts.slice(0, 3).join(".")) continue;
+      const walkBack = walkBackBound();
+      const distance = Number(ptrParts[3]) - Number(pinParts[3]);
+      expect(
+        distance,
+        `${WORKFLOW}: pinned row '${major}' (${pin}) sits ${distance} patches below ` +
+          `LATEST_RELEASE_${major} (${pointer}); the ${walkBack}-patch walk-back under the ` +
+          `pointer swallows it, so the row adds no candidate. Pin more than ${walkBack} below.`,
+      ).toBeGreaterThan(walkBack);
+    }
   });
 
   it("names its dated review home so the pin cannot outlive its gate", () => {

--- a/tests/scripts/tauri-webdriver-pin.test.ts
+++ b/tests/scripts/tauri-webdriver-pin.test.ts
@@ -89,14 +89,29 @@ function driverStepRun(): string {
 const run = driverStepRun();
 
 /**
- * `run` with whole-line PowerShell comments removed. Everything that asserts the
- * script still DOES something must use this — see the header note; a `#` prefix
- * disables a line while leaving its text intact for `toContain`.
+ * `run` with PowerShell comments removed — BOTH forms. Everything that asserts
+ * the script still DOES something must use this; a comment marker disables a
+ * line while leaving its text intact for `toContain`.
+ *
+ * The block form `<# … #>` is not optional. With only the whole-line `#` filter,
+ * wrapping the last-resort net in a block comment disabled it while the suite
+ * stayed fully green — the exact "grep-shaped test asserting a string while
+ * claiming a semantic property" failure this file exists to avoid. Blank the
+ * span rather than deleting it so line-relative reading of `runCode` still
+ * lines up with the workflow.
  */
 const runCode = run
+  .replace(/<#[\s\S]*?#>/g, (m) => m.replace(/[^\n]/g, " "))
   .split("\n")
   .filter((line) => !/^\s*#/.test(line))
   .join("\n");
+
+/** Index of `needle` in `runCode`, throwing rather than returning -1. */
+function at(needle: string): number {
+  const i = runCode.indexOf(needle);
+  if (i < 0) throw new Error(`${WORKFLOW}: the driver step no longer contains \`${needle}\``);
+  return i;
+}
 
 /** Throws rather than returning `[]`: an empty table must fail, not pass quietly. */
 function pinnedRows(): [string, string][] {
@@ -125,13 +140,15 @@ describe("tauri-webdriver.yml — trigger surface", () => {
 });
 
 describe("tauri-webdriver.yml — Edge WebDriver candidate chain (#1197)", () => {
-  it("still tries the live sources before the hand-pinned net", () => {
-    // Order is load-bearing: an exact runtime match first, then Microsoft's
-    // pointer, then the walk-back, and only then the pin. A refactor that drops
-    // any of these leaves the remaining ones doing more work than they should.
-    expect(runCode).toContain("Add-Candidate $pv");
-    expect(runCode).toContain("Add-Candidate $latest");
-    expect(runCode).toContain("Add-Candidate $pinned[$major]");
+  it("still tries the live sources BEFORE the hand-pinned net", () => {
+    // Order is load-bearing, and asserting only PRESENCE does not capture it:
+    // `Add-Candidate` appends, and the first candidate whose zip downloads wins,
+    // so hoisting the pin above `$pv` makes a stale driver outrank the exact
+    // runtime match — the silent degradation this chain exists to prevent.
+    // Measured: with three order-blind `toContain` calls, that hoist left the
+    // suite 9/9 green.
+    expect(at("Add-Candidate $pv")).toBeLessThan(at("Add-Candidate $latest"));
+    expect(at("Add-Candidate $latest")).toBeLessThan(at("Add-Candidate $pinned[$major]"));
   });
 
   it("still warns when the runners reach a major with no pinned row", () => {
@@ -172,12 +189,32 @@ describe("tauri-webdriver.yml — the $pinned last-resort table", () => {
     expect(misKeyed).toEqual([]);
   });
 
+  it("records that a pinned row must differ from its LATEST_RELEASE pointer", () => {
+    // This invariant cannot be checked offline — it needs a live fetch of
+    // LATEST_RELEASE_<major> — so what is pinned here is that the RULE stays
+    // written down where the #1345 reviewer will meet it. (Same shape as
+    // tests/docs/loopback-gate-claims.test.ts: deleting the prose breaks a test
+    // rather than silently dropping the check.)
+    //
+    // Why it matters: Add-Candidate deduplicates, so a pin equal to the pointer
+    // is dropped, and in exactly the #1197 failure — the pointer naming a build
+    // whose zip is missing — the net contributes no candidate at all. Both new
+    // rows were byte-identical to their pointer when first written.
+    expect(run).toContain("must NOT equal today's LATEST_RELEASE_<major>");
+    expect(run).toMatch(/Verified 2026-\d\d-\d\d/);
+  });
+
   it("names its dated review home so the pin cannot outlive its gate", () => {
     // CLAUDE.md's dated-gate rule: a version pin needs a review path answerable
     // from tracked files. #1345 (2026-11-01) is that path and already lists this
     // table as evidence. Deleting the reference breaks this test rather than
     // silently dropping the link.
-    expect(run).toContain("#1345");
+    // Pin the SENTENCE, not the number. `#1345` occurs three times and `#1197`
+    // seven times in this step, so a bare `toContain("#1345")` survives rewriting
+    // the one line that names the review home — measured: rewriting it to
+    // "REVIEW HOME: nowhere" left the suite 9/9 green.
+    expect(run).toContain("REVIEW HOME: #1345");
+    expect(run).toMatch(/REVIEW HOME: #1345[\s\S]{0,80}2026-11-01/);
     expect(run).toContain("#1197");
   });
 });

--- a/tests/scripts/tauri-webdriver-pin.test.ts
+++ b/tests/scripts/tauri-webdriver-pin.test.ts
@@ -60,17 +60,27 @@ const workflow = parse(readFileSync(path.join(ROOT, WORKFLOW), "utf-8")) as {
 };
 
 /**
- * Located by the CDN host it downloads from — the step's whole reason to exist —
+ * Located by the driver archive it downloads — the step's whole reason to exist —
  * and NOT by any of the strings this file goes on to assert about, which would
  * make those assertions self-satisfying.
+ *
+ * The anchor is the ARCHIVE NAME rather than the CDN host it is fetched from,
+ * even though the host reads as the more natural landmark. A `.includes()` of a
+ * URL prefix is the shape of `js/incomplete-url-substring-sanitization`, and
+ * CodeQL flags it on sight — correctly in general, since `https://host/` can sit
+ * anywhere in a longer string. It is not a security decision here (this only
+ * picks a YAML step out of a file we control), but an alert that has to be
+ * explained away on every future read is worse than an anchor that raises none.
+ * `edgedriver_win64.zip` is just as unique — one occurrence in the whole
+ * workflow, inside this step — and just as load-bearing.
  */
 function driverStepRun(): string {
   const step = workflow.jobs.webdriver?.steps?.find(
-    (s) => typeof s.run === "string" && s.run.includes("https://msedgedriver.microsoft.com/"),
+    (s) => typeof s.run === "string" && s.run.includes("edgedriver_win64.zip"),
   );
   if (!step?.run) {
     throw new Error(
-      `${WORKFLOW}: the "webdriver" job has no step downloading from msedgedriver.microsoft.com`,
+      `${WORKFLOW}: the "webdriver" job has no step downloading edgedriver_win64.zip`,
     );
   }
   return step.run;

--- a/tests/scripts/tauri-webdriver-pin.test.ts
+++ b/tests/scripts/tauri-webdriver-pin.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const WORKFLOW = ".github/workflows/tauri-webdriver.yml";
+
+/**
+ * `.github/workflows/tauri-webdriver.yml` resolves an Edge WebDriver for the
+ * runner's WebView2 Runtime by walking an ordered in-major candidate list, whose
+ * last resort is a hand-pinned `$pinned` table (#1197, PR #1261). Until this file
+ * existed, NOTHING in the repo read that workflow — `grep -rn tauri-webdriver`
+ * found only prose — so the table could be edited, mis-keyed or deleted with
+ * every check green.
+ *
+ * That matters more here than for a workflow CI runs, because this job is
+ * `workflow_dispatch`-only (disabled 2026-08-08, #1345). Its own `::warning::`
+ * annotations only render on a run, and nobody has run it since. Those
+ * annotations therefore cannot be the guard; a vitest file, which runs on every
+ * PR, is the only thing that can see this table at all.
+ *
+ * Two silent failure shapes are pinned below. A **missing** row leaves
+ * `$pinned[$major]` as `$null`, and `Add-Candidate` returns at its `if (-not $v)`
+ * guard, so the net vanishes without an error. A **mis-keyed** row
+ * (`'152' = '151.0...'`) is worse: `Add-Candidate`'s in-major filter drops it just
+ * as silently, and unlike a missing row it does NOT trip the workflow's
+ * `ContainsKey` warning, because the key is present.
+ *
+ * What is deliberately NOT asserted: that the table covers the WebView2 majors
+ * Microsoft currently ships. No offline test can know that, and checking it
+ * against a hand-maintained constant elsewhere in this repo would be circular.
+ * That criterion is dated and human-reviewed, in #1345 (2026-11-01), which
+ * already names this table among the evidence it weighs.
+ *
+ * Following `tests/scripts/acceptance-harness-wiring.test.ts`: PARSE the YAML
+ * rather than substring-matching the file (a commented-out step then simply does
+ * not exist), locate the step by its `run` content rather than its prose `name`
+ * (a rename must not be able to blind the guard), and make every extractor THROW
+ * rather than return a sentinel — an assertion built on `-1` or `null` passes
+ * vacuously the moment the thing it guards is deleted.
+ *
+ * One more, learned the hard way while mutation-testing this file: assertions
+ * about the SCRIPT run against `runCode`, which has PowerShell comment lines
+ * stripped. An early draft matched the raw `run`, and prefixing
+ * `Add-Candidate $pinned[$major]` with a single `#` — disabling the last-resort
+ * net outright — left all nine assertions green, because the string was still
+ * there inside the comment. That is the same reversion
+ * `acceptance-harness-wiring.test.ts` records surviving its own first draft.
+ * Only the two issue-number assertions read the full `run`, because the
+ * references they guard deliberately live in comments.
+ */
+
+type Step = { name?: string; run?: string; uses?: string };
+
+const workflow = parse(readFileSync(path.join(ROOT, WORKFLOW), "utf-8")) as {
+  on: Record<string, unknown>;
+  jobs: Record<string, { steps: Step[] }>;
+};
+
+/**
+ * Located by the CDN host it downloads from — the step's whole reason to exist —
+ * and NOT by any of the strings this file goes on to assert about, which would
+ * make those assertions self-satisfying.
+ */
+function driverStepRun(): string {
+  const step = workflow.jobs.webdriver?.steps?.find(
+    (s) => typeof s.run === "string" && s.run.includes("https://msedgedriver.microsoft.com/"),
+  );
+  if (!step?.run) {
+    throw new Error(
+      `${WORKFLOW}: the "webdriver" job has no step downloading from msedgedriver.microsoft.com`,
+    );
+  }
+  return step.run;
+}
+
+const run = driverStepRun();
+
+/**
+ * `run` with whole-line PowerShell comments removed. Everything that asserts the
+ * script still DOES something must use this — see the header note; a `#` prefix
+ * disables a line while leaving its text intact for `toContain`.
+ */
+const runCode = run
+  .split("\n")
+  .filter((line) => !/^\s*#/.test(line))
+  .join("\n");
+
+/** Throws rather than returning `[]`: an empty table must fail, not pass quietly. */
+function pinnedRows(): [string, string][] {
+  const block = runCode.match(/\$pinned = @\{([\s\S]*?)\n\s*\}/);
+  if (!block?.[1]) {
+    throw new Error(`${WORKFLOW}: cannot find a '$pinned = @{ ... }' hashtable in the driver step`);
+  }
+  const rows = [...block[1].matchAll(/'([^']+)'\s*=\s*'([^']+)'/g)].map(
+    (m) => [m[1], m[2]] as [string, string],
+  );
+  if (rows.length === 0) {
+    throw new Error(
+      `${WORKFLOW}: '$pinned' parsed to zero rows — the last-resort driver net is empty`,
+    );
+  }
+  return rows;
+}
+
+describe("tauri-webdriver.yml — trigger surface", () => {
+  it("is workflow_dispatch-only (#1345 owns the decision to re-enable)", () => {
+    // Every claim below, plus docs/release-smoke-checklist.md's "not applicable:
+    // disabled 2026-08-08" row and .claude/skills/release/SKILL.md, rests on this
+    // job not running on a tag. Re-adding a trigger has to update those too.
+    expect(Object.keys(workflow.on)).toEqual(["workflow_dispatch"]);
+  });
+});
+
+describe("tauri-webdriver.yml — Edge WebDriver candidate chain (#1197)", () => {
+  it("still tries the live sources before the hand-pinned net", () => {
+    // Order is load-bearing: an exact runtime match first, then Microsoft's
+    // pointer, then the walk-back, and only then the pin. A refactor that drops
+    // any of these leaves the remaining ones doing more work than they should.
+    expect(runCode).toContain("Add-Candidate $pv");
+    expect(runCode).toContain("Add-Candidate $latest");
+    expect(runCode).toContain("Add-Candidate $pinned[$major]");
+  });
+
+  it("still warns when the runners reach a major with no pinned row", () => {
+    expect(runCode).toContain("$pinned.ContainsKey($major)");
+    expect(runCode).toContain("::warning::No hand-pinned Edge WebDriver");
+  });
+
+  it("still warns when ONLY the hand-pinned net resolved", () => {
+    // The other half of #1197's "fail loudly": if the pin wins, every live
+    // candidate missed — the CDN failure that opened #1197, recurring — and
+    // without this the run is an ordinary green.
+    expect(runCode).toContain("::warning::Only the hand-pinned Edge WebDriver");
+    expect(runCode).toContain("$driverVersion -eq $pinned[$major]");
+  });
+});
+
+describe("tauri-webdriver.yml — the $pinned last-resort table", () => {
+  const rows = pinnedRows();
+
+  it("has at least one row", () => {
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it("keys are bare WebView2 majors", () => {
+    expect(rows.filter(([major]) => !/^\d+$/.test(major))).toEqual([]);
+  });
+
+  it("values are four-part driver versions", () => {
+    expect(rows.filter(([, version]) => !/^\d+\.\d+\.\d+\.\d+$/.test(version))).toEqual([]);
+  });
+
+  it("every row's version is IN the major it is keyed under", () => {
+    // The silent one. `Add-Candidate` drops any candidate outside `$major`, so a
+    // mis-keyed row is discarded with no error — and the ContainsKey warning
+    // above does not fire either, because the key exists. The row looks present
+    // and maintained while providing no net whatsoever.
+    const misKeyed = rows.filter(([major, version]) => version.split(".")[0] !== major);
+    expect(misKeyed).toEqual([]);
+  });
+
+  it("names its dated review home so the pin cannot outlive its gate", () => {
+    // CLAUDE.md's dated-gate rule: a version pin needs a review path answerable
+    // from tracked files. #1345 (2026-11-01) is that path and already lists this
+    // table as evidence. Deleting the reference breaks this test rather than
+    // silently dropping the link.
+    expect(run).toContain("#1345");
+    expect(run).toContain("#1197");
+  });
+});


### PR DESCRIPTION
Refs #1197. Deliberately **not** `Closes` — see "What is left" below.

## What #1197 filed, and what is actually left

#1197's cause (a) — Microsoft's `LATEST_RELEASE_` pointer naming a build whose zip was never published (`BlobNotFound`) — was **already fixed** by PR #1261's in-major candidate chain. What that fix left behind is a hand-pinned `$pinned` last-resort table with no tracked review path, and it has since gone stale.

Cause (b), `DevToolsActivePort file doesn't exist`, is untouched here, and its verdict belongs to #1345 — whose "retire it" outcome explicitly instructs the 2026-11-01 reviewer to close #1197. Auto-closing #1197 in August would destroy that tracked home and leave the workflow's remaining failure with no issue, so this PR only references it.

**Measured 2026-08-20:** the table had rows for **149 and 150 only**. A run today resolves `$pinned['151']` to `$null`, `Add-Candidate` returns at its `if (-not $v)` guard, and the last-resort net is simply *absent*. The workflow does emit a `::warning::` for a missing row, but this job is `workflow_dispatch`-only and has not been dispatched since 2026-08-08, so that annotation reaches nobody.

The runners are on major 151: `LATEST_STABLE` is 151.0.4129.93. (The image also carries Edge browser 151.0.4129.72, but that is the *browser* build — the step's own header warns it is not the WebView2 Runtime version, so it is corroboration, not proof.)

Also measured, and it contradicted the old comment: **the CDN does not drop old blobs.** 149.0.4022.98 still serves HTTP 200 today, 13 months on. The rot is new-major coverage, not blob expiry.

## Changes

- **Add rows for 151 and 152, pinned BELOW their pointer.** This is the correction that matters most. The first cut pinned 151.0.4129.93 and 152.0.4191.35 — byte-identical to today's `LATEST_RELEASE_<major>`. `Add-Candidate` deduplicates, so a pin equal to the pointer is dropped at its `if (-not $candidates.Contains($v))` guard: in exactly the #1197 failure (the pointer names a build whose zip is missing) the net contributes no candidate at all, and the new warning below can never fire either, because its `$driverVersion -ne $latest` clause is false. The rows are now 151.0.4129.50 and 152.0.4191.10 — both below their pointer and below the 16-patch walk-back window under it, so each is always a candidate the live sources cannot supply. Both fetched: HTTP 200, `msedgedriver.exe` present (41,848,192 B and 23,035,776 B).
- **Deliberately no row for 153**: its pointer is 153.0.4229.0, a `.0` canary whose zip 404s and which no runner ships. A speculative row is worse than none, because it suppresses the missing-row warning.
- **Warn when ONLY the pinned row resolved.** The other half of #1197's "fail loudly". If the pin wins, the exact runtime version, the pointer and every walk-back build missed — #1197's original CDN failure recurring — and the run was otherwise an ordinary green. The candidate count is interpolated from `$candidates.Count`, not hard-coded: the list is 34 builds only when both live sources resolve, and 18 when the pointer fetch throws.
- **Rewrite the table's comment** with the measured failure account, state the pin-must-differ-from-pointer rule next to the table, and name **#1345 (2026-11-01)** as its dated review home. #1345 already lists this table among the evidence it weighs.
- **Add `tests/scripts/tauri-webdriver-pin.test.ts`.** Nothing in the repo read this workflow before — `git grep -l tauri-webdriver` on master found only prose — so the table could be deleted or mis-keyed with every check green.

## Why the test is shaped the way it is

The **mis-keyed row** (`'152' = '151.0...'`) is the silent failure shape: `Add-Candidate`'s in-major filter drops it with no error and, unlike a missing row, it does **not** trip the `ContainsKey` warning either, because the key is present. The row looks maintained while providing no net at all.

The test parses the YAML rather than substring-matching (a commented-out step then simply does not exist), locates the step by its `run` content rather than its prose name (a rename must not blind the guard), and throws rather than returning a sentinel. Assertions about the script run against a **comment-stripped** view — both `#` line comments and `<# ... #>` block spans.

Three assertions were rewritten after review found each passing against a mutation that broke what it claimed:

- The order test used three order-blind `toContain` calls under a comment reading "order is load-bearing". Hoisting the pin above `Add-Candidate $pv` — making a stale driver outrank the exact runtime match — left it 9/9 green. It now asserts positions via an `at()` helper that throws on a missing needle.
- `runCode` stripped only whole-line `#` comments, so wrapping the net in `<# ... #>` disabled it with the suite fully green.
- The dated-gate check was a bare `toContain("#1345")`, satisfied by any of three incidental occurrences. Rewriting the one line that names the review home to "REVIEW HOME: nowhere" left it green. It now pins the sentence and its date.

Deliberately **not** asserted: that the table covers the majors Microsoft currently ships, or that each row still differs from its live pointer. No offline test can know either — both need a network fetch. Those criteria are dated and human-reviewed, in #1345; the rule is written next to the table so the reviewer meets it, and a test pins that prose.

## Verification

- `tests/scripts/tauri-webdriver-pin.test.ts` — 10/10 pass.
- Every rule above is mutation-verified. The four mutations that review found passing green are now each red: hoisting the pin above `$pv`; block-commenting the net; rewriting the review-home line; dropping the pin-vs-pointer rule. Two that must stay green were re-checked: renaming the step keeps it passing; commenting the whole step out fails with "no tests" and exit 1 rather than passing vacuously.
- All four pinned blobs verified live today: 149.0.4022.98, 150.0.4078.83, 151.0.4129.50, 152.0.4191.10 — each HTTP 200 with `msedgedriver.exe` in the zip. Pointers re-read: `LATEST_RELEASE_151` = 151.0.4129.93, `LATEST_RELEASE_152` = 152.0.4191.35, confirming both rows sit below their pointer.
- Full pre-push gate (biome + vitest + `cargo test`) green.

## Not covered

The workflow itself cannot be run from this session — it is dispatch-only and Windows-only. Cause (b) of #1197 is untouched, by design.