### PR TITLE
docs: record the v0.24.0 release and its smoke run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,9 +241,9 @@ Mechanism, ops and failure modes: [docs/licensing-explained.md](docs/licensing-e
 
 ## Status
 
-**Shipped: v0.23.0** (2026-08-18). Release history is [CHANGELOG.md](CHANGELOG.md); remaining
+**Shipped: v0.24.0** (2026-08-21). Release history is [CHANGELOG.md](CHANGELOG.md); remaining
 v1.0 work is [docs/roadmap.md](docs/roadmap.md#active--toward-v10); what the last smoke run
-settled is in [docs/release-smoke-checklist.md](docs/release-smoke-checklist.md#what-the-v0230-run-settled).
+settled is in [docs/release-smoke-checklist.md](docs/release-smoke-checklist.md#what-the-v0240-run-settled).
 **Do not re-narrate any of them here.**
 
 Core is complete — 29 active MCP tools, multi-doc tabs, CRDT-anchored annotations, chat, four

--- a/docs/release-smoke-checklist.md
+++ b/docs/release-smoke-checklist.md
@@ -104,6 +104,43 @@ Note the outcome (platforms covered, anything skipped, anything found) in a
 comment on the release's tracking issue or the release PR. A skipped platform
 is fine when stated; an unstated skip reads as "verified" and isn't.
 
+## What the v0.24.0 run settled
+
+v0.24.0 (2026-08-21). §0 and §4 executed and passed on Windows 11 Pro (26200);
+**§1 Windows desktop was not run, and §2 macOS / §3 Linux were skipped for want of
+hardware.** The full record is on PR #1586. §1 is the consequential gap this time
+rather than §2: the updater row is the only check that can catch #1118's
+false-positive mode, where the "Tandem may not have finished updating" banner fires
+after a *successful* update. That banner is new in this release, and if it misfires
+it reaches every user at once.
+
+Three things this run established:
+
+- **The Windows signing leg is a real flake vector, and its failure carries no
+  diagnosis.** `sign.exe` (Azure Trusted Signing) failed on `tandem-reaper`
+  immediately after signing `node-sidecar` in the same job. tauri swallows the tool's
+  output, so the log says only ``failed to run …\sign.exe`` — nothing about auth,
+  quota or throttling. What made "transient" the right call rather than a guess was
+  the *diff*: nothing in `v0.23.0..HEAD` touched `tauri-release.yml`,
+  `tauri.conf.json` or the signing config, and the same leg was green at v0.23.0. A
+  single `gh run rerun --failed` passed. **A second occurrence makes "transient" the
+  wrong diagnosis** — at that point capture `sign.exe`'s own output before re-running.
+- **A failed leg leaves a partial draft that looks ordinary.** The draft sat at 13
+  assets with `release-check` red and `verify-release-manifest` *skipped* — and a
+  skipped verifier is not a failing one, so nothing in the run summary shouts. The
+  asset count is the tell, which is why the manual 1-release / 17-assets / 11-keys
+  confirmation is worth keeping even now that `create-release` made the split-draft
+  race structural.
+- **§4's boot log is worth reading, not just its exit code.** `doctor` exited 0 with
+  no FAIL while the server had already logged
+  `integrations.json schemaVersion 4 is newer than this Tandem build supports (3)`
+  and disabled the launcher supervisor. That one traced to a **paused, unmerged
+  branch** (`db14a9b`, #1265 Codex) that wrote the file on 2026-08-04 —
+  `INTEGRATIONS_SCHEMA_VERSION` has been `3` since it was introduced and no shipped
+  path writes `4` — so it is local residue and the forward-compat guard behaved
+  correctly. But `doctor` has no row for it, so the exit code alone would have
+  reported a degraded launcher as clean.
+
 ## What the v0.23.0 run settled
 
 v0.23.0 (2026-08-18). §1 and §4 executed on Windows 11 Pro (26200); §0 and §3 are


### PR DESCRIPTION
Post-release follow-up to #1586, matching the v0.23.0 pattern (bump PR, then status PR).

- `CLAUDE.md` **Status** now reads v0.24.0 and points at the new smoke section.
- `docs/release-smoke-checklist.md` gains **What the v0.24.0 run settled**.

The smoke section names **§1 Windows desktop** as this release's consequential gap rather than the usual §2 macOS one. §1's updater row is the only check that can catch #1118's false-positive mode — the "Tandem may not have finished updating" banner firing after a *successful* update. That banner is new in v0.24.0, and a misfire reaches every user simultaneously.

Three findings carried forward:

- **Windows Trusted Signing failed once with no diagnosis.** `sign.exe` failed on `tandem-reaper` seconds after signing `node-sidecar` in the same job, and tauri swallows the tool's output. What made "transient" a call rather than a guess was the diff — nothing in `v0.23.0..HEAD` touched `tauri-release.yml`, `tauri.conf.json` or the signing config, and the leg was green at v0.23.0. A single `--failed` re-run passed. The section says plainly that a second occurrence makes that diagnosis wrong.
- **A failed leg leaves a partial draft that looks ordinary.** 13 assets, `release-check` red, and `verify-release-manifest` reporting **skipped** — a skipped verifier is not a failing one. The asset count is the tell, which is why the manual 1-release / 17-assets / 11-keys confirmation earns its place even after `create-release` made the split-draft race structural.
- **§4's exit code is not the whole signal.** `tandem doctor` exited 0 with no `[FAIL]` while the server had already logged `integrations.json schemaVersion 4 is newer than this Tandem build supports (3)` and disabled its launcher supervisor. That traced to `db14a9b` — the paused, unmerged Codex branch (#1265) — writing the file on 2026-08-04; `INTEGRATIONS_SCHEMA_VERSION` has been `3` since introduction and no shipped path writes `4`, so the guard behaved correctly. But `doctor` has no row for it, so the exit code alone reports a degraded launcher as clean.

Docs only. `npx vitest run tests/docs` green (15 files, 110 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ix39E9oguyfF6RP8zp6Cr