### PR TITLE
fix(tests): recognise every cfg spelling that gates a test module

### DIFF
--- a/tests/docs/rust-sources.ts
+++ b/tests/docs/rust-sources.ts
@@ -122,13 +122,41 @@ export function stripRustTestModules(src: string): string {
   let out = "";
   let i = 0;
   for (;;) {
-    const at = src.indexOf("#[cfg(test)]", i);
+    const at = nextTestCfg(src, i);
     if (at === -1) return out + src.slice(i);
     const open = src.indexOf("{", at);
     if (open === -1) return out + src.slice(i);
     out += src.slice(i, at);
     i = matchRustBrace(src, open) + 1;
   }
+}
+
+/**
+ * Index of the next `#[cfg(…)]` that gates on `test`, or -1.
+ *
+ * **`#[cfg(test)]` is not the only spelling, and keying on that literal was a
+ * real hole.** `lib.rs` carries two `#[cfg(all(test, target_os = "windows"))]`
+ * modules, and the substring scan this replaced matched neither — so the
+ * "a `#[cfg(test)]` mock defeats the locator identically" defense that
+ * `rustSourceDefining` documents simply did not fire for them. Found by review
+ * while planning Unit 11d, which is the first unit to move a file containing
+ * that spelling into this scan's path.
+ *
+ * `not(` anywhere in the predicate means **don't strip**, and that asymmetry is
+ * deliberate: `#[cfg(not(test))]` gates production code, and the safe error here
+ * is to leave a block in (a scan that reads too much fails loud on the extra
+ * match) rather than to remove one (a scan that reads too little passes
+ * silently).
+ */
+function nextTestCfg(src: string, from: number): number {
+  for (let i = src.indexOf("#[cfg(", from); i !== -1; i = src.indexOf("#[cfg(", i + 1)) {
+    const close = src.indexOf(")]", i);
+    if (close === -1) return -1;
+    const predicate = src.slice(i + "#[cfg(".length, close);
+    if (predicate.includes("not(")) continue;
+    if (/(^|[^A-Za-z0-9_])test([^A-Za-z0-9_]|$)/.test(predicate)) return i;
+  }
+  return -1;
 }
 
 /** Index of the `}` closing the `{` at `open`. Throws if the block never closes. */

--- a/tests/docs/startup-open-failure-wiring-claims.test.ts
+++ b/tests/docs/startup-open-failure-wiring-claims.test.ts
@@ -136,6 +136,30 @@ describe("#1416 open-failure wiring that only source-scanning can pin", () => {
     ).toContain("CODE_AFTER_THE_TEST_MODULE");
     expect(survivor, "the test module itself must still be stripped").not.toContain("not json");
 
+    // `#[cfg(test)]` is not the only spelling. `lib.rs` carries two
+    // `#[cfg(all(test, target_os = "windows"))]` modules, and the substring scan
+    // this stripper used until Unit 11d matched NEITHER — so a scan reading that
+    // file saw their bodies as production code. Both directions are asserted,
+    // because a stripper that fixed the `all(...)` form by matching any cfg
+    // mentioning `test` would eat `#[cfg(not(test))]`, which gates production.
+    const cfgForms = [
+      '#[cfg(all(test, target_os = "windows"))]',
+      '#[cfg(all(test, feature = "x"))]',
+      "#[cfg(test)]",
+    ];
+    for (const attr of cfgForms) {
+      const stripped = stripRustTestModules(
+        [attr, "mod t {", "    fn f() {}", "}", "const AFTER: u8 = 1;"].join("\n"),
+      );
+      expect(stripped, `${attr} must be recognised as a test gate`).not.toContain("fn f()");
+      expect(stripped, `${attr} must not eat what follows it`).toContain("const AFTER");
+    }
+    const production = ["#[cfg(not(test))]", "mod real {", "    fn keep_me() {}", "}"].join("\n");
+    expect(
+      stripRustTestModules(production),
+      "#[cfg(not(test))] gates PRODUCTION code — stripping it would hollow the scan silently",
+    ).toContain("keep_me");
+
     // ...and a block that genuinely never closes fails loud rather than truncating.
     expect(
       () => stripRustTestModules("#[cfg(test)]\nmod t {\n    fn f() {\n"),


### PR DESCRIPTION
A defect in the shared Rust-source scan that [#1646](https://github.com/bloknayrb/tandem/pull/1646) (Unit 11c) introduced, found by review while planning Unit 11d. Split out of that unit because it is a bug fix in merged code and shouldn't wait behind the epic's largest refactor.

## What was wrong

`stripRustTestModules` scanned for the literal string `#[cfg(test)]`. `lib.rs` carries two modules gated as `#[cfg(all(test, target_os = "windows"))]` — `workspace_entry_written_tests` (`lib.rs:3505`) and `cowork_heal_pass_tests` (`lib.rs:4257`) — and that substring matches neither. Both bodies were read as production code by every scan built on the stripper.

The concrete cost is in `rustSourceDefining`, whose doc comment claims a `#[cfg(test)]` mock of a command's shape cannot hijack the module locator *because test modules are stripped first*. For those two spellings, it could. Nothing is wrong on master today — I checked both bodies, and no `fn` name in either collides with anything a locator looks for — but Unit 11d moves exactly that code into a file the locator scans, which is what turns a latent gap into a live one.

## Why no test caught it

The existing control used a `#[cfg(test)]` fixture, so it could only ever exercise the spelling that already worked. This is the repo's own recurring shape: the guard's bug was its anchor, not its matching.

## The `not(` asymmetry is deliberate

`not(` anywhere in the predicate now means **don't strip**. `#[cfg(not(test))]` gates production code, and the safe error for a stripper is to leave a block in — a scan that reads too much fails loud on the extra match — rather than to remove one, which passes silently.

## Verification

- The control now runs three gating spellings (`#[cfg(test)]`, `#[cfg(all(test, target_os = "windows"))]`, `#[cfg(all(test, feature = "x"))]`) and one `#[cfg(not(test))]` counter-case, asserting both directions on each.
- **Measured, not assumed:** reverting the scan to the old substring turns that control red. Run against only that spec, since a whole-file exit code would go red for other reasons.
- `npx vitest run tests/docs/` — 19 files, 147 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QE5fw38BFJgwvrHUxP8GLv
