### PR TITLE
fix(client): broadcast the mode after ctrl sync, and read the key back

### DIFF
--- a/docs/design-system-impl/derived-spec.md
+++ b/docs/design-system-impl/derived-spec.md
@@ -179,6 +179,13 @@ Each row:
   left, scrolling content panel on the right. `.settings-nav-btn`
   (`app.css:750`) for sidebar items, `.settings-mode-btn` (`app.css:784`)
   for segmented controls inside tabs.
+  > **No production surface consumes the segmented-control recipe as of
+  > #1623.** Its only consumer was the Collaboration tab's Default Mode
+  > radiogroup, which was deleted along with the setting — the mode toggle
+  > already persists the user's last choice, so a second source for the same
+  > preference could only disagree with it. The production
+  > `.settings-mode-btn` rules went with it. The bundle reference stands; the
+  > next tab that wants a segmented control re-adds the rules from it.
 - **Tokens.** Tab labels = `--tandem-ui-*` (token family added in audit).
   Section dividers = `1px solid var(--tandem-border)` with 16px vertical
   rhythm. Footer link rows (used in About) = `.settings-close-btn` style

--- a/docs/design-system-impl/testid-manifest.md
+++ b/docs/design-system-impl/testid-manifest.md
@@ -202,8 +202,7 @@ more lines in `__snapshots__/testid-set.snap.txt`.
   `settings-modal-mcp-status`, `settings-modal-tab-{*}`,
   `settings-modal-display-name`, `settings-modal-shortcuts-list`,
   `settings-modal-app-info-footer`
-- `settings-modal-default-mode-{tandem,solo}-btn`,
-  `settings-modal-solo-rail-hidden-toggle`,
+- `settings-modal-solo-rail-hidden-toggle`,
   `settings-modal-dwell-time-slider`,
   `settings-modal-selection-toolbar-toggle`,
   `settings-modal-margin-view-toggle`,

--- a/src/client/App.svelte
+++ b/src/client/App.svelte
@@ -207,6 +207,10 @@ const selectionDwellMs = $derived(settingsState.settings.selectionDwellMs);
 const modeState = createTandemModeBroadcast(
   () => yjsSync.bootstrapYdoc,
   () => selectionDwellMs,
+  // #1621: the broadcast must wait for the ctrl provider's first sync, or it
+  // races it and loses a CRDT tie silently. `createChatState` below already
+  // takes `ctrlInitialSyncComplete` for the same reason.
+  () => yjsSync.ctrlInitialSyncComplete,
 );
 
 // Remapped-shortcut override layer (ADR-041). Rebuilt whenever the user's

--- a/src/client/components/SettingsModal.svelte
+++ b/src/client/components/SettingsModal.svelte
@@ -1078,58 +1078,6 @@ async function handleReplayTutorial(): Promise<void> {
     color: var(--tandem-fg-subtle);
   }
 
-  /* Shared segmented-control recipe used by per-tab mode toggles
-     (Collaboration: Tandem/Solo default-mode pair). Active state is driven
-     by [aria-checked="true"] so the markup stays semantically a radiogroup.
-     Matches the bundle's `.settings-mode-btn` shape (flex:1, 2px border,
-     accent-active) while using production radii/spacing tokens for visual
-     consistency with the shell's other controls. */
-  :global(.settings-mode-btns) {
-    display: flex;
-    gap: var(--tandem-space-2);
-  }
-  :global(.settings-mode-btn) {
-    flex: 1;
-    padding: var(--tandem-space-2);
-    min-height: 30px;
-    border: 2px solid var(--tandem-border);
-    border-radius: var(--tandem-r-3);
-    background: var(--tandem-surface);
-    color: var(--tandem-fg-muted);
-    font-size: 12px;
-    font-weight: 400;
-    cursor: pointer;
-    transition: background 100ms, color 100ms, border-color 100ms;
-  }
-  /* Mode radios are styled globally because the tabs render them, so the guard
-     doubles the `:global` — the target selector is fully global and a scoped
-     descendant would never match it. The checked border/background are the
-     state readout; reduced motion just skips the fade into them. */
-  :global(body.tandem-reduce-motion) :global(.settings-mode-btn) {
-    transition: none;
-  }
-  @media (prefers-reduced-motion: reduce) {
-    :global(.settings-mode-btn) {
-      transition: none;
-    }
-  }
-  :global(.settings-mode-btn[aria-checked="true"]) {
-    border-color: var(--tandem-accent);
-    background: var(--tandem-accent-bg);
-    color: var(--tandem-accent-fg-strong);
-    font-weight: 600;
-  }
-  :global(.settings-mode-btn:focus-visible) {
-    outline: 2px solid var(--tandem-accent);
-    outline-offset: 1px;
-  }
-  /* Forward-compat read-only store: the tab sets `disabled` on these radios;
-     the affordance lives here with the rest of the class's state variants. */
-  :global(.settings-mode-btn:disabled) {
-    cursor: not-allowed;
-    opacity: 0.5;
-  }
-
   /* W9: narrow viewports collapse the persistent sidebar grid column into a
      slide-in drawer toggled by the header hamburger. The drawer is
      absolutely positioned so it overlays the content rather than pushing

--- a/src/client/components/settings-tabs/SettingsCollaborationTab.svelte
+++ b/src/client/components/settings-tabs/SettingsCollaborationTab.svelte
@@ -47,41 +47,6 @@ $effect(() => {
   />
 </div>
 
-<div>
-  <div id="settings-modal-default-mode-label" class="settings-section-label">Default Mode</div>
-  <div
-    role="radiogroup"
-    aria-labelledby="settings-modal-default-mode-label"
-    class="settings-mode-btns"
-  >
-    <button
-      type="button"
-      data-testid="settings-modal-default-mode-tandem-btn"
-      role="radio"
-      aria-checked={ctx.settings.defaultMode === "tandem"}
-      disabled={ctx.readOnly}
-      onclick={() => ctx.onUpdate({ defaultMode: "tandem" })}
-      class="settings-mode-btn"
-    >
-      Tandem
-    </button>
-    <button
-      type="button"
-      data-testid="settings-modal-default-mode-solo-btn"
-      role="radio"
-      aria-checked={ctx.settings.defaultMode === "solo"}
-      disabled={ctx.readOnly}
-      onclick={() => ctx.onUpdate({ defaultMode: "solo" })}
-      class="settings-mode-btn"
-    >
-      Solo
-    </button>
-  </div>
-  <div class="settings-hint" style="margin-top: var(--tandem-space-1);">
-    Sets the preferred starting mode for new sessions.
-  </div>
-</div>
-
 <label
   data-testid="settings-modal-solo-rail-hidden-toggle"
   style="display: flex; align-items: center; gap: var(--tandem-space-2); cursor: pointer; font-size: 12px; color: var(--tandem-fg); min-height: 24px;"

--- a/src/client/hooks/useTandemModeBroadcast.svelte.ts
+++ b/src/client/hooks/useTandemModeBroadcast.svelte.ts
@@ -10,6 +10,7 @@ import {
 import { withBrowser } from "../../shared/origins.js";
 import type { TandemMode } from "../../shared/types.js";
 import { TandemModeSchema } from "../../shared/types.js";
+import { logClientWarning } from "../utils/client-log.js";
 import { API_BASE } from "../utils/fileUpload.js";
 
 /**
@@ -69,19 +70,72 @@ export interface TandemModeBroadcastState {
 export function createTandemModeBroadcast(
   getBootstrapYdoc: () => Y.Doc | null,
   getSelectionDwellMs: () => number,
+  /**
+   * True once the CTRL provider has completed its first authoritative sync
+   * (`yjsSync.ctrlInitialSyncComplete`). Gates the broadcasts below — see #1621.
+   *
+   * REQUIRED, deliberately. A default of `() => true` would be the pre-#1621
+   * behaviour exactly — broadcast into an unsynced doc, concurrent with the
+   * incumbent, clientID coin flip — so an omitted argument would revert the fix
+   * silently and typecheck. Review found that every spec in
+   * `tests/client/tandem-mode-race.test.ts` stays green under that revert,
+   * because they drive the hook through a fixture that passes its own getters.
+   * Requiring it makes the revert a compile error instead. The remaining hole,
+   * passing a `const` snapshot rather than a live getter, is pinned statically by
+   * `tests/client/tandem-mode-wiring.test.ts`.
+   */
+  getCtrlSynced: () => boolean,
 ): TandemModeBroadcastState {
   let tandemMode = $state<TandemMode>(
     (() => {
       try {
         const saved = localStorage.getItem(TANDEM_MODE_KEY);
         const parsed = TandemModeSchema.safeParse(saved);
-        return parsed.success ? parsed.data : TANDEM_MODE_DEFAULT;
+        if (parsed.success) return parsed.data;
       } catch (err) {
         console.warn(`[tandem] localStorage unavailable reading ${TANDEM_MODE_KEY}:`, err);
         return TANDEM_MODE_DEFAULT;
       }
+      // #1623: the user's last mode IS the preference — there is no separate
+      // configured default. Settings → Collaboration used to carry one, stored
+      // and validated and migrated and read by nothing; rather than wire it up,
+      // it was removed, because persisting the toggle already expresses the same
+      // intent and two sources for one preference can disagree.
+      return TANDEM_MODE_DEFAULT;
     })(),
   );
+
+  /**
+   * #1621: the mode this client last wrote into the room, or null if it has not
+   * written to the current ctrl doc yet.
+   *
+   * A PLAIN variable, deliberately not `$state` — and the reason is narrower
+   * than an earlier version of this comment claimed, in a way that matters to
+   * anyone editing the observer.
+   *
+   * The hazard is real in general: Svelte bills a signal read to whatever
+   * reaction is active, the Y.Map observer below runs synchronously inside the
+   * broadcast effect's own `withBrowser` transaction, and a rune read there
+   * would add itself to the BROADCAST effect's dependency set — which, since
+   * that effect also writes it, is a self-invalidation. It was measured, on an
+   * earlier design that mirrored the room value into a rune and read it on that
+   * path: the broadcast re-ran on every remote change and re-stamped its own
+   * value before anything else could see the arriving one.
+   *
+   * It is NOT reachable in the code as it now stands, and the guard ORDER is the
+   * only thing keeping it that way. `if (transaction.local) return` bails before
+   * the first read of `lastBroadcast`, so the local re-entrant path — the one
+   * with an active reaction — never reads it; the remote path runs from the
+   * provider's socket handler, where no reaction is active. Moving that read
+   * above the `local` guard resurrects the measured behaviour. So a rune here
+   * would buy nothing and add a signal, and a future reader must not "restore"
+   * one on the grounds that the danger is hypothetical.
+   *
+   * Null also gates the detector: before this client has written, the room
+   * legitimately holds the previous session's persisted mode (`restoreCtrlDoc`),
+   * so comparing then would warn on every launch.
+   */
+  let lastBroadcast: TandemMode | null = null;
 
   // Persist tandem mode to localStorage
   $effect(() => {
@@ -93,24 +147,140 @@ export function createTandemModeBroadcast(
     }
   });
 
-  // Broadcast tandem mode to CTRL_ROOM Y.Map
+  // Broadcast tandem mode to CTRL_ROOM Y.Map.
+  //
+  // #1621: GATED ON CTRL SYNC, and that gate is the fix. `bootstrapYdoc` is
+  // published at provider construction, before any server state has arrived, so
+  // writing on the bare non-null transition made this write CONCURRENT with
+  // whatever the server already held. Yjs breaks a concurrent Y.Map tie by
+  // highest clientID, not recency, and clientIDs are random per launch — so
+  // every startup was a coin flip, silently, because nothing read the key back.
+  // Writing after sync makes THIS LAUNCH'S write causally after the incumbent it
+  // has already received, so it wins regardless of clientID. Measured both
+  // orderings; see the tie-break spec. The server-side half of that ordering is
+  // load-bearing and lives elsewhere: `restoreCtrlSession()` runs before
+  // `startHocuspocus()` in `src/server/index.ts`, so the WS port is not bound
+  // when the restore's blind `applyUpdate` lands and no client can have written
+  // first.
+  //
+  // It does NOT close the class, and the comment used to imply it did. Four
+  // concurrent cases remain, none of them regressions: the key absent entirely
+  // (fresh install, or a lost ctrl session file — every writer then has a null
+  // left origin); two already-synced clients toggling at once; `/api/mode/release`
+  // racing a client toggle; and a toggle made during a network blip, since
+  // `ctrlInitialSyncComplete` latches and is cleared only on doc replacement,
+  // never on a plain disconnect. The read-back below is what makes those audible.
+  //
+  // Both getters are read UNCONDITIONALLY before the early return: Svelte 5
+  // recomputes an effect's dependency set on every run, so a getter skipped by
+  // an early return is not tracked and the effect would not re-run when the
+  // flag flips.
   $effect(() => {
     const bootstrapYdoc = getBootstrapYdoc();
+    const synced = getCtrlSynced();
     const mode = tandemMode;
-    if (!bootstrapYdoc) return;
+    // Clearing here is what stops the detector comparing the NEW room's restored
+    // value against a write that only happened on the previous generation's doc.
+    //
+    // The two halves are NOT interchangeable, though an earlier comment here said
+    // so. `bootstrapCleanup` and `startBootstrap` run synchronously within one
+    // call, so Svelte never observes the intermediate `(null, false)` state and
+    // the effect flushes once against the final `(newDoc, false)` — where
+    // `!bootstrapYdoc` is already false. So `!synced` is what covers a doc swap;
+    // `!bootstrapYdoc` covers only pre-bootstrap and post-`destroy()`. A
+    // doc-identity check was here too and was removed: no reachable scenario
+    // could distinguish it, because `startBootstrap` sets
+    // `ctrlInitialSyncComplete = false` before publishing the new doc and only an
+    // async `provider.on("synced")` sets it true.
+    if (!bootstrapYdoc || !synced) {
+      lastBroadcast = null;
+      return;
+    }
     try {
       const awareness = bootstrapYdoc.getMap(Y_MAP_USER_AWARENESS);
       withBrowser(bootstrapYdoc, () => awareness.set(Y_MAP_MODE, mode));
+      lastBroadcast = mode;
     } catch (err) {
       console.warn("[tandem] failed to broadcast tandem mode to Y.Map:", err);
     }
   });
 
-  // Broadcast selection dwell time to CTRL_ROOM
+  // #1621 part 2: read the key BACK, and report a disagreement.
+  //
+  // Part 1 fixes today's race. This is what stops the NEXT one being silent —
+  // the broadcast was write-only, which is the whole reason a lost CRDT tie went
+  // unnoticed through a shipped release. Two cases part 1 does not close and
+  // this does report: two editors with different stored modes (the Tauri WebView
+  // and a browser tab have separate localStorage), and `/api/mode/release`
+  // writing "tandem" unconditionally over a second client sitting in Solo.
+  //
+  // It DOES NOT adopt the room's value, and that is a decision rather than a
+  // simplification. Adopting would let another window — or the server's own
+  // release route — take the user out of Solo without them touching anything,
+  // and Solo is a privacy control whose toggle promises Claude will not see
+  // their comments. A mechanism added to make that promise honest must not be
+  // able to revoke it.
+  //
+  // The asymmetry was considered, not overlooked. The mirror case — we hold
+  // "solo" and the room holds "tandem" — is the one that actually breaks Solo's
+  // promise, and re-asserting our own value there WOULD win, because our write
+  // would be causally after the competitor's item. It is not done here because
+  // two clients that both re-assert never converge, and bounding that needs its
+  // own design. Warn-only is the half that cannot make things worse.
+  //
+  // Registered on the Yjs observer rather than in an `$effect` over a mirrored
+  // rune: the mirror is what coupled the two effects in the first place (see
+  // `lastBroadcast`). Nothing here reads or writes reactive state, so there is
+  // no ordering question and no `state_unsafe_mutation` exposure.
   $effect(() => {
     const bootstrapYdoc = getBootstrapYdoc();
-    const dwellMs = getSelectionDwellMs();
     if (!bootstrapYdoc) return;
+    const awareness = bootstrapYdoc.getMap(Y_MAP_USER_AWARENESS);
+    const observer = (event: Y.YMapEvent<unknown>, transaction: Y.Transaction) => {
+      // `local` is the discriminator, not an equality check on the value. Our
+      // own `awareness.set` re-enters this observer synchronously inside the
+      // broadcast effect's transaction with `local === true`; only an update the
+      // provider applied from the wire can carry a competing writer's value.
+      if (transaction.local) return;
+      if (!event.keysChanged.has(Y_MAP_MODE)) return;
+      if (lastBroadcast === null) return;
+      const parsed = TandemModeSchema.safeParse(awareness.get(Y_MAP_MODE));
+      if (!parsed.success || parsed.data === lastBroadcast) return;
+      // `logClientWarning`, never a bare `console.warn` (#1439): the release
+      // desktop build ships no devtools feature, so a console line there is
+      // written to a sink nobody can read. This lands in Copy Diagnostics and
+      // the prefilled bug report instead. The event is two static literals
+      // rather than an interpolated pair because `scope`/`event` must be
+      // literals — that is the privacy control, pinned by
+      // `tests/client/client-log-callsites.test.ts`.
+      if (parsed.data === "solo") {
+        logClientWarning("tandem-mode", "room-holds-solo-not-ours");
+      } else {
+        logClientWarning("tandem-mode", "room-holds-tandem-not-ours");
+      }
+    };
+    awareness.observe(observer);
+    return () => {
+      awareness.unobserve(observer);
+    };
+  });
+
+  // Broadcast selection dwell time to CTRL_ROOM. Same race, same gate — this
+  // write is concurrent in exactly the way the mode write was.
+  //
+  // Same race, but deliberately NO detector, which is a decision and not an
+  // omission. Its source is a per-client settings slider, so two windows with
+  // different values genuinely disagree forever with no resolution: a read-back
+  // here would warn continuously and train everyone to ignore the diagnostics
+  // buffer, which is the failure this file argues against elsewhere. The mode
+  // key is different because both windows are claiming the same global fact.
+  // `tests/shared/mode-writer-set.test.ts` pins this key's writer set too, while
+  // the answer is still "one".
+  $effect(() => {
+    const bootstrapYdoc = getBootstrapYdoc();
+    const synced = getCtrlSynced();
+    const dwellMs = getSelectionDwellMs();
+    if (!bootstrapYdoc || !synced) return;
     try {
       const awareness = bootstrapYdoc.getMap(Y_MAP_USER_AWARENESS);
       withBrowser(bootstrapYdoc, () => awareness.set(Y_MAP_DWELL_MS, dwellMs));

--- a/src/client/hooks/useTandemSettings.ts
+++ b/src/client/hooks/useTandemSettings.ts
@@ -5,7 +5,6 @@ import {
   TANDEM_SETTINGS_KEY,
 } from "../../shared/constants";
 import { type ModelProvider, VALID_MODEL_PROVIDERS } from "../../shared/models/contract.js";
-import type { TandemMode } from "../../shared/types.js";
 import type { ShortcutChord } from "../actions/keybindings.js";
 import { parseCustomShortcuts } from "../actions/shortcut-conflicts.js";
 
@@ -145,7 +144,6 @@ export interface TandemSettings {
    */
   defaultSaveDirectory: string | null;
   density: Density;
-  defaultMode: TandemMode;
   highContrast: boolean;
   annotationPatterns: boolean;
   selectionToolbar: boolean;
@@ -256,7 +254,7 @@ function prefersReducedMotion(): boolean {
 const DEFAULTS: TandemSettings = {
   leftPanelVisible: false,
   rightPanelVisible: true,
-  schemaVersion: 19,
+  schemaVersion: 20,
   primaryTab: "annotations",
   panelOrder: "chat-editor-annotations",
   editorMeasure: "comfortable",
@@ -271,7 +269,6 @@ const DEFAULTS: TandemSettings = {
   fontByExtension: {},
   defaultSaveDirectory: null,
   density: "cozy",
-  defaultMode: "tandem",
   highContrast: false,
   annotationPatterns: false,
   selectionToolbar: true,
@@ -503,8 +500,16 @@ function parseFontByExtension(raw: unknown): Partial<Record<string, EditorFont>>
  *   an explicit override); `normalizeKnownFields` defaults a missing field to
  *   `true` so upgrading users gain the affordance without opting in, and
  *   preserves an explicit `false`.
+ * v19→v20: remove `defaultMode` (#1623). It was stored, validated, migrated
+ *   and unit-tested, and read by nothing — the live mode has always come from
+ *   the `tandem:mode` localStorage key that the mode toggle writes, so a user
+ *   who set Solo here never started in Solo. Rather than wire it up, the
+ *   setting and its Settings → Collaboration radiogroup were deleted:
+ *   persisting the toggle already expresses the same intent, and two sources
+ *   for one preference can only disagree. The field is deleted on read and
+ *   listed in REMOVED_FIELDS so it cannot resurrect via forward-compat.
  */
-export const CURRENT_SCHEMA_VERSION = 19;
+export const CURRENT_SCHEMA_VERSION = 20;
 
 /**
  * Validate + clamp every known field on a parsed settings blob.
@@ -597,10 +602,6 @@ function normalizeKnownFields(parsed: Record<string, unknown>): TandemSettings {
       parsed.density === "compact" || parsed.density === "cozy" || parsed.density === "spacious"
         ? parsed.density
         : DEFAULTS.density,
-    defaultMode:
-      parsed.defaultMode === "solo" || parsed.defaultMode === "tandem"
-        ? parsed.defaultMode
-        : DEFAULTS.defaultMode,
     highContrast: parsed.highContrast === true,
     annotationPatterns: parsed.annotationPatterns === true,
     selectionToolbar: parsed.selectionToolbar === false ? false : DEFAULTS.selectionToolbar,
@@ -858,6 +859,19 @@ export function loadSettings(): TandemSettings {
         // normalizeKnownFields defaults a missing value to true.
         parsed = { ...parsed, schemaVersion: 19 };
       }
+      if (parsed.schemaVersion === 19) {
+        // v19→v20: remove `defaultMode` (#1623) — a setting nothing read. There
+        // is no value to carry anywhere: the mode the user actually gets has
+        // always come from `tandem:mode`, a separate key with its own
+        // lifecycle, so a stored `"solo"` here was already inert and migrating
+        // it into that key would CHANGE behaviour rather than preserve it.
+        // The strip is belt-and-suspenders — normalizeKnownFields already drops
+        // the unknown key, and REMOVED_FIELDS blocks the forward-compat
+        // passthrough.
+        const next: Record<string, unknown> = { ...parsed, schemaVersion: 20 };
+        delete next.defaultMode;
+        parsed = next;
+      }
       // Forward-compat: an on-disk version newer than what we can migrate
       // is loaded defensively and never written back. `_readOnly: true`
       // is the contract `createTandemSettings.updateSettings` checks.
@@ -914,6 +928,7 @@ export function loadSettings(): TandemSettings {
           "showAnnotationDecorations",
           "editorWidthPercent",
           "holdAnnotationsWhileOffline",
+          "defaultMode",
         ]);
         const futureFields: Record<string, unknown> = {};
         for (const [k, v] of Object.entries(parsed)) {

--- a/tests/client/fixtures/TandemModeHarness.svelte
+++ b/tests/client/fixtures/TandemModeHarness.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+import type * as Y from "yjs";
+import { createTandemModeBroadcast } from "../../../src/client/hooks/useTandemModeBroadcast.svelte";
+import type { TandemMode } from "../../../src/shared/types";
+
+let {
+  doc,
+  synced,
+  dwellMs = 1000,
+}: {
+  /** null models the pre-bootstrap window, where `bootstrapYdoc` is still null. */
+  doc: Y.Doc | null;
+  synced: boolean;
+  dwellMs?: number;
+} = $props();
+
+// The hook owns its own Y.Map observer, so this fixture deliberately exposes no
+// way to inject a "room value". A prop would let a spec assert against a state
+// production cannot reach — the detector derives the room value FROM the map —
+// and the code would then be defending against the fixture. Specs drive remote
+// changes by applying a real Yjs update from a second doc.
+const modeState = createTandemModeBroadcast(
+  () => doc,
+  () => dwellMs,
+  () => synced,
+);
+
+export function setMode(mode: TandemMode) {
+  modeState.setTandemMode(mode);
+}
+</script>
+
+<output data-testid="mode">{modeState.tandemMode}</output>

--- a/tests/client/settings-readonly-ui.test.ts
+++ b/tests/client/settings-readonly-ui.test.ts
@@ -131,11 +131,6 @@ const CASES: ControlCase[] = [
     innerInput: true,
   },
   {
-    name: "SettingsCollaborationTab default-mode radio",
-    component: SettingsCollaborationTab,
-    testid: "settings-modal-default-mode-solo-btn",
-  },
-  {
     name: "SettingsCollaborationTab solo-rail checkbox",
     component: SettingsCollaborationTab,
     testid: "settings-modal-solo-rail-hidden-toggle",

--- a/tests/client/tandem-mode-race.test.ts
+++ b/tests/client/tandem-mode-race.test.ts
@@ -1,0 +1,540 @@
+// @vitest-environment happy-dom
+
+/**
+ * #1621 — the CTRL_ROOM mode broadcast used to race the ctrl provider's first
+ * sync, and lose silently.
+ *
+ * The broadcast wrote `Y_MAP_MODE` into a fresh, unsynced `Y.Doc`, which made it
+ * CONCURRENT with whatever the server already held for the same key. Yjs breaks
+ * a concurrent `Y.Map` tie by highest clientID, not recency, and clientIDs are
+ * random per launch — so every startup was a coin flip. The loser was silent
+ * because nothing client-side read the key back, so the toggle kept showing the
+ * mode the user picked while `tandem_status` served a dead session's value, and
+ * a connected agent held annotations for a writer waiting on comments.
+ *
+ * The tie-break specs pin BOTH clientID orderings deliberately: pinning one
+ * would be a green test over a live bug rather than a regression pin.
+ *
+ * Remote changes are driven by applying a real Yjs update from a second doc, so
+ * the value the detector reads and the value in the map cannot disagree. There
+ * is no "room value" prop on the fixture on purpose — injecting one would let a
+ * spec assert against a state production cannot reach.
+ */
+
+import { cleanup, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+import { _resetClientLog, readClientLog } from "../../src/client/utils/client-log";
+import {
+  TANDEM_MODE_DEFAULT,
+  TANDEM_MODE_KEY,
+  Y_MAP_DWELL_MS,
+  Y_MAP_MODE,
+  Y_MAP_USER_AWARENESS,
+} from "../../src/shared/constants";
+import { BROWSER_ORIGIN } from "../../src/shared/origins";
+import type { TandemMode } from "../../src/shared/types";
+import TandemModeHarness from "./fixtures/TandemModeHarness.svelte";
+
+/** A doc with a pinned clientID, so a tie has a decided winner. */
+function docWithClientId(clientID: number): Y.Doc {
+  const doc = new Y.Doc();
+  doc.clientID = clientID;
+  return doc;
+}
+
+/**
+ * Stands in for the Hocuspocus provider as a transaction origin.
+ *
+ * Load-bearing, not decoration. Production applies wire updates as
+ * `Y.applyUpdate(doc, update, provider)` — a NON-NULL origin. A bare
+ * `Y.applyUpdate(to, update)` leaves `transaction.origin === null`, and review
+ * found the gap that opens: swapping the detector's `transaction.local` check
+ * for `transaction.origin !== null` left every spec green while, in production,
+ * skipping every wire update so the detector could never fire once. Passing a
+ * sentinel here makes that mutant red.
+ */
+const REMOTE_ORIGIN = { provider: "test-hocuspocus" };
+
+function sync(from: Y.Doc, to: Y.Doc): void {
+  Y.applyUpdate(to, Y.encodeStateAsUpdate(from), REMOTE_ORIGIN);
+}
+
+function modeOf(doc: Y.Doc): unknown {
+  return doc.getMap(Y_MAP_USER_AWARENESS).get(Y_MAP_MODE);
+}
+
+function setServerMode(doc: Y.Doc, mode: TandemMode): void {
+  doc.getMap(Y_MAP_USER_AWARENESS).set(Y_MAP_MODE, mode);
+}
+
+/**
+ * The DISTINCT `tandem-mode` events in the diagnostics buffer, not one entry
+ * per fire. `readClientLog` coalesces repeats into a single entry carrying a
+ * `count`, so this can never show the same event twice — a spec that needs to
+ * see a second fire must assert on that `count` instead.
+ */
+function distinctModeWarnings(): readonly string[] {
+  return readClientLog()
+    .filter((e) => e.scope === "tandem-mode")
+    .map((e) => e.event);
+}
+
+/**
+ * A second writer overwrites the key after this client's broadcast landed. Goes
+ * through a real merge rather than a direct `set` on the client doc, so the
+ * observer sees `transaction.local === false` exactly as it would on the wire.
+ */
+function landRemoteWrite(client: Y.Doc, mode: TandemMode): void {
+  const other = docWithClientId(DEAD_SESSION_CLIENT_ID);
+  sync(client, other);
+  setServerMode(other, mode);
+  sync(other, client);
+}
+
+/**
+ * A genuinely CONCURRENT competing write: `other` is built from the client's
+ * state BEFORE the client writes, so neither item has seen the other and Yjs
+ * must break the tie by clientID.
+ *
+ * `landRemoteWrite` above is the clean case — it syncs first, so the competitor
+ * is causally after us and simply wins. This is the #1621 shape itself, where
+ * this client can LOSE, and the detector has to report from the losing side.
+ */
+function landConcurrentWrite(client: Y.Doc, before: Uint8Array, mode: TandemMode): void {
+  const other = docWithClientId(DEAD_SESSION_CLIENT_ID);
+  Y.applyUpdate(other, before);
+  setServerMode(other, mode);
+  sync(other, client);
+}
+
+/**
+ * The server's incumbent value, written by a since-dead session. In the live
+ * instance that surfaced this there were competing writes to the one key from
+ * 20+ distinct clientIDs, nearly all at clock 0 — one per app launch.
+ */
+const DEAD_SESSION_CLIENT_ID = 2_587_528_963;
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  localStorage.clear();
+  _resetClientLog();
+  // `logClientWarning` also writes to the console by design; silence it so a
+  // deliberate warn in a passing spec does not read as a failure.
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  fetchSpy = vi.fn(async () => new Response("{}", { status: 200 }));
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  _resetClientLog();
+  localStorage.clear();
+});
+
+describe("#1621 mode broadcast vs. the ctrl provider's first sync", () => {
+  // The same scenario with the client's clientID moved to either side of the
+  // incumbent's. Both must pass: the fix works by making the write causally
+  // ordered rather than concurrent, which wins regardless of clientID, so an
+  // implementation that merely got lucky fails one of them.
+  for (const [label, clientID] of [
+    ["lower than the incumbent's", DEAD_SESSION_CLIENT_ID - 1_000_000],
+    ["higher than the incumbent's", DEAD_SESSION_CLIENT_ID + 1_000_000],
+  ] as const) {
+    it(`wins the merge when this client's clientID is ${label}`, async () => {
+      const server = docWithClientId(DEAD_SESSION_CLIENT_ID);
+      setServerMode(server, "solo");
+
+      localStorage.setItem(TANDEM_MODE_KEY, "tandem");
+      const client = docWithClientId(clientID);
+
+      // Mount BEFORE sync, exactly as the provider does: `bootstrapYdoc` is
+      // assigned at construction, so consumers see the doc while it is still
+      // empty and unsynced.
+      const view = render(TandemModeHarness, { props: { doc: client, synced: false } });
+      await waitFor(() => expect(view.getByTestId("mode").textContent).toBe("tandem"));
+      expect(modeOf(client)).toBeUndefined();
+
+      // The provider syncs, then reports it.
+      sync(server, client);
+      await view.rerender({ doc: client, synced: true });
+      await waitFor(() => expect(modeOf(client)).toBe("tandem"));
+
+      sync(client, server);
+      expect(modeOf(server)).toBe("tandem");
+      expect(view.getByTestId("mode").textContent).toBe("tandem");
+    });
+  }
+
+  it("writes nothing into the ctrl doc before the provider reports sync", async () => {
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const client = new Y.Doc();
+    render(TandemModeHarness, { props: { doc: client, synced: false, dwellMs: 250 } });
+
+    // Deliberately asserts the dwell key too: it is broadcast by a sibling
+    // effect with the identical race, and fixing only the loud one leaves a
+    // second concurrent write on the same map.
+    await waitFor(() => expect(modeOf(client)).toBeUndefined());
+    expect(client.getMap(Y_MAP_USER_AWARENESS).get(Y_MAP_DWELL_MS)).toBeUndefined();
+  });
+
+  it("never broadcasts while the provider never syncs (offline start)", async () => {
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const client = new Y.Doc();
+    const view = render(TandemModeHarness, { props: { doc: client, synced: false } });
+    await view.rerender({ doc: client, synced: false, dwellMs: 500 });
+
+    // The key stays absent rather than wrong. An absent key reads as
+    // `indeterminate` server-side and `reportedMode` falls back to the default,
+    // which is strictly better than the coin-flip loss this replaces.
+    await waitFor(() => expect(view.getByTestId("mode").textContent).toBe("solo"));
+    expect(modeOf(client)).toBeUndefined();
+  });
+});
+
+describe("#1621 reading the key back", () => {
+  it("reports a disagreement in BOTH directions without adopting either", async () => {
+    // The "does NOT adopt" property, pinned symmetrically. Asserting only the
+    // room-holds-tandem direction leaves an adopt-when-solo mutant green — and
+    // that is the worse direction, because it drags the window INTO Solo and the
+    // persist effect writes it to localStorage, so it outlives the session.
+    //
+    // The absent POST is the other half: `setTandemMode` fires
+    // `triggerSoloRelease` on Solo→Tandem, so an adopt routed through the
+    // public setter would release held annotations as a side effect of a merge.
+    for (const [local, remote, event] of [
+      ["tandem", "solo", "room-holds-solo-not-ours"],
+      ["solo", "tandem", "room-holds-tandem-not-ours"],
+    ] as const) {
+      _resetClientLog();
+      localStorage.setItem(TANDEM_MODE_KEY, local);
+      const client = new Y.Doc();
+      const view = render(TandemModeHarness, { props: { doc: client, synced: true } });
+      await waitFor(() => expect(modeOf(client)).toBe(local));
+
+      landRemoteWrite(client, remote);
+      await waitFor(() => expect(distinctModeWarnings()).toEqual([event]));
+
+      expect(view.getByTestId("mode").textContent).toBe(local);
+      expect(localStorage.getItem(TANDEM_MODE_KEY)).toBe(local);
+      expect(modeOf(client)).toBe(remote);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      cleanup();
+    }
+  });
+
+  it("does NOT report this client's own broadcast", async () => {
+    // The `transaction.local` gate. Our own `awareness.set` re-enters the
+    // observer synchronously inside the broadcast effect's transaction, so
+    // without it every toggle would file a disagreement against itself.
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const client = new Y.Doc();
+    const view = render<typeof TandemModeHarness>(TandemModeHarness, {
+      props: { doc: client, synced: true },
+    });
+    await waitFor(() => expect(modeOf(client)).toBe("solo"));
+
+    for (const mode of ["tandem", "solo", "tandem"] as const) {
+      view.component.setMode(mode);
+      await waitFor(() => expect(modeOf(client)).toBe(mode));
+    }
+    expect(distinctModeWarnings()).toEqual([]);
+  });
+
+  it("does NOT report the room's value on first sync, ahead of its own broadcast", async () => {
+    // On first sync the map legitimately holds the previous session's persisted
+    // mode — `restoreCtrlDoc` re-applies the whole CTRL doc — so comparing
+    // before this client has written would warn on every single launch and train
+    // everyone to ignore the signal.
+    const server = docWithClientId(DEAD_SESSION_CLIENT_ID);
+    setServerMode(server, "solo");
+    localStorage.setItem(TANDEM_MODE_KEY, "tandem");
+
+    const client = new Y.Doc();
+    const view = render(TandemModeHarness, { props: { doc: client, synced: false } });
+    await waitFor(() => expect(view.getByTestId("mode").textContent).toBe("tandem"));
+
+    sync(server, client);
+    await view.rerender({ doc: client, synced: true });
+    await waitFor(() => expect(modeOf(client)).toBe("tandem"));
+    expect(distinctModeWarnings()).toEqual([]);
+  });
+
+  it("does NOT report a pre-rebuild value after a reconnect", async () => {
+    // The generation gate replaces the ctrl Y.Doc and resets
+    // `ctrlInitialSyncComplete`. A `lastBroadcast` left standing from the
+    // previous generation would compare the new room's restored value against a
+    // write that never happened on this doc — the same false positive as first
+    // sync, on reconnect only, which no first-launch spec can see.
+    localStorage.setItem(TANDEM_MODE_KEY, "tandem");
+    const first = new Y.Doc();
+    const view = render(TandemModeHarness, { props: { doc: first, synced: true } });
+    await waitFor(() => expect(modeOf(first)).toBe("tandem"));
+
+    const server = docWithClientId(DEAD_SESSION_CLIENT_ID);
+    setServerMode(server, "solo");
+    const rebuilt = new Y.Doc();
+    await view.rerender({ doc: rebuilt, synced: false });
+    sync(server, rebuilt);
+    await view.rerender({ doc: rebuilt, synced: true });
+
+    await waitFor(() => expect(modeOf(rebuilt)).toBe("tandem"));
+    expect(distinctModeWarnings()).toEqual([]);
+  });
+
+  it("stays silent when the server echoes this client's own Solo release", async () => {
+    // The product's most common remote-mode write, and it must NOT be reported.
+    // `setTandemMode` fires `triggerSoloRelease` on Solo→Tandem, and
+    // `/api/mode/release` answers by writing "tandem" into the ctrl doc — a
+    // NON-LOCAL transaction that lands right back in this observer. It is silent
+    // only because the broadcast effect refreshes `lastBroadcast` on every
+    // toggle; a one-character `lastBroadcast ??= mode` freezes it at the mount
+    // value and files a disagreement against the server echoing the user's own
+    // action, on every Solo→Tandem toggle there is.
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const client = new Y.Doc();
+    const view = render<typeof TandemModeHarness>(TandemModeHarness, {
+      props: { doc: client, synced: true },
+    });
+    await waitFor(() => expect(modeOf(client)).toBe("solo"));
+
+    view.component.setMode("tandem");
+    await waitFor(() => expect(modeOf(client)).toBe("tandem"));
+    expect(fetchSpy).toHaveBeenCalled();
+
+    landRemoteWrite(client, "tandem");
+    await waitFor(() => expect(modeOf(client)).toBe("tandem"));
+    expect(distinctModeWarnings()).toEqual([]);
+  });
+
+  it("reports from the LOSING side of a genuine concurrent tie", async () => {
+    // #1621's own shape, which every other spec here avoids: `landRemoteWrite`
+    // syncs first, so the competitor is causally after us and merely wins. Here
+    // neither writer has seen the other, so Yjs breaks the tie by clientID — and
+    // the competitor is higher, so this client loses exactly as it did on
+    // 0.24.1. The detector has to speak from the losing side.
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const client = docWithClientId(DEAD_SESSION_CLIENT_ID - 1_000_000);
+    const before = Y.encodeStateAsUpdate(client);
+    render(TandemModeHarness, { props: { doc: client, synced: true } });
+    await waitFor(() => expect(modeOf(client)).toBe("solo"));
+
+    landConcurrentWrite(client, before, "tandem");
+    await waitFor(() => expect(modeOf(client)).toBe("tandem"));
+    expect(distinctModeWarnings()).toEqual(["room-holds-tandem-not-ours"]);
+  });
+
+  it("does not re-fire on a remote write to a DIFFERENT key of the same map", async () => {
+    // `Y_MAP_DWELL_MS` lives on this very map and is broadcast four lines away
+    // from the mode. Without the `keysChanged` filter, ANY remote write to the
+    // awareness map re-runs the comparison — so once a genuine disagreement
+    // exists, a second window nudging its dwell slider re-files the same warning
+    // on every nudge and floods the buffer the user pastes into an issue.
+    //
+    // The disagreement has to be established FIRST, and the assertion has to be
+    // on `count`, not on the event list. Without a standing disagreement the
+    // value comparison short-circuits and the missing filter is invisible; and
+    // `readClientLog` coalesces duplicates into one entry, so `distinctModeWarnings()`
+    // reports the SET of events and can never see a second fire.
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const client = new Y.Doc();
+    render(TandemModeHarness, { props: { doc: client, synced: true } });
+    await waitFor(() => expect(modeOf(client)).toBe("solo"));
+
+    landRemoteWrite(client, "tandem");
+    await waitFor(() => expect(distinctModeWarnings()).toEqual(["room-holds-tandem-not-ours"]));
+    const firstCount = readClientLog().find((e) => e.scope === "tandem-mode")?.count;
+    expect(firstCount).toBe(1);
+
+    const other = docWithClientId(DEAD_SESSION_CLIENT_ID);
+    sync(client, other);
+    other.getMap(Y_MAP_USER_AWARENESS).set(Y_MAP_DWELL_MS, 2500);
+    sync(other, client);
+
+    await waitFor(() => expect(client.getMap(Y_MAP_USER_AWARENESS).get(Y_MAP_DWELL_MS)).toBe(2500));
+    expect(readClientLog().find((e) => e.scope === "tandem-mode")?.count).toBe(1);
+  });
+
+  it("stays silent rather than mislabelling an unparseable room value", async () => {
+    // The one branch where the detector chooses silence. A deleted or legacy
+    // value must not be reported as "room-holds-tandem-not-ours": the warning
+    // lands in an artifact the user pastes into a public issue, and a
+    // confidently wrong diagnostic there is worse than none.
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const client = new Y.Doc();
+    render(TandemModeHarness, { props: { doc: client, synced: true } });
+    await waitFor(() => expect(modeOf(client)).toBe("solo"));
+
+    const other = docWithClientId(DEAD_SESSION_CLIENT_ID);
+    sync(client, other);
+    other.getMap(Y_MAP_USER_AWARENESS).set(Y_MAP_MODE, "not-a-mode");
+    sync(other, client);
+
+    await waitFor(() => expect(modeOf(client)).toBe("not-a-mode"));
+    expect(distinctModeWarnings()).toEqual([]);
+  });
+
+  it("broadcasts under the browser origin, not another helper", async () => {
+    // Critical Rule 2: the helper choice IS the contract, and `audit:origins`
+    // counts tagged sites without checking WHICH helper — so swapping
+    // `withBrowser` for `withInternal` here is a silent change every other spec
+    // tolerates. Only `browser` writes generate channel events.
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const client = new Y.Doc();
+    const origins: unknown[] = [];
+    client.on("afterTransaction", (txn: Y.Transaction) => {
+      if (txn.local) origins.push(txn.origin);
+    });
+    render(TandemModeHarness, { props: { doc: client, synced: true } });
+    await waitFor(() => expect(modeOf(client)).toBe("solo"));
+
+    expect(origins.length).toBeGreaterThan(0);
+    expect(new Set(origins)).toEqual(new Set([BROWSER_ORIGIN]));
+  });
+
+  it("registers exactly one observer per ctrl doc and releases it on replace", async () => {
+    // Without this the leak is invisible to every other spec here: an unguarded
+    // `.observe()` in a value-reactive effect accumulates a listener per toggle,
+    // and a missing `.unobserve()` keeps the old doc's listener alive across the
+    // rebuild that #1621's own reconnect path performs.
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const client = new Y.Doc();
+    const awareness = client.getMap(Y_MAP_USER_AWARENESS);
+    const observeSpy = vi.spyOn(awareness, "observe");
+    const unobserveSpy = vi.spyOn(awareness, "unobserve");
+
+    const view = render<typeof TandemModeHarness>(TandemModeHarness, {
+      props: { doc: client, synced: true },
+    });
+    await waitFor(() => expect(modeOf(client)).toBe("solo"));
+
+    for (const mode of ["tandem", "solo"] as const) {
+      view.component.setMode(mode);
+      await waitFor(() => expect(modeOf(client)).toBe(mode));
+    }
+    expect(observeSpy).toHaveBeenCalledTimes(1);
+    expect(unobserveSpy).not.toHaveBeenCalled();
+
+    // `synced: false` on the swap, matching production: `startBootstrap` sets
+    // `ctrlInitialSyncComplete = false` BEFORE publishing the new doc, both
+    // synchronously, so `(a fresh doc, synced: true)` is a pairing the app never
+    // produces. The counts hold either way — the detector effect depends only on
+    // the doc — but a spec that reaches a state the app cannot is one step from
+    // a claim that only holds in the fixture.
+    await view.rerender({ doc: new Y.Doc(), synced: false });
+    await waitFor(() => expect(unobserveSpy).toHaveBeenCalledTimes(1));
+    expect(observeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not touch the ctrl map while the doc is still null", async () => {
+    // The pre-bootstrap window, and the post-`bootstrapCleanup` one: `yjsSync`
+    // publishes `bootstrapYdoc` as null before `startBootstrap` and again after
+    // `ydoc.destroy()`. Without this spec the `!bootstrapYdoc` half of the
+    // broadcast gate — and the detector's own null return — are covered by
+    // nothing: deleting either leaves every other spec in this file green.
+    //
+    // The two gates fail differently, and each half is pinned by a different
+    // observation. Deleting the BROADCAST gate reaches `.getMap()` on null and
+    // the effect's own `catch` swallows it as a console warning — so `warnSpy`
+    // staying clean is what covers it, and `lastBroadcast` is left holding the
+    // previous generation's value for the detector to compare against. The
+    // DETECTOR effect has no `catch`, so deleting its null return throws out of
+    // the effect body and fails the render itself. Both were confirmed by
+    // mutation rather than assumed.
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const view = render(TandemModeHarness, {
+      props: { doc: null, synced: true },
+    });
+    await waitFor(() => expect(view.getByTestId("mode").textContent).toBe("solo"));
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // And it starts working normally once a doc arrives, so the spec above is
+    // pinning a quiet gate rather than a permanently dead hook.
+    const client = new Y.Doc();
+    await view.rerender({ doc: client, synced: false });
+    await view.rerender({ doc: client, synced: true });
+    await waitFor(() => expect(modeOf(client)).toBe("solo"));
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("#1623 the persisted last mode is the only preference", () => {
+  // #1623 was filed as "Settings -> Collaboration `defaultMode` is stored,
+  // validated, migrated, unit-tested and read by nothing". It was resolved by
+  // DELETING the setting rather than wiring it up: the mode toggle already
+  // persists to `localStorage`, so a second source for the same preference could
+  // only ever disagree with the first. These specs pin what is left.
+  it("restores the mode the user last chose", async () => {
+    localStorage.setItem(TANDEM_MODE_KEY, "solo");
+    const client = new Y.Doc();
+    const view = render(TandemModeHarness, { props: { doc: client, synced: true } });
+    await waitFor(() => expect(view.getByTestId("mode").textContent).toBe("solo"));
+    expect(modeOf(client)).toBe("solo");
+  });
+
+  it("starts in the default mode when nothing has been chosen yet", async () => {
+    const client = new Y.Doc();
+    const view = render(TandemModeHarness, { props: { doc: client, synced: true } });
+    await waitFor(() => expect(view.getByTestId("mode").textContent).toBe(TANDEM_MODE_DEFAULT));
+  });
+
+  it("writes the user's choice back so the next launch restores it", async () => {
+    // The other half of the contract, and the half nothing else covers. Deleting
+    // the `localStorage.setItem` in the persist effect leaves every other spec in
+    // this file green — they SEED storage and never read it back — while the
+    // user's toggle silently stops sticking across launches. Since #1623 removed
+    // the Settings default-mode control, this write is the ONLY thing that
+    // carries a mode from one session to the next.
+    const client = new Y.Doc();
+    const view = render(TandemModeHarness, { props: { doc: client, synced: true } });
+    await waitFor(() => expect(modeOf(client)).toBe(TANDEM_MODE_DEFAULT));
+
+    view.component.setMode("solo");
+    await waitFor(() => expect(localStorage.getItem(TANDEM_MODE_KEY)).toBe("solo"));
+
+    view.component.setMode("tandem");
+    await waitFor(() => expect(localStorage.getItem(TANDEM_MODE_KEY)).toBe("tandem"));
+  });
+
+  it("falls back to the default when the stored value is corrupt", async () => {
+    localStorage.setItem(TANDEM_MODE_KEY, "not-a-mode");
+    const client = new Y.Doc();
+    const view = render(TandemModeHarness, { props: { doc: client, synced: true } });
+    await waitFor(() => expect(view.getByTestId("mode").textContent).toBe(TANDEM_MODE_DEFAULT));
+  });
+
+  it("falls back to the default when localStorage throws", async () => {
+    // A storage-disabled browser is a supported case here (CLAUDE.md calls it
+    // out), and the catch branch is the only path that survives it.
+    //
+    // The `warnSpy` assertion is the discriminating precondition, not decoration.
+    // Asserting only the resulting mode passes whether or not the stub throws:
+    // the no-stored-value path returns the same constant. Proving the throw
+    // happened is what makes the green mean something.
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("storage disabled");
+      },
+      setItem: () => {
+        throw new Error("storage disabled");
+      },
+      removeItem: () => {},
+      clear: () => {},
+    });
+
+    const client = new Y.Doc();
+    const view = render(TandemModeHarness, { props: { doc: client, synced: true } });
+    await waitFor(() => expect(view.getByTestId("mode").textContent).toBe(TANDEM_MODE_DEFAULT));
+
+    expect(
+      warnSpy.mock.calls.some((c: unknown[]) =>
+        String(c[0]).includes("localStorage unavailable reading"),
+      ),
+    ).toBe(true);
+    expect(modeOf(client)).toBe(TANDEM_MODE_DEFAULT);
+  });
+});

--- a/tests/client/tandem-mode-wiring.test.ts
+++ b/tests/client/tandem-mode-wiring.test.ts
@@ -1,0 +1,190 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { filesMentioning, stripComments } from "../helpers/src-tree.js";
+
+/**
+ * How `App.svelte` wires `createTandemModeBroadcast` (#1621).
+ *
+ * ## Why a source-level check, when the parameter is already required
+ *
+ * Making `getCtrlSynced` required turns an OMITTED argument into a compile
+ * error. It does nothing about a WRONG one, and the wrong one is the regression
+ * review actually constructed:
+ *
+ * ```js
+ * const ctrlSynced = yjsSync.ctrlInitialSyncComplete;   // no $derived
+ * createTandemModeBroadcast(…, () => ctrlSynced, …);
+ * ```
+ *
+ * That is a getter, it typechecks, `svelte-check` is clean, and every spec in
+ * `tandem-mode-race.test.ts` stays green — because they drive the hook through a
+ * fixture that supplies its own props and never touches this call
+ * site. In the running app the getter is frozen at `false` forever: the mode is
+ * never broadcast at all, `readModeState()` returns `indeterminate`,
+ * `reportedMode` collapses that to `"tandem"`, and a user sitting in Solo has
+ * their annotations shipped to Claude. #1621 turned from a coin flip into a
+ * certainty, silently.
+ *
+ * The diff *invites* it, which is why this file exists rather than a comment:
+ * the `const selectionDwellMs = $derived(...)` line immediately above
+ * establishes the "narrow through a memo" idiom, and the next person applying it
+ * to `ctrlInitialSyncComplete` without the `$derived` wrapper writes exactly the
+ * shape above. Precedent for the instrument: `app-action-mount-contract.test.ts`,
+ * which pins a composition fact for the same reason — losing it is silent.
+ *
+ * ## The controls are the load-bearing half
+ *
+ * A contract check that cannot fail is not a check. The matcher is extracted and
+ * run over synthetic sources — the snapshot regression, a dropped argument, a
+ * reordered pair, and a `$state` in place of `$derived` — plus the positive
+ * control of the real shape. Without them this file would be green against a
+ * matcher that returned `true` unconditionally.
+ *
+ * The fourth argument this file used to pin, `() => defaultMode`, is gone: #1623
+ * was resolved by deleting the Settings default-mode control rather than wiring
+ * it up, so the persisted last mode is now the only source of the startup mode.
+ */
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const APP = join(ROOT, "src", "client", "App.svelte");
+const HOOK = "src/client/hooks/useTandemModeBroadcast.svelte.ts";
+
+/**
+ * The argument list of the single `createTandemModeBroadcast(` call, split on
+ * top-level commas only.
+ *
+ * Paren-depth aware rather than `split(",")`: an argument like
+ * `() => foo(a, b)` contains a comma that is not an argument separator, and a
+ * naive split would silently produce a longer list whose entries then fail to
+ * match for the wrong reason.
+ */
+function modeBroadcastArgs(src: string): string[] | null {
+  const code = stripComments(src);
+  const open = code.indexOf("createTandemModeBroadcast(");
+  if (open === -1) return null;
+  let i = open + "createTandemModeBroadcast(".length;
+  let depth = 1;
+  const args: string[] = [];
+  let current = "";
+  for (; i < code.length && depth > 0; i++) {
+    const ch = code[i];
+    if (ch === "(" || ch === "[" || ch === "{") depth++;
+    else if (ch === ")" || ch === "]" || ch === "}") depth--;
+    if (depth === 0) break;
+    if (ch === "," && depth === 1) {
+      args.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (depth !== 0) return null;
+  if (current.trim().length > 0) args.push(current.trim());
+  return args;
+}
+
+/**
+ * True when the wiring is live in every position that can silently revert a fix.
+ *
+ * Each getter body must be the reactive read ITSELF, not an identifier standing
+ * in for one — except the `$derived` memo, which is matched by name and then
+ * required to be declared as `$derived` of the settings field. Matching
+ * `() => selectionDwellMs` without that second half would accept the snapshot
+ * bug in the position where the idiom makes it most likely.
+ */
+function wiringIsLive(src: string): boolean {
+  const args = modeBroadcastArgs(src);
+  if (args === null || args.length !== 3) return false;
+  const norm = (s: string) => s.replace(/\s+/g, " ").trim();
+  if (norm(args[0]) !== "() => yjsSync.bootstrapYdoc") return false;
+  if (norm(args[1]) !== "() => selectionDwellMs") return false;
+  if (norm(args[2]) !== "() => yjsSync.ctrlInitialSyncComplete") return false;
+  const code = norm(stripComments(src));
+  return code.includes(
+    "const selectionDwellMs = $derived(settingsState.settings.selectionDwellMs)",
+  );
+}
+
+const REAL_APP = readFileSync(APP, "utf8");
+
+/** The real call, reduced to just the fragment the controls vary. */
+const GOOD = `
+const selectionDwellMs = $derived(settingsState.settings.selectionDwellMs);
+const modeState = createTandemModeBroadcast(
+  () => yjsSync.bootstrapYdoc,
+  () => selectionDwellMs,
+  () => yjsSync.ctrlInitialSyncComplete,
+);
+`;
+
+describe("App.svelte wires the mode broadcast to live reactive reads", () => {
+  it("matches the real App.svelte", () => {
+    expect(wiringIsLive(REAL_APP)).toBe(true);
+  });
+
+  it("has exactly one call site in all of src/", () => {
+    // A second construction — a new window model, a Tauri path, a test double
+    // promoted into src — would not be covered by the matcher above, which reads
+    // App.svelte only. This is the sweep that notices one arriving.
+    expect(filesMentioning("createTandemModeBroadcast")).toEqual(["src/client/App.svelte", HOOK]);
+  });
+
+  describe("controls — each of these must be rejected", () => {
+    it("accepts the good shape (positive control)", () => {
+      expect(wiringIsLive(GOOD)).toBe(true);
+    });
+
+    it("rejects a const snapshot in place of the live sync read", () => {
+      const bad = GOOD.replace(
+        "() => yjsSync.ctrlInitialSyncComplete,",
+        "() => ctrlSyncedSnapshot,",
+      );
+      expect(wiringIsLive(bad)).toBe(false);
+    });
+
+    it("rejects a dropped argument", () => {
+      expect(wiringIsLive(GOOD.replace("  () => yjsSync.ctrlInitialSyncComplete,\n", ""))).toBe(
+        false,
+      );
+    });
+
+    it("rejects the dwell and sync getters being swapped", () => {
+      const bad = GOOD.replace(
+        "  () => selectionDwellMs,\n  () => yjsSync.ctrlInitialSyncComplete,\n",
+        "  () => yjsSync.ctrlInitialSyncComplete,\n  () => selectionDwellMs,\n",
+      );
+      expect(wiringIsLive(bad)).toBe(false);
+    });
+
+    it("rejects $state where $derived is required, which does not re-read settings", () => {
+      const bad = GOOD.replace(
+        "const selectionDwellMs = $derived(settingsState.settings.selectionDwellMs);",
+        "const selectionDwellMs = $state(settingsState.settings.selectionDwellMs);",
+      );
+      expect(wiringIsLive(bad)).toBe(false);
+    });
+
+    it("rejects a source with no call at all", () => {
+      expect(wiringIsLive("const x = 1;\n")).toBe(false);
+    });
+
+    it("does not read the call out of a comment", () => {
+      const bad = `// ${GOOD.replace(/\n/g, " ")}\nconst x = 1;\n`;
+      expect(wiringIsLive(bad)).toBe(false);
+    });
+  });
+
+  describe("the argument splitter", () => {
+    it("does not split inside a nested call", () => {
+      const src = "createTandemModeBroadcast(() => f(a, b), () => c);";
+      expect(modeBroadcastArgs(src)).toEqual(["() => f(a, b)", "() => c"]);
+    });
+
+    it("returns null on an unbalanced call rather than a short list", () => {
+      // Fails closed: a truncated read must not look like "fewer arguments",
+      // which the matcher would report as a wiring regression at the wrong site.
+      expect(modeBroadcastArgs("createTandemModeBroadcast(() => a,")).toBeNull();
+    });
+  });
+});

--- a/tests/client/use-tandem-settings-migration.test.ts
+++ b/tests/client/use-tandem-settings-migration.test.ts
@@ -417,6 +417,36 @@ describe("loadSettings — migration chain", () => {
     expect(raw(s).holdAnnotationsWhileOffline).toBeUndefined();
   });
 
+  // v19→v20: drop `defaultMode` (#1623), a setting read by nothing. The mode
+  // the user actually gets has always come from the separate `tandem:mode` key,
+  // so there is nothing to carry forward — only a dead field to strip.
+  it("v19→v20: strips defaultMode", () => {
+    writeRaw({ schemaVersion: 19, defaultMode: "solo", theme: "dark" });
+    const s = loadSettings();
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(raw(s).defaultMode).toBeUndefined();
+    expect(s.theme).toBe("dark");
+  });
+
+  it("a full v2→current migration also strips defaultMode", () => {
+    writeRaw({ schemaVersion: 2, defaultMode: "solo" });
+    const s = loadSettings();
+    expect(s.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(raw(s).defaultMode).toBeUndefined();
+  });
+
+  it("forward-compat strips defaultMode via REMOVED_FIELDS", () => {
+    // The half the version bump alone does not cover: a blob written by a
+    // FUTURE client takes the `> CURRENT_SCHEMA_VERSION` branch, skipping every
+    // migration step, and its unknown keys pass through verbatim. Without the
+    // REMOVED_FIELDS entry the retired name would ride back onto the settings
+    // object and pin a contract this removal intends to retire.
+    writeRaw({ schemaVersion: 99, defaultMode: "solo" });
+    const s = loadSettings();
+    expect(s._readOnly).toBe(true);
+    expect(raw(s).defaultMode).toBeUndefined();
+  });
+
   it("v1 blob with showIntegrationWizard migrates fully stripping it", () => {
     writeRaw({
       schemaVersion: 1,
@@ -755,7 +785,6 @@ describe("loadSettings — migration chain", () => {
       editorFont: "serif" as const,
       fontByExtension: { md: "mono" },
       density: "spacious" as const,
-      defaultMode: "solo" as const,
       highContrast: true,
       annotationPatterns: true,
       selectionToolbar: false,
@@ -788,7 +817,6 @@ describe("loadSettings — migration chain", () => {
     expect(s.editorFont).toBe("serif");
     expect(s.fontByExtension).toEqual({ md: "mono" });
     expect(s.density).toBe("spacious");
-    expect(s.defaultMode).toBe("solo");
     expect(s.highContrast).toBe(true);
     expect(s.annotationPatterns).toBe(true);
     expect(s.selectionToolbar).toBe(false);

--- a/tests/client/useTandemSettings.test.ts
+++ b/tests/client/useTandemSettings.test.ts
@@ -321,7 +321,6 @@ describe("useTandemSettings — updateSettings write path", () => {
     fontByExtension: {},
     defaultSaveDirectory: null,
     density: "cozy",
-    defaultMode: "tandem",
     highContrast: false,
     annotationPatterns: false,
     selectionToolbar: true,
@@ -553,16 +552,6 @@ describe("loadSettings — new fields (PR 2: Schema Foundations)", () => {
   it("falls back to 'cozy' for unknown density", () => {
     writeRawSettings({ density: "ultra-tight" });
     expect(loadSettings().density).toBe("cozy");
-  });
-
-  it.each(["solo", "tandem"] as const)("accepts defaultMode '%s'", (mode) => {
-    writeRawSettings({ defaultMode: mode });
-    expect(loadSettings().defaultMode).toBe(mode);
-  });
-
-  it("falls back to 'tandem' for unknown defaultMode", () => {
-    writeRawSettings({ defaultMode: "pair" });
-    expect(loadSettings().defaultMode).toBe("tandem");
   });
 
   it("accepts highContrast: true", () => {

--- a/tests/design-system-impl/__snapshots__/testid-set.snap.txt
+++ b/tests/design-system-impl/__snapshots__/testid-set.snap.txt
@@ -391,8 +391,6 @@ settings-modal-connect-ai-callout
 settings-modal-content
 settings-modal-copy-diagnostics-btn
 settings-modal-cowork-suspense-fallback
-settings-modal-default-mode-solo-btn
-settings-modal-default-mode-tandem-btn
 settings-modal-display-name
 settings-modal-dwell-time-slider
 settings-modal-margin-view-hint

--- a/tests/e2e/settings-and-filters.spec.ts
+++ b/tests/e2e/settings-and-filters.spec.ts
@@ -128,38 +128,6 @@ test("editor-measure presets thread through to the stage's --editor-measure CSS 
   }
 });
 
-test("settings dialog surfaces default mode and persists it", async ({ page }) => {
-  await mcp.callTool("tandem_open", { filePath: path.join(tmpDir, "sample.md") });
-
-  await page.goto("/");
-  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
-
-  await openSettingsViaBrandMenu(page);
-  const modal = page.locator("[data-testid='settings-modal']");
-  await expect(modal).toBeVisible({ timeout: 2_000 });
-
-  await page.locator("[data-testid='settings-modal-tab-collaboration']").click();
-  const soloDefault = modal.locator("[data-testid='settings-modal-default-mode-solo-btn']");
-  await expect(soloDefault).toBeVisible();
-  await soloDefault.click();
-  await expect(soloDefault).toHaveAttribute("aria-checked", "true");
-
-  const savedDefaultMode = await page.evaluate((key) => {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as { defaultMode?: string }).defaultMode : null;
-  }, TANDEM_SETTINGS_KEY);
-  expect(savedDefaultMode).toBe("solo");
-
-  await page.reload();
-  await expect(page.locator(".tandem-editor")).toBeVisible({ timeout: 10_000 });
-  await openSettingsViaBrandMenu(page);
-  const reloadedModal = page.locator("[data-testid='settings-modal']");
-  await reloadedModal.locator("[data-testid='settings-modal-tab-collaboration']").click();
-  await expect(
-    reloadedModal.locator("[data-testid='settings-modal-default-mode-solo-btn']"),
-  ).toHaveAttribute("aria-checked", "true");
-});
-
 test("settings dialog sections and About panel reflect the redesign closeout", async ({ page }) => {
   await page.route("**/api/info", async (route) => {
     // The client bootstraps its collaboration layer from this route too: it

--- a/tests/e2e/settings-modal.spec.ts
+++ b/tests/e2e/settings-modal.spec.ts
@@ -108,7 +108,7 @@ test("tab switching shows tab-specific content", async ({ page }) => {
   await page.locator("[data-testid='settings-modal-tab-collaboration']").click();
   await expect(page.locator("[data-testid='settings-modal-display-name']")).toBeVisible();
   await expect(
-    page.locator("[data-testid='settings-modal-default-mode-tandem-btn']"),
+    page.locator("[data-testid='settings-modal-solo-rail-hidden-toggle']"),
   ).toBeVisible();
 
   // Shortcuts tab.

--- a/tests/shared/mode-writer-set.test.ts
+++ b/tests/shared/mode-writer-set.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { filesMentioning, SRC_FILES, stripComments } from "../helpers/src-tree.js";
+
+/**
+ * #1621: who is allowed to write `Y_MAP_MODE`, pinned — and how many times.
+ *
+ * ## Why a writer-set pin and not a runtime guard
+ *
+ * The mode lives in a SINGLETON key of a shared `Y.Map`. That shape is safe only
+ * when it has exactly one writer, or is rewritten often enough that a lost tie
+ * self-heals before anyone acts on it. `Y_MAP_MODE` has neither property: it is
+ * multi-writer AND written once per session, then read for minutes. When two
+ * writes are concurrent, Yjs breaks the tie by highest clientID — not recency —
+ * and the loser gets no signal at all. That is #1621, and it survived a shipped
+ * release precisely because nothing anywhere said "this key has two writers."
+ *
+ * The client-side detector in `useTandemModeBroadcast.svelte.ts` reports a
+ * disagreement AFTER it happens, into the diagnostics buffer. This is the other
+ * half, and the cheaper one: it fires when a THIRD writer is added, which is the
+ * last point at which anyone can still reason about the tie for free. It needs
+ * no human to remember a step, which is this project's bar for a safeguard being
+ * structural.
+ *
+ * Adding a writer is not forbidden. It requires deciding, in review, how its
+ * write orders against the others — and then editing these lists.
+ *
+ * ## Occurrences, not just files
+ *
+ * The counts are the point, and a file-set assertion was the first version's
+ * hole. A SECOND `.set(Y_MAP_MODE, …)` added inside a file already on the list
+ * leaves a file-set check green — so the guard could not see #1621 being
+ * reintroduced inside the very file it names as the fixed writer. Counting
+ * occurrences per file is what closes that.
+ *
+ * ## Why the mention set is pinned too, and what it does NOT cover
+ *
+ * A shape scan for `.set(Y_MAP_MODE` is beaten by any indirection: a local alias
+ * for the key, a generic `setCtrlKey(k, v)` helper, a computed member access. So
+ * the shape scan is the precise half and the mention set is the wide half — a
+ * new module touching the constant at all fails this file even when its write is
+ * unrecognisable to the regex.
+ *
+ * But the mention set is a FILE ALLOWLIST, so it cannot see a write appearing in
+ * a file already on it — and `src/server/mode.ts`, which already owns
+ * `readModeState`/`reportedMode` and holds the ctrl doc, is exactly where someone
+ * would naturally add a `setMode()`. The third describe closes that: files on the
+ * mention list that are not expected writers must contain no write shape against
+ * the awareness map at all.
+ *
+ * Three things still outside all of it, named so nobody reads this as complete:
+ *
+ * 1. **`restoreCtrlDoc` is a de-facto materializer.** `persistCtrlSnapshot`
+ *    encodes the whole ctrl doc, `Y_MAP_USER_AWARENESS` included, and restore
+ *    blind-`applyUpdate`s it back — which is how a dead session's mode reaches a
+ *    fresh ctrl doc across a restart. It never mentions the constant, so both
+ *    scans miss it structurally. Causally it replays the original writes rather
+ *    than issuing a new one, so "two writers" stays true; but what the snapshot
+ *    carries decides what the key holds at bootstrap, and changing that fires
+ *    nothing here.
+ * 2. **Scope is `src/` only.** `SRC_FILES` walks `src/` and nothing else, so a
+ *    writer in `scripts/`, `infra/` or `src-tauri/` is invisible.
+ * 3. **A raw string key** (`awareness.set("mode", …)`) escapes both scans. That
+ *    is a Critical Rule 1 violation, and its complement is
+ *    `scripts/audit-ymap-keys.ts` — which is a package.json script with **no CI
+ *    step and no wiring test**, so do not read it as a gate that covers this.
+ */
+
+/** Files whose code (not comments) writes the key, and how many times each. */
+const EXPECTED_MODE_WRITES: Array<[string, number]> = [
+  // The user's toggle. Gated on the ctrl provider's first sync so the write is
+  // causally ordered rather than concurrent — that gate is #1621's fix.
+  ["src/client/hooks/useTandemModeBroadcast.svelte.ts", 1],
+  // The Solo-to-Tandem release, server-side and UNCONDITIONAL: any client's flip
+  // writes "tandem" for everyone. This is the writer that makes adoption unsafe
+  // on the client — see the both-directions spec in tandem-mode-race.test.ts.
+  ["src/server/mcp/routes/mode-release.ts", 1],
+];
+
+/** Every file mentioning the constant, writers and readers alike. */
+const EXPECTED_MENTIONS = [
+  "src/client/hooks/useTandemModeBroadcast.svelte.ts",
+  // `tandem_status` — what Claude is told the mode is.
+  "src/server/mcp/document.ts",
+  "src/server/mcp/routes/mode-release.ts",
+  // `readModeState` / `reportedMode` — the hide predicate for held annotations.
+  "src/server/mode.ts",
+  // The declaration itself.
+  "src/shared/constants.ts",
+] as const;
+
+/**
+ * `Y_MAP_DWELL_MS` has the identical shape — singleton key, shared map, written
+ * once per session from per-client settings — and today has exactly one writer.
+ * Pinned now, while the answer is still "one", rather than after the second
+ * arrives. It deliberately has no runtime detector; the reasoning is in the
+ * dwell effect's own comment.
+ */
+const EXPECTED_DWELL_WRITES: Array<[string, number]> = [
+  ["src/client/hooks/useTandemModeBroadcast.svelte.ts", 1],
+];
+
+function writeShape(constantName: string): RegExp {
+  return new RegExp(`\\.set\\(\\s*${constantName}\\b`, "g");
+}
+
+/** `[file, occurrences]` for every file whose code matches, sorted by file. */
+function writeCounts(constantName: string): Array<[string, number]> {
+  const out: Array<[string, number]> = [];
+  for (const [rel, contents] of SRC_FILES) {
+    const hits = stripComments(contents).match(writeShape(constantName));
+    if (hits) out.push([rel, hits.length]);
+  }
+  return out.sort(([a], [b]) => a.localeCompare(b));
+}
+
+describe("Y_MAP_MODE writer set (#1621)", () => {
+  it("has exactly the writes this project has reasoned about", () => {
+    expect(writeCounts("Y_MAP_MODE")).toEqual(EXPECTED_MODE_WRITES);
+  });
+
+  it("is mentioned only where this project expects", () => {
+    expect(filesMentioning("Y_MAP_MODE")).toEqual([...EXPECTED_MENTIONS].sort());
+  });
+
+  it("keeps every mention-only file free of awareness-map writes", () => {
+    // The hole a file allowlist cannot see: a third writer landing inside a file
+    // already on the mention list passes both scans above. `src/server/mode.ts`
+    // is the natural home for a `setMode()` and is already listed.
+    const writers = new Set(EXPECTED_MODE_WRITES.map(([f]) => f));
+    const readOnly = EXPECTED_MENTIONS.filter((f) => !writers.has(f));
+    expect(readOnly.length).toBeGreaterThan(0);
+    for (const rel of readOnly) {
+      const code = stripComments(SRC_FILES.get(rel) ?? "");
+      expect(code, `${rel} is a reader; it must not write the awareness map`).not.toMatch(
+        /Y_MAP_USER_AWARENESS\s*\)?\s*\.set\(|\.set\(\s*Y_MAP_(MODE|DWELL_MS)\b/,
+      );
+    }
+  });
+
+  it("would notice if the constant were renamed out from under it", () => {
+    // The floor. Renaming `Y_MAP_MODE` leaves both scans matching nothing, and
+    // empty-equals-empty passes — the zero-of-zero failure this codebase has hit
+    // before. A positive anchor is what makes the greens above mean something.
+    expect(filesMentioning("Y_MAP_MODE").length).toBeGreaterThan(0);
+    expect(writeCounts("Y_MAP_MODE").length).toBeGreaterThan(0);
+    expect(SRC_FILES.get("src/shared/constants.ts")).toContain('Y_MAP_MODE = "mode"');
+  });
+
+  it("counts a write only in code, never in prose about one", () => {
+    // `stripComments` is doing real work: this file's own doc comment contains
+    // the literal `.set(Y_MAP_MODE`, and so does the hook's. A scan that read
+    // comments would report writers that do not exist and mask a real one.
+    const commented = "// awareness.set(Y_MAP_MODE, mode)\nconst x = 1;\n";
+    expect(stripComments(commented).match(writeShape("Y_MAP_MODE"))).toBeNull();
+    expect(commented.match(writeShape("Y_MAP_MODE"))).not.toBeNull();
+  });
+});
+
+describe("Y_MAP_DWELL_MS writer set (#1621, same shape)", () => {
+  it("still has exactly one writer", () => {
+    expect(writeCounts("Y_MAP_DWELL_MS")).toEqual(EXPECTED_DWELL_WRITES);
+  });
+
+  it("would notice a rename", () => {
+    expect(writeCounts("Y_MAP_DWELL_MS").length).toBeGreaterThan(0);
+    expect(SRC_FILES.get("src/shared/constants.ts")).toContain("Y_MAP_DWELL_MS");
+  });
+});


### PR DESCRIPTION
## The bug

`createTandemModeBroadcast`'s effect wrote `Y_MAP_MODE` into the ctrl `Y.Doc` the moment `bootstrapYdoc` went non-null — which `startBootstrap` does at provider construction, before the provider has synced. The write was therefore **concurrent** with whatever the server already held, and Yjs breaks a concurrent `Y.Map` tie by **highest clientID, not recency**. clientIDs are random per launch, so it was a coin flip every startup, and the odds worsen over a server's life: the surviving incumbent's clientID is monotonically non-decreasing, so P(a fresh client wins) only falls.

It was silent because nothing client-side ever read the key back. The consequence is behavioural — the MCP instruction block tells the agent to hold annotations in Solo, so a user sitting in Tandem waits for margin comments that never arrive, invisibly from both sides. Observed on 0.24.1: `tandem_status` returned `solo` for minutes while the editor toggle read Tandem.

`Y_MAP_DWELL_MS` had the identical race and is fixed the same way.

## Part 1 — gate on ctrl sync

Both broadcasts now wait for `ctrlInitialSyncComplete`. Writing after sync makes this launch's write causally after the incumbent it has already received, so it wins regardless of clientID. Both orderings are pinned — a server clientID above and below the client's.

The parameter is **required, not defaulted**. A default of `() => true` is the pre-fix behaviour exactly, so an omitted argument would revert the fix and typecheck cleanly. Review found that every spec in `tandem-mode-race.test.ts` stays green under that revert, because they drive the hook through a fixture supplying its own getters.

That leaves one hole a required parameter cannot close:

```js
const ctrlSynced = yjsSync.ctrlInitialSyncComplete;   // no $derived
createTandemModeBroadcast(…, () => ctrlSynced, …);
```

A getter, typechecks, `svelte-check` clean, every unit spec green — and in the running app frozen at `false` forever, so the mode is never broadcast, `readModeState()` returns `indeterminate`, `reportedMode` collapses that to `"tandem"`, and a user in Solo has their annotations shipped. `tandem-mode-wiring.test.ts` pins the call site against exactly that.

**Behaviour change worth knowing:** if the provider never syncs, the mode never reaches the server at all. That is strictly better than a coin-flip loss — an absent key reads as `indeterminate` and falls back to the default — but it is a change, and it has a spec.

## Part 2 — read the key back, warn only

Nothing in `src/client/` observed the ctrl room's awareness map, which is precisely why a lost tie went unnoticed through a shipped release. A `Y.Map` observer now compares the room's value against what this client last wrote and files a `logClientWarning` on a disagreement.

It **does not adopt** the room's value, and that is a decision. Adopting would let another window — or `/api/mode/release`, which writes `"tandem"` unconditionally — take the user out of Solo without them touching anything. Solo is a privacy control whose toggle promises Claude will not see their comments; a mechanism added to make that promise honest must not be able to revoke it.

The asymmetry was considered rather than overlooked, and the code says so: the mirror case (we hold Solo, the room holds Tandem) is the one that actually breaks the promise, and re-asserting there *would* win — but two clients that both re-assert never converge, and bounding that needs its own design. Warn-only is the half that cannot make things worse.

`logClientWarning`, not `console.warn` (#1439): the release desktop build ships no devtools feature, so a console line there is written to a sink nobody can read. This lands in Copy Diagnostics and the prefilled bug report.

The gate does **not** close the class, and the code names the four concurrent cases that remain rather than implying it does: the key absent entirely, two synced clients toggling at once, `/api/mode/release` racing a toggle, and a toggle during a network blip (`ctrlInitialSyncComplete` latches and clears only on doc replacement). The read-back is what makes those audible.

## #1623 — the Default Mode setting is deleted, not wired up

The setting was stored, validated, migrated, unit-tested — and read by nothing. The live mode has always come from the `tandem:mode` localStorage key the toggle writes, so a user who set Solo in Settings never started in Solo. Rather than wire it up, the setting and its radiogroup are gone: persisting the toggle already expresses the same intent, and two sources for one preference can only disagree.

Schema **v19 to v20** with a `REMOVED_FIELDS` entry, following the file's documented one-way ratchet and the v15 to v16 precedent. Honest note on those three migration specs: only the forward-compat `REMOVED_FIELDS` one is a real gate. I mutated the other two — deleting the `delete next.defaultMode` and disabling the whole `schemaVersion === 19` step — and both stayed green, because `normalizeKnownFields` rebuilds from a fixed allowlist and stamps `CURRENT_SCHEMA_VERSION` unconditionally. That is true of every pure-bump step already in the file; the ladder entry documents the version's meaning, it does not enforce it.

Two testids leave the contract (`settings-modal-default-mode-{tandem,solo}-btn`) and the snapshot is regenerated — deliberate, per Critical Rule 7.

## What review changed

Two mutants survived my first battery and were found by review, not by me:

- **Dropping `!bootstrapYdoc` from the broadcast gate** survived because no spec ever passed `doc: null`. In the app that window is real (pre-bootstrap, and post-`bootstrapCleanup`): the effect would deref null, the `catch` would swallow it as a console warning, and `lastBroadcast` would be left holding the previous generation's value for the detector to compare against.
- **Deleting the mode's write-back to `localStorage`** survived because every other spec *seeds* storage and never reads it back — the user's toggle would silently stop sticking across launches with the suite green. Since #1623 removed the settings field, that write is the only thing carrying a mode between sessions.

Review also disproved a load-bearing comment of mine. The `lastBroadcast` docblock claimed a rune there would be billed to the broadcast effect's dependency set, citing a measurement. The mechanism is real, but the `if (transaction.local) return` guard fires *before* the first read, so the local re-entrant path — the only one with an active reaction — never reaches it. The measurement was taken against an earlier mirrored-`ctrlMode` design and the comment outlived it. The decision stands; the comment now states the actual invariant and names the guard ordering as the thing keeping it true.

## Verification

- `npm run typecheck` + `typecheck:tests` clean
- `npm test` — 614 files, 10,119 passed
- `npm run test:e2e` — 391 passed, 11 skipped
- **12-mutant battery, all 12 killed**, each by a named spec

Not done: no manual run against a real desktop launch. #1621 is a coin flip per startup, so a handful of clean launches would not be evidence either way — the both-orderings tie-break spec is the stronger check, and I would rather say so than claim a smoke test I did not run.

Follow-up worth filing separately: **server-side mode provenance** — record which live connection last wrote `mode` and surface it on `tandem_status` / `tandem_checkInbox`. The client-side detector can only see disagreements this client is a party to.

Closes #1621
Closes #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2pmHqviC4eGjh13jaG8Xz
