### PR TITLE
test(single-flight): wait for followers instead of racing them

### DIFF
--- a/src-tauri/src/single_flight.rs
+++ b/src-tauri/src/single_flight.rs
@@ -183,6 +183,34 @@ mod tests {
     use std::sync::{mpsc, Barrier};
     use std::thread;
 
+    /// Block until `n` followers have provably enlisted on the registered slot.
+    ///
+    /// The witness is the registered `Arc`'s strong count read *under `inner`'s
+    /// lock* — the same lock `enlist` clones under, which is what makes this an
+    /// ordering edge rather than a relaxed peek at a counter. Holders are the
+    /// registration itself, the leader's `LeaderGuard`, and one per enlisted
+    /// follower, so the target is `n + 2`. The count cannot fall while we spin:
+    /// a follower drops its clone only after `run` returns, and `run` cannot
+    /// return until the leader publishes, which is after this call.
+    ///
+    /// Panics on timeout. Its caller asserts on the panic payload, because this
+    /// unwinds the leader thread exactly like the deliberate panic does.
+    fn wait_for_followers<T: Clone>(flight: &SingleFlight<T>, n: usize) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let holders = lock(&flight.inner).as_ref().map_or(0, Arc::strong_count);
+            if holders >= n + 2 {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "only {holders} of the expected {} slot holders enlisted",
+                n + 2
+            );
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
     /// THE test that separates this design from the rejected blocking mutex:
     /// with a mutex the counter is N, with coalescing it is exactly 1.
     #[test]
@@ -253,6 +281,12 @@ mod tests {
     /// in 5s rather than the test hanging for two minutes.
     ///
     /// The leader's panic message on stderr is expected output, not a failure.
+    ///
+    /// The leader waits on [`wait_for_followers`] rather than on a sleep. A
+    /// follower that enlists *after* the leader's `Drop` clears the registration
+    /// is a late caller by design and correctly gets its own fresh run — so a
+    /// fixed 20ms-versus-100ms margin does not test the library, it tests the
+    /// scheduler, and a macOS CI runner won it with `Some(7)` on 2026-08-21.
     #[test]
     fn a_panicking_leader_does_not_wedge_followers() {
         let flight: Arc<SingleFlight<usize>> = Arc::new(SingleFlight::new());
@@ -265,7 +299,7 @@ mod tests {
             thread::spawn(move || {
                 flight.run(|| {
                     barrier.wait();
-                    thread::sleep(Duration::from_millis(100));
+                    wait_for_followers(&flight, 3);
                     panic!("deliberate leader panic");
                 })
             })
@@ -276,9 +310,9 @@ mod tests {
             let barrier = Arc::clone(&barrier);
             let tx = tx.clone();
             thread::spawn(move || {
+                // The barrier already proves the leader is registered: it
+                // enlists before `f` runs, and `f` is what waits here.
                 barrier.wait();
-                // Give the leader time to install itself before we enlist.
-                thread::sleep(Duration::from_millis(20));
                 let _ = tx.send(flight.run(|| 7usize));
             });
         }
@@ -290,7 +324,15 @@ mod tests {
                 .unwrap_or_else(|e| panic!("follower {i} never returned: {e}"));
             assert_eq!(got, None, "an abandoned flight must not hand back a value");
         }
-        assert!(leader.join().is_err(), "the leader's panic must still propagate");
+        // Assert on the payload, not merely that *a* panic happened: a
+        // `wait_for_followers` timeout also unwinds this thread, and a bare
+        // `is_err()` would read that failure as the deliberate panic and pass.
+        let payload = leader.join().expect_err("the leader's panic must still propagate");
+        assert_eq!(
+            payload.downcast_ref::<&str>().copied(),
+            Some("deliberate leader panic"),
+            "the leader unwound for some other reason"
+        );
 
         // And the flight is usable again afterwards.
         let runs = AtomicUsize::new(0);


### PR DESCRIPTION
`single_flight::tests::a_panicking_leader_does_not_wedge_followers` failed on the macOS leg of master's CI on 2026-08-21 (run 32529207251):

```
assertion `left == right` failed: an abandoned flight must not hand back a value
  left: Some(7)
  right: None
```

## It is the test that is wrong, not the library

The test synchronised four threads with a bare sleep margin: the leader slept 100ms before panicking, each follower slept 20ms before enlisting. Nothing enforced that ordering. When a macOS runner descheduled a follower past the leader's `Drop`, that follower found the registration already cleared, became a leader of its own flight, ran `|| 7usize` and returned `Some(7)`.

That is the library behaving exactly as specified. `a_later_caller_starts_a_fresh_run` pins the same behaviour as *correct* — the module doc calls it guard-not-cache, and it is load-bearing: a cached answer would survive the VM starting or stopping and tell the user something false about their machine. So the assertion was measuring the scheduler, and only macOS ever won.

Confirmed by an independent read of `run`/`enlist`/`follow`/`LeaderGuard::drop`: `Some(7)` has exactly one reachable path, and it runs through no defect.

## The fix

`wait_for_followers` blocks until the registered `Arc`'s strong count shows every follower enlisted. The count is read **under `inner`'s own lock** — the same lock `enlist` clones under — so it is an acquire/release ordering edge, not a relaxed peek at a counter. Holders are the registration, the leader's `LeaderGuard`, and one per enlisted follower, hence `n + 2`; those are the only three `Arc` clone sites in the file. The count cannot fall while the helper spins, because a follower drops its clone only after `run` returns and `run` cannot return until the leader publishes — which is after this call.

The followers' 20ms sleep is deleted rather than kept. Its comment said it was there to let the leader install itself, but the barrier already proves that: `enlist` runs before `f`, and `f` is what waits on the barrier. It was guarding a race that was already closed while doing nothing about the one that bit.

**A timeout in the helper unwinds the leader thread exactly like the deliberate panic does**, so `leader.join()` now asserts on the panic *payload* rather than merely that something unwound — a bare `is_err()` would have read a timeout as a pass. `panic!` with a literal yields an `&str` payload and `assert!` with format args yields a `String`, so the two are distinguishable; verified empirically, not assumed.

## Verification

Neutering the new wait alone survives 15 of 15 runs on Windows — which is the whole reason this only ever surfaced on macOS, and why that control cannot discriminate here. So the delay the macOS runner imposed was injected directly (a 200ms follower stall):

| condition | result |
|---|---|
| old sleep margin + 200ms follower stall | **5 of 5 FAIL**, exact `left: Some(7) / right: None` signature |
| `wait_for_followers` + 200ms follower stall | **8 of 8 pass** |
| unreachable target (`n = 4`), forcing the 5s timeout | **FAILS** with "the leader unwound for some other reason" — the masking guard fires |

Full `cargo test` green via the pre-push hook. `cargo clippy --lib --all-targets` reports nothing for this file.

## Scope

Test-only. No change to `run`, `enlist`, `follow` or `LeaderGuard::drop`, and no change to the clear-then-publish order that `tests/build/cowork-subnet-probe-contract.test.ts` pins from outside the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WimX2rbTSabSNfLrRR51vx
