### PR TITLE
fix(prompts): apply prompt audit updates

### DIFF
--- a/.claude/agents/annotation-model-reviewer.md
+++ b/.claude/agents/annotation-model-reviewer.md
@@ -10,7 +10,7 @@ You are a specialized reviewer for Tandem's annotation data model and lifecycle 
 - Annotations are stored in `Y.Map('annotations')` keyed by annotation ID
 - Each annotation has: `id`, `type` ("highlight"|"comment"|"note"), `range` (flat offsets), optional `relRange` (CRDT-anchored), `status` ("pending"|"accepted"|"dismissed"), `author` ("user"|"claude"|"import"), optional `audience` ("private"|"outbound" — derived by sanitizeAnnotation on read; notes/highlights are always private, comments default to outbound)
 - All annotation creation must produce both flat `range` and CRDT `relRange` via `anchoredRange()`
-- Server-side Y.Map mutations must be wrapped in `doc.transact(() => { ... }, MCP_ORIGIN)` to prevent channel echo
+- Server-side Y.Map mutations must go through an origin-tagging helper from `src/shared/origins.ts` (`withMcp` for MCP tool handlers) — raw `doc.transact(...)` is forbidden anywhere in `src/`, client included (ADR-031, #1482)
 - Notes (`type: "note"`) are user-private per ADR-027 — never exposed to MCP tool responses or channel events
 - The annotations observer in `src/server/events/observers/annotations.ts` skips transactions with `MCP_ORIGIN` and `FILE_SYNC_ORIGIN`, and filters notes structurally (only `type: "comment"` events reach the channel)
 - `sanitizeAnnotation()` in `src/shared/sanitize.ts` normalizes legacy shapes and derives `audience`; note filtering for MCP responses happens in `tandem_getAnnotations`/`tandem_exportAnnotations` in `annotations.ts`
@@ -40,8 +40,8 @@ Read these before reviewing changes:
 - **Exception:** `refreshRange()` updates flat offsets on any annotation (this keeps coordinates fresh, not content).
 
 ### 3. Origin-Tagged Transaction Wrappers (ADR-031)
-- **Rule:** Every Y.Doc write goes through one of the five wrapper helpers in `src/shared/origins.ts` — `withMcp` / `withFileSync` / `withInternal` / `withReload` / `withBrowser`. Raw `doc.transact(...)` is forbidden outside `src/shared/origins.ts` (caught by `.claude/hooks/check-raw-transact.sh`).
-- **Check:** Grep for `.transact(` in `src/server/mcp/`. Every callsite should be a `withX` helper. MCP tool handlers must use `withMcp` (Claude-initiated user intent).
+- **Rule:** Every Y.Doc write goes through one of the six wrapper helpers in `src/shared/origins.ts` — `withMcp` / `withFileSync` / `withInternal` / `withReload` / `withBrowser` / `withModeRelease`. Raw `doc.transact(...)` is forbidden outside `src/shared/origins.ts`. Enforcement is warn-only and PostToolUse-only (`.claude/hooks/check-raw-transact.sh` never sees code no agent edited), so a clean hook run is not evidence — the CI gate is `tests/scripts/audit-origins.test.ts`.
+- **Check:** Grep for `.transact(` across all of `src/`, `.svelte` files included — there is no `src/client` exemption (#1482), and three raw client calls survived for months precisely because sweeps were scoped to the server. Every callsite should be a `withX` helper. MCP tool handlers must use `withMcp` (Claude-initiated user intent). A bare `map.set(...)` is invisible to this grep; the DEV-only `installUntaggedWriteWarning` is its complement.
 - **Skip-set matrix:** channel event queue skips `mcp / file-sync / internal / reload` (only `browser` emits). Durable-sync observer skips `file-sync / internal`. Tombstone observer skips `file-sync / internal`. Picking the wrong helper is a silent bug.
 - **Shared helpers** (e.g. `addReplyToAnnotation`) accept a `wrap: (doc, fn) => void` parameter — caller supplies `withMcp` or `withBrowser`. Verify the helper signature passes the wrapper through to the actual `transact`.
 
@@ -49,8 +49,8 @@ Read these before reviewing changes:
 - **Rule:** Annotations with `type: "note"` must never appear in:
   - MCP tool responses (`tandem_getAnnotations`, `tandem_checkInbox`, `tandem_exportAnnotations`)
   - Channel SSE events (`annotation:created`, `annotation:edited`)
-- **Check:** Verify `tandem_getAnnotations`/`tandem_exportAnnotations` in `src/server/mcp/annotations.ts` filter notes before returning. Verify the annotations observer in `src/server/events/observers/annotations.ts` only emits events for `type: "comment"` (the `if (ann.type !== "comment") continue` guard on line 39).
-- **Also check:** `tandem_editAnnotation` should reject edits to notes (they're user-private, Claude can't modify them).
+- **Check:** Verify `tandem_getAnnotations`/`tandem_exportAnnotations` in `src/server/mcp/annotations.ts` filter notes before returning. Verify the annotations observer in `src/server/events/observers/annotations.ts` only emits events for `type: "comment"` — grep the file for the `ann.type !== "comment"` guard rather than trusting a line number.
+- **Also check the other three write families — a read filter is not a write guard, and covering only the edit path is what let three write paths disagree until #1680.** The guards sit on `editPending`, `transitionPending`, `AnnotationLifecycle.remove` and `AnnotationLifecycle.reply`, and each must run AFTER `sanitizeAnnotation` (a legacy `flag` is only a note once normalized). Two omissions are deliberate, so flagging them is a regression rather than a finding: `removeAnnotationRecord` is unguarded because the browser's Archive calls it directly, and `addUserReply` is unguarded because replying inside one's own note thread is what #1000 permits. The reply guard tests `type === "note"` OR `type === "comment" && audience !== "outbound"` — not `type !== "comment"`, which would make a highlight parent answer `invalid-note` instead of `not-repliable`.
 
 ### 5. Channel Event Origin Filtering (ADR-031)
 - **Rule:** Channel-event observers (in `src/server/events/observers/`) must call `shouldSkipChannel(txn.origin)` and early-return when true. This skips mcp / file-sync / internal / reload, leaving only browser-origin writes to project to channel events.

--- a/.claude/agents/crdt-reviewer.md
+++ b/.claude/agents/crdt-reviewer.md
@@ -21,7 +21,7 @@ Read these before reviewing changes:
 - `src/server/mcp/annotations.ts` — annotation CRUD, captureSnapshot, range validation on write
 - `src/server/file-io/docx-comments.ts` — Word comment import (heading prefix + separator math)
 - `src/client/editor/extensions/annotation.ts` — decoration rendering, buildDecorations fallback logic
-- `docs/architecture.md` (lines 310-389) — coordinate system documentation
+- `docs/architecture.md` → **Coordinate Systems** section — coordinate system documentation
 
 ## Focus Areas
 
@@ -43,7 +43,7 @@ Read these before reviewing changes:
 ### 4. Client-Server Contract
 - **Inverted range detection:** After resolving `relRange`, `from > to` means concurrent edits moved the anchors past each other. This must be detected and logged in both `refreshRange()` (server) and `annotationToPmRange()` (client). Neither should silently accept inverted ranges.
 - **Client fallback path:** `annotationToPmRange()` must prefer `relRange` resolution. When `relRange` fails, fall back to `flatOffsetToPmPos()` and emit `console.warn` so CRDT degradation is visible in browser devtools. Verify the `method` field in the result is set to `'rel'` or `'flat'` correctly.
-- **Transaction origin tagging (ADR-031):** Every Y.Doc write goes through one of `withMcp` / `withFileSync` / `withInternal` / `withReload` / `withBrowser` from `src/shared/origins.ts`. Raw `doc.transact(...)` is forbidden outside the helpers file. MCP tools use `withMcp`; the file-watcher reload path uses `withReload`; server-internal setup writes (file population, tutorial seeding, metadata broadcasts, cleanup-after-failure) use `withInternal`; durable-annotation file-writer echoes use `withFileSync`; browser edits use `withBrowser`. Channel observers skip mcp / file-sync / internal / reload (only browser emits). Picking the wrong helper is a silent bug — see the skip-set matrix in ADR-031.
+- **Transaction origin tagging (ADR-031):** Every Y.Doc write goes through one of `withMcp` / `withFileSync` / `withInternal` / `withReload` / `withBrowser` / `withModeRelease` from `src/shared/origins.ts`. Raw `doc.transact(...)` is forbidden outside the helpers file. MCP tools use `withMcp`; the file-watcher reload path uses `withReload`; server-internal setup writes (file population, tutorial seeding, metadata broadcasts, cleanup-after-failure) use `withInternal`; durable-annotation file-writer echoes use `withFileSync`; browser edits use `withBrowser`. Channel observers skip mcp / file-sync / internal / reload (only browser emits). Picking the wrong helper is a silent bug — see the skip-set matrix in ADR-031.
 
 ## Output Format
 For each finding:
@@ -54,4 +54,4 @@ For each finding:
 - **Proof**: Concrete scenario that triggers the bug (e.g., "Insert text at annotation start boundary, annotation shrinks instead of growing")
 - **Recommendation**: Specific fix
 
-Start by reading `docs/architecture.md` (lines 310-389) and `src/shared/offsets.ts`, then work through each focus area systematically.
+Start by reading the **Coordinate Systems** section of `docs/architecture.md` and `src/shared/offsets.ts`, then work through each focus area systematically.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -14,10 +14,10 @@ You are a security reviewer for Tandem, a collaborative AI-human document editor
 
 ## Existing Mitigations (verify these still work)
 - DNS rebinding protection on `/mcp` routes (via `createMcpExpressApp({ host })`)
-- DNS rebinding protection on `/api` routes (Host-header validation in `apiMiddleware`)
-- CORS on `/api` reflects `http://127.0.0.1:*` origins only (bare `localhost` was narrowed out in PR #637)
+- DNS rebinding protection on `/api` routes: the load-bearing control is `isLoopback(req.socket.remoteAddress)` in `src/server/auth/middleware.ts` — the `Host` header is deliberately never consulted for it, and that is what makes rebinding non-exploitable. `apiMiddleware`'s `isHostAllowed()` check is a second layer, not the primary one; a change that "simplifies" loopback detection onto the Host header is the regression to look for.
+- CORS on `/api` reflects only `127.0.0.1` and `tauri.localhost` origins (plus `TAURI_LINUX_ORIGIN`); bare `localhost` is rejected. Denial is by ABSENCE of `Access-Control-Allow-Origin` — emitting `null` is a grant, not a refusal (#1291).
 - UNC path rejection on Windows (prevents NTLM hash leakage)
-- File extension allowlist: `.md`, `.txt`, `.html`, `.htm`, `.docx`
+- File extension allowlist (`SUPPORTED_EXTENSIONS`, `src/shared/constants.ts`): `.md`, `.markdown`, `.txt`, `.html`, `.htm`, `.docx`
 - File size limit: 50MB
 - Atomic file writes (temp + rename)
 

--- a/.claude/agents/svelte-migration-reviewer.md
+++ b/.claude/agents/svelte-migration-reviewer.md
@@ -115,11 +115,17 @@ You are a specialized reviewer for Svelte 5 reactive patterns in the Tandem code
   ```
 - **Also:** In tests, async `onMount` requires `await new Promise(r => setTimeout(r, 0))` + `tick()` before asserting on state it sets.
 
+### 7. $state Written From a Tiptap Event Handler
+- **Rule:** Never write `$state` synchronously from a Tiptap event handler — bridge through `createCoalescingTick` (`src/client/utils/coalescing-tick.ts`).
+- **Why:** a `$state` write inside an active Svelte reaction throws `state_unsafe_mutation` **in production too**. The error text names only `$derived`/`$inspect`, but a plain `{#if}` block triggers it, so the message misdirects.
+- **Check:** `transaction` subscribers are the exposed ones — the blur transaction carries no doc change while `update` is gated on `docChanged`. `transaction` also fires on every cursor move, which is why the tick coalesces.
+- **Non-finding:** writing state from `update` is the same class with no observed instance. Do not propose migrating handlers onto `transaction`.
+
 ## Output Format
 
 For each finding:
 - **Severity**: Critical / High / Medium / Low / Info
-- **Pattern**: Which focus area (1-6) is violated
+- **Pattern**: Which focus area (1-7) is violated
 - **Location**: file:line
 - **Description**: What the reactive bug is
 - **Proof**: What user-visible behavior breaks (stale UI, crash, infinite loop)

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -12,7 +12,7 @@ Start the Tandem development servers and verify everything is connected.
 - The server MUST be running before Claude Code connects via MCP
 - `freePort()` kills any existing process on :3478/:3479 at startup — you cannot run two instances
 - `freePort()` does NOT cover :5173 — an orphaned Vite from a killed `dev:standalone` survives, and because `vite.config.ts` sets `strictPort: true` the new Vite **exits with an error** rather than falling back to another port. The symptom is a dev server that won't start, not a silently-wrong URL (see step 2)
-- E2E tests (`npm run test:e2e`) will also kill dev servers on those ports
+- E2E tests (`npm run test:e2e`) do NOT touch :3478/:3479 — since #1492 they run on the reserved harness pair in `scripts/test-ports.ts` (Vite 4573, backend 4728/4729), so a suite run and a dev server coexist. What the harness does SIGKILL is anything holding 4728/4729.
 
 ## Steps
 

--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -9,7 +9,7 @@ disable-model-invocation: true
 Run the Playwright end-to-end test suite for Tandem.
 
 ## Ports (#1492)
-The suite runs on **reserved ports** from `scripts/test-ports.ts` — Vite on 4573, backend on 4728 (ws) / 4729 (MCP). The product's 3478/3479 are untouched, so a running Tandem or `dev:server` coexists with an E2E run; you no longer need to quit anything.
+The suite runs on **reserved ports** from `scripts/test-ports.ts` — Vite on 4573, backend on 4728 (ws) / 4729 (MCP). The product's 3478/3479 are untouched, so a running Tandem or `dev:server` coexists with an E2E run — leave it up.
 
 **The reserved pair is *reserved*, not politely refused.** Playwright raises its terse "already used" error only for something answering 200–403 on :4729. Anything else holding the pair — a wedged stale E2E server, a non-HTTP process, or *anything at all* on :4728, which no Playwright check ever probes — is SIGKILLed by the E2E server's own boot (`freePort()`). For a stale E2E server that is desirable self-healing. Two guards still run in `scripts/e2e-guard.ts` (`globalSetup`): a fail-closed identity probe of :4729 (#1483), and a check that the Vite server actually serving the suite carries the harness env — a served client still baked to :3479 would drive the destructive suite into your REAL Tandem through the UI.
 

--- a/.claude/skills/screenshots/SKILL.md
+++ b/.claude/skills/screenshots/SKILL.md
@@ -26,11 +26,9 @@ It brings its own server, so there is **no** `dev:standalone` precondition, and
 it runs against an isolated per-run `TANDEM_APP_DATA_DIR`, so it cannot capture
 the operator's real chat history into a public image.
 
-`scripts/take-screenshots.mjs` no longer exists. It was deleted in the
-post-v0.22.1 documentation overhaul: two pipelines writing the same filenames
-meant whichever ran last decided what the README showed, and for the three shots
-they shared they used different framing and different seed data. Its unique
-recipes were ported into the spec first.
+There is exactly one capture pipeline, and a second one must not be added: two
+pipelines writing the same filenames means whichever ran last decides what the
+README shows, with different framing and seed data per shot.
 
 ## Critical warning — the reserved harness ports
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,6 @@ These WILL break things if violated:
 
 ## Development Workflow
 
-Quality over speed. Claude is an AI — time and effort have no cost. Never abbreviate steps.
-The only goal is the best possible work product.
-
 For every feature or fix: draft a plan (`/plan`), **spawn adversarial agents to review the plan
 from multiple angles before writing any code**, implement, run `/simplify`, then verify (`npm run typecheck` +
 `npm test`; add `npm run test:e2e` for client/integration changes), do whatever manual testing

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -440,7 +440,11 @@ export function registerAnnotationTools(server: McpServer): void {
 
   server.tool(
     "tandem_resolveAnnotation",
-    "Accept or dismiss an annotation",
+    "Move a pending annotation to accepted or dismissed. Accepting one that carries " +
+      "suggestedText applies that text to the document; dismissing leaves the document " +
+      "unchanged. Only pending annotations can transition, and user notes cannot be " +
+      "transitioned at all (ADR-027). The record is kept either way — use " +
+      "tandem_removeAnnotation to delete it.",
     {
       id: z.string().describe("Annotation ID"),
       action: AnnotationActionSchema.describe("Action to take"),
@@ -482,7 +486,10 @@ export function registerAnnotationTools(server: McpServer): void {
 
   server.tool(
     "tandem_removeAnnotation",
-    "Remove an annotation entirely",
+    "Delete an annotation and its whole reply thread permanently. Not the same as " +
+      "tandem_resolveAnnotation, which keeps the record and moves it to accepted/dismissed — " +
+      "prefer resolve unless the annotation should leave no trace. Refuses to remove user notes " +
+      '(type: "note"), which are private per ADR-027. There is no undo.',
     {
       id: z.string().describe("Annotation ID"),
       documentId: z

--- a/src/server/mcp/awareness.ts
+++ b/src/server/mcp/awareness.ts
@@ -238,7 +238,11 @@ export function finalizeClaudeChatMessage(id: string): void {
 export function registerAwarenessTools(server: McpServer): void {
   server.tool(
     "tandem_getActivity",
-    "Check if the user is actively editing and where their cursor is",
+    "Report whether the user is currently typing (`isTyping`), where their cursor and selection " +
+      "are, and which document they are in. Call it before annotating or editing near the " +
+      "user's cursor — annotating text someone is mid-sentence on is disruptive, and the range " +
+      "is likely to move under you. Returns presence only; it does not return document content " +
+      "or pending user messages (use tandem_checkInbox for those).",
     {
       documentId: z
         .string()
@@ -276,7 +280,7 @@ export function registerAwarenessTools(server: McpServer): void {
     "tandem_checkInbox",
     {
       description:
-        "Check for user actions you haven't seen yet — new comments, chat messages, and responses to your annotations. You cannot tell whether real-time push is reaching you, so poll at a steady cadence: every 2-3 tool calls, after completing any task, between steps, and whenever you pause. Items already returned by a previous poll are de-duplicated, so frequent calls are cheap. An item flagged `alreadyPushed` was also emitted as a real-time event — if you recognize it and already responded, don't respond twice. Low token cost — when in doubt, call it.",
+        'Return user actions not yet returned by a previous poll — new comments, chat messages, and replies to your annotations — plus the current collaboration `mode` and `activity`. This is the authoritative delivery path: real-time push cannot be confirmed to have reached a client, so nothing here is suppressed on the strength of a push, and steady polling is the only reliable way to see user activity. Repeat calls de-duplicate against what was already returned, so frequent polling never double-reports. An item carries `alreadyPushed: true` when it was also emitted as a real-time event; that describes the server\'s side only. Does not return user notes (`type: "note"`), which are private per ADR-027.',
       inputSchema: {
         documentId: z
           .string()

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -553,7 +553,13 @@ export function registerDocumentTools(server: McpServer): void {
     "tandem_getTextContent",
     {
       description:
-        "Read document as plain text whose offsets match the annotation coordinate system.",
+        "Read the document as plain text whose character offsets are the coordinate system every " +
+        "range-taking tool uses (tandem_edit, tandem_comment, tandem_resolveRange). This is the " +
+        'read to use before anchoring: the text includes heading prefixes such as "## " and ' +
+        "joins blocks with newlines, so offsets taken from it line up exactly. Pass `section` " +
+        "with a heading's text (case-insensitive) to read just that section. It never returns " +
+        "Markdown, even for .md files — Markdown syntax would shift offsets out of this " +
+        "coordinate system; call tandem_save and read the file if you need real Markdown.",
       inputSchema: {
         section: z.string().optional().describe("Optional heading text to read only that section"),
         documentId: z
@@ -1125,7 +1131,13 @@ export function registerDocumentTools(server: McpServer): void {
 
   server.tool(
     "tandem_save",
-    "Save the current document back to disk",
+    "Write the document's current content back to its file on disk. Tandem snapshots the file's " +
+      "original bytes before its first write each server run, so a save is reversible via " +
+      "tandem_restoreBackup. On .docx this also writes shared comments back as native Word " +
+      "comments and returns `fidelityWarnings` when the export downgraded anything — report those " +
+      "rather than claiming a clean round-trip. If the file changed on disk since it was opened " +
+      "the save is REFUSED and a conflict is reported instead; it is never silently overwritten. " +
+      "Uploaded (upload://) documents have no path, so the save is session-only.",
     {
       documentId: z
         .string()


### PR DESCRIPTION
## Summary
- update reviewer and skill guidance from the prompt audit
- expand MCP tool descriptions with delivery, range, save, and annotation lifecycle contracts
- remove unnecessary effort-maximizing prompt language

## Validation
- npm run typecheck
- npm test -- tests/skill-instruction-contract.test.ts
- pre-push hook: full Vitest suite and cargo test