### PR TITLE
ci: declare least-privilege token scopes for every job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,33 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least privilege for every job here (CodeQL `actions/missing-workflow-permissions`).
+# Without this block each job gets the repository's default token scopes, which on
+# a repo configured for read/write is far more than any of them uses.
+#
+# `contents: read` is the whole set, and it is not the reflex answer — it is what
+# the jobs were audited to need. Nothing in this file comments on a PR, publishes a
+# check run, pushes a ref, or calls the API: there is no `secrets.`, `GITHUB_TOKEN`,
+# `github.token` or `gh` invocation anywhere in it. The cache and artifact services
+# (`Swatinem/rust-cache`, `setup-node`'s `cache: npm`, `upload-artifact` v4+)
+# authenticate with ACTIONS_RUNTIME_TOKEN rather than GITHUB_TOKEN, so they need no
+# scope of their own.
+#
+# **`contents: read` is load-bearing, not decorative.** Besides `actions/checkout`,
+# the `check` job runs `git fetch --no-tags --depth=1 origin tag v0.21.0` over the
+# credential checkout persists — the acceptance harness reads its immutable skill
+# baseline from that tag via `git show`, and `actions/checkout` is depth-1 and
+# tagless. `permissions: {}` would 403 there, and the failure would look like a
+# harness bug rather than a permissions one.
+#
+# Declared at workflow level rather than per job, deliberately: all five jobs need
+# the identical minimum, and inheritance means a job added later is least-privileged
+# by default instead of silently reacquiring the repo default. A future job needing
+# more takes a job-level block — which REPLACES rather than merges, so such an
+# override must restate `contents: read` if it still checks out code.
+permissions:
+  contents: read
+
 jobs:
   rust-test:
     # macos-latest is here for coverage, not parity: the `NativeHost::MacOs`


### PR DESCRIPTION
Closes the five `actions/missing-workflow-permissions` code-scanning alerts (#145, #164, #169, #171, #172) — one per job, and `ci.yml` has exactly five jobs, so every job in the file was flagged.

## Why only this file

The other four workflows already declare scopes (`claude-code-review.yml` and `tauri-webdriver.yml` at workflow level, `publish.yml` and `tauri-release.yml` per job). `ci.yml` had no `permissions:` anywhere, so all five of its jobs ran with whatever the repository default grants.

## `contents: read` is audited, not reflexive

I checked what each job actually does rather than applying the usual answer. There is no `secrets.`, `GITHUB_TOKEN`, `github.token` or `gh` invocation anywhere in the file. Nothing comments on a PR, publishes a check run, pushes a ref, or calls the API. The cache and artifact services — `Swatinem/rust-cache`, `setup-node`'s `cache: npm`, `upload-artifact` v4+ — authenticate with `ACTIONS_RUNTIME_TOKEN` rather than `GITHUB_TOKEN`, so none of them needs a scope.

**It is load-bearing rather than decorative**, which is why the empty `permissions: {}` form this repo uses in `tauri-release.yml`'s `release-check` would be wrong here. Besides `actions/checkout`, the `check` job runs `git fetch --no-tags --depth=1 origin tag v0.21.0` over the credential checkout persists — the acceptance harness reads its immutable v9 skill baseline from that tag via `git show`, and `actions/checkout` is depth-1 and tagless. Denying contents would 403 there, and the failure would read as a harness bug rather than a permissions one.

## Workflow-level, deliberately

All five jobs need the identical minimum, so per-job blocks would be five copies of one line — and the failure modes differ. Inherited scopes mean a job added later is least-privileged by default; with per-job blocks only, the next job silently reacquires the repo default and this alert class comes back. A future job that genuinely needs more takes a job-level block, which **replaces** rather than merges — so such an override must restate `contents: read` if it still checks out code. That's noted in the file.

## What could have broken, and didn't

Four tests parse `ci.yml`: the acceptance-harness, windows-acl-proof, typecheck-tests and coverage-manifest wiring guards. A repo-wide search confirms there is no fifth consumer, so this is complete rather than sampled. Each was checked against the parsed document rather than assumed — they read `on`, `defaults`, `jobs` entries and per-step keys, and the coverage one line-scans for `TANDEM_COVERAGE`. A workflow-level `permissions` key is none of those, and there is no key-count, ordering, byte-length or snapshot assertion on the workflow anywhere.

`npx vitest run tests/scripts` — 13 files, 227 passed.

**CI on this PR is the real verification** that `contents: read` is sufficient: a scope that is too narrow fails loudly at the tag fetch, not silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QE5fw38BFJgwvrHUxP8GLv
