### PR TITLE
test: make stdio and docx-apply timeouts legible (#1674)

### DIFF
--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
@@ -1,17 +1,18 @@
-# G2 — #1672 `docx-apply.test.ts`'s ~36 s relocating cost is gone; the comment that sized its ceiling is not
+# G2 — #1672 `docx-apply.test.ts`'s ~36 s relocating cost is gone; the comments that sized its ceiling are not
 
-Branch `fix/test-timing-1674`. Closes #1672. Non-review issue: no `areas/*.md` row, no named
-experiment, no `refuted.md` entry — the ledger row is
-`docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test timing"). Probe:
-`npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
+Branch `fix/test-timing-1674` — named for the group's implementation-order first issue (#1674);
+the ledger row lists "#1672 #1699 #1674", so branch and row reconcile through that clause.
+Closes #1672. Non-review issue: no `areas/*.md` row, no named experiment, no `refuted.md` entry —
+the ledger row is `docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test
+timing"). Probe: `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
 
 ## Problem
 
 #1672 reports a ~36 s one-time cost inside `tests/server/docx-apply.test.ts` that **moves
-between specs**, measured against `REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000, 300_000)`
-(`:55`) whose comment (`:42-54`) states its premise as "measured at ~21s on a dev machine". The
-issue's preferred remedy is to pay the cost once in a `beforeAll`; its fallback (option 3) is to
-record the real measured range in that comment.
+between specs**, measured against `REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000, 300_000)` (`:55`)
+whose comment (`:44-54`) states its premise as "measured at ~21s on a dev machine". The issue's
+preferred remedy is to pay the cost once in a `beforeAll`; its fallback (option 3) is to record
+the real measured range in that comment.
 
 **The premise no longer holds, and the owner's own second comment on #1672 is why.** The
 contention was traced to a leaked `claude-agent-acp@0.59.0` tree holding 30 abandoned sessions
@@ -20,44 +21,58 @@ green with no code change. That comment is explicit that this does not retire th
 60 s ceiling sized against a ~21 s measurement is a bad check whether or not a leak was present"
 — so the finding survives as a *legibility* defect, not a cost defect.
 
-Re-measured on this box, 2026-09-06, `docx-apply.test.ts` alone:
+Re-measured on this box, 2026-09-06 (`--reporter=verbose`, 53 passed, `Duration 3.73s`):
 
 | | |
 |---|---|
-| whole file | **4.14 s**, 53 passed |
-| slowest specs | 620 ms and 617 ms — the two `#1749` watcher-reload specs, whose cost is a real `fs.watch` debounce they deliberately wait on |
-| every spec #1672 and #1699 name as slow | `takes a pre-overwrite snapshot` **8 ms**; `keeps an extensionless backupPath absolute` **18 ms**; `marks the imported Word comment done` **20 ms**; `refuses a source file deleted mid-apply` **4 ms** |
+| whole file | **~3–4 s**, 53 passed (`Duration 3.73s`, tests 1.38 s) |
+| the two `#1749` watcher-reload specs | 621 ms and 520 ms — a real `fs.watch` debounce they deliberately wait on, not warm-up |
+| the other **nine** specs carrying `REAL_APPLY_TIMEOUT_MS` | 4–23 ms |
+| `reports a source file deleted mid-apply as SOURCE_MISSING, not an fs crash` | 4 ms — and it does **not** carry the ceiling; it runs on the project 15 s default |
 
 So **there is no ~36 s cost to relocate and none to pay once**. A `beforeAll` warm-up would
-attribute ~19 ms to setup — option 1 buys nothing, and adds a hook to a file that does not need
+attribute ~20 ms to setup — option 1 buys nothing and adds a hook to a file that does not need
 one. What is left is option 3, and it is the whole fix.
 
 ## Fix
 
-One block, `tests/server/docx-apply.test.ts:42-54` — the doc comment above
-`REAL_APPLY_TIMEOUT_MS`. **`const REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000, 300_000)` is
-unchanged, and no per-`it` `REAL_APPLY_TIMEOUT_MS` argument is removed** (group policy: do not
-raise ceilings, do not delete the per-spec timeouts wholesale). Rewrite the comment to carry:
+**Two comment blocks, not one** — the file carries its timing rationale in two places and both
+hold the refuted premises, so editing only the first ships two contradictory diagnoses in one
+file, which defeats the only deliverable. **`const REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000,
+300_000)` is unchanged, and no per-`it` `REAL_APPLY_TIMEOUT_MS` argument is removed** (group
+policy: do not raise ceilings, do not delete the per-spec timeouts wholesale). Division of labour
+between the blocks, stated so they cannot drift apart again:
 
-- **The dated measurement replacing the ~21 s premise**: whole file 4.14 s / 53 specs on
-  2026-09-06; the carrying specs at 4–20 ms; the two `#1749` watcher-reload specs at ~620 ms and
-  why (a real debounce, not a warm-up). Keep the existing and still-correct sentences: duration
-  is not the property these specs assert, and `timeoutMs` exists because an explicit second
-  argument to `it` beats `--testTimeout`.
-- **What a red here means**, which is the "legible failure" half of #1672 and #1699. Vitest's
-  message is `Test timed out in 60000ms` (`300000` under `TANDEM_COVERAGE=1`) under the spec's
-  own name — neither literal appears in the file, so the comment must name both so the number in
-  the log is greppable. The awaited phase is unambiguous per spec: every carrying spec awaits
-  exactly one `applyChangesCore(...)` plus cheap `fsp` calls, and the one that also waits on the
-  watcher (`:1141-1146`) does so under its own `vi.waitFor({ timeout: 20_000 })`, which fails
-  with its own assertion instead. So: a bare `Test timed out` here is the apply; a `vi.waitFor`
-  failure is the reload.
-- **That a red is the machine, not the code**, with the #1672 evidence named: the observed
-  ~36 s was an unrelated leaked process tree, and the file measures 4.14 s at rest — so the
-  response is to look at the box, not to raise this number.
-- Keep the existing negative control sentence verbatim (set `REAL_APPLY_TIMEOUT_MS` to 1 and
-  every carrying spec fails naming that value). It is the only observation here that can come
-  back negative, and it is what stops the ceiling being decorative.
+**Block A — `tests/server/docx-apply.test.ts:44-54`, the doc comment above the constant.** Owns
+the *sizing* of the number. Rewrite to carry:
+
+- **The dated measurement replacing the ~21 s premise**: 2026-09-06, whole file ~3–4 s / 53 specs
+  (`Duration 3.73s` on this box); nine of the eleven carrying specs at 4–23 ms; the two `#1749`
+  watcher-reload specs at ~0.5–0.7 s and why. Keep the still-correct sentences: duration is not
+  the property these specs assert, and `timeoutMs` exists because an explicit second argument to
+  `it` beats `--testTimeout`.
+- **What a red here means.** Vitest prints `Test timed out in 60000ms` (`300000` under
+  `TANDEM_COVERAGE=1`) under the spec's own name. **Say that the greppable literal is the
+  un-underscored `60000` vitest prints, not the `60_000` in this file** — `60_000` does appear
+  three times (`:1066`, `:1095`, `:1130`) as unrelated mtime arithmetic, so "neither literal
+  appears" would be wrong.
+- **Which phase timed out.** Nine carrying specs await exactly one `applyChangesCore(...)` plus
+  cheap `fsp` calls. The **two** that also wait on the watcher — `:1111` (clean doc) and `:1159`
+  (DIRTY doc), both `#1749` — do so under their own `vi.waitFor({ timeout: 20_000, interval: 100 })`
+  (`:1145`, `:1179`), which fails with its own assertion. So: a bare `Test timed out in 60000ms`
+  is the apply; a `vi.waitFor` failure is the reload.
+- **That a red is the machine, not the code**, with the #1672 evidence named: the observed ~36 s
+  was an unrelated leaked process tree, and the file measures ~3–4 s at rest — so the response is
+  to look at the box, not to raise this number.
+
+**Block B — `tests/server/docx-apply.test.ts:1019-1043`, the "EVERY test in this block" comment.**
+Owns the *membership rule* and the negative control. Keep verbatim: the #1617 lesson ("name the
+SET that does the expensive thing, never the members that happened to trip") and the negative
+control ("set `REAL_APPLY_TIMEOUT_MS` to 1 and every spec carrying it fails naming that value").
+**Replace** its two refuted premises — "measured in isolation at 1977ms and 463ms against 20-24ms
+for the refusals" and "a 7.6x slowdown crosses the ceiling, and it did: three of four full-suite
+runs on one branch failed here" — with a one-line pointer to Block A's dated measurement. The
+negative control ends up in **exactly one place, Block B**; Block A must not duplicate it.
 
 **Rules that bite.** Do **not** introduce `expectWithinMs` into this file:
 `tests/scripts/coverage-manifest-wiring.test.ts:226-270` requires
@@ -65,7 +80,7 @@ raise ceilings, do not delete the per-spec timeouts wholesale). Rewrite the comm
 (`scripts/ci/coverage-manifest.mjs:122-126`), which does not list `docx-apply.test.ts`; adding a
 call without editing that list turns `check` red, and editing it would be adding a mechanism this
 group is not adding. Never set `TANDEM_COVERAGE=1`. No `src/` change, so Critical Rules 1–9 are
-not engaged; `timeoutMs` stays imported (`:41`).
+not engaged; `timeoutMs` stays imported (`:42`).
 
 ## Tests
 
@@ -74,22 +89,29 @@ test could assert about this change is a wall-clock duration, and both #1672 and
 say that a wall-clock bound in a shared pool measures the machine. Adding one would re-create the
 defect under a new name, and this group is forbidden sweep tests, drift guards and frozen lists.
 
-What is run and recorded in the PR body instead:
+**Nothing in "Done when" is machine-checked, and that is by design — so the reviewer's job is
+explicit**: diff the pasted verbose table against the numbers written into Blocks A and B line by
+line, including the run's `Duration` and `Tests N passed` footer so the sample is identifiable.
+Quote every spec title **verbatim** from the run (paste-able into a `-t` filter); a paraphrased
+title is un-greppable, which is the failure mode this change exists to remove.
 
-- `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose` — the per-spec table above,
-  pasted, so the comment's numbers have a tracked source. *Discriminates* the fix from a
-  rewritten comment that invents numbers.
+What is run and recorded in the PR body:
+
+- `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose` — the full per-spec table
+  with its footer. *Discriminates* the fix from a rewritten comment that invents numbers.
 - The existing negative control, executed once: set `REAL_APPLY_TIMEOUT_MS` to `1`, confirm every
   spec carrying it fails naming `1`, revert. *Kills* the reading that the ceiling is ignored and
-  the comment therefore describes nothing.
+  the comments therefore describe nothing.
 - The full suite via the pre-push hook, which is where a genuine regression in these 53 specs
   would surface.
 
 ## Done when
 
-The comment above `REAL_APPLY_TIMEOUT_MS` states the 2026-09-06 measurement, what a red means and
-which literal to grep; the constant and every per-`it` timeout are byte-identical; the verbose
-table and the negative-control result are in the PR body; suite green.
+Block A (`:44-54`) states the 2026-09-06 measurement, which literal to grep and which phase a red
+names; Block B (`:1019-1043`) keeps the #1617 rule and the negative control with its 1977ms/463ms
+and 7.6x premises replaced by a pointer to Block A; the negative control appears once; the
+constant and every per-`it` timeout are byte-identical; the verbose table with its footer and the
+negative-control result are in the PR body; suite green.
 
 ## Not in scope
 
@@ -101,8 +123,39 @@ is not in this group's issue set. `tests/cli/mcp-stdio.test.ts` (spec G2-1674). 
 
 ## Bryan
 
-Both this issue and #1699 are, on today's measurement, **closeable with the measurement rather
-than fixable**: the cost they describe is not present, and its cause was an unrelated leaked
-process tree that you diagnosed yourself in #1672's second comment. The legibility change above
-ships either way. The call to close them (rather than leave them open awaiting another
-contended run) is yours.
+On today's measurement #1672 and #1699 are **closeable with the measurement rather than fixable**:
+the cost they describe is not present, and its cause was an unrelated leaked process tree you
+diagnosed yourself in #1672's second comment. **This spec owns that call rather than deferring
+it** — the PR closes both with the measurement as the reason, and reopening is the escape hatch
+if a contended run ever reproduces the ~36 s. Flag it if you would rather they stayed open.
+
+## Review corrections (round 1)
+
+**Adopted.**
+
+- *Blocking* — the edit now covers the **second** timing block at `:1019-1043`, which carried the
+  "1977ms and 463ms" and "7.6x / three of four full-suite runs" premises the change exists to
+  retire and would otherwise have stood next to its own refutation. Blocks A and B have an
+  explicit division of labour, and the negative control lives in exactly one of them (B, where it
+  already is) — the previous text told the builder to keep it "verbatim" in a block that does not
+  contain it, which would have duplicated it.
+- *Blocking* / *non-blocking* — **two** specs wait on the watcher, not one: `:1111` and `:1159`,
+  with `vi.waitFor` at `:1145` and `:1179`. Both named.
+- *Non-blocking* — `refuses a source file deleted mid-apply` was quoted by a title that does not
+  exist and listed as a carrier. Corrected to its verbatim title and marked as running on the 15 s
+  default; the Tests section now requires verbatim titles throughout.
+- *Non-blocking* — edit range corrected to `:44-54` (`:42` is the `timeoutMs` import, `:55` the
+  constant), so a literal rewrite cannot delete the import.
+- *Non-blocking* — measurement rewritten as a dated band from a fresh run in this worktree (53
+  passed, `Duration 3.73s`, watcher specs 621/520 ms, other carriers 4–23 ms) rather than
+  two-significant-figure per-spec numbers that did not reproduce.
+- *Non-blocking* — "neither literal appears in the file" corrected: `60_000` appears three times
+  as mtime arithmetic; the greppable literal is vitest's un-underscored `60000`.
+- *Non-blocking* — the review-only nature of the change is stated plainly, with the reviewer's
+  diff-the-table job and the footer requirement.
+- *Non-blocking* — `Closes` vs the Bryan section: the spec now **owns the close** (the group's
+  ledger row lists #1672 among its `closes`), with reopen as the escape hatch, instead of
+  shipping a closing keyword and a "the call is yours" paragraph together.
+- *Non-blocking* — branch-name clause added.
+
+**Not adopted.** None.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
@@ -2,9 +2,11 @@
 
 Branch `fix/test-timing-1674` — named for the group's implementation-order first issue (#1674);
 the ledger row lists "#1672 #1699 #1674", so branch and row reconcile through that clause.
-Closes #1672. Non-review issue: no `areas/*.md` row, no named experiment, no `refuted.md` entry —
-the ledger row is `docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test
-timing"). Probe: `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
+Closes #1672 — the group's args set `closes: true` explicitly, overriding the sweep contract's
+default of `false` for a spec with a non-empty "Not in scope". Non-review issue: no `areas/*.md`
+row, no named experiment, no `refuted.md` entry — the ledger row is
+`docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test timing"). Probe:
+`npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
 
 ## Problem
 
@@ -21,14 +23,21 @@ green with no code change. That comment is explicit that this does not retire th
 60 s ceiling sized against a ~21 s measurement is a bad check whether or not a leak was present"
 — so the finding survives as a *legibility* defect, not a cost defect.
 
-Re-measured on this box, 2026-09-06 (`--reporter=verbose`, 53 passed, `Duration 3.73s`):
+Re-measured on this box, 2026-09-06, **single-file `vitest run --reporter=verbose`, not under
+full-suite parallelism** (53 passed, `Duration 3.72s`, tests 1.37 s):
 
 | | |
 |---|---|
-| whole file | **~3–4 s**, 53 passed (`Duration 3.73s`, tests 1.38 s) |
-| the two `#1749` watcher-reload specs | 621 ms and 520 ms — a real `fs.watch` debounce they deliberately wait on, not warm-up |
-| the other **nine** specs carrying `REAL_APPLY_TIMEOUT_MS` | 4–23 ms |
-| `reports a source file deleted mid-apply as SOURCE_MISSING, not an fs crash` | 4 ms — and it does **not** carry the ceiling; it runs on the project 15 s default |
+| whole file | **~3–4 s**, 53 specs |
+| the two `#1749` watcher-reload specs | **~0.5–0.7 s** — a real `fs.watch` debounce they deliberately wait on, not warm-up |
+| the other **nine** specs carrying `REAL_APPLY_TIMEOUT_MS` | **single-digit to low-tens of ms** (4–25 ms across samples) |
+| `reports a source file deleted mid-apply as SOURCE_MISSING, not an fs crash` | ~3–4 ms — and it does **not** carry the ceiling; it runs on the project 15 s default |
+
+**Bands, not point values, and that is deliberate**: repeated runs on this same box move
+individual specs by ~2x (e.g. one sample gives the four #1699-named specs at 15–21 ms, another at
+6–11 ms) while the bands and the file total reproduce exactly. Writing a single-run per-spec
+millisecond figure into a tracked comment is the same construction as the premises being retired
+(`:45` "~21s on a dev machine", `:1021-1022` "1977ms and 463ms") and would go stale the same way.
 
 So **there is no ~36 s cost to relocate and none to pay once**. A `beforeAll` warm-up would
 attribute ~20 ms to setup — option 1 buys nothing and adds a hook to a file that does not need
@@ -47,23 +56,36 @@ between the blocks, stated so they cannot drift apart again:
 the *sizing* of the number. Rewrite to carry:
 
 - **The dated measurement replacing the ~21 s premise**: 2026-09-06, whole file ~3–4 s / 53 specs
-  (`Duration 3.73s` on this box); nine of the eleven carrying specs at 4–23 ms; the two `#1749`
-  watcher-reload specs at ~0.5–0.7 s and why. Keep the still-correct sentences: duration is not
-  the property these specs assert, and `timeoutMs` exists because an explicit second argument to
-  `it` beats `--testTimeout`.
+  — stated as a **single-file `vitest run`, not under full-suite parallelism** — with nine of the
+  eleven carrying specs in the single-digit-to-low-tens-of-ms band and the two `#1749`
+  watcher-reload specs at ~0.5–0.7 s, and why. **Bands, never per-spec point values** (see
+  Problem). Keep the still-correct sentences: duration is not the property these specs assert, and
+  `timeoutMs` exists because an explicit second argument to `it` beats `--testTimeout`.
+- **#1699's four named specs, quoted verbatim, as members of the fast band** — `keeps an
+  extensionless backupPath absolute instead of resolving it against cwd`, `marks the imported Word
+  comment done after its promoted suggestion is applied`, `does not refuse on mtime drift within
+  the tolerance`, `takes a pre-overwrite snapshot, not just the sidecar backup` — so the next
+  reader of a red does not repeat the "which spec got slow" bisect. This bullet is what satisfies
+  G2-1699's Done-when; omitting it ships a comment that fails that spec.
 - **What a red here means.** Vitest prints `Test timed out in 60000ms` (`300000` under
   `TANDEM_COVERAGE=1`) under the spec's own name. **Say that the greppable literal is the
   un-underscored `60000` vitest prints, not the `60_000` in this file** — `60_000` does appear
   three times (`:1066`, `:1095`, `:1130`) as unrelated mtime arithmetic, so "neither literal
   appears" would be wrong.
 - **Which phase timed out.** Nine carrying specs await exactly one `applyChangesCore(...)` plus
-  cheap `fsp` calls. The **two** that also wait on the watcher — `:1111` (clean doc) and `:1159`
-  (DIRTY doc), both `#1749` — do so under their own `vi.waitFor({ timeout: 20_000, interval: 100 })`
-  (`:1145`, `:1179`), which fails with its own assertion. So: a bare `Test timed out in 60000ms`
-  is the apply; a `vi.waitFor` failure is the reload.
-- **That a red is the machine, not the code**, with the #1672 evidence named: the observed ~36 s
-  was an unrelated leaked process tree, and the file measures ~3–4 s at rest — so the response is
-  to look at the box, not to raise this number.
+  cheap `fsp` calls. The **two** that also wait on the watcher — `the watcher reload that
+  completes an apply finally lands (#1749) — clean doc` (`it(` at `:1111`) and `the watcher reload
+  that completes an apply flags a conflict on a DIRTY doc (#1749)` (`it(` at `:1159`) — do so under
+  their own `vi.waitFor(…)` at `:1141` and `:1175` (options `{ timeout: 20_000, interval: 100 }` at
+  `:1145`/`:1179`), which fails with its own assertion. So: a bare `Test timed out in 60000ms` is
+  the apply; a `vi.waitFor` failure is the reload. **Name these two by their verbatim titles in the
+  shipped comment, not by line number** — the comment lives in the same file, so its own line
+  citations invalidate on the next edit.
+- **What a red is, and what it is not.** At single-digit-to-low-tens of ms against a 60 s ceiling,
+  a red here **cannot be gradual growth — it is a HANG or a starved machine.** Check first for a
+  never-settling `await` or an unreleased lock in the apply (this file drives `wireFileWatcher` /
+  `unwatchFile` at `:1135`, `:1152`); the #1672 precedent — a leaked third-party process tree —
+  is the machine case. **Raising this number is not the response to either.**
 
 **Block B — `tests/server/docx-apply.test.ts:1019-1043`, the "EVERY test in this block" comment.**
 Owns the *membership rule* and the negative control. Keep verbatim: the #1617 lesson ("name the
@@ -71,8 +93,11 @@ SET that does the expensive thing, never the members that happened to trip") and
 control ("set `REAL_APPLY_TIMEOUT_MS` to 1 and every spec carrying it fails naming that value").
 **Replace** its two refuted premises — "measured in isolation at 1977ms and 463ms against 20-24ms
 for the refusals" and "a 7.6x slowdown crosses the ceiling, and it did: three of four full-suite
-runs on one branch failed here" — with a one-line pointer to Block A's dated measurement. The
-negative control ends up in **exactly one place, Block B**; Block A must not duplicate it.
+runs on one branch failed here" — with a one-line pointer to Block A's dated measurement **plus a
+clause attributing the retirement of the 7.6x premise to #1672's leaked-process-tree evidence, not
+to the at-rest measurement**: the premise was a full-suite-parallelism claim and an at-rest
+single-file run does not by itself refute it. The negative control ends up in **exactly one place,
+Block B**; Block A must not duplicate it.
 
 **Rules that bite.** Do **not** introduce `expectWithinMs` into this file:
 `tests/scripts/coverage-manifest-wiring.test.ts:226-270` requires
@@ -90,10 +115,11 @@ say that a wall-clock bound in a shared pool measures the machine. Adding one wo
 defect under a new name, and this group is forbidden sweep tests, drift guards and frozen lists.
 
 **Nothing in "Done when" is machine-checked, and that is by design — so the reviewer's job is
-explicit**: diff the pasted verbose table against the numbers written into Blocks A and B line by
-line, including the run's `Duration` and `Tests N passed` footer so the sample is identifiable.
-Quote every spec title **verbatim** from the run (paste-able into a `-t` filter); a paraphrased
-title is un-greppable, which is the failure mode this change exists to remove.
+explicit**: diff the pasted verbose table against Blocks A and B, checking that every band written
+into the comment contains the run's numbers and that no per-spec point value was written in.
+Include the run's `Duration` and `Tests N passed` footer so the sample is identifiable. Quote every
+spec title **verbatim** from the run (paste-able into a `-t` filter); a paraphrased title is
+un-greppable, which is the failure mode this change exists to remove.
 
 What is run and recorded in the PR body:
 
@@ -107,19 +133,30 @@ What is run and recorded in the PR body:
 
 ## Done when
 
-Block A (`:44-54`) states the 2026-09-06 measurement, which literal to grep and which phase a red
-names; Block B (`:1019-1043`) keeps the #1617 rule and the negative control with its 1977ms/463ms
-and 7.6x premises replaced by a pointer to Block A; the negative control appears once; the
-constant and every per-`it` timeout are byte-identical; the verbose table with its footer and the
-negative-control result are in the PR body; suite green.
+Block A (`:44-54`) states the dated 2026-09-06 measurement as bands qualified "single-file, not
+under full-suite parallelism", names #1699's four specs verbatim as members of the fast band,
+says which literal to grep, which phase a red names (the two watcher specs by verbatim title), and
+that a red is a hang or a starved box rather than growth; Block B (`:1019-1043`) keeps the #1617
+rule and the negative control with its 1977ms/463ms and 7.6x premises replaced by a pointer to
+Block A plus the leaked-process-tree attribution; the negative control appears once; no per-spec
+point millisecond value is written into either block; the constant and every per-`it` timeout are
+byte-identical; the verbose table with its footer and the negative-control result are in the PR
+body; suite green.
 
 ## Not in scope
 
 A `beforeAll` warm-up (refuted by measurement above). Raising or lowering any ceiling. The
-project-wide 15 s default in `vitest.config.ts:43,:75`. `documents-boundary.test.ts`, named in
-#1672's "not only about docx-apply" aside — no current measurement supports touching it, and it
-is not in this group's issue set. `tests/cli/mcp-stdio.test.ts` (spec G2-1674). `CLAUDE.md` and
-`docs/gotchas.md` are owned by later groups.
+project-wide 15 s default in `vitest.config.ts:43,:75`. **`tests/helpers/timing.ts:66-72`, whose
+`timeoutMs` doc comment says "Both current callers" when there are five** (`tests/cli/doctor.test.ts:29`,
+`tests/client/authorship-block-structure.test.ts:512`, `tests/server/documents-open.test.ts:257`,
+`tests/server/docx-apply.test.ts:55`, `tests/server/file-io/roundtrip-repo-metric.test.ts:232`) —
+the same stale-measurement defect this group is retiring, in a **shared helper** a mid-wave edit
+would collide with other groups over. Block A keeps pointing readers there for the
+duration-is-the-assertion case; record it in the PR body as observed-not-fixed.
+`documents-boundary.test.ts`, named in #1672's "not only about docx-apply" aside — no current
+measurement supports touching it, and it is not in this group's issue set.
+`tests/cli/mcp-stdio.test.ts` (spec G2-1674). `CLAUDE.md` and `docs/gotchas.md` are owned by later
+groups.
 
 ## Bryan
 
@@ -139,23 +176,50 @@ if a contended run ever reproduces the ~36 s. Flag it if you would rather they s
   explicit division of labour, and the negative control lives in exactly one of them (B, where it
   already is) — the previous text told the builder to keep it "verbatim" in a block that does not
   contain it, which would have duplicated it.
-- *Blocking* / *non-blocking* — **two** specs wait on the watcher, not one: `:1111` and `:1159`,
-  with `vi.waitFor` at `:1145` and `:1179`. Both named.
+- *Blocking* / *non-blocking* — **two** specs wait on the watcher, not one; both named.
 - *Non-blocking* — `refuses a source file deleted mid-apply` was quoted by a title that does not
   exist and listed as a carrier. Corrected to its verbatim title and marked as running on the 15 s
   default; the Tests section now requires verbatim titles throughout.
 - *Non-blocking* — edit range corrected to `:44-54` (`:42` is the `timeoutMs` import, `:55` the
   constant), so a literal rewrite cannot delete the import.
-- *Non-blocking* — measurement rewritten as a dated band from a fresh run in this worktree (53
-  passed, `Duration 3.73s`, watcher specs 621/520 ms, other carriers 4–23 ms) rather than
-  two-significant-figure per-spec numbers that did not reproduce.
+- *Non-blocking* — measurement rewritten as a dated band from a fresh run in this worktree.
 - *Non-blocking* — "neither literal appears in the file" corrected: `60_000` appears three times
   as mtime arithmetic; the greppable literal is vitest's un-underscored `60000`.
 - *Non-blocking* — the review-only nature of the change is stated plainly, with the reviewer's
   diff-the-table job and the footer requirement.
-- *Non-blocking* — `Closes` vs the Bryan section: the spec now **owns the close** (the group's
-  ledger row lists #1672 among its `closes`), with reopen as the escape hatch, instead of
-  shipping a closing keyword and a "the call is yours" paragraph together.
+- *Non-blocking* — `Closes` vs the Bryan section: the spec now **owns the close**, with reopen as
+  the escape hatch.
 - *Non-blocking* — branch-name clause added.
+
+**Not adopted.** None.
+
+## Review corrections (round 2)
+
+**Adopted.**
+
+- *Blocking* — per-spec single-run millisecond figures are gone. Both the measurement table and
+  Done-when now require **dated bands** plus the run footer, with an explicit note that repeated
+  runs on this box move individual specs ~2x while the bands reproduce — writing a point value
+  would ship the same construction the change exists to retire.
+- *Non-blocking* — the "a red is the machine, not the code / look at the box" bullet is reworded:
+  at this speed a 60 s red cannot be gradual growth, so it is a **hang or a starved box**, and the
+  reader is sent to look for a never-settling `await` or an unreleased lock (`:1135`, `:1152`)
+  before blaming the machine. Raising the number is the response to neither.
+- *Non-blocking* — `vi.waitFor` citations corrected from `:1145`/`:1179` (the options object) to
+  `:1141`/`:1175` (the calls), and the shipped comment must name those two specs by **verbatim
+  title** rather than line number, since a comment in the same file invalidates its own line
+  citations.
+- *Non-blocking* — Block A gains a bullet naming #1699's four specs verbatim as members of the
+  fast band, and Done-when requires it, so a builder working only from this spec cannot ship a
+  comment that fails G2-1699's Done-when.
+- *Non-blocking* — Block A's headline number is qualified "single-file `vitest run`, not under
+  full-suite parallelism", and Block B's replacement line must attribute the retirement of the
+  7.6x premise to #1672's leaked-process-tree evidence rather than to the at-rest measurement.
+- *Non-blocking* (twice) — `tests/helpers/timing.ts:66-72`'s stale "Both current callers" (there
+  are five, enumerated) is named explicitly in **Not in scope** as observed-not-fixed, with the
+  reason: it is a shared helper a mid-wave edit would collide with other groups over. It is
+  recorded in the PR body so a later group can pick it up.
+- *Non-blocking* — header notes that the group's args set `closes: true` explicitly over the
+  sweep contract's default for a spec with a non-empty "Not in scope".
 
 **Not adopted.** None.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
@@ -1,0 +1,108 @@
+# G2 — #1672 `docx-apply.test.ts`'s ~36 s relocating cost is gone; the comment that sized its ceiling is not
+
+Branch `fix/test-timing-1674`. Closes #1672. Non-review issue: no `areas/*.md` row, no named
+experiment, no `refuted.md` entry — the ledger row is
+`docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test timing"). Probe:
+`npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
+
+## Problem
+
+#1672 reports a ~36 s one-time cost inside `tests/server/docx-apply.test.ts` that **moves
+between specs**, measured against `REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000, 300_000)`
+(`:55`) whose comment (`:42-54`) states its premise as "measured at ~21s on a dev machine". The
+issue's preferred remedy is to pay the cost once in a `beforeAll`; its fallback (option 3) is to
+record the real measured range in that comment.
+
+**The premise no longer holds, and the owner's own second comment on #1672 is why.** The
+contention was traced to a leaked `claude-agent-acp@0.59.0` tree holding 30 abandoned sessions
+(13.6 GB working set, commit charge 92.7%); killing it took a suite that had failed twice to
+green with no code change. That comment is explicit that this does not retire the issue — "a
+60 s ceiling sized against a ~21 s measurement is a bad check whether or not a leak was present"
+— so the finding survives as a *legibility* defect, not a cost defect.
+
+Re-measured on this box, 2026-09-06, `docx-apply.test.ts` alone:
+
+| | |
+|---|---|
+| whole file | **4.14 s**, 53 passed |
+| slowest specs | 620 ms and 617 ms — the two `#1749` watcher-reload specs, whose cost is a real `fs.watch` debounce they deliberately wait on |
+| every spec #1672 and #1699 name as slow | `takes a pre-overwrite snapshot` **8 ms**; `keeps an extensionless backupPath absolute` **18 ms**; `marks the imported Word comment done` **20 ms**; `refuses a source file deleted mid-apply` **4 ms** |
+
+So **there is no ~36 s cost to relocate and none to pay once**. A `beforeAll` warm-up would
+attribute ~19 ms to setup — option 1 buys nothing, and adds a hook to a file that does not need
+one. What is left is option 3, and it is the whole fix.
+
+## Fix
+
+One block, `tests/server/docx-apply.test.ts:42-54` — the doc comment above
+`REAL_APPLY_TIMEOUT_MS`. **`const REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000, 300_000)` is
+unchanged, and no per-`it` `REAL_APPLY_TIMEOUT_MS` argument is removed** (group policy: do not
+raise ceilings, do not delete the per-spec timeouts wholesale). Rewrite the comment to carry:
+
+- **The dated measurement replacing the ~21 s premise**: whole file 4.14 s / 53 specs on
+  2026-09-06; the carrying specs at 4–20 ms; the two `#1749` watcher-reload specs at ~620 ms and
+  why (a real debounce, not a warm-up). Keep the existing and still-correct sentences: duration
+  is not the property these specs assert, and `timeoutMs` exists because an explicit second
+  argument to `it` beats `--testTimeout`.
+- **What a red here means**, which is the "legible failure" half of #1672 and #1699. Vitest's
+  message is `Test timed out in 60000ms` (`300000` under `TANDEM_COVERAGE=1`) under the spec's
+  own name — neither literal appears in the file, so the comment must name both so the number in
+  the log is greppable. The awaited phase is unambiguous per spec: every carrying spec awaits
+  exactly one `applyChangesCore(...)` plus cheap `fsp` calls, and the one that also waits on the
+  watcher (`:1141-1146`) does so under its own `vi.waitFor({ timeout: 20_000 })`, which fails
+  with its own assertion instead. So: a bare `Test timed out` here is the apply; a `vi.waitFor`
+  failure is the reload.
+- **That a red is the machine, not the code**, with the #1672 evidence named: the observed
+  ~36 s was an unrelated leaked process tree, and the file measures 4.14 s at rest — so the
+  response is to look at the box, not to raise this number.
+- Keep the existing negative control sentence verbatim (set `REAL_APPLY_TIMEOUT_MS` to 1 and
+  every carrying spec fails naming that value). It is the only observation here that can come
+  back negative, and it is what stops the ceiling being decorative.
+
+**Rules that bite.** Do **not** introduce `expectWithinMs` into this file:
+`tests/scripts/coverage-manifest-wiring.test.ts:226-270` requires
+`git grep -l expectWithinMs -- tests/` to equal `SUSPENDED_TIMING_SITES`
+(`scripts/ci/coverage-manifest.mjs:122-126`), which does not list `docx-apply.test.ts`; adding a
+call without editing that list turns `check` red, and editing it would be adding a mechanism this
+group is not adding. Never set `TANDEM_COVERAGE=1`. No `src/` change, so Critical Rules 1–9 are
+not engaged; `timeoutMs` stays imported (`:41`).
+
+## Tests
+
+**No new test, deliberately** — and the reason is the issue's own argument. The only thing a new
+test could assert about this change is a wall-clock duration, and both #1672 and #1699 exist to
+say that a wall-clock bound in a shared pool measures the machine. Adding one would re-create the
+defect under a new name, and this group is forbidden sweep tests, drift guards and frozen lists.
+
+What is run and recorded in the PR body instead:
+
+- `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose` — the per-spec table above,
+  pasted, so the comment's numbers have a tracked source. *Discriminates* the fix from a
+  rewritten comment that invents numbers.
+- The existing negative control, executed once: set `REAL_APPLY_TIMEOUT_MS` to `1`, confirm every
+  spec carrying it fails naming `1`, revert. *Kills* the reading that the ceiling is ignored and
+  the comment therefore describes nothing.
+- The full suite via the pre-push hook, which is where a genuine regression in these 53 specs
+  would surface.
+
+## Done when
+
+The comment above `REAL_APPLY_TIMEOUT_MS` states the 2026-09-06 measurement, what a red means and
+which literal to grep; the constant and every per-`it` timeout are byte-identical; the verbose
+table and the negative-control result are in the PR body; suite green.
+
+## Not in scope
+
+A `beforeAll` warm-up (refuted by measurement above). Raising or lowering any ceiling. The
+project-wide 15 s default in `vitest.config.ts:43,:75`. `documents-boundary.test.ts`, named in
+#1672's "not only about docx-apply" aside — no current measurement supports touching it, and it
+is not in this group's issue set. `tests/cli/mcp-stdio.test.ts` (spec G2-1674). `CLAUDE.md` and
+`docs/gotchas.md` are owned by later groups.
+
+## Bryan
+
+Both this issue and #1699 are, on today's measurement, **closeable with the measurement rather
+than fixable**: the cost they describe is not present, and its cause was an unrelated leaked
+process tree that you diagnosed yourself in #1672's second comment. The legibility change above
+ships either way. The call to close them (rather than leave them open awaiting another
+contended run) is yours.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
@@ -104,15 +104,17 @@ run's numbers, and no per-spec point value may appear. Recorded in the PR body:
 ## Done when
 
 All three blocks are edited and agree: Block A carries the dated 2026-09-06 bands (qualified
-single-file), names the two watcher specs by verbatim title, says which phase a red names and which
-literal to grep, and says a red is a hang or a starved box rather than growth; Block B keeps the
-#1617 rule and the negative control with its 1977ms/463ms and 7.6x premises replaced by a pointer to
-Block A plus the leaked-process-tree attribution; Block C keeps its two verbatim sentences with the
-~21 s clause replaced by the same pointer. **`grep -n "21s on a dev" tests/server/docx-apply.test.ts`
-returns nothing.** The negative control appears once; **no per-spec point millisecond value and no
-numeric millisecond range** appears in any block; the constant and every per-`it` timeout are
-byte-identical; the verbose table with its footer and the negative-control result are in the PR body;
-suite green.
+single-file), names the two watcher specs by verbatim title, says which phase a red names and
+which literal to grep, and says a red is a hang or a starved box rather than growth; Block B keeps
+the #1617 rule and the negative control with its 1977ms/463ms and 7.6x premises replaced by a
+pointer to Block A plus the leaked-process-tree attribution; Block C keeps its two verbatim
+sentences with the ~21 s clause replaced by the same pointer. **`grep -n "21s"
+tests/server/docx-apply.test.ts` and `grep -n "1977ms\|7.6x" tests/server/docx-apply.test.ts` both
+return nothing** — today the first hits `:45` (Block A) and `:1274` (Block C) and the second hits
+`:1021` and `:1032` (Block B), so between them they discriminate all three blocks. The negative
+control appears once; **no per-spec point millisecond value and no numeric millisecond range**
+appears in any block; the constant and every per-`it` timeout are byte-identical; the verbose
+table with its footer and the negative-control result are in the PR body; suite green.
 
 ## Not in scope
 
@@ -146,3 +148,15 @@ at `:1272-1275` carries the same refuted "~21s on a dev machine" premise, three 
 the specs the measurement calls fast-band. Block C is now specified (owns nothing of its own; keeps
 its two verbatim sentences, takes the same pointer to Block A), the Fix header says three blocks, and
 Done-when adds `grep -n "21s on a dev"` returning nothing.
+
+## Review corrections (post-cut)
+
+**Fixed directly.** Done-when's one machine-checkable criterion was
+`grep -n "21s on a dev" tests/server/docx-apply.test.ts` returning nothing — **already vacuous for
+Block A**, the block whose refuted premise is this spec's whole subject: Block A's sentence wraps
+across `:45-46` (`~21s on a` / `dev machine`), so that exact string never existed there and the grep
+hits only `:1274`. A change touching Block C alone would have passed the stated check while shipping
+the contradictory diagnoses the Fix section says defeat the deliverable. The criterion is now
+`grep -n "21s"` (hits `:45` and `:1274`) plus `grep -n "1977ms\|7.6x"` (hits `:1021` and `:1032`),
+which together cover all three blocks. This supersedes the `grep -n "21s on a dev"` criterion named
+in the scope-cut log above.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
@@ -24,18 +24,23 @@ green with no code change. That comment is explicit that this does not retire th
 — so the finding survives as a *legibility* defect, not a cost defect.
 
 Re-measured on this box, 2026-09-06, **single-file `vitest run --reporter=verbose`, not under
-full-suite parallelism** (53 passed, `Duration 3.72s`, tests 1.37 s):
+full-suite parallelism** (53 passed, whole-file `Duration` in the ~3–4 s band across samples —
+3.72 s, 3.65 s, 3.74 s):
 
 | | |
 |---|---|
 | whole file | **~3–4 s**, 53 specs |
 | the two `#1749` watcher-reload specs | **~0.5–0.7 s** — a real `fs.watch` debounce they deliberately wait on, not warm-up |
-| the other **nine** specs carrying `REAL_APPLY_TIMEOUT_MS` | **single-digit to low-tens of ms** (4–25 ms across samples) |
+| the other **nine** specs carrying `REAL_APPLY_TIMEOUT_MS` | **single-digit to low-tens of ms** |
 | `reports a source file deleted mid-apply as SOURCE_MISSING, not an fs crash` | ~3–4 ms — and it does **not** carry the ceiling; it runs on the project 15 s default |
 
 **Bands, not point values, and that is deliberate**: repeated runs on this same box move
 individual specs by ~2x (e.g. one sample gives the four #1699-named specs at 15–21 ms, another at
-6–11 ms) while the bands and the file total reproduce exactly. Writing a single-run per-spec
+6–11 ms) while the bands and the file total reproduce exactly. **No numeric range goes into the
+shipped comment either** — a third sample put `allows an unsaved-restore conflict over an UNCHANGED
+disk` at 27 ms, outside a "4–25 ms" bracket an earlier draft of this spec proposed, so even a range
+is a point value with extra steps. The qualitative band is what reproduces; the exact per-spec
+figures live in the PR body's pasted table, where a stale number is harmless. Writing a single-run per-spec
 millisecond figure into a tracked comment is the same construction as the premises being retired
 (`:45` "~21s on a dev machine", `:1021-1022` "1977ms and 463ms") and would go stale the same way.
 
@@ -45,9 +50,10 @@ one. What is left is option 3, and it is the whole fix.
 
 ## Fix
 
-**Two comment blocks, not one** — the file carries its timing rationale in two places and both
-hold the refuted premises, so editing only the first ships two contradictory diagnoses in one
-file, which defeats the only deliverable. **`const REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000,
+**Three comment blocks, not one** — the file carries its timing rationale in three places and all
+three hold the refuted premises, so editing only some of them ships contradictory diagnoses in one
+file, which defeats the only deliverable. (`grep -n "headroom\|15s\|measured\|ceiling"
+tests/server/docx-apply.test.ts` returns exactly these three: `:45-46`, `:1020-1021`, `:1273-1274`.) **`const REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000,
 300_000)` is unchanged, and no per-`it` `REAL_APPLY_TIMEOUT_MS` argument is removed** (group
 policy: do not raise ceilings, do not delete the per-spec timeouts wholesale). Division of labour
 between the blocks, stated so they cannot drift apart again:
@@ -84,7 +90,7 @@ the *sizing* of the number. Rewrite to carry:
 - **What a red is, and what it is not.** At single-digit-to-low-tens of ms against a 60 s ceiling,
   a red here **cannot be gradual growth — it is a HANG or a starved machine.** Check first for a
   never-settling `await` or an unreleased lock in the apply (this file drives `wireFileWatcher` /
-  `unwatchFile` at `:1135`, `:1152`); the #1672 precedent — a leaked third-party process tree —
+  `unwatchFile` at `:1134`/`:1153` in the clean-doc spec and `:1172`/`:1184` in its dirty twin); the #1672 precedent — a leaked third-party process tree —
   is the machine case. **Raising this number is not the response to either.**
 
 **Block B — `tests/server/docx-apply.test.ts:1019-1043`, the "EVERY test in this block" comment.**
@@ -99,6 +105,19 @@ to the at-rest measurement**: the premise was a full-suite-parallelism claim and
 single-file run does not by itself refute it. The negative control ends up in **exactly one place,
 Block B**; Block A must not duplicate it.
 
+**Block C — `tests/server/docx-apply.test.ts:1272-1275`, above the `applyChangesCore — the backup
+sidecar` describe (`:1230`).** Owns **nothing of its own** — it is the write-guards rationale
+restated for a second describe, and it carries the same refuted premise. It is not a harmless
+duplicate: the first spec it governs, at `:1277`, is `keeps an extensionless backupPath absolute
+instead of resolving it against cwd` — one of the four #1699-named specs that Block A must record
+verbatim as a member of the dated fast band. Measured at **21 ms** in the run above, so
+"measured at ~21s on a dev machine" is *false*, not merely stale, and leaving it would put a ~21 s
+claim three lines above a spec Block A calls single-digit-to-low-tens-of-ms. **Keep verbatim** the
+first clause "Same headroom, same reason as the write-guards block above" and the closing sentence
+"Without it they fail as timeouts rather than as assertions"; **replace** the "measured at ~21s on a
+dev machine against a 15s default" clause with the **same one-line pointer to Block A** that Block B
+gets. No second copy of the measurement, no second negative control.
+
 **Rules that bite.** Do **not** introduce `expectWithinMs` into this file:
 `tests/scripts/coverage-manifest-wiring.test.ts:226-270` requires
 `git grep -l expectWithinMs -- tests/` to equal `SUSPENDED_TIMING_SITES`
@@ -106,6 +125,30 @@ Block B**; Block A must not duplicate it.
 call without editing that list turns `check` red, and editing it would be adding a mechanism this
 group is not adding. Never set `TANDEM_COVERAGE=1`. No `src/` change, so Critical Rules 1–9 are
 not engaged; `timeoutMs` stays imported (`:42`).
+
+**One bundled one-line comment fix — `tests/helpers/timing.ts:66-72`.** Its `timeoutMs` doc comment
+says "Both current callers are in that position" when there are **five**
+(`tests/cli/doctor.test.ts:29`, `tests/client/authorship-block-structure.test.ts:512`,
+`tests/server/documents-open.test.ts:257`, `tests/server/docx-apply.test.ts:55`,
+`tests/server/file-io/roundtrip-repo-metric.test.ts:232`). This is the same stale-measurement defect
+the group is retiring, one hop up from the file being edited, and Block A keeps pointing readers at
+it for the duration-is-the-assertion case — so shipping the fix while leaving its own pointer stale
+is the contradiction this change exists to remove. **Round 2 deferred it to "a later group"; there is
+no such group** — the wave table (`docs/plans/2026-09-06-open-issues-sweep.md:224-232`) lists no
+group touching `tests/helpers/`, and CLAUDE.md's two-person rule is "if you find something broken
+while working, fix it rather than filing it", with its dated-gate rule warning that a criterion with
+no tracked owner fails toward deletion. Change **"Both current callers are in that position"** to
+name the count without enumerating (the enumeration would itself go stale): e.g. "Its callers are all
+in that position — one builds 1,500 editor entries, another scans every tracked `.md` in the repo
+(measured at 175s instrumented, against a 120s ceiling)." Behaviour untouched; comment only.
+**Collision check before committing**: confirm no other wave-1 group (`K1 test gates` #1783 #1784
+#1721, `A-rest` #1768 #1797) has `tests/helpers/timing.ts` in its planned `filesTouched`; if one
+does, drop this hunk and record it in the PR body as observed-not-fixed instead.
+
+**One commit, not two.** #1672 and #1699 are a single edit to a single file; the sweep's implement
+stage says "one commit per issue", which would split one comment rewrite across two incoherent
+diffs. They land as **one commit referencing both issue numbers** in the subject, and both appear
+under `## Closes` in the PR body.
 
 ## Tests
 
@@ -133,26 +176,24 @@ What is run and recorded in the PR body:
 
 ## Done when
 
-Block A (`:44-54`) states the dated 2026-09-06 measurement as bands qualified "single-file, not
-under full-suite parallelism", names #1699's four specs verbatim as members of the fast band,
-says which literal to grep, which phase a red names (the two watcher specs by verbatim title), and
-that a red is a hang or a starved box rather than growth; Block B (`:1019-1043`) keeps the #1617
-rule and the negative control with its 1977ms/463ms and 7.6x premises replaced by a pointer to
-Block A plus the leaked-process-tree attribution; the negative control appears once; no per-spec
-point millisecond value is written into either block; the constant and every per-`it` timeout are
-byte-identical; the verbose table with its footer and the negative-control result are in the PR
-body; suite green.
+**All three blocks** are edited. Block A (`:44-54`) states the dated 2026-09-06 measurement as
+bands qualified "single-file, not under full-suite parallelism", names #1699's four specs verbatim
+as members of the fast band, says which literal to grep, which phase a red names (the two watcher
+specs by verbatim title), and that a red is a hang or a starved box rather than growth; Block B
+(`:1019-1043`) keeps the #1617 rule and the negative control with its 1977ms/463ms and 7.6x premises
+replaced by a pointer to Block A plus the leaked-process-tree attribution; Block C (`:1272-1275`)
+keeps its two verbatim sentences with the "~21s on a dev machine" clause replaced by the same
+pointer to Block A. **`grep -n "21s on a dev" tests/server/docx-apply.test.ts` returns nothing**, and
+`grep -n "headroom\|15s\|measured\|ceiling"` shows all three blocks agreeing. The negative control
+appears once (Block B); **no per-spec point millisecond value and no numeric millisecond range** is
+written into any block; the constant and every per-`it` timeout are byte-identical; the verbose table
+with its footer and the negative-control result are in the PR body; suite green.
 
 ## Not in scope
 
 A `beforeAll` warm-up (refuted by measurement above). Raising or lowering any ceiling. The
-project-wide 15 s default in `vitest.config.ts:43,:75`. **`tests/helpers/timing.ts:66-72`, whose
-`timeoutMs` doc comment says "Both current callers" when there are five** (`tests/cli/doctor.test.ts:29`,
-`tests/client/authorship-block-structure.test.ts:512`, `tests/server/documents-open.test.ts:257`,
-`tests/server/docx-apply.test.ts:55`, `tests/server/file-io/roundtrip-repo-metric.test.ts:232`) —
-the same stale-measurement defect this group is retiring, in a **shared helper** a mid-wave edit
-would collide with other groups over. Block A keeps pointing readers there for the
-duration-is-the-assertion case; record it in the PR body as observed-not-fixed.
+project-wide 15 s default in `vitest.config.ts:43,:75`. Raising the ceiling in `tests/helpers/timing.ts`, or any change to `timeoutMs`'s behaviour —
+**but its stale doc comment IS in scope and is fixed here** (see the bundled fix at the end of the Fix section).
 `documents-boundary.test.ts`, named in #1672's "not only about docx-apply" aside — no current
 measurement supports touching it, and it is not in this group's issue set.
 `tests/cli/mcp-stdio.test.ts` (spec G2-1674). `CLAUDE.md` and `docs/gotchas.md` are owned by later
@@ -221,5 +262,40 @@ if a contended run ever reproduces the ~36 s. Flag it if you would rather they s
   recorded in the PR body so a later group can pick it up.
 - *Non-blocking* — header notes that the group's args set `closes: true` explicitly over the
   sweep contract's default for a spec with a non-empty "Not in scope".
+
+**Not adopted.** None.
+
+## Review corrections (round 3)
+
+**Adopted.**
+
+- *Blocking* — there is a **third** rationale block, `tests/server/docx-apply.test.ts:1272-1275`,
+  above the `backup sidecar` describe, and it carries the same refuted "measured at ~21s on a dev
+  machine against a 15s default" premise. It is not a duplicate: the first spec it governs (`:1277`)
+  is `keeps an extensionless backupPath absolute instead of resolving it against cwd`, one of the
+  four #1699-named specs Block A must record as fast-band — measured at 21 ms, so the comment three
+  lines above it is false, not stale. Editing only A and B would ship exactly the self-contradiction
+  round 1's blocking finding identified, one level deeper, while both Done-whens read green. Block C
+  is now specified (owns nothing of its own; keeps its two verbatim sentences, replaces the ~21 s
+  clause with the same one-line pointer to Block A that Block B gets), the Fix header says three
+  blocks, and Done-when adds `grep -n "21s on a dev"` returning nothing.
+- *Non-blocking* (raised twice) — the numeric parenthetical "(4–25 ms across samples)" is dropped.
+  A fresh run in this worktree puts `allows an unsaved-restore conflict over an UNCHANGED disk` at
+  27 ms, outside that bracket, so Done-when's "every band written into the comment contains the run's
+  numbers" would have rejected a comment written to this spec's own instruction. Only the
+  qualitative band ships; exact figures stay in the PR body's table.
+- *Non-blocking* (raised twice) — `wireFileWatcher` / `unwatchFile` citations corrected from
+  `:1135`, `:1152` to `:1134`, `:1153`, with the dirty twin's `:1172`, `:1184` named too.
+- *Non-blocking* — the whole-file `Duration` is stated as the ~3–4 s band across three samples
+  (3.72 s, 3.65 s, 3.74 s) rather than one run's point value, so this spec and G2-1699 cannot
+  disagree about it.
+- *Non-blocking* — `tests/helpers/timing.ts:66-72`'s stale "Both current callers" is no longer
+  deferred to "a later group": the wave table lists no group touching `tests/helpers/`, and a
+  criterion with no tracked owner fails toward deletion (CLAUDE.md's dated-gate rule) while its
+  two-person rule says fix rather than file. The one-line comment correction is bundled, with an
+  explicit collision check against the other two wave-1 groups and a stated fallback if one claims
+  the file. **`filesTouched` therefore gains `tests/helpers/timing.ts`.**
+- *Non-blocking* — the sweep's "one commit per issue" is reconciled explicitly: #1672 and #1699 are
+  one edit to one file and land as a single commit naming both issues, with both under `## Closes`.
 
 **Not adopted.** None.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1672.md
@@ -1,301 +1,148 @@
 # G2 — #1672 `docx-apply.test.ts`'s ~36 s relocating cost is gone; the comments that sized its ceiling are not
 
-Branch `fix/test-timing-1674` — named for the group's implementation-order first issue (#1674);
-the ledger row lists "#1672 #1699 #1674", so branch and row reconcile through that clause.
-Closes #1672 — the group's args set `closes: true` explicitly, overriding the sweep contract's
-default of `false` for a spec with a non-empty "Not in scope". Non-review issue: no `areas/*.md`
-row, no named experiment, no `refuted.md` entry — the ledger row is
-`docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test timing"). Probe:
-`npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
+Branch `fix/test-timing-1674` (named for the group's first issue; the ledger row lists
+"#1672 #1699 #1674"). Closes #1672 (the group's args set `closes: true`). Non-review issue: ledger
+row `docs/plans/2026-09-06-open-issues-sweep.md:226`; no `areas/*.md` row, experiment or
+`refuted.md` entry. Probe: `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
 
 ## Problem
 
-#1672 reports a ~36 s one-time cost inside `tests/server/docx-apply.test.ts` that **moves
-between specs**, measured against `REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000, 300_000)` (`:55`)
-whose comment (`:44-54`) states its premise as "measured at ~21s on a dev machine". The issue's
-preferred remedy is to pay the cost once in a `beforeAll`; its fallback (option 3) is to record
-the real measured range in that comment.
+#1672 reports a ~36 s one-time cost inside `tests/server/docx-apply.test.ts` that **moves between
+specs**, measured against `REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000, 300_000)` (`:55`) whose comment
+(`:44-54`) states its premise as "measured at ~21s on a dev machine". Its preferred remedy is to pay
+the cost once in a `beforeAll`; its fallback (option 3) is to record the real measured range.
 
-**The premise no longer holds, and the owner's own second comment on #1672 is why.** The
-contention was traced to a leaked `claude-agent-acp@0.59.0` tree holding 30 abandoned sessions
-(13.6 GB working set, commit charge 92.7%); killing it took a suite that had failed twice to
-green with no code change. That comment is explicit that this does not retire the issue — "a
-60 s ceiling sized against a ~21 s measurement is a bad check whether or not a leak was present"
-— so the finding survives as a *legibility* defect, not a cost defect.
+**The premise no longer holds, and the owner's own second comment on #1672 is why.** The contention
+was traced to a leaked `claude-agent-acp@0.59.0` tree holding 30 abandoned sessions (13.6 GB working
+set, commit charge 92.7%); killing it took a suite that had failed twice to green with no code
+change. That comment is explicit that this does not retire the issue — "a 60 s ceiling sized against
+a ~21 s measurement is a bad check whether or not a leak was present" — so the finding survives as a
+**legibility** defect, not a cost defect.
 
-Re-measured on this box, 2026-09-06, **single-file `vitest run --reporter=verbose`, not under
-full-suite parallelism** (53 passed, whole-file `Duration` in the ~3–4 s band across samples —
-3.72 s, 3.65 s, 3.74 s):
-
-| | |
-|---|---|
-| whole file | **~3–4 s**, 53 specs |
-| the two `#1749` watcher-reload specs | **~0.5–0.7 s** — a real `fs.watch` debounce they deliberately wait on, not warm-up |
-| the other **nine** specs carrying `REAL_APPLY_TIMEOUT_MS` | **single-digit to low-tens of ms** |
-| `reports a source file deleted mid-apply as SOURCE_MISSING, not an fs crash` | ~3–4 ms — and it does **not** carry the ceiling; it runs on the project 15 s default |
-
-**Bands, not point values, and that is deliberate**: repeated runs on this same box move
-individual specs by ~2x (e.g. one sample gives the four #1699-named specs at 15–21 ms, another at
-6–11 ms) while the bands and the file total reproduce exactly. **No numeric range goes into the
-shipped comment either** — a third sample put `allows an unsaved-restore conflict over an UNCHANGED
-disk` at 27 ms, outside a "4–25 ms" bracket an earlier draft of this spec proposed, so even a range
-is a point value with extra steps. The qualitative band is what reproduces; the exact per-spec
-figures live in the PR body's pasted table, where a stale number is harmless. Writing a single-run per-spec
-millisecond figure into a tracked comment is the same construction as the premises being retired
-(`:45` "~21s on a dev machine", `:1021-1022` "1977ms and 463ms") and would go stale the same way.
-
-So **there is no ~36 s cost to relocate and none to pay once**. A `beforeAll` warm-up would
-attribute ~20 ms to setup — option 1 buys nothing and adds a hook to a file that does not need
-one. What is left is option 3, and it is the whole fix.
+Re-measured here 2026-09-06, single-file `vitest run --reporter=verbose`, **not under full-suite
+parallelism**: 53 passed, whole file in the **~3–4 s** band (3.72 s, 3.65 s, 3.79 s), the two `#1749`
+watcher-reload specs at ~0.5–0.7 s (a real `fs.watch` debounce they wait on by design), every other
+carrying spec in the **single-digit-to-low-tens-of-ms** band. **Bands, not point values, and no
+numeric range either**: repeated runs move individual specs ~2x (15–21 ms, then 6–11 ms, then 27 ms)
+while the bands and the file total reproduce, so a single-run figure in a tracked comment is the same
+construction being retired (`:45`, `:1021-1022`, `:1274`). There is **no ~36 s cost to relocate and
+none to pay once** — a `beforeAll` warm-up would attribute ~20 ms to setup. Option 3 is the whole fix.
 
 ## Fix
 
-**Three comment blocks, not one** — the file carries its timing rationale in three places and all
-three hold the refuted premises, so editing only some of them ships contradictory diagnoses in one
-file, which defeats the only deliverable. (`grep -n "headroom\|15s\|measured\|ceiling"
-tests/server/docx-apply.test.ts` returns exactly these three: `:45-46`, `:1020-1021`, `:1273-1274`.) **`const REAL_APPLY_TIMEOUT_MS = timeoutMs(60_000,
-300_000)` is unchanged, and no per-`it` `REAL_APPLY_TIMEOUT_MS` argument is removed** (group
-policy: do not raise ceilings, do not delete the per-spec timeouts wholesale). Division of labour
-between the blocks, stated so they cannot drift apart again:
+Comment-only, in `tests/server/docx-apply.test.ts`. **`REAL_APPLY_TIMEOUT_MS` is unchanged and no
+per-`it` timeout argument is removed** (group policy: do not raise ceilings, do not delete the
+per-spec timeouts wholesale). Three blocks carry the refuted premises —
+`grep -n "headroom\|15s\|measured\|ceiling" tests/server/docx-apply.test.ts` hits inside exactly
+three comment blocks, A at `:45-48`, B at `:1020-1039` and C at `:1273-1274` — and editing only some
+of them ships contradictory diagnoses in one file, which defeats the only deliverable.
 
-**Block A — `tests/server/docx-apply.test.ts:44-54`, the doc comment above the constant.** Owns
-the *sizing* of the number. Rewrite to carry:
+**Block A — `:44-54`, above the constant.** Owns the sizing. Keep the still-correct sentences
+(duration is not the property these specs assert; `timeoutMs` exists because an explicit second
+argument to `it` beats `--testTimeout`) and replace the ~21 s premise with:
 
-- **The dated measurement replacing the ~21 s premise**: 2026-09-06, whole file ~3–4 s / 53 specs
-  — stated as a **single-file `vitest run`, not under full-suite parallelism** — with nine of the
-  eleven carrying specs in the single-digit-to-low-tens-of-ms band and the two `#1749`
-  watcher-reload specs at ~0.5–0.7 s, and why. **Bands, never per-spec point values** (see
-  Problem). Keep the still-correct sentences: duration is not the property these specs assert, and
-  `timeoutMs` exists because an explicit second argument to `it` beats `--testTimeout`.
-- **#1699's four named specs, quoted verbatim, as members of the fast band** — `keeps an
-  extensionless backupPath absolute instead of resolving it against cwd`, `marks the imported Word
-  comment done after its promoted suggestion is applied`, `does not refuse on mtime drift within
-  the tolerance`, `takes a pre-overwrite snapshot, not just the sidecar backup` — so the next
-  reader of a red does not repeat the "which spec got slow" bisect. This bullet is what satisfies
-  G2-1699's Done-when; omitting it ships a comment that fails that spec.
-- **What a red here means.** Vitest prints `Test timed out in 60000ms` (`300000` under
-  `TANDEM_COVERAGE=1`) under the spec's own name. **Say that the greppable literal is the
-  un-underscored `60000` vitest prints, not the `60_000` in this file** — `60_000` does appear
-  three times (`:1066`, `:1095`, `:1130`) as unrelated mtime arithmetic, so "neither literal
-  appears" would be wrong.
-- **Which phase timed out.** Nine carrying specs await exactly one `applyChangesCore(...)` plus
-  cheap `fsp` calls. The **two** that also wait on the watcher — `the watcher reload that
-  completes an apply finally lands (#1749) — clean doc` (`it(` at `:1111`) and `the watcher reload
-  that completes an apply flags a conflict on a DIRTY doc (#1749)` (`it(` at `:1159`) — do so under
-  their own `vi.waitFor(…)` at `:1141` and `:1175` (options `{ timeout: 20_000, interval: 100 }` at
-  `:1145`/`:1179`), which fails with its own assertion. So: a bare `Test timed out in 60000ms` is
-  the apply; a `vi.waitFor` failure is the reload. **Name these two by their verbatim titles in the
-  shipped comment, not by line number** — the comment lives in the same file, so its own line
-  citations invalidate on the next edit.
-- **What a red is, and what it is not.** At single-digit-to-low-tens of ms against a 60 s ceiling,
-  a red here **cannot be gradual growth — it is a HANG or a starved machine.** Check first for a
-  never-settling `await` or an unreleased lock in the apply (this file drives `wireFileWatcher` /
-  `unwatchFile` at `:1134`/`:1153` in the clean-doc spec and `:1172`/`:1184` in its dirty twin); the #1672 precedent — a leaked third-party process tree —
-  is the machine case. **Raising this number is not the response to either.**
+- the dated measurement as **bands**, qualified single-file rather than full-suite: 2026-09-06, whole
+  file ~3–4 s / 53 specs, every spec carrying this ceiling in the single-digit-to-low-tens-of-ms band
+  **except** the two `#1749` watcher-reload specs at ~0.5–0.7 s, which wait on a real `fs.watch`
+  debounce. Name those two by **verbatim title**, never by line number — the comment lives in the
+  same file, so its own line citations invalidate on the next edit. No per-spec point value and no
+  numeric range goes into the comment; exact figures live in the PR body's table, where a stale
+  number is harmless.
+- **which phase a red names**: the carrying specs await one `applyChangesCore(...)` plus cheap `fsp`
+  calls, while the two watcher specs additionally wait under their own `vi.waitFor(…)` (`:1141`,
+  `:1175`), which fails with its own assertion — so a bare `Test timed out in 60000ms` is the apply
+  and a `vi.waitFor` failure is the reload. The greppable literal is vitest's **un-underscored
+  `60000`** (`300000` under `TANDEM_COVERAGE=1`), not this file's `60_000`, which also appears three
+  times (`:1066`, `:1095`, `:1130`) as unrelated mtime arithmetic.
+- **what a red is not**: at single-digit-to-low-tens of ms against a 60 s ceiling it **cannot be
+  gradual growth — it is a hang or a starved machine.** Look first for a never-settling `await` or an
+  unreleased lock in the apply (`wireFileWatcher` / `unwatchFile` at `:1134`/`:1153` and
+  `:1172`/`:1184`); #1672's leaked third-party process tree is the machine case. Raising the number
+  is the response to neither.
 
-**Block B — `tests/server/docx-apply.test.ts:1019-1043`, the "EVERY test in this block" comment.**
-Owns the *membership rule* and the negative control. Keep verbatim: the #1617 lesson ("name the
-SET that does the expensive thing, never the members that happened to trip") and the negative
-control ("set `REAL_APPLY_TIMEOUT_MS` to 1 and every spec carrying it fails naming that value").
-**Replace** its two refuted premises — "measured in isolation at 1977ms and 463ms against 20-24ms
-for the refusals" and "a 7.6x slowdown crosses the ceiling, and it did: three of four full-suite
-runs on one branch failed here" — with a one-line pointer to Block A's dated measurement **plus a
-clause attributing the retirement of the 7.6x premise to #1672's leaked-process-tree evidence, not
-to the at-rest measurement**: the premise was a full-suite-parallelism claim and an at-rest
-single-file run does not by itself refute it. The negative control ends up in **exactly one place,
-Block B**; Block A must not duplicate it.
+**Block B — `:1019-1043`, the "EVERY test in this block" comment.** Owns the membership rule and the
+negative control; both stay **verbatim** — the #1617 lesson ("name the SET that does the expensive
+thing, never the members that happened to trip") and "set `REAL_APPLY_TIMEOUT_MS` to 1 and every spec
+carrying it fails naming that value". Replace its two refuted premises ("measured in isolation at
+1977ms and 463ms against 20-24ms for the refusals"; "a 7.6x slowdown crosses the ceiling, and it did:
+three of four full-suite runs…") with a one-line pointer to Block A **plus a clause attributing the
+retirement of the 7.6x premise to #1672's leaked-process-tree evidence, not to the at-rest
+measurement** — that premise was a full-suite-parallelism claim and a single-file run does not by
+itself refute it. The negative control stays in exactly one place; Block A must not duplicate it.
 
-**Block C — `tests/server/docx-apply.test.ts:1272-1275`, above the `applyChangesCore — the backup
-sidecar` describe (`:1230`).** Owns **nothing of its own** — it is the write-guards rationale
-restated for a second describe, and it carries the same refuted premise. It is not a harmless
-duplicate: the first spec it governs, at `:1277`, is `keeps an extensionless backupPath absolute
-instead of resolving it against cwd` — one of the four #1699-named specs that Block A must record
-verbatim as a member of the dated fast band. Measured at **21 ms** in the run above, so
-"measured at ~21s on a dev machine" is *false*, not merely stale, and leaving it would put a ~21 s
-claim three lines above a spec Block A calls single-digit-to-low-tens-of-ms. **Keep verbatim** the
-first clause "Same headroom, same reason as the write-guards block above" and the closing sentence
-"Without it they fail as timeouts rather than as assertions"; **replace** the "measured at ~21s on a
-dev machine against a 15s default" clause with the **same one-line pointer to Block A** that Block B
-gets. No second copy of the measurement, no second negative control.
+**Block C — `:1272-1275`, above the `applyChangesCore — the backup sidecar` describe.** Owns nothing
+of its own: it restates the write-guards rationale for a second describe and carries the same refuted
+premise, three lines above `keeps an extensionless backupPath absolute instead of resolving it
+against cwd`, measured at 22 ms in the run above — so "measured at ~21s on a dev machine against a
+15s default" is **false, not merely stale**. Keep verbatim its first clause ("Same headroom, same
+reason as the write-guards block above") and its last sentence ("Without it they fail as timeouts
+rather than as assertions"); replace the ~21 s clause with the **same one-line pointer to Block A**
+that Block B gets. No second copy of the measurement, no second negative control.
 
-**Rules that bite.** Do **not** introduce `expectWithinMs` into this file:
-`tests/scripts/coverage-manifest-wiring.test.ts:226-270` requires
-`git grep -l expectWithinMs -- tests/` to equal `SUSPENDED_TIMING_SITES`
-(`scripts/ci/coverage-manifest.mjs:122-126`), which does not list `docx-apply.test.ts`; adding a
-call without editing that list turns `check` red, and editing it would be adding a mechanism this
-group is not adding. Never set `TANDEM_COVERAGE=1`. No `src/` change, so Critical Rules 1–9 are
-not engaged; `timeoutMs` stays imported (`:42`).
-
-**One bundled one-line comment fix — `tests/helpers/timing.ts:66-72`.** Its `timeoutMs` doc comment
-says "Both current callers are in that position" when there are **five**
-(`tests/cli/doctor.test.ts:29`, `tests/client/authorship-block-structure.test.ts:512`,
-`tests/server/documents-open.test.ts:257`, `tests/server/docx-apply.test.ts:55`,
-`tests/server/file-io/roundtrip-repo-metric.test.ts:232`). This is the same stale-measurement defect
-the group is retiring, one hop up from the file being edited, and Block A keeps pointing readers at
-it for the duration-is-the-assertion case — so shipping the fix while leaving its own pointer stale
-is the contradiction this change exists to remove. **Round 2 deferred it to "a later group"; there is
-no such group** — the wave table (`docs/plans/2026-09-06-open-issues-sweep.md:224-232`) lists no
-group touching `tests/helpers/`, and CLAUDE.md's two-person rule is "if you find something broken
-while working, fix it rather than filing it", with its dated-gate rule warning that a criterion with
-no tracked owner fails toward deletion. Change **"Both current callers are in that position"** to
-name the count without enumerating (the enumeration would itself go stale): e.g. "Its callers are all
-in that position — one builds 1,500 editor entries, another scans every tracked `.md` in the repo
-(measured at 175s instrumented, against a 120s ceiling)." Behaviour untouched; comment only.
-**Collision check before committing**: confirm no other wave-1 group (`K1 test gates` #1783 #1784
-#1721, `A-rest` #1768 #1797) has `tests/helpers/timing.ts` in its planned `filesTouched`; if one
-does, drop this hunk and record it in the PR body as observed-not-fixed instead.
-
-**One commit, not two.** #1672 and #1699 are a single edit to a single file; the sweep's implement
-stage says "one commit per issue", which would split one comment rewrite across two incoherent
-diffs. They land as **one commit referencing both issue numbers** in the subject, and both appear
-under `## Closes` in the PR body.
+**Rules that bite.** Do not introduce `expectWithinMs` here —
+`tests/scripts/coverage-manifest-wiring.test.ts:226-270` pins `git grep -l expectWithinMs -- tests/`
+to `SUSPENDED_TIMING_SITES`, which does not list this file. Never set `TANDEM_COVERAGE=1`. No `src/`
+change; `timeoutMs` stays imported (`:42`). #1672 and #1699 are one edit to one file and land as
+**one commit** naming both issues, both under `## Closes` in the PR body.
 
 ## Tests
 
-**No new test, deliberately** — and the reason is the issue's own argument. The only thing a new
-test could assert about this change is a wall-clock duration, and both #1672 and #1699 exist to
-say that a wall-clock bound in a shared pool measures the machine. Adding one would re-create the
-defect under a new name, and this group is forbidden sweep tests, drift guards and frozen lists.
+**No new test, deliberately.** The only property a new test could assert here is a wall-clock
+duration, and both issues exist to say that a wall-clock bound in a shared pool measures the machine;
+adding one would re-create the defect under a new name. Sweep tests, drift guards and frozen lists
+are out by group policy. Nothing in Done-when is machine-checked, so the reviewer's job is to diff
+the pasted verbose table against the three blocks: every band written into a comment must contain the
+run's numbers, and no per-spec point value may appear. Recorded in the PR body:
 
-**Nothing in "Done when" is machine-checked, and that is by design — so the reviewer's job is
-explicit**: diff the pasted verbose table against Blocks A and B, checking that every band written
-into the comment contains the run's numbers and that no per-spec point value was written in.
-Include the run's `Duration` and `Tests N passed` footer so the sample is identifiable. Quote every
-spec title **verbatim** from the run (paste-able into a `-t` filter); a paraphrased title is
-un-greppable, which is the failure mode this change exists to remove.
-
-What is run and recorded in the PR body:
-
-- `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose` — the full per-spec table
-  with its footer. *Discriminates* the fix from a rewritten comment that invents numbers.
+- `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`, pasted **with its `Duration` /
+  `Tests N passed` footer** so the sample is identifiable, every title verbatim. *Discriminates* the
+  fix from a rewritten comment that invents numbers.
 - The existing negative control, executed once: set `REAL_APPLY_TIMEOUT_MS` to `1`, confirm every
-  spec carrying it fails naming `1`, revert. *Kills* the reading that the ceiling is ignored and
-  the comments therefore describe nothing.
-- The full suite via the pre-push hook, which is where a genuine regression in these 53 specs
-  would surface.
+  carrying spec fails naming `1`, revert. *Kills* the reading that the ceiling is inert.
+- The full suite via the pre-push hook.
 
 ## Done when
 
-**All three blocks** are edited. Block A (`:44-54`) states the dated 2026-09-06 measurement as
-bands qualified "single-file, not under full-suite parallelism", names #1699's four specs verbatim
-as members of the fast band, says which literal to grep, which phase a red names (the two watcher
-specs by verbatim title), and that a red is a hang or a starved box rather than growth; Block B
-(`:1019-1043`) keeps the #1617 rule and the negative control with its 1977ms/463ms and 7.6x premises
-replaced by a pointer to Block A plus the leaked-process-tree attribution; Block C (`:1272-1275`)
-keeps its two verbatim sentences with the "~21s on a dev machine" clause replaced by the same
-pointer to Block A. **`grep -n "21s on a dev" tests/server/docx-apply.test.ts` returns nothing**, and
-`grep -n "headroom\|15s\|measured\|ceiling"` shows all three blocks agreeing. The negative control
-appears once (Block B); **no per-spec point millisecond value and no numeric millisecond range** is
-written into any block; the constant and every per-`it` timeout are byte-identical; the verbose table
-with its footer and the negative-control result are in the PR body; suite green.
+All three blocks are edited and agree: Block A carries the dated 2026-09-06 bands (qualified
+single-file), names the two watcher specs by verbatim title, says which phase a red names and which
+literal to grep, and says a red is a hang or a starved box rather than growth; Block B keeps the
+#1617 rule and the negative control with its 1977ms/463ms and 7.6x premises replaced by a pointer to
+Block A plus the leaked-process-tree attribution; Block C keeps its two verbatim sentences with the
+~21 s clause replaced by the same pointer. **`grep -n "21s on a dev" tests/server/docx-apply.test.ts`
+returns nothing.** The negative control appears once; **no per-spec point millisecond value and no
+numeric millisecond range** appears in any block; the constant and every per-`it` timeout are
+byte-identical; the verbose table with its footer and the negative-control result are in the PR body;
+suite green.
 
 ## Not in scope
 
-A `beforeAll` warm-up (refuted by measurement above). Raising or lowering any ceiling. The
-project-wide 15 s default in `vitest.config.ts:43,:75`. Raising the ceiling in `tests/helpers/timing.ts`, or any change to `timeoutMs`'s behaviour —
-**but its stale doc comment IS in scope and is fixed here** (see the bundled fix at the end of the Fix section).
-`documents-boundary.test.ts`, named in #1672's "not only about docx-apply" aside — no current
-measurement supports touching it, and it is not in this group's issue set.
-`tests/cli/mcp-stdio.test.ts` (spec G2-1674). `CLAUDE.md` and `docs/gotchas.md` are owned by later
-groups.
+A `beforeAll` warm-up (refuted by measurement). Raising or lowering any ceiling. `vitest.config.ts`'s
+15 s defaults. **`tests/helpers/timing.ts`** — its `timeoutMs` doc comment says "Both current callers"
+when there are five; a second file the issues do not name, recorded in the PR body as
+observed-not-fixed. `documents-boundary.test.ts`, named in #1672's aside with no measurement
+supporting a touch. `tests/cli/mcp-stdio.test.ts` (G2-1674). `CLAUDE.md` and `docs/gotchas.md` are
+owned by later groups.
 
 ## Bryan
 
 On today's measurement #1672 and #1699 are **closeable with the measurement rather than fixable**:
-the cost they describe is not present, and its cause was an unrelated leaked process tree you
-diagnosed yourself in #1672's second comment. **This spec owns that call rather than deferring
-it** — the PR closes both with the measurement as the reason, and reopening is the escape hatch
-if a contended run ever reproduces the ~36 s. Flag it if you would rather they stayed open.
+the cost they describe is not present, and its cause was the unrelated leaked process tree you
+diagnosed in #1672's second comment. This spec owns that call — the PR closes both with the
+measurement as the reason and ships the legibility change anyway, since a 60 s ceiling explained by a
+refuted ~21 s premise misleads the next reader either way. Reopening is the escape hatch if a
+contended run ever reproduces the ~36 s. Flag it if you would rather they stayed open.
 
-## Review corrections (round 1)
+## Review corrections (scope cut)
 
-**Adopted.**
+**Removed, not repaired:** the bundled `tests/helpers/timing.ts:66-72` comment fix (a second file
+neither issue names — now observed-not-fixed in the PR body); the requirement to quote **#1699's four
+named specs verbatim** inside Block A, replaced by the band statement covering *every* spec carrying
+the ceiling, which subsumes those four and cannot go stale when a title changes; the per-block
+required-content restatements duplicated across this spec and G2-1699; and the round 1–3 correction
+logs, replaced by this section.
 
-- *Blocking* — the edit now covers the **second** timing block at `:1019-1043`, which carried the
-  "1977ms and 463ms" and "7.6x / three of four full-suite runs" premises the change exists to
-  retire and would otherwise have stood next to its own refutation. Blocks A and B have an
-  explicit division of labour, and the negative control lives in exactly one of them (B, where it
-  already is) — the previous text told the builder to keep it "verbatim" in a block that does not
-  contain it, which would have duplicated it.
-- *Blocking* / *non-blocking* — **two** specs wait on the watcher, not one; both named.
-- *Non-blocking* — `refuses a source file deleted mid-apply` was quoted by a title that does not
-  exist and listed as a carrier. Corrected to its verbatim title and marked as running on the 15 s
-  default; the Tests section now requires verbatim titles throughout.
-- *Non-blocking* — edit range corrected to `:44-54` (`:42` is the `timeoutMs` import, `:55` the
-  constant), so a literal rewrite cannot delete the import.
-- *Non-blocking* — measurement rewritten as a dated band from a fresh run in this worktree.
-- *Non-blocking* — "neither literal appears in the file" corrected: `60_000` appears three times
-  as mtime arithmetic; the greppable literal is vitest's un-underscored `60000`.
-- *Non-blocking* — the review-only nature of the change is stated plainly, with the reviewer's
-  diff-the-table job and the footer requirement.
-- *Non-blocking* — `Closes` vs the Bryan section: the spec now **owns the close**, with reopen as
-  the escape hatch.
-- *Non-blocking* — branch-name clause added.
-
-**Not adopted.** None.
-
-## Review corrections (round 2)
-
-**Adopted.**
-
-- *Blocking* — per-spec single-run millisecond figures are gone. Both the measurement table and
-  Done-when now require **dated bands** plus the run footer, with an explicit note that repeated
-  runs on this box move individual specs ~2x while the bands reproduce — writing a point value
-  would ship the same construction the change exists to retire.
-- *Non-blocking* — the "a red is the machine, not the code / look at the box" bullet is reworded:
-  at this speed a 60 s red cannot be gradual growth, so it is a **hang or a starved box**, and the
-  reader is sent to look for a never-settling `await` or an unreleased lock (`:1135`, `:1152`)
-  before blaming the machine. Raising the number is the response to neither.
-- *Non-blocking* — `vi.waitFor` citations corrected from `:1145`/`:1179` (the options object) to
-  `:1141`/`:1175` (the calls), and the shipped comment must name those two specs by **verbatim
-  title** rather than line number, since a comment in the same file invalidates its own line
-  citations.
-- *Non-blocking* — Block A gains a bullet naming #1699's four specs verbatim as members of the
-  fast band, and Done-when requires it, so a builder working only from this spec cannot ship a
-  comment that fails G2-1699's Done-when.
-- *Non-blocking* — Block A's headline number is qualified "single-file `vitest run`, not under
-  full-suite parallelism", and Block B's replacement line must attribute the retirement of the
-  7.6x premise to #1672's leaked-process-tree evidence rather than to the at-rest measurement.
-- *Non-blocking* (twice) — `tests/helpers/timing.ts:66-72`'s stale "Both current callers" (there
-  are five, enumerated) is named explicitly in **Not in scope** as observed-not-fixed, with the
-  reason: it is a shared helper a mid-wave edit would collide with other groups over. It is
-  recorded in the PR body so a later group can pick it up.
-- *Non-blocking* — header notes that the group's args set `closes: true` explicitly over the
-  sweep contract's default for a spec with a non-empty "Not in scope".
-
-**Not adopted.** None.
-
-## Review corrections (round 3)
-
-**Adopted.**
-
-- *Blocking* — there is a **third** rationale block, `tests/server/docx-apply.test.ts:1272-1275`,
-  above the `backup sidecar` describe, and it carries the same refuted "measured at ~21s on a dev
-  machine against a 15s default" premise. It is not a duplicate: the first spec it governs (`:1277`)
-  is `keeps an extensionless backupPath absolute instead of resolving it against cwd`, one of the
-  four #1699-named specs Block A must record as fast-band — measured at 21 ms, so the comment three
-  lines above it is false, not stale. Editing only A and B would ship exactly the self-contradiction
-  round 1's blocking finding identified, one level deeper, while both Done-whens read green. Block C
-  is now specified (owns nothing of its own; keeps its two verbatim sentences, replaces the ~21 s
-  clause with the same one-line pointer to Block A that Block B gets), the Fix header says three
-  blocks, and Done-when adds `grep -n "21s on a dev"` returning nothing.
-- *Non-blocking* (raised twice) — the numeric parenthetical "(4–25 ms across samples)" is dropped.
-  A fresh run in this worktree puts `allows an unsaved-restore conflict over an UNCHANGED disk` at
-  27 ms, outside that bracket, so Done-when's "every band written into the comment contains the run's
-  numbers" would have rejected a comment written to this spec's own instruction. Only the
-  qualitative band ships; exact figures stay in the PR body's table.
-- *Non-blocking* (raised twice) — `wireFileWatcher` / `unwatchFile` citations corrected from
-  `:1135`, `:1152` to `:1134`, `:1153`, with the dirty twin's `:1172`, `:1184` named too.
-- *Non-blocking* — the whole-file `Duration` is stated as the ~3–4 s band across three samples
-  (3.72 s, 3.65 s, 3.74 s) rather than one run's point value, so this spec and G2-1699 cannot
-  disagree about it.
-- *Non-blocking* — `tests/helpers/timing.ts:66-72`'s stale "Both current callers" is no longer
-  deferred to "a later group": the wave table lists no group touching `tests/helpers/`, and a
-  criterion with no tracked owner fails toward deletion (CLAUDE.md's dated-gate rule) while its
-  two-person rule says fix rather than file. The one-line comment correction is bundled, with an
-  explicit collision check against the other two wave-1 groups and a stated fallback if one claims
-  the file. **`filesTouched` therefore gains `tests/helpers/timing.ts`.**
-- *Non-blocking* — the sweep's "one commit per issue" is reconciled explicitly: #1672 and #1699 are
-  one edit to one file and land as a single commit naming both issues, with both under `## Closes`.
-
-**Not adopted.** None.
+**Fixed directly.** *Blocking* — the fix covered only Blocks A and B while a **third** rationale block
+at `:1272-1275` carries the same refuted "~21s on a dev machine" premise, three lines above one of
+the specs the measurement calls fast-band. Block C is now specified (owns nothing of its own; keeps
+its two verbatim sentences, takes the same pointer to Block A), the Fix header says three blocks, and
+Done-when adds `grep -n "21s on a dev"` returning nothing.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
@@ -117,13 +117,19 @@ in the same tick as its `spawn`.
    `readOneLine` calls return line 1 then line 2. *Kills* a cursorless shared buffer.
 3. **"waits for the newline rather than serving the unterminated tail"** — child writes `{"a":1`, then
    `}\n` 200 ms later; `JSON.parse(await readOneLine(child, 2_000))` equals `{ a: 1 }`.
-4. **"names the awaited subject and the child's liveness"** — three arms on one helper: a child that
-   writes nothing and exits, where `readOneLine(child, 300)` with **no third argument** rejects
-   matching `/^no stdout within 300ms \(child exited with code 0\)/` (the only exercise of the
-   default); a SIGKILLed sleeping child whose rejection contains `exited` and `SIGKILL` (the only
-   case where `exitCode` is `null`, so the only one that kills an `exitCode`-only liveness test); and
-   a sleeping child where `readOneLine(child, 300, "synthesized -32000 on stdout")` rejects
-   containing both `synthesized -32000` and `still running`.
+4. **"names the awaited subject and the child's liveness"** — three arms on one helper. Liveness
+   is read in the deadline callback, so the two `exited` arms **await termination before the read**
+   (`await new Promise<void>((r) => { child.once("close", () => r()); })`). Buffering from spawn
+   means waiting loses nothing, and the 300 ms bound then measures only the timer instead of racing
+   subprocess spawn latency under full-suite parallelism — the fixed-ms race this file already
+   records at `:838-845` (#687) and the defect this PR exists to remove. Arm 1: a child that writes
+   nothing and exits; after its `close`, `readOneLine(child, 300)` with **no third argument**
+   rejects matching `/^no stdout within 300ms \(child exited with code 0\)/` (the only exercise of
+   the default). Arm 2: a sleeping child, then `child.kill("SIGKILL")`, then await `close`, then
+   `readOneLine(child, 300)` rejects containing `exited` and `SIGKILL` (the only case where
+   `exitCode` is `null`, so the only one that kills an `exitCode`-only liveness test). Arm 3 takes
+   **no** wait — the child must still be running: `readOneLine(child, 300, "synthesized -32000 on
+   stdout")` on a sleeping child rejects containing both `synthesized -32000` and `still running`.
 
 Plus the existing file green, `npm run typecheck`, `npm run typecheck:tests`, and the full suite via
 the pre-push hook. **Negative control:** revert `outputOf` to per-call attachment — spec 1 reds
@@ -138,7 +144,9 @@ unterminated line (spec 3) and pops the tail before dropping blanks; the two neg
 proves the child reached the **preflight-failure branch** — a liveness assertion plus the
 `/preflight failed/i` stderr line, never an exit-code equality, because the bridge measurably exits
 `0`; the deadline message keeps `no stdout within Nms` as its default (spec 4) and names the awaited
-subject and both liveness branches; the four new specs pass and the describe tears its children down;
+subject and both liveness branches; spec 4's two `exited` arms await `close` before reading, so no
+arm's 300 ms deadline races spawn latency; the four new specs pass and the describe tears its
+children down;
 no ceiling changed; the `shutdown(1)`-exits-`0` observation is in the PR body; typecheck and suite
 green.
 
@@ -165,3 +173,14 @@ The precondition is now a liveness assertion plus the `/preflight failed/i` stde
 `exitCode` is not 1, report it" instruction is deleted (it mandated a derail into `src/` this spec
 forbids); Done-when says "preflight-failure **branch**"; the `shutdown(1)`-exits-`0` finding is
 recorded as observed-not-fixed.
+
+## Review corrections (post-cut)
+
+**Fixed directly.** Spec 4's arms 1 and 2 asserted the `exited` half of the rejection message
+without awaiting the child's termination, which gated the 300 ms deadline on bare spawn→exit
+latency: under the full-suite parallelism this same file documents (`:838-839`, `:896-897`), the
+child is still running when the deadline fires, the message reads `child still running`, and the
+anchored regex reds — an intermittent failure inside the required `check` job, and the #687 class
+the same spec forbids two paragraphs earlier. Both arms now await `close` before the read (arm 2
+after its `SIGKILL`); arm 3 deliberately does not, since it needs a live child. Done-when carries
+the clause. Raised twice in review as the same defect.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
@@ -1,467 +1,167 @@
 # G2 — #1674 `mcp-stdio.test.ts` loses the line it is waiting for, then blames the bridge
 
-Branch `fix/test-timing-1674` — named for the implementation-order first issue (#1674); the
-ledger row lists the group as "#1672 #1699 #1674", so branch and row reconcile through that
-clause. Closes #1674 — the group's args set `closes: true` explicitly, overriding the sweep
-contract's default of `false` for a spec with a non-empty "Not in scope"; the close is justified
-because the remaining #724-class cause (below) is made *distinguishable from the message*, not
-eliminated. Non-review issue: no `areas/*.md` row, no named experiment, no `refuted.md` entry —
-the ledger row is `docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test
-timing"). Probe: a two-case Node script settling the stream semantics the fix rests on, plus
-`npx vitest run tests/cli/mcp-stdio.test.ts`.
+Branch `fix/test-timing-1674`, named for this issue. Closes #1674 (the group's args set
+`closes: true`). Non-review issue: ledger row `docs/plans/2026-09-06-open-issues-sweep.md:226`; no
+`areas/*.md` row, experiment or `refuted.md` entry. Probe: `npx vitest run tests/cli/mcp-stdio.test.ts`.
 
 ## Problem
 
-The reported red is `no stdout within 5000ms. stderr= stdout=` on `mcp-stdio per-request timeout
-> does not synthesize double -32000 when timer fires before upstream crash arrives`. **Raising
-the 5000 ms bound cannot fix it**: the line the spec waits for was already delivered to a
-*different* listener and is gone.
+The reported red is `no stdout within 5000ms. stderr= stdout=` on `mcp-stdio per-request timeout >
+does not synthesize double -32000 when timer fires before upstream crash arrives`. **Raising the
+5 000 ms bound cannot fix it**: the line was delivered to a *different* listener and is gone.
+`readOneLine` (`:21-47`) attaches its `stdout`/`stderr` collectors **at call time**, while that spec
+attaches its own raw collector right after `spawn` (`:831-833`), putting `child.stdout` into flowing
+mode — anything emitted in between reaches only the first collector. `TANDEM_REQUEST_TIMEOUT_MS` is
+`300`, so when the gap between `waitForPosts` returning and `readOneLine` attaching exceeds the
+remaining timer, the `-32000` lands in `stdoutChunks` and `readOneLine` waits its full 5 000 ms on a
+stream that will never speak again.
 
-`readOneLine` (`tests/cli/mcp-stdio.test.ts:21-47`) attaches its `stdout`/`stderr` collectors
-**at call time**. That spec attaches its own raw collector immediately after `spawn` (`:831-833`
-— comment, `stdoutChunks`, listener), putting `child.stdout` into flowing mode; anything emitted
-between that attach and `readOneLine`'s attach reaches the first collector only.
+Measured on this box 2026-09-06 (`node` probes): a paused stream buffers **only while the child is
+alive** — with a listener already attached, a second one 400 ms later saw `""`; and for an **exited**
+child, listeners attached 0/50/300 ms after `close` all saw `""`. The second half is why
+`outputOf(child)` must be called in the same tick as `spawn`. **A second, independently sufficient
+cause of the same text survives this fix**: `tests/cli/dev-standalone.test.ts:63-70` records #724
+(leaked handles starving subprocess startup). No `src/` change is warranted — `sendErrorResponse`
+(`src/cli/mcp-stdio.ts:488-503`) writes nothing to stderr on success, so an empty stderr does not
+rule out "the bridge never emitted"; naming the awaited subject and the child's liveness in the
+rejection is what separates the two causes.
 
-Measured, not reasoned (`node` probes, this box, 2026-09-06). **A paused stream buffers only while
-the child is alive**, and the two probes bound that precisely:
-
-- *Live child.* With a listener attached at spawn, a second listener attached 400 ms later saw `""`
-  while the first held `"LINE-A\n"`; with **no** listener until 500 ms after the write, the late
-  listener still saw `"LINE-B\n"`. So on a live child late attachment loses data **only** when an
-  earlier listener already put the stream in flowing mode — which is exactly the shape of the specs
-  holding a pre-attached collector.
-- *Exited child.* A child writing `L1\nL2\n` and exiting: a listener attached in the same tick as
-  `spawn` saw `"L1\nL2\n"`; listeners attached 0 ms, 50 ms and 300 ms **after `close`** each saw
-  `""`. Once an exited child's stdio streams tear down, unread data is discarded outright, with no
-  competing listener needed.
-
-Both halves matter downstream: the first is #1674's reported failure, the second is why
-`outputOf(child)` must be called **in the same tick as `spawn`**, before any `await`, for every
-write-then-exit child.
-
-**A second, independently sufficient cause of the same text exists and this fix does not
-eliminate it.** `tests/cli/dev-standalone.test.ts:63-70` records #724: handles leaked by another
-test file slowed subprocess startup enough that this file's timing-sensitive assertions flaked
-with `no stdout within Nms`. Both causes print `stderr= stdout=`. On current evidence **no `src/`
-change is warranted** — an empty stderr does not discriminate, because `armRequestTimer` →
-`sendErrorResponse` (`src/cli/mcp-stdio.ts:488-503`) writes nothing to stderr on the success
-path, so "the bridge never emitted" is not ruled out by the red alone. After the fix, a rejection
-naming the awaited subject plus the liveness branch is what tells a bridge that never emitted
-from a machine that starved.
-
-The timing that fires the removable half: `TANDEM_REQUEST_TIMEOUT_MS` is `300`, armed just before
-the POST; when the gap between `waitForPosts` returning and `readOneLine` attaching exceeds the
-~290 ms of remaining timer, the `-32000` lands in `stdoutChunks` and `readOneLine` waits its full
-5 000 ms on a stream that will never speak again.
-
-Two more instances of the same class, both latent, both in scope:
-
-- `"clears pendingRequests after a successful response"` calls `readOneLine` twice on one child
-  (`:598`, `:614`) plus `readLines` (`:621`). Each attaches a fresh collector and none is removed.
-- `"does not synthesize for notifications (no id) on preflight failure"` (`:428-458`) is the
-  defect in its terminal form, **and it is doubly vacuous**: `:443-445` builds `stdoutChunks`,
-  attaches the listener, and `:446-447` joins **in the same tick**, so `allOutput` is always `""`
-  and `lines` always `[]`; *and* the `expect(parsed.error?.code).not.toBe(-32000)` at `:453` sits
-  **inside the `try` whose `catch` at `:454` discards everything as "non-JSON line"**, so an
-  AssertionError would be swallowed even with a populated buffer. Populating the buffer alone
-  does not make this spec assert. **Both halves must be fixed together.**
+One site holds the defect in terminal form: `does not synthesize for notifications (no id) on
+preflight failure` (`:428-458`) builds its collector **after** awaiting the child's exit and joins it
+in the same tick (`:443-447`), so `lines` is always `[]`; and its `expect` at `:453` sits inside the
+`try` whose `catch` at `:454` discards everything as "non-JSON". Both halves are vacuous and must be
+fixed together.
 
 ## Fix
 
-All in `tests/cli/mcp-stdio.test.ts`, plus one stale citation in `scripts/ci/stdio-smoke.mjs`.
-No `src/` change (see Problem).
+All in `tests/cli/mcp-stdio.test.ts`. No `src/` change.
 
-**1. Buffer from spawn, once per child.** Add a module-level
-`const childOutputs = new WeakMap<ChildProcessWithoutNullStreams, ChildOutput>()` and
-`function outputOf(child): ChildOutput`, attaching the `data` listeners on first call and
-returning the same object thereafter. The model is already in this file: `collect()` at `:1774`
-("Attach once and accumulate; repeated `readLines()` calls would drop data") — that describe
-solved this locally; this generalises it to the two shared helpers rather than adding a third
-mechanism. `collect()` already exposes `stdout: () => out` (`:1774-1787`); `ChildOutput` keeps
-that accessor for the same reason.
+**1. Buffer from spawn, once per child.** A module-level
+`WeakMap<ChildProcessWithoutNullStreams, ChildOutput>` plus `outputOf(child)`, attaching the `data`
+listeners on first call and returning the same object thereafter — the model `collect()` (`:1774`)
+already uses locally. Three views, no line-array accessor: `stdout()` is the raw buffer, which the
+two negative guards (`:446-447`, `:861-862`) keep splitting exactly as today
+(`.split("\n").filter(l => l.trim())`) so an unterminated final frame is still counted; `stderr()`
+feeds the failure message; and `takeLine()` returns the next complete line no reader has taken, via
+an index cursor. **`takeLine()` yields only newline-terminated lines** (today's `nl >= 0` gate,
+`:31-36`) — an unterminated tail stays pending until its `\n`, or `JSON.parse` throws at the reader
+sites whenever a frame straddles a chunk boundary. Its order is the contract: split on `\n`, **pop
+the trailing element first**, *then* drop whitespace-only entries (`:85-87`); filter-then-pop loses
+the last complete line when stdout ends in a newline (`"a\nb\n"` → `["a"]`), which is #1674's own
+symptom re-shipped.
 
-`ChildOutput` needs **four** views, and conflating them breaks live assertions:
+**2. Route both readers through it**, neither attaching a listener of its own. `readOneLine` polls
+`takeLine()`; `readLines` polls it and, in the tick where the threshold is met, drains every line then
+available rather than exactly `n` — today's loop does the same, which keeps `:517`/`:773`'s
+`toHaveLength(3)` sensitive to an over-delivered 4th frame — and still resolves (never rejects) on its
+deadline. **Stated semantics change:** readers consume stdout in emission order from spawn, so
+`:621`'s `readLines(child, 1, 500)` becomes strictly stronger; a red there is a real extra frame, not
+a helper regression. Say so in the PR body.
 
-- `stdout(): string` — the raw accumulated stdout, unsplit and unfiltered. The two negative
-  guards (`:446-447`, `:861-862`) split it **exactly as they do today**
-  (`.split("\n").filter(l => l.trim())`), so a final *unterminated* frame — the plausible shape at
-  `:446-447`, where the bridge writes then dies on `shutdown(1)` after `PREFLIGHT_GRACE_MS` — is
-  still counted. Routing those two sites through `lines()` would silently narrow them.
-- `takeLine(): string | undefined` — the next complete line no reader has taken, via an index
-  cursor. **Only newline-terminated lines are ever yielded**: the unterminated tail of the buffer
-  is never returned and stays pending until its `\n` arrives, preserving today's `nl >= 0` gate at
-  `:31-36`. A `takeLine` that could hand back a partial frame would make `JSON.parse` throw at
-  `:599`, `:615`, `:731`, `:852` and `:909` whenever a frame straddles a chunk boundary — a new
-  load-dependent flake of exactly the class being removed. **The two rules are order-sensitive and
-  the order is the contract**: split on `\n`, **POP the trailing element first** (that is the
-  unterminated tail), *then* drop whitespace-only entries. Filtering before popping loses the last
-  *complete* line whenever stdout ends with a newline — `"a\nb\n".split("\n")` is
-  `["a","b",""]`, so pop-then-filter yields `["a","b"]` while filter-then-pop yields `["a"]`, which
-  reproduces #1674's own symptom (a reader hanging on a line already emitted).
-- `stderr(): string` — accumulated stderr, for the failure message.
+**3. Make the deadline name its subject** (#1674's third direction). `readOneLine` gains an optional
+third argument **`what = "stdout"`** — today's exact noun, so the nine unchanged sites keep printing
+`no stdout within Nms` and `dev-standalone.test.ts:68`'s #724 cross-reference stays valid. The
+rejection reads `no <what> within <timeoutMs>ms (child exited with code N | child still running).
+stderr=<last 500 chars, prefixed … when truncated> stdout=<stdout()>`. Liveness is
+`exitCode !== null || signalCode !== null`, rendered `exitCode ?? signalCode` — `exitCode` is `null`
+for a signal-killed child and this file SIGKILLs in `afterEach` (`:236-239`, `:404-408`). Pass an
+explicit `what`, phrased to read after "no", at the three `readOneLine` calls in
+`describe("mcp-stdio per-request timeout")` (`:730`, `:851`, `:908`); `readLines` takes none.
 
-`takeLine()` **skips whitespace-only lines**, matching the `if (part.trim())` filter in today's
-`readLines` (`:85-87`) that `:517`/`:773`'s `toHaveLength(3)` and their `JSON.parse` depend on.
-`stdout()` filters nothing — its callers do their own. **Line splitting stays an internal helper of
-`ChildOutput`, not a third accessor on the returned object**: after the fix no call site reads a
-whole-line array (the two negative guards read `stdout()`, both readers read `takeLine()`), so
-exposing one would ship dead surface in a change whose deliverable is "`outputOf` is the file's
-single stdout consumer".
-
-**Semantics change, stated because a reader will otherwise assume it did not happen.** Readers now
-consume the child's stdout **in emission order from spawn**, not "first line after attach". Two
-consequences to expect: at `:851` the reader asserts on the genuinely first stdout frame of that
-child (benign — a half-open child emits only the synthesized `-32000`, and `expect(first.id)
-.toBe(30)` still names any surprise); and `:621`'s `readLines(child, 1, 500)` becomes **strictly
-stronger** — it now also catches a frame emitted earlier that no reader took. A red at `:621` is
-a real extra frame, not a helper regression; say so in the PR body.
-
-**2. Route both readers through it.** `readOneLine` polls `takeLine()`. `readLines` polls
-`takeLine()` and, **in the poll tick where the threshold is first met, drains every line then
-available rather than exactly `n`** — this is a stated change, not "unchanged": today's loop
-pushes every complete line found in that tick, so a 4th frame arriving in the same 50 ms window
-makes `lines` length 4, and `:517`/`:773`'s `expect(lines).toHaveLength(3)` catch it. A cursor
-drained exactly `n` times could never return 4 and would silently lose that over-delivery
-sensitivity — at `:773` a 4th frame would be a duplicate synthesized `-32000`, the exact bug the
-neighbouring spec at `:851-872` guards. `readLines` still resolves (never rejects) on its
-deadline. Neither reader attaches a listener of its own any more.
-
-**3. Make the deadline name its subject** (#1674's third suggested direction). `readOneLine`
-takes an optional third argument **`what = "stdout"`** — the default is deliberately today's exact
-noun, so the nine unchanged call sites keep printing `no stdout within Nms` and the
-cross-reference at `tests/cli/dev-standalone.test.ts:68`, which records that string as #724's
-symptom, stays valid. The rejection reads
-`no <what> within <timeoutMs>ms (child exited with code N | child still running). stderr=<…>
-stdout=<stdout()>`. **Render only the TAIL of stderr** — the last 500 characters, prefixed with `…`
-when truncated. Moving collection to spawn time means stderr now also holds `--import tsx` startup
-noise and the bridge's two-line preflight guidance, and burying the test-relevant tail under it
-works against the legibility this fix exists to deliver. `stdout()` is rendered whole: it is the
-evidence the reader is actually looking for. **The liveness branch is `child.exitCode !== null || child.signalCode !== null`
-and renders `child exited with code <exitCode ?? signalCode>`** — `exitCode` is `null` for a
-signal-killed child, and this file kills children in `afterEach` (`:236-239`, `:404-408`), so an
-`exitCode`-only test would report a SIGKILLed child as "still running". Pass an explicit `what` at
-the **three `readOneLine`** calls inside `describe("mcp-stdio per-request timeout")` — `:730`,
-`:851`, `:908` — phrased to read grammatically after "no", e.g.
-`"synthesized -32000 for id=30 on stdout"`. **`readLines` takes no `what` and keeps its
-resolve-on-deadline contract**, because `:621`'s `expect(extra).toHaveLength(0)` asserts an empty
-*resolve*; `:773` is a `readLines` call and gets its legibility from `expect(lines)
-.toHaveLength(3)` naming the shortfall.
-
-**4. Convert both raw collectors.**
-
-(a) Delete `:831-833` (the comment, `stdoutChunks`, and the listener), call `outputOf(child)`
-immediately after that `spawn`, and rewrite `:861-862` to split `outputOf(child).stdout()`
-with the same `.split("\n").filter(l => l.trim())` it uses today. The `setTimeout(500)` quiet
-window at `:860` is unchanged in sensitivity: the pre-attached collector it replaces already saw
-every chunk, and `stdout()` is its exact equivalent.
-
-(b) At `:428-458`: call `outputOf(child)` immediately after the `spawn` at `:431-434`; change the
-`child.once("exit", …)` await at `:441` to `child.once("close", …)` (`close` fires after the
-stdio streams are closed, so the buffer is complete); replace `:443-447` with a split of
-`outputOf(child).stdout()`, identical in shape to today's; and **rewrite `:449-457` so the
-assertion cannot be swallowed and does not depend on the loop body running**:
+**4. Convert both raw collectors.** (a) Delete `:831-833`, call `outputOf(child)` immediately after
+that `spawn`, and rewrite `:861-862` to split `outputOf(child).stdout()` as today; the
+`setTimeout(500)` quiet window at `:860` is unchanged in sensitivity. (b) At `:428-458`: call
+`outputOf(child)` immediately after the `spawn` at `:431-434`; change the `child.once("exit", …)`
+await at `:441` to `"close"` so the buffer is complete; replace `:443-447` with a split of
+`outputOf(child).stdout()`; and rewrite `:449-457` so the assertion cannot be swallowed:
 
 ```
-// Preconditions, so an empty `lines` is a meaningful pass rather than a vacuous one:
 expect(child.exitCode ?? child.signalCode).not.toBeNull(); // the child actually terminated
 expect(outputOf(child).stderr()).toMatch(/preflight failed/i); // it reached the preflight refusal
 const synthesized = lines.filter((l) => {
-  let parsed: { error?: { code?: number } };
-  try { parsed = JSON.parse(l); } catch { return false; }
-  return parsed.error?.code === -32000;
+  try { return (JSON.parse(l) as { error?: { code?: number } }).error?.code === -32000; }
+  catch { return false; }
 });
 expect(synthesized).toEqual([]);
 ```
 
-Parsing happens **outside** any assertion, and the `expect` runs unconditionally, so an empty
-`lines` is now a *pass with a stated precondition* rather than a vacuous one. **The precondition is
-the stderr line, not an exit code**, and this is measured rather than assumed: spawning exactly what
-`:431-434` spawns with `TANDEM_URL=http://127.0.0.1:1`, writing the same
-`notifications/initialized` frame and awaiting `close`, the child terminates after ~1 830 ms with
-**`exitCode = 0`**, empty stdout, and stderr
-`[tandem mcp-stdio] Tandem server preflight failed at http://127.0.0.1:1 (fetch failed).` —
-`deferredShutdown` calls `shutdown(1, synth)` (`src/cli/mcp-stdio.ts:726`), but `await stdio.close()`
-inside `shutdown` (`:712`) fires `stdio.onclose` (`:821-823`), which re-enters `shutdown(0)`, falls
-straight through the `shuttingDown` latch and reaches `process.exit(0)` (`:717`) before the outer
-call reaches its own `process.exit(1)`. **So `expect(child.exitCode).toBe(1)` would be a
-deterministically red assertion**, and an exit code of `1` would not discriminate anyway — a Node or
-`tsx` module-load failure also exits `1`. The stderr line is what separates "no stdout because the
-bridge was correct" from "no stdout because the `--import tsx` child never started"; the liveness
-assertion adds that it reached a deliberate exit rather than being killed or left running.
-**If a `-32000` frame appears, that is a real finding to report, never to silence.** The
-`shutdown(1)`-exits-`0` observation is out of this group's scope (no `src/` change) and goes into
-the PR body as **observed-not-fixed**, with the measurement, so no later test or plugin host quietly
-relies on the bridge's exit status.
+**Do not assert `exitCode === 1`.** Measured 2026-09-06 (same spawn, `TANDEM_URL=http://127.0.0.1:1`,
+awaiting `close`): the child terminates after ~1 830 ms with **`exitCode = 0`**, empty stdout, stderr
+`… Tandem server preflight failed at http://127.0.0.1:1 (fetch failed).` — `deferredShutdown` calls
+`shutdown(1, synth)` (`src/cli/mcp-stdio.ts:726`), but `await stdio.close()` (`:712`) fires
+`stdio.onclose` (`:821-823`) → `shutdown(0)`, which falls through the `shuttingDown` latch to
+`process.exit(0)` (`:717`) first. The stderr line, not an exit code, separates "no stdout because the
+bridge was correct" from "no stdout because the `--import tsx` child never started". Record the
+`shutdown(1)`-exits-`0` observation in the PR body as **observed-not-fixed**.
 
-Afterwards `outputOf` is the only stdout consumer outside the `collect()` describe. Say so in a
-comment on `outputOf` — nothing enforces it, and a drift guard is out of scope for this group;
-the Tests section carries the one-line manual check instead.
-
-**5. Fix the stale cross-reference.** `scripts/ci/stdio-smoke.mjs:50` reads "ported from
-tests/cli/mcp-stdio.test.ts:46-75", which is already wrong and moves again here. Drop the line
-numbers from that comment (keep the file reference) in the same commit.
-
-**Ceilings are unchanged.** The 5 000 ms at `:851` and `:908` stay 5 000: once the line cannot be
-missed, that bound measures the bridge's 300 ms timer plus slack, not spawn latency, so #1674's
-"decouple the assertion from spawn latency" is satisfied by construction rather than by a larger
-number. No `timeoutMs()` or load scaling is introduced.
-
-**Sweep (issue's direction 2), scoped to what shares the defect.** In scope by construction: all
-**12** `await readOneLine(` and **3** `await readLines(` calls, plus the two raw collectors above.
-Explicitly **not** changed, because late attachment cannot lose what they read: `waitForCount`
-(`:56`), `waitForPosts` (`:691`), `waitFor` (`:1801`) and `settle` (`:1529`) poll counters/arrays
-owned by the test process; `collect()` (`:1774`) already attaches once; the boot `setTimeout(500)`
-sleeps (`:218`, `:1191`, `:1211`, `:1229`) precede a *first* reader on a paused stream **belonging to
-a child that is still alive**, which is what makes them safe (liveness, not buffering as such — see
-the exited-child probe in Problem); the `3_000` deadline at `:918` is about process exit, not
-streams.
-
-**Rules that bite.** `tests/scripts/coverage-manifest-wiring.test.ts:226-270` asserts
-`git grep -l expectWithinMs -- tests/` equals `SUSPENDED_TIMING_SITES`
-(`scripts/ci/coverage-manifest.mjs:122-126`); this file is on that list solely because of
-`expectWithinMs(…, 3_000, "the bridge exits promptly on stdin end")` at `:2219` — **do not delete
-or relocate it**, and do not convert any deadline here into `expectWithinMs` (that helper is for
-bounds where duration *is* the assertion; these are presence deadlines). Never set
-`TANDEM_COVERAGE=1`. The new specs go inside the existing file, so `tsconfig.tests.node.json`
-already covers them and there is no orphan risk. No `src/`, no Y.Doc write, no `data-testid`, no
-MCP tool or `/api` route: Critical Rules 1–2, 7 and 9 are not engaged.
+**5. Ceilings unchanged, no load scaling.** `:851`/`:908` stay 5 000 ms, which once the line cannot be
+missed measures the bridge's 300 ms timer plus slack, not spawn latency. The 12 `readOneLine` /
+3 `readLines` sites change helper, not call shape; nothing else is touched (`waitForCount`,
+`waitForPosts`, `waitFor`, `settle` poll in-process state; `collect()` already attaches once; the
+boot `setTimeout(500)` sleeps precede a *first* reader on a live child). Do not add, move or delete
+`expectWithinMs` here — `tests/scripts/coverage-manifest-wiring.test.ts:226-270` pins the site list
+and `:2219` is why this file is on it. Never set `TANDEM_COVERAGE=1`.
 
 ## Tests
 
-One new `describe("child output buffering")` in the same file, driving trivial
-`process.execPath -e` children rather than the bridge (~2 s total). **It holds
-`let child: ChildProcessWithoutNullStreams | undefined` and an
-`afterEach(() => { child?.kill(); child = undefined; })`, mirroring `:236-239`, and every spec
-assigns its spawn into that binding — including the already-exited children of specs 4 and 5.** Leaked child
-handles are the documented cause of #724's flakes in this exact file, so a describe without
-teardown would ship the mechanism that produces #1674's symptom.
+One new `describe("child output buffering")` in the same file, driving trivial `process.execPath -e`
+children, holding a `child` binding and `afterEach(() => { child?.kill(); child = undefined; })`
+mirroring `:236-239` (leaked child handles are #724's mechanism). Every spec calls `outputOf(child)`
+in the same tick as its `spawn`.
 
-**Every spec calls `outputOf(child)` in the same tick as its `spawn`, before any `await`** — the
-exited-child probe in Problem shows a collector attached after `close` sees nothing, and this file's
-own idiom (`:218`, `:1191`, `:1211`, `:1229`) is exactly the kind of intervening `await` that would
-make specs 2, 3 and 4 flaky-by-construction otherwise.
+1. **"delivers a line emitted before the first `readOneLine`"** — child writes one line and stays
+   alive; poll until `out.stdout().includes("\n")` (never a bare sleep — `:838-845`, #687), then
+   `readOneLine(child, 1_000)` resolves with it. *Kills* the current helper: pre-fix it rejects with
+   `stderr= stdout=`, #1674 in miniature.
+2. **"hands successive readers successive lines"** — child writes two lines and exits; two sequential
+   `readOneLine` calls return line 1 then line 2. *Kills* a cursorless shared buffer.
+3. **"waits for the newline rather than serving the unterminated tail"** — child writes `{"a":1`, then
+   `}\n` 200 ms later; `JSON.parse(await readOneLine(child, 2_000))` equals `{ a: 1 }`.
+4. **"names the awaited subject and the child's liveness"** — three arms on one helper: a child that
+   writes nothing and exits, where `readOneLine(child, 300)` with **no third argument** rejects
+   matching `/^no stdout within 300ms \(child exited with code 0\)/` (the only exercise of the
+   default); a SIGKILLed sleeping child whose rejection contains `exited` and `SIGKILL` (the only
+   case where `exitCode` is `null`, so the only one that kills an `exitCode`-only liveness test); and
+   a sleeping child where `readOneLine(child, 300, "synthesized -32000 on stdout")` rejects
+   containing both `synthesized -32000` and `still running`.
 
-1. **"delivers a line emitted before the first `readOneLine`, with another listener already
-   attached"** — child writes one JSON line then stays alive (killed by `afterEach`). Hold
-   `const out = outputOf(child)` **at spawn**, then poll a small local loop (the shape of `waitFor`
-   at `:1801`, which is describe-scoped and not reusable here) **until `out.stdout().includes("\n")`**
-   — never a bare sleep. A fixed 300 ms wait racing `node -e` startup is the load-dependent timing
-   assumption this whole group exists to remove, and this file already records subprocess startup
-   overrunning fixed sleeps under load (`:838-845`, `:895-901`, #687); on a slow box that sleep would
-   let spec 1 pass under the reverted helper and report a false "no red". Once the newline is in the
-   pre-attached buffer, `readOneLine(child, 1_000)` resolves with the line. *Kills the current
-   helper*: pre-fix this rejects with `stderr= stdout=`, reproducing #1674 in miniature. It is also
-   the only spec that fails if `outputOf` is added but the readers keep their own collectors.
-2. **"hands successive readers successive lines"** — child writes two lines then exits; two
-   sequential `readOneLine` calls return line 1 then line 2. *Kills* a shared buffer with no
-   cursor.
-3. **"reports nothing new as zero lines once earlier readers drained the queue"** —
-   **self-contained**: spawns its own child that writes exactly two lines and exits, drains both
-   with two `readOneLine` calls **in this spec**, then asserts `readLines(child, 1, 300)` resolves
-   `[]`. It must not depend on spec 2's child — the mandated `afterEach` kills it and nulls the
-   binding — and it must not simply spawn a silent child, which would pass under every
-   implementation including a reader that re-serves every line ever emitted, which is the one it
-   exists to kill (that reader would turn `:621`'s `expect(extra).toHaveLength(0)` into a false red).
-4. **"defaults to `no stdout` and names an exited child"** — child writes nothing and exits; await
-   its `close`, then call `readOneLine(child, 300)` **with no third argument** and assert the
-   rejection matches `/^no stdout within 300ms \(child exited with code 0\)/`. This is the only spec
-   that exercises the `what = "stdout"` default, which is what keeps the nine unchanged call sites
-   printing today's exact string and keeps `tests/cli/dev-standalone.test.ts:68`'s #724
-   cross-reference valid — a Done-when item nothing else would assert.
-5. **"names a signal-killed child as exited, not as still running"** — spawn a sleeping child,
-   `child.kill("SIGKILL")`, await its `close`, then `readOneLine(child, 300)` rejects with a message
-   containing `exited` and `SIGKILL`. This is the **only** case where `exitCode` is `null` while
-   `signalCode` is set, so it is the only spec that kills an `exitCode !== null`-only liveness test —
-   the lazy variant the Fix section explicitly names. Specs 4 and 6 both pass under that variant.
-6. **"names the awaited subject and a still-running child"** — child sleeps without writing;
-   `readOneLine(child, 300, "synthesized -32000 on stdout")` rejects with a message containing both
-   `synthesized -32000` and `still running`. Together with spec 4 this *kills* a fix that buffers
-   correctly but leaves the message as `no stdout within Xms`, and covers the labelled arm against
-   spec 4's default arm.
-7. **"waits for the newline rather than serving the unterminated tail"** — spawn
-   `process.execPath -e "process.stdout.write('{\"a\":1'); setTimeout(()=>process.stdout.write('}\\n'),200)"`,
-   call `outputOf(child)` at spawn, then
-   `expect(JSON.parse(await readOneLine(child, 2_000))).toEqual({ a: 1 })`. **This is the only spec
-   that can fail a `takeLine()` which yields the unterminated tail** — that implementation resolves
-   `{"a":1` and the `JSON.parse` throws — so without it the newline-termination contract is a
-   Done-when item no test exercises, and the load-dependent chunk-boundary flake it exists to
-   prevent ships anyway. Deterministic, ~0.3 s, no new mechanism.
-
-Plus the existing file green (`npx vitest run tests/cli/mcp-stdio.test.ts`, 73 specs).
-
-**Two manual checks, pasted into the PR body**, because two Done-when items have no machine gate
-and this group forbids adding one:
-
-- `grep -n "stdout.on\|stderr.on" tests/cli/mcp-stdio.test.ts` returns **exactly four hits: two
-  inside `outputOf` and two inside `collect()`** (the `spawnBridge` describe's local collector,
-  today at `:1774-1787`). **State it as a count and a location, never as pre-edit line numbers** —
-  today's seven hits are at `:27`, `:28`, `:76`, `:445`, `:833`, `:1777`, `:1780`, and the same
-  change deletes or moves four of them, so "no hit at `:445`" is satisfied by any diff that merely
-  shifts line numbers and discriminates nothing. Paste the grep output itself into the PR body.
-  That is the "single stdout consumer" item.
-- the `afterEach` hunk of the new describe, shown in the diff. That is the teardown item.
-
-**Negative control:** revert `outputOf` to per-call attachment. Spec 1 goes red
-**deterministically** — its poll proves the line reached the pre-attached collector before
-`readOneLine` runs, so the reverted helper's fresh listener provably has nothing left to see, on any
-machine. The `:851` spec is **also expected to red** — step 4a pre-attaches `outputOf(child)` right
-after that spawn, which is #1674's own symptom reproduced on demand. Do not claim spec 1 is the only
-failure.
+Plus the existing file green, `npm run typecheck`, `npm run typecheck:tests`, and the full suite via
+the pre-push hook. **Negative control:** revert `outputOf` to per-call attachment — spec 1 reds
+deterministically, and the `:851` spec reds too (that being the original bug); do not claim spec 1 is
+the only failure.
 
 ## Done when
 
-`outputOf` is the file's single stdout consumer outside `collect()` — evidenced by the grep above
-returning **exactly four hits, two in `outputOf` and two in `collect()`**, pasted into the PR body;
-both readers share its cursor and `takeLine()` never yields an unterminated line (**asserted by spec
-7**, splitting pop-first-then-filter); no whole-line array is exposed on `ChildOutput`; the two
-negative guards read `stdout()` and split it exactly as before; at `:449-457` the `-32000` check can
-no longer be swallowed by its own `catch` and the spec **proves the child reached the
-preflight-failure branch** — a liveness assertion plus the `/preflight failed/i` stderr line, never
-an exit-code equality, because the bridge measurably exits `0` there; the **seven** new specs pass,
-the new describe tears its children down (diff hunk in the PR body), and spec 1 fails on the pre-fix
-helper; the deadline message keeps `no stdout within Nms` as its default (**asserted by spec 4**),
-names the awaited subject (**spec 6**), renders only the last 500 chars of stderr, and names both
-liveness branches including a **signal-killed** child (**spec 5**); no ceiling changed;
-`scripts/ci/stdio-smoke.mjs:50` no longer cites moved line numbers; the `shutdown(1)`-exits-`0`
-observation is recorded in the PR body as observed-not-fixed; `npm run typecheck`,
-`npm run typecheck:tests` and the full vitest suite green.
+Both readers share `outputOf`'s cursor and neither attaches a listener; `takeLine()` never yields an
+unterminated line (spec 3) and pops the tail before dropping blanks; the two negative guards read
+`stdout()` and split it as before; the `:428-458` spec's `-32000` check can no longer be swallowed and
+proves the child reached the **preflight-failure branch** — a liveness assertion plus the
+`/preflight failed/i` stderr line, never an exit-code equality, because the bridge measurably exits
+`0`; the deadline message keeps `no stdout within Nms` as its default (spec 4) and names the awaited
+subject and both liveness branches; the four new specs pass and the describe tears its children down;
+no ceiling changed; the `shutdown(1)`-exits-`0` observation is in the PR body; typecheck and suite
+green.
 
 ## Not in scope
 
-Unifying `collect()` (`:1774`) with `outputOf` — that describe is already correct. Any change to
-`src/cli/mcp-stdio.ts`. Any load scaling or calibration of the deadlines; any sweep test or drift
-guard pinning "only `outputOf` may attach" (group policy). `docx-apply.test.ts` (specs G2-1672 /
-G2-1699). `CLAUDE.md` and `docs/gotchas.md` are owned by later groups.
+Any change to `src/cli/mcp-stdio.ts`. Any file but `tests/cli/mcp-stdio.test.ts` — including
+`scripts/ci/stdio-smoke.mjs`'s stale line-range citation, noted in the PR body only. Unifying
+`collect()` with `outputOf`. Load scaling or calibration; any sweep test, drift guard, frozen list or
+grep-based "single consumer" check. `docx-apply.test.ts` (G2-1672 / G2-1699). `CLAUDE.md` and
+`docs/gotchas.md` are owned by later groups.
 
-## Review corrections (round 1)
+## Review corrections (scope cut)
 
-**Adopted.**
+**Removed, not repaired:** the `scripts/ci/stdio-smoke.mjs:50` comment fix (a second file the issue
+does not name; now a PR-body note); the "`outputOf` is the file's single stdout consumer" claim and
+its two mandated manual greps (an exact hit count and an `afterEach` diff hunk — a hand-run count
+pinned in a spec is a frozen list); the `lines(): string[]` accessor (no call site after the fix);
+the seven-spec new describe, folded to four, since the three message arms are one-line assertions on
+one helper; and the round 1–3 correction logs, replaced by this section.
 
-- *Blocking* — `:444-446` is a second raw collector that makes its spec vacuous, so both the
-  "only stdout consumer" comment and the Done-when item were false as written. Fixed by converting
-  the site (Fix step 4b), naming it in Problem, and requiring the builder to treat a red there as
-  a finding. `close` replaces `exit` so the buffer is complete.
-- *Blocking* — site counts corrected to 12 `readOneLine` / 3 `readLines` (`grep -c`).
-- *Blocking* (twice, independently) — the new describe spawned children with no teardown, the
-  documented #724 mechanism. It now holds a `child` binding and an `afterEach` mirroring `:236-239`.
-- *Blocking* / *non-blocking* — `:773` is a `readLines` call and cannot take a `what`; the site
-  list is now the three `readOneLine` calls, with one sentence on why `readLines` keeps
-  resolve-on-deadline (`:621`).
-- *Non-blocking* — blank-line handling: both views skip whitespace-only lines, matching `:85-87`.
-- *Non-blocking* — `scripts/ci/stdio-smoke.mjs:50` line-range citation added to the fix.
-- *Non-blocking* — the cursor's semantics change is now stated, including that `:621` is
-  strengthened rather than preserved, and what a red there means.
-- *Non-blocking* — the quiet-window claim corrected from "strictly more sensitive" to unchanged.
-- *Non-blocking* — #724 named as a second sufficient cause of the same message.
-- *Non-blocking* — spec 5 added so the "still running" branch is observed, not asserted.
-- *Non-blocking* — line references re-derived against branch head.
-- *Non-blocking* — branch-name clause added reconciling `fix/test-timing-1674` with the ledger row.
-
-**Not adopted.** None.
-
-## Review corrections (round 2)
-
-**Adopted.**
-
-- *Blocking* — the `does not synthesize for notifications` spec is vacuous for a **second**
-  reason: the `expect` at `:453` is inside the `try` whose `catch` at `:454` swallows
-  AssertionErrors, and after the fix `lines` is legitimately empty so the loop body never runs
-  either way. Fix step 4b now rewrites `:449-457` to parse outside the assertion, assert on a
-  filtered set unconditionally, and add `expect(child.exitCode).toBe(1)` so a correct bridge is
-  distinguishable from a child that never started. Done-when restated accordingly — the false
-  "asserts for the first time" claim is gone.
-- *Blocking* — `takeLine()` was under-specified and could have returned the unterminated tail,
-  making `JSON.parse` throw at five reader sites on a chunk-boundary split. The `ChildOutput`
-  contract now pins newline-termination for both `takeLine()` and `lines()`, citing today's
-  `nl >= 0` gate at `:31-36`.
-- *Blocking* — `ChildOutput` gains a raw **`stdout(): string`** view, and both negative-assertion
-  sites (`:446-447`, `:861-862`) split it exactly as they do today rather than calling `lines()`.
-  `lines()` would drop an unterminated final frame, which is the plausible shape at `:446-447`
-  (the bridge writes then `shutdown(1)`s). The `collect()` precedent at `:1774-1787` already
-  exposes the same accessor. This also resolves the companion non-blocking finding about
-  narrowing both negative guards.
-- *Non-blocking* — `readLines` is no longer described as "unchanged": it drains every available
-  line in the tick where the threshold is met, so `:517`/`:773`'s `toHaveLength(3)` keep their
-  over-delivery sensitivity.
-- *Non-blocking* — "the bridge is not defective" softened to "no `src/` change is warranted on
-  current evidence", with the reason an empty stderr does not discriminate.
-- *Non-blocking* — line citations corrected: the raw collector block is `:831-833` (comment,
-  const, listener), the second collector `:443-445` with its read at `:446-447`, the spec
-  `:428-458` and its spawn `:431-434`.
-- *Non-blocking* — the `what` default is now `"stdout"`, so the nine unchanged sites keep printing
-  today's exact string and `tests/cli/dev-standalone.test.ts:68`'s #724 cross-reference stays
-  valid; the three explicit labels are phrased to read grammatically after "no".
-- *Non-blocking* — the liveness branch is `exitCode !== null || signalCode !== null`, rendering
-  `exitCode ?? signalCode`, so a SIGKILLed child (this file's `afterEach` shape) is not reported
-  as running.
-- *Non-blocking* (twice) — new spec 3 restated as self-contained, with an explicit warning that a
-  silent child would make it non-discriminating.
-- *Non-blocking* — the negative control no longer claims spec 1 is the only failure: the `:851`
-  spec is expected to red too, that being the original bug.
-- *Non-blocking* — two manual checks added to Tests (the `stdout.on|stderr.on` grep and the
-  `afterEach` diff hunk) so the two unmachine-checkable Done-when items have a stated evidence
-  step without adding a forbidden drift guard.
-- *Non-blocking* — header notes that the group's args set `closes: true` explicitly over the sweep
-  contract's default, and why the close is justified despite the surviving #724-class cause.
-
-**Not adopted.** None.
-
-## Review corrections (round 3)
-
-**Adopted.**
-
-- *Blocking* (raised twice, independently) — `expect(child.exitCode).toBe(1)` in Fix step 4b is
-  empirically false: measured on this box 2026-09-06, spawning exactly what `:431-434` spawns with
-  `TANDEM_URL=http://127.0.0.1:1` and awaiting `close` gives `exitCode = 0` after ~1 830 ms, empty
-  stdout, stderr `… preflight failed …`. `deferredShutdown` calls `shutdown(1, synth)`
-  (`src/cli/mcp-stdio.ts:726`) but `await stdio.close()` (`:712`) re-enters via `stdio.onclose`
-  (`:821-823`) → `shutdown(0)`, which falls through the `shuttingDown` latch to `process.exit(0)`
-  (`:717`) first. The precondition is now `expect(child.exitCode ?? child.signalCode).not.toBeNull()`
-  plus `expect(outputOf(child).stderr()).toMatch(/preflight failed/i)`; the "if `exitCode` is not 1,
-  report it" instruction is deleted (it mandated a derail into `src/`, which this spec forbids); the
-  Done-when clause now reads "reached the preflight-failure **branch**". The companion non-blocking
-  point — that exit code `1` would not have discriminated a module-load failure anyway — is folded
-  into the same rewrite.
-- *Non-blocking* — the `shutdown(1)`-can-never-exit-`1` observation is a real product finding out of
-  this group's scope; it is now required in the PR body as observed-not-fixed, with the measurement.
-- *Non-blocking* — the stream-semantics premise was over-generalised. Problem now states that a
-  paused stream buffers **only while the child is alive**, with the measured exited-child probe
-  (listeners attached 0/50/300 ms after `close` all see `""`), and Tests requires `outputOf(child)`
-  in the same tick as `spawn` for **every** spec. The boot `setTimeout(500)` sleeps are re-attributed
-  to liveness rather than to buffering.
-- *Non-blocking* — `takeLine()`'s two rules are now order-pinned: split, **pop the tail first**, then
-  drop blanks. Filter-then-pop loses the last complete line when stdout ends with a newline
-  (`"a\nb\n"` → `["a"]`), which is #1674's own symptom re-shipped.
-- *Non-blocking* — `lines(): string[]` had no call site after the fix. It is gone from the
-  `ChildOutput` contract and described as an internal helper of `takeLine()`, not an accessor on the
-  returned object; the one downstream reference in spec 3 is reworded.
-- *Non-blocking* — the rejection message renders only the **last 500 chars** of stderr (prefixed `…`
-  when truncated), since spawn-time collection now sweeps in `--import tsx` startup noise and the
-  bridge's two-line preflight guidance. `stdout()` stays whole.
-- *Non-blocking* — spec 7 added: a child writing `{"a":1` then `}\n` 200 ms later. It is the only
-  spec that can fail a `takeLine()` yielding the unterminated tail, which was a Done-when contract
-  that round 2 closed with prose alone.
-- *Non-blocking* — spec 5 added (SIGKILLed child) so the `signalCode` liveness branch is asserted
-  rather than merely required; the old specs 4/5 both passed under an `exitCode`-only test.
-- *Non-blocking* — spec 4 now calls `readOneLine(child, 300)` with **no** third argument, so the
-  `what = "stdout"` default — the thing keeping the nine unchanged sites and
-  `dev-standalone.test.ts:68`'s #724 cross-reference valid — is exercised; the labelled arm moves to
-  spec 6.
-- *Non-blocking* — spec 1's bare 300 ms sleep is replaced by a poll on
-  `out.stdout().includes("\n")`. The sleep raced `node -e` startup, which this file already documents
-  overrunning fixed sleeps under load (`:838-845`, `:895-901`, #687), so on a loaded box the negative
-  control could have reported a false "no red".
-- *Non-blocking* — the manual "single stdout consumer" grep is restated as a **count and location**
-  (exactly four hits, two in `outputOf`, two in `collect()`) with the grep output pasted, since the
-  old pre-edit line numbers (`:445`, `:833`) are deleted by the same change and would have been
-  trivially satisfied.
-
-**Not adopted.**
-
-- *Non-blocking* — "fold the round-1/round-2 correction logs and drop the Fix-step restatements to
-  get back under the ~120-line budget." The correction logs are this pipeline's only audit trail for
-  what a reviewer raised and how it was closed, and round 3 has just shown that a claim closed with
-  prose alone (`takeLine()`'s termination contract) is worth re-reading; compressing them trades a
-  real record for a length target the group brief states as approximate. The Fix/Done-when overlap
-  is deliberate for the same reason the reviewer gives — a builder who implements from Done-when
-  alone must still find the contract there.
+**Fixed directly.** *Blocking* (raised twice) — `expect(child.exitCode).toBe(1)` in step 4b is
+empirically false; the bridge exits `0` there via the `shutdown(0)` re-entry through `stdio.onclose`.
+The precondition is now a liveness assertion plus the `/preflight failed/i` stderr match; the "if
+`exitCode` is not 1, report it" instruction is deleted (it mandated a derail into `src/` this spec
+forbids); Done-when says "preflight-failure **branch**"; the `shutdown(1)`-exits-`0` finding is
+recorded as observed-not-fixed.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
@@ -2,9 +2,12 @@
 
 Branch `fix/test-timing-1674` — named for the implementation-order first issue (#1674); the
 ledger row lists the group as "#1672 #1699 #1674", so branch and row reconcile through that
-clause. Closes #1674. Non-review issue: no `areas/*.md` row, no named experiment, no `refuted.md`
-entry — the ledger row is `docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2
-test timing"). Probe: a two-case Node script settling the stream semantics the fix rests on, plus
+clause. Closes #1674 — the group's args set `closes: true` explicitly, overriding the sweep
+contract's default of `false` for a spec with a non-empty "Not in scope"; the close is justified
+because the remaining #724-class cause (below) is made *distinguishable from the message*, not
+eliminated. Non-review issue: no `areas/*.md` row, no named experiment, no `refuted.md` entry —
+the ledger row is `docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test
+timing"). Probe: a two-case Node script settling the stream semantics the fix rests on, plus
 `npx vitest run tests/cli/mcp-stdio.test.ts`.
 
 ## Problem
@@ -15,10 +18,9 @@ the 5000 ms bound cannot fix it**: the line the spec waits for was already deliv
 *different* listener and is gone.
 
 `readOneLine` (`tests/cli/mcp-stdio.test.ts:21-47`) attaches its `stdout`/`stderr` collectors
-**at call time**. That spec attaches its own raw collector immediately after `spawn` (`:832-833`,
-"Collect stdout so we can count total -32000 lines later"), putting `child.stdout` into flowing
-mode; anything emitted between that attach and `readOneLine`'s attach reaches the first collector
-only.
+**at call time**. That spec attaches its own raw collector immediately after `spawn` (`:831-833`
+— comment, `stdoutChunks`, listener), putting `child.stdout` into flowing mode; anything emitted
+between that attach and `readOneLine`'s attach reaches the first collector only.
 
 Measured, not reasoned (`node` probe, this box, 2026-09-06): with a listener attached at spawn, a
 second listener attached 400 ms later saw `""` while the first held `"LINE-A\n"`; with **no**
@@ -28,9 +30,12 @@ buffers. The loss is specific to the specs holding a pre-attached collector.
 **A second, independently sufficient cause of the same text exists and this fix does not
 eliminate it.** `tests/cli/dev-standalone.test.ts:63-70` records #724: handles leaked by another
 test file slowed subprocess startup enough that this file's timing-sensitive assertions flaked
-with `no stdout within Nms`. Both causes print `stderr= stdout=`. The loss-to-first-collector
-defect is real and removable; after the fix, the improved message (phase + `child.exitCode`) is
-what tells the two apart on the next occurrence.
+with `no stdout within Nms`. Both causes print `stderr= stdout=`. On current evidence **no `src/`
+change is warranted** — an empty stderr does not discriminate, because `armRequestTimer` →
+`sendErrorResponse` (`src/cli/mcp-stdio.ts:488-503`) writes nothing to stderr on the success
+path, so "the bridge never emitted" is not ruled out by the red alone. After the fix, a rejection
+naming the awaited subject plus the liveness branch is what tells a bridge that never emitted
+from a machine that starved.
 
 The timing that fires the removable half: `TANDEM_REQUEST_TIMEOUT_MS` is `300`, armed just before
 the POST; when the gap between `waitForPosts` returning and `readOneLine` attaching exceeds the
@@ -41,16 +46,18 @@ Two more instances of the same class, both latent, both in scope:
 
 - `"clears pendingRequests after a successful response"` calls `readOneLine` twice on one child
   (`:598`, `:614`) plus `readLines` (`:621`). Each attaches a fresh collector and none is removed.
-- `"does not synthesize for notifications (no id) on preflight failure"` (`:427-457`) is the
-  defect in its terminal form: `:444-446` builds `stdoutChunks`, attaches the listener, and joins
-  **in the same tick**, so `allOutput` is always `""`, `lines` is always `[]`, and the
-  `expect(parsed.error?.code).not.toBe(-32000)` loop at `:450-457` has never executed. **That spec
-  asserts nothing today.**
+- `"does not synthesize for notifications (no id) on preflight failure"` (`:428-458`) is the
+  defect in its terminal form, **and it is doubly vacuous**: `:443-445` builds `stdoutChunks`,
+  attaches the listener, and `:446-447` joins **in the same tick**, so `allOutput` is always `""`
+  and `lines` always `[]`; *and* the `expect(parsed.error?.code).not.toBe(-32000)` at `:453` sits
+  **inside the `try` whose `catch` at `:454` discards everything as "non-JSON line"**, so an
+  AssertionError would be swallowed even with a populated buffer. Populating the buffer alone
+  does not make this spec assert. **Both halves must be fixed together.**
 
 ## Fix
 
 All in `tests/cli/mcp-stdio.test.ts`, plus one stale citation in `scripts/ci/stdio-smoke.mjs`.
-**No `src/` change** — the bridge is not defective.
+No `src/` change (see Problem).
 
 **1. Buffer from spawn, once per child.** Add a module-level
 `const childOutputs = new WeakMap<ChildProcessWithoutNullStreams, ChildOutput>()` and
@@ -58,18 +65,29 @@ All in `tests/cli/mcp-stdio.test.ts`, plus one stale citation in `scripts/ci/std
 returning the same object thereafter. The model is already in this file: `collect()` at `:1774`
 ("Attach once and accumulate; repeated `readLines()` calls would drop data") — that describe
 solved this locally; this generalises it to the two shared helpers rather than adding a third
-mechanism.
+mechanism. `collect()` already exposes `stdout: () => out` (`:1774-1787`); `ChildOutput` keeps
+that accessor for the same reason.
 
-`ChildOutput` needs **both** views, and conflating them breaks a live assertion:
+`ChildOutput` needs **four** views, and conflating them breaks live assertions:
 
-- `lines(): string[]` — every complete stdout line ever emitted, in order, **never consumed**.
-  `:861-872` counts `-32000` frames for id=30 across the whole run and must still see the one a
-  reader took.
-- `takeLine(): string | undefined` — the next line no reader has taken, via an index cursor.
+- `stdout(): string` — the raw accumulated stdout, unsplit and unfiltered. The two negative
+  guards (`:446-447`, `:861-862`) split it **exactly as they do today**
+  (`.split("\n").filter(l => l.trim())`), so a final *unterminated* frame — the plausible shape at
+  `:446-447`, where the bridge writes then dies on `shutdown(1)` after `PREFLIGHT_GRACE_MS` — is
+  still counted. Routing those two sites through `lines()` would silently narrow them.
+- `lines(): string[]` — every **complete** (newline-terminated) stdout line ever emitted, in
+  order, **never consumed**.
+- `takeLine(): string | undefined` — the next complete line no reader has taken, via an index
+  cursor. **Only newline-terminated lines are ever yielded**: the unterminated tail of the buffer
+  is never returned and stays pending until its `\n` arrives, preserving today's `nl >= 0` gate at
+  `:31-36`. `lines()` excludes it too. A `takeLine` that could hand back a partial frame would
+  make `JSON.parse` throw at `:599`, `:615`, `:731`, `:852` and `:909` whenever a frame straddles
+  a chunk boundary — a new load-dependent flake of exactly the class being removed.
 - `stderr(): string` — accumulated stderr, for the failure message.
 
-**Both views skip whitespace-only lines**, matching the `if (part.trim())` filter in today's
-`readLines` (`:85-87`) that `:517`/`:773`'s `toHaveLength(3)` and their `JSON.parse` depend on.
+`lines()` and `takeLine()` **skip whitespace-only lines**, matching the `if (part.trim())` filter
+in today's `readLines` (`:85-87`) that `:517`/`:773`'s `toHaveLength(3)` and their `JSON.parse`
+depend on. `stdout()` filters nothing — its callers do their own.
 
 **Semantics change, stated because a reader will otherwise assume it did not happen.** Readers now
 consume the child's stdout **in emission order from spawn**, not "first line after attach". Two
@@ -79,30 +97,66 @@ child (benign — a half-open child emits only the synthesized `-32000`, and `ex
 stronger** — it now also catches a frame emitted earlier that no reader took. A red at `:621` is
 a real extra frame, not a helper regression; say so in the PR body.
 
-**2. Route both readers through it.** `readOneLine` polls `takeLine()`; `readLines` polls
-`takeLine()` up to `n` times and still resolves (never rejects) on its deadline, unchanged.
-Neither attaches a listener of its own any more.
+**2. Route both readers through it.** `readOneLine` polls `takeLine()`. `readLines` polls
+`takeLine()` and, **in the poll tick where the threshold is first met, drains every line then
+available rather than exactly `n`** — this is a stated change, not "unchanged": today's loop
+pushes every complete line found in that tick, so a 4th frame arriving in the same 50 ms window
+makes `lines` length 4, and `:517`/`:773`'s `expect(lines).toHaveLength(3)` catch it. A cursor
+drained exactly `n` times could never return 4 and would silently lose that over-delivery
+sensitivity — at `:773` a 4th frame would be a duplicate synthesized `-32000`, the exact bug the
+neighbouring spec at `:851-872` guards. `readLines` still resolves (never rejects) on its
+deadline. Neither reader attaches a listener of its own any more.
 
 **3. Make the deadline name its subject** (#1674's third suggested direction). `readOneLine`
-takes an optional third argument `what = "a line on child stdout"`; its rejection reads
+takes an optional third argument **`what = "stdout"`** — the default is deliberately today's exact
+noun, so the nine unchanged call sites keep printing `no stdout within Nms` and the
+cross-reference at `tests/cli/dev-standalone.test.ts:68`, which records that string as #724's
+symptom, stays valid. The rejection reads
 `no <what> within <timeoutMs>ms (child exited with code N | child still running). stderr=<…>
-stdout=<lines().join("\n")>`. Pass an explicit `what` at the **three `readOneLine`** calls inside
-`describe("mcp-stdio per-request timeout")` — `:730`, `:851`, `:908` — e.g.
-`"the synthesized -32000 for id=30"`. **`readLines` takes no `what` and keeps its
+stdout=<stdout()>`. **The liveness branch is `child.exitCode !== null || child.signalCode !== null`
+and renders `child exited with code <exitCode ?? signalCode>`** — `exitCode` is `null` for a
+signal-killed child, and this file kills children in `afterEach` (`:236-239`, `:404-408`), so an
+`exitCode`-only test would report a SIGKILLed child as "still running". Pass an explicit `what` at
+the **three `readOneLine`** calls inside `describe("mcp-stdio per-request timeout")` — `:730`,
+`:851`, `:908` — phrased to read grammatically after "no", e.g.
+`"synthesized -32000 for id=30 on stdout"`. **`readLines` takes no `what` and keeps its
 resolve-on-deadline contract**, because `:621`'s `expect(extra).toHaveLength(0)` asserts an empty
 *resolve*; `:773` is a `readLines` call and gets its legibility from `expect(lines)
-.toHaveLength(3)` naming the shortfall. Leave other call sites' labels at the default.
+.toHaveLength(3)` naming the shortfall.
 
-**4. Convert both raw collectors.** (a) Delete `:832-833`, call `outputOf(child)` immediately
-after that `spawn`, and rewrite `:861-872` to read `outputOf(child).lines()`. (b) At `:427-457`,
-call `outputOf(child)` immediately after the `spawn` at `:429-433`, change the
+**4. Convert both raw collectors.**
+
+(a) Delete `:831-833` (the comment, `stdoutChunks`, and the listener), call `outputOf(child)`
+immediately after that `spawn`, and rewrite `:861-862` to split `outputOf(child).stdout()`
+with the same `.split("\n").filter(l => l.trim())` it uses today. The `setTimeout(500)` quiet
+window at `:860` is unchanged in sensitivity: the pre-attached collector it replaces already saw
+every chunk, and `stdout()` is its exact equivalent.
+
+(b) At `:428-458`: call `outputOf(child)` immediately after the `spawn` at `:431-434`; change the
 `child.once("exit", …)` await at `:441` to `child.once("close", …)` (`close` fires after the
-stdio streams are closed, so the buffer is complete), and read `outputOf(child).lines()` at
-`:444-446`. This makes a spec that has asserted nothing since it was written assert for the first
-time — **run it; if it goes red, that is a real finding to report, never to silence.**
+stdio streams are closed, so the buffer is complete); replace `:443-447` with a split of
+`outputOf(child).stdout()`, identical in shape to today's; and **rewrite `:449-457` so the
+assertion cannot be swallowed and does not depend on the loop body running**:
+
+```
+expect(child.exitCode).toBe(1); // reached the preflight-failure exit, so "no output" is meaningful
+const synthesized = lines.filter((l) => {
+  let parsed: { error?: { code?: number } };
+  try { parsed = JSON.parse(l); } catch { return false; }
+  return parsed.error?.code === -32000;
+});
+expect(synthesized).toEqual([]);
+```
+
+Parsing happens **outside** any assertion, and the `expect` runs unconditionally, so an empty
+`lines` is now a *pass with a stated precondition* rather than a vacuous one — and the exit-code
+check distinguishes "no stdout because the bridge was correct" from "no stdout because the
+`--import tsx` child never started" (`TANDEM_URL` is `127.0.0.1:1`). **If `exitCode` is not 1, or
+a `-32000` frame appears, that is a real finding to report, never to silence.**
 
 Afterwards `outputOf` is the only stdout consumer outside the `collect()` describe. Say so in a
-comment on `outputOf` — nothing enforces it, and a drift guard is out of scope for this group.
+comment on `outputOf` — nothing enforces it, and a drift guard is out of scope for this group;
+the Tests section carries the one-line manual check instead.
 
 **5. Fix the stale cross-reference.** `scripts/ci/stdio-smoke.mjs:50` reads "ported from
 tests/cli/mcp-stdio.test.ts:46-75", which is already wrong and moves again here. Drop the line
@@ -119,10 +173,8 @@ Explicitly **not** changed, because late attachment cannot lose what they read: 
 (`:56`), `waitForPosts` (`:691`), `waitFor` (`:1801`) and `settle` (`:1529`) poll counters/arrays
 owned by the test process; `collect()` (`:1774`) already attaches once; the boot `setTimeout(500)`
 sleeps (`:218`, `:1191`, `:1211`, `:1229`) precede a *first* reader on a paused stream, which the
-probe's second case shows is safe; the negative `setTimeout(500)` at `:860` is a deliberate quiet
-window and is **unchanged in sensitivity** — the pre-attached collector it replaces already saw
-every chunk, and `lines()` is its exact equivalent; the `3_000` deadline at `:918` is about
-process exit, not streams.
+probe's second case shows is safe; the `3_000` deadline at `:918` is about process exit, not
+streams.
 
 **Rules that bite.** `tests/scripts/coverage-manifest-wiring.test.ts:226-270` asserts
 `git grep -l expectWithinMs -- tests/` equals `SUSPENDED_TIMING_SITES`
@@ -153,30 +205,48 @@ teardown would ship the mechanism that produces #1674's symptom.
 2. **"hands successive readers successive lines"** — child writes two lines then exits; two
    sequential `readOneLine` calls return line 1 then line 2. *Kills* a shared buffer with no
    cursor.
-3. **"reports nothing new as zero lines once earlier readers drained the queue"** — after 2,
-   `readLines(child, 1, 300)` resolves `[]`. *Kills* a `lines()`-returns-everything reader, which
-   would turn `:621`'s `expect(extra).toHaveLength(0)` into a false red.
+3. **"reports nothing new as zero lines once earlier readers drained the queue"** —
+   **self-contained**: spawns its own child that writes exactly two lines and exits, drains both
+   with two `readOneLine` calls **in this spec**, then asserts `readLines(child, 1, 300)` resolves
+   `[]`. It must not depend on spec 2's child — the mandated `afterEach` kills it and nulls the
+   binding — and it must not simply spawn a silent child, which would pass under every
+   implementation including the `lines()`-returns-everything reader it exists to kill (that reader
+   would turn `:621`'s `expect(extra).toHaveLength(0)` into a false red).
 4. **"names what it waited for and whether the child exited"** — child writes nothing and exits;
-   await its `close`, then `readOneLine(child, 300, "the synthesized -32000")` rejects with a
-   message containing both `the synthesized -32000` and `exited`.
+   await its `close`, then `readOneLine(child, 300, "synthesized -32000 on stdout")` rejects with a
+   message containing both `synthesized -32000` and `exited`.
 5. **"names a still-running child as still running"** — child sleeps without writing;
-   `readOneLine(child, 300, "the synthesized -32000")` rejects with a message containing
+   `readOneLine(child, 300, "synthesized -32000 on stdout")` rejects with a message containing
    `still running`. Specs 4 and 5 together *kill* a fix that buffers correctly but leaves the
    message as `no stdout within Xms`, and *kill* an implementation that hardcodes one liveness
    branch.
 
-Plus the existing file green (`npx vitest run tests/cli/mcp-stdio.test.ts`, 73 specs), and the
-negative control in the PR body: reverting `outputOf` to per-call attachment turns spec 1 red
-while every pre-existing spec stays green, which is what "latent" means.
+Plus the existing file green (`npx vitest run tests/cli/mcp-stdio.test.ts`, 73 specs).
+
+**Two manual checks, pasted into the PR body**, because two Done-when items have no machine gate
+and this group forbids adding one:
+
+- `grep -n "stdout.on\|stderr.on" tests/cli/mcp-stdio.test.ts` returns only the lines inside
+  `outputOf` and inside `collect()` — post-fix there must be no hit at `:27-28`, `:76`, `:445` or
+  `:833`. That is the "single stdout consumer" item.
+- the `afterEach` hunk of the new describe, shown in the diff. That is the teardown item.
+
+**Negative control:** revert `outputOf` to per-call attachment. Spec 1 goes red
+**deterministically**, and the `:851` spec is **also expected to red** — step 4a pre-attaches
+`outputOf(child)` right after that spawn, which is #1674's own symptom reproduced on demand. Do
+not claim spec 1 is the only failure.
 
 ## Done when
 
-`outputOf` is the file's single stdout consumer outside `collect()` — including at `:444-446`,
-which now asserts for the first time; both readers share its cursor; the five new specs pass, the
-new describe tears its children down, and spec 1 fails on the pre-fix helper; the deadline message
-names the awaited subject and both liveness branches; no ceiling changed;
-`scripts/ci/stdio-smoke.mjs:50` no longer cites moved line numbers; `npm run typecheck`,
-`npm run typecheck:tests` and the full vitest suite green.
+`outputOf` is the file's single stdout consumer outside `collect()` (evidenced by the grep above);
+both readers share its cursor and `takeLine()` never yields an unterminated line; the two negative
+guards read `stdout()` and split it exactly as before; at `:449-457` the `-32000` check can no
+longer be swallowed by its own `catch` and the spec proves the child reached its preflight-failure
+exit; the five new specs pass, the new describe tears its children down (diff hunk in the PR body),
+and spec 1 fails on the pre-fix helper; the deadline message keeps `no stdout within Nms` as its
+default and names the awaited subject and both liveness branches (including a signal-killed child);
+no ceiling changed; `scripts/ci/stdio-smoke.mjs:50` no longer cites moved line numbers;
+`npm run typecheck`, `npm run typecheck:tests` and the full vitest suite green.
 
 ## Not in scope
 
@@ -206,8 +276,54 @@ G2-1699). `CLAUDE.md` and `docs/gotchas.md` are owned by later groups.
 - *Non-blocking* — the quiet-window claim corrected from "strictly more sensitive" to unchanged.
 - *Non-blocking* — #724 named as a second sufficient cause of the same message.
 - *Non-blocking* — spec 5 added so the "still running" branch is observed, not asserted.
-- *Non-blocking* — line references re-derived against branch head (`readOneLine` `:21-47`, raw
-  collector `:832-833`, count block `:861-872`).
+- *Non-blocking* — line references re-derived against branch head.
 - *Non-blocking* — branch-name clause added reconciling `fix/test-timing-1674` with the ledger row.
+
+**Not adopted.** None.
+
+## Review corrections (round 2)
+
+**Adopted.**
+
+- *Blocking* — the `does not synthesize for notifications` spec is vacuous for a **second**
+  reason: the `expect` at `:453` is inside the `try` whose `catch` at `:454` swallows
+  AssertionErrors, and after the fix `lines` is legitimately empty so the loop body never runs
+  either way. Fix step 4b now rewrites `:449-457` to parse outside the assertion, assert on a
+  filtered set unconditionally, and add `expect(child.exitCode).toBe(1)` so a correct bridge is
+  distinguishable from a child that never started. Done-when restated accordingly — the false
+  "asserts for the first time" claim is gone.
+- *Blocking* — `takeLine()` was under-specified and could have returned the unterminated tail,
+  making `JSON.parse` throw at five reader sites on a chunk-boundary split. The `ChildOutput`
+  contract now pins newline-termination for both `takeLine()` and `lines()`, citing today's
+  `nl >= 0` gate at `:31-36`.
+- *Blocking* — `ChildOutput` gains a raw **`stdout(): string`** view, and both negative-assertion
+  sites (`:446-447`, `:861-862`) split it exactly as they do today rather than calling `lines()`.
+  `lines()` would drop an unterminated final frame, which is the plausible shape at `:446-447`
+  (the bridge writes then `shutdown(1)`s). The `collect()` precedent at `:1774-1787` already
+  exposes the same accessor. This also resolves the companion non-blocking finding about
+  narrowing both negative guards.
+- *Non-blocking* — `readLines` is no longer described as "unchanged": it drains every available
+  line in the tick where the threshold is met, so `:517`/`:773`'s `toHaveLength(3)` keep their
+  over-delivery sensitivity.
+- *Non-blocking* — "the bridge is not defective" softened to "no `src/` change is warranted on
+  current evidence", with the reason an empty stderr does not discriminate.
+- *Non-blocking* — line citations corrected: the raw collector block is `:831-833` (comment,
+  const, listener), the second collector `:443-445` with its read at `:446-447`, the spec
+  `:428-458` and its spawn `:431-434`.
+- *Non-blocking* — the `what` default is now `"stdout"`, so the nine unchanged sites keep printing
+  today's exact string and `tests/cli/dev-standalone.test.ts:68`'s #724 cross-reference stays
+  valid; the three explicit labels are phrased to read grammatically after "no".
+- *Non-blocking* — the liveness branch is `exitCode !== null || signalCode !== null`, rendering
+  `exitCode ?? signalCode`, so a SIGKILLed child (this file's `afterEach` shape) is not reported
+  as running.
+- *Non-blocking* (twice) — new spec 3 restated as self-contained, with an explicit warning that a
+  silent child would make it non-discriminating.
+- *Non-blocking* — the negative control no longer claims spec 1 is the only failure: the `:851`
+  spec is expected to red too, that being the original bug.
+- *Non-blocking* — two manual checks added to Tests (the `stdout.on|stderr.on` grep and the
+  `afterEach` diff hunk) so the two unmachine-checkable Done-when items have a stated evidence
+  step without adding a forbidden drift guard.
+- *Non-blocking* — header notes that the group's args set `closes: true` explicitly over the sweep
+  contract's default, and why the close is justified despite the surviving #724-class cause.
 
 **Not adopted.** None.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
@@ -22,10 +22,22 @@ the 5000 ms bound cannot fix it**: the line the spec waits for was already deliv
 — comment, `stdoutChunks`, listener), putting `child.stdout` into flowing mode; anything emitted
 between that attach and `readOneLine`'s attach reaches the first collector only.
 
-Measured, not reasoned (`node` probe, this box, 2026-09-06): with a listener attached at spawn, a
-second listener attached 400 ms later saw `""` while the first held `"LINE-A\n"`; with **no**
-listener until 500 ms after the write, the late listener still saw `"LINE-B\n"` — a paused stream
-buffers. The loss is specific to the specs holding a pre-attached collector.
+Measured, not reasoned (`node` probes, this box, 2026-09-06). **A paused stream buffers only while
+the child is alive**, and the two probes bound that precisely:
+
+- *Live child.* With a listener attached at spawn, a second listener attached 400 ms later saw `""`
+  while the first held `"LINE-A\n"`; with **no** listener until 500 ms after the write, the late
+  listener still saw `"LINE-B\n"`. So on a live child late attachment loses data **only** when an
+  earlier listener already put the stream in flowing mode — which is exactly the shape of the specs
+  holding a pre-attached collector.
+- *Exited child.* A child writing `L1\nL2\n` and exiting: a listener attached in the same tick as
+  `spawn` saw `"L1\nL2\n"`; listeners attached 0 ms, 50 ms and 300 ms **after `close`** each saw
+  `""`. Once an exited child's stdio streams tear down, unread data is discarded outright, with no
+  competing listener needed.
+
+Both halves matter downstream: the first is #1674's reported failure, the second is why
+`outputOf(child)` must be called **in the same tick as `spawn`**, before any `await`, for every
+write-then-exit child.
 
 **A second, independently sufficient cause of the same text exists and this fix does not
 eliminate it.** `tests/cli/dev-standalone.test.ts:63-70` records #724: handles leaked by another
@@ -75,19 +87,26 @@ that accessor for the same reason.
   (`.split("\n").filter(l => l.trim())`), so a final *unterminated* frame — the plausible shape at
   `:446-447`, where the bridge writes then dies on `shutdown(1)` after `PREFLIGHT_GRACE_MS` — is
   still counted. Routing those two sites through `lines()` would silently narrow them.
-- `lines(): string[]` — every **complete** (newline-terminated) stdout line ever emitted, in
-  order, **never consumed**.
 - `takeLine(): string | undefined` — the next complete line no reader has taken, via an index
   cursor. **Only newline-terminated lines are ever yielded**: the unterminated tail of the buffer
   is never returned and stays pending until its `\n` arrives, preserving today's `nl >= 0` gate at
-  `:31-36`. `lines()` excludes it too. A `takeLine` that could hand back a partial frame would
-  make `JSON.parse` throw at `:599`, `:615`, `:731`, `:852` and `:909` whenever a frame straddles
-  a chunk boundary — a new load-dependent flake of exactly the class being removed.
+  `:31-36`. A `takeLine` that could hand back a partial frame would make `JSON.parse` throw at
+  `:599`, `:615`, `:731`, `:852` and `:909` whenever a frame straddles a chunk boundary — a new
+  load-dependent flake of exactly the class being removed. **The two rules are order-sensitive and
+  the order is the contract**: split on `\n`, **POP the trailing element first** (that is the
+  unterminated tail), *then* drop whitespace-only entries. Filtering before popping loses the last
+  *complete* line whenever stdout ends with a newline — `"a\nb\n".split("\n")` is
+  `["a","b",""]`, so pop-then-filter yields `["a","b"]` while filter-then-pop yields `["a"]`, which
+  reproduces #1674's own symptom (a reader hanging on a line already emitted).
 - `stderr(): string` — accumulated stderr, for the failure message.
 
-`lines()` and `takeLine()` **skip whitespace-only lines**, matching the `if (part.trim())` filter
-in today's `readLines` (`:85-87`) that `:517`/`:773`'s `toHaveLength(3)` and their `JSON.parse`
-depend on. `stdout()` filters nothing — its callers do their own.
+`takeLine()` **skips whitespace-only lines**, matching the `if (part.trim())` filter in today's
+`readLines` (`:85-87`) that `:517`/`:773`'s `toHaveLength(3)` and their `JSON.parse` depend on.
+`stdout()` filters nothing — its callers do their own. **Line splitting stays an internal helper of
+`ChildOutput`, not a third accessor on the returned object**: after the fix no call site reads a
+whole-line array (the two negative guards read `stdout()`, both readers read `takeLine()`), so
+exposing one would ship dead surface in a change whose deliverable is "`outputOf` is the file's
+single stdout consumer".
 
 **Semantics change, stated because a reader will otherwise assume it did not happen.** Readers now
 consume the child's stdout **in emission order from spawn**, not "first line after attach". Two
@@ -113,7 +132,11 @@ noun, so the nine unchanged call sites keep printing `no stdout within Nms` and 
 cross-reference at `tests/cli/dev-standalone.test.ts:68`, which records that string as #724's
 symptom, stays valid. The rejection reads
 `no <what> within <timeoutMs>ms (child exited with code N | child still running). stderr=<…>
-stdout=<stdout()>`. **The liveness branch is `child.exitCode !== null || child.signalCode !== null`
+stdout=<stdout()>`. **Render only the TAIL of stderr** — the last 500 characters, prefixed with `…`
+when truncated. Moving collection to spawn time means stderr now also holds `--import tsx` startup
+noise and the bridge's two-line preflight guidance, and burying the test-relevant tail under it
+works against the legibility this fix exists to deliver. `stdout()` is rendered whole: it is the
+evidence the reader is actually looking for. **The liveness branch is `child.exitCode !== null || child.signalCode !== null`
 and renders `child exited with code <exitCode ?? signalCode>`** — `exitCode` is `null` for a
 signal-killed child, and this file kills children in `afterEach` (`:236-239`, `:404-408`), so an
 `exitCode`-only test would report a SIGKILLed child as "still running". Pass an explicit `what` at
@@ -139,7 +162,9 @@ stdio streams are closed, so the buffer is complete); replace `:443-447` with a 
 assertion cannot be swallowed and does not depend on the loop body running**:
 
 ```
-expect(child.exitCode).toBe(1); // reached the preflight-failure exit, so "no output" is meaningful
+// Preconditions, so an empty `lines` is a meaningful pass rather than a vacuous one:
+expect(child.exitCode ?? child.signalCode).not.toBeNull(); // the child actually terminated
+expect(outputOf(child).stderr()).toMatch(/preflight failed/i); // it reached the preflight refusal
 const synthesized = lines.filter((l) => {
   let parsed: { error?: { code?: number } };
   try { parsed = JSON.parse(l); } catch { return false; }
@@ -149,10 +174,24 @@ expect(synthesized).toEqual([]);
 ```
 
 Parsing happens **outside** any assertion, and the `expect` runs unconditionally, so an empty
-`lines` is now a *pass with a stated precondition* rather than a vacuous one — and the exit-code
-check distinguishes "no stdout because the bridge was correct" from "no stdout because the
-`--import tsx` child never started" (`TANDEM_URL` is `127.0.0.1:1`). **If `exitCode` is not 1, or
-a `-32000` frame appears, that is a real finding to report, never to silence.**
+`lines` is now a *pass with a stated precondition* rather than a vacuous one. **The precondition is
+the stderr line, not an exit code**, and this is measured rather than assumed: spawning exactly what
+`:431-434` spawns with `TANDEM_URL=http://127.0.0.1:1`, writing the same
+`notifications/initialized` frame and awaiting `close`, the child terminates after ~1 830 ms with
+**`exitCode = 0`**, empty stdout, and stderr
+`[tandem mcp-stdio] Tandem server preflight failed at http://127.0.0.1:1 (fetch failed).` —
+`deferredShutdown` calls `shutdown(1, synth)` (`src/cli/mcp-stdio.ts:726`), but `await stdio.close()`
+inside `shutdown` (`:712`) fires `stdio.onclose` (`:821-823`), which re-enters `shutdown(0)`, falls
+straight through the `shuttingDown` latch and reaches `process.exit(0)` (`:717`) before the outer
+call reaches its own `process.exit(1)`. **So `expect(child.exitCode).toBe(1)` would be a
+deterministically red assertion**, and an exit code of `1` would not discriminate anyway — a Node or
+`tsx` module-load failure also exits `1`. The stderr line is what separates "no stdout because the
+bridge was correct" from "no stdout because the `--import tsx` child never started"; the liveness
+assertion adds that it reached a deliberate exit rather than being killed or left running.
+**If a `-32000` frame appears, that is a real finding to report, never to silence.** The
+`shutdown(1)`-exits-`0` observation is out of this group's scope (no `src/` change) and goes into
+the PR body as **observed-not-fixed**, with the measurement, so no later test or plugin host quietly
+relies on the bridge's exit status.
 
 Afterwards `outputOf` is the only stdout consumer outside the `collect()` describe. Say so in a
 comment on `outputOf` — nothing enforces it, and a drift guard is out of scope for this group;
@@ -172,8 +211,9 @@ number. No `timeoutMs()` or load scaling is introduced.
 Explicitly **not** changed, because late attachment cannot lose what they read: `waitForCount`
 (`:56`), `waitForPosts` (`:691`), `waitFor` (`:1801`) and `settle` (`:1529`) poll counters/arrays
 owned by the test process; `collect()` (`:1774`) already attaches once; the boot `setTimeout(500)`
-sleeps (`:218`, `:1191`, `:1211`, `:1229`) precede a *first* reader on a paused stream, which the
-probe's second case shows is safe; the `3_000` deadline at `:918` is about process exit, not
+sleeps (`:218`, `:1191`, `:1211`, `:1229`) precede a *first* reader on a paused stream **belonging to
+a child that is still alive**, which is what makes them safe (liveness, not buffering as such — see
+the exited-child probe in Problem); the `3_000` deadline at `:918` is about process exit, not
 streams.
 
 **Rules that bite.** `tests/scripts/coverage-manifest-wiring.test.ts:226-270` asserts
@@ -189,19 +229,29 @@ MCP tool or `/api` route: Critical Rules 1–2, 7 and 9 are not engaged.
 ## Tests
 
 One new `describe("child output buffering")` in the same file, driving trivial
-`process.execPath -e` children rather than the bridge (~1 s total). **It holds
+`process.execPath -e` children rather than the bridge (~2 s total). **It holds
 `let child: ChildProcessWithoutNullStreams | undefined` and an
 `afterEach(() => { child?.kill(); child = undefined; })`, mirroring `:236-239`, and every spec
-assigns its spawn into that binding — including spec 4's already-exited child.** Leaked child
+assigns its spawn into that binding — including the already-exited children of specs 4 and 5.** Leaked child
 handles are the documented cause of #724's flakes in this exact file, so a describe without
 teardown would ship the mechanism that produces #1674's symptom.
 
+**Every spec calls `outputOf(child)` in the same tick as its `spawn`, before any `await`** — the
+exited-child probe in Problem shows a collector attached after `close` sees nothing, and this file's
+own idiom (`:218`, `:1191`, `:1211`, `:1229`) is exactly the kind of intervening `await` that would
+make specs 2, 3 and 4 flaky-by-construction otherwise.
+
 1. **"delivers a line emitted before the first `readOneLine`, with another listener already
-   attached"** — child writes one JSON line then stays alive (killed by `afterEach`); call
-   `outputOf(child)` at spawn; wait 300 ms; `readOneLine(child, 1_000)` resolves with the line.
-   *Kills the current helper*: pre-fix this rejects with `stderr= stdout=`, reproducing #1674 in
-   miniature. It is also the only spec that fails if `outputOf` is added but the readers keep
-   their own collectors.
+   attached"** — child writes one JSON line then stays alive (killed by `afterEach`). Hold
+   `const out = outputOf(child)` **at spawn**, then poll a small local loop (the shape of `waitFor`
+   at `:1801`, which is describe-scoped and not reusable here) **until `out.stdout().includes("\n")`**
+   — never a bare sleep. A fixed 300 ms wait racing `node -e` startup is the load-dependent timing
+   assumption this whole group exists to remove, and this file already records subprocess startup
+   overrunning fixed sleeps under load (`:838-845`, `:895-901`, #687); on a slow box that sleep would
+   let spec 1 pass under the reverted helper and report a false "no red". Once the newline is in the
+   pre-attached buffer, `readOneLine(child, 1_000)` resolves with the line. *Kills the current
+   helper*: pre-fix this rejects with `stderr= stdout=`, reproducing #1674 in miniature. It is also
+   the only spec that fails if `outputOf` is added but the readers keep their own collectors.
 2. **"hands successive readers successive lines"** — child writes two lines then exits; two
    sequential `readOneLine` calls return line 1 then line 2. *Kills* a shared buffer with no
    cursor.
@@ -210,43 +260,71 @@ teardown would ship the mechanism that produces #1674's symptom.
    with two `readOneLine` calls **in this spec**, then asserts `readLines(child, 1, 300)` resolves
    `[]`. It must not depend on spec 2's child — the mandated `afterEach` kills it and nulls the
    binding — and it must not simply spawn a silent child, which would pass under every
-   implementation including the `lines()`-returns-everything reader it exists to kill (that reader
-   would turn `:621`'s `expect(extra).toHaveLength(0)` into a false red).
-4. **"names what it waited for and whether the child exited"** — child writes nothing and exits;
-   await its `close`, then `readOneLine(child, 300, "synthesized -32000 on stdout")` rejects with a
-   message containing both `synthesized -32000` and `exited`.
-5. **"names a still-running child as still running"** — child sleeps without writing;
-   `readOneLine(child, 300, "synthesized -32000 on stdout")` rejects with a message containing
-   `still running`. Specs 4 and 5 together *kill* a fix that buffers correctly but leaves the
-   message as `no stdout within Xms`, and *kill* an implementation that hardcodes one liveness
-   branch.
+   implementation including a reader that re-serves every line ever emitted, which is the one it
+   exists to kill (that reader would turn `:621`'s `expect(extra).toHaveLength(0)` into a false red).
+4. **"defaults to `no stdout` and names an exited child"** — child writes nothing and exits; await
+   its `close`, then call `readOneLine(child, 300)` **with no third argument** and assert the
+   rejection matches `/^no stdout within 300ms \(child exited with code 0\)/`. This is the only spec
+   that exercises the `what = "stdout"` default, which is what keeps the nine unchanged call sites
+   printing today's exact string and keeps `tests/cli/dev-standalone.test.ts:68`'s #724
+   cross-reference valid — a Done-when item nothing else would assert.
+5. **"names a signal-killed child as exited, not as still running"** — spawn a sleeping child,
+   `child.kill("SIGKILL")`, await its `close`, then `readOneLine(child, 300)` rejects with a message
+   containing `exited` and `SIGKILL`. This is the **only** case where `exitCode` is `null` while
+   `signalCode` is set, so it is the only spec that kills an `exitCode !== null`-only liveness test —
+   the lazy variant the Fix section explicitly names. Specs 4 and 6 both pass under that variant.
+6. **"names the awaited subject and a still-running child"** — child sleeps without writing;
+   `readOneLine(child, 300, "synthesized -32000 on stdout")` rejects with a message containing both
+   `synthesized -32000` and `still running`. Together with spec 4 this *kills* a fix that buffers
+   correctly but leaves the message as `no stdout within Xms`, and covers the labelled arm against
+   spec 4's default arm.
+7. **"waits for the newline rather than serving the unterminated tail"** — spawn
+   `process.execPath -e "process.stdout.write('{\"a\":1'); setTimeout(()=>process.stdout.write('}\\n'),200)"`,
+   call `outputOf(child)` at spawn, then
+   `expect(JSON.parse(await readOneLine(child, 2_000))).toEqual({ a: 1 })`. **This is the only spec
+   that can fail a `takeLine()` which yields the unterminated tail** — that implementation resolves
+   `{"a":1` and the `JSON.parse` throws — so without it the newline-termination contract is a
+   Done-when item no test exercises, and the load-dependent chunk-boundary flake it exists to
+   prevent ships anyway. Deterministic, ~0.3 s, no new mechanism.
 
 Plus the existing file green (`npx vitest run tests/cli/mcp-stdio.test.ts`, 73 specs).
 
 **Two manual checks, pasted into the PR body**, because two Done-when items have no machine gate
 and this group forbids adding one:
 
-- `grep -n "stdout.on\|stderr.on" tests/cli/mcp-stdio.test.ts` returns only the lines inside
-  `outputOf` and inside `collect()` — post-fix there must be no hit at `:27-28`, `:76`, `:445` or
-  `:833`. That is the "single stdout consumer" item.
+- `grep -n "stdout.on\|stderr.on" tests/cli/mcp-stdio.test.ts` returns **exactly four hits: two
+  inside `outputOf` and two inside `collect()`** (the `spawnBridge` describe's local collector,
+  today at `:1774-1787`). **State it as a count and a location, never as pre-edit line numbers** —
+  today's seven hits are at `:27`, `:28`, `:76`, `:445`, `:833`, `:1777`, `:1780`, and the same
+  change deletes or moves four of them, so "no hit at `:445`" is satisfied by any diff that merely
+  shifts line numbers and discriminates nothing. Paste the grep output itself into the PR body.
+  That is the "single stdout consumer" item.
 - the `afterEach` hunk of the new describe, shown in the diff. That is the teardown item.
 
 **Negative control:** revert `outputOf` to per-call attachment. Spec 1 goes red
-**deterministically**, and the `:851` spec is **also expected to red** — step 4a pre-attaches
-`outputOf(child)` right after that spawn, which is #1674's own symptom reproduced on demand. Do
-not claim spec 1 is the only failure.
+**deterministically** — its poll proves the line reached the pre-attached collector before
+`readOneLine` runs, so the reverted helper's fresh listener provably has nothing left to see, on any
+machine. The `:851` spec is **also expected to red** — step 4a pre-attaches `outputOf(child)` right
+after that spawn, which is #1674's own symptom reproduced on demand. Do not claim spec 1 is the only
+failure.
 
 ## Done when
 
-`outputOf` is the file's single stdout consumer outside `collect()` (evidenced by the grep above);
-both readers share its cursor and `takeLine()` never yields an unterminated line; the two negative
-guards read `stdout()` and split it exactly as before; at `:449-457` the `-32000` check can no
-longer be swallowed by its own `catch` and the spec proves the child reached its preflight-failure
-exit; the five new specs pass, the new describe tears its children down (diff hunk in the PR body),
-and spec 1 fails on the pre-fix helper; the deadline message keeps `no stdout within Nms` as its
-default and names the awaited subject and both liveness branches (including a signal-killed child);
-no ceiling changed; `scripts/ci/stdio-smoke.mjs:50` no longer cites moved line numbers;
-`npm run typecheck`, `npm run typecheck:tests` and the full vitest suite green.
+`outputOf` is the file's single stdout consumer outside `collect()` — evidenced by the grep above
+returning **exactly four hits, two in `outputOf` and two in `collect()`**, pasted into the PR body;
+both readers share its cursor and `takeLine()` never yields an unterminated line (**asserted by spec
+7**, splitting pop-first-then-filter); no whole-line array is exposed on `ChildOutput`; the two
+negative guards read `stdout()` and split it exactly as before; at `:449-457` the `-32000` check can
+no longer be swallowed by its own `catch` and the spec **proves the child reached the
+preflight-failure branch** — a liveness assertion plus the `/preflight failed/i` stderr line, never
+an exit-code equality, because the bridge measurably exits `0` there; the **seven** new specs pass,
+the new describe tears its children down (diff hunk in the PR body), and spec 1 fails on the pre-fix
+helper; the deadline message keeps `no stdout within Nms` as its default (**asserted by spec 4**),
+names the awaited subject (**spec 6**), renders only the last 500 chars of stderr, and names both
+liveness branches including a **signal-killed** child (**spec 5**); no ceiling changed;
+`scripts/ci/stdio-smoke.mjs:50` no longer cites moved line numbers; the `shutdown(1)`-exits-`0`
+observation is recorded in the PR body as observed-not-fixed; `npm run typecheck`,
+`npm run typecheck:tests` and the full vitest suite green.
 
 ## Not in scope
 
@@ -327,3 +405,63 @@ G2-1699). `CLAUDE.md` and `docs/gotchas.md` are owned by later groups.
   contract's default, and why the close is justified despite the surviving #724-class cause.
 
 **Not adopted.** None.
+
+## Review corrections (round 3)
+
+**Adopted.**
+
+- *Blocking* (raised twice, independently) — `expect(child.exitCode).toBe(1)` in Fix step 4b is
+  empirically false: measured on this box 2026-09-06, spawning exactly what `:431-434` spawns with
+  `TANDEM_URL=http://127.0.0.1:1` and awaiting `close` gives `exitCode = 0` after ~1 830 ms, empty
+  stdout, stderr `… preflight failed …`. `deferredShutdown` calls `shutdown(1, synth)`
+  (`src/cli/mcp-stdio.ts:726`) but `await stdio.close()` (`:712`) re-enters via `stdio.onclose`
+  (`:821-823`) → `shutdown(0)`, which falls through the `shuttingDown` latch to `process.exit(0)`
+  (`:717`) first. The precondition is now `expect(child.exitCode ?? child.signalCode).not.toBeNull()`
+  plus `expect(outputOf(child).stderr()).toMatch(/preflight failed/i)`; the "if `exitCode` is not 1,
+  report it" instruction is deleted (it mandated a derail into `src/`, which this spec forbids); the
+  Done-when clause now reads "reached the preflight-failure **branch**". The companion non-blocking
+  point — that exit code `1` would not have discriminated a module-load failure anyway — is folded
+  into the same rewrite.
+- *Non-blocking* — the `shutdown(1)`-can-never-exit-`1` observation is a real product finding out of
+  this group's scope; it is now required in the PR body as observed-not-fixed, with the measurement.
+- *Non-blocking* — the stream-semantics premise was over-generalised. Problem now states that a
+  paused stream buffers **only while the child is alive**, with the measured exited-child probe
+  (listeners attached 0/50/300 ms after `close` all see `""`), and Tests requires `outputOf(child)`
+  in the same tick as `spawn` for **every** spec. The boot `setTimeout(500)` sleeps are re-attributed
+  to liveness rather than to buffering.
+- *Non-blocking* — `takeLine()`'s two rules are now order-pinned: split, **pop the tail first**, then
+  drop blanks. Filter-then-pop loses the last complete line when stdout ends with a newline
+  (`"a\nb\n"` → `["a"]`), which is #1674's own symptom re-shipped.
+- *Non-blocking* — `lines(): string[]` had no call site after the fix. It is gone from the
+  `ChildOutput` contract and described as an internal helper of `takeLine()`, not an accessor on the
+  returned object; the one downstream reference in spec 3 is reworded.
+- *Non-blocking* — the rejection message renders only the **last 500 chars** of stderr (prefixed `…`
+  when truncated), since spawn-time collection now sweeps in `--import tsx` startup noise and the
+  bridge's two-line preflight guidance. `stdout()` stays whole.
+- *Non-blocking* — spec 7 added: a child writing `{"a":1` then `}\n` 200 ms later. It is the only
+  spec that can fail a `takeLine()` yielding the unterminated tail, which was a Done-when contract
+  that round 2 closed with prose alone.
+- *Non-blocking* — spec 5 added (SIGKILLed child) so the `signalCode` liveness branch is asserted
+  rather than merely required; the old specs 4/5 both passed under an `exitCode`-only test.
+- *Non-blocking* — spec 4 now calls `readOneLine(child, 300)` with **no** third argument, so the
+  `what = "stdout"` default — the thing keeping the nine unchanged sites and
+  `dev-standalone.test.ts:68`'s #724 cross-reference valid — is exercised; the labelled arm moves to
+  spec 6.
+- *Non-blocking* — spec 1's bare 300 ms sleep is replaced by a poll on
+  `out.stdout().includes("\n")`. The sleep raced `node -e` startup, which this file already documents
+  overrunning fixed sleeps under load (`:838-845`, `:895-901`, #687), so on a loaded box the negative
+  control could have reported a false "no red".
+- *Non-blocking* — the manual "single stdout consumer" grep is restated as a **count and location**
+  (exactly four hits, two in `outputOf`, two in `collect()`) with the grep output pasted, since the
+  old pre-edit line numbers (`:445`, `:833`) are deleted by the same change and would have been
+  trivially satisfied.
+
+**Not adopted.**
+
+- *Non-blocking* — "fold the round-1/round-2 correction logs and drop the Fix-step restatements to
+  get back under the ~120-line budget." The correction logs are this pipeline's only audit trail for
+  what a reviewer raised and how it was closed, and round 3 has just shown that a claim closed with
+  prose alone (`takeLine()`'s termination contract) is worth re-reading; compressing them trades a
+  real record for a length target the group brief states as approximate. The Fix/Done-when overlap
+  is deliberate for the same reason the reviewer gives — a builder who implements from Done-when
+  alone must still find the contract there.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
@@ -1,0 +1,142 @@
+# G2 — #1674 `mcp-stdio.test.ts` loses the line it is waiting for, then blames the bridge
+
+Branch `fix/test-timing-1674`. Closes #1674. Non-review issue: no `areas/*.md` row, no named
+experiment, no `refuted.md` entry — the ledger row is
+`docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test timing"). Probe: a
+two-case Node script settling the stream semantics the fix rests on, plus
+`npx vitest run tests/cli/mcp-stdio.test.ts`.
+
+## Problem
+
+The reported red is `no stdout within 5000ms. stderr= stdout=` on `mcp-stdio per-request timeout
+> does not synthesize double -32000 when timer fires before upstream crash arrives`. **The cause
+is not the size of the 5000 ms bound, and raising it cannot fix this**: the line the spec waits
+for was already delivered to a *different* listener and is gone.
+
+`readOneLine` (`tests/cli/mcp-stdio.test.ts:21-48`) attaches its `stdout`/`stderr` collectors
+**at call time**. That spec attaches its own raw collector immediately after `spawn` (`:830-831`,
+"Collect stdout so we can count total -32000 lines later"), putting `child.stdout` into flowing
+mode; anything emitted between that attach and `readOneLine`'s attach reaches the first collector
+only.
+
+Measured, not reasoned (`node` probe, this box, 2026-09-06): with a listener attached at spawn, a
+second listener attached 400 ms later saw `""` while the first held `"LINE-A\n"`; with **no**
+listener until 500 ms after the write, the late listener still saw `"LINE-B\n"` — a paused stream
+buffers. So the loss is specific to the one spec holding a pre-attached collector, which is
+exactly the spec #1674 names.
+
+The timing that fires it: `TANDEM_REQUEST_TIMEOUT_MS` is `300`, armed just before the POST;
+`waitForPosts` polls at 50 ms; under load the gap between `waitForPosts` returning and
+`readOneLine` attaching exceeds the ~290 ms of remaining timer, the `-32000` lands in
+`stdoutChunks`, and `readOneLine` waits its full 5 000 ms on a stream that will never speak
+again. Both streams read empty because stderr was genuinely silent.
+
+Second, latent instance: `"clears pendingRequests after a successful response"` calls
+`readOneLine` twice on one child (`:598`, `:614`) plus `readLines` (`:621`). Each attaches a
+fresh collector and none is ever removed, so a line emitted between one reader resolving and the
+next attaching is lost. It has not fired only because the id=2 error is triggered by the test
+itself, after reader 2 attaches.
+
+## Fix
+
+All in `tests/cli/mcp-stdio.test.ts`. **No `src/` change** — the bridge is not defective.
+
+**1. Buffer from spawn, once per child.** Add a module-level
+`const childOutputs = new WeakMap<ChildProcessWithoutNullStreams, ChildOutput>()` and
+`function outputOf(child): ChildOutput`, attaching the `data` listeners on first call and
+returning the same object thereafter. The model is already in this file: `collect()` at `:1774`
+("Attach once and accumulate; repeated `readLines()` calls would drop data") — that describe
+solved this locally; this generalises it to the two shared helpers rather than adding a third
+mechanism.
+
+`ChildOutput` needs **both** views, and conflating them breaks a live assertion:
+
+- `lines(): string[]` — every complete stdout line ever emitted, in order, **never consumed**.
+  `:860-869` counts `-32000` frames for id=30 across the whole run and must still see the one a
+  reader took.
+- `takeLine(): string | undefined` — the next line no reader has taken, via an index cursor. This
+  preserves the per-call semantics `:621`'s `expect(extra).toHaveLength(0)` depends on.
+- `stderr(): string` — accumulated stderr, for the failure message.
+
+**2. Route both readers through it.** `readOneLine` polls `takeLine()`; `readLines` polls
+`takeLine()` up to `n` times and still resolves (never rejects) on its deadline, unchanged.
+Neither attaches a listener of its own any more.
+
+**3. Make the deadline name its subject** (#1674's third suggested direction). `readOneLine`
+takes an optional third argument `what = "a line on child stdout"`; its rejection reads
+`no <what> within <timeoutMs>ms (child exited with code N | child still running). stderr=<…>
+stdout=<lines().join("\n")>`. `child.exitCode`/`signalCode` are the single most diagnostic fact
+available and cost one interpolation. Pass an explicit `what` at the four rejecting reader calls
+inside `describe("mcp-stdio per-request timeout")` (`:730`, `:773`, `:851`, `:908`) — e.g.
+`"the synthesized -32000 for id=30"`. Leave other call sites' labels at the default.
+
+**4. Delete the raw collector at `:830-831`**, calling `outputOf(child)` immediately after that
+`spawn` instead, and rewrite `:860-869` to read `outputOf(child).lines()`. This is the site that
+made the loss possible; afterwards `outputOf` is the only stdout consumer outside the `collect()`
+describe. Say so in a comment on `outputOf` — nothing enforces it, and a drift guard is out of
+scope for this group.
+
+**Ceilings are unchanged.** The 5 000 ms at `:851` and `:908` stay 5 000: once the line cannot be
+missed, that bound measures the bridge's 300 ms timer plus slack, not spawn latency, so #1674's
+"decouple the assertion from spawn latency" is satisfied by construction rather than by a larger
+number. No `timeoutMs()` or load scaling is introduced.
+
+**Sweep (issue's direction 2), scoped to what shares the defect.** In scope by construction:
+every `readOneLine` (10 sites) and `readLines` (4 sites) call. Explicitly **not** changed, because
+late attachment cannot lose what they read: `waitForCount` (`:56`), `waitForPosts` (`:691`),
+`waitFor` (`:1801`) and `settle` (`:1529`) poll counters/arrays owned by the test process;
+`collect()` (`:1774`) already attaches once; the boot `setTimeout(500)` sleeps (`:218`, `:1191`,
+`:1211`, `:1229`) precede a *first* reader on a paused stream, which the probe's second case
+shows is safe; the negative `setTimeout(500)` at `:860` is a deliberate quiet window and becomes
+strictly more sensitive once the count reads all lines; the `3_000` deadline at `:918` is about
+process exit, not streams.
+
+**Rules that bite.** `tests/scripts/coverage-manifest-wiring.test.ts:226-270` asserts
+`git grep -l expectWithinMs -- tests/` equals `SUSPENDED_TIMING_SITES`
+(`scripts/ci/coverage-manifest.mjs:122-126`); this file is on that list solely because of
+`expectWithinMs(…, 3_000, "the bridge exits promptly on stdin end")` at `:2219` — **do not delete
+or relocate it**, and do not convert any deadline here into `expectWithinMs` (that helper is for
+bounds where duration *is* the assertion; these are presence deadlines). Never set
+`TANDEM_COVERAGE=1`. The new specs go inside the existing file, so `tsconfig.tests.node.json`
+already covers them and there is no orphan risk. No `src/`, no Y.Doc write, no `data-testid`, no
+MCP tool or `/api` route: Critical Rules 1–2, 7 and 9 are not engaged.
+
+## Tests
+
+One new `describe("child output buffering")` in the same file, driving trivial
+`process.execPath -e` children rather than the bridge (~1 s total, and it isolates the helper
+from every bridge behaviour):
+
+1. **"delivers a line emitted before the first `readOneLine`, with another listener already
+   attached"** — child writes one JSON line then stays alive; call `outputOf(child)` at spawn;
+   wait 300 ms; `readOneLine(child, 1_000)` resolves with the line. *Kills the current helper*:
+   pre-fix this rejects with `stderr= stdout=`, reproducing #1674 in miniature. It is also the
+   only spec that fails if `outputOf` is added but the readers keep their own collectors.
+2. **"hands successive readers successive lines"** — child writes two lines; two sequential
+   `readOneLine` calls return line 1 then line 2. *Kills* a shared buffer with no cursor.
+3. **"reports nothing new as zero lines once earlier readers drained the queue"** — after 2,
+   `readLines(child, 1, 300)` resolves `[]`. *Kills* a `lines()`-returns-everything reader, which
+   would turn `:621`'s `expect(extra).toHaveLength(0)` into a false red.
+4. **"names what it waited for and whether the child is still running"** — child writes nothing
+   and exits; await its `exit`, then `readOneLine(child, 300, "the synthesized -32000")` rejects
+   with a message containing both `the synthesized -32000` and `exited`. *Kills* a fix that
+   buffers correctly but leaves the message as `no stdout within Xms` — the half of #1674 about
+   the red naming the wrong subject.
+
+Plus the existing file green (`npx vitest run tests/cli/mcp-stdio.test.ts`, 73 specs), and the
+negative control in the PR body: reverting `outputOf` to per-call attachment turns spec 1 red
+while every pre-existing spec stays green, which is what "latent" means.
+
+## Done when
+
+`outputOf` is the file's single stdout consumer outside `collect()`; both readers share its
+cursor; the four new specs pass and spec 1 fails on the pre-fix helper; the deadline message names
+the awaited subject and the child's liveness; no ceiling changed; `npm run typecheck`,
+`npm run typecheck:tests` and the full vitest suite green.
+
+## Not in scope
+
+Unifying `collect()` (`:1774`) with `outputOf` — that describe is already correct. Any change to
+`src/cli/mcp-stdio.ts`. Any load scaling or calibration of the deadlines; any sweep test or drift
+guard pinning "only `outputOf` may attach" (group policy). `docx-apply.test.ts` (specs G2-1672 /
+G2-1699). `CLAUDE.md` and `docs/gotchas.md` are owned by later groups.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1674.md
@@ -1,20 +1,21 @@
 # G2 — #1674 `mcp-stdio.test.ts` loses the line it is waiting for, then blames the bridge
 
-Branch `fix/test-timing-1674`. Closes #1674. Non-review issue: no `areas/*.md` row, no named
-experiment, no `refuted.md` entry — the ledger row is
-`docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test timing"). Probe: a
-two-case Node script settling the stream semantics the fix rests on, plus
+Branch `fix/test-timing-1674` — named for the implementation-order first issue (#1674); the
+ledger row lists the group as "#1672 #1699 #1674", so branch and row reconcile through that
+clause. Closes #1674. Non-review issue: no `areas/*.md` row, no named experiment, no `refuted.md`
+entry — the ledger row is `docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2
+test timing"). Probe: a two-case Node script settling the stream semantics the fix rests on, plus
 `npx vitest run tests/cli/mcp-stdio.test.ts`.
 
 ## Problem
 
 The reported red is `no stdout within 5000ms. stderr= stdout=` on `mcp-stdio per-request timeout
-> does not synthesize double -32000 when timer fires before upstream crash arrives`. **The cause
-is not the size of the 5000 ms bound, and raising it cannot fix this**: the line the spec waits
-for was already delivered to a *different* listener and is gone.
+> does not synthesize double -32000 when timer fires before upstream crash arrives`. **Raising
+the 5000 ms bound cannot fix it**: the line the spec waits for was already delivered to a
+*different* listener and is gone.
 
-`readOneLine` (`tests/cli/mcp-stdio.test.ts:21-48`) attaches its `stdout`/`stderr` collectors
-**at call time**. That spec attaches its own raw collector immediately after `spawn` (`:830-831`,
+`readOneLine` (`tests/cli/mcp-stdio.test.ts:21-47`) attaches its `stdout`/`stderr` collectors
+**at call time**. That spec attaches its own raw collector immediately after `spawn` (`:832-833`,
 "Collect stdout so we can count total -32000 lines later"), putting `child.stdout` into flowing
 mode; anything emitted between that attach and `readOneLine`'s attach reaches the first collector
 only.
@@ -22,24 +23,34 @@ only.
 Measured, not reasoned (`node` probe, this box, 2026-09-06): with a listener attached at spawn, a
 second listener attached 400 ms later saw `""` while the first held `"LINE-A\n"`; with **no**
 listener until 500 ms after the write, the late listener still saw `"LINE-B\n"` — a paused stream
-buffers. So the loss is specific to the one spec holding a pre-attached collector, which is
-exactly the spec #1674 names.
+buffers. The loss is specific to the specs holding a pre-attached collector.
 
-The timing that fires it: `TANDEM_REQUEST_TIMEOUT_MS` is `300`, armed just before the POST;
-`waitForPosts` polls at 50 ms; under load the gap between `waitForPosts` returning and
-`readOneLine` attaching exceeds the ~290 ms of remaining timer, the `-32000` lands in
-`stdoutChunks`, and `readOneLine` waits its full 5 000 ms on a stream that will never speak
-again. Both streams read empty because stderr was genuinely silent.
+**A second, independently sufficient cause of the same text exists and this fix does not
+eliminate it.** `tests/cli/dev-standalone.test.ts:63-70` records #724: handles leaked by another
+test file slowed subprocess startup enough that this file's timing-sensitive assertions flaked
+with `no stdout within Nms`. Both causes print `stderr= stdout=`. The loss-to-first-collector
+defect is real and removable; after the fix, the improved message (phase + `child.exitCode`) is
+what tells the two apart on the next occurrence.
 
-Second, latent instance: `"clears pendingRequests after a successful response"` calls
-`readOneLine` twice on one child (`:598`, `:614`) plus `readLines` (`:621`). Each attaches a
-fresh collector and none is ever removed, so a line emitted between one reader resolving and the
-next attaching is lost. It has not fired only because the id=2 error is triggered by the test
-itself, after reader 2 attaches.
+The timing that fires the removable half: `TANDEM_REQUEST_TIMEOUT_MS` is `300`, armed just before
+the POST; when the gap between `waitForPosts` returning and `readOneLine` attaching exceeds the
+~290 ms of remaining timer, the `-32000` lands in `stdoutChunks` and `readOneLine` waits its full
+5 000 ms on a stream that will never speak again.
+
+Two more instances of the same class, both latent, both in scope:
+
+- `"clears pendingRequests after a successful response"` calls `readOneLine` twice on one child
+  (`:598`, `:614`) plus `readLines` (`:621`). Each attaches a fresh collector and none is removed.
+- `"does not synthesize for notifications (no id) on preflight failure"` (`:427-457`) is the
+  defect in its terminal form: `:444-446` builds `stdoutChunks`, attaches the listener, and joins
+  **in the same tick**, so `allOutput` is always `""`, `lines` is always `[]`, and the
+  `expect(parsed.error?.code).not.toBe(-32000)` loop at `:450-457` has never executed. **That spec
+  asserts nothing today.**
 
 ## Fix
 
-All in `tests/cli/mcp-stdio.test.ts`. **No `src/` change** — the bridge is not defective.
+All in `tests/cli/mcp-stdio.test.ts`, plus one stale citation in `scripts/ci/stdio-smoke.mjs`.
+**No `src/` change** — the bridge is not defective.
 
 **1. Buffer from spawn, once per child.** Add a module-level
 `const childOutputs = new WeakMap<ChildProcessWithoutNullStreams, ChildOutput>()` and
@@ -52,11 +63,21 @@ mechanism.
 `ChildOutput` needs **both** views, and conflating them breaks a live assertion:
 
 - `lines(): string[]` — every complete stdout line ever emitted, in order, **never consumed**.
-  `:860-869` counts `-32000` frames for id=30 across the whole run and must still see the one a
+  `:861-872` counts `-32000` frames for id=30 across the whole run and must still see the one a
   reader took.
-- `takeLine(): string | undefined` — the next line no reader has taken, via an index cursor. This
-  preserves the per-call semantics `:621`'s `expect(extra).toHaveLength(0)` depends on.
+- `takeLine(): string | undefined` — the next line no reader has taken, via an index cursor.
 - `stderr(): string` — accumulated stderr, for the failure message.
+
+**Both views skip whitespace-only lines**, matching the `if (part.trim())` filter in today's
+`readLines` (`:85-87`) that `:517`/`:773`'s `toHaveLength(3)` and their `JSON.parse` depend on.
+
+**Semantics change, stated because a reader will otherwise assume it did not happen.** Readers now
+consume the child's stdout **in emission order from spawn**, not "first line after attach". Two
+consequences to expect: at `:851` the reader asserts on the genuinely first stdout frame of that
+child (benign — a half-open child emits only the synthesized `-32000`, and `expect(first.id)
+.toBe(30)` still names any surprise); and `:621`'s `readLines(child, 1, 500)` becomes **strictly
+stronger** — it now also catches a frame emitted earlier that no reader took. A red at `:621` is
+a real extra frame, not a helper regression; say so in the PR body.
 
 **2. Route both readers through it.** `readOneLine` polls `takeLine()`; `readLines` polls
 `takeLine()` up to `n` times and still resolves (never rejects) on its deadline, unchanged.
@@ -65,30 +86,42 @@ Neither attaches a listener of its own any more.
 **3. Make the deadline name its subject** (#1674's third suggested direction). `readOneLine`
 takes an optional third argument `what = "a line on child stdout"`; its rejection reads
 `no <what> within <timeoutMs>ms (child exited with code N | child still running). stderr=<…>
-stdout=<lines().join("\n")>`. `child.exitCode`/`signalCode` are the single most diagnostic fact
-available and cost one interpolation. Pass an explicit `what` at the four rejecting reader calls
-inside `describe("mcp-stdio per-request timeout")` (`:730`, `:773`, `:851`, `:908`) — e.g.
-`"the synthesized -32000 for id=30"`. Leave other call sites' labels at the default.
+stdout=<lines().join("\n")>`. Pass an explicit `what` at the **three `readOneLine`** calls inside
+`describe("mcp-stdio per-request timeout")` — `:730`, `:851`, `:908` — e.g.
+`"the synthesized -32000 for id=30"`. **`readLines` takes no `what` and keeps its
+resolve-on-deadline contract**, because `:621`'s `expect(extra).toHaveLength(0)` asserts an empty
+*resolve*; `:773` is a `readLines` call and gets its legibility from `expect(lines)
+.toHaveLength(3)` naming the shortfall. Leave other call sites' labels at the default.
 
-**4. Delete the raw collector at `:830-831`**, calling `outputOf(child)` immediately after that
-`spawn` instead, and rewrite `:860-869` to read `outputOf(child).lines()`. This is the site that
-made the loss possible; afterwards `outputOf` is the only stdout consumer outside the `collect()`
-describe. Say so in a comment on `outputOf` — nothing enforces it, and a drift guard is out of
-scope for this group.
+**4. Convert both raw collectors.** (a) Delete `:832-833`, call `outputOf(child)` immediately
+after that `spawn`, and rewrite `:861-872` to read `outputOf(child).lines()`. (b) At `:427-457`,
+call `outputOf(child)` immediately after the `spawn` at `:429-433`, change the
+`child.once("exit", …)` await at `:441` to `child.once("close", …)` (`close` fires after the
+stdio streams are closed, so the buffer is complete), and read `outputOf(child).lines()` at
+`:444-446`. This makes a spec that has asserted nothing since it was written assert for the first
+time — **run it; if it goes red, that is a real finding to report, never to silence.**
+
+Afterwards `outputOf` is the only stdout consumer outside the `collect()` describe. Say so in a
+comment on `outputOf` — nothing enforces it, and a drift guard is out of scope for this group.
+
+**5. Fix the stale cross-reference.** `scripts/ci/stdio-smoke.mjs:50` reads "ported from
+tests/cli/mcp-stdio.test.ts:46-75", which is already wrong and moves again here. Drop the line
+numbers from that comment (keep the file reference) in the same commit.
 
 **Ceilings are unchanged.** The 5 000 ms at `:851` and `:908` stay 5 000: once the line cannot be
 missed, that bound measures the bridge's 300 ms timer plus slack, not spawn latency, so #1674's
 "decouple the assertion from spawn latency" is satisfied by construction rather than by a larger
 number. No `timeoutMs()` or load scaling is introduced.
 
-**Sweep (issue's direction 2), scoped to what shares the defect.** In scope by construction:
-every `readOneLine` (10 sites) and `readLines` (4 sites) call. Explicitly **not** changed, because
-late attachment cannot lose what they read: `waitForCount` (`:56`), `waitForPosts` (`:691`),
-`waitFor` (`:1801`) and `settle` (`:1529`) poll counters/arrays owned by the test process;
-`collect()` (`:1774`) already attaches once; the boot `setTimeout(500)` sleeps (`:218`, `:1191`,
-`:1211`, `:1229`) precede a *first* reader on a paused stream, which the probe's second case
-shows is safe; the negative `setTimeout(500)` at `:860` is a deliberate quiet window and becomes
-strictly more sensitive once the count reads all lines; the `3_000` deadline at `:918` is about
+**Sweep (issue's direction 2), scoped to what shares the defect.** In scope by construction: all
+**12** `await readOneLine(` and **3** `await readLines(` calls, plus the two raw collectors above.
+Explicitly **not** changed, because late attachment cannot lose what they read: `waitForCount`
+(`:56`), `waitForPosts` (`:691`), `waitFor` (`:1801`) and `settle` (`:1529`) poll counters/arrays
+owned by the test process; `collect()` (`:1774`) already attaches once; the boot `setTimeout(500)`
+sleeps (`:218`, `:1191`, `:1211`, `:1229`) precede a *first* reader on a paused stream, which the
+probe's second case shows is safe; the negative `setTimeout(500)` at `:860` is a deliberate quiet
+window and is **unchanged in sensitivity** — the pre-attached collector it replaces already saw
+every chunk, and `lines()` is its exact equivalent; the `3_000` deadline at `:918` is about
 process exit, not streams.
 
 **Rules that bite.** `tests/scripts/coverage-manifest-wiring.test.ts:226-270` asserts
@@ -104,24 +137,33 @@ MCP tool or `/api` route: Critical Rules 1–2, 7 and 9 are not engaged.
 ## Tests
 
 One new `describe("child output buffering")` in the same file, driving trivial
-`process.execPath -e` children rather than the bridge (~1 s total, and it isolates the helper
-from every bridge behaviour):
+`process.execPath -e` children rather than the bridge (~1 s total). **It holds
+`let child: ChildProcessWithoutNullStreams | undefined` and an
+`afterEach(() => { child?.kill(); child = undefined; })`, mirroring `:236-239`, and every spec
+assigns its spawn into that binding — including spec 4's already-exited child.** Leaked child
+handles are the documented cause of #724's flakes in this exact file, so a describe without
+teardown would ship the mechanism that produces #1674's symptom.
 
 1. **"delivers a line emitted before the first `readOneLine`, with another listener already
-   attached"** — child writes one JSON line then stays alive; call `outputOf(child)` at spawn;
-   wait 300 ms; `readOneLine(child, 1_000)` resolves with the line. *Kills the current helper*:
-   pre-fix this rejects with `stderr= stdout=`, reproducing #1674 in miniature. It is also the
-   only spec that fails if `outputOf` is added but the readers keep their own collectors.
-2. **"hands successive readers successive lines"** — child writes two lines; two sequential
-   `readOneLine` calls return line 1 then line 2. *Kills* a shared buffer with no cursor.
+   attached"** — child writes one JSON line then stays alive (killed by `afterEach`); call
+   `outputOf(child)` at spawn; wait 300 ms; `readOneLine(child, 1_000)` resolves with the line.
+   *Kills the current helper*: pre-fix this rejects with `stderr= stdout=`, reproducing #1674 in
+   miniature. It is also the only spec that fails if `outputOf` is added but the readers keep
+   their own collectors.
+2. **"hands successive readers successive lines"** — child writes two lines then exits; two
+   sequential `readOneLine` calls return line 1 then line 2. *Kills* a shared buffer with no
+   cursor.
 3. **"reports nothing new as zero lines once earlier readers drained the queue"** — after 2,
    `readLines(child, 1, 300)` resolves `[]`. *Kills* a `lines()`-returns-everything reader, which
    would turn `:621`'s `expect(extra).toHaveLength(0)` into a false red.
-4. **"names what it waited for and whether the child is still running"** — child writes nothing
-   and exits; await its `exit`, then `readOneLine(child, 300, "the synthesized -32000")` rejects
-   with a message containing both `the synthesized -32000` and `exited`. *Kills* a fix that
-   buffers correctly but leaves the message as `no stdout within Xms` — the half of #1674 about
-   the red naming the wrong subject.
+4. **"names what it waited for and whether the child exited"** — child writes nothing and exits;
+   await its `close`, then `readOneLine(child, 300, "the synthesized -32000")` rejects with a
+   message containing both `the synthesized -32000` and `exited`.
+5. **"names a still-running child as still running"** — child sleeps without writing;
+   `readOneLine(child, 300, "the synthesized -32000")` rejects with a message containing
+   `still running`. Specs 4 and 5 together *kill* a fix that buffers correctly but leaves the
+   message as `no stdout within Xms`, and *kill* an implementation that hardcodes one liveness
+   branch.
 
 Plus the existing file green (`npx vitest run tests/cli/mcp-stdio.test.ts`, 73 specs), and the
 negative control in the PR body: reverting `outputOf` to per-call attachment turns spec 1 red
@@ -129,9 +171,11 @@ while every pre-existing spec stays green, which is what "latent" means.
 
 ## Done when
 
-`outputOf` is the file's single stdout consumer outside `collect()`; both readers share its
-cursor; the four new specs pass and spec 1 fails on the pre-fix helper; the deadline message names
-the awaited subject and the child's liveness; no ceiling changed; `npm run typecheck`,
+`outputOf` is the file's single stdout consumer outside `collect()` — including at `:444-446`,
+which now asserts for the first time; both readers share its cursor; the five new specs pass, the
+new describe tears its children down, and spec 1 fails on the pre-fix helper; the deadline message
+names the awaited subject and both liveness branches; no ceiling changed;
+`scripts/ci/stdio-smoke.mjs:50` no longer cites moved line numbers; `npm run typecheck`,
 `npm run typecheck:tests` and the full vitest suite green.
 
 ## Not in scope
@@ -140,3 +184,30 @@ Unifying `collect()` (`:1774`) with `outputOf` — that describe is already corr
 `src/cli/mcp-stdio.ts`. Any load scaling or calibration of the deadlines; any sweep test or drift
 guard pinning "only `outputOf` may attach" (group policy). `docx-apply.test.ts` (specs G2-1672 /
 G2-1699). `CLAUDE.md` and `docs/gotchas.md` are owned by later groups.
+
+## Review corrections (round 1)
+
+**Adopted.**
+
+- *Blocking* — `:444-446` is a second raw collector that makes its spec vacuous, so both the
+  "only stdout consumer" comment and the Done-when item were false as written. Fixed by converting
+  the site (Fix step 4b), naming it in Problem, and requiring the builder to treat a red there as
+  a finding. `close` replaces `exit` so the buffer is complete.
+- *Blocking* — site counts corrected to 12 `readOneLine` / 3 `readLines` (`grep -c`).
+- *Blocking* (twice, independently) — the new describe spawned children with no teardown, the
+  documented #724 mechanism. It now holds a `child` binding and an `afterEach` mirroring `:236-239`.
+- *Blocking* / *non-blocking* — `:773` is a `readLines` call and cannot take a `what`; the site
+  list is now the three `readOneLine` calls, with one sentence on why `readLines` keeps
+  resolve-on-deadline (`:621`).
+- *Non-blocking* — blank-line handling: both views skip whitespace-only lines, matching `:85-87`.
+- *Non-blocking* — `scripts/ci/stdio-smoke.mjs:50` line-range citation added to the fix.
+- *Non-blocking* — the cursor's semantics change is now stated, including that `:621` is
+  strengthened rather than preserved, and what a red there means.
+- *Non-blocking* — the quiet-window claim corrected from "strictly more sensitive" to unchanged.
+- *Non-blocking* — #724 named as a second sufficient cause of the same message.
+- *Non-blocking* — spec 5 added so the "still running" branch is observed, not asserted.
+- *Non-blocking* — line references re-derived against branch head (`readOneLine` `:21-47`, raw
+  collector `:832-833`, count block `:861-872`).
+- *Non-blocking* — branch-name clause added reconciling `fix/test-timing-1674` with the ledger row.
+
+**Not adopted.** None.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
@@ -1,0 +1,103 @@
+# G2 — #1699 `docx-apply.test.ts`'s 60 s timeout on a rotating spec: the 800 ms baseline is now 4–20 ms
+
+Branch `fix/test-timing-1674`. Closes #1699. Non-review issue: no `areas/*.md` row, no named
+experiment, no `refuted.md` entry — the ledger row is
+`docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test timing"). Probe:
+`npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
+
+## Problem
+
+#1699 reports `tests/server/docx-apply.test.ts` hitting its 60 s ceiling in full-suite runs on a
+**different spec each time** — four distinct specs across five runs on two branches — while the
+same specs run at 801/825/816 ms in isolation and the file is green in 13.4 s. It calls that a
+~75× blowup, names the `write guards` / `backup sidecar` / `originating Word comment` describes
+as the ones doing real filesystem work, and is explicit that raising the per-test timeout would
+hide the signal. It leaves the mechanism undetermined and asks for `--reporter=verbose` durations
+under load before theorising.
+
+That measurement now exists, and it settles both halves.
+
+**The mechanism** is not in this file. #1672's second comment (same owner, same week) traces the
+contention to a leaked `claude-agent-acp@0.59.0` tree holding 30 abandoned sessions — 13.6 GB
+working set, commit charge 92.7%, nothing to do with this project. Killing it took a commit that
+had failed the suite twice to green with no code, test or rebase change, and the suite got faster
+(295.5 s → 257.4 s). That is the "fs contention across the shared worker pool" hypothesis
+confirmed, with the source outside the repo. It also explains "a different spec each time": the
+four named specs are simply the ones with real `fs` work, so a starved pool lands on whichever
+one is scheduled during the squeeze.
+
+**The baseline** is no longer 800 ms either. Re-measured on this box, 2026-09-06, whole file
+**4.14 s / 53 passed** — against the 13.4 s #1699 recorded — with all three of its named
+offenders in milliseconds:
+
+| spec (as named in #1699) | now |
+|---|---|
+| `keeps an extensionless backupPath absolute instead of resolving it against cwd` | 18 ms |
+| `marks the imported Word comment done after its promoted suggestion is applied` | 20 ms |
+| `does not refuse on mtime drift within the tolerance` | ≤ 20 ms (in the 4–20 ms band with the rest of `write guards`) |
+| slowest in the file | 620 ms / 617 ms — the two `#1749` watcher-reload specs, waiting on a real `fs.watch` debounce by design |
+
+So the ~75× gap is now a ~3000× headroom against a ceiling that is not the thing at fault.
+
+## Fix
+
+**Shared with spec `G2-1672.md` — one edit, not two.** The whole change is the doc comment above
+`REAL_APPLY_TIMEOUT_MS` in `tests/server/docx-apply.test.ts:42-54`; see G2-1672 for the exact
+content. What #1699 contributes to that comment, and must appear in it:
+
+- the four specs it named, recorded at their measured milliseconds, so the next reader of a red
+  here does not repeat the "which spec got slow" bisect #1672 warns is the wrong chase;
+- the sentence that a red here means the box, with the leaked-process-tree precedent named — this
+  is #1699's "not yet determined" question answered in the tracked file rather than in a comment
+  thread;
+- **what to grep**: vitest prints `Test timed out in 60000ms` (`300000` under
+  `TANDEM_COVERAGE=1`) and neither literal appears in the file, because the ceiling is
+  `timeoutMs(60_000, 300_000)`.
+
+**Ceilings unchanged** — `REAL_APPLY_TIMEOUT_MS` keeps `timeoutMs(60_000, 300_000)` and no
+per-`it` timeout argument is removed, which is both this group's policy and #1699's own position
+("raising the per-test timeout would hide the signal"; the converse, deleting them, would hand
+these specs the 15 s project default and re-open the #1749 watcher-reload specs to a real red).
+
+**Rules that bite.** Do not add `expectWithinMs` to this file —
+`tests/scripts/coverage-manifest-wiring.test.ts:226-270` pins
+`git grep -l expectWithinMs -- tests/` to `SUSPENDED_TIMING_SITES`
+(`scripts/ci/coverage-manifest.mjs:122-126`), which does not list `docx-apply.test.ts`. Never set
+`TANDEM_COVERAGE=1`. No `src/` change; Critical Rules 1–9 are not engaged.
+
+## Tests
+
+**No new test**, for the reason #1699 itself gives: the only property a new test could pin here
+is a duration, and a wall-clock bound in a contended pool measures the pool. Pinning one would be
+the defect this issue reports, re-committed. Sweep tests, drift guards and frozen lists are out
+by group policy.
+
+Run and recorded in the PR body:
+
+- `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`, pasted — the table above.
+  *Discriminates* the fix from a comment whose numbers were invented, and is the measurement
+  #1699 asked for.
+- The negative control already documented in the file: set `REAL_APPLY_TIMEOUT_MS` to `1`, watch
+  every carrying spec fail naming `1`, revert. *Kills* the reading that the ceiling is inert and
+  the comment describes nothing.
+- Full suite via the pre-push hook.
+
+## Done when
+
+The comment records #1699's four specs at their measured durations, says a red is the machine and
+names the greppable literal; ceilings byte-identical; verbose table in the PR body; suite green.
+
+## Not in scope
+
+Any `beforeAll` warm-up (#1672 option 1 — refuted: there is no fixed cost to move). Any ceiling
+change in either direction. `vitest.config.ts`'s 15 s project defaults. `#1617`, cited by #1699
+as the same class in a different file. `tests/cli/mcp-stdio.test.ts` (spec G2-1674). `CLAUDE.md`
+and `docs/gotchas.md` are owned by later groups.
+
+## Bryan
+
+Same call as G2-1672: on today's measurement this is **closeable with the measurement** rather
+than fixable — the 75× blowup is not reproducible, and its cause was the leaked third-party
+process tree you identified in #1672's second comment. The comment change ships either way; the
+decision to close #1699 (and #1672) instead of holding them open for another contended run is
+yours.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
@@ -1,9 +1,10 @@
-# G2 — #1699 `docx-apply.test.ts`'s 60 s timeout on a rotating spec: the 800 ms baseline is now 4–20 ms
+# G2 — #1699 `docx-apply.test.ts`'s 60 s timeout on a rotating spec: the 800 ms baseline is now 4–23 ms
 
-Branch `fix/test-timing-1674`. Closes #1699. Non-review issue: no `areas/*.md` row, no named
-experiment, no `refuted.md` entry — the ledger row is
-`docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test timing"). Probe:
-`npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
+Branch `fix/test-timing-1674` — named for the group's implementation-order first issue (#1674);
+the ledger row lists "#1672 #1699 #1674", so branch and row reconcile through that clause.
+Closes #1699. Non-review issue: no `areas/*.md` row, no named experiment, no `refuted.md` entry —
+the ledger row is `docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test
+timing"). Probe: `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
 
 ## Problem
 
@@ -23,41 +24,49 @@ working set, commit charge 92.7%, nothing to do with this project. Killing it to
 had failed the suite twice to green with no code, test or rebase change, and the suite got faster
 (295.5 s → 257.4 s). That is the "fs contention across the shared worker pool" hypothesis
 confirmed, with the source outside the repo. It also explains "a different spec each time": the
-four named specs are simply the ones with real `fs` work, so a starved pool lands on whichever
-one is scheduled during the squeeze.
+named specs are simply the ones with real `fs` work, so a starved pool lands on whichever one is
+scheduled during the squeeze.
 
 **The baseline** is no longer 800 ms either. Re-measured on this box, 2026-09-06, whole file
-**4.14 s / 53 passed** — against the 13.4 s #1699 recorded — with all three of its named
-offenders in milliseconds:
+**53 passed / `Duration 3.73s`** — against the 13.4 s #1699 recorded — with its named offenders
+in milliseconds (titles verbatim from the run):
 
-| spec (as named in #1699) | now |
+| spec | now |
 |---|---|
-| `keeps an extensionless backupPath absolute instead of resolving it against cwd` | 18 ms |
-| `marks the imported Word comment done after its promoted suggestion is applied` | 20 ms |
-| `does not refuse on mtime drift within the tolerance` | ≤ 20 ms (in the 4–20 ms band with the rest of `write guards`) |
-| slowest in the file | 620 ms / 617 ms — the two `#1749` watcher-reload specs, waiting on a real `fs.watch` debounce by design |
+| `keeps an extensionless backupPath absolute instead of resolving it against cwd` | 17 ms |
+| `marks the imported Word comment done after its promoted suggestion is applied` | 21 ms |
+| `does not refuse on mtime drift within the tolerance` | 14 ms |
+| `takes a pre-overwrite snapshot, not just the sidecar backup` | 15 ms |
+| slowest in the file | 621 ms / 520 ms — the two `#1749` watcher-reload specs, waiting on a real `fs.watch` debounce by design |
 
-So the ~75× gap is now a ~3000× headroom against a ceiling that is not the thing at fault.
+So the ~75× gap is now ~3000× of headroom against a ceiling that is not the thing at fault.
 
 ## Fix
 
-**Shared with spec `G2-1672.md` — one edit, not two.** The whole change is the doc comment above
-`REAL_APPLY_TIMEOUT_MS` in `tests/server/docx-apply.test.ts:42-54`; see G2-1672 for the exact
-content. What #1699 contributes to that comment, and must appear in it:
+**Shared with spec `G2-1672.md` — one change, not two.** It is **two comment blocks** in
+`tests/server/docx-apply.test.ts`: Block A at `:44-54` (above `REAL_APPLY_TIMEOUT_MS`, owning how
+the number was sized) and Block B at `:1019-1043` (the "EVERY test in this block" comment, owning
+the #1617 membership rule and the negative control). G2-1672 carries the exact content and the
+division of labour; editing only Block A would leave its refuted "1977ms and 463ms" / "7.6x …
+three of four full-suite runs" premises standing next to their own refutation. What **#1699**
+contributes, and must appear:
 
-- the four specs it named, recorded at their measured milliseconds, so the next reader of a red
-  here does not repeat the "which spec got slow" bisect #1672 warns is the wrong chase;
+- the **four specs it named**, recorded at the milliseconds in the table above, so the next reader
+  of a red here does not repeat the "which spec got slow" bisect #1672 warns is the wrong chase;
 - the sentence that a red here means the box, with the leaked-process-tree precedent named — this
   is #1699's "not yet determined" question answered in the tracked file rather than in a comment
   thread;
 - **what to grep**: vitest prints `Test timed out in 60000ms` (`300000` under
-  `TANDEM_COVERAGE=1`) and neither literal appears in the file, because the ceiling is
-  `timeoutMs(60_000, 300_000)`.
+  `TANDEM_COVERAGE=1`). The greppable literal is that **un-underscored `60000`**, not the
+  `60_000` in the source — the ceiling is written `timeoutMs(60_000, 300_000)` (`:55`), and
+  `60_000` separately appears three times (`:1066`, `:1095`, `:1130`) as unrelated mtime
+  arithmetic.
 
 **Ceilings unchanged** — `REAL_APPLY_TIMEOUT_MS` keeps `timeoutMs(60_000, 300_000)` and no
 per-`it` timeout argument is removed, which is both this group's policy and #1699's own position
 ("raising the per-test timeout would hide the signal"; the converse, deleting them, would hand
-these specs the 15 s project default and re-open the #1749 watcher-reload specs to a real red).
+these specs the 15 s project default and re-open the two `#1749` watcher-reload specs to a real
+red).
 
 **Rules that bite.** Do not add `expectWithinMs` to this file —
 `tests/scripts/coverage-manifest-wiring.test.ts:226-270` pins
@@ -72,20 +81,26 @@ is a duration, and a wall-clock bound in a contended pool measures the pool. Pin
 the defect this issue reports, re-committed. Sweep tests, drift guards and frozen lists are out
 by group policy.
 
+**So nothing here is machine-checked, and the reviewer's job is the discriminator**: diff the
+pasted verbose table against the numbers written into Blocks A and B, line by line, with the run's
+`Duration` and `Tests N passed` footer included so the sample is identifiable, and every spec
+title quoted verbatim.
+
 Run and recorded in the PR body:
 
-- `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`, pasted — the table above.
-  *Discriminates* the fix from a comment whose numbers were invented, and is the measurement
-  #1699 asked for.
-- The negative control already documented in the file: set `REAL_APPLY_TIMEOUT_MS` to `1`, watch
+- `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`, pasted with its footer —
+  the table above. *Discriminates* the fix from a comment whose numbers were invented, and is the
+  measurement #1699 asked for.
+- The negative control already documented in Block B: set `REAL_APPLY_TIMEOUT_MS` to `1`, watch
   every carrying spec fail naming `1`, revert. *Kills* the reading that the ceiling is inert and
-  the comment describes nothing.
+  the comments describe nothing.
 - Full suite via the pre-push hook.
 
 ## Done when
 
-The comment records #1699's four specs at their measured durations, says a red is the machine and
-names the greppable literal; ceilings byte-identical; verbose table in the PR body; suite green.
+Blocks A and B together record #1699's four named specs at their measured durations, say a red is
+the machine and name the greppable literal as vitest's `60000`; ceilings byte-identical; the
+verbose table with its footer in the PR body; suite green.
 
 ## Not in scope
 
@@ -98,6 +113,33 @@ and `docs/gotchas.md` are owned by later groups.
 
 Same call as G2-1672: on today's measurement this is **closeable with the measurement** rather
 than fixable — the 75× blowup is not reproducible, and its cause was the leaked third-party
-process tree you identified in #1672's second comment. The comment change ships either way; the
-decision to close #1699 (and #1672) instead of holding them open for another contended run is
-yours.
+process tree you identified in #1672's second comment. **This spec owns that call rather than
+deferring it**: the PR closes #1699 with the measurement as the reason, and reopening is the
+escape hatch if a contended run ever reproduces it. Flag it if you would rather it stayed open.
+
+## Review corrections (round 1)
+
+**Adopted.**
+
+- *Blocking* — the fix now names **both** comment blocks (`:44-54` and `:1019-1043`) and points at
+  G2-1672 for the division of labour, instead of scoping the change to `:42-54` alone and leaving
+  the second block's refuted premises in the same file.
+- *Blocking* / *non-blocking* — **two** `#1749` watcher-reload specs wait on the watcher under
+  their own `vi.waitFor`, not one; the table's "slowest in the file" row now says so and G2-1672
+  names `:1111`/`:1159` with their `vi.waitFor` lines.
+- *Non-blocking* — the `≤ 20 ms` guessed band for `does not refuse on mtime drift within the
+  tolerance` is replaced by its measured **14 ms**, and the table now holds the four specs the
+  Done-when counts (the fourth, `takes a pre-overwrite snapshot…`, was previously only in
+  G2-1672's table), so table and Done-when agree.
+- *Non-blocking* — the edit range corrected from `:42-54` to `:44-54` (`:42` is the `timeoutMs`
+  import).
+- *Non-blocking* — "neither literal appears in the file" corrected: `60_000` appears three times
+  as mtime arithmetic; the greppable literal is vitest's un-underscored `60000`.
+- *Non-blocking* — measurement re-taken in this worktree and written with its footer (53 passed,
+  `Duration 3.73s`); titles quoted verbatim so they paste into a `-t` filter.
+- *Non-blocking* — the review-only nature of the change and the reviewer's diff job stated.
+- *Non-blocking* — `Closes` vs the Bryan section: the spec now owns the close rather than shipping
+  a closing keyword alongside a "the decision is yours" paragraph.
+- *Non-blocking* — branch-name clause added.
+
+**Not adopted.** None.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
@@ -31,7 +31,8 @@ scheduled during the squeeze.
 
 **The baseline** is no longer 800 ms either. Re-measured on this box, 2026-09-06 — a **single-file
 `vitest run --reporter=verbose`, not under full-suite parallelism** — the whole file is
-**53 passed / `Duration 3.72s`** against the 13.4 s #1699 recorded, and its four named specs
+**53 passed** in the **~3–4 s** band (samples: 3.72 s, 3.65 s, 3.74 s) against the 13.4 s #1699
+recorded, and its four named specs
 (titles verbatim from the run) all land in the file's fast band:
 
 | spec | now |
@@ -40,26 +41,35 @@ scheduled during the squeeze.
 | `marks the imported Word comment done after its promoted suggestion is applied` | fast band |
 | `does not refuse on mtime drift within the tolerance` | fast band |
 | `takes a pre-overwrite snapshot, not just the sidecar backup` | fast band |
-| **fast band** | **single-digit to low-tens of ms** (4–25 ms across samples) |
+| **fast band** | **single-digit to low-tens of ms** |
 | slowest in the file | ~0.5–0.7 s — the two `#1749` watcher-reload specs, waiting on a real `fs.watch` debounce by design |
 
-**Bands, not point values.** Repeated runs on this same box move these four by ~2x (one sample
-gives 15/21/15/17 ms, another 7/11/6/10 ms) while the bands and the file total reproduce exactly.
-A single-run per-spec figure written into a tracked comment is the same construction as the
-premises being retired (`:45` "~21s on a dev machine", `:1021-1022` "1977ms and 463ms"), so this
-spec requires the band and the identifying run footer instead.
+**Bands, not point values — and no numeric range either.** Repeated runs on this same box move
+these four by ~2x (one sample gives 15/21/15/17 ms, another 7/11/6/10 ms) while the bands and the
+file total reproduce exactly; a third sample puts a fifth carrying spec at 27 ms, outside the
+"4–25 ms" bracket an earlier draft proposed, which is why a range is a point value with extra steps.
+A single-run per-spec figure written into a tracked comment is the same construction as the premises
+being retired (`:45` "~21s on a dev machine", `:1021-1022` "1977ms and 463ms", `:1274` "~21s on a dev
+machine" again), so this spec requires the qualitative band in the comment and the identifying run
+footer in the PR body instead.
 
 So the ~75× gap is now three orders of magnitude of headroom against a ceiling that is not the
 thing at fault.
 
 ## Fix
 
-**Shared with spec `G2-1672.md` — one change, not two.** It is **two comment blocks** in
-`tests/server/docx-apply.test.ts`: Block A at `:44-54` (above `REAL_APPLY_TIMEOUT_MS`, owning how
-the number was sized) and Block B at `:1019-1043` (the "EVERY test in this block" comment, owning
-the #1617 membership rule and the negative control). G2-1672 carries the exact content and the
-division of labour; editing only Block A would leave its refuted "1977ms and 463ms" / "7.6x …
-three of four full-suite runs" premises standing next to their own refutation. What **#1699**
+**Shared with spec `G2-1672.md` — one change, not two, and it lands as ONE commit naming both
+issues** (the sweep's "one commit per issue" would otherwise split a single comment rewrite across
+two incoherent diffs; both issues go under `## Closes` in the PR body). It is **three comment
+blocks** in `tests/server/docx-apply.test.ts`: Block A at `:44-54` (above `REAL_APPLY_TIMEOUT_MS`,
+owning how the number was sized), Block B at `:1019-1043` (the "EVERY test in this block" comment,
+owning the #1617 membership rule and the negative control), and **Block C at `:1272-1275`, above the
+`applyChangesCore — the backup sidecar` describe** — which owns nothing of its own but repeats the
+refuted "measured at ~21s on a dev machine" premise **three lines above `keeps an extensionless
+backupPath absolute instead of resolving it against cwd`, one of this issue's own four named specs**,
+measured at 21 ms. G2-1672 carries the exact content and the division of labour; editing only Block A
+would leave Block B's refuted "1977ms and 463ms" / "7.6x … three of four full-suite runs" premises
+and Block C's ~21 s claim standing next to their own refutation. What **#1699**
 contributes, and must appear — G2-1672's Block A bullet list carries all three, so following it
 satisfies this spec:
 
@@ -120,19 +130,23 @@ Run and recorded in the PR body:
 
 ## Done when
 
-Blocks A and B together name #1699's four specs **verbatim** as members of the dated fast band
-(single-digit to low-tens of ms, 2026-09-06, single-file run, whole file 53 passed /
-`Duration 3.72s`, the two `#1749` watcher specs ~0.5–0.7 s), say a red is a hang or a starved box
-rather than growth, and name the greppable literal as vitest's `60000`; no per-spec point
-millisecond value appears in either block; ceilings byte-identical; the verbose table with its
-footer in the PR body; suite green.
+Blocks A, B **and C** are all edited. A and B together name #1699's four specs **verbatim** as
+members of the dated fast band (single-digit to low-tens of ms, 2026-09-06, single-file run, whole
+file **~3–4 s / 53 specs** — the same band G2-1672 requires, so the two specs cannot disagree — with
+the two `#1749` watcher specs at ~0.5–0.7 s), say a red is a hang or a starved box rather than
+growth, and name the greppable literal as vitest's `60000`; Block C keeps its two verbatim sentences
+with the ~21 s clause replaced by a pointer to Block A, so
+**`grep -n "21s on a dev" tests/server/docx-apply.test.ts` returns nothing**; no per-spec point
+millisecond value **and no numeric millisecond range** appears in any block; ceilings byte-identical;
+the verbose table with its `Duration` / `Tests N passed` footer — the run's point values, which are
+harmless there — is in the PR body; suite green.
 
 ## Not in scope
 
 Any `beforeAll` warm-up (#1672 option 1 — refuted: there is no fixed cost to move). Any ceiling
-change in either direction. `vitest.config.ts`'s 15 s project defaults. `tests/helpers/timing.ts`'s
-own stale "Both current callers" comment — named in G2-1672's Not-in-scope with the five real
-callers, observed-not-fixed. `#1617`, cited by #1699 as the same class in a different file.
+change in either direction. `vitest.config.ts`'s 15 s project defaults. Any change to `timeoutMs`'s behaviour —
+though its stale "Both current callers" doc comment **is** fixed, as a bundled one-liner specified
+in G2-1672's Fix section (it is one hop from this edit and no wave group owns it). `#1617`, cited by #1699 as the same class in a different file.
 `tests/cli/mcp-stdio.test.ts` (spec G2-1674). `CLAUDE.md` and `docs/gotchas.md` are owned by later
 groups.
 
@@ -190,5 +204,32 @@ escape hatch if a contended run ever reproduces it. Flag it if you would rather 
   reference to G2-1672, which carries the enumeration.
 - *Non-blocking* — header notes that the group's args set `closes: true` explicitly over the sweep
   contract's default.
+
+**Not adopted.** None.
+
+## Review corrections (round 3)
+
+**Adopted.**
+
+- *Blocking* — the fix is **three** comment blocks, not two. `tests/server/docx-apply.test.ts:1272-1275`
+  repeats the refuted "measured at ~21s on a dev machine against a 15s default" premise **three lines
+  above `keeps an extensionless backupPath absolute instead of resolving it against cwd`** — one of
+  the four specs this issue names and that Blocks A/B must record as fast-band, measured at 21 ms. The
+  Fix cross-reference and Done-when now name Block C, and Done-when adds
+  `grep -n "21s on a dev"` returning nothing. Without this, both Done-whens were satisfiable while the
+  file still told the next reader the wrong thing.
+- *Non-blocking* (raised twice) — the "(4–25 ms across samples)" parenthetical is dropped from the
+  measurement table and from the Done-when requirement. A fresh run puts a carrying spec at 27 ms,
+  outside that bracket, so the shipped comment would have failed this spec's own "every band contains
+  the run's numbers" check.
+- *Non-blocking* — Done-when no longer writes the single-run point value `Duration 3.72s` into the
+  required comment content. It now requires the same `~3–4 s / 53 specs` band as G2-1672 (three
+  samples: 3.72 s, 3.65 s, 3.74 s), with the run footer moved to the PR-body requirement — which is
+  what the spec's own "the two specs cannot disagree" claim needs to be true.
+- *Non-blocking* — the sweep's "one commit per issue" is reconciled: #1672 and #1699 are one edit to
+  one file and land as a single commit naming both, with both under `## Closes`.
+- *Non-blocking* — `tests/helpers/timing.ts`'s stale caller count moves from observed-not-fixed to a
+  bundled one-line fix carried by G2-1672 (no wave group owns `tests/helpers/`); Not-in-scope updated
+  to say so. **`filesTouched` gains `tests/helpers/timing.ts`.**
 
 **Not adopted.** None.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
@@ -1,235 +1,116 @@
 # G2 — #1699 `docx-apply.test.ts`'s 60 s timeout on a rotating spec: the 800 ms baseline is now milliseconds
 
-Branch `fix/test-timing-1674` — named for the group's implementation-order first issue (#1674);
-the ledger row lists "#1672 #1699 #1674", so branch and row reconcile through that clause.
-Closes #1699 — the group's args set `closes: true` explicitly, overriding the sweep contract's
-default of `false` for a spec with a non-empty "Not in scope". Non-review issue: no `areas/*.md`
-row, no named experiment, no `refuted.md` entry — the ledger row is
-`docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test timing"). Probe:
-`npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
+Branch `fix/test-timing-1674` (named for the group's first issue; the ledger row lists
+"#1672 #1699 #1674"). Closes #1699 (the group's args set `closes: true`). Non-review issue: ledger
+row `docs/plans/2026-09-06-open-issues-sweep.md:226`; no `areas/*.md` row, experiment or
+`refuted.md` entry. Probe: `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
 
 ## Problem
 
 #1699 reports `tests/server/docx-apply.test.ts` hitting its 60 s ceiling in full-suite runs on a
-**different spec each time** — four distinct specs across five runs on two branches — while the
-same specs run at 801/825/816 ms in isolation and the file is green in 13.4 s. It calls that a
-~75× blowup, names the `write guards` / `backup sidecar` / `originating Word comment` describes
-as the ones doing real filesystem work, and is explicit that raising the per-test timeout would
-hide the signal. It leaves the mechanism undetermined and asks for `--reporter=verbose` durations
-under load before theorising.
+**different spec each time** — four distinct specs across five runs on two branches — while those
+specs run at 801/825/816 ms in isolation and the file is green in 13.4 s. It calls that a ~75×
+blowup, names the `write guards` / `backup sidecar` / `originating Word comment` describes as the
+ones doing real filesystem work, is explicit that raising the per-test timeout would hide the signal,
+leaves the mechanism undetermined, and asks for `--reporter=verbose` durations before theorising.
 
-That measurement now exists, and it settles both halves.
+That measurement now exists and settles both halves.
 
-**The mechanism** is not in this file. #1672's second comment (same owner, same week) traces the
-contention to a leaked `claude-agent-acp@0.59.0` tree holding 30 abandoned sessions — 13.6 GB
-working set, commit charge 92.7%, nothing to do with this project. Killing it took a commit that
-had failed the suite twice to green with no code, test or rebase change, and the suite got faster
-(295.5 s → 257.4 s). That is the "fs contention across the shared worker pool" hypothesis
-confirmed, with the source outside the repo. It also explains "a different spec each time": the
-named specs are simply the ones with real `fs` work, so a starved pool lands on whichever one is
-scheduled during the squeeze.
+**The mechanism is not in this file.** #1672's second comment (same owner, same week) traces the
+contention to a leaked `claude-agent-acp@0.59.0` tree holding 30 abandoned sessions — 13.6 GB working
+set, commit charge 92.7%, nothing to do with this project. Killing it took a commit that had failed
+the suite twice to green with no code, test or rebase change, and the suite got faster (295.5 s →
+257.4 s). That is the "fs contention across the shared worker pool" hypothesis confirmed with the
+source outside the repo, and it explains "a different spec each time": the named specs are simply the
+ones doing real `fs` work, so a starved pool lands on whichever is scheduled during the squeeze.
 
-**The baseline** is no longer 800 ms either. Re-measured on this box, 2026-09-06 — a **single-file
-`vitest run --reporter=verbose`, not under full-suite parallelism** — the whole file is
-**53 passed** in the **~3–4 s** band (samples: 3.72 s, 3.65 s, 3.74 s) against the 13.4 s #1699
-recorded, and its four named specs
-(titles verbatim from the run) all land in the file's fast band:
-
-| spec | now |
-|---|---|
-| `keeps an extensionless backupPath absolute instead of resolving it against cwd` | fast band |
-| `marks the imported Word comment done after its promoted suggestion is applied` | fast band |
-| `does not refuse on mtime drift within the tolerance` | fast band |
-| `takes a pre-overwrite snapshot, not just the sidecar backup` | fast band |
-| **fast band** | **single-digit to low-tens of ms** |
-| slowest in the file | ~0.5–0.7 s — the two `#1749` watcher-reload specs, waiting on a real `fs.watch` debounce by design |
-
-**Bands, not point values — and no numeric range either.** Repeated runs on this same box move
-these four by ~2x (one sample gives 15/21/15/17 ms, another 7/11/6/10 ms) while the bands and the
-file total reproduce exactly; a third sample puts a fifth carrying spec at 27 ms, outside the
-"4–25 ms" bracket an earlier draft proposed, which is why a range is a point value with extra steps.
-A single-run per-spec figure written into a tracked comment is the same construction as the premises
-being retired (`:45` "~21s on a dev machine", `:1021-1022` "1977ms and 463ms", `:1274` "~21s on a dev
-machine" again), so this spec requires the qualitative band in the comment and the identifying run
-footer in the PR body instead.
-
-So the ~75× gap is now three orders of magnitude of headroom against a ceiling that is not the
-thing at fault.
+**The baseline is no longer 800 ms.** Re-measured here 2026-09-06 — a single-file
+`vitest run --reporter=verbose`, **not under full-suite parallelism** — the file is 53 passed in the
+**~3–4 s** band against the 13.4 s #1699 recorded, and all four of its named specs land in the file's
+fast band (single-digit to low-tens of ms), as does every other spec carrying the ceiling; the
+slowest are the two `#1749` watcher-reload specs at ~0.5–0.7 s, waiting on a real `fs.watch` debounce
+by design. **Bands, not point values, and no numeric range**: repeated runs move these four ~2x (one
+sample 15/21/15/17 ms, another 7/11/6/10 ms) while the bands and the file total reproduce. So the
+~75× gap is now three orders of magnitude of headroom against a ceiling that is not what is at fault.
 
 ## Fix
 
-**Shared with spec `G2-1672.md` — one change, not two, and it lands as ONE commit naming both
-issues** (the sweep's "one commit per issue" would otherwise split a single comment rewrite across
-two incoherent diffs; both issues go under `## Closes` in the PR body). It is **three comment
-blocks** in `tests/server/docx-apply.test.ts`: Block A at `:44-54` (above `REAL_APPLY_TIMEOUT_MS`,
-owning how the number was sized), Block B at `:1019-1043` (the "EVERY test in this block" comment,
-owning the #1617 membership rule and the negative control), and **Block C at `:1272-1275`, above the
-`applyChangesCore — the backup sidecar` describe** — which owns nothing of its own but repeats the
-refuted "measured at ~21s on a dev machine" premise **three lines above `keeps an extensionless
-backupPath absolute instead of resolving it against cwd`, one of this issue's own four named specs**,
-measured at 21 ms. G2-1672 carries the exact content and the division of labour; editing only Block A
-would leave Block B's refuted "1977ms and 463ms" / "7.6x … three of four full-suite runs" premises
-and Block C's ~21 s claim standing next to their own refutation. What **#1699**
-contributes, and must appear — G2-1672's Block A bullet list carries all three, so following it
-satisfies this spec:
+**Shared with `G2-1672.md` — one change, landing as one commit naming both issues**, both under
+`## Closes` in the PR body. It is the three comment blocks in `tests/server/docx-apply.test.ts`:
+Block A (`:44-54`, above `REAL_APPLY_TIMEOUT_MS`, owning how the number was sized), Block B
+(`:1019-1043`, owning the #1617 membership rule and the negative control), and Block C (`:1272-1275`,
+above the `applyChangesCore — the backup sidecar` describe, owning nothing of its own but repeating
+the refuted "measured at ~21s on a dev machine" premise **three lines above `keeps an extensionless
+backupPath absolute instead of resolving it against cwd`** — one of this issue's own four named
+specs, measured at 22 ms). G2-1672 carries the content and the division of labour; editing fewer
+blocks leaves a refuted premise standing next to its own refutation.
 
-- the **four specs it named, quoted verbatim, recorded as members of the fast band** (not at
-  per-spec point values), so the next reader of a red here does not repeat the "which spec got
-  slow" bisect #1672 warns is the wrong chase;
-- the sentence that a red here is **a hang or a starved box, never gradual growth** — at
-  single-digit-to-low-tens of ms a 60 s ceiling cannot be crossed by drift — with the reader sent
-  to look for a never-settling `await` or an unreleased lock in the apply first, and the
-  leaked-process-tree precedent named as the machine case. This is #1699's "not yet determined"
-  question answered in the tracked file rather than in a comment thread;
-- **what to grep**: vitest prints `Test timed out in 60000ms` (`300000` under
-  `TANDEM_COVERAGE=1`). The greppable literal is that **un-underscored `60000`**, not the
-  `60_000` in the source — the ceiling is written `timeoutMs(60_000, 300_000)` (`:55`), and
-  `60_000` separately appears three times (`:1066`, `:1095`, `:1130`) as unrelated mtime
-  arithmetic.
+What **#1699** contributes, and which G2-1672's Block A bullets already satisfy:
 
-The two watcher-waiting specs are named in Block A by **verbatim title** — `the watcher reload
-that completes an apply finally lands (#1749) — clean doc` and `the watcher reload that completes
-an apply flags a conflict on a DIRTY doc (#1749)` — with their `vi.waitFor` calls at `:1141` and
-`:1175` (options at `:1145`/`:1179`) cited here, in the spec, and deliberately **not** as line
-numbers inside the shipped comment, which would invalidate on the next edit to the same file.
+- the dated fast band recorded as covering **every spec carrying the ceiling** — which subsumes this
+  issue's four named specs without pinning their titles in a comment that a rename would falsify — so
+  the next reader of a red does not repeat the "which spec got slow" bisect;
+- the sentence that a red here is **a hang or a starved box, never gradual growth**, with the reader
+  sent to look for a never-settling `await` or an unreleased lock in the apply first and the
+  leaked-process-tree precedent named as the machine case. That is #1699's "not yet determined"
+  question answered in a tracked file rather than in a comment thread;
+- **what to grep**: vitest prints `Test timed out in 60000ms` (`300000` under `TANDEM_COVERAGE=1`),
+  so the greppable literal is that un-underscored `60000`, not the `60_000` at `:55`, which also
+  appears three times (`:1066`, `:1095`, `:1130`) as unrelated mtime arithmetic.
 
-**Ceilings unchanged** — `REAL_APPLY_TIMEOUT_MS` keeps `timeoutMs(60_000, 300_000)` and no
-per-`it` timeout argument is removed, which is both this group's policy and #1699's own position
-("raising the per-test timeout would hide the signal"; the converse, deleting them, would hand
-these specs the 15 s project default and re-open the two `#1749` watcher-reload specs to a real
-red).
-
-**Rules that bite.** Do not add `expectWithinMs` to this file —
-`tests/scripts/coverage-manifest-wiring.test.ts:226-270` pins
-`git grep -l expectWithinMs -- tests/` to `SUSPENDED_TIMING_SITES`
-(`scripts/ci/coverage-manifest.mjs:122-126`), which does not list `docx-apply.test.ts`. Never set
-`TANDEM_COVERAGE=1`. No `src/` change; Critical Rules 1–9 are not engaged.
+**Ceilings unchanged** — `REAL_APPLY_TIMEOUT_MS` keeps `timeoutMs(60_000, 300_000)` and no per-`it`
+timeout argument is removed. That is both this group's policy and #1699's own position ("raising the
+per-test timeout would hide the signal"); the converse, deleting them, would hand these specs the
+15 s project default and re-open the two `#1749` watcher specs to a real red. Do not add
+`expectWithinMs` to this file (`tests/scripts/coverage-manifest-wiring.test.ts:226-270` pins the site
+list). Never set `TANDEM_COVERAGE=1`. No `src/` change.
 
 ## Tests
 
-**No new test**, for the reason #1699 itself gives: the only property a new test could pin here
-is a duration, and a wall-clock bound in a contended pool measures the pool. Pinning one would be
-the defect this issue reports, re-committed. Sweep tests, drift guards and frozen lists are out
-by group policy.
-
-**So nothing here is machine-checked, and the reviewer's job is the discriminator**: diff the
-pasted verbose table against Blocks A and B — every band written into the comment must contain the
-run's numbers, and no per-spec point value may appear — with the run's `Duration` and
-`Tests N passed` footer included so the sample is identifiable, and every spec title quoted
-verbatim.
-
-Run and recorded in the PR body:
-
-- `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`, pasted with its footer —
-  the measurement #1699 asked for. *Discriminates* the fix from a comment whose numbers were
-  invented.
-- The negative control already documented in Block B: set `REAL_APPLY_TIMEOUT_MS` to `1`, watch
-  every carrying spec fail naming `1`, revert. *Kills* the reading that the ceiling is inert and
-  the comments describe nothing.
-- Full suite via the pre-push hook.
+**No new test**, for the reason #1699 itself gives: the only property a new test could pin here is a
+duration, and a wall-clock bound in a contended pool measures the pool. Sweep tests, drift guards and
+frozen lists are out by group policy. Nothing is machine-checked, so the reviewer diffs the pasted
+verbose table against the blocks — every band in a comment must contain the run's numbers, no
+per-spec point value may appear. Run and recorded in the PR body: the verbose run with its
+`Duration` / `Tests N passed` footer (the measurement #1699 asked for); the negative control already
+documented in Block B (set `REAL_APPLY_TIMEOUT_MS` to `1`, watch every carrying spec fail naming `1`,
+revert); the full suite via the pre-push hook.
 
 ## Done when
 
-Blocks A, B **and C** are all edited. A and B together name #1699's four specs **verbatim** as
-members of the dated fast band (single-digit to low-tens of ms, 2026-09-06, single-file run, whole
-file **~3–4 s / 53 specs** — the same band G2-1672 requires, so the two specs cannot disagree — with
-the two `#1749` watcher specs at ~0.5–0.7 s), say a red is a hang or a starved box rather than
-growth, and name the greppable literal as vitest's `60000`; Block C keeps its two verbatim sentences
-with the ~21 s clause replaced by a pointer to Block A, so
-**`grep -n "21s on a dev" tests/server/docx-apply.test.ts` returns nothing**; no per-spec point
-millisecond value **and no numeric millisecond range** appears in any block; ceilings byte-identical;
-the verbose table with its `Duration` / `Tests N passed` footer — the run's point values, which are
-harmless there — is in the PR body; suite green.
+Blocks A, B **and C** are edited per G2-1672, so the dated 2026-09-06 fast band (single-file, whole
+file ~3–4 s / 53 specs, the two `#1749` watcher specs at ~0.5–0.7 s) covers every carrying spec and
+therefore this issue's four; a red is described as a hang or a starved box rather than growth; the
+greppable literal is named as vitest's `60000`; **`grep -n "21s on a dev"
+tests/server/docx-apply.test.ts` returns nothing**; no per-spec point millisecond value and no numeric
+range appears in any block; ceilings byte-identical; the verbose table with its footer is in the PR
+body; suite green.
 
 ## Not in scope
 
-Any `beforeAll` warm-up (#1672 option 1 — refuted: there is no fixed cost to move). Any ceiling
-change in either direction. `vitest.config.ts`'s 15 s project defaults. Any change to `timeoutMs`'s behaviour —
-though its stale "Both current callers" doc comment **is** fixed, as a bundled one-liner specified
-in G2-1672's Fix section (it is one hop from this edit and no wave group owns it). `#1617`, cited by #1699 as the same class in a different file.
-`tests/cli/mcp-stdio.test.ts` (spec G2-1674). `CLAUDE.md` and `docs/gotchas.md` are owned by later
-groups.
+Any `beforeAll` warm-up (#1672 option 1 — refuted: there is no fixed cost to move). Any ceiling change
+in either direction. `vitest.config.ts`'s 15 s defaults. `tests/helpers/timing.ts` — a second file
+neither issue names; its stale "Both current callers" comment is recorded in the PR body as
+observed-not-fixed. #1617, cited by #1699 as the same class in a different file.
+`tests/cli/mcp-stdio.test.ts` (G2-1674). `CLAUDE.md` and `docs/gotchas.md` are owned by later groups.
 
 ## Bryan
 
-Same call as G2-1672: on today's measurement this is **closeable with the measurement** rather
-than fixable — the 75× blowup is not reproducible, and its cause was the leaked third-party
-process tree you identified in #1672's second comment. **This spec owns that call rather than
-deferring it**: the PR closes #1699 with the measurement as the reason, and reopening is the
-escape hatch if a contended run ever reproduces it. Flag it if you would rather it stayed open.
+Same call as G2-1672: on today's measurement this is **closeable with the measurement** rather than
+fixable — the 75× blowup is not reproducible and its cause was the leaked third-party process tree
+you identified in #1672's second comment. The PR closes #1699 with the measurement as the reason and
+still ships the legibility change, since the comments explaining the ceiling are false either way.
+Reopening is the escape hatch if a contended run ever reproduces it.
 
-## Review corrections (round 1)
+## Review corrections (scope cut)
 
-**Adopted.**
+**Removed, not repaired:** the requirement that the shipped comment quote this issue's **four spec
+titles verbatim** — replaced by the band statement covering every carrying spec, which subsumes them
+and does not falsify on a rename; the duplicated per-block content restatements (G2-1672 owns them,
+this spec points at it); the `tests/helpers/timing.ts` bundled fix; and the round 1–3 correction
+logs, replaced by this section.
 
-- *Blocking* — the fix now names **both** comment blocks (`:44-54` and `:1019-1043`) and points at
-  G2-1672 for the division of labour, instead of scoping the change to `:42-54` alone and leaving
-  the second block's refuted premises in the same file.
-- *Blocking* / *non-blocking* — **two** `#1749` watcher-reload specs wait on the watcher under
-  their own `vi.waitFor`, not one; the table's "slowest in the file" row now says so.
-- *Non-blocking* — the `≤ 20 ms` guessed band for `does not refuse on mtime drift within the
-  tolerance` is replaced by measurement, and the table now holds all four specs the Done-when
-  counts, so table and Done-when agree.
-- *Non-blocking* — the edit range corrected from `:42-54` to `:44-54` (`:42` is the `timeoutMs`
-  import).
-- *Non-blocking* — "neither literal appears in the file" corrected: `60_000` appears three times
-  as mtime arithmetic; the greppable literal is vitest's un-underscored `60000`.
-- *Non-blocking* — measurement re-taken in this worktree and written with its footer; titles
-  quoted verbatim so they paste into a `-t` filter.
-- *Non-blocking* — the review-only nature of the change and the reviewer's diff job stated.
-- *Non-blocking* — `Closes` vs the Bryan section: the spec now owns the close.
-- *Non-blocking* — branch-name clause added.
-
-**Not adopted.** None.
-
-## Review corrections (round 2)
-
-**Adopted.**
-
-- *Blocking* — the four per-spec millisecond point values are gone from the table and from
-  Done-when. Both now require a **dated band** (single-digit to low-tens of ms) plus the
-  identifying run footer, with the two contradicting samples recorded as the reason: a point value
-  from one run is the construction this change exists to retire.
-- *Non-blocking* — Done-when is now satisfiable by following G2-1672's Block A bullet list, which
-  gained a bullet naming these four specs verbatim; the two specs cannot disagree.
-- *Non-blocking* — "a red means the box" sharpened to "a hang or a starved box, never gradual
-  growth", with the reader sent to look for a never-settling `await` or an unreleased lock before
-  blaming the machine.
-- *Non-blocking* — `vi.waitFor` citations corrected from `:1145`/`:1179` (the options object) to
-  `:1141`/`:1175` (the calls); the shipped comment names those specs by verbatim title, not line
-  number.
-- *Non-blocking* — the headline measurement is qualified "single-file run, not under full-suite
-  parallelism", so it is not read as refuting a full-suite-parallelism premise on its own.
-- *Non-blocking* — `tests/helpers/timing.ts`'s stale caller count noted in Not-in-scope by
-  reference to G2-1672, which carries the enumeration.
-- *Non-blocking* — header notes that the group's args set `closes: true` explicitly over the sweep
-  contract's default.
-
-**Not adopted.** None.
-
-## Review corrections (round 3)
-
-**Adopted.**
-
-- *Blocking* — the fix is **three** comment blocks, not two. `tests/server/docx-apply.test.ts:1272-1275`
-  repeats the refuted "measured at ~21s on a dev machine against a 15s default" premise **three lines
-  above `keeps an extensionless backupPath absolute instead of resolving it against cwd`** — one of
-  the four specs this issue names and that Blocks A/B must record as fast-band, measured at 21 ms. The
-  Fix cross-reference and Done-when now name Block C, and Done-when adds
-  `grep -n "21s on a dev"` returning nothing. Without this, both Done-whens were satisfiable while the
-  file still told the next reader the wrong thing.
-- *Non-blocking* (raised twice) — the "(4–25 ms across samples)" parenthetical is dropped from the
-  measurement table and from the Done-when requirement. A fresh run puts a carrying spec at 27 ms,
-  outside that bracket, so the shipped comment would have failed this spec's own "every band contains
-  the run's numbers" check.
-- *Non-blocking* — Done-when no longer writes the single-run point value `Duration 3.72s` into the
-  required comment content. It now requires the same `~3–4 s / 53 specs` band as G2-1672 (three
-  samples: 3.72 s, 3.65 s, 3.74 s), with the run footer moved to the PR-body requirement — which is
-  what the spec's own "the two specs cannot disagree" claim needs to be true.
-- *Non-blocking* — the sweep's "one commit per issue" is reconciled: #1672 and #1699 are one edit to
-  one file and land as a single commit naming both, with both under `## Closes`.
-- *Non-blocking* — `tests/helpers/timing.ts`'s stale caller count moves from observed-not-fixed to a
-  bundled one-line fix carried by G2-1672 (no wave group owns `tests/helpers/`); Not-in-scope updated
-  to say so. **`filesTouched` gains `tests/helpers/timing.ts`.**
-
-**Not adopted.** None.
+**Fixed directly.** *Blocking* — this spec's cross-reference and Done-when named only two comment
+blocks while a **third**, `:1272-1275`, carries the same refuted "~21s on a dev machine" premise three
+lines above one of this issue's own named specs. Both now name three blocks, and Done-when adds
+`grep -n "21s on a dev"` returning nothing.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
@@ -78,13 +78,15 @@ revert); the full suite via the pre-push hook.
 
 ## Done when
 
-Blocks A, B **and C** are edited per G2-1672, so the dated 2026-09-06 fast band (single-file, whole
-file ~3–4 s / 53 specs, the two `#1749` watcher specs at ~0.5–0.7 s) covers every carrying spec and
-therefore this issue's four; a red is described as a hang or a starved box rather than growth; the
-greppable literal is named as vitest's `60000`; **`grep -n "21s on a dev"
-tests/server/docx-apply.test.ts` returns nothing**; no per-spec point millisecond value and no numeric
-range appears in any block; ceilings byte-identical; the verbose table with its footer is in the PR
-body; suite green.
+Blocks A, B **and C** are edited per G2-1672, so the dated 2026-09-06 fast band (single-file,
+whole file ~3–4 s / 53 specs, the two `#1749` watcher specs at ~0.5–0.7 s) covers every carrying
+spec and therefore this issue's four; a red is described as a hang or a starved box rather than
+growth; the greppable literal is named as vitest's `60000`; **`grep -n "21s"
+tests/server/docx-apply.test.ts` and `grep -n "1977ms\|7.6x" tests/server/docx-apply.test.ts` both
+return nothing** (today `:45`, `:1274` and `:1021`, `:1032` respectively, so the pair
+discriminates all three blocks); no per-spec point millisecond value and no numeric range appears
+in any block; ceilings byte-identical; the verbose table with its footer is in the PR body; suite
+green.
 
 ## Not in scope
 
@@ -114,3 +116,13 @@ logs, replaced by this section.
 blocks while a **third**, `:1272-1275`, carries the same refuted "~21s on a dev machine" premise three
 lines above one of this issue's own named specs. Both now name three blocks, and Done-when adds
 `grep -n "21s on a dev"` returning nothing.
+
+## Review corrections (post-cut)
+
+**Fixed directly.** Done-when's one machine-checkable criterion,
+`grep -n "21s on a dev" tests/server/docx-apply.test.ts` returning nothing, was **already vacuous
+for Block A**: that block's sentence wraps across `:45-46`, so the exact phrase never existed there
+and the grep matched only Block C at `:1274`. A Block-C-only change would have passed it. Replaced
+by `grep -n "21s"` plus `grep -n "1977ms\|7.6x"`, which between them hit all three blocks. Same
+correction as `G2-1672.md`, which owns the fix content; this supersedes the `grep -n "21s on a dev"`
+criterion named in the scope-cut log above.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/G2-1699.md
@@ -1,10 +1,12 @@
-# G2 — #1699 `docx-apply.test.ts`'s 60 s timeout on a rotating spec: the 800 ms baseline is now 4–23 ms
+# G2 — #1699 `docx-apply.test.ts`'s 60 s timeout on a rotating spec: the 800 ms baseline is now milliseconds
 
 Branch `fix/test-timing-1674` — named for the group's implementation-order first issue (#1674);
 the ledger row lists "#1672 #1699 #1674", so branch and row reconcile through that clause.
-Closes #1699. Non-review issue: no `areas/*.md` row, no named experiment, no `refuted.md` entry —
-the ledger row is `docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test
-timing"). Probe: `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
+Closes #1699 — the group's args set `closes: true` explicitly, overriding the sweep contract's
+default of `false` for a spec with a non-empty "Not in scope". Non-review issue: no `areas/*.md`
+row, no named experiment, no `refuted.md` entry — the ledger row is
+`docs/plans/2026-09-06-open-issues-sweep.md:226` (wave 1, group "G2 test timing"). Probe:
+`npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`.
 
 ## Problem
 
@@ -27,19 +29,28 @@ confirmed, with the source outside the repo. It also explains "a different spec 
 named specs are simply the ones with real `fs` work, so a starved pool lands on whichever one is
 scheduled during the squeeze.
 
-**The baseline** is no longer 800 ms either. Re-measured on this box, 2026-09-06, whole file
-**53 passed / `Duration 3.73s`** — against the 13.4 s #1699 recorded — with its named offenders
-in milliseconds (titles verbatim from the run):
+**The baseline** is no longer 800 ms either. Re-measured on this box, 2026-09-06 — a **single-file
+`vitest run --reporter=verbose`, not under full-suite parallelism** — the whole file is
+**53 passed / `Duration 3.72s`** against the 13.4 s #1699 recorded, and its four named specs
+(titles verbatim from the run) all land in the file's fast band:
 
 | spec | now |
 |---|---|
-| `keeps an extensionless backupPath absolute instead of resolving it against cwd` | 17 ms |
-| `marks the imported Word comment done after its promoted suggestion is applied` | 21 ms |
-| `does not refuse on mtime drift within the tolerance` | 14 ms |
-| `takes a pre-overwrite snapshot, not just the sidecar backup` | 15 ms |
-| slowest in the file | 621 ms / 520 ms — the two `#1749` watcher-reload specs, waiting on a real `fs.watch` debounce by design |
+| `keeps an extensionless backupPath absolute instead of resolving it against cwd` | fast band |
+| `marks the imported Word comment done after its promoted suggestion is applied` | fast band |
+| `does not refuse on mtime drift within the tolerance` | fast band |
+| `takes a pre-overwrite snapshot, not just the sidecar backup` | fast band |
+| **fast band** | **single-digit to low-tens of ms** (4–25 ms across samples) |
+| slowest in the file | ~0.5–0.7 s — the two `#1749` watcher-reload specs, waiting on a real `fs.watch` debounce by design |
 
-So the ~75× gap is now ~3000× of headroom against a ceiling that is not the thing at fault.
+**Bands, not point values.** Repeated runs on this same box move these four by ~2x (one sample
+gives 15/21/15/17 ms, another 7/11/6/10 ms) while the bands and the file total reproduce exactly.
+A single-run per-spec figure written into a tracked comment is the same construction as the
+premises being retired (`:45` "~21s on a dev machine", `:1021-1022` "1977ms and 463ms"), so this
+spec requires the band and the identifying run footer instead.
+
+So the ~75× gap is now three orders of magnitude of headroom against a ceiling that is not the
+thing at fault.
 
 ## Fix
 
@@ -49,18 +60,28 @@ the number was sized) and Block B at `:1019-1043` (the "EVERY test in this block
 the #1617 membership rule and the negative control). G2-1672 carries the exact content and the
 division of labour; editing only Block A would leave its refuted "1977ms and 463ms" / "7.6x …
 three of four full-suite runs" premises standing next to their own refutation. What **#1699**
-contributes, and must appear:
+contributes, and must appear — G2-1672's Block A bullet list carries all three, so following it
+satisfies this spec:
 
-- the **four specs it named**, recorded at the milliseconds in the table above, so the next reader
-  of a red here does not repeat the "which spec got slow" bisect #1672 warns is the wrong chase;
-- the sentence that a red here means the box, with the leaked-process-tree precedent named — this
-  is #1699's "not yet determined" question answered in the tracked file rather than in a comment
-  thread;
+- the **four specs it named, quoted verbatim, recorded as members of the fast band** (not at
+  per-spec point values), so the next reader of a red here does not repeat the "which spec got
+  slow" bisect #1672 warns is the wrong chase;
+- the sentence that a red here is **a hang or a starved box, never gradual growth** — at
+  single-digit-to-low-tens of ms a 60 s ceiling cannot be crossed by drift — with the reader sent
+  to look for a never-settling `await` or an unreleased lock in the apply first, and the
+  leaked-process-tree precedent named as the machine case. This is #1699's "not yet determined"
+  question answered in the tracked file rather than in a comment thread;
 - **what to grep**: vitest prints `Test timed out in 60000ms` (`300000` under
   `TANDEM_COVERAGE=1`). The greppable literal is that **un-underscored `60000`**, not the
   `60_000` in the source — the ceiling is written `timeoutMs(60_000, 300_000)` (`:55`), and
   `60_000` separately appears three times (`:1066`, `:1095`, `:1130`) as unrelated mtime
   arithmetic.
+
+The two watcher-waiting specs are named in Block A by **verbatim title** — `the watcher reload
+that completes an apply finally lands (#1749) — clean doc` and `the watcher reload that completes
+an apply flags a conflict on a DIRTY doc (#1749)` — with their `vi.waitFor` calls at `:1141` and
+`:1175` (options at `:1145`/`:1179`) cited here, in the spec, and deliberately **not** as line
+numbers inside the shipped comment, which would invalidate on the next edit to the same file.
 
 **Ceilings unchanged** — `REAL_APPLY_TIMEOUT_MS` keeps `timeoutMs(60_000, 300_000)` and no
 per-`it` timeout argument is removed, which is both this group's policy and #1699's own position
@@ -82,15 +103,16 @@ the defect this issue reports, re-committed. Sweep tests, drift guards and froze
 by group policy.
 
 **So nothing here is machine-checked, and the reviewer's job is the discriminator**: diff the
-pasted verbose table against the numbers written into Blocks A and B, line by line, with the run's
-`Duration` and `Tests N passed` footer included so the sample is identifiable, and every spec
-title quoted verbatim.
+pasted verbose table against Blocks A and B — every band written into the comment must contain the
+run's numbers, and no per-spec point value may appear — with the run's `Duration` and
+`Tests N passed` footer included so the sample is identifiable, and every spec title quoted
+verbatim.
 
 Run and recorded in the PR body:
 
 - `npx vitest run tests/server/docx-apply.test.ts --reporter=verbose`, pasted with its footer —
-  the table above. *Discriminates* the fix from a comment whose numbers were invented, and is the
-  measurement #1699 asked for.
+  the measurement #1699 asked for. *Discriminates* the fix from a comment whose numbers were
+  invented.
 - The negative control already documented in Block B: set `REAL_APPLY_TIMEOUT_MS` to `1`, watch
   every carrying spec fail naming `1`, revert. *Kills* the reading that the ceiling is inert and
   the comments describe nothing.
@@ -98,16 +120,21 @@ Run and recorded in the PR body:
 
 ## Done when
 
-Blocks A and B together record #1699's four named specs at their measured durations, say a red is
-the machine and name the greppable literal as vitest's `60000`; ceilings byte-identical; the
-verbose table with its footer in the PR body; suite green.
+Blocks A and B together name #1699's four specs **verbatim** as members of the dated fast band
+(single-digit to low-tens of ms, 2026-09-06, single-file run, whole file 53 passed /
+`Duration 3.72s`, the two `#1749` watcher specs ~0.5–0.7 s), say a red is a hang or a starved box
+rather than growth, and name the greppable literal as vitest's `60000`; no per-spec point
+millisecond value appears in either block; ceilings byte-identical; the verbose table with its
+footer in the PR body; suite green.
 
 ## Not in scope
 
 Any `beforeAll` warm-up (#1672 option 1 — refuted: there is no fixed cost to move). Any ceiling
-change in either direction. `vitest.config.ts`'s 15 s project defaults. `#1617`, cited by #1699
-as the same class in a different file. `tests/cli/mcp-stdio.test.ts` (spec G2-1674). `CLAUDE.md`
-and `docs/gotchas.md` are owned by later groups.
+change in either direction. `vitest.config.ts`'s 15 s project defaults. `tests/helpers/timing.ts`'s
+own stale "Both current callers" comment — named in G2-1672's Not-in-scope with the five real
+callers, observed-not-fixed. `#1617`, cited by #1699 as the same class in a different file.
+`tests/cli/mcp-stdio.test.ts` (spec G2-1674). `CLAUDE.md` and `docs/gotchas.md` are owned by later
+groups.
 
 ## Bryan
 
@@ -125,21 +152,43 @@ escape hatch if a contended run ever reproduces it. Flag it if you would rather 
   G2-1672 for the division of labour, instead of scoping the change to `:42-54` alone and leaving
   the second block's refuted premises in the same file.
 - *Blocking* / *non-blocking* — **two** `#1749` watcher-reload specs wait on the watcher under
-  their own `vi.waitFor`, not one; the table's "slowest in the file" row now says so and G2-1672
-  names `:1111`/`:1159` with their `vi.waitFor` lines.
+  their own `vi.waitFor`, not one; the table's "slowest in the file" row now says so.
 - *Non-blocking* — the `≤ 20 ms` guessed band for `does not refuse on mtime drift within the
-  tolerance` is replaced by its measured **14 ms**, and the table now holds the four specs the
-  Done-when counts (the fourth, `takes a pre-overwrite snapshot…`, was previously only in
-  G2-1672's table), so table and Done-when agree.
+  tolerance` is replaced by measurement, and the table now holds all four specs the Done-when
+  counts, so table and Done-when agree.
 - *Non-blocking* — the edit range corrected from `:42-54` to `:44-54` (`:42` is the `timeoutMs`
   import).
 - *Non-blocking* — "neither literal appears in the file" corrected: `60_000` appears three times
   as mtime arithmetic; the greppable literal is vitest's un-underscored `60000`.
-- *Non-blocking* — measurement re-taken in this worktree and written with its footer (53 passed,
-  `Duration 3.73s`); titles quoted verbatim so they paste into a `-t` filter.
+- *Non-blocking* — measurement re-taken in this worktree and written with its footer; titles
+  quoted verbatim so they paste into a `-t` filter.
 - *Non-blocking* — the review-only nature of the change and the reviewer's diff job stated.
-- *Non-blocking* — `Closes` vs the Bryan section: the spec now owns the close rather than shipping
-  a closing keyword alongside a "the decision is yours" paragraph.
+- *Non-blocking* — `Closes` vs the Bryan section: the spec now owns the close.
 - *Non-blocking* — branch-name clause added.
+
+**Not adopted.** None.
+
+## Review corrections (round 2)
+
+**Adopted.**
+
+- *Blocking* — the four per-spec millisecond point values are gone from the table and from
+  Done-when. Both now require a **dated band** (single-digit to low-tens of ms) plus the
+  identifying run footer, with the two contradicting samples recorded as the reason: a point value
+  from one run is the construction this change exists to retire.
+- *Non-blocking* — Done-when is now satisfiable by following G2-1672's Block A bullet list, which
+  gained a bullet naming these four specs verbatim; the two specs cannot disagree.
+- *Non-blocking* — "a red means the box" sharpened to "a hang or a starved box, never gradual
+  growth", with the reader sent to look for a never-settling `await` or an unreleased lock before
+  blaming the machine.
+- *Non-blocking* — `vi.waitFor` citations corrected from `:1145`/`:1179` (the options object) to
+  `:1141`/`:1175` (the calls); the shipped comment names those specs by verbatim title, not line
+  number.
+- *Non-blocking* — the headline measurement is qualified "single-file run, not under full-suite
+  parallelism", so it is not read as refuting a full-suite-parallelism premise on its own.
+- *Non-blocking* — `tests/helpers/timing.ts`'s stale caller count noted in Not-in-scope by
+  reference to G2-1672, which carries the enumeration.
+- *Non-blocking* — header notes that the group's args set `closes: true` explicitly over the sweep
+  contract's default.
 
 **Not adopted.** None.

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -119,6 +119,36 @@ async function readOneLine(
   });
 }
 
+/** The awaited subject shared by every spec that waits on a synthesized error. */
+const SYNTHESIZED_32000 = "synthesized -32000 on stdout";
+
+/** Resolve once the child's stdio buffers are complete ("close", not "exit"). */
+function awaitClose(child: ChildProcessWithoutNullStreams): Promise<void> {
+  return new Promise<void>((r) => {
+    child.once("close", () => r());
+  });
+}
+
+/**
+ * The JSON-RPC error replies in `stdout` carrying `code`, optionally narrowed
+ * to one request `id`. Non-JSON lines are noise, not failures — but the parse
+ * lives here rather than inside a caller's `try`, where a throw used to swallow
+ * the assertion that followed it.
+ */
+function errorReplies(stdout: string, code: number, id?: number): string[] {
+  return stdout
+    .split("\n")
+    .filter((l) => l.trim())
+    .filter((l) => {
+      try {
+        const p = JSON.parse(l) as { id?: number; error?: { code?: number } };
+        return p.error?.code === code && (id === undefined || p.id === id);
+      } catch {
+        return false;
+      }
+    });
+}
+
 /**
  * Polls `counter()` until it returns >= `n` or `timeoutMs` elapses.
  * Throws a descriptive error on timeout so CI output names the bottleneck.
@@ -507,37 +537,22 @@ describe("mcp-stdio error synthesis on upstream unavailability", () => {
     // Buffer from spawn: an exited child's paused stream yields nothing to a
     // listener attached afterwards, so the old post-exit collector always
     // read "" and this spec asserted on an empty list (#1674).
-    outputOf(child);
+    const output = outputOf(child);
 
     // Write a notification (no id) — must never produce a -32000 reply.
     const notification = { jsonrpc: "2.0", method: "notifications/initialized" };
     child.stdin.write(`${JSON.stringify(notification)}\n`);
 
-    // Wait for "close" (not "exit") so the stdio buffers are complete.
-    await new Promise<void>((r) => child!.once("close", () => r()));
-
-    const lines = outputOf(child)
-      .stdout()
-      .split("\n")
-      .filter((l) => l.trim());
+    await awaitClose(child);
 
     // Preconditions: the child really terminated and really reached the
     // preflight refusal. Not an exit-code equality — the bridge measurably
     // exits 0 here, because stdio.onclose runs shutdown(0) before
     // deferredShutdown's shutdown(1) can take the latch.
     expect(child.exitCode ?? child.signalCode).not.toBeNull();
-    expect(outputOf(child).stderr()).toMatch(/preflight failed/i);
+    expect(output.stderr()).toMatch(/preflight failed/i);
 
-    // No line may be a -32000 error reply. Filtering outside the try means a
-    // parse failure can no longer swallow the assertion.
-    const synthesized = lines.filter((l) => {
-      try {
-        return (JSON.parse(l) as { error?: { code?: number } }).error?.code === -32000;
-      } catch {
-        return false;
-      }
-    });
-    expect(synthesized).toEqual([]);
+    expect(errorReplies(output.stdout(), -32000)).toEqual([]);
   }, 15_000);
 
   it("synthesizes -32000 for multiple concurrent pending requests on mid-session upstream death", async () => {
@@ -810,7 +825,7 @@ describe("mcp-stdio per-request timeout", () => {
     await waitForPosts(postsReceived, 1);
 
     // Expect -32000 within 500ms timer + processing slack.
-    const line = await readOneLine(child, 3_000, "synthesized -32000 on stdout");
+    const line = await readOneLine(child, 3_000, SYNTHESIZED_32000);
     const parsed = JSON.parse(line) as {
       id: number;
       error?: { code: number; message: string; data?: { detail: string } };
@@ -932,7 +947,7 @@ describe("mcp-stdio per-request timeout", () => {
 
     // Wait for the 300ms timer to fire and produce the -32000. Loose bound
     // (5s) to absorb scheduling jitter under parallel test load.
-    const firstLine = await readOneLine(child, 5_000, "synthesized -32000 on stdout");
+    const firstLine = await readOneLine(child, 5_000, SYNTHESIZED_32000);
     const first = JSON.parse(firstLine) as { id: number; error?: { code: number } };
     expect(first.id).toBe(30);
     expect(first.error?.code).toBe(-32000);
@@ -942,18 +957,8 @@ describe("mcp-stdio per-request timeout", () => {
 
     // Wait 500ms for any spurious second -32000 to arrive.
     await new Promise((r) => setTimeout(r, 500));
-    const allOutput = outputOf(child).stdout();
-    const allLines = allOutput.split("\n").filter((l) => l.trim());
-    const errorCount = allLines.filter((l) => {
-      try {
-        const p = JSON.parse(l) as { id?: number; error?: { code?: number } };
-        return p.id === 30 && p.error?.code === -32000;
-      } catch {
-        return false;
-      }
-    }).length;
     // Exactly one -32000 for id=30 — timer fired first, catch found map empty.
-    expect(errorCount).toBe(1);
+    expect(errorReplies(outputOf(child).stdout(), -32000, 30)).toHaveLength(1);
   }, 20_000);
 
   it("process exits in <3s after half-open timeout fires (no orphan handles)", async () => {
@@ -991,7 +996,7 @@ describe("mcp-stdio per-request timeout", () => {
     await waitForPosts(postsReceived, 1);
 
     // Wait for the -32000 to arrive (timer fired). Loose bound for full-suite load.
-    const line = await readOneLine(child, 5_000, "synthesized -32000 on stdout");
+    const line = await readOneLine(child, 5_000, SYNTHESIZED_32000);
     const parsed = JSON.parse(line) as { id: number; error?: { code: number } };
     expect(parsed.id).toBe(40);
     expect(parsed.error?.code).toBe(-32000);
@@ -1012,18 +1017,19 @@ describe("mcp-stdio per-request timeout", () => {
 });
 
 describe("child output buffering", () => {
-  let child: ChildProcessWithoutNullStreams | undefined;
+  const spawned: ChildProcessWithoutNullStreams[] = [];
 
   // Leaked child handles starve subprocess startup for the rest of the suite
-  // (#724) — the second, independently sufficient cause of #1674's text.
+  // (#724) — the second, independently sufficient cause of #1674's text. Every
+  // spawn is tracked, not just the latest, because one spec spawns three.
   afterEach(() => {
-    child?.kill();
-    child = undefined;
+    for (const c of spawned) c.kill();
+    spawned.length = 0;
   });
 
   function spawnNode(script: string): ChildProcessWithoutNullStreams {
     const c = spawn(process.execPath, ["-e", script], { stdio: ["pipe", "pipe", "pipe"] });
-    child = c;
+    spawned.push(c);
     // Same tick as the spawn: an exited child's stream yields nothing to a
     // listener attached afterwards.
     outputOf(c);
@@ -1032,13 +1038,21 @@ describe("child output buffering", () => {
 
   const STAY_ALIVE = "setInterval(() => {}, 1000);";
 
+  /** The Error a deadline rejected with; a resolved read fails loudly instead. */
+  const rejectionOf = (p: Promise<string>): Promise<Error> =>
+    p.then(
+      (line) => {
+        throw new Error(`expected a rejection, got ${JSON.stringify(line)}`);
+      },
+      (e: Error) => e,
+    );
+
   it("delivers a line emitted before the first readOneLine", async () => {
     const c = spawnNode(`process.stdout.write("first\\n"); ${STAY_ALIVE}`);
     const out = outputOf(c);
-    // Poll for the line rather than sleeping a fixed span (#687).
-    for (let i = 0; i < 200 && !out.stdout().includes("\n"); i++) {
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    // Poll for the line rather than sleeping a fixed span (#687), so the
+    // 1s deadline below measures the reader and not subprocess startup.
+    await waitForCount(() => (out.stdout().includes("\n") ? 1 : 0), 1, 5_000);
     await expect(readOneLine(c, 1_000)).resolves.toBe("first");
   }, 15_000);
 
@@ -1059,32 +1073,24 @@ describe("child output buffering", () => {
     // Arm 1 — exited cleanly, default subject. Await termination first so the
     // 300ms deadline measures the timer, not spawn latency (#687).
     const exited = spawnNode("process.exit(0);");
-    await new Promise<void>((r) => {
-      exited.once("close", () => r());
-    });
+    await awaitClose(exited);
     await expect(readOneLine(exited, 300)).rejects.toThrow(
       /^no stdout within 300ms \(child exited with code 0\)/,
     );
-    exited.kill();
 
     // Arm 2 — signal-killed, so exitCode is null and only signalCode names it.
     const killed = spawnNode(STAY_ALIVE);
     killed.kill("SIGKILL");
-    await new Promise<void>((r) => {
-      killed.once("close", () => r());
-    });
-    const killedErr = await readOneLine(killed, 300).catch((e: Error) => e);
-    expect((killedErr as Error).message).toContain("exited");
-    expect((killedErr as Error).message).toContain("SIGKILL");
+    await awaitClose(killed);
+    const killedErr = await rejectionOf(readOneLine(killed, 300));
+    expect(killedErr.message).toContain("exited");
+    expect(killedErr.message).toContain("SIGKILL");
 
     // Arm 3 — still running, custom subject. No wait: the child must be live.
     const alive = spawnNode(STAY_ALIVE);
-    const aliveErr = await readOneLine(alive, 300, "synthesized -32000 on stdout").catch(
-      (e: Error) => e,
-    );
-    expect((aliveErr as Error).message).toContain("synthesized -32000");
-    expect((aliveErr as Error).message).toContain("still running");
-    alive.kill();
+    const aliveErr = await rejectionOf(readOneLine(alive, 300, SYNTHESIZED_32000));
+    expect(aliveErr.message).toContain("synthesized -32000");
+    expect(aliveErr.message).toContain("still running");
   }, 20_000);
 });
 

--- a/tests/cli/mcp-stdio.test.ts
+++ b/tests/cli/mcp-stdio.test.ts
@@ -18,29 +18,101 @@ import {
 } from "../../src/cli/mcp-stdio.js";
 import { expectWithinMs } from "../helpers/timing.js";
 
+interface ChildOutput {
+  /** Everything the child has written to stdout since `outputOf` first ran. */
+  stdout: () => string;
+  /** Everything the child has written to stderr since `outputOf` first ran. */
+  stderr: () => string;
+  /**
+   * The next complete (newline-terminated) line no reader has taken yet, or
+   * `undefined` while none is pending. Whitespace-only lines are skipped, as
+   * the old per-call `readLines` filter did.
+   */
+  takeLine: () => string | undefined;
+}
+
+const childOutputs = new WeakMap<ChildProcessWithoutNullStreams, ChildOutput>();
+
+/**
+ * Buffer a child's stdout/stderr ONCE, from the moment it is spawned (#1674).
+ *
+ * Attaching a `data` listener puts the stream into flowing mode, so a second
+ * listener attached later never sees what the first already consumed — and a
+ * paused stream only buffers while the child is alive. That is why every
+ * reader shares one buffer per child instead of attaching its own, and why
+ * specs that also inspect raw stdout call `outputOf(child)` in the same tick
+ * as their `spawn`. Readers consume stdout in emission order from that point
+ * via `takeLine()`'s cursor; the raw `stdout()` view is unconsumed.
+ */
+function outputOf(child: ChildProcessWithoutNullStreams): ChildOutput {
+  const existing = childOutputs.get(child);
+  if (existing) return existing;
+  let out = "";
+  let err = "";
+  let cursor = 0;
+  child.stdout.on("data", (c: Buffer) => {
+    out += c.toString("utf8");
+  });
+  child.stderr.on("data", (c: Buffer) => {
+    err += c.toString("utf8");
+  });
+  const view: ChildOutput = {
+    stdout: () => out,
+    stderr: () => err,
+    takeLine: () => {
+      // Only newline-terminated lines: an unterminated tail stays pending
+      // until its "\n" arrives, so a frame split across chunks is never
+      // handed to JSON.parse in halves.
+      for (;;) {
+        const nl = out.indexOf("\n", cursor);
+        if (nl < 0) return undefined;
+        const line = out.slice(cursor, nl);
+        cursor = nl + 1;
+        if (line.trim()) return line;
+      }
+    },
+  };
+  childOutputs.set(child, view);
+  return view;
+}
+
+/**
+ * Await the next line the child writes to stdout.
+ *
+ * `what` names the awaited subject in the rejection ("no <what> within Nms"),
+ * defaulting to today's noun so unchanged call sites keep printing
+ * `no stdout within Nms`. The rejection also names whether the child had
+ * terminated, which is what separates "the bridge never emitted" from "the
+ * subprocess never started" (#1674, #724).
+ */
 async function readOneLine(
   child: ChildProcessWithoutNullStreams,
   timeoutMs = 10_000,
+  what = "stdout",
 ): Promise<string> {
-  const stdoutChunks: string[] = [];
-  const stderrChunks: string[] = [];
-  child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c.toString("utf8")));
-  child.stderr.on("data", (c: Buffer) => stderrChunks.push(c.toString("utf8")));
+  const output = outputOf(child);
   return new Promise<string>((resolveResp, rejectResp) => {
     const checker = setInterval(() => {
-      const joined = stdoutChunks.join("");
-      const nl = joined.indexOf("\n");
-      if (nl >= 0) {
+      const line = output.takeLine();
+      if (line !== undefined) {
         clearTimeout(timer);
         clearInterval(checker);
-        resolveResp(joined.slice(0, nl));
+        resolveResp(line);
       }
     }, 50);
     const timer = setTimeout(() => {
       clearInterval(checker);
+      // exitCode is null for a signal-killed child, and this file SIGKILLs in
+      // afterEach — so liveness reads both fields.
+      const terminated = child.exitCode !== null || child.signalCode !== null;
+      const liveness = terminated
+        ? `child exited with code ${child.exitCode ?? child.signalCode}`
+        : "child still running";
+      const err = output.stderr();
+      const tail = err.length > 500 ? `…${err.slice(-500)}` : err;
       rejectResp(
         new Error(
-          `no stdout within ${timeoutMs}ms. stderr=${stderrChunks.join("")} stdout=${stdoutChunks.join("")}`,
+          `no ${what} within ${timeoutMs}ms (${liveness}). stderr=${tail} stdout=${output.stdout()}`,
         ),
       );
     }, timeoutMs);
@@ -72,19 +144,18 @@ async function readLines(
   n: number,
   timeoutMs = 10_000,
 ): Promise<string[]> {
-  const stdoutChunks: string[] = [];
-  child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c.toString("utf8")));
+  const output = outputOf(child);
+  const lines: string[] = [];
+  const drain = () => {
+    for (let line = output.takeLine(); line !== undefined; line = output.takeLine()) {
+      lines.push(line);
+    }
+  };
   return new Promise<string[]>((resolveResp) => {
-    const lines: string[] = [];
-    let remainder = "";
     const checker = setInterval(() => {
-      const joined = remainder + stdoutChunks.join("");
-      stdoutChunks.length = 0;
-      const parts = joined.split("\n");
-      remainder = parts.pop() ?? "";
-      for (const part of parts) {
-        if (part.trim()) lines.push(part);
-      }
+      // Drain everything available in this tick rather than exactly n, so an
+      // over-delivered extra frame still shows up in the caller's count.
+      drain();
       if (lines.length >= n) {
         clearTimeout(timer);
         clearInterval(checker);
@@ -93,6 +164,7 @@ async function readLines(
     }, 50);
     const timer = setTimeout(() => {
       clearInterval(checker);
+      drain();
       resolveResp(lines);
     }, timeoutMs);
   });
@@ -432,29 +504,40 @@ describe("mcp-stdio error synthesis on upstream unavailability", () => {
       env: { ...process.env, TANDEM_URL: "http://127.0.0.1:1" },
       stdio: ["pipe", "pipe", "pipe"],
     });
+    // Buffer from spawn: an exited child's paused stream yields nothing to a
+    // listener attached afterwards, so the old post-exit collector always
+    // read "" and this spec asserted on an empty list (#1674).
+    outputOf(child);
 
     // Write a notification (no id) — must never produce a -32000 reply.
     const notification = { jsonrpc: "2.0", method: "notifications/initialized" };
     child.stdin.write(`${JSON.stringify(notification)}\n`);
 
-    // Wait for child to exit (it exits 1 after PREFLIGHT_GRACE_MS).
-    await new Promise<void>((r) => child!.once("exit", () => r()));
+    // Wait for "close" (not "exit") so the stdio buffers are complete.
+    await new Promise<void>((r) => child!.once("close", () => r()));
 
-    // Collect any stdout lines that arrived.
-    const stdoutChunks: string[] = [];
-    child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c.toString("utf8")));
-    const allOutput = stdoutChunks.join("");
-    const lines = allOutput.split("\n").filter((l) => l.trim());
+    const lines = outputOf(child)
+      .stdout()
+      .split("\n")
+      .filter((l) => l.trim());
 
-    // No line should be a -32000 error reply.
-    for (const line of lines) {
+    // Preconditions: the child really terminated and really reached the
+    // preflight refusal. Not an exit-code equality — the bridge measurably
+    // exits 0 here, because stdio.onclose runs shutdown(0) before
+    // deferredShutdown's shutdown(1) can take the latch.
+    expect(child.exitCode ?? child.signalCode).not.toBeNull();
+    expect(outputOf(child).stderr()).toMatch(/preflight failed/i);
+
+    // No line may be a -32000 error reply. Filtering outside the try means a
+    // parse failure can no longer swallow the assertion.
+    const synthesized = lines.filter((l) => {
       try {
-        const parsed = JSON.parse(line) as { error?: { code?: number } };
-        expect(parsed.error?.code).not.toBe(-32000);
+        return (JSON.parse(l) as { error?: { code?: number } }).error?.code === -32000;
       } catch {
-        // Non-JSON line — fine, ignore.
+        return false;
       }
-    }
+    });
+    expect(synthesized).toEqual([]);
   }, 15_000);
 
   it("synthesizes -32000 for multiple concurrent pending requests on mid-session upstream death", async () => {
@@ -727,7 +810,7 @@ describe("mcp-stdio per-request timeout", () => {
     await waitForPosts(postsReceived, 1);
 
     // Expect -32000 within 500ms timer + processing slack.
-    const line = await readOneLine(child, 3_000);
+    const line = await readOneLine(child, 3_000, "synthesized -32000 on stdout");
     const parsed = JSON.parse(line) as {
       id: number;
       error?: { code: number; message: string; data?: { detail: string } };
@@ -828,9 +911,10 @@ describe("mcp-stdio per-request timeout", () => {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
-    // Collect stdout so we can count total -32000 lines later.
-    const stdoutChunks: string[] = [];
-    child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c.toString("utf8")));
+    // Buffer stdout from spawn (#1674). A second listener attached later —
+    // which is what readOneLine used to do — would never see the -32000 this
+    // spec waits for, and the deadline would then blame the bridge.
+    outputOf(child);
 
     // Send the request immediately — preReadyBuffer holds it until httpReady
     // flips, then forwardToUpstream fires and the 300ms timer starts. Polling
@@ -848,7 +932,7 @@ describe("mcp-stdio per-request timeout", () => {
 
     // Wait for the 300ms timer to fire and produce the -32000. Loose bound
     // (5s) to absorb scheduling jitter under parallel test load.
-    const firstLine = await readOneLine(child, 5_000);
+    const firstLine = await readOneLine(child, 5_000, "synthesized -32000 on stdout");
     const first = JSON.parse(firstLine) as { id: number; error?: { code: number } };
     expect(first.id).toBe(30);
     expect(first.error?.code).toBe(-32000);
@@ -858,7 +942,7 @@ describe("mcp-stdio per-request timeout", () => {
 
     // Wait 500ms for any spurious second -32000 to arrive.
     await new Promise((r) => setTimeout(r, 500));
-    const allOutput = stdoutChunks.join("");
+    const allOutput = outputOf(child).stdout();
     const allLines = allOutput.split("\n").filter((l) => l.trim());
     const errorCount = allLines.filter((l) => {
       try {
@@ -897,15 +981,17 @@ describe("mcp-stdio per-request timeout", () => {
     // vitest load, where `--import tsx` startup can far exceed 500ms. The ordering
     // is load-bearing: the 300ms timer is armed just before http.send, so when
     // waitForPosts returns (POST received) it has been running only for the
-    // network round-trip — ~290ms still remain, so readOneLine's listener
-    // attaches well before the -32000 is emitted.
+    // network round-trip — ~290ms still remain when the -32000 is emitted.
+    // (Since #1674 the buffer is attached at spawn, so a reader can no longer
+    // miss a line it was late for; the polling still keeps the deadline off
+    // subprocess startup latency.)
     child.stdin.write(
       `${JSON.stringify({ jsonrpc: "2.0", id: 40, method: "initialize", params: { protocolVersion: "2024-11-05", clientInfo: { name: "test", version: "0" }, capabilities: {} } })}\n`,
     );
     await waitForPosts(postsReceived, 1);
 
     // Wait for the -32000 to arrive (timer fired). Loose bound for full-suite load.
-    const line = await readOneLine(child, 5_000);
+    const line = await readOneLine(child, 5_000, "synthesized -32000 on stdout");
     const parsed = JSON.parse(line) as { id: number; error?: { code: number } };
     expect(parsed.id).toBe(40);
     expect(parsed.error?.code).toBe(-32000);
@@ -922,6 +1008,83 @@ describe("mcp-stdio per-request timeout", () => {
       });
     });
     expect(closed).toBe(true);
+  }, 20_000);
+});
+
+describe("child output buffering", () => {
+  let child: ChildProcessWithoutNullStreams | undefined;
+
+  // Leaked child handles starve subprocess startup for the rest of the suite
+  // (#724) — the second, independently sufficient cause of #1674's text.
+  afterEach(() => {
+    child?.kill();
+    child = undefined;
+  });
+
+  function spawnNode(script: string): ChildProcessWithoutNullStreams {
+    const c = spawn(process.execPath, ["-e", script], { stdio: ["pipe", "pipe", "pipe"] });
+    child = c;
+    // Same tick as the spawn: an exited child's stream yields nothing to a
+    // listener attached afterwards.
+    outputOf(c);
+    return c;
+  }
+
+  const STAY_ALIVE = "setInterval(() => {}, 1000);";
+
+  it("delivers a line emitted before the first readOneLine", async () => {
+    const c = spawnNode(`process.stdout.write("first\\n"); ${STAY_ALIVE}`);
+    const out = outputOf(c);
+    // Poll for the line rather than sleeping a fixed span (#687).
+    for (let i = 0; i < 200 && !out.stdout().includes("\n"); i++) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    await expect(readOneLine(c, 1_000)).resolves.toBe("first");
+  }, 15_000);
+
+  it("hands successive readers successive lines", async () => {
+    const c = spawnNode('process.stdout.write("one\\ntwo\\n");');
+    expect(await readOneLine(c, 2_000)).toBe("one");
+    expect(await readOneLine(c, 2_000)).toBe("two");
+  }, 15_000);
+
+  it("waits for the newline rather than serving the unterminated tail", async () => {
+    const c = spawnNode(
+      `process.stdout.write('{"a":1'); setTimeout(() => process.stdout.write("}\\n"), 200); ${STAY_ALIVE}`,
+    );
+    expect(JSON.parse(await readOneLine(c, 2_000))).toEqual({ a: 1 });
+  }, 15_000);
+
+  it("names the awaited subject and the child's liveness", async () => {
+    // Arm 1 — exited cleanly, default subject. Await termination first so the
+    // 300ms deadline measures the timer, not spawn latency (#687).
+    const exited = spawnNode("process.exit(0);");
+    await new Promise<void>((r) => {
+      exited.once("close", () => r());
+    });
+    await expect(readOneLine(exited, 300)).rejects.toThrow(
+      /^no stdout within 300ms \(child exited with code 0\)/,
+    );
+    exited.kill();
+
+    // Arm 2 — signal-killed, so exitCode is null and only signalCode names it.
+    const killed = spawnNode(STAY_ALIVE);
+    killed.kill("SIGKILL");
+    await new Promise<void>((r) => {
+      killed.once("close", () => r());
+    });
+    const killedErr = await readOneLine(killed, 300).catch((e: Error) => e);
+    expect((killedErr as Error).message).toContain("exited");
+    expect((killedErr as Error).message).toContain("SIGKILL");
+
+    // Arm 3 — still running, custom subject. No wait: the child must be live.
+    const alive = spawnNode(STAY_ALIVE);
+    const aliveErr = await readOneLine(alive, 300, "synthesized -32000 on stdout").catch(
+      (e: Error) => e,
+    );
+    expect((aliveErr as Error).message).toContain("synthesized -32000");
+    expect((aliveErr as Error).message).toContain("still running");
+    alive.kill();
   }, 20_000);
 });
 

--- a/tests/server/docx-apply.test.ts
+++ b/tests/server/docx-apply.test.ts
@@ -1045,11 +1045,10 @@ describe("applyChangesCore — write guards", () => {
     expect(await onDisk()).toEqual(before);
   });
 
-  // EVERY test in this block that expects applyChangesCore to RESOLVE gets
-  // explicit headroom over the project's 15s default -- they are the only ones
-  // here that perform a real .docx apply. How the ceiling was sized, what it
-  // measures today and what a red names: the REAL_APPLY_TIMEOUT_MS comment at
-  // the top of this file.
+  // EVERY test in this block that expects applyChangesCore to RESOLVE carries
+  // REAL_APPLY_TIMEOUT_MS -- they are the only ones here that perform a real
+  // .docx apply. How the ceiling was sized, why it is safe, and what a red
+  // names: that constant's comment at the top of this file.
   //
   // "Every" is load-bearing, and getting it wrong is what #1617 was. The first
   // pass at this budgeted the two specs that had been OBSERVED failing rather
@@ -1065,12 +1064,9 @@ describe("applyChangesCore — write guards", () => {
   // cannot by itself refute a parallelism claim. CI was green throughout, so
   // this was wall-clock headroom, not a defect.
   //
-  // Safe because duration is NOT the property under test -- these assert
-  // `applied: 1`. Where duration IS the assertion, raising the ceiling turns a
-  // real gate into a slower real gate that catches nothing; see
-  // `tests/helpers/timing.ts`. Proved honoured rather than ignored: set
-  // REAL_APPLY_TIMEOUT_MS to 1 and every spec carrying it fails naming that
-  // value -- the only observation available here that can come back negative.
+  // Proved honoured rather than ignored: set REAL_APPLY_TIMEOUT_MS to 1 and
+  // every spec carrying it fails naming that value -- the only observation
+  // available here that can come back negative.
 
   it(
     "allows an unsaved-restore conflict over an UNCHANGED disk",
@@ -1301,9 +1297,8 @@ describe("applyChangesCore — the backup sidecar", () => {
   });
 
   // Same headroom, same reason as the write-guards block above: these perform a
-  // real .docx apply. How the ceiling was sized, what it measures today and
-  // what a red names: the REAL_APPLY_TIMEOUT_MS comment at the top of this
-  // file. Without it they fail as timeouts rather than as assertions.
+  // real .docx apply, and without it they fail as timeouts rather than as
+  // assertions.
 
   it(
     "keeps an extensionless backupPath absolute instead of resolving it against cwd",

--- a/tests/server/docx-apply.test.ts
+++ b/tests/server/docx-apply.test.ts
@@ -42,11 +42,40 @@ import { toFlatOffset } from "../../src/shared/types.js";
 import { timeoutMs } from "../helpers/timing.js";
 
 /**
- * Headroom for the specs that perform a REAL .docx apply, measured at ~21s on a
- * dev machine against the project's 15s default. Duration is not the property
- * any of them asserts — they assert `applied: 1`, a savedAtVersion, a snapshot
- * count — so raising the ceiling makes them slower real gates rather than
- * blunting them. Where duration IS the assertion, see `tests/helpers/timing.ts`.
+ * Headroom for the specs that perform a REAL .docx apply, over the project's
+ * 15s default. Duration is not the property any of them asserts — they assert
+ * `applied: 1`, a savedAtVersion, a snapshot count — so raising the ceiling
+ * makes them slower real gates rather than blunting them. Where duration IS the
+ * assertion, see `tests/helpers/timing.ts`.
+ *
+ * What it measures today (#1672, #1699). Measured 2026-09-06 with a single-file
+ * `vitest run --reporter=verbose` — NOT under full-suite parallelism: the whole
+ * file runs in the low-single-digit-seconds band over 53 specs, and every spec
+ * carrying this ceiling lands in the single-digit-to-low-tens-of-ms band. The
+ * two exceptions are "the watcher reload that completes an apply finally lands
+ * (#1749) — clean doc" and "the watcher reload that completes an apply flags a
+ * conflict on a DIRTY doc (#1749)", both in the sub-second band because they
+ * wait on a real `fs.watch` debounce by design. Bands, not point values:
+ * repeated runs move individual specs about twofold while the bands and the
+ * file total reproduce, so a figure pinned in this comment would be the same
+ * construction that sized — and misdescribed — this ceiling before.
+ *
+ * Which phase a red names. The carrying specs await one `applyChangesCore(...)`
+ * plus cheap `fsp` calls; the two watcher specs additionally wait under their
+ * own `vi.waitFor(…)`, which fails with its own assertion. So a bare
+ * `Test timed out in 60000ms` is the apply, and a `vi.waitFor` failure is the
+ * reload. The greppable literal is vitest's un-underscored 60000 (300000 under
+ * a coverage run), not this file's `60_000`, which also appears below as
+ * unrelated mtime arithmetic.
+ *
+ * What a red is NOT. At this distance from the ceiling it cannot be gradual
+ * growth — it is a hang or a starved machine. Look first for a never-settling
+ * `await` or an unreleased lock in the apply (the `wireFileWatcher` /
+ * `unwatchFile` pairs in the two watcher specs); the machine case has a
+ * precedent in #1672, where a leaked third-party process tree holding 30
+ * abandoned sessions starved the shared worker pool and a suite that had failed
+ * twice went green with no code change. Raising the number is the response to
+ * neither.
  *
  * Via `timeoutMs` rather than a bare literal: an explicit second argument to
  * `it` beats `--testTimeout`, so a coverage run (1.1-1.5x instrumented) would
@@ -1018,8 +1047,9 @@ describe("applyChangesCore — write guards", () => {
 
   // EVERY test in this block that expects applyChangesCore to RESOLVE gets
   // explicit headroom over the project's 15s default -- they are the only ones
-  // here that perform a real .docx apply, measured in isolation at 1977ms and
-  // 463ms against 20-24ms for the refusals, which return before doing any work.
+  // here that perform a real .docx apply. How the ceiling was sized, what it
+  // measures today and what a red names: the REAL_APPLY_TIMEOUT_MS comment at
+  // the top of this file.
   //
   // "Every" is load-bearing, and getting it wrong is what #1617 was. The first
   // pass at this budgeted the two specs that had been OBSERVED failing rather
@@ -1029,11 +1059,11 @@ describe("applyChangesCore — write guards", () => {
   // load. The rule the file wants is name the SET that does the expensive
   // thing, never the members that happened to trip.
   //
-  // Under the full suite's worker parallelism a 7.6x slowdown crosses the
-  // ceiling, and it did: three of four full-suite runs on one branch failed
-  // here, twice on the same test, including the fastest run of the four with
-  // nothing else on the machine. CI is green throughout, so this is wall-clock
-  // headroom, not a defect.
+  // The full-suite-parallelism slowdown that once sized this is retired by
+  // #1672's evidence -- an unrelated leaked process tree starving the machine
+  // -- and NOT by the at-rest measurement above, which is single-file and so
+  // cannot by itself refute a parallelism claim. CI was green throughout, so
+  // this was wall-clock headroom, not a defect.
   //
   // Safe because duration is NOT the property under test -- these assert
   // `applied: 1`. Where duration IS the assertion, raising the ceiling turns a
@@ -1271,8 +1301,9 @@ describe("applyChangesCore — the backup sidecar", () => {
   });
 
   // Same headroom, same reason as the write-guards block above: these perform a
-  // real .docx apply, measured at ~21s on a dev machine against a 15s default.
-  // Without it they fail as timeouts rather than as assertions.
+  // real .docx apply. How the ceiling was sized, what it measures today and
+  // what a red names: the REAL_APPLY_TIMEOUT_MS comment at the top of this
+  // file. Without it they fail as timeouts rather than as assertions.
 
   it(
     "keeps an extensionless backupPath absolute instead of resolving it against cwd",


### PR DESCRIPTION
## Summary

**#1674 — `tests/cli/mcp-stdio.test.ts` lost output the child had already written.** `readOneLine`
attached its own `stdout`/`stderr` `data` listeners at call time. Attaching a listener puts the
stream into flowing mode, so a line the child emitted before the call was consumed by whichever
listener came first and never reached the later one; and once the child had exited, a listener
attached afterwards saw nothing at all. The deadline then expired with the exact text the issue
quotes — `no stdout within Nms. stderr= stdout=` — blaming the bridge for a line it had in fact
emitted. Scaling the 5 000 ms deadlines could never repair that, because the data was already gone.
The change buffers each child's output once, from spawn, in a per-child `WeakMap` accumulator with a
never-consumed `stdout()`/`stderr()` view plus a `takeLine()` cursor that hands successive readers
successive newline-terminated lines. `readOneLine` and `readLines` now share that buffer instead of
each attaching their own collectors, and the rejection gained a liveness clause
(`child still running` vs `child exited with code N`) plus an optional `what` label, so a red says
which subject timed out rather than naming stdout generically. No deadline value changed.

**#1672 / #1699 — the `tests/server/docx-apply.test.ts` timeout rationale described a cost that no
longer exists.** The `REAL_APPLY_TIMEOUT_MS` comment justified its headroom with a "7.6x
parallelism slowdown" and point durations measured on a machine that was, per the issue's own
second comment, starved by a leaked third-party process tree holding 30 abandoned sessions. On
today's measurement a real `applyChangesCore` costs tens of milliseconds, the whole 53-spec file
runs in ~4.2 s, and the carrying specs land at 22–645 ms against a 60 000 ms ceiling even under
252-file parallel load — so there is no fixed cost to amortize into a `beforeAll` and no evidence
on which to lower the ceiling. The change is legibility only: the constant's comment is re-dated,
states the measured bands rather than point values it cannot reproduce, names which phase a red
implicates (a bare `Test timed out in 60000ms` is the apply; a `vi.waitFor` failure is the watcher
reload), and says explicitly that a red at this distance from the ceiling is a hang or a starved
machine, not gradual growth — so raising the number is the response to neither. Ceilings are
unchanged and the per-`it` timeouts are intact.

## Closes

Closes #1672
Closes #1699
Closes #1674

## Verification

Commands run in the worktree:

- `npm run typecheck:tests` — clean across all three configs.
- `npx biome format --write` on the two changed test files — `Checked 2 files ... No fixes applied`.
- `npx vitest run tests/cli/mcp-stdio.test.ts` and `npx vitest run tests/server/docx-apply.test.ts`,
  plus `tests/server/` in full (252 files) for the parallel-load numbers below.
- `git push` with the pre-push hook armed: biome + `npm run typecheck:tests` + the full vitest suite
  + `cargo test` (`CARGO_TARGET_DIR=/home/user/tandem/src-tauri/target`) — all green, hooks never
  bypassed.
- No E2E (neither issue touches a client or integration surface). No server was started — none of
  the three issues touches a server surface.

Probe output:

```
#1674 — tests/cli/mcp-stdio.test.ts
  Fixed state:  Test Files 1 passed (1) / Tests 77 passed (77), Duration 93.12s
    ✓ child output buffering > delivers a line emitted before the first readOneLine 104ms
    ✓ child output buffering > hands successive readers successive lines 104ms
    ✓ child output buffering > waits for the newline rather than serving the unterminated tail 255ms
    ✓ child output buffering > names the awaited subject and the child's liveness 938ms
    ✓ error synthesis ... > does not synthesize for notifications (no id) on preflight failure 1846ms
  Negative control (collector re-attached per call = pre-fix behaviour):
    × delivers a line emitted before the first readOneLine 1075ms
      → Error: no stdout within 1000ms (child still running). stderr= stdout=
    × hands successive readers successive lines 2058ms
      → no stdout within 2000ms (child exited with code 0). stderr= stdout=
      Tests  2 failed | 2 passed | 73 skipped (77)
  => the control reproduces #1674's quoted "no stdout within Nms ... stderr= stdout=" text verbatim,
     and the fix's new liveness clause ("child still running" vs "child exited with code 0") is what
     now separates "bridge never emitted" from "subprocess never started". Not still broken.

#1672 / #1699 — tests/server/docx-apply.test.ts
  Single-file:  Test Files 1 passed (1) / Tests 53 passed (53), Duration 4.22s
    ✓ write guards > allows an unsaved-restore conflict over an UNCHANGED disk 34ms
    ✓ write guards > watcher reload ... clean doc 645ms
    ✓ write guards > watcher reload ... DIRTY doc 533ms
    ✓ backup sidecar > keeps an extensionless backupPath absolute 67ms
  Under tests/server/ parallel load (252 files, 4538 tests, 114.97s wall):
    ✓ watcher reload ... clean doc 629ms   ✓ watcher reload ... DIRTY doc 547ms
    ✓ keeps an extensionless backupPath absolute 22ms      Test Files 250 passed | 2 skipped
  => carrying specs stay 22–645 ms against a 60_000 ms ceiling even under full parallelism, so the
     retired "7.6x parallelism slowdown" sizing is refuted by measurement, not just by #1672's
     leaked-process-tree evidence. No fixed cost exists to move into beforeAll.
  Negative control (REAL_APPLY_TIMEOUT_MS = 1): 11 specs fail, each "Test timed out in 1ms"
      Tests  11 failed | 42 passed (53)
  => the ceiling is honoured by all 11 carrying sites, and the greppable literal really is vitest's
     un-underscored form. Not still broken.

Hygiene: npm run typecheck:tests clean (3 configs); biome "Checked 2 files ... No fixes applied";
working tree clean after both controls restored (git status shows only untracked node_modules).
No server was started — none of the three issues touches a server surface.
```

No visible UI change, so no screenshots.

## Review

Plan review rounds: 4. PR review rounds: 1. Unresolved findings: none.

## Assumptions

- #1674's failure mechanism is late collector attachment, not an undersized deadline. Established by
  measurement rather than assumed: a listener attached at spawn keeps the data and a second listener
  attached 400 ms later sees `""`, while a late-only listener on a live child still sees everything.
  Only one spec in the file has a pre-attached collector, and it is the spec #1674 names.
- The right shape is a per-child `WeakMap` accumulator with a never-consumed `lines()` view plus a
  `takeLine()` cursor — chosen over (a) editing all ~14 spawn sites to call an explicit `collect()`
  and (b) unifying with the existing `collect()` helper at `:1774`, both larger diffs for the same
  property. The file's own `collect()` is named as the precedent.
- The 5 000 ms deadlines at `:851`/`:908` stay 5 000. Once the line cannot be missed they measure the
  bridge's 300 ms timer plus slack, so #1674's "decouple from spawn latency" is satisfied
  structurally. No number in either file changes.
- `what` labels are added only at the four rejecting reader calls inside
  `describe("mcp-stdio per-request timeout")`, not at all ten `readOneLine` sites — those four are
  the ones whose red misnamed its subject.
- #1672's preferred remedy (pay the cost once in a `beforeAll`) is refuted by measurement: the whole
  file is 4.14 s / 53 specs, the named "slow" specs are 4–20 ms, so there is no fixed cost to
  relocate. Option 3 from the issue body (record the measured range) is therefore the entire change,
  and no `beforeAll` is added.
- "Legible" for docx-apply means the comment above `REAL_APPLY_TIMEOUT_MS`, not a wrapper that names
  phases at runtime. Vitest already names the spec; each carrying spec awaits exactly one
  `applyChangesCore(...)`, and the one that also waits on the watcher does so under its own
  `vi.waitFor({timeout: 20_000})` which fails with a different message — so the comment naming that
  split makes the phase unambiguous without a mechanism.
- No new test accompanies the docx-apply change. The only assertable property would be a duration,
  which is the exact check both issues argue against; the existing negative control (set the constant
  to 1, every carrying spec fails naming it) is run and recorded instead.
- #1672 and #1699 share one edit to one comment block; `G2-1699.md` defers to `G2-1672.md` for its
  content rather than duplicating it, so there is no risk of two conflicting rewrites of
  `docx-apply.test.ts:42-54`.

## For Bryan

- **Policy call.** On today's measurement #1672 and #1699 are closeable *with the measurement* rather
  than fixable. The whole `docx-apply.test.ts` file is 4.14 s / 53 specs at rest (2026-09-06); every
  spec both issues name as slow runs at 4–20 ms; the ~36 s / 60 s costs came from the leaked
  `claude-agent-acp@0.59.0` tree you diagnosed yourself in #1672's second comment, which is gone. The
  legibility change (the dated comment above `REAL_APPLY_TIMEOUT_MS`) ships either way — the decision
  is whether this PR retires both issues on that basis or leaves them open awaiting another contended
  run. #1674 is a real code defect and is repaired regardless.
- If you want the docx-apply half to be more than a comment, the only remaining options are a
  `beforeAll` warm-up (measurement says it would attribute ~19 ms and buy nothing) or a runtime
  phase-naming wrapper (a mechanism this group's policy excludes). Say so and it becomes a scope
  change, not a plan revision.
- The ~36 s / 75x blowup does not reproduce: the file is 53 specs in ~4 s single-file, and the cause
  you diagnosed in #1672's second comment (the leaked `claude-agent-acp` tree holding 30 abandoned
  sessions) is outside the repo. Both issues are listed under **Closes** on that basis — tell me if
  you would rather they stay open as watch items, in which case drop them from that section and leave
  the comment edit as the whole change.
- **Closure recommendation.** The spec asked whether the right outcome is to retire both on the
  measurement. The measurement supports it — a real `applyChangesCore` costs tens of ms, the whole
  53-spec file runs in 4.22 s, and the carrying specs are 22–645 ms against the 60 s ceiling even
  under 252-file parallel load, so there is nothing to amortize into `beforeAll` and no ceiling to
  lower on evidence. What shipped is the legibility change only (the constant's comment now names the
  phase a red implicates and what a red is not); the ceilings are unchanged and the per-`it` timeouts
  are intact per policy. Recommend retiring #1672 and #1699 as measured-and-legible rather than
  leaving them open for a further timing change.
- **Machine-dependence caveat that cannot be settled here.** The historical ~36 s and 60 s durations
  in #1672 came from a leaked third-party process tree on your machine, which no longer exists on
  this box. All numbers above are from this CI-class container, so they confirm the ceiling is far
  from binding here but cannot prove the same on your hardware or on a loaded GitHub runner. If a red
  ever recurs on either, the comment now directs the reader to a hang or a starved machine rather
  than to raising the number — worth a glance the next time `docx-apply.test.ts` goes red anywhere.
- **Two observed-not-fixed items you may want filed** rather than left in a PR body:
  `scripts/ci/stdio-smoke.mjs:50`'s stale `mcp-stdio.test.ts:46-75` citation, and
  `tests/helpers/timing.ts`'s "Both current callers" comment (there are five). Both are one-line
  edits in files these issues do not name, so this group left them alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TGJ1qCXfMX24Rt5AhR1Ma

---
_Generated by [Claude Code](https://claude.ai/code/session_011TGJ1qCXfMX24Rt5AhR1Ma)_