### PR TITLE
test(local-model): pin the run-scoped streamed write volume (#1292)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -154,7 +154,25 @@ Open as of v0.22.1:
 
 Still open from the v0.21.0 security gate, whose RC re-run failed on 2026-08-05 with two HIGH:
 
-- **#1292 — the last HIGH.** Its code fix shipped in v0.21.0, but it gates on the BYO-models flag flip rather than on the release, so the v0.21.0 changelog entry does not close it. Verify the issue state, not the changelog.
+- **#1292 — the last HIGH.** It gates on the BYO-models flag flip rather than on the release, so no changelog entry closes it. Verify the issue state, not the changelog — and read the state below before repeating either of the two wrong summaries this finding has already produced.
+
+  **"The v0.21.0 fix closed it" is wrong**, and the issue was very nearly closed on it. #1317's two caps (`MAX_STREAMED_CHARS` 64 KiB on the sink, `MAX_STREAMED_RESPONSE_BYTES` 4 MiB on the wire) *bounded* the amplification; they did not remove it. `updateClaudeChatMessage` still re-`set` the whole message value on every flush, so the cost stayed `O(n²)` — measured 2026-08-07 against a live ctrl `Y.Doc`: a 64 KiB reply cost **27 MB** of broadcast, and because the sink's cap resets on `onTurnEnd({ hadToolCalls: true })` while `maxTurns` defaults to 12, a model looping on tool calls reached **~86 MB** at 12 turns (worst case ~325 MB against the 5-minute deadline) — silently, with no truncation marker and no abort.
+
+  **"The 27 MB / 325 MB figures are current" is also wrong.** #1340 replaced the whole-value re-`set` with a minimal diff-splice into a per-message `Y.Text` in the `chatStream` sidecar, which is what actually made the class linear. Re-measured on master 2026-08-20, same rig:
+
+  | shape | content | ctrl update bytes | vs. 2026-08-07 |
+  |---|---|---|---|
+  | 1 turn, 2 KB | 2,000 | 2,214 (1.1×) | 33 KB |
+  | 1 turn, 16 KB | 16,384 | 37,378 (2.3×) | 1.7 MB |
+  | 1 turn, at the cap | 65,536 | 136,090 (2.1×) | 27 MB |
+  | 1 turn, 200 KB offered | 200,000 | 136,090 — capped, marker written, run aborted | — |
+  | 12 tool-call turns × 65 KB | 780,000 | 808,621 (1.0×) | 85.8 MB |
+
+  So the quadratic is gone and the per-turn reset costs ~0.8 MB per run rather than ~86 MB. **What has not changed is the shape**: the cap is still per-turn, and a tool-call turn still writes no marker and does not abort. That is bounded rather than a hole because `onTurnEnd({ hadToolCalls: true })` *discards* the turn's buffer — the content was preamble, the next turn replaces it, and the visible reply is one turn's worth whatever the turn count. A run-scoped *character* budget would therefore be the wrong instrument: it would count characters that were deliberately thrown away and truncate a legitimate agentic run.
+
+  **Whether the residual clears a HIGH is a re-decision, not a fact**, and it belongs to the same person who made the 2026-08-08 call — that call was recorded against 27 MB / 325 MB, which are now wrong by two orders of magnitude. `docs/roadmap.md`'s local-model gate turns on it. Nothing here is reachable in a shipped build: `BYO_MODELS_ENABLED` is a literal `const false` and `startLocalModelCollaborator()` early-returns before `wire()`.
+
+  **The write-volume assertions are the thing that keeps this fixed**, and they are why the numbers above cannot silently rot: `tests/server/local-model/collaborator.test.ts` pins single-turn cost at ≤12×L (#1340) and run-scoped tool-call-loop cost at ≤4× total content (#1292), both byte-shaped rather than wall-clock, plus a pin that a tool-call turn discards its buffer — the load-bearing half of the argument against a run-scoped budget. Each of those three regressions — reverting the sidecar primitive, disabling its prefix scan, making tool-call turns accumulate — turns one or more of them red, verified by hash-guarded mutation.
 
 Closed from that same gate: #1291 (CORS opaque-origin grant), #1293 (inverted loopback gate), #1294, and #1295 (the six-finding LOW batch).
 

--- a/tests/server/local-model/collaborator.test.ts
+++ b/tests/server/local-model/collaborator.test.ts
@@ -1219,4 +1219,95 @@ describe("collaborator — streamed write volume at the caller level (#1340)", (
     expect(bytes).toBeGreaterThan(L); // sanity: content was transmitted
     expect(bytes).toBeLessThanOrEqual(12 * L); // RED on master (~104×L)
   });
+
+  it("a tool-call-looping run costs O(total content), not O(per-turn²) × turns (#1292)", async () => {
+    // The path #1292's decision comment named as unanalysed, and the one the
+    // test above cannot reach: it ends its single turn with `hadToolCalls:
+    // false`, so it never crosses a turn boundary. `onTurnEnd({ hadToolCalls:
+    // true })` resets the sink's buffer and its cap counter, so the ramp
+    // restarts on every turn and `loop.ts` defaults `maxTurns` to 12 — which
+    // under the pre-#1340 whole-value re-`set` made the run-scoped cost
+    // `turns × O(perTurn²)` rather than `O(turns × perTurn)`.
+    //
+    // Measured here: 236,110 bytes for 196,608 chars of content — 1.2×, and
+    // stable to ~70 bytes across runs. The same shape on the whole-value
+    // primitive is ~32× (each turn re-sends every prefix: 512 + 1024 + … +
+    // 32768 per turn). The 4× ceiling sits between the two with room on both
+    // sides, and is byte-shaped rather than wall-clock because this box runs
+    // under load.
+    setupDoc("doc-loop-bytes", "Body");
+    const TURNS = 6;
+    const PER_TURN = 32_768;
+    const STEP = 512;
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          for (let turn = 0; turn < TURNS; turn++) {
+            for (let sent = 0; sent < PER_TURN; sent += STEP) {
+              opts.onContentDelta?.("x".repeat(STEP));
+              await new Promise((r) => setTimeout(r, 0));
+            }
+            // Every turn but the last ends WITH tool calls — the reset path.
+            opts.onTurnEnd?.({ hadToolCalls: turn < TURNS - 1 });
+          }
+          return cleanResult("");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+
+    const ctrl = getOrCreateDocument(CTRL_ROOM);
+    let bytes = 0;
+    const onUpdate = (u: Uint8Array) => {
+      bytes += u.byteLength;
+    };
+    ctrl.on("update", onUpdate);
+    try {
+      collab.onEvent(chatEvent("go", { documentId: "doc-loop-bytes" }));
+      await drain(collab);
+    } finally {
+      ctrl.off("update", onUpdate);
+    }
+
+    const content = TURNS * PER_TURN;
+    expect(bytes).toBeGreaterThan(PER_TURN); // sanity: content was transmitted
+    expect(bytes).toBeLessThanOrEqual(4 * content);
+  });
+
+  it("a tool-call turn discards its buffer, so no run-scoped budget is needed (#1292)", async () => {
+    // Why the per-turn cap reset is bounded rather than a hole, and why a
+    // run-scoped CHARACTER budget would be the wrong instrument: the content of
+    // a turn that ends in tool calls is preamble, and `onTurnEnd` throws it
+    // away so the next turn REPLACES it. The visible reply is one turn's worth
+    // whatever the turn count, and a run-scoped budget would be counting
+    // characters that were deliberately discarded — truncating a legitimate
+    // agentic run to pay for a cost the sidecar primitive already removed.
+    //
+    // Pinned because it is the load-bearing half of the argument: if a future
+    // change ever made tool-call turns ACCUMULATE, the run-scoped byte
+    // assertion above would still pass while the reply grew without a ceiling.
+    setupDoc("doc-loop-cap", "Body");
+    const PER_TURN = 40_000; // under the 64 KiB cap on its own; 3× is over it
+    const collab = createLocalModelCollaborator(
+      makeDeps({
+        runTurn: async (opts) => {
+          for (let turn = 0; turn < 3; turn++) {
+            opts.onContentDelta?.("x".repeat(PER_TURN));
+            await new Promise((r) => setTimeout(r, 0));
+            opts.onTurnEnd?.({ hadToolCalls: turn < 2 });
+          }
+          return cleanResult("");
+        },
+      }),
+    );
+    collab.__setConfigForTests(CONFIG);
+    collab.onEvent(chatEvent("go", { documentId: "doc-loop-cap" }));
+    await drain(collab);
+
+    const text = chatMessages()[0].text;
+    // Exactly the LAST turn — not 3×, and not truncated: the cap never tripped
+    // because no single turn reached it.
+    expect(text).toBe("x".repeat(PER_TURN));
+    expect(text).not.toContain("Reply truncated");
+  });
 });


### PR DESCRIPTION
Advances #1292. **No behaviour change** — this is a test and a correction to what the security register says about master.

#1292's 2026-08-08 decision named two things the code did not have: a run-scoped write-volume assertion, and an analysis of the per-turn cap reset. Both are here.

## The coverage gap was specific

The existing volume test (#1340, `a whole streamed run costs O(L) ctrl update bytes`) ends its single turn with `hadToolCalls: false`, so it never crosses a turn boundary — and the turn boundary is where the interesting cost lived. `onTurnEnd({ hadToolCalls: true })` resets the sink's buffer and its cap counter, `loop.ts` defaults `maxTurns` to 12, so under the pre-#1340 whole-value re-`set` a tool-call loop cost `turns × O(perTurn²)`. That is the ~86 MB (worst case ~325 MB) path the decision comment flagged as unanalysed, and no test could see it.

## Re-measured on master

Same rig as the decision comment — a live ctrl `Y.Doc`, counting `update` event bytes through the collaborator's real flush machinery, deltas delivered one macrotask per simulated chunk:

| shape | content | ctrl update bytes | 2026-08-07 |
|---|---|---|---|
| 1 turn, 2 KB | 2,000 | 2,214 (1.1×) | 33 KB |
| 1 turn, 16 KB | 16,384 | 37,378 (2.3×) | 1.7 MB |
| 1 turn, at the cap | 65,536 | 136,090 (2.1×) | 27 MB |
| 1 turn, 200 KB offered | 200,000 | 136,090 — capped, marker written, run aborted | — |
| 12 tool-call turns × 65 KB | 780,000 | 808,621 (1.0×) | 85.8 MB |

#1340's sidecar `Y.Text` diff-splice is what did it. #1317's caps *bounded* the amplification without removing it — which is the summary this finding has twice been closed and reopened over, and which `docs/security.md` was still asserting.

## Two assertions

- **Run-scoped bytes** — 6 tool-call turns × 32 KiB, ceiling `4 ×` total content. Measured 1.2× and stable to ~70 bytes across runs; the whole-value primitive is ~32× on the same shape, so the ceiling sits between them with room on both sides. Byte-shaped, never wall-clock.
- **A tool-call turn discards its buffer** — the load-bearing half of the argument that the per-turn reset is *bounded* rather than a hole, and the reason a run-scoped **character** budget would be the wrong instrument: it would count characters that were deliberately thrown away and truncate a legitimate agentic run. If tool-call turns ever started accumulating, the byte assertion alone would stay green while the reply grew without a ceiling.

## What has NOT changed

The cap is still per-turn, and a tool-call turn still writes no truncation marker and does not abort. That is now ~0.8 MB per run rather than ~86 MB, which is why this PR does not add a run-scoped budget: the instrument was proposed against numbers that #1340 has since moved by two orders of magnitude.

**Whether the residual clears a HIGH is a re-decision, not a fact** — it belongs to whoever made the 2026-08-08 call, and `docs/roadmap.md`'s local-model gate turns on it. Nothing here is reachable in a shipped build (`BYO_MODELS_ENABLED` is a literal `const false`; `startLocalModelCollaborator()` early-returns before `wire()`).

## Verification

Three hash-guarded mutations, all red, each naming the test it kills:

| mutation | result |
|---|---|
| revert `updateClaudeChatMessage` to the whole-value re-`set` | RED (3 tests, incl. the new run-scoped one) |
| disable its longest-common-prefix scan | RED (both byte tests) |
| remove the tool-call buffer discard | RED (5 tests, incl. the new discard pin) |

`npm run typecheck` clean; biome clean; full vitest 7736 passed / 24 skipped. No E2E — test-only, plus a doc.

`docs/security.md`'s #1292 entry now carries both wrong summaries it has produced, the measured table, what has not changed, and the note that the residual-severity question is a re-decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_018DdaCvomDgPsumrDAmNH13)_