### PR TITLE
docs: record the v0.24.1 release and its smoke gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,10 +242,13 @@ Mechanism, ops and failure modes: [docs/licensing-explained.md](docs/licensing-e
 
 ## Status
 
-**Shipped: v0.24.0** (2026-08-21). Release history is [CHANGELOG.md](CHANGELOG.md); remaining
+**Shipped: v0.24.1** (2026-08-23). Release history is [CHANGELOG.md](CHANGELOG.md); remaining
 v1.0 work is [docs/roadmap.md](docs/roadmap.md#active--toward-v10); what the last smoke run
-settled is in [docs/release-smoke-checklist.md](docs/release-smoke-checklist.md#what-the-v0240-run-settled).
-**Do not re-narrate any of them here.**
+settled is in [docs/release-smoke-checklist.md](docs/release-smoke-checklist.md#what-the-v0241-run-settled).
+**Do not re-narrate any of them here.** **§1 Windows has now gone two releases unrun**, so
+#1118's post-update banner — the one whose false-positive reaches every user at once — is
+unverified against a real upgrade rather than merely untested this cycle; tracked with a
+date in #1596.
 
 Core is complete — 29 active MCP tools, multi-doc tabs, CRDT-anchored annotations, chat, four
 push paths (self-armed wake, plugin monitor, opt-in channel shim, supervisor stdin),

--- a/docs/release-smoke-checklist.md
+++ b/docs/release-smoke-checklist.md
@@ -104,6 +104,48 @@ Note the outcome (platforms covered, anything skipped, anything found) in a
 comment on the release's tracking issue or the release PR. A skipped platform
 is fine when stated; an unstated skip reads as "verified" and isn't.
 
+## What the v0.24.1 run settled
+
+v0.24.1 (2026-08-23). **§0 executed and passed in full. §4 was executed in part.
+§1 Windows, §2 macOS and §3 Linux-by-hand were NOT RUN — no operator at the
+hardware.** The full record is on PR #1595.
+
+**§1 is the consequential gap, and it is the same gap as v0.24.0's.** The updater
+row is the only check that can catch #1118's false-positive mode — the "Tandem may
+not have finished updating" banner firing after a *successful* update — and that
+banner is now two releases old without ever having been exercised against a real
+upgrade. v0.24.0's record already named this as the gap; carrying it a second time
+turns "not yet verified" into a standing condition, so it now has a dated tracked
+home in [#1596](https://github.com/bloknayrb/tandem/issues/1596) rather than a
+caveat repeated each release. If it misfires it reaches every
+user at once.
+
+§4 is partial, not passed: the global install was upgraded and `tandem doctor`
+returned no `[FAIL]` with `Global tandem-editor@0.24.1 matches this build`, but the
+"`tandem` starts the server and the editor loads" row was **not** run — a v0.24.0
+instance held 3478/3479 and killing a live port holder was not worth the row.
+
+Three things this run established:
+
+- **§0's green summary is not the same as §0's evidence, and two of its rows only
+  look checked.** The macOS arm64 launch-smoke row was confirmed from the step's own
+  output (`ok: our sidecar booted + /health returned status=ok`) rather than from the
+  job's overall conclusion, and the Linux container row from `RESULT: PASS` on both
+  images **with no emitted `ENVIRONMENT` warning** — the fault mode where the mirror
+  is unreachable, the package is never evaluated, and the step still reports success.
+  Reading the conclusion instead of the output would have passed both rows either way.
+- **`tauri-webdriver.yml` is confirmed still disabled by the absence of a run**, not
+  by reading the workflow: no run exists for `v0.24.1`, the last being v0.20.1. That
+  is the only check the box's wording actually permits, and the distinction matters
+  because a re-enabled workflow that then fails would look identical from the file.
+- **A red macOS `rust-test` leg preceded this cut and was a test defect, not a
+  product one.** `single_flight::tests::a_panicking_leader_does_not_wedge_followers`
+  co-ordinated four threads with a fixed sleep; a macOS runner descheduled a follower
+  past the leader's `Drop`, so it correctly started its own flight and returned a
+  value the test forbids. Neutering the fix survives 15 of 15 runs on Windows — the
+  control cannot discriminate there, which is why only macOS ever saw it. Injecting
+  the delay the runner imposed reproduced it 5 of 5 and the fix passed 8 of 8 (#1594).
+
 ## What the v0.24.0 run settled
 
 v0.24.0 (2026-08-21). §0 and §4 executed and passed on Windows 11 Pro (26200);


### PR DESCRIPTION
Post-release pass for v0.24.1. Status line moves to v0.24.1; the smoke record is added.

## The record is mostly about what was not run

**§0 passed in full. §4 was partial. §1 Windows, §2 macOS and §3 by-hand were NOT RUN** — no operator at the hardware.

§4 is written as partial rather than passed: the global install was upgraded and `tandem doctor` returned no `[FAIL]` with `Global tandem-editor@0.24.1 matches this build`, but the "`tandem` starts the server and the editor loads" row was not run, because a live v0.24.0 instance held 3478/3479 and that row was not worth killing a port holder for.

## Why §1 gets a sentence in CLAUDE.md and a dated issue

This is the **second consecutive release** with §1 unrun. The v0.24.0 record already named the same row as the consequential gap, so writing the same caveat again would just be a caveat.

The row is #1118's updater check — the only thing that can catch the *"Tandem may not have finished updating"* banner firing after an update that **succeeded**. Nothing else re-checks: the app leaves itself a marker before the installer runs because the process that started the update is gone before it can see the result. A false positive there reaches every user who takes the update, and tells them to install something they already have. It shipped in v0.24.0 and has never met a real upgrade.

#1596 gives that a date and a criterion answerable from a tracked file, so it surfaces in `gh issue list` rather than living only in a doc — the #1308 discipline. There is a mild irony worth recording: the v0.24.1 machine had a live v0.24.0 install on it, which is the *ideal* updater baseline, and it went unused. That baseline is perishable.

## Two §0 rows where the summary is not the evidence

Both would have passed on the job's conclusion alone, so the record says how they were actually checked:

- The macOS arm64 launch smoke was read from its own output — `ok: our sidecar booted + /health returned status=ok` — not from the leg being green.
- The Linux containers were read from `RESULT: PASS` on both images **and** the absence of an emitted `ENVIRONMENT` warning. That warning is the mode where the mirror is unreachable, the package is never evaluated, and the step still succeeds.

`tauri-webdriver.yml` is recorded as confirmed-disabled by the **absence of a run** for the tag, which is the only claim the checklist's wording permits.

## The red macOS leg before the cut

`single_flight::tests::a_panicking_leader_does_not_wedge_followers` failed on master's macOS leg on 2026-08-21 and is recorded as a test defect, not a product one. It co-ordinated four threads with a fixed sleep; a follower descheduled past the leader's `Drop` correctly started its own flight and returned a value the test forbids — the documented guard-not-cache contract. Fixed in #1594.

Worth carrying: neutering that fix survives 15 of 15 runs on Windows, so the obvious control cannot discriminate on the platform the work was done on. Injecting the delay the macOS runner imposed reproduced the exact failure 5 of 5 and the fix passed 8 of 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WimX2rbTSabSNfLrRR51vx
