### PR TITLE
feat(client): render markdown in annotation bodies and replies (#1626 part 1)

### DIFF
--- a/src/client/panels/AnnotationBody.svelte
+++ b/src/client/panels/AnnotationBody.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+import type { Annotation, ReplyAuthor } from "../../shared/types";
+import { renderMarkdown } from "./chat-markdown";
+import "./markdown-body.css";
+
+interface Props {
+  /** The body text. Non-string values are tolerated — `renderMarkdown` returns "". */
+  text: string;
+  /**
+   * Who wrote it. Only `"claude"` renders as markdown; see below.
+   *
+   * The union covers both callers: annotation bodies carry `Annotation["author"]`
+   * (`"user" | "claude" | "import"`) and replies carry `ReplyAuthor`.
+   */
+  author: Annotation["author"] | ReplyAuthor | undefined;
+  /** Rendered when `text` is empty. */
+  placeholder?: string;
+}
+
+let { text, author, placeholder = "" }: Props = $props();
+
+/**
+ * Markdown renders for Claude-authored text only.
+ *
+ * **This is a semantic choice, not a trust boundary.** A user typing `*load*
+ * bearing*` in a comment means asterisks, and silently italicising their prose
+ * would be editing it. Claude, by contrast, writes markdown by default — that is
+ * what the issue is about.
+ *
+ * It is emphatically NOT a security gate, and must not be read as one:
+ * `renderMarkdown`'s escaping is what makes the `{@html}` safe, and it applies
+ * to every author equally. Claude's output is shaped by document and `.docx`
+ * content that can come from outside the project, so this text is exactly as
+ * untrusted as the user's.
+ *
+ * `"claude"` also covers local-model replies when #1123 M4 arms — the collaborator
+ * writes with the same author value, so nothing here needs to change then.
+ */
+const asMarkdown = $derived(author === "claude");
+
+const body = $derived(text || placeholder);
+
+/**
+ * Keep a link click from also activating the card.
+ *
+ * `AnnotationCard` puts `onclick` + `tabindex` on its wrapper (it scrolls the
+ * document to the annotation), so without this an anchor inside a rendered
+ * reply both navigates AND scrolls the document out from under the user.
+ */
+function onBodyClick(event: MouseEvent) {
+  if ((event.target as HTMLElement | null)?.closest("a")) event.stopPropagation();
+}
+</script>
+
+{#if asMarkdown}
+  <!--
+    The `{@html}` sink. Safe because `renderMarkdown` escapes the whole input
+    before constructing any tag — see its docstring, which states the invariant
+    and the one counterexample that motivated the URL guard.
+
+    A `<div>`, never a `<p>`: markdown emits block-level children (`<p>`, `<pre>`,
+    `<h1>`, `<li>`), and a block inside a `<p>` is invalid HTML that the parser
+    silently reparents, breaking the layout in a way that looks like a CSS bug.
+    All three annotation targets were `<p>` before #1626.
+  -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="tandem-markdown ab-body" onclick={onBodyClick}>
+    {@html renderMarkdown(body)}
+  </div>
+{:else}
+  <!-- `pre-wrap` so a user's own line breaks survive, matching what the markdown
+       branch does with them. Without it the two branches disagree about
+       whitespace and a comment reflows on edit. -->
+  <div class="ab-body ab-plain">{body}</div>
+{/if}
+
+<style>
+  .ab-plain {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+</style>

--- a/src/client/panels/AnnotationBody.svelte
+++ b/src/client/panels/AnnotationBody.svelte
@@ -4,7 +4,7 @@ import { renderMarkdown } from "./chat-markdown";
 import "./markdown-body.css";
 
 interface Props {
-  /** The body text. Non-string values are tolerated — `renderMarkdown` returns "". */
+  /** The body text. */
   text: string;
   /**
    * Who wrote it. Only `"claude"` renders as markdown; see below.
@@ -35,21 +35,27 @@ let { text, author, placeholder = "" }: Props = $props();
  *
  * `"claude"` also covers local-model replies when #1123 M4 arms — the collaborator
  * writes with the same author value, so nothing here needs to change then.
+ *
+ * **Known asymmetry: `author` tracks who OWNS the annotation, not who wrote the
+ * current text.** `tandem_editAnnotation` has no author gate and spreads the
+ * existing record, so Claude editing a user's comment leaves `author: "user"` —
+ * and that Claude-written markdown renders as literal asterisks, while the same
+ * text in a comment Claude *created* renders formatted. Cosmetic, and the honest
+ * fix is a separate `editedBy` field rather than rewriting `author`, which would
+ * corrupt the authorship model and the header dot.
  */
 const asMarkdown = $derived(author === "claude");
 
-const body = $derived(text || placeholder);
-
 /**
- * Keep a link click from also activating the card.
+ * The rendered text.
  *
- * `AnnotationCard` puts `onclick` + `tabindex` on its wrapper (it scrolls the
- * document to the annotation), so without this an anchor inside a rendered
- * reply both navigates AND scrolls the document out from under the user.
+ * `String(...)` because these values come off a Y.Map and both branches need to
+ * survive a non-string. `renderMarkdown` guards itself, but the plain branch is
+ * a bare `{body}` interpolation, which would stringify an object to
+ * `[object Object]` — and the plain branch is where user and import text goes,
+ * so it is the MAJORITY path, not the edge one.
  */
-function onBodyClick(event: MouseEvent) {
-  if ((event.target as HTMLElement | null)?.closest("a")) event.stopPropagation();
-}
+const body = $derived(typeof text === "string" ? text || placeholder : placeholder);
 </script>
 
 {#if asMarkdown}
@@ -63,9 +69,7 @@ function onBodyClick(event: MouseEvent) {
     silently reparents, breaking the layout in a way that looks like a CSS bug.
     All three annotation targets were `<p>` before #1626.
   -->
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="tandem-markdown ab-body" onclick={onBodyClick}>
+  <div class="tandem-markdown ab-body">
     {@html renderMarkdown(body)}
   </div>
 {:else}

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -194,6 +194,29 @@ function handleKeyDown(e: KeyboardEvent) {
     handleCancel();
   }
 }
+/**
+ * Card activation, declining clicks that started on a link.
+ *
+ * A rendered Claude body (#1626) can contain anchors. Without this, following a
+ * link both navigates AND scrolls the document to the annotation.
+ *
+ * The check lives HERE, on the element that owns `onClick`, rather than as a
+ * `stopPropagation` in `AnnotationBody`. That version worked, but only because
+ * Svelte 5 delegates `click` and its simulated walk breaks on `cancelBubble` —
+ * so converting either handler to a `use:` action or an explicit
+ * `addEventListener` would silently disable the guard with no type error and no
+ * failing test. Reading the target is order-independent. It also avoids
+ * re-adding the `a11y_click_events_have_key_events` suppression that #1184
+ * deliberately removed project-wide.
+ *
+ * The keyboard path needs no equivalent: `activationKeydown(..., {selfOnly:
+ * true})` already declines when the event target is an inner element, and
+ * activating a focused anchor synthesizes a click that lands here.
+ */
+function onCardClick(event: MouseEvent) {
+  if ((event.target as HTMLElement | null)?.closest("a")) return;
+  onClick?.();
+}
 </script>
 
 <!-- Keyboard activation on the card root uses plain tabindex, not roving —
@@ -211,7 +234,7 @@ function handleKeyDown(e: KeyboardEvent) {
   class:is-density-stub={resolvedDensity === "stub"}
   in:cardEnter={{ enabled: lifecycleMotion, reduceMotion }}
   out:cardExit={{ enabled: lifecycleMotion, reduceMotion, id: annotation.id, modes: exitModes }}
-  onclick={onClick}
+  onclick={onCardClick}
   onkeydown={activationKeydown(() => onClick?.(), { selfOnly: true })}
   tabindex={onClick ? 0 : undefined}
   data-testid="annotation-card-{annotation.id}"
@@ -487,6 +510,19 @@ function handleKeyDown(e: KeyboardEvent) {
     padding: 0;
     border: none;
     background: none;
+    /* `<pre>` carries `white-space: pre-wrap`, which keeps honouring the
+       literal newlines in a fenced block even once the box is inline — so
+       without this a code block still renders one line per line of code. */
+    white-space: normal;
+  }
+  /* `<br>` is the other half, and the more common one: `renderMarkdown` turns
+     every single newline into one, so a bullet list — the likeliest thing
+     Claude writes into a comment — emits a `<br>` between every item. `display:
+     inline` is a `<br>`'s NORMAL value and does not stop it breaking the line;
+     `none` is what does. */
+  .is-density-clamped :global(.aca-body .tandem-markdown br),
+  .is-density-compact :global(.aca-body .tandem-markdown br) {
+    display: none;
   }
 
   .is-density-clamped :global([data-testid^="annotation-snippet-"]),

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -473,6 +473,22 @@ function handleKeyDown(e: KeyboardEvent) {
     line-clamp: 1;
     overflow: clip;
   }
+  /* Markdown bodies (#1626) render BLOCK children — `<p>`, `<pre>`, `<li>` —
+     and each one opens its own line box, so the `-webkit-line-clamp: 1` above
+     collapses to one line per block rather than one line total. A two-paragraph
+     Claude comment would show two lines in a card sized for one, overflowing the
+     clamped band. Flattening the descendants to inline is what makes the teaser
+     single-line again; formatting is irrelevant at this size, and the full
+     rendering returns as soon as the card expands. */
+  .is-density-clamped :global(.aca-body .tandem-markdown *),
+  .is-density-compact :global(.aca-body .tandem-markdown *) {
+    display: inline;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: none;
+  }
+
   .is-density-clamped :global([data-testid^="annotation-snippet-"]),
   .is-density-clamped :global(.art-root),
   .is-density-compact :global([data-testid^="annotation-snippet-"]),

--- a/src/client/panels/ChatPanel.svelte
+++ b/src/client/panels/ChatPanel.svelte
@@ -9,6 +9,7 @@ import { flatOffsetToPmPos } from "../positions";
 import { agentColor } from "../utils/agent-color";
 import { localChatDateLabel } from "./chat-export";
 import { renderMarkdown } from "./chat-markdown";
+import "./markdown-body.css";
 
 const TYPING_DOT_DELAYS = [0, 0.2, 0.4];
 
@@ -363,7 +364,7 @@ async function exportChat() {
 
         <!-- Message text -->
         {#if msg.author === "claude"}
-          <div class="chat-markdown">
+          <div class="chat-markdown tandem-markdown">
             {@html renderMarkdown(msg.text)}
           </div>
         {:else}
@@ -575,33 +576,6 @@ async function exportChat() {
         opacity: 1;
       }
     }
-  }
-
-  .chat-markdown :global(h1),
-  .chat-markdown :global(h2),
-  .chat-markdown :global(h3) {
-    margin: 0.5em 0 0.25em;
-    font-weight: 600;
-  }
-  .chat-markdown :global(p) {
-    margin: 0.25em 0;
-  }
-  .chat-markdown :global(code) {
-    font-family: monospace;
-    font-size: 0.9em;
-    background: var(--tandem-surface-muted);
-    padding: 1px 4px;
-    border-radius: var(--tandem-r-2);
-  }
-  .chat-markdown :global(li) {
-    margin-left: 1.25em;
-    list-style: disc;
-  }
-  .chat-markdown :global(strong) {
-    font-weight: 600;
-  }
-  .chat-markdown :global(em) {
-    font-style: italic;
   }
 
   /* Anchor quote — collapsed to a 60px teaser, expands on hover OR focus so

--- a/src/client/panels/CommentCard.svelte
+++ b/src/client/panels/CommentCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Annotation } from "../../shared/types";
+import AnnotationBody from "./AnnotationBody.svelte";
 import AnnotationCardHeader from "./AnnotationCardHeader.svelte";
 import AnnotationSnippet from "./AnnotationSnippet.svelte";
 
@@ -31,6 +32,10 @@ let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: 
 
 {#if !isEditing}
   <div class="aca-body" style="margin: 0; color: var(--tandem-fg); line-height: 1.45;">
-    <p style="margin: 0;">{annotation.content || "(no note)"}</p>
+    <AnnotationBody
+      text={annotation.content}
+      author={annotation.author}
+      placeholder="(no note)"
+    />
   </div>
 {/if}

--- a/src/client/panels/CommentThread.svelte
+++ b/src/client/panels/CommentThread.svelte
@@ -2,6 +2,7 @@
 import type { AnnotationReply } from "../../shared/types";
 import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
 import { agentTintColor } from "../utils/agent-color";
+import AnnotationBody from "./AnnotationBody.svelte";
 import { formatRelativeTime } from "./annotation-card-helpers";
 
 interface Props {
@@ -57,7 +58,7 @@ const agentLabel = createAgentLabel();
             {formatRelativeTime(reply.timestamp)}
           </span>
         </div>
-        <p class="ct-body">{reply.text}</p>
+        <div class="ct-body"><AnnotationBody text={reply.text} author={reply.author} /></div>
       </div>
     {/each}
   </div>

--- a/src/client/panels/SuggestionCard.svelte
+++ b/src/client/panels/SuggestionCard.svelte
@@ -2,6 +2,7 @@
 import { isSnapshotTruncated } from "../../shared/snapshot";
 import type { Annotation } from "../../shared/types";
 import { diffWords } from "../utils/word-diff";
+import AnnotationBody from "./AnnotationBody.svelte";
 import AnnotationCardHeader from "./AnnotationCardHeader.svelte";
 import AnnotationSnippet from "./AnnotationSnippet.svelte";
 
@@ -95,9 +96,9 @@ const originalTruncated = $derived(isSnapshotTruncated(annotation));
     {/if}
   </div>
   {#if annotation.content}
-    <p style="margin: 0; font-size: 12px; color: var(--tandem-fg-muted);">
-      {annotation.content}
-    </p>
+    <div style="margin: 0; font-size: 12px; color: var(--tandem-fg-muted);">
+      <AnnotationBody text={annotation.content} author={annotation.author} />
+    </div>
   {/if}
 </div>
 {/if}

--- a/src/client/panels/chat-markdown.ts
+++ b/src/client/panels/chat-markdown.ts
@@ -28,10 +28,11 @@ function escapeHtml(text: string): string {
  * is one of this function's own literals, and each is closed before any
  * input-derived text.**
  *
- * **Do not read the caller's `author` as a security boundary.** The one caller
- * (`ChatPanel.svelte`, `msg.author === "claude"`) renders markdown for
- * Claude-authored text only, but that is a SEMANTIC choice — a user typing `*`
- * should not silently italicize. It is not a trust boundary: Claude's output is
+ * **Do not read the caller's `author` as a security boundary.** Both callers
+ * (`ChatPanel.svelte` on `msg.author`, `AnnotationBody.svelte` on an annotation
+ * or reply author) render markdown for Claude-authored text only, but that is a
+ * SEMANTIC choice — a user typing `*` should not silently italicize. It is not a
+ * trust boundary: Claude's output is
  * influenced by document and `.docx` content that may come from outside the
  * project, so `author: "claude"` text is as untrusted as any other. The escaping
  * is what makes this safe, for every author.

--- a/src/client/panels/markdown-body.css
+++ b/src/client/panels/markdown-body.css
@@ -1,0 +1,121 @@
+/*
+ * Shared presentation for `renderMarkdown` output.
+ *
+ * This is a plain `.css` imported from a component `<script>`, which lands
+ * GLOBAL rather than Svelte-scoped. That is the point: the same rendered HTML
+ * appears in the chat panel and in three annotation cards, and a
+ * component-scoped copy cannot reach markup another component owns. The rules
+ * lived inside `ChatPanel.svelte`'s `<style>` until #1626 for exactly that
+ * reason — they were unreachable, so annotation cards had no way to render
+ * markdown at all.
+ *
+ * It goes through lightningcss (CLAUDE.md, CSS-pipeline gotcha), so write the
+ * STANDARD property alone — a hand-written prefixed pair can collapse to the
+ * `-webkit-` form and go inert. `-webkit-line-clamp` is the documented
+ * exception and is not used here.
+ *
+ * Everything is scoped under `.tandem-markdown` so it can never leak onto
+ * user-authored text, which renders as plain text by design.
+ */
+
+.tandem-markdown {
+  /* The container is inline-flow; block children below supply their own
+     spacing. `overflow-wrap` matters more than it looks: a long unbroken token
+     (a URL, a hash) in a 160px-wide clamped annotation card otherwise pushes
+     the card past the rail and trips the E2E scrollWidth gates. */
+  overflow-wrap: anywhere;
+}
+
+/*
+ * NO `> :first-child { margin-top: 0 }` rule, deliberately — it would introduce
+ * a visible bug rather than fix one.
+ *
+ * `renderMarkdown` builds paragraphs by replacing `\n\n` with `</p><p>`, which
+ * is unbalanced: there is no opening tag at the start and no closing tag at the
+ * end. Parsed, `a\n\nb` becomes the TEXT NODE `a` followed by `<p>b</p>` — so
+ * the first paragraph is not an element at all, and `> :first-child` selects
+ * paragraph *two*. Zeroing its top margin runs the first two paragraphs
+ * together. Verified against happy-dom, not assumed.
+ *
+ * As it stands the spacing is already right: each `<p>` from the second onward
+ * carries the gap that separates it from what precedes it. Balancing the
+ * markup properly is a renderer change, not a CSS one, and it has to keep
+ * `<pre>` OUT of the wrapping `<p>` — the invalid-nesting trap this whole change
+ * exists to fix. Tracked separately.
+ */
+.tandem-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+/* Headings are capped at 1em. A markdown `#` inside a 12px annotation card is
+   a *emphasis* marker, not a document outline — rendering it at UA `2em` makes
+   a reply shout louder than the card's own header. Weight carries the emphasis
+   instead. */
+.tandem-markdown h1,
+.tandem-markdown h2,
+.tandem-markdown h3 {
+  margin: 0.5em 0 0.25em;
+  font-size: 1em;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.tandem-markdown p {
+  margin: 0.25em 0;
+}
+
+.tandem-markdown strong {
+  font-weight: 600;
+}
+
+.tandem-markdown em {
+  font-style: italic;
+}
+
+.tandem-markdown li {
+  margin-left: 1.25em;
+  list-style: disc;
+}
+
+.tandem-markdown code {
+  font-family: monospace;
+  font-size: 0.9em;
+  background: var(--tandem-surface-muted);
+  padding: 1px 4px;
+  border-radius: var(--tandem-r-2);
+}
+
+/* `pre` had NO rule before this file existed — a defect in chat, not only in
+   the annotation cards. Without `white-space: pre-wrap` the UA default is
+   `pre`, so a fenced block never wraps and scrolls the whole panel sideways;
+   `overflow-x: auto` keeps any remaining overflow inside the block. */
+.tandem-markdown pre {
+  margin: 0.4em 0;
+  padding: 6px 8px;
+  background: var(--tandem-surface-sunk);
+  border: 1px solid var(--tandem-border);
+  border-radius: var(--tandem-r-2);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Reset the inline-code chrome inside a block — otherwise every fenced block
+   carries the inline pill's background and padding on top of the `pre`'s own. */
+.tandem-markdown pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: 0.9em;
+}
+
+/* `a` had no rule either, so links rendered in the UA's untokened blue —
+   the one colour in the app that ignores the theme entirely. */
+.tandem-markdown a {
+  color: var(--tandem-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.tandem-markdown a:hover {
+  color: var(--tandem-accent-hover);
+}

--- a/src/client/panels/markdown-body.css
+++ b/src/client/panels/markdown-body.css
@@ -41,7 +41,8 @@
  * carries the gap that separates it from what precedes it. Balancing the
  * markup properly is a renderer change, not a CSS one, and it has to keep
  * `<pre>` OUT of the wrapping `<p>` — the invalid-nesting trap this whole change
- * exists to fix. Tracked separately.
+ * exists to fix. Tracked in #1639, which also owns removing this comment and
+ * adding the rule it currently forbids.
  */
 .tandem-markdown > :last-child {
   margin-bottom: 0;
@@ -153,13 +154,12 @@
   }
 }
 
-/* `renderMarkdown` emits `</p><p>` for a blank line with no opening tag, so
-   `intro
-
-```ts…` parses to `intro<p></p><pre>…` — a stray EMPTY paragraph
-   carrying real vertical space. This is a band-aid on that, not a fix: the fix
-   is balancing the renderer's paragraph markup, which has to keep `<pre>`
-   outside the wrapping `<p>`. Verified against a parser. */
+/* `renderMarkdown` emits `</p><p>` for a blank line with no opening tag, so an
+   intro line followed by a fenced block parses to `intro<p></p><pre>…` — a stray
+   EMPTY paragraph carrying real vertical space. This is a band-aid on that, not
+   a fix: the fix is balancing the renderer's paragraph markup, which has to keep
+   `<pre>` outside the wrapping `<p>`. Verified against a parser. Tracked in
+   #1639, which owns deleting this rule. */
 .tandem-markdown p:empty {
   display: none;
 }

--- a/src/client/panels/markdown-body.css
+++ b/src/client/panels/markdown-body.css
@@ -47,17 +47,28 @@
   margin-bottom: 0;
 }
 
-/* Headings are capped at 1em. A markdown `#` inside a 12px annotation card is
-   a *emphasis* marker, not a document outline — rendering it at UA `2em` makes
-   a reply shout louder than the card's own header. Weight carries the emphasis
-   instead. */
 .tandem-markdown h1,
 .tandem-markdown h2,
 .tandem-markdown h3 {
   margin: 0.5em 0 0.25em;
-  font-size: 1em;
   font-weight: 600;
   line-height: 1.3;
+}
+
+/* Headings are capped at 1em on the CARD host only (`.ab-body`, emitted by
+   AnnotationBody), not app-wide. A markdown `#` inside a 12px annotation card is
+   an emphasis marker rather than a document outline, and at the UA's 2em it
+   shouts louder than the card's own header.
+   
+   Scoped deliberately: the rules above were moved out of `ChatPanel.svelte`,
+   which set no `font-size` at all, so capping globally would silently shrink
+   every heading in Claude's chat messages from 2em to 1em — a change to a
+   surface this work is not about, justified by an argument (12px, short) that
+   does not apply to a chat bubble. */
+.ab-body.tandem-markdown h1,
+.ab-body.tandem-markdown h2,
+.ab-body.tandem-markdown h3 {
+  font-size: 1em;
 }
 
 .tandem-markdown p {
@@ -78,7 +89,7 @@
 }
 
 .tandem-markdown code {
-  font-family: monospace;
+  font-family: var(--tandem-font-mono);
   font-size: 0.9em;
   background: var(--tandem-surface-muted);
   padding: 1px 4px;
@@ -111,11 +122,44 @@
 
 /* `a` had no rule either, so links rendered in the UA's untokened blue —
    the one colour in the app that ignores the theme entirely. */
+/* `accent-fg-strong`, NOT `accent`.
+   
+   A review-target card renders on `--tandem-accent-bg` (`AnnotationCard.svelte`
+   sets that background), and `accent` on `accent-bg` measures ~4.95:1 in light
+   mode — over the AA floor but marginal, and `index.html`'s own token comment
+   calls out that exact pairing and says `accent-fg-strong` "clears it
+   comfortably". ChatPanel already made this call twice (the anchor quote and the
+   selection indicator), so matching it is consistency, not invention.
+   
+   The underline is what satisfies SC 1.4.1 — links stay distinguishable without
+   relying on colour at all. */
 .tandem-markdown a {
-  color: var(--tandem-accent);
+  color: var(--tandem-accent-fg-strong);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 .tandem-markdown a:hover {
   color: var(--tandem-accent-hover);
+}
+
+/* Under forced colors, `--tandem-accent` maps to `Highlight` and
+   `--tandem-accent-hover` is not remapped at all — so a link would render in
+   the selection-FILL colour, or off the system palette entirely on hover.
+   `LinkText` is the keyword that exists for this. */
+@media (forced-colors: active) {
+  .tandem-markdown a,
+  .tandem-markdown a:hover {
+    color: LinkText;
+  }
+}
+
+/* `renderMarkdown` emits `</p><p>` for a blank line with no opening tag, so
+   `intro
+
+```ts…` parses to `intro<p></p><pre>…` — a stray EMPTY paragraph
+   carrying real vertical space. This is a band-aid on that, not a fix: the fix
+   is balancing the renderer's paragraph markup, which has to keep `<pre>`
+   outside the wrapping `<p>`. Verified against a parser. */
+.tandem-markdown p:empty {
+  display: none;
 }

--- a/tests/client/annotation-body.test.ts
+++ b/tests/client/annotation-body.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment happy-dom
+
+import { render } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vitest";
+import AnnotationBody from "../../src/client/panels/AnnotationBody.svelte";
+import AnnotationCard from "../../src/client/panels/AnnotationCard.svelte";
+import { TUTORIAL_ANNOTATIONS } from "../../src/server/mcp/tutorial-annotations";
+import { toFlatOffset } from "../../src/shared/positions/types.js";
+import type { Annotation } from "../../src/shared/types";
+import { makeAnnotation as makeBaseAnnotation } from "../helpers/ydoc-factory.js";
+
+function body(props: { text: string; author?: string; placeholder?: string }) {
+  return render(AnnotationBody, {
+    props: { author: undefined, ...props } as never,
+  }).container;
+}
+
+describe("AnnotationBody — who gets markdown", () => {
+  it("renders markdown for claude-authored text", () => {
+    const c = body({ text: "**bold** and `code`", author: "claude" });
+
+    expect(c.querySelector("strong")?.textContent).toBe("bold");
+    expect(c.querySelector("code")?.textContent).toBe("code");
+  });
+
+  it("renders user-authored text literally, asterisks and all", () => {
+    // The reason this gate exists. A user typing `*load* bearing*` means
+    // asterisks; silently italicising their prose would be editing it.
+    const c = body({ text: "*load* bearing*", author: "user" });
+
+    expect(c.querySelector("em")).toBeNull();
+    expect(c.textContent).toBe("*load* bearing*");
+  });
+
+  it("renders imported word text literally too", () => {
+    // `author: "import"` is a Word comment. It is not markdown and was never
+    // written as markdown, so formatting it would misrepresent the source
+    // document rather than reveal anything.
+    const c = body({ text: "# not a heading", author: "import" });
+
+    expect(c.querySelector("h1")).toBeNull();
+    expect(c.textContent).toBe("# not a heading");
+  });
+
+  it("renders literally when the author is unknown", () => {
+    // Fails toward plain text: an author this component has never heard of is
+    // not a reason to start interpreting their punctuation.
+    expect(body({ text: "**x**", author: undefined }).querySelector("strong")).toBeNull();
+  });
+
+  it("shows the placeholder when the text is empty, without formatting it", () => {
+    const c = body({ text: "", author: "claude", placeholder: "(no note)" });
+    expect(c.textContent).toBe("(no note)");
+  });
+});
+
+describe("AnnotationBody — block-level markup needs a block-level host", () => {
+  it("never puts a block child inside a <p>", () => {
+    // The bug that made #1626 part 1 more than a one-line change. All three
+    // render targets were `<p>`, and `<p><pre>` / `<p><h1>` are invalid: the
+    // parser silently closes the `<p>` and reparents the block, so the layout
+    // breaks in a way that reads as a CSS bug rather than a markup one.
+    //
+    // Asserted structurally, so it fails on any host element that cannot
+    // legally contain a block — not just on the specific one we started with.
+    const c = body({
+      text: "para one\n\npara two\n\n```js\ncode\n```\n\n# heading",
+      author: "claude",
+    });
+
+    for (const block of Array.from(c.querySelectorAll("p, pre, h1, h2, h3, li, div"))) {
+      expect(block.closest("p") === block || block.closest("p") === null).toBe(true);
+    }
+    expect(c.querySelector("pre")).not.toBeNull();
+    expect(c.querySelector("h1")).not.toBeNull();
+  });
+
+  it("carries the shared markdown class so the global stylesheet reaches it", () => {
+    // The rules live in `markdown-body.css` (global, shared with ChatPanel), not
+    // in this component's `<style>`. Losing the class is a silent regression:
+    // the markup still renders, unstyled, with UA-blue links and a `<pre>` that
+    // scrolls the rail sideways.
+    expect(body({ text: "x", author: "claude" }).querySelector(".tandem-markdown")).not.toBeNull();
+    // ...and never on the plain branch, which must not inherit code/link styling.
+    expect(body({ text: "x", author: "user" }).querySelector(".tandem-markdown")).toBeNull();
+  });
+});
+
+describe("AnnotationBody — clicking a link must not also activate the card", () => {
+  // Exercised through a real AnnotationCard rather than a hand-built ancestor.
+  //
+  // Svelte 5 DELEGATES `click` to the app root, so `stopPropagation` inside a
+  // handler stops Svelte's own walk up the tree — not native bubbling. A test
+  // that attaches a plain `addEventListener` to a parent element measures the
+  // native chain, which the card's `onclick` is not in, and reports a failure
+  // that does not exist in the app. The card's handler is delegated exactly as
+  // this component's is, so composing the two is the only assertion that means
+  // anything.
+  function cardWith(content: string) {
+    const onClick = vi.fn();
+    const { container } = render(AnnotationCard, {
+      props: {
+        annotation: makeBaseAnnotation({
+          id: "a1",
+          type: "comment",
+          author: "claude",
+          content,
+          range: { from: toFlatOffset(0), to: toFlatOffset(1) },
+          timestamp: 0,
+        }) as Annotation,
+        onClick,
+      },
+    });
+    return { container, onClick };
+  }
+
+  it("does not activate the card when the click started on a link", () => {
+    // The card's onClick scrolls the document to the annotation. Without the
+    // guard, following a link in a Claude comment both navigates AND scrolls
+    // the document out from under the user.
+    const { container, onClick } = cardWith("[docs](https://x.test)");
+    const anchor = container.querySelector("a");
+
+    expect(anchor).not.toBeNull();
+    anchor?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("still activates the card when the click started on ordinary body text", () => {
+    // The other half. Swallowing every click inside the body would make the
+    // card unclickable wherever a Claude comment has text — which is all of them.
+    const { container, onClick } = cardWith("just prose");
+    // The markdown host itself, not a `<p>`: a single-paragraph message has no
+    // `<p>` at all, because the paragraph pass only fires on a blank-line split.
+    const text = container.querySelector(".tandem-markdown");
+
+    expect(text?.textContent).toBe("just prose");
+    text?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AnnotationBody — the tutorial is not accidentally reformatted", () => {
+  it("renders every tutorial annotation's content as its literal prose", () => {
+    // Tutorial annotations ship with `author: "claude"`, so they now take the
+    // markdown branch. Their copy is prose — but it is the first thing a new
+    // user sees, and a stray `*` or `#` added to it later would render as
+    // formatting instead of as the character someone typed. This is the guard
+    // on that, and it fails at the point the copy changes rather than in a
+    // screenshot review.
+    for (const def of TUTORIAL_ANNOTATIONS) {
+      const c = body({ text: def.content, author: "claude" });
+      expect(c.textContent, def.id).toBe(def.content);
+      expect(c.querySelector("strong, em, h1, h2, h3, code, pre, li, a"), def.id).toBeNull();
+    }
+  });
+});

--- a/tests/client/annotation-body.test.ts
+++ b/tests/client/annotation-body.test.ts
@@ -140,6 +140,32 @@ describe("AnnotationBody — clicking a link must not also activate the card", (
   });
 });
 
+describe("AnnotationBody — the shapes a clamped card has to survive", () => {
+  // These pin the MARKUP the density rules in `AnnotationCard.svelte` have to
+  // flatten. They cannot pin the layout — happy-dom has no layout — but they
+  // fail if `renderMarkdown` stops emitting the shape those rules target, which
+  // is how a CSS rule quietly stops covering anything.
+  it("emits a <br> between list items, not just <li> elements", () => {
+    // The reason `display: inline` alone was not enough: `renderMarkdown` turns
+    // every single newline into `<br>`, so a bullet list — the likeliest thing
+    // Claude writes into a comment — carries one line break per item on top of
+    // the `<li>` boxes. A `<br>`'s normal display IS inline, so flattening the
+    // blocks left every break in place and the one-line teaser stayed N lines.
+    const c = body({ text: "Findings:\n- alpha\n- beta", author: "claude" });
+
+    expect(c.querySelectorAll("li")).toHaveLength(2);
+    expect(c.querySelectorAll("br").length).toBeGreaterThan(0);
+  });
+
+  it("keeps literal newlines inside a fenced block", () => {
+    // The other half: `<pre>` carries `white-space: pre-wrap`, which keeps
+    // honouring these newlines even once the box is inline — so the density rule
+    // has to reset `white-space` too, not just `display`.
+    const pre = body({ text: "```ts\na\nb\n```", author: "claude" }).querySelector("pre");
+    expect(pre?.textContent).toContain("\n");
+  });
+});
+
 describe("AnnotationBody — the tutorial is not accidentally reformatted", () => {
   it("renders every tutorial annotation's content as its literal prose", () => {
     // Tutorial annotations ship with `author: "claude"`, so they now take the

--- a/tests/e2e/annotation-markdown.spec.ts
+++ b/tests/e2e/annotation-markdown.spec.ts
@@ -96,17 +96,34 @@ test("a claude comment renders markdown and still fits its column", async ({ pag
   }));
   expect(fit.scrollWidth).toBeLessThanOrEqual(fit.clientWidth + 1);
 
-  // 3. The link is styled from a theme token rather than the UA's untokened
-  //    blue. `markdown-body.css` had no `a` rule before #1626 — a defect that
-  //    was live in chat too.
-  const linkColor = await card
+  // 3. The link takes its colour from the intended TOKEN. `markdown-body.css`
+  //    had no `a` rule at all before #1626 — a defect that was live in chat too.
+  //
+  //    Compared against the resolved token rather than merely "not UA blue":
+  //    the weaker form passes on any colour, including the inherited body colour
+  //    you would get if the `a` rule were deleted outright. The token is
+  //    resolved through a probe element because its value is an `oklch()` with a
+  //    nested `var()`, so the raw custom-property string cannot be compared to a
+  //    computed one.
+  const { linkColor, expected, inherited } = await card
     .locator(".tandem-markdown a")
-    .evaluate((el) => getComputedStyle(el).color);
-  const bodyAccent = await page.evaluate(() =>
-    getComputedStyle(document.documentElement).getPropertyValue("--tandem-accent").trim(),
-  );
-  expect(bodyAccent).not.toBe("");
-  expect(linkColor).not.toBe("rgb(0, 0, 238)"); // the UA default
+    .evaluate((el) => {
+      const probe = document.createElement("span");
+      probe.style.color = "var(--tandem-accent-fg-strong)";
+      el.parentElement?.appendChild(probe);
+      const expectedColor = getComputedStyle(probe).color;
+      probe.remove();
+      return {
+        linkColor: getComputedStyle(el).color,
+        expected: expectedColor,
+        inherited: getComputedStyle(el.parentElement as HTMLElement).color,
+      };
+    });
+
+  expect(linkColor).toBe(expected);
+  // ...and the token is not coincidentally the same as plain body text, which
+  // would make the assertion above pass with no `a` rule present.
+  expect(expected).not.toBe(inherited);
 });
 
 test("a user comment with the same text renders as literal prose", async ({ page }) => {

--- a/tests/e2e/annotation-markdown.spec.ts
+++ b/tests/e2e/annotation-markdown.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "@playwright/test";
+import path from "path";
+import {
+  cleanupAllOpenDocuments,
+  cleanupFixtureDir,
+  createFixtureDir,
+  McpTestClient,
+  openAnnotatePopup,
+  selectTextStable,
+} from "./helpers";
+
+/**
+ * E2E coverage for #1626 part 1 — markdown in annotation bodies.
+ *
+ * This suite exists because the risk is a LAYOUT risk, and layout is the one
+ * thing the unit tests cannot see. `tests/client/annotation-body.test.ts` runs
+ * under happy-dom, where every element has zero width and `scrollWidth` is
+ * meaningless — so it can prove the right markup is produced and nothing at all
+ * about whether a `<pre>` fits in a 280px rail.
+ *
+ * The specific hazard: a fenced code block has UA `white-space: pre`, so a long
+ * unwrapped line pushes its container arbitrarily wide. Inside the annotation
+ * rail that spills past the column edge — the same failure the stub-band gate in
+ * `margin-view.spec.ts` was written for, arriving by a new route. The existing
+ * gates cannot catch it because no annotation in any other spec contains
+ * markdown.
+ */
+
+let mcp: McpTestClient;
+let tmpDir: string;
+
+// "# Test Document" — the heading prefix is 2 chars, so the title spans 2..15.
+const TITLE_FROM = 2;
+const TITLE_TO = 15;
+const TITLE_TEXT = "Test Document";
+
+// A fenced block whose single line is far wider than any rail, plus an unbroken
+// token — the two shapes that overflow for different reasons (`white-space: pre`
+// and a word with no break opportunity).
+const MARKDOWN_BODY = [
+  "Here is a **suggested** change:",
+  "",
+  "```ts",
+  "const veryLongIdentifier = someFunction(withAnArgument, andAnother, andYetAnotherOne);",
+  "```",
+  "",
+  // An explicit `[label](url)` — this renderer does NOT autolink a bare URL, so
+  // writing one here would silently yield no anchor and the link assertion
+  // below would hang rather than fail on the thing it is about.
+  "See [the docs](https://example.test/a/very/long/path/that/will/not/wrap/at/all).",
+  "",
+  // A bare unbroken token as well: it overflows for a different reason than the
+  // fenced block (no break opportunity, rather than `white-space: pre`).
+  "https://example.test/another/extremely/long/unbroken/token/with/no/spaces/in/it",
+].join("\n");
+
+test.beforeEach(async () => {
+  mcp = new McpTestClient();
+  await mcp.connect();
+  tmpDir = createFixtureDir("sample.md");
+});
+
+test.afterEach(async () => {
+  await cleanupAllOpenDocuments(mcp);
+  await mcp.close();
+  cleanupFixtureDir(tmpDir);
+});
+
+test("a claude comment renders markdown and still fits its column", async ({ page }) => {
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await mcp.callTool("tandem_comment", {
+    from: TITLE_FROM,
+    to: TITLE_TO,
+    text: MARKDOWN_BODY,
+    textSnapshot: TITLE_TEXT,
+  });
+
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+
+  const card = page.locator("[data-testid^='annotation-card-']").first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+
+  // 1. The markdown actually rendered — otherwise the fit assertions below pass
+  //    trivially on plain text, which is the wrong fix for the right reason.
+  await expect(card.locator(".tandem-markdown pre code")).toBeVisible({ timeout: 5_000 });
+  await expect(card.locator(".tandem-markdown strong")).toHaveText("suggested");
+
+  // 2. THE GATE: no horizontal spill. `scrollWidth > clientWidth` is the overflow
+  //    signature; 1px absorbs sub-pixel rounding. Asserted on the card, not on
+  //    the `<pre>` — the block is allowed to scroll inside itself
+  //    (`overflow-x: auto`), it just must not widen the card.
+  const fit = await card.evaluate((el) => ({
+    scrollWidth: (el as HTMLElement).scrollWidth,
+    clientWidth: (el as HTMLElement).clientWidth,
+  }));
+  expect(fit.scrollWidth).toBeLessThanOrEqual(fit.clientWidth + 1);
+
+  // 3. The link is styled from a theme token rather than the UA's untokened
+  //    blue. `markdown-body.css` had no `a` rule before #1626 — a defect that
+  //    was live in chat too.
+  const linkColor = await card
+    .locator(".tandem-markdown a")
+    .evaluate((el) => getComputedStyle(el).color);
+  const bodyAccent = await page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue("--tandem-accent").trim(),
+  );
+  expect(bodyAccent).not.toBe("");
+  expect(linkColor).not.toBe("rgb(0, 0, 238)"); // the UA default
+});
+
+test("a user comment with the same text renders as literal prose", async ({ page }) => {
+  // The gate is on AUTHOR, and it is the half that is easy to lose: rendering
+  // everyone's markdown would silently reformat text a user typed by hand.
+  //
+  // Written through the real popup rather than seeded over MCP, because an MCP
+  // write is Claude-authored by construction — there is no way to ask the server
+  // for a user-authored annotation, and faking one would test a state the app
+  // cannot reach.
+  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
+  await page.goto("/");
+  await expect(page.locator(".tandem-editor")).toContainText(TITLE_TEXT, { timeout: 10_000 });
+
+  const editor = page.locator(".tiptap");
+  await editor.click();
+  await selectTextStable(editor.locator("p").first());
+  await openAnnotatePopup(page);
+  await page.locator("[data-testid='popup-annotation-input']").fill("**not bold** and `not code`");
+  await page.locator("[data-testid='popup-comment-submit']").click();
+
+  const card = page.locator("[data-testid^='annotation-card-']").first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  await expect(card).toContainText("**not bold**", { timeout: 5_000 });
+  await expect(card.locator(".tandem-markdown")).toHaveCount(0);
+});


### PR DESCRIPTION
Closes the rendering half of #1626. **Stacked on #1635** — that PR fixes two `renderMarkdown` defects that would otherwise ship straight into the annotation cards.

Claude writes markdown. The annotation cards printed it raw, so a proposed change in a comment reply arrived as literal backticks and asterisks — the screenshot on the issue.

## Why this wasn't the small change the issue describes

**All three render targets were `<p>`.** Markdown emits block-level children (`<p>`, `<pre>`, `<h1>`, `<li>`); a block inside a `<p>` is invalid, and the parser silently closes the paragraph and reparents the block. The naive change ships a broken layout that reads as a CSS bug and isn't one.

Three defects had to be fixed before the feature could work at all:

| | |
|---|---|
| `<p>` → `<div>` | `CommentThread.svelte`, `CommentCard.svelte`, `SuggestionCard.svelte` |
| CSS unreachable | `.chat-markdown` was component-scoped inside `ChatPanel.svelte` and could not reach markup another component owns |
| CSS incomplete | **no `pre` rule and no `a` rule — a live defect in chat too** |

That third one is worth calling out: a fenced block in chat has UA `white-space: pre` and scrolls the panel sideways, and every link renders in the UA's untokened blue, the one colour in the app that ignores the theme. Both are fixed here, for both surfaces.

## Shape

`AnnotationBody.svelte` is the single place that decides — one `{@html}`, one author predicate, one stylesheet — instead of the same decision copied into three components that would drift. `markdown-body.css` is a plain stylesheet imported from a component `<script>`, which lands global; that is the mechanism that makes it reachable from both panels.

**The author gate is semantic, not security.** A user typing `*load* bearing*` means asterisks, and silently italicising their prose would be editing it. It is **not** a trust boundary: `renderMarkdown`'s escaping is what makes the sink safe, it applies to every author equally, and Claude's output is shaped by document and `.docx` content from outside the project. `"claude"` also covers local-model replies when #1123 M4 arms, with no change needed here.

## Scope, stated rather than implied

`HighlightCard`, `NoteCard` and `ImportedCard` also use `.aca-body` and are deliberately **not** wired. A note is user-authored by definition and an import is a Word comment, so both would be dead branches; a highlight carries no prose worth formatting. The one Claude-authored highlight is `tutorial-highlight-1`, whose copy is plain prose — pinned by a test, so a later `*` added to that copy fails loudly instead of quietly rendering as emphasis.

Export and `.docx` are untouched. This is presentation only.

## Two things found while building it

**A density-clamp interaction.** `.aca-body` carries `-webkit-line-clamp: 1`, which assumes one block child; several would each open their own line box and overflow the clamped band. Markdown descendants are flattened to inline under `is-density-clamped` / `is-density-compact`.

**`renderMarkdown`'s paragraph markup is unbalanced.** `\n\n` → `</p><p>` has no opening tag at the start, so `a\n\nb` parses as the *text node* `a` followed by `<p>b</p>` — the first paragraph is not an element at all. The obvious `> :first-child { margin-top: 0 }` rule therefore selects paragraph **two** and runs the first two together. Verified against a parser rather than assumed; the rule is deliberately absent, with a comment saying why. Balancing it properly is a renderer change that has to keep `<pre>` out of the wrapping `<p>` — the same invalid-nesting trap this PR exists to fix — so it is filed as #1639 rather than done here. That issue owns deleting both workarounds this PR ships (the absent `:first-child` rule and `p:empty`), and probing it against the running renderer turned up the same defect in the list pass: bare `<li>` with no `<ul>`, each preceded by a stray `<br>`.

## Tests

10 unit (`annotation-body.test.ts`) + 2 E2E (`annotation-markdown.spec.ts`).

**The E2E is the load-bearing half and could not have been a unit test.** The risk is *layout* — a fenced block widening the card past the rail — and happy-dom gives every element zero width, so `scrollWidth` there is meaningless. I mutation-checked the gate rather than trusting it: removing `white-space: pre-wrap` and `overflow-wrap: anywhere` makes it fail with `scrollWidth 471`, so it measures what it claims to.

The user-authored arm goes through the real annotate popup, because an MCP write is Claude-authored by construction and faking a user annotation would test a state the app cannot reach.

Two of my test assumptions were wrong before they were right, both corrected rather than worked around:

- Svelte 5 **delegates `click`**, so a native `addEventListener` on a parent is not in the same propagation chain as the card's handler. A test built that way reports a failure that does not exist in the app — the link-vs-card test composes a real `AnnotationCard` instead.
- This renderer **does not autolink a bare URL**. The link assertion needed an explicit `[label](url)`, and with a bare one it hung rather than failing on the thing it was about.

## Verification

- `npm test` — 564 files, 9248 passed, 24 skipped
- `npx playwright test tests/e2e/margin-view.spec.ts` — 35 passed (no regression in the rail-fit gates)
- `npx playwright test tests/e2e/annotation-markdown.spec.ts` — 2 passed
- `npm run typecheck` (incl. `svelte-check --fail-on-warnings`) and `npm run typecheck:tests` — clean
- biome and `npm run check:tokens` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nyKigTTxQV9GpQgW3GzUF

