### PR TITLE
fix(session): keep a restored document read-only

### DIFF
--- a/src/server/mcp/document-service.ts
+++ b/src/server/mcp/document-service.ts
@@ -1653,9 +1653,12 @@ export async function restoreOpenDocuments(previousActiveDocId: string | null): 
   if (sessions.length === 0) return 0;
 
   let restoredCount = 0;
-  for (const { filePath } of sessions) {
+  for (const { filePath, readOnly } of sessions) {
     try {
-      await openFileByPath(filePath);
+      // Carry the persisted read-only flag back through: without it every
+      // restored document takes `resolveAndValidatePath`'s hardcoded `false`,
+      // and a read-only tab (View Changelog) comes back writable.
+      await openFileByPath(filePath, { readOnly });
       restoredCount++;
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;

--- a/src/server/session/manager.ts
+++ b/src/server/session/manager.ts
@@ -8,6 +8,8 @@ import {
   Y_MAP_CHAT,
   Y_MAP_CHAT_DOCUMENT_NAMES,
   Y_MAP_CHAT_STREAM,
+  Y_MAP_DOCUMENT_META,
+  Y_MAP_READ_ONLY,
 } from "../../shared/constants.js";
 import { withInternal } from "../../shared/origins.js";
 import { isUploadPath } from "../../shared/paths.js";
@@ -43,6 +45,20 @@ export function sessionKey(filePath: string): string {
  * caller writes the session BEFORE clearing the flag, so a self-read would
  * persist a conflict the save just resolved and re-raise a banner on a clean,
  * in-sync document.
+ *
+ * `readOnly` is the mirror-image decision: derived HERE off `doc`, never an
+ * option — because it is a different KIND of flag from the two above. `dirty`
+ * and `conflict` are point-in-time snapshots of a save race that only the
+ * caller can take. `readOnly` is static document metadata that `writeDocMeta`
+ * already mirrors into the Y.Map in lockstep with the open-docs registry on
+ * every open path, so there is no moment at which caller and doc disagree.
+ *
+ * Given that, deriving once here is the safer half of the trade: `saveSession`
+ * rewrites the whole record with no merge, and two call sites
+ * (`document-service`'s save-all and the 60s autosave tick) are unconditional
+ * loops over every open document — so a tenth call site that forgot to pass the
+ * flag would not merely fail to set it, it would erase a correct value on a
+ * timer.
  */
 export async function saveSession(
   filePath: string,
@@ -65,6 +81,8 @@ export async function saveSession(
   const state = Y.encodeStateAsUpdate(doc);
   const ydocState = Buffer.from(state).toString("base64");
 
+  const readOnly = doc.getMap(Y_MAP_DOCUMENT_META).get(Y_MAP_READ_ONLY) === true;
+
   const data: SessionData = {
     filePath,
     format,
@@ -74,6 +92,9 @@ export async function saveSession(
     modelRevision: DOCUMENT_MODEL_REVISION,
     ...(opts?.dirty ? { dirty: true } : {}),
     ...(opts?.conflict ? { conflict: opts.conflict } : {}),
+    // Conditional spread, not `readOnly`, so a writable document's record stays
+    // byte-identical to the shape it had before this field existed.
+    ...(readOnly ? { readOnly: true } : {}),
   };
 
   if (!sessionDirReady) {
@@ -438,12 +459,12 @@ export function restoreCtrlDoc(doc: Y.Doc, base64State: string): void {
  * Returns file paths sorted by most recently accessed first.
  */
 export async function listSessionFilePaths(): Promise<
-  Array<{ filePath: string; lastAccessed: number }>
+  Array<{ filePath: string; lastAccessed: number; readOnly: boolean }>
 > {
   try {
     await fs.mkdir(SESSION_DIR, { recursive: true });
     const files = await fs.readdir(SESSION_DIR);
-    const results: Array<{ filePath: string; lastAccessed: number }> = [];
+    const results: Array<{ filePath: string; lastAccessed: number; readOnly: boolean }> = [];
 
     for (const file of files) {
       if (!file.endsWith(".json")) continue;
@@ -468,7 +489,17 @@ export async function listSessionFilePaths(): Promise<
           console.error(`[Tandem] Omitting session ${file} from restore list: ${unsafe}`);
           continue;
         }
-        results.push({ filePath: data.filePath, lastAccessed: data.lastAccessed ?? 0 });
+        results.push({
+          filePath: data.filePath,
+          lastAccessed: data.lastAccessed ?? 0,
+          // Strict `=== true`, same don't-trust-a-bare-`JSON.parse` rule as
+          // `narrowConflict`: this value comes off disk and decides whether the
+          // restored tab is writable, so `"true"`, `1` or `{}` must all restore
+          // writable rather than truthily locking a document the user can edit.
+          // Absent → false, which is every record written before this field
+          // existed, and every writable document today.
+          readOnly: data.readOnly === true,
+        });
       } catch (err) {
         console.error(`[Tandem] Skipping unreadable session file ${file}:`, err);
       }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -456,6 +456,31 @@ export interface SessionData {
    * field existed, which is exactly the population that needs discarding.
    */
   modelRevision?: number;
+  /**
+   * True when the document was open read-only at session-save time — the
+   * upgrade changelog and Settings → View Changelog / View Documentation paths.
+   * Without it a read-only tab comes back
+   * writable after a restart, because the restore path takes the derived default
+   * (`resolveAndValidatePath` hardcodes `false`) and `writeDocMeta` deliberately
+   * tombstones any session-persisted `readOnly` in `documentMeta` so a stale Y.Map
+   * value can never outvote the caller. The flag therefore has to travel as session
+   * metadata, not as CRDT state.
+   *
+   * Unlike `dirty` and `conflict` above, this is derived inside `saveSession`
+   * rather than passed by callers; the reasoning for the asymmetry lives on
+   * that function.
+   *
+   * Persisting this deliberately makes read-only sticky. Before it, restarting
+   * silently downgraded a read-only tab to writable — which is the bug, since
+   * the autosave gates stop protecting the file — but that accident was also
+   * the only way back to editable, and read-only is otherwise a one-way door
+   * (`openFileByPath` only upgrades; `handleAlreadyOpen` never downgrades).
+   * Accepted knowingly; an explicit downgrade affordance is #1590.
+   *
+   * Absent means false — that is the shape of every record written before this
+   * field existed, and of every writable document today.
+   */
+  readOnly?: boolean;
 }
 
 /**

--- a/tests/server/session-readonly-restore.test.ts
+++ b/tests/server/session-readonly-restore.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Read-only survives a session restore.
+ *
+ * A document opened read-only (Settings → View Changelog) came back writable
+ * after a restart: `SessionData` had no `readOnly` field, `listSessionFilePaths`
+ * projected the record to `{filePath, lastAccessed}`, and `restoreOpenDocuments`
+ * called `openFileByPath(filePath)` with no options — so every restored document
+ * took `resolveAndValidatePath`'s hardcoded `readOnly = false`.
+ *
+ * The flag cannot be recovered from the persisted `ydocState`: `writeDocMeta`
+ * deliberately tombstones and overwrites `documentMeta.readOnly` on every open so
+ * a stale session's Y.Map clock can never outvote the caller. It has to travel as
+ * session metadata instead, derived inside `saveSession` off the `doc` argument.
+ *
+ * Covered here:
+ *  - round-trip: a read-only document's session records `readOnly: true`, and a
+ *    writable one's record stays byte-identical to the pre-fix shape;
+ *  - a legacy record (field absent) restores writable;
+ *  - a record whose `readOnly` is a non-boolean truthy value restores writable —
+ *    the `=== true` narrowing, same don't-trust-`JSON.parse` rule as
+ *    `narrowConflict`;
+ *  - autosave refuses to write a restored read-only document back to disk.
+ */
+
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/server/platform", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/server/platform")>();
+  const osMod = await import("os");
+  const pathMod = await import("path");
+  const cryptoMod = await import("crypto");
+  const appDataDir = pathMod.join(
+    osMod.tmpdir(),
+    `tandem-test-readonly-restore-${cryptoMod.randomUUID()}`,
+  );
+  process.env.TANDEM_APP_DATA_DIR = appDataDir;
+  return {
+    ...original,
+    SESSION_DIR: pathMod.join(appDataDir, "sessions"),
+  };
+});
+
+// The real watcher would leave fs handles open across the suite.
+vi.mock("../../src/server/file-watcher", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/server/file-watcher")>()),
+  watchFile: vi.fn(),
+  suppressNextChange: vi.fn(),
+}));
+
+import * as Y from "yjs";
+import { markDirty, resetForTesting as resetDirtyState } from "../../src/server/documents/dirty.js";
+import {
+  autoSaveAllToDisk,
+  getOpenDocs,
+  restoreOpenDocuments,
+} from "../../src/server/mcp/document-service.js";
+import { openFileByPath } from "../../src/server/mcp/file-opener.js";
+import { SESSION_DIR } from "../../src/server/platform.js";
+import { listSessionFilePaths, saveSession, sessionKey } from "../../src/server/session/manager.js";
+import { getOrCreateDocument } from "../../src/server/yjs/provider.js";
+import { withBrowser } from "../../src/shared/origins.js";
+import type { SessionData } from "../../src/shared/types.js";
+import { clearOpenDocs } from "../helpers/doc-service.js";
+
+let tmpDir: string;
+
+async function writeFixture(name: string, body: string): Promise<string> {
+  const p = path.join(tmpDir, name);
+  await fs.writeFile(p, body, "utf-8");
+  return p;
+}
+
+/** Write the session for an already-open document, the way the 60s tick does. */
+async function saveOpenedSession(
+  filePath: string,
+  opened: { documentId: string; format: string },
+): Promise<void> {
+  await saveSession(filePath, opened.format, getOrCreateDocument(opened.documentId));
+}
+
+/** Simulate the restart: drop all in-memory state, then restore from disk. */
+async function restoreFresh(): Promise<number> {
+  clearOpenDocs();
+  return restoreOpenDocuments(null);
+}
+
+/** The restored open-docs registry entry for `filePath`, if it came back. */
+function stateFor(filePath: string) {
+  return [...getOpenDocs().values()].find((d) => d.filePath === filePath);
+}
+
+async function readSessionRecord(filePath: string): Promise<SessionData> {
+  const raw = await fs.readFile(path.join(SESSION_DIR, `${sessionKey(filePath)}.json`), "utf-8");
+  return JSON.parse(raw) as SessionData;
+}
+
+/** Overwrite a session record's `readOnly` with an arbitrary (untrusted) value. */
+async function tamperReadOnly(filePath: string, value: unknown): Promise<void> {
+  const sessionPath = path.join(SESSION_DIR, `${sessionKey(filePath)}.json`);
+  const record = JSON.parse(await fs.readFile(sessionPath, "utf-8")) as Record<string, unknown>;
+  if (value === undefined) delete record.readOnly;
+  else record.readOnly = value;
+  await fs.writeFile(sessionPath, JSON.stringify(record), "utf-8");
+}
+
+beforeEach(async () => {
+  clearOpenDocs();
+  resetDirtyState();
+  vi.clearAllMocks();
+  await fs.mkdir(SESSION_DIR, { recursive: true });
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tandem-readonly-restore-"));
+});
+
+afterEach(async () => {
+  clearOpenDocs();
+  // Each test owns the whole session dir — wipe it so listSessionFilePaths in
+  // the next test sees only what that test wrote.
+  await fs.rm(SESSION_DIR, { recursive: true, force: true }).catch(() => {});
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+});
+
+describe("read-only survives a session restore", () => {
+  it("records readOnly:true for a read-only document and restores it read-only", async () => {
+    const filePath = await writeFixture("changelog.md", "# Changelog\n\nEntry.\n");
+    const opened = await openFileByPath(filePath, { readOnly: true });
+    expect(opened.readOnly).toBe(true);
+
+    await saveOpenedSession(filePath, opened);
+
+    expect((await readSessionRecord(filePath)).readOnly).toBe(true);
+
+    const listed = await listSessionFilePaths();
+    const entry = listed.find((r) => r.filePath === filePath);
+    expect(entry?.readOnly).toBe(true);
+
+    expect(await restoreFresh()).toBe(1);
+    expect(stateFor(filePath)?.readOnly).toBe(true);
+  });
+
+  it("leaves a writable document's record byte-identical to the pre-fix shape", async () => {
+    const filePath = await writeFixture("notes.md", "# Notes\n\nBody.\n");
+    const opened = await openFileByPath(filePath);
+    expect(opened.readOnly).toBe(false);
+
+    await saveOpenedSession(filePath, opened);
+
+    const record = (await readSessionRecord(filePath)) as Record<string, unknown>;
+    // Absent, not `false`: the conditional spread is what keeps clean records
+    // identical to what shipped before the field existed.
+    expect("readOnly" in record).toBe(false);
+    expect(Object.keys(record).sort()).toEqual(
+      [
+        "filePath",
+        "format",
+        "lastAccessed",
+        "modelRevision",
+        "sourceFileMtime",
+        "ydocState",
+      ].sort(),
+    );
+  });
+
+  it("restores a legacy record (no readOnly field) writable", async () => {
+    const filePath = await writeFixture("legacy.md", "# Legacy\n\nBody.\n");
+    const opened = await openFileByPath(filePath, { readOnly: true });
+    await saveOpenedSession(filePath, opened);
+    // Strip the field to reproduce a record written before it existed.
+    await tamperReadOnly(filePath, undefined);
+
+    const entry = (await listSessionFilePaths()).find((r) => r.filePath === filePath);
+    expect(entry?.readOnly).toBe(false);
+
+    await restoreFresh();
+    expect(stateFor(filePath)?.readOnly).toBe(false);
+  });
+
+  it.each([
+    ['the string "true"', "true"],
+    ["the number 1", 1],
+    ["an object", {}],
+  ])("restores writable when readOnly is %s off disk", async (_label, value) => {
+    const filePath = await writeFixture("tampered.md", "# Tampered\n\nBody.\n");
+    const opened = await openFileByPath(filePath, { readOnly: true });
+    await saveOpenedSession(filePath, opened);
+    await tamperReadOnly(filePath, value);
+
+    const entry = (await listSessionFilePaths()).find((r) => r.filePath === filePath);
+    expect(entry?.readOnly).toBe(false);
+
+    await restoreFresh();
+    expect(stateFor(filePath)?.readOnly).toBe(false);
+  });
+
+  it("autosave refuses to write a restored read-only document to disk", async () => {
+    const original = "# Changelog\n\nOriginal.\n";
+    const filePath = await writeFixture("autosave.md", original);
+    const opened = await openFileByPath(filePath, { readOnly: true });
+    await saveOpenedSession(filePath, opened);
+
+    resetDirtyState();
+    await restoreFresh();
+
+    const state = stateFor(filePath);
+    expect(state).toBeDefined();
+    // Dirty it so the readOnly guard — not the #851 not-dirty skip — is what
+    // has to stop the write.
+    const restoredDoc = getOrCreateDocument(state!.id);
+    withBrowser(restoredDoc, () => {
+      const fragment = restoredDoc.getXmlFragment("default");
+      const p = new Y.XmlElement("paragraph");
+      const t = new Y.XmlText();
+      p.insert(0, [t]);
+      fragment.insert(fragment.length, [p]);
+      t.insert(0, "edit that must never reach disk");
+    });
+    markDirty(state!.id);
+
+    await autoSaveAllToDisk();
+
+    expect(await fs.readFile(filePath, "utf-8")).toBe(original);
+  });
+});


### PR DESCRIPTION
A document opened read-only came back writable after a restart. Found by hand during the v0.24.0 Windows release smoke: Settings → Changelog opens with an `RO` badge and a "Review Only" chip, tray Quit, relaunch — the tab returns with neither, and accepts typed input.

That matters because `OpenDoc.readOnly` is what the server-side autosave gates key on (`document-service.ts:298`, `:651`, `:935`). After a restore the field was `false`, so the protection that keeps autosave from round-tripping `CHANGELOG.md` through `remark-stringify` simply wasn't there. `workflows.md` was worse off than `CHANGELOG.md`: the upgrade path at `index.ts:609` re-applies the flag to CHANGELOG on a version change, so it self-heals on the next upgrade, while nothing ever re-applies `workflows.md`'s.

## Why three changes and not one

The flag was dropped three separate times, so fixing only the visible one would have left it broken:

1. `SessionData` had no `readOnly` field, so `saveSession` never recorded it.
2. `listSessionFilePaths` projected each record down to `{filePath, lastAccessed}` — dropped at the listing layer even if it had been stored.
3. `restoreOpenDocuments` called `openFileByPath(filePath)` with no options, so every restored document took the derived default that `resolveAndValidatePath` hardcodes to `false`.

It also can't be recovered from the persisted `ydocState`, even though `documentMeta.readOnly` is inside that blob: `writeDocMeta` (`file-opener.ts:1456`) deliberately tombstones and overwrites it on every restore so a stale session value can never outvote the caller. That tombstone is correct and stays; the flag travels as session metadata beside it.

## The one design decision worth reviewing

`saveSession` derives the value itself rather than accepting it as an option, which is deliberately unlike the neighbouring `dirty` and `conflict`.

Those two are point-in-time snapshots of a save race that only the caller can take — the `conflict` rationale already written on `saveSession` explains that a self-read would persist a conflict the save just resolved. `readOnly` has no such race: it is static document metadata that `writeDocMeta` already mirrors into the Y.Map in lockstep with the open-docs registry on every open path.

Given that, deriving once is the safer half of the trade. `saveSession` rewrites the whole record with no merge, and two of its call sites (`document-service.ts:1560` and the 60-second tick at `file-opener.ts:1922`) are unconditional loops over every open document. A tenth call site that forgot to pass the flag would not merely fail to set it — it would erase a correct value on a timer.

Read off the `doc` argument rather than the registry because `saveSession` receives no `docId`.

The value is narrowed with `=== true` on the way back in, following `narrowConflict`: this is the first `readOnly` whose source is disk written by a *previous process* rather than live in-process intent, and `loadSession` is a bare `JSON.parse` with no schema validation.

## Accepted trade

Persisting the flag makes read-only sticky. Read-only is otherwise a one-way door — `openFileByPath` only upgrades (`:131`), `handleAlreadyOpen` never downgrades (`:742`) — so restarting was the only way back to editable, and that accident is exactly the bug being fixed. Accepted knowingly; #1590 tracks an explicit downgrade affordance.

## Verification

Beyond the unit tests, this was run against a real server on isolated ports and its own data dir:

- the on-disk session record for the read-only document carries `readOnly: true`;
- a writable document's record has **no** `readOnly` key at all, so existing records keep their exact shape;
- after a genuine process restart the restored document refuses to save with `skipCode: READ_ONLY` — the disk-write gate itself, not a self-reported flag.

Negative control: with the three source files stashed and the tests left in place, 6 of 7 fail, including the round-trip and the autosave refusal. Full suite 555 files / 8937 passed / 23 skipped, exit 0.

## Noted, not fixed here

`POST /api/open` on an already-open document returns the caller's computed `readOnly` rather than the document's actual state (`file-opener.ts:772`), so it reports `readOnly: false` for a document that is genuinely read-only. Pre-existing, out of scope, and it fooled this PR's own manual verification before the behavioural check settled it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ix39E9oguyfF6RP8zp6Cr
