### PR TITLE
fix(cowork): split pre-flight `unknown` into `unavailable` vs `failed` (#1436)

### DIFF
--- a/docs/design-system-impl/testid-manifest.md
+++ b/docs/design-system-impl/testid-manifest.md
@@ -279,12 +279,24 @@ shipped and were removed:
   `cowork-preflight-{blocked,retry-btn}`. The retry button **replaces** the
   enable-confirm button while detection is known-failing, so a spec asserting
   `*-enable-confirm-btn` visible must first establish the probe did not block.
+- Broken-probe line (#1436): `cowork-preflight-failed`,
+  `cowork-onboarding-preflight-failed` and
+  `integration-wizard-cowork-preflight-failed`. Distinct from `-blocked`
+  because the two say opposite things: `-blocked` reports a detection failure
+  we watched happen and so **replaces** Enable with a retry, while `-failed`
+  reports that the check never ran and therefore leaves Enable exactly where it
+  was — a spec asserting `*-preflight-failed` must find no `*-retry-btn`. The
+  no-probe case renders neither — but note every surface that probes is already
+  gated on `isTauriRuntime()` and `osSupported`, so in the shipped app that case
+  is effectively unreachable and `-failed` is the arm a real session lands on.
+  Absence of all three is still not evidence the probe passed.
 - Pre-flight live regions (#1376): `cowork-preflight-live`,
   `cowork-onboarding-preflight-live` and `integration-wizard-cowork-preflight-live`.
   The `role="status"` wrapper, mounted for the life of the confirm (the wizard's
   for the life of the sub-view) so a hint arriving later is announced rather than
   inserted silently with its region. The `-blocked` testids sit INSIDE it, which
-  is why they still come and go; the wrapper never does. The wizard's carries
+  is why they still come and go; the wrapper never does — `-failed` sits there
+  for the same reason. The wizard's carries
   `display: contents` — its parent is a gapped flex column, so an empty box
   there would be a permanent gap; the other two parents are plain blocks.
   Thirteen more live regions app-wide still have the pre-#1376 shape (#1431).

--- a/src/client/components/CoworkOnboardingStep.svelte
+++ b/src/client/components/CoworkOnboardingStep.svelte
@@ -2,6 +2,7 @@
 import { TANDEM_REPO_URL } from "../../shared/constants";
 import {
   COWORK_PREFLIGHT_CHECKING,
+  COWORK_PREFLIGHT_FAILED,
   formatCoworkError,
   writeCoworkOnboardingSkipped,
 } from "../cowork/cowork-helpers";
@@ -115,6 +116,12 @@ function handleSkip(): void {
                whose failure we have already observed. -->
           <div class="cos-preflight" data-testid="cowork-onboarding-preflight-blocked">
             {probe.preflight.hint}
+          </div>
+        {:else if probe.preflight?.status === "failed"}
+          <!-- #1436: see the note in CoworkSettings. Hedged, and no retry —
+               nothing was observed to fail, so Enable stays. -->
+          <div class="cos-checking" data-testid="cowork-onboarding-preflight-failed">
+            {COWORK_PREFLIGHT_FAILED}
           </div>
         {/if}
         {#if probe.probing}

--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -8,6 +8,7 @@ import {
 import {
   aggregateWorkspaceStatus,
   COWORK_PREFLIGHT_CHECKING,
+  COWORK_PREFLIGHT_FAILED,
   coworkReachability,
   coworkReachabilityCopy,
   coworkSettingsVariant,
@@ -339,6 +340,14 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
                  than an Enable button whose outcome we know. -->
             <div class="cs-preflight" data-testid="cowork-preflight-blocked">
               {probe.preflight.hint}
+            </div>
+          {:else if probe.preflight?.status === "failed"}
+            <!-- #1436: `ok` renders nothing, so a broken probe that also
+                 rendered nothing was pixel-identical to a pass. Hedged, and
+                 NOT a retry: we did not observe detection fail, so we have no
+                 grounds to replace Enable. -->
+            <div class="cs-help-text" data-testid="cowork-preflight-failed">
+              {COWORK_PREFLIGHT_FAILED}
             </div>
           {/if}
           {#if probe.probing}

--- a/src/client/components/IntegrationWizardModal.svelte
+++ b/src/client/components/IntegrationWizardModal.svelte
@@ -30,6 +30,7 @@ import { BYO_MODELS_ENABLED, CLAUDE_PLUGIN_INSTALL_COMMANDS } from "../../shared
 import type { ApplyItemResult, ExistingMcpInstall } from "../../shared/integrations/contract.js";
 import {
   COWORK_PREFLIGHT_CHECKING,
+  COWORK_PREFLIGHT_FAILED,
   coworkSettingsVariant,
   formatCoworkError,
   isTauriRuntime,
@@ -333,9 +334,10 @@ $effect(() => {
  *
  *  Unlike the other two Enable surfaces this one has no confirm step — the
  *  button in the footer fires the real enable directly — so the probe hangs off
- *  view entry instead. Same three-state contract: only a structured firewall
- *  error swaps the button for a retry; a probe that could not run leaves the
- *  button alone rather than blocking an enable that would have worked. */
+ *  view entry instead. Same contract as the other two: only a structured
+ *  firewall error swaps the button for a retry; a probe that could not run
+ *  leaves the button alone rather than blocking an enable that would have
+ *  worked — it only says so, and only when the failure was ours (#1436). */
 function openCoworkView(): void {
   coworkError = null;
   coworkBusy = false;
@@ -876,6 +878,16 @@ function pushSupportNoteFor(id: string): PushSupportNote | null {
                   {@render warningIcon()}
                   <span>{coworkProbe.preflight.hint}</span>
                 </div>
+              {:else if coworkProbe.preflight?.status === "failed"}
+                <!-- #1436: see the note in CoworkSettings. `iw-hint-text`
+                     rather than `iw-banner-warning` on purpose — the claim is
+                     "we don't know", not "this will fail". -->
+                <p
+                  class="iw-hint-text"
+                  data-testid="integration-wizard-cowork-preflight-failed"
+                >
+                  {COWORK_PREFLIGHT_FAILED}
+                </p>
               {/if}
               {#if coworkProbe.probing}
                 <p class="iw-hint-text">{COWORK_PREFLIGHT_CHECKING}</p>

--- a/src/client/cowork/cowork-helpers.ts
+++ b/src/client/cowork/cowork-helpers.ts
@@ -29,6 +29,29 @@ import type {
 export const COWORK_PREFLIGHT_CHECKING = "Checking your network…";
 
 /**
+ * What the live region says when the pre-flight ran and BROKE (#1436).
+ *
+ * The `ok` case renders nothing, which is only readable if the failure case
+ * renders something: before this existed, a probe that threw emptied the region
+ * and left behind exactly the picture a passing probe leaves behind. The
+ * reasonable reading was "the check passed". For a screen-reader user it was
+ * worse — `role="status"` announces text that is added or changed, and says
+ * nothing at all when a region is EMPTIED, so the sequence was "Checking your
+ * network…" followed by permanent silence.
+ *
+ * Hedged on purpose, and the hedge is the accurate claim: a probe that could
+ * not classify its own failure has said nothing about whether the firewall
+ * write would succeed. This is not `blocked` — it must not swap Enable for
+ * "Check again", because that button exists for the case where we watched
+ * detection fail and know the outcome.
+ *
+ * Distinct from the `unavailable` case, which renders nothing and should: no
+ * Tauri bridge and non-Windows are the ordinary way this probe does not run,
+ * and a hedged warning there would fire on the routine path.
+ */
+export const COWORK_PREFLIGHT_FAILED = "Couldn't check your network — enabling may still work.";
+
+/**
  * High-level branch the Settings UI renders. Collapses the `osSupported` /
  * `coworkDetected` / `uacDeclined` / normal states into a single label.
  */

--- a/src/client/cowork/cowork-invoke.ts
+++ b/src/client/cowork/cowork-invoke.ts
@@ -25,9 +25,13 @@ export type InvokeFn = <T = unknown>(cmd: string, args?: Record<string, unknown>
 export const TAURI_NOT_AVAILABLE = "Tauri runtime not available";
 
 /**
- * Mirrors `WINDOWS_ONLY_ERR` in `src-tauri/src/lib.rs`. Used only to keep an
- * expected rejection out of `console.error` — a drift here costs a noisy log
- * line, never behaviour, so it is deliberately not pinned by a test.
+ * Mirrors `WINDOWS_ONLY_ERR` in `src-tauri/src/lib.rs`.
+ *
+ * Since #1436 this string SELECTS BEHAVIOUR, not just a log level: it is what
+ * routes the non-Windows rejection to `unavailable` (silent) rather than
+ * `failed` (a visible hedged line). A drift here used to cost a noisy log line;
+ * it now paints a warning on a routine path, so the substring match and its
+ * fixtures are load-bearing.
  */
 export const COWORK_WINDOWS_ONLY = "Cowork integration is Windows-only";
 
@@ -82,14 +86,16 @@ export function coworkDetectVethernetSubnet(invoke: InvokeFn): Promise<string> {
 }
 
 /**
- * Outcome of the enable pre-flight. Three states, not two, because "the probe
- * failed" and "enabling would fail" are different claims:
+ * Outcome of the enable pre-flight. Four states, because "the probe failed"
+ * and "enabling would fail" are different claims, and so are the two reasons a
+ * probe does not answer:
  *
  * - `ok` — a subnet was detected; the enable path's own detection should agree.
  * - `blocked` — the probe returned a structured `FirewallError`, so we can say
  *   what is wrong and offer a retry instead of a button that cannot work.
- * - `unknown` — the probe itself couldn't run. Never block on this; a broken
- *   probe must not stop a user whose enable would have succeeded.
+ * - `unavailable` / `failed` — the probe itself couldn't run. Never block on
+ *   either; a broken probe must not stop a user whose enable would have
+ *   succeeded. Their per-variant notes below carry the rest.
  *
  * The same reasoning applies while a probe is still in flight: callers must
  * leave Enable **clickable** during the probe, not merely re-enable it
@@ -102,7 +108,30 @@ export function coworkDetectVethernetSubnet(invoke: InvokeFn): Promise<string> {
 export type SubnetPreflight =
   | { status: "ok"; cidr: string }
   | { status: "blocked"; hint: string }
-  | { status: "unknown" };
+  /**
+   * The probe cannot run in this environment — not Windows, or no Tauri bridge
+   * in a session that never claimed to have one. Renders nothing, which is
+   * correct: nothing has gone wrong, and a warning would be permanent noise.
+   *
+   * Every surface that probes today is already gated on `isTauriRuntime()` and
+   * on `osSupported`, so in the shipped app this is effectively unreachable —
+   * it is the answer for a caller that probes WITHOUT those gates (the Svelte
+   * harness does) and the reason the `failed` arm can be as loud as it is.
+   * Do not "simplify" it away by folding it into `failed`: the moment a surface
+   * probes ungated, that fold paints a warning on every browser session.
+   */
+  | { status: "unavailable" }
+  /**
+   * The probe ran and broke: an unregistered command, a serde shape drift, a
+   * throw from the bridge. Renders a hedged line (#1436) — the `ok` case is
+   * silent, and silence is only readable if the failure case is not.
+   *
+   * These were one `unknown` value until #1436, which made a genuine fault
+   * pixel-identical to a pass. Splitting them is the whole fix: the two halves
+   * were already distinguished HERE (one logs at `error`, the other at
+   * `debug`), and that distinction simply never reached the wire.
+   */
+  | { status: "failed" };
 
 export async function coworkPreflightSubnet(invoke: InvokeFn): Promise<SubnetPreflight> {
   try {
@@ -111,20 +140,29 @@ export async function coworkPreflightSubnet(invoke: InvokeFn): Promise<SubnetPre
     const rawMsg = err instanceof Error ? err.message : String(err);
     const variant = parseFirewallErrorVariant(rawMsg);
     if (!variant) {
-      // `unknown` is deliberately never rendered, so an unparseable failure is
-      // invisible to the user by design — but it is also how an unregistered
-      // command or a serde downgrade on the Rust side would present, and those
-      // are bugs. Log everything except the two expected cases so a real fault
-      // is diagnosable from a pasted console rather than indistinguishable
-      // from "we couldn't tell".
+      // #1436: the two arms below already existed — one logs at `error`, the
+      // other at `debug` — and the fact that both then returned one `unknown`
+      // is what made a real fault indistinguishable from an environment the
+      // probe was never going to run in.
       //
-      // Safe to log verbatim, but NOT for the reason this comment used to
-      // give. Since #1372 this command's `subnetDetectionFailed` does carry a
-      // `stderrTail`, so "payload-free on the wire" is no longer true. What
-      // makes it safe is the branch: nothing reaches here unless
+      // `TAURI_NOT_AVAILABLE` alone is NOT enough to call it an environment,
+      // and reading it that way was the first cut's bug. `loadInvoke` emits
+      // that string from its own catch when `import("@tauri-apps/api/core")`
+      // fails — so OUTSIDE Tauri it is the ordinary no-bridge case, but INSIDE
+      // Tauri it means a chunk that should exist did not load (a partial
+      // update, a CSP block), which is a fault and the single most likely way
+      // a shipped desktop build reaches this function at all. Every surface
+      // that probes is already gated on `isTauriRuntime()`, so treating it as
+      // an environment sent the one reachable fault straight back to the
+      // silence #1436 is about.
+      //
+      // Logging `rawMsg` verbatim is safe, but NOT for the reason this comment
+      // used to give. Since #1372 this command's `subnetDetectionFailed` does
+      // carry a `stderrTail`, so "payload-free on the wire" is no longer true.
+      // What makes it safe is the BRANCH: nothing reaches here unless
       // `parseFirewallErrorVariant` already returned null, i.e. `rawMsg` did
       // not parse as JSON with a string `kind`. Keep that ordering if this is
-      // ever restructured.
+      // ever restructured, and do not widen the logging to the parsed variants.
       //
       // One caveat, so nobody reads that as stronger than it is. `lib.rs` sends
       // `serde_json::to_string(&e).unwrap_or_else(|_| e.to_string())`, and the
@@ -136,12 +174,15 @@ export async function coworkPreflightSubnet(invoke: InvokeFn): Promise<SubnetPre
       // The Rust side still keeps the raw `io::Error` from a failed spawn off
       // the wire entirely (it names the resolved executable path); the wire
       // carries only the closed `AdapterEnumerationReason`. Do not widen that.
-      if (rawMsg === TAURI_NOT_AVAILABLE || rawMsg.includes(COWORK_WINDOWS_ONLY)) {
+      if (
+        rawMsg.includes(COWORK_WINDOWS_ONLY) ||
+        (rawMsg === TAURI_NOT_AVAILABLE && !isTauriRuntime())
+      ) {
         console.debug("[cowork] subnet pre-flight unavailable:", rawMsg);
-      } else {
-        console.error("[cowork] subnet pre-flight could not be classified:", rawMsg);
+        return { status: "unavailable" };
       }
-      return { status: "unknown" };
+      console.error("[cowork] subnet pre-flight could not be classified:", rawMsg);
+      return { status: "failed" };
     }
     return { status: "blocked", hint: firewallErrorHint(variant) };
   }

--- a/src/client/hooks/useCoworkPreflight.svelte.ts
+++ b/src/client/hooks/useCoworkPreflight.svelte.ts
@@ -115,18 +115,22 @@ export function createSubnetPreflight(): SubnetPreflightState {
       preflight = result;
     } catch (err) {
       if (mine !== token) return;
-      // Reaching here means the bridge didn't load, `coworkPreflightSubnet`
-      // threw rather than resolving, or an unrelated `$effect` threw through
-      // the `tick()` flush above — several distinct causes that all say
-      // nothing about whether enabling would work, so fall through to the
-      // unguarded button. Log it: `unknown` is never rendered, so without this
-      // a genuine client fault is invisible on both sides of the bridge.
-      // Via `logClientError`, so it also reaches a bug report — the release
-      // desktop build has no devtools console to read (#1439). Note Tauri
-      // `invoke` rejects with the Rust error's `Display` STRING, not an `Error`,
-      // which is why `describeCause` keeps a string branch at all.
+      // `failed`, not `unavailable` (#1436). `loadInvoke()` does not throw —
+      // outside Tauri it resolves to an invoke that REJECTS with
+      // `TAURI_NOT_AVAILABLE`, which `coworkPreflightSubnet` catches and
+      // classifies as `unavailable`. So the ordinary no-bridge path never
+      // reaches this arm, and what does reach it is a genuine client fault:
+      // `coworkPreflightSubnet` threw rather than resolving, or an unrelated
+      // `$effect` threw through the `tick()` flush above. Those say nothing
+      // about whether enabling would work, so the button stays unguarded and
+      // the region says so rather than emptying.
+      //
+      // Still logged, via `logClientError` so it also reaches a bug report —
+      // the release desktop build has no devtools console to read (#1439).
+      // Note Tauri `invoke` rejects with the Rust error's `Display` STRING, not
+      // an `Error`, which is why `describeCause` keeps a string branch at all.
       logClientError("cowork", "subnet pre-flight threw", err);
-      preflight = { status: "unknown" };
+      preflight = { status: "failed" };
     } finally {
       if (mine === token) probing = false;
     }

--- a/tests/client/cowork-onboarding-step-mounted.test.ts
+++ b/tests/client/cowork-onboarding-step-mounted.test.ts
@@ -18,14 +18,17 @@
 import { cleanup, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { COWORK_PREFLIGHT_CHECKING } from "../../src/client/cowork/cowork-helpers";
+import {
+  COWORK_PREFLIGHT_CHECKING,
+  COWORK_PREFLIGHT_FAILED,
+} from "../../src/client/cowork/cowork-helpers";
 import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
 import { coworkStatusFixture } from "../helpers/cowork-status-fixture";
 
 const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
 const fakeInvoke = vi.fn();
 
-const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unknown" }));
+const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unavailable" }));
 
 // Spread `importOriginal` rather than re-declaring the module: `cowork-invoke`
 // exports nine symbols and each suite's mock used to name a different subset,
@@ -84,7 +87,7 @@ beforeEach(() => {
   toggleIntegration.mockImplementation(async () => ({ ok: true as const }));
   fakeInvoke.mockClear();
   preflightSubnet.mockClear();
-  preflightSubnet.mockResolvedValue({ status: "unknown" });
+  preflightSubnet.mockResolvedValue({ status: "unavailable" });
 });
 
 afterEach(() => {
@@ -259,6 +262,58 @@ describe("CoworkOnboardingStep — pre-flight live region (#1376)", () => {
       );
     });
     expect(q(container, "cowork-onboarding-preflight-live")).toBe(before);
+  });
+
+  it("says so in the live region when the probe itself breaks (#1436)", async () => {
+    // Onboarding is the surface where silence costs most: a first-run user has
+    // no prior expectation to compare against, so a probe that rendered
+    // nothing read as "checked, all clear". The line has to reach the region
+    // that is already in the a11y tree, not a new one mounted with it.
+    preflightSubnet.mockResolvedValue({ status: "failed" });
+    const { container } = mount();
+    await openConfirm(container);
+    const before = q(container, "cowork-onboarding-preflight-live");
+    expect(before).toBeTruthy();
+
+    await waitFor(() => {
+      expect(q(container, "cowork-onboarding-preflight-failed")?.textContent ?? "").toContain(
+        COWORK_PREFLIGHT_FAILED,
+      );
+    });
+    expect(q(container, "cowork-onboarding-preflight-live")).toBe(before);
+    // CONTAINMENT, not merely presence. Lifting the branch out to a sibling
+    // `{#if}` next to the region leaves node identity and the `-failed` testid
+    // intact while reproducing the original silence exactly, so a test that
+    // stops at the two assertions above pins nothing.
+    expect(q(container, "cowork-onboarding-preflight-live")?.textContent ?? "").toContain(
+      COWORK_PREFLIGHT_FAILED,
+    );
+    // Not a retry: nothing was observed to fail, so Enable stays.
+    expect(q(container, "cowork-onboarding-preflight-retry-btn")).toBeNull();
+    // Muted help text, never the warning-token banner the `blocked` hint uses —
+    // the claim is "we don't know", not "this will fail".
+    expect(q(container, "cowork-onboarding-preflight-failed")?.className ?? "").not.toContain(
+      "cos-preflight",
+    );
+  });
+
+  it("stays silent when the probe was never available", async () => {
+    // The other half of the split, and why it is a split rather than one loud
+    // state: `unavailable` is a probe that was never going to answer, so a
+    // hedged line there would be permanent noise rather than news.
+    preflightSubnet.mockResolvedValue({ status: "unavailable" });
+    const { container } = mount();
+    await openConfirm(container);
+    await probeCount(1);
+    await waitFor(() => {
+      expect(q(container, "cowork-onboarding-preflight-live")?.textContent ?? "").not.toContain(
+        COWORK_PREFLIGHT_CHECKING,
+      );
+    });
+
+    expect(q(container, "cowork-onboarding-preflight-failed")).toBeNull();
+    expect(q(container, "cowork-onboarding-preflight-blocked")).toBeNull();
+    expect(q(container, "cowork-onboarding-preflight-live")?.textContent?.trim()).toBe("");
   });
 
   it("keeps the hint mounted while re-checking it", async () => {

--- a/tests/client/cowork-preflight-hook.test.ts
+++ b/tests/client/cowork-preflight-hook.test.ts
@@ -184,21 +184,27 @@ describe("createSubnetPreflight", () => {
     expect(probe.preflight).toEqual(OK);
   });
 
-  it("reports unknown rather than throwing when the probe rejects", async () => {
+  it("reports failed rather than throwing when the probe rejects", async () => {
+    // `failed`, not `unavailable` (#1436). `loadInvoke()` does not throw —
+    // outside Tauri it resolves to an invoke that REJECTS, which
+    // `coworkPreflightSubnet` catches and classifies as `unavailable`. So the
+    // ordinary no-bridge path never reaches this arm; what does reach it is a
+    // genuine client fault, and the user has to be told the check did not run.
     preflightSubnet.mockRejectedValueOnce(new Error("bridge gone"));
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     const probe = createSubnetPreflight();
     await probe.run();
 
-    expect(probe.preflight).toEqual({ status: "unknown" });
+    expect(probe.preflight).toEqual({ status: "failed" });
     expect(probe.probing).toBe(false);
   });
 
   it("records the failure where a bug report can reach it (#1439)", async () => {
-    // `unknown` is never rendered, and the release desktop build ships no
-    // devtools, so before #1439 the cause of a pre-flight failure was
-    // unrecoverable from a user's bug report.
+    // The rendered `failed` line is deliberately vague — it tells the user the
+    // check did not run, not why. The release desktop build ships no devtools,
+    // so without this log the cause of a pre-flight failure would still be
+    // unrecoverable from a user's bug report (#1439).
     _resetClientLog();
     preflightSubnet.mockRejectedValueOnce(new Error("bridge gone"));
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/tests/client/cowork-settings-mounted.test.ts
+++ b/tests/client/cowork-settings-mounted.test.ts
@@ -20,14 +20,17 @@
 import { cleanup, render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { COWORK_PREFLIGHT_CHECKING } from "../../src/client/cowork/cowork-helpers";
+import {
+  COWORK_PREFLIGHT_CHECKING,
+  COWORK_PREFLIGHT_FAILED,
+} from "../../src/client/cowork/cowork-helpers";
 import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
 import { coworkErrorCell, coworkStatusCell } from "../helpers/cowork-fixtures.svelte";
 
 const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
 const fakeInvoke = vi.fn();
 
-const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unknown" }));
+const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unavailable" }));
 const setLanIpOverride = vi.fn(async () => {});
 
 // Spread `importOriginal` rather than re-declaring the module: `cowork-invoke`
@@ -149,7 +152,7 @@ beforeEach(() => {
   setLanIpOverride.mockClear();
   setLanIpOverride.mockImplementation(async () => {});
   preflightSubnet.mockClear();
-  preflightSubnet.mockResolvedValue({ status: "unknown" });
+  preflightSubnet.mockResolvedValue({ status: "unavailable" });
 });
 
 afterEach(() => {
@@ -511,6 +514,73 @@ describe("CoworkSettings — pre-flight live region (#1376)", () => {
       expect(q(container, "cowork-preflight-live")?.textContent ?? "").toContain("no adapter");
     });
     expect(q(container, "cowork-preflight-live")).toBe(before);
+  });
+
+  it("lands the broken-probe line in the region that is already mounted (#1436)", async () => {
+    // The bug this issue names: `role="status"` announces added and changed
+    // text, but EMPTYING a region announces nothing. Before the split, a probe
+    // that could not run rendered nothing, so the sequence a screen reader got
+    // was the in-flight line followed by permanent silence. Captured before
+    // the line arrives, so this fails if the copy is ever moved into a wrapper
+    // that mounts with it.
+    preflightSubnet.mockResolvedValue({ status: "failed" });
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    const before = q(container, "cowork-preflight-live");
+    expect(before).toBeTruthy();
+
+    await waitFor(() => {
+      expect(q(container, "cowork-preflight-failed")?.textContent ?? "").toContain(
+        COWORK_PREFLIGHT_FAILED,
+      );
+    });
+    expect(q(container, "cowork-preflight-live")).toBe(before);
+    expect(q(container, "cowork-preflight-live")?.textContent ?? "").toContain(
+      COWORK_PREFLIGHT_FAILED,
+    );
+  });
+
+  it("keeps Enable — a check that did not run is not a check that failed", async () => {
+    // `blocked` swaps Enable for "Check again" because we watched detection
+    // fail and know the outcome. `failed` knows nothing, so taking Enable away
+    // would block a user whose Cowork setup is fine on the strength of our own
+    // bug. The two must not share a branch.
+    preflightSubnet.mockResolvedValue({ status: "failed" });
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    await waitFor(() => {
+      expect(q(container, "cowork-preflight-failed")).toBeTruthy();
+    });
+
+    expect(q(container, "cowork-preflight-retry-btn")).toBeNull();
+    const enable = q(container, "cowork-enable-confirm-btn") as HTMLButtonElement;
+    expect(enable).toBeTruthy();
+    expect(enable.disabled).toBe(false);
+    // Muted help text, never `cs-preflight` — that class is the warning-token
+    // banner the `blocked` hint wears, and wearing it here would say "this will
+    // fail" about something we did not observe.
+    expect(q(container, "cowork-preflight-failed")?.className ?? "").not.toContain("cs-preflight");
+  });
+
+  it("renders nothing at all when the probe was never available", async () => {
+    // The other half of the split. `unavailable` is every non-Windows and
+    // non-Tauri session — the overwhelmingly common case — and it has no news,
+    // so a hedged line there would be permanent noise for people whose network
+    // was never going to be probed. Only the region and its in-flight line.
+    preflightSubnet.mockResolvedValue({ status: "unavailable" });
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    await probeCount(1);
+    await waitFor(() => {
+      expect(q(container, "cowork-preflight-live")?.textContent ?? "").not.toContain(
+        COWORK_PREFLIGHT_CHECKING,
+      );
+    });
+
+    expect(q(container, "cowork-preflight-failed")).toBeNull();
+    expect(q(container, "cowork-preflight-blocked")).toBeNull();
+    expect(q(container, "cowork-preflight-live")?.textContent?.trim()).toBe("");
+    expect(q(container, "cowork-enable-confirm-btn")).toBeTruthy();
   });
 
   it("announces the re-probe without dropping the hint it is re-checking", async () => {

--- a/tests/client/cowork-settings.test.ts
+++ b/tests/client/cowork-settings.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   aggregateWorkspaceStatus,
+  COWORK_PREFLIGHT_FAILED,
   coworkReachability,
   coworkReachabilityCopy,
   coworkSettingsVariant,
@@ -508,8 +509,10 @@ describe("formatCoworkError", () => {
 
 // ---------------------------------------------------------------------------
 // coworkPreflightSubnet (#1298) — the probe that decides whether Enable is
-// offered at all. Three states, because "the probe failed" and "enabling would
-// fail" are different claims and only the second one may block a button.
+// offered at all. "The probe failed" and "enabling would fail" are different
+// claims and only the second one may block a button; #1436 then split the
+// first one again, into an environment that was never going to answer and a
+// fault that owes the user a sentence.
 // ---------------------------------------------------------------------------
 
 describe("coworkPreflightSubnet", () => {
@@ -544,27 +547,126 @@ describe("coworkPreflightSubnet", () => {
     expect(result.hint).not.toContain("set up on this machine");
   });
 
-  it("reports unknown — never blocked — when the probe itself cannot run", async () => {
+  it("reports unavailable or failed — never blocked — when the probe cannot run", async () => {
     // A broken probe says nothing about whether enabling would work. Blocking
     // here would stop a user whose enable would have succeeded, which is a
     // worse failure than the one #1298 is fixing.
+    //
+    // #1436 splits the two reasons a probe does not answer. The environment
+    // ones are `unavailable` and stay silent on every surface; anything else is
+    // `failed` and says so. The two were already distinguished by their log
+    // level here — that distinction simply never reached the wire.
+    // Both literals, not the module constants: `rawMsg.includes(...)` is a
+    // substring test against a string the Rust side owns, so a fixture built
+    // from the constant would follow a rename that broke the real match. The
+    // pre-#1436 fixture here read "Windows only" and matched NOTHING — with a
+    // single `unknown` on both arms that was invisible, and it is exactly the
+    // drift this spelling guards.
     for (const thrown of [
       new Error("Tauri runtime not available"),
-      new Error("Windows only"),
-      "a bare string",
+      new Error("Cowork integration is Windows-only"),
     ]) {
       const invoke = (async () => {
         throw thrown;
       }) as InvokeFn;
-      await expect(coworkPreflightSubnet(invoke)).resolves.toEqual({ status: "unknown" });
+      await expect(coworkPreflightSubnet(invoke)).resolves.toEqual({ status: "unavailable" });
     }
+    const bareString = (async () => {
+      throw "a bare string";
+    }) as InvokeFn;
+    await expect(coworkPreflightSubnet(bareString)).resolves.toEqual({ status: "failed" });
   });
 
-  it("treats a non-firewall JSON error as unknown, not blocked", () => {
+  it("treats a non-firewall JSON error as failed, not blocked", () => {
+    // A JSON error with no recognised `kind` is a serde drift or an
+    // unregistered command — a bug on our side, not an environment we cannot
+    // run in. It must not stop the user from enabling, and it must not pretend
+    // the check passed.
     const invoke = (async () => {
       throw new Error(JSON.stringify({ error: "oops" }));
     }) as InvokeFn;
-    return expect(coworkPreflightSubnet(invoke)).resolves.toEqual({ status: "unknown" });
+    return expect(coworkPreflightSubnet(invoke)).resolves.toEqual({ status: "failed" });
+  });
+
+  it("calls a missing bridge INSIDE Tauri a fault, not an environment", async () => {
+    // The finding that made this split worth re-doing. `TAURI_NOT_AVAILABLE`
+    // comes from `loadInvoke`'s own catch when the `@tauri-apps/api/core`
+    // import fails. Outside Tauri that is the ordinary no-bridge case; INSIDE
+    // Tauri it means a chunk that must exist did not load — a partial update, a
+    // CSP block — and since every probing surface is gated on
+    // `isTauriRuntime()`, it is the ONE way a shipped desktop build reaches
+    // this arm at all. Reading it as an environment sent the only reachable
+    // fault straight back to the silence #1436 exists to end.
+    const notLoaded = (async () => {
+      throw new Error("Tauri runtime not available");
+    }) as InvokeFn;
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("window", { __TAURI_INTERNALS__: {} } as unknown as Window);
+    try {
+      // `await` inside the `try`, not `return promise` — a returned promise
+      // runs the `finally` before it settles, and the unstub would then land
+      // while the classification is still reading the global.
+      await expect(coworkPreflightSubnet(notLoaded)).resolves.toEqual({ status: "failed" });
+    } finally {
+      vi.unstubAllGlobals();
+      error.mockRestore();
+    }
+  });
+
+  it("says something announceable, in the literal", () => {
+    // Every render assertion in the mounted suites reads
+    // `textContent.toContain(COWORK_PREFLIGHT_FAILED)`, which is VACUOUS if the
+    // constant is empty or whitespace — a live region that adds no announceable
+    // text would pass the whole suite that exists to prevent exactly that. This
+    // is the one assertion written against the literal, so the constant cannot
+    // silently go blank.
+    expect(COWORK_PREFLIGHT_FAILED).toContain("Couldn't check your network");
+    expect(COWORK_PREFLIGHT_FAILED.trim().length).toBeGreaterThan(20);
+  });
+
+  it("matches a DECORATED Windows-only rejection, not just the bare string", () => {
+    // The `includes` half of the classification exists for this and only this:
+    // the message can arrive wrapped (`Error: …`, a Tauri prefix). Since #1436
+    // the two arms select silence vs a visible warning line, so a miss here
+    // paints a hedged warning on every non-Windows run — the routine path.
+    const decorated = (async () => {
+      throw new Error("Error: Cowork integration is Windows-only");
+    }) as InvokeFn;
+    return expect(coworkPreflightSubnet(decorated)).resolves.toEqual({
+      status: "unavailable",
+    });
+  });
+
+  it("keeps `unavailable` off the error log and `failed` on it", async () => {
+    // The split is only worth having if the two halves stay on the two sides.
+    // A regression that routed the routine non-Windows path to `failed` would
+    // both paint a warning on every non-Windows run and bury a real fault in
+    // the noise.
+    //
+    // `async`/`await`, not `try { return promise } finally`: that shape runs
+    // the `finally` when the promise is RETURNED, so `mockRestore()` wipes the
+    // call history before the assertions read it and every count reads 0.
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const notTauri = (async () => {
+        throw new Error("Tauri runtime not available");
+      }) as InvokeFn;
+      const broken = (async () => {
+        throw new Error("something nobody expected");
+      }) as InvokeFn;
+      const [unavailable, failed] = await Promise.all([
+        coworkPreflightSubnet(notTauri),
+        coworkPreflightSubnet(broken),
+      ]);
+      expect(unavailable).toEqual({ status: "unavailable" });
+      expect(failed).toEqual({ status: "failed" });
+      expect(debug).toHaveBeenCalledTimes(1);
+      expect(error).toHaveBeenCalledTimes(1);
+    } finally {
+      debug.mockRestore();
+      error.mockRestore();
+    }
   });
 });
 

--- a/tests/client/integration-wizard-cowork.test.ts
+++ b/tests/client/integration-wizard-cowork.test.ts
@@ -25,7 +25,10 @@
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { COWORK_PREFLIGHT_CHECKING } from "../../src/client/cowork/cowork-helpers";
+import {
+  COWORK_PREFLIGHT_CHECKING,
+  COWORK_PREFLIGHT_FAILED,
+} from "../../src/client/cowork/cowork-helpers";
 import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
 import { coworkStatusFixture } from "../helpers/cowork-status-fixture";
 
@@ -44,7 +47,7 @@ vi.mock("../../src/client/cowork/cowork-helpers", async (importOriginal) => {
 // The real type, not a transcription: a hand-copied union goes stale silently,
 // and `tests/` is typechecked by nothing (`tsconfig.json` includes only `src`),
 // so the copy would not even fail to compile.
-const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unknown" }));
+const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unavailable" }));
 
 // Spread `importOriginal` rather than re-declaring the module: `cowork-invoke`
 // exports nine symbols and each suite's mock used to name a different subset,
@@ -123,7 +126,7 @@ describe("integration wizard — Cowork sub-view gating", () => {
     toggleIntegration.mockClear();
     fakeInvoke.mockClear();
     preflightSubnet.mockClear();
-    preflightSubnet.mockResolvedValue({ status: "unknown" });
+    preflightSubnet.mockResolvedValue({ status: "unavailable" });
   });
 
   afterEach(() => {
@@ -359,6 +362,53 @@ describe("integration wizard — Cowork sub-view gating", () => {
       );
     });
     expect(q(container, "integration-wizard-cowork-preflight-live")).toBe(before);
+  });
+
+  it("tells the user the check did not run, hedged (#1436)", async () => {
+    // `iw-hint-text`, not `iw-banner-warning`: the claim is "we don't know",
+    // and a warning banner in the wizard's own visual language would read as
+    // "this will fail" — which we have no evidence for.
+    preflightSubnet.mockResolvedValue({ status: "failed" });
+    const { container } = render(IntegrationWizardModal, {
+      props: { open: true, onClose: vi.fn() },
+    });
+    await tick();
+    (q(container, "integration-wizard-cowork-setup") as HTMLButtonElement).click();
+    await tick();
+    const before = q(container, "integration-wizard-cowork-preflight-live");
+    expect(before).toBeTruthy();
+
+    await waitFor(() => {
+      expect(
+        q(container, "integration-wizard-cowork-preflight-failed")?.textContent ?? "",
+      ).toContain(COWORK_PREFLIGHT_FAILED);
+    });
+    expect(q(container, "integration-wizard-cowork-preflight-live")).toBe(before);
+    // CONTAINMENT, not merely presence: lifting the branch out to a sibling
+    // `{#if}` beside the region keeps node identity and the testid while
+    // reproducing the original silence exactly.
+    expect(q(container, "integration-wizard-cowork-preflight-live")?.textContent ?? "").toContain(
+      COWORK_PREFLIGHT_FAILED,
+    );
+    expect(q(container, "integration-wizard-cowork-preflight-failed")?.className ?? "").toContain(
+      "iw-hint-text",
+    );
+    expect(q(container, "integration-wizard-cowork-preflight-retry-btn")).toBeNull();
+  });
+
+  it("stays silent when the probe was never available", async () => {
+    // `unavailable` is a probe that was never going to answer; a hedged line
+    // there would be permanent noise rather than news.
+    preflightSubnet.mockResolvedValue({ status: "unavailable" });
+    const { container } = render(IntegrationWizardModal, {
+      props: { open: true, onClose: vi.fn() },
+    });
+    await tick();
+    await openCoworkSubView(container);
+
+    expect(q(container, "integration-wizard-cowork-preflight-failed")).toBeNull();
+    expect(q(container, "integration-wizard-cowork-preflight-blocked")).toBeNull();
+    expect(q(container, "integration-wizard-cowork-preflight-live")?.textContent?.trim()).toBe("");
   });
 
   it("leaves Enable available when the probe itself cannot run", async () => {

--- a/tests/client/integration-wizard-push-support.test.ts
+++ b/tests/client/integration-wizard-push-support.test.ts
@@ -117,7 +117,7 @@ vi.mock("../../src/client/cowork/cowork-invoke", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../src/client/cowork/cowork-invoke")>()),
   loadInvoke: vi.fn(async () => vi.fn()),
   coworkToggleIntegration: vi.fn(async () => ({ ok: true })),
-  coworkPreflightSubnet: vi.fn(async () => ({ status: "unknown" })),
+  coworkPreflightSubnet: vi.fn(async () => ({ status: "unavailable" })),
 }));
 
 import IntegrationWizardModal from "../../src/client/components/IntegrationWizardModal.svelte";

--- a/tests/client/settings-claude-code-tab-cowork.test.ts
+++ b/tests/client/settings-claude-code-tab-cowork.test.ts
@@ -43,7 +43,7 @@ vi.mock("../../src/client/cowork/cowork-invoke", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../src/client/cowork/cowork-invoke")>()),
   loadInvoke: vi.fn(async () => vi.fn()),
   coworkToggleIntegration: vi.fn(async () => ({ ok: true })),
-  coworkPreflightSubnet: vi.fn(async () => ({ status: "unknown" })),
+  coworkPreflightSubnet: vi.fn(async () => ({ status: "unavailable" })),
 }));
 
 import SettingsClaudeCodeTab from "../../src/client/components/settings-tabs/SettingsClaudeCodeTab.svelte";

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -83,11 +83,13 @@ cowork-onboarding-error
 cowork-onboarding-learn-more-btn
 cowork-onboarding-learn-more-link
 cowork-onboarding-preflight-blocked
+cowork-onboarding-preflight-failed
 cowork-onboarding-preflight-live
 cowork-onboarding-preflight-retry-btn
 cowork-onboarding-skip-btn
 cowork-onboarding-step
 cowork-preflight-blocked
+cowork-preflight-failed
 cowork-preflight-live
 cowork-preflight-retry-btn
 cowork-reachability
@@ -215,6 +217,7 @@ integration-wizard-cowork-back
 integration-wizard-cowork-error
 integration-wizard-cowork-explainer
 integration-wizard-cowork-preflight-blocked
+integration-wizard-cowork-preflight-failed
 integration-wizard-cowork-preflight-live
 integration-wizard-cowork-preflight-retry-btn
 integration-wizard-cowork-setup


### PR DESCRIPTION
Closes #1436.

## The defect

`SubnetPreflight` collapsed two unrelated outcomes into a single `unknown` state:

- "this platform has no Cowork integration to probe" (a non-Windows box, no Tauri bridge), and
- "the probe ran and we could not classify what came back" (a genuine fault).

Both rendered as **silence**. A real pre-flight failure was indistinguishable from a no-op on a machine where the feature does not exist, so the user saw nothing and the developer got nothing beyond a `console.debug`.

## The fix

`SubnetPreflight` is now four states — `ok`, `blocked`, `unavailable`, `failed`.

### The classification was also wrong, not just under-expressed

The producer treated a `TAURI_NOT_AVAILABLE` message as "no Tauri bridge, so this is an environment without the feature". But every surface that reaches this code is already gated on `isTauriRuntime()` **and** `osSupported`. Inside Tauri, that message means a chunk that must exist did not load — a **fault**, not an environment.

So the arm is now:

```ts
if (
  rawMsg.includes(COWORK_WINDOWS_ONLY) ||
  (rawMsg === TAURI_NOT_AVAILABLE && !isTauriRuntime())
) {
  console.debug("[cowork] subnet pre-flight unavailable:", rawMsg);
  return { status: "unavailable" };
}
console.error("[cowork] subnet pre-flight could not be classified:", rawMsg);
return { status: "failed" };
```

A consequence worth stating plainly: **`unavailable` is unreachable in the shipped app.** The doc comment says so, and says why it must not be folded into `failed` anyway — the distinction is what makes the `failed` arm's `console.error` meaningful, and the gating that makes it unreachable is three call sites away and could change.

`COWORK_WINDOWS_ONLY`'s doc comment now records that the string **selects behaviour**, not merely a log level — the previous wording invited someone to "clean up" the literal.

### What the user sees

`failed` renders one new line — `Couldn't check your network — enabling may still work.` — **inside the existing `role="status"` live region** at all three surfaces:

| Surface | class | `data-testid` |
|---|---|---|
| `CoworkSettings.svelte` | `cs-help-text` | `cowork-preflight-failed` |
| `CoworkOnboardingStep.svelte` | `cos-checking` | `cowork-onboarding-preflight-failed` |
| `IntegrationWizardModal.svelte` | `iw-hint-text` | `integration-wizard-cowork-preflight-failed` |

None of them swaps **Enable** for **Check again** — only `blocked` does that, because only `blocked` means we know something about the network is actually wrong. `failed` means we don't know, and the copy says exactly that.

`unavailable` stays silent, and there is a test on each surface asserting that silence, so a later "helpful" branch can't quietly appear there.

### Privacy note in the code

Logging `rawMsg` on the `failed` arm is safe **not** because the wire is payload-free, but because nothing reaches that arm unless `parseFirewallErrorVariant` already returned null. The comment says that, and flags that #1577 adds `stderr_tail` to `SubnetDetectionFailed` — so this arm needs re-checking when that lands.

## Verification

- `npm run typecheck` — clean
- `biome check` — clean
- `npm test` — **7745 passed, 24 skipped**
- `npm run test:e2e` — **358 passed, 11 skipped**, exit 0
- **Two hash-guarded mutation sweeps, 15 mutations, zero survivors** — covering the classification split, the live-region *containment* of each new branch (an early attempt "survived" because the moved block was still inside the `role="status"` div; the real mutation moves it past the closing tag), and the silence of `unavailable`.

Three `data-testid` values added, none removed. `docs/design-system-impl/testid-manifest.md` and `tests/design-system-impl/__snapshots__/testid-set.snap.txt` regenerated per Critical Rule 7.

## Not tier A

This adds user-visible copy and three new rendered branches, so it falls outside the docs/test/tooling tier. It needs a look on Windows hardware before merge — specifically, that the `failed` line reads sensibly in the wizard's cramped hint row.

## Test-fixture note

`tests/client/cowork-settings.test.ts` previously used `new Error("Windows only")` as the Windows-only fixture. That string does **not** match `COWORK_WINDOWS_ONLY` (`"Cowork integration is Windows-only"`), so it classified as the fallback. Pre-split both arms returned one `unknown`, so the drift was invisible. The fixture now uses the real Rust literal, with a comment explaining why the literal — not the imported constant — is the right spelling for a fixture whose whole job is to detect drift between the two sides.

---
_Generated by [Claude Code](https://claude.ai/code/session_018DdaCvomDgPsumrDAmNH13)_