### PR TITLE
test(server): stop the apply-route suite rewriting the operator's installed skill

### DIFF
--- a/docs/plans/2026-09-06-open-issues-sweep.md
+++ b/docs/plans/2026-09-06-open-issues-sweep.md
@@ -313,11 +313,15 @@ container's record and names the MCP tools that session had; the script no longe
 - **The verify stage's stdio smoke is not sandboxed by `TANDEM_APP_DATA_DIR`** (found in wave 2).
   `scripts/ci/stdio-smoke.mjs` boots `dist/server` on the product ports 3478/3479, the server
   `freePort()`s whatever holds them, and the boot's `refreshExistingSkillIfStale()` writes
-  `~/.claude/skills/tandem/SKILL.md` when the bundled version is higher — J1's verify overwrote the
-  operator's installed skill with unmerged branch text. The script now skips the smoke when a real
-  Tandem is listening, serialises it across groups with a mkdir lock, and points
-  `USERPROFILE`/`HOME` at a scratch dir for the boot. If you ran an older script, check the
-  installed skill's `version:` against `origin/master` and restore it.
+  `~/.claude/skills/tandem/SKILL.md` when the bundled version is higher. The script now skips the
+  smoke when a real Tandem is listening, serialises it across groups with a mkdir lock, and points
+  `USERPROFILE`/`HOME` at a scratch dir for the boot. **Correction (2026-09-07):** the smoke was
+  NOT what overwrote J1's installed skill — that was `tests/server/integrations/api-routes.test.ts`
+  driving the real apply route, whose `installSkill()` wrote the checkout's bundled skill over the
+  real home on every `npm test` and every pre-push hook (it downgraded a v15 install to v14 three
+  more times that night, once per push). Fixed by #1894 (an injected `installSkill` seam in the
+  route deps, spy by default in the suite). The smoke sandboxing stays. If you ran an older
+  checkout, check the installed skill's `version:` against `origin/master` and restore it.
 - **A workflow agent can wedge on one tool call, and nothing times it out** (found in wave 2).
   F-runtime's post-ship agent issued `npm run typecheck` in the worktree and never got a result;
   the workflow sat for three hours looking "in progress". The tell is the run's `journal.jsonl`

--- a/src/server/integrations/api-routes.ts
+++ b/src/server/integrations/api-routes.ts
@@ -147,6 +147,17 @@ export interface IntegrationsRoutesDeps {
    */
   shouldRegisterChannelShim?: typeof shouldRegisterChannelShim;
   /**
+   * Optional skill-install override. Production leaves this undefined and
+   * calls the real `installSkill()`, which writes `~/.claude/skills/tandem/SKILL.md`
+   * under the REAL home directory — there is deliberately no request-body
+   * `homeOverride` (see `parseApplyBody`). Tests MUST inject a spy: the apply
+   * suite drives the real route, and without this seam every `npm test` and
+   * every pre-push hook silently overwrote the operator's installed skill with
+   * whatever the checkout happened to bundle (found 2026-09-07 — it had
+   * downgraded a v15 install to v14 three times in one night).
+   */
+  installSkill?: typeof installSkill;
+  /**
    * Optional Claude-CLI binary detector override. Production leaves this
    * undefined and calls the real `detectClaudeCli()`. Tests inject a stub so
    * the status route's response doesn't depend on whether the test process
@@ -994,7 +1005,7 @@ function makeApplyHandler(deps: IntegrationsRoutesDeps): Handler {
       // Skill install runs once if anything applied (per-user side effect).
       if (anyApplied) {
         try {
-          await installSkill();
+          await (deps.installSkill ?? installSkill)();
         } catch (err) {
           // Non-fatal; log only.
           console.error("[Tandem] apply: skill install failed:", err);

--- a/tests/server/integrations/api-routes.test.ts
+++ b/tests/server/integrations/api-routes.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import express, { type Express, type NextFunction, type Request, type Response } from "express";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   _resetApplyGateForTests,
@@ -156,11 +156,18 @@ describe("integrations API routes", () => {
   let tmpDir: string;
   let deps: IntegrationsRoutesDeps;
   let backend: ReturnType<typeof memoryBackend>;
+  // The real `installSkill()` writes under the REAL home directory and the
+  // route deliberately accepts no `homeOverride`, so every app built from
+  // `deps` gets this spy. Without it the apply tests below rewrote the
+  // operator's `~/.claude/skills/tandem/SKILL.md` on every run.
+  let installSkillSpy: ReturnType<typeof vi.fn<() => Promise<void>>>;
 
   beforeEach(async () => {
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tandem-int-api-"));
     backend = memoryBackend();
+    installSkillSpy = vi.fn(async () => {});
     deps = {
+      installSkill: installSkillSpy,
       store: createIntegrationsStore(tmpDir),
       keychain: createKeychain(backend),
       readExisting: async () =>
@@ -1150,6 +1157,9 @@ describe("integrations API routes", () => {
           TAURI_ORIGIN,
         );
         expect(res.status).toBe(200);
+        // Pins the "exactly once after the loop" contract AND that the route
+        // took the injected seam rather than the real home-directory writer.
+        expect(installSkillSpy).toHaveBeenCalledTimes(1);
         const body = res.body as { results: Array<{ status: string }>; nextNonce: string };
         expect(body.results[0]?.status).toBe("applied");
         const after = JSON.parse(fs.readFileSync(tmpClaudeJson, "utf-8"));


### PR DESCRIPTION
## Summary

`tests/server/integrations/api-routes.test.ts` drives the real apply route, and that route calls `installSkill()` once after its loop. `installSkill()` deliberately takes no request-level `homeOverride`, so under test it resolved the real home directory and wrote the checkout's bundled `skills/tandem/SKILL.md` over `~/.claude/skills/tandem/SKILL.md`. Every `npm test` and every pre-push hook on a contributor's machine did this silently. On this machine it downgraded a v15 install to v14 three times in one night (2026-09-07), and the open-issues-sweep ledger had blamed the stdio smoke for the first occurrence; the smoke sandboxing in #1893 stays useful but was not the writer.

The fix adds an optional `installSkill` seam to `IntegrationsRoutesDeps`, next to the existing `detectTargets` and `shouldRegisterChannelShim` seams. Production leaves it undefined and calls the real writer. The suite's default deps inject a spy, and the real-`applyConfig` test asserts it was called exactly once, which pins the seam and the "once after the loop" contract that the route's docblock already claims.

## Verification

- Reproduced: with the installed skill at v15 and the checkout bundling v14, running the suite alone flipped the installed file to v14 (mtime moved); the other four apply-adjacent suites did not.
- Fixed: 76 passed, installed file untouched (mtime and version unchanged).
- Mutation: reverting the one-line seam makes `removes tandem-channel from the target config…` fail on `toHaveBeenCalledTimes(1)`; restored from a file copy.
- `tsc -p tsconfig.server.json`, `typecheck:tests`, biome clean; pre-push hook (full vitest + `cargo test`).

Refs #1827 (found during the sweep). The ledger's stdio-smoke lesson is corrected in this PR's second commit, now that #1893 has merged the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z7FSDdV1rUQKy1xEMncYQ
