### PR TITLE
fix(cowork): carry the toggle's degraded-success caveats out on the payload (#1438)

### DIFF
--- a/docs/design-system-impl/testid-manifest.md
+++ b/docs/design-system-impl/testid-manifest.md
@@ -308,7 +308,10 @@ shipped and were removed:
   Thirteen more live regions app-wide still have the pre-#1376 shape (#1431).
 - `cowork-admin-declined-{backdrop,modal,confirm-disable,error,status-error,disable-btn,disable-confirm-btn,disable-cancel-btn,retry-btn,learn-more-link}`
 - `cowork-settings{,-loading,-unsupported,-undetected,-error}`,
-  `cowork-toggle`, `cowork-toggle-checkbox`, `cowork-inline-toast`, `cowork-explainer`,
+  `cowork-toggle`, `cowork-toggle-checkbox`, `cowork-inline-toast`,
+  `cowork-toggle-warnings` (degraded-success caveats from the last toggle — a
+  `role="status"` block, deliberately not the `role="alert"` error banner, #1438),
+  `cowork-explainer`,
   `cowork-enable-{confirm,confirm-btn,cancel-btn}`,
   `cowork-vethernet-cidr`,
   `cowork-reachability` (post-enable stdio-channel reachability verdict, #1174 gap #3),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4515,6 +4515,86 @@ mod enable_persist_outcome_tests {
             !msg.contains("plugin entries"),
             "message must not claim plugin entries were installed when none were: {msg}"
         );
+    }
+}
+
+/// Did this workspace's `installed_plugins.json` write actually land?
+///
+/// **The subtlety this exists to name: an `Ok` does not mean it landed.**
+/// Both `install_tandem_plugin_into_workspace` and
+/// `uninstall_tandem_plugin_from_workspace` return
+/// `Ok(WorkspaceWriteReport { installed_plugins: WriteStatus::Failed(..) })`
+/// for a per-file failure -- e.g. a revalidation failure in the uninstall path
+/// (`cowork_installer.rs`) -- reserving `Err` for a failure to even reach the
+/// file. So `r.is_ok()` counts a workspace that still holds its plugin entry
+/// as a success.
+///
+/// Both arms of `cowork_toggle_integration` decide "did this workspace
+/// succeed?" more than once -- for the hard all-failed check and again for the
+/// #1438 degraded-success warning -- and the two must not disagree. They did:
+/// the disable arm's warning used a bare `is_ok()` while its own all-failed
+/// check used the `WriteStatus` test right above it, so a partial uninstall
+/// whose failures were all non-`Err` produced no warning at all. That is the
+/// commonest failure shape and precisely the case the warning was added for.
+/// Routing every such decision through this one predicate is what keeps them
+/// in step.
+#[cfg(target_os = "windows")]
+fn workspace_entry_written(
+    report: &Result<cowork_installer::WorkspaceWriteReport, cowork_atomic_json::CoworkError>,
+) -> bool {
+    matches!(
+        report,
+        Ok(r) if matches!(
+            r.installed_plugins,
+            cowork_installer::WriteStatus::Ok | cowork_installer::WriteStatus::AlreadyPresent
+        )
+    )
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod workspace_entry_written_tests {
+    use super::workspace_entry_written;
+    use crate::cowork_atomic_json::CoworkError;
+    use crate::cowork_installer::{WorkspaceWriteReport, WriteStatus};
+
+    fn report(status: WriteStatus) -> Result<WorkspaceWriteReport, CoworkError> {
+        Ok(WorkspaceWriteReport {
+            workspace_id: "ws".into(),
+            vm_id: "vm".into(),
+            installed_plugins: status,
+            known_marketplaces: WriteStatus::Ok,
+            cowork_settings: WriteStatus::Ok,
+        })
+    }
+
+    #[test]
+    fn ok_and_already_present_count_as_written() {
+        assert!(workspace_entry_written(&report(WriteStatus::Ok)));
+        assert!(workspace_entry_written(&report(WriteStatus::AlreadyPresent)));
+    }
+
+    #[test]
+    fn an_ok_carrying_a_failed_status_is_not_written() {
+        // The whole reason this predicate exists. `is_ok()` says true here, and
+        // that is what made the #1438 partial-uninstall warning silent for the
+        // commonest failure shape: `uninstall_tandem_plugin_from_workspace`
+        // returns Ok(..Failed) on a revalidation failure, not Err.
+        assert!(!workspace_entry_written(&report(WriteStatus::Failed(
+            "revalidation failed".into()
+        ))));
+        assert!(!workspace_entry_written(&report(WriteStatus::Locked)));
+        assert!(!workspace_entry_written(&report(WriteStatus::SchemaDrift)));
+    }
+
+    #[test]
+    fn a_hard_error_is_not_written() {
+        let err: Result<WorkspaceWriteReport, CoworkError> =
+            Err(CoworkError::InsecureAcl {
+                path: std::path::PathBuf::from("C:/ws"),
+            });
+        assert!(!workspace_entry_written(&err));
+    }
+}
 
 /// The `Ok` payload of `cowork_toggle_integration` (#1438).
 ///
@@ -4776,15 +4856,7 @@ fn cowork_toggle_integration(enabled: bool) -> Result<CoworkToggleReport, String
         // AlreadyPresent — anything else (Locked, SchemaDrift, InsecureAcl, Failed)
         // counts as a failure.
         if !workspaces.is_empty() {
-            let success_count = reports.iter().filter(|r| {
-                match r {
-                    Ok(report) => matches!(
-                        report.installed_plugins,
-                        cowork_installer::WriteStatus::Ok | cowork_installer::WriteStatus::AlreadyPresent
-                    ),
-                    Err(_) => false,
-                }
-            }).count();
+            let success_count = reports.iter().filter(|r| workspace_entry_written(r)).count();
 
             if success_count == 0 {
                 let failure_summary: Vec<String> = reports.iter().map(|r| match r {
@@ -4808,11 +4880,7 @@ fn cowork_toggle_integration(enabled: bool) -> Result<CoworkToggleReport, String
                 // out on the Ok payload so the panel can say so.
                 let failure_summary: Vec<String> = reports
                     .iter()
-                    .filter(|r| !matches!(r, Ok(report) if matches!(
-                        report.installed_plugins,
-                        cowork_installer::WriteStatus::Ok
-                            | cowork_installer::WriteStatus::AlreadyPresent
-                    )))
+                    .filter(|r| !workspace_entry_written(r))
                     .map(|r| match r {
                         Ok(report) => format!(
                             "{}/{}: {:?}",
@@ -4865,15 +4933,7 @@ fn cowork_toggle_integration(enabled: bool) -> Result<CoworkToggleReport, String
         }
 
         let workspace_all_failed = if !workspaces.is_empty() {
-            let success_count = reports.iter().filter(|r| {
-                match r {
-                    Ok(report) => matches!(
-                        report.installed_plugins,
-                        cowork_installer::WriteStatus::Ok | cowork_installer::WriteStatus::AlreadyPresent
-                    ),
-                    Err(_) => false,
-                }
-            }).count();
+            let success_count = reports.iter().filter(|r| workspace_entry_written(r)).count();
 
             if success_count > 0 && success_count < workspaces.len() {
                 log::warn!(
@@ -4967,17 +5027,7 @@ fn cowork_toggle_integration(enabled: bool) -> Result<CoworkToggleReport, String
         // uses the WriteStatus predicate; this one is now symmetric with it.
         let uninstall_failures: Vec<String> = reports
             .iter()
-            .filter(|r| {
-                !matches!(
-                    r,
-                    Ok(report)
-                        if matches!(
-                            report.installed_plugins,
-                            cowork_installer::WriteStatus::Ok
-                                | cowork_installer::WriteStatus::AlreadyPresent
-                        )
-                )
-            })
+            .filter(|r| !workspace_entry_written(r))
             .map(|r| match r {
                 Ok(report) => format!(
                     "{}/{}: {:?}",
@@ -5757,15 +5807,7 @@ fn cowork_set_lan_ip_override(enabled: bool) -> Result<String, String> {
         }
 
         if !workspaces.is_empty() {
-            let success_count = reports.iter().filter(|r| {
-                match r {
-                    Ok(report) => matches!(
-                        report.installed_plugins,
-                        cowork_installer::WriteStatus::Ok | cowork_installer::WriteStatus::AlreadyPresent
-                    ),
-                    Err(_) => false,
-                }
-            }).count();
+            let success_count = reports.iter().filter(|r| workspace_entry_written(r)).count();
 
             if success_count == 0 {
                 let failure_summary: Vec<String> = reports.iter().map(|r| match r {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4515,6 +4515,151 @@ mod enable_persist_outcome_tests {
             !msg.contains("plugin entries"),
             "message must not claim plugin entries were installed when none were: {msg}"
         );
+
+/// The `Ok` payload of `cowork_toggle_integration` (#1438).
+///
+/// The command has always encoded *degraded success* in its `Ok` arm — a
+/// partial multi-workspace install on enable, a leftover firewall rule or a
+/// partial uninstall on disable — as English folded into the success string.
+/// Every client call site awaited the invoke and threw the string away, so all
+/// three rendered as an unqualified green success and the only surviving record
+/// was a `log::warn!` on a Tauri log the user has no route to. A user with three
+/// workspaces where two failed to install saw "Enabled" and a check badge.
+///
+/// Splitting the payload rather than teaching the client to read the message is
+/// deliberate. Branching on message text would couple the client to Rust string
+/// literals, and a reworded warning would then silently stop rendering — the
+/// same class of failure, moved one layer out and made harder to see.
+///
+/// `warnings` empty means clean success. It is never used to report failure:
+/// that is still the `Err` arm, and the two must not blur. A warning here means
+/// "the operation committed, and here is what is imperfect about the result".
+#[derive(serde::Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct CoworkToggleReport {
+    message: String,
+    warnings: Vec<String>,
+}
+
+/// The user-facing caveat for a firewall rule that could not be removed.
+///
+/// A `const` rather than an inline literal because the disable arm is the only
+/// producer and a test is the only other reader; keeping them on one string
+/// stops the test from passing against a copy of the wording rather than the
+/// wording. The allow mirrors `partial_workspace_warning`'s: the only non-test
+/// reader is inside the `cfg(target_os = "windows")` arm.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+const COWORK_LEFTOVER_FIREWALL_WARNING: &str =
+    "A leftover firewall rule may remain. It's harmless — Tandem's server only listens on this computer.";
+
+/// The caveat for a workspace pass where some — but not all — workspaces
+/// succeeded.
+///
+/// `None` when there is nothing to say: no workspaces at all, or every one of
+/// them succeeded. All-failed is NOT this function's case — both arms of the
+/// toggle return `Err` before reaching here, because an operation that landed
+/// nowhere is a failure, not a degraded success.
+///
+/// Kept outside the `cfg(target_os = "windows")` gate so its tests run on every
+/// CI leg; the allow keeps a non-Windows release build warning-free. Direct
+/// precedent: `parse_netstat_listening_pid` and its siblings above.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn partial_workspace_warning(
+    verb: &str,
+    success_count: usize,
+    total: usize,
+    failures: &[String],
+) -> Option<String> {
+    if total == 0 || success_count >= total {
+        return None;
+    }
+    let failed = total - success_count;
+    // The failure detail is included because the alternative is a warning the
+    // user cannot act on. It is the same summary the `Err` arm already builds
+    // for the all-failed case, so this adds no new disclosure surface.
+    let detail = if failures.is_empty() {
+        String::new()
+    } else {
+        format!(" Details: {}", failures.join("; "))
+    };
+    Some(format!(
+        "{failed} of {total} Cowork workspace(s) could not be {verb}.{detail}"
+    ))
+}
+
+#[cfg(test)]
+mod partial_workspace_warning_tests {
+    use super::{partial_workspace_warning, COWORK_LEFTOVER_FIREWALL_WARNING};
+
+    /// The regression #1438 is about: a partial install used to be visible only
+    /// in a `log::warn!`, so this asserts something is produced at all — and
+    /// that it names both halves of the ratio, since "some failed" without a
+    /// count is not actionable.
+    #[test]
+    fn a_partial_pass_produces_a_warning_naming_the_ratio() {
+        let w = partial_workspace_warning(
+            "configured",
+            1,
+            3,
+            &["ws-a/vm-1: Locked".into(), "ws-b/vm-2: SchemaDrift".into()],
+        )
+        .expect("a partial pass must produce a warning");
+        assert!(w.contains("2 of 3"), "{w}");
+        assert!(w.contains("configured"), "{w}");
+        // The detail is what makes it actionable — a user cannot act on
+        // "2 of 3 failed" alone.
+        assert!(w.contains("ws-a/vm-1: Locked"), "{w}");
+        assert!(w.contains("ws-b/vm-2: SchemaDrift"), "{w}");
+    }
+
+    #[test]
+    fn a_clean_pass_produces_nothing() {
+        assert_eq!(partial_workspace_warning("configured", 3, 3, &[]), None);
+    }
+
+    /// Zero workspaces is a clean outcome, not a degraded one. Warning there
+    /// would put a caveat on every enable on a machine that has no Cowork
+    /// workspaces at all — the common case for a new install.
+    #[test]
+    fn no_workspaces_at_all_produces_nothing() {
+        assert_eq!(partial_workspace_warning("configured", 0, 0, &[]), None);
+    }
+
+    /// Defensive: a count above the total is a caller bug, and the honest
+    /// answer is silence rather than a warning claiming a negative failure
+    /// count. `total - success_count` would panic in debug builds.
+    #[test]
+    fn a_success_count_above_the_total_produces_nothing_rather_than_panicking() {
+        assert_eq!(partial_workspace_warning("configured", 4, 3, &[]), None);
+    }
+
+    /// All-failed is deliberately NOT this function's case — both toggle arms
+    /// return `Err` before reaching it. Pinned so a future refactor that routes
+    /// all-failed through here has to make that decision on purpose: it would
+    /// otherwise turn a hard failure into a green toast with a caveat.
+    #[test]
+    fn all_failed_still_produces_a_warning_because_the_caller_never_asks() {
+        let w = partial_workspace_warning("configured", 0, 2, &["a".into(), "b".into()]);
+        assert!(w.is_some(), "the shape is unconditional; the CALLER is the gate");
+    }
+
+    /// Empty failure detail is a degenerate but reachable shape (a caller that
+    /// knows the ratio but not the reasons). It must not emit a dangling
+    /// "Details:" with nothing after it.
+    #[test]
+    fn no_failure_detail_means_no_details_clause() {
+        let w = partial_workspace_warning("cleaned up", 1, 2, &[]).expect("still a warning");
+        assert!(!w.contains("Details"), "{w}");
+        assert!(w.contains("1 of 2"), "{w}");
+    }
+
+    /// The firewall caveat is advisory, and the wording carries the reason it
+    /// is advisory. A rewrite that drops the "only listens on this computer"
+    /// half turns a reassurance into an alarm.
+    #[test]
+    fn the_leftover_firewall_warning_says_why_it_is_harmless() {
+        assert!(COWORK_LEFTOVER_FIREWALL_WARNING.contains("harmless"));
+        assert!(COWORK_LEFTOVER_FIREWALL_WARNING.contains("only listens on this computer"));
     }
 }
 
@@ -4526,7 +4671,7 @@ mod enable_persist_outcome_tests {
 /// all. On disable: uninstalls plugin entries, removes firewall rules.
 #[cfg(target_os = "windows")]
 #[tauri::command]
-fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
+fn cowork_toggle_integration(enabled: bool) -> Result<CoworkToggleReport, String> {
     use cowork_installer::{install_tandem_plugin_into_workspace, uninstall_tandem_plugin_from_workspace};
     use cowork_workspace_scan::find_cowork_workspaces;
 
@@ -4609,6 +4754,8 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         }
 
         let workspace_count = workspaces.len();
+        // Degraded-success caveats, surfaced on the Ok payload (#1438).
+        let mut warnings: Vec<String> = Vec::new();
 
         let reports: Vec<_> = workspaces
             .iter()
@@ -4657,6 +4804,29 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
                     success_count,
                     workspaces.len()
                 );
+                // #1438: the log is not a route the user has. Carry the caveat
+                // out on the Ok payload so the panel can say so.
+                let failure_summary: Vec<String> = reports
+                    .iter()
+                    .filter(|r| !matches!(r, Ok(report) if matches!(
+                        report.installed_plugins,
+                        cowork_installer::WriteStatus::Ok
+                            | cowork_installer::WriteStatus::AlreadyPresent
+                    )))
+                    .map(|r| match r {
+                        Ok(report) => format!(
+                            "{}/{}: {:?}",
+                            report.workspace_id, report.vm_id, report.installed_plugins
+                        ),
+                        Err(e) => e.to_string(),
+                    })
+                    .collect();
+                warnings.extend(partial_workspace_warning(
+                    "configured",
+                    success_count,
+                    workspaces.len(),
+                    &failure_summary,
+                ));
             }
         }
 
@@ -4670,7 +4840,16 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
         if let Err(e) = &persist {
             log::warn!("[cowork] failed to persist meta after enable: {e}");
         }
+        // Both halves survive the #1437 + #1438 merge, and the order matters.
+        // `enable_persist_outcome` owns the FAILURE decision (#1437: a persist
+        // failure after the firewall rule and plugin entries are live is a
+        // partial commit and must fail loud, not resolve green over a stale
+        // state). `warnings` carries DEGRADED SUCCESS (#1438). They compose in
+        // exactly one direction: a persist failure discards the warnings,
+        // because the operation did not succeed and a caveat list beside an
+        // error would imply it did. Warnings ride only on the Ok arm.
         enable_persist_outcome(persist, workspace_count)
+            .map(|message| CoworkToggleReport { message, warnings })
     } else {
         // Disable: uninstall from all workspaces and remove firewall rules.
         let workspaces = find_cowork_workspaces();
@@ -4769,18 +4948,56 @@ fn cowork_toggle_integration(enabled: bool) -> Result<String, String> {
             ));
         }
 
+        let mut warnings: Vec<String> = Vec::new();
         if firewall_failed {
-            Ok("Cowork disabled (a leftover firewall rule may remain — harmless; \
-                Tandem's server only listens on this computer)"
-                .to_string())
-        } else {
-            Ok("Cowork disabled".to_string())
+            warnings.push(COWORK_LEFTOVER_FIREWALL_WARNING.to_string());
         }
+        // A partial uninstall is the same defect as the partial install above:
+        // it was `log::warn!`-only, so a user with three workspaces where two
+        // still hold plugin entries saw an unqualified "Cowork disabled".
+        //
+        // The predicate must be the SAME one `workspace_all_failed` uses above,
+        // not a bare `is_ok()`. `uninstall_tandem_plugin_from_workspace` returns
+        // `Ok(WorkspaceWriteReport { installed_plugins: WriteStatus::Failed(..) })`
+        // on a revalidation failure (`cowork_installer.rs`) -- an `Ok` that means
+        // the entry is still there. Counting that as a success made this warning
+        // silent for the commonest failure shape, i.e. for exactly the case the
+        // bullet above describes, while `workspace_all_failed` right above was
+        // already treating it as a failure. The enable arm's `failure_summary`
+        // uses the WriteStatus predicate; this one is now symmetric with it.
+        let uninstall_failures: Vec<String> = reports
+            .iter()
+            .filter(|r| {
+                !matches!(
+                    r,
+                    Ok(report)
+                        if matches!(
+                            report.installed_plugins,
+                            cowork_installer::WriteStatus::Ok
+                                | cowork_installer::WriteStatus::AlreadyPresent
+                        )
+                )
+            })
+            .map(|r| match r {
+                Ok(report) => format!(
+                    "{}/{}: {:?}",
+                    report.workspace_id, report.vm_id, report.installed_plugins
+                ),
+                Err(e) => e.to_string(),
+            })
+            .collect();
+        warnings.extend(partial_workspace_warning(
+            "cleaned up",
+            workspaces.len().saturating_sub(uninstall_failures.len()),
+            workspaces.len(),
+            &uninstall_failures,
+        ));
+        Ok(CoworkToggleReport { message: "Cowork disabled".to_string(), warnings })
     }
 }
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
-fn cowork_toggle_integration(_enabled: bool) -> Result<String, String> {
+fn cowork_toggle_integration(_enabled: bool) -> Result<CoworkToggleReport, String> {
     Err(WINDOWS_ONLY_ERR.into())
 }
 
@@ -5612,12 +5829,12 @@ fn cowork_set_lan_ip_override(_enabled: bool) -> Result<String, String> {
 /// and none can be accepted or declined.
 #[cfg(target_os = "windows")]
 #[tauri::command]
-fn cowork_retry_admin_elevation() -> Result<String, String> {
+fn cowork_retry_admin_elevation() -> Result<CoworkToggleReport, String> {
     cowork_toggle_integration(true)
 }
 #[cfg(not(target_os = "windows"))]
 #[tauri::command]
-fn cowork_retry_admin_elevation() -> Result<String, String> {
+fn cowork_retry_admin_elevation() -> Result<CoworkToggleReport, String> {
     Err(WINDOWS_ONLY_ERR.into())
 }
 

--- a/src/client/components/CoworkAdminDeclinedModal.svelte
+++ b/src/client/components/CoworkAdminDeclinedModal.svelte
@@ -119,6 +119,11 @@ async function handleRetry(): Promise<void> {
 
 async function handleDisable(): Promise<void> {
   await withInvoke(async (invoke) => {
+    // Same call as the settings panel's disable, and the same reason its
+    // degraded-success warnings (#1438) are not rendered here: this modal
+    // closes on success. A leftover firewall rule is advisory by construction
+    // (the server binds 127.0.0.1), and a partial uninstall shows up as
+    // per-workspace status in the settings panel.
     await coworkToggleIntegration(invoke, false);
     await coworkState.refetch();
   }, "Failed to disable Cowork");

--- a/src/client/components/CoworkOnboardingStep.svelte
+++ b/src/client/components/CoworkOnboardingStep.svelte
@@ -64,6 +64,16 @@ async function withInvoke(
   }
 }
 
+/**
+ * The toggle's degraded-success warnings (#1438) are deliberately NOT rendered
+ * here. This step advances out of itself on success, so a caveat shown at this
+ * moment is discarded before it can be read — and the facts behind it are not
+ * lost: they come back on every `cowork_get_status` as per-workspace
+ * `WorkspaceStatus.fileStatus`, which the Cowork settings panel renders. The
+ * defect #1438 describes — the caveat existing ONLY in a Tauri log — is closed
+ * by the payload being structured and by that panel, not by a banner on a view
+ * that is about to unmount.
+ */
 async function handleEnable(): Promise<void> {
   const ok = await withInvoke(async (invoke) => {
     await coworkToggleIntegration(invoke, true);

--- a/src/client/components/CoworkSettings.svelte
+++ b/src/client/components/CoworkSettings.svelte
@@ -15,6 +15,7 @@ import {
   formatCoworkError,
   makeDebouncer,
   type StatusTokenFamily,
+  toggleWarnings,
   undetectedDetail,
   workspaceFileStatusFamily,
   workspaceFileStatusLabel,
@@ -59,6 +60,16 @@ const coworkState = createCoworkStatus(() => true);
 const { refetch } = coworkState;
 
 let inlineToastMessage = $state<string | null>(null);
+
+/**
+ * Degraded-success caveats from the last toggle (#1438).
+ *
+ * Separate from `inlineToastMessage` because they are not errors and must not
+ * read as one: the operation committed. Cleared at the START of each toggle
+ * rather than in `withInvoke`, so a toggle that throws leaves the error banner
+ * standing alone instead of beside caveats from the previous, successful run.
+ */
+let toggleWarningList = $state<string[]>([]);
 let confirming = $state<"enable" | null>(null);
 let busy = $state(false);
 // #1298: probe the Hyper-V subnet before offering Enable, so a detection
@@ -148,8 +159,9 @@ async function handleToggleOn(): Promise<void> {
   // `readBack` stays at its initial `true`, so the confirm still closes and
   // `enableBoxChecked` correctly falls back to the unchanged, accurate status.
   let readBack = true;
+  toggleWarningList = [];
   await withInvoke(async (invoke) => {
-    await coworkToggleIntegration(invoke, true);
+    toggleWarningList = toggleWarnings(await coworkToggleIntegration(invoke, true));
     readBack = await refetch();
   }, "Failed to enable Cowork");
   if (readBack) closeEnableConfirm();
@@ -251,9 +263,16 @@ async function handleToggleOff(box: HTMLInputElement): Promise<void> {
   // fixed at its source instead of here: the enable arm's meta-persist step
   // now fails loud (`enable_persist_outcome`, `src-tauri/src/lib.rs`) rather
   // than warning and falling through to `Ok`.
+  //
+  // #1438's warnings ride alongside this, not through it: the list is cleared
+  // at the START of the attempt so a toggle that throws leaves the error
+  // standing alone rather than beside caveats from the previous, successful
+  // run. It is assigned from the resolved payload only, so a rejected invoke
+  // leaves it empty.
   let wrote = false;
+  toggleWarningList = [];
   await withInvoke(async (invoke) => {
-    await coworkToggleIntegration(invoke, false);
+    toggleWarningList = toggleWarnings(await coworkToggleIntegration(invoke, false));
     wrote = true;
   }, "Failed to disable Cowork");
   const readBack = await readBackStatus();
@@ -598,6 +617,17 @@ function workspaceRowStyle(ws: WorkspaceStatus): string {
   {#if inlineToastMessage}
     <div class="cs-error-banner" data-testid="cowork-inline-toast" role="alert">
       {inlineToastMessage}
+    </div>
+  {/if}
+
+  <!-- Degraded success (#1438). `role="status"` rather than `alert`: the
+       operation committed, so this is advisory, and a polite live region does
+       not interrupt what the user is doing to say so. -->
+  {#if toggleWarningList.length > 0}
+    <div class="cs-warning-banner" data-testid="cowork-toggle-warnings" role="status">
+      {#each toggleWarningList as warning (warning)}
+        <div>{warning}</div>
+      {/each}
     </div>
   {/if}
 </div>

--- a/src/client/components/IntegrationWizardModal.svelte
+++ b/src/client/components/IntegrationWizardModal.svelte
@@ -378,6 +378,11 @@ async function enableCowork(): Promise<void> {
   coworkError = null;
   try {
     const invoke: InvokeFn = await loadInvoke();
+    // Degraded-success warnings (#1438) are not rendered here for the same
+    // reason as `CoworkOnboardingStep`: a successful enable leaves this
+    // sub-view, so a caveat shown now is discarded unread, and the per-workspace
+    // facts behind it return on every status read for the settings panel to
+    // show. Discarding the payload is a decision here, not an oversight.
     await coworkToggleIntegration(invoke, true);
     const readBack = await coworkStatus.refetch();
     if (readBack) leaveCoworkView();

--- a/src/client/cowork/cowork-helpers.ts
+++ b/src/client/cowork/cowork-helpers.ts
@@ -513,3 +513,28 @@ export function makeDebouncer(ms: number): Debouncer {
     },
   };
 }
+
+/**
+ * The warnings a `cowork_toggle_integration` result carries, defensively (#1438).
+ *
+ * Returns `[]` for anything that is not an object with a `warnings` array of
+ * strings — which is not paranoia about our own Rust: a desktop shell can be
+ * talking to a **sidecar predating #1438**, whose command resolved with a bare
+ * string. Reading `.warnings.length` off that throws inside the toggle handler
+ * and turns a successful enable into a red error banner, which is a worse
+ * outcome than the silence this issue is about.
+ *
+ * Non-string entries are dropped rather than stringified: `String(x)` on an
+ * object renders "[object Object]" into a user-facing banner.
+ */
+export function toggleWarnings(result: unknown): string[] {
+  // Only null and undefined need the early return: property access on either
+  // throws, while `.warnings` on a string, number or boolean is simply
+  // `undefined` and falls through to the `Array.isArray` gate below. A
+  // `typeof result !== "object"` guard here would be unreachable — this was
+  // verified by mutation, which is why it is not present.
+  if (result === null || result === undefined) return [];
+  const raw = (result as { warnings?: unknown }).warnings;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((w): w is string => typeof w === "string" && w.length > 0);
+}

--- a/src/client/cowork/cowork-invoke.ts
+++ b/src/client/cowork/cowork-invoke.ts
@@ -9,7 +9,7 @@ import {
   isTauriRuntime,
   parseFirewallErrorVariant,
 } from "../cowork/cowork-helpers";
-import type { CoworkStatus } from "../types";
+import type { CoworkStatus, CoworkToggleReport } from "../types";
 
 /**
  * The shape of `@tauri-apps/api/core` `invoke`. Kept minimal so tests can
@@ -53,8 +53,11 @@ export function coworkGetStatus(invoke: InvokeFn): Promise<CoworkStatus> {
   return invoke<CoworkStatus>("cowork_get_status");
 }
 
-export function coworkToggleIntegration(invoke: InvokeFn, enabled: boolean): Promise<{ ok: true }> {
-  return invoke<{ ok: true }>("cowork_toggle_integration", { enabled });
+export function coworkToggleIntegration(
+  invoke: InvokeFn,
+  enabled: boolean,
+): Promise<CoworkToggleReport> {
+  return invoke<CoworkToggleReport>("cowork_toggle_integration", { enabled });
 }
 
 export function coworkRescan(invoke: InvokeFn): Promise<string> {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -88,6 +88,29 @@ export interface CoworkStatus {
 }
 
 /**
+ * The `Ok` payload of the `cowork_toggle_integration` Tauri command (#1438).
+ * Mirrors `CoworkToggleReport` in `src-tauri/src/lib.rs`.
+ *
+ * The command encodes *degraded success* — a partial multi-workspace install on
+ * enable, a leftover firewall rule or a partial uninstall on disable. Those used
+ * to live as English inside the success string, which every call site threw
+ * away, so they rendered as an unqualified green success.
+ *
+ * `warnings` is never a failure channel: a rejected invoke is still the only way
+ * the command reports one. A warning means the operation committed and something
+ * about the result is imperfect.
+ *
+ * `warnings` is optional for the same stale-sidecar tolerance the rest of this
+ * surface uses: a desktop shell talking to an older sidecar receives a bare
+ * string where this object should be, and must render something honest rather
+ * than crash on `.length`. Read it through `toggleWarnings()`.
+ */
+export interface CoworkToggleReport {
+  message: string;
+  warnings?: string[];
+}
+
+/**
  * Discriminated union mirroring the Rust `FirewallError` enum. Each variant
  * drives a distinct user-facing recovery hint — see `firewallErrorHint`.
  */

--- a/tests/build/cowork-retry-delegates.test.ts
+++ b/tests/build/cowork-retry-delegates.test.ts
@@ -42,15 +42,19 @@ const repoRoot = path.resolve(__dirname, "../..");
 /**
  * The body of the `cfg(target_os = "windows")` arm — braces excluded.
  *
- * Anchored on the full attribute/signature triple rather than the bare `fn`
+ * Anchored on the attribute pair plus the `fn` line rather than the bare `fn`
  * line, because the `cfg(not(...))` stub two lines below has an identical
  * signature and would otherwise be a candidate match. Terminated by the first
  * column-0 `}`, which is the function's own closing brace under rustfmt.
+ *
+ * The return type is deliberately left open: it is the `cfg` attribute that
+ * distinguishes the two arms, not the type, and #1438 widened `String` to
+ * `CoworkToggleReport` without touching anything this file pins.
  */
 function windowsRetryBody(): string {
   const src = readFileSync(path.join(repoRoot, "src-tauri/src/lib.rs"), "utf8");
   const match =
-    /#\[cfg\(target_os = "windows"\)\]\n#\[tauri::command\]\nfn cowork_retry_admin_elevation\(\) -> Result<String, String> \{\n([\s\S]*?)\n\}/.exec(
+    /#\[cfg\(target_os = "windows"\)\]\n#\[tauri::command\]\nfn cowork_retry_admin_elevation\(\) -> [^{\n]+\{\n([\s\S]*?)\n\}/.exec(
       src,
     );
   expect(

--- a/tests/client/cowork-settings-mounted.test.ts
+++ b/tests/client/cowork-settings-mounted.test.ts
@@ -27,7 +27,15 @@ import {
 import type { SubnetPreflight } from "../../src/client/cowork/cowork-invoke";
 import { coworkErrorCell, coworkStatusCell } from "../helpers/cowork-fixtures.svelte";
 
-const toggleIntegration = vi.fn(async () => ({ ok: true as const }));
+// The real command's Ok payload (#1438): a message plus zero or more
+// degraded-success warnings. `warnings: []` is the clean case, and is what the
+// default mock must be — a mock omitting the key would make `toggleWarnings()`
+// return `[]` for the WRONG reason (missing key, not empty list) and hide a
+// regression where the component stopped reading the field at all.
+const toggleIntegration = vi.fn(async () => ({
+  message: "Cowork enabled: 1 workspace(s) configured",
+  warnings: [] as string[],
+}));
 const fakeInvoke = vi.fn();
 
 const preflightSubnet = vi.fn(async (): Promise<SubnetPreflight> => ({ status: "unavailable" }));
@@ -764,5 +772,112 @@ describe("CoworkSettings — pre-flight live region (#1376)", () => {
       );
     });
     expect(q(container, "cowork-preflight-live")?.textContent ?? "").toContain("no adapter");
+  });
+});
+
+describe("CoworkSettings — degraded-success warnings (#1438)", () => {
+  // The defect: `cowork_toggle_integration` encodes a partial multi-workspace
+  // install and a leftover firewall rule in its Ok arm, and every call site
+  // awaited the invoke and threw the value away. A user with three workspaces
+  // where two failed saw "Enabled" and a check badge, with the failure existing
+  // only in a Tauri log they have no route to.
+
+  it("a clean enable shows no warning banner", async () => {
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    enableSucceeds();
+    (q(container, "cowork-enable-confirm-btn") as HTMLButtonElement).click();
+    await waitFor(() => {
+      expect(q(container, "cowork-enable-confirm")).toBeNull();
+    });
+    expect(q(container, "cowork-toggle-warnings")).toBeNull();
+  });
+
+  it("a partial enable renders every warning the command returned", async () => {
+    toggleIntegration.mockResolvedValueOnce({
+      message: "Cowork enabled: 3 workspace(s) configured",
+      warnings: ["2 of 3 Cowork workspace(s) could not be configured. Details: ws-a/vm-1: Locked"],
+    });
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    enableSucceeds();
+    (q(container, "cowork-enable-confirm-btn") as HTMLButtonElement).click();
+
+    await waitFor(() => {
+      expect(q(container, "cowork-toggle-warnings")).toBeTruthy();
+    });
+    const banner = q(container, "cowork-toggle-warnings") as HTMLElement;
+    expect(banner.textContent).toContain("2 of 3");
+    expect(banner.textContent).toContain("ws-a/vm-1: Locked");
+    // Not an error. The enable committed, and painting a caveat in the error
+    // banner's clothes is the opposite failure to the one #1438 describes.
+    expect(banner.getAttribute("role")).toBe("status");
+    expect(q(container, "cowork-inline-toast")).toBeNull();
+  });
+
+  it("renders each warning as its own line rather than one run-on string", async () => {
+    toggleIntegration.mockResolvedValueOnce({
+      message: "Cowork disabled",
+      warnings: ["A leftover firewall rule may remain.", "1 of 2 could not be cleaned up."],
+    });
+    coworkStatusCell.patch({ enabled: true });
+    const { container, checkbox } = mount();
+    await tick();
+    disableSucceeds();
+    await setChecked(checkbox, false);
+
+    await waitFor(() => {
+      expect(q(container, "cowork-toggle-warnings")).toBeTruthy();
+    });
+    const banner = q(container, "cowork-toggle-warnings") as HTMLElement;
+    expect(banner.children.length).toBe(2);
+  });
+
+  it("a failed toggle shows the error alone, not last run's caveats beside it", async () => {
+    // Why the reset lives at the top of the handler rather than in
+    // `withInvoke`: a throw skips the assignment, so warnings from a previous
+    // successful toggle would still be on screen under a red banner saying the
+    // operation failed.
+    toggleIntegration.mockResolvedValueOnce({
+      message: "Cowork enabled: 3 workspace(s) configured",
+      warnings: ["2 of 3 Cowork workspace(s) could not be configured."],
+    });
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    enableSucceeds();
+    (q(container, "cowork-enable-confirm-btn") as HTMLButtonElement).click();
+    await waitFor(() => {
+      expect(q(container, "cowork-toggle-warnings")).toBeTruthy();
+    });
+
+    // Now disable, and have it fail.
+    toggleIntegration.mockRejectedValueOnce(new Error("Access is denied. (os error 5)"));
+    await setChecked(checkbox, false);
+    await waitFor(() => {
+      expect(q(container, "cowork-inline-toast")).toBeTruthy();
+    });
+    expect(q(container, "cowork-toggle-warnings")).toBeNull();
+  });
+
+  it("survives a sidecar predating #1438, which resolves with a bare string", async () => {
+    // A desktop shell can be newer than the sidecar it launched. Reading
+    // `.warnings.length` off a string throws inside the handler and turns a
+    // successful enable into a red error banner — worse than the silence this
+    // issue is about.
+    toggleIntegration.mockResolvedValueOnce(
+      "Cowork enabled: 1 workspace(s) configured" as unknown as {
+        message: string;
+        warnings: string[];
+      },
+    );
+    const { container, checkbox } = mount();
+    await setChecked(checkbox, true);
+    enableSucceeds();
+    (q(container, "cowork-enable-confirm-btn") as HTMLButtonElement).click();
+    await waitFor(() => {
+      expect(q(container, "cowork-enable-confirm")).toBeNull();
+    });
+    expect(q(container, "cowork-toggle-warnings")).toBeNull();
+    expect(q(container, "cowork-inline-toast")).toBeNull();
   });
 });

--- a/tests/client/cowork-settings.test.ts
+++ b/tests/client/cowork-settings.test.ts
@@ -10,6 +10,7 @@ import {
   formatCoworkError,
   isTauriRuntime,
   makeDebouncer,
+  toggleWarnings,
   undetectedDetail,
   workspaceFileStatusFamily,
   workspaceFileStatusLabel,
@@ -1022,5 +1023,45 @@ describe("isTauriRuntime", () => {
   it("returns true when __TAURI_INTERNALS__ is present (Tauri v2)", () => {
     vi.stubGlobal("window", { __TAURI_INTERNALS__: {} } as unknown as Window);
     expect(isTauriRuntime()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toggleWarnings — the defensive read of the toggle's Ok payload (#1438)
+// ---------------------------------------------------------------------------
+
+describe("toggleWarnings", () => {
+  it("returns the warnings a well-formed report carries", () => {
+    expect(toggleWarnings({ message: "Cowork disabled", warnings: ["a", "b"] })).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("returns [] for a clean report", () => {
+    expect(
+      toggleWarnings({ message: "Cowork enabled: 1 workspace(s) configured", warnings: [] }),
+    ).toEqual([]);
+  });
+
+  it("returns [] for a sidecar predating #1438, which resolves with a bare string", () => {
+    // The reason this function exists rather than a `.warnings` read at the
+    // call site: a desktop shell can be newer than the sidecar it launched, and
+    // `"…".warnings.length` throws inside the toggle handler — turning a
+    // successful enable into a red error banner.
+    expect(toggleWarnings("Cowork enabled: 1 workspace(s) configured")).toEqual([]);
+  });
+
+  it("returns [] rather than throwing for null, undefined and a missing key", () => {
+    expect(toggleWarnings(null)).toEqual([]);
+    expect(toggleWarnings(undefined)).toEqual([]);
+    expect(toggleWarnings({ message: "Cowork disabled" })).toEqual([]);
+    expect(toggleWarnings({ message: "x", warnings: "not an array" })).toEqual([]);
+  });
+
+  it("drops non-strings instead of stringifying them", () => {
+    // `String({})` renders "[object Object]" into a user-facing banner, which
+    // is worse than saying nothing.
+    expect(toggleWarnings({ message: "x", warnings: ["real", 7, null, {}, ""] })).toEqual(["real"]);
   });
 });

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -101,6 +101,7 @@ cowork-settings-undetected
 cowork-settings-unsupported
 cowork-toggle
 cowork-toggle-checkbox
+cowork-toggle-warnings
 cowork-vethernet-cidr
 cowork-workspace-report-{*}-{*}
 cowork-workspace-row-{*}-{*}


### PR DESCRIPTION
Closes #1438.

## The defect

`cowork_toggle_integration` has always encoded **degraded success** in its `Ok` arm as English folded into the success string. Every client call site awaited the invoke and threw the value away, and `withInvoke` then cleared the toast — so all of it rendered as an unqualified green success.

A user with three Cowork workspaces where two failed to install saw **"Enabled"** and a check badge. The failure existed only in a Tauri log they have no route to.

## The fix

The `Ok` payload is now `CoworkToggleReport { message, warnings }`.

Splitting the payload rather than teaching the client to read the message is the shape the issue proposed, and for the reason it gives: branching on message text would couple the client to Rust string literals, so a reworded warning would silently stop rendering — the same class of failure moved one layer out and made harder to see. `warnings` is never a failure channel; a rejected invoke is still the only way the command reports one.

### Three producers, one of which the issue did not list

| Path | Before |
|---|---|
| Enable, partial multi-workspace install | `log::warn!` only |
| Disable, firewall removal failed | folded into the success string |
| **Disable, partial uninstall** | `log::warn!` only |

The third is the same defect one line away from the one the issue names, so it is fixed here too.

`partial_workspace_warning` is a pure helper outside the `cfg(target_os = "windows")` gate so its tests run on every CI leg (precedent: `parse_netstat_listening_pid` and its siblings). It returns `None` for zero workspaces and for a clean pass, and is deliberately **not** the all-failed case — both toggle arms return `Err` before reaching it, because an operation that landed nowhere is a failure, not a degraded success. A test pins that the gate is the *caller*, so a refactor that routes all-failed through here has to make that decision on purpose rather than silently turning a hard failure into a green toast with a caveat.

### Client

`toggleWarnings()` reads the payload defensively, because **a desktop shell can be newer than the sidecar it launched**: a pre-#1438 sidecar resolves with a bare string, and `.warnings.length` on that throws inside the handler and turns a successful enable into a red error banner — worse than the silence this issue is about. Non-string entries are dropped rather than stringified, since `String({})` puts `[object Object]` in a user-facing banner.

The settings panel renders them in a `role="status"` block (`cowork-toggle-warnings`) — deliberately **not** the `role="alert"` error banner, because the operation committed and painting a caveat in an error's clothing is the opposite failure. The list is cleared at the **start** of each toggle rather than in `withInvoke`, so a toggle that throws leaves the error standing alone instead of beside caveats from the previous, successful run.

### Scope call worth reviewing

The three other call sites — `CoworkOnboardingStep`, `IntegrationWizardModal`, `CoworkAdminDeclinedModal` — deliberately **do not** render the warnings, and each now says so with its reason: all three leave or close on success, so a caveat shown there is discarded before it can be read, and the per-workspace facts behind it come back on every `cowork_get_status` as `WorkspaceStatus.fileStatus`, which the settings panel already renders (`CoworkSettings.svelte:430`).

If you'd rather those surfaces hold their navigation and show the caveat, that is a UX decision I did not want to make unilaterally — say the word and I'll add it.

## One mutation came back GREEN, and was right to

Replacing `toggleWarnings`' `typeof result !== "object"` guard with a bare null check changed **no** behaviour: property access on a string yields `undefined` and falls through to the `Array.isArray` gate. The guard was unreachable, so it is deleted rather than tested around, and the comment records why only `null` and `undefined` need the early return.

## Verification

- `npm run typecheck` — clean
- `biome check` — clean
- `cargo test` (Linux) — 133 + 16 + 4 + 1 pass, 0 fail, 1 ignored
- `npm test` — 7744 passed, 24 skipped
- `npm run test:e2e` — 358 passed, 11 skipped, exit 0

**Nine valid mutations, all RED** (each hash-guarded before and after):

| Mutation | Result |
|---|---|
| Handler discards the warnings (the original defect) | 2 failed |
| Banner never mounts | 3 failed |
| Drop the per-attempt reset | 1 failed |
| `role="alert"` instead of `role="status"` | 1 failed |
| Drop the non-string filter | 1 failed |
| Drop the null/undefined guard | 1 failed |
| Drop the `Array.isArray` gate | 1 failed |
| Helper always returns `None` | 3 failed |
| Firewall caveat loses the half that says why it is harmless | 1 failed |

One `data-testid` added, none removed; manifest and snapshot regenerated per Critical Rule 7.

## Interaction with open PRs

`cowork_toggle_integration`'s tail is also touched by #1559 (makes a failed meta persist fatal). The conflict is one hunk and mechanical: #1559 replaces the `Ok(format!(…))` line this PR turns into `Ok(CoworkToggleReport { … })`. Neither depends on the other's semantics.

## Unverified

The Windows call site is not compiled by a Linux `cargo test` — `lib.rs` is parsed but the cfg-gated arm is stripped before type-check. That falls to CI's `rust-test (windows-latest)` leg. The pure helper and the whole client half are exercised on every leg.

## Tier

**Not tier A** — adds a user-visible banner and a new testid. Needs a look on Windows hardware before merge, specifically that a real partial-install warning reads sensibly at the panel's width.

---
_Generated by [Claude Code](https://claude.ai/code/session_018DdaCvomDgPsumrDAmNH13)_