### PR TITLE
docs(changelog): lead with What's New and tighten entry prose

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -11,11 +11,13 @@ Generate a formatted CHANGELOG entry from commits since the last release tag.
 ## Steps
 
 1. Find the last release tag:
+
 ```bash
 git describe --tags --abbrev=0
 ```
 
 2. List commits since that tag:
+
 ```bash
 git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
 ```
@@ -38,36 +40,146 @@ git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
    - `perf(...)` → **Performance**
    - Security-related commits → **Security**
 
-5. **Open the version with a plain-language summary, before any `###` subsection.** Two or
-   three sentences for someone who does not know the codebase, the issue numbers, or our
-   vocabulary, answering "what is different for me now?" Name the one or two changes most
-   people will notice, and say plainly if the release is mostly internal. No issue numbers,
-   no file paths, no subsystem names in the summary — those belong in the entries below it.
+5. **Write the entries** (see *Writing the prose* below), ordered within each section by user
+   impact, most impactful first. Not by issue number, not by merge order, not by subsystem. A
+   reader who stops after the first bullet of each section should still have the release's
+   substance.
 
-6. **Order entries within each section by user impact, most impactful first.** Not by issue
-   number, not by merge order, not by subsystem. Ask which bullet a user would be sorriest to
-   miss and put it at the top. A reader who stops after the first bullet of each section
-   should still have the release's substance.
+6. **Then write a `### What's New` section and place it first**, above every other subsection.
+   It is written last and read first — you cannot summarise entries you have not drafted.
 
-7. Format as a `## [Unreleased]` section. Each entry should be:
+   - 3–6 bullets, most impactful first, one line each (≤20 words).
+   - No PR numbers, no subsystem names, no file paths, no bounds — those live in the entries.
+   - Each bullet is derived from an entry's bold clause. **Re-derive the bullet whenever you
+     edit that entry**; nothing checks that the two agree, so this is the only thing keeping
+     the summary from drifting away from the detail it summarises.
+   - If the release is mostly internal, one bullet says so plainly.
+
+   **Lead with 1–2 sentences of prose above the bullets only when a genuinely large feature or
+   change headlines the release** — something that changes how Tandem is used or how a release
+   should be approached, not a good bug fix. Otherwise go straight to the bullets.
+
+7. Format as a `## [Unreleased]` section. Each entry is:
    - Bold summary with PR number: `- **Description** (#N)`
-   - Group related commits into a single entry where appropriate
-   - Use imperative mood ("Add", "Fix", "Remove" — not "Added", "Fixes")
+   - Related commits grouped into a single entry
+   - Imperative mood ("Add", "Fix", "Remove" — not "Added", "Fixes")
 
 8. Output the formatted block for the user to review and paste into `CHANGELOG.md`.
+
+## Writing the prose
+
+Entries earned their length historically by carrying honest qualifications, and they also
+accumulated a lot of narration. Tighten the narration; keep the qualifications.
+
+**The shape is the discipline, not a word count.** An entry is:
+
+1. A bold clause: what is different now.
+2. One sentence of consequence: what the user saw, or would have seen, when it was wrong.
+3. Zero or more **bounds**, one sentence each — see below.
+
+Nothing else. If a sentence is doing a fourth job, it belongs in the PR. **120 words is a
+runaway backstop, not a target**, and bounds do not count toward it — an entry that needs
+three honest bounds gets three sentences and is still correct. Draft the entry, then cut it to
+shape; do not aim short and stop early, because the first draft is where you find out what
+actually mattered.
+
+### Bounds
+
+A bound is a sentence that changes what the reader would **do or believe**. Label it
+**Bound:** (or a more specific label when it is not a scope limit — **Unverified:**, **Not
+exercised before release:**). Real fixes often carry more than one, and each gets its own
+sentence; do not merge two bounds about two different populations of files into one, and do
+not pick a winner between them.
+
+Keep a bound when it answers any of:
+
+- Am I affected? — including *when* the fault existed and what produces it, where that is the
+  test for "are my files affected". ("A file Word wrote was never affected; it needs a `.docx`
+  built by something else.")
+- Will something visibly change for me on upgrade?
+- Is there residue I should clean up?
+- Is this narrower than it sounds? — say what it does **not** cover, especially when the
+  obvious reading is that it now does.
+- Was this actually verified? — an unexercised path, or one smoke-tested on one platform, says
+  so.
+
+Drop a hedge that only qualifies a mechanism the entry no longer describes.
+
+### Cut
+
+- **Mechanism archaeology.** How the bug worked, which field held the wrong value, which two
+  code paths disagreed, which one was written first. That is what the PR is for. Duration is
+  *not* archaeology when it is the "am I affected" test — see Bounds.
+- **Self-narration.** "Two changes, neither of which alters…", "This was the more serious of
+  the two", "found by a test written to check the opposite."
+- **Reassurance about what was not affected**, when nobody would have assumed otherwise. When
+  they would, it is a bound: one sentence, not a paragraph.
+- **Discovery attribution**, unless it is a severity signal — "not caught by any scanner" tells
+  a security-minded reader that sibling instances may be undiscovered, and stays.
+- Hedging stacks ("could potentially sometimes"), and "the system" where "Tandem" is meant.
+
+Voice: active; present tense for current behaviour, past for what it used to do.
+
+### Worked example — an ordinary fix
+
+Before (247 words):
+
+> - **Accepting a suggestion that came from a Word comment now marks that comment resolved in
+>   the `.docx`.** When you open a `.docx`, its reviewer comments come in as personal notes;
+>   send one to Claude, take Claude's suggested wording, accept it, and `tandem_applyChanges`
+>   writes the edit back as a tracked change. It was supposed to tick the original Word comment
+>   off as done in the same pass, and never did — not for some comments, for all of them.
+>   Tandem was working out which Word comment a suggestion came from by reading its own
+>   internal id, in a shape those ids stopped using four months ago, twelve days after the
+>   resolving step was written, so the answer was always "no comment" and the resolving step
+>   quietly did nothing. Reopening the file in Word showed every comment still outstanding,
+>   including the ones you had just addressed. Tandem now reads the original comment number off
+>   the note itself, which is where it has been stored all along.
+
+After (44 words):
+
+> - **Accepting a suggestion from a Word comment now resolves that comment in the `.docx`
+>   (#1234).** `tandem_applyChanges` wrote the tracked change but never ticked the original
+>   comment off, so reopening in Word showed every comment still outstanding — including ones
+>   you had just addressed.
+
+### Worked example — a security entry with two bounds
+
+This is the shape that goes wrong. The entry compresses; the bounds do not.
+
+> - **Claude can no longer choose the name of a file Tandem writes for you — only the folder
+>   (#1234).** The annotation export and the `.docx`-to-Markdown conversion both took a
+>   caller-supplied filename, so a session talked into it could drop a `CLAUDE.md` into a
+>   project that had none — a file every future session there loads as instructions. Exports
+>   must now end `.annotations.md` or `.annotations.json`, and a conversion takes a folder,
+>   naming the file after the document. **Bound:** this narrows rather than closes — renaming
+>   your document first still reaches a chosen name, but that changes the tab in front of you.
+>   **Bound:** nothing in Tandem's own interface passed these values, so no workflow of yours
+>   changes.
 
 ## Important
 
 - Do NOT write directly to CHANGELOG.md — output the block for editorial review
-- Check the existing CHANGELOG.md format to match style (indentation, heading levels, PR references)
+- Check the existing CHANGELOG.md for **formatting** style (indentation, heading levels, PR
+  references). Do **not** match the length of pre-2026-09 entries; they predate the shape above.
 - If there's already an `[Unreleased]` section, show what to append, not a replacement
 - Omit empty categories (don't show "### Security" if there are no security commits)
+- **Never retighten an already-released entry.** Three doc-claim tests grep CHANGELOG prose for
+  exact phrasing inside historical sections — `tests/docs/wake-availability-claims.test.ts`,
+  `tests/docs/monitor-arming-claims.test.ts`, `tests/docs/native-theme-claims.test.ts` — so a
+  tidy-up of old versions turns `check` red for reasons the diff will not explain. Shipped
+  entries are also a record of what users were told. Editorial cleanup is forward-only.
 - **List spacing is load-bearing.** `CHANGELOG.md` has a byte-identical `serializeMdast`
-  round-trip golden test (`tests/server/file-io/markdown-escaping.test.ts`). `### Fixed` uses
-  tight lists (no blank line between bullets) while `### Added`/`### Changed` use loose ones;
-  mixing them fails the test. Run that test after editing, not at the end.
-- **The in-app View Changelog surface renders this file**, so an HTML comment is invisible
-  there. Caveats and hedges go in the prose or they reach nobody.
+  round-trip golden test (`tests/server/file-io/markdown-escaping.test.ts`). The serializer
+  decides tight-vs-loose **per list node** (`spread` on the list, not on the item): one
+  multi-paragraph bullet makes every bullet in that list loose. So spacing is uniform within a
+  section, and a single entry spilling into a second paragraph forces blank lines between all
+  of that section's entries. One-paragraph entries keep every list tight. `### What's New` is
+  its own list and does not propagate. Run that test after editing, not at the end.
+- **The in-app View Changelog surface renders this file** as an ordinary read-only document,
+  scrolled linearly. An HTML comment is invisible there, so caveats go in the prose or they
+  reach nobody — and a reader meets each `What's New` bullet again in full a few inches later,
+  which is why the bullets stay one short line.
 
 ## Releasing
 


### PR DESCRIPTION
Rewrites `.claude/skills/changelog/SKILL.md`. Forward-only — `CHANGELOG.md` is untouched.

## What changed

**`### What's New` opens every version.** 3–6 bullets, one line each (≤20 words), most impactful first, no PR numbers or subsystem names. It is written *last* and placed *first* — you cannot summarise entries you have not drafted. A 1–2 sentence prose lead sits above the bullets only when a genuinely large feature or change headlines the release.

**The concision lever is shape, not word count.** An entry is a bold clause, one sentence of consequence, then zero or more bounds. 120 words is a runaway backstop rather than a target, and **bounds do not count toward it**.

## Why bounds are exempt

The first draft of this rewrite had a hard 50-word cap plus a blanket cut list. Adversarial review applied it to real v0.25.0 entries and it deleted the honest qualifications, not the narration — the notes-privacy fix carries four independent bounds about four different populations of files, and one cap forces you to pick which one to drop. Bounds now get one sentence each, with an explicit keep-test (am I affected / does something visibly change on upgrade / is there residue / is this narrower than it sounds / was it actually verified).

Two cut categories were also too wide and are now carve-outs:

- **Duration is not archaeology** when it is the "are my files affected" test. The Word-comment collision entry's bound is precisely that Word never produces the triggering shape.
- **Discovery attribution stays when it is a severity signal.** "Not caught by any scanner" tells a security-minded reader that sibling instances may be undiscovered.

## Two things the review turned up

- **Released entries must never be retightened.** `tests/docs/wake-availability-claims.test.ts`, `tests/docs/monitor-arming-claims.test.ts` and `tests/docs/native-theme-claims.test.ts` grep CHANGELOG prose for exact phrasing inside historical version sections, so a tidy-up of old versions turns `check` red for reasons the diff will not explain. Now a stated rule with the file names.
- **The list-spacing note described a convention, not the mechanism.** It said `### Fixed` is tight while `### Added`/`### Changed` are loose. Verified in `mdast-util-to-markdown`: `spread` lives on the *list* node, so any section is tight or loose depending on its content shape — one multi-paragraph bullet makes every bullet in that list loose. `### What's New` is its own list and does not propagate.

Also resolves a contradiction the draft inherited: "match the existing CHANGELOG style" now scopes to formatting explicitly, since pre-2026-09 entries run 3–6× the new shape.

## Testing

No behaviour change; `CHANGELOG.md` is unmodified, so the `serializeMdast` golden test and the three doc-claim tests are untouched. Full pre-push suite (biome + vitest + `cargo test`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019U7J7fCmLoYPgzBP9UPna2
