### PR TITLE
feat(client): tint annotation cards by author, carry type on an icon

### DIFF
--- a/docs/design-system-impl/derived-spec.md
+++ b/docs/design-system-impl/derived-spec.md
@@ -338,13 +338,29 @@ wrapping `role="img"`, and a visually-hidden word is revealed under
 | `claude`  | `user`   | —             | `CommentCard`      | `comment-user`    | user tint | cobalt dot · "You" · comment icon | Resolve (primary) · Edit (ghost) · Delete (ghost) |
 | `claude`  | `claude` | —             | `CommentCard`      | (`comment`)       | claude tint | agent-coloured dot · "Claude" · comment icon | Resolve (primary) · Edit (ghost) · Delete (ghost) |
 | `claude`  | `claude` | present       | `SuggestionCard`   | `suggest`         | claude tint | agent-coloured dot · "Claude" · replacement icon | Accept (primary) · Dismiss (ghost) · Edit (ghost) |
-| `claude`  | `import` | —             | `ImportedCard`     | (production-only) | import tint | no author dot · italic byline "Sarah · 2024-12-05" (`--tandem-fg-subtle`) | Promote (primary) · Dismiss (ghost) |
+| `private` | `import` | —             | `ImportedCard`     | (production-only) | import tint | no author dot · italic byline "Sarah · 2024-12-05" (`--tandem-fg-subtle`) · note icon (accessible name "Private note") | Promote (primary) · Dismiss (ghost) |
 
-The hollow note dot is the **only** thing carrying privacy in the header, and
-it is deliberately zero-width-cost: it swaps `background` for a `border` on an
+Note the first column on that last row: imported Word comments land as
+`type: "note"`, `audience: "private"`, `author: "import"`
+(`src/server/file-io/docx-comments.ts:635-637`), and `BatchPromoteBar` is what
+flips all three at once. An earlier revision of this table said `claude`, which
+read as though an import were visible to the AI on arrival. It is not.
+
+Privacy is carried by **three** header signals, not one, and which of them are
+present depends on the row:
+
+- the **hollow note dot** — user-authored notes only, since `ImportedCard` has
+  no author dot at all;
+- the **Private pill**, at full/compact/clamped density;
+- the **note glyph**, whose accessible name is literally "Private note", and
+  which is what `ImportedCard` relies on.
+
+`getCardLabel` also prefixes the card's own aria-label with `private `, so the
+signal survives even where every visual carrier is suppressed. The hollow dot
+is deliberately zero-width-cost — it swaps `background` for a `border` on an
 element that already exists, so it cannot disturb the stub-density width
 budget. Do not replace it with a pill or an extra glyph without re-checking
-that budget.
+that budget, and do not treat it as load-bearing on its own.
 
 **Suggestions are Claude-only.** Users can author notes, comments, and
 highlights; they cannot author suggestions. A `suggestedText` field on a

--- a/docs/design-system-impl/derived-spec.md
+++ b/docs/design-system-impl/derived-spec.md
@@ -118,19 +118,22 @@ Each row:
   fade-and-slide. Edit form open/close = no motion (form swap in place).
 - **Anti-patterns.** **Do NOT use a left-border edge color for the card.**
   The visual taxonomy below is BACKGROUND TINT + HEADER (author dot +
-  name + type badge), NOT a colored border. The README "Annotation card
+  name + type icon), NOT a colored border. The README "Annotation card
   edge colors" line is stale text superseded by the current
-  `AnnotationCard.svelte`. Do NOT branch the tint on
-  `author === "claude"` directly — the discriminator is the production
-  card variant (NoteCard / CommentCard / SuggestionCard / ImportedCard /
-  HighlightCard), each owning its own background-tint class. Do NOT
-  introduce a colored author-dot for the imported card — imported
-  annotations carry a Word commentor byline ("Sarah · 2024-12-05" in
-  italic at `--tandem-fg-subtle`), not the user/Claude authorship dot.
-  Do NOT add a type badge to NoteCard — notes hide the badge per
-  `AnnotationCard.svelte:31` (`{#if anno.type !== 'highlight'}` was the
-  bundle's gate; notes show the badge there but production keys on
-  audience and may suppress).
+  `AnnotationCard.svelte`. **Tint IS branched on author, deliberately** —
+  a single `cardTint` in `AnnotationCard.svelte` reads `annotation.author`
+  and returns one of three tokens. An earlier revision of this file said
+  the opposite ("the discriminator is the production card variant, each
+  owning its own background-tint class"); that instruction predates the
+  author-tint change and following it now would reintroduce the
+  contradiction the change removed, since two variants can share an
+  author. Do NOT introduce a colored author-dot for the imported card —
+  imported annotations carry a Word commentor byline ("Sarah · 2024-12-05"
+  in italic at `--tandem-fg-subtle`), not the user/Claude authorship dot.
+  Notes DO carry a type icon; what distinguishes them is a **hollow**
+  author dot, keyed in CSS off `[data-annotation-type="note"]` on the card
+  root. A prior instruction here said to suppress the badge on `NoteCard`;
+  that was the text-pill era and no longer applies.
 
 ### 3.4 Batch + bulk actions — C7 BatchPromoteBar, C8 BulkActions
 
@@ -302,13 +305,46 @@ the annotation is for picks the variant first, with author and
 (`note`, `comment-user`, `suggest`, `highlight` in `samples.ts:32–51`)
 map to production's five-component split.
 
-| audience  | author   | suggestedText | Production variant | Bundle `cardType` | Background tint | Header (dot + name + badge) | Actions row |
-| --------- | -------- | ------------- | ------------------ | ----------------- | --------------- | --------------------------- | ----------- |
-| `private` | `user`   | —             | `NoteCard`         | `note`            | default surface (no tint) | cobalt dot · "You" · no badge | Send to Claude (neutral + coral disc) · Archive (ghost) |
-| `claude`  | `user`   | —             | `CommentCard`      | `comment-user`    | cobalt tint (`oklch(0.987 0.005 250)` / `oklch(0.24 0.03 250)`) | cobalt dot · "You" · "Comment" badge (cobalt) | Resolve (primary) · Edit (ghost) · Delete (ghost) |
-| `claude`  | `claude` | —             | `CommentCard`      | (`comment`, no tint variant) | default surface | coral dot · "Claude" · "Comment" badge (cobalt) | Resolve (primary) · Edit (ghost) · Delete (ghost) |
-| `claude`  | `claude` | present       | `SuggestionCard`   | `suggest`         | violet tint (`oklch(0.985 0.008 295)` / `oklch(0.24 0.04 295)`) | coral dot · "Claude" · "Suggestion" badge (violet) | Accept (primary) · Dismiss (ghost) · Edit (ghost) |
-| `claude`  | `import` | —             | `ImportedCard`     | (production-only) | default surface | no author dot · italic byline "Sarah · 2024-12-05" (`--tandem-fg-subtle`) | Promote (primary) · Dismiss (ghost) |
+**Two axes, and they are separate on purpose.** *Author* picks the background
+tint; *type* picks the header icon. The variant component picks neither — it
+owns the body and the actions row. Before this split the tint was per-variant,
+which put a user comment and a user note on different grounds while both
+carried the same authorship dot, so the rail contradicted itself. Three tints,
+three authors:
+
+| `annotation.author` | Background tint |
+| --- | --- |
+| `user`   | `var(--tandem-author-user-bg)` |
+| `claude` | `var(--tandem-author-claude-bg)` |
+| `import` | `var(--tandem-author-import-bg)` (aliases `--tandem-surface-muted`) |
+
+`isReviewTarget` overrides all three with `var(--tandem-accent-bg)`; that is a
+state, not a taxonomy row.
+
+The **type icon** is a 13×13 `<svg>` at `viewBox 0 0 16 16`, `stroke:
+currentColor`, keyed on the *display* type — `comment`, `note`, `highlight` or
+`replacement` (the last derived from `suggestedText !== undefined`, not
+stored). It replaced a text pill: the pill spent horizontal room the 160px
+narrow margin band does not have, and it repeated what the card body already
+says. Only `highlight` is filled, and its fill is the user's picked highlight
+colour — the one place that colour still appears now that the body is tinted
+by author. The icon is hidden at stub density; its accessible name sits on the
+wrapping `role="img"`, and a visually-hidden word is revealed under
+`forced-colors: active`, where every tint collapses to `Canvas`.
+
+| audience  | author   | suggestedText | Production variant | Bundle `cardType` | Background tint | Header (dot + name + icon) | Actions row |
+| --------- | -------- | ------------- | ------------------ | ----------------- | --------------- | -------------------------- | ----------- |
+| `private` | `user`   | —             | `NoteCard`         | `note`            | user tint | **hollow** cobalt dot · "You" · note icon | Send to Claude (neutral + coral disc) · Archive (ghost) |
+| `claude`  | `user`   | —             | `CommentCard`      | `comment-user`    | user tint | cobalt dot · "You" · comment icon | Resolve (primary) · Edit (ghost) · Delete (ghost) |
+| `claude`  | `claude` | —             | `CommentCard`      | (`comment`)       | claude tint | agent-coloured dot · "Claude" · comment icon | Resolve (primary) · Edit (ghost) · Delete (ghost) |
+| `claude`  | `claude` | present       | `SuggestionCard`   | `suggest`         | claude tint | agent-coloured dot · "Claude" · replacement icon | Accept (primary) · Dismiss (ghost) · Edit (ghost) |
+| `claude`  | `import` | —             | `ImportedCard`     | (production-only) | import tint | no author dot · italic byline "Sarah · 2024-12-05" (`--tandem-fg-subtle`) | Promote (primary) · Dismiss (ghost) |
+
+The hollow note dot is the **only** thing carrying privacy in the header, and
+it is deliberately zero-width-cost: it swaps `background` for a `border` on an
+element that already exists, so it cannot disturb the stub-density width
+budget. Do not replace it with a pill or an extra glyph without re-checking
+that budget.
 
 **Suggestions are Claude-only.** Users can author notes, comments, and
 highlights; they cannot author suggestions. A `suggestedText` field on a
@@ -324,7 +360,7 @@ from the user-picked highlight color in `HIGHLIGHT_COLOR_VARS`
 **Header chrome details (per `app.css:518–547`):**
 - `.author-dot` = 6×6px circle, `var(--tandem-author-user)` or `var(--tandem-author-claude)` background, `flex-shrink: 0`
 - `.author-name` = 11px, 600 weight; cobalt for user (`oklch(0.35 0.14 245)`), gold for Claude (`oklch(0.40 0.12 45)` light, `oklch(0.78 0.12 45)` dark)
-- `.type-badge` = 9px monospace pill, uppercase, with per-type tints (violet for `.suggest`, cobalt for `.comment`)
+- `.annotation-type-badge` = the 13×13 type-icon wrapper, `role="img"` with the type as its accessible name. It replaced the bundle's `.type-badge` 9px monospace pill, and the per-type *pill tints* (violet for `.suggest`, cobalt for `.comment`) went with it — the icon is `currentColor`, and the card's author tint carries the colour signal now.
 - `.card-time` = 9px monospace at `--tandem-fg-faint`, right-aligned via `margin-left: auto`
 
 **Anti-patterns:**
@@ -332,17 +368,23 @@ from the user-picked highlight color in `HIGHLIGHT_COLOR_VARS`
   load-bearing correction vs the older design. Background tint is the
   primary signal; the border is the standard 1px `var(--tandem-border)`
   all the way around.
-- Do NOT branch tint on `author === "claude"` directly — the production
-  card variant (`NoteCard` / `CommentCard` / `SuggestionCard` /
-  `ImportedCard`) owns the tint via its own CSS class. The variant IS
-  the predicate; the dispatcher just routes.
+- Do NOT move the tint back onto the card variants. It is keyed on
+  `annotation.author` in exactly one place (`cardTint` in
+  `AnnotationCard.svelte`) so that two variants sharing an author cannot
+  disagree. An earlier revision of this list said the opposite; it
+  predates the change.
 - Do NOT change the protected tokens (`--tandem-author-user`,
   `--tandem-author-claude`, `--tandem-suggestion*`) without re-running
   `token-protection.test.ts`. The card chrome reads them through the
   audited values, not via local overrides.
 - Do NOT show the author dot for `ImportedCard` — imported annotations
   came from a Word commentor, not a Claude/user author; the header
-  byline replaces the dot.
+  byline replaces the dot. Imports do still get a tint of their own
+  (`--tandem-author-import-bg`); "no dot" is about the dot only.
+- Do NOT give the type icon a colour of its own. It is `currentColor`
+  everywhere except the `highlight` fill, which carries the user's picked
+  highlight colour. A second coloured element in the header competes with
+  the author dot for the same signal.
 - Do NOT add an `Accept` action to non-suggestion cards. The bundle's
   `card-actions` row is type-specific:
   - `note` → Send to Claude (neutral `.aca-btn--send` + coral destination disc), Archive (ghost)

--- a/index.html
+++ b/index.html
@@ -125,6 +125,23 @@
         --tandem-author-claude-fg: oklch(0.24 0.03 55);
         --tandem-author-user-bg: color-mix(in srgb, var(--tandem-author-user) 10%, var(--tandem-surface));
         --tandem-author-claude-bg: color-mix(in srgb, var(--tandem-author-claude) 10%, var(--tandem-surface));
+        /* Third authorship tint, completing the set so annotation cards can be
+           tinted by AUTHOR alone (user / claude / import) with type carried by
+           an icon instead of a colour.
+
+           Deliberately an ALIAS, not a hand-authored per-theme value like its
+           two siblings above. Import is neutral-by-intent — it is the "not one
+           of us" ground, and surface-muted is already exactly that in every
+           theme. Aliasing means this single :root definition re-resolves
+           correctly in [data-theme="dark"], [data-theme="warm"] AND the
+           forced-colors block (where surface-muted becomes Canvas), so there is
+           no fourth place to forget. Copying the literal instead would silently
+           regress warm, which defines its own surface-muted.
+
+           Rendering for imports is byte-identical to the pre-token behaviour;
+           what this buys is the NAME, so "tint is author-keyed" is true in the
+           stylesheet rather than only inside a Svelte branch. */
+        --tandem-author-import-bg: var(--tandem-surface-muted);
         --tandem-claude-focus-bg: color-mix(in srgb, var(--tandem-author-claude) 10%, transparent);
         --tandem-claude-focus-border: color-mix(in srgb, var(--tandem-author-claude) 40%, transparent);
         /* Per-agent authorship colors (#1123 M4, ADR-039). Keyed to the closed

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -547,26 +547,48 @@ function onCardClick(event: MouseEvent) {
   /* PRIVACY SIGNAL — a note's author dot is a ring, not a disc.
 
      Under author-tint a note and a comment by the same person share a card
-     ground, so the amber that used to mean "private" is gone. The Private pill
-     covers the full/compact/clamped bands, but it lives inside `.ach-type`,
-     which stub hides outright — and it is `aria-hidden`, so it was never the
-     accessibility answer either. At stub density the tint WAS the only
-     surviving note signal.
+     ground, so the amber that used to mean "private" is gone. This is a
+     visual belt-and-braces signal, NOT the load-bearing one — be careful not
+     to overstate it:
+       - the card root's `aria-label` prefixes "private " at every density
+         (`getCardLabel`), which is the accessibility answer;
+       - in the margin, notes render in the LEFT column and comments in the
+         right (`marginSides.ts`), and that split is density-independent —
+         so it, not this ring, is what actually carries the signal in the one
+         band where `.ach-type` is hidden;
+       - at full/compact/clamped there is also the Private pill and the lock
+         glyph, whose accessible name is literally "Private note".
+     The ring earns its place by covering the side panel, where there is no
+     left/right split and where a note and a comment by the same author would
+     otherwise differ only inside `.ach-type`.
 
-     A hollow dot costs zero width, so it cannot disturb the stub scrollWidth
-     gate the way a larger glyph would; it needs no new markup, because
-     `data-annotation-type` is already on the card root; and it survives
-     forced-colors, where a CanvasText border is still a border.
+     A hollow dot costs zero width (`box-sizing: border-box` is global), so it
+     cannot disturb the stub scrollWidth gate the way a larger glyph would; it
+     needs no new markup, because `data-annotation-type` is already on the card
+     root; and it survives forced-colors, where a CanvasText border is still a
+     border.
 
      Keyed on `type === "note"`, deliberately NOT on `audience`. Notes are what
      ADR-027 actually defends; `audience: "private"` is the muddled field —
      user highlights carry it and are still returned to Claude (#1710). */
   /* The whole selector must sit inside one `:global(...)` — `.ach-dot` belongs
      to AnnotationCardHeader, so a Svelte-scoped trailing class gets this
-     component's hash appended and matches nothing. */
+     component's hash appended and matches nothing.
+
+     `border-color` is NOT set here. The header emits it inline alongside the
+     dot's background so the ring tracks the ANNOTATION'S OWN author colour —
+     `agentColor(agentIdentity)` for an agent, the user token otherwise.
+     Hardcoding `--tandem-author-user` here looked right (notes are user-only
+     today) but is wrong for a legacy `flag`: `sanitizeAnnotation` migrates
+     `flag` -> `note` while preserving `author`, so a Claude-written flag
+     renders a Claude-tinted card with a user-coloured ring — the tint and the
+     dot contradicting each other, which is the exact failure this whole change
+     removes. `!important` IS needed on `background` (the inline style would
+     otherwise win) and is deliberately absent on the border half. */
   :global([data-annotation-type="note"] .ach-dot) {
     background: transparent !important;
-    border: 1.5px solid var(--tandem-author-user);
+    border-width: 1.5px;
+    border-style: solid;
   }
 
   /* Stub (stub band, inactive): a ~22px anchor pip — the 6px author dot only.

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -5,7 +5,7 @@ import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
 import { activationKeydown } from "../utils/keyboard-activate";
 import AnnotationCardActions from "./AnnotationCardActions.svelte";
 import AnnotationEditForm from "./AnnotationEditForm.svelte";
-import { getCardLabel, getHighlightBorder } from "./annotation-card-helpers";
+import { getCardLabel } from "./annotation-card-helpers";
 import CommentCard from "./CommentCard.svelte";
 import type { Density } from "./cardDensity";
 import { cardEnter, cardExit } from "./cardMotion";
@@ -147,19 +147,27 @@ $effect(() => {
     replyOpenNonce = req.nonce;
   }
 });
-// Per-type body tint replaces the old 3px left-edge border (Conflict #8
-// "lift color" interpretation, sub-PR 1.5 — full-taxonomy tints so every type
-// stays differentiated, not just the two the bundle tints). getHighlightBorder
-// is called inside the derivation so the highlight tint re-tracks annotation.color.
-const cardTint = $derived.by(() => {
-  if (annotation.author === "import") return "var(--tandem-surface-muted)";
-  if (annotation.type === "highlight")
-    return `color-mix(in srgb, ${getHighlightBorder(annotation)} 18%, var(--tandem-surface))`;
-  if (annotation.type === "note") return "var(--tandem-warning-bg)";
-  if (annotation.suggestedText !== undefined) return "var(--tandem-suggestion-bg)";
-  if (annotation.author === "claude") return "var(--tandem-author-claude-bg)";
-  return "var(--tandem-author-user-bg)";
-});
+// Tint is AUTHOR, always — three values, one per author role. Type is carried
+// by the header's icon instead (`annotation-type-icon.ts`).
+//
+// This replaces a six-branch derivation that mixed the two axes: it tinted by
+// type for note/highlight/suggestion and by author for everything else, so one
+// colour was asked to answer two questions and answered neither cleanly. A
+// Claude-authored highlight looked identical to a user-authored one — and the
+// tutorial seeds highlights as `author: "claude"`, so that collision was on the
+// first card every new user meets. Meanwhile the margin leader lines pointing
+// AT these cards were already author-keyed (`leaderColorForAuthor`), so the
+// rail contradicted itself.
+//
+// The highlight's picked colour is not lost — it moved to the type icon, which
+// is the one place it still means something.
+const cardTint = $derived(
+  annotation.author === "claude"
+    ? "var(--tandem-author-claude-bg)"
+    : annotation.author === "import"
+      ? "var(--tandem-author-import-bg)"
+      : "var(--tandem-author-user-bg)",
+);
 
 // Review-target override wins over the type tint; the accent ring is applied
 // via the .is-review-target class (see the style block below) so it composes
@@ -540,6 +548,31 @@ function onCardClick(event: MouseEvent) {
   .is-density-clamped :global(.aca-undo-row),
   .is-density-clamped :global(.aca-standalone) {
     display: none;
+  }
+
+  /* PRIVACY SIGNAL — a note's author dot is a ring, not a disc.
+
+     Under author-tint a note and a comment by the same person share a card
+     ground, so the amber that used to mean "private" is gone. The Private pill
+     covers the full/compact/clamped bands, but it lives inside `.ach-type`,
+     which stub hides outright — and it is `aria-hidden`, so it was never the
+     accessibility answer either. At stub density the tint WAS the only
+     surviving note signal.
+
+     A hollow dot costs zero width, so it cannot disturb the stub scrollWidth
+     gate the way a larger glyph would; it needs no new markup, because
+     `data-annotation-type` is already on the card root; and it survives
+     forced-colors, where a CanvasText border is still a border.
+
+     Keyed on `type === "note"`, deliberately NOT on `audience`. Notes are what
+     ADR-027 actually defends; `audience: "private"` is the muddled field —
+     user highlights carry it and are still returned to Claude (#1710). */
+  /* The whole selector must sit inside one `:global(...)` — `.ach-dot` belongs
+     to AnnotationCardHeader, so a Svelte-scoped trailing class gets this
+     component's hash appended and matches nothing. */
+  :global([data-annotation-type="note"] .ach-dot) {
+    background: transparent !important;
+    border: 1.5px solid var(--tandem-author-user);
   }
 
   /* Stub (stub band, inactive): a ~22px anchor pip — the 6px author dot only.

--- a/src/client/panels/AnnotationCard.svelte
+++ b/src/client/panels/AnnotationCard.svelte
@@ -5,7 +5,7 @@ import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
 import { activationKeydown } from "../utils/keyboard-activate";
 import AnnotationCardActions from "./AnnotationCardActions.svelte";
 import AnnotationEditForm from "./AnnotationEditForm.svelte";
-import { getCardLabel } from "./annotation-card-helpers";
+import { getCardLabel, getCardTint } from "./annotation-card-helpers";
 import CommentCard from "./CommentCard.svelte";
 import type { Density } from "./cardDensity";
 import { cardEnter, cardExit } from "./cardMotion";
@@ -161,13 +161,7 @@ $effect(() => {
 //
 // The highlight's picked colour is not lost — it moved to the type icon, which
 // is the one place it still means something.
-const cardTint = $derived(
-  annotation.author === "claude"
-    ? "var(--tandem-author-claude-bg)"
-    : annotation.author === "import"
-      ? "var(--tandem-author-import-bg)"
-      : "var(--tandem-author-user-bg)",
-);
+const cardTint = $derived(getCardTint(annotation.author));
 
 // Review-target override wins over the type tint; the accent ring is applied
 // via the .is-review-target class (see the style block below) so it composes

--- a/src/client/panels/AnnotationCardHeader.svelte
+++ b/src/client/panels/AnnotationCardHeader.svelte
@@ -3,7 +3,13 @@ import type { Snippet } from "svelte";
 import type { Annotation } from "../../shared/types";
 import { createAgentLabel } from "../hooks/useAgentLabel.svelte";
 import { agentColor } from "../utils/agent-color";
-import { formatRelativeTime, getAuthorLabel, getDisplayType } from "./annotation-card-helpers";
+import {
+  formatRelativeTime,
+  getAuthorLabel,
+  getDisplayType,
+  getHighlightBorder,
+} from "./annotation-card-helpers";
+import { ANNOTATION_TYPE_GLYPHS } from "./annotation-type-icon";
 
 interface Props {
   annotation: Annotation;
@@ -11,24 +17,13 @@ interface Props {
   isReviewTarget?: boolean;
   isEditing: boolean;
   canEdit: boolean;
-  badgeBg: string;
-  badgeFg: string;
   onEnterEdit: () => void;
   /** Optional extra pill rendered next to the type badge (e.g. Private pill on NoteCard). */
   extraPill?: Snippet;
 }
 
-let {
-  annotation,
-  isPending,
-  isReviewTarget,
-  isEditing,
-  canEdit,
-  badgeBg,
-  badgeFg,
-  onEnterEdit,
-  extraPill,
-}: Props = $props();
+let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit, extraPill }: Props =
+  $props();
 
 const agentLabel = createAgentLabel();
 const displayType = $derived(getDisplayType(annotation));
@@ -45,15 +40,50 @@ const dotColor = $derived(
     ? agentColor(annotation.agentIdentity)
     : "var(--tandem-author-user)",
 );
+// Both MUST be $derived. As plain consts they freeze at mount with no type
+// error and no failing test: recolour a highlight and the swatch keeps the old
+// colour; edit a suggestion to drop suggestedText and the icon stays
+// "replacement" forever. `displayType` above is already reactive, which is
+// exactly what makes a plain-const lookup off it stale.
+const glyph = $derived(ANNOTATION_TYPE_GLYPHS[displayType]);
+// Highlights carry the user's chosen colour on the icon itself — the one place
+// that colour still appears now that the card body is tinted by author.
+const glyphFill = $derived(glyph.filled ? getHighlightBorder(annotation) : "none");
 </script>
 
 <div class="ach-row">
   <span class="ach-type">
+    <!-- Type icon. Explicit width/height are REQUIRED — a viewBox alone leaves
+         an <svg> with no intrinsic size, so it resolves to 300x150 and blows
+         out the header (worst in the 160px narrow margin band). -->
     <span
       class="ach-badge annotation-type-badge"
-      style="background: {badgeBg}; color: {badgeFg};"
+      role="img"
+      aria-label={glyph.label}
+      title={glyph.label}
     >
-      {displayType}
+      <svg
+        viewBox="0 0 16 16"
+        width="13"
+        height="13"
+        fill={glyphFill}
+        stroke="currentColor"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        {#each glyph.paths as d (d)}
+          <path {d} />
+        {/each}
+      </svg>
+      <!-- The type WORD, hidden in normal rendering and revealed under
+           forced-colors. In High Contrast every authorship tint collapses to
+           Canvas, so the card's background stops distinguishing anything — and
+           with the word gone the type would have no carrier at all. (Author
+           still reads: `.ach-author` renders "You"/"Assistant"/"Imported" as
+           real text.) Cheap insurance; costs nothing in the normal case. -->
+      <span class="ach-badge-word">{glyph.label}</span>
     </span>
     {#if extraPill}{@render extraPill()}{/if}
     {#if annotation.heldInSolo}
@@ -129,13 +159,25 @@ const dotColor = $derived(
     color: var(--tandem-fg-muted);
     font-size: 11px;
   }
+  /* Icon badge. The old text-pill recipe (mono font, uppercase, letter-spacing,
+     `padding: 1px 7px`, pill radius) is gone deliberately: four of those were
+     inert on an SVG, but padding is NOT — it applies to replaced elements, so
+     keeping it would render a 13px glyph inside a wide empty pill. */
   .ach-badge {
-    font-family: var(--tandem-font-mono);
-    font-size: var(--tandem-text-2xs);
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    padding: 1px 7px;
-    border-radius: var(--tandem-r-pill);
+    display: inline-flex;
+    align-items: center;
+    color: var(--tandem-fg-muted);
+    flex-shrink: 0;
+  }
+  /* Visually hidden, but revealed in forced-colors below — NOT `display: none`,
+     which would take it out of the box the reveal needs. */
+  .ach-badge-word {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
   }
   /* WS-A2: amber "Held" pill — matches the held-annotation banner token family
      (--tandem-warning-*). Signals a Solo-created comment the AI hasn't seen yet. */
@@ -205,8 +247,26 @@ const dotColor = $derived(
   }
 
   @media (forced-colors: active) {
-    .annotation-type-badge {
+    /* In High Contrast the three authorship tints all become Canvas, so the
+       card ground can no longer say who wrote it and the icon's own colours
+       are force-adjusted. Swap to the word: it is the only carrier of type
+       that survives. */
+    .annotation-type-badge svg {
+      display: none;
+    }
+    .ach-badge-word {
+      position: static;
+      width: auto;
+      height: auto;
+      overflow: visible;
+      clip-path: none;
+      font-family: var(--tandem-font-mono);
+      font-size: var(--tandem-text-2xs);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      padding: 1px 7px;
       border: 1px solid ButtonText;
+      border-radius: var(--tandem-r-pill);
     }
   }
 </style>

--- a/src/client/panels/AnnotationCardHeader.svelte
+++ b/src/client/panels/AnnotationCardHeader.svelte
@@ -7,7 +7,7 @@ import {
   formatRelativeTime,
   getAuthorLabel,
   getDisplayType,
-  getHighlightBorder,
+  getHighlightSwatchColor,
 } from "./annotation-card-helpers";
 import { ANNOTATION_TYPE_GLYPHS } from "./annotation-type-icon";
 
@@ -48,7 +48,7 @@ const dotColor = $derived(
 const glyph = $derived(ANNOTATION_TYPE_GLYPHS[displayType]);
 // Highlights carry the user's chosen colour on the icon itself — the one place
 // that colour still appears now that the card body is tinted by author.
-const glyphFill = $derived(glyph.filled ? getHighlightBorder(annotation) : "none");
+const glyphFill = $derived(glyph.filled ? getHighlightSwatchColor(annotation) : "none");
 </script>
 
 <div class="ach-row">
@@ -82,7 +82,22 @@ const glyphFill = $derived(glyph.filled ? getHighlightBorder(annotation) : "none
            Canvas, so the card's background stops distinguishing anything — and
            with the word gone the type would have no carrier at all. (Author
            still reads: `.ach-author` renders "You"/"Assistant"/"Imported" as
-           real text.) Cheap insurance; costs nothing in the normal case. -->
+           real text.)
+
+           This is a VISUAL fallback only, not an accessibility one — the
+           obvious reading of a clip-path-hidden span is wrong here. The
+           wrapper is `role="img"` with an `aria-label`, which makes its whole
+           subtree presentational: a screen reader announces the label and never
+           reaches this span. That is the intended behaviour (the name is
+           already there, and reading it twice would be worse), but it means
+           deleting the span costs sighted High Contrast users everything and
+           costs AT users nothing, so an a11y audit will not catch it. The
+           forced-colors e2e assertion is the only thing that does.
+
+           It also does not paint at every density: at stub density the whole
+           `.ach-type` group is `display: none` from AnnotationCard, so under
+           forcing the type has no carrier there either. That is a deliberate
+           narrow-margin tradeoff, not a gap this span can close. -->
       <span class="ach-badge-word">{glyph.label}</span>
     </span>
     {#if extraPill}{@render extraPill()}{/if}
@@ -127,7 +142,7 @@ const glyphFill = $derived(glyph.filled ? getHighlightBorder(annotation) : "none
         class="ach-dot"
         data-testid="annotation-author-dot-{annotation.id}"
         aria-hidden="true"
-        style="background: {dotColor};"
+        style="background: {dotColor}; border-color: {dotColor};"
       ></span>
     {/if}
     {authorLabel}
@@ -253,6 +268,24 @@ const glyphFill = $derived(glyph.filled ? getHighlightBorder(annotation) : "none
        that survives. */
     .annotation-type-badge svg {
       display: none;
+    }
+    /* MEASURED, not precautionary. `.ach-row` is `space-between` with
+       `overflow: hidden` and `.ach-badge` is `flex-shrink: 0`, so once the
+       13px glyph becomes a padded word the row cannot give anywhere: at the
+       side panel's 250px the content wanted 278px and the right-hand 28px —
+       the tail of `.ach-author`, i.e. the timestamp — was silently cut off.
+       That was with "Private note"; "Suggested replacement" is 75% wider.
+       Wrapping is the only fix that costs nothing: shrinking the badge would
+       truncate the ONLY type carrier that survives forcing, and shortening the
+       labels would throw away the accessible name. Height is cheap here and
+       clipping is not. `flex-wrap` is the load-bearing half and is pinned by
+       forced-colors.spec.ts's headerClipped assertion — drop it and that goes
+       red. `row-gap` is cosmetic (it keeps the wrapped lines off each other)
+       and is NOT pinned by anything. */
+    .ach-row,
+    .ach-type {
+      flex-wrap: wrap;
+      row-gap: 4px;
     }
     .ach-badge-word {
       position: static;

--- a/src/client/panels/CommentCard.svelte
+++ b/src/client/panels/CommentCard.svelte
@@ -23,8 +23,6 @@ let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: 
   {isReviewTarget}
   {isEditing}
   {canEdit}
-  badgeBg="var(--tandem-surface-sunk)"
-  badgeFg="var(--tandem-fg-muted)"
   {onEnterEdit}
 />
 

--- a/src/client/panels/HighlightCard.svelte
+++ b/src/client/panels/HighlightCard.svelte
@@ -21,8 +21,6 @@ let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: 
   {isReviewTarget}
   {isEditing}
   {canEdit}
-  badgeBg="var(--tandem-surface-sunk)"
-  badgeFg="var(--tandem-fg-muted)"
   {onEnterEdit}
 />
 

--- a/src/client/panels/ImportedCard.svelte
+++ b/src/client/panels/ImportedCard.svelte
@@ -48,8 +48,6 @@ let {
       {isReviewTarget}
       {isEditing}
       {canEdit}
-      badgeBg="var(--tandem-surface-sunk)"
-      badgeFg="var(--tandem-fg-muted)"
       {onEnterEdit}
     />
 

--- a/src/client/panels/NoteCard.svelte
+++ b/src/client/panels/NoteCard.svelte
@@ -21,8 +21,6 @@ let { annotation, isPending, isReviewTarget, isEditing, canEdit, onEnterEdit }: 
   {isReviewTarget}
   {isEditing}
   {canEdit}
-  badgeBg="var(--tandem-warning-bg)"
-  badgeFg="var(--tandem-warning-fg-strong)"
   {onEnterEdit}
 >
   {#snippet extraPill()}

--- a/src/client/panels/SuggestionCard.svelte
+++ b/src/client/panels/SuggestionCard.svelte
@@ -41,8 +41,6 @@ const originalTruncated = $derived(isSnapshotTruncated(annotation));
   {isReviewTarget}
   {isEditing}
   {canEdit}
-  badgeBg="var(--tandem-suggestion-bg)"
-  badgeFg="var(--tandem-suggestion-fg-strong)"
   {onEnterEdit}
 />
 

--- a/src/client/panels/annotation-card-helpers.ts
+++ b/src/client/panels/annotation-card-helpers.ts
@@ -84,9 +84,21 @@ export function getCardTint(author: Annotation["author"]): string {
   return "var(--tandem-author-user-bg)";
 }
 
-export function getHighlightBorder(ann: Annotation): string {
-  if (ann.type === "highlight" && ann.color) {
-    return HIGHLIGHT_COLOR_VARS[normalizeHighlightColor(ann.color)];
-  }
-  return "var(--tandem-author-user)";
+/**
+ * The colour to paint a highlight's filled type glyph.
+ *
+ * `normalizeHighlightColor` exists precisely to default a missing colour to
+ * yellow, so this must NOT short-circuit on `!ann.color` before calling it.
+ * The previous form did, and returned the user authorship token instead — so a
+ * colourless highlight painted YELLOW in the document (`extensions/annotation.ts`
+ * calls `normalizeHighlightColor` unguarded) while its card swatch painted
+ * cobalt. That mattered little when this fed a faint 18%-mixed card wash; as an
+ * opaque 13px swatch it is the loudest colour in the header, and an authorship
+ * token appearing there is the exact collision the two-axis model forbids.
+ *
+ * The `type === "highlight"` half of the old guard was redundant too: the only
+ * caller reaches this behind `glyph.filled`, which only `highlight` sets.
+ */
+export function getHighlightSwatchColor(ann: Annotation): string {
+  return HIGHLIGHT_COLOR_VARS[normalizeHighlightColor(ann.color)];
 }

--- a/src/client/panels/annotation-card-helpers.ts
+++ b/src/client/panels/annotation-card-helpers.ts
@@ -62,6 +62,28 @@ export function getCardLabel(ann: Annotation): string {
   return `${isPrivate ? "private " : ""}${displayType} annotation${trunc ? ": " + trunc : ""}, ${ann.status}`;
 }
 
+/**
+ * Background tint for an annotation card, keyed on AUTHOR.
+ *
+ * Author is the tint axis and type is the icon axis — deliberately separate.
+ * Tinting per card variant instead put a user comment and a user note on
+ * different grounds while both carried the same authorship dot, so the rail
+ * contradicted itself.
+ *
+ * Extracted rather than left inline in `AnnotationCard.svelte` so the `import`
+ * branch is reachable from a unit test. The other two are pinned end-to-end by
+ * `annotation-lifecycle.spec.ts`, but rendering an imported card needs a
+ * `.docx` import, so that branch would otherwise be covered by nothing.
+ *
+ * The review-target override (`--tandem-accent-bg`) is NOT here: it is a state,
+ * not a taxonomy row, and it belongs with the rest of the card's state styling.
+ */
+export function getCardTint(author: Annotation["author"]): string {
+  if (author === "claude") return "var(--tandem-author-claude-bg)";
+  if (author === "import") return "var(--tandem-author-import-bg)";
+  return "var(--tandem-author-user-bg)";
+}
+
 export function getHighlightBorder(ann: Annotation): string {
   if (ann.type === "highlight" && ann.color) {
     return HIGHLIGHT_COLOR_VARS[normalizeHighlightColor(ann.color)];

--- a/src/client/panels/annotation-card-helpers.ts
+++ b/src/client/panels/annotation-card-helpers.ts
@@ -34,7 +34,18 @@ export function formatRelativeTime(timestamp: number): string {
   return new Date(timestamp).toLocaleDateString();
 }
 
-export function getDisplayType(ann: Annotation): string {
+/**
+ * The four kinds a card can present as: the three stored `type` values plus
+ * `replacement`, which is a comment carrying `suggestedText`.
+ *
+ * Narrowed from a bare `string` so `ANNOTATION_TYPE_GLYPHS` can be an
+ * exhaustive `Record` over it. With `string` the icon lookup would need a
+ * fallback branch, and a fallback is precisely how a missing glyph turns into
+ * a silently-blank icon instead of a type error.
+ */
+export type AnnotationDisplayType = Annotation["type"] | "replacement";
+
+export function getDisplayType(ann: Annotation): AnnotationDisplayType {
   if (ann.suggestedText !== undefined) return "replacement";
   return ann.type;
 }

--- a/src/client/panels/annotation-type-icon.ts
+++ b/src/client/panels/annotation-type-icon.ts
@@ -1,0 +1,66 @@
+import type { AnnotationDisplayType } from "./annotation-card-helpers";
+
+/**
+ * Type glyphs for the annotation card header, keyed by `getDisplayType()`.
+ *
+ * Since the author-tint change, a card's BACKGROUND says who wrote it (user /
+ * claude / import) and this icon says what KIND it is. Before that, one colour
+ * tried to carry both and could carry neither cleanly — a Claude-authored
+ * highlight and a user-authored one looked identical, while a note and a
+ * comment by the same person did not.
+ *
+ * Path data lives here and the SVG is inlined by `AnnotationCardHeader`,
+ * matching the codebase's existing convention (`components/activityCenter.ts`
+ * states it outright: "the codebase inlines SVGs per-component rather than
+ * shipping an icon component"; `editor/slash-menu/commands.ts` does the same).
+ *
+ * All paths are authored for a **16x16 viewBox**. The consumer MUST set
+ * explicit `width`/`height` — a viewBox alone gives an `<svg>` no intrinsic
+ * size, so it resolves to the 300x150 replaced-element default and blows out
+ * the header. The slash menu gets away with omitting them only because
+ * `index.html` carries a sizing rule for its icons; there is no such rule here.
+ */
+export interface AnnotationTypeGlyph {
+  /** Accessible name — becomes the icon's `aria-label` and `title`. */
+  label: string;
+  /** `<path d>` values, drawn with `stroke="currentColor"`, `fill="none"`. */
+  paths: string[];
+  /**
+   * When true the glyph is a filled swatch rather than a stroked outline, and
+   * the consumer paints it with the annotation's own highlight colour. Only
+   * `highlight` sets this: it is the one type whose colour is user-chosen and
+   * therefore worth showing.
+   */
+  filled?: boolean;
+}
+
+export const ANNOTATION_TYPE_GLYPHS: Record<AnnotationDisplayType, AnnotationTypeGlyph> = {
+  // Speech bubble — the outbound, Claude-visible annotation.
+  comment: {
+    label: "Comment",
+    paths: ["M2.5 3.5h11v8h-6l-3 2.5v-2.5h-2z"],
+  },
+  // Lock over a page — privacy is the whole point of a note, so the glyph
+  // leads with it rather than showing yet another sheet of paper.
+  note: {
+    label: "Private note",
+    paths: ["M4 7V5.5a4 4 0 018 0V7", "M3 7h10v6.5H3z"],
+  },
+  // Rounded swatch. FILLED, not stroked, and it keeps a 1px outline: the four
+  // highlight colours are pale washes, and a hairline stroke in
+  // --tandem-highlight-yellow on an authorship tint is close to invisible. A
+  // filled shape with a token border reads at any colour on either theme, and
+  // WCAG 1.4.11's 3:1 then applies to the border, which is built to clear it.
+  highlight: {
+    label: "Highlight",
+    paths: ["M2.5 4.5h11v7h-11z"],
+    filled: true,
+  },
+  // Arrow into a bar — a substitution, not a remark. This is the only card
+  // whose Accept button edits the document, so its glyph is deliberately the
+  // least like the speech bubble.
+  replacement: {
+    label: "Suggested replacement",
+    paths: ["M2 8h7", "M6.5 5l3 3-3 3", "M12.5 3.5v9"],
+  },
+};

--- a/tests/client/annotation-card-header.test.ts
+++ b/tests/client/annotation-card-header.test.ts
@@ -3,6 +3,7 @@
 import { render } from "@testing-library/svelte";
 import { describe, expect, it } from "vitest";
 import AnnotationCardHeader from "../../src/client/panels/AnnotationCardHeader.svelte";
+import { ANNOTATION_TYPE_GLYPHS } from "../../src/client/panels/annotation-type-icon";
 import type { Annotation } from "../../src/shared/types";
 
 function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
@@ -18,16 +19,18 @@ function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
   } as Annotation;
 }
 
+function headerProps(annotation: Annotation) {
+  return {
+    annotation,
+    isPending: true,
+    isEditing: false,
+    canEdit: false,
+    onEnterEdit: () => {},
+  };
+}
+
 function renderHeader(annotation: Annotation) {
-  return render(AnnotationCardHeader, {
-    props: {
-      annotation,
-      isPending: true,
-      isEditing: false,
-      canEdit: false,
-      onEnterEdit: () => {},
-    },
-  });
+  return render(AnnotationCardHeader, { props: headerProps(annotation) });
 }
 
 function dotStyle(container: HTMLElement): string {
@@ -103,5 +106,102 @@ describe("AnnotationCardHeader type icon (author-tint model)", () => {
     );
     expect(badge(plain).getAttribute("aria-label")).toBe("Comment");
     expect(badge(sugg).getAttribute("aria-label")).toBe("Suggested replacement");
+  });
+});
+
+describe("annotation type glyphs are distinguishable", () => {
+  // The render tests below prove an <svg> appears and carries a name. They do
+  // NOT prove the four types look or sound different from each other: blanking
+  // every `paths` array, or swapping two types' path data, or giving two types
+  // the same `label`, all left the suite green. A type badge that renders the
+  // same mark for a private note and an outbound comment is worse than none.
+  const glyphs = Object.values(ANNOTATION_TYPE_GLYPHS);
+
+  it("gives every type a non-empty path set", () => {
+    for (const [type, glyph] of Object.entries(ANNOTATION_TYPE_GLYPHS)) {
+      expect(glyph.paths.length, `${type} has no path data`).toBeGreaterThan(0);
+      expect(
+        glyph.paths.every((d) => d.trim() !== ""),
+        `${type} has an empty path`,
+      ).toBe(true);
+    }
+  });
+
+  it("draws a DIFFERENT shape for every type", () => {
+    expect(new Set(glyphs.map((g) => g.paths.join("|"))).size).toBe(glyphs.length);
+  });
+
+  it("names every type DIFFERENTLY", () => {
+    // The label is the accessible name, so two types sharing one is a
+    // screen-reader collision, not just a cosmetic one. `highlight` was the
+    // unpinned member: no aria-label test rendered it.
+    expect(new Set(glyphs.map((g) => g.label)).size).toBe(glyphs.length);
+  });
+
+  it("fills the highlight glyph and only the highlight glyph", () => {
+    const filled = Object.entries(ANNOTATION_TYPE_GLYPHS)
+      .filter(([, g]) => g.filled)
+      .map(([type]) => type);
+    expect(filled).toEqual(["highlight"]);
+  });
+});
+
+describe("AnnotationCardHeader stays reactive to the annotation it is given", () => {
+  // The source comment says a plain `const` here would freeze at mount "with no
+  // type error and no failing test" — which was still true after the icon
+  // landed, because nothing re-rendered with changed props. Both paths below
+  // are reachable from real UI: the highlight colour picker, and
+  // `tandem_editAnnotation` adding suggestedText to a pending comment.
+  it("repaints the swatch when a highlight is recoloured", async () => {
+    const green = makeAnnotation({ type: "highlight", author: "user", color: "green" });
+    const { container, rerender } = render(AnnotationCardHeader, {
+      props: headerProps(green),
+    });
+    expect(container.querySelector(".annotation-type-badge svg")?.getAttribute("fill")).toBe(
+      "var(--tandem-highlight-green)",
+    );
+
+    await rerender(
+      headerProps(makeAnnotation({ type: "highlight", author: "user", color: "yellow" })),
+    );
+    expect(container.querySelector(".annotation-type-badge svg")?.getAttribute("fill")).toBe(
+      "var(--tandem-highlight-yellow)",
+    );
+  });
+
+  it("switches the glyph when a comment gains suggestedText", async () => {
+    const comment = makeAnnotation({ type: "comment" });
+    const { container, rerender } = render(AnnotationCardHeader, {
+      props: headerProps(comment),
+    });
+    expect(container.querySelector(".annotation-type-badge")?.getAttribute("aria-label")).toBe(
+      ANNOTATION_TYPE_GLYPHS.comment.label,
+    );
+
+    await rerender(headerProps(makeAnnotation({ type: "comment", suggestedText: "replacement" })));
+    expect(container.querySelector(".annotation-type-badge")?.getAttribute("aria-label")).toBe(
+      ANNOTATION_TYPE_GLYPHS.replacement.label,
+    );
+  });
+});
+
+describe("AnnotationCardHeader author dot presence", () => {
+  it("omits the dot entirely for an import", () => {
+    // An imported Word comment has no user/Claude author, and `dotColor`'s else
+    // branch is the USER token — so dropping this guard paints an import as
+    // though the user wrote it, which is the collision the tint model exists to
+    // prevent. Nothing rendered an `import` author before this.
+    const { container } = renderHeader(makeAnnotation({ author: "import" }));
+    expect(container.querySelector("[data-testid^='annotation-author-dot-']")).toBeNull();
+  });
+
+  it("renders the dot for user and claude", () => {
+    for (const author of ["user", "claude"] as const) {
+      const { container } = renderHeader(makeAnnotation({ author }));
+      expect(
+        container.querySelector("[data-testid^='annotation-author-dot-']"),
+        `${author} must keep its dot`,
+      ).not.toBeNull();
+    }
   });
 });

--- a/tests/client/annotation-card-header.test.ts
+++ b/tests/client/annotation-card-header.test.ts
@@ -25,8 +25,6 @@ function renderHeader(annotation: Annotation) {
       isPending: true,
       isEditing: false,
       canEdit: false,
-      badgeBg: "transparent",
-      badgeFg: "inherit",
       onEnterEdit: () => {},
     },
   });
@@ -56,5 +54,54 @@ describe("AnnotationCardHeader author dot color (#1123 M4)", () => {
   it("a user annotation is unaffected by identity wiring", () => {
     const { container } = renderHeader(makeAnnotation({ author: "user" }));
     expect(dotStyle(container)).toContain("background: var(--tandem-author-user);");
+  });
+});
+
+describe("AnnotationCardHeader type icon (author-tint model)", () => {
+  function badge(container: HTMLElement): HTMLElement {
+    const el = container.querySelector<HTMLElement>(".annotation-type-badge");
+    expect(el).toBeTruthy();
+    return el as HTMLElement;
+  }
+
+  // Queried by CLASS, not by a data-testid, deliberately: adding a testid would
+  // force a testid-set snapshot regeneration and a manifest update under
+  // Critical Rule 7, for a purely internal assertion handle.
+  it("renders a sized svg glyph, never an unsized one", () => {
+    const { container } = renderHeader(makeAnnotation());
+    const svg = badge(container).querySelector("svg");
+    expect(svg).toBeTruthy();
+    // A viewBox alone gives an <svg> no intrinsic size — it resolves to the
+    // 300x150 replaced-element default and blows out the header. There is no
+    // CSS sizing rule for this icon, so the attributes are load-bearing.
+    expect(svg?.getAttribute("width")).toBe("13");
+    expect(svg?.getAttribute("height")).toBe("13");
+  });
+
+  it("names the type accessibly even though the word is visually hidden", () => {
+    const { container } = renderHeader(makeAnnotation({ type: "note", author: "user" }));
+    expect(badge(container).getAttribute("aria-label")).toBe("Private note");
+  });
+
+  it("paints a highlight's chosen color onto the icon, not the card", () => {
+    const { container } = renderHeader(
+      makeAnnotation({ type: "highlight", author: "user", color: "green" }),
+    );
+    const svg = badge(container).querySelector("svg");
+    expect(svg?.getAttribute("fill")).toBe("var(--tandem-highlight-green)");
+  });
+
+  it("leaves non-highlight glyphs unfilled so they read as outlines", () => {
+    const { container } = renderHeader(makeAnnotation({ type: "comment" }));
+    expect(badge(container).querySelector("svg")?.getAttribute("fill")).toBe("none");
+  });
+
+  it("distinguishes a suggestion from a plain comment by glyph", () => {
+    const { container: plain } = renderHeader(makeAnnotation({ type: "comment" }));
+    const { container: sugg } = renderHeader(
+      makeAnnotation({ type: "comment", suggestedText: "replacement" }),
+    );
+    expect(badge(plain).getAttribute("aria-label")).toBe("Comment");
+    expect(badge(sugg).getAttribute("aria-label")).toBe("Suggested replacement");
   });
 });

--- a/tests/client/annotation-card-helpers.test.ts
+++ b/tests/client/annotation-card-helpers.test.ts
@@ -7,19 +7,31 @@ import {
 import type { Annotation } from "../../src/shared/types";
 
 describe("getCardTint (author is the tint axis)", () => {
-  // Exhaustive over the union rather than three hand-picked cases: `author` is
-  // a closed set, so a fourth role added without a tint would otherwise fall
-  // through to the user tint silently — a new author looking like the user is
-  // exactly the collision this model exists to prevent.
-  const AUTHORS: Annotation["author"][] = ["user", "claude", "import"];
+  // A `Record` over the union, NOT a hand-written array. An array annotated
+  // `Annotation["author"][]` is not required to be complete, so the previous
+  // form's claim to be "exhaustive over the union" was false: add a fourth
+  // author role and the array silently keeps three entries, `getCardTint`'s
+  // final branch returns the USER tint, and the suite stays green — the exact
+  // fall-through this is supposed to prevent. A `Record` keyed on the union
+  // fails to compile until the new role is listed.
+  //
+  // Values are spelled out rather than interpolated from the key for the same
+  // reason the mapping exists: `var(--tandem-author-${author}-bg)` would be
+  // satisfied by any implementation that interpolates, including one naming a
+  // token that does not exist. `card-tint-tokens.test.ts` closes the other half
+  // by checking these strings resolve against index.html.
+  const EXPECTED: Record<Annotation["author"], string> = {
+    user: "var(--tandem-author-user-bg)",
+    claude: "var(--tandem-author-claude-bg)",
+    import: "var(--tandem-author-import-bg)",
+  };
 
-  it.each(AUTHORS)("maps %s to its own token", (author) => {
-    expect(getCardTint(author)).toBe(`var(--tandem-author-${author}-bg)`);
+  it.each(Object.entries(EXPECTED))("maps %s to %s", (author, token) => {
+    expect(getCardTint(author as Annotation["author"])).toBe(token);
   });
 
   it("gives every author a DISTINCT token", () => {
-    const tints = AUTHORS.map(getCardTint);
-    expect(new Set(tints).size).toBe(AUTHORS.length);
+    expect(new Set(Object.values(EXPECTED)).size).toBe(Object.keys(EXPECTED).length);
   });
 
   // The `import` branch is the reason this function was extracted from

--- a/tests/client/annotation-card-helpers.test.ts
+++ b/tests/client/annotation-card-helpers.test.ts
@@ -2,7 +2,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   formatRelativeTime,
   getAuthorLabel,
+  getCardTint,
 } from "../../src/client/panels/annotation-card-helpers";
+import type { Annotation } from "../../src/shared/types";
+
+describe("getCardTint (author is the tint axis)", () => {
+  // Exhaustive over the union rather than three hand-picked cases: `author` is
+  // a closed set, so a fourth role added without a tint would otherwise fall
+  // through to the user tint silently — a new author looking like the user is
+  // exactly the collision this model exists to prevent.
+  const AUTHORS: Annotation["author"][] = ["user", "claude", "import"];
+
+  it.each(AUTHORS)("maps %s to its own token", (author) => {
+    expect(getCardTint(author)).toBe(`var(--tandem-author-${author}-bg)`);
+  });
+
+  it("gives every author a DISTINCT token", () => {
+    const tints = AUTHORS.map(getCardTint);
+    expect(new Set(tints).size).toBe(AUTHORS.length);
+  });
+
+  // The `import` branch is the reason this function was extracted from
+  // AnnotationCard.svelte at all. `annotation-lifecycle.spec.ts` pins user vs
+  // claude against a real stylesheet, but rendering an imported card needs a
+  // `.docx` import, so without this assertion that branch is covered nowhere:
+  // deleting it would fall through to the user tint, and an imported Word
+  // comment would render as though the user had written it.
+  it("does not let an import fall through to the user tint", () => {
+    expect(getCardTint("import")).not.toBe(getCardTint("user"));
+  });
+});
 
 // #1123 M3: the agent byline prefers the specific authoring model's
 // `agentIdentity.displayName`, then the active-model family label, then a

--- a/tests/design-system-impl/card-tint-tokens.test.ts
+++ b/tests/design-system-impl/card-tint-tokens.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { getCardTint } from "../../src/client/panels/annotation-card-helpers";
+import type { Annotation } from "../../src/shared/types";
+
+/**
+ * Every token `getCardTint` can return must actually be declared.
+ *
+ * `annotation-card-helpers.test.ts` pins the author -> token-NAME map, and
+ * `token-contrast.spec.ts` sweeps the tinted surfaces for contrast. Neither
+ * catches a token that does not exist, and the gap is not theoretical:
+ *
+ *  - the unit test compares strings, so it is happy with a name nothing defines;
+ *  - the contrast sweep resolves each token off `:root` and its `add()` helper
+ *    bails silently when either side is null ("token not defined in this theme
+ *    — not a failure"), so an ABSENT token is indistinguishable from a swept
+ *    one, which is precisely the property that entry was added to provide;
+ *  - no E2E renders an imported card at all — that needs a `.docx` import.
+ *
+ * So `--tandem-author-import-bg` could be deleted from index.html outright and
+ * the entire suite stays green while every imported Word comment renders with
+ * no background. This closes that, cheaply, without a browser.
+ *
+ * Deliberately a TEXT check against `index.html` rather than a computed-style
+ * check: this is asking whether the declaration exists, and the two CSS
+ * pipelines mean `index.html`'s inline `<style>` is emitted verbatim, so its
+ * text is the shipped truth.
+ */
+
+const INDEX_HTML = readFileSync(join(import.meta.dirname, "..", "..", "index.html"), "utf-8");
+
+const AUTHORS: Record<Annotation["author"], true> = { user: true, claude: true, import: true };
+
+describe("card tint tokens are declared", () => {
+  it.each(
+    Object.keys(AUTHORS) as Annotation["author"][],
+  )("%s's tint token exists in index.html", (author) => {
+    const token = getCardTint(author);
+    const name = /^var\((--[a-z0-9-]+)\)$/.exec(token)?.[1];
+    expect(
+      name,
+      `getCardTint("${author}") returned ${token}, which is not a bare var()`,
+    ).toBeTruthy();
+    // A DECLARATION (`--x:`), not merely a mention — a token that only ever
+    // appears inside some other rule's `var(--x)` is exactly the broken case.
+    expect(
+      INDEX_HTML.includes(`${name}:`),
+      `${name} is never declared in index.html, so a ${author} card renders with no background`,
+    ).toBe(true);
+  });
+});

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -7,8 +7,10 @@ import {
   cleanupFixtureDir,
   createFixtureDir,
   McpTestClient,
+  openAnnotatePopup,
   openSettingsViaBrandMenu,
   selectTextStable,
+  submitAnnotation,
   switchToAnnotationsTab,
 } from "./helpers";
 
@@ -301,6 +303,35 @@ const SURFACES: Surface[] = [
     // fg-muted, fg-subtle and fg-faint adjacent in a single header row, and a
     // rank inversion between two of those tiers went undetected through a full
     // green run. An empty container is not the surface.
+    //
+    // BOTH author tints, not just one. Cards are tinted by AUTHOR, so a single
+    // Claude comment renders the whole header stack on --tandem-author-claude-bg
+    // and leaves --tandem-author-user-bg unscanned — the same "an empty
+    // container is not the surface" mistake one level in. The note below is a
+    // real user annotation and is the only way to get the user tint on screen:
+    // notes are user-only by ADR-027, so no MCP tool can create one.
+    //
+    // WHAT THIS DOES NOT BUY, stated because the obvious reading is wrong.
+    // Adding the note does NOT make this a contrast gate for the user tint.
+    // Measured (#1721): paint the note card `#4a4a4a` — mid-grey behind dark
+    // body text, an unmissable AA failure — and all three themes still report
+    // `violations: []`. axe files 25 color-contrast nodes under `incomplete`
+    // against 17 under `passes`, and the assertion below reads only
+    // `violations`. The same page scanned with `.withRules(["color-contrast"])`
+    // finds 4 real violations inside this card, so axe can see it; the bucket
+    // we assert on is what drops it. Fixing that is suite-wide work, hence the
+    // issue rather than a local patch here.
+    //
+    // What the note IS worth: it puts a second card variant through every OTHER
+    // rule — roles, names, the visually-hidden badge word, the Private pill —
+    // none of which have that problem.
+    //
+    // And two things nothing covers anywhere: axe's color-contrast rule
+    // evaluates TEXT, so the highlight icon's `<svg>` fill against the card tint
+    // and the note dot's hollow `<span>` border are unevaluated by construction.
+    // `token-contrast.spec.ts` covers what is expressible as a token pair,
+    // including the import tint — which needs a `.docx` import to render and so
+    // has no card here.
     open: async (page) => {
       await bootWithContent(page);
       await mcp.callTool("tandem_comment", {
@@ -308,8 +339,14 @@ const SURFACES: Surface[] = [
         to: 15,
         text: "Contrast probe — exercises the muted/subtle/faint header stack.",
       });
+      await selectFirstParagraph(page);
+      await openAnnotatePopup(page);
+      await page
+        .locator("[data-testid='popup-annotation-input']")
+        .fill("Contrast probe — the user tint, which no Claude annotation can render.");
+      await submitAnnotation(page, "note");
       await switchToAnnotationsTab(page);
-      await expect(page.locator("[data-testid^='annotation-card-']").first()).toBeVisible({
+      await expect(page.locator("[data-testid^='annotation-card-']")).toHaveCount(2, {
         timeout: 10_000,
       });
     },

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -315,12 +315,26 @@ const SURFACES: Surface[] = [
     // Adding the note does NOT make this a contrast gate for the user tint.
     // Measured (#1721): paint the note card `#4a4a4a` — mid-grey behind dark
     // body text, an unmissable AA failure — and all three themes still report
-    // `violations: []`. axe files 25 color-contrast nodes under `incomplete`
-    // against 17 under `passes`, and the assertion below reads only
-    // `violations`. The same page scanned with `.withRules(["color-contrast"])`
-    // finds 4 real violations inside this card, so axe can see it; the bucket
-    // we assert on is what drops it. Fixing that is suite-wide work, hence the
-    // issue rather than a local patch here.
+    // `violations: []`, so the assertion below does not gate it.
+    //
+    // The structural reason is certain and is the durable half: NOTHING in this
+    // suite reads `results.incomplete`, so whatever axe files there is
+    // unasserted by construction. `color-contrast` is not in `disableRules`, so
+    // the rule does run — this is a bucketing gap, not a disabled rule.
+    //
+    // The exact mechanism is NOT established, and an earlier version of this
+    // comment asserted one it could not support. That run observed 25
+    // color-contrast nodes under `incomplete` against 17 under `passes`, but a
+    // faithful standalone repro of these tints — `oklch` tokens, `color-mix`
+    // grounds, the clip-path hidden word — reports the bad card as a plain
+    // VIOLATION with zero incomplete under the same axe version. So it is
+    // something structural in the live app (overlap/obscuring is the likely
+    // check), not the modern colour syntax, which is the first thing the next
+    // reader will suspect. Do not repeat the earlier claim that a
+    // `.withRules(["color-contrast"])` scan finds violations the default scan
+    // buckets away: `withRules` narrows which rules RUN, it does not change how
+    // a rule buckets a node, and those two probes were not the same page state.
+    // Fixing this is suite-wide work, hence the issue rather than a patch here.
     //
     // What the note IS worth: it puts a second card variant through every OTHER
     // rule — roles, names, the visually-hidden badge word, the Private pill —

--- a/tests/e2e/annotation-lifecycle.spec.ts
+++ b/tests/e2e/annotation-lifecycle.spec.ts
@@ -48,48 +48,73 @@ test.afterEach(async () => {
 });
 
 /**
- * The author-tint model, pinned where it actually renders.
+ * The author-tint model, pinned AT ITS CALL SITE.
  *
- * Two rules ship here and neither is visible to a unit test, because both are
- * composited: the card background is an inline `var(--tandem-author-*-bg)` that
- * only resolves against a real stylesheet, and the hollow note dot is a
- * `:global([data-annotation-type="note"] .ach-dot)` rule in a PARENT component
- * styling a CHILD component's element. Delete either and every vitest suite
- * stays green.
+ * Read the two assertions below together — either one alone is worthless here,
+ * and the first revision of this test learned that the expensive way.
  *
- * WHY THE DOT IS LOAD-BEARING. It is the only privacy signal left in the
- * header. Notes and comments authored by the same person now share a tint by
- * design — that is the point of tinting by author — so the tint cannot
- * distinguish them, and the type icon is hidden entirely at stub density. The
- * hollow dot is what remains, and it was chosen because swapping `background`
- * for a `border` on an element that already exists costs zero width and so
- * cannot disturb the stub-density budget.
+ * THE TRAP. That revision compared a user NOTE against a Claude COMMENT and
+ * asserted the backgrounds differ. Those two cards differ on BOTH axes, so the
+ * assertion passes under the model this change replaced as well: the old
+ * six-branch derivation tinted a note `--tandem-warning-bg` and a Claude
+ * comment `--tandem-author-claude-bg`, which are also not equal. Reverting
+ * `AnnotationCard.svelte` to the old model left the whole suite green,
+ * `getCardTint` included — the unit test proves the MAP, and nothing proved the
+ * map is the TINT.
  *
- * Asserting the two cards DIFFER rather than pinning literal colours: the
- * tokens are free to be retuned (token-contrast.spec.ts owns their contrast),
- * but a user card and a Claude card collapsing to the same ground is the
- * regression, and it is invisible in a screenshot diff of either card alone.
+ * So the pin needs a pair that isolates each axis:
+ *   - user note vs user comment must be the SAME  -> type is not the axis
+ *   - user comment vs claude comment must DIFFER  -> author is the axis
+ * The first is the one that actually kills the revert; "differ" can never
+ * distinguish the two models on its own.
+ *
+ * The dot assertions need the same care. Note-hollow / comment-filled is only
+ * meaningful between cards by the SAME author — against a Claude comment, a
+ * rule that hollowed every user-authored dot would pass too.
+ *
+ * WHY `cssAlpha(...) === 1` ON EACH BACKGROUND. `not.toBe` also passes when one
+ * side is broken: typo a token and `var()` falls back to the initial value, so
+ * the card computes `rgba(0, 0, 0, 0)` — different from the other card, and
+ * untinted. Asserting each ground is actually opaque is what separates "these
+ * two tints differ" from "one of them failed to resolve".
+ *
+ * Colours are compared to each other rather than pinned literally: the tokens
+ * are free to be retuned (`token-contrast.spec.ts` owns their contrast), while
+ * two authors collapsing onto one ground is the regression — and that is
+ * invisible in a screenshot diff of either card alone.
+ *
+ * None of this is reachable from a unit test: the tint is an inline
+ * `var(--tandem-author-*-bg)` that needs a real stylesheet, and the hollow dot
+ * is a `:global(...)` rule in a PARENT component styling a CHILD's element.
  */
-test("cards are tinted by author, and a note's dot is hollow", async ({ page }) => {
+test("tint follows author and not type, and a note's dot is hollow", async ({ page }) => {
   await openWithComment(tmpDir, "Claude-authored comment");
   await page.goto("/");
   const editor = page.locator(".tiptap");
   await expect(editor.locator("p").first()).toContainText("first paragraph", { timeout: 10_000 });
 
-  // A note can only be made through the UI — notes are user-only by ADR-027,
-  // so no MCP tool can create one.
-  await editor.click();
-  await selectTextStable(editor.locator("p").first());
-  await openAnnotatePopup(page);
-  await page.locator("[data-testid='popup-annotation-input']").fill("User-authored note");
-  await submitAnnotation(page, "note");
+  // Both user-authored annotations come through the UI. A note cannot come from
+  // MCP at all (user-only, ADR-027), and routing the user comment the same way
+  // keeps the two cards differing ONLY in type, which is the whole point.
+  const seed = async (text: string, audience: "note" | "comment") => {
+    await editor.click();
+    await selectTextStable(editor.locator("p").first());
+    await openAnnotatePopup(page);
+    await page.locator("[data-testid='popup-annotation-input']").fill(text);
+    await submitAnnotation(page, audience);
+  };
+  await seed("User-authored note", "note");
+  await seed("User-authored comment", "comment");
 
   await switchToAnnotationsTab(page);
   const cards = page.locator("[data-testid^='annotation-card-']");
-  await expect(cards).toHaveCount(2, { timeout: 10_000 });
+  await expect(cards).toHaveCount(3, { timeout: 10_000 });
 
-  const read = async (type: "note" | "comment") => {
-    const card = page.locator(`[data-testid^='annotation-card-'][data-annotation-type="${type}"]`);
+  // Keyed on the rendered content, not on `data-annotation-type` — two of the
+  // three cards are comments, so a type selector is ambiguous for exactly the
+  // pair this test exists to compare.
+  const read = async (text: string) => {
+    const card = cards.filter({ hasText: text });
     await expect(card).toHaveCount(1);
     return card.evaluate((el) => {
       const dot = el.querySelector("[data-testid^='annotation-author-dot-']");
@@ -103,19 +128,40 @@ test("cards are tinted by author, and a note's dot is hollow", async ({ page }) 
     });
   };
 
-  const note = await read("note");
-  const comment = await read("comment");
+  const userNote = await read("User-authored note");
+  const userComment = await read("User-authored comment");
+  const claudeComment = await read("Claude-authored comment");
+
+  for (const [name, card] of [
+    ["user note", userNote],
+    ["user comment", userComment],
+    ["claude comment", claudeComment],
+  ] as const) {
+    expect(
+      cssAlpha(card.cardBg),
+      `the ${name} card's ground is not opaque (${card.cardBg}) — its token probably failed to resolve`,
+    ).toBe(1);
+  }
 
   expect(
-    note.cardBg,
-    "a user note and a Claude comment must not share a background — author IS the tint axis",
-  ).not.toBe(comment.cardBg);
+    userNote.cardBg,
+    "a note and a comment by the SAME author must share a ground — type is not the tint axis",
+  ).toBe(userComment.cardBg);
 
-  // `transparent` computes to rgba(0, 0, 0, 0); read the alpha rather than
-  // matching a string, since the serialization is not guaranteed.
-  expect(cssAlpha(note.dotBg), `the note dot must have no fill; got ${note.dotBg}`).toBe(0);
-  expect(note.dotBorder, "a hollow dot with no border is an invisible dot").toBeGreaterThan(0);
-  expect(cssAlpha(comment.dotBg), `a comment dot must stay filled; got ${comment.dotBg}`).toBe(1);
+  expect(
+    userComment.cardBg,
+    "two authors must not share a ground — author IS the tint axis",
+  ).not.toBe(claudeComment.cardBg);
+
+  // Same author on both sides, so this isolates type. `transparent` computes to
+  // rgba(0, 0, 0, 0); read the alpha rather than matching a string, since the
+  // serialization is not guaranteed.
+  expect(cssAlpha(userNote.dotBg), `the note dot must have no fill; got ${userNote.dotBg}`).toBe(0);
+  expect(userNote.dotBorder, "a hollow dot with no border is an invisible dot").toBeGreaterThan(0);
+  expect(
+    cssAlpha(userComment.dotBg),
+    `a comment dot by the same author must stay filled; got ${userComment.dotBg}`,
+  ).toBe(1);
 });
 
 test("document loads in editor", async ({ page }) => {

--- a/tests/e2e/annotation-lifecycle.spec.ts
+++ b/tests/e2e/annotation-lifecycle.spec.ts
@@ -4,7 +4,11 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
+  cssAlpha,
   McpTestClient,
+  openAnnotatePopup,
+  selectTextStable,
+  submitAnnotation,
   switchToAnnotationsTab,
 } from "./helpers";
 
@@ -41,6 +45,77 @@ test.afterEach(async () => {
   await cleanupAllOpenDocuments(mcp);
   await mcp.close();
   cleanupFixtureDir(tmpDir);
+});
+
+/**
+ * The author-tint model, pinned where it actually renders.
+ *
+ * Two rules ship here and neither is visible to a unit test, because both are
+ * composited: the card background is an inline `var(--tandem-author-*-bg)` that
+ * only resolves against a real stylesheet, and the hollow note dot is a
+ * `:global([data-annotation-type="note"] .ach-dot)` rule in a PARENT component
+ * styling a CHILD component's element. Delete either and every vitest suite
+ * stays green.
+ *
+ * WHY THE DOT IS LOAD-BEARING. It is the only privacy signal left in the
+ * header. Notes and comments authored by the same person now share a tint by
+ * design — that is the point of tinting by author — so the tint cannot
+ * distinguish them, and the type icon is hidden entirely at stub density. The
+ * hollow dot is what remains, and it was chosen because swapping `background`
+ * for a `border` on an element that already exists costs zero width and so
+ * cannot disturb the stub-density budget.
+ *
+ * Asserting the two cards DIFFER rather than pinning literal colours: the
+ * tokens are free to be retuned (token-contrast.spec.ts owns their contrast),
+ * but a user card and a Claude card collapsing to the same ground is the
+ * regression, and it is invisible in a screenshot diff of either card alone.
+ */
+test("cards are tinted by author, and a note's dot is hollow", async ({ page }) => {
+  await openWithComment(tmpDir, "Claude-authored comment");
+  await page.goto("/");
+  const editor = page.locator(".tiptap");
+  await expect(editor.locator("p").first()).toContainText("first paragraph", { timeout: 10_000 });
+
+  // A note can only be made through the UI — notes are user-only by ADR-027,
+  // so no MCP tool can create one.
+  await editor.click();
+  await selectTextStable(editor.locator("p").first());
+  await openAnnotatePopup(page);
+  await page.locator("[data-testid='popup-annotation-input']").fill("User-authored note");
+  await submitAnnotation(page, "note");
+
+  await switchToAnnotationsTab(page);
+  const cards = page.locator("[data-testid^='annotation-card-']");
+  await expect(cards).toHaveCount(2, { timeout: 10_000 });
+
+  const read = async (type: "note" | "comment") => {
+    const card = page.locator(`[data-testid^='annotation-card-'][data-annotation-type="${type}"]`);
+    await expect(card).toHaveCount(1);
+    return card.evaluate((el) => {
+      const dot = el.querySelector("[data-testid^='annotation-author-dot-']");
+      if (!dot) throw new Error("card has no author dot");
+      const dotStyle = getComputedStyle(dot);
+      return {
+        cardBg: getComputedStyle(el).backgroundColor,
+        dotBg: dotStyle.backgroundColor,
+        dotBorder: parseFloat(dotStyle.borderTopWidth),
+      };
+    });
+  };
+
+  const note = await read("note");
+  const comment = await read("comment");
+
+  expect(
+    note.cardBg,
+    "a user note and a Claude comment must not share a background — author IS the tint axis",
+  ).not.toBe(comment.cardBg);
+
+  // `transparent` computes to rgba(0, 0, 0, 0); read the alpha rather than
+  // matching a string, since the serialization is not guaranteed.
+  expect(cssAlpha(note.dotBg), `the note dot must have no fill; got ${note.dotBg}`).toBe(0);
+  expect(note.dotBorder, "a hollow dot with no border is an invisible dot").toBeGreaterThan(0);
+  expect(cssAlpha(comment.dotBg), `a comment dot must stay filled; got ${comment.dotBg}`).toBe(1);
 });
 
 test("document loads in editor", async ({ page }) => {

--- a/tests/e2e/forced-colors.spec.ts
+++ b/tests/e2e/forced-colors.spec.ts
@@ -369,3 +369,87 @@ test("destination markers stay distinguishable by shape, not colour", async ({ p
     shapes.send.background,
   );
 });
+
+test("the annotation type survives forcing as a word, not just an icon", async ({ page }) => {
+  // The ONLY carrier of annotation type under High Contrast, and until now
+  // nothing referenced `.ach-badge-word` or the `@media (forced-colors: active)`
+  // block that reveals it. Deleting either left the suite green while the type
+  // lost every carrier at once: the card tint collapses to Canvas (so author
+  // and type both stop being colour-coded), and the glyph is hidden precisely
+  // because a force-adjusted 13px outline is not a reliable discriminator.
+  //
+  // Asserting a real bounding box rather than `toBeVisible()`: the word is
+  // hidden by `clip-path: inset(50%)` at 1x1, which Playwright still reports as
+  // visible. A reveal that undoes only SOME of the five hiding properties would
+  // pass a visibility check and paint nothing.
+  await boot(page);
+
+  const editor = page.locator(".tiptap");
+  await editor.click();
+  await editor.locator("p").first().selectText();
+  await openAnnotatePopup(page);
+  await page.locator("[data-testid='popup-annotation-input']").fill("forced-colors type check");
+  await submitAnnotation(page, "note");
+
+  const badge = page.locator(".annotation-type-badge").first();
+  await expect(badge).toBeVisible({ timeout: 10_000 });
+
+  const shape = await badge.evaluate((el) => {
+    const svg = el.querySelector("svg") as SVGElement | null;
+    const word = el.querySelector(".ach-badge-word") as HTMLElement | null;
+    const wordRect = word?.getBoundingClientRect();
+    return {
+      svgDisplay: svg ? getComputedStyle(svg).display : "missing",
+      hasWord: Boolean(word),
+      wordText: word?.textContent?.trim() ?? "",
+      wordWidth: wordRect?.width ?? 0,
+      wordHeight: wordRect?.height ?? 0,
+      wordClipPath: word ? getComputedStyle(word).clipPath : "missing",
+    };
+  });
+
+  expect(shape.hasWord, "the visually-hidden type word is gone from the markup").toBe(true);
+  expect(shape.svgDisplay, "the glyph must be hidden under forcing, not doubled up").toBe("none");
+  expect(shape.wordText.toLowerCase()).toContain("note");
+  expect(
+    shape.wordClipPath,
+    `the reveal must undo clip-path; got ${shape.wordClipPath}`,
+  ).not.toContain("inset(50%)");
+  expect(shape.wordWidth, "the revealed word has no width — it paints nothing").toBeGreaterThan(4);
+  expect(shape.wordHeight, "the revealed word has no height — it paints nothing").toBeGreaterThan(
+    4,
+  );
+
+  // This half FOUND A BUG rather than confirming one, so it is not decoration.
+  // The reveal swaps a 13px glyph for a padded word, `.ach-badge` is
+  // `flex-shrink: 0`, and `.ach-row` is `space-between` with
+  // `overflow: hidden` — so the row had nowhere to give. At the side panel's
+  // 250px the content wanted 278px and the right-hand 28px was silently cut
+  // off: the tail of `.ach-author`, i.e. the timestamp. Invisible in every
+  // other spec, because nothing else renders this row with a word in the badge.
+  //
+  // The fix is `flex-wrap: wrap` + `row-gap` on `.ach-row` and `.ach-type`
+  // inside the forced-colors block of AnnotationCardHeader.svelte. Delete
+  // either declaration and headerClipped goes back to true.
+  //
+  // COVERAGE BOUND, because the passing number below is easy to over-read:
+  // this measures "Private note" (12 characters), which is what this card
+  // shows. The longest label in the set is "Suggested replacement" at 21, and
+  // it is still NOT covered — seeding a suggestion into this fixture needs the
+  // MCP document-open sequence the other specs do, and doing it just to widen
+  // this assertion put a second unrelated failure mode into a test whose job
+  // is the reveal. That gap is #1724.
+  const row = await badge.evaluate((el) => {
+    const header = el.closest(".ach-row") as HTMLElement | null;
+    const author = header?.querySelector(".ach-author") as HTMLElement | null;
+    if (!header || !author) throw new Error("the badge is not inside a card header row");
+    return {
+      headerClipped: header.scrollWidth > header.clientWidth + 1,
+      authorClipped: author.scrollWidth > author.clientWidth + 1,
+      authorWidth: author.getBoundingClientRect().width,
+    };
+  });
+  expect(row.headerClipped, "the revealed word overflows the header row").toBe(false);
+  expect(row.authorClipped, "the revealed word starved the author side out of the row").toBe(false);
+  expect(row.authorWidth, "the author side was squeezed to nothing").toBeGreaterThan(20);
+});

--- a/tests/e2e/forced-colors.spec.ts
+++ b/tests/e2e/forced-colors.spec.ts
@@ -4,6 +4,7 @@ import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
   createFixtureDir,
+  cssAlpha,
   McpTestClient,
   openAnnotatePopup,
   submitAnnotation,
@@ -322,9 +323,11 @@ test("destination markers stay distinguishable by shape, not colour", async ({ p
   // resolving to the `rgba(0, 0, 0, 0)` it does in ordinary rendering — this
   // run returns `rgba(255, 255, 255, 0)`. The RGB triple is the UA's business;
   // alpha 0 is the thing that makes the ring a ring.
-  const noteAlpha = Number(
-    /rgba?\([^)]*?(?:,\s*([\d.]+))?\)$/.exec(shapes.note.background)?.[1] ?? "1",
-  );
+  // Was a hand-rolled regex taking "the last number before the paren", which
+  // reads the BLUE channel out of a three-component `rgb()` — so an opaque
+  // black fill scored alpha 0 and passed this very assertion. `cssAlpha`
+  // counts components instead.
+  const noteAlpha = cssAlpha(shapes.note.background);
   expect(noteAlpha, `the private marker must have no fill; got ${shapes.note.background}`).toBe(0);
 
   // The audience toggle's SELECTED state. Under forcing, the sliding thumb's

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -296,6 +296,23 @@ export async function submitAnnotation(page: Page, audience: "note" | "comment")
 }
 
 /**
+ * Alpha channel of a computed CSS color, 0–1.
+ *
+ * `getComputedStyle` serializes an unset/`transparent` background as
+ * `rgba(0, 0, 0, 0)` but an opaque one as `rgb(r, g, b)` — three components,
+ * no alpha. The obvious regex for "the last number before the paren" reads the
+ * BLUE channel out of the three-component form, so `rgb(0, 0, 0)` scores an
+ * alpha of 0 and an opaque black fill passes a "must be transparent"
+ * assertion. Count the components instead: 4 means the last one is alpha,
+ * anything else is opaque.
+ */
+export function cssAlpha(color: string): number {
+  const parts = color.match(/[\d.]+/g);
+  if (!parts) return 1;
+  return parts.length === 4 ? Number(parts[3]) : 1;
+}
+
+/**
  * Wait for `n` animation frames inside the page. Use after viewport resizes or
  * other DOM mutations that propagate through ResizeObserver → Svelte `$state` →
  * `$effect` → DOM, instead of `page.waitForTimeout(fixedMs)`.

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -296,20 +296,54 @@ export async function submitAnnotation(page: Page, audience: "note" | "comment")
 }
 
 /**
- * Alpha channel of a computed CSS color, 0–1.
+ * Alpha channel of a computed CSS color, 0-1.
  *
  * `getComputedStyle` serializes an unset/`transparent` background as
- * `rgba(0, 0, 0, 0)` but an opaque one as `rgb(r, g, b)` — three components,
- * no alpha. The obvious regex for "the last number before the paren" reads the
+ * `rgba(0, 0, 0, 0)` but an opaque one as `rgb(r, g, b)` — three components, no
+ * alpha. The obvious regex for "the last number before the paren" reads the
  * BLUE channel out of the three-component form, so `rgb(0, 0, 0)` scores an
  * alpha of 0 and an opaque black fill passes a "must be transparent"
- * assertion. Count the components instead: 4 means the last one is alpha,
- * anything else is opaque.
+ * assertion. That is the bug this replaced.
+ *
+ * Counting components instead is NOT enough, and getting that wrong once is
+ * why this is spelled out. Chrome already serializes this app's computed
+ * backgrounds as `color(srgb ...)` and `oklch(...)`, and a digit-bearing
+ * colorspace re-creates the identical failure: `color(display-p3 1 0 0)` has
+ * four digit runs, so a counting parser reports an opaque red as fully
+ * transparent, and `color(rec2020 0.5 0.2 0.1)` hands back the blue channel
+ * again. So: anchor on the `/` that modern CSS color syntax REQUIRES before an
+ * alpha, and only fall back to the legacy comma form.
+ *
+ * Unparseable input throws rather than defaulting. A helper whose failure mode
+ * is "reports opaque" turns a broken assertion into a passing one, which is the
+ * whole class of bug this exists to prevent.
  */
 export function cssAlpha(color: string): number {
-  const parts = color.match(/[\d.]+/g);
-  if (!parts) return 1;
-  return parts.length === 4 ? Number(parts[3]) : 1;
+  const value = color.trim();
+  if (value === "transparent") return 0;
+
+  // Modern syntax: rgb() / oklch() / color() / hsl() with `/ <alpha>`.
+  const slashed = /\/\s*([\d.]+)(%?)\s*\)\s*$/.exec(value);
+  if (slashed) {
+    const raw = Number(slashed[1]);
+    return slashed[2] === "%" ? raw / 100 : raw;
+  }
+
+  // Legacy comma form: rgba(r, g, b, a) / hsla(...). Exactly four components,
+  // and only for a function whose name we recognise — `color(a b c d)` is a
+  // colorspace plus three channels, not four channels.
+  const legacy = /^(rgba?|hsla?)\(([^)]*)\)$/i.exec(value);
+  if (legacy) {
+    const parts = legacy[2].split(/[\s,]+/).filter(Boolean);
+    if (parts.length === 4) return Number(parts[3]);
+    if (parts.length === 3) return 1;
+  }
+
+  // Anything else with a recognisable function head and no alpha is opaque:
+  // `color(srgb 0.9 0.9 0.9)`, `oklch(0.55 0.14 245)`, `#rrggbb`, `red`.
+  if (/^(#|[a-z-]+\()/i.test(value) || /^[a-z]+$/i.test(value)) return 1;
+
+  throw new Error(`cssAlpha: unrecognised color serialization ${JSON.stringify(color)}`);
 }
 
 /**

--- a/tests/e2e/margin-view.spec.ts
+++ b/tests/e2e/margin-view.spec.ts
@@ -1200,6 +1200,14 @@ test("C-2: stub band collapses every card to a pip that fits the column and stay
   // is clickable (stub ≠ display:none).
   await expect(cardA.locator(".aca-body")).toBeHidden();
   await expect(cardA.locator("[data-testid^='accept-btn-']")).toBeHidden();
+  // The header's type row goes too, and it needs its own assertion rather than
+  // riding on the two above. `.ach-type` is the last selector in a
+  // comma-separated group in AnnotationCard.svelte, so a change that unhides
+  // only IT leaves every other member of that group hiding correctly. Since the
+  // type badge became an icon it is the widest thing in that row, and the stub
+  // track is where width is scarcest — the scrollWidth gate below is measured
+  // on a pip that fits comfortably, so it will not reliably catch the spill.
+  await expect(cardA.locator(".ach-type")).toBeHidden();
 
   // THE ACCEPTANCE GATE (advisor): the stub card must FIT inside its column —
   // no horizontal spill past the column edge (the clipping bug the continuum

--- a/tests/e2e/token-contrast.spec.ts
+++ b/tests/e2e/token-contrast.spec.ts
@@ -40,6 +40,13 @@ const SURFACES = [
   "accent-bg",
   "author-user-bg",
   "author-claude-bg",
+  // Currently `var(--tandem-surface-muted)`, already swept two entries up, so
+  // this adds no new number today. It is here because the alias is the thing
+  // that could change: give imports their own tint and the sweep must follow
+  // without anyone remembering to come back. An unswept pair is
+  // indistinguishable from a passing one, which is the whole argument for this
+  // list being wide.
+  "author-import-bg",
   "success-bg",
   "warning-bg",
   "error-bg",


### PR DESCRIPTION
Annotation cards were tinted by **type**, which meant one colour was answering two questions and answering neither cleanly. This tints by **author** instead and moves type onto a header icon.

The concrete collision: a Claude-authored highlight looked identical to a user-authored one — and `tutorial-annotations.ts` seeds highlights as `author: "claude"`, so that collision was on the first card every new user meets. Meanwhile the margin leader lines pointing *at* these cards were already author-keyed (`leaderColorForAuthor`), so the rail contradicted itself.

## Two axes, kept separate

| axis | picks | where |
| --- | --- | --- |
| `annotation.author` | background tint | `getCardTint` — one function, three tokens |
| display type | header icon | `annotation-type-icon.ts` — comment / note / highlight / replacement |
| card variant | body + actions row | unchanged |

`--tandem-author-import-bg` is new, and is deliberately an **alias** for `--tandem-surface-muted` — one `:root` definition, so dark, warm and `forced-colors` all inherit it without three more hand-tuned values.

The highlight's picked colour is not lost. It moved to the type icon, which is the one place it still means something now that the body is tinted by author.

## What replaced the text badge

A 13×13 `<svg>`, `stroke: currentColor`, explicit `width`/`height` (a `viewBox` alone leaves an `<svg>` with no intrinsic size — it resolves to 300×150 and blows out the header, worst in the 160px narrow band). The pill it replaced spent horizontal room the narrow band does not have and repeated what the card body already says.

Two accessibility carve-outs, because the icon is the only type signal now:
- The accessible name sits on the wrapping `role="img"`; a **visually-hidden word** is revealed under `forced-colors: active`, where every tint collapses to `Canvas` and the icon is hidden.
- Notes keep their privacy signal through a **hollow** author dot, keyed off `[data-annotation-type="note"]`. Chosen because swapping `background` for a `border` on an element that already exists costs zero width, so it cannot disturb the stub-density budget — the type icon is hidden entirely at stub.

## Second commit: the pins, because most of this was unpinned

Mutation-tested every rule by reverting it and watching for a red test. **Three of five were green under mutation** — the user/claude tint collapse, the hollow dot, and the stub-density icon hide.

The third is worth reading. It *looked* pinned: unhiding the type row turned an e2e red. But the red was on an unrelated `accept-btn` assertion, and only because my mutation was not surgical — `.ach-type` is the last selector in a comma-separated group, so a change unhiding only *it* leaves every other member of that group hiding correctly. Re-mutated surgically: nothing caught it. It now has its own assertion.

Added:

- **`annotation-lifecycle.spec.ts`** — renders a user note beside a Claude comment, asserts the backgrounds differ and the dots differ in fill. Both rules are composited and invisible to a unit test: the tint is an inline `var()` needing a real stylesheet, and the hollow dot is a `:global()` rule in a *parent* component styling a *child's* element. Asserts they **differ** rather than pinning literal colours — retuning a token is allowed, collapsing two authors onto one ground is not.
- **`getCardTint`** extracted so the `import` branch is reachable at all. It is the only branch no rendered test can reach without a `.docx` import, and deleting it falls through to the user tint — an imported Word comment rendering as though the user wrote it. Covered exhaustively over the author union, so a fourth role added without a tint fails rather than silently inheriting the user's.
- **`margin-view.spec.ts`** — direct `.ach-type` hidden assertion in the stub band.
- **`token-contrast.spec.ts`** — sweeps `author-import-bg`. Adds no new number today since it aliases `surface-muted`; it is there because the *alias* is what can change, and an unswept pair is indistinguishable from a passing one.

## A latent bug found on the way

`forced-colors.spec.ts` parsed an alpha channel with a regex taking "the last number before the paren". `getComputedStyle` serializes transparent as `rgba(0,0,0,0)` but opaque as `rgb(r,g,b)` — three components, no alpha — so that regex reads the **blue channel**, and `rgb(0, 0, 0)` scores an alpha of 0. An opaque black fill would have passed the "must have no fill" assertion it guards. Replaced with a shared `cssAlpha` that counts components. I hit the identical bug writing the note-dot assertion, which is how it surfaced.

## The accessibility scenario, and what it is not

The axe `annotation card` surface now seeds a note, so a second card variant goes through every rule instead of only a Claude comment.

It is **not** a contrast gate for the user tint, and the comment in the file says so. Measured: painting that card `#4a4a4a` — an unmissable AA failure — still reports `violations: []` in all three themes, because axe files 25 `color-contrast` nodes under `incomplete` against 17 under `passes`, and the suite asserts only `violations`. The same page scanned with `.withRules(["color-contrast"])` finds 4 real violations in that card, so axe can see it; the bucket we assert on is what drops it. That is suite-wide rather than specific to this card → **#1721**.

Also recorded there, since a green run reads like more than it is: axe's `color-contrast` rule evaluates **text**. The highlight icon's svg fill against the card tint and the note dot's hollow border are unevaluated by construction — by anything, not just by axe.

## The design record was instructing the opposite

`derived-spec.md` told a reader to do exactly what this undoes:

> Do NOT branch the tint on `author === "claude"` directly — the discriminator is the production card variant, each owning its own background-tint class.

and separately, *"Do NOT add a type badge to NoteCard"*. Following either now would reintroduce the contradiction this removes. The C1 taxonomy is rewritten for the two-axis model, with the stale instructions **called out as superseded rather than quietly deleted** — a reader who remembers the old rule needs to know it changed, not to find the sentence missing.

## Verification

`typecheck` · `typecheck:tests` · **9958 vitest** · **383 e2e passing, 11 skipped** (full suite). Every rule listed above was mutation-verified red and then restored from a file copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPgCHx8uBs7zssaBsYp6fw
