### PR TITLE
fix(client): pin the tab close button to the pill's right edge (#1736)

### DIFF
--- a/src/client/tabs/TabItem.svelte
+++ b/src/client/tabs/TabItem.svelte
@@ -302,7 +302,15 @@ function handleMouseLeaveClose() {
          wrapper's min-content, so no CSS can express "floor at my own natural
          width". `max-width` is the opposite end: the most filename a tab shows
          when the strip has width to spare (unreachable under `uniformTabWidth`,
-         which pins every tab to the floor). -->
+         which pins every tab to the floor).
+
+         `flex-grow` belongs on that prohibited list too, and is the tempting
+         one: adding it here would neatly absorb the slack a short name leaves
+         inside a uniform-mode pill (#1736) — and would silently collapse
+         ADAPTIVE mode into uniform, because `measureTabFloor` reads this
+         span's natural width as `scrollWidth`, which reports a grown BOX.
+         `tab-floor.ts` states the mechanism in full at that read. The slack is
+         absorbed by an auto margin on the close button below instead. -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <span
       data-testid={`tab-name-${tab.id}`}
@@ -327,6 +335,23 @@ function handleMouseLeaveClose() {
     </span>
   {/if}
 
+  <!-- `margin-left: auto` pins this button to the pill's right padding (#1736).
+       Under `uniformTabWidth` the wrapper is pinned to 142px and the pill fills
+       it, so a short name leaves slack inside the pill; with every child at
+       `flex-grow: 0` and `justify-content` at its default `flex-start`, that
+       slack parked after the LAST child — this button — leaving ~38px of void
+       between the × and the tab's right edge.
+
+       An auto margin rather than growing the name span, because it is the only
+       sink `measureTabFloor` cannot see: auto margins resolve AFTER flex
+       grow/shrink, so at the adaptive floor the free space is 0 and this
+       collapses to 0, and they count as 0 for intrinsic sizing. See the name
+       span's comment above, and `tab-floor.ts` for what growing it would break.
+
+       This RELOCATES the whitespace rather than removing it: the gap now sits
+       between the filename (or the RO badge) and the ×, which is the
+       conventional browser-tab layout and keeps the RO badge beside the name
+       it describes. -->
   <button
     bind:this={closeBtn}
     onclick={(e) => {
@@ -336,7 +361,7 @@ function handleMouseLeaveClose() {
     onpointerdown={(e) => e.stopPropagation()}
     onmouseenter={handleMouseEnterClose}
     onmouseleave={handleMouseLeaveClose}
-    style="background: none; border: none; cursor: pointer; font-size: var(--tandem-text-md); line-height: 1; color: var(--tandem-fg-muted); padding: 0 2px; border-radius: var(--tandem-r-1);"
+    style="background: none; border: none; cursor: pointer; font-size: var(--tandem-text-md); line-height: 1; color: var(--tandem-fg-muted); padding: 0 2px; border-radius: var(--tandem-r-1); margin-left: auto;"
     title="Close document"
     aria-label={`Close ${tab.fileName}`}
   >

--- a/src/client/tabs/TabItem.svelte
+++ b/src/client/tabs/TabItem.svelte
@@ -336,17 +336,18 @@ function handleMouseLeaveClose() {
   {/if}
 
   <!-- `margin-left: auto` pins this button to the pill's right padding (#1736).
-       Under `uniformTabWidth` the wrapper is pinned to 142px and the pill fills
-       it, so a short name leaves slack inside the pill; with every child at
+       Under `uniformTabWidth` the wrapper is pinned to `TAB_FLOOR_PX` (142px)
+       and the pill fills it, so a short name leaves slack inside the pill; with every child at
        `flex-grow: 0` and `justify-content` at its default `flex-start`, that
        slack parked after the LAST child — this button — leaving ~38px of void
        between the × and the tab's right edge.
 
        An auto margin rather than growing the name span, because it is the only
        sink `measureTabFloor` cannot see: auto margins resolve AFTER flex
-       grow/shrink, so at the adaptive floor the free space is 0 and this
-       collapses to 0, and they count as 0 for intrinsic sizing. See the name
-       span's comment above, and `tab-floor.ts` for what growing it would break.
+       grow/shrink, so at the adaptive floor the free space is at most that
+       function's deliberate 1px rounding allowance and this collapses to ~0,
+       and they count as 0 for intrinsic sizing. See the name span's comment
+       above, and `tab-floor.ts` for what growing it would break.
 
        This RELOCATES the whitespace rather than removing it: the gap now sits
        between the filename (or the RO badge) and the ×, which is the

--- a/src/client/tabs/tab-floor.ts
+++ b/src/client/tabs/tab-floor.ts
@@ -35,9 +35,9 @@ export function measureTabFloor(wrapper: HTMLElement): number {
   // (Until #1736 that slack sat after the last child, parked there by
   // `flex-start`; it now lands in the close button's auto margin instead. The
   // conclusion is unchanged — the slack is still not chrome.) Sum the real
-  // boxes — this also self-corrects for the read-only badge (~29px,
-  // `flex-shrink: 0`) and for the 2px border delta between an active and an
-  // inactive pill.
+  // boxes — this also self-corrects for the read-only badge and its gap
+  // (~29px together; the badge alone is ~23px and `flex-shrink: 0`) and for
+  // the 2px border delta between an active and an inactive pill.
   const cs = getComputedStyle(pill);
   const kids = Array.from(pill.children).filter((k): k is HTMLElement => k instanceof HTMLElement);
   let chrome =
@@ -57,14 +57,22 @@ export function measureTabFloor(wrapper: HTMLElement): number {
   // THIS READ IS THE WHOLE REASON THE NAME SPAN MAY NOT GROW (#1736), and it
   // is the canonical statement of that rule — TabItem points here rather than
   // restating it. `scrollWidth` is `max(scrolling area, padding box)`, so it
-  // means "the filename's width" only while the span is shrink-wrapped. Grow
-  // the span and it reports the BOX: on this function's first pass every
-  // wrapper still carries only the base `.tab-flip { min-width: 142px }`, so a
-  // grown span measures 142 here, that gets written back as the tab's inline
-  // floor, and the next pass measures 142 again. Adaptive mode silently
-  // becomes uniform mode. Whatever absorbs slack inside the pill therefore
-  // must not be this span; TabItem uses an auto margin on the close button,
-  // which resolves after flex layout and is invisible to this measurement.
+  // means "the filename's width" only while the span is shrink-wrapped.
+  //
+  // Grow the span and it reports the BOX instead, which makes this function
+  // measure its own input. On the first pass every wrapper still carries only
+  // the base `.tab-flip { min-width: TAB_FLOOR_PX }`, so a grown span reports
+  // whatever is left of that wrapper (~80px on a short name, not the floor
+  // itself) — and `chrome` above is BY CONSTRUCTION everything in the pill
+  // except the name, so `chrome + nameNatural` just reconstructs the wrapper's
+  // own width and the `Math.min` below clamps it to TAB_FLOOR_PX. That is
+  // written back as the tab's inline floor, and the next pass reconstructs it
+  // again. Adaptive mode silently becomes uniform mode — no flicker, no error,
+  // every tab simply the same width.
+  //
+  // Whatever absorbs slack inside the pill therefore must not be this span;
+  // TabItem uses an auto margin on the close button, which resolves after flex
+  // layout and is invisible to this measurement.
   const cap = parseFloat(getComputedStyle(name).maxWidth) || Number.POSITIVE_INFINITY;
   const nameNatural = Math.min(name.scrollWidth + 1, cap);
   const floor = Math.min(chrome + nameNatural, TAB_FLOOR_PX);

--- a/src/client/tabs/tab-floor.ts
+++ b/src/client/tabs/tab-floor.ts
@@ -31,10 +31,13 @@ export function measureTabFloor(wrapper: HTMLElement): number {
   if (!pill || !name) return TAB_FLOOR_PX;
 
   // Chrome is NOT a constant and must not be derived as `pill − name`: a
-  // floored tab carries slack that flex-start parks after the last child,
-  // which that subtraction would count as chrome. Sum the real boxes — this
-  // also self-corrects for the read-only badge (~29px, `flex-shrink: 0`) and
-  // for the 2px border delta between an active and an inactive pill.
+  // floored tab carries slack, which that subtraction would count as chrome.
+  // (Until #1736 that slack sat after the last child, parked there by
+  // `flex-start`; it now lands in the close button's auto margin instead. The
+  // conclusion is unchanged — the slack is still not chrome.) Sum the real
+  // boxes — this also self-corrects for the read-only badge (~29px,
+  // `flex-shrink: 0`) and for the 2px border delta between an active and an
+  // inactive pill.
   const cs = getComputedStyle(pill);
   const kids = Array.from(pill.children).filter((k): k is HTMLElement => k instanceof HTMLElement);
   let chrome =
@@ -50,6 +53,18 @@ export function measureTabFloor(wrapper: HTMLElement): number {
   // `scrollWidth` is integer-rounded, so a name that exactly fits can still
   // pick up an ellipsis; +1 buys that back. Read the cap off the span itself
   // rather than restating TabItem's 240px literal here.
+  //
+  // THIS READ IS THE WHOLE REASON THE NAME SPAN MAY NOT GROW (#1736), and it
+  // is the canonical statement of that rule — TabItem points here rather than
+  // restating it. `scrollWidth` is `max(scrolling area, padding box)`, so it
+  // means "the filename's width" only while the span is shrink-wrapped. Grow
+  // the span and it reports the BOX: on this function's first pass every
+  // wrapper still carries only the base `.tab-flip { min-width: 142px }`, so a
+  // grown span measures 142 here, that gets written back as the tab's inline
+  // floor, and the next pass measures 142 again. Adaptive mode silently
+  // becomes uniform mode. Whatever absorbs slack inside the pill therefore
+  // must not be this span; TabItem uses an auto margin on the close button,
+  // which resolves after flex layout and is invisible to this measurement.
   const cap = parseFloat(getComputedStyle(name).maxWidth) || Number.POSITIVE_INFINITY;
   const nameNatural = Math.min(name.scrollWidth + 1, cap);
   const floor = Math.min(chrome + nameNatural, TAB_FLOOR_PX);

--- a/tests/e2e/tab-overflow.spec.ts
+++ b/tests/e2e/tab-overflow.spec.ts
@@ -211,9 +211,12 @@ async function openFixtureTabs(page: Page, uniform: boolean) {
     await mcp.callTool("tandem_open", { filePath });
   }
 
-  // Seed the setting before first paint. `schemaVersion` must be the CURRENT
-  // one: seed it lower and loadSettings migrates (fine), but seed it higher and
-  // the whole run silently goes `_readOnly`.
+  // Seed the setting before first paint. `schemaVersion` must be AT MOST the
+  // current one: seed it lower and loadSettings migrates (fine — 18 is two
+  // behind `CURRENT_SCHEMA_VERSION` today and migrates through), but seed it
+  // higher and the whole run silently goes `_readOnly`. This comment used to
+  // say "must be the CURRENT one", which stopped being what the code does the
+  // first time the schema was bumped past 18.
   await page.addInitScript(
     ([key, value]) => {
       window.localStorage.setItem(
@@ -249,16 +252,45 @@ async function measureTabStrip(page: Page) {
         const pill = wrapper.firstElementChild as HTMLElement;
         // Null while a tab is renaming — the span is swapped for an input.
         const name = pill.querySelector("[data-testid^='tab-name-']");
+        // Right edge of the pill's CONTENT box, read off computed style rather
+        // than restating TabItem's `padding: 0 10px 0 12px`. Reading it matters
+        // for more than tidiness: the active pill's border is 1px and every
+        // inactive one's is 2px (TabItem's `border-right` ternary), so a
+        // hardcoded offset would be off by a pixel on exactly one tab — which
+        // is the same size as the tolerance any flushness assertion needs.
+        const cs = getComputedStyle(pill);
+        const pillBox = box(pill)!;
         return {
           uniform: wrapper.classList.contains("uniform"),
+          // The filename as rendered, so a test can name the fixture it means
+          // instead of rediscovering it from pixel widths.
+          label: name?.textContent?.trim() ?? null,
           wrapper: box(wrapper)!,
-          pill: box(pill)!,
+          pill: pillBox,
           name: box(name),
           close: box(pill.querySelector("button[aria-label^='Close']"))!,
+          contentRight:
+            pillBox.right - parseFloat(cs.borderRightWidth) - parseFloat(cs.paddingRight),
         };
       }),
     };
   });
+}
+
+/**
+ * Shared by both modes: the × sits ON the pill's content edge, never floating
+ * inside it (#1736). Distinct from `assertNothingSpills`, which only catches a
+ * button that has escaped its pill — a button parked 38px short of the edge
+ * satisfies that one completely.
+ */
+function assertCloseFlush(measured: Awaited<ReturnType<typeof measureTabStrip>>) {
+  for (const tab of measured.tabs) {
+    // Sub-pixel only. A regression here is tens of pixels, not fractions.
+    expect(
+      Math.abs(tab.contentRight - tab.close.right),
+      `the close button drifted off the pill's content edge on "${tab.label}"`,
+    ).toBeLessThanOrEqual(1);
+  }
 }
 
 /** Shared by both modes: nothing escapes its pill, and the actions cluster survives. */
@@ -299,6 +331,72 @@ test("uniform mode: every tab is the same width, and the strip still scrolls", a
   expect(Math.max(...widths)).toBeCloseTo(FLOOR_PX, 0);
 
   assertNothingSpills(measured);
+});
+
+/**
+ * #1736. A uniform-mode pill is padded out to 142px, so a short name leaves
+ * slack inside it — and that slack used to park after the last child, leaving
+ * ~38px of void between the × and the tab's right edge. `assertNothingSpills`
+ * is blind to it: nothing overflowed, it was just wrong.
+ *
+ * The second assertion is the load-bearing one, and it is here rather than in
+ * the adaptive tests on purpose. The rejected fix — growing the name span —
+ * produces close-button pixels identical to the shipped one, so `assertCloseFlush`
+ * passes under it; what it breaks is the adaptive floor (see `measureTabFloor`,
+ * whose `scrollWidth` read is the canonical explanation). The adaptive tests
+ * below do go red, but they read as unrelated breakage. This assertion names
+ * the cause at the site of the change.
+ *
+ * Both assertions need real layout, so neither can move to the unit suite:
+ * happy-dom has no layout engine, and a vitest check on the style string would
+ * pin the fix's spelling rather than its effect.
+ */
+test("uniform mode: the close button sits flush at the tab's right edge whatever the name's length (#1736)", async ({
+  page,
+}) => {
+  await openFixtureTabs(page, true);
+  const measured = await measureTabStrip(page);
+
+  assertCloseFlush(measured);
+
+  // The slack must land BETWEEN the name and the ×, which is the same thing as
+  // saying the name span never absorbed it. `ab.md` is the declared dispersion
+  // probe: its name box stays shrink-wrapped at its text width while the pill
+  // around it is padded to 142px, so a real gap opens before the button.
+  const probe = measured.tabs.find((t) => t.label === "ab.md");
+  expect(probe, "the ab.md dispersion probe is missing from the strip").toBeDefined();
+  expect(
+    probe!.close.left - probe!.name!.right,
+    "ab.md's name span absorbed the slack — see `measureTabFloor`",
+  ).toBeGreaterThan(20);
+
+  assertNothingSpills(measured);
+});
+
+test("adaptive mode: the close button is flush there too, with no slack to absorb (#1736)", async ({
+  page,
+}) => {
+  await openFixtureTabs(page, false);
+  const measured = await measureTabStrip(page);
+
+  assertCloseFlush(measured);
+
+  // No fixture tab is renaming, so every tab has a name span. Asserted rather
+  // than filtered: skipping a nameless tab would silently skip the tab the
+  // assertion below exists for.
+  expect(
+    measured.tabs.every((t) => t.name),
+    "a tab was renaming mid-measurement",
+  ).toBe(true);
+
+  // The mode's own invariant, stated as geometry: the measured floor IS
+  // chrome + the name's natural width, so the × lands right after the name with
+  // only the 6px column gap between them (plus `measureTabFloor`'s 1px
+  // rounding allowance). Nothing to absorb, nothing to park. If this ever
+  // grows, the floor and the rendered pill have desynchronised.
+  for (const tab of measured.tabs) {
+    expect(tab.close.left - tab.name!.right).toBeLessThanOrEqual(8);
+  }
 });
 
 test("adaptive mode: tabs size to their own name, and long ones still compress", async ({

--- a/tests/e2e/tab-overflow.spec.ts
+++ b/tests/e2e/tab-overflow.spec.ts
@@ -1,6 +1,7 @@
 import { expect, type Page, test } from "@playwright/test";
 import fs from "fs";
 import path from "path";
+import { E2E_MCP_PORT } from "../../scripts/test-ports.js";
 import {
   cleanupAllOpenDocuments,
   cleanupFixtureDir,
@@ -198,7 +199,34 @@ const FIXTURE_NAMES = [
   "notes.md",
 ];
 
-async function openFixtureTabs(page: Page, uniform: boolean) {
+/**
+ * Opens each name in `readOnlyNames` READ-ONLY, in addition to `FIXTURE_NAMES`.
+ *
+ * It has to go through `POST /api/open` — the route the "View Changelog" button
+ * uses — because `tandem_open` has NO `readOnly` parameter: its zod schema is
+ * `{ filePath, force, authoredBy }` and silently DROPS the extra key, so the
+ * MCP spelling yields a writable tab and a vacuously passing test. (A `.docx`
+ * fixture is not a shortcut either — `openFromDisk` sets `readOnly = false` for
+ * every disk open regardless of extension, #576.)
+ *
+ * Fetched from Node rather than in-page: 127.0.0.1 is loopback either way, and
+ * `open` is one of the routes that deliberately carries NO origin gate (the
+ * Tauri sidecar POSTs it without an `Origin`), so a Node-side call is not
+ * routing around a check. Doing it before `page.goto` also means the tab is
+ * present at first paint like every other fixture, rather than arriving after.
+ * The URL is built from the harness constant — a raw `:3479` literal here would
+ * aim the open at the developer's real desktop Tandem and SUCCEED there.
+ */
+async function openReadOnlyFixture(name: string) {
+  const res = await fetch(`http://127.0.0.1:${E2E_MCP_PORT}/api/open`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ filePath: path.join(tmpDir, name), readOnly: true, force: false }),
+  });
+  expect(res.status, `/api/open refused the read-only fixture "${name}"`).toBe(200);
+}
+
+async function openFixtureTabs(page: Page, uniform: boolean, readOnlyNames: string[] = []) {
   // `tabEnter`/`tabExit` animate `width` and inject `min-width: 0`, so a pill
   // measured mid-transition reports a collapsing box rather than its resting
   // size. Zeroing both durations makes these measurements deterministic instead
@@ -209,6 +237,11 @@ async function openFixtureTabs(page: Page, uniform: boolean) {
     const filePath = path.join(tmpDir, name);
     fs.writeFileSync(filePath, `# ${name}\n\nSizing fixture.\n`);
     await mcp.callTool("tandem_open", { filePath });
+  }
+
+  for (const name of readOnlyNames) {
+    fs.writeFileSync(path.join(tmpDir, name), `# ${name}\n\nRead-only sizing fixture.\n`);
+    await openReadOnlyFixture(name);
   }
 
   // Seed the setting before first paint. `schemaVersion` must be AT MOST the
@@ -231,7 +264,18 @@ async function openFixtureTabs(page: Page, uniform: boolean) {
   await page.waitForSelector("[data-testid='tab-scroll-container']");
   await expect
     .poll(() => page.locator(".tab-flip").count(), { timeout: 10_000 })
-    .toBeGreaterThanOrEqual(FIXTURE_NAMES.length);
+    .toBeGreaterThanOrEqual(FIXTURE_NAMES.length + readOnlyNames.length);
+  // SN Pro is self-hosted with `font-display: swap` (index.html), so first
+  // paint measures at FALLBACK metrics and the real face swaps in later.
+  // Production re-floors on `document.fonts.ready` (DocumentTabs' `fontsSettled`
+  // is a tracked dep of the floor effect) — but between those two moments the
+  // floors were computed against one font and the names render in another, and
+  // the residual slack in that window is NOT bounded by `measureTabFloor`'s
+  // deliberate 1px allowance. The adaptive gap assertion's `<= 8` has ~1px of
+  // measured headroom, so it is exactly what a mid-swap measurement lands on.
+  // Nothing above gates the swap: the selector wait and the count poll are both
+  // satisfied at first paint.
+  await page.evaluate(() => document.fonts.ready);
 }
 
 async function measureTabStrip(page: Page) {
@@ -240,6 +284,11 @@ async function measureTabStrip(page: Page) {
       if (!el) return null;
       const b = el.getBoundingClientRect();
       return { left: b.left, right: b.right, width: b.width };
+    };
+    const textRight = (el: Element) => {
+      const r = document.createRange();
+      r.selectNodeContents(el);
+      return r.getBoundingClientRect().right;
     };
     const scroller = document.querySelector("[data-testid='tab-scroll-container']") as HTMLElement;
     const actions = document.querySelector(".title-bar-actions") as HTMLElement;
@@ -262,12 +311,25 @@ async function measureTabStrip(page: Page) {
         const pillBox = box(pill)!;
         return {
           uniform: wrapper.classList.contains("uniform"),
-          // The filename as rendered, so a test can name the fixture it means
+          // The span's FULL text — `textContent` is unaffected by the CSS
+          // ellipsis, so this is the fixture's real name even on the ten tabs
+          // that render truncated. Lets a test name the fixture it means
           // instead of rediscovering it from pixel widths.
           label: name?.textContent?.trim() ?? null,
           wrapper: box(wrapper)!,
           pill: pillBox,
           name: box(name),
+          // Null on every writable tab. Present, it sits BETWEEN the name and
+          // the ×, so it — not the name — is the last content box before the
+          // button, and `measureTabFloor` folds it into the chrome sum.
+          badge: box(pill.querySelector(".tab-ro-badge")),
+          // Right edge of the filename's actual GLYPHS, via a Range over the
+          // span's contents — not the span's box. The two part company exactly
+          // when this PR's bug is present, and `scrollWidth` cannot tell them
+          // apart: on a grown span it reports the box as well (that is the
+          // whole mechanism `measureTabFloor` documents), so it reads
+          // shrink-wrapped under the very fix it would need to catch.
+          nameTextRight: name ? textRight(name) : null,
           close: box(pill.querySelector("button[aria-label^='Close']"))!,
           contentRight:
             pillBox.right - parseFloat(cs.borderRightWidth) - parseFloat(cs.paddingRight),
@@ -342,10 +404,10 @@ test("uniform mode: every tab is the same width, and the strip still scrolls", a
  * The second assertion is the load-bearing one, and it is here rather than in
  * the adaptive tests on purpose. The rejected fix — growing the name span —
  * produces close-button pixels identical to the shipped one, so `assertCloseFlush`
- * passes under it; what it breaks is the adaptive floor (see `measureTabFloor`,
- * whose `scrollWidth` read is the canonical explanation). The adaptive tests
- * below do go red, but they read as unrelated breakage. This assertion names
- * the cause at the site of the change.
+ * passes under it; what it breaks is the adaptive floor (see `measureTabFloor` in
+ * `src/client/tabs/tab-floor.ts`, whose `scrollWidth` read is the canonical
+ * explanation). The adaptive tests below do go red, but they read as unrelated
+ * breakage. This assertion names the cause at the site of the change.
  *
  * Both assertions need real layout, so neither can move to the unit suite:
  * happy-dom has no layout engine, and a vitest check on the style string would
@@ -389,14 +451,79 @@ test("adaptive mode: the close button is flush there too, with no slack to absor
     "a tab was renaming mid-measurement",
   ).toBe(true);
 
-  // The mode's own invariant, stated as geometry: the measured floor IS
-  // chrome + the name's natural width, so the × lands right after the name with
-  // only the 6px column gap between them (plus `measureTabFloor`'s 1px
-  // rounding allowance). Nothing to absorb, nothing to park. If this ever
-  // grows, the floor and the rendered pill have desynchronised.
+  // The mode's own invariant, stated as geometry: nothing in the pill can park
+  // slack. It gets there two different ways, and the bound holds for both — on
+  // a SHORT name the floor is chrome + the name's natural width, so free space
+  // is only `measureTabFloor`'s deliberate 1px rounding allowance; on a LONG
+  // name the floor clamps to TAB_FLOOR_PX and the name span (`flex-shrink: 1;
+  // min-width: 0`) shrinks to fill and ellipsizes, so free space is ≤ 0.
+  // Either way the × lands right after the name with the 6px column gap
+  // between them. 8 = 6 gap + 1 rounding + 1 subpixel.
+  //
+  // Measured from the badge when there is one — it, not the name, is then the
+  // last content box before the ×. `FIXTURE_NAMES` opens no read-only tab, so
+  // this reduces to the name here; the read-only test below is where the badge
+  // branch is actually exercised.
   for (const tab of measured.tabs) {
-    expect(tab.close.left - tab.name!.right).toBeLessThanOrEqual(8);
+    expect(
+      tab.close.left - (tab.badge ?? tab.name!).right,
+      `slack opened before the × on "${tab.label}"`,
+    ).toBeLessThanOrEqual(8);
   }
+});
+
+/**
+ * Read-only is a distinct measurement regime, not a cosmetic variant: the RO
+ * badge is a real child, so it lands in `measureTabFloor`'s gap term AND its
+ * chrome sum, and `readOnly` is a tracked dep of DocumentTabs' floor effect.
+ *
+ * It is also the SECOND discriminator against the rejected fix, and the one
+ * that pins the reason #1736 went the way it did. Growing the name span carries
+ * the badge and the × to the pill's right edge together while the filename's
+ * glyphs stay at the left, opening a void between the name and the badge that
+ * labels it. An auto margin on the button opens the gap after both instead —
+ * the whole "keeps the RO badge beside the name it describes" claim, which was
+ * argued in the PR body and tested nowhere until here.
+ *
+ * Uniform mode on purpose: it pads the pill to `FLOOR_PX`, so a two-character
+ * name leaves ~38px of slack for the assertions to see the placement of.
+ */
+test("read-only mode: the RO badge stays beside its filename and the × stays flush (#1736)", async ({
+  page,
+}) => {
+  await openFixtureTabs(page, true, ["ro.md"]);
+  const measured = await measureTabStrip(page);
+
+  const ro = measured.tabs.find((t) => t.label === "ro.md");
+  expect(ro, "the read-only fixture is missing from the strip").toBeDefined();
+  expect(
+    ro!.badge,
+    "ro.md opened WRITABLE — the tab has no RO badge, so this test is vacuous",
+  ).not.toBeNull();
+
+  assertCloseFlush(measured);
+
+  // The claim, measured against the GLYPHS rather than the span's box, which is
+  // the difference between a guard and a decoration here. Two spellings were
+  // written first and both were measured passing under the rejected fix:
+  // `badge.left − name.right`, because the badge stays glued to the span's
+  // right EDGE while that edge travels to the far side of the pill; and
+  // `name.width − name.scrollWidth`, because `scrollWidth` reports the grown
+  // box too — the exact mechanism `measureTabFloor` is documented around, which
+  // makes it the one probe that cannot detect its own failure mode.
+  // 8 = the 6px column gap + 1 rounding + 1 subpixel.
+  expect(
+    ro!.badge!.left - ro!.nameTextRight!,
+    "the RO badge is no longer beside the filename's glyphs — the name span grew past its text",
+  ).toBeLessThanOrEqual(8);
+
+  // And the slack lands after BOTH of them, in the button's auto margin.
+  expect(
+    ro!.close.left - ro!.badge!.right,
+    "no gap before the × on a short read-only name — the slack went somewhere else",
+  ).toBeGreaterThan(20);
+
+  assertNothingSpills(measured);
 });
 
 test("adaptive mode: tabs size to their own name, and long ones still compress", async ({
@@ -474,6 +601,11 @@ test("toggling the setting live re-sizes the strip, stranding no per-tab floor",
   // min-width would still let the tabs agree with one another at the wrong size.
   expect(Math.max(...after.tabs.map((t) => t.wrapper.width))).toBeCloseTo(FLOOR_PX, 0);
   assertNothingSpills(after);
+  // #1736 through the ONE path where it meets a mid-flight DOM: the class flip
+  // and the inline-`min-width` clear land in separate flushes (see the poll
+  // above). Adding this to the two pre-seeded mode tests would be duplication —
+  // they measure the same settled DOM the dedicated tests already do.
+  assertCloseFlush(after);
 });
 
 /**


### PR DESCRIPTION
Fixes #1736.

With **Uniform tab width** on (the settings default), a tab with a short filename
left ~38px of empty space between the close (×) button and the tab's right edge.

## Cause

`.tab-flip.uniform` pins the wrapper to 142px and `.tab-pill` fills it
(`flex: 1 1 auto`, deliberate — otherwise a short name leaves a ragged gap
between slots). But every pill child was `flex-grow: 0` and `justify-content`
sat at its default `flex-start`, so the leftover width parked after the **last**
child — the close button. `assertNothingSpills` could never catch it: nothing
overflowed, it was just wrong.

Adaptive mode is unaffected, because the per-tab measured floor equals the tab's
own content width, so there is no slack to park.

## The fix, and the one that looks identical

`margin-left: auto` on the close button — **not** `flex-grow: 1` on the name span.

The two produce the same pixels. The second silently destroys adaptive mode:
`measureTabFloor` reads the filename's natural width as `name.scrollWidth`,
which reports the span's **box** once it is grown. On the first pass every
wrapper still carries only the base `.tab-flip { min-width: 142px }`, so a grown
span reports whatever is left of that wrapper — and `chrome` is by construction
everything in the pill *except* the name, so `chrome + nameNatural` reconstructs
the wrapper's own width and clamps to 142. That is written back as the tab's
inline floor, and the next pass reconstructs it again. Every adaptive tab
latches at the uniform width — no flicker, no error, the tabs are simply all the
same width.

Two independent reviewers found this before any code was written; it was then
confirmed by mutation test, not by reading.

An auto margin is immune **by construction**, which is why it beat gating the
grow behind a `uniformTabWidth` prop:

- auto margins resolve *after* flex grow/shrink, so at the adaptive floor the
  only free space is `measureTabFloor`'s deliberate 1px rounding allowance and
  the margin resolves to ~1px;
- they count as 0 for intrinsic sizing, so the wrapper's max-content is unchanged;
- a margin is not a child, so it touches neither the gap term nor the chrome sum
  that `measureTabFloor` also reads — which is what ruled out a grow-only spacer
  element, the most self-documenting option on paper.

A gate would have worked too, but a future reader can delete a gate.

## It relocates the whitespace, it does not remove it

Worth stating plainly rather than claiming "the gap is gone". The gap now sits
between the filename (or the RO badge) and the ×. That is the conventional
browser-tab layout, and it keeps the read-only badge beside the name it
describes — which growing the name span would not have done, since the badge
would have been shoved right to sit against the ×. The two reviewers disagreed
on exactly this point; it went the way that keeps the badge with its filename.

## Tests

`tests/e2e/tab-overflow.spec.ts`, and it has to be E2E — happy-dom has no layout
engine, so a unit test could pin the fix's spelling but never its effect.

- **`assertCloseFlush`**, a sibling of the file's existing `assertNothingSpills`:
  for every tab, the × sits within 1px of the pill's **content** edge. Border and
  padding are read off computed style rather than hardcoded, because the active
  pill's border is 1px and every inactive one's is 2px — a hardcoded offset would
  be wrong by exactly the tolerance the assertion needs.
- **The load-bearing one:** `ab.md`'s name span must stay shrink-wrapped. The
  rejected fix *passes* the flushness check, so flushness alone cannot tell the
  two apart. This one fails with the cause in the message.
- **A read-only tab**, added in review. Read-only is a distinct measurement
  regime, not a cosmetic variant: the RO badge is a real child, so it lands in
  `measureTabFloor`'s gap term *and* its chrome sum, and `readOnly` is a tracked
  dep of the floor effect. It is also the second discriminator against the
  rejected fix, and it tests the "keeps the badge beside its filename" claim this
  PR body argues — which nothing tested until it was added.

All of them run in the `check` job (`ci.yml:409`), which is a required status
check — so this is a merge-blocking gate, not an advisory one.

### Three assertions that look like guards and are not

Worth recording, because two of them were written before the one that works, and
each was measured *passing* under the mutant it was meant to catch:

| Written | Why it does not work |
|---|---|
| `badge.left − name.right ≤ gap` | The badge stays glued to the span's right **edge** while that edge travels across the pill. |
| `name.width − name.scrollWidth ≈ 0` | `scrollWidth` reports the grown box too — the exact mechanism `measureTabFloor` is documented around, which makes it the one probe that cannot detect its own failure mode. |
| flushness alone | Identical pixels under the rejected fix, by design. |

What works is a `Range` over the span's contents: the filename's **glyphs**,
not its box.

### Mutation-tested — 3 mutants, 0 survivors

Re-measured against the full 13-test spec after the review additions:

| Mutation | Result |
|---|---|
| M1 — drop `margin-left: auto` | **RED** — 3 failed |
| M2 — the tempting wrong fix: grow the name span instead | **RED** — 5 failed |
| M3 — grow the name span *in addition* to the fix | **RED** — 5 failed |

Under **M2 the flushness assertion passed**, exactly as designed. The shrink-wrap
guard caught it at `Received: 6` against an expected `> 20`, and the read-only
glyph probe fails first at `27.70` against `<= 8` — naming the cause rather than
the symptom.

### Also fixed in review

- **The `<= 8` adaptive bound raced the webfont swap.** SN Pro is self-hosted
  with `font-display: swap`, so first paint measures at *fallback* metrics.
  Production re-floors on `document.fonts.ready`, but between those two moments
  the floors were computed against one font while the names render in another,
  and the residual slack in that window is not bounded by the deliberate 1px
  allowance. That bound has ~1px of measured headroom, and `openFixtureTabs`
  gated nothing — both the selector wait and the count poll are satisfied at
  first paint. It now awaits `document.fonts.ready`. This suite runs in `check`
  with `enforce_admins: true`, so a flake here would block merges for everyone.
  (The cross-platform-font worry that prompted the look is refuted: the faces
  are self-hosted woff2, so metrics are identical on ubuntu and Windows.)
- `assertCloseFlush` added to the live-toggle test — the one path where the
  invariant meets a mid-flight DOM, since the class flip and the inline
  `min-width` clear land in separate flushes.

### Deliberately not added

A uniform→adaptive toggle test: `measureTabFloor` never reads the wrapper's or
the pill's own width, so the measurement is mode-independent by construction —
`ab.md` measures `33.016 / 33` in both modes. A rename-state test: the span is
absent, so the function bails to `TAB_FLOOR_PX` — one regime, not two, and the
residual margin is sub-2px either way. And no loosening of `> 20` or `<= 1`,
which measure `52.80` and `0.00` on the pass side against `6.00` and `0.00`
under the mutant.

## Verification

`typecheck` (1375 files, 0 errors), `typecheck:tests` (e2e config), `biome`, the
tab unit suites (73 passed), and the full `tab-overflow` spec (12 passed).
Visually confirmed in a real Chromium run: every × sits at its own tab's right
edge across six tabs of mixed name length.

## Also in this PR

Comment corrections, all of them drift this work exposed — including one the
branch itself introduced:

- `tab-floor.ts` said **"a grown span measures 142 here"**. It measures ~80px:
  the remainder of the 142px wrapper after the indicator, the gaps and the close
  button. What reaches 142 is `chrome + nameNatural`. The rule and the mechanism
  were right and the arithmetic was wrong — in the file this PR promotes to
  canonical, with `TabItem.svelte` pointing at it twice. A maintainer opening
  devtools would have read ~80, concluded the comment was wrong, and been one
  step from concluding the rule was wrong.
- `TabItem.svelte` said the auto margin "collapses to 0" while the spec said
  "plus the 1px rounding allowance". The spec was right.
- The adaptive test stated its invariant as "the floor **is** chrome + the name's
  natural width" — true for 2 of the 12 fixtures. The other ten clamp to the
  floor and satisfy the same bound by a different mechanism: the span shrinks to
  fill and ellipsizes.
- `tab-floor.ts` said the slack "parks after the last child" — no longer true
  once it lands in an auto margin. Its conclusion (don't derive chrome as
  `pill − name`) is unchanged.
- `openFixtureTabs` said `schemaVersion` "must be the CURRENT one". It seeds 18
  while `CURRENT_SCHEMA_VERSION` is 20; *at most* the current one is the real
  requirement. That comment stopped being true the first time the schema was
  bumped past 18.

The mechanism is now stated **once**, at the `scrollWidth` read in `tab-floor.ts`
that creates the constraint, with pointers from `TabItem.svelte` at both the name
span (where the tempting edit gets made) and the close button. An earlier draft of
this branch stated it in full in three places.

## Follow-up

**#1845** — `measureTabFloor` is coupled to the pill's child structure in three
ways (child count → gap term, non-name child boxes → chrome, the name's box →
`scrollWidth`), each of which breaks silently. Filed rather than fixed here
because hardening only the `scrollWidth` read fixes a third of the problem while
reading as though it fixed all of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFgYiXtE5WQ7qSRUrC3j22
