### PR TITLE
fix(dev): disable ui-inspector screenshots — native capture is broken on Windows

### DIFF
--- a/.claude/skills/ui-inspector/SKILL.md
+++ b/.claude/skills/ui-inspector/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: ui-inspector
-description: Resolve a durable @ui_ reference from the Tandem desktop element picker into source, metadata and screenshots. Use when a request names @ui_…, ui_…, "the element I picked", "this button/panel", or an inspector screenshot.
+description: Resolve a durable @ui_ reference from the Tandem desktop element picker into its source location, DOM/ARIA metadata and locators. Use when a request names @ui_…, ui_…, "the element I picked", or "this button/panel".
 ---
 
 # UI inspector references
 
 Bryan picked an element in the running Tandem desktop app and it was recorded as
 `@ui_<ULID>` — DOM + ARIA metadata, ranked locators, the `.svelte` source
-location, a full native window screenshot and an element crop.
+location. (Screenshots are disabled in Tandem — see "Pixels are OFF" below.)
 
 **Use the recorded reference. Never infer the element from the description when
 an `@ui_` id is available.** The whole point of the reference is that it removes
@@ -31,7 +31,8 @@ Three failure modes look identical from the CLI (a timeout, or exit 3):
 |---|---|
 | exit 3, no `.ui-inspector/run/instance.json` | app not running, or built without `--features ui-inspector` |
 | bridge installed, every capture rejected | cargo feature off — the ACL has no `ui-inspector:default` grant. The WebView console says so |
-| `pick` hangs to timeout | wrong `--window`, or another pick/resolve is already active |
+| `pick` hangs to timeout | wrong `--window`, or another pick/resolve is already active. Also seen on the very first `pick` after `npm install`: Vite re-optimizes the two `@tauri-ui-inspector/*` deps on first import and force-reloads the page, which tears down the bridge that had just installed. Retry once |
+| `no native window matched the Tauri process and window title` | someone re-enabled `capture_screenshots`. See "Pixels are OFF" below |
 
 The store is pinned to the **repo root** (`<repo>/.ui-inspector/`), so the CLI
 works from anywhere in the tree — it walks *up* looking for a directory that
@@ -48,30 +49,32 @@ ui-inspector get @ui_01... --json
 Never scrape the human-readable format.
 
 Read these fields first: `summary`, `element.role`, `element.accessibleName`,
-`source.location`, `source.component`, `element.locators`, `screenshots.element`,
-`screenshots.window`, `dom.ancestry`.
+`source.location`, `source.component`, `element.locators`, `dom.ancestry`.
+`screenshots` is always empty here.
 
 Exit 2 means the reference is absent — **stop and ask** for the right project or
 id. Do not substitute a similar reference.
 
-## Inspect the pixels
+## Pixels are OFF — do not offer them
 
-```sh
-ui-inspector screenshot @ui_01... --json
-```
+**Tandem sets `capture_screenshots(false)`, so there are no `element.png` /
+`window.png` files and `ui-inspector screenshot` has nothing to return.** This is
+not a setting anyone should flip casually: native capture is broken on Windows
+(`xcap::Window::all()` omits the calling process's own windows, so the plugin's
+pid filter never matches), and with capture ON a failure aborts the *entire*
+capture — no reference is written at all. Off is what makes the tool work.
 
-Read `element.png` before editing. Read `window.png` when the request is about
-spacing, alignment, layering or consistency with neighbouring controls — Tandem's
-rail/panel invariants are usually a *relationship* between elements, not a
-property of one.
+So when a request is about spacing, alignment, layering, or how an element
+relates to its neighbours, **say plainly that you cannot see it** and work from
+`dom.ancestry`, the computed metadata, and the source file. Do not guess at
+appearance from a component name, and do not describe pixels you have not seen.
+If seeing it genuinely matters, ask Bryan for a screenshot.
 
-If the screenshot fields are null, work from the structured metadata and say
-plainly that pixels were unavailable.
-
-**Never publish or upload the screenshots or the reference JSON.** They are
-pictures of whatever document Bryan had open. `redactText` is on for the JSON
-record; nothing can redact pixels. `.ui-inspector/` is gitignored — keep it that
-way, and never attach one of these images to an issue or PR.
+**Never publish or upload the reference JSON.** Even with `redactText` on and
+screenshots off, the record still carries a compact HTML fragment, parent
+context and accessible names taken from whatever document Bryan had open.
+`.ui-inspector/` is gitignored — keep it that way, and never paste a
+`reference.json` into an issue or PR.
 
 ## Locate the source
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ push paths (self-armed wake, plugin monitor, opt-in channel shim, supervisor std
 - `.claude/skills/e2e-debug/SKILL.md` -- Debug Playwright E2E test failures (port conflicts, server startup, post-mortem)
 - `.claude/skills/release/SKILL.md` -- Cut a Tandem release (six-surface version bump, tag, GitHub Release publish, smoke checklist)
 - `.claude/skills/screenshots/SKILL.md` -- Capture README screenshots via Playwright + MCP
-- `.claude/skills/ui-inspector/SKILL.md` -- Resolve a `@ui_<ULID>` reference from the desktop element picker into source + screenshots
+- `.claude/skills/ui-inspector/SKILL.md` -- Resolve a `@ui_<ULID>` reference from the desktop element picker into its source location, metadata and locators (screenshots are off — see the skill)
 
 Those seven are the complete set. `skills/tandem/SKILL.md` (no leading dot) is a different thing entirely: the skill **shipped to users** in the npm package and installed into `~/.claude/skills/tandem/` by `tandem setup --apply`. It is behavioural instruction loaded into real user sessions, so treat a stale rule there as a product bug, and bump its frontmatter `version` when you change it — the installed copy only refreshes when the bundled version is newer.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,16 @@ Three things about it that are easy to get wrong:
   npm global install serves the same client into a plain browser). A `cargo tauri dev` *without*
   the feature still installs the frontend bridge, so every capture is then rejected by the ACL and
   the CLI reports only a timeout — the WebView console names the flag.
-- **The reference store is sensitive.** `.ui-inspector/` at the repo root holds screenshots of
+- **Screenshots are off, and that is what makes it work.** `capture_screenshots(false)` is set in
+  `src/lib.rs`. Native capture is broken on Windows: measured against the same live pid at the same
+  moment with the same xcap 0.9.8, `xcap::Window::all()` returns Tandem's windows when called from
+  *outside* the process and returns **zero** windows matching the pid when called from *inside* it.
+  The plugin's `find_window` filters that list by `std::process::id()`, so the match set is always
+  empty and every capture fails with `no native window matched the Tauri process and window title`
+  — and a failed capture aborts the whole capture, writing no reference at all. Everything else
+  (metadata, locators, Svelte source, persistence, live `resolve`) works with it off. Tracked in
+  #1633; upstream's E2E evidence is macOS-only.
+- **The reference store is sensitive.** `.ui-inspector/` at the repo root holds a record of
   whatever document was open. It is gitignored; never attach one to an issue or PR. The path is
   pinned to the repo root via `CARGO_MANIFEST_DIR` rather than left at the plugin's CWD-relative
   default — the CLI finds a store by walking *up* from where you invoke it, and the app's CWD under

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1667,15 +1667,45 @@ pub fn run() {
     // machine are the same machine. If that ever stops being true, this
     // baked-in path is the first thing that breaks.
     //
-    // Treat the store as sensitive: it holds screenshots of whatever document
-    // was open. Gitignored; never attach one to an issue or PR.
+    // Treat the store as sensitive: it holds whatever document was open.
+    // Gitignored; never attach a reference to an issue or PR.
+    //
+    // `capture_screenshots(false)` is NOT a preference — native capture is
+    // broken on Windows and leaving it on makes the whole plugin unusable
+    // here, because a failed capture fails the ENTIRE capture: no reference is
+    // written at all, and every `ui-inspector pick` returns
+    // "no native window matched the Tauri process and window title".
+    //
+    // Root cause, measured on this machine (#1633) against the same live pid,
+    // the same moment, and the same xcap 0.9.8:
+    //
+    //   called from OUTSIDE tandem-desktop -> 15 windows, both Tandem windows present
+    //   called from INSIDE  tandem-desktop -> 13 windows, ZERO matching self pid
+    //
+    // `xcap::Window::all()` omits the calling process's own windows on
+    // Windows. The plugin's `find_window` filters that list by
+    // `std::process::id()` and returns `WindowNotFound` when the result is
+    // empty, so the pid filter can never match from in-process. Nothing at the
+    // integration layer can fix it — it needs an upstream capture path that
+    // works on the app's own HWND. Upstream's E2E evidence is macOS-only, which
+    // is consistent with this never having been exercised on Windows.
+    //
+    // Everything else works with it off, verified end to end: DOM/ARIA
+    // metadata, ranked locators (`data-testid` first at confidence 1.0), the
+    // Svelte source location and component ancestry, persistence, and live
+    // `ui-inspector resolve`. That is the bulk of the value for an agent; the
+    // pixels are the part we lose.
+    //
+    // Flip this back to the upstream default (screenshots on) once the capture
+    // path is fixed, and delete this comment with it.
     #[cfg(feature = "ui-inspector")]
     {
         let mut inspector = tauri_plugin_ui_inspector::Builder::new();
         inspector
             .storage_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/../.ui-inspector"))
             .max_history(100)
-            .crop_padding(8);
+            .crop_padding(8)
+            .capture_screenshots(false);
         builder = builder.plugin(inspector.build());
     }
 

--- a/tests/build/ui-inspector-dev-only.test.ts
+++ b/tests/build/ui-inspector-dev-only.test.ts
@@ -1,17 +1,16 @@
 /**
  * Regression pin: the UI element inspector must stay out of everything we ship.
  *
- * WHAT THIS IS: a pin on three one-line mistakes that each produce a shipped
- * artifact nobody asked for, with no other signal — no type error, no failing
- * behaviour test, no lint. Every assertion here corresponds to a decision made
- * deliberately when the plugin was added, not to a bug that was found.
+ * WHAT THIS IS: a pin on four one-line mistakes that each break something with
+ * no other signal — no type error, no failing behaviour test, no lint. The first
+ * three ship an artifact nobody asked for; the fourth breaks the tool outright.
  *
  * WHAT THIS IS NOT: proof the inspector is absent from a built bundle. That is
  * a property of the actual build output, and the only real check for it is
  * `npm run build` followed by grepping `dist/client/` — which this suite does
  * not run. This file guards the *inputs* that make that build come out right.
  *
- * The three mistakes, and why each is silent:
+ * The four mistakes, and why each is silent:
  *
  *  1. Dropping `optional = true` from the Cargo dependency, or adding the
  *     `ui-inspector` feature to a `default` feature list. Cargo cannot gate a
@@ -27,6 +26,9 @@
  *     production build only if nothing outside the branch pulls the module in;
  *     a static import defeats that while the dev experience stays identical,
  *     so the regression is invisible until someone greps a shipped bundle.
+ *  4. Removing `capture_screenshots(false)`. Native capture is broken on
+ *     Windows and a failed capture aborts the whole capture, so re-enabling it
+ *     makes every `pick` fail with no reference written. See #1633.
  *
  * See CONTRIBUTING.md ("UI element inspector") for the developer-facing half.
  */
@@ -83,6 +85,25 @@ describe("ui-inspector stays development-only", () => {
     const feature = /^\s*ui-inspector\s*=\s*\[(.*?)\]/ms.exec(cargoToml);
     expect(feature, "the `ui-inspector` feature is no longer declared").not.toBeNull();
     expect(feature?.[1]).toContain("tauri/dynamic-acl");
+  });
+
+  it("screenshot capture stays disabled", () => {
+    // Not a preference — a regression pin. Native capture is broken on Windows:
+    // `xcap::Window::all()` omits the calling process's own windows, so the
+    // plugin's `find_window` pid filter is always empty and returns
+    // WindowNotFound. A failed capture aborts the ENTIRE capture, so turning
+    // this back on writes no reference at all and makes the plugin unusable.
+    //
+    // This is a source-text check, which is weaker than it looks: it proves the
+    // call is written, not that it runs. It exists because the real failure is
+    // silent at build time and only shows up as a CLI timeout at the far end.
+    // Re-enable only once upstream's capture path works on the app's own HWND
+    // (#1633), and delete this test with it.
+    const libRs = readFileSync(join(repoRoot, "src-tauri/src/lib.rs"), "utf8");
+    expect(
+      libRs,
+      "capture_screenshots(false) was removed — see #1633 before re-enabling",
+    ).toContain(".capture_screenshots(false)");
   });
 
   it.each(NPM_PACKAGES)("%s is a devDependency, not a dependency", (name) => {


### PR DESCRIPTION
> **Stacked on #1628**, which is itself stacked on #1627. This is the outcome of actually running the inspector against the live desktop app — the verification #1628 said it had not done.
>
> **If you'd rather keep the stack at two, cherry-pick `ffac22e7` onto `feat/ui-inspector` and close this.** It's a one-line config change plus docs; it only exists as its own PR because you asked for results on `ui-refinement`.

## What the live run confirmed

Two claims #1628 listed as unverified are now verified:

- **The runtime `add_capability` grant is accepted** — `[app_lib][INFO] UI inspector enabled` is logged *after* the `?`, so a rejected grant would have aborted startup instead.
- **The `CARGO_MANIFEST_DIR` storage pin resolves to the repo root** — `.ui-inspector/` landed at the worktree root, *not* under `src-tauri/`, and the CLI found the running app with no `--project` flag. That is precisely what the plugin's CWD-relative default would have broken.

## What it also found

**Native window capture cannot work on Windows**, and leaving it on makes the plugin unusable rather than degraded — a failed capture aborts the *entire* capture, so no reference is written and every `pick` returns `no native window matched the Tauri process and window title`.

Measured against the same live pid, at the same moment, with the same xcap 0.9.8:

| Caller | `Window::all()` | matching self pid |
|---|---|---|
| **outside** `tandem-desktop` | 15 | 2 (`"Tandem"`, `"com.tandem.editor-siw"`) |
| **inside** `tandem-desktop` | 13 | **0** |

`xcap::Window::all()` omits the calling process's own windows on Windows. `find_window` filters that list by `std::process::id()` and returns `WindowNotFound` on an empty result, so the pid filter can never match from in-process.

Evidence came from temporarily adding `xcap` as a direct dep and running the same enumeration from `tauri::async_runtime::spawn` (where command handlers run), with an external probe binary as the control. Both diagnostics are reverted — the tree is clean.

Nothing at the integration layer fixes this; it needs an upstream capture path that works on the app's own HWND. Upstream's checked-in E2E evidence is macOS-only, consistent with Windows never having been exercised.

## With screenshots off, it works

Verified end to end against the running app:

```
summary:  ActivityTray: button at src/client/components/ActivityTray.svelte:319:5
ancestry: App.svelte:2462 → Root.svelte:7 → ErrorBoundary.svelte:41
locators: testId "activity-pill"  confidence 1.0  unique
          aria-label "Open activity tray"  confidence 0.8
resolve:  {"status":"resolved","locatorIndex":0,...}  exit 0
```

`data-testid` ranking first at confidence 1.0 is the Tandem-specific case that makes this worth having.

## Honest limits

- **I could not drive the picker itself.** CDP `Input.dispatchMouseEvent` arms it (`cursor: crosshair` confirms the bridge received the request) but the click reads as a cancel — synthetic events don't satisfy its pointer handling. The capture path was exercised via `inspectSelector` instead, which is the same Rust path minus upstream's own pointer code. **A real human click is still unproven.**
- The `no reference written` behaviour means a future upstream regression here fails loudly, not silently — that part is fine.

## Guard

`tests/build/ui-inspector-dev-only.test.ts` gains a fourth pin on `capture_screenshots(false)`, naming #1633. Mutation confirmed red. It is a source-text check, which is weaker than it looks — it proves the call is written, not that it runs — and the test says so.

#1633 is the dated gate (review **2027-02-26**) with a re-enable criterion answerable from tracked files.

**Not done:** nothing reported upstream to `mathematic-inc/tauri-plugin-ui-inspector` yet. Say the word and I'll file it with the table above.

## Verification

`cargo check` clean with the feature **on** and **off** · full pre-push suite green (biome + vitest + `cargo test`) · `npm run check:links` 348 links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pTHywPsWBgsnNxVdhsWwo