### PR TITLE
chore(release): cut v0.25.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "Edit and iterate on documents with any MCP-capable AI. Claude is the default and best-supported client today.",
   "author": {
     "name": "Tandem"
@@ -11,14 +11,14 @@
   "mcpServers": {
     "tandem": {
       "command": "npx",
-      "args": ["-y", "tandem-editor@0.24.1", "mcp-stdio"],
+      "args": ["-y", "tandem-editor@0.25.0", "mcp-stdio"],
       "env": {
         "TANDEM_URL": "http://127.0.0.1:3479"
       }
     },
     "tandem-channel": {
       "command": "npx",
-      "args": ["-y", "tandem-editor@0.24.1", "channel"],
+      "args": ["-y", "tandem-editor@0.25.0", "channel"],
       "env": {
         "TANDEM_URL": "http://127.0.0.1:3479"
       }
@@ -28,13 +28,13 @@
     "monitors": [
       {
         "name": "tandem-events",
-        "command": "npx -y tandem-editor@0.24.1 monitor",
+        "command": "npx -y tandem-editor@0.25.0 monitor",
         "description": "Tandem real-time document events (annotations, chat, selections)",
         "when": "on-skill-invoke:tandem:tandem"
       },
       {
         "name": "tandem-events-user-skill",
-        "command": "npx -y tandem-editor@0.24.1 monitor",
+        "command": "npx -y tandem-editor@0.25.0 monitor",
         "description": "Tandem real-time document events (annotations, chat, selections)",
         "when": "on-skill-invoke:tandem"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-09-05
+
 ### Added
 
 - **A Paragraph command in the slash menu, to undo block formatting.** Every other slash command turns plain text into something; there was no way back. Typing `/p` now resets the current block to ordinary body text, lifting it out of a list or a quote in one step — previously you had to toggle off whichever formatting you had applied, and if you had forgotten which it was, hunt for it. It sits first in the menu, which also changes what pressing `Enter` on the unfiltered menu does: it used to insert a Heading 1 you had not asked for, and now does nothing.
@@ -30,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Annotation files left behind by a newer Tandem are now reported.** When a build finds an annotation file written by a later version than itself, it sets that file aside untouched rather than risk mangling it. That is the right behaviour, and it was invisible: the file matched neither of doctor's two filters, so someone who had gone back to an older Tandem got no signal at all that a document's annotations were sitting on disk unread. Doctor now names them, and says that updating brings them back.
 
 - **Accepting a suggestion that came from a Word comment now marks that comment resolved in the `.docx`.** When you open a `.docx`, its reviewer comments come in as personal notes; send one to Claude, take Claude's suggested wording, accept it, and `tandem_applyChanges` writes the edit back as a tracked change. It was supposed to tick the original Word comment off as done in the same pass, and never did — not for some comments, for all of them. Tandem was working out which Word comment a suggestion came from by reading its own internal id, in a shape those ids stopped using four months ago, twelve days after the resolving step was written, so the answer was always "no comment" and the resolving step quietly did nothing. Reopening the file in Word showed every comment still outstanding, including the ones you had just addressed. Tandem now reads the original comment number off the note itself, which is where it has been stored all along.
+
+- **Recover a document when its saved session state is damaged (#1864).** A corrupt Yjs session snapshot could make a document fail to open every time. Tandem now quarantines the bad state, clears partial in-memory recovery safely, and opens the document from disk instead.
+
+- **Complete the Tiptap v3 editor migration (#1865).** Update editor extensions, links, table attributes, and scroll restoration so established editing and collaboration workflows continue to work on the current editor foundation.
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,10 +243,10 @@ Mechanism, ops and failure modes: [docs/licensing-explained.md](docs/licensing-e
 
 ## Status
 
-**Shipped: v0.24.1** (2026-08-23). Release history is [CHANGELOG.md](CHANGELOG.md); remaining
+**Shipped: v0.25.0** (2026-09-05). Release history is [CHANGELOG.md](CHANGELOG.md); remaining
 v1.0 work is [docs/roadmap.md](docs/roadmap.md#active--toward-v10); what the last smoke run
 settled is in [docs/release-smoke-checklist.md](docs/release-smoke-checklist.md#what-the-v0241-run-settled).
-**Do not re-narrate any of them here.** **§1 Windows has now gone two releases unrun**, so
+**Do not re-narrate any of them here.** **§1 Windows has now gone three releases unrun**, so
 #1118's post-update banner — the one whose false-positive reaches every user at once — is
 unverified against a real upgrade rather than merely untested this cycle; tracked with a
 date in #1596.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-editor",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-editor",
-      "version": "0.24.1",
+      "version": "0.25.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@hocuspocus/provider": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-editor",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "Edit and iterate on documents with any MCP-capable AI (Claude by default). Real-time push via the channel shim.",
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6353,7 +6353,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-desktop"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "base64 0.23.1",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-desktop"
-version = "0.24.1"
+version = "0.25.0"
 description = "Collaborative AI-human document editor"
 authors = ["Bryan Kolb"]
 license = "BUSL-1.1"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "identifier": "com.tandem.editor",
   "build": {
     "frontendDist": "../dist/client",


### PR DESCRIPTION
## Summary

- bump every release version surface to v0.25.0
- publish the approved changelog section, including session recovery and the Tiptap v3 migration
- regenerate npm and Cargo lockfiles

## Validation

- npm run typecheck
- npm test -- --run
- npm run lint
- cargo test --manifest-path src-tauri/Cargo.toml