### PR TITLE
fix(a11y): expose which rail panel is selected to assistive tech (#1452)

### DIFF
--- a/docs/a11y-gate-results.md
+++ b/docs/a11y-gate-results.md
@@ -148,6 +148,22 @@ Four real defects, all found by the suite failing first:
    30s. Fixed with a longer timeout, **not** retries — retries would also have
    masked the flake class the file guards.
 
+> **Amendment 2026-08-20 (#1452).** An **eighth** test was added to this file:
+> *"the rail's panel switcher exposes which panel is selected"*. The counts above
+> are left at their 2026-08-05 values because this table records that run.
+>
+> The gap it closes is the same class as defect 1 — correct markup that an axe
+> scan cannot fault. The right rail's Annotations/Chat switcher distinguished the
+> active panel with a CSS class and nothing else, so a screen reader announced two
+> identically-shaped buttons with no selected state between them. axe reports no
+> violation for that: an unmarked button is valid markup, just uninformative.
+>
+> Fixed with `aria-current="page"` on the active button, following the Settings
+> sidebar switcher (`SettingsModal.svelte`) rather than the APG tabs pattern —
+> `role="tab"` obliges a roving tabindex, which would take one of the two buttons
+> out of the tab order and is a keyboard behaviour change rather than an additive
+> fix. #1452 records the full pattern as still available if it is ever wanted.
+
 ## A6 — WCAG AA contrast
 
 Two suites, because axe alone cannot answer the criterion as written. axe

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -2668,8 +2668,15 @@ const shouldShowModelPicker = $derived(
           {@render edgeCollapse("right", toggleRightPanel)}
           <div class="rail-tabs-row">
             <div class="rail-tabs-track">
+              <!-- `aria-current` rather than role="tab"/aria-selected: this mirrors
+                   the Settings sidebar switcher (SettingsModal.svelte), which is the
+                   same shape — plain buttons that swap which always-mounted panel is
+                   displayed. role="tab" would oblige the APG pattern's roving
+                   tabindex, taking one of these two buttons out of the tab order;
+                   that is a keyboard behaviour change, not an additive fix. See #1452. -->
               <button
                 data-testid="annotations-tab"
+                aria-current={activeRailTab === "annotations" ? "page" : undefined}
                 class={"rail-tab" + (activeRailTab === "annotations" ? " on" : "")}
                 onclick={() => selectRailTab("annotations")}
               >
@@ -2682,6 +2689,7 @@ const shouldShowModelPicker = $derived(
               </button>
               <button
                 data-testid="chat-tab"
+                aria-current={activeRailTab === "chat" ? "page" : undefined}
                 class={"rail-tab" + (activeRailTab === "chat" ? " on" : "")}
                 onmousedown={captureSelectionForChat}
                 onclick={() => selectRailTab("chat")}

--- a/tests/e2e/keyboard-a11y.spec.ts
+++ b/tests/e2e/keyboard-a11y.spec.ts
@@ -236,3 +236,63 @@ test("brand menu returns focus to its trigger when dismissed from outside", asyn
   expect(parked, "focus was stranded on <body> after an outside dismiss").toBe(false);
   expect(await focusId(page)).toBe("titlebar-brand-menu");
 });
+
+// ---------------------------------------------------------------------------
+// Selected-ness of the rail's panel switcher (#1452)
+// ---------------------------------------------------------------------------
+
+/**
+ * Which rail panel you are on was conveyed by an `on` class and nothing else, so
+ * a screen reader announced two identically-shaped buttons. `aria-current` is the
+ * signal; this asserts it TRACKS the selection rather than merely existing.
+ *
+ * Both halves are load-bearing and neither implies the other: a hard-coded
+ * attribute passes the "active tab has it" check forever, and an attribute that
+ * is never set passes the "inactive tab lacks it" check forever. Asserting the
+ * pair on both tabs, before and after a switch, is what pins the binding.
+ *
+ * This deliberately does NOT assert `role="tab"`. The switcher follows the
+ * Settings sidebar's plain-button + `aria-current` shape; adopting the APG tabs
+ * pattern would oblige a roving tabindex, which is a keyboard behaviour change.
+ * If that is ever adopted, this test SHOULD fail and be rewritten — it is
+ * pinning the current contract, not forbidding a better one.
+ */
+test("the rail's panel switcher exposes which panel is selected", async ({ page }) => {
+  await boot(page);
+
+  const annotations = page.locator("[data-testid='annotations-tab']");
+  const chat = page.locator("[data-testid='chat-tab']");
+
+  // Three-panel layout renders both panels side by side with static headers and
+  // no tab buttons at all (see `switchToAnnotationsTab` in helpers.ts). Skip
+  // rather than fail, so a layout-mode default change does not read as an a11y
+  // regression.
+  if ((await annotations.count()) === 0) {
+    test.skip(true, "tabbed rail layout is not active; there is no switcher to assert on");
+  }
+
+  await expect(annotations).toBeVisible({ timeout: 5_000 });
+  await expect(chat).toBeVisible({ timeout: 5_000 });
+
+  // Which tab starts active follows the user's `primaryTab` setting, so this
+  // asserts the INVARIANT (exactly one is marked) rather than naming a winner.
+  // Both failure modes it catches are real: nothing marked leaves a screen
+  // reader with no selection at all, and both marked is worse than neither.
+  const marked = async () =>
+    await page
+      .locator(
+        "[data-testid='annotations-tab'][aria-current], [data-testid='chat-tab'][aria-current]",
+      )
+      .count();
+  expect(await marked(), "exactly one rail tab should be marked current").toBe(1);
+
+  await chat.click();
+  await expect(page.locator("[data-testid='chat-panel']")).toBeVisible({ timeout: 5_000 });
+  await expect(chat).toHaveAttribute("aria-current", "page");
+  await expect(annotations).not.toHaveAttribute("aria-current", /.*/);
+
+  // And back — a one-way binding would survive everything above.
+  await annotations.click();
+  await expect(annotations).toHaveAttribute("aria-current", "page");
+  await expect(chat).not.toHaveAttribute("aria-current", /.*/);
+});


### PR DESCRIPTION
Closes #1452.

## The defect

The right rail's Annotations/Chat switcher renders as two bare `<button>`s whose only difference is an appended `on` class. No `role`, no `aria-selected`, no `aria-current` — so which panel you are on was conveyed by CSS and nothing else, and a screen reader announced two identically-shaped buttons.

#1382 removed the words "Annotations" and "Chat" from the two panel headers on the premise that the tab above already says which panel you are on. That premise is **true visually and false programmatically**, which is what makes this worth closing rather than leaving as a latent nicety. The panels stay individually named, so nothing is unnamed today; what was missing is *selected-ness*.

## The fix, and why it is not the APG tabs pattern

`aria-current="page"` on the active button. Two lines, plus the comment carrying the argument.

The issue framed this as a choice between the full APG tabs pattern and a smaller intermediate step. **It turned out to be a consistency question rather than a design one**: the Settings sidebar switcher (`SettingsModal.svelte:640`) is the same shape — plain buttons inside a container, swapping which always-mounted panel is displayed — and already uses exactly this attribute. Following it makes the two switchers agree instead of introducing a third convention.

`role="tab"` would additionally oblige the pattern's roving tabindex, which takes one of the two buttons out of the tab order. That is a keyboard behaviour change, not an additive fix, and it is the one thing the issue explicitly flagged as needing a decision. **If the full pattern is wanted, this is a reopen, not a rework** — the attribute added here is a strict subset of what that pattern would need.

Not adopted, and deliberately so:

- **`aria-controls`** — `role="tab"` implies the panel is a `tabpanel` it controls. Both panels are always mounted and toggled by CSS `display`, so `aria-controls` would point at a node that is in the DOM but `display: none`. The issue names this as needing confirmation before relying on it; nothing here relies on it.
- **`role="tablist"` on the track** — would then require `role="tab"` children, or `aria-required-children` fires.

## The test

An eighth test in `tests/e2e/keyboard-a11y.spec.ts` (the a11y **behaviour** spec; `accessibility.spec.ts` is a pure axe-scan surface loop and a behavioural assertion would be off-shape there).

**Proved load-bearing rather than assumed.** Hash-guarded, with the `App.svelte` change reverted:

| `App.svelte` sha | Result |
|---|---|
| `2d96081c` (fixed) | 1 passed (19.0s) |
| `3f583265` (reverted) | **1 failed** — `exactly one rail tab should be marked current`, `Received: 0` |

`Received: 0` is the defect itself: no tab marked at all. Restored to byte-identical `2d96081c` afterwards.

Three things about its shape:

- **It asserts the invariant, not a winner.** Which tab starts active follows the user's `primaryTab` setting, so naming one would encode a settings default as an a11y contract. Both failure modes the invariant catches are real: nothing marked leaves a screen reader with no selection at all, and both marked is worse than neither.
- **The switch is driven in both directions.** A one-way binding would survive a single click.
- **`role="tab"` is deliberately not asserted.** If the APG pattern is ever adopted this test *should* fail and be rewritten; it pins the current contract rather than forbidding a better one, and the docstring says so.

It skips rather than fails in three-panel layout, where both panels render side by side with static headers and no tab buttons exist at all (see `switchToAnnotationsTab` in `helpers.ts`) — a layout-mode default change should not read as an a11y regression.

## Docs

`docs/a11y-gate-results.md` gets a **dated amendment, not an edited count**. Its A5 row records the 2026-08-05 gate run and enumerates "Seven tests"; retroactively changing that to eight would assert something false about that run. The amendment notes the eighth test beneath it and records why the gap survived the original audit — the same class as A5's defect 1: correct markup that an axe scan cannot fault, because an unmarked button is valid, just uninformative.

## Gates

| Gate | Result |
|---|---|
| `npx biome check` | clean |
| `npm run typecheck` | exit 0 — 1341 files, 0 errors, 0 warnings |
| `accessibility.spec.ts` + `keyboard-a11y.spec.ts` | **56 passed (3.4m)**, exit 0 |
| `npx vitest --run` (full) | **7734 passed, 24 skipped, 0 failed** |
| `cargo test` | 126 + 16 + 4 + 1 pass, 0 fail, 1 ignored |
| pre-push hook (biome + full vitest + `cargo test`) | passed |

The axe run is the load-bearing one for the added attribute: `aria-current` is a global ARIA attribute, and the 45-surface scan confirms no `aria-allowed-attr` finding on either button across all three themes.

## Unverified

- **No screen-reader walkthrough.** A1/A2 in `docs/a11y-gate-results.md` are still recorded as unrun and need a human at a real OS. This change makes the *input* correct — the DOM now carries the selected state — but whether the resulting announcement reads well in Narrator or VoiceOver is not derivable from the DOM, and nothing here should be read as evidence about it.
- No visual change of any kind, so there is nothing to look at in a browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_018DdaCvomDgPsumrDAmNH13)_