### PR TITLE
fix(release): validate manifest asset URLs

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -879,7 +879,7 @@ jobs:
             const assets = await github.paginate(github.rest.repos.listReleaseAssets, {
               owner, repo, release_id, per_page: 100,
             });
-            const names = new Set(assets.map((a) => a.name));
+            const assetUrls = new Set(assets.map((a) => a.url));
             core.info(`release ${release_id} has ${assets.length} assets`);
 
             const manifest = assets.find((a) => a.name === 'latest.json');
@@ -915,13 +915,16 @@ jobs:
               );
             }
 
-            // Every URL must point at a file actually attached to THIS release.
-            // Catches the split-release case, where a manifest looks complete
-            // but half its artifacts live on a sibling draft.
+            // The updater records GitHub asset API URLs, not browser download
+            // URLs: their final path segment is an asset ID rather than a file
+            // name. Compare against the release's API URLs so this verifies
+            // the intended invariant without rejecting a valid manifest.
+            // This still catches a split release, where a manifest looks
+            // complete but half its artifacts live on a sibling draft.
             const dangling = [];
             for (const [key, p] of Object.entries(json.platforms)) {
-              const file = decodeURIComponent(String(p.url).split('/').pop() ?? '');
-              if (!names.has(file)) dangling.push(`${key} -> ${file}`);
+              const url = String(p.url);
+              if (!assetUrls.has(url)) dangling.push(`${key} -> ${url}`);
               if (!p.signature) dangling.push(`${key} -> missing signature`);
             }
             if (dangling.length) {


### PR DESCRIPTION
## Problem
The v0.25.0 draft release produced a complete, signed latest.json, but erify-release-manifest compared each updater API URL's numeric asset ID with release asset filenames. That caused a false failure and blocked publication.

## Solution
Compare manifest URLs directly with the release assets' API URLs. This retains the split-release guard while validating the URL format Tauri writes.

## Validation
- Exercised the corrected condition against the v0.25.0 draft: all 11 platform entries have signatures and their URLs match assets on release 383431884.
- git diff --check
- Local pre-push suite ran to completion but had two unrelated environment failures: stale dist in 	ests/build/version-baked.test.ts, and a 60-second timeout in 	ests/server/docx-apply.test.ts. GitHub PR CI is the merge gate.

No product code or release artifacts change in this PR.