### PR TITLE
refactor(annotations): wire the sanitization relay through accept/dismiss (ADR-035 Unit 8d)

### DIFF
--- a/src/server/annotations/lifecycle.ts
+++ b/src/server/annotations/lifecycle.ts
@@ -316,10 +316,18 @@ export interface AnnotationLifecycle {
    * programme exists to stop.
    */
   editPending(id: string, patch: EditPatch, onLossy: OnLossy): EditResult;
-  /** Accept a pending annotation (pending → accepted). */
-  accept(id: string): LifecycleResult<Annotation>;
-  /** Dismiss a pending annotation (pending → dismissed). */
-  dismiss(id: string): LifecycleResult<Annotation>;
+  /**
+   * Accept a pending annotation (pending → accepted).
+   *
+   * `onLossy` is required for the same reason it is on {@link editPending}: a
+   * sink with a default is a sink a caller can neuter without saying so. Unit
+   * 8d wired the real relay here; before that this path sanitized into
+   * `() => {}` and every legacy-shape migration performed on an accept was
+   * invisible.
+   */
+  accept(id: string, onLossy: OnLossy): LifecycleResult<Annotation>;
+  /** Dismiss a pending annotation (pending → dismissed). See {@link accept}. */
+  dismiss(id: string, onLossy: OnLossy): LifecycleResult<Annotation>;
 }
 
 /**
@@ -365,8 +373,8 @@ export function createAnnotationLifecycle(ydoc: Y.Doc): AnnotationLifecycle {
       annotation: mintAnnotation(ydoc, map, "comment", input.anchored, input.content, input.extras),
     }),
     editPending: (id, patch, onLossy) => editPendingAnnotation(id, ydoc, map, patch, onLossy),
-    accept: (id) => transitionPending(id, ydoc, map, "accepted"),
-    dismiss: (id) => transitionPending(id, ydoc, map, "dismissed"),
+    accept: (id, onLossy) => transitionPending(id, ydoc, map, "accepted", onLossy),
+    dismiss: (id, onLossy) => transitionPending(id, ydoc, map, "dismissed", onLossy),
   };
 }
 
@@ -494,23 +502,28 @@ function transitionPending(
   ydoc: Y.Doc,
   map: Y.Map<unknown>,
   nextStatus: "accepted" | "dismissed",
+  onLossy: OnLossy,
 ): LifecycleResult<Annotation> {
   const raw = map.get(id);
   if (raw === undefined) return { kind: "not-found", id };
 
   // Sanitize first so the status check + result arm both see normalized
-  // fields. `sanitizeAnnotation` accepts a `RawAnnotation` shape (which
-  // permits legacy fields); the lifecycle uses a no-op sink for migration
-  // events because docHash-keyed relay belongs upstream of the lifecycle
-  // (scoped to the doc context, not the per-mutation seam).
+  // fields. `sanitizeAnnotation` accepts a `RawAnnotation` shape, which permits
+  // legacy fields.
   //
-  // Unit 8b deliberately left this a no-op. Wiring the real
-  // `relaySanitizationEvent` here would change accept/dismiss behavior —
-  // accepting a legacy `flag` would begin emitting a migration log line and
-  // consuming a dedup slot — inside a PR whose subject is create, which would
-  // make it non-cleanly revertible against Unit 8d. The upgrade belongs to 8d,
-  // where accept/dismiss is the subject and can be tested.
-  const ann = sanitizeAnnotation(raw as RawAnnotation, () => {});
+  // **Unit 8d replaced the `() => {}` that stood here.** Until then, accepting a
+  // legacy-shaped record silently performed the migration and reported nothing:
+  // the sink was a no-op, so `flag→note`, `question→comment`, a malformed
+  // suggestion JSON and an unknown type all normalized without a log line.
+  //
+  // **This emits even when the write is then refused**, and that ordering is
+  // worth stating because it reads backwards. A stored `flag` sanitizes to a
+  // note, fires `flag-to-note` HERE, and only then hits the ADR-027 guard below
+  // and returns `invalid-note` — so the migration is reported for a transition
+  // that never happened. That is correct: the event describes what sanitize
+  // read, not what the lifecycle wrote, and the relay is an observability sink
+  // rather than an audit of mutations.
+  const ann = sanitizeAnnotation(raw as RawAnnotation, onLossy);
 
   // ADR-027 (#1680): notes are user-private. Claude must not resolve them.
   //
@@ -632,18 +645,35 @@ function editPendingAnnotation(
   return { kind: "ok", annotation: updated };
 }
 
+/**
+ * Pre-ADR-035 accept entry point.
+ *
+ * **No production caller reaches these two** — `YDocStore` goes through
+ * {@link createAnnotationLifecycle}, and a census of `src/` finds only these
+ * definitions. They survive because the seam census
+ * (`tests/server/annotation-create-seam-census.test.ts`) names them and roughly
+ * thirty specs drive them; retiring them is Unit 8j's, along with
+ * {@link mintAnnotation}.
+ *
+ * `onLossy` is required here too rather than defaulted, so a test driving this
+ * export cannot accidentally be measuring a different sanitize contract from
+ * the one production runs.
+ */
 export function acceptPending(
   id: string,
   ydoc: Y.Doc,
   map: Y.Map<unknown>,
+  onLossy: OnLossy,
 ): LifecycleResult<Annotation> {
-  return transitionPending(id, ydoc, map, "accepted");
+  return transitionPending(id, ydoc, map, "accepted", onLossy);
 }
 
+/** Pre-ADR-035 dismiss entry point. See {@link acceptPending}. */
 export function dismissPending(
   id: string,
   ydoc: Y.Doc,
   map: Y.Map<unknown>,
+  onLossy: OnLossy,
 ): LifecycleResult<Annotation> {
-  return transitionPending(id, ydoc, map, "dismissed");
+  return transitionPending(id, ydoc, map, "dismissed", onLossy);
 }

--- a/src/server/mcp/document-store.ts
+++ b/src/server/mcp/document-store.ts
@@ -261,21 +261,29 @@ export class YDocStore implements DocumentStore {
    * Delegates to the lifecycle (ADR-034/035 Unit 8c). The guards, the `rev`
    * bump and the `withMcp` tag all live there now.
    *
-   * **The sink is passed, not defaulted.** `transitionPending` supplies a no-op
-   * whose wiring is deferred to Unit 8d; edit already had a real relay at this
-   * caller, and handing it down is what stops 8d's decision from silently
-   * becoming edit's.
+   * **The sink is passed, not defaulted**, and as of Unit 8d every mutation
+   * method on this store does the same.
    */
   editAnnotation(id: string, patch: EditPatch): EditAnnotationResult {
     return this.lifecycle.editPending(id, patch, (e) => this.onLossy(e));
   }
 
+  /**
+   * Delegates to the lifecycle, passing the store's real relay (Unit 8d).
+   *
+   * `(e) => this.onLossy(e)` rather than `this.onLossy` — the method reads
+   * `this.docHash`, and an unbound reference loses it. That failure is not
+   * loud: `logLegacyMigration` treats an undefined docHash as a reason to skip
+   * dedup and log unconditionally, so the relay would still print and only the
+   * per-document keying would be gone.
+   */
   acceptAnnotation(id: string): LifecycleResult<Annotation> {
-    return this.lifecycle.accept(id);
+    return this.lifecycle.accept(id, (e) => this.onLossy(e));
   }
 
+  /** See {@link acceptAnnotation}. */
   dismissAnnotation(id: string): LifecycleResult<Annotation> {
-    return this.lifecycle.dismiss(id);
+    return this.lifecycle.dismiss(id, (e) => this.onLossy(e));
   }
 
   /**

--- a/tests/helpers/ydoc-factory.ts
+++ b/tests/helpers/ydoc-factory.ts
@@ -4,6 +4,7 @@ import { populateYDoc } from "../../src/server/mcp/document.js";
 import { anchoredRange } from "../../src/server/positions.js";
 import { Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import { type AnchoredRangeResult, toFlatOffset } from "../../src/shared/positions/types.js";
+import type { OnLossy } from "../../src/shared/sanitize.js";
 import type { Annotation } from "../../src/shared/types.js";
 
 /** Create a Y.Doc populated with text content */
@@ -98,4 +99,56 @@ export function rangeOf(from: number, to: number, ydoc: Y.Doc): AnchoredRangeRes
   const result = anchoredRange(ydoc, toFlatOffset(from), toFlatOffset(to));
   if (!result.ok) throw new Error("anchoredRange failed in test helper");
   return result;
+}
+
+/**
+ * Write a RAW annotation record straight into the map, bypassing the mint path.
+ *
+ * The point is to store a shape production never produces — a legacy `flag` or
+ * `question`, an explicit `audience: "outbound"` on a user note — so a spec can
+ * exercise the sanitize-then-guard ordering that only such a record reaches.
+ * `makeAnnotation` above is the opposite tool: it builds a WELL-FORMED record.
+ *
+ * Deliberately untyped in `extra`: a `Partial<Annotation>` would reject exactly
+ * the legacy shapes this exists to write.
+ */
+export function seedRawAnnotation(
+  map: Y.Map<unknown>,
+  doc: Y.Doc,
+  id: string,
+  extra: Record<string, unknown>,
+): void {
+  map.set(id, {
+    id,
+    type: "comment",
+    author: "user",
+    audience: "private",
+    status: "pending",
+    range: rangeOf(0, 5, doc).range,
+    content: "legacy",
+    timestamp: Date.now(),
+    rev: 1,
+    ...extra,
+  });
+}
+
+/**
+ * A sink that discards migration events.
+ *
+ * Named rather than written inline at each call so a reader can tell "this spec
+ * does not care about the relay" from "this spec forgot" — the distinction the
+ * required-not-defaulted `onLossy` parameter exists to make visible in the
+ * first place. Specs that DO care pass their own sink.
+ */
+export const noRelay: OnLossy = () => {};
+
+/**
+ * Drop the two fields that legitimately differ between any two annotations
+ * minted a moment apart, so two records can be compared whole.
+ *
+ * Whole-record comparison rather than a field list on purpose: a list silently
+ * stops covering whatever field is added next.
+ */
+export function normalizeForParity(a: Annotation): Annotation {
+  return { ...a, id: "", timestamp: 0 } as Annotation;
 }

--- a/tests/server/adr027-note-write-guards.test.ts
+++ b/tests/server/adr027-note-write-guards.test.ts
@@ -27,8 +27,15 @@ import { processInboxAnnotations } from "../../src/server/mcp/awareness.js";
 import { YDocStore } from "../../src/server/mcp/document-store.js";
 import { TUTORIAL_ANNOTATIONS } from "../../src/server/mcp/tutorial-annotations.js";
 import { Y_MAP_ANNOTATION_REPLIES } from "../../src/shared/constants.js";
+import type { OnLossy } from "../../src/shared/sanitize.js";
 import type { Annotation } from "../../src/shared/types.js";
 import { getAnnotationsMap, makeDoc, rangeOf } from "../helpers/ydoc-factory.js";
+
+/** No sink: these specs are about the guards and the write, not the relay.
+ *  Named rather than inlined so "does not care" is distinguishable from
+ *  "forgot" at a glance. The relay's own coverage lives in the specs that pass
+ *  a real one. */
+const noRelay: OnLossy = () => {};
 
 let doc: Y.Doc;
 let map: Y.Map<unknown>;
@@ -67,7 +74,7 @@ describe("resolve refuses notes (ADR-027)", () => {
     seed("n1", { type: "note" });
     const before = { ...(map.get("n1") as Annotation) };
 
-    const result = acceptPending("n1", doc, map);
+    const result = acceptPending("n1", doc, map, noRelay);
 
     expect(result).toStrictEqual({ kind: "invalid-note" });
     expect(map.get("n1"), "a guard that returns after the write passes an arm check").toStrictEqual(
@@ -80,7 +87,7 @@ describe("resolve refuses notes (ADR-027)", () => {
     // above. This is the positive control for the guard, not for the harness.
     seed("c1", { type: "comment", author: "claude", audience: "outbound" });
 
-    const result = acceptPending("c1", doc, map);
+    const result = acceptPending("c1", doc, map, noRelay);
 
     expect(result.kind).toBe("ok");
     expect((map.get("c1") as Annotation).status).toBe("accepted");
@@ -93,8 +100,8 @@ describe("resolve refuses notes (ADR-027)", () => {
     // exists and is merely resolved — a disclosure ADR-027 does not make.
     seed("n2", { type: "note", status: "dismissed" });
 
-    expect(acceptPending("n2", doc, map)).toStrictEqual({ kind: "invalid-note" });
-    expect(dismissPending("n2", doc, map)).toStrictEqual({ kind: "invalid-note" });
+    expect(acceptPending("n2", doc, map, noRelay)).toStrictEqual({ kind: "invalid-note" });
+    expect(dismissPending("n2", doc, map, noRelay)).toStrictEqual({ kind: "invalid-note" });
   });
 
   it("refuses a stored `flag`, which is a note only after sanitize", () => {
@@ -104,7 +111,7 @@ describe("resolve refuses notes (ADR-027)", () => {
     // guard sits after sanitize rather than before it.
     seed("f1", { type: "flag" });
 
-    expect(acceptPending("f1", doc, map)).toStrictEqual({ kind: "invalid-note" });
+    expect(acceptPending("f1", doc, map, noRelay)).toStrictEqual({ kind: "invalid-note" });
     expect((map.get("f1") as Annotation).status, "and it is not resolved").toBe("pending");
   });
 
@@ -113,7 +120,7 @@ describe("resolve refuses notes (ADR-027)", () => {
     // swallowed the pending arm for non-notes.
     seed("c2", { type: "comment", author: "claude", audience: "outbound", status: "accepted" });
 
-    expect(acceptPending("c2", doc, map)).toStrictEqual({
+    expect(acceptPending("c2", doc, map, noRelay)).toStrictEqual({
       kind: "not-pending",
       id: "c2",
       currentStatus: "accepted",
@@ -240,8 +247,8 @@ describe("the tutorial note, which is the reachable instance", () => {
     expect(noteId, "and its id is still a constant, not a nonce").toBe("tutorial-note-1");
     seed(noteId, { type: "note" });
 
-    expect(acceptPending(noteId, doc, map)).toStrictEqual({ kind: "invalid-note" });
-    expect(dismissPending(noteId, doc, map)).toStrictEqual({ kind: "invalid-note" });
+    expect(acceptPending(noteId, doc, map, noRelay)).toStrictEqual({ kind: "invalid-note" });
+    expect(dismissPending(noteId, doc, map, noRelay)).toStrictEqual({ kind: "invalid-note" });
     expect(store.removeAnnotation(noteId).ok).toBe(false);
     expect(map.has(noteId), "and it is still there").toBe(true);
   });

--- a/tests/server/adr027-note-write-guards.test.ts
+++ b/tests/server/adr027-note-write-guards.test.ts
@@ -27,15 +27,8 @@ import { processInboxAnnotations } from "../../src/server/mcp/awareness.js";
 import { YDocStore } from "../../src/server/mcp/document-store.js";
 import { TUTORIAL_ANNOTATIONS } from "../../src/server/mcp/tutorial-annotations.js";
 import { Y_MAP_ANNOTATION_REPLIES } from "../../src/shared/constants.js";
-import type { OnLossy } from "../../src/shared/sanitize.js";
 import type { Annotation } from "../../src/shared/types.js";
-import { getAnnotationsMap, makeDoc, rangeOf } from "../helpers/ydoc-factory.js";
-
-/** No sink: these specs are about the guards and the write, not the relay.
- *  Named rather than inlined so "does not care" is distinguishable from
- *  "forgot" at a glance. The relay's own coverage lives in the specs that pass
- *  a real one. */
-const noRelay: OnLossy = () => {};
+import { getAnnotationsMap, makeDoc, noRelay, seedRawAnnotation } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 let map: Y.Map<unknown>;
@@ -49,21 +42,9 @@ beforeEach(() => {
   store = new YDocStore(doc, "C:/tmp/guards.md", "doc-guards");
 });
 
-/** Seed a record RAW so a spec can choose a stored shape the mint path would
- *  never produce — a `flag` in particular, which is a note only post-sanitize. */
+/** Shorthand for the shared raw-record seeder, bound to this file's doc. */
 function seed(id: string, extra: Record<string, unknown>): void {
-  map.set(id, {
-    id,
-    type: "comment",
-    author: "user",
-    audience: "private",
-    status: "pending",
-    range: rangeOf(0, 5, doc).range,
-    content: "private thought",
-    timestamp: Date.now(),
-    rev: 1,
-    ...extra,
-  });
+  seedRawAnnotation(map, doc, id, extra);
 }
 
 describe("resolve refuses notes (ADR-027)", () => {

--- a/tests/server/annotation-lifecycle.test.ts
+++ b/tests/server/annotation-lifecycle.test.ts
@@ -13,8 +13,16 @@ import { beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import { acceptPending, dismissPending } from "../../src/server/annotations/lifecycle.js";
 import { createAnnotation } from "../../src/server/mcp/annotations.js";
+import { MCP_ORIGIN } from "../../src/shared/origins.js";
+import type { OnLossy } from "../../src/shared/sanitize.js";
 import type { Annotation } from "../../src/shared/types.js";
 import { getAnnotationsMap, makeDoc, rangeOf } from "../helpers/ydoc-factory.js";
+
+/** No sink: these specs are about the guards and the write, not the relay.
+ *  Named rather than inlined so "does not care" is distinguishable from
+ *  "forgot" at a glance. The relay's own coverage lives in the specs that pass
+ *  a real one. */
+const noRelay: OnLossy = () => {};
 
 let doc: Y.Doc;
 
@@ -28,7 +36,7 @@ describe("acceptPending", () => {
     const id = createAnnotation(map, doc, "comment", rangeOf(0, 5, doc), "test");
     const before = map.get(id) as Annotation;
 
-    const result = acceptPending(id, doc, map);
+    const result = acceptPending(id, doc, map, noRelay);
 
     expect(result.kind).toBe("ok");
     if (result.kind !== "ok") throw new Error("unreachable");
@@ -37,21 +45,58 @@ describe("acceptPending", () => {
 
     const after = map.get(id) as Annotation;
     expect(after.status).toBe("accepted");
+    // The STORED rev, not just the returned one. Until Unit 8d this line was
+    // absent and the title's "bumps rev" was satisfied by the return value
+    // alone — a write of `{...updated, rev: ann.rev}` passed, and so did
+    // `nextRev(ann) -> nextRev()`, which pins every accept at 1.
+    expect(after.rev, "the rev that was WRITTEN, which is the one that matters").toBe(
+      result.data.rev,
+    );
+    expect(after.rev).toBeGreaterThan(before.rev ?? 0);
+  });
+
+  it("preserves every field the record already carried", () => {
+    // **The highest-value spec in this file, and the family had nothing like
+    // it.** Accept is the most common resolve action, and `transitionPending`
+    // rebuilds the record with a spread. Replace that spread with a
+    // field-listing rebuild — or write the RAW record instead of the sanitized
+    // one — and `relRange`, `textSnapshot`, `audience` and `suggestedText` fall
+    // off silently. A dropped `relRange` is CRDT degradation: the annotation
+    // falls back to flat offsets and drifts on the next edit.
+    //
+    // It reads `map.get(id)`, never `result.data`, because the two mutants
+    // differ exactly there — `result.data` IS the object the literal built, so
+    // a return-value assertion cannot see a divergent write.
+    const map = getAnnotationsMap(doc);
+    const id = createAnnotation(map, doc, "comment", rangeOf(0, 5, doc), "test", {
+      suggestedText: "replacement",
+      textSnapshot: "Hello",
+    });
+    const before = map.get(id) as Annotation;
+    expect(before.relRange, "fixture precondition: the record is anchored").toBeDefined();
+
+    acceptPending(id, doc, map, noRelay);
+
+    const after = map.get(id) as Annotation;
+    // Status and rev are the two fields the transition OWNS; everything else
+    // must survive byte-for-byte, so assert the whole record rather than a
+    // field list that a future field would silently escape.
+    expect(after).toStrictEqual({ ...before, status: "accepted", rev: after.rev });
   });
 
   it("returns kind: 'not-found' when the annotation doesn't exist", () => {
     const map = getAnnotationsMap(doc);
-    const result = acceptPending("nonexistent", doc, map);
+    const result = acceptPending("nonexistent", doc, map, noRelay);
     expect(result.kind).toBe("not-found");
   });
 
   it("returns kind: 'not-pending' for an already-accepted annotation; rev unchanged", () => {
     const map = getAnnotationsMap(doc);
     const id = createAnnotation(map, doc, "comment", rangeOf(0, 5, doc), "test");
-    acceptPending(id, doc, map); // first accept
+    acceptPending(id, doc, map, noRelay); // first accept
     const acceptedRev = (map.get(id) as Annotation).rev;
 
-    const result = acceptPending(id, doc, map); // second accept attempt
+    const result = acceptPending(id, doc, map, noRelay); // second accept attempt
 
     expect(result.kind).toBe("not-pending");
     if (result.kind !== "not-pending") throw new Error("unreachable");
@@ -65,9 +110,9 @@ describe("acceptPending", () => {
   it("returns kind: 'not-pending' for an already-dismissed annotation", () => {
     const map = getAnnotationsMap(doc);
     const id = createAnnotation(map, doc, "comment", rangeOf(0, 5, doc), "test");
-    dismissPending(id, doc, map);
+    dismissPending(id, doc, map, noRelay);
 
-    const result = acceptPending(id, doc, map);
+    const result = acceptPending(id, doc, map, noRelay);
     expect(result.kind).toBe("not-pending");
     if (result.kind !== "not-pending") throw new Error("unreachable");
     expect(result.currentStatus).toBe("dismissed");
@@ -79,7 +124,7 @@ describe("dismissPending", () => {
     const map = getAnnotationsMap(doc);
     const id = createAnnotation(map, doc, "comment", rangeOf(0, 5, doc), "test");
 
-    const result = dismissPending(id, doc, map);
+    const result = dismissPending(id, doc, map, noRelay);
     expect(result.kind).toBe("ok");
     if (result.kind !== "ok") throw new Error("unreachable");
     expect(result.data.status).toBe("dismissed");
@@ -88,10 +133,32 @@ describe("dismissPending", () => {
   it("returns kind: 'not-pending' for an already-resolved annotation", () => {
     const map = getAnnotationsMap(doc);
     const id = createAnnotation(map, doc, "comment", rangeOf(0, 5, doc), "test");
-    acceptPending(id, doc, map);
+    acceptPending(id, doc, map, noRelay);
 
-    const result = dismissPending(id, doc, map);
+    const result = dismissPending(id, doc, map, noRelay);
     expect(result.kind).toBe("not-pending");
+  });
+
+  it("returns kind: 'not-found' when the annotation doesn't exist", () => {
+    // Accept had this arm covered and dismiss did not. The two share a body
+    // today, which is exactly why the asymmetry was invisible — and why it
+    // would stay invisible if the bodies ever diverged.
+    const map = getAnnotationsMap(doc);
+
+    expect(dismissPending("nonexistent", doc, map, noRelay)).toStrictEqual({
+      kind: "not-found",
+      id: "nonexistent",
+    });
+  });
+
+  it("bumps the STORED rev", () => {
+    const map = getAnnotationsMap(doc);
+    const id = createAnnotation(map, doc, "comment", rangeOf(0, 5, doc), "test");
+    const before = map.get(id) as Annotation;
+
+    dismissPending(id, doc, map, noRelay);
+
+    expect((map.get(id) as Annotation).rev).toBeGreaterThan(before.rev ?? 0);
   });
 });
 
@@ -99,8 +166,14 @@ describe("transactions are tagged with MCP_ORIGIN (channel-event skip)", () => {
   // ADR-031: catches a wrong-helper substitution (e.g. `withBrowser` for
   // `withMcp`) that the raw-`doc.transact` pre-commit hook cannot see.
   it.each([
-    ["acceptPending", (id: string, d: Y.Doc, m: Y.Map<unknown>) => acceptPending(id, d, m)],
-    ["dismissPending", (id: string, d: Y.Doc, m: Y.Map<unknown>) => dismissPending(id, d, m)],
+    [
+      "acceptPending",
+      (id: string, d: Y.Doc, m: Y.Map<unknown>) => acceptPending(id, d, m, noRelay),
+    ],
+    [
+      "dismissPending",
+      (id: string, d: Y.Doc, m: Y.Map<unknown>) => dismissPending(id, d, m, noRelay),
+    ],
   ])("%s fires under MCP_ORIGIN", (_label, op) => {
     const map = getAnnotationsMap(doc);
     const id = createAnnotation(map, doc, "comment", rangeOf(0, 5, doc), "test");
@@ -110,6 +183,13 @@ describe("transactions are tagged with MCP_ORIGIN (channel-event skip)", () => {
 
     op(id, doc, map);
 
-    expect(origins).toContain("mcp");
+    // `toStrictEqual`, not `toContain`. The describe title claims a
+    // CHANNEL-EVENT SKIP, and existence cannot establish that: a correct
+    // `withMcp` write plus a spurious `withBrowser` echo contains "mcp" and
+    // emits the channel event anyway. Sound as a bare equality here only
+    // because the listener is attached after `createAnnotation` and nothing
+    // else transacts in this spec — do NOT add a `tr.changed` key filter, which
+    // is empty on `beforeTransaction` and would silently assert over `[]`.
+    expect(origins).toStrictEqual([MCP_ORIGIN]);
   });
 });

--- a/tests/server/annotation-lifecycle.test.ts
+++ b/tests/server/annotation-lifecycle.test.ts
@@ -14,15 +14,8 @@ import * as Y from "yjs";
 import { acceptPending, dismissPending } from "../../src/server/annotations/lifecycle.js";
 import { createAnnotation } from "../../src/server/mcp/annotations.js";
 import { MCP_ORIGIN } from "../../src/shared/origins.js";
-import type { OnLossy } from "../../src/shared/sanitize.js";
 import type { Annotation } from "../../src/shared/types.js";
-import { getAnnotationsMap, makeDoc, rangeOf } from "../helpers/ydoc-factory.js";
-
-/** No sink: these specs are about the guards and the write, not the relay.
- *  Named rather than inlined so "does not care" is distinguishable from
- *  "forgot" at a glance. The relay's own coverage lives in the specs that pass
- *  a real one. */
-const noRelay: OnLossy = () => {};
+import { getAnnotationsMap, makeDoc, noRelay, rangeOf } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 
@@ -72,7 +65,13 @@ describe("acceptPending", () => {
       suggestedText: "replacement",
       textSnapshot: "Hello",
     });
-    const before = map.get(id) as Annotation;
+    // **A SPREAD, not the reference.** `map.get` hands back the stored object, so
+    // a bare `const before = map.get(id)` is a live alias — and a mutant that
+    // writes the record in place (`Object.assign(raw, updated); map.set(id, raw)`)
+    // then makes the assertion below compare an object to a spread of itself and
+    // pass. Measured, not reasoned: that mutant left this spec green and reds
+    // only the two rev specs.
+    const before = { ...(map.get(id) as Annotation) };
     expect(before.relRange, "fixture precondition: the record is anchored").toBeDefined();
 
     acceptPending(id, doc, map, noRelay);
@@ -80,8 +79,13 @@ describe("acceptPending", () => {
     const after = map.get(id) as Annotation;
     // Status and rev are the two fields the transition OWNS; everything else
     // must survive byte-for-byte, so assert the whole record rather than a
-    // field list that a future field would silently escape.
-    expect(after).toStrictEqual({ ...before, status: "accepted", rev: after.rev });
+    // field list that a future field would silently escape. `rev` is asserted
+    // by its own specs above and below — reading it off `after` here would be
+    // circular, so it is excluded from the comparison rather than smuggled in.
+    const { rev: _afterRev, ...afterRest } = after;
+    const { rev: _beforeRev, ...beforeRest } = before;
+    expect(afterRest).toStrictEqual({ ...beforeRest, status: "accepted" });
+    expect(after.rev, "and the transition did bump it").toBeGreaterThan(before.rev ?? 0);
   });
 
   it("returns kind: 'not-found' when the annotation doesn't exist", () => {
@@ -183,13 +187,21 @@ describe("transactions are tagged with MCP_ORIGIN (channel-event skip)", () => {
 
     op(id, doc, map);
 
-    // `toStrictEqual`, not `toContain`. The describe title claims a
-    // CHANNEL-EVENT SKIP, and existence cannot establish that: a correct
-    // `withMcp` write plus a spurious `withBrowser` echo contains "mcp" and
-    // emits the channel event anyway. Sound as a bare equality here only
-    // because the listener is attached after `createAnnotation` and nothing
-    // else transacts in this spec — do NOT add a `tr.changed` key filter, which
-    // is empty on `beforeTransaction` and would silently assert over `[]`.
-    expect(origins).toStrictEqual([MCP_ORIGIN]);
+    // The title claims a CHANNEL-EVENT SKIP, and `toContain("mcp")` cannot
+    // establish it: a correct `withMcp` write plus a spurious `withBrowser`
+    // echo contains "mcp" and emits the channel event anyway. So assert the
+    // absence of any other origin, plus that something happened at all.
+    //
+    // Phrased that way rather than as `toStrictEqual([MCP_ORIGIN])` on purpose:
+    // an exact-array pin also reds a refactor that splits the write into two
+    // `withMcp` transactions, which emits no channel event and does not violate
+    // this title. The invariant is "nothing but mcp", not "exactly one write".
+    //
+    // Sound with no `tr.changed` key filter only because the listener is
+    // attached after `createAnnotation` and nothing else transacts here — do
+    // NOT add one, since `changed` is empty on `beforeTransaction` and the
+    // filter would silently assert over `[]`.
+    expect(origins.filter((o) => o !== MCP_ORIGIN)).toStrictEqual([]);
+    expect(origins.length, "and the write happened").toBeGreaterThan(0);
   });
 });

--- a/tests/server/annotation-tools.test.ts
+++ b/tests/server/annotation-tools.test.ts
@@ -19,7 +19,7 @@ import {
 import type { Annotation } from "../../src/shared/types.js";
 import { clearOpenDocs, setupDoc } from "../helpers/doc-service.js";
 import { unanchored } from "../helpers/positions.js";
-import { rangeOf } from "../helpers/ydoc-factory.js";
+import { noRelay, rangeOf } from "../helpers/ydoc-factory.js";
 
 const DOC_HASH = "sha256:annotation-tools";
 
@@ -199,7 +199,7 @@ describe("tandem_resolveAnnotation tool logic", () => {
     const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, ydoc, "comment", unanchored(0, 5), "review me");
 
-    const result = op(id, ydoc, map, () => {});
+    const result = op(id, ydoc, map, noRelay);
 
     expect(result.kind).toBe("ok");
     expect((map.get(id) as Annotation).status).toBe(want);

--- a/tests/server/annotation-tools.test.ts
+++ b/tests/server/annotation-tools.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
+import { acceptPending, dismissPending } from "../../src/server/annotations/lifecycle.js";
 import { exportAnnotations } from "../../src/server/file-io/docx.js";
 import {
   collectAnnotations,
@@ -185,28 +186,23 @@ describe("tandem_getAnnotations tool logic", () => {
 });
 
 describe("tandem_resolveAnnotation tool logic", () => {
-  it("accepts an annotation", () => {
-    const ydoc = setupDoc("ra-1", "Hello world");
+  // **These two hand-wrote `map.set({...ann, status})` and then asserted their
+  // own write**, so deleting `transitionPending` outright left them green under
+  // exactly the title someone searching for resolve coverage would find. They
+  // now drive the real functions. (The hand `map.set` calls were also untagged
+  // raw writes — Critical Rule 2 hygiene, gone with them.)
+  it.each([
+    ["accepts", acceptPending, "accepted"],
+    ["dismisses", dismissPending, "dismissed"],
+  ])("%s an annotation", (_label, op, want) => {
+    const ydoc = setupDoc(`ra-${want}`, "Hello world");
     const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const id = createAnnotation(map, ydoc, "comment", unanchored(0, 5), "review me");
 
-    const ann = map.get(id) as Annotation;
-    map.set(id, { ...ann, status: "accepted" as const });
+    const result = op(id, ydoc, map, () => {});
 
-    const updated = map.get(id) as Annotation;
-    expect(updated.status).toBe("accepted");
-  });
-
-  it("dismisses an annotation", () => {
-    const ydoc = setupDoc("ra-2", "Hello world");
-    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
-    const id = createAnnotation(map, ydoc, "comment", unanchored(0, 5), "review me");
-
-    const ann = map.get(id) as Annotation;
-    map.set(id, { ...ann, status: "dismissed" as const });
-
-    const updated = map.get(id) as Annotation;
-    expect(updated.status).toBe("dismissed");
+    expect(result.kind).toBe("ok");
+    expect((map.get(id) as Annotation).status).toBe(want);
   });
 
   it("returns error for non-existent annotation ID", () => {

--- a/tests/server/annotation-transition-relay.test.ts
+++ b/tests/server/annotation-transition-relay.test.ts
@@ -17,13 +17,20 @@
  *
  * **Three hazards make a relay spec silently vacuous, and all three are handled
  * here rather than noted.** `logLegacyMigration` dedups on `${docHash}:${kind}`
- * in module-level state, so (1) `resetMigrationLog()` runs before every spec;
- * (2) each spec uses its OWN `filePath`, since every store in
- * `document-store.test.ts` shares `/tmp/doc.md` and one relay anywhere in a file
- * silences every later assertion of the same kind; and (3) no spec reads an
- * annotation before the transition — `listAnnotations` AND the single-record
- * `getAnnotation` both relay under the same key, and `removeAnnotation` calls
- * `getAnnotation` internally, so a read is an invisible consumer.
+ * in module-level state, so (1) `resetMigrationLog()` runs before every spec —
+ * **this is the one that carries the invariant**; and (2) no spec reads an
+ * annotation before the transition, because `listAnnotations` AND the
+ * single-record `getAnnotation` both relay under the same key, and
+ * `removeAnnotation` calls `getAnnotation` internally, so a read is an
+ * invisible consumer.
+ *
+ * The per-spec `filePath` below is redundancy, deliberately not stated as a
+ * requirement: `beforeEach` already clears the Set and vitest isolates module
+ * state per file, so `document-store.test.ts`'s shared `/tmp/doc.md` cannot
+ * reach here. It costs nothing and it means a future `resetMigrationLog`
+ * removal degrades instead of silently voiding the file — but calling it
+ * necessary would be inventing the kind of folk rule this header exists to
+ * prevent.
  *
  * The assertion is a **count of exactly one message naming this doc's hash**,
  * never a bare "console.error was called". `relaySanitizationEvent(undefined, e)`
@@ -43,7 +50,7 @@ import { resetMigrationLog } from "../../src/server/annotations/migration-log.js
 import { YDocStore } from "../../src/server/mcp/document-store.js";
 import type { OnLossy, SanitizationEvent } from "../../src/shared/sanitize.js";
 import type { Annotation } from "../../src/shared/types.js";
-import { getAnnotationsMap, makeDoc, rangeOf } from "../helpers/ydoc-factory.js";
+import { getAnnotationsMap, makeDoc, seedRawAnnotation } from "../helpers/ydoc-factory.js";
 
 let doc: Y.Doc;
 let map: Y.Map<unknown>;
@@ -66,20 +73,17 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/** Seed a record RAW, so a spec can store a shape the mint path never produces. */
+/** Shorthand for the shared raw-record seeder, bound to this file's doc. */
 function seed(id: string, extra: Record<string, unknown>): void {
-  map.set(id, {
-    id,
-    type: "comment",
-    author: "user",
-    audience: "private",
-    status: "pending",
-    range: rangeOf(0, 5, doc).range,
-    content: "legacy",
-    timestamp: Date.now(),
-    rev: 1,
-    ...extra,
-  });
+  seedRawAnnotation(map, doc, id, extra);
+}
+
+/** A store with a filePath nothing else in this file uses. The distinct path
+ *  is redundancy over `resetMigrationLog` (see the header), but deriving it
+ *  from the label means a new spec gets it without knowing that. */
+function storeFor(label: string): { store: YDocStore; filePath: string } {
+  const filePath = `/tmp/relay-${label}.md`;
+  return { store: new YDocStore(doc, filePath, `relay-${label}`), filePath };
 }
 
 /** Messages naming THIS doc's hash. The hash is in the message body —
@@ -95,8 +99,7 @@ describe("YDocStore.acceptAnnotation relays sanitization events", () => {
     // to a pending comment, so this one spec asserts the relay fired AND the
     // transition completed. A fixture that gets refused cannot do the second
     // half, which is how a relay spec passes on a path that gave up early.
-    const filePath = "/tmp/relay-accept.md";
-    const store = new YDocStore(doc, filePath, "relay-accept");
+    const { store, filePath } = storeFor("accept");
     seed("q1", { type: "question", author: "claude", audience: "outbound" });
 
     const result = store.acceptAnnotation("q1");
@@ -108,8 +111,7 @@ describe("YDocStore.acceptAnnotation relays sanitization events", () => {
   });
 
   it("dismiss relays too — the two share a body and can still diverge at the store", () => {
-    const filePath = "/tmp/relay-dismiss.md";
-    const store = new YDocStore(doc, filePath, "relay-dismiss");
+    const { store, filePath } = storeFor("dismiss");
     seed("q2", { type: "question", author: "claude", audience: "outbound" });
 
     expect(store.dismissAnnotation("q2").kind).toBe("ok");
@@ -120,8 +122,7 @@ describe("YDocStore.acceptAnnotation relays sanitization events", () => {
     // Reads backwards and is worth pinning: sanitize runs BEFORE the note
     // guard, so a stored `flag` fires `flag-to-note` and is only then refused.
     // The event describes what sanitize read, not what the lifecycle wrote.
-    const filePath = "/tmp/relay-flag.md";
-    const store = new YDocStore(doc, filePath, "relay-flag");
+    const { store, filePath } = storeFor("flag");
     seed("f1", { type: "flag" });
 
     expect(store.acceptAnnotation("f1")).toStrictEqual({ kind: "invalid-note" });
@@ -138,8 +139,7 @@ describe("YDocStore.acceptAnnotation relays sanitization events", () => {
     // record keeps its legacy `question`. A clean fixture cannot separate them
     // from correct code at all, because for a minted record raw and sanitized
     // are the same object.
-    const filePath = "/tmp/relay-sanitized-write.md";
-    const store = new YDocStore(doc, filePath, "relay-sanitized-write");
+    const { store } = storeFor("sanitized-write");
     seed("q9", { type: "question", author: "claude", audience: "outbound" });
 
     const result = store.acceptAnnotation("q9");
@@ -149,17 +149,36 @@ describe("YDocStore.acceptAnnotation relays sanitization events", () => {
     expect((map.get("q9") as Annotation).status).toBe("accepted");
   });
 
+  it.each([
+    ["malformed-suggestion-json", { type: "suggestion", content: "not json{" }],
+    ["unknown-type", { type: "zzz-from-the-future" }],
+  ])("relays %s too", (kind, extra) => {
+    // The header names four kinds that the pre-8d no-op swallowed. Two of them
+    // had no spec, which made the header claim more coverage than the file had.
+    // One sink argument covers every kind, so these are cheap — but "cheap to
+    // add" is not "already asserted".
+    const { store, filePath } = storeFor(`kind-${kind}`);
+    seed("k1", { author: "claude", audience: "outbound", ...extra });
+
+    expect(store.acceptAnnotation("k1").kind).toBe("ok");
+
+    expect(relayedFor(filePath)).toHaveLength(1);
+    expect(relayedFor(filePath)[0]).toContain(kind);
+  });
+
   it("a clean record relays nothing", () => {
     // The negative control. Without it, a relay that fires unconditionally —
     // or a spy that captures some other console.error — passes every spec
     // above.
-    const filePath = "/tmp/relay-clean.md";
-    const store = new YDocStore(doc, filePath, "relay-clean");
+    const { store, filePath } = storeFor("clean");
     seed("c1", { type: "comment", author: "claude", audience: "outbound" });
 
     expect(store.acceptAnnotation("c1").kind).toBe("ok");
     expect(relayedFor(filePath)).toHaveLength(0);
-    expect(errors, "and no un-keyed line either").toHaveLength(0);
+    expect(
+      errors.filter((e) => e.includes("no docHash")),
+      "and no un-keyed line either",
+    ).toHaveLength(0);
   });
 
   it("the message names the store's docHash, not the undefined variant", () => {
@@ -167,28 +186,31 @@ describe("YDocStore.acceptAnnotation relays sanitization events", () => {
     // `(undefined, e)`. That mutant still logs, so every count-of-errors
     // assertion above survives it; only the docHash in the body distinguishes
     // the two, and `logLegacyMigration` prints `(no docHash)` for the mutant.
-    const filePath = "/tmp/relay-keyed.md";
-    const store = new YDocStore(doc, filePath, "relay-keyed");
+    const { store, filePath } = storeFor("keyed");
     seed("q3", { type: "question", author: "claude", audience: "outbound" });
 
     store.acceptAnnotation("q3");
 
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toContain(`in ${docHash(filePath)}`);
-    expect(errors[0]).not.toContain("no docHash");
+    expect(relayedFor(filePath)).toHaveLength(1);
+    expect(
+      errors.filter((e) => e.includes("no docHash")),
+      "the undefined-docHash variant is what this spec exists to exclude",
+    ).toHaveLength(0);
   });
 
   it("dedups per (doc, kind), so a second accept of the same kind is silent", () => {
-    // Not a nicety — it is why every spec in this file needs its own filePath,
-    // and pinning it here is what makes that requirement discoverable rather
-    // than folk knowledge.
-    const filePath = "/tmp/relay-dedup.md";
-    const store = new YDocStore(doc, filePath, "relay-dedup");
+    // Pinned because the dedup is what every other spec in this file is working
+    // around; a reader who does not know it exists cannot tell why the header
+    // insists on `resetMigrationLog`.
+    const { store, filePath } = storeFor("dedup");
     seed("q4", { type: "question", author: "claude", audience: "outbound" });
     seed("q5", { type: "question", author: "claude", audience: "outbound" });
 
-    store.acceptAnnotation("q4");
-    store.acceptAnnotation("q5");
+    // Both arms asserted, because "one line" is also what a mutant that makes
+    // the second transition fail early produces — and that reads as dedup
+    // working.
+    expect(store.acceptAnnotation("q4").kind).toBe("ok");
+    expect(store.acceptAnnotation("q5").kind).toBe("ok");
 
     expect(relayedFor(filePath)).toHaveLength(1);
   });

--- a/tests/server/annotation-transition-relay.test.ts
+++ b/tests/server/annotation-transition-relay.test.ts
@@ -1,0 +1,234 @@
+/**
+ * The sanitization relay on accept/dismiss (ADR-034/035 Unit 8d).
+ *
+ * Until 8d, `transitionPending` sanitized into a literal `() => {}`. Accepting a
+ * legacy-shaped record therefore performed the migration — `flag→note`,
+ * `question→comment`, a malformed suggestion JSON, an unknown type — and
+ * reported nothing. This file is the guard that the real relay is wired, and it
+ * is deliberately at TWO altitudes because the seam has two halves that fail
+ * independently:
+ *
+ *  - the **store** must hand its own docHash-bound relay down
+ *    (`YDocStore.acceptAnnotation`), and
+ *  - the **lifecycle** must forward the argument it was given rather than
+ *    substituting a sink of its own (`createAnnotationLifecycle`).
+ *
+ * A spec at either altitude alone passes with the other half broken.
+ *
+ * **Three hazards make a relay spec silently vacuous, and all three are handled
+ * here rather than noted.** `logLegacyMigration` dedups on `${docHash}:${kind}`
+ * in module-level state, so (1) `resetMigrationLog()` runs before every spec;
+ * (2) each spec uses its OWN `filePath`, since every store in
+ * `document-store.test.ts` shares `/tmp/doc.md` and one relay anywhere in a file
+ * silences every later assertion of the same kind; and (3) no spec reads an
+ * annotation before the transition — `listAnnotations` AND the single-record
+ * `getAnnotation` both relay under the same key, and `removeAnnotation` calls
+ * `getAnnotation` internally, so a read is an invisible consumer.
+ *
+ * The assertion is a **count of exactly one message naming this doc's hash**,
+ * never a bare "console.error was called". `relaySanitizationEvent(undefined, e)`
+ * still logs — the `(no docHash)` variant with dedup disabled — so a presence
+ * check passes with the docHash binding destroyed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as Y from "yjs";
+import { docHash } from "../../src/server/annotations/doc-hash.js";
+import {
+  acceptPending,
+  createAnnotationLifecycle,
+  dismissPending,
+} from "../../src/server/annotations/lifecycle.js";
+import { resetMigrationLog } from "../../src/server/annotations/migration-log.js";
+import { YDocStore } from "../../src/server/mcp/document-store.js";
+import type { OnLossy, SanitizationEvent } from "../../src/shared/sanitize.js";
+import type { Annotation } from "../../src/shared/types.js";
+import { getAnnotationsMap, makeDoc, rangeOf } from "../helpers/ydoc-factory.js";
+
+let doc: Y.Doc;
+let map: Y.Map<unknown>;
+let errors: string[];
+
+beforeEach(() => {
+  resetMigrationLog();
+  doc = makeDoc("Hello world");
+  map = getAnnotationsMap(doc);
+  errors = [];
+  // `vitest.config.ts` sets no `restoreMocks`, so this restores explicitly in
+  // `afterEach` — an un-restored console spy swallows diagnostics for every
+  // later spec in the run.
+  vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+    errors.push(args.map(String).join(" "));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Seed a record RAW, so a spec can store a shape the mint path never produces. */
+function seed(id: string, extra: Record<string, unknown>): void {
+  map.set(id, {
+    id,
+    type: "comment",
+    author: "user",
+    audience: "private",
+    status: "pending",
+    range: rangeOf(0, 5, doc).range,
+    content: "legacy",
+    timestamp: Date.now(),
+    rev: 1,
+    ...extra,
+  });
+}
+
+/** Messages naming THIS doc's hash. The hash is in the message body —
+ *  `logLegacyMigration` formats `legacy migration: ${kind} in ${docHash}`. */
+function relayedFor(filePath: string): string[] {
+  const hash = docHash(filePath);
+  return errors.filter((e) => e.includes("legacy migration") && e.includes(hash));
+}
+
+describe("YDocStore.acceptAnnotation relays sanitization events", () => {
+  it("emits exactly one migration line, keyed to the store's own docHash", () => {
+    // `question` is the fixture because it survives BOTH guards: it sanitizes
+    // to a pending comment, so this one spec asserts the relay fired AND the
+    // transition completed. A fixture that gets refused cannot do the second
+    // half, which is how a relay spec passes on a path that gave up early.
+    const filePath = "/tmp/relay-accept.md";
+    const store = new YDocStore(doc, filePath, "relay-accept");
+    seed("q1", { type: "question", author: "claude", audience: "outbound" });
+
+    const result = store.acceptAnnotation("q1");
+
+    expect(result.kind, "the transition itself still completes").toBe("ok");
+    expect((map.get("q1") as Annotation).status).toBe("accepted");
+    expect(relayedFor(filePath), "one line, under THIS doc's hash").toHaveLength(1);
+    expect(relayedFor(filePath)[0]).toContain("question-to-comment");
+  });
+
+  it("dismiss relays too — the two share a body and can still diverge at the store", () => {
+    const filePath = "/tmp/relay-dismiss.md";
+    const store = new YDocStore(doc, filePath, "relay-dismiss");
+    seed("q2", { type: "question", author: "claude", audience: "outbound" });
+
+    expect(store.dismissAnnotation("q2").kind).toBe("ok");
+    expect(relayedFor(filePath)).toHaveLength(1);
+  });
+
+  it("relays a rewrite even when the ADR-027 guard then refuses the write", () => {
+    // Reads backwards and is worth pinning: sanitize runs BEFORE the note
+    // guard, so a stored `flag` fires `flag-to-note` and is only then refused.
+    // The event describes what sanitize read, not what the lifecycle wrote.
+    const filePath = "/tmp/relay-flag.md";
+    const store = new YDocStore(doc, filePath, "relay-flag");
+    seed("f1", { type: "flag" });
+
+    expect(store.acceptAnnotation("f1")).toStrictEqual({ kind: "invalid-note" });
+    expect(relayedFor(filePath)).toHaveLength(1);
+    expect(relayedFor(filePath)[0]).toContain("flag-to-note");
+    expect((map.get("f1") as Annotation).status, "and nothing was written").toBe("pending");
+  });
+
+  it("writes the SANITIZED record, not the raw one", () => {
+    // Two mutants live here and neither is visible from a return value.
+    // `const ann = raw as Annotation` (no sanitize) and
+    // `map.set(id, {...raw, status, rev})` (sanitize, return it, write the raw
+    // one) both leave `result.data.type === "comment"` correct while the stored
+    // record keeps its legacy `question`. A clean fixture cannot separate them
+    // from correct code at all, because for a minted record raw and sanitized
+    // are the same object.
+    const filePath = "/tmp/relay-sanitized-write.md";
+    const store = new YDocStore(doc, filePath, "relay-sanitized-write");
+    seed("q9", { type: "question", author: "claude", audience: "outbound" });
+
+    const result = store.acceptAnnotation("q9");
+
+    expect(result.kind === "ok" && result.data.type, "the RETURNED type").toBe("comment");
+    expect((map.get("q9") as Annotation).type, "and the STORED one").toBe("comment");
+    expect((map.get("q9") as Annotation).status).toBe("accepted");
+  });
+
+  it("a clean record relays nothing", () => {
+    // The negative control. Without it, a relay that fires unconditionally —
+    // or a spy that captures some other console.error — passes every spec
+    // above.
+    const filePath = "/tmp/relay-clean.md";
+    const store = new YDocStore(doc, filePath, "relay-clean");
+    seed("c1", { type: "comment", author: "claude", audience: "outbound" });
+
+    expect(store.acceptAnnotation("c1").kind).toBe("ok");
+    expect(relayedFor(filePath)).toHaveLength(0);
+    expect(errors, "and no un-keyed line either").toHaveLength(0);
+  });
+
+  it("the message names the store's docHash, not the undefined variant", () => {
+    // The kill for `relaySanitizationEvent(this.docHash, e)` →
+    // `(undefined, e)`. That mutant still logs, so every count-of-errors
+    // assertion above survives it; only the docHash in the body distinguishes
+    // the two, and `logLegacyMigration` prints `(no docHash)` for the mutant.
+    const filePath = "/tmp/relay-keyed.md";
+    const store = new YDocStore(doc, filePath, "relay-keyed");
+    seed("q3", { type: "question", author: "claude", audience: "outbound" });
+
+    store.acceptAnnotation("q3");
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(`in ${docHash(filePath)}`);
+    expect(errors[0]).not.toContain("no docHash");
+  });
+
+  it("dedups per (doc, kind), so a second accept of the same kind is silent", () => {
+    // Not a nicety — it is why every spec in this file needs its own filePath,
+    // and pinning it here is what makes that requirement discoverable rather
+    // than folk knowledge.
+    const filePath = "/tmp/relay-dedup.md";
+    const store = new YDocStore(doc, filePath, "relay-dedup");
+    seed("q4", { type: "question", author: "claude", audience: "outbound" });
+    seed("q5", { type: "question", author: "claude", audience: "outbound" });
+
+    store.acceptAnnotation("q4");
+    store.acceptAnnotation("q5");
+
+    expect(relayedFor(filePath)).toHaveLength(1);
+  });
+});
+
+describe("the lifecycle forwards the sink it was given", () => {
+  it.each([
+    [
+      "accept",
+      (l: ReturnType<typeof createAnnotationLifecycle>, id: string, s: OnLossy) => l.accept(id, s),
+    ],
+    [
+      "dismiss",
+      (l: ReturnType<typeof createAnnotationLifecycle>, id: string, s: OnLossy) => l.dismiss(id, s),
+    ],
+  ])("%s reaches the caller's own sink", (_label, op) => {
+    // **The store half cannot see this.** A `createAnnotationLifecycle` that
+    // accepts `onLossy` and still passes `() => {}` down to `sanitizeAnnotation`
+    // leaves every store spec above green, because the store's relay is a
+    // `console.error` the mutant simply never triggers — indistinguishable from
+    // "this record needed no migration". Asserting on a caller-supplied sink is
+    // what separates "the argument was accepted" from "the argument was used".
+    const seen: SanitizationEvent[] = [];
+    const lifecycle = createAnnotationLifecycle(doc);
+    seed("q6", { type: "question", author: "claude", audience: "outbound" });
+
+    op(lifecycle, "q6", (e) => seen.push(e));
+
+    expect(seen).toStrictEqual([{ kind: "question-to-comment", id: "q6" }]);
+  });
+
+  it("the bare exports forward it too", () => {
+    const seen: SanitizationEvent[] = [];
+    seed("q7", { type: "question", author: "claude", audience: "outbound" });
+
+    acceptPending("q7", doc, map, (e) => seen.push(e));
+
+    seed("q8", { type: "question", author: "claude", audience: "outbound" });
+    dismissPending("q8", doc, map, (e) => seen.push(e));
+
+    expect(seen.map((e) => e.kind)).toStrictEqual(["question-to-comment", "question-to-comment"]);
+  });
+});

--- a/tests/server/document-store.test.ts
+++ b/tests/server/document-store.test.ts
@@ -24,16 +24,9 @@ import { getDocumentStore, YDocStore } from "../../src/server/mcp/document-store
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import { MCP_ORIGIN } from "../../src/shared/origins.js";
 import { toFlatOffset } from "../../src/shared/positions/types.js";
-import type { OnLossy } from "../../src/shared/sanitize.js";
 import type { Annotation } from "../../src/shared/types.js";
 import { clearOpenDocs, setupDoc } from "../helpers/doc-service.js";
-import { rangeOf } from "../helpers/ydoc-factory.js";
-
-/** No sink: these specs are about the guards and the write, not the relay.
- *  Named rather than inlined so "does not care" is distinguishable from
- *  "forgot" at a glance. The relay's own coverage lives in the specs that pass
- *  a real one. */
-const noRelay: OnLossy = () => {};
+import { noRelay, normalizeForParity, rangeOf } from "../helpers/ydoc-factory.js";
 
 beforeEach(() => {
   clearOpenDocs();
@@ -60,8 +53,7 @@ describe("YDocStore.createAnnotation parity", () => {
     const recStore = map.get(idStore) as Annotation;
     const recHelper = map.get(idHelper) as Annotation;
 
-    const norm = (a: Annotation) => ({ ...a, id: "X", timestamp: 0 });
-    expect(norm(recStore)).toEqual(norm(recHelper));
+    expect(normalizeForParity(recStore)).toEqual(normalizeForParity(recHelper));
     expect(recStore.author).toBe("claude");
     expect(recStore.type).toBe("comment");
     expect(recStore.suggestedText).toBe("Hi");
@@ -202,6 +194,10 @@ describe("YDocStore lifecycle parity", () => {
     const idStore = store.createAnnotation("comment", rangeOf(0, 5, ydoc), "x");
     const idHelper = createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "x");
 
+    // Without this, `normalizeForParity` blanking `id` and `timestamp` would be
+    // the whole of the comparison if `rangeOf` ever stopped anchoring.
+    expect((map.get(idStore) as Annotation).relRange, "the fixtures are anchored").toBeDefined();
+
     const resStore = viaStore(store, idStore);
     const resHelper = viaHelper(idHelper, ydoc, map);
 
@@ -213,9 +209,8 @@ describe("YDocStore lifecycle parity", () => {
 
     // The records, modulo the two fields that legitimately differ between any
     // two annotations minted a moment apart.
-    const norm = (a: Annotation) => ({ ...a, id: "", timestamp: 0 });
-    expect(norm(map.get(idStore) as Annotation)).toStrictEqual(
-      norm(map.get(idHelper) as Annotation),
+    expect(normalizeForParity(map.get(idStore) as Annotation)).toStrictEqual(
+      normalizeForParity(map.get(idHelper) as Annotation),
     );
     expect((map.get(idStore) as Annotation).status).toBe(want);
   });

--- a/tests/server/document-store.test.ts
+++ b/tests/server/document-store.test.ts
@@ -24,9 +24,16 @@ import { getDocumentStore, YDocStore } from "../../src/server/mcp/document-store
 import { Y_MAP_ANNOTATION_REPLIES, Y_MAP_ANNOTATIONS } from "../../src/shared/constants.js";
 import { MCP_ORIGIN } from "../../src/shared/origins.js";
 import { toFlatOffset } from "../../src/shared/positions/types.js";
+import type { OnLossy } from "../../src/shared/sanitize.js";
 import type { Annotation } from "../../src/shared/types.js";
 import { clearOpenDocs, setupDoc } from "../helpers/doc-service.js";
 import { rangeOf } from "../helpers/ydoc-factory.js";
+
+/** No sink: these specs are about the guards and the write, not the relay.
+ *  Named rather than inlined so "does not care" is distinguishable from
+ *  "forgot" at a glance. The relay's own coverage lives in the specs that pass
+ *  a real one. */
+const noRelay: OnLossy = () => {};
 
 beforeEach(() => {
   clearOpenDocs();
@@ -134,7 +141,7 @@ describe("YDocStore.editAnnotation parity (handler guard order)", () => {
     const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
     const store = new YDocStore(ydoc, FILE_PATH, "edit-np");
     const id = store.createAnnotation("comment", rangeOf(0, 5, ydoc), "x");
-    acceptPending(id, ydoc, map);
+    acceptPending(id, ydoc, map, noRelay);
     expect(store.editAnnotation(id, { content: "y" })).toEqual({
       kind: "not-pending",
       currentStatus: "accepted",
@@ -162,29 +169,55 @@ describe("YDocStore.editAnnotation parity (handler guard order)", () => {
 });
 
 describe("YDocStore lifecycle parity", () => {
-  it("acceptAnnotation matches acceptPending", () => {
-    const a = setupDoc("acc-a", "Hello world");
-    const b = setupDoc("acc-b", "Hello world");
-    const storeA = new YDocStore(a, FILE_PATH, "acc-a");
-    const idA = storeA.createAnnotation("comment", rangeOf(0, 5, a), "x");
-    const idB = createAnnotation(b.getMap(Y_MAP_ANNOTATIONS), b, "comment", rangeOf(0, 5, b), "x");
+  // **Both specs ran against TWO Y.Docs and asserted the parity of nothing.**
+  // `acceptAnnotation matches acceptPending` compared only `resA.kind` to
+  // `resB.kind` — an unconditional `{kind: "ok"}` matches itself — and the
+  // dismiss twin discarded both return values entirely, so deleting its
+  // `dismissPending` call left it green.
+  //
+  // Fixing that by comparing records across two docs does not work and would
+  // make things worse: `relRange` embeds the doc's client id, so a cross-doc
+  // comparison must normalise it away — and normalising `relRange` away is
+  // exactly what the field-survival mutant needs to survive. The create-parity
+  // spec above already solved this by driving both paths against ONE doc, and
+  // says so; these two now do the same.
+  it.each([
+    [
+      "accept",
+      (s: YDocStore, id: string) => s.acceptAnnotation(id),
+      (id: string, d: Y.Doc, m: Y.Map<unknown>) => acceptPending(id, d, m, noRelay),
+      "accepted",
+    ],
+    [
+      "dismiss",
+      (s: YDocStore, id: string) => s.dismissAnnotation(id),
+      (id: string, d: Y.Doc, m: Y.Map<unknown>) => dismissPending(id, d, m, noRelay),
+      "dismissed",
+    ],
+  ])("%sAnnotation writes what the standalone helper writes", (_label, viaStore, viaHelper, want) => {
+    const ydoc = setupDoc(`parity-${want}`, "Hello world");
+    const map = ydoc.getMap(Y_MAP_ANNOTATIONS);
+    const store = new YDocStore(ydoc, FILE_PATH, `parity-${want}`);
 
-    const resA = storeA.acceptAnnotation(idA);
-    const resB = acceptPending(idB, b, b.getMap(Y_MAP_ANNOTATIONS));
-    expect(resA.kind).toBe(resB.kind);
-    expect((a.getMap(Y_MAP_ANNOTATIONS).get(idA) as Annotation).status).toBe("accepted");
-  });
+    const idStore = store.createAnnotation("comment", rangeOf(0, 5, ydoc), "x");
+    const idHelper = createAnnotation(map, ydoc, "comment", rangeOf(0, 5, ydoc), "x");
 
-  it("dismissAnnotation matches dismissPending", () => {
-    const a = setupDoc("dis-a", "Hello world");
-    const b = setupDoc("dis-b", "Hello world");
-    const storeA = new YDocStore(a, FILE_PATH, "dis-a");
-    const idA = storeA.createAnnotation("comment", rangeOf(0, 5, a), "x");
-    const idB = createAnnotation(b.getMap(Y_MAP_ANNOTATIONS), b, "comment", rangeOf(0, 5, b), "x");
+    const resStore = viaStore(store, idStore);
+    const resHelper = viaHelper(idHelper, ydoc, map);
 
-    storeA.dismissAnnotation(idA);
-    dismissPending(idB, b, b.getMap(Y_MAP_ANNOTATIONS));
-    expect((a.getMap(Y_MAP_ANNOTATIONS).get(idA) as Annotation).status).toBe("dismissed");
+    // Both arms, not just their kinds — `.kind` alone is matched by any two
+    // results that happen to succeed.
+    expect(resStore.kind).toBe("ok");
+    expect(resHelper.kind).toBe("ok");
+    if (resStore.kind !== "ok" || resHelper.kind !== "ok") return;
+
+    // The records, modulo the two fields that legitimately differ between any
+    // two annotations minted a moment apart.
+    const norm = (a: Annotation) => ({ ...a, id: "", timestamp: 0 });
+    expect(norm(map.get(idStore) as Annotation)).toStrictEqual(
+      norm(map.get(idHelper) as Annotation),
+    );
+    expect((map.get(idStore) as Annotation).status).toBe(want);
   });
 });
 


### PR DESCRIPTION
ADR-034/035 Unit 8d.

`transitionPending` sanitized into a literal `() => {}`, so every legacy-shape migration performed on an accept or dismiss happened silently — `flag→note`, `question→comment`, a malformed suggestion JSON, an unknown type, and `audience-conflict-resolved`. Unit 8b left the sink deliberately un-wired because wiring it changes accept/dismiss behaviour and that PR's subject was create; this is where it belongs.

## The wiring

`onLossy` is a **required** parameter at every layer — `transitionPending`, `AnnotationLifecycle.accept`/`.dismiss`, and the two pre-ADR-035 exports — never an optional with a default. A defaultable sink is the neuterable-argument shape this programme keeps finding.

**Option A (sink at the call site) over Option B (bind it in `createAnnotationLifecycle`), and two earlier justifications for A were wrong.** The first draft argued revertibility, which proves too much: it would have forbidden Unit 8c. The second argued that Option B would hand `local-model/tools.ts:295` an `undefined` docHash, making `logLegacyMigration` the loudest possible sink. **Two reviewers falsified that independently** — that site narrows to `Pick<AnnotationLifecycle, "create">`, and `create` reaches `mintAnnotation`, which never sanitizes and can emit no event. What survives is a visibility argument: the sink is readable at the call site rather than at a construction three layers away, matching what 8c established for `editPending`. Recorded as that and nothing stronger.

## Behaviour change, operator-visible only

Accepting a legacy-shaped record now emits one deduped stderr line per `(doc, kind)`. Nothing reaches Claude — `relaySanitizationEvent` discards the event's `id`, carries no content, and the docHash is SHA-256 of the resolved path. Channel events, `checkInbox` and `getAnnotations` are byte-identical.

**It emits even when the ADR-027 note guard then refuses the write**, because sanitize runs first. That reads backwards and is pinned by a spec: a stored `flag` fires `flag-to-note` and *then* returns `invalid-note`. The event describes what sanitize read, not what the lifecycle wrote.

## Six specs that asserted nothing, or nothing they claimed

- `annotation-tools.test.ts` — both `tandem_resolveAnnotation` specs `map.set` the record by hand and assert their own write. Deleting `transitionPending` outright left them green, under exactly the title someone searching for resolve coverage would find. (Their hand `map.set` calls were also untagged raw writes — Critical Rule 2 hygiene, gone with them.)
- `document-store.test.ts` — `acceptAnnotation matches acceptPending` compared `resA.kind` to `resB.kind`; an unconditional `{kind:"ok"}` matches itself. The dismiss twin discarded **both** return values, so deleting its `dismissPending` call left it green.
- `annotation-lifecycle.test.ts` — "bumps rev" was discharged for the returned object only; a write of `{...updated, rev: ann.rev}` passed.
- The origin spec's describe claims a **channel-event skip** and `toContain("mcp")` cannot establish it.
- `dismissPending` had no `not-found` spec and no rev spec at all.

Fixing the parity pair needed restructuring rather than more assertions: they drove two Y.Docs, whose records legitimately differ in `relRange` (it embeds the doc's client id), and normalising `relRange` away to compare across docs is exactly what the field-survival mutant needs to survive. They now use one doc, as the create-parity spec above them already did.

## Verification

A 10-mutant battery behind a required-GREEN probe, **every row RED as expected**, then judged again by the pre-existing `tests/server/` — 237 files, not a hand-picked list, because a three-file scope scores at least one row wrongly.

| mutant | new | pre-existing |
|---|---|---|
| `withMcp` → `withBrowser` / → `withFileSync` | RED | RED |
| sanitize dropped entirely | RED | RED |
| **correct `withMcp` write plus a spurious `withBrowser` echo** | RED | **GREEN** |
| **field-listing rebuild at the write** | RED | **GREEN** |
| **writes the raw record, returns the sanitized one** | RED | **GREEN** |
| pending guard deleted | RED | RED |
| `nextRev(ann)` → `nextRev()` | RED | RED |
| relay under an undefined docHash | RED | RED |
| **lifecycle takes the sink and passes a no-op down** | RED | **GREEN** |

The four GREEN rows are the genuine gaps. "Store passes `() => {}`" has **no** pre-existing row at all and is marked N/A rather than GREEN: `onLossy` is not a parameter before this PR, so the pre-existing code *is* the mutant, and scoring it GREEN would be a zero-of-zero pass.

Excluded with the reason corrected: "sanitize moved after the status check" is INVALID (the note guard reads `ann`, which would not yet exist) rather than unkillable as an earlier draft claimed.

## Three reviews, and what they caught

- **`map.get(id)` returns the stored object**, so `const before = map.get(id)` is a live alias — a mutant writing the record in place made the field-survival assertion compare an object to a spread of itself. Demonstrated, not argued. `before` is now a copy, and `rev` is lifted out of the comparison rather than read off the object under test.
- Two relay rows asserted the **total** `console.error` count, which is the discipline the file header argues against three paragraphs earlier.
- The dedup spec read "one line" as proof; a mutant making the second transition fail early produces one line too.
- The header named four swallowed kinds and the file covered two.
- Two source comments were wrong: the unbound-`this.onLossy` note claimed the failure degrades to un-deduped logging when it **throws inside sanitize's relay guard and loses the event outright** (reviewer ran it); and "every mutation method on this store passes a sink" is false — `addReply` still sanitizes its parent under `makeOnLossy(undefined)`, now named as a known gap rather than left as an assumed absence.

`/simplify`: `seed`, `noRelay` and the parity normalizer were duplicated across files and now live in `tests/helpers/ydoc-factory.ts`; the per-spec store preamble became `storeFor(label)`, so the distinct-filePath property is a consequence of taking a label rather than seven sites remembering.

`npm run typecheck`, `npm run typecheck:tests` and biome clean; full suite 9793 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdqygN6gqPc8Hr8BifXTQ
