### PR TITLE
fix(release): publish to npm via trusted publishing

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -191,7 +191,21 @@ prevents them drifting.
    installers + 4 `.sig`, 2 `.app.tar.gz` + 2 `.sig`, 2 dmg, deb/rpm/AppImage
    + sigs).
    Publishing is the npm trigger: `.github/workflows/publish.yml` fires on
-   `release: [published]` and runs `npm publish --provenance`. If macOS
+   `release: [published]` and runs `npm publish --provenance`. It authenticates
+   with **npm Trusted Publishing (OIDC), not a secret** — there is no
+   `NPM_TOKEN` any more; the granular token it replaced lapsed at 90 days and
+   took v0.25.0's publish down after the GitHub release was already public.
+   Three things that gate it live on npmjs.com and are validated only at publish
+   time — repo + workflow filename, the `npm` environment name, and the
+   `npm publish` allowed action (configs created after 2026-09-03 default to
+   `npm stage publish` only). All three fail as an auth-shaped error; the
+   workflow header enumerates them.
+
+   **A failed npm publish cannot be fixed by re-running it.** A `release` event
+   runs the workflow file *from the tag*, so the retry re-executes whatever
+   `publish.yml` the tag carries. Use the `workflow_dispatch` on `publish.yml`
+   from master instead, passing the tag — it resolves the tag to its commit,
+   requires a published release for it, and publishes that tree. If macOS
    notarization 403s on "agreement missing/expired," that is an Apple
    legal-agreement lapse only the Account Holder (Bryan) can clear at
    developer.apple.com / App Store Connect — re-run the failed jobs after he

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,37 @@
 name: Publish to npm
 
+# Authentication is npm Trusted Publishing (OIDC) — there is no NPM_TOKEN. The
+# secret this replaced was a granular write token, which npm caps at 90 days;
+# it lapsed silently and v0.25.0's publish failed with a 404 on PUT after the
+# GitHub release was already public (#1748 item 3).
+#
+# THREE THINGS LIVE ON npmjs.com, NOT HERE, and npm validates none of them when
+# you save them — a mistake in any one surfaces only at publish time, as an
+# auth-shaped error indistinguishable from the dead token above:
+#   1. Repository `bloknayrb/tandem` and workflow filename `publish.yml`.
+#   2. Environment `npm`, matching this job's `environment:`. Leaving it blank
+#      WIDENS access rather than narrowing it: the OIDC claim would then prove
+#      only "this repo, this workflow file", dropping the environment's
+#      protection rules from the check.
+#   3. Allowed action `npm publish`. Configurations created after 2026-09-03
+#      default to `npm stage publish` ONLY, so a fresh config that is not
+#      explicitly widened rejects the publish step below.
+
 on:
   release:
     types: [published]
+  # Recovery path. A `release` event runs the workflow file FROM THE TAG
+  # (measured: run 34007101172 for v0.25.0 has headSha == the tag commit, while
+  # master had already moved on), so a publish that failed under an old
+  # publish.yml can never be retried with a fixed one — which is exactly the
+  # situation this file was written in. A dispatch runs master's copy against a
+  # tag resolved below.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Published release tag to publish to npm (e.g. v0.25.0)"
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -12,16 +41,81 @@ jobs:
       id-token: write
     environment: npm
     steps:
+      # The dispatch input is free text, and `ref:` would accept a branch or a
+      # bare SHA just as happily as a tag — so the input is resolved through the
+      # TAG namespace only, dereferenced to a commit, and required to have a
+      # published (non-draft) release. Without this the recovery path could ship
+      # a tree no release names, and the version check further down would not
+      # catch it: it compares the input against the package.json of whatever was
+      # checked out, so any ref carrying a matching version passes.
+      - name: Resolve dispatched tag
+        id: resolve
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            v[0-9]*) ;;
+            *) echo "refusing '$TAG': expected a v-prefixed release tag" >&2; exit 1 ;;
+          esac
+          ref=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG")
+          sha=$(echo "$ref" | jq -r '.object.sha')
+          if [ "$(echo "$ref" | jq -r '.object.type')" = "tag" ]; then
+            sha=$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$sha" --jq '.object.sha')
+          fi
+          # 404s on a draft, which `set -e` turns into a failure here.
+          draft=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" --jq '.draft')
+          if [ "$draft" != "false" ]; then
+            echo "$TAG has no published release" >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Empty for a `release` event, where GITHUB_REF is already the tag.
+          ref: ${{ steps.resolve.outputs.sha || github.ref }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
-          cache: npm
+          node-version: 24
           registry-url: https://registry.npmjs.org
+          # No dependency cache in the job that publishes: `prepublishOnly`
+          # builds the tree we ship, so a poisoned or stale cache entry would be
+          # restored into it. npm's own trusted-publishing example sets
+          # `package-manager-cache: false` for this reason; omitting `cache:` is
+          # the same thing.
+
+      # Trusted publishing needs npm >= 11.5.1. Node 24 bundles a newer npm
+      # today, but that is the runner image's choice and not ours. Without this
+      # step an older npm ignores OIDC entirely and fails at `npm publish` with
+      # a bare auth error — the same shape as a dead token and as a misconfigured
+      # publisher above, which is the wrong diagnosis for the next person.
+      - name: Require npm >= 11.5.1
+        run: |
+          node -e 'const v=process.argv[1].split(".").map(Number),m=[11,5,1];for(let i=0;i<3;i++){if(v[i]>m[i])process.exit(0);if(v[i]<m[i]){console.error(`npm ${process.argv[1]} is older than 11.5.1, which trusted publishing requires`);process.exit(1);}}' "$(npm --version)"
+
+      # A `release` event fires for a release on ANY tag, and nothing else here
+      # binds the published version to the tag it is named after.
+      - name: Tag and package.json version must agree
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          pkg="v$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$pkg" ]; then
+            echo "tag $TAG does not match package.json $pkg" >&2
+            exit 1
+          fi
 
       - run: npm ci
 
+      # `--provenance` is redundant under trusted publishing — npm generates the
+      # attestation either way — but it is kept because it is the fail-closed
+      # form: with the flag, a publish that cannot produce provenance errors
+      # instead of silently shipping without it. It has always been driven by
+      # the same `id-token: write` OIDC token, so it is orthogonal to the auth
+      # change.
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/plans/2026-09-06-open-issues-sweep.md
+++ b/docs/plans/2026-09-06-open-issues-sweep.md
@@ -242,7 +242,7 @@ literal in `tests/skill-instruction-contract.test.ts` moves with it). `Hooks arm
 | 6 | H the flip | #1788 → #1785 → #1793+#1786 (+#1825 infra section, same ledger row; code only, **no deploy**) → #1789 #1819 — three PRs in the ledger | — | — | — | — | planned-not-started | |
 | 6 | CI-trust | #1862 #1673 | — | — | — | — | planned-not-started | |
 | 7 | G8 docx comments | #1693 | — | — | — | — | planned-not-started | |
-| 7 | I-release | #1748 (+G) #1856 #1830 #1831 #1832 (fix halves; policy halves to Bryan) + #1825 CI section | — | — | — | — | planned-not-started | |
+| 7 | I-release | #1748 (+G) #1856 #1830 #1831 #1832 (fix halves; policy halves to Bryan) + #1825 CI section | — | — | — | — | planned-not-started | **#1748 item 3 is already done** — the `NPM_TOKEN` expired mid-release and `publish.yml` moved to npm Trusted Publishing out of band on 2026-09-06. Items 1, 2 and 4 remain. |
 | 7 | E2-rust | #1762 #1808 #1809 #1810 + #1455 pointer (Refs) + #1825 Tauri section | — | — | — | — | planned-not-started | |
 | 7 | K-client | #1824 remainder #1713 #1724 #1727-split (Refs) #1709 #1544 | — | — | — | — | planned-not-started | |
 | 7 | K-tests | #1825 Tests remainder #1855 #1861 #1734 (e2e) #1584 #1599 checkboxes (Refs) | — | — | — | — | planned-not-started | |

--- a/docs/reviews/2026-09-02-v1-review/tracks/I-supply-chain.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/I-supply-chain.md
@@ -59,6 +59,11 @@ reading rather than a formality.
   secret-bearing set is also **three, not two**: `publish.yml` holds `NPM_TOKEN` *and*
   `id-token: write`, so a moved `setup-node` tag there mints a provenance-attested malicious npm
   package.
+  *Appended 2026-09-06:* `publish.yml` no longer holds `NPM_TOKEN` — that token expired and the
+  workflow moved to npm Trusted Publishing (OIDC), closing #1748 item 3. **The pin argument is
+  unchanged in force**: the job still carries `id-token: write`, and under trusted publishing that
+  token now authenticates the publish as well as signing provenance, so a moved `setup-node` tag
+  there still mints a malicious package. One fewer credential to steal, the same reason to pin.
 - **The sidecar says 22.23.2 and the drift check is green** — met, plus two things #1747 did not
   ask for. The expected archive hashes are now committed (the fetched `SHASUMS256.txt` comes from
   the same host and CDN as the tarball, so it detects transport corruption and nothing else), and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -375,6 +375,7 @@ Future hardening (not blocking release):
 - Windows installer smoke test — NSIS covered per-release by [release-smoke-checklist.md](release-smoke-checklist.md); the MSI artifact (`targets: "all"` also builds one) is not covered
 - ~~Node.js 20 → 24 GitHub Actions migration (CI-wide, all workflow files) — deadline June 2, 2026~~ **Done 2026-06-11.** This was about the GitHub Actions *runtime* (JS actions), not the project's Node: GitHub forced the node24 default on 2026-06-02 and removes node20 entirely 2026-09-16. First-party actions bumped to node24 majors (`checkout@v6`, `setup-node@v6`, `upload-artifact@v7`) across all five workflow files; `node-version: 22` is unchanged and correct (matches `engines` + the bundled sidecar Node).
   - *Appended 2026-09-02, not rewritten — the line above records what was done then and should keep saying so.* The current tree runs `upload-artifact@v6`, not `@v7`: v7 was never adopted. Every action in all five workflows is now SHA-pinned rather than tag-pinned (#1745), so the majors named above are what the trailing comment on each pin records, not what the ref resolves.
+  - *Appended 2026-09-06.* `node-version: 22` is no longer unanimous: `publish.yml` runs **24**, because npm Trusted Publishing requires npm ≥ 11.5.1 and Node ≥ 22.14, and 24 is what npm's own example uses. The other four workflows are unchanged at 22.
 
 ### Future Tauri Enhancements
 


### PR DESCRIPTION
## Why

v0.25.0's npm publish failed with `404 Not Found - PUT https://registry.npmjs.org/tandem-editor` after the GitHub release was already public. The `NPM_TOKEN` was a granular write token, which npm caps at 90 days; it was set 2026-05-26 and v0.24.1 published 2026-08-23, one day inside that window. This is [#1748](https://github.com/bloknayrb/tandem/issues/1748) item 3 firing exactly as the pre-v1.0 review described it, down to the consequence — the npm half silently keeps resolving the previous version for the plugin's `npx -y tandem-editor@<pin>` specs and `tandem setup`.

Rotating the token restarts the same clock. OIDC removes the credential.

## What changed

`.github/workflows/publish.yml`:

- **Trusted publishing.** No `NODE_AUTH_TOKEN`, no `NPM_TOKEN`. `permissions` is unchanged — `id-token: write` was already there for provenance.
- **`workflow_dispatch` recovery path.** A `release` event runs the workflow file *from the tag*: the failed run for v0.25.0 has `headSha == 2525eb2`, the tag commit, while master had already moved to the #1876 merge. Re-running it can only re-execute the broken file, so there was no way to retry this release under a fixed workflow. The dispatch runs master's copy against a tag.
- **The dispatched tag is resolved, not trusted.** Adversarial review found the first draft fed the free-text input straight to `actions/checkout`'s `ref:`, which accepts a branch or a bare SHA, and that the tag/`package.json` check could not catch it — that check compares the input against whatever was checked out, so any ref carrying a matching version passes. The input is now shape-checked, resolved through `git/ref/tags`, dereferenced from the annotated-tag object to its commit, and required to have a published (non-draft) release. Dry-run against the real API: `v0.25.0` resolves to `2525eb2c…`, matching `git rev-list -n1 v0.25.0`; `master` and a `v0.25` prefix both 404.
- **`--provenance` kept** even though trusted publishing generates the attestation without it. With the flag, a publish that cannot produce provenance fails rather than silently shipping without it. It has always been driven by the same OIDC token, so it is orthogonal to the auth change.
- **Node 22 → 24, and npm ≥ 11.5.1 asserted.** Trusted publishing requires it. Node 24 bundles a new enough npm today, but that is the runner image's choice; without the assertion an older npm ignores OIDC and fails with a bare auth error — the same shape as a dead token, which is the wrong diagnosis for the next reader.
- **Tag and `package.json` version must agree.** The `release` trigger fires for a release on any tag and nothing bound the published version to it. Partially covers the `v*`-guard Low in #1825.
- **No dependency cache in the publish job.** `prepublishOnly` builds the tree we ship, so a stale or poisoned cache entry would be restored into it. Matches npm's own trusted-publishing example.

Docs: the release skill's step 7 (how auth works now, the three npmjs.com-side gates, and that a failed publish must be retried by dispatch rather than re-run), the roadmap's `node-version: 22` claim, the supply-chain track's "`publish.yml` holds `NPM_TOKEN`" line, and the open-issues sweep ledger so wave 7 does not redo item 3.

## Bryan has to do one thing before this can publish anything

Create the trusted publisher at npmjs.com → `tandem-editor` → Settings → Trusted Publisher, with **repository `bloknayrb/tandem`**, **workflow filename `publish.yml`**, **environment `npm`**, and **the `npm publish` action explicitly allowed**.

All three matter and npm validates none of them when you save:

- Leaving the environment blank *widens* access rather than narrowing it — the OIDC claim would then prove only "this repo, this workflow file", dropping the `npm` environment's protection rules from the check.
- Configurations created after 2026-09-03 default to permitting `npm stage publish` **only**. This workflow runs `npm publish`, so an unwidened config rejects it.

A mistake in any of them surfaces at publish time as an auth-shaped error indistinguishable from the dead token. The workflow header enumerates them for that reason.

## Verification

- `npx vitest run tests/scripts/workflow-action-pin.test.ts` — 25 passed. Action pins and the allowlist are untouched; the two `uses:` SHAs are byte-identical.
- `wrkflw validate` — all five workflows valid.
- Full pre-push suite green: biome, 10,525 vitest tests, `cargo test`.
- The tag-resolution and npm-version-assertion shell was dry-run locally against the real GitHub API and against `11.6.2` / `11.5.1` / `11.5.0` / `10.9.4`.

**Not verified, and cannot be from here:** the publish itself. `publish.yml` runs only on a published release or a dispatch, so no PR-time CI reaches any of this, and trusted publishing had a real `setup-node` dummy-token bug (actions/setup-node#1440) fixed only in v7.0.0 — which is the SHA pinned here, so the fix is present, but the first live dispatch should be watched rather than assumed green.

## Deliberately not done

- The `docs/reviews/…/areas/ci-build.md` finding row is left as written. It records what the review found on 2026-09-02; the issue carries state.
- #1748 items 1 (RC tags auto-updating every install), 2 (Test before Build) and 4 (inert CodeQL config) are untouched and stay open.
- `CHANGELOG.md:1439` already claims v0.2.12 shipped OIDC trusted publishing, which was not true then and is a pre-existing error, not one this PR introduces.

Refs #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKUqbXNoaBcyF5ExjcdrB
