### PR TITLE
test(client): point the slash-command suite at the schema we ship (#1720)

### DIFF
--- a/tests/client/heading-menu-focus-restore.test.ts
+++ b/tests/client/heading-menu-focus-restore.test.ts
@@ -31,6 +31,13 @@ import FormattingToolbar from "../../src/client/editor/toolbar/FormattingToolbar
 
 const mounted: Array<{ editor: Editor; container: HTMLElement }> = [];
 
+/**
+ * Bare `StarterKit`, which is NOT the production schema — see
+ * `buildSchemaExtensions()`. Fine here: every spec in this file is about focus
+ * restoration around the heading menu and none inspects document structure. Do
+ * not copy this harness into a suite that asserts on `getHTML()`; #1720 is what
+ * that costs.
+ */
 function makeEditor(): Editor {
   const host = document.createElement("div");
   document.body.appendChild(host);

--- a/tests/client/list-item-checkbox.test.ts
+++ b/tests/client/list-item-checkbox.test.ts
@@ -20,6 +20,21 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
+/**
+ * A DELIBERATELY partial extension set — `StarterKit` minus its `listItem`,
+ * plus ours — because these specs are about `ListItemCheckbox` itself and want
+ * nothing else in the way.
+ *
+ * Stated because it is not the production schema (no `SoftWrapParagraph`, no
+ * tables, no `ListSpreadExtension`), and a suite that measures a schema
+ * production does not use has already cost one wrong bug report: #1720 was
+ * diagnosed as slash-command corruption when it was stock StarterKit's
+ * `paragraph block*` listItem repairing an illegal shape at parse time. That is
+ * safe here only because nothing in this file drives a block-type conversion —
+ * `setNode`/`clearNodes` never run. Anything added here that DOES should pass
+ * `buildSchemaExtensions()` via `opts.extensions`, as the Enter-key block near
+ * the bottom of this file already does.
+ */
 function makeEditor(opts: { extensions?: AnyExtension[]; content?: Content } = {}): Editor {
   const container = document.createElement("div");
   document.body.appendChild(container);

--- a/tests/client/slash-command.test.ts
+++ b/tests/client/slash-command.test.ts
@@ -1,10 +1,9 @@
 import { Editor } from "@tiptap/core";
-import Table from "@tiptap/extension-table";
-import TableCell from "@tiptap/extension-table-cell";
-import TableHeader from "@tiptap/extension-table-header";
-import TableRow from "@tiptap/extension-table-row";
-import StarterKit from "@tiptap/starter-kit";
+import Collaboration from "@tiptap/extension-collaboration";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ySyncPluginKey } from "y-prosemirror";
+import * as Y from "yjs";
+import { buildSchemaExtensions } from "../../src/client/editor/editor-extensions";
 import {
   filterSlashCommands,
   findSlashCommandMatch,
@@ -12,23 +11,43 @@ import {
   SlashCommandExtension,
   slashCommandPluginKey,
 } from "../../src/client/editor/slash-menu";
+import { loadMarkdown, saveMarkdown } from "../../src/server/file-io/markdown";
 
+/**
+ * THE PRODUCTION SCHEMA, and that is the point of this helper (#1720).
+ *
+ * This suite used to build `StarterKit.configure({ history: false })` plus the
+ * four stock Table extensions. The shipped editor (`Editor.svelte`) builds
+ * `buildSchemaExtensions()`, which configures StarterKit
+ * `{ listItem: false, paragraph: false }` and substitutes `ListItemCheckbox`
+ * (content `block+`, widened for #1664) and `SoftWrapParagraph`, and registers
+ * the table nodes itself. Stock `listItem` is `paragraph block*`.
+ *
+ * That one difference produced a wrong bug report. `<li><h2>x</h2></li>` is
+ * ILLEGAL under `paragraph block*`, so ProseMirror repairs it at PARSE time —
+ * inserting an empty paragraph and pushing the heading out to the parent item —
+ * and #1720 read the repair as slash-command corruption. Under `block+` the
+ * shape is legal, parses intact, and the command retypes it in place. A suite
+ * that measures a schema production does not use has already cost one wrong
+ * diagnosis; it does not get to cost a second.
+ *
+ * The `Y.Doc` is not incidental either: `Collaboration` is what puts a real
+ * `ySyncPlugin` in the state, which the remote-insertion spec below needs in
+ * order to be testing anything.
+ */
 function makeEditor() {
   const container = document.createElement("div");
   document.body.appendChild(container);
+  const ydoc = new Y.Doc();
   const editor = new Editor({
     element: container,
     extensions: [
-      StarterKit.configure({ history: false }),
-      Table,
-      TableRow,
-      TableCell,
-      TableHeader,
+      ...buildSchemaExtensions(),
+      Collaboration.configure({ document: ydoc }),
       SlashCommandExtension,
     ],
-    content: "",
   });
-  return { editor, container };
+  return { editor, container, ydoc };
 }
 
 describe("slash command parsing", () => {
@@ -114,10 +133,29 @@ describe("paragraph slash command", () => {
     container.remove();
   });
 
-  function runParagraph() {
+  function runParagraphOn(target: Editor) {
     const command = SLASH_COMMANDS.find((c) => c.id === "paragraph");
     if (!command) throw new Error("paragraph command missing");
-    command.run(editor);
+    command.run(target);
+  }
+
+  function runParagraph() {
+    runParagraphOn(editor);
+  }
+
+  /** First position inside the text node containing `needle`. */
+  function posOf(target: Editor, needle: string): number {
+    let found = -1;
+    target.state.doc.descendants((node, pos) => {
+      if (found >= 0) return false;
+      if (node.isText && node.text?.includes(needle)) {
+        found = pos + node.text.indexOf(needle) + 1;
+        return false;
+      }
+      return true;
+    });
+    if (found < 0) throw new Error(`"${needle}" not found in ${target.getHTML()}`);
+    return found;
   }
 
   // Pins ARRAY POSITION 0, which is the one thing the source comment calls
@@ -249,6 +287,131 @@ describe("paragraph slash command", () => {
     editor.commands.setTextSelection(8);
     runParagraph();
     expect(editor.getHTML()).toBe("<ul><li><p>x</p><p>hello</p></li></ul>");
+  });
+
+  /**
+   * #1720 reported that a heading or code block in a DOUBLY-nested list item
+   * comes out corrupted — an orphan empty `<li>` plus the converted block
+   * re-parented into the outer item. It does not, under the schema this editor
+   * actually has. The report was measured against a stock-StarterKit harness,
+   * where `listItem` is `paragraph block*` and `<li><h2>` is illegal, so the
+   * damage is done by ProseMirror's PARSE-TIME repair before any command runs.
+   *
+   * Each case therefore asserts TWICE, and the first assertion is the load-
+   * bearing one. Pinning only the post-command HTML would go red under a
+   * revert of `ListItemCheckbox`'s `block+` — but it would read as a slash-
+   * command regression, sending the next person into `commands.ts` and its
+   * `clearNodes` docblock. The parse assertion says where the break is.
+   */
+  const DEEP_CASES: Array<[string, string, string]> = [
+    [
+      "a heading",
+      "<ul><li><p>a</p><ul><li><h2>deep</h2></li></ul></li></ul>",
+      "<ul><li><p>a</p><ul><li><p>deep</p></li></ul></li></ul>",
+    ],
+    [
+      "a code block",
+      "<ul><li><p>a</p><ul><li><pre><code>deep</code></pre></li></ul></li></ul>",
+      "<ul><li><p>a</p><ul><li><p>deep</p></li></ul></li></ul>",
+    ],
+    [
+      "a heading that follows a paragraph in the same item",
+      "<ul><li><p>a</p><ul><li><p>x</p><h2>deep</h2></li></ul></li></ul>",
+      "<ul><li><p>a</p><ul><li><p>x</p><p>deep</p></li></ul></li></ul>",
+    ],
+    [
+      "a heading in an ordered list",
+      "<ol><li><p>a</p><ol><li><h2>deep</h2></li></ol></li></ol>",
+      "<ol><li><p>a</p><ol><li><p>deep</p></li></ol></li></ol>",
+    ],
+  ];
+
+  it.each(
+    DEEP_CASES,
+  )("parses %s in a doubly-nested item intact, then retypes it in place (#1720)", (_label, input, expected) => {
+    editor.commands.setContent(input);
+    // Parse-time. A `paragraph block*` listItem reports HERE, naming the
+    // schema rather than the command.
+    expect(editor.getHTML()).toBe(input);
+
+    editor.commands.setTextSelection(posOf(editor, "deep"));
+    runParagraph();
+    expect(editor.getHTML()).toBe(expected);
+  });
+
+  /**
+   * The behaviour #1720 got right, pinned as CURRENT behaviour rather than as
+   * desired behaviour.
+   *
+   * `/p` on a block that is ALREADY a paragraph has nothing to retype, so
+   * `setNode` falls through to `clearNodes()`, which lifts out of EVERY
+   * wrapper. At depth 1 with no siblings that is the documented reset above
+   * ("resets a list item to a top-level paragraph"). With siblings it must
+   * split the list — you cannot have a paragraph in the middle of one — and at
+   * depth 2 the lift goes all the way to the document root, taking the OUTER
+   * list apart as well. The issue's own table calls the sibling-free version of
+   * this "lifts correctly".
+   *
+   * Whether the lift should stop at the nearest list item instead is a design
+   * question, tracked separately. These pins exist so that changing it is a
+   * deliberate act with a visible diff, and so nobody re-derives the current
+   * shape from scratch the way #1720 did.
+   */
+  const LIFT_CASES: Array<[string, string, string]> = [
+    [
+      "splits the list when the item has siblings",
+      "<ul><li><p>x</p></li><li><p>deep</p></li></ul>",
+      "<ul><li><p>x</p></li></ul><p>deep</p>",
+    ],
+    [
+      "lifts to the document ROOT from depth 2, taking the outer list apart",
+      "<ul><li><p>a</p><ul><li><p>x</p></li><li><p>deep</p></li></ul></li></ul>",
+      "<ul><li><p>a</p></li></ul><ul><li><p>x</p></li></ul><p>deep</p>",
+    ],
+  ];
+
+  it.each(LIFT_CASES)("/p on an already-paragraph item %s", (_label, input, expected) => {
+    editor.commands.setContent(input);
+    editor.commands.setTextSelection(posOf(editor, "deep"));
+    runParagraph();
+    expect(editor.getHTML()).toBe(expected);
+  });
+
+  it("leaves the nesting alone when the target is NOT already a paragraph", () => {
+    // The discriminator for the two blocks above, and the reason the
+    // precondition is "already a paragraph" rather than "nested": the same
+    // shape with a heading in it retypes in place and keeps both lists. Without
+    // this, "nesting is what breaks it" survives every other spec here.
+    editor.commands.setContent(
+      "<ul><li><p>a</p><ul><li><p>x</p></li><li><h2>deep</h2></li></ul></li></ul>",
+    );
+    editor.commands.setTextSelection(posOf(editor, "deep"));
+    runParagraph();
+    expect(editor.getHTML()).toBe(
+      "<ul><li><p>a</p><ul><li><p>x</p></li><li><p>deep</p></li></ul></li></ul>",
+    );
+  });
+
+  it("round-trips a doubly-nested heading through markdown (#1720)", () => {
+    // The user-facing statement of the same fact, and the surface a schema
+    // regression reaches first: what lands on disk. `setContent` above proves
+    // the command; this proves the whole chain the user actually drives —
+    // markdown -> Y.Doc -> ProseMirror -> command -> Y.Doc -> markdown.
+    const { editor: bound, container: boundContainer, ydoc } = makeEditor();
+    try {
+      loadMarkdown(ydoc, "- a\n\n  - ## deep\n");
+      bound.commands.setTextSelection(posOf(bound, "deep"));
+      runParagraphOn(bound);
+      expect(saveMarkdown(ydoc)).toBe("- a\n\n  - deep\n");
+    } finally {
+      // The suite's own afterEach only owns the beforeEach editor, so this
+      // second one cleans up after itself — `makeEditor` appends to
+      // document.body, and a discarded handle leaks the node for the rest of
+      // the run.
+      bound.destroy();
+      boundContainer.remove();
+      ydoc.destroy();
+    }
   });
 });
 
@@ -391,12 +554,29 @@ describe("slash command open gating (#998)", () => {
   });
 
   it("does NOT open from a remote (y-sync) insertion", () => {
+    // The forged meta is `{ isChangeOrigin: true }` and NOT a bare `true`, and
+    // the difference is the whole spec. The slash menu itself only checks
+    // truthiness, so a boolean satisfies its gate and this assertion passes
+    // either way — but the REAL `ySyncPlugin.apply` reads `change.isChangeOrigin`
+    // off the meta value, gets `undefined` from a boolean, and treats the
+    // transaction as an ordinary LOCAL edit. Under a boolean this spec silently
+    // tests local-insertion suppression while claiming to test remote.
+    //
+    // The plugin-state read is the assertion that can actually fail, and it is
+    // NOT the more obvious "the text never reached the Y.Doc" — that one is
+    // false, which measuring it is how I found out. `ySyncPlugin`'s view update
+    // diffs the PM doc into the CRDT outside the origin check, so a forged
+    // remote transaction propagates either way; `isChangeOrigin` governs
+    // re-entrancy, and the plugin's own state is the only place a bare `true`
+    // is visibly discarded.
     editor.chain().focus().run();
     const pos = editor.state.selection.from;
     const tr = editor.state.tr.insertText("/h", pos);
-    tr.setMeta("y-sync$", true);
+    tr.setMeta("y-sync$", { isChangeOrigin: true });
     editor.view.dispatch(tr);
+
     expect(active()).toBeNull();
+    expect(ySyncPluginKey.getState(editor.state)?.isChangeOrigin).toBe(true);
   });
 
   it("opens when '/' is typed over a non-empty selection", () => {


### PR DESCRIPTION
Closes #1720. Follow-up filed as #1741.

## What #1720 actually was

A block command applied to a heading or code block in a doubly-nested list item was reported to
leave an orphan bullet and re-parent the text. It does not — not in the editor we ship. The
measurement was taken in this suite's own harness, which builds stock
`StarterKit.configure({ history: false })`. `Editor.svelte` builds `buildSchemaExtensions()`, where
`ListItemCheckbox` replaces the stock node **under the same name** with content `block+` rather than
`paragraph block*` (widened for #1664).

```
STOCK StarterKit
  parsed: <ul><li><p>a</p><ul><li><p></p></li></ul><h2>deep</h2></li></ul>   <- corrupt ALREADY
  after:  <ul><li><p>a</p><ul><li><p></p></li></ul><p>deep</p></li></ul>

PRODUCTION schema
  parsed: <ul><li><p>a</p><ul><li><h2>deep</h2></li></ul></li></ul>
  after:  <ul><li><p>a</p><ul><li><p>deep</p></li></ul></li></ul>
```

The orphan and the relocation are in the **`parsed:`** line — present before any command runs.
`<li><h2>` is illegal under `paragraph block*`, so ProseMirror repairs it at parse time. The issue
reached for the right question ("the defect is in Tiptap's `clearNodes` lift/mapping, not our call
site") and the answer was one step earlier still: not the lift, the parse.

Re-ran the issue's whole matrix under the production schema — depth 1 and 2, sole child and
non-first child, paragraph / heading / code block, `ul` and `ol`, `/p` and `/h1`. All correct. One
shape additionally end-to-end through `loadMarkdown` -> Y.Doc -> command -> `saveMarkdown`.

## The change

The suite now builds the production extension set over a real `Y.Doc`. **All 47 existing specs pass
unchanged** — including the two `clearNodes` `RangeError` pins, which were measured to still throw
under both schemas *before* this was written, because a pin that quietly stops meaning what it says
is worse than no pin.

New depth-2 cases assert the **parsed** document as well as the result, and that order is the point:
reverting `ListItemCheckbox` to `paragraph block*` reds five specs, and the first assertion to fail
names the schema instead of sending the next reader into `commands.ts`.

## Three things this turned up

**The remote-insertion spec was about to go quietly wrong.** It forged `setMeta("y-sync$", true)`.
The slash menu only checks truthiness so it passed, but the real `ySyncPlugin` reads
`change.isChangeOrigin` off that value and gets `undefined` from a boolean — so with `Collaboration`
now live it would have been testing *local* insertion suppression while claiming remote. It forges
the real shape and reads the flag back off plugin state. Worth recording that the more obvious
assertion — that the text never reached the Y.Doc — **is false**: ySync's view update diffs the PM
doc into the CRDT outside the origin check, so a forged remote transaction propagates either way.
Measured, not reasoned.

**A real defect, different from the reported one, now pinned.** `/p` on an item that is *already* a
paragraph falls through to `clearNodes()` and lifts out of every wrapper — splitting the list when
the item has siblings, and at depth 2 dismantling the outer list as well. It survives under the
production schema. But the depth-1 form of it is shipped, pinned behaviour ("resets a list item to a
top-level paragraph") and #1720's own table calls the sibling-free version "lifts correctly", so
this is a design decision rather than an obvious bug — #1741. Pinned here as CURRENT behaviour with
a discriminating control (the same shape with a heading keeps its nesting), so changing it produces
a visible diff.

**The two other suites that build a non-production editor now say so**, and say what it costs.
Neither drives a block conversion, which is what makes them safe.

## Verification

`npm run typecheck`, `npm run typecheck:tests`, `npm test` (10170 passed), biome — all green. No
`src/` file is touched, so there is no E2E surface. Two mutants, both killed by named specs:
reverting `ListItemCheckbox.content` to `paragraph block*` (5 specs, failing on the parse assertion),
and the y-sync meta back to a bare `true`.

Review found four things, all applied: an `it.each` label that composed into "in an ORDERED
doubly-nested item in a doubly-nested item", a leaked container and Y.Doc in the round-trip spec,
two mechanically identical lift pins that wanted to be one table, and a comment paragraph that
re-derived its own previous paragraph. Two suggestions were skipped as outside this diff: a shared
`productionEditor()` factory (three suites hand-roll the same three lines) and reconciling `posOf`
with `list-item-checkbox.test.ts`'s `findTextPos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2pmHqviC4eGjh13jaG8Xz
